### PR TITLE
[Test] RAPTOR short-turn terminal regression (#1620)

### DIFF
--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -1164,6 +1164,30 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("V2 planner는 단축 운행 열차를 종착 이후 목적지로 연결하지 않는다")
+	void routeV2PlannerDoesNotRouteShortTurnTripPastTerminal() {
+		var planner = new RouteV2Planner(legacySearchMustNotBeCalled(), shortTurnRouteTimetablePort());
+
+		var plan = planner.search(new RouteV2SearchUseCase.SearchRouteV2Command(
+			"station-a",
+			"station-c",
+			OffsetDateTime.parse("2026-07-01T09:00:00+09:00"),
+			MobilityType.SENIOR,
+			ConstraintMode.PREFER_STEP_FREE,
+			false,
+			1,
+			3
+		));
+
+		assertThat(plan.statuses()).containsExactly(RouteV2Status.FOUND);
+		assertThat(plan.itineraries().getFirst().estimatedDurationSeconds()).isEqualTo(1920);
+		assertThat(plan.itineraries().getFirst().steps())
+			.filteredOn(step -> "ride".equals(step.stepType()))
+			.extracting("lineName", "fromStationId", "toStationId", "estimatedMinutes")
+			.containsExactly(tuple("테스트 단축운행", "station-a", "station-c", 17));
+	}
+
+	@Test
 	@DisplayName("V2 planner는 calendar exception 제거일의 시간표를 제외한다")
 	void routeV2PlannerRemovesCalendarDateExceptionService() {
 		var planner = new RouteV2Planner(legacySearchMustNotBeCalled(), removedCalendarDateRouteTimetablePort());
@@ -2458,6 +2482,61 @@ class RouteSearchServiceTest {
 				new LoadRouteTimetablePort.TransitStopTime("trip-seoul-4-2350", 2, "station-b", "seoul-4", 86700, 86700, 0, 0),
 				new LoadRouteTimetablePort.TransitStopTime("trip-seoul-4-2410", 1, "station-a", "seoul-4", 87000, 87000, 0, 0),
 				new LoadRouteTimetablePort.TransitStopTime("trip-seoul-4-2410", 2, "station-b", "seoul-4", 87900, 87900, 0, 0)
+			),
+			List.of()
+		);
+	}
+
+	private static LoadRouteTimetablePort shortTurnRouteTimetablePort() {
+		return () -> new LoadRouteTimetablePort.RouteTimetable(
+			List.of(new LoadRouteTimetablePort.ServiceCalendar(
+				"weekday-2026",
+				true,
+				true,
+				true,
+				true,
+				true,
+				false,
+				false,
+				LocalDate.parse("2026-07-01"),
+				LocalDate.parse("2026-12-31"),
+				"Asia/Seoul"
+			)),
+			List.of(),
+			List.of(new LoadRouteTimetablePort.TransitRoute(
+				"route-short-turn",
+				"line-short",
+				"S",
+				"테스트 단축운행",
+				"연장운행",
+				"Asia/Seoul"
+			)),
+			List.of(
+				new LoadRouteTimetablePort.TransitTrip(
+					"short-terminal-0908",
+					"route-short-turn",
+					"weekday-2026",
+					"단축종착",
+					"0",
+					"LOCAL",
+					0
+				),
+				new LoadRouteTimetablePort.TransitTrip(
+					"fullrun-0912",
+					"route-short-turn",
+					"weekday-2026",
+					"연장운행",
+					"0",
+					"LOCAL",
+					0
+				)
+			),
+			List.of(
+				new LoadRouteTimetablePort.TransitStopTime("short-terminal-0908", 1, "station-a", "line-short", 32880, 32880, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime("short-terminal-0908", 2, "station-terminal", "line-short", 33720, 33720, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime("fullrun-0912", 1, "station-a", "line-short", 33120, 33120, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime("fullrun-0912", 2, "station-terminal", "line-short", 33960, 33960, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime("fullrun-0912", 3, "station-c", "line-short", 34140, 34140, 0, 0)
 			),
 			List.of()
 		);


### PR DESCRIPTION
## 관련 이슈

Refs #1620

## 작업 배경

- RAPTOR planner core #1620의 prototype/backend fixture parity 중 short-turn terminal 회귀 계약을 backend test로 고정합니다.

## 작업 내용

- V2 planner가 단축 운행 열차를 종착 이후 목적지로 연결하지 않고, 목적지까지 운행하는 full-run trip을 선택하는 회귀 테스트를 추가했습니다.
- frontend 변경 없음.

## 검증

- 실행한 명령과 결과:
- ./backend/gradlew -p backend test --tests com.easysubway.route.application.service.RouteSearchServiceTest.routeV2PlannerDoesNotRouteShortTurnTripPastTerminal: 성공
- ./backend/gradlew -p backend test --tests com.easysubway.route.application.service.RouteSearchServiceTest: 성공
- node --test tools/routes/*.test.mjs: 성공, 54개 통과
- git diff --check: 성공

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| backend RAPTOR short-turn 회귀 | backend | Gradle 단일/전체 테스트 | 터미널 출력 | 성공 |
| route prototype fixture parity | tooling | node --test tools/routes/*.test.mjs | 터미널 출력 | 성공 |
| UI/접근성 수동 증거 | 해당 없음 | test-only backend 변경 | frontend 변경 없음 | 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [ ] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [ ] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: RouteSearchServiceTest의 short-turn terminal 회귀 fixture

## 리스크

- test-only 변경이라 runtime 영향은 없습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.