### PR TITLE
[Feat] 데이터팩 파이프라인 뷰 — 단계 그래프·후보 상세 재구성·승격 확인 (#1745)

### DIFF
--- a/backend/src/main/java/com/easysubway/admin/navigation/AdminProgram.java
+++ b/backend/src/main/java/com/easysubway/admin/navigation/AdminProgram.java
@@ -20,6 +20,7 @@ public enum AdminProgram {
 	INCIDENTS("a-incidents", "운영·분석", "장애관리", "/admin/incidents/page", AdminPermission.OPERATIONS_MANAGE),
 	ROUTE_SEARCHES("a-route-searches", "운영·분석", "경로 검색 분석", "/admin/routes/searches/page", AdminPermission.ADMIN_VIEW),
 	ROUTE_FEEDBACK("a-route-feedback", "운영·분석", "경로 피드백 분석", "/admin/routes/feedback/page", AdminPermission.ADMIN_VIEW),
+	DATAPACK_PIPELINE("a-datapack-pipeline", "데이터팩", "파이프라인 개요", "/admin/datapack/pipeline/page", AdminPermission.DATAPACK_READ),
 	DATAPACK_SOURCE_SNAPSHOTS("a-datapack-source-snapshots", "데이터팩", "원천 스냅샷", "/admin/datapack/source-snapshots/page", AdminPermission.DATAPACK_READ),
 	DATAPACK_ALIAS_QUARANTINE("a-datapack-alias-quarantine", "데이터팩", "별칭·격리 검토", "/admin/datapack/alias-quarantine/page", AdminPermission.DATAPACK_READ),
 	DATAPACK_FACILITY_EVIDENCE("a-datapack-facility-evidence", "데이터팩", "시설 근거 검토", "/admin/datapack/facility-evidence/page", AdminPermission.DATAPACK_READ),

--- a/backend/src/main/java/com/easysubway/datapack/adapter/in/web/DatapackPipelineAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/datapack/adapter/in/web/DatapackPipelineAdminPageController.java
@@ -1,0 +1,127 @@
+package com.easysubway.datapack.adapter.in.web;
+
+import com.easysubway.datapack.application.port.in.DatapackReleaseBlockerSummaryUseCase;
+import com.easysubway.datapack.application.port.in.DatapackReleaseBlockerSummaryUseCase.DatapackReleaseBlockerSummary;
+import java.util.List;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+/**
+ * 데이터팩 파이프라인 개요(#1745). 원천 스냅샷 → 후보 생성 → 게이트 6종 → 채널 승격을 한 화면의
+ * 단계 그래프로 보여주고, 각 단계에서 해당 화면으로 드릴다운한다. 단계별 blocker 수는 대시보드·역
+ * 요약과 같은 {@link DatapackReleaseBlockerSummaryUseCase}를 재사용해 정합을 보장한다(중복 집계 없음).
+ *
+ * <p>승인·게시 트리거 자체는 #1694 범위다. 이 화면은 정보 구조·드릴다운까지만 제공한다.
+ */
+@Controller
+class DatapackPipelineAdminPageController {
+
+	private final DatapackReleaseBlockerSummaryUseCase releaseBlockerSummaryUseCase;
+
+	DatapackPipelineAdminPageController(DatapackReleaseBlockerSummaryUseCase releaseBlockerSummaryUseCase) {
+		this.releaseBlockerSummaryUseCase = releaseBlockerSummaryUseCase;
+	}
+
+	@GetMapping("/admin/datapack/pipeline/page")
+	@PreAuthorize("hasAuthority('admin.datapack.read')")
+	String pipeline(Model model) {
+		model.addAttribute("pipeline", PipelineView.from(releaseBlockerSummaryUseCase.summarize()));
+		return "admin/datapack/pipeline/list";
+	}
+
+	/**
+	 * 파이프라인 화면 뷰. 단계 그래프 노드와 sha 축약·채널 승격 정보를 표시용으로 정리한다.
+	 */
+	record PipelineView(
+		String candidateId,
+		String candidateIdShort,
+		String scopeId,
+		String status,
+		String statusTone,
+		String candidateCreatedAt,
+		Sha sourceSnapshotSetHash,
+		Sha manifestSha256,
+		Sha evidenceBundleSha256,
+		String evidenceWorkflowRunUrl,
+		String productionCandidateId,
+		String rollbackCandidateId,
+		long totalBlockers,
+		boolean productionPromoteAllowed,
+		String productionPromoteReason,
+		List<StageNode> stages
+	) {
+
+		static PipelineView from(DatapackReleaseBlockerSummary summary) {
+			boolean hasCandidate = !"-".equals(summary.candidateId());
+			String candidateDrill = hasCandidate
+				? "/admin/datapack/candidates/" + summary.candidateId() + "/page"
+				: "/admin/datapack/candidates/page";
+			List<StageNode> stages = List.of(
+				stage(1, "원천 스냅샷", 0, "/admin/datapack/source-snapshots/page", "원천 스냅샷 목록"),
+				stage(2, "후보 생성", 0, candidateDrill, hasCandidate ? "후보 상세" : "후보 목록"),
+				stage(3, "후보 게이트", summary.candidateGateBlockers(), "/admin/datapack/candidates/page", "후보 팩"),
+				stage(4, "별칭·격리", summary.aliasBlockers() + summary.quarantineBlockers(),
+					"/admin/datapack/alias-quarantine/page", "별칭·격리 검토"),
+				stage(5, "시설 근거", summary.facilityBlockers(), "/admin/datapack/facility-evidence/page", "시설 근거 검토"),
+				stage(6, "경로 게이트", summary.routeGateBlockers(), "/admin/datapack/route-gates/page", "경로 게이트"),
+				stage(7, "수동 오버라이드", summary.manualOverrideBlockers(),
+					"/admin/datapack/manual-overrides/page", "수동 오버라이드"),
+				stage(8, "매니페스트 서명", summary.manifestBlockers(), candidateDrill, "후보 상세"),
+				stage(9, "채널 승격", 0, "/admin/datapack/release-channels/page", "배포 채널"));
+			return new PipelineView(
+				summary.candidateId(),
+				shortHash(summary.candidateId()),
+				summary.scopeId(),
+				summary.status(),
+				statusTone(summary.status()),
+				summary.candidateCreatedAt() == null ? "-" : summary.candidateCreatedAt().toString(),
+				Sha.of(summary.sourceSnapshotSetHash()),
+				Sha.of(summary.manifestSha256()),
+				Sha.of(summary.evidenceBundleSha256()),
+				summary.evidenceWorkflowRunUrl(),
+				summary.productionCandidateId(),
+				summary.rollbackCandidateId(),
+				summary.totalBlockers(),
+				summary.productionPromoteAllowed(),
+				summary.productionPromoteReason(),
+				stages);
+		}
+
+		private static StageNode stage(int order, String label, long blockerCount, String drillUrl, String drillLabel) {
+			return new StageNode(order, label, blockerCount, blockerCount > 0, drillUrl, drillLabel);
+		}
+
+		private static String statusTone(String status) {
+			return switch (status) {
+				case "READY" -> "good";
+				case "확인 필요" -> "warn";
+				default -> "bad";
+			};
+		}
+
+		private static String shortHash(String value) {
+			if (value == null || value.isBlank() || "-".equals(value)) {
+				return "-";
+			}
+			return value.length() <= 8 ? value : value.substring(0, 8) + "…";
+		}
+	}
+
+	/** 단계 그래프 노드. blocker>0이면 blocked 강조하고, 클릭 시 해당 화면으로 드릴다운한다. */
+	record StageNode(int order, String label, long blockerCount, boolean blocked, String drillUrl, String drillLabel) {
+	}
+
+	/** sha 표기: 축약(첫 8자)과 원문을 함께 담아 복사·hover 전체 확인을 지원한다. */
+	record Sha(String shortValue, String fullValue) {
+
+		static Sha of(String value) {
+			if (value == null || value.isBlank() || "-".equals(value)) {
+				return new Sha("-", "-");
+			}
+			String shortValue = value.length() <= 8 ? value : value.substring(0, 8) + "…";
+			return new Sha(shortValue, value);
+		}
+	}
+}

--- a/backend/src/main/resources/templates/admin/datapack/candidates/detail.html
+++ b/backend/src/main/resources/templates/admin/datapack/candidates/detail.html
@@ -4,7 +4,7 @@
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<meta name="htmx-config" content='{"includeIndicatorStyles":false}'>
-	<title>Candidate Pack Detail</title>
+	<title>후보 팩 상세</title>
 	<link rel="stylesheet" th:href="@{/css/admin-v3.css}">
 </head>
 <body class="admin-v3">
@@ -14,70 +14,108 @@
 <main class="admin-main">
 	<div th:replace="~{admin/fragments/shell :: topbar}"></div>
 	<div th:replace="~{admin/fragments/shell :: contentStart}"></div>
+	<nav th:replace="~{admin/fragments/shell :: breadcrumb('데이터팩', '파이프라인 개요', '/admin/datapack/pipeline/page', ${candidate.id})}"></nav>
 	<header class="admin-page-head">
 		<div>
 			<h1 th:text="${candidate.id}">candidate-id</h1>
-			<p>buildSpec, candidate 입력, release evidence bundle을 읽기 전용으로 확인합니다.</p>
+			<p th:text="${'scope ' + candidate.scopeId + ' · ' + candidate.artifactKind + ' · ' + candidate.version}">scope</p>
+		</div>
+		<div class="admin-actions">
+			<a class="admin-btn" th:href="@{/admin/datapack/pipeline/page}">파이프라인 개요</a>
 		</div>
 	</header>
 
 	<section class="admin-panel">
-		<h2>Artifact</h2>
+		<h2>게이트 체크리스트</h2>
+		<p class="summary" th:text="${evidenceBundle.productionPromoteReason()}">production promote 상태</p>
 		<table>
+			<thead>
+			<tr>
+				<th scope="col">게이트</th>
+				<th scope="col">상태</th>
+			</tr>
+			</thead>
 			<tbody>
-			<tr><th scope="row">scope</th><td th:text="${candidate.scopeId}">scope</td></tr>
-			<tr><th scope="row">artifactKind</th><td th:text="${candidate.artifactKind}">DATAPACK</td></tr>
-			<tr><th scope="row">version</th><td th:text="${candidate.version}">version</td></tr>
-			<tr><th scope="row">approval</th><td th:text="${candidate.approvalStatus}">READY_FOR_APPROVAL</td></tr>
-			<tr><th scope="row">sourceSnapshotSetHash</th><td th:text="${candidate.sourceSnapshotSetHash}">sha</td></tr>
-			<tr><th scope="row">overrideSetHash</th><td th:text="${candidate.overrideSetHash}">sha</td></tr>
-			<tr><th scope="row">buildSpec</th><td th:text="${candidate.buildSpecSha256}">sha</td></tr>
-			<tr><th scope="row">sourceInventory</th><td th:text="${candidate.sourceInventorySha256}">sha</td></tr>
-			<tr><th scope="row">sqlite/gzip/manifest</th><td><span th:text="${candidate.sqliteSha256}">sqlite</span> <span th:text="${candidate.gzipSha256}">gzip</span> <span th:text="${candidate.manifestSha256}">manifest</span></td></tr>
+			<tr>
+				<td>원천 커버리지</td>
+				<td><span th:replace="~{admin/fragments/shell :: statusAuto(${candidate.coverageStatus})}">확인 필요</span></td>
+			</tr>
+			<tr>
+				<td>검증기(Validator)</td>
+				<td><span th:replace="~{admin/fragments/shell :: statusAuto(${candidate.validatorStatus})}">확인 필요</span></td>
+			</tr>
+			<tr>
+				<td>경로 회귀</td>
+				<td><span th:replace="~{admin/fragments/shell :: statusAuto(${candidate.routeRegressionStatus})}">확인 필요</span></td>
+			</tr>
+			<tr>
+				<td>Android 증거</td>
+				<td><span th:replace="~{admin/fragments/shell :: statusAuto(${candidate.androidEvidenceStatus})}">확인 필요</span></td>
+			</tr>
+			<tr>
+				<td>매니페스트 서명</td>
+				<td><span th:replace="~{admin/fragments/shell :: statusAuto(${evidenceBundle.manifestSignatureStatus})}">확인 필요</span></td>
+			</tr>
+			<tr>
+				<td>승인</td>
+				<td><span th:replace="~{admin/fragments/shell :: statusAuto(${candidate.approvalStatus})}">확인 필요</span></td>
+			</tr>
 			</tbody>
 		</table>
 	</section>
 
 	<section class="admin-panel">
-		<h2>Input</h2>
+		<h2>증거·산출물</h2>
+		<dl class="admin-meta-list">
+			<dt>증거 워크플로</dt>
+			<dd th:text="${evidenceBundle.workflowRunUrl}">workflow</dd>
+			<dt>증거 번들 sha256</dt>
+			<dd><span th:title="${evidenceBundle.evidenceBundleSha256}" th:text="${#strings.abbreviate(evidenceBundle.evidenceBundleSha256, 11)}">sha</span></dd>
+			<dt>매니페스트 sha256</dt>
+			<dd><span th:title="${candidate.manifestSha256}" th:text="${#strings.abbreviate(candidate.manifestSha256, 11)}">sha</span></dd>
+			<dt>원천 스냅샷 세트 hash</dt>
+			<dd><span th:title="${candidate.sourceSnapshotSetHash}" th:text="${#strings.abbreviate(candidate.sourceSnapshotSetHash, 11)}">sha</span></dd>
+			<dt>오버라이드 세트 hash</dt>
+			<dd><span th:title="${candidate.overrideSetHash}" th:text="${#strings.abbreviate(candidate.overrideSetHash, 11)}">sha</span></dd>
+		</dl>
+		<details>
+			<summary>sha 원문 보기</summary>
+			<table>
+				<tbody>
+				<tr><th scope="row">buildSpec</th><td th:text="${candidate.buildSpecSha256}">sha</td></tr>
+				<tr><th scope="row">sourceInventory</th><td th:text="${candidate.sourceInventorySha256}">sha</td></tr>
+				<tr><th scope="row">sqlite</th><td th:text="${candidate.sqliteSha256}">sha</td></tr>
+				<tr><th scope="row">gzip</th><td th:text="${candidate.gzipSha256}">sha</td></tr>
+				<tr><th scope="row">manifest</th><td th:text="${candidate.manifestSha256}">sha</td></tr>
+				<tr><th scope="row">evidenceBundle</th><td th:text="${evidenceBundle.evidenceBundleSha256}">sha</td></tr>
+				</tbody>
+			</table>
+		</details>
+	</section>
+
+	<section class="admin-panel">
+		<h2>입력 원장</h2>
 		<table>
 			<tbody>
-			<tr><th scope="row">sourceSnapshotIds</th><td th:text="${candidateInput.sourceSnapshotIds}">snapshot ids</td></tr>
-			<tr><th scope="row">approvedAliasLedgerHash</th><td th:text="${candidateInput.approvedAliasLedgerHash}">sha</td></tr>
-			<tr><th scope="row">facilityEvidenceLedgerHash</th><td th:text="${candidateInput.facilityEvidenceLedgerHash}">sha</td></tr>
-			<tr><th scope="row">routeEvidenceLedgerHash</th><td th:text="${candidateInput.routeEvidenceLedgerHash}">sha</td></tr>
-			<tr><th scope="row">approvedOverrideSetHash</th><td th:text="${candidateInput.approvedOverrideSetHash}">sha</td></tr>
+			<tr><th scope="row">원천 스냅샷 ids</th><td th:text="${candidateInput.sourceSnapshotIds}">snapshot ids</td></tr>
+			<tr><th scope="row">승인 별칭 원장 hash</th><td><span th:title="${candidateInput.approvedAliasLedgerHash}" th:text="${#strings.abbreviate(candidateInput.approvedAliasLedgerHash, 11)}">sha</span></td></tr>
+			<tr><th scope="row">시설 근거 원장 hash</th><td><span th:title="${candidateInput.facilityEvidenceLedgerHash}" th:text="${#strings.abbreviate(candidateInput.facilityEvidenceLedgerHash, 11)}">sha</span></td></tr>
+			<tr><th scope="row">경로 근거 원장 hash</th><td><span th:title="${candidateInput.routeEvidenceLedgerHash}" th:text="${#strings.abbreviate(candidateInput.routeEvidenceLedgerHash, 11)}">sha</span></td></tr>
+			<tr><th scope="row">승인 오버라이드 세트 hash</th><td><span th:title="${candidateInput.approvedOverrideSetHash}" th:text="${#strings.abbreviate(candidateInput.approvedOverrideSetHash, 11)}">sha</span></td></tr>
 			</tbody>
 		</table>
 	</section>
 
 	<section class="admin-panel">
-		<h2>Evidence Bundle</h2>
-		<p class="summary">raw evidence 원문은 표시하지 않고 검증된 hash/status만 표시합니다.</p>
-		<p class="summary" th:text="${evidenceBundle.productionPromoteReason()}">production promote 차단</p>
-		<table>
-			<tbody>
-			<tr><th scope="row">evidenceBundleSha256</th><td th:text="${evidenceBundle.evidenceBundleSha256}">sha</td></tr>
-			<tr><th scope="row">workflowRunUrl</th><td th:text="${evidenceBundle.workflowRunUrl}">workflow</td></tr>
-			<tr><th scope="row">validator</th><td th:text="${evidenceBundle.validatorStatus}">PASS</td></tr>
-			<tr><th scope="row">routeRegression</th><td th:text="${evidenceBundle.routeRegressionStatus}">PASS</td></tr>
-			<tr><th scope="row">manifestSignature</th><td th:text="${evidenceBundle.manifestSignatureStatus}">PASS</td></tr>
-			<tr><th scope="row">androidEvidence</th><td th:text="${evidenceBundle.androidEvidenceStatus}">PASS</td></tr>
-			</tbody>
-		</table>
-	</section>
-
-	<section class="admin-panel">
-		<h2>Gate 재실행</h2>
+		<h2>게이트 재실행</h2>
 		<form method="post" th:action="@{'/admin/datapack/candidates/' + ${candidate.id} + '/rerun-gates'}">
 			<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 			<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 			<input type="hidden" name="idempotencyKey" th:value="${'candidate-rerun-' + candidate.id}">
-			<label>
-				reason
+			<label>사유
 				<input name="reason" value="candidate gates rerun requested" required>
 			</label>
-			<button type="submit">gate 재실행</button>
+			<button type="submit">게이트 재실행</button>
 		</form>
 	</section>
 </main>

--- a/backend/src/main/resources/templates/admin/datapack/pipeline/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/pipeline/list.html
@@ -1,0 +1,115 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="htmx-config" content='{"includeIndicatorStyles":false}'>
+	<title>데이터팩 파이프라인 개요</title>
+	<link rel="stylesheet" th:href="@{/css/admin-v3.css}">
+</head>
+<body class="admin-v3">
+<a th:replace="~{admin/fragments/shell :: skipLink}"></a>
+<div class="admin-shell">
+<div th:replace="~{admin/fragments/shell :: sidebar('a-datapack-pipeline')}"></div>
+<main class="admin-main">
+	<div th:replace="~{admin/fragments/shell :: topbar}"></div>
+	<div th:replace="~{admin/fragments/shell :: contentStart}"></div>
+	<header class="admin-page-head">
+		<div>
+			<h1>데이터팩 파이프라인 개요</h1>
+			<p>원천 스냅샷 → 후보 생성 → 게이트 6종 → 채널 승격을 한 화면에서 보고, 각 단계에서 상세로 이동합니다.</p>
+		</div>
+	</header>
+
+	<section>
+		<h2>현재 후보</h2>
+		<div class="metric-grid" aria-label="현재 후보 요약">
+			<div class="metric">
+				<span>후보</span>
+				<strong><span th:title="${pipeline.candidateId}" th:text="${pipeline.candidateIdShort}">-</span></strong>
+				<em th:text="${'scope ' + pipeline.scopeId}">scope</em>
+			</div>
+			<div class="metric">
+				<span>상태</span>
+				<strong><span th:replace="~{admin/fragments/shell :: status(${pipeline.status}, ${pipeline.statusTone})}">확인 필요</span></strong>
+				<em th:text="${pipeline.productionPromoteReason}">production promote</em>
+			</div>
+			<div class="metric" th:classappend="${pipeline.totalBlockers > 0} ? ' tone-bad'">
+				<span>총 blocker</span>
+				<strong th:text="${pipeline.totalBlockers}">0</strong>
+				<em th:text="${'생성 ' + pipeline.candidateCreatedAt}">생성 시각</em>
+			</div>
+			<div class="metric">
+				<span>production / rollback</span>
+				<strong th:text="${pipeline.productionCandidateId}">-</strong>
+				<em th:text="${'rollback ' + pipeline.rollbackCandidateId}">rollback</em>
+			</div>
+		</div>
+	</section>
+
+	<section>
+		<h2>파이프라인 단계</h2>
+		<p>단계 노드를 눌러 해당 화면으로 이동합니다. blocker가 있는 단계는 강조됩니다.</p>
+		<ol class="datapack-pipeline" aria-label="데이터팩 파이프라인 단계">
+			<li th:each="node : ${pipeline.stages}" class="datapack-pipeline-node"
+			    th:classappend="${node.blocked} ? ' is-blocked'">
+				<a th:href="@{${node.drillUrl}}">
+					<span class="datapack-pipeline-label" th:text="${node.label}">단계</span>
+					<span class="datapack-pipeline-badge"
+					      th:classappend="${node.blocked} ? ' bad' : ' good'"
+					      th:text="${node.blocked} ? ('blocker ' + node.blockerCount + '건') : '통과'">통과</span>
+					<span class="meta" th:text="${node.drillLabel}">이동</span>
+				</a>
+			</li>
+		</ol>
+	</section>
+
+	<section>
+		<h2>단계별 blocker (표)</h2>
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">단계</th>
+				<th scope="col">blocker</th>
+				<th scope="col">상세</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:each="node : ${pipeline.stages}" th:classappend="${node.blocked} ? ' is-blocked'">
+				<td th:text="${node.label}">단계</td>
+				<td th:text="${node.blocked} ? node.blockerCount : 0">0</td>
+				<td><a th:href="@{${node.drillUrl}}" th:text="${node.drillLabel}">이동</a></td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+
+	<section>
+		<h2>서명·증거</h2>
+		<dl class="admin-meta-list">
+			<dt>원천 스냅샷 세트</dt>
+			<dd><span th:title="${pipeline.sourceSnapshotSetHash.fullValue}" th:text="${pipeline.sourceSnapshotSetHash.shortValue}">-</span></dd>
+			<dt>매니페스트 sha256</dt>
+			<dd><span th:title="${pipeline.manifestSha256.fullValue}" th:text="${pipeline.manifestSha256.shortValue}">-</span></dd>
+			<dt>증거 번들 sha256</dt>
+			<dd><span th:title="${pipeline.evidenceBundleSha256.fullValue}" th:text="${pipeline.evidenceBundleSha256.shortValue}">-</span></dd>
+			<dt>증거 워크플로</dt>
+			<dd th:text="${pipeline.evidenceWorkflowRunUrl}">-</dd>
+		</dl>
+		<details>
+			<summary>sha 원문 보기</summary>
+			<dl class="admin-meta-list">
+				<dt>원천 스냅샷 세트</dt>
+				<dd th:text="${pipeline.sourceSnapshotSetHash.fullValue}">-</dd>
+				<dt>매니페스트 sha256</dt>
+				<dd th:text="${pipeline.manifestSha256.fullValue}">-</dd>
+				<dt>증거 번들 sha256</dt>
+				<dd th:text="${pipeline.evidenceBundleSha256.fullValue}">-</dd>
+			</dl>
+		</details>
+	</section>
+</main>
+</div>
+<th:block th:replace="~{admin/fragments/shell :: scripts}"></th:block>
+</body>
+</html>

--- a/backend/src/main/resources/templates/admin/datapack/release-channels/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/release-channels/list.html
@@ -4,7 +4,7 @@
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<meta name="htmx-config" content='{"includeIndicatorStyles":false}'>
-	<title>Release Channels</title>
+	<title>배포 채널</title>
 	<link rel="stylesheet" th:href="@{/css/admin-v3.css}">
 </head>
 <body class="admin-v3">
@@ -16,8 +16,8 @@
 	<div th:replace="~{admin/fragments/shell :: contentStart}"></div>
 	<header class="admin-page-head">
 		<div>
-			<h1>Release Channels</h1>
-			<p>앱이 채택할 데이터팩 manifest pointer와 rollback 가능 상태를 읽기 전용으로 확인합니다.</p>
+			<h1>배포 채널</h1>
+			<p>앱이 채택할 데이터팩 manifest pointer와 rollback 가능 상태를 확인하고, 확인 단계를 거쳐 승격·rollback합니다.</p>
 		</div>
 	</header>
 
@@ -59,7 +59,11 @@
 					<span th:text="${channel.lastOperationType}">PROMOTE</span>
 					<span th:text="${channel.lastOperationStatus}">PASS</span>
 					<span th:text="${channel.idempotencyKey}">idempotency</span>
-					<form method="post" th:action="@{/admin/datapack/release-channels/{channel}/promote(channel=${channel.channel})}">
+					<details class="admin-promote-confirm">
+						<summary th:text="${'승격 승인 (' + channel.channel + ')'}">승격 승인</summary>
+						<p class="meta"
+						   th:text="${'대상 채널 ' + channel.channel + ' · 현재 후보 ' + channel.candidateId + '. 확인하면 승격 요청이 접수됩니다(게시 워크플로 자동 트리거는 #1694 범위).'}">영향</p>
+						<form method="post" th:action="@{/admin/datapack/release-channels/{channel}/promote(channel=${channel.channel})}">
 						<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 						<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 						<input type="hidden" name="previousCandidateId" th:value="${channel.candidateId}">
@@ -93,8 +97,13 @@
 							<input name="workflowRunUrl" type="url" required>
 						</label>
 						<button type="submit">production 승인</button>
-					</form>
-					<form method="post" th:if="${channel.previousStableCandidateId != '-'}" th:action="@{/admin/datapack/release-channels/{channel}/rollback(channel=${channel.channel})}">
+						</form>
+					</details>
+					<details class="admin-promote-confirm" th:if="${channel.previousStableCandidateId != '-'}">
+						<summary th:text="${'rollback (' + channel.channel + ')'}">rollback</summary>
+						<p class="meta"
+						   th:text="${'대상 채널 ' + channel.channel + ' · rollback 대상 ' + channel.previousStableCandidateId + '. 확인하면 이전 안정 후보로 되돌립니다.'}">영향</p>
+						<form method="post" th:action="@{/admin/datapack/release-channels/{channel}/rollback(channel=${channel.channel})}">
 						<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 						<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 						<input type="hidden" name="previousCandidateId" th:value="${channel.candidateId}">
@@ -118,7 +127,8 @@
 							<input name="workflowRunUrl" type="url" required>
 						</label>
 						<button type="submit">rollback 실행</button>
-					</form>
+						</form>
+					</details>
 				</td>
 				<td>
 					<span th:text="${channel.requestedBy}">requested</span>

--- a/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackCandidateAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackCandidateAdminPageControllerTest.java
@@ -79,16 +79,18 @@ class DatapackCandidateAdminPageControllerTest {
 
 		assertThat(detailHtml)
 			.contains("candidate-capital-1")
-			.contains("sourceSnapshotIds")
+			.contains("게이트 체크리스트")
+			.contains("매니페스트 서명")
+			.contains("원천 스냅샷 ids")
 			.contains("snapshot-kric-20260629")
 			.contains("buildSpec")
-			.contains("workflowRunUrl")
+			.contains("증거 워크플로")
 			.contains("https://github.com/AquilaXk/easysubway/actions/runs/123?redacted")
-			.contains("evidenceBundleSha256")
-			.contains("raw evidence 원문은 표시하지 않고 검증된 hash/status만 표시합니다.")
+			.contains("증거 번들 sha256")
+			.contains("sha 원문 보기")
 			.contains("production promote 가능")
 			.contains("name=\"commandToken\"")
-			.contains("gate 재실행")
+			.contains("게이트 재실행")
 			.doesNotContain("production 승인")
 			.doesNotContain("serviceKey");
 	}

--- a/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackPipelineAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackPipelineAdminPageControllerTest.java
@@ -1,0 +1,60 @@
+package com.easysubway.datapack.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+	"easysubway.admin.username=admin-user",
+	"easysubway.admin.password=admin-test-password"
+})
+@AutoConfigureMockMvc
+@DisplayName("관리자 데이터팩 파이프라인 개요 화면")
+class DatapackPipelineAdminPageControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("datapack read 권한 관리자는 파이프라인 단계 그래프와 드릴다운 링크를 확인한다")
+	void datapackReadAdminViewsPipelineStages() throws Exception {
+		String html = mockMvc.perform(get("/admin/datapack/pipeline/page")
+				.with(user("datapack-viewer").authorities(new SimpleGrantedAuthority("admin.datapack.read"))))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("데이터팩 파이프라인 개요")
+			.contains("파이프라인 단계")
+			.contains("원천 스냅샷")
+			.contains("후보 게이트")
+			.contains("별칭·격리")
+			.contains("매니페스트 서명")
+			.contains("채널 승격")
+			.contains("/admin/datapack/source-snapshots/page")
+			.contains("/admin/datapack/alias-quarantine/page")
+			.contains("/admin/datapack/route-gates/page")
+			.contains("/admin/datapack/release-channels/page")
+			.contains("서명·증거")
+			.contains("sha 원문 보기");
+	}
+
+	@Test
+	@DisplayName("datapack read 권한이 없으면 파이프라인 화면에 접근할 수 없다")
+	void pipelineRequiresDatapackReadAuthority() throws Exception {
+		mockMvc.perform(get("/admin/datapack/pipeline/page")
+				.with(user("no-datapack").authorities(new SimpleGrantedAuthority("admin.view"))))
+			.andExpect(status().isForbidden());
+	}
+}

--- a/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackReleaseChannelAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackReleaseChannelAdminPageControllerTest.java
@@ -60,7 +60,9 @@ class DatapackReleaseChannelAdminPageControllerTest {
 			.getContentAsString();
 
 		assertThat(html)
-			.contains("Release Channels")
+			.contains("배포 채널")
+			.contains("승격 승인")
+			.contains("rollback 대상")
 			.contains("production")
 			.contains("candidate-stable-3")
 			.contains("2026.06.29-stable.3")


### PR DESCRIPTION
## 관련 이슈

관련: #1745 (핵심 파이프라인 뷰·후보 상세·승격 확인 — 7화면 전체 표준화는 후속 증분)

## 작업 배경

데이터팩 7개 화면을 순회하며 머릿속으로 파이프라인을 조립하던 것을, 원천 스냅샷 → 후보 생성 → 게이트 6종 → 채널 승격이 한 화면의 단계 그래프로 보이도록 통합한다. 단계 집계는 대시보드·역 요약과 같은 `DatapackReleaseBlockerSummaryUseCase`를 재사용해 정합을 보장한다. 승격→게시 자동 트리거는 #1694 범위이며, 이 PR은 UI·정보 구조·확인 단계 좌석까지만 제공한다.

## 작업 내용

증분 3개(핵심)를 커밋했다.

1. **파이프라인 개요 화면 (1/N)** — `/admin/datapack/pipeline/page`(데이터팩 그룹 최상단). `summarize()` 재사용으로 단계 노드 9개(원천→후보→게이트 6종→채널)를 blocker 뱃지·드릴다운 링크로 렌더. sha 축약(첫 8자+원문 title/details), no-JS 대체 표, `DATAPACK_READ` 권한. 사이드바가 `AdminProgram` enum 기반이라 마이그레이션 불필요.
2. **후보 상세 재구성 (2/N)** — 게이트 체크리스트(원천 커버리지·검증기·경로 회귀·Android 증거·매니페스트 서명·승인)를 상단 상태 뱃지로, 증거·sha는 정리된 메타 블록으로(축약 + "sha 원문 보기" details), 영문 라벨 한글화, 파이프라인↔후보 breadcrumb·복귀 링크.
3. **승격·rollback 확인 단계 (3/N)** — 배포 채널 승격·rollback을 실행 전 확인 단계(대상 채널·현재/rollback 후보 표시)로 감싼다. endpoint(#1162)는 그대로, 게시 자동 트리거는 #1694로 남김. "배포 채널" 한글화.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test` (backend 전체) → **BUILD SUCCESSFUL** (2m 6s). `AdminProgram` 신규 메뉴는 전 관리자 화면 사이드바에 영향하므로 전체 스위트로 회귀 확인.
  - `node --test tools/ci/repository-contract.test.mjs` → **158 pass / 0 fail**.
  - main 머지 재현: `git merge origin/main --no-commit --no-ff`(#1801 병합됨=main 9ad1024e) → 충돌 없음(데이터팩과 disjoint) → abort.
  - 신규 Flyway 없음(사이드바 enum 기반).

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 파이프라인 단계·드릴다운·권한 | backend | `DatapackPipelineAdminPageControllerTest` | 테스트 pass | 통과 |
| 후보 상세 체크리스트·sha 축약·한글 | backend | `DatapackCandidateAdminPageControllerTest` | 테스트 pass | 통과 |
| 승격·rollback 확인 단계 | backend | `DatapackReleaseChannelAdminPageControllerTest` | 테스트 pass | 통과 |
| 단계 뱃지=화면 blocker 정합 | backend | 같은 `summarize()` 소스 재사용(by-construction) | 코드 | 구조적 보장(시드 E2E는 후속) |
| 시각/3클릭/드릴다운 E2E | admin web | Claude Chrome 미연결 | — | **#1749로 이월** |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 배포 대상(데이터팩 파이프라인 화면). 신규 Flyway 없음.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 파이프라인 단계 뱃지는 `DatapackReleaseBlockerSummaryUseCase.summarize()`(대시보드·역 요약과 동일 소스)만 재사용 → 정합 by-construction, 중복 집계 없음.
  - **#1694 중복 없음**: 승격·rollback endpoint는 기존 #1162 것을 그대로 쓰고, 게시 워크플로 자동 트리거 로직은 이 PR에 없다(확인 단계 UI 좌석만).
  - sha는 축약(첫 8자)+title/details 원문. 복사 버튼(JS)·시드 정합 E2E는 후속/#1749.
  - **후속(이 PR 밖)**: 7화면 전체 표준 테이블 v4·검색/필터·후보 컨텍스트 유지 드릴다운(증분 ④). 이 PR은 파이프라인 뷰·후보 상세·승격 확인의 핵심까지.

## 리스크

- `AdminProgram`에 메뉴 1개 추가 — 전 관리자 화면 사이드바 렌더에 영향하나 전체 스위트로 회귀 없음 확인. 권한 없는 사용자에겐 `visibleTo` RBAC로 노출되지 않음.
- 시각·3클릭 드릴다운·키보드 E2E는 브라우저 미연결로 계약·렌더까지만 → **#1749 이월**.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
