### PR TITLE
[Backend] Expose route walk time source labels (#1702)

### DIFF
--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
@@ -13,6 +13,7 @@ import com.easysubway.route.domain.EtaConfidence;
 import com.easysubway.route.domain.EtaSource;
 import com.easysubway.route.domain.ProfileWalkTimeCalculator;
 import com.easysubway.route.domain.ProfileWalkTimeCalculator.MobilityPreset;
+import com.easysubway.route.domain.ProfileWalkTimeCalculator.WalkTimeSource;
 import com.easysubway.route.domain.RouteRefreshResult;
 import com.easysubway.route.domain.RouteRefreshStatus;
 import com.easysubway.route.domain.RouteSearchResult;
@@ -548,7 +549,7 @@ class RouteSearchController {
 				etaSourceOf(step).name(),
 				etaConfidenceOf(step),
 				walkSeconds,
-				step.timeSource(),
+				timeSource(step, legType, walkSeconds),
 				walkSeconds > 0 ? mobilityPreset : "",
 				step.reasonCodes(),
 				step.providerSnapshotId(),
@@ -567,6 +568,16 @@ class RouteSearchController {
 				return step.walkSeconds();
 			}
 			return hasTimetableWait ? 0 : durationSeconds;
+		}
+
+		private static String timeSource(RouteStep step, String legType, int walkSeconds) {
+			if ("RIDE".equals(legType) || walkSeconds <= 0) {
+				return step.timeSource();
+			}
+			if ("TIMETABLE".equals(step.distanceSource())) {
+				return WalkTimeSource.OFFICIAL_BASELINE.name();
+			}
+			return WalkTimeSource.MEASURED_PATHWAY.name();
 		}
 
 		private static int slackSeconds(String legType, MobilityType mobilityType) {

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
@@ -603,7 +603,7 @@ class RouteSearchV2ControllerTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.mobilityPreset").value("STEP_FREE"))
 			.andExpect(jsonPath("$.data.itineraries[0].legs[0].walkSeconds").value(240))
-			.andExpect(jsonPath("$.data.itineraries[0].legs[0].timeSource").value("STATIC_BACKEND_V1"))
+			.andExpect(jsonPath("$.data.itineraries[0].legs[0].timeSource").value("MEASURED_PATHWAY"))
 			.andExpect(jsonPath("$.data.itineraries[0].legs[0].appliedPreset").value("STEP_FREE"));
 	}
 
@@ -632,6 +632,7 @@ class RouteSearchV2ControllerTest {
 					"""))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.itineraries[0].legs[0].walkSeconds").value(160))
+			.andExpect(jsonPath("$.data.itineraries[0].legs[0].timeSource").value("OFFICIAL_BASELINE"))
 			.andExpect(jsonPath("$.data.itineraries[0].legs[0].appliedPreset").value("STEP_FREE"));
 	}
 
@@ -660,6 +661,7 @@ class RouteSearchV2ControllerTest {
 					"""))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.itineraries[0].legs[0].walkSeconds").value(160))
+			.andExpect(jsonPath("$.data.itineraries[0].legs[0].timeSource").value("OFFICIAL_BASELINE"))
 			.andExpect(jsonPath("$.data.itineraries[0].legs[0].appliedPreset").value("STEP_FREE"));
 	}
 


### PR DESCRIPTION
## 관련 이슈

Refs #1702
Refs #1620

## 작업 배경

- #1702의 V2 보행 leg 계약에서 `walkSeconds`와 함께 보행 시간 기준 source 라벨이 필요합니다.
- 기존 응답은 `etaSource`와 별도로 존재하는 `timeSource`에 ETA source 값을 그대로 넣어, 보행시간 기준선이 pathway인지 timetable baseline인지 구분할 수 없었습니다.

## 작업 내용

- V2 leg 조립 시 보행 leg의 `timeSource`를 walk time source 라벨로 노출합니다.
- legacy/access graph 보행 leg는 `MEASURED_PATHWAY`, RAPTOR TIMETABLE access/egress leg는 `OFFICIAL_BASELINE`으로 고정했습니다.
- ride leg와 `walkSeconds == 0` leg는 기존 `timeSource`를 유지합니다.

## 검증

- 실행한 명령과 결과:
  - `./backend/gradlew -p backend test --tests com.easysubway.route.adapter.in.web.RouteSearchV2ControllerTest.routeSearchV2EchoesExplicitMobilityPreset --tests com.easysubway.route.adapter.in.web.RouteSearchV2ControllerTest.routeSearchV2DoesNotExposeTimetableWaitAsWalkSeconds --tests com.easysubway.route.adapter.in.web.RouteSearchV2ControllerTest.routeSearchV2ExposesTimetableEgressWalkSeconds` red 후 green
  - `./backend/gradlew -p backend test --tests com.easysubway.route.adapter.in.web.RouteSearchV2ControllerTest` 성공
  - `./backend/gradlew -p backend test` 성공
  - `node --test tools/routes/*.test.mjs` 성공, 54 pass
  - `git diff --check` 성공

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| V2 route walk time source API contract | Backend | controller/backend/tooling automated tests | 터미널 출력 | 성공 |
| UI/접근성 수동 QA | N/A | backend DTO contract only | 증거 불필요: frontend/mobile 변경 없음 | 해당 없음 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [ ] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [ ] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: V2 leg `timeSource`를 보행 leg에서 walk time source label로 명확화
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `RouteSearchController.LegDto.timeSource()` 변환과 `RouteSearchV2ControllerTest` 기대값

## 리스크

- 기존 클라이언트가 `timeSource`를 ETA source로 읽고 있었다면 보행 leg에서 의미가 달라질 수 있습니다. `etaSource`는 별도 필드로 유지됩니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.