### PR TITLE
[Test] 배포 후 스모크 4축 도입 — readiness 단일 프로브 → 핵심 API 게이트 (#1688)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -109,6 +109,8 @@ jobs:
       group: cd-production-deploy
       cancel-in-progress: false
     if: ${{ needs.plan.outputs.deploy_target_relevant == 'true' }}
+    outputs:
+      deploy_ready: ${{ steps.remote.outputs.deploy_ready }}
 
     steps:
       - name: CD Deploy / Checkout repository
@@ -334,20 +336,10 @@ jobs:
             INCOMING_DIR="${incoming}" \
             bash "${incoming}/deploy-backend.sh"
 
-      - name: CD Deploy / Verify public readiness
-        if: ${{ steps.remote.outputs.deploy_ready == 'true' }}
-        shell: bash
-        env:
-          DEPLOY_PUBLIC_API_BASE_URL: ${{ vars.DEPLOY_PUBLIC_API_BASE_URL }}
-        run: |
-          set -euo pipefail
-
-          if [[ -z "${DEPLOY_PUBLIC_API_BASE_URL}" ]]; then
-            echo "::notice title=CD public readiness::DEPLOY_PUBLIC_API_BASE_URL is not configured; remote local readiness was already checked."
-            exit 0
-          fi
-
-          curl -fsS --retry 6 --retry-delay 10 --max-time 10 "${DEPLOY_PUBLIC_API_BASE_URL%/}/actuator/health/readiness"
+      # Public readiness is now one axis of the post-deploy-smoke job (below),
+      # which runs on ubuntu-latest so it also verifies true external
+      # reachability of the deployed URL (issue #1688). Local readiness is
+      # already enforced inside deploy-backend.sh before the container swap.
 
       - name: CD Deploy / Summarize deployment result
         if: ${{ always() }}
@@ -375,6 +367,61 @@ jobs:
           fi
           rm -rf "${RUNNER_TEMP}/deploy-env"
 
+  post-deploy-smoke:
+    name: Post-deploy smoke
+    needs: deploy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    if: ${{ needs.deploy.outputs.deploy_ready == 'true' }}
+    steps:
+      - name: Post-deploy smoke / Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Post-deploy smoke / Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24"
+
+      - name: Post-deploy smoke / Run core API smoke
+        shell: bash
+        env:
+          DEPLOY_PUBLIC_API_BASE_URL: ${{ vars.DEPLOY_PUBLIC_API_BASE_URL }}
+        run: |
+          set -euo pipefail
+
+          # A configured public base URL is required: "not configured, so it
+          # passed" is not a gate (issue #1688). Set the repo variable
+          # DEPLOY_PUBLIC_API_BASE_URL to the live deployment URL.
+          if [[ -z "${DEPLOY_PUBLIC_API_BASE_URL}" ]]; then
+            echo "::error title=Post-deploy smoke::DEPLOY_PUBLIC_API_BASE_URL repo variable is not configured." >&2
+            exit 1
+          fi
+
+          # The datapack distribution URL is the contract default in
+          # post-deploy-smoke-contract.json (the same OCI value pinned by the
+          # repository contract test); no workflow var override is used.
+          #
+          # A public smoke failure is intentionally NOT auto-rolled back: local
+          # readiness already passed inside deploy-backend.sh, so a failure here
+          # is likely edge/DNS/datapack-URL and auto-reverting a healthy deploy
+          # is the larger risk. The job fails and notify-slack-cd-result alerts.
+          node tools/ops/post-deploy-smoke.mjs \
+            --base-url "${DEPLOY_PUBLIC_API_BASE_URL}" \
+            --timeout-seconds 90 \
+            --report "${RUNNER_TEMP}/post-deploy-smoke-report.json" | tee -a "${GITHUB_STEP_SUMMARY}"
+
+      - name: Post-deploy smoke / Upload report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: post-deploy-smoke-report
+          path: ${{ runner.temp }}/post-deploy-smoke-report.json
+          retention-days: 14
+          if-no-files-found: ignore
+
   notify-slack-cd-result:
     name: Slack / CD result
     runs-on: ubuntu-latest
@@ -382,6 +429,7 @@ jobs:
     needs:
       - plan
       - deploy
+      - post-deploy-smoke
     if: >-
       ${{
         always() &&

--- a/tools/ci/backend-deploy.test.mjs
+++ b/tools/ci/backend-deploy.test.mjs
@@ -251,6 +251,24 @@ test("백엔드 SSH 배포 스크립트는 상태, drift, 백업, readiness 롤�
   assert.doesNotMatch(cd, /EASYSUBWAY_ENV_FILE:-\/dev\/null/);
 });
 
+test("CD 배포 후 검증은 readiness 단일 프로브가 아니라 핵심 API 스모크로 게이트한다", () => {
+  const cd = read(".github/workflows/cd.yml");
+
+  // The old skip-on-unset public readiness step is removed: "not configured, so
+  // it passed" is not a gate (issue #1688).
+  assert.doesNotMatch(cd, /DEPLOY_PUBLIC_API_BASE_URL is not configured; remote local readiness was already checked/);
+
+  // A dedicated ubuntu-latest smoke job runs the contract-driven smoke script,
+  // requires the public base URL, and fails when it is unset.
+  assert.match(cd, /post-deploy-smoke:/);
+  assert.match(cd, /node tools\/ops\/post-deploy-smoke\.mjs/);
+  assert.match(cd, /DEPLOY_PUBLIC_API_BASE_URL repo variable is not configured/);
+  assert.match(cd, /if: \$\{\{ needs\.deploy\.outputs\.deploy_ready == 'true' \}\}/);
+
+  // Smoke failures must propagate into the CD result Slack notification.
+  assert.match(cd, /needs:\n {6}- plan\n {6}- deploy\n {6}- post-deploy-smoke/);
+});
+
 test("Compose backend 서비스는 bootJar 기반 이미지와 제한된 바인딩을 사용한다", () => {
   const compose = read("infra/docker-compose.yml");
 

--- a/tools/ops/post-deploy-smoke-contract.json
+++ b/tools/ops/post-deploy-smoke-contract.json
@@ -1,0 +1,53 @@
+{
+  "schemaVersion": 1,
+  "gate": "post-deploy-smoke",
+  "issue": 1688,
+  "descriptionKo": "매 백엔드 배포 직후 핵심 4축이 배포 URL에서 실제 동작하는지 확인하는 경량 스모크 계약. 대표 OD·필수 응답 필드가 바뀌면 스크립트가 아니라 이 파일만 갱신한다.",
+  "axes": {
+    "readiness": {
+      "id": "readiness",
+      "titleKo": "헬스 (플랫폼)",
+      "deploymentAttributed": true,
+      "path": "/actuator/health/readiness",
+      "expectStatusField": "status",
+      "expectStatusValue": "UP"
+    },
+    "routeSearch": {
+      "id": "route-search",
+      "titleKo": "경로 탐색 (북극성)",
+      "deploymentAttributed": true,
+      "method": "POST",
+      "path": "/api/v2/routes/search",
+      "request": {
+        "originStationId": "station-sangnoksu",
+        "destinationStationId": "station-sadang",
+        "mobilityType": "SENIOR",
+        "constraintMode": "ALLOW_WITH_WARNINGS",
+        "useRealtime": false,
+        "maxTransfers": 3,
+        "alternativeCount": 3
+      },
+      "departureLocalTime": "09:15:00",
+      "departureUtcOffset": "+09:00",
+      "expectedContractVersion": "ROUTE_SEARCH_V2",
+      "minItineraries": 1,
+      "legEtaSourceField": "etaSource",
+      "downgradeLadderNoteKo": "강등 사다리 존중: leg의 etaSource가 REALTIME이 아니어도(PLANNED·STATIC_BACKEND_ESTIMATE 등) 실패로 처리하지 않는다. 실시간 provider 상태에 의존하는 flaky 게이트를 만들지 않기 위해 useRealtime=false로 고정한다."
+    },
+    "adminLogin": {
+      "id": "admin-login",
+      "titleKo": "관리자 웹",
+      "deploymentAttributed": true,
+      "path": "/admin/login",
+      "mustIncludeAny": ["<form", "login", "로그인"]
+    },
+    "datapack": {
+      "id": "datapack",
+      "titleKo": "데이터팩 배포 URL (오프라인)",
+      "deploymentAttributed": false,
+      "baseUrl": "https://objectstorage.ap-seoul-1.oraclecloud.com/n/axvym6vk8g7i/b/easysubway-datapacks/o",
+      "catalogPath": "/catalog/current.json",
+      "requiredArrayField": "packs"
+    }
+  }
+}

--- a/tools/ops/post-deploy-smoke.mjs
+++ b/tools/ops/post-deploy-smoke.mjs
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+// Post-deploy smoke: verifies that the core user-facing flows actually answer at
+// the deployed URL after a backend deploy (issue #1688). Four axes mirror the
+// service structure: platform health, route search (north star), admin web, and
+// the datapack distribution URL (independent OCI Object Storage infra).
+//
+// Design constraints (see issue #1688):
+// - Respect the downgrade ladder: a non-realtime eta source (PLANNED/STATIC) is
+//   NOT a failure. useRealtime is fixed to false so the gate never depends on a
+//   flaky realtime provider.
+// - The datapack axis is a DIFFERENT failure domain than the backend deploy; the
+//   report labels each axis with `deploymentAttributed` so an operator can tell a
+//   backend regression apart from an offline-data-supply outage.
+// - No auto-rollback: a failure exits non-zero so the CD job fails and Slack
+//   notifies; it does not revert an already-healthy container.
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { argValue } from "../release/summary-validation-utils.mjs";
+
+const DEFAULT_CONTRACT = path.join(import.meta.dirname, "post-deploy-smoke-contract.json");
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function buildDepartureTime(axis, now = Date.now()) {
+  const match = /^([+-])(\d{2}):(\d{2})$/.exec(axis.departureUtcOffset);
+  if (!match) throw new Error(`invalid departureUtcOffset: ${axis.departureUtcOffset}`);
+  const sign = match[1] === "-" ? -1 : 1;
+  const offsetSeconds = sign * (Number(match[2]) * 3600 + Number(match[3]) * 60);
+  const local = new Date(now + offsetSeconds * 1000);
+  const year = local.getUTCFullYear();
+  const month = String(local.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(local.getUTCDate()).padStart(2, "0");
+  return `${year}-${month}-${day}T${axis.departureLocalTime}${axis.departureUtcOffset}`;
+}
+
+async function httpRequest(url, { method = "GET", body, headers = {}, timeoutMs }) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(url, { method, body, headers, signal: controller.signal });
+    const text = await response.text();
+    return { status: response.status, text };
+  } catch (error) {
+    if (error.name === "AbortError") throw new Error(`request timed out after ${timeoutMs}ms`);
+    throw new Error(error.message);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function parseJson(text, label) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new Error(`${label} did not return valid JSON`);
+  }
+}
+
+async function retry(check, { maxMs, delayMs }) {
+  const deadline = Date.now() + maxMs;
+  let attempts = 0;
+  let lastError;
+  for (;;) {
+    attempts += 1;
+    try {
+      await check();
+      return { ok: true, attempts, error: null };
+    } catch (error) {
+      lastError = error;
+      if (Date.now() + delayMs >= deadline) {
+        return { ok: false, attempts, error: lastError };
+      }
+      await sleep(delayMs);
+    }
+  }
+}
+
+function joinUrl(base, pathname) {
+  return `${base.replace(/\/+$/, "")}${pathname}`;
+}
+
+async function checkReadiness(baseUrl, axis, timeoutMs) {
+  const url = joinUrl(baseUrl, axis.path);
+  const { status, text } = await httpRequest(url, { timeoutMs });
+  if (status !== 200) throw new Error(`readiness returned HTTP ${status}`);
+  const body = parseJson(text, "readiness");
+  if (body[axis.expectStatusField] !== axis.expectStatusValue) {
+    throw new Error(`readiness ${axis.expectStatusField} was ${body[axis.expectStatusField]}, expected ${axis.expectStatusValue}`);
+  }
+}
+
+async function checkRouteSearch(baseUrl, axis, timeoutMs) {
+  const url = joinUrl(baseUrl, axis.path);
+  const requestBody = { ...axis.request, departureTime: buildDepartureTime(axis) };
+  const { status, text } = await httpRequest(url, {
+    method: axis.method ?? "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(requestBody),
+    timeoutMs,
+  });
+  if (status !== 200) throw new Error(`route search returned HTTP ${status}`);
+  const body = parseJson(text, "route search");
+  if (body.success !== true) throw new Error("route search response.success was not true");
+  const data = body.data;
+  if (!data || data.contractVersion !== axis.expectedContractVersion) {
+    throw new Error(`route search contractVersion was ${data?.contractVersion}, expected ${axis.expectedContractVersion}`);
+  }
+  const itineraries = data.itineraries;
+  if (!Array.isArray(itineraries) || itineraries.length < axis.minItineraries) {
+    throw new Error(`route search returned ${itineraries?.length ?? 0} itineraries, expected >= ${axis.minItineraries}`);
+  }
+  const legs = itineraries.flatMap((entry) => (Array.isArray(entry.legs) ? entry.legs : []));
+  if (legs.length < 1) throw new Error("route search itineraries contained no legs");
+  for (const leg of legs) {
+    const label = leg[axis.legEtaSourceField];
+    if (typeof label !== "string" || label.length === 0) {
+      throw new Error(`route search leg is missing a ${axis.legEtaSourceField} label`);
+    }
+  }
+}
+
+async function checkAdminLogin(baseUrl, axis, timeoutMs) {
+  const url = joinUrl(baseUrl, axis.path);
+  const { status, text } = await httpRequest(url, { timeoutMs });
+  if (status !== 200) throw new Error(`admin login returned HTTP ${status}`);
+  const haystack = text.toLowerCase();
+  const matched = axis.mustIncludeAny.some((needle) => haystack.includes(needle.toLowerCase()));
+  if (!matched) throw new Error("admin login page did not contain a login form marker");
+}
+
+async function checkDatapack(datapackBaseUrl, axis, timeoutMs) {
+  const url = joinUrl(datapackBaseUrl, axis.catalogPath);
+  const { status, text } = await httpRequest(url, { timeoutMs });
+  if (status !== 200) throw new Error(`datapack catalog returned HTTP ${status}`);
+  const body = parseJson(text, "datapack catalog");
+  const packs = body[axis.requiredArrayField];
+  if (!Array.isArray(packs) || packs.length === 0) {
+    throw new Error(`datapack catalog ${axis.requiredArrayField} was empty`);
+  }
+}
+
+async function runAxis(axis, check, { maxMs, delayMs }) {
+  const startedAt = Date.now();
+  const perRequestTimeout = Math.min(10000, Math.max(2000, maxMs));
+  const outcome = await retry(() => check(perRequestTimeout), { maxMs, delayMs });
+  return {
+    id: axis.id,
+    titleKo: axis.titleKo,
+    deploymentAttributed: axis.deploymentAttributed,
+    result: outcome.ok ? "PASS" : "FAIL",
+    latencyMs: Date.now() - startedAt,
+    attempts: outcome.attempts,
+    detail: outcome.ok ? "ok" : outcome.error.message,
+  };
+}
+
+function renderTable(report) {
+  const lines = [
+    "| 축 | 결과 | 배포 기인 | latency(ms) | 시도 | 상세 |",
+    "|---|---|---|---|---|---|",
+  ];
+  for (const axis of report.axes) {
+    lines.push(
+      `| ${axis.titleKo} | ${axis.result} | ${axis.deploymentAttributed ? "예" : "아니오(독립 인프라)"} | ${axis.latencyMs} | ${axis.attempts} | ${axis.detail} |`,
+    );
+  }
+  lines.push("", `overall: **${report.overall}**`);
+  return lines.join("\n");
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const baseUrl = argValue(args, "--base-url");
+  if (!baseUrl) throw new Error("--base-url is required");
+
+  const contractPath = argValue(args, "--contract", DEFAULT_CONTRACT);
+  const contract = JSON.parse(await readFile(contractPath, "utf8"));
+  const { readiness, routeSearch, adminLogin, datapack } = contract.axes;
+
+  const datapackBaseUrl = argValue(args, "--datapack-base-url", datapack.baseUrl);
+  const budgetMs = Number(argValue(args, "--timeout-seconds", "90")) * 1000;
+
+  const axes = [];
+  axes.push(await runAxis(readiness, (t) => checkReadiness(baseUrl, readiness, t), {
+    maxMs: Math.max(6000, budgetMs * 0.55),
+    delayMs: 3000,
+  }));
+  axes.push(await runAxis(routeSearch, (t) => checkRouteSearch(baseUrl, routeSearch, t), {
+    maxMs: Math.max(3000, budgetMs * 0.2),
+    delayMs: 2000,
+  }));
+  axes.push(await runAxis(adminLogin, (t) => checkAdminLogin(baseUrl, adminLogin, t), {
+    maxMs: Math.max(2000, budgetMs * 0.1),
+    delayMs: 2000,
+  }));
+  if (datapackBaseUrl) {
+    axes.push(await runAxis(datapack, (t) => checkDatapack(datapackBaseUrl, datapack, t), {
+      maxMs: Math.max(2000, budgetMs * 0.15),
+      delayMs: 2000,
+    }));
+  } else {
+    axes.push({
+      id: datapack.id,
+      titleKo: datapack.titleKo,
+      deploymentAttributed: datapack.deploymentAttributed,
+      result: "SKIPPED",
+      latencyMs: 0,
+      attempts: 0,
+      detail: "datapack base url not provided",
+    });
+  }
+
+  const report = {
+    schemaVersion: 1,
+    gate: "post-deploy-smoke",
+    generatedAt: new Date().toISOString(),
+    baseUrl,
+    datapackBaseUrl: datapackBaseUrl || null,
+    overall: axes.some((axis) => axis.result === "FAIL") ? "FAIL" : "PASS",
+    axes,
+  };
+
+  const reportPath = argValue(args, "--report");
+  if (reportPath) {
+    await writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`);
+  }
+  process.stdout.write(`${renderTable(report)}\n`);
+
+  if (report.overall !== "PASS") {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});

--- a/tools/ops/post-deploy-smoke.test.mjs
+++ b/tools/ops/post-deploy-smoke.test.mjs
@@ -1,0 +1,253 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import http from "node:http";
+import { mkdir, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import test from "node:test";
+
+const execFileAsync = promisify(execFile);
+const root = path.resolve(import.meta.dirname, "../..");
+const script = "tools/ops/post-deploy-smoke.mjs";
+
+function itinerary(overrides = {}) {
+  return {
+    itineraryId: "route-search-1-primary",
+    status: "FOUND",
+    etaSource: "PLANNED",
+    legs: [
+      { legType: "ACCESS", etaSource: "PLANNED" },
+      { legType: "RIDE", etaSource: "STATIC_BACKEND_ESTIMATE" },
+    ],
+    ...overrides,
+  };
+}
+
+function defaultRoutes() {
+  return {
+    readiness: () => ({ status: 200, body: { status: "UP" } }),
+    routeSearch: () => ({
+      status: 200,
+      body: { success: true, data: { contractVersion: "ROUTE_SEARCH_V2", itineraries: [itinerary()] } },
+    }),
+    adminLogin: () => ({ status: 200, body: "<html><body><form method=\"post\">login</form></body></html>", raw: true }),
+    datapack: () => ({ status: 200, body: { packs: [{ id: "capital", version: "2026.07.01" }] } }),
+  };
+}
+
+async function withServer(routes, fn) {
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url, "http://localhost");
+    let handler;
+    if (url.pathname === "/actuator/health/readiness") handler = routes.readiness;
+    else if (url.pathname === "/api/v2/routes/search" && req.method === "POST") handler = routes.routeSearch;
+    else if (url.pathname === "/admin/login") handler = routes.adminLogin;
+    else if (url.pathname === "/catalog/current.json") handler = routes.datapack;
+
+    if (!handler) {
+      res.writeHead(404).end("not found");
+      return;
+    }
+    const chunks = [];
+    req.on("data", (chunk) => chunks.push(chunk));
+    req.on("end", () => {
+      const out = handler(Buffer.concat(chunks).toString("utf8"));
+      const payload = out.raw ? out.body : JSON.stringify(out.body);
+      res.writeHead(out.status, { "content-type": out.raw ? "text/html" : "application/json" }).end(payload);
+    });
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}`;
+  try {
+    return await fn(baseUrl);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+async function runSmoke(baseUrl, extraArgs = []) {
+  const dir = path.join(tmpdir(), `smoke-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  await rm(dir, { recursive: true, force: true });
+  await mkdir(dir, { recursive: true });
+  const reportPath = path.join(dir, "report.json");
+  const args = [
+    script,
+    "--base-url",
+    baseUrl,
+    "--datapack-base-url",
+    baseUrl,
+    "--timeout-seconds",
+    "4",
+    "--report",
+    reportPath,
+    ...extraArgs,
+  ];
+  try {
+    const { stdout } = await execFileAsync(process.execPath, args, { cwd: root });
+    const report = JSON.parse(await readFile(reportPath, "utf8"));
+    return { code: 0, stdout, report };
+  } catch (error) {
+    let report = null;
+    try {
+      report = JSON.parse(await readFile(reportPath, "utf8"));
+    } catch {
+      report = null;
+    }
+    return { code: error.code ?? 1, stdout: error.stdout ?? "", stderr: error.stderr ?? "", report };
+  }
+}
+
+function axis(report, id) {
+  return report.axes.find((entry) => entry.id === id);
+}
+
+test("post-deploy smoke passes when all four axes respond correctly", async () => {
+  await withServer(defaultRoutes(), async (baseUrl) => {
+    const { code, report } = await runSmoke(baseUrl);
+    assert.equal(code, 0);
+    assert.equal(report.overall, "PASS");
+    assert.equal(report.axes.length, 4);
+    for (const id of ["readiness", "route-search", "admin-login", "datapack"]) {
+      assert.equal(axis(report, id).result, "PASS", `${id} should pass`);
+    }
+    assert.equal(axis(report, "datapack").deploymentAttributed, false);
+    assert.equal(axis(report, "readiness").deploymentAttributed, true);
+  });
+});
+
+test("post-deploy smoke tolerates downgraded (non-realtime) eta sources", async () => {
+  const routes = defaultRoutes();
+  routes.routeSearch = () => ({
+    status: 200,
+    body: {
+      success: true,
+      data: {
+        contractVersion: "ROUTE_SEARCH_V2",
+        itineraries: [
+          itinerary({
+            etaSource: "PLANNED",
+            legs: [
+              { legType: "ACCESS", etaSource: "PLANNED" },
+              { legType: "RIDE", etaSource: "PLANNED" },
+            ],
+          }),
+        ],
+      },
+    },
+  });
+  await withServer(routes, async (baseUrl) => {
+    const { code, report } = await runSmoke(baseUrl);
+    assert.equal(code, 0);
+    assert.equal(axis(report, "route-search").result, "PASS");
+  });
+});
+
+test("post-deploy smoke fails when route search omits itineraries", async () => {
+  const routes = defaultRoutes();
+  routes.routeSearch = () => ({
+    status: 200,
+    body: { success: true, data: { contractVersion: "ROUTE_SEARCH_V2", itineraries: [] } },
+  });
+  await withServer(routes, async (baseUrl) => {
+    const { code, report } = await runSmoke(baseUrl);
+    assert.equal(code, 1);
+    assert.equal(report.overall, "FAIL");
+    assert.equal(axis(report, "route-search").result, "FAIL");
+  });
+});
+
+test("post-deploy smoke fails when a leg is missing its eta source label", async () => {
+  const routes = defaultRoutes();
+  routes.routeSearch = () => ({
+    status: 200,
+    body: {
+      success: true,
+      data: {
+        contractVersion: "ROUTE_SEARCH_V2",
+        itineraries: [itinerary({ legs: [{ legType: "ACCESS" }] })],
+      },
+    },
+  });
+  await withServer(routes, async (baseUrl) => {
+    const { code, report } = await runSmoke(baseUrl);
+    assert.equal(code, 1);
+    assert.equal(axis(report, "route-search").result, "FAIL");
+  });
+});
+
+test("post-deploy smoke fails when readiness is not UP", async () => {
+  const routes = defaultRoutes();
+  routes.readiness = () => ({ status: 503, body: { status: "DOWN" } });
+  await withServer(routes, async (baseUrl) => {
+    const { code, report } = await runSmoke(baseUrl);
+    assert.equal(code, 1);
+    assert.equal(axis(report, "readiness").result, "FAIL");
+  });
+});
+
+test("post-deploy smoke fails when datapack catalog has empty packs (independent infra, still attributed)", async () => {
+  const routes = defaultRoutes();
+  routes.datapack = () => ({ status: 200, body: { packs: [] } });
+  await withServer(routes, async (baseUrl) => {
+    const { code, report } = await runSmoke(baseUrl);
+    assert.equal(code, 1);
+    assert.equal(axis(report, "datapack").result, "FAIL");
+    assert.equal(axis(report, "datapack").deploymentAttributed, false);
+  });
+});
+
+test("post-deploy smoke fails fast when the base url is unreachable", async () => {
+  // Reserve a port by binding then closing so nothing is listening.
+  const probe = http.createServer();
+  await new Promise((resolve) => probe.listen(0, "127.0.0.1", resolve));
+  const { port } = probe.address();
+  await new Promise((resolve) => probe.close(resolve));
+  const { code, report } = await runSmoke(`http://127.0.0.1:${port}`);
+  assert.equal(code, 1);
+  assert.equal(report.overall, "FAIL");
+  assert.equal(axis(report, "readiness").result, "FAIL");
+});
+
+test("post-deploy smoke contract file matches the expected schema", async () => {
+  const contract = JSON.parse(await readFile(path.join(root, "tools/ops/post-deploy-smoke-contract.json"), "utf8"));
+  assert.equal(contract.schemaVersion, 1);
+  assert.equal(contract.gate, "post-deploy-smoke");
+  assert.equal(contract.issue, 1688);
+
+  const { readiness, routeSearch, adminLogin, datapack } = contract.axes;
+  assert.equal(readiness.deploymentAttributed, true);
+  assert.equal(readiness.path, "/actuator/health/readiness");
+  assert.equal(readiness.expectStatusValue, "UP");
+
+  assert.equal(routeSearch.deploymentAttributed, true);
+  assert.equal(routeSearch.path, "/api/v2/routes/search");
+  assert.equal(routeSearch.expectedContractVersion, "ROUTE_SEARCH_V2");
+  assert.ok(routeSearch.minItineraries >= 1);
+  assert.equal(routeSearch.legEtaSourceField, "etaSource");
+  // useRealtime must stay false so the gate never depends on a flaky provider.
+  assert.equal(routeSearch.request.useRealtime, false);
+  assert.equal(routeSearch.request.originStationId, "station-sangnoksu");
+  assert.equal(routeSearch.request.destinationStationId, "station-sadang");
+  assert.match(routeSearch.departureLocalTime, /^\d{2}:\d{2}:\d{2}$/);
+  assert.match(routeSearch.departureUtcOffset, /^[+-]\d{2}:\d{2}$/);
+
+  assert.equal(adminLogin.deploymentAttributed, true);
+  assert.equal(adminLogin.path, "/admin/login");
+  assert.ok(Array.isArray(adminLogin.mustIncludeAny) && adminLogin.mustIncludeAny.length >= 1);
+
+  // The datapack axis is an independent failure domain (OCI Object Storage).
+  assert.equal(datapack.deploymentAttributed, false);
+  assert.equal(datapack.catalogPath, "/catalog/current.json");
+  assert.equal(datapack.requiredArrayField, "packs");
+  // Same OCI value pinned by the repository contract test.
+  assert.match(datapack.baseUrl, /^https:\/\/objectstorage\.ap-seoul-1\.oraclecloud\.com\/n\/axvym6vk8g7i\/b\/easysubway-datapacks\/o$/);
+});
+
+test("post-deploy smoke requires an explicit base url", async () => {
+  await assert.rejects(
+    execFileAsync(process.execPath, [script, "--datapack-base-url", "https://example.com"], { cwd: root }),
+    /--base-url is required/,
+  );
+});


### PR DESCRIPTION
## 관련 이슈

close #1688

## 작업 배경

- 기존 PR 본문 참조.

## 작업 내용

<details>
<summary>기존 PR 본문</summary>

## 관련 이슈

close #1688

## 작업 배경

배포 후 검증이 사실상 readiness 프로브 1개(+ `DEPLOY_PUBLIC_API_BASE_URL` 미설정 시 통과)뿐이라 "프로세스가 살아있다"만 확인하고 "서비스가 실제 동작한다"는 아무도 확인하지 않았다. #1414 출시 판정 원칙 "배포 artifact는 레포 입력이 아니라 실제 배포 URL 기준으로 검증"(#1393)과 어긋난다.

## 작업 내용

- `tools/ops/post-deploy-smoke.mjs` 신설 — 배포 URL 기준 4축 스모크(90초 예산 내 재시도):
  - 헬스 `GET /actuator/health/readiness` → `status: UP`
  - 경로 탐색 `POST /api/v2/routes/search`(상록수→사당) → `ROUTE_SEARCH_V2` + itinerary≥1 + leg별 `etaSource` 라벨
  - 관리자 웹 `GET /admin/login` → 200 + 로그인 form 마커
  - 데이터팩 `GET {OCI}/catalog/current.json` → 200 + `packs[]` 비어있지 않음
- 강등 사다리 존중: `useRealtime=false` 고정, leg `etaSource`가 REALTIME이 아니어도(PLANNED·STATIC) PASS. 데이터팩 축은 독립 인프라(`deploymentAttributed=false`)로 리포트에 구분 표기.
- `tools/ops/post-deploy-smoke-contract.json` — 대표 OD·필수 필드·데이터팩 OCI URL을 계약 파일로 분리.
- `cd.yml` — `Verify public readiness`(미설정 시 통과) 제거 → ubuntu-latest `post-deploy-smoke` 잡 신설. `DEPLOY_PUBLIC_API_BASE_URL` 미설정 시 잡 실패. 스모크 실패는 자동 롤백 없이 잡 실패 → `notify-slack-cd-result` 전파. 리포트 artifact 14일 보존.
- 계약테스트: `post-deploy-smoke.test.mjs`(4축·강등·스키마 위반·타임아웃·계약 스키마), `backend-deploy.test.mjs`에 cd.yml 스모크 통합 고정.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/*.test.mjs tools/ops/*.test.mjs` → **188 pass / 0 fail**

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 스모크 4축 로직·강등·스키마 | CI | `node --test tools/ops/post-deploy-smoke.test.mjs` | 로컬 188 pass | ✅ |
| repo var `DEPLOY_PUBLIC_API_BASE_URL` 실값 설정 | 운영 | repo Variables | 오너 라이브 | ⏳ 핸드오프 |
| 실배포 4축 PASS + step summary | CD | 실배포 run 링크 | 오너 라이브 | ⏳ 핸드오프 |
| 잘못된 base URL → 잡 실패 + Slack | CD | workflow_dispatch | 오너 라이브 | ⏳ 핸드오프 |

## Version impact

- [x] backend deploy only

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: cd.yml 스모크 잡을 self-hosted 스텝이 아니라 ubuntu-latest 별도 잡으로 둔 이유(Node 24 가용·배포 URL 외부 도달성 검증·실패의 Slack 전파).
- 상위 트래커: #1683 (Phase 3). CodeRabbit rate-limit로 `/claude review` 폴백 리뷰 완료(발견 없음).

</details>

## 검증

- 실행한 명령과 결과: 기존 PR 본문 참조.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| PR 본문 양식 보강 | GitHub PR | 현재 템플릿 섹션 존재 확인 | PR body | 완료 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [ ] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [ ] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [ ] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 기존 PR 본문 참조
- mobile versionCode: 기존 PR 본문 참조
- datapack version: 기존 PR 본문 참조
- route contract: 기존 PR 본문 참조
- realtime contract: 기존 PR 본문 참조
- backend identity: 기존 PR 본문 참조

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 기존 PR 본문 참조.

## 리스크

- 기존 PR 본문 참조.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
