### PR TITLE
[Chore] Cover RAPTOR transfer profile feasibility (#1620)

### DIFF
--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -1095,6 +1095,25 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("V2 planner는 보행 프리셋별 환승 가능 시간을 시간표 scan에 반영한다")
+	void routeV2PlannerAppliesMobilityPresetToTransferFeasibility() {
+		var planner = new RouteV2Planner(legacySearchMustNotBeCalled(), transferRouteTimetablePort(33630));
+
+		var seniorPlan = planner.search(routeV2Command(ConstraintMode.PREFER_STEP_FREE, MobilityType.SENIOR, 1, 3));
+		var standardPlan = planner.search(routeV2Command(
+			ConstraintMode.PREFER_STEP_FREE,
+			MobilityType.SENIOR,
+			MobilityPreset.STANDARD,
+			1,
+			3
+		));
+
+		assertThat(seniorPlan.statuses()).containsExactly(RouteV2Status.NO_TIMETABLE_SERVICE);
+		assertThat(standardPlan.statuses()).containsExactly(RouteV2Status.FOUND);
+		assertThat(standardPlan.itineraries().getFirst().transferCount()).isEqualTo(1);
+	}
+
+	@Test
 	@DisplayName("V2 planner는 maxTransfers 0에서 시간표 환승 후보를 제외한다")
 	void routeV2PlannerRejectsTimetableTransferWhenMaxTransfersIsZero() {
 		var planner = new RouteV2Planner(legacySearchMustNotBeCalled(), transferRouteTimetablePort());


### PR DESCRIPTION
## 관련 이슈

Refs #1620
Refs #1414

## 작업 배경

- #1620 RAPTOR planner의 profile walk time 입력이 실제 환승 가능성 scan에 반영되는지 backend regression으로 고정합니다.
- 프론트엔드 변경 없음.

## 작업 내용

- `RouteSearchServiceTest`에 보행 프리셋별 환승 feasibility 테스트를 추가했습니다.
- 같은 timetable에서 SENIOR 기본 SLOW 프리셋은 환승을 놓치고, 명시적 STANDARD 프리셋은 같은 환승을 잡는 경계를 검증합니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.route.application.service.RouteSearchServiceTest.routeV2PlannerAppliesMobilityPresetToTransferFeasibility` PASS
  - `./gradlew test --tests com.easysubway.route.application.service.RouteSearchServiceTest` PASS
  - `node --test tools/ci/repository-contract.test.mjs` PASS 158
  - `node --test tools/routes/*.test.mjs` PASS 54
  - `git diff --check` PASS

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Backend planner regression | backend | Gradle focused/class test | local terminal output | PASS |
| Repository contract | repository | node test runner | local terminal output | PASS |
| Route prototype contract | tools/routes | node test runner | local terminal output | PASS |
| UI/접근성 수동 QA | N/A | test-only backend 변경 | 프론트엔드/화면 변경 없음 | 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: unchanged
- mobile versionCode: unchanged
- datapack version: unchanged
- route contract: unchanged
- realtime contract: unchanged
- backend identity: test-only

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `RouteSearchServiceTest.routeV2PlannerAppliesMobilityPresetToTransferFeasibility`

## 리스크

- 프로덕션 코드 변경 없음. 위험은 테스트 fixture 기대값이 planner profile 정책과 어긋나는 경우로 제한됩니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
