### PR TITLE
[Test] RAPTOR max transfer boundary (#1620)

### DIFF
--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -898,6 +898,17 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("V2 planner는 maxTransfers 0에서 시간표 환승 후보를 제외한다")
+	void routeV2PlannerRejectsTimetableTransferWhenMaxTransfersIsZero() {
+		var planner = new RouteV2Planner(legacySearchMustNotBeCalled(), transferRouteTimetablePort());
+
+		var plan = planner.search(routeV2Command(ConstraintMode.PREFER_STEP_FREE, MobilityType.SENIOR, 0, 3));
+
+		assertThat(plan.statuses()).containsExactly(RouteV2Status.NO_TIMETABLE_SERVICE);
+		assertThat(plan.itineraries()).isEmpty();
+	}
+
+	@Test
 	@DisplayName("V2 planner는 시간표 scan 결과를 refresh와 feedback 조회 경로에 저장한다")
 	void routeV2PlannerPersistsTimetableScanResultsForRefreshAndFeedback() {
 		var repository = new InMemoryRouteSearchRepository();


### PR DESCRIPTION
## 관련 이슈

Refs #1620

## 작업 배경

- #1620 완료 조건 중 `maxTransfers`가 RAPTOR 시간표 scan에 실제 반영되는지 경계 회귀가 약했습니다.

## 작업 내용

- `maxTransfers=0` 요청에서 시간표 환승 후보가 반환되지 않는 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.route.application.service.RouteSearchServiceTest.routeV2PlannerRejectsTimetableTransferWhenMaxTransfersIsZero` 성공
  - `./gradlew test --tests com.easysubway.route.application.service.RouteSearchServiceTest` 성공
  - `node --test tools/routes/*.test.mjs` 성공
  - `git diff --check` 성공

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| RAPTOR maxTransfers 경계 | backend | Gradle test | 터미널 출력 | 성공 |
| Route tools regression | tools | node test | 터미널 출력 | 성공 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 테스트만 변경

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `RouteSearchServiceTest.routeV2PlannerRejectsTimetableTransferWhenMaxTransfersIsZero`

## 리스크

- 테스트만 추가하므로 런타임 리스크 없음

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
