### PR TITLE
[Test] RAPTOR late-night next service regression (#1620)

### DIFF
--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -1136,6 +1136,34 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("V2 planner는 막차 이후 요청에서 다음 24시대 운행을 선택한다")
+	void routeV2PlannerSelectsNextAfterLateNightMissedTrain() {
+		var planner = new RouteV2Planner(legacySearchMustNotBeCalled(), lateNightMissedLastTrainRouteTimetablePort());
+
+		var plan = planner.search(new RouteV2SearchUseCase.SearchRouteV2Command(
+			"station-a",
+			"station-b",
+			OffsetDateTime.parse("2026-07-01T23:55:00+09:00"),
+			MobilityType.SENIOR,
+			ConstraintMode.PREFER_STEP_FREE,
+			false,
+			1,
+			3
+		));
+
+		assertThat(plan.statuses()).containsExactly(RouteV2Status.FOUND);
+		assertThat(plan.itineraries().getFirst().createdAt()).isEqualTo(LocalDate.of(2026, 7, 1).atTime(23, 55));
+		assertThat(plan.itineraries().getFirst().estimatedDurationSeconds()).isEqualTo(1980);
+		assertThat(plan.itineraries().getFirst().steps())
+			.extracting("stepType", "estimatedMinutes")
+			.containsExactly(
+				tuple("entry", 15),
+				tuple("ride", 15),
+				tuple("exit", 3)
+			);
+	}
+
+	@Test
 	@DisplayName("V2 planner는 calendar exception 제거일의 시간표를 제외한다")
 	void routeV2PlannerRemovesCalendarDateExceptionService() {
 		var planner = new RouteV2Planner(legacySearchMustNotBeCalled(), removedCalendarDateRouteTimetablePort());
@@ -2379,6 +2407,60 @@ class RouteSearchServiceTest {
 				timetable.transitFrequencies()
 			);
 		};
+	}
+
+	private static LoadRouteTimetablePort lateNightMissedLastTrainRouteTimetablePort() {
+		return () -> new LoadRouteTimetablePort.RouteTimetable(
+			List.of(new LoadRouteTimetablePort.ServiceCalendar(
+				"weekday-2026",
+				true,
+				true,
+				true,
+				true,
+				true,
+				false,
+				false,
+				LocalDate.parse("2026-07-01"),
+				LocalDate.parse("2026-07-01"),
+				"Asia/Seoul"
+			)),
+			List.of(),
+			List.of(new LoadRouteTimetablePort.TransitRoute(
+				"route-seoul-4",
+				"seoul-4",
+				"4",
+				"수도권 4호선",
+				"사당 방면",
+				"Asia/Seoul"
+			)),
+			List.of(
+				new LoadRouteTimetablePort.TransitTrip(
+					"trip-seoul-4-2350",
+					"route-seoul-4",
+					"weekday-2026",
+					"사당",
+					"0",
+					"LOCAL",
+					0
+				),
+				new LoadRouteTimetablePort.TransitTrip(
+					"trip-seoul-4-2410",
+					"route-seoul-4",
+					"weekday-2026",
+					"사당",
+					"0",
+					"LOCAL",
+					0
+				)
+			),
+			List.of(
+				new LoadRouteTimetablePort.TransitStopTime("trip-seoul-4-2350", 1, "station-a", "seoul-4", 85800, 85800, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime("trip-seoul-4-2350", 2, "station-b", "seoul-4", 86700, 86700, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime("trip-seoul-4-2410", 1, "station-a", "seoul-4", 87000, 87000, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime("trip-seoul-4-2410", 2, "station-b", "seoul-4", 87900, 87900, 0, 0)
+			),
+			List.of()
+		);
 	}
 
 	private static LoadRouteTimetablePort removedCalendarDateRouteTimetablePort() {


### PR DESCRIPTION
## 관련 이슈

Refs #1620

## 작업 배경

- RAPTOR runtime의 심야 시간축 계약을 backend test로 고정합니다.

## 작업 내용

- 23:55 요청에서 이미 지난 23:50 열차를 제외하고 24:10 운행을 선택하는 회귀 테스트를 추가했습니다.
- production code와 frontend는 변경하지 않았습니다.

## 검증

- 실행한 명령과 결과:
- `./gradlew test --tests com.easysubway.route.application.service.RouteSearchServiceTest.routeV2PlannerSelectsNextAfterLateNightMissedTrain` 성공
- `./gradlew test --tests com.easysubway.route.application.service.RouteSearchServiceTest` 성공
- `node --test tools/routes/*.test.mjs` 성공
- `git diff --check` 성공

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| backend RAPTOR test | backend | Gradle targeted test | local command output | 성공 |
| route prototype contracts | tools/routes | node test runner | local command output | 성공 |
| UI/접근성 수동 QA | 해당 없음 | frontend 변경 없음 | 해당 없음 | 해당 없음 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [ ] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [ ] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `RouteSearchServiceTest.routeV2PlannerSelectsNextAfterLateNightMissedTrain`

## 리스크

- 테스트만 추가한 변경입니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
