### PR TITLE
[Chore] Report TAGO schedule collection counts (#1415)

### DIFF
--- a/tools/datapack/plan-tago-schedule-collection.test.mjs
+++ b/tools/datapack/plan-tago-schedule-collection.test.mjs
@@ -27,6 +27,7 @@ test("TAGO 시간표 수집 plan은 daily limit과 checkpoint resume을 적용�
   );
   assert.equal(plan.artifactKind, "tago-schedule-collection-plan");
   assert.equal(plan.dailyLimit, 3);
+  assert.equal(plan.stationCount, 2);
   assert.equal(plan.totalRequestCount, 12);
   assert.equal(plan.completedRequestCount, 1);
   assert.deepEqual(
@@ -231,6 +232,16 @@ test("TAGO 시간표 수집기는 checkpoint 다음 batch만 호출하고 secret
   assert.equal(collection.requestedCount, 2);
   assert.equal(collection.pendingRequestCount, 9);
   assert.equal(collection.collectionStatus, "completed_batch");
+  assert.deepEqual(collection.collectionReport, {
+    stationCount: 2,
+    totalCallCount: 12,
+    attemptedCallCount: 2,
+    successfulCallCount: 2,
+    failedCallCount: 0,
+    retryCount: 0,
+    quotaObservedRequestCount: 2,
+    quotaDailyLimit: 2,
+  });
   assert.deepEqual(
     collection.responses.map((response) => response.requestKey),
     ["MTRKR4448|01|D", "MTRKR4448|02|U"],
@@ -367,6 +378,8 @@ test("TAGO 시간표 수집기는 batch 중간 실패 시 성공분 checkpoint�
       assert.equal(error.message, "TAGO schedule fetch failed before response: MTRKR4448|02|U");
       assert.equal(error.collection.collectionStatus, "partial_failed");
       assert.equal(error.collection.failedRequestKey, "MTRKR4448|02|U");
+      assert.equal(error.collection.collectionReport.failedCallCount, 1);
+      assert.equal(error.collection.collectionReport.quotaObservedRequestCount, 2);
       assert.deepEqual(error.collection.completedRequestKeys, ["MTRKR4448|01|D", "MTRKR4448|01|U"]);
       assert.deepEqual(
         error.collection.responses.map((response) => response.requestKey),

--- a/tools/datapack/validate-tago-schedule-sample.mjs
+++ b/tools/datapack/validate-tago-schedule-sample.mjs
@@ -122,7 +122,8 @@ function buildTagoScheduleCollectionPlan(input, checkpoint = {}, dailyLimit = 10
     throw new Error("dailyLimit must be a positive integer");
   }
   const completed = new Set(checkpoint.completedRequestKeys ?? []);
-  const allRequests = tagoStationIds(input).flatMap((stationId) =>
+  const stationIds = tagoStationIds(input);
+  const allRequests = stationIds.flatMap((stationId) =>
     [...DAILY_TYPE_CODES].flatMap((dailyTypeCode) =>
       [...UP_DOWN_CODES].map((upDownTypeCode) => {
         const requestKey = `${stationId}|${dailyTypeCode}|${upDownTypeCode}`;
@@ -142,6 +143,7 @@ function buildTagoScheduleCollectionPlan(input, checkpoint = {}, dailyLimit = 10
     sourceId: "molit-tago-subway-info",
     endpoint: TAGO_SCHEDULE_ENDPOINT,
     dailyLimit,
+    stationCount: stationIds.length,
     totalRequestCount: allRequests.length,
     completedRequestCount: allRequests.length - pending.length,
     pendingRequestCount: pending.length,
@@ -273,6 +275,7 @@ async function collectTagoSchedules(input, options = {}) {
 
 function buildTagoScheduleCollectionArtifact(plan, options, collectedAt, responses, failure = {}) {
   const checkpoint = options.checkpoint ?? {};
+  const failedRequestCount = failure.failedRequestKey ? 1 : 0;
   const completedRequestKeys = [
     ...new Set([...(checkpoint.completedRequestKeys ?? []), ...responses.map((response) => response.requestKey)]),
   ].sort((left, right) => left.localeCompare(right));
@@ -290,6 +293,17 @@ function buildTagoScheduleCollectionArtifact(plan, options, collectedAt, respons
     completedRequestKeys,
     checkpoint: { completedRequestKeys },
     collectionStatus: failure.failedRequestKey ? "partial_failed" : "completed_batch",
+    collectionReport: {
+      stationCount: plan.stationCount,
+      totalCallCount: plan.totalRequestCount,
+      attemptedCallCount: responses.length + failedRequestCount,
+      successfulCallCount: responses.length,
+      failedCallCount: failedRequestCount,
+      // ponytail: no retry loop yet; count actual retries here if collection adds one.
+      retryCount: 0,
+      quotaObservedRequestCount: responses.length + failedRequestCount,
+      quotaDailyLimit: plan.dailyLimit,
+    },
     ...(failure.failedRequestKey ? { failedRequestKey: failure.failedRequestKey } : {}),
     responses,
   };


### PR DESCRIPTION
## 관련 이슈

Refs #1415
Refs #1414

## 작업 배경

- #1415 close 게이트가 pilot 수집 리포트에 역수·콜수·실패·재시도·quota 실측을 요구하지만, 기존 `--collect` 산출물에는 이 요약이 없었습니다.

## 작업 내용

- TAGO 시간표 수집 plan에 `stationCount`를 추가했습니다.
- TAGO 시간표 collection 산출물에 `collectionReport`를 추가해 역수, 총/시도/성공/실패 call 수, retry 수, quota 관측 call 수를 기록합니다.
- provider key는 로컬에 없어 실제 수집은 실행하지 않았고, 기존 fake fetch 테스트로 산출 계약만 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/datapack/plan-tago-schedule-collection.test.mjs` — pass 14
  - `node tools/datapack/validate-tago-schedule-sample.mjs --plan --input tools/datapack/inputs/capital-pilot-production-source-input.json --daily-limit 1000` — pass, stationCount 2 / totalRequestCount 12 출력
  - `node --test tools/datapack/plan-tago-schedule-collection.test.mjs tools/datapack/datapack-tools.test.mjs` — pass 195
  - `node --test tools/ci/repository-contract.test.mjs` — pass 158
  - `git diff --check origin/main..HEAD` — pass

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| TAGO 수집 리포트 계약 | local | node test | `node --test tools/datapack/plan-tago-schedule-collection.test.mjs` | pass |
| pilot 수집 plan call count | local | CLI 출력 | `stationCount: 2`, `totalRequestCount: 12` | pass |
| UI/접근성 | N/A | datapack tool contract only | frontend 변경 없음 | 해당 없음 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: unchanged
- mobile versionCode: unchanged
- datapack version: unchanged
- route contract: unchanged
- realtime contract: unchanged
- backend identity: unchanged

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `tools/datapack/validate-tago-schedule-sample.mjs`의 `collectionReport` 산출과 `plan-tago-schedule-collection.test.mjs` 기대값입니다.

## 리스크

- 실제 TAGO provider 호출은 로컬 `DATA_GO_KR_SERVICE_KEY` 부재로 실행하지 않았습니다. 이번 PR은 수집 실행 전 리포트 계약 보강입니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.