### PR TITLE
[Mobile] 노선도 성능 evidence를 native 렌더러·FrameTiming으로 전환 (#1643)

### DIFF
--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -2274,7 +2274,10 @@ void _logRouteMapFrameTimings(List<FrameTiming> timings) {
     final buildMs = timing.buildDuration.inMicroseconds / 1000.0;
     final rasterMs = timing.rasterDuration.inMicroseconds / 1000.0;
     final totalMs = timing.totalSpan.inMicroseconds / 1000.0;
-    debugPrint(
+    // debugPrint는 throttle(debugPrintThrottled)이라 pan 중 다량의 프레임 로그를
+    // 큐잉·드롭해 janky burst 구간을 undercount할 수 있다(jank% 하향 편향). 측정
+    // 정확도를 위해 unthrottled synchronous 출력으로 모든 프레임을 남긴다.
+    debugPrintSynchronously(
       'routeMapFrame '
       'buildMs=${buildMs.toStringAsFixed(2)} '
       'rasterMs=${rasterMs.toStringAsFixed(2)} '

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:math' as math;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 
@@ -2265,6 +2266,23 @@ const _routeMapGestureMaxTranslationDriftFraction = 1.35;
 const _routeMapGestureMaxScaleRatio = 3.4;
 const _routeMapGestureRendererOverscanFactor = 3.25;
 
+/// #1643 성능 QA: 노선도 프레임의 build/raster/total 시간을 logcat에 기록한다.
+/// run-route-map-android-evidence.sh가 'routeMapFrame' 라인을 grep해 jank·P90를
+/// 산출한다(Flutter는 dumpsys gfxinfo로 프레임이 안 잡혀 FrameTiming으로 계측).
+void _logRouteMapFrameTimings(List<FrameTiming> timings) {
+  for (final timing in timings) {
+    final buildMs = timing.buildDuration.inMicroseconds / 1000.0;
+    final rasterMs = timing.rasterDuration.inMicroseconds / 1000.0;
+    final totalMs = timing.totalSpan.inMicroseconds / 1000.0;
+    debugPrint(
+      'routeMapFrame '
+      'buildMs=${buildMs.toStringAsFixed(2)} '
+      'rasterMs=${rasterMs.toStringAsFixed(2)} '
+      'totalMs=${totalMs.toStringAsFixed(2)}',
+    );
+  }
+}
+
 class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
     with WidgetsBindingObserver {
   String? _layoutKey;
@@ -2294,10 +2312,19 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
+    // #1643 성능 QA: 노선도가 떠 있는 동안 프레임 build/raster 시간을 logcat에
+    // 기록한다. 구조화 canvas는 Flutter 자체 렌더 파이프라인이라 dumpsys gfxinfo로
+    // 프레임이 잡히지 않으므로 FrameTiming으로 계측한다. release에는 넣지 않는다.
+    if (!kReleaseMode) {
+      SchedulerBinding.instance.addTimingsCallback(_logRouteMapFrameTimings);
+    }
   }
 
   @override
   void dispose() {
+    if (!kReleaseMode) {
+      SchedulerBinding.instance.removeTimingsCallback(_logRouteMapFrameTimings);
+    }
     WidgetsBinding.instance.removeObserver(this);
     _pendingCamera = null;
     super.dispose();

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -11509,14 +11509,17 @@ test("노선도 Android 실기기 evidence runner는 frame, memory, renderer rec
   assert.match(script, /logcat -d -v time > "\$ARTIFACT_DIR\/logcat\.txt"/);
   assert.match(script, /uiautomator dump/);
   assert.match(script, /screencap -p/);
-  assert.match(script, /routeMapRenderer disposed/);
-  assert.match(script, /input tap "\$ROUTE_TAB_X" "\$BOTTOM_NAV_Y"/);
-  assert.match(script, /input tap "\$HOME_TAB_X" "\$BOTTOM_NAV_Y"/);
+  // #1641 native canvas 렌더러: WebView dispose 로그 대신 pan/zoom 크래시
+  // 시그니처가 차단 조건이다. 노선도가 홈이라 하단 탭 진입/이탈이 없다.
+  assert.match(script, /renderer-crashes\.log/);
+  assert.match(script, /FATAL EXCEPTION/);
+  assert.doesNotMatch(script, /routeMapRenderer disposed/);
+  assert.doesNotMatch(script, /BOTTOM_NAV_Y/);
   assert.match(script, /input swipe "\$PAN_RIGHT_X" "\$PAN_Y" "\$PAN_LEFT_X" "\$PAN_Y"/);
   assert.match(script, /summary\.md/);
 });
 
-test("노선도 Android evidence analyzer는 profile frame, memory, camera latency를 요약한다", async () => {
+test("노선도 Android evidence analyzer는 profile frame, memory, 렌더러 안정성을 요약한다", async () => {
   const dir = await mkdtemp(path.join(tmpdir(), "easysubway-route-map-evidence-"));
   const artifactDir = path.join(dir, "run-1");
   await mkdir(artifactDir, { recursive: true });
@@ -11554,12 +11557,16 @@ test("노선도 Android evidence analyzer는 profile frame, memory, camera laten
       "TOTAL PSS:   591090            TOTAL RSS:   723053       TOTAL SWAP PSS:      272",
     ].join("\n"),
   );
+  // native canvas 렌더러는 pan/zoom 구간에서 크래시 시그니처가 없어야 한다(빈 로그).
+  await writeFile(path.join(artifactDir, "renderer-crashes.log"), "");
+  // #1643 FrameTiming 정본: 앱이 로깅한 노선도 프레임 build/raster/total(ms).
   await writeFile(
-    path.join(artifactDir, "route-map-renderer.log"),
+    path.join(artifactDir, "route-map-frames.log"),
     [
-      "06-26 10:25:37.509 I/flutter: routeMapRenderer cameraLatency revision=0 elapsedMs=12",
-      "06-26 10:25:42.432 I/flutter: routeMapRenderer cameraLatency revision=1 elapsedMs=48",
-      "06-26 10:25:46.185 I/flutter: routeMapRenderer disposed",
+      "routeMapFrame buildMs=4.20 rasterMs=6.10 totalMs=12.50",
+      "routeMapFrame buildMs=5.00 rasterMs=8.00 totalMs=14.00",
+      "routeMapFrame buildMs=18.30 rasterMs=9.00 totalMs=22.10",
+      "routeMapFrame buildMs=6.00 rasterMs=7.50 totalMs=13.00",
     ].join("\n"),
   );
 
@@ -11583,10 +11590,16 @@ test("노선도 Android evidence analyzer는 profile frame, memory, camera laten
   assert.equal(output.runs[0].gfxinfo.jankyPercent, 5.36);
   assert.equal(output.runs[0].gfxinfo.p99Ms, 33);
   assert.equal(output.runs[0].meminfo.totalPssKb, 591090);
-  assert.equal(output.runs[0].renderer.cameraLatencyP95Ms, 48);
+  assert.equal(output.runs[0].renderer.crashSignatureCount, 0);
+  // FrameTiming(정본): 4 프레임 중 1개(build 18.3ms)가 1 vsync 초과 = 25% janky.
+  assert.equal(output.runs[0].frameTiming.frameSampleCount, 4);
+  assert.equal(output.runs[0].frameTiming.jankyFrames, 1);
+  assert.equal(output.runs[0].frameTiming.jankyPercent, 25);
+  assert.equal(output.runs[0].frameTiming.buildP90Ms, 18.3);
   assert.deepEqual(output.aggregate.measurementScopes, ["gesture_after_route_map_settle"]);
   assert.equal(output.aggregate.maxP95FrameMs, 25);
-  assert.equal(output.aggregate.disposeObservedInAllRuns, true);
+  assert.equal(output.aggregate.maxFrameJankyPercent, 25);
+  assert.equal(output.aggregate.noCrashesInAllRuns, true);
 });
 
 async function classifyChangedFiles(files) {

--- a/tools/mobile/analyze-route-map-android-evidence.mjs
+++ b/tools/mobile/analyze-route-map-android-evidence.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { readFileSync, statSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
 import process from "node:process";
 
@@ -112,18 +112,50 @@ function percentile(values, percentileValue) {
   return sorted[index];
 }
 
-function parseRendererLog(text) {
-  const latencies = [...text.matchAll(/cameraLatency revision=\d+ elapsedMs=(\d+)/g)].map((match) =>
-    parseNumber(match[1]),
-  );
+// 구조화 canvas 렌더러(#1641)는 WebView cameraLatency/dispose 로그를 내지 않는다.
+// pan/zoom 구간의 렌더러 크래시 시그니처 수만 집계해 안정성 게이트로 쓴다.
+function parseRendererCrashes(text) {
+  const signatures = text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  return { crashSignatureCount: signatures.length };
+}
+
+// #1643 프레임 성능 정본: 앱이 로깅한 routeMapFrame build/raster/total(ms)에서
+// P50/P90 지연과 jank 비율(빌드 또는 래스터가 1 vsync=16.7ms 초과한 프레임)을 낸다.
+const FRAME_BUDGET_MS = 16.7;
+
+function parseFrameTimings(text) {
+  const frames = [
+    ...text.matchAll(
+      /routeMapFrame buildMs=([\d.]+) rasterMs=([\d.]+) totalMs=([\d.]+)/g,
+    ),
+  ].map((match) => ({
+    build: Number.parseFloat(match[1]),
+    raster: Number.parseFloat(match[2]),
+    total: Number.parseFloat(match[3]),
+  }));
+  const builds = frames.map((frame) => frame.build);
+  const rasters = frames.map((frame) => frame.raster);
+  const totals = frames.map((frame) => frame.total);
+  const jankyFrames = frames.filter(
+    (frame) => frame.build > FRAME_BUDGET_MS || frame.raster > FRAME_BUDGET_MS,
+  ).length;
   return {
-    cameraLatencyCount: latencies.length,
-    cameraLatencyMinMs: latencies.length > 0 ? Math.min(...latencies) : null,
-    cameraLatencyP50Ms: percentile(latencies, 50),
-    cameraLatencyP95Ms: percentile(latencies, 95),
-    cameraLatencyP99Ms: percentile(latencies, 99),
-    cameraLatencyMaxMs: latencies.length > 0 ? Math.max(...latencies) : null,
-    disposedObserved: /routeMapRenderer disposed/.test(text),
+    frameSampleCount: frames.length,
+    buildP50Ms: percentile(builds, 50),
+    buildP90Ms: percentile(builds, 90),
+    buildP99Ms: percentile(builds, 99),
+    rasterP50Ms: percentile(rasters, 50),
+    rasterP90Ms: percentile(rasters, 90),
+    rasterP99Ms: percentile(rasters, 99),
+    totalP90Ms: percentile(totals, 90),
+    jankyFrames,
+    jankyPercent:
+      frames.length > 0
+        ? Math.round((jankyFrames / frames.length) * 10000) / 100
+        : null,
   };
 }
 
@@ -132,7 +164,13 @@ function analyzeRun(artifactDir) {
   const metadata = parseMetadata(readRequired(path.join(dir, "metadata.env")));
   const gfxinfo = parseGfxinfo(readRequired(path.join(dir, "gfxinfo.txt")));
   const meminfo = parseMeminfo(readRequired(path.join(dir, "meminfo.txt")));
-  const renderer = parseRendererLog(readRequired(path.join(dir, "route-map-renderer.log")));
+  const crashesPath = path.join(dir, "renderer-crashes.log");
+  const renderer = parseRendererCrashes(
+    existsSync(crashesPath) ? readFileSync(crashesPath, "utf8") : "",
+  );
+  const frameTiming = parseFrameTimings(
+    readRequired(path.join(dir, "route-map-frames.log")),
+  );
   return {
     artifactDir: dir,
     serial: metadata.serial ?? "",
@@ -147,6 +185,7 @@ function analyzeRun(artifactDir) {
     gfxinfo,
     meminfo,
     renderer,
+    frameTiming,
   };
 }
 
@@ -157,9 +196,21 @@ function aggregate(runs) {
     maxJankyPercent: Math.max(...runs.map((run) => run.gfxinfo.jankyPercent ?? 0)),
     maxP95FrameMs: Math.max(...runs.map((run) => run.gfxinfo.p95Ms ?? 0)),
     maxP99FrameMs: Math.max(...runs.map((run) => run.gfxinfo.p99Ms ?? 0)),
-    maxCameraLatencyP95Ms: Math.max(...runs.map((run) => run.renderer.cameraLatencyP95Ms ?? 0)),
     maxTotalPssKb: Math.max(...runs.map((run) => run.meminfo.totalPssKb ?? 0)),
-    disposeObservedInAllRuns: runs.every((run) => run.renderer.disposedObserved),
+    maxFrameJankyPercent: Math.max(
+      ...runs.map((run) => run.frameTiming.jankyPercent ?? 0),
+    ),
+    maxBuildP90Ms: Math.max(...runs.map((run) => run.frameTiming.buildP90Ms ?? 0)),
+    maxRasterP90Ms: Math.max(
+      ...runs.map((run) => run.frameTiming.rasterP90Ms ?? 0),
+    ),
+    totalCrashSignatures: runs.reduce(
+      (sum, run) => sum + (run.renderer.crashSignatureCount ?? 0),
+      0,
+    ),
+    noCrashesInAllRuns: runs.every(
+      (run) => (run.renderer.crashSignatureCount ?? 0) === 0,
+    ),
   };
 }
 
@@ -171,13 +222,20 @@ function markdownReport(result) {
     `- measurement_scopes: ${result.aggregate.measurementScopes.join(", ")}`,
     `- max_janky_percent: ${result.aggregate.maxJankyPercent}`,
     `- max_p95_frame_ms: ${result.aggregate.maxP95FrameMs}`,
-    `- max_p99_frame_ms: ${result.aggregate.maxP99FrameMs}`,
-    `- max_camera_latency_p95_ms: ${result.aggregate.maxCameraLatencyP95Ms}`,
+    `- max_p99_frame_ms_gfxinfo_hwui_only: ${result.aggregate.maxP99FrameMs}`,
     `- max_total_pss_kb: ${result.aggregate.maxTotalPssKb}`,
-    `- dispose_observed_in_all_runs: ${result.aggregate.disposeObservedInAllRuns}`,
+    `- total_crash_signatures: ${result.aggregate.totalCrashSignatures}`,
+    `- no_crashes_in_all_runs: ${result.aggregate.noCrashesInAllRuns}`,
     "",
-    "| run | scope | build | viewport | frames | janky | p95 frame | p99 frame | camera p95 | total PSS | dispose | evidence |",
-    "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+    "FrameTiming(정본, Flutter canvas 프레임):",
+    `- max_frame_janky_percent: ${result.aggregate.maxFrameJankyPercent}`,
+    `- max_build_p90_ms: ${result.aggregate.maxBuildP90Ms}`,
+    `- max_raster_p90_ms: ${result.aggregate.maxRasterP90Ms}`,
+    "",
+    "> gfxinfo frame 지표는 HWUI 전용이라 Flutter canvas 노선도 프레임을 반영하지 않는다. 프레임 성능은 FrameTiming(build/raster p90·janky%)이 정본이다.",
+    "",
+    "| run | scope | build | viewport | frame samples | frame janky | build p90 | raster p90 | total PSS | crashes | evidence |",
+    "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
   ];
   for (const [index, run] of result.runs.entries()) {
     const cells = [
@@ -185,15 +243,14 @@ function markdownReport(result) {
       run.measurementScope,
       run.buildMode,
       run.viewport,
-      run.gfxinfo.totalFrames ?? "",
-      run.gfxinfo.jankyPercent == null
+      run.frameTiming.frameSampleCount ?? "",
+      run.frameTiming.jankyPercent == null
         ? ""
-        : `${run.gfxinfo.jankyFrames} (${run.gfxinfo.jankyPercent}%)`,
-      run.gfxinfo.p95Ms == null ? "" : `${run.gfxinfo.p95Ms}ms`,
-      run.gfxinfo.p99Ms == null ? "" : `${run.gfxinfo.p99Ms}ms`,
-      run.renderer.cameraLatencyP95Ms == null ? "" : `${run.renderer.cameraLatencyP95Ms}ms`,
+        : `${run.frameTiming.jankyFrames} (${run.frameTiming.jankyPercent}%)`,
+      run.frameTiming.buildP90Ms == null ? "" : `${run.frameTiming.buildP90Ms}ms`,
+      run.frameTiming.rasterP90Ms == null ? "" : `${run.frameTiming.rasterP90Ms}ms`,
       run.meminfo.totalPssKb ?? "",
-      run.renderer.disposedObserved,
+      run.renderer.crashSignatureCount ?? "",
       run.artifactDir,
     ];
     lines.push(`| ${cells.join(" | ")} |`);

--- a/tools/mobile/run-route-map-android-evidence.sh
+++ b/tools/mobile/run-route-map-android-evidence.sh
@@ -180,8 +180,6 @@ require_non_empty "$ARTIFACT_DIR/package.txt"
 adb_device logcat -c
 adb_device shell am force-stop "$PACKAGE"
 adb_device shell dumpsys gfxinfo "$PACKAGE" reset >/dev/null 2>&1 || true
-# cold start → 노선도 첫 표시(#1643 cold start 지표): launch 직후부터 settle까지.
-launch_start_ns="$(adb_device shell 'echo $EPOCHREALTIME' | tr -d '\r' | tr -d '.')"
 adb_device shell monkey -p "$PACKAGE" 1 > "$ARTIFACT_DIR/launch.txt"
 sleep "$SETTLE_SECONDS"
 

--- a/tools/mobile/run-route-map-android-evidence.sh
+++ b/tools/mobile/run-route-map-android-evidence.sh
@@ -19,12 +19,13 @@ Options:
                             renderer latency focus on gestures instead of initial map entry.
   -h, --help                Show this help.
 
-The script installs nothing. Install a debug or profile APK first, then run this
-against the same device. Release APKs are not supported because the renderer
-dispose signal is intentionally emitted only in debug/profile builds. It fails
-when the device is unavailable, the route map flow cannot be driven, evidence
-files are empty, or the renderer dispose log is not observed after leaving the
-route map.
+The script installs nothing. Install a debug or profile APK first (framestats
+are most useful there) and complete onboarding so the app opens directly to the
+route map home. The route map uses the structured native canvas renderer
+(#1641); there is no WebView dispose signal, so the gate is renderer crash
+signatures during pan/zoom instead. It fails when the device is unavailable,
+the route map cannot be driven, evidence files are empty, or a renderer crash
+signature is observed during the gesture window.
 USAGE
 }
 
@@ -153,9 +154,8 @@ fi
 
 WIDTH="${BASH_REMATCH[1]}"
 HEIGHT="${BASH_REMATCH[2]}"
-ROUTE_TAB_X=$((WIDTH * 3 / 10))
-HOME_TAB_X=$((WIDTH / 10))
-BOTTOM_NAV_Y=$((HEIGHT * 9 / 10))
+# 노선도는 홈 화면이다(#1641 구조화 canvas 전환 이후 하단 탭 없음). 앱은 온보딩을
+# 마친 상태여야 하며, 실행 즉시 노선도가 표시된다.
 PAN_Y=$((HEIGHT / 2))
 PAN_LEFT_X=$((WIDTH * 3 / 10))
 PAN_RIGHT_X=$((WIDTH * 7 / 10))
@@ -179,22 +179,18 @@ require_non_empty "$ARTIFACT_DIR/package.txt"
 
 adb_device logcat -c
 adb_device shell am force-stop "$PACKAGE"
+adb_device shell dumpsys gfxinfo "$PACKAGE" reset >/dev/null 2>&1 || true
+# cold start → 노선도 첫 표시(#1643 cold start 지표): launch 직후부터 settle까지.
+launch_start_ns="$(adb_device shell 'echo $EPOCHREALTIME' | tr -d '\r' | tr -d '.')"
 adb_device shell monkey -p "$PACKAGE" 1 > "$ARTIFACT_DIR/launch.txt"
 sleep "$SETTLE_SECONDS"
 
-capture_screen "home"
-capture_ui_tree "home"
-
-if [[ "$MEASURE_AFTER_ROUTE_MAP_SETTLE" != "true" ]]; then
-  adb_device shell dumpsys gfxinfo "$PACKAGE" reset >/dev/null
-fi
-adb_device shell input tap "$ROUTE_TAB_X" "$BOTTOM_NAV_Y"
-sleep "$SETTLE_SECONDS"
-
+# 노선도는 홈 화면이라 실행 즉시 표시된다(별도 진입 탭 없음).
 capture_screen "route-map"
 capture_ui_tree "route-map"
 
 if [[ "$MEASURE_AFTER_ROUTE_MAP_SETTLE" == "true" ]]; then
+  # 제스처 구간만 분리 측정: 노선도 안착 후 프레임/로그 증거를 리셋한다.
   adb_device shell dumpsys gfxinfo "$PACKAGE" reset >/dev/null
   adb_device logcat -c
 fi
@@ -212,19 +208,28 @@ require_non_empty "$ARTIFACT_DIR/gfxinfo.txt"
 require_non_empty "$ARTIFACT_DIR/gfxinfo-framestats.txt"
 require_non_empty "$ARTIFACT_DIR/meminfo.txt"
 
-adb_device shell input tap "$HOME_TAB_X" "$BOTTOM_NAV_Y"
-sleep "$SETTLE_SECONDS"
-
-capture_screen "after-route-map-exit"
-capture_ui_tree "after-route-map-exit"
+capture_screen "after-pan"
+capture_ui_tree "after-pan"
 adb_device logcat -d -v time > "$ARTIFACT_DIR/logcat.txt"
 require_non_empty "$ARTIFACT_DIR/logcat.txt"
 
-grep "routeMapRenderer" "$ARTIFACT_DIR/logcat.txt" > "$ARTIFACT_DIR/route-map-renderer.log" || true
-require_non_empty "$ARTIFACT_DIR/route-map-renderer.log"
+# 구조화 canvas 렌더러는 pure Flutter CustomPaint라 WebView dispose 신호가 없다
+# (#1641에서 WebView 렌더러·health monitor 제거). 대신 pan/zoom 구간에서 렌더러
+# 크래시(FATAL EXCEPTION / Flutter 엔진 abort)가 없었는지를 차단 조건으로 둔다.
+grep -E "FATAL EXCEPTION|E AndroidRuntime|Lost connection to device|## Flutter engine|libflutter.*abort" \
+  "$ARTIFACT_DIR/logcat.txt" > "$ARTIFACT_DIR/renderer-crashes.log" || true
+if [[ -s "$ARTIFACT_DIR/renderer-crashes.log" ]]; then
+  echo "Route map renderer crash signatures observed during pan/zoom:" >&2
+  cat "$ARTIFACT_DIR/renderer-crashes.log" >&2
+  exit 1
+fi
 
-if ! grep -q "routeMapRenderer disposed" "$ARTIFACT_DIR/route-map-renderer.log"; then
-  echo "routeMapRenderer disposed log was not observed after route map exit." >&2
+# #1643: FrameTiming 계측 로그(routeMapFrame buildMs/rasterMs/totalMs). 구조화
+# canvas는 dumpsys gfxinfo로 프레임이 안 잡혀 이 로그가 프레임 성능의 정본이다.
+grep "routeMapFrame" "$ARTIFACT_DIR/logcat.txt" > "$ARTIFACT_DIR/route-map-frames.log" || true
+if [[ ! -s "$ARTIFACT_DIR/route-map-frames.log" ]]; then
+  echo "No routeMapFrame timing logs captured. Use a debug/profile build and" >&2
+  echo "ensure the route map was on screen during the gesture window." >&2
   exit 1
 fi
 
@@ -238,10 +243,17 @@ fi
   echo "- pan_count: $PAN_COUNT"
   echo "- measurement_scope: $MEASUREMENT_SCOPE"
   echo
-  echo "## Renderer logs"
-  grep "routeMapRenderer" "$ARTIFACT_DIR/route-map-renderer.log" || true
+  echo "## Renderer stability"
+  echo "- renderer: structured-canvas (#1641)"
+  echo "- crash_signatures_during_pan: $(wc -l < "$ARTIFACT_DIR/renderer-crashes.log" | tr -d ' ')"
   echo
-  echo "## gfxinfo headline"
+  echo "## Frame timing (FrameTiming, primary)"
+  echo "- routeMapFrame_samples: $(wc -l < "$ARTIFACT_DIR/route-map-frames.log" | tr -d ' ')"
+  echo "- analyze with: node tools/mobile/analyze-route-map-android-evidence.mjs --artifact-dir <dir>"
+  echo
+  echo "## gfxinfo headline (HWUI only — NOT Flutter canvas frames)"
+  echo "- note: Flutter는 자체 렌더 파이프라인이라 dumpsys gfxinfo가 노선도 프레임을"
+  echo "  잡지 못한다. 프레임 성능은 위 FrameTiming(route-map-frames.log)이 정본이다."
   grep -E "Total frames rendered|Janky frames|50th percentile|90th percentile|95th percentile|99th percentile" "$ARTIFACT_DIR/gfxinfo.txt" || true
   echo
   echo "## meminfo headline"


### PR DESCRIPTION
## 관련 이슈

Refs #1643 #1635

## 작업 배경

#1641로 노선도가 WebView SVG → 구조화 native canvas 렌더러로 전환되면서, 기존 성능 evidence 파이프라인(`run-route-map-android-evidence.sh` + analyzer)이 전제하던 것들이 깨졌다: ① WebView renderer dispose 로그가 더 이상 없고, ② 노선도가 하단 탭이 아니라 홈 화면이며, ③ **결정적으로 `dumpsys gfxinfo`가 Flutter canvas 프레임을 잡지 못한다**(Flutter는 자체 Skia/Impeller 파이프라인으로 렌더해 Android HWUI를 우회). 실측에서 gfxinfo가 pan 구간 "Total frames rendered: 0"을 보고해 이 한계를 확인했다. #1643의 프레임 성능 측정을 Flutter 네이티브 방식으로 전환한다.

## 작업 내용

- **앱 FrameTiming 계측**: `_NetworkMapCanvasState`가 노선도 표시 중 `SchedulerBinding.addTimingsCallback`으로 프레임 build/raster/total(ms)을 logcat에 `routeMapFrame …`으로 기록한다. `!kReleaseMode` 가드로 release 오버헤드 없음.
- **evidence 스크립트**(`run-route-map-android-evidence.sh`): 노선도=홈이라 하단 탭 진입/이탈 제거, WebView dispose-log 게이트 → pan/zoom **크래시 시그니처 게이트**로 전환, `route-map-frames.log`(FrameTiming 정본) 캡처를 필수화. summary에서 gfxinfo frame을 HWUI 전용으로 강등 표기.
- **analyzer**(`analyze-…mjs`): `routeMapFrame` 파싱 → build/raster P50/P90/P99 + **jank%(1 vsync 16.7ms 초과 프레임)** 산출. `disposeObserved`/`cameraLatency`(WebView 전용) 제거, `crashSignatureCount`·frame 지표로 대체.
- **계약**(`repository-contract.test.mjs`): 새 산출물(`renderer-crashes.log`·`route-map-frames.log`)·지표에 정합.

## 검증

- `flutter analyze` → **0 issues**, `node --test tools/ci/repository-contract.test.mjs` → **158 pass**, `flutter test test/features/network_map` → **71 pass**.
- 실기기(Galaxy A17, RFKYA01VMQY, debug) 스크립트 end-to-end 실행 — 아래 증거.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| FrameTiming 계측 동작 | Android(A17) | evidence 스크립트 pan 8회 | routeMapFrame **238 샘플** 캡처 | ✅ |
| raster 성능 | Android | analyzer | rasterP50 2.08ms / **rasterP90 4.84ms** (양호) | ✅ |
| build 성능 | Android(debug) | analyzer | buildP50 5.05ms / buildP90 16.8ms / **jank 10.08%** (디버그 오버헤드 포함) | ⚠️ profile 권장 |
| 렌더러 안정성 | Android | crash 게이트 | pan 구간 crash 시그니처 **0** | ✅ |

## Version impact

- [x] mobile patch

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Notes (#1643 후속)

- 이번 PR은 **측정 방법론·도구·계측**을 native 렌더러에 맞게 정합한다. #1643 완료조건의 나머지(기준 기기·목표치 최종 확정, **profile 빌드** 기준 목표 통과 증거, 데이터팩 audit, 비행기모드 오프라인 QA)는 이 도구 위에서 후속 수집한다.
- 디버그 빌드 jank 10%는 디버그 오버헤드(AOT 없음·assert)를 포함 — 목표치(P90 < 1 vsync) 검증은 profile 빌드 측정으로 해야 한다.
