### PR TITLE
[Style] 좌측 메뉴 최근 검색 항목 제거·역 검색 통합 (#1581)

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1504,8 +1504,6 @@ class _HomeScreenState extends State<HomeScreen> {
           viewportRepository: widget.networkMapViewportRepository,
           realtimeRepository: widget.realtimeRepository,
           onOpenSavedItems: openSavedTab,
-          onOpenRecentSearch: () =>
-              unawaited(openStationSearch(StationSearchEntryMode.recent)),
           onOpenNearbyStations: () =>
               unawaited(openStationSearch(StationSearchEntryMode.nearby)),
           onOpenSettings: openMoreTab,

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -368,7 +368,6 @@ class NetworkMapScreen extends StatefulWidget {
     this.viewportRepository,
     this.realtimeRepository,
     this.onOpenSavedItems,
-    this.onOpenRecentSearch,
     this.onOpenNearbyStations,
     this.onOpenSettings,
     this.onOpenDataSources,
@@ -386,7 +385,6 @@ class NetworkMapScreen extends StatefulWidget {
   final NetworkMapViewportRepository? viewportRepository;
   final RealtimeRepository? realtimeRepository;
   final VoidCallback? onOpenSavedItems;
-  final VoidCallback? onOpenRecentSearch;
   final VoidCallback? onOpenNearbyStations;
   final VoidCallback? onOpenSettings;
   final VoidCallback? onOpenDataSources;
@@ -761,7 +759,6 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
           onOpenRouteSearch: widget.onOpenRouteSearch,
           onOpenSavedItems: widget.onOpenSavedItems,
           onOpenNearbyStations: widget.onOpenNearbyStations,
-          onOpenRecentSearch: widget.onOpenRecentSearch,
           onOpenSettings: widget.onOpenSettings,
           onOpenDataSources: widget.onOpenDataSources,
         );
@@ -1900,7 +1897,6 @@ class _NetworkMapMenuPanel extends StatelessWidget {
     required this.onOpenRouteSearch,
     required this.onOpenSavedItems,
     required this.onOpenNearbyStations,
-    required this.onOpenRecentSearch,
     required this.onOpenSettings,
     required this.onOpenDataSources,
   });
@@ -1909,7 +1905,6 @@ class _NetworkMapMenuPanel extends StatelessWidget {
   final Future<void> Function() onOpenRouteSearch;
   final VoidCallback? onOpenSavedItems;
   final VoidCallback? onOpenNearbyStations;
-  final VoidCallback? onOpenRecentSearch;
   final VoidCallback? onOpenSettings;
   final VoidCallback? onOpenDataSources;
 
@@ -1970,13 +1965,6 @@ class _NetworkMapMenuPanel extends StatelessWidget {
                           label: '가까운 역',
                           onTap: () =>
                               _runAction(context, onOpenNearbyStations!),
-                        ),
-                      if (onOpenRecentSearch != null)
-                        _NetworkMapMenuTile(
-                          key: const Key('networkMapMenuRecentButton'),
-                          icon: Icons.history,
-                          label: '최근 검색',
-                          onTap: () => _runAction(context, onOpenRecentSearch!),
                         ),
                       if (onOpenSavedItems != null ||
                           onOpenSettings != null) ...[
@@ -2702,7 +2690,6 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
       for (final station in data.stations) station.id: station.nameKo,
     };
   }
-
 }
 
 String _networkMapStationLineKey(String stationId, String lineId) =>

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -1867,7 +1867,7 @@ class StationSearchScreen extends StatefulWidget {
   State<StationSearchScreen> createState() => _StationSearchScreenState();
 }
 
-enum StationSearchEntryMode { search, recent, nearby }
+enum StationSearchEntryMode { search, nearby }
 
 class _StationSearchScreenState extends State<StationSearchScreen> {
   late final StationSearchController _controller;
@@ -1938,7 +1938,6 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final isRecentEntry = widget.entryMode == StationSearchEntryMode.recent;
     final isNearbyEntry = widget.entryMode == StationSearchEntryMode.nearby;
     const showSearchInput = true;
     final showNearbyRetryButton = isNearbyEntry && !_hasSearchQuery;
@@ -1996,24 +1995,13 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
       builder: (context, _) {
         final isSearching =
             _controller.state.status == StationSearchStatus.loading;
-        if (isNearbyEntry || _hasSearchQuery) {
+        if (isNearbyEntry || _hasSearchQuery || _recentQueries.isEmpty) {
           return const SizedBox.shrink();
-        }
-        if (_recentQueries.isEmpty) {
-          return isRecentEntry
-              ? Padding(
-                  padding: const EdgeInsets.only(bottom: 12),
-                  child: _StationRecentSearchEmptyState(
-                    onSearchTap: _openStationSearch,
-                  ),
-                )
-              : const SizedBox.shrink();
         }
         return Padding(
           padding: const EdgeInsets.only(bottom: 12),
           child: _StationRecentSearchSection(
             queries: _recentQueries,
-            showTitle: !isRecentEntry,
             enabled: !isSearching && !_isNearbySearchRunning,
             onQuerySelected: _searchRecentQuery,
             onQueryRemoved: _removeRecentQuery,
@@ -2074,12 +2062,11 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
     return Scaffold(
       appBar: AppBar(
         title: Text(switch (widget.entryMode) {
-          StationSearchEntryMode.recent => '최근 검색',
           StationSearchEntryMode.nearby => '가까운 역',
           StationSearchEntryMode.search => '역 검색',
         }),
         actions: [
-          if (!isRecentEntry && !isNearbyEntry)
+          if (!isNearbyEntry)
             TextButton.icon(
               key: const Key('nearbyStationAppBarButton'),
               onPressed: _isNearbySearchRunning ? null : _searchNearby,
@@ -2143,26 +2130,6 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
       selection: TextSelection.collapsed(offset: query.length),
     );
     _submit(query);
-  }
-
-  void _openStationSearch() {
-    Navigator.of(context).pushReplacement(
-      MaterialPageRoute<void>(
-        builder: (_) => StationSearchScreen(
-          repository: widget.repository,
-          locationProvider: widget.locationProvider,
-          reportRepository: widget.reportRepository,
-          favoriteRepository: widget.favoriteRepository,
-          searchHistoryRepository: widget.searchHistoryRepository,
-          realtimeRepository: widget.realtimeRepository,
-          routeDraftController: widget.routeDraftController,
-          onOpenRouteSearch: widget.onOpenRouteSearch,
-          facilityReportDraftTargetStore: widget.facilityReportDraftTargetStore,
-          internalRouteRepository: widget.internalRouteRepository,
-          internalRouteMobilityType: widget.internalRouteMobilityType,
-        ),
-      ),
-    );
   }
 
   Future<void> _removeRecentQuery(String query) async {
@@ -2301,7 +2268,6 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
 class _StationRecentSearchSection extends StatelessWidget {
   const _StationRecentSearchSection({
     required this.queries,
-    required this.showTitle,
     required this.enabled,
     required this.onQuerySelected,
     required this.onQueryRemoved,
@@ -2309,7 +2275,6 @@ class _StationRecentSearchSection extends StatelessWidget {
   });
 
   final List<String> queries;
-  final bool showTitle;
   final bool enabled;
   final ValueChanged<String> onQuerySelected;
   final ValueChanged<String> onQueryRemoved;
@@ -2321,30 +2286,15 @@ class _StationRecentSearchSection extends StatelessWidget {
       key: const Key('stationRecentSearchSection'),
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        if (showTitle) ...[
-          Text(
-            '최근 검색',
-            style: Theme.of(context).textTheme.titleMedium?.copyWith(
-              color: EasySubwayAccessibleColors.text,
-              fontWeight: FontWeight.w800,
-              height: 1.25,
-            ),
-          ),
-          const SizedBox(height: 8),
-        ],
         Row(
           children: [
             Expanded(
-              child: Semantics(
-                excludeSemantics: true,
-                label: '최근 사용 순서로 ${queries.length}개 표시',
-                child: Text(
-                  '최근 사용 순서 · ${queries.length}개',
-                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                    color: EasySubwayAccessibleColors.mutedText,
-                    fontWeight: FontWeight.w700,
-                    height: 1.3,
-                  ),
+              child: Text(
+                '최근 검색',
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  color: EasySubwayAccessibleColors.text,
+                  fontWeight: FontWeight.w800,
+                  height: 1.25,
                 ),
               ),
             ),
@@ -2472,33 +2422,6 @@ class _StationRecentSearchItem extends StatelessWidget {
           ),
         ),
       ),
-    );
-  }
-}
-
-class _StationRecentSearchEmptyState extends StatelessWidget {
-  const _StationRecentSearchEmptyState({required this.onSearchTap});
-
-  final VoidCallback onSearchTap;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      key: const Key('stationRecentSearchEmptyState'),
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        const _StationSearchMessage(
-          message: '최근 검색한 역이 없습니다.',
-          liveRegion: false,
-        ),
-        const SizedBox(height: 12),
-        FilledButton.icon(
-          key: const Key('stationRecentSearchEmptySearchButton'),
-          onPressed: onSearchTap,
-          icon: const Icon(Icons.search),
-          label: const Text('역 검색하기'),
-        ),
-      ],
     );
   }
 }

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -6248,17 +6248,20 @@ void main() {
 
       await tester.tap(find.byKey(const Key('networkMapMenuButton')));
       await tester.pumpAndSettle();
-      await tester.tap(find.byKey(const Key('networkMapMenuRecentButton')));
+      await tester.tap(
+        find.byKey(const Key('networkMapMenuStationSearchButton')),
+      );
       await tester.pumpAndSettle();
 
-      expect(find.text('최근 검색'), findsOneWidget);
+      // 최근 검색은 역 검색 화면의 빈 상태 섹션으로 통합됐다(#1581).
       expect(find.byKey(const Key('stationSearchInput')), findsOneWidget);
       expect(
         find.byKey(const Key('stationRecentSearchSection')),
         findsOneWidget,
       );
-      expect(find.text('최근 사용 순서 · 2개'), findsOneWidget);
-      expect(find.bySemanticsLabel('최근 사용 순서로 2개 표시'), findsOneWidget);
+      expect(find.text('최근 검색'), findsOneWidget);
+      // 시스템 캡션('최근 사용 순서 …')은 제거됐다(#1581).
+      expect(find.textContaining('최근 사용 순서'), findsNothing);
       expect(find.text('최근 사용 1번째'), findsOneWidget);
       expect(
         find.byKey(const Key('stationRecentSearchQuery-상록수')),
@@ -6299,7 +6302,7 @@ void main() {
     }
   });
 
-  testWidgets('역 검색 최근 검색은 개별 삭제와 전체 삭제 및 빈 상태 CTA를 제공한다', (tester) async {
+  testWidgets('역 검색 화면 안에서 최근 검색을 개별·전체 삭제한다', (tester) async {
     final searchHistoryRepository = FakeSearchHistoryRepository(['상록수', '사당']);
 
     await tester.pumpWidget(
@@ -6315,7 +6318,9 @@ void main() {
 
     await tester.tap(find.byKey(const Key('networkMapMenuButton')));
     await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const Key('networkMapMenuRecentButton')));
+    await tester.tap(
+      find.byKey(const Key('networkMapMenuStationSearchButton')),
+    );
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const Key('stationRecentSearchRemove-상록수')));
@@ -6323,26 +6328,17 @@ void main() {
 
     expect(searchHistoryRepository.removedQueries, ['상록수']);
     expect(find.byKey(const Key('stationRecentSearchQuery-상록수')), findsNothing);
-    expect(find.text('최근 사용 순서 · 1개'), findsOneWidget);
+    expect(find.byKey(const Key('stationRecentSearchSection')), findsOneWidget);
 
     await tester.tap(
       find.byKey(const Key('stationRecentSearchClearAllButton')),
     );
     await tester.pumpAndSettle();
 
+    // 최근 검색이 비면 전용 빈 상태 대신 섹션이 사라지고 검색 입력만 남는다(#1581).
     expect(searchHistoryRepository.clearCount, 1);
-    expect(
-      find.byKey(const Key('stationRecentSearchEmptyState')),
-      findsOneWidget,
-    );
-    expect(find.text('최근 검색한 역이 없습니다.'), findsOneWidget);
-    expect(find.widgetWithText(FilledButton, '역 검색하기'), findsOneWidget);
-
-    await tester.tap(
-      find.byKey(const Key('stationRecentSearchEmptySearchButton')),
-    );
-    await tester.pumpAndSettle();
-
+    expect(find.byKey(const Key('stationRecentSearchSection')), findsNothing);
+    expect(find.text('최근 검색한 역이 없습니다.'), findsNothing);
     expect(find.byKey(const Key('stationSearchInput')), findsOneWidget);
   });
 


### PR DESCRIPTION
## 관련 이슈

close #1581
상위 트래커: #1575 (출시 품질 3차 정비) 5단계. 선행 #1566(역 검색 다이어트, 병합됨)이 빈 검색 상태에 최근 검색을 이미 포함 → 전용 진입·메뉴 항목이 중복이 됨.

## 작업 배경

- 좌측 메뉴 탐색 섹션(역 검색 / 길찾기 / 가까운 역 / **최근 검색**)에서 '최근 검색'만 행동이 아니라 기록이다. 메뉴 항목이 줄어야 메뉴가 스캔된다.
- 최근 검색 전용 진입은 역 검색을 `StationSearchEntryMode.recent`로 여는 것뿐이었고, 동일 기능이 역 검색 빈 상태에 이미 있어 중복이다.
- 전용 화면에 "최근 사용 순서 · N개" 같은 시스템 캡션이 있었다.

## 작업 내용

- **좌측 메뉴 '최근 검색' 항목 제거**: `network_map.dart`의 `networkMapMenuRecentButton` 타일과 `onOpenRecentSearch` 콜백 플러밍(패널·홈)을 전부 제거. 탐색 섹션이 역 검색/길찾기/가까운 역 3항목이 됨.
- **`StationSearchEntryMode.recent` 모드 제거**: enum에서 `recent` 제거. 진입점이 없어진 recent 전용 분기(appbar 타이틀 '최근 검색', 전용 빈 상태, 섹션 제목 숨김)를 정리.
- **최근 검색 = 역 검색 화면 통합**: 역 검색 빈 상태(검색어 없음)에서 최근 검색 섹션이 보기·재사용(탭 재검색)·개별 삭제·전체 삭제를 모두 제공(#1566 흡수 확인). 최근 검색이 비면 섹션이 사라지고 검색 입력만 남는다.
- **시스템 캡션 제거**: "최근 사용 순서 · N개" / "최근 사용 순서로 N개 표시" 캡션 제거, 섹션 제목('최근 검색')+전체 삭제 버튼 한 행으로 정리.
- **데드코드 정리**: 미사용이 된 `_StationRecentSearchEmptyState` 위젯과 `_openStationSearch` 메서드 제거.
- **위젯 테스트 갱신**: 드로어 recent 진입 → 역 검색 진입으로, 빈 상태 CTA 검증 → 섹션 소멸 검증으로.

### 이번 범위 밖(후속)
- 없음.

## 검증

- 실행한 명령과 결과:
  - `dart format` (lib/network_map·main·station_search, test/widget_test) → 정상
  - `flutter analyze lib test` → **No issues found!**
  - `flutter test` → **All tests passed!** (667건)
  - `node --test tools/ci/repository-contract.test.mjs` → **pass 158 / fail 0**

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 메뉴 항목 제거·역 검색 통합 회귀 | Mobile (Flutter) | `flutter analyze` + `flutter test` | 자동 테스트 667건 | 통과 |
| 저장소 계약 | tools/ci | `node --test repository-contract` | 계약 158건 | 통과 |
| 좌측 메뉴·역 검색 빈 상태 전/후 스크린샷 | Mobile 실기기 | 스크린샷 | #1573 최종 게이트 | 대기 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 먼저 볼 지점: (1) `network_map.dart` 드로어에서 recent 타일·플러밍 완전 제거, (2) `station_search.dart` `entryMode`에서 recent 분기 제거 후 빈 상태 섹션이 삭제 기능을 온전히 흡수하는지.

## 리스크

- 최근 검색이 비면 전용 빈 상태(역 검색하기 CTA) 대신 섹션이 사라진다. 역 검색 입력이 바로 위에 있어 CTA가 불필요하다는 판단.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)