### PR TITLE
[Fix] fdl-excel 내보내기 메모리 테스트 flaky 제거 — 힙 측정 대신 결정적 가드

### DIFF
--- a/backend/src/test/java/com/easysubway/common/web/export/EgovExcelExportSupportTest.java
+++ b/backend/src/test/java/com/easysubway/common/web/export/EgovExcelExportSupportTest.java
@@ -38,28 +38,28 @@ class EgovExcelExportSupportTest {
 	}
 
 	@Test
-	@DisplayName("1만 행 내보내기는 힙 증분 상한 안에서 완료된다(메모리 방어 증거)")
-	void bounds10kRowExportMemory() throws Exception {
+	@DisplayName("여러 행 내보내기도 순서대로 유효한 xlsx를 만든다")
+	void rendersMultiRowXlsx() throws Exception {
+		int rowCount = 1_000;
 		List<List<String>> rows = new ArrayList<>();
-		for (int index = 0; index < 10_000; index++) {
+		for (int index = 0; index < rowCount; index++) {
 			rows.add(List.of("station-" + index, "facility-" + index, String.valueOf(index), "detail-" + index));
 		}
 
-		System.gc();
-		long before = usedHeapBytes();
-		byte[] xlsx = support.toXlsx("large", List.of("a", "b", "c", "d"), rows);
-		long increment = usedHeapBytes() - before;
+		byte[] xlsx = support.toXlsx("multi", List.of("a", "b", "c", "d"), rows);
 
 		try (var workbook = new XSSFWorkbook(new ByteArrayInputStream(xlsx))) {
-			assertThat(workbook.getSheetAt(0).getLastRowNum()).isEqualTo(10_000);
+			Sheet sheet = workbook.getSheetAt(0);
+			assertThat(sheet.getLastRowNum()).isEqualTo(rowCount);
+			assertThat(cell(sheet, 1, 0)).isEqualTo("station-0");
+			assertThat(cell(sheet, rowCount, 2)).isEqualTo(String.valueOf(rowCount - 1));
 		}
-		// in-memory XSSF 10k행×4열의 힙 증분은 넉넉한 상한(256MB) 안에 머문다.
-		assertThat(increment).isLessThan(256L * 1024 * 1024);
 	}
 
 	@Test
-	@DisplayName("행 수 상한을 초과하면 발번을 거부한다(상한 초과 시 실패)")
+	@DisplayName("행 수 상한을 초과하면 발번을 거부한다(메모리 방어 — 상한 초과 시 실패)")
 	void rejectsRowsBeyondLimit() {
+		// 상한 초과 목록은 tasklet 없이 크기만 검사되어 즉시 거부된다(XSSF 워크북 미생성).
 		List<List<String>> rows = new ArrayList<>();
 		for (int index = 0; index < EgovExcelExportSupport.MAX_EXPORT_ROWS + 1; index++) {
 			rows.add(List.of(String.valueOf(index)));
@@ -73,10 +73,5 @@ class EgovExcelExportSupportTest {
 	private static String cell(Sheet sheet, int rowIndex, int columnIndex) {
 		Row row = sheet.getRow(rowIndex);
 		return row == null ? null : row.getCell(columnIndex).getStringCellValue();
-	}
-
-	private static long usedHeapBytes() {
-		Runtime runtime = Runtime.getRuntime();
-		return runtime.totalMemory() - runtime.freeMemory();
 	}
 }


### PR DESCRIPTION
## 관련 이슈

Refs #1822

## 작업 배경

- 기존 PR 본문 참조.

## 작업 내용

<details>
<summary>기존 PR 본문</summary>

## 무엇을 / 왜 (초긴급)

`EgovExcelExportSupportTest.bounds10kRowExportMemory`(S4 #1822에서 도입)가 **무관 PR CI까지 간헐 OOM/red로 막고 있어** 제거·재설계한다. (memory note: "eGovFrame 메모리 테스트가 무관 PR CI도 간헐 red")

## 원인

- `usedHeapBytes() = Runtime.totalMemory() - freeMemory()`는 **공유 테스트 JVM 전체 힙**을 재므로 GC 타이밍·병렬 포크·캐시된 `@SpringBootTest` 컨텍스트에 오염돼 측정이 비결정적(음수/거대값).
- 10k행 `XSSFWorkbook`을 통째로 만들고 **다시 읽어(이중 인스턴스)** 힙을 크게 쓴 뒤 OOM으로 터진다.

## 수정 (테스트 전용, 격리)

- ❌ 제거: `bounds10kRowExportMemory`(힙 측정), `usedHeapBytes()`.
- ✅ 유지: `rejectsRowsBeyondLimit` — `MAX_EXPORT_ROWS`(50k) 초과 시 실패. **이것이 실질 메모리 방어**(in-memory XSSF 무한 증가 차단, 워크북 생성 전 크기만 검사 → 경량·결정적).
- ➕ 추가: `rendersMultiRowXlsx`(1000행) — 순서·유효성 회귀 커버(힙 측정 없음, 저메모리).

`build.gradle`의 `maxHeapSize=2g`는 유지(usage 등 커진 스위트 공통). production 내보내기는 도메인상 소규모라 in-memory XSSF로 충분하고 상한 가드가 방어 역할.

## 검증

```
cd backend && ./gradlew test --tests "*EgovExcelExportSupportTest"   # green, OOM 없음(6s)
```

메모리 방어 증거(#1822 게이트)는 결정적 상한 가드로 유지되며, flaky 힙 측정만 제거한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>

## 검증

- 실행한 명령과 결과: 기존 PR 본문 참조.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| PR 본문 양식 보강 | GitHub PR | 현재 템플릿 섹션 존재 확인 | PR body | 완료 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [ ] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [ ] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [ ] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 기존 PR 본문 참조
- mobile versionCode: 기존 PR 본문 참조
- datapack version: 기존 PR 본문 참조
- route contract: 기존 PR 본문 참조
- realtime contract: 기존 PR 본문 참조
- backend identity: 기존 PR 본문 참조

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 기존 PR 본문 참조.

## 리스크

- 기존 PR 본문 참조.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
