### PR TITLE
[Route Map] 수도권 노선도 커버리지 회귀 가드 (#1638)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,7 @@ jobs:
           node --test tools/ci/repository-contract.test.mjs
           node tools/ci/check-map-attribution.mjs
           node --test tools/ci/check-map-attribution.test.mjs
+          node --test tools/route-map/capital-route-map-coverage.test.mjs
 
   repository-contracts:
     name: Repository CI

--- a/tools/route-map/capital-route-map-coverage.test.mjs
+++ b/tools/route-map/capital-route-map-coverage.test.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const root = path.resolve(import.meta.dirname, "../..");
+
+// #1638 회귀 가드: 커밋된 수도권 오프라인 팩(capital.sqlite.gz)이 구조화 노선도
+// 커버리지(노선 선 path·라벨 폴리곤·환승 그룹·LOD)를 유지하는지 검증한다.
+// enrich 도구를 --check(읽기 전용)로 실행해 CI에도 배선한다. 누군가 enrich
+// 단계 없이 build-datapack으로 팩을 재생성하면 up/down_path가 0으로 떨어지는데,
+// 이 테스트가 그 회귀를 잡는다.
+test("committed capital route map pack retains structured coverage (#1638 guard)", async () => {
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    [
+      "tools/route-map/enrich-capital-route-map-layer.mjs",
+      "--pack",
+      "apps/mobile/assets/datapacks/capital.sqlite.gz",
+      "--index",
+      "apps/mobile/assets/datapacks/index.json",
+      "--check",
+    ],
+    { cwd: root, maxBuffer: 16 * 1024 * 1024 },
+  );
+
+  const report = JSON.parse(stdout);
+  const after = report.after;
+
+  assert.equal(after.region, "수도권");
+  // 역 point 796 / 24개 노선 (#1638 실측 기준).
+  assert.ok(
+    after.positions >= 796,
+    `capital 역 point는 796 이상이어야 함 (실측 ${after.positions})`,
+  );
+  assert.equal(after.lines, 24, "capital 노선 수는 24여야 함");
+
+  // 이 이슈의 최대 갭이었던 노선 선 path가 채워져 있어야 한다(과거 0건).
+  assert.ok(
+    after.upPaths >= 700,
+    `capital up_path 커버리지가 있어야 함 (실측 ${after.upPaths})`,
+  );
+  assert.ok(
+    after.downPaths >= 700,
+    `capital down_path 커버리지가 있어야 함 (실측 ${after.downPaths})`,
+  );
+
+  // 라벨 폴리곤이 전 역에 채워져 있어야 한다(과거 1건).
+  assert.equal(
+    after.labelPolygons,
+    after.positions,
+    "모든 capital 역에 label_polygon이 있어야 함",
+  );
+
+  // 환승 그룹과 LOD가 구조화되어 있고 서로 정합한다.
+  assert.ok(after.transferGroups > 0, "환승 그룹이 도출되어야 함");
+  assert.equal(after.lod.zoom0, "lines_only");
+  assert.equal(
+    after.lod.zoom1MajorLabels,
+    after.transferGroups,
+    "zoom1 major 라벨 수는 환승 그룹 수와 일치해야 함",
+  );
+  assert.equal(
+    after.lod.zoom2StationLabels,
+    after.positions,
+    "zoom2 라벨 수는 전체 역 수와 일치해야 함",
+  );
+
+  // zoom-out(환승·주요역) 라벨은 서로 겹치지 않아야 한다.
+  assert.equal(
+    report.labelCollisionQa.zoom1.overlapCount,
+    0,
+    "zoom1 환승/주요역 라벨은 겹치면 안 됨",
+  );
+});


### PR DESCRIPTION
## Summary
- #1638의 수도권 구조화 노선도 데이터(노선 선 path·라벨 폴리곤·환승 그룹·LOD)는 이미 main의 `enrich-capital-route-map-layer.mjs`와 `capital.sqlite.gz`로 **완성**되어 있으나, 이를 지키는 **회귀 가드가 없었습니다**. enrich 단계 없이 `build-datapack`으로 팩을 재생성하면 `up/down_path`가 0으로 떨어져도 CI가 통과하는 갭을 닫습니다.
- `tools/route-map/capital-route-map-coverage.test.mjs` 신설 — 커밋된 수도권 오프라인 팩을 `enrich --check`(읽기 전용)로 검증하고 커버리지 임계값을 assert: 역 point ≥796, 노선 24, up/down_path 커버리지, **전 역 label_polygon**, 환승 그룹>0, **LOD 정합**(zoom1 major = 환승 그룹, zoom2 = 전체 역), **zoom1 라벨 무충돌**.
- `ci.yml`의 **Release Gate Consistency**(전 PR 무조건 실행) 스텝에 배선 — route-map glob(repository 트리거) 외에도, 팩만 바뀌는 커밋(mobile 필터)에서도 커버리지 회귀를 잡습니다.

## 배경 (왜 데이터 PR이 아니라 가드 PR인가)
- 수도권 데이터팩 enrich 작업(노선 선 path 0→772, label_polygon 1→796, 환승 113, LOD)은 선행 세션에서 main에 이미 병합되어 있어 재빌드/재커밋할 것이 없습니다(`capital-datapack-1638` 브랜치는 main과 동일해 subsume).
- 남은 리스크는 이 성과가 **테스트로 고정되어 있지 않다**는 점이라, 회귀 가드로 #1638의 "완성"을 잠급니다.

## Test Plan
- `node --test tools/route-map/capital-route-map-coverage.test.mjs` (신규, 1 pass)
- `node --test tools/route-map/*.test.mjs` (27 pass)
- `node --test tools/ci/repository-contract.test.mjs` (158 pass — ci.yml 변경 계약 검증)
- `enrich --check` 실측: 796 positions / 24 lines / 772 up·down_path / 796 label_polygons / 113 transfers / zoom1 overlap 0

## 남은 완료 조건 (하드웨어 필요, 별도)
- 확대/이동 성능 QA 증거(`run-route-map-android-evidence.sh`)와 신규역 4개·도라산 제외 화면 QA는 실기기가 필요해 QA 이슈(#1642/#1643)에서 수행합니다. 그래서 본 PR은 `Closes`가 아니라 `Refs`입니다.

Refs #1638