### PR TITLE
[Chore] KRIC subwayTimetable normalizer → 재구성 중간 행 (#1415)

### DIFF
--- a/tools/datapack/normalize-kric-timetable.mjs
+++ b/tools/datapack/normalize-kric-timetable.mjs
@@ -1,0 +1,78 @@
+// KRIC trainUseInfo/subwayTimetable 응답 → 재구성 코어의 provider-중립 중간 행 계약으로 변환하는
+// 얇은 normalizer(가드레일 1). 라이브 스파이크로 확정한 스키마 기준:
+//   { railOprIsttCd, trnNo, dayCd, dayNm, stinCd, lnCd, arvTm, dptTm }
+//   - arvTm/dptTm은 HHMMSS(6자리) 또는 null(시발역 arvTm·종착역 dptTm).
+//   - 한쪽이 null이면 있는 쪽으로 대체(도착=출발), 둘 다 null이면 무의미 행이라 버린다.
+//   - stinCd/lnCd/railOprIsttCd는 canonical stationId/lineId로 매핑(context 제공).
+//   - dayCd(8/7/9)는 그대로 전달 — serviceId 매핑은 적재 시 context.serviceIdByDayCd가 담당.
+
+const DEFAULT_SERVICE_PATTERN = "LOCAL";
+
+export function normalizeKricSubwayTimetable(kricRows, context) {
+  const stationIdByProviderStation = asLookup(context?.stationIdByProviderStation, "stationIdByProviderStation");
+  const lineIdByProviderLine = asLookup(context?.lineIdByProviderLine, "lineIdByProviderLine");
+  const servicePattern = context?.servicePattern ?? DEFAULT_SERVICE_PATTERN;
+
+  const rows = [];
+  for (const kric of kricRows ?? []) {
+    const arrivalSeconds = parseKricTime(kric.arvTm);
+    const departureSeconds = parseKricTime(kric.dptTm);
+    if (arrivalSeconds === null && departureSeconds === null) {
+      continue; // 시각 정보가 전혀 없는 행은 버린다(재구성 입력으로 무의미).
+    }
+    const providerStationKey = `${kric.railOprIsttCd}|${kric.lnCd}|${kric.stinCd}`;
+    const stationId = requireMapping(stationIdByProviderStation, providerStationKey, "canonical station");
+    const lineId = requireMapping(lineIdByProviderLine, `${kric.railOprIsttCd}|${kric.lnCd}`, "canonical line");
+    rows.push({
+      stationId,
+      lineId,
+      trnNo: requireText(kric.trnNo, "trnNo"),
+      dayCd: requireText(kric.dayCd, "dayCd"),
+      arrivalSeconds: arrivalSeconds ?? departureSeconds,
+      departureSeconds: departureSeconds ?? arrivalSeconds,
+      servicePattern,
+    });
+  }
+  return rows;
+}
+
+function parseKricTime(value) {
+  if (value == null || value === "") {
+    return null;
+  }
+  if (!/^\d{6}$/.test(value)) {
+    throw new TypeError(`normalize-kric: time must be HHMMSS: ${JSON.stringify(value)}`);
+  }
+  const hours = Number(value.slice(0, 2));
+  const minutes = Number(value.slice(2, 4));
+  const seconds = Number(value.slice(4, 6));
+  if (hours > 29 || minutes > 59 || seconds > 59) {
+    throw new RangeError(`normalize-kric: time out of range: ${value}`);
+  }
+  return hours * 3600 + minutes * 60 + seconds;
+}
+
+function requireMapping(lookup, key, label) {
+  const value = lookup[key];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`normalize-kric: no ${label} for ${key}`);
+  }
+  return value;
+}
+
+function requireText(value, label) {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new TypeError(`normalize-kric: ${label} must be a non-empty string`);
+  }
+  return value;
+}
+
+function asLookup(value, label) {
+  if (value instanceof Map) {
+    return Object.fromEntries(value);
+  }
+  if (value && typeof value === "object") {
+    return value;
+  }
+  throw new Error(`normalize-kric: context.${label} is required`);
+}

--- a/tools/datapack/normalize-kric-timetable.test.mjs
+++ b/tools/datapack/normalize-kric-timetable.test.mjs
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { normalizeKricSubwayTimetable } from "./normalize-kric-timetable.mjs";
+import { reconstructTransitTrips } from "./reconstruct-transit-trips.mjs";
+
+const hms = (h, m, s = 0) => h * 3600 + m * 60 + s;
+
+// KRIC trainUseInfo/subwayTimetable 실응답 body 행(라이브 스파이크 캡처, 사당 4호선 S1)
+const KRIC_ROWS = [
+  { railOprIsttCd: "S1", trnNo: "4719", dayCd: "8", dayNm: "평일", stinCd: "433", lnCd: "4", arvTm: "084830", dptTm: "084900" }, // through
+  { railOprIsttCd: "S1", trnNo: "4236", dayCd: "8", dayNm: "평일", stinCd: "433", lnCd: "4", arvTm: null, dptTm: "092400" }, // 시발(도착 없음)
+  { railOprIsttCd: "S1", trnNo: "4227", dayCd: "8", dayNm: "평일", stinCd: "433", lnCd: "4", arvTm: "085330", dptTm: null }, // 종착(출발 없음)
+];
+
+const CONTEXT = {
+  stationIdByProviderStation: { "S1|4|433": "station-sadang", "S1|4|432": "station-sadang-next" },
+  lineIdByProviderLine: { "S1|4": "seoul-4" },
+};
+
+test("KRIC normalizer는 응답 행을 재구성 코어의 중간 행 계약으로 정규화한다", () => {
+  const rows = normalizeKricSubwayTimetable(KRIC_ROWS, CONTEXT);
+  assert.equal(rows.length, 3);
+  assert.deepEqual(rows[0], {
+    stationId: "station-sadang",
+    lineId: "seoul-4",
+    trnNo: "4719",
+    dayCd: "8",
+    arrivalSeconds: hms(8, 48, 30),
+    departureSeconds: hms(8, 49, 0),
+    servicePattern: "LOCAL",
+  });
+});
+
+test("KRIC normalizer는 시발(arvTm null)·종착(dptTm null)을 도착=출발로 처리한다", () => {
+  const rows = normalizeKricSubwayTimetable(KRIC_ROWS, CONTEXT);
+  const origin = rows.find((r) => r.trnNo === "4236");
+  assert.equal(origin.arrivalSeconds, hms(9, 24, 0));
+  assert.equal(origin.departureSeconds, hms(9, 24, 0));
+  const terminal = rows.find((r) => r.trnNo === "4227");
+  assert.equal(terminal.arrivalSeconds, hms(8, 53, 30));
+  assert.equal(terminal.departureSeconds, hms(8, 53, 30));
+});
+
+test("KRIC normalizer는 arvTm·dptTm이 모두 없으면 그 행을 버린다", () => {
+  const rows = normalizeKricSubwayTimetable(
+    [{ railOprIsttCd: "S1", trnNo: "9999", dayCd: "8", stinCd: "433", lnCd: "4", arvTm: null, dptTm: null }],
+    CONTEXT,
+  );
+  assert.equal(rows.length, 0);
+});
+
+test("KRIC normalizer는 canonical station 매핑이 없으면 거부한다", () => {
+  assert.throws(
+    () => normalizeKricSubwayTimetable([{ ...KRIC_ROWS[0], stinCd: "999" }], CONTEXT),
+    /no canonical station for S1\|4\|999/,
+  );
+});
+
+test("KRIC normalizer는 servicePattern override(급행)를 반영한다", () => {
+  const rows = normalizeKricSubwayTimetable(KRIC_ROWS, { ...CONTEXT, servicePattern: "EXPRESS" });
+  assert.ok(rows.every((r) => r.servicePattern === "EXPRESS"));
+});
+
+test("KRIC normalizer 출력은 재구성 코어에 그대로 투입돼 trip을 만든다(가드레일 1 합성)", () => {
+  const kricTwoStops = [
+    { railOprIsttCd: "S1", trnNo: "4719", dayCd: "8", stinCd: "433", lnCd: "4", arvTm: "084830", dptTm: "084900" },
+    { railOprIsttCd: "S1", trnNo: "4719", dayCd: "8", stinCd: "432", lnCd: "4", arvTm: "085030", dptTm: "085100" },
+  ];
+  const intermediate = normalizeKricSubwayTimetable(kricTwoStops, CONTEXT);
+  const { transitTrips, transitStopTimes } = reconstructTransitTrips(intermediate, {
+    lineSequenceByStationLine: { "station-sadang|seoul-4": 28, "station-sadang-next|seoul-4": 29 },
+    routeIdByLineDirection: { "seoul-4|up": "route-seoul-4-oido" },
+    serviceIdByDayCd: { "8": "weekday-2026" },
+  });
+  assert.equal(transitTrips.length, 1);
+  assert.equal(transitTrips[0].serviceId, "weekday-2026");
+  assert.equal(transitStopTimes.length, 2);
+});
+
+test("KRIC normalizer는 잘못된 시각 포맷·범위·필수 필드·context 누락을 거부한다", () => {
+  assert.throws(() => normalizeKricSubwayTimetable([{ ...KRIC_ROWS[0], arvTm: "8:48" }], CONTEXT), /time must be HHMMSS/);
+  assert.throws(() => normalizeKricSubwayTimetable([{ ...KRIC_ROWS[0], dptTm: "306000" }], CONTEXT), /time out of range/);
+  assert.throws(() => normalizeKricSubwayTimetable([{ ...KRIC_ROWS[0], trnNo: "" }], CONTEXT), /trnNo must be a non-empty string/);
+  assert.throws(() => normalizeKricSubwayTimetable([{ ...KRIC_ROWS[0], dayCd: "" }], CONTEXT), /dayCd must be a non-empty string/);
+  assert.throws(() => normalizeKricSubwayTimetable(KRIC_ROWS, { ...CONTEXT, lineIdByProviderLine: null }), /context.lineIdByProviderLine is required/);
+});
+
+test("KRIC normalizer는 context를 Map으로도 받는다", () => {
+  const rows = normalizeKricSubwayTimetable([KRIC_ROWS[0]], {
+    stationIdByProviderStation: new Map([["S1|4|433", "station-sadang"]]),
+    lineIdByProviderLine: new Map([["S1|4", "seoul-4"]]),
+  });
+  assert.equal(rows[0].stationId, "station-sadang");
+});


### PR DESCRIPTION
## 관련 이슈

Refs #1415

## 작업 배경

- **①KRIC 라이브 스파이크 완료**(운영계정 서비스키): `trainUseInfo/subwayTimetable`을 pilot 2역(사당=S1 서울교통공사·상록수=KR 코레일, 4호선)에 호출.
  - ✅ `trnNo`(열차번호) 포함 → 결정적 재구성 성립. ✅ 시각 HHMMSS(6자리). ✅ **S1·KR 둘 다 커버** → 최악 시나리오(코레일 TAGO 하이브리드) 회피, ②코어 순수 group-by 유지.
  - KRIC↔TAGO 사당 dptTm **95.8% 정확 일치**(스케줄 정합 확인). 시발역 `arvTm=null`·종착역 `dptTm=null`.
- 이 PR은 ③의 첫 조각인 **KRIC normalizer**(가드레일 1의 "얇은 provider 층").

## 작업 내용

- `normalize-kric-timetable.mjs` — `normalizeKricSubwayTimetable(kricRows, context)` → 재구성 코어(#1797)의 중간 행 `{stationId, lineId, trnNo, dayCd, arrivalSeconds, departureSeconds, servicePattern}`.
  - `arvTm`/`dptTm`: HHMMSS→초. **null(시발/종착)이면 있는 쪽으로 대체(도착=출발)**, 둘 다 null이면 행 폐기.
  - `stinCd`/`lnCd`/`railOprIsttCd` → canonical `stationId`/`lineId` 매핑(context). `dayCd`(8/7/9)는 그대로(serviceId 매핑은 적재 시).
  - `servicePattern` override(급행 endpoint용) 지원.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/datapack/normalize-kric-timetable.test.mjs` 통과 (8 tests, **100% line coverage**)
  - `node --test tools/ci/repository-contract.test.mjs` 통과 (158)
  - `git diff --check` 통과
- TDD: RED(모듈 없음)→GREEN. **라이브 스파이크 실샘플**(through/시발/종착)을 fixture로 사용 + normalizer→코어 합성 test(가드레일 1).

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| KRIC normalizer 정확성 | datapack tooling | 실샘플 fixture(through/시발/종착) + 코어 합성 | `normalize-kric-timetable.test.mjs` 8건 | 통과 |
| ①스파이크 검증 | ops | 라이브 KRIC 호출(사당 S1 473행·상록수 KR 253행) | trnNo·HHMMSS·95.8% TAGO 정합 | 통과 |
| UI/접근성 | 해당 없음 | 순수 변환 모듈 | UI 변경 없음 | 해당 없음 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음(도구 모듈만)
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - null 시각 처리(시발 arvTm=null / 종착 dptTm=null → 도착=출발). 둘 다 null 행은 폐기.
  - normalizer는 provider 특화 층이고, canonical 매핑·재구성은 각각 context·코어(#1797)가 담당(가드레일 1). 코어는 이 PR에서 불변.
  - dayCd(8/7/9)는 KRIC 원값 그대로 전달 — serviceId 매핑은 ③ 적재 단계 context.
  - fixture 행은 라이브 스파이크 캡처값(스케줄 데이터, 키 무관 — 안전).

## 리스크

- ①스파이크에서 KRIC(355)이 TAGO(582)보다 사당 열차가 적었다(95.8%는 정합). 완결성 차이는 ③ 적재 후 TAGO 대비 재검(별도 관찰) — 이 normalizer 자체 리스크는 낮음(순수 변환·100% coverage).

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.