### PR TITLE
[Feat] 데이터팩 단계적 롤아웃 mobile — rollout 파싱·salt·버킷 판정·분포 테스트 (#1692)

### DIFF
--- a/apps/mobile/lib/core/datapack/data_pack_manifest.dart
+++ b/apps/mobile/lib/core/datapack/data_pack_manifest.dart
@@ -19,6 +19,7 @@ class DataPackManifest {
     this.keyId,
     this.signature,
     this.manifestHash,
+    this.rollout,
   });
 
   factory DataPackManifest.fromJson(
@@ -73,6 +74,7 @@ class DataPackManifest {
       manifestHash: manifestVersion == 2
           ? sha256.convert(utf8.encode(signedCanonicalManifest!)).toString()
           : null,
+      rollout: manifestVersion == 2 ? _parseRollout(json['rollout']) : null,
     );
     manifest._validateEnvelopeSignature(json, productionSigningPublicKey);
     return manifest;
@@ -90,6 +92,7 @@ class DataPackManifest {
   final String? keyId;
   final DataPackSignature? signature;
   final String? manifestHash;
+  final RolloutManifest? rollout;
 
   bool get hasReplayProtection => manifestVersion == 2;
 
@@ -698,6 +701,31 @@ const _representativeRoutePatterns = {
   'LOOP_BRANCH',
   'EXPRESS_LOCAL',
 };
+
+class RolloutManifest {
+  const RolloutManifest({required this.percentage, required this.seed});
+
+  final int percentage;
+  final String seed;
+}
+
+RolloutManifest? _parseRollout(Object? raw) {
+  if (raw == null) return null;
+  if (raw is! Map<String, Object?>) {
+    throw const FormatException('Invalid data pack manifest rollout.');
+  }
+  final percentage = raw['percentage'];
+  final seed = raw['seed'];
+  if (percentage is! int || percentage < 0 || percentage > 100) {
+    throw const FormatException(
+      'Invalid data pack manifest rollout percentage.',
+    );
+  }
+  if (seed is! String || seed.isEmpty) {
+    throw const FormatException('Invalid data pack manifest rollout seed.');
+  }
+  return RolloutManifest(percentage: percentage, seed: seed);
+}
 
 class EmergencyOverrideManifest {
   const EmergencyOverrideManifest({

--- a/apps/mobile/lib/core/datapack/data_pack_update_state.dart
+++ b/apps/mobile/lib/core/datapack/data_pack_update_state.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:drift/drift.dart';
 
 import '../database/user/user_database.dart' as user_db;
@@ -16,9 +18,11 @@ class DataPackUpdateStateRepository {
   static const _acceptedSequencePrefix = 'datapack_manifest_accepted_sequence_';
   static const _acceptedHashPrefix = 'datapack_manifest_accepted_hash_';
   static const _acceptedAtPrefix = 'datapack_manifest_accepted_at_ms_';
+  static const _rolloutSaltKey = 'datapack_rollout_salt';
 
   final user_db.UserDatabase userDatabase;
   final DateTime Function() _now;
+  final _secureRandom = Random.secure();
 
   Future<DataPackManifestCache?> readManifestCache() async {
     final rows = await userDatabase
@@ -92,9 +96,7 @@ class DataPackUpdateStateRepository {
   Future<void> ensureManifestCanBeAccepted(DataPackManifest manifest) async {
     if (!manifest.hasReplayProtection) {
       if (await hasAcceptedManifestState()) {
-        throw const DataPackManifestReplayException(
-          '앱 이동 정보를 안전하게 확인하지 못했어요.',
-        );
+        throw const DataPackManifestReplayException('앱 이동 정보를 안전하게 확인하지 못했어요.');
       }
       return;
     }
@@ -192,6 +194,31 @@ class DataPackUpdateStateRepository {
       return false;
     }
     return !now.isAfter(cache.checkedAt.add(cache.ttl));
+  }
+
+  Future<String?> _readValue(String key) async {
+    final rows = await userDatabase
+        .customSelect(
+          'SELECT value FROM data_pack_update_state WHERE key = ?',
+          variables: [Variable<String>(key)],
+          readsFrom: {userDatabase.dataPackUpdateState},
+        )
+        .get();
+    if (rows.isEmpty) return null;
+    return rows.single.read<String>('value');
+  }
+
+  /// 단말별 rollout 버킷 판정용 salt를 로컬에서 1회 생성·영속한다.
+  /// 재호출 시 동일 값 반환(안정). salt는 절대 네트워크로 전송하지 않는다.
+  Future<String> readOrCreateRolloutSalt() async {
+    final existing = await _readValue(_rolloutSaltKey);
+    if (existing != null && RegExp(r'^[a-f0-9]{32}$').hasMatch(existing)) {
+      return existing;
+    }
+    final bytes = List<int>.generate(16, (_) => _secureRandom.nextInt(256));
+    final salt = bytes.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+    await _put(_rolloutSaltKey, salt, _now());
+    return salt;
   }
 
   Future<void> _put(String key, String value, DateTime updatedAt) async {

--- a/apps/mobile/lib/core/datapack/data_pack_updater.dart
+++ b/apps/mobile/lib/core/datapack/data_pack_updater.dart
@@ -1,5 +1,8 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
+
+import 'package:crypto/crypto.dart';
 
 import 'data_pack_client.dart';
 import 'data_pack_installer.dart';
@@ -32,6 +35,25 @@ class DataPackUpdater {
       return const [];
     }
 
+    // rollout 버킷 판정 — salt + seed → sha256 → bucket % 100
+    final rollout = manifest.rollout;
+    bool rolloutApplies = true; // rollout 부재 = 100%(항상 채택)
+    if (rollout != null) {
+      final salt = await client.stateRepository.readOrCreateRolloutSalt();
+      final digest = sha256
+          .convert(utf8.encode('$salt:${rollout.seed}'))
+          .toString();
+      final bucket = int.parse(digest.substring(0, 8), radix: 16) % 100;
+      rolloutApplies = bucket < rollout.percentage;
+    }
+    final rolloutDecision = rollout == null
+        ? 'noRollout'
+        : rolloutApplies
+        ? 'applied'
+        : 'heldOut';
+    // ignore: avoid_print
+    print('[DataPackUpdater] rolloutDecision=$rolloutDecision');
+
     final preUpdateCurrentPointer = await _readCurrentPointerSafely();
     final override = manifest.emergencyOverride;
     final protectedVersionsByPackId = <String, Set<String>>{};
@@ -51,7 +73,7 @@ class DataPackUpdater {
     }
 
     final packBaseUri = _packBaseUriForManifest(client.manifestUri);
-    final packs = _packsToInstall(manifest);
+    final packs = _packsToInstall(manifest, rolloutApplies: rolloutApplies);
     final results = <DataPackInstallResult>[];
     for (final pack in packs) {
       final uri = packBaseUri.resolve(pack.url.toString());
@@ -131,14 +153,20 @@ class DataPackUpdater {
     }
   }
 
-  List<DataPackManifestEntry> _packsToInstall(DataPackManifest manifest) {
+  List<DataPackManifestEntry> _packsToInstall(
+    DataPackManifest manifest, {
+    bool rolloutApplies = true,
+  }) {
     final activePack = manifest.activePack;
     final override = manifest.emergencyOverride;
     final selectedPacks = manifest.packs
         .where((pack) {
+          // emergencyOverride 대상 팩은 rollout과 무관하게 항상 포함
+          if (_matchesOverride(pack, override)) return true;
+          // rollout 비대상이면 일반 팩 제외
+          if (!rolloutApplies) return false;
           final selectedActiveId = activePack?.id ?? activePackId;
-          return pack.id == selectedActiveId ||
-              _matchesOverride(pack, override);
+          return pack.id == selectedActiveId;
         })
         .toList(growable: false);
     final selectedDependencies = selectedPacks

--- a/apps/mobile/lib/core/datapack/data_pack_updater.dart
+++ b/apps/mobile/lib/core/datapack/data_pack_updater.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:developer' as developer;
 import 'dart:io';
 
 import 'package:crypto/crypto.dart';
@@ -48,8 +49,7 @@ class DataPackUpdater {
         : isRolloutApplied
         ? 'applied'
         : 'heldOut';
-    // ignore: avoid_print
-    print('[DataPackUpdater] rolloutDecision=$rolloutDecision');
+    developer.log('rolloutDecision=$rolloutDecision', name: 'DataPackUpdater');
 
     final preUpdateCurrentPointer = await _readCurrentPointerSafely();
     final override = manifest.emergencyOverride;
@@ -91,6 +91,7 @@ class DataPackUpdater {
       final currentPointer = await _currentPointerForManifest(
         manifest: manifest,
         results: results,
+        rolloutApplies: isRolloutApplied,
       );
       if (currentPointer != null) {
         await installer.activateCurrentPointer(currentPointer);
@@ -187,6 +188,7 @@ class DataPackUpdater {
   Future<InstalledDataPackPointer?> _currentPointerForManifest({
     required DataPackManifest manifest,
     required List<DataPackInstallResult> results,
+    bool rolloutApplies = true,
   }) async {
     final activePack = manifest.activePack;
     if (activePack != null) {
@@ -204,6 +206,11 @@ class DataPackUpdater {
       );
       if (installedPointer != null) {
         return installedPointer;
+      }
+      // heldOut 단말 + activePack 미설치: 예외 대신 null 반환(기존 포인터 유지).
+      // rolloutApplied 단말이거나 activePack이 설치된 경우는 이미 위에서 반환.
+      if (!rolloutApplies) {
+        return null;
       }
       throw const DataPackClientException('사용할 이동 정보를 선택하지 못했어요.');
     }

--- a/apps/mobile/lib/core/datapack/data_pack_updater.dart
+++ b/apps/mobile/lib/core/datapack/data_pack_updater.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:crypto/crypto.dart';
+import 'package:meta/meta.dart';
 
 import 'data_pack_client.dart';
 import 'data_pack_installer.dart';
@@ -37,18 +38,14 @@ class DataPackUpdater {
 
     // rollout 버킷 판정 — salt + seed → sha256 → bucket % 100
     final rollout = manifest.rollout;
-    bool rolloutApplies = true; // rollout 부재 = 100%(항상 채택)
+    bool isRolloutApplied = true; // rollout 부재 = 100%(항상 채택)
     if (rollout != null) {
       final salt = await client.stateRepository.readOrCreateRolloutSalt();
-      final digest = sha256
-          .convert(utf8.encode('$salt:${rollout.seed}'))
-          .toString();
-      final bucket = int.parse(digest.substring(0, 8), radix: 16) % 100;
-      rolloutApplies = bucket < rollout.percentage;
+      isRolloutApplied = rolloutApplies(salt, rollout);
     }
     final rolloutDecision = rollout == null
         ? 'noRollout'
-        : rolloutApplies
+        : isRolloutApplied
         ? 'applied'
         : 'heldOut';
     // ignore: avoid_print
@@ -73,7 +70,7 @@ class DataPackUpdater {
     }
 
     final packBaseUri = _packBaseUriForManifest(client.manifestUri);
-    final packs = _packsToInstall(manifest, rolloutApplies: rolloutApplies);
+    final packs = _packsToInstall(manifest, rolloutApplies: isRolloutApplied);
     final results = <DataPackInstallResult>[];
     for (final pack in packs) {
       final uri = packBaseUri.resolve(pack.url.toString());
@@ -316,4 +313,23 @@ void _protectVersion(
 
 String _normalizedVersion(String version) {
   return _versionNumber(version).toString();
+}
+
+/// salt + seed → sha256 → 첫 8 hex 자리를 정수로 파싱 → % 100 → 0~99 버킷.
+///
+/// 버킷은 seed에만 의존하므로 percentage와 독립적이다. percentage를 올려도
+/// 기존 버킷이 변하지 않아 단조 편입(monotonic enrollment)이 자동 성립한다.
+@visibleForTesting
+int rolloutBucket(String salt, String seed) {
+  final digest = sha256.convert(utf8.encode('$salt:$seed')).toString();
+  return int.parse(digest.substring(0, 8), radix: 16) % 100;
+}
+
+/// [rolloutBucket] 결과가 [r.percentage] 미만이면 채택(true), 그렇지 않으면 보류(false).
+///
+/// percentage == 0 이면 항상 false(전면 heldOut = kill switch).
+/// percentage == 100 이면 항상 true(전면 채택).
+@visibleForTesting
+bool rolloutApplies(String salt, RolloutManifest r) {
+  return rolloutBucket(salt, r.seed) < r.percentage;
 }

--- a/apps/mobile/pubspec.lock
+++ b/apps/mobile/pubspec.lock
@@ -665,7 +665,7 @@ packages:
     source: hosted
     version: "0.13.0"
   meta:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: meta
       sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   dio: ^5.9.2
   path_provider: ^2.1.6
   crypto: ^3.0.7
+  meta: ^1.18.0
   archive: ^4.0.9
   path: ^1.9.1
   collection: ^1.19.1

--- a/apps/mobile/test/core/datapack/data_pack_manifest_test.dart
+++ b/apps/mobile/test/core/datapack/data_pack_manifest_test.dart
@@ -653,6 +653,16 @@ void main() {
     );
   });
 
+  test('rollout 필드를 파싱한다(부재 시 null)', () {
+    final withR = DataPackManifest.fromJson(
+      _v2ManifestJson(rollout: {'percentage': 10, 'seed': 'a' * 32}),
+    );
+    expect(withR.rollout!.percentage, 10);
+    expect(withR.rollout!.seed, 'a' * 32);
+    final without = DataPackManifest.fromJson(_v2ManifestJson());
+    expect(without.rollout, isNull);
+  });
+
   test('데이터팩 manifest는 파일 경로로 안전하지 않은 pack id와 version을 거부한다', () {
     expect(
       () => DataPackManifest.fromJson({
@@ -820,6 +830,72 @@ String _signatureValue(
         utf8.encode('$id:$version:$compressedSha256:$sqliteSha256:$sizeBytes'),
       )
       .toString();
+}
+
+Map<String, Object?> _v2ManifestJson({Map<String, Object?>? rollout}) {
+  final manifest = <String, Object?>{
+    'manifestVersion': 2,
+    'channel': 'production',
+    'releaseSequence': 42,
+    'publishedAt': '2026-06-25T00:00:00.000Z',
+    'expiresAt': '2026-06-26T00:00:00.000Z',
+    'ttlSeconds': 3600,
+    'keyId': 'fixture-key',
+    'activePack': {'id': 'capital', 'version': '18'},
+    'packs': [
+      {
+        'id': 'capital',
+        'version': '18',
+        'url': 'catalog/capital-v18.sqlite.gz',
+        'sha256': 'a' * 64,
+        'sqliteSha256': 'b' * 64,
+        'sizeBytes': 1024,
+        'artifactKind': 'fixture',
+        'representativeRouteRegressions': _representativeRouteRegressions,
+        'representativeRouteRegressionSignature': {
+          'algorithm': 'sha256-route-regression-v1',
+          'value': _routeRegressionSignatureValue(
+            'capital',
+            '18',
+            'a' * 64,
+            'b' * 64,
+            1024,
+          ),
+        },
+        'signature': {
+          'algorithm': 'sha256-pack-manifest-v2',
+          'value': _signatureValue('capital', '18', 'a' * 64, 'b' * 64, 1024),
+        },
+        'sourceInventory': [
+          {
+            'id': 'fixture-capital-catalog',
+            'owner': '테스트',
+            'url': 'https://example.invalid/fixture',
+            'license': 'fixture-only',
+            'licenseStatus': 'fixture-only',
+            'redistributionAllowed': false,
+            'updateFrequency': 'manual',
+            'updatedAt': '2026-06-19T00:00:00.000Z',
+            'fields': ['stations', 'network_edges'],
+          },
+        ],
+        'regionalQualityMetrics': {
+          'stationCount': 2,
+          'facilityCoverageRatio': 0.5,
+          'edgeCount': 2,
+          'unknownAccessibilityRatio': 0.0,
+        },
+        'schemaVersion': '1',
+        'requiredTables': ['catalog_metadata', 'stations'],
+      },
+    ],
+    'rollout': ?rollout,
+  };
+  manifest['signature'] = {
+    'algorithm': 'sha256-manifest-v2',
+    'value': sha256.convert(utf8.encode(_canonicalJson(manifest))).toString(),
+  };
+  return manifest;
 }
 
 Map<String, Object?> _v2FixtureManifest() {

--- a/apps/mobile/test/core/datapack/data_pack_rollout_test.dart
+++ b/apps/mobile/test/core/datapack/data_pack_rollout_test.dart
@@ -1,0 +1,100 @@
+import 'dart:math';
+
+import 'package:easysubway_mobile/core/datapack/data_pack_manifest.dart';
+import 'package:easysubway_mobile/core/datapack/data_pack_updater.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+final _rng = Random(42); // 결정론적
+
+String _randomHex32() => List.generate(
+  16,
+  (_) => _rng.nextInt(256).toRadixString(16).padLeft(2, '0'),
+).join();
+
+void main() {
+  group('rollout 버킷 함수', () {
+    test('분포: 1만 salt 샘플에서 percentage 근사(±2%p)', () {
+      const seed = 'abcdef0123456789abcdef0123456789';
+      for (final pct in [10, 50, 90]) {
+        var applied = 0;
+        for (var i = 0; i < 10000; i++) {
+          final salt = _randomHex32();
+          if (rolloutApplies(
+            salt,
+            RolloutManifest(percentage: pct, seed: seed),
+          )) {
+            applied++;
+          }
+        }
+        expect(
+          (applied / 100.0 - pct).abs(),
+          lessThan(2.0),
+          reason: 'pct=$pct applied=$applied',
+        );
+      }
+    });
+
+    test('판정 안정성: 같은 salt+seed는 불변', () {
+      const seed = 'abcdef0123456789abcdef0123456789';
+      const salt = 'deadbeef01234567deadbeef01234567';
+      final bucket1 = rolloutBucket(salt, seed);
+      final bucket2 = rolloutBucket(salt, seed);
+      final bucket3 = rolloutBucket(salt, seed);
+      expect(bucket1, equals(bucket2));
+      expect(bucket2, equals(bucket3));
+      expect(bucket1, inInclusiveRange(0, 99));
+    });
+
+    test('단조 편입: 10→50%로 올려도 기존 대상은 유지', () {
+      const seed = 'abcdef0123456789abcdef0123456789';
+      final salts = List.generate(2000, (_) => _randomHex32());
+      final at10 = salts
+          .where(
+            (s) =>
+                rolloutApplies(s, RolloutManifest(percentage: 10, seed: seed)),
+          )
+          .toSet();
+      final at50 = salts
+          .where(
+            (s) =>
+                rolloutApplies(s, RolloutManifest(percentage: 50, seed: seed)),
+          )
+          .toSet();
+      // 10% 대상 ⊆ 50% 대상
+      expect(at10.difference(at50), isEmpty);
+    });
+
+    test('percentage 0 = 전면 heldOut', () {
+      const seed = 'abcdef0123456789abcdef0123456789';
+      for (var i = 0; i < 500; i++) {
+        final salt = _randomHex32();
+        expect(
+          rolloutApplies(salt, RolloutManifest(percentage: 0, seed: seed)),
+          isFalse,
+          reason: 'salt=$salt should be heldOut at percentage=0',
+        );
+      }
+    });
+
+    test('rolloutBucket 반환값은 0~99 범위', () {
+      const seed = 'abcdef0123456789abcdef0123456789';
+      for (var i = 0; i < 200; i++) {
+        final salt = _randomHex32();
+        final bucket = rolloutBucket(salt, seed);
+        expect(bucket, inInclusiveRange(0, 99));
+      }
+    });
+
+    test('rolloutApplies: percentage 100 = 전면 채택', () {
+      const seed = 'abcdef0123456789abcdef0123456789';
+      for (var i = 0; i < 500; i++) {
+        final salt = _randomHex32();
+        expect(
+          rolloutApplies(salt, RolloutManifest(percentage: 100, seed: seed)),
+          isTrue,
+          reason: 'salt=$salt should be applied at percentage=100',
+        );
+      }
+    });
+  });
+}

--- a/apps/mobile/test/core/datapack/data_pack_update_state_test.dart
+++ b/apps/mobile/test/core/datapack/data_pack_update_state_test.dart
@@ -427,6 +427,16 @@ void main() {
     expect(cache?.checkedAt, DateTime.utc(2026, 6, 25, 12));
   });
 
+  test('rollout salt는 최초 생성 후 안정적으로 재사용된다', () async {
+    final db = user_db.UserDatabase.memory();
+    addTearDown(db.close);
+    final repo = DataPackUpdateStateRepository(userDatabase: db);
+    final s1 = await repo.readOrCreateRolloutSalt();
+    final s2 = await repo.readOrCreateRolloutSalt();
+    expect(s1, matches(RegExp(r'^[a-f0-9]{32}$')));
+    expect(s2, s1); // 안정
+  });
+
   test('update state는 v2 manifest downgrade와 equivocation을 거부한다', () async {
     final userDatabase = user_db.UserDatabase.memory();
     addTearDown(userDatabase.close);

--- a/apps/mobile/test/core/datapack/data_pack_updater_test.dart
+++ b/apps/mobile/test/core/datapack/data_pack_updater_test.dart
@@ -1408,6 +1408,255 @@ void main() {
     expect(override?.version, '17');
     expect(override?.reason, '시설 상태 긴급 정정');
   });
+
+  // ─── rollout 버킷 판정 테스트 ────────────────────────────────────────────
+
+  test('updater는 rollout percentage 0일 때 일반 팩 채택을 건너뛴다', () async {
+    final directory = await Directory.systemTemp.createTemp(
+      'easysubway-datapack-updater-rollout-held-',
+    );
+    addTearDown(() => directory.delete(recursive: true));
+    final userDatabase = user_db.UserDatabase.memory();
+    addTearDown(userDatabase.close);
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+    server.listen((request) {
+      if (request.uri.path.endsWith('/current.json')) {
+        request.response
+          ..statusCode = HttpStatus.ok
+          ..headers.contentType = ContentType.json
+          ..write(
+            jsonEncode(
+              _addV2Signature({
+                'manifestVersion': 2,
+                'channel': 'production',
+                'releaseSequence': 1,
+                'publishedAt': '2026-07-07T00:00:00.000Z',
+                'expiresAt': '2099-01-01T00:00:00.000Z',
+                'keyId': 'test-key',
+                'ttlSeconds': 60,
+                'packs': [
+                  {
+                    'id': 'capital',
+                    'version': '18',
+                    'url': 'catalog/capital-v18.sqlite.gz',
+                    'sha256': '0' * 64,
+                    'sqliteSha256': '0' * 64,
+                    'schemaVersion': '1',
+                    'requiredTables': ['catalog_metadata'],
+                    'artifactKind': 'fixture',
+                  },
+                ],
+                'rollout': {'percentage': 0, 'seed': 'held-out-seed'},
+              }),
+            ),
+          )
+          ..close();
+        return;
+      }
+      // 팩 다운로드 요청이 오면 안 됨
+      request.response
+        ..statusCode = HttpStatus.internalServerError
+        ..close();
+    });
+    final updater = DataPackUpdater(
+      client: DataPackClient(
+        manifestUri: Uri.parse(
+          'http://${server.address.host}:${server.port}/datapacks/catalog/current.json',
+        ),
+        stateRepository: DataPackUpdateStateRepository(
+          userDatabase: userDatabase,
+          now: () => DateTime.utc(2026, 7, 7, 10),
+        ),
+      ),
+      installer: DataPackInstaller(
+        catalogDirectory: Directory('${directory.path}/catalog'),
+        userDatabase: userDatabase,
+      ),
+    );
+
+    final results = await updater.checkForUpdates();
+
+    // heldOut → 일반 팩 채택 없음
+    expect(results, isEmpty);
+  });
+
+  test('updater는 rollout heldOut이어도 emergencyOverride 팩을 채택한다', () async {
+    final directory = await Directory.systemTemp.createTemp(
+      'easysubway-datapack-updater-rollout-override-',
+    );
+    addTearDown(() => directory.delete(recursive: true));
+    final userDatabase = user_db.UserDatabase.memory();
+    addTearDown(userDatabase.close);
+    final overrideSqliteBytes = await _validCatalogSqliteBytes(directory);
+    final overrideCompressedBytes = gzip.encode(overrideSqliteBytes);
+    final overrideCompressedSha256 = sha256
+        .convert(overrideCompressedBytes)
+        .toString();
+    final overrideSqliteSha256 = sha256.convert(overrideSqliteBytes).toString();
+    final overrideRepository = EmergencyOverrideRepository(
+      userDatabase: userDatabase,
+    );
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+    server.listen((request) {
+      switch (request.uri.path) {
+        case '/datapacks/catalog/current.json':
+          request.response
+            ..statusCode = HttpStatus.ok
+            ..headers.contentType = ContentType.json
+            ..write(
+              jsonEncode(
+                _addV2Signature({
+                  'manifestVersion': 2,
+                  'channel': 'production',
+                  'releaseSequence': 1,
+                  'publishedAt': '2026-07-07T00:00:00.000Z',
+                  'expiresAt': '2099-01-01T00:00:00.000Z',
+                  'keyId': 'test-key',
+                  'ttlSeconds': 60,
+                  'emergencyOverride': {
+                    'id': 'capital',
+                    'version': '18',
+                    'reason': '테스트 긴급 정정',
+                  },
+                  'packs': [
+                    // 일반 팩(v19) — rollout heldOut으로 건너뜀
+                    {
+                      'id': 'capital',
+                      'version': '19',
+                      'url': 'catalog/capital-v19.sqlite.gz',
+                      'sha256': '0' * 64,
+                      'sqliteSha256': '0' * 64,
+                      'schemaVersion': '1',
+                      'requiredTables': ['catalog_metadata'],
+                      'artifactKind': 'fixture',
+                    },
+                    // override 팩(v18) — rollout 무관, 항상 채택
+                    {
+                      'id': 'capital',
+                      'version': '18',
+                      'url': 'catalog/capital-v18.sqlite.gz',
+                      'sha256': overrideCompressedSha256,
+                      'sqliteSha256': overrideSqliteSha256,
+                      'schemaVersion': '1',
+                      'requiredTables': ['catalog_metadata'],
+                      'artifactKind': 'fixture',
+                    },
+                  ],
+                  'rollout': {'percentage': 0, 'seed': 'held-out-seed'},
+                }),
+              ),
+            )
+            ..close();
+        case '/datapacks/catalog/capital-v18.sqlite.gz':
+          request.response
+            ..statusCode = HttpStatus.ok
+            ..add(overrideCompressedBytes)
+            ..close();
+        default:
+          // v19 다운로드 요청이 오면 안 됨
+          request.response
+            ..statusCode = HttpStatus.internalServerError
+            ..close();
+      }
+    });
+    final catalogDirectory = Directory('${directory.path}/catalog');
+    final installer = DataPackInstaller(
+      catalogDirectory: catalogDirectory,
+      userDatabase: userDatabase,
+    );
+    final updater = DataPackUpdater(
+      client: DataPackClient(
+        manifestUri: Uri.parse(
+          'http://${server.address.host}:${server.port}/datapacks/catalog/current.json',
+        ),
+        stateRepository: DataPackUpdateStateRepository(
+          userDatabase: userDatabase,
+          now: () => DateTime.utc(2026, 7, 7, 10),
+        ),
+      ),
+      installer: installer,
+      emergencyOverrideRepository: overrideRepository,
+    );
+
+    final results = await updater.checkForUpdates();
+    final override = await overrideRepository.readOverride();
+
+    // override 팩(v18)만 채택됨
+    expect(results.single.status, DataPackInstallStatus.installed);
+    expect(results.single.pointer?.id, 'capital');
+    expect(results.single.pointer?.version, '18');
+    // emergencyOverride 저장됨
+    expect(override?.id, 'capital');
+    expect(override?.version, '18');
+  });
+
+  test('updater는 rollout 부재(v1 manifest) 시 항상 팩을 채택한다', () async {
+    final directory = await Directory.systemTemp.createTemp(
+      'easysubway-datapack-updater-no-rollout-',
+    );
+    addTearDown(() => directory.delete(recursive: true));
+    final userDatabase = user_db.UserDatabase.memory();
+    addTearDown(userDatabase.close);
+    final catalogDirectory = Directory('${directory.path}/catalog');
+    final sqliteBytes = await _validCatalogSqliteBytes(directory);
+    final compressedBytes = gzip.encode(sqliteBytes);
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+    server.listen((request) {
+      switch (request.uri.path) {
+        case '/datapacks/catalog/current.json':
+          request.response
+            ..statusCode = HttpStatus.ok
+            ..headers.contentType = ContentType.json
+            ..write(
+              jsonEncode({
+                'ttlSeconds': 60,
+                'packs': [
+                  _packJson(
+                    version: '18',
+                    url: 'catalog/capital-v18.sqlite.gz',
+                    compressedBytes: compressedBytes,
+                    sqliteBytes: sqliteBytes,
+                  ),
+                ],
+                // rollout 없음 → 항상 채택
+              }),
+            )
+            ..close();
+        case '/datapacks/catalog/capital-v18.sqlite.gz':
+          request.response
+            ..statusCode = HttpStatus.ok
+            ..add(compressedBytes)
+            ..close();
+        default:
+          request.response
+            ..statusCode = HttpStatus.notFound
+            ..close();
+      }
+    });
+    final updater = DataPackUpdater(
+      client: DataPackClient(
+        manifestUri: Uri.parse(
+          'http://${server.address.host}:${server.port}/datapacks/catalog/current.json',
+        ),
+        stateRepository: DataPackUpdateStateRepository(
+          userDatabase: userDatabase,
+          now: () => DateTime.utc(2026, 7, 7, 11),
+        ),
+      ),
+      installer: DataPackInstaller(
+        catalogDirectory: catalogDirectory,
+        userDatabase: userDatabase,
+      ),
+    );
+
+    final results = await updater.checkForUpdates();
+
+    // rollout 부재 → 채택(하위 호환)
+    expect(results.single.status, DataPackInstallStatus.installed);
+  });
 }
 
 Map<String, Object?> _packJson({
@@ -1520,6 +1769,35 @@ String _routeRegressionSignatureValue(
         ),
       )
       .toString();
+}
+
+// ─── v2 매니페스트 서명 헬퍼 ────────────────────────────────────────────────
+
+/// 매니페스트 객체(signature 제외)를 받아 sha256-manifest-v2 서명을 추가한다.
+Map<String, Object?> _addV2Signature(
+  Map<String, Object?> bodyWithoutSignature,
+) {
+  final canonical = jsonEncode(_canonicalMapValue(bodyWithoutSignature));
+  final signatureValue = sha256.convert(utf8.encode(canonical)).toString();
+  return {
+    ...bodyWithoutSignature,
+    'signature': {'algorithm': 'sha256-manifest-v2', 'value': signatureValue},
+  };
+}
+
+/// data_pack_manifest.dart 의 _canonicalValue 를 테스트에서 복제한다(private 접근 불가).
+Object? _canonicalMapValue(Object? value) {
+  if (value == null || value is String || value is num || value is bool) {
+    return value;
+  }
+  if (value is List<Object?>) {
+    return value.map(_canonicalMapValue).toList(growable: false);
+  }
+  if (value is Map<String, Object?>) {
+    final sortedKeys = value.keys.toList()..sort();
+    return {for (final key in sortedKeys) key: _canonicalMapValue(value[key])};
+  }
+  throw ArgumentError('Unsupported canonical value type: ${value.runtimeType}');
 }
 
 Future<List<int>> _validCatalogSqliteBytes(Directory directory) async {

--- a/apps/mobile/test/core/datapack/data_pack_updater_test.dart
+++ b/apps/mobile/test/core/datapack/data_pack_updater_test.dart
@@ -1657,6 +1657,221 @@ void main() {
     // rollout 부재 → 채택(하위 호환)
     expect(results.single.status, DataPackInstallStatus.installed);
   });
+
+  // ─── heldOut + activePack 미설치 크래시 방어 ─────────────────────────────
+
+  test('updater는 rollout heldOut + activePack 미설치 시 예외 없이 그레이스풀 반환한다', () async {
+    // 시나리오A: heldOut + manifest.activePack 설정(미설치) + override 없음
+    // → checkForUpdates가 예외 없이 반환, 새 팩 미채택, 기존 포인터 유지
+    final directory = await Directory.systemTemp.createTemp(
+      'easysubway-datapack-updater-heldout-activePack-',
+    );
+    addTearDown(() => directory.delete(recursive: true));
+    final userDatabase = user_db.UserDatabase.memory();
+    addTearDown(userDatabase.close);
+    final catalogDirectory = Directory('${directory.path}/catalog');
+    await catalogDirectory.create(recursive: true);
+    // 기존 current pointer(v17) 설정 — 이 포인터가 유지돼야 함
+    final oldPack = File('${catalogDirectory.path}/capital-v17.sqlite');
+    await oldPack.writeAsString('old pack');
+    await File('${catalogDirectory.path}/current.json').writeAsString(
+      jsonEncode({
+        'id': 'capital',
+        'version': '17',
+        'path': oldPack.path,
+        'sha256': 'old-sha',
+      }),
+    );
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+    server.listen((request) {
+      if (request.uri.path.endsWith('/current.json')) {
+        request.response
+          ..statusCode = HttpStatus.ok
+          ..headers.contentType = ContentType.json
+          ..write(
+            jsonEncode(
+              _addV2Signature({
+                'manifestVersion': 2,
+                'channel': 'production',
+                'releaseSequence': 1,
+                'publishedAt': '2026-07-07T00:00:00.000Z',
+                'expiresAt': '2099-01-01T00:00:00.000Z',
+                'keyId': 'test-key',
+                'ttlSeconds': 60,
+                // activePack v19 설정 — 단말에 미설치
+                'activePack': {'id': 'capital', 'version': '19'},
+                'packs': [
+                  {
+                    'id': 'capital',
+                    'version': '19',
+                    'url': 'catalog/capital-v19.sqlite.gz',
+                    'sha256': '0' * 64,
+                    'sqliteSha256': '0' * 64,
+                    'schemaVersion': '1',
+                    'requiredTables': ['catalog_metadata'],
+                    'artifactKind': 'fixture',
+                  },
+                ],
+                // percentage 0 → 이 단말은 항상 heldOut
+                'rollout': {'percentage': 0, 'seed': 'held-out-seed'},
+              }),
+            ),
+          )
+          ..close();
+        return;
+      }
+      // v19 다운로드 요청이 오면 안 됨
+      request.response
+        ..statusCode = HttpStatus.internalServerError
+        ..close();
+    });
+    final installer = DataPackInstaller(
+      catalogDirectory: catalogDirectory,
+      userDatabase: userDatabase,
+    );
+    final updater = DataPackUpdater(
+      client: DataPackClient(
+        manifestUri: Uri.parse(
+          'http://${server.address.host}:${server.port}/datapacks/catalog/current.json',
+        ),
+        stateRepository: DataPackUpdateStateRepository(
+          userDatabase: userDatabase,
+          now: () => DateTime.utc(2026, 7, 7, 10),
+        ),
+      ),
+      installer: installer,
+    );
+
+    // heldOut + activePack 미설치 → 예외 없이 그레이스풀 반환
+    final results = await updater.checkForUpdates();
+    final pointer = await installer.readCurrentPointer();
+
+    expect(results, isEmpty);
+    // v19 미채택 — 기존 v17 포인터 유지
+    expect(pointer?.version, '17');
+  });
+
+  test(
+    'updater는 rollout heldOut + activePack 미설치 시에도 emergencyOverride를 저장한다',
+    () async {
+      // 시나리오B: heldOut + activePack 미설치 + emergencyOverride 설정
+      // → override 팩 채택 + saveOverride 수행(불변식), 예외 없음
+      final directory = await Directory.systemTemp.createTemp(
+        'easysubway-datapack-updater-heldout-override-activePack-',
+      );
+      addTearDown(() => directory.delete(recursive: true));
+      final userDatabase = user_db.UserDatabase.memory();
+      addTearDown(userDatabase.close);
+      final overrideRepository = EmergencyOverrideRepository(
+        userDatabase: userDatabase,
+      );
+      final overrideSqliteBytes = await _validCatalogSqliteBytes(directory);
+      final overrideCompressedBytes = gzip.encode(overrideSqliteBytes);
+      final overrideCompressedSha256 = sha256
+          .convert(overrideCompressedBytes)
+          .toString();
+      final overrideSqliteSha256 = sha256
+          .convert(overrideSqliteBytes)
+          .toString();
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(server.close);
+      server.listen((request) {
+        switch (request.uri.path) {
+          case '/datapacks/catalog/current.json':
+            request.response
+              ..statusCode = HttpStatus.ok
+              ..headers.contentType = ContentType.json
+              ..write(
+                jsonEncode(
+                  _addV2Signature({
+                    'manifestVersion': 2,
+                    'channel': 'production',
+                    'releaseSequence': 1,
+                    'publishedAt': '2026-07-07T00:00:00.000Z',
+                    'expiresAt': '2099-01-01T00:00:00.000Z',
+                    'keyId': 'test-key',
+                    'ttlSeconds': 60,
+                    // activePack v19 설정 — 단말에 미설치
+                    'activePack': {'id': 'capital', 'version': '19'},
+                    'emergencyOverride': {
+                      'id': 'capital',
+                      'version': '18',
+                      'reason': '테스트 긴급 정정',
+                    },
+                    'packs': [
+                      // activePack(v19) — heldOut으로 건너뜀
+                      {
+                        'id': 'capital',
+                        'version': '19',
+                        'url': 'catalog/capital-v19.sqlite.gz',
+                        'sha256': '0' * 64,
+                        'sqliteSha256': '0' * 64,
+                        'schemaVersion': '1',
+                        'requiredTables': ['catalog_metadata'],
+                        'artifactKind': 'fixture',
+                      },
+                      // override 팩(v18) — rollout 무관, 항상 채택
+                      {
+                        'id': 'capital',
+                        'version': '18',
+                        'url': 'catalog/capital-v18.sqlite.gz',
+                        'sha256': overrideCompressedSha256,
+                        'sqliteSha256': overrideSqliteSha256,
+                        'schemaVersion': '1',
+                        'requiredTables': ['catalog_metadata'],
+                        'artifactKind': 'fixture',
+                      },
+                    ],
+                    // percentage 0 → 이 단말은 항상 heldOut
+                    'rollout': {'percentage': 0, 'seed': 'held-out-seed'},
+                  }),
+                ),
+              )
+              ..close();
+          case '/datapacks/catalog/capital-v18.sqlite.gz':
+            request.response
+              ..statusCode = HttpStatus.ok
+              ..add(overrideCompressedBytes)
+              ..close();
+          default:
+            // v19 다운로드 요청이 오면 안 됨
+            request.response
+              ..statusCode = HttpStatus.internalServerError
+              ..close();
+        }
+      });
+      final catalogDirectory = Directory('${directory.path}/catalog');
+      final installer = DataPackInstaller(
+        catalogDirectory: catalogDirectory,
+        userDatabase: userDatabase,
+      );
+      final updater = DataPackUpdater(
+        client: DataPackClient(
+          manifestUri: Uri.parse(
+            'http://${server.address.host}:${server.port}/datapacks/catalog/current.json',
+          ),
+          stateRepository: DataPackUpdateStateRepository(
+            userDatabase: userDatabase,
+            now: () => DateTime.utc(2026, 7, 7, 10),
+          ),
+        ),
+        installer: installer,
+        emergencyOverrideRepository: overrideRepository,
+      );
+
+      final results = await updater.checkForUpdates();
+      final override = await overrideRepository.readOverride();
+
+      // override 팩(v18)만 채택됨
+      expect(results.single.status, DataPackInstallStatus.installed);
+      expect(results.single.pointer?.id, 'capital');
+      expect(results.single.pointer?.version, '18');
+      // emergencyOverride 저장됨(불변식)
+      expect(override?.id, 'capital');
+      expect(override?.version, '18');
+    },
+  );
 }
 
 Map<String, Object?> _packJson({


### PR DESCRIPTION
## 관련 이슈

Closes #1692

> #1690 데이터팩 상용 전송 체계 ② 단계적 롤아웃의 **mobile 절반(Task 6~9)**. tools+workflow 절반 PR1 #1862(`Refs #1692`) 위에 스택. PR1 병합 시 본 PR이 main으로 자동 retarget되며 `Closes #1692`.

## 작업 배경

PR1이 매니페스트에 rollout 필드·워크플로 단계 확산을 도입했다. 클라이언트가 로컬 salt+seed로 버킷을 계산해 **비대상이면 채택을 건너뛰고**, percentage 0 = 신규 채택 중지(kill switch)로 동작해야 확산이 실제로 게이팅된다. **프라이버시 불변: 버킷 키는 단말 로컬 랜덤 salt만, 네트워크 전송 금지.**

## 작업 내용 (mobile)

- **T6 파싱**: `DataPackManifest.rollout` → `RolloutManifest?{percentage,seed}`(부재=null=100%). `_withoutSignature`는 signature만 제거 → rollout은 서명 경계 안 자동 포함.
- **T7 salt 영속**: `DataPackUpdateStateRepository.readOrCreateRolloutSalt()` — `Random.secure()` 16B hex32, Drift 로컬 저장·재사용 안정. **네트워크 전송 없음.**
- **T8 버킷 판정·override 우선**: `checkForUpdates()`에서 `bucket = sha256(salt:seed)[0:8]%100 < percentage`. **emergencyOverride 팩은 heldOut이어도 항상 채택**, 일반 팩만 게이팅. rolloutDecision(applied/heldOut/noRollout) 기록.
- **T9 테스트·순수함수**: `@visibleForTesting rolloutBucket/rolloutApplies` 추출. 분포(1만 샘플 ±2%p)·판정 안정성·단조 편입(10%⊆50%)·kill switch(pct 0).

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && flutter test test/core/datapack/` → 63 tests, All passed
  - `flutter analyze lib test` → No issues
  - `dart format .` → 적용

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 프라이버시(salt 로컬-only) | mobile | diff에서 salt 전송 경로 부재 | data_pack_update_state·updater | ✅ |
| emergencyOverride 우선 | mobile | pct 0 heldOut에도 override 채택 | updater_test | ✅ |
| 분포 ±2%p·단조 편입 | mobile | 1만 샘플·at10⊆at50 | data_pack_rollout_test | ✅ |
| kill switch(pct 0) | mobile | 전면 heldOut | data_pack_rollout_test | ✅ |
| staging 10%→50%→0% 실기기 | 운영 | 배포·salt 조작 단말 | 사용자 후속(외부-게이팅) | ⏳ |

## Version impact

- [ ] no version change
- [x] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

> rollout 클라이언트 게이팅 추가(하위호환: rollout 부재=100% 채택). 매니페스트 계약 변경 없음(선택 필드). 신버전 앱부터 게이팅 유효.

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음(내부 로직 patch, 릴리스 시 반영)
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `_withoutSignature`가 rollout을 포함하는지(서명 경계).
  - salt가 네트워크로 나가지 않는지(프라이버시 불변).
  - emergencyOverride가 rollout 게이트 앞에서 항상 채택되는지.
  - 단조 편입(rolloutBucket이 percentage 독립).

## 리스크

- rollout은 **이 코드를 포함한 앱 버전부터** 유효. 구클라이언트는 rollout을 무시(=100% 채택) — generic canonical 서명 검증은 통과. staging evidence는 신버전 앱에서만 관측.
- rolloutDecision 기록에 bare `print` 사용(릴리스 stdout 노이즈) — 후속 로거 교체 여지.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.(스택 PR — CodeRabbit skip, /claude review 폴백 게시 예정)
- [ ] GitHub PR Review 객체가 있는지 확인했다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.(SDD 4-태스크 리뷰 완료 → /claude review 폴백 단일 review 게시 예정)
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.(신버전 앱부터 유효, 시크릿 미주입 dormant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
