### PR TITLE
[Chore] JDBC 시간표 port adapter 추가 (#1620)

### DIFF
--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/JdbcRouteTimetableRepository.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/JdbcRouteTimetableRepository.java
@@ -9,9 +9,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 @Profile("prod | staging | release | prod-like")
+@Transactional(readOnly = true)
 public class JdbcRouteTimetableRepository implements LoadRouteTimetablePort {
 
 	private final JdbcTemplate jdbcTemplate;
@@ -23,6 +25,20 @@ public class JdbcRouteTimetableRepository implements LoadRouteTimetablePort {
 
 	JdbcRouteTimetableRepository(JdbcTemplate jdbcTemplate) {
 		this.jdbcTemplate = jdbcTemplate;
+	}
+
+	@Override
+	public boolean hasRouteTimetable() {
+		return Boolean.TRUE.equals(jdbcTemplate.queryForObject(
+			"""
+				SELECT CASE
+					WHEN EXISTS (SELECT 1 FROM transit_trips)
+						AND EXISTS (SELECT 1 FROM transit_stop_times)
+					THEN TRUE ELSE FALSE
+				END
+				""",
+			Boolean.class
+		));
 	}
 
 	@Override

--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/JdbcRouteTimetableRepository.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/JdbcRouteTimetableRepository.java
@@ -1,0 +1,133 @@
+package com.easysubway.route.adapter.out.persistence;
+
+import com.easysubway.route.application.port.out.LoadRouteTimetablePort;
+import com.easysubway.route.application.port.out.LoadRouteTimetablePort.RouteTimetable;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Profile("prod | staging | release | prod-like")
+public class JdbcRouteTimetableRepository implements LoadRouteTimetablePort {
+
+	private final JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	public JdbcRouteTimetableRepository(DataSource dataSource) {
+		this(new JdbcTemplate(dataSource));
+	}
+
+	JdbcRouteTimetableRepository(JdbcTemplate jdbcTemplate) {
+		this.jdbcTemplate = jdbcTemplate;
+	}
+
+	@Override
+	public RouteTimetable loadRouteTimetable() {
+		return new RouteTimetable(
+			jdbcTemplate.query(
+				"""
+					SELECT service_id, monday, tuesday, wednesday, thursday, friday, saturday, sunday,
+						start_date, end_date, timezone
+					FROM service_calendars
+					ORDER BY service_id
+					""",
+				(resultSet, rowNumber) -> new ServiceCalendar(
+					resultSet.getString("service_id"),
+					resultSet.getBoolean("monday"),
+					resultSet.getBoolean("tuesday"),
+					resultSet.getBoolean("wednesday"),
+					resultSet.getBoolean("thursday"),
+					resultSet.getBoolean("friday"),
+					resultSet.getBoolean("saturday"),
+					resultSet.getBoolean("sunday"),
+					serviceDate(resultSet.getString("start_date")),
+					serviceDate(resultSet.getString("end_date")),
+					resultSet.getString("timezone")
+				)
+			),
+			jdbcTemplate.query(
+				"""
+					SELECT service_id, date, exception_type
+					FROM service_calendar_dates
+					ORDER BY service_id, date
+					""",
+				(resultSet, rowNumber) -> new ServiceCalendarDate(
+					resultSet.getString("service_id"),
+					serviceDate(resultSet.getString("date")),
+					resultSet.getInt("exception_type")
+				)
+			),
+			jdbcTemplate.query(
+				"""
+					SELECT id, line_id, route_short_name, route_long_name, direction_name, timezone
+					FROM transit_routes
+					ORDER BY id
+					""",
+				(resultSet, rowNumber) -> new TransitRoute(
+					resultSet.getString("id"),
+					resultSet.getString("line_id"),
+					resultSet.getString("route_short_name"),
+					resultSet.getString("route_long_name"),
+					resultSet.getString("direction_name"),
+					resultSet.getString("timezone")
+				)
+			),
+			jdbcTemplate.query(
+				"""
+					SELECT id, route_id, service_id, trip_headsign, direction_id, service_pattern, service_day_start_seconds
+					FROM transit_trips
+					ORDER BY id
+					""",
+				(resultSet, rowNumber) -> new TransitTrip(
+					resultSet.getString("id"),
+					resultSet.getString("route_id"),
+					resultSet.getString("service_id"),
+					resultSet.getString("trip_headsign"),
+					resultSet.getString("direction_id"),
+					resultSet.getString("service_pattern"),
+					resultSet.getInt("service_day_start_seconds")
+				)
+			),
+			jdbcTemplate.query(
+				"""
+					SELECT trip_id, stop_sequence, station_id, line_id, arrival_seconds, departure_seconds,
+						pickup_type, drop_off_type
+					FROM transit_stop_times
+					ORDER BY trip_id, stop_sequence
+					""",
+				(resultSet, rowNumber) -> new TransitStopTime(
+					resultSet.getString("trip_id"),
+					resultSet.getInt("stop_sequence"),
+					resultSet.getString("station_id"),
+					resultSet.getString("line_id"),
+					resultSet.getInt("arrival_seconds"),
+					resultSet.getInt("departure_seconds"),
+					resultSet.getInt("pickup_type"),
+					resultSet.getInt("drop_off_type")
+				)
+			),
+			jdbcTemplate.query(
+				"""
+					SELECT trip_id, start_time_seconds, end_time_seconds, headway_seconds, exact_times
+					FROM transit_frequencies
+					ORDER BY trip_id, start_time_seconds
+					""",
+				(resultSet, rowNumber) -> new TransitFrequency(
+					resultSet.getString("trip_id"),
+					resultSet.getInt("start_time_seconds"),
+					resultSet.getInt("end_time_seconds"),
+					resultSet.getInt("headway_seconds"),
+					resultSet.getBoolean("exact_times")
+				)
+			)
+		);
+	}
+
+	private static LocalDate serviceDate(String value) {
+		return LocalDate.parse(value, DateTimeFormatter.BASIC_ISO_DATE);
+	}
+}

--- a/backend/src/main/java/com/easysubway/route/application/port/out/LoadRouteTimetablePort.java
+++ b/backend/src/main/java/com/easysubway/route/application/port/out/LoadRouteTimetablePort.java
@@ -9,6 +9,11 @@ public interface LoadRouteTimetablePort {
 
 	RouteTimetable loadRouteTimetable();
 
+	default boolean hasRouteTimetable() {
+		RouteTimetable timetable = loadRouteTimetable();
+		return !timetable.transitTrips().isEmpty() && !timetable.transitStopTimes().isEmpty();
+	}
+
 	record RouteTimetable(
 		List<ServiceCalendar> serviceCalendars,
 		List<ServiceCalendarDate> serviceCalendarDates,

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
@@ -56,8 +56,7 @@ public class RouteV2Planner implements RouteV2SearchUseCase {
 	@Override
 	public RouteV2Plan search(SearchRouteV2Command command) {
 		try {
-			RouteTimetable timetable = routeTimetablePort.loadRouteTimetable();
-			if (timetableRequired && (timetable.transitTrips().isEmpty() || timetable.transitStopTimes().isEmpty())) {
+			if (timetableRequired && !routeTimetablePort.hasRouteTimetable()) {
 				return new RouteV2Plan(List.of(), List.of(RouteV2Status.NO_TIMETABLE_SERVICE), PLANNER_ADR);
 			}
 			SearchRouteCommand searchRouteCommand = toSearchRouteCommand(command);

--- a/backend/src/test/java/com/easysubway/route/adapter/out/persistence/JdbcRouteTimetableRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/out/persistence/JdbcRouteTimetableRepositoryTest.java
@@ -22,6 +22,7 @@ class JdbcRouteTimetableRepositoryTest {
 			""
 		);
 		jdbcTemplate = new JdbcTemplate(dataSource);
+		jdbcTemplate.execute("DROP ALL OBJECTS");
 		jdbcTemplate.execute("RUNSCRIPT FROM 'src/main/resources/db/migration/h2/V29__canonical_transit_schedule.sql'");
 		repository = new JdbcRouteTimetableRepository(jdbcTemplate);
 	}
@@ -42,6 +43,16 @@ class JdbcRouteTimetableRepositoryTest {
 		assertThat(timetable.transitTrips().getFirst().servicePattern()).isEqualTo("LOCAL");
 		assertThat(timetable.transitStopTimes().getFirst().stationId()).isEqualTo("station-sangnoksu");
 		assertThat(timetable.transitFrequencies().getFirst().headwaySeconds()).isEqualTo(600);
+	}
+
+	@Test
+	@DisplayName("시간표 availability는 stop_times 전체를 읽지 않고 판정한다")
+	void hasRouteTimetableChecksOnlyTripAndStopTimePresence() {
+		assertThat(repository.hasRouteTimetable()).isFalse();
+
+		insertTimetableRows();
+
+		assertThat(repository.hasRouteTimetable()).isTrue();
 	}
 
 	private void insertTimetableRows() {

--- a/backend/src/test/java/com/easysubway/route/adapter/out/persistence/JdbcRouteTimetableRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/out/persistence/JdbcRouteTimetableRepositoryTest.java
@@ -1,0 +1,81 @@
+package com.easysubway.route.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+@DisplayName("JDBC 경로 시간표 저장소")
+class JdbcRouteTimetableRepositoryTest {
+
+	private JdbcTemplate jdbcTemplate;
+	private JdbcRouteTimetableRepository repository;
+
+	@BeforeEach
+	void setUp() {
+		var dataSource = new DriverManagerDataSource(
+			"jdbc:h2:mem:route-timetable;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+			"sa",
+			""
+		);
+		jdbcTemplate = new JdbcTemplate(dataSource);
+		jdbcTemplate.execute("RUNSCRIPT FROM 'src/main/resources/db/migration/h2/V29__canonical_transit_schedule.sql'");
+		repository = new JdbcRouteTimetableRepository(jdbcTemplate);
+	}
+
+	@Test
+	@DisplayName("canonical 시간표 테이블을 RouteTimetable port record로 읽는다")
+	void loadRouteTimetableMapsCanonicalScheduleTables() {
+		insertTimetableRows();
+
+		var timetable = repository.loadRouteTimetable();
+
+		assertThat(timetable.serviceCalendars()).hasSize(1);
+		assertThat(timetable.serviceCalendarDates()).hasSize(1);
+		assertThat(timetable.transitRoutes()).hasSize(1);
+		assertThat(timetable.transitTrips()).hasSize(1);
+		assertThat(timetable.transitStopTimes()).hasSize(2);
+		assertThat(timetable.transitFrequencies()).hasSize(1);
+		assertThat(timetable.transitTrips().getFirst().servicePattern()).isEqualTo("LOCAL");
+		assertThat(timetable.transitStopTimes().getFirst().stationId()).isEqualTo("station-sangnoksu");
+		assertThat(timetable.transitFrequencies().getFirst().headwaySeconds()).isEqualTo(600);
+	}
+
+	private void insertTimetableRows() {
+		jdbcTemplate.update("""
+			INSERT INTO service_calendars (
+				service_id, start_date, end_date, timezone,
+				monday, tuesday, wednesday, thursday, friday, saturday, sunday
+			) VALUES ('weekday-2026', '20260701', '20261231', 'Asia/Seoul', TRUE, TRUE, TRUE, TRUE, TRUE, FALSE, FALSE)
+			""");
+		jdbcTemplate.update("""
+			INSERT INTO service_calendar_dates (service_id, date, exception_type)
+			VALUES ('weekday-2026', '20261003', 2)
+			""");
+		jdbcTemplate.update("""
+			INSERT INTO transit_routes (id, timezone, line_id, route_short_name, route_long_name, direction_name)
+			VALUES ('route-seoul-4-oido', 'Asia/Seoul', 'seoul-4', '4', '상록수-사당', '사당 방면')
+			""");
+		jdbcTemplate.update("""
+			INSERT INTO transit_trips (
+				id, route_id, service_id, service_pattern,
+				service_day_start_seconds, trip_headsign, direction_id
+			) VALUES ('trip-seoul-4-0900', 'route-seoul-4-oido', 'weekday-2026', 'LOCAL', 0, '사당', 'down')
+			""");
+		jdbcTemplate.update("""
+			INSERT INTO transit_stop_times (
+				trip_id, stop_sequence, station_id, line_id,
+				pickup_type, drop_off_type, arrival_seconds, departure_seconds
+			) VALUES
+				('trip-seoul-4-0900', 1, 'station-sangnoksu', 'seoul-4', 0, 0, 32400, 32400),
+				('trip-seoul-4-0900', 2, 'station-sadang', 'seoul-4', 0, 0, 33000, 33000)
+			""");
+		jdbcTemplate.update("""
+			INSERT INTO transit_frequencies (trip_id, start_time_seconds, headway_seconds, end_time_seconds, exact_times)
+			VALUES ('trip-seoul-4-0900', 32400, 600, 36000, FALSE)
+			""");
+	}
+}

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -795,6 +795,28 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("V2 planner는 시간표 availability 확인에 전체 snapshot을 읽지 않는다")
+	void routeV2PlannerDoesNotLoadFullTimetableForAvailabilityGuard() {
+		var repository = new InMemoryRouteSearchRepository();
+		var routeSearchService = new RouteSearchService(repository, repository, new RampAccessibleTransitMasterPort(), CLOCK);
+		var planner = new RouteV2Planner(routeSearchService, new LoadRouteTimetablePort() {
+			@Override
+			public boolean hasRouteTimetable() {
+				return true;
+			}
+
+			@Override
+			public LoadRouteTimetablePort.RouteTimetable loadRouteTimetable() {
+				throw new AssertionError("RouteV2Planner must not materialize the full timetable before RAPTOR uses it");
+			}
+		});
+
+		var plan = planner.search(routeV2Command(ConstraintMode.PREFER_STEP_FREE, MobilityType.SENIOR, 1, 3));
+
+		assertThat(plan.statuses()).containsExactly(RouteV2Status.FOUND);
+	}
+
+	@Test
 	@DisplayName("V2 planner는 접근성 차단 경로를 BLOCKED_ACCESSIBILITY status로 반환한다")
 	void routeV2PlannerReturnsBlockedAccessibilityStatus() {
 		var planner = routeV2Planner(new StairOnlyTransitMasterPort());

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -9466,8 +9466,8 @@ test("V2 경로 검색은 production planner 경계를 통해 요청 조건을 �
   assert.match(planner, /ObjectProvider<LoadRouteTimetablePort>/);
   assert.match(planner, /getIfAvailable\(\)/);
   assert.match(planner, /timetableRequired && routeTimetablePort != null/);
-  assert.match(planner, /timetableRequired && \(timetable\.transitTrips\(\)\.isEmpty\(\) \|\| timetable\.transitStopTimes\(\)\.isEmpty\(\)\)/);
-  assert.match(planner, /loadRouteTimetable\(\)/);
+  assert.match(planner, /timetableRequired && !routeTimetablePort\.hasRouteTimetable\(\)/);
+  assert.match(planner, /hasRouteTimetable\(\)/);
   assert.match(planner, /searchRouteAlternatives/);
   assert.match(planner, /statusesOf/);
   assert.match(useCase, /record SearchRouteV2Command/);
@@ -9482,6 +9482,7 @@ test("V2 경로 검색은 production planner 경계를 통해 요청 조건을 �
   assert.match(useCase, /List<RouteV2Status> statuses/);
   assert.match(timetablePort, /interface LoadRouteTimetablePort/);
   assert.match(timetablePort, /loadRouteTimetable/);
+  assert.match(timetablePort, /hasRouteTimetable/);
   assert.match(timetablePort, /record RouteTimetable/);
   for (const schemaRecord of [
     "ServiceCalendar",


### PR DESCRIPTION
## 관련 이슈

Refs #1620
Refs #1414

## 작업 배경

- #1620 Range RAPTOR production 승격 전에 backend가 canonical 시간표 테이블을 `LoadRouteTimetablePort`로 읽을 수 있어야 합니다.

## 작업 내용

- `JdbcRouteTimetableRepository`를 추가해 `service_calendars`, `service_calendar_dates`, `transit_routes`, `transit_trips`, `transit_stop_times`, `transit_frequencies`를 `RouteTimetable` record로 매핑했습니다.
- H2 canonical schedule migration 기반 repository test를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.route.adapter.out.persistence.JdbcRouteTimetableRepositoryTest` 통과
  - `./gradlew test --tests com.easysubway.route.adapter.out.persistence.JdbcRouteTimetableRepositoryTest --tests com.easysubway.route.application.port.out.LoadRouteTimetablePortTest --tests com.easysubway.route.application.service.RouteSearchServiceTest` 통과
  - `node --test --test-name-pattern "V2 경로 검색" tools/ci/repository-contract.test.mjs` 통과
  - `git diff --cached --check` 통과

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| JDBC 시간표 port adapter | backend | Gradle/JUnit | 터미널 출력 | 통과 |
| repository contract | repo | Node test | 터미널 출력 | 통과 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: backend timetable load port adapter 추가
- realtime contract: 변경 없음
- backend identity: route timetable JDBC adapter

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `JdbcRouteTimetableRepository`가 V29 canonical schedule table을 그대로 매핑하는지 확인해 주세요.

## 리스크

- RAPTOR 스캔 구현은 아직 아닙니다. 이 PR은 backend가 시간표 테이블을 읽는 adapter만 추가합니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
