### PR TITLE
[Feat] 역·시설 마스터 허브화 — 허브 탭·표준 테이블 v4·미확인/확인필요 뱃지·크로스링크 (#1741)

### DIFF
--- a/backend/src/main/java/com/easysubway/report/adapter/out/persistence/InMemoryFacilityReportRepository.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/out/persistence/InMemoryFacilityReportRepository.java
@@ -140,6 +140,18 @@ public class InMemoryFacilityReportRepository implements
 	}
 
 	@Override
+	public Map<String, Long> countPendingReportsByStation() {
+		Map<String, Long> counts = new HashMap<>();
+		for (FacilityReport report : reports.values()) {
+			if (report.status() == FacilityReportStatus.SUBMITTED
+				|| report.status() == FacilityReportStatus.UNDER_REVIEW) {
+				counts.merge(report.stationId(), 1L, Long::sum);
+			}
+		}
+		return Map.copyOf(counts);
+	}
+
+	@Override
 	public long countReportsCreatedSince(LocalDateTime cutoff) {
 		return reports.values()
 			.stream()

--- a/backend/src/main/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportRepository.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportRepository.java
@@ -387,6 +387,26 @@ public class JdbcFacilityReportRepository implements
 	}
 
 	@Override
+	public Map<String, Long> countPendingReportsByStation() {
+		return jdbcTemplate.query(
+			"""
+				SELECT station_id,
+					COUNT(*) AS report_count
+				FROM facility_reports
+				WHERE status IN ('SUBMITTED', 'UNDER_REVIEW')
+				GROUP BY station_id
+				""",
+			resultSet -> {
+				Map<String, Long> counts = new java.util.HashMap<>();
+				while (resultSet.next()) {
+					counts.put(resultSet.getString("station_id"), resultSet.getLong("report_count"));
+				}
+				return Map.copyOf(counts);
+			}
+		);
+	}
+
+	@Override
 	public long countReportsCreatedSince(LocalDateTime cutoff) {
 		Long count = jdbcTemplate.queryForObject(
 			"""

--- a/backend/src/main/java/com/easysubway/report/application/port/in/FacilityReportUseCase.java
+++ b/backend/src/main/java/com/easysubway/report/application/port/in/FacilityReportUseCase.java
@@ -60,6 +60,9 @@ public interface FacilityReportUseCase {
 	/** 같은 역·시설로 접수된 신고 요약(최신순, 상한 적용). 드로어의 "같은 시설 신고 목록"에 쓴다. */
 	List<FacilityReportSummary> listReportsForFacility(String stationId, String facilityId);
 
+	/** 대기 제보 수를 역 단위로 집계한다(역 목록 "미확인 제보" 뱃지용). 대기 없는 역은 결과에 없다. */
+	java.util.Map<String, Long> countPendingReportsByStation();
+
 	FacilityReport reviewReport(ReviewFacilityReportCommand command);
 
 	FacilityReport confirmReportResult(String reportId, String userId);

--- a/backend/src/main/java/com/easysubway/report/application/port/out/LoadFacilityReportPort.java
+++ b/backend/src/main/java/com/easysubway/report/application/port/out/LoadFacilityReportPort.java
@@ -45,4 +45,10 @@ public interface LoadFacilityReportPort {
 	 * 목록이 폭주하지 않도록 limit로 상한을 둔다. 호출부에서 현재 신고는 제외한다.
 	 */
 	List<FacilityReportSummary> loadReportsForFacility(String stationId, String facilityId, int limit);
+
+	/**
+	 * 대기 상태(SUBMITTED·UNDER_REVIEW) 제보 수를 역 단위로 집계한다(역 목록 "미확인 제보" 뱃지용).
+	 * 단일 GROUP BY 집계라 역별 N+1 조회를 피한다. 대기 제보가 없는 역은 결과에 담기지 않는다.
+	 */
+	Map<String, Long> countPendingReportsByStation();
 }

--- a/backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java
+++ b/backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java
@@ -615,6 +615,11 @@ public class FacilityReportService implements FacilityReportUseCase {
 	}
 
 	@Override
+	public Map<String, Long> countPendingReportsByStation() {
+		return loadFacilityReportPort.countPendingReportsByStation();
+	}
+
+	@Override
 	@Transactional
 	public FacilityReport reviewReport(ReviewFacilityReportCommand command) {
 		requireReviewDecision(command);

--- a/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitFacilityAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitFacilityAdminPageController.java
@@ -7,13 +7,18 @@ import com.easysubway.transit.application.port.in.TransitMasterAdminUseCase;
 import com.easysubway.transit.application.port.in.UpdateAccessibilityFacilityStatusCommand;
 import com.easysubway.transit.domain.AccessibilityFacilityStatus;
 import com.easysubway.transit.domain.MasterDataWriteNotAllowedException;
+import io.github.wimdeblauwe.htmx.spring.boot.mvc.HxRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.security.Principal;
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -21,6 +26,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
@@ -41,19 +47,145 @@ class TransitFacilityAdminPageController {
 
 	@GetMapping("/admin/facilities/page")
 	String facilitiesPage(
+		@RequestParam(required = false) String query,
+		@RequestParam(required = false) String type,
+		@RequestParam(required = false) AccessibilityFacilityStatus status,
+		@RequestParam(required = false) String stationId,
+		@RequestParam(required = false) String sort,
 		@RequestParam(required = false) Integer page,
 		@RequestParam(required = false) Integer size,
 		Model model
 	) {
+		populateFacilityStatusList(query, type, status, stationId, sort, page, size, model);
+		return "admin/facilities/list";
+	}
+
+	// 시설 상태판 표준 테이블(#1741): 검색·유형·상태·역 필터는 htmx 부분 갱신, no-JS는 form GET.
+	@HxRequest
+	@GetMapping("/admin/facilities/page")
+	String facilitiesListFragment(
+		@RequestParam(required = false) String query,
+		@RequestParam(required = false) String type,
+		@RequestParam(required = false) AccessibilityFacilityStatus status,
+		@RequestParam(required = false) String stationId,
+		@RequestParam(required = false) String sort,
+		@RequestParam(required = false) Integer page,
+		@RequestParam(required = false) Integer size,
+		@RequestHeader(value = "HX-History-Restore-Request", required = false) boolean historyRestore,
+		Model model
+	) {
+		if (historyRestore) {
+			return facilitiesPage(query, type, status, stationId, sort, page, size, model);
+		}
+		populateFacilityStatusList(query, type, status, stationId, sort, page, size, model);
+		return "admin/facilities/list :: facilityResults";
+	}
+
+	private void populateFacilityStatusList(
+		String query,
+		String type,
+		AccessibilityFacilityStatus status,
+		String stationId,
+		String sort,
+		Integer page,
+		Integer size,
+		Model model
+	) {
 		AdminPageRequest pageRequest = AdminPageRequest.of(page, size);
-		List<FacilityStatusRow> facilities = facilityStatusAssembler.assemble();
+		List<FacilityStatusRow> all = facilityStatusAssembler.assemble();
+		// 필터 옵션(유형·역)은 필터 전 전체에서 뽑아 항상 전체 후보를 보여준다.
+		model.addAttribute("typeOptions", distinctTypeOptions(all, type));
+		model.addAttribute("stationFilterOptions", distinctStationOptions(all, stationId));
+
+		String keyword = blankToNull(query);
+		String typeLabel = blankToNull(type);
+		String activeStation = blankToNull(stationId);
+		String lowerKeyword = keyword == null ? null : keyword.toLowerCase(Locale.ROOT);
+		List<FacilityStatusRow> facilities = all.stream()
+			.filter(row -> lowerKeyword == null
+				|| row.facilityName().toLowerCase(Locale.ROOT).contains(lowerKeyword)
+				|| row.stationName().toLowerCase(Locale.ROOT).contains(lowerKeyword))
+			.filter(row -> typeLabel == null || typeLabel.equals(row.typeLabel()))
+			.filter(row -> status == null || row.status() == status)
+			.filter(row -> activeStation == null || activeStation.equals(row.stationId()))
+			.sorted(facilityOrder(sort))
+			.toList();
+
 		EgovPaginationView pageView = EgovPaginationView.from(pageRequest.page(), pageRequest.size(), facilities.size());
 		model.addAttribute("facilities", pageView.pageItems(facilities));
 		model.addAttribute("page", pageView);
-		model.addAttribute("paginationLinks", pageView.links("/admin/facilities/page", Collections.emptyMap()));
+		Map<String, Object> linkParams = new LinkedHashMap<>();
+		linkParams.put("query", keyword);
+		linkParams.put("type", typeLabel);
+		linkParams.put("status", status);
+		linkParams.put("stationId", activeStation);
+		linkParams.put("sort", blankToNull(sort));
+		model.addAttribute("paginationLinks", pageView.links("/admin/facilities/page", linkParams));
 		model.addAttribute("statusOptions", statusOptions());
+		model.addAttribute("searchKeyword", keyword);
+		model.addAttribute("selectedType", typeLabel);
+		model.addAttribute("selectedStatus", status);
+		model.addAttribute("selectedStationFilter", activeStation);
+		model.addAttribute("selectedSort", blankToNull(sort));
 		model.addAttribute("masterDataWritable", transitMasterAdminUseCase.masterDataCapability().writable());
-		return "admin/facilities/list";
+	}
+
+	private static List<FilterOption> distinctTypeOptions(List<FacilityStatusRow> rows, String selected) {
+		List<FilterOption> options = new ArrayList<>();
+		options.add(new FilterOption("", "전체 유형", blankToNull(selected) == null));
+		rows.stream()
+			.map(FacilityStatusRow::typeLabel)
+			.distinct()
+			.sorted()
+			.forEach(label -> options.add(new FilterOption(label, label, label.equals(selected))));
+		return options;
+	}
+
+	private static List<FilterOption> distinctStationOptions(List<FacilityStatusRow> rows, String selected) {
+		List<FilterOption> options = new ArrayList<>();
+		options.add(new FilterOption("", "전체 역", blankToNull(selected) == null));
+		rows.stream()
+			.collect(java.util.stream.Collectors.toMap(
+				FacilityStatusRow::stationId, FacilityStatusRow::stationName, (a, b) -> a, LinkedHashMap::new))
+			.entrySet()
+			.stream()
+			.sorted(Map.Entry.comparingByValue())
+			.forEach(entry -> options.add(
+				new FilterOption(entry.getKey(), entry.getValue(), entry.getKey().equals(selected))));
+		return options;
+	}
+
+	// 정렬: 상태(확인 필요 우선)·역명·갱신일. 기본은 역명 → 시설명.
+	private static Comparator<FacilityStatusRow> facilityOrder(String sort) {
+		String value = sort == null ? "" : sort;
+		return switch (value) {
+			case "attention" -> Comparator.comparingInt((FacilityStatusRow row) -> attentionRank(row.status()))
+				.thenComparing(FacilityStatusRow::stationName)
+				.thenComparing(FacilityStatusRow::facilityName);
+			case "updated" -> Comparator.comparing(FacilityStatusRow::lastUpdatedAt).reversed()
+				.thenComparing(FacilityStatusRow::stationName);
+			default -> Comparator.comparing(FacilityStatusRow::stationName)
+				.thenComparing(FacilityStatusRow::facilityName);
+		};
+	}
+
+	// 확인이 필요한 상태(고장·공사·폐쇄·확인 필요·사용자 제보)를 앞으로 정렬하기 위한 순위.
+	private static int attentionRank(AccessibilityFacilityStatus status) {
+		return needsAttention(status) ? 0 : 1;
+	}
+
+	static boolean needsAttention(AccessibilityFacilityStatus status) {
+		return switch (status) {
+			case BROKEN, UNDER_CONSTRUCTION, CLOSED, UNKNOWN, USER_REPORTED -> true;
+			case NORMAL, ADMIN_VERIFIED -> false;
+		};
+	}
+
+	private static String blankToNull(String value) {
+		return value == null || value.isBlank() ? null : value;
+	}
+
+	record FilterOption(String value, String label, boolean selected) {
 	}
 
 	@PostMapping("/admin/facilities/{facilityId}/page/status")
@@ -69,7 +201,7 @@ class TransitFacilityAdminPageController {
 	) {
 		if (bindingResult.hasErrors()) {
 			response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-			facilitiesPage(null, null, model);
+			facilitiesPage(null, null, null, null, null, null, null, model);
 			AdminFormErrorView.expose(model, bindingResult);
 			return "admin/facilities/list";
 		}

--- a/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitFacilityAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitFacilityAdminPageController.java
@@ -169,16 +169,9 @@ class TransitFacilityAdminPageController {
 		};
 	}
 
-	// 확인이 필요한 상태(고장·공사·폐쇄·확인 필요·사용자 제보)를 앞으로 정렬하기 위한 순위.
+	// 확인이 필요한 상태(고장·공사·폐쇄·확인 필요·사용자 제보)를 앞으로 정렬하기 위한 순위. 판정은 도메인이 소유.
 	private static int attentionRank(AccessibilityFacilityStatus status) {
-		return needsAttention(status) ? 0 : 1;
-	}
-
-	static boolean needsAttention(AccessibilityFacilityStatus status) {
-		return switch (status) {
-			case BROKEN, UNDER_CONSTRUCTION, CLOSED, UNKNOWN, USER_REPORTED -> true;
-			case NORMAL, ADMIN_VERIFIED -> false;
-		};
+		return status.needsAttention() ? 0 : 1;
 	}
 
 	private static String blankToNull(String value) {

--- a/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitStationAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitStationAdminPageController.java
@@ -80,7 +80,6 @@ class TransitStationAdminPageController {
 	private final FieldVerificationUseCase fieldVerificationUseCase;
 	private final AdminMasterLabelResolver labelResolver;
 	private final WebMessageResolver messages;
-	private final TransitFacilityStatusAssembler facilityStatusAssembler;
 
 	TransitStationAdminPageController(
 		TransitMasterQueryUseCase transitMasterQueryUseCase,
@@ -89,8 +88,7 @@ class TransitStationAdminPageController {
 		FacilityReportUseCase facilityReportUseCase,
 		FieldVerificationUseCase fieldVerificationUseCase,
 		AdminMasterLabelResolver labelResolver,
-		WebMessageResolver messages,
-		TransitFacilityStatusAssembler facilityStatusAssembler
+		WebMessageResolver messages
 	) {
 		this.transitMasterQueryUseCase = transitMasterQueryUseCase;
 		this.transitMasterAdminUseCase = transitMasterAdminUseCase;
@@ -99,7 +97,6 @@ class TransitStationAdminPageController {
 		this.fieldVerificationUseCase = fieldVerificationUseCase;
 		this.labelResolver = labelResolver;
 		this.messages = messages;
-		this.facilityStatusAssembler = facilityStatusAssembler;
 	}
 
 	@GetMapping("/admin/stations/page")
@@ -148,7 +145,8 @@ class TransitStationAdminPageController {
 		AdminPageRequest pageRequest = AdminPageRequest.of(page, size);
 		Map<String, StationMasterDataCounts> counts = transitMasterQueryUseCase.countStationMasterDataByStationId();
 		Map<String, Long> pendingByStation = facilityReportUseCase.countPendingReportsByStation();
-		Map<String, Long> attentionByStation = attentionFacilitiesByStation();
+		// 확인 필요 시설 뱃지: 시설 전체 1회 벌크 집계(needsAttention). 시설 상태판과 같은 도메인 판정으로 정합.
+		Map<String, Long> attentionByStation = transitMasterQueryUseCase.countAttentionFacilitiesByStation();
 		// 검색만 서버에서 걸고(searchStations), 지역·노선 필터·정렬은 결과 위에서 적용해 조회를 1회로 유지한다.
 		List<StationWithLines> matched = transitMasterQueryUseCase.searchStations(new StationSearchCommand(query, null));
 		// 필터 옵션(지역·노선)은 노선/지역 필터가 걸리기 전 결과에서 뽑아 항상 전체 후보를 보여준다.
@@ -346,15 +344,6 @@ class TransitStationAdminPageController {
 			.map(RouteEdgeRow::from)
 			.toList());
 		model.addAttribute("layoutEditorHref", "/admin/stations/%s/layouts/page".formatted(stationId));
-	}
-
-	// 확인이 필요한(고장·공사·폐쇄·확인 필요·사용자 제보) 시설 수를 역 단위로 집계한다(역 목록 "확인 필요 시설" 뱃지).
-	// 시설 상태판(#1741 3/N)과 같은 assemble() 소스·needsAttention 판정을 재사용해 두 화면의 수치가 정합한다.
-	private Map<String, Long> attentionFacilitiesByStation() {
-		return facilityStatusAssembler.assemble().stream()
-			.filter(row -> TransitFacilityAdminPageController.needsAttention(row.status()))
-			.collect(java.util.stream.Collectors.groupingBy(
-				FacilityStatusRow::stationId, java.util.stream.Collectors.counting()));
 	}
 
 	private long countPendingStationReports(String stationId) {

--- a/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitStationAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitStationAdminPageController.java
@@ -80,6 +80,7 @@ class TransitStationAdminPageController {
 	private final FieldVerificationUseCase fieldVerificationUseCase;
 	private final AdminMasterLabelResolver labelResolver;
 	private final WebMessageResolver messages;
+	private final TransitFacilityStatusAssembler facilityStatusAssembler;
 
 	TransitStationAdminPageController(
 		TransitMasterQueryUseCase transitMasterQueryUseCase,
@@ -88,7 +89,8 @@ class TransitStationAdminPageController {
 		FacilityReportUseCase facilityReportUseCase,
 		FieldVerificationUseCase fieldVerificationUseCase,
 		AdminMasterLabelResolver labelResolver,
-		WebMessageResolver messages
+		WebMessageResolver messages,
+		TransitFacilityStatusAssembler facilityStatusAssembler
 	) {
 		this.transitMasterQueryUseCase = transitMasterQueryUseCase;
 		this.transitMasterAdminUseCase = transitMasterAdminUseCase;
@@ -97,6 +99,7 @@ class TransitStationAdminPageController {
 		this.fieldVerificationUseCase = fieldVerificationUseCase;
 		this.labelResolver = labelResolver;
 		this.messages = messages;
+		this.facilityStatusAssembler = facilityStatusAssembler;
 	}
 
 	@GetMapping("/admin/stations/page")
@@ -145,6 +148,7 @@ class TransitStationAdminPageController {
 		AdminPageRequest pageRequest = AdminPageRequest.of(page, size);
 		Map<String, StationMasterDataCounts> counts = transitMasterQueryUseCase.countStationMasterDataByStationId();
 		Map<String, Long> pendingByStation = facilityReportUseCase.countPendingReportsByStation();
+		Map<String, Long> attentionByStation = attentionFacilitiesByStation();
 		// 검색만 서버에서 걸고(searchStations), 지역·노선 필터·정렬은 결과 위에서 적용해 조회를 1회로 유지한다.
 		List<StationWithLines> matched = transitMasterQueryUseCase.searchStations(new StationSearchCommand(query, null));
 		// 필터 옵션(지역·노선)은 노선/지역 필터가 걸리기 전 결과에서 뽑아 항상 전체 후보를 보여준다.
@@ -160,7 +164,8 @@ class TransitStationAdminPageController {
 			.map(station -> StationRow.from(
 				station,
 				counts.getOrDefault(station.station().id(), StationMasterDataCounts.empty()),
-				pendingByStation.getOrDefault(station.station().id(), 0L)))
+				pendingByStation.getOrDefault(station.station().id(), 0L),
+				attentionByStation.getOrDefault(station.station().id(), 0L)))
 			.sorted(stationOrder(sort))
 			.toList();
 
@@ -343,6 +348,15 @@ class TransitStationAdminPageController {
 		model.addAttribute("layoutEditorHref", "/admin/stations/%s/layouts/page".formatted(stationId));
 	}
 
+	// 확인이 필요한(고장·공사·폐쇄·확인 필요·사용자 제보) 시설 수를 역 단위로 집계한다(역 목록 "확인 필요 시설" 뱃지).
+	// 시설 상태판(#1741 3/N)과 같은 assemble() 소스·needsAttention 판정을 재사용해 두 화면의 수치가 정합한다.
+	private Map<String, Long> attentionFacilitiesByStation() {
+		return facilityStatusAssembler.assemble().stream()
+			.filter(row -> TransitFacilityAdminPageController.needsAttention(row.status()))
+			.collect(java.util.stream.Collectors.groupingBy(
+				FacilityStatusRow::stationId, java.util.stream.Collectors.counting()));
+	}
+
 	private long countPendingStationReports(String stationId) {
 		return countStationReports(stationId, FacilityReportStatus.SUBMITTED)
 			+ countStationReports(stationId, FacilityReportStatus.UNDER_REVIEW);
@@ -484,13 +498,15 @@ class TransitStationAdminPageController {
 		int layoutSourceCount,
 		int routeNodeCount,
 		int routeEdgeCount,
-		long pendingReportCount
+		long pendingReportCount,
+		long attentionFacilityCount
 	) {
 
 		static StationRow from(
 			StationWithLines stationWithLines,
 			StationMasterDataCounts counts,
-			long pendingReportCount
+			long pendingReportCount,
+			long attentionFacilityCount
 		) {
 			return new StationRow(
 				stationWithLines.station().id(),
@@ -504,7 +520,8 @@ class TransitStationAdminPageController {
 				counts.layoutSourceCount(),
 				counts.routeNodeCount(),
 				counts.routeEdgeCount(),
-				pendingReportCount
+				pendingReportCount,
+				attentionFacilityCount
 			);
 		}
 	}

--- a/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitStationAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitStationAdminPageController.java
@@ -3,9 +3,19 @@ package com.easysubway.transit.adapter.in.web;
 import com.easysubway.admin.authorization.AdminAuthorization;
 import com.easysubway.admin.authorization.AdminPermission;
 import com.easysubway.admin.web.AdminFormErrorView;
+import com.easysubway.admin.web.AdminMasterLabelResolver;
+import com.easysubway.common.web.WebMessageResolver;
 import com.easysubway.common.web.pagination.AdminPageRequest;
 import com.easysubway.common.web.pagination.EgovPaginationView;
 import com.easysubway.datapack.application.port.in.DatapackReleaseBlockerSummaryUseCase;
+import com.easysubway.field.application.port.in.FieldVerificationUseCase;
+import com.easysubway.field.domain.FieldVerificationChangeHistory;
+import com.easysubway.field.domain.FieldVerificationSession;
+import com.easysubway.field.domain.FieldVerificationStatus;
+import com.easysubway.report.application.port.in.FacilityReportListQuery;
+import com.easysubway.report.application.port.in.FacilityReportUseCase;
+import com.easysubway.report.domain.FacilityReportStatus;
+import com.easysubway.report.domain.FacilityReportSummary;
 import com.easysubway.transit.application.port.in.CreateAccessibilityFacilityCommand;
 import com.easysubway.transit.application.port.in.StationMasterDataCounts;
 import com.easysubway.transit.application.port.in.StationSearchCommand;
@@ -24,12 +34,15 @@ import com.easysubway.transit.domain.RouteNode;
 import com.easysubway.transit.domain.StationExit;
 import com.easysubway.transit.domain.StationLayoutSource;
 import com.easysubway.transit.domain.StationWithLines;
+import io.github.wimdeblauwe.htmx.spring.boot.mvc.HxRequest;
 import java.math.BigDecimal;
 import java.security.Principal;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -43,24 +56,48 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @Controller
 class TransitStationAdminPageController {
 
+	// 역 상세 허브 탭(#1741). no-JS는 ?tab= 링크로 전체 페이지, htmx는 tabPanel fragment만 부분 갱신한다.
+	static final String TAB_OVERVIEW = "overview";
+	static final String TAB_FACILITIES = "facilities";
+	static final String TAB_REPORTS = "reports";
+	static final String TAB_FIELD = "field";
+	static final String TAB_STRUCTURE = "structure";
+	private static final List<String> STATION_HUB_TABS = List.of(
+		TAB_OVERVIEW, TAB_FACILITIES, TAB_REPORTS, TAB_FIELD, TAB_STRUCTURE);
+	// 제보 이력 탭은 최근 N건만 보여주고 전체는 필터된 제보 목록으로 딥링크한다(query budget 보호).
+	private static final int STATION_HUB_REPORT_LIMIT = 10;
+
 	private final TransitMasterQueryUseCase transitMasterQueryUseCase;
 	private final TransitMasterAdminUseCase transitMasterAdminUseCase;
 	private final DatapackReleaseBlockerSummaryUseCase datapackReleaseBlockerSummaryUseCase;
+	private final FacilityReportUseCase facilityReportUseCase;
+	private final FieldVerificationUseCase fieldVerificationUseCase;
+	private final AdminMasterLabelResolver labelResolver;
+	private final WebMessageResolver messages;
 
 	TransitStationAdminPageController(
 		TransitMasterQueryUseCase transitMasterQueryUseCase,
 		TransitMasterAdminUseCase transitMasterAdminUseCase,
-		DatapackReleaseBlockerSummaryUseCase datapackReleaseBlockerSummaryUseCase
+		DatapackReleaseBlockerSummaryUseCase datapackReleaseBlockerSummaryUseCase,
+		FacilityReportUseCase facilityReportUseCase,
+		FieldVerificationUseCase fieldVerificationUseCase,
+		AdminMasterLabelResolver labelResolver,
+		WebMessageResolver messages
 	) {
 		this.transitMasterQueryUseCase = transitMasterQueryUseCase;
 		this.transitMasterAdminUseCase = transitMasterAdminUseCase;
 		this.datapackReleaseBlockerSummaryUseCase = datapackReleaseBlockerSummaryUseCase;
+		this.facilityReportUseCase = facilityReportUseCase;
+		this.fieldVerificationUseCase = fieldVerificationUseCase;
+		this.labelResolver = labelResolver;
+		this.messages = messages;
 	}
 
 	@GetMapping("/admin/stations/page")
@@ -91,23 +128,139 @@ class TransitStationAdminPageController {
 	}
 
 	@GetMapping("/admin/stations/{stationId}/page")
-	String stationDetailPage(@PathVariable String stationId, Model model, Authentication authentication) {
+	String stationDetailPage(
+		@PathVariable String stationId,
+		@RequestParam(required = false) String tab,
+		Model model,
+		Authentication authentication
+	) {
+		populateStationHub(stationId, tab, model, authentication);
+		return "admin/stations/detail";
+	}
+
+	// 허브 탭 전환(#1741): 같은 URL을 htmx로 열면 tabPanel fragment만 반환한다. 히스토리 복원은 풀페이지.
+	@HxRequest
+	@GetMapping("/admin/stations/{stationId}/page")
+	String stationDetailTab(
+		@PathVariable String stationId,
+		@RequestParam(required = false) String tab,
+		@RequestHeader(value = "HX-History-Restore-Request", required = false) boolean historyRestore,
+		Model model,
+		Authentication authentication
+	) {
+		if (historyRestore) {
+			return stationDetailPage(stationId, tab, model, authentication);
+		}
+		populateStationHub(stationId, tab, model, authentication);
+		return "admin/stations/detail :: tabPanel";
+	}
+
+	private void populateStationHub(String stationId, String tab, Model model, Authentication authentication) {
+		String activeTab = tab != null && STATION_HUB_TABS.contains(tab) ? tab : TAB_OVERVIEW;
 		StationWithLines station = transitMasterQueryUseCase.getStation(stationId);
 		model.addAttribute("station", StationDetail.from(station));
+		model.addAttribute("activeTab", activeTab);
+		long pendingReportCount = countPendingStationReports(stationId);
+		model.addAttribute("pendingReportCount", pendingReportCount);
+		model.addAttribute("tabs", stationHubTabs(stationId, activeTab, pendingReportCount));
+		switch (activeTab) {
+			case TAB_FACILITIES -> populateFacilitiesTab(stationId, model);
+			case TAB_REPORTS -> populateReportsTab(stationId, model);
+			case TAB_FIELD -> populateFieldTab(stationId, model);
+			case TAB_STRUCTURE -> populateStructureTab(stationId, model);
+			default -> populateOverviewTab(stationId, model, authentication);
+		}
+	}
+
+	private List<StationHubTab> stationHubTabs(String stationId, String activeTab, long pendingReportCount) {
+		return List.of(
+			stationHubTab(stationId, TAB_OVERVIEW, "개요", activeTab, null),
+			stationHubTab(stationId, TAB_FACILITIES, "시설", activeTab, null),
+			stationHubTab(stationId, TAB_REPORTS, "제보 이력", activeTab,
+				pendingReportCount > 0 ? pendingReportCount : null),
+			stationHubTab(stationId, TAB_FIELD, "현장 확인", activeTab, null),
+			stationHubTab(stationId, TAB_STRUCTURE, "구조·동선", activeTab, null)
+		);
+	}
+
+	private static StationHubTab stationHubTab(
+		String stationId,
+		String token,
+		String label,
+		String activeTab,
+		Long badge
+	) {
+		String href = "/admin/stations/%s/page?tab=%s".formatted(stationId, token);
+		return new StationHubTab(token, label, href, token.equals(activeTab), badge);
+	}
+
+	private void populateOverviewTab(String stationId, Model model, Authentication authentication) {
+		model.addAttribute("facilityCount", transitMasterQueryUseCase.listStationFacilities(stationId).size());
+		model.addAttribute("layoutSourceCount", transitMasterQueryUseCase.listStationLayoutSources(stationId).size());
+		model.addAttribute("routeNodeCount", transitMasterQueryUseCase.listRouteNodes(stationId).size());
+		model.addAttribute("routeEdgeCount", transitMasterQueryUseCase.listRouteEdges(stationId).size());
+		if (AdminAuthorization.hasPermission(authentication, AdminPermission.DATAPACK_READ)) {
+			model.addAttribute("stationReleaseSummary", datapackReleaseBlockerSummaryUseCase.summarizeStation(stationId));
+		}
+	}
+
+	private void populateFacilitiesTab(String stationId, Model model) {
 		model.addAttribute("exits", transitMasterQueryUseCase.listStationExits(stationId).stream()
 			.map(ExitRow::from)
 			.toList());
 		model.addAttribute("facilities", transitMasterQueryUseCase.listStationFacilities(stationId).stream()
 			.map(FacilityRow::from)
 			.toList());
-		model.addAttribute("layoutSourceCount", transitMasterQueryUseCase.listStationLayoutSources(stationId).size());
-		model.addAttribute("layoutCount", transitMasterQueryUseCase.listSimplifiedStationLayouts(stationId).size());
-		model.addAttribute("routeNodeCount", transitMasterQueryUseCase.listRouteNodes(stationId).size());
-		model.addAttribute("routeEdgeCount", transitMasterQueryUseCase.listRouteEdges(stationId).size());
-		if (AdminAuthorization.hasPermission(authentication, AdminPermission.DATAPACK_READ)) {
-			model.addAttribute("stationReleaseSummary", datapackReleaseBlockerSummaryUseCase.summarizeStation(stationId));
-		}
-		return "admin/stations/detail";
+	}
+
+	private void populateReportsTab(String stationId, Model model) {
+		FacilityReportListQuery query = FacilityReportListQuery.of(
+			null, null, stationId, null, null, null, null, null, 0, STATION_HUB_REPORT_LIMIT);
+		List<FacilityReportSummary> items = facilityReportUseCase.searchReportSummaries(query).items();
+		Map<String, String> facilityLabels = labelResolver.facilityLabels(
+			items.stream().map(FacilityReportSummary::facilityId).toList());
+		model.addAttribute("stationReports", items.stream()
+			.map(summary -> StationReportRow.from(summary, messages, facilityLabels))
+			.toList());
+		// 전체 제보는 역 필터가 걸린 제보 대기열로 딥링크한다(#1740 station 필터 재사용).
+		model.addAttribute("stationReportsHref", "/admin/reports/page?station=" + stationId);
+	}
+
+	private void populateFieldTab(String stationId, Model model) {
+		// getStationVerification은 세션이 없으면 예외라, 목록에서 걸러 Optional로 안전하게 처리한다.
+		Optional<FieldVerificationSession> session = fieldVerificationUseCase.listStationVerifications().stream()
+			.filter(candidate -> candidate.stationId().equals(stationId))
+			.findFirst();
+		model.addAttribute("fieldSession", session.map(StationFieldSession::from).orElse(null));
+		model.addAttribute("fieldHistory", session.isEmpty() ? List.of()
+			: fieldVerificationUseCase.listStationChangeHistory(stationId).stream()
+				.limit(5)
+				.map(StationFieldHistoryRow::from)
+				.toList());
+		model.addAttribute("fieldVerificationHref", "/admin/field-verifications/" + stationId + "/page");
+	}
+
+	private void populateStructureTab(String stationId, Model model) {
+		model.addAttribute("layoutSources", transitMasterQueryUseCase.listStationLayoutSources(stationId).stream()
+			.map(LayoutSourceRow::from)
+			.toList());
+		model.addAttribute("routeNodes", transitMasterQueryUseCase.listRouteNodes(stationId).stream()
+			.map(RouteNodeRow::from)
+			.toList());
+		model.addAttribute("routeEdges", transitMasterQueryUseCase.listRouteEdges(stationId).stream()
+			.map(RouteEdgeRow::from)
+			.toList());
+		model.addAttribute("layoutEditorHref", "/admin/stations/%s/layouts/page".formatted(stationId));
+	}
+
+	private long countPendingStationReports(String stationId) {
+		return countStationReports(stationId, FacilityReportStatus.SUBMITTED)
+			+ countStationReports(stationId, FacilityReportStatus.UNDER_REVIEW);
+	}
+
+	private long countStationReports(String stationId, FacilityReportStatus status) {
+		return facilityReportUseCase.countReports(
+			FacilityReportListQuery.of(status, null, stationId, null, null, null, null, null, 0, 1));
 	}
 
 	@GetMapping("/admin/facilities/editor/page")
@@ -443,5 +596,92 @@ class TransitStationAdminPageController {
 				edge.reliabilityScore()
 			);
 		}
+	}
+
+	// 역 상세 허브 탭 네비 항목(#1741). badge는 값이 있을 때만 노출(예: 제보 이력의 대기 건수).
+	record StationHubTab(String token, String label, String href, boolean active, Long badge) {
+
+		public boolean hasBadge() {
+			return badge != null;
+		}
+	}
+
+	// 제보 이력 탭 행(#1741): 제보 대기열(#1740) 요약을 이름(코드)·라벨로 재사용한다.
+	record StationReportRow(
+		String reportId,
+		String facilityLabel,
+		String typeLabel,
+		String statusLabel,
+		LocalDateTime createdAt,
+		boolean hasPhoto,
+		String href
+	) {
+
+		static StationReportRow from(
+			FacilityReportSummary summary,
+			WebMessageResolver messages,
+			Map<String, String> facilityLabels
+		) {
+			return new StationReportRow(
+				summary.id(),
+				facilityLabels.getOrDefault(summary.facilityId(), summary.facilityId()),
+				messages.enumLabel("admin.report.type", summary.reportType()),
+				messages.enumLabel("admin.report.status", summary.status()),
+				summary.createdAt(),
+				summary.hasPhoto(),
+				"/admin/reports/%s/page".formatted(summary.id())
+			);
+		}
+	}
+
+	// 현장 확인 탭 세션 요약(#1741).
+	record StationFieldSession(
+		String stationName,
+		String verifiedAt,
+		String verifiedBy,
+		String statusLabel,
+		String note,
+		int itemCount
+	) {
+
+		static StationFieldSession from(FieldVerificationSession session) {
+			return new StationFieldSession(
+				session.stationName(),
+				String.valueOf(session.verifiedAt()),
+				session.verifiedBy(),
+				TransitStationAdminPageController.fieldStatusLabel(session.status()),
+				session.note(),
+				session.items().size()
+			);
+		}
+	}
+
+	// 현장 확인 탭 상태 변경 이력 행(#1741).
+	record StationFieldHistoryRow(
+		String itemId,
+		String previousStatusLabel,
+		String newStatusLabel,
+		String changedBy,
+		LocalDateTime changedAt
+	) {
+
+		static StationFieldHistoryRow from(FieldVerificationChangeHistory history) {
+			return new StationFieldHistoryRow(
+				history.itemId(),
+				TransitStationAdminPageController.fieldStatusLabel(history.previousStatus()),
+				TransitStationAdminPageController.fieldStatusLabel(history.newStatus()),
+				history.changedBy(),
+				history.changedAt()
+			);
+		}
+	}
+
+	private static String fieldStatusLabel(FieldVerificationStatus status) {
+		return switch (status) {
+			case PLANNED -> "예정";
+			case IN_PROGRESS -> "진행 중";
+			case VERIFIED -> "확인 완료";
+			case NEEDS_RECHECK -> "다시 확인 필요";
+		};
 	}
 }

--- a/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitStationAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitStationAdminPageController.java
@@ -39,7 +39,6 @@ import java.math.BigDecimal;
 import java.security.Principal;
 import java.time.LocalDateTime;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -103,28 +102,119 @@ class TransitStationAdminPageController {
 	@GetMapping("/admin/stations/page")
 	String stationsPage(
 		@RequestParam(required = false) String query,
+		@RequestParam(required = false) String region,
+		@RequestParam(required = false) String lineId,
+		@RequestParam(required = false) String sort,
 		@RequestParam(required = false) Integer page,
 		@RequestParam(required = false) Integer size,
 		Model model
 	) {
+		populateStationList(query, region, lineId, sort, page, size, model);
+		return "admin/stations/list";
+	}
+
+	// 역 목록 표준 테이블(#1741): 검색은 htmx 부분 갱신, no-JS는 form GET. 같은 모델·같은 필터를 공유한다.
+	@HxRequest
+	@GetMapping("/admin/stations/page")
+	String stationsListFragment(
+		@RequestParam(required = false) String query,
+		@RequestParam(required = false) String region,
+		@RequestParam(required = false) String lineId,
+		@RequestParam(required = false) String sort,
+		@RequestParam(required = false) Integer page,
+		@RequestParam(required = false) Integer size,
+		@RequestHeader(value = "HX-History-Restore-Request", required = false) boolean historyRestore,
+		Model model
+	) {
+		if (historyRestore) {
+			return stationsPage(query, region, lineId, sort, page, size, model);
+		}
+		populateStationList(query, region, lineId, sort, page, size, model);
+		return "admin/stations/list :: stationResults";
+	}
+
+	private void populateStationList(
+		String query,
+		String region,
+		String lineId,
+		String sort,
+		Integer page,
+		Integer size,
+		Model model
+	) {
 		AdminPageRequest pageRequest = AdminPageRequest.of(page, size);
 		Map<String, StationMasterDataCounts> counts = transitMasterQueryUseCase.countStationMasterDataByStationId();
-		List<StationRow> stations = transitMasterQueryUseCase.searchStations(new StationSearchCommand(query, null))
-			.stream()
-			.map(station -> StationRow.from(station, counts.getOrDefault(
-				station.station().id(),
-				StationMasterDataCounts.empty()
-			)))
+		Map<String, Long> pendingByStation = facilityReportUseCase.countPendingReportsByStation();
+		// 검색만 서버에서 걸고(searchStations), 지역·노선 필터·정렬은 결과 위에서 적용해 조회를 1회로 유지한다.
+		List<StationWithLines> matched = transitMasterQueryUseCase.searchStations(new StationSearchCommand(query, null));
+		// 필터 옵션(지역·노선)은 노선/지역 필터가 걸리기 전 결과에서 뽑아 항상 전체 후보를 보여준다.
+		model.addAttribute("regionOptions", distinctRegions(matched, region));
+		model.addAttribute("lineOptions", distinctLines(matched, lineId));
+
+		String activeRegion = blankToNull(region);
+		String activeLine = blankToNull(lineId);
+		List<StationRow> stations = matched.stream()
+			.filter(station -> activeRegion == null || activeRegion.equals(station.station().region()))
+			.filter(station -> activeLine == null
+				|| station.lines().stream().anyMatch(line -> activeLine.equals(line.id())))
+			.map(station -> StationRow.from(
+				station,
+				counts.getOrDefault(station.station().id(), StationMasterDataCounts.empty()),
+				pendingByStation.getOrDefault(station.station().id(), 0L)))
+			.sorted(stationOrder(sort))
 			.toList();
+
 		EgovPaginationView pageView = EgovPaginationView.from(pageRequest.page(), pageRequest.size(), stations.size());
 		model.addAttribute("stations", pageView.pageItems(stations));
 		model.addAttribute("page", pageView);
-		model.addAttribute("paginationLinks", pageView.links(
-			"/admin/stations/page",
-			Collections.singletonMap("query", query)
-		));
+		Map<String, Object> linkParams = new java.util.LinkedHashMap<>();
+		linkParams.put("query", query);
+		linkParams.put("region", activeRegion);
+		linkParams.put("lineId", activeLine);
+		linkParams.put("sort", blankToNull(sort));
+		model.addAttribute("paginationLinks", pageView.links("/admin/stations/page", linkParams));
 		model.addAttribute("query", query);
-		return "admin/stations/list";
+		model.addAttribute("selectedRegion", activeRegion);
+		model.addAttribute("selectedLine", activeLine);
+		model.addAttribute("selectedSort", blankToNull(sort));
+	}
+
+	private static List<FilterOption> distinctRegions(List<StationWithLines> stations, String selected) {
+		List<FilterOption> options = new java.util.ArrayList<>();
+		options.add(new FilterOption("", "전체 지역", blankToNull(selected) == null));
+		stations.stream()
+			.map(station -> station.station().region())
+			.filter(value -> value != null && !value.isBlank())
+			.distinct()
+			.sorted()
+			.forEach(value -> options.add(new FilterOption(value, value, value.equals(selected))));
+		return options;
+	}
+
+	private static List<FilterOption> distinctLines(List<StationWithLines> stations, String selected) {
+		List<FilterOption> options = new java.util.ArrayList<>();
+		options.add(new FilterOption("", "전체 노선", blankToNull(selected) == null));
+		stations.stream()
+			.flatMap(station -> station.lines().stream())
+			.collect(java.util.stream.Collectors.toMap(line -> line.id(), line -> line.name(), (a, b) -> a,
+				java.util.LinkedHashMap::new))
+			.entrySet()
+			.stream()
+			.sorted(Map.Entry.comparingByValue())
+			.forEach(entry -> options.add(
+				new FilterOption(entry.getKey(), entry.getValue(), entry.getKey().equals(selected))));
+		return options;
+	}
+
+	// 정렬: 미확인 제보 많은 순(pending)·역명 오름/내림차순. 기본은 역명 오름차순.
+	private static java.util.Comparator<StationRow> stationOrder(String sort) {
+		String value = sort == null ? "" : sort;
+		return switch (value) {
+			case "pending" -> java.util.Comparator.comparingLong(StationRow::pendingReportCount).reversed()
+				.thenComparing(StationRow::stationName);
+			case "name_desc" -> java.util.Comparator.comparing(StationRow::stationName).reversed();
+			default -> java.util.Comparator.comparing(StationRow::stationName);
+		};
 	}
 
 	@GetMapping("/admin/stations/{stationId}/page")
@@ -393,10 +483,15 @@ class TransitStationAdminPageController {
 		int facilityCount,
 		int layoutSourceCount,
 		int routeNodeCount,
-		int routeEdgeCount
+		int routeEdgeCount,
+		long pendingReportCount
 	) {
 
-		static StationRow from(StationWithLines stationWithLines, StationMasterDataCounts counts) {
+		static StationRow from(
+			StationWithLines stationWithLines,
+			StationMasterDataCounts counts,
+			long pendingReportCount
+		) {
 			return new StationRow(
 				stationWithLines.station().id(),
 				stationWithLines.station().nameKo(),
@@ -408,9 +503,14 @@ class TransitStationAdminPageController {
 				counts.facilityCount(),
 				counts.layoutSourceCount(),
 				counts.routeNodeCount(),
-				counts.routeEdgeCount()
+				counts.routeEdgeCount(),
+				pendingReportCount
 			);
 		}
+	}
+
+	// 역 목록 필터 select 옵션(지역·노선). value가 빈 문자열이면 "전체".
+	record FilterOption(String value, String label, boolean selected) {
 	}
 
 	record StationDetail(

--- a/backend/src/main/java/com/easysubway/transit/application/port/in/TransitMasterQueryUseCase.java
+++ b/backend/src/main/java/com/easysubway/transit/application/port/in/TransitMasterQueryUseCase.java
@@ -28,6 +28,9 @@ public interface TransitMasterQueryUseCase {
 
 	Map<String, StationMasterDataCounts> countStationMasterDataByStationId();
 
+	/** 확인이 필요한(needsAttention) 접근성 시설 수를 역 단위로 집계한다(역 목록 "확인 필요 시설" 뱃지). */
+	Map<String, Long> countAttentionFacilitiesByStation();
+
 	StationWithLines getStation(String stationId);
 
 	List<StationExit> listStationExits(String stationId);

--- a/backend/src/main/java/com/easysubway/transit/application/service/TransitMasterService.java
+++ b/backend/src/main/java/com/easysubway/transit/application/service/TransitMasterService.java
@@ -283,6 +283,15 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 	}
 
 	@Override
+	public Map<String, Long> countAttentionFacilitiesByStation() {
+		// 시설 전체를 한 번만 벌크 로드해 역 단위로 집계한다(역별 재조회 N+1 회피, countStationMasterData…와 같은 패턴).
+		return loadTransitMasterPort.loadAccessibilityFacilities()
+			.stream()
+			.filter(facility -> facility.status().needsAttention())
+			.collect(Collectors.groupingBy(AccessibilityFacility::stationId, Collectors.counting()));
+	}
+
+	@Override
 	public StationWithLines getStation(String stationId) {
 		return withLines(loadActiveStation(stationId));
 	}

--- a/backend/src/main/java/com/easysubway/transit/domain/AccessibilityFacilityStatus.java
+++ b/backend/src/main/java/com/easysubway/transit/domain/AccessibilityFacilityStatus.java
@@ -7,5 +7,16 @@ public enum AccessibilityFacilityStatus {
 	CLOSED,
 	UNKNOWN,
 	USER_REPORTED,
-	ADMIN_VERIFIED
+	ADMIN_VERIFIED;
+
+	/**
+	 * 운영자가 확인해야 하는 상태인지(#1741 역 목록 "확인 필요 시설" 뱃지·시설 상태판 정렬의 단일 판정 기준).
+	 * 고장·공사·폐쇄·확인 필요·사용자 제보는 확인 대상, 정상·관리자 확인은 아니다.
+	 */
+	public boolean needsAttention() {
+		return switch (this) {
+			case BROKEN, UNDER_CONSTRUCTION, CLOSED, UNKNOWN, USER_REPORTED -> true;
+			case NORMAL, ADMIN_VERIFIED -> false;
+		};
+	}
 }

--- a/backend/src/main/resources/static/css/admin-v3.css
+++ b/backend/src/main/resources/static/css/admin-v3.css
@@ -734,6 +734,22 @@ body.admin-v3 {
 	flex-wrap: wrap;
 }
 
+/* 역 목록 미확인 제보 뱃지(#1741): 대기 건수, 클릭 시 역 필터 제보 대기열로 이동 */
+.admin-v3 .count-badge {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 22px;
+	height: 20px;
+	padding: 0 7px;
+	border-radius: 10px;
+	background: var(--admin-accent, #1f6f6a);
+	color: #fff;
+	font-size: 12px;
+	font-weight: 600;
+	text-decoration: none;
+}
+
 .admin-v3 .bulk-actionbar {
 	position: sticky;
 	bottom: 0;

--- a/backend/src/main/resources/static/css/admin-v3.css
+++ b/backend/src/main/resources/static/css/admin-v3.css
@@ -678,6 +678,62 @@ body.admin-v3 {
 	font-size: 11px;
 }
 
+/* 역 상세 허브 탭(#1741) */
+.admin-v3 .hub-tabs {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 4px;
+	border-bottom: 1px solid var(--admin-border);
+	margin: 16px 0;
+}
+
+.admin-v3 .hub-tabs a {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	padding: 8px 14px;
+	border: 1px solid transparent;
+	border-bottom: none;
+	border-radius: 8px 8px 0 0;
+	color: var(--admin-ink-2);
+	text-decoration: none;
+	font-size: 14px;
+}
+
+.admin-v3 .hub-tabs a:hover {
+	background: var(--admin-surface-2, rgba(22, 48, 47, 0.05));
+}
+
+.admin-v3 .hub-tabs a.is-active {
+	border-color: var(--admin-border);
+	background: var(--admin-surface);
+	color: var(--admin-ink);
+	font-weight: 600;
+	margin-bottom: -1px;
+}
+
+.admin-v3 .hub-tab-badge {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 18px;
+	height: 18px;
+	padding: 0 5px;
+	border-radius: 9px;
+	background: var(--admin-accent, #1f6f6a);
+	color: #fff;
+	font-size: 11px;
+	font-weight: 600;
+}
+
+.admin-v3 .hub-panel-head {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	flex-wrap: wrap;
+}
+
 .admin-v3 .bulk-actionbar {
 	position: sticky;
 	bottom: 0;

--- a/backend/src/main/resources/static/css/admin-v3.css
+++ b/backend/src/main/resources/static/css/admin-v3.css
@@ -734,7 +734,7 @@ body.admin-v3 {
 	flex-wrap: wrap;
 }
 
-/* 역 목록 미확인 제보 뱃지(#1741): 대기 건수, 클릭 시 역 필터 제보 대기열로 이동 */
+/* 역 목록 카운트 뱃지(#1741): 미확인 제보·확인 필요 시설. 클릭 시 해당 필터 화면으로 이동 */
 .admin-v3 .count-badge {
 	display: inline-flex;
 	align-items: center;
@@ -748,6 +748,10 @@ body.admin-v3 {
 	font-size: 12px;
 	font-weight: 600;
 	text-decoration: none;
+}
+
+.admin-v3 .count-badge.is-warn {
+	background: var(--admin-warn, #b4690e);
 }
 
 .admin-v3 .bulk-actionbar {

--- a/backend/src/main/resources/templates/admin/facilities/list.html
+++ b/backend/src/main/resources/templates/admin/facilities/list.html
@@ -34,56 +34,100 @@
 	</div>
 	<div th:replace="~{admin/fragments/form-errors :: summary}"></div>
 
-	<p class="empty" th:if="${facilities.isEmpty()}">등록된 시설이 없습니다.</p>
-	<table th:if="${!facilities.isEmpty()}">
-		<thead>
-		<tr>
-			<th scope="col">시설</th>
-			<th scope="col">역</th>
-			<th scope="col">현재 상태</th>
+	<!--
+	  시설 상태판 표준 테이블(#1741): 검색·유형·상태·역 필터 툴바 + 표 + 페이지네이션을 facilityResults로 묶는다.
+	  JS 있으면 htmx가 이 컨테이너만 교체하고 URL을 push, 없으면 form GET·링크가 전체 페이지로 동작한다.
+	-->
+	<div id="facility-results" th:fragment="facilityResults"
+	     hx-target="#facility-results" hx-swap="outerHTML" hx-push-url="true">
+		<form class="table-toolbar" method="get" th:action="@{/admin/facilities/page}"
+		      role="search" aria-label="시설 검색"
+		      hx-target="#facility-results" hx-swap="outerHTML" hx-push-url="true"
+		      th:attr="hx-get=@{/admin/facilities/page}"
+		      hx-trigger="submit, change, keyup changed delay:300ms">
+			<input type="search" name="query" th:value="${searchKeyword}"
+			       placeholder="시설·역 이름 검색" aria-label="시설·역 이름 검색" autocomplete="off">
+			<select name="type" aria-label="유형 필터">
+				<option th:each="opt : ${typeOptions}" th:value="${opt.value}"
+				        th:text="${opt.label}" th:selected="${opt.selected}">전체 유형</option>
+			</select>
+			<select name="status" aria-label="상태 필터">
+				<option value="" th:selected="${selectedStatus == null}">전체 상태</option>
+				<option th:each="option : ${statusOptions}" th:value="${option.value}"
+				        th:text="${option.label}" th:selected="${option.value == selectedStatus}">정상</option>
+			</select>
+			<select name="stationId" aria-label="역 필터">
+				<option th:each="opt : ${stationFilterOptions}" th:value="${opt.value}"
+				        th:text="${opt.label}" th:selected="${opt.selected}">전체 역</option>
+			</select>
+			<select name="sort" aria-label="정렬">
+				<option value="" th:selected="${selectedSort == null}">역명순</option>
+				<option value="attention" th:selected="${selectedSort == 'attention'}">확인 필요 먼저</option>
+				<option value="updated" th:selected="${selectedSort == 'updated'}">갱신일 최신순</option>
+			</select>
+			<button type="submit">검색</button>
+		</form>
+
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">시설</th>
+				<th scope="col">역</th>
+				<th scope="col">현재 상태</th>
 				<th scope="col">확인 상태</th>
-			<th scope="col">갱신일</th>
-			<th scope="col">상태 변경</th>
-		</tr>
-		</thead>
-		<tbody>
-		<tr th:each="facility : ${facilities}">
-			<td>
-				<span th:text="${facility.facilityName}">1번 출구 엘리베이터</span>
-				<span class="meta" th:text="${facility.typeLabel}">엘리베이터</span>
-				<span class="meta" th:text="${facility.facilityId}">facility-id</span>
-			</td>
-			<td>
-				<span th:text="${facility.stationName}">상록수</span>
-				<span class="meta" th:text="${facility.stationId}">station-id</span>
-			</td>
-			<td><span th:replace="~{admin/fragments/shell :: statusAuto(${facility.statusLabel})}">정상</span></td>
-			<td>
-				<span th:text="${facility.confidenceLabel}">최근 확인된 정보</span>
-				<span class="meta" th:text="${facility.sourceLabel}">공식 안내</span>
-			</td>
-			<td th:text="${facility.lastUpdatedAt}">2026-06-12</td>
-			<td>
-				<form th:action="@{/admin/facilities/{facilityId}/page/status(facilityId=${facility.facilityId})}"
-				      method="post">
-					<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
-					<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
-					<label>
-						<span class="meta">변경할 상태</span>
-						<select name="status">
-							<option th:each="option : ${statusOptions}"
-							        th:value="${option.value}"
-							        th:selected="${option.value == facility.status}"
-							        th:text="${option.label}">정상</option>
-						</select>
-					</label>
-					<button type="submit" th:disabled="${!masterDataWritable}">저장</button>
-				</form>
-			</td>
-		</tr>
-		</tbody>
-	</table>
-	<div th:replace="~{admin/fragments/pagination :: pager('시설 상태 목록 페이지', ${page}, ${paginationLinks})}"></div>
+				<th scope="col">갱신일</th>
+				<th scope="col">제보</th>
+				<th scope="col">상태 변경</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:if="${facilities.isEmpty()}">
+				<td colspan="7">
+					<div th:replace="~{admin/fragments/empty-state :: panel('조건에 맞는 시설이 없습니다.', '검색어·유형·상태·역 필터를 조정해 보세요.')}"></div>
+				</td>
+			</tr>
+			<tr th:each="facility : ${facilities}">
+				<td>
+					<span th:text="${facility.facilityName}">1번 출구 엘리베이터</span>
+					<span class="meta" th:text="${facility.typeLabel}">엘리베이터</span>
+				</td>
+				<td>
+					<a th:href="@{/admin/stations/{stationId}/page(stationId=${facility.stationId},tab='facilities')}"
+					   th:text="${facility.stationName}">상록수</a>
+				</td>
+				<td><span th:replace="~{admin/fragments/shell :: statusAuto(${facility.statusLabel})}">정상</span></td>
+				<td>
+					<span th:text="${facility.confidenceLabel}">최근 확인된 정보</span>
+					<span class="meta" th:text="${facility.sourceLabel}">공식 안내</span>
+				</td>
+				<td th:text="${facility.lastUpdatedAt}">2026-06-12</td>
+				<td>
+					<!-- 관련 제보: 이 시설의 역으로 필터된 제보 대기열(#1740)로 이동한다. -->
+					<a th:href="@{/admin/reports/page(station=${facility.stationId})}"
+					   th:attr="aria-label=|${facility.stationName} 제보 보기|">제보 보기</a>
+				</td>
+				<td>
+					<form th:action="@{/admin/facilities/{facilityId}/page/status(facilityId=${facility.facilityId})}"
+					      method="post">
+						<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+						<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
+						<label>
+							<span class="meta">변경할 상태</span>
+							<select name="status">
+								<option th:each="option : ${statusOptions}"
+								        th:value="${option.value}"
+								        th:selected="${option.value == facility.status}"
+								        th:text="${option.label}">정상</option>
+							</select>
+						</label>
+						<button type="submit" th:disabled="${!masterDataWritable}">저장</button>
+					</form>
+				</td>
+			</tr>
+			</tbody>
+		</table>
+		<div th:replace="~{admin/fragments/pagination :: pager('시설 상태 목록 페이지', ${page}, ${paginationLinks})}"></div>
+	</div>
 </main>
 </div>
 <th:block th:replace="~{admin/fragments/shell :: scripts}"></th:block>

--- a/backend/src/main/resources/templates/admin/reports/detail.html
+++ b/backend/src/main/resources/templates/admin/reports/detail.html
@@ -46,7 +46,11 @@
 			<dt>내용</dt>
 			<dd th:text="${report.description}">신고 내용</dd>
 			<dt>역</dt>
-			<dd th:text="${stationLabel}">상록수(station-id)</dd>
+			<dd>
+				<!-- 역 허브 크로스링크(#1741): 이름(코드) → 역 상세 허브. -->
+				<a th:href="@{/admin/stations/{stationId}/page(stationId=${report.stationId},tab='reports')}"
+				   th:text="${stationLabel}">상록수(코드)</a>
+			</dd>
 			<dt>시설</dt>
 			<dd th:text="${facilityLabel}">엘리베이터(facility-id)</dd>
 			<dt th:if="${report.correctionOverrideHref != null}">임시 override</dt>

--- a/backend/src/main/resources/templates/admin/reports/list.html
+++ b/backend/src/main/resources/templates/admin/reports/list.html
@@ -209,7 +209,11 @@
 					<td><span th:replace="~{admin/fragments/shell :: statusAuto(${report.statusLabel})}">접수됨</span></td>
 					<td th:text="${report.reportTypeLabel}">고장</td>
 					<td th:text="${report.description}">신고 내용</td>
-					<td th:text="${report.stationLabel}">상록수(station-id)</td>
+					<td>
+						<!-- 역 허브 크로스링크(#1741): 이름(코드) → 역 상세 허브 제보 탭. -->
+						<a th:href="@{/admin/stations/{stationId}/page(stationId=${report.stationId},tab='reports')}"
+						   th:text="${report.stationLabel}">상록수(코드)</a>
+					</td>
 					<td th:text="${report.facilityLabel}">엘리베이터(facility-id)</td>
 					<td th:text="${#temporals.format(report.createdAt, 'yyyy-MM-dd HH:mm')}">2026-06-17 09:00</td>
 					<td>

--- a/backend/src/main/resources/templates/admin/stations/detail.html
+++ b/backend/src/main/resources/templates/admin/stations/detail.html
@@ -18,8 +18,6 @@
 		<div>
 			<h1 th:text="${station.stationName}">역 상세</h1>
 			<p>
-				<span th:text="${station.stationId}">station-id</span>
-				<span> · </span>
 				<span th:text="${station.region}">수도권</span>
 				<span> · </span>
 				<span th:text="${station.lineNames}">4호선</span>
@@ -31,112 +29,274 @@
 		</div>
 	</header>
 
-	<div class="metric-grid">
-		<div class="metric"><span>데이터 품질</span><strong th:text="${station.qualityLabel}">정보 확인 중</strong></div>
-		<div class="metric"><span>접근성 시설</span><strong th:text="${facilities.size()}">0</strong></div>
-		<div class="metric"><span>구조 자료</span><strong th:text="${layoutSourceCount}">0</strong></div>
-		<div class="metric"><span>노드 / 간선</span><strong th:text="|${routeNodeCount} / ${routeEdgeCount}|">0 / 0</strong></div>
+	<!--
+	  역 상세 허브 탭(#1741): 개요·시설·제보 이력·현장 확인·구조·동선. 탭 네비와 패널을 한 fragment로 묶어
+	  htmx가 이 컨테이너만 outerHTML로 교체하고 URL(?tab=)을 push한다. no-JS는 링크가 전체 페이지 이동으로 동작.
+	-->
+	<div id="station-hub" th:fragment="tabPanel"
+	     hx-target="#station-hub" hx-swap="outerHTML" hx-push-url="true">
+		<nav class="hub-tabs" aria-label="역 상세 탭">
+			<a th:each="t : ${tabs}"
+			   th:href="${t.href}"
+			   th:attr="hx-get=${t.href},aria-current=${t.active ? 'page' : null}"
+			   th:classappend="${t.active} ? ' is-active'">
+				<span th:text="${t.label}">개요</span>
+				<span class="hub-tab-badge" th:if="${t.hasBadge()}" th:text="${t.badge}">0</span>
+			</a>
+		</nav>
+
+		<div class="hub-panel">
+			<!-- 개요 -->
+			<th:block th:if="${activeTab == 'overview'}">
+				<div class="metric-grid">
+					<div class="metric"><span>데이터 품질</span><strong th:text="${station.qualityLabel}">정보 확인 중</strong></div>
+					<div class="metric"><span>접근성 시설</span><strong th:text="${facilityCount}">0</strong></div>
+					<div class="metric"><span>구조 자료</span><strong th:text="${layoutSourceCount}">0</strong></div>
+					<div class="metric"><span>노드 / 간선</span><strong th:text="|${routeNodeCount} / ${routeEdgeCount}|">0 / 0</strong></div>
+				</div>
+
+				<section class="admin-panel">
+					<h2>역 주요 정보</h2>
+					<table>
+						<tbody>
+						<tr><th scope="row">한글 역명</th><td th:text="${station.stationName}">상록수</td></tr>
+						<tr><th scope="row">지역</th><td th:text="${station.region}">수도권</td></tr>
+						<tr><th scope="row">위도</th><td th:text="${station.latitude}">0</td></tr>
+						<tr><th scope="row">경도</th><td th:text="${station.longitude}">0</td></tr>
+						<tr><th scope="row">출처 유형</th><td th:text="${station.sourceType}">OPERATOR</td></tr>
+						<tr><th scope="row">마지막 확인</th><td th:text="${station.lastVerifiedAt}">2026-06-20</td></tr>
+						</tbody>
+					</table>
+				</section>
+
+				<section th:if="${stationReleaseSummary != null}">
+					<h2>Release readiness</h2>
+					<p class="summary" th:text="|${station.stationName}역 release blocker|">상록수역 release blocker</p>
+					<p class="summary">
+						<strong th:text="|${stationReleaseSummary.status} ${stationReleaseSummary.totalBlockers}건|">확인 필요 0건</strong>
+					</p>
+					<table>
+						<thead>
+						<tr>
+							<th scope="col">항목</th>
+							<th scope="col">상태</th>
+							<th scope="col">blocker</th>
+						</tr>
+						</thead>
+						<tbody>
+						<tr th:each="row : ${stationReleaseSummary.rows}">
+							<td th:text="${row.label}">Facility evidence</td>
+							<td><span th:replace="~{admin/fragments/shell :: statusAuto(${row.status})}">확인 필요</span></td>
+							<td th:text="${row.blockerCount}">0</td>
+						</tr>
+						</tbody>
+					</table>
+				</section>
+			</th:block>
+
+			<!-- 시설 -->
+			<th:block th:if="${activeTab == 'facilities'}">
+				<section>
+					<h2>출구</h2>
+					<table th:if="${!exits.isEmpty()}">
+						<thead>
+						<tr>
+							<th scope="col">출구</th>
+							<th scope="col">이름</th>
+							<th scope="col">엘리베이터</th>
+							<th scope="col">계단 경로</th>
+							<th scope="col">확인 상태</th>
+						</tr>
+						</thead>
+						<tbody>
+						<tr th:each="exit : ${exits}">
+							<td th:text="${exit.exitNumber}">1</td>
+							<td th:text="${exit.name}">1번 출구</td>
+							<td th:text="${exit.elevatorLabel}">엘리베이터 연결</td>
+							<td th:text="${exit.stairOnlyLabel}">계단 전용 아님</td>
+							<td th:text="${exit.confidenceLabel}">높음</td>
+						</tr>
+						</tbody>
+					</table>
+					<p th:if="${exits.isEmpty()}">등록된 출구가 없습니다.</p>
+				</section>
+
+				<section>
+					<h2>접근성 시설</h2>
+					<table th:if="${!facilities.isEmpty()}">
+						<thead>
+						<tr>
+							<th scope="col">시설</th>
+							<th scope="col">위치</th>
+							<th scope="col">상태</th>
+							<th scope="col">확인 상태</th>
+							<th scope="col">작업</th>
+						</tr>
+						</thead>
+						<tbody>
+						<tr th:each="facility : ${facilities}">
+							<td>
+								<strong th:text="${facility.facilityName}">엘리베이터</strong>
+								<span class="meta" th:text="${facility.typeLabel}">ELEVATOR</span>
+							</td>
+							<td th:text="${facility.floorLabel}">B1 → 지상</td>
+							<td th:text="${facility.statusLabel}">정상</td>
+							<td th:text="${facility.confidenceLabel}">높음</td>
+							<td>
+								<a class="admin-btn"
+								   th:href="@{/admin/facilities/editor/page(stationId=${station.stationId},facilityId=${facility.facilityId})}">수정</a>
+							</td>
+						</tr>
+						</tbody>
+					</table>
+					<div th:if="${facilities.isEmpty()}"
+					     th:replace="~{admin/fragments/empty-state :: panel('등록된 접근성 시설이 없습니다.', '구조·동선 편집에서 시설을 추가하세요.')}"></div>
+				</section>
+			</th:block>
+
+			<!-- 제보 이력 -->
+			<th:block th:if="${activeTab == 'reports'}">
+				<section>
+					<div class="hub-panel-head">
+						<h2>제보 이력</h2>
+						<a class="admin-btn" th:href="@{${stationReportsHref}}">전체 제보 보기</a>
+					</div>
+					<table th:if="${!stationReports.isEmpty()}">
+						<thead>
+						<tr>
+							<th scope="col">상태</th>
+							<th scope="col">유형</th>
+							<th scope="col">시설</th>
+							<th scope="col">사진</th>
+							<th scope="col">접수일</th>
+							<th scope="col">상세</th>
+						</tr>
+						</thead>
+						<tbody>
+						<tr th:each="report : ${stationReports}">
+							<td><span th:replace="~{admin/fragments/shell :: statusAuto(${report.statusLabel})}">접수됨</span></td>
+							<td th:text="${report.typeLabel}">고장</td>
+							<td th:text="${report.facilityLabel}">엘리베이터(코드)</td>
+							<td th:text="${report.hasPhoto ? '있음' : '없음'}">없음</td>
+							<td th:text="${#temporals.format(report.createdAt, 'yyyy-MM-dd HH:mm')}">2026-06-17 09:00</td>
+							<td><a th:href="@{${report.href}}">상세 보기</a></td>
+						</tr>
+						</tbody>
+					</table>
+					<div th:if="${stationReports.isEmpty()}"
+					     th:replace="~{admin/fragments/empty-state :: panel('이 역의 제보가 없습니다.', '접수되면 여기와 제보 대기열에 함께 표시됩니다.')}"></div>
+				</section>
+			</th:block>
+
+			<!-- 현장 확인 -->
+			<th:block th:if="${activeTab == 'field'}">
+				<section>
+					<div class="hub-panel-head">
+						<h2>현장 확인</h2>
+						<a class="admin-btn" th:href="@{${fieldVerificationHref}}">현장 확인 화면</a>
+					</div>
+					<div th:if="${fieldSession == null}"
+					     th:replace="~{admin/fragments/empty-state :: panel('현장 확인 세션이 없습니다.', '현장 확인 화면에서 확인 일정을 등록하세요.')}"></div>
+					<div th:if="${fieldSession != null}">
+						<table>
+							<tbody>
+							<tr><th scope="row">확인 상태</th><td th:text="${fieldSession.statusLabel}">확인 완료</td></tr>
+							<tr><th scope="row">확인일</th><td th:text="${fieldSession.verifiedAt}">2026-06-20</td></tr>
+							<tr><th scope="row">확인자</th><td th:text="${fieldSession.verifiedBy}">operator</td></tr>
+							<tr><th scope="row">확인 항목</th><td th:text="|${fieldSession.itemCount}개|">0개</td></tr>
+							<tr th:if="${fieldSession.note != null}"><th scope="row">메모</th><td th:text="${fieldSession.note}">-</td></tr>
+							</tbody>
+						</table>
+						<h3>최근 상태 변경</h3>
+						<table th:if="${!fieldHistory.isEmpty()}">
+							<thead>
+							<tr>
+								<th scope="col">항목</th>
+								<th scope="col">이전</th>
+								<th scope="col">이후</th>
+								<th scope="col">변경자</th>
+								<th scope="col">변경일</th>
+							</tr>
+							</thead>
+							<tbody>
+							<tr th:each="change : ${fieldHistory}">
+								<td th:text="${change.itemId}">항목</td>
+								<td th:text="${change.previousStatusLabel}">예정</td>
+								<td th:text="${change.newStatusLabel}">확인 완료</td>
+								<td th:text="${change.changedBy}">operator</td>
+								<td th:text="${#temporals.format(change.changedAt, 'yyyy-MM-dd HH:mm')}">2026-06-20 10:00</td>
+							</tr>
+							</tbody>
+						</table>
+						<p th:if="${fieldHistory.isEmpty()}">상태 변경 이력이 없습니다.</p>
+					</div>
+				</section>
+			</th:block>
+
+			<!-- 구조·동선 -->
+			<th:block th:if="${activeTab == 'structure'}">
+				<section>
+					<div class="hub-panel-head">
+						<h2>구조·동선</h2>
+						<a class="admin-btn" th:href="@{${layoutEditorHref}}">구조·동선 편집</a>
+					</div>
+					<h3>구조 자료</h3>
+					<table th:if="${!layoutSources.isEmpty()}">
+						<thead>
+						<tr>
+							<th scope="col">자료명</th>
+							<th scope="col">출처 유형</th>
+							<th scope="col">라이선스</th>
+						</tr>
+						</thead>
+						<tbody>
+						<tr th:each="source : ${layoutSources}">
+							<td th:text="${source.sourceName}">자료</td>
+							<td th:text="${source.sourceType}">OPERATOR</td>
+							<td th:text="${source.license}">-</td>
+						</tr>
+						</tbody>
+					</table>
+					<p th:if="${layoutSources.isEmpty()}">등록된 구조 자료가 없습니다.</p>
+
+					<h3>동선 노드 / 간선</h3>
+					<table th:if="${!routeNodes.isEmpty()}">
+						<thead>
+						<tr>
+							<th scope="col">노드</th>
+							<th scope="col">유형</th>
+							<th scope="col">층</th>
+						</tr>
+						</thead>
+						<tbody>
+						<tr th:each="node : ${routeNodes}">
+							<td th:text="${node.nodeName}">노드</td>
+							<td th:text="${node.nodeType}">PLATFORM</td>
+							<td th:text="${node.floor}">B1</td>
+						</tr>
+						</tbody>
+					</table>
+					<p th:if="${routeNodes.isEmpty()}">등록된 동선 노드가 없습니다.</p>
+					<table th:if="${!routeEdges.isEmpty()}">
+						<thead>
+						<tr>
+							<th scope="col">간선</th>
+							<th scope="col">유형</th>
+							<th scope="col">신뢰도</th>
+						</tr>
+						</thead>
+						<tbody>
+						<tr th:each="edge : ${routeEdges}">
+							<td th:text="${edge.edgeName}">노드 → 노드</td>
+							<td th:text="${edge.edgeType}">WALK</td>
+							<td th:text="${edge.confidenceScore}">0</td>
+						</tr>
+						</tbody>
+					</table>
+				</section>
+			</th:block>
+		</div>
 	</div>
-
-	<div class="admin-grid-2">
-		<section class="admin-panel">
-				<h2>역 주요 정보</h2>
-			<table>
-				<tbody>
-				<tr><th scope="row">한글 역명</th><td th:text="${station.stationName}">상록수</td></tr>
-				<tr><th scope="row">지역</th><td th:text="${station.region}">수도권</td></tr>
-				<tr><th scope="row">위도</th><td th:text="${station.latitude}">0</td></tr>
-				<tr><th scope="row">경도</th><td th:text="${station.longitude}">0</td></tr>
-				<tr><th scope="row">출처 유형</th><td th:text="${station.sourceType}">OPERATOR</td></tr>
-				<tr><th scope="row">마지막 확인</th><td th:text="${station.lastVerifiedAt}">2026-06-20</td></tr>
-				</tbody>
-			</table>
-		</section>
-
-		<section class="admin-panel">
-			<h2>사용자 화면 미리보기</h2>
-			<p class="summary">현재 시설 상태와 확인일을 사용자가 읽을 수 있는 형태로 확인합니다.</p>
-			<div class="admin-status warn" th:if="${!facilities.isEmpty()}" th:text="|시설 ${facilities.size()}개 연결됨|">시설 0개</div>
-		</section>
-	</div>
-
-	<section th:if="${stationReleaseSummary != null}">
-		<h2>Release readiness</h2>
-		<p class="summary" th:text="|${station.stationName}역 release blocker|">상록수역 release blocker</p>
-		<p class="summary">
-			<strong th:text="|${stationReleaseSummary.status} ${stationReleaseSummary.totalBlockers}건|">확인 필요 0건</strong>
-		</p>
-		<table>
-			<thead>
-			<tr>
-				<th scope="col">항목</th>
-				<th scope="col">상태</th>
-				<th scope="col">blocker</th>
-			</tr>
-			</thead>
-			<tbody>
-			<tr th:each="row : ${stationReleaseSummary.rows}">
-				<td th:text="${row.label}">Facility evidence</td>
-				<td><span th:replace="~{admin/fragments/shell :: statusAuto(${row.status})}">확인 필요</span></td>
-				<td th:text="${row.blockerCount}">0</td>
-			</tr>
-			</tbody>
-		</table>
-	</section>
-
-	<section>
-		<h2>출구</h2>
-		<table>
-			<thead>
-			<tr>
-				<th scope="col">출구</th>
-				<th scope="col">이름</th>
-				<th scope="col">엘리베이터</th>
-				<th scope="col">계단 경로</th>
-					<th scope="col">확인 상태</th>
-			</tr>
-			</thead>
-			<tbody>
-			<tr th:each="exit : ${exits}">
-				<td th:text="${exit.exitNumber}">1</td>
-				<td th:text="${exit.name}">1번 출구</td>
-				<td th:text="${exit.elevatorLabel}">엘리베이터 연결</td>
-				<td th:text="${exit.stairOnlyLabel}">계단 전용 아님</td>
-				<td th:text="${exit.confidenceLabel}">높음</td>
-			</tr>
-			</tbody>
-		</table>
-	</section>
-
-	<section>
-		<h2>접근성 시설</h2>
-		<table>
-			<thead>
-			<tr>
-				<th scope="col">시설</th>
-				<th scope="col">위치</th>
-				<th scope="col">상태</th>
-					<th scope="col">확인 상태</th>
-				<th scope="col">수정</th>
-			</tr>
-			</thead>
-			<tbody>
-			<tr th:each="facility : ${facilities}">
-				<td>
-					<strong th:text="${facility.facilityName}">엘리베이터</strong>
-					<span class="meta" th:text="${facility.typeLabel}">ELEVATOR</span>
-				</td>
-				<td th:text="${facility.floorLabel}">B1 → 지상</td>
-				<td th:text="${facility.statusLabel}">정상</td>
-				<td th:text="${facility.confidenceLabel}">높음</td>
-				<td>
-					<a class="admin-btn"
-					   th:href="@{/admin/facilities/editor/page(stationId=${station.stationId},facilityId=${facility.facilityId})}">수정</a>
-				</td>
-			</tr>
-			</tbody>
-		</table>
-	</section>
 </main>
 </div>
 <th:block th:replace="~{admin/fragments/shell :: scripts}"></th:block>

--- a/backend/src/main/resources/templates/admin/stations/list.html
+++ b/backend/src/main/resources/templates/admin/stations/list.html
@@ -17,49 +17,86 @@
 	<header class="admin-page-head">
 		<div>
 			<h1>역 목록</h1>
-			<p>역을 검색하고 데이터 품질과 하위 데이터 개수를 비교합니다.</p>
+			<p>역을 검색·필터하고 미확인 제보와 데이터 품질을 비교합니다.</p>
 		</div>
-		<form class="admin-actions" th:action="@{/admin/stations/page}" method="get">
-			<input name="query" th:value="${query}" placeholder="역 이름 검색">
-			<button type="submit">검색</button>
-		</form>
 	</header>
 
-	<table>
-		<thead>
-		<tr>
-			<th scope="col">역</th>
-			<th scope="col">노선</th>
-			<th scope="col">지역</th>
-			<th scope="col">품질</th>
-			<th scope="col">출구 / 시설 / 자료</th>
-			<th scope="col">노드 / 간선</th>
-			<th scope="col">마지막 확인</th>
-			<th scope="col">작업</th>
-		</tr>
-		</thead>
-		<tbody>
-		<tr th:if="${stations.isEmpty()}">
-			<td colspan="8">검색된 역이 없습니다.</td>
-		</tr>
-		<tr th:each="station : ${stations}">
-			<td>
-				<strong th:text="${station.stationName}">상록수</strong>
-				<span class="meta" th:text="${station.stationId}">station-id</span>
-			</td>
-			<td th:text="${station.lineNames}">4호선</td>
-			<td th:text="${station.region}">수도권</td>
-			<td><span class="admin-status" th:text="${station.qualityLabel}">정보 확인 중</span></td>
-			<td th:text="|${station.exitCount} / ${station.facilityCount} / ${station.layoutSourceCount}|">0 / 0 / 0</td>
-			<td th:text="|${station.routeNodeCount} / ${station.routeEdgeCount}|">0 / 0</td>
-			<td th:text="${station.lastVerifiedAt}">2026-06-20</td>
-			<td>
-				<a class="admin-btn" th:href="@{/admin/stations/{stationId}/page(stationId=${station.stationId})}">상세</a>
-			</td>
-		</tr>
-		</tbody>
-	</table>
-	<div th:replace="~{admin/fragments/pagination :: pager('역 목록 페이지', ${page}, ${paginationLinks})}"></div>
+	<!--
+	  역 목록 표준 테이블(#1741): 검색·지역·노선·정렬 툴바 + 표 + 페이지네이션을 stationResults fragment로 묶는다.
+	  JS 있으면 htmx가 이 컨테이너만 교체하고 URL을 push, 없으면 form GET·링크가 전체 페이지로 동작한다.
+	-->
+	<div id="station-results" th:fragment="stationResults"
+	     hx-target="#station-results" hx-swap="outerHTML" hx-push-url="true">
+		<form class="table-toolbar" method="get" th:action="@{/admin/stations/page}"
+		      role="search" aria-label="역 검색"
+		      hx-target="#station-results" hx-swap="outerHTML" hx-push-url="true"
+		      th:attr="hx-get=@{/admin/stations/page}"
+		      hx-trigger="submit, change, keyup changed delay:300ms">
+			<input type="search" name="query" th:value="${query}"
+			       placeholder="역 이름 검색" aria-label="역 이름 검색" autocomplete="off">
+			<select name="region" aria-label="지역 필터">
+				<option th:each="opt : ${regionOptions}" th:value="${opt.value}"
+				        th:text="${opt.label}" th:selected="${opt.selected}">전체 지역</option>
+			</select>
+			<select name="lineId" aria-label="노선 필터">
+				<option th:each="opt : ${lineOptions}" th:value="${opt.value}"
+				        th:text="${opt.label}" th:selected="${opt.selected}">전체 노선</option>
+			</select>
+			<select name="sort" aria-label="정렬">
+				<option value="" th:selected="${selectedSort == null}">역명순</option>
+				<option value="name_desc" th:selected="${selectedSort == 'name_desc'}">역명 역순</option>
+				<option value="pending" th:selected="${selectedSort == 'pending'}">미확인 제보 많은 순</option>
+			</select>
+			<button type="submit">검색</button>
+		</form>
+
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">역</th>
+				<th scope="col">노선</th>
+				<th scope="col">지역</th>
+				<th scope="col">미확인 제보</th>
+				<th scope="col">품질</th>
+				<th scope="col">출구 / 시설 / 자료</th>
+				<th scope="col">노드 / 간선</th>
+				<th scope="col">마지막 확인</th>
+				<th scope="col">작업</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:if="${stations.isEmpty()}">
+				<td colspan="9">
+					<div th:replace="~{admin/fragments/empty-state :: panel('검색된 역이 없습니다.', '검색어·지역·노선 필터를 조정해 보세요.')}"></div>
+				</td>
+			</tr>
+			<tr th:each="station : ${stations}">
+				<td>
+					<a th:href="@{/admin/stations/{stationId}/page(stationId=${station.stationId})}"
+					   th:text="${station.stationName}">상록수</a>
+				</td>
+				<td th:text="${station.lineNames}">4호선</td>
+				<td th:text="${station.region}">수도권</td>
+				<td>
+					<!-- 미확인 제보 뱃지: 대기(SUBMITTED+UNDER_REVIEW) 건수. 0이면 표시하지 않는다. -->
+					<a th:if="${station.pendingReportCount > 0}" class="count-badge"
+					   th:href="@{/admin/reports/page(station=${station.stationId})}"
+					   th:text="${station.pendingReportCount}"
+					   th:attr="aria-label=|${station.stationName} 미확인 제보 ${station.pendingReportCount}건|">0</a>
+					<span th:unless="${station.pendingReportCount > 0}" class="meta">0</span>
+				</td>
+				<td><span class="admin-status" th:text="${station.qualityLabel}">정보 확인 중</span></td>
+				<td th:text="|${station.exitCount} / ${station.facilityCount} / ${station.layoutSourceCount}|">0 / 0 / 0</td>
+				<td th:text="|${station.routeNodeCount} / ${station.routeEdgeCount}|">0 / 0</td>
+				<td th:text="${station.lastVerifiedAt}">2026-06-20</td>
+				<td>
+					<a class="admin-btn" th:href="@{/admin/stations/{stationId}/page(stationId=${station.stationId})}">상세</a>
+				</td>
+			</tr>
+			</tbody>
+		</table>
+		<div th:replace="~{admin/fragments/pagination :: pager('역 목록 페이지', ${page}, ${paginationLinks})}"></div>
+	</div>
 </main>
 </div>
 <th:block th:replace="~{admin/fragments/shell :: scripts}"></th:block>

--- a/backend/src/main/resources/templates/admin/stations/list.html
+++ b/backend/src/main/resources/templates/admin/stations/list.html
@@ -57,6 +57,7 @@
 				<th scope="col">노선</th>
 				<th scope="col">지역</th>
 				<th scope="col">미확인 제보</th>
+				<th scope="col">확인 필요 시설</th>
 				<th scope="col">품질</th>
 				<th scope="col">출구 / 시설 / 자료</th>
 				<th scope="col">노드 / 간선</th>
@@ -66,7 +67,7 @@
 			</thead>
 			<tbody>
 			<tr th:if="${stations.isEmpty()}">
-				<td colspan="9">
+				<td colspan="10">
 					<div th:replace="~{admin/fragments/empty-state :: panel('검색된 역이 없습니다.', '검색어·지역·노선 필터를 조정해 보세요.')}"></div>
 				</td>
 			</tr>
@@ -84,6 +85,14 @@
 					   th:text="${station.pendingReportCount}"
 					   th:attr="aria-label=|${station.stationName} 미확인 제보 ${station.pendingReportCount}건|">0</a>
 					<span th:unless="${station.pendingReportCount > 0}" class="meta">0</span>
+				</td>
+				<td>
+					<!-- 확인 필요 시설 뱃지: 고장·공사·폐쇄·확인 필요·사용자 제보 시설 수. 클릭 시 역 필터 시설 상태판. -->
+					<a th:if="${station.attentionFacilityCount > 0}" class="count-badge is-warn"
+					   th:href="@{/admin/facilities/page(stationId=${station.stationId},sort='attention')}"
+					   th:text="${station.attentionFacilityCount}"
+					   th:attr="aria-label=|${station.stationName} 확인 필요 시설 ${station.attentionFacilityCount}개|">0</a>
+					<span th:unless="${station.attentionFacilityCount > 0}" class="meta">0</span>
 				</td>
 				<td><span class="admin-status" th:text="${station.qualityLabel}">정보 확인 중</span></td>
 				<td th:text="|${station.exitCount} / ${station.facilityCount} / ${station.layoutSourceCount}|">0 / 0 / 0</td>

--- a/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminV3PageSmokeTest.java
+++ b/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminV3PageSmokeTest.java
@@ -45,6 +45,35 @@ class AdminV3PageSmokeTest {
 	}
 
 	@Test
+	@DisplayName("시설 상태판은 유형·상태·역 필터 툴바와 제보·허브 크로스링크를 렌더한다")
+	void facilityStatusBoardRendersV4ToolbarAndCrossLinks() throws Exception {
+		String html = mockMvc.perform(get("/admin/facilities/page")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn().getResponse().getContentAsString();
+
+		assertThat(html)
+			.contains("시설·역 이름 검색")
+			.contains("유형 필터")
+			.contains("상태 필터")
+			.contains("역 필터")
+			.contains("확인 필요 먼저")
+			// 역명은 허브(시설 탭)로, 제보는 역 필터 제보 대기열로 크로스링크한다.
+			.contains("/admin/stations/station-sangnoksu/page?tab=facilities")
+			.contains("/admin/reports/page?station=station-sangnoksu");
+
+		String fragment = mockMvc.perform(get("/admin/facilities/page")
+				.param("sort", "attention")
+				.header("HX-Request", "true")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn().getResponse().getContentAsString();
+		assertThat(fragment)
+			.contains("id=\"facility-results\"")
+			.doesNotContain("admin-shell");
+	}
+
+	@Test
 	@DisplayName("역 목록은 검색·지역·노선·정렬 툴바와 미확인 제보 뱃지를 렌더한다")
 	void stationListRendersV4ToolbarAndPendingBadge() throws Exception {
 		String html = mockMvc.perform(get("/admin/stations/page")

--- a/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminV3PageSmokeTest.java
+++ b/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminV3PageSmokeTest.java
@@ -45,6 +45,35 @@ class AdminV3PageSmokeTest {
 	}
 
 	@Test
+	@DisplayName("역 목록은 검색·지역·노선·정렬 툴바와 미확인 제보 뱃지를 렌더한다")
+	void stationListRendersV4ToolbarAndPendingBadge() throws Exception {
+		String html = mockMvc.perform(get("/admin/stations/page")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn().getResponse().getContentAsString();
+
+		assertThat(html)
+			.contains("역 이름 검색")
+			.contains("지역 필터")
+			.contains("노선 필터")
+			.contains("미확인 제보 많은 순")
+			.contains("미확인 제보")
+			// 상록수 역 링크가 상세 허브로 연결된다.
+			.contains("/admin/stations/station-sangnoksu/page");
+
+		// 정렬·지역 파라미터가 페이지네이션/툴바에 유지된다(htmx 부분 갱신도 같은 필터 공유).
+		String sorted = mockMvc.perform(get("/admin/stations/page")
+				.param("sort", "pending")
+				.header("HX-Request", "true")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn().getResponse().getContentAsString();
+		assertThat(sorted)
+			.contains("id=\"station-results\"")
+			.doesNotContain("admin-shell");
+	}
+
+	@Test
 	@DisplayName("역 상세는 허브 탭으로 개요·시설·제보·현장·구조를 오간다")
 	void stationDetailHubTabsNavigate() throws Exception {
 		String overview = getStationHub(null);

--- a/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminV3PageSmokeTest.java
+++ b/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminV3PageSmokeTest.java
@@ -45,6 +45,67 @@ class AdminV3PageSmokeTest {
 	}
 
 	@Test
+	@DisplayName("역 상세는 허브 탭으로 개요·시설·제보·현장·구조를 오간다")
+	void stationDetailHubTabsNavigate() throws Exception {
+		String overview = getStationHub(null);
+		assertThat(overview)
+			.contains("상록수")
+			.contains("개요")
+			.contains("제보 이력")
+			.contains("현장 확인")
+			.contains("구조·동선")
+			.contains("데이터 품질");
+
+		String reports = getStationHub("reports");
+		assertThat(reports)
+			.contains("제보 이력")
+			.contains("전체 제보 보기")
+			// 제보 이력 탭은 역 필터가 걸린 제보 대기열(#1740)로 딥링크한다.
+			.contains("/admin/reports/page?station=station-sangnoksu");
+
+		String field = getStationHub("field");
+		assertThat(field)
+			.contains("현장 확인")
+			.contains("/admin/field-verifications/station-sangnoksu/page");
+
+		String structure = getStationHub("structure");
+		assertThat(structure)
+			.contains("구조·동선")
+			.contains("/admin/stations/station-sangnoksu/layouts/page");
+
+		assertThat(getStationHub("facilities")).contains("접근성 시설");
+	}
+
+	@Test
+	@DisplayName("역 허브 탭 htmx 요청은 셸 없이 탭 패널 fragment만 돌려준다")
+	void stationDetailHubTabHtmxReturnsFragmentOnly() throws Exception {
+		String fragment = mockMvc.perform(get("/admin/stations/station-sangnoksu/page")
+				.param("tab", "reports")
+				.header("HX-Request", "true")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn().getResponse().getContentAsString();
+
+		assertThat(fragment)
+			.contains("id=\"station-hub\"")
+			.contains("제보 이력")
+			// fragment 응답은 셸(사이드바·<html>)을 포함하지 않는다.
+			.doesNotContain("admin-shell")
+			.doesNotContain("<html");
+	}
+
+	private String getStationHub(String tab) throws Exception {
+		var request = get("/admin/stations/station-sangnoksu/page")
+			.with(httpBasic("admin-user", "admin-test-password"));
+		if (tab != null) {
+			request = request.param("tab", tab);
+		}
+		return mockMvc.perform(request)
+			.andExpect(status().isOk())
+			.andReturn().getResponse().getContentAsString();
+	}
+
+	@Test
 	@DisplayName("관리자 시스템 화면은 health component 표를 표시한다")
 	void adminSystemPageShowsHealthComponents() throws Exception {
 		String html = mockMvc.perform(get("/admin/system/page")

--- a/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminV3PageSmokeTest.java
+++ b/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminV3PageSmokeTest.java
@@ -87,6 +87,7 @@ class AdminV3PageSmokeTest {
 			.contains("노선 필터")
 			.contains("미확인 제보 많은 순")
 			.contains("미확인 제보")
+			.contains("확인 필요 시설")
 			// 상록수 역 링크가 상세 허브로 연결된다.
 			.contains("/admin/stations/station-sangnoksu/page");
 

--- a/backend/src/test/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportRepositoryTest.java
@@ -520,6 +520,46 @@ class JdbcFacilityReportRepositoryTest {
 			.containsExactly("c", "b");
 	}
 
+	@Test
+	@DisplayName("대기 제보 집계는 역별로 SUBMITTED·UNDER_REVIEW만 센다")
+	void countPendingReportsByStationCountsOnlyPendingStatuses() {
+		repository.saveReport(reportAtFacilityStatus("a", "station-a", "facility-1", FacilityReportStatus.SUBMITTED));
+		repository.saveReport(reportAtFacilityStatus("b", "station-a", "facility-2", FacilityReportStatus.UNDER_REVIEW));
+		repository.saveReport(reportAtFacilityStatus("c", "station-a", "facility-1", FacilityReportStatus.ACCEPTED));
+		repository.saveReport(reportAtFacilityStatus("d", "station-b", "facility-1", FacilityReportStatus.SUBMITTED));
+
+		assertThat(repository.countPendingReportsByStation())
+			.hasSize(2)
+			.containsEntry("station-a", 2L)
+			.containsEntry("station-b", 1L);
+	}
+
+	private FacilityReport reportAtFacilityStatus(
+		String reportId,
+		String stationId,
+		String facilityId,
+		FacilityReportStatus status
+	) {
+		return new FacilityReport(
+			reportId,
+			"anonymous-user-1",
+			stationId,
+			facilityId,
+			FacilityReportType.BROKEN,
+			"신고 내용",
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			status,
+			LocalDateTime.of(2026, 6, 17, 9, 0),
+			null,
+			null
+		);
+	}
+
 	private FacilityReport reportAtFacility(
 		String reportId,
 		String stationId,

--- a/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitReadOnlyAdminPageModelTest.java
+++ b/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitReadOnlyAdminPageModelTest.java
@@ -88,8 +88,7 @@ class TransitReadOnlyAdminPageModelTest {
 			mock(FacilityReportUseCase.class),
 			mock(FieldVerificationUseCase.class),
 			AdminMasterLabelResolver.empty(),
-			WebMessageResolver.defaultMessages(),
-			new TransitFacilityStatusAssembler(transitMasterService)
+			WebMessageResolver.defaultMessages()
 		);
 		var model = new ExtendedModelMap();
 
@@ -109,8 +108,7 @@ class TransitReadOnlyAdminPageModelTest {
 			mock(FacilityReportUseCase.class),
 			mock(FieldVerificationUseCase.class),
 			AdminMasterLabelResolver.empty(),
-			WebMessageResolver.defaultMessages(),
-			new TransitFacilityStatusAssembler(transitMasterService)
+			WebMessageResolver.defaultMessages()
 		);
 		var redirectAttributes = new RedirectAttributesModelMap();
 

--- a/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitReadOnlyAdminPageModelTest.java
+++ b/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitReadOnlyAdminPageModelTest.java
@@ -88,7 +88,8 @@ class TransitReadOnlyAdminPageModelTest {
 			mock(FacilityReportUseCase.class),
 			mock(FieldVerificationUseCase.class),
 			AdminMasterLabelResolver.empty(),
-			WebMessageResolver.defaultMessages()
+			WebMessageResolver.defaultMessages(),
+			new TransitFacilityStatusAssembler(transitMasterService)
 		);
 		var model = new ExtendedModelMap();
 
@@ -108,7 +109,8 @@ class TransitReadOnlyAdminPageModelTest {
 			mock(FacilityReportUseCase.class),
 			mock(FieldVerificationUseCase.class),
 			AdminMasterLabelResolver.empty(),
-			WebMessageResolver.defaultMessages()
+			WebMessageResolver.defaultMessages(),
+			new TransitFacilityStatusAssembler(transitMasterService)
 		);
 		var redirectAttributes = new RedirectAttributesModelMap();
 

--- a/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitReadOnlyAdminPageModelTest.java
+++ b/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitReadOnlyAdminPageModelTest.java
@@ -49,7 +49,7 @@ class TransitReadOnlyAdminPageModelTest {
 		);
 		var model = new ExtendedModelMap();
 
-		String viewName = controller.facilitiesPage(null, null, model);
+		String viewName = controller.facilitiesPage(null, null, null, null, null, null, null, model);
 
 		assertThat(viewName).isEqualTo("admin/facilities/list");
 		assertThat(model.get("masterDataWritable")).isEqualTo(false);

--- a/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitReadOnlyAdminPageModelTest.java
+++ b/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitReadOnlyAdminPageModelTest.java
@@ -3,7 +3,11 @@ package com.easysubway.transit.adapter.in.web;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
+import com.easysubway.admin.web.AdminMasterLabelResolver;
+import com.easysubway.common.web.WebMessageResolver;
 import com.easysubway.datapack.application.port.in.DatapackReleaseBlockerSummaryUseCase;
+import com.easysubway.field.application.port.in.FieldVerificationUseCase;
+import com.easysubway.report.application.port.in.FacilityReportUseCase;
 import com.easysubway.transit.adapter.out.persistence.UnavailableTransitMasterRepository;
 import com.easysubway.transit.application.service.TransitMasterService;
 import com.easysubway.transit.domain.AccessibilityFacilityStatus;
@@ -80,7 +84,11 @@ class TransitReadOnlyAdminPageModelTest {
 		var controller = new TransitStationAdminPageController(
 			transitMasterService,
 			transitMasterService,
-			mock(DatapackReleaseBlockerSummaryUseCase.class)
+			mock(DatapackReleaseBlockerSummaryUseCase.class),
+			mock(FacilityReportUseCase.class),
+			mock(FieldVerificationUseCase.class),
+			AdminMasterLabelResolver.empty(),
+			WebMessageResolver.defaultMessages()
 		);
 		var model = new ExtendedModelMap();
 
@@ -96,7 +104,11 @@ class TransitReadOnlyAdminPageModelTest {
 		var controller = new TransitStationAdminPageController(
 			transitMasterService,
 			transitMasterService,
-			mock(DatapackReleaseBlockerSummaryUseCase.class)
+			mock(DatapackReleaseBlockerSummaryUseCase.class),
+			mock(FacilityReportUseCase.class),
+			mock(FieldVerificationUseCase.class),
+			AdminMasterLabelResolver.empty(),
+			WebMessageResolver.defaultMessages()
 		);
 		var redirectAttributes = new RedirectAttributesModelMap();
 

--- a/backend/src/test/java/com/easysubway/transit/domain/AccessibilityFacilityStatusTest.java
+++ b/backend/src/test/java/com/easysubway/transit/domain/AccessibilityFacilityStatusTest.java
@@ -1,0 +1,24 @@
+package com.easysubway.transit.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("접근성 시설 상태")
+class AccessibilityFacilityStatusTest {
+
+	@Test
+	@DisplayName("확인 필요 판정은 고장·공사·폐쇄·확인 필요·사용자 제보만 참이다")
+	void needsAttentionCoversNonOperationalStatuses() {
+		// 역 목록 "확인 필요 시설" 뱃지와 시설 상태판 정렬이 공유하는 단일 판정 기준(#1741).
+		assertThat(AccessibilityFacilityStatus.BROKEN.needsAttention()).isTrue();
+		assertThat(AccessibilityFacilityStatus.UNDER_CONSTRUCTION.needsAttention()).isTrue();
+		assertThat(AccessibilityFacilityStatus.CLOSED.needsAttention()).isTrue();
+		assertThat(AccessibilityFacilityStatus.UNKNOWN.needsAttention()).isTrue();
+		assertThat(AccessibilityFacilityStatus.USER_REPORTED.needsAttention()).isTrue();
+
+		assertThat(AccessibilityFacilityStatus.NORMAL.needsAttention()).isFalse();
+		assertThat(AccessibilityFacilityStatus.ADMIN_VERIFIED.needsAttention()).isFalse();
+	}
+}


### PR DESCRIPTION
## 관련 이슈

close #1741

## 작업 배경

역·시설 마스터를 **허브 구조**로 재편해 역 상세 한 화면에서 시설·제보·현장 확인·구조/동선을 오가고, 콘솔 어디서든 역/시설 이름으로 도달하게 한다. 마스터 화면군에서 원시 ID 노출을 제거한다. #1737 공용 UI(표준 테이블·빈상태·AdminMasterLabelResolver)와 #1740 제보 대기열(stationId 필터·제보 요약)을 재사용한다.

## 작업 내용

- **역 상세 허브 탭**(1/N): `stations/detail`을 탭(개요·시설·제보 이력·현장 확인·구조·동선)으로 재편. htmx `tabPanel` fragment(`?tab=` push-url), no-JS는 링크. 탭별 데이터만 로드(query budget). 제보 이력 탭=`FacilityReportUseCase`(#1740 stationId 질의) 재사용·이름(코드)·`?station=` 딥링크·대기 배지, 현장 확인 탭=`FieldVerificationUseCase` 세션/이력. 헤더 원시 stationId 제거.
- **역 목록 v4**(2/N): 검색·지역·노선 필터·정렬 htmx 툴바 + **미확인 제보 뱃지**(대기 건수, 역 필터 제보 대기열 딥링크). `countPendingReportsByStation()` 단일 GROUP BY 집계로 N+1 회피.
- **시설 상태판 v4**(3/N): 검색·유형·상태·역 필터·정렬 htmx 툴바. 원시 facilityId·stationId 제거, 역명→허브·시설행→관련 제보 크로스링크. `needsAttention` 판정.
- **확인 필요 시설 뱃지 + 크로스링크**(4/N): 역 목록 "확인 필요 시설" 뱃지(시설 상태판과 같은 `assemble()`·`needsAttention` 소스 재사용 → 정합). 제보 목록·상세 역 표기를 역 허브 딥링크로 통일 → 제보→허브 2클릭 완성.

## 검증

- 실행한 명령과 결과:
  - `cd backend && ./gradlew test` → **BUILD SUCCESSFUL** (전체 스위트, 2m4s)
  - `node --test tools/ci/repository-contract.test.mjs` → **158 pass / 0 fail**
  - #1740 병합(main=40387b42) 후 `git rebase --onto origin/main`로 재배치, `git merge origin/main` → Already up to date(충돌 없음)
  - 신규 테스트: MockMvc(허브 탭 네비·딥링크·htmx fragment / 역 목록 툴바·미확인 제보·확인 필요 뱃지 / 시설 상태판 툴바·크로스링크·fragment), JDBC `countPendingReportsByStation` 집계

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 허브 탭·역/시설 목록 v4 렌더·크로스링크 | backend | MockMvc 풀페이지/fragment 렌더 assert | `AdminV3PageSmokeTest` | ✅ 통과 |
| 대기 제보 역별 집계 | backend | JDBC(H2 PostgreSQL 모드) 집계 테스트 | `JdbcFacilityReportRepositoryTest` | ✅ 통과 |
| 읽기 전용 마스터·기존 화면 회귀 | backend | 컨트롤러 단위·release readiness·facilities API | `TransitReadOnlyAdminPageModelTest` 외 | ✅ 통과 |
| 탭 전환 시각·키보드 완주·스크린리더·2클릭 E2E | web | 브라우저 필요(Claude Chrome 미연결) | 자동 테스트는 서버 렌더·딥링크·no-JS만 커버 | ⏭ #1749 접근성 QA 이월 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 관리자 콘솔 화면·조회 로직만 변경(신규 마이그레이션 없음, 계약 불변). 백엔드 재배포만 필요.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `TransitStationAdminPageController` — 허브 탭 per-tab 로딩(query budget)과 새 의존성(FacilityReportUseCase·FieldVerificationUseCase·AdminMasterLabelResolver·WebMessageResolver·TransitFacilityStatusAssembler) 주입. `getStationVerification`은 미존재 시 예외라 `listStationVerifications().filter()`로 Optional 처리.
  - 뱃지 정합: 역 목록 "확인 필요 시설" 뱃지와 시설 상태판이 같은 `assemble()`+`needsAttention(BROKEN·UNDER_CONSTRUCTION·CLOSED·UNKNOWN·USER_REPORTED)`를 재사용한다.
  - `FacilityStatusRow`는 시설 상태 API 응답 형태라 필드 추가를 피하고 유형 필터는 `typeLabel` 문자열로 처리.
  - 원시 ID 제거: stations list/detail·facilities list에서 raw station/facility ID 단독 노출을 없앴다(ID는 URL에만). stations layouts·facilities editor는 원래 selects/names라 clean.

## 리스크

- 탭 전환 시각·키보드 완주·스크린리더 낭독·"제보→허브→시설 이력 2클릭" E2E는 브라우저 런타임 검증이 필요하나 Claude Chrome 미연결로 이번 PR 미수행 → #1749 접근성 QA 이월(자동 테스트는 서버 렌더·`?tab=`/딥링크·no-JS fallback·집계 정합 커버).
- `facilities/editor`(구조·동선 편집 UX 재설계)는 이슈 범위에서 제외(회귀 없음만 확인), 별도 후속.
- 허브 집계가 다른 바운디드 컨텍스트(report·field) 인바운드 포트를 읽는다 — 관리자 집계 화면의 read-only 재사용으로 결합을 허용, 쓰기 경로는 각 컨텍스트가 소유.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (backend deploy only — 병합 후 CD 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 시설/역 목록과 상세 화면에 필터, 정렬, 탭 기반 탐색이 추가되어 원하는 정보로 더 빠르게 이동할 수 있습니다.
  * 역 상세에서 개요, 시설, 제보 이력, 현장 확인, 구조 정보를 탭으로 나눠 볼 수 있습니다.
  * 역별 미확인 제보 수와 확인 필요 시설 수가 목록에 표시됩니다.

* **Bug Fixes**
  * 검색·필터·탭 전환 시 페이지 상태와 URL이 더 잘 유지되도록 개선되었습니다.
  * 제보 및 시설 관련 화면에서 관련 역으로 이동하는 링크가 더 명확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->