### PR TITLE
[CI] main ruleset 필수 체크 정합 도구화 + 코디네이터 동적 조회 (#1685)

### DIFF
--- a/.github/workflows/automerge-queue.yml
+++ b/.github/workflows/automerge-queue.yml
@@ -52,13 +52,17 @@ jobs:
           # without editing this workflow. Fall back to the known set if the
           # ruleset query fails, so a transient API error never lets a PR with a
           # failing required check slip past the derail logic.
+          ruleset_err="$(mktemp)"
           required_checks=$(gh api "repos/${REPO}/rules/branches/main" \
             --jq '[.[] | select(.type == "required_status_checks")
-              | .parameters.required_status_checks[].context]' 2>/dev/null || echo '')
+              | .parameters.required_status_checks[].context]' 2>"${ruleset_err}" || true)
           if [ -z "${required_checks}" ] || [ "${required_checks}" = "[]" ]; then
-            echo "::warning::main ruleset required_status_checks 동적 조회 실패 — 하드코딩 폴백 사용."
+            # Preserve the underlying gh api error so repeated fallbacks are
+            # diagnosable from the workflow log (permission/API change/transient).
+            echo "::warning::main ruleset required_status_checks 동적 조회 실패($(tr '\n' ' ' <"${ruleset_err}")) — 하드코딩 폴백 사용."
             required_checks='["Changes","Repository CI","Backend CI","Mobile App CI","Android CI","Release Gate Consistency","PR Title"]'
           fi
+          rm -f "${ruleset_err}"
 
           queue=$(gh pr list --repo "${REPO}" --label automerge --base main --state open \
             --json number,createdAt,isDraft \

--- a/.github/workflows/automerge-queue.yml
+++ b/.github/workflows/automerge-queue.yml
@@ -47,7 +47,18 @@ jobs:
             echo "::warning::AUTOMERGE_PAT secret이 없어 GITHUB_TOKEN으로 실행한다. update-branch push가 PR CI를 트리거하지 못해 큐 체인이 멈출 수 있다."
           fi
 
-          required_checks='["Changes","Repository CI","Backend CI","Mobile App CI","Android CI"]'
+          # Derive the required checks from the main ruleset so newly required
+          # checks (Release Gate Consistency, PR Title — #1685) are honored
+          # without editing this workflow. Fall back to the known set if the
+          # ruleset query fails, so a transient API error never lets a PR with a
+          # failing required check slip past the derail logic.
+          required_checks=$(gh api "repos/${REPO}/rules/branches/main" \
+            --jq '[.[] | select(.type == "required_status_checks")
+              | .parameters.required_status_checks[].context]' 2>/dev/null || echo '')
+          if [ -z "${required_checks}" ] || [ "${required_checks}" = "[]" ]; then
+            echo "::warning::main ruleset required_status_checks 동적 조회 실패 — 하드코딩 폴백 사용."
+            required_checks='["Changes","Repository CI","Backend CI","Mobile App CI","Android CI","Release Gate Consistency","PR Title"]'
+          fi
 
           queue=$(gh pr list --repo "${REPO}" --label automerge --base main --state open \
             --json number,createdAt,isDraft \

--- a/tools/ci/apply-main-ruleset-required-checks.mjs
+++ b/tools/ci/apply-main-ruleset-required-checks.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+// Bring the main branch ruleset's required_status_checks in line with the CI
+// jobs that must gate merges (issue #1685). The live PUT is an irreversible
+// governance change, so this tool defaults to a dry run and only mutates when
+// invoked with --apply; it always writes a backup first for a rollback path.
+//
+// Usage (owner-run):
+//   node tools/ci/apply-main-ruleset-required-checks.mjs --backup ruleset-backup.json
+//     → dry run: prints which contexts would be added.
+//   node tools/ci/apply-main-ruleset-required-checks.mjs --backup ruleset-backup.json --apply
+//     → writes backup, then PUTs the updated ruleset.
+//
+// The context list is the single source of truth shared (via the contract test)
+// with ci.yml job names and the automerge-queue coordinator fallback.
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { argValue } from "../release/summary-validation-utils.mjs";
+
+export const MAIN_RULESET_ID = "17584352";
+
+// 1:1 with the ci.yml job `name:` values. Renaming a job here without updating
+// ci.yml (or vice versa) is caught by repository-contract.test.mjs.
+export const REQUIRED_STATUS_CHECK_CONTEXTS = [
+  "Changes",
+  "Repository CI",
+  "Backend CI",
+  "Mobile App CI",
+  "Android CI",
+  "Release Gate Consistency",
+  "PR Title",
+];
+
+// Returns a new ruleset object whose required_status_checks rule contains every
+// context in `contexts`, plus the list of contexts that were added. Existing
+// contexts, other rules, and the strict policy flag are preserved.
+export function ensureRequiredChecks(ruleset, contexts) {
+  const next = structuredClone(ruleset);
+  const rule = (next.rules ?? []).find((entry) => entry.type === "required_status_checks");
+  if (!rule) {
+    throw new Error("ruleset has no required_status_checks rule");
+  }
+  const existing = rule.parameters.required_status_checks ?? [];
+  const present = new Set(existing.map((check) => check.context));
+  const added = [];
+  for (const context of contexts) {
+    if (!present.has(context)) {
+      existing.push({ context });
+      added.push(context);
+    }
+  }
+  rule.parameters.required_status_checks = existing;
+  return { ruleset: next, added };
+}
+
+// The GitHub PUT rejects read-only envelope fields returned by GET.
+function toWritableRuleset(ruleset) {
+  const { name, target, enforcement, bypass_actors, conditions, rules } = ruleset;
+  return { name, target, enforcement, bypass_actors, conditions, rules };
+}
+
+function ghApi(args, stdin) {
+  return execFileSync("gh", ["api", ...args], { encoding: "utf8", input: stdin });
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const apply = args.includes("--apply");
+  const backupPath = argValue(args, "--backup");
+  const repo = argValue(args, "--repo", process.env.GITHUB_REPOSITORY || "AquilaXk/easysubway");
+  const inputPath = argValue(args, "--input");
+
+  const current = inputPath
+    ? JSON.parse(readFileSync(inputPath, "utf8"))
+    : JSON.parse(ghApi([`repos/${repo}/rulesets/${MAIN_RULESET_ID}`]));
+
+  if (backupPath) {
+    writeFileSync(backupPath, `${JSON.stringify(current, null, 2)}\n`);
+    console.error(`backup written: ${backupPath}`);
+  }
+
+  const { ruleset, added } = ensureRequiredChecks(current, REQUIRED_STATUS_CHECK_CONTEXTS);
+  if (added.length === 0) {
+    console.error("required_status_checks already up to date; nothing to add");
+    return;
+  }
+  console.error(`contexts to add: ${added.join(", ")}`);
+
+  if (!apply) {
+    console.error("dry run (pass --apply to PUT the updated ruleset)");
+    return;
+  }
+  if (!backupPath) {
+    throw new Error("--backup is required with --apply (rollback path)");
+  }
+
+  const body = JSON.stringify(toWritableRuleset(ruleset));
+  ghApi(["-X", "PUT", `repos/${repo}/rulesets/${MAIN_RULESET_ID}`, "--input", "-"], body);
+  console.error("ruleset updated");
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/tools/ci/apply-main-ruleset-required-checks.mjs
+++ b/tools/ci/apply-main-ruleset-required-checks.mjs
@@ -1,18 +1,19 @@
 #!/usr/bin/env node
-// Bring the main branch ruleset's required_status_checks in line with the CI
-// jobs that must gate merges (issue #1685). The live PUT is an irreversible
-// governance change, so this tool defaults to a dry run and only mutates when
-// invoked with --apply; it always writes a backup first for a rollback path.
+// Compute the main branch ruleset payload whose required_status_checks are in
+// line with the CI jobs that must gate merges (issue #1685). This is a pure
+// transform — it does NOT call the GitHub API itself; the owner runs the gh
+// get/put around it, keeping the irreversible governance change explicit and
+// out of any spawned process.
 //
 // Usage (owner-run):
-//   node tools/ci/apply-main-ruleset-required-checks.mjs --backup ruleset-backup.json
-//     → dry run: prints which contexts would be added.
-//   node tools/ci/apply-main-ruleset-required-checks.mjs --backup ruleset-backup.json --apply
-//     → writes backup, then PUTs the updated ruleset.
+//   gh api repos/AquilaXk/easysubway/rulesets/17584352 > current.json
+//   node tools/ci/apply-main-ruleset-required-checks.mjs \
+//     --input current.json --output updated.json --backup ruleset-backup.json
+//   # review updated.json, then apply:
+//   gh api -X PUT repos/AquilaXk/easysubway/rulesets/17584352 --input updated.json
 //
 // The context list is the single source of truth shared (via the contract test)
 // with ci.yml job names and the automerge-queue coordinator fallback.
-import { execFileSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
 import { argValue } from "../release/summary-validation-utils.mjs";
 
@@ -52,27 +53,22 @@ export function ensureRequiredChecks(ruleset, contexts) {
   return { ruleset: next, added };
 }
 
-// The GitHub PUT rejects read-only envelope fields returned by GET.
-function toWritableRuleset(ruleset) {
+// The GitHub PUT rejects the read-only envelope fields returned by GET.
+export function toWritableRuleset(ruleset) {
   const { name, target, enforcement, bypass_actors, conditions, rules } = ruleset;
   return { name, target, enforcement, bypass_actors, conditions, rules };
 }
 
-function ghApi(args, stdin) {
-  return execFileSync("gh", ["api", ...args], { encoding: "utf8", input: stdin });
-}
-
 function main() {
   const args = process.argv.slice(2);
-  const apply = args.includes("--apply");
-  const backupPath = argValue(args, "--backup");
-  const repo = argValue(args, "--repo", process.env.GITHUB_REPOSITORY || "AquilaXk/easysubway");
   const inputPath = argValue(args, "--input");
+  if (!inputPath) {
+    throw new Error("--input <ruleset-json> is required (gh api repos/.../rulesets/17584352 > current.json)");
+  }
+  const outputPath = argValue(args, "--output");
+  const backupPath = argValue(args, "--backup");
 
-  const current = inputPath
-    ? JSON.parse(readFileSync(inputPath, "utf8"))
-    : JSON.parse(ghApi([`repos/${repo}/rulesets/${MAIN_RULESET_ID}`]));
-
+  const current = JSON.parse(readFileSync(inputPath, "utf8"));
   if (backupPath) {
     writeFileSync(backupPath, `${JSON.stringify(current, null, 2)}\n`);
     console.error(`backup written: ${backupPath}`);
@@ -81,21 +77,17 @@ function main() {
   const { ruleset, added } = ensureRequiredChecks(current, REQUIRED_STATUS_CHECK_CONTEXTS);
   if (added.length === 0) {
     console.error("required_status_checks already up to date; nothing to add");
-    return;
-  }
-  console.error(`contexts to add: ${added.join(", ")}`);
-
-  if (!apply) {
-    console.error("dry run (pass --apply to PUT the updated ruleset)");
-    return;
-  }
-  if (!backupPath) {
-    throw new Error("--backup is required with --apply (rollback path)");
+  } else {
+    console.error(`contexts to add: ${added.join(", ")}`);
   }
 
-  const body = JSON.stringify(toWritableRuleset(ruleset));
-  ghApi(["-X", "PUT", `repos/${repo}/rulesets/${MAIN_RULESET_ID}`, "--input", "-"], body);
-  console.error("ruleset updated");
+  const payload = `${JSON.stringify(toWritableRuleset(ruleset), null, 2)}\n`;
+  if (outputPath) {
+    writeFileSync(outputPath, payload);
+    console.error(`updated ruleset written: ${outputPath} (review, then gh api -X PUT --input ${outputPath})`);
+  } else {
+    process.stdout.write(payload);
+  }
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/tools/ci/apply-main-ruleset-required-checks.test.mjs
+++ b/tools/ci/apply-main-ruleset-required-checks.test.mjs
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  MAIN_RULESET_ID,
+  REQUIRED_STATUS_CHECK_CONTEXTS,
+  ensureRequiredChecks,
+} from "./apply-main-ruleset-required-checks.mjs";
+
+function baselineRuleset() {
+  return {
+    id: 17584352,
+    name: "main",
+    target: "branch",
+    enforcement: "active",
+    conditions: { ref_name: { include: ["~DEFAULT_BRANCH"], exclude: [] } },
+    rules: [
+      { type: "deletion" },
+      {
+        type: "required_status_checks",
+        parameters: {
+          strict_required_status_checks_policy: true,
+          required_status_checks: [
+            { context: "Changes" },
+            { context: "Repository CI" },
+            { context: "Backend CI" },
+            { context: "Mobile App CI" },
+            { context: "Android CI" },
+          ],
+        },
+      },
+    ],
+  };
+}
+
+test("adds only the missing contexts and reports them", () => {
+  const { ruleset, added } = ensureRequiredChecks(baselineRuleset(), REQUIRED_STATUS_CHECK_CONTEXTS);
+  assert.deepEqual(added, ["Release Gate Consistency", "PR Title"]);
+  const rule = ruleset.rules.find((entry) => entry.type === "required_status_checks");
+  const contexts = rule.parameters.required_status_checks.map((check) => check.context);
+  assert.deepEqual(contexts, REQUIRED_STATUS_CHECK_CONTEXTS);
+  // Strict policy and other rules are preserved.
+  assert.equal(rule.parameters.strict_required_status_checks_policy, true);
+  assert.ok(ruleset.rules.some((entry) => entry.type === "deletion"));
+});
+
+test("is idempotent once all contexts are present", () => {
+  const once = ensureRequiredChecks(baselineRuleset(), REQUIRED_STATUS_CHECK_CONTEXTS).ruleset;
+  const { added } = ensureRequiredChecks(once, REQUIRED_STATUS_CHECK_CONTEXTS);
+  assert.deepEqual(added, []);
+});
+
+test("does not mutate the input ruleset", () => {
+  const input = baselineRuleset();
+  ensureRequiredChecks(input, REQUIRED_STATUS_CHECK_CONTEXTS);
+  const rule = input.rules.find((entry) => entry.type === "required_status_checks");
+  assert.equal(rule.parameters.required_status_checks.length, 5);
+});
+
+test("throws when the ruleset has no required_status_checks rule", () => {
+  const ruleset = { rules: [{ type: "deletion" }] };
+  assert.throws(() => ensureRequiredChecks(ruleset, REQUIRED_STATUS_CHECK_CONTEXTS), /no required_status_checks rule/);
+});
+
+test("targets the documented main ruleset id and the seven gate contexts", () => {
+  assert.equal(MAIN_RULESET_ID, "17584352");
+  assert.deepEqual(REQUIRED_STATUS_CHECK_CONTEXTS, [
+    "Changes",
+    "Repository CI",
+    "Backend CI",
+    "Mobile App CI",
+    "Android CI",
+    "Release Gate Consistency",
+    "PR Title",
+  ]);
+});

--- a/tools/ci/apply-main-ruleset-required-checks.test.mjs
+++ b/tools/ci/apply-main-ruleset-required-checks.test.mjs
@@ -4,6 +4,7 @@ import {
   MAIN_RULESET_ID,
   REQUIRED_STATUS_CHECK_CONTEXTS,
   ensureRequiredChecks,
+  toWritableRuleset,
 } from "./apply-main-ruleset-required-checks.mjs";
 
 function baselineRuleset() {
@@ -59,6 +60,35 @@ test("does not mutate the input ruleset", () => {
 test("throws when the ruleset has no required_status_checks rule", () => {
   const ruleset = { rules: [{ type: "deletion" }] };
   assert.throws(() => ensureRequiredChecks(ruleset, REQUIRED_STATUS_CHECK_CONTEXTS), /no required_status_checks rule/);
+});
+
+test("toWritableRuleset keeps only the PUT-writable fields and drops read-only envelope", () => {
+  const fromGet = {
+    id: 17584352,
+    node_id: "RRS_x",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-02T00:00:00Z",
+    source_type: "Repository",
+    source: "AquilaXk/easysubway",
+    current_user_can_bypass: "always",
+    _links: { self: { href: "..." } },
+    name: "main",
+    target: "branch",
+    enforcement: "active",
+    bypass_actors: [{ actor_id: 1 }],
+    conditions: { ref_name: { include: ["~DEFAULT_BRANCH"], exclude: [] } },
+    rules: [{ type: "deletion" }],
+  };
+  const writable = toWritableRuleset(fromGet);
+  assert.deepEqual(
+    Object.keys(writable).sort(),
+    ["bypass_actors", "conditions", "enforcement", "name", "rules", "target"],
+  );
+  for (const readOnly of ["id", "node_id", "created_at", "updated_at", "source", "_links", "current_user_can_bypass"]) {
+    assert.ok(!(readOnly in writable), `${readOnly} must be dropped`);
+  }
+  assert.equal(writable.name, "main");
+  assert.deepEqual(writable.rules, [{ type: "deletion" }]);
 });
 
 test("targets the documented main ruleset id and the seven gate contexts", () => {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -8,6 +8,7 @@ import path from "node:path";
 import test from "node:test";
 import { promisify } from "node:util";
 import { inflateSync } from "node:zlib";
+import { REQUIRED_STATUS_CHECK_CONTEXTS } from "./apply-main-ruleset-required-checks.mjs";
 
 const root = process.cwd();
 const execFileAsync = promisify(execFile);
@@ -720,6 +721,30 @@ test("지속적 통합 작업과 스텝 이름은 실패 영역을 구분할 수
   assert.match(workflow, /Mobile App CI \/ Run mobile contracts/);
   assert.match(workflow, /Android CI \/ Build Flutter Android debug APK/);
   assert.doesNotMatch(releaseGateJob, /iOS CI \/ Build Flutter iOS simulator app/);
+});
+
+test("main ruleset 필수 체크는 ci.yml 잡 이름·automerge 코디네이터와 1:1로 고정된다", () => {
+  // These context names correspond 1:1 to main ruleset 17584352's
+  // required_status_checks. Renaming a ci.yml job without updating the ruleset
+  // (via apply-main-ruleset-required-checks.mjs) would leave a required check
+  // forever pending and block every merge — this test is the tripwire.
+  const workflow = read(".github/workflows/ci.yml");
+  for (const context of REQUIRED_STATUS_CHECK_CONTEXTS) {
+    assert.match(workflow, new RegExp(`name: ${context.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\$&")}\\n`));
+  }
+  // Release Gate Consistency and PR Title are the two checks #1685 promotes to
+  // required, so they must be part of the canonical set.
+  assert.ok(REQUIRED_STATUS_CHECK_CONTEXTS.includes("Release Gate Consistency"));
+  assert.ok(REQUIRED_STATUS_CHECK_CONTEXTS.includes("PR Title"));
+
+  // The automerge coordinator derives the list from the ruleset at runtime, and
+  // its hardcoded fallback must match the canonical set exactly (#1685 note).
+  const coordinator = read(".github/workflows/automerge-queue.yml");
+  assert.match(coordinator, /gh api "repos\/\$\{REPO\}\/rules\/branches\/main"/);
+  assert.match(coordinator, /select\(\.type == "required_status_checks"\)/);
+  const fallbackMatch = coordinator.match(/required_checks='(\[[^']*\])'/);
+  assert.ok(fallbackMatch, "coordinator must keep a hardcoded fallback list");
+  assert.deepEqual(JSON.parse(fallbackMatch[1]), REQUIRED_STATUS_CHECK_CONTEXTS);
 });
 
 test("필수 지속적 통합 작업은 변경 없는 영역도 성공 상태로 종료한다", () => {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -730,7 +730,9 @@ test("main ruleset 필수 체크는 ci.yml 잡 이름·automerge 코디네이터
   // forever pending and block every merge — this test is the tripwire.
   const workflow = read(".github/workflows/ci.yml");
   for (const context of REQUIRED_STATUS_CHECK_CONTEXTS) {
-    assert.match(workflow, new RegExp(`name: ${context.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\$&")}\\n`));
+    // Context names are plain job names; a literal substring check avoids
+    // regex-escaping the value.
+    assert.ok(workflow.includes(`name: ${context}\n`), `ci.yml must define a job named ${context}`);
   }
   // Release Gate Consistency and PR Title are the two checks #1685 promotes to
   // required, so they must be part of the canonical set.


### PR DESCRIPTION
## 관련 이슈

close #1685

## 작업 배경

- 기존 PR 본문 참조.

## 작업 내용

<details>
<summary>기존 PR 본문</summary>

## 관련 이슈

close #1685

## 작업 배경

`ci.yml`에는 매 PR 실행되지만 **필수가 아닌** 잡이 2개(`Release Gate Consistency`·`PR Title`) 있어, 릴리즈 게이트 계약테스트가 실패해도 머지가 가능했다. 매 PR 실행하면서 통과를 강제하지 않는 것은 모순이다. ruleset은 코드 밖 설정이라 잡 이름 변경 시 조용히 어긋나는 위험도 있다.

## 작업 내용

- `tools/ci/apply-main-ruleset-required-checks.mjs` 신설 — ruleset 17584352에 7개 컨텍스트(기존 5 + Release Gate Consistency·PR Title)를 정합시키는 **순수 변환기**. 입력 ruleset JSON → 수정 JSON 출력만 하고 gh 호출은 안 한다(오너가 앞뒤로 실행):
  ```
  gh api repos/AquilaXk/easysubway/rulesets/17584352 > current.json
  node tools/ci/apply-main-ruleset-required-checks.mjs --input current.json --output updated.json --backup ruleset-backup.json
  gh api -X PUT repos/AquilaXk/easysubway/rulesets/17584352 --input updated.json
  ```
- `ensureRequiredChecks` 순수함수(멱등·strict 정책·타 rule 보존)·`toWritableRuleset`(read-only 필드 제거).
- `.github/workflows/automerge-queue.yml` — 코디네이터 필수 체크 판정을 하드코딩 5종 → **ruleset 동적 조회**로 전환. 조회 실패 시 7종 폴백. (#1751 note)
- 계약테스트: 7개 컨텍스트 ↔ ci.yml 잡 `name:` ↔ 코디네이터 폴백 1:1 tripwire.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/*.test.mjs` → **180 pass / 0 fail**
  - 순수 변환 CLI: 추가 대상 `Release Gate Consistency, PR Title` 감지 + 백업 기록 + updated.json에서 read-only 필드 제거 확인

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 변환 로직·멱등·코디네이터 계약 | CI | `node --test tools/ci/*.test.mjs` | 로컬 180 pass | ✅ |
| ruleset 필수 체크 7개 갱신 + 백업 첨부 | 운영 | 위 gh get→도구→gh put | 오너 라이브(되돌리기 어려운 거버넌스 변경) | ⏳ 핸드오프 |
| 머지 차단 리허설 2건(게이트·title) | 운영 | 리허설 PR | 오너 라이브 | ⏳ 핸드오프 |

## Version impact

- [x] no version change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음

## 리뷰어 메모

- 라이브 ruleset PUT은 되돌리기 어려운 거버넌스 변경이라 도구는 순수 변환만 하고 실행은 오너 핸드오프(도구가 gh를 spawn하지 않음 = SonarCloud S4036도 해소). 코디네이터 동적 조회 전환을 같은 PR에 포함(#1685 착수 조건).
- 상위 트래커 #1683(Phase 1). `/claude review` 폴백에서 깨진 이스케이프 정규식 1건 발견·수정.

</details>

## 검증

- 실행한 명령과 결과: 기존 PR 본문 참조.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| PR 본문 양식 보강 | GitHub PR | 현재 템플릿 섹션 존재 확인 | PR body | 완료 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [ ] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [ ] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [ ] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 기존 PR 본문 참조
- mobile versionCode: 기존 PR 본문 참조
- datapack version: 기존 PR 본문 참조
- route contract: 기존 PR 본문 참조
- realtime contract: 기존 PR 본문 참조
- backend identity: 기존 PR 본문 참조

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 기존 PR 본문 참조.

## 리스크

- 기존 PR 본문 참조.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
