### PR TITLE
[Mobile] 노선도 라벨 겹침 자동 검사 (지역×zoom bucket 겹침 0 기계 판정) (#1642)

### DIFF
--- a/apps/mobile/lib/features/network_map/presentation/structured_route_map_painter.dart
+++ b/apps/mobile/lib/features/network_map/presentation/structured_route_map_painter.dart
@@ -39,6 +39,86 @@ int routeMapZoomBucket(MapCameraState camera) {
   return 2;
 }
 
+/// 라벨 우선순위(낮을수록 먼저 자리 차지): 환승 0 > 주요 1 > 일반 2.
+int routeMapLabelPriorityFor(RouteMapLabelClass labelClass) {
+  switch (labelClass) {
+    case RouteMapLabelClass.transfer:
+      return 0;
+    case RouteMapLabelClass.major:
+      return 1;
+    case RouteMapLabelClass.regular:
+      return 2;
+  }
+}
+
+/// #1642 라벨 렌더 경로의 순수 후보 생성. painter의 `_paintLabels`와 동일한
+/// bucket·LOD·환승/역 규칙으로 [RouteMapLabelCandidate] 목록을 만든다. 텍스트
+/// 실측([measure])·가시성([isVisible])만 주입받아 순수 함수라, 테스트가 지역·
+/// zoom bucket별로 후보 구성과 (placeRouteMapLabels 후) 겹침 0을 기계 판정할 수
+/// 있다. bucket 0(선만)이나 텍스트 없는 역은 후보에서 제외한다.
+List<RouteMapLabelCandidate> routeMapLabelCandidates(
+  StructuredRouteMap map,
+  MapCameraState camera,
+  int bucket, {
+  required Map<String, String> labelTextByStationId,
+  required Size Function(String id, String text) measure,
+  required bool Function(Offset source) isVisible,
+  required double stationRadius,
+  required double transferAnchorPadding,
+}) {
+  final candidates = <RouteMapLabelCandidate>[];
+  if (bucket < 1) {
+    return candidates;
+  }
+  if (bucket >= minLabelZoomBucketFor(RouteMapLabelClass.transfer)) {
+    for (final group in map.transferGroups) {
+      if (!isVisible(group.centroid)) {
+        continue;
+      }
+      final text = labelTextByStationId[group.stationId];
+      if (text == null || text.isEmpty) {
+        continue;
+      }
+      final id = 'transfer:${group.stationId}';
+      candidates.add(
+        RouteMapLabelCandidate(
+          id: id,
+          anchor: camera.sourceToViewportPoint(group.centroid),
+          size: measure(id, text),
+          priority: routeMapLabelPriorityFor(RouteMapLabelClass.transfer),
+          anchorPadding: transferAnchorPadding,
+        ),
+      );
+    }
+  }
+  for (final station in map.stations) {
+    if (station.labelClass == RouteMapLabelClass.transfer) {
+      continue;
+    }
+    if (bucket < minLabelZoomBucketFor(station.labelClass)) {
+      continue;
+    }
+    if (!isVisible(station.position)) {
+      continue;
+    }
+    final text = labelTextByStationId[station.stationId];
+    if (text == null || text.isEmpty) {
+      continue;
+    }
+    final id = '${station.stationId}:${station.lineId}';
+    candidates.add(
+      RouteMapLabelCandidate(
+        id: id,
+        anchor: camera.sourceToViewportPoint(station.position),
+        size: measure(id, text),
+        priority: routeMapLabelPriorityFor(station.labelClass),
+        anchorPadding: stationRadius,
+      ),
+    );
+  }
+  return candidates;
+}
+
 /// polyline의 bounding box가 [rect]와 겹치는지 — viewport culling 판정.
 bool routeMapPolylineIntersectsRect(List<Offset> polyline, Rect rect) {
   if (polyline.isEmpty) {
@@ -111,18 +191,6 @@ class StructuredRouteMapPainter extends CustomPainter {
   // 텍스트 실측은 비싸므로 TextPainter를 캐시한다. 외부(StatefulWidget)가 캐시를
   // 주입하면 rebuild 간에도 유지되고 소유자가 dispose한다. 없으면 인스턴스 수명용.
   final Map<String, TextPainter> _labelPainters;
-
-  /// 라벨 class → 배치 우선순위(낮을수록 우선). #1636 station_labels.priority.
-  static int _labelPriorityFor(RouteMapLabelClass labelClass) {
-    switch (labelClass) {
-      case RouteMapLabelClass.transfer:
-        return 0;
-      case RouteMapLabelClass.major:
-        return 1;
-      case RouteMapLabelClass.regular:
-        return 2;
-    }
-  }
 
   // 프레임마다 재할당하지 않도록 Paint를 인스턴스/정적 필드로 hoist한다.
   final Paint _linePaint = Paint()
@@ -227,66 +295,19 @@ class StructuredRouteMapPainter extends CustomPainter {
       return;
     }
     final bucket = routeMapZoomBucket(camera);
-    // 어떤 class든 라벨 최소 bucket은 1 — bucket 0은 lines only.
-    if (bucket < 1) {
-      return;
-    }
-    final candidates = <RouteMapLabelCandidate>[];
+    // 후보 생성은 순수 함수 routeMapLabelCandidates로 공유 — painter와 테스트가
+    // 동일 bucket·LOD·환승/역 규칙을 태운다(#1642 겹침 0 기계 판정 가능).
     final painterById = <String, TextPainter>{};
-
-    // 환승 라벨: transferGroups 중심, 마커 반지름만큼 여백을 둔다.
-    if (bucket >= minLabelZoomBucketFor(RouteMapLabelClass.transfer)) {
-      for (final group in map.transferGroups) {
-        if (!visible.contains(group.centroid)) {
-          continue;
-        }
-        final text = labelTextByStationId[group.stationId];
-        if (text == null || text.isEmpty) {
-          continue;
-        }
-        final id = 'transfer:${group.stationId}';
-        final painter = _labelPainter(text);
-        painterById[id] = painter;
-        candidates.add(
-          RouteMapLabelCandidate(
-            id: id,
-            anchor: camera.sourceToViewportPoint(group.centroid),
-            size: painter.size,
-            priority: _labelPriorityFor(RouteMapLabelClass.transfer),
-            anchorPadding: transferStationRadius + _transferBorderWidth,
-          ),
-        );
-      }
-    }
-
-    // 비환승 역 라벨(주요/일반): class별 LOD·우선순위를 적용한다.
-    for (final station in map.stations) {
-      if (station.labelClass == RouteMapLabelClass.transfer) {
-        continue;
-      }
-      if (bucket < minLabelZoomBucketFor(station.labelClass)) {
-        continue;
-      }
-      if (!visible.contains(station.position)) {
-        continue;
-      }
-      final text = labelTextByStationId[station.stationId];
-      if (text == null || text.isEmpty) {
-        continue;
-      }
-      final id = '${station.stationId}:${station.lineId}';
-      final painter = _labelPainter(text);
-      painterById[id] = painter;
-      candidates.add(
-        RouteMapLabelCandidate(
-          id: id,
-          anchor: camera.sourceToViewportPoint(station.position),
-          size: painter.size,
-          priority: _labelPriorityFor(station.labelClass),
-          anchorPadding: stationRadius,
-        ),
-      );
-    }
+    final candidates = routeMapLabelCandidates(
+      map,
+      camera,
+      bucket,
+      labelTextByStationId: labelTextByStationId,
+      isVisible: visible.contains,
+      stationRadius: stationRadius,
+      transferAnchorPadding: transferStationRadius + _transferBorderWidth,
+      measure: (id, text) => (painterById[id] ??= _labelPainter(text)).size,
+    );
 
     final placed = placeRouteMapLabels(
       candidates,

--- a/apps/mobile/test/features/network_map/presentation/route_map_label_overlap_test.dart
+++ b/apps/mobile/test/features/network_map/presentation/route_map_label_overlap_test.dart
@@ -1,0 +1,198 @@
+import 'dart:ui';
+
+import 'package:easysubway_mobile/features/network_map/domain/map_camera.dart';
+import 'package:easysubway_mobile/features/network_map/domain/structured_route_map.dart';
+import 'package:easysubway_mobile/features/network_map/presentation/route_map_label_placement.dart';
+import 'package:easysubway_mobile/features/network_map/presentation/structured_route_map_painter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// #1642 라벨 겹침 0건 기계 판정: painter가 소비하는 순수 후보 생성
+// routeMapLabelCandidates + placeRouteMapLabels 파이프라인을 지역·zoom bucket별로
+// 태워, 렌더될 라벨이 서로 겹치지 않고 LOD 정책(bucket 0 선만 / 1 환승·주요 /
+// 2 전체)을 지키는지 검증한다. 텍스트 실측은 결정적 크기로 주입한다.
+
+const _labelSize = Size(40, 12);
+
+MapCameraState _camera({double scale = 2.0}) {
+  return MapCameraState(
+    sourceBounds: const Rect.fromLTWH(0, 0, 4000, 4000),
+    viewportSize: const Size(1080, 2000),
+    center: const Offset(2000, 2000),
+    scale: scale,
+    minScale: 0.5,
+    maxScale: 3.5,
+    revision: 1,
+  );
+}
+
+/// 대표 지역 맵: 환승 2 + 주요 3 + 일반 N을 격자로 배치한다. [spacing]이 크면
+/// 투영 라벨이 서로 멀어 전부 배치되고, 작으면 뭉쳐 충돌 해소가 일어난다.
+StructuredRouteMap _gridMap({required double spacing, int regularCount = 12}) {
+  final stations = <RouteMapStructuredStation>[];
+  final transfers = <RouteMapTransferGroup>[];
+  var seq = 0;
+  Offset at(int i, int j) => Offset(1500 + i * spacing, 1500 + j * spacing);
+
+  for (var t = 0; t < 2; t += 1) {
+    final id = 'transfer-$t';
+    stations.add(RouteMapStructuredStation(
+      stationId: id,
+      lineId: 'L1',
+      sequence: seq += 1,
+      position: at(t, 0),
+      labelPolygon: const [],
+      labelClass: RouteMapLabelClass.transfer,
+    ));
+    transfers.add(RouteMapTransferGroup(
+      stationId: id,
+      lineIds: const ['L1', 'L2'],
+      centroid: at(t, 0),
+    ));
+  }
+  for (var m = 0; m < 3; m += 1) {
+    stations.add(RouteMapStructuredStation(
+      stationId: 'major-$m',
+      lineId: 'L1',
+      sequence: seq += 1,
+      position: at(m, 1),
+      labelPolygon: const [],
+      labelClass: RouteMapLabelClass.major,
+    ));
+  }
+  for (var r = 0; r < regularCount; r += 1) {
+    stations.add(RouteMapStructuredStation(
+      stationId: 'regular-$r',
+      lineId: 'L1',
+      sequence: seq += 1,
+      position: at(r % 6, 2 + r ~/ 6),
+      labelPolygon: const [],
+      labelClass: RouteMapLabelClass.regular,
+    ));
+  }
+  return StructuredRouteMap(
+    lines: const [],
+    stations: stations,
+    transferGroups: transfers,
+  );
+}
+
+Map<String, String> _labelText(StructuredRouteMap map) => {
+      for (final s in map.stations) s.stationId: s.stationId,
+    };
+
+List<PlacedRouteMapLabel> _place(StructuredRouteMap map, int bucket) {
+  final candidates = routeMapLabelCandidates(
+    map,
+    _camera(),
+    bucket,
+    labelTextByStationId: _labelText(map),
+    measure: (_, _) => _labelSize,
+    isVisible: (_) => true,
+    stationRadius: 3,
+    transferAnchorPadding: 7,
+  );
+  return placeRouteMapLabels(
+    candidates,
+    gap: 4,
+    viewportBounds: const Rect.fromLTWH(-2000, -2000, 8000, 8000),
+  );
+}
+
+int _overlapPairs(List<PlacedRouteMapLabel> placed) {
+  var count = 0;
+  for (var i = 0; i < placed.length; i += 1) {
+    for (var j = i + 1; j < placed.length; j += 1) {
+      if (placed[i].rect.overlaps(placed[j].rect)) count += 1;
+    }
+  }
+  return count;
+}
+
+void main() {
+  group('routeMapLabelCandidates LOD 정책', () {
+    test('bucket 0은 라벨 후보가 없다 (선만)', () {
+      final map = _gridMap(spacing: 60);
+      final candidates = routeMapLabelCandidates(
+        map,
+        _camera(),
+        0,
+        labelTextByStationId: _labelText(map),
+        measure: (_, _) => _labelSize,
+        isVisible: (_) => true,
+        stationRadius: 3,
+        transferAnchorPadding: 7,
+      );
+      expect(candidates, isEmpty);
+    });
+
+    test('bucket 1은 환승·주요만, 일반은 제외한다', () {
+      final map = _gridMap(spacing: 60);
+      final ids = routeMapLabelCandidates(
+        map,
+        _camera(),
+        1,
+        labelTextByStationId: _labelText(map),
+        measure: (_, _) => _labelSize,
+        isVisible: (_) => true,
+        stationRadius: 3,
+        transferAnchorPadding: 7,
+      ).map((c) => c.id).toList();
+      expect(ids.where((id) => id.startsWith('transfer:')), hasLength(2));
+      expect(ids.where((id) => id.startsWith('major-')), hasLength(3));
+      expect(ids.any((id) => id.startsWith('regular-')), isFalse);
+    });
+
+    test('bucket 2는 일반 라벨까지 후보에 포함한다', () {
+      final map = _gridMap(spacing: 60);
+      final ids = routeMapLabelCandidates(
+        map,
+        _camera(),
+        2,
+        labelTextByStationId: _labelText(map),
+        measure: (_, _) => _labelSize,
+        isVisible: (_) => true,
+        stationRadius: 3,
+        transferAnchorPadding: 7,
+      ).map((c) => c.id).toList();
+      expect(ids.any((id) => id.startsWith('regular-')), isTrue);
+    });
+  });
+
+  group('라벨 겹침 0건 (지역 × zoom bucket)', () {
+    for (final bucket in [1, 2]) {
+      test('bucket $bucket: 배치된 라벨은 서로 겹치지 않는다 (여유 배치)', () {
+        final placed = _place(_gridMap(spacing: 80), bucket);
+        expect(placed, isNotEmpty);
+        expect(_overlapPairs(placed), 0, reason: 'bucket $bucket 라벨 겹침');
+      });
+
+      test('bucket $bucket: 밀집 배치에서도 겹침 0 (충돌분은 숨김)', () {
+        final placed = _place(_gridMap(spacing: 14), bucket);
+        expect(_overlapPairs(placed), 0, reason: 'bucket $bucket 밀집 겹침');
+      });
+    }
+
+    test('여유 있는 지역은 모든 후보가 배치된다 (과잉 숨김 없음)', () {
+      final map = _gridMap(spacing: 80);
+      final candidates = routeMapLabelCandidates(
+        map,
+        _camera(),
+        2,
+        labelTextByStationId: _labelText(map),
+        measure: (_, _) => _labelSize,
+        isVisible: (_) => true,
+        stationRadius: 3,
+        transferAnchorPadding: 7,
+      );
+      final placed = _place(map, 2);
+      expect(placed, hasLength(candidates.length));
+    });
+
+    test('밀집 지역에서 환승(최우선) 라벨은 반드시 배치된다', () {
+      final placed = _place(_gridMap(spacing: 14), 2);
+      final placedIds = placed.map((p) => p.candidate.id).toSet();
+      expect(placedIds.contains('transfer:transfer-0'), isTrue);
+      expect(placedIds.contains('transfer:transfer-1'), isTrue);
+    });
+  });
+}

--- a/apps/mobile/test/features/network_map/presentation/route_map_label_overlap_test.dart
+++ b/apps/mobile/test/features/network_map/presentation/route_map_label_overlap_test.dart
@@ -98,6 +98,19 @@ List<PlacedRouteMapLabel> _place(StructuredRouteMap map, int bucket) {
   );
 }
 
+List<RouteMapLabelCandidate> _candidates(StructuredRouteMap map, int bucket) {
+  return routeMapLabelCandidates(
+    map,
+    _camera(),
+    bucket,
+    labelTextByStationId: _labelText(map),
+    measure: (_, _) => _labelSize,
+    isVisible: (_) => true,
+    stationRadius: 3,
+    transferAnchorPadding: 7,
+  );
+}
+
 int _overlapPairs(List<PlacedRouteMapLabel> placed) {
   var count = 0;
   for (var i = 0; i < placed.length; i += 1) {
@@ -111,50 +124,28 @@ int _overlapPairs(List<PlacedRouteMapLabel> placed) {
 void main() {
   group('routeMapLabelCandidates LOD 정책', () {
     test('bucket 0은 라벨 후보가 없다 (선만)', () {
-      final map = _gridMap(spacing: 60);
-      final candidates = routeMapLabelCandidates(
-        map,
-        _camera(),
-        0,
-        labelTextByStationId: _labelText(map),
-        measure: (_, _) => _labelSize,
-        isVisible: (_) => true,
-        stationRadius: 3,
-        transferAnchorPadding: 7,
-      );
-      expect(candidates, isEmpty);
+      expect(_candidates(_gridMap(spacing: 60), 0), isEmpty);
     });
 
     test('bucket 1은 환승·주요만, 일반은 제외한다', () {
-      final map = _gridMap(spacing: 60);
-      final ids = routeMapLabelCandidates(
-        map,
-        _camera(),
-        1,
-        labelTextByStationId: _labelText(map),
-        measure: (_, _) => _labelSize,
-        isVisible: (_) => true,
-        stationRadius: 3,
-        transferAnchorPadding: 7,
-      ).map((c) => c.id).toList();
+      final ids = _candidates(_gridMap(spacing: 60), 1).map((c) => c.id);
       expect(ids.where((id) => id.startsWith('transfer:')), hasLength(2));
       expect(ids.where((id) => id.startsWith('major-')), hasLength(3));
       expect(ids.any((id) => id.startsWith('regular-')), isFalse);
     });
 
     test('bucket 2는 일반 라벨까지 후보에 포함한다', () {
-      final map = _gridMap(spacing: 60);
-      final ids = routeMapLabelCandidates(
-        map,
-        _camera(),
-        2,
-        labelTextByStationId: _labelText(map),
-        measure: (_, _) => _labelSize,
-        isVisible: (_) => true,
-        stationRadius: 3,
-        transferAnchorPadding: 7,
-      ).map((c) => c.id).toList();
+      final ids = _candidates(_gridMap(spacing: 60), 2).map((c) => c.id);
       expect(ids.any((id) => id.startsWith('regular-')), isTrue);
+    });
+
+    // painter는 candidate.id로 painterById를 keying해 배치 후 paint한다. id 포맷이
+    // 드리프트하면 paint lookup이 null이 되어 라벨이 조용히 누락되므로 계약으로 핀.
+    test('candidate id 포맷은 painter의 painterById key 규약을 따른다', () {
+      final ids = _candidates(_gridMap(spacing: 60), 2).map((c) => c.id).toSet();
+      expect(ids.contains('transfer:transfer-0'), isTrue);
+      expect(ids.contains('regular-0:L1'), isTrue);
+      expect(ids.contains('major-0:L1'), isTrue);
     });
   });
 
@@ -167,29 +158,32 @@ void main() {
       });
 
       test('bucket $bucket: 밀집 배치에서도 겹침 0 (충돌분은 숨김)', () {
-        final placed = _place(_gridMap(spacing: 14), bucket);
+        final map = _gridMap(spacing: 8);
+        final candidates = _candidates(map, bucket);
+        final placed = _place(map, bucket);
+        // vacuous pass 방지: 후보는 있는데 전부 사라지면 안 되고(추출 회귀),
+        // 충돌 해소가 실제로 일어났음(placed < candidates)을 함께 단정한다.
+        expect(candidates, isNotEmpty);
+        expect(placed, isNotEmpty, reason: 'bucket $bucket 최우선 라벨은 남아야');
+        expect(
+          placed.length,
+          lessThan(candidates.length),
+          reason: 'bucket $bucket 밀집인데 억제가 없다',
+        );
         expect(_overlapPairs(placed), 0, reason: 'bucket $bucket 밀집 겹침');
       });
     }
 
     test('여유 있는 지역은 모든 후보가 배치된다 (과잉 숨김 없음)', () {
       final map = _gridMap(spacing: 80);
-      final candidates = routeMapLabelCandidates(
-        map,
-        _camera(),
-        2,
-        labelTextByStationId: _labelText(map),
-        measure: (_, _) => _labelSize,
-        isVisible: (_) => true,
-        stationRadius: 3,
-        transferAnchorPadding: 7,
-      );
+      final candidates = _candidates(map, 2);
       final placed = _place(map, 2);
+      expect(candidates, isNotEmpty);
       expect(placed, hasLength(candidates.length));
     });
 
     test('밀집 지역에서 환승(최우선) 라벨은 반드시 배치된다', () {
-      final placed = _place(_gridMap(spacing: 14), 2);
+      final placed = _place(_gridMap(spacing: 8), 2);
       final placedIds = placed.map((p) => p.candidate.id).toSet();
       expect(placedIds.contains('transfer:transfer-0'), isTrue);
       expect(placedIds.contains('transfer:transfer-1'), isTrue);


### PR DESCRIPTION
## 관련 이슈

Refs #1642 #1635

## 작업 배경

#1642 완료조건 중 "**라벨 겹침 자동 검사(audit 또는 renderer golden test)가 CI 또는 재현 가능한 스크립트로 남는다 — 지역·zoom bucket별 겹침 0건 기계 판정**"을 이행한다. 라벨 배치 기하(`placeRouteMapLabels`)는 이미 단위 테스트가 있으나, painter의 실제 렌더 경로(bucket·LOD·환승/역 후보 생성 → 배치)를 지역×bucket으로 태운 겹침 0 기계 판정이 없었다.

## 작업 내용

- **순수 함수 추출**: painter `_paintLabels`의 라벨 후보 생성 로직을 top-level `routeMapLabelCandidates(map, camera, bucket, {measure, isVisible, ...})`로 추출(`routeMapLabelPriorityFor` 포함). painter는 이 함수를 소비해 **동작 불변**(텍스트 실측 `measure`·가시성 `isVisible`만 주입, 순수). 기존 `_labelPriorityFor` static 제거.
- **자동 검사 테스트** `route_map_label_overlap_test.dart`: 대표 지역 격자 맵(환승 2·주요 3·일반 N)을 zoom bucket 0/1/2로 태워 기계 판정 —
  - LOD 정책: bucket 0 선만 / 1 환승·주요 / 2 전체.
  - **배치된 라벨 겹침 0건** (여유·밀집 배치 모두 — 밀집은 충돌분 숨김).
  - 여유 지역 과잉 숨김 없음(모든 후보 배치), 밀집 지역 환승(최우선) 라벨 항상 배치.

## 검증

- `flutter analyze` → **0 issues**
- `flutter test test/features/network_map` → 전부 통과(신규 9건 + 기존 painter/label 테스트 회귀 없음).

## Version impact

- [x] no version change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Notes (#1642 후속)

- 이 PR은 **겹침 0 자동 검사(CI화 가능)** 를 남긴다. #1642의 나머지 완료조건(지역별 대표 viewport×bucket 실기기 스크린샷 QA, TalkBack 스크린리더, 큰 글자/고대비, hit target 48dp)은 실기기 증거로 후속 수집한다.
