### PR TITLE
[Test] RAPTOR candidate accessibility ranking (#1620)

### DIFF
--- a/backend/src/main/java/com/easysubway/route/application/port/in/RouteSearchUseCase.java
+++ b/backend/src/main/java/com/easysubway/route/application/port/in/RouteSearchUseCase.java
@@ -23,6 +23,15 @@ public interface RouteSearchUseCase {
 		return List.copyOf(timetableResults);
 	}
 
+	default List<RouteSearchResult> stabilizeTimetableRouteCandidates(
+		SearchRouteCommand command,
+		int candidateCount,
+		int alternativeCount,
+		List<RouteSearchResult> timetableResults
+	) {
+		return stabilizeTimetableRouteResults(command, alternativeCount, timetableResults);
+	}
+
 	default boolean supportsRealtimeOverlay() {
 		return true;
 	}

--- a/backend/src/main/java/com/easysubway/route/application/port/in/RouteSearchUseCase.java
+++ b/backend/src/main/java/com/easysubway/route/application/port/in/RouteSearchUseCase.java
@@ -5,6 +5,7 @@ import com.easysubway.route.domain.RouteFeedback;
 import com.easysubway.route.domain.RouteRefreshResult;
 import com.easysubway.route.domain.RouteSearchResult;
 import java.util.List;
+import java.util.function.UnaryOperator;
 
 public interface RouteSearchUseCase {
 
@@ -30,6 +31,21 @@ public interface RouteSearchUseCase {
 		List<RouteSearchResult> timetableResults
 	) {
 		return stabilizeTimetableRouteResults(command, alternativeCount, timetableResults);
+	}
+
+	default List<RouteSearchResult> stabilizeTimetableRouteCandidates(
+		SearchRouteCommand command,
+		int candidateCount,
+		int alternativeCount,
+		List<RouteSearchResult> timetableResults,
+		UnaryOperator<List<RouteSearchResult>> selectCandidates
+	) {
+		return selectCandidates.apply(stabilizeTimetableRouteCandidates(
+			command,
+			candidateCount,
+			alternativeCount,
+			timetableResults
+		));
 	}
 
 	default boolean supportsRealtimeOverlay() {

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -212,10 +212,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 	) {
 		try {
 			List<RouteSearchResult> accessibilityCheckedResults = buildRouteSearchAlternatives(command, candidateCount);
-			List<RouteSearchResult> returnableAccessibilityResults = accessibilityCheckedResults.stream()
-				.limit(alternativeCount)
-				.toList();
-			if (returnableAccessibilityResults.stream().anyMatch(this::hasAccessibilitySignal)) {
+			if (accessibilityCheckedResults.stream().anyMatch(this::hasAccessibilitySignal)) {
 				return accessibilityCheckedResults.stream()
 					.map(saveRouteSearchPort::saveRouteSearch)
 					.toList();

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -224,9 +224,9 @@ public class RouteSearchService implements RouteSearchUseCase {
 	) {
 		try {
 			List<RouteSearchResult> accessibilityCheckedResults = buildRouteSearchAlternatives(command, candidateCount);
-			if (accessibilityCheckedResults.stream().anyMatch(this::hasAccessibilitySignal)) {
-				return selectCandidates.apply(accessibilityCheckedResults)
-					.stream()
+			List<RouteSearchResult> selectedAccessibilityCheckedResults = selectCandidates.apply(accessibilityCheckedResults);
+			if (selectedAccessibilityCheckedResults.stream().anyMatch(this::hasAccessibilitySignal)) {
+				return selectedAccessibilityCheckedResults.stream()
 					.map(saveRouteSearchPort::saveRouteSearch)
 					.toList();
 			}

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -58,6 +58,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -210,10 +211,22 @@ public class RouteSearchService implements RouteSearchUseCase {
 		int alternativeCount,
 		List<RouteSearchResult> timetableResults
 	) {
+		return stabilizeTimetableRouteCandidates(command, candidateCount, alternativeCount, timetableResults, List::copyOf);
+	}
+
+	@Override
+	public List<RouteSearchResult> stabilizeTimetableRouteCandidates(
+		SearchRouteCommand command,
+		int candidateCount,
+		int alternativeCount,
+		List<RouteSearchResult> timetableResults,
+		UnaryOperator<List<RouteSearchResult>> selectCandidates
+	) {
 		try {
 			List<RouteSearchResult> accessibilityCheckedResults = buildRouteSearchAlternatives(command, candidateCount);
 			if (accessibilityCheckedResults.stream().anyMatch(this::hasAccessibilitySignal)) {
-				return accessibilityCheckedResults.stream()
+				return selectCandidates.apply(accessibilityCheckedResults)
+					.stream()
 					.map(saveRouteSearchPort::saveRouteSearch)
 					.toList();
 			}
@@ -221,7 +234,8 @@ public class RouteSearchService implements RouteSearchUseCase {
 			// Timetable coverage can lead legacy graph coverage while #1400 closes the production graph gap.
 			log.debug("Legacy graph could not stabilize timetable route {} -> {}", command.originStationId(), command.destinationStationId(), exception);
 		}
-		return timetableResults.stream()
+		return selectCandidates.apply(timetableResults)
+			.stream()
 			.map(this::storedTimetableRouteResult)
 			.map(saveRouteSearchPort::saveRouteSearch)
 			.toList();

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -200,10 +200,23 @@ public class RouteSearchService implements RouteSearchUseCase {
 		int alternativeCount,
 		List<RouteSearchResult> timetableResults
 	) {
+		return stabilizeTimetableRouteCandidates(command, alternativeCount, alternativeCount, timetableResults);
+	}
+
+	@Override
+	public List<RouteSearchResult> stabilizeTimetableRouteCandidates(
+		SearchRouteCommand command,
+		int candidateCount,
+		int alternativeCount,
+		List<RouteSearchResult> timetableResults
+	) {
 		try {
-			List<RouteSearchResult> accessibilityCheckedResults = buildRouteSearchAlternatives(command, alternativeCount);
-			if (accessibilityCheckedResults.stream().anyMatch(this::hasAccessibilitySignal)) {
-				return accessibilityCheckedResults.stream()
+			List<RouteSearchResult> accessibilityCheckedResults = buildRouteSearchAlternatives(command, candidateCount);
+			List<RouteSearchResult> returnableAccessibilityResults = accessibilityCheckedResults.stream()
+				.limit(alternativeCount)
+				.toList();
+			if (returnableAccessibilityResults.stream().anyMatch(this::hasAccessibilitySignal)) {
+				return returnableAccessibilityResults.stream()
 					.map(saveRouteSearchPort::saveRouteSearch)
 					.toList();
 			}

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -216,7 +216,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 				.limit(alternativeCount)
 				.toList();
 			if (returnableAccessibilityResults.stream().anyMatch(this::hasAccessibilitySignal)) {
-				return returnableAccessibilityResults.stream()
+				return accessibilityCheckedResults.stream()
 					.map(saveRouteSearchPort::saveRouteSearch)
 					.toList();
 			}

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
@@ -14,7 +14,9 @@ import com.easysubway.route.domain.EtaSource;
 import com.easysubway.route.domain.RouteNotFoundException;
 import com.easysubway.route.domain.RouteSearchResult;
 import com.easysubway.route.domain.RouteSearchStatus;
+import com.easysubway.route.domain.RouteStep;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.ObjectProvider;
@@ -78,6 +80,7 @@ public class RouteV2Planner implements RouteV2SearchUseCase {
 					command.alternativeCount(),
 					timetableItineraries
 				);
+				timetableItineraries = rankTimetableItineraries(timetableItineraries);
 				return new RouteV2Plan(timetableItineraries, statusesOf(timetableItineraries, command.useRealtime()), PLANNER_ADR);
 			}
 			SearchRouteCommand searchRouteCommand = toSearchRouteCommand(command);
@@ -112,6 +115,30 @@ public class RouteV2Planner implements RouteV2SearchUseCase {
 			}
 			return cachedRouteTimetable;
 		}
+	}
+
+	private List<RouteSearchResult> rankTimetableItineraries(List<RouteSearchResult> itineraries) {
+		return itineraries.stream()
+			.sorted(Comparator.comparingInt(RouteSearchResult::estimatedDurationSeconds)
+				.thenComparingInt(RouteSearchResult::transferCount)
+				.thenComparingInt(this::accessibilityRiskScore))
+			.toList();
+	}
+
+	private int accessibilityRiskScore(RouteSearchResult itinerary) {
+		int score = itinerary.warnings().size() * 1_000 + itinerary.blockedReasons().size() * 1_000;
+		for (RouteStep step : itinerary.steps()) {
+			if (step.includesStairs()) {
+				score += 100;
+			}
+			if ("UNKNOWN".equals(step.stairAccessState())) {
+				score += 10;
+			}
+			if (step.requiresAccessibilityCheck()) {
+				score += 1;
+			}
+		}
+		return score;
 	}
 
 	private List<RouteV2Status> statusesOf(List<RouteSearchResult> itineraries, boolean useRealtime) {

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
@@ -76,9 +76,10 @@ public class RouteV2Planner implements RouteV2SearchUseCase {
 				if (timetableItineraries.isEmpty()) {
 					return new RouteV2Plan(List.of(), List.of(RouteV2Status.NO_TIMETABLE_SERVICE), PLANNER_ADR);
 				}
-				timetableItineraries = routeSearchUseCase.stabilizeTimetableRouteResults(
+				timetableItineraries = routeSearchUseCase.stabilizeTimetableRouteCandidates(
 					searchRouteCommand,
 					RANKING_CANDIDATE_LIMIT,
+					command.alternativeCount(),
 					timetableItineraries
 				);
 				timetableItineraries = rankTimetableItineraries(timetableItineraries, command.alternativeCount());

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
@@ -135,8 +135,8 @@ public class RouteV2Planner implements RouteV2SearchUseCase {
 	private List<RouteSearchResult> rankTimetableItineraries(List<RouteSearchResult> itineraries, int alternativeCount) {
 		return itineraries.stream()
 			.sorted(Comparator.comparingInt(RouteSearchResult::estimatedDurationSeconds)
-				.thenComparingInt(RouteSearchResult::transferCount)
-				.thenComparingInt(this::accessibilityRiskScore))
+				.thenComparingInt(this::accessibilityRiskScore)
+				.thenComparingInt(RouteSearchResult::transferCount))
 			.limit(alternativeCount)
 			.toList();
 	}

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
@@ -80,9 +80,9 @@ public class RouteV2Planner implements RouteV2SearchUseCase {
 					searchRouteCommand,
 					RANKING_CANDIDATE_LIMIT,
 					command.alternativeCount(),
-					timetableItineraries
+					timetableItineraries,
+					candidates -> rankTimetableItineraries(candidates, command.alternativeCount())
 				);
-				timetableItineraries = rankTimetableItineraries(timetableItineraries, command.alternativeCount());
 				return new RouteV2Plan(timetableItineraries, statusesOf(timetableItineraries, command.useRealtime()), PLANNER_ADR);
 			}
 			SearchRouteCommand searchRouteCommand = toSearchRouteCommand(command);

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
@@ -26,6 +26,7 @@ import org.springframework.stereotype.Service;
 public class RouteV2Planner implements RouteV2SearchUseCase {
 
 	private static final String PLANNER_ADR = "tools/routes/route-algorithm-v2-adr.json";
+	private static final int RANKING_CANDIDATE_LIMIT = 3;
 
 	private final RouteSearchUseCase routeSearchUseCase;
 	private final LoadRouteTimetablePort routeTimetablePort;
@@ -69,7 +70,7 @@ public class RouteV2Planner implements RouteV2SearchUseCase {
 				SearchRouteCommand searchRouteCommand = toSearchRouteCommand(command);
 				routeSearchUseCase.validateRouteSearch(searchRouteCommand);
 				List<RouteSearchResult> timetableItineraries = timetableRaptorPlanner.search(
-					command,
+					rankingCommand(command),
 					routeTimetable()
 				);
 				if (timetableItineraries.isEmpty()) {
@@ -77,10 +78,10 @@ public class RouteV2Planner implements RouteV2SearchUseCase {
 				}
 				timetableItineraries = routeSearchUseCase.stabilizeTimetableRouteResults(
 					searchRouteCommand,
-					command.alternativeCount(),
+					RANKING_CANDIDATE_LIMIT,
 					timetableItineraries
 				);
-				timetableItineraries = rankTimetableItineraries(timetableItineraries);
+				timetableItineraries = rankTimetableItineraries(timetableItineraries, command.alternativeCount());
 				return new RouteV2Plan(timetableItineraries, statusesOf(timetableItineraries, command.useRealtime()), PLANNER_ADR);
 			}
 			SearchRouteCommand searchRouteCommand = toSearchRouteCommand(command);
@@ -117,11 +118,25 @@ public class RouteV2Planner implements RouteV2SearchUseCase {
 		}
 	}
 
-	private List<RouteSearchResult> rankTimetableItineraries(List<RouteSearchResult> itineraries) {
+	private SearchRouteV2Command rankingCommand(SearchRouteV2Command command) {
+		return new SearchRouteV2Command(
+			command.originStationId(),
+			command.destinationStationId(),
+			command.departureTime(),
+			command.mobilityType(),
+			command.constraintMode(),
+			command.useRealtime(),
+			command.maxTransfers(),
+			RANKING_CANDIDATE_LIMIT
+		);
+	}
+
+	private List<RouteSearchResult> rankTimetableItineraries(List<RouteSearchResult> itineraries, int alternativeCount) {
 		return itineraries.stream()
 			.sorted(Comparator.comparingInt(RouteSearchResult::estimatedDurationSeconds)
 				.thenComparingInt(RouteSearchResult::transferCount)
 				.thenComparingInt(this::accessibilityRiskScore))
+			.limit(alternativeCount)
 			.toList();
 	}
 

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -2189,6 +2189,7 @@ class RouteSearchServiceTest {
 		boolean requiresAccessibilityCheck,
 		int estimatedMinutes
 	) {
+		boolean includesStairs = "STAIR_ONLY".equals(stairAccessState);
 		return new RouteStep(
 			sequence,
 			stepType,
@@ -2200,7 +2201,7 @@ class RouteSearchServiceTest {
 			"station-b",
 			estimatedMinutes,
 			100,
-			false,
+			includesStairs,
 			stairAccessState,
 			requiresAccessibilityCheck,
 			EtaSource.PLANNED.name(),

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -955,6 +955,31 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("시간표 후보 stabilization은 탈락 후보의 접근성 signal로 응답 source를 바꾸지 않는다")
+	void stabilizeTimetableRouteCandidatesIgnoresDroppedAccessibilitySignals() {
+		var repository = new InMemoryRouteSearchRepository();
+		var routeSearchService = new RouteSearchService(
+			repository,
+			repository,
+			new MixedTransferAccessibilityTransitMasterPort(),
+			CLOCK
+		);
+
+		var results = routeSearchService.stabilizeTimetableRouteCandidates(
+			new SearchRouteCommand("station-a", "station-b", MobilityType.WHEELCHAIR, ConstraintMode.STRICT_STEP_FREE, 1),
+			2,
+			1,
+			List.of(routeSearchResultWithAccessState("route-timetable", "AVAILABLE", false)),
+			candidates -> candidates.stream()
+				.limit(1)
+				.toList()
+		);
+
+		assertThat(results).hasSize(1);
+		assertThat(results.getFirst().etaSource()).isEqualTo(EtaSource.PLANNED);
+	}
+
+	@Test
 	@DisplayName("V2 planner는 legacy graph가 놓친 시간표 경로를 NO_TIMETABLE_SERVICE로 버리지 않는다")
 	void routeV2PlannerKeepsTimetableRouteWhenLegacyGraphMisses() {
 		var repository = new InMemoryRouteSearchRepository();

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -33,6 +33,7 @@ import com.easysubway.route.domain.RouteRefreshStatus;
 import com.easysubway.route.domain.RouteSearchResult;
 import com.easysubway.route.domain.RouteSearchNotFoundException;
 import com.easysubway.route.domain.RouteSearchStatus;
+import com.easysubway.route.domain.RouteStep;
 import com.easysubway.route.domain.RouteWarningCode;
 import com.easysubway.transit.adapter.out.persistence.InMemoryTransitMasterRepository;
 import com.easysubway.transit.application.port.out.LoadTransitMasterPort;
@@ -848,6 +849,20 @@ class RouteSearchServiceTest {
 		assertThat(plan.statuses())
 			.containsExactly(RouteV2Status.FOUND, RouteV2Status.REALTIME_UNAVAILABLE_PLANNED_USED);
 		assertThat(plan.itineraries().getFirst().etaSource()).isEqualTo(EtaSource.PLANNED);
+	}
+
+	@Test
+	@DisplayName("V2 planner는 동일 ETA 후보에서 접근성 미확인 위험이 낮은 경로를 우선한다")
+	void routeV2PlannerRanksLowerAccessibilityRiskForSameEtaCandidates() {
+		var risky = routeSearchResultWithAccessState("route-risky", "UNKNOWN", true);
+		var verified = routeSearchResultWithAccessState("route-verified", "AVAILABLE", false);
+		var planner = new RouteV2Planner(stabilizingRouteSearchUseCase(List.of(risky, verified)), routeTimetablePort());
+
+		var plan = planner.search(routeV2Command(ConstraintMode.PREFER_STEP_FREE, MobilityType.SENIOR, 1, 3));
+
+		assertThat(plan.itineraries())
+			.extracting(RouteSearchResult::routeSearchId)
+			.containsExactly("route-verified", "route-risky");
 	}
 
 	@Test
@@ -2054,6 +2069,102 @@ class RouteSearchServiceTest {
 				throw new AssertionError("RouteV2Planner must not submit feedback during search");
 			}
 		};
+	}
+
+	private static RouteSearchUseCase stabilizingRouteSearchUseCase(List<RouteSearchResult> stabilizedResults) {
+		return new RouteSearchUseCase() {
+			@Override
+			public RouteSearchResult searchRoute(SearchRouteCommand command) {
+				throw new AssertionError("RouteV2Planner must use timetable scan for this test");
+			}
+
+			@Override
+			public List<RouteSearchResult> searchRouteAlternatives(SearchRouteCommand command, int alternativeCount) {
+				throw new AssertionError("RouteV2Planner must use timetable scan for this test");
+			}
+
+			@Override
+			public List<RouteSearchResult> stabilizeTimetableRouteResults(
+				SearchRouteCommand command,
+				int alternativeCount,
+				List<RouteSearchResult> timetableResults
+			) {
+				return stabilizedResults;
+			}
+
+			@Override
+			public InternalRouteResult searchInternalRoute(SearchInternalRouteCommand command) {
+				throw new AssertionError("RouteV2Planner must not call internal route search");
+			}
+
+			@Override
+			public RouteSearchResult getRouteSearch(String routeSearchId) {
+				throw new AssertionError("RouteV2Planner must not load legacy route search results");
+			}
+
+			@Override
+			public RouteRefreshResult refreshRoute(String routeSearchId) {
+				throw new AssertionError("RouteV2Planner must not refresh legacy route search results");
+			}
+
+			@Override
+			public RouteFeedback submitRouteFeedback(SubmitRouteFeedbackCommand command) {
+				throw new AssertionError("RouteV2Planner must not submit feedback during search");
+			}
+		};
+	}
+
+	private static RouteSearchResult routeSearchResultWithAccessState(
+		String routeSearchId,
+		String stairAccessState,
+		boolean requiresAccessibilityCheck
+	) {
+		return new RouteSearchResult(
+			routeSearchId,
+			"station-a",
+			"출발역",
+			"station-b",
+			"도착역",
+			MobilityType.SENIOR,
+			RouteSearchStatus.FOUND,
+			"seoul-4",
+			"4호선",
+			0,
+			List.of(
+				timetableStep(1, "entry", stairAccessState, requiresAccessibilityCheck),
+				timetableStep(2, "ride", "AVAILABLE", false),
+				timetableStep(3, "exit", stairAccessState, requiresAccessibilityCheck)
+			),
+			List.of(),
+			List.of(),
+			LocalDate.of(2026, 7, 1).atStartOfDay()
+		);
+	}
+
+	private static RouteStep timetableStep(
+		int sequence,
+		String stepType,
+		String stairAccessState,
+		boolean requiresAccessibilityCheck
+	) {
+		return new RouteStep(
+			sequence,
+			stepType,
+			stepType,
+			"시간표 경로",
+			"seoul-4",
+			"4호선",
+			"station-a",
+			"station-b",
+			5,
+			100,
+			false,
+			stairAccessState,
+			requiresAccessibilityCheck,
+			EtaSource.PLANNED.name(),
+			"TIMETABLE",
+			"시간표"
+		);
 	}
 
 	private static LoadRouteTimetablePort routeTimetablePort() {

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -855,7 +855,7 @@ class RouteSearchServiceTest {
 	@DisplayName("V2 planner는 동일 ETA 후보에서 접근성 미확인 위험이 낮은 경로를 우선한다")
 	void routeV2PlannerRanksLowerAccessibilityRiskForSameEtaCandidates() {
 		var risky = routeSearchResultWithAccessState("route-risky", "UNKNOWN", true);
-		var verified = routeSearchResultWithAccessState("route-verified", "AVAILABLE", false);
+		var verified = transferRouteSearchResultWithAccessState("route-verified", "AVAILABLE", false);
 		var planner = new RouteV2Planner(stabilizingRouteSearchUseCase(List.of(risky, verified)), routeTimetablePort());
 
 		var plan = planner.search(routeV2Command(ConstraintMode.PREFER_STEP_FREE, MobilityType.SENIOR, 1, 1));
@@ -2144,11 +2144,50 @@ class RouteSearchServiceTest {
 		);
 	}
 
+	private static RouteSearchResult transferRouteSearchResultWithAccessState(
+		String routeSearchId,
+		String stairAccessState,
+		boolean requiresAccessibilityCheck
+	) {
+		return new RouteSearchResult(
+			routeSearchId,
+			"station-a",
+			"출발역",
+			"station-b",
+			"도착역",
+			MobilityType.SENIOR,
+			RouteSearchStatus.FOUND,
+			"seoul-4",
+			"4호선",
+			0,
+			List.of(
+				timetableStep(1, "entry", stairAccessState, requiresAccessibilityCheck, 3),
+				timetableStep(2, "ride", "AVAILABLE", false, 3),
+				timetableStep(3, "transfer", stairAccessState, requiresAccessibilityCheck, 3),
+				timetableStep(4, "ride", "AVAILABLE", false, 3),
+				timetableStep(5, "exit", stairAccessState, requiresAccessibilityCheck, 3)
+			),
+			List.of(),
+			List.of(),
+			LocalDate.of(2026, 7, 1).atStartOfDay()
+		);
+	}
+
 	private static RouteStep timetableStep(
 		int sequence,
 		String stepType,
 		String stairAccessState,
 		boolean requiresAccessibilityCheck
+	) {
+		return timetableStep(sequence, stepType, stairAccessState, requiresAccessibilityCheck, 5);
+	}
+
+	private static RouteStep timetableStep(
+		int sequence,
+		String stepType,
+		String stairAccessState,
+		boolean requiresAccessibilityCheck,
+		int estimatedMinutes
 	) {
 		return new RouteStep(
 			sequence,
@@ -2159,7 +2198,7 @@ class RouteSearchServiceTest {
 			"4호선",
 			"station-a",
 			"station-b",
-			5,
+			estimatedMinutes,
 			100,
 			false,
 			stairAccessState,

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -858,11 +858,11 @@ class RouteSearchServiceTest {
 		var verified = routeSearchResultWithAccessState("route-verified", "AVAILABLE", false);
 		var planner = new RouteV2Planner(stabilizingRouteSearchUseCase(List.of(risky, verified)), routeTimetablePort());
 
-		var plan = planner.search(routeV2Command(ConstraintMode.PREFER_STEP_FREE, MobilityType.SENIOR, 1, 3));
+		var plan = planner.search(routeV2Command(ConstraintMode.PREFER_STEP_FREE, MobilityType.SENIOR, 1, 1));
 
 		assertThat(plan.itineraries())
 			.extracting(RouteSearchResult::routeSearchId)
-			.containsExactly("route-verified", "route-risky");
+			.containsExactly("route-verified");
 	}
 
 	@Test
@@ -2089,7 +2089,9 @@ class RouteSearchServiceTest {
 				int alternativeCount,
 				List<RouteSearchResult> timetableResults
 			) {
-				return stabilizedResults;
+				return stabilizedResults.stream()
+					.limit(alternativeCount)
+					.toList();
 			}
 
 			@Override

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -2084,13 +2084,14 @@ class RouteSearchServiceTest {
 			}
 
 			@Override
-			public List<RouteSearchResult> stabilizeTimetableRouteResults(
+			public List<RouteSearchResult> stabilizeTimetableRouteCandidates(
 				SearchRouteCommand command,
+				int candidateCount,
 				int alternativeCount,
 				List<RouteSearchResult> timetableResults
 			) {
 				return stabilizedResults.stream()
-					.limit(alternativeCount)
+					.limit(candidateCount)
 					.toList();
 			}
 

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -931,6 +931,30 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("시간표 후보 stabilization은 응답에서 제외된 후보를 저장하지 않는다")
+	void stabilizeTimetableRouteCandidatesDoesNotPersistDroppedCandidates() {
+		var repository = new InMemoryRouteSearchRepository();
+		var routeSearchService = new RouteSearchService(repository, repository, new DisconnectedTransitMasterPort(), CLOCK);
+
+		var results = routeSearchService.stabilizeTimetableRouteCandidates(
+			new SearchRouteCommand("station-a", "station-b", MobilityType.SENIOR, ConstraintMode.PREFER_STEP_FREE, 1),
+			3,
+			1,
+			List.of(
+				routeSearchResultWithAccessState("route-dropped", "UNKNOWN", true),
+				routeSearchResultWithAccessState("route-selected", "AVAILABLE", false)
+			),
+			candidates -> candidates.stream()
+				.filter(candidate -> "route-selected".equals(candidate.routeSearchId()))
+				.toList()
+		);
+
+		assertThat(results).hasSize(1);
+		assertThat(repository.summarizeRouteSearches().totalCount()).isEqualTo(1);
+		assertThat(repository.loadRouteSearch(results.getFirst().routeSearchId())).isPresent();
+	}
+
+	@Test
 	@DisplayName("V2 planner는 legacy graph가 놓친 시간표 경로를 NO_TIMETABLE_SERVICE로 버리지 않는다")
 	void routeV2PlannerKeepsTimetableRouteWhenLegacyGraphMisses() {
 		var repository = new InMemoryRouteSearchRepository();
@@ -2088,11 +2112,12 @@ class RouteSearchServiceTest {
 				SearchRouteCommand command,
 				int candidateCount,
 				int alternativeCount,
-				List<RouteSearchResult> timetableResults
+				List<RouteSearchResult> timetableResults,
+				java.util.function.UnaryOperator<List<RouteSearchResult>> selectCandidates
 			) {
-				return stabilizedResults.stream()
+				return selectCandidates.apply(stabilizedResults.stream()
 					.limit(candidateCount)
-					.toList();
+					.toList());
 			}
 
 			@Override


### PR DESCRIPTION
## 관련 이슈

Refs #1620

## 작업 배경

- #1620 완료 조건의 RAPTOR ranking 순서 중 동일 ETA/환승 후보에서 verified step-free와 lower unknown risk 우선순위를 backend planner에 고정합니다.

## 작업 내용

- timetable RAPTOR path에서 stabilized itinerary를 `estimatedDurationSeconds -> transferCount -> accessibilityRisk` 순서로 정렬합니다.
- 동일 ETA 후보가 접근성 미확인 위험 순서로 들어와도 낮은 risk 후보가 먼저 반환되는 regression test를 추가했습니다.
- frontend 변경 없음.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.route.application.service.RouteSearchServiceTest.routeV2PlannerRanksLowerAccessibilityRiskForSameEtaCandidates` 성공
  - `./gradlew test --tests com.easysubway.route.application.service.RouteSearchServiceTest` 성공
  - `node --test --test-name-pattern "V2 경로 검색" tools/ci/repository-contract.test.mjs` 성공
  - `./gradlew check --no-daemon` 성공
  - `node --test tools/routes/*.test.mjs` 성공
  - `git diff --check` 성공

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| RAPTOR ranking regression | backend | Gradle/Node local tests | 터미널 출력 | 통과 |
| UI/접근성 수동 QA | mobile/web | backend-only planner 정렬 변경 | 해당 없음 | 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [ ] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [ ] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `RouteV2Planner.rankTimetableItineraries()`, `RouteSearchServiceTest.routeV2PlannerRanksLowerAccessibilityRiskForSameEtaCandidates()`

## 리스크

- 동일 ETA/환승 후보의 표시 순서만 바꾸며, legacy fallback path와 frontend에는 영향이 없습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 시간표 기반 경로 후보를 더 정교하게 정렬해, 예상 소요시간·환승 횟수·접근성 위험을 함께 반영한 결과를 제공합니다.
  * 더 많은 후보를 검토한 뒤, 최종 추천 개수만큼만 보여주도록 개선했습니다.

* **Bug Fixes**
  * 접근성 관련 신호가 일부 후보에만 있더라도 결과 선택이 더 안정적으로 동작하도록 조정했습니다.
  * 동일한 도착 시간대 후보 중에서도 접근성 확인이 덜 필요한 경로가 우선될 수 있도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->