### PR TITLE
[Backend] Apply profile walk time to route access legs (#1702)

### DIFF
--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -1854,10 +1854,11 @@ record AccessPath(
 		String stationId,
 		String fromLineId,
 		String toLineId,
-		boolean includesStairs
+		boolean includesStairs,
+		RouteProfileWeight profileWeight
 	) {
 		return new AccessPath(
-			6,
+			profileWeight.profiledMinutes(360),
 			260,
 			includesStairs,
 			includesStairs ? "STAIR_ONLY" : "UNKNOWN",
@@ -1899,7 +1900,7 @@ final class AccessGraphRouter {
 		if (profileWeight.blocksStairOnlyAccess() && includesStairs) {
 			return AccessPath.blocked(List.of("STAIR_ONLY_ACCESS"));
 		}
-		return AccessPath.found(4, 180, includesStairs, stationId, lineId, "entry");
+		return AccessPath.found(profileWeight.profiledMinutes(240), 180, includesStairs, stationId, lineId, "entry");
 	}
 
 	AccessPath egressAccess(
@@ -1911,7 +1912,7 @@ final class AccessGraphRouter {
 		if (profileWeight.blocksStairOnlyAccess() && includesStairs) {
 			return AccessPath.blocked(List.of("STAIR_ONLY_ACCESS"));
 		}
-		return AccessPath.found(3, 120, includesStairs, stationId, lineId, "egress");
+		return AccessPath.found(profileWeight.profiledMinutes(180), 120, includesStairs, stationId, lineId, "egress");
 	}
 
 	AccessPath generatedConnector(String edgeId, RouteProfileWeight profileWeight) {
@@ -1934,7 +1935,7 @@ final class StationPathwayRouter {
 		if (profileWeight.blocksStairOnlyAccess() && includesStairs) {
 			return AccessPath.blocked(List.of("STAIR_ONLY_ACCESS"));
 		}
-		return AccessPath.transfer(stationId, fromLineId, toLineId, includesStairs);
+		return AccessPath.transfer(stationId, fromLineId, toLineId, includesStairs, profileWeight);
 	}
 }
 

--- a/backend/src/main/java/com/easysubway/route/domain/RouteProfileWeight.java
+++ b/backend/src/main/java/com/easysubway/route/domain/RouteProfileWeight.java
@@ -9,10 +9,12 @@ public record RouteProfileWeight(
 	int transferPenalty,
 	boolean blocksStairOnlyAccess,
 	String entryGuidance,
-	String exitGuidance
+	String exitGuidance,
+	ProfileWalkTimeCalculator.MobilityPreset mobilityPreset
 ) {
 
 	public static RouteProfileWeight from(MobilityType mobilityType) {
+		var preset = ProfileWalkTimeCalculator.presetFor(mobilityType);
 		// 점수는 시간 예측이 아니라 같은 경로 후보를 비교하기 위한 접근 부담 비용이다.
 		return switch (mobilityType) {
 			case SENIOR -> new RouteProfileWeight(
@@ -22,7 +24,8 @@ public record RouteProfileWeight(
 				12,
 				false,
 				"계단을 피하고 이동 거리가 짧은 출구를 먼저 확인합니다.",
-				"도착역에서 계단을 피할 수 있는 출구와 짧은 동선을 확인합니다."
+				"도착역에서 계단을 피할 수 있는 출구와 짧은 동선을 확인합니다.",
+				preset
 			);
 			case STROLLER -> new RouteProfileWeight(
 				20,
@@ -31,7 +34,8 @@ public record RouteProfileWeight(
 				15,
 				false,
 				"엘리베이터와 넓은 통로가 있는 출구를 먼저 확인합니다.",
-				"도착역에서 엘리베이터와 넓은 통로가 있는 출구를 확인합니다."
+				"도착역에서 엘리베이터와 넓은 통로가 있는 출구를 확인합니다.",
+				preset
 			);
 			case WHEELCHAIR -> new RouteProfileWeight(
 				24,
@@ -40,7 +44,8 @@ public record RouteProfileWeight(
 				18,
 				true,
 				"엘리베이터, 리프트, 경사로 연결을 먼저 확인합니다.",
-				"도착역에서 엘리베이터, 리프트, 경사로 연결 출구를 확인합니다."
+				"도착역에서 엘리베이터, 리프트, 경사로 연결 출구를 확인합니다.",
+				preset
 			);
 			case PREGNANT -> new RouteProfileWeight(
 				17,
@@ -49,7 +54,8 @@ public record RouteProfileWeight(
 				14,
 				false,
 				"엘리베이터와 짧은 이동 동선을 먼저 확인합니다.",
-				"도착역에서 짧게 걸을 수 있는 엘리베이터 출구를 확인합니다."
+				"도착역에서 짧게 걸을 수 있는 엘리베이터 출구를 확인합니다.",
+				preset
 			);
 			case TEMPORARY_INJURY -> new RouteProfileWeight(
 				22,
@@ -58,7 +64,8 @@ public record RouteProfileWeight(
 				17,
 				false,
 				"계단을 피하고 쉬어 갈 수 있는 동선을 먼저 확인합니다.",
-				"도착역에서 계단을 피하고 천천히 이동할 수 있는 출구를 확인합니다."
+				"도착역에서 계단을 피하고 천천히 이동할 수 있는 출구를 확인합니다.",
+				preset
 			);
 			case LUGGAGE -> new RouteProfileWeight(
 				16,
@@ -67,7 +74,8 @@ public record RouteProfileWeight(
 				10,
 				false,
 				"엘리베이터와 넓은 출구 동선을 먼저 확인합니다.",
-				"도착역에서 큰 짐을 들고 지나가기 쉬운 출구를 확인합니다."
+				"도착역에서 큰 짐을 들고 지나가기 쉬운 출구를 확인합니다.",
+				preset
 			);
 		};
 	}
@@ -81,7 +89,18 @@ public record RouteProfileWeight(
 			base.transferPenalty(),
 			constraintMode == ConstraintMode.STRICT_STEP_FREE,
 			base.entryGuidance(),
-			base.exitGuidance()
+			base.exitGuidance(),
+			base.mobilityPreset()
 		);
+	}
+
+	public int profiledMinutes(int baselineSeconds) {
+		int seconds = ProfileWalkTimeCalculator.estimateSeconds(
+			baselineSeconds,
+			mobilityPreset,
+			ProfileWalkTimeCalculator.WalkTimeSource.MEASURED_PATHWAY,
+			false
+		).seconds();
+		return Math.toIntExact(Math.ceilDiv(seconds, 60));
 	}
 }

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -113,7 +113,7 @@ class RouteSearchServiceTest {
 		assertThat(result.steps())
 			.extracting("stepType")
 			.containsExactly("entry", "ride", "exit");
-		assertThat(result.steps().get(0).estimatedMinutes()).isEqualTo(4);
+		assertThat(result.steps().get(0).estimatedMinutes()).isEqualTo(5);
 		assertThat(result.steps().get(0).distanceMeters()).isEqualTo(180);
 		assertThat(result.steps().get(0).includesStairs()).isFalse();
 		assertThat(result.steps().get(0).stairAccessState()).isEqualTo("UNKNOWN");
@@ -405,7 +405,7 @@ class RouteSearchServiceTest {
 			);
 		assertThat(result.steps().get(2).description())
 			.isEqualTo("환승역의 엘리베이터와 계단 없는 연결 동선을 먼저 확인합니다.");
-		assertThat(result.steps().get(2).estimatedMinutes()).isEqualTo(6);
+		assertThat(result.steps().get(2).estimatedMinutes()).isEqualTo(9);
 		assertThat(result.steps().get(2).distanceMeters()).isEqualTo(260);
 		assertThat(result.steps().get(2).requiresAccessibilityCheck()).isTrue();
 	}
@@ -577,16 +577,16 @@ class RouteSearchServiceTest {
 		var egress = accessRouter.egressAccess("station-b", "line-b", false, profileWeight);
 		var ready = new TransferAccessResolver().resolve(transfer, 600, 1000);
 
-		assertThat(entry.estimatedMinutes()).isEqualTo(4);
-		assertThat(transfer.estimatedMinutes()).isEqualTo(6);
-		assertThat(egress.estimatedMinutes()).isEqualTo(3);
+		assertThat(entry.estimatedMinutes()).isEqualTo(5);
+		assertThat(transfer.estimatedMinutes()).isEqualTo(7);
+		assertThat(egress.estimatedMinutes()).isEqualTo(4);
 		assertThat(transfer.evidenceSources()).containsExactly(
 			"station:station-x",
 			"transfer:line-a:line-b",
 			"access:transfer"
 		);
-		assertThat(ready.transferReadyAtMinutes()).isEqualTo(606);
-		assertThat(ready.slackMinutes()).isEqualTo(394);
+		assertThat(ready.transferReadyAtMinutes()).isEqualTo(607);
+		assertThat(ready.slackMinutes()).isEqualTo(393);
 		assertThat(ready.feasible()).isTrue();
 		assertThat(accessRouter.entryAccess("station-a", "line-a", true, profileWeight).noPathReason())
 			.isEqualTo(AccessNoPathReason.BLOCKED);
@@ -595,6 +595,21 @@ class RouteSearchServiceTest {
 		assertThat(AccessPath.unsupported(List.of("STRICT_EVIDENCE_UNSUPPORTED")).noPathReason())
 			.isEqualTo(AccessNoPathReason.UNSUPPORTED);
 		assertThat(AccessPath.noData().noPathReason()).isEqualTo(AccessNoPathReason.NO_DATA);
+	}
+
+	@Test
+	@DisplayName("access graph 시간은 mobility type 기본 보행 프리셋을 반영한다")
+	void accessGraphTimesApplyMobilityProfilePreset() {
+		var profileWeight = RouteProfileWeight.from(MobilityType.LUGGAGE);
+		var accessRouter = new AccessGraphRouter();
+		var stationRouter = new StationPathwayRouter();
+
+		assertThat(accessRouter.entryAccess("station-a", "line-a", false, profileWeight).estimatedMinutes())
+			.isEqualTo(5);
+		assertThat(stationRouter.transferPath("station-x", "line-a", "line-b", false, profileWeight).estimatedMinutes())
+			.isEqualTo(8);
+		assertThat(accessRouter.egressAccess("station-b", "line-b", false, profileWeight).estimatedMinutes())
+			.isEqualTo(4);
 	}
 
 	@Test
@@ -1362,7 +1377,7 @@ class RouteSearchServiceTest {
 
 		assertThat(resolver.callCount()).isEqualTo(1);
 		assertThat(resolver.lastQuery().stationId()).isEqualTo("station-a");
-		assertThat(resolver.lastQuery().readyAt()).isEqualTo(Instant.parse("2026-07-01T00:05:30Z"));
+		assertThat(resolver.lastQuery().readyAt()).isEqualTo(Instant.parse("2026-07-01T00:07:30Z"));
 		assertThat(plan.itineraries().getFirst().etaSource()).isEqualTo(EtaSource.MIXED);
 		assertThat(plan.itineraries().getFirst().steps())
 			.filteredOn(step -> "ride".equals(step.stepType()))
@@ -1374,8 +1389,8 @@ class RouteSearchServiceTest {
 			.satisfies(step -> {
 				assertThat(step.reasonCodes()).containsExactly("MATCHED_REALTIME");
 				assertThat(step.providerSnapshotId()).isEqualTo("test-realtime-snapshot");
-				assertThat(step.providerObservedAt()).isEqualTo("2026-07-01T00:05:00Z");
-				assertThat(step.gatewayReceivedAt()).isEqualTo("2026-07-01T00:05:00Z");
+				assertThat(step.providerObservedAt()).isEqualTo("2026-07-01T00:07:00Z");
+				assertThat(step.gatewayReceivedAt()).isEqualTo("2026-07-01T00:07:00Z");
 				assertThat(step.servedAt()).isEqualTo("2026-06-13T09:00:00Z");
 			});
 		assertThat(plan.statuses()).containsExactly(RouteV2Status.FOUND);
@@ -1410,8 +1425,8 @@ class RouteSearchServiceTest {
 		assertThat(resolver.queries())
 			.extracting(RealtimeArrivalResolver.Query::readyAt)
 			.containsExactly(
-				Instant.parse("2026-07-01T00:05:30Z"),
-				Instant.parse("2026-07-01T00:19:00Z")
+				Instant.parse("2026-07-01T00:07:30Z"),
+				Instant.parse("2026-07-01T00:24:00Z")
 			);
 		assertThat(plan.itineraries().getFirst().steps())
 			.filteredOn(step -> "ride".equals(step.stepType()))
@@ -1452,8 +1467,8 @@ class RouteSearchServiceTest {
 		assertThat(resolver.queries())
 			.extracting(RealtimeArrivalResolver.Query::readyAt)
 			.containsExactly(
-				Instant.parse("2026-07-01T00:05:30Z"),
-				Instant.parse("2026-07-01T00:17:00Z")
+				Instant.parse("2026-07-01T00:07:30Z"),
+				Instant.parse("2026-07-01T00:22:00Z")
 			);
 		assertThat(plan.itineraries().getFirst().steps())
 			.filteredOn(step -> "ride".equals(step.stepType()))


### PR DESCRIPTION
## 관련 이슈

Refs #1702
Refs #1620

## 작업 배경

- #1702의 보행 프로필 시간 모델을 legacy route access/transfer/egress 시간 계산에도 연결합니다.

## 작업 내용

- `RouteProfileWeight`가 mobility type 기본 보행 preset을 보관합니다.
- access graph entry/transfer/egress baseline 시간을 `ProfileWalkTimeCalculator`로 환산합니다.
- profile 적용으로 바뀐 realtime readyAt/route step 시간 기대값을 갱신했습니다.

## 검증

- 실행한 명령과 결과:
  - `./backend/gradlew -p backend test --tests com.easysubway.route.application.service.RouteSearchServiceTest.accessGraphTimesApplyMobilityProfilePreset` 실패 확인 후 성공
  - `./backend/gradlew -p backend test --tests com.easysubway.route.application.service.RouteSearchServiceTest` 성공
  - `node --test tools/routes/*.test.mjs` 성공
  - `git diff --check` 성공
  - `./backend/gradlew -p backend test` 성공

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| backend profile walk time | backend | Gradle/Jest 로컬 테스트 | 증거 불필요 사유: backend 계산 로직과 자동화 테스트만 변경 | 성공 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [ ] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [ ] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `RouteProfileWeight.profiledMinutes`, `AccessGraphRouter`, `StationPathwayRouter`

## 리스크

- legacy route ETA가 mobility type별 보행 preset을 반영하면서 기존 상수 기반 ETA보다 늦어질 수 있습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
