### PR TITLE
[Fix] TAGO provider row order handling (#1415)

### DIFF
--- a/.github/workflows/tago-schedule-collection.yml
+++ b/.github/workflows/tago-schedule-collection.yml
@@ -64,7 +64,7 @@ jobs:
           if [[ -f "${RUNNER_TEMP}/tago-collection.json" ]]; then
             node -e 'const fs=require("fs"); const c=JSON.parse(fs.readFileSync(process.env.RUNNER_TEMP + "/tago-collection.json", "utf8")); delete c.responses; fs.writeFileSync(process.env.RUNNER_TEMP + "/tago-report.json", JSON.stringify(c, null, 2) + "\n");'
           fi
-          if [[ -f "${RUNNER_TEMP}/tago-collection.json" ]]; then
+          if [[ -f "${RUNNER_TEMP}/tago-collection.json" ]] && node -e 'const fs=require("fs"); const c=JSON.parse(fs.readFileSync(process.env.RUNNER_TEMP + "/tago-collection.json", "utf8")); process.exit(((c.responses?.length ?? 0) > 0 || (c.checkpoint?.completedRequestKeys?.length ?? 0) > 0) ? 0 : 1);'; then
             node tools/datapack/validate-tago-schedule-sample.mjs \
               --summary \
               --quiet \

--- a/tools/datapack/plan-tago-schedule-collection.test.mjs
+++ b/tools/datapack/plan-tago-schedule-collection.test.mjs
@@ -151,6 +151,23 @@ test("TAGO 시간표 검증은 provider row order에 의존하지 않는다", ()
   );
 });
 
+test("TAGO 시간표 검증은 같은 시간 row도 deterministic하게 정렬한다", () => {
+  const first = validateTagoScheduleSample(
+    tagoResponse("MTRKR4448", "01", "U", [
+      ["051000", "051500", "MTRKR410"],
+      ["051000", "051500", "MTRKR409"],
+    ]),
+  );
+  const second = validateTagoScheduleSample(
+    tagoResponse("MTRKR4448", "01", "U", [
+      ["051000", "051500", "MTRKR409"],
+      ["051000", "051500", "MTRKR410"],
+    ]),
+  );
+
+  assert.deepEqual(first.providerRecordHashes, second.providerRecordHashes);
+});
+
 test("TAGO 시간표 수집 summary evidence hash는 checkpoint 상태를 포함한다", () => {
   const response = {
     requestKey: "MTRKR4448|02|U",
@@ -529,8 +546,8 @@ function tagoResponse(
       header: { resultCode: "00" },
       body: {
         items: {
-          item: times.map(([arrTime, depTime]) =>
-            tagoRow(stationId, dailyTypeCode, upDownTypeCode, arrTime, depTime),
+          item: times.map(([arrTime, depTime, endSubwayStationId]) =>
+            tagoRow(stationId, dailyTypeCode, upDownTypeCode, arrTime, depTime, endSubwayStationId),
           ),
         },
       },
@@ -538,7 +555,7 @@ function tagoResponse(
   });
 }
 
-function tagoRow(stationId, dailyTypeCode, upDownTypeCode, arrTime, depTime) {
+function tagoRow(stationId, dailyTypeCode, upDownTypeCode, arrTime, depTime, endSubwayStationId = "MTRKR409") {
   return {
     subwayRouteId: "MTRKR4",
     subwayStationId: stationId,
@@ -548,6 +565,6 @@ function tagoRow(stationId, dailyTypeCode, upDownTypeCode, arrTime, depTime) {
     arrTime,
     depTime,
     endSubwayStationNm: "당고개",
-    endSubwayStationId: "MTRKR409",
+    endSubwayStationId,
   };
 }

--- a/tools/datapack/plan-tago-schedule-collection.test.mjs
+++ b/tools/datapack/plan-tago-schedule-collection.test.mjs
@@ -9,6 +9,7 @@ import {
   buildTagoScheduleCollectionPlan,
   buildTagoScheduleCollectionSummary,
   collectTagoSchedules,
+  validateTagoScheduleSample,
 } from "./validate-tago-schedule-sample.mjs";
 
 const execFileAsync = promisify(execFile);
@@ -134,6 +135,20 @@ test("TAGO 시간표 수집 summary는 완료 checkpoint와 evidence hash를 남
   assert.match(summary.rawSha256ByRequest["MTRKR4448|01|U"], /^[0-9a-f]{64}$/);
   assert.match(summary.evidenceHash, /^[0-9a-f]{64}$/);
   assert.equal(summary.productionUseAllowed, false);
+});
+
+test("TAGO 시간표 검증은 provider row order에 의존하지 않는다", () => {
+  const validation = validateTagoScheduleSample(
+    tagoResponse("MTRKR4448", "01", "U", [
+      ["052000", "052500"],
+      ["051000", "051500"],
+    ]),
+  );
+
+  assert.deepEqual(
+    validation.departures.map((departure) => departure.departureSeconds),
+    [18_900, 19_500],
+  );
 });
 
 test("TAGO 시간표 수집 summary evidence hash는 checkpoint 상태를 포함한다", () => {
@@ -500,16 +515,23 @@ test("TAGO 시간표 수집기는 service key가 없으면 provider 호출 전�
   );
 });
 
-function tagoResponse(stationId, dailyTypeCode, upDownTypeCode) {
+function tagoResponse(
+  stationId,
+  dailyTypeCode,
+  upDownTypeCode,
+  times = [
+    ["051000", "051500"],
+    ["052000", "052500"],
+  ],
+) {
   return JSON.stringify({
     response: {
       header: { resultCode: "00" },
       body: {
         items: {
-          item: [
-            tagoRow(stationId, dailyTypeCode, upDownTypeCode, "051000", "051500"),
-            tagoRow(stationId, dailyTypeCode, upDownTypeCode, "052000", "052500"),
-          ],
+          item: times.map(([arrTime, depTime]) =>
+            tagoRow(stationId, dailyTypeCode, upDownTypeCode, arrTime, depTime),
+          ),
         },
       },
     },

--- a/tools/datapack/validate-tago-schedule-sample.mjs
+++ b/tools/datapack/validate-tago-schedule-sample.mjs
@@ -83,8 +83,10 @@ function validateTagoScheduleSample(rawText) {
     if (arrivalSeconds > departureSeconds) {
       throw new Error(`TAGO schedule row ${index} arrival must be <= departure`);
     }
+    const rowHash = sha256(JSON.stringify(sortObject(row)));
     parsedRows.push({
       row,
+      rowHash,
       subwayStationId: row.subwayStationId,
       subwayRouteId: row.subwayRouteId,
       dailyTypeCode: row.dailyTypeCode,
@@ -94,10 +96,13 @@ function validateTagoScheduleSample(rawText) {
     });
   }
   parsedRows.sort(
-    (left, right) => left.departureSeconds - right.departureSeconds || left.arrivalSeconds - right.arrivalSeconds,
+    (left, right) =>
+      left.departureSeconds - right.departureSeconds ||
+      left.arrivalSeconds - right.arrivalSeconds ||
+      left.rowHash.localeCompare(right.rowHash),
   );
-  const providerRecordHashes = parsedRows.map(({ row }) => sha256(JSON.stringify(sortObject(row))));
-  const departures = parsedRows.map(({ row: _row, ...departure }) => departure);
+  const providerRecordHashes = parsedRows.map(({ rowHash }) => rowHash);
+  const departures = parsedRows.map(({ row: _row, rowHash: _rowHash, ...departure }) => departure);
 
   return {
     artifactKind: "tago-schedule-sample-importer-validation",

--- a/tools/datapack/validate-tago-schedule-sample.mjs
+++ b/tools/datapack/validate-tago-schedule-sample.mjs
@@ -65,9 +65,7 @@ function validateTagoScheduleSample(rawText) {
     }
   }
 
-  let previousDeparture = -1;
-  const providerRecordHashes = [];
-  const departures = [];
+  const parsedRows = [];
   for (const [index, row] of rows.entries()) {
     for (const field of REQUIRED_FIELDS) {
       if (typeof row[field] !== "string" || row[field].length === 0) {
@@ -85,12 +83,8 @@ function validateTagoScheduleSample(rawText) {
     if (arrivalSeconds > departureSeconds) {
       throw new Error(`TAGO schedule row ${index} arrival must be <= departure`);
     }
-    if (departureSeconds < previousDeparture) {
-      throw new Error(`TAGO schedule rows must be sorted by depTime`);
-    }
-    previousDeparture = departureSeconds;
-    providerRecordHashes.push(sha256(JSON.stringify(sortObject(row))));
-    departures.push({
+    parsedRows.push({
+      row,
       subwayStationId: row.subwayStationId,
       subwayRouteId: row.subwayRouteId,
       dailyTypeCode: row.dailyTypeCode,
@@ -99,6 +93,11 @@ function validateTagoScheduleSample(rawText) {
       departureSeconds,
     });
   }
+  parsedRows.sort(
+    (left, right) => left.departureSeconds - right.departureSeconds || left.arrivalSeconds - right.arrivalSeconds,
+  );
+  const providerRecordHashes = parsedRows.map(({ row }) => sha256(JSON.stringify(sortObject(row))));
+  const departures = parsedRows.map(({ row: _row, ...departure }) => departure);
 
   return {
     artifactKind: "tago-schedule-sample-importer-validation",


### PR DESCRIPTION
## 관련 이슈

Refs #1415
Refs #1414

## 작업 배경

- TAGO Schedule Collection run `28728159631`이 첫 request `MTRKR4448|01|U`에서 `TAGO schedule rows must be sorted by depTime`로 실패했습니다.
- provider 응답 row order는 수집 성공 조건으로 볼 수 없어서 importer 검증기가 정렬 후 해석하도록 보정합니다.

## 작업 내용

- TAGO timetable validation이 provider row order에 의존하지 않도록 departure time 기준으로 정렬한 뒤 evidence hash와 departures를 생성합니다.
- 첫 호출 실패처럼 성공 응답과 checkpoint가 모두 0건인 partial collection에서는 summary 생성을 건너뜁니다.
- provider row order 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/datapack/plan-tago-schedule-collection.test.mjs` — pass 18
  - `node --check tools/datapack/validate-tago-schedule-sample.mjs` — pass
  - `node --test tools/ci/repository-contract.test.mjs` — pass 158
  - `git diff --check origin/main` — pass

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| TAGO collection 실패 root cause | GitHub Actions | run `28728159631` 실패 로그와 artifact 확인 | `.codex/evidence/1415-tago-run-28728159631/` | 첫 request provider row order 검증 실패 확인 |
| TAGO validator regression | local | `node --test tools/datapack/plan-tago-schedule-collection.test.mjs` | terminal output | pass 18 |
| Repository contract | local | `node --test tools/ci/repository-contract.test.mjs` | terminal output | pass 158 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: no version change
- mobile versionCode: no version change
- datapack version: no datapack release
- route contract: unchanged
- realtime contract: unchanged
- backend identity: unchanged

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `validateTagoScheduleSample`에서 provider order를 검증 조건으로 보지 않고 정렬 후 summary evidence를 만드는 부분.

## 리스크

- 실제 TAGO 재수집 workflow는 이 PR merge 후 다시 실행해야 합니다.
- provider가 같은 departure time row를 여러 개 반환하면 현재 정렬은 departure/arrival 기준까지만 고정합니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
