### PR TITLE
[Feat] 운행 공지 관리자 화면 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/admin/navigation/AdminProgram.java
+++ b/backend/src/main/java/com/easysubway/admin/navigation/AdminProgram.java
@@ -18,6 +18,7 @@ public enum AdminProgram {
 	BATCHES("a-batches", "운영·분석", "배치 운영", "/admin/batches/page", AdminPermission.DATA_OPERATE),
 	CODES("a-codes", "운영·분석", "공통코드", "/admin/codes/page", AdminPermission.OPERATIONS_MANAGE),
 	INCIDENTS("a-incidents", "운영·분석", "장애관리", "/admin/incidents/page", AdminPermission.OPERATIONS_MANAGE),
+	SERVICE_NOTICES("a-service-notices", "운영·분석", "운행 공지", "/admin/notices/page", AdminPermission.OPERATIONS_MANAGE),
 	ROUTE_SEARCHES("a-route-searches", "운영·분석", "경로 검색 분석", "/admin/routes/searches/page", AdminPermission.ADMIN_VIEW),
 	ROUTE_FEEDBACK("a-route-feedback", "운영·분석", "경로 피드백 분석", "/admin/routes/feedback/page", AdminPermission.ADMIN_VIEW),
 	DATAPACK_PIPELINE("a-datapack-pipeline", "데이터팩", "파이프라인 개요", "/admin/datapack/pipeline/page", AdminPermission.DATAPACK_READ),

--- a/backend/src/main/java/com/easysubway/notice/adapter/in/web/ServiceNoticeAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/notice/adapter/in/web/ServiceNoticeAdminPageController.java
@@ -1,0 +1,128 @@
+package com.easysubway.notice.adapter.in.web;
+
+import com.easysubway.admin.audit.application.service.AdminAuditWriter;
+import com.easysubway.admin.audit.domain.AdminAuditOutcome;
+import com.easysubway.notice.application.port.out.ServiceNoticeRepository;
+import com.easysubway.notice.application.service.PublishNoticeCommand;
+import com.easysubway.notice.application.service.ServiceNoticeService;
+import com.easysubway.notice.domain.ServiceNotice;
+import com.easysubway.notice.domain.ServiceNoticeScope;
+import com.easysubway.notice.domain.ServiceNoticeSeverity;
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.LocalDateTime;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@Controller
+class ServiceNoticeAdminPageController {
+
+	private static final int NOTICE_LIMIT = 50;
+
+	private final ServiceNoticeRepository repository;
+	private final ServiceNoticeService service;
+	private final AdminAuditWriter auditWriter;
+
+	ServiceNoticeAdminPageController(
+		ServiceNoticeRepository repository,
+		ServiceNoticeService service,
+		AdminAuditWriter auditWriter
+	) {
+		this.repository = repository;
+		this.service = service;
+		this.auditWriter = auditWriter;
+	}
+
+	@GetMapping("/admin/notices/page")
+	@PreAuthorize("hasAuthority('admin.operations.manage')")
+	String page(Model model) {
+		model.addAttribute("notices", repository.findRecent(NOTICE_LIMIT).stream()
+			.map(ServiceNoticeView::from)
+			.toList());
+		model.addAttribute("scopes", ServiceNoticeScope.values());
+		model.addAttribute("severities", ServiceNoticeSeverity.values());
+		return "admin/notices/list";
+	}
+
+	@PostMapping("/admin/notices/page")
+	@PreAuthorize("hasAuthority('admin.operations.manage')")
+	String publish(
+		@ModelAttribute NoticeForm form,
+		Authentication authentication,
+		HttpServletRequest request
+	) {
+		ServiceNotice published = service.publish(form.toCommand(), authentication.getName());
+		auditWriter.noticeChange(
+			authentication, request, published.id(), "PUBLISH_NOTICE",
+			AdminAuditOutcome.SUCCESS, "service notice published");
+		return "redirect:/admin/notices/page";
+	}
+
+	@PostMapping("/admin/notices/{id}/unpublish/page")
+	@PreAuthorize("hasAuthority('admin.operations.manage')")
+	String unpublish(
+		@PathVariable String id,
+		Authentication authentication,
+		HttpServletRequest request
+	) {
+		service.unpublish(id);
+		auditWriter.noticeChange(
+			authentication, request, id, "UNPUBLISH_NOTICE",
+			AdminAuditOutcome.SUCCESS, "service notice unpublished");
+		return "redirect:/admin/notices/page";
+	}
+
+	record NoticeForm(
+		String scope,
+		String scopeValue,
+		String title,
+		String body,
+		String severity,
+		String expiresAt
+	) {
+		PublishNoticeCommand toCommand() {
+			ServiceNoticeScope parsedScope = ServiceNoticeScope.valueOf(scope);
+			return new PublishNoticeCommand(
+				parsedScope,
+				parsedScope == ServiceNoticeScope.ALL ? null : scopeValue,
+				title,
+				body,
+				ServiceNoticeSeverity.valueOf(severity),
+				parseExpiresAt(expiresAt));
+		}
+
+		private static LocalDateTime parseExpiresAt(String value) {
+			return value == null || value.isBlank() ? null : LocalDateTime.parse(value);
+		}
+	}
+
+	record ServiceNoticeView(
+		String id,
+		String scope,
+		String scopeValue,
+		String title,
+		String body,
+		String severity,
+		LocalDateTime publishedAt,
+		LocalDateTime expiresAt,
+		String publishedBy
+	) {
+		static ServiceNoticeView from(ServiceNotice notice) {
+			return new ServiceNoticeView(
+				notice.id(),
+				notice.scope().name(),
+				notice.scopeValue() == null ? "-" : notice.scopeValue(),
+				notice.title(),
+				notice.body(),
+				notice.severity().name(),
+				notice.publishedAt(),
+				notice.expiresAt(),
+				notice.publishedBy());
+		}
+	}
+}

--- a/backend/src/main/java/com/easysubway/notice/adapter/in/web/ServiceNoticeAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/notice/adapter/in/web/ServiceNoticeAdminPageController.java
@@ -2,6 +2,8 @@ package com.easysubway.notice.adapter.in.web;
 
 import com.easysubway.admin.audit.application.service.AdminAuditWriter;
 import com.easysubway.admin.audit.domain.AdminAuditOutcome;
+import com.easysubway.common.error.InvalidRequestException;
+import com.easysubway.common.error.ResourceNotFoundException;
 import com.easysubway.notice.application.port.out.ServiceNoticeRepository;
 import com.easysubway.notice.application.service.PublishNoticeCommand;
 import com.easysubway.notice.application.service.ServiceNoticeService;
@@ -9,10 +11,12 @@ import com.easysubway.notice.domain.ServiceNotice;
 import com.easysubway.notice.domain.ServiceNoticeScope;
 import com.easysubway.notice.domain.ServiceNoticeSeverity;
 import jakarta.servlet.http.HttpServletRequest;
+import java.time.format.DateTimeParseException;
 import java.time.LocalDateTime;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -51,6 +55,7 @@ class ServiceNoticeAdminPageController {
 
 	@PostMapping("/admin/notices/page")
 	@PreAuthorize("hasAuthority('admin.operations.manage')")
+	@Transactional
 	String publish(
 		@ModelAttribute NoticeForm form,
 		Authentication authentication,
@@ -65,11 +70,15 @@ class ServiceNoticeAdminPageController {
 
 	@PostMapping("/admin/notices/{id}/unpublish/page")
 	@PreAuthorize("hasAuthority('admin.operations.manage')")
+	@Transactional
 	String unpublish(
 		@PathVariable String id,
 		Authentication authentication,
 		HttpServletRequest request
 	) {
+		if (repository.findById(id).isEmpty()) {
+			throw new ResourceNotFoundException("운행 공지를 찾을 수 없습니다: " + id);
+		}
 		service.unpublish(id);
 		auditWriter.noticeChange(
 			authentication, request, id, "UNPUBLISH_NOTICE",
@@ -86,18 +95,36 @@ class ServiceNoticeAdminPageController {
 		String expiresAt
 	) {
 		PublishNoticeCommand toCommand() {
-			ServiceNoticeScope parsedScope = ServiceNoticeScope.valueOf(scope);
+			ServiceNoticeScope parsedScope = parseEnum(ServiceNoticeScope.class, scope, "scope");
 			return new PublishNoticeCommand(
 				parsedScope,
 				parsedScope == ServiceNoticeScope.ALL ? null : scopeValue,
 				title,
 				body,
-				ServiceNoticeSeverity.valueOf(severity),
+				parseEnum(ServiceNoticeSeverity.class, severity, "severity"),
 				parseExpiresAt(expiresAt));
 		}
 
 		private static LocalDateTime parseExpiresAt(String value) {
-			return value == null || value.isBlank() ? null : LocalDateTime.parse(value);
+			if (value == null || value.isBlank()) {
+				return null;
+			}
+			try {
+				return LocalDateTime.parse(value);
+			} catch (DateTimeParseException exception) {
+				throw new InvalidRequestException("expiresAt 형식이 올바르지 않습니다.", exception);
+			}
+		}
+
+		private static <E extends Enum<E>> E parseEnum(Class<E> type, String value, String field) {
+			if (value == null || value.isBlank()) {
+				throw new InvalidRequestException(field + "은(는) 필수입니다.");
+			}
+			try {
+				return Enum.valueOf(type, value);
+			} catch (IllegalArgumentException exception) {
+				throw new InvalidRequestException("알 수 없는 " + field + ": " + value, exception);
+			}
 		}
 	}
 

--- a/backend/src/main/java/com/easysubway/notice/adapter/out/persistence/JdbcServiceNoticeRepository.java
+++ b/backend/src/main/java/com/easysubway/notice/adapter/out/persistence/JdbcServiceNoticeRepository.java
@@ -71,6 +71,13 @@ public class JdbcServiceNoticeRepository implements ServiceNoticeRepository {
 	}
 
 	@Override
+	public List<ServiceNotice> findRecent(int limit) {
+		return jdbcTemplate.query(
+			"SELECT * FROM service_notice ORDER BY published_at DESC LIMIT ?",
+			ROW_MAPPER, limit);
+	}
+
+	@Override
 	public void deleteById(String id) {
 		jdbcTemplate.update("DELETE FROM service_notice WHERE id=?", id);
 	}

--- a/backend/src/main/java/com/easysubway/notice/application/port/out/ServiceNoticeRepository.java
+++ b/backend/src/main/java/com/easysubway/notice/application/port/out/ServiceNoticeRepository.java
@@ -19,5 +19,7 @@ public interface ServiceNoticeRepository {
 	 */
 	List<ServiceNotice> findActiveAt(LocalDateTime now);
 
+	List<ServiceNotice> findRecent(int limit);
+
 	void deleteById(String id);
 }

--- a/backend/src/main/resources/templates/admin/notices/list.html
+++ b/backend/src/main/resources/templates/admin/notices/list.html
@@ -1,0 +1,103 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>운행 공지</title>
+	<link rel="stylesheet" th:href="@{/css/admin-v3.css}">
+</head>
+<body class="admin-v3">
+<a th:replace="~{admin/fragments/shell :: skipLink}"></a>
+<div class="admin-shell">
+<div th:replace="~{admin/fragments/shell :: sidebar('a-service-notices')}"></div>
+<main class="admin-main">
+	<div th:replace="~{admin/fragments/shell :: topbar}"></div>
+	<div th:replace="~{admin/fragments/shell :: contentStart}"></div>
+	<header class="admin-page-head">
+		<div>
+			<h1>운행 공지</h1>
+			<p>앱 홈 배너와 운행 공지 목록에 노출할 공지를 발행하고 내립니다.</p>
+		</div>
+	</header>
+
+	<section class="admin-panel">
+		<h2>공지 발행</h2>
+		<form method="post" th:action="@{/admin/notices/page}">
+			<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+			<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
+			<label>
+				대상
+				<select name="scope">
+					<option th:each="scope : ${scopes}" th:value="${scope}" th:text="${scope}">ALL</option>
+				</select>
+			</label>
+			<label>
+				대상 값
+				<input name="scopeValue" placeholder="LINE이면 노선 id, REGION이면 지역">
+			</label>
+			<label>
+				심각도
+				<select name="severity">
+					<option th:each="severity : ${severities}" th:value="${severity}" th:text="${severity}">INFO</option>
+				</select>
+			</label>
+			<label>
+				제목
+				<input name="title" required maxlength="255">
+			</label>
+			<label>
+				본문
+				<textarea name="body" required rows="4" maxlength="2000"></textarea>
+			</label>
+			<label>
+				만료 시각
+				<input name="expiresAt" type="datetime-local">
+			</label>
+			<button type="submit">공지 발행</button>
+		</form>
+	</section>
+
+	<section class="admin-panel">
+		<h2>최근 공지</h2>
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">제목</th>
+				<th scope="col">대상</th>
+				<th scope="col">심각도</th>
+				<th scope="col">본문</th>
+				<th scope="col">게시</th>
+				<th scope="col">만료</th>
+				<th scope="col">발행자</th>
+				<th scope="col">액션</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:if="${notices.isEmpty()}">
+				<td colspan="8">공지 없음</td>
+			</tr>
+			<tr th:each="notice : ${notices}">
+				<td th:text="${notice.title}">제목</td>
+				<td th:text="${notice.scope + ' ' + notice.scopeValue}">대상</td>
+				<td th:text="${notice.severity}">INFO</td>
+				<td th:text="${notice.body}">본문</td>
+				<td th:text="${notice.publishedAt}">2026-07-09T10:00</td>
+				<td th:text="${notice.expiresAt != null ? notice.expiresAt : '-'}">-</td>
+				<td th:text="${notice.publishedBy}">operator</td>
+				<td>
+					<form method="post"
+					      th:action="@{/admin/notices/{id}/unpublish/page(id=${notice.id})}">
+						<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+						<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
+						<button type="submit">즉시 내리기</button>
+					</form>
+				</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+</main>
+</div>
+<th:block th:replace="~{admin/fragments/shell :: scripts}"></th:block>
+</body>
+</html>

--- a/backend/src/test/java/com/easysubway/notice/adapter/in/web/ServiceNoticeAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/notice/adapter/in/web/ServiceNoticeAdminPageControllerTest.java
@@ -70,7 +70,7 @@ class ServiceNoticeAdminPageControllerTest {
 				.param("severity", "DISRUPTION")
 				.param("title", "2호선 지연")
 				.param("body", "강남-역삼 상행 지연입니다.")
-				.param("expiresAt", "2026-07-09T18:30"))
+				.param("expiresAt", LocalDateTime.now(ZoneOffset.UTC).plusHours(1).toString()))
 			.andExpect(status().is3xxRedirection())
 			.andExpect(redirectedUrl("/admin/notices/page"));
 

--- a/backend/src/test/java/com/easysubway/notice/adapter/in/web/ServiceNoticeAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/notice/adapter/in/web/ServiceNoticeAdminPageControllerTest.java
@@ -108,6 +108,36 @@ class ServiceNoticeAdminPageControllerTest {
 			.andExpect(status().isForbidden());
 	}
 
+	@Test
+	@DisplayName("잘못된 발행 입력은 400으로 거부된다")
+	void invalidPublishFormRejectedAsBadRequest() throws Exception {
+		mockMvc.perform(post("/admin/notices/page")
+				.with(csrf())
+				.with(commandToken())
+				.with(operationsManager())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("scope", "ALL")
+				.param("severity", "WARN")
+				.param("title", "잘못된 공지")
+				.param("body", "본문"))
+			.andExpect(status().isBadRequest());
+
+		assertThat(repository.findActiveAt(LocalDateTime.now(ZoneOffset.UTC))).isEmpty();
+	}
+
+	@Test
+	@DisplayName("없는 공지 내리기는 성공 audit 없이 404로 닫는다")
+	void missingUnpublishRejectedAsNotFound() throws Exception {
+		mockMvc.perform(post("/admin/notices/missing/unpublish/page")
+				.with(csrf())
+				.with(commandToken())
+				.with(operationsManager())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED))
+			.andExpect(status().isNotFound());
+
+		assertThat(auditRecorded("UNPUBLISH_NOTICE", "missing")).isFalse();
+	}
+
 	private RequestPostProcessor operationsManager() {
 		return user("operator").authorities(new SimpleGrantedAuthority("admin.operations.manage"));
 	}

--- a/backend/src/test/java/com/easysubway/notice/adapter/in/web/ServiceNoticeAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/notice/adapter/in/web/ServiceNoticeAdminPageControllerTest.java
@@ -1,0 +1,150 @@
+package com.easysubway.notice.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.easysubway.admin.audit.adapter.out.persistence.InMemoryAdminAuditEventRepository;
+import com.easysubway.admin.audit.domain.AdminAuditEvent;
+import com.easysubway.admin.audit.domain.AdminAuditEventType;
+import com.easysubway.notice.application.port.out.ServiceNoticeRepository;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@DisplayName("관리자 운행 공지 화면")
+class ServiceNoticeAdminPageControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+	@Autowired
+	private ServiceNoticeRepository repository;
+	@Autowired
+	private InMemoryAdminAuditEventRepository auditEventRepository;
+
+	@BeforeEach
+	void setUp() {
+		jdbcTemplate.update("DELETE FROM service_notice");
+	}
+
+	@Test
+	@DisplayName("운영 권한 관리자는 화면에서 공지를 발행하고 즉시 내린다")
+	void operationsManagerPublishesAndUnpublishesNotice() throws Exception {
+		String emptyPage = mockMvc.perform(get("/admin/notices/page")
+				.with(operationsManager()))
+			.andExpect(status().isOk())
+			.andReturn().getResponse().getContentAsString();
+		assertThat(emptyPage)
+			.contains("운행 공지")
+			.contains("name=\"commandToken\"")
+			.contains("공지 없음");
+
+		mockMvc.perform(post("/admin/notices/page")
+				.with(csrf())
+				.with(commandToken())
+				.with(operationsManager())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("scope", "LINE")
+				.param("scopeValue", "2")
+				.param("severity", "DISRUPTION")
+				.param("title", "2호선 지연")
+				.param("body", "강남-역삼 상행 지연입니다.")
+				.param("expiresAt", "2026-07-09T18:30"))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl("/admin/notices/page"));
+
+		var notices = repository.findActiveAt(LocalDateTime.now(ZoneOffset.UTC));
+		assertThat(notices).hasSize(1);
+		String noticeId = notices.get(0).id();
+		assertThat(auditRecorded("PUBLISH_NOTICE", noticeId)).isTrue();
+
+		String populatedPage = mockMvc.perform(get("/admin/notices/page")
+				.with(operationsManager()))
+			.andExpect(status().isOk())
+			.andReturn().getResponse().getContentAsString();
+		assertThat(populatedPage)
+			.contains("2호선 지연")
+			.contains("강남-역삼 상행 지연입니다.")
+			.contains("/admin/notices/" + noticeId + "/unpublish/page");
+
+		mockMvc.perform(post("/admin/notices/{id}/unpublish/page", noticeId)
+				.with(csrf())
+				.with(commandToken())
+				.with(operationsManager())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl("/admin/notices/page"));
+
+		assertThat(repository.findById(noticeId)).isEmpty();
+		assertThat(auditRecorded("UNPUBLISH_NOTICE", noticeId)).isTrue();
+	}
+
+	@Test
+	@DisplayName("운영 권한이 없으면 운행 공지 화면에 접근할 수 없다")
+	void pageRequiresOperationsManage() throws Exception {
+		mockMvc.perform(get("/admin/notices/page")
+				.with(user("viewer").authorities(new SimpleGrantedAuthority("admin.view"))))
+			.andExpect(status().isForbidden());
+	}
+
+	private RequestPostProcessor operationsManager() {
+		return user("operator").authorities(new SimpleGrantedAuthority("admin.operations.manage"));
+	}
+
+	private boolean auditRecorded(String action, String targetId) {
+		List<AdminAuditEvent> events =
+			auditEventRepository.findRecent(AdminAuditEventType.ADMIN_ACTION, 100);
+		return events.stream().anyMatch(event ->
+			"SERVICE_NOTICE".equals(event.targetType())
+				&& action.equals(event.action())
+				&& targetId.equals(event.targetId()));
+	}
+
+	private RequestPostProcessor commandToken() {
+		return request -> {
+			MockHttpSession session = (MockHttpSession) request.getSession();
+			request.addParameter("commandToken", commandTokenFrom(getAdminHtml(session)));
+			return request;
+		};
+	}
+
+	private String getAdminHtml(MockHttpSession session) {
+		try {
+			return mockMvc.perform(get("/admin/notices/page")
+					.session(session)
+					.with(operationsManager()))
+				.andReturn().getResponse().getContentAsString();
+		} catch (Exception exception) {
+			throw new IllegalStateException(exception);
+		}
+	}
+
+	private static String commandTokenFrom(String html) {
+		var matcher = Pattern.compile("name=\"commandToken\" value=\"([^\"]+)\"").matcher(html);
+		if (!matcher.find()) {
+			throw new IllegalStateException("commandToken missing");
+		}
+		return matcher.group(1);
+	}
+}

--- a/backend/src/test/java/com/easysubway/notice/application/service/ServiceNoticeServiceTest.java
+++ b/backend/src/test/java/com/easysubway/notice/application/service/ServiceNoticeServiceTest.java
@@ -12,6 +12,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -45,7 +46,10 @@ class ServiceNoticeServiceTest {
 
 		@Override
 		public List<ServiceNotice> findRecent(int limit) {
-			return stored.stream().limit(limit).toList();
+			return stored.stream()
+				.sorted(Comparator.comparing(ServiceNotice::publishedAt).reversed())
+				.limit(limit)
+				.toList();
 		}
 
 		@Override

--- a/backend/src/test/java/com/easysubway/notice/application/service/ServiceNoticeServiceTest.java
+++ b/backend/src/test/java/com/easysubway/notice/application/service/ServiceNoticeServiceTest.java
@@ -44,6 +44,11 @@ class ServiceNoticeServiceTest {
 		}
 
 		@Override
+		public List<ServiceNotice> findRecent(int limit) {
+			return stored.stream().limit(limit).toList();
+		}
+
+		@Override
 		public void deleteById(String id) {
 			stored.removeIf(n -> n.id().equals(id));
 		}


### PR DESCRIPTION
## 관련 이슈

Refs #1767

## 작업 배경

- 운행 공지 공개 API/모바일 표시 기반은 있으나, 운영자가 최근 공지 상태를 보고 발행·내리기를 수행하는 관리자 화면이 비어 있었다.

## 작업 내용

- 관리자 운행 공지 목록 화면과 controller를 추가했다.
- 최근 공지 조회용 repository 메서드를 추가했다.
- 관리자 권한, 발행·내리기, 감사 로그, command token 회귀 테스트를 보강했다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests '*ServiceNoticeAdminPageControllerTest'` 통과
  - `./gradlew test --tests '*ServiceNotice*'` 통과
  - `./gradlew test --tests '*AdminV3PageSmokeTest'` 통과
  - `git diff --check` 통과

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 관리자 공지 화면 렌더링 | Backend admin | `AdminV3PageSmokeTest` | 로컬 테스트 로그 | 통과 |
| 공지 발행·내리기 권한/감사 | Backend | `ServiceNoticeAdminPageControllerTest` | 로컬 테스트 로그 | 통과 |
| 앱 배너/오프라인 수동 QA | Mobile | 이번 PR 비범위, #1767 잔여 완료 조건 | 없음 | 후속 필요 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: backend deploy only

## 리뷰어 메모

- `ServiceNoticeAdminPageController`, `templates/admin/notices/list.html`, `JdbcServiceNoticeRepository.findRecent`를 먼저 보면 된다.

## 리스크

- 관리자 화면 추가만 포함한다. 모바일 배너 노출 녹화와 FCM topic push는 이 PR에서 닫지 않는다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 관리자용 운행 공지 관리 화면이 추가되었습니다.
  * 최근 공지 목록을 확인하고, 새 공지를 등록하거나 기존 공지를 즉시 내릴 수 있습니다.
  * 관리자 메뉴에 운행 공지 항목이 추가되었습니다.

* **Bug Fixes**
  * 공지 발행 상태와 내림 처리 결과가 화면과 저장소에 일관되게 반영됩니다.
  * 권한이 없는 사용자는 운행 공지 관리 화면에 접근할 수 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->