### PR TITLE
[CI] CD production environment 선언 + 배포 기록·태그 자동화 (#1687)

### DIFF
--- a/.github/workflows/actions-storage-cleanup.yml
+++ b/.github/workflows/actions-storage-cleanup.yml
@@ -39,3 +39,42 @@ jobs:
         run: |
           set -euo pipefail
           gh cache delete --all --succeed-on-no-caches
+
+  cleanup-deploy-tags:
+    name: Prune old deploy tags
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Delete deploy/backend tags older than 90 days
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # deploy/backend/<UTC yyyyMMdd-HHmm>-<sha> tags accumulate one per
+          # deploy (issue #1687). Always keep the 20 most recent; among the rest,
+          # delete any dated more than 90 days ago. Names sort chronologically.
+          mapfile -t tags < <(gh api --paginate \
+            "repos/${REPO}/git/matching-refs/tags/deploy/backend/" \
+            --jq '.[].ref' 2>/dev/null | sed 's#refs/tags/##' | sort || true)
+
+          count=${#tags[@]}
+          if [ "${count}" -le 20 ]; then
+            echo "only ${count} deploy tags; nothing to prune."
+            exit 0
+          fi
+
+          cutoff="$(date -u -d '90 days ago' +%Y%m%d)"
+          prune_upto=$((count - 20))
+          for ((i = 0; i < prune_upto; i++)); do
+            tag="${tags[i]}"
+            datepart="${tag#deploy/backend/}"
+            datepart="${datepart%%-*}"
+            if [[ "${datepart}" =~ ^[0-9]{8}$ && "${datepart}" < "${cutoff}" ]]; then
+              echo "deleting ${tag}"
+              gh api -X DELETE "repos/${REPO}/git/refs/tags/${tag}" || true
+            fi
+          done

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -105,10 +105,16 @@ jobs:
     permissions:
       actions: read
       contents: read
+    environment:
+      name: production
+      url: ${{ vars.DEPLOY_PUBLIC_API_BASE_URL }}
     concurrency:
       group: cd-production-deploy
       cancel-in-progress: false
     if: ${{ needs.plan.outputs.deploy_target_relevant == 'true' }}
+    outputs:
+      sha: ${{ steps.target.outputs.sha }}
+      deploy_ready: ${{ steps.remote.outputs.deploy_ready }}
 
     steps:
       - name: CD Deploy / Checkout repository
@@ -375,6 +381,49 @@ jobs:
           fi
           rm -rf "${RUNNER_TEMP}/deploy-env"
 
+  record-deploy:
+    name: CD Record deployment
+    needs: deploy
+    runs-on: ubuntu-latest
+    # Only this job may write refs; the self-hosted deploy job stays read-only.
+    permissions:
+      contents: write
+    if: ${{ needs.deploy.result == 'success' && needs.deploy.outputs.deploy_ready == 'true' }}
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+    steps:
+      - name: CD Record deployment / Tag deployed SHA
+        id: tag
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          DEPLOY_SHA: ${{ needs.deploy.outputs.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ ! "${DEPLOY_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "record-deploy received an invalid sha" >&2
+            exit 1
+          fi
+
+          tag="deploy/backend/$(date -u +%Y%m%d-%H%M)-${DEPLOY_SHA:0:12}"
+          # Lightweight tag on the deployed commit — GitHub-side deploy history
+          # to complement the environment deployment record (issue #1687). Uses
+          # curl (not gh) to match cd.yml's existing GitHub API convention.
+          curl -fsS -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/git/refs" \
+            -d "{\"ref\":\"refs/tags/${tag}\",\"sha\":\"${DEPLOY_SHA}\"}"
+
+          echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
+          {
+            echo "### CD deployment recorded"
+            echo "- sha: \`${DEPLOY_SHA}\`"
+            echo "- tag: \`${tag}\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
   notify-slack-cd-result:
     name: Slack / CD result
     runs-on: ubuntu-latest
@@ -382,6 +431,7 @@ jobs:
     needs:
       - plan
       - deploy
+      - record-deploy
     if: >-
       ${{
         always() &&
@@ -410,5 +460,7 @@ jobs:
                     *EasySubway CD ${{ contains(needs.*.result, 'failure') && '실패' || contains(needs.*.result, 'cancelled') && '취소' || '성공' }}*
                     • repo: `${{ github.repository }}`
                     • ref: `${{ github.ref_name }}`
+                    • sha: `${{ needs.deploy.outputs.sha || 'unknown' }}`
+                    • tag: `${{ needs.record-deploy.outputs.tag || 'not_recorded' }}`
                     • actor: `${{ github.actor }}`
                     • run: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|GitHub Actions 열기>

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -792,6 +792,34 @@ test("지속적 배포 준비 상태는 단일 dotenv secret과 배포 설정을
   assert.doesNotMatch(workflow, /secrets\.EASYSUBWAY_(DATASOURCE|REDIS|TRUSTED_PROXY|POSTGRES)/);
 });
 
+test("CD 배포는 production environment를 선언하고 배포 태그는 record-deploy 잡만 기록한다", () => {
+  const cd = read(".github/workflows/cd.yml");
+  const cleanup = read(".github/workflows/actions-storage-cleanup.yml");
+
+  // production environment gives the deploy GitHub deployment history and lets a
+  // branch protection rule (deployment branches = main) apply (issue #1687).
+  assert.match(cd, /environment:\n\s*name: production\n\s*url: \$\{\{ vars\.DEPLOY_PUBLIC_API_BASE_URL \}\}/);
+  assert.match(cd, /outputs:\n\s*sha: \$\{\{ steps\.target\.outputs\.sha \}\}/);
+
+  // A lightweight deploy/backend/* tag records the deployed sha on GitHub.
+  assert.match(cd, /record-deploy:/);
+  assert.match(cd, /tag="deploy\/backend\/\$\(date -u \+%Y%m%d-%H%M\)-\$\{DEPLOY_SHA:0:12\}"/);
+  assert.match(cd, /"https:\/\/api\.github\.com\/repos\/\$\{GITHUB_REPOSITORY\}\/git\/refs"/);
+
+  // Permission containment: only record-deploy may write refs; the self-hosted
+  // deploy job stays read-only.
+  assert.equal((cd.match(/contents: write/g) ?? []).length, 1);
+  assert.match(cd, /record-deploy:[\s\S]*permissions:\n\s*contents: write/);
+
+  // Slack CD result carries the sha and tag.
+  assert.match(cd, /sha: `\$\{\{ needs\.deploy\.outputs\.sha \|\| 'unknown' \}\}`/);
+  assert.match(cd, /tag: `\$\{\{ needs\.record-deploy\.outputs\.tag \|\| 'not_recorded' \}\}`/);
+
+  // Deploy tags are pruned (keep newest 20, drop >90 days) in weekly cleanup.
+  assert.match(cleanup, /cleanup-deploy-tags:/);
+  assert.match(cleanup, /matching-refs\/tags\/deploy\/backend\//);
+});
+
 test("풀 리퀘스트 템플릿은 리뷰와 배포 확인 게이트를 포함한다", () => {
   const template = read(".github/pull_request_template.md");
 
@@ -1027,7 +1055,7 @@ test("GitHub Actions Slack 알림은 채널별 webhook secret으로 필터링한
   assert.equal((inlineSlackWorkflows.match(/SLACK_RELEASE_WEBHOOK_URL: \$\{\{ secrets\.SLACK_RELEASE_WEBHOOK_URL \}\}/g) ?? []).length, 4);
   assert.equal((inlineSlackWorkflows.match(/SLACK_SECURITY_WEBHOOK_URL: \$\{\{ secrets\.SLACK_SECURITY_WEBHOOK_URL \}\}/g) ?? []).length, 1);
   assert.match(ciWorkflow, /notify-slack-ci-failure:[\s\S]*needs:\s*\n\s*-\s*changes[\s\S]*github\.event_name == 'push'[\s\S]*github\.ref == 'refs\/heads\/main'[\s\S]*contains\(needs\.\*\.result, 'failure'\)/);
-  assert.match(cdWorkflow, /notify-slack-cd-result:[\s\S]*needs:\s*\n\s*-\s*plan\n\s*-\s*deploy[\s\S]*SLACK_RELEASE_WEBHOOK_URL/);
+  assert.match(cdWorkflow, /notify-slack-cd-result:[\s\S]*needs:\s*\n\s*-\s*plan\n\s*-\s*deploy\n\s*-\s*record-deploy[\s\S]*SLACK_RELEASE_WEBHOOK_URL/);
   assert.match(releaseArtifactsWorkflow, /notify-slack-release-result:[\s\S]*github\.event_name != 'pull_request'[\s\S]*SLACK_RELEASE_WEBHOOK_URL/);
   assert.match(dataPackReleaseWorkflow, /notify-slack-datapack-result:[\s\S]*SLACK_RELEASE_WEBHOOK_URL/);
   assert.match(storeDistributionWorkflow, /notify-slack-store-result:[\s\S]*SLACK_RELEASE_WEBHOOK_URL/);


### PR DESCRIPTION
## 관련 이슈

close #1687

## 작업 배경

- 기존 PR 본문 참조.

## 작업 내용

<details>
<summary>기존 PR 본문</summary>

## 관련 이슈

close #1687

## 작업 배경

데이터팩 릴리즈는 GitHub environment로 승인·이력을 남기는데 백엔드 프로덕션 배포(cd.yml `deploy`)는 environment 선언이 없어 배포 이력이 GitHub에 남지 않았고, 릴리즈 태그·기록도 전무했다. 이 레포는 evidence 기반 출시 판정인데 백엔드 배포만 증거 사슬에서 빠져 있었다.

## 작업 내용

- `cd.yml deploy` 잡: `environment: production`(url=`vars.DEPLOY_PUBLIC_API_BASE_URL`) 선언 → deployments 이력 + branch protection(main only) 적용 가능. `outputs`로 `sha`·`deploy_ready` 노출.
- `record-deploy` 잡(ubuntu-latest, **`contents: write` 단독**): 배포 성공+deploy_ready 시 `deploy/backend/<UTC yyyyMMdd-HHmm>-<short sha>` 경량 태그를 배포 sha에 부착(curl로 `git/refs` POST — cd.yml gh 미사용 규약 준수). self-hosted 배포 잡은 read-only 유지.
- Slack CD 결과에 sha·태그 추가.
- `actions-storage-cleanup.yml`: 주간 `deploy/backend/*` 태그 정리(최신 20 보존, 90일 초과 삭제).
- 계약테스트: deploy `environment.name=production`, `contents: write`는 record-deploy만, Slack sha·태그, 태그 정리 잡.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/*.test.mjs` → **175 pass / 0 fail**

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| environment·태그·권한 계약 | CI | `node --test tools/ci/*.test.mjs` | 로컬 175 pass | ✅ |
| production environment 생성(branch=main) | 운영 | repo Settings→Environments | 오너 라이브 | ⏳ 핸드오프 |
| 실배포 후 environment 이력·`deploy/backend/*` 태그 | CD | 실배포 run·`git ls-remote --tags` | 오너 라이브 | ⏳ 핸드오프 |

## Version impact

- [x] backend deploy only

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음

## 리뷰어 메모

- 설계 결정: preflight(수동 dispatch)도 environment 배포 이력을 남기는 점은 수용(빈도 낮음, 태그는 미생성). digest 배포 요약 편입은 #1686 병합 후.
- cd.yml 교차: #1686·#1688과 deploy 잡/needs 겹침 → 병합 순서 #1686→#1687→#1688, 뒤 PR rebase. 상위 트래커 #1683(Phase 2). `/claude review` 폴백 발견 없음.

</details>

## 검증

- 실행한 명령과 결과: 기존 PR 본문 참조.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| PR 본문 양식 보강 | GitHub PR | 현재 템플릿 섹션 존재 확인 | PR body | 완료 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [ ] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [ ] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [ ] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 기존 PR 본문 참조
- mobile versionCode: 기존 PR 본문 참조
- datapack version: 기존 PR 본문 참조
- route contract: 기존 PR 본문 참조
- realtime contract: 기존 PR 본문 참조
- backend identity: 기존 PR 본문 참조

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 기존 PR 본문 참조.

## 리스크

- 기존 PR 본문 참조.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
