### PR TITLE
[Style] 데이터 삭제 결과 화면 다이어트 (#1580)

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -41,7 +41,6 @@ const _mainListPagePadding = EdgeInsets.fromLTRB(17, 18, 17, 32);
 const _appSectionTitlePadding = EdgeInsets.fromLTRB(1, 22, 1, 11);
 const _settingsPagePadding = EdgeInsets.fromLTRB(20, 16, 20, 32);
 const _mainScaffoldBackgroundColor = EasySubwayAccessibleColors.scaffoldSurface;
-const _dataDeletionResultIconRadius = 16.0;
 const _mainThemeControlRadius = BorderRadius.all(Radius.circular(12));
 const _mainIconControlRadius = BorderRadius.all(Radius.circular(12));
 const _appCardShadowColor = EasySubwayAccessibleColors.cardShadow;
@@ -627,7 +626,6 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
   late OnboardingResult? _lastPersistedOnboardingResult =
       widget.initialOnboardingState.result;
   UserDataDeletionResult? _dataDeletionResult;
-  UserDataDeletionScope _dataDeletionScope = UserDataDeletionScope.deviceOnly;
 
   @override
   void initState() {
@@ -650,12 +648,9 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
     final dataDeletionResult = _dataDeletionResult;
     if (dataDeletionResult != null) {
       return UserDataDeletionResultScreen(
-        result: dataDeletionResult,
-        deletionScope: _dataDeletionScope,
         onRestart: () {
           setState(() {
             _dataDeletionResult = null;
-            _dataDeletionScope = UserDataDeletionScope.deviceOnly;
           });
         },
       );
@@ -757,9 +752,6 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
       _startScreenDismissed = false;
       _introScreenDismissed = false;
       _dataDeletionResult = result;
-      _dataDeletionScope = _userDataDeletionScope(
-        widget.userDataDeletionRepository,
-      );
     });
   }
 
@@ -3955,15 +3947,8 @@ class _UserDataDeletionScreenState extends State<UserDataDeletionScreen> {
 }
 
 class UserDataDeletionResultScreen extends StatelessWidget {
-  const UserDataDeletionResultScreen({
-    required this.result,
-    required this.deletionScope,
-    required this.onRestart,
-    super.key,
-  });
+  const UserDataDeletionResultScreen({required this.onRestart, super.key});
 
-  final UserDataDeletionResult result;
-  final UserDataDeletionScope deletionScope;
   final VoidCallback onRestart;
 
   @override
@@ -4013,63 +3998,6 @@ class UserDataDeletionResultScreen extends StatelessWidget {
                 ],
               ),
             ),
-            const _AppSectionTitle(title: '삭제 결과'),
-            _AppCard(
-              child: Column(
-                children: [
-                  _DataDeletionResultRow(
-                    id: 'favoriteStations',
-                    icon: Icons.train_outlined,
-                    title: '즐겨찾기한 역',
-                    value: '${result.deletedFavoriteStationCount}개 삭제',
-                  ),
-                  const SizedBox(height: 16),
-                  _DataDeletionResultRow(
-                    id: 'favoriteFacilities',
-                    icon: Icons.elevator_outlined,
-                    title: '즐겨찾기한 시설',
-                    value: '${result.deletedFavoriteFacilityCount}개 삭제',
-                  ),
-                  const SizedBox(height: 16),
-                  _DataDeletionResultRow(
-                    id: 'favoriteRoutes',
-                    icon: Icons.route_outlined,
-                    title: '즐겨찾기한 경로',
-                    value: '${result.deletedFavoriteRouteCount}개 삭제',
-                  ),
-                  const SizedBox(height: 16),
-                  _DataDeletionResultRow(
-                    id: 'notifications',
-                    icon: Icons.notifications_none,
-                    title: '알림 설정',
-                    value: result.notificationSettingsDeleted
-                        ? '삭제'
-                        : '알림 설정은 이미 비어 있어요',
-                  ),
-                  const SizedBox(height: 12),
-                  _DataDeletionResultRow(
-                    id: 'reportReceipts',
-                    icon: Icons.report_outlined,
-                    title: deletionScope == UserDataDeletionScope.deviceOnly
-                        ? '이 기기의 제보 기록'
-                        : '보낸 제보 기록',
-                    value: deletionScope == UserDataDeletionScope.deviceOnly
-                        ? '${result.anonymizedReportCount}건 삭제'
-                        : '${result.anonymizedReportCount}건을 누구의 정보인지 알 수 없게 바꿈',
-                  ),
-                  if (deletionScope != UserDataDeletionScope.deviceOnly)
-                    const SizedBox(height: 16),
-                  if (deletionScope != UserDataDeletionScope.deviceOnly)
-                    _DataDeletionResultRow(
-                      id: 'routeFeedback',
-                      icon: Icons.rate_review_outlined,
-                      title: '경로 의견',
-                      value:
-                          '${result.anonymizedRouteFeedbackCount}건을 누구의 정보인지 알 수 없게 바꿈',
-                    ),
-                ],
-              ),
-            ),
             const SizedBox(height: 12),
             const _AppCard(
               showBorder: true,
@@ -4078,115 +4006,6 @@ class UserDataDeletionResultScreen extends StatelessWidget {
                 iconColor: EasySubwayAccessibleColors.primary,
                 title: '노선도와 역 정보는 계속 이용할 수 있어요',
               ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _DataDeletionResultRow extends StatelessWidget {
-  const _DataDeletionResultRow({
-    required this.id,
-    required this.icon,
-    required this.title,
-    required this.value,
-  });
-
-  final String id;
-  final IconData icon;
-  final String title;
-  final String value;
-
-  @override
-  Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
-    final textScaler = MediaQuery.textScalerOf(context).scale(1);
-    final content = Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          title,
-          style: textTheme.titleMedium?.copyWith(
-            color: EasySubwayAccessibleColors.text,
-            fontWeight: FontWeight.w800,
-          ),
-        ),
-        const SizedBox(height: 4),
-        Text(
-          value,
-          style: textTheme.bodyMedium?.copyWith(
-            color: EasySubwayAccessibleColors.mutedText,
-            fontWeight: FontWeight.w800,
-          ),
-        ),
-      ],
-    );
-    // 삭제 완료는 복구/완료 상태 의미가 있어 민트 뱃지를 유지한다.
-    final statusBadge = Container(
-      key: Key('dataDeletionResultStatus-$id'),
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-      decoration: BoxDecoration(
-        color: EasySubwayAccessibleColors.mintSoft,
-        borderRadius: _mainThemeControlRadius,
-        border: Border.all(color: EasySubwayAccessibleColors.mintBorder),
-      ),
-      child: const Text(
-        '완료',
-        style: TextStyle(
-          color: EasySubwayAccessibleColors.mintDark,
-          fontWeight: FontWeight.w800,
-        ),
-      ),
-    );
-
-    return Semantics(
-      key: Key('dataDeletionResultRow-$id'),
-      container: true,
-      label: '$title, $value, 완료',
-      child: ExcludeSemantics(
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            Container(
-              key: Key('dataDeletionResultIcon-$id'),
-              width: 60,
-              height: 60,
-              decoration: BoxDecoration(
-                color: Colors.white,
-                borderRadius: BorderRadius.circular(
-                  _dataDeletionResultIconRadius,
-                ),
-                border: Border.all(
-                  color: EasySubwayAccessibleColors.mintDark,
-                  width: 2,
-                ),
-              ),
-              child: Icon(
-                icon,
-                color: EasySubwayAccessibleColors.mintDark,
-                size: 30,
-              ),
-            ),
-            const SizedBox(width: 16),
-            Expanded(
-              child: textScaler >= 1.5
-                  ? Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        content,
-                        const SizedBox(height: 8),
-                        statusBadge,
-                      ],
-                    )
-                  : Row(
-                      children: [
-                        Expanded(child: content),
-                        const SizedBox(width: 12),
-                        statusBadge,
-                      ],
-                    ),
             ),
           ],
         ),

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1657,9 +1657,7 @@ void main() {
         find.byKey(const Key('networkMapInteractiveViewer')),
         findsNothing,
       );
-      final renderer = tester.getSize(
-        find.byType(StructuredRouteMapView),
-      );
+      final renderer = tester.getSize(find.byType(StructuredRouteMapView));
       final surface = tester.getSize(
         find.byKey(const Key('networkMapSurface')),
       );
@@ -4879,35 +4877,19 @@ void main() {
     expect(deletionRepository.deleteCount, 1);
     expect(find.text('삭제 완료'), findsOneWidget);
     expect(find.text('내 정보가 삭제됐어요'), findsOneWidget);
-    expect(find.text('즐겨찾기한 역'), findsOneWidget);
-    expect(find.text('1개 삭제'), findsWidgets);
-    expect(find.text('이 기기의 제보 기록'), findsOneWidget);
-    expect(find.text('1건 삭제'), findsOneWidget);
+    expect(find.text('앱이 처음 사용하는 상태로 돌아갑니다.'), findsOneWidget);
+    expect(find.text('노선도와 역 정보는 계속 이용할 수 있어요'), findsOneWidget);
+    // 내부 처리 카테고리 카운트·시스템 독백은 결과 화면에서 사라진다(#1580).
+    expect(find.textContaining('개 삭제'), findsNothing);
+    expect(find.textContaining('건 삭제'), findsNothing);
+    expect(find.textContaining('누구의 정보인지 알 수 없게'), findsNothing);
+    expect(
+      find.byKey(const Key('dataDeletionResultRow-favoriteStations')),
+      findsNothing,
+    );
     expect(find.textContaining('연결 정보'), findsNothing);
     expect(find.textContaining('익명화'), findsNothing);
     expect(find.textContaining('local-user'), findsNothing);
-    expect(
-      find.byKey(const Key('dataDeletionResultStatus-favoriteStations')),
-      findsOneWidget,
-    );
-    final stationIconBadge = tester.widget<Container>(
-      find.byKey(const Key('dataDeletionResultIcon-favoriteStations')),
-    );
-    final stationIconDecoration = stationIconBadge.decoration! as BoxDecoration;
-    expect(stationIconDecoration.border, isNotNull);
-    expect(stationIconDecoration.color, Colors.white);
-    expect(
-      (stationIconDecoration.border! as Border).top.color,
-      EasySubwayAccessibleColors.mintDark,
-    );
-    expect((stationIconDecoration.border! as Border).top.width, 2);
-    final stationRow = tester.getRect(
-      find.byKey(const Key('dataDeletionResultRow-favoriteStations')),
-    );
-    final facilityRow = tester.getRect(
-      find.byKey(const Key('dataDeletionResultRow-favoriteFacilities')),
-    );
-    expect(facilityRow.top - stationRow.bottom, greaterThanOrEqualTo(16));
     expectNoForbiddenUserCopy(tester);
 
     await tester.tap(find.byKey(const Key('dataDeletionResultStartButton')));
@@ -4933,24 +4915,7 @@ void main() {
     addTearDown(tester.view.resetViewPadding);
 
     await tester.pumpWidget(
-      MaterialApp(
-        home: UserDataDeletionResultScreen(
-          result: const UserDataDeletionResult(
-            userId: 'anonymous-user-1',
-            deletedFavoriteStationCount: 1,
-            deletedFavoriteFacilityCount: 1,
-            deletedFavoriteRouteCount: 1,
-            anonymizedRouteFeedbackCount: 1,
-            notificationSettingsDeleted: true,
-            deletedRegisteredDeviceCount: 1,
-            deletedPushNotificationCount: 1,
-            mobilityProfileDeleted: true,
-            anonymizedReportCount: 1,
-          ),
-          deletionScope: UserDataDeletionScope.deviceOnly,
-          onRestart: () {},
-        ),
-      ),
+      MaterialApp(home: UserDataDeletionResultScreen(onRestart: () {})),
     );
 
     final screenBottom =
@@ -4962,58 +4927,21 @@ void main() {
     expect(screenBottom - buttonRect.bottom, greaterThanOrEqualTo(66));
   });
 
-  testWidgets('데이터 삭제 결과는 지울 알림 설정이 없을 때 쉬운 문구로 보여준다', (tester) async {
+  testWidgets('데이터 삭제 결과는 완료 안내와 다음 행동만 보여준다', (tester) async {
     await tester.pumpWidget(
-      MaterialApp(
-        home: UserDataDeletionResultScreen(
-          result: const UserDataDeletionResult(
-            userId: 'anonymous-user-1',
-            deletedFavoriteStationCount: 0,
-            deletedFavoriteFacilityCount: 0,
-            deletedFavoriteRouteCount: 0,
-            anonymizedRouteFeedbackCount: 0,
-            notificationSettingsDeleted: false,
-            deletedRegisteredDeviceCount: 0,
-            deletedPushNotificationCount: 0,
-            mobilityProfileDeleted: false,
-            anonymizedReportCount: 0,
-          ),
-          deletionScope: UserDataDeletionScope.deviceOnly,
-          onRestart: () {},
-        ),
-      ),
+      MaterialApp(home: UserDataDeletionResultScreen(onRestart: () {})),
     );
 
-    expect(find.text('알림 설정은 이미 비어 있어요'), findsOneWidget);
-    expect(find.text('삭제할 항목 없음'), findsNothing);
-  });
-
-  testWidgets('데이터 삭제 결과는 보낸 정보 정리를 쉬운 문구로 보여준다', (tester) async {
-    await tester.pumpWidget(
-      MaterialApp(
-        home: UserDataDeletionResultScreen(
-          result: const UserDataDeletionResult(
-            userId: 'anonymous-user-1',
-            deletedFavoriteStationCount: 0,
-            deletedFavoriteFacilityCount: 0,
-            deletedFavoriteRouteCount: 0,
-            anonymizedRouteFeedbackCount: 1,
-            notificationSettingsDeleted: false,
-            deletedRegisteredDeviceCount: 0,
-            deletedPushNotificationCount: 0,
-            mobilityProfileDeleted: false,
-            anonymizedReportCount: 2,
-          ),
-          deletionScope: UserDataDeletionScope.remoteAndDevice,
-          onRestart: () {},
-        ),
-      ),
+    expect(find.text('내 정보가 삭제됐어요'), findsOneWidget);
+    expect(find.text('노선도와 역 정보는 계속 이용할 수 있어요'), findsOneWidget);
+    expect(
+      find.byKey(const Key('dataDeletionResultStartButton')),
+      findsOneWidget,
     );
-
-    expect(find.text('보낸 제보 기록'), findsOneWidget);
-    expect(find.text('2건을 누구의 정보인지 알 수 없게 바꿈'), findsOneWidget);
-    expect(find.text('경로 의견'), findsOneWidget);
-    expect(find.text('1건을 누구의 정보인지 알 수 없게 바꿈'), findsOneWidget);
+    // 내부 처리 카테고리·시스템 독백은 노출하지 않는다(#1580).
+    expect(find.text('삭제 결과'), findsNothing);
+    expect(find.text('알림 설정은 이미 비어 있어요'), findsNothing);
+    expect(find.textContaining('누구의 정보인지 알 수 없게'), findsNothing);
     expectNoForbiddenUserCopy(tester);
   });
 


### PR DESCRIPTION
## 관련 이슈

close #1580
상위 트래커: #1575 (출시 품질 3차 정비) 5단계. #1571(삭제 확인 3줄 축약)의 확장 — 같은 파일이라 #1571 병합 후 진행.

## 작업 배경

- 삭제 결과 화면이 "즐겨찾기 역 n개 삭제 / 시설 n개 / 경로 n개 / 알림 설정은 이미 비어 있어요 / n건을 누구의 정보인지 알 수 없게 바꿈" 식으로 **내부 처리 결과를 카테고리별 전시**했다. 사용자에게 필요한 건 "삭제 완료, 처음 화면으로" 뿐.
- "누구의 정보인지 알 수 없게 바꿈"은 익명화의 직역, "이미 비어 있어요"는 시스템 독백 — 사용자 언어가 아니다.
- 삭제 유형별 3벌 장문·법정 보관 중복은 이미 #1571에서 `_UserDataDeletionCopy` 3요소로 단일화됨.

## 작업 내용

- **결과 화면 카테고리 카운트 나열 제거**: '삭제 결과' 섹션(즐겨찾기 역/시설/경로 카운트, 알림 설정, 제보 기록, 경로 의견 행)을 걷어내고, 완료 카드('내 정보가 삭제됐어요' + '앱이 처음 사용하는 상태로 돌아갑니다.') + '노선도와 역 정보는 계속 이용할 수 있어요' 안내 + '처음부터 시작' 버튼만 남겼다.
- **시스템 독백 제거**: '누구의 정보인지 알 수 없게 바꿈'·'이미 비어 있어요'를 화면에서 제거.
- **죽은 코드 정리**: 결과 화면에서 미표시가 된 `result`·`deletionScope` 필드와 상태 필드 `_dataDeletionScope`(write-only) 및 그 할당, `_DataDeletionResultRow` 위젯·전용 상수 `_dataDeletionResultIconRadius`를 제거했다. 실제 삭제 동작(저장소·scope 판정)은 불변.
- **위젯 테스트 갱신**: 카운트·행 단정 → 완료 안내 중심으로 교체, 카테고리 전용 테스트 2건을 완료 안내 검증 1건으로 통합.

### 이번 범위 밖(후속)
- 없음. (#1571에서 확인 화면 카피·도움말 위임·법정보관 위임 완료, 본 PR이 결과 화면까지 마무리.)

## 검증

- 실행한 명령과 결과:
  - `dart format lib/main.dart test/widget_test.dart` → 정상
  - `flutter analyze lib test` → **No issues found!**
  - `flutter test` → **All tests passed!** (667건)
  - `node --test tools/ci/repository-contract.test.mjs` → **pass 158 / fail 0**

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 삭제 결과 화면 다이어트 회귀 | Mobile (Flutter) | `flutter analyze` + `flutter test` | 자동 테스트 667건 | 통과 |
| 저장소 카피 계약 | tools/ci | `node --test repository-contract` | 계약 158건 | 통과 |
| 삭제 3플로우·결과 화면 전/후 스크린샷 | Mobile 실기기 | 스크린샷 | #1573 최종 게이트 | 대기 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 먼저 볼 지점: (1) `UserDataDeletionResultScreen`가 `result`/`deletionScope` 없이 완료 안내만 렌더하는지, (2) `_dataDeletionScope` 제거가 실제 삭제 동작에 무관한지(디스플레이 전용이었음).

## 리스크

- 결과 화면에서 카테고리 카운트가 사라지므로 "무엇이 몇 개 지워졌는지" 상세는 노출되지 않는다. 의도된 다이어트(내부 처리 결과 비전시).

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)