### PR TITLE
[Backend] 실시간 trip mapping 실패 계측 (#1416)

### DIFF
--- a/backend/src/main/java/com/easysubway/realtime/application/RealtimeGatewayService.java
+++ b/backend/src/main/java/com/easysubway/realtime/application/RealtimeGatewayService.java
@@ -378,7 +378,10 @@ public class RealtimeGatewayService {
 			arrival.rawDestination(),
 			arrival.rawServicePattern()
 		).map((mapping) -> mappedArrival(arrival, mapping))
-			.orElse(arrival);
+			.orElseGet(() -> {
+				providerMetrics.recordTripMappingFailure();
+				return arrival;
+			});
 	}
 
 	private RealtimeArrival mappedArrival(RealtimeArrival arrival, RealtimeTripMapping mapping) {
@@ -575,6 +578,7 @@ public class RealtimeGatewayService {
 		private final AtomicLong providerTimeoutCount = new AtomicLong();
 		private final AtomicLong providerQuotaExceededCount = new AtomicLong();
 		private final AtomicLong providerEmptyResultCount = new AtomicLong();
+		private final AtomicLong tripMappingFailureCount = new AtomicLong();
 		private final AtomicLong providerLatencyMsTotal = new AtomicLong();
 		private final AtomicLong resultCount = new AtomicLong();
 		private final AtomicLong freshResultCount = new AtomicLong();
@@ -597,6 +601,10 @@ public class RealtimeGatewayService {
 
 		private void recordEmptyResult() {
 			providerEmptyResultCount.incrementAndGet();
+		}
+
+		private void recordTripMappingFailure() {
+			tripMappingFailureCount.incrementAndGet();
 		}
 
 		private void recordResult(RealtimeStatus status) {
@@ -627,6 +635,7 @@ public class RealtimeGatewayService {
 				providerTimeoutCount.get(),
 				providerQuotaExceededCount.get(),
 				providerEmptyResultCount.get(),
+				tripMappingFailureCount.get(),
 				ratio(freshResultCount.get(), results),
 				ratio(staleResultCount.get(), results),
 				ratio(unsupportedResultCount.get(), results),

--- a/backend/src/main/java/com/easysubway/realtime/application/RealtimeProviderHealthSnapshot.java
+++ b/backend/src/main/java/com/easysubway/realtime/application/RealtimeProviderHealthSnapshot.java
@@ -8,6 +8,7 @@ public record RealtimeProviderHealthSnapshot(
 	long providerTimeoutCount,
 	long providerQuotaExceededCount,
 	long providerEmptyResultCount,
+	long tripMappingFailureCount,
 	double freshResultRatio,
 	double staleResultRatio,
 	double unsupportedRatio,

--- a/backend/src/test/java/com/easysubway/realtime/application/RealtimeGatewayServiceTest.java
+++ b/backend/src/test/java/com/easysubway/realtime/application/RealtimeGatewayServiceTest.java
@@ -185,6 +185,26 @@ class RealtimeGatewayServiceTest {
 	}
 
 	@Test
+	@DisplayName("provider trip mapping 실패는 도착 row를 버리지 않고 metric으로 계측한다")
+	void arrivalTripMappingMissIsCountedWithoutDroppingArrival() {
+		CountingProvider provider = new CountingProvider();
+		StubMappingPort mappingPort = new StubMappingPort();
+		mappingPort.add(mapping("station-sangnoksu", "seoul-4", "1004", "1004000448", "상록수", true, true, "OFFICIAL"));
+		RealtimeGatewayService service = service(
+			provider,
+			Clock.fixed(Instant.parse("2026-06-26T08:00:00Z"), ZoneOffset.UTC),
+			mappingPort
+		);
+
+		RealtimeArrivalResult result = service.arrivals(sangnoksuQuery());
+		RealtimeProviderHealthSnapshot snapshot = service.providerHealthSnapshot();
+
+		assertThat(result.status()).hasToString("FRESH");
+		assertThat(result.arrivals()).hasSize(1);
+		assertThat(snapshot.tripMappingFailureCount()).isEqualTo(1);
+	}
+
+	@Test
 	@DisplayName("quota 초과는 circuit을 열고 다음 요청에서 provider를 호출하지 않는다")
 	void quotaExhaustionOpensCircuit() {
 		MutableClock clock = new MutableClock(Instant.parse("2026-06-26T08:00:00Z"));


### PR DESCRIPTION
## 관련 이슈

Refs #1416

## 작업 배경

- TOPIS 실시간 overlay에서 canonical trip mapping 실패 row를 폐기하지 않고 계측해야 합니다.

## 작업 내용

- `RealtimeGatewayService`가 trip mapping miss를 health metric으로 집계합니다.
- `RealtimeProviderHealthSnapshot`에 `tripMappingFailureCount`를 노출합니다.
- mapping miss가 도착 row를 버리지 않는 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.realtime.application.RealtimeGatewayServiceTest` PASS
  - `node --test tools/ci/repository-contract.test.mjs` PASS
  - `git diff --check` PASS
  - `./gradlew test` PASS

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| realtime trip mapping miss metric | backend | automated test | `RealtimeGatewayServiceTest` | PASS |
| repository contract | repository | node test | `tools/ci/repository-contract.test.mjs` | PASS |
| UI evidence | N/A | backend metric only | 증거 불필요: UI 변경 없음 | PASS |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: health snapshot에 `tripMappingFailureCount` 추가
- backend identity: PR merge commit SHA

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `RealtimeGatewayService.canonicalizeArrival`

## 리스크

- health snapshot 응답 필드가 하나 늘어납니다. 기존 필드는 제거하지 않습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 도착 정보의 매핑이 실패해도 해당 항목을 그대로 유지하고, 처리 상태는 정상적으로 이어지도록 개선했습니다.
  * 매핑 실패 횟수가 건강 상태 요약에 반영되도록 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->