### PR TITLE
[Feat] 데이터팩 단계적 롤아웃 tools+workflow — rollout 스키마·재서명·publish-rollout·워크플로 모드 (#1692)

### DIFF
--- a/.github/workflows/datapack-release.yml
+++ b/.github/workflows/datapack-release.yml
@@ -20,7 +20,7 @@ on:
         type: choice
         required: true
         default: exploratory
-        options: [exploratory, release-candidate, production-publish, rollback]
+        options: [exploratory, release-candidate, production-publish, rollback, rollout-update]
       targetChannel:
         description: Target data pack channel
         type: choice
@@ -45,7 +45,7 @@ jobs:
     permissions:
       contents: read
     environment:
-      name: ${{ (github.event.inputs.mode == 'production-publish' || github.event.inputs.mode == 'rollback') && 'production-datapack' || 'datapack-release-check' }}
+      name: ${{ (github.event.inputs.mode == 'production-publish' || github.event.inputs.mode == 'rollback' || github.event.inputs.mode == 'rollout-update') && 'production-datapack' || 'datapack-release-check' }}
     env:
       NODE_OPTIONS: --disable-warning=ExperimentalWarning
 
@@ -97,7 +97,7 @@ jobs:
               console.error("modeArgs must be a JSON object");
               process.exit(1);
             }
-            const keys = ["buildSpecPath","releaseRequestId","releaseRequestPath","androidEvidencePath","strictRouteRegressionPath","allowGaps","rollbackTargetSequence","rollbackReason","rollbackIdempotencyKey"];
+            const keys = ["buildSpecPath","releaseRequestId","releaseRequestPath","androidEvidencePath","strictRouteRegressionPath","allowGaps","rollbackTargetSequence","rollbackReason","rollbackIdempotencyKey","rolloutPercentage","rolloutTargetSequence"];
             const out = [];
             for (const k of keys) {
               const v = String(a[k] ?? "");
@@ -209,6 +209,11 @@ jobs:
             echo "mode=${mode}"
             echo "allow_gaps=${allow_gaps}"
             echo "target_channel=${target_channel}"
+            if [[ "${mode}" == "rollback" || "${mode}" == "rollout-update" ]]; then
+              echo "is-pointer-only=true"
+            else
+              echo "is-pointer-only=false"
+            fi
           } >> "${GITHUB_OUTPUT}"
 
       - name: Data Pack Release / Restore GitHub Actions dotenv secret
@@ -307,7 +312,7 @@ jobs:
           echo "RELEASE_REQUEST_PATH=release-request.json" >> "$GITHUB_ENV"
 
       - name: Data Pack Release / Prepare release fixture
-        if: ${{ steps.release-mode.outputs.mode != 'rollback' }}
+        if: ${{ steps.release-mode.outputs.is-pointer-only != 'true' }}
         id: release-fixture
         run: |
           set -euo pipefail
@@ -353,7 +358,7 @@ jobs:
           echo "EASYSUBWAY_DATAPACK_BUILD_FIXTURE=${build_fixture}" >> "${GITHUB_ENV}"
 
       - name: Data Pack Release / Audit route map coordinate coverage
-        if: ${{ steps.release-mode.outputs.mode != 'rollback' }}
+        if: ${{ steps.release-mode.outputs.is-pointer-only != 'true' }}
         run: |
           set -euo pipefail
           mkdir -p "${EASYSUBWAY_DATAPACK_STAGE}"
@@ -365,7 +370,7 @@ jobs:
           test -s "${EASYSUBWAY_ROUTE_MAP_AUDIT_REPORT}"
 
       - name: Data Pack Release / Build data packs
-        if: ${{ steps.release-mode.outputs.mode != 'rollback' }}
+        if: ${{ steps.release-mode.outputs.is-pointer-only != 'true' }}
         run: |
           set -euo pipefail
           if [[ "${EASYSUBWAY_DATAPACK_RELEASE_MODE}" =~ ^(release-candidate|production-publish)$ ]]; then
@@ -379,7 +384,7 @@ jobs:
           fi
 
       - name: Data Pack Release / Validate source inventory
-        if: ${{ steps.release-mode.outputs.mode != 'rollback' }}
+        if: ${{ steps.release-mode.outputs.is-pointer-only != 'true' }}
         run: |
           set -euo pipefail
           node tools/datapack/validate-source-inventory.mjs \
@@ -387,7 +392,7 @@ jobs:
             --scope apps/mobile/release/production-datapack-scope.json
 
       - name: Data Pack Release / Validate generated data packs
-        if: ${{ steps.release-mode.outputs.mode != 'rollback' }}
+        if: ${{ steps.release-mode.outputs.is-pointer-only != 'true' }}
         run: |
           set -euo pipefail
           test -f tools/datapack/schema/manifest.schema.json
@@ -404,7 +409,7 @@ jobs:
           node -e "const manifest=require(process.env.EASYSUBWAY_DATAPACK_OUTPUT + '/current.json'); if (!manifest.packs.every((pack) => Array.isArray(pack.sourceInventory) && pack.sourceInventory.length > 0)) throw new Error('sourceInventory missing');"
 
       - name: Data Pack Release / Write coverage gap evidence
-        if: ${{ steps.release-mode.outputs.mode != 'rollback' }}
+        if: ${{ steps.release-mode.outputs.is-pointer-only != 'true' }}
         run: |
           set -euo pipefail
           mkdir -p "${EASYSUBWAY_DATAPACK_STAGE}"
@@ -422,7 +427,7 @@ jobs:
           test -s "${EASYSUBWAY_COVERAGE_GAP_REPORT}"
 
       - name: Data Pack Release / Stage pack files
-        if: ${{ steps.release-mode.outputs.mode != 'rollback' }}
+        if: ${{ steps.release-mode.outputs.is-pointer-only != 'true' }}
         run: |
           set -euo pipefail
           mkdir -p "${EASYSUBWAY_DATAPACK_STAGE}/catalog"
@@ -433,7 +438,7 @@ jobs:
           test -n "$(find "${EASYSUBWAY_DATAPACK_STAGE}/catalog" -name "*.sqlite.gz" -type f -print -quit)"
 
       - name: Data Pack Release / Verify uploaded pack checksums before manifest publish
-        if: ${{ steps.release-mode.outputs.mode != 'rollback' }}
+        if: ${{ steps.release-mode.outputs.is-pointer-only != 'true' }}
         run: |
           set -euo pipefail
           node tools/datapack/validate-datapack.mjs \
@@ -441,7 +446,7 @@ jobs:
             --root "${EASYSUBWAY_DATAPACK_STAGE}"
 
       - name: Data Pack Release / Stage manifest
-        if: ${{ steps.release-mode.outputs.mode != 'rollback' }}
+        if: ${{ steps.release-mode.outputs.is-pointer-only != 'true' }}
         run: |
           set -euo pipefail
           cp "${EASYSUBWAY_DATAPACK_OUTPUT}/current.json" "${EASYSUBWAY_DATAPACK_STAGE}/catalog/current.json"
@@ -450,7 +455,7 @@ jobs:
             --root "${EASYSUBWAY_DATAPACK_STAGE}"
 
       - name: Data Pack Release / Write route graph topology evidence
-        if: ${{ steps.release-mode.outputs.mode != 'rollback' }}
+        if: ${{ steps.release-mode.outputs.is-pointer-only != 'true' }}
         run: |
           set -euo pipefail
           node tools/datapack/build-route-graph-topology-report.mjs \
@@ -460,7 +465,7 @@ jobs:
           test -s "${EASYSUBWAY_ROUTE_GRAPH_TOPOLOGY_REPORT}"
 
       - name: Data Pack Release / Write headway evidence
-        if: ${{ steps.release-mode.outputs.mode != 'rollback' }}
+        if: ${{ steps.release-mode.outputs.is-pointer-only != 'true' }}
         run: |
           set -euo pipefail
           node tools/datapack/build-headway-report.mjs \
@@ -469,7 +474,7 @@ jobs:
           test -s "${EASYSUBWAY_HEADWAY_REPORT}"
 
       - name: Data Pack Release / Write release evidence bundle
-        if: ${{ steps.release-mode.outputs.mode != 'rollback' }}
+        if: ${{ steps.release-mode.outputs.is-pointer-only != 'true' }}
         id: evidence-bundle
         run: |
           set -euo pipefail
@@ -558,7 +563,7 @@ jobs:
           NODE
 
       - name: Data Pack Release / Validate release evidence bundle
-        if: ${{ steps.release-mode.outputs.mode != 'rollback' }}
+        if: ${{ steps.release-mode.outputs.is-pointer-only != 'true' }}
         run: |
           set -euo pipefail
           bundle_args=(--bundle "${EASYSUBWAY_RELEASE_EVIDENCE_BUNDLE}")
@@ -568,7 +573,7 @@ jobs:
           node tools/datapack/validate-release-evidence-bundle.mjs "${bundle_args[@]}"
 
       - name: Data Pack Release / Create manifest-last publish preflight plan
-        if: ${{ steps.release-mode.outputs.mode != 'rollback' }}
+        if: ${{ steps.release-mode.outputs.is-pointer-only != 'true' }}
         run: |
           set -euo pipefail
           node tools/datapack/create-publish-plan.mjs \
@@ -578,7 +583,7 @@ jobs:
           test -f "${EASYSUBWAY_DATAPACK_PUBLISH_PLAN}"
 
       - name: Data Pack Release / Validate object storage publish executor dry run
-        if: ${{ steps.release-mode.outputs.mode != 'rollback' }}
+        if: ${{ steps.release-mode.outputs.is-pointer-only != 'true' }}
         run: |
           set -euo pipefail
           node tools/datapack/publish-object-storage.mjs \
@@ -663,6 +668,20 @@ jobs:
             --base-url "${EASYSUBWAY_OBJECT_STORAGE_PREAUTH_BASE_URL}" \
             --reason "${ROLLBACK_REASON}" \
             --idempotency-key "${ROLLBACK_IDEMPOTENCY_KEY}"
+
+      - name: Data Pack Release / Rollout update pointer swap
+        if: ${{ steps.release-mode.outputs.mode == 'rollout-update' && steps.remote-publish-env.outputs.enabled == 'true' && github.ref == 'refs/heads/main' }}
+        env:
+          # workflow_dispatch 자유입력을 셸에 직접 보간하지 않고 env로 전달한다(GHA expression injection 방지).
+          ROLLOUT_TARGET_SEQUENCE: ${{ steps.args.outputs.rolloutTargetSequence }}
+          ROLLOUT_PERCENTAGE: ${{ steps.args.outputs.rolloutPercentage }}
+        run: |
+          set -euo pipefail
+          node tools/datapack/publish-rollout.mjs \
+            --base-url "${EASYSUBWAY_OBJECT_STORAGE_PREAUTH_BASE_URL}" \
+            --target-sequence "${ROLLOUT_TARGET_SEQUENCE}" \
+            --percentage "${ROLLOUT_PERCENTAGE}" \
+            --channel production
 
       - name: Data Pack Release / Write observability metadata
         if: ${{ always() }}

--- a/.github/workflows/datapack-release.yml
+++ b/.github/workflows/datapack-release.yml
@@ -682,6 +682,7 @@ jobs:
             --target-sequence "${ROLLOUT_TARGET_SEQUENCE}" \
             --percentage "${ROLLOUT_PERCENTAGE}" \
             --channel production
+          echo "EASYSUBWAY_DATAPACK_REMOTE_PUBLISH_RESULT=success" >> "${GITHUB_ENV}"
 
       - name: Data Pack Release / Write observability metadata
         if: ${{ always() }}

--- a/tools/ci/datapack-release-workflow.test.mjs
+++ b/tools/ci/datapack-release-workflow.test.mjs
@@ -58,3 +58,12 @@ test("production-publish는 release request 조회 스텝과 !cancelled() 콜백
   // evidence-bundle 출력을 콜백 게이트로 사용하면 release-candidate에서도 발사 → 금지
   assert.doesNotMatch(yml, /steps\.evidence-bundle\.outputs\.manifestSha256/);
 });
+
+test("워크플로는 rollout-update 모드·publish-rollout 스텝을 가지고 빌드 스텝을 pointer-only로 게이트한다", () => {
+  assert.match(yml, /rollout-update/);
+  assert.match(yml, /publish-rollout\.mjs/);
+  assert.match(yml, /rolloutPercentage/);
+  assert.match(yml, /rolloutTargetSequence/);
+  assert.match(yml, /is-pointer-only/);            // 빌드 스텝 게이팅 output
+  assert.doesNotMatch(yml, /mode != 'rollback'/);  // 구 게이트가 pointer-only로 통합됨
+});

--- a/tools/datapack/build-datapack.mjs
+++ b/tools/datapack/build-datapack.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { createHash, createSign } from "node:crypto";
+import { createHash } from "node:crypto";
 import { mkdir, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import { gzipSync } from "node:zlib";
 import { DatabaseSync } from "node:sqlite";
@@ -15,6 +15,7 @@ import {
   validatePackUrlMatchesStagedPath,
   withoutSignature,
 } from "./lib/manifest-validation.mjs";
+import { rsaSha256Signature, signingPrivateKey } from "./lib/manifest-signing.mjs";
 
 const root = path.resolve(import.meta.dirname, "../..");
 const productionMinimumTableRowNames = [
@@ -584,18 +585,6 @@ function canonicalRouteRegressionScope(scope) {
 
 function canonicalProductionPackUrl(packUrl) {
   return new URL(packUrl).toString();
-}
-
-function signingPrivateKey() {
-  const key = process.env.EASYSUBWAY_DATAPACK_SIGNING_PRIVATE_KEY_PEM?.trim();
-  if (!key) {
-    throw new Error("EASYSUBWAY_DATAPACK_SIGNING_PRIVATE_KEY_PEM is required for production data pack signatures");
-  }
-  return key;
-}
-
-function rsaSha256Signature(privateKey, value) {
-  return createSign("RSA-SHA256").update(value).sign(privateKey).toString("base64url");
 }
 
 function regionalQualityMetrics(pack) {

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -10,6 +10,7 @@ import path from "node:path";
 import { promisify } from "node:util";
 import test from "node:test";
 import { sortJson } from "./run-source-admission-pipeline.mjs";
+import { validateManifest } from "./lib/manifest-validation.mjs";
 
 const execFileAsync = promisify(execFile);
 const root = path.resolve(import.meta.dirname, "../..");
@@ -11925,3 +11926,78 @@ function representativeRouteRegressionPayload(routes) {
     })),
   );
 }
+
+// rollout 검증 단위 테스트용 최소 유효 v1 fixture 매니페스트 생성 헬퍼
+function minimalFixtureManifest() {
+  const hex64 = "a".repeat(64);
+  return {
+    ttlSeconds: 3600,
+    packs: [
+      {
+        id: "test",
+        version: "1",
+        artifactKind: "fixture",
+        url: "catalog/test-v1.sqlite.gz",
+        sha256: hex64,
+        sqliteSha256: hex64,
+        sizeBytes: 1,
+        signature: { algorithm: "sha256-pack-manifest-v1", value: hex64 },
+        schemaVersion: "1",
+        sourceInventory: [
+          {
+            id: "src",
+            owner: "test",
+            url: "https://example.com",
+            license: "fixture",
+            licenseStatus: "fixture-only",
+            redistributionAllowed: false,
+            updateFrequency: "manual",
+            updatedAt: "2026-01-01",
+            fields: ["test"],
+          },
+        ],
+        regionalQualityMetrics: {
+          stationCount: 0,
+          facilityCoverageRatio: 0,
+          requiredFacilityEvidenceCoverageRatio: 0,
+          strictRouteEligibleFacilityRatio: 0,
+          operationalKnownRatio: 0,
+          freshnessValidRatio: 0,
+          fieldVerifiedPathwayRatio: 0,
+          edgeCount: 0,
+          unknownAccessibilityRatio: 0,
+          unknownEdgeRatioByProfile: { wheelchair: 0, stroller: 0, lowMobility: 0 },
+        },
+        representativeRouteRegressions: [],
+        representativeRouteRegressionSignature: {
+          algorithm: "sha256-route-regression-v1",
+          value: hex64,
+        },
+        requiredTables: ["catalog_metadata"],
+      },
+    ],
+  };
+}
+
+test("매니페스트 rollout은 percentage 0~100·seed hex32만 허용한다", () => {
+  const base = minimalFixtureManifest();
+  const ok = { ...base, rollout: { percentage: 10, seed: "a".repeat(32) } };
+  assert.doesNotThrow(() => validateManifest(ok));
+  assert.throws(
+    () => validateManifest({ ...base, rollout: { percentage: 101, seed: "a".repeat(32) } }),
+    /rollout.*percentage/,
+  );
+  assert.throws(
+    () => validateManifest({ ...base, rollout: { percentage: 10, seed: "zz" } }),
+    /rollout.*seed/,
+  );
+});
+
+test("releases 게시 대상 매니페스트에 rollout이 있으면 거부한다", () => {
+  const base = minimalFixtureManifest();
+  const withRollout = { ...base, rollout: { percentage: 10, seed: "a".repeat(32) } };
+  assert.throws(
+    () => validateManifest(withRollout, { releasesTarget: true }),
+    /releases.*rollout/i,
+  );
+});

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -12052,3 +12052,176 @@ test("manifest-signing: manifestSignatureValue는 canonicalJson(withoutSignature
     else delete process.env.EASYSUBWAY_DATAPACK_SIGNING_PRIVATE_KEY_PEM;
   }
 });
+
+// ─── buildRolloutManifest 단위 테스트 (#1692) ──────────────────────────────────
+// production releases 픽스처 생성 헬퍼 (keyId="production-v1", RSA-SHA256 서명 계산)
+
+function _rolloutCanonicalValue(value) {
+  if (value === null || typeof value === "string" || typeof value === "number" || typeof value === "boolean") return value;
+  if (Array.isArray(value)) return value.map(_rolloutCanonicalValue);
+  return Object.fromEntries(
+    Object.keys(value).sort((a, b) => (a < b ? -1 : a > b ? 1 : 0)).map((k) => [k, _rolloutCanonicalValue(value[k])]),
+  );
+}
+
+function _rolloutCanonicalJson(value) {
+  return JSON.stringify(_rolloutCanonicalValue(value));
+}
+
+function _rolloutSign(data) {
+  return createSign("RSA-SHA256").update(data).sign(testPrivateKeyPem).toString("base64url");
+}
+
+function buildProductionReleasesManifest(overrides = {}) {
+  const hex64 = "a".repeat(64);
+  const base = {
+    manifestVersion: 2,
+    channel: "production",
+    releaseSequence: 5,
+    publishedAt: "2026-07-07T00:00:00.000Z",
+    expiresAt: "2999-01-01T00:00:00.000Z",
+    keyId: "production-v1",
+    ttlSeconds: 3600,
+    signature: { algorithm: "rsa-sha256-manifest-v2", value: "placeholder" },
+    packs: [
+      {
+        id: "capital",
+        version: "1",
+        artifactKind: "production",
+        url: "https://cdn.example.com/catalog/capital-v1.sqlite.gz",
+        sha256: hex64,
+        sqliteSha256: hex64,
+        sizeBytes: 1000,
+        signature: {
+          algorithm: "rsa-sha256-pack-manifest-v2",
+          value: _rolloutSign("pack-payload"),
+        },
+        schemaVersion: "1",
+        sourceInventory: [
+          {
+            id: "src1",
+            owner: "test-owner",
+            url: "https://data.example.com/catalog",
+            license: "CC-BY-4.0",
+            licenseStatus: "redistributable",
+            redistributionAllowed: true,
+            updateFrequency: "daily",
+            updatedAt: "2026-07-07T00:00:00.000Z",
+            fields: ["stations"],
+            coverageScope: {
+              regionIds: ["seoul"],
+              operatorIds: ["seoulmetro"],
+              sourceDomains: ["station_map"],
+            },
+          },
+        ],
+        regionalQualityMetrics: {
+          stationCount: 100,
+          edgeCount: 200,
+          facilityCoverageRatio: 0.5,
+          requiredFacilityEvidenceCoverageRatio: 0.5,
+          strictRouteEligibleFacilityRatio: 0.5,
+          operationalKnownRatio: 1.0,
+          freshnessValidRatio: 0.8,
+          fieldVerifiedPathwayRatio: 0.3,
+          unknownAccessibilityRatio: 0.2,
+          unknownEdgeRatioByProfile: { wheelchair: 0.1, stroller: 0.1, lowMobility: 0.1 },
+        },
+        representativeRouteRegressions: [],
+        representativeRouteRegressionSignature: {
+          algorithm: "rsa-sha256-route-regression-v1",
+          value: _rolloutSign("regression-payload"),
+        },
+        requiredTables: ["stations"],
+        minimumTableRows: {
+          stations: 1,
+          station_lines: 1,
+          network_edges: 1,
+          facilities: 1,
+          station_facility_evidence: 1,
+        },
+      },
+    ],
+    ...overrides,
+  };
+  const { signature: _dropSig, ...unsigned } = base;
+  base.signature = {
+    algorithm: "rsa-sha256-manifest-v2",
+    value: _rolloutSign(_rolloutCanonicalJson(unsigned)),
+  };
+  return base;
+}
+
+test("buildRolloutManifest (a): percentage 50 → rollout{50,seed hex32} + validateManifest 통과(재서명 유효)", async () => {
+  const { buildRolloutManifest } = await import("./update-rollout.mjs");
+  const { verifyRsaSha256Signature, canonicalJson, withoutSignature } = await import("./lib/manifest-validation.mjs");
+  const releases = buildProductionReleasesManifest();
+  const savedPriv = process.env.EASYSUBWAY_DATAPACK_SIGNING_PRIVATE_KEY_PEM;
+  const savedPub = process.env.EASYSUBWAY_DATAPACK_SIGNING_PUBLIC_KEY_PEM;
+  try {
+    process.env.EASYSUBWAY_DATAPACK_SIGNING_PRIVATE_KEY_PEM = testPrivateKeyPem;
+    process.env.EASYSUBWAY_DATAPACK_SIGNING_PUBLIC_KEY_PEM = testPublicKeyPem;
+    const result = buildRolloutManifest({ releases, current: null, targetSequence: 5, percentage: 50 });
+    assert.ok(result.rollout, "rollout 필드 있어야 함");
+    assert.equal(result.rollout.percentage, 50);
+    assert.match(result.rollout.seed, /^[a-f0-9]{32}$/, "seed hex32 이어야 함");
+    assert.ok(
+      verifyRsaSha256Signature(testPublicKeyPem, canonicalJson(withoutSignature(result)), result.signature.value),
+      "재서명이 공개키로 검증되어야 함",
+    );
+    assert.doesNotThrow(() => validateManifest(result, { requireProduction: true }), "validateManifest 통과해야 함");
+  } finally {
+    if (savedPriv !== undefined) process.env.EASYSUBWAY_DATAPACK_SIGNING_PRIVATE_KEY_PEM = savedPriv;
+    else delete process.env.EASYSUBWAY_DATAPACK_SIGNING_PRIVATE_KEY_PEM;
+    if (savedPub !== undefined) process.env.EASYSUBWAY_DATAPACK_SIGNING_PUBLIC_KEY_PEM = savedPub;
+    else delete process.env.EASYSUBWAY_DATAPACK_SIGNING_PUBLIC_KEY_PEM;
+  }
+});
+
+test("buildRolloutManifest (b): percentage 100 → rollout 없음, releases에서 rollout 제거한 구조와 deepStrictEqual", async () => {
+  const { buildRolloutManifest } = await import("./update-rollout.mjs");
+  const releases = buildProductionReleasesManifest();
+  const { rollout: _dropRollout, ...releasesWithoutRollout } = releases;
+  const result = buildRolloutManifest({ releases, current: null, targetSequence: releases.releaseSequence, percentage: 100 });
+  assert.deepStrictEqual(result, releasesWithoutRollout);
+});
+
+test("buildRolloutManifest (c): current.rollout.seed 존재 → 신규 percentage 결과 seed 계승", async () => {
+  const { buildRolloutManifest } = await import("./update-rollout.mjs");
+  const releases = buildProductionReleasesManifest();
+  const existingSeed = "b".repeat(32);
+  const current = { ...releases, rollout: { percentage: 30, seed: existingSeed } };
+  const savedPriv = process.env.EASYSUBWAY_DATAPACK_SIGNING_PRIVATE_KEY_PEM;
+  const savedPub = process.env.EASYSUBWAY_DATAPACK_SIGNING_PUBLIC_KEY_PEM;
+  try {
+    process.env.EASYSUBWAY_DATAPACK_SIGNING_PRIVATE_KEY_PEM = testPrivateKeyPem;
+    process.env.EASYSUBWAY_DATAPACK_SIGNING_PUBLIC_KEY_PEM = testPublicKeyPem;
+    const result = buildRolloutManifest({ releases, current, targetSequence: releases.releaseSequence, percentage: 70 });
+    assert.equal(result.rollout.seed, existingSeed, "seed 계승해야 함");
+    assert.equal(result.rollout.percentage, 70);
+  } finally {
+    if (savedPriv !== undefined) process.env.EASYSUBWAY_DATAPACK_SIGNING_PRIVATE_KEY_PEM = savedPriv;
+    else delete process.env.EASYSUBWAY_DATAPACK_SIGNING_PRIVATE_KEY_PEM;
+    if (savedPub !== undefined) process.env.EASYSUBWAY_DATAPACK_SIGNING_PUBLIC_KEY_PEM = savedPub;
+    else delete process.env.EASYSUBWAY_DATAPACK_SIGNING_PUBLIC_KEY_PEM;
+  }
+});
+
+test("buildRolloutManifest (d): targetSequence ≠ releases.releaseSequence → throws /sequence mismatch/", async () => {
+  const { buildRolloutManifest } = await import("./update-rollout.mjs");
+  const releases = buildProductionReleasesManifest();
+  assert.throws(
+    () => buildRolloutManifest({ releases, current: null, targetSequence: 999, percentage: 50 }),
+    /sequence mismatch/,
+  );
+});
+
+test("buildRolloutManifest (e): current.releaseSequence ≠ targetSequence → throws /다른 릴리즈/", async () => {
+  const { buildRolloutManifest } = await import("./update-rollout.mjs");
+  const releases = buildProductionReleasesManifest();
+  const staleRelease = buildProductionReleasesManifest({ releaseSequence: 3 });
+  assert.throws(
+    () => buildRolloutManifest({ releases, current: staleRelease, targetSequence: releases.releaseSequence, percentage: 50 }),
+    /다른 릴리즈/,
+  );
+});

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -12225,3 +12225,220 @@ test("buildRolloutManifest (e): current.releaseSequence ≠ targetSequence → t
     /다른 릴리즈/,
   );
 });
+
+// ─── publish-rollout CLI 테스트 (#1692) ────────────────────────────────────────
+// rollback-manifest.test.mjs의 startStorage·패턴을 재사용해 mock 객체스토리지를 구성.
+
+const ROLLOUT_PACK_BYTES = Buffer.from("rollout-test-pack-bytes");
+const ROLLOUT_PACK_SHA = createHash("sha256").update(ROLLOUT_PACK_BYTES).digest("hex");
+
+function buildRolloutTestReleasesManifest(overrides = {}) {
+  const sqliteSha = "a".repeat(64);
+  const base = {
+    manifestVersion: 2,
+    channel: "production",
+    releaseSequence: 10,
+    publishedAt: "2026-07-07T00:00:00.000Z",
+    expiresAt: "2999-01-01T00:00:00.000Z",
+    keyId: "production-v1",
+    ttlSeconds: 3600,
+    signature: { algorithm: "rsa-sha256-manifest-v2", value: "placeholder" },
+    packs: [
+      {
+        id: "capital",
+        version: "1",
+        artifactKind: "production",
+        url: "https://cdn.example.com/catalog/capital-v1.sqlite.gz",
+        sha256: ROLLOUT_PACK_SHA,
+        sqliteSha256: sqliteSha,
+        sizeBytes: ROLLOUT_PACK_BYTES.length,
+        signature: {
+          algorithm: "rsa-sha256-pack-manifest-v2",
+          value: _rolloutSign("rollout-pack-payload"),
+        },
+        schemaVersion: "1",
+        sourceInventory: [
+          {
+            id: "src1",
+            owner: "test-owner",
+            url: "https://data.example.com/catalog",
+            license: "CC-BY-4.0",
+            licenseStatus: "redistributable",
+            redistributionAllowed: true,
+            updateFrequency: "daily",
+            updatedAt: "2026-07-07T00:00:00.000Z",
+            fields: ["stations"],
+            coverageScope: {
+              regionIds: ["seoul"],
+              operatorIds: ["seoulmetro"],
+              sourceDomains: ["station_map"],
+            },
+          },
+        ],
+        regionalQualityMetrics: {
+          stationCount: 100,
+          edgeCount: 200,
+          facilityCoverageRatio: 0.5,
+          requiredFacilityEvidenceCoverageRatio: 0.5,
+          strictRouteEligibleFacilityRatio: 0.5,
+          operationalKnownRatio: 1.0,
+          freshnessValidRatio: 0.8,
+          fieldVerifiedPathwayRatio: 0.3,
+          unknownAccessibilityRatio: 0.2,
+          unknownEdgeRatioByProfile: { wheelchair: 0.1, stroller: 0.1, lowMobility: 0.1 },
+        },
+        representativeRouteRegressions: [],
+        representativeRouteRegressionSignature: {
+          algorithm: "rsa-sha256-route-regression-v1",
+          value: _rolloutSign("rollout-regression-payload"),
+        },
+        requiredTables: ["stations"],
+        minimumTableRows: {
+          stations: 1,
+          station_lines: 1,
+          network_edges: 1,
+          facilities: 1,
+          station_facility_evidence: 1,
+        },
+      },
+    ],
+    ...overrides,
+  };
+  const { signature: _dropSig, ...unsigned } = base;
+  base.signature = {
+    algorithm: "rsa-sha256-manifest-v2",
+    value: _rolloutSign(_rolloutCanonicalJson(unsigned)),
+  };
+  return base;
+}
+
+async function startRolloutTestStorage(seed) {
+  const objects = new Map(seed);
+  const server = createServer((req, res) => {
+    const key = decodeURIComponent(req.url.replace(/^\//, ""));
+    if (req.method === "PUT") {
+      const chunks = [];
+      req.on("data", (c) => chunks.push(c));
+      req.on("end", () => {
+        objects.set(key, { body: Buffer.concat(chunks) });
+        res.statusCode = 200;
+        res.end();
+      });
+      return;
+    }
+    const found = objects.get(key);
+    if (!found) { res.statusCode = 404; res.end(); return; }
+    res.setHeader("content-length", String(found.body.length));
+    res.statusCode = 200;
+    res.end(req.method === "HEAD" ? undefined : found.body);
+  });
+  return new Promise((r) => server.listen(0, "127.0.0.1", () => r({ server, objects, port: server.address().port })));
+}
+
+const rolloutTestEnv = {
+  ...process.env,
+  EASYSUBWAY_DATAPACK_SIGNING_PUBLIC_KEY_PEM: testPublicKeyPem,
+  EASYSUBWAY_DATAPACK_SIGNING_PRIVATE_KEY_PEM: testPrivateKeyPem,
+};
+
+async function runPublishRollout(args, baseUrl) {
+  return execFileAsync(
+    "node",
+    [path.join(root, "tools/datapack/publish-rollout.mjs"), "--base-url", baseUrl, ...args],
+    { env: rolloutTestEnv },
+  );
+}
+
+test("publish-rollout (①): --percentage 30 → current.json에 rollout{30,seed hex32}+서명 유효+참조 pack sha 검증 통과", async () => {
+  const manifest = buildRolloutTestReleasesManifest();
+  const manifestBytes = Buffer.from(JSON.stringify(manifest));
+  const oldCurrentBytes = Buffer.from(JSON.stringify({ ...manifest, rollout: { percentage: 10, seed: "c".repeat(32) } }));
+
+  const storage = await startRolloutTestStorage([
+    ["catalog/releases/10.json", { body: manifestBytes }],
+    ["catalog/capital-v1.sqlite.gz", { body: ROLLOUT_PACK_BYTES }],
+    ["catalog/current.json", { body: oldCurrentBytes }],
+  ]);
+  const baseUrl = `http://127.0.0.1:${storage.port}`;
+  try {
+    const { stdout } = await runPublishRollout(
+      ["--target-sequence", "10", "--percentage", "30"],
+      baseUrl,
+    );
+    const report = JSON.parse(stdout);
+    assert.equal(report.targetSequence, 10);
+    assert.equal(report.percentage, 30);
+    assert.equal(report.channel, "production");
+
+    // PUT된 current.json 검증
+    const currentBytes = storage.objects.get("catalog/current.json").body;
+    const current = JSON.parse(currentBytes.toString("utf8"));
+    assert.ok(current.rollout, "rollout 필드 있어야 함");
+    assert.equal(current.rollout.percentage, 30);
+    assert.match(current.rollout.seed, /^[a-f0-9]{32}$/, "seed hex32 이어야 함");
+
+    // 서명 재검증 — 재서명된 manifest 서명이 공개키로 검증되어야 한다
+    const { verifyRsaSha256Signature, canonicalJson, withoutSignature } = await import("./lib/manifest-validation.mjs");
+    assert.ok(
+      verifyRsaSha256Signature(testPublicKeyPem, canonicalJson(withoutSignature(current)), current.signature.value),
+      "재서명이 공개키로 검증되어야 함",
+    );
+
+    // 리포트 newCurrentSha256이 저장된 bytes와 일치
+    const storedSha = createHash("sha256").update(currentBytes).digest("hex");
+    assert.equal(report.newCurrentSha256, storedSha);
+  } finally {
+    storage.server.close();
+  }
+});
+
+test("publish-rollout (②): 참조 팩 sha256 불일치 → PUT 없이 throw (fail-closed)", async () => {
+  const manifest = buildRolloutTestReleasesManifest();
+  const manifestBytes = Buffer.from(JSON.stringify(manifest));
+  // current.json에는 releases와 동일한 매니페스트를 넣어 buildRolloutManifest가 통과하도록 한다.
+  // 팩 sha256 불일치만이 fail-closed의 트리거가 되어야 한다.
+  const originalCurrentBytes = Buffer.from(JSON.stringify(manifest));
+
+  const storage = await startRolloutTestStorage([
+    ["catalog/releases/10.json", { body: manifestBytes }],
+    // 훼손된 팩 바이트 — sha256 불일치
+    ["catalog/capital-v1.sqlite.gz", { body: Buffer.from("tampered-pack-bytes") }],
+    ["catalog/current.json", { body: originalCurrentBytes }],
+  ]);
+  const baseUrl = `http://127.0.0.1:${storage.port}`;
+  try {
+    await assert.rejects(
+      runPublishRollout(["--target-sequence", "10", "--percentage", "30"], baseUrl),
+      /sha256 mismatch/,
+    );
+    // fail-closed: current.json은 원본 그대로 보존되어야 한다
+    assert.deepEqual(storage.objects.get("catalog/current.json").body, originalCurrentBytes);
+  } finally {
+    storage.server.close();
+  }
+});
+
+test("publish-rollout (③): --dry-run → current.json 수정 없이 exit 0 + 리포트 반환", async () => {
+  const manifest = buildRolloutTestReleasesManifest();
+  const manifestBytes = Buffer.from(JSON.stringify(manifest));
+  const originalCurrentBytes = Buffer.from(JSON.stringify(manifest));
+
+  const storage = await startRolloutTestStorage([
+    ["catalog/releases/10.json", { body: manifestBytes }],
+    ["catalog/capital-v1.sqlite.gz", { body: ROLLOUT_PACK_BYTES }],
+    ["catalog/current.json", { body: originalCurrentBytes }],
+  ]);
+  const baseUrl = `http://127.0.0.1:${storage.port}`;
+  try {
+    const { stdout } = await runPublishRollout(
+      ["--dry-run", "--target-sequence", "10", "--percentage", "50"],
+      baseUrl,
+    );
+    const report = JSON.parse(stdout);
+    assert.equal(report.percentage, 50);
+    // current.json은 원본 그대로 (PUT 미수행)
+    assert.deepEqual(storage.objects.get("catalog/current.json").body, originalCurrentBytes);
+  } finally {
+    storage.server.close();
+  }
+});

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -12001,3 +12001,54 @@ test("releases 게시 대상 매니페스트에 rollout이 있으면 거부한�
     /releases.*rollout/i,
   );
 });
+
+test("manifest-signing: rsaSha256Signature는 base64url 서명을 반환하고 공개키로 검증된다", async () => {
+  const { rsaSha256Signature } = await import("./lib/manifest-signing.mjs");
+  const { verifyRsaSha256Signature } = await import("./lib/manifest-validation.mjs");
+  const value = "manifest-signing-unit-test-fixture-payload";
+  const sig = rsaSha256Signature(testPrivateKeyPem, value);
+  assert.ok(typeof sig === "string", "서명은 문자열이어야 함");
+  assert.ok(/^[A-Za-z0-9_-]+$/.test(sig), "base64url 형식이어야 함");
+  assert.ok(verifyRsaSha256Signature(testPublicKeyPem, value, sig), "공개키로 검증되어야 함");
+});
+
+test("manifest-signing: signingPrivateKey는 env 미설정 시 throw, 설정 시 PEM 반환", async () => {
+  const { signingPrivateKey } = await import("./lib/manifest-signing.mjs");
+  const savedKey = process.env.EASYSUBWAY_DATAPACK_SIGNING_PRIVATE_KEY_PEM;
+  try {
+    delete process.env.EASYSUBWAY_DATAPACK_SIGNING_PRIVATE_KEY_PEM;
+    assert.throws(() => signingPrivateKey(), /EASYSUBWAY_DATAPACK_SIGNING_PRIVATE_KEY_PEM/);
+    process.env.EASYSUBWAY_DATAPACK_SIGNING_PRIVATE_KEY_PEM = testPrivateKeyPem;
+    assert.equal(signingPrivateKey(), testPrivateKeyPem.trim());
+  } finally {
+    if (savedKey !== undefined) process.env.EASYSUBWAY_DATAPACK_SIGNING_PRIVATE_KEY_PEM = savedKey;
+    else delete process.env.EASYSUBWAY_DATAPACK_SIGNING_PRIVATE_KEY_PEM;
+  }
+});
+
+test("manifest-signing: manifestSignatureValue는 canonicalJson(withoutSignature) 기반 RSA 서명을 반환한다", async () => {
+  const { manifestSignatureValue } = await import("./lib/manifest-signing.mjs");
+  const { verifyRsaSha256Signature, canonicalJson, withoutSignature } = await import("./lib/manifest-validation.mjs");
+  const manifest = {
+    manifestVersion: 2,
+    channel: "test",
+    releaseSequence: 1,
+    publishedAt: "2026-01-01T00:00:00.000Z",
+    expiresAt: "2026-01-02T00:00:00.000Z",
+    keyId: "test-key",
+    ttlSeconds: 3600,
+    packs: [],
+    signature: { algorithm: "rsa-sha256-manifest-v2", value: "PLACEHOLDER" },
+  };
+  const savedKey = process.env.EASYSUBWAY_DATAPACK_SIGNING_PRIVATE_KEY_PEM;
+  try {
+    process.env.EASYSUBWAY_DATAPACK_SIGNING_PRIVATE_KEY_PEM = testPrivateKeyPem;
+    const sigValue = manifestSignatureValue(manifest);
+    const canonical = canonicalJson(withoutSignature(manifest));
+    assert.ok(/^[A-Za-z0-9_-]+$/.test(sigValue), "base64url 형식이어야 함");
+    assert.ok(verifyRsaSha256Signature(testPublicKeyPem, canonical, sigValue), "서명 검증 통과해야 함");
+  } finally {
+    if (savedKey !== undefined) process.env.EASYSUBWAY_DATAPACK_SIGNING_PRIVATE_KEY_PEM = savedKey;
+    else delete process.env.EASYSUBWAY_DATAPACK_SIGNING_PRIVATE_KEY_PEM;
+  }
+});

--- a/tools/datapack/lib/manifest-signing.mjs
+++ b/tools/datapack/lib/manifest-signing.mjs
@@ -1,0 +1,18 @@
+import { createSign } from "node:crypto";
+import { canonicalJson, withoutSignature } from "./manifest-validation.mjs";
+
+export function signingPrivateKey() {
+  const pem = process.env.EASYSUBWAY_DATAPACK_SIGNING_PRIVATE_KEY_PEM?.trim();
+  if (!pem) {
+    throw new Error("EASYSUBWAY_DATAPACK_SIGNING_PRIVATE_KEY_PEM is required for production data pack signatures");
+  }
+  return pem;
+}
+
+export function rsaSha256Signature(privateKey, value) {
+  return createSign("RSA-SHA256").update(value).sign(privateKey).toString("base64url");
+}
+
+export function manifestSignatureValue(manifest) {
+  return rsaSha256Signature(signingPrivateKey(), canonicalJson(withoutSignature(manifest)));
+}

--- a/tools/datapack/lib/manifest-validation.mjs
+++ b/tools/datapack/lib/manifest-validation.mjs
@@ -472,7 +472,7 @@ export function validateManifestSignature(manifest) {
   }
 }
 
-export function validateManifest(manifest, { requireProduction = false } = {}) {
+export function validateManifest(manifest, { requireProduction = false, releasesTarget = false } = {}) {
   validateManifestJsonSchema(manifest);
   if (!manifest || typeof manifest !== "object") {
     throw new Error("manifest must be an object");
@@ -503,6 +503,20 @@ export function validateManifest(manifest, { requireProduction = false } = {}) {
   if (manifest.emergencyOverride !== undefined) {
     validatePackIdentity(manifest.emergencyOverride, "emergencyOverride");
     requiredString(manifest.emergencyOverride.reason, "emergencyOverride.reason");
+  }
+  if (manifest.rollout !== undefined) {
+    if (releasesTarget) {
+      throw new Error("releases 게시 대상 매니페스트에는 rollout을 넣을 수 없다");
+    }
+    const r = manifest.rollout;
+    if (typeof r !== "object" || r === null) throw new Error("rollout must be object");
+    if (!Number.isInteger(r.percentage) || r.percentage < 0 || r.percentage > 100) {
+      throw new Error("rollout.percentage must be integer 0..100");
+    }
+    if (typeof r.seed !== "string" || !/^[a-f0-9]{32}$/.test(r.seed)) {
+      throw new Error("rollout.seed must be 32-char lowercase hex");
+    }
+    // 서명 경계 안 필드이므로 별도 처리 없음(canonicalJson이 자동 포함)
   }
   for (const pack of manifest.packs) {
     validatePackIdentity(pack, "pack");

--- a/tools/datapack/lib/object-storage-publish.mjs
+++ b/tools/datapack/lib/object-storage-publish.mjs
@@ -3,6 +3,8 @@ import { createHash } from "node:crypto";
 import http from "node:http";
 import https from "node:https";
 
+const REQUEST_TIMEOUT_MS = 30_000;
+
 // ─── 기본 HTTP 요청 ────────────────────────────────────────────────────────────
 
 export function request(url, method, body = Buffer.alloc(0), headers = {}) {
@@ -12,6 +14,10 @@ export function request(url, method, body = Buffer.alloc(0), headers = {}) {
     const req = transport.request(url, { method, headers }, (res) => {
       res.on("data", (c) => chunks.push(c));
       res.on("end", () => { res.body = Buffer.concat(chunks); resolve(res); });
+      res.on("error", reject);
+    });
+    req.setTimeout(REQUEST_TIMEOUT_MS, () => {
+      req.destroy(new Error(`request timeout after ${REQUEST_TIMEOUT_MS}ms`));
     });
     req.on("error", reject);
     if (body.length > 0) req.write(body);
@@ -43,11 +49,11 @@ export async function verifyReferencedPacks(baseUrl, manifest) {
       : `catalog/${pack.id}-v${pack.version}.sqlite.gz`;
     const packResponse = await request(objectUrl(baseUrl, packKey), "GET");
     if (packResponse.statusCode !== 200) {
-      throw new Error(`rollback target references missing pack ${packKey} (HTTP ${packResponse.statusCode})`);
+      throw new Error(`referenced pack ${packKey} not found (HTTP ${packResponse.statusCode})`);
     }
     const storedSha256 = sha256(packResponse.body);
     if (storedSha256 !== pack.sha256) {
-      throw new Error(`rollback target pack ${packKey} sha256 mismatch: stored=${storedSha256} manifest=${pack.sha256}`);
+      throw new Error(`referenced pack ${packKey} sha256 mismatch: stored=${storedSha256} manifest=${pack.sha256}`);
     }
   }
 }

--- a/tools/datapack/lib/object-storage-publish.mjs
+++ b/tools/datapack/lib/object-storage-publish.mjs
@@ -1,0 +1,76 @@
+// #1692: 객체스토리지 PUT 공유 I/O — rollback-manifest·publish-rollout가 함께 사용.
+import { createHash } from "node:crypto";
+import http from "node:http";
+import https from "node:https";
+
+// ─── 기본 HTTP 요청 ────────────────────────────────────────────────────────────
+
+export function request(url, method, body = Buffer.alloc(0), headers = {}) {
+  const transport = url.protocol === "https:" ? https : http;
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    const req = transport.request(url, { method, headers }, (res) => {
+      res.on("data", (c) => chunks.push(c));
+      res.on("end", () => { res.body = Buffer.concat(chunks); resolve(res); });
+    });
+    req.on("error", reject);
+    if (body.length > 0) req.write(body);
+    req.end();
+  });
+}
+
+// ─── URL 생성 ─────────────────────────────────────────────────────────────────
+
+export function objectUrl(baseUrl, key) {
+  const url = new URL(baseUrl.toString());
+  const base = url.pathname.replace(/\/+$/, "");
+  url.pathname = `${base}/${key.split("/").map(encodeURIComponent).join("/")}`;
+  return url;
+}
+
+// ─── SHA-256 헬퍼 ─────────────────────────────────────────────────────────────
+
+export function sha256(bytes) { return createHash("sha256").update(bytes).digest("hex"); }
+
+// ─── 참조 팩 존재·sha256 대조 (fail-closed) ──────────────────────────────────
+// preauth(OCI PAR) 대상은 HEAD/meta sha를 신뢰할 수 없어 GET 본문 sha256을 직접 대조한다.
+// 팩이 유실·훼손·교체되면 즉시 throw.
+
+export async function verifyReferencedPacks(baseUrl, manifest) {
+  for (const pack of manifest.packs) {
+    const packKey = pack.url && !/^https:\/\//.test(pack.url)
+      ? pack.url
+      : `catalog/${pack.id}-v${pack.version}.sqlite.gz`;
+    const packResponse = await request(objectUrl(baseUrl, packKey), "GET");
+    if (packResponse.statusCode !== 200) {
+      throw new Error(`rollback target references missing pack ${packKey} (HTTP ${packResponse.statusCode})`);
+    }
+    const storedSha256 = sha256(packResponse.body);
+    if (storedSha256 !== pack.sha256) {
+      throw new Error(`rollback target pack ${packKey} sha256 mismatch: stored=${storedSha256} manifest=${pack.sha256}`);
+    }
+  }
+}
+
+// ─── current.json PUT + 재검증 ─────────────────────────────────────────────────
+// GET으로 이전 sha256를 얻은 뒤 bytes를 PUT하고, 재GET으로 바이트 동일성을 검증한다.
+// 이전 sha256(없으면 null)을 반환한다.
+
+export async function putCurrentAndVerify(baseUrl, bytes) {
+  const currentUrl = objectUrl(baseUrl, "catalog/current.json");
+  const previous = await request(currentUrl, "GET");
+  const previousCurrentSha256 = previous.statusCode === 200 ? sha256(previous.body) : null;
+  const put = await request(currentUrl, "PUT", bytes, {
+    "content-type": "application/json",
+    "content-length": String(bytes.length),
+    "cache-control": "public, max-age=60",
+  });
+  if (put.statusCode < 200 || put.statusCode >= 300) {
+    throw new Error(`current.json PUT failed with HTTP ${put.statusCode}`);
+  }
+  const verify = await request(currentUrl, "GET");
+  if (sha256(verify.body) !== sha256(bytes)) {
+    throw new Error("current.json byte-identity verification failed");
+  }
+  return previousCurrentSha256;
+}

--- a/tools/datapack/publish-rollout.mjs
+++ b/tools/datapack/publish-rollout.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+// #1692: releases/<N>.json을 rollout 변환 후 catalog/current.json으로 PUT 게시.
+// 흐름: GET releases/<N> + current.json → buildRolloutManifest → verifyReferencedPacks(fail-closed)
+//       → putCurrentAndVerify(변환본) / dry-run 시 PUT 생략.
+import {
+  request,
+  objectUrl,
+  sha256,
+  verifyReferencedPacks,
+  putCurrentAndVerify,
+} from "./lib/object-storage-publish.mjs";
+import {
+  validateManifest,
+} from "./lib/manifest-validation.mjs";
+import { buildRolloutManifest } from "./update-rollout.mjs";
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const targetSequence = Number(requireArg(args, "target-sequence"));
+  const percentage = Number(requireArg(args, "percentage"));
+  const baseUrl = new URL(requireArg(args, "base-url"));
+  const channel = args.get("channel") ?? "production";
+  const reason = args.get("reason") ?? null;
+  const idempotencyKey = args.get("idempotency-key") ?? null;
+  const dryRun = args.has("dry-run");
+
+  if (!Number.isInteger(targetSequence) || targetSequence < 1) {
+    throw new Error("--target-sequence must be a positive integer");
+  }
+  if (!Number.isInteger(percentage) || percentage < 0 || percentage > 100) {
+    throw new Error("--percentage must be integer 0..100");
+  }
+
+  // (1) releases/<N>.json GET + 검증
+  const releaseKey = `catalog/releases/${targetSequence}.json`;
+  const releaseResponse = await request(objectUrl(baseUrl, releaseKey), "GET");
+  if (releaseResponse.statusCode !== 200) {
+    throw new Error(`rollout target ${releaseKey} not found (HTTP ${releaseResponse.statusCode})`);
+  }
+  const manifest = JSON.parse(releaseResponse.body.toString("utf8"));
+  validateManifest(manifest, { requireProduction: channel === "production" });
+
+  // (2) current.json GET (seed 계승 + previousSha 기록용)
+  const currentUrl = objectUrl(baseUrl, "catalog/current.json");
+  const currentRes = await request(currentUrl, "GET");
+  const currentBytes = currentRes.statusCode === 200 ? currentRes.body : null;
+  const current = currentBytes ? JSON.parse(currentBytes.toString("utf8")) : null;
+  const previousCurrentSha256 = currentBytes ? sha256(currentBytes) : null;
+
+  // (3) rollout 변환본 계산
+  const rolloutManifest = buildRolloutManifest({ releases: manifest, current, targetSequence, percentage });
+  const rolloutBytes = Buffer.from(JSON.stringify(rolloutManifest));
+
+  // (4) 참조 팩 존재·sha256 대조 (fail-closed)
+  await verifyReferencedPacks(baseUrl, manifest);
+
+  // (5) current.json PUT + 재검증 (dry-run 시 생략)
+  if (!dryRun) {
+    await putCurrentAndVerify(baseUrl, rolloutBytes);
+  }
+
+  process.stdout.write(`${JSON.stringify({
+    targetSequence, percentage, channel, previousCurrentSha256,
+    newCurrentSha256: sha256(rolloutBytes), reason, idempotencyKey,
+  })}\n`);
+}
+
+function parseArgs(argv) {
+  const args = new Map();
+  for (let i = 0; i < argv.length; i += 1) {
+    const key = argv[i];
+    if (key === "--dry-run") { args.set("dry-run", "true"); continue; }
+    const value = argv[i + 1];
+    if (!key?.startsWith("--") || value === undefined || value.startsWith("--")) {
+      throw new Error(`invalid argument near ${key ?? "<end>"}`);
+    }
+    args.set(key.slice(2), value); i += 1;
+  }
+  return args;
+}
+
+function requireArg(args, name) {
+  const v = args.get(name);
+  if (!v) throw new Error(`missing required argument: --${name}`);
+  return v;
+}
+
+main().catch((error) => { console.error(error.message); process.exitCode = 1; });

--- a/tools/datapack/publish-rollout.mjs
+++ b/tools/datapack/publish-rollout.mjs
@@ -38,7 +38,7 @@ async function main() {
     throw new Error(`rollout target ${releaseKey} not found (HTTP ${releaseResponse.statusCode})`);
   }
   const manifest = JSON.parse(releaseResponse.body.toString("utf8"));
-  validateManifest(manifest, { requireProduction: channel === "production" });
+  validateManifest(manifest, { requireProduction: channel === "production", releasesTarget: true });
 
   // (2) current.json GET (seed 계승 + previousSha 기록용)
   const currentUrl = objectUrl(baseUrl, "catalog/current.json");

--- a/tools/datapack/rollback-manifest.mjs
+++ b/tools/datapack/rollback-manifest.mjs
@@ -1,10 +1,14 @@
 #!/usr/bin/env node
-import { createHash } from "node:crypto";
-import http from "node:http";
-import https from "node:https";
 import {
   validateManifest,
 } from "./lib/manifest-validation.mjs";
+import {
+  request,
+  objectUrl,
+  sha256,
+  verifyReferencedPacks,
+  putCurrentAndVerify,
+} from "./lib/object-storage-publish.mjs";
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
@@ -40,65 +44,23 @@ async function main() {
     throw new Error("rollback target expired; rebuild required");
   }
 
-  // (4) 참조 팩 존재·sha256 대조
-  // preauth(OCI PAR) 대상은 HEAD/meta sha를 신뢰할 수 없어(publish-object-storage와 동일 이유)
-  // GET 본문 sha256을 manifest pack.sha256과 직접 대조한다 — 팩이 훼손·교체되면 스왑 거부(fail-closed).
-  for (const pack of manifest.packs) {
-    const packKey = pack.url && !/^https:\/\//.test(pack.url) ? pack.url : `catalog/${pack.id}-v${pack.version}.sqlite.gz`;
-    const packResponse = await request(objectUrl(baseUrl, packKey), "GET");
-    if (packResponse.statusCode !== 200) {
-      throw new Error(`rollback target references missing pack ${packKey} (HTTP ${packResponse.statusCode})`);
-    }
-    const storedSha256 = sha256(packResponse.body);
-    if (storedSha256 !== pack.sha256) {
-      throw new Error(`rollback target pack ${packKey} sha256 mismatch: stored=${storedSha256} manifest=${pack.sha256}`);
-    }
-  }
+  // (4) 참조 팩 존재·sha256 대조 (lib 공유, fail-closed)
+  await verifyReferencedPacks(baseUrl, manifest);
 
-  // (5) 바이트 동일 current.json PUT + 재검증
-  const currentUrl = objectUrl(baseUrl, "catalog/current.json");
-  const previous = await request(currentUrl, "GET");
-  const previousCurrentSha256 = previous.statusCode === 200 ? sha256(previous.body) : null;
-  if (!dryRun) {
-    const put = await request(currentUrl, "PUT", releaseBytes, {
-      "content-type": "application/json",
-      "content-length": String(releaseBytes.length),
-      "cache-control": "public, max-age=60",
-    });
-    if (put.statusCode < 200 || put.statusCode >= 300) {
-      throw new Error(`current.json PUT failed with HTTP ${put.statusCode}`);
-    }
-    const verify = await request(currentUrl, "GET");
-    if (sha256(verify.body) !== sha256(releaseBytes)) {
-      throw new Error("current.json byte-identity verification failed");
-    }
+  // (5) 바이트 동일 current.json PUT + 재검증 (dry-run 시 GET만)
+  let previousCurrentSha256;
+  if (dryRun) {
+    const currentUrl = objectUrl(baseUrl, "catalog/current.json");
+    const previous = await request(currentUrl, "GET");
+    previousCurrentSha256 = previous.statusCode === 200 ? sha256(previous.body) : null;
+  } else {
+    previousCurrentSha256 = await putCurrentAndVerify(baseUrl, releaseBytes);
   }
 
   process.stdout.write(`${JSON.stringify({
     targetSequence, channel, previousCurrentSha256,
     newCurrentSha256: sha256(releaseBytes), reason, idempotencyKey,
   })}\n`);
-}
-
-function request(url, method, body = Buffer.alloc(0), headers = {}) {
-  const transport = url.protocol === "https:" ? https : http;
-  return new Promise((resolve, reject) => {
-    const chunks = [];
-    const req = transport.request(url, { method, headers }, (res) => {
-      res.on("data", (c) => chunks.push(c));
-      res.on("end", () => { res.body = Buffer.concat(chunks); resolve(res); });
-    });
-    req.on("error", reject);
-    if (body.length > 0) req.write(body);
-    req.end();
-  });
-}
-
-function objectUrl(baseUrl, key) {
-  const url = new URL(baseUrl.toString());
-  const base = url.pathname.replace(/\/+$/, "");
-  url.pathname = `${base}/${key.split("/").map(encodeURIComponent).join("/")}`;
-  return url;
 }
 
 function parseArgs(argv) {
@@ -120,7 +82,5 @@ function requireArg(args, name) {
   if (!v) throw new Error(`missing required argument: --${name}`);
   return v;
 }
-
-function sha256(bytes) { return createHash("sha256").update(bytes).digest("hex"); }
 
 main().catch((error) => { console.error(error.message); process.exitCode = 1; });

--- a/tools/datapack/rollback-manifest.test.mjs
+++ b/tools/datapack/rollback-manifest.test.mjs
@@ -278,7 +278,7 @@ test("③ 참조 팩이 스토리지에 없으면 거부한다", async () => {
   try {
     await assert.rejects(
       runRollback(["--target-sequence", "2", "--channel", "staging", "--reason", "test", "--idempotency-key", "k3"], baseUrl),
-      /missing pack/,
+      /referenced pack.*not found/,
     );
   } finally {
     storage.server.close();

--- a/tools/datapack/schema/manifest.schema.json
+++ b/tools/datapack/schema/manifest.schema.json
@@ -84,6 +84,15 @@
         }
       ]
     },
+    "rollout": {
+      "type": "object",
+      "required": ["percentage", "seed"],
+      "additionalProperties": false,
+      "properties": {
+        "percentage": { "type": "integer", "minimum": 0, "maximum": 100 },
+        "seed": { "type": "string", "pattern": "^[a-f0-9]{32}$" }
+      }
+    },
     "packs": {
       "type": "array",
       "minItems": 1,

--- a/tools/datapack/update-rollout.mjs
+++ b/tools/datapack/update-rollout.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+// #1692: releases/<N>.json에 rollout 주입·재서명해 current.json 게시본 객체를 만든다(순수).
+import { readFileSync, writeFileSync } from "node:fs";
+import { randomBytes } from "node:crypto";
+import { manifestSignatureValue } from "./lib/manifest-signing.mjs";
+import { validateManifest } from "./lib/manifest-validation.mjs";
+
+export function buildRolloutManifest({ releases, current, targetSequence, percentage }) {
+  if (releases.releaseSequence !== targetSequence) {
+    throw new Error(`sequence mismatch: releases ${releases.releaseSequence} target ${targetSequence}`);
+  }
+  if (current && current.releaseSequence !== targetSequence) {
+    throw new Error(`current.json은 다른 릴리즈(${current.releaseSequence}) — 릴리즈 전환은 production-publish/rollback만`);
+  }
+  if (!Number.isInteger(percentage) || percentage < 0 || percentage > 100) {
+    throw new Error("percentage must be integer 0..100");
+  }
+  if (percentage === 100) {
+    const { rollout: _drop, ...rest } = releases; // releases 본 그대로(서명 유효)
+    return rest;
+  }
+  const seed = current?.rollout?.seed ?? randomBytes(16).toString("hex");
+  const { signature: _dropSig, ...unsignedRest } = releases;
+  const unsigned = { ...unsignedRest, rollout: { percentage, seed } };
+  const out = { ...unsigned, signature: { ...releases.signature, value: manifestSignatureValue(unsigned) } };
+  validateManifest(out, { requireProduction: true });
+  return out;
+}
+
+// 얇은 CLI(standalone 산출)
+function arg(n) { const i = process.argv.indexOf(n); return i > 0 ? process.argv[i + 1] : undefined; }
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const releases = JSON.parse(readFileSync(arg("--releases-manifest"), "utf8"));
+  const cp = arg("--current-manifest");
+  const current = cp ? JSON.parse(readFileSync(cp, "utf8")) : null;
+  const out = buildRolloutManifest({
+    releases,
+    current,
+    targetSequence: Number(arg("--target-sequence")),
+    percentage: Number(arg("--percentage")),
+  });
+  writeFileSync(arg("--out"), JSON.stringify(out));
+}

--- a/tools/datapack/update-rollout.mjs
+++ b/tools/datapack/update-rollout.mjs
@@ -2,6 +2,7 @@
 // #1692: releases/<N>.json에 rollout 주입·재서명해 current.json 게시본 객체를 만든다(순수).
 import { readFileSync, writeFileSync } from "node:fs";
 import { randomBytes } from "node:crypto";
+import { pathToFileURL } from "node:url";
 import { manifestSignatureValue } from "./lib/manifest-signing.mjs";
 import { validateManifest } from "./lib/manifest-validation.mjs";
 
@@ -29,7 +30,7 @@ export function buildRolloutManifest({ releases, current, targetSequence, percen
 
 // 얇은 CLI(standalone 산출)
 function arg(n) { const i = process.argv.indexOf(n); return i > 0 ? process.argv[i + 1] : undefined; }
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   const releases = JSON.parse(readFileSync(arg("--releases-manifest"), "utf8"));
   const cp = arg("--current-manifest");
   const current = cp ? JSON.parse(readFileSync(cp, "utf8")) : null;

--- a/tools/datapack/validate-datapack.mjs
+++ b/tools/datapack/validate-datapack.mjs
@@ -53,8 +53,9 @@ async function main() {
   const manifestPath = path.resolve(requireArg(args, "manifest"));
   const root = path.resolve(requireArg(args, "root"));
   const requireProduction = args["require-production"] === true;
+  const releasesTarget = args["releases-target"] === true;
   const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
-  validateManifest(manifest, { requireProduction });
+  validateManifest(manifest, { requireProduction, releasesTarget });
 
   const temporaryDir = await mkdtemp(path.join(tmpdir(), "easysubway-datapack-validate-"));
   try {
@@ -1695,6 +1696,10 @@ function parseArgs(argv) {
     const key = argv[index];
     if (key === "--require-production") {
       args["require-production"] = true;
+      continue;
+    }
+    if (key === "--releases-target") {
+      args["releases-target"] = true;
       continue;
     }
     const value = argv[index + 1];


### PR DESCRIPTION
## 관련 이슈

Refs #1692

> #1690 데이터팩 상용 전송 체계 트래커의 ② 단계적 롤아웃. 본 PR은 **tools+workflow 절반(Task 1~5)**. mobile 절반(Task 6~9)은 후속 PR `feat/datapack-rollout-mobile-1692`가 이 위에 스택하며 `Closes #1692`. 선행 #1691(releases 불변·rollback-manifest) CLOSED.

## 작업 배경

`catalog/current.json` 교체 순간 전 단말 100% 즉시 확산 → 문제 팩이 게이트를 뚫으면 동시 전면 피해. 매니페스트 서명 경계 안에 `rollout{percentage,seed}`를 도입해 current.json만 재서명 단계 확산(0~100%)하고, percentage 0 = 신규 채택 kill switch로 쓴다. 서명 키는 워크플로 env에만 있으므로 확산 단계 변경은 워크플로 안에서만 실행된다.

## 작업 내용 (tools+workflow)

- **T1 스키마·검증**: `manifest.schema.json`에 `rollout{percentage:0~100, seed:hex32}`(서명 경계 안, 부재=100% 하위호환). `validateManifest`에 범위·형식 검증 + `releasesTarget` 시 rollout 금지(#1691 불변 계약).
- **T2 서명 lib 추출**: `build-datapack.mjs`의 RSA 서명 primitive를 `lib/manifest-signing.mjs`로 추출(sha256 분기 보존, 동작 무변경).
- **T3 `update-rollout.mjs`**: 순수 `buildRolloutManifest`(releases에 rollout 주입·재서명, seed 계승=단조 편입, percentage 100=rollout 제거·재서명 없음, seq 불일치 거부).
- **T4 `publish-rollout.mjs` + `lib/object-storage-publish.mjs`**: #1691 rollback-manifest 패턴(참조 pack 실재·sha 대조 fail-closed → current.json 직접 PUT → 재검증). 공유 I/O를 lib으로 추출, rollback-manifest도 재사용(무회귀).
- **T5 워크플로**: `rollout-update` 모드 + `is-pointer-only` output으로 빌드 스텝 15개 게이팅 통합(rollback·rollout-update는 빌드 스킵) + rollback과 동형 pointer-swap 스텝(`publish-rollout.mjs` 호출).

## 검증

- 실행한 명령과 결과:
  - `node --test tools/datapack/datapack-tools.test.mjs` → 199 pass / 0 fail
  - `node --test tools/datapack/rollback-manifest.test.mjs` → 8 pass (무회귀)
  - `node --test tools/ci/datapack-release-workflow.test.mjs` → 4 pass
  - `node --test tools/ci/repository-contract.test.mjs` → 166 pass

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| rollout 재서명 유효 | tools | RSA 서명 재검증 + validateManifest | datapack-tools.test (a) | ✅ |
| 단조 편입(seed 계승) | tools | current.rollout.seed 계승 케이스 | datapack-tools.test (c) | ✅ |
| fail-closed 게시 | tools | pack sha 불일치 시 PUT 없이 throw | publish-rollout 테스트 | ✅ |
| rollback 무회귀 | tools | 추출 후 rollback-manifest.test 8/8 | 무회귀 | ✅ |
| 워크플로 게이팅 | ci | mode!=rollback 잔존 0·is-pointer-only | workflow.test doesNotMatch | ✅ |
| staging 10%→50%→0% 실기기 | 운영 | 배포·salt 조작 단말 | 사용자 후속(외부-게이팅) | ⏳ |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [x] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

> 데이터팩 게시 기구(워크플로+도구) 변경. 매니페스트 스키마에 선택 rollout 필드 추가(하위호환). 배포 영향 없음(시크릿 미주입 시 dormant).

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음(rollout은 게시 기구, 콘텐츠 버전 무관)
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음(이 PR은 tools+workflow)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `buildRolloutManifest` 순수성·재서명·seed 계승(단조 편입 보장).
  - `publish-rollout`이 fail-closed(pack 검증 PUT 전)·rollback-manifest 무회귀.
  - 워크플로 `is-pointer-only` 게이팅으로 rollout-update가 빌드 파이프라인을 타지 않는지.

## 리스크

- rollout은 **신버전 앱부터** 유효. 구클라이언트는 generic canonical 서명 검증을 통과하나 rollout을 무시(=100% 채택). staging evidence는 신버전 앱에서만 관측. 하위호환상 자연스러운 전제.
- 시크릿(서명키) 미주입 시 워크플로 dormant. 확산 실행은 사용자 후속.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.(/claude review 폴백 게시 예정)
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.(시크릿 미주입 dormant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 롤아웃 업데이트 모드가 추가되어 배포 과정에서 점진적 전환을 지원합니다.
  * 롤아웃 비율과 대상 순서를 반영해 게시본을 생성·검증하는 흐름이 새로 도입되었습니다.
  * 객체 저장소에 대한 게시와 재검증 기능이 추가되어 업로드 후 무결성을 확인합니다.

* **버그 수정**
  * 매니페스트 검증이 롤아웃 필드의 형식과 범위를 더 엄격하게 확인하도록 개선되었습니다.
  * 참조 파일 불일치나 해시 오류가 있으면 게시가 중단되도록 안전장치가 강화되었습니다.

* **테스트**
  * 롤아웃 생성, 서명, 게시, 드라이런 동작을 검증하는 테스트가 확장되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->