### PR TITLE
[Mobile] 운행 공지 UI — 홈 disruption 배너·좌측 메뉴 목록·조회 훅 (#1767)

### DIFF
--- a/apps/mobile/lib/app/app_dependencies.dart
+++ b/apps/mobile/lib/app/app_dependencies.dart
@@ -15,6 +15,8 @@ import '../features/network_map/data/drift_network_map_viewport_repository.dart'
 import '../features/preferences/data/drift_notification_settings_repository.dart';
 import '../features/realtime/realtime_repository.dart';
 import '../features/search_history/data/drift_search_history_repository.dart';
+import '../features/service_notice/data/drift_notice_cache_store.dart';
+import '../features/service_notice/data/notice_repository.dart';
 import '../features/stations/data/station_api_repository.dart';
 import '../features/stations/data/drift_station_repository.dart';
 import '../internal_route.dart';
@@ -50,6 +52,7 @@ class AppDependencies {
     required this.locationProvider,
     required this.userDataDeletionRepository,
     this.getOffAlarmController,
+    required this.noticeRepository,
   });
 
   factory AppDependencies.resolve({
@@ -69,6 +72,7 @@ class AppDependencies {
     NotificationPermissionProvider? notificationPermissionProvider,
     CurrentLocationProvider? locationProvider,
     UserDataDeletionRepository? userDataDeletionRepository,
+    NoticeRepository? noticeRepository,
     CatalogDatabase? catalogDatabase,
     UserDatabase? userDatabase,
     Uri? Function() apiBaseUri = defaultOptionalStationApiBaseUri,
@@ -240,6 +244,11 @@ class AppDependencies {
             userDatabase: userDatabase,
           ),
       getOffAlarmController: _resolveGetOffAlarmController(userDatabase),
+      noticeRepository:
+          noticeRepository ??
+          (userDatabase == null
+              ? null
+              : _LazyDefaultNoticeRepository(optionalBaseUri, userDatabase)),
     );
   }
 
@@ -260,6 +269,47 @@ class AppDependencies {
   final CurrentLocationProvider locationProvider;
   final UserDataDeletionRepository? userDataDeletionRepository;
   final GetOffAlarmController? getOffAlarmController;
+  final NoticeRepository? noticeRepository;
+}
+
+/// 공개 공지 API는 선택 기능이라 앱 시작 중 base URL을 강제 평가하지 않는다.
+/// 첫 조회 시점에 base URL을 해소하고, 없으면 조용히 빈 결과를 돌려준다.
+class _LazyDefaultNoticeRepository implements NoticeRepository {
+  _LazyDefaultNoticeRepository(this._baseUri, this._userDatabase);
+
+  final Uri? Function() _baseUri;
+  final UserDatabase _userDatabase;
+  NoticeRepository? _delegate;
+
+  @override
+  Future<ActiveNoticesResult> activeNotices() {
+    return _resolveDelegate().activeNotices();
+  }
+
+  NoticeRepository _resolveDelegate() {
+    final cachedDelegate = _delegate;
+    if (cachedDelegate != null) {
+      return cachedDelegate;
+    }
+    final resolvedBaseUri = _baseUri();
+    final resolvedDelegate = resolvedBaseUri == null
+        ? const _UnavailableNoticeRepository()
+        : ApiNoticeRepository(
+            apiClient: HttpNoticeApiClient(ApiClient(baseUri: resolvedBaseUri)),
+            cacheStore: DriftNoticeCacheStore(userDatabase: _userDatabase),
+          );
+    _delegate = resolvedDelegate;
+    return resolvedDelegate;
+  }
+}
+
+class _UnavailableNoticeRepository implements NoticeRepository {
+  const _UnavailableNoticeRepository();
+
+  @override
+  Future<ActiveNoticesResult> activeNotices() async {
+    return const ActiveNoticesResult(notices: [], stale: false);
+  }
 }
 
 RealtimeRepository _defaultRealtimeRepository({

--- a/apps/mobile/lib/features/service_notice/presentation/notice_controller.dart
+++ b/apps/mobile/lib/features/service_notice/presentation/notice_controller.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 
 import '../data/notice_repository.dart';
 import '../domain/service_notice.dart';
+import 'notice_time_label.dart';
 
 /// 운행 공지의 앱 시작·포그라운드 복귀 조회 상태를 들고, 노선도 홈 배너와
 /// "운행 공지" 목록 화면이 함께 구독하는 컨트롤러.
@@ -16,6 +17,7 @@ class NoticeController extends ChangeNotifier {
 
   ActiveNoticesResult? _result;
   bool _loading = false;
+  bool _disposed = false;
   Future<void>? _inFlight;
   final Set<String> _dismissedBannerIds = <String>{};
 
@@ -28,6 +30,16 @@ class NoticeController extends ChangeNotifier {
   bool get isStale => _result?.stale ?? false;
 
   DateTime? get asOf => _result?.asOf;
+
+  /// 오프라인 강등 시 마지막 수신 시각 라벨("N시간 전 기준"). 배너·목록이 공유하는
+  /// 단일 출처(신선하면 null).
+  String? staleLabel(DateTime now) {
+    final at = asOf;
+    if (!isStale || at == null) {
+      return null;
+    }
+    return formatNoticeAsOf(at, now);
+  }
 
   /// 배너로 승격할 첫 disruption. 이미 닫은 공지는 제외한다.
   ServiceNotice? get topDisruption {
@@ -46,7 +58,7 @@ class NoticeController extends ChangeNotifier {
 
   Future<void> _run() async {
     _loading = true;
-    notifyListeners();
+    _safeNotify();
     try {
       final result = await repository.activeNotices();
       _result = result;
@@ -57,13 +69,27 @@ class NoticeController extends ChangeNotifier {
     } finally {
       _loading = false;
       _inFlight = null;
-      notifyListeners();
+      // 조회가 in-flight인 동안 소유 State가 dispose되면 컨트롤러가 먼저 dispose되므로,
+      // 완료 후 통지는 dispose 이후 사용(FlutterError)을 피하려 가드한다.
+      _safeNotify();
     }
   }
 
   void dismissBanner(String id) {
     if (_dismissedBannerIds.add(id)) {
+      _safeNotify();
+    }
+  }
+
+  void _safeNotify() {
+    if (!_disposed) {
       notifyListeners();
     }
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    super.dispose();
   }
 }

--- a/apps/mobile/lib/features/service_notice/presentation/notice_controller.dart
+++ b/apps/mobile/lib/features/service_notice/presentation/notice_controller.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/foundation.dart';
+
+import '../data/notice_repository.dart';
+import '../domain/service_notice.dart';
+
+/// 운행 공지의 앱 시작·포그라운드 복귀 조회 상태를 들고, 노선도 홈 배너와
+/// "운행 공지" 목록 화면이 함께 구독하는 컨트롤러.
+///
+/// 별도 폴링 주기를 신설하지 않는다 — [refresh]는 앱 시작과 포그라운드 복귀
+/// 트리거에서만 호출된다. 배너 닫기는 세션 동안만 유지한다(다음 조회에서 여전히
+/// 활성이면 목록에는 남지만 배너는 사용자가 닫은 채로 둔다).
+class NoticeController extends ChangeNotifier {
+  NoticeController({required this.repository});
+
+  final NoticeRepository repository;
+
+  ActiveNoticesResult? _result;
+  bool _loading = false;
+  Future<void>? _inFlight;
+  final Set<String> _dismissedBannerIds = <String>{};
+
+  ActiveNoticesResult? get result => _result;
+
+  bool get loading => _loading;
+
+  List<ServiceNotice> get notices => _result?.notices ?? const [];
+
+  bool get isStale => _result?.stale ?? false;
+
+  DateTime? get asOf => _result?.asOf;
+
+  /// 배너로 승격할 첫 disruption. 이미 닫은 공지는 제외한다.
+  ServiceNotice? get topDisruption {
+    for (final notice in notices) {
+      if (notice.isDisruption && !_dismissedBannerIds.contains(notice.id)) {
+        return notice;
+      }
+    }
+    return null;
+  }
+
+  /// 활성 공지를 다시 조회한다. 이미 진행 중이면 그 호출에 합류한다.
+  Future<void> refresh() {
+    return _inFlight ??= _run();
+  }
+
+  Future<void> _run() async {
+    _loading = true;
+    notifyListeners();
+    try {
+      final result = await repository.activeNotices();
+      _result = result;
+    } catch (error, stackTrace) {
+      // 조회 실패는 조용히 이전 상태를 유지한다(repository가 이미 stale 강등을
+      // 담당하므로 여기까지 오는 예외는 표시할 사용자 메시지가 없다).
+      debugPrint('운행 공지 조회 실패: $error\n$stackTrace');
+    } finally {
+      _loading = false;
+      _inFlight = null;
+      notifyListeners();
+    }
+  }
+
+  void dismissBanner(String id) {
+    if (_dismissedBannerIds.add(id)) {
+      notifyListeners();
+    }
+  }
+}

--- a/apps/mobile/lib/features/service_notice/presentation/notice_time_label.dart
+++ b/apps/mobile/lib/features/service_notice/presentation/notice_time_label.dart
@@ -1,0 +1,17 @@
+/// 오프라인 강등된 마지막 수신본에 붙이는 "N시간 전 기준" 라벨을 만든다.
+///
+/// 데이터 출처의 최종 갱신 시점을 숨기지 않는다는 원칙(강등 사다리)에 따라,
+/// stale 상태에서 [asOf] 수신 시각을 사용자 언어로 표기한다.
+String formatNoticeAsOf(DateTime asOf, DateTime now) {
+  final elapsed = now.difference(asOf);
+  if (elapsed.inMinutes < 1) {
+    return '방금 전 기준';
+  }
+  if (elapsed.inHours < 1) {
+    return '${elapsed.inMinutes}분 전 기준';
+  }
+  if (elapsed.inDays < 1) {
+    return '${elapsed.inHours}시간 전 기준';
+  }
+  return '${elapsed.inDays}일 전 기준';
+}

--- a/apps/mobile/lib/features/service_notice/presentation/service_notice_banner.dart
+++ b/apps/mobile/lib/features/service_notice/presentation/service_notice_banner.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+
+import '../../../accessible_design.dart';
+import 'notice_controller.dart';
+import 'notice_time_label.dart';
+
+/// 노선도 홈 상단에 얹는 disruption 공지 1줄 배너.
+///
+/// - disruption 심각도만 승격한다(info는 목록에서만 본다).
+/// - 모달이 아니라 닫기 가능한 얇은 바다. 본문을 누르면 목록으로 이동한다.
+/// - 오프라인 강등이면 "N시간 전 기준" 라벨을 함께 붙인다.
+class ServiceNoticeBanner extends StatelessWidget {
+  const ServiceNoticeBanner({
+    required this.controller,
+    required this.onOpenList,
+    this.now = DateTime.now,
+    super.key,
+  });
+
+  final NoticeController controller;
+  final VoidCallback onOpenList;
+  final DateTime Function() now;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: controller,
+      builder: (context, _) {
+        final notice = controller.topDisruption;
+        if (notice == null) {
+          return const SizedBox.shrink();
+        }
+        final asOf = controller.asOf;
+        final staleLabel = controller.isStale && asOf != null
+            ? formatNoticeAsOf(asOf, now())
+            : null;
+        return Padding(
+          padding: const EdgeInsets.fromLTRB(12, 8, 12, 0),
+          child: Material(
+            key: const Key('serviceNoticeBanner'),
+            color: EasySubwayAccessibleColors.amberSoft,
+            borderRadius: BorderRadius.circular(14),
+            child: Padding(
+              padding: const EdgeInsets.only(left: 14, right: 4),
+              child: Row(
+                children: [
+                  const Icon(
+                    Icons.warning_amber_rounded,
+                    size: 20,
+                    color: EasySubwayAccessibleColors.amber,
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: InkWell(
+                      key: const Key('serviceNoticeBannerBody'),
+                      onTap: onOpenList,
+                      child: Semantics(
+                        button: true,
+                        label: '운행 공지: ${notice.title}',
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(vertical: 12),
+                          child: Row(
+                            children: [
+                              Expanded(
+                                child: Text(
+                                  notice.title,
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: const TextStyle(
+                                    color: EasySubwayAccessibleColors.amber,
+                                    fontSize: 15,
+                                    fontWeight: FontWeight.w700,
+                                    height: 1.2,
+                                  ),
+                                ),
+                              ),
+                              if (staleLabel != null) ...[
+                                const SizedBox(width: 8),
+                                Text(
+                                  staleLabel,
+                                  maxLines: 1,
+                                  style: const TextStyle(
+                                    color: EasySubwayAccessibleColors.mutedText,
+                                    fontSize: 12,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                              ],
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                  IconButton(
+                    key: const Key('serviceNoticeBannerDismiss'),
+                    onPressed: () => controller.dismissBanner(notice.id),
+                    iconSize: 20,
+                    color: EasySubwayAccessibleColors.amber,
+                    visualDensity: VisualDensity.compact,
+                    tooltip: '공지 닫기',
+                    icon: const Icon(Icons.close_rounded),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/apps/mobile/lib/features/service_notice/presentation/service_notice_banner.dart
+++ b/apps/mobile/lib/features/service_notice/presentation/service_notice_banner.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 
 import '../../../accessible_design.dart';
 import 'notice_controller.dart';
-import 'notice_time_label.dart';
 
 /// 노선도 홈 상단에 얹는 disruption 공지 1줄 배너.
 ///
@@ -30,10 +29,7 @@ class ServiceNoticeBanner extends StatelessWidget {
         if (notice == null) {
           return const SizedBox.shrink();
         }
-        final asOf = controller.asOf;
-        final staleLabel = controller.isStale && asOf != null
-            ? formatNoticeAsOf(asOf, now())
-            : null;
+        final staleLabel = controller.staleLabel(now());
         return Padding(
           padding: const EdgeInsets.fromLTRB(12, 8, 12, 0),
           child: Material(

--- a/apps/mobile/lib/features/service_notice/presentation/service_notice_list_screen.dart
+++ b/apps/mobile/lib/features/service_notice/presentation/service_notice_list_screen.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import '../../../accessible_design.dart';
 import '../domain/service_notice.dart';
 import 'notice_controller.dart';
-import 'notice_time_label.dart';
 
 /// 좌측 메뉴 "운행 공지"에서 여는 목록 화면. 활성 공지 전체(info·disruption)를
 /// 보여주고, 오프라인 강등이면 마지막 수신 시각을 함께 알린다.
@@ -31,39 +30,37 @@ class ServiceNoticeListScreen extends StatelessWidget {
         listenable: controller,
         builder: (context, _) {
           final notices = controller.notices;
-          final asOf = controller.asOf;
-          final staleLabel = controller.isStale && asOf != null
-              ? formatNoticeAsOf(asOf, now())
-              : null;
+          final staleLabel = controller.staleLabel(now());
+          if (notices.isEmpty) {
+            return RefreshIndicator(
+              onRefresh: controller.refresh,
+              child: _EmptyNotices(staleLabel: staleLabel),
+            );
+          }
+          // stale 바는 리스트 항목이 아니라 헤더로 둔다 — 항목 인덱스가 notices와
+          // 1:1이라 offset 산술이 사라진다.
           return RefreshIndicator(
             onRefresh: controller.refresh,
-            child: notices.isEmpty
-                ? _EmptyNotices(staleLabel: staleLabel)
-                : ListView.separated(
+            child: Column(
+              children: [
+                if (staleLabel != null) _StaleBar(label: staleLabel),
+                Expanded(
+                  child: ListView.separated(
                     physics: const AlwaysScrollableScrollPhysics(),
                     padding: const EdgeInsets.symmetric(vertical: 8),
-                    itemCount: notices.length + (staleLabel == null ? 0 : 1),
-                    separatorBuilder: (context, index) {
-                      if (staleLabel != null && index == 0) {
-                        return const SizedBox.shrink();
-                      }
-                      return const Divider(
-                        height: 1,
-                        indent: 20,
-                        endIndent: 20,
-                        color: EasySubwayAccessibleColors.line,
-                      );
-                    },
-                    itemBuilder: (context, index) {
-                      if (staleLabel != null) {
-                        if (index == 0) {
-                          return _StaleBar(label: staleLabel);
-                        }
-                        return _NoticeItem(notice: notices[index - 1]);
-                      }
-                      return _NoticeItem(notice: notices[index]);
-                    },
+                    itemCount: notices.length,
+                    separatorBuilder: (context, index) => const Divider(
+                      height: 1,
+                      indent: 20,
+                      endIndent: 20,
+                      color: EasySubwayAccessibleColors.line,
+                    ),
+                    itemBuilder: (context, index) =>
+                        _NoticeItem(notice: notices[index]),
                   ),
+                ),
+              ],
+            ),
           );
         },
       ),

--- a/apps/mobile/lib/features/service_notice/presentation/service_notice_list_screen.dart
+++ b/apps/mobile/lib/features/service_notice/presentation/service_notice_list_screen.dart
@@ -1,0 +1,237 @@
+import 'package:flutter/material.dart';
+
+import '../../../accessible_design.dart';
+import '../domain/service_notice.dart';
+import 'notice_controller.dart';
+import 'notice_time_label.dart';
+
+/// 좌측 메뉴 "운행 공지"에서 여는 목록 화면. 활성 공지 전체(info·disruption)를
+/// 보여주고, 오프라인 강등이면 마지막 수신 시각을 함께 알린다.
+class ServiceNoticeListScreen extends StatelessWidget {
+  const ServiceNoticeListScreen({
+    required this.controller,
+    this.now = DateTime.now,
+    super.key,
+  });
+
+  final NoticeController controller;
+  final DateTime Function() now;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: EasySubwayAccessibleColors.surface,
+      appBar: AppBar(
+        title: const Text('운행 공지'),
+        backgroundColor: EasySubwayAccessibleColors.surface,
+        surfaceTintColor: Colors.transparent,
+        elevation: 0,
+      ),
+      body: ListenableBuilder(
+        listenable: controller,
+        builder: (context, _) {
+          final notices = controller.notices;
+          final asOf = controller.asOf;
+          final staleLabel = controller.isStale && asOf != null
+              ? formatNoticeAsOf(asOf, now())
+              : null;
+          return RefreshIndicator(
+            onRefresh: controller.refresh,
+            child: notices.isEmpty
+                ? _EmptyNotices(staleLabel: staleLabel)
+                : ListView.separated(
+                    physics: const AlwaysScrollableScrollPhysics(),
+                    padding: const EdgeInsets.symmetric(vertical: 8),
+                    itemCount: notices.length + (staleLabel == null ? 0 : 1),
+                    separatorBuilder: (context, index) {
+                      if (staleLabel != null && index == 0) {
+                        return const SizedBox.shrink();
+                      }
+                      return const Divider(
+                        height: 1,
+                        indent: 20,
+                        endIndent: 20,
+                        color: EasySubwayAccessibleColors.line,
+                      );
+                    },
+                    itemBuilder: (context, index) {
+                      if (staleLabel != null) {
+                        if (index == 0) {
+                          return _StaleBar(label: staleLabel);
+                        }
+                        return _NoticeItem(notice: notices[index - 1]);
+                      }
+                      return _NoticeItem(notice: notices[index]);
+                    },
+                  ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _StaleBar extends StatelessWidget {
+  const _StaleBar({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      key: const Key('serviceNoticeStaleBar'),
+      margin: const EdgeInsets.fromLTRB(16, 8, 16, 12),
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+      decoration: BoxDecoration(
+        color: EasySubwayAccessibleColors.scaffoldSurface,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        children: [
+          const Icon(
+            Icons.cloud_off_rounded,
+            size: 18,
+            color: EasySubwayAccessibleColors.mutedText,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              '오프라인 · $label',
+              style: const TextStyle(
+                color: EasySubwayAccessibleColors.mutedText,
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _NoticeItem extends StatelessWidget {
+  const _NoticeItem({required this.notice});
+
+  final ServiceNotice notice;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDisruption = notice.isDisruption;
+    final accent = isDisruption
+        ? EasySubwayAccessibleColors.amber
+        : EasySubwayAccessibleColors.primary;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 16, 20, 18),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Container(
+                width: 8,
+                height: 8,
+                decoration: BoxDecoration(
+                  color: accent,
+                  shape: BoxShape.circle,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Text(
+                isDisruption ? '운행 장애' : '안내',
+                style: TextStyle(
+                  color: accent,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w800,
+                  letterSpacing: 0.1,
+                ),
+              ),
+              const Spacer(),
+              Text(
+                _formatPublishedAt(notice.publishedAt),
+                style: const TextStyle(
+                  color: EasySubwayAccessibleColors.mutedText,
+                  fontSize: 12,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(
+            notice.title,
+            style: const TextStyle(
+              color: EasySubwayAccessibleColors.text,
+              fontSize: 16,
+              fontWeight: FontWeight.w700,
+              height: 1.3,
+            ),
+          ),
+          if (notice.body.isNotEmpty) ...[
+            const SizedBox(height: 6),
+            Text(
+              notice.body,
+              style: const TextStyle(
+                color: EasySubwayAccessibleColors.secondaryText,
+                fontSize: 14,
+                fontWeight: FontWeight.w500,
+                height: 1.4,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _EmptyNotices extends StatelessWidget {
+  const _EmptyNotices({this.staleLabel});
+
+  final String? staleLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      physics: const AlwaysScrollableScrollPhysics(),
+      children: [
+        if (staleLabel != null) _StaleBar(label: staleLabel!),
+        SizedBox(height: MediaQuery.sizeOf(context).height * 0.22),
+        const Icon(
+          Icons.check_circle_outline_rounded,
+          size: 44,
+          color: EasySubwayAccessibleColors.mutedText,
+        ),
+        const SizedBox(height: 14),
+        const Text(
+          '지금은 운행 공지가 없어요',
+          textAlign: TextAlign.center,
+          style: TextStyle(
+            color: EasySubwayAccessibleColors.text,
+            fontSize: 17,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        const SizedBox(height: 6),
+        const Text(
+          '운행 장애나 안내가 생기면 여기에 표시돼요',
+          textAlign: TextAlign.center,
+          style: TextStyle(
+            color: EasySubwayAccessibleColors.mutedText,
+            fontSize: 14,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+String _formatPublishedAt(DateTime publishedAt) {
+  final local = publishedAt.toLocal();
+  final month = local.month;
+  final day = local.day;
+  final hour = local.hour.toString().padLeft(2, '0');
+  final minute = local.minute.toString().padLeft(2, '0');
+  return '$month월 $day일 $hour:$minute';
+}

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -22,6 +22,10 @@ import 'legacy_credential_cleanup.dart';
 import 'mobility_profile.dart';
 import 'network_map.dart';
 import 'notification_settings.dart';
+import 'features/service_notice/data/notice_repository.dart';
+import 'features/service_notice/presentation/notice_controller.dart';
+import 'features/service_notice/presentation/service_notice_banner.dart';
+import 'features/service_notice/presentation/service_notice_list_screen.dart';
 import 'onboarding.dart';
 import 'route_search.dart';
 import 'station_search.dart';
@@ -261,6 +265,7 @@ class EasySubwayApp extends StatelessWidget {
     NotificationPermissionProvider? notificationPermissionProvider,
     CurrentLocationProvider? locationProvider,
     UserDataDeletionRepository? userDataDeletionRepository,
+    NoticeRepository? noticeRepository,
     LegacyCredentialCleaner legacyCredentialCleaner =
         const NoLegacyCredentialCleaner(),
     OnboardingResultStore? onboardingStore,
@@ -293,6 +298,7 @@ class EasySubwayApp extends StatelessWidget {
                notificationPermissionProvider: notificationPermissionProvider,
                locationProvider: locationProvider,
                userDataDeletionRepository: userDataDeletionRepository,
+               noticeRepository: noticeRepository,
                enablePushNotifications: enablePushNotifications,
              ),
          initialOnboardingState: initialOnboardingState,
@@ -340,7 +346,8 @@ class EasySubwayApp extends StatelessWidget {
            dependencies.notificationPermissionProvider,
        locationProvider = dependencies.locationProvider,
        userDataDeletionRepository = dependencies.userDataDeletionRepository,
-       getOffAlarmController = dependencies.getOffAlarmController;
+       getOffAlarmController = dependencies.getOffAlarmController,
+       noticeRepository = dependencies.noticeRepository;
 
   final StationSearchRepository repository;
   final FacilityReportRepository reportRepository;
@@ -359,6 +366,7 @@ class EasySubwayApp extends StatelessWidget {
   final CurrentLocationProvider locationProvider;
   final UserDataDeletionRepository? userDataDeletionRepository;
   final GetOffAlarmController? getOffAlarmController;
+  final NoticeRepository? noticeRepository;
   final OnboardingState initialOnboardingState;
   final OnboardingResultStore? onboardingStore;
   final FacilityReportDraftTargetStore? facilityReportDraftTargetStore;
@@ -447,6 +455,7 @@ class EasySubwayApp extends StatelessWidget {
         supportAccessInfo: supportAccessInfo,
         supportAccessLauncher: supportAccessLauncher,
         userDataDeletionRepository: userDataDeletionRepository,
+        noticeRepository: noticeRepository,
         recentRoutesFuture: recentRoutesFuture,
       ),
     );
@@ -616,6 +625,7 @@ class _EasySubwayHome extends StatefulWidget {
     required this.supportAccessInfo,
     required this.supportAccessLauncher,
     required this.userDataDeletionRepository,
+    required this.noticeRepository,
     required this.recentRoutesFuture,
   });
 
@@ -643,6 +653,7 @@ class _EasySubwayHome extends StatefulWidget {
   final SupportAccessInfo supportAccessInfo;
   final SupportAccessLauncher supportAccessLauncher;
   final UserDataDeletionRepository? userDataDeletionRepository;
+  final NoticeRepository? noticeRepository;
   final Future<List<FavoriteRoute>>? recentRoutesFuture;
 
   @override
@@ -760,6 +771,7 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
         supportAccessInfo: widget.supportAccessInfo,
         supportAccessLauncher: widget.supportAccessLauncher,
         userDataDeletionRepository: widget.userDataDeletionRepository,
+        noticeRepository: widget.noticeRepository,
         recentRoutesFuture: widget.recentRoutesFuture,
         onUserDataDeleted: _handleUserDataDeleted,
         onMobilityProfileChanged: _saveMobilityProfile,
@@ -1257,6 +1269,7 @@ class HomeScreen extends StatefulWidget {
     required this.supportAccessInfo,
     required this.supportAccessLauncher,
     required this.userDataDeletionRepository,
+    this.noticeRepository,
     required this.onUserDataDeleted,
     required this.onMobilityProfileChanged,
     required this.onViewPreferencesChanged,
@@ -1288,6 +1301,7 @@ class HomeScreen extends StatefulWidget {
   final SupportAccessInfo supportAccessInfo;
   final SupportAccessLauncher supportAccessLauncher;
   final UserDataDeletionRepository? userDataDeletionRepository;
+  final NoticeRepository? noticeRepository;
   final Future<void> Function(UserDataDeletionResult result)? onUserDataDeleted;
   final Future<void> Function(MobilityProfileOption profile)?
   onMobilityProfileChanged;
@@ -1303,13 +1317,14 @@ class HomeScreen extends StatefulWidget {
   State<HomeScreen> createState() => _HomeScreenState();
 }
 
-class _HomeScreenState extends State<HomeScreen> {
+class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
   int _selectedTabIndex = 0;
   late String _mobilityType;
   String? _routeTabMobilityType;
   late final RouteDraftController _routeDraftController;
   Future<List<FavoriteFacility>>? _favoriteFacilitiesFuture;
   late Future<bool> _hasNotificationItemsFuture;
+  NoticeController? _noticeController;
 
   @override
   void initState() {
@@ -1319,10 +1334,31 @@ class _HomeScreenState extends State<HomeScreen> {
     final facilitiesFuture = _loadNotificationFacilities();
     _favoriteFacilitiesFuture = facilitiesFuture;
     _hasNotificationItemsFuture = _loadHasNotificationItems(facilitiesFuture);
+    final noticeRepository = widget.noticeRepository;
+    if (noticeRepository != null) {
+      final controller = NoticeController(repository: noticeRepository);
+      _noticeController = controller;
+      // 앱 시작 시 최초 조회. 이후 조회는 포그라운드 복귀 트리거에서만 일어난다
+      // (별도 폴링 주기를 신설하지 않는다).
+      unawaited(controller.refresh());
+      WidgetsBinding.instance.addObserver(this);
+    }
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    super.didChangeAppLifecycleState(state);
+    if (state == AppLifecycleState.resumed) {
+      unawaited(_noticeController?.refresh());
+    }
   }
 
   @override
   void dispose() {
+    if (_noticeController != null) {
+      WidgetsBinding.instance.removeObserver(this);
+      _noticeController!.dispose();
+    }
     _routeDraftController.dispose();
     super.dispose();
   }
@@ -1518,6 +1554,18 @@ class _HomeScreenState extends State<HomeScreen> {
       );
     }
 
+    final noticeController = _noticeController;
+    void openServiceNotices() {
+      if (noticeController == null) {
+        return;
+      }
+      Navigator.of(context).push(
+        MaterialPageRoute<void>(
+          builder: (_) => ServiceNoticeListScreen(controller: noticeController),
+        ),
+      );
+    }
+
     Widget rootTab(Widget child) {
       return PopScope(
         canPop: false,
@@ -1547,6 +1595,15 @@ class _HomeScreenState extends State<HomeScreen> {
               unawaited(openStationSearch(StationSearchEntryMode.nearby)),
           onOpenSettings: openMoreTab,
           onOpenDataSources: openDataSources,
+          onOpenServiceNotices: noticeController == null
+              ? null
+              : openServiceNotices,
+          disruptionBanner: noticeController == null
+              ? null
+              : ServiceNoticeBanner(
+                  controller: noticeController,
+                  onOpenList: openServiceNotices,
+                ),
           notificationAction: notificationRepository == null
               ? null
               : FutureBuilder<bool>(

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -384,7 +384,9 @@ class NetworkMapScreen extends StatefulWidget {
     this.onOpenNearbyStations,
     this.onOpenSettings,
     this.onOpenDataSources,
+    this.onOpenServiceNotices,
     this.notificationAction,
+    this.disruptionBanner,
     this.bottomNavigationBar,
     super.key,
   });
@@ -401,7 +403,13 @@ class NetworkMapScreen extends StatefulWidget {
   final VoidCallback? onOpenNearbyStations;
   final VoidCallback? onOpenSettings;
   final VoidCallback? onOpenDataSources;
+
+  /// 좌측 메뉴 "운행 공지" 목록 화면 열기.
+  final VoidCallback? onOpenServiceNotices;
   final Widget? notificationAction;
+
+  /// 상단 disruption 공지 1줄 배너. 표시할 공지가 없으면 스스로 빈 위젯이 된다.
+  final Widget? disruptionBanner;
   final Widget? bottomNavigationBar;
 
   @override
@@ -507,6 +515,7 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
               expressView: _expressView,
               showServicePatternToggle: true,
               notificationAction: widget.notificationAction,
+              disruptionBanner: widget.disruptionBanner,
               onMenuTap: _openMapMenu,
               onSearchTap: widget.onOpenStationSearch,
               onRegionSelected: (region) => _reload(region: region),
@@ -531,6 +540,7 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
               expressView: _expressView,
               showServicePatternToggle: true,
               notificationAction: widget.notificationAction,
+              disruptionBanner: widget.disruptionBanner,
               onMenuTap: _openMapMenu,
               onSearchTap: widget.onOpenStationSearch,
               onRegionSelected: (region) => _reload(region: region),
@@ -563,6 +573,7 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
             expressView: _expressView,
             showServicePatternToggle: true,
             notificationAction: widget.notificationAction,
+            disruptionBanner: widget.disruptionBanner,
             onMenuTap: _openMapMenu,
             onSearchTap: widget.onOpenStationSearch,
             onRegionSelected: (region) => _reload(region: region),
@@ -772,6 +783,7 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
           onOpenRouteSearch: widget.onOpenRouteSearch,
           onOpenSavedItems: widget.onOpenSavedItems,
           onOpenNearbyStations: widget.onOpenNearbyStations,
+          onOpenServiceNotices: widget.onOpenServiceNotices,
           onOpenSettings: widget.onOpenSettings,
           onOpenDataSources: widget.onOpenDataSources,
         );
@@ -878,6 +890,7 @@ class _NetworkMapChrome extends StatelessWidget {
     required this.expressView,
     required this.showServicePatternToggle,
     required this.notificationAction,
+    required this.disruptionBanner,
     required this.onMenuTap,
     required this.onSearchTap,
     required this.onRegionSelected,
@@ -898,6 +911,7 @@ class _NetworkMapChrome extends StatelessWidget {
   final bool expressView;
   final bool showServicePatternToggle;
   final Widget? notificationAction;
+  final Widget? disruptionBanner;
   final VoidCallback onMenuTap;
   final VoidCallback onSearchTap;
   final ValueChanged<String> onRegionSelected;
@@ -934,6 +948,13 @@ class _NetworkMapChrome extends StatelessWidget {
             onRegionSelected: onRegionSelected,
           ),
         ),
+        if (disruptionBanner != null)
+          Positioned(
+            left: 0,
+            right: 0,
+            top: topPadding + _networkMapTopBarHeight,
+            child: disruptionBanner!,
+          ),
         if (showServicePatternToggle)
           Positioned(
             left: 16,
@@ -1910,6 +1931,7 @@ class _NetworkMapMenuPanel extends StatelessWidget {
     required this.onOpenRouteSearch,
     required this.onOpenSavedItems,
     required this.onOpenNearbyStations,
+    required this.onOpenServiceNotices,
     required this.onOpenSettings,
     required this.onOpenDataSources,
   });
@@ -1918,6 +1940,7 @@ class _NetworkMapMenuPanel extends StatelessWidget {
   final Future<void> Function() onOpenRouteSearch;
   final VoidCallback? onOpenSavedItems;
   final VoidCallback? onOpenNearbyStations;
+  final VoidCallback? onOpenServiceNotices;
   final VoidCallback? onOpenSettings;
   final VoidCallback? onOpenDataSources;
 
@@ -1997,17 +2020,29 @@ class _NetworkMapMenuPanel extends StatelessWidget {
                             onTap: () => _runAction(context, onOpenSettings!),
                           ),
                       ],
-                      if (onOpenDataSources != null) ...[
+                      if (onOpenServiceNotices != null ||
+                          onOpenDataSources != null) ...[
                         const _NetworkMapMenuSectionLabel('안내'),
-                        _NetworkMapMenuTile(
-                          key: const Key('networkMapMenuDataSourcesButton'),
-                          icon: Icons.source_outlined,
-                          label: '자료 제공 정보',
-                          onTap: () => _runActionAfterMenuClose(
-                            context,
-                            onOpenDataSources!,
+                        if (onOpenServiceNotices != null)
+                          _NetworkMapMenuTile(
+                            key: const Key(
+                              'networkMapMenuServiceNoticesButton',
+                            ),
+                            icon: Icons.campaign_outlined,
+                            label: '운행 공지',
+                            onTap: () =>
+                                _runAction(context, onOpenServiceNotices!),
                           ),
-                        ),
+                        if (onOpenDataSources != null)
+                          _NetworkMapMenuTile(
+                            key: const Key('networkMapMenuDataSourcesButton'),
+                            icon: Icons.source_outlined,
+                            label: '자료 제공 정보',
+                            onTap: () => _runActionAfterMenuClose(
+                              context,
+                              onOpenDataSources!,
+                            ),
+                          ),
                       ],
                     ],
                   ),

--- a/apps/mobile/test/app_dependencies_test.dart
+++ b/apps/mobile/test/app_dependencies_test.dart
@@ -7,6 +7,7 @@ import 'package:easysubway_mobile/core/database/user/user_database.dart'
     as user_db;
 import 'package:easysubway_mobile/facility_report.dart';
 import 'package:easysubway_mobile/features/realtime/realtime_repository.dart';
+import 'package:easysubway_mobile/features/service_notice/data/notice_repository.dart';
 import 'package:easysubway_mobile/features/stations/data/drift_station_repository.dart';
 import 'package:easysubway_mobile/main.dart' as app;
 import 'package:easysubway_mobile/route_search.dart';
@@ -184,6 +185,52 @@ void main() {
       ),
       throwsA(isA<FacilityReportException>()),
     );
+  });
+
+  test('userDatabase가 있으면 운행 공지 조회 의존성이 배선된다', () async {
+    final catalogDatabase = CatalogDatabase.memory();
+    final userDatabase = user_db.UserDatabase.memory();
+    addTearDown(catalogDatabase.close);
+    addTearDown(userDatabase.close);
+    await catalogDatabase.seedBaselineIfEmpty();
+
+    final dependencies = AppDependencies.resolve(
+      catalogDatabase: catalogDatabase,
+      userDatabase: userDatabase,
+      reportRepository: const UnavailableFacilityReportRepository(),
+      apiBaseUri: () => Uri.parse('https://example.test'),
+      enablePushNotifications: false,
+    );
+
+    expect(dependencies.noticeRepository, isA<NoticeRepository>());
+  });
+
+  test('운행 공지 의존성은 resolve 시점에 API 주소를 읽지 않고, 주소가 없으면 빈 결과로 동작한다', () async {
+    final catalogDatabase = CatalogDatabase.memory();
+    final userDatabase = user_db.UserDatabase.memory();
+    var apiBaseReads = 0;
+    addTearDown(catalogDatabase.close);
+    addTearDown(userDatabase.close);
+    await catalogDatabase.seedBaselineIfEmpty();
+
+    final dependencies = AppDependencies.resolve(
+      catalogDatabase: catalogDatabase,
+      userDatabase: userDatabase,
+      reportRepository: const UnavailableFacilityReportRepository(),
+      apiBaseUri: () {
+        apiBaseReads++;
+        return null;
+      },
+      enablePushNotifications: false,
+    );
+
+    // 앱 시작 중에는 공개 공지 base URL을 강제 평가하지 않는다(선택 기능).
+    expect(apiBaseReads, 0);
+
+    final result = await dependencies.noticeRepository!.activeNotices();
+
+    expect(result.notices, isEmpty);
+    expect(result.stale, isFalse);
   });
 
   test('로컬 데이터베이스가 없으면 API 주소 없는 원격 fallback을 만들지 않는다', () {

--- a/apps/mobile/test/features/service_notice/notice_controller_test.dart
+++ b/apps/mobile/test/features/service_notice/notice_controller_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:easysubway_mobile/features/service_notice/data/notice_repository.dart';
 import 'package:easysubway_mobile/features/service_notice/domain/service_notice.dart';
 import 'package:easysubway_mobile/features/service_notice/presentation/notice_controller.dart';
@@ -34,6 +36,18 @@ class _ThrowingRepository implements NoticeRepository {
   @override
   Future<ActiveNoticesResult> activeNotices() async {
     throw StateError('boom');
+  }
+}
+
+class _DeferredRepository implements NoticeRepository {
+  _DeferredRepository(this._future);
+  final Future<ActiveNoticesResult> _future;
+  int calls = 0;
+
+  @override
+  Future<ActiveNoticesResult> activeNotices() {
+    calls++;
+    return _future;
   }
 }
 
@@ -115,5 +129,43 @@ void main() {
     await Future.wait([controller.refresh(), controller.refresh()]);
 
     expect(repo.calls, 1);
+  });
+
+  test('dispose 후 in-flight refresh가 완료돼도 통지하지 않는다', () async {
+    final completer = Completer<ActiveNoticesResult>();
+    final controller = NoticeController(
+      repository: _DeferredRepository(completer.future),
+    );
+    var notifiedAfterDispose = false;
+
+    final pending = controller.refresh();
+    controller.addListener(() => notifiedAfterDispose = true);
+    controller.dispose();
+    completer.complete(const ActiveNoticesResult(notices: [], stale: false));
+
+    // dispose된 ChangeNotifier에 통지하면 FlutterError를 던진다 — 던지지 않아야 한다.
+    await expectLater(pending, completes);
+    expect(notifiedAfterDispose, isFalse);
+  });
+
+  test('staleLabel은 stale일 때만 라벨을 낸다', () async {
+    final now = DateTime(2026, 7, 6, 12, 0, 0);
+    final fresh = _FakeRepository([
+      ActiveNoticesResult(notices: [notice('n1')], stale: false),
+    ]);
+    final freshController = NoticeController(repository: fresh);
+    await freshController.refresh();
+    expect(freshController.staleLabel(now), isNull);
+
+    final stale = _FakeRepository([
+      ActiveNoticesResult(
+        notices: [notice('n1')],
+        stale: true,
+        asOf: DateTime(2026, 7, 6, 9, 0, 0),
+      ),
+    ]);
+    final staleController = NoticeController(repository: stale);
+    await staleController.refresh();
+    expect(staleController.staleLabel(now), '3시간 전 기준');
   });
 }

--- a/apps/mobile/test/features/service_notice/notice_controller_test.dart
+++ b/apps/mobile/test/features/service_notice/notice_controller_test.dart
@@ -1,0 +1,119 @@
+import 'package:easysubway_mobile/features/service_notice/data/notice_repository.dart';
+import 'package:easysubway_mobile/features/service_notice/domain/service_notice.dart';
+import 'package:easysubway_mobile/features/service_notice/presentation/notice_controller.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+ServiceNotice notice(
+  String id, {
+  NoticeSeverity severity = NoticeSeverity.disruption,
+}) {
+  return ServiceNotice(
+    id: id,
+    scope: NoticeScope.all,
+    title: '제목 $id',
+    body: '본문 $id',
+    severity: severity,
+    publishedAt: DateTime(2026, 7, 6, 9, 0, 0),
+  );
+}
+
+class _FakeRepository implements NoticeRepository {
+  _FakeRepository(this._results);
+  final List<ActiveNoticesResult> _results;
+  int calls = 0;
+
+  @override
+  Future<ActiveNoticesResult> activeNotices() async {
+    final result = _results[calls.clamp(0, _results.length - 1)];
+    calls++;
+    return result;
+  }
+}
+
+class _ThrowingRepository implements NoticeRepository {
+  @override
+  Future<ActiveNoticesResult> activeNotices() async {
+    throw StateError('boom');
+  }
+}
+
+void main() {
+  test('refresh는 결과를 반영하고 리스너에 통지한다', () async {
+    final repo = _FakeRepository([
+      ActiveNoticesResult(notices: [notice('n1')], stale: false),
+    ]);
+    final controller = NoticeController(repository: repo);
+    var notified = 0;
+    controller.addListener(() => notified++);
+
+    await controller.refresh();
+
+    expect(controller.notices, hasLength(1));
+    expect(controller.isStale, isFalse);
+    expect(notified, greaterThan(0));
+  });
+
+  test('topDisruption은 disruption만 승격하고 info는 배너에서 제외', () async {
+    final repo = _FakeRepository([
+      ActiveNoticesResult(
+        notices: [
+          notice('info1', severity: NoticeSeverity.info),
+          notice('dis1'),
+        ],
+        stale: false,
+      ),
+    ]);
+    final controller = NoticeController(repository: repo);
+
+    await controller.refresh();
+
+    expect(controller.topDisruption?.id, 'dis1');
+  });
+
+  test('배너를 닫으면 해당 공지는 topDisruption에서 빠진다', () async {
+    final repo = _FakeRepository([
+      ActiveNoticesResult(
+        notices: [notice('dis1'), notice('dis2')],
+        stale: false,
+      ),
+    ]);
+    final controller = NoticeController(repository: repo);
+    await controller.refresh();
+
+    controller.dismissBanner('dis1');
+
+    expect(controller.topDisruption?.id, 'dis2');
+  });
+
+  test('모든 disruption을 닫으면 topDisruption은 null', () async {
+    final repo = _FakeRepository([
+      ActiveNoticesResult(notices: [notice('dis1')], stale: false),
+    ]);
+    final controller = NoticeController(repository: repo);
+    await controller.refresh();
+
+    controller.dismissBanner('dis1');
+
+    expect(controller.topDisruption, isNull);
+  });
+
+  test('저장소가 예외를 던져도 이전 상태를 유지하고 삼킨다', () async {
+    final controller = NoticeController(repository: _ThrowingRepository());
+
+    await controller.refresh();
+
+    expect(controller.notices, isEmpty);
+    expect(controller.loading, isFalse);
+  });
+
+  test('진행 중 refresh가 있으면 중복 호출은 합류(single-flight)', () async {
+    final repo = _FakeRepository([
+      ActiveNoticesResult(notices: [notice('n1')], stale: false),
+    ]);
+    final controller = NoticeController(repository: repo);
+
+    await Future.wait([controller.refresh(), controller.refresh()]);
+
+    expect(repo.calls, 1);
+  });
+}

--- a/apps/mobile/test/features/service_notice/notice_time_label_test.dart
+++ b/apps/mobile/test/features/service_notice/notice_time_label_test.dart
@@ -1,0 +1,41 @@
+import 'package:easysubway_mobile/features/service_notice/presentation/notice_time_label.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final now = DateTime(2026, 7, 6, 12, 0, 0);
+
+  test('1분 미만이면 "방금 전 기준"', () {
+    expect(
+      formatNoticeAsOf(now.subtract(const Duration(seconds: 30)), now),
+      '방금 전 기준',
+    );
+  });
+
+  test('미래 시각(시계 오차)도 "방금 전 기준"으로 안전 처리', () {
+    expect(
+      formatNoticeAsOf(now.add(const Duration(minutes: 5)), now),
+      '방금 전 기준',
+    );
+  });
+
+  test('1시간 미만이면 분 단위', () {
+    expect(
+      formatNoticeAsOf(now.subtract(const Duration(minutes: 12)), now),
+      '12분 전 기준',
+    );
+  });
+
+  test('24시간 미만이면 시간 단위', () {
+    expect(
+      formatNoticeAsOf(now.subtract(const Duration(hours: 3)), now),
+      '3시간 전 기준',
+    );
+  });
+
+  test('24시간 이상이면 일 단위', () {
+    expect(
+      formatNoticeAsOf(now.subtract(const Duration(days: 2, hours: 5)), now),
+      '2일 전 기준',
+    );
+  });
+}

--- a/apps/mobile/test/features/service_notice/service_notice_banner_test.dart
+++ b/apps/mobile/test/features/service_notice/service_notice_banner_test.dart
@@ -1,0 +1,124 @@
+import 'package:easysubway_mobile/features/service_notice/data/notice_repository.dart';
+import 'package:easysubway_mobile/features/service_notice/domain/service_notice.dart';
+import 'package:easysubway_mobile/features/service_notice/presentation/notice_controller.dart';
+import 'package:easysubway_mobile/features/service_notice/presentation/service_notice_banner.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+ServiceNotice _notice(
+  String id, {
+  NoticeSeverity severity = NoticeSeverity.disruption,
+  String? title,
+}) {
+  return ServiceNotice(
+    id: id,
+    scope: NoticeScope.all,
+    title: title ?? '제목 $id',
+    body: '본문 $id',
+    severity: severity,
+    publishedAt: DateTime(2026, 7, 6, 9, 0, 0),
+  );
+}
+
+class _FakeRepository implements NoticeRepository {
+  _FakeRepository(this.result);
+  final ActiveNoticesResult result;
+  @override
+  Future<ActiveNoticesResult> activeNotices() async => result;
+}
+
+Future<NoticeController> _seed(
+  WidgetTester tester,
+  ActiveNoticesResult result,
+) async {
+  final controller = NoticeController(repository: _FakeRepository(result));
+  await controller.refresh();
+  return controller;
+}
+
+Widget _host(NoticeController controller, {VoidCallback? onTap}) {
+  return MaterialApp(
+    home: Scaffold(
+      body: ServiceNoticeBanner(
+        controller: controller,
+        onOpenList: onTap ?? () {},
+        now: () => DateTime(2026, 7, 6, 12, 0, 0),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('disruption 공지가 있으면 제목을 1줄로 노출한다', (tester) async {
+    final controller = await _seed(
+      tester,
+      ActiveNoticesResult(
+        notices: [_notice('n1', title: '2호선 강남–역삼 지연 — 우회 경로를 확인하세요')],
+        stale: false,
+      ),
+    );
+
+    await tester.pumpWidget(_host(controller));
+
+    expect(find.byKey(const Key('serviceNoticeBanner')), findsOneWidget);
+    expect(find.text('2호선 강남–역삼 지연 — 우회 경로를 확인하세요'), findsOneWidget);
+  });
+
+  testWidgets('disruption이 없으면 아무것도 그리지 않는다', (tester) async {
+    final controller = await _seed(
+      tester,
+      ActiveNoticesResult(
+        notices: [_notice('i1', severity: NoticeSeverity.info)],
+        stale: false,
+      ),
+    );
+
+    await tester.pumpWidget(_host(controller));
+
+    expect(find.byKey(const Key('serviceNoticeBanner')), findsNothing);
+  });
+
+  testWidgets('닫기를 누르면 배너가 사라진다', (tester) async {
+    final controller = await _seed(
+      tester,
+      ActiveNoticesResult(notices: [_notice('n1')], stale: false),
+    );
+
+    await tester.pumpWidget(_host(controller));
+    expect(find.byKey(const Key('serviceNoticeBanner')), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('serviceNoticeBannerDismiss')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('serviceNoticeBanner')), findsNothing);
+  });
+
+  testWidgets('배너 본문을 누르면 목록 열기 콜백이 호출된다', (tester) async {
+    var opened = false;
+    final controller = await _seed(
+      tester,
+      ActiveNoticesResult(notices: [_notice('n1')], stale: false),
+    );
+
+    await tester.pumpWidget(_host(controller, onTap: () => opened = true));
+    await tester.tap(find.byKey(const Key('serviceNoticeBannerBody')));
+    await tester.pumpAndSettle();
+
+    expect(opened, isTrue);
+  });
+
+  testWidgets('오프라인(stale)이면 "N시간 전 기준" 라벨을 붙인다', (tester) async {
+    final controller = await _seed(
+      tester,
+      ActiveNoticesResult(
+        notices: [_notice('n1')],
+        stale: true,
+        asOf: DateTime(2026, 7, 6, 9, 0, 0),
+      ),
+    );
+
+    await tester.pumpWidget(_host(controller));
+
+    expect(find.text('3시간 전 기준'), findsOneWidget);
+  });
+}

--- a/apps/mobile/test/features/service_notice/service_notice_list_screen_test.dart
+++ b/apps/mobile/test/features/service_notice/service_notice_list_screen_test.dart
@@ -1,0 +1,94 @@
+import 'package:easysubway_mobile/features/service_notice/data/notice_repository.dart';
+import 'package:easysubway_mobile/features/service_notice/domain/service_notice.dart';
+import 'package:easysubway_mobile/features/service_notice/presentation/notice_controller.dart';
+import 'package:easysubway_mobile/features/service_notice/presentation/service_notice_list_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+ServiceNotice _notice(
+  String id, {
+  NoticeSeverity severity = NoticeSeverity.disruption,
+  String? title,
+}) {
+  return ServiceNotice(
+    id: id,
+    scope: NoticeScope.all,
+    title: title ?? '제목 $id',
+    body: '본문 $id',
+    severity: severity,
+    publishedAt: DateTime(2026, 7, 6, 9, 0, 0),
+  );
+}
+
+class _FakeRepository implements NoticeRepository {
+  _FakeRepository(this.result);
+  final ActiveNoticesResult result;
+  int calls = 0;
+  @override
+  Future<ActiveNoticesResult> activeNotices() async {
+    calls++;
+    return result;
+  }
+}
+
+Future<NoticeController> _seed(ActiveNoticesResult result) async {
+  final controller = NoticeController(repository: _FakeRepository(result));
+  await controller.refresh();
+  return controller;
+}
+
+Widget _host(NoticeController controller) {
+  return MaterialApp(
+    home: ServiceNoticeListScreen(
+      controller: controller,
+      now: () => DateTime(2026, 7, 6, 12, 0, 0),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('제목·본문·심각도를 목록으로 노출한다', (tester) async {
+    final controller = await _seed(
+      ActiveNoticesResult(
+        notices: [
+          _notice('n1', title: '2호선 지연'),
+          _notice('i1', severity: NoticeSeverity.info, title: '역사 안내'),
+        ],
+        stale: false,
+      ),
+    );
+
+    await tester.pumpWidget(_host(controller));
+    await tester.pumpAndSettle();
+
+    expect(find.text('운행 공지'), findsOneWidget);
+    expect(find.text('2호선 지연'), findsOneWidget);
+    expect(find.text('역사 안내'), findsOneWidget);
+  });
+
+  testWidgets('공지가 없으면 빈 상태 안내를 노출한다', (tester) async {
+    final controller = await _seed(
+      const ActiveNoticesResult(notices: [], stale: false),
+    );
+
+    await tester.pumpWidget(_host(controller));
+    await tester.pumpAndSettle();
+
+    expect(find.text('지금은 운행 공지가 없어요'), findsOneWidget);
+  });
+
+  testWidgets('오프라인(stale)이면 "N시간 전 기준" 라벨을 노출한다', (tester) async {
+    final controller = await _seed(
+      ActiveNoticesResult(
+        notices: [_notice('n1')],
+        stale: true,
+        asOf: DateTime(2026, 7, 6, 9, 0, 0),
+      ),
+    );
+
+    await tester.pumpWidget(_host(controller));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('3시간 전 기준'), findsOneWidget);
+  });
+}

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -11,6 +11,8 @@ import 'package:easysubway_mobile/favorite_facility.dart';
 import 'package:easysubway_mobile/features/network_map/domain/map_camera.dart';
 import 'package:easysubway_mobile/features/realtime/realtime_repository.dart';
 import 'package:easysubway_mobile/features/route_draft/application/route_draft_controller.dart';
+import 'package:easysubway_mobile/features/service_notice/data/notice_repository.dart';
+import 'package:easysubway_mobile/features/service_notice/domain/service_notice.dart';
 import 'package:easysubway_mobile/features/route_draft/domain/route_draft.dart';
 import 'package:easysubway_mobile/internal_route.dart';
 import 'package:easysubway_mobile/legacy_credential_cleanup.dart';
@@ -54,6 +56,15 @@ OnboardingState _completedOnboardingStateWithPreferences({
       preferences: preferences,
     ),
   );
+}
+
+class _FakeNoticeRepository implements NoticeRepository {
+  _FakeNoticeRepository(this._result);
+
+  final ActiveNoticesResult _result;
+
+  @override
+  Future<ActiveNoticesResult> activeNotices() async => _result;
 }
 
 Future<void> _openFavoriteList(
@@ -1291,6 +1302,87 @@ void main() {
     expect(find.text('노선도별로 보기'), findsNothing);
     expect(find.text('노선별 역 보기'), findsNothing);
     expect(find.text('노선별 목록에서 역을 선택하세요.'), findsNothing);
+  });
+
+  testWidgets('운행 공지 disruption은 홈 배너·좌측 메뉴·목록까지 배선된다', (tester) async {
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        noticeRepository: _FakeNoticeRepository(
+          ActiveNoticesResult(
+            notices: [
+              ServiceNotice(
+                id: 'n1',
+                scope: NoticeScope.all,
+                title: '2호선 강남–역삼 지연 — 우회 경로를 확인하세요',
+                body: '상행 지연이 이어지고 있어요.',
+                severity: NoticeSeverity.disruption,
+                publishedAt: DateTime(2026, 7, 6, 9, 0, 0),
+              ),
+            ],
+            stale: false,
+          ),
+        ),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // ① 홈 상단 disruption 배너.
+    expect(find.byKey(const Key('serviceNoticeBanner')), findsOneWidget);
+    expect(find.text('2호선 강남–역삼 지연 — 우회 경로를 확인하세요'), findsOneWidget);
+
+    // ② 좌측 메뉴 "운행 공지" 진입점 → 목록 화면.
+    await tester.tap(find.byKey(const Key('networkMapMenuButton')));
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(const Key('networkMapMenuServiceNoticesButton')),
+      findsOneWidget,
+    );
+
+    await tester.tap(
+      find.byKey(const Key('networkMapMenuServiceNoticesButton')),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('운행 공지'), findsOneWidget); // 목록 화면 AppBar 제목.
+    expect(find.text('상행 지연이 이어지고 있어요.'), findsOneWidget);
+  });
+
+  testWidgets('운행 공지 배너는 닫기로 사라진다', (tester) async {
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        noticeRepository: _FakeNoticeRepository(
+          ActiveNoticesResult(
+            notices: [
+              ServiceNotice(
+                id: 'n1',
+                scope: NoticeScope.all,
+                title: '1호선 지연 안내',
+                body: '지연이 이어지고 있어요.',
+                severity: NoticeSeverity.disruption,
+                publishedAt: DateTime(2026, 7, 6, 9, 0, 0),
+              ),
+            ],
+            stale: false,
+          ),
+        ),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('serviceNoticeBanner')), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('serviceNoticeBannerDismiss')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('serviceNoticeBanner')), findsNothing);
   });
 
   test('노선도 camera revision은 같은 gesture update에서도 단조 증가한다', () {


### PR DESCRIPTION
## 관련 이슈

Refs #1767

> `Closes`가 아니라 `Refs`인 이유: 이 PR은 #1767 (a) 앱 내 공지의 **mobile 사용자 노출 UI**(홈 배너·좌측 메뉴 목록·조회 훅)만 담는다. 데이터층 #1863은 이미 main 병합(e6e41453)돼 이 PR은 main 기준이다. (b) 노선 구독 FCM 푸시는 오너 결정 게이트 뒤 별도 스택이라 이 PR로 #1767을 닫지 않는다. 상위 트래커 #1762.

## 작업 배경

- 데이터층 #1863(`ApiNoticeRepository`·`ServiceNotice`·ETag 캐시·오프라인 강등)이 main 병합됐고, 이 PR이 그 위에 사용자 화면을 얹는다(base=main).
- 현재는 경로 결과 안 경고 배지(#1416)뿐이라 경로를 탐색하지 않은 사용자는 파업·장애·연장운행을 알 길이 없다. 노선도 홈 배너 + 목록으로 그 공백을 메운다.
- 실시간성 overlay라 데이터팩이 아닌 온라인 조회. 앱 시작·포그라운드 복귀 트리거에서만 조회하고 **별도 폴링 주기를 신설하지 않는다**(#1693과 같은 시점).

## 작업 내용

- **홈 상단 disruption 배너**(`ServiceNoticeBanner`): `NoticeController.topDisruption`만 승격(info 제외), amber 소프트 1줄·닫기 가능·모달 아님. 본문 탭 → 목록. 노선도 chrome의 top bar 바로 아래 오버레이(`_NetworkMapChrome`에 `disruptionBanner` 슬롯 추가). 닫기는 세션 동안 유지.
- **좌측 메뉴 "운행 공지" → 목록**(`ServiceNoticeListScreen`): 메뉴 "안내" 섹션에 진입점(`networkMapMenuServiceNoticesButton`). 목록은 info·disruption 전체를 심각도 점+라벨·제목·본문·게시시각으로 표시. 빈 상태 안내·당겨서 새로고침 포함. 심각도 점+라벨로 과한 박스를 피한다(family look).
- **조회 훅**: `NoticeController`(ChangeNotifier, single-flight)를 `_HomeScreenState`가 소유. `initState`(앱 시작) + `didChangeAppLifecycleState`==resumed(포그라운드 복귀)에서만 `refresh()`. **폴링 타이머 없음.**
- **오프라인 라벨**: `result.stale && asOf`면 `formatNoticeAsOf` → "N시간 전 기준"을 배너·목록에 붙인다(무음 숨김 없이 강등 사다리 노출).
- **배선**: `AppDependencies`에 `NoticeRepository?` 추가 — `userDatabase`가 있으면 `_LazyDefaultNoticeRepository`로 첫 조회 시점에만 base URL 해소(앱 시작 중 강제 평가 없음), 없으면 조용히 빈 결과. `EasySubwayApp`→`_EasySubwayHome`→`HomeScreen` 생성자 체인으로 전달. 공개 API 호출에 식별자 미전송(데이터층 계약 유지).

## 검증

- 실행한 명령과 결과:
  - `dart format`(변경 파일) — 0 changed
  - `flutter analyze lib test` — **No issues found**
  - `flutter test`(전체) — **804 passed** (신규 23: 라벨 5·컨트롤러 6·배너 5·목록 3·DI 2·앱통합 2)
  - `node --test tools/ci/repository-contract.test.mjs` — **167 passed**

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| disruption 배너 표시·info 미승격 | 유닛/위젯 | `flutter test` | service_notice_banner_test 5 | ✅ green |
| 컨트롤러 topDisruption·닫기·single-flight·오류 삼킴 | 유닛 | fake repo | notice_controller_test 6 | ✅ green |
| "N시간 전 기준" 라벨 포맷 | 유닛 | `flutter test` | notice_time_label_test 5 | ✅ green |
| 목록 항목·빈 상태·stale 라벨 | 위젯 | `flutter test` | service_notice_list_screen_test 3 | ✅ green |
| 홈 배너→메뉴→목록 배선·닫기 | 위젯(앱) | EasySubwayApp pump | widget_test 신규 2 | ✅ green |
| noticeRepository 배선·base lazy·빈 결과 | 유닛 | h2 UserDatabase | app_dependencies_test 2 | ✅ green |
| 관리자 발행→60초 내 배너→내리기→소멸 | Android 실기기 | QA 녹화 | ⏳ QA | ⏳ 후속 |
| 오프라인 마지막 수신본 "N시간 전 기준" | Android 실기기 | QA 스크린샷 | ⏳ QA | ⏳ 후속 |
| 공지 조회에 식별자 미전송(area:privacy) | 요청 캡처 | QA | ⏳ QA(데이터층 계약 상속) | ⏳ 후속 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

> 신규 화면이지만 버전 노출 규약상 mobile 슬라이스 스택은 최종 파트에서 버전 결정. 이 PR은 스택 중간(부모 #1863과 함께 병합)이라 단독 버전 변화 없음. DB 마이그레이션 없음(캐시는 기존 `app_preferences` 재사용).

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `NoticeController`의 `topDisruption`(dismiss 필터)·single-flight·오류 삼킴(repository가 stale 강등을 담당하므로 표시할 메시지 없음).
  - `_NetworkMapChrome`의 `disruptionBanner` 배치(top bar 아래 오버레이)와 3개 호출부 전달.
  - `_HomeScreenState`의 라이프사이클: initState 최초 조회 + resumed 재조회, dispose에서 observer 제거·controller dispose. 폴링 타이머 없음.
  - `AppDependencies`의 `_LazyDefaultNoticeRepository` — base URL을 조회 시점에만 해소(앱 시작 중 강제 평가 회피), 없으면 빈 결과.

## 리스크

- 배너가 노선도 상단을 얇게 덮는다(1줄, 닫기 가능, disruption 한정) — 지도 조작 방해 최소.
- 실기기 evidence(발행→배너, 오프라인 라벨, 식별자 미전송)는 QA 후속. 데이터층 계약(식별자 미전송)을 UI가 깨지 않음은 코드로 확인.
- (b) FCM 푸시는 이 PR 범위 밖(오너 결정 게이트 뒤).

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
