### PR TITLE
[Chore] Wire KRIC service key overlay (#1397)

### DIFF
--- a/.github/workflows/datapack-release.yml
+++ b/.github/workflows/datapack-release.yml
@@ -204,6 +204,7 @@ jobs:
           EASYSUBWAY_ENV_SECRET: ${{ secrets.EASYSUBWAY_ENV }}
           EASYSUBWAY_SEOUL_TOPIS_SERVICE_KEY_SECRET: ${{ secrets.EASYSUBWAY_SEOUL_TOPIS_SERVICE_KEY }}
           DATA_GO_KR_SERVICE_KEY_SECRET: ${{ secrets.DATA_GO_KR_SERVICE_KEY }}
+          KRIC_SERVICE_KEY_SECRET: ${{ secrets.KRIC_SERVICE_KEY }}
         run: |
           set -euo pipefail
           umask 077
@@ -216,15 +217,20 @@ jobs:
           filtered_env_file="${RUNNER_TEMP}/easysubway-deploy.filtered.env"
           drop_topis_key=false
           drop_data_go_key=false
+          drop_kric_key=false
           [[ -n "${EASYSUBWAY_SEOUL_TOPIS_SERVICE_KEY_SECRET}" ]] && drop_topis_key=true
           [[ -n "${DATA_GO_KR_SERVICE_KEY_SECRET}" ]] && drop_data_go_key=true
-          awk -F= -v drop_topis_key="${drop_topis_key}" -v drop_data_go_key="${drop_data_go_key}" '
+          [[ -n "${KRIC_SERVICE_KEY_SECRET}" ]] && drop_kric_key=true
+          awk -F= -v drop_topis_key="${drop_topis_key}" -v drop_data_go_key="${drop_data_go_key}" -v drop_kric_key="${drop_kric_key}" '
             BEGIN {
               if (drop_topis_key == "true") {
                 drop["EASYSUBWAY_SEOUL_TOPIS_SERVICE_KEY"] = 1
               }
               if (drop_data_go_key == "true") {
                 drop["DATA_GO_KR_SERVICE_KEY"] = 1
+              }
+              if (drop_kric_key == "true") {
+                drop["KRIC_SERVICE_KEY"] = 1
               }
             }
             !($1 in drop)
@@ -245,6 +251,13 @@ jobs:
                 exit 1
               fi
               printf 'DATA_GO_KR_SERVICE_KEY=%s\n' "${DATA_GO_KR_SERVICE_KEY_SECRET}"
+            fi
+            if [[ -n "${KRIC_SERVICE_KEY_SECRET}" ]]; then
+              if [[ "${KRIC_SERVICE_KEY_SECRET}" == *$'\n'* || "${KRIC_SERVICE_KEY_SECRET}" == *$'\r'* ]]; then
+                echo "KRIC_SERVICE_KEY secret must be a single line" >&2
+                exit 1
+              fi
+              printf 'KRIC_SERVICE_KEY=%s\n' "${KRIC_SERVICE_KEY_SECRET}"
             fi
           } >> "${env_file}"
           chmod 600 "${env_file}"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 
 `.env.example`은 로컬 실행과 배포에 필요한 dotenv 양식입니다. 실제 값은 git에 올리지 않는 로컬 `.env`에만 둡니다.
 
-GitHub Actions에는 애플리케이션 환경값을 개별 환경변수로 여러 개 만들지 않고, 로컬 `.env` 파일 전체를 `EASYSUBWAY_ENV` secret 하나로 저장합니다. 단, provider key 회전은 전체 dotenv 재업로드 없이 `EASYSUBWAY_SEOUL_TOPIS_SERVICE_KEY`, `DATA_GO_KR_SERVICE_KEY` repository secret으로 덮어쓸 수 있습니다.
+GitHub Actions에는 애플리케이션 환경값을 개별 환경변수로 여러 개 만들지 않고, 로컬 `.env` 파일 전체를 `EASYSUBWAY_ENV` secret 하나로 저장합니다. 단, provider key 회전은 전체 dotenv 재업로드 없이 `EASYSUBWAY_SEOUL_TOPIS_SERVICE_KEY`, `DATA_GO_KR_SERVICE_KEY`, `KRIC_SERVICE_KEY` repository secret으로 덮어쓸 수 있습니다.
 
 ```bash
 scripts/github/sync-actions-env-secret.sh .env

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -400,6 +400,7 @@ function assertActionsEnvSecretPolicy(file, source) {
     ".github/workflows/datapack-release.yml": new Set([
       "EASYSUBWAY_SEOUL_TOPIS_SERVICE_KEY",
       "DATA_GO_KR_SERVICE_KEY",
+      "KRIC_SERVICE_KEY",
     ]),
     ".github/workflows/release-artifacts.yml": new Set([
       "EASYSUBWAY_ANDROID_UPLOAD_KEYSTORE_BASE64",
@@ -959,7 +960,7 @@ test("GitHub Actions 환경값은 dotenv secret과 provider key overlay로 관�
   const datapackReleaseWorkflow = read(".github/workflows/datapack-release.yml");
 
   assert.match(readme, /로컬 `\.env` 파일 전체를 `EASYSUBWAY_ENV` secret 하나로 저장합니다/);
-  assert.match(readme, /provider key 회전은 전체 dotenv 재업로드 없이 `EASYSUBWAY_SEOUL_TOPIS_SERVICE_KEY`, `DATA_GO_KR_SERVICE_KEY` repository secret으로 덮어쓸 수 있습니다/);
+  assert.match(readme, /provider key 회전은 전체 dotenv 재업로드 없이 `EASYSUBWAY_SEOUL_TOPIS_SERVICE_KEY`, `DATA_GO_KR_SERVICE_KEY`, `KRIC_SERVICE_KEY` repository secret으로 덮어쓸 수 있습니다/);
   assert.match(readme, /scripts\/github\/sync-actions-env-secret\.sh \.env/);
   assert.match(readme, /secrets\.EASYSUBWAY_ENV/);
   assert.match(readme, /provider key overlay를 append/);
@@ -981,6 +982,8 @@ test("GitHub Actions 환경값은 dotenv secret과 provider key overlay로 관�
   assert.match(cdWorkflow, /tail -c 1 "\$\{env_file\}"/);
   assert.match(datapackReleaseWorkflow, /drop_topis_key/);
   assert.match(datapackReleaseWorkflow, /drop_data_go_key/);
+  assert.match(datapackReleaseWorkflow, /drop_kric_key/);
+  assert.match(datapackReleaseWorkflow, /KRIC_SERVICE_KEY_SECRET: \$\{\{ secrets\.KRIC_SERVICE_KEY \}\}/);
   assert.match(datapackReleaseWorkflow, /!\(\$1 in drop\)/);
   assert.match(datapackReleaseWorkflow, /tail -c 1 "\$\{env_file\}"/);
   assert.match(cdWorkflow, /tools\/ci\/validate-deployment-env\.sh "\$\{EASYSUBWAY_ENV_FILE\}"/);


### PR DESCRIPTION
## 관련 이슈

Refs #1397
Refs #1414

## 작업 배경

- #1397 KRIC 10건 live sample 수집 실행 지침에서 `KRIC_SERVICE_KEY`를 CI/데이터팩 릴리즈 secret overlay로 확정했지만, datapack-release workflow는 아직 TOPIS/Data.go.kr key만 덮어썼다.

## 작업 내용

- `datapack-release.yml`의 dotenv 복원 단계에 `KRIC_SERVICE_KEY` repository secret overlay를 추가했다.
- 기존 dotenv 안의 `KRIC_SERVICE_KEY`는 scoped secret이 있으면 제거한 뒤 단일행 secret만 다시 append하게 했다.
- README와 repository contract test에 provider key overlay 목록을 갱신했다.

## 검증

- 실행한 명령과 결과:
- `node --test tools/ci/repository-contract.test.mjs` 성공
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts f }' .github/workflows/datapack-release.yml` 성공
- `git diff --check` 성공

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| KRIC secret overlay | GitHub Actions | repository contract + YAML parse | 터미널 출력 | 성공 |
| UI/접근성 | 해당 없음 | workflow/README/test만 변경 | 증거 불필요 | 해당 없음 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `.github/workflows/datapack-release.yml`의 `KRIC_SERVICE_KEY_SECRET` overlay와 단일행 검증

## 리스크

- 실제 KRIC live sample 호출은 secret 값이 필요하므로 이 PR에서는 수행하지 않았다. 이 PR은 secret 주입 경로만 연다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.