### PR TITLE
[Backend] Apply profile walk time to RAPTOR access (#1702)

### DIFF
--- a/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
@@ -11,6 +11,8 @@ import com.easysubway.route.application.port.out.LoadRouteTimetablePort.TransitS
 import com.easysubway.route.application.port.out.LoadRouteTimetablePort.TransitTrip;
 import com.easysubway.route.domain.BoardingSlackPolicy;
 import com.easysubway.route.domain.EtaSource;
+import com.easysubway.route.domain.ProfileWalkTimeCalculator;
+import com.easysubway.route.domain.ProfileWalkTimeCalculator.WalkTimeSource;
 import com.easysubway.route.domain.RouteSearchResult;
 import com.easysubway.route.domain.RouteSearchStatus;
 import com.easysubway.route.domain.RouteStep;
@@ -111,7 +113,10 @@ class RouteTimetableRaptorPlanner {
 
 	private boolean canBoard(SearchRouteV2Command command, Label label, TransitStopTime stopTime, int round) {
 		int slackSeconds = BoardingSlackPolicy.secondsFor(command.mobilityType());
-		int accessSeconds = label.boardings() > 0 ? TRANSFER_DURATION_SECONDS : ENTRY_DURATION_SECONDS;
+		int accessSeconds = profiledWalkSeconds(
+			command,
+			label.boardings() > 0 ? TRANSFER_DURATION_SECONDS : ENTRY_DURATION_SECONDS
+		);
 		return label.boardings() == round && stopTime.departureSeconds() >= label.timeSeconds() + accessSeconds + slackSeconds;
 	}
 
@@ -175,6 +180,9 @@ class RouteTimetableRaptorPlanner {
 		List<RouteStep> steps = new ArrayList<>();
 		int sequence = 1;
 		int boardingSlackSeconds = BoardingSlackPolicy.secondsFor(command.mobilityType());
+		int entryDurationSeconds = profiledWalkSeconds(command, ENTRY_DURATION_SECONDS);
+		int transferDurationSeconds = profiledWalkSeconds(command, TRANSFER_DURATION_SECONDS);
+		int exitDurationSeconds = profiledWalkSeconds(command, EXIT_DURATION_SECONDS);
 		List<RideLeg> path = label.path();
 		RideLeg firstLeg = path.getFirst();
 		RideLeg lastLeg = path.getLast();
@@ -185,7 +193,7 @@ class RouteTimetableRaptorPlanner {
 			firstLeg.from().stationId(),
 			firstLeg.lineId(),
 			firstLeg.lineName(),
-			waitMinutesBeforeBoarding(label.startSeconds(), firstLeg.from().departureSeconds(), ENTRY_DURATION_SECONDS, boardingSlackSeconds),
+			waitMinutesBeforeBoarding(label.startSeconds(), firstLeg.from().departureSeconds(), entryDurationSeconds, boardingSlackSeconds),
 			ENTRY_DISTANCE_METERS
 		));
 		sequence += 1;
@@ -200,7 +208,7 @@ class RouteTimetableRaptorPlanner {
 					leg.from().stationId(),
 					leg.lineId(),
 					leg.lineName(),
-					waitMinutesBeforeBoarding(previousLeg.to().arrivalSeconds(), leg.from().departureSeconds(), TRANSFER_DURATION_SECONDS, boardingSlackSeconds),
+					waitMinutesBeforeBoarding(previousLeg.to().arrivalSeconds(), leg.from().departureSeconds(), transferDurationSeconds, boardingSlackSeconds),
 					TRANSFER_DISTANCE_METERS
 				));
 				sequence += 1;
@@ -233,7 +241,7 @@ class RouteTimetableRaptorPlanner {
 			command.destinationStationId(),
 			lastLeg.lineId(),
 			lastLeg.lineName(),
-			EXIT_DURATION_SECONDS / 60,
+			(int) Math.ceil(exitDurationSeconds / 60.0),
 			EXIT_DISTANCE_METERS
 		));
 		return new RouteSearchResult(
@@ -253,6 +261,15 @@ class RouteTimetableRaptorPlanner {
 			List.of(),
 			LocalDateTime.of(serviceDay.date(), java.time.LocalTime.MIDNIGHT).plusSeconds(label.startSeconds())
 		);
+	}
+
+	private static int profiledWalkSeconds(SearchRouteV2Command command, int baselineSeconds) {
+		return ProfileWalkTimeCalculator.estimateSeconds(
+			baselineSeconds,
+			ProfileWalkTimeCalculator.presetFor(command.mobilityType()),
+			WalkTimeSource.OFFICIAL_BASELINE,
+			false
+		).seconds();
 	}
 
 	private static RouteStep timetableAccessStep(

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -811,7 +811,7 @@ class RouteSearchServiceTest {
 		assertThat(plan.statuses()).containsExactly(RouteV2Status.FOUND);
 		assertThat(plan.itineraries()).hasSize(1);
 		assertThat(plan.itineraries().getFirst().etaSource()).isEqualTo(EtaSource.PLANNED);
-		assertThat(plan.itineraries().getFirst().estimatedDurationSeconds()).isEqualTo(1140);
+		assertThat(plan.itineraries().getFirst().estimatedDurationSeconds()).isEqualTo(1320);
 		assertThat(plan.itineraries().getFirst().steps())
 			.extracting("stepType", "fromStationId", "toStationId", "timeSource")
 			.containsExactly(
@@ -822,9 +822,27 @@ class RouteSearchServiceTest {
 		assertThat(plan.itineraries().getFirst().steps())
 			.extracting("stepType", "estimatedMinutes")
 			.containsExactly(
-				tuple("entry", 6),
+				tuple("entry", 7),
 				tuple("ride", 10),
-				tuple("exit", 3)
+				tuple("exit", 5)
+			);
+	}
+
+	@Test
+	@DisplayName("V2 planner는 이동 프로필 보행 시간을 시간표 접근 step에 반영한다")
+	void routeV2PlannerAppliesMobilityProfileWalkTimeToTimetableAccessSteps() {
+		var planner = new RouteV2Planner(legacySearchMustNotBeCalled(), routeTimetablePort());
+
+		var plan = planner.search(routeV2Command(ConstraintMode.PREFER_STEP_FREE, MobilityType.LUGGAGE, 1, 3));
+
+		assertThat(plan.statuses()).containsExactly(RouteV2Status.FOUND);
+		assertThat(plan.itineraries().getFirst().estimatedDurationSeconds()).isEqualTo(1260);
+		assertThat(plan.itineraries().getFirst().steps())
+			.extracting("stepType", "estimatedMinutes")
+			.containsExactly(
+				tuple("entry", 7),
+				tuple("ride", 10),
+				tuple("exit", 4)
 			);
 	}
 
@@ -1109,7 +1127,7 @@ class RouteSearchServiceTest {
 		));
 
 		assertThat(plan.statuses()).containsExactly(RouteV2Status.FOUND);
-		assertThat(plan.itineraries().getFirst().estimatedDurationSeconds()).isEqualTo(1980);
+		assertThat(plan.itineraries().getFirst().estimatedDurationSeconds()).isEqualTo(2100);
 	}
 
 	@Test
@@ -1153,13 +1171,13 @@ class RouteSearchServiceTest {
 
 		assertThat(plan.statuses()).containsExactly(RouteV2Status.FOUND);
 		assertThat(plan.itineraries().getFirst().createdAt()).isEqualTo(LocalDate.of(2026, 7, 1).atTime(23, 55));
-		assertThat(plan.itineraries().getFirst().estimatedDurationSeconds()).isEqualTo(1980);
+		assertThat(plan.itineraries().getFirst().estimatedDurationSeconds()).isEqualTo(2100);
 		assertThat(plan.itineraries().getFirst().steps())
 			.extracting("stepType", "estimatedMinutes")
 			.containsExactly(
 				tuple("entry", 15),
 				tuple("ride", 15),
-				tuple("exit", 3)
+				tuple("exit", 5)
 			);
 	}
 
@@ -1180,7 +1198,7 @@ class RouteSearchServiceTest {
 		));
 
 		assertThat(plan.statuses()).containsExactly(RouteV2Status.FOUND);
-		assertThat(plan.itineraries().getFirst().estimatedDurationSeconds()).isEqualTo(1920);
+		assertThat(plan.itineraries().getFirst().estimatedDurationSeconds()).isEqualTo(2040);
 		assertThat(plan.itineraries().getFirst().steps())
 			.filteredOn(step -> "ride".equals(step.stepType()))
 			.extracting("lineName", "fromStationId", "toStationId", "estimatedMinutes")
@@ -1204,7 +1222,7 @@ class RouteSearchServiceTest {
 		));
 
 		assertThat(plan.statuses()).containsExactly(RouteV2Status.FOUND);
-		assertThat(plan.itineraries().getFirst().estimatedDurationSeconds()).isEqualTo(1740);
+		assertThat(plan.itineraries().getFirst().estimatedDurationSeconds()).isEqualTo(1920);
 		assertThat(plan.itineraries().getFirst().steps())
 			.filteredOn(step -> "ride".equals(step.stepType()))
 			.extracting("lineName", "fromStationId", "toStationId", "estimatedMinutes")
@@ -2408,8 +2426,8 @@ class RouteSearchServiceTest {
 				0
 			)),
 			List.of(
-				new LoadRouteTimetablePort.TransitStopTime("trip-seoul-4-0900", 1, "station-a", "seoul-4", 32760, 32760, 0, 0),
-				new LoadRouteTimetablePort.TransitStopTime("trip-seoul-4-0900", 2, "station-b", "seoul-4", 33360, 33360, 0, 0)
+				new LoadRouteTimetablePort.TransitStopTime("trip-seoul-4-0900", 1, "station-a", "seoul-4", 32820, 32820, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime("trip-seoul-4-0900", 2, "station-b", "seoul-4", 33420, 33420, 0, 0)
 			),
 			List.of()
 		);
@@ -2623,8 +2641,8 @@ class RouteSearchServiceTest {
 			List.of(
 				new LoadRouteTimetablePort.TransitStopTime("express-0904", 1, "station-a", "line-express", 32640, 32640, 0, 0),
 				new LoadRouteTimetablePort.TransitStopTime("express-0904", 2, "station-b", "line-express", 33180, 33180, 0, 0),
-				new LoadRouteTimetablePort.TransitStopTime("local-0905", 1, "station-a", "line-local", 32700, 32700, 0, 0),
-				new LoadRouteTimetablePort.TransitStopTime("local-0905", 2, "station-b", "line-local", 33900, 33900, 0, 0)
+				new LoadRouteTimetablePort.TransitStopTime("local-0905", 1, "station-a", "line-local", 32760, 32760, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime("local-0905", 2, "station-b", "line-local", 33960, 33960, 0, 0)
 			),
 			List.of()
 		);
@@ -2680,7 +2698,7 @@ class RouteSearchServiceTest {
 	}
 
 	private static LoadRouteTimetablePort transferRouteTimetablePort() {
-		return transferRouteTimetablePort(33720);
+		return transferRouteTimetablePort(33780);
 	}
 
 	private static LoadRouteTimetablePort sameArrivalRouteTimetablePort() {
@@ -2710,11 +2728,11 @@ class RouteSearchServiceTest {
 				new LoadRouteTimetablePort.TransitTrip("trip-b", "route-line-b", "weekday-2026", "도착", "0", "LOCAL", 0)
 			),
 			List.of(
-				new LoadRouteTimetablePort.TransitStopTime("trip-direct", 1, "station-a", "line-direct", 32760, 32760, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime("trip-direct", 1, "station-a", "line-direct", 32820, 32820, 0, 0),
 				new LoadRouteTimetablePort.TransitStopTime("trip-direct", 2, "station-b", "line-direct", 34200, 34200, 0, 0),
-				new LoadRouteTimetablePort.TransitStopTime("trip-a", 1, "station-a", "line-a", 32760, 32760, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime("trip-a", 1, "station-a", "line-a", 32820, 32820, 0, 0),
 				new LoadRouteTimetablePort.TransitStopTime("trip-a", 2, "station-transfer", "line-a", 33180, 33180, 0, 0),
-				new LoadRouteTimetablePort.TransitStopTime("trip-b", 1, "station-transfer", "line-b", 33720, 33720, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime("trip-b", 1, "station-transfer", "line-b", 33780, 33780, 0, 0),
 				new LoadRouteTimetablePort.TransitStopTime("trip-b", 2, "station-b", "line-b", 34200, 34200, 0, 0)
 			),
 			List.of()
@@ -2776,7 +2794,7 @@ class RouteSearchServiceTest {
 				)
 			),
 			List.of(
-				new LoadRouteTimetablePort.TransitStopTime("trip-line-a-0900", 1, "station-a", "line-a", 32760, 32760, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime("trip-line-a-0900", 1, "station-a", "line-a", 32820, 32820, 0, 0),
 				new LoadRouteTimetablePort.TransitStopTime("trip-line-a-0900", 2, "station-transfer", "line-a", 33180, 33180, 0, 0),
 				new LoadRouteTimetablePort.TransitStopTime("trip-line-b-0915", 1, "station-transfer", "line-b", secondDepartureSeconds, secondDepartureSeconds, 0, 0),
 				new LoadRouteTimetablePort.TransitStopTime("trip-line-b-0915", 2, "station-b", "line-b", secondDepartureSeconds + 420, secondDepartureSeconds + 420, 0, 0)


### PR DESCRIPTION
## 관련 이슈

Refs #1702
Refs #1620

## 작업 배경

- #1702의 `ProfileWalkTimeCalculator`를 #1620 RAPTOR 시간표 planner의 access/transfer/exit 시간 입력에 연결합니다.
- 프론트엔드, 모바일, API 응답 필드 확장은 범위에서 제외했습니다.

## 작업 내용

- `RouteTimetableRaptorPlanner`의 entry/transfer/exit baseline seconds를 `ProfileWalkTimeCalculator`로 변환해 boarding feasibility와 access step duration에 반영했습니다.
- RAPTOR fixture를 SENIOR=SLOW profile 시간 기준으로 갱신하고, LUGGAGE(NO_STAIRS) profile이 exit step 시간을 바꾸는 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `./backend/gradlew -p backend test --tests com.easysubway.route.application.service.RouteSearchServiceTest.routeV2PlannerAppliesMobilityProfileWalkTimeToTimetableAccessSteps` 성공
  - `./backend/gradlew -p backend test --tests com.easysubway.route.application.service.RouteSearchServiceTest` 성공
  - `./backend/gradlew -p backend test --tests com.easysubway.route.domain.ProfileWalkTimeCalculatorTest --tests com.easysubway.route.application.service.RouteSearchServiceTest` 성공
  - `./backend/gradlew -p backend test` 성공
  - `node --test tools/routes/*.test.mjs` 성공, 54 tests
  - `git diff --check` 성공

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| RAPTOR profile walk time | backend | Gradle test | terminal output | 성공 |
| route tooling regression | tools/routes | Node test runner | terminal output | 성공 |
| UI evidence | frontend/mobile | 변경 없음 | 프론트엔드/모바일 파일 미변경 | 해당 없음 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [ ] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [ ] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: `feat: apply profile walk time to RAPTOR access`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `RouteTimetableRaptorPlanner.profiledWalkSeconds()`와 `canBoard()`의 entry/transfer 적용.

## 리스크

- SENIOR/LUGGAGE 등 기존 `MobilityType` mapping이 RAPTOR 시간표 탑승 가능성과 access step duration에 반영되어 fixture ETA가 profile 기준으로 바뀝니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
