### PR TITLE
[Fix] 관리자 템플릿 input aria-label·셸 title — SonarCloud 신뢰성 A 복구

### DIFF
--- a/backend/src/main/resources/templates/admin/fragments/shell.html
+++ b/backend/src/main/resources/templates/admin/fragments/shell.html
@@ -1,5 +1,9 @@
 <!doctype html>
 <html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="utf-8">
+	<title>통합 관리자 공용 셸</title>
+</head>
 <body>
 <nav class="admin-sidebar" id="admin-primary-nav" th:fragment="sidebar(active)" aria-label="통합 관리자 화면">
 	<div class="admin-brand">

--- a/backend/src/main/resources/templates/admin/incidents/list.html
+++ b/backend/src/main/resources/templates/admin/incidents/list.html
@@ -117,10 +117,12 @@
 								<input type="hidden" name="targetStatus" th:value="${option.code}">
 								<th:block th:if="${option.requiresResolution}">
 									<label th:for="${'incident-resolution-' + incident.incidentId}">해결 기록</label>
-									<input th:id="${'incident-resolution-' + incident.incidentId}" name="resolution" required placeholder="해결 기록">
+									<input th:id="${'incident-resolution-' + incident.incidentId}" name="resolution" required
+									       aria-label="해결 기록" placeholder="해결 기록">
 								</th:block>
 								<label th:for="${'incident-note-' + incident.incidentId + '-' + option.code}">메모</label>
-								<input th:id="${'incident-note-' + incident.incidentId + '-' + option.code}" name="note" placeholder="전이 메모(선택)">
+								<input th:id="${'incident-note-' + incident.incidentId + '-' + option.code}" name="note"
+								       aria-label="전이 메모" placeholder="전이 메모(선택)">
 								<button type="submit" th:text="${option.label + '(으)로'}">전이</button>
 							</form>
 						</div>

--- a/backend/src/main/resources/templates/admin/stations/layouts.html
+++ b/backend/src/main/resources/templates/admin/stations/layouts.html
@@ -57,7 +57,7 @@
 					      method="post">
 						<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 						<label class="meta" th:for="|source-type-${source.id}|">자료 유형</label>
-						<select name="sourceType" th:id="|source-type-${source.id}|">
+						<select name="sourceType" th:id="|source-type-${source.id}|" aria-label="자료 유형">
 							<option th:each="option : ${sourceTypeOptions}"
 							        th:value="${option.value}"
 							        th:text="${option.label}"
@@ -65,29 +65,29 @@
 						</select>
 						<label class="meta" th:for="|source-name-${source.id}|">자료 이름</label>
 						<input type="text" name="sourceName" th:id="|source-name-${source.id}|"
-						       th:value="${source.sourceName}" required>
+						       aria-label="자료 이름" th:value="${source.sourceName}" required>
 						<label class="meta" th:for="|source-url-${source.id}|">자료 URL</label>
 						<input type="url" name="sourceUrl" th:id="|source-url-${source.id}|"
-						       th:value="${source.sourceUrl}" required>
+						       aria-label="자료 URL" th:value="${source.sourceUrl}" required>
 						<label class="meta" th:for="|source-license-${source.id}|">라이선스</label>
 						<input type="text" name="license" th:id="|source-license-${source.id}|"
-						       th:value="${source.license}" required>
+						       aria-label="라이선스" th:value="${source.license}" required>
 						<label class="meta" th:for="|commercial-use-${source.id}|">상업적 이용</label>
-						<select name="commercialUseAllowed" th:id="|commercial-use-${source.id}|">
+						<select name="commercialUseAllowed" th:id="|commercial-use-${source.id}|" aria-label="상업적 이용">
 							<option value="false" th:selected="${!source.commercialUseAllowed}">불가</option>
 							<option value="true" th:selected="${source.commercialUseAllowed}">가능</option>
 						</select>
 						<label class="meta" th:for="|attribution-${source.id}|">출처 표시</label>
-						<select name="attributionRequired" th:id="|attribution-${source.id}|">
+						<select name="attributionRequired" th:id="|attribution-${source.id}|" aria-label="출처 표시">
 							<option value="true" th:selected="${source.attributionRequired}">필요</option>
 							<option value="false" th:selected="${!source.attributionRequired}">불필요</option>
 						</select>
 						<label class="meta" th:for="|captured-at-${source.id}|">수집일</label>
 						<input type="date" name="capturedAt" th:id="|captured-at-${source.id}|"
-						       th:value="${source.capturedAt}" required>
+						       aria-label="수집일" th:value="${source.capturedAt}" required>
 						<label class="meta" th:for="|reviewed-at-${source.id}|">확인일</label>
 						<input type="date" name="reviewedAt" th:id="|reviewed-at-${source.id}|"
-						       th:value="${source.rawReviewedAt}">
+						       aria-label="확인일" th:value="${source.rawReviewedAt}">
 						<button type="submit" th:disabled="${!masterDataWritable}">저장</button>
 					</form>
 					<span class="meta" th:text="${source.sourceName}">상록수역 역사 안내도</span>
@@ -134,7 +134,7 @@
 						<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 						<input type="hidden" name="expectedVersion" th:value="${layout.version}">
 							<label class="meta" th:for="|status-${layout.id}|">확인 상태</label>
-						<select name="status" th:id="|status-${layout.id}|">
+						<select name="status" th:id="|status-${layout.id}|" aria-label="확인 상태">
 							<option th:each="option : ${layoutStatusOptions}"
 							        th:value="${option.value}"
 							        th:text="${option.label}"
@@ -179,16 +179,16 @@
 						<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 						<label class="meta" th:for="|display-label-${node.id}|">표시 라벨</label>
 						<input type="text" name="displayLabel" th:id="|display-label-${node.id}|"
-						       th:value="${node.displayLabel}" required>
+						       aria-label="표시 라벨" th:value="${node.displayLabel}" required>
 						<label class="meta" th:for="|display-x-${node.id}|">x</label>
 						<input type="number" name="displayX" th:id="|display-x-${node.id}|"
-						       th:value="${node.displayX}" min="0" required>
+						       aria-label="표시 x 좌표" th:value="${node.displayX}" min="0" required>
 						<label class="meta" th:for="|display-y-${node.id}|">y</label>
 						<input type="number" name="displayY" th:id="|display-y-${node.id}|"
-						       th:value="${node.displayY}" min="0" required>
+						       aria-label="표시 y 좌표" th:value="${node.displayY}" min="0" required>
 						<label class="meta" th:for="|accessibility-note-${node.id}|">접근성 메모</label>
 						<input type="text" name="accessibilityNote" th:id="|accessibility-note-${node.id}|"
-						       th:value="${node.rawAccessibilityNote}">
+						       aria-label="접근성 메모" th:value="${node.rawAccessibilityNote}">
 						<button type="submit" th:disabled="${!masterDataWritable}">저장</button>
 						<span class="meta" th:text="${node.positionLabel}">x 120, y 240</span>
 						<span class="meta" th:text="${node.layoutId}">layout-sangnoksu-draft</span>
@@ -227,36 +227,36 @@
 						<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 						<label class="meta" th:for="|distance-meters-${edge.id}|">거리 m</label>
 						<input type="number" name="distanceMeters" th:id="|distance-meters-${edge.id}|"
-						       th:value="${edge.distanceMeters}" min="0" required>
+						       aria-label="거리 m" th:value="${edge.distanceMeters}" min="0" required>
 						<label class="meta" th:for="|estimated-seconds-${edge.id}|">예상 초</label>
 						<input type="number" name="estimatedSeconds" th:id="|estimated-seconds-${edge.id}|"
-						       th:value="${edge.estimatedSeconds}" min="0" required>
+						       aria-label="예상 초" th:value="${edge.estimatedSeconds}" min="0" required>
 						<label class="meta" th:for="|slope-level-${edge.id}|">경사</label>
 						<input type="number" name="slopeLevel" th:id="|slope-level-${edge.id}|"
-						       th:value="${edge.slopeLevel}" min="1" max="5" required>
+						       aria-label="경사 수준" th:value="${edge.slopeLevel}" min="1" max="5" required>
 						<label class="meta" th:for="|width-level-${edge.id}|">폭</label>
 						<input type="number" name="widthLevel" th:id="|width-level-${edge.id}|"
-						       th:value="${edge.widthLevel}" min="1" max="5" required>
+						       aria-label="폭 수준" th:value="${edge.widthLevel}" min="1" max="5" required>
 							<label class="meta" th:for="|reliability-score-${edge.id}|">확인 정도</label>
 						<input type="number" name="reliabilityScore" th:id="|reliability-score-${edge.id}|"
-						       th:value="${edge.reliabilityScore}" min="0" max="100" required>
+						       aria-label="확인 정도" th:value="${edge.reliabilityScore}" min="0" max="100" required>
 						<label class="meta" th:for="|has-stairs-${edge.id}|">계단</label>
-						<select name="hasStairs" th:id="|has-stairs-${edge.id}|">
+						<select name="hasStairs" th:id="|has-stairs-${edge.id}|" aria-label="계단">
 							<option value="false" th:selected="${!edge.hasStairs}">없음</option>
 							<option value="true" th:selected="${edge.hasStairs}">포함</option>
 						</select>
 						<label class="meta" th:for="|requires-elevator-${edge.id}|">엘리베이터</label>
-						<select name="requiresElevator" th:id="|requires-elevator-${edge.id}|">
+						<select name="requiresElevator" th:id="|requires-elevator-${edge.id}|" aria-label="엘리베이터 필요">
 							<option value="false" th:selected="${!edge.requiresElevator}">불필요</option>
 							<option value="true" th:selected="${edge.requiresElevator}">필요</option>
 						</select>
 						<label class="meta" th:for="|requires-escalator-${edge.id}|">에스컬레이터</label>
-						<select name="requiresEscalator" th:id="|requires-escalator-${edge.id}|">
+						<select name="requiresEscalator" th:id="|requires-escalator-${edge.id}|" aria-label="에스컬레이터 필요">
 							<option value="false" th:selected="${!edge.requiresEscalator}">불필요</option>
 							<option value="true" th:selected="${edge.requiresEscalator}">필요</option>
 						</select>
 						<label class="meta" th:for="|active-${edge.id}|">활성</label>
-						<select name="active" th:id="|active-${edge.id}|">
+						<select name="active" th:id="|active-${edge.id}|" aria-label="활성 여부">
 							<option value="true" th:selected="${edge.active}">활성</option>
 							<option value="false" th:selected="${!edge.active}">비활성</option>
 						</select>


### PR DESCRIPTION
## 관련 이슈

관련: #1735 (관리자 콘솔 에픽 품질 게이트)

## 작업 배경

main(#1800 병합 후 f62aa3af)에서 SonarCloud Quality Gate가 실패했다 — "C Reliability Rating on New Code (required ≥ A)". 원인은 Thymeleaf `th:for`/`th:id`로 라벨을 연결한 입력을 SonarCloud 정적 HTML 분석이 해석하지 못해 생기는 `Web:InputWithoutLabelCheck` 오탐(+ 프래그먼트 셸의 `Web:PageWithoutTitleCheck`)이다. SonarCloud는 필수 체크는 아니지만, 팀 규약(정적 aria-label·fragment title로 신뢰성 A 유지)대로 신규 코드 신뢰성을 A로 되돌린다.

## 작업 내용

렌더 동작·폼 제출 로직 변화 없이 정적 접근성 속성만 보강한다.

- **incidents/list.html**: 장애 전이 폼의 `note`·`resolution` 입력에 `aria-label`(#1742 신규분 2건).
- **stations/layouts.html**: 자료·내부 이동 노드·간선 편집 폼의 입력/셀렉트 22개에 `aria-label`(#1737/#1738 신규분).
- **fragments/shell.html**: 프래그먼트 파일에 `<head><title>` 추가(프래그먼트는 추출 사용이라 title은 렌더에 출력되지 않음).

시각 라벨(`<label th:for>`)은 그대로 유지하고 aria-label을 중복 제공해 스크린리더·Sonar 양쪽을 만족한다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test` (backend 전체) → **BUILD SUCCESSFUL** (2m 10s). 셸은 전 관리자 화면 공용이라 회귀 확인.
  - `node --test tools/ci/repository-contract.test.mjs` → **158 pass / 0 fail**.
  - 대상: SonarCloud 신규 코드 비제외 신뢰성 버그(incidents 2 + layouts 22 + shell 1) 해소.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 관리자 템플릿 회귀 없음 | backend | 전체 스위트(셸 공용 렌더 포함) | BUILD SUCCESSFUL | 통과 |
| repository-contract | ci | `repository-contract.test.mjs` | 158 pass | 통과 |
| SonarCloud 신뢰성 A 복구 | ci | 병합 후 SonarCloud 재분석 | 병합 후 확인 | 병합 후 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 배포 대상(정적 템플릿 속성만). 신규 Flyway 없음.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `th:for`/`th:id`로 이미 라벨이 연결돼 있어 이는 Sonar 정적 분석의 한계에서 오는 오탐이다. aria-label은 시각 라벨과 중복이며 스크린리더에도 유효하다. 폼 name·제출 로직·검증은 불변.

## 리스크

- fragment/shell.html에 head/title 추가 — 프래그먼트는 `th:fragment`/`th:replace`로 추출 사용되어 자체 head는 렌더 출력에 포함되지 않는다. 전체 스위트가 전 관리자 화면 렌더로 회귀 없음을 확인.
- 이번 범위 밖: `tools/**` 스크립트의 Sonar 신뢰성 이슈(신규-코드 미해당으로 게이트 C에 미포함). 별건.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 관리자 화면의 여러 입력 폼에 접근성 라벨을 보강해 스크린 리더 사용성을 개선했습니다.
  * 전이 입력 영역의 해결 기록과 메모 입력에 안내 문구와 접근성 속성을 추가해 작성 경험을 개선했습니다.
* **Style**
  * 관리자 공용 셸의 문서 헤더와 페이지 제목을 정리해 상단 구조를 명확하게 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->