### PR TITLE
[Backend] 다음 시간표 운행 시각 노출 (#1620)

### DIFF
--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
@@ -235,6 +235,7 @@ class RouteSearchController {
 		int maxTransfers,
 		int alternativeCount,
 		List<String> statuses,
+		String nextServiceTime,
 		List<ItineraryDto> itineraries
 	) {
 
@@ -257,6 +258,7 @@ class RouteSearchController {
 				plan.statuses().stream()
 					.map(Enum::name)
 					.toList(),
+				plan.nextServiceTime() == null ? null : formatOffset(plan.nextServiceTime()),
 				plan.itineraries().stream()
 					.map(result -> ItineraryDto.from(result, departureTime, request.mobilityPresetName()))
 					.toList()

--- a/backend/src/main/java/com/easysubway/route/application/port/in/RouteV2SearchUseCase.java
+++ b/backend/src/main/java/com/easysubway/route/application/port/in/RouteV2SearchUseCase.java
@@ -74,8 +74,17 @@ public interface RouteV2SearchUseCase {
 	record RouteV2Plan(
 		List<RouteSearchResult> itineraries,
 		List<RouteV2Status> statuses,
-		String plannerAdr
+		String plannerAdr,
+		OffsetDateTime nextServiceTime
 	) {
+		public RouteV2Plan(
+			List<RouteSearchResult> itineraries,
+			List<RouteV2Status> statuses,
+			String plannerAdr
+		) {
+			this(itineraries, statuses, plannerAdr, null);
+		}
+
 		public RouteV2Plan {
 			itineraries = List.copyOf(Objects.requireNonNull(itineraries, "itineraries must not be null"));
 			statuses = List.copyOf(Objects.requireNonNull(statuses, "statuses must not be null"));

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
@@ -56,7 +56,7 @@ class RouteTimetableRaptorPlanner {
 		ServiceDay serviceDay = serviceDay(command);
 		for (int dayOffset = 0; dayOffset <= 7; dayOffset += 1) {
 			LocalDate candidateServiceDate = serviceDay.date().plusDays(dayOffset);
-			int startSeconds = dayOffset == 0 ? serviceDay.departureSeconds() : 0;
+			int startSeconds = candidateServiceDateStartSeconds(command, candidateServiceDate);
 			Optional<Integer> departureSeconds = firstFeasibleDepartureSeconds(
 				command,
 				timetable,
@@ -70,6 +70,20 @@ class RouteTimetableRaptorPlanner {
 			}
 		}
 		return Optional.empty();
+	}
+
+	private static int candidateServiceDateStartSeconds(SearchRouteV2Command command, LocalDate candidateServiceDate) {
+		long seconds = Duration.between(
+			candidateServiceDate.atStartOfDay(SERVICE_ZONE),
+			command.departureTime().atZoneSameInstant(SERVICE_ZONE)
+		).toSeconds();
+		if (seconds <= 0) {
+			return 0;
+		}
+		if (seconds >= LoadRouteTimetablePort.SERVICE_DAY_SECONDS_LIMIT_EXCLUSIVE) {
+			return LoadRouteTimetablePort.SERVICE_DAY_SECONDS_LIMIT_EXCLUSIVE;
+		}
+		return Math.toIntExact(seconds);
 	}
 
 	private Optional<Integer> firstFeasibleDepartureSeconds(

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
@@ -56,16 +56,13 @@ class RouteTimetableRaptorPlanner {
 		ServiceDay serviceDay = serviceDay(command);
 		for (int dayOffset = 0; dayOffset <= 7; dayOffset += 1) {
 			LocalDate candidateServiceDate = serviceDay.date().plusDays(dayOffset);
-			ServiceDay candidateServiceDay = new ServiceDay(candidateServiceDate, 0);
 			int startSeconds = dayOffset == 0 ? serviceDay.departureSeconds() : 0;
-			Optional<Integer> departureSeconds = scanDestinationLabels(
+			Optional<Integer> departureSeconds = firstFeasibleDepartureSeconds(
 				command,
 				timetable,
-				candidateServiceDay,
+				candidateServiceDate,
 				startSeconds
-			).labels().stream()
-				.map(label -> label.path().getFirst().from().departureSeconds())
-				.min(Integer::compareTo);
+			);
 			if (departureSeconds.isPresent()) {
 				return Optional.of(candidateServiceDate.atStartOfDay(SERVICE_ZONE)
 					.plusSeconds(departureSeconds.get())
@@ -75,26 +72,100 @@ class RouteTimetableRaptorPlanner {
 		return Optional.empty();
 	}
 
+	private Optional<Integer> firstFeasibleDepartureSeconds(
+		SearchRouteV2Command command,
+		RouteTimetable timetable,
+		LocalDate serviceDate,
+		int startSeconds
+	) {
+		List<ScheduledTrip> trips = activeScheduledTrips(timetable, serviceDate);
+		Integer firstDepartureSeconds = null;
+		int entrySeconds = profiledWalkSeconds(command, ENTRY_DURATION_SECONDS);
+		int slackSeconds = BoardingSlackPolicy.secondsFor(command.mobilityType());
+		for (ScheduledTrip trip : trips) {
+			List<TransitStopTime> stopTimes = trip.stopTimes();
+			for (int stopIndex = 0; stopIndex < stopTimes.size(); stopIndex += 1) {
+				TransitStopTime stopTime = stopTimes.get(stopIndex);
+				if (!command.originStationId().equals(stopTime.stationId())
+					|| !allowsPickup(stopTime)
+					|| stopTime.departureSeconds() < startSeconds + entrySeconds + slackSeconds) {
+					continue;
+				}
+				if (canReachDestinationAfterBoarding(command, trips, trip, stopIndex, 0, new HashSet<>())) {
+					firstDepartureSeconds = firstDepartureSeconds == null
+						? stopTime.departureSeconds()
+						: Math.min(firstDepartureSeconds, stopTime.departureSeconds());
+				}
+			}
+		}
+		return Optional.ofNullable(firstDepartureSeconds);
+	}
+
+	private boolean canReachDestinationAfterBoarding(
+		SearchRouteV2Command command,
+		List<ScheduledTrip> trips,
+		ScheduledTrip trip,
+		int boardingStopIndex,
+		int transfersUsed,
+		Set<String> visited
+	) {
+		List<TransitStopTime> stopTimes = trip.stopTimes();
+		for (int stopIndex = boardingStopIndex + 1; stopIndex < stopTimes.size(); stopIndex += 1) {
+			TransitStopTime stopTime = stopTimes.get(stopIndex);
+			if (!allowsDropOff(stopTime)) {
+				continue;
+			}
+			if (command.destinationStationId().equals(stopTime.stationId())) {
+				return true;
+			}
+			if (canReachDestinationAfterAlighting(command, trips, stopTime.stationId(), stopTime.arrivalSeconds(), transfersUsed, visited)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private boolean canReachDestinationAfterAlighting(
+		SearchRouteV2Command command,
+		List<ScheduledTrip> trips,
+		String stationId,
+		int readySeconds,
+		int transfersUsed,
+		Set<String> visited
+	) {
+		if (transfersUsed >= command.maxTransfers()) {
+			return false;
+		}
+		String stateKey = stationId + "|" + readySeconds + "|" + transfersUsed;
+		if (!visited.add(stateKey)) {
+			return false;
+		}
+		int transferSeconds = profiledWalkSeconds(command, TRANSFER_DURATION_SECONDS);
+		int slackSeconds = BoardingSlackPolicy.secondsFor(command.mobilityType());
+		for (ScheduledTrip trip : trips) {
+			List<TransitStopTime> stopTimes = trip.stopTimes();
+			for (int stopIndex = 0; stopIndex < stopTimes.size(); stopIndex += 1) {
+				TransitStopTime stopTime = stopTimes.get(stopIndex);
+				if (!stationId.equals(stopTime.stationId())
+					|| !allowsPickup(stopTime)
+					|| stopTime.departureSeconds() < readySeconds + transferSeconds + slackSeconds) {
+					continue;
+				}
+				if (canReachDestinationAfterBoarding(command, trips, trip, stopIndex, transfersUsed + 1, visited)) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
 	private ScanResult scanDestinationLabels(
 		SearchRouteV2Command command,
 		RouteTimetable timetable,
 		ServiceDay serviceDay,
 		int startSeconds
 	) {
-		Set<String> activeServiceIds = activeServiceIds(timetable, serviceDay.date());
-		if (activeServiceIds.isEmpty()) {
-			return new ScanResult(serviceDay, List.of());
-		}
-		Map<String, TransitRoute> routesById = routesById(timetable);
-		Map<String, List<TransitStopTime>> stopTimesByTrip = stopTimesByTrip(timetable);
-		Map<String, List<TransitFrequency>> frequenciesByTrip = frequenciesByTrip(timetable);
-		List<ScheduledTrip> trips = timetable.transitTrips().stream()
-			.filter(trip -> activeServiceIds.contains(trip.serviceId()))
-			.filter(trip -> stopTimesByTrip.getOrDefault(trip.id(), List.of()).size() > 1)
-			.flatMap(trip -> scheduledTrips(trip, routesById.get(trip.routeId()), stopTimesByTrip.get(trip.id()), frequenciesByTrip.getOrDefault(trip.id(), List.of())).stream())
-			.sorted(Comparator.comparing((ScheduledTrip scheduledTrip) -> scheduledTrip.trip().id())
-				.thenComparingInt(scheduledTrip -> scheduledTrip.stopTimes().getFirst().departureSeconds()))
-			.toList();
+		List<ScheduledTrip> trips = activeScheduledTrips(timetable, serviceDay.date());
 		if (trips.isEmpty()) {
 			return new ScanResult(serviceDay, List.of());
 		}
@@ -451,6 +522,23 @@ class RouteTimetableRaptorPlanner {
 			));
 		}
 		return java.util.Optional.of(List.copyOf(shifted));
+	}
+
+	private List<ScheduledTrip> activeScheduledTrips(RouteTimetable timetable, LocalDate serviceDate) {
+		Set<String> activeServiceIds = activeServiceIds(timetable, serviceDate);
+		if (activeServiceIds.isEmpty()) {
+			return List.of();
+		}
+		Map<String, TransitRoute> routesById = routesById(timetable);
+		Map<String, List<TransitStopTime>> stopTimesByTrip = stopTimesByTrip(timetable);
+		Map<String, List<TransitFrequency>> frequenciesByTrip = frequenciesByTrip(timetable);
+		return timetable.transitTrips().stream()
+			.filter(trip -> activeServiceIds.contains(trip.serviceId()))
+			.filter(trip -> stopTimesByTrip.getOrDefault(trip.id(), List.of()).size() > 1)
+			.flatMap(trip -> scheduledTrips(trip, routesById.get(trip.routeId()), stopTimesByTrip.get(trip.id()), frequenciesByTrip.getOrDefault(trip.id(), List.of())).stream())
+			.sorted(Comparator.comparing((ScheduledTrip scheduledTrip) -> scheduledTrip.trip().id())
+				.thenComparingInt(scheduledTrip -> scheduledTrip.stopTimes().getFirst().departureSeconds()))
+			.toList();
 	}
 
 	private static Set<String> activeServiceIds(RouteTimetable timetable, LocalDate serviceDate) {

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
@@ -19,6 +19,7 @@ import com.easysubway.route.domain.RouteStep;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -27,6 +28,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 class RouteTimetableRaptorPlanner {
@@ -83,6 +85,75 @@ class RouteTimetableRaptorPlanner {
 			.limit(Math.min(command.alternativeCount(), PARETO_LIMIT))
 			.map(label -> toRouteSearchResult(command, label, serviceDay))
 			.toList();
+	}
+
+	Optional<OffsetDateTime> nextServiceTime(SearchRouteV2Command command, RouteTimetable timetable) {
+		ServiceDay serviceDay = serviceDay(command);
+		int sameServiceDayReadySeconds = serviceDay.departureSeconds()
+			+ profiledWalkSeconds(command, ENTRY_DURATION_SECONDS)
+			+ BoardingSlackPolicy.secondsFor(command.mobilityType());
+		for (int dayOffset = 0; dayOffset <= 7; dayOffset += 1) {
+			LocalDate candidateServiceDate = serviceDay.date().plusDays(dayOffset);
+			int minimumDepartureSeconds = dayOffset == 0 ? sameServiceDayReadySeconds : 0;
+			Optional<Integer> departureSeconds = earliestDirectDepartureSeconds(
+				command,
+				timetable,
+				candidateServiceDate,
+				minimumDepartureSeconds
+			);
+			if (departureSeconds.isPresent()) {
+				return Optional.of(candidateServiceDate.atStartOfDay(SERVICE_ZONE)
+					.plusSeconds(departureSeconds.get())
+					.toOffsetDateTime());
+			}
+		}
+		return Optional.empty();
+	}
+
+	private Optional<Integer> earliestDirectDepartureSeconds(
+		SearchRouteV2Command command,
+		RouteTimetable timetable,
+		LocalDate serviceDate,
+		int minimumDepartureSeconds
+	) {
+		Set<String> activeServiceIds = activeServiceIds(timetable, serviceDate);
+		if (activeServiceIds.isEmpty()) {
+			return Optional.empty();
+		}
+		Map<String, TransitRoute> routesById = routesById(timetable);
+		Map<String, List<TransitStopTime>> stopTimesByTrip = stopTimesByTrip(timetable);
+		Map<String, List<TransitFrequency>> frequenciesByTrip = frequenciesByTrip(timetable);
+		return timetable.transitTrips().stream()
+			.filter(trip -> activeServiceIds.contains(trip.serviceId()))
+			.filter(trip -> stopTimesByTrip.getOrDefault(trip.id(), List.of()).size() > 1)
+			.flatMap(trip -> scheduledTrips(trip, routesById.get(trip.routeId()), stopTimesByTrip.get(trip.id()), frequenciesByTrip.getOrDefault(trip.id(), List.of())).stream())
+			.map(scheduledTrip -> directDepartureSeconds(command, scheduledTrip, minimumDepartureSeconds))
+			.flatMap(Optional::stream)
+			.min(Integer::compareTo);
+	}
+
+	private Optional<Integer> directDepartureSeconds(
+		SearchRouteV2Command command,
+		ScheduledTrip trip,
+		int minimumDepartureSeconds
+	) {
+		TransitStopTime boardingStop = null;
+		for (TransitStopTime stopTime : trip.stopTimes()) {
+			if (boardingStop == null
+				&& command.originStationId().equals(stopTime.stationId())
+				&& allowsPickup(stopTime)
+				&& stopTime.departureSeconds() >= minimumDepartureSeconds) {
+				boardingStop = stopTime;
+				continue;
+			}
+			if (boardingStop != null
+				&& stopTime.stopSequence() > boardingStop.stopSequence()
+				&& command.destinationStationId().equals(stopTime.stationId())
+				&& allowsDropOff(stopTime)) {
+				return Optional.of(boardingStop.departureSeconds());
+			}
+		}
+		return Optional.empty();
 	}
 
 	private void scanTrip(

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
@@ -45,11 +45,46 @@ class RouteTimetableRaptorPlanner {
 
 	List<RouteSearchResult> search(SearchRouteV2Command command, RouteTimetable timetable) {
 		ServiceDay serviceDay = serviceDay(command);
+		return scanDestinationLabels(command, timetable, serviceDay, serviceDay.departureSeconds()).labels().stream()
+			.sorted(RouteTimetableRaptorPlanner::compareLabels)
+			.limit(Math.min(command.alternativeCount(), PARETO_LIMIT))
+			.map(label -> toRouteSearchResult(command, label, serviceDay))
+			.toList();
+	}
+
+	Optional<OffsetDateTime> nextServiceTime(SearchRouteV2Command command, RouteTimetable timetable) {
+		ServiceDay serviceDay = serviceDay(command);
+		for (int dayOffset = 0; dayOffset <= 7; dayOffset += 1) {
+			LocalDate candidateServiceDate = serviceDay.date().plusDays(dayOffset);
+			ServiceDay candidateServiceDay = new ServiceDay(candidateServiceDate, 0);
+			int startSeconds = dayOffset == 0 ? serviceDay.departureSeconds() : 0;
+			Optional<Integer> departureSeconds = scanDestinationLabels(
+				command,
+				timetable,
+				candidateServiceDay,
+				startSeconds
+			).labels().stream()
+				.map(label -> label.path().getFirst().from().departureSeconds())
+				.min(Integer::compareTo);
+			if (departureSeconds.isPresent()) {
+				return Optional.of(candidateServiceDate.atStartOfDay(SERVICE_ZONE)
+					.plusSeconds(departureSeconds.get())
+					.toOffsetDateTime());
+			}
+		}
+		return Optional.empty();
+	}
+
+	private ScanResult scanDestinationLabels(
+		SearchRouteV2Command command,
+		RouteTimetable timetable,
+		ServiceDay serviceDay,
+		int startSeconds
+	) {
 		Set<String> activeServiceIds = activeServiceIds(timetable, serviceDay.date());
 		if (activeServiceIds.isEmpty()) {
-			return List.of();
+			return new ScanResult(serviceDay, List.of());
 		}
-
 		Map<String, TransitRoute> routesById = routesById(timetable);
 		Map<String, List<TransitStopTime>> stopTimesByTrip = stopTimesByTrip(timetable);
 		Map<String, List<TransitFrequency>> frequenciesByTrip = frequenciesByTrip(timetable);
@@ -61,14 +96,14 @@ class RouteTimetableRaptorPlanner {
 				.thenComparingInt(scheduledTrip -> scheduledTrip.stopTimes().getFirst().departureSeconds()))
 			.toList();
 		if (trips.isEmpty()) {
-			return List.of();
+			return new ScanResult(serviceDay, List.of());
 		}
 
 		Map<String, List<Label>> labels = new HashMap<>();
 		labels.put(command.originStationId(), List.of(new Label(
 			command.originStationId(),
-			serviceDay.departureSeconds(),
-			serviceDay.departureSeconds(),
+			startSeconds,
+			startSeconds,
 			0,
 			List.of()
 		)));
@@ -79,81 +114,12 @@ class RouteTimetableRaptorPlanner {
 			}
 		}
 
-		return labels.getOrDefault(command.destinationStationId(), List.of()).stream()
+		List<Label> destinationLabels = labels.getOrDefault(command.destinationStationId(), List.of()).stream()
 			.filter(label -> !label.path().isEmpty())
 			.sorted(RouteTimetableRaptorPlanner::compareLabels)
-			.limit(Math.min(command.alternativeCount(), PARETO_LIMIT))
-			.map(label -> toRouteSearchResult(command, label, serviceDay))
+			.limit(PARETO_LIMIT)
 			.toList();
-	}
-
-	Optional<OffsetDateTime> nextServiceTime(SearchRouteV2Command command, RouteTimetable timetable) {
-		ServiceDay serviceDay = serviceDay(command);
-		int sameServiceDayReadySeconds = serviceDay.departureSeconds()
-			+ profiledWalkSeconds(command, ENTRY_DURATION_SECONDS)
-			+ BoardingSlackPolicy.secondsFor(command.mobilityType());
-		for (int dayOffset = 0; dayOffset <= 7; dayOffset += 1) {
-			LocalDate candidateServiceDate = serviceDay.date().plusDays(dayOffset);
-			int minimumDepartureSeconds = dayOffset == 0 ? sameServiceDayReadySeconds : 0;
-			Optional<Integer> departureSeconds = earliestDirectDepartureSeconds(
-				command,
-				timetable,
-				candidateServiceDate,
-				minimumDepartureSeconds
-			);
-			if (departureSeconds.isPresent()) {
-				return Optional.of(candidateServiceDate.atStartOfDay(SERVICE_ZONE)
-					.plusSeconds(departureSeconds.get())
-					.toOffsetDateTime());
-			}
-		}
-		return Optional.empty();
-	}
-
-	private Optional<Integer> earliestDirectDepartureSeconds(
-		SearchRouteV2Command command,
-		RouteTimetable timetable,
-		LocalDate serviceDate,
-		int minimumDepartureSeconds
-	) {
-		Set<String> activeServiceIds = activeServiceIds(timetable, serviceDate);
-		if (activeServiceIds.isEmpty()) {
-			return Optional.empty();
-		}
-		Map<String, TransitRoute> routesById = routesById(timetable);
-		Map<String, List<TransitStopTime>> stopTimesByTrip = stopTimesByTrip(timetable);
-		Map<String, List<TransitFrequency>> frequenciesByTrip = frequenciesByTrip(timetable);
-		return timetable.transitTrips().stream()
-			.filter(trip -> activeServiceIds.contains(trip.serviceId()))
-			.filter(trip -> stopTimesByTrip.getOrDefault(trip.id(), List.of()).size() > 1)
-			.flatMap(trip -> scheduledTrips(trip, routesById.get(trip.routeId()), stopTimesByTrip.get(trip.id()), frequenciesByTrip.getOrDefault(trip.id(), List.of())).stream())
-			.map(scheduledTrip -> directDepartureSeconds(command, scheduledTrip, minimumDepartureSeconds))
-			.flatMap(Optional::stream)
-			.min(Integer::compareTo);
-	}
-
-	private Optional<Integer> directDepartureSeconds(
-		SearchRouteV2Command command,
-		ScheduledTrip trip,
-		int minimumDepartureSeconds
-	) {
-		TransitStopTime boardingStop = null;
-		for (TransitStopTime stopTime : trip.stopTimes()) {
-			if (boardingStop == null
-				&& command.originStationId().equals(stopTime.stationId())
-				&& allowsPickup(stopTime)
-				&& stopTime.departureSeconds() >= minimumDepartureSeconds) {
-				boardingStop = stopTime;
-				continue;
-			}
-			if (boardingStop != null
-				&& stopTime.stopSequence() > boardingStop.stopSequence()
-				&& command.destinationStationId().equals(stopTime.stationId())
-				&& allowsDropOff(stopTime)) {
-				return Optional.of(boardingStop.departureSeconds());
-			}
-		}
-		return Optional.empty();
+		return new ScanResult(serviceDay, destinationLabels);
 	}
 
 	private void scanTrip(
@@ -535,6 +501,9 @@ class RouteTimetableRaptorPlanner {
 	}
 
 	private record ServiceDay(LocalDate date, int departureSeconds) {
+	}
+
+	private record ScanResult(ServiceDay serviceDay, List<Label> labels) {
 	}
 
 	private record Label(String stationId, int timeSeconds, int startSeconds, int boardings, List<RideLeg> path) {

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
@@ -90,23 +90,29 @@ class RouteTimetableRaptorPlanner {
 		int startSeconds
 	) {
 		List<ScheduledTrip> trips = activeScheduledTrips(timetable, serviceDate);
+		Map<String, List<BoardingStop>> boardingsByStation = boardingsByStation(trips);
+		Map<ReachabilityState, Boolean> reachabilityCache = new HashMap<>();
 		Integer firstDepartureSeconds = null;
 		int entrySeconds = profiledWalkSeconds(command, ENTRY_DURATION_SECONDS);
 		int slackSeconds = BoardingSlackPolicy.secondsFor(command.mobilityType());
-		for (ScheduledTrip trip : trips) {
-			List<TransitStopTime> stopTimes = trip.stopTimes();
-			for (int stopIndex = 0; stopIndex < stopTimes.size(); stopIndex += 1) {
-				TransitStopTime stopTime = stopTimes.get(stopIndex);
-				if (!command.originStationId().equals(stopTime.stationId())
-					|| !allowsPickup(stopTime)
-					|| stopTime.departureSeconds() < startSeconds + entrySeconds + slackSeconds) {
-					continue;
-				}
-				if (canReachDestinationAfterBoarding(command, trips, trip, stopIndex, 0, new HashSet<>())) {
-					firstDepartureSeconds = firstDepartureSeconds == null
-						? stopTime.departureSeconds()
-						: Math.min(firstDepartureSeconds, stopTime.departureSeconds());
-				}
+		for (BoardingStop boardingStop : boardingsByStation.getOrDefault(command.originStationId(), List.of())) {
+			TransitStopTime stopTime = boardingStop.stopTime();
+			if (!allowsPickup(stopTime)
+				|| stopTime.departureSeconds() < startSeconds + entrySeconds + slackSeconds) {
+				continue;
+			}
+			if (canReachDestinationAfterBoarding(
+				command,
+				boardingsByStation,
+				boardingStop.trip(),
+				boardingStop.stopIndex(),
+				0,
+				new HashSet<>(),
+				reachabilityCache
+			)) {
+				firstDepartureSeconds = firstDepartureSeconds == null
+					? stopTime.departureSeconds()
+					: Math.min(firstDepartureSeconds, stopTime.departureSeconds());
 			}
 		}
 		return Optional.ofNullable(firstDepartureSeconds);
@@ -114,11 +120,12 @@ class RouteTimetableRaptorPlanner {
 
 	private boolean canReachDestinationAfterBoarding(
 		SearchRouteV2Command command,
-		List<ScheduledTrip> trips,
+		Map<String, List<BoardingStop>> boardingsByStation,
 		ScheduledTrip trip,
 		int boardingStopIndex,
 		int transfersUsed,
-		Set<String> visited
+		Set<ReachabilityState> visiting,
+		Map<ReachabilityState, Boolean> reachabilityCache
 	) {
 		List<TransitStopTime> stopTimes = trip.stopTimes();
 		for (int stopIndex = boardingStopIndex + 1; stopIndex < stopTimes.size(); stopIndex += 1) {
@@ -129,7 +136,15 @@ class RouteTimetableRaptorPlanner {
 			if (command.destinationStationId().equals(stopTime.stationId())) {
 				return true;
 			}
-			if (canReachDestinationAfterAlighting(command, trips, stopTime.stationId(), stopTime.arrivalSeconds(), transfersUsed, visited)) {
+			if (canReachDestinationAfterAlighting(
+				command,
+				boardingsByStation,
+				stopTime.stationId(),
+				stopTime.arrivalSeconds(),
+				transfersUsed,
+				visiting,
+				reachabilityCache
+			)) {
 				return true;
 			}
 		}
@@ -138,36 +153,51 @@ class RouteTimetableRaptorPlanner {
 
 	private boolean canReachDestinationAfterAlighting(
 		SearchRouteV2Command command,
-		List<ScheduledTrip> trips,
+		Map<String, List<BoardingStop>> boardingsByStation,
 		String stationId,
 		int readySeconds,
 		int transfersUsed,
-		Set<String> visited
+		Set<ReachabilityState> visiting,
+		Map<ReachabilityState, Boolean> reachabilityCache
 	) {
 		if (transfersUsed >= command.maxTransfers()) {
 			return false;
 		}
-		String stateKey = stationId + "|" + readySeconds + "|" + transfersUsed;
-		if (!visited.add(stateKey)) {
+		ReachabilityState state = new ReachabilityState(stationId, readySeconds, transfersUsed);
+		Boolean cached = reachabilityCache.get(state);
+		if (cached != null) {
+			return cached;
+		}
+		if (!visiting.add(state)) {
 			return false;
 		}
 		int transferSeconds = profiledWalkSeconds(command, TRANSFER_DURATION_SECONDS);
 		int slackSeconds = BoardingSlackPolicy.secondsFor(command.mobilityType());
-		for (ScheduledTrip trip : trips) {
-			List<TransitStopTime> stopTimes = trip.stopTimes();
-			for (int stopIndex = 0; stopIndex < stopTimes.size(); stopIndex += 1) {
-				TransitStopTime stopTime = stopTimes.get(stopIndex);
-				if (!stationId.equals(stopTime.stationId())
-					|| !allowsPickup(stopTime)
+		try {
+			for (BoardingStop boardingStop : boardingsByStation.getOrDefault(stationId, List.of())) {
+				TransitStopTime stopTime = boardingStop.stopTime();
+				if (!allowsPickup(stopTime)
 					|| stopTime.departureSeconds() < readySeconds + transferSeconds + slackSeconds) {
 					continue;
 				}
-				if (canReachDestinationAfterBoarding(command, trips, trip, stopIndex, transfersUsed + 1, visited)) {
+				if (canReachDestinationAfterBoarding(
+					command,
+					boardingsByStation,
+					boardingStop.trip(),
+					boardingStop.stopIndex(),
+					transfersUsed + 1,
+					visiting,
+					reachabilityCache
+				)) {
+					reachabilityCache.put(state, true);
 					return true;
 				}
 			}
+			reachabilityCache.put(state, false);
+			return false;
+		} finally {
+			visiting.remove(state);
 		}
-		return false;
 	}
 
 	private ScanResult scanDestinationLabels(
@@ -552,6 +582,24 @@ class RouteTimetableRaptorPlanner {
 			.toList();
 	}
 
+	private Map<String, List<BoardingStop>> boardingsByStation(List<ScheduledTrip> trips) {
+		Map<String, List<BoardingStop>> boardings = new HashMap<>();
+		for (ScheduledTrip trip : trips) {
+			List<TransitStopTime> stopTimes = trip.stopTimes();
+			for (int stopIndex = 0; stopIndex < stopTimes.size(); stopIndex += 1) {
+				TransitStopTime stopTime = stopTimes.get(stopIndex);
+				boardings.computeIfAbsent(stopTime.stationId(), ignored -> new ArrayList<>())
+					.add(new BoardingStop(trip, stopIndex, stopTime));
+			}
+		}
+		for (Map.Entry<String, List<BoardingStop>> entry : boardings.entrySet()) {
+			entry.setValue(entry.getValue().stream()
+				.sorted(Comparator.comparingInt(boarding -> boarding.stopTime().departureSeconds()))
+				.toList());
+		}
+		return Map.copyOf(boardings);
+	}
+
 	private static Set<String> activeServiceIds(RouteTimetable timetable, LocalDate serviceDate) {
 		Set<String> active = new HashSet<>();
 		for (ServiceCalendar calendar : timetable.serviceCalendars()) {
@@ -612,6 +660,12 @@ class RouteTimetableRaptorPlanner {
 	}
 
 	private record ScheduledTrip(TransitTrip trip, TransitRoute route, List<TransitStopTime> stopTimes) {
+	}
+
+	private record BoardingStop(ScheduledTrip trip, int stopIndex, TransitStopTime stopTime) {
+	}
+
+	private record ReachabilityState(String stationId, int readySeconds, int transfersUsed) {
 	}
 
 	private record RideLeg(TransitTrip trip, TransitRoute route, TransitStopTime from, TransitStopTime to) {

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
@@ -77,9 +77,6 @@ class RouteTimetableRaptorPlanner {
 			candidateServiceDate.atStartOfDay(SERVICE_ZONE),
 			command.departureTime().atZoneSameInstant(SERVICE_ZONE)
 		).toSeconds();
-		if (seconds <= 0) {
-			return 0;
-		}
 		if (seconds >= LoadRouteTimetablePort.SERVICE_DAY_SECONDS_LIMIT_EXCLUSIVE) {
 			return LoadRouteTimetablePort.SERVICE_DAY_SECONDS_LIMIT_EXCLUSIVE;
 		}

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
@@ -17,6 +17,7 @@ import com.easysubway.route.domain.RouteNotFoundException;
 import com.easysubway.route.domain.RouteSearchResult;
 import com.easysubway.route.domain.RouteSearchStatus;
 import com.easysubway.route.domain.RouteStep;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -76,7 +77,7 @@ public class RouteV2Planner implements RouteV2SearchUseCase {
 					routeTimetable()
 				);
 				if (timetableItineraries.isEmpty()) {
-					return new RouteV2Plan(List.of(), List.of(RouteV2Status.NO_TIMETABLE_SERVICE), PLANNER_ADR);
+					return noTimetableServicePlan(command);
 				}
 				timetableItineraries = routeSearchUseCase.stabilizeTimetableRouteCandidates(
 					searchRouteCommand,
@@ -101,6 +102,11 @@ public class RouteV2Planner implements RouteV2SearchUseCase {
 		} catch (RouteNotFoundException exception) {
 			return new RouteV2Plan(List.of(), List.of(RouteV2Status.NO_TIMETABLE_SERVICE), PLANNER_ADR);
 		}
+	}
+
+	private RouteV2Plan noTimetableServicePlan(SearchRouteV2Command command) {
+		OffsetDateTime nextServiceTime = timetableRaptorPlanner.nextServiceTime(command, routeTimetable()).orElse(null);
+		return new RouteV2Plan(List.of(), List.of(RouteV2Status.NO_TIMETABLE_SERVICE), PLANNER_ADR, nextServiceTime);
 	}
 
 	private boolean canUseTimetableRaptor(SearchRouteV2Command command) {

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
@@ -220,6 +220,30 @@ class RouteSearchV2ControllerTest {
 	}
 
 	@Test
+	@DisplayName("V2 경로 검색은 막차 이후 다음 운행 시각을 함께 반환한다")
+	void routeSearchV2ReturnsNextServiceTimeAfterLastTrain() throws Exception {
+		mockMvc.perform(post("/api/v2/routes/search")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "originStationId": "station-sangnoksu",
+					  "destinationStationId": "station-sadang",
+					  "departureTime": "2026-07-01T23:55:00+09:00",
+					  "mobilityType": "SENIOR",
+					  "constraintMode": "PREFER_STEP_FREE",
+					  "useRealtime": false,
+					  "maxTransfers": 1,
+					  "alternativeCount": 3
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.statuses[0]").value("NO_TIMETABLE_SERVICE"))
+			.andExpect(jsonPath("$.data.nextServiceTime").value("2026-07-02T09:00:00+09:00"))
+			.andExpect(jsonPath("$.data.itineraries").isEmpty());
+	}
+
+	@Test
 	@DisplayName("V2 route refresh는 저장된 itinerary와 refresh 상태를 반환한다")
 	void routeRefreshV2ReturnsRefreshStatusAndStoredRoute() throws Exception {
 		when(routeSearchUseCase.refreshRoute("route-search-1"))

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -805,6 +805,27 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("V2 planner는 막차 이후 NO_TIMETABLE_SERVICE에 다음 운행 시각을 포함한다")
+	void routeV2PlannerReturnsNextServiceTimeAfterLastTrain() {
+		var planner = new RouteV2Planner(legacySearchMustNotBeCalled(), routeTimetablePort());
+
+		var plan = planner.search(new RouteV2SearchUseCase.SearchRouteV2Command(
+			"station-a",
+			"station-b",
+			OffsetDateTime.parse("2026-07-01T23:55:00+09:00"),
+			MobilityType.SENIOR,
+			ConstraintMode.PREFER_STEP_FREE,
+			false,
+			1,
+			3
+		));
+
+		assertThat(plan.statuses()).containsExactly(RouteV2Status.NO_TIMETABLE_SERVICE);
+		assertThat(plan.itineraries()).isEmpty();
+		assertThat(plan.nextServiceTime()).isEqualTo(OffsetDateTime.parse("2026-07-02T09:07:00+09:00"));
+	}
+
+	@Test
 	@DisplayName("V2 planner는 시간표 adapter 미연결 fallback에서는 기존 경로 검색을 유지한다")
 	void routeV2PlannerKeepsLegacySearchWhenTimetableAdapterMissing() {
 		var repository = new InMemoryRouteSearchRepository();

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -889,6 +889,27 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("V2 planner는 미래 service day의 00시대 운행에 요청 직후 대기 시간을 반영한다")
+	void routeV2PlannerKeepsLeadTimeForFutureServiceDayNextService() {
+		var planner = new RouteV2Planner(legacySearchMustNotBeCalled(), futureMidnightNextServiceRouteTimetablePort());
+
+		var plan = planner.search(new RouteV2SearchUseCase.SearchRouteV2Command(
+			"station-a",
+			"station-b",
+			OffsetDateTime.parse("2026-07-01T23:55:00+09:00"),
+			MobilityType.SENIOR,
+			ConstraintMode.PREFER_STEP_FREE,
+			false,
+			1,
+			3
+		));
+
+		assertThat(plan.statuses()).containsExactly(RouteV2Status.NO_TIMETABLE_SERVICE);
+		assertThat(plan.itineraries()).isEmpty();
+		assertThat(plan.nextServiceTime()).isEqualTo(OffsetDateTime.parse("2026-07-02T00:03:00+09:00"));
+	}
+
+	@Test
 	@DisplayName("V2 planner는 시간표 adapter 미연결 fallback에서는 기존 경로 검색을 유지한다")
 	void routeV2PlannerKeepsLegacySearchWhenTimetableAdapterMissing() {
 		var repository = new InMemoryRouteSearchRepository();
@@ -2897,6 +2918,44 @@ class RouteSearchServiceTest {
 			List.of(
 				new LoadRouteTimetablePort.TransitStopTime("trip-seoul-4-0010", 1, "station-a", "seoul-4", 600, 600, 0, 0),
 				new LoadRouteTimetablePort.TransitStopTime("trip-seoul-4-0010", 2, "station-b", "seoul-4", 1500, 1500, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime("trip-seoul-4-0907", 1, "station-a", "seoul-4", 32820, 32820, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime("trip-seoul-4-0907", 2, "station-b", "seoul-4", 33720, 33720, 0, 0)
+			),
+			List.of()
+		);
+	}
+
+	private static LoadRouteTimetablePort futureMidnightNextServiceRouteTimetablePort() {
+		return () -> new LoadRouteTimetablePort.RouteTimetable(
+			List.of(new LoadRouteTimetablePort.ServiceCalendar(
+				"weekday-2026",
+				true,
+				true,
+				true,
+				true,
+				true,
+				false,
+				false,
+				LocalDate.parse("2026-07-01"),
+				LocalDate.parse("2026-12-31"),
+				"Asia/Seoul"
+			)),
+			List.of(),
+			List.of(new LoadRouteTimetablePort.TransitRoute(
+				"route-seoul-4",
+				"seoul-4",
+				"4",
+				"수도권 4호선",
+				"사당 방면",
+				"Asia/Seoul"
+			)),
+			List.of(
+				new LoadRouteTimetablePort.TransitTrip("trip-seoul-4-0003", "route-seoul-4", "weekday-2026", "사당", "0", "LOCAL", 0),
+				new LoadRouteTimetablePort.TransitTrip("trip-seoul-4-0907", "route-seoul-4", "weekday-2026", "사당", "0", "LOCAL", 0)
+			),
+			List.of(
+				new LoadRouteTimetablePort.TransitStopTime("trip-seoul-4-0003", 1, "station-a", "seoul-4", 180, 180, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime("trip-seoul-4-0003", 2, "station-b", "seoul-4", 1080, 1080, 0, 0),
 				new LoadRouteTimetablePort.TransitStopTime("trip-seoul-4-0907", 1, "station-a", "seoul-4", 32820, 32820, 0, 0),
 				new LoadRouteTimetablePort.TransitStopTime("trip-seoul-4-0907", 2, "station-b", "seoul-4", 33720, 33720, 0, 0)
 			),

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -826,6 +826,27 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("V2 planner는 환승 전용 경로의 다음 운행 시각도 RAPTOR scan으로 계산한다")
+	void routeV2PlannerReturnsNextServiceTimeForTransferOnlyRoute() {
+		var planner = new RouteV2Planner(legacySearchMustNotBeCalled(), transferRouteTimetablePort());
+
+		var plan = planner.search(new RouteV2SearchUseCase.SearchRouteV2Command(
+			"station-a",
+			"station-b",
+			OffsetDateTime.parse("2026-07-01T23:55:00+09:00"),
+			MobilityType.SENIOR,
+			ConstraintMode.PREFER_STEP_FREE,
+			false,
+			1,
+			3
+		));
+
+		assertThat(plan.statuses()).containsExactly(RouteV2Status.NO_TIMETABLE_SERVICE);
+		assertThat(plan.itineraries()).isEmpty();
+		assertThat(plan.nextServiceTime()).isEqualTo(OffsetDateTime.parse("2026-07-02T09:07:00+09:00"));
+	}
+
+	@Test
 	@DisplayName("V2 planner는 시간표 adapter 미연결 fallback에서는 기존 경로 검색을 유지한다")
 	void routeV2PlannerKeepsLegacySearchWhenTimetableAdapterMissing() {
 		var repository = new InMemoryRouteSearchRepository();

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -868,6 +868,27 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("V2 planner는 03시 전 요청에서 이미 지난 당일 00시대 운행을 다음 운행으로 반환하지 않는다")
+	void routeV2PlannerKeepsNextServiceTimeAfterEarlyMorningDeparture() {
+		var planner = new RouteV2Planner(legacySearchMustNotBeCalled(), earlyMorningNextServiceRouteTimetablePort());
+
+		var plan = planner.search(new RouteV2SearchUseCase.SearchRouteV2Command(
+			"station-a",
+			"station-b",
+			OffsetDateTime.parse("2026-07-02T02:50:00+09:00"),
+			MobilityType.SENIOR,
+			ConstraintMode.PREFER_STEP_FREE,
+			false,
+			1,
+			3
+		));
+
+		assertThat(plan.statuses()).containsExactly(RouteV2Status.NO_TIMETABLE_SERVICE);
+		assertThat(plan.itineraries()).isEmpty();
+		assertThat(plan.nextServiceTime()).isEqualTo(OffsetDateTime.parse("2026-07-02T09:07:00+09:00"));
+	}
+
+	@Test
 	@DisplayName("V2 planner는 시간표 adapter 미연결 fallback에서는 기존 경로 검색을 유지한다")
 	void routeV2PlannerKeepsLegacySearchWhenTimetableAdapterMissing() {
 		var repository = new InMemoryRouteSearchRepository();
@@ -2840,6 +2861,44 @@ class RouteSearchServiceTest {
 				new LoadRouteTimetablePort.TransitStopTime("local-0907", 2, "station-b", "line-local", 34200, 34200, 0, 0),
 				new LoadRouteTimetablePort.TransitStopTime("express-0909", 1, "station-a", "line-express", 32940, 32940, 0, 0),
 				new LoadRouteTimetablePort.TransitStopTime("express-0909", 2, "station-b", "line-express", 33600, 33600, 0, 0)
+			),
+			List.of()
+		);
+	}
+
+	private static LoadRouteTimetablePort earlyMorningNextServiceRouteTimetablePort() {
+		return () -> new LoadRouteTimetablePort.RouteTimetable(
+			List.of(new LoadRouteTimetablePort.ServiceCalendar(
+				"weekday-2026",
+				true,
+				true,
+				true,
+				true,
+				true,
+				false,
+				false,
+				LocalDate.parse("2026-07-01"),
+				LocalDate.parse("2026-12-31"),
+				"Asia/Seoul"
+			)),
+			List.of(),
+			List.of(new LoadRouteTimetablePort.TransitRoute(
+				"route-seoul-4",
+				"seoul-4",
+				"4",
+				"수도권 4호선",
+				"사당 방면",
+				"Asia/Seoul"
+			)),
+			List.of(
+				new LoadRouteTimetablePort.TransitTrip("trip-seoul-4-0010", "route-seoul-4", "weekday-2026", "사당", "0", "LOCAL", 0),
+				new LoadRouteTimetablePort.TransitTrip("trip-seoul-4-0907", "route-seoul-4", "weekday-2026", "사당", "0", "LOCAL", 0)
+			),
+			List.of(
+				new LoadRouteTimetablePort.TransitStopTime("trip-seoul-4-0010", 1, "station-a", "seoul-4", 600, 600, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime("trip-seoul-4-0010", 2, "station-b", "seoul-4", 1500, 1500, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime("trip-seoul-4-0907", 1, "station-a", "seoul-4", 32820, 32820, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime("trip-seoul-4-0907", 2, "station-b", "seoul-4", 33720, 33720, 0, 0)
 			),
 			List.of()
 		);

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -847,6 +847,27 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("V2 planner는 먼저 출발한 유효 운행이 추월되어도 다음 운행 시각으로 유지한다")
+	void routeV2PlannerReturnsEarliestNextServiceTimeWhenLaterTripOvertakes() {
+		var planner = new RouteV2Planner(legacySearchMustNotBeCalled(), overtakenNextServiceRouteTimetablePort());
+
+		var plan = planner.search(new RouteV2SearchUseCase.SearchRouteV2Command(
+			"station-a",
+			"station-b",
+			OffsetDateTime.parse("2026-07-01T23:55:00+09:00"),
+			MobilityType.SENIOR,
+			ConstraintMode.PREFER_STEP_FREE,
+			false,
+			1,
+			3
+		));
+
+		assertThat(plan.statuses()).containsExactly(RouteV2Status.NO_TIMETABLE_SERVICE);
+		assertThat(plan.itineraries()).isEmpty();
+		assertThat(plan.nextServiceTime()).isEqualTo(OffsetDateTime.parse("2026-07-02T09:07:00+09:00"));
+	}
+
+	@Test
 	@DisplayName("V2 planner는 시간표 adapter 미연결 fallback에서는 기존 경로 검색을 유지한다")
 	void routeV2PlannerKeepsLegacySearchWhenTimetableAdapterMissing() {
 		var repository = new InMemoryRouteSearchRepository();
@@ -2788,6 +2809,40 @@ class RouteSearchServiceTest {
 
 	private static LoadRouteTimetablePort transferRouteTimetablePort() {
 		return transferRouteTimetablePort(33780);
+	}
+
+	private static LoadRouteTimetablePort overtakenNextServiceRouteTimetablePort() {
+		return () -> new LoadRouteTimetablePort.RouteTimetable(
+			List.of(new LoadRouteTimetablePort.ServiceCalendar(
+				"weekday-2026",
+				true,
+				true,
+				true,
+				true,
+				true,
+				false,
+				false,
+				LocalDate.parse("2026-07-01"),
+				LocalDate.parse("2026-12-31"),
+				"Asia/Seoul"
+			)),
+			List.of(),
+			List.of(
+				new LoadRouteTimetablePort.TransitRoute("route-local", "line-local", "L", "완행", "도착 방면", "Asia/Seoul"),
+				new LoadRouteTimetablePort.TransitRoute("route-express", "line-express", "X", "급행", "도착 방면", "Asia/Seoul")
+			),
+			List.of(
+				new LoadRouteTimetablePort.TransitTrip("local-0907", "route-local", "weekday-2026", "도착", "0", "LOCAL", 0),
+				new LoadRouteTimetablePort.TransitTrip("express-0909", "route-express", "weekday-2026", "도착", "0", "EXPRESS", 0)
+			),
+			List.of(
+				new LoadRouteTimetablePort.TransitStopTime("local-0907", 1, "station-a", "line-local", 32820, 32820, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime("local-0907", 2, "station-b", "line-local", 34200, 34200, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime("express-0909", 1, "station-a", "line-express", 32940, 32940, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime("express-0909", 2, "station-b", "line-express", 33600, 33600, 0, 0)
+			),
+			List.of()
+		);
 	}
 
 	private static LoadRouteTimetablePort sameArrivalRouteTimetablePort() {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -9463,6 +9463,8 @@ test("V2 경로 검색은 production planner 경계를 통해 요청 조건을 �
   assert.match(controller, /toV2Command\(departureTime\)/);
   assert.match(controller, /RouteSearchV2Response\.from\(plan, request, departureTime\)/);
   assert.match(controller, /plan\.statuses\(\)/);
+  assert.match(controller, /String nextServiceTime/);
+  assert.match(controller, /plan\.nextServiceTime\(\)/);
   assert.doesNotMatch(controller, /List\.of\(\s*"FOUND"[\s\S]*"ROUTE_GRAPH_UNKNOWN"/);
   assert.match(planner, /class RouteV2Planner implements RouteV2SearchUseCase/);
   assert.match(planner, /LoadRouteTimetablePort/);
@@ -9475,9 +9477,13 @@ test("V2 경로 검색은 production planner 경계를 통해 요청 조건을 �
   assert.match(planner, /canUseTimetableRaptor/);
   assert.match(planner, /loadRouteTimetable\(\)/);
   assert.match(planner, /RouteTimetableRaptorPlanner/);
+  assert.match(planner, /noTimetableServicePlan/);
+  assert.match(planner, /nextServiceTime\(command, routeTimetable\(\)\)/);
   assert.match(planner, /searchRouteAlternatives/);
   assert.match(planner, /statusesOf/);
   assert.match(raptorPlanner, /class RouteTimetableRaptorPlanner/);
+  assert.match(raptorPlanner, /Optional<OffsetDateTime> nextServiceTime/);
+  assert.match(raptorPlanner, /earliestDirectDepartureSeconds/);
   assert.match(raptorPlanner, /BoardingSlackPolicy\.secondsFor/);
   assert.match(raptorPlanner, /SERVICE_DAY_CUTOFF_HOUR\s*=\s*3/);
   assert.match(raptorPlanner, /activeServiceIds/);
@@ -9496,6 +9502,7 @@ test("V2 경로 검색은 production planner 경계를 통해 요청 조건을 �
   assert.match(useCase, /alternativeCount < 1/);
   assert.match(useCase, /enum RouteV2Status/);
   assert.match(useCase, /List<RouteV2Status> statuses/);
+  assert.match(useCase, /OffsetDateTime nextServiceTime/);
   assert.match(timetablePort, /interface LoadRouteTimetablePort/);
   assert.match(timetablePort, /loadRouteTimetable/);
   assert.match(timetablePort, /hasRouteTimetable/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -9483,7 +9483,8 @@ test("V2 경로 검색은 production planner 경계를 통해 요청 조건을 �
   assert.match(planner, /statusesOf/);
   assert.match(raptorPlanner, /class RouteTimetableRaptorPlanner/);
   assert.match(raptorPlanner, /Optional<OffsetDateTime> nextServiceTime/);
-  assert.match(raptorPlanner, /earliestDirectDepartureSeconds/);
+  assert.match(raptorPlanner, /scanDestinationLabels/);
+  assert.doesNotMatch(raptorPlanner, /directDepartureSeconds/);
   assert.match(raptorPlanner, /BoardingSlackPolicy\.secondsFor/);
   assert.match(raptorPlanner, /SERVICE_DAY_CUTOFF_HOUR\s*=\s*3/);
   assert.match(raptorPlanner, /activeServiceIds/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -9483,6 +9483,7 @@ test("V2 경로 검색은 production planner 경계를 통해 요청 조건을 �
   assert.match(planner, /statusesOf/);
   assert.match(raptorPlanner, /class RouteTimetableRaptorPlanner/);
   assert.match(raptorPlanner, /Optional<OffsetDateTime> nextServiceTime/);
+  assert.match(raptorPlanner, /candidateServiceDateStartSeconds/);
   assert.match(raptorPlanner, /firstFeasibleDepartureSeconds/);
   assert.match(raptorPlanner, /scanDestinationLabels/);
   assert.doesNotMatch(raptorPlanner, /directDepartureSeconds/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -9485,6 +9485,8 @@ test("V2 경로 검색은 production planner 경계를 통해 요청 조건을 �
   assert.match(raptorPlanner, /Optional<OffsetDateTime> nextServiceTime/);
   assert.match(raptorPlanner, /candidateServiceDateStartSeconds/);
   assert.match(raptorPlanner, /firstFeasibleDepartureSeconds/);
+  assert.match(raptorPlanner, /boardingsByStation/);
+  assert.match(raptorPlanner, /ReachabilityState/);
   assert.match(raptorPlanner, /scanDestinationLabels/);
   assert.doesNotMatch(raptorPlanner, /directDepartureSeconds/);
   assert.match(raptorPlanner, /BoardingSlackPolicy\.secondsFor/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -9483,6 +9483,7 @@ test("V2 경로 검색은 production planner 경계를 통해 요청 조건을 �
   assert.match(planner, /statusesOf/);
   assert.match(raptorPlanner, /class RouteTimetableRaptorPlanner/);
   assert.match(raptorPlanner, /Optional<OffsetDateTime> nextServiceTime/);
+  assert.match(raptorPlanner, /firstFeasibleDepartureSeconds/);
   assert.match(raptorPlanner, /scanDestinationLabels/);
   assert.doesNotMatch(raptorPlanner, /directDepartureSeconds/);
   assert.match(raptorPlanner, /BoardingSlackPolicy\.secondsFor/);


### PR DESCRIPTION
## 관련 이슈

Refs #1620
Refs #1414

## 작업 배경

- #1620 완료 조건 중 첫차 이전/막차 이후 `NO_TIMETABLE_SERVICE` 응답이 다음 운행 시각을 안내해야 하는 backend 계약이 비어 있었다.
- #1671로 RAPTOR scanner는 production 경로에 들어왔지만, no-service plan/API 응답은 status와 빈 itinerary만 반환했다.

## 작업 내용

- `RouteV2Plan`에 nullable `nextServiceTime`을 추가하고 기존 생성자 호환성을 유지했다.
- RAPTOR timetable scanner가 막차 이후 같은 OD의 다음 직통 boardable stop_time을 최대 7 service day 안에서 찾아 반환하게 했다.
- V2 route search 응답에 `nextServiceTime`을 노출하고 planner/API/contract 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
- `./gradlew test --tests com.easysubway.route.application.service.RouteSearchServiceTest.routeV2PlannerReturnsNextServiceTimeAfterLastTrain --tests com.easysubway.route.adapter.in.web.RouteSearchV2ControllerTest.routeSearchV2ReturnsNextServiceTimeAfterLastTrain` 실패 후 구현, 이후 성공
- `./gradlew test --tests com.easysubway.route.application.service.RouteSearchServiceTest --tests com.easysubway.route.adapter.in.web.RouteSearchV2ControllerTest` 성공
- `node --test --test-name-pattern "V2 경로 검색" tools/ci/repository-contract.test.mjs` 성공
- `./gradlew test` 성공
- `node --test tools/ci/repository-contract.test.mjs` 성공
- `git diff --check` 성공

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| RAPTOR no-service next time | Backend | Gradle planner/controller tests | 로컬 명령 출력 | 성공 |
| V2 API contract | Backend | repository contract test | 로컬 명령 출력 | 성공 |
| UI/접근성 수동 QA | Mobile | UI 변경 없음 | 불필요: backend API 계약만 변경 | 해당 없음 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: V2 `NO_TIMETABLE_SERVICE` 응답에 `nextServiceTime` 추가
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `RouteTimetableRaptorPlanner.nextServiceTime()`의 service day 검색과 `RouteSearchV2Response.nextServiceTime`

## 리스크

- 이번 slice의 next service 안내는 같은 trip 안에서 출발역 이후 목적지역까지 가는 직통 후보만 계산한다. 환승 기반 no-service 안내는 RAPTOR 후속 slice에서 확장한다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * V2 경로 검색 결과에 다음 운행 예정 시각이 함께 표시됩니다.
  * 막차 이후 검색 시에도 다음 열차/버스 운행 시간을 확인할 수 있습니다.

* **Bug Fixes**
  * 운행 정보가 없는 경우에도 응답이 더 유용하게 반환되도록 개선했습니다.
  * 다음 운행 시간이 없으면 해당 값은 비어 있는 상태로 안정적으로 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->