### PR TITLE
[Chore] 노선도 실제 track 렌더 파이프라인 도구·계약 (#1638 PR-1/3)

### DIFF
--- a/tools/route-map/apply-route-map-line-tracks.mjs
+++ b/tools/route-map/apply-route-map-line-tracks.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { gunzipSync, gzipSync } from "node:zlib";
+import { DatabaseSync } from "node:sqlite";
+
+// build-route-map-line-tracks가 만든 tracks.json(들)을 capital 팩의
+// route_map_line_tracks 테이블에 기록한다. 라이선스 메타데이터는 같은
+// (region, line_id)의 route_map_positions에서 승계한다(광주 CC BY-SA 등 유지).
+// --check는 파일을 쓰지 않고 커버리지·빈 path만 검증한다.
+
+function usage() {
+  return `Usage: node tools/route-map/apply-route-map-line-tracks.mjs --pack apps/mobile/assets/datapacks/capital.sqlite.gz --index apps/mobile/assets/datapacks/index.json --tracks <tracks.json> [--tracks <...>] [--check]`;
+}
+
+function parseArgs(argv) {
+  const options = { pack: null, index: null, tracks: [], check: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case "--pack": options.pack = argv[++index]; break;
+      case "--index": options.index = argv[++index]; break;
+      case "--tracks": options.tracks.push(argv[++index]); break;
+      case "--check": options.check = true; break;
+      case "--help":
+      case "-h":
+        console.log(usage());
+        process.exit(0);
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  if (!options.pack || !options.index) throw new Error("--pack and --index are required");
+  if (options.tracks.length === 0) throw new Error("at least one --tracks is required");
+  return options;
+}
+
+function createLineTracksTable(database) {
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS route_map_line_tracks (
+      region TEXT NOT NULL,
+      line_id TEXT NOT NULL,
+      track_index INTEGER NOT NULL,
+      path TEXT NOT NULL,
+      svg_color TEXT NOT NULL DEFAULT '',
+      source_id TEXT NOT NULL,
+      source_name TEXT NOT NULL,
+      source_url TEXT NOT NULL,
+      license TEXT NOT NULL,
+      license_status TEXT NOT NULL,
+      commercial_use_allowed INTEGER NOT NULL DEFAULT 0 CHECK (commercial_use_allowed IN (0, 1)),
+      attribution_required INTEGER NOT NULL DEFAULT 1 CHECK (attribution_required IN (0, 1)),
+      updated_at INTEGER,
+      PRIMARY KEY (region, line_id, track_index)
+    )`);
+}
+
+// 한 region의 tracks 문서를 기록한다. 같은 region 기존 행은 DELETE 후 INSERT(재실행 안전).
+function applyLineTracks(database, tracksDoc) {
+  const licenseByLine = new Map(
+    database
+      .prepare(
+        `SELECT line_id, source_id, source_name, source_url, license, license_status,
+                commercial_use_allowed, attribution_required
+         FROM route_map_positions WHERE region = ? GROUP BY line_id`,
+      )
+      .all(tracksDoc.region)
+      .map((row) => [row.line_id, row]),
+  );
+  const insert = database.prepare(`
+    INSERT INTO route_map_line_tracks (
+      region, line_id, track_index, path, svg_color, source_id, source_name,
+      source_url, license, license_status, commercial_use_allowed,
+      attribution_required, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`);
+  const updatedAt = Math.floor(Date.now() / 1000);
+  database.exec("BEGIN");
+  try {
+    database.prepare("DELETE FROM route_map_line_tracks WHERE region = ?").run(tracksDoc.region);
+    for (const line of tracksDoc.lines) {
+      const meta = licenseByLine.get(line.lineId);
+      if (!meta) {
+        throw new Error(`route_map_positions에 없는 노선을 tracks가 참조: ${line.lineId} (${tracksDoc.region})`);
+      }
+      line.paths.forEach((pathString, trackIndex) => {
+        insert.run(
+          tracksDoc.region, line.lineId, trackIndex, pathString, line.svgColor ?? "",
+          meta.source_id, meta.source_name, meta.source_url, meta.license,
+          meta.license_status, meta.commercial_use_allowed, meta.attribution_required, updatedAt,
+        );
+      });
+    }
+    database.exec("COMMIT");
+  } catch (error) {
+    database.exec("ROLLBACK");
+    throw error;
+  }
+}
+
+// region의 route_map_positions 노선 전부가 track을 갖고, 빈 path가 없는지 검증.
+function verifyLineTracks(database, tracksDoc) {
+  const lineIds = new Set(
+    database
+      .prepare("SELECT DISTINCT line_id FROM route_map_positions WHERE region = ?")
+      .all(tracksDoc.region)
+      .map((row) => row.line_id),
+  );
+  const covered = new Set();
+  const emptyPaths = [];
+  for (const line of tracksDoc.lines) {
+    covered.add(line.lineId);
+    if (!line.paths || line.paths.length === 0) emptyPaths.push(line.lineId);
+    if (!lineIds.has(line.lineId)) {
+      throw new Error(`route_map_positions에 없는 노선을 tracks가 참조: ${line.lineId} (${tracksDoc.region})`);
+    }
+  }
+  const missing = [...lineIds].filter((id) => !covered.has(id));
+  if (missing.length > 0) throw new Error(`track이 없는 노선: ${missing.join(", ")} (${tracksDoc.region})`);
+  if (emptyPaths.length > 0) throw new Error(`빈 track path: ${emptyPaths.join(", ")} (${tracksDoc.region})`);
+  return { region: tracksDoc.region, lines: tracksDoc.lines.length };
+}
+
+async function updateIndex(indexPath, compressedBytes, sqliteBytes) {
+  const index = JSON.parse(await readFile(indexPath, "utf8"));
+  const capital = index.packs.find((pack) => pack.id === "capital");
+  if (!capital) throw new Error("capital pack not found in datapack index");
+  capital.sha256 = sha256(compressedBytes);
+  capital.sqliteSha256 = sha256(sqliteBytes);
+  capital.byteSize = compressedBytes.length;
+  await writeFile(indexPath, `${JSON.stringify(index, null, 2)}\n`);
+}
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const root = path.resolve(import.meta.dirname, "../..");
+  const packPath = path.resolve(root, options.pack);
+  const indexPath = path.resolve(root, options.index);
+  const tracksDocs = await Promise.all(
+    options.tracks.map(async (file) => JSON.parse(await readFile(path.resolve(root, file), "utf8"))),
+  );
+
+  const tmp = await mkdtemp(path.join(tmpdir(), "easysubway-line-tracks-"));
+  const sqlitePath = path.join(tmp, "capital.sqlite");
+  try {
+    await writeFile(sqlitePath, gunzipSync(await readFile(packPath)));
+    const database = new DatabaseSync(sqlitePath);
+    const summary = [];
+    try {
+      if (!options.check) {
+        createLineTracksTable(database);
+        for (const tracksDoc of tracksDocs) applyLineTracks(database, tracksDoc);
+      }
+      for (const tracksDoc of tracksDocs) summary.push(verifyLineTracks(database, tracksDoc));
+    } finally {
+      database.close();
+    }
+    console.log(JSON.stringify({ applied: !options.check, regions: summary }, null, 2));
+    if (!options.check) {
+      const sqliteBytes = await readFile(sqlitePath);
+      const compressedBytes = gzipSync(sqliteBytes, { level: 9, mtime: 0 });
+      await writeFile(packPath, compressedBytes);
+      await updateIndex(indexPath, compressedBytes, sqliteBytes);
+    }
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+}
+
+// CLI로 직접 실행할 때만 main을 돌린다(import 시 실행 안 함).
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exit(1);
+  });
+}

--- a/tools/route-map/audit-route-map.mjs
+++ b/tools/route-map/audit-route-map.mjs
@@ -12,7 +12,7 @@ const severityRank = new Map([
 ]);
 
 function usage() {
-  return `Usage: node tools/route-map/audit-route-map.mjs --fixture <catalog-fixture.json> [--reviewed-ambiguities reviewed.json] [--require-label-polygons] [--fail-on BLOCKER,HIGH] [--pretty]
+  return `Usage: node tools/route-map/audit-route-map.mjs --fixture <catalog-fixture.json> [--line-tracks tracks.json]... [--reviewed-ambiguities reviewed.json] [--require-label-polygons] [--fail-on BLOCKER,HIGH] [--pretty]
 
 Audits routeMapPositions against stationLines so production route-map coordinate
 coverage can be checked before rebuilding datapacks.`;
@@ -23,6 +23,7 @@ function parseArgs(argv) {
     fixture: null,
     reviewedAmbiguities: null,
     requireLabelPolygons: false,
+    lineTracks: [],
     failOn: [],
     pretty: false,
   };
@@ -31,6 +32,9 @@ function parseArgs(argv) {
     switch (arg) {
       case "--fixture":
         options.fixture = argv[++index];
+        break;
+      case "--line-tracks":
+        options.lineTracks.push(argv[++index]);
         break;
       case "--reviewed-ambiguities":
         options.reviewedAmbiguities = argv[++index];
@@ -935,12 +939,89 @@ function packRequiresRouteMapPositions(pack, positions) {
   });
 }
 
+// build/apply-route-map-line-tracks의 tracks.json(들)을 fixture 노선 집합과 대조해
+// 커버리지·무결성 findings를 만든다. #1638 track 직접 렌더 게이트.
+function auditLineTracks(packs, lineTracksDocs) {
+  const lineIdsByRegion = new Map();
+  for (const pack of packs) {
+    for (const position of pack.routeMapPositions ?? []) {
+      const region = position.region;
+      if (!region) continue;
+      if (!lineIdsByRegion.has(region)) lineIdsByRegion.set(region, new Set());
+      lineIdsByRegion.get(region).add(position.lineId);
+    }
+  }
+  const findings = [];
+  const coveredRegions = new Set(lineTracksDocs.map((doc) => doc.region));
+  for (const region of lineIdsByRegion.keys()) {
+    if (!coveredRegions.has(region)) {
+      addFinding(findings, {
+        severity: "BLOCKER",
+        code: "LINE_TRACKS_MISSING_REGION",
+        region,
+        message: `route-map region '${region}'에 line-track 문서가 없다.`,
+      });
+    }
+  }
+  for (const doc of lineTracksDocs) {
+    const region = doc.region ?? "";
+    const expected = lineIdsByRegion.get(region) ?? new Set();
+    // 색↔노선 1:1 전제는 SVG stroke 원천에만 적용(Route B는 색이 없다).
+    if (doc.source === "svg-strokes" && Number.isInteger(doc.colorCount) && Number.isInteger(doc.lineCount) && doc.colorCount !== doc.lineCount) {
+      addFinding(findings, {
+        severity: "BLOCKER",
+        code: "LINE_TRACKS_COLOR_LINE_MISMATCH",
+        region,
+        message: `track 색 수(${doc.colorCount}) ≠ 노선 수(${doc.lineCount}) — 색이 노선 식별자라는 전제 위반.`,
+      });
+    }
+    const covered = new Set();
+    for (const line of doc.lines ?? []) {
+      covered.add(line.lineId);
+      if (!line.paths || line.paths.length === 0) {
+        addFinding(findings, {
+          severity: "BLOCKER",
+          code: "LINE_TRACKS_EMPTY_PATH",
+          region,
+          lineId: line.lineId,
+          message: "line-track path가 비어 있다.",
+        });
+      }
+      if (line.matchVotes === 0) {
+        addFinding(findings, {
+          severity: "HIGH",
+          code: "LINE_TRACKS_ZERO_VOTE",
+          region,
+          lineId: line.lineId,
+          message: `근접 역 0표 소거법 배정(색 ${line.svgColor || "-"}). SVG와 육안 대조 수동 검수 대상.`,
+        });
+      }
+    }
+    for (const lineId of expected) {
+      if (!covered.has(lineId)) {
+        addFinding(findings, {
+          severity: "BLOCKER",
+          code: "LINE_TRACKS_MISSING_LINE",
+          region,
+          lineId,
+          message: "노선에 대응 line-track이 없다.",
+        });
+      }
+    }
+  }
+  return findings;
+}
+
 function auditFixture(fixturePath, fixture, reviewedAmbiguities, options = {}) {
   const packs = Array.isArray(fixture.packs) ? fixture.packs : [];
   const auditedPacks = packs.map((pack) =>
     auditPack(pack, reviewedAmbiguities, options),
   );
   const findings = auditedPacks.flatMap((pack) => pack.findings);
+  const lineTracksDocs = options.lineTracks ?? [];
+  if (lineTracksDocs.length > 0) {
+    findings.push(...auditLineTracks(packs, lineTracksDocs));
+  }
   const findingCounts = {};
   for (const severity of severityRank.keys()) {
     findingCounts[severity] = 0;
@@ -970,8 +1051,12 @@ async function main() {
         JSON.parse(await readFile(options.reviewedAmbiguities, "utf8")),
       )
     : new Map();
+  const lineTracksDocs = await Promise.all(
+    options.lineTracks.map(async (file) => JSON.parse(await readFile(file, "utf8"))),
+  );
   const report = auditFixture(options.fixture, fixture, reviewedAmbiguities, {
     requireLabelPolygons: options.requireLabelPolygons,
+    lineTracks: lineTracksDocs,
   });
   console.log(JSON.stringify(report, null, options.pretty ? 2 : 0));
 

--- a/tools/route-map/build-route-map-line-tracks.mjs
+++ b/tools/route-map/build-route-map-line-tracks.mjs
@@ -23,9 +23,17 @@ import { tmpdir } from "node:os";
 // 역 라벨을 track에 근접 배정할 때의 반경(root px). 라벨은 track에서 20~35px
 // 떨어져 있어(폰트 높이 근처) 이보다 크면 이웃 노선까지 삼킨다.
 const SNAP_RADIUS = 35;
+// 같은 색 track 조각의 끝점이 이 거리(root px) 이내면 한 조각으로 이어 붙인다.
+const STITCH_TOLERANCE = 1.5;
+// 색 정제: RGB 거리가 이 값 이내인 두 색은 같은 노선의 변종으로 보고 병합한다.
+// (대구 3호선 노랑 #fdc30d/#ffc512 = 거리 ≈ 6.)
+const MERGE_COLOR_DISTANCE = 24;
+// 색 정제: HSV 채도가 이 값 미만이면 무채색(외곽선·테두리·배경)으로 보고 제외 후보.
+// 노선색은 최소 0.43(부산 #7189c5)이라 여유가 있다.
+const ACHROMATIC_THRESHOLD = 0.2;
 
 function usage() {
-  return `Usage: node tools/route-map/build-route-map-line-tracks.mjs --geometry <geom.json> --pack <capital.sqlite[.gz]> --region <name> [--out <tracks.json>] [--check] [--snap-radius <px>]
+  return `Usage: node tools/route-map/build-route-map-line-tracks.mjs --geometry <geom.json> --pack <capital.sqlite[.gz]> --region <name> [--out <tracks.json>] [--check] [--snap-radius <px>] [--stitch-tolerance <px>] [--merge-color-distance <rgb>] [--achromatic-threshold <0-1>]
 
 extract-svg-geometry v2 결과의 노선 track(polyline/path)을 색↔line_id 최적매칭으로
 region 노선별 track geometry로 변환한다. --check는 파일을 쓰지 않고 무결성만 검증한다.
@@ -33,7 +41,13 @@ region 노선별 track geometry로 변환한다. --check는 파일을 쓰지 않
 }
 
 function parseArgs(argv) {
-  const options = { geometry: null, pack: null, region: null, out: null, check: false, snapRadius: SNAP_RADIUS };
+  const options = {
+    geometry: null, pack: null, region: null, out: null, check: false,
+    snapRadius: SNAP_RADIUS,
+    stitchTolerance: STITCH_TOLERANCE,
+    mergeColorDistance: MERGE_COLOR_DISTANCE,
+    achromaticThreshold: ACHROMATIC_THRESHOLD,
+  };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     switch (arg) {
@@ -46,6 +60,9 @@ function parseArgs(argv) {
       case "--out": options.out = argv[++index] ?? null; break;
       case "--check": options.check = true; break;
       case "--snap-radius": options.snapRadius = Number.parseFloat(argv[++index] ?? ""); break;
+      case "--stitch-tolerance": options.stitchTolerance = Number.parseFloat(argv[++index] ?? ""); break;
+      case "--merge-color-distance": options.mergeColorDistance = Number.parseFloat(argv[++index] ?? ""); break;
+      case "--achromatic-threshold": options.achromaticThreshold = Number.parseFloat(argv[++index] ?? ""); break;
       default:
         if (arg.startsWith("--")) throw new Error(`Unknown option: ${arg}`);
     }
@@ -54,6 +71,9 @@ function parseArgs(argv) {
   if (!options.pack) throw new Error("--pack is required.");
   if (!options.region) throw new Error("--region is required.");
   if (!Number.isFinite(options.snapRadius) || options.snapRadius <= 0) throw new Error("--snap-radius must be a positive number.");
+  if (!Number.isFinite(options.stitchTolerance) || options.stitchTolerance <= 0) throw new Error("--stitch-tolerance must be a positive number.");
+  if (!Number.isFinite(options.mergeColorDistance) || options.mergeColorDistance < 0) throw new Error("--merge-color-distance must be a non-negative number.");
+  if (!Number.isFinite(options.achromaticThreshold) || options.achromaticThreshold < 0) throw new Error("--achromatic-threshold must be a non-negative number.");
   return options;
 }
 
@@ -150,7 +170,98 @@ function pathString(points) {
     .join(" ");
 }
 
-async function buildLineTracks({ geometry, pack, region, snapRadius }) {
+// "#rrggbb" → [r, g, b].
+function rgb(hex) {
+  return [1, 3, 5].map((offset) => Number.parseInt(hex.slice(offset, offset + 2), 16));
+}
+
+// HSV 채도(0=무채색). 외곽선·테두리·배경 같은 비노선 색을 가려낸다.
+function saturation(hex) {
+  const [r, g, b] = rgb(hex);
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  return max === 0 ? 0 : (max - min) / max;
+}
+
+function colorDistance(a, b) {
+  const [ar, ag, ab] = rgb(a);
+  const [br, bg, bb] = rgb(b);
+  return Math.hypot(ar - br, ag - bg, ab - bb);
+}
+
+// 두 정점열을 끝점이 tolerance 이내면 (방향 4조합 시도) 이어 붙인다. 아니면 null.
+function joinChains(a, b, tolerance) {
+  const close = (p, q) => Math.hypot(p.x - q.x, p.y - q.y) <= tolerance;
+  if (close(a[a.length - 1], b[0])) return [...a, ...b.slice(1)];
+  if (close(b[b.length - 1], a[0])) return [...b, ...a.slice(1)];
+  if (close(a[a.length - 1], b[b.length - 1])) return [...a, ...[...b].reverse().slice(1)];
+  if (close(a[0], b[0])) return [...[...a].reverse(), ...b.slice(1)];
+  return null;
+}
+
+// 같은 색 조각들을 끝점 tolerance로 이어 붙인다. 조각 수가 작아 반복 병합 O(n²)로 충분.
+function stitchChains(pointLists, tolerance) {
+  const chains = pointLists.map((points) => [...points]);
+  let merged = true;
+  while (merged) {
+    merged = false;
+    outer: for (let i = 0; i < chains.length; i += 1) {
+      for (let j = i + 1; j < chains.length; j += 1) {
+        const joined = joinChains(chains[i], chains[j], tolerance);
+        if (joined) {
+          chains[i] = joined;
+          chains.splice(j, 1);
+          merged = true;
+          break outer;
+        }
+      }
+    }
+  }
+  return chains;
+}
+
+// 색 정제: 색 수 > 노선 수일 때만 발동. (1) 유사색 병합 (2) 무채색 최저표 제외
+// (3) 최저표 제외. 색 수 = 노선 수면 그대로 둔다(수도권 회색 노선 #797979 보존).
+// items: [{ color, tracks: stroke[], weightRow: number[] }], weightRow는 색×line 표.
+function refineColors(items, lineCount, { mergeDistance, achromaticThreshold }) {
+  const report = { originalColorCount: items.length, merged: [], dropped: [] };
+  const rowSum = (item) => item.weightRow.reduce((sum, value) => sum + value, 0);
+  let guard = items.length * 2;
+  while (items.length > lineCount && guard-- > 0) {
+    // 1. 가장 가까운 유사색 쌍 병합 (표 많은 쪽을 대표색으로).
+    let bestPair = null;
+    let bestDistance = Infinity;
+    for (let i = 0; i < items.length; i += 1) {
+      for (let j = i + 1; j < items.length; j += 1) {
+        const distance = colorDistance(items[i].color, items[j].color);
+        if (distance <= mergeDistance && distance < bestDistance) {
+          bestDistance = distance;
+          bestPair = [i, j];
+        }
+      }
+    }
+    if (bestPair) {
+      const [i, j] = bestPair;
+      const keep = rowSum(items[i]) >= rowSum(items[j]) ? i : j;
+      const drop = keep === i ? j : i;
+      report.merged.push([items[keep].color, items[drop].color]);
+      items[keep].tracks.push(...items[drop].tracks);
+      items[keep].weightRow = items[keep].weightRow.map((value, index) => value + items[drop].weightRow[index]);
+      items.splice(drop, 1);
+      continue;
+    }
+    // 2. 무채색 중 최저표 제외. 없으면 3. 전체 최저표 제외(경고는 호출부에서).
+    const achromatic = items.filter((item) => saturation(item.color) < achromaticThreshold);
+    const pool = achromatic.length > 0 ? achromatic : items;
+    let victim = pool[0];
+    for (const item of pool) if (rowSum(item) < rowSum(victim)) victim = item;
+    report.dropped.push({ color: victim.color, achromatic: saturation(victim.color) < achromaticThreshold, votes: rowSum(victim) });
+    items.splice(items.indexOf(victim), 1);
+  }
+  return report;
+}
+
+async function buildLineTracks({ geometry, pack, region, snapRadius, stitchTolerance, mergeColorDistance, achromaticThreshold }) {
   const geom = JSON.parse(await readFile(path.resolve(geometry), "utf8"));
   const strokes = (geom.strokes ?? []).filter((stroke) => stroke.tag !== "line" && !stroke.dashed);
   if (strokes.length === 0) throw new Error("geometry에 노선 track(polyline/path stroke)이 없다. extract-svg-geometry v2 결과인지 확인.");
@@ -176,10 +287,12 @@ async function buildLineTracks({ geometry, pack, region, snapRadius }) {
   }
   const colors = [...tracksByColor.keys()];
   const lineIds = [...new Set(stations.map((station) => station.lineId))];
-
-  // 색×line_id 근접 표수: 각 역을 "가장 가까운 색"에 투표(snapRadius 이내일 때만).
-  const weight = colors.map(() => new Array(lineIds.length).fill(0));
   const lineIndex = new Map(lineIds.map((id, index) => [id, index]));
+
+  // 색×line_id 근접 표수 + 좌표계 검증용 근접 역 수: 각 역을 "가장 가까운 색"에
+  // 투표(snapRadius 이내일 때만). votedStations는 어떤 색에든 배정된 역 = 근접률.
+  const weight = colors.map(() => new Array(lineIds.length).fill(0));
+  let votedStations = 0;
   for (const station of stations) {
     let bestColor = -1;
     let bestDistance = Infinity;
@@ -189,35 +302,56 @@ async function buildLineTracks({ geometry, pack, region, snapRadius }) {
     });
     if (bestColor >= 0 && bestDistance <= snapRadius) {
       weight[bestColor][lineIndex.get(station.lineId)] += 1;
+      votedStations += 1;
     }
   }
+  const stationProximityRatio = Math.round((votedStations / stations.length) * 1000) / 1000;
 
-  // 색↔line_id 전역 최적 1:1 매칭.
-  const lineForColor = maximumWeightMatching(weight, colors.length, lineIds.length);
+  // 색 정제: 색 수 > 노선 수면 유사색 병합·무채색 제외로 색=노선을 성립시킨다.
+  const items = colors.map((color, colorIndex) => ({
+    color,
+    tracks: tracksByColor.get(color),
+    weightRow: weight[colorIndex],
+  }));
+  const refinement = refineColors(items, lineIds.length, {
+    mergeDistance: mergeColorDistance,
+    achromaticThreshold,
+  });
+
+  // 정제된 색으로 전역 최적 1:1 매칭.
+  const refinedColors = items.map((item) => item.color);
+  const refinedWeight = items.map((item) => item.weightRow);
+  const lineForColor = maximumWeightMatching(refinedWeight, refinedColors.length, lineIds.length);
   const stationCountByLine = new Map();
   for (const station of stations) stationCountByLine.set(station.lineId, (stationCountByLine.get(station.lineId) ?? 0) + 1);
 
   const lines = [];
   const warnings = [];
   const colorToLineId = {};
-  colors.forEach((color, colorIndex) => {
+  for (const dropped of refinement.dropped) {
+    if (!dropped.achromatic) warnings.push(`색 ${dropped.color}: 색>노선 초과분으로 제외(표 ${dropped.votes}, 무채색 아님). 검수 필요.`);
+  }
+  items.forEach((item, colorIndex) => {
     const matchedLineIndex = lineForColor[colorIndex];
     const lineId = matchedLineIndex >= 0 ? lineIds[matchedLineIndex] : null;
-    const votes = matchedLineIndex >= 0 ? weight[colorIndex][matchedLineIndex] : 0;
-    const bestVotes = Math.max(0, ...weight[colorIndex]);
+    const votes = matchedLineIndex >= 0 ? item.weightRow[matchedLineIndex] : 0;
+    const bestVotes = Math.max(0, ...item.weightRow);
     if (!lineId) {
-      warnings.push(`색 ${color}: 매칭된 노선 없음(track ${tracksByColor.get(color).length}개).`);
+      warnings.push(`색 ${item.color}: 매칭된 노선 없음(track ${item.tracks.length}개).`);
       return;
     }
-    colorToLineId[color] = lineId;
-    if (votes === 0) warnings.push(`색 ${color} → ${lineId}: 근접 역 0표(소거법 배정). 위치 검수 필요.`);
-    else if (votes !== bestVotes) warnings.push(`색 ${color} → ${lineId}: 최적매칭 표(${votes})가 국소 최다표(${bestVotes})와 다름.`);
-    const paths = tracksByColor.get(color)
-      .filter((track) => track.points.length >= 2)
-      .map((track) => pathString(track.points));
+    colorToLineId[item.color] = lineId;
+    if (votes === 0) warnings.push(`색 ${item.color} → ${lineId}: 근접 역 0표(소거법 배정). 위치 검수 필요.`);
+    else if (votes !== bestVotes) warnings.push(`색 ${item.color} → ${lineId}: 최적매칭 표(${votes})가 국소 최다표(${bestVotes})와 다름.`);
+    const paths = stitchChains(
+      item.tracks.map((track) => track.points).filter((points) => points.length >= 2),
+      stitchTolerance,
+    )
+      .filter((points) => points.length >= 2)
+      .map((points) => pathString(points));
     lines.push({
       lineId,
-      svgColor: color,
+      svgColor: item.color,
       trackCount: paths.length,
       matchVotes: votes,
       stationCount: stationCountByLine.get(lineId) ?? 0,
@@ -234,9 +368,12 @@ async function buildLineTracks({ geometry, pack, region, snapRadius }) {
     schemaVersion: 1,
     region,
     snapRadius,
+    stitchTolerance,
+    stationProximityRatio,
     sourceExtractorVersion: geom.extractorVersion ?? null,
-    colorCount: colors.length,
+    colorCount: refinedColors.length,
     lineCount: lineIds.length,
+    refinement,
     colorToLineId,
     lines: lines.sort((a, b) => a.lineId.localeCompare(b.lineId)),
     warnings,
@@ -248,14 +385,13 @@ function assertIntegrity(result) {
   if (result.colorCount !== result.lineCount) {
     problems.push(`track 색 수(${result.colorCount}) ≠ 노선 수(${result.lineCount}) — 색이 노선 식별자라는 전제 위반.`);
   }
-  const zeroVote = result.lines.filter((line) => line.matchVotes === 0);
-  if (zeroVote.length > 0) {
-    problems.push(`근접 역 0표로 배정된 노선 ${zeroVote.length}개: ${zeroVote.map((line) => line.lineId).join(", ")}`);
-  }
   const emptyPaths = result.lines.filter((line) => line.trackCount === 0);
   if (emptyPaths.length > 0) {
     problems.push(`track path가 비어 있는 노선 ${emptyPaths.length}개: ${emptyPaths.map((line) => line.lineId).join(", ")}`);
   }
+  // 0표(소거법 배정) 노선은 track이 존재하므로 무음 fallback이 아니다. BLOCKER가 아닌
+  // 수동 검수 대상(audit LINE_TRACKS_ZERO_VOTE=HIGH)이며 warnings로 이미 노출된다.
+  // 색≠노선/빈 path만 build --check의 차단 사유로 둔다.
   return problems;
 }
 
@@ -268,7 +404,9 @@ async function main() {
   const result = await buildLineTracks(options);
   const problems = assertIntegrity(result);
 
-  process.stderr.write(`[${result.region}] 색 ${result.colorCount} / 노선 ${result.lineCount} · track 노선 ${result.lines.length} · 경고 ${result.warnings.length}\n`);
+  process.stderr.write(`[${result.region}] 색 ${result.colorCount}(원본 ${result.refinement.originalColorCount}) / 노선 ${result.lineCount} · track 노선 ${result.lines.length} · 근접률 ${result.stationProximityRatio} · 경고 ${result.warnings.length}\n`);
+  if (result.refinement.merged.length > 0) process.stderr.write(`  ↳ 병합 ${result.refinement.merged.map((pair) => pair.join("←")).join(", ")}\n`);
+  if (result.refinement.dropped.length > 0) process.stderr.write(`  ↳ 제외 ${result.refinement.dropped.map((drop) => `${drop.color}${drop.achromatic ? "(무채색)" : ""}`).join(", ")}\n`);
   for (const warning of result.warnings) process.stderr.write(`  ⚠ ${warning}\n`);
 
   if (options.check) {

--- a/tools/route-map/build-route-map-line-tracks.mjs
+++ b/tools/route-map/build-route-map-line-tracks.mjs
@@ -43,6 +43,7 @@ region 노선별 track geometry로 변환한다. --check는 파일을 쓰지 않
 function parseArgs(argv) {
   const options = {
     geometry: null, pack: null, region: null, out: null, check: false,
+    source: "svg-strokes",
     snapRadius: SNAP_RADIUS,
     stitchTolerance: STITCH_TOLERANCE,
     mergeColorDistance: MERGE_COLOR_DISTANCE,
@@ -59,6 +60,7 @@ function parseArgs(argv) {
       case "--region": options.region = argv[++index] ?? null; break;
       case "--out": options.out = argv[++index] ?? null; break;
       case "--check": options.check = true; break;
+      case "--source": options.source = argv[++index] ?? ""; break;
       case "--snap-radius": options.snapRadius = Number.parseFloat(argv[++index] ?? ""); break;
       case "--stitch-tolerance": options.stitchTolerance = Number.parseFloat(argv[++index] ?? ""); break;
       case "--merge-color-distance": options.mergeColorDistance = Number.parseFloat(argv[++index] ?? ""); break;
@@ -67,7 +69,11 @@ function parseArgs(argv) {
         if (arg.startsWith("--")) throw new Error(`Unknown option: ${arg}`);
     }
   }
-  if (!options.geometry) throw new Error("--geometry is required.");
+  if (!["svg-strokes", "pack-down-path"].includes(options.source)) {
+    throw new Error(`--source must be svg-strokes or pack-down-path, got: ${options.source}`);
+  }
+  // pack-down-path(Route B)는 SVG 없이 pack 실측 down_path만 변환하므로 geometry 불요.
+  if (options.source === "svg-strokes" && !options.geometry) throw new Error("--geometry is required (source=svg-strokes).");
   if (!options.pack) throw new Error("--pack is required.");
   if (!options.region) throw new Error("--region is required.");
   if (!Number.isFinite(options.snapRadius) || options.snapRadius <= 0) throw new Error("--snap-radius must be a positive number.");
@@ -367,6 +373,7 @@ async function buildLineTracks({ geometry, pack, region, snapRadius, stitchToler
   return {
     schemaVersion: 1,
     region,
+    source: "svg-strokes",
     snapRadius,
     stitchTolerance,
     stationProximityRatio,
@@ -380,9 +387,98 @@ async function buildLineTracks({ geometry, pack, region, snapRadius, stitchToler
   };
 }
 
+// "M x y L x y ..." 절대좌표 path를 정점 목록으로 파싱(parseRouteMapPolyline과 동일 규칙).
+function parseAbsolutePolyline(pathText) {
+  const numbers = (pathText.match(/-?\d+(?:\.\d+)?/g) ?? []).map(Number);
+  const points = [];
+  for (let index = 0; index + 1 < numbers.length; index += 2) {
+    points.push({ x: numbers[index], y: numbers[index + 1] });
+  }
+  return points;
+}
+
+// Route B: pack 실측 down_path를 sequence 순으로 체이닝해 동일 tracks.json 스키마로
+// 변환한다. 렌더러는 SVG track과 구분하지 않고 소비한다(무음 fallback 아님 —
+// track 원천이 명시적으로 pack-down-path일 뿐). 체이닝 규칙은 앱
+// _assemblePolylines(structured_route_map.dart)와 동일: 끝점=시작점이면 잇고 아니면 끊는다.
+async function buildLineTracksFromDownPath({ pack, region, stitchTolerance }) {
+  const { db, tempDir } = await openPack(pack);
+  let rows;
+  try {
+    rows = db
+      .prepare(
+        `SELECT rmp.line_id AS lineId, rmp.down_path AS downPath
+         FROM route_map_positions rmp
+         JOIN station_lines sl ON sl.station_id = rmp.station_id AND sl.line_id = rmp.line_id
+         WHERE rmp.region = ?
+         ORDER BY rmp.line_id, sl.line_sequence, rmp.station_id`,
+      )
+      .all(region);
+  } finally {
+    db.close();
+    if (tempDir) await rm(tempDir, { recursive: true, force: true });
+  }
+  if (rows.length === 0) throw new Error(`region '${region}'의 route_map_positions가 비어 있다.`);
+
+  const segmentsByLine = new Map();
+  const stationCountByLine = new Map();
+  for (const row of rows) {
+    if (!segmentsByLine.has(row.lineId)) segmentsByLine.set(row.lineId, []);
+    segmentsByLine.get(row.lineId).push(row.downPath ?? "");
+    stationCountByLine.set(row.lineId, (stationCountByLine.get(row.lineId) ?? 0) + 1);
+  }
+
+  const lines = [];
+  const warnings = [];
+  const orderedLineIds = [...segmentsByLine.keys()].sort((a, b) => a.localeCompare(b));
+  for (const lineId of orderedLineIds) {
+    // sequence 순 down_path 세그먼트를 끝점 연속이면 이어 붙인다.
+    const polylines = [];
+    let current = null;
+    for (const segment of segmentsByLine.get(lineId)) {
+      const points = parseAbsolutePolyline(segment);
+      if (points.length === 0) continue;
+      const tail = current?.[current.length - 1];
+      if (current && tail.x === points[0].x && tail.y === points[0].y) {
+        current.push(...points.slice(1));
+      } else {
+        current = [...points];
+        polylines.push(current);
+      }
+    }
+    // 미세 hole은 stitching으로 추가 통합.
+    const paths = stitchChains(polylines.filter((points) => points.length >= 2), stitchTolerance)
+      .filter((points) => points.length >= 2)
+      .map((points) => pathString(points));
+    if (paths.length === 0) warnings.push(`노선 ${lineId}: down_path 세그먼트가 없어 빈 track.`);
+    lines.push({
+      lineId,
+      svgColor: "",
+      trackCount: paths.length,
+      matchVotes: null,
+      stationCount: stationCountByLine.get(lineId) ?? 0,
+      paths,
+    });
+  }
+
+  return {
+    schemaVersion: 1,
+    region,
+    source: "pack-down-path",
+    stitchTolerance,
+    stationProximityRatio: null,
+    colorCount: null,
+    lineCount: segmentsByLine.size,
+    refinement: null,
+    lines,
+    warnings,
+  };
+}
+
 function assertIntegrity(result) {
   const problems = [];
-  if (result.colorCount !== result.lineCount) {
+  // 색↔노선 전제는 SVG stroke 원천에만 적용(Route B는 색이 없다).
+  if (result.source === "svg-strokes" && result.colorCount !== result.lineCount) {
     problems.push(`track 색 수(${result.colorCount}) ≠ 노선 수(${result.lineCount}) — 색이 노선 식별자라는 전제 위반.`);
   }
   const emptyPaths = result.lines.filter((line) => line.trackCount === 0);
@@ -401,12 +497,18 @@ async function main() {
     process.stdout.write(usage());
     return;
   }
-  const result = await buildLineTracks(options);
+  const result = options.source === "pack-down-path"
+    ? await buildLineTracksFromDownPath(options)
+    : await buildLineTracks(options);
   const problems = assertIntegrity(result);
 
-  process.stderr.write(`[${result.region}] 색 ${result.colorCount}(원본 ${result.refinement.originalColorCount}) / 노선 ${result.lineCount} · track 노선 ${result.lines.length} · 근접률 ${result.stationProximityRatio} · 경고 ${result.warnings.length}\n`);
-  if (result.refinement.merged.length > 0) process.stderr.write(`  ↳ 병합 ${result.refinement.merged.map((pair) => pair.join("←")).join(", ")}\n`);
-  if (result.refinement.dropped.length > 0) process.stderr.write(`  ↳ 제외 ${result.refinement.dropped.map((drop) => `${drop.color}${drop.achromatic ? "(무채색)" : ""}`).join(", ")}\n`);
+  if (result.source === "pack-down-path") {
+    process.stderr.write(`[${result.region}] (down_path 변환) 노선 ${result.lineCount} · track 노선 ${result.lines.length} · 경고 ${result.warnings.length}\n`);
+  } else {
+    process.stderr.write(`[${result.region}] 색 ${result.colorCount}(원본 ${result.refinement.originalColorCount}) / 노선 ${result.lineCount} · track 노선 ${result.lines.length} · 근접률 ${result.stationProximityRatio} · 경고 ${result.warnings.length}\n`);
+    if (result.refinement.merged.length > 0) process.stderr.write(`  ↳ 병합 ${result.refinement.merged.map((pair) => pair.join("←")).join(", ")}\n`);
+    if (result.refinement.dropped.length > 0) process.stderr.write(`  ↳ 제외 ${result.refinement.dropped.map((drop) => `${drop.color}${drop.achromatic ? "(무채색)" : ""}`).join(", ")}\n`);
+  }
   for (const warning of result.warnings) process.stderr.write(`  ⚠ ${warning}\n`);
 
   if (options.check) {

--- a/tools/route-map/build-route-map-line-tracks.mjs
+++ b/tools/route-map/build-route-map-line-tracks.mjs
@@ -1,0 +1,296 @@
+#!/usr/bin/env node
+// SVG track geometry(extract-svg-geometry v2의 strokes)를 노선별 실제 track
+// polyline으로 변환한다. 핵심 통찰:
+//
+//   1. route_map_positions.x,y는 라벨 위치라 track 위 마커가 아니다 → 역을 track에
+//      직접 snap할 수 없다. 대신 track polyline 자체가 이미 실제 노선 모양이므로
+//      그대로 노선 geometry로 쓴다(역별 down_path 재생성 불필요).
+//   2. SVG stroke 색은 노선의 실제 식별자다(CSS 클래스 = 노선). 색 종류 수 = 노선
+//      수이며, 색↔line_id는 완전 1:1이다. greedy 다수결은 환승 밀집/평행 노선에서
+//      중복·오류를 내므로, 색×line_id 근접 표수 행렬 위에서 최대가중 완전매칭
+//      (Hungarian)으로 전역 최적 1:1 배정을 구한다.
+//
+// 렌더 색은 여기서 정하지 않는다 — pack lines.color(apply-route-map-line-colors로
+// 반영된 공식 색)를 렌더러가 쓴다. 이 스크립트는 track geometry와 색↔line_id
+// 매핑만 산출한다.
+import { readFile, writeFile } from "node:fs/promises";
+import { gunzipSync } from "node:zlib";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { mkdtemp, rm, writeFile as writeTemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+
+// 역 라벨을 track에 근접 배정할 때의 반경(root px). 라벨은 track에서 20~35px
+// 떨어져 있어(폰트 높이 근처) 이보다 크면 이웃 노선까지 삼킨다.
+const SNAP_RADIUS = 35;
+
+function usage() {
+  return `Usage: node tools/route-map/build-route-map-line-tracks.mjs --geometry <geom.json> --pack <capital.sqlite[.gz]> --region <name> [--out <tracks.json>] [--check] [--snap-radius <px>]
+
+extract-svg-geometry v2 결과의 노선 track(polyline/path)을 색↔line_id 최적매칭으로
+region 노선별 track geometry로 변환한다. --check는 파일을 쓰지 않고 무결성만 검증한다.
+`;
+}
+
+function parseArgs(argv) {
+  const options = { geometry: null, pack: null, region: null, out: null, check: false, snapRadius: SNAP_RADIUS };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case "--help":
+      case "-h":
+        return { help: true };
+      case "--geometry": options.geometry = argv[++index] ?? null; break;
+      case "--pack": options.pack = argv[++index] ?? null; break;
+      case "--region": options.region = argv[++index] ?? null; break;
+      case "--out": options.out = argv[++index] ?? null; break;
+      case "--check": options.check = true; break;
+      case "--snap-radius": options.snapRadius = Number.parseFloat(argv[++index] ?? ""); break;
+      default:
+        if (arg.startsWith("--")) throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+  if (!options.geometry) throw new Error("--geometry is required.");
+  if (!options.pack) throw new Error("--pack is required.");
+  if (!options.region) throw new Error("--region is required.");
+  if (!Number.isFinite(options.snapRadius) || options.snapRadius <= 0) throw new Error("--snap-radius must be a positive number.");
+  return options;
+}
+
+// 점 p에서 선분 ab까지 최단거리.
+function distanceToSegment(p, a, b) {
+  const dx = b.x - a.x;
+  const dy = b.y - a.y;
+  const lengthSquared = dx * dx + dy * dy;
+  if (lengthSquared === 0) return Math.hypot(p.x - a.x, p.y - a.y);
+  let t = ((p.x - a.x) * dx + (p.y - a.y) * dy) / lengthSquared;
+  t = Math.max(0, Math.min(1, t));
+  return Math.hypot(p.x - (a.x + t * dx), p.y - (a.y + t * dy));
+}
+
+// 역 p에서 track(정점열들의 묶음)까지 최단거리.
+function distanceToTracks(p, tracks) {
+  let best = Infinity;
+  for (const track of tracks) {
+    for (let index = 1; index < track.points.length; index += 1) {
+      const distance = distanceToSegment(p, track.points[index - 1], track.points[index]);
+      if (distance < best) best = distance;
+    }
+  }
+  return best;
+}
+
+// 최대가중 완전 이분매칭 (Hungarian, O(n^3)). weight[i][j] 최대화. 정사각 확장.
+function maximumWeightMatching(weight, rowCount, columnCount) {
+  const n = Math.max(rowCount, columnCount);
+  const cost = Array.from({ length: n }, (_, i) => Array.from({ length: n }, (_, j) => -(weight[i]?.[j] ?? 0)));
+  const INF = Number.POSITIVE_INFINITY;
+  const u = new Array(n + 1).fill(0);
+  const v = new Array(n + 1).fill(0);
+  const p = new Array(n + 1).fill(0);
+  const way = new Array(n + 1).fill(0);
+  for (let i = 1; i <= n; i += 1) {
+    p[0] = i;
+    let j0 = 0;
+    const minv = new Array(n + 1).fill(INF);
+    const used = new Array(n + 1).fill(false);
+    do {
+      used[j0] = true;
+      const i0 = p[j0];
+      let delta = INF;
+      let j1 = -1;
+      for (let j = 1; j <= n; j += 1) {
+        if (used[j]) continue;
+        const current = cost[i0 - 1][j - 1] - u[i0] - v[j];
+        if (current < minv[j]) { minv[j] = current; way[j] = j0; }
+        if (minv[j] < delta) { delta = minv[j]; j1 = j; }
+      }
+      for (let j = 0; j <= n; j += 1) {
+        if (used[j]) { u[p[j]] += delta; v[j] -= delta; }
+        else minv[j] -= delta;
+      }
+      j0 = j1;
+    } while (p[j0] !== 0);
+    do {
+      const j1 = way[j0];
+      p[j0] = p[j1];
+      j0 = j1;
+    } while (j0);
+  }
+  // p[j]는 열 j에 매칭된 행. 호출부는 행(색)→열(노선)을 원하므로 뒤집어 반환한다.
+  const columnForRow = new Array(rowCount).fill(-1);
+  for (let j = 1; j <= n; j += 1) {
+    const row = p[j] - 1;
+    const column = j - 1;
+    if (row >= 0 && row < rowCount && column < columnCount) columnForRow[row] = column;
+  }
+  return columnForRow;
+}
+
+async function openPack(packPath) {
+  const resolved = path.resolve(packPath);
+  const raw = await readFile(resolved);
+  if (resolved.endsWith(".gz")) {
+    const tempDir = await mkdtemp(path.join(tmpdir(), "easysubway-line-tracks-"));
+    const tempFile = path.join(tempDir, "pack.sqlite");
+    await writeTemp(tempFile, gunzipSync(raw));
+    return { db: new DatabaseSync(tempFile), tempDir };
+  }
+  return { db: new DatabaseSync(resolved), tempDir: null };
+}
+
+function number(value) {
+  return Math.round(value * 1000) / 1000;
+}
+
+// track 정점열 → "M x y L x y ..." (parseRouteMapPolyline 호환).
+function pathString(points) {
+  return points
+    .map((point, index) => `${index === 0 ? "M" : "L"} ${number(point.x)} ${number(point.y)}`)
+    .join(" ");
+}
+
+async function buildLineTracks({ geometry, pack, region, snapRadius }) {
+  const geom = JSON.parse(await readFile(path.resolve(geometry), "utf8"));
+  const strokes = (geom.strokes ?? []).filter((stroke) => stroke.tag !== "line" && !stroke.dashed);
+  if (strokes.length === 0) throw new Error("geometry에 노선 track(polyline/path stroke)이 없다. extract-svg-geometry v2 결과인지 확인.");
+
+  const { db, tempDir } = await openPack(pack);
+  let stations;
+  try {
+    stations = db
+      .prepare("SELECT station_id, line_id, x, y FROM route_map_positions WHERE region = ?")
+      .all(region)
+      .map((row) => ({ lineId: row.line_id, x: row.x, y: row.y }));
+  } finally {
+    db.close();
+    if (tempDir) await rm(tempDir, { recursive: true, force: true });
+  }
+  if (stations.length === 0) throw new Error(`region '${region}'의 route_map_positions가 비어 있다.`);
+
+  // 색별 track 묶음.
+  const tracksByColor = new Map();
+  for (const stroke of strokes) {
+    if (!tracksByColor.has(stroke.stroke)) tracksByColor.set(stroke.stroke, []);
+    tracksByColor.get(stroke.stroke).push(stroke);
+  }
+  const colors = [...tracksByColor.keys()];
+  const lineIds = [...new Set(stations.map((station) => station.lineId))];
+
+  // 색×line_id 근접 표수: 각 역을 "가장 가까운 색"에 투표(snapRadius 이내일 때만).
+  const weight = colors.map(() => new Array(lineIds.length).fill(0));
+  const lineIndex = new Map(lineIds.map((id, index) => [id, index]));
+  for (const station of stations) {
+    let bestColor = -1;
+    let bestDistance = Infinity;
+    colors.forEach((color, colorIndex) => {
+      const distance = distanceToTracks(station, tracksByColor.get(color));
+      if (distance < bestDistance) { bestDistance = distance; bestColor = colorIndex; }
+    });
+    if (bestColor >= 0 && bestDistance <= snapRadius) {
+      weight[bestColor][lineIndex.get(station.lineId)] += 1;
+    }
+  }
+
+  // 색↔line_id 전역 최적 1:1 매칭.
+  const lineForColor = maximumWeightMatching(weight, colors.length, lineIds.length);
+  const stationCountByLine = new Map();
+  for (const station of stations) stationCountByLine.set(station.lineId, (stationCountByLine.get(station.lineId) ?? 0) + 1);
+
+  const lines = [];
+  const warnings = [];
+  const colorToLineId = {};
+  colors.forEach((color, colorIndex) => {
+    const matchedLineIndex = lineForColor[colorIndex];
+    const lineId = matchedLineIndex >= 0 ? lineIds[matchedLineIndex] : null;
+    const votes = matchedLineIndex >= 0 ? weight[colorIndex][matchedLineIndex] : 0;
+    const bestVotes = Math.max(0, ...weight[colorIndex]);
+    if (!lineId) {
+      warnings.push(`색 ${color}: 매칭된 노선 없음(track ${tracksByColor.get(color).length}개).`);
+      return;
+    }
+    colorToLineId[color] = lineId;
+    if (votes === 0) warnings.push(`색 ${color} → ${lineId}: 근접 역 0표(소거법 배정). 위치 검수 필요.`);
+    else if (votes !== bestVotes) warnings.push(`색 ${color} → ${lineId}: 최적매칭 표(${votes})가 국소 최다표(${bestVotes})와 다름.`);
+    const paths = tracksByColor.get(color)
+      .filter((track) => track.points.length >= 2)
+      .map((track) => pathString(track.points));
+    lines.push({
+      lineId,
+      svgColor: color,
+      trackCount: paths.length,
+      matchVotes: votes,
+      stationCount: stationCountByLine.get(lineId) ?? 0,
+      paths,
+    });
+  });
+
+  // 미매칭 노선(track 색이 배정되지 않은 line_id).
+  const matchedLineIds = new Set(lines.map((line) => line.lineId));
+  const unmatchedLines = lineIds.filter((id) => !matchedLineIds.has(id));
+  for (const id of unmatchedLines) warnings.push(`노선 ${id}: 대응 track 색 없음.`);
+
+  return {
+    schemaVersion: 1,
+    region,
+    snapRadius,
+    sourceExtractorVersion: geom.extractorVersion ?? null,
+    colorCount: colors.length,
+    lineCount: lineIds.length,
+    colorToLineId,
+    lines: lines.sort((a, b) => a.lineId.localeCompare(b.lineId)),
+    warnings,
+  };
+}
+
+function assertIntegrity(result) {
+  const problems = [];
+  if (result.colorCount !== result.lineCount) {
+    problems.push(`track 색 수(${result.colorCount}) ≠ 노선 수(${result.lineCount}) — 색이 노선 식별자라는 전제 위반.`);
+  }
+  const zeroVote = result.lines.filter((line) => line.matchVotes === 0);
+  if (zeroVote.length > 0) {
+    problems.push(`근접 역 0표로 배정된 노선 ${zeroVote.length}개: ${zeroVote.map((line) => line.lineId).join(", ")}`);
+  }
+  const emptyPaths = result.lines.filter((line) => line.trackCount === 0);
+  if (emptyPaths.length > 0) {
+    problems.push(`track path가 비어 있는 노선 ${emptyPaths.length}개: ${emptyPaths.map((line) => line.lineId).join(", ")}`);
+  }
+  return problems;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    process.stdout.write(usage());
+    return;
+  }
+  const result = await buildLineTracks(options);
+  const problems = assertIntegrity(result);
+
+  process.stderr.write(`[${result.region}] 색 ${result.colorCount} / 노선 ${result.lineCount} · track 노선 ${result.lines.length} · 경고 ${result.warnings.length}\n`);
+  for (const warning of result.warnings) process.stderr.write(`  ⚠ ${warning}\n`);
+
+  if (options.check) {
+    if (problems.length > 0) {
+      for (const problem of problems) process.stderr.write(`  ✗ ${problem}\n`);
+      process.exitCode = 1;
+      return;
+    }
+    process.stderr.write("  ✓ 무결성 통과\n");
+    return;
+  }
+
+  const output = JSON.stringify(result, null, 2);
+  if (options.out) {
+    await writeFile(path.resolve(options.out), `${output}\n`);
+    process.stderr.write(`  → ${options.out}\n`);
+  } else {
+    process.stdout.write(`${output}\n`);
+  }
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error.message}\n`);
+  process.exitCode = 1;
+});

--- a/tools/route-map/build-route-map-line-tracks.mjs
+++ b/tools/route-map/build-route-map-line-tracks.mjs
@@ -176,6 +176,19 @@ function pathString(points) {
     .join(" ");
 }
 
+// 정점열 묶음 → stitching 후 유효 조각만 path 문자열로. svg-strokes/pack-down-path
+// 두 소스가 같은 규칙으로 path를 만들도록 공유한다(스키마 드리프트 방지).
+function toPaths(pointLists, tolerance) {
+  return stitchChains(pointLists.filter((points) => points.length >= 2), tolerance)
+    .filter((points) => points.length >= 2)
+    .map((points) => pathString(points));
+}
+
+// tracks.json의 노선 레코드. 두 소스가 동일 shape를 내도록 공유한다.
+function makeLine({ lineId, svgColor, matchVotes, stationCount, paths }) {
+  return { lineId, svgColor, trackCount: paths.length, matchVotes, stationCount, paths };
+}
+
 // "#rrggbb" → [r, g, b].
 function rgb(hex) {
   return [1, 3, 5].map((offset) => Number.parseInt(hex.slice(offset, offset + 2), 16));
@@ -349,20 +362,14 @@ async function buildLineTracks({ geometry, pack, region, snapRadius, stitchToler
     colorToLineId[item.color] = lineId;
     if (votes === 0) warnings.push(`색 ${item.color} → ${lineId}: 근접 역 0표(소거법 배정). 위치 검수 필요.`);
     else if (votes !== bestVotes) warnings.push(`색 ${item.color} → ${lineId}: 최적매칭 표(${votes})가 국소 최다표(${bestVotes})와 다름.`);
-    const paths = stitchChains(
-      item.tracks.map((track) => track.points).filter((points) => points.length >= 2),
-      stitchTolerance,
-    )
-      .filter((points) => points.length >= 2)
-      .map((points) => pathString(points));
-    lines.push({
+    const paths = toPaths(item.tracks.map((track) => track.points), stitchTolerance);
+    lines.push(makeLine({
       lineId,
       svgColor: item.color,
-      trackCount: paths.length,
       matchVotes: votes,
       stationCount: stationCountByLine.get(lineId) ?? 0,
       paths,
-    });
+    }));
   });
 
   // 미매칭 노선(track 색이 배정되지 않은 line_id).
@@ -447,18 +454,15 @@ async function buildLineTracksFromDownPath({ pack, region, stitchTolerance }) {
       }
     }
     // 미세 hole은 stitching으로 추가 통합.
-    const paths = stitchChains(polylines.filter((points) => points.length >= 2), stitchTolerance)
-      .filter((points) => points.length >= 2)
-      .map((points) => pathString(points));
+    const paths = toPaths(polylines, stitchTolerance);
     if (paths.length === 0) warnings.push(`노선 ${lineId}: down_path 세그먼트가 없어 빈 track.`);
-    lines.push({
+    lines.push(makeLine({
       lineId,
       svgColor: "",
-      trackCount: paths.length,
       matchVotes: null,
       stationCount: stationCountByLine.get(lineId) ?? 0,
       paths,
-    });
+    }));
   }
 
   return {

--- a/tools/route-map/extract-svg-geometry.mjs
+++ b/tools/route-map/extract-svg-geometry.mjs
@@ -9,12 +9,21 @@ import path from "node:path";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
-const extractorVersion = "route-map-svg-geometry-v1";
+// v2: <text> 라벨에 더해 노선 track geometry(line/polyline/polygon/path)를
+// root 좌표 정점 목록 + 확정 stroke 색(getComputedStyle)으로 함께 추출한다.
+const extractorVersion = "route-map-svg-geometry-v2";
+
+// 이 길이(root 좌표) 미만인 stroke는 노선이 아니라 역 마커 틱/장식으로 보고 버린다.
+// seoul SVG의 <line class="SDI">(≈20px 대각선 장식)를 걸러내는 하한이다.
+const MIN_STROKE_LENGTH = 24;
+// path는 정점 정보가 d 안에 있어 직접 못 읽으므로 등간격으로 재샘플한다(root 좌표 px).
+const PATH_SAMPLE_SPACING = 8;
 
 function usage() {
   return `Usage: node tools/route-map/extract-svg-geometry.mjs <svg-file> --region <name> [--browser <path>] [--pretty]
 
-Extract visible SVG <text> bounding polygons in root SVG coordinates.
+Extract visible SVG <text> bounding polygons and line/polyline/polygon/path
+stroke geometry (with computed stroke color) in root SVG coordinates.
 `;
 }
 
@@ -77,7 +86,7 @@ function stripSvgPreamble(svg) {
 
 function browserExtractorExpression(svg) {
   const svgBase64 = Buffer.from(stripSvgPreamble(svg), "utf8").toString("base64");
-  return `(${async function extract(value) {
+  return `(${async function extract(value, config) {
     function decodeBase64Utf8(base64) {
       const binary = atob(base64);
       const bytes = new Uint8Array(binary.length);
@@ -101,11 +110,26 @@ function browserExtractorExpression(svg) {
       const point = new DOMPoint(x, y).matrixTransform(matrix);
       return { x: number(point.x), y: number(point.y) };
     }
+    // matrix의 등방 스케일 근사(root px = local px × scale). path 재샘플 간격 환산용.
+    function matrixScale(matrix) {
+      return Math.hypot(matrix.a, matrix.b) || 1;
+    }
+    // getComputedStyle의 "rgb(r,g,b)"/"rgba(r,g,b,a)"를 "#rrggbb"로. 투명/none은 null.
+    function normalizeColor(value) {
+      const match = /rgba?\(([^)]+)\)/i.exec(value || "");
+      if (!match) return null;
+      const parts = match[1].split(",").map((part) => Number.parseFloat(part.trim()));
+      const [r, g, b, a = 1] = parts;
+      if (![r, g, b].every(Number.isFinite) || a <= 0) return null;
+      const hex = (n) => Math.max(0, Math.min(255, Math.round(n))).toString(16).padStart(2, "0");
+      return `#${hex(r)}${hex(g)}${hex(b)}`;
+    }
     function elementClasses(element) {
       if (typeof element.className === "string") return element.className;
       return element.className?.baseVal ?? "";
     }
-    function descriptorFor(element, text, bbox) {
+    // svg 루트 전까지의 조상 체인 — descriptor(sourceElementKey 원천)에 공통 사용.
+    function ancestorChain(element) {
       const ancestors = [];
       let current = element.parentElement;
       while (current && current.tagName.toLowerCase() !== "svg") {
@@ -117,13 +141,16 @@ function browserExtractorExpression(svg) {
         });
         current = current.parentElement;
       }
+      return ancestors;
+    }
+    function descriptorFor(element, text, bbox) {
       return {
         text,
         tag: element.tagName.toLowerCase(),
         id: element.id || "",
         className: elementClasses(element),
         transform: element.getAttribute("transform") || "",
-        ancestors,
+        ancestors: ancestorChain(element),
         bbox: {
           x: number(bbox.x),
           y: number(bbox.y),
@@ -131,6 +158,34 @@ function browserExtractorExpression(svg) {
           height: number(bbox.height),
         },
       };
+    }
+    function strokeDescriptor(element, stroke) {
+      return {
+        tag: element.tagName.toLowerCase(),
+        id: element.id || "",
+        className: elementClasses(element),
+        transform: element.getAttribute("transform") || "",
+        stroke,
+        ancestors: ancestorChain(element),
+      };
+    }
+    // line/polyline/polygon의 로컬 정점 목록(원본 꺾임점 그대로 보존). path는 별도 재샘플.
+    function localVertices(element, tag) {
+      if (tag === "line") {
+        return [
+          { x: Number.parseFloat(element.getAttribute("x1") || "0"), y: Number.parseFloat(element.getAttribute("y1") || "0") },
+          { x: Number.parseFloat(element.getAttribute("x2") || "0"), y: Number.parseFloat(element.getAttribute("y2") || "0") },
+        ];
+      }
+      const list = element.points;
+      const vertices = [];
+      for (let index = 0; index < list.numberOfItems; index += 1) {
+        const point = list.getItem(index);
+        vertices.push({ x: point.x, y: point.y });
+      }
+      // polygon은 닫힌 도형 — 마지막→첫 정점 세그먼트를 명시적으로 잇는다.
+      if (tag === "polygon" && vertices.length > 1) vertices.push({ ...vertices[0] });
+      return vertices;
     }
     function isVisibleText(element, root) {
       if (element.closest("defs")) return false;
@@ -202,8 +257,62 @@ function browserExtractorExpression(svg) {
       });
     }
 
-    return { sourceViewBox: sourceViewBox(root), labels };
-  }})(${JSON.stringify(svgBase64)})`;
+    // 노선 track geometry: stroke가 있는 line/polyline/polygon/path를 root 좌표
+    // 정점 목록 + 확정 stroke 색으로 모은다. fill 전용 도형(마커/배경)과 장식 틱은
+    // stroke 없음/길이 하한으로 자연 배제한다. 점선(미개통/예정)은 dashed로 표시.
+    const strokes = [];
+    for (const element of root.querySelectorAll("line, polyline, polygon, path")) {
+      if (element.closest("defs") || !isVisibleText(element, root)) continue;
+      const style = getComputedStyle(element);
+      const stroke = normalizeColor(style.stroke);
+      if (!stroke) continue; // stroke 없는 도형은 노선 track이 아니다.
+      const elementMatrix = element.getScreenCTM();
+      if (!elementMatrix) continue;
+      const matrix = rootInverse.multiply(elementMatrix);
+      const tag = element.tagName.toLowerCase();
+
+      let vertices;
+      if (tag === "path") {
+        const totalLength = element.getTotalLength();
+        if (!(totalLength > 0)) continue;
+        // root 좌표 기준 등간격이 되도록 로컬 길이를 스케일로 환산해 샘플 수를 정한다.
+        const rootLength = totalLength * matrixScale(matrix);
+        const samples = Math.max(2, Math.min(600, Math.ceil(rootLength / config.pathSampleSpacing)));
+        vertices = [];
+        for (let step = 0; step <= samples; step += 1) {
+          const point = element.getPointAtLength((totalLength * step) / samples);
+          vertices.push({ x: point.x, y: point.y });
+        }
+      } else {
+        vertices = localVertices(element, tag);
+      }
+      if (vertices.length < 2) continue;
+
+      const points = vertices.map((vertex) => matrixPoint(matrix, vertex.x, vertex.y));
+      let length = 0;
+      for (let index = 1; index < points.length; index += 1) {
+        length += Math.hypot(points[index].x - points[index - 1].x, points[index].y - points[index - 1].y);
+      }
+      if (length < config.minStrokeLength) continue; // 역 마커 틱/장식 배제.
+
+      const dashArray = style.strokeDasharray;
+      const dashed = Boolean(dashArray) && dashArray !== "none" && dashArray.trim() !== "";
+      strokes.push({
+        tag,
+        stroke,
+        strokeWidth: Number.parseFloat(style.strokeWidth) || 0,
+        dashed,
+        length: number(length),
+        points,
+        descriptor: strokeDescriptor(element, stroke),
+      });
+    }
+
+    return { sourceViewBox: sourceViewBox(root), labels, strokes };
+  }})(${JSON.stringify(svgBase64)}, ${JSON.stringify({
+    minStrokeLength: MIN_STROKE_LENGTH,
+    pathSampleSpacing: PATH_SAMPLE_SPACING,
+  })})`;
 }
 
 async function browserVersion(browser) {
@@ -349,6 +458,12 @@ async function extractSvgGeometry({ svgFile, region, browser }) {
         const sourceElementKey = sha256(JSON.stringify(descriptor));
         const { descriptor: _descriptor, ...publicLabel } = label;
         return { ...publicLabel, polygonIndex, sourceElementKey };
+      }),
+      strokes: extracted.strokes.map((stroke, strokeIndex) => {
+        const descriptor = { ...stroke.descriptor, sourceSvgSha256 };
+        const sourceElementKey = sha256(JSON.stringify(descriptor));
+        const { descriptor: _descriptor, ...publicStroke } = stroke;
+        return { ...publicStroke, strokeIndex, sourceElementKey };
       }),
     };
   } finally {

--- a/tools/route-map/route-map-tools.test.mjs
+++ b/tools/route-map/route-map-tools.test.mjs
@@ -48,6 +48,50 @@ async function runBuildLineTracks({ geometry, region, stations, args = [] }) {
   }
 }
 
+// --source pack-down-path 모드용: route_map_positions(down_path)+station_lines(line_sequence)를
+// 만들고 실행한다(앱 drift_station_repository의 조회 구조와 동일).
+async function runBuildLineTracksFromPack({ region, rows, args = [] }) {
+  const dir = await mkdtemp(path.join(tmpdir(), "easysubway-line-tracks-pack-"));
+  try {
+    const packPath = path.join(dir, "pack.sqlite");
+    const db = new DatabaseSync(packPath);
+    db.exec(
+      `CREATE TABLE route_map_positions (
+        station_id TEXT NOT NULL,
+        line_id TEXT NOT NULL,
+        region TEXT NOT NULL,
+        x INTEGER NOT NULL,
+        y INTEGER NOT NULL,
+        down_path TEXT NOT NULL DEFAULT ''
+      );
+      CREATE TABLE station_lines (
+        station_id TEXT NOT NULL,
+        line_id TEXT NOT NULL,
+        line_sequence INTEGER NOT NULL
+      )`,
+    );
+    const insertPosition = db.prepare(
+      "INSERT INTO route_map_positions (station_id, line_id, region, x, y, down_path) VALUES (?, ?, ?, ?, ?, ?)",
+    );
+    const insertLine = db.prepare(
+      "INSERT INTO station_lines (station_id, line_id, line_sequence) VALUES (?, ?, ?)",
+    );
+    for (const row of rows) {
+      insertPosition.run(row.station_id, row.line_id, region, row.x, row.y, row.down_path ?? "");
+      insertLine.run(row.station_id, row.line_id, row.sequence);
+    }
+    db.close();
+    const { stdout } = await execFileAsync(
+      "node",
+      [buildLineTracksScript, "--source", "pack-down-path", "--pack", packPath, "--region", region, ...args],
+      { cwd: root, maxBuffer: 4 * 1024 * 1024 },
+    );
+    return JSON.parse(stdout);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
 test("structured route map contract pins nationwide vector-rendered layers", async () => {
   const contract = JSON.parse(
     await readFile(
@@ -1994,4 +2038,21 @@ test("build-route-map-line-tracks refines surplus colors (achromatic drop + simi
   // 빨강 노선은 병합으로 한 조각(0→200), 파랑은 별도.
   const redLine = result.lines.find((line) => line.svgColor === "#ff0000");
   assert.ok(redLine, "대표색 #ff0000 노선이 있어야 한다");
+});
+
+test("build-route-map-line-tracks --source pack-down-path chains existing segments", async () => {
+  // down_path "M 0 0 L 10 0" → "M 10 0 L 20 0": 끝점=시작점이라 한 조각으로 이어진다.
+  const result = await runBuildLineTracksFromPack({
+    region: "테스트권",
+    rows: [
+      { station_id: "s1", line_id: "line-a", sequence: 1, x: 0, y: 0, down_path: "" },
+      { station_id: "s2", line_id: "line-a", sequence: 2, x: 10, y: 0, down_path: "M 0 0 L 10 0" },
+      { station_id: "s3", line_id: "line-a", sequence: 3, x: 20, y: 0, down_path: "M 10 0 L 20 0" },
+    ],
+  });
+  assert.equal(result.source, "pack-down-path");
+  assert.equal(result.lines.length, 1);
+  assert.equal(result.lines[0].lineId, "line-a");
+  assert.equal(result.lines[0].trackCount, 1);
+  assert.equal(result.lines[0].paths[0], "M 0 0 L 10 0 L 20 0");
 });

--- a/tools/route-map/route-map-tools.test.mjs
+++ b/tools/route-map/route-map-tools.test.mjs
@@ -219,7 +219,22 @@ test("structured route map contract pins nationwide vector-rendered layers", asy
   );
   assert.deepEqual(
     contract.layers.find((layer) => layer.id === "line_geometry").requiredFields,
-    ["station_id", "line_id", "region", "x", "y", "up_path", "down_path"],
+    ["region", "line_id", "track_index", "path"],
+  );
+  assert.deepEqual(
+    contract.layers.find((layer) => layer.id === "line_geometry").source,
+    ["route_map_line_tracks"],
+  );
+  assert.ok(
+    /track 직접 렌더/.test(
+      contract.layers.find((layer) => layer.id === "line_geometry").deriveRule,
+    ),
+    "line_geometry deriveRule은 track 직접 렌더를 명시해야 한다",
+  );
+  assert.ok(
+    Array.isArray(contract.routeMapLineTracksColumns) &&
+      contract.routeMapLineTracksColumns.includes("path"),
+    "routeMapLineTracksColumns에 path가 있어야 한다",
   );
   assert.equal(
     contract.layers.find((layer) => layer.id === "station_nodes").featureId,

--- a/tools/route-map/route-map-tools.test.mjs
+++ b/tools/route-map/route-map-tools.test.mjs
@@ -13,6 +13,37 @@ const execFileAsync = promisify(execFile);
 const root = path.resolve(import.meta.dirname, "../..");
 const buildLineTracksScript = path.resolve(import.meta.dirname, "build-route-map-line-tracks.mjs");
 const applyLineTracksScript = path.resolve(import.meta.dirname, "apply-route-map-line-tracks.mjs");
+const auditRouteMapScript = path.resolve(import.meta.dirname, "audit-route-map.mjs");
+
+// audit-route-map을 temp fixture + line-tracks 문서로 실행하고 report JSON을 돌려준다.
+// --fail-on으로 exit 1이 나도 stdout에 report가 있으므로 그대로 파싱한다.
+async function runAuditRouteMap({ fixture, lineTracks = [], failOn = [] }) {
+  const dir = await mkdtemp(path.join(tmpdir(), "easysubway-audit-tracks-"));
+  try {
+    const fixturePath = path.join(dir, "fixture.json");
+    await writeFile(fixturePath, JSON.stringify(fixture));
+    const trackArgs = [];
+    for (let i = 0; i < lineTracks.length; i += 1) {
+      const trackPath = path.join(dir, `line-tracks-${i}.json`);
+      await writeFile(trackPath, JSON.stringify(lineTracks[i]));
+      trackArgs.push("--line-tracks", trackPath);
+    }
+    const failArgs = failOn.length > 0 ? ["--fail-on", failOn.join(",")] : [];
+    let stdout;
+    try {
+      ({ stdout } = await execFileAsync(
+        "node",
+        [auditRouteMapScript, "--fixture", fixturePath, ...trackArgs, ...failArgs],
+        { cwd: root, maxBuffer: 4 * 1024 * 1024 },
+      ));
+    } catch (error) {
+      stdout = error.stdout; // --fail-on exit 1이어도 report는 stdout에 있다.
+    }
+    return JSON.parse(stdout);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
 
 // temp .gz pack(route_map_positions 라이선스 메타 포함) + index.json + tracks.json을
 // 만들어 apply-route-map-line-tracks를 실행하고, 기록된 route_map_line_tracks 행을
@@ -2150,6 +2181,48 @@ test("apply-route-map-line-tracks writes tracks with inherited license metadata"
   // 재실행(같은 region)은 기존 행 DELETE 후 INSERT — 중복 없음.
   const rerun = await runApplyLineTracks({ region: "테스트권", positions, tracksDocs });
   assert.equal(rerun.rows.length, 2);
+});
+
+test("audit-route-map flags line-track gaps as blockers", async () => {
+  const fixture = {
+    packs: [{
+      id: "test",
+      routeMapPositions: [
+        { stationId: "s1", lineId: "line-a", region: "테스트권", x: 0, y: 0 },
+        { stationId: "s2", lineId: "line-b", region: "테스트권", x: 10, y: 10 },
+      ],
+    }],
+  };
+  // tracks에 line-a만(line-b 누락) + 색≠노선.
+  const lineTracks = [{
+    region: "테스트권", source: "svg-strokes", colorCount: 1, lineCount: 2,
+    lines: [{ lineId: "line-a", svgColor: "#ff0000", matchVotes: 5, paths: ["M 0 0 L 1 0"] }],
+  }];
+  const report = await runAuditRouteMap({ fixture, lineTracks });
+  const codes = report.findings.map((finding) => finding.code);
+  assert.ok(codes.includes("LINE_TRACKS_MISSING_LINE"), "누락 노선 blocker");
+  assert.ok(codes.includes("LINE_TRACKS_COLOR_LINE_MISMATCH"), "색≠노선 blocker");
+  const missing = report.findings.find((finding) => finding.code === "LINE_TRACKS_MISSING_LINE");
+  assert.equal(missing.severity, "BLOCKER");
+  assert.equal(missing.lineId, "line-b");
+});
+
+test("audit-route-map flags zero-vote tracks as HIGH for manual review", async () => {
+  const fixture = {
+    packs: [{
+      id: "test",
+      routeMapPositions: [{ stationId: "s1", lineId: "line-a", region: "테스트권", x: 0, y: 0 }],
+    }],
+  };
+  const lineTracks = [{
+    region: "테스트권", source: "svg-strokes", colorCount: 1, lineCount: 1,
+    lines: [{ lineId: "line-a", svgColor: "#ff0000", matchVotes: 0, paths: ["M 0 0 L 1 0"] }],
+  }];
+  const report = await runAuditRouteMap({ fixture, lineTracks });
+  const zeroVote = report.findings.find((finding) => finding.code === "LINE_TRACKS_ZERO_VOTE");
+  assert.ok(zeroVote, "0표 노선 finding");
+  assert.equal(zeroVote.severity, "HIGH");
+  assert.equal(zeroVote.lineId, "line-a");
 });
 
 test("apply-route-map-line-tracks --check does not write and flags missing line license", async () => {

--- a/tools/route-map/route-map-tools.test.mjs
+++ b/tools/route-map/route-map-tools.test.mjs
@@ -5,10 +5,48 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { DatabaseSync } from "node:sqlite";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 const root = path.resolve(import.meta.dirname, "../..");
+const buildLineTracksScript = path.resolve(import.meta.dirname, "build-route-map-line-tracks.mjs");
+
+// build-route-map-line-tracks를 temp pack + geometry로 실행하고 stdout JSON을 돌려준다.
+// route_map_positions는 build가 SELECT하는 컬럼(station_id/line_id/region/x/y)만 만든다.
+async function runBuildLineTracks({ geometry, region, stations, args = [] }) {
+  const dir = await mkdtemp(path.join(tmpdir(), "easysubway-line-tracks-test-"));
+  try {
+    const packPath = path.join(dir, "pack.sqlite");
+    const db = new DatabaseSync(packPath);
+    db.exec(
+      `CREATE TABLE route_map_positions (
+        station_id TEXT NOT NULL,
+        line_id TEXT NOT NULL,
+        region TEXT NOT NULL,
+        x INTEGER NOT NULL,
+        y INTEGER NOT NULL
+      )`,
+    );
+    const insert = db.prepare(
+      "INSERT INTO route_map_positions (station_id, line_id, region, x, y) VALUES (?, ?, ?, ?, ?)",
+    );
+    for (const station of stations) {
+      insert.run(station.station_id, station.line_id, region, station.x, station.y);
+    }
+    db.close();
+    const geometryPath = path.join(dir, "geometry.json");
+    await writeFile(geometryPath, JSON.stringify(geometry));
+    const { stdout } = await execFileAsync(
+      "node",
+      [buildLineTracksScript, "--geometry", geometryPath, "--pack", packPath, "--region", region, ...args],
+      { cwd: root, maxBuffer: 4 * 1024 * 1024 },
+    );
+    return JSON.parse(stdout);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
 
 test("structured route map contract pins nationwide vector-rendered layers", async () => {
   const contract = JSON.parse(
@@ -132,7 +170,7 @@ test("SVG geometry extractor returns transformed visible text polygons", async (
 
   assert.equal(output.schemaVersion, 1);
   assert.equal(output.region, "fixture");
-  assert.equal(output.extractorVersion, "route-map-svg-geometry-v1");
+  assert.equal(output.extractorVersion, "route-map-svg-geometry-v2");
   assert.equal(output.sourceSvgSha256, createHash("sha256").update(source).digest("hex"));
   assert.deepEqual(output.sourceViewBox, [0, 0, 200, 120]);
   assert.match(output.browser.version, /Chrome|Chromium/i);
@@ -1901,4 +1939,59 @@ test("MOLIT nationwide fixture builder emits route map source hashes", async () 
   } finally {
     await rm(tmp, { recursive: true, force: true });
   }
+});
+
+test("build-route-map-line-tracks stitches touching fragments and reports proximity", async () => {
+  // 같은 색 두 조각: (0,0)-(10,0) 와 (10.5,0)-(20,0) → tolerance 1.5로 한 조각.
+  const geometry = {
+    extractorVersion: 2,
+    strokes: [
+      { tag: "polyline", stroke: "#ff0000", dashed: false, points: [{ x: 0, y: 0 }, { x: 10, y: 0 }] },
+      { tag: "polyline", stroke: "#ff0000", dashed: false, points: [{ x: 10.5, y: 0 }, { x: 20, y: 0 }] },
+    ],
+  };
+  const result = await runBuildLineTracks({
+    geometry,
+    region: "테스트권",
+    stations: [
+      { station_id: "s1", line_id: "line-a", x: 2, y: 5 },
+      { station_id: "s2", line_id: "line-a", x: 18, y: 5 },
+    ],
+  });
+  assert.equal(result.lines.length, 1);
+  assert.equal(result.lines[0].trackCount, 1); // 2 조각 → 1 (stitched)
+  assert.equal(result.lines[0].paths[0], "M 0 0 L 10 0 L 20 0");
+  assert.equal(result.stationProximityRatio, 1); // 2/2 역이 반경 내
+});
+
+test("build-route-map-line-tracks refines surplus colors (achromatic drop + similar merge)", async () => {
+  // 노선 2개(line-a, line-b). 색 4개 = 빨강·빨강변종(line-a)·파랑(line-b)·검정(무채색 외곽선).
+  // 정제: 빨강 변종 병합 + 무채색 검정 제외 → 색2 = 노선2.
+  const geometry = {
+    extractorVersion: 2,
+    strokes: [
+      { tag: "polyline", stroke: "#ff0000", dashed: false, points: [{ x: 0, y: 0 }, { x: 100, y: 0 }] },
+      { tag: "polyline", stroke: "#fe0202", dashed: false, points: [{ x: 100, y: 0 }, { x: 200, y: 0 }] },
+      { tag: "polyline", stroke: "#0000ff", dashed: false, points: [{ x: 0, y: 100 }, { x: 100, y: 100 }] },
+      { tag: "polyline", stroke: "#1a1a1a", dashed: false, points: [{ x: 0, y: 400 }, { x: 200, y: 400 }] },
+    ],
+  };
+  const result = await runBuildLineTracks({
+    geometry,
+    region: "테스트권",
+    stations: [
+      { station_id: "a1", line_id: "line-a", x: 5, y: 5 },
+      { station_id: "a2", line_id: "line-a", x: 195, y: 5 },
+      { station_id: "b1", line_id: "line-b", x: 5, y: 105 },
+      { station_id: "b2", line_id: "line-b", x: 95, y: 105 },
+    ],
+  });
+  assert.equal(result.lines.length, 2);
+  assert.equal(result.colorCount, 2); // 정제 후 색 수 = 노선 수
+  assert.equal(result.refinement.originalColorCount, 4);
+  assert.ok(result.refinement.dropped.some((drop) => drop.color === "#1a1a1a" && drop.achromatic)); // 무채색 제외
+  assert.ok(result.refinement.merged.some((pair) => pair.includes("#fe0202"))); // 유사색 병합
+  // 빨강 노선은 병합으로 한 조각(0→200), 파랑은 별도.
+  const redLine = result.lines.find((line) => line.svgColor === "#ff0000");
+  assert.ok(redLine, "대표색 #ff0000 노선이 있어야 한다");
 });

--- a/tools/route-map/route-map-tools.test.mjs
+++ b/tools/route-map/route-map-tools.test.mjs
@@ -6,11 +6,79 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { DatabaseSync } from "node:sqlite";
+import { gunzipSync, gzipSync } from "node:zlib";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 const root = path.resolve(import.meta.dirname, "../..");
 const buildLineTracksScript = path.resolve(import.meta.dirname, "build-route-map-line-tracks.mjs");
+const applyLineTracksScript = path.resolve(import.meta.dirname, "apply-route-map-line-tracks.mjs");
+
+// temp .gz pack(route_map_positions 라이선스 메타 포함) + index.json + tracks.json을
+// 만들어 apply-route-map-line-tracks를 실행하고, 기록된 route_map_line_tracks 행을
+// region 순으로 돌려준다. args로 --check 등을 전달할 수 있다.
+async function runApplyLineTracks({ region, positions, tracksDocs, args = [] }) {
+  const dir = await mkdtemp(path.join(tmpdir(), "easysubway-apply-tracks-"));
+  try {
+    const sqlitePath = path.join(dir, "capital.sqlite");
+    const db = new DatabaseSync(sqlitePath);
+    db.exec(
+      `CREATE TABLE route_map_positions (
+        station_id TEXT NOT NULL, line_id TEXT NOT NULL, region TEXT NOT NULL,
+        x INTEGER NOT NULL, y INTEGER NOT NULL,
+        source_id TEXT NOT NULL, source_name TEXT NOT NULL, source_url TEXT NOT NULL,
+        license TEXT NOT NULL, license_status TEXT NOT NULL,
+        commercial_use_allowed INTEGER NOT NULL, attribution_required INTEGER NOT NULL
+      )`,
+    );
+    const insert = db.prepare(
+      `INSERT INTO route_map_positions
+       (station_id, line_id, region, x, y, source_id, source_name, source_url,
+        license, license_status, commercial_use_allowed, attribution_required)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    for (const p of positions) {
+      insert.run(p.station_id, p.line_id, region, p.x ?? 0, p.y ?? 0, p.source_id, p.source_name,
+        p.source_url, p.license, p.license_status, p.commercial_use_allowed, p.attribution_required);
+    }
+    db.close();
+    const packPath = path.join(dir, "capital.sqlite.gz");
+    await writeFile(packPath, gzipSync(await readFile(sqlitePath), { level: 9, mtime: 0 }));
+    const indexPath = path.join(dir, "index.json");
+    await writeFile(indexPath, `${JSON.stringify({ packs: [{ id: "capital", sha256: "old", sqliteSha256: "old", byteSize: 0 }] }, null, 2)}\n`);
+    const trackArgs = [];
+    for (let i = 0; i < tracksDocs.length; i += 1) {
+      const trackPath = path.join(dir, `tracks-${i}.json`);
+      await writeFile(trackPath, JSON.stringify(tracksDocs[i]));
+      trackArgs.push("--tracks", trackPath);
+    }
+    await execFileAsync(
+      "node",
+      [applyLineTracksScript, "--pack", packPath, "--index", indexPath, ...trackArgs, ...args],
+      { cwd: root, maxBuffer: 4 * 1024 * 1024 },
+    );
+    const readback = path.join(dir, "readback.sqlite");
+    await writeFile(readback, gunzipSync(await readFile(packPath)));
+    const verifyDb = new DatabaseSync(readback);
+    let rows = [];
+    try {
+      const hasTable = verifyDb
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='route_map_line_tracks'")
+        .get();
+      if (hasTable) {
+        rows = verifyDb
+          .prepare("SELECT * FROM route_map_line_tracks WHERE region = ? ORDER BY line_id, track_index")
+          .all(region);
+      }
+    } finally {
+      verifyDb.close();
+    }
+    const index = JSON.parse(await readFile(indexPath, "utf8"));
+    return { rows, indexCapital: index.packs.find((pack) => pack.id === "capital") };
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
 
 // build-route-map-line-tracks를 temp pack + geometry로 실행하고 stdout JSON을 돌려준다.
 // route_map_positions는 build가 SELECT하는 컬럼(station_id/line_id/region/x/y)만 만든다.
@@ -2055,4 +2123,57 @@ test("build-route-map-line-tracks --source pack-down-path chains existing segmen
   assert.equal(result.lines[0].lineId, "line-a");
   assert.equal(result.lines[0].trackCount, 1);
   assert.equal(result.lines[0].paths[0], "M 0 0 L 10 0 L 20 0");
+});
+
+test("apply-route-map-line-tracks writes tracks with inherited license metadata", async () => {
+  const positions = [{
+    station_id: "s1", line_id: "line-a", x: 0, y: 0,
+    source_id: "src-official", source_name: "공식 노선도", source_url: "https://example.test",
+    license: "public-reference", license_status: "reviewed",
+    commercial_use_allowed: 0, attribution_required: 1,
+  }];
+  const tracksDocs = [{
+    region: "테스트권", source: "svg-strokes",
+    lines: [{ lineId: "line-a", svgColor: "#ff0000", paths: ["M 0 0 L 10 0", "M 20 0 L 30 0"] }],
+  }];
+  const { rows, indexCapital } = await runApplyLineTracks({ region: "테스트권", positions, tracksDocs });
+  assert.equal(rows.length, 2);
+  assert.equal(rows[0].track_index, 0);
+  assert.equal(rows[1].track_index, 1);
+  assert.equal(rows[0].svg_color, "#ff0000");
+  assert.equal(rows[0].license, "public-reference"); // 라이선스 승계
+  assert.equal(rows[0].attribution_required, 1);
+  assert.equal(rows[0].source_id, "src-official");
+  assert.match(rows[0].path, /^M -?\d/);
+  assert.notEqual(indexCapital.sqliteSha256, "old"); // index sha 갱신
+
+  // 재실행(같은 region)은 기존 행 DELETE 후 INSERT — 중복 없음.
+  const rerun = await runApplyLineTracks({ region: "테스트권", positions, tracksDocs });
+  assert.equal(rerun.rows.length, 2);
+});
+
+test("apply-route-map-line-tracks --check does not write and flags missing line license", async () => {
+  const positions = [{
+    station_id: "s1", line_id: "line-a", x: 0, y: 0,
+    source_id: "src", source_name: "공식", source_url: "https://example.test",
+    license: "public-reference", license_status: "reviewed",
+    commercial_use_allowed: 0, attribution_required: 1,
+  }];
+  // --check: 파일 미기록 → route_map_line_tracks 없음(빈 rows).
+  const checkRun = await runApplyLineTracks({
+    region: "테스트권", positions,
+    tracksDocs: [{ region: "테스트권", source: "svg-strokes", lines: [{ lineId: "line-a", svgColor: "#ff0000", paths: ["M 0 0 L 10 0"] }] }],
+    args: ["--check"],
+  });
+  assert.equal(checkRun.rows.length, 0);
+  assert.equal(checkRun.indexCapital.sqliteSha256, "old"); // --check는 index도 안 건드림
+
+  // route_map_positions에 없는 노선을 tracks가 참조하면 실패.
+  await assert.rejects(
+    runApplyLineTracks({
+      region: "테스트권", positions,
+      tracksDocs: [{ region: "테스트권", source: "svg-strokes", lines: [{ lineId: "line-ghost", svgColor: "#00ff00", paths: ["M 0 0 L 1 0"] }] }],
+    }),
+    /line-ghost/,
+  );
 });

--- a/tools/route-map/structured-route-map-contract.json
+++ b/tools/route-map/structured-route-map-contract.json
@@ -6,8 +6,9 @@
   "layers": [
     {
       "id": "line_geometry",
-      "source": ["network_edges", "route_map_positions.up_path", "route_map_positions.down_path"],
-      "requiredFields": ["station_id", "line_id", "region", "x", "y", "up_path", "down_path"],
+      "source": ["route_map_line_tracks"],
+      "requiredFields": ["region", "line_id", "track_index", "path"],
+      "deriveRule": "노선 track polyline을 노선 단위로 저장된 path 그대로 그린다. 역별 up_path/down_path 조립은 line_geometry의 source가 아니다(#1638 track 직접 렌더 전환). track은 공식 SVG stroke(색↔노선 매칭) 또는 SVG가 fill 렌더라 추출 불가한 region의 실측 down_path 변환(pack-down-path)에서 온다.",
       "lod": [
         { "minZoom": 0, "visible": true, "labelPolicy": "hide_station_labels" },
         { "minZoom": 1, "visible": true, "labelPolicy": "major_transfer_labels" },
@@ -67,6 +68,21 @@
     "commercial_use_allowed",
     "attribution_required",
     "reviewed_at",
+    "updated_at"
+  ],
+  "routeMapLineTracksColumns": [
+    "region",
+    "line_id",
+    "track_index",
+    "path",
+    "svg_color",
+    "source_id",
+    "source_name",
+    "source_url",
+    "license",
+    "license_status",
+    "commercial_use_allowed",
+    "attribution_required",
     "updated_at"
   ],
   "lineStationProgression": {


### PR DESCRIPTION
## Summary
공식 노선도 SVG의 실제 노선 track geometry를 노선 단위로 추출·저장하는 **도구·계약 계층**입니다. 렌더 무영향(pack 반영은 PR-3). 현재 down_path=역-역 직선(부채꼴 원인)을 실제 SVG track polyline으로 대체하기 위한 파이프라인입니다.

`추출(extract v2) → 색↔노선 Hungarian 매칭(build-line-tracks) → pack 기록(apply) → audit 게이트 → 계약`

## Phase 0 판정 (region별 Route A/B)
| region | 노선 | stroke | 판정 | 근거 |
|--------|------|--------|------|------|
| 수도권 | 24 | 97 | Route A | 색24=노선24, 근접률0.63 |
| 부산권 | 6 | 131 | Route A | `#211d1c`(무채색) 제외 → 색6=6, 근접률1.0 |
| 대구권 | 4 | 23 | Route A | 노랑 병합+무채색 제외 → 색4=4, 근접률1.0 |
| 대전권 | 1 | 0 | Route B | SVG가 fill 렌더(stroke 없음) → 실측 down_path 변환 |
| 광주권 | 1 | 0 | Route B | 동일 fill 방식 |

## 핵심 통찰
- **역 (x,y)는 라벨 위치**라 track 위 마커가 아님 → 역→track 스냅 불가. track polyline 자체가 실제 노선 모양이므로 그대로 렌더(역별 down_path 재생성 안 함).
- **SVG 색은 노선 식별자**(CSS 클래스=노선). 색↔line_id는 완전 1:1이며 Hungarian 최대가중 매칭으로 전역 최적 배정(greedy 다수결의 중복·오류 해소).
- 색 정제: 색>노선일 때만 유사색 병합·무채색 제외(수도권 회색 노선 `#797979` 보존).

## 변경
- `extract-svg-geometry.mjs` v2: line/polyline/path stroke + `getComputedStyle` 색 + root 좌표 정규화
- `build-route-map-line-tracks.mjs`: 색↔노선 매칭, stitching, 근접률, 색 정제, `--source pack-down-path`(Route B)
- `apply-route-map-line-tracks.mjs`: `route_map_line_tracks` 테이블 기록, 라이선스 승계(광주 CC BY-SA 유지), index sha 갱신
- `audit-route-map.mjs`: `--line-tracks` 게이트(MISSING/EMPTY/COLOR_MISMATCH=BLOCKER, ZERO_VOTE=HIGH)
- `structured-route-map-contract.json`: line_geometry source를 track으로

## 무음 fallback 0
데이터 결손은 빌드 게이트(`--check`, audit BLOCKER)가 막습니다. 렌더러는 단일 소비 경로(Route A/B 구분 없음).

## Test
route-map 도구 테스트 33개 + 계약/attribution 161개 통과. 실기기 QA는 PR-3(팩 반영).

Refs #1638