### PR TITLE
[Style] 앱 시작 로딩 흰 화면+스피너 → 브랜디드 로딩 (#1785)

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -538,6 +538,54 @@ class SupportAccessInfo {
   }
 }
 
+/// 앱 시작 시 온보딩 상태를 복원하는 짧은 구간에 보여주는 브랜디드 로딩 화면.
+///
+/// 예전에는 흰 배경 + 스피너만 떠서 네이티브 스플래시(브랜드)에서 홈으로 가는
+/// 사이에 흰 화면이 튀어 첫인상을 해쳤다(#1785). 브랜드 색과 앱 이름을 그대로
+/// 이어 스플래시에서 로딩, 콘텐츠까지 매끄럽게 연결되도록 한다.
+class _StartupLoadingScreen extends StatelessWidget {
+  const _StartupLoadingScreen();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      key: const Key('startupLoadingScreen'),
+      backgroundColor: EasySubwayAccessibleColors.primary,
+      body: SafeArea(
+        child: Center(
+          child: Semantics(
+            label: '쉬운 지하철을 불러오는 중',
+            liveRegion: true,
+            child: ExcludeSemantics(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    '쉬운 지하철',
+                    style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                      color: Colors.white,
+                      fontWeight: FontWeight.w800,
+                    ),
+                  ),
+                  const SizedBox(height: 20),
+                  const SizedBox(
+                    width: 26,
+                    height: 26,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2.5,
+                      valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 class _EasySubwayHome extends StatefulWidget {
   const _EasySubwayHome({
     required this.repository,
@@ -624,9 +672,9 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
   @override
   Widget build(BuildContext context) {
     if (_loadingOnboardingState) {
-      return const Scaffold(
-        body: SafeArea(child: Center(child: CircularProgressIndicator())),
-      );
+      // 스플래시와 홈 사이에 흰 화면+스피너가 튀지 않도록, 브랜드 색과 앱 이름을
+      // 그대로 잇는 브랜디드 로딩을 보여준다(#1785).
+      return const _StartupLoadingScreen();
     }
 
     final dataDeletionResult = _dataDeletionResult;

--- a/apps/mobile/test/onboarding_app_flow_test.dart
+++ b/apps/mobile/test/onboarding_app_flow_test.dart
@@ -1,3 +1,4 @@
+import 'package:easysubway_mobile/accessible_design.dart';
 import 'package:easysubway_mobile/facility_report.dart';
 import 'package:easysubway_mobile/legacy_credential_cleanup.dart';
 import 'package:easysubway_mobile/main.dart';
@@ -20,6 +21,31 @@ import 'fake_secure_key_value_storage.dart';
 // 첫 실행 앱은 알림 권한 제공자가 직접 주입되면 온보딩 알림 권한을 요청한다
 
 void main() {
+  testWidgets('앱 시작 로딩은 흰 화면 대신 브랜디드 로딩을 보여준다', (tester) async {
+    await tester.pumpWidget(
+      _testApp(onboardingStore: MemoryOnboardingResultStore()),
+    );
+
+    // 온보딩 상태를 복원하는 첫 프레임에는 흰 배경+스피너가 아니라 브랜드 색과
+    // 앱 이름을 그대로 잇는 로딩을 보여준다(#1785).
+    expect(find.byKey(const Key('startupLoadingScreen')), findsOneWidget);
+    expect(find.text('쉬운 지하철'), findsOneWidget);
+    final loadingScaffold = tester.widget<Scaffold>(
+      find.byKey(const Key('startupLoadingScreen')),
+    );
+    expect(loadingScaffold.backgroundColor, EasySubwayAccessibleColors.primary);
+    expect(find.bySemanticsLabel('쉬운 지하철을 불러오는 중'), findsOneWidget);
+
+    await tester.pumpAndSettle();
+
+    // 복원이 끝나면 로딩은 사라지고 온보딩 인트로가 뜬다.
+    expect(find.byKey(const Key('startupLoadingScreen')), findsNothing);
+    expect(
+      find.text('빠른 길보다,\n갈 수 있는 길을\n먼저 안내해요.', findRichText: true),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('첫 실행 앱은 온보딩을 완료한 뒤 홈으로 이동한다', (tester) async {
     final onboardingStore = MemoryOnboardingResultStore();
     final legacyCredentialStorage = FakeSecureKeyValueStorage()


### PR DESCRIPTION
## 관련 이슈

Closes #1785

## 작업 배경

- 실기기 release QA(사용자 지적) 중 발견: 앱 시작 시 온보딩 상태를 복원하는 짧은 구간에 `_EasySubwayHome`가 **흰 배경 + 스피너만** 보여줘, 네이티브 스플래시(브랜드 앱 아이콘) → 흰 화면+스피너 → 홈으로 **흰 플래시가 튀어** 첫인상을 해쳤다.
- 참고(같은 QA): "release 시작 hang"은 실제 버그가 아니라 **release-config(개인정보처리방침 URL·지원/삭제/보안 이메일) dart-define 누락 시 검증 throw**였음. 설정 주입한 release는 ~1.2초에 정상 실행. 본 PR과 별개.

## 작업 내용

- `_EasySubwayHomeState.build`의 시작 로딩 분기(`Scaffold(body: Center(CircularProgressIndicator()))`)를 **`_StartupLoadingScreen`**으로 교체: 브랜드 teal(`EasySubwayAccessibleColors.primary`) 배경 + 앱 이름 '쉬운 지하철' + 은은한 흰 인디케이터. 스플래시→로딩→콘텐츠가 브랜디드하게 매끄럽게 이어진다.
- 시맨틱 `쉬운 지하철을 불러오는 중`(liveRegion) 유지.
- `onboarding_app_flow_test`에 브랜디드 로딩 노출(key·앱 이름·브랜드 배경색·시맨틱)과 복원 완료 후 해제(온보딩 인트로 전환) 잠금 테스트 추가.

## 검증

- `dart format` — 정상
- `flutter analyze lib test` — **No issues found**
- `flutter test` — **All tests passed (737)**
- `node --test tools/ci/repository-contract.test.mjs` — **pass 158 / fail 0**

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 정적 분석 | Mobile | `flutter analyze lib test` | No issues found | 통과 |
| 전체 테스트 | Mobile | `flutter test` | All tests passed (737) | 통과 |
| 브랜디드 로딩 노출/해제 | Mobile | `onboarding_app_flow_test`('앱 시작 로딩은 흰 화면 대신 브랜디드 로딩을 보여준다') | 신규 테스트 통과 | 통과 |
| 실기기 스플래시→로딩→콘텐츠 흐름 | Mobile | 수동 QA | 미첨부 — release 빌드 필요, #1573 QA에서 시각 확인 | 후속(#1573) |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `_StartupLoadingScreen`이 온보딩 인트로(teal)와 같은 브랜드 aesthetic인지, 시작 로딩→콘텐츠 전환에 잔상/깜빡임이 없는지(로딩 분기는 `onboardingStore != null && !isCompleted`일 때만, 복원 완료 시 해제). 실기기 시각 확인은 #1573 QA에서.

## 리스크

- 시작 로딩 화면 위젯 교체(로직 무관). 회귀는 전체 테스트(737)·계약(158)로 커버. 로딩 분기 조건 자체는 불변.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
