### PR TITLE
[Backend] Profile walk time calculator (#1702)

### DIFF
--- a/backend/src/main/java/com/easysubway/route/domain/ProfileWalkTimeCalculator.java
+++ b/backend/src/main/java/com/easysubway/route/domain/ProfileWalkTimeCalculator.java
@@ -1,0 +1,61 @@
+package com.easysubway.route.domain;
+
+import com.easysubway.profile.domain.MobilityType;
+import java.util.Objects;
+
+public final class ProfileWalkTimeCalculator {
+
+	private static final int STEP_FREE_FACILITY_WAIT_SECONDS = 60;
+
+	private ProfileWalkTimeCalculator() {
+	}
+
+	public static WalkTime estimateSeconds(
+		int baselineSeconds,
+		MobilityPreset preset,
+		WalkTimeSource timeSource,
+		boolean facilityWaitAlreadyIncluded
+	) {
+		if (baselineSeconds < 0) {
+			throw new IllegalArgumentException("baselineSeconds must not be negative");
+		}
+		Objects.requireNonNull(preset, "preset must not be null");
+		Objects.requireNonNull(timeSource, "timeSource must not be null");
+
+		int seconds = Math.toIntExact(Math.ceilDiv((long) baselineSeconds * preset.speedFactorPercent, 100));
+		if (preset == MobilityPreset.STEP_FREE && !facilityWaitAlreadyIncluded) {
+			seconds += STEP_FREE_FACILITY_WAIT_SECONDS;
+		}
+		return new WalkTime(seconds, timeSource, preset);
+	}
+
+	public static MobilityPreset presetFor(MobilityType mobilityType) {
+		return switch (Objects.requireNonNull(mobilityType, "mobilityType must not be null")) {
+			case SENIOR, PREGNANT, TEMPORARY_INJURY -> MobilityPreset.SLOW;
+			case LUGGAGE -> MobilityPreset.NO_STAIRS;
+			case STROLLER, WHEELCHAIR -> MobilityPreset.STEP_FREE;
+		};
+	}
+
+	public record WalkTime(int seconds, WalkTimeSource timeSource, MobilityPreset appliedPreset) {
+	}
+
+	public enum WalkTimeSource {
+		MEASURED_PATHWAY,
+		OFFICIAL_BASELINE,
+		DISTANCE_ESTIMATE
+	}
+
+	public enum MobilityPreset {
+		STANDARD(100),
+		SLOW(135),
+		NO_STAIRS(120),
+		STEP_FREE(100);
+
+		private final int speedFactorPercent;
+
+		MobilityPreset(int speedFactorPercent) {
+			this.speedFactorPercent = speedFactorPercent;
+		}
+	}
+}

--- a/backend/src/test/java/com/easysubway/route/domain/ProfileWalkTimeCalculatorTest.java
+++ b/backend/src/test/java/com/easysubway/route/domain/ProfileWalkTimeCalculatorTest.java
@@ -1,0 +1,53 @@
+package com.easysubway.route.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.easysubway.profile.domain.MobilityType;
+import com.easysubway.route.domain.ProfileWalkTimeCalculator.MobilityPreset;
+import com.easysubway.route.domain.ProfileWalkTimeCalculator.WalkTimeSource;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("보행 프로필 시간 계산기")
+class ProfileWalkTimeCalculatorTest {
+
+	@Test
+	@DisplayName("프리셋별 speedFactor와 timeSource 라벨을 적용한다")
+	void appliesPresetSpeedFactorAndTimeSource() {
+		assertThat(ProfileWalkTimeCalculator.estimateSeconds(100, MobilityPreset.STANDARD, WalkTimeSource.MEASURED_PATHWAY, false))
+			.isEqualTo(new ProfileWalkTimeCalculator.WalkTime(100, WalkTimeSource.MEASURED_PATHWAY, MobilityPreset.STANDARD));
+		assertThat(ProfileWalkTimeCalculator.estimateSeconds(100, MobilityPreset.SLOW, WalkTimeSource.OFFICIAL_BASELINE, false))
+			.isEqualTo(new ProfileWalkTimeCalculator.WalkTime(135, WalkTimeSource.OFFICIAL_BASELINE, MobilityPreset.SLOW));
+		assertThat(ProfileWalkTimeCalculator.estimateSeconds(100, MobilityPreset.NO_STAIRS, WalkTimeSource.DISTANCE_ESTIMATE, false))
+			.isEqualTo(new ProfileWalkTimeCalculator.WalkTime(120, WalkTimeSource.DISTANCE_ESTIMATE, MobilityPreset.NO_STAIRS));
+		assertThat(ProfileWalkTimeCalculator.estimateSeconds(100, MobilityPreset.STEP_FREE, WalkTimeSource.MEASURED_PATHWAY, false))
+			.isEqualTo(new ProfileWalkTimeCalculator.WalkTime(160, WalkTimeSource.MEASURED_PATHWAY, MobilityPreset.STEP_FREE));
+	}
+
+	@Test
+	@DisplayName("시설 대기 시간이 baseline에 이미 포함됐으면 중복 가산하지 않는다")
+	void doesNotDoubleCountFacilityWait() {
+		assertThat(ProfileWalkTimeCalculator.estimateSeconds(160, MobilityPreset.STEP_FREE, WalkTimeSource.MEASURED_PATHWAY, true))
+			.isEqualTo(new ProfileWalkTimeCalculator.WalkTime(160, WalkTimeSource.MEASURED_PATHWAY, MobilityPreset.STEP_FREE));
+	}
+
+	@Test
+	@DisplayName("기존 mobilityType은 기본 preset으로 매핑한다")
+	void mapsMobilityTypeToPreset() {
+		assertThat(ProfileWalkTimeCalculator.presetFor(MobilityType.SENIOR)).isEqualTo(MobilityPreset.SLOW);
+		assertThat(ProfileWalkTimeCalculator.presetFor(MobilityType.PREGNANT)).isEqualTo(MobilityPreset.SLOW);
+		assertThat(ProfileWalkTimeCalculator.presetFor(MobilityType.TEMPORARY_INJURY)).isEqualTo(MobilityPreset.SLOW);
+		assertThat(ProfileWalkTimeCalculator.presetFor(MobilityType.LUGGAGE)).isEqualTo(MobilityPreset.NO_STAIRS);
+		assertThat(ProfileWalkTimeCalculator.presetFor(MobilityType.STROLLER)).isEqualTo(MobilityPreset.STEP_FREE);
+		assertThat(ProfileWalkTimeCalculator.presetFor(MobilityType.WHEELCHAIR)).isEqualTo(MobilityPreset.STEP_FREE);
+	}
+
+	@Test
+	@DisplayName("baseline은 음수가 될 수 없다")
+	void rejectsNegativeBaseline() {
+		assertThatThrownBy(() -> ProfileWalkTimeCalculator.estimateSeconds(-1, MobilityPreset.STANDARD, WalkTimeSource.MEASURED_PATHWAY, false))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("baselineSeconds must not be negative");
+	}
+}


### PR DESCRIPTION
## 관련 이슈

Refs #1702
Refs #1620

## 작업 배경

- #1702의 보행 프로필 시간 모델을 #1620 RAPTOR 입력으로 소비할 수 있게 backend 순수 계산기부터 분리합니다.

## 작업 내용

- `ProfileWalkTimeCalculator`를 추가해 preset별 speedFactor, STEP_FREE 시설 대기 60초, timeSource 라벨, appliedPreset 결과를 계산합니다.
- 기존 `MobilityType`에서 기본 `MobilityPreset`으로 매핑하는 계약을 추가했습니다.
- frontend/mobile/API 변경 없음.

## 검증

- 실행한 명령과 결과:
- ./backend/gradlew -p backend test --tests com.easysubway.route.domain.ProfileWalkTimeCalculatorTest: 성공
- ./backend/gradlew -p backend test --tests com.easysubway.route.domain.ProfileWalkTimeCalculatorTest --tests com.easysubway.route.application.service.RouteSearchServiceTest: 성공
- node --test tools/routes/*.test.mjs: 성공, 54개 통과
- git diff --check: 성공

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| profile walk time calculator | backend | Gradle 단일 테스트 | 터미널 출력 | 성공 |
| route regression | backend/tooling | RouteSearchServiceTest + node route tests | 터미널 출력 | 성공 |
| UI/접근성 수동 증거 | 해당 없음 | backend-only 순수 계산기 | frontend/API 변경 없음 | 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [ ] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [ ] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `ProfileWalkTimeCalculator`의 speedFactor/timeSource/preset mapping 계약

## 리스크

- 아직 planner/API에 연결하지 않은 순수 계산기라 runtime 경로 영향은 없습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
