### PR TITLE
[Fix] 광고 공개 API 캐시 freshness 보정

### DIFF
--- a/backend/src/main/java/com/easysubway/ads/adapter/in/web/AdPublicController.java
+++ b/backend/src/main/java/com/easysubway/ads/adapter/in/web/AdPublicController.java
@@ -23,6 +23,7 @@ import org.springframework.web.server.ResponseStatusException;
 class AdPublicController {
 
 	private static final CacheControl AD_CACHE = CacheControl.maxAge(300, TimeUnit.SECONDS).cachePublic();
+	private static final CacheControl NO_AD_CACHE = CacheControl.noStore();
 
 	private final AdService service;
 
@@ -37,7 +38,7 @@ class AdPublicController {
 	) {
 		return service.activeCreative(placement)
 			.map(creative -> activeResponse(creative, webRequest))
-			.orElseGet(() -> ResponseEntity.noContent().cacheControl(AD_CACHE).build());
+			.orElseGet(() -> ResponseEntity.noContent().cacheControl(NO_AD_CACHE).build());
 	}
 
 	@PostMapping("/api/ads/events")
@@ -63,8 +64,15 @@ class AdPublicController {
 	}
 
 	private static String etagFor(AdResponse response, AdCreative creative) {
-		String fingerprint = response.placement() + "@" + response.creativeId()
-			+ "@" + creative.startsAt() + "~" + creative.endsAt();
+		String fingerprint = String.join("@",
+			response.placement(),
+			response.creativeId(),
+			response.imageUrl(),
+			response.landingUrl(),
+			response.advertiserName(),
+			response.altText(),
+			String.valueOf(creative.startsAt()),
+			String.valueOf(creative.endsAt()));
 		return "\"" + DigestUtils.md5DigestAsHex(fingerprint.getBytes(StandardCharsets.UTF_8)) + "\"";
 	}
 

--- a/backend/src/test/java/com/easysubway/ads/adapter/in/web/AdPublicControllerTest.java
+++ b/backend/src/test/java/com/easysubway/ads/adapter/in/web/AdPublicControllerTest.java
@@ -74,6 +74,41 @@ class AdPublicControllerTest {
 	}
 
 	@Test
+	@DisplayName("활성 소재가 없으면 무재고 응답을 저장하지 않는다")
+	void doesNotCacheNoActiveCreative() throws Exception {
+		mockMvc.perform(get("/api/ads/active")
+				.param("placement", "route-result-bottom"))
+			.andExpect(status().isNoContent())
+			.andExpect(header().string("Cache-Control", containsString("no-store")));
+	}
+
+	@Test
+	@DisplayName("소재 응답 필드가 바뀌면 같은 creative도 ETag가 바뀐다")
+	void changesEtagWhenCreativeContentChanges() throws Exception {
+		LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);
+		insertPlacement("route-result-bottom");
+		insertCreative("active", "route-result-bottom", now.minusHours(1), now.plusHours(1), true);
+
+		MvcResult first = mockMvc.perform(get("/api/ads/active")
+				.param("placement", "route-result-bottom"))
+			.andExpect(status().isOk())
+			.andReturn();
+
+		jdbcTemplate.update("""
+			UPDATE ad_creatives
+			SET image_url=?
+			WHERE id=?
+			""", "https://cdn.easysubway.example/ads/active-v2.png", "active");
+
+		mockMvc.perform(get("/api/ads/active")
+				.param("placement", "route-result-bottom")
+				.header("If-None-Match", first.getResponse().getHeader("ETag")))
+			.andExpect(status().isOk())
+			.andExpect(header().string("ETag", org.hamcrest.Matchers.not(first.getResponse().getHeader("ETag"))))
+			.andExpect(jsonPath("$.data.imageUrl").value("https://cdn.easysubway.example/ads/active-v2.png"));
+	}
+
+	@Test
 	@DisplayName("이벤트는 placement·creative·종류·일자 count만 집계한다")
 	void aggregatesAnonymousEventsByDay() throws Exception {
 		LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);


### PR DESCRIPTION
## 관련 이슈

close #1895

## 작업 배경

- #1893 병합 직후 Codex fallback 리뷰에서 광고 공개 API 캐시 freshness 지적 2건이 확인됐다.
- 무재고 204 응답이 일반 광고 TTL과 같은 5분 공개 캐시를 쓰면 신규 소재 반영이 지연될 수 있다.
- ETag가 응답 필드 전체를 포함하지 않아 같은 creative row의 소재 URL/랜딩/문구 변경이 stale 304로 남을 수 있다.

## 작업 내용

- `/api/ads/active` 무재고 204 응답을 `Cache-Control: no-store`로 분리했다.
- 광고 ETag fingerprint에 `imageUrl`, `landingUrl`, `advertiserName`, `altText`까지 포함했다.
- 무재고 캐시와 소재 필드 변경 ETag 회귀 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --rerun-tasks --tests com.easysubway.ads.adapter.in.web.AdPublicControllerTest` → BUILD SUCCESSFUL
  - `node --test tools/ci/repository-contract.test.mjs` → 169 pass, 0 fail
  - `git diff --check origin/main...HEAD` → 통과

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 광고 공개 API 캐시 회귀 | backend API | `AdPublicControllerTest` | 터미널 출력: BUILD SUCCESSFUL | 통과 |
| 저장소 계약 | repository | `node --test tools/ci/repository-contract.test.mjs` | 터미널 출력: 169 pass, 0 fail | 통과 |
| whitespace | repository | `git diff --check origin/main...HEAD` | 출력 없음 | 통과 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 광고 공개 API 캐시 헤더/ETag 동작 보정

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `AdPublicController`의 무재고 `no-store`, ETag fingerprint 필드 목록, `AdPublicControllerTest`의 두 회귀 테스트.

## 리스크

- 캐시 TTL을 없앤 범위는 활성 소재가 없는 204 응답뿐이라 정상 광고 소재 응답의 5분 public cache는 유지된다.
- ETag 입력 필드가 늘어 소재 변경 freshness는 개선되지만, 같은 필드 값이면 기존 304 동작은 유지된다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰 상태를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (PR 단계 CD 실행 없음, merge 후 post-merge 상태 확인 예정)
