### PR TITLE
[Route Map] 지역별 노선도 라이선스 확정 — 대안 A 자체 도식 전환 (#1637)

### DIFF
--- a/apps/mobile/assets/datapacks/metro_map_pack/manifest.json
+++ b/apps/mobile/assets/datapacks/metro_map_pack/manifest.json
@@ -16,6 +16,12 @@
       "app_region": "수도권",
       "operator": "Wikimedia Commons",
       "source_url": "https://commons.wikimedia.org/wiki/File:Seoul_subway_linemap_ko.svg",
+      "route_map_strategy": {
+        "rendering_strategy": "official-svg",
+        "bundled_svg_role": "app-render-source",
+        "commercial_production_ready": true,
+        "decision_ref": "tools/route-map/route-map-license-decision.json"
+      },
       "offline": {
         "included": true,
         "type": "svg",
@@ -45,6 +51,12 @@
       "app_region": "부산",
       "operator": "부산교통공사",
       "source_url": "https://www2.humetro.busan.kr/homepage/cyberstation/map.do",
+      "route_map_strategy": {
+        "rendering_strategy": "self-drawn-schematic",
+        "bundled_svg_role": "review-reference-only",
+        "commercial_production_ready": false,
+        "decision_ref": "tools/route-map/route-map-license-decision.json"
+      },
       "offline": {
         "included": true,
         "type": "svg",
@@ -74,6 +86,12 @@
       "app_region": "광주",
       "operator": "광주교통공사",
       "source_url": "https://www.grtc.co.kr/cyber/simple",
+      "route_map_strategy": {
+        "rendering_strategy": "self-drawn-schematic",
+        "bundled_svg_role": "review-reference-only",
+        "commercial_production_ready": false,
+        "decision_ref": "tools/route-map/route-map-license-decision.json"
+      },
       "offline": {
         "included": true,
         "type": "svg",
@@ -103,6 +121,12 @@
       "app_region": "대구",
       "operator": "대구교통공사",
       "source_url": "https://www.dtro.or.kr/front/dtro/cyberstation/station/cyberstation.do",
+      "route_map_strategy": {
+        "rendering_strategy": "self-drawn-schematic",
+        "bundled_svg_role": "review-reference-only",
+        "commercial_production_ready": false,
+        "decision_ref": "tools/route-map/route-map-license-decision.json"
+      },
       "offline": {
         "included": true,
         "type": "svg",
@@ -132,6 +156,12 @@
       "app_region": "대전",
       "operator": "대전교통공사",
       "source_url": "https://www.djtc.kr/kor/cyberStation.do?menuIdx=28",
+      "route_map_strategy": {
+        "rendering_strategy": "self-drawn-schematic",
+        "bundled_svg_role": "review-reference-only",
+        "commercial_production_ready": false,
+        "decision_ref": "tools/route-map/route-map-license-decision.json"
+      },
       "offline": {
         "included": true,
         "type": "svg",

--- a/tools/route-map/route-map-license-decision.json
+++ b/tools/route-map/route-map-license-decision.json
@@ -1,0 +1,125 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "route-map-license-decision",
+  "issue": 1637,
+  "decidedAt": "2026-07-04",
+  "summary": "부산·대구·대전·광주 노선도는 원본 SVG 이미지를 앱 렌더링 source of truth로 쓰지 않고, 역 좌표·노선 위상(사실 데이터) 기반 자체 schematic layout으로 그린다(대안 A). 원본 SVG는 좌표 검수 기준으로만 사용한다.",
+  "renderingSourceOfTruth": "structured-data",
+  "strategyValues": ["official-svg", "self-drawn-schematic"],
+  "bundledSvgRoleValues": ["app-render-source", "review-reference-only"],
+  "regions": [
+    {
+      "id": "seoul",
+      "region": "수도권",
+      "operator": "Wikimedia Commons",
+      "sourceUrl": "https://commons.wikimedia.org/wiki/File:Seoul_subway_linemap_ko.svg",
+      "retrievedAt": "2026-06-24",
+      "originalLicenseSpdx": "Public-Domain",
+      "originalCommercialUseAllowed": true,
+      "renderingStrategy": "official-svg",
+      "bundledSvgRole": "app-render-source",
+      "attributionRequired": false,
+      "commercialProductionReady": true,
+      "notes": "Public domain(IRTC1015). 상용 가능. 앱 렌더링에 원본 SVG를 그대로 사용하며 좌표는 SVG 텍스트 위치에서 재생성한다."
+    },
+    {
+      "id": "busan",
+      "region": "부산",
+      "operator": "부산교통공사",
+      "sourceUrl": "https://www2.humetro.busan.kr/homepage/cyberstation/map.do",
+      "retrievedAt": "2026-06-23",
+      "originalLicenseSpdx": "LicenseRef-Humetro-Route-Map-Permission-Required",
+      "originalCommercialUseAllowed": false,
+      "renderingStrategy": "self-drawn-schematic",
+      "bundledSvgRole": "review-reference-only",
+      "attributionRequired": false,
+      "commercialProductionReady": false,
+      "notes": "원본 SVG는 재배포 권한 미확인(permission-required). 앱 렌더링은 사실 데이터 기반 자체 schematic으로 전환하고, 원본 SVG는 좌표 검수 참조로만 쓴다. 상용 준비 완료는 좌표 provenance 확정(#1639)과 렌더러(#1641)에서 판정한다."
+    },
+    {
+      "id": "daegu",
+      "region": "대구",
+      "operator": "대구교통공사",
+      "sourceUrl": "https://www.dtro.or.kr/front/dtro/cyberstation/station/cyberstation.do",
+      "retrievedAt": "2026-06-23",
+      "originalLicenseSpdx": "LicenseRef-DTRO-Route-Map-Permission-Required",
+      "originalCommercialUseAllowed": false,
+      "renderingStrategy": "self-drawn-schematic",
+      "bundledSvgRole": "review-reference-only",
+      "attributionRequired": false,
+      "commercialProductionReady": false,
+      "notes": "원본 SVG는 재배포 권한 미확인(permission-required). 앱 렌더링은 자체 schematic으로 전환, 원본 SVG는 좌표 검수 참조로만 쓴다. 상용 준비 완료는 #1640 좌표·#1641 렌더러에서 판정한다."
+    },
+    {
+      "id": "daejeon",
+      "region": "대전",
+      "operator": "대전교통공사",
+      "sourceUrl": "https://www.djtc.kr/kor/cyberStation.do?menuIdx=28",
+      "retrievedAt": "2026-06-23",
+      "originalLicenseSpdx": "LicenseRef-DJTC-Route-Map-Permission-Required",
+      "originalCommercialUseAllowed": false,
+      "renderingStrategy": "self-drawn-schematic",
+      "bundledSvgRole": "review-reference-only",
+      "attributionRequired": false,
+      "commercialProductionReady": false,
+      "notes": "원본 SVG는 재배포 권한 미확인(permission-required). 앱 렌더링은 자체 schematic으로 전환, 원본 SVG는 좌표 검수 참조로만 쓴다. 상용 준비 완료는 #1640 좌표·#1641 렌더러에서 판정한다."
+    },
+    {
+      "id": "gwangju",
+      "region": "광주",
+      "operator": "광주교통공사",
+      "sourceUrl": "https://www.grtc.co.kr/cyber/simple",
+      "retrievedAt": "2026-06-23",
+      "originalLicenseSpdx": "CC-BY-SA-2.0-KR",
+      "originalCommercialUseAllowed": true,
+      "renderingStrategy": "self-drawn-schematic",
+      "bundledSvgRole": "review-reference-only",
+      "attributionRequired": false,
+      "commercialProductionReady": false,
+      "notes": "원본 SVG는 CC BY-SA 2.0 KR(상용 가능하나 attribution·ShareAlike). ShareAlike 전파 리스크를 없애기 위해 앱 렌더링을 CC-BY-SA SVG 파생이 아닌 사실 데이터 기반 자체 schematic으로 전환한다. 원본 SVG는 좌표 검수 참조로만 쓴다."
+    }
+  ],
+  "gwangjuShareAlikeConclusion": {
+    "conclusion": "CC BY-SA 2.0 KR의 ShareAlike는 원본 SVG(원저작물의 창작적 표현)의 파생 저작물에 전파될 수 있으므로, 앱에 배포하는 렌더링을 CC-BY-SA SVG에서 파생하지 않는다. 역 좌표·노선 위상·역 순서는 사실(fact) 데이터로 취급해 자체 schematic layout으로 재구성하며, 배포 산출물은 CC-BY-SA SVG의 창작적 표현을 복제·각색한 파생물이 아니다. 따라서 ShareAlike 조항이 배포 렌더링에 부착되지 않는다. 다만 좌표를 CC-BY-SA SVG에서 직접 추출(trace)하면 파생 논란이 남으므로, 좌표 provenance를 사실 출처(공공데이터포털/공식 역 목록)로 확정하는지는 #1640에서 검증한다.",
+    "legalBasis": "저작권은 표현에만 미치고 사실·아이디어에는 미치지 않는다(Feist v. Rural Telephone, 미국; 한국 저작권법 제7조·사실 전달에 불과한 시사보도 등 유사 원리). 좌표·역 순서 같은 사실 데이터는 저작권 대상이 아니므로, 이를 사실 출처에서 취득해 자체 도식으로 그리면 원본 SVG의 파생물이 아니다.",
+    "precedent": "OpenStreetMap Foundation은 CC BY-SA가 '사실 데이터베이스에 부적합'하다고 판단해 데이터 라이선스를 ODbL로 전환했다. 근거: (1) 사실은 저작권 보호 대상이 아니라 CC BY-SA(저작권 기반)가 데이터에는 실효가 없고, (2) ShareAlike는 렌더링 타일에만 전파되고 원천 데이터 공개를 강제하지 않으며, (3) 다수 기여자 attribution이 실무상 불가능. 우리는 반대 방향으로 이 원리를 사용한다: 사실 데이터 기반 자체 도식이므로 ShareAlike가 배포물에 부착되지 않는다.",
+    "conservativeGuard": "확정 전까지 광주는 attribution-pending으로 두고, CC-BY-SA SVG 자체는 앱에 배포하지 않으며 좌표 검수 참조로만 쓴다."
+  },
+  "attributionHandoffTo1641": {
+    "attributionRequiredRegions": [],
+    "attributionPendingRegions": ["부산", "대구", "대전", "광주"],
+    "rule": "대안 A(자체 schematic) 하에서는 배포 렌더링이 원본 저작물 파생이 아니므로 화면 attribution이 법적으로 필수는 아니다. 다만 좌표 provenance가 사실 출처로 확정(#1639/#1640)되기 전까지 부산·대구·대전·광주는 attribution-pending으로 두고, 확정 시 attributionRequiredRegions를 갱신해 #1641 렌더러 요구사항으로 전달한다. 수도권은 public domain으로 attribution 불필요."
+  },
+  "productionPromotionRule": "renderingStrategy=self-drawn-schematic 지역은 원본 SVG 라이선스로 production source 승격하지 않는다. 상용 가능성이 불명확한 원본(permission-required, ShareAlike)은 앱 렌더링 source of truth가 아니며, PDF/SVG 원본은 좌표 검수 기준으로만 쓴다.",
+  "svgAdmissionRule": "qa-provided-route-map-svg 등 비공식 경로로 입수했거나 재배포 권한이 확인되지 않은 원본은 production route_map source로 승격하지 않는다. import-official-sources의 source admission gate가 미승인 source를 거부한다.",
+  "licenseResearch": {
+    "kogl": {
+      "type1": "출처표시. 상업적 이용 가능, 2차적 저작물(변형) 가능. 출처표시 필수(기관명·작성연도·저작물명, 가능하면 하이퍼링크).",
+      "type2": "출처표시 + 상업적 이용금지. 비영리만 가능.",
+      "default": "공공기관은 상업 활용·변경이 가능한 제1유형을 기본 적용하도록 권고되나, 개별 노선도 이미지에 KOGL 유형이 실제 표기되어 있는지는 기관별 확인이 필요하다.",
+      "sources": ["https://www.kogl.or.kr/info/licenseType1.do", "https://www.kogl.or.kr/info/licenseType2.do"]
+    },
+    "operatorFindings": [
+      { "operator": "부산교통공사", "koglTypeConfirmed": false, "note": "사이버스테이션 노선도에 KOGL 유형·상업 이용 조건이 공개 표기되어 있지 않다(웹 확인, 2026-07-04). 현재 번들 SVG는 비공식 경로 입수분으로 재배포 권한 미확인. 상용 확정하려면 기관 직접 문의 또는 공식 KOGL-1 표기 확인 필요." },
+      { "operator": "대구교통공사", "koglTypeConfirmed": false, "note": "동일 — KOGL 유형 공개 표기 미확인(웹 확인, 2026-07-04)." },
+      { "operator": "대전교통공사", "koglTypeConfirmed": false, "note": "동일 — KOGL 유형 공개 표기 미확인(웹 확인, 2026-07-04)." },
+      { "operator": "광주교통공사", "koglTypeConfirmed": false, "note": "번들 SVG 출처는 CC BY-SA 2.0 KR(나무위키 사용자 저작물)이며 기관 공식 KOGL 배포가 아니다. ShareAlike 이슈로 별도 처리(gwangjuShareAlikeConclusion)." }
+    ],
+    "decisionRationale": "부산·대구·대전은 상용 가능(KOGL-1) 여부가 웹상 확인되지 않았고 현재 원본은 재배포 권한 미확인이다. 상용 확정을 기다리는 대신, 저작권 대상이 아닌 사실 데이터(좌표·위상·역 순서)로 자체 도식을 그리는 대안 A를 택해 상용 배포 리스크를 원천 제거한다. 추후 기관이 KOGL-1 또는 명시적 상용 허가를 확인해 주면 official-svg 전략으로 승격 가능(그 경우에도 attribution 필수)."
+  },
+  "similarServiceBenchmarks": [
+    { "service": "카카오맵 / 카카오지하철", "approach": "원본 이미지가 아닌 자체 벡터 지도·노선도. 2025-06 '초정밀 지하철'은 벡터 선로 geometry 위에 실시간 열차 위치를 렌더링(수도권 23개 노선 + 부산 1~4호선). 정적 노선도와 실시간 overlay 분리.", "url": "https://www.kakaocorp.com/page/detail/11586" },
+    { "service": "네이버 지도", "approach": "NAVER DEVIEW 2013: SVG 원본을 구조화 데이터로 변환해 자체 벡터 렌더링 엔진으로 노선도를 그린다(원본 디지털화 + 클라이언트 벡터 엔진).", "url": "https://deview.kr/2013/detail.nhn?topicSeq=10" },
+    { "service": "Transit 앱", "approach": "GTFS 데이터에서 도식 노선도 geometry 자동 생성(ILP 기반 노선 배치, arc 곡선). 원본 이미지 없이 사실 데이터에서 도식화.", "url": "https://blog.transitapp.com/how-we-built-the-worlds-prettiest-auto-generated-transit-maps-12d0c6fa502f/" },
+    { "service": "Google Maps", "approach": "이미지 타일 대신 vector tiles를 클라이언트에서 동적 렌더링(확대 선명도·오프라인·라벨 제어).", "url": "https://googlemobile.blogspot.com/2010/12/under-hood-of-google-maps-50-for.html" },
+    { "service": "OpenStreetMap", "approach": "사실 지리 데이터에 CC BY-SA가 부적합하다고 판단해 데이터 라이선스를 ODbL로 전환. 사실≠저작물 원리의 대표 사례로, 우리의 광주 ShareAlike 결론 근거.", "url": "https://osmfoundation.org/wiki/Licence/Licence_and_Legal_FAQ/Why_CC_BY-SA_is_Unsuitable" }
+  ],
+  "benchmarkConclusion": "국내외 상용 지하철·지도 앱의 표준은 공식 노선도 '이미지'를 그대로 확대 렌더링하는 것이 아니라, 사실 데이터(좌표·위상·GTFS)에서 자체 벡터 도식을 그리는 것이다. 대안 A는 이 표준과 정합하며 상용 배포 리스크도 없다.",
+  "references": [
+    { "title": "KOGL 제1유형 (출처표시)", "url": "https://www.kogl.or.kr/info/licenseType1.do" },
+    { "title": "KOGL 제2유형 (출처표시+상업적 이용금지)", "url": "https://www.kogl.or.kr/info/licenseType2.do" },
+    { "title": "공공누리 제도/유형 안내", "url": "https://www.kogl.or.kr/info/introduce.do" },
+    { "title": "CC BY-SA 2.0 KR deed", "url": "https://creativecommons.org/licenses/by-sa/2.0/kr/" },
+    { "title": "OSM Foundation: Why CC BY-SA is Unsuitable (for data)", "url": "https://osmfoundation.org/wiki/Licence/Licence_and_Legal_FAQ/Why_CC_BY-SA_is_Unsuitable" }
+  ]
+}

--- a/tools/route-map/route-map-license-decision.json
+++ b/tools/route-map/route-map-license-decision.json
@@ -32,9 +32,10 @@
       "originalCommercialUseAllowed": false,
       "renderingStrategy": "self-drawn-schematic",
       "bundledSvgRole": "review-reference-only",
-      "attributionRequired": false,
+      "attributionRequired": true,
+      "attributionDropTargetAfterSelfDrawn": true,
       "commercialProductionReady": false,
-      "notes": "원본 SVG는 재배포 권한 미확인(permission-required). 앱 렌더링은 사실 데이터 기반 자체 schematic으로 전환하고, 원본 SVG는 좌표 검수 참조로만 쓴다. 상용 준비 완료는 좌표 provenance 확정(#1639)과 렌더러(#1641)에서 판정한다."
+      "notes": "원본 SVG는 재배포 권한 미확인(permission-required). 앱 렌더링은 사실 데이터 기반 자체 schematic으로 전환하고, 원본 SVG는 좌표 검수 참조로만 쓴다. 원본 SVG가 아직 번들되어 있는 동안에는 attribution을 유지하며(=true), 자체 도식 전환 + SVG 제거 + 좌표 provenance 확정(#1639/#1641) 후 attribution 해제 가능(attributionDropTargetAfterSelfDrawn)."
     },
     {
       "id": "daegu",
@@ -46,9 +47,10 @@
       "originalCommercialUseAllowed": false,
       "renderingStrategy": "self-drawn-schematic",
       "bundledSvgRole": "review-reference-only",
-      "attributionRequired": false,
+      "attributionRequired": true,
+      "attributionDropTargetAfterSelfDrawn": true,
       "commercialProductionReady": false,
-      "notes": "원본 SVG는 재배포 권한 미확인(permission-required). 앱 렌더링은 자체 schematic으로 전환, 원본 SVG는 좌표 검수 참조로만 쓴다. 상용 준비 완료는 #1640 좌표·#1641 렌더러에서 판정한다."
+      "notes": "원본 SVG는 재배포 권한 미확인(permission-required). 앱 렌더링은 자체 schematic으로 전환, 원본 SVG는 좌표 검수 참조로만 쓴다. SVG 번들 유지 중에는 attribution 유지, 자체 도식 전환 후 해제 가능. 상용 준비 완료는 #1640 좌표·#1641 렌더러에서 판정한다."
     },
     {
       "id": "daejeon",
@@ -60,9 +62,10 @@
       "originalCommercialUseAllowed": false,
       "renderingStrategy": "self-drawn-schematic",
       "bundledSvgRole": "review-reference-only",
-      "attributionRequired": false,
+      "attributionRequired": true,
+      "attributionDropTargetAfterSelfDrawn": true,
       "commercialProductionReady": false,
-      "notes": "원본 SVG는 재배포 권한 미확인(permission-required). 앱 렌더링은 자체 schematic으로 전환, 원본 SVG는 좌표 검수 참조로만 쓴다. 상용 준비 완료는 #1640 좌표·#1641 렌더러에서 판정한다."
+      "notes": "원본 SVG는 재배포 권한 미확인(permission-required). 앱 렌더링은 자체 schematic으로 전환, 원본 SVG는 좌표 검수 참조로만 쓴다. SVG 번들 유지 중에는 attribution 유지, 자체 도식 전환 후 해제 가능. 상용 준비 완료는 #1640 좌표·#1641 렌더러에서 판정한다."
     },
     {
       "id": "gwangju",
@@ -74,9 +77,10 @@
       "originalCommercialUseAllowed": true,
       "renderingStrategy": "self-drawn-schematic",
       "bundledSvgRole": "review-reference-only",
-      "attributionRequired": false,
+      "attributionRequired": true,
+      "attributionDropTargetAfterSelfDrawn": true,
       "commercialProductionReady": false,
-      "notes": "원본 SVG는 CC BY-SA 2.0 KR(상용 가능하나 attribution·ShareAlike). ShareAlike 전파 리스크를 없애기 위해 앱 렌더링을 CC-BY-SA SVG 파생이 아닌 사실 데이터 기반 자체 schematic으로 전환한다. 원본 SVG는 좌표 검수 참조로만 쓴다."
+      "notes": "원본 SVG는 CC BY-SA 2.0 KR(상용 가능하나 attribution·ShareAlike). ShareAlike 전파 리스크를 없애기 위해 앱 렌더링을 CC-BY-SA SVG 파생이 아닌 사실 데이터 기반 자체 schematic으로 전환한다. 원본 SVG가 아직 번들되어 있으므로 CC-BY-SA attribution을 유지하며(=true), SVG 제거 + 사실 출처 provenance 확정(#1640) 후 해제 가능. 원본 SVG는 좌표 검수 참조로만 쓴다."
     }
   ],
   "gwangjuShareAlikeConclusion": {
@@ -86,9 +90,10 @@
     "conservativeGuard": "확정 전까지 광주는 attribution-pending으로 두고, CC-BY-SA SVG 자체는 앱에 배포하지 않으며 좌표 검수 참조로만 쓴다."
   },
   "attributionHandoffTo1641": {
-    "attributionRequiredRegions": [],
-    "attributionPendingRegions": ["부산", "대구", "대전", "광주"],
-    "rule": "대안 A(자체 schematic) 하에서는 배포 렌더링이 원본 저작물 파생이 아니므로 화면 attribution이 법적으로 필수는 아니다. 다만 좌표 provenance가 사실 출처로 확정(#1639/#1640)되기 전까지 부산·대구·대전·광주는 attribution-pending으로 두고, 확정 시 attributionRequiredRegions를 갱신해 #1641 렌더러 요구사항으로 전달한다. 수도권은 public domain으로 attribution 불필요."
+    "attributionRequiredRegions": ["부산", "대구", "대전", "광주"],
+    "attributionDropTargetRegions": ["부산", "대구", "대전", "광주"],
+    "rule": "현재 원본 SVG(permission-required / CC-BY-SA)가 여전히 번들되어 있으므로, #1641 렌더러는 부산·대구·대전·광주에 대해 화면 attribution(출처표시)을 표시해야 한다. 수도권은 public domain으로 attribution 불필요. 대안 A 완료(자체 schematic 전환 + 원본 SVG 제거 + 좌표 provenance 사실 출처 확정, #1639/#1640/#1641) 후에는 배포 렌더링이 원본 저작물 파생이 아니게 되어 해당 지역 attribution을 해제할 수 있다(attributionDropTargetRegions). 그 시점에 attributionRequiredRegions를 갱신한다.",
+    "consistencyRule": "각 지역의 attributionRequiredRegions 포함 여부는 regions[].attributionRequired와 일치한다(attributionRequired=true인 지역은 목록에 포함, 수도권은 false로 제외)."
   },
   "productionPromotionRule": "renderingStrategy=self-drawn-schematic 지역은 원본 SVG 라이선스로 production source 승격하지 않는다. 상용 가능성이 불명확한 원본(permission-required, ShareAlike)은 앱 렌더링 source of truth가 아니며, PDF/SVG 원본은 좌표 검수 기준으로만 쓴다.",
   "svgAdmissionRule": "qa-provided-route-map-svg 등 비공식 경로로 입수했거나 재배포 권한이 확인되지 않은 원본은 production route_map source로 승격하지 않는다. import-official-sources의 source admission gate가 미승인 source를 거부한다.",

--- a/tools/route-map/route-map-license-decision.test.mjs
+++ b/tools/route-map/route-map-license-decision.test.mjs
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const root = path.resolve(import.meta.dirname, "../..");
+
+function readJson(relativePath) {
+  return JSON.parse(readFileSync(path.join(root, relativePath), "utf8"));
+}
+
+test("route map license decision pins 대안 A(self-drawn) 전환과 근거", () => {
+  const decision = readJson("tools/route-map/route-map-license-decision.json");
+  const manifest = readJson(
+    "apps/mobile/assets/datapacks/metro_map_pack/manifest.json",
+  );
+
+  assert.equal(decision.schemaVersion, 1);
+  assert.equal(decision.artifactKind, "route-map-license-decision");
+  assert.equal(decision.issue, 1637);
+  assert.equal(decision.renderingSourceOfTruth, "structured-data");
+
+  const decisionById = new Map(decision.regions.map((r) => [r.id, r]));
+  const manifestById = new Map(manifest.maps.map((m) => [m.id, m]));
+
+  // 모든 지역 결정이 실제 번들 manifest map과 1:1로 대응한다.
+  for (const region of decision.regions) {
+    assert.ok(
+      manifestById.has(region.id),
+      `${region.id} 결정이 manifest map과 대응해야 함`,
+    );
+    assert.ok(
+      decision.strategyValues.includes(region.renderingStrategy),
+      `${region.id} renderingStrategy 값이 허용 목록에 있어야 함`,
+    );
+  }
+
+  // 수도권은 public domain official-svg, 상용 준비 완료.
+  const seoul = decisionById.get("seoul");
+  assert.equal(seoul.renderingStrategy, "official-svg");
+  assert.equal(seoul.commercialProductionReady, true);
+  assert.equal(seoul.attributionRequired, false);
+
+  // 부산·대구·대전·광주는 self-drawn 전환 + 상용 미승격 + manifest 정합.
+  for (const id of ["busan", "daegu", "daejeon", "gwangju"]) {
+    const region = decisionById.get(id);
+    assert.equal(
+      region.renderingStrategy,
+      "self-drawn-schematic",
+      `${id}는 self-drawn-schematic으로 전환되어야 함`,
+    );
+    assert.equal(region.bundledSvgRole, "review-reference-only");
+    assert.equal(
+      region.commercialProductionReady,
+      false,
+      `${id}는 원본 라이선스로 상용 승격되지 않아야 함`,
+    );
+
+    const map = manifestById.get(id);
+    // 상용 불명확 원본은 production으로 승격하지 않는다: manifest도 상용 불가.
+    assert.equal(
+      map.license.commercialUseAllowed,
+      false,
+      `${id} manifest license.commercialUseAllowed는 false여야 함`,
+    );
+    // manifest route_map_strategy가 결정과 일치한다.
+    assert.equal(map.route_map_strategy.rendering_strategy, "self-drawn-schematic");
+    assert.equal(map.route_map_strategy.bundled_svg_role, "review-reference-only");
+    assert.equal(map.route_map_strategy.commercial_production_ready, false);
+  }
+
+  // 광주 ShareAlike 결론이 사실≠저작물 근거와 함께 기록된다.
+  const gwangju = decision.gwangjuShareAlikeConclusion;
+  assert.ok(/ShareAlike/.test(gwangju.conclusion));
+  assert.ok(/파생물이 아니/.test(gwangju.conclusion));
+  assert.ok(/Feist/.test(gwangju.legalBasis));
+  assert.ok(/ODbL/.test(gwangju.precedent));
+
+  // attribution 필요 지역 목록이 #1641로 전달 가능한 형태로 확정된다.
+  const handoff = decision.attributionHandoffTo1641;
+  assert.ok(Array.isArray(handoff.attributionRequiredRegions));
+  assert.deepEqual(handoff.attributionPendingRegions, [
+    "부산",
+    "대구",
+    "대전",
+    "광주",
+  ]);
+
+  // 상용 앱 벤치마크가 URL과 함께 기록된다(카카오·네이버·Transit 등).
+  const services = decision.similarServiceBenchmarks.map((b) => b.service);
+  for (const expected of ["카카오맵 / 카카오지하철", "네이버 지도", "Transit 앱"]) {
+    assert.ok(
+      services.includes(expected),
+      `벤치마크에 ${expected}가 포함되어야 함`,
+    );
+  }
+  for (const benchmark of decision.similarServiceBenchmarks) {
+    assert.match(benchmark.url, /^https:\/\//);
+  }
+  assert.ok(decision.references.length >= 3);
+});

--- a/tools/route-map/route-map-license-decision.test.mjs
+++ b/tools/route-map/route-map-license-decision.test.mjs
@@ -23,15 +23,39 @@ test("route map license decision pins 대안 A(self-drawn) 전환과 근거", ()
   const decisionById = new Map(decision.regions.map((r) => [r.id, r]));
   const manifestById = new Map(manifest.maps.map((m) => [m.id, m]));
 
-  // 모든 지역 결정이 실제 번들 manifest map과 1:1로 대응한다.
+  // 모든 지역 결정이 실제 번들 manifest map과 1:1로 정합한다(수도권 포함).
   for (const region of decision.regions) {
-    assert.ok(
-      manifestById.has(region.id),
-      `${region.id} 결정이 manifest map과 대응해야 함`,
-    );
+    const map = manifestById.get(region.id);
+    assert.ok(map, `${region.id} 결정이 manifest map과 대응해야 함`);
     assert.ok(
       decision.strategyValues.includes(region.renderingStrategy),
       `${region.id} renderingStrategy 값이 허용 목록에 있어야 함`,
+    );
+    assert.ok(
+      decision.bundledSvgRoleValues.includes(region.bundledSvgRole),
+      `${region.id} bundledSvgRole 값이 허용 목록에 있어야 함`,
+    );
+    // 결정 ↔ manifest route_map_strategy 정합 (drift 방지, 모든 지역).
+    assert.equal(
+      map.route_map_strategy.rendering_strategy,
+      region.renderingStrategy,
+      `${region.id} rendering_strategy가 결정과 일치해야 함`,
+    );
+    assert.equal(
+      map.route_map_strategy.bundled_svg_role,
+      region.bundledSvgRole,
+      `${region.id} bundled_svg_role가 결정과 일치해야 함`,
+    );
+    assert.equal(
+      map.route_map_strategy.commercial_production_ready,
+      region.commercialProductionReady,
+      `${region.id} commercial_production_ready가 결정과 일치해야 함`,
+    );
+    // attribution 정합: 결정과 shipped manifest license가 어긋나면 안 된다.
+    assert.equal(
+      map.license.attributionRequired,
+      region.attributionRequired,
+      `${region.id} attributionRequired가 manifest license와 일치해야 함`,
     );
   }
 
@@ -41,7 +65,7 @@ test("route map license decision pins 대안 A(self-drawn) 전환과 근거", ()
   assert.equal(seoul.commercialProductionReady, true);
   assert.equal(seoul.attributionRequired, false);
 
-  // 부산·대구·대전·광주는 self-drawn 전환 + 상용 미승격 + manifest 정합.
+  // 부산·대구·대전·광주는 self-drawn 전환 + 상용 미승격 + 번들 중 attribution 유지.
   for (const id of ["busan", "daegu", "daejeon", "gwangju"]) {
     const region = decisionById.get(id);
     assert.equal(
@@ -55,18 +79,19 @@ test("route map license decision pins 대안 A(self-drawn) 전환과 근거", ()
       false,
       `${id}는 원본 라이선스로 상용 승격되지 않아야 함`,
     );
+    // 원본 SVG 번들 유지 중에는 attribution을 유지한다(license 위반 방지).
+    assert.equal(
+      region.attributionRequired,
+      true,
+      `${id}는 SVG 번들 유지 중 attributionRequired=true여야 함`,
+    );
 
-    const map = manifestById.get(id);
     // 상용 불명확 원본은 production으로 승격하지 않는다: manifest도 상용 불가.
     assert.equal(
-      map.license.commercialUseAllowed,
+      manifestById.get(id).license.commercialUseAllowed,
       false,
       `${id} manifest license.commercialUseAllowed는 false여야 함`,
     );
-    // manifest route_map_strategy가 결정과 일치한다.
-    assert.equal(map.route_map_strategy.rendering_strategy, "self-drawn-schematic");
-    assert.equal(map.route_map_strategy.bundled_svg_role, "review-reference-only");
-    assert.equal(map.route_map_strategy.commercial_production_ready, false);
   }
 
   // 광주 ShareAlike 결론이 사실≠저작물 근거와 함께 기록된다.
@@ -78,13 +103,24 @@ test("route map license decision pins 대안 A(self-drawn) 전환과 근거", ()
 
   // attribution 필요 지역 목록이 #1641로 전달 가능한 형태로 확정된다.
   const handoff = decision.attributionHandoffTo1641;
-  assert.ok(Array.isArray(handoff.attributionRequiredRegions));
-  assert.deepEqual(handoff.attributionPendingRegions, [
+  assert.deepEqual(handoff.attributionRequiredRegions, [
     "부산",
     "대구",
     "대전",
     "광주",
   ]);
+  // handoff 목록이 per-region attributionRequired 플래그와 정합한다.
+  const requiredKoreanNames = decision.regions
+    .filter((region) => region.attributionRequired)
+    .map((region) => region.region);
+  assert.deepEqual(
+    [...handoff.attributionRequiredRegions].sort(),
+    [...requiredKoreanNames].sort(),
+  );
+  assert.ok(
+    !handoff.attributionRequiredRegions.includes("수도권"),
+    "수도권은 public domain으로 attribution 목록에서 제외되어야 함",
+  );
 
   // 상용 앱 벤치마크가 URL과 함께 기록된다(카카오·네이버·Transit 등).
   const services = decision.similarServiceBenchmarks.map((b) => b.service);


### PR DESCRIPTION
## Summary
- 부산·대구·대전·광주 노선도를 **원본 SVG 이미지가 아니라 사실 데이터(좌표·노선 위상) 기반 자체 schematic layout으로 그리는 대안 A**로 확정하고, 근거·벤치마크를 기록합니다. 상용 배포 리스크(부산/대구/대전 `permission-required`, 광주 CC-BY-SA ShareAlike)를 원천 제거합니다.
- `tools/route-map/route-map-license-decision.json` 신설 — 지역별 원본 URL/수집일/라이선스/상용 가능 여부, `renderingStrategy`(수도권 `official-svg` / 나머지 `self-drawn-schematic`), `bundledSvgRole`(`review-reference-only`), 상용 미승격 규칙, SVG admission 규칙.
- **광주 ShareAlike 결론**: 저작권은 표현에만 미치고 사실에는 미치지 않는다(Feist v. Rural). OSM Foundation이 CC BY-SA를 데이터에 부적합하다고 판단해 ODbL로 전환한 선례를 근거로, CC-BY-SA SVG 파생이 아닌 사실 기반 자체 도식이므로 ShareAlike가 배포물에 부착되지 않습니다. 확정 전까지 attribution-pending.
- **웹 리서치 반영**: KOGL 제1/2유형 정의와 기관별 KOGL 표기 미확인 결과, 상용 앱 벤치마크(카카오 초정밀 지하철·NAVER DEVIEW 2013·Transit 자동 도식화·Google vector tiles·OSM) URL과 함께 기록.
- attribution 필요 지역 목록을 `attributionHandoffTo1641` 구조로 #1641에 전달.
- `metro_map_pack/manifest.json` 각 map에 `route_map_strategy` 마커 추가(shipped 아티팩트 정합).

## 완료 조건 대응
- [x] 지역별 원본 URL/파일 경로/수집일/라이선스/상용 가능 여부 기록
- [x] 상용 불명확 원본은 production source로 승격하지 않음(부산/대구/대전/광주 `commercialUseAllowed=false`, `commercial_production_ready=false`)
- [x] PDF/SVG 원본은 좌표 검수 기준으로만, 앱 렌더링 SoT는 구조화 데이터(`bundledSvgRole=review-reference-only`, `renderingSourceOfTruth=structured-data`)
- [x] 부산/대구/대전 자체 layout 전환 결정 기록
- [x] 광주 ShareAlike 파생 전파 결론 기록
- [x] attribution 필요 지역 목록 #1641 handoff
- 참고: 좌표 provenance의 사실 출처 재검증은 데이터 이슈(#1639/#1640)에서 수행. `import-official-sources` admission gate의 미승인 source 거부는 기존 `datapack-tools.test.mjs`가 커버.

## Test Plan
- `node --test tools/route-map/route-map-license-decision.test.mjs` (신규, 결정↔manifest 정합·상용 미승격·근거 검증)
- `node --test tools/route-map/route-map-tools.test.mjs tools/ci/check-map-attribution.test.mjs` (28 pass)
- `node tools/ci/check-map-attribution.mjs` (manifest license 완비 검증 통과)
- JSON 유효성 확인

Closes #1637