### PR TITLE
[Feat] 제보 확인 대기열 상용화 — SLA·역/유형/사진 필터·썸네일·키보드·리치 드로어 (#1740)

### DIFF
--- a/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageController.java
@@ -64,6 +64,8 @@ class FacilityReportAdminPageController {
 	private static final int REPORT_SURGE_ALERT_THRESHOLD = 10;
 	private static final long REPORT_SURGE_LOOKBACK_HOURS = 24;
 	private static final String REPORTS_PROGRAM_ID = "a-reports";
+	// 사진 endpoint의 @PreAuthorize('admin.report.photo.read')와 같은 권한. 목록 썸네일 노출 게이팅에 쓴다.
+	private static final String REPORT_PHOTO_READ_AUTHORITY = "admin.report.photo.read";
 
 	private final FacilityReportUseCase facilityReportUseCase;
 	private final LoadFacilityReportPhotoPort loadFacilityReportPhotoPort;
@@ -267,6 +269,9 @@ class FacilityReportAdminPageController {
 
 		model.addAttribute("reports", reports);
 		model.addAttribute("page", pageView);
+		// 사진 열람 권한(REPORT_PHOTO_READ·V15)이 있는 계정에만 썸네일을 노출한다. 권한이 없으면
+		// 썸네일 endpoint 자체가 403이므로 깨진 이미지를 막고 '있음' 텍스트만 보여준다.
+		model.addAttribute("canReadPhoto", hasReportPhotoReadAuthority(authentication));
 		model.addAttribute("paginationLinks", pageView.links("/admin/reports/page", queryParams(query)));
 		model.addAttribute("selectedStatus", query.status());
 		model.addAttribute("statusOptions", statusOptions());
@@ -713,6 +718,11 @@ class FacilityReportAdminPageController {
 
 	private static boolean hasText(String value) {
 		return value != null && !value.isBlank();
+	}
+
+	private static boolean hasReportPhotoReadAuthority(Authentication authentication) {
+		return authentication != null && authentication.getAuthorities().stream()
+			.anyMatch(authority -> REPORT_PHOTO_READ_AUTHORITY.equals(authority.getAuthority()));
 	}
 
 	record FacilityReportListPageRow(

--- a/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageController.java
@@ -503,7 +503,7 @@ class FacilityReportAdminPageController {
 		Authentication authentication,
 		HttpServletRequest request
 	) {
-		populateReportDetailModel(reportId, model, null);
+		populateReportDetailModel(reportId, model, null, authentication);
 		auditReportDetailRead(authentication, request, reportId);
 		return "admin/reports/detail";
 	}
@@ -519,13 +519,35 @@ class FacilityReportAdminPageController {
 		Authentication authentication,
 		HttpServletRequest request
 	) {
-		populateReportDetailModel(reportId, model, null);
+		populateReportDetailModel(reportId, model, null, authentication);
 		auditReportDetailRead(authentication, request, reportId);
 		return "admin/reports/detail :: detailBody";
 	}
 
-	private void populateReportDetailModel(String reportId, Model model, ReviewReportForm submittedForm) {
-		model.addAttribute("report", FacilityReportDetailPageView.from(facilityReportUseCase.getReport(reportId), messages));
+	private void populateReportDetailModel(
+		String reportId,
+		Model model,
+		ReviewReportForm submittedForm,
+		Authentication authentication
+	) {
+		FacilityReport report = facilityReportUseCase.getReport(reportId);
+		model.addAttribute("report", FacilityReportDetailPageView.from(report, messages));
+		// 원시 ID 단독 노출 금지(#1740): 역·시설을 "이름(코드)"로 해석한다. 같은 시설 신고 행에도 재사용한다.
+		Map<String, String> stationLabels = labelResolver.stationLabels(List.of(report.stationId()));
+		Map<String, String> facilityLabels = labelResolver.facilityLabels(List.of(report.facilityId()));
+		model.addAttribute("stationLabel", stationLabels.getOrDefault(report.stationId(), report.stationId()));
+		model.addAttribute("facilityLabel", facilityLabels.getOrDefault(report.facilityId(), report.facilityId()));
+		model.addAttribute("canReadPhoto", hasReportPhotoReadAuthority(authentication));
+		// 같은 시설 신고 목록(#1740): 현재 신고는 제외하고 최신순으로 보여준다. 판정 전 반복 신고 맥락을 준다.
+		// #1163 중복 병합 기능과 독립적인 읽기 전용 목록이라 회귀 위험이 없다.
+		LocalDateTime now = LocalDateTime.now(clock);
+		List<FacilityReportListPageRow> sameFacilityReports = facilityReportUseCase
+			.listReportsForFacility(report.stationId(), report.facilityId())
+			.stream()
+			.filter(summary -> !summary.id().equals(reportId))
+			.map(summary -> FacilityReportListPageRow.from(summary, messages, stationLabels, facilityLabels, now))
+			.toList();
+		model.addAttribute("sameFacilityReports", sameFacilityReports);
 		model.addAttribute(
 			"reviewAudits",
 			facilityReportUseCase.listReviewAudits(reportId)
@@ -602,7 +624,7 @@ class FacilityReportAdminPageController {
 	) {
 		if (bindingResult.hasErrors()) {
 			response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-			populateReportDetailModel(reportId, model, form);
+			populateReportDetailModel(reportId, model, form, authentication);
 			auditReportDetailRead(authentication, request, reportId);
 			AdminFormErrorView.expose(model, bindingResult);
 			return "admin/reports/detail";

--- a/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageController.java
@@ -16,6 +16,7 @@ import com.easysubway.report.application.port.in.ReviewFacilityReportCommand;
 import com.easysubway.report.domain.FacilityReport;
 import com.easysubway.report.domain.FacilityReportReviewAudit;
 import com.easysubway.report.domain.FacilityReportReviewDecision;
+import com.easysubway.report.domain.ReportSlaBadge;
 import com.easysubway.report.domain.FacilityReportSummary;
 import com.easysubway.report.domain.FacilityReportStatus;
 import com.easysubway.report.domain.ReportProcessingTimeSummary;
@@ -242,7 +243,8 @@ class FacilityReportAdminPageController {
 		Map<String, String> facilityLabels = labelResolver.facilityLabels(
 			items.stream().map(FacilityReportSummary::facilityId).toList());
 		List<FacilityReportListPageRow> reports = items.stream()
-			.map(report -> FacilityReportListPageRow.from(report, messages, stationLabels, facilityLabels))
+			.map(report -> FacilityReportListPageRow.from(
+				report, messages, stationLabels, facilityLabels, LocalDateTime.now(clock)))
 			.toList();
 
 		model.addAttribute("reports", reports);
@@ -656,15 +658,19 @@ class FacilityReportAdminPageController {
 		String statusLabel,
 		LocalDateTime createdAt,
 		boolean hasPhoto,
-		String coordinateLabel
+		String coordinateLabel,
+		String slaLabel,
+		String slaTone
 	) {
 
 		static FacilityReportListPageRow from(
 			FacilityReportSummary report,
 			WebMessageResolver messages,
 			Map<String, String> stationLabels,
-			Map<String, String> facilityLabels
+			Map<String, String> facilityLabels,
+			LocalDateTime now
 		) {
+			ReportSlaBadge sla = ReportSlaBadge.of(report.status(), report.createdAt(), now);
 			return new FacilityReportListPageRow(
 				report.id(),
 				report.stationId(),
@@ -676,7 +682,9 @@ class FacilityReportAdminPageController {
 				messages.enumLabel("admin.report.status", report.status()),
 				report.createdAt(),
 				FacilityReportAdminPageController.hasCompletePhoto(report),
-				FacilityReportAdminPageController.coordinateLabel(report.latitude(), report.longitude())
+				FacilityReportAdminPageController.coordinateLabel(report.latitude(), report.longitude()),
+				sla.label(),
+				sla.tone()
 			);
 		}
 	}

--- a/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageController.java
@@ -19,6 +19,7 @@ import com.easysubway.report.domain.FacilityReportReviewDecision;
 import com.easysubway.report.domain.ReportSlaBadge;
 import com.easysubway.report.domain.FacilityReportSummary;
 import com.easysubway.report.domain.FacilityReportStatus;
+import com.easysubway.report.domain.FacilityReportType;
 import com.easysubway.report.domain.ReportProcessingTimeSummary;
 import com.easysubway.transit.domain.MasterDataWriteNotAllowedException;
 import io.github.wimdeblauwe.htmx.spring.boot.mvc.HxRequest;
@@ -136,6 +137,9 @@ class FacilityReportAdminPageController {
 	String reportListPage(
 		@RequestParam(required = false) FacilityReportStatus status,
 		@RequestParam(required = false) String keyword,
+		@RequestParam(required = false) String station,
+		@RequestParam(required = false) FacilityReportType type,
+		@RequestParam(required = false) Boolean hasPhoto,
 		@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
 		@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
 		@RequestParam(required = false) String sort,
@@ -145,11 +149,13 @@ class FacilityReportAdminPageController {
 		Model model
 	) {
 		// 기본 저장 뷰 자동 적용: 필터 없이 목록에 진입하면 사용자의 기본 뷰 질의로 리다이렉트한다.
-		String defaultViewUrl = defaultViewRedirect(status, keyword, from, to, sort, page, size, authentication);
+		String defaultViewUrl = defaultViewRedirect(
+			status, keyword, station, type, hasPhoto, from, to, sort, page, size, authentication);
 		if (defaultViewUrl != null) {
 			return "redirect:" + defaultViewUrl;
 		}
-		FacilityReportListQuery query = FacilityReportListQuery.of(status, keyword, from, to, sort, page, size);
+		FacilityReportListQuery query = FacilityReportListQuery.of(
+			status, keyword, station, type, hasPhoto, from, to, sort, page, size);
 		EgovPaginationView pageView = reportListPageView(query);
 		if (pageView.page() != query.page() || pageView.size() != query.size()) {
 			return redirectToReportList(query, pageView);
@@ -164,6 +170,9 @@ class FacilityReportAdminPageController {
 	private String defaultViewRedirect(
 		FacilityReportStatus status,
 		String keyword,
+		String station,
+		FacilityReportType type,
+		Boolean hasPhoto,
 		LocalDate from,
 		LocalDate to,
 		String sort,
@@ -171,7 +180,8 @@ class FacilityReportAdminPageController {
 		Integer size,
 		Authentication authentication
 	) {
-		boolean freshEntry = status == null && keyword == null && from == null && to == null
+		boolean freshEntry = status == null && keyword == null && station == null && type == null
+			&& hasPhoto == null && from == null && to == null
 			&& sort == null && page == null && size == null;
 		if (!freshEntry || authentication == null) {
 			return null;
@@ -193,6 +203,9 @@ class FacilityReportAdminPageController {
 	String reportListFragment(
 		@RequestParam(required = false) FacilityReportStatus status,
 		@RequestParam(required = false) String keyword,
+		@RequestParam(required = false) String station,
+		@RequestParam(required = false) FacilityReportType type,
+		@RequestParam(required = false) Boolean hasPhoto,
 		@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
 		@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
 		@RequestParam(required = false) String sort,
@@ -203,9 +216,11 @@ class FacilityReportAdminPageController {
 		Model model
 	) {
 		if (historyRestore) {
-			return reportListPage(status, keyword, from, to, sort, page, size, authentication, model);
+			return reportListPage(
+				status, keyword, station, type, hasPhoto, from, to, sort, page, size, authentication, model);
 		}
-		FacilityReportListQuery query = FacilityReportListQuery.of(status, keyword, from, to, sort, page, size);
+		FacilityReportListQuery query = FacilityReportListQuery.of(
+			status, keyword, station, type, hasPhoto, from, to, sort, page, size);
 		EgovPaginationView pageView = reportListPageView(query);
 		addReportResultsAttributes(clampQuery(query, pageView), pageView, authentication, model);
 		return "admin/reports/list :: reportResults";
@@ -219,6 +234,9 @@ class FacilityReportAdminPageController {
 		return new FacilityReportListQuery(
 			query.status(),
 			query.keyword(),
+			query.stationId(),
+			query.reportType(),
+			query.hasPhoto(),
 			query.createdFrom(),
 			query.createdTo(),
 			query.sortField(),
@@ -253,6 +271,9 @@ class FacilityReportAdminPageController {
 		model.addAttribute("selectedStatus", query.status());
 		model.addAttribute("statusOptions", statusOptions());
 		model.addAttribute("searchKeyword", query.keyword());
+		model.addAttribute("selectedStation", query.stationId());
+		model.addAttribute("selectedType", query.reportType());
+		model.addAttribute("selectedHasPhoto", query.hasPhoto());
 		model.addAttribute("createdFrom", query.createdFrom());
 		model.addAttribute("createdTo", query.createdTo());
 		model.addAttribute("reportQuery", query);
@@ -261,48 +282,55 @@ class FacilityReportAdminPageController {
 		model.addAttribute("sortParam", sortParam);
 
 		// 링크는 컨트롤러에서 조립한다: Thymeleaf @{...(p=${null})}은 null도 빈 파라미터로 렌더해 URL을 오염시킨다.
-		String currentSort = sortParam == null ? null : sortParam.toString();
-		String keyword = query.keyword();
-		LocalDate createdFromDate = query.createdFrom();
-		LocalDate createdToDate = query.createdTo();
+		// hrefWith(query, overrides)는 현재 질의(상태·키워드·역·유형·사진·기간·정렬)를 유지하고 지정한
+		// 차원만 덮어쓴다(override 값 null이면 그 파라미터를 제거).
 		model.addAttribute("allFilter", new StatusFilterLink(
-			"전체", hrefWith(null, keyword, createdFromDate, createdToDate, currentSort), query.status() == null));
+			"전체", hrefWith(query, override("status", null)), query.status() == null));
 		model.addAttribute("statusFilters", statusOptions().stream()
 			.map(option -> new StatusFilterLink(
 				option.label(),
-				hrefWith(option.value(), keyword, createdFromDate, createdToDate, currentSort),
+				hrefWith(query, override("status", option.value())),
 				query.status() == option.value()))
 			.toList());
 		// 일괄 처리·저장된 뷰 변경 후 현재 필터·정렬 컨텍스트로 되돌아갈 returnTo.
-		model.addAttribute("currentListHref",
-			hrefWith(query.status(), keyword, createdFromDate, createdToDate, currentSort));
+		model.addAttribute("currentListHref", hrefWith(query, Map.of()));
 		model.addAttribute("statusSort", new SortHeaderLink(
-			hrefWith(query.status(), keyword, createdFromDate, createdToDate, query.nextSortFor("status")),
+			hrefWith(query, override("sort", query.nextSortFor("status"))),
 			query.ariaSortFor("status")));
 		model.addAttribute("createdSort", new SortHeaderLink(
-			hrefWith(query.status(), keyword, createdFromDate, createdToDate, query.nextSortFor("created_at")),
+			hrefWith(query, override("sort", query.nextSortFor("created_at"))),
 			query.ariaSortFor("created_at")));
+
+		// 유형 필터(툴바 select): 전체 유형 + 신고 유형별. no-JS는 select 변경 후 검색 버튼, JS는 change 즉시.
+		model.addAttribute("typeFilters", typeFilterOptions(query));
+		// 사진 유무 필터(툴바 select): 전체 / 사진 있음 / 사진 없음.
+		model.addAttribute("photoFilters", photoFilterOptions(query));
 
 		// 기간 프리셋(오늘·최근 7일·최근 30일·전체 기간). 접수일 기준.
 		LocalDate today = LocalDate.now(clock);
+		LocalDate createdFromDate = query.createdFrom();
+		LocalDate createdToDate = query.createdTo();
 		model.addAttribute("datePresets", List.of(
-			datePreset(query, "오늘", today, today, currentSort),
-			datePreset(query, "최근 7일", today.minusDays(6), today, currentSort),
-			datePreset(query, "최근 30일", today.minusDays(29), today, currentSort),
+			datePreset(query, "오늘", today, today),
+			datePreset(query, "최근 7일", today.minusDays(6), today),
+			datePreset(query, "최근 30일", today.minusDays(29), today),
 			new DatePresetLink("전체 기간",
-				hrefWith(query.status(), keyword, null, null, currentSort),
+				hrefWith(query, dateOverride(null, null)),
 				createdFromDate == null && createdToDate == null)
 		));
 
-		// 활성 필터 칩(개별 제거). 상태는 상단 필터 nav로 표현하므로 칩은 키워드·기간만 담는다.
+		// 활성 필터 칩(개별 제거). 상태·유형·사진은 상단 필터·툴바로 표현하므로 칩은 키워드·역·기간만 담는다.
 		List<FilterChip> chips = new java.util.ArrayList<>();
-		if (keyword != null) {
-			chips.add(new FilterChip("검색: " + keyword,
-				hrefWith(query.status(), null, createdFromDate, createdToDate, currentSort)));
+		if (query.hasKeyword()) {
+			chips.add(new FilterChip("검색: " + query.keyword(), hrefWith(query, override("keyword", null))));
+		}
+		if (query.hasStation()) {
+			String stationLabel = stationLabels.getOrDefault(query.stationId(), query.stationId());
+			chips.add(new FilterChip("역: " + stationLabel, hrefWith(query, override("station", null))));
 		}
 		if (createdFromDate != null || createdToDate != null) {
 			chips.add(new FilterChip("기간: " + dateRangeLabel(createdFromDate, createdToDate),
-				hrefWith(query.status(), keyword, null, null, currentSort)));
+				hrefWith(query, dateOverride(null, null))));
 		}
 		model.addAttribute("filterChips", chips);
 
@@ -334,11 +362,31 @@ class FacilityReportAdminPageController {
 		FacilityReportListQuery query,
 		String label,
 		LocalDate from,
-		LocalDate to,
-		String currentSort
+		LocalDate to
 	) {
 		boolean active = from.equals(query.createdFrom()) && to.equals(query.createdTo());
-		return new DatePresetLink(label, hrefWith(query.status(), query.keyword(), from, to, currentSort), active);
+		return new DatePresetLink(label, hrefWith(query, dateOverride(from, to)), active);
+	}
+
+	private List<FilterSelectOption> typeFilterOptions(FacilityReportListQuery query) {
+		List<FilterSelectOption> options = new java.util.ArrayList<>();
+		options.add(new FilterSelectOption("", "전체 유형", query.reportType() == null));
+		for (FacilityReportType type : FacilityReportType.values()) {
+			options.add(new FilterSelectOption(
+				type.name(),
+				messages.enumLabel("admin.report.type", type),
+				query.reportType() == type));
+		}
+		return options;
+	}
+
+	private static List<FilterSelectOption> photoFilterOptions(FacilityReportListQuery query) {
+		Boolean hasPhoto = query.hasPhoto();
+		return List.of(
+			new FilterSelectOption("", "사진 전체", hasPhoto == null),
+			new FilterSelectOption("true", "사진 있음", Boolean.TRUE.equals(hasPhoto)),
+			new FilterSelectOption("false", "사진 없음", Boolean.FALSE.equals(hasPhoto))
+		);
 	}
 
 	private static String dateRangeLabel(LocalDate from, LocalDate to) {
@@ -348,21 +396,35 @@ class FacilityReportAdminPageController {
 		return from != null ? from + " ~" : "~ " + to;
 	}
 
-	// 상태·검색·기간·정렬을 명시적으로 받아 링크 URL을 만든다. null 값은 생략한다.
-	private static String hrefWith(
-		FacilityReportStatus status,
-		String keyword,
-		LocalDate from,
-		LocalDate to,
-		String sort
-	) {
+	// 현재 질의(상태·키워드·역·유형·사진·기간·정렬)를 유지하되 overrides로 특정 파라미터만 덮어쓴 목록 URL을 만든다.
+	// override 값이 null이면 그 파라미터를 제거한다(예: 필터 칩의 개별 제거 링크). null·빈 값은 URL에서 생략한다.
+	private static String hrefWith(FacilityReportListQuery query, Map<String, Object> overrides) {
+		Map<String, Object> params = new LinkedHashMap<>();
+		params.put("status", query.status());
+		params.put("keyword", query.keyword());
+		params.put("station", query.stationId());
+		params.put("type", query.reportType());
+		params.put("hasPhoto", query.hasPhoto());
+		params.put("from", query.createdFrom());
+		params.put("to", query.createdTo());
+		params.put("sort", queryParams(query).get("sort"));
+		params.putAll(overrides);
 		UriComponentsBuilder builder = UriComponentsBuilder.fromPath("/admin/reports/page");
-		appendParam(builder, "status", status);
-		appendParam(builder, "keyword", keyword);
-		appendParam(builder, "from", from);
-		appendParam(builder, "to", to);
-		appendParam(builder, "sort", sort);
+		params.forEach((name, value) -> appendParam(builder, name, value));
 		return builder.build().encode().toUriString();
+	}
+
+	private static Map<String, Object> override(String key, Object value) {
+		Map<String, Object> overrides = new java.util.HashMap<>();
+		overrides.put(key, value);
+		return overrides;
+	}
+
+	private static Map<String, Object> dateOverride(LocalDate from, LocalDate to) {
+		Map<String, Object> overrides = new java.util.HashMap<>();
+		overrides.put("from", from);
+		overrides.put("to", to);
+		return overrides;
 	}
 
 	private static void appendParam(UriComponentsBuilder builder, String name, Object value) {
@@ -372,6 +434,9 @@ class FacilityReportAdminPageController {
 	}
 
 	record StatusFilterLink(String label, String href, boolean current) {
+	}
+
+	record FilterSelectOption(String value, String label, boolean selected) {
 	}
 
 	record SortHeaderLink(String href, String ariaSort) {
@@ -402,6 +467,9 @@ class FacilityReportAdminPageController {
 		Map<String, Object> params = new LinkedHashMap<>();
 		params.put("status", query.status());
 		params.put("keyword", query.keyword());
+		params.put("station", query.stationId());
+		params.put("type", query.reportType());
+		params.put("hasPhoto", query.hasPhoto());
 		params.put("from", query.createdFrom());
 		params.put("to", query.createdTo());
 		if (query.sortField() != FacilityReportListQuery.SortField.CREATED_AT

--- a/backend/src/main/java/com/easysubway/report/adapter/out/persistence/InMemoryFacilityReportRepository.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/out/persistence/InMemoryFacilityReportRepository.java
@@ -109,6 +109,9 @@ public class InMemoryFacilityReportRepository implements
 			.filter(report -> keyword == null
 				|| (report.description() != null
 					&& report.description().toLowerCase(Locale.ROOT).contains(keyword)))
+			.filter(report -> !query.hasStation() || query.stationId().equals(report.stationId()))
+			.filter(report -> !query.hasReportType() || report.reportType() == query.reportType())
+			.filter(report -> !query.hasPhotoFilter() || report.hasPhoto() == query.hasPhoto())
 			.filter(report -> query.createdFrom() == null
 				|| !report.createdAt().isBefore(query.createdFrom().atStartOfDay()))
 			.filter(report -> query.createdTo() == null

--- a/backend/src/main/java/com/easysubway/report/adapter/out/persistence/InMemoryFacilityReportRepository.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/out/persistence/InMemoryFacilityReportRepository.java
@@ -190,6 +190,17 @@ public class InMemoryFacilityReportRepository implements
 	}
 
 	@Override
+	public List<FacilityReportSummary> loadReportsForFacility(String stationId, String facilityId, int limit) {
+		return reports.values()
+			.stream()
+			.filter(report -> stationId.equals(report.stationId()) && facilityId.equals(report.facilityId()))
+			.sorted(reportOrder())
+			.limit(Math.max(limit, 0))
+			.map(FacilityReportSummary::from)
+			.toList();
+	}
+
+	@Override
 	public FacilityReport saveReport(FacilityReport report) {
 		reports.put(report.id(), report);
 		return report;

--- a/backend/src/main/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportRepository.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportRepository.java
@@ -448,6 +448,44 @@ public class JdbcFacilityReportRepository implements
 	}
 
 	@Override
+	public List<FacilityReportSummary> loadReportsForFacility(String stationId, String facilityId, int limit) {
+		return jdbcTemplate.query(
+			"""
+				SELECT report_id,
+					public_receipt_code,
+					user_id,
+					station_id,
+					facility_id,
+					report_type,
+					description,
+					CASE
+						WHEN photo_file_name IS NOT NULL
+							AND photo_content_type IS NOT NULL
+							AND photo_object_key IS NOT NULL
+						THEN TRUE
+						ELSE FALSE
+					END AS has_photo,
+					latitude,
+					longitude,
+					duplicate_of_report_id,
+					status,
+					created_at,
+					reviewed_at,
+					reviewed_by
+				FROM facility_reports
+				WHERE station_id = ?
+					AND facility_id = ?
+				ORDER BY created_at DESC, report_id ASC
+				LIMIT ?
+				""",
+			this::mapFacilityReportSummary,
+			stationId,
+			facilityId,
+			limit
+		);
+	}
+
+	@Override
 	public FacilityReport saveReport(FacilityReport report) {
 		upsertReport(report);
 		return report;

--- a/backend/src/main/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportRepository.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportRepository.java
@@ -318,7 +318,11 @@ public class JdbcFacilityReportRepository implements
 		return count == null ? 0L : count;
 	}
 
-	// 상태·키워드(신고 내용 부분일치)·접수 기간을 동적 WHERE로 조립하고 바인딩 값을 args에 채운다.
+	// 사진 첨부 판정: 파일명·MIME·오브젝트 키가 모두 있어야 첨부로 본다(요약 has_photo 표현식과 동일).
+	private static final String HAS_PHOTO_PREDICATE =
+		"(photo_file_name IS NOT NULL AND photo_content_type IS NOT NULL AND photo_object_key IS NOT NULL)";
+
+	// 상태·키워드(신고 내용 부분일치)·역·유형·사진 유무·접수 기간을 동적 WHERE로 조립하고 바인딩 값을 args에 채운다.
 	private String buildReportSearchWhere(FacilityReportListQuery query, List<Object> args) {
 		List<String> clauses = new ArrayList<>();
 		if (query.status() != null) {
@@ -329,6 +333,18 @@ public class JdbcFacilityReportRepository implements
 			// LIKE 메타문자(%,_,\)를 이스케이프해 부분일치를 리터럴로 맞춘다(InMemory .contains()와 시맨틱 일치).
 			clauses.add("LOWER(description) LIKE ? ESCAPE '\\'");
 			args.add("%" + escapeLike(query.keyword().toLowerCase(Locale.ROOT)) + "%");
+		}
+		if (query.hasStation()) {
+			clauses.add("station_id = ?");
+			args.add(query.stationId());
+		}
+		if (query.hasReportType()) {
+			clauses.add("report_type = ?");
+			args.add(query.reportType().name());
+		}
+		if (query.hasPhotoFilter()) {
+			// 첨부 유무 필터: 참이면 첨부된 신고, 거짓이면 첨부 없는 신고만. 바인딩 값이 없는 리터럴 술어다.
+			clauses.add(query.hasPhoto() ? HAS_PHOTO_PREDICATE : "NOT " + HAS_PHOTO_PREDICATE);
 		}
 		if (query.createdFrom() != null) {
 			clauses.add("created_at >= ?");

--- a/backend/src/main/java/com/easysubway/report/application/port/in/FacilityReportListQuery.java
+++ b/backend/src/main/java/com/easysubway/report/application/port/in/FacilityReportListQuery.java
@@ -1,6 +1,7 @@
 package com.easysubway.report.application.port.in;
 
 import com.easysubway.report.domain.FacilityReportStatus;
+import com.easysubway.report.domain.FacilityReportType;
 import com.easysubway.report.domain.InvalidFacilityReportException;
 import java.time.LocalDate;
 import java.util.Locale;
@@ -8,13 +9,16 @@ import java.util.Locale;
 /**
  * 관리자 신고 대기열 표준 테이블(#1737)의 서버 파라미터 질의.
  *
- * <p>상태 필터에 더해 키워드 검색(신고 내용)·접수 기간·정렬을 담는다. 모든 값은 URL 쿼리에서
- * 오며 no-JS(폼 제출)와 htmx(부분 갱신)가 같은 파라미터를 공유한다. 잘못된 정렬 토큰은 500이
- * 아니라 기본값(최신순)으로 관대하게 처리한다.
+ * <p>상태 필터에 더해 키워드 검색(신고 내용)·역·유형·사진 유무·접수 기간·정렬을 담는다. 모든 값은
+ * URL 쿼리에서 오며 no-JS(폼 제출)와 htmx(부분 갱신)가 같은 파라미터를 공유한다. 잘못된 정렬
+ * 토큰은 500이 아니라 기본값(최신순)으로 관대하게 처리한다.
  */
 public record FacilityReportListQuery(
 	FacilityReportStatus status,
 	String keyword,
+	String stationId,
+	FacilityReportType reportType,
+	Boolean hasPhoto,
 	LocalDate createdFrom,
 	LocalDate createdTo,
 	SortField sortField,
@@ -57,6 +61,7 @@ public record FacilityReportListQuery(
 
 	public FacilityReportListQuery {
 		keyword = (keyword == null || keyword.isBlank()) ? null : keyword.trim();
+		stationId = (stationId == null || stationId.isBlank()) ? null : stationId.trim();
 		sortField = sortField == null ? SortField.CREATED_AT : sortField;
 		sortDirection = sortDirection == null ? SortDirection.DESC : sortDirection;
 		if (page < 0 || size <= 0) {
@@ -74,6 +79,9 @@ public record FacilityReportListQuery(
 	public static FacilityReportListQuery of(
 		FacilityReportStatus status,
 		String keyword,
+		String stationId,
+		FacilityReportType reportType,
+		Boolean hasPhoto,
 		LocalDate createdFrom,
 		LocalDate createdTo,
 		String sort,
@@ -94,6 +102,9 @@ public record FacilityReportListQuery(
 		return new FacilityReportListQuery(
 			status,
 			keyword,
+			stationId,
+			reportType,
+			hasPhoto,
 			createdFrom,
 			createdTo,
 			field,
@@ -170,5 +181,18 @@ public record FacilityReportListQuery(
 
 	public boolean hasKeyword() {
 		return keyword != null;
+	}
+
+	public boolean hasStation() {
+		return stationId != null;
+	}
+
+	public boolean hasReportType() {
+		return reportType != null;
+	}
+
+	/** 사진 유무 필터가 지정됐는지. 지정 시 {@link #hasPhoto()}가 있음/없음을 가리킨다. */
+	public boolean hasPhotoFilter() {
+		return hasPhoto != null;
 	}
 }

--- a/backend/src/main/java/com/easysubway/report/application/port/in/FacilityReportUseCase.java
+++ b/backend/src/main/java/com/easysubway/report/application/port/in/FacilityReportUseCase.java
@@ -57,6 +57,9 @@ public interface FacilityReportUseCase {
 
 	List<RepeatedBrokenFacilityReportSummary> listRepeatedBrokenReportFacilities();
 
+	/** 같은 역·시설로 접수된 신고 요약(최신순, 상한 적용). 드로어의 "같은 시설 신고 목록"에 쓴다. */
+	List<FacilityReportSummary> listReportsForFacility(String stationId, String facilityId);
+
 	FacilityReport reviewReport(ReviewFacilityReportCommand command);
 
 	FacilityReport confirmReportResult(String reportId, String userId);

--- a/backend/src/main/java/com/easysubway/report/application/port/out/LoadFacilityReportPort.java
+++ b/backend/src/main/java/com/easysubway/report/application/port/out/LoadFacilityReportPort.java
@@ -39,4 +39,10 @@ public interface LoadFacilityReportPort {
 	ReportProcessingTimeSummary loadReportProcessingTimeSummary();
 
 	List<RepeatedBrokenFacilityReportSummary> loadRepeatedBrokenReportFacilities();
+
+	/**
+	 * 같은 역·시설로 접수된 신고 요약을 최신순으로 조회한다(드로어의 "같은 시설 신고 목록"용).
+	 * 목록이 폭주하지 않도록 limit로 상한을 둔다. 호출부에서 현재 신고는 제외한다.
+	 */
+	List<FacilityReportSummary> loadReportsForFacility(String stationId, String facilityId, int limit);
 }

--- a/backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java
+++ b/backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java
@@ -67,6 +67,8 @@ public class FacilityReportService implements FacilityReportUseCase {
 	private static final String LOCAL_DEV_RECEIPT_TOKEN_PEPPER = "local-dev-report-receipt-pepper";
 	private static final String UNCLAIMED_UPLOAD_OBJECT_PREFIX = "facility-reports/unclaimed/";
 	private static final int PUBLIC_RECEIPT_CODE_SAVE_ATTEMPTS = 3;
+	// 드로어 "같은 시설 신고 목록" 상한(현재 신고 제외 전 조회 수). 폭주 방지·query budget 보호.
+	private static final int SAME_FACILITY_REPORT_LIMIT = 20;
 
 	private final LoadTransitMasterPort loadTransitMasterPort;
 	private final SaveAccessibilityFacilityStatusPort saveAccessibilityFacilityStatusPort;
@@ -601,6 +603,15 @@ public class FacilityReportService implements FacilityReportUseCase {
 	@Override
 	public List<RepeatedBrokenFacilityReportSummary> listRepeatedBrokenReportFacilities() {
 		return loadFacilityReportPort.loadRepeatedBrokenReportFacilities();
+	}
+
+	@Override
+	public List<FacilityReportSummary> listReportsForFacility(String stationId, String facilityId) {
+		if (stationId == null || facilityId == null) {
+			return List.of();
+		}
+		return loadFacilityReportPort.loadReportsForFacility(
+			stationId, facilityId, SAME_FACILITY_REPORT_LIMIT);
 	}
 
 	@Override

--- a/backend/src/main/java/com/easysubway/report/domain/ReportSlaBadge.java
+++ b/backend/src/main/java/com/easysubway/report/domain/ReportSlaBadge.java
@@ -1,0 +1,44 @@
+package com.easysubway.report.domain;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+/**
+ * 제보 확인 대기열(#1740)의 SLA 경과 뱃지. 대기 상태(SUBMITTED·UNDER_REVIEW) 제보가 접수 후
+ * 임계 시간을 넘기면 경과를 표시해 "오래된 것부터" 처리하도록 유도한다.
+ *
+ * <p>종결 상태(ACCEPTED·REJECTED·RESOLVED·DUPLICATE)는 경과가 의미 없어 뱃지를 비운다.
+ * 임계값은 상용 모더레이션 큐 기준선(24h 경고·72h 위반)을 기본으로 한다.
+ *
+ * @param label 표시 문구(없으면 빈 문자열)
+ * @param tone  status 프래그먼트 톤(warn·bad)
+ */
+public record ReportSlaBadge(String label, String tone) {
+
+	static final long WARN_HOURS = 24;
+	static final long BREACH_HOURS = 72;
+
+	private static final ReportSlaBadge NONE = new ReportSlaBadge("", "");
+
+	public static ReportSlaBadge of(FacilityReportStatus status, LocalDateTime createdAt, LocalDateTime now) {
+		if (createdAt == null || !isPending(status)) {
+			return NONE;
+		}
+		long hours = Duration.between(createdAt, now).toHours();
+		if (hours >= BREACH_HOURS) {
+			return new ReportSlaBadge(BREACH_HOURS + "시간 초과", "bad");
+		}
+		if (hours >= WARN_HOURS) {
+			return new ReportSlaBadge(WARN_HOURS + "시간 초과", "warn");
+		}
+		return NONE;
+	}
+
+	private static boolean isPending(FacilityReportStatus status) {
+		return status == FacilityReportStatus.SUBMITTED || status == FacilityReportStatus.UNDER_REVIEW;
+	}
+
+	public boolean present() {
+		return !label.isEmpty();
+	}
+}

--- a/backend/src/main/resources/static/css/admin-v3.css
+++ b/backend/src/main/resources/static/css/admin-v3.css
@@ -593,6 +593,20 @@ body.admin-v3 {
 	text-align: center;
 }
 
+/* 신고 사진 썸네일(#1740): 목록에서 첨부 미리보기, 클릭 시 원본으로 이동 */
+.admin-v3 .report-thumb {
+	display: inline-block;
+	line-height: 0;
+}
+
+.admin-v3 .report-thumb img {
+	width: 48px;
+	height: 48px;
+	object-fit: cover;
+	border-radius: 6px;
+	border: 1px solid var(--admin-border);
+}
+
 .admin-v3 .bulk-actionbar {
 	position: sticky;
 	bottom: 0;

--- a/backend/src/main/resources/static/css/admin-v3.css
+++ b/backend/src/main/resources/static/css/admin-v3.css
@@ -607,6 +607,77 @@ body.admin-v3 {
 	border: 1px solid var(--admin-border);
 }
 
+/* 키보드로 이동한 행 강조(#1740): 상세 링크에 포커스가 들어오면 행 전체를 표시 */
+.admin-v3 .report-row:focus-within {
+	background: var(--admin-surface-2, rgba(22, 48, 47, 0.06));
+	outline: 2px solid var(--admin-accent, #1f6f6a);
+	outline-offset: -2px;
+}
+
+/* 단축키 도움말(#1740): 버튼 + 오버레이 다이얼로그 */
+.admin-v3 .shortcut-help-trigger {
+	margin-left: auto;
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	padding: 4px 10px;
+	border: 1px solid var(--admin-border);
+	border-radius: 6px;
+	background: var(--admin-surface);
+	color: var(--admin-ink-2);
+	font-size: 13px;
+	cursor: pointer;
+}
+
+.admin-v3 .shortcut-help-trigger kbd {
+	padding: 1px 6px;
+	border: 1px solid var(--admin-border-strong);
+	border-radius: 4px;
+	font-size: 11px;
+}
+
+.admin-v3 .shortcut-help {
+	position: fixed;
+	inset: 0;
+	z-index: 90;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: rgba(22, 48, 47, 0.35);
+}
+
+.admin-v3 .shortcut-help-panel {
+	background: var(--admin-surface);
+	border: 1px solid var(--admin-border);
+	border-radius: 10px;
+	padding: 20px 24px;
+	max-width: 360px;
+	width: calc(100% - 32px);
+	box-shadow: 0 12px 32px rgba(0, 0, 0, 0.18);
+}
+
+.admin-v3 .shortcut-help-panel h2 {
+	margin: 0 0 12px;
+	font-size: 16px;
+}
+
+.admin-v3 .shortcut-help-panel ul {
+	list-style: none;
+	margin: 0 0 16px;
+	padding: 0;
+	display: grid;
+	gap: 8px;
+	font-size: 13px;
+	color: var(--admin-ink-2);
+}
+
+.admin-v3 .shortcut-help-panel kbd {
+	padding: 1px 6px;
+	border: 1px solid var(--admin-border-strong);
+	border-radius: 4px;
+	font-size: 11px;
+}
+
 .admin-v3 .bulk-actionbar {
 	position: sticky;
 	bottom: 0;

--- a/backend/src/main/resources/static/css/admin-v3.css
+++ b/backend/src/main/resources/static/css/admin-v3.css
@@ -649,10 +649,11 @@ body.admin-v3 {
 	padding-bottom: 16px;
 }
 
-.admin-v3 table.hide-col-coordinate td:nth-child(8),
-.admin-v3 table.hide-col-coordinate th:nth-child(8),
-.admin-v3 table.hide-col-photo td:nth-child(9),
-.admin-v3 table.hide-col-photo th:nth-child(9) {
+/* 경과 컬럼(#1740)이 접수일과 좌표 사이(8열)에 들어가 좌표=9열·사진=10열로 밀렸다. */
+.admin-v3 table.hide-col-coordinate td:nth-child(9),
+.admin-v3 table.hide-col-coordinate th:nth-child(9),
+.admin-v3 table.hide-col-photo td:nth-child(10),
+.admin-v3 table.hide-col-photo th:nth-child(10) {
 	display: none;
 }
 

--- a/backend/src/main/resources/static/js/admin/app.js
+++ b/backend/src/main/resources/static/js/admin/app.js
@@ -262,19 +262,24 @@ document.addEventListener('alpine:init', function () {
 			rowLinks: function () {
 				return Array.prototype.slice.call(this.$root.querySelectorAll('.report-row .detail-link'));
 			},
-			// 현재 포커스가 향한 행의 상세 링크. 포커스가 표 밖이면 첫 행으로 대체한다.
+			// 현재 포커스가 향한 행의 상세 링크. 포커스가 표 밖이면 첫 행으로 대체한다(비파괴 동작 전용).
 			currentLink: function () {
 				var links = this.rowLinks();
 				if (!links.length) {
 					return null;
 				}
+				return this.focusedRowLink() || links[0];
+			},
+			// 포커스가 실제로 어느 행 안에 있을 때만 그 행의 상세 링크를 준다(없으면 null, 첫 행 폴백 없음).
+			// 승인·반려처럼 파괴적인 단축키가 포커스가 표 밖일 때 첫 행을 잘못 처리하지 않게 한다.
+			focusedRowLink: function () {
 				var active = document.activeElement;
+				var links = this.rowLinks();
 				if (links.indexOf(active) !== -1) {
 					return active;
 				}
 				var row = active && active.closest ? active.closest('.report-row') : null;
-				var link = row ? row.querySelector('.detail-link') : null;
-				return link || links[0];
+				return row ? row.querySelector('.detail-link') : null;
 			},
 			isFormField: function (element) {
 				if (!element) {
@@ -306,8 +311,9 @@ document.addEventListener('alpine:init', function () {
 				}
 			},
 			// 활성 행 하나만 선택 상태로 만들고 일괄 검수 폼을 해당 결정으로 제출한다(단일 처리 시맨틱).
+			// 포커스가 표 밖이면 아무 것도 하지 않는다(첫 행 오처리 방지) — focusedRowLink는 폴백이 없다.
 			processActive: function (decision) {
-				var link = this.currentLink();
+				var link = this.focusedRowLink();
 				if (!link) {
 					return;
 				}

--- a/backend/src/main/resources/static/js/admin/app.js
+++ b/backend/src/main/resources/static/js/admin/app.js
@@ -214,6 +214,7 @@ document.addEventListener('alpine:init', function () {
 			density: 'default',
 			hideCoordinate: false,
 			hidePhoto: false,
+			helpVisible: false,
 			get selectionLabel() {
 				return this.count > 0 ? '선택한 신고 ' + this.count + '건' : '선택한 신고 일괄 처리';
 			},
@@ -243,6 +244,127 @@ document.addEventListener('alpine:init', function () {
 			},
 			togglePhoto: function (event) {
 				this.hidePhoto = event.target.checked;
+			},
+			// 키보드 단축키(#1740): j/k 행 이동·o 상세 열기·a 승인·r 반려·Esc 닫기·? 도움말.
+			// 모더레이터가 마우스 없이 대기열을 처리하도록 한다(Reddit modqueue·모더레이션 API 공통 패턴).
+			// 진화형 향상 — 모든 단축키 동작은 버튼(상세 링크·일괄 승인/반려·도움말)으로도 존재해 스크린리더/no-JS를
+			// 커버한다. 입력·select·textarea 포커스 중에는 비활성해 타이핑을 방해하지 않는다.
+			// 런타임/실제 키 입력 검증은 브라우저가 필요해 접근성 QA(#1749)로 이월한다.
+			get helpExpanded() {
+				return this.helpVisible ? 'true' : 'false';
+			},
+			toggleHelp: function () {
+				this.helpVisible = !this.helpVisible;
+			},
+			hideHelp: function () {
+				this.helpVisible = false;
+			},
+			rowLinks: function () {
+				return Array.prototype.slice.call(this.$root.querySelectorAll('.report-row .detail-link'));
+			},
+			// 현재 포커스가 향한 행의 상세 링크. 포커스가 표 밖이면 첫 행으로 대체한다.
+			currentLink: function () {
+				var links = this.rowLinks();
+				if (!links.length) {
+					return null;
+				}
+				var active = document.activeElement;
+				if (links.indexOf(active) !== -1) {
+					return active;
+				}
+				var row = active && active.closest ? active.closest('.report-row') : null;
+				var link = row ? row.querySelector('.detail-link') : null;
+				return link || links[0];
+			},
+			isFormField: function (element) {
+				if (!element) {
+					return false;
+				}
+				var tag = element.tagName ? element.tagName.toLowerCase() : '';
+				return tag === 'input' || tag === 'textarea' || tag === 'select' || element.isContentEditable;
+			},
+			moveActive: function (delta) {
+				var links = this.rowLinks();
+				if (!links.length) {
+					return;
+				}
+				var index = links.indexOf(document.activeElement);
+				var next;
+				if (index === -1) {
+					next = delta > 0 ? links[0] : links[links.length - 1];
+				} else {
+					next = links[index + delta];
+				}
+				if (next) {
+					next.focus();
+				}
+			},
+			openActive: function () {
+				var link = this.currentLink();
+				if (link) {
+					link.click();
+				}
+			},
+			// 활성 행 하나만 선택 상태로 만들고 일괄 검수 폼을 해당 결정으로 제출한다(단일 처리 시맨틱).
+			processActive: function (decision) {
+				var link = this.currentLink();
+				if (!link) {
+					return;
+				}
+				var row = link.closest('.report-row');
+				var form = this.$root.querySelector('.bulk-form');
+				if (!row || !form) {
+					return;
+				}
+				this.$root.querySelectorAll('input[name="reportIds"]').forEach(function (checkbox) {
+					checkbox.checked = false;
+				});
+				var checkbox = row.querySelector('input[name="reportIds"]');
+				if (checkbox) {
+					checkbox.checked = true;
+				}
+				var button = form.querySelector('button[value="' + decision + '"]');
+				if (button) {
+					button.click();
+				}
+			},
+			handleKey: function (event) {
+				if (this.isFormField(document.activeElement) || event.ctrlKey || event.metaKey || event.altKey) {
+					return;
+				}
+				switch (event.key) {
+					case '?':
+						this.toggleHelp();
+						event.preventDefault();
+						break;
+					case 'j':
+						this.moveActive(1);
+						event.preventDefault();
+						break;
+					case 'k':
+						this.moveActive(-1);
+						event.preventDefault();
+						break;
+					case 'o':
+						this.openActive();
+						event.preventDefault();
+						break;
+					case 'a':
+						this.processActive('ACCEPT');
+						event.preventDefault();
+						break;
+					case 'r':
+						this.processActive('REJECT');
+						event.preventDefault();
+						break;
+					case 'Escape':
+						if (this.helpVisible) {
+							this.hideHelp();
+						}
+						break;
+					default:
+						break;
+				}
 			},
 		};
 	});

--- a/backend/src/main/resources/templates/admin/reports/detail.html
+++ b/backend/src/main/resources/templates/admin/reports/detail.html
@@ -45,10 +45,10 @@
 			<dd th:text="${report.reportTypeLabel}">고장</dd>
 			<dt>내용</dt>
 			<dd th:text="${report.description}">신고 내용</dd>
-			<dt>역 ID</dt>
-			<dd th:text="${report.stationId}">station-id</dd>
-			<dt>시설 ID</dt>
-			<dd th:text="${report.facilityId}">facility-id</dd>
+			<dt>역</dt>
+			<dd th:text="${stationLabel}">상록수(station-id)</dd>
+			<dt>시설</dt>
+			<dd th:text="${facilityLabel}">엘리베이터(facility-id)</dd>
 			<dt th:if="${report.correctionOverrideHref != null}">임시 override</dt>
 			<dd th:if="${report.correctionOverrideHref != null}"><a class="admin-btn" th:href="@{__${report.correctionOverrideHref}__}">manual override 요청</a></dd>
 			<dt>신고자</dt>
@@ -68,10 +68,12 @@
 			<dt>미리보기</dt>
 			<dd>
 				<span th:if="${!report.hasPhoto()}">없음</span>
-				<img th:if="${report.hasPhoto()}"
+				<!-- 사진 열람 권한(REPORT_PHOTO_READ)이 있을 때만 미리보기, 없으면 '있음' 텍스트(#1740). -->
+				<img th:if="${report.hasPhoto() and canReadPhoto}"
 				     class="photo-preview"
 				     th:src="@{/admin/reports/{reportId}/photo/thumbnail(reportId=${report.id})}"
 				     alt="첨부 사진">
+				<span th:if="${report.hasPhoto() and !canReadPhoto}">있음</span>
 			</dd>
 		</dl>
 	</section>
@@ -108,6 +110,32 @@
 				<td th:text="${audit.previousStatusLabel}">접수됨</td>
 				<td th:text="${audit.nextStatusLabel}">반영됨</td>
 				<td th:text="${audit.createdAt}">2026-06-15T10:00:00</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+
+	<section>
+		<h2>같은 시설 신고</h2>
+		<!-- 같은 역·시설의 다른 신고(#1740): 판정 전 반복 신고 맥락을 준다. 읽기 전용 목록으로 #1163 병합과 독립. -->
+		<p th:if="${sameFacilityReports.isEmpty()}">같은 시설의 다른 신고가 없습니다.</p>
+		<table th:if="${!sameFacilityReports.isEmpty()}">
+			<thead>
+			<tr>
+				<th scope="col">상태</th>
+				<th scope="col">유형</th>
+				<th scope="col">신고 내용</th>
+				<th scope="col">접수일</th>
+				<th scope="col">상세</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:each="row : ${sameFacilityReports}">
+				<td><span th:replace="~{admin/fragments/shell :: statusAuto(${row.statusLabel})}">접수됨</span></td>
+				<td th:text="${row.reportTypeLabel}">고장</td>
+				<td th:text="${row.description}">신고 내용</td>
+				<td th:text="${#temporals.format(row.createdAt, 'yyyy-MM-dd HH:mm')}">2026-06-17 09:00</td>
+				<td><a th:href="@{/admin/reports/{id}/page(id=${row.id})}">상세 보기</a></td>
 			</tr>
 			</tbody>
 		</table>

--- a/backend/src/main/resources/templates/admin/reports/list.html
+++ b/backend/src/main/resources/templates/admin/reports/list.html
@@ -174,6 +174,7 @@
 					<th scope="col" th:attr="aria-sort=${createdSort.ariaSort}">
 						<a th:href="${createdSort.href}" th:attr="hx-get=${createdSort.href}">접수일</a>
 					</th>
+					<th scope="col">경과</th>
 					<th scope="col">좌표</th>
 					<th scope="col">사진</th>
 					<th scope="col">상세</th>
@@ -181,7 +182,7 @@
 				</thead>
 				<tbody>
 				<tr th:if="${reports.isEmpty()}">
-					<td class="empty" colspan="10">
+					<td class="empty" colspan="11">
 						<div th:replace="~{admin/fragments/empty-state :: panel('확인할 신고가 없습니다.', '검색어·상태·기간 필터를 조정해 보세요.')}"></div>
 					</td>
 				</tr>
@@ -197,6 +198,12 @@
 					<td th:text="${report.stationLabel}">상록수(station-id)</td>
 					<td th:text="${report.facilityLabel}">엘리베이터(facility-id)</td>
 					<td th:text="${#temporals.format(report.createdAt, 'yyyy-MM-dd HH:mm')}">2026-06-17 09:00</td>
+					<td>
+						<!-- SLA 경과 뱃지(#1740): 대기 상태가 24h/72h를 넘기면 표시, 아니면 빈 칸. -->
+						<th:block th:if="${!report.slaTone.isEmpty()}">
+							<span th:replace="~{admin/fragments/shell :: status(${report.slaLabel}, ${report.slaTone})}">경과</span>
+						</th:block>
+					</td>
 					<td th:text="${report.coordinateLabel}">위치 없음</td>
 					<td th:text="${report.hasPhoto ? '있음' : '없음'}">없음</td>
 					<td>

--- a/backend/src/main/resources/templates/admin/reports/list.html
+++ b/backend/src/main/resources/templates/admin/reports/list.html
@@ -146,7 +146,7 @@
 		  일괄 검수(#1737): 체크박스로 선택한 신고를 한 번에 승인/반려한다. command token + CSRF POST.
 		  진화형 향상 — JS 없으면 체크박스 + 액션 버튼이 그대로 동작하고, 있으면 전체 선택·선택 수 표시가 붙는다.
 		-->
-		<div class="report-table" x-data="reportTable">
+		<div class="report-table" x-data="reportTable" x-on:keydown.window="handleKey">
 			<!--
 			  표 보기 설정(#1737): 밀도 3단·컬럼 표시 토글. 순수 표시 설정이라 폼 밖에 두어 제출되지 않는다.
 			  진화형 향상 — JS 없으면 기본 밀도·전체 컬럼으로 보이고, 있으면 즉시 반영된다(CSP: 메서드 참조만).
@@ -163,6 +163,10 @@
 					<label><input type="checkbox" x-on:change="toggleCoordinate"> 좌표 숨김</label>
 					<label><input type="checkbox" x-on:change="togglePhoto"> 사진 숨김</label>
 				</fieldset>
+				<!-- 단축키 도움말(#1740): 버튼으로도 여닫아 스크린리더·마우스 사용자도 접근한다. no-JS는 x-cloak로 숨김. -->
+				<button type="button" class="shortcut-help-trigger" x-cloak
+				        x-on:click="toggleHelp" x-bind:aria-expanded="helpExpanded"
+				        aria-label="키보드 단축키 도움말 열기">단축키 <kbd>?</kbd></button>
 			</div>
 			<form class="bulk-form" method="post" th:action="@{/admin/reports/bulk-review}">
 				<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
@@ -196,7 +200,7 @@
 						<div th:replace="~{admin/fragments/empty-state :: panel('확인할 신고가 없습니다.', '검색어·상태·기간 필터를 조정해 보세요.')}"></div>
 					</td>
 				</tr>
-				<tr th:each="report : ${reports}">
+				<tr class="report-row" th:each="report : ${reports}">
 					<td class="select-col">
 						<input type="checkbox" name="reportIds" th:value="${report.id}"
 						       aria-label="신고 선택"
@@ -245,6 +249,25 @@
 				<button type="submit" name="decision" value="REJECT">선택 반려</button>
 			</div>
 			</form>
+			<!--
+			  키보드 단축키 도움말 오버레이(#1740): ? 또는 도움말 버튼으로 열고 Esc·닫기 버튼으로 닫는다.
+			  x-cloak로 JS 준비 전·no-JS에서는 숨긴다(단축키 자체가 JS 전용이라 no-JS엔 불필요).
+			-->
+			<div class="shortcut-help" x-cloak x-show="helpVisible" role="dialog" aria-modal="true"
+			     aria-label="키보드 단축키 도움말">
+				<div class="shortcut-help-panel">
+					<h2>키보드 단축키</h2>
+					<ul>
+						<li><kbd>j</kbd> / <kbd>k</kbd> 다음 / 이전 신고</li>
+						<li><kbd>o</kbd> / <kbd>Enter</kbd> 상세 패널 열기</li>
+						<li><kbd>a</kbd> 활성 신고 승인</li>
+						<li><kbd>r</kbd> 활성 신고 반려</li>
+						<li><kbd>Esc</kbd> 패널 · 도움말 닫기</li>
+						<li><kbd>?</kbd> 이 도움말 열기 / 닫기</li>
+					</ul>
+					<button type="button" x-on:click="hideHelp">닫기</button>
+				</div>
+			</div>
 		</div>
 
 		<!-- 페이지네이션은 공용 pager fragment(hx-get 없음)라 이 파일럿에서는 전체 새로고침으로 동작한다.

--- a/backend/src/main/resources/templates/admin/reports/list.html
+++ b/backend/src/main/resources/templates/admin/reports/list.html
@@ -51,16 +51,26 @@
 	-->
 	<div id="report-results" th:fragment="reportResults"
 	     hx-target="#report-results" hx-swap="outerHTML" hx-push-url="true">
-		<!-- 검색 툴바(#1737): 키워드 live search. JS 있으면 300ms debounce htmx 부분 갱신,
-		     없으면 form GET 제출로 동일 동작. 상태·정렬·기간은 hidden으로 유지된다. -->
+		<!-- 검색 툴바(#1737·#1740): 키워드 live search + 유형·사진 유무 select. JS 있으면 keyword는
+		     300ms debounce, select 변경(change)은 즉시 htmx 부분 갱신, 없으면 form GET 제출로 동일 동작.
+		     상태·정렬·기간·역은 hidden으로 유지된다(select·검색이 다른 필터를 덮어쓰지 않게). -->
 		<form class="table-toolbar" method="get" th:action="@{/admin/reports/page}"
 		      role="search" aria-label="신고 검색"
 		      hx-target="#report-results" hx-swap="outerHTML" hx-push-url="true"
 		      th:attr="hx-get=@{/admin/reports/page}"
-		      hx-trigger="submit, keyup changed delay:300ms">
+		      hx-trigger="submit, change, keyup changed delay:300ms">
 			<input type="search" name="keyword" th:value="${searchKeyword}"
 			       placeholder="신고 내용 검색" aria-label="신고 내용 검색" autocomplete="off">
+			<select name="type" aria-label="신고 유형 필터">
+				<option th:each="opt : ${typeFilters}" th:value="${opt.value}"
+				        th:text="${opt.label}" th:selected="${opt.selected}">전체 유형</option>
+			</select>
+			<select name="hasPhoto" aria-label="사진 유무 필터">
+				<option th:each="opt : ${photoFilters}" th:value="${opt.value}"
+				        th:text="${opt.label}" th:selected="${opt.selected}">사진 전체</option>
+			</select>
 			<input type="hidden" name="status" th:if="${selectedStatus != null}" th:value="${selectedStatus}">
+			<input type="hidden" name="station" th:if="${selectedStation != null}" th:value="${selectedStation}">
 			<input type="hidden" name="sort" th:if="${sortParam != null}" th:value="${sortParam}">
 			<input type="hidden" name="from" th:if="${createdFrom != null}" th:value="${createdFrom}">
 			<input type="hidden" name="to" th:if="${createdTo != null}" th:value="${createdTo}">

--- a/backend/src/main/resources/templates/admin/reports/list.html
+++ b/backend/src/main/resources/templates/admin/reports/list.html
@@ -215,7 +215,20 @@
 						</th:block>
 					</td>
 					<td th:text="${report.coordinateLabel}">위치 없음</td>
-					<td th:text="${report.hasPhoto ? '있음' : '없음'}">없음</td>
+					<td>
+						<!-- 사진 썸네일(#1740): 첨부가 있고 사진 열람 권한(REPORT_PHOTO_READ)이 있으면 썸네일을
+						     보여주고 클릭 시 원본으로 이동한다. 권한이 없으면 '있음' 텍스트만(썸네일 endpoint 403). -->
+						<th:block th:if="${report.hasPhoto}">
+							<a th:if="${canReadPhoto}" class="report-thumb"
+							   th:href="@{/admin/reports/{reportId}/photo/original(reportId=${report.id})}"
+							   th:attr="aria-label=|${report.stationLabel} 신고 사진 원본 보기|">
+								<img th:src="@{/admin/reports/{reportId}/photo/thumbnail(reportId=${report.id})}"
+								     alt="신고 사진 미리보기" loading="lazy" width="48" height="48">
+							</a>
+							<span th:unless="${canReadPhoto}">있음</span>
+						</th:block>
+						<span th:unless="${report.hasPhoto}">없음</span>
+					</td>
 					<td>
 						<!-- 드로어로 열되(hx-target 오버라이드) no-JS는 상세 페이지로 이동. hx-push-url=false로 URL 유지 -->
 						<a class="detail-link"

--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageControllerTest.java
@@ -109,6 +109,28 @@ class FacilityReportAdminPageControllerTest {
 	}
 
 	@Test
+	@DisplayName("신고 대기열은 키보드 단축키 도움말과 버튼 대체 수단을 함께 제공한다")
+	void adminReportListPageExposesKeyboardShortcutAffordances() throws Exception {
+		createReport("단축키 대상 신고");
+
+		String html = mockMvc.perform(get("/admin/reports/page")
+				.with(httpBasic("admin-test", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn().getResponse().getContentAsString();
+
+		assertThat(html)
+			// 키보드 리스너·행 마커·단축키 도움말이 렌더된다(런타임 키 동작은 #1749 접근성 QA에서 검증).
+			.contains("x-on:keydown.window=\"handleKey\"")
+			.contains("class=\"report-row\"")
+			.contains("키보드 단축키")
+			// 스크린리더·no-JS를 위해 모든 단축키 동작은 버튼으로도 존재한다: 상세(o)·승인(a)·반려(r)·도움말(?).
+			.contains(">상세 보기</a>")
+			.contains("value=\"ACCEPT\"")
+			.contains("value=\"REJECT\"")
+			.contains("단축키 도움말 열기");
+	}
+
+	@Test
 	@DisplayName("관리자는 신고 목록 화면에서 다음 페이지로 이동한다")
 	void adminReportListPageShowsNextPageLink() throws Exception {
 		createReport("페이지 이동 신고 1");

--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageControllerTest.java
@@ -265,6 +265,27 @@ class FacilityReportAdminPageControllerTest {
 	}
 
 	@Test
+	@DisplayName("신고 상세는 역·시설 이름을 보여주고 같은 시설 신고 목록을 노출한다")
+	void adminReportDetailShowsLabelsAndSameFacilityReports() throws Exception {
+		String first = createReport("첫 신고");
+		String second = createReport("같은 시설 두 번째 신고");
+
+		String html = mockMvc.perform(get("/admin/reports/{reportId}/page", first)
+				.with(httpBasic("admin-test", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn().getResponse().getContentAsString();
+
+		assertThat(html)
+			// 원시 ID 단독 노출 제거: '역 ID'/'시설 ID' 라벨 대신 역·시설 이름(코드).
+			.doesNotContain("역 ID")
+			.doesNotContain("시설 ID")
+			// 같은 시설 신고 목록에 다른 신고와 상세 크로스링크가 뜬다(현재 신고는 제외).
+			.contains("같은 시설 신고")
+			.contains("같은 시설 두 번째 신고")
+			.contains("/admin/reports/%s/page".formatted(second));
+	}
+
+	@Test
 	@DisplayName("관리자는 시설 상태 증거가 아닌 신고에서 override 링크를 보지 않는다")
 	void adminReportDetailPageHidesOverrideLinkForNonFacilityStatusEvidence() throws Exception {
 		String reportId = createReport("경로가 막힌 신고", "ROUTE_BLOCKED", "");

--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageControllerTest.java
@@ -70,6 +70,45 @@ class FacilityReportAdminPageControllerTest {
 	}
 
 	@Test
+	@DisplayName("관리자는 유형·사진·역 필터로 신고 대기열을 좁힌다")
+	void adminReportListPageFiltersByTypeStationAndPhoto() throws Exception {
+		createReportWithPhotoAndLocation("사진 있는 고장 신고");
+		createReport("사진 없는 정보 오류 신고", "INFORMATION_WRONG", "");
+
+		// 유형 필터: INFORMATION_WRONG만 남기고 필터·페이지 링크에 type 파라미터가 유지된다.
+		String typeFiltered = mockMvc.perform(get("/admin/reports/page")
+				.param("type", "INFORMATION_WRONG")
+				.with(httpBasic("admin-test", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn().getResponse().getContentAsString();
+		assertThat(typeFiltered)
+			.contains("사진 없는 정보 오류 신고")
+			.doesNotContain("사진 있는 고장 신고")
+			.contains("type=INFORMATION_WRONG");
+
+		// 사진 유무 필터: 사진 있는 신고만 남는다.
+		String photoFiltered = mockMvc.perform(get("/admin/reports/page")
+				.param("hasPhoto", "true")
+				.with(httpBasic("admin-test", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn().getResponse().getContentAsString();
+		assertThat(photoFiltered)
+			.contains("사진 있는 고장 신고")
+			.doesNotContain("사진 없는 정보 오류 신고")
+			.contains("hasPhoto=true");
+
+		// 역 필터: 매칭되지 않는 역으로 좁히면 빈 상태 + 제거 가능한 역 칩이 뜬다.
+		String stationFiltered = mockMvc.perform(get("/admin/reports/page")
+				.param("station", "station-none")
+				.with(httpBasic("admin-test", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn().getResponse().getContentAsString();
+		assertThat(stationFiltered)
+			.contains("확인할 신고가 없습니다.")
+			.contains("역: station-none");
+	}
+
+	@Test
 	@DisplayName("관리자는 신고 목록 화면에서 다음 페이지로 이동한다")
 	void adminReportListPageShowsNextPageLink() throws Exception {
 		createReport("페이지 이동 신고 1");

--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageControllerTest.java
@@ -303,6 +303,32 @@ class FacilityReportAdminPageControllerTest {
 	}
 
 	@Test
+	@DisplayName("사진 열람 권한이 있는 관리자만 목록에서 썸네일을 본다")
+	void adminReportListShowsPhotoThumbnailOnlyWithReadPermission() throws Exception {
+		String reportId = createReportWithPhotoAndLocation("썸네일로 확인할 신고");
+
+		// 사진 열람 권한이 있는 계정(admin-test): 썸네일 img + 원본 링크 노출.
+		String withPermission = mockMvc.perform(get("/admin/reports/page")
+				.with(httpBasic("admin-test", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn().getResponse().getContentAsString();
+		assertThat(withPermission)
+			.contains("/admin/reports/%s/photo/thumbnail".formatted(reportId))
+			.contains("/admin/reports/%s/photo/original".formatted(reportId));
+
+		// 검수 권한만 있고 사진 열람 권한이 없는 계정: 썸네일 미노출, '있음' 텍스트만.
+		RequestPostProcessor reportReviewer = user("report-reviewer")
+			.authorities(new SimpleGrantedAuthority(AdminPermission.REPORT_REVIEW.authority()));
+		String withoutPermission = mockMvc.perform(get("/admin/reports/page")
+				.with(reportReviewer))
+			.andExpect(status().isOk())
+			.andReturn().getResponse().getContentAsString();
+		assertThat(withoutPermission)
+			.doesNotContain("/admin/reports/%s/photo/thumbnail".formatted(reportId))
+			.contains("있음");
+	}
+
+	@Test
 	@DisplayName("관리자 신고 사진 조회는 object key query endpoint를 열지 않는다")
 	void adminReportPhotoQueryEndpointIsNotExposed() throws Exception {
 		createReportWithPhotoAndLocation("object key 조회를 막을 신고");

--- a/backend/src/test/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportRepositoryTest.java
@@ -488,6 +488,64 @@ class JdbcFacilityReportRepositoryTest {
 		assertThat(repository.countReports(withPhoto)).isEqualTo(1L);
 	}
 
+	@Test
+	@DisplayName("같은 시설 신고 조회는 역·시설이 일치하는 신고만 최신순으로 돌려준다")
+	void loadReportsForFacilityReturnsMatchingReportsNewestFirst() {
+		repository.saveReport(reportAtFacility("f1-old", "station-a", "facility-1",
+			LocalDateTime.of(2026, 6, 17, 8, 0)));
+		repository.saveReport(reportAtFacility("f1-new", "station-a", "facility-1",
+			LocalDateTime.of(2026, 6, 17, 10, 0)));
+		repository.saveReport(reportAtFacility("f2", "station-a", "facility-2",
+			LocalDateTime.of(2026, 6, 17, 9, 0)));
+		repository.saveReport(reportAtFacility("other-station", "station-b", "facility-1",
+			LocalDateTime.of(2026, 6, 17, 9, 0)));
+
+		assertThat(repository.loadReportsForFacility("station-a", "facility-1", 10))
+			.extracting(FacilityReportSummary::id)
+			.containsExactly("f1-new", "f1-old");
+	}
+
+	@Test
+	@DisplayName("같은 시설 신고 조회는 limit로 상한을 둔다")
+	void loadReportsForFacilityRespectsLimit() {
+		repository.saveReport(reportAtFacility("a", "station-a", "facility-1",
+			LocalDateTime.of(2026, 6, 17, 8, 0)));
+		repository.saveReport(reportAtFacility("b", "station-a", "facility-1",
+			LocalDateTime.of(2026, 6, 17, 9, 0)));
+		repository.saveReport(reportAtFacility("c", "station-a", "facility-1",
+			LocalDateTime.of(2026, 6, 17, 10, 0)));
+
+		assertThat(repository.loadReportsForFacility("station-a", "facility-1", 2))
+			.extracting(FacilityReportSummary::id)
+			.containsExactly("c", "b");
+	}
+
+	private FacilityReport reportAtFacility(
+		String reportId,
+		String stationId,
+		String facilityId,
+		LocalDateTime createdAt
+	) {
+		return new FacilityReport(
+			reportId,
+			"anonymous-user-1",
+			stationId,
+			facilityId,
+			FacilityReportType.BROKEN,
+			"신고 내용",
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			FacilityReportStatus.SUBMITTED,
+			createdAt,
+			null,
+			null
+		);
+	}
+
 	private FacilityReport reportWith(
 		String reportId,
 		String stationId,

--- a/backend/src/test/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportRepositoryTest.java
@@ -358,11 +358,11 @@ class JdbcFacilityReportRepositoryTest {
 			LocalDateTime.of(2026, 6, 17, 10, 0)));
 
 		var page = repository.loadReportSummaries(
-			FacilityReportListQuery.of(null, "elevator", null, null, null, 0, 20));
+			FacilityReportListQuery.of(null, "elevator", null, null, null, null, null, null, 0, 20));
 
 		assertThat(page.items()).extracting(FacilityReportSummary::id).containsExactly("r-1");
 		assertThat(repository.countReports(
-			FacilityReportListQuery.of(null, "elevator", null, null, null, 0, 20))).isEqualTo(1L);
+			FacilityReportListQuery.of(null, "elevator", null, null, null, null, null, null, 0, 20))).isEqualTo(1L);
 	}
 
 	@Test
@@ -374,7 +374,7 @@ class JdbcFacilityReportRepositoryTest {
 			LocalDateTime.of(2026, 6, 17, 10, 0)));
 
 		var percentPage = repository.loadReportSummaries(
-			FacilityReportListQuery.of(null, "10%", null, null, null, 0, 20));
+			FacilityReportListQuery.of(null, "10%", null, null, null, null, null, null, 0, 20));
 		assertThat(percentPage.items()).extracting(FacilityReportSummary::id).containsExactly("pct-hit");
 
 		repository.saveReport(reportAt("us-hit", "a_b 코드 오류", FacilityReportStatus.SUBMITTED,
@@ -382,7 +382,7 @@ class JdbcFacilityReportRepositoryTest {
 		repository.saveReport(reportAt("us-miss", "axb 코드 오류", FacilityReportStatus.SUBMITTED,
 			LocalDateTime.of(2026, 6, 17, 12, 0)));
 		var underscorePage = repository.loadReportSummaries(
-			FacilityReportListQuery.of(null, "a_b", null, null, null, 0, 20));
+			FacilityReportListQuery.of(null, "a_b", null, null, null, null, null, null, 0, 20));
 		assertThat(underscorePage.items()).extracting(FacilityReportSummary::id).containsExactly("us-hit");
 	}
 
@@ -397,7 +397,8 @@ class JdbcFacilityReportRepositoryTest {
 			LocalDateTime.of(2026, 6, 19, 1, 0)));
 
 		var page = repository.loadReportSummaries(FacilityReportListQuery.of(
-			null, null, java.time.LocalDate.of(2026, 6, 16), java.time.LocalDate.of(2026, 6, 18), null, 0, 20));
+			null, null, null, null, null,
+			java.time.LocalDate.of(2026, 6, 16), java.time.LocalDate.of(2026, 6, 18), null, 0, 20));
 
 		assertThat(page.items()).extracting(FacilityReportSummary::id).containsExactly("r-17");
 	}
@@ -411,7 +412,7 @@ class JdbcFacilityReportRepositoryTest {
 			LocalDateTime.of(2026, 6, 17, 8, 0)));
 
 		var page = repository.loadReportSummaries(
-			FacilityReportListQuery.of(null, null, null, null, "created_at,asc", 0, 20));
+			FacilityReportListQuery.of(null, null, null, null, null, null, null, "created_at,asc", 0, 20));
 
 		assertThat(page.items()).extracting(FacilityReportSummary::id).containsExactly("r-old", "r-new");
 	}
@@ -427,12 +428,91 @@ class JdbcFacilityReportRepositoryTest {
 			LocalDateTime.of(2026, 6, 17, 10, 0)));
 
 		var query = FacilityReportListQuery.of(
-			FacilityReportStatus.SUBMITTED, "신고", null, null, null, 0, 20);
+			FacilityReportStatus.SUBMITTED, "신고", null, null, null, null, null, null, 0, 20);
 
 		assertThat(repository.loadReportSummaries(query).items())
 			.extracting(FacilityReportSummary::id)
 			.containsExactlyInAnyOrder("s-1", "s-2");
 		assertThat(repository.countReports(query)).isEqualTo(2L);
+	}
+
+	@Test
+	@DisplayName("검색 질의는 역 식별자로 신고를 거른다")
+	void searchFiltersByStationId() {
+		repository.saveReport(reportWith("sang-1", "station-sangnoksu", FacilityReportType.BROKEN, false,
+			LocalDateTime.of(2026, 6, 17, 9, 0)));
+		repository.saveReport(reportWith("hanl-1", "station-hanlim", FacilityReportType.BROKEN, false,
+			LocalDateTime.of(2026, 6, 17, 10, 0)));
+
+		var query = FacilityReportListQuery.of(
+			null, null, "station-sangnoksu", null, null, null, null, null, 0, 20);
+
+		assertThat(repository.loadReportSummaries(query).items())
+			.extracting(FacilityReportSummary::id).containsExactly("sang-1");
+		assertThat(repository.countReports(query)).isEqualTo(1L);
+	}
+
+	@Test
+	@DisplayName("검색 질의는 신고 유형으로 거른다")
+	void searchFiltersByReportType() {
+		repository.saveReport(reportWith("broken-1", "station-sangnoksu", FacilityReportType.BROKEN, false,
+			LocalDateTime.of(2026, 6, 17, 9, 0)));
+		repository.saveReport(reportWith("info-1", "station-sangnoksu", FacilityReportType.INFORMATION_WRONG, false,
+			LocalDateTime.of(2026, 6, 17, 10, 0)));
+
+		var query = FacilityReportListQuery.of(
+			null, null, null, FacilityReportType.INFORMATION_WRONG, null, null, null, null, 0, 20);
+
+		assertThat(repository.loadReportSummaries(query).items())
+			.extracting(FacilityReportSummary::id).containsExactly("info-1");
+		assertThat(repository.countReports(query)).isEqualTo(1L);
+	}
+
+	@Test
+	@DisplayName("검색 질의는 사진 유무로 거른다")
+	void searchFiltersByPhotoPresence() {
+		repository.saveReport(reportWith("with-photo", "station-sangnoksu", FacilityReportType.BROKEN, true,
+			LocalDateTime.of(2026, 6, 17, 9, 0)));
+		repository.saveReport(reportWith("no-photo", "station-sangnoksu", FacilityReportType.BROKEN, false,
+			LocalDateTime.of(2026, 6, 17, 10, 0)));
+
+		var withPhoto = FacilityReportListQuery.of(
+			null, null, null, null, true, null, null, null, 0, 20);
+		var withoutPhoto = FacilityReportListQuery.of(
+			null, null, null, null, false, null, null, null, 0, 20);
+
+		assertThat(repository.loadReportSummaries(withPhoto).items())
+			.extracting(FacilityReportSummary::id).containsExactly("with-photo");
+		assertThat(repository.loadReportSummaries(withoutPhoto).items())
+			.extracting(FacilityReportSummary::id).containsExactly("no-photo");
+		assertThat(repository.countReports(withPhoto)).isEqualTo(1L);
+	}
+
+	private FacilityReport reportWith(
+		String reportId,
+		String stationId,
+		FacilityReportType reportType,
+		boolean withPhoto,
+		LocalDateTime createdAt
+	) {
+		return new FacilityReport(
+			reportId,
+			"anonymous-user-1",
+			stationId,
+			"facility-elevator-1",
+			reportType,
+			"신고 내용",
+			withPhoto ? "photo.jpg" : null,
+			withPhoto ? "image/jpeg" : null,
+			withPhoto ? "photo-object-key" : null,
+			null,
+			null,
+			null,
+			FacilityReportStatus.SUBMITTED,
+			createdAt,
+			null,
+			null
+		);
 	}
 
 	private FacilityReport reportAt(

--- a/backend/src/test/java/com/easysubway/report/domain/ReportSlaBadgeTest.java
+++ b/backend/src/test/java/com/easysubway/report/domain/ReportSlaBadgeTest.java
@@ -1,0 +1,56 @@
+package com.easysubway.report.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("제보 SLA 경과 뱃지")
+class ReportSlaBadgeTest {
+
+	private static final LocalDateTime NOW = LocalDateTime.of(2026, 7, 5, 12, 0);
+
+	@Test
+	@DisplayName("대기 상태가 72시간을 넘기면 위반(bad) 뱃지를 준다")
+	void breachAfter72Hours() {
+		ReportSlaBadge badge = ReportSlaBadge.of(
+			FacilityReportStatus.SUBMITTED, NOW.minusHours(80), NOW);
+
+		assertThat(badge.present()).isTrue();
+		assertThat(badge.label()).isEqualTo("72시간 초과");
+		assertThat(badge.tone()).isEqualTo("bad");
+	}
+
+	@Test
+	@DisplayName("대기 상태가 24시간을 넘기면 경고(warn) 뱃지를 준다")
+	void warnAfter24Hours() {
+		ReportSlaBadge badge = ReportSlaBadge.of(
+			FacilityReportStatus.UNDER_REVIEW, NOW.minusHours(30), NOW);
+
+		assertThat(badge.label()).isEqualTo("24시간 초과");
+		assertThat(badge.tone()).isEqualTo("warn");
+	}
+
+	@Test
+	@DisplayName("24시간 미만이면 뱃지가 없다")
+	void noneWithinThreshold() {
+		assertThat(ReportSlaBadge.of(FacilityReportStatus.SUBMITTED, NOW.minusHours(10), NOW).present())
+			.isFalse();
+	}
+
+	@Test
+	@DisplayName("종결 상태는 경과가 길어도 뱃지가 없다")
+	void terminalStatusHasNoBadge() {
+		assertThat(ReportSlaBadge.of(FacilityReportStatus.ACCEPTED, NOW.minusHours(100), NOW).present())
+			.isFalse();
+		assertThat(ReportSlaBadge.of(FacilityReportStatus.DUPLICATE, NOW.minusHours(100), NOW).present())
+			.isFalse();
+	}
+
+	@Test
+	@DisplayName("접수 시간이 없으면 뱃지가 없다")
+	void nullCreatedAtHasNoBadge() {
+		assertThat(ReportSlaBadge.of(FacilityReportStatus.SUBMITTED, null, NOW).present()).isFalse();
+	}
+}


### PR DESCRIPTION
## 관련 이슈

close #1740

## 작업 배경

제보 확인 대기열(`/admin/reports/page`)을 상용 모더레이션 큐 수준으로 끌어올린다. 목표는 **건당 처리 시간 단축** — 모더레이터가 마우스 왕복 없이 필터→확인→처리→다음 건으로 흐르게 한다(Reddit modqueue·모더레이션 API 공통 패턴). 기존에 검색·기간·상태 필터·저장된 뷰·일괄 검수·드로어(#1737)는 있었고, 이번 PR은 남은 격차(SLA·역/유형/사진 필터·썸네일·키보드·리치 드로어)를 채운다.

## 작업 내용

- **SLA 경과 뱃지**(1/N): 대기 상태(SUBMITTED·UNDER_REVIEW) 제보가 접수 후 24h/72h 초과 시 경과 뱃지. 종결 상태는 비움. `ReportSlaBadge` 도메인 + 뱃지 열.
- **역·유형·사진 유무 필터**(2/N): `FacilityReportListQuery`에 `stationId·reportType·hasPhoto` 추가. 유형·사진은 툴바 select(빈 옵션=전체), 역은 딥링크+제거 칩(#1741 허브 크로스링크 대비). JDBC 동적 WHERE + InMemory 병렬 필터로 시맨틱 일치. `hrefWith(query, overrides)`로 링크 조립 리팩터링.
- **사진 썸네일**(3/N): 목록 사진 열을 '있음/없음' 텍스트 → 48px 썸네일(클릭 시 원본). `REPORT_PHOTO_READ`(V15) 권한 게이팅 — 권한 없으면 '있음' 텍스트(썸네일 endpoint 403 회피).
- **키보드 단축키**(4/N): `j/k` 행 이동·`o`/Enter 상세 열기·`a` 승인·`r` 반려·`Esc` 닫기·`?` 도움말. Alpine CSP 컴포넌트(메서드/게터 이름만), 입력·select 포커스 중 비활성. 모든 동작은 버튼으로도 존재(스크린리더·no-JS).
- **리치 드로어**(5/N): 상세/드로어 역·시설을 원시 ID → "이름(코드)"로 해석(원시 ID 단독 노출 0건), 상세 사진도 권한 게이팅, "같은 시설 신고" 목록(현재 제외·최신순·상세 크로스링크). `loadReportsForFacility(limit)` 포트 추가(#1163 병합과 독립 읽기 전용).

## 검증

- 실행한 명령과 결과:
  - `cd backend && ./gradlew test` → **BUILD SUCCESSFUL** (전체 스위트, 1m58s)
  - `node --test tools/ci/repository-contract.test.mjs` → **158 pass / 0 fail**
  - main 머지 재현: `git merge origin/main --no-commit --no-ff` → 충돌 없음(main 변경은 전부 모바일/route-map), 병합 트리에서 계약 158 pass + `./gradlew compileJava` exit 0 → abort
  - 신규 테스트: JDBC 역·유형·사진·같은시설·limit 필터 5건, MockMvc 유형/사진/역 필터·권한별 썸네일·키보드 대체수단·상세 라벨/같은시설 6건, `ReportSlaBadgeTest`

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 필터·SLA·썸네일 권한·상세 라벨 렌더 | backend | MockMvc 풀페이지/드로어 fragment 렌더 assert | `FacilityReportAdminPageControllerTest` | ✅ 통과 |
| 필터·같은시설 질의 SQL 정합 | backend | JDBC(H2 PostgreSQL 모드) 저장소 테스트 | `JdbcFacilityReportRepositoryTest` | ✅ 통과 |
| SLA 임계 판정 | backend | 도메인 단위 테스트 | `ReportSlaBadgeTest` | ✅ 통과 |
| 키보드 런타임 동작·스크린리더·키보드만 완주 E2E | web | 브라우저 필요(Claude Chrome 미연결) | 자동 테스트는 버튼 대체수단·도움말 렌더만 커버 | ⏭ #1749 접근성 QA 이월 |
| 시각/썸네일 이미지 렌더 | web | 브라우저 필요 | HTTP 라이브 미수행 | ⏭ #1749 이월 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 관리자 콘솔 화면·조회 로직만 변경(신규 마이그레이션 없음, 계약 불변). 백엔드 재배포만 필요.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `FacilityReportAdminPageController#hrefWith(query, overrides)` — 필터 차원 확장에 따라 8개 위치 인자 대신 override 맵 방식으로 리팩터링. 기존 링크(상태·기간·정렬·칩)가 새 차원(역·유형·사진)을 항상 유지하는지.
  - 필터 툴바 select의 빈 "전체" 옵션 — Spring `StringToEnum`/`StringToBoolean` 변환기가 빈 문자열을 null로 변환하므로 `type=`·`hasPhoto=` 빈 제출이 400이 아니라 필터 해제로 동작.
  - 사진 열람 권한 게이팅 — 목록·상세 모두 `canReadPhoto`(=`admin.report.photo.read`)로 썸네일 노출 제어, endpoint `@PreAuthorize`와 동일 권한.
  - `loadReportsForFacility`는 `LIMIT ?`로 상한(20), 현재 신고는 컨트롤러에서 제외.

## 리스크

- 키보드 단축키·썸네일 이미지 렌더는 브라우저 런타임 검증이 필요하나 Claude Chrome 미연결로 이번 PR에서 미수행 → #1749 접근성 QA로 이월(자동 테스트는 버튼 대체수단·no-JS fallback·권한 게이팅만 커버). 완료 조건의 "키보드만으로 완주 E2E"·스크린리더 낭독도 #1749에서 최종 확인.
- 역 필터는 딥링크+칩 방식으로, 전국 역 select는 비현실적이라 채택하지 않음. #1741 역 허브 크로스링크는 허브 미구현으로 후속.
- 신규 마이그레이션 없음 — SLA 임계값은 상수(24/72h)로 처리(이슈의 공통코드 override는 후속).

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (backend deploy only — 병합 후 CD 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 신고 목록에 역, 유형, 사진 유무 필터가 추가되고, 같은 시설의 다른 신고를 함께 볼 수 있게 되었습니다.
  * 신고 상태에 따라 경과 시간이 표시되는 배지가 추가되었습니다.
  * 관리자 화면에 키보드 단축키 도움말과 빠른 조작 기능이 추가되었습니다.

* **Bug Fixes**
  * 목록/상세 화면에서 선택한 필터와 현재 문맥이 더 일관되게 유지되도록 개선되었습니다.
  * 사진 권한에 따라 썸네일 표시가 정확히 분기되도록 수정되었습니다.

* **Style**
  * 관리자 목록과 상세 화면의 표/레이아웃이 일부 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->