### PR TITLE
[Mobile] 하차 알림 예정시각 보존 및 foreground 재예약

### DIFF
--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'accessible_design.dart';
@@ -1945,6 +1946,8 @@ class RouteSearchStep {
     required String title,
     required String lineName,
     required String actionDetail,
+    String? plannedArrivalTimeIso,
+    String? realtimeArrivalTimeIso,
   }) {
     return RouteSearchStep(
       sequence: sequence,
@@ -1967,6 +1970,10 @@ class RouteSearchStep {
       timeSource: timeSource,
       distanceSource: distanceSource,
       confidenceLabel: confidenceLabel,
+      plannedArrivalTimeIso:
+          plannedArrivalTimeIso ?? this.plannedArrivalTimeIso,
+      realtimeArrivalTimeIso:
+          realtimeArrivalTimeIso ?? this.realtimeArrivalTimeIso,
     );
   }
 
@@ -2304,10 +2311,14 @@ class RouteSearchController extends ChangeNotifier {
       if (staleRefresh()) {
         return;
       }
+      final refreshedResult = _preserveGetOffAlarmArrivalTimes(
+        next: refreshed.result,
+        previous: currentResult,
+      );
       _emitState(
         RouteSearchState(
           status: RouteSearchViewStatus.success,
-          result: refreshed.result,
+          result: refreshedResult,
           refreshMessage: refreshed.userMessage,
         ),
       );
@@ -2438,7 +2449,42 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.resumed) {
-      _controller.refreshCurrentRoute();
+      unawaited(_refreshCurrentRouteAndAlarm());
+    }
+  }
+
+  Future<void> _refreshCurrentRouteAndAlarm() async {
+    await _controller.refreshCurrentRoute();
+    final getOffAlarmController = widget.getOffAlarmController;
+    final result = _controller.state.result;
+    if (getOffAlarmController == null || result == null) {
+      return;
+    }
+    final rideLegs = _rideLegArrivalsFromResult(result);
+    if (rideLegs.isEmpty) {
+      return;
+    }
+    try {
+      await getOffAlarmController.refresh(
+        stops: getOffAlarmStopsFromRideLegs(
+          rideLegs: rideLegs,
+          stationName: (id) => id,
+        ),
+        transferAlarmEnabled: true,
+      );
+      if (kDebugMode && getOffAlarmController.state.enabled) {
+        debugPrint(
+          'get_off_alarm foreground_refresh '
+          'scheduled_count=${getOffAlarmController.state.scheduledCount} '
+          'mode=${getOffAlarmController.state.scheduleMode?.name ?? 'unknown'}',
+        );
+      }
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '하차 알림 foreground 재예약 중 예외가 발생했습니다.',
+      );
     }
   }
 
@@ -4082,18 +4128,7 @@ class _GetOffAlarmEntryPoint extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final rideLegs = <RideLegArrival>[];
-    for (final step in result.steps) {
-      if (step.stepType == 'ride' && step.plannedArrivalTimeIso.isNotEmpty) {
-        rideLegs.add(
-          RideLegArrival(
-            toStationId: step.toStationId,
-            plannedArrivalIso: step.plannedArrivalTimeIso,
-            realtimeArrivalIso: step.realtimeArrivalTimeIso,
-          ),
-        );
-      }
-    }
+    final rideLegs = _rideLegArrivalsFromResult(result);
     if (rideLegs.isEmpty) {
       return const SizedBox.shrink();
     }
@@ -4107,6 +4142,81 @@ class _GetOffAlarmEntryPoint extends StatelessWidget {
       ),
     );
   }
+}
+
+List<RideLegArrival> _rideLegArrivalsFromResult(RouteSearchResult result) {
+  final rideLegs = <RideLegArrival>[];
+  for (final step in result.steps) {
+    if (step.stepType == 'ride' && step.plannedArrivalTimeIso.isNotEmpty) {
+      rideLegs.add(
+        RideLegArrival(
+          toStationId: step.toStationId,
+          plannedArrivalIso: step.plannedArrivalTimeIso,
+          realtimeArrivalIso: step.realtimeArrivalTimeIso,
+        ),
+      );
+    }
+  }
+  return rideLegs;
+}
+
+RouteSearchResult _preserveGetOffAlarmArrivalTimes({
+  required RouteSearchResult next,
+  required RouteSearchResult previous,
+}) {
+  if (_rideLegArrivalsFromResult(next).isNotEmpty ||
+      _rideLegArrivalsFromResult(previous).isEmpty) {
+    return next;
+  }
+  final previousRideSteps = previous.steps
+      .where(
+        (step) =>
+            step.stepType == 'ride' && step.plannedArrivalTimeIso.isNotEmpty,
+      )
+      .toList(growable: false);
+  var rideIndex = 0;
+  final steps = next.steps
+      .map((step) {
+        if (step.stepType != 'ride' || step.plannedArrivalTimeIso.isNotEmpty) {
+          return step;
+        }
+        final matched = _matchingPreviousRideStep(
+          step: step,
+          previousRideSteps: previousRideSteps,
+          fallbackIndex: rideIndex,
+        );
+        rideIndex += 1;
+        if (matched == null) {
+          return step;
+        }
+        return step.withDisplayLabels(
+          title: step.title,
+          lineName: step.lineName,
+          actionDetail: step.actionDetail,
+          plannedArrivalTimeIso: matched.plannedArrivalTimeIso,
+          realtimeArrivalTimeIso: matched.realtimeArrivalTimeIso,
+        );
+      })
+      .toList(growable: false);
+  return next.withDisplayLabels(steps: steps);
+}
+
+RouteSearchStep? _matchingPreviousRideStep({
+  required RouteSearchStep step,
+  required List<RouteSearchStep> previousRideSteps,
+  required int fallbackIndex,
+}) {
+  for (final previousStep in previousRideSteps) {
+    if (previousStep.fromStationId == step.fromStationId &&
+        previousStep.toStationId == step.toStationId &&
+        previousStep.lineId == step.lineId) {
+      return previousStep;
+    }
+  }
+  if (fallbackIndex < previousRideSteps.length) {
+    return previousRideSteps[fallbackIndex];
+  }
+  return null;
 }
 
 class _RouteResultsListView extends StatelessWidget {

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -2455,6 +2455,9 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
 
   Future<void> _refreshCurrentRouteAndAlarm() async {
     await _controller.refreshCurrentRoute();
+    if (!mounted) {
+      return;
+    }
     final getOffAlarmController = widget.getOffAlarmController;
     final result = _controller.state.result;
     if (getOffAlarmController == null || result == null) {
@@ -2465,12 +2468,17 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
       return;
     }
     try {
+      final activeSubscription = await getOffAlarmController.repository
+          .loadActive();
+      if (!mounted) {
+        return;
+      }
       await getOffAlarmController.refresh(
         stops: getOffAlarmStopsFromRideLegs(
           rideLegs: rideLegs,
           stationName: (id) => id,
         ),
-        transferAlarmEnabled: true,
+        transferAlarmEnabled: activeSubscription?.transferAlarmEnabled ?? true,
       );
       if (kDebugMode && getOffAlarmController.state.enabled) {
         debugPrint(
@@ -4164,8 +4172,7 @@ RouteSearchResult _preserveGetOffAlarmArrivalTimes({
   required RouteSearchResult next,
   required RouteSearchResult previous,
 }) {
-  if (_rideLegArrivalsFromResult(next).isNotEmpty ||
-      _rideLegArrivalsFromResult(previous).isEmpty) {
+  if (_rideLegArrivalsFromResult(previous).isEmpty) {
     return next;
   }
   final previousRideSteps = previous.steps
@@ -4174,7 +4181,7 @@ RouteSearchResult _preserveGetOffAlarmArrivalTimes({
             step.stepType == 'ride' && step.plannedArrivalTimeIso.isNotEmpty,
       )
       .toList(growable: false);
-  var rideIndex = 0;
+  var changed = false;
   final steps = next.steps
       .map((step) {
         if (step.stepType != 'ride' || step.plannedArrivalTimeIso.isNotEmpty) {
@@ -4183,12 +4190,11 @@ RouteSearchResult _preserveGetOffAlarmArrivalTimes({
         final matched = _matchingPreviousRideStep(
           step: step,
           previousRideSteps: previousRideSteps,
-          fallbackIndex: rideIndex,
         );
-        rideIndex += 1;
         if (matched == null) {
           return step;
         }
+        changed = true;
         return step.withDisplayLabels(
           title: step.title,
           lineName: step.lineName,
@@ -4198,13 +4204,15 @@ RouteSearchResult _preserveGetOffAlarmArrivalTimes({
         );
       })
       .toList(growable: false);
+  if (!changed) {
+    return next;
+  }
   return next.withDisplayLabels(steps: steps);
 }
 
 RouteSearchStep? _matchingPreviousRideStep({
   required RouteSearchStep step,
   required List<RouteSearchStep> previousRideSteps,
-  required int fallbackIndex,
 }) {
   for (final previousStep in previousRideSteps) {
     if (previousStep.fromStationId == step.fromStationId &&
@@ -4212,9 +4220,6 @@ RouteSearchStep? _matchingPreviousRideStep({
         previousStep.lineId == step.lineId) {
       return previousStep;
     }
-  }
-  if (fallbackIndex < previousRideSteps.length) {
-    return previousRideSteps[fallbackIndex];
   }
   return null;
 }

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -103,6 +103,14 @@ void main() {
       expect(result.steps.first.actionTitle, isEmpty);
       expect(result.steps.first.actionDetail, '상록수 승강장 접근 동선을 확인합니다.');
       expect(result.steps.last.title, isNot(contains('station-')));
+      expect(
+        result.steps.last.plannedArrivalTimeIso,
+        '2026-07-01T09:15:00+09:00',
+      );
+      expect(
+        result.steps.last.realtimeArrivalTimeIso,
+        '2026-07-01T09:13:00+09:00',
+      );
       expect(result.etaSource, 'REALTIME');
       expect(result.isLocalResult, isFalse);
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -9415,11 +9415,14 @@ void main() {
 
   testWidgets('foreground 복귀는 활성 하차 알림을 현재 경로 시간으로 재예약한다', (tester) async {
     final notifier = _RecordingGetOffAlarmNotifier();
+    final now = DateTime.parse('2026-07-06T09:00:00+09:00');
+    final arrivalAt = DateTime.parse('2026-07-06T09:37:30+09:00');
+    final fireAt = DateTime.parse('2026-07-06T09:35:30+09:00');
     final controller = GetOffAlarmController(
       notifier: notifier,
       permissionGate: _StubExactAlarmPermissionGate(),
       repository: _MemoryGetOffAlarmStateRepository(),
-      now: () => DateTime(2026, 7, 6, 9, 0),
+      now: () => now,
     );
     addTearDown(controller.dispose);
     final repository = FakeRouteSearchRepository(
@@ -9501,7 +9504,7 @@ void main() {
         GetOffAlarmStop(
           stationId: 'station-sadang',
           stationName: '사당',
-          arrivalAt: DateTime(2026, 7, 6, 9, 37, 30),
+          arrivalAt: arrivalAt,
           kind: GetOffAlarmKind.destination,
         ),
       ],
@@ -9518,8 +9521,8 @@ void main() {
     expect(notifier.scheduleCalls, 1);
     expect(notifier.scheduledMode, GetOffAlarmScheduleMode.exact);
     expect(
-      notifier.scheduledAlarms.single.fireAt.toIso8601String(),
-      contains('2026-07-06T09:35:30'),
+      notifier.scheduledAlarms.single.fireAt.isAtSameMomentAs(fireAt),
+      isTrue,
     );
   });
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -9416,12 +9416,14 @@ void main() {
   testWidgets('foreground 복귀는 활성 하차 알림을 현재 경로 시간으로 재예약한다', (tester) async {
     final notifier = _RecordingGetOffAlarmNotifier();
     final now = DateTime.parse('2026-07-06T09:00:00+09:00');
+    final transferArrivalAt = DateTime.parse('2026-07-06T09:20:00+09:00');
     final arrivalAt = DateTime.parse('2026-07-06T09:37:30+09:00');
     final fireAt = DateTime.parse('2026-07-06T09:35:30+09:00');
+    final stateRepository = _MemoryGetOffAlarmStateRepository();
     final controller = GetOffAlarmController(
       notifier: notifier,
       permissionGate: _StubExactAlarmPermissionGate(),
-      repository: _MemoryGetOffAlarmStateRepository(),
+      repository: stateRepository,
       now: () => now,
     );
     addTearDown(controller.dispose);
@@ -9431,14 +9433,29 @@ void main() {
           RouteSearchStep(
             sequence: 1,
             stepType: 'ride',
-            title: '상록수에서 사당까지 이동',
+            title: '상록수에서 금정까지 이동',
             description: '열차를 이용해 이동합니다.',
             lineId: 'seoul-4',
             lineName: '수도권 4호선',
             fromStationId: 'station-sangnoksu',
+            toStationId: 'station-geumjeong',
+            estimatedMinutes: 15,
+            distanceMeters: 6300,
+            includesStairs: false,
+            requiresAccessibilityCheck: true,
+            plannedArrivalTimeIso: '2026-07-06T09:20:00+09:00',
+          ),
+          RouteSearchStep(
+            sequence: 2,
+            stepType: 'ride',
+            title: '금정에서 사당까지 이동',
+            description: '열차를 이용해 이동합니다.',
+            lineId: 'seoul-4',
+            lineName: '수도권 4호선',
+            fromStationId: 'station-geumjeong',
             toStationId: 'station-sadang',
-            estimatedMinutes: 32,
-            distanceMeters: 13500,
+            estimatedMinutes: 17,
+            distanceMeters: 7200,
             includesStairs: false,
             requiresAccessibilityCheck: true,
             plannedArrivalTimeIso: '2026-07-06T09:37:30+09:00',
@@ -9455,14 +9472,29 @@ void main() {
           RouteSearchStep(
             sequence: 1,
             stepType: 'ride',
-            title: '수도권 4호선으로 사당역까지 이동',
+            title: '수도권 4호선으로 금정역까지 이동',
             description: '열차를 이용해 이동합니다.',
             lineId: 'seoul-4',
             lineName: '수도권 4호선',
             fromStationId: 'station-sangnoksu',
+            toStationId: 'station-geumjeong',
+            estimatedMinutes: 15,
+            distanceMeters: 6300,
+            includesStairs: false,
+            requiresAccessibilityCheck: true,
+            plannedArrivalTimeIso: '2026-07-06T09:20:00+09:00',
+          ),
+          RouteSearchStep(
+            sequence: 2,
+            stepType: 'ride',
+            title: '수도권 4호선으로 사당역까지 이동',
+            description: '열차를 이용해 이동합니다.',
+            lineId: 'seoul-4',
+            lineName: '수도권 4호선',
+            fromStationId: 'station-geumjeong',
             toStationId: 'station-sadang',
-            estimatedMinutes: 30,
-            distanceMeters: 13500,
+            estimatedMinutes: 17,
+            distanceMeters: 7200,
             includesStairs: false,
             requiresAccessibilityCheck: true,
           ),
@@ -9502,13 +9534,19 @@ void main() {
       routeId: 'route-1',
       stops: [
         GetOffAlarmStop(
+          stationId: 'station-geumjeong',
+          stationName: '금정',
+          arrivalAt: transferArrivalAt,
+          kind: GetOffAlarmKind.transfer,
+        ),
+        GetOffAlarmStop(
           stationId: 'station-sadang',
           stationName: '사당',
           arrivalAt: arrivalAt,
           kind: GetOffAlarmKind.destination,
         ),
       ],
-      transferAlarmEnabled: true,
+      transferAlarmEnabled: false,
     );
     notifier.reset();
 
@@ -9520,10 +9558,12 @@ void main() {
     expect(repository.refreshRouteSearchIds, ['route-1']);
     expect(notifier.scheduleCalls, 1);
     expect(notifier.scheduledMode, GetOffAlarmScheduleMode.exact);
+    expect(notifier.scheduledAlarms.single.stationId, 'station-sadang');
     expect(
       notifier.scheduledAlarms.single.fireAt.isAtSameMomentAs(fireAt),
       isTrue,
     );
+    expect((await stateRepository.loadActive())?.transferAlarmEnabled, isFalse);
   });
 
   testWidgets('추천 경로 항목은 스크린리더에서 상세 진입 버튼으로 남는다', (tester) async {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -9,6 +9,13 @@ import 'package:easysubway_mobile/main.dart';
 import 'package:easysubway_mobile/facility_report.dart';
 import 'package:easysubway_mobile/favorite_facility.dart';
 import 'package:easysubway_mobile/core/external/kakao_map_launcher.dart';
+import 'package:easysubway_mobile/features/get_off_alarm/data/get_off_alarm_state_repository.dart';
+import 'package:easysubway_mobile/features/get_off_alarm/exact_alarm_permission.dart';
+import 'package:easysubway_mobile/features/get_off_alarm/get_off_alarm_controller.dart';
+import 'package:easysubway_mobile/features/get_off_alarm/get_off_alarm_notifier.dart';
+import 'package:easysubway_mobile/features/get_off_alarm/get_off_alarm_schedule_mode.dart';
+import 'package:easysubway_mobile/features/get_off_alarm/get_off_alarm_scheduler.dart';
+import 'package:easysubway_mobile/features/get_off_alarm/get_off_alarm_subscription.dart';
 import 'package:easysubway_mobile/features/network_map/domain/map_camera.dart';
 import 'package:easysubway_mobile/features/realtime/realtime_repository.dart';
 import 'package:easysubway_mobile/features/route_draft/application/route_draft_controller.dart';
@@ -9333,6 +9340,189 @@ void main() {
     expect(find.textContaining('시간표'), findsNothing);
   });
 
+  testWidgets('planned 승차 시간이 있는 경로 결과는 하차 알림 토글을 보여준다', (tester) async {
+    final controller = GetOffAlarmController(
+      notifier: _RecordingGetOffAlarmNotifier(),
+      permissionGate: _StubExactAlarmPermissionGate(),
+      repository: _MemoryGetOffAlarmStateRepository(),
+      now: () => DateTime(2026, 7, 6, 9, 0),
+    );
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RouteSearchScreen(
+          repository: FakeRouteSearchRepository(
+            result: _sampleRouteSearchResult(
+              steps: const [
+                RouteSearchStep(
+                  sequence: 1,
+                  stepType: 'entry',
+                  title: '상록수 승강장 접근',
+                  description: '승강장까지 이동합니다.',
+                  lineId: 'seoul-4',
+                  lineName: '수도권 4호선',
+                  fromStationId: 'station-sangnoksu',
+                  toStationId: 'station-sangnoksu',
+                  estimatedMinutes: 6,
+                  distanceMeters: 180,
+                  includesStairs: false,
+                  requiresAccessibilityCheck: true,
+                ),
+                RouteSearchStep(
+                  sequence: 2,
+                  stepType: 'ride',
+                  title: '상록수에서 사당까지 이동',
+                  description: '열차를 이용해 이동합니다.',
+                  lineId: 'seoul-4',
+                  lineName: '수도권 4호선',
+                  fromStationId: 'station-sangnoksu',
+                  toStationId: 'station-sadang',
+                  estimatedMinutes: 32,
+                  distanceMeters: 13500,
+                  includesStairs: false,
+                  requiresAccessibilityCheck: true,
+                  plannedArrivalTimeIso: '2026-07-06T09:37:30+09:00',
+                ),
+              ],
+              etaSource: 'STATIC_BACKEND_ESTIMATE',
+            ),
+          ),
+          stationRepository: FakeStationSearchRepository(),
+          getOffAlarmController: controller,
+          initialMobilityType: 'SENIOR',
+          initialDraft: RouteDraft(
+            origin: const RouteDraftStation(
+              id: 'station-sangnoksu',
+              nameKo: '상록수',
+            ),
+            destination: const RouteDraftStation(
+              id: 'station-sadang',
+              nameKo: '사당',
+            ),
+            lastModifiedAt: DateTime(2026, 7, 6),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('하차 알림'), findsOneWidget);
+    expect(find.text('폰을 보지 않아도 내릴 때 알려드려요.'), findsOneWidget);
+  });
+
+  testWidgets('foreground 복귀는 활성 하차 알림을 현재 경로 시간으로 재예약한다', (tester) async {
+    final notifier = _RecordingGetOffAlarmNotifier();
+    final controller = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: _StubExactAlarmPermissionGate(),
+      repository: _MemoryGetOffAlarmStateRepository(),
+      now: () => DateTime(2026, 7, 6, 9, 0),
+    );
+    addTearDown(controller.dispose);
+    final repository = FakeRouteSearchRepository(
+      result: _sampleRouteSearchResult(
+        steps: const [
+          RouteSearchStep(
+            sequence: 1,
+            stepType: 'ride',
+            title: '상록수에서 사당까지 이동',
+            description: '열차를 이용해 이동합니다.',
+            lineId: 'seoul-4',
+            lineName: '수도권 4호선',
+            fromStationId: 'station-sangnoksu',
+            toStationId: 'station-sadang',
+            estimatedMinutes: 32,
+            distanceMeters: 13500,
+            includesStairs: false,
+            requiresAccessibilityCheck: true,
+            plannedArrivalTimeIso: '2026-07-06T09:37:30+09:00',
+          ),
+        ],
+        etaSource: 'STATIC_BACKEND_ESTIMATE',
+      ),
+    );
+    repository.refreshResult = RouteRefreshResult(
+      routeSearchId: 'route-1',
+      status: 'UNCHANGED',
+      result: _sampleRouteSearchResult(
+        steps: const [
+          RouteSearchStep(
+            sequence: 1,
+            stepType: 'ride',
+            title: '수도권 4호선으로 사당역까지 이동',
+            description: '열차를 이용해 이동합니다.',
+            lineId: 'seoul-4',
+            lineName: '수도권 4호선',
+            fromStationId: 'station-sangnoksu',
+            toStationId: 'station-sadang',
+            estimatedMinutes: 30,
+            distanceMeters: 13500,
+            includesStairs: false,
+            requiresAccessibilityCheck: true,
+          ),
+        ],
+        etaSource: 'STATIC_BACKEND_ESTIMATE',
+      ),
+      refreshedAt: '2026-07-06T09:01:00+09:00',
+      etaSource: 'STATIC_BACKEND_ESTIMATE',
+      etaConfidence: 'LOW',
+      sourceLabel: '상수 추정 기준',
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RouteSearchScreen(
+          repository: repository,
+          stationRepository: FakeStationSearchRepository(),
+          getOffAlarmController: controller,
+          initialDraft: RouteDraft(
+            origin: const RouteDraftStation(
+              id: 'station-sangnoksu',
+              nameKo: '상록수',
+            ),
+            destination: const RouteDraftStation(
+              id: 'station-sadang',
+              nameKo: '사당',
+            ),
+            lastModifiedAt: DateTime(2026, 7, 6),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
+    await tester.pumpAndSettle();
+    await controller.enable(
+      routeId: 'route-1',
+      stops: [
+        GetOffAlarmStop(
+          stationId: 'station-sadang',
+          stationName: '사당',
+          arrivalAt: DateTime(2026, 7, 6, 9, 37, 30),
+          kind: GetOffAlarmKind.destination,
+        ),
+      ],
+      transferAlarmEnabled: true,
+    );
+    notifier.reset();
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+    await tester.pump();
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pumpAndSettle();
+
+    expect(repository.refreshRouteSearchIds, ['route-1']);
+    expect(notifier.scheduleCalls, 1);
+    expect(notifier.scheduledMode, GetOffAlarmScheduleMode.exact);
+    expect(
+      notifier.scheduledAlarms.single.fireAt.toIso8601String(),
+      contains('2026-07-06T09:35:30'),
+    );
+  });
+
   testWidgets('추천 경로 항목은 스크린리더에서 상세 진입 버튼으로 남는다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
     try {
@@ -12363,6 +12553,8 @@ class FakeRouteSearchRepository implements RouteSearchRepository {
   final RouteSearchResult result;
   final Object? error;
   final requests = <RouteSearchRequest>[];
+  final refreshRouteSearchIds = <String>[];
+  RouteRefreshResult? refreshResult;
 
   @override
   Future<RouteSearchResult> searchRoute(RouteSearchRequest request) async {
@@ -12376,15 +12568,65 @@ class FakeRouteSearchRepository implements RouteSearchRepository {
 
   @override
   Future<RouteRefreshResult> refreshRoute(String routeSearchId) async {
-    return RouteRefreshResult(
-      routeSearchId: routeSearchId,
-      status: 'UNCHANGED',
-      result: result,
-      refreshedAt: '2026-07-01T15:30:00',
-      etaSource: 'PLANNED',
-      etaConfidence: 'MEDIUM',
-      sourceLabel: '계획 시간 기준',
-    );
+    refreshRouteSearchIds.add(routeSearchId);
+    return refreshResult ??
+        RouteRefreshResult(
+          routeSearchId: routeSearchId,
+          status: 'UNCHANGED',
+          result: result,
+          refreshedAt: '2026-07-01T15:30:00',
+          etaSource: 'PLANNED',
+          etaConfidence: 'MEDIUM',
+          sourceLabel: '계획 시간 기준',
+        );
+  }
+}
+
+class _RecordingGetOffAlarmNotifier implements GetOffAlarmNotifier {
+  int scheduleCalls = 0;
+  List<ScheduledGetOffAlarm> scheduledAlarms = const [];
+  GetOffAlarmScheduleMode? scheduledMode;
+
+  void reset() {
+    scheduleCalls = 0;
+    scheduledAlarms = const [];
+    scheduledMode = null;
+  }
+
+  @override
+  Future<void> cancelAll() async {}
+
+  @override
+  Future<void> scheduleAlarms(
+    List<ScheduledGetOffAlarm> alarms, {
+    required GetOffAlarmScheduleMode mode,
+  }) async {
+    scheduleCalls += 1;
+    scheduledAlarms = alarms;
+    scheduledMode = mode;
+  }
+}
+
+class _StubExactAlarmPermissionGate implements ExactAlarmPermissionGate {
+  @override
+  Future<bool> isExactAlarmPermitted() async => true;
+
+  @override
+  Future<bool> requestExactAlarmPermission() async => true;
+}
+
+class _MemoryGetOffAlarmStateRepository implements GetOffAlarmStateRepository {
+  GetOffAlarmSubscription? _active;
+
+  @override
+  Future<void> clearActive() async => _active = null;
+
+  @override
+  Future<GetOffAlarmSubscription?> loadActive() async => _active;
+
+  @override
+  Future<void> saveActive(GetOffAlarmSubscription subscription) async {
+    _active = subscription;
   }
 }
 


### PR DESCRIPTION
## 관련 이슈

Refs #1766

## 작업 배경

#1766 하차 알림 QA evidence 수집 중 online-first V2 경로 결과에는 `plannedArrivalTime`이 있었지만, 모바일 표시 라벨 변환과 foreground refresh 이후 경로 상태에서 해당 시간이 빠져 하차 알림 토글/재예약 증거가 불안정했습니다.

이 PR은 #1766의 일부 evidence blocker를 줄이는 모바일 보존/재예약 수정입니다. 실기기 백그라운드 2분 전 알림 녹화는 아직 없으므로 #1766은 닫지 않습니다.

## 작업 내용

- V2 backend itinerary의 ride leg `plannedArrivalTime`/`realtimeArrivalTime`을 `RouteSearchStep.withDisplayLabels()` 이후에도 보존했습니다.
- foreground 복귀 시 현재 경로를 refresh한 뒤 활성 하차 알림을 현재 경로 시간으로 재예약하도록 연결했습니다.
- refresh 응답이 예정시각을 누락해도 기존 ride leg와 같은 구간이면 하차 알림용 예정시각을 유지하도록 최소 보존 로직을 추가했습니다.
- 하차 알림 토글 노출, foreground 재예약, online-first 예정시각 보존 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `dart format --set-exit-if-changed apps/mobile/lib/route_search.dart apps/mobile/test/widget_test.dart apps/mobile/test/features/routes/local_route_repository_test.dart` → 통과, 0 changed
  - `/Volumes/MACSSD/Android/flutter/flutter/bin/flutter analyze` → 통과, No issues found
  - `/Volumes/MACSSD/Android/flutter/flutter/bin/flutter test test/widget_test.dart --plain-name 'planned 승차 시간이 있는 경로 결과는 하차 알림 토글을 보여준다'` → 통과
  - `/Volumes/MACSSD/Android/flutter/flutter/bin/flutter test test/widget_test.dart --plain-name 'foreground 복귀는 활성 하차 알림을 현재 경로 시간으로 재예약한다'` → 통과
  - `env TZ=UTC /Volumes/MACSSD/Android/flutter/flutter/bin/flutter test test/widget_test.dart --plain-name 'foreground 복귀는 활성 하차 알림을 현재 경로 시간으로 재예약한다'` → 통과
  - `/Volumes/MACSSD/Android/flutter/flutter/bin/flutter test test/features/routes/local_route_repository_test.dart --plain-name 'online-first repository는 flag가 켜지면 V2 backend itinerary를 우선 사용한다'` → 통과
  - `env TZ=UTC /Volumes/MACSSD/Android/flutter/flutter/bin/flutter test` → 통과, All tests passed
  - `/Volumes/MACSSD/Android/flutter/flutter/bin/flutter build apk --debug --dart-define=EASYSUBWAY_API_BASE_URL=http://10.0.2.2:18080 --dart-define=EASYSUBWAY_ROUTE_V2_ONLINE_FIRST_ENABLED=true` → 통과, `build/app/outputs/flutter-apk/app-debug.apk` 생성
  - `git diff --check` → 통과

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| V2 예정시각 경로의 하차 알림 토글 노출 | Android emulator | 상록수→사당 경로 검색 후 route screen 확인 | `.codex/evidence/1766-get-off-alarm-20260710/head-latest-toggle.png`, `.codex/evidence/1766-get-off-alarm-20260710/head-latest-toggle-ui.xml` | 통과 |
| 하차 알림 toggle on 상태 | Android emulator | 하차 알림 switch 활성화 | `.codex/evidence/1766-get-off-alarm-20260710/head-latest-toggle-on.png`, `.codex/evidence/1766-get-off-alarm-20260710/head-latest-toggle-on-ui.xml` | 통과 |
| foreground 복귀 후 토글 유지 | Android emulator | Home→앱 복귀 후 refresh 및 스크롤로 토글 확인 | `.codex/evidence/1766-get-off-alarm-20260710/head-latest-after-foreground-toggle-visible.png`, `.codex/evidence/1766-get-off-alarm-20260710/head-latest-after-foreground-toggle-visible-ui.xml` | 통과 |
| foreground 재예약 로그 | Android emulator | logcat에서 debug 로그 확인 | `.codex/evidence/1766-get-off-alarm-20260710/head-latest-foreground-logcat.txt` | `scheduled_count=1 mode=exact` 확인 |
| 실기기 백그라운드 2분 전 알림 | Android physical device | 아직 미수행 | 없음 | #1766 잔여 blocker, close 금지 |

## Version impact

- [ ] no version change
- [x] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `apps/mobile/lib/route_search.dart`의 `RouteSearchStep.withDisplayLabels()` 예정시각 보존
  - `RouteSearchScreen.didChangeAppLifecycleState()` foreground 재예약 연결
  - `_preserveGetOffAlarmArrivalTimes()`의 refresh 응답 예정시각 보존 조건

## 리스크

- 실기기 백그라운드 상태에서 도착 2분 전 알림이 실제 노출되는지는 이 PR로 증명하지 않습니다.
- canonical station ID 기반 production route evidence는 #1415 정렬 blocker 영향이 남아 있습니다.
- debug 로그는 `kDebugMode`에서만 출력됩니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
