### PR TITLE
[CI] 취약점 스캔 상시화 + Dependabot 자동 업데이트 도입 (#1684)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,63 @@
+# Dependabot keeps SHA-pinned actions and lockfiles from silently aging — the
+# counterpart to this repo's pinning policy (issue #1684).
+#
+# Governance (see #1751 automerge FIFO queue):
+# - groups keep the weekly PR burst to ~1 PR per ecosystem.
+# - auto-rebase is turned off — the merge-queue coordinator owns up-to-date
+#   (branch update); Dependabot must not race it by auto-rebasing.
+# - No automerge label is auto-attached: labels are added only after the code
+#   review gate, Dependabot PRs included.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    rebase-strategy: disabled
+    groups:
+      actions-all:
+        patterns:
+          - "*"
+
+  - package-ecosystem: gradle
+    directory: "/backend"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    rebase-strategy: disabled
+    groups:
+      gradle-backend-minor:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: gradle
+    directory: "/apps/mobile/android"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    rebase-strategy: disabled
+    groups:
+      gradle-android-minor:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: pub
+    directory: "/apps/mobile"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    rebase-strategy: disabled
+    groups:
+      pub-minor:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,10 @@ jobs:
   pr-title:
     name: PR Title
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' }}
+    # Dependabot PR titles follow its own convention, not the bracket prefix.
+    # Skipping the job (rather than loosening the human regex) reports as skipped,
+    # which a required-check ruleset treats as satisfied (issue #1684, #1685).
+    if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
     permissions:
       contents: read
     env:

--- a/.github/workflows/osv-scheduled.yml
+++ b/.github/workflows/osv-scheduled.yml
@@ -1,0 +1,65 @@
+name: Scheduled Dependency Vulnerability Scan
+
+# The PR-triggered OSV scan in ci.yml only catches CVEs when a PR is open.
+# This scheduled scan closes the "no PR" detection gap by re-scanning the same
+# lockfiles weekly and on demand (issue #1684). It uses the non-PR OSV reusable
+# workflow pinned to the same SHA as ci.yml.
+
+on:
+  schedule:
+    # Tuesday 06:17 KST (Monday 21:17 UTC) — offset from the other repo crons.
+    - cron: "17 21 * * 1"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  osv-scan:
+    name: Scheduled OSV Scan
+    permissions:
+      actions: read
+      security-events: write
+      contents: read
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2
+    with:
+      scan-args: |-
+        --lockfile=apps/mobile/pubspec.lock
+        --lockfile=apps/mobile/android/app/gradle.lockfile
+        --lockfile=backend/gradle.lockfile
+
+  notify-slack-security-failure:
+    name: Slack / Security failure
+    runs-on: ubuntu-latest
+    permissions: {}
+    needs:
+      - osv-scan
+    if: >-
+      ${{
+        always() &&
+        (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
+      }}
+    env:
+      SLACK_SECURITY_WEBHOOK_URL: ${{ secrets.SLACK_SECURITY_WEBHOOK_URL }}
+    steps:
+      - name: Slack / Skip missing security webhook
+        if: ${{ env.SLACK_SECURITY_WEBHOOK_URL == '' }}
+        run: echo "::notice title=Slack notification::SLACK_SECURITY_WEBHOOK_URL is not configured."
+
+      - name: Slack / Notify security failure
+        if: ${{ env.SLACK_SECURITY_WEBHOOK_URL != '' }}
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c
+        with:
+          webhook: ${{ env.SLACK_SECURITY_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "EasySubway scheduled dependency scan failed"
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: |
+                    *EasySubway 스케줄 취약점 스캔 실패*
+                    • repo: `${{ github.repository }}`
+                    • ref: `${{ github.ref_name }}`
+                    • actor: `${{ github.actor }}`
+                    • run: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|GitHub Actions 열기>

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1002,6 +1002,7 @@ test("GitHub Actions Slack 알림은 채널별 webhook secret으로 필터링한
   const dataPackReleaseWorkflow = read(".github/workflows/datapack-release.yml");
   const sonarCloudWorkflow = read(".github/workflows/sonarcloud.yml");
   const storeDistributionWorkflow = read(".github/workflows/store-distribution-evidence.yml");
+  const osvScheduledWorkflow = read(".github/workflows/osv-scheduled.yml");
   const inlineSlackWorkflows = [
     ciWorkflow,
     cdWorkflow,
@@ -1009,29 +1010,31 @@ test("GitHub Actions Slack 알림은 채널별 webhook secret으로 필터링한
     dataPackReleaseWorkflow,
     sonarCloudWorkflow,
     storeDistributionWorkflow,
+    osvScheduledWorkflow,
   ].join("\n---\n");
   const readme = read("README.md");
   const envExample = read(".env.example");
 
   assert.ok(!existsSync(path.join(root, removedWorkflowPath)), "Slack notification workflow must not create standalone skipped runs");
-  assert.equal((inlineSlackWorkflows.match(/uses: slackapi\/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c/g) ?? []).length, 6);
-  assert.equal((inlineSlackWorkflows.match(/webhook-type: incoming-webhook/g) ?? []).length, 6);
+  assert.equal((inlineSlackWorkflows.match(/uses: slackapi\/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c/g) ?? []).length, 7);
+  assert.equal((inlineSlackWorkflows.match(/webhook-type: incoming-webhook/g) ?? []).length, 7);
   assert.doesNotMatch(inlineSlackWorkflows, /uses: slackapi\/slack-github-action@v3\.0\.3/);
   const slackPayloads = inlineSlackWorkflows.match(/payload: \|\n(?: {10,}.+\n?)*/g) ?? [];
-  assert.equal(slackPayloads.length, 6);
+  assert.equal(slackPayloads.length, 7);
   for (const payload of slackPayloads) {
     assert.doesNotMatch(payload, /^\s+(channel|username|icon_emoji|icon_url):/m);
   }
   assert.doesNotMatch(inlineSlackWorkflows, /webhook:\s*\$\{\{ secrets\.EASYSUBWAY_ENV \}\}/);
   assert.equal((inlineSlackWorkflows.match(/SLACK_CI_WEBHOOK_URL: \$\{\{ secrets\.SLACK_CI_WEBHOOK_URL \}\}/g) ?? []).length, 1);
   assert.equal((inlineSlackWorkflows.match(/SLACK_RELEASE_WEBHOOK_URL: \$\{\{ secrets\.SLACK_RELEASE_WEBHOOK_URL \}\}/g) ?? []).length, 4);
-  assert.equal((inlineSlackWorkflows.match(/SLACK_SECURITY_WEBHOOK_URL: \$\{\{ secrets\.SLACK_SECURITY_WEBHOOK_URL \}\}/g) ?? []).length, 1);
+  assert.equal((inlineSlackWorkflows.match(/SLACK_SECURITY_WEBHOOK_URL: \$\{\{ secrets\.SLACK_SECURITY_WEBHOOK_URL \}\}/g) ?? []).length, 2);
   assert.match(ciWorkflow, /notify-slack-ci-failure:[\s\S]*needs:\s*\n\s*-\s*changes[\s\S]*github\.event_name == 'push'[\s\S]*github\.ref == 'refs\/heads\/main'[\s\S]*contains\(needs\.\*\.result, 'failure'\)/);
   assert.match(cdWorkflow, /notify-slack-cd-result:[\s\S]*needs:\s*\n\s*-\s*plan\n\s*-\s*deploy[\s\S]*SLACK_RELEASE_WEBHOOK_URL/);
   assert.match(releaseArtifactsWorkflow, /notify-slack-release-result:[\s\S]*github\.event_name != 'pull_request'[\s\S]*SLACK_RELEASE_WEBHOOK_URL/);
   assert.match(dataPackReleaseWorkflow, /notify-slack-datapack-result:[\s\S]*SLACK_RELEASE_WEBHOOK_URL/);
   assert.match(storeDistributionWorkflow, /notify-slack-store-result:[\s\S]*SLACK_RELEASE_WEBHOOK_URL/);
   assert.match(sonarCloudWorkflow, /notify-slack-security-failure:[\s\S]*github\.event_name == 'push'[\s\S]*SLACK_SECURITY_WEBHOOK_URL/);
+  assert.match(osvScheduledWorkflow, /notify-slack-security-failure:[\s\S]*needs:\s*\n\s*-\s*osv-scan[\s\S]*SLACK_SECURITY_WEBHOOK_URL/);
 
   assert.match(readme, /Slack webhook secret은 애플리케이션 런타임 dotenv인 `EASYSUBWAY_ENV`에 섞지 않습니다/);
   assert.match(readme, /SLACK_CI_WEBHOOK_URL/);
@@ -1041,6 +1044,60 @@ test("GitHub Actions Slack 알림은 채널별 webhook secret으로 필터링한
   assert.match(envExample, /^SLACK_CI_WEBHOOK_URL=$/m);
   assert.match(envExample, /^SLACK_RELEASE_WEBHOOK_URL=$/m);
   assert.match(envExample, /^SLACK_SECURITY_WEBHOOK_URL=$/m);
+});
+
+test("스케줄 취약점 스캔은 PR 스캔과 동일 SHA·동일 lockfile로 상시 감시한다", () => {
+  const scheduled = read(".github/workflows/osv-scheduled.yml");
+  const ci = read(".github/workflows/ci.yml");
+
+  // Same pinned reusable OSV workflow SHA as ci.yml, non-PR variant.
+  assert.match(
+    ci,
+    /uses: google\/osv-scanner-action\/\.github\/workflows\/osv-scanner-reusable-pr\.yml@9a498708959aeaef5ef730655706c5a1df1edbc2/,
+  );
+  assert.match(
+    scheduled,
+    /uses: google\/osv-scanner-action\/\.github\/workflows\/osv-scanner-reusable\.yml@9a498708959aeaef5ef730655706c5a1df1edbc2/,
+  );
+  assert.match(scheduled, /- cron: "17 21 \* \* 1"/);
+  assert.match(scheduled, /workflow_dispatch:/);
+  for (const lockfile of [
+    "--lockfile=apps/mobile/pubspec.lock",
+    "--lockfile=apps/mobile/android/app/gradle.lockfile",
+    "--lockfile=backend/gradle.lockfile",
+  ]) {
+    assert.ok(scheduled.includes(lockfile), `scheduled scan must include ${lockfile}`);
+  }
+  // Least privilege on the scan job; top-level workflow has no ambient perms.
+  assert.match(scheduled, /permissions: \{\}/);
+  assert.match(scheduled, /security-events: write/);
+
+  // Dependabot PR titles bypass the human bracket-prefix check via actor skip,
+  // not by loosening the regex (skipped == satisfied for required checks).
+  assert.match(ci, /github\.actor != 'dependabot\[bot\]'/);
+});
+
+test("Dependabot는 4개 ecosystem을 큐 규약(그룹·rebase 비활성)으로 자동 업데이트한다", () => {
+  const dependabot = read(".github/dependabot.yml");
+  assert.match(dependabot, /^version: 2$/m);
+
+  const ecosystems = [...dependabot.matchAll(/package-ecosystem: (\S+)\n\s*directory: "([^"]+)"/g)].map(
+    (match) => `${match[1]}:${match[2]}`,
+  );
+  assert.deepEqual(ecosystems.sort(), [
+    "github-actions:/",
+    "gradle:/apps/mobile/android",
+    "gradle:/backend",
+    "pub:/apps/mobile",
+  ]);
+
+  // #1751 coordinator owns branch-up-to-date; Dependabot must not auto-rebase.
+  assert.equal((dependabot.match(/rebase-strategy: disabled/g) ?? []).length, 4);
+  // Grouped so the weekly burst stays ~1 PR per ecosystem.
+  assert.equal((dependabot.match(/groups:/g) ?? []).length, 4);
+  assert.equal((dependabot.match(/open-pull-requests-limit: 5/g) ?? []).length, 4);
+  // No auto-label: the automerge label is added only after the review gate.
+  assert.doesNotMatch(dependabot, /labels:/);
 });
 
 test("CD dotenv 검증은 운영 fallback env 계약을 반영한다", async () => {


### PR DESCRIPTION
## 관련 이슈

Refs #1684 #1751 #1685 #1683

## 작업 배경

- 기존 PR 본문 참조.

## 작업 내용

<details>
<summary>기존 PR 본문</summary>

## 요약 (#1684, Phase 1)

취약점 탐지를 PR 이벤트 의존에서 **스케줄 상시 감시**로 확장하고, SHA 고정 정책의 짝인 **Dependabot 자동 업데이트 PR**을 붙인다.

## 변경

- **`.github/workflows/osv-scheduled.yml`** — 주 1회(화 06:17 KST, `17 21 * * 1`) + `workflow_dispatch`. ci.yml과 **동일 고정 SHA**의 비-PR reusable OSV 워크플로(`osv-scanner-reusable.yml`)로 3개 lockfile(`apps/mobile/pubspec.lock`, `apps/mobile/android/app/gradle.lockfile`, `backend/gradle.lockfile`) 스캔. 실패 시 `SLACK_SECURITY_WEBHOOK_URL` 통지(sonarcloud `notify-slack-security-failure` 패턴 복제, webhook 미설정 시 notice 후 스킵).
- **`.github/dependabot.yml`** — 4개 ecosystem(github-actions `/`, gradle `/backend`, gradle `/apps/mobile/android`, pub `/apps/mobile`) weekly. **#1751 큐 규약 반영**: `groups`로 ecosystem당 ~1 PR, `rebase-strategy: disabled`(코디네이터가 up-to-date 전담), `open-pull-requests-limit: 5`, **라벨 자동부착 없음**(리뷰 게이트 후에만 부착).
- **ci.yml `pr-title`** — `github.actor != 'dependabot[bot]'` 예외. #1685에서 `PR Title` 필수화 시 dependabot PR은 skipped→ruleset 충족으로 머지 차단 없음.
- **계약테스트** — 스케줄 스캔 SHA·lockfile·최소권한, Dependabot 4 ecosystem·그룹·rebase 비활성·무라벨, Slack pin 카운트 6→7.

## 검증 (로컬)

- `node --test tools/ci/*.test.mjs` → **176 pass / 0 fail**

## 오너 라이브 검증 필요 (핸드오프 — 시간·외부 이벤트 의존)

- [ ] `osv-scheduled.yml` schedule 트리거 1회 이상 성공 run 링크
- [ ] 의도적 실패(또는 dispatch)로 보안 Slack 통지 수신 확인
- [ ] Dependabot 4 ecosystem PR 생성 + 1건 이상 필수 체크 통과 후 머지
- [ ] Dependabot PR에서 `pr-title` 잡 실패하지 않음(예외 동작 확인)

## 비범위

CodeQL 도입, OSV 필수 체크 승격(3개월 후 재평가), Renovate 전환.

상위: #1683 (Phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>

## 검증

- 실행한 명령과 결과: 기존 PR 본문 참조.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| PR 본문 양식 보강 | GitHub PR | 현재 템플릿 섹션 존재 확인 | PR body | 완료 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [ ] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [ ] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [ ] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 기존 PR 본문 참조
- mobile versionCode: 기존 PR 본문 참조
- datapack version: 기존 PR 본문 참조
- route contract: 기존 PR 본문 참조
- realtime contract: 기존 PR 본문 참조
- backend identity: 기존 PR 본문 참조

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 기존 PR 본문 참조.

## 리스크

- 기존 PR 본문 참조.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
