### PR TITLE
[Backend] Explicit route mobility preset (#1702)

### DIFF
--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
@@ -11,6 +11,8 @@ import com.easysubway.route.domain.BoardingSlackPolicy;
 import com.easysubway.route.domain.ConstraintMode;
 import com.easysubway.route.domain.EtaConfidence;
 import com.easysubway.route.domain.EtaSource;
+import com.easysubway.route.domain.ProfileWalkTimeCalculator;
+import com.easysubway.route.domain.ProfileWalkTimeCalculator.MobilityPreset;
 import com.easysubway.route.domain.RouteRefreshResult;
 import com.easysubway.route.domain.RouteRefreshStatus;
 import com.easysubway.route.domain.RouteSearchResult;
@@ -150,6 +152,7 @@ class RouteSearchController {
 		String departureTime,
 		@NotNull(message = "이동 유형을 선택해야 합니다.")
 		MobilityType mobilityType,
+		String mobilityPreset,
 		@NotBlank(message = "이동 제약 조건을 선택해야 합니다.")
 		String constraintMode,
 		@NotNull(message = "실시간 반영 여부를 선택해야 합니다.")
@@ -169,6 +172,7 @@ class RouteSearchController {
 				destinationStationId,
 				departureTime,
 				mobilityType,
+				parseMobilityPreset(mobilityPreset),
 				parseConstraintMode(mobilityType, constraintMode),
 				Boolean.TRUE.equals(useRealtime),
 				maxTransfers,
@@ -182,6 +186,13 @@ class RouteSearchController {
 			} catch (DateTimeParseException exception) {
 				throw new InvalidRequestException("출발 시간은 ISO offset 형식이어야 합니다.", exception);
 			}
+		}
+
+		String mobilityPresetName() {
+			MobilityPreset parsedMobilityPreset = parseMobilityPreset(mobilityPreset);
+			return (parsedMobilityPreset == null
+				? ProfileWalkTimeCalculator.presetFor(mobilityType)
+				: parsedMobilityPreset).name();
 		}
 
 	}
@@ -217,6 +228,7 @@ class RouteSearchController {
 		String destinationStationId,
 		String departureTime,
 		MobilityType mobilityType,
+		String mobilityPreset,
 		String constraintMode,
 		boolean useRealtime,
 		int maxTransfers,
@@ -236,6 +248,7 @@ class RouteSearchController {
 				request.destinationStationId(),
 				request.departureTime(),
 				request.mobilityType(),
+				request.mobilityPresetName(),
 				request.constraintMode(),
 				Boolean.TRUE.equals(request.useRealtime()),
 				request.maxTransfers(),
@@ -607,5 +620,16 @@ class RouteSearchController {
 			return ConstraintMode.defaultFor(mobilityType);
 		}
 		return parseConstraintMode(value);
+	}
+
+	private static MobilityPreset parseMobilityPreset(String value) {
+		if (value == null || value.isBlank()) {
+			return null;
+		}
+		try {
+			return MobilityPreset.valueOf(value);
+		} catch (IllegalArgumentException exception) {
+			throw new InvalidRequestException("보행 프리셋을 확인해야 합니다.", exception);
+		}
 	}
 }

--- a/backend/src/main/java/com/easysubway/route/application/port/in/RouteV2SearchUseCase.java
+++ b/backend/src/main/java/com/easysubway/route/application/port/in/RouteV2SearchUseCase.java
@@ -2,6 +2,8 @@ package com.easysubway.route.application.port.in;
 
 import com.easysubway.profile.domain.MobilityType;
 import com.easysubway.route.domain.ConstraintMode;
+import com.easysubway.route.domain.ProfileWalkTimeCalculator;
+import com.easysubway.route.domain.ProfileWalkTimeCalculator.MobilityPreset;
 import com.easysubway.route.domain.RouteSearchResult;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -16,16 +18,43 @@ public interface RouteV2SearchUseCase {
 		String destinationStationId,
 		OffsetDateTime departureTime,
 		MobilityType mobilityType,
+		MobilityPreset mobilityPreset,
 		ConstraintMode constraintMode,
 		boolean useRealtime,
 		int maxTransfers,
 		int alternativeCount
 	) {
+		public SearchRouteV2Command(
+			String originStationId,
+			String destinationStationId,
+			OffsetDateTime departureTime,
+			MobilityType mobilityType,
+			ConstraintMode constraintMode,
+			boolean useRealtime,
+			int maxTransfers,
+			int alternativeCount
+		) {
+			this(
+				originStationId,
+				destinationStationId,
+				departureTime,
+				mobilityType,
+				null,
+				constraintMode,
+				useRealtime,
+				maxTransfers,
+				alternativeCount
+			);
+		}
+
 		public SearchRouteV2Command {
 			requireText(originStationId, "originStationId");
 			requireText(destinationStationId, "destinationStationId");
 			Objects.requireNonNull(departureTime, "departureTime must not be null");
 			Objects.requireNonNull(mobilityType, "mobilityType must not be null");
+			mobilityPreset = mobilityPreset == null
+				? ProfileWalkTimeCalculator.presetFor(mobilityType)
+				: mobilityPreset;
 			Objects.requireNonNull(constraintMode, "constraintMode must not be null");
 			if (maxTransfers < 0) {
 				throw new IllegalArgumentException("maxTransfers must not be negative");

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
@@ -266,7 +266,7 @@ class RouteTimetableRaptorPlanner {
 	private static int profiledWalkSeconds(SearchRouteV2Command command, int baselineSeconds) {
 		return ProfileWalkTimeCalculator.estimateSeconds(
 			baselineSeconds,
-			ProfileWalkTimeCalculator.presetFor(command.mobilityType()),
+			command.mobilityPreset(),
 			WalkTimeSource.OFFICIAL_BASELINE,
 			false
 		).seconds();

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
@@ -1,5 +1,6 @@
 package com.easysubway.route.application.service;
 
+import com.easysubway.common.error.InvalidRequestException;
 import com.easysubway.profile.domain.MobilityType;
 import com.easysubway.route.application.port.in.RouteSearchUseCase;
 import com.easysubway.route.application.port.in.SearchRouteCommand;
@@ -11,6 +12,7 @@ import com.easysubway.route.application.port.out.LoadRouteTimetablePort;
 import com.easysubway.route.application.port.out.LoadRouteTimetablePort.RouteTimetable;
 import com.easysubway.route.domain.ConstraintMode;
 import com.easysubway.route.domain.EtaSource;
+import com.easysubway.route.domain.ProfileWalkTimeCalculator;
 import com.easysubway.route.domain.RouteNotFoundException;
 import com.easysubway.route.domain.RouteSearchResult;
 import com.easysubway.route.domain.RouteSearchStatus;
@@ -85,6 +87,7 @@ public class RouteV2Planner implements RouteV2SearchUseCase {
 				);
 				return new RouteV2Plan(timetableItineraries, statusesOf(timetableItineraries, command.useRealtime()), PLANNER_ADR);
 			}
+			rejectUnsupportedMobilityPreset(command);
 			SearchRouteCommand searchRouteCommand = toSearchRouteCommand(command);
 			List<RouteSearchResult> itineraries = routeSearchUseCase.searchRouteAlternatives(
 				searchRouteCommand,
@@ -104,6 +107,12 @@ public class RouteV2Planner implements RouteV2SearchUseCase {
 		return command.constraintMode() != ConstraintMode.STRICT_STEP_FREE
 			&& command.mobilityType() != MobilityType.WHEELCHAIR
 			&& (!command.useRealtime() || !routeSearchUseCase.supportsRealtimeOverlay());
+	}
+
+	private void rejectUnsupportedMobilityPreset(SearchRouteV2Command command) {
+		if (command.mobilityPreset() != ProfileWalkTimeCalculator.presetFor(command.mobilityType())) {
+			throw new InvalidRequestException("보행 프리셋은 RAPTOR 시간표 경로에서만 변경할 수 있습니다.");
+		}
 	}
 
 	private RouteTimetable routeTimetable() {

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
@@ -125,6 +125,7 @@ public class RouteV2Planner implements RouteV2SearchUseCase {
 			command.destinationStationId(),
 			command.departureTime(),
 			command.mobilityType(),
+			command.mobilityPreset(),
 			command.constraintMode(),
 			command.useRealtime(),
 			command.maxTransfers(),

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
@@ -578,6 +578,59 @@ class RouteSearchV2ControllerTest {
 	}
 
 	@Test
+	@DisplayName("V2 명시적 mobilityPreset은 응답 계약에 그대로 노출한다")
+	void routeSearchV2EchoesExplicitMobilityPreset() throws Exception {
+		when(routeSearchUseCase.searchRouteAlternatives(argThat(command ->
+			command.mobilityType() == MobilityType.STROLLER
+				&& command.constraintMode() == ConstraintMode.STRICT_STEP_FREE
+		), eq(1))).thenReturn(List.of(foundRouteSearch()));
+
+		mockMvc.perform(post("/api/v2/routes/search")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "originStationId": "station-sangnoksu",
+					  "destinationStationId": "station-sadang",
+					  "departureTime": "2026-06-30T09:15:00+09:00",
+					  "mobilityType": "STROLLER",
+					  "mobilityPreset": "STANDARD",
+					  "constraintMode": "STRICT_STEP_FREE",
+					  "useRealtime": true,
+					  "maxTransfers": 1,
+					  "alternativeCount": 1
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.mobilityPreset").value("STANDARD"));
+	}
+
+	@Test
+	@DisplayName("알 수 없는 V2 mobilityPreset은 search 저장 전에 JSON 400으로 거부한다")
+	void unknownRouteSearchV2MobilityPresetReturnsBadRequestBeforeSearch() throws Exception {
+		mockMvc.perform(post("/api/v2/routes/search")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "originStationId": "station-sangnoksu",
+					  "destinationStationId": "station-sadang",
+					  "departureTime": "2026-06-30T09:15:00+09:00",
+					  "mobilityType": "STROLLER",
+					  "mobilityPreset": "FAST",
+					  "constraintMode": "STRICT_STEP_FREE",
+					  "useRealtime": true,
+					  "maxTransfers": 1,
+					  "alternativeCount": 1
+					}
+					"""))
+			.andExpect(status().isBadRequest())
+			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.message").value("보행 프리셋을 확인해야 합니다."));
+
+		verifyNoInteractions(routeSearchUseCase);
+	}
+
+	@Test
 	@DisplayName("V2 allow-with-warnings는 constraintMode를 command와 응답에 반영한다")
 	void routeSearchV2AllowWithWarningsKeepsConstraintMode() throws Exception {
 		when(routeSearchUseCase.searchRouteAlternatives(argThat(command ->

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
@@ -593,7 +593,7 @@ class RouteSearchV2ControllerTest {
 					  "destinationStationId": "station-sadang",
 					  "departureTime": "2026-06-30T09:15:00+09:00",
 					  "mobilityType": "STROLLER",
-					  "mobilityPreset": "STANDARD",
+					  "mobilityPreset": "STEP_FREE",
 					  "constraintMode": "STRICT_STEP_FREE",
 					  "useRealtime": true,
 					  "maxTransfers": 1,
@@ -601,7 +601,33 @@ class RouteSearchV2ControllerTest {
 					}
 					"""))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.data.mobilityPreset").value("STANDARD"));
+			.andExpect(jsonPath("$.data.mobilityPreset").value("STEP_FREE"));
+	}
+
+	@Test
+	@DisplayName("legacy 경로로 강등되는 V2 요청은 기본값과 다른 mobilityPreset을 거부한다")
+	void nonDefaultRouteSearchV2MobilityPresetOnLegacyPathReturnsBadRequestBeforeSearch() throws Exception {
+		mockMvc.perform(post("/api/v2/routes/search")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "originStationId": "station-sangnoksu",
+					  "destinationStationId": "station-sadang",
+					  "departureTime": "2026-06-30T09:15:00+09:00",
+					  "mobilityType": "STROLLER",
+					  "mobilityPreset": "STANDARD",
+					  "constraintMode": "STRICT_STEP_FREE",
+					  "useRealtime": true,
+					  "maxTransfers": 1,
+					  "alternativeCount": 1
+					}
+					"""))
+			.andExpect(status().isBadRequest())
+			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.message").value("보행 프리셋은 RAPTOR 시간표 경로에서만 변경할 수 있습니다."));
+
+		verifyNoInteractions(routeSearchUseCase);
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -27,6 +27,7 @@ import com.easysubway.route.domain.RouteFeedback;
 import com.easysubway.route.domain.RouteNotFoundException;
 import com.easysubway.route.domain.RouteEtaOffsetBucket;
 import com.easysubway.route.domain.RouteFeedbackRating;
+import com.easysubway.route.domain.ProfileWalkTimeCalculator.MobilityPreset;
 import com.easysubway.route.domain.RouteProfileWeight;
 import com.easysubway.route.domain.RouteRefreshResult;
 import com.easysubway.route.domain.RouteRefreshStatus;
@@ -843,6 +844,30 @@ class RouteSearchServiceTest {
 				tuple("entry", 7),
 				tuple("ride", 10),
 				tuple("exit", 4)
+			);
+	}
+
+	@Test
+	@DisplayName("V2 planner는 명시적 보행 프리셋을 mobility type 기본값보다 우선한다")
+	void routeV2PlannerUsesExplicitMobilityPresetBeforeMobilityTypeMapping() {
+		var planner = new RouteV2Planner(legacySearchMustNotBeCalled(), routeTimetablePort());
+
+		var plan = planner.search(routeV2Command(
+			ConstraintMode.PREFER_STEP_FREE,
+			MobilityType.SENIOR,
+			MobilityPreset.STANDARD,
+			1,
+			3
+		));
+
+		assertThat(plan.statuses()).containsExactly(RouteV2Status.FOUND);
+		assertThat(plan.itineraries().getFirst().estimatedDurationSeconds()).isEqualTo(1200);
+		assertThat(plan.itineraries().getFirst().steps())
+			.extracting("stepType", "estimatedMinutes")
+			.containsExactly(
+				tuple("entry", 7),
+				tuple("ride", 10),
+				tuple("exit", 3)
 			);
 	}
 
@@ -2850,11 +2875,22 @@ class RouteSearchServiceTest {
 		int maxTransfers,
 		int alternativeCount
 	) {
+		return routeV2Command(constraintMode, mobilityType, null, maxTransfers, alternativeCount);
+	}
+
+	private static RouteV2SearchUseCase.SearchRouteV2Command routeV2Command(
+		ConstraintMode constraintMode,
+		MobilityType mobilityType,
+		MobilityPreset mobilityPreset,
+		int maxTransfers,
+		int alternativeCount
+	) {
 		return new RouteV2SearchUseCase.SearchRouteV2Command(
 			"station-a",
 			"station-b",
 			OffsetDateTime.parse("2026-07-01T09:00:00+09:00"),
 			mobilityType,
+			mobilityPreset,
 			constraintMode,
 			false,
 			maxTransfers,


### PR DESCRIPTION
## 관련 이슈

Refs #1702
Refs #1620

## 작업 배경

- Route V2 RAPTOR 입력에서 mobilityType 기본 매핑 외에 명시적 보행 프리셋을 받을 수 있어야 합니다.
- 프론트엔드/mobile 변경 없이 backend API와 planner command 경계만 확장합니다.

## 작업 내용

- `SearchRouteV2Command`에 optional `mobilityPreset`을 추가하고 없으면 기존 `mobilityType` mapping을 사용합니다.
- RAPTOR access/transfer/egress walk seconds 계산이 명시적 preset을 우선 사용하도록 변경했습니다.
- `POST /api/v2/routes/search` request/response에 `mobilityPreset`을 추가하고 알 수 없는 값은 JSON 400으로 거부합니다.

## 검증

- 실행한 명령과 결과:
  - `./backend/gradlew -p backend test --tests com.easysubway.route.adapter.in.web.RouteSearchV2ControllerTest.routeSearchV2EchoesExplicitMobilityPreset --tests com.easysubway.route.adapter.in.web.RouteSearchV2ControllerTest.unknownRouteSearchV2MobilityPresetReturnsBadRequestBeforeSearch` 성공
  - `./backend/gradlew -p backend test --tests com.easysubway.route.domain.ProfileWalkTimeCalculatorTest --tests com.easysubway.route.application.service.RouteSearchServiceTest --tests com.easysubway.route.adapter.in.web.RouteSearchV2ControllerTest` 성공
  - `node --test tools/routes/*.test.mjs` 성공
  - `git diff --check` 성공
  - `./backend/gradlew -p backend test` 성공

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| V2 API mobilityPreset 계약 | backend | MockMvc 테스트 | `RouteSearchV2ControllerTest` | 성공 |
| RAPTOR preset 우선순위 | backend | planner service 테스트 | `RouteSearchServiceTest` | 성공 |
| 회귀 | backend/tools | Gradle test, route tool tests | 로컬 터미널 출력 | 성공 |
| UI/접근성 수동 QA | mobile | 변경 없음 | 프론트엔드/mobile 미수정 | 해당 없음 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: V2 request/response `mobilityPreset` 추가
- realtime contract: 변경 없음
- backend identity: route V2 explicit mobility preset

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `RouteV2SearchUseCase.SearchRouteV2Command`, `RouteTimetableRaptorPlanner.profiledWalkSeconds`, `RouteSearchController.RouteSearchV2Request`

## 리스크

- 응답에 `mobilityPreset` 필드가 추가됩니다. 기존 요청은 mobilityType mapping으로 유지됩니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 경로 검색 V2에서 보행 프리셋을 직접 지정할 수 있게 되었습니다.
  * 요청에 프리셋이 없으면 기본값을 자동으로 적용하며, 응답에도 선택된 프리셋이 표시됩니다.

* **버그 수정**
  * 지원되지 않는 보행 프리셋은 즉시 거부되도록 개선되었습니다.
  * 시간표 기반 경로에서만 프리셋 변경이 가능하도록 검증이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->