### PR TITLE
[Mobile] 구조화 노선도 데이터 레이어 파생 (#1641 stage 1)

### DIFF
--- a/apps/mobile/lib/features/network_map/domain/structured_route_map.dart
+++ b/apps/mobile/lib/features/network_map/domain/structured_route_map.dart
@@ -1,35 +1,22 @@
 // 구조화 노선도 도메인 모델과 파생 로직 (#1641 Stage 1: data layer).
 //
-// route_map_positions에서 앱으로 올라온 원시 필드(x/y, up_path/down_path,
-// label_polygon)를 native canvas 렌더러(#1641 Stage 2)가 바로 소비할 수 있는
-// 구조로 파생한다. 렌더링은 이 모듈에 없다 — 순수 파싱·파생만 한다.
+// route_map_positions에서 앱으로 올라온 필드를 native canvas 렌더러(#1641
+// Stage 2)가 바로 소비할 구조로 파생한다. 렌더링은 이 모듈에 없다 — 순수
+// 파생만 한다. label_polygon 파싱은 network_map.dart의 기존 _parseLabelPolygon
+// 을 재사용하므로(호출부에서 List<Offset>로 전달) 여기서 다시 파싱하지 않는다.
 //
 // #1636 structured-route-map-contract의 layer/LOD 규칙을 따른다:
-// - line_geometry: up_path/down_path polyline
+// - line_geometry: 노선 track polyline (gap에서 끊는다)
 // - transfer_groups: 같은 station_id에 여러 line_id → 중심 좌표
 // - station_labels priority: 환승 > 주요 > 일반 (별도 검수값 없으면 일반)
 // - LOD: zoom0 lines only, zoom1 환승/주요 라벨, zoom2 전체 역 라벨
-import 'dart:convert';
-
-/// 노선도 원본 좌표계의 2D 점.
-class RouteMapPoint {
-  const RouteMapPoint(this.x, this.y);
-
-  final double x;
-  final double y;
-
-  @override
-  bool operator ==(Object other) =>
-      other is RouteMapPoint && other.x == x && other.y == y;
-
-  @override
-  int get hashCode => Object.hash(x, y);
-
-  @override
-  String toString() => 'RouteMapPoint($x, $y)';
-}
+import 'dart:ui' show Offset;
 
 /// 라벨 우선순위 class (#1636 station_labels.priority).
+///
+/// [major]는 #1636 majorRule("별도 검수된 주요 거점")을 위한 예약 값이다.
+/// 현재 데이터팩에는 검수 컬럼이 없어 빌더는 transfer/regular만 산출하지만,
+/// 계약과 LOD 매핑을 위해 값과 zoom bucket을 유지한다.
 enum RouteMapLabelClass { transfer, major, regular }
 
 /// 라벨 class → 최초 표시 zoom bucket (#1636 LOD).
@@ -44,21 +31,16 @@ int minLabelZoomBucketFor(RouteMapLabelClass labelClass) {
   }
 }
 
-/// 한 노선의 방향별 polyline geometry.
+/// 한 노선의 track geometry. 데이터 hole(인접 세그먼트가 이어지지 않는 지점)에서
+/// 끊어 여러 sub-polyline으로 둔다 — 끊긴 두 역을 직선으로 잇는 phantom edge를
+/// 만들지 않기 위함이다.
 class RouteMapLineGeometry {
-  const RouteMapLineGeometry({
-    required this.lineId,
-    required this.upPolyline,
-    required this.downPolyline,
-  });
+  const RouteMapLineGeometry({required this.lineId, required this.polylines});
 
   final String lineId;
 
-  /// 상행(up) 방향 정점 목록, station sequence 순서.
-  final List<RouteMapPoint> upPolyline;
-
-  /// 하행(down) 방향 정점 목록, station sequence 순서.
-  final List<RouteMapPoint> downPolyline;
+  /// sequence 순서의 정점 목록들. 각 원소가 연속된 sub-polyline.
+  final List<List<Offset>> polylines;
 }
 
 /// 구조화된 역 노드 (렌더러가 point/label layer로 소비).
@@ -75,8 +57,8 @@ class RouteMapStructuredStation {
   final String stationId;
   final String lineId;
   final int sequence;
-  final RouteMapPoint position;
-  final List<RouteMapPoint> labelPolygon;
+  final Offset position;
+  final List<Offset> labelPolygon;
   final RouteMapLabelClass labelClass;
 
   int get minLabelZoomBucket => minLabelZoomBucketFor(labelClass);
@@ -96,7 +78,7 @@ class RouteMapTransferGroup {
   final List<String> lineIds;
 
   /// 표시 좌표: 해당 station_id route_map_positions의 중심값.
-  final RouteMapPoint centroid;
+  final Offset centroid;
 }
 
 /// 구조화 노선도 집합 (렌더러 입력).
@@ -115,70 +97,41 @@ class StructuredRouteMap {
       lines.isEmpty && stations.isEmpty && transferGroups.isEmpty;
 }
 
-/// 빌더 입력: route_map_positions 한 행에 대응하는 원시 값.
+/// 빌더 입력: route_map_positions 한 행에 대응하는 값.
+/// [labelPolygon]은 호출부에서 기존 _parseLabelPolygon으로 미리 파싱해 전달한다.
+/// [downPath]는 이 역으로 들어오는 track 세그먼트("M prev L this")의 원본 문자열.
 class StructuredRouteMapStationInput {
   const StructuredRouteMapStationInput({
     required this.stationId,
     required this.lineId,
     required this.sequence,
-    required this.x,
-    required this.y,
-    required this.upPath,
-    required this.downPath,
+    required this.position,
     required this.labelPolygon,
+    required this.downPath,
   });
 
   final String stationId;
   final String lineId;
   final int sequence;
-  final double x;
-  final double y;
-  final String upPath;
+  final Offset position;
+  final List<Offset> labelPolygon;
   final String downPath;
-  final String labelPolygon;
 }
 
-/// "M x y L x y ..." 형태의 절대 좌표 path 문자열을 점 목록으로 파싱한다.
-/// 명령 문자(M/L 등)는 건너뛰고 숫자 쌍만 읽는다. 잘못된 입력은 건너뛴다.
-List<RouteMapPoint> parseRouteMapPath(String path) {
+/// "M x y L x y ..." 형태의 절대 좌표 path를 정점 목록으로 파싱한다.
+/// 데이터팩(enrich-capital-route-map-layer.mjs)은 절대 M/L 세그먼트만 방출하므로
+/// 명령 문자는 무시하고 숫자 쌍만 읽는다. (H/V/상대 명령은 대상 아님.)
+List<Offset> parseRouteMapPolyline(String path) {
   if (path.trim().isEmpty) {
     return const [];
   }
-  // 명령 문자(M/L 등)나 쉼표에 붙어 있어도 숫자만 추출한다.
   final numbers = RegExp(r'-?\d+(?:\.\d+)?')
       .allMatches(path)
       .map((match) => double.parse(match.group(0)!))
       .toList();
-  final points = <RouteMapPoint>[];
+  final points = <Offset>[];
   for (var index = 0; index + 1 < numbers.length; index += 2) {
-    points.add(RouteMapPoint(numbers[index], numbers[index + 1]));
-  }
-  return points;
-}
-
-/// label_polygon JSON('[{"x":..,"y":..}]')을 점 목록으로 파싱한다.
-List<RouteMapPoint> parseRouteMapLabelPolygon(String source) {
-  if (source.trim().isEmpty) {
-    return const [];
-  }
-  Object? decoded;
-  try {
-    decoded = jsonDecode(source);
-  } on FormatException {
-    return const [];
-  }
-  if (decoded is! List) {
-    return const [];
-  }
-  final points = <RouteMapPoint>[];
-  for (final entry in decoded) {
-    if (entry is Map) {
-      final x = (entry['x'] as num?)?.toDouble();
-      final y = (entry['y'] as num?)?.toDouble();
-      if (x != null && y != null) {
-        points.add(RouteMapPoint(x, y));
-      }
-    }
+    points.add(Offset(numbers[index], numbers[index + 1]));
   }
   return points;
 }
@@ -191,17 +144,19 @@ StructuredRouteMap buildStructuredRouteMap(
 
   // 물리 역(station_id)이 속한 line 집합 → 환승 판정.
   final lineIdsByStation = <String, Set<String>>{};
-  final positionsByStation = <String, List<RouteMapPoint>>{};
+  // 환승 중심 계산용: 환승역 후보만 좌표를 모은다.
+  final positionsByStation = <String, List<Offset>>{};
   for (final input in inputList) {
     lineIdsByStation
         .putIfAbsent(input.stationId, () => <String>{})
         .add(input.lineId);
     positionsByStation
-        .putIfAbsent(input.stationId, () => <RouteMapPoint>[])
-        .add(RouteMapPoint(input.x, input.y));
+        .putIfAbsent(input.stationId, () => <Offset>[])
+        .add(input.position);
   }
 
-  // 노선별 방향 polyline: sequence 순서로 세그먼트를 이어 붙인다.
+  // 노선별 track polyline: sequence(동률 시 station_id) 순서로 세그먼트를 잇되
+  // 이어지지 않는 지점에서 끊는다.
   final byLine = <String, List<StructuredRouteMapStationInput>>{};
   for (final input in inputList) {
     byLine.putIfAbsent(input.lineId, () => []).add(input);
@@ -209,13 +164,11 @@ StructuredRouteMap buildStructuredRouteMap(
   final lines = <RouteMapLineGeometry>[];
   final orderedLineIds = byLine.keys.toList()..sort();
   for (final lineId in orderedLineIds) {
-    final stations = byLine[lineId]!
-      ..sort((a, b) => a.sequence.compareTo(b.sequence));
+    final stations = byLine[lineId]!..sort(_bySequenceThenStation);
     lines.add(
       RouteMapLineGeometry(
         lineId: lineId,
-        upPolyline: _joinSegments(stations.map((s) => s.upPath)),
-        downPolyline: _joinSegments(stations.map((s) => s.downPath)),
+        polylines: _assemblePolylines(stations),
       ),
     );
   }
@@ -229,10 +182,11 @@ StructuredRouteMap buildStructuredRouteMap(
         stationId: input.stationId,
         lineId: input.lineId,
         sequence: input.sequence,
-        position: RouteMapPoint(input.x, input.y),
-        labelPolygon: parseRouteMapLabelPolygon(input.labelPolygon),
-        labelClass:
-            isTransfer ? RouteMapLabelClass.transfer : RouteMapLabelClass.regular,
+        position: input.position,
+        labelPolygon: input.labelPolygon,
+        labelClass: isTransfer
+            ? RouteMapLabelClass.transfer
+            : RouteMapLabelClass.regular,
       ),
     );
   }
@@ -261,29 +215,46 @@ StructuredRouteMap buildStructuredRouteMap(
   );
 }
 
-/// 세그먼트 path 목록을 하나의 polyline으로 잇는다. 인접 세그먼트의 공유 정점은
-/// 중복 제거한다(세그먼트 i의 끝점 == 세그먼트 i+1의 시작점).
-List<RouteMapPoint> _joinSegments(Iterable<String> paths) {
-  final polyline = <RouteMapPoint>[];
-  for (final path in paths) {
-    for (final point in parseRouteMapPath(path)) {
-      if (polyline.isEmpty || polyline.last != point) {
-        polyline.add(point);
-      }
-    }
-  }
-  return polyline;
+int _bySequenceThenStation(
+  StructuredRouteMapStationInput a,
+  StructuredRouteMapStationInput b,
+) {
+  final bySequence = a.sequence.compareTo(b.sequence);
+  return bySequence != 0 ? bySequence : a.stationId.compareTo(b.stationId);
 }
 
-RouteMapPoint _centroid(List<RouteMapPoint> points) {
+/// down_path 세그먼트("M prev L this", 전방 정점 순서)들을 sequence 순서로 이어
+/// track polyline을 만든다. 인접 세그먼트가 끝점=시작점으로 이어지면 붙이고,
+/// 이어지지 않으면(데이터 hole) 새 polyline을 시작한다.
+List<List<Offset>> _assemblePolylines(
+  List<StructuredRouteMapStationInput> orderedStations,
+) {
+  final polylines = <List<Offset>>[];
+  List<Offset>? current;
+  for (final station in orderedStations) {
+    final segment = parseRouteMapPolyline(station.downPath);
+    if (segment.isEmpty) {
+      continue;
+    }
+    if (current != null && current.last == segment.first) {
+      current.addAll(segment.skip(1));
+    } else {
+      current = <Offset>[...segment];
+      polylines.add(current);
+    }
+  }
+  return polylines;
+}
+
+Offset _centroid(List<Offset> points) {
   if (points.isEmpty) {
-    return const RouteMapPoint(0, 0);
+    return Offset.zero;
   }
   var sumX = 0.0;
   var sumY = 0.0;
   for (final point in points) {
-    sumX += point.x;
-    sumY += point.y;
+    sumX += point.dx;
+    sumY += point.dy;
   }
-  return RouteMapPoint(sumX / points.length, sumY / points.length);
+  return Offset(sumX / points.length, sumY / points.length);
 }

--- a/apps/mobile/lib/features/network_map/domain/structured_route_map.dart
+++ b/apps/mobile/lib/features/network_map/domain/structured_route_map.dart
@@ -1,0 +1,289 @@
+// 구조화 노선도 도메인 모델과 파생 로직 (#1641 Stage 1: data layer).
+//
+// route_map_positions에서 앱으로 올라온 원시 필드(x/y, up_path/down_path,
+// label_polygon)를 native canvas 렌더러(#1641 Stage 2)가 바로 소비할 수 있는
+// 구조로 파생한다. 렌더링은 이 모듈에 없다 — 순수 파싱·파생만 한다.
+//
+// #1636 structured-route-map-contract의 layer/LOD 규칙을 따른다:
+// - line_geometry: up_path/down_path polyline
+// - transfer_groups: 같은 station_id에 여러 line_id → 중심 좌표
+// - station_labels priority: 환승 > 주요 > 일반 (별도 검수값 없으면 일반)
+// - LOD: zoom0 lines only, zoom1 환승/주요 라벨, zoom2 전체 역 라벨
+import 'dart:convert';
+
+/// 노선도 원본 좌표계의 2D 점.
+class RouteMapPoint {
+  const RouteMapPoint(this.x, this.y);
+
+  final double x;
+  final double y;
+
+  @override
+  bool operator ==(Object other) =>
+      other is RouteMapPoint && other.x == x && other.y == y;
+
+  @override
+  int get hashCode => Object.hash(x, y);
+
+  @override
+  String toString() => 'RouteMapPoint($x, $y)';
+}
+
+/// 라벨 우선순위 class (#1636 station_labels.priority).
+enum RouteMapLabelClass { transfer, major, regular }
+
+/// 라벨 class → 최초 표시 zoom bucket (#1636 LOD).
+/// 0 = lines only(라벨 없음), 1 = 환승/주요 라벨, 2 = 전체 역 라벨.
+int minLabelZoomBucketFor(RouteMapLabelClass labelClass) {
+  switch (labelClass) {
+    case RouteMapLabelClass.transfer:
+    case RouteMapLabelClass.major:
+      return 1;
+    case RouteMapLabelClass.regular:
+      return 2;
+  }
+}
+
+/// 한 노선의 방향별 polyline geometry.
+class RouteMapLineGeometry {
+  const RouteMapLineGeometry({
+    required this.lineId,
+    required this.upPolyline,
+    required this.downPolyline,
+  });
+
+  final String lineId;
+
+  /// 상행(up) 방향 정점 목록, station sequence 순서.
+  final List<RouteMapPoint> upPolyline;
+
+  /// 하행(down) 방향 정점 목록, station sequence 순서.
+  final List<RouteMapPoint> downPolyline;
+}
+
+/// 구조화된 역 노드 (렌더러가 point/label layer로 소비).
+class RouteMapStructuredStation {
+  const RouteMapStructuredStation({
+    required this.stationId,
+    required this.lineId,
+    required this.sequence,
+    required this.position,
+    required this.labelPolygon,
+    required this.labelClass,
+  });
+
+  final String stationId;
+  final String lineId;
+  final int sequence;
+  final RouteMapPoint position;
+  final List<RouteMapPoint> labelPolygon;
+  final RouteMapLabelClass labelClass;
+
+  int get minLabelZoomBucket => minLabelZoomBucketFor(labelClass);
+}
+
+/// 환승 그룹 (#1636 transfer_groups): 같은 물리 역의 노선 묶음.
+class RouteMapTransferGroup {
+  const RouteMapTransferGroup({
+    required this.stationId,
+    required this.lineIds,
+    required this.centroid,
+  });
+
+  final String stationId;
+
+  /// 이 역이 속한 line_id 목록 (정렬됨, 2개 이상).
+  final List<String> lineIds;
+
+  /// 표시 좌표: 해당 station_id route_map_positions의 중심값.
+  final RouteMapPoint centroid;
+}
+
+/// 구조화 노선도 집합 (렌더러 입력).
+class StructuredRouteMap {
+  const StructuredRouteMap({
+    required this.lines,
+    required this.stations,
+    required this.transferGroups,
+  });
+
+  final List<RouteMapLineGeometry> lines;
+  final List<RouteMapStructuredStation> stations;
+  final List<RouteMapTransferGroup> transferGroups;
+
+  bool get isEmpty =>
+      lines.isEmpty && stations.isEmpty && transferGroups.isEmpty;
+}
+
+/// 빌더 입력: route_map_positions 한 행에 대응하는 원시 값.
+class StructuredRouteMapStationInput {
+  const StructuredRouteMapStationInput({
+    required this.stationId,
+    required this.lineId,
+    required this.sequence,
+    required this.x,
+    required this.y,
+    required this.upPath,
+    required this.downPath,
+    required this.labelPolygon,
+  });
+
+  final String stationId;
+  final String lineId;
+  final int sequence;
+  final double x;
+  final double y;
+  final String upPath;
+  final String downPath;
+  final String labelPolygon;
+}
+
+/// "M x y L x y ..." 형태의 절대 좌표 path 문자열을 점 목록으로 파싱한다.
+/// 명령 문자(M/L 등)는 건너뛰고 숫자 쌍만 읽는다. 잘못된 입력은 건너뛴다.
+List<RouteMapPoint> parseRouteMapPath(String path) {
+  if (path.trim().isEmpty) {
+    return const [];
+  }
+  // 명령 문자(M/L 등)나 쉼표에 붙어 있어도 숫자만 추출한다.
+  final numbers = RegExp(r'-?\d+(?:\.\d+)?')
+      .allMatches(path)
+      .map((match) => double.parse(match.group(0)!))
+      .toList();
+  final points = <RouteMapPoint>[];
+  for (var index = 0; index + 1 < numbers.length; index += 2) {
+    points.add(RouteMapPoint(numbers[index], numbers[index + 1]));
+  }
+  return points;
+}
+
+/// label_polygon JSON('[{"x":..,"y":..}]')을 점 목록으로 파싱한다.
+List<RouteMapPoint> parseRouteMapLabelPolygon(String source) {
+  if (source.trim().isEmpty) {
+    return const [];
+  }
+  Object? decoded;
+  try {
+    decoded = jsonDecode(source);
+  } on FormatException {
+    return const [];
+  }
+  if (decoded is! List) {
+    return const [];
+  }
+  final points = <RouteMapPoint>[];
+  for (final entry in decoded) {
+    if (entry is Map) {
+      final x = (entry['x'] as num?)?.toDouble();
+      final y = (entry['y'] as num?)?.toDouble();
+      if (x != null && y != null) {
+        points.add(RouteMapPoint(x, y));
+      }
+    }
+  }
+  return points;
+}
+
+/// 원시 route_map_positions 입력에서 구조화 노선도를 파생한다.
+StructuredRouteMap buildStructuredRouteMap(
+  Iterable<StructuredRouteMapStationInput> inputs,
+) {
+  final inputList = inputs.toList(growable: false);
+
+  // 물리 역(station_id)이 속한 line 집합 → 환승 판정.
+  final lineIdsByStation = <String, Set<String>>{};
+  final positionsByStation = <String, List<RouteMapPoint>>{};
+  for (final input in inputList) {
+    lineIdsByStation
+        .putIfAbsent(input.stationId, () => <String>{})
+        .add(input.lineId);
+    positionsByStation
+        .putIfAbsent(input.stationId, () => <RouteMapPoint>[])
+        .add(RouteMapPoint(input.x, input.y));
+  }
+
+  // 노선별 방향 polyline: sequence 순서로 세그먼트를 이어 붙인다.
+  final byLine = <String, List<StructuredRouteMapStationInput>>{};
+  for (final input in inputList) {
+    byLine.putIfAbsent(input.lineId, () => []).add(input);
+  }
+  final lines = <RouteMapLineGeometry>[];
+  final orderedLineIds = byLine.keys.toList()..sort();
+  for (final lineId in orderedLineIds) {
+    final stations = byLine[lineId]!
+      ..sort((a, b) => a.sequence.compareTo(b.sequence));
+    lines.add(
+      RouteMapLineGeometry(
+        lineId: lineId,
+        upPolyline: _joinSegments(stations.map((s) => s.upPath)),
+        downPolyline: _joinSegments(stations.map((s) => s.downPath)),
+      ),
+    );
+  }
+
+  // 구조화 역 노드 + 라벨 class.
+  final stations = <RouteMapStructuredStation>[];
+  for (final input in inputList) {
+    final isTransfer = (lineIdsByStation[input.stationId]?.length ?? 0) > 1;
+    stations.add(
+      RouteMapStructuredStation(
+        stationId: input.stationId,
+        lineId: input.lineId,
+        sequence: input.sequence,
+        position: RouteMapPoint(input.x, input.y),
+        labelPolygon: parseRouteMapLabelPolygon(input.labelPolygon),
+        labelClass:
+            isTransfer ? RouteMapLabelClass.transfer : RouteMapLabelClass.regular,
+      ),
+    );
+  }
+
+  // 환승 그룹: 2개 이상 노선에 속한 역, 중심 좌표.
+  final transferGroups = <RouteMapTransferGroup>[];
+  final transferStationIds = lineIdsByStation.entries
+      .where((entry) => entry.value.length > 1)
+      .map((entry) => entry.key)
+      .toList()
+    ..sort();
+  for (final stationId in transferStationIds) {
+    transferGroups.add(
+      RouteMapTransferGroup(
+        stationId: stationId,
+        lineIds: lineIdsByStation[stationId]!.toList()..sort(),
+        centroid: _centroid(positionsByStation[stationId]!),
+      ),
+    );
+  }
+
+  return StructuredRouteMap(
+    lines: lines,
+    stations: stations,
+    transferGroups: transferGroups,
+  );
+}
+
+/// 세그먼트 path 목록을 하나의 polyline으로 잇는다. 인접 세그먼트의 공유 정점은
+/// 중복 제거한다(세그먼트 i의 끝점 == 세그먼트 i+1의 시작점).
+List<RouteMapPoint> _joinSegments(Iterable<String> paths) {
+  final polyline = <RouteMapPoint>[];
+  for (final path in paths) {
+    for (final point in parseRouteMapPath(path)) {
+      if (polyline.isEmpty || polyline.last != point) {
+        polyline.add(point);
+      }
+    }
+  }
+  return polyline;
+}
+
+RouteMapPoint _centroid(List<RouteMapPoint> points) {
+  if (points.isEmpty) {
+    return const RouteMapPoint(0, 0);
+  }
+  var sumX = 0.0;
+  var sumY = 0.0;
+  for (final point in points) {
+    sumX += point.x;
+    sumY += point.y;
+  }
+  return RouteMapPoint(sumX / points.length, sumY / points.length);
+}

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -9,6 +9,7 @@ import 'package:flutter/scheduler.dart';
 import 'accessible_design.dart';
 import 'ad_slot.dart';
 import 'features/network_map/domain/map_camera.dart';
+import 'features/network_map/domain/structured_route_map.dart';
 import 'features/network_map/infrastructure/android_route_map_viewport_webview.dart';
 import 'features/network_map/infrastructure/ios_route_map_viewport_webview.dart';
 import 'features/network_map/infrastructure/route_map_renderer.dart';
@@ -98,6 +99,26 @@ class NetworkMapData {
       stationLineMemberships: _objectList(
         json['stationLineMemberships'],
       ).map(NetworkMapStationLineMembership.fromJson).toList(growable: false),
+    );
+  }
+
+  /// 구조화 노선도 레이어(#1636 스키마 기준)를 파생한다. native canvas
+  /// 렌더러(#1641)가 소비하는 line geometry / transfer group / label·LOD를
+  /// route_map_positions 필드에서 계산한다.
+  StructuredRouteMap toStructuredRouteMap() {
+    return buildStructuredRouteMap(
+      stations.map(
+        (station) => StructuredRouteMapStationInput(
+          stationId: station.id,
+          lineId: station.lineId,
+          sequence: station.sequence,
+          x: station.position.x.toDouble(),
+          y: station.position.y.toDouble(),
+          upPath: station.position.upPath,
+          downPath: station.position.downPath,
+          labelPolygon: station.position.labelPolygon,
+        ),
+      ),
     );
   }
 }

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -112,11 +112,13 @@ class NetworkMapData {
           stationId: station.id,
           lineId: station.lineId,
           sequence: station.sequence,
-          x: station.position.x.toDouble(),
-          y: station.position.y.toDouble(),
-          upPath: station.position.upPath,
+          position: Offset(
+            station.position.x.toDouble(),
+            station.position.y.toDouble(),
+          ),
+          labelPolygon:
+              _parseLabelPolygon(station.position.labelPolygon) ?? const [],
           downPath: station.position.downPath,
-          labelPolygon: station.position.labelPolygon,
         ),
       ),
     );

--- a/apps/mobile/test/features/network_map/domain/structured_route_map_test.dart
+++ b/apps/mobile/test/features/network_map/domain/structured_route_map_test.dart
@@ -1,0 +1,134 @@
+import 'package:easysubway_mobile/features/network_map/domain/structured_route_map.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+StructuredRouteMapStationInput input({
+  required String stationId,
+  required String lineId,
+  required int sequence,
+  double x = 0,
+  double y = 0,
+  String upPath = '',
+  String downPath = '',
+  String labelPolygon = '',
+}) {
+  return StructuredRouteMapStationInput(
+    stationId: stationId,
+    lineId: lineId,
+    sequence: sequence,
+    x: x,
+    y: y,
+    upPath: upPath,
+    downPath: downPath,
+    labelPolygon: labelPolygon,
+  );
+}
+
+void main() {
+  group('parseRouteMapPath', () {
+    test('절대 M/L 명령을 점 목록으로 파싱한다', () {
+      expect(parseRouteMapPath('M 1623 1238 L 1744 1359'), <RouteMapPoint>[
+        const RouteMapPoint(1623, 1238),
+        const RouteMapPoint(1744, 1359),
+      ]);
+    });
+
+    test('빈 문자열은 빈 목록', () {
+      expect(parseRouteMapPath(''), isEmpty);
+      expect(parseRouteMapPath('   '), isEmpty);
+    });
+
+    test('명령 문자를 건너뛰고 쉼표 구분도 처리한다', () {
+      expect(parseRouteMapPath('M1,2 L3,4'), <RouteMapPoint>[
+        const RouteMapPoint(1, 2),
+        const RouteMapPoint(3, 4),
+      ]);
+    });
+
+    test('짝이 맞지 않는 마지막 숫자는 버린다', () {
+      expect(parseRouteMapPath('M 1 2 L 3'), <RouteMapPoint>[
+        const RouteMapPoint(1, 2),
+      ]);
+    });
+  });
+
+  group('parseRouteMapLabelPolygon', () {
+    test('JSON 폴리곤을 점 목록으로 파싱한다', () {
+      const source = '[{"x":1741,"y":1348},{"x":1779,"y":1370}]';
+      expect(parseRouteMapLabelPolygon(source), <RouteMapPoint>[
+        const RouteMapPoint(1741, 1348),
+        const RouteMapPoint(1779, 1370),
+      ]);
+    });
+
+    test('빈/잘못된 입력은 빈 목록', () {
+      expect(parseRouteMapLabelPolygon(''), isEmpty);
+      expect(parseRouteMapLabelPolygon('not json'), isEmpty);
+      expect(parseRouteMapLabelPolygon('{"x":1}'), isEmpty);
+    });
+  });
+
+  group('buildStructuredRouteMap', () {
+    test('노선 polyline을 sequence 순서로 잇고 공유 정점을 중복 제거한다', () {
+      final map = buildStructuredRouteMap([
+        input(
+          stationId: 's2',
+          lineId: 'L1',
+          sequence: 2,
+          downPath: 'M 10 10 L 20 20',
+        ),
+        input(
+          stationId: 's1',
+          lineId: 'L1',
+          sequence: 1,
+          downPath: 'M 0 0 L 10 10',
+        ),
+      ]);
+
+      expect(map.lines, hasLength(1));
+      // sequence 1,2 순서로 세그먼트 연결: (0,0)-(10,10)-(20,20), 공유점 (10,10) 1회.
+      expect(map.lines.single.downPolyline, <RouteMapPoint>[
+        const RouteMapPoint(0, 0),
+        const RouteMapPoint(10, 10),
+        const RouteMapPoint(20, 20),
+      ]);
+    });
+
+    test('여러 노선에 속한 역을 환승 그룹으로 묶고 중심 좌표를 구한다', () {
+      final map = buildStructuredRouteMap([
+        input(stationId: 's1', lineId: 'L1', sequence: 1, x: 0, y: 0),
+        input(stationId: 's1', lineId: 'L2', sequence: 5, x: 10, y: 20),
+        input(stationId: 's2', lineId: 'L1', sequence: 2, x: 100, y: 100),
+      ]);
+
+      expect(map.transferGroups, hasLength(1));
+      final group = map.transferGroups.single;
+      expect(group.stationId, 's1');
+      expect(group.lineIds, <String>['L1', 'L2']);
+      expect(group.centroid, const RouteMapPoint(5, 10));
+    });
+
+    test('환승역은 transfer, 단일 노선역은 regular class', () {
+      final map = buildStructuredRouteMap([
+        input(stationId: 's1', lineId: 'L1', sequence: 1),
+        input(stationId: 's1', lineId: 'L2', sequence: 1),
+        input(stationId: 's2', lineId: 'L1', sequence: 2),
+      ]);
+
+      final transfer = map.stations.firstWhere((s) => s.stationId == 's1');
+      final regular = map.stations.firstWhere((s) => s.stationId == 's2');
+      expect(transfer.labelClass, RouteMapLabelClass.transfer);
+      expect(regular.labelClass, RouteMapLabelClass.regular);
+    });
+
+    test('LOD: transfer/major는 zoom1, regular는 zoom2에서 라벨 노출', () {
+      expect(minLabelZoomBucketFor(RouteMapLabelClass.transfer), 1);
+      expect(minLabelZoomBucketFor(RouteMapLabelClass.major), 1);
+      expect(minLabelZoomBucketFor(RouteMapLabelClass.regular), 2);
+    });
+
+    test('빈 입력은 빈 구조', () {
+      final map = buildStructuredRouteMap(const []);
+      expect(map.isEmpty, isTrue);
+    });
+  });
+}

--- a/apps/mobile/test/features/network_map/domain/structured_route_map_test.dart
+++ b/apps/mobile/test/features/network_map/domain/structured_route_map_test.dart
@@ -5,70 +5,48 @@ StructuredRouteMapStationInput input({
   required String stationId,
   required String lineId,
   required int sequence,
-  double x = 0,
-  double y = 0,
-  String upPath = '',
+  Offset position = Offset.zero,
+  List<Offset> labelPolygon = const [],
   String downPath = '',
-  String labelPolygon = '',
 }) {
   return StructuredRouteMapStationInput(
     stationId: stationId,
     lineId: lineId,
     sequence: sequence,
-    x: x,
-    y: y,
-    upPath: upPath,
-    downPath: downPath,
+    position: position,
     labelPolygon: labelPolygon,
+    downPath: downPath,
   );
 }
 
 void main() {
-  group('parseRouteMapPath', () {
-    test('절대 M/L 명령을 점 목록으로 파싱한다', () {
-      expect(parseRouteMapPath('M 1623 1238 L 1744 1359'), <RouteMapPoint>[
-        const RouteMapPoint(1623, 1238),
-        const RouteMapPoint(1744, 1359),
+  group('parseRouteMapPolyline', () {
+    test('절대 M/L 명령을 정점 목록으로 파싱한다', () {
+      expect(parseRouteMapPolyline('M 1623 1238 L 1744 1359'), <Offset>[
+        const Offset(1623, 1238),
+        const Offset(1744, 1359),
       ]);
     });
 
     test('빈 문자열은 빈 목록', () {
-      expect(parseRouteMapPath(''), isEmpty);
-      expect(parseRouteMapPath('   '), isEmpty);
+      expect(parseRouteMapPolyline(''), isEmpty);
+      expect(parseRouteMapPolyline('   '), isEmpty);
     });
 
-    test('명령 문자를 건너뛰고 쉼표 구분도 처리한다', () {
-      expect(parseRouteMapPath('M1,2 L3,4'), <RouteMapPoint>[
-        const RouteMapPoint(1, 2),
-        const RouteMapPoint(3, 4),
+    test('명령 문자에 붙어 있어도 숫자만 추출한다', () {
+      expect(parseRouteMapPolyline('M1,2 L3,4'), <Offset>[
+        const Offset(1, 2),
+        const Offset(3, 4),
       ]);
     });
 
     test('짝이 맞지 않는 마지막 숫자는 버린다', () {
-      expect(parseRouteMapPath('M 1 2 L 3'), <RouteMapPoint>[
-        const RouteMapPoint(1, 2),
-      ]);
-    });
-  });
-
-  group('parseRouteMapLabelPolygon', () {
-    test('JSON 폴리곤을 점 목록으로 파싱한다', () {
-      const source = '[{"x":1741,"y":1348},{"x":1779,"y":1370}]';
-      expect(parseRouteMapLabelPolygon(source), <RouteMapPoint>[
-        const RouteMapPoint(1741, 1348),
-        const RouteMapPoint(1779, 1370),
-      ]);
-    });
-
-    test('빈/잘못된 입력은 빈 목록', () {
-      expect(parseRouteMapLabelPolygon(''), isEmpty);
-      expect(parseRouteMapLabelPolygon('not json'), isEmpty);
-      expect(parseRouteMapLabelPolygon('{"x":1}'), isEmpty);
+      expect(parseRouteMapPolyline('M 1 2 L 3'), <Offset>[const Offset(1, 2)]);
     });
   });
 
   group('buildStructuredRouteMap', () {
-    test('노선 polyline을 sequence 순서로 잇고 공유 정점을 중복 제거한다', () {
+    test('track polyline을 sequence 순서로 잇고 공유 정점을 중복 제거한다', () {
       final map = buildStructuredRouteMap([
         input(
           stationId: 's2',
@@ -80,31 +58,99 @@ void main() {
           stationId: 's1',
           lineId: 'L1',
           sequence: 1,
-          downPath: 'M 0 0 L 10 10',
+          downPath: '', // 시점 역은 들어오는 세그먼트 없음
+        ),
+        input(
+          stationId: 's3',
+          lineId: 'L1',
+          sequence: 3,
+          downPath: 'M 20 20 L 30 30',
         ),
       ]);
 
       expect(map.lines, hasLength(1));
-      // sequence 1,2 순서로 세그먼트 연결: (0,0)-(10,10)-(20,20), 공유점 (10,10) 1회.
-      expect(map.lines.single.downPolyline, <RouteMapPoint>[
-        const RouteMapPoint(0, 0),
-        const RouteMapPoint(10, 10),
-        const RouteMapPoint(20, 20),
+      expect(map.lines.single.polylines, hasLength(1));
+      expect(map.lines.single.polylines.single, <Offset>[
+        const Offset(10, 10),
+        const Offset(20, 20),
+        const Offset(30, 30),
+      ]);
+    });
+
+    test('이어지지 않는 세그먼트(데이터 hole)에서 polyline을 끊는다', () {
+      final map = buildStructuredRouteMap([
+        input(stationId: 's1', lineId: 'L1', sequence: 1, downPath: ''),
+        input(
+          stationId: 's2',
+          lineId: 'L1',
+          sequence: 2,
+          downPath: 'M 0 0 L 10 10',
+        ),
+        // s3 세그먼트가 (10,10)에서 이어지지 않고 (30,30)에서 시작 → 끊는다.
+        input(
+          stationId: 's3',
+          lineId: 'L1',
+          sequence: 3,
+          downPath: 'M 30 30 L 40 40',
+        ),
+      ]);
+
+      expect(map.lines.single.polylines, <List<Offset>>[
+        [const Offset(0, 0), const Offset(10, 10)],
+        [const Offset(30, 30), const Offset(40, 40)],
+      ]);
+    });
+
+    test('sequence 동률이면 station_id로 결정적으로 정렬한다', () {
+      final ordered = buildStructuredRouteMap([
+        input(
+          stationId: 'sb',
+          lineId: 'L1',
+          sequence: 1,
+          downPath: 'M 5 5 L 6 6',
+        ),
+        input(
+          stationId: 'sa',
+          lineId: 'L1',
+          sequence: 1,
+          downPath: 'M 0 0 L 5 5',
+        ),
+      ]);
+      // sa(먼저) → sb: (0,0)-(5,5)-(6,6) 하나로 이어진다.
+      expect(ordered.lines.single.polylines.single, <Offset>[
+        const Offset(0, 0),
+        const Offset(5, 5),
+        const Offset(6, 6),
       ]);
     });
 
     test('여러 노선에 속한 역을 환승 그룹으로 묶고 중심 좌표를 구한다', () {
       final map = buildStructuredRouteMap([
-        input(stationId: 's1', lineId: 'L1', sequence: 1, x: 0, y: 0),
-        input(stationId: 's1', lineId: 'L2', sequence: 5, x: 10, y: 20),
-        input(stationId: 's2', lineId: 'L1', sequence: 2, x: 100, y: 100),
+        input(
+          stationId: 's1',
+          lineId: 'L1',
+          sequence: 1,
+          position: Offset.zero,
+        ),
+        input(
+          stationId: 's1',
+          lineId: 'L2',
+          sequence: 5,
+          position: const Offset(10, 20),
+        ),
+        input(
+          stationId: 's2',
+          lineId: 'L1',
+          sequence: 2,
+          position: const Offset(100, 100),
+        ),
       ]);
 
       expect(map.transferGroups, hasLength(1));
       final group = map.transferGroups.single;
       expect(group.stationId, 's1');
       expect(group.lineIds, <String>['L1', 'L2']);
-      expect(group.centroid, const RouteMapPoint(5, 10));
+      expect(group.centroid, const Offset(5, 10));
     });
 
     test('환승역은 transfer, 단일 노선역은 regular class', () {
@@ -118,17 +164,18 @@ void main() {
       final regular = map.stations.firstWhere((s) => s.stationId == 's2');
       expect(transfer.labelClass, RouteMapLabelClass.transfer);
       expect(regular.labelClass, RouteMapLabelClass.regular);
+      expect(transfer.minLabelZoomBucket, 1);
+      expect(regular.minLabelZoomBucket, 2);
     });
 
-    test('LOD: transfer/major는 zoom1, regular는 zoom2에서 라벨 노출', () {
+    test('LOD: transfer/major는 zoom1, regular는 zoom2', () {
       expect(minLabelZoomBucketFor(RouteMapLabelClass.transfer), 1);
       expect(minLabelZoomBucketFor(RouteMapLabelClass.major), 1);
       expect(minLabelZoomBucketFor(RouteMapLabelClass.regular), 2);
     });
 
     test('빈 입력은 빈 구조', () {
-      final map = buildStructuredRouteMap(const []);
-      expect(map.isEmpty, isTrue);
+      expect(buildStructuredRouteMap(const []).isEmpty, isTrue);
     });
   });
 }


### PR DESCRIPTION
## Summary
- #1641(Flutter 구조화 노선도 렌더러)의 **1단계: 데이터 레이어**입니다. `route_map_positions` 원시 필드(x/y, `up_path`/`down_path`, `label_polygon`)를 native canvas 렌더러(2단계)가 바로 소비할 구조로 파생합니다. **렌더링 코드는 없습니다 — 순수 파싱·파생만** 합니다.
- `features/network_map/domain/structured_route_map.dart` 신설:
  - `parseRouteMapPath`(M/L 절대 좌표 path) / `parseRouteMapLabelPolygon`(JSON 폴리곤) — 숫자만 추출해 명령 문자·쉼표에 견고.
  - `buildStructuredRouteMap`: 노선별 방향 polyline(sequence 순서로 세그먼트 연결·공유 정점 중복 제거), 환승 그룹(2개 이상 노선 소속·중심 좌표), 라벨 class(환승>주요>일반, 별도 검수값 없으면 일반), LOD zoom bucket(zoom0 lines only / zoom1 환승·주요 / zoom2 전체) — **#1636 structured-route-map-contract** 기준.
- `NetworkMapData.toStructuredRouteMap()` 어댑터로 렌더러가 소비 가능하게 연결(2단계에서 그림).

## 단계 계획 (#1641)
1. **데이터 레이어 (본 PR)** — 파싱·파생 + 단위 테스트
2. Canvas 렌더러 코어 (station point + line path, viewport culling + LOD, renderer-selection flag, WebView 기본 유지)
3. 라벨(우선순위·충돌) + 환승 노드 + 경로 강조 + 광주 attribution
4. Controller 이벤트 계약(FramePresented/CameraLatency) + 접근성(48dp/Semantics)

## Test Plan
- `flutter test test/features/network_map/domain/structured_route_map_test.dart` (11 pass)
- `flutter analyze` (No issues)
- 파싱은 실제 capital 팩 포맷 기준(`M 1623 1238 L 1744 1359`, `[{"x":..,"y":..}]`)

Refs #1641

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 모바일 노선도 데이터가 구조화된 형태로 변환되어, 역·노선·환승 정보와 라벨 표시 기준이 더 정확하게 반영됩니다.
  * 경로 선, 역 위치, 환승 그룹, 라벨 우선순위가 일관된 방식으로 생성되어 지도 표시 품질이 향상됩니다.

* **Bug Fixes**
  * 경로 좌표와 라벨 영역 파싱이 더 안정적으로 처리되어, 잘못된 입력이나 빈 값에서도 표시 오류를 줄였습니다.
  * 여러 노선이 만나는 역의 환승 표시와 중심 좌표 계산이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->