### PR TITLE
[Style] 이동 조건 설명 문구 단일 소스 통일 (#1568)

### DIFF
--- a/apps/mobile/lib/onboarding.dart
+++ b/apps/mobile/lib/onboarding.dart
@@ -880,7 +880,7 @@ class _OnboardingProfileCard extends StatelessWidget {
                           mainAxisAlignment: MainAxisAlignment.center,
                           children: [
                             Text(
-                              _profileDisplayTitle(profile),
+                              profile.title,
                               style: Theme.of(context).textTheme.titleMedium
                                   ?.copyWith(
                                     color: EasySubwayAccessibleColors.text,
@@ -890,7 +890,11 @@ class _OnboardingProfileCard extends StatelessWidget {
                             ),
                             const SizedBox(height: 4),
                             Text(
-                              _profileDisplaySummary(profile),
+                              // 이동 조건 설명은 앱 전체가 mobilityProfileOptions의
+                              // summary 한 벌만 쓴다(#1568). 온보딩 전용 축약 문구
+                              // (_profileDisplaySummary)를 없애 화면마다 다른 표현을
+                              // 제거하고 카드 시맨틱 라벨과도 일치시킨다.
+                              profile.summary,
                               style: Theme.of(context).textTheme.bodyLarge
                                   ?.copyWith(
                                     color: EasySubwayAccessibleColors.mutedText,
@@ -911,22 +915,6 @@ class _OnboardingProfileCard extends StatelessWidget {
         ),
       ),
     );
-  }
-
-  String _profileDisplayTitle(MobilityProfileOption profile) {
-    return profile.title;
-  }
-
-  String _profileDisplaySummary(MobilityProfileOption profile) {
-    return switch (profile.id) {
-      'elderly' => '걷기와 환승 줄이기',
-      'wheelchair' => '계단 없는 길',
-      'stroller' => '엘리베이터 우선',
-      'pregnant' => '걷는 거리 줄이기',
-      'injured' => '계단 피하기',
-      'luggage' => '넓은 길 우선',
-      _ => profile.summary,
-    };
   }
 }
 

--- a/apps/mobile/test/onboarding_test.dart
+++ b/apps/mobile/test/onboarding_test.dart
@@ -96,6 +96,10 @@ void main() {
       expect(find.text('어떤 도움이 필요한가요?'), findsOneWidget);
       expect(find.text('천천히 이동'), findsOneWidget);
       expect(find.text('휠체어 이용'), findsOneWidget);
+      // 이동 조건 설명은 mobilityProfileOptions.summary 한 벌로 통일됐다(#1568):
+      // 온보딩 전용 축약 문구를 없애고 카드 본문이 정본 summary를 그대로 보여준다.
+      expect(find.text('계단을 피하고 쉬운 환승을 우선해요'), findsOneWidget);
+      expect(find.text('걷기와 환승 줄이기'), findsNothing);
 
       final disabledDoneButton = tester.widget<FilledButton>(
         find.byKey(const Key('onboardingDoneButton')),


### PR DESCRIPTION
## 관련 이슈

Closes #1568

## 작업 배경

- #1568(길찾기 폼 틴트 카드 디박싱과 이동 조건 카피 통일)의 item 1~3(이동 조건 틴트 카드→플랫 행, '켜면 경로가 줄거나 없을 수 있어요' 협박형 캡션 삭제, '…조건을 선택했습니다' 헤더 삭제)은 앞선 #1674에서 이미 main에 반영됐다.
- 남은 item 4(이동 조건 프로필별 설명 문구를 온보딩·이동 조건·길찾기 폼에서 단일 소스로 통일)를 처리해 이슈를 완결한다.

## 작업 내용

- **현상**: 이동 조건 화면(`MobilityProfileScreen`)과 길찾기 폼 옵션 시트(`_RouteMobilityTypeOptionButton`)는 정본 `mobilityProfileOptions[].summary`('계단을 피하고 쉬운 환승을 우선해요' 등)를 쓰는데, **온보딩 프로필 카드만** 화면 전용 축약 문구(`_profileDisplaySummary`: '걷기와 환승 줄이기', '계단 없는 길' 등)를 별도로 갖고 있었다. 심지어 온보딩 카드의 **시맨틱 라벨은 정본**(`profile.summary`)을 써서 가시 텍스트와도 어긋났다.
- **변경**: 온보딩 카드 본문을 `profile.summary`로 바꾸고, 단순 passthrough였던 `_profileDisplayTitle`과 축약 override `_profileDisplaySummary` 헬퍼를 제거했다. 이제 이동 조건 설명 문구는 앱 전체가 `mobilityProfileOptions[].summary` **한 벌**만 쓴다(온보딩·이동 조건 화면·길찾기 폼 + 온보딩 시맨틱 라벨 일치).
- **정본 선택 근거**: `.summary`는 이동 조건 선택의 authoritative 화면과 길찾기 옵션 시트, 온보딩 시맨틱 라벨까지 3곳 이상이 이미 사용. 축약 문구는 온보딩 가시 텍스트 1곳에만 존재하고 테스트 단정도 없어, `.summary`로 통일하는 것이 최소 blast radius이자 완료 기준("같은 이동 조건 설명 문구가 앱 전체에서 한 벌")에 부합.
- **테스트**: `onboarding_test`에 카드가 정본 summary('계단을 피하고 쉬운 환승을 우선해요')를 노출하고 축약 문구('걷기와 환승 줄이기')는 사라졌다는 단정 추가.

## 검증

- 실행한 명령과 결과:
  - `dart format lib/onboarding.dart test/onboarding_test.dart` — 변경 없음(포맷 정상)
  - `flutter analyze lib test` — **No issues found**
  - `flutter test` — **All tests passed (672)**
  - `node --test tools/ci/repository-contract.test.mjs` — **pass 158 / fail 0**

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 정적 분석 | Mobile | `flutter analyze lib test` | No issues found | 통과 |
| 전체 위젯/유닛 테스트 | Mobile | `flutter test` | All tests passed (672) | 통과 |
| 온보딩 정본 카피 노출 | Mobile | `onboarding_test`(카드 본문 '계단을 피하고 쉬운 환승을 우선해요' 노출·축약 '걷기와 환승 줄이기' 부재) | 추가 단정 통과 | 통과 |
| repository 계약 | tools/ci | `node --test repository-contract.test.mjs` | pass 158 / fail 0 | 통과 |
| 온보딩/이동조건/길찾기 폼 스크린샷 | Mobile | 수동 QA(실기기) | 미첨부 — 카피 통일만이라 텍스트만 바뀜, 위젯 테스트로 기계 커버. 실기기 스크린샷 QA는 #1573 소관 | 후속 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 정본을 `.summary`(fuller sentence)로 잡은 판단 — 축약 문구를 정본으로 삼지 않은 이유(이동 조건 화면·길찾기 옵션 시트·온보딩 시맨틱이 이미 `.summary`를 쓰고, 축약본은 테스트 단정도 없이 온보딩 가시 텍스트 1곳에만 존재). 온보딩 카드가 다소 길어진 문구를 minHeight 78 카드에서 수용하는지(이동 조건 화면 카드와 동일 문구·레이아웃).

## 리스크

- 카피 통일(텍스트 변경)만으로 로직 변화 없음. 리스크는 온보딩 카드에서 문구가 길어져 줄바꿈되는 정도이며 이동 조건 화면이 이미 동일 문구를 같은 카드 패턴으로 표시. 회귀는 위젯 테스트(672)·계약(158)로 커버. 실기기 시각 QA는 #1573.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
