### PR TITLE
[Mobile] 노선도 서울메트로 룩 — 환승 흰 원 + 간선 노선번호 색 원 (#1789)

### DIFF
--- a/apps/mobile/lib/features/network_map/presentation/route_map_label_layout.dart
+++ b/apps/mobile/lib/features/network_map/presentation/route_map_label_layout.dart
@@ -1,5 +1,5 @@
 import 'dart:math' as math;
-import 'dart:ui' show Color, Offset, Rect, Size;
+import 'dart:ui' show Offset, Rect, Size;
 
 import '../domain/route_map_design_space.dart';
 import '../domain/structured_route_map.dart';
@@ -78,7 +78,6 @@ class _Candidate {
     required this.priority,
     required this.anchorPadding,
     required this.bold,
-    this.badgeLineId,
   });
   final String id;
   final String text;
@@ -87,31 +86,80 @@ class _Candidate {
   final int priority;
   final double anchorPadding;
   final bool bold;
-  final String? badgeLineId; // null이면 역 라벨.
 }
 
-/// 환승 캡슐의 design space 외접 Rect — 라벨 배치의 선점 장애물(#1789).
-/// painter와 같은 [routeMapTransferMarkers] 호출로 기하 정합을 보장한다
-/// (색은 캡슐 기하에 영향이 없어 placeholder를 넘긴다).
+// 노선 뱃지 개수: 트렁크가 길면 3, 아니면 2(#1789 — 노선당 소수, 클러터 회피).
+int _badgeCountForLine(RouteMapLineGeometry line, RouteMapDesignSpace design) {
+  var maxLen = 0.0;
+  for (final poly in line.polylines) {
+    var len = 0.0;
+    for (var i = 1; i < poly.length; i += 1) {
+      len += (design.toDesign(poly[i]) - design.toDesign(poly[i - 1])).distance;
+    }
+    if (len > maxLen) {
+      maxLen = len;
+    }
+  }
+  return maxLen > 2000 ? 3 : 2;
+}
+
+// 간선(가장 긴 polyline) arc-length 균등 후보 앵커(design px). 후보를 넉넉히 만들어
+//   겹치는 위치를 건너뛰고 다음을 시도할 여지를 준다(1/8..7/8).
+List<Offset> _badgeAnchorsAlong(
+  RouteMapLineGeometry line,
+  RouteMapDesignSpace design,
+) {
+  var trunk = const <Offset>[];
+  var trunkLen = -1.0;
+  for (final poly in line.polylines) {
+    final pts = [for (final p in poly) design.toDesign(p)];
+    var len = 0.0;
+    for (var i = 1; i < pts.length; i += 1) {
+      len += (pts[i] - pts[i - 1]).distance;
+    }
+    if (len > trunkLen) {
+      trunkLen = len;
+      trunk = pts;
+    }
+  }
+  if (trunk.length < 2 || trunkLen <= 0) {
+    return const [];
+  }
+  const divisions = 7;
+  return [
+    for (var i = 1; i <= divisions; i += 1)
+      _pointAtFraction(trunk, trunkLen, i / (divisions + 1)),
+  ];
+}
+
+// polyline 위 arc-length fraction(0..1) 위치의 점.
+Offset _pointAtFraction(List<Offset> pts, double totalLen, double fraction) {
+  final target = totalLen * fraction;
+  var acc = 0.0;
+  for (var i = 1; i < pts.length; i += 1) {
+    final seg = (pts[i] - pts[i - 1]).distance;
+    if (acc + seg >= target) {
+      final t = seg == 0 ? 0.0 : (target - acc) / seg;
+      return Offset.lerp(pts[i - 1], pts[i], t)!;
+    }
+    acc += seg;
+  }
+  return pts.last;
+}
+
+/// 환승 흰 원의 design space 외접 Rect — 라벨 배치의 선점 장애물(#1789).
+/// painter와 같은 [routeMapTransferRings] 호출로 기하 정합을 보장한다.
 List<Rect> routeMapTransferObstacleRects(
   StructuredRouteMap map,
   RouteMapDesignSpace design,
 ) {
   final rects = <Rect>[];
   for (final group in map.transferGroups) {
-    final centers = [for (final p in group.memberPositions) design.toDesign(p)];
-    final markers = routeMapTransferMarkers(
-      memberCenters: centers,
-      colors: List<Color>.filled(centers.length, const Color(0xFF000000)),
-      designSpread:
-          offsetsMaxPairwiseDistance(group.memberPositions) *
-          design.designScale,
-      dotRadius: kRouteMapTransferDotRadiusPx,
-      dotGap: kRouteMapTransferDotGapPx,
-      padding: kRouteMapTransferDotPaddingPx,
+    final marker = routeMapTransferRings(
+      members: [for (final p in group.memberPositions) design.toDesign(p)],
     );
-    for (final marker in markers) {
-      rects.add(marker.capsule.outerRect);
+    for (final ring in marker.rings) {
+      rects.add(Rect.fromCircle(center: ring.center, radius: ring.radius));
     }
   }
   return rects;
@@ -128,66 +176,10 @@ RouteMapStaticLabelLayout solveRouteMapLabelLayout({
   final terminusIds = routeMapTerminusStationIds(map);
   final candidates = <_Candidate>[];
 
-  // 1) 노선 뱃지: 끝점 + arc length 반복 (스펙 S4 — 노선 중간 확대에도 식별).
-  for (final line in map.lines) {
-    final label = badgeLabelByLineId[line.lineId];
-    if (label == null || label.isEmpty) {
-      continue;
-    }
-    final size = measureBadge(label);
-    var emitted = 0;
-    void emit(Offset source) {
-      candidates.add(
-        _Candidate(
-          id: 'badge:${line.lineId}:${emitted++}',
-          text: label,
-          anchor: design.toDesign(source),
-          size: size,
-          priority: -1,
-          anchorPadding: kRouteMapDesignBadgeRadiusPx,
-          bold: false,
-          badgeLineId: line.lineId,
-        ),
-      );
-    }
+  // 노선 뱃지(색 원)는 역 라벨 배치가 끝난 뒤 별도 pass에서 간선 arc-length 위에
+  //   놓는다(아래) — 역명을 가리면 생략(역명 판독 우선, #1789).
 
-    // 노선 뱃지는 **종점에만** 둔다(공식 노선도 관례). 선 따라 반복하면 역명을
-    // 덮어 가독을 해친다 — 중간 구간은 선 색으로 노선을 식별한다(#1789 튜닝).
-    //
-    // anchor = 실제 양 극점(모든 조각 끝점 중 상호 최원 쌍). 다중 조각 노선에서
-    // first/last가 중앙 조각 경계로 잡혀 뱃지가 도심을 덮던 문제를 고친다(#1789).
-    final endpoints = <Offset>[];
-    for (final polyline in line.polylines) {
-      if (polyline.isEmpty) {
-        continue;
-      }
-      endpoints.add(polyline.first);
-      if (polyline.length > 1) {
-        endpoints.add(polyline.last);
-      }
-    }
-    Offset? a;
-    Offset? b;
-    var maxD = -1.0;
-    for (var i = 0; i < endpoints.length; i += 1) {
-      for (var j = i + 1; j < endpoints.length; j += 1) {
-        final d = (endpoints[i] - endpoints[j]).distanceSquared;
-        if (d > maxD) {
-          maxD = d;
-          a = endpoints[i];
-          b = endpoints[j];
-        }
-      }
-    }
-    if (a != null) {
-      emit(a);
-    }
-    if (b != null && b != a) {
-      emit(b); // 순환선(양 극점 근접)은 a==b → 한 번만.
-    }
-  }
-
-  // 2) 환승 라벨(그룹당 1) + 역 라벨(환승 멤버 제외).
+  // 환승 라벨(그룹당 1) + 역 라벨(환승 멤버 제외).
   for (final group in map.transferGroups) {
     final text = labelTextByStationId[group.stationId];
     if (text == null || text.isEmpty) {
@@ -297,25 +289,52 @@ RouteMapStaticLabelLayout solveRouteMapLabelLayout({
       unresolved += 1; // 라벨-라벨 겹침을 못 피한 경우만 집계.
     }
     placedRects.add(rect);
-    if (candidate.badgeLineId != null) {
+    labels.add(
+      RouteMapStaticLabel(
+        id: candidate.id,
+        text: candidate.text,
+        rect: rect,
+        bold: candidate.bold,
+      ),
+    );
+  }
+
+  // 노선 뱃지 색 원: 간선 arc-length 위 후보 중 이미 배치된 역 라벨·환승 원·다른
+  //   뱃지와 안 겹치는 위치에만 놓는다(역명 판독 > 노선번호 존재 — 겹치면 생략,
+  //   노선당 0개 허용). 간선 색 위에 놓이는 것은 정상(공식 서울메트로 룩).
+  for (final line in map.lines) {
+    final label = badgeLabelByLineId[line.lineId];
+    if (label == null || label.isEmpty) {
+      continue;
+    }
+    final size = measureBadge(label);
+    final radius = math.max(kRouteMapDesignBadgeRadiusPx, size.width / 2 + 1);
+    final maxBadges = _badgeCountForLine(line, design);
+    var placed = 0;
+    for (final anchor in _badgeAnchorsAlong(line, design)) {
+      if (placed >= maxBadges) {
+        break;
+      }
+      final rect = Rect.fromCircle(center: anchor, radius: radius);
+      var clash = false;
+      for (final other in placedRects) {
+        final overlap = rect.intersect(other);
+        if (overlap.width > 0 && overlap.height > 0) {
+          clash = true;
+          break;
+        }
+      }
+      if (clash) {
+        continue; // 역명 등과 겹치면 이 위치는 생략(어거지 삽입 금지).
+      }
+      placedRects.add(rect);
       badges.add(
-        RouteMapStaticBadge(
-          lineId: candidate.badgeLineId!,
-          label: candidate.text,
-          rect: rect,
-        ),
+        RouteMapStaticBadge(lineId: line.lineId, label: label, rect: rect),
       );
-    } else {
-      labels.add(
-        RouteMapStaticLabel(
-          id: candidate.id,
-          text: candidate.text,
-          rect: rect,
-          bold: candidate.bold,
-        ),
-      );
+      placed += 1;
     }
   }
+
   return RouteMapStaticLabelLayout(
     labels: labels,
     badges: badges,

--- a/apps/mobile/lib/features/network_map/presentation/route_map_transfer_marker.dart
+++ b/apps/mobile/lib/features/network_map/presentation/route_map_transfer_marker.dart
@@ -14,6 +14,10 @@ const double kRouteMapTransferDotRadiusPx = 2.5;
 const double kRouteMapTransferDotGapPx = 1.5;
 const double kRouteMapTransferDotPaddingPx = 1.5;
 
+// 서울메트로 흰 원 환승 마커 반경(design px). 간선 색 선이 만나는 지점에 흰
+// 채움+짙은 테두리 원을 얹는다(#1789 캡슐+도트 스택 대체). 캘리브레이션 값.
+const double kRouteMapTransferRingRadiusPx = 6.0;
+
 /// 환승 마커의 색 도트 한 개 (노선별).
 class RouteMapTransferDot {
   const RouteMapTransferDot({required this.center, required this.color});
@@ -210,4 +214,64 @@ List<RouteMapTransferMarker> routeMapTransferMarkers({
         horizontalDots: horizontalDots,
       ),
   ];
+}
+
+/// 환승 흰 원 하나(서울메트로 룩). 간선 색 선 위에 얹히는 흰 채움+테두리 원.
+class RouteMapTransferRing {
+  const RouteMapTransferRing({required this.center, required this.radius});
+
+  final Offset center;
+  final double radius;
+
+  @override
+  bool operator ==(Object other) =>
+      other is RouteMapTransferRing &&
+      other.center == center &&
+      other.radius == radius;
+
+  @override
+  int get hashCode => Object.hash(center, radius);
+}
+
+/// 한 환승역의 링 마커 기하: 흰 원(들) + (대분산 시) centroid 연결선.
+class RouteMapTransferMarkerV2 {
+  const RouteMapTransferMarkerV2({
+    required this.rings,
+    required this.connectors,
+  });
+
+  final List<RouteMapTransferRing> rings;
+
+  /// 각 원소가 [멤버, centroid] 2점 선분(대분산 환승의 도보 연결 표현).
+  final List<List<Offset>> connectors;
+}
+
+/// 환승 멤버 좌표에서 서울메트로식 흰 원 마커를 만든다(#1789 접근 A 하이브리드).
+///
+/// - 멤버 spread < 2*[radius](수렴·소분산): centroid에 **흰 원 1개**. 간선 선이
+///   원에 닿아 색이 자연 연결된다.
+/// - spread >= 2*[radius](대분산, 물리적으로 먼 환승): 멤버별 원 + centroid로
+///   잇는 얇은 연결선(공식 지도의 도보 연결 표현).
+RouteMapTransferMarkerV2 routeMapTransferRings({
+  required List<Offset> members,
+  double radius = kRouteMapTransferRingRadiusPx,
+}) {
+  if (members.isEmpty) {
+    return const RouteMapTransferMarkerV2(rings: [], connectors: []);
+  }
+  final centroid = _meanOffset(members);
+  if (offsetsMaxPairwiseDistance(members) < 2 * radius) {
+    return RouteMapTransferMarkerV2(
+      rings: [RouteMapTransferRing(center: centroid, radius: radius)],
+      connectors: const [],
+    );
+  }
+  return RouteMapTransferMarkerV2(
+    rings: [
+      for (final m in members) RouteMapTransferRing(center: m, radius: radius),
+    ],
+    connectors: [
+      for (final m in members) [m, centroid],
+    ],
+  );
 }

--- a/apps/mobile/lib/features/network_map/presentation/structured_route_map_painter.dart
+++ b/apps/mobile/lib/features/network_map/presentation/structured_route_map_painter.dart
@@ -61,6 +61,13 @@ String routeMapStationLabel(String nameKo) {
   return i <= 0 ? nameKo : nameKo.substring(0, i);
 }
 
+/// 노선 색 원 뱃지 위 텍스트 대비색(#1789 서울메트로 룩). 노선 색의 WCAG 상대
+/// 휘도가 높으면(밝은 색) 검정, 낮으면 흰색 — 번호 판독을 보장한다.
+Color routeMapBadgeTextColor(Color lineColor) =>
+    lineColor.computeLuminance() > 0.5
+    ? const Color(0xFF000000)
+    : const Color(0xFFFFFFFF);
+
 // 스타일 상수 (design px — 캘리브레이션 상수 소비).
 const TextStyle _labelStyle = TextStyle(
   color: Color(0xFF102A2C),
@@ -207,21 +214,19 @@ ui.Picture recordRouteMapPicture({
     painter.dispose();
   }
 
-  // 5) 노선 뱃지 pill.
+  // 5) 노선 번호 색 원(서울메트로 룩) — 노선 색 원 + 대비색 번호. 간선 위에 얹힌다.
   final badgeFill = Paint()
     ..style = PaintingStyle.fill
     ..isAntiAlias = true;
   for (final badge in layout.badges) {
-    badgeFill.color = lineColors[badge.lineId] ?? _fallbackLineColor;
-    canvas.drawRRect(
-      RRect.fromRectAndRadius(
-        badge.rect,
-        Radius.circular(badge.rect.height / 2),
-      ),
-      badgeFill,
-    );
+    final lineColor = lineColors[badge.lineId] ?? _fallbackLineColor;
+    badgeFill.color = lineColor;
+    canvas.drawCircle(badge.rect.center, badge.rect.width / 2, badgeFill);
     final painter = TextPainter(
-      text: TextSpan(text: badge.label, style: _badgeStyle),
+      text: TextSpan(
+        text: badge.label,
+        style: _badgeStyle.copyWith(color: routeMapBadgeTextColor(lineColor)),
+      ),
       textDirection: TextDirection.ltr,
       maxLines: 1,
     )..layout();

--- a/apps/mobile/lib/features/network_map/presentation/structured_route_map_painter.dart
+++ b/apps/mobile/lib/features/network_map/presentation/structured_route_map_painter.dart
@@ -108,43 +108,12 @@ final Paint _transferBorderPaint = Paint()
   ..strokeWidth = _transferBorderWidth
   ..color = _transferBorder
   ..isAntiAlias = true;
-final Paint _transferDotPaint = Paint()
-  ..style = PaintingStyle.fill
+// 대분산 환승(물리적으로 먼 두 역)의 도보 연결 표현 — 얇은 회색 선.
+final Paint _transferConnectorPaint = Paint()
+  ..style = PaintingStyle.stroke
+  ..strokeWidth = _transferBorderWidth
+  ..color = _transferBorder.withValues(alpha: 0.45)
   ..isAntiAlias = true;
-
-// 환승 국소 corridor 우세 방향(design px) → 도트 가로/세로 결정. 멤버 노선들의
-// centroid 최근접 선분 방향을 반원으로 접어(반대 방향 상쇄 방지) 평균한다.
-bool _transferDotsHorizontal(
-  StructuredRouteMap map,
-  RouteMapTransferGroup group,
-  RouteMapDesignSpace design,
-) {
-  final c = design.toDesign(group.centroid);
-  var sx = 0.0, sy = 0.0;
-  for (final line in map.lines) {
-    if (!group.lineIds.contains(line.lineId)) continue;
-    var best = double.infinity;
-    var bestDir = Offset.zero;
-    for (final poly in line.polylines) {
-      for (var i = 1; i < poly.length; i += 1) {
-        final a = design.toDesign(poly[i - 1]);
-        final b = design.toDesign(poly[i]);
-        final d = ((a + b) / 2 - c).distanceSquared;
-        final seg = b - a;
-        if (d < best && seg.distance > 0) {
-          best = d;
-          bestDir = seg / seg.distance;
-        }
-      }
-    }
-    if (bestDir.dx < 0 || (bestDir.dx == 0 && bestDir.dy < 0)) {
-      bestDir = -bestDir; // 반원 접기
-    }
-    sx += bestDir.dx;
-    sy += bestDir.dy;
-  }
-  return sx.abs() > sy.abs();
-}
 
 /// design space에서 전 레이어를 1회 녹화한다 (#1789 스펙 S6).
 /// 프레임 루프에는 이 Picture의 재생만 남는다. 호출자가 dispose 책임.
@@ -207,34 +176,20 @@ ui.Picture recordRouteMapPicture({
     );
   }
 
-  // 3) 환승 캡슐 — 기존 routeMapTransferMarkers를 design 좌표로 호출.
+  // 3) 환승 흰 원(서울메트로 룩) — 간선 색 선이 만나는 지점에 흰 채움+짙은 테두리
+  //    원을 얹는다. 수렴·소분산은 원 1개, 대분산(물리적으로 먼 환승)은 멤버별 원 +
+  //    centroid 연결선(공식 지도의 도보 연결 표현).
   for (final group in map.transferGroups) {
-    final markers = routeMapTransferMarkers(
-      memberCenters: [
-        for (final p in group.memberPositions) design.toDesign(p),
-      ],
-      colors: [
-        for (final id in group.lineIds) lineColors[id] ?? _fallbackLineColor,
-      ],
-      designSpread:
-          offsetsMaxPairwiseDistance(group.memberPositions) *
-          design.designScale,
-      dotRadius: kRouteMapTransferDotRadiusPx,
-      dotGap: kRouteMapTransferDotGapPx,
-      padding: kRouteMapTransferDotPaddingPx,
-      horizontalDots: _transferDotsHorizontal(map, group, design),
+    final marker = routeMapTransferRings(
+      members: [for (final p in group.memberPositions) design.toDesign(p)],
     );
-    for (final marker in markers) {
-      canvas.drawRRect(marker.capsule, _transferFillPaint);
-      canvas.drawRRect(marker.capsule, _transferBorderPaint);
-      for (final dot in marker.dots) {
-        _transferDotPaint.color = dot.color;
-        canvas.drawCircle(
-          dot.center,
-          kRouteMapTransferDotRadiusPx,
-          _transferDotPaint,
-        );
-      }
+    // 연결선을 먼저(원 아래).
+    for (final connector in marker.connectors) {
+      canvas.drawLine(connector.first, connector.last, _transferConnectorPaint);
+    }
+    for (final ring in marker.rings) {
+      canvas.drawCircle(ring.center, ring.radius, _transferFillPaint);
+      canvas.drawCircle(ring.center, ring.radius, _transferBorderPaint);
     }
   }
 

--- a/apps/mobile/test/features/network_map/presentation/capital_label_overlap_gate_test.dart
+++ b/apps/mobile/test/features/network_map/presentation/capital_label_overlap_gate_test.dart
@@ -22,10 +22,12 @@ Size _measureBadge(String text) => Size(
 // 분리 불가한 기약 케이스 — 도심 겹침은 0이다(스펙 R3). baseline은 악화 금지.
 const int kCapitalUnresolvedBaseline = 2;
 
-// 2026-07-06 실기기 클러터 게이트 확장 — 라벨-라벨 외 라벨-선·뱃지 겹침도 측정해
-// "게이트=실기기 체감" 정합. baseline은 현재 실측값(악화 금지); 후속 #2·#3 수정이 낮춘다.
+// 2026-07-06 실기기 클러터 게이트 — 라벨-라벨 외 라벨-선 겹침도 측정해 "게이트=
+// 실기기 체감" 정합. baseline은 현재 실측값(악화 금지).
 const int kCapitalLabelLineOverlapBaseline = 17;
-const int kCapitalBadgeLineOverlapBaseline = 1;
+// 노선번호 색 원은 간선 위에 얹히는 게 서울메트로 룩의 의도라 뱃지-선 겹침은 측정
+// 하지 않는다(#1789). 대신 뱃지가 역명을 가리지 않는 것(뱃지-라벨 겹침 0)이 핵심
+// 제약 — 뱃지 pass가 라벨과 겹치는 후보를 생략한다.
 const int kCapitalBadgeLabelOverlapBaseline = 0;
 
 void main() {
@@ -72,17 +74,11 @@ void main() {
       reason:
           '라벨-선 겹침 $labelLine — baseline $kCapitalLabelLineOverlapBaseline 악화 금지',
     );
-    expect(
-      badge.line,
-      lessThanOrEqualTo(kCapitalBadgeLineOverlapBaseline),
-      reason:
-          '뱃지-선 겹침 ${badge.line} — baseline $kCapitalBadgeLineOverlapBaseline 악화 금지',
-    );
+    // 노선번호 원이 역명을 가리지 않는다(핵심 제약) — 간선 위 배치는 의도.
     expect(
       badge.label,
       lessThanOrEqualTo(kCapitalBadgeLabelOverlapBaseline),
-      reason:
-          '뱃지-라벨 겹침 ${badge.label} — baseline $kCapitalBadgeLabelOverlapBaseline 악화 금지',
+      reason: '뱃지-라벨 겹침 ${badge.label} — 역명 판독 우선(0 유지, 겹치는 후보는 생략)',
     );
   });
 }

--- a/apps/mobile/test/features/network_map/presentation/route_map_label_layout_test.dart
+++ b/apps/mobile/test/features/network_map/presentation/route_map_label_layout_test.dart
@@ -96,11 +96,29 @@ void main() {
     );
   });
 
-  test('뱃지는 노선 종점 2개만 (반복 없음 — 역명 가림 방지)', () {
+  test('노선번호 뱃지는 역명을 가리지 않고 노선당 소수', () {
     final map = _gridMap(count: 60);
     final layout = _solve(map);
-    // 공식 노선도 관례: 노선명은 종점에만. 중간 반복은 역명을 덮으므로 없앤다.
-    expect(layout.badges.length, 2);
+    // 역명 판독 우선(#1789): 뱃지가 어떤 역 라벨도 덮지 않는다(겹치면 생략).
+    for (final b in layout.badges) {
+      for (final l in layout.labels) {
+        final o = b.rect.intersect(l.rect);
+        expect(
+          o.width > 0 && o.height > 0,
+          isFalse,
+          reason: '뱃지 ${b.lineId}가 라벨 ${l.id}를 덮음',
+        );
+      }
+    }
+    // 노선당 최대 3개(간선 위 소수), clear 자리 없으면 0개 허용.
+    expect(layout.badges.length, lessThanOrEqualTo(3));
+  });
+
+  test('여유 구간에서는 노선번호 뱃지가 간선 위에 배치된다', () {
+    // 널널한 단일 행 노선(긴 트렁크) → 뱃지가 라벨 없는 간선 구간에 배치.
+    final map = _gridMap(count: 6, sourceSpacing: 200);
+    final layout = _solve(map);
+    expect(layout.badges, isNotEmpty);
   });
 
   test('전부 충돌이어도 숨기지 않고 최소 겹침 배치 + unresolved 집계', () {
@@ -142,9 +160,9 @@ void main() {
     expect(byId['s5:L1']!.bold, isFalse); // 일반
   });
 
-  test('라벨은 환승 캡슐 rect를 덮지 않는다 (캡슐 장애물)', () {
-    // 환승 1(스팬 캡슐) + 바로 옆 일반역 1 — 일반역 라벨의 기본 방향 후보가
-    // 캡슐과 부딪히도록 배치한다.
+  test('라벨은 환승 흰 원 rect를 덮지 않는다 (원 장애물)', () {
+    // 환승 1(소분산 → 단일 흰 원) + 바로 옆 일반역 1 — 일반역 라벨의 기본 방향
+    // 후보가 원과 부딪히도록 배치한다.
     final map = StructuredRouteMap(
       lines: const [],
       stations: [
@@ -170,7 +188,7 @@ void main() {
           stationId: 't',
           lineIds: const ['L1', 'L2'],
           centroid: const Offset(0, 0),
-          memberPositions: const [Offset(-6, 0), Offset(6, 0)], // 스팬 이격 12
+          memberPositions: const [Offset(-3, 0), Offset(3, 0)], // 소분산 → 원 1개
         ),
       ],
     );
@@ -192,7 +210,7 @@ void main() {
         expect(
           overlap.width > 0 && overlap.height > 0,
           isFalse,
-          reason: '${label.id} 라벨이 캡슐을 덮음',
+          reason: '${label.id} 라벨이 환승 원을 덮음',
         );
       }
     }

--- a/apps/mobile/test/features/network_map/presentation/route_map_transfer_marker_test.dart
+++ b/apps/mobile/test/features/network_map/presentation/route_map_transfer_marker_test.dart
@@ -163,4 +163,48 @@ void main() {
       5,
     );
   });
+
+  group('routeMapTransferRings (서울메트로 흰 원)', () {
+    test('수렴 멤버는 centroid 흰 원 1개, 연결선 없음', () {
+      final m = routeMapTransferRings(
+        members: const [Offset(100, 100), Offset(100, 100)],
+      );
+      expect(m.rings, hasLength(1));
+      expect(m.rings.single.center, const Offset(100, 100));
+      expect(m.connectors, isEmpty);
+    });
+
+    test('소분산(< 2*radius) 멤버도 centroid 원 1개', () {
+      final m = routeMapTransferRings(
+        members: const [Offset(100, 100), Offset(104, 100)],
+        radius: 6,
+      );
+      expect(m.rings, hasLength(1));
+      expect(m.rings.single.center, const Offset(102, 100));
+      expect(m.connectors, isEmpty);
+    });
+
+    test('대분산(>= 2*radius) 멤버는 멤버별 원 + centroid 연결선', () {
+      final m = routeMapTransferRings(
+        members: const [Offset(0, 0), Offset(100, 0)],
+        radius: 6,
+      );
+      expect(m.rings, hasLength(2));
+      expect(
+        m.rings.map((r) => r.center),
+        containsAll(const [Offset(0, 0), Offset(100, 0)]),
+      );
+      expect(m.connectors, hasLength(2));
+      // 각 연결선의 끝점은 centroid.
+      for (final c in m.connectors) {
+        expect(c.last, const Offset(50, 0));
+      }
+    });
+
+    test('멤버 0개는 빈 마커', () {
+      final m = routeMapTransferRings(members: const []);
+      expect(m.rings, isEmpty);
+      expect(m.connectors, isEmpty);
+    });
+  });
 }

--- a/apps/mobile/test/features/network_map/presentation/structured_route_map_painter_test.dart
+++ b/apps/mobile/test/features/network_map/presentation/structured_route_map_painter_test.dart
@@ -109,4 +109,17 @@ void main() {
     // 맨 앞이 '('이면 축약할 역명이 없으므로 원문 유지.
     expect(routeMapStationLabel('(임시)역'), '(임시)역');
   });
+
+  test('routeMapBadgeTextColor: 밝은 노선색은 검정, 어두운색은 흰색', () {
+    // 3호선 계열 노랑(밝음) → 검정.
+    expect(
+      routeMapBadgeTextColor(const Color(0xFFFFD400)),
+      const Color(0xFF000000),
+    );
+    // 1호선 파랑(어두움) → 흰색.
+    expect(
+      routeMapBadgeTextColor(const Color(0xFF0052A4)),
+      const Color(0xFFFFFFFF),
+    );
+  });
 }


### PR DESCRIPTION
## 관련 이슈

Refs #1789 (노선도 서울메트로 룩 폴리싱)

## 작업 배경

- 재간격 팩 확정 후, 서울메트로 공식 지도 수준의 환승·노선번호 표현으로 폴리싱.
- 정본 스펙: `docs/superpowers/specs/2026-07-06-route-map-seoul-metro-look-design.md`, 계획: `docs/superpowers/plans/2026-07-06-route-map-seoul-metro-look.md`.

## 작업 내용

- **환승 마커**: 흰 캡슐+색 도트 스택 → **흰 채움+짙은 테두리 원**(서울메트로식). 수렴/소분산은 원 1개, 대분산(물리적으로 먼 환승)은 멤버별 원 + centroid 연결선. 순수 함수 `routeMapTransferRings`.
- **노선번호**: 종점 텍스트 뱃지 → **노선색 원 + WCAG 대비색 번호**. 간선 arc-length 위 노선당 최대 2~3개, **역명을 가리면 생략**(역명 판독 우선 — 라벨 배치 후 별도 pass, 겹치는 후보 skip, 노선당 0개 허용).
- painter 렌더 전환 + 라벨 솔버 환승 원 장애물 시드.

## 검증

- 실행한 명령과 결과:
  - `flutter analyze lib test` → No issues
  - `flutter test` → **744 passed** (환승 원 기하·대비색·뱃지 arc-length/생략·실데이터 겹침 게이트 포함)
  - 실데이터 게이트: **뱃지-라벨 겹침 0**(역명 안 가림), 라벨-라벨 겹침 ≤ 1
  - **헤드리스 렌더 QA**: capital 팩을 실제 painter로 PNG 래스터화 — 흰 원 환승·노선색 원 뱃지·정확한 노선색·역명 미가림 육안 확인(오버뷰+도심 크롭).

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 환승 원 기하 | mobile | 순수함수 단위 테스트 | flutter test | 수렴/소분산 1원·대분산 다원+연결선 |
| 뱃지 역명 미가림 | mobile | 실데이터 겹침 게이트 | flutter test | 뱃지-라벨 겹침 0 |
| 서울메트로 룩 렌더 | mobile | 헤드리스 painter PNG | 로컬 QA(scratchpad) | 흰 원·색 원·색상 정상 |
| 전체 회귀 | mobile | flutter test 전체 | 744 passed | green |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음 (앱 미출시·렌더 폴리싱)
- mobile versionCode: 변경 없음
- datapack version: 영향 없음(팩 미변경 — 렌더만)
- route contract: 영향 없음
- realtime contract: 영향 없음
- backend identity: 영향 없음

## 리뷰어 메모

- 먼저 볼 지점: `route_map_transfer_marker.dart`(routeMapTransferRings 분류), `route_map_label_layout.dart`(뱃지 arc-length pass·역명 우선 생략), `structured_route_map_painter.dart`(원·색원뱃지 드로우). 스택 base=#1826(→#1825→main), 자동 retarget.

## 리스크

- 팩 미변경(렌더 전용). 대분산 환승의 연결선은 얇은 회색(도보 연결 표현). 텍스트 legibility는 실기기 폰트 대상(헤드리스 QA는 형태·배치 검증).

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
