### PR TITLE
[Backend] RAPTOR calendar exception 추가 운행 회귀 보강 (#1620)

### DIFF
--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -1393,6 +1393,43 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("V2 planner는 calendar exception 추가일의 임시 시간표를 탐색한다")
+	void routeV2PlannerAddsCalendarDateExceptionService() {
+		var planner = new RouteV2Planner(legacySearchMustNotBeCalled(), addedCalendarDateRouteTimetablePort(
+			LocalDate.parse("2026-07-01")
+		));
+
+		var plan = planner.search(routeV2Command(ConstraintMode.PREFER_STEP_FREE, MobilityType.SENIOR, 1, 3));
+
+		assertThat(plan.statuses()).containsExactly(RouteV2Status.FOUND);
+		assertThat(plan.itineraries()).hasSize(1);
+		assertThat(plan.itineraries().getFirst().etaSource()).isEqualTo(EtaSource.PLANNED);
+	}
+
+	@Test
+	@DisplayName("V2 planner는 다음 운행 시각 계산에도 calendar exception 추가일을 반영한다")
+	void routeV2PlannerUsesAddedCalendarDateForNextServiceTime() {
+		var planner = new RouteV2Planner(legacySearchMustNotBeCalled(), addedCalendarDateRouteTimetablePort(
+			LocalDate.parse("2026-07-02")
+		));
+
+		var plan = planner.search(new RouteV2SearchUseCase.SearchRouteV2Command(
+			"station-a",
+			"station-b",
+			OffsetDateTime.parse("2026-07-01T23:55:00+09:00"),
+			MobilityType.SENIOR,
+			ConstraintMode.PREFER_STEP_FREE,
+			false,
+			1,
+			3
+		));
+
+		assertThat(plan.statuses()).containsExactly(RouteV2Status.NO_TIMETABLE_SERVICE);
+		assertThat(plan.itineraries()).isEmpty();
+		assertThat(plan.nextServiceTime()).isEqualTo(OffsetDateTime.parse("2026-07-02T09:07:00+09:00"));
+	}
+
+	@Test
 	@DisplayName("V2 planner는 pickup/drop-off 제한 stop_times를 승하차 후보에서 제외한다")
 	void routeV2PlannerHonorsPickupAndDropOffRestrictions() {
 		var noPickupPlanner = new RouteV2Planner(legacySearchMustNotBeCalled(), restrictedStopRouteTimetablePort(1, 0));
@@ -2818,6 +2855,35 @@ class RouteSearchServiceTest {
 				timetable.transitFrequencies()
 			);
 		};
+	}
+
+	private static LoadRouteTimetablePort addedCalendarDateRouteTimetablePort(LocalDate serviceDate) {
+		return () -> new LoadRouteTimetablePort.RouteTimetable(
+			List.of(),
+			List.of(new LoadRouteTimetablePort.ServiceCalendarDate("special-2026", serviceDate, 1)),
+			List.of(new LoadRouteTimetablePort.TransitRoute(
+				"route-seoul-4-special",
+				"seoul-4",
+				"4",
+				"수도권 4호선 임시",
+				"사당 방면",
+				"Asia/Seoul"
+			)),
+			List.of(new LoadRouteTimetablePort.TransitTrip(
+				"trip-seoul-4-special-0907",
+				"route-seoul-4-special",
+				"special-2026",
+				"사당",
+				"0",
+				"LOCAL",
+				0
+			)),
+			List.of(
+				new LoadRouteTimetablePort.TransitStopTime("trip-seoul-4-special-0907", 1, "station-a", "seoul-4", 32820, 32820, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime("trip-seoul-4-special-0907", 2, "station-b", "seoul-4", 33420, 33420, 0, 0)
+			),
+			List.of()
+		);
 	}
 
 	private static LoadRouteTimetablePort restrictedStopRouteTimetablePort(int pickupType, int dropOffType) {


### PR DESCRIPTION
## 관련 이슈

Refs #1620
Refs #1414

## 작업 배경

- #1620의 RAPTOR 시간표 core 완료 조건 중 service_calendar_dates exception 평가를 backend planner 회귀로 더 좁게 고정합니다.

## 작업 내용

- calendar exception_type=1 추가 운행만 있는 service_id를 RAPTOR scan 후보로 사용하는 테스트를 추가했습니다.
- 막차 이후 nextServiceTime 계산도 추가 운행일을 반영하는지 고정했습니다.

## 검증

- 실행한 명령과 결과:
- `./gradlew test --tests com.easysubway.route.application.service.RouteSearchServiceTest` PASS
- `git diff --check` PASS
- `node --test tools/ci/repository-contract.test.mjs` PASS (158 tests)
- `./gradlew test` PASS

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| RAPTOR calendar addition regression | backend | Gradle test | local terminal output | PASS |
| Repository contract | repo | node test | local terminal output | PASS |
| UI/접근성/배포 증거 | 해당 없음 | backend test-only 변경 | 화면/배포 변경 없음 | 증거 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: test-only 변경, 배포 identity 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `RouteSearchServiceTest`의 calendar exception 추가 운행 RAPTOR 회귀 2건

## 리스크

- production 로직 변경 없음. #1620 완료 조건 중 calendar exception 평가 회귀를 보강하는 테스트 PR입니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.