### PR TITLE
[Backend] Route V2 leg walk profile contract (#1702)

### DIFF
--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
@@ -257,7 +257,7 @@ class RouteSearchController {
 					.map(Enum::name)
 					.toList(),
 				plan.itineraries().stream()
-					.map(result -> ItineraryDto.from(result, departureTime))
+					.map(result -> ItineraryDto.from(result, departureTime, request.mobilityPresetName()))
 					.toList()
 			);
 		}
@@ -278,8 +278,8 @@ class RouteSearchController {
 		boolean commercialEtaEligible
 	) {
 
-		private static ItineraryDto from(RouteSearchResult result, OffsetDateTime departureTime) {
-			List<LegDto> legs = LegDto.fromSteps(result.steps(), departureTime, result.mobilityType());
+		private static ItineraryDto from(RouteSearchResult result, OffsetDateTime departureTime, String mobilityPreset) {
+			List<LegDto> legs = LegDto.fromSteps(result.steps(), departureTime, result.mobilityType(), mobilityPreset);
 			OffsetDateTime plannedArrivalTime = legs.isEmpty()
 				? departureTime
 				: OffsetDateTime.parse(legs.get(legs.size() - 1).plannedArrivalTime());
@@ -486,6 +486,9 @@ class RouteSearchController {
 		int distanceMeters,
 		String etaSource,
 		String confidence,
+		int walkSeconds,
+		String timeSource,
+		String appliedPreset,
 		List<String> reasonCodes,
 		String providerSnapshotId,
 		String providerObservedAt,
@@ -497,7 +500,8 @@ class RouteSearchController {
 		private static List<LegDto> fromSteps(
 			List<RouteStep> steps,
 			OffsetDateTime departureTime,
-			MobilityType mobilityType
+			MobilityType mobilityType,
+			String mobilityPreset
 		) {
 			List<LegDto> legs = new ArrayList<>();
 			OffsetDateTime cursor = departureTime;
@@ -507,7 +511,7 @@ class RouteSearchController {
 				int slackSeconds = slackSeconds(step, legType, mobilityType);
 				OffsetDateTime plannedDepartureTime = cursor.plusSeconds(slackSeconds);
 				OffsetDateTime plannedArrivalTime = plannedDepartureTime.plusSeconds(durationSeconds);
-				legs.add(from(step, legType, plannedDepartureTime, plannedArrivalTime, durationSeconds, slackSeconds));
+				legs.add(from(step, legType, plannedDepartureTime, plannedArrivalTime, durationSeconds, slackSeconds, mobilityPreset));
 				cursor = plannedArrivalTime;
 			}
 			return List.copyOf(legs);
@@ -519,8 +523,10 @@ class RouteSearchController {
 			OffsetDateTime departureTime,
 			OffsetDateTime plannedArrivalTime,
 			int durationSeconds,
-			int slackSeconds
+			int slackSeconds,
+			String mobilityPreset
 		) {
+			int walkSeconds = "RIDE".equals(legType) ? 0 : durationSeconds;
 			return new LegDto(
 				legType,
 				step.fromStationId(),
@@ -540,6 +546,9 @@ class RouteSearchController {
 				Math.max(0, step.distanceMeters()),
 				etaSourceOf(step).name(),
 				etaConfidenceOf(step),
+				walkSeconds,
+				step.timeSource(),
+				walkSeconds > 0 ? mobilityPreset : "",
 				step.reasonCodes(),
 				step.providerSnapshotId(),
 				step.providerObservedAt(),

--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
@@ -526,7 +526,8 @@ class RouteSearchController {
 			int slackSeconds,
 			String mobilityPreset
 		) {
-			int walkSeconds = "RIDE".equals(legType) || "TIMETABLE".equals(step.distanceSource()) ? 0 : durationSeconds;
+			boolean hasTimetableWait = "TIMETABLE".equals(step.distanceSource()) && !"exit".equals(step.stepType());
+			int walkSeconds = "RIDE".equals(legType) || hasTimetableWait ? 0 : durationSeconds;
 			return new LegDto(
 				legType,
 				step.fromStationId(),

--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
@@ -526,7 +526,7 @@ class RouteSearchController {
 			int slackSeconds,
 			String mobilityPreset
 		) {
-			int walkSeconds = "RIDE".equals(legType) ? 0 : durationSeconds;
+			int walkSeconds = "RIDE".equals(legType) || "TIMETABLE".equals(step.distanceSource()) ? 0 : durationSeconds;
 			return new LegDto(
 				legType,
 				step.fromStationId(),

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
@@ -636,6 +636,34 @@ class RouteSearchV2ControllerTest {
 	}
 
 	@Test
+	@DisplayName("V2 TIMETABLE egress leg는 순수 보행 시간을 walkSeconds로 노출한다")
+	void routeSearchV2ExposesTimetableEgressWalkSeconds() throws Exception {
+		when(routeSearchUseCase.searchRouteAlternatives(argThat(command ->
+			command.mobilityType() == MobilityType.STROLLER
+				&& command.constraintMode() == ConstraintMode.STRICT_STEP_FREE
+		), eq(1))).thenReturn(List.of(foundTimetableEgressRouteSearch()));
+
+		mockMvc.perform(post("/api/v2/routes/search")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "originStationId": "station-sangnoksu",
+					  "destinationStationId": "station-sadang",
+					  "departureTime": "2026-06-30T09:15:00+09:00",
+					  "mobilityType": "STROLLER",
+					  "mobilityPreset": "STEP_FREE",
+					  "constraintMode": "STRICT_STEP_FREE",
+					  "useRealtime": true,
+					  "maxTransfers": 1,
+					  "alternativeCount": 1
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.itineraries[0].legs[0].walkSeconds").value(180))
+			.andExpect(jsonPath("$.data.itineraries[0].legs[0].appliedPreset").value("STEP_FREE"));
+	}
+
+	@Test
 	@DisplayName("legacy 경로로 강등되는 V2 요청은 기본값과 다른 mobilityPreset을 거부한다")
 	void nonDefaultRouteSearchV2MobilityPresetOnLegacyPathReturnsBadRequestBeforeSearch() throws Exception {
 		mockMvc.perform(post("/api/v2/routes/search")
@@ -850,6 +878,42 @@ class RouteSearchV2ControllerTest {
 				"station-sangnoksu",
 				9,
 				180,
+				false,
+				"UNKNOWN",
+				true,
+				"PLANNED",
+				"TIMETABLE",
+				"시간표"
+			)),
+			List.of(),
+			List.of(),
+			LocalDateTime.of(2026, 6, 30, 9, 0)
+		);
+	}
+
+	private RouteSearchResult foundTimetableEgressRouteSearch() {
+		return new RouteSearchResult(
+			"route-search-1",
+			"station-sangnoksu",
+			"상록수",
+			"station-sadang",
+			"사당",
+			MobilityType.STROLLER,
+			RouteSearchStatus.FOUND,
+			"line-4",
+			"수도권 4호선",
+			18,
+			List.of(new RouteStep(
+				1,
+				"exit",
+				"사당역 출구 이동",
+				"시간표 경로의 승하차 접근성과 환승 동선을 확인합니다.",
+				"line-4",
+				"수도권 4호선",
+				"station-sadang",
+				"station-sadang",
+				3,
+				120,
 				false,
 				"UNKNOWN",
 				true,

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
@@ -608,6 +608,34 @@ class RouteSearchV2ControllerTest {
 	}
 
 	@Test
+	@DisplayName("V2 TIMETABLE 보행 leg는 대기 포함 시간을 walkSeconds로 노출하지 않는다")
+	void routeSearchV2DoesNotExposeTimetableWaitAsWalkSeconds() throws Exception {
+		when(routeSearchUseCase.searchRouteAlternatives(argThat(command ->
+			command.mobilityType() == MobilityType.STROLLER
+				&& command.constraintMode() == ConstraintMode.STRICT_STEP_FREE
+		), eq(1))).thenReturn(List.of(foundTimetableRouteSearch()));
+
+		mockMvc.perform(post("/api/v2/routes/search")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "originStationId": "station-sangnoksu",
+					  "destinationStationId": "station-sadang",
+					  "departureTime": "2026-06-30T09:15:00+09:00",
+					  "mobilityType": "STROLLER",
+					  "mobilityPreset": "STEP_FREE",
+					  "constraintMode": "STRICT_STEP_FREE",
+					  "useRealtime": true,
+					  "maxTransfers": 1,
+					  "alternativeCount": 1
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.itineraries[0].legs[0].walkSeconds").value(0))
+			.andExpect(jsonPath("$.data.itineraries[0].legs[0].appliedPreset").value(""));
+	}
+
+	@Test
 	@DisplayName("legacy 경로로 강등되는 V2 요청은 기본값과 다른 mobilityPreset을 거부한다")
 	void nonDefaultRouteSearchV2MobilityPresetOnLegacyPathReturnsBadRequestBeforeSearch() throws Exception {
 		mockMvc.perform(post("/api/v2/routes/search")
@@ -794,6 +822,42 @@ class RouteSearchV2ControllerTest {
 				"LOW"
 			)),
 			List.of(new RouteWarning(RouteWarningCode.STALE_ACCESSIBILITY_DATA)),
+			List.of(),
+			LocalDateTime.of(2026, 6, 30, 9, 0)
+		);
+	}
+
+	private RouteSearchResult foundTimetableRouteSearch() {
+		return new RouteSearchResult(
+			"route-search-1",
+			"station-sangnoksu",
+			"상록수",
+			"station-sadang",
+			"사당",
+			MobilityType.STROLLER,
+			RouteSearchStatus.FOUND,
+			"line-4",
+			"수도권 4호선",
+			18,
+			List.of(new RouteStep(
+				1,
+				"entry",
+				"상록수역 진입",
+				"시간표 경로의 승하차 접근성과 환승 동선을 확인합니다.",
+				"line-4",
+				"수도권 4호선",
+				"station-sangnoksu",
+				"station-sangnoksu",
+				9,
+				180,
+				false,
+				"UNKNOWN",
+				true,
+				"PLANNED",
+				"TIMETABLE",
+				"시간표"
+			)),
+			List.of(),
 			List.of(),
 			LocalDateTime.of(2026, 6, 30, 9, 0)
 		);

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
@@ -601,7 +601,10 @@ class RouteSearchV2ControllerTest {
 					}
 					"""))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.data.mobilityPreset").value("STEP_FREE"));
+			.andExpect(jsonPath("$.data.mobilityPreset").value("STEP_FREE"))
+			.andExpect(jsonPath("$.data.itineraries[0].legs[0].walkSeconds").value(240))
+			.andExpect(jsonPath("$.data.itineraries[0].legs[0].timeSource").value("STATIC_BACKEND_V1"))
+			.andExpect(jsonPath("$.data.itineraries[0].legs[0].appliedPreset").value("STEP_FREE"));
 	}
 
 	@Test


### PR DESCRIPTION
## 관련 이슈

Refs #1702
Refs #1620

## 작업 배경

- Route V2 응답이 top-level `mobilityPreset`만 노출하고 leg별 보행 시간/preset 근거는 노출하지 않았습니다.
- 프론트엔드/mobile 변경 없이 backend response contract만 확장합니다.

## 작업 내용

- V2 leg 응답에 `walkSeconds`, `timeSource`, `appliedPreset`을 추가했습니다.
- 보행 leg는 duration 기반 walk seconds와 요청에서 선택된 preset을 노출합니다.
- ride leg는 `walkSeconds=0`으로 유지합니다.

## 검증

- 실행한 명령과 결과:
  - `./backend/gradlew -p backend test --tests com.easysubway.route.adapter.in.web.RouteSearchV2ControllerTest.routeSearchV2EchoesExplicitMobilityPreset` 실패 확인 후 구현
  - `./backend/gradlew -p backend test --tests com.easysubway.route.adapter.in.web.RouteSearchV2ControllerTest.routeSearchV2EchoesExplicitMobilityPreset` 성공
  - `./backend/gradlew -p backend test --tests com.easysubway.route.adapter.in.web.RouteSearchV2ControllerTest` 성공
  - `node --test tools/routes/*.test.mjs` 성공
  - `git diff --check` 성공
  - `./backend/gradlew -p backend test` 성공

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| V2 leg profile contract | backend | MockMvc 테스트 | `RouteSearchV2ControllerTest.routeSearchV2EchoesExplicitMobilityPreset` | 성공 |
| 회귀 | backend/tools | Gradle test, route tool tests | 로컬 터미널 출력 | 성공 |
| UI/접근성 수동 QA | mobile | 변경 없음 | 프론트엔드/mobile 미수정 | 해당 없음 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: V2 leg `walkSeconds`, `timeSource`, `appliedPreset` 추가
- realtime contract: 변경 없음
- backend identity: route V2 leg walk profile contract

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `RouteSearchController.LegDto`, `RouteSearchV2ControllerTest.routeSearchV2EchoesExplicitMobilityPreset`

## 리스크

- 응답 leg에 optional 성격의 필드가 추가됩니다. 기존 mobile parser는 알 수 없는 JSON field를 무시합니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.