### PR TITLE
[Test] RAPTOR same-arrival transfer dominance (#1620)

### DIFF
--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -880,6 +880,19 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("V2 planner는 동일 도착 시각 시간표 후보에서 환승 수가 많은 경로를 제거한다")
+	void routeV2PlannerDropsMoreTransfersForSameArrivalTimetableScanCandidates() {
+		var planner = new RouteV2Planner(legacySearchMustNotBeCalled(), sameArrivalRouteTimetablePort());
+
+		var plan = planner.search(routeV2Command(ConstraintMode.PREFER_STEP_FREE, MobilityType.SENIOR, 1, 2));
+
+		assertThat(plan.statuses()).containsExactly(RouteV2Status.FOUND);
+		assertThat(plan.itineraries())
+			.extracting(RouteSearchResult::transferCount)
+			.containsExactly(0);
+	}
+
+	@Test
 	@DisplayName("V2 planner는 시간표 환승 경로에 접근과 환승 step을 보강한다")
 	void routeV2PlannerAddsAccessAndTransferStepsToTimetableTransferRoute() {
 		var planner = new RouteV2Planner(legacySearchMustNotBeCalled(), transferRouteTimetablePort());
@@ -2419,6 +2432,44 @@ class RouteSearchServiceTest {
 
 	private static LoadRouteTimetablePort transferRouteTimetablePort() {
 		return transferRouteTimetablePort(33720);
+	}
+
+	private static LoadRouteTimetablePort sameArrivalRouteTimetablePort() {
+		return () -> new LoadRouteTimetablePort.RouteTimetable(
+			List.of(new LoadRouteTimetablePort.ServiceCalendar(
+				"weekday-2026",
+				true,
+				true,
+				true,
+				true,
+				true,
+				false,
+				false,
+				LocalDate.parse("2026-07-01"),
+				LocalDate.parse("2026-12-31"),
+				"Asia/Seoul"
+			)),
+			List.of(),
+			List.of(
+				new LoadRouteTimetablePort.TransitRoute("route-direct", "line-direct", "D", "직통 노선", "도착 방면", "Asia/Seoul"),
+				new LoadRouteTimetablePort.TransitRoute("route-line-a", "line-a", "A", "A 노선", "환승 방면", "Asia/Seoul"),
+				new LoadRouteTimetablePort.TransitRoute("route-line-b", "line-b", "B", "B 노선", "도착 방면", "Asia/Seoul")
+			),
+			List.of(
+				new LoadRouteTimetablePort.TransitTrip("trip-direct", "route-direct", "weekday-2026", "도착", "0", "LOCAL", 0),
+				new LoadRouteTimetablePort.TransitTrip("trip-a", "route-line-a", "weekday-2026", "환승", "0", "LOCAL", 0),
+				new LoadRouteTimetablePort.TransitTrip("trip-b", "route-line-b", "weekday-2026", "도착", "0", "LOCAL", 0)
+			),
+			List.of(
+				new LoadRouteTimetablePort.TransitStopTime("trip-direct", 1, "station-a", "line-direct", 32760, 32760, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime("trip-direct", 2, "station-b", "line-direct", 34200, 34200, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime("trip-a", 1, "station-a", "line-a", 32760, 32760, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime("trip-a", 2, "station-transfer", "line-a", 33180, 33180, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime("trip-b", 1, "station-transfer", "line-b", 33720, 33720, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime("trip-b", 2, "station-b", "line-b", 34200, 34200, 0, 0)
+			),
+			List.of()
+		);
 	}
 
 	private static LoadRouteTimetablePort transferRouteTimetablePort(int secondDepartureSeconds) {


### PR DESCRIPTION
## 관련 이슈

Refs #1620

## 작업 배경

- #1620의 RAPTOR Pareto/ranking 조건 중 동일 도착 시각 후보에서 환승 수가 많은 경로가 제거되는 backend runtime 증거를 보강합니다.

## 작업 내용

- backend RAPTOR timetable scan test에 동일 arrival direct/transfer 후보 fixture를 추가했습니다.
- 동일 도착 시각이면 더 많은 환승 후보가 Pareto frontier에서 제거되고 direct 후보만 남는 계약을 고정했습니다.

## 검증

- 실행한 명령과 결과:
- `./gradlew test --tests com.easysubway.route.application.service.RouteSearchServiceTest.routeV2PlannerDropsMoreTransfersForSameArrivalTimetableScanCandidates` success
- `./gradlew test --tests com.easysubway.route.application.service.RouteSearchServiceTest` success
- `node --test tools/routes/*.test.mjs` success (54 tests)
- `git diff --check` success

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| RAPTOR same-arrival dominance | backend | Gradle route service test | 터미널 출력 | success |
| UI evidence | N/A | backend test only | 증거 불필요: UI 변경 없음 | N/A |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: unchanged
- mobile versionCode: unchanged
- datapack version: unchanged
- route contract: backend RAPTOR Pareto dominance regression only
- realtime contract: unchanged
- backend identity: PR head SHA `6c933fe3a07f00e475dbd4e4f156e7a946d9642c`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `routeV2PlannerDropsMoreTransfersForSameArrivalTimetableScanCandidates`

## 리스크

- production code 변경 없음. 테스트 fixture가 기존 RAPTOR dominance 계약과 어긋나면 실패합니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.