### PR TITLE
[Style] 알림 기능 노출 정합성 정리 — 온보딩 알림 요청 단일 소스화 (#1579)

### DIFF
--- a/apps/mobile/lib/onboarding.dart
+++ b/apps/mobile/lib/onboarding.dart
@@ -420,12 +420,15 @@ class _PermissionInfoCard extends StatelessWidget {
     required this.notificationSelected,
     required this.onLocationChanged,
     required this.onNotificationChanged,
+    required this.notificationAvailable,
   });
 
   final bool locationSelected;
   final bool notificationSelected;
   final ValueChanged<bool> onLocationChanged;
   final ValueChanged<bool> onNotificationChanged;
+  // 알림 기능이 이 빌드에서 제공되지 않으면 켜라고 요청하지 않는다(#1579).
+  final bool notificationAvailable;
 
   @override
   Widget build(BuildContext context) {
@@ -439,14 +442,16 @@ class _PermissionInfoCard extends StatelessWidget {
             value: locationSelected,
             onChanged: onLocationChanged,
           ),
-          const _IntroDivider(),
-          _PermissionInfoRow(
-            icon: Icons.notifications_none,
-            title: '알림',
-            subtitle: '시설 고장·복구 알림',
-            value: notificationSelected,
-            onChanged: onNotificationChanged,
-          ),
+          if (notificationAvailable) ...[
+            const _IntroDivider(),
+            _PermissionInfoRow(
+              icon: Icons.notifications_none,
+              title: '알림',
+              subtitle: '시설 고장·복구 알림',
+              value: notificationSelected,
+              onChanged: onNotificationChanged,
+            ),
+          ],
         ],
       ),
     );
@@ -558,6 +563,9 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
   Widget build(BuildContext context) {
     final selectedProfile = _selectedProfile;
     final textTheme = Theme.of(context).textTheme;
+    // 알림 기능 가용 여부의 단일 소스: 알림 권한 provider가 주입됐는지(#1579).
+    // 더보기 알림 섹션(notificationRepository)과 함께 켜지고 꺼진다.
+    final notificationAvailable = widget.notificationPermissionProvider != null;
     final listBottomPadding = _currentStep == 1 ? 32.0 : 104.0;
     final profileOptions = [
       mobilityProfileOptions.firstWhere((profile) => profile.id == 'elderly'),
@@ -643,7 +651,9 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                   Semantics(
                     header: true,
                     child: Text(
-                      '위치와 알림은 나중에도 켤 수 있어요',
+                      notificationAvailable
+                          ? '위치와 알림은 나중에도 켤 수 있어요'
+                          : '위치는 나중에도 켤 수 있어요',
                       style: textTheme.headlineSmall?.copyWith(
                         color: EasySubwayAccessibleColors.text,
                         fontWeight: FontWeight.w900,
@@ -659,6 +669,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                         setState(() => _locationPermissionSelected = value),
                     onNotificationChanged: (value) =>
                         setState(() => _notificationPermissionSelected = value),
+                    notificationAvailable: notificationAvailable,
                   ),
                   if (_showNotificationPermissionFailureNextAction) ...[
                     const SizedBox(height: 12),

--- a/apps/mobile/test/onboarding_app_flow_test.dart
+++ b/apps/mobile/test/onboarding_app_flow_test.dart
@@ -95,10 +95,12 @@ void main() {
     expect(find.byType(HomeScreen), findsOneWidget);
   });
 
-  testWidgets('첫 실행 앱은 알림 설정 저장소가 없어도 권한 선택 화면을 유지한다', (tester) async {
+  testWidgets('첫 실행 앱은 알림이 비활성이면 온보딩 알림 요청을 숨기고 위치만 남긴다', (tester) async {
     await tester.pumpWidget(
       _testApp(
+        // 알림 가용성 단일 소스: 저장소·권한 provider를 함께 비활성으로 둔다(#1579).
         notificationRepository: null,
+        notificationPermissionProvider: null,
         onboardingStore: MemoryOnboardingResultStore(),
       ),
     );
@@ -106,10 +108,12 @@ void main() {
     await _openOnboarding(tester);
     await _continueFromProfileToPermission(tester);
 
-    expect(find.text('위치와 알림은 나중에도 켤 수 있어요'), findsOneWidget);
+    // 켜라고 요청하지 않는다(더보기 '사용할 수 없어요' 고지와의 모순 제거, #1579).
+    expect(find.text('위치는 나중에도 켤 수 있어요'), findsOneWidget);
+    expect(find.text('위치와 알림은 나중에도 켤 수 있어요'), findsNothing);
     expect(find.text('필요한 권한을 나중에 켤 수 있어요'), findsNothing);
     expect(find.text('현재 위치'), findsOneWidget);
-    expect(find.text('알림'), findsOneWidget);
+    expect(find.text('알림'), findsNothing);
     expect(
       find.byKey(const Key('onboardingPermissionSkipButton')),
       findsOneWidget,
@@ -196,7 +200,9 @@ EasySubwayApp _testApp({
       const NoLegacyCredentialCleaner(),
   NotificationSettingsRepository? notificationRepository =
       const _DefaultNotificationSettingsRepository(),
-  NotificationPermissionProvider? notificationPermissionProvider,
+  // 알림 가용성은 단일 소스라(#1579) 기본은 저장소·권한 provider를 함께 제공한다.
+  NotificationPermissionProvider? notificationPermissionProvider =
+      const _DefaultNotificationPermissionProvider(),
   CurrentLocationProvider? locationProvider,
 }) {
   return EasySubwayApp(
@@ -306,6 +312,16 @@ class FakeFavoriteStationRepository implements FavoriteStationRepository {
 
   @override
   Future<void> removeFavoriteStation(String stationId) async {}
+}
+
+class _DefaultNotificationPermissionProvider
+    implements NotificationPermissionProvider {
+  const _DefaultNotificationPermissionProvider();
+
+  @override
+  Future<NotificationPermissionStatus> requestNotificationPermission() async {
+    return NotificationPermissionStatus.granted;
+  }
 }
 
 class _DefaultNotificationSettingsRepository

--- a/apps/mobile/test/onboarding_test.dart
+++ b/apps/mobile/test/onboarding_test.dart
@@ -83,6 +83,8 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: OnboardingScreen(
+            notificationPermissionProvider:
+                _FakeNotificationPermissionProvider(),
             onCompleted: (result) {
               completedResult = result;
             },
@@ -297,7 +299,12 @@ void main() {
 
   testWidgets('온보딩 2·3단계는 이전 단계로 돌아갈 수 있다', (tester) async {
     await tester.pumpWidget(
-      MaterialApp(home: OnboardingScreen(onCompleted: (_) {})),
+      MaterialApp(
+        home: OnboardingScreen(
+          notificationPermissionProvider: _FakeNotificationPermissionProvider(),
+          onCompleted: (_) {},
+        ),
+      ),
     );
 
     await tester.tap(find.byKey(const Key('onboardingProfileCard-elderly')));

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -639,9 +639,10 @@ void main() {
     await tester.tap(find.byKey(const Key('onboardingDoneButton')));
     await tester.pumpAndSettle();
 
-    // 2단계: 권한 — 조건 확인 화면과 옛 CTA는 없다.
+    // 2단계: 권한 — 조건 확인 화면과 옛 CTA는 없다. 알림 provider 미주입이라
+    // 알림 요청은 숨고 위치만 남는다(#1579).
     expect(find.text('적용할 조건을 확인하세요'), findsNothing);
-    expect(find.text('위치와 알림은 나중에도 켤 수 있어요'), findsOneWidget);
+    expect(find.text('위치는 나중에도 켤 수 있어요'), findsOneWidget);
     expect(find.text('2 / 2'), findsOneWidget);
     expect(find.text('시작하기'), findsOneWidget);
     expect(find.text('선택한 기능 설정하고 시작'), findsNothing);


### PR DESCRIPTION
## 관련 이슈

Closes #1579. (base: `main` — 3차 정비 스택 병합 완료 후 최신 main 기준)

## 작업 배경

- 온보딩 마지막 단계에서 알림 권한 토글("시설 고장·복구 알림")을 켜라고 요청하면서, 같은 빌드의 더보기에서는 "알림은 아직 사용할 수 없어요"를 전시하던 **정면 모순**을 없앱니다(#1570에서 더보기 고지는 이미 제거).

## 작업 내용

- **알림 가용성 단일 소스**: 부트스트랩(`app_dependencies.dart`)의 `pushNotificationsEnabled` 한 플래그가 `notificationRepository`와 `notificationPermissionProvider`를 **함께** 켜고 끕니다. 이를 신호로 온보딩·더보기·알림함이 함께 켜지고 꺼집니다.
- **온보딩 불가 상태**: `notificationPermissionProvider == null`이면 `_PermissionInfoCard`에서 알림 행·구분선을 숨기고, 권한 스텝 헤더를 "위치와 알림은…" → "위치는 나중에도 켤 수 있어요"로 바꿉니다. → 켜라고 요청하지 않습니다.
- **더보기·알림함**: 이미 `notificationRepository`로 gate돼 있어(#1570 + 기존), 세 곳이 일관됩니다.
- **위젯 테스트**: 가용 상태(provider 주입) 흐름은 유지하고, **불가 상태 전용 테스트**(둘 다 null → 알림 요청 숨김·위치만)를 추가했습니다. app_flow `_testApp` 기본 provider를 저장소와 함께 가용으로 정합했습니다.

## 검증

- `dart format`, `flutter analyze lib/onboarding.dart` → **No issues found!**
- `flutter test` → **All tests passed!** (687건)
- `node --test tools/ci/repository-contract.test.mjs` → 158 pass / 0 fail
- 완료 기준: "아직 사용할 수 없어요"류 문구가 lib에 존재하지 않음 확인.

## 완료 기준 충족

- [x] 어떤 빌드 구성에서도 "켜 달라고 요청"과 "못 쓴다고 고지"가 공존하지 않는다(단일 소스).
- [x] "아직 사용할 수 없어요"류 문구가 앱에 존재하지 않는다.
- [x] 가용/불가 두 상태 온보딩 위젯 테스트.

## Version impact

- [x] no version change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)
