### PR TITLE
[Chore] gate JSON의 README 참조 잔재 정리 — 상품 소개 전용 README 정합

### DIFF
--- a/apps/mobile/release/backup-restore-rehearsal-gate.json
+++ b/apps/mobile/release/backup-restore-rehearsal-gate.json
@@ -40,8 +40,7 @@
       "linkedArtifacts": [
         "tools/ops/facility-report-photo-backup.sh",
         "tools/ops/facility-report-photo-restore-check.mjs",
-        "backend/src/main/resources/db/migration/postgresql/V2__facility_report_photo_object_storage.sql",
-        "README.md"
+        "backend/src/main/resources/db/migration/postgresql/V2__facility_report_photo_object_storage.sql"
       ]
     },
     {

--- a/apps/mobile/release/operations-observability-gate.json
+++ b/apps/mobile/release/operations-observability-gate.json
@@ -27,7 +27,7 @@
       "thresholdKo": "readiness가 DOWN이거나 storage/datapack/report 상태가 5분 이상 비정상이면 배포 차단",
       "firstResponseKo": "최근 CD, DB 연결, object storage 설정, report upload 설정을 확인한다.",
       "evidence": ["actuator-readiness", "productionReadiness-health-group", "backend-log-review"],
-      "linkedArtifacts": ["backend/src/main/resources/application-prod.yml", "README.md"]
+      "linkedArtifacts": ["backend/src/main/resources/application-prod.yml"]
     },
     {
       "id": "report_api_error_rate",
@@ -36,7 +36,7 @@
       "thresholdKo": "5분 API 오류율 5% 이상 또는 신고 제출 오류 3건 이상이면 조사",
       "firstResponseKo": "사용자 활동 API 오류율, report controller 로그, abuse control 설정을 확인한다.",
       "evidence": ["admin-usage-api-error-rate", "report-controller-error-log"],
-      "linkedArtifacts": ["backend/src/main/java/com/easysubway/usage/adapter/in/web/UserActivityTrackingFilter.java", "README.md"]
+      "linkedArtifacts": ["backend/src/main/java/com/easysubway/usage/adapter/in/web/UserActivityTrackingFilter.java"]
     },
     {
       "id": "admin_review_latency",
@@ -45,7 +45,7 @@
       "thresholdKo": "신고 평균 검수 시간이 24시간을 넘거나 미검수 backlog가 증가하면 담당자 확인",
       "firstResponseKo": "관리자 신고 검수 화면의 평균 처리 시간과 최근 review audit을 확인한다.",
       "evidence": ["report-processing-time-summary", "review-audit-log"],
-      "linkedArtifacts": ["backend/src/main/java/com/easysubway/report/domain/ReportProcessingTimeSummary.java", "README.md"]
+      "linkedArtifacts": ["backend/src/main/java/com/easysubway/report/domain/ReportProcessingTimeSummary.java"]
     },
     {
       "id": "datapack_release_publish_result",
@@ -54,7 +54,7 @@
       "thresholdKo": "main 데이터팩 릴리즈 실패, publish_result 실패, source_updated_at 누락은 배포 차단",
       "firstResponseKo": "Data Pack Release workflow의 datapack-observability.txt와 staged manifest를 확인한다.",
       "evidence": ["datapack-observability-artifact", "pack-version", "source-updated-at", "publish-result"],
-      "linkedArtifacts": [".github/workflows/datapack-release.yml", "tools/datapack/source-inventory.json", "README.md"]
+      "linkedArtifacts": [".github/workflows/datapack-release.yml", "tools/datapack/source-inventory.json"]
     },
     {
       "id": "mobile_crash_free_rate",
@@ -63,7 +63,7 @@
       "thresholdKo": "릴리즈 후보 crash-free sessions 99.5% 미만이면 공개 배포 보류",
       "firstResponseKo": "store internal track 또는 crash provider 대시보드의 crash-free 세션을 확인한다.",
       "evidence": ["crash-free-session-dashboard-or-external-blocker"],
-      "linkedArtifacts": ["apps/mobile/release/release-security-gate.json", "README.md"]
+      "linkedArtifacts": ["apps/mobile/release/release-security-gate.json"]
     },
     {
       "id": "mobile_anr_rate",
@@ -72,7 +72,7 @@
       "thresholdKo": "Android vitals ANR rate가 Play bad behavior 기준에 근접하면 공개 배포 보류",
       "firstResponseKo": "Play Console pre-launch report와 Android vitals를 확인한다.",
       "evidence": ["play-vitals-anr-or-external-blocker"],
-      "linkedArtifacts": ["apps/mobile/release/accessibility-release-qa.json", "README.md"]
+      "linkedArtifacts": ["apps/mobile/release/accessibility-release-qa.json"]
     },
     {
       "id": "mobile_app_start_failure_rate",
@@ -81,7 +81,7 @@
       "thresholdKo": "앱 시작 실패 또는 빈 화면 신고가 릴리즈 후보에서 재현되면 배포 차단",
       "firstResponseKo": "릴리즈 산출물 smoke log, app start test, store install evidence를 확인한다.",
       "evidence": ["release-app-start-smoke", "store-install-log"],
-      "linkedArtifacts": [".github/workflows/release-artifacts.yml", "README.md"]
+      "linkedArtifacts": [".github/workflows/release-artifacts.yml"]
     },
     {
       "id": "route_search_found_blocked_unknown_distribution",
@@ -90,7 +90,7 @@
       "thresholdKo": "FOUND/BLOCKED/UNKNOWN 분포가 이전 릴리즈 대비 급변하면 데이터팩 또는 route engine 회귀로 조사",
       "firstResponseKo": "route search test, 데이터팩 manifest, route engine version을 함께 확인한다.",
       "evidence": ["route-result-distribution", "route-engine-version"],
-      "linkedArtifacts": ["apps/mobile/test/route_search_test.dart", "README.md"]
+      "linkedArtifacts": ["apps/mobile/test/route_search_test.dart"]
     },
     {
       "id": "route_quality_observability_dashboard",
@@ -108,7 +108,7 @@
       "thresholdKo": "설치 실패 후 기존 pack 유지 또는 rollback 실패가 1건이라도 재현되면 배포 차단",
       "firstResponseKo": "data pack updater test와 릴리즈 로그에서 active pack version 변화를 확인한다.",
       "evidence": ["datapack-updater-test", "rollback-log"],
-      "linkedArtifacts": ["apps/mobile/test/core/datapack/data_pack_updater_test.dart", "README.md"]
+      "linkedArtifacts": ["apps/mobile/test/core/datapack/data_pack_updater_test.dart"]
     },
     {
       "id": "realtime_provider_success_stale_timeout_latency_eta_error",
@@ -117,7 +117,7 @@
       "thresholdKo": "provider timeout/stale/ETA error가 지속되면 앱은 fallback label을 표시하고 운영자는 provider 상태를 조사",
       "firstResponseKo": "provider snapshot source age, timeout count, fallback label count를 확인한다.",
       "evidence": ["provider-success-rate", "source-age", "timeout-count", "fallback-label-count-or-external-blocker"],
-      "linkedArtifacts": ["README.md"]
+      "linkedArtifacts": ["backend/src/main/java/com/easysubway/realtime/application/TopisRealtimeProvider.java", "backend/src/main/java/com/easysubway/realtime/application/RealtimeProviderHealthSnapshot.java", "apps/mobile/lib/features/realtime/realtime_repository.dart"]
     },
     {
       "id": "report_upload_failure_duplicate_orphan_cleanup_rate",
@@ -126,7 +126,7 @@
       "thresholdKo": "업로드 실패, 중복 claim, orphan cleanup 실패가 증가하면 object storage와 receipt flow를 조사",
       "firstResponseKo": "report upload intent, claim, cleanup 로그에서 receipt token과 upload URL이 제거됐는지 확인한다.",
       "evidence": ["report-upload-failure-count", "duplicate-claim-count", "orphan-cleanup-count"],
-      "linkedArtifacts": ["backend/src/main/java/com/easysubway/report", "README.md"]
+      "linkedArtifacts": ["backend/src/main/java/com/easysubway/report"]
     },
     {
       "id": "cross_version_correlation_ids",
@@ -135,7 +135,7 @@
       "thresholdKo": "장애 증거에 app/datapack/route/provider version 중 하나라도 없으면 release readiness 미충족",
       "firstResponseKo": "앱 버전, 데이터팩 버전, route engine version, provider snapshot id를 같은 증거 묶음으로 기록한다.",
       "evidence": ["app-datapack-route-provider-correlation", "release-metadata"],
-      "linkedArtifacts": [".github/workflows/release-artifacts.yml", ".github/workflows/datapack-release.yml", "README.md"]
+      "linkedArtifacts": [".github/workflows/release-artifacts.yml", ".github/workflows/datapack-release.yml"]
     },
     {
       "id": "android_mapping_retention",
@@ -144,7 +144,7 @@
       "thresholdKo": "mapping.txt가 릴리즈 artifact에 90일 보관되지 않으면 배포 차단",
       "firstResponseKo": "Release Artifacts workflow의 Android artifact와 release-metadata를 확인한다.",
       "evidence": ["android-mapping-artifact-retention"],
-      "linkedArtifacts": [".github/workflows/release-artifacts.yml", "README.md"]
+      "linkedArtifacts": [".github/workflows/release-artifacts.yml"]
     },
     {
       "id": "ios_dsym_retention",
@@ -153,7 +153,7 @@
       "thresholdKo": "Android-first 배포에서는 후순위 범위로 둔다. iOS 출시 준비 PR에서 dSYM zip 90일 보관 workflow를 복구하지 않으면 iOS 배포 차단",
       "firstResponseKo": "Android-first release에서는 deferred 상태를 확인하고, iOS release PR에서 dSYM artifact producer와 release-metadata를 함께 복구한다.",
       "evidence": ["ios-dsym-artifact-retention-deferred"],
-      "linkedArtifacts": ["apps/mobile/release/signed-release-artifact-gate.json", "README.md"]
+      "linkedArtifacts": ["apps/mobile/release/signed-release-artifact-gate.json"]
     }
   ]
 }

--- a/apps/mobile/release/play-store-submission-content.json
+++ b/apps/mobile/release/play-store-submission-content.json
@@ -13,7 +13,7 @@
     "privacyPolicyUrl": {
       "result": "PASS_PUBLIC_HTTPS",
       "url": "https://easysubway-api.aquilaxk.site/easysubway/privacy",
-      "requiredIn": ["Play Console", "app help", "README.md or public policy page"],
+      "requiredIn": ["Play Console", "app help", "public policy page"],
       "remainingActionKo": "Play Console URL 입력 화면과 앱 도움말 화면의 같은 URL 캡처를 최종 제출 전에 다시 확인한다."
     },
     "publicContactMailboxes": {
@@ -410,7 +410,7 @@
   "privacyPolicyRequirements": {
     "urlMustBePublicHttps": true,
     "urlMustBeUnauthenticated": true,
-    "sameUrlRequiredIn": ["Play Console", "app help", "README.md or public policy page"],
+    "sameUrlRequiredIn": ["Play Console", "app help", "public policy page"],
     "requiredContentKo": [
       "수집 항목",
       "수집 목적",

--- a/apps/mobile/release/release-security-gate.json
+++ b/apps/mobile/release/release-security-gate.json
@@ -234,7 +234,7 @@
       "ownerKo": "개인정보/릴리즈 담당",
       "readyWhenKo": "Data safety, App Privacy, PrivacyInfo, 스토어 심사 정보, 앱 도움말, 보안 문의 경로와 release network trace가 같은 데이터 처리와 삭제 요청 기준을 설명한다.",
       "evidence": ["privacy-inventory-cross-check", "store-submission-readiness-review", "help-screen-review", "release-network-trace-review"],
-      "linkedArtifacts": ["apps/mobile/release/store-privacy-inventory.json", "apps/mobile/release/store-submission-readiness.json", "apps/mobile/ios/Runner/PrivacyInfo.xcprivacy", "README.md"]
+      "linkedArtifacts": ["apps/mobile/release/store-privacy-inventory.json", "apps/mobile/release/store-submission-readiness.json", "apps/mobile/ios/Runner/PrivacyInfo.xcprivacy"]
     }
   ]
 }

--- a/apps/mobile/release/store-submission-readiness.json
+++ b/apps/mobile/release/store-submission-readiness.json
@@ -47,9 +47,9 @@
       "category": "store-listing",
       "titleKo": "Play 개인정보처리방침 URL",
       "decisionOwnerKo": "운영/개인정보 담당",
-      "readyWhenKo": "인증 없이 열리는 public HTTPS 개인정보처리방침 URL이 Play store listing, 앱 도움말, README 또는 공개 정책 페이지에 같은 값으로 공개되고 수집 항목, 목적, 보관, 삭제, 연락처, 제3자 공유 없음, tracking 없음, 사진/위치 선택 사용 조건을 포함한다.",
+      "readyWhenKo": "인증 없이 열리는 public HTTPS 개인정보처리방침 URL이 Play store listing, 앱 도움말, 공개 정책 페이지에 같은 값으로 공개되고 수집 항목, 목적, 보관, 삭제, 연락처, 제3자 공유 없음, tracking 없음, 사진/위치 선택 사용 조건을 포함한다.",
       "evidence": ["store-listing-url", "app-help-screen-url"],
-      "linkedArtifacts": ["README.md", "apps/mobile/lib/main.dart"],
+      "linkedArtifacts": ["apps/mobile/lib/main.dart"],
       "configurationSources": ["EASYSUBWAY_PRIVACY_POLICY_URL"]
     },
     {
@@ -82,7 +82,7 @@
       "decisionOwnerKo": "제품/운영 담당",
       "readyWhenKo": "대중교통 접근성 정보 앱 특성, 사용자 생성 신고 내용, 외부 웹 열람 없음, 광고 없음 기준으로 콘텐츠 등급 설문을 완료한다.",
       "evidence": ["content-rating-certificate", "questionnaire-export"],
-      "linkedArtifacts": ["README.md", "apps/mobile/lib/facility_report.dart"],
+      "linkedArtifacts": ["apps/mobile/lib/facility_report.dart"],
       "configurationSources": ["product scope", "facility report moderation policy"]
     },
     {
@@ -93,7 +93,7 @@
       "decisionOwnerKo": "제품/운영 담당",
       "readyWhenKo": "전체 사용자용 이동 보조 앱이며 어린이 대상 아님 기준으로 대상 연령과 콘텐츠 적합성 답변을 확정한다.",
       "evidence": ["target-audience-declaration", "store-copy-review"],
-      "linkedArtifacts": ["README.md", "apps/mobile/release/accessibility-release-qa.json"],
+      "linkedArtifacts": ["apps/mobile/release/accessibility-release-qa.json"],
       "configurationSources": ["primary users: seniors, pregnant users, disabled users"]
     },
     {
@@ -104,7 +104,7 @@
       "decisionOwnerKo": "제품/사업 담당",
       "readyWhenKo": "앱 코드와 출시 계획에 광고 SDK와 광고 지면이 없음을 확인하고 Play Console 광고 포함 여부를 아니오로 제출한다.",
       "evidence": ["dependency-review", "business-model-review"],
-      "linkedArtifacts": ["apps/mobile/lib/main.dart", "README.md"],
+      "linkedArtifacts": ["apps/mobile/lib/main.dart"],
       "configurationSources": ["no ad SDK dependency", "no in-app ad placement"]
     },
     {
@@ -115,7 +115,7 @@
       "decisionOwnerKo": "제품/마케팅 담당",
       "readyWhenKo": "쉬운 지하철의 핵심 목적이 대중교통 접근성 이동 보조임을 기준으로 Play 앱 카테고리와 대중교통, 접근성, 지하철, 경로 안내 태그를 제품 설명과 일치시킨다.",
       "evidence": ["store-category-selection", "listing-copy-review"],
-      "linkedArtifacts": ["README.md", "apps/mobile/lib/main.dart"],
+      "linkedArtifacts": ["apps/mobile/lib/main.dart"],
       "configurationSources": ["public transit accessibility helper"]
     },
     {
@@ -126,7 +126,7 @@
       "decisionOwnerKo": "운영 담당",
       "readyWhenKo": "스토어 공개 연락처 이메일과 앱 도움말의 고객지원 메일이 같은 운영 수신함으로 연결되고 릴리즈 전 수신 테스트를 통과한다.",
       "evidence": ["support-mailbox-test", "store-contact-preview"],
-      "linkedArtifacts": ["README.md", "apps/mobile/lib/main.dart"],
+      "linkedArtifacts": ["apps/mobile/lib/main.dart"],
       "configurationSources": ["EASYSUBWAY_SUPPORT_EMAIL"]
     },
     {
@@ -148,7 +148,7 @@
       "decisionOwnerKo": "개인정보/운영 담당",
       "readyWhenKo": "계정 없는 익명 사용 구조에서도 데이터 삭제 요청 경로가 앱 도움말과 Play Console에 공개되고 삭제 요청 수신함을 검증한다.",
       "evidence": ["data-deletion-contact-test", "help-screen-review"],
-      "linkedArtifacts": ["README.md", "apps/mobile/lib/main.dart", "apps/mobile/release/store-privacy-inventory.json"],
+      "linkedArtifacts": ["apps/mobile/lib/main.dart", "apps/mobile/release/store-privacy-inventory.json"],
       "configurationSources": ["EASYSUBWAY_DATA_DELETION_EMAIL"]
     },
     {
@@ -159,7 +159,7 @@
       "decisionOwnerKo": "제품/마케팅 담당",
       "readyWhenKo": "설명, 고정 스크린샷 세트, 7인치/10인치 태블릿, Chromebook, Android XR 16:9 후보 이미지, 기능 문구가 실제 앱 화면과 일치하고 실시간 안전 경로 보장처럼 과장된 표현을 사용하지 않는다.",
       "evidence": ["screenshot-review", "large-screen-screenshot-review", "copy-review"],
-      "linkedArtifacts": ["README.md", "apps/mobile/lib/main.dart", "apps/mobile/release/accessibility-release-qa.json", "apps/mobile/release/play-store-submission-content.json"],
+      "linkedArtifacts": ["apps/mobile/lib/main.dart", "apps/mobile/release/accessibility-release-qa.json", "apps/mobile/release/play-store-submission-content.json"],
       "configurationSources": ["release build screenshots"]
     },
     {
@@ -181,7 +181,7 @@
       "decisionOwnerKo": "운영/개인정보 담당",
       "readyWhenKo": "App Store Connect의 개인정보처리방침 URL과 앱 도움말 화면 URL이 같은 HTTPS 주소로 공개된다.",
       "evidence": ["app-information-url", "app-help-screen-url"],
-      "linkedArtifacts": ["README.md", "apps/mobile/lib/main.dart"],
+      "linkedArtifacts": ["apps/mobile/lib/main.dart"],
       "configurationSources": ["EASYSUBWAY_PRIVACY_POLICY_URL"]
     },
     {
@@ -192,7 +192,7 @@
       "decisionOwnerKo": "운영 담당",
       "readyWhenKo": "공개 지원 URL 또는 지원 페이지가 준비되고, 앱 도움말의 고객지원 메일과 같은 운영 채널로 연결된다.",
       "evidence": ["support-page-check", "support-mailbox-test"],
-      "linkedArtifacts": ["README.md", "apps/mobile/lib/main.dart"],
+      "linkedArtifacts": ["apps/mobile/lib/main.dart"],
       "configurationSources": ["EASYSUBWAY_SUPPORT_EMAIL", "public support page"]
     },
     {
@@ -203,7 +203,7 @@
       "decisionOwnerKo": "제품/운영 담당",
       "readyWhenKo": "대중교통 정보, 사용자 신고 입력, 외부 웹 열람 없음, 광고 없음 기준으로 App Store Connect 연령 등급 설문을 완료한다.",
       "evidence": ["age-rating-result", "questionnaire-review"],
-      "linkedArtifacts": ["README.md", "apps/mobile/lib/facility_report.dart"],
+      "linkedArtifacts": ["apps/mobile/lib/facility_report.dart"],
       "configurationSources": ["product scope", "facility report moderation policy"]
     },
     {
@@ -214,7 +214,7 @@
       "decisionOwnerKo": "제품/마케팅 담당",
       "readyWhenKo": "앱의 주요 목적이 대중교통 이동 보조임을 기준으로 기본 카테고리와 보조 카테고리를 제품 설명과 일치시킨다.",
       "evidence": ["category-selection", "listing-copy-review"],
-      "linkedArtifacts": ["README.md", "apps/mobile/lib/main.dart"],
+      "linkedArtifacts": ["apps/mobile/lib/main.dart"],
       "configurationSources": ["public transit accessibility helper"]
     },
     {
@@ -225,7 +225,7 @@
       "decisionOwnerKo": "운영 담당",
       "readyWhenKo": "심사 기간에 응답 가능한 이름, 전화번호, 이메일을 App Store Connect Review Information에 입력하고 운영 수신 테스트를 마친다.",
       "evidence": ["review-contact-test", "review-information-preview"],
-      "linkedArtifacts": ["README.md", "apps/mobile/lib/main.dart"],
+      "linkedArtifacts": ["apps/mobile/lib/main.dart"],
       "configurationSources": ["release reviewer contact"]
     },
     {
@@ -247,7 +247,7 @@
       "decisionOwnerKo": "제품/운영 담당",
       "readyWhenKo": "지도, 역 정보, 시설 정보, 아이콘, 스크린샷에 대한 사용 권리와 출처를 출시 전 확인하고 App Store Connect의 콘텐츠 권리 답변과 일치시킨다.",
       "evidence": ["content-rights-review", "asset-source-review"],
-      "linkedArtifacts": ["README.md", "apps/mobile/ios/Runner/Assets.xcassets/AppIcon.appiconset/Contents.json"],
+      "linkedArtifacts": ["apps/mobile/ios/Runner/Assets.xcassets/AppIcon.appiconset/Contents.json"],
       "configurationSources": ["transport data source agreement", "asset source records"]
     },
     {
@@ -269,7 +269,7 @@
       "decisionOwnerKo": "제품/마케팅 담당",
       "readyWhenKo": "스크린샷과 설명이 실제 앱 동작, 접근성 도움 범위, 안전 고지와 일치하며 보장할 수 없는 실시간 안전 표현을 쓰지 않는다.",
       "evidence": ["screenshot-review", "copy-review"],
-      "linkedArtifacts": ["README.md", "apps/mobile/lib/main.dart", "apps/mobile/release/accessibility-release-qa.json"],
+      "linkedArtifacts": ["apps/mobile/lib/main.dart", "apps/mobile/release/accessibility-release-qa.json"],
       "configurationSources": ["release build screenshots"]
     },
     {
@@ -280,7 +280,7 @@
       "decisionOwnerKo": "제품/마케팅 담당",
       "readyWhenKo": "Google Play와 App Store의 앱 이름은 쉬운 지하철로 맞추고, 영문 식별자는 easysubway를 사용하며 Play 이름 길이 제한을 넘지 않는다.",
       "evidence": ["store-name-preview", "release-build-name-check"],
-      "linkedArtifacts": ["README.md", "apps/mobile/lib/main.dart"],
+      "linkedArtifacts": ["apps/mobile/lib/main.dart"],
       "configurationSources": ["appNameKo", "appNameEn"]
     },
     {
@@ -291,7 +291,7 @@
       "decisionOwnerKo": "개인정보/모바일 담당",
       "readyWhenKo": "Play Data safety, App Privacy, PrivacyInfo.xcprivacy, 앱 도움말 안내가 같은 데이터 수집 범위와 삭제 요청 경로를 설명한다.",
       "evidence": ["privacy-cross-check", "release-help-screen-review"],
-      "linkedArtifacts": ["README.md", "apps/mobile/release/store-privacy-inventory.json", "apps/mobile/ios/Runner/PrivacyInfo.xcprivacy", "apps/mobile/lib/main.dart"],
+      "linkedArtifacts": ["apps/mobile/release/store-privacy-inventory.json", "apps/mobile/ios/Runner/PrivacyInfo.xcprivacy", "apps/mobile/lib/main.dart"],
       "configurationSources": ["EASYSUBWAY_PRIVACY_POLICY_URL", "EASYSUBWAY_DATA_DELETION_EMAIL"]
     },
     {

--- a/apps/mobile/release/store-submission-readiness.json
+++ b/apps/mobile/release/store-submission-readiness.json
@@ -49,7 +49,7 @@
       "decisionOwnerKo": "운영/개인정보 담당",
       "readyWhenKo": "인증 없이 열리는 public HTTPS 개인정보처리방침 URL이 Play store listing, 앱 도움말, 공개 정책 페이지에 같은 값으로 공개되고 수집 항목, 목적, 보관, 삭제, 연락처, 제3자 공유 없음, tracking 없음, 사진/위치 선택 사용 조건을 포함한다.",
       "evidence": ["store-listing-url", "app-help-screen-url"],
-      "linkedArtifacts": ["apps/mobile/lib/main.dart"],
+      "linkedArtifacts": ["apps/mobile/lib/main.dart", "apps/mobile/release/store-privacy-inventory.json"],
       "configurationSources": ["EASYSUBWAY_PRIVACY_POLICY_URL"]
     },
     {
@@ -181,7 +181,7 @@
       "decisionOwnerKo": "운영/개인정보 담당",
       "readyWhenKo": "App Store Connect의 개인정보처리방침 URL과 앱 도움말 화면 URL이 같은 HTTPS 주소로 공개된다.",
       "evidence": ["app-information-url", "app-help-screen-url"],
-      "linkedArtifacts": ["apps/mobile/lib/main.dart"],
+      "linkedArtifacts": ["apps/mobile/lib/main.dart", "apps/mobile/release/store-privacy-inventory.json"],
       "configurationSources": ["EASYSUBWAY_PRIVACY_POLICY_URL"]
     },
     {
@@ -192,7 +192,7 @@
       "decisionOwnerKo": "운영 담당",
       "readyWhenKo": "공개 지원 URL 또는 지원 페이지가 준비되고, 앱 도움말의 고객지원 메일과 같은 운영 채널로 연결된다.",
       "evidence": ["support-page-check", "support-mailbox-test"],
-      "linkedArtifacts": ["apps/mobile/lib/main.dart"],
+      "linkedArtifacts": ["apps/mobile/lib/main.dart", "apps/mobile/release/store-privacy-inventory.json"],
       "configurationSources": ["EASYSUBWAY_SUPPORT_EMAIL", "public support page"]
     },
     {

--- a/apps/mobile/release/support-incident-response-gate.json
+++ b/apps/mobile/release/support-incident-response-gate.json
@@ -30,7 +30,7 @@
       "id": "support_email",
       "source": "EASYSUBWAY_SUPPORT_EMAIL",
       "ownerKo": "고객지원 담당자",
-      "readyWhenKo": "스토어 연락처, 앱 도움말, README의 support email이 같은 운영 수신함으로 연결되고 수신 테스트를 통과한다.",
+      "readyWhenKo": "스토어 연락처, 앱 도움말, 공개 정책 페이지의 support email이 같은 운영 수신함으로 연결되고 수신 테스트를 통과한다.",
       "requiredEvidence": ["support-mailbox-receive-test", "store-contact-preview", "app-help-screen-contact-check"]
     },
     {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -3144,7 +3144,7 @@ test("스토어 개인정보 제출 기준선은 release artifact placeholder �
   ]) {
     const item = readinessItems.get(id);
     assert.ok(item, `${id} must be present in store submission readiness`);
-    assert.ok(item.linkedArtifacts.includes("README.md"), `${id} must link README for public user-facing path`);
+    assert.ok(item.linkedArtifacts.length > 0, `${id} must link at least one public evidence artifact`);
   }
 
 
@@ -10650,7 +10650,7 @@ test("모바일 스토어 심사 정보 기준선은 제출 전 필수 항목을
   assert.deepEqual(playStoreContent.latestQaEvidenceSummary.privacyPolicyUrl.requiredIn, [
     "Play Console",
     "app help",
-    "README.md or public policy page",
+    "public policy page",
   ]);
   assert.equal(
     playStoreContent.latestQaEvidenceSummary.publicContactMailboxes.result,
@@ -10847,7 +10847,7 @@ test("모바일 스토어 심사 정보 기준선은 제출 전 필수 항목을
   assert.deepEqual(playStoreContent.privacyPolicyRequirements.sameUrlRequiredIn, [
     "Play Console",
     "app help",
-    "README.md or public policy page",
+    "public policy page",
   ]);
   assert.ok(playStoreContent.privacyPolicyRequirements.requiredContentKo.includes("제3자 공유 없음"));
   assert.ok(playStoreContent.privacyPolicyRequirements.requiredContentKo.includes("tracking 없음"));

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -3144,7 +3144,10 @@ test("스토어 개인정보 제출 기준선은 release artifact placeholder �
   ]) {
     const item = readinessItems.get(id);
     assert.ok(item, `${id} must be present in store submission readiness`);
-    assert.ok(item.linkedArtifacts.length > 0, `${id} must link at least one public evidence artifact`);
+    assert.ok(
+      item.linkedArtifacts.includes("apps/mobile/release/store-privacy-inventory.json"),
+      `${id} must link the store privacy inventory as its public evidence anchor`,
+    );
   }
 
 


### PR DESCRIPTION
## 관련 이슈

Closes #1873

## 작업 배경

- README가 상품 소개 전용으로 전환(#1871, PR #1872)되면서, release gate JSON들이 README.md를 "공개 계약 문서 위치"로 참조하던 항목들의 의미가 깨졌다(#1872 리뷰어 메모에서 후속 정리 후보로 기록).

## 작업 내용

- linkedArtifacts에서 `README.md` 제거 32건: operations-observability(13)·store-submission-readiness(17)·backup-restore-rehearsal(1)·release-security(1). 원본 JSON 포맷 보존(텍스트 수술, 재직렬화 잡음 없음).
- README가 유일한 artifact였던 `realtime_provider_success_stale_timeout_latency_eta_error` 신호는 실제 정본 코드 경로(TopisRealtimeProvider·RealtimeProviderHealthSnapshot·realtime_repository.dart)로 교체.
- 개인정보처리방침 공개 위치 문구에서 README 제외: play-store-submission-content `"README.md or public policy page"` → `"public policy page"`(2곳), store-submission-readiness "README 또는 공개 정책 페이지" → "공개 정책 페이지", support-incident-response "README의 support email" → "공개 정책 페이지의 support email". 실제 공개 URL은 backend 정책 페이지로 불변.
- 테스트 동기화: store readiness 5개 항목의 `linkedArtifacts.includes("README.md")` 강제를 "비어 있지 않은 공개 증거 artifact" 검사로 교체, requiredIn deepEqual 2곳 갱신.
- 유지: release-governance-gate의 경로 감시 목록 내 README.md — 상품 소개(공개 claim 표면) 변경 감시는 여전히 유효.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/repository-contract.test.mjs` → tests 168, pass 168, fail 0
  - `grep '"README' apps/mobile/release/*.json` → release-governance 경로 목록 1건만 잔존(의도)
  - diff 규모 39+/40-(포맷 보존 확인)

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 계약 테스트 | repo | node --test | 로컬 + PR CI | 168/168 pass |
| JSON 유효성 | repo | 테스트 내 readJson 파싱 | 동일 실행 | 예외 없음 |
| README 참조 잔재 | repo | grep | 로컬 실행 | 의도 1건 외 0 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: (1) linkedArtifacts에서 README 제거 후 빈 배열이 된 항목이 없는지(전 항목 잔여 artifact 존재 확인함), (2) Data Safety·privacy 공개 위치에서 README를 뺀 것이 스토어 제출 요건과 충돌하지 않는지(요건은 "공개 HTTPS URL" — backend 정책 페이지가 충족, README는 애초에 URL이 아님), (3) realtime 신호의 새 artifact 경로 실재.
- gate의 실질 계약(신호 ID·완료 조건·claim 정책)은 무변경.

## 리스크

- 스토어 제출 증거 수집 시 README를 참조하던 과거 절차 문서(local-only)가 있다면 새 경로 기준으로 읽어야 한다 — gate JSON이 정본이므로 실질 영향 없음.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.