### PR TITLE
[Build] 백엔드 이미지 GHCR digest 배포·롤백 전환 (#1686)

### DIFF
--- a/.github/workflows/actions-storage-cleanup.yml
+++ b/.github/workflows/actions-storage-cleanup.yml
@@ -60,11 +60,21 @@ jobs:
           # Keep the 10 newest versions for rollback headroom (issue #1686); the
           # digest of the previous deploy is what rollback pulls, so retention
           # must comfortably exceed the depth we might roll back to.
+          # per_page=100 (single page, no --paginate): the backend image keeps
+          # only ~10 tagged versions, so one page covers retention; --paginate
+          # would run --jq per page and break the cross-page created_at sort.
+          versions_err="$(mktemp)"
           versions="$(gh api \
             "/users/${OWNER}/packages/container/${PACKAGE}/versions?per_page=100" \
-            --jq 'sort_by(.created_at) | reverse | .[].id' 2>/dev/null || true)"
+            --jq 'sort_by(.created_at) | reverse | .[].id' 2>"${versions_err}" || true)"
+          if [ -s "${versions_err}" ]; then
+            # Surface a real error (auth/rate-limit/wrong path) instead of a
+            # silently green no-op that pruned nothing.
+            echo "::warning title=GHCR cleanup::versions 조회 오류: $(tr '\n' ' ' <"${versions_err}")"
+          fi
+          rm -f "${versions_err}"
           if [ -z "${versions}" ]; then
-            echo "::notice title=GHCR cleanup::no ${PACKAGE} versions found or token lacks packages scope."
+            echo "::notice title=GHCR cleanup::no ${PACKAGE} versions to prune (or token lacks packages scope)."
             exit 0
           fi
 

--- a/.github/workflows/actions-storage-cleanup.yml
+++ b/.github/workflows/actions-storage-cleanup.yml
@@ -39,3 +39,43 @@ jobs:
         run: |
           set -euo pipefail
           gh cache delete --all --succeed-on-no-caches
+
+  cleanup-ghcr-backend-images:
+    name: Prune old GHCR backend images
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Keep the latest 10 backend image versions
+        env:
+          # github.token can prune package versions only if it owns them; a
+          # classic PAT with delete:packages is the fallback for user-owned GHCR.
+          GH_TOKEN: ${{ secrets.GHCR_CLEANUP_PAT != '' && secrets.GHCR_CLEANUP_PAT || github.token }}
+          OWNER: aquilaxk
+          PACKAGE: easysubway-backend
+        run: |
+          set -euo pipefail
+
+          # Keep the 10 newest versions for rollback headroom (issue #1686); the
+          # digest of the previous deploy is what rollback pulls, so retention
+          # must comfortably exceed the depth we might roll back to.
+          versions="$(gh api \
+            "/users/${OWNER}/packages/container/${PACKAGE}/versions?per_page=100" \
+            --jq 'sort_by(.created_at) | reverse | .[].id' 2>/dev/null || true)"
+          if [ -z "${versions}" ]; then
+            echo "::notice title=GHCR cleanup::no ${PACKAGE} versions found or token lacks packages scope."
+            exit 0
+          fi
+
+          index=0
+          while read -r version_id; do
+            [ -n "${version_id}" ] || continue
+            index=$((index + 1))
+            if [ "${index}" -le 10 ]; then
+              continue
+            fi
+            echo "deleting ${PACKAGE} version ${version_id}"
+            gh api -X DELETE \
+              "/users/${OWNER}/packages/container/${PACKAGE}/versions/${version_id}" || true
+          done <<< "${versions}"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -32,6 +32,7 @@ jobs:
       contents: read
     outputs:
       deploy_target_relevant: ${{ steps.changes.outputs.deploy }}
+      sha: ${{ steps.target.outputs.sha }}
     if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main' && github.event.workflow_run.head_repository.full_name == github.repository) }}
 
     steps:
@@ -96,15 +97,102 @@ jobs:
           fi
           bash tools/ci/detect-changed-paths.sh changed-files.txt
 
+  build-image:
+    name: CD Build image
+    needs: plan
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+    if: ${{ needs.plan.outputs.deploy_target_relevant == 'true' }}
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
+    steps:
+      - name: CD Build image / Checkout target SHA
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ needs.plan.outputs.sha }}
+          persist-credentials: false
+
+      - name: CD Build image / Set up Java
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: gradle
+
+      - name: CD Build image / Build bootJar
+        working-directory: backend
+        shell: bash
+        run: ./gradlew bootJar --no-daemon
+
+      - name: CD Build image / Log in to GHCR
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: CD Build image / Build and push arm64 image
+        id: push
+        shell: bash
+        env:
+          IMAGE: ghcr.io/aquilaxk/easysubway-backend
+          DEPLOY_SHA: ${{ needs.plan.outputs.sha }}
+        run: |
+          set -euo pipefail
+          tag="${IMAGE}:sha-${DEPLOY_SHA}"
+
+          # Idempotent re-deploy: reuse the existing digest if this SHA tag was
+          # already pushed (e.g. a workflow_dispatch redeploy) — issue #1686.
+          if manifest="$(docker buildx imagetools inspect "${tag}" --format '{{json .Manifest}}' 2>/dev/null)"; then
+            digest="$(jq -r '.digest' <<<"${manifest}")"
+            echo "reusing existing digest ${digest} for ${tag}"
+          else
+            # Native arm64 build on the ubuntu-24.04-arm runner (OCI A1 target).
+            docker build \
+              -f backend/Dockerfile \
+              --label "org.opencontainers.image.revision=${DEPLOY_SHA}" \
+              --label "org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY}" \
+              -t "${tag}" \
+              backend
+
+            # An amd64 image would not even start on the aarch64 server, so gate
+            # the architecture before publishing.
+            arch="$(docker image inspect "${tag}" --format '{{.Os}}/{{.Architecture}}')"
+            if [[ "${arch}" != "linux/arm64" ]]; then
+              echo "built image arch ${arch}, expected linux/arm64" >&2
+              exit 1
+            fi
+
+            docker push "${tag}"
+            digest="$(docker buildx imagetools inspect "${tag}" --format '{{json .Manifest}}' | jq -r '.digest')"
+          fi
+
+          if [[ ! "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "failed to resolve pushed image digest" >&2
+            exit 1
+          fi
+          echo "digest=${digest}" >> "${GITHUB_OUTPUT}"
+          {
+            echo "### CD Build image"
+            echo "- tag: \`${tag}\`"
+            echo "- digest: \`${digest}\`"
+            echo "- arch: linux/arm64"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
   deploy:
     name: CD Deploy
-    needs: plan
+    needs:
+      - plan
+      - build-image
     runs-on:
       - self-hosted
       - easysubway-production
     permissions:
       actions: read
       contents: read
+      packages: read
     concurrency:
       group: cd-production-deploy
       cancel-in-progress: false
@@ -253,29 +341,32 @@ jobs:
           EASYSUBWAY_BACKEND_ENV_FILE="${PREPARED_ENV_DIR}/backend.env" \
             docker compose --env-file "${PREPARED_ENV_DIR}/compose.env" -f infra/docker-compose.yml config --quiet
 
-      - name: CD Deploy / Set up Java
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+      - name: CD Deploy / Log in to GHCR
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
         with:
-          distribution: temurin
-          java-version: "21"
-          cache: gradle
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: CD Deploy / Build backend bootJar
+      - name: CD Deploy / Pull backend image by digest
         shell: bash
-        working-directory: backend
+        env:
+          IMAGE: ghcr.io/aquilaxk/easysubway-backend
+          DEPLOY_IMAGE_DIGEST: ${{ needs.build-image.outputs.digest }}
         run: |
           set -euo pipefail
 
-          ./gradlew bootJar --no-daemon
-          jar_file="$(find build/libs -maxdepth 1 -type f -name '*.jar' ! -name '*-plain.jar' | head -n 1)"
-          if [[ -z "${jar_file}" ]]; then
-            echo "bootJar artifact not found" >&2
+          if [[ ! "${DEPLOY_IMAGE_DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "build-image did not produce a valid digest" >&2
             exit 1
           fi
 
-          cp "${jar_file}" "${RUNNER_TEMP}/backend.jar"
-          cd "${RUNNER_TEMP}"
-          sha256sum backend.jar > backend.jar.sha256
+          # build-once, deploy-same: pull the exact digest CI pushed, then retag
+          # to the local name the compose file and deploy script already expect,
+          # so their --no-build and image-drift contracts are unchanged (#1686).
+          docker pull "${IMAGE}@${DEPLOY_IMAGE_DIGEST}"
+          docker tag "${IMAGE}@${DEPLOY_IMAGE_DIGEST}" "easysubway-backend:${DEPLOY_SHA}"
+          echo "DEPLOY_IMAGE_DIGEST=${DEPLOY_IMAGE_DIGEST}" >> "${GITHUB_ENV}"
 
       - name: CD Deploy / Decide remote deploy readiness
         id: remote
@@ -321,8 +412,6 @@ jobs:
 
           install -m 700 -d "${incoming}"
           cp \
-            "${RUNNER_TEMP}/backend.jar" \
-            "${RUNNER_TEMP}/backend.jar.sha256" \
             "${PREPARED_ENV_DIR}/compose.env" \
             "${PREPARED_ENV_DIR}/backend.env" \
             tools/deploy/deploy-backend.sh \
@@ -331,6 +420,7 @@ jobs:
           DEPLOY_ROOT="${DEPLOY_ROOT}" \
             DEPLOY_COMPOSE_PROJECT="${DEPLOY_COMPOSE_PROJECT}" \
             DEPLOY_SHA="${DEPLOY_SHA}" \
+            DEPLOY_IMAGE_DIGEST="${DEPLOY_IMAGE_DIGEST}" \
             INCOMING_DIR="${incoming}" \
             bash "${incoming}/deploy-backend.sh"
 
@@ -358,6 +448,7 @@ jobs:
           {
             echo "### CD Deploy"
             echo "- target sha: ${DEPLOY_SHA:-unknown}"
+            echo "- image digest: ${{ needs.build-image.outputs.digest || 'unknown' }}"
             echo "- dotenv source: ${{ steps.dotenv.outputs.source || 'unknown' }}"
             echo "- mode: ${{ steps.target.outputs.mode || 'unknown' }}"
             echo "- remote deployment: ${{ steps.remote.outputs.deploy_ready == 'true' && 'started' || 'not_started' }}"
@@ -369,7 +460,6 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          rm -f "${RUNNER_TEMP}/backend.jar" "${RUNNER_TEMP}/backend.jar.sha256"
           if [[ -n "${EASYSUBWAY_ENV_FILE:-}" ]]; then
             rm -f "${EASYSUBWAY_ENV_FILE}"
           fi
@@ -381,6 +471,7 @@ jobs:
     permissions: {}
     needs:
       - plan
+      - build-image
       - deploy
     if: >-
       ${{

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -109,7 +109,9 @@ jobs:
       digest: ${{ steps.push.outputs.digest }}
     steps:
       - name: CD Build image / Checkout target SHA
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        # Not fork code: workflow_run is gated to same-repo main CI by the plan
+        # job's `if`, and the ref is a plan-verified main-ancestor SHA.
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # NOSONAR
         with:
           ref: ${{ needs.plan.outputs.sha }}
           persist-credentials: false

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -145,8 +145,8 @@ jobs:
 
           # Idempotent re-deploy: reuse the existing digest if this SHA tag was
           # already pushed (e.g. a workflow_dispatch redeploy) — issue #1686.
-          if manifest="$(docker buildx imagetools inspect "${tag}" --format '{{json .Manifest}}' 2>/dev/null)"; then
-            digest="$(jq -r '.digest' <<<"${manifest}")"
+          # {{.Manifest.digest}} is the documented descriptor digest accessor.
+          if digest="$(docker buildx imagetools inspect "${tag}" --format '{{.Manifest.digest}}' 2>/dev/null)" && [[ -n "${digest}" ]]; then
             echo "reusing existing digest ${digest} for ${tag}"
           else
             # Native arm64 build on the ubuntu-24.04-arm runner (OCI A1 target).
@@ -166,7 +166,9 @@ jobs:
             fi
 
             docker push "${tag}"
-            digest="$(docker buildx imagetools inspect "${tag}" --format '{{json .Manifest}}' | jq -r '.digest')"
+            # RepoDigests is populated by the push; take the digest after the '@'.
+            repo_digest="$(docker image inspect "${tag}" --format '{{index .RepoDigests 0}}')"
+            digest="${repo_digest##*@}"
           fi
 
           if [[ ! "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -440,6 +440,9 @@ jobs:
         run: |
           rm -f "${RUNNER_TEMP}/easysubway-ci-release.jks" "${RUNNER_TEMP}/easysubway-upload-key.jks" "${RUNNER_TEMP}/easysubway-release.env"
 
+  # Validation only: builds and inspects the backend image as a PR-time dry-run
+  # and does NOT push. The single production image producer is the CD build-image
+  # job (cd.yml), which publishes the arm64 image to GHCR by digest (#1686).
   backend-release:
     name: Backend Release Image
     runs-on: ubuntu-latest

--- a/tools/ci/backend-deploy.test.mjs
+++ b/tools/ci/backend-deploy.test.mjs
@@ -142,11 +142,15 @@ test("백엔드 SSH 배포 스크립트는 상태, drift, 백업, readiness 롤�
   const composeConfig = 'compose "${BACKEND_ENV}" "${COMPOSE_ENV}" "${DEPLOY_SHA}" config --quiet';
   assert.equal(deploy.match(/git checkout --detach "\$\{DEPLOY_SHA\}"/g)?.length, 1);
   assert.ok(deploy.indexOf(checkoutTarget) < deploy.indexOf(composeConfig));
-  assert.match(deploy, /sha256sum -c/);
+  // The deployed artifact is verified by GHCR digest, not by re-hashing a jar,
+  // and there is no on-server image build (issue #1686).
+  assert.doesNotMatch(deploy, /sha256sum -c/);
+  assert.match(deploy, /docker image inspect "easysubway-backend:\$\{DEPLOY_SHA\}"/);
+  assert.match(deploy, /image_digest_mismatch/);
   assert.match(deploy, /up -d --no-build postgres object-storage/);
   assert.doesNotMatch(deploy, /timeout [0-9]+ compose/);
   assert.match(deploy, /timeout 600 docker compose/);
-  assert.match(deploy, /timeout 900 docker compose/);
+  assert.doesNotMatch(deploy, /timeout 900 docker compose/);
   assert.match(deploy, /wait_stateful_service/);
   assert.match(deploy, /report_upload_bucket="\$\(read_env_value "\$\{BACKEND_ENV\}" EASYSUBWAY_REPORT_UPLOAD_BUCKET\)"/);
   assert.match(deploy, /stop_legacy_backend_service\(\)/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -772,8 +772,17 @@ test("지속적 배포 준비 상태는 단일 dotenv secret과 배포 설정을
   assert.match(workflow, /tools\/deploy\/backend-app-env\.allowlist/);
   assert.match(workflow, /CD Deploy \/ Validate Docker Compose deployment config/);
   assert.match(workflow, /docker compose --env-file "\$\{PREPARED_ENV_DIR\}\/compose\.env" -f infra\/docker-compose\.yml config --quiet/);
-  assert.match(workflow, /CD Deploy \/ Build backend bootJar/);
-  assert.match(workflow, /sha256sum backend\.jar > backend\.jar\.sha256/);
+  // build-once, deploy-same: the arm64 image is built and pushed to GHCR by the
+  // build-image job; the deploy job pulls it by digest instead of building a jar
+  // on the runner or on the server (issue #1686).
+  assert.match(workflow, /CD Build image \/ Build and push arm64 image/);
+  assert.match(workflow, /ghcr\.io\/aquilaxk\/easysubway-backend/);
+  assert.match(workflow, /if \[\[ "\$\{arch\}" != "linux\/arm64" \]\]; then/);
+  assert.match(workflow, /CD Deploy \/ Pull backend image by digest/);
+  assert.match(workflow, /docker tag "\$\{IMAGE\}@\$\{DEPLOY_IMAGE_DIGEST\}" "easysubway-backend:\$\{DEPLOY_SHA\}"/);
+  assert.match(workflow, /DEPLOY_IMAGE_DIGEST="\$\{DEPLOY_IMAGE_DIGEST\}"/);
+  assert.doesNotMatch(workflow, /CD Deploy \/ Build backend bootJar/);
+  assert.doesNotMatch(workflow, /sha256sum backend\.jar > backend\.jar\.sha256/);
   assert.match(workflow, /CD Deploy \/ Run local deployment/);
   assert.match(workflow, /install -m 700 -d "\$\{incoming\}"/);
   assert.match(workflow, /bash "\$\{incoming\}\/deploy-backend\.sh"/);
@@ -790,6 +799,30 @@ test("지속적 배포 준비 상태는 단일 dotenv secret과 배포 설정을
   assert.match(workflow, /deploy-backend\.sh/);
   assert.doesNotMatch(workflow, /runs-on: ubuntu-latest\s*\n\s*env:\s*\n\s*EASYSUBWAY_ENV_SECRET/);
   assert.doesNotMatch(workflow, /secrets\.EASYSUBWAY_(DATASOURCE|REDIS|TRUSTED_PROXY|POSTGRES)/);
+});
+
+test("백엔드 배포는 GHCR digest를 pull하고 서버 위 build 경로를 갖지 않는다", () => {
+  const deploy = read("tools/deploy/deploy-backend.sh");
+
+  // The deploy script must require the digest and never build an image itself.
+  assert.match(deploy, /DEPLOY_IMAGE_DIGEST="\$\{DEPLOY_IMAGE_DIGEST:\?DEPLOY_IMAGE_DIGEST is required\}"/);
+  assert.match(deploy, /\^sha256:\[0-9a-f\]\{64\}\$/);
+  // No on-server image build (the `build` compose subcommand); --no-build stays.
+  assert.doesNotMatch(deploy, /docker-compose\.yml build\b/);
+  assert.doesNotMatch(deploy, /gradlew bootJar/);
+  assert.doesNotMatch(deploy, /backend\/build\/libs\/app\.jar/);
+  assert.doesNotMatch(deploy, /JAR_FILE=/);
+
+  // Identity verification: pulled image must match the expected digest + revision.
+  assert.match(deploy, /image_digest_mismatch/);
+  assert.match(deploy, /image_revision_mismatch/);
+  assert.match(deploy, /org\.opencontainers\.image\.revision/);
+
+  // Rollback no longer depends on the server-local image cache: a pruned image
+  // is restored from GHCR by digest.
+  assert.match(deploy, /ensure_rollback_image/);
+  assert.match(deploy, /docker pull "\$\{GHCR_IMAGE\}@\$\{prev_digest\}"/);
+  assert.match(deploy, /current-image-digest/);
 });
 
 test("풀 리퀘스트 템플릿은 리뷰와 배포 확인 게이트를 포함한다", () => {
@@ -1027,7 +1060,7 @@ test("GitHub Actions Slack 알림은 채널별 webhook secret으로 필터링한
   assert.equal((inlineSlackWorkflows.match(/SLACK_RELEASE_WEBHOOK_URL: \$\{\{ secrets\.SLACK_RELEASE_WEBHOOK_URL \}\}/g) ?? []).length, 4);
   assert.equal((inlineSlackWorkflows.match(/SLACK_SECURITY_WEBHOOK_URL: \$\{\{ secrets\.SLACK_SECURITY_WEBHOOK_URL \}\}/g) ?? []).length, 1);
   assert.match(ciWorkflow, /notify-slack-ci-failure:[\s\S]*needs:\s*\n\s*-\s*changes[\s\S]*github\.event_name == 'push'[\s\S]*github\.ref == 'refs\/heads\/main'[\s\S]*contains\(needs\.\*\.result, 'failure'\)/);
-  assert.match(cdWorkflow, /notify-slack-cd-result:[\s\S]*needs:\s*\n\s*-\s*plan\n\s*-\s*deploy[\s\S]*SLACK_RELEASE_WEBHOOK_URL/);
+  assert.match(cdWorkflow, /notify-slack-cd-result:[\s\S]*needs:\s*\n\s*-\s*plan\n\s*-\s*build-image\n\s*-\s*deploy[\s\S]*SLACK_RELEASE_WEBHOOK_URL/);
   assert.match(releaseArtifactsWorkflow, /notify-slack-release-result:[\s\S]*github\.event_name != 'pull_request'[\s\S]*SLACK_RELEASE_WEBHOOK_URL/);
   assert.match(dataPackReleaseWorkflow, /notify-slack-datapack-result:[\s\S]*SLACK_RELEASE_WEBHOOK_URL/);
   assert.match(storeDistributionWorkflow, /notify-slack-store-result:[\s\S]*SLACK_RELEASE_WEBHOOK_URL/);

--- a/tools/deploy/deploy-backend.sh
+++ b/tools/deploy/deploy-backend.sh
@@ -6,12 +6,20 @@ DEPLOY_REPO_URL="${DEPLOY_REPO_URL:-https://github.com/AquilaXk/easysubway.git}"
 DEPLOY_COMPOSE_PROJECT="${DEPLOY_COMPOSE_PROJECT:?DEPLOY_COMPOSE_PROJECT is required}"
 DEPLOY_SHA="${DEPLOY_SHA:?DEPLOY_SHA is required}"
 INCOMING_DIR="${INCOMING_DIR:?INCOMING_DIR is required}"
+# GHCR image digest of the arm64 image the CD build-image job pushed for this
+# SHA (issue #1686). The image is pulled and retagged as easysubway-backend:SHA
+# by the CD deploy job before this script runs; here we only verify identity.
+DEPLOY_IMAGE_DIGEST="${DEPLOY_IMAGE_DIGEST:?DEPLOY_IMAGE_DIGEST is required}"
 
 case "${DEPLOY_SHA}" in
 	*[!0-9a-f]*|"") printf 'invalid DEPLOY_SHA\n' >&2; exit 2 ;;
 esac
 if [[ ${#DEPLOY_SHA} -ne 40 ]]; then
 	printf 'invalid DEPLOY_SHA length\n' >&2
+	exit 2
+fi
+if [[ ! "${DEPLOY_IMAGE_DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+	printf 'invalid DEPLOY_IMAGE_DIGEST\n' >&2
 	exit 2
 fi
 if [[ "${DEPLOY_REPO_URL}" != "https://github.com/AquilaXk/easysubway.git" ]]; then
@@ -35,15 +43,20 @@ STATE_FILE="${SHARED_DIR}/deployment-state.env"
 RESULT_FILE="${SHARED_DIR}/last-result.env"
 LOCK_FILE="${DEPLOY_ROOT}/deploy.lock"
 
-JAR_FILE="${INCOMING_DIR}/backend.jar"
-CHECKSUM_FILE="${INCOMING_DIR}/backend.jar.sha256"
 COMPOSE_ENV="${INCOMING_DIR}/compose.env"
 BACKEND_ENV="${INCOMING_DIR}/backend.env"
 RUNTIME_SERVICES=(backend back-worker)
 OBSERVABILITY_SERVICES=(public-edge-probe docker-runtime-probe alertmanager prometheus loki grafana)
 OBSERVABILITY_CONFIG_SERVICES=(alertmanager prometheus loki grafana)
 
-for file in "${JAR_FILE}" "${CHECKSUM_FILE}" "${COMPOSE_ENV}" "${BACKEND_ENV}"; do
+# The image content sha (digest hex) replaces the former jar sha256 as the
+# deployed-artifact identity; it flows into the compose metadata label.
+image_digest_hex="${DEPLOY_IMAGE_DIGEST#sha256:}"
+# GHCR repository the CD build-image job pushes to; used as the rollback source
+# of truth when a previous image is no longer in the server-local cache.
+GHCR_IMAGE="${DEPLOY_GHCR_IMAGE:-ghcr.io/aquilaxk/easysubway-backend}"
+
+for file in "${COMPOSE_ENV}" "${BACKEND_ENV}"; do
 	[[ -f "${file}" ]] || { printf 'missing staged file: %s\n' "${file}" >&2; exit 2; }
 	chmod 600 "${file}"
 done
@@ -119,11 +132,6 @@ fi
 
 git checkout --detach "${DEPLOY_SHA}"
 git clean -ffdx
-
-pushd "${INCOMING_DIR}" >/dev/null
-sha256sum -c "$(basename "${CHECKSUM_FILE}")"
-popd >/dev/null
-jar_sha="$(cut -d ' ' -f 1 "${CHECKSUM_FILE}")"
 
 read_env_value() {
 	local file="$1"
@@ -225,7 +233,7 @@ compose() {
 	shift 3
 	EASYSUBWAY_BACKEND_ENV_FILE="${backend_env}" \
 	EASYSUBWAY_BACKEND_IMAGE_TAG="${image_tag}" \
-	EASYSUBWAY_BACKEND_JAR_SHA256="${jar_sha}" \
+	EASYSUBWAY_BACKEND_JAR_SHA256="${image_digest_hex}" \
 	EASYSUBWAY_ALERTMANAGER_CONFIG_FILE="${SHARED_DIR}/current-env/alertmanager.yml" \
 	docker compose --project-name "${DEPLOY_COMPOSE_PROJECT}" --env-file "${compose_env}" -f infra/docker-compose.yml "$@"
 }
@@ -340,7 +348,7 @@ stop_legacy_backend_service() {
 
 EASYSUBWAY_BACKEND_ENV_FILE="${BACKEND_ENV}" \
 EASYSUBWAY_BACKEND_IMAGE_TAG="${DEPLOY_SHA}" \
-EASYSUBWAY_BACKEND_JAR_SHA256="${jar_sha}" \
+EASYSUBWAY_BACKEND_JAR_SHA256="${image_digest_hex}" \
 	timeout 600 docker compose --project-name "${DEPLOY_COMPOSE_PROJECT}" --env-file "${COMPOSE_ENV}" -f infra/docker-compose.yml up -d --no-build postgres object-storage
 
 wait_stateful_service() {
@@ -438,19 +446,23 @@ if [[ "${current_sha}" == "${DEPLOY_SHA}" && "${current_env_hash}" == "${target_
 	fi
 fi
 
-mkdir -p backend/build/libs
-cp "${JAR_FILE}" backend/build/libs/app.jar
-
-needs_build=1
-if [[ "${current_sha}" == "${DEPLOY_SHA}" ]]; then
-	needs_build=0
+# build-once, deploy-same: the arm64 image was built and pushed to GHCR by the
+# CD build-image job, then pulled and retagged as easysubway-backend:SHA by the
+# CD deploy job. There is no on-server build; we only verify the pulled image is
+# exactly the digest CI produced, and that it carries the expected revision.
+if ! docker image inspect "easysubway-backend:${DEPLOY_SHA}" >/dev/null 2>&1; then
+	write_result "blocked" "image_missing"
+	exit 1
 fi
-
-if [[ "${needs_build}" -eq 1 ]]; then
-	EASYSUBWAY_BACKEND_ENV_FILE="${BACKEND_ENV}" \
-	EASYSUBWAY_BACKEND_IMAGE_TAG="${DEPLOY_SHA}" \
-	EASYSUBWAY_BACKEND_JAR_SHA256="${jar_sha}" \
-		timeout 900 docker compose --project-name "${DEPLOY_COMPOSE_PROJECT}" --env-file "${COMPOSE_ENV}" -f infra/docker-compose.yml build backend
+repo_digests="$(docker image inspect "easysubway-backend:${DEPLOY_SHA}" --format '{{join .RepoDigests "\n"}}' 2>/dev/null || true)"
+if ! grep -qF "@${DEPLOY_IMAGE_DIGEST}" <<<"${repo_digests}"; then
+	write_result "blocked" "image_digest_mismatch"
+	exit 1
+fi
+image_revision="$(docker image inspect "easysubway-backend:${DEPLOY_SHA}" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' 2>/dev/null || true)"
+if [[ "${image_revision}" != "${DEPLOY_SHA}" ]]; then
+	write_result "blocked" "image_revision_mismatch"
+	exit 1
 fi
 
 needs_backup=0
@@ -486,7 +498,7 @@ cp "${BACKEND_ENV}" "${tmp_env_set}/backend.env"
 write_alertmanager_config "${tmp_env_set}/alertmanager.yml"
 {
 	printf 'sha=%s\n' "${DEPLOY_SHA}"
-	printf 'jar_sha256=%s\n' "${jar_sha}"
+	printf 'image_digest=%s\n' "${DEPLOY_IMAGE_DIGEST}"
 	printf 'env_hash=%s\n' "${target_env_hash}"
 } > "${tmp_env_set}/metadata.env"
 chmod 600 "${tmp_env_set}/compose.env" "${tmp_env_set}/backend.env" "${tmp_env_set}/metadata.env"
@@ -500,11 +512,32 @@ fi
 ln -sfn "${env_set}" "${SHARED_DIR}/current-env.next"
 mv -Tf "${SHARED_DIR}/current-env.next" "${SHARED_DIR}/current-env"
 
+ensure_rollback_image() {
+	local sha="$1"
+	if docker image inspect "easysubway-backend:${sha}" >/dev/null 2>&1; then
+		return 0
+	fi
+	# Local image was pruned; restore it from GHCR using the digest recorded when
+	# that SHA was deployed (issue #1686 — removes server-local cache dependence).
+	local prev_digest=""
+	if [[ -f "${SHARED_DIR}/previous-env/metadata.env" ]]; then
+		prev_digest="$(sed -n 's/^image_digest=//p' "${SHARED_DIR}/previous-env/metadata.env")"
+	fi
+	if [[ ! "${prev_digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+		return 1
+	fi
+	if ! timeout 300 docker pull "${GHCR_IMAGE}@${prev_digest}" >/dev/null 2>&1; then
+		return 1
+	fi
+	docker tag "${GHCR_IMAGE}@${prev_digest}" "easysubway-backend:${sha}"
+}
+
 fail_backend_deployment() {
 	local detail="$1"
 	if [[ -n "${current_sha}" && -L "${SHARED_DIR}/previous-env" ]]; then
 		ln -sfn "$(readlink "${SHARED_DIR}/previous-env")" "${SHARED_DIR}/current-env.next"
 		mv -Tf "${SHARED_DIR}/current-env.next" "${SHARED_DIR}/current-env"
+		ensure_rollback_image "${current_sha}" || true
 		compose "${SHARED_DIR}/current-env/backend.env" "${SHARED_DIR}/current-env/compose.env" "${current_sha}" up -d --no-deps --no-build "${RUNTIME_SERVICES[@]}" || true
 		start_observability_services "${SHARED_DIR}/current-env/backend.env" "${SHARED_DIR}/current-env/compose.env" "${current_sha}" "${recreate_alertmanager}" "${recreate_observability_config}" || true
 		write_result "failed" "${detail}_rollback_attempted"
@@ -575,7 +608,7 @@ legacy_restore_on_error=0
 trap - ERR INT TERM HUP
 
 printf '%s\n' "${DEPLOY_SHA}" > "${SHARED_DIR}/current-sha"
-printf '%s\n' "${jar_sha}" > "${SHARED_DIR}/current-jar.sha256"
-chmod 600 "${SHARED_DIR}/current-sha" "${SHARED_DIR}/current-jar.sha256"
+printf '%s\n' "${DEPLOY_IMAGE_DIGEST}" > "${SHARED_DIR}/current-image-digest"
+chmod 600 "${SHARED_DIR}/current-sha" "${SHARED_DIR}/current-image-digest"
 write_phase "completed"
 write_result "success" "backend_ready"


### PR DESCRIPTION
## 관련 이슈

close #1686

## 작업 배경

- 기존 PR 본문 참조.

## 작업 내용

<details>
<summary>기존 PR 본문</summary>

## 관련 이슈

close #1686

## 작업 배경

백엔드 배포가 "빌드-한번, 배포-그대로" 원칙이 깨져 있었다: CI 검증 빌드, release-artifacts 이미지(push 없음), CD self-hosted jar 재빌드, **서버 위 `docker compose build`**(deploy-backend.sh)가 전부 서로 다른 산출물이었다. 롤백도 이전 이미지가 서버 로컬에 있어야만 동작했다. 프로덕션은 OCI A1(**aarch64**)이라 반드시 linux/arm64 이미지가 필요하다.

## 작업 내용

- `cd.yml build-image` 잡(ubuntu-24.04-arm 네이티브): bootJar→docker build→**arm64 assert**→GHCR push→digest 출력. 동일 SHA 재배포 시 기존 digest 재사용(멱등).
- `cd.yml deploy` 잡: setup-java/bootJar 제거 → GHCR 로그인·`docker pull @digest`·retag(`easysubway-backend:SHA`). `DEPLOY_IMAGE_DIGEST` 전달, `packages: read`.
- `deploy-backend.sh`: jar 스테이징·서버 build 제거 → 이미지 identity 검증(`RepoDigests` digest 포함 + `revision`==SHA). 롤백 강화: 로컬 이미지 부재 시 previous-env digest로 **GHCR pull 폴백**. `current-image-digest` 기록.
- `actions-storage-cleanup.yml`: 월간 GHCR 이미지 정리(최신 10 보존). `release-artifacts.yml` backend-release: 검증-전용 명시.
- 계약테스트: compose-build 미포함·digest 검증·GHCR 롤백, build-image·arm64 게이트.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/*.test.mjs` → **175 pass / 0 fail**, `bash -n deploy-backend.sh` OK
  - **서버 리허설(오너 OCI 접속으로 세션 실측)**: read-only(aarch64·GHCR 도달·revision 라벨) + **preflight run [28762884555](https://github.com/AquilaXk/easysubway/actions/runs/28762884555) 전 잡 success** — build-image arm64 GHCR push(`sha256:d874dbe25ecd...`)→서버 pull/retag(linux/arm64·revision 일치) 확인, 컨테이너 무교체(무중단)

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 계약테스트·스크립트 문법 | CI/local | node test·bash -n | 175 pass | ✅ |
| 서버 aarch64·GHCR·revision | OCI 서버 | ssh read-only | PR 코멘트 evidence | ✅ |
| build→GHCR push→pull→retag→identity | CD+서버 | preflight run 28762884555 | 전 잡 success·서버 실측 | ✅ |
| 실배포 후 컨테이너 digest==GHCR digest | CD+서버 | 병합 후 첫 실배포 | 병합 후 라이브 | ⏳ 핸드오프 |
| 롤백 리허설(로컬 삭제→GHCR pull 복원) | 서버 | 첫 배포 직후 dispatch | 병합 후 라이브 | ⏳ 핸드오프 |
| GHCR 패키지 private 전환 | GHCR | 패키지 설정 | preflight가 public 생성 → 오너 private 전환 | ⏳ 핸드오프 |

## Version impact

- [x] backend deploy only

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음

## 리뷰어 메모

- **병합 게이트**: preflight로 build/push/pull/retag/identity 실서버 검증 완료. 남은 컨테이너 교체+롤백은 구조상 병합 후 첫 실배포에서 검증(readiness 게이트+현재 이미지 롤백이 안전망).
- cd.yml 교차: #1687·#1688과 겹침 → 병합 순서 #1686→#1687→#1688. 상위 트래커 #1683(Phase 2 핵심). `/claude review` 폴백에서 digest 추출을 `{{.Manifest.digest}}`/RepoDigests로 견고화. SonarCloud S7631(fork 코드) 대응 예정.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 배포 과정이 컨테이너 이미지 기반으로 개선되어, 더 일관된 배포가 가능해졌습니다.
  * 배포 후 검증과 알림 흐름이 새 배포 방식에 맞게 업데이트되었습니다.

* **버그 수정**
  * 배포 아티팩트 검증 방식이 강화되어 잘못된 이미지 배포 가능성을 줄였습니다.
  * 롤백 시 필요한 이전 이미지를 더 안정적으로 복구하도록 개선했습니다.

* **유지보수**
  * 오래된 컨테이너 이미지를 자동 정리해 저장소 사용량을 줄입니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

</details>

## 검증

- 실행한 명령과 결과: 기존 PR 본문 참조.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| PR 본문 양식 보강 | GitHub PR | 현재 템플릿 섹션 존재 확인 | PR body | 완료 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [ ] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [ ] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [ ] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 기존 PR 본문 참조
- mobile versionCode: 기존 PR 본문 참조
- datapack version: 기존 PR 본문 참조
- route contract: 기존 PR 본문 참조
- realtime contract: 기존 PR 본문 참조
- backend identity: 기존 PR 본문 참조

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 기존 PR 본문 참조.

## 리스크

- 기존 PR 본문 참조.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
