### PR TITLE
[Chore] Add TAGO pilot collection workflow (#1415)

### DIFF
--- a/.github/workflows/tago-schedule-collection.yml
+++ b/.github/workflows/tago-schedule-collection.yml
@@ -64,7 +64,7 @@ jobs:
           if [[ -f "${RUNNER_TEMP}/tago-collection.json" ]]; then
             node -e 'const fs=require("fs"); const c=JSON.parse(fs.readFileSync(process.env.RUNNER_TEMP + "/tago-collection.json", "utf8")); delete c.responses; fs.writeFileSync(process.env.RUNNER_TEMP + "/tago-report.json", JSON.stringify(c, null, 2) + "\n");'
           fi
-          if [[ "${collect_status}" -eq 0 ]]; then
+          if [[ -f "${RUNNER_TEMP}/tago-collection.json" ]]; then
             node tools/datapack/validate-tago-schedule-sample.mjs \
               --summary \
               --quiet \

--- a/.github/workflows/tago-schedule-collection.yml
+++ b/.github/workflows/tago-schedule-collection.yml
@@ -20,7 +20,6 @@ jobs:
       contents: read
     env:
       NODE_OPTIONS: --disable-warning=ExperimentalWarning
-      DATA_GO_KR_SERVICE_KEY: ${{ secrets.DATA_GO_KR_SERVICE_KEY }}
       TAGO_DAILY_LIMIT: ${{ github.event.inputs.dailyLimit }}
       TAGO_CHECKPOINT_JSON: ${{ github.event.inputs.checkpointJson }}
 
@@ -41,6 +40,8 @@ jobs:
           node -e 'const fs=require("fs"); const value=JSON.parse(process.env.TAGO_CHECKPOINT_JSON); if (!Array.isArray(value.completedRequestKeys)) throw new Error("checkpointJson.completedRequestKeys must be an array"); fs.writeFileSync(process.env.RUNNER_TEMP + "/tago-checkpoint.json", JSON.stringify(value, null, 2) + "\n");'
 
       - name: TAGO Schedule Collection / Collect pilot batch
+        env:
+          DATA_GO_KR_SERVICE_KEY: ${{ secrets.DATA_GO_KR_SERVICE_KEY }}
         run: |
           set -euo pipefail
           test -n "${DATA_GO_KR_SERVICE_KEY}"

--- a/.github/workflows/tago-schedule-collection.yml
+++ b/.github/workflows/tago-schedule-collection.yml
@@ -1,0 +1,85 @@
+name: TAGO Schedule Collection
+
+on:
+  workflow_dispatch:
+    inputs:
+      dailyLimit:
+        description: Maximum provider calls for this batch
+        required: true
+        default: "12"
+      checkpointJson:
+        description: Previous checkpoint JSON
+        required: true
+        default: '{"completedRequestKeys":[]}'
+
+jobs:
+  collect:
+    name: TAGO Schedule Collection
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      NODE_OPTIONS: --disable-warning=ExperimentalWarning
+      DATA_GO_KR_SERVICE_KEY: ${{ secrets.DATA_GO_KR_SERVICE_KEY }}
+      TAGO_DAILY_LIMIT: ${{ github.event.inputs.dailyLimit }}
+      TAGO_CHECKPOINT_JSON: ${{ github.event.inputs.checkpointJson }}
+
+    steps:
+      - name: TAGO Schedule Collection / Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: TAGO Schedule Collection / Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24"
+
+      - name: TAGO Schedule Collection / Prepare checkpoint
+        run: |
+          set -euo pipefail
+          node -e 'const fs=require("fs"); const value=JSON.parse(process.env.TAGO_CHECKPOINT_JSON); if (!Array.isArray(value.completedRequestKeys)) throw new Error("checkpointJson.completedRequestKeys must be an array"); fs.writeFileSync(process.env.RUNNER_TEMP + "/tago-checkpoint.json", JSON.stringify(value, null, 2) + "\n");'
+
+      - name: TAGO Schedule Collection / Collect pilot batch
+        run: |
+          set -euo pipefail
+          test -n "${DATA_GO_KR_SERVICE_KEY}"
+          node tools/datapack/validate-tago-schedule-sample.mjs \
+            --plan \
+            --quiet \
+            --input tools/datapack/inputs/capital-pilot-production-source-input.json \
+            --daily-limit "${TAGO_DAILY_LIMIT}" \
+            --checkpoint "${RUNNER_TEMP}/tago-checkpoint.json" \
+            --output "${RUNNER_TEMP}/tago-plan.json"
+          collect_status=0
+          node tools/datapack/validate-tago-schedule-sample.mjs \
+            --collect \
+            --quiet \
+            --input tools/datapack/inputs/capital-pilot-production-source-input.json \
+            --daily-limit "${TAGO_DAILY_LIMIT}" \
+            --checkpoint "${RUNNER_TEMP}/tago-checkpoint.json" \
+            --service-key-env DATA_GO_KR_SERVICE_KEY \
+            --output "${RUNNER_TEMP}/tago-collection.json" || collect_status=$?
+          if [[ -f "${RUNNER_TEMP}/tago-collection.json" ]]; then
+            node -e 'const fs=require("fs"); const c=JSON.parse(fs.readFileSync(process.env.RUNNER_TEMP + "/tago-collection.json", "utf8")); delete c.responses; fs.writeFileSync(process.env.RUNNER_TEMP + "/tago-report.json", JSON.stringify(c, null, 2) + "\n");'
+          fi
+          if [[ "${collect_status}" -eq 0 ]]; then
+            node tools/datapack/validate-tago-schedule-sample.mjs \
+              --summary \
+              --quiet \
+              --input "${RUNNER_TEMP}/tago-collection.json" \
+              --output "${RUNNER_TEMP}/tago-summary.json"
+          fi
+          exit "${collect_status}"
+
+      - name: TAGO Schedule Collection / Upload sanitized evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: tago-schedule-collection-evidence
+          path: |
+            ${{ runner.temp }}/tago-plan.json
+            ${{ runner.temp }}/tago-summary.json
+            ${{ runner.temp }}/tago-report.json
+          if-no-files-found: error
+          retention-days: 14

--- a/tools/datapack/plan-tago-schedule-collection.test.mjs
+++ b/tools/datapack/plan-tago-schedule-collection.test.mjs
@@ -153,6 +153,27 @@ test("TAGO 시간표 수집 summary evidence hash는 checkpoint 상태를 포함
   assert.notEqual(baseSummary.evidenceHash, editedCheckpointSummary.evidenceHash);
 });
 
+test("TAGO 시간표 수집 summary는 완료 checkpoint no-op을 허용한다", () => {
+  const summary = buildTagoScheduleCollectionSummary({
+    checkpoint: { completedRequestKeys: ["MTRKR4448|01|U"] },
+    responses: [],
+  });
+
+  assert.equal(summary.responseCount, 0);
+  assert.equal(summary.rowCount, 0);
+  assert.deepEqual(summary.completedRequestKeys, ["MTRKR4448|01|U"]);
+});
+
+test("TAGO 시간표 수집 summary는 응답과 checkpoint가 모두 없으면 거부한다", () => {
+  assert.throws(
+    () =>
+      buildTagoScheduleCollectionSummary({
+        responses: [],
+      }),
+    /responses must be non-empty unless checkpoint has completedRequestKeys/,
+  );
+});
+
 test("TAGO 시간표 수집 summary는 requestKey와 raw 응답 불일치를 거부한다", () => {
   assert.throws(
     () =>

--- a/tools/datapack/plan-tago-schedule-collection.test.mjs
+++ b/tools/datapack/plan-tago-schedule-collection.test.mjs
@@ -91,6 +91,31 @@ test("TAGO 시간표 수집 plan CLI는 checkpoint와 output을 적용한다", a
   );
 });
 
+test("TAGO 시간표 수집 plan CLI는 quiet 모드에서 stdout을 비운다", async (t) => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "tago-plan-quiet-"));
+  t.after(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+  const inputPath = path.join(dir, "input.json");
+  const outputPath = path.join(dir, "plan.json");
+  await writeFile(
+    inputPath,
+    `${JSON.stringify({
+      stationLineRows: [{ stationCode: "448", lineId: "seoul-4" }],
+    })}\n`,
+  );
+
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    [tagoScheduleToolPath, "--plan", "--quiet", "--input", inputPath, "--output", outputPath],
+    { timeout: 10_000 },
+  );
+
+  assert.equal(stdout, "");
+  const plan = JSON.parse(await readFile(outputPath, "utf8"));
+  assert.equal(plan.totalRequestCount, 6);
+});
+
 test("TAGO 시간표 수집 summary는 완료 checkpoint와 evidence hash를 남긴다", () => {
   const summary = buildTagoScheduleCollectionSummary({
     responses: [

--- a/tools/datapack/validate-tago-schedule-sample.mjs
+++ b/tools/datapack/validate-tago-schedule-sample.mjs
@@ -153,10 +153,13 @@ function buildTagoScheduleCollectionPlan(input, checkpoint = {}, dailyLimit = 10
 
 function buildTagoScheduleCollectionSummary(collection) {
   const responses = collection?.responses;
-  if (!Array.isArray(responses) || responses.length === 0) {
-    throw new Error("responses must be a non-empty array");
+  if (!Array.isArray(responses)) {
+    throw new Error("responses must be an array");
   }
   const checkpointRequestKeys = collection?.checkpoint?.completedRequestKeys ?? [];
+  if (responses.length === 0 && checkpointRequestKeys.length === 0) {
+    throw new Error("responses must be non-empty unless checkpoint has completedRequestKeys");
+  }
   for (const requestKey of checkpointRequestKeys) {
     requestKeyParts(requestKey);
   }

--- a/tools/datapack/validate-tago-schedule-sample.mjs
+++ b/tools/datapack/validate-tago-schedule-sample.mjs
@@ -30,7 +30,7 @@ function parseArgs(argv) {
     if (!flag.startsWith("--")) {
       throw new Error(`unexpected argument: ${flag}`);
     }
-    if (flag === "--plan" || flag === "--summary" || flag === "--collect") {
+    if (flag === "--plan" || flag === "--summary" || flag === "--collect" || flag === "--quiet") {
       args[flag.slice(2)] = true;
       continue;
     }
@@ -486,7 +486,9 @@ async function main() {
   if (args.output) {
     await writeJsonOutput(args.output, result);
   }
-  console.log(JSON.stringify(result, null, 2));
+  if (!args.quiet) {
+    console.log(JSON.stringify(result, null, 2));
+  }
 }
 
 async function writeJsonOutput(outputPath, value) {


### PR DESCRIPTION
## 관련 이슈

Refs #1415
Refs #1414

## 작업 배경

- #1415의 pilot 시간표 수집 실행 리포트를 GitHub secret 기반으로 남길 수 있게 한다.
- 로컬에는 DATA_GO_KR_SERVICE_KEY가 없고, GitHub secret은 등록되어 있어 Actions 수동 실행 경로가 필요하다.

## 작업 내용

- TAGO pilot 수집 전용 수동 workflow를 추가했다.
- 수집 raw 응답은 runner temp에만 두고, artifact에는 plan/summary/raw 제거 report만 업로드한다.
- collect CLI에 --quiet 옵션을 추가해 raw 응답이 Actions log로 출력되지 않게 했다.

## 검증

- 실행한 명령과 결과:
  - node --test tools/datapack/plan-tago-schedule-collection.test.mjs — pass 15
  - node --test tools/ci/repository-contract.test.mjs — pass 158
  - git diff --check — pass

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| TAGO 수집 workflow 계약 | GitHub Actions | repository contract + workflow 파일 검토 | 로컬 명령 출력 | pass |
| raw 응답 로그 차단 | CLI | --quiet stdout 회귀 테스트 | 로컬 명령 출력 | pass |
| UI/접근성 | 해당 없음 | workflow/datapack tool 변경만 포함 | 해당 없음 | 해당 없음 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: unchanged
- mobile versionCode: unchanged
- datapack version: unchanged
- route contract: unchanged
- realtime contract: unchanged
- backend identity: unchanged

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: .github/workflows/tago-schedule-collection.yml, --quiet 출력 차단

## 리스크

- 실제 provider 호출은 PR merge 후 workflow_dispatch에서 DATA_GO_KR_SERVICE_KEY secret으로 별도 실행해야 한다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.