### PR TITLE
[Chore] station-level 시간표 → trip 재구성 코어 (#1415)

### DIFF
--- a/tools/datapack/reconstruct-transit-trips.mjs
+++ b/tools/datapack/reconstruct-transit-trips.mjs
@@ -1,0 +1,137 @@
+// Provider-중립 trip 재구성 코어.
+//
+// 입력은 특정 provider(KRIC/TAGO) 응답이 아니라 정규화된 "중간 행" 계약이다:
+//   { stationId, lineId, trnNo, dayCd, arrivalSeconds, departureSeconds, servicePattern? }
+// provider 응답 → 중간 행 normalizer는 라이브 스키마가 확정된 뒤 별도 얇은 층으로 붙인다
+// (최악의 경우 코레일 구간이 TAGO 하이브리드가 되어도 이 코어와 검증은 그대로 재사용된다).
+//
+// 재구성은 (trnNo, dayCd) group-by로 결정적이다(휴리스틱 매칭 아님). 각 group이 한 trip이며,
+// 정차는 시각순으로 정렬되고 lineSequence가 방향당 단조(line-wide)임을 강제한다 — 이것이 기존
+// blocker(line_wide_trip_stop_sequence_validation_required)가 요구하는 검증이다.
+
+const DEFAULT_SERVICE_PATTERN = "LOCAL";
+
+export function reconstructTransitTrips(rows, context) {
+  const lineSequenceByStationLine = asLookup(context?.lineSequenceByStationLine, "lineSequenceByStationLine");
+  const routeIdByLineDirection = asLookup(context?.routeIdByLineDirection, "routeIdByLineDirection");
+  const serviceIdByDayCd = asLookup(context?.serviceIdByDayCd, "serviceIdByDayCd");
+
+  const groups = new Map();
+  for (const row of rows ?? []) {
+    requireRow(row);
+    const key = `${row.trnNo}|${row.dayCd}`;
+    if (!groups.has(key)) {
+      groups.set(key, []);
+    }
+    groups.get(key).push(row);
+  }
+
+  const transitTrips = [];
+  const transitStopTimes = [];
+
+  for (const key of [...groups.keys()].sort((left, right) => left.localeCompare(right))) {
+    const groupRows = groups.get(key);
+    const ordered = [...groupRows]
+      .map((row) => ({ ...row, lineSequence: resolveLineSequence(lineSequenceByStationLine, row) }))
+      .sort(
+        (left, right) =>
+          left.departureSeconds - right.departureSeconds ||
+          left.arrivalSeconds - right.arrivalSeconds ||
+          left.lineSequence - right.lineSequence,
+      );
+
+    if (ordered.length < 2) {
+      throw new Error(`reconstruct: trip must have at least 2 stops: ${key}`);
+    }
+
+    const directionId = validateLineWideOrderAndDirection(ordered, key);
+    const lineId = ordered[0].lineId;
+    const { trnNo, dayCd } = groupRows[0];
+    const routeId = requireMapping(routeIdByLineDirection, `${lineId}|${directionId}`, "route");
+    const serviceId = requireMapping(serviceIdByDayCd, dayCd, "serviceId");
+    const servicePattern = groupRows[0].servicePattern ?? DEFAULT_SERVICE_PATTERN;
+    const tripId = `${routeId}-${trnNo}-${dayCd}`;
+
+    transitTrips.push({
+      id: tripId,
+      routeId,
+      serviceId,
+      tripHeadsign: ordered[ordered.length - 1].stationId,
+      directionId,
+      servicePattern,
+    });
+    ordered.forEach((row, index) => {
+      transitStopTimes.push({
+        tripId,
+        stopSequence: index + 1,
+        stationId: row.stationId,
+        lineId: row.lineId,
+        arrivalSeconds: row.arrivalSeconds,
+        departureSeconds: row.departureSeconds,
+      });
+    });
+  }
+
+  return { transitTrips, transitStopTimes };
+}
+
+// 시각순으로 정렬된 정차들이 lineSequence 기준 방향당 단조인지 강제하고 방향을 도출한다.
+// (zigzag/loop-wrap 같은 비단조 패턴은 거부 — 기존 line-wide 검증과 동일한 계약.)
+function validateLineWideOrderAndDirection(ordered, key) {
+  let direction = 0;
+  for (let index = 1; index < ordered.length; index += 1) {
+    const delta = ordered[index].lineSequence - ordered[index - 1].lineSequence;
+    if (delta === 0) {
+      throw new Error(`reconstruct: lineSequence must change between stops: ${key}`);
+    }
+    const step = Math.sign(delta);
+    if (direction === 0) {
+      direction = step;
+    } else if (step !== direction) {
+      throw new Error(`reconstruct: stop order must follow station lineSequence (line-wide): ${key}`);
+    }
+  }
+  return direction > 0 ? "up" : "down";
+}
+
+function resolveLineSequence(lookup, row) {
+  const value = lookup[`${row.stationId}|${row.lineId}`];
+  if (!Number.isInteger(value)) {
+    throw new Error(`reconstruct: unknown lineSequence for ${row.stationId}|${row.lineId}`);
+  }
+  return value;
+}
+
+function requireMapping(lookup, key, label) {
+  const value = lookup[key];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`reconstruct: no ${label} mapping for ${key}`);
+  }
+  return value;
+}
+
+function requireRow(row) {
+  for (const field of ["stationId", "lineId", "trnNo", "dayCd"]) {
+    if (typeof row?.[field] !== "string" || row[field].length === 0) {
+      throw new Error(`reconstruct: row missing field ${field}`);
+    }
+  }
+  for (const field of ["arrivalSeconds", "departureSeconds"]) {
+    if (!Number.isInteger(row[field]) || row[field] < 0) {
+      throw new Error(`reconstruct: row ${field} must be a non-negative integer`);
+    }
+  }
+  if (row.arrivalSeconds > row.departureSeconds) {
+    throw new Error(`reconstruct: arrivalSeconds must be <= departureSeconds: ${row.trnNo}|${row.stationId}`);
+  }
+}
+
+function asLookup(value, label) {
+  if (value instanceof Map) {
+    return Object.fromEntries(value);
+  }
+  if (value && typeof value === "object") {
+    return value;
+  }
+  throw new Error(`reconstruct: context.${label} is required`);
+}

--- a/tools/datapack/reconstruct-transit-trips.mjs
+++ b/tools/datapack/reconstruct-transit-trips.mjs
@@ -19,7 +19,8 @@ export function reconstructTransitTrips(rows, context) {
   const groups = new Map();
   for (const row of rows ?? []) {
     requireRow(row);
-    const key = `${row.trnNo}|${row.dayCd}`;
+    // lineId를 키에 포함 — 노선 간 동일 trnNo+dayCd 충돌로 다른 노선 정차가 한 trip으로 병합되는 것을 막는다.
+    const key = `${row.lineId}|${row.trnNo}|${row.dayCd}`;
     if (!groups.has(key)) {
       groups.set(key, []);
     }
@@ -49,7 +50,7 @@ export function reconstructTransitTrips(rows, context) {
     const { trnNo, dayCd } = groupRows[0];
     const routeId = requireMapping(routeIdByLineDirection, `${lineId}|${directionId}`, "route");
     const serviceId = requireMapping(serviceIdByDayCd, dayCd, "serviceId");
-    const servicePattern = groupRows[0].servicePattern ?? DEFAULT_SERVICE_PATTERN;
+    const servicePattern = resolveGroupServicePattern(groupRows, key);
     const tripId = `${routeId}-${trnNo}-${dayCd}`;
 
     transitTrips.push({
@@ -92,6 +93,16 @@ function validateLineWideOrderAndDirection(ordered, key) {
     }
   }
   return direction > 0 ? "up" : "down";
+}
+
+// 한 trip(그룹)의 servicePattern은 입력 순서가 아니라 그룹 값으로 결정한다. 값이 섞여 있으면
+// 데이터 오류이므로 거부하고, 없으면 LOCAL로 본다(결정적).
+function resolveGroupServicePattern(groupRows, key) {
+  const distinct = [...new Set(groupRows.map((row) => row.servicePattern).filter((value) => value != null && value !== ""))];
+  if (distinct.length > 1) {
+    throw new Error(`reconstruct: inconsistent servicePattern within trip ${key}: ${distinct.sort().join(", ")}`);
+  }
+  return distinct[0] ?? DEFAULT_SERVICE_PATTERN;
 }
 
 function resolveLineSequence(lookup, row) {

--- a/tools/datapack/reconstruct-transit-trips.mjs
+++ b/tools/datapack/reconstruct-transit-trips.mjs
@@ -57,7 +57,7 @@ export function reconstructTransitTrips(rows, context) {
       id: tripId,
       routeId,
       serviceId,
-      tripHeadsign: ordered[ordered.length - 1].stationId,
+      tripHeadsign: ordered.at(-1).stationId,
       directionId,
       servicePattern,
     });
@@ -100,7 +100,9 @@ function validateLineWideOrderAndDirection(ordered, key) {
 function resolveGroupServicePattern(groupRows, key) {
   const distinct = [...new Set(groupRows.map((row) => row.servicePattern).filter((value) => value != null && value !== ""))];
   if (distinct.length > 1) {
-    throw new Error(`reconstruct: inconsistent servicePattern within trip ${key}: ${distinct.sort().join(", ")}`);
+    throw new Error(
+      `reconstruct: inconsistent servicePattern within trip ${key}: ${[...distinct].sort((left, right) => left.localeCompare(right)).join(", ")}`,
+    );
   }
   return distinct[0] ?? DEFAULT_SERVICE_PATTERN;
 }
@@ -108,7 +110,7 @@ function resolveGroupServicePattern(groupRows, key) {
 function resolveLineSequence(lookup, row) {
   const value = lookup[`${row.stationId}|${row.lineId}`];
   if (!Number.isInteger(value)) {
-    throw new Error(`reconstruct: unknown lineSequence for ${row.stationId}|${row.lineId}`);
+    throw new TypeError(`reconstruct: unknown lineSequence for ${row.stationId}|${row.lineId}`);
   }
   return value;
 }

--- a/tools/datapack/reconstruct-transit-trips.test.mjs
+++ b/tools/datapack/reconstruct-transit-trips.test.mjs
@@ -138,3 +138,39 @@ test("재구성은 인접 정차의 lineSequence가 같으면 거부한다", () 
   ];
   assert.throws(() => reconstructTransitTrips(rows, ctx), /lineSequence must change/);
 });
+
+test("재구성은 다른 노선의 동일 trnNo+dayCd를 별도 trip으로 분리한다(lineId 키)", () => {
+  const ctx = {
+    lineSequenceByStationLine: {
+      "station-sadang|seoul-4": 28,
+      "station-sangnoksu|seoul-4": 43,
+      "station-a|seoul-2": 1,
+      "station-b|seoul-2": 2,
+    },
+    routeIdByLineDirection: {
+      "seoul-4|up": "route-seoul-4-oido",
+      "seoul-2|up": "route-seoul-2-inner",
+    },
+    serviceIdByDayCd: { "01": "weekday-2026" },
+  };
+  const rows = [
+    { stationId: "station-sadang", lineId: "seoul-4", trnNo: "100", dayCd: "01", arrivalSeconds: 30000, departureSeconds: 30000 },
+    { stationId: "station-sangnoksu", lineId: "seoul-4", trnNo: "100", dayCd: "01", arrivalSeconds: 31200, departureSeconds: 31200 },
+    { stationId: "station-a", lineId: "seoul-2", trnNo: "100", dayCd: "01", arrivalSeconds: 30000, departureSeconds: 30000 },
+    { stationId: "station-b", lineId: "seoul-2", trnNo: "100", dayCd: "01", arrivalSeconds: 30300, departureSeconds: 30300 },
+  ];
+  const { transitTrips } = reconstructTransitTrips(rows, ctx);
+  assert.equal(transitTrips.length, 2);
+  assert.deepEqual(
+    transitTrips.map((t) => t.routeId).sort(),
+    ["route-seoul-2-inner", "route-seoul-4-oido"],
+  );
+});
+
+test("재구성은 한 trip 안에서 servicePattern이 섞이면 거부한다(결정성 계약)", () => {
+  const rows = [
+    { stationId: "station-sadang", lineId: "seoul-4", trnNo: "M100", dayCd: "01", arrivalSeconds: 30000, departureSeconds: 30000, servicePattern: "LOCAL" },
+    { stationId: "station-sangnoksu", lineId: "seoul-4", trnNo: "M100", dayCd: "01", arrivalSeconds: 31200, departureSeconds: 31200, servicePattern: "EXPRESS" },
+  ];
+  assert.throws(() => reconstructTransitTrips(rows, CONTEXT), /inconsistent servicePattern/);
+});

--- a/tools/datapack/reconstruct-transit-trips.test.mjs
+++ b/tools/datapack/reconstruct-transit-trips.test.mjs
@@ -91,7 +91,7 @@ test("재구성은 dayCd(평일/토/휴일)를 별도 trip과 serviceId로 분�
   const { transitTrips } = reconstructTransitTrips(rows, CONTEXT);
   assert.equal(transitTrips.length, 3);
   assert.deepEqual(
-    transitTrips.map((t) => t.serviceId).sort(),
+    transitTrips.map((t) => t.serviceId).sort((left, right) => left.localeCompare(right)),
     ["holiday-2026", "saturday-2026", "weekday-2026"],
   );
 });
@@ -162,7 +162,7 @@ test("재구성은 다른 노선의 동일 trnNo+dayCd를 별도 trip으로 분�
   const { transitTrips } = reconstructTransitTrips(rows, ctx);
   assert.equal(transitTrips.length, 2);
   assert.deepEqual(
-    transitTrips.map((t) => t.routeId).sort(),
+    transitTrips.map((t) => t.routeId).sort((left, right) => left.localeCompare(right)),
     ["route-seoul-2-inner", "route-seoul-4-oido"],
   );
 });

--- a/tools/datapack/reconstruct-transit-trips.test.mjs
+++ b/tools/datapack/reconstruct-transit-trips.test.mjs
@@ -174,3 +174,48 @@ test("재구성은 한 trip 안에서 servicePattern이 섞이면 거부한다(�
   ];
   assert.throws(() => reconstructTransitTrips(rows, CONTEXT), /inconsistent servicePattern/);
 });
+
+test("재구성은 필수 필드 누락·잘못된 시각·arr>dep 행을 거부한다", () => {
+  const base = { stationId: "station-sadang", lineId: "seoul-4", trnNo: "E1", dayCd: "01", arrivalSeconds: 30000, departureSeconds: 30000 };
+  assert.throws(() => reconstructTransitTrips([{ ...base, stationId: "" }], CONTEXT), /missing field stationId/);
+  assert.throws(() => reconstructTransitTrips([{ ...base, arrivalSeconds: -1 }], CONTEXT), /arrivalSeconds must be a non-negative integer/);
+  assert.throws(() => reconstructTransitTrips([{ ...base, arrivalSeconds: 31000, departureSeconds: 30000 }], CONTEXT), /arrivalSeconds must be <= departureSeconds/);
+});
+
+test("재구성은 lineSequence·route·serviceId 매핑이 없으면 거부한다", () => {
+  const rows = [
+    { stationId: "station-sadang", lineId: "seoul-4", trnNo: "E2", dayCd: "01", arrivalSeconds: 30000, departureSeconds: 30000 },
+    { stationId: "station-unknown", lineId: "seoul-4", trnNo: "E2", dayCd: "01", arrivalSeconds: 31000, departureSeconds: 31000 },
+  ];
+  assert.throws(() => reconstructTransitTrips(rows, CONTEXT), /unknown lineSequence for station-unknown/);
+
+  const upOnly = { ...CONTEXT, routeIdByLineDirection: { "seoul-4|up": "route-seoul-4-oido" } };
+  const downRows = [
+    { stationId: "station-sangnoksu", lineId: "seoul-4", trnNo: "E3", dayCd: "01", arrivalSeconds: 40000, departureSeconds: 40000 },
+    { stationId: "station-sadang", lineId: "seoul-4", trnNo: "E3", dayCd: "01", arrivalSeconds: 41000, departureSeconds: 41000 },
+  ];
+  assert.throws(() => reconstructTransitTrips(downRows, upOnly), /no route mapping for seoul-4\|down/);
+
+  const noService = { ...CONTEXT, serviceIdByDayCd: { "01": "weekday-2026" } };
+  const satRows = [
+    { stationId: "station-sadang", lineId: "seoul-4", trnNo: "E4", dayCd: "02", arrivalSeconds: 30000, departureSeconds: 30000 },
+    { stationId: "station-sangnoksu", lineId: "seoul-4", trnNo: "E4", dayCd: "02", arrivalSeconds: 31000, departureSeconds: 31000 },
+  ];
+  assert.throws(() => reconstructTransitTrips(satRows, noService), /no serviceId mapping for 02/);
+});
+
+test("재구성 context는 Map도 허용하고, 누락되면 거부한다", () => {
+  const rows = [
+    { stationId: "station-sadang", lineId: "seoul-4", trnNo: "E5", dayCd: "01", arrivalSeconds: 30000, departureSeconds: 30000 },
+    { stationId: "station-sangnoksu", lineId: "seoul-4", trnNo: "E5", dayCd: "01", arrivalSeconds: 31000, departureSeconds: 31000 },
+  ];
+  const mapCtx = {
+    lineSequenceByStationLine: new Map([["station-sadang|seoul-4", 28], ["station-sangnoksu|seoul-4", 43]]),
+    routeIdByLineDirection: new Map([["seoul-4|up", "route-seoul-4-oido"]]),
+    serviceIdByDayCd: new Map([["01", "weekday-2026"]]),
+  };
+  const { transitTrips } = reconstructTransitTrips(rows, mapCtx);
+  assert.equal(transitTrips[0].routeId, "route-seoul-4-oido");
+
+  assert.throws(() => reconstructTransitTrips(rows, { ...CONTEXT, serviceIdByDayCd: null }), /context.serviceIdByDayCd is required/);
+});

--- a/tools/datapack/reconstruct-transit-trips.test.mjs
+++ b/tools/datapack/reconstruct-transit-trips.test.mjs
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { reconstructTransitTrips } from "./reconstruct-transit-trips.mjs";
+
+// 4호선 pilot 축약 lineSequence (오이도 방면으로 갈수록 큰 값)
+const LINE_SEQUENCE = {
+  "station-sadang|seoul-4": 28,
+  "station-oido|seoul-4": 47,
+  "station-sangnoksu|seoul-4": 43,
+  "station-geumjeong|seoul-4": 35,
+};
+
+const CONTEXT = {
+  lineSequenceByStationLine: LINE_SEQUENCE,
+  routeIdByLineDirection: {
+    "seoul-4|up": "route-seoul-4-oido",
+    "seoul-4|down": "route-seoul-4-danggogae",
+  },
+  serviceIdByDayCd: { "01": "weekday-2026", "02": "saturday-2026", "03": "holiday-2026" },
+};
+
+// ground-truth trip → station-level 중간 행으로 사영(trip 구조 제거)
+function projectTripToRows(trip) {
+  return trip.stops.map((stop) => ({
+    stationId: stop.stationId,
+    lineId: "seoul-4",
+    trnNo: trip.trnNo,
+    dayCd: trip.dayCd,
+    arrivalSeconds: stop.arrivalSeconds,
+    departureSeconds: stop.departureSeconds,
+    servicePattern: trip.servicePattern,
+  }));
+}
+
+test("재구성은 (trnNo,dayCd) group-by로 station 행에서 trip과 stop_times를 복원한다", () => {
+  // upbound: sadang(28) → geumjeong(35) → sangnoksu(43) 시각 증가
+  const trips = [
+    {
+      trnNo: "K4501",
+      dayCd: "01",
+      servicePattern: "LOCAL",
+      stops: [
+        { stationId: "station-sadang", arrivalSeconds: 30000, departureSeconds: 30000 },
+        { stationId: "station-geumjeong", arrivalSeconds: 30600, departureSeconds: 30630 },
+        { stationId: "station-sangnoksu", arrivalSeconds: 31200, departureSeconds: 31200 },
+      ],
+    },
+  ];
+  const rows = trips.flatMap(projectTripToRows);
+  // 입력 순서에 의존하지 않음을 보이려 역순으로
+  rows.reverse();
+
+  const { transitTrips, transitStopTimes } = reconstructTransitTrips(rows, CONTEXT);
+
+  assert.equal(transitTrips.length, 1);
+  const trip = transitTrips[0];
+  assert.equal(trip.routeId, "route-seoul-4-oido");
+  assert.equal(trip.serviceId, "weekday-2026");
+  assert.equal(trip.directionId, "up");
+  assert.equal(trip.tripHeadsign, "station-sangnoksu");
+  assert.equal(trip.servicePattern, "LOCAL");
+
+  const stops = transitStopTimes.filter((s) => s.tripId === trip.id);
+  assert.deepEqual(
+    stops.map((s) => [s.stopSequence, s.stationId, s.arrivalSeconds, s.departureSeconds]),
+    [
+      [1, "station-sadang", 30000, 30000],
+      [2, "station-geumjeong", 30600, 30630],
+      [3, "station-sangnoksu", 31200, 31200],
+    ],
+  );
+});
+
+test("재구성은 lineSequence 감소 방향을 down으로 도출한다", () => {
+  const rows = [
+    { stationId: "station-sangnoksu", lineId: "seoul-4", trnNo: "K4502", dayCd: "01", arrivalSeconds: 40000, departureSeconds: 40000 },
+    { stationId: "station-geumjeong", lineId: "seoul-4", trnNo: "K4502", dayCd: "01", arrivalSeconds: 40600, departureSeconds: 40630 },
+    { stationId: "station-sadang", lineId: "seoul-4", trnNo: "K4502", dayCd: "01", arrivalSeconds: 41200, departureSeconds: 41200 },
+  ];
+  const { transitTrips } = reconstructTransitTrips(rows, CONTEXT);
+  assert.equal(transitTrips[0].directionId, "down");
+  assert.equal(transitTrips[0].routeId, "route-seoul-4-danggogae");
+  assert.equal(transitTrips[0].tripHeadsign, "station-sadang");
+});
+
+test("재구성은 dayCd(평일/토/휴일)를 별도 trip과 serviceId로 분리한다", () => {
+  const rows = ["01", "02", "03"].flatMap((dayCd) => [
+    { stationId: "station-sadang", lineId: "seoul-4", trnNo: "K4600", dayCd, arrivalSeconds: 30000, departureSeconds: 30000 },
+    { stationId: "station-sangnoksu", lineId: "seoul-4", trnNo: "K4600", dayCd, arrivalSeconds: 31200, departureSeconds: 31200 },
+  ]);
+  const { transitTrips } = reconstructTransitTrips(rows, CONTEXT);
+  assert.equal(transitTrips.length, 3);
+  assert.deepEqual(
+    transitTrips.map((t) => t.serviceId).sort(),
+    ["holiday-2026", "saturday-2026", "weekday-2026"],
+  );
+});
+
+test("재구성은 급행(정차역 skip)을 단조 유지로 허용하고 servicePattern을 보존한다", () => {
+  // sadang(28) → sangnoksu(43): geumjeong(35) 통과 — 여전히 단조 증가
+  const rows = [
+    { stationId: "station-sadang", lineId: "seoul-4", trnNo: "X4701", dayCd: "01", arrivalSeconds: 50000, departureSeconds: 50000, servicePattern: "EXPRESS" },
+    { stationId: "station-sangnoksu", lineId: "seoul-4", trnNo: "X4701", dayCd: "01", arrivalSeconds: 50900, departureSeconds: 50900, servicePattern: "EXPRESS" },
+  ];
+  const { transitTrips, transitStopTimes } = reconstructTransitTrips(rows, CONTEXT);
+  assert.equal(transitTrips[0].servicePattern, "EXPRESS");
+  assert.equal(transitStopTimes.length, 2);
+});
+
+test("재구성은 lineSequence 비단조(zigzag) trip을 거부한다", () => {
+  // 시각순 sadang(28) → sangnoksu(43) → geumjeong(35): 마지막에 감소 → 비단조
+  const rows = [
+    { stationId: "station-sadang", lineId: "seoul-4", trnNo: "Z4801", dayCd: "01", arrivalSeconds: 60000, departureSeconds: 60000 },
+    { stationId: "station-sangnoksu", lineId: "seoul-4", trnNo: "Z4801", dayCd: "01", arrivalSeconds: 60600, departureSeconds: 60600 },
+    { stationId: "station-geumjeong", lineId: "seoul-4", trnNo: "Z4801", dayCd: "01", arrivalSeconds: 61200, departureSeconds: 61200 },
+  ];
+  assert.throws(
+    () => reconstructTransitTrips(rows, CONTEXT),
+    /stop order must follow station lineSequence/,
+  );
+});
+
+test("재구성은 정차가 1개뿐인 group을 거부한다", () => {
+  const rows = [
+    { stationId: "station-sadang", lineId: "seoul-4", trnNo: "S4901", dayCd: "01", arrivalSeconds: 30000, departureSeconds: 30000 },
+  ];
+  assert.throws(() => reconstructTransitTrips(rows, CONTEXT), /at least 2 stops/);
+});
+
+test("재구성은 인접 정차의 lineSequence가 같으면 거부한다", () => {
+  const ctx = {
+    ...CONTEXT,
+    lineSequenceByStationLine: { ...LINE_SEQUENCE, "station-dup|seoul-4": 28 },
+  };
+  const rows = [
+    { stationId: "station-sadang", lineId: "seoul-4", trnNo: "D4001", dayCd: "01", arrivalSeconds: 30000, departureSeconds: 30000 },
+    { stationId: "station-dup", lineId: "seoul-4", trnNo: "D4001", dayCd: "01", arrivalSeconds: 30600, departureSeconds: 30600 },
+  ];
+  assert.throws(() => reconstructTransitTrips(rows, ctx), /lineSequence must change/);
+});


### PR DESCRIPTION
## 관련 이슈

Refs #1415

## 작업 배경

- 라이브 수집(run `28740300285`, 상록수·사당 1287행)으로 **아키텍처 갭**을 확인: TAGO 수집은 station-level(역별 출발시각+종착역, 열차번호 없음)인데 pack 스키마·planner는 trip 기반이라 직접 적재 불가. 이것이 blocker `line_wide_trip_stop_sequence_validation_required`의 실체.
- 웹 검증 결과 **KRIC `subwayTimetable`(id=162)은 응답에 `trnNo`(열차번호) 포함** → trip 재구성이 휴리스틱 매칭이 아니라 **결정적 `(trnNo, dayCd)` group-by**로 단순화된다. 이 PR은 그 재구성 **코어**(② 단계, fixture-TDD)다.

## 작업 내용

- `reconstruct-transit-trips.mjs` — `reconstructTransitTrips(intermediateRows, context)` → `{transitTrips, transitStopTimes}`.
  - `(trnNo, dayCd)` group-by = 한 trip. 정차는 시각순 정렬 후 **lineSequence 방향당 단조를 강제**(line-wide 검증). direction(up/down)·headsign(종착)은 정차 순서에서 도출, `servicePattern`(EXPRESS 등) 보존.
- **가드레일**:
  1. **provider-중립 코어** — 입력은 KRIC/TAGO 응답 원형이 아니라 중간 행 계약 `{stationId, lineId, trnNo, dayCd, arrivalSeconds, departureSeconds, servicePattern?}`. provider→중간행 normalizer는 라이브 스키마 확정(①스파이크) 후 별도 얇은 층. 최악 시 코레일 TAGO 하이브리드가 되어도 코어·검증기 재사용.
  2. **기존 게이트 통과 출력** — build-datapack/validate-datapack의 transitTrips/transitStopTimes 행 shape 그대로. 새 검증 규칙을 발명하지 않고 기존 line-wide 검증(단조 lineSequence)을 도구 pass 조건으로 구현. **blocker 문자열은 이 PR에서 플립하지 않음**(실데이터 통과 시에만).
  3. **ground-truth 사영 fixture** — 합성 trip → station 행 사영 → 재구성 → 동치 assert. edge: up/down 방향, dayCd 3종 분리, arr=dep(시발·종착), 급행 skip, zigzag/단일정차/동일seq 음성.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/datapack/reconstruct-transit-trips.test.mjs` 통과 (7 tests)
  - `node --test tools/ci/repository-contract.test.mjs` 통과 (158)
  - `git diff --check` 통과
- TDD: RED(모듈 없음)→GREEN(happy path 사영 roundtrip)→edge/negative 6건.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 재구성 코어 정확성 | datapack tooling | ground-truth 사영 roundtrip + edge/negative | `reconstruct-transit-trips.test.mjs` 7건 | 통과 |
| 기존 계약 무영향 | tooling | repo contract test | blocker 문자열 유지 확인 | 통과 |
| UI/접근성 | 해당 없음 | 순수 재구성 로직 모듈만 추가 | UI 변경 없음 | 해당 없음 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음(도구 모듈만, pack 미빌드)
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `validateLineWideOrderAndDirection` — 단조 lineSequence 강제 = 기존 import-official-sources의 line-wide 검증과 동일 계약. loop-wrap(순환선)은 현재 거부(4호선 pilot 비순환) — 순환선 지원은 후속.
  - **blocker 미플립**: `line_wide_trip_stop_sequence_validation_required`는 유지(실데이터 통과 전까지). 이 PR은 fixture 통과만.
  - KRIC normalizer는 없음(①스파이크로 라이브 스키마 확정 후 별도 층). 코어는 중간 행 계약만 소비.

## 리스크

- ①스파이크가 KRIC 코레일 구간 미제공을 밝히면 normalizer 자리에 TAGO 체이닝 매칭기가 추가될 수 있으나, provider-중립 코어·검증기는 그대로 재사용된다(가드레일 1). 코어 자체 리스크 낮음(순수 함수·fixture 커버).

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 중간 정차 행을 바탕으로 trip과 stopTimes를 자동 복원하는 기능이 추가되었습니다.
  * 정차 순서를 기준으로 direction, route, service 정보를 일관되게 생성하며, 결과는 transitTrips / transitStopTimes 형태로 반환됩니다.

* **Tests**
  * trip 복원 규칙, 정렬 순서, 서비스 구분, 예외 처리 조건을 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->