### PR TITLE
[Test] RAPTOR service day calendar regression (#1620)

### DIFF
--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -2084,13 +2084,35 @@ class RouteSearchServiceTest {
 	}
 
 	private static LoadRouteTimetablePort lateNightRouteTimetablePort() {
-		return () -> routeTimetable(
-			List.of(
-				new LoadRouteTimetablePort.TransitStopTime("trip-seoul-4-late", 1, "station-a", "seoul-4", 87000, 87000, 0, 0),
-				new LoadRouteTimetablePort.TransitStopTime("trip-seoul-4-late", 2, "station-b", "seoul-4", 87900, 87900, 0, 0)
-			),
-			List.of()
-		);
+		return () -> {
+			var timetable = routeTimetable(
+				List.of(
+					new LoadRouteTimetablePort.TransitStopTime("trip-seoul-4-late", 1, "station-a", "seoul-4", 87000, 87000, 0, 0),
+					new LoadRouteTimetablePort.TransitStopTime("trip-seoul-4-late", 2, "station-b", "seoul-4", 87900, 87900, 0, 0)
+				),
+				List.of()
+			);
+			return new LoadRouteTimetablePort.RouteTimetable(
+				List.of(new LoadRouteTimetablePort.ServiceCalendar(
+					"weekday-2026",
+					true,
+					true,
+					true,
+					true,
+					true,
+					false,
+					false,
+					LocalDate.parse("2026-07-01"),
+					LocalDate.parse("2026-07-01"),
+					"Asia/Seoul"
+				)),
+				timetable.serviceCalendarDates(),
+				timetable.transitRoutes(),
+				timetable.transitTrips(),
+				timetable.transitStopTimes(),
+				timetable.transitFrequencies()
+			);
+		};
 	}
 
 	private static LoadRouteTimetablePort removedCalendarDateRouteTimetablePort() {

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -988,6 +988,40 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("V2 planner는 심야 24시대 시간표를 이전 service day로 탐색한다")
+	void routeV2PlannerUsesPreviousServiceDayForAfterMidnightTrips() {
+		var planner = new RouteV2Planner(legacySearchMustNotBeCalled(), lateNightRouteTimetablePort());
+
+		var plan = planner.search(new RouteV2SearchUseCase.SearchRouteV2Command(
+			"station-a",
+			"station-b",
+			OffsetDateTime.parse("2026-07-02T00:00:00+09:00"),
+			MobilityType.SENIOR,
+			ConstraintMode.PREFER_STEP_FREE,
+			false,
+			1,
+			3
+		));
+
+		assertThat(plan.statuses()).containsExactly(RouteV2Status.FOUND);
+		assertThat(plan.itineraries().getFirst().steps())
+			.filteredOn(step -> "ride".equals(step.stepType()))
+			.extracting("fromStationId", "toStationId", "estimatedMinutes")
+			.containsExactly(tuple("station-a", "station-b", 15));
+	}
+
+	@Test
+	@DisplayName("V2 planner는 calendar exception 제거일의 시간표를 제외한다")
+	void routeV2PlannerRemovesCalendarDateExceptionService() {
+		var planner = new RouteV2Planner(legacySearchMustNotBeCalled(), removedCalendarDateRouteTimetablePort());
+
+		var plan = planner.search(routeV2Command(ConstraintMode.PREFER_STEP_FREE, MobilityType.SENIOR, 1, 3));
+
+		assertThat(plan.statuses()).containsExactly(RouteV2Status.NO_TIMETABLE_SERVICE);
+		assertThat(plan.itineraries()).isEmpty();
+	}
+
+	@Test
 	@DisplayName("V2 planner는 pickup/drop-off 제한 stop_times를 승하차 후보에서 제외한다")
 	void routeV2PlannerHonorsPickupAndDropOffRestrictions() {
 		var noPickupPlanner = new RouteV2Planner(legacySearchMustNotBeCalled(), restrictedStopRouteTimetablePort(1, 0));
@@ -2047,6 +2081,36 @@ class RouteSearchServiceTest {
 			),
 			List.of(new LoadRouteTimetablePort.TransitFrequency("trip-seoul-4-frequency", 32400, 36000, 600, false))
 		);
+	}
+
+	private static LoadRouteTimetablePort lateNightRouteTimetablePort() {
+		return () -> routeTimetable(
+			List.of(
+				new LoadRouteTimetablePort.TransitStopTime("trip-seoul-4-late", 1, "station-a", "seoul-4", 87000, 87000, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime("trip-seoul-4-late", 2, "station-b", "seoul-4", 87900, 87900, 0, 0)
+			),
+			List.of()
+		);
+	}
+
+	private static LoadRouteTimetablePort removedCalendarDateRouteTimetablePort() {
+		return () -> {
+			var timetable = routeTimetable(
+				List.of(
+					new LoadRouteTimetablePort.TransitStopTime("trip-seoul-4-removed", 1, "station-a", "seoul-4", 32760, 32760, 0, 0),
+					new LoadRouteTimetablePort.TransitStopTime("trip-seoul-4-removed", 2, "station-b", "seoul-4", 33360, 33360, 0, 0)
+				),
+				List.of()
+			);
+			return new LoadRouteTimetablePort.RouteTimetable(
+				timetable.serviceCalendars(),
+				List.of(new LoadRouteTimetablePort.ServiceCalendarDate("weekday-2026", LocalDate.parse("2026-07-01"), 2)),
+				timetable.transitRoutes(),
+				timetable.transitTrips(),
+				timetable.transitStopTimes(),
+				timetable.transitFrequencies()
+			);
+		};
 	}
 
 	private static LoadRouteTimetablePort restrictedStopRouteTimetablePort(int pickupType, int dropOffType) {


### PR DESCRIPTION
## 관련 이슈

Refs #1620
Refs #1414

## 작업 배경

- #1671로 backend RAPTOR core가 들어갔고, #1620 완료 조건 중 Asia/Seoul service day, 24시대 심야 trip, calendar exception 평가를 backend 회귀 테스트로 고정합니다.
- 프론트엔드 변경은 하지 않습니다.

## 작업 내용

- RAPTOR가 00:00 이후 요청을 이전 service day의 24시대 stop_times로 탐색하는 테스트를 추가했습니다.
- `service_calendar_dates` exception type 2가 해당 날짜 시간표를 제거하는 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.route.application.service.RouteSearchServiceTest` 통과
  - `node --test --test-name-pattern "V2 경로 검색" tools/ci/repository-contract.test.mjs` 통과
  - `node --test tools/routes/*.test.mjs` 통과
  - `git diff --check` 통과

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| RAPTOR service day/calendar regression | Backend | Gradle route service test | 로컬 명령 출력 | 통과 |
| UI/접근성 수동 QA | Mobile | UI 변경 없음 | 불필요: backend test-only 변경 | 해당 없음 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: RAPTOR service day/calendar regression coverage 추가
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `RouteSearchServiceTest`의 심야 24시대 stop_times와 calendar exception 회귀 테스트

## 리스크

- test-only 변경입니다. #1620의 실시간 overlay, golden OD, production schedule data 적재는 후속 작업입니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.