### PR TITLE
[Feat] 푸시 알림 콘솔 고도화 — 이력·마스킹·실패 분해·재발송 안전장치

### DIFF
--- a/backend/src/main/java/com/easysubway/admin/alert/AdminAlertService.java
+++ b/backend/src/main/java/com/easysubway/admin/alert/AdminAlertService.java
@@ -114,7 +114,8 @@ public class AdminAlertService {
 				"푸시 발송 실패",
 				failed + "건 실패",
 				"failure",
-				AdminProgram.PUSH.path()));
+				// 실패 신호는 푸시 화면의 실패 필터 이력으로 바로 딥링크한다(#1746).
+				AdminProgram.PUSH.path() + "?status=FAILED"));
 		}
 	}
 

--- a/backend/src/main/java/com/easysubway/admin/audit/application/service/AdminAuditWriter.java
+++ b/backend/src/main/java/com/easysubway/admin/audit/application/service/AdminAuditWriter.java
@@ -126,6 +126,17 @@ public class AdminAuditWriter {
 		writeAudit(authentication, request, AdminAuditEventType.ADMIN_ACTION, "ADMIN_SAVED_VIEW", targetId, action, outcome, reason);
 	}
 
+	public void pushResend(
+		Authentication authentication,
+		HttpServletRequest request,
+		String targetId,
+		String action,
+		AdminAuditOutcome outcome,
+		String reason
+	) {
+		writeAudit(authentication, request, AdminAuditEventType.ADMIN_ACTION, "PUSH_NOTIFICATION_RESEND", targetId, action, outcome, reason);
+	}
+
 	public void analyticsExport(
 		Authentication authentication,
 		HttpServletRequest request,

--- a/backend/src/main/java/com/easysubway/admin/code/adapter/out/persistence/InMemoryAdminCommonCodeRepository.java
+++ b/backend/src/main/java/com/easysubway/admin/code/adapter/out/persistence/InMemoryAdminCommonCodeRepository.java
@@ -29,6 +29,7 @@ public class InMemoryAdminCommonCodeRepository implements AdminCommonCodeReposit
 		seedGroup(AdminCommonCodeGroups.INCIDENT_SEVERITY, "장애 심각도", "운영 incident 심각도", 40, now);
 		seedGroup(AdminCommonCodeGroups.INCIDENT_STATUS, "장애 상태", "운영 incident 처리 상태", 50, now);
 		seedGroup(AdminCommonCodeGroups.INCIDENT_SOURCE, "장애 출처", "incident 발생 출처", 60, now);
+		seedGroup(AdminCommonCodeGroups.PUSH_RESEND_LIMIT, "푸시 재발송 상한", "1회 재발송으로 처리할 수 있는 최대 건수", 70, now);
 		seedCode(AdminCommonCodeGroups.REPORT_REJECTION_REASON, "DUPLICATE", "중복 제보", "이미 처리 중인 동일 제보", 10, true, now);
 		seedCode(AdminCommonCodeGroups.REPORT_REJECTION_REASON, "INSUFFICIENT", "정보 부족", "역·시설·사진 정보 부족", 20, true, now);
 		seedCode(AdminCommonCodeGroups.FACILITY_STATUS_REASON, "INSPECTION", "정기 점검", "운영기관 정기 점검", 10, true, now);
@@ -43,6 +44,7 @@ public class InMemoryAdminCommonCodeRepository implements AdminCommonCodeReposit
 		seedCode(AdminCommonCodeGroups.INCIDENT_STATUS, "RESOLVED", "종결", "해결·종료됨", 40, true, now);
 		seedCode(AdminCommonCodeGroups.INCIDENT_SOURCE, "HEALTH", "Health", "health 상태", 10, true, now);
 		seedCode(AdminCommonCodeGroups.INCIDENT_SOURCE, "BATCH", "Batch", "배치 실행", 20, true, now);
+		seedCode(AdminCommonCodeGroups.PUSH_RESEND_LIMIT, "50", "1회 재발송 상한(건)", "한 번에 재발송할 수 있는 최대 실패 건수", 10, true, now);
 	}
 
 	@Override

--- a/backend/src/main/java/com/easysubway/admin/code/domain/AdminCommonCodeGroups.java
+++ b/backend/src/main/java/com/easysubway/admin/code/domain/AdminCommonCodeGroups.java
@@ -10,6 +10,7 @@ public final class AdminCommonCodeGroups {
 	public static final String INCIDENT_SEVERITY = "INCIDENT_SEVERITY";
 	public static final String INCIDENT_STATUS = "INCIDENT_STATUS";
 	public static final String INCIDENT_SOURCE = "INCIDENT_SOURCE";
+	public static final String PUSH_RESEND_LIMIT = "PUSH_RESEND_LIMIT";
 
 	private static final Set<String> REQUIRED_INCIDENT_CODES = Set.of(
 		INCIDENT_SEVERITY + ":MAJOR",

--- a/backend/src/main/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminPageController.java
@@ -1,24 +1,83 @@
 package com.easysubway.notification.adapter.in.web;
 
+import com.easysubway.admin.metric.adapter.in.web.AnalyticsComparisonCard;
+import com.easysubway.admin.metric.application.service.AdminMetricQueryService;
+import com.easysubway.admin.metric.application.service.AdminMetricQueryService.AdminMetricChart;
+import com.easysubway.admin.metric.domain.AdminMetricKeys;
 import com.easysubway.notification.application.port.in.PushNotificationDashboardUseCase;
 import com.easysubway.notification.domain.PushNotificationDashboardSummary;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.wimdeblauwe.htmx.spring.boot.mvc.HxRequest;
+import java.util.List;
+import java.util.Set;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 class PushNotificationAdminPageController {
 
-	private final PushNotificationDashboardUseCase pushNotificationDashboardUseCase;
+	// 발송 시도는 도달(증가)이, 발송 실패는 감소가 좋은 신호다(증감 카드 tone 판정).
+	private static final Set<String> HIGHER_IS_BETTER = Set.of(AdminMetricKeys.PUSH_ATTEMPTED);
+	private static final List<String> TREND_KEYS =
+		List.of(AdminMetricKeys.PUSH_ATTEMPTED, AdminMetricKeys.PUSH_FAILED);
 
-	PushNotificationAdminPageController(PushNotificationDashboardUseCase pushNotificationDashboardUseCase) {
+	private final PushNotificationDashboardUseCase pushNotificationDashboardUseCase;
+	private final AdminMetricQueryService metricQueryService;
+	private final ObjectMapper objectMapper;
+
+	PushNotificationAdminPageController(
+		PushNotificationDashboardUseCase pushNotificationDashboardUseCase,
+		AdminMetricQueryService metricQueryService,
+		ObjectMapper objectMapper
+	) {
 		this.pushNotificationDashboardUseCase = pushNotificationDashboardUseCase;
+		this.metricQueryService = metricQueryService;
+		this.objectMapper = objectMapper;
 	}
 
 	@GetMapping("/admin/notifications/push/page")
-	String pushNotificationDashboardPage(Model model) {
+	String pushNotificationDashboardPage(
+		@RequestParam(name = "days", defaultValue = "7") int days,
+		Model model
+	) {
 		PushNotificationDashboardSummary summary = pushNotificationDashboardUseCase.summarizePushNotifications();
 		model.addAttribute("summary", PushNotificationDashboardView.from(summary));
+		populateTrends(days, model);
 		return "admin/notifications/push";
+	}
+
+	// 실패 분석 추이·증감 부분 갱신(#1746): 기간 버튼이 이 fragment를 htmx로 다시 불러 차트·증감·대체표를 갈아끼운다.
+	@HxRequest
+	@GetMapping("/admin/notifications/push/trends")
+	String pushNotificationTrends(
+		@RequestParam(name = "days", defaultValue = "7") int days,
+		Model model
+	) {
+		populateTrends(days, model);
+		return "admin/notifications/push :: trends";
+	}
+
+	private void populateTrends(int days, Model model) {
+		AdminMetricChart chart = metricQueryService.chart(TREND_KEYS, days);
+		model.addAttribute("trendChart", chart);
+		model.addAttribute("trendJson", toJson(chart));
+		model.addAttribute("trendDays", chart.days());
+		model.addAttribute("exportKeys", TREND_KEYS);
+		model.addAttribute("comparisons", metricQueryService.compare(TREND_KEYS, days)
+			.stream()
+			.map(comparison -> AnalyticsComparisonCard.from(comparison, HIGHER_IS_BETTER.contains(comparison.key())))
+			.toList());
+	}
+
+	// Chart.js가 읽을 데이터 섬(JSON). 직렬화 실패 시 빈 차트로 안전 폴백(details 표가 대체).
+	private String toJson(AdminMetricChart chart) {
+		try {
+			return objectMapper.writeValueAsString(chart);
+		} catch (JsonProcessingException exception) {
+			return "{\"labels\":[],\"series\":[]}";
+		}
 	}
 }

--- a/backend/src/main/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminPageController.java
@@ -1,19 +1,34 @@
 package com.easysubway.notification.adapter.in.web;
 
+import com.easysubway.admin.audit.application.service.AdminAuditWriter;
 import com.easysubway.admin.metric.adapter.in.web.AnalyticsComparisonCard;
 import com.easysubway.admin.metric.application.service.AdminMetricQueryService;
 import com.easysubway.admin.metric.application.service.AdminMetricQueryService.AdminMetricChart;
 import com.easysubway.admin.metric.domain.AdminMetricKeys;
+import com.easysubway.common.domain.PageResult;
+import com.easysubway.common.web.pagination.EgovPaginationView;
 import com.easysubway.notification.application.port.in.PushNotificationDashboardUseCase;
+import com.easysubway.notification.application.port.in.PushNotificationHistoryQuery;
+import com.easysubway.notification.application.port.in.PushNotificationHistoryUseCase;
+import com.easysubway.notification.domain.PushNotification;
 import com.easysubway.notification.domain.PushNotificationDashboardSummary;
+import com.easysubway.notification.domain.PushNotificationStatus;
+import com.easysubway.notification.domain.PushNotificationType;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.wimdeblauwe.htmx.spring.boot.mvc.HxRequest;
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.LocalDate;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
@@ -23,30 +38,169 @@ class PushNotificationAdminPageController {
 	private static final Set<String> HIGHER_IS_BETTER = Set.of(AdminMetricKeys.PUSH_ATTEMPTED);
 	private static final List<String> TREND_KEYS =
 		List.of(AdminMetricKeys.PUSH_ATTEMPTED, AdminMetricKeys.PUSH_FAILED);
+	private static final String HISTORY_PATH = "/admin/notifications/push/history";
 
 	private final PushNotificationDashboardUseCase pushNotificationDashboardUseCase;
+	private final PushNotificationHistoryUseCase pushNotificationHistoryUseCase;
 	private final AdminMetricQueryService metricQueryService;
+	private final AdminAuditWriter auditWriter;
 	private final ObjectMapper objectMapper;
 
 	PushNotificationAdminPageController(
 		PushNotificationDashboardUseCase pushNotificationDashboardUseCase,
+		PushNotificationHistoryUseCase pushNotificationHistoryUseCase,
 		AdminMetricQueryService metricQueryService,
+		AdminAuditWriter auditWriter,
 		ObjectMapper objectMapper
 	) {
 		this.pushNotificationDashboardUseCase = pushNotificationDashboardUseCase;
+		this.pushNotificationHistoryUseCase = pushNotificationHistoryUseCase;
 		this.metricQueryService = metricQueryService;
+		this.auditWriter = auditWriter;
 		this.objectMapper = objectMapper;
 	}
 
 	@GetMapping("/admin/notifications/push/page")
 	String pushNotificationDashboardPage(
 		@RequestParam(name = "days", defaultValue = "7") int days,
+		@RequestParam(name = "status", required = false) PushNotificationStatus status,
+		@RequestParam(name = "type", required = false) PushNotificationType type,
+		@RequestParam(name = "keyword", required = false) String keyword,
+		@RequestParam(name = "from", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+		@RequestParam(name = "to", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+		@RequestParam(name = "page", required = false) Integer page,
+		Authentication authentication,
+		HttpServletRequest request,
 		Model model
 	) {
 		PushNotificationDashboardSummary summary = pushNotificationDashboardUseCase.summarizePushNotifications();
 		model.addAttribute("summary", PushNotificationDashboardView.from(summary));
 		populateTrends(days, model);
+		populateHistory(historyQuery(status, type, keyword, from, to, page), authentication, request, model);
 		return "admin/notifications/push";
+	}
+
+	// no-JS 발송 이력 필터: 폼 제출이 이 경로로 GET하면 이력이 채워진 풀페이지를 돌려준다.
+	@GetMapping(HISTORY_PATH)
+	String pushNotificationHistoryPage(
+		@RequestParam(name = "status", required = false) PushNotificationStatus status,
+		@RequestParam(name = "type", required = false) PushNotificationType type,
+		@RequestParam(name = "keyword", required = false) String keyword,
+		@RequestParam(name = "from", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+		@RequestParam(name = "to", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+		@RequestParam(name = "page", required = false) Integer page,
+		Authentication authentication,
+		HttpServletRequest request,
+		Model model
+	) {
+		return pushNotificationDashboardPage(7, status, type, keyword, from, to, page, authentication, request, model);
+	}
+
+	// 발송 이력 부분 갱신(#1746): 필터·페이지 링크가 이 fragment를 htmx로 다시 불러 표·페이지네이션만 갈아끼운다.
+	// htmx 히스토리 복원 요청은 셸을 포함한 풀페이지를 돌려줘 화면이 깨지지 않게 한다.
+	@HxRequest
+	@GetMapping(HISTORY_PATH)
+	String pushNotificationHistoryFragment(
+		@RequestParam(name = "status", required = false) PushNotificationStatus status,
+		@RequestParam(name = "type", required = false) PushNotificationType type,
+		@RequestParam(name = "keyword", required = false) String keyword,
+		@RequestParam(name = "from", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+		@RequestParam(name = "to", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+		@RequestParam(name = "page", required = false) Integer page,
+		@RequestHeader(value = "HX-History-Restore-Request", required = false) boolean historyRestore,
+		Authentication authentication,
+		HttpServletRequest request,
+		Model model
+	) {
+		if (historyRestore) {
+			return pushNotificationHistoryPage(status, type, keyword, from, to, page, authentication, request, model);
+		}
+		populateHistory(historyQuery(status, type, keyword, from, to, page), authentication, request, model);
+		return "admin/notifications/push :: historyResults";
+	}
+
+	private static PushNotificationHistoryQuery historyQuery(
+		PushNotificationStatus status,
+		PushNotificationType type,
+		String keyword,
+		LocalDate from,
+		LocalDate to,
+		Integer page
+	) {
+		return PushNotificationHistoryQuery.of(status, type, keyword, from, to, page, null);
+	}
+
+	// 발송 이력 표준 테이블: 필터·페이지네이션이 적용된 목록을 채운다. 수신자 식별자는 마스킹되며
+	// 열람은 감사에 남긴다(개인정보 최소 노출 원칙). 목록·건수·분해가 같은 질의를 공유해 정합을 보장한다.
+	private void populateHistory(
+		PushNotificationHistoryQuery query,
+		Authentication authentication,
+		HttpServletRequest request,
+		Model model
+	) {
+		long total = pushNotificationHistoryUseCase.countPushNotifications(query);
+		EgovPaginationView pageView = EgovPaginationView.from(query.page(), query.size(), total);
+		PushNotificationHistoryQuery pageQuery = query.withPage(pageView.page());
+		PageResult<PushNotification> historyPage = pushNotificationHistoryUseCase.searchPushNotifications(pageQuery);
+		List<PushNotificationHistoryRow> rows = historyPage.items().stream()
+			.map(PushNotificationHistoryRow::from)
+			.toList();
+
+		model.addAttribute("historyRows", rows);
+		model.addAttribute("historyPage", pageView);
+		model.addAttribute("historyTotal", total);
+		model.addAttribute("historyPaginationLinks", pageView.links(HISTORY_PATH, historyParams(pageQuery)));
+		model.addAttribute("historySelectedStatus", pageQuery.status());
+		model.addAttribute("historySelectedType", pageQuery.type());
+		model.addAttribute("historyKeyword", pageQuery.keyword());
+		model.addAttribute("historyFrom", pageQuery.createdFrom());
+		model.addAttribute("historyTo", pageQuery.createdTo());
+		model.addAttribute("historyStatusOptions", statusOptions(pageQuery.status()));
+		model.addAttribute("historyTypeOptions", typeOptions(pageQuery.type()));
+
+		// 마스킹된 수신자 식별자를 노출하는 조회라 열람 자체를 감사에 남긴다(원문·free-text 없음).
+		auditWriter.privacyRead(
+			authentication,
+			request,
+			"PUSH_NOTIFICATION_HISTORY",
+			"list",
+			"VIEW_PUSH_HISTORY",
+			"업무 맥락: 푸시 발송 이력 조회(수신자 식별자 마스킹)"
+		);
+	}
+
+	// 페이지네이션·필터 링크가 현재 필터를 유지하도록 활성 파라미터만 전달한다(널·빈 값은 생략).
+	private static Map<String, Object> historyParams(PushNotificationHistoryQuery query) {
+		Map<String, Object> params = new LinkedHashMap<>();
+		params.put("status", query.status());
+		params.put("type", query.type());
+		params.put("keyword", query.keyword());
+		params.put("from", query.createdFrom());
+		params.put("to", query.createdTo());
+		return params;
+	}
+
+	private static List<FilterOption> statusOptions(PushNotificationStatus selected) {
+		List<FilterOption> options = new java.util.ArrayList<>();
+		options.add(new FilterOption("", "상태 전체", selected == null));
+		for (PushNotificationStatus status : PushNotificationStatus.values()) {
+			options.add(new FilterOption(
+				status.name(), PushNotificationHistoryRow.statusLabel(status), status == selected));
+		}
+		return options;
+	}
+
+	private static List<FilterOption> typeOptions(PushNotificationType selected) {
+		List<FilterOption> options = new java.util.ArrayList<>();
+		options.add(new FilterOption("", "유형 전체", selected == null));
+		for (PushNotificationType type : PushNotificationType.values()) {
+			options.add(new FilterOption(
+				type.name(), PushNotificationHistoryRow.typeLabel(type), type == selected));
+		}
+		return options;
+	}
+
+	record FilterOption(String value, String label, boolean selected) {
 	}
 
 	// 실패 분석 추이·증감 부분 갱신(#1746): 기간 버튼이 이 fragment를 htmx로 다시 불러 차트·증감·대체표를 갈아끼운다.

--- a/backend/src/main/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminPageController.java
@@ -12,6 +12,7 @@ import com.easysubway.notification.application.port.in.PushNotificationHistoryQu
 import com.easysubway.notification.application.port.in.PushNotificationHistoryUseCase;
 import com.easysubway.notification.domain.PushNotification;
 import com.easysubway.notification.domain.PushNotificationDashboardSummary;
+import com.easysubway.notification.domain.PushNotificationFailureReasonCount;
 import com.easysubway.notification.domain.PushNotificationStatus;
 import com.easysubway.notification.domain.PushNotificationType;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -30,6 +31,7 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Controller
 class PushNotificationAdminPageController {
@@ -66,6 +68,7 @@ class PushNotificationAdminPageController {
 		@RequestParam(name = "status", required = false) PushNotificationStatus status,
 		@RequestParam(name = "type", required = false) PushNotificationType type,
 		@RequestParam(name = "keyword", required = false) String keyword,
+		@RequestParam(name = "reason", required = false) String reason,
 		@RequestParam(name = "from", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
 		@RequestParam(name = "to", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
 		@RequestParam(name = "page", required = false) Integer page,
@@ -76,7 +79,7 @@ class PushNotificationAdminPageController {
 		PushNotificationDashboardSummary summary = pushNotificationDashboardUseCase.summarizePushNotifications();
 		model.addAttribute("summary", PushNotificationDashboardView.from(summary));
 		populateTrends(days, model);
-		populateHistory(historyQuery(status, type, keyword, from, to, page), authentication, request, model);
+		populateHistory(historyQuery(status, type, keyword, reason, from, to, page), authentication, request, model);
 		return "admin/notifications/push";
 	}
 
@@ -86,6 +89,7 @@ class PushNotificationAdminPageController {
 		@RequestParam(name = "status", required = false) PushNotificationStatus status,
 		@RequestParam(name = "type", required = false) PushNotificationType type,
 		@RequestParam(name = "keyword", required = false) String keyword,
+		@RequestParam(name = "reason", required = false) String reason,
 		@RequestParam(name = "from", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
 		@RequestParam(name = "to", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
 		@RequestParam(name = "page", required = false) Integer page,
@@ -93,7 +97,8 @@ class PushNotificationAdminPageController {
 		HttpServletRequest request,
 		Model model
 	) {
-		return pushNotificationDashboardPage(7, status, type, keyword, from, to, page, authentication, request, model);
+		return pushNotificationDashboardPage(
+			7, status, type, keyword, reason, from, to, page, authentication, request, model);
 	}
 
 	// 발송 이력 부분 갱신(#1746): 필터·페이지 링크가 이 fragment를 htmx로 다시 불러 표·페이지네이션만 갈아끼운다.
@@ -104,6 +109,7 @@ class PushNotificationAdminPageController {
 		@RequestParam(name = "status", required = false) PushNotificationStatus status,
 		@RequestParam(name = "type", required = false) PushNotificationType type,
 		@RequestParam(name = "keyword", required = false) String keyword,
+		@RequestParam(name = "reason", required = false) String reason,
 		@RequestParam(name = "from", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
 		@RequestParam(name = "to", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
 		@RequestParam(name = "page", required = false) Integer page,
@@ -113,9 +119,10 @@ class PushNotificationAdminPageController {
 		Model model
 	) {
 		if (historyRestore) {
-			return pushNotificationHistoryPage(status, type, keyword, from, to, page, authentication, request, model);
+			return pushNotificationHistoryPage(
+				status, type, keyword, reason, from, to, page, authentication, request, model);
 		}
-		populateHistory(historyQuery(status, type, keyword, from, to, page), authentication, request, model);
+		populateHistory(historyQuery(status, type, keyword, reason, from, to, page), authentication, request, model);
 		return "admin/notifications/push :: historyResults";
 	}
 
@@ -123,11 +130,12 @@ class PushNotificationAdminPageController {
 		PushNotificationStatus status,
 		PushNotificationType type,
 		String keyword,
+		String reason,
 		LocalDate from,
 		LocalDate to,
 		Integer page
 	) {
-		return PushNotificationHistoryQuery.of(status, type, keyword, from, to, page, null);
+		return PushNotificationHistoryQuery.of(status, type, keyword, reason, from, to, page, null);
 	}
 
 	// 발송 이력 표준 테이블: 필터·페이지네이션이 적용된 목록을 채운다. 수신자 식별자는 마스킹되며
@@ -158,6 +166,26 @@ class PushNotificationAdminPageController {
 		model.addAttribute("historyStatusOptions", statusOptions(pageQuery.status()));
 		model.addAttribute("historyTypeOptions", typeOptions(pageQuery.type()));
 
+		// 실패 사유별 분해(막대) + 드릴다운. 목록과 같은 필터 컨텍스트를 공유해 분해 수치 = 사유 필터 목록 건수 정합.
+		List<PushNotificationFailureReasonCount> breakdown =
+			pushNotificationHistoryUseCase.summarizeFailureReasons(pageQuery);
+		long maxReasonCount = breakdown.stream()
+			.mapToLong(PushNotificationFailureReasonCount::count)
+			.max()
+			.orElse(0L);
+		List<FailureBreakdownBar> bars = breakdown.stream()
+			.map(item -> new FailureBreakdownBar(
+				item.reason(),
+				item.count(),
+				maxReasonCount == 0 ? 0 : Math.round(item.count() * 100.0 / maxReasonCount),
+				historyReasonHref(pageQuery, item.reason()),
+				item.reason().equals(pageQuery.failureReason())))
+			.toList();
+		model.addAttribute("failureBreakdown", bars);
+		model.addAttribute("hasReasonFilter", pageQuery.hasFailureReason());
+		model.addAttribute("selectedReason", pageQuery.failureReason());
+		model.addAttribute("clearReasonHref", historyReasonHref(pageQuery, null));
+
 		// 마스킹된 수신자 식별자를 노출하는 조회라 열람 자체를 감사에 남긴다(원문·free-text 없음).
 		auditWriter.privacyRead(
 			authentication,
@@ -175,9 +203,26 @@ class PushNotificationAdminPageController {
 		params.put("status", query.status());
 		params.put("type", query.type());
 		params.put("keyword", query.keyword());
+		params.put("reason", query.failureReason());
 		params.put("from", query.createdFrom());
 		params.put("to", query.createdTo());
 		return params;
+	}
+
+	// 사유 드릴다운 링크: 현재 필터(상태·유형·검색·기간)를 유지하고 reason만 설정/해제한다(페이지는 처음으로).
+	private static String historyReasonHref(PushNotificationHistoryQuery query, String reason) {
+		Map<String, Object> params = new LinkedHashMap<>(historyParams(query));
+		params.put("reason", reason);
+		UriComponentsBuilder builder = UriComponentsBuilder.fromPath(HISTORY_PATH);
+		params.forEach((name, value) -> {
+			if (value != null && !value.toString().isBlank()) {
+				builder.queryParam(name, value);
+			}
+		});
+		return builder.build().encode().toUriString();
+	}
+
+	record FailureBreakdownBar(String reason, long count, long percent, String href, boolean active) {
 	}
 
 	private static List<FilterOption> statusOptions(PushNotificationStatus selected) {

--- a/backend/src/main/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminPageController.java
@@ -1,6 +1,10 @@
 package com.easysubway.notification.adapter.in.web;
 
 import com.easysubway.admin.audit.application.service.AdminAuditWriter;
+import com.easysubway.admin.audit.domain.AdminAuditOutcome;
+import com.easysubway.admin.code.application.service.AdminCommonCodeService;
+import com.easysubway.admin.code.domain.AdminCommonCode;
+import com.easysubway.admin.code.domain.AdminCommonCodeGroups;
 import com.easysubway.admin.metric.adapter.in.web.AnalyticsComparisonCard;
 import com.easysubway.admin.metric.application.service.AdminMetricQueryService;
 import com.easysubway.admin.metric.application.service.AdminMetricQueryService.AdminMetricChart;
@@ -10,9 +14,12 @@ import com.easysubway.common.web.pagination.EgovPaginationView;
 import com.easysubway.notification.application.port.in.PushNotificationDashboardUseCase;
 import com.easysubway.notification.application.port.in.PushNotificationHistoryQuery;
 import com.easysubway.notification.application.port.in.PushNotificationHistoryUseCase;
+import com.easysubway.notification.application.port.in.PushNotificationResendUseCase;
+import com.easysubway.notification.application.port.in.ResendPushNotificationsCommand;
 import com.easysubway.notification.domain.PushNotification;
 import com.easysubway.notification.domain.PushNotificationDashboardSummary;
 import com.easysubway.notification.domain.PushNotificationFailureReasonCount;
+import com.easysubway.notification.domain.PushNotificationResendResult;
 import com.easysubway.notification.domain.PushNotificationStatus;
 import com.easysubway.notification.domain.PushNotificationType;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -29,8 +36,10 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import org.springframework.web.util.UriComponentsBuilder;
 
 @Controller
@@ -40,24 +49,34 @@ class PushNotificationAdminPageController {
 	private static final Set<String> HIGHER_IS_BETTER = Set.of(AdminMetricKeys.PUSH_ATTEMPTED);
 	private static final List<String> TREND_KEYS =
 		List.of(AdminMetricKeys.PUSH_ATTEMPTED, AdminMetricKeys.PUSH_FAILED);
-	private static final String HISTORY_PATH = "/admin/notifications/push/history";
+	// URL에 "/page"가 있어야 AdminHtmlRequest.matches가 commandTokens를 노출한다(#1742 gotcha와 동일).
+	private static final String HISTORY_PATH = "/admin/notifications/push/page/history";
+	private static final String PUSH_PAGE_PATH = "/admin/notifications/push/page";
+	// 공통코드가 없거나 숫자가 아닐 때의 안전한 기본 상한(대량 오발송 방지).
+	private static final int DEFAULT_RESEND_LIMIT = 50;
 
 	private final PushNotificationDashboardUseCase pushNotificationDashboardUseCase;
 	private final PushNotificationHistoryUseCase pushNotificationHistoryUseCase;
+	private final PushNotificationResendUseCase pushNotificationResendUseCase;
 	private final AdminMetricQueryService metricQueryService;
+	private final AdminCommonCodeService commonCodeService;
 	private final AdminAuditWriter auditWriter;
 	private final ObjectMapper objectMapper;
 
 	PushNotificationAdminPageController(
 		PushNotificationDashboardUseCase pushNotificationDashboardUseCase,
 		PushNotificationHistoryUseCase pushNotificationHistoryUseCase,
+		PushNotificationResendUseCase pushNotificationResendUseCase,
 		AdminMetricQueryService metricQueryService,
+		AdminCommonCodeService commonCodeService,
 		AdminAuditWriter auditWriter,
 		ObjectMapper objectMapper
 	) {
 		this.pushNotificationDashboardUseCase = pushNotificationDashboardUseCase;
 		this.pushNotificationHistoryUseCase = pushNotificationHistoryUseCase;
+		this.pushNotificationResendUseCase = pushNotificationResendUseCase;
 		this.metricQueryService = metricQueryService;
+		this.commonCodeService = commonCodeService;
 		this.auditWriter = auditWriter;
 		this.objectMapper = objectMapper;
 	}
@@ -126,6 +145,91 @@ class PushNotificationAdminPageController {
 		return "admin/notifications/push :: historyResults";
 	}
 
+	// 실패 푸시 재발송(#1746): 선택 실패 건을 재발송한다. no-JS 폼 기준선(command token + CSRF는 인터셉터가 검증).
+	// 멱등(성공 건 제외)·1회 상한(대량 오발송 방지)은 유스케이스가 보장하고, 결과는 flash 토스트로 안내한다.
+	@PostMapping("/admin/notifications/push/resend")
+	String resendPushNotifications(
+		@RequestParam(name = "notificationIds", required = false) List<String> notificationIds,
+		@RequestParam(name = "returnTo", required = false) String returnTo,
+		Authentication authentication,
+		HttpServletRequest request,
+		RedirectAttributes redirectAttributes
+	) {
+		int limit = resendLimit();
+		List<String> ids = notificationIds == null ? List.of() : notificationIds;
+		PushNotificationResendResult result = pushNotificationResendUseCase.resend(
+			new ResendPushNotificationsCommand(ids, limit));
+
+		auditWriter.pushResend(
+			authentication,
+			request,
+			"selection",
+			"RESEND_PUSH",
+			result.blocked() ? AdminAuditOutcome.FAILURE : AdminAuditOutcome.SUCCESS,
+			"업무 맥락: 실패 푸시 재발송 요청 %d건(상한 %d)".formatted(result.requestedCount(), limit)
+		);
+
+		redirectAttributes.addFlashAttribute("flashMessage", resendMessage(result));
+		redirectAttributes.addFlashAttribute("flashTone", resendTone(result));
+		return "redirect:" + safePushReturnTo(returnTo);
+	}
+
+	private static String resendMessage(PushNotificationResendResult result) {
+		if (result.blocked()) {
+			return "선택 %d건이 1회 재발송 상한(%d건)을 초과해 재발송하지 않았습니다. 나눠서 다시 시도해 주세요."
+				.formatted(result.requestedCount(), result.maxPerResend());
+		}
+		if (result.requestedCount() == 0) {
+			return "재발송할 항목을 선택해 주세요.";
+		}
+		if (result.resentCount() == 0) {
+			return "선택 %d건은 이미 처리되었거나 실패 상태가 아니라 재발송하지 않았습니다.".formatted(result.requestedCount());
+		}
+		if (result.skippedCount() == 0) {
+			return "실패 %d건을 재발송했습니다.".formatted(result.resentCount());
+		}
+		return "실패 %d건을 재발송하고, %d건은 이미 처리되어 제외했습니다."
+			.formatted(result.resentCount(), result.skippedCount());
+	}
+
+	private static String resendTone(PushNotificationResendResult result) {
+		if (result.blocked() || result.requestedCount() == 0 || result.resentCount() == 0) {
+			return "warning";
+		}
+		return "good";
+	}
+
+	// open-redirect 방지: 푸시 화면 경로만 허용한다.
+	private static String safePushReturnTo(String returnTo) {
+		if (returnTo != null
+			&& returnTo.startsWith(PUSH_PAGE_PATH.substring(0, PUSH_PAGE_PATH.lastIndexOf('/')))
+			&& !returnTo.contains("://")
+			&& !returnTo.contains("\n")
+			&& !returnTo.contains("\r")) {
+			return returnTo;
+		}
+		return PUSH_PAGE_PATH;
+	}
+
+	// 1회 재발송 상한을 공통코드(PUSH_RESEND_LIMIT)에서 읽는다. 값은 code 문자열의 정수이며, 없거나
+	// 숫자가 아니면 안전한 기본값으로 폴백한다. 활성 code가 여러 개면 가장 작은 값(가장 보수적)을 쓴다.
+	private int resendLimit() {
+		return commonCodeService.enabledCodes(AdminCommonCodeGroups.PUSH_RESEND_LIMIT).stream()
+			.map(AdminCommonCode::code)
+			.map(PushNotificationAdminPageController::parsePositiveInt)
+			.filter(value -> value != null && value > 0)
+			.min(Integer::compareTo)
+			.orElse(DEFAULT_RESEND_LIMIT);
+	}
+
+	private static Integer parsePositiveInt(String value) {
+		try {
+			return Integer.valueOf(value.trim());
+		} catch (NumberFormatException exception) {
+			return null;
+		}
+	}
+
 	private static PushNotificationHistoryQuery historyQuery(
 		PushNotificationStatus status,
 		PushNotificationType type,
@@ -185,6 +289,10 @@ class PushNotificationAdminPageController {
 		model.addAttribute("hasReasonFilter", pageQuery.hasFailureReason());
 		model.addAttribute("selectedReason", pageQuery.failureReason());
 		model.addAttribute("clearReasonHref", historyReasonHref(pageQuery, null));
+
+		// 재발송 안전장치(#1746): 실패 행 선택 → 재발송 폼의 확인 단계에 노출할 1회 상한·되돌아갈 목록 URL.
+		model.addAttribute("resendLimit", resendLimit());
+		model.addAttribute("currentListHref", historyReasonHref(pageQuery, pageQuery.failureReason()));
 
 		// 마스킹된 수신자 식별자를 노출하는 조회라 열람 자체를 감사에 남긴다(원문·free-text 없음).
 		auditWriter.privacyRead(

--- a/backend/src/main/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminPageController.java
@@ -221,10 +221,11 @@ class PushNotificationAdminPageController {
 		return "good";
 	}
 
-	// open-redirect 방지: 푸시 화면 경로만 허용한다.
+	// open-redirect 방지: 푸시 화면 경로(/page·/page/history)만 허용한다. 넓은 접두사(.../push)는
+	// /pushEVIL 같은 우회를 허용하므로 /page 전체 접두사로 좁힌다.
 	private static String safePushReturnTo(String returnTo) {
 		if (returnTo != null
-			&& returnTo.startsWith(PUSH_PAGE_PATH.substring(0, PUSH_PAGE_PATH.lastIndexOf('/')))
+			&& returnTo.startsWith(PUSH_PAGE_PATH)
 			&& !returnTo.contains("://")
 			&& !returnTo.contains("\n")
 			&& !returnTo.contains("\r")) {

--- a/backend/src/main/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminPageController.java
@@ -8,7 +8,9 @@ import com.easysubway.admin.code.domain.AdminCommonCodeGroups;
 import com.easysubway.admin.metric.adapter.in.web.AnalyticsComparisonCard;
 import com.easysubway.admin.metric.application.service.AdminMetricQueryService;
 import com.easysubway.admin.metric.application.service.AdminMetricQueryService.AdminMetricChart;
+import com.easysubway.admin.metric.application.service.AdminMetricQueryService.AdminMetricSeries;
 import com.easysubway.admin.metric.domain.AdminMetricKeys;
+import com.easysubway.admin.metric.domain.AdminMetricSparkline;
 import com.easysubway.common.domain.PageResult;
 import com.easysubway.common.web.pagination.EgovPaginationView;
 import com.easysubway.notification.application.port.in.PushNotificationDashboardUseCase;
@@ -98,8 +100,28 @@ class PushNotificationAdminPageController {
 		PushNotificationDashboardSummary summary = pushNotificationDashboardUseCase.summarizePushNotifications();
 		model.addAttribute("summary", PushNotificationDashboardView.from(summary));
 		populateTrends(days, model);
+		populateSummarySparklines(model);
 		populateHistory(historyQuery(status, type, keyword, reason, from, to, page), authentication, request, model);
 		return "admin/notifications/push";
+	}
+
+	// 요약 카드 7일 스파크라인(#1746): 발송 시도·실패의 최근 7일 추이를 CSP-safe 서버 SVG polyline으로 그린다.
+	// 기간 버튼과 무관하게 항상 7일이며, 실패 카드에는 실패 목록 필터 딥링크를 함께 노출한다.
+	private void populateSummarySparklines(Model model) {
+		AdminMetricChart weekChart = metricQueryService.chart(TREND_KEYS, 7);
+		model.addAttribute("attemptedSparkline", sparklinePoints(weekChart, AdminMetricKeys.PUSH_ATTEMPTED));
+		model.addAttribute("failedSparkline", sparklinePoints(weekChart, AdminMetricKeys.PUSH_FAILED));
+		// 실패 경고·실패 카드에서 실패 이력으로 바로 가는 딥링크.
+		model.addAttribute("failedHistoryHref", PUSH_PAGE_PATH + "?status=FAILED");
+	}
+
+	private static String sparklinePoints(AdminMetricChart chart, String key) {
+		return chart.series().stream()
+			.filter(series -> series.key().equals(key))
+			.findFirst()
+			.map(AdminMetricSeries::values)
+			.map(values -> AdminMetricSparkline.points(values, 100, 24))
+			.orElse("");
 	}
 
 	// no-JS 발송 이력 필터: 폼 제출이 이 경로로 GET하면 이력이 채워진 풀페이지를 돌려준다.

--- a/backend/src/main/java/com/easysubway/notification/adapter/in/web/PushNotificationHistoryRow.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/in/web/PushNotificationHistoryRow.java
@@ -1,0 +1,73 @@
+package com.easysubway.notification.adapter.in.web;
+
+import com.easysubway.notification.domain.PushNotification;
+import com.easysubway.notification.domain.PushNotificationStatus;
+import com.easysubway.notification.domain.PushNotificationType;
+import java.time.LocalDateTime;
+
+/**
+ * 관리자 발송 이력 표준 테이블(#1746)의 행. 수신자 식별자(사용자·기기 토큰)는 마스킹해 노출하고,
+ * 상태·유형은 한글 라벨로, 실패 사유 원문은 행 확장(details)에서만 보여준다.
+ */
+record PushNotificationHistoryRow(
+	String notificationId,
+	String maskedUserId,
+	String maskedDeviceToken,
+	String platformLabel,
+	String typeLabel,
+	String statusLabel,
+	String statusTone,
+	String title,
+	String failureReason,
+	LocalDateTime createdAt
+) {
+
+	static PushNotificationHistoryRow from(PushNotification notification) {
+		return new PushNotificationHistoryRow(
+			notification.notificationId(),
+			PushRecipientMask.maskUserId(notification.userId()),
+			PushRecipientMask.maskDeviceToken(notification.deviceToken()),
+			platformLabel(notification.platform().name()),
+			typeLabel(notification.type()),
+			statusLabel(notification.status()),
+			statusTone(notification.status()),
+			notification.title(),
+			notification.failureReason(),
+			notification.createdAt()
+		);
+	}
+
+	private static String platformLabel(String platform) {
+		return switch (platform) {
+			case "ANDROID" -> "안드로이드";
+			case "IOS" -> "iOS";
+			default -> platform;
+		};
+	}
+
+	static String typeLabel(PushNotificationType type) {
+		return switch (type) {
+			case FAVORITE_STATION_FACILITY -> "즐겨찾는 역 시설";
+			case FAVORITE_ROUTE_FACILITY -> "즐겨찾는 경로 시설";
+			case REPORT_STATUS -> "제보 처리 상태";
+			case DATA_QUALITY -> "데이터 품질";
+		};
+	}
+
+	static String statusLabel(PushNotificationStatus status) {
+		return switch (status) {
+			case PENDING -> "대기 중";
+			case PROCESSING -> "처리 중";
+			case SENT -> "발송 완료";
+			case FAILED -> "발송 실패";
+		};
+	}
+
+	private static String statusTone(PushNotificationStatus status) {
+		return switch (status) {
+			case PENDING, PROCESSING -> "pending";
+			case SENT -> "ok";
+			case FAILED -> "failure";
+		};
+	}
+}

--- a/backend/src/main/java/com/easysubway/notification/adapter/in/web/PushRecipientMask.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/in/web/PushRecipientMask.java
@@ -1,0 +1,34 @@
+package com.easysubway.notification.adapter.in.web;
+
+/**
+ * 관리자 발송 이력 콘솔(#1746)의 수신자 식별자 마스킹.
+ *
+ * <p>개인정보 최소 노출 원칙: 사용자 식별자·기기 토큰은 원문을 그대로 노출하지 않고 앞 일부만 남긴다.
+ * 남은 길이를 드러내지 않도록 고정 마커(••••)를 붙인다. 열람 자체는 감사에 남긴다.
+ */
+final class PushRecipientMask {
+
+	private static final String MASK_MARKER = "••••";
+
+	private PushRecipientMask() {
+	}
+
+	static String maskUserId(String userId) {
+		return mask(userId, 4);
+	}
+
+	static String maskDeviceToken(String deviceToken) {
+		return mask(deviceToken, 6);
+	}
+
+	private static String mask(String value, int visiblePrefix) {
+		if (value == null || value.isBlank()) {
+			return MASK_MARKER;
+		}
+		String trimmed = value.trim();
+		if (trimmed.length() <= visiblePrefix) {
+			return MASK_MARKER;
+		}
+		return trimmed.substring(0, visiblePrefix) + MASK_MARKER;
+	}
+}

--- a/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/InMemoryPushNotificationOutboxRepository.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/InMemoryPushNotificationOutboxRepository.java
@@ -8,6 +8,7 @@ import com.easysubway.notification.application.port.out.SearchPushNotificationOu
 import com.easysubway.notification.application.port.out.SummarizePushNotificationOutboxPort;
 import com.easysubway.notification.domain.PushNotification;
 import com.easysubway.notification.domain.PushNotificationDashboardSummary;
+import com.easysubway.notification.domain.PushNotificationFailureReasonCount;
 import com.easysubway.notification.domain.PushNotificationStatus;
 import com.easysubway.user.application.port.out.DeleteUserPushNotificationPort;
 import java.time.Clock;
@@ -179,6 +180,41 @@ public class InMemoryPushNotificationOutboxRepository implements
 		return matchingHistory(query).count();
 	}
 
+	@Override
+	public List<PushNotificationFailureReasonCount> countFailureReasons(PushNotificationHistoryQuery query) {
+		Map<String, Long> countsByReason = new java.util.LinkedHashMap<>();
+		notificationsByUserId.values().stream()
+			.flatMap(List::stream)
+			.filter(notification -> matchesFailureBreakdown(notification, query))
+			.forEach(notification ->
+				countsByReason.merge(notification.failureReason(), 1L, Long::sum));
+		return countsByReason.entrySet().stream()
+			.map(entry -> new PushNotificationFailureReasonCount(entry.getKey(), entry.getValue()))
+			.sorted(Comparator
+				.comparingLong(PushNotificationFailureReasonCount::count).reversed()
+				.thenComparing(PushNotificationFailureReasonCount::reason))
+			.toList();
+	}
+
+	// 실패 분해: status=FAILED 고정 + 유형·검색·기간(사유 드릴다운·상태 필터는 무시).
+	private boolean matchesFailureBreakdown(PushNotification notification, PushNotificationHistoryQuery query) {
+		if (notification.status() != PushNotificationStatus.FAILED || notification.failureReason() == null) {
+			return false;
+		}
+		if (query.hasType() && notification.type() != query.type()) {
+			return false;
+		}
+		if (query.hasKeyword() && !matchesKeyword(notification, query.keyword())) {
+			return false;
+		}
+		LocalDateTime createdAt = notification.createdAt();
+		if (query.createdFrom() != null && createdAt.isBefore(query.createdFrom().atStartOfDay())) {
+			return false;
+		}
+		return query.createdTo() == null
+			|| createdAt.isBefore(query.createdTo().plusDays(1).atStartOfDay());
+	}
+
 	private Stream<PushNotification> matchingHistory(PushNotificationHistoryQuery query) {
 		return notificationsByUserId.values().stream()
 			.flatMap(List::stream)
@@ -193,6 +229,9 @@ public class InMemoryPushNotificationOutboxRepository implements
 			return false;
 		}
 		if (query.hasKeyword() && !matchesKeyword(notification, query.keyword())) {
+			return false;
+		}
+		if (query.hasFailureReason() && !query.failureReason().equals(notification.failureReason())) {
 			return false;
 		}
 		LocalDateTime createdAt = notification.createdAt();

--- a/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/InMemoryPushNotificationOutboxRepository.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/InMemoryPushNotificationOutboxRepository.java
@@ -215,6 +215,18 @@ public class InMemoryPushNotificationOutboxRepository implements
 			|| createdAt.isBefore(query.createdTo().plusDays(1).atStartOfDay());
 	}
 
+	@Override
+	public List<PushNotification> loadPushNotificationsByIds(List<String> notificationIds) {
+		if (notificationIds == null || notificationIds.isEmpty()) {
+			return List.of();
+		}
+		java.util.Set<String> ids = new java.util.HashSet<>(notificationIds);
+		return notificationsByUserId.values().stream()
+			.flatMap(List::stream)
+			.filter(notification -> ids.contains(notification.notificationId()))
+			.toList();
+	}
+
 	private Stream<PushNotification> matchingHistory(PushNotificationHistoryQuery query) {
 		return notificationsByUserId.values().stream()
 			.flatMap(List::stream)

--- a/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/InMemoryPushNotificationOutboxRepository.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/InMemoryPushNotificationOutboxRepository.java
@@ -1,8 +1,10 @@
 package com.easysubway.notification.adapter.out.persistence;
 
+import com.easysubway.notification.application.port.in.PushNotificationHistoryQuery;
 import com.easysubway.notification.application.port.out.LoadPendingPushNotificationOutboxPort;
 import com.easysubway.notification.application.port.out.LoadPushNotificationOutboxPort;
 import com.easysubway.notification.application.port.out.SavePushNotificationOutboxPort;
+import com.easysubway.notification.application.port.out.SearchPushNotificationOutboxPort;
 import com.easysubway.notification.application.port.out.SummarizePushNotificationOutboxPort;
 import com.easysubway.notification.domain.PushNotification;
 import com.easysubway.notification.domain.PushNotificationDashboardSummary;
@@ -13,7 +15,9 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Stream;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -26,6 +30,7 @@ public class InMemoryPushNotificationOutboxRepository implements
 	LoadPushNotificationOutboxPort,
 	LoadPendingPushNotificationOutboxPort,
 	SavePushNotificationOutboxPort,
+	SearchPushNotificationOutboxPort,
 	SummarizePushNotificationOutboxPort,
 	DeleteUserPushNotificationPort {
 
@@ -154,6 +159,54 @@ public class InMemoryPushNotificationOutboxRepository implements
 			failedCount,
 			latestFailedNotification == null ? null : latestFailedNotification.failureReason()
 		);
+	}
+
+	@Override
+	public List<PushNotification> searchPushNotifications(PushNotificationHistoryQuery query) {
+		List<PushNotification> matched = matchingHistory(query)
+			.sorted(Comparator
+				.comparing(PushNotification::createdAt)
+				.thenComparing(PushNotification::notificationId)
+				.reversed())
+			.toList();
+		int fromIndex = Math.min(query.offset(), matched.size());
+		int toIndex = Math.min(fromIndex + query.size(), matched.size());
+		return List.copyOf(matched.subList(fromIndex, toIndex));
+	}
+
+	@Override
+	public long countPushNotifications(PushNotificationHistoryQuery query) {
+		return matchingHistory(query).count();
+	}
+
+	private Stream<PushNotification> matchingHistory(PushNotificationHistoryQuery query) {
+		return notificationsByUserId.values().stream()
+			.flatMap(List::stream)
+			.filter(notification -> matchesHistory(notification, query));
+	}
+
+	private boolean matchesHistory(PushNotification notification, PushNotificationHistoryQuery query) {
+		if (query.hasStatus() && notification.status() != query.status()) {
+			return false;
+		}
+		if (query.hasType() && notification.type() != query.type()) {
+			return false;
+		}
+		if (query.hasKeyword() && !matchesKeyword(notification, query.keyword())) {
+			return false;
+		}
+		LocalDateTime createdAt = notification.createdAt();
+		if (query.createdFrom() != null && createdAt.isBefore(query.createdFrom().atStartOfDay())) {
+			return false;
+		}
+		return query.createdTo() == null
+			|| createdAt.isBefore(query.createdTo().plusDays(1).atStartOfDay());
+	}
+
+	private static boolean matchesKeyword(PushNotification notification, String keyword) {
+		String needle = keyword.toLowerCase(Locale.ROOT);
+		return notification.title().toLowerCase(Locale.ROOT).contains(needle)
+			|| notification.body().toLowerCase(Locale.ROOT).contains(needle);
 	}
 
 	@Override

--- a/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepository.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepository.java
@@ -9,6 +9,7 @@ import com.easysubway.notification.application.port.out.SummarizePushNotificatio
 import com.easysubway.notification.domain.DevicePlatform;
 import com.easysubway.notification.domain.PushNotification;
 import com.easysubway.notification.domain.PushNotificationDashboardSummary;
+import com.easysubway.notification.domain.PushNotificationFailureReasonCount;
 import com.easysubway.notification.domain.PushNotificationStatus;
 import com.easysubway.notification.domain.PushNotificationType;
 import com.easysubway.user.application.port.out.DeleteUserPushNotificationPort;
@@ -261,6 +262,10 @@ public class JdbcPushNotificationOutboxRepository implements
 			arguments.add(pattern);
 			arguments.add(pattern);
 		}
+		if (query.hasFailureReason()) {
+			conditions.add("failure_reason = ?");
+			arguments.add(query.failureReason());
+		}
 		if (query.createdFrom() != null) {
 			conditions.add("created_at >= ?");
 			arguments.add(query.createdFrom().atStartOfDay());
@@ -271,6 +276,50 @@ public class JdbcPushNotificationOutboxRepository implements
 		}
 		if (conditions.isEmpty()) {
 			return "";
+		}
+		return " WHERE " + String.join(" AND ", conditions);
+	}
+
+	@Override
+	public List<PushNotificationFailureReasonCount> countFailureReasons(PushNotificationHistoryQuery query) {
+		// 분해는 항상 실패 전체를 사유별로 본다: status=FAILED 강제, 사유 드릴다운은 제외하고 기간·유형·검색만 반영.
+		List<Object> arguments = new ArrayList<>();
+		String whereClause = buildFailureBreakdownWhere(query, arguments);
+		return jdbcTemplate.query(
+			"SELECT failure_reason, COUNT(*) AS count FROM push_notification_outbox"
+				+ whereClause
+				+ " GROUP BY failure_reason ORDER BY count DESC, failure_reason ASC",
+			(resultSet, rowNumber) -> new PushNotificationFailureReasonCount(
+				resultSet.getString("failure_reason"),
+				resultSet.getLong("count")
+			),
+			arguments.toArray()
+		);
+	}
+
+	// 실패 분해 WHERE: status=FAILED 고정 + 유형·검색·기간(사유 드릴다운·상태 필터는 무시).
+	private String buildFailureBreakdownWhere(PushNotificationHistoryQuery query, List<Object> arguments) {
+		List<String> conditions = new ArrayList<>();
+		conditions.add("status = ?");
+		arguments.add(PushNotificationStatus.FAILED.name());
+		conditions.add("failure_reason IS NOT NULL");
+		if (query.hasType()) {
+			conditions.add("notification_type = ?");
+			arguments.add(query.type().name());
+		}
+		if (query.hasKeyword()) {
+			conditions.add("(LOWER(title) LIKE ? ESCAPE '\\' OR LOWER(body) LIKE ? ESCAPE '\\')");
+			String pattern = "%" + escapeLike(query.keyword().toLowerCase(java.util.Locale.ROOT)) + "%";
+			arguments.add(pattern);
+			arguments.add(pattern);
+		}
+		if (query.createdFrom() != null) {
+			conditions.add("created_at >= ?");
+			arguments.add(query.createdFrom().atStartOfDay());
+		}
+		if (query.createdTo() != null) {
+			conditions.add("created_at < ?");
+			arguments.add(query.createdTo().plusDays(1).atStartOfDay());
 		}
 		return " WHERE " + String.join(" AND ", conditions);
 	}

--- a/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepository.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepository.java
@@ -1,8 +1,10 @@
 package com.easysubway.notification.adapter.out.persistence;
 
+import com.easysubway.notification.application.port.in.PushNotificationHistoryQuery;
 import com.easysubway.notification.application.port.out.LoadPendingPushNotificationOutboxPort;
 import com.easysubway.notification.application.port.out.LoadPushNotificationOutboxPort;
 import com.easysubway.notification.application.port.out.SavePushNotificationOutboxPort;
+import com.easysubway.notification.application.port.out.SearchPushNotificationOutboxPort;
 import com.easysubway.notification.application.port.out.SummarizePushNotificationOutboxPort;
 import com.easysubway.notification.domain.DevicePlatform;
 import com.easysubway.notification.domain.PushNotification;
@@ -14,6 +16,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import javax.sql.DataSource;
@@ -30,6 +33,7 @@ public class JdbcPushNotificationOutboxRepository implements
 	LoadPushNotificationOutboxPort,
 	LoadPendingPushNotificationOutboxPort,
 	SavePushNotificationOutboxPort,
+	SearchPushNotificationOutboxPort,
 	SummarizePushNotificationOutboxPort,
 	DeleteUserPushNotificationPort {
 
@@ -198,6 +202,84 @@ public class JdbcPushNotificationOutboxRepository implements
 			failedCount,
 			latestFailureReason
 		);
+	}
+
+	@Override
+	public List<PushNotification> searchPushNotifications(PushNotificationHistoryQuery query) {
+		List<Object> arguments = new ArrayList<>();
+		String whereClause = buildHistoryWhere(query, arguments);
+		arguments.add(query.size());
+		arguments.add(query.offset());
+		return jdbcTemplate.query(
+			"""
+				SELECT notification_id,
+					user_id,
+					platform,
+					device_token,
+					notification_type,
+					title,
+					body,
+					status,
+					failure_reason,
+					created_at
+				FROM push_notification_outbox
+				"""
+				+ whereClause
+				+ " ORDER BY created_at DESC, notification_id DESC LIMIT ? OFFSET ?",
+			this::mapPushNotification,
+			arguments.toArray()
+		);
+	}
+
+	@Override
+	public long countPushNotifications(PushNotificationHistoryQuery query) {
+		List<Object> arguments = new ArrayList<>();
+		String whereClause = buildHistoryWhere(query, arguments);
+		Long count = jdbcTemplate.queryForObject(
+			"SELECT COUNT(*) FROM push_notification_outbox" + whereClause,
+			Long.class,
+			arguments.toArray()
+		);
+		return count == null ? 0L : count;
+	}
+
+	// 이력 필터를 화이트리스트 컬럼으로만 조립한다. 키워드는 제목·본문만 매칭하고(수신자 식별자는 제외)
+	// LIKE 메타문자를 이스케이프한다. 기간은 created_at 기준(종료일 포함).
+	private String buildHistoryWhere(PushNotificationHistoryQuery query, List<Object> arguments) {
+		List<String> conditions = new ArrayList<>();
+		if (query.hasStatus()) {
+			conditions.add("status = ?");
+			arguments.add(query.status().name());
+		}
+		if (query.hasType()) {
+			conditions.add("notification_type = ?");
+			arguments.add(query.type().name());
+		}
+		if (query.hasKeyword()) {
+			conditions.add("(LOWER(title) LIKE ? ESCAPE '\\' OR LOWER(body) LIKE ? ESCAPE '\\')");
+			String pattern = "%" + escapeLike(query.keyword().toLowerCase(java.util.Locale.ROOT)) + "%";
+			arguments.add(pattern);
+			arguments.add(pattern);
+		}
+		if (query.createdFrom() != null) {
+			conditions.add("created_at >= ?");
+			arguments.add(query.createdFrom().atStartOfDay());
+		}
+		if (query.createdTo() != null) {
+			conditions.add("created_at < ?");
+			arguments.add(query.createdTo().plusDays(1).atStartOfDay());
+		}
+		if (conditions.isEmpty()) {
+			return "";
+		}
+		return " WHERE " + String.join(" AND ", conditions);
+	}
+
+	private static String escapeLike(String value) {
+		return value
+			.replace("\\", "\\\\")
+			.replace("%", "\\%")
+			.replace("_", "\\_");
 	}
 
 	@Override

--- a/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepository.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepository.java
@@ -244,6 +244,31 @@ public class JdbcPushNotificationOutboxRepository implements
 		return count == null ? 0L : count;
 	}
 
+	@Override
+	public List<PushNotification> loadPushNotificationsByIds(List<String> notificationIds) {
+		if (notificationIds == null || notificationIds.isEmpty()) {
+			return List.of();
+		}
+		String placeholders = String.join(", ", java.util.Collections.nCopies(notificationIds.size(), "?"));
+		return jdbcTemplate.query(
+			"""
+				SELECT notification_id,
+					user_id,
+					platform,
+					device_token,
+					notification_type,
+					title,
+					body,
+					status,
+					failure_reason,
+					created_at
+				FROM push_notification_outbox
+				WHERE notification_id IN (""" + placeholders + ")",
+			this::mapPushNotification,
+			notificationIds.toArray()
+		);
+	}
+
 	// 이력 필터를 화이트리스트 컬럼으로만 조립한다. 키워드는 제목·본문만 매칭하고(수신자 식별자는 제외)
 	// LIKE 메타문자를 이스케이프한다. 기간은 created_at 기준(종료일 포함).
 	private String buildHistoryWhere(PushNotificationHistoryQuery query, List<Object> arguments) {

--- a/backend/src/main/java/com/easysubway/notification/application/port/in/PushNotificationHistoryQuery.java
+++ b/backend/src/main/java/com/easysubway/notification/application/port/in/PushNotificationHistoryQuery.java
@@ -8,15 +8,16 @@ import java.time.LocalDate;
 /**
  * 관리자 푸시 발송 이력 표준 테이블(#1746)의 서버 파라미터 질의.
  *
- * <p>상태·알림 유형·발송 기간 필터와 내용 키워드 검색, 페이지네이션을 담는다. 모든 값은 URL 쿼리에서
- * 오며 no-JS(폼 제출)와 htmx(부분 갱신)가 같은 파라미터를 공유한다. 수신자 식별자(userId·기기 토큰)는
- * 개인정보라 검색 대상에서 제외하고 제목·본문만 매칭한다. 목록·건수·실패 분해가 같은 질의를 공유해
+ * <p>상태·알림 유형·발송 기간 필터와 내용 키워드 검색, 실패 사유 드릴다운, 페이지네이션을 담는다. 모든 값은
+ * URL 쿼리에서 오며 no-JS(폼 제출)와 htmx(부분 갱신)가 같은 파라미터를 공유한다. 수신자 식별자(userId·기기
+ * 토큰)는 개인정보라 검색 대상에서 제외하고 제목·본문만 매칭한다. 목록·건수·실패 분해가 같은 질의를 공유해
  * 분해 수치와 목록 건수의 정합을 by-construction으로 보장한다.
  */
 public record PushNotificationHistoryQuery(
 	PushNotificationStatus status,
 	PushNotificationType type,
 	String keyword,
+	String failureReason,
 	LocalDate createdFrom,
 	LocalDate createdTo,
 	int page,
@@ -29,6 +30,7 @@ public record PushNotificationHistoryQuery(
 
 	public PushNotificationHistoryQuery {
 		keyword = (keyword == null || keyword.isBlank()) ? null : keyword.trim();
+		failureReason = (failureReason == null || failureReason.isBlank()) ? null : failureReason.trim();
 		if (page < 0 || size <= 0) {
 			throw new InvalidPushNotificationException("페이지 요청 값을 확인해야 합니다.");
 		}
@@ -45,6 +47,7 @@ public record PushNotificationHistoryQuery(
 		PushNotificationStatus status,
 		PushNotificationType type,
 		String keyword,
+		String failureReason,
 		LocalDate createdFrom,
 		LocalDate createdTo,
 		Integer page,
@@ -53,12 +56,13 @@ public record PushNotificationHistoryQuery(
 		int normalizedPage = page == null ? DEFAULT_PAGE : page;
 		int requestedSize = size == null ? DEFAULT_SIZE : size;
 		return new PushNotificationHistoryQuery(
-			status, type, keyword, createdFrom, createdTo, normalizedPage, requestedSize);
+			status, type, keyword, failureReason, createdFrom, createdTo, normalizedPage, requestedSize);
 	}
 
-	/** 필터(상태·유형·기간·키워드)는 그대로 두고 페이지만 바꾼 질의. 클램프·기본 뷰 재조립에 쓴다. */
+	/** 필터는 그대로 두고 페이지만 바꾼 질의. 클램프·기본 뷰 재조립에 쓴다. */
 	public PushNotificationHistoryQuery withPage(int nextPage) {
-		return new PushNotificationHistoryQuery(status, type, keyword, createdFrom, createdTo, nextPage, size);
+		return new PushNotificationHistoryQuery(
+			status, type, keyword, failureReason, createdFrom, createdTo, nextPage, size);
 	}
 
 	public boolean hasKeyword() {
@@ -71,6 +75,10 @@ public record PushNotificationHistoryQuery(
 
 	public boolean hasType() {
 		return type != null;
+	}
+
+	public boolean hasFailureReason() {
+		return failureReason != null;
 	}
 
 	public int offset() {

--- a/backend/src/main/java/com/easysubway/notification/application/port/in/PushNotificationHistoryQuery.java
+++ b/backend/src/main/java/com/easysubway/notification/application/port/in/PushNotificationHistoryQuery.java
@@ -1,0 +1,79 @@
+package com.easysubway.notification.application.port.in;
+
+import com.easysubway.notification.domain.InvalidPushNotificationException;
+import com.easysubway.notification.domain.PushNotificationStatus;
+import com.easysubway.notification.domain.PushNotificationType;
+import java.time.LocalDate;
+
+/**
+ * 관리자 푸시 발송 이력 표준 테이블(#1746)의 서버 파라미터 질의.
+ *
+ * <p>상태·알림 유형·발송 기간 필터와 내용 키워드 검색, 페이지네이션을 담는다. 모든 값은 URL 쿼리에서
+ * 오며 no-JS(폼 제출)와 htmx(부분 갱신)가 같은 파라미터를 공유한다. 수신자 식별자(userId·기기 토큰)는
+ * 개인정보라 검색 대상에서 제외하고 제목·본문만 매칭한다. 목록·건수·실패 분해가 같은 질의를 공유해
+ * 분해 수치와 목록 건수의 정합을 by-construction으로 보장한다.
+ */
+public record PushNotificationHistoryQuery(
+	PushNotificationStatus status,
+	PushNotificationType type,
+	String keyword,
+	LocalDate createdFrom,
+	LocalDate createdTo,
+	int page,
+	int size
+) {
+
+	public static final int DEFAULT_PAGE = 0;
+	public static final int DEFAULT_SIZE = 20;
+	public static final int MAX_SIZE = 100;
+
+	public PushNotificationHistoryQuery {
+		keyword = (keyword == null || keyword.isBlank()) ? null : keyword.trim();
+		if (page < 0 || size <= 0) {
+			throw new InvalidPushNotificationException("페이지 요청 값을 확인해야 합니다.");
+		}
+		size = Math.min(size, MAX_SIZE);
+		if (page > Integer.MAX_VALUE / size) {
+			throw new InvalidPushNotificationException("페이지 요청 값을 확인해야 합니다.");
+		}
+		if (createdFrom != null && createdTo != null && createdFrom.isAfter(createdTo)) {
+			throw new InvalidPushNotificationException("발송 기간 시작이 종료보다 늦을 수 없습니다.");
+		}
+	}
+
+	public static PushNotificationHistoryQuery of(
+		PushNotificationStatus status,
+		PushNotificationType type,
+		String keyword,
+		LocalDate createdFrom,
+		LocalDate createdTo,
+		Integer page,
+		Integer size
+	) {
+		int normalizedPage = page == null ? DEFAULT_PAGE : page;
+		int requestedSize = size == null ? DEFAULT_SIZE : size;
+		return new PushNotificationHistoryQuery(
+			status, type, keyword, createdFrom, createdTo, normalizedPage, requestedSize);
+	}
+
+	/** 필터(상태·유형·기간·키워드)는 그대로 두고 페이지만 바꾼 질의. 클램프·기본 뷰 재조립에 쓴다. */
+	public PushNotificationHistoryQuery withPage(int nextPage) {
+		return new PushNotificationHistoryQuery(status, type, keyword, createdFrom, createdTo, nextPage, size);
+	}
+
+	public boolean hasKeyword() {
+		return keyword != null;
+	}
+
+	public boolean hasStatus() {
+		return status != null;
+	}
+
+	public boolean hasType() {
+		return type != null;
+	}
+
+	public int offset() {
+		return page * size;
+	}
+}

--- a/backend/src/main/java/com/easysubway/notification/application/port/in/PushNotificationHistoryUseCase.java
+++ b/backend/src/main/java/com/easysubway/notification/application/port/in/PushNotificationHistoryUseCase.java
@@ -1,0 +1,14 @@
+package com.easysubway.notification.application.port.in;
+
+import com.easysubway.common.domain.PageResult;
+import com.easysubway.notification.domain.PushNotification;
+
+/**
+ * 관리자 푸시 발송 이력 조회(#1746). 필터·페이지네이션이 적용된 이력과 총 건수를 준다.
+ */
+public interface PushNotificationHistoryUseCase {
+
+	PageResult<PushNotification> searchPushNotifications(PushNotificationHistoryQuery query);
+
+	long countPushNotifications(PushNotificationHistoryQuery query);
+}

--- a/backend/src/main/java/com/easysubway/notification/application/port/in/PushNotificationHistoryUseCase.java
+++ b/backend/src/main/java/com/easysubway/notification/application/port/in/PushNotificationHistoryUseCase.java
@@ -2,13 +2,17 @@ package com.easysubway.notification.application.port.in;
 
 import com.easysubway.common.domain.PageResult;
 import com.easysubway.notification.domain.PushNotification;
+import com.easysubway.notification.domain.PushNotificationFailureReasonCount;
+import java.util.List;
 
 /**
- * 관리자 푸시 발송 이력 조회(#1746). 필터·페이지네이션이 적용된 이력과 총 건수를 준다.
+ * 관리자 푸시 발송 이력 조회(#1746). 필터·페이지네이션이 적용된 이력·총 건수·실패 사유 분해를 준다.
  */
 public interface PushNotificationHistoryUseCase {
 
 	PageResult<PushNotification> searchPushNotifications(PushNotificationHistoryQuery query);
 
 	long countPushNotifications(PushNotificationHistoryQuery query);
+
+	List<PushNotificationFailureReasonCount> summarizeFailureReasons(PushNotificationHistoryQuery query);
 }

--- a/backend/src/main/java/com/easysubway/notification/application/port/in/PushNotificationResendUseCase.java
+++ b/backend/src/main/java/com/easysubway/notification/application/port/in/PushNotificationResendUseCase.java
@@ -1,0 +1,11 @@
+package com.easysubway.notification.application.port.in;
+
+import com.easysubway.notification.domain.PushNotificationResendResult;
+
+/**
+ * 실패 푸시 재발송(#1746). 멱등(성공 건 제외)·상한(대량 오발송 방지)을 보장한다.
+ */
+public interface PushNotificationResendUseCase {
+
+	PushNotificationResendResult resend(ResendPushNotificationsCommand command);
+}

--- a/backend/src/main/java/com/easysubway/notification/application/port/in/ResendPushNotificationsCommand.java
+++ b/backend/src/main/java/com/easysubway/notification/application/port/in/ResendPushNotificationsCommand.java
@@ -1,0 +1,22 @@
+package com.easysubway.notification.application.port.in;
+
+import java.util.List;
+
+/**
+ * 실패 푸시 재발송 명령(#1746). 선택한 알림 식별자와 1회 재발송 상한을 담는다.
+ *
+ * <p>상한(maxPerResend)은 공통코드로 관리되며 컨트롤러에서 주입한다. 대량 오발송을 막기 위해 선택 건수가
+ * 상한을 넘으면 서비스가 재발송을 차단한다. 멱등: 이미 발송 성공(SENT)한 건은 재발송 대상에서 제외된다.
+ */
+public record ResendPushNotificationsCommand(List<String> notificationIds, int maxPerResend) {
+
+	public ResendPushNotificationsCommand {
+		notificationIds = notificationIds == null
+			? List.of()
+			: notificationIds.stream()
+				.filter(id -> id != null && !id.isBlank())
+				.map(String::trim)
+				.distinct()
+				.toList();
+	}
+}

--- a/backend/src/main/java/com/easysubway/notification/application/port/out/SearchPushNotificationOutboxPort.java
+++ b/backend/src/main/java/com/easysubway/notification/application/port/out/SearchPushNotificationOutboxPort.java
@@ -1,0 +1,18 @@
+package com.easysubway.notification.application.port.out;
+
+import com.easysubway.notification.application.port.in.PushNotificationHistoryQuery;
+import com.easysubway.notification.domain.PushNotification;
+import java.util.List;
+
+/**
+ * 관리자 발송 이력 콘솔(#1746)의 outbox 조회 포트.
+ *
+ * <p>필터·페이지네이션이 적용된 이력 목록과 그 총 건수를 준다. 목록과 건수가 같은 질의를 공유해
+ * 페이지네이션·정합을 보장한다.
+ */
+public interface SearchPushNotificationOutboxPort {
+
+	List<PushNotification> searchPushNotifications(PushNotificationHistoryQuery query);
+
+	long countPushNotifications(PushNotificationHistoryQuery query);
+}

--- a/backend/src/main/java/com/easysubway/notification/application/port/out/SearchPushNotificationOutboxPort.java
+++ b/backend/src/main/java/com/easysubway/notification/application/port/out/SearchPushNotificationOutboxPort.java
@@ -2,17 +2,24 @@ package com.easysubway.notification.application.port.out;
 
 import com.easysubway.notification.application.port.in.PushNotificationHistoryQuery;
 import com.easysubway.notification.domain.PushNotification;
+import com.easysubway.notification.domain.PushNotificationFailureReasonCount;
 import java.util.List;
 
 /**
  * 관리자 발송 이력 콘솔(#1746)의 outbox 조회 포트.
  *
- * <p>필터·페이지네이션이 적용된 이력 목록과 그 총 건수를 준다. 목록과 건수가 같은 질의를 공유해
- * 페이지네이션·정합을 보장한다.
+ * <p>필터·페이지네이션이 적용된 이력 목록과 그 총 건수, 실패 사유별 분해를 준다. 목록·건수·분해가
+ * 같은 질의를 공유해 페이지네이션·정합을 보장한다.
  */
 public interface SearchPushNotificationOutboxPort {
 
 	List<PushNotification> searchPushNotifications(PushNotificationHistoryQuery query);
 
 	long countPushNotifications(PushNotificationHistoryQuery query);
+
+	/**
+	 * 같은 필터 컨텍스트(기간·유형·검색)에서 status=FAILED 를 사유별로 GROUP BY 한 분해. 사유 드릴다운·상태
+	 * 필터는 무시한다(분해는 항상 실패 전체를 사유별로 보여줘야 함). 건수 내림차순.
+	 */
+	List<PushNotificationFailureReasonCount> countFailureReasons(PushNotificationHistoryQuery query);
 }

--- a/backend/src/main/java/com/easysubway/notification/application/port/out/SearchPushNotificationOutboxPort.java
+++ b/backend/src/main/java/com/easysubway/notification/application/port/out/SearchPushNotificationOutboxPort.java
@@ -17,6 +17,9 @@ public interface SearchPushNotificationOutboxPort {
 
 	long countPushNotifications(PushNotificationHistoryQuery query);
 
+	/** 선택한 알림 식별자들의 현재 상태를 로드한다(재발송 대상 검증·멱등 판정용). 순서·존재는 보장하지 않는다. */
+	List<PushNotification> loadPushNotificationsByIds(List<String> notificationIds);
+
 	/**
 	 * 같은 필터 컨텍스트(기간·유형·검색)에서 status=FAILED 를 사유별로 GROUP BY 한 분해. 사유 드릴다운·상태
 	 * 필터는 무시한다(분해는 항상 실패 전체를 사유별로 보여줘야 함). 건수 내림차순.

--- a/backend/src/main/java/com/easysubway/notification/application/service/PushNotificationHistoryService.java
+++ b/backend/src/main/java/com/easysubway/notification/application/service/PushNotificationHistoryService.java
@@ -1,0 +1,30 @@
+package com.easysubway.notification.application.service;
+
+import com.easysubway.common.domain.PageResult;
+import com.easysubway.notification.application.port.in.PushNotificationHistoryQuery;
+import com.easysubway.notification.application.port.in.PushNotificationHistoryUseCase;
+import com.easysubway.notification.application.port.out.SearchPushNotificationOutboxPort;
+import com.easysubway.notification.domain.PushNotification;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PushNotificationHistoryService implements PushNotificationHistoryUseCase {
+
+	private final SearchPushNotificationOutboxPort searchPushNotificationOutboxPort;
+
+	public PushNotificationHistoryService(SearchPushNotificationOutboxPort searchPushNotificationOutboxPort) {
+		this.searchPushNotificationOutboxPort = searchPushNotificationOutboxPort;
+	}
+
+	@Override
+	public PageResult<PushNotification> searchPushNotifications(PushNotificationHistoryQuery query) {
+		List<PushNotification> items = searchPushNotificationOutboxPort.searchPushNotifications(query);
+		return new PageResult<>(items, query.page(), query.size(), false);
+	}
+
+	@Override
+	public long countPushNotifications(PushNotificationHistoryQuery query) {
+		return searchPushNotificationOutboxPort.countPushNotifications(query);
+	}
+}

--- a/backend/src/main/java/com/easysubway/notification/application/service/PushNotificationHistoryService.java
+++ b/backend/src/main/java/com/easysubway/notification/application/service/PushNotificationHistoryService.java
@@ -5,6 +5,7 @@ import com.easysubway.notification.application.port.in.PushNotificationHistoryQu
 import com.easysubway.notification.application.port.in.PushNotificationHistoryUseCase;
 import com.easysubway.notification.application.port.out.SearchPushNotificationOutboxPort;
 import com.easysubway.notification.domain.PushNotification;
+import com.easysubway.notification.domain.PushNotificationFailureReasonCount;
 import java.util.List;
 import org.springframework.stereotype.Service;
 
@@ -26,5 +27,10 @@ public class PushNotificationHistoryService implements PushNotificationHistoryUs
 	@Override
 	public long countPushNotifications(PushNotificationHistoryQuery query) {
 		return searchPushNotificationOutboxPort.countPushNotifications(query);
+	}
+
+	@Override
+	public List<PushNotificationFailureReasonCount> summarizeFailureReasons(PushNotificationHistoryQuery query) {
+		return searchPushNotificationOutboxPort.countFailureReasons(query);
 	}
 }

--- a/backend/src/main/java/com/easysubway/notification/application/service/PushNotificationResendService.java
+++ b/backend/src/main/java/com/easysubway/notification/application/service/PushNotificationResendService.java
@@ -1,0 +1,73 @@
+package com.easysubway.notification.application.service;
+
+import com.easysubway.notification.application.port.in.DeliverPushNotificationsCommand;
+import com.easysubway.notification.application.port.in.PushNotificationDeliveryUseCase;
+import com.easysubway.notification.application.port.in.PushNotificationResendUseCase;
+import com.easysubway.notification.application.port.in.ResendPushNotificationsCommand;
+import com.easysubway.notification.application.port.out.SavePushNotificationOutboxPort;
+import com.easysubway.notification.application.port.out.SearchPushNotificationOutboxPort;
+import com.easysubway.notification.domain.PushNotification;
+import com.easysubway.notification.domain.PushNotificationResendResult;
+import com.easysubway.notification.domain.PushNotificationStatus;
+import java.util.List;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PushNotificationResendService implements PushNotificationResendUseCase {
+
+	private final SearchPushNotificationOutboxPort searchPushNotificationOutboxPort;
+	private final SavePushNotificationOutboxPort savePushNotificationOutboxPort;
+	private final PushNotificationDeliveryUseCase pushNotificationDeliveryUseCase;
+
+	public PushNotificationResendService(
+		SearchPushNotificationOutboxPort searchPushNotificationOutboxPort,
+		SavePushNotificationOutboxPort savePushNotificationOutboxPort,
+		PushNotificationDeliveryUseCase pushNotificationDeliveryUseCase
+	) {
+		this.searchPushNotificationOutboxPort = searchPushNotificationOutboxPort;
+		this.savePushNotificationOutboxPort = savePushNotificationOutboxPort;
+		this.pushNotificationDeliveryUseCase = pushNotificationDeliveryUseCase;
+	}
+
+	@Override
+	public PushNotificationResendResult resend(ResendPushNotificationsCommand command) {
+		List<String> ids = command.notificationIds();
+		int requested = ids.size();
+		if (requested == 0) {
+			return new PushNotificationResendResult(0, 0, 0, false, command.maxPerResend());
+		}
+		// 대량 오발송 방지: 선택 건수가 1회 상한을 넘으면 아무것도 발송하지 않고 차단한다.
+		if (command.maxPerResend() > 0 && requested > command.maxPerResend()) {
+			return PushNotificationResendResult.blocked(requested, command.maxPerResend());
+		}
+
+		Map<String, PushNotification> byId = searchPushNotificationOutboxPort.loadPushNotificationsByIds(ids).stream()
+			.collect(Collectors.toMap(PushNotification::notificationId, Function.identity(), (first, second) -> first));
+
+		// 멱등: 실패 상태였던 건만 대기(PENDING)로 되돌린다(성공·대기·처리중·없는 건은 건너뜀).
+		Set<String> affectedUserIds = new LinkedHashSet<>();
+		int resent = 0;
+		for (String id : ids) {
+			PushNotification notification = byId.get(id);
+			if (notification == null || notification.status() != PushNotificationStatus.FAILED) {
+				continue;
+			}
+			savePushNotificationOutboxPort.savePushNotification(
+				notification.withStatus(PushNotificationStatus.PENDING));
+			affectedUserIds.add(notification.userId());
+			resent++;
+		}
+
+		// 되돌린 건을 즉시 전달 시도한다(기존 배송 유스케이스 재사용). 발송 어댑터 미설정 시 다시 실패로 남는다.
+		for (String userId : affectedUserIds) {
+			pushNotificationDeliveryUseCase.deliverPending(new DeliverPushNotificationsCommand(userId));
+		}
+
+		return new PushNotificationResendResult(requested, resent, requested - resent, false, command.maxPerResend());
+	}
+}

--- a/backend/src/main/java/com/easysubway/notification/domain/PushNotificationFailureReasonCount.java
+++ b/backend/src/main/java/com/easysubway/notification/domain/PushNotificationFailureReasonCount.java
@@ -1,0 +1,8 @@
+package com.easysubway.notification.domain;
+
+/**
+ * 관리자 발송 이력 콘솔(#1746)의 실패 사유별 분해 한 줄. 같은 필터 컨텍스트(기간·유형·검색)에서
+ * status=FAILED 를 사유별로 GROUP BY 한 건수라, 사유 드릴다운으로 필터한 목록 건수와 정합한다.
+ */
+public record PushNotificationFailureReasonCount(String reason, long count) {
+}

--- a/backend/src/main/java/com/easysubway/notification/domain/PushNotificationResendResult.java
+++ b/backend/src/main/java/com/easysubway/notification/domain/PushNotificationResendResult.java
@@ -1,0 +1,20 @@
+package com.easysubway.notification.domain;
+
+/**
+ * 실패 푸시 재발송 결과(#1746).
+ *
+ * <p>{@code blocked}면 상한 초과로 아무것도 재발송하지 않았다. 그 외에는 선택 건수(requested) 중 실패
+ * 상태였던 건만 재발송(resent)하고 나머지(이미 성공·대기·없음)는 멱등하게 건너뛴다(skipped).
+ */
+public record PushNotificationResendResult(
+	int requestedCount,
+	int resentCount,
+	int skippedCount,
+	boolean blocked,
+	int maxPerResend
+) {
+
+	public static PushNotificationResendResult blocked(int requestedCount, int maxPerResend) {
+		return new PushNotificationResendResult(requestedCount, 0, 0, true, maxPerResend);
+	}
+}

--- a/backend/src/main/resources/db/migration/h2/V41__push_resend_limit_common_code.sql
+++ b/backend/src/main/resources/db/migration/h2/V41__push_resend_limit_common_code.sql
@@ -1,0 +1,7 @@
+-- 푸시 재발송 1회 상한(#1746): 대량 오발송 방지를 위해 공통코드로 관리한다.
+-- 상한 값은 code 문자열에 숫자로 담고, 관리자 공통코드 콘솔에서 변경한다(비활성 후 새 값 추가).
+INSERT INTO admin_common_code_groups (group_code, display_name, description, sort_order, enabled, created_at, updated_at)
+VALUES ('PUSH_RESEND_LIMIT', '푸시 재발송 상한', '1회 재발송으로 처리할 수 있는 최대 건수', 70, TRUE, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+INSERT INTO admin_common_codes (group_code, code, display_name, description, sort_order, enabled, created_at, updated_at)
+VALUES ('PUSH_RESEND_LIMIT', '50', '1회 재발송 상한(건)', '한 번에 재발송할 수 있는 최대 실패 건수', 10, TRUE, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);

--- a/backend/src/main/resources/db/migration/postgresql/V41__push_resend_limit_common_code.sql
+++ b/backend/src/main/resources/db/migration/postgresql/V41__push_resend_limit_common_code.sql
@@ -1,0 +1,7 @@
+-- 푸시 재발송 1회 상한(#1746): 대량 오발송 방지를 위해 공통코드로 관리한다.
+-- 상한 값은 code 문자열에 숫자로 담고, 관리자 공통코드 콘솔에서 변경한다(비활성 후 새 값 추가).
+INSERT INTO admin_common_code_groups (group_code, display_name, description, sort_order, enabled, created_at, updated_at)
+VALUES ('PUSH_RESEND_LIMIT', '푸시 재발송 상한', '1회 재발송으로 처리할 수 있는 최대 건수', 70, TRUE, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+INSERT INTO admin_common_codes (group_code, code, display_name, description, sort_order, enabled, created_at, updated_at)
+VALUES ('PUSH_RESEND_LIMIT', '50', '1회 재발송 상한(건)', '한 번에 재발송할 수 있는 최대 실패 건수', 10, TRUE, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);

--- a/backend/src/main/resources/static/css/admin-v3.css
+++ b/backend/src/main/resources/static/css/admin-v3.css
@@ -1825,6 +1825,28 @@ body.admin-v3 {
 }
 
 /* 발송 이력 콘솔(#1746) */
+.admin-v3 .card-sparkline {
+	display: block;
+	width: 100%;
+	height: 24px;
+	margin-top: 6px;
+}
+
+.admin-v3 .card-sparkline polyline {
+	stroke: #b3261e;
+	stroke-width: 1.5;
+	vector-effect: non-scaling-stroke;
+}
+
+.admin-v3 .metric .card-sparkline polyline {
+	fill: none;
+}
+
+.admin-v3 .delivery-alert-link {
+	margin: -8px 0 12px;
+	font-size: 14px;
+}
+
 .admin-v3 .section-hint {
 	color: #5f6b7a;
 	font-size: 13px;

--- a/backend/src/main/resources/static/css/admin-v3.css
+++ b/backend/src/main/resources/static/css/admin-v3.css
@@ -1823,3 +1823,109 @@ body.admin-v3 {
 	width: 100%;
 	height: 100%;
 }
+
+/* 발송 이력 콘솔(#1746) */
+.admin-v3 .section-hint {
+	color: #5f6b7a;
+	font-size: 13px;
+	margin: 4px 0 12px;
+}
+
+.admin-v3 .table-summary {
+	color: #384250;
+	font-size: 14px;
+	margin: 12px 0;
+}
+
+.admin-v3 .table-summary .filter-clear {
+	margin-left: 6px;
+	font-size: 13px;
+}
+
+.admin-v3 .status-badge {
+	display: inline-block;
+	padding: 2px 8px;
+	border-radius: 10px;
+	font-size: 12px;
+	background: #eef1f5;
+	color: #384250;
+}
+
+.admin-v3 .status-badge.tone-ok {
+	background: #e4f4ea;
+	color: #1f7a44;
+}
+
+.admin-v3 .status-badge.tone-failure {
+	background: #fbe6e6;
+	color: #b3261e;
+}
+
+.admin-v3 .status-badge.tone-pending {
+	background: #fff2da;
+	color: #8a5a00;
+}
+
+.admin-v3 .row-detail summary {
+	cursor: pointer;
+	color: #2456b3;
+}
+
+.admin-v3 .row-detail-list {
+	margin: 8px 0 0;
+	display: grid;
+	grid-template-columns: max-content 1fr;
+	gap: 4px 12px;
+}
+
+.admin-v3 .row-detail-list dt {
+	color: #5f6b7a;
+	font-size: 13px;
+}
+
+.admin-v3 .row-detail-list dd {
+	margin: 0;
+	font-size: 13px;
+}
+
+.admin-v3 .failure-breakdown {
+	margin: 16px 0;
+}
+
+.admin-v3 .breakdown-bars {
+	list-style: none;
+	margin: 8px 0 0;
+	padding: 0;
+	display: grid;
+	gap: 6px;
+}
+
+.admin-v3 .breakdown-bars a {
+	display: grid;
+	grid-template-columns: minmax(140px, 1fr) 2fr max-content;
+	align-items: center;
+	gap: 12px;
+	text-decoration: none;
+	color: #384250;
+	padding: 4px 8px;
+	border-radius: 6px;
+}
+
+.admin-v3 .breakdown-bars a:hover,
+.admin-v3 .breakdown-bars a[aria-current="true"] {
+	background: #eef4ff;
+}
+
+.admin-v3 .breakdown-bar {
+	width: 100%;
+	height: 12px;
+}
+
+.admin-v3 .breakdown-bar rect {
+	fill: #b3261e;
+}
+
+.admin-v3 .breakdown-count {
+	font-variant-numeric: tabular-nums;
+	text-align: right;
+}

--- a/backend/src/main/resources/static/js/admin/app.js
+++ b/backend/src/main/resources/static/js/admin/app.js
@@ -456,6 +456,10 @@ document.addEventListener('alpine:init', function () {
 			get hasSelection() {
 				return this.count > 0;
 			},
+			// CSP 빌드는 x-bind 안의 연산자(!)를 평가하지 않는다 — 부정은 getter로 노출한다.
+			get submitDisabled() {
+				return this.count === 0;
+			},
 			recount: function () {
 				this.count = this.$root.querySelectorAll('input[name="notificationIds"]:checked').length;
 			},

--- a/backend/src/main/resources/static/js/admin/app.js
+++ b/backend/src/main/resources/static/js/admin/app.js
@@ -444,4 +444,21 @@ document.addEventListener('alpine:init', function () {
 			},
 		};
 	});
+
+	// 실패 푸시 재발송 선택(#1746): 확인 단계에 선택 건수를 보여주고, 선택이 없으면 제출을 막는다.
+	// 진화형 향상 — no-JS에서는 버튼이 항상 활성이고 서버가 빈 선택을 안내한다. 런타임/키 검증은 #1749.
+	Alpine.data('pushResendSelection', function () {
+		return {
+			count: 0,
+			get selectionLabel() {
+				return this.count > 0 ? '선택한 실패 ' + this.count + '건 재발송' : '재발송할 실패 건 선택';
+			},
+			get hasSelection() {
+				return this.count > 0;
+			},
+			recount: function () {
+				this.count = this.$root.querySelectorAll('input[name="notificationIds"]:checked').length;
+			},
+		};
+	});
 });

--- a/backend/src/main/resources/templates/admin/notifications/push.html
+++ b/backend/src/main/resources/templates/admin/notifications/push.html
@@ -238,7 +238,7 @@
 						<td>
 							<input type="checkbox" name="notificationIds" th:value="${row.notificationId}"
 							       th:if="${row.statusTone == 'failure'}"
-							       th:attr="aria-label=|재발송 선택 ${row.title}|">
+							       aria-label="재발송 대상 선택">
 						</td>
 						<td th:text="${#temporals.format(row.createdAt, 'yyyy-MM-dd HH:mm')}">2026-07-06 09:00</td>
 						<td th:text="${row.typeLabel}">제보 처리 상태</td>

--- a/backend/src/main/resources/templates/admin/notifications/push.html
+++ b/backend/src/main/resources/templates/admin/notifications/push.html
@@ -273,7 +273,7 @@
 					<p>선택한 실패 알림을 재발송합니다. 이미 발송 성공한 건은 자동으로 제외되며,
 						한 번에 최대 <strong th:text="${resendLimit}">50</strong>건까지 처리합니다.
 						상한을 넘으면 재발송되지 않으니 나눠서 처리하세요.</p>
-					<button type="submit" x-bind:disabled="!hasSelection">선택한 실패 건 재발송</button>
+					<button type="submit" x-bind:disabled="submitDisabled">선택한 실패 건 재발송</button>
 				</details>
 			</form>
 

--- a/backend/src/main/resources/templates/admin/notifications/push.html
+++ b/backend/src/main/resources/templates/admin/notifications/push.html
@@ -132,6 +132,91 @@
 			</tbody>
 		</table>
 	</section>
+
+	<section aria-labelledby="push-history-heading">
+		<h2 id="push-history-heading">발송 이력</h2>
+		<p class="section-hint">수신자 식별자는 개인정보 보호를 위해 마스킹됩니다. 열람 기록은 감사 로그에 남습니다.</p>
+
+		<!--
+		  발송 이력 표준 테이블(#1746): 기간·상태·유형 필터·내용 검색·페이지네이션을 historyResults fragment로 묶는다.
+		  필터·페이지 링크는 th:href(진화형 향상 fallback)와 hx-get을 함께 갖는다. JS가 있으면 htmx가
+		  이 컨테이너만 부분 갱신하고, 없으면 링크·폼 제출로 풀페이지가 동작한다.
+		  hx-target·hx-swap·hx-push-url은 이 컨테이너에서 하위 링크로 상속된다.
+		-->
+		<div id="push-history" th:fragment="historyResults"
+		     hx-target="#push-history" hx-swap="outerHTML" hx-push-url="true">
+			<form class="table-toolbar" method="get" th:action="@{/admin/notifications/push/history}"
+			      role="search" aria-label="발송 이력 검색"
+			      hx-target="#push-history" hx-swap="outerHTML" hx-push-url="true"
+			      th:attr="hx-get=@{/admin/notifications/push/history}"
+			      hx-trigger="submit, change, keyup changed delay:300ms">
+				<input type="search" name="keyword" th:value="${historyKeyword}"
+				       placeholder="제목·본문 검색" aria-label="발송 내용 검색" autocomplete="off">
+				<select name="status" aria-label="발송 상태 필터">
+					<option th:each="opt : ${historyStatusOptions}" th:value="${opt.value}"
+					        th:text="${opt.label}" th:selected="${opt.selected}">상태 전체</option>
+				</select>
+				<select name="type" aria-label="알림 유형 필터">
+					<option th:each="opt : ${historyTypeOptions}" th:value="${opt.value}"
+					        th:text="${opt.label}" th:selected="${opt.selected}">유형 전체</option>
+				</select>
+				<input type="date" name="from" th:value="${historyFrom}" aria-label="발송 기간 시작">
+				<input type="date" name="to" th:value="${historyTo}" aria-label="발송 기간 종료">
+				<button type="submit">검색</button>
+			</form>
+
+			<p class="table-summary" aria-live="polite">
+				전체 <strong th:text="${historyTotal}">0</strong>건
+			</p>
+
+			<table th:if="${!historyRows.isEmpty()}">
+				<caption class="sr-only">푸시 발송 이력</caption>
+				<thead>
+				<tr>
+					<th scope="col">발송 시각</th>
+					<th scope="col">유형</th>
+					<th scope="col">상태</th>
+					<th scope="col">수신자</th>
+					<th scope="col">제목</th>
+					<th scope="col">상세</th>
+				</tr>
+				</thead>
+				<tbody>
+				<tr th:each="row : ${historyRows}">
+					<td th:text="${#temporals.format(row.createdAt, 'yyyy-MM-dd HH:mm')}">2026-07-06 09:00</td>
+					<td th:text="${row.typeLabel}">제보 처리 상태</td>
+					<td>
+						<span class="status-badge" th:classappend="${'tone-' + row.statusTone}"
+						      th:text="${row.statusLabel}">발송 완료</span>
+					</td>
+					<td th:text="${row.maskedUserId}">ano••••</td>
+					<td th:text="${row.title}">알림 제목</td>
+					<td>
+						<details class="row-detail">
+							<summary>시도 이력</summary>
+							<dl class="row-detail-list">
+								<dt>기기 토큰</dt>
+								<dd th:text="${row.maskedDeviceToken}">device••••</dd>
+								<dt>플랫폼</dt>
+								<dd th:text="${row.platformLabel}">안드로이드</dd>
+								<dt>발송 상태</dt>
+								<dd th:text="${row.statusLabel}">발송 완료</dd>
+								<dt th:if="${row.failureReason != null}">실패 사유</dt>
+								<dd th:if="${row.failureReason != null}" class="failure-reason"
+								    th:text="${row.failureReason}">외부 발송 어댑터가 설정되지 않았습니다.</dd>
+							</dl>
+						</details>
+					</td>
+				</tr>
+				</tbody>
+			</table>
+
+			<div th:if="${historyRows.isEmpty()}"
+			     th:replace="~{admin/fragments/empty-state :: panel('조건에 맞는 발송 이력이 없습니다.', '필터를 변경하거나 기간을 넓혀 보세요.')}"></div>
+
+			<div th:replace="~{admin/fragments/pagination :: pager('발송 이력 페이지', ${historyPage}, ${historyPaginationLinks})}"></div>
+		</div>
+	</section>
 </main>
 </div>
 <th:block th:replace="~{admin/fragments/shell :: scripts}"></th:block>

--- a/backend/src/main/resources/templates/admin/notifications/push.html
+++ b/backend/src/main/resources/templates/admin/notifications/push.html
@@ -145,10 +145,10 @@
 		-->
 		<div id="push-history" th:fragment="historyResults"
 		     hx-target="#push-history" hx-swap="outerHTML" hx-push-url="true">
-			<form class="table-toolbar" method="get" th:action="@{/admin/notifications/push/history}"
+			<form class="table-toolbar" method="get" th:action="@{/admin/notifications/push/page/history}"
 			      role="search" aria-label="발송 이력 검색"
 			      hx-target="#push-history" hx-swap="outerHTML" hx-push-url="true"
-			      th:attr="hx-get=@{/admin/notifications/push/history}"
+			      th:attr="hx-get=@{/admin/notifications/push/page/history}"
 			      hx-trigger="submit, change, keyup changed delay:300ms">
 				<input type="search" name="keyword" th:value="${historyKeyword}"
 				       placeholder="제목·본문 검색" aria-label="발송 내용 검색" autocomplete="off">
@@ -197,47 +197,73 @@
 				</ul>
 			</section>
 
-			<table th:if="${!historyRows.isEmpty()}">
-				<caption class="sr-only">푸시 발송 이력</caption>
-				<thead>
-				<tr>
-					<th scope="col">발송 시각</th>
-					<th scope="col">유형</th>
-					<th scope="col">상태</th>
-					<th scope="col">수신자</th>
-					<th scope="col">제목</th>
-					<th scope="col">상세</th>
-				</tr>
-				</thead>
-				<tbody>
-				<tr th:each="row : ${historyRows}">
-					<td th:text="${#temporals.format(row.createdAt, 'yyyy-MM-dd HH:mm')}">2026-07-06 09:00</td>
-					<td th:text="${row.typeLabel}">제보 처리 상태</td>
-					<td>
-						<span class="status-badge" th:classappend="${'tone-' + row.statusTone}"
-						      th:text="${row.statusLabel}">발송 완료</span>
-					</td>
-					<td th:text="${row.maskedUserId}">ano••••</td>
-					<td th:text="${row.title}">알림 제목</td>
-					<td>
-						<details class="row-detail">
-							<summary>시도 이력</summary>
-							<dl class="row-detail-list">
-								<dt>기기 토큰</dt>
-								<dd th:text="${row.maskedDeviceToken}">device••••</dd>
-								<dt>플랫폼</dt>
-								<dd th:text="${row.platformLabel}">안드로이드</dd>
-								<dt>발송 상태</dt>
-								<dd th:text="${row.statusLabel}">발송 완료</dd>
-								<dt th:if="${row.failureReason != null}">실패 사유</dt>
-								<dd th:if="${row.failureReason != null}" class="failure-reason"
-								    th:text="${row.failureReason}">외부 발송 어댑터가 설정되지 않았습니다.</dd>
-							</dl>
-						</details>
-					</td>
-				</tr>
-				</tbody>
-			</table>
+			<!--
+			  재발송 안전장치(#1746): 실패 행을 선택 → 재발송. no-JS 폼 기준선(command token + CSRF는 인터셉터가 검증).
+			  멱등(이미 성공한 건 서버가 제외)·1회 상한(대량 오발송 방지)은 유스케이스가 보장한다. 확인 단계는
+			  네이티브 details 안의 제출 버튼이며, JS가 있으면 선택 건수를 보여주고 선택이 없으면 제출을 막는다.
+			-->
+			<form th:if="${!historyRows.isEmpty()}" method="post"
+			      th:action="@{/admin/notifications/push/resend}" class="resend-form"
+			      x-data="pushResendSelection" x-on:change="recount">
+				<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+				<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
+				<input type="hidden" name="returnTo" th:value="${currentListHref}">
+				<table>
+					<caption class="sr-only">푸시 발송 이력</caption>
+					<thead>
+					<tr>
+						<th scope="col"><span class="sr-only">재발송 선택</span></th>
+						<th scope="col">발송 시각</th>
+						<th scope="col">유형</th>
+						<th scope="col">상태</th>
+						<th scope="col">수신자</th>
+						<th scope="col">제목</th>
+						<th scope="col">상세</th>
+					</tr>
+					</thead>
+					<tbody>
+					<tr th:each="row : ${historyRows}">
+						<td>
+							<input type="checkbox" name="notificationIds" th:value="${row.notificationId}"
+							       th:if="${row.statusTone == 'failure'}"
+							       th:attr="aria-label=|재발송 선택 ${row.title}|">
+						</td>
+						<td th:text="${#temporals.format(row.createdAt, 'yyyy-MM-dd HH:mm')}">2026-07-06 09:00</td>
+						<td th:text="${row.typeLabel}">제보 처리 상태</td>
+						<td>
+							<span class="status-badge" th:classappend="${'tone-' + row.statusTone}"
+							      th:text="${row.statusLabel}">발송 완료</span>
+						</td>
+						<td th:text="${row.maskedUserId}">ano••••</td>
+						<td th:text="${row.title}">알림 제목</td>
+						<td>
+							<details class="row-detail">
+								<summary>시도 이력</summary>
+								<dl class="row-detail-list">
+									<dt>기기 토큰</dt>
+									<dd th:text="${row.maskedDeviceToken}">device••••</dd>
+									<dt>플랫폼</dt>
+									<dd th:text="${row.platformLabel}">안드로이드</dd>
+									<dt>발송 상태</dt>
+									<dd th:text="${row.statusLabel}">발송 완료</dd>
+									<dt th:if="${row.failureReason != null}">실패 사유</dt>
+									<dd th:if="${row.failureReason != null}" class="failure-reason"
+									    th:text="${row.failureReason}">외부 발송 어댑터가 설정되지 않았습니다.</dd>
+								</dl>
+							</details>
+						</td>
+					</tr>
+					</tbody>
+				</table>
+
+				<details class="resend-confirm">
+					<summary><span x-text="selectionLabel">선택한 실패 건 재발송</span></summary>
+					<p>선택한 실패 알림을 재발송합니다. 이미 발송 성공한 건은 자동으로 제외되며,
+						한 번에 최대 <strong th:text="${resendLimit}">50</strong>건까지 처리합니다.
+						상한을 넘으면 재발송되지 않으니 나눠서 처리하세요.</p>
+					<button type="submit" x-bind:disabled="!hasSelection">선택한 실패 건 재발송</button>
+				</details>
+			</form>
 
 			<div th:if="${historyRows.isEmpty()}"
 			     th:replace="~{admin/fragments/empty-state :: panel('조건에 맞는 발송 이력이 없습니다.', '필터를 변경하거나 기간을 넓혀 보세요.')}"></div>

--- a/backend/src/main/resources/templates/admin/notifications/push.html
+++ b/backend/src/main/resources/templates/admin/notifications/push.html
@@ -167,7 +167,35 @@
 
 			<p class="table-summary" aria-live="polite">
 				전체 <strong th:text="${historyTotal}">0</strong>건
+				<span th:if="${hasReasonFilter}">
+					· 사유: <strong th:text="${selectedReason}">실패 사유</strong>
+					<a th:href="${clearReasonHref}" th:attr="hx-get=${clearReasonHref}" class="filter-clear">해제</a>
+				</span>
 			</p>
+
+			<!--
+			  실패 사유별 분해(#1746): 같은 필터 컨텍스트에서 status=FAILED 를 사유별로 GROUP BY 한 막대.
+			  막대는 CSP-safe한 서버 SVG(인라인 style 금지)로 그리며, 각 막대는 사유 드릴다운 링크다.
+			  분해 수치 = 해당 사유로 필터한 목록 건수(같은 질의 공유).
+			-->
+			<section class="failure-breakdown" th:if="${!failureBreakdown.isEmpty()}"
+			         aria-labelledby="push-failure-breakdown-heading">
+				<h3 id="push-failure-breakdown-heading">실패 사유별 분해</h3>
+				<ul class="breakdown-bars">
+					<li th:each="bar : ${failureBreakdown}">
+						<a th:href="${bar.href}"
+						   th:attr="hx-get=${bar.href},aria-current=${bar.active ? 'true' : null}"
+						   th:title="|${bar.reason} · ${bar.count}건|">
+							<span class="breakdown-reason" th:text="${bar.reason}">발송 어댑터 미설정</span>
+							<svg class="breakdown-bar" viewBox="0 0 100 12" preserveAspectRatio="none"
+							     role="img" th:attr="aria-label=|${bar.reason} ${bar.count}건|">
+								<rect x="0" y="0" height="12" th:attr="width=${bar.percent}"></rect>
+							</svg>
+							<span class="breakdown-count" th:text="${bar.count}">0</span>
+						</a>
+					</li>
+				</ul>
+			</section>
 
 			<table th:if="${!historyRows.isEmpty()}">
 				<caption class="sr-only">푸시 발송 이력</caption>

--- a/backend/src/main/resources/templates/admin/notifications/push.html
+++ b/backend/src/main/resources/templates/admin/notifications/push.html
@@ -37,10 +37,18 @@
 		<div class="metric">
 			<span>발송 실패</span>
 			<strong th:text="${summary.failedCount}">0</strong>
+			<svg th:if="${failedSparkline != ''}" class="card-sparkline" viewBox="0 0 100 24"
+			     preserveAspectRatio="none" role="img" aria-label="발송 실패 최근 7일 추이">
+				<polyline th:attr="points=${failedSparkline}" fill="none"></polyline>
+			</svg>
 		</div>
 		<div class="metric">
 			<span>발송 시도</span>
 			<strong th:text="${summary.deliveryAttemptCount}">0</strong>
+			<svg th:if="${attemptedSparkline != ''}" class="card-sparkline" viewBox="0 0 100 24"
+			     preserveAspectRatio="none" role="img" aria-label="발송 시도 최근 7일 추이">
+				<polyline th:attr="points=${attemptedSparkline}" fill="none"></polyline>
+			</svg>
 		</div>
 		<div class="metric">
 			<span>발송 성공률</span>
@@ -55,6 +63,10 @@
 	<p th:class="'delivery-alert ' + ${summary.failureAlertClass}"
 	   th:text="${summary.failureAlertLabel} + ': ' + ${summary.failureAlertDescription}">
 		점검 필요: 발송 실패가 있어 푸시 어댑터와 provider 상태를 확인하세요.
+	</p>
+
+	<p class="delivery-alert-link" th:if="${summary.failedCount > 0}">
+		<a th:href="${failedHistoryHref}">실패 발송 목록 보기</a>
 	</p>
 
 	<p class="failure-reason"

--- a/backend/src/main/resources/templates/admin/notifications/push.html
+++ b/backend/src/main/resources/templates/admin/notifications/push.html
@@ -61,6 +61,58 @@
 	   th:if="${summary.latestFailureReason != null}"
 	   th:text="'최근 실패: ' + ${summary.latestFailureReason}">최근 실패: 외부 푸시 발송 어댑터가 설정되지 않았습니다.</p>
 
+	<div id="push-trends" th:fragment="trends" class="dashboard-trends-section">
+		<div class="trend-periods" role="group" aria-label="추이 기간 선택">
+			<a th:each="d : ${ {7, 30, 90} }"
+			   th:href="@{/admin/notifications/push/page(days=${d})}"
+			   th:attr="hx-get=@{/admin/notifications/push/trends(days=${d})},aria-current=${trendDays == d} ? 'true' : null"
+			   hx-target="#push-trends" hx-swap="outerHTML"
+			   th:classappend="${trendDays == d} ? ' is-active'"
+			   th:text="|${d}일|">7일</a>
+		</div>
+
+		<p class="admin-export">
+			<a class="admin-export-link" th:href="@{/admin/analytics/metrics/export(keys=${exportKeys},days=${trendDays})}"
+			   download>CSV 내보내기</a>
+		</p>
+
+		<div class="metric-grid" aria-label="전 기간 대비 증감">
+			<div th:each="card : ${comparisons}" class="metric" th:classappend="${'tone-' + card.tone}">
+				<span th:text="${card.label}">지표</span>
+				<strong th:text="${card.currentLabel}">0</strong>
+				<em th:text="${'직전 ' + card.previousLabel + ' · ' + card.deltaPercentLabel}">직전 대비</em>
+			</div>
+		</div>
+
+		<div class="trend-charts">
+			<section class="admin-panel trend-chart-panel">
+				<h2 th:text="|발송 시도·실패 최근 ${trendDays}일 추이|">발송 시도·실패 추이</h2>
+				<div class="trend-canvas-wrap">
+					<canvas id="push-trend-canvas" class="trend-canvas" role="img"
+					        th:attr="aria-label=|푸시 발송 최근 ${trendDays}일 추이|,data-chart=${trendJson}"></canvas>
+				</div>
+				<details class="dashboard-details">
+					<summary>데이터 표로 보기</summary>
+					<table>
+						<thead>
+						<tr>
+							<th scope="col">날짜</th>
+							<th th:each="s : ${trendChart.series}" scope="col" th:text="${s.label}">지표</th>
+						</tr>
+						</thead>
+						<tbody>
+						<tr th:each="label, iter : ${trendChart.labels}">
+							<th scope="row" th:text="${label}">날짜</th>
+							<td th:each="s : ${trendChart.series}"
+							    th:text="${s.values[iter.index] != null ? s.values[iter.index] : '—'}">0</td>
+						</tr>
+						</tbody>
+					</table>
+				</details>
+			</section>
+		</div>
+	</div>
+
 	<section>
 		<h2>상태별 알림</h2>
 		<table>
@@ -83,5 +135,7 @@
 </main>
 </div>
 <th:block th:replace="~{admin/fragments/shell :: scripts}"></th:block>
+<th:block th:replace="~{admin/fragments/shell :: chartScripts}"></th:block>
+<script th:src="@{/js/admin/dashboard-charts.js}" defer></script>
 </body>
 </html>

--- a/backend/src/test/java/com/easysubway/admin/alert/AdminAlertServiceTest.java
+++ b/backend/src/test/java/com/easysubway/admin/alert/AdminAlertServiceTest.java
@@ -80,7 +80,7 @@ class AdminAlertServiceTest {
 			.filteredOn(item -> item.id().equals("push-failure"))
 			.singleElement()
 			.satisfies(item -> {
-				assertThat(item.href()).isEqualTo("/admin/notifications/push/page");
+				assertThat(item.href()).isEqualTo("/admin/notifications/push/page?status=FAILED");
 				assertThat(item.tone()).isEqualTo("failure");
 			});
 	}

--- a/backend/src/test/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminPageControllerTest.java
@@ -12,9 +12,12 @@ import com.easysubway.admin.audit.domain.AdminAuditEventType;
 import com.easysubway.notification.application.port.in.NotificationPreferenceUseCase;
 import com.easysubway.notification.application.port.in.RegisterDeviceCommand;
 import com.easysubway.notification.domain.DevicePlatform;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
@@ -140,7 +143,7 @@ class PushNotificationAdminPageControllerTest {
 	@Test
 	@DisplayName("발송 이력 조회는 열람 감사(PRIVACY_READ)를 남긴다")
 	void pushHistoryViewWritesPrivacyReadAudit() throws Exception {
-		mockMvc.perform(get("/admin/notifications/push/history")
+		mockMvc.perform(get("/admin/notifications/push/page/history")
 				.header("HX-Request", "true")
 				.with(httpBasic("admin-user", "admin-test-password")))
 			.andExpect(status().isOk());
@@ -179,7 +182,7 @@ class PushNotificationAdminPageControllerTest {
 		dispatchNotification("REPORT_STATUS", "신고 처리 알림");
 		deliverPendingNotifications();
 
-		String fragment = mockMvc.perform(get("/admin/notifications/push/history")
+		String fragment = mockMvc.perform(get("/admin/notifications/push/page/history")
 				.param("reason", "외부 푸시 발송 어댑터가 설정되지 않았습니다.")
 				.header("HX-Request", "true")
 				.with(httpBasic("admin-user", "admin-test-password")))
@@ -200,7 +203,7 @@ class PushNotificationAdminPageControllerTest {
 		registerDevice();
 		dispatchNotification("REPORT_STATUS", "대기 중 알림");
 
-		String fragment = mockMvc.perform(get("/admin/notifications/push/history")
+		String fragment = mockMvc.perform(get("/admin/notifications/push/page/history")
 				.param("status", "FAILED")
 				.header("HX-Request", "true")
 				.with(httpBasic("admin-user", "admin-test-password")))
@@ -214,6 +217,60 @@ class PushNotificationAdminPageControllerTest {
 			.contains("조건에 맞는 발송 이력이 없습니다.")
 			.doesNotContain("admin-shell")
 			.doesNotContain("대기 중 알림");
+	}
+
+	@Test
+	@DisplayName("재발송은 command token 없이는 차단된다(중복·위조 방지)")
+	void resendRequiresCommandToken() throws Exception {
+		mockMvc.perform(post("/admin/notifications/push/resend")
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("notificationIds", "push-x")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf()))
+			.andExpect(status().isConflict());
+	}
+
+	@Test
+	@DisplayName("실패 건 재발송은 command token으로 처리하고 결과 토스트·감사를 남긴다")
+	void resendFailedNotificationTogglesToPendingAndAudits() throws Exception {
+		registerDevice();
+		dispatchNotification("REPORT_STATUS", "신고 처리 알림");
+		deliverPendingNotifications();
+
+		MockHttpSession session = new MockHttpSession();
+		String html = mockMvc.perform(get("/admin/notifications/push/page")
+				.session(session)
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		// 실패 행의 재발송 체크박스 값과 폼의 command token을 페이지에서 뽑아 no-JS 폼처럼 제출한다.
+		assertThat(html).contains("최대 <strong>50</strong>건");
+		String token = extract(html, "name=\"commandToken\" value=\"([^\"]+)\"");
+		String notificationId = extract(html, "name=\"notificationIds\" value=\"([^\"]+)\"");
+
+		mockMvc.perform(post("/admin/notifications/push/resend")
+				.session(session)
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("notificationIds", notificationId)
+				.param("commandToken", token)
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf()))
+			.andExpect(status().is3xxRedirection());
+
+		assertThat(auditEventRepository.findRecent(AdminAuditEventType.ADMIN_ACTION, 10))
+			.anySatisfy(event -> {
+				assertThat(event.action()).isEqualTo("RESEND_PUSH");
+				assertThat(event.targetType()).isEqualTo("PUSH_NOTIFICATION_RESEND");
+			});
+	}
+
+	private static String extract(String html, String regex) {
+		Matcher matcher = Pattern.compile(regex).matcher(html);
+		assertThat(matcher.find()).isTrue();
+		return matcher.group(1);
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminPageControllerTest.java
@@ -153,6 +153,48 @@ class PushNotificationAdminPageControllerTest {
 	}
 
 	@Test
+	@DisplayName("발송 이력은 실패 사유별 분해 막대와 사유 드릴다운 링크를 렌더링한다")
+	void pushHistoryRendersFailureBreakdownWithDrilldown() throws Exception {
+		registerDevice();
+		dispatchNotification("REPORT_STATUS", "신고 처리 알림");
+		deliverPendingNotifications();
+
+		String html = mockMvc.perform(get("/admin/notifications/push/page")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("실패 사유별 분해")
+			.contains("외부 푸시 발송 어댑터가 설정되지 않았습니다")
+			.contains("reason=");
+	}
+
+	@Test
+	@DisplayName("사유 드릴다운은 해당 사유의 실패만 목록에 남기고 분해 건수와 정합한다")
+	void pushHistoryDrilldownFiltersByReason() throws Exception {
+		registerDevice();
+		dispatchNotification("REPORT_STATUS", "신고 처리 알림");
+		deliverPendingNotifications();
+
+		String fragment = mockMvc.perform(get("/admin/notifications/push/history")
+				.param("reason", "외부 푸시 발송 어댑터가 설정되지 않았습니다.")
+				.header("HX-Request", "true")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(fragment)
+			.contains("신고 처리 알림")
+			.contains("전체 <strong>1</strong>")
+			.contains("해제");
+	}
+
+	@Test
 	@DisplayName("발송 이력 fragment는 상태 필터를 적용하고 셸 없이 목록만 반환한다")
 	void pushHistoryFragmentFiltersByStatus() throws Exception {
 		registerDevice();

--- a/backend/src/test/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminPageControllerTest.java
@@ -220,6 +220,25 @@ class PushNotificationAdminPageControllerTest {
 	}
 
 	@Test
+	@DisplayName("실패가 있으면 실패 경고에 실패 이력 필터 딥링크를 노출한다")
+	void pushPageShowsFailureDeepLinkWhenFailuresExist() throws Exception {
+		registerDevice();
+		dispatchNotification("REPORT_STATUS", "신고 처리 알림");
+		deliverPendingNotifications();
+
+		String html = mockMvc.perform(get("/admin/notifications/push/page")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("실패 발송 목록 보기")
+			.contains("status=FAILED");
+	}
+
+	@Test
 	@DisplayName("재발송은 command token 없이는 차단된다(중복·위조 방지)")
 	void resendRequiresCommandToken() throws Exception {
 		mockMvc.perform(post("/admin/notifications/push/resend")

--- a/backend/src/test/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminPageControllerTest.java
@@ -7,6 +7,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.easysubway.admin.audit.adapter.out.persistence.InMemoryAdminAuditEventRepository;
+import com.easysubway.admin.audit.domain.AdminAuditEventType;
 import com.easysubway.notification.application.port.in.NotificationPreferenceUseCase;
 import com.easysubway.notification.application.port.in.RegisterDeviceCommand;
 import com.easysubway.notification.domain.DevicePlatform;
@@ -35,6 +37,9 @@ class PushNotificationAdminPageControllerTest {
 
 	@Autowired
 	private NotificationPreferenceUseCase notificationPreferenceUseCase;
+
+	@Autowired
+	private InMemoryAdminAuditEventRepository auditEventRepository;
 
 	@Test
 	@DisplayName("관리자는 푸시 알림 outbox의 전체와 상태별 건수를 확인한다")
@@ -108,6 +113,65 @@ class PushNotificationAdminPageControllerTest {
 			.contains("최근 30일 추이")
 			.doesNotContain("admin-shell")
 			.doesNotContain("상태별 알림");
+	}
+
+	@Test
+	@DisplayName("발송 이력은 수신자 식별자를 마스킹하고 원문 토큰·사용자ID를 노출하지 않는다")
+	void pushHistoryMasksRecipientIdentifiers() throws Exception {
+		registerDevice();
+		dispatchNotification("REPORT_STATUS", "신고 처리 알림");
+
+		String html = mockMvc.perform(get("/admin/notifications/push/page")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("발송 이력")
+			.contains("신고 처리 알림")
+			.contains("제보 처리 상태")
+			.contains("••••")
+			.doesNotContain("secret-device-token")
+			.doesNotContain("anonymous-user-1");
+	}
+
+	@Test
+	@DisplayName("발송 이력 조회는 열람 감사(PRIVACY_READ)를 남긴다")
+	void pushHistoryViewWritesPrivacyReadAudit() throws Exception {
+		mockMvc.perform(get("/admin/notifications/push/history")
+				.header("HX-Request", "true")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk());
+
+		assertThat(auditEventRepository.findRecent(AdminAuditEventType.PRIVACY_READ, 5))
+			.anySatisfy(event -> {
+				assertThat(event.action()).isEqualTo("VIEW_PUSH_HISTORY");
+				assertThat(event.targetType()).isEqualTo("PUSH_NOTIFICATION_HISTORY");
+			});
+	}
+
+	@Test
+	@DisplayName("발송 이력 fragment는 상태 필터를 적용하고 셸 없이 목록만 반환한다")
+	void pushHistoryFragmentFiltersByStatus() throws Exception {
+		registerDevice();
+		dispatchNotification("REPORT_STATUS", "대기 중 알림");
+
+		String fragment = mockMvc.perform(get("/admin/notifications/push/history")
+				.param("status", "FAILED")
+				.header("HX-Request", "true")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(fragment)
+			.contains("id=\"push-history\"")
+			.contains("조건에 맞는 발송 이력이 없습니다.")
+			.doesNotContain("admin-shell")
+			.doesNotContain("대기 중 알림");
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminPageControllerTest.java
@@ -72,6 +72,45 @@ class PushNotificationAdminPageControllerTest {
 	}
 
 	@Test
+	@DisplayName("푸시 화면은 실패 분석 추이 차트·증감 카드·기간 버튼을 렌더링한다")
+	void pushPageRendersFailureTrendChart() throws Exception {
+		String html = mockMvc.perform(get("/admin/notifications/push/page")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("id=\"push-trends\"")
+			.contains("추이 기간 선택")
+			.contains("/admin/notifications/push/trends")
+			.contains("전 기간 대비 증감")
+			.contains("push-trend-canvas")
+			.contains("발송 시도·실패")
+			.contains("/js/admin/dashboard-charts.js");
+	}
+
+	@Test
+	@DisplayName("기간 추이 fragment는 셸 없이 추이 영역만 반환한다")
+	void pushTrendsFragmentReturnsSectionOnly() throws Exception {
+		String fragment = mockMvc.perform(get("/admin/notifications/push/trends")
+				.param("days", "30")
+				.header("HX-Request", "true")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(fragment)
+			.contains("id=\"push-trends\"")
+			.contains("최근 30일 추이")
+			.doesNotContain("admin-shell")
+			.doesNotContain("상태별 알림");
+	}
+
+	@Test
 	@DisplayName("푸시 알림 현황 페이지는 관리자 인증을 요구한다")
 	void pushNotificationDashboardRequiresAdminAuthentication() throws Exception {
 		mockMvc.perform(get("/admin/notifications/push/page"))

--- a/backend/src/test/java/com/easysubway/notification/adapter/out/persistence/InMemoryPushNotificationOutboxRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/notification/adapter/out/persistence/InMemoryPushNotificationOutboxRepositoryTest.java
@@ -87,6 +87,70 @@ class InMemoryPushNotificationOutboxRepositoryTest {
 			.isTrue();
 	}
 
+	@Test
+	@DisplayName("이력 검색은 상태·유형·키워드로 필터하고 최신순으로 정렬한다")
+	void searchPushNotificationsFiltersAndOrders() {
+		repository.savePushNotification(historyNotification(
+			"push-1", "user-1", PushNotificationType.REPORT_STATUS, PushNotificationStatus.PENDING,
+			"신고 처리 알림", LocalDateTime.of(2026, 6, 17, 9, 0)));
+		repository.savePushNotification(new PushNotification(
+			"push-2", "user-2", DevicePlatform.ANDROID, "device-token-2", PushNotificationType.DATA_QUALITY,
+			"데이터 품질 알림", "본문", PushNotificationStatus.FAILED, "provider timeout",
+			LocalDateTime.of(2026, 6, 17, 10, 0)));
+		repository.savePushNotification(historyNotification(
+			"push-3", "user-3", PushNotificationType.REPORT_STATUS, PushNotificationStatus.SENT,
+			"신고 완료 알림", LocalDateTime.of(2026, 6, 17, 11, 0)));
+
+		assertThat(repository.searchPushNotifications(query(PushNotificationStatus.FAILED, null, null)))
+			.extracting(PushNotification::notificationId).containsExactly("push-2");
+		assertThat(repository.searchPushNotifications(query(null, PushNotificationType.REPORT_STATUS, null)))
+			.extracting(PushNotification::notificationId).containsExactly("push-3", "push-1");
+		assertThat(repository.searchPushNotifications(query(null, null, "품질")))
+			.extracting(PushNotification::notificationId).containsExactly("push-2");
+	}
+
+	@Test
+	@DisplayName("이력 검색은 페이지 크기·오프셋으로 잘라내고 전체 건수를 센다")
+	void searchPushNotificationsPaginatesAndCounts() {
+		for (int index = 0; index < 5; index++) {
+			repository.savePushNotification(historyNotification(
+				"push-" + index, "user-1", PushNotificationType.REPORT_STATUS, PushNotificationStatus.PENDING,
+				"신고 알림 " + index, LocalDateTime.of(2026, 6, 17, 9 + index, 0)));
+		}
+
+		assertThat(repository.searchPushNotifications(
+			new com.easysubway.notification.application.port.in.PushNotificationHistoryQuery(
+				null, null, null, null, null, 0, 2)))
+			.extracting(PushNotification::notificationId).containsExactly("push-4", "push-3");
+		assertThat(repository.searchPushNotifications(
+			new com.easysubway.notification.application.port.in.PushNotificationHistoryQuery(
+				null, null, null, null, null, 2, 2)))
+			.extracting(PushNotification::notificationId).containsExactly("push-0");
+		assertThat(repository.countPushNotifications(query(null, null, null))).isEqualTo(5);
+	}
+
+	private static com.easysubway.notification.application.port.in.PushNotificationHistoryQuery query(
+		PushNotificationStatus status,
+		PushNotificationType type,
+		String keyword
+	) {
+		return com.easysubway.notification.application.port.in.PushNotificationHistoryQuery.of(
+			status, type, keyword, null, null, null, null);
+	}
+
+	private PushNotification historyNotification(
+		String notificationId,
+		String userId,
+		PushNotificationType type,
+		PushNotificationStatus status,
+		String title,
+		LocalDateTime createdAt
+	) {
+		return new PushNotification(
+			notificationId, userId, DevicePlatform.ANDROID, "device-token-" + notificationId, type,
+			title, "본문 " + notificationId, status, createdAt);
+	}
+
 	private static org.assertj.core.groups.Tuple tuple(Object... values) {
 		return org.assertj.core.api.Assertions.tuple(values);
 	}

--- a/backend/src/test/java/com/easysubway/notification/adapter/out/persistence/InMemoryPushNotificationOutboxRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/notification/adapter/out/persistence/InMemoryPushNotificationOutboxRepositoryTest.java
@@ -120,13 +120,40 @@ class InMemoryPushNotificationOutboxRepositoryTest {
 
 		assertThat(repository.searchPushNotifications(
 			new com.easysubway.notification.application.port.in.PushNotificationHistoryQuery(
-				null, null, null, null, null, 0, 2)))
+				null, null, null, null, null, null, 0, 2)))
 			.extracting(PushNotification::notificationId).containsExactly("push-4", "push-3");
 		assertThat(repository.searchPushNotifications(
 			new com.easysubway.notification.application.port.in.PushNotificationHistoryQuery(
-				null, null, null, null, null, 2, 2)))
+				null, null, null, null, null, null, 2, 2)))
 			.extracting(PushNotification::notificationId).containsExactly("push-0");
 		assertThat(repository.countPushNotifications(query(null, null, null))).isEqualTo(5);
+	}
+
+	@Test
+	@DisplayName("실패 사유별 분해는 status=FAILED를 사유별로 GROUP BY 하고 목록 건수와 정합한다")
+	void countFailureReasonsGroupsFailedByReason() {
+		repository.savePushNotification(new PushNotification(
+			"push-1", "user-1", DevicePlatform.ANDROID, "device-token-1", PushNotificationType.REPORT_STATUS,
+			"제목", "본문", PushNotificationStatus.FAILED, "provider timeout", LocalDateTime.of(2026, 6, 17, 9, 0)));
+		repository.savePushNotification(new PushNotification(
+			"push-2", "user-2", DevicePlatform.ANDROID, "device-token-2", PushNotificationType.REPORT_STATUS,
+			"제목", "본문", PushNotificationStatus.FAILED, "provider timeout", LocalDateTime.of(2026, 6, 17, 10, 0)));
+		repository.savePushNotification(new PushNotification(
+			"push-3", "user-3", DevicePlatform.ANDROID, "device-token-3", PushNotificationType.DATA_QUALITY,
+			"제목", "본문", PushNotificationStatus.FAILED, "invalid token", LocalDateTime.of(2026, 6, 17, 11, 0)));
+		repository.savePushNotification(historyNotification(
+			"push-4", "user-4", PushNotificationType.REPORT_STATUS, PushNotificationStatus.SENT,
+			"제목", LocalDateTime.of(2026, 6, 17, 12, 0)));
+
+		assertThat(repository.countFailureReasons(query(null, null, null)))
+			.extracting(
+				com.easysubway.notification.domain.PushNotificationFailureReasonCount::reason,
+				com.easysubway.notification.domain.PushNotificationFailureReasonCount::count)
+			.containsExactly(tuple("provider timeout", 2L), tuple("invalid token", 1L));
+
+		var drilldown = com.easysubway.notification.application.port.in.PushNotificationHistoryQuery.of(
+			null, null, null, "provider timeout", null, null, null, null);
+		assertThat(repository.countPushNotifications(drilldown)).isEqualTo(2);
 	}
 
 	private static com.easysubway.notification.application.port.in.PushNotificationHistoryQuery query(
@@ -135,7 +162,7 @@ class InMemoryPushNotificationOutboxRepositoryTest {
 		String keyword
 	) {
 		return com.easysubway.notification.application.port.in.PushNotificationHistoryQuery.of(
-			status, type, keyword, null, null, null, null);
+			status, type, keyword, null, null, null, null, null);
 	}
 
 	private PushNotification historyNotification(

--- a/backend/src/test/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepositoryTest.java
@@ -274,10 +274,10 @@ class JdbcPushNotificationOutboxRepositoryTest {
 
 		var firstPage = repository.searchPushNotifications(
 			new com.easysubway.notification.application.port.in.PushNotificationHistoryQuery(
-				null, null, null, null, null, 0, 2));
+				null, null, null, null, null, null, 0, 2));
 		var secondPage = repository.searchPushNotifications(
 			new com.easysubway.notification.application.port.in.PushNotificationHistoryQuery(
-				null, null, null, null, null, 1, 2));
+				null, null, null, null, null, null, 1, 2));
 
 		assertThat(firstPage).extracting(PushNotification::notificationId).containsExactly("push-4", "push-3");
 		assertThat(secondPage).extracting(PushNotification::notificationId).containsExactly("push-2", "push-1");
@@ -299,13 +299,38 @@ class JdbcPushNotificationOutboxRepositoryTest {
 			.containsExactly("push-pct");
 	}
 
+	@Test
+	@DisplayName("실패 사유별 분해는 status=FAILED를 사유별로 GROUP BY 하고 목록 건수와 정합한다")
+	void countFailureReasonsGroupsFailedByReason() {
+		repository.savePushNotification(failedNotification(
+			"push-1", "user-1", PushNotificationType.REPORT_STATUS, "provider timeout", 9));
+		repository.savePushNotification(failedNotification(
+			"push-2", "user-2", PushNotificationType.REPORT_STATUS, "provider timeout", 10));
+		repository.savePushNotification(failedNotification(
+			"push-3", "user-3", PushNotificationType.DATA_QUALITY, "invalid token", 11));
+		repository.savePushNotification(notification("push-4", "user-4", PushNotificationType.REPORT_STATUS, 12));
+
+		var breakdown = repository.countFailureReasons(query(null, null, null));
+
+		assertThat(breakdown)
+			.extracting(
+				com.easysubway.notification.domain.PushNotificationFailureReasonCount::reason,
+				com.easysubway.notification.domain.PushNotificationFailureReasonCount::count)
+			.containsExactly(tuple("provider timeout", 2L), tuple("invalid token", 1L));
+
+		// 분해 수치 = 사유 드릴다운 목록 건수 정합.
+		var drilldown = com.easysubway.notification.application.port.in.PushNotificationHistoryQuery.of(
+			null, null, null, "provider timeout", null, null, null, null);
+		assertThat(repository.countPushNotifications(drilldown)).isEqualTo(2);
+	}
+
 	private static com.easysubway.notification.application.port.in.PushNotificationHistoryQuery query(
 		PushNotificationStatus status,
 		PushNotificationType type,
 		String keyword
 	) {
 		return com.easysubway.notification.application.port.in.PushNotificationHistoryQuery.of(
-			status, type, keyword, null, null, null, null);
+			status, type, keyword, null, null, null, null, null);
 	}
 
 	private PushNotification notification(

--- a/backend/src/test/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepositoryTest.java
@@ -7,6 +7,7 @@ import com.easysubway.notification.domain.PushNotification;
 import com.easysubway.notification.domain.PushNotificationStatus;
 import com.easysubway.notification.domain.PushNotificationType;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -322,6 +323,19 @@ class JdbcPushNotificationOutboxRepositoryTest {
 		var drilldown = com.easysubway.notification.application.port.in.PushNotificationHistoryQuery.of(
 			null, null, null, "provider timeout", null, null, null, null);
 		assertThat(repository.countPushNotifications(drilldown)).isEqualTo(2);
+	}
+
+	@Test
+	@DisplayName("식별자 목록으로 알림들을 로드한다(재발송 대상 검증용)")
+	void loadPushNotificationsByIdsReturnsMatchingNotifications() {
+		repository.savePushNotification(notification("push-1", "user-1", PushNotificationType.REPORT_STATUS, 9));
+		repository.savePushNotification(notification("push-2", "user-2", PushNotificationType.DATA_QUALITY, 10));
+		repository.savePushNotification(notification("push-3", "user-3", PushNotificationType.REPORT_STATUS, 11));
+
+		assertThat(repository.loadPushNotificationsByIds(List.of("push-1", "push-3", "missing")))
+			.extracting(PushNotification::notificationId)
+			.containsExactlyInAnyOrder("push-1", "push-3");
+		assertThat(repository.loadPushNotificationsByIds(List.of())).isEmpty();
 	}
 
 	private static com.easysubway.notification.application.port.in.PushNotificationHistoryQuery query(

--- a/backend/src/test/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepositoryTest.java
@@ -245,6 +245,69 @@ class JdbcPushNotificationOutboxRepositoryTest {
 			.containsExactly(notification("push-3", "anonymous-user-2", PushNotificationType.FAVORITE_ROUTE_FACILITY, 11));
 	}
 
+	@Test
+	@DisplayName("이력 검색은 상태·유형·키워드·기간으로 필터하고 최신순으로 정렬한다")
+	void searchPushNotificationsFiltersAndOrders() {
+		repository.savePushNotification(notification("push-1", "user-1", PushNotificationType.REPORT_STATUS, 9));
+		repository.savePushNotification(failedNotification(
+			"push-2", "user-2", PushNotificationType.DATA_QUALITY, "provider timeout", 10));
+		repository.savePushNotification(notification(
+			"push-3", "user-3", PushNotificationType.REPORT_STATUS, PushNotificationStatus.SENT, 11));
+
+		var byStatus = repository.searchPushNotifications(query(PushNotificationStatus.FAILED, null, null));
+		assertThat(byStatus).extracting(PushNotification::notificationId).containsExactly("push-2");
+
+		var byType = repository.searchPushNotifications(query(null, PushNotificationType.REPORT_STATUS, null));
+		assertThat(byType).extracting(PushNotification::notificationId).containsExactly("push-3", "push-1");
+
+		var byKeyword = repository.searchPushNotifications(query(null, null, "제목 push-2"));
+		assertThat(byKeyword).extracting(PushNotification::notificationId).containsExactly("push-2");
+	}
+
+	@Test
+	@DisplayName("이력 검색은 페이지 크기·오프셋으로 잘라내고 전체 건수를 센다")
+	void searchPushNotificationsPaginatesAndCounts() {
+		for (int index = 0; index < 5; index++) {
+			repository.savePushNotification(notification(
+				"push-" + index, "user-1", PushNotificationType.REPORT_STATUS, 9 + index));
+		}
+
+		var firstPage = repository.searchPushNotifications(
+			new com.easysubway.notification.application.port.in.PushNotificationHistoryQuery(
+				null, null, null, null, null, 0, 2));
+		var secondPage = repository.searchPushNotifications(
+			new com.easysubway.notification.application.port.in.PushNotificationHistoryQuery(
+				null, null, null, null, null, 1, 2));
+
+		assertThat(firstPage).extracting(PushNotification::notificationId).containsExactly("push-4", "push-3");
+		assertThat(secondPage).extracting(PushNotification::notificationId).containsExactly("push-2", "push-1");
+		assertThat(repository.countPushNotifications(query(null, null, null))).isEqualTo(5);
+		assertThat(repository.countPushNotifications(query(null, null, "제목 push-0"))).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("LIKE 메타문자가 든 키워드는 리터럴로 매칭한다")
+	void searchPushNotificationsEscapesLikeMetacharacters() {
+		repository.savePushNotification(new PushNotification(
+			"push-pct", "user-1", DevicePlatform.ANDROID, "device-token-pct",
+			PushNotificationType.REPORT_STATUS, "50% 할인 안내", "본문", PushNotificationStatus.PENDING,
+			LocalDateTime.of(2026, 6, 17, 9, 0)));
+		repository.savePushNotification(notification("push-plain", "user-1", PushNotificationType.REPORT_STATUS, 10));
+
+		assertThat(repository.searchPushNotifications(query(null, null, "50%")))
+			.extracting(PushNotification::notificationId)
+			.containsExactly("push-pct");
+	}
+
+	private static com.easysubway.notification.application.port.in.PushNotificationHistoryQuery query(
+		PushNotificationStatus status,
+		PushNotificationType type,
+		String keyword
+	) {
+		return com.easysubway.notification.application.port.in.PushNotificationHistoryQuery.of(
+			status, type, keyword, null, null, null, null);
+	}
+
 	private PushNotification notification(
 		String notificationId,
 		String userId,

--- a/backend/src/test/java/com/easysubway/notification/application/service/PushNotificationResendServiceTest.java
+++ b/backend/src/test/java/com/easysubway/notification/application/service/PushNotificationResendServiceTest.java
@@ -1,0 +1,105 @@
+package com.easysubway.notification.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.easysubway.notification.adapter.out.persistence.InMemoryPushNotificationOutboxRepository;
+import com.easysubway.notification.application.port.in.DeliverPushNotificationsCommand;
+import com.easysubway.notification.application.port.in.PushNotificationDeliveryUseCase;
+import com.easysubway.notification.application.port.in.ResendPushNotificationsCommand;
+import com.easysubway.notification.domain.DevicePlatform;
+import com.easysubway.notification.domain.PushNotification;
+import com.easysubway.notification.domain.PushNotificationDeliveryResult;
+import com.easysubway.notification.domain.PushNotificationResendResult;
+import com.easysubway.notification.domain.PushNotificationStatus;
+import com.easysubway.notification.domain.PushNotificationType;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("실패 푸시 재발송 서비스")
+class PushNotificationResendServiceTest {
+
+	private final InMemoryPushNotificationOutboxRepository repository = new InMemoryPushNotificationOutboxRepository();
+	private final List<String> deliveredUserIds = new ArrayList<>();
+	private final PushNotificationDeliveryUseCase deliveryUseCase = new RecordingDeliveryUseCase(deliveredUserIds);
+	private final PushNotificationResendService service =
+		new PushNotificationResendService(repository, repository, deliveryUseCase);
+
+	@Test
+	@DisplayName("실패 건만 대기로 되돌리고 성공 건은 멱등하게 제외한다")
+	void resendResetsFailedOnlyAndSkipsSent() {
+		repository.savePushNotification(failed("push-1", "user-1", "provider timeout"));
+		repository.savePushNotification(sent("push-2", "user-1"));
+
+		PushNotificationResendResult result = service.resend(
+			new ResendPushNotificationsCommand(List.of("push-1", "push-2"), 5));
+
+		assertThat(result.blocked()).isFalse();
+		assertThat(result.requestedCount()).isEqualTo(2);
+		assertThat(result.resentCount()).isEqualTo(1);
+		assertThat(result.skippedCount()).isEqualTo(1);
+		assertThat(repository.loadPushNotificationsByIds(List.of("push-1")))
+			.singleElement()
+			.extracting(PushNotification::status)
+			.isEqualTo(PushNotificationStatus.PENDING);
+		assertThat(repository.loadPushNotificationsByIds(List.of("push-2")))
+			.singleElement()
+			.extracting(PushNotification::status)
+			.isEqualTo(PushNotificationStatus.SENT);
+		assertThat(deliveredUserIds).containsExactly("user-1");
+	}
+
+	@Test
+	@DisplayName("선택 건수가 1회 상한을 넘으면 아무것도 재발송하지 않고 차단한다")
+	void resendBlocksWhenOverLimit() {
+		repository.savePushNotification(failed("push-1", "user-1", "provider timeout"));
+		repository.savePushNotification(failed("push-2", "user-2", "provider timeout"));
+		repository.savePushNotification(failed("push-3", "user-3", "provider timeout"));
+
+		PushNotificationResendResult result = service.resend(
+			new ResendPushNotificationsCommand(List.of("push-1", "push-2", "push-3"), 2));
+
+		assertThat(result.blocked()).isTrue();
+		assertThat(result.resentCount()).isZero();
+		assertThat(deliveredUserIds).isEmpty();
+		assertThat(repository.loadPushNotificationsByIds(List.of("push-1")))
+			.singleElement()
+			.extracting(PushNotification::status)
+			.isEqualTo(PushNotificationStatus.FAILED);
+	}
+
+	@Test
+	@DisplayName("이미 성공한 건만 재발송 시도하면 멱등하게 제외한다")
+	void resendAlreadySentIsIdempotentNoop() {
+		repository.savePushNotification(sent("push-1", "user-1"));
+
+		PushNotificationResendResult result = service.resend(
+			new ResendPushNotificationsCommand(List.of("push-1"), 5));
+
+		assertThat(result.resentCount()).isZero();
+		assertThat(result.skippedCount()).isEqualTo(1);
+		assertThat(deliveredUserIds).isEmpty();
+	}
+
+	private static PushNotification failed(String id, String userId, String reason) {
+		return new PushNotification(id, userId, DevicePlatform.ANDROID, "device-token-" + id,
+			PushNotificationType.REPORT_STATUS, "제목", "본문", PushNotificationStatus.FAILED, reason,
+			LocalDateTime.of(2026, 6, 17, 9, 0));
+	}
+
+	private static PushNotification sent(String id, String userId) {
+		return new PushNotification(id, userId, DevicePlatform.ANDROID, "device-token-" + id,
+			PushNotificationType.REPORT_STATUS, "제목", "본문", PushNotificationStatus.SENT,
+			LocalDateTime.of(2026, 6, 17, 9, 0));
+	}
+
+	private record RecordingDeliveryUseCase(List<String> deliveredUserIds) implements PushNotificationDeliveryUseCase {
+		@Override
+		public PushNotificationDeliveryResult deliverPending(DeliverPushNotificationsCommand command) {
+			deliveredUserIds.add(command.userId());
+			return new PushNotificationDeliveryResult(command.userId(), 0, 0, List.of());
+		}
+	}
+}


### PR DESCRIPTION
## 관련 이슈

close #1746

## 작업 배경

푸시 알림 화면이 요약 카드 조회 전용이라 화면에서 할 수 있는 조치가 없었다(폼 0개). 개별 발송 이력·실패 원인 분석·안전한 재발송 UI가 없어 "최근 실패" 텍스트 1건이 전부였다. 이를 이력·원인 분석·안전한 재발송이 가능한 운영 콘솔로 고도화한다. 에픽 #1735 Phase 1의 마지막 화면군이며, #1737 표준 테이블·#1739 푸시 시리즈·#1738 알림 센터·#1744 분석 차트 자산을 재사용한다.

## 작업 내용

증분 5단계(1/N은 선행 병합 브랜치에 포함, 이 PR은 1~5 전체):

- **1/N 실패 분석 추이**: #1744 분석 차트 패턴 재사용 — `push.attempted`·`push.failed` 시계열 라인·증감 카드·7/30/90 기간 htmx 부분 갱신·CSV·details 대체표.
- **2/N 발송 이력 표준 테이블**: 조회 포트(`SearchPushNotificationOutboxPort`)·질의 값객체·유스케이스·서비스 신설. Jdbc(동적 WHERE 화이트리스트·LIKE 이스케이프·LIMIT/OFFSET)·InMemory 병렬 필터. 기간/상태/유형 필터·내용 검색·페이지네이션·행 확장 시도 이력. **수신자 식별자(사용자ID·기기 토큰) 마스킹** + **열람 PRIVACY_READ 감사**. no-JS 폼 + htmx 부분 갱신 공존.
- **3/N 실패 사유별 분해**: 같은 필터 컨텍스트에서 `status=FAILED`를 사유별 GROUP BY. CSP-safe 서버 SVG 막대(인라인 style 금지), 각 막대는 사유 드릴다운 링크. **분해 수치 = 사유 필터 목록 건수 정합**(같은 질의 공유).
- **4/N 재발송 안전장치**: 실패 건 선택 → 재발송 유스케이스/서비스. **멱등(이미 성공한 건 제외)**·**1회 재발송 상한(대량 오발송 방지)**. 상한은 공통코드 `PUSH_RESEND_LIMIT`로 관리(**Flyway V41** h2+postgresql, InMemory 시드, 기본 50 폴백). 재발송 폼은 command token+CSRF(인터셉터 검증)·확인 details·선택 건수 CSP Alpine·결과 flash 토스트. 감사(`RESEND_PUSH`).
- **5/N 요약·연계**: 발송 시도·실패 카드 7일 CSP-safe 서버 SVG 스파크라인. 실패 경고 → 실패 이력 필터(`status=FAILED`) 딥링크. 알림센터(#1738) 푸시 실패 신호도 같은 필터로 딥링크.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test` (backend 전체) → **BUILD SUCCESSFUL** (2m 13s)
  - `./gradlew test --tests DatabaseMigrationContainerTest` (postgres Flyway V41) → **BUILD SUCCESSFUL**
  - 신규/변경 단위·통합: outbox 검색·건수·실패 분해·loadByIds(Jdbc+InMemory), 재발송 서비스(멱등·상한), 컨트롤러 MockMvc(마스킹·감사·드릴다운·재발송 command token·실패 딥링크), 알림센터 딥링크 → 전부 green

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Flyway V41(h2) | Backend | SpringBootTest 부팅 시 마이그레이션 적용 | 전체 스위트 green | 통과 |
| Flyway V41(postgres) | Backend | `DatabaseMigrationContainerTest` | BUILD SUCCESSFUL | 통과 |
| 수신자 마스킹 | Backend | MockMvc: 원문 토큰·userId 미노출 단언 | `pushHistoryMasksRecipientIdentifiers` | 통과 |
| 열람 감사 | Backend | MockMvc: PRIVACY_READ `VIEW_PUSH_HISTORY` | `pushHistoryViewWritesPrivacyReadAudit` | 통과 |
| 재발송 멱등·상한 | Backend | 서비스 단위 테스트 | `PushNotificationResendServiceTest` | 통과 |
| 재발송 command token | Backend | MockMvc: 토큰 없이 409, 토큰으로 처리·감사 | `resendRequiresCommandToken`, `resendFailedNotification…` | 통과 |
| 분해=목록 정합 | Backend | Jdbc+InMemory: 사유 분해 = 드릴다운 count | `countFailureReasonsGroupsFailedByReason` | 통과 |
| 스파크라인·키보드 런타임 시각 | Browser | Claude Chrome 확장 미연결 | 자동 테스트가 조건 렌더·no-JS·CSP-safe 커버 | #1749 이월 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [x] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 코드 변경(무중단 배포)

## 리뷰어 메모

- 먼저 볼 지점: `PushNotificationAdminPageController`(이력/분해/재발송 배선), `PushNotificationResendService`(멱등·상한 로직), 공통코드 상한 조회(`resendLimit()`, Flyway V41).
- 마스킹은 `PushRecipientMask`(앞 일부만 노출·길이 은닉), 열람은 목록 조회마다 PRIVACY_READ 감사.
- URL에 `/page`가 포함돼야 `commandTokens`가 노출되는 gotcha(#1742) 때문에 이력 경로를 `/admin/notifications/push/page/history`로 뒀다.

## 리스크

- 재발송은 되돌린 건을 즉시 배송 시도한다(기존 delivery 유스케이스 재사용). 외부 발송 어댑터 미설정 환경에서는 다시 실패로 남는다(설계상 정상, 상한·멱등으로 안전).
- 상한 공통코드가 여러 개 활성이면 가장 보수적인(작은) 값을 쓴다. 관리자 콘솔에서 단일 활성 유지 권장.
- 스파크라인·키보드·시각 런타임 E2E는 브라우저 미연결로 #1749(접근성 QA)로 이월.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
