### PR TITLE
[Style] 전 화면 부가설명 제로베이스 감사 (#1572)

### DIFF
--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -1483,15 +1483,6 @@ class _MyReportEmpty extends StatelessWidget {
                 height: 1.3,
               ),
             ),
-            const SizedBox(height: 8),
-            Text(
-              '시설 제보를 남기면 여기에서 진행 상황을 확인할 수 있어요.',
-              textAlign: TextAlign.center,
-              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                color: EasySubwayAccessibleColors.mutedText,
-                height: 1.4,
-              ),
-            ),
           ],
         ),
       ),

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -2588,7 +2588,6 @@ class _AppSettingsScreenState extends State<AppSettingsScreen> {
                       key: const Key('notificationSettingsButton'),
                       icon: Icons.notifications_active_outlined,
                       title: '알림 설정',
-                      subtitle: '시설 상태, 제보 진행 상황, 최신 안내 알림을 관리해요',
                       onTap: () {
                         Navigator.of(context).push(
                           MaterialPageRoute<void>(

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -3729,11 +3729,11 @@ void main() {
       );
       expect(
         settingsActionSemantics(
-          '알림 설정, 시설 상태, 제보 진행 상황, 최신 안내 알림을 관리해요',
+          '알림 설정',
         ).getSemanticsData().hasAction(SemanticsAction.tap),
         isTrue,
       );
-      // 자명한 행은 부가설명 없이 제목만 시맨틱에 담는다(#1570).
+      // 자명한 행은 부가설명 없이 제목만 시맨틱에 담는다(#1570·#1572).
       expect(
         settingsActionSemantics(
           '도움말·문의',


### PR DESCRIPTION
## 관련 이슈

close #1572
상위 트래커: #1575 (출시 품질 3차 정비) 6단계 — 화면별 이슈(#1567~1581) 완료 후 마감 스윕.

## 작업 배경

- 화면별 다이어트(#1570·#1571·#1579 등) 이후에도 리스트 행·빈 상태에 관성적 부가설명이 남아 있는지 전 화면 화이트리스트 감사(기본 삭제, "행동 결과가 자명하지 않은 경우"만 유지).

## 작업 내용

`apps/mobile/lib` 전 화면의 literal subtitle/부가설명 ~25건과 빈 상태 문구를 전수 판정. **도달 화면 잔존 삭제 후보는 2건**이었고, 나머지는 동적 데이터·에러 복구·권한 근거·상태 라벨로 정당한 유지, OfflineDataScreen은 범위 밖.

- **내 제보 빈 상태 이중문구 → 1문구**: `facility_report.dart` '접수한 제보가 없습니다.' 아래 '시설 제보를 남기면 여기에서 진행 상황을 확인할 수 있어요.'(화면 목적 동어반복) 제거.
- **'알림 설정' 나av 타일 subtitle 제거**: `main.dart` '시설 상태, 제보 진행 상황, 최신 안내 알림을 관리해요' — '알림 설정' 제목으로 목적지가 자명, 카테고리 열거는 TMI.
- **위젯 테스트 갱신**: 설정 시맨틱 라벨을 제목만으로.

### 감사 표 (문구 / 화면 / 판정 / 사유)

| 문구 | 화면 | 판정 | 사유 |
| --- | --- | --- | --- |
| 시설 제보를 남기면 여기에서 진행 상황을… | 내 제보 빈 상태 | **삭제** | 제목 '접수한 제보가 없습니다' + 화면 목적과 동어반복 |
| 시설 상태, 제보 진행 상황, 최신 안내 알림을 관리해요 | 설정·알림 설정 | **삭제** | '알림 설정' 제목으로 목적지 자명, 열거는 TMI |
| 필수 행동과 상태 안내를 먼저 보여줘요 | 설정·간편 보기(토글) | 유지 | 토글 효과가 라벨만으로 비자명 |
| 버튼과 상태 문구의 대비를 더 강하게 보여줘요 | 설정·고대비(토글) | 유지 | a11y 토글 범위 명확화(고령·저시력 대상) |
| 역, 시설, 경로에서 즐겨찾기를 추가해 주세요 | 즐겨찾기 빈 상태 | 유지 | CTA 없음, 추가 진입점이 비자명한 유일 안내(1문구 유지) |
| 가까운 역 찾기 / 시설 고장·복구 알림 | 온보딩 권한 카드 | 유지 | 권한 요청 근거(법적·UX 필수) |
| 잠시 후 다시 시도해 주세요 / 다시 불러와 주세요 등 | 각 에러 상태 | 유지 | 에러 복구 방법 비자명 |
| 제보 번호 X / 제공·소유 X / 3번 출구 앞 | 각 상세·항목 | 유지 | 동적 데이터 |
| 지역·노선·역 보기 · 출구와 엘리베이터 보기 등 | 인터넷 없이 이용(OfflineDataScreen) | 범위 밖 | #1570 후속으로 화면 자체 삭제 예정(도달 경로 없음) |
| …아직 알 수 없어요 / 안내할 수 있는 경로가 없습니다 등 | 경로 검색 상태 | 유지 | 동적 경로 상태 라벨 |

### 이번 범위 밖(후속)
- **OfflineDataScreen('인터넷 없이 이용') 완전 삭제**: 진입점 없는 dead screen. #1570 후속 삭제 트랙에서 처리(본 감사에서 문구 손대지 않음).

## 검증

- 실행한 명령과 결과:
  - `dart format` (facility_report·main, widget_test) → 정상
  - `flutter analyze lib test` → **No issues found!**
  - `flutter test` → **All tests passed!** (677건)
  - `node --test tools/ci/repository-contract.test.mjs` → **pass 158 / fail 0**

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 부가설명 감사 회귀 | Mobile (Flutter) | `flutter analyze` + `flutter test` | 자동 테스트 677건 | 통과 |
| 저장소 계약 | tools/ci | `node --test repository-contract` | 계약 158건 | 통과 |
| 내 제보 빈 상태·설정 화면 전/후 스크린샷 | Mobile 실기기 | 스크린샷 | #1573 최종 게이트 | 대기 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 먼저 볼 지점: 감사 표의 삭제 2건 판정과 유지 사유. 유지 항목은 화이트리스트 원칙("남길 이유")으로 근거를 붙였다.

## 리스크

- 부가설명 삭제는 정보 손실이 아니라 자명·중복 제거. 유지 항목은 표로 근거 관리.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)