### PR TITLE
[Chore] 요약 RIDE edge fixture-only 정책 정리

### DIFF
--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -8478,7 +8478,7 @@ test("공식 source ingest adapter는 cross-line EXPRESS summary edge도 격리 
 
   await assert.rejects(
     importOfficialSourceInput(outputDir, input),
-    /routeGraphTopologyPolicy\.summaryRideEdges must mark non-adjacent EXPRESS RIDE edges as release-blocking-regression-only/,
+    /production routeEdges non-adjacent EXPRESS summary edge is fixture-only/,
   );
 });
 
@@ -8950,9 +8950,9 @@ test("수도권 pilot production source input은 UNKNOWN strict coverage gap을 
   const adjacencySafeInputPath = path.join(outputDir, "capital-pilot-production-adjacency-safe.json");
   await writeFile(adjacencySafeInputPath, `${JSON.stringify(adjacencySafeInput, null, 2)}\n`);
 
-  const summaryRideRegressionInput = withProductionSummaryRideEdges(input);
-  const summaryRideRegressionInputPath = path.join(outputDir, "summary-ride-regression-only.json");
-  await writeFile(summaryRideRegressionInputPath, `${JSON.stringify(summaryRideRegressionInput, null, 2)}\n`);
+  const summaryRideFixtureOnlyInput = withProductionSummaryRideEdges(input);
+  const summaryRideFixtureOnlyInputPath = path.join(outputDir, "summary-ride-fixture-only.json");
+  await writeFile(summaryRideFixtureOnlyInputPath, `${JSON.stringify(summaryRideFixtureOnlyInput, null, 2)}\n`);
   await assert.rejects(
     execFileAsync(
       process.execPath,
@@ -8961,13 +8961,13 @@ test("수도권 pilot production source input은 UNKNOWN strict coverage gap을 
         "--inventory",
         "tools/datapack/source-inventory.json",
         "--input",
-        summaryRideRegressionInputPath,
+        summaryRideFixtureOnlyInputPath,
         "--output",
-        path.join(outputDir, "summary-ride-regression-only-fixture.json"),
+        path.join(outputDir, "summary-ride-fixture-only-output.json"),
       ],
       { cwd: root },
     ),
-    /production routeEdges non-adjacent EXPRESS summary edge is regression-only/,
+    /production routeEdges non-adjacent EXPRESS summary edge is fixture-only/,
   );
 
   const lowercaseRideEdgeInput = JSON.parse(JSON.stringify(withProductionSummaryRideEdges(input)));
@@ -8990,7 +8990,7 @@ test("수도권 pilot production source input은 UNKNOWN strict coverage gap을 
       ],
       { cwd: root },
     ),
-    /production routeEdges non-adjacent EXPRESS summary edge is regression-only/,
+    /production routeEdges non-adjacent EXPRESS summary edge is fixture-only/,
   );
 
   await execFileAsync(
@@ -11339,13 +11339,7 @@ function withProductionSummaryRideEdges(input, servicePattern = "EXPRESS") {
     ...input,
     routeEdges: [...productionSummaryRideEdges(servicePattern), ...input.routeEdges],
     routeGraphTopologyPolicy: {
-      summaryRideEdges: "release-blocking-regression-only",
-      productionReadinessRequirement:
-        "replace summary RIDE edges with adjacent-station LOCAL RIDE edges before ETA or release-readiness claim",
-      nonAdjacentExpressRideEdgeIds: [
-        "edge-sangnoksu-sadang-seoul-4",
-        "edge-sadang-sangnoksu-seoul-4",
-      ],
+      summaryRideEdges: "fixture-only",
     },
   };
 }

--- a/tools/datapack/import-official-sources.mjs
+++ b/tools/datapack/import-official-sources.mjs
@@ -2,6 +2,8 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 
+const SUMMARY_RIDE_EDGE_PRODUCTION_POLICY = "fixture-only";
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const inventory = JSON.parse(await readFile(requireArg(args, "inventory"), "utf8"));
@@ -789,32 +791,14 @@ function validateProductionSummaryRideEdgePolicy(stationLines, networkEdges, pol
   if (nonAdjacentExpressRideEdgeIds.length === 0) {
     return;
   }
-  if (policy?.summaryRideEdges === "release-blocking-regression-only") {
+  if (policy?.summaryRideEdges && policy.summaryRideEdges !== SUMMARY_RIDE_EDGE_PRODUCTION_POLICY) {
     throw new Error(
-      `production routeEdges non-adjacent EXPRESS summary edge is regression-only: ${nonAdjacentExpressRideEdgeIds.join(", ")}`,
+      `routeGraphTopologyPolicy.summaryRideEdges must be ${SUMMARY_RIDE_EDGE_PRODUCTION_POLICY} for non-adjacent EXPRESS RIDE edges`,
     );
   }
-  if (
-    !policy ||
-    typeof policy !== "object" ||
-    Array.isArray(policy) ||
-    policy.summaryRideEdges !== "release-blocking-regression-only"
-  ) {
-    throw new Error(
-      "routeGraphTopologyPolicy.summaryRideEdges must mark non-adjacent EXPRESS RIDE edges as release-blocking-regression-only",
-    );
-  }
-  const declaredEdgeIds = requiredStringArray(
-    policy.nonAdjacentExpressRideEdgeIds,
-    "routeGraphTopologyPolicy.nonAdjacentExpressRideEdgeIds",
+  throw new Error(
+    `production routeEdges non-adjacent EXPRESS summary edge is ${SUMMARY_RIDE_EDGE_PRODUCTION_POLICY}: ${nonAdjacentExpressRideEdgeIds.join(", ")}`,
   );
-  const declaredEdgeIdSet = new Set(declaredEdgeIds);
-  for (const edgeId of nonAdjacentExpressRideEdgeIds) {
-    if (!declaredEdgeIdSet.has(edgeId)) {
-      throw new Error(`routeGraphTopologyPolicy.nonAdjacentExpressRideEdgeIds missing: ${edgeId}`);
-    }
-  }
-  requiredString(policy.productionReadinessRequirement, "routeGraphTopologyPolicy.productionReadinessRequirement");
 }
 
 function stationLineNodeFromRouteNode(nodeId) {


### PR DESCRIPTION
## 관련 이슈

Refs #1400
Refs #1414

## 작업 배경

- production routing graph의 요약 RIDE edge 정책 표현이 `release-blocking-regression-only`로 남아 있어 fixture-only 의도가 흐렸습니다.

## 작업 내용

- non-adjacent EXPRESS summary RIDE edge production import 실패 메시지를 `fixture-only` 정책으로 정리했습니다.
- 관련 datapack importer 회귀 테스트 기대값과 helper policy를 `fixture-only`로 맞췄습니다.

## 검증

- 실행한 명령과 결과:
- `node --test tools/datapack/datapack-tools.test.mjs` PASS (181)
- `git diff --check` PASS
- `node --test tools/ci/repository-contract.test.mjs` PASS (158)

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| datapack importer regression | local | `node --test tools/datapack/datapack-tools.test.mjs` | terminal output | PASS |
| repository contract | local | `node --test tools/ci/repository-contract.test.mjs` | terminal output | PASS |
| diff whitespace | local | `git diff --check` | terminal output | PASS |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `tools/datapack/import-official-sources.mjs`의 summary RIDE edge production reject path

## 리스크

- production import 실패 메시지와 test helper 이름 정리만 포함합니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.