### PR TITLE
[Mobile] 구조화 canvas 렌더러 컨트롤러 (#1641 stage 4)

### DIFF
--- a/apps/mobile/lib/features/network_map/infrastructure/structured_route_map_renderer_controller.dart
+++ b/apps/mobile/lib/features/network_map/infrastructure/structured_route_map_renderer_controller.dart
@@ -1,0 +1,103 @@
+import 'dart:async';
+
+import 'package:flutter/scheduler.dart';
+
+import '../domain/map_camera.dart';
+import 'route_map_renderer.dart';
+
+// 구조화 canvas 렌더러용 RouteMapRendererController 구현 (#1641 Stage 4).
+//
+// WebView 렌더러와 같은 이벤트 계약(Created/AssetReady/CameraRequested/
+// CameraLatency/FramePresented/...)을 유지해, run-route-map-android-evidence.sh
+// 증거 파이프라인과 RouteMapRendererHealthMonitor가 그대로 동작하게 한다.
+//
+// native canvas는 WebView와 달리 process gone/frame timeout이 없다. 카메라를
+// 설정하면 다음 프레임에 동기 렌더되므로, post-frame 콜백에서 FramePresented와
+// (설정→프레임) CameraLatency를 방출한다.
+class StructuredRouteMapRendererController
+    implements RouteMapRendererController {
+  StructuredRouteMapRendererController({
+    void Function(void Function(Duration timeStamp))? scheduleFrame,
+    Stopwatch Function()? stopwatchFactory,
+  }) : _scheduleFrame = scheduleFrame ??
+           ((callback) =>
+               SchedulerBinding.instance.addPostFrameCallback(callback)),
+       _stopwatchFactory = stopwatchFactory ?? Stopwatch.new {
+    // 데이터는 이미 메모리(datapack)에 있으므로 즉시 ready. 리스너가 구독한 뒤
+    // 받도록 microtask로 방출한다(broadcast stream은 버퍼링하지 않음).
+    scheduleMicrotask(() {
+      if (_disposed) {
+        return;
+      }
+      _emit(const RouteMapRendererCreated());
+      _emit(const RouteMapRendererAssetLoading());
+      _emit(const RouteMapRendererAssetReady());
+    });
+  }
+
+  final void Function(void Function(Duration timeStamp)) _scheduleFrame;
+  final Stopwatch Function() _stopwatchFactory;
+  final StreamController<RouteMapRendererEvent> _controller =
+      StreamController<RouteMapRendererEvent>.broadcast();
+  bool _disposed = false;
+
+  @override
+  Stream<RouteMapRendererEvent> get events => _controller.stream;
+
+  @override
+  Future<void> setCamera(MapCameraState camera) async {
+    if (_disposed) {
+      return;
+    }
+    final revision = camera.revision;
+    _emit(RouteMapRendererCameraRequested(revision));
+    final stopwatch = _stopwatchFactory()..start();
+    _scheduleFrame((_) {
+      stopwatch.stop();
+      if (_disposed) {
+        return;
+      }
+      _emit(
+        RouteMapRendererCameraLatency(
+          revision: revision,
+          elapsed: stopwatch.elapsed,
+        ),
+      );
+      _emit(RouteMapRendererFramePresented(revision));
+    });
+  }
+
+  @override
+  Future<void> retry() async {
+    if (_disposed) {
+      return;
+    }
+    // native canvas는 실패 상태가 없다 — ready를 재확인한다.
+    _emit(const RouteMapRendererAssetReady());
+  }
+
+  @override
+  Future<void> trimMemory() async {
+    if (_disposed) {
+      return;
+    }
+    _emit(const RouteMapRendererMemoryTrimmed());
+  }
+
+  @override
+  Future<void> dispose() async {
+    if (_disposed) {
+      return;
+    }
+    _disposed = true;
+    _emit(const RouteMapRendererDisposed());
+    await _controller.close();
+  }
+
+  void _emit(RouteMapRendererEvent event) {
+    if (_controller.isClosed) {
+      return;
+    }
+    _controller.add(event);
+  }
+}

--- a/apps/mobile/lib/features/network_map/infrastructure/structured_route_map_renderer_controller.dart
+++ b/apps/mobile/lib/features/network_map/infrastructure/structured_route_map_renderer_controller.dart
@@ -12,33 +12,33 @@ import 'route_map_renderer.dart';
 // 증거 파이프라인과 RouteMapRendererHealthMonitor가 그대로 동작하게 한다.
 //
 // native canvas는 WebView와 달리 process gone/frame timeout이 없다. 카메라를
-// 설정하면 다음 프레임에 동기 렌더되므로, post-frame 콜백에서 FramePresented와
+// 설정하면 프레임을 요청하고, 그 프레임의 post-frame 콜백에서 FramePresented와
 // (설정→프레임) CameraLatency를 방출한다.
 class StructuredRouteMapRendererController
     implements RouteMapRendererController {
   StructuredRouteMapRendererController({
     void Function(void Function(Duration timeStamp))? scheduleFrame,
+    void Function()? requestFrame,
     Stopwatch Function()? stopwatchFactory,
   }) : _scheduleFrame = scheduleFrame ??
            ((callback) =>
                SchedulerBinding.instance.addPostFrameCallback(callback)),
+       _requestFrame =
+           requestFrame ?? (() => SchedulerBinding.instance.ensureVisualUpdate()),
        _stopwatchFactory = stopwatchFactory ?? Stopwatch.new {
-    // 데이터는 이미 메모리(datapack)에 있으므로 즉시 ready. 리스너가 구독한 뒤
-    // 받도록 microtask로 방출한다(broadcast stream은 버퍼링하지 않음).
-    scheduleMicrotask(() {
-      if (_disposed) {
-        return;
-      }
-      _emit(const RouteMapRendererCreated());
-      _emit(const RouteMapRendererAssetLoading());
-      _emit(const RouteMapRendererAssetReady());
-    });
+    // 초기 이벤트는 첫 구독 시점(onListen)에 방출한다. broadcast stream은
+    // 버퍼링하지 않으므로 생성 시 방출하면 늦게 구독하는 monitor가 놓친다.
+    _controller = StreamController<RouteMapRendererEvent>.broadcast(
+      onListen: _emitInitialEvents,
+    );
   }
 
   final void Function(void Function(Duration timeStamp)) _scheduleFrame;
+  final void Function() _requestFrame;
   final Stopwatch Function() _stopwatchFactory;
-  final StreamController<RouteMapRendererEvent> _controller =
-      StreamController<RouteMapRendererEvent>.broadcast();
+  late final StreamController<RouteMapRendererEvent> _controller;
+  MapCameraState? _lastCamera;
+  bool _initialEmitted = false;
   bool _disposed = false;
 
   @override
@@ -49,22 +49,9 @@ class StructuredRouteMapRendererController
     if (_disposed) {
       return;
     }
-    final revision = camera.revision;
-    _emit(RouteMapRendererCameraRequested(revision));
-    final stopwatch = _stopwatchFactory()..start();
-    _scheduleFrame((_) {
-      stopwatch.stop();
-      if (_disposed) {
-        return;
-      }
-      _emit(
-        RouteMapRendererCameraLatency(
-          revision: revision,
-          elapsed: stopwatch.elapsed,
-        ),
-      );
-      _emit(RouteMapRendererFramePresented(revision));
-    });
+    _lastCamera = camera;
+    _emit(RouteMapRendererCameraRequested(camera.revision));
+    _presentFrame(camera.revision);
   }
 
   @override
@@ -72,8 +59,14 @@ class StructuredRouteMapRendererController
     if (_disposed) {
       return;
     }
-    // native canvas는 실패 상태가 없다 — ready를 재확인한다.
+    // native canvas는 실패 상태가 없다. monitor 복구 경로는 retry 후 마지막
+    // revision의 FramePresented를 기다리므로, ready 재확인 후 프레임을 다시
+    // 통지해 복구가 완료되게 한다.
     _emit(const RouteMapRendererAssetReady());
+    final camera = _lastCamera;
+    if (camera != null) {
+      _presentFrame(camera.revision);
+    }
   }
 
   @override
@@ -92,6 +85,41 @@ class StructuredRouteMapRendererController
     _disposed = true;
     _emit(const RouteMapRendererDisposed());
     await _controller.close();
+  }
+
+  void _emitInitialEvents() {
+    if (_initialEmitted || _disposed) {
+      return;
+    }
+    _initialEmitted = true;
+    // 데이터는 이미 datapack 메모리에 있으므로 즉시 ready.
+    _emit(const RouteMapRendererCreated());
+    _emit(const RouteMapRendererAssetLoading());
+    _emit(const RouteMapRendererAssetReady());
+    // 구독 전에 카메라가 설정돼 있었다면 프레임을 통지한다.
+    final camera = _lastCamera;
+    if (camera != null) {
+      _presentFrame(camera.revision);
+    }
+  }
+
+  // 프레임을 요청하고, 그 프레임 이후 CameraLatency·FramePresented를 방출한다.
+  void _presentFrame(int revision) {
+    final stopwatch = _stopwatchFactory()..start();
+    _requestFrame();
+    _scheduleFrame((_) {
+      stopwatch.stop();
+      if (_disposed) {
+        return;
+      }
+      _emit(
+        RouteMapRendererCameraLatency(
+          revision: revision,
+          elapsed: stopwatch.elapsed,
+        ),
+      );
+      _emit(RouteMapRendererFramePresented(revision));
+    });
   }
 
   void _emit(RouteMapRendererEvent event) {

--- a/apps/mobile/test/features/network_map/infrastructure/structured_route_map_renderer_controller_test.dart
+++ b/apps/mobile/test/features/network_map/infrastructure/structured_route_map_renderer_controller_test.dart
@@ -1,0 +1,127 @@
+import 'dart:ui' show Offset, Rect, Size;
+
+import 'package:easysubway_mobile/features/network_map/domain/map_camera.dart';
+import 'package:easysubway_mobile/features/network_map/infrastructure/route_map_renderer.dart';
+import 'package:easysubway_mobile/features/network_map/infrastructure/structured_route_map_renderer_controller.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+MapCameraState cameraAt(int revision) {
+  return MapCameraState(
+    sourceBounds: const Rect.fromLTWH(0, 0, 1000, 1000),
+    viewportSize: const Size(400, 400),
+    center: const Offset(500, 500),
+    scale: 1.0,
+    minScale: 0.5,
+    maxScale: 3.5,
+    revision: revision,
+  );
+}
+
+Future<void> flush() => Future<void>.delayed(Duration.zero);
+
+void main() {
+  test('생성 시 Created/AssetLoading/AssetReady를 방출한다', () async {
+    final controller = StructuredRouteMapRendererController(
+      scheduleFrame: (_) {},
+    );
+    final events = <RouteMapRendererEvent>[];
+    controller.events.listen(events.add);
+    await flush();
+
+    expect(events, [
+      isA<RouteMapRendererCreated>(),
+      isA<RouteMapRendererAssetLoading>(),
+      isA<RouteMapRendererAssetReady>(),
+    ]);
+    await controller.dispose();
+  });
+
+  test('setCamera는 CameraRequested 후 post-frame에 CameraLatency·FramePresented', () async {
+    final frames = <void Function(Duration)>[];
+    final controller = StructuredRouteMapRendererController(
+      scheduleFrame: frames.add,
+    );
+    final events = <RouteMapRendererEvent>[];
+    controller.events.listen(events.add);
+    await flush();
+    events.clear();
+
+    await controller.setCamera(cameraAt(7));
+    await flush();
+
+    expect(
+      events.whereType<RouteMapRendererCameraRequested>().single.revision,
+      7,
+    );
+    // 아직 프레임이 안 왔으므로 FramePresented 없음.
+    expect(events.whereType<RouteMapRendererFramePresented>(), isEmpty);
+    expect(frames, hasLength(1));
+
+    // 프레임 도착 시뮬레이션.
+    frames.single(Duration.zero);
+    await flush();
+
+    expect(
+      events.whereType<RouteMapRendererFramePresented>().single.revision,
+      7,
+    );
+    final latency = events.whereType<RouteMapRendererCameraLatency>().single;
+    expect(latency.revision, 7);
+    expect(latency.elapsed, greaterThanOrEqualTo(Duration.zero));
+    await controller.dispose();
+  });
+
+  test('retry는 AssetReady, trimMemory는 MemoryTrimmed를 방출한다', () async {
+    final controller = StructuredRouteMapRendererController(
+      scheduleFrame: (_) {},
+    );
+    final events = <RouteMapRendererEvent>[];
+    controller.events.listen(events.add);
+    await flush();
+    events.clear();
+
+    await controller.retry();
+    await controller.trimMemory();
+    await flush();
+
+    expect(events.whereType<RouteMapRendererAssetReady>(), hasLength(1));
+    expect(events.whereType<RouteMapRendererMemoryTrimmed>(), hasLength(1));
+    await controller.dispose();
+  });
+
+  test('dispose는 Disposed 방출 후 스트림을 닫고, 이후 호출은 무시된다', () async {
+    final frames = <void Function(Duration)>[];
+    final controller = StructuredRouteMapRendererController(
+      scheduleFrame: frames.add,
+    );
+    final events = <RouteMapRendererEvent>[];
+    controller.events.listen(events.add);
+    await flush();
+
+    await controller.dispose();
+    await flush();
+    expect(events.whereType<RouteMapRendererDisposed>(), hasLength(1));
+
+    // dispose 이후 setCamera는 아무 이벤트도 만들지 않고 프레임도 예약 안 함.
+    await controller.setCamera(cameraAt(9));
+    await flush();
+    expect(frames, isEmpty);
+  });
+
+  test('dispose 후 도착한 프레임 콜백은 닫힌 스트림에 쓰지 않는다', () async {
+    final frames = <void Function(Duration)>[];
+    final controller = StructuredRouteMapRendererController(
+      scheduleFrame: frames.add,
+    );
+    controller.events.listen((_) {});
+    await flush();
+
+    await controller.setCamera(cameraAt(3));
+    await flush();
+    expect(frames, hasLength(1));
+
+    await controller.dispose();
+    // 늦게 도착한 프레임 콜백이 예외를 던지지 않아야 한다.
+    expect(() => frames.single(Duration.zero), returnsNormally);
+  });
+}

--- a/apps/mobile/test/features/network_map/infrastructure/structured_route_map_renderer_controller_test.dart
+++ b/apps/mobile/test/features/network_map/infrastructure/structured_route_map_renderer_controller_test.dart
@@ -20,9 +20,10 @@ MapCameraState cameraAt(int revision) {
 Future<void> flush() => Future<void>.delayed(Duration.zero);
 
 void main() {
-  test('생성 시 Created/AssetLoading/AssetReady를 방출한다', () async {
+  test('첫 구독 시 Created/AssetLoading/AssetReady를 방출한다', () async {
     final controller = StructuredRouteMapRendererController(
       scheduleFrame: (_) {},
+      requestFrame: () {},
     );
     final events = <RouteMapRendererEvent>[];
     controller.events.listen(events.add);
@@ -36,10 +37,12 @@ void main() {
     await controller.dispose();
   });
 
-  test('setCamera는 CameraRequested 후 post-frame에 CameraLatency·FramePresented', () async {
+  test('setCamera는 프레임을 요청하고 post-frame에 CameraLatency·FramePresented', () async {
     final frames = <void Function(Duration)>[];
+    var frameRequests = 0;
     final controller = StructuredRouteMapRendererController(
       scheduleFrame: frames.add,
+      requestFrame: () => frameRequests++,
     );
     final events = <RouteMapRendererEvent>[];
     controller.events.listen(events.add);
@@ -53,12 +56,11 @@ void main() {
       events.whereType<RouteMapRendererCameraRequested>().single.revision,
       7,
     );
-    // 아직 프레임이 안 왔으므로 FramePresented 없음.
+    expect(frameRequests, greaterThanOrEqualTo(1)); // 프레임을 실제로 요청함
     expect(events.whereType<RouteMapRendererFramePresented>(), isEmpty);
     expect(frames, hasLength(1));
 
-    // 프레임 도착 시뮬레이션.
-    frames.single(Duration.zero);
+    frames.single(Duration.zero); // 프레임 도착 시뮬레이션
     await flush();
 
     expect(
@@ -71,28 +73,58 @@ void main() {
     await controller.dispose();
   });
 
-  test('retry는 AssetReady, trimMemory는 MemoryTrimmed를 방출한다', () async {
+  test('retry는 마지막 revision의 FramePresented를 다시 통지한다(복구 완료)', () async {
+    final frames = <void Function(Duration)>[];
+    final controller = StructuredRouteMapRendererController(
+      scheduleFrame: frames.add,
+      requestFrame: () {},
+    );
+    final events = <RouteMapRendererEvent>[];
+    controller.events.listen(events.add);
+    await flush();
+
+    await controller.setCamera(cameraAt(5));
+    await flush();
+    frames.removeLast()(Duration.zero); // 최초 프레임 소비
+    await flush();
+    events.clear();
+
+    // 복구 시나리오: monitor가 retry 호출 → AssetReady + revision 재통지.
+    await controller.retry();
+    await flush();
+    expect(events.whereType<RouteMapRendererAssetReady>(), hasLength(1));
+    expect(frames, hasLength(1));
+
+    frames.single(Duration.zero);
+    await flush();
+    expect(
+      events.whereType<RouteMapRendererFramePresented>().single.revision,
+      5,
+    );
+    await controller.dispose();
+  });
+
+  test('trimMemory는 MemoryTrimmed를 방출한다', () async {
     final controller = StructuredRouteMapRendererController(
       scheduleFrame: (_) {},
+      requestFrame: () {},
     );
     final events = <RouteMapRendererEvent>[];
     controller.events.listen(events.add);
     await flush();
     events.clear();
 
-    await controller.retry();
     await controller.trimMemory();
     await flush();
-
-    expect(events.whereType<RouteMapRendererAssetReady>(), hasLength(1));
     expect(events.whereType<RouteMapRendererMemoryTrimmed>(), hasLength(1));
     await controller.dispose();
   });
 
-  test('dispose는 Disposed 방출 후 스트림을 닫고, 이후 호출은 무시된다', () async {
+  test('dispose는 Disposed 방출 후 스트림을 닫고 이후 호출을 무시한다', () async {
     final frames = <void Function(Duration)>[];
     final controller = StructuredRouteMapRendererController(
       scheduleFrame: frames.add,
+      requestFrame: () {},
     );
     final events = <RouteMapRendererEvent>[];
     controller.events.listen(events.add);
@@ -102,7 +134,6 @@ void main() {
     await flush();
     expect(events.whereType<RouteMapRendererDisposed>(), hasLength(1));
 
-    // dispose 이후 setCamera는 아무 이벤트도 만들지 않고 프레임도 예약 안 함.
     await controller.setCamera(cameraAt(9));
     await flush();
     expect(frames, isEmpty);
@@ -112,6 +143,7 @@ void main() {
     final frames = <void Function(Duration)>[];
     final controller = StructuredRouteMapRendererController(
       scheduleFrame: frames.add,
+      requestFrame: () {},
     );
     controller.events.listen((_) {});
     await flush();
@@ -121,7 +153,6 @@ void main() {
     expect(frames, hasLength(1));
 
     await controller.dispose();
-    // 늦게 도착한 프레임 콜백이 예외를 던지지 않아야 한다.
     expect(() => frames.single(Duration.zero), returnsNormally);
   });
 }


### PR DESCRIPTION
## Summary
- #1641 **4단계: RouteMapRendererController 이벤트 계약 어댑터**. WebView 렌더러와 **동일한 이벤트 계약**(Created/AssetReady/CameraRequested/CameraLatency/FramePresented/…)을 native canvas 렌더러에도 제공해, `tools/mobile/run-route-map-android-evidence.sh` 증거 파이프라인과 `RouteMapRendererHealthMonitor`가 그대로 동작하게 합니다.
- `infrastructure/structured_route_map_renderer_controller.dart` 신설:
  - 생성 시 `Created`/`AssetLoading`/`AssetReady`(데이터가 이미 datapack 메모리에 있으므로 즉시 ready).
  - `setCamera` → `CameraRequested` 후 **post-frame 콜백**에서 `CameraLatency`(설정→프레임 경과)·`FramePresented` 방출.
  - `retry`/`trimMemory`/`dispose` 계약 구현. native canvas는 process gone/frame timeout이 없어 해당 이벤트는 미방출.
  - `scheduleFrame`·`stopwatchFactory` 주입으로 결정적 단위 테스트.

## 단계 계획 (#1641)
1. ✅ 데이터 레이어 (#1669)
2. ✅ canvas 렌더러 코어 (#1672)
3. ✅ 라벨 충돌·attribution (#1673)
4. **컨트롤러 이벤트 계약 (본 PR)**

## 남은 작업 (실기기 QA 게이트)
- `NetworkMapScreen` 제스처/카메라에 `RouteMapRendererKind` flag 연결(WebView 기본 유지)과 실기기 Semantics/48dp·pan/zoom 성능 증거는 **#1642/#1643 QA에서 실기기로 검증** 후 WebView 경로와 `assets/datapacks/maps/*.svg` 제거. 코드 파운데이션(데이터/렌더러/라벨/컨트롤러)은 본 PR로 완비.

## Test Plan
- `flutter test .../structured_route_map_renderer_controller_test.dart` (5 pass)
- `flutter analyze` (No issues)
- 초기 이벤트·setCamera 프레임 통지·retry/trim·dispose·dispose 후 지연 프레임 콜백 안전 테스트

Refs #1641