### PR TITLE
[Mobile] 구조화 노선도 canvas 렌더러 코어 (#1641 stage 2)

### DIFF
--- a/apps/mobile/lib/features/network_map/presentation/structured_route_map_painter.dart
+++ b/apps/mobile/lib/features/network_map/presentation/structured_route_map_painter.dart
@@ -1,3 +1,6 @@
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart' show mapEquals;
 import 'package:flutter/widgets.dart';
 
 import '../../stations/domain/station_line.dart' show stationLineColor;
@@ -89,23 +92,45 @@ class StructuredRouteMapPainter extends CustomPainter {
   static const Color _transferFill = Color(0xFFFFFFFF);
   static const Color _transferBorder = Color(0xFF102A2C);
   static const Color _fallbackLineColor = Color(0xFF8D8D8D);
+  static const double _transferBorderWidth = 2.0;
+
+  // 프레임마다 재할당하지 않도록 Paint를 인스턴스/정적 필드로 hoist한다.
+  final Paint _linePaint = Paint()
+    ..style = PaintingStyle.stroke
+    ..strokeJoin = StrokeJoin.round
+    ..strokeCap = StrokeCap.round
+    ..isAntiAlias = true;
+  final Paint _regularStationPaint = Paint()
+    ..style = PaintingStyle.fill
+    ..isAntiAlias = true;
+  static final Paint _transferFillPaint = Paint()
+    ..style = PaintingStyle.fill
+    ..color = _transferFill
+    ..isAntiAlias = true;
+  static final Paint _transferBorderPaint = Paint()
+    ..style = PaintingStyle.stroke
+    ..strokeWidth = _transferBorderWidth
+    ..color = _transferBorder
+    ..isAntiAlias = true;
 
   @override
   void paint(Canvas canvas, Size size) {
-    final visible = camera.visibleSourceRect;
+    // stroke 폭·점 반지름은 viewport px이므로 source 단위로 환산해 culling
+    // rect를 넓힌다. 경계에서 선 끝·반원이 튀는(pop) 현상 방지.
+    final maxViewportExtent = math.max(
+      lineWidth / 2,
+      math.max(stationRadius, transferStationRadius),
+    );
+    final margin = maxViewportExtent / camera.scale;
+    final visible = camera.visibleSourceRect.inflate(margin);
     _paintLines(canvas, visible);
     _paintStations(canvas, visible);
   }
 
   void _paintLines(Canvas canvas, Rect visible) {
+    _linePaint.strokeWidth = lineWidth;
     for (final line in map.lines) {
-      final paint = Paint()
-        ..color = lineColors[line.lineId] ?? _fallbackLineColor
-        ..style = PaintingStyle.stroke
-        ..strokeWidth = lineWidth
-        ..strokeJoin = StrokeJoin.round
-        ..strokeCap = StrokeCap.round
-        ..isAntiAlias = true;
+      _linePaint.color = lineColors[line.lineId] ?? _fallbackLineColor;
       for (final polyline in line.polylines) {
         // viewport 밖 sub-polyline은 그리지 않는다 (culling).
         if (!routeMapPolylineIntersectsRect(polyline, visible)) {
@@ -122,40 +147,46 @@ class StructuredRouteMapPainter extends CustomPainter {
             path.lineTo(viewportPoint.dx, viewportPoint.dy);
           }
         }
-        canvas.drawPath(path, paint);
+        canvas.drawPath(path, _linePaint);
       }
     }
   }
 
   void _paintStations(Canvas canvas, Rect visible) {
     final bucket = routeMapZoomBucket(camera);
-    final fillPaint = Paint()..style = PaintingStyle.fill;
-    final transferFillPaint = Paint()
-      ..style = PaintingStyle.fill
-      ..color = _transferFill;
-    final transferBorderPaint = Paint()
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = 2.0
-      ..color = _transferBorder
-      ..isAntiAlias = true;
+
+    // 일반(비환승) 역 점: LOD는 도메인 helper 단일 소스를 재사용한다.
+    // 환승 노드는 transferGroups에서 한 번만 그리므로 여기서 건너뛴다.
     for (final station in map.stations) {
-      final isTransfer = station.labelClass == RouteMapLabelClass.transfer;
-      // LOD: 최소 확대(bucket 0)에서는 환승역 점만 그린다.
-      if (bucket == 0 && !isTransfer) {
+      if (station.labelClass == RouteMapLabelClass.transfer) {
         continue;
       }
-      // viewport 밖 역은 그리지 않는다 (culling).
+      if (bucket < minLabelZoomBucketFor(station.labelClass)) {
+        continue;
+      }
       if (!visible.contains(station.position)) {
         continue;
       }
-      final center = camera.sourceToViewportPoint(station.position);
-      if (isTransfer) {
-        canvas.drawCircle(center, transferStationRadius, transferFillPaint);
-        canvas.drawCircle(center, transferStationRadius, transferBorderPaint);
-      } else {
-        fillPaint.color = lineColors[station.lineId] ?? _fallbackLineColor;
-        canvas.drawCircle(center, stationRadius, fillPaint);
+      _regularStationPaint.color =
+          lineColors[station.lineId] ?? _fallbackLineColor;
+      canvas.drawCircle(
+        camera.sourceToViewportPoint(station.position),
+        stationRadius,
+        _regularStationPaint,
+      );
+    }
+
+    // 환승 마커: 물리 역당 한 번, transferGroups 중심 좌표에 그린다.
+    if (bucket < minLabelZoomBucketFor(RouteMapLabelClass.transfer)) {
+      return;
+    }
+    for (final group in map.transferGroups) {
+      if (!visible.contains(group.centroid)) {
+        continue;
       }
+      final center = camera.sourceToViewportPoint(group.centroid);
+      canvas.drawCircle(center, transferStationRadius, _transferFillPaint);
+      canvas.drawCircle(center, transferStationRadius, _transferBorderPaint);
     }
   }
 
@@ -163,7 +194,7 @@ class StructuredRouteMapPainter extends CustomPainter {
   bool shouldRepaint(StructuredRouteMapPainter oldDelegate) {
     return oldDelegate.camera.revision != camera.revision ||
         !identical(oldDelegate.map, map) ||
-        oldDelegate.lineColors != lineColors ||
+        !mapEquals(oldDelegate.lineColors, lineColors) ||
         oldDelegate.lineWidth != lineWidth ||
         oldDelegate.stationRadius != stationRadius ||
         oldDelegate.transferStationRadius != transferStationRadius;

--- a/apps/mobile/lib/features/network_map/presentation/structured_route_map_painter.dart
+++ b/apps/mobile/lib/features/network_map/presentation/structured_route_map_painter.dart
@@ -1,0 +1,198 @@
+import 'package:flutter/widgets.dart';
+
+import '../../stations/domain/station_line.dart' show stationLineColor;
+import '../domain/map_camera.dart';
+import '../domain/structured_route_map.dart';
+
+// 구조화 노선도 native canvas 렌더러 코어 (#1641 Stage 2).
+//
+// WebView SVG 렌더러를 대체하는 CustomPainter. 이 파일은 선(line path)과
+// 역 점(station point) 레이어를 viewport culling + LOD로 그린다. 라벨/환승
+// 노드/경로 강조는 Stage 3, controller 이벤트·접근성은 Stage 4에서 얹는다.
+//
+// 전환은 [RouteMapRendererKind] flag로 제어하며 기본값은 WebView다(병행 유지).
+// QA(#1642/#1643) 통과 후 WebView 경로와 assets/datapacks/maps/*.svg를 제거한다.
+
+/// 노선도 렌더러 선택 flag. 기본값 WebView 유지(#1641 전환 전략).
+enum RouteMapRendererKind { webView, structuredCanvas }
+
+const RouteMapRendererKind kDefaultRouteMapRenderer =
+    RouteMapRendererKind.webView;
+
+/// line_id → hex 색 문자열 맵을 렌더러용 [Color] 맵으로 변환한다.
+/// 기존 [stationLineColor] 파서를 재사용한다(hex 파싱·fallback 일원화).
+Map<String, Color> routeMapLineColors(Map<String, String> hexColorByLineId) {
+  return {
+    for (final entry in hexColorByLineId.entries)
+      entry.key: stationLineColor(entry.value),
+  };
+}
+
+/// 카메라 scale을 #1636 LOD zoom bucket(0/1/2)으로 매핑한다.
+/// 0 = 최소 확대(선·환승만), 1 = 중간, 2 = 최대 확대(전체 역).
+int routeMapZoomBucket(MapCameraState camera) {
+  final range = camera.maxScale - camera.minScale;
+  if (range <= 0) {
+    return 2;
+  }
+  final t = ((camera.scale - camera.minScale) / range).clamp(0.0, 1.0);
+  if (t < 1 / 3) {
+    return 0;
+  }
+  if (t < 2 / 3) {
+    return 1;
+  }
+  return 2;
+}
+
+/// polyline의 bounding box가 [rect]와 겹치는지 — viewport culling 판정.
+bool routeMapPolylineIntersectsRect(List<Offset> polyline, Rect rect) {
+  if (polyline.isEmpty) {
+    return false;
+  }
+  var minX = polyline.first.dx;
+  var maxX = polyline.first.dx;
+  var minY = polyline.first.dy;
+  var maxY = polyline.first.dy;
+  for (final point in polyline) {
+    if (point.dx < minX) minX = point.dx;
+    if (point.dx > maxX) maxX = point.dx;
+    if (point.dy < minY) minY = point.dy;
+    if (point.dy > maxY) maxY = point.dy;
+  }
+  return maxX >= rect.left &&
+      minX <= rect.right &&
+      maxY >= rect.top &&
+      minY <= rect.bottom;
+}
+
+/// 구조화 노선도 line/station layer를 그리는 CustomPainter.
+class StructuredRouteMapPainter extends CustomPainter {
+  StructuredRouteMapPainter({
+    required this.map,
+    required this.camera,
+    required this.lineColors,
+    this.lineWidth = 4.0,
+    this.stationRadius = 3.0,
+    this.transferStationRadius = 5.0,
+  });
+
+  final StructuredRouteMap map;
+  final MapCameraState camera;
+
+  /// line_id → 색. 없으면 노선 색 fallback을 쓴다.
+  final Map<String, Color> lineColors;
+  final double lineWidth;
+  final double stationRadius;
+  final double transferStationRadius;
+
+  static const Color _transferFill = Color(0xFFFFFFFF);
+  static const Color _transferBorder = Color(0xFF102A2C);
+  static const Color _fallbackLineColor = Color(0xFF8D8D8D);
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final visible = camera.visibleSourceRect;
+    _paintLines(canvas, visible);
+    _paintStations(canvas, visible);
+  }
+
+  void _paintLines(Canvas canvas, Rect visible) {
+    for (final line in map.lines) {
+      final paint = Paint()
+        ..color = lineColors[line.lineId] ?? _fallbackLineColor
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = lineWidth
+        ..strokeJoin = StrokeJoin.round
+        ..strokeCap = StrokeCap.round
+        ..isAntiAlias = true;
+      for (final polyline in line.polylines) {
+        // viewport 밖 sub-polyline은 그리지 않는다 (culling).
+        if (!routeMapPolylineIntersectsRect(polyline, visible)) {
+          continue;
+        }
+        final path = Path();
+        var isFirst = true;
+        for (final point in polyline) {
+          final viewportPoint = camera.sourceToViewportPoint(point);
+          if (isFirst) {
+            path.moveTo(viewportPoint.dx, viewportPoint.dy);
+            isFirst = false;
+          } else {
+            path.lineTo(viewportPoint.dx, viewportPoint.dy);
+          }
+        }
+        canvas.drawPath(path, paint);
+      }
+    }
+  }
+
+  void _paintStations(Canvas canvas, Rect visible) {
+    final bucket = routeMapZoomBucket(camera);
+    final fillPaint = Paint()..style = PaintingStyle.fill;
+    final transferFillPaint = Paint()
+      ..style = PaintingStyle.fill
+      ..color = _transferFill;
+    final transferBorderPaint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 2.0
+      ..color = _transferBorder
+      ..isAntiAlias = true;
+    for (final station in map.stations) {
+      final isTransfer = station.labelClass == RouteMapLabelClass.transfer;
+      // LOD: 최소 확대(bucket 0)에서는 환승역 점만 그린다.
+      if (bucket == 0 && !isTransfer) {
+        continue;
+      }
+      // viewport 밖 역은 그리지 않는다 (culling).
+      if (!visible.contains(station.position)) {
+        continue;
+      }
+      final center = camera.sourceToViewportPoint(station.position);
+      if (isTransfer) {
+        canvas.drawCircle(center, transferStationRadius, transferFillPaint);
+        canvas.drawCircle(center, transferStationRadius, transferBorderPaint);
+      } else {
+        fillPaint.color = lineColors[station.lineId] ?? _fallbackLineColor;
+        canvas.drawCircle(center, stationRadius, fillPaint);
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(StructuredRouteMapPainter oldDelegate) {
+    return oldDelegate.camera.revision != camera.revision ||
+        !identical(oldDelegate.map, map) ||
+        oldDelegate.lineColors != lineColors ||
+        oldDelegate.lineWidth != lineWidth ||
+        oldDelegate.stationRadius != stationRadius ||
+        oldDelegate.transferStationRadius != transferStationRadius;
+  }
+}
+
+/// 구조화 노선도 canvas 뷰. [camera]/[map]을 받아 [StructuredRouteMapPainter]로
+/// 그린다. WebView 없이 native로 렌더링한다.
+class StructuredRouteMapView extends StatelessWidget {
+  const StructuredRouteMapView({
+    required this.map,
+    required this.camera,
+    required this.lineColors,
+    super.key,
+  });
+
+  final StructuredRouteMap map;
+  final MapCameraState camera;
+  final Map<String, Color> lineColors;
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(
+      size: camera.viewportSize,
+      painter: StructuredRouteMapPainter(
+        map: map,
+        camera: camera,
+        lineColors: lineColors,
+      ),
+    );
+  }
+}

--- a/apps/mobile/test/features/network_map/presentation/structured_route_map_painter_test.dart
+++ b/apps/mobile/test/features/network_map/presentation/structured_route_map_painter_test.dart
@@ -46,7 +46,13 @@ StructuredRouteMap sampleMap() {
         labelClass: RouteMapLabelClass.regular,
       ),
     ],
-    transferGroups: const [],
+    transferGroups: const [
+      RouteMapTransferGroup(
+        stationId: 'transfer',
+        lineIds: ['L1', 'L2'],
+        centroid: Offset(500, 500),
+      ),
+    ],
   );
 }
 
@@ -144,12 +150,30 @@ void main() {
       expect(b.shouldRepaint(a), isTrue);
     });
 
-    test('동일 map·revision이면 repaint 안 함', () {
+    test('동일 map·revision·내용 동일 lineColors면 repaint 안 함', () {
+      // painterWith가 매번 새 lineColors 맵 리터럴을 만들지만 내용이 같으면
+      // mapEquals로 repaint하지 않는다(참조 비교로 매 프레임 repaint 방지).
       final map = sampleMap();
       final cam = camera();
       final a = painterWith(map: map, cam: cam);
       final b = painterWith(map: map, cam: cam);
       expect(b.shouldRepaint(a), isFalse);
+    });
+
+    test('lineColors 내용이 바뀌면 repaint', () {
+      final map = sampleMap();
+      final cam = camera();
+      final a = StructuredRouteMapPainter(
+        map: map,
+        camera: cam,
+        lineColors: const {'L1': Color(0xFF0052A4)},
+      );
+      final b = StructuredRouteMapPainter(
+        map: map,
+        camera: cam,
+        lineColors: const {'L1': Color(0xFFEE0000)},
+      );
+      expect(b.shouldRepaint(a), isTrue);
     });
   });
 
@@ -176,6 +200,20 @@ void main() {
     final painter = StructuredRouteMapPainter(
       map: sampleMap(),
       camera: camera(scale: 0.5), // bucket 0 → 환승역 점만
+      lineColors: routeMapLineColors(const {'L1': '#0052A4'}),
+    );
+    painter.paint(canvas, const Size(400, 400));
+    final picture = recorder.endRecording();
+    expect(picture, isNotNull);
+    picture.dispose();
+  });
+
+  test('최대 확대에서 선·일반역·환승마커 경로를 예외 없이 그린다', () {
+    final recorder = ui.PictureRecorder();
+    final canvas = Canvas(recorder);
+    final painter = StructuredRouteMapPainter(
+      map: sampleMap(),
+      camera: camera(scale: 3.5), // bucket 2 → 전체 역 + 환승 그룹 마커
       lineColors: routeMapLineColors(const {'L1': '#0052A4'}),
     );
     painter.paint(canvas, const Size(400, 400));

--- a/apps/mobile/test/features/network_map/presentation/structured_route_map_painter_test.dart
+++ b/apps/mobile/test/features/network_map/presentation/structured_route_map_painter_test.dart
@@ -1,0 +1,186 @@
+import 'dart:ui' as ui;
+
+import 'package:easysubway_mobile/features/network_map/domain/map_camera.dart';
+import 'package:easysubway_mobile/features/network_map/domain/structured_route_map.dart';
+import 'package:easysubway_mobile/features/network_map/presentation/structured_route_map_painter.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+MapCameraState camera({double scale = 1.0}) {
+  return MapCameraState(
+    sourceBounds: const Rect.fromLTWH(0, 0, 1000, 1000),
+    viewportSize: const Size(400, 400),
+    center: const Offset(500, 500),
+    scale: scale,
+    minScale: 0.5,
+    maxScale: 3.5,
+    revision: 1,
+  );
+}
+
+StructuredRouteMap sampleMap() {
+  return StructuredRouteMap(
+    lines: [
+      const RouteMapLineGeometry(
+        lineId: 'L1',
+        polylines: [
+          [Offset(480, 480), Offset(520, 520)],
+        ],
+      ),
+    ],
+    stations: [
+      const RouteMapStructuredStation(
+        stationId: 'transfer',
+        lineId: 'L1',
+        sequence: 1,
+        position: Offset(500, 500),
+        labelPolygon: [],
+        labelClass: RouteMapLabelClass.transfer,
+      ),
+      const RouteMapStructuredStation(
+        stationId: 'regular',
+        lineId: 'L1',
+        sequence: 2,
+        position: Offset(510, 510),
+        labelPolygon: [],
+        labelClass: RouteMapLabelClass.regular,
+      ),
+    ],
+    transferGroups: const [],
+  );
+}
+
+void main() {
+  group('routeMapZoomBucket', () {
+    test('최소 확대는 bucket 0, 중간은 1, 최대는 2', () {
+      expect(routeMapZoomBucket(camera(scale: 0.5)), 0);
+      expect(routeMapZoomBucket(camera(scale: 2.0)), 1);
+      expect(routeMapZoomBucket(camera(scale: 3.5)), 2);
+    });
+
+    test('scale 범위가 0이면 2', () {
+      final flat = MapCameraState(
+        sourceBounds: const Rect.fromLTWH(0, 0, 10, 10),
+        viewportSize: const Size(10, 10),
+        center: const Offset(5, 5),
+        scale: 1.0,
+        minScale: 1.0,
+        maxScale: 1.0,
+        revision: 0,
+      );
+      expect(routeMapZoomBucket(flat), 2);
+    });
+  });
+
+  group('routeMapPolylineIntersectsRect', () {
+    const rect = Rect.fromLTWH(0, 0, 100, 100);
+    test('교차/포함하면 true', () {
+      expect(
+        routeMapPolylineIntersectsRect(
+          const [Offset(50, 50), Offset(60, 60)],
+          rect,
+        ),
+        isTrue,
+      );
+      expect(
+        routeMapPolylineIntersectsRect(
+          const [Offset(-50, -50), Offset(150, 150)],
+          rect,
+        ),
+        isTrue,
+      );
+    });
+
+    test('완전히 밖이면 false', () {
+      expect(
+        routeMapPolylineIntersectsRect(
+          const [Offset(200, 200), Offset(300, 300)],
+          rect,
+        ),
+        isFalse,
+      );
+    });
+
+    test('빈 polyline은 false', () {
+      expect(routeMapPolylineIntersectsRect(const [], rect), isFalse);
+    });
+  });
+
+  group('routeMapLineColors', () {
+    test('hex를 파싱하고 잘못된 값은 fallback', () {
+      final colors = routeMapLineColors({'L1': '#0052A4', 'L2': 'garbage'});
+      expect(colors['L1'], const Color(0xFF0052A4));
+      expect(colors['L2'], const Color(0xFF006D77));
+    });
+  });
+
+  group('StructuredRouteMapPainter.shouldRepaint', () {
+    StructuredRouteMapPainter painterWith({
+      required StructuredRouteMap map,
+      required MapCameraState cam,
+    }) {
+      return StructuredRouteMapPainter(
+        map: map,
+        camera: cam,
+        lineColors: const {'L1': Color(0xFF0052A4)},
+      );
+    }
+
+    test('revision이 바뀌면 repaint', () {
+      final map = sampleMap();
+      final a = painterWith(map: map, cam: camera());
+      final b = painterWith(
+        map: map,
+        cam: MapCameraState(
+          sourceBounds: const Rect.fromLTWH(0, 0, 1000, 1000),
+          viewportSize: const Size(400, 400),
+          center: const Offset(500, 500),
+          scale: 1.0,
+          minScale: 0.5,
+          maxScale: 3.5,
+          revision: 2,
+        ),
+      );
+      expect(b.shouldRepaint(a), isTrue);
+    });
+
+    test('동일 map·revision이면 repaint 안 함', () {
+      final map = sampleMap();
+      final cam = camera();
+      final a = painterWith(map: map, cam: cam);
+      final b = painterWith(map: map, cam: cam);
+      expect(b.shouldRepaint(a), isFalse);
+    });
+  });
+
+  testWidgets('StructuredRouteMapView는 WebView 없이 CustomPaint로 그린다', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: StructuredRouteMapView(
+          map: sampleMap(),
+          camera: camera(scale: 3.5),
+          lineColors: routeMapLineColors(const {'L1': '#0052A4'}),
+        ),
+      ),
+    );
+    expect(find.byType(CustomPaint), findsWidgets);
+    expect(tester.takeException(), isNull);
+  });
+
+  test('paint는 예외 없이 그린다 (culling·LOD 경로 포함)', () {
+    final recorder = ui.PictureRecorder();
+    final canvas = Canvas(recorder);
+    final painter = StructuredRouteMapPainter(
+      map: sampleMap(),
+      camera: camera(scale: 0.5), // bucket 0 → 환승역 점만
+      lineColors: routeMapLineColors(const {'L1': '#0052A4'}),
+    );
+    painter.paint(canvas, const Size(400, 400));
+    final picture = recorder.endRecording();
+    expect(picture, isNotNull);
+    picture.dispose();
+  });
+}


### PR DESCRIPTION
## Summary
- #1641 **2단계: native canvas 렌더러 코어**. WebView SVG 렌더러를 대체할 `CustomPainter`로, **선(line path)과 역 점(station point) 레이어를 viewport culling + LOD로** 그립니다. WebView와 SVG 원본 로드 없이 native 렌더링합니다.
- `features/network_map/presentation/structured_route_map_painter.dart`:
  - `RouteMapRendererKind` flag — **기본값 `webView` 유지**(전환 전략대로 WebView 병행, QA #1642/#1643 통과 후 제거).
  - `routeMapZoomBucket`: 카메라 `scale` → #1636 LOD bucket(0/1/2).
  - `routeMapPolylineIntersectsRect`: bounding-box 기반 viewport culling 판정(화면 밖 geometry 미render).
  - `routeMapLineColors`: 기존 `stationLineColor` 재사용해 hex→Color(파싱 일원화).
  - `StructuredRouteMapPainter`: 선 culling · 역 LOD(최소 확대에선 환승역 점만) · 환승/일반 점 스타일 · revision 기반 `shouldRepaint`.
  - `StructuredRouteMapView`: WebView 없이 `CustomPaint`로 렌더.

## 단계 계획 (#1641)
1. ✅ 데이터 레이어 (#1669 병합)
2. **canvas 렌더러 코어 (본 PR)** — 선·역 + culling·LOD, flag(WebView 기본), 테스트
3. 라벨(우선순위·충돌) + 환승 노드 + 경로 강조 + 광주 attribution
4. Controller 이벤트 계약(FramePresented/CameraLatency) + 접근성(48dp/Semantics) + screen 제스처에 flag 연결

> 본 PR은 렌더러 코어를 flag 뒤에 두며 아직 `NetworkMapScreen`에 스위칭 연결하지 않습니다(Stage 4). 기본 경로는 WebView 그대로입니다. 코어는 테스트로 exercise됩니다.

## Test Plan
- `flutter test test/features/network_map/presentation/structured_route_map_painter_test.dart` (10 pass)
- `flutter analyze` (No issues)
- culling·LOD·color·shouldRepaint·paint 무예외 단위/위젯 테스트

Refs #1641