### PR TITLE
[Mobile] 노선도 역 tap hit target 48dp 접근성 회귀 가드 (#1642)

### DIFF
--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -3376,8 +3376,10 @@ _StationTapScore? _stationTapScore(
   );
   final nodeHitRect = Rect.fromCenter(
     center: nodeCenter,
-    width: _maximumStationHitDistance * 2,
-    height: _maximumStationHitDistance * 2,
+    // 노출 상수를 단일 소스로 써서, 48dp 접근성 회귀 가드 테스트가 실제 hit
+    // rect를 지키게 한다(상수와 rect의 독립 재유도 드리프트 방지).
+    width: networkMapStationHitTargetLogicalSize,
+    height: networkMapStationHitTargetLogicalSize,
   );
   final containsNode = nodeHitRect.contains(viewportPosition);
   final nodeDistance = (viewportPosition - nodeCenter).distance;

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -3244,6 +3244,14 @@ class _StationSpatialCell {
 
 const _maximumStationHitDistance = 24.0;
 
+/// 역 tap hit target 한 변 길이(logical px). 노드 중심에서 사방
+/// [_maximumStationHitDistance]까지 tap을 받으므로 hit rect 한 변은 그 2배다.
+/// AGENTS.md 큰 터치 영역 hard rule + WCAG 2.5.5(target size 최소 48×48)를
+/// 노선도 역 선택에 보장한다 — #1642 접근성 회귀 가드.
+@visibleForTesting
+const double networkMapStationHitTargetLogicalSize =
+    _maximumStationHitDistance * 2;
+
 List<NetworkMapStation> _canonicalStations(
   Iterable<NetworkMapStation> stations,
   _MapGeometry geometry,

--- a/apps/mobile/test/accessibility_baseline_test.dart
+++ b/apps/mobile/test/accessibility_baseline_test.dart
@@ -5,6 +5,7 @@ import 'package:easysubway_mobile/accessible_design.dart';
 import 'package:easysubway_mobile/facility_report.dart';
 import 'package:easysubway_mobile/main.dart';
 import 'package:easysubway_mobile/mobility_profile.dart';
+import 'package:easysubway_mobile/network_map.dart';
 import 'package:easysubway_mobile/onboarding.dart';
 import 'package:easysubway_mobile/route_search.dart';
 import 'package:easysubway_mobile/station_search.dart';
@@ -22,6 +23,16 @@ void main() {
     expect(
       _contrastRatio(EasySubwayAccessibleColors.mutedText, appBackground),
       greaterThanOrEqualTo(4.5),
+    );
+  });
+
+  test('노선도 역 tap hit target은 48dp 최소 상호작용 크기를 만족한다', () {
+    // AGENTS.md 큰 터치 영역 hard rule + WCAG 2.5.5(target size 48×48).
+    // 노드 중심 사방 24px hit → 48×48 hit rect. #1642 접근성 회귀 가드:
+    // _maximumStationHitDistance를 24 미만으로 낮추면(=<48dp) 이 테스트가 잡는다.
+    expect(
+      networkMapStationHitTargetLogicalSize,
+      greaterThanOrEqualTo(kMinInteractiveDimension),
     );
   });
 


### PR DESCRIPTION
## 관련 이슈

Refs #1642 #1635

## 작업 배경

#1642 완료조건 "**터치 hit target 48dp 이상 유지 확인 (기존 accessibility baseline test 연계)**"를 이행한다. 노선도 역 선택 hit test는 노드 중심 사방 `_maximumStationHitDistance`(24px)까지 tap을 받아 hit rect가 48×48 logical px — AGENTS.md 큰 터치 영역 hard rule + WCAG 2.5.5(target size 최소 48×48)를 **이미 충족**한다. 다만 이 불변을 지키는 회귀 가드가 없었다(`accessibility_baseline_test`는 색 대비·홈 접근성만 커버).

## 작업 내용

- `network_map.dart`: `networkMapStationHitTargetLogicalSize`(`@visibleForTesting`, = `_maximumStationHitDistance * 2` = 48)로 48dp hit target 불변을 노출.
- `accessibility_baseline_test.dart`: `networkMapStationHitTargetLogicalSize >= kMinInteractiveDimension`(48) 단정 추가. `_maximumStationHitDistance`를 24 미만으로 낮추면(=<48dp) CI가 잡는다.

## 검증

- `flutter analyze` → 0 issues
- `flutter test test/accessibility_baseline_test.dart` → 통과(신규 hit-target 가드 포함), network_map 테스트 회귀 없음.

## Version impact

- [x] no version change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Notes (#1642 후속)

- 자동화 가능한 접근성 가드(라벨 겹침 #1732, hit target 이 PR) 완료. 남은 #1642 완료조건은 실기기 증거: TalkBack 스크린리더, 큰 글자(1.3x/2x)·고대비 스크린샷, 지역별 viewport×bucket 스크린샷 QA — 후속 device 증거로 이슈에 첨부.
