### PR TITLE
[Chore] automerge FIFO 병합 큐 코디네이터 추가 (#1751)

### DIFF
--- a/.github/workflows/automerge-queue.yml
+++ b/.github/workflows/automerge-queue.yml
@@ -1,0 +1,109 @@
+name: Automerge Queue
+
+# 다중 세션 병합 경합 해소용 FIFO 코디네이터 (#1751).
+# automerge 라벨이 붙은 PR을 생성순으로 한 번에 하나만 처리한다:
+# head PR에 auto-merge를 예약하고 BEHIND면 update-branch 한다.
+# 병합이 일어나면 push 이벤트가 이 워크플로우를 다시 실행해 다음 PR을 처리한다.
+# 라벨은 merge-workflow 규약 4단계(코드리뷰 게이트) 완료 후에만 붙인다.
+# 코디네이터는 review 객체가 없는 PR을 큐에서 제외해 규약을 재검증한다.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - labeled
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: automerge-queue
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  coordinate:
+    name: Automerge Queue
+    if: github.event_name != 'pull_request' || github.event.label.name == 'automerge'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Process queue head
+        env:
+          # GITHUB_TOKEN의 push는 PR CI를 트리거하지 못하므로 PAT가 없으면 체인이 멈춘다.
+          GH_TOKEN: ${{ secrets.AUTOMERGE_PAT != '' && secrets.AUTOMERGE_PAT || github.token }}
+          HAS_PAT: ${{ secrets.AUTOMERGE_PAT != '' }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          if [ "${HAS_PAT}" != "true" ]; then
+            echo "::warning::AUTOMERGE_PAT secret이 없어 GITHUB_TOKEN으로 실행한다. update-branch push가 PR CI를 트리거하지 못해 큐 체인이 멈출 수 있다."
+          fi
+
+          required_checks='["Changes","Repository CI","Backend CI","Mobile App CI","Android CI"]'
+
+          queue=$(gh pr list --repo "${REPO}" --label automerge --base main --state open \
+            --json number,createdAt,isDraft \
+            --jq 'sort_by(.createdAt) | map(select(.isDraft | not)) | .[].number')
+
+          if [ -z "${queue}" ]; then
+            echo "automerge 큐가 비어 있다."
+            exit 0
+          fi
+
+          derail() {
+            pr_number="$1"
+            reason="$2"
+            gh pr comment "${pr_number}" --repo "${REPO}" \
+              --body "automerge 큐에서 제외: ${reason} 해결 후 automerge 라벨을 다시 붙여주세요."
+            gh pr edit "${pr_number}" --repo "${REPO}" --remove-label automerge
+          }
+
+          for pr_number in ${queue}; do
+            state=$(gh pr view "${pr_number}" --repo "${REPO}" \
+              --json mergeStateStatus,reviews,statusCheckRollup)
+            merge_state=$(jq -r '.mergeStateStatus' <<<"${state}")
+            review_count=$(jq -r '.reviews | length' <<<"${state}")
+            failed_required=$(jq -r --argjson required "${required_checks}" \
+              '[.statusCheckRollup[]?
+                | select(($required | index(.name? // .context?)) != null)
+                | select(((.conclusion? // .state?) // "") as $c
+                  | $c == "FAILURE" or $c == "ERROR")] | length' <<<"${state}")
+
+            echo "PR #${pr_number}: mergeStateStatus=${merge_state}, reviews=${review_count}, failedRequiredChecks=${failed_required}"
+
+            if [ "${review_count}" -eq 0 ]; then
+              derail "${pr_number}" "GitHub PR Review 객체가 없습니다 (merge-workflow 규약 4단계 코드리뷰 게이트 미충족)."
+              continue
+            fi
+
+            if [ "${merge_state}" = "DIRTY" ]; then
+              derail "${pr_number}" "main과 충돌(DIRTY) 상태입니다. 충돌 해결이 필요합니다."
+              continue
+            fi
+
+            if [ "${failed_required}" -gt 0 ]; then
+              derail "${pr_number}" "실패한 필수 status check가 있습니다."
+              continue
+            fi
+
+            # 여기부터 큐 head 확정 — 한 번에 하나만 처리한다.
+            gh pr merge "${pr_number}" --repo "${REPO}" --squash --auto \
+              || echo "::warning::PR #${pr_number} auto-merge 예약 실패 — 다음 트리거에서 재시도한다."
+
+            if [ "${merge_state}" = "BEHIND" ]; then
+              gh api --method PUT "repos/${REPO}/pulls/${pr_number}/update-branch" \
+                -H "Accept: application/vnd.github+json" \
+                || echo "::warning::PR #${pr_number} update-branch 실패(transient 가능) — 다음 트리거에서 재시도한다."
+            fi
+
+            echo "큐 head PR #${pr_number} 처리 완료 — 필수 체크 통과 시 auto-merge가 병합한다."
+            exit 0
+          done
+
+          echo "큐에 병합 가능 후보가 없다."

--- a/.github/workflows/automerge-queue.yml
+++ b/.github/workflows/automerge-queue.yml
@@ -23,14 +23,16 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   coordinate:
     name: Automerge Queue
     if: github.event_name != 'pull_request' || github.event.label.name == 'automerge'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # update-branch API에 필요
+      pull-requests: write # auto-merge 예약, PR 코멘트, automerge 라벨 제거에 필요
     steps:
       - name: Process queue head
         env:


### PR DESCRIPTION
## 관련 이슈

close #1751

## 작업 배경

- 여러 세션이 병렬로 PR을 만들면서 main ruleset의 `strict_required_status_checks_policy: true` 때문에 병합 경합이 발생한다: 한 PR이 병합되는 순간 나머지 PR이 전부 BEHIND가 되어 update-branch → 필수 체크 5개 재실행 → 그 사이 다른 PR이 먼저 병합되면 다시 무효화되는 레이스.
- GitHub merge queue는 조직 소유 리포 전용이라 사용할 수 없어, 기존 도구(auto-merge + update-branch)로 병합을 직렬화하는 FIFO 코디네이터를 추가한다.
- 선행 설정은 2026-07-05 적용 완료: `allow_auto_merge: true`, `allow_update_branch: true`, `squash_merge_commit_title: PR_TITLE`, `automerge` 라벨 신설.

## 작업 내용

- `.github/workflows/automerge-queue.yml` 신설: push(main)·pull_request(labeled)·schedule(30분)·workflow_dispatch 트리거로 `automerge` 라벨 PR을 생성순(FIFO)으로 **한 번에 하나만** 처리한다.
- 큐 head 처리: `gh pr merge --squash --auto` 예약 + `mergeStateStatus == BEHIND`면 update-branch API 호출. 병합이 일어나면 push 이벤트가 다음 PR을 자동 처리하는 자가 구동 체인.
- 거버넌스 재검증: review 객체가 없는 PR(`reviews: []`), 충돌(DIRTY), 필수 체크 실패 PR은 코멘트를 남기고 라벨을 제거해 큐 정체를 방지한다 — merge-workflow 규약 4단계(코드리뷰 게이트)를 큐 레벨에서 강제.
- 토큰: `AUTOMERGE_PAT` secret 우선, 없으면 GITHUB_TOKEN으로 실행하되 체인 정지 가능성을 warning으로 알린다 (GITHUB_TOKEN push는 PR CI를 트리거하지 못함).

## 검증

- 실행한 명령과 결과:
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/automerge-queue.yml")'` — YAML OK
- `node --test tools/ci/repository-contract.test.mjs` — fail 0

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| workflow YAML 유효성 | GitHub Actions | ruby YAML parse | 터미널 출력 | 성공 |
| repository contract | repo | node test | 터미널 출력 | fail 0 |
| 큐 사이클 end-to-end | GitHub Actions | merge 후 automerge 라벨 PR 2건 순차 병합 evidence | #1751 완료 기준에서 수집 (merge 전 검증 불가) | 병합 후 확인 |
| UI/접근성 | 해당 없음 | workflow 파일만 추가 | 증거 불필요 | 해당 없음 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: derail 로직(라벨 제거 조건 3가지)이 merge-workflow 규약과 정합한지, `statusCheckRollup`의 CheckRun(`name`/`conclusion`)·StatusContext(`context`/`state`) 양쪽을 jq가 모두 처리하는지.
- 큐 head가 아닌 PR은 건드리지 않는다 — CI 재실행은 head 승격 시점에만 발생 (PR당 정확히 1회).

## 리스크

- `AUTOMERGE_PAT` 미등록 시 update-branch push가 PR CI를 트리거하지 못해 체인이 멈춘다 → warning 로그로 알리고, schedule 트리거가 30분마다 재시도한다. secret 등록은 #1751 체크리스트로 추적.
- auto-merge는 ruleset의 필수 체크·thread resolution을 그대로 따르므로 게이트 우회는 발생하지 않는다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `automerge` 라벨이 붙은 PR을 생성 순서대로 자동 처리하는 순차 병합 흐름이 추가되었습니다.
  * 병합 전 필수 검증, 충돌 상태, 리뷰 여부를 확인해 조건에 맞는 PR만 다음 단계로 진행합니다.
  * 대기열이 비어 있으면 즉시 종료되며, 수동 실행과 주기 실행도 지원합니다.

* **Bug Fixes**
  * 동시에 여러 자동 병합 작업이 실행되지 않도록 처리되어 병합 충돌 가능성을 줄였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->