### PR TITLE
[Chore] Plan KRIC route graph collection (#1400)

### DIFF
--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -6268,6 +6268,7 @@ test("KRIC route graph 수집 계획은 실제 serviceKey가 섞인 후보를 �
   await mkdir(outputDir, { recursive: true });
   const candidates = JSON.parse(await readFile("tools/datapack/source-candidates.json", "utf8"));
   const candidate = candidates.candidates.find((entry) => entry.id === "kric-subway-route-info");
+  const originalSampleUrl = candidate.evidence.sampleUrl;
   candidate.evidence.sampleUrl = candidate.evidence.sampleUrl.replace("[서비스키값]", "real-secret-key");
   await writeFile(candidatesPath, `${JSON.stringify(candidates, null, 2)}\n`);
 
@@ -6283,7 +6284,24 @@ test("KRIC route graph 수집 계획은 실제 serviceKey가 섞인 후보를 �
       ],
       { cwd: root },
     ),
-    /sampleUrl must keep serviceKey redacted/,
+    /sampleUrl must keep exactly one redacted serviceKey/,
+  );
+
+  candidate.evidence.sampleUrl = `${originalSampleUrl}&serviceKey=real-secret-key`;
+  await writeFile(candidatesPath, `${JSON.stringify(candidates, null, 2)}\n`);
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/plan-kric-route-graph-collection.mjs",
+        "--candidates",
+        candidatesPath,
+        "--candidate",
+        "kric-subway-route-info",
+      ],
+      { cwd: root },
+    ),
+    /sampleUrl must keep exactly one redacted serviceKey/,
   );
 });
 

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -6303,6 +6303,23 @@ test("KRIC route graph 수집 계획은 실제 serviceKey가 섞인 후보를 �
     ),
     /sampleUrl must keep exactly one redacted serviceKey/,
   );
+
+  candidate.evidence.sampleUrl = `${originalSampleUrl}&ServiceKey=real-secret-key`;
+  await writeFile(candidatesPath, `${JSON.stringify(candidates, null, 2)}\n`);
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/plan-kric-route-graph-collection.mjs",
+        "--candidates",
+        candidatesPath,
+        "--candidate",
+        "kric-subway-route-info",
+      ],
+      { cwd: root },
+    ),
+    /sampleUrl must keep exactly one redacted serviceKey/,
+  );
 });
 
 test("source candidate sample 검증기는 evidence hash metadata 누락을 거부한다", async () => {

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -6228,6 +6228,65 @@ test("source candidate sample 검증기는 KRIC live evidence metadata를 허용
   assert.match(stdout, /source candidate sample evidence valid: kric-subway-route-info/);
 });
 
+test("KRIC route graph 수집 계획은 인접역 membership 후보를 JSON redacted URL로 고정한다", async () => {
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    [
+      "tools/datapack/plan-kric-route-graph-collection.mjs",
+    ],
+    { cwd: root },
+  );
+  const plan = JSON.parse(stdout);
+
+  assert.equal(plan.artifactKind, "kric-route-graph-membership-collection-plan");
+  assert.equal(plan.serviceKeyEnv, "KRIC_SERVICE_KEY");
+  assert.equal(plan.productionUseAllowed, false);
+  assert.deepEqual(
+    plan.requests.map((request) => request.candidateId),
+    ["kric-subway-route-info", "kric-station-info"],
+  );
+  assert.equal(plan.requests[0].priority, 1);
+  assert.match(plan.requests[0].url, /serviceKey=\[서비스키값\]/);
+  assert.match(plan.requests[0].url, /format=json/);
+  assert.doesNotMatch(plan.requests[0].url, /format=xml/);
+  assert.deepEqual(plan.requests[0].expectedFields, [
+    "lnCd",
+    "mreaWideCd",
+    "railOprIsttCd",
+    "routCd",
+    "routNm",
+    "stinCd",
+    "stinConsOrdr",
+    "stinNm",
+  ]);
+});
+
+test("KRIC route graph 수집 계획은 실제 serviceKey가 섞인 후보를 거부한다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-kric-plan-secret-${Date.now()}`);
+  const candidatesPath = path.join(outputDir, "source-candidates.json");
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+  const candidates = JSON.parse(await readFile("tools/datapack/source-candidates.json", "utf8"));
+  const candidate = candidates.candidates.find((entry) => entry.id === "kric-subway-route-info");
+  candidate.evidence.sampleUrl = candidate.evidence.sampleUrl.replace("[서비스키값]", "real-secret-key");
+  await writeFile(candidatesPath, `${JSON.stringify(candidates, null, 2)}\n`);
+
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/plan-kric-route-graph-collection.mjs",
+        "--candidates",
+        candidatesPath,
+        "--candidate",
+        "kric-subway-route-info",
+      ],
+      { cwd: root },
+    ),
+    /sampleUrl must keep serviceKey redacted/,
+  );
+});
+
 test("source candidate sample 검증기는 evidence hash metadata 누락을 거부한다", async () => {
   const outputDir = path.join(tmpdir(), `easysubway-source-candidate-sample-hash-${Date.now()}`);
   const samplePath = path.join(outputDir, "sample.json");

--- a/tools/datapack/plan-kric-route-graph-collection.mjs
+++ b/tools/datapack/plan-kric-route-graph-collection.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+import { readFile } from "node:fs/promises";
+
+const DEFAULT_CANDIDATE_IDS = ["kric-subway-route-info", "kric-station-info"];
+const DEFAULT_CANDIDATES_PATH = "tools/datapack/source-candidates.json";
+
+function buildKricRouteGraphCollectionPlan(candidatesDocument, candidateIds = DEFAULT_CANDIDATE_IDS) {
+  const candidates = candidatesDocument.candidates ?? [];
+  const requests = candidateIds.map((candidateId, index) => {
+    const candidate = candidates.find((entry) => entry.id === candidateId);
+    if (!candidate) {
+      throw new Error(`unknown KRIC route graph candidate: ${candidateId}`);
+    }
+    return planRequest(candidate, index + 1);
+  });
+  return {
+    artifactKind: "kric-route-graph-membership-collection-plan",
+    serviceKeyEnv: "KRIC_SERVICE_KEY",
+    sourcePurpose: "route_graph_station_membership",
+    totalRequestCount: requests.length,
+    requests,
+    productionUseAllowed: false,
+    remainingAdmissionBlocker: "validated_live_sample_and_admin_review_required",
+  };
+}
+
+function planRequest(candidate, priority) {
+  requireCandidateState(candidate);
+  const evidence = candidate.evidence ?? {};
+  const sampleUrl = forceJsonFormat(requiredText(evidence.sampleUrl, `${candidate.id}.evidence.sampleUrl`));
+  if (!/[?&]serviceKey=\[서비스키값\](?:&|$)/.test(sampleUrl)) {
+    throw new Error(`${candidate.id} sampleUrl must keep serviceKey redacted`);
+  }
+  if (!(evidence.formats ?? []).some((format) => String(format).toLowerCase() === "json")) {
+    throw new Error(`${candidate.id} must support JSON sample collection`);
+  }
+  return {
+    priority,
+    candidateId: candidate.id,
+    endpoint: requiredText(evidence.endpoint, `${candidate.id}.evidence.endpoint`),
+    url: sampleUrl,
+    expectedFields: [...(evidence.outputFields ?? [])].sort((left, right) => left.localeCompare(right)),
+    evidenceOutput: `.codex/evidence/kric/${candidate.id}.sample.json`,
+    rawArchiveOutput: `.codex/evidence/kric/${candidate.id}.raw.json`,
+  };
+}
+
+function requireCandidateState(candidate) {
+  if (!candidate.id.startsWith("kric-")) {
+    throw new Error(`candidate is not KRIC: ${candidate.id}`);
+  }
+  if (candidate.sampleEvidenceStatus !== "sample_url_documented_key_required") {
+    throw new Error(`${candidate.id} sampleEvidenceStatus must stay pending until live sample evidence is recorded`);
+  }
+  if (candidate.admissionStatus !== "evidence_recorded_admin_review_required") {
+    throw new Error(`${candidate.id} admissionStatus must require admin review before production use`);
+  }
+}
+
+function forceJsonFormat(sampleUrl) {
+  const url = new URL(sampleUrl);
+  url.searchParams.set("format", "json");
+  return url.toString().replace("serviceKey=%5B%EC%84%9C%EB%B9%84%EC%8A%A4%ED%82%A4%EA%B0%92%5D", "serviceKey=[서비스키값]");
+}
+
+function requiredText(value, label) {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${label} is required`);
+  }
+  return value;
+}
+
+function cliOptions(argv) {
+  const options = { candidates: DEFAULT_CANDIDATES_PATH, candidate: DEFAULT_CANDIDATE_IDS.join(",") };
+  for (let index = 0; index < argv.length; index += 2) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (!flag?.startsWith("--") || !value || value.startsWith("--")) {
+      throw new Error(`${flag ?? "argument"} requires a value`);
+    }
+    options[flag.slice(2)] = value;
+  }
+  return options;
+}
+
+async function run(argv) {
+  const options = cliOptions(argv);
+  const candidates = JSON.parse(await readFile(options.candidates, "utf8"));
+  const candidateIds = options.candidate.split(",").map((value) => value.trim()).filter(Boolean);
+  return buildKricRouteGraphCollectionPlan(candidates, candidateIds);
+}
+
+run(process.argv.slice(2))
+  .then((plan) => console.log(JSON.stringify(plan, null, 2)))
+  .catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });

--- a/tools/datapack/plan-kric-route-graph-collection.mjs
+++ b/tools/datapack/plan-kric-route-graph-collection.mjs
@@ -28,9 +28,7 @@ function planRequest(candidate, priority) {
   requireCandidateState(candidate);
   const evidence = candidate.evidence ?? {};
   const sampleUrl = forceJsonFormat(requiredText(evidence.sampleUrl, `${candidate.id}.evidence.sampleUrl`));
-  if (!/[?&]serviceKey=\[서비스키값\](?:&|$)/.test(sampleUrl)) {
-    throw new Error(`${candidate.id} sampleUrl must keep serviceKey redacted`);
-  }
+  assertRedactedServiceKey(sampleUrl, candidate.id);
   if (!(evidence.formats ?? []).some((format) => String(format).toLowerCase() === "json")) {
     throw new Error(`${candidate.id} must support JSON sample collection`);
   }
@@ -61,6 +59,13 @@ function forceJsonFormat(sampleUrl) {
   const url = new URL(sampleUrl);
   url.searchParams.set("format", "json");
   return url.toString().replace("serviceKey=%5B%EC%84%9C%EB%B9%84%EC%8A%A4%ED%82%A4%EA%B0%92%5D", "serviceKey=[서비스키값]");
+}
+
+function assertRedactedServiceKey(sampleUrl, candidateId) {
+  const serviceKeys = new URL(sampleUrl).searchParams.getAll("serviceKey");
+  if (serviceKeys.length !== 1 || serviceKeys[0] !== "[서비스키값]") {
+    throw new Error(`${candidateId} sampleUrl must keep exactly one redacted serviceKey`);
+  }
 }
 
 function requiredText(value, label) {

--- a/tools/datapack/plan-kric-route-graph-collection.mjs
+++ b/tools/datapack/plan-kric-route-graph-collection.mjs
@@ -62,7 +62,9 @@ function forceJsonFormat(sampleUrl) {
 }
 
 function assertRedactedServiceKey(sampleUrl, candidateId) {
-  const serviceKeys = new URL(sampleUrl).searchParams.getAll("serviceKey");
+  const serviceKeys = [...new URL(sampleUrl).searchParams.entries()]
+    .filter(([name]) => name.toLowerCase() === "servicekey")
+    .map(([, value]) => value);
   if (serviceKeys.length !== 1 || serviceKeys[0] !== "[서비스키값]") {
     throw new Error(`${candidateId} sampleUrl must keep exactly one redacted serviceKey`);
   }


### PR DESCRIPTION
## 관련 이슈

Refs #1400
Refs #1414

## 작업 배경

- #1414 runbook Step 2 오프라인 데이터 축에서 #1400의 KRIC 인접역 membership 수집 준비를 진행합니다.
- Step 0 외부 신청/키 발급 작업은 보류한다는 QA 지시에 따라 실제 provider 호출과 secret 사용은 하지 않았습니다.
- 프론트엔드 변경 없음.

## 작업 내용

- `tools/datapack/plan-kric-route-graph-collection.mjs` 추가.
- `kric-subway-route-info`, `kric-station-info` 후보의 route graph membership 수집 계획을 `KRIC_SERVICE_KEY` env 기준으로 산출합니다.
- 계획 URL은 `serviceKey=[서비스키값]` 마스킹과 `format=json`을 강제하고, 실제 serviceKey가 후보 URL에 섞이면 실패합니다.

## 검증

- 실행한 명령과 결과:
  - `node tools/datapack/plan-kric-route-graph-collection.mjs` PASS
  - `node --test --test-name-pattern "KRIC route graph 수집 계획" tools/datapack/datapack-tools.test.mjs` PASS 2
  - `node --test tools/datapack/datapack-tools.test.mjs` PASS 183
  - `node --test tools/ci/repository-contract.test.mjs` PASS 158
  - `git diff --check origin/main..HEAD` PASS

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| KRIC route graph collection plan | tools/datapack | node CLI | local terminal output | PASS |
| Datapack tool regression | tools/datapack | node test runner | local terminal output | PASS |
| Repository contract | repository | node test runner | local terminal output | PASS |
| UI/접근성 수동 QA | N/A | datapack tool-only 변경 | 프론트엔드/화면 변경 없음 | 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: unchanged
- mobile versionCode: unchanged
- datapack version: unchanged
- route contract: unchanged
- realtime contract: unchanged
- backend identity: unchanged

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `tools/datapack/plan-kric-route-graph-collection.mjs`

## 리스크

- 실제 KRIC 호출은 하지 않습니다. 이 PR은 redacted collection plan과 secret leak guard만 추가합니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
