### PR TITLE
[Fix] Route V2 realtime planned RAPTOR fallback (#1620)

### DIFF
--- a/backend/src/main/java/com/easysubway/route/application/port/in/RouteSearchUseCase.java
+++ b/backend/src/main/java/com/easysubway/route/application/port/in/RouteSearchUseCase.java
@@ -23,6 +23,10 @@ public interface RouteSearchUseCase {
 		return List.copyOf(timetableResults);
 	}
 
+	default boolean supportsRealtimeOverlay() {
+		return true;
+	}
+
 	InternalRouteResult searchInternalRoute(SearchInternalRouteCommand command);
 
 	RouteSearchResult getRouteSearch(String routeSearchId);

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -147,6 +147,11 @@ public class RouteSearchService implements RouteSearchUseCase {
 		this.realtimeEtaOverlay = new RealtimeEtaOverlay();
 	}
 
+	@Override
+	public boolean supportsRealtimeOverlay() {
+		return realtimeArrivalResolver != null;
+	}
+
 	public RouteSearchService(
 		LoadRouteSearchPort loadRouteSearchPort,
 		SaveRouteSearchPort saveRouteSearchPort,

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
@@ -78,7 +78,7 @@ public class RouteV2Planner implements RouteV2SearchUseCase {
 					command.alternativeCount(),
 					timetableItineraries
 				);
-				return new RouteV2Plan(timetableItineraries, statusesOf(timetableItineraries, false), PLANNER_ADR);
+				return new RouteV2Plan(timetableItineraries, statusesOf(timetableItineraries, command.useRealtime()), PLANNER_ADR);
 			}
 			SearchRouteCommand searchRouteCommand = toSearchRouteCommand(command);
 			List<RouteSearchResult> itineraries = routeSearchUseCase.searchRouteAlternatives(
@@ -96,9 +96,9 @@ public class RouteV2Planner implements RouteV2SearchUseCase {
 	}
 
 	private boolean canUseTimetableRaptor(SearchRouteV2Command command) {
-		return !command.useRealtime()
-			&& command.constraintMode() != ConstraintMode.STRICT_STEP_FREE
-			&& command.mobilityType() != MobilityType.WHEELCHAIR;
+		return command.constraintMode() != ConstraintMode.STRICT_STEP_FREE
+			&& command.mobilityType() != MobilityType.WHEELCHAIR
+			&& (!command.useRealtime() || !routeSearchUseCase.supportsRealtimeOverlay());
 	}
 
 	private RouteTimetable routeTimetable() {

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
@@ -26,6 +26,7 @@ import com.easysubway.route.domain.RouteWarningCode;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,6 +51,11 @@ class RouteSearchV2ControllerTest {
 
 	@MockitoBean
 	private RouteSearchUseCase routeSearchUseCase;
+
+	@BeforeEach
+	void setUpRealtimeOverlayCapability() {
+		when(routeSearchUseCase.supportsRealtimeOverlay()).thenReturn(true);
+	}
 
 	@TestConfiguration
 	static class RouteTimetableTestConfiguration {

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -828,6 +828,29 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("V2 planner는 realtime 요청에서 overlay가 없으면 시간표 PLANNED로 강등한다")
+	void routeV2PlannerFallsBackToPlannedTimetableWhenRealtimeOverlayMissing() {
+		var repository = new InMemoryRouteSearchRepository();
+		var routeSearchService = new RouteSearchService(repository, repository, new DisconnectedTransitMasterPort(), CLOCK);
+		var planner = new RouteV2Planner(routeSearchService, routeTimetablePort());
+
+		var plan = planner.search(new RouteV2SearchUseCase.SearchRouteV2Command(
+			"station-a",
+			"station-b",
+			OffsetDateTime.parse("2026-07-01T09:00:00+09:00"),
+			MobilityType.SENIOR,
+			ConstraintMode.PREFER_STEP_FREE,
+			true,
+			1,
+			3
+		));
+
+		assertThat(plan.statuses())
+			.containsExactly(RouteV2Status.FOUND, RouteV2Status.REALTIME_UNAVAILABLE_PLANNED_USED);
+		assertThat(plan.itineraries().getFirst().etaSource()).isEqualTo(EtaSource.PLANNED);
+	}
+
+	@Test
 	@DisplayName("V2 planner는 시간표 환승 경로에 접근과 환승 step을 보강한다")
 	void routeV2PlannerAddsAccessAndTransferStepsToTimetableTransferRoute() {
 		var planner = new RouteV2Planner(legacySearchMustNotBeCalled(), transferRouteTimetablePort());
@@ -1041,7 +1064,7 @@ class RouteSearchServiceTest {
 		var planner = new RouteV2Planner(routeSearchService, new LoadRouteTimetablePort() {
 			@Override
 			public boolean hasRouteTimetable() {
-				return true;
+				return false;
 			}
 
 			@Override
@@ -1061,7 +1084,8 @@ class RouteSearchServiceTest {
 			3
 		));
 
-		assertThat(plan.statuses()).contains(RouteV2Status.FOUND);
+		assertThat(plan.statuses()).containsExactly(RouteV2Status.NO_TIMETABLE_SERVICE);
+		assertThat(plan.itineraries()).isEmpty();
 	}
 
 	@Test


### PR DESCRIPTION
## 관련 이슈

Refs #1620
Refs #1414

## 작업 배경

- Route V2 realtime 요청에서 provider overlay가 없을 때 legacy graph로 내려가면 시간표 기반 PLANNED 품질을 보장하지 못합니다.

## 작업 내용

- realtime resolver가 없으면 Route V2가 RAPTOR 시간표 scan 결과로 PLANNED fallback을 반환하게 했습니다.
- realtime resolver가 있는 기존 provider overlay 경로는 유지했습니다.
- timetable availability guard 테스트와 realtime planned fallback 회귀 테스트를 보강했습니다.

## 검증

- 실행한 명령과 결과:
- `./gradlew test --tests com.easysubway.route.application.service.RouteSearchServiceTest` pass
- `node --test --test-name-pattern "V2 경로 검색" tools/ci/repository-contract.test.mjs` pass
- `node --test tools/routes/*.test.mjs` pass
- `git diff --check` pass

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Route V2 realtime planned fallback | backend | Gradle focused test | local command output | pass |
| Route V2 contract boundary | repository | node repository contract test | local command output | pass |
| Route tooling regression | repository | node routes tests | local command output | pass |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: realtime overlay 미구성 시 Route V2가 RAPTOR PLANNED fallback status를 반환
- realtime contract: provider resolver 존재 시 기존 overlay 유지, 미존재 시 PLANNED 강등
- backend identity: PR merge commit

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `RouteV2Planner.canUseTimetableRaptor()`와 `RouteSearchService.supportsRealtimeOverlay()`

## 리스크

- resolver가 구성된 기존 realtime overlay 경로와 resolver 미구성 PLANNED fallback 분기가 갈립니다. 회귀 테스트로 둘 다 고정했습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 실시간 정보가 지원되는지 자동으로 판단해, 가능한 경우에만 실시간 경로를 더 잘 활용하도록 개선했습니다.
  * 실시간 오버레이를 사용할 수 없는 경우에도 시간표 기반 결과를 대신 제공할 수 있게 되었습니다.

* **버그 수정**
  * 실시간 요청 시 결과 상태와 도착 예상 정보가 실제 사용 가능한 데이터에 맞게 더 정확히 표시되도록 수정했습니다.
  * 실시간 서비스가 없을 때의 경로 검색 결과가 더 일관되게 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->