### PR TITLE
[Fix] TAGO empty schedule responses (#1415)

### DIFF
--- a/tools/datapack/plan-tago-schedule-collection.test.mjs
+++ b/tools/datapack/plan-tago-schedule-collection.test.mjs
@@ -194,6 +194,26 @@ test("TAGO 시간표 수집 summary는 빈 provider 응답을 완료 요청으�
   assert.match(summary.rawSha256ByRequest["MTRKR4448|02|U"], /^[0-9a-f]{64}$/);
 });
 
+test("TAGO 시간표 수집 summary는 malformed 빈 응답을 checkpoint 완료로 보지 않는다", () => {
+  for (const rawText of [
+    JSON.stringify({}),
+    JSON.stringify({ response: { header: { resultCode: "00" }, body: {} } }),
+  ]) {
+    assert.throws(
+      () =>
+        buildTagoScheduleCollectionSummary({
+          responses: [
+            {
+              requestKey: "MTRKR4448|02|U",
+              rawText,
+            },
+          ],
+        }),
+      /TAGO schedule empty response shape is invalid/,
+    );
+  }
+});
+
 test("TAGO 시간표 수집 summary evidence hash는 checkpoint 상태를 포함한다", () => {
   const response = {
     requestKey: "MTRKR4448|02|U",

--- a/tools/datapack/plan-tago-schedule-collection.test.mjs
+++ b/tools/datapack/plan-tago-schedule-collection.test.mjs
@@ -168,6 +168,32 @@ test("TAGO 시간표 검증은 같은 시간 row도 deterministic하게 정렬�
   assert.deepEqual(first.providerRecordHashes, second.providerRecordHashes);
 });
 
+test("TAGO 시간표 단독 검증은 빈 provider 응답을 거부한다", () => {
+  assert.throws(
+    () => validateTagoScheduleSample(emptyTagoResponse()),
+    /TAGO schedule sample has no rows/,
+  );
+});
+
+test("TAGO 시간표 수집 summary는 빈 provider 응답을 완료 요청으로 기록한다", () => {
+  const summary = buildTagoScheduleCollectionSummary({
+    responses: [
+      {
+        requestKey: "MTRKR4448|02|U",
+        rawText: emptyTagoResponse(),
+      },
+    ],
+  });
+
+  assert.deepEqual(summary.completedRequestKeys, ["MTRKR4448|02|U"]);
+  assert.deepEqual(summary.responseRequestKeys, ["MTRKR4448|02|U"]);
+  assert.deepEqual(summary.emptyResponseRequestKeys, ["MTRKR4448|02|U"]);
+  assert.equal(summary.responseCount, 1);
+  assert.equal(summary.rowCount, 0);
+  assert.deepEqual(summary.providerRecordHashes, []);
+  assert.match(summary.rawSha256ByRequest["MTRKR4448|02|U"], /^[0-9a-f]{64}$/);
+});
+
 test("TAGO 시간표 수집 summary evidence hash는 checkpoint 상태를 포함한다", () => {
   const response = {
     requestKey: "MTRKR4448|02|U",
@@ -355,6 +381,47 @@ test("TAGO 시간표 수집기는 checkpoint 다음 batch만 호출하고 secret
   );
   assert.equal(summary.responseCount, collection.responses.length);
   assert.deepEqual(summary.checkpoint.completedRequestKeys, collection.checkpoint.completedRequestKeys);
+});
+
+test("TAGO 시간표 수집기는 빈 provider 응답을 checkpoint에 포함하고 계속 진행한다", async () => {
+  const collection = await collectTagoSchedules(
+    {
+      stationLineRows: [{ stationCode: "448", lineId: "seoul-4" }],
+    },
+    {
+      dailyLimit: 3,
+      serviceKey: "actual-secret-key",
+      fetchImpl: async (url) => {
+        const params = new URL(url).searchParams;
+        return {
+          ok: true,
+          status: 200,
+          async text() {
+            if (params.get("dailyTypeCode") === "02" && params.get("upDownTypeCode") === "U") {
+              return emptyTagoResponse();
+            }
+            return tagoResponse(
+              params.get("subwayStationId"),
+              params.get("dailyTypeCode"),
+              params.get("upDownTypeCode"),
+            );
+          },
+        };
+      },
+    },
+  );
+
+  assert.equal(collection.collectionStatus, "completed_batch");
+  assert.deepEqual(collection.completedRequestKeys, ["MTRKR4448|01|D", "MTRKR4448|01|U", "MTRKR4448|02|U"]);
+  assert.deepEqual(
+    collection.responses.map((response) => response.requestKey),
+    ["MTRKR4448|01|U", "MTRKR4448|01|D", "MTRKR4448|02|U"],
+  );
+
+  const summary = buildTagoScheduleCollectionSummary(collection);
+  assert.deepEqual(summary.emptyResponseRequestKeys, ["MTRKR4448|02|U"]);
+  assert.equal(summary.responseCount, 3);
+  assert.equal(summary.rowCount, 4);
 });
 
 test("TAGO 시간표 수집기는 encoded service key를 이중 인코딩하지 않는다", async () => {
@@ -550,6 +617,17 @@ function tagoResponse(
             tagoRow(stationId, dailyTypeCode, upDownTypeCode, arrTime, depTime, endSubwayStationId),
           ),
         },
+      },
+    },
+  });
+}
+
+function emptyTagoResponse() {
+  return JSON.stringify({
+    response: {
+      header: { resultCode: "00" },
+      body: {
+        items: {},
       },
     },
   });

--- a/tools/datapack/plan-tago-schedule-collection.test.mjs
+++ b/tools/datapack/plan-tago-schedule-collection.test.mjs
@@ -197,6 +197,7 @@ test("TAGO 시간표 수집 summary는 빈 provider 응답을 완료 요청으�
 test("TAGO 시간표 수집 summary는 malformed 빈 응답을 checkpoint 완료로 보지 않는다", () => {
   for (const rawText of [
     JSON.stringify({}),
+    JSON.stringify({ response: { body: { items: {} } } }),
     JSON.stringify({ response: { header: { resultCode: "00" }, body: {} } }),
   ]) {
     assert.throws(

--- a/tools/datapack/validate-tago-schedule-sample.mjs
+++ b/tools/datapack/validate-tago-schedule-sample.mjs
@@ -47,7 +47,7 @@ function parseArgs(argv) {
   return args;
 }
 
-function validateTagoScheduleSample(rawText) {
+function validateTagoScheduleSample(rawText, options = {}) {
   const payload = JSON.parse(rawText);
   rejectCredentialLeak(rawText, payload);
   if (payload.response?.header && payload.response.header.resultCode !== "00") {
@@ -56,7 +56,10 @@ function validateTagoScheduleSample(rawText) {
 
   const rows = normalizeRows(payload.response?.body?.items?.item);
   if (rows.length === 0) {
-    throw new Error("TAGO schedule sample has no rows");
+    if (!options.allowEmptyRows) {
+      throw new Error("TAGO schedule sample has no rows");
+    }
+    return buildTagoScheduleValidationResult(rawText, rows, [], [], true);
   }
   const observedFields = new Set(rows.flatMap((row) => Object.keys(row)));
   for (const field of OBSERVED_FIELDS) {
@@ -104,6 +107,10 @@ function validateTagoScheduleSample(rawText) {
   const providerRecordHashes = parsedRows.map(({ rowHash }) => rowHash);
   const departures = parsedRows.map(({ row: _row, rowHash: _rowHash, ...departure }) => departure);
 
+  return buildTagoScheduleValidationResult(rawText, rows, providerRecordHashes, departures, false);
+}
+
+function buildTagoScheduleValidationResult(rawText, rows, providerRecordHashes, departures, emptyProviderResponse) {
   return {
     artifactKind: "tago-schedule-sample-importer-validation",
     candidateId: "molit-tago-subway-info",
@@ -112,6 +119,7 @@ function validateTagoScheduleSample(rawText) {
     providerRecordHashes,
     rawSha256: sha256(rawText),
     departures,
+    emptyProviderResponse,
     stationLevelOnly: true,
     productionUseAllowed: false,
     remainingAdmissionBlocker: "line_wide_trip_stop_sequence_validation_required",
@@ -168,6 +176,7 @@ function buildTagoScheduleCollectionSummary(collection) {
     requestKeyParts(requestKey);
   }
   const responseRequestKeys = [];
+  const emptyResponseRequestKeys = [];
   const rawSha256ByRequest = {};
   const providerRecordHashes = [];
   let rowCount = 0;
@@ -182,9 +191,12 @@ function buildTagoScheduleCollectionSummary(collection) {
     if (typeof response.rawText !== "string" || response.rawText.length === 0) {
       throw new Error(`responses.rawText is required: ${response.requestKey}`);
     }
-    const validation = validateTagoScheduleSample(response.rawText);
+    const validation = validateTagoScheduleSample(response.rawText, { allowEmptyRows: true });
     assertResponseMatchesRequestKey(validation, response.requestKey);
     responseRequestKeys.push(response.requestKey);
+    if (validation.emptyProviderResponse) {
+      emptyResponseRequestKeys.push(response.requestKey);
+    }
     rawSha256ByRequest[response.requestKey] = validation.rawSha256;
     providerRecordHashes.push(...validation.providerRecordHashes);
     rowCount += validation.rowCount;
@@ -198,6 +210,7 @@ function buildTagoScheduleCollectionSummary(collection) {
     endpoint: TAGO_SCHEDULE_ENDPOINT,
     completedRequestKeys,
     responseRequestKeys,
+    emptyResponseRequestKeys,
     rawSha256ByRequest,
     providerRecordHashes,
   };
@@ -207,6 +220,7 @@ function buildTagoScheduleCollectionSummary(collection) {
     endpoint: evidencePayload.endpoint,
     completedRequestKeys,
     responseRequestKeys,
+    emptyResponseRequestKeys,
     checkpoint: { completedRequestKeys },
     responseCount: responseRequestKeys.length,
     rowCount,
@@ -264,7 +278,7 @@ async function collectTagoSchedules(input, options = {}) {
       );
     }
     try {
-      const validation = validateTagoScheduleSample(rawText);
+      const validation = validateTagoScheduleSample(rawText, { allowEmptyRows: true });
       assertResponseMatchesRequestKey(validation, request.requestKey);
     } catch (error) {
       throw new TagoScheduleCollectionError(

--- a/tools/datapack/validate-tago-schedule-sample.mjs
+++ b/tools/datapack/validate-tago-schedule-sample.mjs
@@ -421,6 +421,9 @@ function normalizeRows(value) {
 }
 
 function isNormalEmptyTagoSchedulePayload(payload) {
+  if (payload.response?.header?.resultCode !== "00") {
+    return false;
+  }
   const items = payload.response?.body?.items;
   if (!items || typeof items !== "object" || Array.isArray(items)) {
     return false;

--- a/tools/datapack/validate-tago-schedule-sample.mjs
+++ b/tools/datapack/validate-tago-schedule-sample.mjs
@@ -59,6 +59,9 @@ function validateTagoScheduleSample(rawText, options = {}) {
     if (!options.allowEmptyRows) {
       throw new Error("TAGO schedule sample has no rows");
     }
+    if (!isNormalEmptyTagoSchedulePayload(payload)) {
+      throw new Error("TAGO schedule empty response shape is invalid");
+    }
     return buildTagoScheduleValidationResult(rawText, rows, [], [], true);
   }
   const observedFields = new Set(rows.flatMap((row) => Object.keys(row)));
@@ -415,6 +418,14 @@ function normalizeRows(value) {
     return [value];
   }
   return [];
+}
+
+function isNormalEmptyTagoSchedulePayload(payload) {
+  const items = payload.response?.body?.items;
+  if (!items || typeof items !== "object" || Array.isArray(items)) {
+    return false;
+  }
+  return !("item" in items) || (Array.isArray(items.item) && items.item.length === 0);
 }
 
 function parseHhmmss(value, label) {


### PR DESCRIPTION
## 관련 이슈

Refs #1415

## 작업 배경

- TAGO Schedule Collection run 28728540568에서 `MTRKR4448|02|U` 정상 응답이 빈 rows로 반환되어 파일럿 수집이 중단됐다.

## 작업 내용

- 단독 TAGO sample 검증은 빈 rows를 계속 거부한다.
- TAGO collection/summary 경로에서는 정상 빈 provider 응답을 completed empty response로 기록한다.
- `emptyResponseRequestKeys`를 summary와 evidence hash에 포함한다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/datapack/plan-tago-schedule-collection.test.mjs` pass 22
  - `node --check tools/datapack/validate-tago-schedule-sample.mjs` pass
  - `node --test tools/ci/repository-contract.test.mjs` pass 158
  - `git diff --check origin/main` pass

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| TAGO 빈 rows 수집 처리 | datapack tool | Node test + repository contract | 로컬 명령 결과 | pass |
| TAGO provider 실패 재현 | GitHub Actions | TAGO Schedule Collection run 확인 | https://github.com/AquilaXk/easysubway/actions/runs/28728540568 | `MTRKR4448|02|U` no rows 확인 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `validateTagoScheduleSample(rawText, { allowEmptyRows: true })`가 collection/summary 경로에만 사용되는지 확인.

## 리스크

- 빈 provider 응답은 row provenance가 없으므로 `emptyResponseRequestKeys`와 raw hash만 evidence로 남긴다. production ETA 승격은 계속 차단된다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 빈 응답이 오는 데이터 수집 과정에서 검증이 불필요하게 실패하던 문제를 개선했습니다.
  * 응답 행이 없는 경우에도 수집은 계속 진행되며, 해당 항목은 빈 응답으로 기록됩니다.
  * 수집 요약과 결과 정보에 빈 응답 항목 수가 더 정확하게 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->