### PR TITLE
[Build] Google Play internal track 자동 업로드 파이프라인 구축 (#1689)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,12 @@ jobs:
           NODE_OPTIONS: --disable-warning=ExperimentalWarning
         run: node --test tools/ops/*.test.mjs
 
+      - name: Repository CI / Run release tool tests
+        if: ${{ needs.changes.outputs.repository == 'true' || needs.changes.outputs.ci == 'true' }}
+        env:
+          NODE_OPTIONS: --disable-warning=ExperimentalWarning
+        run: node --test tools/release/*.test.mjs
+
       - name: Repository CI / Validate Docker Compose config
         if: ${{ needs.changes.outputs.repository == 'true' || needs.changes.outputs.docs_only == 'true' || needs.changes.outputs.ci == 'true' }}
         run: docker compose --env-file .env.example -f infra/docker-compose.yml config --quiet

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -454,6 +454,11 @@ jobs:
     needs: android-production-rc-release
     permissions:
       contents: read
+    # Google Play allows only one active edit per app; serialize uploads and
+    # never cancel an in-flight one so a running commit is not interrupted.
+    concurrency:
+      group: play-internal-upload
+      cancel-in-progress: false
     # Shares the android-production-rc environment approval gate. Opt-in only:
     # play_upload=internal keeps the default build-only flow unchanged (#1689).
     if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && inputs.android_rc_signing_mode == 'production-upload-key' && inputs.play_upload == 'internal' && needs.android-production-rc-release.result == 'success' }}

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -17,6 +17,14 @@ on:
         options:
           - ci-self-signed
           - production-upload-key
+      play_upload:
+        description: Upload the production RC to a Play track
+        type: choice
+        required: false
+        default: none
+        options:
+          - none
+          - internal
 
 concurrency:
   group: release-artifacts-${{ github.workflow }}-${{ github.ref }}
@@ -440,6 +448,89 @@ jobs:
         run: |
           rm -f "${RUNNER_TEMP}/easysubway-ci-release.jks" "${RUNNER_TEMP}/easysubway-upload-key.jks" "${RUNNER_TEMP}/easysubway-release.env"
 
+  play-internal-upload:
+    name: Play internal track upload
+    runs-on: ubuntu-latest
+    needs: android-production-rc-release
+    permissions:
+      contents: read
+    # Shares the android-production-rc environment approval gate. Opt-in only:
+    # play_upload=internal keeps the default build-only flow unchanged (#1689).
+    if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && inputs.android_rc_signing_mode == 'production-upload-key' && inputs.play_upload == 'internal' && needs.android-production-rc-release.result == 'success' }}
+    environment:
+      name: android-production-rc
+    steps:
+      - name: Play internal upload / Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Play internal upload / Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24"
+
+      - name: Play internal upload / Download production RC artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: easysubway-android-production-rc-${{ github.sha }}
+          path: release-artifacts/downloaded/android-production-rc
+
+      - name: Play internal upload / Restore release environment
+        shell: bash
+        env:
+          EASYSUBWAY_ENV_SECRET: ${{ secrets.EASYSUBWAY_ENV }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${EASYSUBWAY_ENV_SECRET}" ]]; then
+            printf 'EASYSUBWAY_ENV secret is required for Play internal uploads.\n' >&2
+            exit 1
+          fi
+          umask 077
+          printf '%s' "${EASYSUBWAY_ENV_SECRET}" > "${RUNNER_TEMP}/easysubway-release.env"
+
+      - name: Play internal upload / Upload AAB to internal track
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          aab="release-artifacts/downloaded/android-production-rc/app-release.aab"
+          mapping="release-artifacts/downloaded/android-production-rc/mapping.txt"
+
+          version_code="$(sed -nE 's/^version:[^+]*\+([0-9]+).*/\1/p' apps/mobile/pubspec.yaml | head -n1)"
+          if [[ -z "${version_code}" ]]; then
+            echo "could not resolve versionCode from apps/mobile/pubspec.yaml" >&2
+            exit 1
+          fi
+
+          mapping_args=()
+          if [[ -f "${mapping}" ]] && ! grep -q '^mapping=not-generated$' "${mapping}"; then
+            mapping_args=(--mapping "${mapping}")
+          fi
+
+          node tools/release/upload-play-internal.mjs \
+            --env-file "${RUNNER_TEMP}/easysubway-release.env" \
+            --aab "${aab}" \
+            --version-code "${version_code}" \
+            --track internal \
+            --report release-artifacts/play-internal-upload-evidence.json \
+            ${mapping_args[@]+"${mapping_args[@]}"}
+
+      - name: Play internal upload / Upload evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: easysubway-play-internal-upload-${{ github.sha }}
+          path: release-artifacts/play-internal-upload-evidence.json
+          if-no-files-found: ignore
+          retention-days: 90
+
+      - name: Play internal upload / Cleanup sensitive files
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          rm -f "${RUNNER_TEMP}/easysubway-release.env"
+
   backend-release:
     name: Backend Release Image
     runs-on: ubuntu-latest
@@ -595,6 +686,7 @@ jobs:
       - changes
       - android-release
       - android-production-rc-release
+      - play-internal-upload
       - backend-release
       - rc-evidence-manifest
     if: >-

--- a/tools/ci/check-google-play-api-access.mjs
+++ b/tools/ci/check-google-play-api-access.mjs
@@ -1,11 +1,16 @@
 #!/usr/bin/env node
 import { appendFile, readFile, writeFile } from "node:fs/promises";
-import { createSign } from "node:crypto";
 import { pathToFileURL } from "node:url";
-
-const androidPublisherScope = "https://www.googleapis.com/auth/androidpublisher";
-const defaultTokenUri = "https://oauth2.googleapis.com/token";
-const defaultApiBaseUrl = "https://androidpublisher.googleapis.com/androidpublisher/v3";
+import {
+  defaultApiBaseUrl,
+  detectServiceAccountSource,
+  encodePath,
+  fetchAccessToken,
+  parseDotenv,
+  readServiceAccount,
+  requestJson,
+  requireJsonString,
+} from "./lib/google-play-auth.mjs";
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
@@ -116,142 +121,8 @@ export async function runGooglePlayApiAccess({
   }
 }
 
-async function fetchAccessToken(serviceAccount, fetchImpl) {
-  const tokenUri = serviceAccount.token_uri || defaultTokenUri;
-  const nowSeconds = Math.floor(Date.now() / 1000);
-  const header = base64UrlJson({ alg: "RS256", typ: "JWT" });
-  const claim = base64UrlJson({
-    iss: requireJsonString(serviceAccount, "client_email"),
-    scope: androidPublisherScope,
-    aud: tokenUri,
-    iat: nowSeconds,
-    exp: nowSeconds + 3600,
-  });
-  const unsignedToken = `${header}.${claim}`;
-  const signature = createSign("RSA-SHA256").update(unsignedToken).sign(requireJsonString(serviceAccount, "private_key"));
-  const assertion = `${unsignedToken}.${signature.toString("base64url")}`;
-  const response = await fetchImpl(tokenUri, {
-    method: "POST",
-    headers: { "content-type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
-      assertion,
-    }),
-  });
-  const body = await response.json().catch(() => ({}));
-  if (!response.ok || typeof body.access_token !== "string") {
-    throw new Error(`google play oauth failed: ${response.status}`);
-  }
-  return body.access_token;
-}
-
-async function requestJson(url, { method, token, body }, fetchImpl) {
-  const response = await fetchImpl(url, {
-    method,
-    headers: {
-      authorization: `Bearer ${token}`,
-      ...(body === undefined ? {} : { "content-type": "application/json" }),
-    },
-    body: body === undefined ? undefined : JSON.stringify(body),
-  });
-  if (response.status === 204) {
-    return {};
-  }
-  const text = await response.text();
-  const parsed = text.length === 0 ? {} : JSON.parse(text);
-  if (!response.ok) {
-    throw new Error(`google play api ${method} failed: ${response.status} ${apiErrorSummary(parsed)}`);
-  }
-  return parsed;
-}
-
-function apiErrorSummary(parsed) {
-  const error = parsed.error;
-  if (!error || typeof error !== "object") {
-    return "status=unknown";
-  }
-  const status = typeof error.status === "string" ? error.status : "unknown";
-  const message = typeof error.message === "string" ? error.message.replace(/\s+/g, " ").slice(0, 180) : "none";
-  return `status=${status} message=${message}`;
-}
-
 function redactReportValue(value) {
   return value.replace(/\s+/g, " ").slice(0, 220);
-}
-
-function detectServiceAccountSource(env) {
-  if (hasValue(env, "EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_JSON")) {
-    return "json";
-  }
-  if (hasValue(env, "EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_BASE64")) {
-    return "base64";
-  }
-  return "missing";
-}
-
-function readServiceAccount(env) {
-  try {
-    if (hasValue(env, "EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_JSON")) {
-      return JSON.parse(env.EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_JSON);
-    }
-    if (hasValue(env, "EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_BASE64")) {
-      return JSON.parse(Buffer.from(env.EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_BASE64.trim(), "base64").toString("utf8"));
-    }
-  } catch {
-    throw new Error("invalid google play service account json");
-  }
-  throw new Error("missing google play service account json");
-}
-
-function parseDotenv(source) {
-  const values = {};
-  for (const line of source.split(/\r?\n/)) {
-    if (!line || line.trimStart().startsWith("#")) {
-      continue;
-    }
-    const match = line.match(/^([A-Z0-9_]+)=(.*)$/);
-    if (match) {
-      values[match[1]] = unquote(match[2]);
-    }
-  }
-  return values;
-}
-
-function unquote(value) {
-  const trimmed = value.trim();
-  if (
-    (trimmed.startsWith("\"") && trimmed.endsWith("\""))
-    || (trimmed.startsWith("'") && trimmed.endsWith("'"))
-  ) {
-    return trimmed.slice(1, -1);
-  }
-  return value;
-}
-
-function hasValue(env, name) {
-  return typeof env[name] === "string" && env[name].trim().length > 0;
-}
-
-function requireEnv(env, name) {
-  if (!hasValue(env, name)) {
-    throw new Error(`missing required env: ${name}`);
-  }
-  return env[name].trim();
-}
-
-function requireJsonString(value, field) {
-  if (typeof value[field] !== "string" || value[field].trim().length === 0) {
-    throw new Error(`missing service account field: ${field}`);
-  }
-  return value[field];
-}
-
-function base64UrlJson(value) {
-  return Buffer.from(JSON.stringify(value)).toString("base64url");
-}
-
-function encodePath(value) {
-  return encodeURIComponent(value).replaceAll("%2E", ".");
 }
 
 function maxVersionCode(tracks) {

--- a/tools/ci/lib/google-play-auth.mjs
+++ b/tools/ci/lib/google-play-auth.mjs
@@ -1,0 +1,158 @@
+// Shared Google Play (Android Publisher API v3) service-account auth and request
+// helpers. Extracted from check-google-play-api-access.mjs so the internal-track
+// upload tool can reuse the exact JWT flow instead of a third-party action
+// (issue #1689 — keeps the supply-chain surface minimal).
+import { createSign } from "node:crypto";
+
+export const androidPublisherScope = "https://www.googleapis.com/auth/androidpublisher";
+export const defaultTokenUri = "https://oauth2.googleapis.com/token";
+export const defaultApiBaseUrl = "https://androidpublisher.googleapis.com/androidpublisher/v3";
+
+export async function fetchAccessToken(serviceAccount, fetchImpl = fetch) {
+  const tokenUri = serviceAccount.token_uri || defaultTokenUri;
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const header = base64UrlJson({ alg: "RS256", typ: "JWT" });
+  const claim = base64UrlJson({
+    iss: requireJsonString(serviceAccount, "client_email"),
+    scope: androidPublisherScope,
+    aud: tokenUri,
+    iat: nowSeconds,
+    exp: nowSeconds + 3600,
+  });
+  const unsignedToken = `${header}.${claim}`;
+  const signature = createSign("RSA-SHA256").update(unsignedToken).sign(requireJsonString(serviceAccount, "private_key"));
+  const assertion = `${unsignedToken}.${signature.toString("base64url")}`;
+  const response = await fetchImpl(tokenUri, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      assertion,
+    }),
+  });
+  const body = await response.json().catch(() => ({}));
+  if (!response.ok || typeof body.access_token !== "string") {
+    throw new Error(`google play oauth failed: ${response.status}`);
+  }
+  return body.access_token;
+}
+
+export async function requestJson(url, { method, token, body }, fetchImpl = fetch) {
+  const response = await fetchImpl(url, {
+    method,
+    headers: {
+      authorization: `Bearer ${token}`,
+      ...(body === undefined ? {} : { "content-type": "application/json" }),
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  if (response.status === 204) {
+    return {};
+  }
+  const text = await response.text();
+  const parsed = text.length === 0 ? {} : JSON.parse(text);
+  if (!response.ok) {
+    throw new Error(`google play api ${method} failed: ${response.status} ${apiErrorSummary(parsed)}`);
+  }
+  return parsed;
+}
+
+// Uploads a binary body (AAB / mapping) to an Android Publisher upload endpoint.
+export async function uploadMedia(url, { token, contentType, data }, fetchImpl = fetch) {
+  const response = await fetchImpl(url, {
+    method: "POST",
+    headers: { authorization: `Bearer ${token}`, "content-type": contentType },
+    body: data,
+  });
+  const text = await response.text();
+  const parsed = text.length === 0 ? {} : JSON.parse(text);
+  if (!response.ok) {
+    throw new Error(`google play upload failed: ${response.status} ${apiErrorSummary(parsed)}`);
+  }
+  return parsed;
+}
+
+export function apiErrorSummary(parsed) {
+  const error = parsed.error;
+  if (!error || typeof error !== "object") {
+    return "status=unknown";
+  }
+  const status = typeof error.status === "string" ? error.status : "unknown";
+  const message = typeof error.message === "string" ? error.message.replace(/\s+/g, " ").slice(0, 180) : "none";
+  return `status=${status} message=${message}`;
+}
+
+export function detectServiceAccountSource(env) {
+  if (hasValue(env, "EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_JSON")) {
+    return "json";
+  }
+  if (hasValue(env, "EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_BASE64")) {
+    return "base64";
+  }
+  return "missing";
+}
+
+export function readServiceAccount(env) {
+  try {
+    if (hasValue(env, "EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_JSON")) {
+      return JSON.parse(env.EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_JSON);
+    }
+    if (hasValue(env, "EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_BASE64")) {
+      return JSON.parse(Buffer.from(env.EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_BASE64.trim(), "base64").toString("utf8"));
+    }
+  } catch {
+    throw new Error("invalid google play service account json");
+  }
+  throw new Error("missing google play service account json");
+}
+
+export function parseDotenv(source) {
+  const values = {};
+  for (const line of source.split(/\r?\n/)) {
+    if (!line || line.trimStart().startsWith("#")) {
+      continue;
+    }
+    const match = line.match(/^([A-Z0-9_]+)=(.*)$/);
+    if (match) {
+      values[match[1]] = unquote(match[2]);
+    }
+  }
+  return values;
+}
+
+export function unquote(value) {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith("\"") && trimmed.endsWith("\""))
+    || (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return value;
+}
+
+export function hasValue(env, name) {
+  return typeof env[name] === "string" && env[name].trim().length > 0;
+}
+
+export function requireEnv(env, name) {
+  if (!hasValue(env, name)) {
+    throw new Error(`missing required env: ${name}`);
+  }
+  return env[name].trim();
+}
+
+export function requireJsonString(value, field) {
+  if (typeof value[field] !== "string" || value[field].trim().length === 0) {
+    throw new Error(`missing service account field: ${field}`);
+  }
+  return value[field];
+}
+
+export function base64UrlJson(value) {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+export function encodePath(value) {
+  return encodeURIComponent(value).replaceAll("%2E", ".");
+}

--- a/tools/ci/lib/google-play-auth.mjs
+++ b/tools/ci/lib/google-play-auth.mjs
@@ -8,6 +8,22 @@ export const androidPublisherScope = "https://www.googleapis.com/auth/androidpub
 export const defaultTokenUri = "https://oauth2.googleapis.com/token";
 export const defaultApiBaseUrl = "https://androidpublisher.googleapis.com/androidpublisher/v3";
 
+// Validate a request URL before it reaches fetch: only absolute HTTPS URLs are
+// allowed, so a bad token_uri / base-url cannot be used to reach an arbitrary
+// (e.g. http or internal) endpoint.
+export function assertRequestUrl(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error("invalid google play request url");
+  }
+  if (parsed.protocol !== "https:") {
+    throw new Error("google play request url must be https");
+  }
+  return parsed.toString();
+}
+
 export async function fetchAccessToken(serviceAccount, fetchImpl = fetch) {
   const tokenUri = serviceAccount.token_uri || defaultTokenUri;
   const nowSeconds = Math.floor(Date.now() / 1000);
@@ -22,7 +38,7 @@ export async function fetchAccessToken(serviceAccount, fetchImpl = fetch) {
   const unsignedToken = `${header}.${claim}`;
   const signature = createSign("RSA-SHA256").update(unsignedToken).sign(requireJsonString(serviceAccount, "private_key"));
   const assertion = `${unsignedToken}.${signature.toString("base64url")}`;
-  const response = await fetchImpl(tokenUri, {
+  const response = await fetchImpl(assertRequestUrl(tokenUri), {
     method: "POST",
     headers: { "content-type": "application/x-www-form-urlencoded" },
     body: new URLSearchParams({
@@ -38,7 +54,7 @@ export async function fetchAccessToken(serviceAccount, fetchImpl = fetch) {
 }
 
 export async function requestJson(url, { method, token, body }, fetchImpl = fetch) {
-  const response = await fetchImpl(url, {
+  const response = await fetchImpl(assertRequestUrl(url), {
     method,
     headers: {
       authorization: `Bearer ${token}`,
@@ -59,7 +75,7 @@ export async function requestJson(url, { method, token, body }, fetchImpl = fetc
 
 // Uploads a binary body (AAB / mapping) to an Android Publisher upload endpoint.
 export async function uploadMedia(url, { token, contentType, data }, fetchImpl = fetch) {
-  const response = await fetchImpl(url, {
+  const response = await fetchImpl(assertRequestUrl(url), {
     method: "POST",
     headers: { authorization: `Bearer ${token}`, "content-type": contentType },
     body: data,

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -4061,12 +4061,42 @@ test("스토어 배포 증거 workflow는 단일 dotenv secret과 명시적 cred
   assert.match(preflight, /EASYSUBWAY_OBJECT_STORAGE_PREAUTH_BASE_URL/);
   assert.doesNotMatch(preflight, /console\.log\(.*env\[/, "preflight must not print secret values");
 
-  assert.match(playApiAccess, /https:\/\/www\.googleapis\.com\/auth\/androidpublisher/);
+  // The OAuth scope and JWT auth now live in the shared lib that both the access
+  // checker and the internal-track uploader import (issue #1689).
+  const playAuthLib = read("tools/ci/lib/google-play-auth.mjs");
+  assert.match(playAuthLib, /https:\/\/www\.googleapis\.com\/auth\/androidpublisher/);
+  assert.match(playApiAccess, /from "\.\/lib\/google-play-auth\.mjs"/);
   assert.match(playApiAccess, /\/applications\/\$\{encodePath\(packageName\)\}\/edits/);
   assert.match(playApiAccess, /\/tracks/);
   assert.match(playApiAccess, /:validate/);
   assert.match(playApiAccess, /method: "DELETE"/);
   assert.doesNotMatch(playApiAccess, /client_email=.*\$\{/, "API access report must not print service account email");
+});
+
+test("Play internal track 업로드는 versionCode 정책·mapping·evidence를 갖춘 자체 도구로 수행한다", () => {
+  const tool = read("tools/release/upload-play-internal.mjs");
+  const workflow = read(".github/workflows/release-artifacts.yml");
+
+  // Self-contained tool reusing the shared auth lib (no third-party action).
+  assert.match(tool, /from "\.\.\/ci\/lib\/google-play-auth\.mjs"/);
+  // versionCode monotonic policy enforced before any binary upload.
+  assert.match(tool, /is not greater than current Play max/);
+  const gateIndex = tool.indexOf("is not greater than current Play max");
+  const uploadIndex = tool.indexOf("/bundles?uploadType=media");
+  assert.ok(gateIndex !== -1 && uploadIndex !== -1 && gateIndex < uploadIndex, "monotonic gate must precede bundle upload");
+  // Bundle, deobfuscation mapping, track completion, commit.
+  assert.match(tool, /\/bundles\?uploadType=media/);
+  assert.match(tool, /\/deobfuscationFiles\/\$\{encodePath\(String\(versionCode\)\)\}\/proguard/);
+  assert.match(tool, /status: "completed", versionCodes: \[String\(versionCode\)\]/);
+  assert.match(tool, /:commit\?changesNotSentForReview=/);
+
+  // Opt-in workflow job that shares the RC environment approval and default off.
+  assert.match(workflow, /play_upload:\n\s*description:[\s\S]*options:\n\s*- none\n\s*- internal/);
+  assert.match(workflow, /play-internal-upload:/);
+  assert.match(workflow, /inputs\.play_upload == 'internal'/);
+  assert.match(workflow, /environment:\n\s*name: android-production-rc/);
+  assert.match(workflow, /node tools\/release\/upload-play-internal\.mjs/);
+  assert.match(workflow, /name: easysubway-play-internal-upload-\$\{\{ github\.sha \}\}/);
 });
 
 test("스토어 배포 증거 preflight는 iOS 누락을 Android 출시 blocker로 보지 않는다", async () => {

--- a/tools/release/upload-play-internal.mjs
+++ b/tools/release/upload-play-internal.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+// Upload a production-signed AAB (+ deobfuscation mapping) to the Google Play
+// internal track via the Android Publisher API v3 (issue #1689). Self-contained
+// Node — no third-party upload action — reusing the service-account JWT flow in
+// tools/ci/lib/google-play-auth.mjs.
+//
+// The versionCode monotonic policy is enforced BEFORE any upload: if the AAB's
+// versionCode is not strictly greater than the highest versionCode already on
+// any track, the run fails without touching Play (versionCodeMonotonicPolicy).
+import { readFile as readFileFs, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { pathToFileURL } from "node:url";
+import {
+  defaultApiBaseUrl,
+  encodePath,
+  fetchAccessToken,
+  parseDotenv,
+  readServiceAccount,
+  requestJson,
+  requireEnv,
+  requireJsonString,
+  uploadMedia,
+} from "../ci/lib/google-play-auth.mjs";
+
+const defaultUploadBaseUrl = "https://androidpublisher.googleapis.com/upload/androidpublisher/v3";
+
+function maxTrackVersionCode(tracks) {
+  const list = Array.isArray(tracks) ? tracks : [];
+  let max;
+  for (const track of list) {
+    for (const release of track.releases ?? []) {
+      for (const code of release.versionCodes ?? []) {
+        if (!/^(0|[1-9]\d*)$/.test(String(code))) continue;
+        const parsed = BigInt(code);
+        if (max === undefined || parsed > max) max = parsed;
+      }
+    }
+  }
+  return max;
+}
+
+function sha256OfBuffer(buffer) {
+  return createHash("sha256").update(buffer).digest("hex");
+}
+
+export async function runUploadPlayInternal({
+  envFile,
+  aabPath,
+  mappingPath,
+  versionCode,
+  track = "internal",
+  reportPath,
+  packageNameOverride,
+  apiBaseUrl = defaultApiBaseUrl,
+  uploadBaseUrl = defaultUploadBaseUrl,
+  changesNotSentForReview = false,
+  fetchImpl = fetch,
+  readFileImpl = readFileFs,
+}) {
+  const api = apiBaseUrl.replace(/\/$/, "");
+  const upload = uploadBaseUrl.replace(/\/$/, "");
+
+  if (!/^[1-9]\d*$/.test(String(versionCode))) {
+    throw new Error("versionCode must be a positive integer");
+  }
+  const targetVersionCode = BigInt(versionCode);
+
+  const env = parseDotenv(await readFileImpl(envFile, "utf8"));
+  const packageName = packageNameOverride?.trim()
+    || env.EASYSUBWAY_GOOGLE_PLAY_PACKAGE_NAME?.trim()
+    || "com.easysubway.app";
+  const serviceAccount = readServiceAccount(env);
+  const token = await fetchAccessToken(serviceAccount, fetchImpl);
+
+  const aab = await readFileImpl(aabPath);
+  const aabSha256 = sha256OfBuffer(aab);
+  let mapping;
+  let mappingSha256;
+  if (mappingPath) {
+    mapping = await readFileImpl(mappingPath);
+    mappingSha256 = sha256OfBuffer(mapping);
+  }
+
+  const editsBase = `${api}/applications/${encodePath(packageName)}/edits`;
+  const edit = await requestJson(editsBase, { method: "POST", token, body: {} }, fetchImpl);
+  const editId = requireJsonString(edit, "id");
+
+  // versionCode monotonic policy — reject before any upload.
+  const tracks = await requestJson(`${editsBase}/${encodePath(editId)}/tracks`, { method: "GET", token }, fetchImpl);
+  const currentMax = maxTrackVersionCode(tracks.tracks);
+  if (currentMax !== undefined && targetVersionCode <= currentMax) {
+    throw new Error(
+      `versionCode ${targetVersionCode} is not greater than current Play max ${currentMax}`,
+    );
+  }
+
+  const uploadEditsBase = `${upload}/applications/${encodePath(packageName)}/edits`;
+  const bundle = await uploadMedia(
+    `${uploadEditsBase}/${encodePath(editId)}/bundles?uploadType=media`,
+    { token, contentType: "application/octet-stream", data: aab },
+    fetchImpl,
+  );
+  const uploadedVersionCode = bundle.versionCode;
+  if (String(uploadedVersionCode) !== String(versionCode)) {
+    throw new Error(
+      `uploaded bundle versionCode ${uploadedVersionCode} does not match expected ${versionCode}`,
+    );
+  }
+
+  if (mapping) {
+    await uploadMedia(
+      `${uploadEditsBase}/${encodePath(editId)}/deobfuscationFiles/${encodePath(String(versionCode))}/proguard?uploadType=media`,
+      { token, contentType: "application/octet-stream", data: mapping },
+      fetchImpl,
+    );
+  }
+
+  await requestJson(
+    `${editsBase}/${encodePath(editId)}/tracks/${encodePath(track)}`,
+    {
+      method: "PUT",
+      token,
+      body: { track, releases: [{ status: "completed", versionCodes: [String(versionCode)] }] },
+    },
+    fetchImpl,
+  );
+
+  await requestJson(
+    `${editsBase}/${encodePath(editId)}:commit?changesNotSentForReview=${changesNotSentForReview ? "true" : "false"}`,
+    { method: "POST", token },
+    fetchImpl,
+  );
+
+  const evidence = {
+    schemaVersion: 1,
+    gate: "play-internal-upload",
+    issue: 1689,
+    packageName,
+    track,
+    editId,
+    versionCode: String(versionCode),
+    aabSha256,
+    mappingSha256: mappingSha256 ?? null,
+    changesNotSentForReview,
+    uploadedAt: new Date().toISOString(),
+  };
+  if (reportPath) {
+    await writeFile(reportPath, `${JSON.stringify(evidence, null, 2)}\n`);
+  }
+  return evidence;
+}
+
+function parseArgs(argv) {
+  const args = new Map();
+  const flags = new Set();
+  for (let index = 0; index < argv.length; index += 1) {
+    const key = argv[index];
+    if (!key?.startsWith("--")) throw new Error(`invalid argument near ${key ?? "<end>"}`);
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith("--")) {
+      flags.add(key.slice(2));
+    } else {
+      args.set(key.slice(2), value);
+      index += 1;
+    }
+  }
+  return { args, flags };
+}
+
+function requireArg(args, name) {
+  const value = args.get(name);
+  if (!value) throw new Error(`missing required argument: --${name}`);
+  return value;
+}
+
+async function main() {
+  const { args, flags } = parseArgs(process.argv.slice(2));
+  const evidence = await runUploadPlayInternal({
+    envFile: requireArg(args, "env-file"),
+    aabPath: requireArg(args, "aab"),
+    mappingPath: args.get("mapping"),
+    versionCode: requireArg(args, "version-code"),
+    track: args.get("track") ?? "internal",
+    reportPath: args.get("report"),
+    packageNameOverride: args.get("package-name"),
+    apiBaseUrl: args.get("api-base-url") ?? defaultApiBaseUrl,
+    uploadBaseUrl: args.get("upload-base-url") ?? defaultUploadBaseUrl,
+    changesNotSentForReview: flags.has("changes-not-sent-for-review"),
+  });
+  process.stdout.write(`play internal upload complete: versionCode ${evidence.versionCode} track ${evidence.track}\n`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/tools/release/upload-play-internal.mjs
+++ b/tools/release/upload-play-internal.mjs
@@ -17,7 +17,6 @@ import {
   parseDotenv,
   readServiceAccount,
   requestJson,
-  requireEnv,
   requireJsonString,
   uploadMedia,
 } from "../ci/lib/google-play-auth.mjs";

--- a/tools/release/upload-play-internal.test.mjs
+++ b/tools/release/upload-play-internal.test.mjs
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { generateKeyPairSync } from "node:crypto";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { runUploadPlayInternal } from "./upload-play-internal.mjs";
+
+const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+
+function serviceAccountEnv() {
+  const serviceAccount = {
+    client_email: "uploader@easysubway.iam.gserviceaccount.com",
+    private_key: privateKey.export({ type: "pkcs8", format: "pem" }),
+    token_uri: "https://oauth2.example/token",
+  };
+  return `EASYSUBWAY_GOOGLE_PLAY_PACKAGE_NAME=com.easysubway.app\nEASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_JSON=${JSON.stringify(serviceAccount)}\n`;
+}
+
+function jsonResponse(status, body) {
+  const text = JSON.stringify(body);
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => text,
+  };
+}
+
+// Builds a mock Android Publisher API. `tracks` is the existing track list, and
+// `overrides` can force specific endpoints (e.g. an auth failure).
+function mockPlay({ tracks = [], uploadedVersionCode = "10005", overrides = {} } = {}) {
+  const requests = [];
+  const fetchImpl = async (url, options = {}) => {
+    const method = options.method ?? "GET";
+    requests.push({ url, method });
+    if (overrides.token && url.includes("/token")) return overrides.token;
+    if (url.includes("/token")) return jsonResponse(200, { access_token: "token-123" });
+    if (url.endsWith("/edits") && method === "POST") return jsonResponse(200, { id: "edit-1" });
+    if (url.endsWith("/tracks") && method === "GET") return jsonResponse(200, { tracks });
+    if (url.includes("/bundles?uploadType=media")) return jsonResponse(200, { versionCode: uploadedVersionCode });
+    if (url.includes("/deobfuscationFiles/")) return jsonResponse(200, {});
+    if (url.includes("/tracks/") && method === "PUT") return jsonResponse(200, { track: "internal" });
+    if (url.includes(":commit")) return jsonResponse(200, {});
+    return jsonResponse(404, { error: { status: "NOT_FOUND", message: url } });
+  };
+  return { fetchImpl, requests };
+}
+
+async function withFiles(fn) {
+  const dir = await mkdtemp(path.join(tmpdir(), "play-upload-"));
+  const envFile = path.join(dir, "env");
+  const aabPath = path.join(dir, "app.aab");
+  const mappingPath = path.join(dir, "mapping.txt");
+  const reportPath = path.join(dir, "evidence.json");
+  await writeFile(envFile, serviceAccountEnv());
+  await writeFile(aabPath, "fake-aab-bytes");
+  await writeFile(mappingPath, "fake-mapping");
+  return fn({ envFile, aabPath, mappingPath, reportPath });
+}
+
+test("uploads an AAB and mapping to the internal track and emits evidence", async () => {
+  await withFiles(async ({ envFile, aabPath, mappingPath, reportPath }) => {
+    const { fetchImpl, requests } = mockPlay({ tracks: [], uploadedVersionCode: "10005" });
+    const evidence = await runUploadPlayInternal({
+      envFile,
+      aabPath,
+      mappingPath,
+      versionCode: "10005",
+      reportPath,
+      apiBaseUrl: "https://api.example/v3",
+      uploadBaseUrl: "https://upload.example/v3",
+      fetchImpl,
+    });
+
+    assert.equal(evidence.versionCode, "10005");
+    assert.equal(evidence.track, "internal");
+    assert.equal(evidence.editId, "edit-1");
+    assert.equal(evidence.packageName, "com.easysubway.app");
+    assert.match(evidence.aabSha256, /^[0-9a-f]{64}$/);
+    assert.match(evidence.mappingSha256, /^[0-9a-f]{64}$/);
+
+    const flow = requests.map((request) => `${request.method} ${request.url.replace(/^https:\/\/[^/]+/, "")}`);
+    assert.ok(flow.some((entry) => entry.includes("/bundles?uploadType=media")));
+    assert.ok(flow.some((entry) => entry.includes("/deobfuscationFiles/10005/proguard")));
+    assert.ok(flow.some((entry) => entry.startsWith("PUT ") && entry.includes("/tracks/internal")));
+    assert.ok(flow.some((entry) => entry.includes(":commit?changesNotSentForReview=false")));
+  });
+});
+
+test("rejects a versionCode that is not greater than the current Play max before uploading", async () => {
+  await withFiles(async ({ envFile, aabPath, mappingPath, reportPath }) => {
+    const tracks = [{ track: "internal", releases: [{ status: "completed", versionCodes: ["10005"] }] }];
+    const { fetchImpl, requests } = mockPlay({ tracks });
+    await assert.rejects(
+      runUploadPlayInternal({
+        envFile,
+        aabPath,
+        mappingPath,
+        versionCode: "10005",
+        reportPath,
+        apiBaseUrl: "https://api.example/v3",
+        uploadBaseUrl: "https://upload.example/v3",
+        fetchImpl,
+      }),
+      /not greater than current Play max 10005/,
+    );
+    // The monotonic gate must fire before any binary is uploaded.
+    assert.ok(!requests.some((request) => request.url.includes("/bundles")));
+  });
+});
+
+test("fails when service-account authentication is rejected", async () => {
+  await withFiles(async ({ envFile, aabPath, mappingPath, reportPath }) => {
+    const { fetchImpl } = mockPlay({ overrides: { token: jsonResponse(401, { error: "unauthorized" }) } });
+    await assert.rejects(
+      runUploadPlayInternal({
+        envFile,
+        aabPath,
+        mappingPath,
+        versionCode: "10005",
+        reportPath,
+        apiBaseUrl: "https://api.example/v3",
+        uploadBaseUrl: "https://upload.example/v3",
+        fetchImpl,
+      }),
+      /google play oauth failed: 401/,
+    );
+  });
+});
+
+test("fails when the uploaded bundle versionCode does not match the expected one", async () => {
+  await withFiles(async ({ envFile, aabPath, mappingPath, reportPath }) => {
+    const { fetchImpl } = mockPlay({ tracks: [], uploadedVersionCode: "10004" });
+    await assert.rejects(
+      runUploadPlayInternal({
+        envFile,
+        aabPath,
+        mappingPath,
+        versionCode: "10005",
+        reportPath,
+        apiBaseUrl: "https://api.example/v3",
+        uploadBaseUrl: "https://upload.example/v3",
+        fetchImpl,
+      }),
+      /does not match expected 10005/,
+    );
+  });
+});

--- a/tools/release/upload-play-internal.test.mjs
+++ b/tools/release/upload-play-internal.test.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 import test from "node:test";
 
 import { runUploadPlayInternal } from "./upload-play-internal.mjs";
+import { assertRequestUrl } from "../ci/lib/google-play-auth.mjs";
 
 const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
 
@@ -147,4 +148,16 @@ test("fails when the uploaded bundle versionCode does not match the expected one
       /does not match expected 10005/,
     );
   });
+});
+
+test("assertRequestUrl only accepts absolute HTTPS URLs (SSRF guard)", () => {
+  assert.equal(
+    assertRequestUrl("https://androidpublisher.googleapis.com/androidpublisher/v3/x"),
+    "https://androidpublisher.googleapis.com/androidpublisher/v3/x",
+  );
+  assert.throws(() => assertRequestUrl("http://androidpublisher.googleapis.com"), /must be https/);
+  assert.throws(() => assertRequestUrl("http://169.254.169.254/latest/meta-data"), /must be https/);
+  assert.throws(() => assertRequestUrl("ftp://example.com/x"), /must be https/);
+  assert.throws(() => assertRequestUrl("/relative/path"), /invalid google play request url/);
+  assert.throws(() => assertRequestUrl("not a url"), /invalid google play request url/);
 });


### PR DESCRIPTION
## 관련 이슈

close AquilaXk/easysubway#1689

## 작업 배경

- 기존 PR 본문 참조.

## 작업 내용

<details>
<summary>기존 PR 본문</summary>

## 관련 이슈

close AquilaXk/easysubway#1689

## 작업 배경

Android RC 빌드는 자동인데 Play Console 업로드는 전 과정 수동이었다. RC evidence manifest의 `play_submission_evidence`가 internal track 업로드 없이는 영원히 blocked였다. 상용 모바일 표준("머지/RC 승인 → internal track 자동 업로드 → 사전검사 리포트")을 이 레포의 evidence 문화에 맞게 도입한다.

## 작업 내용

- `tools/ci/lib/google-play-auth.mjs` 신설 — `check-google-play-api-access.mjs`의 서비스계정 JWT 인증·요청 헬퍼를 공용 모듈로 분리(서드파티 업로드 액션 대신 재사용). fetch 전 `assertRequestUrl`로 절대 https URL만 허용(SSRF 방지). 기존 checker는 이 모듈 import로 리팩토링(동작 불변).
- `tools/release/upload-play-internal.mjs` 신설 — Android Publisher v3: `edits.insert` → `tracks.list` **versionCode 정책 선검증**(전 track 최신보다 크지 않으면 업로드 전 차단) → `bundles.upload` → `deobfuscationFiles.upload`(proguard) → `tracks.update`(internal, completed) → `edits.commit`. evidence JSON 산출.
- `upload-play-internal.test.mjs` — API mock 4건(정상/versionCode 역전 거부/인증 실패/업로드 versionCode 불일치). `ci.yml`에 `tools/release/*.test.mjs` 스텝 추가.
- `release-artifacts.yml`: `play_upload` 입력(none/internal, **default none**) + `play-internal-upload` 잡(`android-production-rc` environment 승인 공유, `production-upload-key`+`internal` 조건). 기본 빌드 플로우 회귀 없음.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/*.test.mjs tools/release/*.test.mjs` → **179 pass / 0 fail** (URL 검증 추가 후 10 pass 재확인)

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Publisher v3 플로우·versionCode 정책·인증 | CI | `node --test tools/release/*.test.mjs` | 로컬 pass | ✅ |
| Play Console 서비스계정 릴리스 권한 | 운영 | Play Console | 오너 라이브 | ⏳ 핸드오프 |
| workflow_dispatch(internal) 실업로드+evidence | CD | 실행 run·콘솔 캡처 | 오너 라이브(v1 크리티컬 패스 후, AquilaXk/easysubway-mobile#8) | ⏳ 핸드오프 |
| RC evidence manifest 연동 | CD | manifest gate | 실 evidence 확보 후 후속 | ⏳ 핸드오프 |

## Version impact

- [x] no version change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음

## 리뷰어 메모

- 파이프라인 구축(도구·잡·계약테스트)은 내부 작업이라 선행, 실제 업로드는 AquilaXk/easysubway-mobile#8 규약상 v1 후 최후순위.
- 상위 트래커 AquilaXk/easysubway#1683(Phase 4)·연관 AquilaXk/easysubway#1414. `/claude review` 폴백 + SonarCloud 반영으로 Play API 요청 URL https 검증 추가(S8476 해소).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * Android 프로덕션 RC에서 내부 트랙 업로드를 선택적으로 실행할 수 있게 되었습니다.
  * 업로드 결과 증거가 함께 생성·저장되어 배포 추적이 쉬워졌습니다.
* **버그 수정**
  * 업로드 전에 버전 코드가 이전 배포보다 반드시 큰지 검사해 잘못된 업로드를 방지합니다.
  * 업로드된 번들의 버전 코드가 예상값과 다를 경우 실패하도록 강화했습니다.
* **개선**
  * 릴리스 관련 자동화 검증이 추가되어 CI 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

</details>

## 검증

- 실행한 명령과 결과: 기존 PR 본문 참조.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| PR 본문 양식 보강 | GitHub PR | 현재 템플릿 섹션 존재 확인 | PR body | 완료 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [ ] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [ ] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [ ] AquilaXk/easysubway#1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [ ] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 기존 PR 본문 참조
- mobile versionCode: 기존 PR 본문 참조
- datapack version: 기존 PR 본문 참조
- route contract: 기존 PR 본문 참조
- realtime contract: 기존 PR 본문 참조
- backend identity: 기존 PR 본문 참조

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 기존 PR 본문 참조.

## 리스크

- 기존 PR 본문 참조.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
