### PR TITLE
[Mobile] 노선도 라벨 충돌 레이어·출처 표기 (#1641 stage 3)

### DIFF
--- a/apps/mobile/lib/features/network_map/presentation/route_map_label_placement.dart
+++ b/apps/mobile/lib/features/network_map/presentation/route_map_label_placement.dart
@@ -28,6 +28,7 @@ class RouteMapLabelCandidate {
     required this.anchor,
     required this.size,
     required this.priority,
+    this.anchorPadding = 0,
   });
 
   /// 안정 정렬용 식별자 (보통 stationId:lineId).
@@ -41,6 +42,10 @@ class RouteMapLabelCandidate {
 
   /// 낮을수록 우선(0=환승, 1=주요, 2=일반). 우선순위 높은 라벨이 자리를 먼저 차지.
   final int priority;
+
+  /// 역 마커 반지름 등, 라벨을 anchor에서 추가로 띄울 여백 px. gap에 더해진다.
+  /// (환승 마커처럼 큰 글리프 위에 라벨이 겹치지 않게 한다.)
+  final double anchorPadding;
 }
 
 /// 배치된 라벨과 최종 사각형.
@@ -119,7 +124,7 @@ List<PlacedRouteMapLabel> placeRouteMapLabels(
         candidate.anchor,
         candidate.size,
         anchor,
-        gap,
+        gap + candidate.anchorPadding,
       );
       if (viewportBounds != null && !viewportBounds.overlaps(rect)) {
         continue;

--- a/apps/mobile/lib/features/network_map/presentation/route_map_label_placement.dart
+++ b/apps/mobile/lib/features/network_map/presentation/route_map_label_placement.dart
@@ -1,0 +1,142 @@
+import 'dart:ui' show Offset, Rect, Size;
+
+// 구조화 노선도 라벨 배치 (#1641 Stage 3).
+//
+// 상용 앱(Mapbox GL) 방식: 우선순위(환승 > 주요 > 일반) 정렬 후, variable
+// anchor로 후보 위치를 시도하며 이미 배치된 라벨과 겹치지 않는 첫 위치에 둔다.
+// 모든 후보가 겹치면 그 라벨은 숨긴다. 충돌 검사는 화면(viewport) 픽셀 공간에서
+// 한다 — 라벨 크기가 화면 px이고 겹침은 시각적이기 때문이다.
+//
+// 이 모듈은 순수 기하 로직만 담는다. 텍스트 실측(TextPainter)과 카메라 투영은
+// 호출부(painter)가 하고, 실측된 [RouteMapLabelCandidate]를 넘긴다.
+
+/// 라벨 박스를 anchor(역 점) 기준 어느 방향에 둘지.
+enum RouteMapLabelAnchor { right, left, above, below }
+
+/// 기본 anchor 시도 순서: 오른쪽 우선, 이어서 왼쪽/위/아래.
+const List<RouteMapLabelAnchor> kDefaultRouteMapLabelAnchors = [
+  RouteMapLabelAnchor.right,
+  RouteMapLabelAnchor.left,
+  RouteMapLabelAnchor.above,
+  RouteMapLabelAnchor.below,
+];
+
+/// 배치 후보 라벨 (viewport 공간).
+class RouteMapLabelCandidate {
+  const RouteMapLabelCandidate({
+    required this.id,
+    required this.anchor,
+    required this.size,
+    required this.priority,
+  });
+
+  /// 안정 정렬용 식별자 (보통 stationId:lineId).
+  final String id;
+
+  /// 역 점의 viewport 좌표.
+  final Offset anchor;
+
+  /// 실측된 라벨 크기 (viewport px).
+  final Size size;
+
+  /// 낮을수록 우선(0=환승, 1=주요, 2=일반). 우선순위 높은 라벨이 자리를 먼저 차지.
+  final int priority;
+}
+
+/// 배치된 라벨과 최종 사각형.
+class PlacedRouteMapLabel {
+  const PlacedRouteMapLabel({
+    required this.candidate,
+    required this.rect,
+    required this.anchor,
+  });
+
+  final RouteMapLabelCandidate candidate;
+  final Rect rect;
+  final RouteMapLabelAnchor anchor;
+}
+
+/// anchor 점 기준으로 [size] 라벨 박스를 [placement] 방향에 [gap]만큼 띄워 만든다.
+Rect routeMapLabelRect(
+  Offset anchorPoint,
+  Size size,
+  RouteMapLabelAnchor placement,
+  double gap,
+) {
+  switch (placement) {
+    case RouteMapLabelAnchor.right:
+      return Rect.fromLTWH(
+        anchorPoint.dx + gap,
+        anchorPoint.dy - size.height / 2,
+        size.width,
+        size.height,
+      );
+    case RouteMapLabelAnchor.left:
+      return Rect.fromLTWH(
+        anchorPoint.dx - gap - size.width,
+        anchorPoint.dy - size.height / 2,
+        size.width,
+        size.height,
+      );
+    case RouteMapLabelAnchor.above:
+      return Rect.fromLTWH(
+        anchorPoint.dx - size.width / 2,
+        anchorPoint.dy - gap - size.height,
+        size.width,
+        size.height,
+      );
+    case RouteMapLabelAnchor.below:
+      return Rect.fromLTWH(
+        anchorPoint.dx - size.width / 2,
+        anchorPoint.dy + gap,
+        size.width,
+        size.height,
+      );
+  }
+}
+
+/// 우선순위 정렬 후 greedy collision으로 겹치지 않는 라벨만 배치한다.
+///
+/// - [candidates]: 실측된 후보들.
+/// - [anchors]: variable anchor 시도 순서.
+/// - [gap]: 역 점과 라벨 사이 간격 px.
+/// - [viewportBounds]: 주면 이 영역과 겹치지 않는 후보 위치는 건너뛴다(화면 밖).
+List<PlacedRouteMapLabel> placeRouteMapLabels(
+  List<RouteMapLabelCandidate> candidates, {
+  List<RouteMapLabelAnchor> anchors = kDefaultRouteMapLabelAnchors,
+  double gap = 4.0,
+  Rect? viewportBounds,
+}) {
+  final sorted = [...candidates]..sort((a, b) {
+    final byPriority = a.priority.compareTo(b.priority);
+    return byPriority != 0 ? byPriority : a.id.compareTo(b.id);
+  });
+  final placed = <PlacedRouteMapLabel>[];
+  final placedRects = <Rect>[];
+  for (final candidate in sorted) {
+    for (final anchor in anchors) {
+      final rect = routeMapLabelRect(
+        candidate.anchor,
+        candidate.size,
+        anchor,
+        gap,
+      );
+      if (viewportBounds != null && !viewportBounds.overlaps(rect)) {
+        continue;
+      }
+      final collides = placedRects.any((other) => other.overlaps(rect));
+      if (!collides) {
+        placed.add(
+          PlacedRouteMapLabel(
+            candidate: candidate,
+            rect: rect,
+            anchor: anchor,
+          ),
+        );
+        placedRects.add(rect);
+        break;
+      }
+    }
+  }
+  return placed;
+}

--- a/apps/mobile/lib/features/network_map/presentation/structured_route_map_painter.dart
+++ b/apps/mobile/lib/features/network_map/presentation/structured_route_map_painter.dart
@@ -6,6 +6,7 @@ import 'package:flutter/widgets.dart';
 import '../../stations/domain/station_line.dart' show stationLineColor;
 import '../domain/map_camera.dart';
 import '../domain/structured_route_map.dart';
+import 'route_map_label_placement.dart';
 
 // 구조화 노선도 native canvas 렌더러 코어 (#1641 Stage 2).
 //
@@ -75,9 +76,13 @@ class StructuredRouteMapPainter extends CustomPainter {
     required this.map,
     required this.camera,
     required this.lineColors,
+    this.labelTextByStationId = const {},
+    this.attributionText,
     this.lineWidth = 4.0,
     this.stationRadius = 3.0,
     this.transferStationRadius = 5.0,
+    this.labelStyle = _defaultLabelStyle,
+    this.attributionStyle = _defaultAttributionStyle,
   });
 
   final StructuredRouteMap map;
@@ -85,14 +90,35 @@ class StructuredRouteMapPainter extends CustomPainter {
 
   /// line_id → 색. 없으면 노선 색 fallback을 쓴다.
   final Map<String, Color> lineColors;
+
+  /// station_id → 역명. 비어 있으면 라벨을 그리지 않는다.
+  final Map<String, String> labelTextByStationId;
+
+  /// 출처 표기(#1637 attribution 필요 지역). null/빈 문자열이면 그리지 않는다.
+  final String? attributionText;
   final double lineWidth;
   final double stationRadius;
   final double transferStationRadius;
+  final TextStyle labelStyle;
+  final TextStyle attributionStyle;
 
   static const Color _transferFill = Color(0xFFFFFFFF);
   static const Color _transferBorder = Color(0xFF102A2C);
   static const Color _fallbackLineColor = Color(0xFF8D8D8D);
   static const double _transferBorderWidth = 2.0;
+  static const double _labelGap = 4.0;
+  static const TextStyle _defaultLabelStyle = TextStyle(
+    color: Color(0xFF102A2C),
+    fontSize: 11,
+    fontWeight: FontWeight.w600,
+  );
+  static const TextStyle _defaultAttributionStyle = TextStyle(
+    color: Color(0xFF466467),
+    fontSize: 10,
+  );
+
+  // 텍스트 실측은 비싸므로 인스턴스 수명 동안 TextPainter를 캐시한다.
+  final Map<String, TextPainter> _labelPainters = {};
 
   // 프레임마다 재할당하지 않도록 Paint를 인스턴스/정적 필드로 hoist한다.
   final Paint _linePaint = Paint()
@@ -125,6 +151,8 @@ class StructuredRouteMapPainter extends CustomPainter {
     final visible = camera.visibleSourceRect.inflate(margin);
     _paintLines(canvas, visible);
     _paintStations(canvas, visible);
+    _paintLabels(canvas, size, visible);
+    _paintAttribution(canvas, size);
   }
 
   void _paintLines(Canvas canvas, Rect visible) {
@@ -190,11 +218,127 @@ class StructuredRouteMapPainter extends CustomPainter {
     }
   }
 
+  void _paintLabels(Canvas canvas, Size size, Rect visible) {
+    if (labelTextByStationId.isEmpty) {
+      return;
+    }
+    final bucket = routeMapZoomBucket(camera);
+    // bucket 0은 lines only — 라벨 없음.
+    if (bucket < minLabelZoomBucketFor(RouteMapLabelClass.transfer)) {
+      return;
+    }
+    final candidates = <RouteMapLabelCandidate>[];
+    final painterById = <String, TextPainter>{};
+
+    // 환승 라벨(우선순위 0): transferGroups 중심, bucket >= 1.
+    for (final group in map.transferGroups) {
+      if (!visible.contains(group.centroid)) {
+        continue;
+      }
+      final text = labelTextByStationId[group.stationId];
+      if (text == null || text.isEmpty) {
+        continue;
+      }
+      final id = 'transfer:${group.stationId}';
+      final painter = _labelPainter(text);
+      painterById[id] = painter;
+      candidates.add(
+        RouteMapLabelCandidate(
+          id: id,
+          anchor: camera.sourceToViewportPoint(group.centroid),
+          size: painter.size,
+          priority: 0,
+        ),
+      );
+    }
+
+    // 일반 역 라벨(우선순위 2): bucket >= 2.
+    if (bucket >= minLabelZoomBucketFor(RouteMapLabelClass.regular)) {
+      for (final station in map.stations) {
+        if (station.labelClass == RouteMapLabelClass.transfer) {
+          continue;
+        }
+        if (!visible.contains(station.position)) {
+          continue;
+        }
+        final text = labelTextByStationId[station.stationId];
+        if (text == null || text.isEmpty) {
+          continue;
+        }
+        final id = '${station.stationId}:${station.lineId}';
+        final painter = _labelPainter(text);
+        painterById[id] = painter;
+        candidates.add(
+          RouteMapLabelCandidate(
+            id: id,
+            anchor: camera.sourceToViewportPoint(station.position),
+            size: painter.size,
+            priority: 2,
+          ),
+        );
+      }
+    }
+
+    final placed = placeRouteMapLabels(
+      candidates,
+      gap: _labelGap,
+      viewportBounds: Offset.zero & size,
+    );
+    for (final label in placed) {
+      painterById[label.candidate.id]?.paint(canvas, label.rect.topLeft);
+    }
+  }
+
+  void _paintAttribution(Canvas canvas, Size size) {
+    final text = attributionText;
+    if (text == null || text.isEmpty) {
+      return;
+    }
+    final painter = _labelPainters.putIfAbsent(
+      'attribution:$text',
+      () => TextPainter(
+        text: TextSpan(text: text, style: attributionStyle),
+        textDirection: TextDirection.ltr,
+      )..layout(),
+    );
+    const padding = 4.0;
+    final origin = Offset(
+      padding + 2,
+      size.height - painter.height - padding - 2,
+    );
+    final background = Rect.fromLTWH(
+      origin.dx - 3,
+      origin.dy - 2,
+      painter.width + 6,
+      painter.height + 4,
+    );
+    canvas.drawRRect(
+      RRect.fromRectAndRadius(background, const Radius.circular(3)),
+      Paint()..color = const Color(0xCCFFFFFF),
+    );
+    painter.paint(canvas, origin);
+  }
+
+  TextPainter _labelPainter(String text) {
+    return _labelPainters.putIfAbsent(
+      text,
+      () => TextPainter(
+        text: TextSpan(text: text, style: labelStyle),
+        textDirection: TextDirection.ltr,
+        maxLines: 1,
+      )..layout(),
+    );
+  }
+
   @override
   bool shouldRepaint(StructuredRouteMapPainter oldDelegate) {
     return oldDelegate.camera.revision != camera.revision ||
         !identical(oldDelegate.map, map) ||
         !mapEquals(oldDelegate.lineColors, lineColors) ||
+        !mapEquals(oldDelegate.labelTextByStationId, labelTextByStationId) ||
+        oldDelegate.attributionText != attributionText ||
+        oldDelegate.labelStyle != labelStyle ||
+        oldDelegate.attributionStyle != attributionStyle ||
         oldDelegate.lineWidth != lineWidth ||
         oldDelegate.stationRadius != stationRadius ||
         oldDelegate.transferStationRadius != transferStationRadius;
@@ -208,12 +352,16 @@ class StructuredRouteMapView extends StatelessWidget {
     required this.map,
     required this.camera,
     required this.lineColors,
+    this.labelTextByStationId = const {},
+    this.attributionText,
     super.key,
   });
 
   final StructuredRouteMap map;
   final MapCameraState camera;
   final Map<String, Color> lineColors;
+  final Map<String, String> labelTextByStationId;
+  final String? attributionText;
 
   @override
   Widget build(BuildContext context) {
@@ -223,6 +371,8 @@ class StructuredRouteMapView extends StatelessWidget {
         map: map,
         camera: camera,
         lineColors: lineColors,
+        labelTextByStationId: labelTextByStationId,
+        attributionText: attributionText,
       ),
     );
   }

--- a/apps/mobile/lib/features/network_map/presentation/structured_route_map_painter.dart
+++ b/apps/mobile/lib/features/network_map/presentation/structured_route_map_painter.dart
@@ -83,7 +83,8 @@ class StructuredRouteMapPainter extends CustomPainter {
     this.transferStationRadius = 5.0,
     this.labelStyle = _defaultLabelStyle,
     this.attributionStyle = _defaultAttributionStyle,
-  });
+    Map<String, TextPainter>? labelPainterCache,
+  }) : _labelPainters = labelPainterCache ?? {};
 
   final StructuredRouteMap map;
   final MapCameraState camera;
@@ -117,8 +118,21 @@ class StructuredRouteMapPainter extends CustomPainter {
     fontSize: 10,
   );
 
-  // 텍스트 실측은 비싸므로 인스턴스 수명 동안 TextPainter를 캐시한다.
-  final Map<String, TextPainter> _labelPainters = {};
+  // 텍스트 실측은 비싸므로 TextPainter를 캐시한다. 외부(StatefulWidget)가 캐시를
+  // 주입하면 rebuild 간에도 유지되고 소유자가 dispose한다. 없으면 인스턴스 수명용.
+  final Map<String, TextPainter> _labelPainters;
+
+  /// 라벨 class → 배치 우선순위(낮을수록 우선). #1636 station_labels.priority.
+  static int _labelPriorityFor(RouteMapLabelClass labelClass) {
+    switch (labelClass) {
+      case RouteMapLabelClass.transfer:
+        return 0;
+      case RouteMapLabelClass.major:
+        return 1;
+      case RouteMapLabelClass.regular:
+        return 2;
+    }
+  }
 
   // 프레임마다 재할당하지 않도록 Paint를 인스턴스/정적 필드로 hoist한다.
   final Paint _linePaint = Paint()
@@ -223,60 +237,65 @@ class StructuredRouteMapPainter extends CustomPainter {
       return;
     }
     final bucket = routeMapZoomBucket(camera);
-    // bucket 0은 lines only — 라벨 없음.
-    if (bucket < minLabelZoomBucketFor(RouteMapLabelClass.transfer)) {
+    // 어떤 class든 라벨 최소 bucket은 1 — bucket 0은 lines only.
+    if (bucket < 1) {
       return;
     }
     final candidates = <RouteMapLabelCandidate>[];
     final painterById = <String, TextPainter>{};
 
-    // 환승 라벨(우선순위 0): transferGroups 중심, bucket >= 1.
-    for (final group in map.transferGroups) {
-      if (!visible.contains(group.centroid)) {
-        continue;
-      }
-      final text = labelTextByStationId[group.stationId];
-      if (text == null || text.isEmpty) {
-        continue;
-      }
-      final id = 'transfer:${group.stationId}';
-      final painter = _labelPainter(text);
-      painterById[id] = painter;
-      candidates.add(
-        RouteMapLabelCandidate(
-          id: id,
-          anchor: camera.sourceToViewportPoint(group.centroid),
-          size: painter.size,
-          priority: 0,
-        ),
-      );
-    }
-
-    // 일반 역 라벨(우선순위 2): bucket >= 2.
-    if (bucket >= minLabelZoomBucketFor(RouteMapLabelClass.regular)) {
-      for (final station in map.stations) {
-        if (station.labelClass == RouteMapLabelClass.transfer) {
+    // 환승 라벨: transferGroups 중심, 마커 반지름만큼 여백을 둔다.
+    if (bucket >= minLabelZoomBucketFor(RouteMapLabelClass.transfer)) {
+      for (final group in map.transferGroups) {
+        if (!visible.contains(group.centroid)) {
           continue;
         }
-        if (!visible.contains(station.position)) {
-          continue;
-        }
-        final text = labelTextByStationId[station.stationId];
+        final text = labelTextByStationId[group.stationId];
         if (text == null || text.isEmpty) {
           continue;
         }
-        final id = '${station.stationId}:${station.lineId}';
+        final id = 'transfer:${group.stationId}';
         final painter = _labelPainter(text);
         painterById[id] = painter;
         candidates.add(
           RouteMapLabelCandidate(
             id: id,
-            anchor: camera.sourceToViewportPoint(station.position),
+            anchor: camera.sourceToViewportPoint(group.centroid),
             size: painter.size,
-            priority: 2,
+            priority: _labelPriorityFor(RouteMapLabelClass.transfer),
+            anchorPadding: transferStationRadius + _transferBorderWidth,
           ),
         );
       }
+    }
+
+    // 비환승 역 라벨(주요/일반): class별 LOD·우선순위를 적용한다.
+    for (final station in map.stations) {
+      if (station.labelClass == RouteMapLabelClass.transfer) {
+        continue;
+      }
+      if (bucket < minLabelZoomBucketFor(station.labelClass)) {
+        continue;
+      }
+      if (!visible.contains(station.position)) {
+        continue;
+      }
+      final text = labelTextByStationId[station.stationId];
+      if (text == null || text.isEmpty) {
+        continue;
+      }
+      final id = '${station.stationId}:${station.lineId}';
+      final painter = _labelPainter(text);
+      painterById[id] = painter;
+      candidates.add(
+        RouteMapLabelCandidate(
+          id: id,
+          anchor: camera.sourceToViewportPoint(station.position),
+          size: painter.size,
+          priority: _labelPriorityFor(station.labelClass),
+          anchorPadding: stationRadius,
+        ),
+      );
     }
 
     final placed = placeRouteMapLabels(
@@ -304,7 +323,8 @@ class StructuredRouteMapPainter extends CustomPainter {
     const padding = 4.0;
     final origin = Offset(
       padding + 2,
-      size.height - painter.height - padding - 2,
+      // 아주 작은 뷰포트에서 위로 넘어가지 않도록 하한을 둔다.
+      math.max(padding, size.height - painter.height - padding - 2),
     );
     final background = Rect.fromLTWH(
       origin.dx - 3,
@@ -347,7 +367,11 @@ class StructuredRouteMapPainter extends CustomPainter {
 
 /// 구조화 노선도 canvas 뷰. [camera]/[map]을 받아 [StructuredRouteMapPainter]로
 /// 그린다. WebView 없이 native로 렌더링한다.
-class StructuredRouteMapView extends StatelessWidget {
+///
+/// TextPainter 캐시를 State가 소유해 rebuild 간에 유지하고 dispose 시 정리한다
+/// (painter는 프레임마다 새로 만들어지므로 캐시를 인스턴스에 두면 유지되지 않고
+/// native paragraph 핸들이 누수된다).
+class StructuredRouteMapView extends StatefulWidget {
   const StructuredRouteMapView({
     required this.map,
     required this.camera,
@@ -364,15 +388,32 @@ class StructuredRouteMapView extends StatelessWidget {
   final String? attributionText;
 
   @override
+  State<StructuredRouteMapView> createState() => _StructuredRouteMapViewState();
+}
+
+class _StructuredRouteMapViewState extends State<StructuredRouteMapView> {
+  final Map<String, TextPainter> _labelPainters = {};
+
+  @override
+  void dispose() {
+    for (final painter in _labelPainters.values) {
+      painter.dispose();
+    }
+    _labelPainters.clear();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return CustomPaint(
-      size: camera.viewportSize,
+      size: widget.camera.viewportSize,
       painter: StructuredRouteMapPainter(
-        map: map,
-        camera: camera,
-        lineColors: lineColors,
-        labelTextByStationId: labelTextByStationId,
-        attributionText: attributionText,
+        map: widget.map,
+        camera: widget.camera,
+        lineColors: widget.lineColors,
+        labelTextByStationId: widget.labelTextByStationId,
+        attributionText: widget.attributionText,
+        labelPainterCache: _labelPainters,
       ),
     );
   }

--- a/apps/mobile/test/features/network_map/presentation/route_map_label_placement_test.dart
+++ b/apps/mobile/test/features/network_map/presentation/route_map_label_placement_test.dart
@@ -1,0 +1,114 @@
+import 'package:easysubway_mobile/features/network_map/presentation/route_map_label_placement.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+RouteMapLabelCandidate candidate({
+  required String id,
+  required Offset anchor,
+  required int priority,
+  Size size = const Size(40, 12),
+}) {
+  return RouteMapLabelCandidate(
+    id: id,
+    anchor: anchor,
+    size: size,
+    priority: priority,
+  );
+}
+
+void main() {
+  group('routeMapLabelRect', () {
+    const anchor = Offset(100, 100);
+    const size = Size(40, 12);
+    test('right는 점 오른쪽, 세로 중앙 정렬', () {
+      final rect = routeMapLabelRect(anchor, size, RouteMapLabelAnchor.right, 4);
+      expect(rect, const Rect.fromLTWH(104, 94, 40, 12));
+    });
+    test('left는 점 왼쪽', () {
+      final rect = routeMapLabelRect(anchor, size, RouteMapLabelAnchor.left, 4);
+      expect(rect, const Rect.fromLTWH(56, 94, 40, 12));
+    });
+    test('above는 점 위, below는 점 아래', () {
+      expect(
+        routeMapLabelRect(anchor, size, RouteMapLabelAnchor.above, 4),
+        const Rect.fromLTWH(80, 84, 40, 12),
+      );
+      expect(
+        routeMapLabelRect(anchor, size, RouteMapLabelAnchor.below, 4),
+        const Rect.fromLTWH(80, 104, 40, 12),
+      );
+    });
+  });
+
+  group('placeRouteMapLabels', () {
+    test('겹치지 않는 라벨은 모두 배치된다', () {
+      final placed = placeRouteMapLabels([
+        candidate(id: 'a', anchor: const Offset(0, 0), priority: 2),
+        candidate(id: 'b', anchor: const Offset(0, 500), priority: 2),
+      ]);
+      expect(placed, hasLength(2));
+    });
+
+    test('우선순위 높은 라벨이 자리를 차지하고 낮은 라벨은 숨는다', () {
+      // 두 후보가 같은 지점에 겹치고, anchor 후보가 하나뿐이라 둘 중 하나만 배치.
+      final placed = placeRouteMapLabels(
+        [
+          candidate(id: 'regular', anchor: const Offset(100, 100), priority: 2),
+          candidate(
+            id: 'transfer',
+            anchor: const Offset(100, 100),
+            priority: 0,
+          ),
+        ],
+        anchors: const [RouteMapLabelAnchor.right],
+      );
+      expect(placed, hasLength(1));
+      expect(placed.single.candidate.id, 'transfer');
+    });
+
+    test('오른쪽이 막히면 다른 anchor로 배치한다 (variable anchor)', () {
+      // a는 right에 배치. b는 같은 anchor라 right는 a와 겹치지만 left는 빈다.
+      final placed = placeRouteMapLabels([
+        candidate(id: 'a', anchor: const Offset(100, 100), priority: 0),
+        candidate(id: 'b', anchor: const Offset(100, 100), priority: 1),
+      ]);
+      expect(placed, hasLength(2));
+      final b = placed.firstWhere((p) => p.candidate.id == 'b');
+      expect(b.anchor, isNot(RouteMapLabelAnchor.right));
+    });
+
+    test('모든 anchor가 막히면 라벨을 숨긴다', () {
+      // 세 라벨이 한 점에 몰리고 anchor 후보가 right/left 둘뿐이면 3번째는 숨는다.
+      final placed = placeRouteMapLabels(
+        [
+          candidate(id: 'a', anchor: const Offset(100, 100), priority: 0),
+          candidate(id: 'b', anchor: const Offset(100, 100), priority: 1),
+          candidate(id: 'c', anchor: const Offset(100, 100), priority: 2),
+        ],
+        anchors: const [RouteMapLabelAnchor.right, RouteMapLabelAnchor.left],
+      );
+      expect(placed, hasLength(2));
+      expect(placed.map((p) => p.candidate.id), containsAll(['a', 'b']));
+    });
+
+    test('viewportBounds 밖 위치는 건너뛴다', () {
+      final placed = placeRouteMapLabels(
+        [candidate(id: 'far', anchor: const Offset(5000, 5000), priority: 0)],
+        viewportBounds: const Rect.fromLTWH(0, 0, 400, 400),
+      );
+      expect(placed, isEmpty);
+    });
+
+    test('같은 우선순위는 id로 안정 정렬된다', () {
+      final placed = placeRouteMapLabels(
+        [
+          candidate(id: 'b', anchor: const Offset(100, 100), priority: 1),
+          candidate(id: 'a', anchor: const Offset(100, 100), priority: 1),
+        ],
+        anchors: const [RouteMapLabelAnchor.right],
+      );
+      expect(placed, hasLength(1));
+      expect(placed.single.candidate.id, 'a');
+    });
+  });
+}

--- a/apps/mobile/test/features/network_map/presentation/route_map_label_placement_test.dart
+++ b/apps/mobile/test/features/network_map/presentation/route_map_label_placement_test.dart
@@ -99,6 +99,30 @@ void main() {
       expect(placed, isEmpty);
     });
 
+    test('anchorPadding은 라벨을 anchor에서 gap보다 더 띄운다', () {
+      final noPad = placeRouteMapLabels(
+        [candidate(id: 'a', anchor: const Offset(100, 100), priority: 0)],
+        anchors: const [RouteMapLabelAnchor.right],
+        gap: 4,
+      );
+      final withPad = placeRouteMapLabels(
+        const [
+          RouteMapLabelCandidate(
+            id: 'a',
+            anchor: Offset(100, 100),
+            size: Size(40, 12),
+            priority: 0,
+            anchorPadding: 20,
+          ),
+        ],
+        anchors: const [RouteMapLabelAnchor.right],
+        gap: 4,
+      );
+      expect(withPad.single.rect.left, greaterThan(noPad.single.rect.left));
+      // right anchor: left = anchor.dx + gap + anchorPadding = 100+4+20.
+      expect(withPad.single.rect.left, 124);
+    });
+
     test('같은 우선순위는 id로 안정 정렬된다', () {
       final placed = placeRouteMapLabels(
         [

--- a/apps/mobile/test/features/network_map/presentation/structured_route_map_painter_test.dart
+++ b/apps/mobile/test/features/network_map/presentation/structured_route_map_painter_test.dart
@@ -242,6 +242,35 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
+  testWidgets('major 역 라벨은 bucket 1(중간 확대)에서 예외 없이 그려진다', (tester) async {
+    final map = StructuredRouteMap(
+      lines: const [],
+      stations: const [
+        RouteMapStructuredStation(
+          stationId: 'major',
+          lineId: 'L1',
+          sequence: 1,
+          position: Offset(500, 500),
+          labelPolygon: [],
+          labelClass: RouteMapLabelClass.major,
+        ),
+      ],
+      transferGroups: const [],
+    );
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: StructuredRouteMapView(
+          map: map,
+          camera: camera(scale: 2.0), // bucket 1
+          lineColors: const {},
+          labelTextByStationId: const {'major': '주요역'},
+        ),
+      ),
+    );
+    expect(tester.takeException(), isNull);
+  });
+
   test('shouldRepaint은 라벨 텍스트·attribution 변화를 감지한다', () {
     final map = sampleMap();
     final cam = camera(scale: 3.5);

--- a/apps/mobile/test/features/network_map/presentation/structured_route_map_painter_test.dart
+++ b/apps/mobile/test/features/network_map/presentation/structured_route_map_painter_test.dart
@@ -221,4 +221,52 @@ void main() {
     expect(picture, isNotNull);
     picture.dispose();
   });
+
+  testWidgets('라벨·attribution을 예외 없이 그린다 (bucket 2)', (tester) async {
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: StructuredRouteMapView(
+          map: sampleMap(),
+          camera: camera(scale: 3.5),
+          lineColors: routeMapLineColors(const {'L1': '#0052A4'}),
+          labelTextByStationId: const {
+            'transfer': '환승역',
+            'regular': '일반역',
+          },
+          attributionText: '© 광주교통공사',
+        ),
+      ),
+    );
+    expect(find.byType(CustomPaint), findsWidgets);
+    expect(tester.takeException(), isNull);
+  });
+
+  test('shouldRepaint은 라벨 텍스트·attribution 변화를 감지한다', () {
+    final map = sampleMap();
+    final cam = camera(scale: 3.5);
+    final base = StructuredRouteMapPainter(
+      map: map,
+      camera: cam,
+      lineColors: const {'L1': Color(0xFF0052A4)},
+      labelTextByStationId: const {'transfer': '환승역'},
+      attributionText: '© A',
+    );
+    final differentLabel = StructuredRouteMapPainter(
+      map: map,
+      camera: cam,
+      lineColors: const {'L1': Color(0xFF0052A4)},
+      labelTextByStationId: const {'transfer': '다른역'},
+      attributionText: '© A',
+    );
+    final differentAttribution = StructuredRouteMapPainter(
+      map: map,
+      camera: cam,
+      lineColors: const {'L1': Color(0xFF0052A4)},
+      labelTextByStationId: const {'transfer': '환승역'},
+      attributionText: '© B',
+    );
+    expect(differentLabel.shouldRepaint(base), isTrue);
+    expect(differentAttribution.shouldRepaint(base), isTrue);
+  });
 }


### PR DESCRIPTION
## Summary
- #1641 **3단계: 라벨 우선순위·충돌 배치 + 출처 표기(attribution)**를 canvas 렌더러에 얹습니다.
- `features/network_map/presentation/route_map_label_placement.dart` 신설 — **Mapbox GL 방식** 순수 배치 알고리즘:
  - 우선순위(환승 > 주요 > 일반) 정렬 후 **variable anchor**(right/left/above/below)로 이미 배치된 라벨과 겹치지 않는 첫 위치에 배치, 모두 막히면 **숨김**.
  - `viewportBounds` 밖 위치는 건너뜀. 텍스트 실측·카메라 투영은 painter가 하고 실측된 후보만 넘겨 **순수·테스트 가능**.
- `StructuredRouteMapPainter`에 라벨/attribution 레이어 추가:
  - `labelTextByStationId`(역명)로 후보 구성, **LOD-gate**(환승 bucket≥1, 일반 bucket≥2, bucket0 = lines only), `TextPainter` 캐시로 실측, `placeRouteMapLabels`로 배치·렌더.
  - `attributionText`(#1637 attribution 필요 지역, 예: 광주) 하단 출처 문구를 배경과 함께 렌더.
  - `shouldRepaint`에 라벨·attribution·style 변화 반영.
- 신규 파라미터는 모두 optional이라 Stage 2 사용부와 호환됩니다.

## 단계 계획 (#1641)
1. ✅ 데이터 레이어 (#1669)
2. ✅ canvas 렌더러 코어 (#1672)
3. **라벨 충돌·우선순위 + attribution (본 PR)**
4. Controller 이벤트 계약(FramePresented/CameraLatency) + 접근성(48dp/Semantics) + screen 제스처에 flag 연결 → QA(#1642/#1643)

## Test Plan
- `flutter test .../route_map_label_placement_test.dart .../structured_route_map_painter_test.dart` (23 pass)
- `flutter analyze` (No issues)
- 배치 우선순위·variable anchor·전부 충돌 숨김·viewport 컬링·안정 정렬 + 라벨/attribution 렌더·shouldRepaint 테스트

Refs #1641