### PR TITLE
[Style] OfflineDataScreen 완전 삭제·오프라인 스레딩 정리 (#1570)

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -10,7 +10,6 @@ import 'package:url_launcher/url_launcher.dart';
 import 'accessible_design.dart';
 import 'app/app_bootstrap.dart';
 import 'app/app_dependencies.dart';
-import 'core/datapack/data_pack_update_state.dart';
 import 'facility_report.dart';
 import 'facility_status.dart';
 import 'favorite_facility.dart';
@@ -77,9 +76,6 @@ Future<void> main() async {
         : null,
   );
   final photoPicker = ImagePickerFacilityReportPhotoPicker();
-  final dataPackUpdateStateRepository = DataPackUpdateStateRepository(
-    userDatabase: bootstrap.userDatabase,
-  );
   runApp(
     AppBootstrapLifecycle(
       close: bootstrap.close,
@@ -90,9 +86,6 @@ Future<void> main() async {
             const SecureFacilityReportDraftTargetStore(),
         facilityReportLostPhotoRestorer: photoPicker.retrieveLostPhoto,
         legacyCredentialCleaner: const SecureLegacyCredentialCleaner(),
-        offlineDataExpiresAtLoader: () async =>
-            (await dataPackUpdateStateRepository.readManifestCache())
-                ?.expiresAt,
       ),
     ),
   );
@@ -276,7 +269,6 @@ class EasySubwayApp extends StatelessWidget {
         const SupportAccessInfo.fromEnvironment(),
     SupportAccessLauncher supportAccessLauncher =
         const UrlLauncherSupportAccessLauncher(),
-    OfflineDataExpiresAtLoader? offlineDataExpiresAtLoader,
     OnboardingState initialOnboardingState = const OnboardingState.initial(),
     bool enablePushNotifications = defaultPushNotificationsEnabled,
     Key? key,
@@ -311,7 +303,6 @@ class EasySubwayApp extends StatelessWidget {
            isReleaseMode: kReleaseMode,
          ),
          supportAccessLauncher: supportAccessLauncher,
-         offlineDataExpiresAtLoader: offlineDataExpiresAtLoader,
          recentRoutesFuture:
              recentRoutesFuture ??
              (defaultDemoHomeDataEnabled
@@ -329,7 +320,6 @@ class EasySubwayApp extends StatelessWidget {
     required this.legacyCredentialCleaner,
     required this.supportAccessInfo,
     required this.supportAccessLauncher,
-    required this.offlineDataExpiresAtLoader,
     required this.recentRoutesFuture,
     super.key,
   }) : repository = dependencies.repository,
@@ -373,7 +363,6 @@ class EasySubwayApp extends StatelessWidget {
   final LegacyCredentialCleaner legacyCredentialCleaner;
   final SupportAccessInfo supportAccessInfo;
   final SupportAccessLauncher supportAccessLauncher;
-  final OfflineDataExpiresAtLoader? offlineDataExpiresAtLoader;
   final Future<List<FavoriteRoute>>? recentRoutesFuture;
 
   @override
@@ -454,14 +443,11 @@ class EasySubwayApp extends StatelessWidget {
         supportAccessInfo: supportAccessInfo,
         supportAccessLauncher: supportAccessLauncher,
         userDataDeletionRepository: userDataDeletionRepository,
-        offlineDataExpiresAtLoader: offlineDataExpiresAtLoader,
         recentRoutesFuture: recentRoutesFuture,
       ),
     );
   }
 }
-
-typedef OfflineDataExpiresAtLoader = Future<DateTime?> Function();
 
 class EasySubwayScrollBehavior extends MaterialScrollBehavior {
   const EasySubwayScrollBehavior();
@@ -577,7 +563,6 @@ class _EasySubwayHome extends StatefulWidget {
     required this.supportAccessInfo,
     required this.supportAccessLauncher,
     required this.userDataDeletionRepository,
-    required this.offlineDataExpiresAtLoader,
     required this.recentRoutesFuture,
   });
 
@@ -604,7 +589,6 @@ class _EasySubwayHome extends StatefulWidget {
   final SupportAccessInfo supportAccessInfo;
   final SupportAccessLauncher supportAccessLauncher;
   final UserDataDeletionRepository? userDataDeletionRepository;
-  final OfflineDataExpiresAtLoader? offlineDataExpiresAtLoader;
   final Future<List<FavoriteRoute>>? recentRoutesFuture;
 
   @override
@@ -722,7 +706,6 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
         supportAccessLauncher: widget.supportAccessLauncher,
         userDataDeletionRepository: widget.userDataDeletionRepository,
         recentRoutesFuture: widget.recentRoutesFuture,
-        offlineDataExpiresAtLoader: widget.offlineDataExpiresAtLoader,
         onUserDataDeleted: _handleUserDataDeleted,
         onMobilityProfileChanged: _saveMobilityProfile,
         onViewPreferencesChanged: _saveViewPreferences,
@@ -1225,7 +1208,6 @@ class HomeScreen extends StatefulWidget {
     this.viewPreferences = const OnboardingViewPreferences.defaults(),
     this.simpleViewEnabled = true,
     this.facilityReportDraftTargetStore,
-    this.offlineDataExpiresAtLoader,
     String? initialMobilityType,
     super.key,
   }) : initialMobilityType =
@@ -1255,7 +1237,6 @@ class HomeScreen extends StatefulWidget {
   final Future<void> Function(OnboardingViewPreferences preferences)
   onViewPreferencesChanged;
   final Future<List<FavoriteRoute>>? recentRoutesFuture;
-  final OfflineDataExpiresAtLoader? offlineDataExpiresAtLoader;
   final String initialMobilityType;
   final OnboardingViewPreferences viewPreferences;
   final bool simpleViewEnabled;
@@ -1586,7 +1567,6 @@ class _HomeScreenState extends State<HomeScreen> {
           onOpenMobilityProfile: _openMobilityProfile,
           onOpenSupportAccess: openSupportAccess,
           onOpenMyReports: openMyReports,
-          offlineDataExpiresAtLoader: widget.offlineDataExpiresAtLoader,
         ),
       );
     }
@@ -2379,14 +2359,12 @@ class _AppInfoRow extends StatelessWidget {
     required this.iconColor,
     required this.title,
     this.subtitle,
-    this.trailing,
   });
 
   final IconData icon;
   final Color iconColor;
   final String title;
   final String? subtitle;
-  final String? trailing;
 
   @override
   Widget build(BuildContext context) {
@@ -2422,49 +2400,11 @@ class _AppInfoRow extends StatelessWidget {
         ],
       ],
     );
-    final textScale = MediaQuery.textScalerOf(context).scale(1);
-    if (textScale >= 2) {
-      return Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              leading,
-              const SizedBox(width: 12),
-              Expanded(child: content),
-            ],
-          ),
-          if (trailing != null)
-            Padding(
-              padding: const EdgeInsets.only(top: 8, left: 55),
-              child: Text(
-                trailing!,
-                style: const TextStyle(
-                  color: EasySubwayAccessibleColors.text,
-                  fontSize: 12,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-            ),
-        ],
-      );
-    }
     return Row(
       children: [
         leading,
         const SizedBox(width: 12),
         Expanded(child: content),
-        if (trailing != null) ...[
-          const SizedBox(width: 8),
-          Text(
-            trailing!,
-            style: const TextStyle(
-              color: EasySubwayAccessibleColors.text,
-              fontSize: 12,
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-        ],
       ],
     );
   }
@@ -2480,7 +2420,6 @@ class AppSettingsScreen extends StatefulWidget {
     required this.onOpenMobilityProfile,
     required this.onOpenSupportAccess,
     required this.onOpenMyReports,
-    this.offlineDataExpiresAtLoader,
     this.bottomNavigationBar,
     super.key,
   });
@@ -2494,7 +2433,6 @@ class AppSettingsScreen extends StatefulWidget {
   final Future<MobilityProfileOption?> Function() onOpenMobilityProfile;
   final VoidCallback onOpenSupportAccess;
   final VoidCallback onOpenMyReports;
-  final OfflineDataExpiresAtLoader? offlineDataExpiresAtLoader;
   final Widget? bottomNavigationBar;
 
   @override
@@ -2576,9 +2514,8 @@ class _AppSettingsScreenState extends State<AppSettingsScreen> {
                   ),
                 ],
               ),
-              // '저장된 안내'(인터넷 없이 이용·데이터 출처) 섹션 제거(#1570):
-              // 오프라인 동작은 설명 없이 그냥 되는 것이고, 데이터·지도 출처는
-              // 도움말·문의 하위에 이미 있어 중복 진입을 없앤다.
+              // 오프라인 안내 섹션·화면은 완전히 제거됐다(#1570): 오프라인 동작은
+              // 설명 없이 그냥 되는 것이고, 데이터·지도 출처는 도움말·문의 하위에 이미 있다.
               if (widget.notificationRepository != null)
                 _AppSettingsSection(
                   key: const Key('settingsSection-notification'),
@@ -3263,150 +3200,6 @@ class _FavoriteHomeFacilityRow extends StatelessWidget {
       ),
     );
   }
-}
-
-class OfflineDataScreen extends StatelessWidget {
-  const OfflineDataScreen({
-    super.key,
-    this.expiresAt,
-    this.expiresAtLoader,
-    this.now,
-  });
-
-  // ponytail: v1 stale badge only needs manifest expiry; add source freshness when surfaced here.
-  static const _offlineDataSourceOfTruth = 'installed catalog metadata';
-
-  final DateTime? expiresAt;
-  final OfflineDataExpiresAtLoader? expiresAtLoader;
-  final DateTime Function()? now;
-
-  @override
-  Widget build(BuildContext context) {
-    assert(_offlineDataSourceOfTruth == 'installed catalog metadata');
-    final loader = expiresAtLoader;
-    if (loader != null && expiresAt == null) {
-      return FutureBuilder<DateTime?>(
-        future: loader(),
-        builder: (context, snapshot) => _buildScaffold(context, snapshot.data),
-      );
-    }
-    return _buildScaffold(context, expiresAt);
-  }
-
-  Widget _buildScaffold(BuildContext context, DateTime? effectiveExpiresAt) {
-    final storedDataStatus = _storedDataStatus(
-      expiresAt: effectiveExpiresAt,
-      now: now,
-    );
-    return Scaffold(
-      appBar: AppBar(title: const Text('인터넷 없이 이용')),
-      body: SafeArea(
-        child: ListView(
-          padding: _mainPagePadding,
-          children: [
-            const _AppCard(
-              showBorder: true,
-              child: _AppInfoRow(
-                icon: Icons.check_circle_outline,
-                iconColor: EasySubwayAccessibleColors.primary,
-                title: '인터넷 없이도 이용할 수 있어요',
-                subtitle: '마지막으로 받은 노선도와 역 정보를 보여줍니다.',
-              ),
-            ),
-            const _AppSectionTitle(title: '저장된 안내 상태'),
-            _AppCard(
-              child: Column(
-                children: [
-                  _AppInfoRow(
-                    icon: Icons.update,
-                    iconColor: EasySubwayAccessibleColors.brand,
-                    title: '마지막 갱신',
-                    subtitle: storedDataStatus.subtitle,
-                    trailing: storedDataStatus.trailing,
-                  ),
-                  const _AppInfoRow(
-                    icon: Icons.manage_search_outlined,
-                    iconColor: EasySubwayAccessibleColors.amber,
-                    title: '저장 정보 다시 확인',
-                    subtitle: '저장 정보 기록을 확인할 수 없으면 현장 안내를 우선 확인해 주세요',
-                    trailing: '확인',
-                  ),
-                  const _AppInfoRow(
-                    icon: Icons.info_outline,
-                    iconColor: EasySubwayAccessibleColors.amber,
-                    title: '제한 사항',
-                    subtitle: '실시간 시설 상태와 제보 전송은 인터넷 연결이 필요해요',
-                    trailing: '주의',
-                  ),
-                ],
-              ),
-            ),
-            const _AppSectionTitle(title: '이용 가능'),
-            const _AppCard(
-              child: Column(
-                children: [
-                  _AppInfoRow(
-                    icon: Icons.map_outlined,
-                    iconColor: EasySubwayAccessibleColors.mintDark,
-                    title: '노선도',
-                    subtitle: '지역·노선·역 보기',
-                    trailing: '가능',
-                  ),
-                  _AppInfoRow(
-                    icon: Icons.train_outlined,
-                    iconColor: EasySubwayAccessibleColors.mintDark,
-                    title: '역·시설 정보',
-                    subtitle: '출구와 엘리베이터 보기',
-                    trailing: '가능',
-                  ),
-                  _AppInfoRow(
-                    icon: Icons.bookmark_border,
-                    iconColor: EasySubwayAccessibleColors.mintDark,
-                    title: '즐겨찾기한 항목',
-                    subtitle: '역·시설·경로 보기',
-                    trailing: '가능',
-                  ),
-                ],
-              ),
-            ),
-            const _AppSectionTitle(title: '인터넷 연결 필요'),
-            const _AppCard(
-              child: Column(
-                children: [
-                  _AppInfoRow(
-                    icon: Icons.report_outlined,
-                    iconColor: EasySubwayAccessibleColors.amber,
-                    title: '시설 제보',
-                    subtitle: '사진과 제보 보내기',
-                    trailing: '연결 필요',
-                  ),
-                  _AppInfoRow(
-                    icon: Icons.refresh,
-                    iconColor: EasySubwayAccessibleColors.amber,
-                    title: '시설 상태 새로 확인',
-                    subtitle: '최신 고장·복구 확인',
-                    trailing: '연결 필요',
-                  ),
-                ],
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-({String subtitle, String trailing}) _storedDataStatus({
-  DateTime? expiresAt,
-  DateTime Function()? now,
-}) {
-  final expiry = expiresAt;
-  final current = (now ?? DateTime.now)().toUtc();
-  if (expiry != null && !current.isBefore(expiry.toUtc())) {
-    return (subtitle: '저장된 데이터 기준 · 갱신 필요', trailing: '갱신 필요');
-  }
-  return (subtitle: '앱 설치 때 함께 받은 안내', trailing: '저장됨');
 }
 
 class SupportAccessScreen extends StatelessWidget {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -3750,38 +3750,6 @@ void main() {
     }
   });
 
-  testWidgets('오프라인 데이터 안내는 저장 범위와 품질 제한을 보여준다', (tester) async {
-    // 더보기 진입점은 제거됐지만(#1570) 화면 자체는 유지되므로 직접 띄워 검증한다.
-    await tester.pumpWidget(const MaterialApp(home: OfflineDataScreen()));
-    await tester.pumpAndSettle();
-
-    expect(find.text('저장된 안내 상태'), findsOneWidget);
-    expect(find.text('검증 구간'), findsNothing);
-    expect(find.text('지금은 상록수역·사당역 구간을 안내해요'), findsNothing);
-    expect(find.text('마지막 갱신'), findsOneWidget);
-    expect(find.text('앱 설치 때 함께 받은 안내'), findsOneWidget);
-    expect(find.text('저장 정보 다시 확인'), findsOneWidget);
-    expect(find.text('저장 정보 기록을 확인할 수 없으면 현장 안내를 우선 확인해 주세요'), findsOneWidget);
-    expect(find.text('안내 범위'), findsNothing);
-    expect(find.text('제한 사항'), findsOneWidget);
-    expect(find.text('실시간 시설 상태와 제보 전송은 인터넷 연결이 필요해요'), findsOneWidget);
-  });
-
-  testWidgets('오프라인 데이터 안내는 만료된 저장 정보를 갱신 필요로 보여준다', (tester) async {
-    await tester.pumpWidget(
-      MaterialApp(
-        home: OfflineDataScreen(
-          expiresAt: DateTime.utc(2026, 6, 25, 12),
-          now: () => DateTime.utc(2026, 6, 25, 12, 1),
-        ),
-      ),
-    );
-
-    expect(find.text('마지막 갱신'), findsOneWidget);
-    expect(find.text('저장된 데이터 기준 · 갱신 필요'), findsOneWidget);
-    expect(find.text('갱신 필요'), findsOneWidget);
-  });
-
   testWidgets('데이터 및 지도 출처 화면은 manifest와 source inventory를 보여준다', (
     tester,
   ) async {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1506,46 +1506,19 @@ test("모바일 설정 저장 실패와 시설 제보 위치 실패 회귀 테�
   assert.match(widgetTest, /시설 신고 화면은 GPS가 꺼져 있으면 위치 설정으로 이동할 수 있다/);
 });
 
-test("모바일 오프라인 안내는 저장된 안내 상태를 쉬운 문구로 보여준다", () => {
+test("모바일 오프라인 안내 화면(OfflineDataScreen)은 완전히 제거됐다 (#1570)", () => {
   const main = read("apps/mobile/lib/main.dart");
   const widgetTest = read("apps/mobile/test/widget_test.dart");
   const finalQaEvidence = readJson("apps/mobile/release/issue-1075-final-qa-evidence.json");
-  const offlineScreenMatch = main.match(/class OfflineDataScreen[\s\S]*?class _SupportSectionTitle/);
-  // 지원 범위 주장(검증 구간·안내 범위·상록수역·사당역 구간)은 #1559에서 화면에서
-  // 제거해, 오프라인 테스트는 이제 이들이 없음(findsNothing)을 확인한다. 패턴은 실제로
-  // 노출되는 저장 상태 안내 순서만 검증한다.
-  const offlineWidgetTestPattern = new RegExp([
-    "testWidgets\\('오프라인 데이터 안내는 저장 범위와 품질 제한을 보여준다'",
-    // 더보기 진입점(offlineDataSettingsButton)은 #1570에서 제거해, 테스트는
-    // OfflineDataScreen을 직접 띄워 검증한다.
-    "OfflineDataScreen\\(\\)",
-    "저장된 안내 상태",
-    "검증 구간'\\), findsNothing",
-    "마지막 갱신",
-    "앱 설치 때 함께 받은 안내",
-    "저장 정보 다시 확인",
-    "저장 정보 기록을 확인할 수 없으면",
-    "안내 범위'\\), findsNothing",
-    "실시간 시설 상태와 제보 전송은 인터넷 연결이 필요해요",
-  ].join("[\\s\\S]*"));
-
-  assert.ok(offlineScreenMatch, "OfflineDataScreen block not found");
-  const offlineScreen = offlineScreenMatch[0];
-  // '저장된 안내' 섹션(인터넷 없이 이용 진입점)은 #1570에서 더보기에서 제거했다.
-  // OfflineDataScreen 화면 자체는 유지된다(직접 진입만 가능).
-  assert.match(main, /class OfflineDataScreen/);
-  assert.doesNotMatch(main, /offlineDataSettingsButton/);
+  // 진입점 없는 dead screen이라 화면·상태 헬퍼·스레딩(offlineDataExpiresAtLoader)까지
+  // 완전 삭제했다(#1570 후속). 오프라인 동작은 설명 없이 그냥 되는 것.
+  assert.doesNotMatch(main, /class OfflineDataScreen/);
   assert.doesNotMatch(main, /title:\s*'인터넷 없이 이용'/);
-  assert.match(main, /_offlineDataSourceOfTruth\s*=\s*'installed catalog metadata'/);
-  assert.match(offlineScreen, /저장된 안내 상태/);
-  assert.doesNotMatch(offlineScreen, /저장된 데이터 상태/);
-  // 지원 범위 주장(검증 구간·안내 범위 + ProductionScopeCopy)은 #1559에서 화면에서
-  // 제거했다. 오프라인 화면이 더는 범위 주장을 노출하지 않는지 가드한다.
-  assert.doesNotMatch(offlineScreen, /ProductionScopeCopy/);
-  assert.match(offlineScreen, /저장 정보 다시 확인[\s\S]*저장 정보 기록을 확인할 수 없으면/);
-  assert.match(offlineScreen, /마지막 갱신[\s\S]*앱 설치 때 함께 받은 안내/);
-  assert.match(offlineScreen, /인터넷 연결 필요[\s\S]*시설 제보[\s\S]*연결 필요/);
-  assert.match(widgetTest, offlineWidgetTestPattern);
+  assert.doesNotMatch(main, /저장된 안내 상태/);
+  assert.doesNotMatch(main, /_offlineDataSourceOfTruth/);
+  assert.doesNotMatch(main, /[Oo]fflineDataExpiresAtLoader/);
+  assert.doesNotMatch(main, /offlineDataSettingsButton/);
+  assert.doesNotMatch(widgetTest, /OfflineDataScreen/);
   assert.match(widgetTest, /testWidgets\('홈 200% 글자 screenshot smoke는 핵심 CTA 렌더 이미지를 만든다'/);
   assert.match(widgetTest, /RepaintBoundary[\s\S]*toImage\(/);
   assert.equal(finalQaEvidence.issue, 1075);


### PR DESCRIPTION
## 관련 이슈

close #1570
상위 트래커: #1575 5단계. #1680(더보기 '저장된 안내' 섹션·미구현 고지 제거)의 후속 — 그 PR에서 진입점만 제거하고 화면은 유지했던 dead screen을 이번에 완전 삭제한다. #1581·#1572에서 도달 경로 없음(dead) 재확인.

## 작업 배경

- `OfflineDataScreen`('인터넷 없이 이용')은 #1680에서 더보기 진입점을 제거해 **lib 어디서도 생성되지 않는 dead screen**이 됐다. 그런데 화면 클래스와 `offlineDataExpiresAtLoader` 스레딩이 위젯 트리 전반(루트→여러 위젯)에 남아 죽은 코드로 유지되고 있었다.

## 작업 내용

- **OfflineDataScreen 완전 삭제**: 화면 클래스 + `_storedDataStatus` 헬퍼 + `_offlineDataSourceOfTruth` 상수 제거.
- **오프라인 스레딩 제거**: `OfflineDataExpiresAtLoader` typedef와, 위젯 트리에 dangling으로 흐르던 `offlineDataExpiresAtLoader`(생성자 파라미터·필드·전달 13곳), 루트 배선(`main()`의 loader wiring), 이제 미사용이 된 `dataPackUpdateStateRepository` 로컬과 `data_pack_update_state.dart` import 제거.
- **`_AppInfoRow.trailing` 제거**: OfflineDataScreen 전용이던 trailing(‘가능/연결 필요/갱신 필요’ 배지) 파라미터를 제거하고, trailing이 없어 동일해진 `textScale >= 2` 분기를 단순 Row로 정리.
- **테스트·계약 갱신**: `OfflineDataScreen`을 직접 생성하던 위젯 테스트 2건 제거, 저장소 계약 테스트를 화면 **존재 단정 → 완전 제거 단정**(class/스레딩/문구 부재)으로 재작성.

### 이번 범위 밖(후속)
- 없음. #1570(더보기 다이어트)의 마지막 후속 트랙 완료.

## 검증

- 실행한 명령과 결과:
  - `dart format` (main, widget_test) → 정상
  - `flutter analyze lib test` → **No issues found!**
  - `flutter test` → **All tests passed!** (675건)
  - `node --test tools/ci/repository-contract.test.mjs` → **pass 158 / fail 0**

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| dead screen·스레딩 제거 회귀 | Mobile (Flutter) | `flutter analyze` + `flutter test` | 자동 테스트 675건 | 통과 |
| 오프라인 화면 완전 제거 계약 | tools/ci | `node --test repository-contract` | 계약 158건(제거 단정) | 통과 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 먼저 볼 지점: (1) `offlineDataExpiresAtLoader` 스레딩이 실제로 소비되지 않은 dangling이었는지(어떤 화면에도 연결 안 됨), (2) `_AppInfoRow.trailing` 제거 후 남은 호출부가 trailing을 넘기지 않는지, (3) 계약 테스트의 '완전 제거' 단정이 comment 오탐 없이 title/class/스레딩 부재를 정확히 가드하는지.

## 리스크

- OfflineDataScreen은 이미 도달 불가였으므로 사용자 노출 변화 없음(순수 dead code 제거).

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)