### PR TITLE
[Chore] PR 템플릿 full/short 2단계 도입 — 등급별 issue/PR 볼륨 제어

### DIFF
--- a/.github/ISSUE_TEMPLATE/refactor_request.yml
+++ b/.github/ISSUE_TEMPLATE/refactor_request.yml
@@ -1,5 +1,5 @@
 name: "리팩터링"
-description: "구조 개선, 책임 분리, 중복 제거처럼 동작 유지가 중요한 개선 작업을 정리합니다."
+description: "구조 개선, 책임 분리, 중복 제거처럼 동작 유지가 중요한 개선 작업을 정리합니다. A등급 제품/운영 위험 작업만 새 issue가 필수입니다. B/C등급은 기존 umbrella issue 재사용 또는 issue 생략을 우선 검토하세요."
 labels: ["enhancement"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/task_request.yml
+++ b/.github/ISSUE_TEMPLATE/task_request.yml
@@ -1,5 +1,5 @@
 name: "작업"
-description: "빌드, CI, 설정, 테스트, 배포처럼 유지보수와 정리가 필요한 작업을 정리합니다."
+description: "빌드, CI, 설정, 테스트, 배포처럼 유지보수와 정리가 필요한 작업을 정리합니다. A등급 제품/운영 위험 작업만 새 issue가 필수입니다. B/C등급은 기존 umbrella issue 재사용 또는 issue 생략을 우선 검토하세요."
 labels: ["documentation"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/test_request.yml
+++ b/.github/ISSUE_TEMPLATE/test_request.yml
@@ -1,5 +1,5 @@
 name: "테스트"
-description: "테스트 추가, 회귀 검증, 품질 게이트 보강 작업을 정리합니다."
+description: "테스트 추가, 회귀 검증, 품질 게이트 보강 작업을 정리합니다. A등급 제품/운영 위험 작업만 새 issue가 필수입니다. B/C등급은 기존 umbrella issue 재사용 또는 issue 생략을 우선 검토하세요."
 labels: ["enhancement"]
 body:
   - type: markdown

--- a/.github/PULL_REQUEST_TEMPLATE/full.md
+++ b/.github/PULL_REQUEST_TEMPLATE/full.md
@@ -1,0 +1,72 @@
+## 관련 이슈
+
+close #
+
+## 작업 배경
+
+-
+
+## 작업 내용
+
+-
+
+## 검증
+
+- 실행한 명령과 결과:
+
+## 검증 증거
+
+UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.
+
+| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
+| --- | --- | --- | --- | --- |
+|  |  |  |  |  |
+
+## Version impact
+
+- [ ] no version change
+- [ ] mobile patch
+- [ ] mobile minor
+- [ ] mobile major
+- [ ] backend deploy only
+- [ ] datapack release only
+- [ ] route/realtime contract change
+- [ ] DB migration change
+
+## Route commercialization gate impact
+
+- [ ] route-commercialization-gate.json 영향 없음
+- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
+- [ ] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.
+
+## Route release readiness tracker impact
+
+- [ ] route-release-readiness-tracker.json 영향 없음
+- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
+- [ ] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.
+
+### Version decision
+
+- mobile versionName:
+- mobile versionCode:
+- datapack version:
+- route contract:
+- realtime contract:
+- backend identity:
+
+## 리뷰어 메모
+
+- 리뷰어가 먼저 봐야 할 지점:
+
+## 리스크
+
+-
+
+## 체크리스트
+
+- [ ] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
+- [ ] CI 결과를 확인했다.
+- [ ] CodeRabbit 리뷰를 확인했다.
+- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
+- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
+- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.

--- a/.github/PULL_REQUEST_TEMPLATE/short.md
+++ b/.github/PULL_REQUEST_TEMPLATE/short.md
@@ -1,0 +1,30 @@
+<!-- B/C등급(일반 코드 변경·낮은 위험 maintenance) 전용. A등급(제품/운영 위험, CI/계약 테스트/release gate 변경)은 full.md를 사용합니다. -->
+
+## 관련 이슈
+
+<!-- umbrella `Refs #N` 또는 `이슈 없음(C등급)` 명기. 빈 칸 금지. -->
+
+Refs #
+
+## 작업 내용
+
+-
+
+## 검증
+
+- 실행한 명령과 결과:
+
+## 영향
+
+- [ ] 제품/운영 위험 없음 (route/accessibility/mobile UX/backend API/auth/security 아님)
+- [ ] DB migration 없음
+- [ ] 배포 영향 없음
+- [ ] route/realtime/datapack contract 영향 없음
+- [ ] CI workflow·계약 테스트·release gate JSON 변경 없음 (있으면 full.md로 전환)
+
+## 체크리스트
+
+- [ ] 이 PR은 B/C등급 작업이며 full template이 필요 없다.
+- [ ] CI 결과를 확인했다.
+- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
+- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 폴백 리뷰를 단일 PR review로 게시했다.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,16 @@
+<!--
+작업 등급에 맞는 템플릿을 사용하세요.
+- A등급(제품/운영 위험: route, accessibility, mobile UX, backend API, DB migration, deploy, auth, security, datapack release, CI workflow·계약 테스트·release gate JSON 변경): .github/PULL_REQUEST_TEMPLATE/full.md 내용으로 교체합니다.
+- B/C등급(일반 코드 변경·낮은 위험 maintenance): .github/PULL_REQUEST_TEMPLATE/short.md 내용으로 교체합니다(아래 기본형과 동일).
+- 웹 UI에서는 ?template=full.md 또는 ?template=short.md 쿼리를 쓸 수 있습니다. gh CLI는 template 쿼리를 지원하지 않으므로 템플릿 파일 내용을 body로 직접 채웁니다.
+- 리뷰·automerge 게이트는 등급과 무관하게 모든 PR 공통입니다.
+-->
+
 ## 관련 이슈
 
-close #
+<!-- 단일 PR은 `Closes #N`, 스택 중간/umbrella는 `Refs #N`, C등급 issue 생략 시 `이슈 없음(C등급)` 명기. 빈 칸 금지. -->
 
-## 작업 배경
-
--
+Refs #
 
 ## 작업 내용
 
@@ -14,59 +20,16 @@ close #
 
 - 실행한 명령과 결과:
 
-## 검증 증거
+## 영향
 
-UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.
-
-| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
-| --- | --- | --- | --- | --- |
-|  |  |  |  |  |
-
-## Version impact
-
-- [ ] no version change
-- [ ] mobile patch
-- [ ] mobile minor
-- [ ] mobile major
-- [ ] backend deploy only
-- [ ] datapack release only
-- [ ] route/realtime contract change
-- [ ] DB migration change
-
-## Route commercialization gate impact
-
-- [ ] route-commercialization-gate.json 영향 없음
-- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
-- [ ] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.
-
-## Route release readiness tracker impact
-
-- [ ] route-release-readiness-tracker.json 영향 없음
-- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
-- [ ] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.
-
-### Version decision
-
-- mobile versionName:
-- mobile versionCode:
-- datapack version:
-- route contract:
-- realtime contract:
-- backend identity:
-
-## 리뷰어 메모
-
-- 리뷰어가 먼저 봐야 할 지점:
-
-## 리스크
-
--
+- [ ] 제품/운영 위험 없음 (route/accessibility/mobile UX/backend API/auth/security 아님)
+- [ ] DB migration 없음
+- [ ] 배포 영향 없음
+- [ ] route/realtime/datapack contract 영향 없음
+- [ ] CI workflow·계약 테스트·release gate JSON 변경 없음 (있으면 full.md로 전환)
 
 ## 체크리스트
 
-- [ ] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
+- [ ] 작업 등급에 맞는 템플릿을 사용했다.
 - [ ] CI 결과를 확인했다.
-- [ ] CodeRabbit 리뷰를 확인했다.
 - [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
-- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
-- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,7 +228,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          unexpected_markdown="$(git ls-files '*.md' ':!:README.md' ':!:.github/pull_request_template.md')"
+          unexpected_markdown="$(git ls-files '*.md' ':!:README.md' ':!:.github/pull_request_template.md' ':!:.github/PULL_REQUEST_TEMPLATE/*.md')"
           if [[ -n "${unexpected_markdown}" ]]; then
             echo "Unexpected tracked Markdown file:"
             echo "${unexpected_markdown}"

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.md
 !/README.md
 !/.github/pull_request_template.md
+!/.github/PULL_REQUEST_TEMPLATE/*.md
 
 # Local environment and secrets
 .env

--- a/apps/mobile/release/release-security-gate.json
+++ b/apps/mobile/release/release-security-gate.json
@@ -94,7 +94,7 @@
       "ownerKo": "백엔드/운영 담당",
       "readyWhenKo": "운영 프로필은 Basic auth를 기본 비활성화하고, 예외적으로 켤 때는 owner와 만료일을 명시한 승인 기록, 관리자와 운영기관 인증 실패 lockout 검증, OIDC/MFA/SSO 전환 결정 증거가 PR 검증 증거에 남아야 한다.",
       "evidence": ["admin-auth-transition-decision-record", "basic-auth-prod-disable-test", "basic-auth-exception-expiry-record", "admin-basic-auth-lockout-tests", "admin-security-config-review"],
-      "linkedArtifacts": ["backend/src/main/java/com/easysubway/common/security/SecurityConfig.java", "backend/src/main/java/com/easysubway/common/security/AdminOperatorLockoutAuthenticationProvider.java", "backend/src/test/java/com/easysubway/common/security/AdminOperatorLockoutAuthenticationProviderTest.java", ".github/pull_request_template.md", "tools/ci/repository-contract.test.mjs"]
+      "linkedArtifacts": ["backend/src/main/java/com/easysubway/common/security/SecurityConfig.java", "backend/src/main/java/com/easysubway/common/security/AdminOperatorLockoutAuthenticationProvider.java", "backend/src/test/java/com/easysubway/common/security/AdminOperatorLockoutAuthenticationProviderTest.java", ".github/PULL_REQUEST_TEMPLATE/full.md", "tools/ci/repository-contract.test.mjs"]
     },
     {
       "id": "backend_role_authorization",
@@ -224,7 +224,7 @@
       "ownerKo": "보안/릴리즈 담당",
       "readyWhenKo": "프로덕션 제출 후보 commit에 대해 Codex Security 저장소 scan과 모바일/백엔드 의존성 점검 결과를 PR 또는 release gate 기록에 남긴다.",
       "evidence": ["codex-security-scan-result", "release-candidate-review"],
-      "linkedArtifacts": ["tools/ci/repository-contract.test.mjs", ".github/pull_request_template.md", ".github/workflows/ci.yml"]
+      "linkedArtifacts": ["tools/ci/repository-contract.test.mjs", ".github/PULL_REQUEST_TEMPLATE/full.md", ".github/workflows/ci.yml"]
     },
     {
       "id": "cross_store_privacy_security_consistency",

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -11290,7 +11290,7 @@ test("릴리즈 보안 기준선은 제출 전 차단 항목을 고정한다", (
   assert.ok(adminBasicAuthGate.linkedArtifacts.includes("backend/src/main/java/com/easysubway/common/security/SecurityConfig.java"));
   assert.ok(adminBasicAuthGate.linkedArtifacts.includes("backend/src/main/java/com/easysubway/common/security/AdminOperatorLockoutAuthenticationProvider.java"));
   assert.ok(adminBasicAuthGate.linkedArtifacts.includes("backend/src/test/java/com/easysubway/common/security/AdminOperatorLockoutAuthenticationProviderTest.java"));
-  assert.ok(adminBasicAuthGate.linkedArtifacts.includes(".github/pull_request_template.md"));
+  assert.ok(adminBasicAuthGate.linkedArtifacts.includes(".github/PULL_REQUEST_TEMPLATE/full.md"));
   assert.match(adminOperatorLockoutProvider, /LockedException/);
   assert.match(adminOperatorLockoutProvider, /BadCredentialsException/);
   assert.match(adminOperatorLockoutProvider, /AdminIdentityRepository/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -80,7 +80,7 @@ test("route commercialization release gate blocks unsupported commercial route c
 
   const gate = readJson(gatePath);
   const readme = read("README.md");
-  const prTemplate = read(".github/pull_request_template.md");
+  const prTemplate = read(".github/PULL_REQUEST_TEMPLATE/full.md");
   const contractReportBuilder = "tools/routes/build-route-v2-contract-report.mjs";
   const routeGraphCoverageBuilder = "tools/routes/build-route-graph-coverage-report.mjs";
 
@@ -271,7 +271,7 @@ test("route release readiness tracker keeps issue 1414 as a release blocker", ()
 
   const tracker = readJson(trackerPath);
   const readme = read("README.md");
-  const prTemplate = read(".github/pull_request_template.md");
+  const prTemplate = read(".github/PULL_REQUEST_TEMPLATE/full.md");
   const issueNumbers = tracker.requiredChildIssues.map((issue) => issue.number);
 
   assert.equal(tracker.schemaVersion, 1);
@@ -670,6 +670,7 @@ test("로컬 에이전트 문서와 README 외 Markdown은 gitignore로 추적�
   assert.match(gitignore, /^\*\.md$/m);
   assert.match(gitignore, /^!\/README\.md$/m);
   assert.match(gitignore, /^!\/\.github\/pull_request_template\.md$/m);
+  assert.match(gitignore, /^!\/\.github\/PULL_REQUEST_TEMPLATE\/\*\.md$/m);
   assert.match(gitignore, /^AGENTS\.md$/m);
   assert.match(gitignore, /^docs\/$/m);
   assert.match(gitignore, /^\.codex\/$/m);
@@ -678,7 +679,10 @@ test("로컬 에이전트 문서와 README 외 Markdown은 gitignore로 추적�
 test("지속적 통합은 README 외 Markdown과 로컬 에이전트 문서 추적 금지를 검사한다", () => {
   const workflow = read(".github/workflows/ci.yml");
 
-  assert.match(workflow, /git ls-files '\*\.md' ':!:README\.md' ':!:\.github\/pull_request_template\.md'/);
+  assert.match(
+    workflow,
+    /git ls-files '\*\.md' ':!:README\.md' ':!:\.github\/pull_request_template\.md' ':!:\.github\/PULL_REQUEST_TEMPLATE\/\*\.md'/,
+  );
   assert.match(workflow, /Unexpected tracked Markdown file/);
   assert.match(workflow, /git ls-files AGENTS\.md CLAUDE\.md GEMINI\.md CURSOR\.md COPILOT\.md docs \.codex/);
   assert.match(workflow, /Unexpected tracked local agent file/);
@@ -880,8 +884,8 @@ test("CD 배포는 production environment를 선언하고 배포 태그는 recor
   assert.match(cleanup, /matching-refs\/tags\/deploy\/backend\//);
 });
 
-test("풀 리퀘스트 템플릿은 리뷰와 배포 확인 게이트를 포함한다", () => {
-  const template = read(".github/pull_request_template.md");
+test("full PR 템플릿은 리뷰와 배포 확인 게이트를 포함한다", () => {
+  const template = read(".github/PULL_REQUEST_TEMPLATE/full.md");
 
   assert.match(template, /## 관련 이슈/);
   assert.match(template, /## 검증/);
@@ -896,6 +900,58 @@ test("풀 리퀘스트 템플릿은 리뷰와 배포 확인 게이트를 포함�
   assert.match(template, /CodeRabbit status check만으로는 리뷰 완료로 보지 않는다/);
   assert.match(template, /CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다/);
   assert.match(template, /CD 상태를 확인했다/);
+});
+
+test("full PR 템플릿은 A등급 12개 섹션 전부를 유지한다", () => {
+  const template = read(".github/PULL_REQUEST_TEMPLATE/full.md");
+
+  for (const heading of [
+    "## 관련 이슈",
+    "## 작업 배경",
+    "## 작업 내용",
+    "## 검증",
+    "## 검증 증거",
+    "## Version impact",
+    "## Route commercialization gate impact",
+    "## Route release readiness tracker impact",
+    "### Version decision",
+    "## 리뷰어 메모",
+    "## 리스크",
+    "## 체크리스트",
+  ]) {
+    assert.ok(template.includes(heading), `full template must include ${heading}`);
+  }
+});
+
+test("short PR 템플릿은 B/C등급 5개 섹션과 리뷰 게이트를 유지한다", () => {
+  const template = read(".github/PULL_REQUEST_TEMPLATE/short.md");
+
+  for (const heading of ["## 관련 이슈", "## 작업 내용", "## 검증", "## 영향", "## 체크리스트"]) {
+    assert.ok(template.includes(heading), `short template must include ${heading}`);
+  }
+  assert.match(template, /이슈 없음\(C등급\)/);
+  assert.match(template, /full\.md를 사용/);
+  assert.match(template, /실행한 명령과 결과/);
+  assert.match(template, /DB migration 없음/);
+  assert.match(template, /CI workflow·계약 테스트·release gate JSON 변경 없음/);
+  assert.match(template, /GitHub PR Review 객체가 있는지 확인했다/);
+  assert.match(template, /CodeRabbit status check만으로는 리뷰 완료로 보지 않는다/);
+  assert.match(template, /폴백 리뷰를 단일 PR review로 게시했다/);
+});
+
+test("기본 PR 템플릿은 등급 안내와 최소 섹션을 포함한다", () => {
+  const template = read(".github/pull_request_template.md");
+
+  assert.match(template, /A등급/);
+  assert.match(template, /B\/C등급/);
+  assert.match(template, /PULL_REQUEST_TEMPLATE\/full\.md/);
+  assert.match(template, /PULL_REQUEST_TEMPLATE\/short\.md/);
+  assert.match(template, /gh CLI는 template 쿼리를 지원하지 않으므로/);
+  assert.match(template, /리뷰·automerge 게이트는 등급과 무관하게 모든 PR 공통/);
+  for (const heading of ["## 관련 이슈", "## 작업 내용", "## 검증", "## 영향", "## 체크리스트"]) {
+    assert.ok(template.includes(heading), `default template must include ${heading}`);
+  }
+  assert.match(template, /GitHub PR Review 객체가 있는지 확인했다/);
 });
 
 test("이슈 템플릿은 에이전트 서술 없이 개발자 판단 정보를 수집한다", () => {


### PR DESCRIPTION
## 관련 이슈

Closes #1867

## 작업 배경

- 작은 chore·문서·maintenance까지 기능/배포 작업과 같은 무게의 full 템플릿(12섹션)과 개별 issue를 요구해 issue/PR 볼륨과 본문 작성 비용이 과도했고, 최근 closed PR 상당수가 템플릿 heading을 채우지 못해 사후 보정이 필요했다.
- 작업을 위험도 4등급(A/B/C/D)으로 나누고 A등급만 full을 유지하는 개편을 로컬 에이전트 문서(CLAUDE.md·AGENTS.md·merge-workflow 정본)와 함께 진행하며, 이 PR은 그 tracked 파트다.

## 작업 내용

- `.github/PULL_REQUEST_TEMPLATE/full.md` 신설: 기존 12섹션 템플릿을 그대로 이관(A등급용).
- `.github/PULL_REQUEST_TEMPLATE/short.md` 신설: B/C등급용 5섹션(관련 이슈/작업 내용/검증/영향/체크리스트). 관련 이슈는 umbrella `Refs #N` 또는 `이슈 없음(C등급)` 명기 강제, 리뷰 게이트 체크리스트 유지.
- root `pull_request_template.md`: 등급 안내 주석 + short 동형 본문으로 전환(웹 `?template=` 쿼리 한계 명시).
- 마크다운 추적 allowlist 확장: `.gitignore`에 `!/.github/PULL_REQUEST_TEMPLATE/*.md`, `ci.yml` unexpected_markdown 검사에 동일 제외 패턴 추가.
- `tools/ci/repository-contract.test.mjs`: gitignore/ci.yml allowlist assertion 갱신, Route commercialization·readiness tracker의 prTemplate read를 full.md로 재지향, full 12섹션·short 5섹션·root 등급 안내 검증 테스트 3건 신설.
- `.github/ISSUE_TEMPLATE/task_request.yml`·`refactor_request.yml`·`test_request.yml` description에 "A등급만 새 issue 필수" 안내 추가.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/repository-contract.test.mjs` → tests 170, pass 170, fail 0 (신설 테스트 3건 포함)
  - `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts f }' .github/ISSUE_TEMPLATE/*.yml` → 8개 파일 전부 파싱 성공
  - `git ls-files '*.md'` → README.md, pull_request_template.md, PULL_REQUEST_TEMPLATE/full.md·short.md만 추적

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 마크다운 추적 정책 | CI | Repository CI unexpected_markdown 검사 | PR CI 결과 | 신규 템플릿 2개 허용 후 green 확인 예정 |
| 템플릿 계약 | repo | `node --test tools/ci/repository-contract.test.mjs` | 로컬 실행 | pass 170 / fail 0 |
| ISSUE_TEMPLATE 파싱 | repo | ruby YAML.load_file | 로컬 실행 | 예외 없음 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: (1) 마크다운 추적 allowlist 3곳(.gitignore·ci.yml·contract test)의 패턴이 서로 일치하는지, (2) 기존 route gate 테스트의 prTemplate 대상을 full.md로 옮긴 것이 계약 의도(gate heading이 A등급 템플릿에 존재)를 유지하는지, (3) short/root 템플릿에 리뷰 게이트 체크 항목이 남아 있는지(게이트 완화 아님).
- 등급 정의의 정본 문구는 로컬 에이전트 문서(CLAUDE.md·AGENTS.md·docs/agent/2026-07-05-merge-workflow.md·docs/AGENT-CONTEXT.md)에 이미 동기화 완료 — gitignored라 이 PR diff에는 나타나지 않는다.

## 리스크

- 웹 UI에서 PR을 만들면 root 기본 템플릿(short 동형)이 뜨므로, A등급 작업자가 full.md 전환 안내 주석을 무시할 수 있다 — full 12섹션 계약 테스트와 세션 규약(등급 선언)으로 보완한다.
- root 템플릿 축소로 기존 "12섹션 root" 관행에 익숙한 도구/스크립트가 있다면 full.md 경로로 갱신이 필요하다(리포 내 검증은 contract test로 완료).

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.