### PR TITLE
[Chore] Add TAGO schedule collector (#1415)

### DIFF
--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -5754,6 +5754,7 @@ test("TAGO 시간표 후보는 production PLANNED ETA 근거로 자동 승격되
     status: "planned_pilot_collection",
     tool: "tools/datapack/validate-tago-schedule-sample.mjs",
     command: "node tools/datapack/validate-tago-schedule-sample.mjs --plan --input tools/datapack/inputs/capital-pilot-production-source-input.json --daily-limit 1000 --checkpoint <checkpoint.json> --output <plan.json>",
+    collectCommand: "node tools/datapack/validate-tago-schedule-sample.mjs --collect --input tools/datapack/inputs/capital-pilot-production-source-input.json --daily-limit 1000 --checkpoint <checkpoint.json> --service-key-env DATA_GO_KR_SERVICE_KEY --output <collection.json>",
     summaryCommand: "node tools/datapack/validate-tago-schedule-sample.mjs --summary --input <collection.json> --output <summary.json>",
     summaryArtifactKind: "tago-schedule-collection-summary",
     input: "tools/datapack/inputs/capital-pilot-production-source-input.json",

--- a/tools/datapack/plan-tago-schedule-collection.test.mjs
+++ b/tools/datapack/plan-tago-schedule-collection.test.mjs
@@ -8,6 +8,7 @@ import { promisify } from "node:util";
 import {
   buildTagoScheduleCollectionPlan,
   buildTagoScheduleCollectionSummary,
+  collectTagoSchedules,
 } from "./validate-tago-schedule-sample.mjs";
 
 const execFileAsync = promisify(execFile);
@@ -174,6 +175,71 @@ test("TAGO 시간표 수집 summary CLI는 rawPath 목록에서 checkpoint summa
   const summary = JSON.parse(await readFile(outputPath, "utf8"));
   assert.deepEqual(summary.checkpoint, { completedRequestKeys: ["MTRKR4448|01|U"] });
   assert.equal(summary.rowCount, 2);
+});
+
+test("TAGO 시간표 수집기는 checkpoint 다음 batch만 호출하고 secret을 출력하지 않는다", async () => {
+  const fetchUrls = [];
+  const collection = await collectTagoSchedules(
+    {
+      stationLineRows: [
+        { stationCode: "448", lineId: "seoul-4" },
+        { stationCode: "433", lineId: "seoul-4" },
+      ],
+    },
+    {
+      checkpoint: { completedRequestKeys: ["MTRKR4448|01|U"] },
+      dailyLimit: 2,
+      serviceKey: "actual-secret-key",
+      serviceKeyEnv: "DATA_GO_KR_SERVICE_KEY",
+      collectedAt: "2026-07-05T00:00:00.000Z",
+      fetchImpl: async (url) => {
+        fetchUrls.push(url);
+        const params = new URL(url).searchParams;
+        return {
+          ok: true,
+          status: 200,
+          async text() {
+            return tagoResponse(
+              params.get("subwayStationId"),
+              params.get("dailyTypeCode"),
+              params.get("upDownTypeCode"),
+            );
+          },
+        };
+      },
+    },
+  );
+
+  assert.equal(collection.artifactKind, "tago-schedule-collection");
+  assert.equal(collection.requestedCount, 2);
+  assert.equal(collection.pendingRequestCount, 9);
+  assert.deepEqual(
+    collection.responses.map((response) => response.requestKey),
+    ["MTRKR4448|01|D", "MTRKR4448|02|U"],
+  );
+  assert.deepEqual(collection.checkpoint.completedRequestKeys, [
+    "MTRKR4448|01|D",
+    "MTRKR4448|01|U",
+    "MTRKR4448|02|U",
+  ]);
+  assert.equal(new URL(fetchUrls[0]).searchParams.get("serviceKey"), "actual-secret-key");
+  assert.doesNotMatch(JSON.stringify(collection), /actual-secret-key/);
+});
+
+test("TAGO 시간표 수집기는 service key가 없으면 provider 호출 전에 실패한다", async () => {
+  await assert.rejects(
+    () =>
+      collectTagoSchedules(
+        { stationLineRows: [{ stationCode: "448", lineId: "seoul-4" }] },
+        {
+          serviceKey: undefined,
+          fetchImpl: async () => {
+            throw new Error("must not fetch");
+          },
+        },
+      ),
+    /serviceKey is required/,
+  );
 });
 
 function tagoResponse(stationId, dailyTypeCode, upDownTypeCode) {

--- a/tools/datapack/plan-tago-schedule-collection.test.mjs
+++ b/tools/datapack/plan-tago-schedule-collection.test.mjs
@@ -224,6 +224,9 @@ test("TAGO 시간표 수집기는 checkpoint 다음 batch만 호출하고 secret
   ]);
   assert.equal(new URL(fetchUrls[0]).searchParams.get("serviceKey"), "actual-secret-key");
   assert.doesNotMatch(JSON.stringify(collection), /actual-secret-key/);
+
+  const summary = buildTagoScheduleCollectionSummary(collection);
+  assert.deepEqual(summary.checkpoint.completedRequestKeys, collection.checkpoint.completedRequestKeys);
 });
 
 test("TAGO 시간표 수집기는 service key가 없으면 provider 호출 전에 실패한다", async () => {

--- a/tools/datapack/plan-tago-schedule-collection.test.mjs
+++ b/tools/datapack/plan-tago-schedule-collection.test.mjs
@@ -110,6 +110,23 @@ test("TAGO 시간표 수집 summary는 완료 checkpoint와 evidence hash를 남
   assert.equal(summary.productionUseAllowed, false);
 });
 
+test("TAGO 시간표 수집 summary evidence hash는 checkpoint 상태를 포함한다", () => {
+  const response = {
+    requestKey: "MTRKR4448|02|U",
+    rawText: tagoResponse("MTRKR4448", "02", "U"),
+  };
+  const baseSummary = buildTagoScheduleCollectionSummary({
+    checkpoint: { completedRequestKeys: ["MTRKR4448|01|U"] },
+    responses: [response],
+  });
+  const editedCheckpointSummary = buildTagoScheduleCollectionSummary({
+    checkpoint: { completedRequestKeys: ["MTRKR4448|01|D"] },
+    responses: [response],
+  });
+
+  assert.notEqual(baseSummary.evidenceHash, editedCheckpointSummary.evidenceHash);
+});
+
 test("TAGO 시간표 수집 summary는 requestKey와 raw 응답 불일치를 거부한다", () => {
   assert.throws(
     () =>
@@ -295,6 +312,53 @@ test("TAGO 시간표 수집기는 batch 중간 실패 시 성공분 checkpoint�
         ["MTRKR4448|01|D"],
       );
       assert.doesNotMatch(JSON.stringify(error.collection), /actual-secret-key/);
+      return true;
+    },
+  );
+});
+
+test("TAGO 시간표 수집기는 body read 실패 시 성공분 checkpoint를 보존한다", async () => {
+  await assert.rejects(
+    () =>
+      collectTagoSchedules(
+        {
+          stationLineRows: [
+            { stationCode: "448", lineId: "seoul-4" },
+            { stationCode: "433", lineId: "seoul-4" },
+          ],
+        },
+        {
+          checkpoint: { completedRequestKeys: ["MTRKR4448|01|U"] },
+          dailyLimit: 3,
+          serviceKey: "actual-secret-key",
+          fetchImpl: async (url) => {
+            const params = new URL(url).searchParams;
+            return {
+              ok: true,
+              status: 200,
+              async text() {
+                if (params.get("upDownTypeCode") === "U" && params.get("dailyTypeCode") === "02") {
+                  throw new Error("connection dropped");
+                }
+                return tagoResponse(
+                  params.get("subwayStationId"),
+                  params.get("dailyTypeCode"),
+                  params.get("upDownTypeCode"),
+                );
+              },
+            };
+          },
+        },
+      ),
+    (error) => {
+      assert.equal(error.name, "TagoScheduleCollectionError");
+      assert.equal(error.message, "TAGO schedule response read failed: MTRKR4448|02|U");
+      assert.equal(error.collection.collectionStatus, "partial_failed");
+      assert.deepEqual(error.collection.completedRequestKeys, ["MTRKR4448|01|D", "MTRKR4448|01|U"]);
+      assert.deepEqual(
+        error.collection.responses.map((response) => response.requestKey),
+        ["MTRKR4448|01|D"],
+      );
       return true;
     },
   );

--- a/tools/datapack/plan-tago-schedule-collection.test.mjs
+++ b/tools/datapack/plan-tago-schedule-collection.test.mjs
@@ -222,8 +222,23 @@ test("TAGO 시간표 수집기는 checkpoint 다음 batch만 호출하고 secret
     "MTRKR4448|01|U",
     "MTRKR4448|02|U",
   ]);
+  assert.deepEqual(collection.completedRequestKeys, collection.checkpoint.completedRequestKeys);
   assert.equal(new URL(fetchUrls[0]).searchParams.get("serviceKey"), "actual-secret-key");
   assert.doesNotMatch(JSON.stringify(collection), /actual-secret-key/);
+
+  const resumedPlan = buildTagoScheduleCollectionPlan(
+    {
+      stationLineRows: [
+        { stationCode: "448", lineId: "seoul-4" },
+        { stationCode: "433", lineId: "seoul-4" },
+      ],
+    },
+    collection,
+    2,
+  );
+  assert.equal(resumedPlan.completedRequestCount, 3);
+  assert.equal(resumedPlan.pendingRequestCount, 9);
+  assert.equal(resumedPlan.batches[0].requests[0].requestKey, "MTRKR4448|02|D");
 
   const summary = buildTagoScheduleCollectionSummary(collection);
   assert.deepEqual(summary.completedRequestKeys, collection.checkpoint.completedRequestKeys);

--- a/tools/datapack/plan-tago-schedule-collection.test.mjs
+++ b/tools/datapack/plan-tago-schedule-collection.test.mjs
@@ -213,6 +213,7 @@ test("TAGO 시간표 수집기는 checkpoint 다음 batch만 호출하고 secret
   assert.equal(collection.artifactKind, "tago-schedule-collection");
   assert.equal(collection.requestedCount, 2);
   assert.equal(collection.pendingRequestCount, 9);
+  assert.equal(collection.collectionStatus, "completed_batch");
   assert.deepEqual(
     collection.responses.map((response) => response.requestKey),
     ["MTRKR4448|01|D", "MTRKR4448|02|U"],
@@ -248,6 +249,55 @@ test("TAGO 시간표 수집기는 checkpoint 다음 batch만 호출하고 secret
   );
   assert.equal(summary.responseCount, collection.responses.length);
   assert.deepEqual(summary.checkpoint.completedRequestKeys, collection.checkpoint.completedRequestKeys);
+});
+
+test("TAGO 시간표 수집기는 batch 중간 실패 시 성공분 checkpoint를 보존한다", async () => {
+  await assert.rejects(
+    () =>
+      collectTagoSchedules(
+        {
+          stationLineRows: [
+            { stationCode: "448", lineId: "seoul-4" },
+            { stationCode: "433", lineId: "seoul-4" },
+          ],
+        },
+        {
+          checkpoint: { completedRequestKeys: ["MTRKR4448|01|U"] },
+          dailyLimit: 3,
+          serviceKey: "actual-secret-key",
+          fetchImpl: async (url) => {
+            const params = new URL(url).searchParams;
+            if (params.get("upDownTypeCode") === "U" && params.get("dailyTypeCode") === "02") {
+              throw new Error("provider timeout");
+            }
+            return {
+              ok: true,
+              status: 200,
+              async text() {
+                return tagoResponse(
+                  params.get("subwayStationId"),
+                  params.get("dailyTypeCode"),
+                  params.get("upDownTypeCode"),
+                );
+              },
+            };
+          },
+        },
+      ),
+    (error) => {
+      assert.equal(error.name, "TagoScheduleCollectionError");
+      assert.equal(error.message, "TAGO schedule fetch failed before response: MTRKR4448|02|U");
+      assert.equal(error.collection.collectionStatus, "partial_failed");
+      assert.equal(error.collection.failedRequestKey, "MTRKR4448|02|U");
+      assert.deepEqual(error.collection.completedRequestKeys, ["MTRKR4448|01|D", "MTRKR4448|01|U"]);
+      assert.deepEqual(
+        error.collection.responses.map((response) => response.requestKey),
+        ["MTRKR4448|01|D"],
+      );
+      assert.doesNotMatch(JSON.stringify(error.collection), /actual-secret-key/);
+      return true;
+    },
+  );
 });
 
 test("TAGO 시간표 수집기는 service key가 없으면 provider 호출 전에 실패한다", async () => {

--- a/tools/datapack/plan-tago-schedule-collection.test.mjs
+++ b/tools/datapack/plan-tago-schedule-collection.test.mjs
@@ -268,6 +268,67 @@ test("TAGO 시간표 수집기는 checkpoint 다음 batch만 호출하고 secret
   assert.deepEqual(summary.checkpoint.completedRequestKeys, collection.checkpoint.completedRequestKeys);
 });
 
+test("TAGO 시간표 수집기는 encoded service key를 이중 인코딩하지 않는다", async () => {
+  const fetchUrls = [];
+  await collectTagoSchedules(
+    {
+      stationLineRows: [{ stationCode: "448", lineId: "seoul-4" }],
+    },
+    {
+      dailyLimit: 1,
+      serviceKey: "encoded%2Bkey%3D",
+      fetchImpl: async (url) => {
+        fetchUrls.push(url);
+        const params = new URL(url).searchParams;
+        return {
+          ok: true,
+          status: 200,
+          async text() {
+            return tagoResponse(
+              params.get("subwayStationId"),
+              params.get("dailyTypeCode"),
+              params.get("upDownTypeCode"),
+            );
+          },
+        };
+      },
+    },
+  );
+
+  assert.match(fetchUrls[0], /serviceKey=encoded%2Bkey%3D/);
+  assert.doesNotMatch(fetchUrls[0], /%252B|%253D/);
+});
+
+test("TAGO 시간표 수집기는 decoded service key를 URL 인코딩한다", async () => {
+  const fetchUrls = [];
+  await collectTagoSchedules(
+    {
+      stationLineRows: [{ stationCode: "448", lineId: "seoul-4" }],
+    },
+    {
+      dailyLimit: 1,
+      serviceKey: "decoded+key=",
+      fetchImpl: async (url) => {
+        fetchUrls.push(url);
+        const params = new URL(url).searchParams;
+        return {
+          ok: true,
+          status: 200,
+          async text() {
+            return tagoResponse(
+              params.get("subwayStationId"),
+              params.get("dailyTypeCode"),
+              params.get("upDownTypeCode"),
+            );
+          },
+        };
+      },
+    },
+  );
+
+  assert.match(fetchUrls[0], /serviceKey=decoded%2Bkey%3D/);
+});
+
 test("TAGO 시간표 수집기는 batch 중간 실패 시 성공분 checkpoint를 보존한다", async () => {
   await assert.rejects(
     () =>

--- a/tools/datapack/plan-tago-schedule-collection.test.mjs
+++ b/tools/datapack/plan-tago-schedule-collection.test.mjs
@@ -226,6 +226,11 @@ test("TAGO 시간표 수집기는 checkpoint 다음 batch만 호출하고 secret
   assert.doesNotMatch(JSON.stringify(collection), /actual-secret-key/);
 
   const summary = buildTagoScheduleCollectionSummary(collection);
+  assert.deepEqual(
+    summary.completedRequestKeys,
+    collection.responses.map((response) => response.requestKey),
+  );
+  assert.equal(summary.responseCount, collection.responses.length);
   assert.deepEqual(summary.checkpoint.completedRequestKeys, collection.checkpoint.completedRequestKeys);
 });
 

--- a/tools/datapack/plan-tago-schedule-collection.test.mjs
+++ b/tools/datapack/plan-tago-schedule-collection.test.mjs
@@ -226,8 +226,9 @@ test("TAGO 시간표 수집기는 checkpoint 다음 batch만 호출하고 secret
   assert.doesNotMatch(JSON.stringify(collection), /actual-secret-key/);
 
   const summary = buildTagoScheduleCollectionSummary(collection);
+  assert.deepEqual(summary.completedRequestKeys, collection.checkpoint.completedRequestKeys);
   assert.deepEqual(
-    summary.completedRequestKeys,
+    summary.responseRequestKeys,
     collection.responses.map((response) => response.requestKey),
   );
   assert.equal(summary.responseCount, collection.responses.length);

--- a/tools/datapack/source-candidates.json
+++ b/tools/datapack/source-candidates.json
@@ -685,6 +685,7 @@
           "status": "planned_pilot_collection",
           "tool": "tools/datapack/validate-tago-schedule-sample.mjs",
           "command": "node tools/datapack/validate-tago-schedule-sample.mjs --plan --input tools/datapack/inputs/capital-pilot-production-source-input.json --daily-limit 1000 --checkpoint <checkpoint.json> --output <plan.json>",
+          "collectCommand": "node tools/datapack/validate-tago-schedule-sample.mjs --collect --input tools/datapack/inputs/capital-pilot-production-source-input.json --daily-limit 1000 --checkpoint <checkpoint.json> --service-key-env DATA_GO_KR_SERVICE_KEY --output <collection.json>",
           "summaryCommand": "node tools/datapack/validate-tago-schedule-sample.mjs --summary --input <collection.json> --output <summary.json>",
           "summaryArtifactKind": "tago-schedule-collection-summary",
           "input": "tools/datapack/inputs/capital-pilot-production-source-input.json",

--- a/tools/datapack/validate-tago-schedule-sample.mjs
+++ b/tools/datapack/validate-tago-schedule-sample.mjs
@@ -205,7 +205,7 @@ async function collectTagoSchedules(input, options = {}) {
   const serviceKey = requiredString(options.serviceKey, "serviceKey");
   const fetchImpl = options.fetchImpl ?? globalThis.fetch;
   if (typeof fetchImpl !== "function") {
-    throw new Error("fetch is required for TAGO schedule collection");
+    throw new TypeError("fetch is required for TAGO schedule collection");
   }
   const checkpoint = options.checkpoint ?? {};
   const dailyLimit = options.dailyLimit ?? 1000;
@@ -232,7 +232,7 @@ async function collectTagoSchedules(input, options = {}) {
 
   const completedRequestKeys = [
     ...new Set([...(checkpoint.completedRequestKeys ?? []), ...responses.map((response) => response.requestKey)]),
-  ].sort();
+  ].sort((left, right) => left.localeCompare(right));
   return {
     artifactKind: "tago-schedule-collection",
     sourceId: plan.sourceId,

--- a/tools/datapack/validate-tago-schedule-sample.mjs
+++ b/tools/datapack/validate-tago-schedule-sample.mjs
@@ -305,15 +305,18 @@ class TagoScheduleCollectionError extends Error {
 
 function buildTagoScheduleRequestUrl(request, serviceKey) {
   const [stationId, dailyTypeCode, upDownTypeCode] = requestKeyParts(request.requestKey);
-  const url = new URL(TAGO_SCHEDULE_ENDPOINT);
-  url.searchParams.set("serviceKey", serviceKey);
-  url.searchParams.set("pageNo", "1");
-  url.searchParams.set("numOfRows", "1000");
-  url.searchParams.set("_type", "json");
-  url.searchParams.set("subwayStationId", stationId);
-  url.searchParams.set("dailyTypeCode", dailyTypeCode);
-  url.searchParams.set("upDownTypeCode", upDownTypeCode);
-  return url.toString();
+  const params = new URLSearchParams();
+  params.set("pageNo", "1");
+  params.set("numOfRows", "1000");
+  params.set("_type", "json");
+  params.set("subwayStationId", stationId);
+  params.set("dailyTypeCode", dailyTypeCode);
+  params.set("upDownTypeCode", upDownTypeCode);
+  return `${TAGO_SCHEDULE_ENDPOINT}?serviceKey=${encodeDataGoKrServiceKey(serviceKey)}&${params.toString()}`;
+}
+
+function encodeDataGoKrServiceKey(serviceKey) {
+  return /%[0-9a-f]{2}/i.test(serviceKey) ? serviceKey : encodeURIComponent(serviceKey);
 }
 
 function assertResponseMatchesRequestKey(validation, requestKey) {

--- a/tools/datapack/validate-tago-schedule-sample.mjs
+++ b/tools/datapack/validate-tago-schedule-sample.mjs
@@ -180,8 +180,9 @@ function buildTagoScheduleCollectionSummary(collection) {
     providerRecordHashes.push(...validation.providerRecordHashes);
     rowCount += validation.rowCount;
   }
-  const completedRequestKeys = [...new Set([...checkpointRequestKeys, ...responseRequestKeys])].sort((left, right) =>
-    left.localeCompare(right),
+  const completedRequestKeys = responseRequestKeys;
+  const checkpointCompletedRequestKeys = [...new Set([...checkpointRequestKeys, ...responseRequestKeys])].sort(
+    (left, right) => left.localeCompare(right),
   );
 
   const evidencePayload = {
@@ -196,7 +197,7 @@ function buildTagoScheduleCollectionSummary(collection) {
     sourceId: evidencePayload.sourceId,
     endpoint: evidencePayload.endpoint,
     completedRequestKeys,
-    checkpoint: { completedRequestKeys },
+    checkpoint: { completedRequestKeys: checkpointCompletedRequestKeys },
     responseCount: completedRequestKeys.length,
     rowCount,
     rawSha256ByRequest,

--- a/tools/datapack/validate-tago-schedule-sample.mjs
+++ b/tools/datapack/validate-tago-schedule-sample.mjs
@@ -154,7 +154,11 @@ function buildTagoScheduleCollectionSummary(collection) {
   if (!Array.isArray(responses) || responses.length === 0) {
     throw new Error("responses must be a non-empty array");
   }
-  const completedRequestKeys = [];
+  const checkpointRequestKeys = collection?.checkpoint?.completedRequestKeys ?? [];
+  for (const requestKey of checkpointRequestKeys) {
+    requestKeyParts(requestKey);
+  }
+  const responseRequestKeys = [];
   const rawSha256ByRequest = {};
   const providerRecordHashes = [];
   let rowCount = 0;
@@ -163,7 +167,7 @@ function buildTagoScheduleCollectionSummary(collection) {
     requestKeyParts(response.requestKey);
   }
   for (const response of [...responses].sort((left, right) => left.requestKey.localeCompare(right.requestKey))) {
-    if (completedRequestKeys.includes(response.requestKey)) {
+    if (responseRequestKeys.includes(response.requestKey)) {
       throw new Error(`duplicate requestKey: ${response.requestKey}`);
     }
     if (typeof response.rawText !== "string" || response.rawText.length === 0) {
@@ -171,11 +175,14 @@ function buildTagoScheduleCollectionSummary(collection) {
     }
     const validation = validateTagoScheduleSample(response.rawText);
     assertResponseMatchesRequestKey(validation, response.requestKey);
-    completedRequestKeys.push(response.requestKey);
+    responseRequestKeys.push(response.requestKey);
     rawSha256ByRequest[response.requestKey] = validation.rawSha256;
     providerRecordHashes.push(...validation.providerRecordHashes);
     rowCount += validation.rowCount;
   }
+  const completedRequestKeys = [...new Set([...checkpointRequestKeys, ...responseRequestKeys])].sort((left, right) =>
+    left.localeCompare(right),
+  );
 
   const evidencePayload = {
     sourceId: "molit-tago-subway-info",

--- a/tools/datapack/validate-tago-schedule-sample.mjs
+++ b/tools/datapack/validate-tago-schedule-sample.mjs
@@ -252,6 +252,7 @@ async function collectTagoSchedules(input, options = {}) {
     requestedCount: responses.length,
     completedRequestCount: completedRequestKeys.length,
     pendingRequestCount: Math.max(0, plan.pendingRequestCount - responses.length),
+    completedRequestKeys,
     checkpoint: { completedRequestKeys },
     responses,
   };

--- a/tools/datapack/validate-tago-schedule-sample.mjs
+++ b/tools/datapack/validate-tago-schedule-sample.mjs
@@ -187,6 +187,7 @@ function buildTagoScheduleCollectionSummary(collection) {
   const evidencePayload = {
     sourceId: "molit-tago-subway-info",
     endpoint: TAGO_SCHEDULE_ENDPOINT,
+    completedRequestKeys,
     responseRequestKeys,
     rawSha256ByRequest,
     providerRecordHashes,
@@ -242,7 +243,17 @@ async function collectTagoSchedules(input, options = {}) {
         }),
       );
     }
-    const rawText = await response.text();
+    let rawText;
+    try {
+      rawText = await response.text();
+    } catch {
+      throw new TagoScheduleCollectionError(
+        `TAGO schedule response read failed: ${request.requestKey}`,
+        buildTagoScheduleCollectionArtifact(plan, options, collectedAt, responses, {
+          failedRequestKey: request.requestKey,
+        }),
+      );
+    }
     try {
       const validation = validateTagoScheduleSample(rawText);
       assertResponseMatchesRequestKey(validation, request.requestKey);

--- a/tools/datapack/validate-tago-schedule-sample.mjs
+++ b/tools/datapack/validate-tago-schedule-sample.mjs
@@ -180,15 +180,14 @@ function buildTagoScheduleCollectionSummary(collection) {
     providerRecordHashes.push(...validation.providerRecordHashes);
     rowCount += validation.rowCount;
   }
-  const completedRequestKeys = responseRequestKeys;
-  const checkpointCompletedRequestKeys = [...new Set([...checkpointRequestKeys, ...responseRequestKeys])].sort(
+  const completedRequestKeys = [...new Set([...checkpointRequestKeys, ...responseRequestKeys])].sort(
     (left, right) => left.localeCompare(right),
   );
 
   const evidencePayload = {
     sourceId: "molit-tago-subway-info",
     endpoint: TAGO_SCHEDULE_ENDPOINT,
-    completedRequestKeys,
+    responseRequestKeys,
     rawSha256ByRequest,
     providerRecordHashes,
   };
@@ -197,8 +196,9 @@ function buildTagoScheduleCollectionSummary(collection) {
     sourceId: evidencePayload.sourceId,
     endpoint: evidencePayload.endpoint,
     completedRequestKeys,
-    checkpoint: { completedRequestKeys: checkpointCompletedRequestKeys },
-    responseCount: completedRequestKeys.length,
+    responseRequestKeys,
+    checkpoint: { completedRequestKeys },
+    responseCount: responseRequestKeys.length,
     rowCount,
     rawSha256ByRequest,
     providerRecordHashes,

--- a/tools/datapack/validate-tago-schedule-sample.mjs
+++ b/tools/datapack/validate-tago-schedule-sample.mjs
@@ -227,17 +227,41 @@ async function collectTagoSchedules(input, options = {}) {
     try {
       response = await fetchImpl(buildTagoScheduleRequestUrl(request, serviceKey));
     } catch {
-      throw new Error(`TAGO schedule fetch failed before response: ${request.requestKey}`);
+      throw new TagoScheduleCollectionError(
+        `TAGO schedule fetch failed before response: ${request.requestKey}`,
+        buildTagoScheduleCollectionArtifact(plan, options, collectedAt, responses, {
+          failedRequestKey: request.requestKey,
+        }),
+      );
     }
     if (!response.ok) {
-      throw new Error(`TAGO schedule fetch failed: ${request.requestKey} status ${response.status}`);
+      throw new TagoScheduleCollectionError(
+        `TAGO schedule fetch failed: ${request.requestKey} status ${response.status}`,
+        buildTagoScheduleCollectionArtifact(plan, options, collectedAt, responses, {
+          failedRequestKey: request.requestKey,
+        }),
+      );
     }
     const rawText = await response.text();
-    const validation = validateTagoScheduleSample(rawText);
-    assertResponseMatchesRequestKey(validation, request.requestKey);
+    try {
+      const validation = validateTagoScheduleSample(rawText);
+      assertResponseMatchesRequestKey(validation, request.requestKey);
+    } catch (error) {
+      throw new TagoScheduleCollectionError(
+        error instanceof Error ? error.message : `TAGO schedule validation failed: ${request.requestKey}`,
+        buildTagoScheduleCollectionArtifact(plan, options, collectedAt, responses, {
+          failedRequestKey: request.requestKey,
+        }),
+      );
+    }
     responses.push({ requestKey: request.requestKey, rawText });
   }
 
+  return buildTagoScheduleCollectionArtifact(plan, options, collectedAt, responses);
+}
+
+function buildTagoScheduleCollectionArtifact(plan, options, collectedAt, responses, failure = {}) {
+  const checkpoint = options.checkpoint ?? {};
   const completedRequestKeys = [
     ...new Set([...(checkpoint.completedRequestKeys ?? []), ...responses.map((response) => response.requestKey)]),
   ].sort((left, right) => left.localeCompare(right));
@@ -254,8 +278,18 @@ async function collectTagoSchedules(input, options = {}) {
     pendingRequestCount: Math.max(0, plan.pendingRequestCount - responses.length),
     completedRequestKeys,
     checkpoint: { completedRequestKeys },
+    collectionStatus: failure.failedRequestKey ? "partial_failed" : "completed_batch",
+    ...(failure.failedRequestKey ? { failedRequestKey: failure.failedRequestKey } : {}),
     responses,
   };
+}
+
+class TagoScheduleCollectionError extends Error {
+  constructor(message, collection) {
+    super(message);
+    this.name = "TagoScheduleCollectionError";
+    this.collection = collection;
+  }
 }
 
 function buildTagoScheduleRequestUrl(request, serviceKey) {
@@ -391,12 +425,19 @@ async function main() {
     const checkpoint = args.checkpoint ? JSON.parse(await readFile(path.resolve(args.checkpoint), "utf8")) : {};
     const dailyLimit = args["daily-limit"] === undefined ? undefined : Number(args["daily-limit"]);
     const serviceKeyEnv = args["service-key-env"] ?? "DATA_GO_KR_SERVICE_KEY";
-    result = await collectTagoSchedules(JSON.parse(await readFile(inputPath, "utf8")), {
-      checkpoint,
-      dailyLimit,
-      serviceKey: process.env[serviceKeyEnv],
-      serviceKeyEnv,
-    });
+    try {
+      result = await collectTagoSchedules(JSON.parse(await readFile(inputPath, "utf8")), {
+        checkpoint,
+        dailyLimit,
+        serviceKey: process.env[serviceKeyEnv],
+        serviceKeyEnv,
+      });
+    } catch (error) {
+      if (error instanceof TagoScheduleCollectionError && args.output) {
+        await writeJsonOutput(args.output, error.collection);
+      }
+      throw error;
+    }
   } else if (args.summary) {
     const input = JSON.parse(await readFile(inputPath, "utf8"));
     const inputDir = path.dirname(inputPath);
@@ -415,9 +456,13 @@ async function main() {
     result = validateTagoScheduleSample(await readFile(inputPath, "utf8"));
   }
   if (args.output) {
-    await writeFile(path.resolve(args.output), `${JSON.stringify(result, null, 2)}\n`);
+    await writeJsonOutput(args.output, result);
   }
   console.log(JSON.stringify(result, null, 2));
+}
+
+async function writeJsonOutput(outputPath, value) {
+  await writeFile(path.resolve(outputPath), `${JSON.stringify(value, null, 2)}\n`);
 }
 
 function requiredString(value, label) {

--- a/tools/datapack/validate-tago-schedule-sample.mjs
+++ b/tools/datapack/validate-tago-schedule-sample.mjs
@@ -30,7 +30,7 @@ function parseArgs(argv) {
     if (!flag.startsWith("--")) {
       throw new Error(`unexpected argument: ${flag}`);
     }
-    if (flag === "--plan" || flag === "--summary") {
+    if (flag === "--plan" || flag === "--summary" || flag === "--collect") {
       args[flag.slice(2)] = true;
       continue;
     }
@@ -201,6 +201,67 @@ function buildTagoScheduleCollectionSummary(collection) {
   };
 }
 
+async function collectTagoSchedules(input, options = {}) {
+  const serviceKey = requiredString(options.serviceKey, "serviceKey");
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+  if (typeof fetchImpl !== "function") {
+    throw new Error("fetch is required for TAGO schedule collection");
+  }
+  const checkpoint = options.checkpoint ?? {};
+  const dailyLimit = options.dailyLimit ?? 1000;
+  const plan = buildTagoScheduleCollectionPlan(input, checkpoint, dailyLimit);
+  const requests = plan.batches[0]?.requests ?? [];
+  const collectedAt = options.collectedAt ?? new Date().toISOString();
+  const responses = [];
+
+  for (const request of requests) {
+    let response;
+    try {
+      response = await fetchImpl(buildTagoScheduleRequestUrl(request, serviceKey));
+    } catch {
+      throw new Error(`TAGO schedule fetch failed before response: ${request.requestKey}`);
+    }
+    if (!response.ok) {
+      throw new Error(`TAGO schedule fetch failed: ${request.requestKey} status ${response.status}`);
+    }
+    const rawText = await response.text();
+    const validation = validateTagoScheduleSample(rawText);
+    assertResponseMatchesRequestKey(validation, request.requestKey);
+    responses.push({ requestKey: request.requestKey, rawText });
+  }
+
+  const completedRequestKeys = [
+    ...new Set([...(checkpoint.completedRequestKeys ?? []), ...responses.map((response) => response.requestKey)]),
+  ].sort();
+  return {
+    artifactKind: "tago-schedule-collection",
+    sourceId: plan.sourceId,
+    endpoint: plan.endpoint,
+    serviceKeyEnv: options.serviceKeyEnv ?? "DATA_GO_KR_SERVICE_KEY",
+    collectedAt,
+    dailyLimit: plan.dailyLimit,
+    totalRequestCount: plan.totalRequestCount,
+    requestedCount: responses.length,
+    completedRequestCount: completedRequestKeys.length,
+    pendingRequestCount: Math.max(0, plan.pendingRequestCount - responses.length),
+    checkpoint: { completedRequestKeys },
+    responses,
+  };
+}
+
+function buildTagoScheduleRequestUrl(request, serviceKey) {
+  const [stationId, dailyTypeCode, upDownTypeCode] = requestKeyParts(request.requestKey);
+  const url = new URL(TAGO_SCHEDULE_ENDPOINT);
+  url.searchParams.set("serviceKey", serviceKey);
+  url.searchParams.set("pageNo", "1");
+  url.searchParams.set("numOfRows", "1000");
+  url.searchParams.set("_type", "json");
+  url.searchParams.set("subwayStationId", stationId);
+  url.searchParams.set("dailyTypeCode", dailyTypeCode);
+  url.searchParams.set("upDownTypeCode", upDownTypeCode);
+  return url.toString();
+}
+
 function assertResponseMatchesRequestKey(validation, requestKey) {
   const [stationId, dailyTypeCode, upDownTypeCode] = requestKeyParts(requestKey);
   if (
@@ -317,6 +378,16 @@ async function main() {
     const checkpoint = args.checkpoint ? JSON.parse(await readFile(path.resolve(args.checkpoint), "utf8")) : {};
     const dailyLimit = args["daily-limit"] === undefined ? undefined : Number(args["daily-limit"]);
     result = buildTagoScheduleCollectionPlan(JSON.parse(await readFile(inputPath, "utf8")), checkpoint, dailyLimit);
+  } else if (args.collect) {
+    const checkpoint = args.checkpoint ? JSON.parse(await readFile(path.resolve(args.checkpoint), "utf8")) : {};
+    const dailyLimit = args["daily-limit"] === undefined ? undefined : Number(args["daily-limit"]);
+    const serviceKeyEnv = args["service-key-env"] ?? "DATA_GO_KR_SERVICE_KEY";
+    result = await collectTagoSchedules(JSON.parse(await readFile(inputPath, "utf8")), {
+      checkpoint,
+      dailyLimit,
+      serviceKey: process.env[serviceKeyEnv],
+      serviceKeyEnv,
+    });
   } else if (args.summary) {
     const input = JSON.parse(await readFile(inputPath, "utf8"));
     const inputDir = path.dirname(inputPath);
@@ -347,7 +418,12 @@ function requiredString(value, label) {
   return value;
 }
 
-export { buildTagoScheduleCollectionPlan, buildTagoScheduleCollectionSummary, validateTagoScheduleSample };
+export {
+  buildTagoScheduleCollectionPlan,
+  buildTagoScheduleCollectionSummary,
+  collectTagoSchedules,
+  validateTagoScheduleSample,
+};
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   main().catch((error) => {


### PR DESCRIPTION
## 관련 이슈

close #1415
Refs #1620
Refs #1414

## 작업 배경

- TAGO 시간표 후보는 plan/summary 검증은 있었지만, checkpoint 기준으로 provider 호출 batch를 실제 collection artifact로 남기는 도구가 없었다.

## 작업 내용

- `validate-tago-schedule-sample.mjs`에 `--collect` 모드를 추가했다.
- collector가 `DATA_GO_KR_SERVICE_KEY` env를 사용해 pending 첫 batch만 호출하고, raw 응답 검증 후 collection/checkpoint를 출력하게 했다.
- secret 누출, checkpoint resume, 공개 후보 command 계약을 테스트로 고정했다.

## 검증

- 실행한 명령과 결과:
- `node --test tools/datapack/plan-tago-schedule-collection.test.mjs` 성공
- `node --test tools/datapack/datapack-tools.test.mjs` 성공
- `node --test tools/ci/repository-contract.test.mjs` 성공
- `node --test tools/datapack/*.test.mjs` 성공
- `git diff --check` 성공

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| TAGO collector | datapack tooling | mock fetch 기반 node test | 터미널 출력 | 성공 |
| Repository contract | repo | node test | 터미널 출력 | 성공 |
| UI/접근성 | 해당 없음 | frontend/mobile 미변경 | 증거 불필요 | 해당 없음 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: TAGO collection evidence command만 추가
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `tools/datapack/validate-tago-schedule-sample.mjs`의 `--collect` 모드와 secret 비노출 테스트

## 리스크

- live provider 호출은 PR 검증에서 수행하지 않았다. 네트워크/API key 의존 없이 mock fetch로 request/checkpoint/secret 계약만 검증했다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TAGO 시간표 수집을 새로 지원해, 필요한 조건에 따라 데이터 수집 작업을 실행할 수 있습니다.
  * 서비스 키를 환경변수로 지정해 수집 작업을 더 유연하게 구성할 수 있습니다.

* **Bug Fixes**
  * 중복 처리와 체크포인트 반영 방식이 개선되어, 이전에 완료된 요청을 더 정확히 이어서 처리합니다.
  * 서비스 키가 없을 때는 수집이 시작되기 전에 즉시 실패하도록 보강했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->