### PR TITLE
[Fix] RAPTOR candidate transfer ranking (#1620)

### DIFF
--- a/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
@@ -135,8 +135,8 @@ public class RouteV2Planner implements RouteV2SearchUseCase {
 	private List<RouteSearchResult> rankTimetableItineraries(List<RouteSearchResult> itineraries, int alternativeCount) {
 		return itineraries.stream()
 			.sorted(Comparator.comparingInt(RouteSearchResult::estimatedDurationSeconds)
-				.thenComparingInt(this::accessibilityRiskScore)
-				.thenComparingInt(RouteSearchResult::transferCount))
+				.thenComparingInt(RouteSearchResult::transferCount)
+				.thenComparingInt(this::accessibilityRiskScore))
 			.limit(alternativeCount)
 			.toList();
 	}

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -852,9 +852,23 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
-	@DisplayName("V2 planner는 동일 ETA 후보에서 접근성 미확인 위험이 낮은 경로를 우선한다")
-	void routeV2PlannerRanksLowerAccessibilityRiskForSameEtaCandidates() {
+	@DisplayName("V2 planner는 동일 ETA 후보에서 접근성 위험보다 환승 수를 먼저 반영한다")
+	void routeV2PlannerRanksFewerTransfersBeforeAccessibilityRiskForSameEtaCandidates() {
 		var risky = routeSearchResultWithAccessState("route-risky", "UNKNOWN", true);
+		var verified = transferRouteSearchResultWithAccessState("route-verified", "AVAILABLE", false);
+		var planner = new RouteV2Planner(stabilizingRouteSearchUseCase(List.of(risky, verified)), routeTimetablePort());
+
+		var plan = planner.search(routeV2Command(ConstraintMode.PREFER_STEP_FREE, MobilityType.SENIOR, 1, 1));
+
+		assertThat(plan.itineraries())
+			.extracting(RouteSearchResult::routeSearchId)
+			.containsExactly("route-risky");
+	}
+
+	@Test
+	@DisplayName("V2 planner는 동일 ETA·환승 수 후보에서 접근성 미확인 위험이 낮은 경로를 우선한다")
+	void routeV2PlannerRanksLowerAccessibilityRiskAfterTransferCountForSameEtaCandidates() {
+		var risky = transferRouteSearchResultWithAccessState("route-risky", "UNKNOWN", true);
 		var verified = transferRouteSearchResultWithAccessState("route-verified", "AVAILABLE", false);
 		var planner = new RouteV2Planner(stabilizingRouteSearchUseCase(List.of(risky, verified)), routeTimetablePort());
 


### PR DESCRIPTION
## 관련 이슈

Refs #1620

## 작업 배경

- #1620의 RAPTOR 후보 ranking 완료 조건은 earliest arrival 다음에 fewer transfers를 먼저 비교합니다.

## 작업 내용

- 시간표 RAPTOR 후보 정렬을 `ETA -> 환승 수 -> 접근성 위험` 순서로 맞췄습니다.
- 동일 ETA/동일 환승 수에서는 접근성 미확인 위험이 낮은 후보가 선택되도록 회귀 테스트를 유지했습니다.

## 검증

- 실행한 명령과 결과:
- `./gradlew test --tests com.easysubway.route.application.service.RouteSearchServiceTest.routeV2PlannerRanksFewerTransfersBeforeAccessibilityRiskForSameEtaCandidates --tests com.easysubway.route.application.service.RouteSearchServiceTest.routeV2PlannerRanksLowerAccessibilityRiskAfterTransferCountForSameEtaCandidates` success
- `./gradlew test --tests com.easysubway.route.application.service.RouteSearchServiceTest` success
- `node --test tools/routes/*.test.mjs` success (54 tests)
- `git diff --check` success

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| RAPTOR ranking regression | backend | Gradle/Jest-compatible node tests | 터미널 출력 | success |
| UI evidence | N/A | backend ranking comparator only | 증거 불필요: UI 변경 없음 | N/A |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: unchanged
- mobile versionCode: unchanged
- datapack version: unchanged
- route contract: RAPTOR candidate ranking comparator only
- realtime contract: unchanged
- backend identity: PR head SHA `2aa5567fb94d99c4c47786c75f46e4c2d56f023d`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `RouteV2Planner.rankTimetableItineraries()` comparator order

## 리스크

- 동일 ETA 후보에서 기존 접근성 우선 정렬보다 직접/저환승 경로가 먼저 선택될 수 있습니다. #1620 명시 ranking 순서에 맞춘 변경입니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 동일한 예상 소요 시간이 같은 경로들에서 우선순위 기준이 조정되어, 환승 수가 더 적은 경로가 먼저 선택되도록 개선되었습니다.
  * 환승 수까지 같은 경우에는 접근성 위험이 더 낮은 경로가 우선되도록 정렬 기준이 유지되도록 보완했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->