### PR TITLE
[Mobile] 하차 알림 운영 경로·권한 재조정 보강 (#1766)

### DIFF
--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -36,6 +36,9 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <receiver
+            android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationReceiver"
+            android:exported="false" />
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/apps/mobile/android/app/src/main/kotlin/com/easysubway/easysubway_mobile/MainActivity.kt
+++ b/apps/mobile/android/app/src/main/kotlin/com/easysubway/easysubway_mobile/MainActivity.kt
@@ -46,6 +46,7 @@ class MainActivity : FlutterActivity() {
             .setMethodCallHandler { call, result ->
                 when (call.method) {
                     "requestNotificationPermission" -> requestNotificationPermission(result)
+                    "notificationPermissionStatus" -> result.success(hasNotificationPermission() && areAppNotificationsEnabled())
                     else -> result.notImplemented()
                 }
             }

--- a/apps/mobile/lib/app/app_bootstrap.dart
+++ b/apps/mobile/lib/app/app_bootstrap.dart
@@ -203,11 +203,13 @@ class AppBootstrapLifecycle extends StatefulWidget {
     required this.close,
     required this.child,
     this.resumeDataPackUpdate,
+    this.resumeGetOffAlarmState,
     super.key,
   });
 
   final Future<void> Function() close;
   final Future<void> Function()? resumeDataPackUpdate;
+  final Future<void> Function()? resumeGetOffAlarmState;
   final Widget child;
 
   @override
@@ -228,6 +230,10 @@ class _AppBootstrapLifecycleState extends State<AppBootstrapLifecycle>
       final resumeDataPackUpdate = widget.resumeDataPackUpdate;
       if (resumeDataPackUpdate != null) {
         unawaited(resumeDataPackUpdate());
+      }
+      final resumeGetOffAlarmState = widget.resumeGetOffAlarmState;
+      if (resumeGetOffAlarmState != null) {
+        unawaited(resumeGetOffAlarmState());
       }
     }
   }

--- a/apps/mobile/lib/app/app_dependencies.dart
+++ b/apps/mobile/lib/app/app_dependencies.dart
@@ -243,7 +243,10 @@ class AppDependencies {
             authProvider: null,
             userDatabase: userDatabase,
           ),
-      getOffAlarmController: _resolveGetOffAlarmController(userDatabase),
+      getOffAlarmController: _resolveGetOffAlarmController(
+        userDatabase,
+        resolvedNotificationPermissionProvider,
+      ),
       noticeRepository:
           noticeRepository ??
           (userDatabase == null
@@ -368,6 +371,7 @@ class _UnavailableNetworkMapRepository implements NetworkMapRepository {
 
 GetOffAlarmController? _resolveGetOffAlarmController(
   UserDatabase? userDatabase,
+  NotificationPermissionProvider? notificationPermissionProvider,
 ) {
   if (userDatabase == null) {
     return null;
@@ -376,6 +380,9 @@ GetOffAlarmController? _resolveGetOffAlarmController(
   return GetOffAlarmController(
     notifier: LocalGetOffAlarmNotifier(plugin),
     permissionGate: PluginExactAlarmPermissionGate(plugin),
+    notificationPermissionProvider:
+        notificationPermissionProvider ??
+        MethodChannelNotificationPermissionProvider(),
     repository: DriftGetOffAlarmStateRepository(userDatabase: userDatabase),
   );
 }

--- a/apps/mobile/lib/features/get_off_alarm/get_off_alarm_controller.dart
+++ b/apps/mobile/lib/features/get_off_alarm/get_off_alarm_controller.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 
+import '../../mobile_error_reporter.dart';
 import '../../notification_settings.dart';
 import 'data/get_off_alarm_state_repository.dart';
 import 'exact_alarm_permission.dart';
@@ -67,9 +68,12 @@ class GetOffAlarmController extends ChangeNotifier {
 
   GetOffAlarmState get state => _state;
 
-  /// 앱 시작 시 영속된 활성 구독을 켜진 상태로 복원한다. OS가 이미 알람을
-  /// 들고 있으므로 재예약하지 않고 상태만 반영한다.
+  /// 앱 시작 시 영속 구독과 OS 알림 상태를 프롬프트 없이 다시 맞춘다.
   Future<void> restore() => _enqueueMutation(_restore);
+
+  /// 포그라운드 복귀 시 설정에서 변경된 권한·정확도와 OS pending을
+  /// 현재 영속 구독에 재조정한다.
+  Future<void> reconcile() => _enqueueMutation(_restore);
 
   Future<void> _restore() async {
     final subscription = await repository.loadActive();
@@ -77,15 +81,40 @@ class GetOffAlarmController extends ChangeNotifier {
       await _turnOff();
       return;
     }
-    _emit(
-      GetOffAlarmState(
-        enabled: true,
-        activeRouteId: subscription.routeId,
-        scheduleMode: subscription.scheduleMode,
-        inexactNotice: subscription.inexactNotice,
-        scheduledCount: subscription.scheduledCount,
-      ),
+    final notificationPermission = await notificationPermissionProvider
+        .notificationPermissionStatus();
+    if (notificationPermission != NotificationPermissionStatus.granted) {
+      await _turnOff(permissionNotice: notificationPermissionDeniedNotice);
+      return;
+    }
+    final pendingCount = await notifier.pendingAlarmCount();
+    if (pendingCount == 0) {
+      await _turnOff();
+      return;
+    }
+    final permitted = await permissionGate.isExactAlarmPermitted();
+    final resolution = resolveGetOffAlarmScheduleMode(
+      exactAlarmPermitted: permitted,
     );
+    final maxExpectedCount =
+        1 +
+        (subscription.transferAlarmEnabled ? subscription.transfers.length : 0);
+    if (resolution.mode != subscription.scheduleMode ||
+        pendingCount > maxExpectedCount) {
+      await _schedule(
+        routeId: subscription.routeId,
+        stops: _stopsFrom(subscription),
+        transferAlarmEnabled: subscription.transferAlarmEnabled,
+        resolution: resolution,
+      );
+      return;
+    }
+    var reconciled = subscription;
+    if (pendingCount != subscription.scheduledCount) {
+      reconciled = _subscriptionWithScheduledCount(subscription, pendingCount);
+      await repository.saveActive(reconciled);
+    }
+    _emitSubscription(reconciled);
   }
 
   /// 하차 알림을 켠다: 정확 알람 권한을 확인해 강등 여부를 정하고, 알림을
@@ -150,6 +179,12 @@ class GetOffAlarmController extends ChangeNotifier {
     if (!_state.enabled || routeId == null) {
       return;
     }
+    final notificationPermission = await notificationPermissionProvider
+        .notificationPermissionStatus();
+    if (notificationPermission != NotificationPermissionStatus.granted) {
+      await _turnOff(permissionNotice: notificationPermissionDeniedNotice);
+      return;
+    }
     final permitted = await permissionGate.isExactAlarmPermitted();
     final resolution = resolveGetOffAlarmScheduleMode(
       exactAlarmPermitted: permitted,
@@ -186,26 +221,22 @@ class GetOffAlarmController extends ChangeNotifier {
       _emit(GetOffAlarmState.off);
       return;
     }
-    await repository.saveActive(
-      _subscriptionFrom(
-        routeId: routeId,
-        stops: stops,
-        transferAlarmEnabled: transferAlarmEnabled,
-        scheduledCount: delivery.scheduledCount,
-        scheduleMode: resolution.mode,
-        inexactNotice: resolution.inexactNotice,
-      ),
+    final subscription = _subscriptionFrom(
+      routeId: routeId,
+      stops: stops,
+      transferAlarmEnabled: transferAlarmEnabled,
+      scheduledCount: delivery.scheduledCount,
+      scheduleMode: resolution.mode,
+      inexactNotice: resolution.inexactNotice,
     );
+    try {
+      await repository.saveActive(subscription);
+    } catch (error, stackTrace) {
+      await _compensateFailedSave();
+      Error.throwWithStackTrace(error, stackTrace);
+    }
 
-    _emit(
-      GetOffAlarmState(
-        enabled: true,
-        activeRouteId: routeId,
-        scheduleMode: resolution.mode,
-        inexactNotice: resolution.inexactNotice,
-        scheduledCount: delivery.scheduledCount,
-      ),
-    );
+    _emitSubscription(subscription);
   }
 
   /// 하차 알림을 끈다: 예약을 취소하고 영속 상태를 지운다. 경로 안내 종료·새
@@ -225,6 +256,28 @@ class GetOffAlarmController extends ChangeNotifier {
     await notifier.cancelAll();
     await repository.clearActive();
     _emit(GetOffAlarmState(permissionNotice: permissionNotice));
+  }
+
+  Future<void> _compensateFailedSave() async {
+    try {
+      await notifier.cancelAll();
+    } catch (error, stackTrace) {
+      _reportCompensationError(error, stackTrace);
+    }
+    try {
+      await repository.clearActive();
+    } catch (error, stackTrace) {
+      _reportCompensationError(error, stackTrace);
+    }
+    _emit(GetOffAlarmState.off);
+  }
+
+  void _reportCompensationError(Object error, StackTrace stackTrace) {
+    reportMobileError(
+      error,
+      stackTrace,
+      context: '하차 알림 저장 실패 보상 정리 중 예외가 발생했습니다.',
+    );
   }
 
   GetOffAlarmSubscription _subscriptionFrom({
@@ -260,6 +313,51 @@ class GetOffAlarmController extends ChangeNotifier {
         arrivalAt: destination.arrivalAt,
       ),
       transfers: transfers,
+    );
+  }
+
+  List<GetOffAlarmStop> _stopsFrom(GetOffAlarmSubscription subscription) {
+    return [
+      for (final transfer in subscription.transfers)
+        GetOffAlarmStop(
+          stationId: transfer.stationId,
+          stationName: transfer.stationName,
+          arrivalAt: transfer.arrivalAt,
+          kind: GetOffAlarmKind.transfer,
+        ),
+      GetOffAlarmStop(
+        stationId: subscription.destination.stationId,
+        stationName: subscription.destination.stationName,
+        arrivalAt: subscription.destination.arrivalAt,
+        kind: GetOffAlarmKind.destination,
+      ),
+    ];
+  }
+
+  GetOffAlarmSubscription _subscriptionWithScheduledCount(
+    GetOffAlarmSubscription subscription,
+    int scheduledCount,
+  ) {
+    return GetOffAlarmSubscription(
+      routeId: subscription.routeId,
+      transferAlarmEnabled: subscription.transferAlarmEnabled,
+      scheduledCount: scheduledCount,
+      scheduleMode: subscription.scheduleMode,
+      inexactNotice: subscription.inexactNotice,
+      destination: subscription.destination,
+      transfers: subscription.transfers,
+    );
+  }
+
+  void _emitSubscription(GetOffAlarmSubscription subscription) {
+    _emit(
+      GetOffAlarmState(
+        enabled: true,
+        activeRouteId: subscription.routeId,
+        scheduleMode: subscription.scheduleMode,
+        inexactNotice: subscription.inexactNotice,
+        scheduledCount: subscription.scheduledCount,
+      ),
     );
   }
 

--- a/apps/mobile/lib/features/get_off_alarm/get_off_alarm_controller.dart
+++ b/apps/mobile/lib/features/get_off_alarm/get_off_alarm_controller.dart
@@ -17,6 +17,7 @@ class GetOffAlarmState {
     this.activeRouteId,
     this.scheduleMode,
     this.inexactNotice,
+    this.permissionNotice,
     this.scheduledCount = 0,
   });
 
@@ -26,6 +27,9 @@ class GetOffAlarmState {
 
   /// 부정확 예약으로 강등됐을 때의 오차 고지 문구(없으면 null).
   final String? inexactNotice;
+
+  /// 휴대전화 알림 권한이 거부됐을 때의 사용자 안내 문구(없으면 null).
+  final String? permissionNotice;
   final int scheduledCount;
 
   static const GetOffAlarmState off = GetOffAlarmState();
@@ -38,6 +42,9 @@ class GetOffAlarmState {
 /// 조합만 한다. 결과 화면의 진입점(#1704 타임라인)이 [enable]/[disable]을
 /// 호출하고, 포그라운드 복귀 시 [refresh]로 실시간 보정 재예약을 트리거한다.
 class GetOffAlarmController extends ChangeNotifier {
+  static const String notificationPermissionDeniedNotice =
+      '휴대전화 알림 권한을 허용해 주세요.';
+
   GetOffAlarmController({
     required this.notifier,
     required this.permissionGate,
@@ -71,11 +78,7 @@ class GetOffAlarmController extends ChangeNotifier {
       GetOffAlarmState(
         enabled: true,
         activeRouteId: subscription.routeId,
-        scheduledCount:
-            1 +
-            (subscription.transferAlarmEnabled
-                ? subscription.transfers.length
-                : 0),
+        scheduledCount: subscription.scheduledCount,
       ),
     );
   }
@@ -99,7 +102,7 @@ class GetOffAlarmController extends ChangeNotifier {
     final notificationPermission = await notificationPermissionProvider
         .requestNotificationPermission();
     if (notificationPermission != NotificationPermissionStatus.granted) {
-      await _turnOff();
+      await _turnOff(permissionNotice: notificationPermissionDeniedNotice);
       return;
     }
     final permitted = await permissionGate.requestExactAlarmPermission();
@@ -129,6 +132,7 @@ class GetOffAlarmController extends ChangeNotifier {
         routeId: routeId,
         stops: stops,
         transferAlarmEnabled: transferAlarmEnabled,
+        scheduledCount: delivery.scheduledCount,
       ),
     );
 
@@ -165,16 +169,17 @@ class GetOffAlarmController extends ChangeNotifier {
     await _turnOff();
   }
 
-  Future<void> _turnOff() async {
+  Future<void> _turnOff({String? permissionNotice}) async {
     await notifier.cancelAll();
     await repository.clearActive();
-    _emit(GetOffAlarmState.off);
+    _emit(GetOffAlarmState(permissionNotice: permissionNotice));
   }
 
   GetOffAlarmSubscription _subscriptionFrom({
     required String routeId,
     required List<GetOffAlarmStop> stops,
     required bool transferAlarmEnabled,
+    required int scheduledCount,
   }) {
     final destination = stops.firstWhere(
       (stop) => stop.kind == GetOffAlarmKind.destination,
@@ -192,6 +197,7 @@ class GetOffAlarmController extends ChangeNotifier {
     return GetOffAlarmSubscription(
       routeId: routeId,
       transferAlarmEnabled: transferAlarmEnabled,
+      scheduledCount: scheduledCount,
       destination: GetOffAlarmStopRef(
         stationId: destination.stationId,
         stationName: destination.stationName,

--- a/apps/mobile/lib/features/get_off_alarm/get_off_alarm_controller.dart
+++ b/apps/mobile/lib/features/get_off_alarm/get_off_alarm_controller.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 
+import '../../notification_settings.dart';
 import 'data/get_off_alarm_state_repository.dart';
 import 'exact_alarm_permission.dart';
 import 'get_off_alarm_notifier.dart';
@@ -40,6 +41,7 @@ class GetOffAlarmController extends ChangeNotifier {
   GetOffAlarmController({
     required this.notifier,
     required this.permissionGate,
+    required this.notificationPermissionProvider,
     required this.repository,
     this.policy = GetOffAlarmPolicyDefaults.policy,
     this.now = DateTime.now,
@@ -47,6 +49,7 @@ class GetOffAlarmController extends ChangeNotifier {
 
   final GetOffAlarmNotifier notifier;
   final ExactAlarmPermissionGate permissionGate;
+  final NotificationPermissionProvider notificationPermissionProvider;
   final GetOffAlarmStateRepository repository;
   final GetOffAlarmPolicy policy;
   final DateTime Function() now;
@@ -93,6 +96,12 @@ class GetOffAlarmController extends ChangeNotifier {
     if (!hasDestination) {
       return;
     }
+    final notificationPermission = await notificationPermissionProvider
+        .requestNotificationPermission();
+    if (notificationPermission != NotificationPermissionStatus.granted) {
+      await _turnOff();
+      return;
+    }
     final permitted = await permissionGate.requestExactAlarmPermission();
     final resolution = resolveGetOffAlarmScheduleMode(
       exactAlarmPermitted: permitted,
@@ -106,7 +115,15 @@ class GetOffAlarmController extends ChangeNotifier {
       now: now(),
     );
 
-    await notifier.scheduleAlarms(alarms, mode: resolution.mode);
+    final delivery = await notifier.scheduleAlarms(
+      alarms,
+      mode: resolution.mode,
+    );
+    if (delivery.scheduledCount == 0) {
+      await repository.clearActive();
+      _emit(GetOffAlarmState.off);
+      return;
+    }
     await repository.saveActive(
       _subscriptionFrom(
         routeId: routeId,
@@ -121,7 +138,7 @@ class GetOffAlarmController extends ChangeNotifier {
         activeRouteId: routeId,
         scheduleMode: resolution.mode,
         inexactNotice: resolution.inexactNotice,
-        scheduledCount: alarms.length,
+        scheduledCount: delivery.scheduledCount,
       ),
     );
   }
@@ -145,6 +162,10 @@ class GetOffAlarmController extends ChangeNotifier {
   /// 하차 알림을 끈다: 예약을 취소하고 영속 상태를 지운다. 경로 안내 종료·새
   /// 경로 탐색 시 호출한다.
   Future<void> disable() async {
+    await _turnOff();
+  }
+
+  Future<void> _turnOff() async {
     await notifier.cancelAll();
     await repository.clearActive();
     _emit(GetOffAlarmState.off);

--- a/apps/mobile/lib/features/get_off_alarm/get_off_alarm_controller.dart
+++ b/apps/mobile/lib/features/get_off_alarm/get_off_alarm_controller.dart
@@ -78,6 +78,8 @@ class GetOffAlarmController extends ChangeNotifier {
       GetOffAlarmState(
         enabled: true,
         activeRouteId: subscription.routeId,
+        scheduleMode: subscription.scheduleMode,
+        inexactNotice: subscription.inexactNotice,
         scheduledCount: subscription.scheduledCount,
       ),
     );
@@ -109,6 +111,41 @@ class GetOffAlarmController extends ChangeNotifier {
     final resolution = resolveGetOffAlarmScheduleMode(
       exactAlarmPermitted: permitted,
     );
+    await _schedule(
+      routeId: routeId,
+      stops: stops,
+      transferAlarmEnabled: transferAlarmEnabled,
+      resolution: resolution,
+    );
+  }
+
+  /// 실시간 보정(#1416)·포그라운드 복귀 시 갱신된 도착 시각으로 재예약한다.
+  Future<void> refresh({
+    required List<GetOffAlarmStop> stops,
+    required bool transferAlarmEnabled,
+  }) async {
+    final routeId = _state.activeRouteId;
+    if (!_state.enabled || routeId == null) {
+      return;
+    }
+    final permitted = await permissionGate.isExactAlarmPermitted();
+    final resolution = resolveGetOffAlarmScheduleMode(
+      exactAlarmPermitted: permitted,
+    );
+    await _schedule(
+      routeId: routeId,
+      stops: stops,
+      transferAlarmEnabled: transferAlarmEnabled,
+      resolution: resolution,
+    );
+  }
+
+  Future<void> _schedule({
+    required String routeId,
+    required List<GetOffAlarmStop> stops,
+    required bool transferAlarmEnabled,
+    required GetOffAlarmScheduleResolution resolution,
+  }) async {
     final effectivePolicy = policy.copyWith(
       transferAlarmEnabled: transferAlarmEnabled,
     );
@@ -133,6 +170,8 @@ class GetOffAlarmController extends ChangeNotifier {
         stops: stops,
         transferAlarmEnabled: transferAlarmEnabled,
         scheduledCount: delivery.scheduledCount,
+        scheduleMode: resolution.mode,
+        inexactNotice: resolution.inexactNotice,
       ),
     );
 
@@ -144,22 +183,6 @@ class GetOffAlarmController extends ChangeNotifier {
         inexactNotice: resolution.inexactNotice,
         scheduledCount: delivery.scheduledCount,
       ),
-    );
-  }
-
-  /// 실시간 보정(#1416)·포그라운드 복귀 시 갱신된 도착 시각으로 재예약한다.
-  Future<void> refresh({
-    required List<GetOffAlarmStop> stops,
-    required bool transferAlarmEnabled,
-  }) async {
-    final routeId = _state.activeRouteId;
-    if (!_state.enabled || routeId == null) {
-      return;
-    }
-    await enable(
-      routeId: routeId,
-      stops: stops,
-      transferAlarmEnabled: transferAlarmEnabled,
     );
   }
 
@@ -180,6 +203,8 @@ class GetOffAlarmController extends ChangeNotifier {
     required List<GetOffAlarmStop> stops,
     required bool transferAlarmEnabled,
     required int scheduledCount,
+    required GetOffAlarmScheduleMode scheduleMode,
+    required String? inexactNotice,
   }) {
     final destination = stops.firstWhere(
       (stop) => stop.kind == GetOffAlarmKind.destination,
@@ -198,6 +223,8 @@ class GetOffAlarmController extends ChangeNotifier {
       routeId: routeId,
       transferAlarmEnabled: transferAlarmEnabled,
       scheduledCount: scheduledCount,
+      scheduleMode: scheduleMode,
+      inexactNotice: inexactNotice,
       destination: GetOffAlarmStopRef(
         stationId: destination.stationId,
         stationName: destination.stationName,

--- a/apps/mobile/lib/features/get_off_alarm/get_off_alarm_controller.dart
+++ b/apps/mobile/lib/features/get_off_alarm/get_off_alarm_controller.dart
@@ -179,6 +179,12 @@ class GetOffAlarmController extends ChangeNotifier {
     if (!_state.enabled || routeId == null) {
       return;
     }
+    final hasDestination = stops.any(
+      (stop) => stop.kind == GetOffAlarmKind.destination,
+    );
+    if (!hasDestination) {
+      return;
+    }
     final notificationPermission = await notificationPermissionProvider
         .notificationPermissionStatus();
     if (notificationPermission != NotificationPermissionStatus.granted) {

--- a/apps/mobile/lib/features/get_off_alarm/get_off_alarm_controller.dart
+++ b/apps/mobile/lib/features/get_off_alarm/get_off_alarm_controller.dart
@@ -62,16 +62,19 @@ class GetOffAlarmController extends ChangeNotifier {
   final DateTime Function() now;
 
   GetOffAlarmState _state = GetOffAlarmState.off;
+  Future<void> _mutationTail = Future<void>.value();
   bool _disposed = false;
 
   GetOffAlarmState get state => _state;
 
   /// 앱 시작 시 영속된 활성 구독을 켜진 상태로 복원한다. OS가 이미 알람을
   /// 들고 있으므로 재예약하지 않고 상태만 반영한다.
-  Future<void> restore() async {
+  Future<void> restore() => _enqueueMutation(_restore);
+
+  Future<void> _restore() async {
     final subscription = await repository.loadActive();
     if (subscription == null) {
-      _emit(GetOffAlarmState.off);
+      await _turnOff();
       return;
     }
     _emit(
@@ -88,6 +91,18 @@ class GetOffAlarmController extends ChangeNotifier {
   /// 하차 알림을 켠다: 정확 알람 권한을 확인해 강등 여부를 정하고, 알림을
   /// 계산·예약한 뒤 활성 구독을 영속 저장한다.
   Future<void> enable({
+    required String routeId,
+    required List<GetOffAlarmStop> stops,
+    required bool transferAlarmEnabled,
+  }) => _enqueueMutation(
+    () => _enable(
+      routeId: routeId,
+      stops: stops,
+      transferAlarmEnabled: transferAlarmEnabled,
+    ),
+  );
+
+  Future<void> _enable({
     required String routeId,
     required List<GetOffAlarmStop> stops,
     required bool transferAlarmEnabled,
@@ -121,6 +136,13 @@ class GetOffAlarmController extends ChangeNotifier {
 
   /// 실시간 보정(#1416)·포그라운드 복귀 시 갱신된 도착 시각으로 재예약한다.
   Future<void> refresh({
+    required List<GetOffAlarmStop> stops,
+    required bool transferAlarmEnabled,
+  }) => _enqueueMutation(
+    () => _refresh(stops: stops, transferAlarmEnabled: transferAlarmEnabled),
+  );
+
+  Future<void> _refresh({
     required List<GetOffAlarmStop> stops,
     required bool transferAlarmEnabled,
   }) async {
@@ -188,8 +210,15 @@ class GetOffAlarmController extends ChangeNotifier {
 
   /// 하차 알림을 끈다: 예약을 취소하고 영속 상태를 지운다. 경로 안내 종료·새
   /// 경로 탐색 시 호출한다.
-  Future<void> disable() async {
-    await _turnOff();
+  Future<void> disable() => _enqueueMutation(_turnOff);
+
+  Future<void> _enqueueMutation(Future<void> Function() mutation) {
+    final result = _mutationTail.then((_) => mutation());
+    _mutationTail = result.then<void>(
+      (_) {},
+      onError: (Object _, StackTrace _) {},
+    );
+    return result;
   }
 
   Future<void> _turnOff({String? permissionNotice}) async {

--- a/apps/mobile/lib/features/get_off_alarm/get_off_alarm_notifier.dart
+++ b/apps/mobile/lib/features/get_off_alarm/get_off_alarm_notifier.dart
@@ -15,14 +15,25 @@ import 'get_off_alarm_scheduler.dart';
 /// 플랫폼 예약만 담당한다. 테스트에서는 이 인터페이스를 가짜로 대체한다.
 abstract class GetOffAlarmNotifier {
   /// [alarms]를 [mode]에 맞춰 예약한다. 기존 활성 알림은 먼저 모두 취소한다
-  /// (단일 경로 원칙).
-  Future<void> scheduleAlarms(
+  /// (단일 경로 원칙). 반환값은 실제 예약 성공·실패 건수다.
+  Future<ScheduleDeliveryResult> scheduleAlarms(
     List<ScheduledGetOffAlarm> alarms, {
     required GetOffAlarmScheduleMode mode,
   });
 
   /// 활성 하차 알림을 모두 취소한다.
   Future<void> cancelAll();
+}
+
+/// 플랫폼에 전달한 하차 알림 예약의 실제 결과.
+class ScheduleDeliveryResult {
+  const ScheduleDeliveryResult({
+    required this.scheduledCount,
+    required this.failedCount,
+  });
+
+  final int scheduledCount;
+  final int failedCount;
 }
 
 /// [GetOffAlarmScheduleMode]를 flutter_local_notifications의
@@ -83,12 +94,15 @@ class LocalGetOffAlarmNotifier implements GetOffAlarmNotifier {
   }
 
   @override
-  Future<void> scheduleAlarms(
+  Future<ScheduleDeliveryResult> scheduleAlarms(
     List<ScheduledGetOffAlarm> alarms, {
     required GetOffAlarmScheduleMode mode,
   }) async {
     if (!Platform.isAndroid) {
-      return;
+      return ScheduleDeliveryResult(
+        scheduledCount: 0,
+        failedCount: alarms.length,
+      );
     }
     await _ensureInitialized();
     await cancelAll();
@@ -114,6 +128,10 @@ class LocalGetOffAlarmNotifier implements GetOffAlarmNotifier {
       }
     }
     _activeIds = assignedIds;
+    return ScheduleDeliveryResult(
+      scheduledCount: assignedIds.length,
+      failedCount: alarms.length - assignedIds.length,
+    );
   }
 
   @override

--- a/apps/mobile/lib/features/get_off_alarm/get_off_alarm_notifier.dart
+++ b/apps/mobile/lib/features/get_off_alarm/get_off_alarm_notifier.dart
@@ -50,13 +50,66 @@ AndroidScheduleMode androidScheduleModeFor(GetOffAlarmScheduleMode mode) {
 
 /// flutter_local_notifications 기반 실제 구현.
 class LocalGetOffAlarmNotifier implements GetOffAlarmNotifier {
-  LocalGetOffAlarmNotifier(this._plugin);
+  LocalGetOffAlarmNotifier(
+    FlutterLocalNotificationsPlugin plugin, {
+    bool? isAndroid,
+    Future<void> Function()? initializePlugin,
+    Future<List<int>> Function()? pendingIds,
+    Future<void> Function(int id)? cancelId,
+    Future<void> Function(
+      int id,
+      String title,
+      String body,
+      DateTime fireAt,
+      AndroidScheduleMode mode,
+    )?
+    scheduleAlarm,
+  }) : _isAndroid = isAndroid ?? Platform.isAndroid,
+       _initializePlugin =
+           initializePlugin ??
+           (() async {
+             await plugin.initialize(
+               settings: const InitializationSettings(
+                 android: AndroidInitializationSettings('@mipmap/ic_launcher'),
+               ),
+             );
+           }),
+       _pendingIds =
+           pendingIds ??
+           (() async {
+             final pending = await plugin.pendingNotificationRequests();
+             return pending.map((request) => request.id).toList();
+           }),
+       _cancelId = cancelId ?? ((id) => plugin.cancel(id: id)),
+       _scheduleAlarm =
+           scheduleAlarm ??
+           ((id, title, body, fireAt, mode) => plugin.zonedSchedule(
+             id: id,
+             title: title,
+             body: body,
+             scheduledDate: tz.TZDateTime.from(fireAt, tz.local),
+             notificationDetails: const NotificationDetails(
+               android: _androidDetails,
+             ),
+             androidScheduleMode: mode,
+           ));
 
-  final FlutterLocalNotificationsPlugin _plugin;
+  final bool _isAndroid;
+  final Future<void> Function() _initializePlugin;
+  final Future<List<int>> Function() _pendingIds;
+  final Future<void> Function(int id) _cancelId;
+  final Future<void> Function(
+    int id,
+    String title,
+    String body,
+    DateTime fireAt,
+    AndroidScheduleMode mode,
+  )
+  _scheduleAlarm;
 
-  /// 하차 알림에 할당하는 알림 ID 기준값. 단일 경로에서 알림 수는 적으므로
-  /// 이 기준값부터 순차 부여하고 취소 시 전부 지운다.
-  static const int _baseNotificationId = 47660;
+  /// 하차 알림 전용 ID 범위 `[baseNotificationId, base + capacity)`.
+  static const int baseNotificationId = 47660;
+  static const int notificationCapacity = 64;
 
   static const String _channelId = 'get_off_alarm';
   static const String _channelName = '하차 알림';
@@ -72,7 +125,6 @@ class LocalGetOffAlarmNotifier implements GetOffAlarmNotifier {
         category: AndroidNotificationCategory.navigation,
       );
 
-  List<int> _activeIds = const [];
   Future<void>? _initialization;
 
   /// 첫 예약 전에 플러그인·타임존을 1회 초기화한다. 진행 중인 초기화 Future를
@@ -85,12 +137,8 @@ class LocalGetOffAlarmNotifier implements GetOffAlarmNotifier {
   Future<void> _initialize() async {
     tz_data.initializeTimeZones();
     tz.setLocalLocation(tz.getLocation('Asia/Seoul'));
-    // Android 전용 초기화(iOS는 #571 DEFERRED). iOS 진입은 아래 Platform 가드가 막는다.
-    await _plugin.initialize(
-      settings: const InitializationSettings(
-        android: AndroidInitializationSettings('@mipmap/ic_launcher'),
-      ),
-    );
+    // Android 전용 초기화(iOS는 #571 DEFERRED). iOS 진입은 아래 platform 가드가 막는다.
+    await _initializePlugin();
   }
 
   @override
@@ -98,7 +146,7 @@ class LocalGetOffAlarmNotifier implements GetOffAlarmNotifier {
     List<ScheduledGetOffAlarm> alarms, {
     required GetOffAlarmScheduleMode mode,
   }) async {
-    if (!Platform.isAndroid) {
+    if (!_isAndroid) {
       return ScheduleDeliveryResult(
         scheduledCount: 0,
         failedCount: alarms.length,
@@ -107,46 +155,49 @@ class LocalGetOffAlarmNotifier implements GetOffAlarmNotifier {
     await _ensureInitialized();
     await cancelAll();
     final scheduleMode = androidScheduleModeFor(mode);
-    final assignedIds = <int>[];
-    for (var index = 0; index < alarms.length; index++) {
+    var scheduledCount = 0;
+    final attemptCount = alarms.length < notificationCapacity
+        ? alarms.length
+        : notificationCapacity;
+    for (var index = 0; index < attemptCount; index++) {
       final alarm = alarms[index];
-      final id = _baseNotificationId + index;
+      final id = baseNotificationId + index;
       try {
-        await _plugin.zonedSchedule(
-          id: id,
-          title: _titleFor(alarm),
-          body: _bodyFor(alarm),
-          scheduledDate: tz.TZDateTime.from(alarm.fireAt, tz.local),
-          notificationDetails: const NotificationDetails(
-            android: _androidDetails,
-          ),
-          androidScheduleMode: scheduleMode,
+        await _scheduleAlarm(
+          id,
+          _titleFor(alarm),
+          _bodyFor(alarm),
+          alarm.fireAt,
+          scheduleMode,
         );
-        assignedIds.add(id);
+        scheduledCount += 1;
       } on Exception catch (error, stackTrace) {
         reportMobileError(error, stackTrace, context: '하차 알림 예약 중 예외가 발생했습니다.');
       }
     }
-    _activeIds = assignedIds;
     return ScheduleDeliveryResult(
-      scheduledCount: assignedIds.length,
-      failedCount: alarms.length - assignedIds.length,
+      scheduledCount: scheduledCount,
+      failedCount: alarms.length - scheduledCount,
     );
   }
 
   @override
   Future<void> cancelAll() async {
-    if (!Platform.isAndroid) {
+    if (!_isAndroid) {
       return;
     }
-    for (final id in _activeIds) {
-      try {
-        await _plugin.cancel(id: id);
-      } on Exception catch (error, stackTrace) {
-        reportMobileError(error, stackTrace, context: '하차 알림 취소 중 예외가 발생했습니다.');
+    await _ensureInitialized();
+    final pendingIds = await _pendingIds();
+    for (final id in pendingIds) {
+      if (_isOwnedNotificationId(id)) {
+        await _cancelId(id);
       }
     }
-    _activeIds = const [];
+  }
+
+  bool _isOwnedNotificationId(int id) {
+    return id >= baseNotificationId &&
+        id < baseNotificationId + notificationCapacity;
   }
 
   String _titleFor(ScheduledGetOffAlarm alarm) {

--- a/apps/mobile/lib/features/get_off_alarm/get_off_alarm_notifier.dart
+++ b/apps/mobile/lib/features/get_off_alarm/get_off_alarm_notifier.dart
@@ -23,6 +23,9 @@ abstract class GetOffAlarmNotifier {
 
   /// 활성 하차 알림을 모두 취소한다.
   Future<void> cancelAll();
+
+  /// 하차 알림 전용 ID 범위에 남은 OS 대기 알림 건수만 반환한다.
+  Future<int> pendingAlarmCount();
 }
 
 /// 플랫폼에 전달한 하차 알림 예약의 실제 결과.
@@ -193,6 +196,16 @@ class LocalGetOffAlarmNotifier implements GetOffAlarmNotifier {
         await _cancelId(id);
       }
     }
+  }
+
+  @override
+  Future<int> pendingAlarmCount() async {
+    if (!_isAndroid) {
+      return 0;
+    }
+    await _ensureInitialized();
+    final pendingIds = await _pendingIds();
+    return pendingIds.where(_isOwnedNotificationId).length;
   }
 
   bool _isOwnedNotificationId(int id) {

--- a/apps/mobile/lib/features/get_off_alarm/get_off_alarm_route_mapping.dart
+++ b/apps/mobile/lib/features/get_off_alarm/get_off_alarm_route_mapping.dart
@@ -1,5 +1,7 @@
 import 'get_off_alarm_scheduler.dart';
 
+enum GetOffAlarmTimeSource { planned, realtime }
+
 /// 경로 결과의 승차(RIDE) leg 하나를 하차 알림 관점으로 투영한 값.
 ///
 /// route_search의 무거운 leg 모델에 결합하지 않도록, UI 어댑터가 RIDE leg를
@@ -24,13 +26,16 @@ class RideLegArrival {
 List<GetOffAlarmStop> getOffAlarmStopsFromRideLegs({
   required List<RideLegArrival> rideLegs,
   required String Function(String stationId) stationName,
+  required GetOffAlarmTimeSource source,
 }) {
   final stops = <GetOffAlarmStop>[];
   for (var index = 0; index < rideLegs.length; index++) {
     final leg = rideLegs[index];
     final isDestination = index == rideLegs.length - 1;
     final arrivalIso =
-        (leg.realtimeArrivalIso != null && leg.realtimeArrivalIso!.isNotEmpty)
+        (source == GetOffAlarmTimeSource.realtime &&
+            leg.realtimeArrivalIso != null &&
+            leg.realtimeArrivalIso!.isNotEmpty)
         ? leg.realtimeArrivalIso!
         : leg.plannedArrivalIso;
     stops.add(

--- a/apps/mobile/lib/features/get_off_alarm/get_off_alarm_subscription.dart
+++ b/apps/mobile/lib/features/get_off_alarm/get_off_alarm_subscription.dart
@@ -6,12 +6,14 @@ class GetOffAlarmSubscription {
   const GetOffAlarmSubscription({
     required this.routeId,
     required this.transferAlarmEnabled,
+    required this.scheduledCount,
     required this.destination,
     required this.transfers,
   });
 
   final String routeId;
   final bool transferAlarmEnabled;
+  final int scheduledCount;
   final GetOffAlarmStopRef destination;
   final List<GetOffAlarmStopRef> transfers;
 
@@ -19,6 +21,7 @@ class GetOffAlarmSubscription {
     return {
       'routeId': routeId,
       'transferAlarmEnabled': transferAlarmEnabled,
+      'scheduledCount': scheduledCount,
       'destination': destination.toJson(),
       'transfers': transfers.map((stop) => stop.toJson()).toList(),
     };
@@ -45,9 +48,20 @@ class GetOffAlarmSubscription {
         transfers.add(stop);
       }
     }
+    final transferAlarmEnabled = json['transferAlarmEnabled'] == true;
+    final maxScheduledCount = 1 + (transferAlarmEnabled ? transfers.length : 0);
+    final scheduledCount = json.containsKey('scheduledCount')
+        ? json['scheduledCount']
+        : maxScheduledCount;
+    if (scheduledCount is! int ||
+        scheduledCount <= 0 ||
+        scheduledCount > maxScheduledCount) {
+      return null;
+    }
     return GetOffAlarmSubscription(
       routeId: routeId,
-      transferAlarmEnabled: json['transferAlarmEnabled'] == true,
+      transferAlarmEnabled: transferAlarmEnabled,
+      scheduledCount: scheduledCount,
       destination: destination,
       transfers: transfers,
     );

--- a/apps/mobile/lib/features/get_off_alarm/get_off_alarm_subscription.dart
+++ b/apps/mobile/lib/features/get_off_alarm/get_off_alarm_subscription.dart
@@ -1,3 +1,5 @@
+import 'get_off_alarm_schedule_mode.dart';
+
 /// 활성 경로 하나에 대한 하차 알림 구독 상태.
 ///
 /// 앱 재시작 후에도 "알림 켜짐" 상태를 복원하고 새 경로 탐색 시 이전 알림을
@@ -7,6 +9,8 @@ class GetOffAlarmSubscription {
     required this.routeId,
     required this.transferAlarmEnabled,
     required this.scheduledCount,
+    required this.scheduleMode,
+    required this.inexactNotice,
     required this.destination,
     required this.transfers,
   });
@@ -14,6 +18,8 @@ class GetOffAlarmSubscription {
   final String routeId;
   final bool transferAlarmEnabled;
   final int scheduledCount;
+  final GetOffAlarmScheduleMode scheduleMode;
+  final String? inexactNotice;
   final GetOffAlarmStopRef destination;
   final List<GetOffAlarmStopRef> transfers;
 
@@ -22,6 +28,8 @@ class GetOffAlarmSubscription {
       'routeId': routeId,
       'transferAlarmEnabled': transferAlarmEnabled,
       'scheduledCount': scheduledCount,
+      'scheduleMode': scheduleMode.name,
+      'inexactNotice': inexactNotice,
       'destination': destination.toJson(),
       'transfers': transfers.map((stop) => stop.toJson()).toList(),
     };
@@ -38,17 +46,21 @@ class GetOffAlarmSubscription {
       return null;
     }
     final transfersJson = json['transfers'];
-    final transfers = <GetOffAlarmStopRef>[];
-    if (transfersJson is List) {
-      for (final entry in transfersJson) {
-        final stop = GetOffAlarmStopRef.fromJson(entry);
-        if (stop == null) {
-          return null;
-        }
-        transfers.add(stop);
-      }
+    if (transfersJson is! List) {
+      return null;
     }
-    final transferAlarmEnabled = json['transferAlarmEnabled'] == true;
+    final transfers = <GetOffAlarmStopRef>[];
+    for (final entry in transfersJson) {
+      final stop = GetOffAlarmStopRef.fromJson(entry);
+      if (stop == null) {
+        return null;
+      }
+      transfers.add(stop);
+    }
+    final transferAlarmEnabled = json['transferAlarmEnabled'];
+    if (transferAlarmEnabled is! bool) {
+      return null;
+    }
     final maxScheduledCount = 1 + (transferAlarmEnabled ? transfers.length : 0);
     final scheduledCount = json.containsKey('scheduledCount')
         ? json['scheduledCount']
@@ -58,10 +70,33 @@ class GetOffAlarmSubscription {
         scheduledCount > maxScheduledCount) {
       return null;
     }
+    final scheduleMode = switch (json['scheduleMode']) {
+      'exact' => GetOffAlarmScheduleMode.exact,
+      'inexact' => GetOffAlarmScheduleMode.inexact,
+      _ => null,
+    };
+    final Object? rawInexactNotice = json['inexactNotice'];
+    final String? inexactNotice;
+    if (rawInexactNotice == null) {
+      inexactNotice = null;
+    } else if (rawInexactNotice is String) {
+      inexactNotice = rawInexactNotice;
+    } else {
+      return null;
+    }
+    if (scheduleMode == null ||
+        (scheduleMode == GetOffAlarmScheduleMode.exact &&
+            inexactNotice != null) ||
+        (scheduleMode == GetOffAlarmScheduleMode.inexact &&
+            (inexactNotice == null || inexactNotice.isEmpty))) {
+      return null;
+    }
     return GetOffAlarmSubscription(
       routeId: routeId,
       transferAlarmEnabled: transferAlarmEnabled,
       scheduledCount: scheduledCount,
+      scheduleMode: scheduleMode,
+      inexactNotice: inexactNotice,
       destination: destination,
       transfers: transfers,
     );

--- a/apps/mobile/lib/features/get_off_alarm/get_off_alarm_toggle.dart
+++ b/apps/mobile/lib/features/get_off_alarm/get_off_alarm_toggle.dart
@@ -19,7 +19,7 @@ class GetOffAlarmToggle extends StatefulWidget {
   final GetOffAlarmController controller;
   final String routeId;
   final List<RideLegArrival> rideLegs;
-  final String Function(String stationId) stationName;
+  final Future<String?> Function(String stationId) stationName;
 
   @override
   State<GetOffAlarmToggle> createState() => _GetOffAlarmToggleState();
@@ -58,9 +58,10 @@ class _GetOffAlarmToggleState extends State<GetOffAlarmToggle> {
     setState(() => _busy = true);
     try {
       if (enabled) {
+        final stationNames = await _resolveStationNames();
         final stops = getOffAlarmStopsFromRideLegs(
           rideLegs: widget.rideLegs,
-          stationName: widget.stationName,
+          stationName: (stationId) => stationNames[stationId]!,
           source:
               widget.rideLegs.any(
                 (leg) => leg.realtimeArrivalIso?.isNotEmpty ?? false,
@@ -88,6 +89,25 @@ class _GetOffAlarmToggleState extends State<GetOffAlarmToggle> {
         setState(() => _busy = false);
       }
     }
+  }
+
+  Future<Map<String, String>> _resolveStationNames() async {
+    final stationNames = <String, String>{};
+    for (final leg in widget.rideLegs) {
+      final stationId = leg.toStationId;
+      if (stationNames.containsKey(stationId)) {
+        continue;
+      }
+      final rawName = await widget.stationName(stationId);
+      final stationName = rawName?.trim();
+      if (stationName == null ||
+          stationName.isEmpty ||
+          stationName == stationId) {
+        throw StateError('하차 알림 역명을 확인하지 못했습니다.');
+      }
+      stationNames[stationId] = stationName;
+    }
+    return stationNames;
   }
 
   @override

--- a/apps/mobile/lib/features/get_off_alarm/get_off_alarm_toggle.dart
+++ b/apps/mobile/lib/features/get_off_alarm/get_off_alarm_toggle.dart
@@ -111,12 +111,17 @@ class _GetOffAlarmToggleState extends State<GetOffAlarmToggle> {
           ),
         ),
         if (notice != null)
-          Padding(
-            padding: const EdgeInsets.only(top: 4),
-            child: Text(
-              notice,
-              style: theme.textTheme.bodySmall?.copyWith(
-                color: theme.colorScheme.error,
+          Semantics(
+            key: const Key('getOffAlarmNotice'),
+            container: true,
+            liveRegion: true,
+            child: Padding(
+              padding: const EdgeInsets.only(top: 4),
+              child: Text(
+                notice,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.error,
+                ),
               ),
             ),
           ),

--- a/apps/mobile/lib/features/get_off_alarm/get_off_alarm_toggle.dart
+++ b/apps/mobile/lib/features/get_off_alarm/get_off_alarm_toggle.dart
@@ -61,6 +61,12 @@ class _GetOffAlarmToggleState extends State<GetOffAlarmToggle> {
         final stops = getOffAlarmStopsFromRideLegs(
           rideLegs: widget.rideLegs,
           stationName: widget.stationName,
+          source:
+              widget.rideLegs.any(
+                (leg) => leg.realtimeArrivalIso?.isNotEmpty ?? false,
+              )
+              ? GetOffAlarmTimeSource.realtime
+              : GetOffAlarmTimeSource.planned,
         );
         await widget.controller.enable(
           routeId: widget.routeId,

--- a/apps/mobile/lib/features/get_off_alarm/get_off_alarm_toggle.dart
+++ b/apps/mobile/lib/features/get_off_alarm/get_off_alarm_toggle.dart
@@ -27,6 +27,7 @@ class GetOffAlarmToggle extends StatefulWidget {
 
 class _GetOffAlarmToggleState extends State<GetOffAlarmToggle> {
   bool _busy = false;
+  int _operationGeneration = 0;
 
   @override
   void initState() {
@@ -40,7 +41,23 @@ class _GetOffAlarmToggleState extends State<GetOffAlarmToggle> {
     super.dispose();
   }
 
+  @override
+  void didUpdateWidget(covariant GetOffAlarmToggle oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!identical(oldWidget.controller, widget.controller)) {
+      oldWidget.controller.removeListener(_onControllerChanged);
+      widget.controller.addListener(_onControllerChanged);
+      _operationGeneration += 1;
+      return;
+    }
+    if (oldWidget.routeId != widget.routeId ||
+        !_sameRideLegs(oldWidget.rideLegs, widget.rideLegs)) {
+      _operationGeneration += 1;
+    }
+  }
+
   void _onControllerChanged() {
+    _operationGeneration += 1;
     if (mounted) {
       setState(() {});
     }
@@ -55,22 +72,32 @@ class _GetOffAlarmToggleState extends State<GetOffAlarmToggle> {
     if (_busy) {
       return;
     }
+    final operationGeneration = ++_operationGeneration;
+    final routeId = widget.routeId;
+    final rideLegs = List<RideLegArrival>.unmodifiable(widget.rideLegs);
+    final stationName = widget.stationName;
     setState(() => _busy = true);
     try {
       if (enabled) {
-        final stationNames = await _resolveStationNames();
+        final stationNames = await _resolveStationNames(
+          rideLegs: rideLegs,
+          resolveStationName: stationName,
+        );
+        if (!mounted ||
+            operationGeneration != _operationGeneration ||
+            widget.routeId != routeId) {
+          return;
+        }
         final stops = getOffAlarmStopsFromRideLegs(
-          rideLegs: widget.rideLegs,
+          rideLegs: rideLegs,
           stationName: (stationId) => stationNames[stationId]!,
           source:
-              widget.rideLegs.any(
-                (leg) => leg.realtimeArrivalIso?.isNotEmpty ?? false,
-              )
+              rideLegs.any((leg) => leg.realtimeArrivalIso?.isNotEmpty ?? false)
               ? GetOffAlarmTimeSource.realtime
               : GetOffAlarmTimeSource.planned,
         );
         await widget.controller.enable(
-          routeId: widget.routeId,
+          routeId: routeId,
           stops: stops,
           transferAlarmEnabled: true,
         );
@@ -91,23 +118,42 @@ class _GetOffAlarmToggleState extends State<GetOffAlarmToggle> {
     }
   }
 
-  Future<Map<String, String>> _resolveStationNames() async {
+  Future<Map<String, String>> _resolveStationNames({
+    required List<RideLegArrival> rideLegs,
+    required Future<String?> Function(String stationId) resolveStationName,
+  }) async {
     final stationNames = <String, String>{};
-    for (final leg in widget.rideLegs) {
+    for (final leg in rideLegs) {
       final stationId = leg.toStationId;
       if (stationNames.containsKey(stationId)) {
         continue;
       }
-      final rawName = await widget.stationName(stationId);
-      final stationName = rawName?.trim();
-      if (stationName == null ||
-          stationName.isEmpty ||
-          stationName == stationId) {
+      final rawName = await resolveStationName(stationId);
+      final resolvedStationName = rawName?.trim();
+      if (resolvedStationName == null ||
+          resolvedStationName.isEmpty ||
+          resolvedStationName == stationId) {
         throw StateError('하차 알림 역명을 확인하지 못했습니다.');
       }
-      stationNames[stationId] = stationName;
+      stationNames[stationId] = resolvedStationName;
     }
     return stationNames;
+  }
+
+  bool _sameRideLegs(List<RideLegArrival> before, List<RideLegArrival> after) {
+    if (before.length != after.length) {
+      return false;
+    }
+    for (var index = 0; index < before.length; index++) {
+      final previous = before[index];
+      final current = after[index];
+      if (previous.toStationId != current.toStationId ||
+          previous.plannedArrivalIso != current.plannedArrivalIso ||
+          previous.realtimeArrivalIso != current.realtimeArrivalIso) {
+        return false;
+      }
+    }
+    return true;
   }
 
   @override

--- a/apps/mobile/lib/features/get_off_alarm/get_off_alarm_toggle.dart
+++ b/apps/mobile/lib/features/get_off_alarm/get_off_alarm_toggle.dart
@@ -88,7 +88,8 @@ class _GetOffAlarmToggleState extends State<GetOffAlarmToggle> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final on = _isOnForThisRoute;
-    final notice = on ? widget.controller.state.inexactNotice : null;
+    final state = widget.controller.state;
+    final notice = on ? state.inexactNotice : state.permissionNotice;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/apps/mobile/lib/features/routes/application/network_graph.dart
+++ b/apps/mobile/lib/features/routes/application/network_graph.dart
@@ -109,6 +109,7 @@ class RouteEdge {
     int? durationSeconds,
     this.distanceMeters = 0,
     this.lineId = '',
+    this.servicePattern = '',
     this.transferStationId = '',
     bool? includesStairs,
     RouteStairAccessState? stairAccessState,
@@ -150,6 +151,7 @@ class RouteEdge {
   final int durationSeconds;
   final int distanceMeters;
   final String lineId;
+  final String servicePattern;
   final String transferStationId;
   final bool includesStairs;
   final RouteStairAccessState stairAccessState;

--- a/apps/mobile/lib/features/routes/application/route_engine.dart
+++ b/apps/mobile/lib/features/routes/application/route_engine.dart
@@ -435,6 +435,7 @@ class RouteAssembler {
           durationSeconds: edge.durationSeconds,
           distanceMeters: edge.distanceMeters,
           lineId: edge.lineId,
+          servicePattern: edge.servicePattern,
           transferStationId: _transferStationId(edge),
           includesStairs: edge.includesStairs,
           stairAccessState: edge.stairAccessState.name,

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -177,8 +177,10 @@ class LocalRouteRepository implements RouteSearchRepository {
     _RouteCatalogSnapshot catalog, {
     required Map<int, String> plannedArrivals,
   }) {
-    return result.steps
-        .map((step) {
+    return _collapseConsecutiveRideSteps(result.steps)
+        .indexed
+        .map((entry) {
+          final (index, step) = entry;
           final fromStationId = catalog.stationIdForNode(step.fromNodeId);
           final toStationId = catalog.stationIdForNode(step.toNodeId);
           final fromName = catalog.stationName(fromStationId);
@@ -186,7 +188,7 @@ class LocalRouteRepository implements RouteSearchRepository {
           final lineName = catalog.lineName(step.lineId);
 
           return RouteSearchStep(
-            sequence: step.sequence,
+            sequence: index + 1,
             stepType: step.type.name,
             title: _stepTitle(step.type.name, fromName, toName, lineName),
             description: _stepDescription(step.type.name, fromName, toName),
@@ -227,7 +229,7 @@ class LocalRouteRepository implements RouteSearchRepository {
     }
     final arrivals = <int, String>{};
     var cursor = now().toUtc();
-    for (final step in result.steps) {
+    for (final step in _collapseConsecutiveRideSteps(result.steps)) {
       if (step.type != route_step.RouteStepType.ride) {
         cursor = cursor.add(Duration(seconds: step.durationSeconds));
         continue;
@@ -236,6 +238,7 @@ class LocalRouteRepository implements RouteSearchRepository {
         fromStationId: catalog.stationIdForNode(step.fromNodeId),
         toStationId: catalog.stationIdForNode(step.toNodeId),
         lineId: step.lineId,
+        servicePattern: step.servicePattern,
         cursor: cursor,
       );
       if (arrival == null) {
@@ -251,6 +254,7 @@ class LocalRouteRepository implements RouteSearchRepository {
     required String fromStationId,
     required String toStationId,
     required String lineId,
+    required String servicePattern,
     required DateTime cursor,
   }) async {
     final koreaNow = cursor.toUtc().add(const Duration(hours: 9));
@@ -274,6 +278,9 @@ class LocalRouteRepository implements RouteSearchRepository {
           ? 0
           : (startMicroseconds + Duration.microsecondsPerSecond - 1) ~/
                 Duration.microsecondsPerSecond;
+      final servicePatternSql = servicePattern.isEmpty
+          ? ''
+          : 'AND trip.service_pattern = ?';
       final row = await catalogDatabase
           .customSelect(
             '''
@@ -306,6 +313,7 @@ class LocalRouteRepository implements RouteSearchRepository {
               AND removed.exception_type = 2
           )
           AND route.line_id = ?
+          $servicePatternSql
           AND board.station_id = ?
           AND board.line_id = ?
           AND board.pickup_type != 1
@@ -323,6 +331,8 @@ class LocalRouteRepository implements RouteSearchRepository {
               Variable.withString(dateKey),
               Variable.withString(dateKey),
               Variable.withString(lineId),
+              if (servicePattern.isNotEmpty)
+                Variable.withString(servicePattern),
               Variable.withString(fromStationId),
               Variable.withString(lineId),
               Variable.withString(toStationId),
@@ -543,6 +553,57 @@ class LocalRouteRepository implements RouteSearchRepository {
       _ => throw const RouteSearchException('지원하지 않는 이동 제약 조건입니다.'),
     };
   }
+}
+
+List<route_step.RouteStep> _collapseConsecutiveRideSteps(
+  List<route_step.RouteStep> steps,
+) {
+  final collapsed = <route_step.RouteStep>[];
+  for (final step in steps) {
+    final previous = collapsed.isEmpty ? null : collapsed.last;
+    final canMerge =
+        previous != null &&
+        previous.type == route_step.RouteStepType.ride &&
+        step.type == route_step.RouteStepType.ride &&
+        previous.toNodeId == step.fromNodeId &&
+        previous.lineId == step.lineId &&
+        previous.servicePattern.isNotEmpty &&
+        previous.servicePattern == step.servicePattern;
+    if (!canMerge) {
+      collapsed.add(step);
+      continue;
+    }
+    collapsed[collapsed.length - 1] = route_step.RouteStep(
+      sequence: previous.sequence,
+      edgeId: previous.edgeId,
+      fromNodeId: previous.fromNodeId,
+      toNodeId: step.toNodeId,
+      type: route_step.RouteStepType.ride,
+      cost: previous.cost + step.cost,
+      durationSeconds: previous.durationSeconds + step.durationSeconds,
+      distanceMeters: previous.distanceMeters + step.distanceMeters,
+      lineId: previous.lineId,
+      servicePattern: previous.servicePattern,
+      includesStairs: previous.includesStairs || step.includesStairs,
+      stairAccessState: previous.stairAccessState == step.stairAccessState
+          ? previous.stairAccessState
+          : 'unknown',
+      evidenceSources: {
+        ...previous.evidenceSources,
+        ...step.evidenceSources,
+      }.toList(growable: false),
+      timeSource: previous.timeSource == step.timeSource
+          ? previous.timeSource
+          : 'UNKNOWN',
+      distanceSource: previous.distanceSource == step.distanceSource
+          ? previous.distanceSource
+          : 'UNKNOWN',
+      confidenceLabel: previous.confidenceLabel == step.confidenceLabel
+          ? previous.confidenceLabel
+          : '안내를 준비 중이에요',
+    );
+  }
+  return collapsed;
 }
 
 class RouteCapabilityMetadata {
@@ -1596,6 +1657,7 @@ graph.RouteEdge _toGraphRouteEdge(
         ? 0
         : networkEdge.durationSeconds,
     lineId: _lineIdForNode(effectiveFromNodeId),
+    servicePattern: networkEdge.servicePattern,
     distanceMeters: networkEdge.distanceMeters,
     includesStairs:
         routeEdgeType == graph.RouteEdgeType.stair ||

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -1,3 +1,5 @@
+import 'package:drift/drift.dart' show Variable;
+
 import '../../../core/database/catalog/catalog_database.dart';
 import '../../../route_hedge_labels.dart';
 import '../../../route_search.dart';
@@ -8,9 +10,13 @@ import '../domain/route_result.dart' as local;
 import '../domain/route_step.dart' as route_step;
 
 class LocalRouteRepository implements RouteSearchRepository {
-  LocalRouteRepository({required this.catalogDatabase});
+  LocalRouteRepository({
+    required this.catalogDatabase,
+    DateTime Function()? now,
+  }) : now = now ?? DateTime.now;
 
   final CatalogDatabase catalogDatabase;
+  final DateTime Function() now;
 
   Future<RouteCapabilityMetadata> routeCapability(
     RouteSearchRequest request,
@@ -91,7 +97,13 @@ class LocalRouteRepository implements RouteSearchRepository {
             ),
           );
 
-    return _toRouteSearchResult(request, result, catalog);
+    final plannedArrivals = await _plannedRideArrivals(result, catalog);
+    return _toRouteSearchResult(
+      request,
+      result,
+      catalog,
+      plannedArrivals: plannedArrivals,
+    );
   }
 
   @override
@@ -102,14 +114,15 @@ class LocalRouteRepository implements RouteSearchRepository {
   RouteSearchResult _toRouteSearchResult(
     RouteSearchRequest request,
     local.LocalRouteResult result,
-    _RouteCatalogSnapshot catalog,
-  ) {
+    _RouteCatalogSnapshot catalog, {
+    required Map<int, String> plannedArrivals,
+  }) {
     final originName = catalog.stationName(request.originStationId);
     final destinationName = catalog.stationName(request.destinationStationId);
     final lineIds = result.lineIds;
     final primaryLineId = lineIds.isEmpty ? '' : lineIds.first;
     final primaryLineName = catalog.lineName(primaryLineId);
-    final steps = _toSteps(result, catalog);
+    final steps = _toSteps(result, catalog, plannedArrivals: plannedArrivals);
 
     return RouteSearchResult(
       routeSearchId:
@@ -161,8 +174,9 @@ class LocalRouteRepository implements RouteSearchRepository {
 
   List<RouteSearchStep> _toSteps(
     local.LocalRouteResult result,
-    _RouteCatalogSnapshot catalog,
-  ) {
+    _RouteCatalogSnapshot catalog, {
+    required Map<int, String> plannedArrivals,
+  }) {
     return result.steps
         .map((step) {
           final fromStationId = catalog.stationIdForNode(step.fromNodeId);
@@ -198,9 +212,126 @@ class LocalRouteRepository implements RouteSearchRepository {
             timeSource: step.timeSource,
             distanceSource: step.distanceSource,
             confidenceLabel: step.confidenceLabel,
+            plannedArrivalTimeIso: plannedArrivals[step.sequence] ?? '',
           );
         })
         .toList(growable: false);
+  }
+
+  Future<Map<int, String>> _plannedRideArrivals(
+    local.LocalRouteResult result,
+    _RouteCatalogSnapshot catalog,
+  ) async {
+    if (result.status != local.RouteStatus.found) {
+      return const {};
+    }
+    final arrivals = <int, String>{};
+    var cursor = now().toUtc();
+    for (final step in result.steps) {
+      if (step.type != route_step.RouteStepType.ride) {
+        cursor = cursor.add(Duration(seconds: step.durationSeconds));
+        continue;
+      }
+      final arrival = await _nextTimetableArrival(
+        fromStationId: catalog.stationIdForNode(step.fromNodeId),
+        toStationId: catalog.stationIdForNode(step.toNodeId),
+        lineId: step.lineId,
+        cursor: cursor,
+      );
+      if (arrival == null) {
+        return const {};
+      }
+      arrivals[step.sequence] = _koreaIso(arrival);
+      cursor = arrival;
+    }
+    return arrivals;
+  }
+
+  Future<DateTime?> _nextTimetableArrival({
+    required String fromStationId,
+    required String toStationId,
+    required String lineId,
+    required DateTime cursor,
+  }) async {
+    final koreaNow = cursor.toUtc().add(const Duration(hours: 9));
+    var firstServiceDate = DateTime.utc(
+      koreaNow.year,
+      koreaNow.month,
+      koreaNow.day,
+    );
+    if (koreaNow.hour < 3) {
+      firstServiceDate = firstServiceDate.subtract(const Duration(days: 1));
+    }
+    for (var dayOffset = 0; dayOffset <= 7; dayOffset += 1) {
+      final serviceDate = firstServiceDate.add(Duration(days: dayOffset));
+      final serviceMidnight = serviceDate.subtract(const Duration(hours: 9));
+      final dateKey = _compactDate(serviceDate);
+      final weekdayColumn = _weekdayColumn(serviceDate.weekday);
+      final startSeconds = cursor.difference(serviceMidnight).inSeconds;
+      final row = await catalogDatabase
+          .customSelect(
+            '''
+        SELECT board.departure_seconds, alight.arrival_seconds
+        FROM transit_trips trip
+        INNER JOIN transit_routes route ON route.id = trip.route_id
+        INNER JOIN service_calendars calendar
+          ON calendar.service_id = trip.service_id
+        INNER JOIN transit_stop_times board ON board.trip_id = trip.id
+        INNER JOIN transit_stop_times alight ON alight.trip_id = trip.id
+        WHERE (
+            (
+              calendar.start_date <= ?
+              AND calendar.end_date >= ?
+              AND calendar.$weekdayColumn != 0
+            )
+            OR EXISTS (
+              SELECT 1
+              FROM service_calendar_dates added
+              WHERE added.service_id = trip.service_id
+                AND added.date = ?
+                AND added.exception_type = 1
+            )
+          )
+          AND NOT EXISTS (
+            SELECT 1
+            FROM service_calendar_dates removed
+            WHERE removed.service_id = trip.service_id
+              AND removed.date = ?
+              AND removed.exception_type = 2
+          )
+          AND route.line_id = ?
+          AND board.station_id = ?
+          AND board.line_id = ?
+          AND board.pickup_type != 1
+          AND alight.station_id = ?
+          AND alight.line_id = ?
+          AND alight.drop_off_type != 1
+          AND alight.stop_sequence > board.stop_sequence
+          AND board.departure_seconds >= ?
+        ORDER BY board.departure_seconds, alight.arrival_seconds, trip.id
+        LIMIT 1
+      ''',
+            variables: [
+              Variable.withString(dateKey),
+              Variable.withString(dateKey),
+              Variable.withString(dateKey),
+              Variable.withString(dateKey),
+              Variable.withString(lineId),
+              Variable.withString(fromStationId),
+              Variable.withString(lineId),
+              Variable.withString(toStationId),
+              Variable.withString(lineId),
+              Variable.withInt(startSeconds),
+            ],
+          )
+          .getSingleOrNull();
+      if (row != null) {
+        return serviceMidnight.add(
+          Duration(seconds: row.read<int>('arrival_seconds')),
+        );
+      }
+    }
+    return null;
   }
 
   int _estimatedDurationSeconds(List<RouteSearchStep> steps) {
@@ -1478,6 +1609,33 @@ int _estimatedMinutesFor(int durationSeconds) {
     return 0;
   }
   return (durationSeconds / 60).ceil().clamp(1, 999);
+}
+
+String _compactDate(DateTime date) {
+  String twoDigits(int value) => value.toString().padLeft(2, '0');
+  return '${date.year}${twoDigits(date.month)}${twoDigits(date.day)}';
+}
+
+String _weekdayColumn(int weekday) {
+  return switch (weekday) {
+    DateTime.monday => 'monday',
+    DateTime.tuesday => 'tuesday',
+    DateTime.wednesday => 'wednesday',
+    DateTime.thursday => 'thursday',
+    DateTime.friday => 'friday',
+    DateTime.saturday => 'saturday',
+    DateTime.sunday => 'sunday',
+    _ => throw ArgumentError.value(weekday, 'weekday'),
+  };
+}
+
+String _koreaIso(DateTime instant) {
+  final local = instant.toUtc().add(const Duration(hours: 9));
+  String twoDigits(int value) => value.toString().padLeft(2, '0');
+  return '${local.year.toString().padLeft(4, '0')}-'
+      '${twoDigits(local.month)}-${twoDigits(local.day)}T'
+      '${twoDigits(local.hour)}:${twoDigits(local.minute)}:'
+      '${twoDigits(local.second)}+09:00';
 }
 
 String _lineIdForNode(String nodeId) {

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -267,7 +267,13 @@ class LocalRouteRepository implements RouteSearchRepository {
       final serviceMidnight = serviceDate.subtract(const Duration(hours: 9));
       final dateKey = _compactDate(serviceDate);
       final weekdayColumn = _weekdayColumn(serviceDate.weekday);
-      final startSeconds = cursor.difference(serviceMidnight).inSeconds;
+      final startMicroseconds = cursor
+          .difference(serviceMidnight)
+          .inMicroseconds;
+      final startSeconds = startMicroseconds <= 0
+          ? 0
+          : (startMicroseconds + Duration.microsecondsPerSecond - 1) ~/
+                Duration.microsecondsPerSecond;
       final row = await catalogDatabase
           .customSelect(
             '''

--- a/apps/mobile/lib/features/routes/domain/route_step.dart
+++ b/apps/mobile/lib/features/routes/domain/route_step.dart
@@ -25,6 +25,7 @@ class RouteStep {
     required this.durationSeconds,
     this.distanceMeters = 0,
     this.lineId = '',
+    this.servicePattern = '',
     this.transferStationId = '',
     this.includesStairs = false,
     this.stairAccessState = 'unknown',
@@ -43,6 +44,7 @@ class RouteStep {
   final int durationSeconds;
   final int distanceMeters;
   final String lineId;
+  final String servicePattern;
   final String transferStationId;
   final bool includesStairs;
   final String stairAccessState;

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -82,7 +82,7 @@ Future<void> main() async {
         ? _DemoSearchHistoryRepository()
         : null,
   );
-  await bootstrap.dependencies.getOffAlarmController?.restore();
+  await restoreGetOffAlarmState(bootstrap.dependencies.getOffAlarmController);
   final photoPicker = ImagePickerFacilityReportPhotoPicker();
   runApp(
     AppBootstrapLifecycle(
@@ -103,6 +103,19 @@ Future<void> main() async {
       ),
     ),
   );
+}
+
+@visibleForTesting
+Future<void> restoreGetOffAlarmState(GetOffAlarmController? controller) async {
+  try {
+    await controller?.restore();
+  } catch (error, stackTrace) {
+    reportMobileError(
+      error,
+      stackTrace,
+      context: '하차 알림 시작 상태 복원 중 예외가 발생했습니다.',
+    );
+  }
 }
 
 void validateReleaseBuildFlags({

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -82,6 +82,7 @@ Future<void> main() async {
         ? _DemoSearchHistoryRepository()
         : null,
   );
+  await bootstrap.dependencies.getOffAlarmController?.restore();
   final photoPicker = ImagePickerFacilityReportPhotoPicker();
   runApp(
     AppBootstrapLifecycle(

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -88,6 +88,9 @@ Future<void> main() async {
     AppBootstrapLifecycle(
       close: bootstrap.close,
       resumeDataPackUpdate: bootstrap.resumeDataPackUpdate,
+      resumeGetOffAlarmState: () => reconcileGetOffAlarmState(
+        bootstrap.dependencies.getOffAlarmController,
+      ),
       child: EasySubwayApp(
         dependencies: bootstrap.dependencies,
         onboardingStore: const SecureOnboardingResultStore(),
@@ -114,6 +117,21 @@ Future<void> restoreGetOffAlarmState(GetOffAlarmController? controller) async {
       error,
       stackTrace,
       context: '하차 알림 시작 상태 복원 중 예외가 발생했습니다.',
+    );
+  }
+}
+
+@visibleForTesting
+Future<void> reconcileGetOffAlarmState(
+  GetOffAlarmController? controller,
+) async {
+  try {
+    await controller?.reconcile();
+  } catch (error, stackTrace) {
+    reportMobileError(
+      error,
+      stackTrace,
+      context: '하차 알림 foreground 상태 재조정 중 예외가 발생했습니다.',
     );
   }
 }

--- a/apps/mobile/lib/notification_settings.dart
+++ b/apps/mobile/lib/notification_settings.dart
@@ -34,6 +34,9 @@ abstract class DeviceRegistrationRepository {
 
 abstract class NotificationPermissionProvider {
   Future<NotificationPermissionStatus> requestNotificationPermission();
+
+  /// 시스템 설정의 현재 알림 권한만 읽고 프롬프트를 띄우지 않는다.
+  Future<NotificationPermissionStatus> notificationPermissionStatus();
 }
 
 enum NotificationPermissionStatus { granted, denied }
@@ -49,15 +52,22 @@ class MethodChannelNotificationPermissionProvider
 
   @override
   Future<NotificationPermissionStatus> requestNotificationPermission() async {
+    return _readStatus('requestNotificationPermission');
+  }
+
+  @override
+  Future<NotificationPermissionStatus> notificationPermissionStatus() async {
+    return _readStatus('notificationPermissionStatus');
+  }
+
+  Future<NotificationPermissionStatus> _readStatus(String method) async {
     try {
-      final granted =
-          await _channel.invokeMethod<bool>('requestNotificationPermission') ??
-          false;
+      final granted = await _channel.invokeMethod<bool>(method) ?? false;
       return granted
           ? NotificationPermissionStatus.granted
           : NotificationPermissionStatus.denied;
     } on PlatformException catch (error, stackTrace) {
-      reportMobileError(error, stackTrace, context: '알림 켜기 요청 중 예외가 발생했습니다.');
+      reportMobileError(error, stackTrace, context: '알림 권한 확인 중 예외가 발생했습니다.');
       throw const NotificationSettingsException(
         _notificationPermissionErrorMessage,
       );

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -4263,17 +4263,22 @@ class _GetOffAlarmEntryPoint extends StatelessWidget {
 }
 
 List<RideLegArrival> _rideLegArrivalsFromResult(RouteSearchResult result) {
+  final rideSteps = result.steps
+      .where((step) => step.stepType == 'ride')
+      .toList(growable: false);
+  if (rideSteps.isEmpty ||
+      rideSteps.any((step) => step.plannedArrivalTimeIso.isEmpty)) {
+    return const [];
+  }
   final rideLegs = <RideLegArrival>[];
-  for (final step in result.steps) {
-    if (step.stepType == 'ride' && step.plannedArrivalTimeIso.isNotEmpty) {
-      rideLegs.add(
-        RideLegArrival(
-          toStationId: step.toStationId,
-          plannedArrivalIso: step.plannedArrivalTimeIso,
-          realtimeArrivalIso: step.realtimeArrivalTimeIso,
-        ),
-      );
-    }
+  for (final step in rideSteps) {
+    rideLegs.add(
+      RideLegArrival(
+        toStationId: step.toStationId,
+        plannedArrivalIso: step.plannedArrivalTimeIso,
+        realtimeArrivalIso: step.realtimeArrivalTimeIso,
+      ),
+    );
   }
   return rideLegs;
 }

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -23,6 +23,8 @@ const _routeSearchTimeout = Duration(seconds: 8);
 const _routeSearchErrorMessage = '경로 정보를 불러오지 못했어요.';
 const _routeOnlineSearchErrorMessage = '실시간/서버 경로를 확인하지 못했어요.';
 const _routeRefreshErrorMessage = '도착 시간을 새로 확인하지 못했어요.';
+const _getOffAlarmRefreshRollbackMessage = '하차 알림을 갱신하지 못해 이전 경로를 유지해요.';
+const _getOffAlarmRefreshFailureMessage = '하차 알림을 새로 맞추지 못했어요. 이전 경로를 유지해요.';
 const _routeFeedbackErrorMessage = '의견을 보내지 못했어요.';
 const _favoriteRouteErrorMessage = '즐겨찾기 경로를 바꾸지 못했어요.';
 const _favoriteRouteLoadErrorMessage = '즐겨찾기 경로를 불러오지 못했어요.';
@@ -2394,6 +2396,23 @@ class RouteSearchController extends ChangeNotifier {
     }
   }
 
+  bool rollbackRefreshAfterAlarmFailure({
+    required RouteSearchState previousState,
+    required RouteSearchResult expectedCurrentResult,
+    required String refreshMessage,
+  }) {
+    if (_disposed || !identical(_state.result, expectedCurrentResult)) {
+      return false;
+    }
+    _emitState(
+      previousState.copyWith(
+        isRefreshing: false,
+        refreshMessage: refreshMessage,
+      ),
+    );
+    return true;
+  }
+
   void reset() {
     if (_disposed) {
       return;
@@ -2501,6 +2520,7 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
   }
 
   Future<void> _refreshCurrentRouteAndAlarm() async {
+    final previousState = _controller.state;
     final outcome = await _controller.refreshCurrentRoute();
     if (!mounted) {
       return;
@@ -2518,7 +2538,13 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
     final rideLegs = _rideLegArrivalsFromResult(result);
     if (rideLegs.isEmpty) {
       if (outcome.refreshed) {
-        await _disableActiveGetOffAlarm();
+        final disabled = await _disableActiveGetOffAlarm();
+        if (!disabled) {
+          _rollbackRouteAfterAlarmFailure(
+            previousState: previousState,
+            expectedCurrentResult: result,
+          );
+        }
       }
       return;
     }
@@ -2541,13 +2567,31 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
           activeSubscription.destination.stationId:
               activeSubscription.destination.stationName,
       };
+      final stationNames = <String, String>{};
+      for (final leg in rideLegs) {
+        final stationId = leg.toStationId;
+        if (stationNames.containsKey(stationId)) {
+          continue;
+        }
+        final stationName = await _resolveGetOffAlarmStationName(
+          stationId: stationId,
+          result: result,
+          stationRepository: widget.stationRepository,
+          preferredStationNames: activeStationNames,
+        );
+        if (stationName == null) {
+          throw StateError('하차 알림 역명을 확인하지 못했습니다.');
+        }
+        stationNames[stationId] = stationName;
+      }
+      if (!mounted ||
+          !identical(_controller.state.result, result) ||
+          !getOffAlarmController.state.enabled) {
+        return;
+      }
       final stops = getOffAlarmStopsFromRideLegs(
         rideLegs: rideLegs,
-        stationName: (id) =>
-            activeStationNames[id] ??
-            (id == result.destinationStationId
-                ? result.destinationStationName
-                : id),
+        stationName: (id) => stationNames[id]!,
         source: source,
       );
       final destination = stops.last;
@@ -2569,12 +2613,34 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
         );
       }
     } catch (error, stackTrace) {
+      final rolledBack =
+          outcome.refreshed &&
+          _rollbackRouteAfterAlarmFailure(
+            previousState: previousState,
+            expectedCurrentResult: result,
+          );
       reportMobileError(
         error,
         stackTrace,
         context: '하차 알림 foreground 재예약 중 예외가 발생했습니다.',
       );
+      if (mounted && rolledBack) {
+        ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+          const SnackBar(content: Text(_getOffAlarmRefreshFailureMessage)),
+        );
+      }
     }
+  }
+
+  bool _rollbackRouteAfterAlarmFailure({
+    required RouteSearchState previousState,
+    required RouteSearchResult expectedCurrentResult,
+  }) {
+    return _controller.rollbackRefreshAfterAlarmFailure(
+      previousState: previousState,
+      expectedCurrentResult: expectedCurrentResult,
+      refreshMessage: _getOffAlarmRefreshRollbackMessage,
+    );
   }
 
   @override
@@ -2720,6 +2786,7 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
                         ? null
                         : _endRoute,
                     getOffAlarmController: widget.getOffAlarmController,
+                    stationRepository: widget.stationRepository,
                   ),
                 ),
               ],
@@ -3013,6 +3080,9 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
     );
 
     if (!mounted || selectedMobilityType == null) {
+      return;
+    }
+    if (selectedMobilityType == _selectedMobilityType) {
       return;
     }
     if (!await _disableActiveGetOffAlarm()) {
@@ -3963,6 +4033,7 @@ class _RouteSearchBody extends StatelessWidget {
     required this.favoriteRouteRepository,
     required this.onShellBackToHome,
     required this.getOffAlarmController,
+    required this.stationRepository,
   });
 
   final RouteSearchState state;
@@ -3970,6 +4041,7 @@ class _RouteSearchBody extends StatelessWidget {
   final FavoriteRouteRepository? favoriteRouteRepository;
   final AsyncCallback? onShellBackToHome;
   final GetOffAlarmController? getOffAlarmController;
+  final StationSearchRepository stationRepository;
 
   @override
   Widget build(BuildContext context) {
@@ -3996,6 +4068,7 @@ class _RouteSearchBody extends StatelessWidget {
         favoriteRouteRepository: favoriteRouteRepository,
         onShellBackToHome: onShellBackToHome,
         getOffAlarmController: getOffAlarmController,
+        stationRepository: stationRepository,
       ),
     };
   }
@@ -4138,6 +4211,7 @@ class _RouteSearchResultCard extends StatefulWidget {
     required this.favoriteRouteRepository,
     required this.onShellBackToHome,
     required this.getOffAlarmController,
+    required this.stationRepository,
   });
 
   final RouteSearchResult result;
@@ -4147,6 +4221,7 @@ class _RouteSearchResultCard extends StatefulWidget {
   final FavoriteRouteRepository? favoriteRouteRepository;
   final AsyncCallback? onShellBackToHome;
   final GetOffAlarmController? getOffAlarmController;
+  final StationSearchRepository stationRepository;
 
   @override
   State<_RouteSearchResultCard> createState() => _RouteSearchResultCardState();
@@ -4178,6 +4253,7 @@ class _RouteSearchResultCardState extends State<_RouteSearchResultCard> {
             _GetOffAlarmEntryPoint(
               controller: widget.getOffAlarmController!,
               result: result,
+              stationRepository: widget.stationRepository,
             ),
         ],
       ),
@@ -4298,10 +4374,12 @@ class _GetOffAlarmEntryPoint extends StatelessWidget {
   const _GetOffAlarmEntryPoint({
     required this.controller,
     required this.result,
+    required this.stationRepository,
   });
 
   final GetOffAlarmController controller;
   final RouteSearchResult result;
+  final StationSearchRepository stationRepository;
 
   @override
   Widget build(BuildContext context) {
@@ -4315,12 +4393,48 @@ class _GetOffAlarmEntryPoint extends StatelessWidget {
         controller: controller,
         routeId: result.routeSearchId,
         rideLegs: rideLegs,
-        stationName: (id) => id == result.destinationStationId
-            ? result.destinationStationName
-            : id,
+        stationName: (id) => _resolveGetOffAlarmStationName(
+          stationId: id,
+          result: result,
+          stationRepository: stationRepository,
+        ),
       ),
     );
   }
+}
+
+Future<String?> _resolveGetOffAlarmStationName({
+  required String stationId,
+  required RouteSearchResult result,
+  required StationSearchRepository stationRepository,
+  Map<String, String> preferredStationNames = const {},
+}) async {
+  final preferredName = _usableGetOffAlarmStationName(
+    preferredStationNames[stationId],
+    stationId,
+  );
+  if (preferredName != null) {
+    return preferredName;
+  }
+  if (stationId == result.destinationStationId) {
+    return _usableGetOffAlarmStationName(
+      result.destinationStationName,
+      stationId,
+    );
+  }
+  final detail = await stationRepository.getStationDetail(stationId);
+  if (detail.id != stationId) {
+    return null;
+  }
+  return _usableGetOffAlarmStationName(detail.nameKo, stationId);
+}
+
+String? _usableGetOffAlarmStationName(String? rawName, String stationId) {
+  final stationName = rawName?.trim();
+  if (stationName == null || stationName.isEmpty || stationName == stationId) {
+    return null;
+  }
+  return stationName;
 }
 
 List<RideLegArrival> _rideLegArrivalsFromResult(RouteSearchResult result) {

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -2219,6 +2219,13 @@ class RouteSearchState {
   }
 }
 
+class RouteRefreshOutcome {
+  const RouteRefreshOutcome({required this.result, required this.refreshed});
+
+  final RouteSearchResult? result;
+  final bool refreshed;
+}
+
 class RouteSearchController extends ChangeNotifier {
   RouteSearchController({required this.repository});
 
@@ -2286,16 +2293,16 @@ class RouteSearchController extends ChangeNotifier {
     }
   }
 
-  Future<void> refreshCurrentRoute() async {
+  Future<RouteRefreshOutcome> refreshCurrentRoute() async {
     if (_disposed) {
-      return;
+      return RouteRefreshOutcome(result: _state.result, refreshed: false);
     }
     final currentResult = _state.result;
     if (_state.status != RouteSearchViewStatus.success ||
         currentResult == null ||
         currentResult.isLocalResult ||
         _state.isRefreshing) {
-      return;
+      return RouteRefreshOutcome(result: currentResult, refreshed: false);
     }
 
     final refreshRequestId = _searchRequestId;
@@ -2309,7 +2316,7 @@ class RouteSearchController extends ChangeNotifier {
     try {
       final refreshed = await repository.refreshRoute(refreshRouteSearchId);
       if (staleRefresh()) {
-        return;
+        return RouteRefreshOutcome(result: _state.result, refreshed: false);
       }
       final refreshedResult = _preserveGetOffAlarmArrivalTimes(
         next: refreshed.result,
@@ -2322,13 +2329,15 @@ class RouteSearchController extends ChangeNotifier {
           refreshMessage: refreshed.userMessage,
         ),
       );
+      return RouteRefreshOutcome(result: refreshedResult, refreshed: true);
     } on RouteSearchException catch (error) {
       if (staleRefresh()) {
-        return;
+        return RouteRefreshOutcome(result: _state.result, refreshed: false);
       }
       _emitState(
         _state.copyWith(isRefreshing: false, refreshMessage: error.message),
       );
+      return RouteRefreshOutcome(result: _state.result, refreshed: false);
     } catch (error, stackTrace) {
       reportMobileError(
         error,
@@ -2336,7 +2345,7 @@ class RouteSearchController extends ChangeNotifier {
         context: '경로 ETA refresh 처리 중 예외가 발생했습니다.',
       );
       if (staleRefresh()) {
-        return;
+        return RouteRefreshOutcome(result: _state.result, refreshed: false);
       }
       _emitState(
         _state.copyWith(
@@ -2344,6 +2353,7 @@ class RouteSearchController extends ChangeNotifier {
           refreshMessage: _routeRefreshErrorMessage,
         ),
       );
+      return RouteRefreshOutcome(result: _state.result, refreshed: false);
     }
   }
 
@@ -2454,37 +2464,53 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
   }
 
   Future<void> _refreshCurrentRouteAndAlarm() async {
-    await _controller.refreshCurrentRoute();
+    final outcome = await _controller.refreshCurrentRoute();
     if (!mounted) {
       return;
     }
     final getOffAlarmController = widget.getOffAlarmController;
-    final result = _controller.state.result;
-    if (getOffAlarmController == null || result == null) {
+    final result = outcome.result;
+    if (getOffAlarmController == null ||
+        !getOffAlarmController.state.enabled ||
+        result == null) {
       return;
     }
     final rideLegs = _rideLegArrivalsFromResult(result);
     if (rideLegs.isEmpty) {
       return;
     }
+    final source =
+        outcome.refreshed &&
+            rideLegs.any((leg) => leg.realtimeArrivalIso?.isNotEmpty ?? false)
+        ? GetOffAlarmTimeSource.realtime
+        : GetOffAlarmTimeSource.planned;
     try {
       final activeSubscription = await getOffAlarmController.repository
           .loadActive();
       if (!mounted) {
         return;
       }
+      final stops = getOffAlarmStopsFromRideLegs(
+        rideLegs: rideLegs,
+        stationName: (id) => id,
+        source: source,
+      );
+      final destination = stops.last;
+      final previousArrivalAt = activeSubscription?.destination.arrivalAt;
+      final deltaSeconds = previousArrivalAt == null
+          ? 0
+          : destination.arrivalAt.difference(previousArrivalAt).inSeconds;
+      final changed = previousArrivalAt != null && deltaSeconds != 0;
       await getOffAlarmController.refresh(
-        stops: getOffAlarmStopsFromRideLegs(
-          rideLegs: rideLegs,
-          stationName: (id) => id,
-        ),
+        stops: stops,
         transferAlarmEnabled: activeSubscription?.transferAlarmEnabled ?? true,
       );
       if (kDebugMode && getOffAlarmController.state.enabled) {
         debugPrint(
-          'get_off_alarm foreground_refresh '
-          'scheduled_count=${getOffAlarmController.state.scheduledCount} '
-          'mode=${getOffAlarmController.state.scheduleMode?.name ?? 'unknown'}',
+          'get_off_alarm foreground_refresh changed=$changed '
+          'delta_seconds=$deltaSeconds source=${source.name} '
+          'mode=${getOffAlarmController.state.scheduleMode?.name} '
+          'scheduled_count=${getOffAlarmController.state.scheduledCount}',
         );
       }
     } catch (error, stackTrace) {
@@ -2547,7 +2573,9 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
         child: SafeArea(
           child: RefreshIndicator(
             key: const Key('routeResultRefreshIndicator'),
-            onRefresh: _controller.refreshCurrentRoute,
+            onRefresh: () async {
+              await _controller.refreshCurrentRoute();
+            },
             child: ListView(
               physics: const AlwaysScrollableScrollPhysics(),
               padding: _routeSearchPagePadding,
@@ -2647,7 +2675,9 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
                     state: _controller.state,
                     routeFeedbackRepository: widget.routeFeedbackRepository,
                     favoriteRouteRepository: widget.favoriteRouteRepository,
-                    onShellBackToHome: widget.onShellBackToHome,
+                    onShellBackToHome: widget.onShellBackToHome == null
+                        ? null
+                        : _endRoute,
                     getOffAlarmController: widget.getOffAlarmController,
                   ),
                 ),
@@ -2672,7 +2702,7 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
           canPop: false,
           onPopInvokedWithResult: (didPop, _) {
             if (!didPop) {
-              onShellBackToHome();
+              unawaited(_endRoute());
             }
           },
           child: child!,
@@ -2681,11 +2711,31 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
     );
   }
 
-  void _submit() {
+  Future<void> _disableActiveGetOffAlarm() async {
+    final getOffAlarmController = widget.getOffAlarmController;
+    if (getOffAlarmController?.state.enabled ?? false) {
+      await getOffAlarmController!.disable();
+    }
+  }
+
+  Future<void> _endRoute() async {
+    await _disableActiveGetOffAlarm();
+    if (!mounted) {
+      return;
+    }
+    _controller.reset();
+    widget.onShellBackToHome?.call();
+  }
+
+  Future<void> _submit() async {
     if (_controller.state.status == RouteSearchViewStatus.loading) {
       return;
     }
     if (_originStation == null || _destinationStation == null) {
+      await _disableActiveGetOffAlarm();
+      if (!mounted) {
+        return;
+      }
       _controller.reset();
       setState(() {
         _validationMessage = '출발역과 도착역을 검색 결과에서 선택해 주세요.';
@@ -2695,9 +2745,13 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
     setState(() {
       _validationMessage = '';
     });
+    await _disableActiveGetOffAlarm();
+    if (!mounted) {
+      return;
+    }
 
     // 화면에는 역 이름을 보여주지만 API에는 안정적인 station id만 전달한다.
-    _controller.search(
+    await _controller.search(
       RouteSearchRequest(
         originStationId: _originStation!.id,
         destinationStationId: _destinationStation!.id,
@@ -2726,7 +2780,11 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
     );
   }
 
-  void _updateOriginStation(StationSearchResult? station) {
+  Future<void> _updateOriginStation(StationSearchResult? station) async {
+    await _disableActiveGetOffAlarm();
+    if (!mounted) {
+      return;
+    }
     setState(() {
       _originStation = station;
       if (station != null) {
@@ -2737,7 +2795,11 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
     _controller.reset();
   }
 
-  void _updateDestinationStation(StationSearchResult? station) {
+  Future<void> _updateDestinationStation(StationSearchResult? station) async {
+    await _disableActiveGetOffAlarm();
+    if (!mounted) {
+      return;
+    }
     setState(() {
       _destinationStation = station;
       if (station != null) {
@@ -2755,7 +2817,11 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
     });
   }
 
-  void _swapStations() {
+  Future<void> _swapStations() async {
+    await _disableActiveGetOffAlarm();
+    if (!mounted) {
+      return;
+    }
     setState(() {
       final origin = _originStation;
       _originStation = _destinationStation;
@@ -2850,6 +2916,10 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
     );
 
     if (!mounted || selectedMobilityType == null) {
+      return;
+    }
+    await _disableActiveGetOffAlarm();
+    if (!mounted) {
       return;
     }
     setState(() {
@@ -4200,7 +4270,7 @@ RouteSearchResult _preserveGetOffAlarmArrivalTimes({
           lineName: step.lineName,
           actionDetail: step.actionDetail,
           plannedArrivalTimeIso: matched.plannedArrivalTimeIso,
-          realtimeArrivalTimeIso: matched.realtimeArrivalTimeIso,
+          realtimeArrivalTimeIso: step.realtimeArrivalTimeIso,
         );
       })
       .toList(growable: false);

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -2517,6 +2517,9 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
     }
     final rideLegs = _rideLegArrivalsFromResult(result);
     if (rideLegs.isEmpty) {
+      if (outcome.refreshed) {
+        await _disableActiveGetOffAlarm();
+      }
       return;
     }
     final source =
@@ -2530,9 +2533,21 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
       if (!mounted) {
         return;
       }
+      final activeStationNames = <String, String>{
+        if (activeSubscription != null)
+          for (final transfer in activeSubscription.transfers)
+            transfer.stationId: transfer.stationName,
+        if (activeSubscription != null)
+          activeSubscription.destination.stationId:
+              activeSubscription.destination.stationName,
+      };
       final stops = getOffAlarmStopsFromRideLegs(
         rideLegs: rideLegs,
-        stationName: (id) => id,
+        stationName: (id) =>
+            activeStationNames[id] ??
+            (id == result.destinationStationId
+                ? result.destinationStationName
+                : id),
         source: source,
       );
       final destination = stops.last;
@@ -2613,9 +2628,7 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
         child: SafeArea(
           child: RefreshIndicator(
             key: const Key('routeResultRefreshIndicator'),
-            onRefresh: () async {
-              await _controller.refreshCurrentRoute();
-            },
+            onRefresh: _refreshCurrentRouteAndAlarm,
             child: ListView(
               physics: const AlwaysScrollableScrollPhysics(),
               padding: _routeSearchPagePadding,
@@ -2675,17 +2688,11 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
                               child: Text(option.title),
                             ),
                         ],
-                        onChanged: (value) {
+                        onChanged: (value) async {
                           if (value == null) {
                             return;
                           }
-                          setState(() {
-                            _selectedMobilityType = value;
-                            _selectedConstraintMode =
-                                RouteSearchRequest._defaultConstraintMode(
-                                  value,
-                                );
-                          });
+                          await _updateMobilityType(value);
                         },
                       ),
                     ),
@@ -2697,13 +2704,7 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
                   // 결과 화면에서 안내한다(#1568).
                   title: const Text('계단 없는 길만'),
                   value: _selectedConstraintMode == 'STRICT_STEP_FREE',
-                  onChanged: (value) {
-                    setState(() {
-                      _selectedConstraintMode = value
-                          ? 'STRICT_STEP_FREE'
-                          : 'PREFER_STEP_FREE';
-                    });
-                  },
+                  onChanged: _updateConstraintMode,
                 ),
                 _RouteRecentDestinationList(
                   repository: widget.favoriteRouteRepository,
@@ -2740,9 +2741,9 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
         }
         return PopScope(
           canPop: false,
-          onPopInvokedWithResult: (didPop, _) {
+          onPopInvokedWithResult: (didPop, _) async {
             if (!didPop) {
-              unawaited(_endRoute());
+              await _endRoute();
             }
           },
           child: child!,
@@ -2751,15 +2752,29 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
     );
   }
 
-  Future<void> _disableActiveGetOffAlarm() async {
+  Future<bool> _disableActiveGetOffAlarm() async {
     final getOffAlarmController = widget.getOffAlarmController;
-    if (getOffAlarmController != null) {
+    if (getOffAlarmController == null) {
+      return true;
+    }
+    try {
       await getOffAlarmController.disable();
+      return true;
+    } catch (error, stackTrace) {
+      reportMobileError(error, stackTrace, context: '하차 알림 취소 중 예외가 발생했습니다.');
+      if (mounted) {
+        ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+          const SnackBar(content: Text('하차 알림을 취소하지 못했어요. 다시 시도해 주세요.')),
+        );
+      }
+      return false;
     }
   }
 
   Future<void> _endRoute() async {
-    await _disableActiveGetOffAlarm();
+    if (!await _disableActiveGetOffAlarm()) {
+      return;
+    }
     if (!mounted) {
       return;
     }
@@ -2772,7 +2787,9 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
       return;
     }
     if (_originStation == null || _destinationStation == null) {
-      await _disableActiveGetOffAlarm();
+      if (!await _disableActiveGetOffAlarm()) {
+        return;
+      }
       if (!mounted) {
         return;
       }
@@ -2785,7 +2802,9 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
     setState(() {
       _validationMessage = '';
     });
-    await _disableActiveGetOffAlarm();
+    if (!await _disableActiveGetOffAlarm()) {
+      return;
+    }
     if (!mounted) {
       return;
     }
@@ -2821,7 +2840,9 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
   }
 
   Future<void> _updateOriginStation(StationSearchResult? station) async {
-    await _disableActiveGetOffAlarm();
+    if (!await _disableActiveGetOffAlarm()) {
+      return;
+    }
     if (!mounted) {
       return;
     }
@@ -2836,7 +2857,9 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
   }
 
   Future<void> _updateDestinationStation(StationSearchResult? station) async {
-    await _disableActiveGetOffAlarm();
+    if (!await _disableActiveGetOffAlarm()) {
+      return;
+    }
     if (!mounted) {
       return;
     }
@@ -2858,7 +2881,9 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
   }
 
   Future<void> _swapStations() async {
-    await _disableActiveGetOffAlarm();
+    if (!await _disableActiveGetOffAlarm()) {
+      return;
+    }
     if (!mounted) {
       return;
     }
@@ -2869,6 +2894,38 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
       _activeStationPicker = null;
       _validationMessage = '';
     });
+    _controller.reset();
+  }
+
+  Future<void> _updateMobilityType(String mobilityType) async {
+    if (mobilityType == _selectedMobilityType ||
+        !await _disableActiveGetOffAlarm()) {
+      return;
+    }
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _selectedMobilityType = mobilityType;
+      _selectedConstraintMode = RouteSearchRequest._defaultConstraintMode(
+        mobilityType,
+      );
+    });
+    _controller.reset();
+  }
+
+  Future<void> _updateConstraintMode(bool strictStepFree) async {
+    final constraintMode = strictStepFree
+        ? 'STRICT_STEP_FREE'
+        : 'PREFER_STEP_FREE';
+    if (constraintMode == _selectedConstraintMode ||
+        !await _disableActiveGetOffAlarm()) {
+      return;
+    }
+    if (!mounted) {
+      return;
+    }
+    setState(() => _selectedConstraintMode = constraintMode);
     _controller.reset();
   }
 
@@ -2958,7 +3015,9 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
     if (!mounted || selectedMobilityType == null) {
       return;
     }
-    await _disableActiveGetOffAlarm();
+    if (!await _disableActiveGetOffAlarm()) {
+      return;
+    }
     if (!mounted) {
       return;
     }
@@ -3909,7 +3968,7 @@ class _RouteSearchBody extends StatelessWidget {
   final RouteSearchState state;
   final RouteFeedbackRepository? routeFeedbackRepository;
   final FavoriteRouteRepository? favoriteRouteRepository;
-  final VoidCallback? onShellBackToHome;
+  final AsyncCallback? onShellBackToHome;
   final GetOffAlarmController? getOffAlarmController;
 
   @override
@@ -4086,7 +4145,7 @@ class _RouteSearchResultCard extends StatefulWidget {
   final bool isRefreshing;
   final RouteFeedbackRepository? routeFeedbackRepository;
   final FavoriteRouteRepository? favoriteRouteRepository;
-  final VoidCallback? onShellBackToHome;
+  final AsyncCallback? onShellBackToHome;
   final GetOffAlarmController? getOffAlarmController;
 
   @override
@@ -4142,9 +4201,9 @@ class _RouteSearchResultCardState extends State<_RouteSearchResultCard> {
     }
     return PopScope(
       canPop: false,
-      onPopInvokedWithResult: (didPop, _) {
+      onPopInvokedWithResult: (didPop, _) async {
         if (!didPop) {
-          onShellBackToHome();
+          await onShellBackToHome();
         }
       },
       child: content,
@@ -4256,7 +4315,9 @@ class _GetOffAlarmEntryPoint extends StatelessWidget {
         controller: controller,
         routeId: result.routeSearchId,
         rideLegs: rideLegs,
-        stationName: (id) => id,
+        stationName: (id) => id == result.destinationStationId
+            ? result.destinationStationName
+            : id,
       ),
     );
   }

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -2220,10 +2220,15 @@ class RouteSearchState {
 }
 
 class RouteRefreshOutcome {
-  const RouteRefreshOutcome({required this.result, required this.refreshed});
+  const RouteRefreshOutcome({
+    required this.result,
+    required this.refreshed,
+    required this.alarmRefreshRequired,
+  });
 
   final RouteSearchResult? result;
   final bool refreshed;
+  final bool alarmRefreshRequired;
 }
 
 class RouteSearchController extends ChangeNotifier {
@@ -2295,14 +2300,22 @@ class RouteSearchController extends ChangeNotifier {
 
   Future<RouteRefreshOutcome> refreshCurrentRoute() async {
     if (_disposed) {
-      return RouteRefreshOutcome(result: _state.result, refreshed: false);
+      return RouteRefreshOutcome(
+        result: _state.result,
+        refreshed: false,
+        alarmRefreshRequired: false,
+      );
     }
     final currentResult = _state.result;
     if (_state.status != RouteSearchViewStatus.success ||
         currentResult == null ||
         currentResult.isLocalResult ||
         _state.isRefreshing) {
-      return RouteRefreshOutcome(result: currentResult, refreshed: false);
+      return RouteRefreshOutcome(
+        result: currentResult,
+        refreshed: false,
+        alarmRefreshRequired: false,
+      );
     }
 
     final refreshRequestId = _searchRequestId;
@@ -2316,7 +2329,11 @@ class RouteSearchController extends ChangeNotifier {
     try {
       final refreshed = await repository.refreshRoute(refreshRouteSearchId);
       if (staleRefresh()) {
-        return RouteRefreshOutcome(result: _state.result, refreshed: false);
+        return RouteRefreshOutcome(
+          result: _state.result,
+          refreshed: false,
+          alarmRefreshRequired: false,
+        );
       }
       final refreshedResult = _preserveGetOffAlarmArrivalTimes(
         next: refreshed.result,
@@ -2329,15 +2346,27 @@ class RouteSearchController extends ChangeNotifier {
           refreshMessage: refreshed.userMessage,
         ),
       );
-      return RouteRefreshOutcome(result: refreshedResult, refreshed: true);
+      return RouteRefreshOutcome(
+        result: refreshedResult,
+        refreshed: true,
+        alarmRefreshRequired: true,
+      );
     } on RouteSearchException catch (error) {
       if (staleRefresh()) {
-        return RouteRefreshOutcome(result: _state.result, refreshed: false);
+        return RouteRefreshOutcome(
+          result: _state.result,
+          refreshed: false,
+          alarmRefreshRequired: false,
+        );
       }
       _emitState(
         _state.copyWith(isRefreshing: false, refreshMessage: error.message),
       );
-      return RouteRefreshOutcome(result: _state.result, refreshed: false);
+      return RouteRefreshOutcome(
+        result: _state.result,
+        refreshed: false,
+        alarmRefreshRequired: true,
+      );
     } catch (error, stackTrace) {
       reportMobileError(
         error,
@@ -2345,7 +2374,11 @@ class RouteSearchController extends ChangeNotifier {
         context: '경로 ETA refresh 처리 중 예외가 발생했습니다.',
       );
       if (staleRefresh()) {
-        return RouteRefreshOutcome(result: _state.result, refreshed: false);
+        return RouteRefreshOutcome(
+          result: _state.result,
+          refreshed: false,
+          alarmRefreshRequired: false,
+        );
       }
       _emitState(
         _state.copyWith(
@@ -2353,7 +2386,11 @@ class RouteSearchController extends ChangeNotifier {
           refreshMessage: _routeRefreshErrorMessage,
         ),
       );
-      return RouteRefreshOutcome(result: _state.result, refreshed: false);
+      return RouteRefreshOutcome(
+        result: _state.result,
+        refreshed: false,
+        alarmRefreshRequired: true,
+      );
     }
   }
 
@@ -2466,6 +2503,9 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
   Future<void> _refreshCurrentRouteAndAlarm() async {
     final outcome = await _controller.refreshCurrentRoute();
     if (!mounted) {
+      return;
+    }
+    if (!outcome.alarmRefreshRequired) {
       return;
     }
     final getOffAlarmController = widget.getOffAlarmController;

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -2753,8 +2753,8 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
 
   Future<void> _disableActiveGetOffAlarm() async {
     final getOffAlarmController = widget.getOffAlarmController;
-    if (getOffAlarmController?.state.enabled ?? false) {
-      await getOffAlarmController!.disable();
+    if (getOffAlarmController != null) {
+      await getOffAlarmController.disable();
     }
   }
 

--- a/apps/mobile/test/core/database/mobile_local_database_test.dart
+++ b/apps/mobile/test/core/database/mobile_local_database_test.dart
@@ -61,6 +61,25 @@ void main() {
     expect(resumeCalled.isCompleted, isTrue);
   });
 
+  testWidgets('앱 lifecycle은 resumed에서 하차 알림 상태를 재조정한다', (tester) async {
+    final reconcileCalled = Completer<void>();
+
+    await tester.pumpWidget(
+      AppBootstrapLifecycle(
+        close: () => Future<void>.value(),
+        resumeGetOffAlarmState: () {
+          reconcileCalled.complete();
+          return Future<void>.value();
+        },
+        child: const SizedBox.shrink(),
+      ),
+    );
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+
+    await reconcileCalled.future.timeout(const Duration(seconds: 5));
+    expect(reconcileCalled.isCompleted, isTrue);
+  });
+
   test('catalog DB는 앱 시작에 필요한 schema와 index를 만든다', () async {
     final database = CatalogDatabase.memory();
     addTearDown(database.close);

--- a/apps/mobile/test/features/get_off_alarm/get_off_alarm_controller_test.dart
+++ b/apps/mobile/test/features/get_off_alarm/get_off_alarm_controller_test.dart
@@ -21,12 +21,15 @@ class _RecordingNotifier implements GetOffAlarmNotifier {
   int cancelAllCount = 0;
   Completer<void>? cancelBarrier;
   Object? cancelErrorOnce;
+  int? pendingCount;
+  int scheduleCalls = 0;
 
   @override
   Future<ScheduleDeliveryResult> scheduleAlarms(
     List<ScheduledGetOffAlarm> alarms, {
     required GetOffAlarmScheduleMode mode,
   }) async {
+    scheduleCalls += 1;
     scheduledAlarms = alarms;
     scheduledMode = mode;
     return result ??
@@ -43,18 +46,28 @@ class _RecordingNotifier implements GetOffAlarmNotifier {
     }
     await cancelBarrier?.future;
   }
+
+  @override
+  Future<int> pendingAlarmCount() async =>
+      pendingCount ?? result?.scheduledCount ?? scheduledAlarms?.length ?? 0;
 }
 
 class _RecordingStateRepository implements GetOffAlarmStateRepository {
-  _RecordingStateRepository({this.loadError});
+  _RecordingStateRepository({this.loadError, this.saveError, this.clearError});
 
   GetOffAlarmSubscription? active;
   Object? loadError;
+  Object? saveError;
+  Object? clearError;
   int clearCount = 0;
 
   @override
   Future<void> clearActive() async {
     clearCount += 1;
+    final error = clearError;
+    if (error != null) {
+      throw error;
+    }
     active = null;
   }
 
@@ -69,6 +82,10 @@ class _RecordingStateRepository implements GetOffAlarmStateRepository {
 
   @override
   Future<void> saveActive(GetOffAlarmSubscription subscription) async {
+    final error = saveError;
+    if (error != null) {
+      throw error;
+    }
     active = subscription;
   }
 }
@@ -115,11 +132,21 @@ class _StubNotificationPermissionProvider
     implements NotificationPermissionProvider {
   _StubNotificationPermissionProvider(this.status);
 
-  final NotificationPermissionStatus status;
+  NotificationPermissionStatus status;
+  int requestCalls = 0;
+  int statusCalls = 0;
 
   @override
-  Future<NotificationPermissionStatus> requestNotificationPermission() async =>
-      status;
+  Future<NotificationPermissionStatus> notificationPermissionStatus() async {
+    statusCalls += 1;
+    return status;
+  }
+
+  @override
+  Future<NotificationPermissionStatus> requestNotificationPermission() async {
+    requestCalls += 1;
+    return status;
+  }
 }
 
 void main() {
@@ -250,7 +277,7 @@ void main() {
     expect(restored.state.scheduledCount, 1);
   });
 
-  test('restore는 저장된 inexact 강등 상태와 고지를 복원한다', () async {
+  test('restore는 현재도 inexact면 저장된 강등 고지를 유지한다', () async {
     final first = controller(exactPermitted: false);
     await first.enable(
       routeId: 'r1',
@@ -258,10 +285,102 @@ void main() {
       transferAlarmEnabled: true,
     );
 
+    final restored = controller(exactPermitted: false);
+    await restored.restore();
+
+    expect(restored.state.enabled, isTrue);
+    expect(restored.state.scheduleMode, GetOffAlarmScheduleMode.inexact);
+    expect(restored.state.inexactNotice, contains('오차'));
+  });
+
+  test('restore에서 알림 권한이 철회되면 프롬프트 없이 pending과 저장을 정리한다', () async {
+    final first = controller(exactPermitted: true);
+    await first.enable(
+      routeId: 'r1',
+      stops: stops(),
+      transferAlarmEnabled: true,
+    );
+    final permission = _StubNotificationPermissionProvider(
+      NotificationPermissionStatus.denied,
+    );
+    final restored = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: _StubExactAlarmGate(true),
+      notificationPermissionProvider: permission,
+      repository: repository,
+      now: () => now,
+    );
+    addTearDown(restored.dispose);
+
+    await restored.restore();
+
+    expect(permission.requestCalls, 0);
+    expect(permission.statusCalls, 1);
+    expect(notifier.cancelAllCount, 1);
+    expect(await repository.loadActive(), isNull);
+    expect(restored.state.enabled, isFalse);
+  });
+
+  test('restore에서 전용 pending이 0건이면 stale 구독을 끄다', () async {
+    final first = controller(exactPermitted: true);
+    await first.enable(
+      routeId: 'r1',
+      stops: stops(),
+      transferAlarmEnabled: true,
+    );
+    notifier.pendingCount = 0;
+
+    final restored = controller(exactPermitted: true);
+    await restored.restore();
+
+    expect(notifier.cancelAllCount, 1);
+    expect(await repository.loadActive(), isNull);
+    expect(restored.state.enabled, isFalse);
+  });
+
+  test('restore는 OS pending 드리프트를 실제 건수로 저장한다', () async {
+    final first = controller(exactPermitted: true);
+    await first.enable(
+      routeId: 'r1',
+      stops: stops(),
+      transferAlarmEnabled: true,
+    );
+    notifier.pendingCount = 1;
+
     final restored = controller(exactPermitted: true);
     await restored.restore();
 
     expect(restored.state.enabled, isTrue);
+    expect(restored.state.scheduledCount, 1);
+    expect((await repository.loadActive())!.scheduledCount, 1);
+    expect(notifier.scheduleCalls, 1);
+  });
+
+  test('restore에서 exact 상태가 바뀌면 저장된 stops로 권한 요청 없이 재예약한다', () async {
+    final first = controller(exactPermitted: true);
+    await first.enable(
+      routeId: 'r1',
+      stops: stops(),
+      transferAlarmEnabled: true,
+    );
+    final permission = _StubNotificationPermissionProvider(
+      NotificationPermissionStatus.granted,
+    );
+    final restored = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: _StubExactAlarmGate(false),
+      notificationPermissionProvider: permission,
+      repository: repository,
+      now: () => now,
+    );
+    addTearDown(restored.dispose);
+
+    await restored.restore();
+
+    expect(permission.requestCalls, 0);
+    expect(permission.statusCalls, 1);
+    expect(notifier.scheduleCalls, 2);
+    expect(notifier.scheduledAlarms, hasLength(2));
     expect(restored.state.scheduleMode, GetOffAlarmScheduleMode.inexact);
     expect(restored.state.inexactNotice, contains('오차'));
   });
@@ -281,6 +400,32 @@ void main() {
     expect(c.state.inexactNotice, contains('오차'));
   });
 
+  test('refresh는 현재 알림 권한이 거부되면 재예약 없이 off로 정리한다', () async {
+    final permission = _StubNotificationPermissionProvider(
+      NotificationPermissionStatus.granted,
+    );
+    final gate = _StubExactAlarmGate(true);
+    final c = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: gate,
+      notificationPermissionProvider: permission,
+      repository: repository,
+      now: () => now,
+    );
+    addTearDown(c.dispose);
+    await c.enable(routeId: 'r1', stops: stops(), transferAlarmEnabled: true);
+    permission.status = NotificationPermissionStatus.denied;
+
+    await c.refresh(stops: stops(), transferAlarmEnabled: true);
+
+    expect(permission.requestCalls, 1);
+    expect(permission.statusCalls, 1);
+    expect(notifier.scheduleCalls, 1);
+    expect(gate.isPermittedCalls, 0);
+    expect(c.state.enabled, isFalse);
+    expect(await repository.loadActive(), isNull);
+  });
+
   test('예약 성공이 0건이면 enabled와 활성 구독을 저장하지 않는다', () async {
     notifier.result = const ScheduleDeliveryResult(
       scheduledCount: 0,
@@ -293,6 +438,73 @@ void main() {
     expect(c.state.enabled, isFalse);
     expect(c.state.scheduledCount, 0);
     expect(await repository.loadActive(), isNull);
+  });
+
+  test('OS 예약 후 활성 저장 실패는 전용 알림과 저장값을 정리하고 원래 오류를 던진다', () async {
+    final saveError = StateError('save failed');
+    final stateRepository = _RecordingStateRepository(saveError: saveError);
+    final c = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: _StubExactAlarmGate(true),
+      notificationPermissionProvider: _StubNotificationPermissionProvider(
+        NotificationPermissionStatus.granted,
+      ),
+      repository: stateRepository,
+      now: () => now,
+    );
+    addTearDown(c.dispose);
+
+    await expectLater(
+      c.enable(routeId: 'r1', stops: stops(), transferAlarmEnabled: true),
+      throwsA(same(saveError)),
+    );
+
+    expect(notifier.scheduledAlarms, hasLength(2));
+    expect(notifier.cancelAllCount, 1);
+    expect(stateRepository.clearCount, 1);
+    expect(stateRepository.active, isNull);
+    expect(c.state.enabled, isFalse);
+  });
+
+  test('저장 실패 보상 정리 오류는 안전한 문맥으로 보고하고 원래 저장 오류를 보존한다', () async {
+    final saveError = StateError('save failed');
+    final cancelError = StateError('cancel failed');
+    final clearError = StateError('clear failed');
+    notifier.cancelErrorOnce = cancelError;
+    final stateRepository = _RecordingStateRepository(
+      saveError: saveError,
+      clearError: clearError,
+    );
+    final c = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: _StubExactAlarmGate(true),
+      notificationPermissionProvider: _StubNotificationPermissionProvider(
+        NotificationPermissionStatus.granted,
+      ),
+      repository: stateRepository,
+      now: () => now,
+    );
+    addTearDown(c.dispose);
+    final reports = <FlutterErrorDetails>[];
+
+    await expectLater(
+      runWithMobileErrorReporter(
+        reports.add,
+        () =>
+            c.enable(routeId: 'r1', stops: stops(), transferAlarmEnabled: true),
+      ),
+      throwsA(same(saveError)),
+    );
+
+    expect(reports.map((report) => report.exception), [
+      cancelError,
+      clearError,
+    ]);
+    expect(
+      reports.map((report) => report.context.toString()),
+      everyElement(equals('하차 알림 저장 실패 보상 정리 중 예외가 발생했습니다.')),
+    );
+    expect(c.state.enabled, isFalse);
   });
 
   test('disable은 알림을 취소하고 영속 상태를 지우며 상태를 끈다', () async {
@@ -360,6 +572,30 @@ void main() {
     await runWithMobileErrorReporter(
       reports.add,
       () => app.restoreGetOffAlarmState(startupController),
+    );
+
+    expect(reports, hasLength(1));
+    expect(reports.single.exception, same(error));
+    expect(reports.single.context.toString(), isNot(contains('route')));
+  });
+
+  test('foreground reconcile 예외는 lifecycle 경계 밖으로 전파하지 않는다', () async {
+    final error = StateError('database unavailable');
+    final foregroundController = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: _StubExactAlarmGate(true),
+      notificationPermissionProvider: _StubNotificationPermissionProvider(
+        NotificationPermissionStatus.granted,
+      ),
+      repository: _RecordingStateRepository(loadError: error),
+      now: () => now,
+    );
+    addTearDown(foregroundController.dispose);
+    final reports = <FlutterErrorDetails>[];
+
+    await runWithMobileErrorReporter(
+      reports.add,
+      () => app.reconcileGetOffAlarmState(foregroundController),
     );
 
     expect(reports, hasLength(1));

--- a/apps/mobile/test/features/get_off_alarm/get_off_alarm_controller_test.dart
+++ b/apps/mobile/test/features/get_off_alarm/get_off_alarm_controller_test.dart
@@ -426,6 +426,44 @@ void main() {
     expect(await repository.loadActive(), isNull);
   });
 
+  test('refresh에 destination이 없으면 기존 예약과 활성 구독을 유지한다', () async {
+    final stateRepository = _RecordingStateRepository();
+    final gate = _StubExactAlarmGate(true);
+    final c = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: gate,
+      notificationPermissionProvider: _StubNotificationPermissionProvider(
+        NotificationPermissionStatus.granted,
+      ),
+      repository: stateRepository,
+      now: () => now,
+    );
+    addTearDown(c.dispose);
+    await c.enable(routeId: 'r1', stops: stops(), transferAlarmEnabled: true);
+    final stateBeforeRefresh = c.state;
+    final subscriptionBeforeRefresh = stateRepository.active;
+    final scheduleCallsBeforeRefresh = notifier.scheduleCalls;
+    final cancelCallsBeforeRefresh = notifier.cancelAllCount;
+
+    await c.refresh(
+      stops: [
+        GetOffAlarmStop(
+          stationId: 'transfer',
+          stationName: '동작',
+          arrivalAt: DateTime(2026, 7, 6, 9, 15, 0),
+          kind: GetOffAlarmKind.transfer,
+        ),
+      ],
+      transferAlarmEnabled: true,
+    );
+
+    expect(notifier.scheduleCalls, scheduleCallsBeforeRefresh);
+    expect(notifier.cancelAllCount, cancelCallsBeforeRefresh);
+    expect(c.state, same(stateBeforeRefresh));
+    expect(stateRepository.active, same(subscriptionBeforeRefresh));
+    expect(gate.isPermittedCalls, 0);
+  });
+
   test('예약 성공이 0건이면 enabled와 활성 구독을 저장하지 않는다', () async {
     notifier.result = const ScheduleDeliveryResult(
       scheduledCount: 0,

--- a/apps/mobile/test/features/get_off_alarm/get_off_alarm_controller_test.dart
+++ b/apps/mobile/test/features/get_off_alarm/get_off_alarm_controller_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:easysubway_mobile/core/database/user/user_database.dart';
 import 'package:easysubway_mobile/features/get_off_alarm/data/get_off_alarm_state_repository.dart';
 import 'package:easysubway_mobile/features/get_off_alarm/exact_alarm_permission.dart';
@@ -5,7 +7,11 @@ import 'package:easysubway_mobile/features/get_off_alarm/get_off_alarm_controlle
 import 'package:easysubway_mobile/features/get_off_alarm/get_off_alarm_notifier.dart';
 import 'package:easysubway_mobile/features/get_off_alarm/get_off_alarm_schedule_mode.dart';
 import 'package:easysubway_mobile/features/get_off_alarm/get_off_alarm_scheduler.dart';
+import 'package:easysubway_mobile/features/get_off_alarm/get_off_alarm_subscription.dart';
+import 'package:easysubway_mobile/main.dart' as app;
+import 'package:easysubway_mobile/mobile_error_reporter.dart';
 import 'package:easysubway_mobile/notification_settings.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class _RecordingNotifier implements GetOffAlarmNotifier {
@@ -13,6 +19,8 @@ class _RecordingNotifier implements GetOffAlarmNotifier {
   GetOffAlarmScheduleMode? scheduledMode;
   ScheduleDeliveryResult? result;
   int cancelAllCount = 0;
+  Completer<void>? cancelBarrier;
+  Object? cancelErrorOnce;
 
   @override
   Future<ScheduleDeliveryResult> scheduleAlarms(
@@ -28,6 +36,40 @@ class _RecordingNotifier implements GetOffAlarmNotifier {
   @override
   Future<void> cancelAll() async {
     cancelAllCount++;
+    final error = cancelErrorOnce;
+    cancelErrorOnce = null;
+    if (error != null) {
+      throw error;
+    }
+    await cancelBarrier?.future;
+  }
+}
+
+class _RecordingStateRepository implements GetOffAlarmStateRepository {
+  _RecordingStateRepository({this.loadError});
+
+  GetOffAlarmSubscription? active;
+  Object? loadError;
+  int clearCount = 0;
+
+  @override
+  Future<void> clearActive() async {
+    clearCount += 1;
+    active = null;
+  }
+
+  @override
+  Future<GetOffAlarmSubscription?> loadActive() async {
+    final error = loadError;
+    if (error != null) {
+      throw error;
+    }
+    return active;
+  }
+
+  @override
+  Future<void> saveActive(GetOffAlarmSubscription subscription) async {
+    active = subscription;
   }
 }
 
@@ -49,6 +91,24 @@ class _StubExactAlarmGate implements ExactAlarmPermissionGate {
     requestCalls += 1;
     return permitted;
   }
+}
+
+class _BlockingRefreshExactAlarmGate implements ExactAlarmPermissionGate {
+  final isPermittedStarted = Completer<void>();
+  final permitted = Completer<bool>();
+  int isPermittedCalls = 0;
+
+  @override
+  Future<bool> isExactAlarmPermitted() {
+    isPermittedCalls += 1;
+    if (!isPermittedStarted.isCompleted) {
+      isPermittedStarted.complete();
+    }
+    return permitted.future;
+  }
+
+  @override
+  Future<bool> requestExactAlarmPermission() async => true;
 }
 
 class _StubNotificationPermissionProvider
@@ -281,5 +341,127 @@ void main() {
 
     expect(restored.state.enabled, isTrue);
     expect(restored.state.activeRouteId, 'r1');
+  });
+
+  test('startup restore 예외는 앱 시작 경계 밖으로 전파하지 않는다', () async {
+    final error = StateError('database unavailable');
+    final startupController = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: _StubExactAlarmGate(true),
+      notificationPermissionProvider: _StubNotificationPermissionProvider(
+        NotificationPermissionStatus.granted,
+      ),
+      repository: _RecordingStateRepository(loadError: error),
+      now: () => now,
+    );
+    addTearDown(startupController.dispose);
+    final reports = <FlutterErrorDetails>[];
+
+    await runWithMobileErrorReporter(
+      reports.add,
+      () => app.restoreGetOffAlarmState(startupController),
+    );
+
+    expect(reports, hasLength(1));
+    expect(reports.single.exception, same(error));
+    expect(reports.single.context.toString(), isNot(contains('route')));
+  });
+
+  test('restore에서 active가 없으면 pending 알림과 저장값을 정리한다', () async {
+    final stateRepository = _RecordingStateRepository();
+    final restored = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: _StubExactAlarmGate(true),
+      notificationPermissionProvider: _StubNotificationPermissionProvider(
+        NotificationPermissionStatus.granted,
+      ),
+      repository: stateRepository,
+      now: () => now,
+    );
+    addTearDown(restored.dispose);
+
+    await restored.restore();
+
+    expect(notifier.cancelAllCount, 1);
+    expect(stateRepository.clearCount, 1);
+    expect(restored.state.enabled, isFalse);
+  });
+
+  test('진행 중 refresh 뒤 disable은 마지막 cancel clear off 상태를 보장한다', () async {
+    final gate = _BlockingRefreshExactAlarmGate();
+    final stateRepository = _RecordingStateRepository();
+    final c = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: gate,
+      notificationPermissionProvider: _StubNotificationPermissionProvider(
+        NotificationPermissionStatus.granted,
+      ),
+      repository: stateRepository,
+      now: () => now,
+    );
+    addTearDown(c.dispose);
+    await c.enable(routeId: 'r1', stops: stops(), transferAlarmEnabled: true);
+
+    final refresh = c.refresh(stops: stops(), transferAlarmEnabled: true);
+    await gate.isPermittedStarted.future;
+    final disable = c.disable();
+    gate.permitted.complete(true);
+    await Future.wait([refresh, disable]);
+
+    expect(notifier.cancelAllCount, 1);
+    expect(stateRepository.active, isNull);
+    expect(c.state.enabled, isFalse);
+    expect(c.state.activeRouteId, isNull);
+  });
+
+  test('disable 뒤 queued refresh는 off 상태를 재확인하고 no-op 한다', () async {
+    final gate = _StubExactAlarmGate(true);
+    final stateRepository = _RecordingStateRepository();
+    final c = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: gate,
+      notificationPermissionProvider: _StubNotificationPermissionProvider(
+        NotificationPermissionStatus.granted,
+      ),
+      repository: stateRepository,
+      now: () => now,
+    );
+    addTearDown(c.dispose);
+    await c.enable(routeId: 'r1', stops: stops(), transferAlarmEnabled: true);
+    notifier.cancelBarrier = Completer<void>();
+
+    final disable = c.disable();
+    await Future<void>.delayed(Duration.zero);
+    final refresh = c.refresh(stops: stops(), transferAlarmEnabled: true);
+    await Future<void>.delayed(Duration.zero);
+    notifier.cancelBarrier!.complete();
+    await Future.wait([disable, refresh]);
+
+    expect(gate.isPermittedCalls, 0);
+    expect(stateRepository.active, isNull);
+    expect(c.state.enabled, isFalse);
+  });
+
+  test('앞선 mutation 오류가 다음 disable queue를 poison하지 않는다', () async {
+    final stateRepository = _RecordingStateRepository();
+    final c = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: _StubExactAlarmGate(true),
+      notificationPermissionProvider: _StubNotificationPermissionProvider(
+        NotificationPermissionStatus.granted,
+      ),
+      repository: stateRepository,
+      now: () => now,
+    );
+    addTearDown(c.dispose);
+    await c.enable(routeId: 'r1', stops: stops(), transferAlarmEnabled: true);
+    notifier.cancelErrorOnce = StateError('cancel failed');
+
+    await expectLater(c.disable(), throwsStateError);
+    await c.disable();
+
+    expect(notifier.cancelAllCount, 2);
+    expect(stateRepository.active, isNull);
+    expect(c.state.enabled, isFalse);
   });
 }

--- a/apps/mobile/test/features/get_off_alarm/get_off_alarm_controller_test.dart
+++ b/apps/mobile/test/features/get_off_alarm/get_off_alarm_controller_test.dart
@@ -5,20 +5,24 @@ import 'package:easysubway_mobile/features/get_off_alarm/get_off_alarm_controlle
 import 'package:easysubway_mobile/features/get_off_alarm/get_off_alarm_notifier.dart';
 import 'package:easysubway_mobile/features/get_off_alarm/get_off_alarm_schedule_mode.dart';
 import 'package:easysubway_mobile/features/get_off_alarm/get_off_alarm_scheduler.dart';
+import 'package:easysubway_mobile/notification_settings.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class _RecordingNotifier implements GetOffAlarmNotifier {
   List<ScheduledGetOffAlarm>? scheduledAlarms;
   GetOffAlarmScheduleMode? scheduledMode;
+  ScheduleDeliveryResult? result;
   int cancelAllCount = 0;
 
   @override
-  Future<void> scheduleAlarms(
+  Future<ScheduleDeliveryResult> scheduleAlarms(
     List<ScheduledGetOffAlarm> alarms, {
     required GetOffAlarmScheduleMode mode,
   }) async {
     scheduledAlarms = alarms;
     scheduledMode = mode;
+    return result ??
+        ScheduleDeliveryResult(scheduledCount: alarms.length, failedCount: 0);
   }
 
   @override
@@ -37,6 +41,17 @@ class _StubExactAlarmGate implements ExactAlarmPermissionGate {
 
   @override
   Future<bool> requestExactAlarmPermission() async => permitted;
+}
+
+class _StubNotificationPermissionProvider
+    implements NotificationPermissionProvider {
+  _StubNotificationPermissionProvider(this.status);
+
+  final NotificationPermissionStatus status;
+
+  @override
+  Future<NotificationPermissionStatus> requestNotificationPermission() async =>
+      status;
 }
 
 void main() {
@@ -71,10 +86,18 @@ void main() {
     await db.close();
   });
 
-  GetOffAlarmController controller({required bool exactPermitted}) {
+  GetOffAlarmController controller({
+    required bool exactPermitted,
+    bool notificationPermitted = true,
+  }) {
     return GetOffAlarmController(
       notifier: notifier,
       permissionGate: _StubExactAlarmGate(exactPermitted),
+      notificationPermissionProvider: _StubNotificationPermissionProvider(
+        notificationPermitted
+            ? NotificationPermissionStatus.granted
+            : NotificationPermissionStatus.denied,
+      ),
       repository: repository,
       now: () => now,
     );
@@ -111,6 +134,44 @@ void main() {
 
     expect(notifier.scheduledAlarms, hasLength(1));
     expect(notifier.scheduledAlarms!.single.kind, GetOffAlarmKind.destination);
+  });
+
+  test('POST_NOTIFICATIONS 거부는 예약과 enabled 저장을 막는다', () async {
+    final c = controller(exactPermitted: true, notificationPermitted: false);
+
+    await c.enable(routeId: 'r1', stops: stops(), transferAlarmEnabled: true);
+
+    expect(notifier.scheduledAlarms, isNull);
+    expect(c.state.enabled, isFalse);
+    expect(await repository.loadActive(), isNull);
+  });
+
+  test('부분 예약 실패는 실제 성공 수만 상태에 반영한다', () async {
+    notifier.result = const ScheduleDeliveryResult(
+      scheduledCount: 1,
+      failedCount: 1,
+    );
+    final c = controller(exactPermitted: true);
+
+    await c.enable(routeId: 'r1', stops: stops(), transferAlarmEnabled: true);
+
+    expect(c.state.enabled, isTrue);
+    expect(c.state.scheduledCount, 1);
+    expect(await repository.loadActive(), isNotNull);
+  });
+
+  test('예약 성공이 0건이면 enabled와 활성 구독을 저장하지 않는다', () async {
+    notifier.result = const ScheduleDeliveryResult(
+      scheduledCount: 0,
+      failedCount: 2,
+    );
+    final c = controller(exactPermitted: true);
+
+    await c.enable(routeId: 'r1', stops: stops(), transferAlarmEnabled: true);
+
+    expect(c.state.enabled, isFalse);
+    expect(c.state.scheduledCount, 0);
+    expect(await repository.loadActive(), isNull);
   });
 
   test('disable은 알림을 취소하고 영속 상태를 지우며 상태를 끈다', () async {

--- a/apps/mobile/test/features/get_off_alarm/get_off_alarm_controller_test.dart
+++ b/apps/mobile/test/features/get_off_alarm/get_off_alarm_controller_test.dart
@@ -143,6 +143,7 @@ void main() {
 
     expect(notifier.scheduledAlarms, isNull);
     expect(c.state.enabled, isFalse);
+    expect(c.state.permissionNotice, '휴대전화 알림 권한을 허용해 주세요.');
     expect(await repository.loadActive(), isNull);
   });
 
@@ -157,7 +158,26 @@ void main() {
 
     expect(c.state.enabled, isTrue);
     expect(c.state.scheduledCount, 1);
-    expect(await repository.loadActive(), isNotNull);
+    expect((await repository.loadActive())!.scheduledCount, 1);
+  });
+
+  test('부분 예약 성공 수는 저장되고 restore에서도 그대로 복원된다', () async {
+    notifier.result = const ScheduleDeliveryResult(
+      scheduledCount: 1,
+      failedCount: 1,
+    );
+    final first = controller(exactPermitted: true);
+    await first.enable(
+      routeId: 'r1',
+      stops: stops(),
+      transferAlarmEnabled: true,
+    );
+
+    final restored = controller(exactPermitted: true);
+    await restored.restore();
+
+    expect(restored.state.enabled, isTrue);
+    expect(restored.state.scheduledCount, 1);
   });
 
   test('예약 성공이 0건이면 enabled와 활성 구독을 저장하지 않는다', () async {

--- a/apps/mobile/test/features/get_off_alarm/get_off_alarm_controller_test.dart
+++ b/apps/mobile/test/features/get_off_alarm/get_off_alarm_controller_test.dart
@@ -34,13 +34,21 @@ class _RecordingNotifier implements GetOffAlarmNotifier {
 class _StubExactAlarmGate implements ExactAlarmPermissionGate {
   _StubExactAlarmGate(this.permitted);
 
-  final bool permitted;
+  bool permitted;
+  int isPermittedCalls = 0;
+  int requestCalls = 0;
 
   @override
-  Future<bool> isExactAlarmPermitted() async => permitted;
+  Future<bool> isExactAlarmPermitted() async {
+    isPermittedCalls += 1;
+    return permitted;
+  }
 
   @override
-  Future<bool> requestExactAlarmPermission() async => permitted;
+  Future<bool> requestExactAlarmPermission() async {
+    requestCalls += 1;
+    return permitted;
+  }
 }
 
 class _StubNotificationPermissionProvider
@@ -75,6 +83,7 @@ void main() {
   late UserDatabase db;
   late DriftGetOffAlarmStateRepository repository;
   late _RecordingNotifier notifier;
+  late _StubExactAlarmGate exactAlarmGate;
 
   setUp(() {
     db = UserDatabase.memory();
@@ -90,9 +99,10 @@ void main() {
     required bool exactPermitted,
     bool notificationPermitted = true,
   }) {
+    exactAlarmGate = _StubExactAlarmGate(exactPermitted);
     return GetOffAlarmController(
       notifier: notifier,
-      permissionGate: _StubExactAlarmGate(exactPermitted),
+      permissionGate: exactAlarmGate,
       notificationPermissionProvider: _StubNotificationPermissionProvider(
         notificationPermitted
             ? NotificationPermissionStatus.granted
@@ -178,6 +188,37 @@ void main() {
 
     expect(restored.state.enabled, isTrue);
     expect(restored.state.scheduledCount, 1);
+  });
+
+  test('restore는 저장된 inexact 강등 상태와 고지를 복원한다', () async {
+    final first = controller(exactPermitted: false);
+    await first.enable(
+      routeId: 'r1',
+      stops: stops(),
+      transferAlarmEnabled: true,
+    );
+
+    final restored = controller(exactPermitted: true);
+    await restored.restore();
+
+    expect(restored.state.enabled, isTrue);
+    expect(restored.state.scheduleMode, GetOffAlarmScheduleMode.inexact);
+    expect(restored.state.inexactNotice, contains('오차'));
+  });
+
+  test('refresh는 exact 권한 상태만 확인하고 권한을 다시 요청하지 않는다', () async {
+    final c = controller(exactPermitted: true);
+    await c.enable(routeId: 'r1', stops: stops(), transferAlarmEnabled: true);
+    expect(exactAlarmGate.requestCalls, 1);
+    expect(exactAlarmGate.isPermittedCalls, 0);
+
+    exactAlarmGate.permitted = false;
+    await c.refresh(stops: stops(), transferAlarmEnabled: true);
+
+    expect(exactAlarmGate.requestCalls, 1);
+    expect(exactAlarmGate.isPermittedCalls, 1);
+    expect(c.state.scheduleMode, GetOffAlarmScheduleMode.inexact);
+    expect(c.state.inexactNotice, contains('오차'));
   });
 
   test('예약 성공이 0건이면 enabled와 활성 구독을 저장하지 않는다', () async {

--- a/apps/mobile/test/features/get_off_alarm/get_off_alarm_notifier_test.dart
+++ b/apps/mobile/test/features/get_off_alarm/get_off_alarm_notifier_test.dart
@@ -34,6 +34,24 @@ void main() {
   });
 
   group('LocalGetOffAlarmNotifier', () {
+    test('대기 건수는 전용 ID 범위만 세고 다른 알림을 취소하지 않는다', () async {
+      final canceledIds = <int>[];
+      final first = LocalGetOffAlarmNotifier.baseNotificationId;
+      final last = first + LocalGetOffAlarmNotifier.notificationCapacity - 1;
+      final notifier = LocalGetOffAlarmNotifier(
+        FlutterLocalNotificationsPlugin(),
+        isAndroid: true,
+        initializePlugin: () async {},
+        pendingIds: () async => [first - 1, first, last, last + 1],
+        cancelId: (id) async => canceledIds.add(id),
+      );
+
+      final count = await notifier.pendingAlarmCount();
+
+      expect(count, 2);
+      expect(canceledIds, isEmpty);
+    });
+
     test('재시작 후 pending 목록에서 전용 ID 범위만 취소한다', () async {
       final canceledIds = <int>[];
       final first = LocalGetOffAlarmNotifier.baseNotificationId;

--- a/apps/mobile/test/features/get_off_alarm/get_off_alarm_notifier_test.dart
+++ b/apps/mobile/test/features/get_off_alarm/get_off_alarm_notifier_test.dart
@@ -1,9 +1,22 @@
 import 'package:easysubway_mobile/features/get_off_alarm/get_off_alarm_notifier.dart';
 import 'package:easysubway_mobile/features/get_off_alarm/get_off_alarm_schedule_mode.dart';
+import 'package:easysubway_mobile/features/get_off_alarm/get_off_alarm_scheduler.dart';
+import 'package:easysubway_mobile/mobile_error_reporter.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  ScheduledGetOffAlarm alarm(int index) {
+    final arrivalAt = DateTime(2026, 7, 10, 10).add(Duration(minutes: index));
+    return ScheduledGetOffAlarm(
+      stationId: 'station-$index',
+      stationName: '테스트역',
+      kind: GetOffAlarmKind.transfer,
+      fireAt: arrivalAt.subtract(const Duration(minutes: 2)),
+      arrivalAt: arrivalAt,
+    );
+  }
+
   group('androidScheduleModeFor', () {
     test('exact 모드는 exactAllowWhileIdle로 예약', () {
       expect(
@@ -17,6 +30,107 @@ void main() {
         androidScheduleModeFor(GetOffAlarmScheduleMode.inexact),
         AndroidScheduleMode.inexactAllowWhileIdle,
       );
+    });
+  });
+
+  group('LocalGetOffAlarmNotifier', () {
+    test('재시작 후 pending 목록에서 전용 ID 범위만 취소한다', () async {
+      final canceledIds = <int>[];
+      final first = LocalGetOffAlarmNotifier.baseNotificationId;
+      final last = first + LocalGetOffAlarmNotifier.notificationCapacity - 1;
+      final notifier = LocalGetOffAlarmNotifier(
+        FlutterLocalNotificationsPlugin(),
+        isAndroid: true,
+        initializePlugin: () async {},
+        pendingIds: () async => [first - 1, first, last, last + 1, 99999],
+        cancelId: (id) async => canceledIds.add(id),
+      );
+
+      await notifier.cancelAll();
+
+      expect(canceledIds, [first, last]);
+    });
+
+    test('전용 ID capacity 초과 알림은 실패 수에 반영하고 예약하지 않는다', () async {
+      final scheduledIds = <int>[];
+      final capacity = LocalGetOffAlarmNotifier.notificationCapacity;
+      final alarms = List.generate(capacity + 2, alarm);
+      final notifier = LocalGetOffAlarmNotifier(
+        FlutterLocalNotificationsPlugin(),
+        isAndroid: true,
+        initializePlugin: () async {},
+        pendingIds: () async => const [],
+        cancelId: (_) async {},
+        scheduleAlarm: (id, _, _, _, _) async => scheduledIds.add(id),
+      );
+
+      final result = await notifier.scheduleAlarms(
+        alarms,
+        mode: GetOffAlarmScheduleMode.exact,
+      );
+
+      expect(scheduledIds, hasLength(capacity));
+      expect(scheduledIds.first, LocalGetOffAlarmNotifier.baseNotificationId);
+      expect(
+        scheduledIds.last,
+        LocalGetOffAlarmNotifier.baseNotificationId + capacity - 1,
+      );
+      expect(result.scheduledCount, capacity);
+      expect(result.failedCount, 2);
+    });
+
+    test('개별 예약 실패는 실제 성공과 실패 수에 반영한다', () async {
+      final first = LocalGetOffAlarmNotifier.baseNotificationId;
+      final notifier = LocalGetOffAlarmNotifier(
+        FlutterLocalNotificationsPlugin(),
+        isAndroid: true,
+        initializePlugin: () async {},
+        pendingIds: () async => const [],
+        cancelId: (_) async {},
+        scheduleAlarm: (id, _, _, _, _) async {
+          if (id == first + 1) {
+            throw Exception('schedule failed');
+          }
+        },
+      );
+
+      late ScheduleDeliveryResult result;
+      await runWithMobileErrorReporter(
+        (_) {},
+        () async => result = await notifier.scheduleAlarms(
+          List.generate(3, alarm),
+          mode: GetOffAlarmScheduleMode.inexact,
+        ),
+      );
+
+      expect(result.scheduledCount, 2);
+      expect(result.failedCount, 1);
+    });
+
+    test('pending 목록 조회 실패를 취소 성공으로 삼키지 않는다', () async {
+      final error = StateError('pending query failed');
+      final notifier = LocalGetOffAlarmNotifier(
+        FlutterLocalNotificationsPlugin(),
+        isAndroid: true,
+        initializePlugin: () async {},
+        pendingIds: () async => throw error,
+        cancelId: (_) async {},
+      );
+
+      await expectLater(notifier.cancelAll(), throwsA(same(error)));
+    });
+
+    test('전용 ID 취소 실패를 성공으로 삼키지 않는다', () async {
+      final error = StateError('cancel failed');
+      final notifier = LocalGetOffAlarmNotifier(
+        FlutterLocalNotificationsPlugin(),
+        isAndroid: true,
+        initializePlugin: () async {},
+        pendingIds: () async => [LocalGetOffAlarmNotifier.baseNotificationId],
+        cancelId: (_) async => throw error,
+      );
+
+      await expectLater(notifier.cancelAll(), throwsA(same(error)));
     });
   });
 }

--- a/apps/mobile/test/features/get_off_alarm/get_off_alarm_route_mapping_test.dart
+++ b/apps/mobile/test/features/get_off_alarm/get_off_alarm_route_mapping_test.dart
@@ -15,6 +15,7 @@ void main() {
           ),
         ],
         stationName: (id) => id == 'sadang' ? '사당' : id,
+        source: GetOffAlarmTimeSource.planned,
       );
 
       expect(stops, hasLength(1));
@@ -37,6 +38,7 @@ void main() {
           ),
         ],
         stationName: upper,
+        source: GetOffAlarmTimeSource.planned,
       );
 
       expect(stops.map((s) => s.kind), [
@@ -56,6 +58,7 @@ void main() {
           ),
         ],
         stationName: (id) => id,
+        source: GetOffAlarmTimeSource.realtime,
       );
 
       expect(stops.single.arrivalAt, DateTime.parse('2026-07-06T09:33:00'));
@@ -71,6 +74,7 @@ void main() {
           ),
         ],
         stationName: (id) => id,
+        source: GetOffAlarmTimeSource.realtime,
       );
 
       expect(stops.single.arrivalAt, DateTime.parse('2026-07-06T09:30:00'));

--- a/apps/mobile/test/features/get_off_alarm/get_off_alarm_state_repository_test.dart
+++ b/apps/mobile/test/features/get_off_alarm/get_off_alarm_state_repository_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:easysubway_mobile/core/database/user/user_database.dart';
 import 'package:easysubway_mobile/features/get_off_alarm/data/get_off_alarm_state_repository.dart';
+import 'package:easysubway_mobile/features/get_off_alarm/get_off_alarm_schedule_mode.dart';
 import 'package:easysubway_mobile/features/get_off_alarm/get_off_alarm_subscription.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -22,6 +23,8 @@ void main() {
     routeId: 'route-1',
     transferAlarmEnabled: true,
     scheduledCount: 2,
+    scheduleMode: GetOffAlarmScheduleMode.inexact,
+    inexactNotice: '정확 알람 권한이 없어 오차가 있을 수 있어요.',
     destination: GetOffAlarmStopRef(
       stationId: 'dest',
       stationName: '사당',
@@ -48,6 +51,8 @@ void main() {
     expect(loaded!.routeId, 'route-1');
     expect(loaded.transferAlarmEnabled, isTrue);
     expect(loaded.scheduledCount, 2);
+    expect(loaded.scheduleMode, GetOffAlarmScheduleMode.inexact);
+    expect(loaded.inexactNotice, contains('오차'));
     expect(loaded.destination.stationName, '사당');
     expect(loaded.destination.arrivalAt, DateTime.utc(2026, 7, 6, 9, 30));
     expect(loaded.transfers, hasLength(1));
@@ -61,6 +66,8 @@ void main() {
         routeId: 'route-2',
         transferAlarmEnabled: false,
         scheduledCount: 1,
+        scheduleMode: GetOffAlarmScheduleMode.exact,
+        inexactNotice: null,
         destination: GetOffAlarmStopRef(
           stationId: 'd2',
           stationName: '서울역',
@@ -88,6 +95,31 @@ void main() {
           ),
         );
   }
+
+  test('scheduleMode와 inexactNotice를 복원한다', () async {
+    await writeRaw({
+      ...subscription.toJson(),
+      'scheduleMode': 'inexact',
+      'inexactNotice': '정확 알람 권한이 없어 오차가 있을 수 있어요.',
+    });
+
+    final loaded = await repository.loadActive();
+
+    expect(loaded, isNotNull);
+    expect(loaded!.scheduleMode, GetOffAlarmScheduleMode.inexact);
+    expect(loaded.inexactNotice, '정확 알람 권한이 없어 오차가 있을 수 있어요.');
+  });
+
+  test('non-list transfers 손상값은 active subscription을 폐기한다', () async {
+    await writeRaw({
+      ...subscription.toJson(),
+      'transferAlarmEnabled': false,
+      'scheduledCount': 1,
+      'transfers': <String, Object?>{},
+    });
+
+    expect(await repository.loadActive(), isNull);
+  });
 
   test('scheduledCount 없는 legacy 구독은 구독 최대 예약 수로 복원한다', () async {
     final legacy = subscription.toJson()..remove('scheduledCount');

--- a/apps/mobile/test/features/get_off_alarm/get_off_alarm_state_repository_test.dart
+++ b/apps/mobile/test/features/get_off_alarm/get_off_alarm_state_repository_test.dart
@@ -121,14 +121,47 @@ void main() {
     expect(await repository.loadActive(), isNull);
   });
 
-  test('scheduledCount 없는 legacy 구독은 구독 최대 예약 수로 복원한다', () async {
-    final legacy = subscription.toJson()..remove('scheduledCount');
-    await writeRaw(legacy);
+  test('scheduledCount 없는 current schema 구독은 최대 예약 수로 복원한다', () async {
+    final currentSchema = subscription.toJson()..remove('scheduledCount');
+    await writeRaw(currentSchema);
 
     final loaded = await repository.loadActive();
 
     expect(loaded, isNotNull);
     expect(loaded!.scheduledCount, 2);
+  });
+
+  test('scheduleMode 없는 실제 legacy 구독은 positive restore하지 않는다', () async {
+    await writeRaw({
+      'routeId': 'legacy-route',
+      'transferAlarmEnabled': true,
+      'destination': {
+        'stationId': 'dest',
+        'stationName': '사당',
+        'arrivalAtEpochMs': DateTime.utc(
+          2026,
+          7,
+          6,
+          9,
+          30,
+        ).millisecondsSinceEpoch,
+      },
+      'transfers': [
+        {
+          'stationId': 'transfer',
+          'stationName': '동작',
+          'arrivalAtEpochMs': DateTime.utc(
+            2026,
+            7,
+            6,
+            9,
+            15,
+          ).millisecondsSinceEpoch,
+        },
+      ],
+    });
+
+    expect(await repository.loadActive(), isNull);
   });
 
   test('scheduledCount 문자열은 손상 구독으로 폐기한다', () async {

--- a/apps/mobile/test/features/get_off_alarm/get_off_alarm_state_repository_test.dart
+++ b/apps/mobile/test/features/get_off_alarm/get_off_alarm_state_repository_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:easysubway_mobile/core/database/user/user_database.dart';
 import 'package:easysubway_mobile/features/get_off_alarm/data/get_off_alarm_state_repository.dart';
 import 'package:easysubway_mobile/features/get_off_alarm/get_off_alarm_subscription.dart';
@@ -19,6 +21,7 @@ void main() {
   final subscription = GetOffAlarmSubscription(
     routeId: 'route-1',
     transferAlarmEnabled: true,
+    scheduledCount: 2,
     destination: GetOffAlarmStopRef(
       stationId: 'dest',
       stationName: '사당',
@@ -44,6 +47,7 @@ void main() {
     expect(loaded, isNotNull);
     expect(loaded!.routeId, 'route-1');
     expect(loaded.transferAlarmEnabled, isTrue);
+    expect(loaded.scheduledCount, 2);
     expect(loaded.destination.stationName, '사당');
     expect(loaded.destination.arrivalAt, DateTime.utc(2026, 7, 6, 9, 30));
     expect(loaded.transfers, hasLength(1));
@@ -56,6 +60,7 @@ void main() {
       GetOffAlarmSubscription(
         routeId: 'route-2',
         transferAlarmEnabled: false,
+        scheduledCount: 1,
         destination: GetOffAlarmStopRef(
           stationId: 'd2',
           stationName: '서울역',
@@ -68,7 +73,54 @@ void main() {
     final loaded = await repository.loadActive();
     expect(loaded!.routeId, 'route-2');
     expect(loaded.transferAlarmEnabled, isFalse);
+    expect(loaded.scheduledCount, 1);
     expect(loaded.transfers, isEmpty);
+  });
+
+  Future<void> writeRaw(Map<String, Object?> value) async {
+    await db
+        .into(db.appPreferences)
+        .insertOnConflictUpdate(
+          AppPreferencesCompanion.insert(
+            key: 'get_off_alarm_active',
+            value: jsonEncode(value),
+            updatedAt: DateTime.utc(2026, 7, 10),
+          ),
+        );
+  }
+
+  test('scheduledCount 없는 legacy 구독은 구독 최대 예약 수로 복원한다', () async {
+    final legacy = subscription.toJson()..remove('scheduledCount');
+    await writeRaw(legacy);
+
+    final loaded = await repository.loadActive();
+
+    expect(loaded, isNotNull);
+    expect(loaded!.scheduledCount, 2);
+  });
+
+  test('scheduledCount 문자열은 손상 구독으로 폐기한다', () async {
+    await writeRaw({...subscription.toJson(), 'scheduledCount': '1'});
+
+    expect(await repository.loadActive(), isNull);
+  });
+
+  test('scheduledCount null은 legacy 누락으로 보지 않고 폐기한다', () async {
+    await writeRaw({...subscription.toJson(), 'scheduledCount': null});
+
+    expect(await repository.loadActive(), isNull);
+  });
+
+  test('scheduledCount 0은 비활성 구독으로 폐기한다', () async {
+    await writeRaw({...subscription.toJson(), 'scheduledCount': 0});
+
+    expect(await repository.loadActive(), isNull);
+  });
+
+  test('scheduledCount가 구독 최대 예약 수를 넘으면 폐기한다', () async {
+    await writeRaw({...subscription.toJson(), 'scheduledCount': 3});
+
+    expect(await repository.loadActive(), isNull);
   });
 
   test('clearActive 후에는 활성 구독이 없다', () async {

--- a/apps/mobile/test/features/get_off_alarm/get_off_alarm_toggle_test.dart
+++ b/apps/mobile/test/features/get_off_alarm/get_off_alarm_toggle_test.dart
@@ -7,6 +7,7 @@ import 'package:easysubway_mobile/features/get_off_alarm/get_off_alarm_scheduler
 import 'package:easysubway_mobile/features/get_off_alarm/get_off_alarm_subscription.dart';
 import 'package:easysubway_mobile/features/get_off_alarm/data/get_off_alarm_state_repository.dart';
 import 'package:easysubway_mobile/features/get_off_alarm/get_off_alarm_toggle.dart';
+import 'package:easysubway_mobile/notification_settings.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -15,11 +16,15 @@ class _RecordingNotifier implements GetOffAlarmNotifier {
   int cancelCount = 0;
 
   @override
-  Future<void> scheduleAlarms(
+  Future<ScheduleDeliveryResult> scheduleAlarms(
     List<ScheduledGetOffAlarm> alarms, {
     required GetOffAlarmScheduleMode mode,
   }) async {
     scheduled = alarms;
+    return ScheduleDeliveryResult(
+      scheduledCount: alarms.length,
+      failedCount: 0,
+    );
   }
 
   @override
@@ -35,6 +40,13 @@ class _StubGate implements ExactAlarmPermissionGate {
   Future<bool> isExactAlarmPermitted() async => permitted;
   @override
   Future<bool> requestExactAlarmPermission() async => permitted;
+}
+
+class _GrantedNotificationPermissionProvider
+    implements NotificationPermissionProvider {
+  @override
+  Future<NotificationPermissionStatus> requestNotificationPermission() async =>
+      NotificationPermissionStatus.granted;
 }
 
 class _FakeRepo implements GetOffAlarmStateRepository {
@@ -54,6 +66,7 @@ void main() {
     final controller = GetOffAlarmController(
       notifier: notifier,
       permissionGate: _StubGate(true),
+      notificationPermissionProvider: _GrantedNotificationPermissionProvider(),
       repository: _FakeRepo(),
       now: () => DateTime(2026, 7, 6, 9, 0, 0),
     );
@@ -94,6 +107,7 @@ void main() {
     final controller = GetOffAlarmController(
       notifier: notifier,
       permissionGate: _StubGate(true),
+      notificationPermissionProvider: _GrantedNotificationPermissionProvider(),
       repository: _FakeRepo(),
       now: () => DateTime(2026, 7, 6, 9, 0, 0),
     );
@@ -132,6 +146,7 @@ void main() {
     final controller = GetOffAlarmController(
       notifier: _RecordingNotifier(),
       permissionGate: _StubGate(false),
+      notificationPermissionProvider: _GrantedNotificationPermissionProvider(),
       repository: _FakeRepo(),
       now: () => DateTime(2026, 7, 6, 9, 0, 0),
     );

--- a/apps/mobile/test/features/get_off_alarm/get_off_alarm_toggle_test.dart
+++ b/apps/mobile/test/features/get_off_alarm/get_off_alarm_toggle_test.dart
@@ -158,6 +158,7 @@ void main() {
   });
 
   testWidgets('exact 권한 거부 시 오차 고지 문구를 노출한다', (tester) async {
+    final semanticsHandle = tester.ensureSemantics();
     final controller = GetOffAlarmController(
       notifier: _RecordingNotifier(),
       permissionGate: _StubGate(false),
@@ -189,10 +190,17 @@ void main() {
     await tester.tap(find.byType(Switch));
     await tester.pumpAndSettle();
 
-    expect(find.textContaining('오차'), findsOneWidget);
+    final noticeFinder = find.textContaining('오차');
+    expect(noticeFinder, findsOneWidget);
+    expect(
+      tester.getSemantics(noticeFinder),
+      isSemantics(label: '정확 알람 권한이 없어 ±수 분 오차가 있을 수 있어요.', isLiveRegion: true),
+    );
+    semanticsHandle.dispose();
   });
 
   testWidgets('알림 권한 거부는 off 상태에서 휴대전화 알림 권한 안내를 보여준다', (tester) async {
+    final semanticsHandle = tester.ensureSemantics();
     final controller = GetOffAlarmController(
       notifier: _RecordingNotifier(),
       permissionGate: _StubGate(true),
@@ -226,7 +234,13 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(controller.state.enabled, isFalse);
-    expect(find.text('휴대전화 알림 권한을 허용해 주세요.'), findsOneWidget);
+    final noticeFinder = find.text('휴대전화 알림 권한을 허용해 주세요.');
+    expect(noticeFinder, findsOneWidget);
+    expect(
+      tester.getSemantics(noticeFinder),
+      isSemantics(label: '휴대전화 알림 권한을 허용해 주세요.', isLiveRegion: true),
+    );
     expect(tester.widget<Switch>(find.byType(Switch)).value, isFalse);
+    semanticsHandle.dispose();
   });
 }

--- a/apps/mobile/test/features/get_off_alarm/get_off_alarm_toggle_test.dart
+++ b/apps/mobile/test/features/get_off_alarm/get_off_alarm_toggle_test.dart
@@ -42,11 +42,17 @@ class _StubGate implements ExactAlarmPermissionGate {
   Future<bool> requestExactAlarmPermission() async => permitted;
 }
 
-class _GrantedNotificationPermissionProvider
+class _StubNotificationPermissionProvider
     implements NotificationPermissionProvider {
+  const _StubNotificationPermissionProvider([
+    this.status = NotificationPermissionStatus.granted,
+  ]);
+
+  final NotificationPermissionStatus status;
+
   @override
   Future<NotificationPermissionStatus> requestNotificationPermission() async =>
-      NotificationPermissionStatus.granted;
+      status;
 }
 
 class _FakeRepo implements GetOffAlarmStateRepository {
@@ -66,7 +72,8 @@ void main() {
     final controller = GetOffAlarmController(
       notifier: notifier,
       permissionGate: _StubGate(true),
-      notificationPermissionProvider: _GrantedNotificationPermissionProvider(),
+      notificationPermissionProvider:
+          const _StubNotificationPermissionProvider(),
       repository: _FakeRepo(),
       now: () => DateTime(2026, 7, 6, 9, 0, 0),
     );
@@ -107,7 +114,8 @@ void main() {
     final controller = GetOffAlarmController(
       notifier: notifier,
       permissionGate: _StubGate(true),
-      notificationPermissionProvider: _GrantedNotificationPermissionProvider(),
+      notificationPermissionProvider:
+          const _StubNotificationPermissionProvider(),
       repository: _FakeRepo(),
       now: () => DateTime(2026, 7, 6, 9, 0, 0),
     );
@@ -146,7 +154,8 @@ void main() {
     final controller = GetOffAlarmController(
       notifier: _RecordingNotifier(),
       permissionGate: _StubGate(false),
-      notificationPermissionProvider: _GrantedNotificationPermissionProvider(),
+      notificationPermissionProvider:
+          const _StubNotificationPermissionProvider(),
       repository: _FakeRepo(),
       now: () => DateTime(2026, 7, 6, 9, 0, 0),
     );
@@ -174,5 +183,43 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.textContaining('오차'), findsOneWidget);
+  });
+
+  testWidgets('알림 권한 거부는 off 상태에서 휴대전화 알림 권한 안내를 보여준다', (tester) async {
+    final controller = GetOffAlarmController(
+      notifier: _RecordingNotifier(),
+      permissionGate: _StubGate(true),
+      notificationPermissionProvider: const _StubNotificationPermissionProvider(
+        NotificationPermissionStatus.denied,
+      ),
+      repository: _FakeRepo(),
+      now: () => DateTime(2026, 7, 6, 9, 0, 0),
+    );
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: GetOffAlarmToggle(
+            controller: controller,
+            routeId: 'r1',
+            rideLegs: const [
+              RideLegArrival(
+                toStationId: 'sadang',
+                plannedArrivalIso: '2026-07-06T09:30:00',
+              ),
+            ],
+            stationName: (id) => id,
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(Switch));
+    await tester.pumpAndSettle();
+
+    expect(controller.state.enabled, isFalse);
+    expect(find.text('휴대전화 알림 권한을 허용해 주세요.'), findsOneWidget);
+    expect(tester.widget<Switch>(find.byType(Switch)).value, isFalse);
   });
 }

--- a/apps/mobile/test/features/get_off_alarm/get_off_alarm_toggle_test.dart
+++ b/apps/mobile/test/features/get_off_alarm/get_off_alarm_toggle_test.dart
@@ -7,6 +7,7 @@ import 'package:easysubway_mobile/features/get_off_alarm/get_off_alarm_scheduler
 import 'package:easysubway_mobile/features/get_off_alarm/get_off_alarm_subscription.dart';
 import 'package:easysubway_mobile/features/get_off_alarm/data/get_off_alarm_state_repository.dart';
 import 'package:easysubway_mobile/features/get_off_alarm/get_off_alarm_toggle.dart';
+import 'package:easysubway_mobile/mobile_error_reporter.dart';
 import 'package:easysubway_mobile/notification_settings.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -98,7 +99,7 @@ void main() {
                 plannedArrivalIso: '2026-07-06T09:30:00',
               ),
             ],
-            stationName: (id) => id == 'sadang' ? '사당' : id,
+            stationName: (id) async => id == 'sadang' ? '사당' : null,
           ),
         ),
       ),
@@ -140,7 +141,7 @@ void main() {
                 plannedArrivalIso: '2026-07-06T09:30:00',
               ),
             ],
-            stationName: (id) => id,
+            stationName: (_) async => '사당',
           ),
         ),
       ),
@@ -155,6 +156,149 @@ void main() {
 
     expect(controller.state.enabled, isFalse);
     expect(notifier.cancelCount, greaterThanOrEqualTo(1));
+  });
+
+  testWidgets('토글은 여러 승차 구간의 역명을 비동기로 해소해 예약과 구독에 저장한다', (tester) async {
+    final notifier = _RecordingNotifier();
+    final repository = _FakeRepo();
+    final controller = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: _StubGate(true),
+      notificationPermissionProvider:
+          const _StubNotificationPermissionProvider(),
+      repository: repository,
+      now: () => DateTime(2026, 7, 6, 9, 0),
+    );
+    addTearDown(controller.dispose);
+    final resolvedStationIds = <String>[];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: GetOffAlarmToggle(
+            controller: controller,
+            routeId: 'r1',
+            rideLegs: const [
+              RideLegArrival(
+                toStationId: 'geumjeong',
+                plannedArrivalIso: '2026-07-06T09:15:00',
+              ),
+              RideLegArrival(
+                toStationId: 'sadang',
+                plannedArrivalIso: '2026-07-06T09:30:00',
+              ),
+            ],
+            stationName: (id) async {
+              resolvedStationIds.add(id);
+              return switch (id) {
+                'geumjeong' => ' 금정 ',
+                'sadang' => '사당',
+                _ => null,
+              };
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(Switch));
+    await tester.pumpAndSettle();
+
+    expect(resolvedStationIds, ['geumjeong', 'sadang']);
+    expect(notifier.scheduled?.map((alarm) => alarm.stationName), ['금정', '사당']);
+    final active = await repository.loadActive();
+    expect(active?.transfers.map((stop) => stop.stationName), ['금정']);
+    expect(active?.destination.stationName, '사당');
+  });
+
+  testWidgets('역명이 비어 있으면 하차 알림을 예약하거나 저장하지 않는다', (tester) async {
+    final notifier = _RecordingNotifier();
+    final repository = _FakeRepo();
+    final controller = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: _StubGate(true),
+      notificationPermissionProvider:
+          const _StubNotificationPermissionProvider(),
+      repository: repository,
+      now: () => DateTime(2026, 7, 6, 9, 0),
+    );
+    addTearDown(controller.dispose);
+    final reports = <FlutterErrorDetails>[];
+
+    await runWithMobileErrorReporter(reports.add, () async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: GetOffAlarmToggle(
+              controller: controller,
+              routeId: 'r1',
+              rideLegs: const [
+                RideLegArrival(
+                  toStationId: 'sadang',
+                  plannedArrivalIso: '2026-07-06T09:30:00',
+                ),
+              ],
+              stationName: (_) async => '   ',
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(Switch));
+      await tester.pumpAndSettle();
+    });
+
+    expect(reports, hasLength(1));
+    expect(find.text('하차 알림을 바꾸지 못했어요. 다시 시도해 주세요.'), findsOneWidget);
+    expect(notifier.scheduled, isNull);
+    expect(await repository.loadActive(), isNull);
+    expect(controller.state.enabled, isFalse);
+  });
+
+  testWidgets('역명 해소가 실패하면 하차 알림을 예약하거나 저장하지 않는다', (tester) async {
+    final notifier = _RecordingNotifier();
+    final repository = _FakeRepo();
+    final controller = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: _StubGate(true),
+      notificationPermissionProvider:
+          const _StubNotificationPermissionProvider(),
+      repository: repository,
+      now: () => DateTime(2026, 7, 6, 9, 0),
+    );
+    addTearDown(controller.dispose);
+    final reports = <FlutterErrorDetails>[];
+    final lookupError = StateError('lookup failed');
+
+    await runWithMobileErrorReporter(reports.add, () async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: GetOffAlarmToggle(
+              controller: controller,
+              routeId: 'r1',
+              rideLegs: const [
+                RideLegArrival(
+                  toStationId: 'sadang',
+                  plannedArrivalIso: '2026-07-06T09:30:00',
+                ),
+              ],
+              stationName: (_) async => throw lookupError,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(Switch));
+      await tester.pumpAndSettle();
+    });
+
+    expect(reports, hasLength(1));
+    expect(reports.single.exception, same(lookupError));
+    expect(find.text('하차 알림을 바꾸지 못했어요. 다시 시도해 주세요.'), findsOneWidget);
+    expect(notifier.scheduled, isNull);
+    expect(await repository.loadActive(), isNull);
+    expect(controller.state.enabled, isFalse);
   });
 
   testWidgets('exact 권한 거부 시 오차 고지 문구를 노출한다', (tester) async {
@@ -181,7 +325,7 @@ void main() {
                 plannedArrivalIso: '2026-07-06T09:30:00',
               ),
             ],
-            stationName: (id) => id,
+            stationName: (_) async => '사당',
           ),
         ),
       ),
@@ -224,7 +368,7 @@ void main() {
                 plannedArrivalIso: '2026-07-06T09:30:00',
               ),
             ],
-            stationName: (id) => id,
+            stationName: (_) async => '사당',
           ),
         ),
       ),

--- a/apps/mobile/test/features/get_off_alarm/get_off_alarm_toggle_test.dart
+++ b/apps/mobile/test/features/get_off_alarm/get_off_alarm_toggle_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:easysubway_mobile/features/get_off_alarm/exact_alarm_permission.dart';
 import 'package:easysubway_mobile/features/get_off_alarm/get_off_alarm_controller.dart';
 import 'package:easysubway_mobile/features/get_off_alarm/get_off_alarm_notifier.dart';
@@ -299,6 +301,51 @@ void main() {
     expect(notifier.scheduled, isNull);
     expect(await repository.loadActive(), isNull);
     expect(controller.state.enabled, isFalse);
+  });
+
+  testWidgets('역명 조회 중 외부 disable이 완료되면 오래된 enable을 실행하지 않는다', (tester) async {
+    final notifier = _RecordingNotifier();
+    final repository = _FakeRepo();
+    final stationName = Completer<String?>();
+    final controller = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: _StubGate(true),
+      notificationPermissionProvider:
+          const _StubNotificationPermissionProvider(),
+      repository: repository,
+      now: () => DateTime(2026, 7, 6, 9, 0, 0),
+    );
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: GetOffAlarmToggle(
+            controller: controller,
+            routeId: 'r1',
+            rideLegs: const [
+              RideLegArrival(
+                toStationId: 'sadang',
+                plannedArrivalIso: '2026-07-06T09:30:00',
+              ),
+            ],
+            stationName: (_) => stationName.future,
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(Switch));
+    await tester.pump();
+    await controller.disable();
+
+    stationName.complete('사당');
+    await tester.pumpAndSettle();
+
+    expect(controller.state.enabled, isFalse);
+    expect(await repository.loadActive(), isNull);
+    expect(notifier.scheduled, isNull);
+    expect(notifier.cancelCount, 1);
   });
 
   testWidgets('exact 권한 거부 시 오차 고지 문구를 노출한다', (tester) async {

--- a/apps/mobile/test/features/get_off_alarm/get_off_alarm_toggle_test.dart
+++ b/apps/mobile/test/features/get_off_alarm/get_off_alarm_toggle_test.dart
@@ -31,6 +31,9 @@ class _RecordingNotifier implements GetOffAlarmNotifier {
   Future<void> cancelAll() async {
     cancelCount++;
   }
+
+  @override
+  Future<int> pendingAlarmCount() async => scheduled?.length ?? 0;
 }
 
 class _StubGate implements ExactAlarmPermissionGate {
@@ -49,6 +52,10 @@ class _StubNotificationPermissionProvider
   ]);
 
   final NotificationPermissionStatus status;
+
+  @override
+  Future<NotificationPermissionStatus> notificationPermissionStatus() async =>
+      status;
 
   @override
   Future<NotificationPermissionStatus> requestNotificationPermission() async =>

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -422,6 +422,39 @@ void main() {
     expect(result.etaSource, 'STATIC_LOCAL');
   });
 
+  test('출발 초보다 500ms 늦은 cursor는 이미 출발한 trip을 건너뛴다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await database.seedBaselineIfEmpty();
+    await _seedBaselineTimetable(database);
+    await database.customStatement('''
+      UPDATE network_edges
+      SET duration_seconds = 0
+      WHERE id = 'entry-sangnoksu-seoul-4'
+    ''');
+    await _insertBaselineTrip(
+      database,
+      tripId: 'trip-after-fractional-cursor',
+      departureSeconds: 28980,
+      arrivalSeconds: 29700,
+    );
+    final repository = LocalRouteRepository(
+      catalogDatabase: database,
+      now: () => DateTime.parse('2026-07-10T08:00:30.500+09:00'),
+    );
+
+    final result = await repository.searchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-sangnoksu',
+        destinationStationId: 'station-sadang',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
+
+    final ride = result.steps.singleWhere((step) => step.stepType == 'ride');
+    expect(ride.plannedArrivalTimeIso, '2026-07-10T08:15:00+09:00');
+  });
+
   test('운행 제외일은 건너뛰고 7일 범위의 다음 활성 서비스를 선택한다', () async {
     final database = CatalogDatabase.memory();
     addTearDown(database.close);

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -399,6 +399,234 @@ void main() {
     expect(result.blockedReasons, isEmpty);
   });
 
+  test('로컬 경로는 현재 이후 공식 시간표의 ride 도착시각을 노출한다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await database.seedBaselineIfEmpty();
+    await _seedBaselineTimetable(database);
+    final repository = LocalRouteRepository(
+      catalogDatabase: database,
+      now: () => DateTime.parse('2026-07-10T07:58:00+09:00'),
+    );
+
+    final result = await repository.searchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-sangnoksu',
+        destinationStationId: 'station-sadang',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
+
+    final ride = result.steps.singleWhere((step) => step.stepType == 'ride');
+    expect(ride.plannedArrivalTimeIso, '2026-07-10T08:12:00+09:00');
+    expect(result.etaSource, 'STATIC_LOCAL');
+  });
+
+  test('운행 제외일은 건너뛰고 7일 범위의 다음 활성 서비스를 선택한다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await database.seedBaselineIfEmpty();
+    await _seedBaselineTimetable(database);
+    await database.customStatement('''
+      INSERT INTO service_calendar_dates (service_id, date, exception_type)
+      VALUES ('weekday-service', '20260710', 2)
+    ''');
+    final repository = LocalRouteRepository(
+      catalogDatabase: database,
+      now: () => DateTime.parse('2026-07-10T07:58:00+09:00'),
+    );
+
+    final result = await repository.searchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-sangnoksu',
+        destinationStationId: 'station-sadang',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
+
+    final ride = result.steps.singleWhere((step) => step.stepType == 'ride');
+    expect(ride.plannedArrivalTimeIso, '2026-07-13T08:12:00+09:00');
+  });
+
+  test('주말에 추가된 예외 서비스를 활성 운행으로 선택한다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await database.seedBaselineIfEmpty();
+    await _seedBaselineTimetable(database);
+    await database.customStatement('''
+      INSERT INTO service_calendar_dates (service_id, date, exception_type)
+      VALUES ('weekday-service', '20260711', 1)
+    ''');
+    final repository = LocalRouteRepository(
+      catalogDatabase: database,
+      now: () => DateTime.parse('2026-07-11T07:58:00+09:00'),
+    );
+
+    final result = await repository.searchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-sangnoksu',
+        destinationStationId: 'station-sadang',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
+
+    final ride = result.steps.singleWhere((step) => step.stepType == 'ride');
+    expect(ride.plannedArrivalTimeIso, '2026-07-11T08:12:00+09:00');
+  });
+
+  test('03:00 이전은 전일 service day의 24시간 초과 시간표를 사용한다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await database.seedBaselineIfEmpty();
+    await _seedBaselineTimetable(database);
+    await database.customStatement('''
+      UPDATE transit_stop_times
+      SET arrival_seconds = CASE stop_sequence WHEN 1 THEN 93600 ELSE 94320 END,
+          departure_seconds = CASE stop_sequence WHEN 1 THEN 93630 ELSE 94350 END
+      WHERE trip_id = 'trip-seoul-4-sangnoksu-sadang'
+    ''');
+    final repository = LocalRouteRepository(
+      catalogDatabase: database,
+      now: () => DateTime.parse('2026-07-11T01:58:00+09:00'),
+    );
+
+    final result = await repository.searchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-sangnoksu',
+        destinationStationId: 'station-sadang',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
+
+    final ride = result.steps.singleWhere((step) => step.stepType == 'ride');
+    expect(ride.plannedArrivalTimeIso, '2026-07-11T02:12:00+09:00');
+  });
+
+  test('pickup·drop-off 금지 trip을 건너뛰고 다음 승하차 가능 trip을 선택한다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await database.seedBaselineIfEmpty();
+    await _seedBaselineTimetable(database);
+    await database.customStatement('''
+      UPDATE transit_stop_times
+      SET pickup_type = 1
+      WHERE trip_id = 'trip-seoul-4-sangnoksu-sadang' AND stop_sequence = 1
+    ''');
+    await _insertBaselineTrip(
+      database,
+      tripId: 'trip-drop-off-blocked',
+      departureSeconds: 28950,
+      arrivalSeconds: 29640,
+      dropOffType: 1,
+    );
+    await _insertBaselineTrip(
+      database,
+      tripId: 'trip-boardable',
+      departureSeconds: 29070,
+      arrivalSeconds: 29760,
+    );
+    final repository = LocalRouteRepository(
+      catalogDatabase: database,
+      now: () => DateTime.parse('2026-07-10T07:58:00+09:00'),
+    );
+
+    final result = await repository.searchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-sangnoksu',
+        destinationStationId: 'station-sadang',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
+
+    final ride = result.steps.singleWhere((step) => step.stepType == 'ride');
+    expect(ride.plannedArrivalTimeIso, '2026-07-10T08:16:00+09:00');
+  });
+
+  test('다중 ride는 이전 도착과 환승 시간 이후의 다음 trip을 순차 선택한다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await _seedTwoLegRoute(database);
+    await _seedTwoLegTimetable(database);
+    final repository = LocalRouteRepository(
+      catalogDatabase: database,
+      now: () => DateTime.parse('2026-07-10T07:58:00+09:00'),
+    );
+
+    final result = await repository.searchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-a',
+        destinationStationId: 'station-c',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
+
+    final rides = result.steps
+        .where((step) => step.stepType == 'ride')
+        .toList(growable: false);
+    expect(rides.map((ride) => ride.plannedArrivalTimeIso), [
+      '2026-07-10T08:10:00+09:00',
+      '2026-07-10T08:22:00+09:00',
+    ]);
+  });
+
+  test('다중 ride 중 하나라도 공식 도착이 없으면 전체 알림 투영을 빈다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await _seedTwoLegRoute(database);
+    await _seedTwoLegTimetable(database);
+    await database.customStatement('''
+      DELETE FROM transit_stop_times
+      WHERE trip_id IN (SELECT id FROM transit_trips WHERE route_id = 'route-alt')
+    ''');
+    await database.customStatement(
+      "DELETE FROM transit_trips WHERE route_id = 'route-alt'",
+    );
+    final repository = LocalRouteRepository(
+      catalogDatabase: database,
+      now: () => DateTime.parse('2026-07-10T07:58:00+09:00'),
+    );
+
+    final result = await repository.searchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-a',
+        destinationStationId: 'station-c',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
+
+    final rides = result.steps.where((step) => step.stepType == 'ride');
+    expect(rides, isNotEmpty);
+    expect(
+      rides,
+      everyElement(
+        predicate<RouteSearchStep>(
+          (ride) => ride.plannedArrivalTimeIso.isEmpty,
+        ),
+      ),
+    );
+  });
+
+  test('공식 시간표가 없으면 static 소요시간으로 절대 도착을 합성하지 않는다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await database.seedBaselineIfEmpty();
+    final repository = LocalRouteRepository(
+      catalogDatabase: database,
+      now: () => DateTime.parse('2026-07-10T07:58:00+09:00'),
+    );
+
+    final result = await repository.searchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-sangnoksu',
+        destinationStationId: 'station-sadang',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
+
+    final ride = result.steps.singleWhere((step) => step.stepType == 'ride');
+    expect(ride.plannedArrivalTimeIso, isEmpty);
+  });
+
   test('로컬 capability는 station 존재와 realtime 지원을 분리한다', () async {
     final database = CatalogDatabase.memory();
     addTearDown(database.close);
@@ -3998,6 +4226,75 @@ Future<void> _seedAvailableFacilityRoute(CatalogDatabase database) async {
   await _addEligibleStationFacilityEvidence(database);
 }
 
+Future<void> _seedTwoLegRoute(CatalogDatabase database) async {
+  await _seedLineWithoutNetworkEdges(database);
+  await _addSecondLineForTransferFixture(database);
+  await database.customStatement('''
+    INSERT INTO station_lines (
+      station_id, line_id, station_code, line_sequence, platform_info
+    )
+    VALUES ('station-b', 'line-alt', 'B2', 2, '')
+  ''');
+  await _insertVerifiedNetworkEdge(
+    database,
+    id: 'ride-a-b-test',
+    fromNodeId: 'station-a:line-test',
+    toNodeId: 'station-b:line-test',
+    edgeType: 'RIDE',
+    durationSeconds: 120,
+  );
+  await _insertVerifiedNetworkEdge(
+    database,
+    id: 'transfer-b-test-alt',
+    fromNodeId: 'station-b:line-test',
+    toNodeId: 'station-b:line-alt',
+    edgeType: 'TRANSFER',
+    durationSeconds: 60,
+  );
+  await _insertVerifiedNetworkEdge(
+    database,
+    id: 'ride-b-c-alt',
+    fromNodeId: 'station-b:line-alt',
+    toNodeId: 'station-c:line-alt',
+    edgeType: 'RIDE',
+    durationSeconds: 120,
+  );
+}
+
+Future<void> _seedTwoLegTimetable(CatalogDatabase database) async {
+  await database.customStatement('''
+    INSERT INTO service_calendars (
+      service_id, monday, tuesday, wednesday, thursday, friday,
+      saturday, sunday, start_date, end_date
+    )
+    VALUES ('weekday-two-leg', 1, 1, 1, 1, 1, 0, 0, '20260101', '20261231')
+  ''');
+  await database.customStatement('''
+    INSERT INTO transit_routes (id, line_id, route_short_name)
+    VALUES ('route-test', 'line-test', 'T'), ('route-alt', 'line-alt', 'A')
+  ''');
+  await database.customStatement('''
+    INSERT INTO transit_trips (id, route_id, service_id)
+    VALUES
+      ('trip-first', 'route-test', 'weekday-two-leg'),
+      ('trip-alt-too-early', 'route-alt', 'weekday-two-leg'),
+      ('trip-alt-boardable', 'route-alt', 'weekday-two-leg')
+  ''');
+  await database.customStatement('''
+    INSERT INTO transit_stop_times (
+      trip_id, stop_sequence, station_id, line_id,
+      arrival_seconds, departure_seconds
+    )
+    VALUES
+      ('trip-first', 1, 'station-a', 'line-test', 28770, 28800),
+      ('trip-first', 2, 'station-b', 'line-test', 29400, 29430),
+      ('trip-alt-too-early', 1, 'station-b', 'line-alt', 29070, 29100),
+      ('trip-alt-too-early', 2, 'station-c', 'line-alt', 29700, 29730),
+      ('trip-alt-boardable', 1, 'station-b', 'line-alt', 29490, 29520),
+      ('trip-alt-boardable', 2, 'station-c', 'line-alt', 30120, 30150)
+  ''');
+}
+
 Future<void> _seedBaselineTimetable(CatalogDatabase database) async {
   await database.customStatement('''
       INSERT INTO service_calendars (
@@ -4052,6 +4349,46 @@ Future<void> _seedBaselineTimetable(CatalogDatabase database) async {
           29550
         )
     ''');
+}
+
+Future<void> _insertBaselineTrip(
+  CatalogDatabase database, {
+  required String tripId,
+  required int departureSeconds,
+  required int arrivalSeconds,
+  int pickupType = 0,
+  int dropOffType = 0,
+}) async {
+  await database.customStatement(
+    '''
+      INSERT INTO transit_trips (
+        id, route_id, service_id, trip_headsign, direction_id, service_pattern
+      )
+      VALUES (?, 'route-seoul-4-down', 'weekday-service', '사당', 'UP', 'LOCAL')
+    ''',
+    [tripId],
+  );
+  await database.customStatement(
+    '''
+      INSERT INTO transit_stop_times (
+        trip_id, stop_sequence, station_id, line_id, arrival_seconds,
+        departure_seconds, pickup_type, drop_off_type
+      )
+      VALUES
+        (?, 1, 'station-sangnoksu', 'seoul-4', ?, ?, ?, 0),
+        (?, 2, 'station-sadang', 'seoul-4', ?, ?, 0, ?)
+    ''',
+    [
+      tripId,
+      departureSeconds - 30,
+      departureSeconds,
+      pickupType,
+      tripId,
+      arrivalSeconds,
+      arrivalSeconds + 30,
+      dropOffType,
+    ],
+  );
 }
 
 Future<void> _seedRealtimeMapping(

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -7,6 +7,8 @@ import 'package:easysubway_mobile/facility_report.dart';
 import 'package:easysubway_mobile/features/routes/application/network_graph.dart'
     as graph;
 import 'package:easysubway_mobile/features/routes/data/local_route_repository.dart';
+import 'package:easysubway_mobile/features/get_off_alarm/get_off_alarm_route_mapping.dart';
+import 'package:easysubway_mobile/features/get_off_alarm/get_off_alarm_scheduler.dart';
 import 'package:easysubway_mobile/route_search.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -420,6 +422,48 @@ void main() {
     final ride = result.steps.singleWhere((step) => step.stepType == 'ride');
     expect(ride.plannedArrivalTimeIso, '2026-07-10T08:12:00+09:00');
     expect(result.etaSource, 'STATIC_LOCAL');
+  });
+
+  test('연속된 동일 노선·패턴 ride는 양 끝을 포함하는 한 trip과 도착 알림 하나로 묶는다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await _seedConsecutiveRideRoute(database);
+    await _seedConsecutiveRideTimetable(database);
+    final repository = LocalRouteRepository(
+      catalogDatabase: database,
+      now: () => DateTime.parse('2026-07-10T07:58:00+09:00'),
+    );
+
+    final result = await repository.searchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-a',
+        destinationStationId: 'station-c',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
+
+    final rides = result.steps
+        .where((step) => step.stepType == 'ride')
+        .toList(growable: false);
+    expect(rides, hasLength(1));
+    expect(rides.single.fromStationId, 'station-a');
+    expect(rides.single.toStationId, 'station-c');
+    expect(rides.single.plannedArrivalTimeIso, '2026-07-10T08:12:00+09:00');
+
+    final alarmStops = getOffAlarmStopsFromRideLegs(
+      rideLegs: [
+        for (final ride in rides)
+          RideLegArrival(
+            toStationId: ride.toStationId,
+            plannedArrivalIso: ride.plannedArrivalTimeIso,
+          ),
+      ],
+      stationName: (stationId) => stationId,
+      source: GetOffAlarmTimeSource.planned,
+    );
+    expect(alarmStops, hasLength(1));
+    expect(alarmStops.single.stationId, 'station-c');
+    expect(alarmStops.single.kind, GetOffAlarmKind.destination);
   });
 
   test('출발 초보다 500ms 늦은 cursor는 이미 출발한 trip을 건너뛴다', () async {
@@ -4052,6 +4096,7 @@ Future<void> _insertVerifiedNetworkEdge(
   required String toNodeId,
   required String edgeType,
   required int durationSeconds,
+  String servicePattern = '',
   String verificationStatus = 'VERIFIED',
   String provenanceKind = 'OFFICIAL_SOURCE',
   int lastVerifiedAtSeconds = 1781827200,
@@ -4062,11 +4107,11 @@ Future<void> _insertVerifiedNetworkEdge(
     '''
       INSERT INTO network_edges (
         id, from_node_id, to_node_id, duration_seconds, edge_type,
-        stair_access_state, accessibility_status, reliability_score,
+        service_pattern, stair_access_state, accessibility_status, reliability_score,
         source_id, source_snapshot_id, provider_record_hash, provenance_kind,
         verification_status, last_verified_at, evidence_hash
       )
-      VALUES (?, ?, ?, ?, ?, 'STEP_FREE', 'AVAILABLE', 95, 'test-source',
+      VALUES (?, ?, ?, ?, ?, ?, 'STEP_FREE', 'AVAILABLE', 95, 'test-source',
         'test-source-snapshot',
         'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
         ?, ?, ?, ?)
@@ -4077,6 +4122,7 @@ Future<void> _insertVerifiedNetworkEdge(
       toNodeId,
       durationSeconds,
       edgeType,
+      servicePattern,
       provenanceKind,
       verificationStatus,
       lastVerifiedAtSeconds,
@@ -4292,6 +4338,56 @@ Future<void> _seedTwoLegRoute(CatalogDatabase database) async {
     edgeType: 'RIDE',
     durationSeconds: 120,
   );
+}
+
+Future<void> _seedConsecutiveRideRoute(CatalogDatabase database) async {
+  await _seedLineWithoutNetworkEdges(database);
+  await _insertVerifiedNetworkEdge(
+    database,
+    id: 'ride-a-b-local',
+    fromNodeId: 'station-a:line-test:LOCAL',
+    toNodeId: 'station-b:line-test:LOCAL',
+    edgeType: 'RIDE',
+    durationSeconds: 300,
+    servicePattern: 'LOCAL',
+  );
+  await _insertVerifiedNetworkEdge(
+    database,
+    id: 'ride-b-c-local',
+    fromNodeId: 'station-b:line-test:LOCAL',
+    toNodeId: 'station-c:line-test:LOCAL',
+    edgeType: 'RIDE',
+    durationSeconds: 300,
+    servicePattern: 'LOCAL',
+  );
+}
+
+Future<void> _seedConsecutiveRideTimetable(CatalogDatabase database) async {
+  await database.customStatement('''
+    INSERT INTO service_calendars (
+      service_id, monday, tuesday, wednesday, thursday, friday,
+      saturday, sunday, start_date, end_date
+    )
+    VALUES ('weekday-consecutive', 1, 1, 1, 1, 1, 0, 0, '20260101', '20261231')
+  ''');
+  await database.customStatement('''
+    INSERT INTO transit_routes (id, line_id, route_short_name)
+    VALUES ('route-consecutive', 'line-test', 'T')
+  ''');
+  await database.customStatement('''
+    INSERT INTO transit_trips (id, route_id, service_id, service_pattern)
+    VALUES ('trip-consecutive', 'route-consecutive', 'weekday-consecutive', 'LOCAL')
+  ''');
+  await database.customStatement('''
+    INSERT INTO transit_stop_times (
+      trip_id, stop_sequence, station_id, line_id,
+      arrival_seconds, departure_seconds
+    )
+    VALUES
+      ('trip-consecutive', 1, 'station-a', 'line-test', 28770, 28800),
+      ('trip-consecutive', 2, 'station-b', 'line-test', 29100, 29130),
+      ('trip-consecutive', 3, 'station-c', 'line-test', 29520, 29550)
+  ''');
 }
 
 Future<void> _seedTwoLegTimetable(CatalogDatabase database) async {

--- a/apps/mobile/test/notification_permission_provider_test.dart
+++ b/apps/mobile/test/notification_permission_provider_test.dart
@@ -27,6 +27,32 @@ void main() {
     expect(calls.single.method, 'requestNotificationPermission');
   });
 
+  test('알림 권한 상태 조회는 프롬프트 없는 네이티브 메서드만 호출한다', () async {
+    const channel = MethodChannel('test/notification-permission-status');
+    final calls = <MethodCall>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          calls.add(call);
+          return false;
+        });
+    addTearDown(
+      () => TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null),
+    );
+    final provider = MethodChannelNotificationPermissionProvider(
+      channel: channel,
+    );
+
+    final result = await provider.notificationPermissionStatus();
+
+    expect(result, NotificationPermissionStatus.denied);
+    expect(calls.single.method, 'notificationPermissionStatus');
+    expect(
+      calls.where((call) => call.method == 'requestNotificationPermission'),
+      isEmpty,
+    );
+  });
+
   test('알림 권한 제공자는 권한 거부를 쉬운 상태로 바꾼다', () async {
     const channel = MethodChannel('test/notification-permission-denied');
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger

--- a/apps/mobile/test/onboarding_app_flow_test.dart
+++ b/apps/mobile/test/onboarding_app_flow_test.dart
@@ -345,6 +345,11 @@ class _DefaultNotificationPermissionProvider
   const _DefaultNotificationPermissionProvider();
 
   @override
+  Future<NotificationPermissionStatus> notificationPermissionStatus() async {
+    return NotificationPermissionStatus.granted;
+  }
+
+  @override
   Future<NotificationPermissionStatus> requestNotificationPermission() async {
     return NotificationPermissionStatus.granted;
   }

--- a/apps/mobile/test/onboarding_test.dart
+++ b/apps/mobile/test/onboarding_test.dart
@@ -450,6 +450,10 @@ class _FakeNotificationPermissionProvider
   int requestCount = 0;
 
   @override
+  Future<NotificationPermissionStatus> notificationPermissionStatus() async =>
+      NotificationPermissionStatus.granted;
+
+  @override
   Future<NotificationPermissionStatus> requestNotificationPermission() async {
     requestCount++;
     final error = this.error;

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -9706,6 +9706,92 @@ void main() {
   });
 
   testWidgets(
+    'pending enable 중 shell route exit는 disable 완료 뒤 경로와 하차 알림을 끝낸다',
+    (tester) async {
+      final notifier = _RecordingGetOffAlarmNotifier();
+      final stateRepository = _MemoryGetOffAlarmStateRepository();
+      final permissionProvider = _BlockingNotificationPermissionProvider();
+      final controller = GetOffAlarmController(
+        notifier: notifier,
+        permissionGate: _StubExactAlarmPermissionGate(),
+        notificationPermissionProvider: permissionProvider,
+        repository: stateRepository,
+        now: () => DateTime.parse('2026-07-06T09:00:00+09:00'),
+      );
+      addTearDown(controller.dispose);
+      var exitCount = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: RouteSearchScreen(
+            repository: FakeRouteSearchRepository(
+              result: _sampleRouteSearchResult(
+                steps: const [
+                  RouteSearchStep(
+                    sequence: 1,
+                    stepType: 'ride',
+                    title: '상록수에서 사당까지 이동',
+                    description: '열차를 이용해 이동합니다.',
+                    lineId: 'seoul-4',
+                    lineName: '수도권 4호선',
+                    fromStationId: 'station-sangnoksu',
+                    toStationId: 'station-sadang',
+                    estimatedMinutes: 32,
+                    distanceMeters: 13500,
+                    includesStairs: false,
+                    requiresAccessibilityCheck: true,
+                    plannedArrivalTimeIso: '2026-07-06T09:37:30+09:00',
+                  ),
+                ],
+              ),
+            ),
+            stationRepository: FakeStationSearchRepository(),
+            getOffAlarmController: controller,
+            onShellBackToHome: () => exitCount += 1,
+            initialDraft: RouteDraft(
+              origin: const RouteDraftStation(
+                id: 'station-sangnoksu',
+                nameKo: '상록수',
+              ),
+              destination: const RouteDraftStation(
+                id: 'station-sadang',
+                nameKo: '사당',
+              ),
+              lastModifiedAt: DateTime(2026, 7, 6),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
+      await tester.pumpAndSettle();
+      await tester.ensureVisible(find.text('하차 알림'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('하차 알림'));
+      await tester.pump();
+      await permissionProvider.started.future;
+
+      expect(controller.state.enabled, isFalse);
+      expect(find.byKey(const Key('routeResultListItem')), findsOneWidget);
+
+      await tester.binding.handlePopRoute();
+      await tester.pump();
+
+      expect(exitCount, 0);
+      expect(find.byKey(const Key('routeResultListItem')), findsOneWidget);
+
+      permissionProvider.result.complete(NotificationPermissionStatus.granted);
+      await tester.pumpAndSettle();
+
+      expect(permissionProvider.requestCount, 1);
+      expect(notifier.cancelCalls, greaterThanOrEqualTo(1));
+      expect(controller.state.enabled, isFalse);
+      expect(await stateRepository.loadActive(), isNull);
+      expect(exitCount, 1);
+      expect(find.byKey(const Key('routeResultListItem')), findsNothing);
+    },
+  );
+
+  testWidgets(
     'offline foreground refresh는 stale realtime 대신 PLANNED 하차 알림을 사용한다',
     (tester) async {
       final previousDebugPrint = debugPrint;
@@ -13236,6 +13322,22 @@ class FakeNotificationPermissionProvider
       throw currentError;
     }
     return nextStatus;
+  }
+}
+
+class _BlockingNotificationPermissionProvider
+    implements NotificationPermissionProvider {
+  final started = Completer<void>();
+  final result = Completer<NotificationPermissionStatus>();
+  int requestCount = 0;
+
+  @override
+  Future<NotificationPermissionStatus> requestNotificationPermission() {
+    requestCount += 1;
+    if (!started.isCompleted) {
+      started.complete();
+    }
+    return result.future;
   }
 }
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -9340,6 +9340,45 @@ void main() {
     expect(find.textContaining('시간표'), findsNothing);
   });
 
+  test('하차 알림 refresh rollback은 사용자 action으로 현재 결과가 바뀌면 적용하지 않는다', () async {
+    final repository = FakeRouteSearchRepository(
+      result: _sampleGetOffAlarmRouteResult(),
+    );
+    final controller = RouteSearchController(repository: repository);
+    addTearDown(controller.dispose);
+    await controller.search(
+      const RouteSearchRequest(
+        originStationId: 'station-sangnoksu',
+        destinationStationId: 'station-sadang',
+        mobilityType: 'SENIOR',
+      ),
+    );
+    final previousState = controller.state;
+    repository.refreshResult = RouteRefreshResult(
+      routeSearchId: 'route-1',
+      status: 'UPDATED_ETA',
+      result: _sampleGetOffAlarmRouteResult(
+        realtimeArrivalTimeIso: '2026-07-06T09:40:00+09:00',
+      ),
+      refreshedAt: '2026-07-06T09:01:00+09:00',
+      etaSource: 'REALTIME',
+      etaConfidence: 'HIGH',
+      sourceLabel: '실시간 도착 정보 기준',
+    );
+    final outcome = await controller.refreshCurrentRoute();
+    controller.reset();
+
+    final rolledBack = controller.rollbackRefreshAfterAlarmFailure(
+      previousState: previousState,
+      expectedCurrentResult: outcome.result!,
+      refreshMessage: '하차 알림을 갱신하지 못해 이전 경로를 유지해요.',
+    );
+
+    expect(rolledBack, isFalse);
+    expect(controller.state.status, RouteSearchViewStatus.idle);
+    expect(controller.state.result, isNull);
+  });
+
   testWidgets('planned 승차 시간이 있는 경로 결과는 하차 알림 토글을 보여준다', (tester) async {
     final notifier = _RecordingGetOffAlarmNotifier();
     final stateRepository = _MemoryGetOffAlarmStateRepository();
@@ -9424,6 +9463,85 @@ void main() {
 
     expect(notifier.scheduledAlarms.single.stationName, '사당');
     expect((await stateRepository.loadActive())?.destination.stationName, '사당');
+  });
+
+  testWidgets('여러 승차 구간 최초 하차 알림은 공식 환승역과 도착역 이름을 저장한다', (tester) async {
+    final notifier = _RecordingGetOffAlarmNotifier();
+    final stateRepository = _MemoryGetOffAlarmStateRepository();
+    final controller = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: _StubExactAlarmPermissionGate(),
+      notificationPermissionProvider: FakeNotificationPermissionProvider(
+        nextStatus: NotificationPermissionStatus.granted,
+      ),
+      repository: stateRepository,
+      now: () => DateTime.parse('2026-07-06T09:00:00+09:00'),
+    );
+    addTearDown(controller.dispose);
+    final stationRepository = FakeStationSearchRepository(
+      stationDetails: {
+        'station-geumjeong': _stationDetail(
+          id: 'station-geumjeong',
+          name: '금정',
+        ),
+      },
+    );
+    final routeRepository = FakeRouteSearchRepository(
+      result: _sampleRouteSearchResult(
+        steps: const [
+          RouteSearchStep(
+            sequence: 1,
+            stepType: 'ride',
+            title: '상록수에서 금정까지 이동',
+            description: '열차를 이용해 이동합니다.',
+            lineId: 'seoul-4',
+            lineName: '수도권 4호선',
+            fromStationId: 'station-sangnoksu',
+            toStationId: 'station-geumjeong',
+            estimatedMinutes: 15,
+            distanceMeters: 6300,
+            includesStairs: false,
+            requiresAccessibilityCheck: true,
+            plannedArrivalTimeIso: '2026-07-06T09:20:00+09:00',
+          ),
+          RouteSearchStep(
+            sequence: 2,
+            stepType: 'ride',
+            title: '금정에서 사당까지 이동',
+            description: '열차를 이용해 이동합니다.',
+            lineId: 'seoul-4',
+            lineName: '수도권 4호선',
+            fromStationId: 'station-geumjeong',
+            toStationId: 'station-sadang',
+            estimatedMinutes: 17,
+            distanceMeters: 7200,
+            includesStairs: false,
+            requiresAccessibilityCheck: true,
+            plannedArrivalTimeIso: '2026-07-06T09:37:30+09:00',
+          ),
+        ],
+      ),
+    );
+
+    await _pumpGetOffAlarmRouteScreen(
+      tester,
+      repository: routeRepository,
+      controller: controller,
+      stationRepository: stationRepository,
+    );
+    await tester.ensureVisible(find.text('하차 알림'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('하차 알림'));
+    await tester.pumpAndSettle();
+
+    expect(notifier.scheduledAlarms.map((alarm) => alarm.stationName), [
+      '금정',
+      '사당',
+    ]);
+    final active = await stateRepository.loadActive();
+    expect(active?.transfers.map((stop) => stop.stationName), ['금정']);
+    expect(active?.destination.stationName, '사당');
+    expect(stationRepository.requestedDetailStationIds, ['station-geumjeong']);
   });
 
   testWidgets('ride 중 하나의 공식 도착이 없으면 부분 하차 알림을 보이지 않는다', (tester) async {
@@ -9657,6 +9775,110 @@ void main() {
     );
     expect((await stateRepository.loadActive())?.transferAlarmEnabled, isFalse);
     expect((await stateRepository.loadActive())?.destination.stationName, '사당');
+  });
+
+  testWidgets('새 환승역이 생긴 foreground refresh는 공식 역명으로 알림과 구독을 갱신한다', (
+    tester,
+  ) async {
+    final notifier = _RecordingGetOffAlarmNotifier();
+    final stateRepository = _MemoryGetOffAlarmStateRepository();
+    final controller = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: _StubExactAlarmPermissionGate(),
+      notificationPermissionProvider: FakeNotificationPermissionProvider(
+        nextStatus: NotificationPermissionStatus.granted,
+      ),
+      repository: stateRepository,
+      now: () => DateTime.parse('2026-07-06T09:00:00+09:00'),
+    );
+    addTearDown(controller.dispose);
+    final stationRepository = FakeStationSearchRepository(
+      stationDetails: {
+        'station-geumjeong': _stationDetail(
+          id: 'station-geumjeong',
+          name: '금정',
+        ),
+      },
+    );
+    final routeRepository =
+        FakeRouteSearchRepository(result: _sampleGetOffAlarmRouteResult())
+          ..refreshResult = RouteRefreshResult(
+            routeSearchId: 'route-1',
+            status: 'UPDATED_ROUTE',
+            result: _sampleRouteSearchResult(
+              steps: const [
+                RouteSearchStep(
+                  sequence: 1,
+                  stepType: 'ride',
+                  title: '상록수에서 금정까지 이동',
+                  description: '열차를 이용해 이동합니다.',
+                  lineId: 'seoul-4',
+                  lineName: '수도권 4호선',
+                  fromStationId: 'station-sangnoksu',
+                  toStationId: 'station-geumjeong',
+                  estimatedMinutes: 15,
+                  distanceMeters: 6300,
+                  includesStairs: false,
+                  requiresAccessibilityCheck: true,
+                  plannedArrivalTimeIso: '2026-07-06T09:20:00+09:00',
+                ),
+                RouteSearchStep(
+                  sequence: 2,
+                  stepType: 'ride',
+                  title: '금정에서 사당까지 이동',
+                  description: '열차를 이용해 이동합니다.',
+                  lineId: 'seoul-4',
+                  lineName: '수도권 4호선',
+                  fromStationId: 'station-geumjeong',
+                  toStationId: 'station-sadang',
+                  estimatedMinutes: 17,
+                  distanceMeters: 7200,
+                  includesStairs: false,
+                  requiresAccessibilityCheck: true,
+                  plannedArrivalTimeIso: '2026-07-06T09:37:30+09:00',
+                  realtimeArrivalTimeIso: '2026-07-06T09:40:00+09:00',
+                ),
+              ],
+            ),
+            refreshedAt: '2026-07-06T09:01:00+09:00',
+            etaSource: 'REALTIME',
+            etaConfidence: 'HIGH',
+            sourceLabel: '실시간 도착 정보 기준',
+          );
+
+    await _pumpGetOffAlarmRouteScreen(
+      tester,
+      repository: routeRepository,
+      controller: controller,
+      stationRepository: stationRepository,
+    );
+    await controller.enable(
+      routeId: 'route-1',
+      stops: [
+        GetOffAlarmStop(
+          stationId: 'station-sadang',
+          stationName: '사당',
+          arrivalAt: DateTime.parse('2026-07-06T09:37:30+09:00'),
+          kind: GetOffAlarmKind.destination,
+        ),
+      ],
+      transferAlarmEnabled: true,
+    );
+    notifier.reset();
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+    await tester.pump();
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pumpAndSettle();
+
+    expect(notifier.scheduledAlarms.map((alarm) => alarm.stationName), [
+      '금정',
+      '사당',
+    ]);
+    final active = await stateRepository.loadActive();
+    expect(active?.transfers.map((stop) => stop.stationName), ['금정']);
+    expect(active?.destination.stationName, '사당');
+    expect(stationRepository.requestedDetailStationIds, ['station-geumjeong']);
   });
 
   testWidgets('pull-to-refresh는 활성 하차 알림을 새 ETA로 재예약한다', (tester) async {
@@ -9970,6 +10192,38 @@ void main() {
       'SENIOR',
     );
     expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('단순 보기에서 현재 이동 조건을 다시 적용하면 활성 알림과 경로를 유지한다', (tester) async {
+    final notifier = _RecordingGetOffAlarmNotifier();
+    final controller = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: _StubExactAlarmPermissionGate(),
+      notificationPermissionProvider: FakeNotificationPermissionProvider(
+        nextStatus: NotificationPermissionStatus.granted,
+      ),
+      repository: _MemoryGetOffAlarmStateRepository(),
+      now: () => DateTime.parse('2026-07-06T09:00:00+09:00'),
+    );
+    addTearDown(controller.dispose);
+    await _pumpGetOffAlarmRouteScreen(
+      tester,
+      repository: FakeRouteSearchRepository(
+        result: _sampleGetOffAlarmRouteResult(),
+      ),
+      controller: controller,
+    );
+    await _enableSampleGetOffAlarm(controller);
+    notifier.reset();
+
+    await tester.tap(find.byKey(const Key('routeSimpleMobilityTypeButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('routeMobilityApplyButton')));
+    await tester.pumpAndSettle();
+
+    expect(notifier.cancelCalls, 0);
+    expect(controller.state.enabled, isTrue);
+    expect(find.byKey(const Key('routeResultListItem')), findsOneWidget);
   });
 
   testWidgets(
@@ -10327,6 +10581,131 @@ void main() {
     expect(notifier.cancelCalls, 1);
     expect(controller.state.enabled, isFalse);
     expect(await stateRepository.loadActive(), isNull);
+  });
+
+  testWidgets('usable ride 없는 refresh의 알림 취소 실패는 이전 경로와 구독을 복원한다', (
+    tester,
+  ) async {
+    final notifier = _RecordingGetOffAlarmNotifier();
+    final stateRepository = _MemoryGetOffAlarmStateRepository();
+    final controller = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: _StubExactAlarmPermissionGate(),
+      notificationPermissionProvider: FakeNotificationPermissionProvider(
+        nextStatus: NotificationPermissionStatus.granted,
+      ),
+      repository: stateRepository,
+      now: () => DateTime.parse('2026-07-06T09:00:00+09:00'),
+    );
+    addTearDown(controller.dispose);
+    final routeRepository =
+        FakeRouteSearchRepository(result: _sampleGetOffAlarmRouteResult())
+          ..refreshResult = RouteRefreshResult(
+            routeSearchId: 'route-1',
+            status: 'UPDATED_ROUTE',
+            result: _sampleRouteSearchResult(steps: const []),
+            refreshedAt: '2026-07-06T09:01:00+09:00',
+            etaSource: 'PLANNED',
+            etaConfidence: 'MEDIUM',
+            sourceLabel: '계획 시간 기준',
+          );
+    await _pumpGetOffAlarmRouteScreen(
+      tester,
+      repository: routeRepository,
+      controller: controller,
+    );
+    await _enableSampleGetOffAlarm(controller);
+    final cancelCallsBeforeRefresh = notifier.cancelCalls;
+    final cancelError = StateError('cancel failed');
+    notifier.cancelError = cancelError;
+    final reports = <FlutterErrorDetails>[];
+
+    await runWithMobileErrorReporter(reports.add, () async {
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+      await tester.pump();
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      await tester.pumpAndSettle();
+    });
+
+    expect(reports.single.exception, same(cancelError));
+    expect(find.text('하차 알림을 갱신하지 못해 이전 경로를 유지해요.'), findsOneWidget);
+    expect(find.text('도착·환승 전에 알려드려요.'), findsOneWidget);
+    expect(controller.state.enabled, isTrue);
+    expect((await stateRepository.loadActive())?.destination.stationName, '사당');
+    expect(notifier.cancelCalls, cancelCallsBeforeRefresh + 1);
+    expect(notifier.scheduleCalls, 1);
+    expect(notifier.scheduledAlarms.single.stationName, '사당');
+  });
+
+  testWidgets('foreground 알림 재예약 실패는 이전 경로와 pending 구독을 복원한다', (tester) async {
+    final notifier = _RecordingGetOffAlarmNotifier();
+    final stateRepository = _MemoryGetOffAlarmStateRepository();
+    final controller = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: _StubExactAlarmPermissionGate(),
+      notificationPermissionProvider: FakeNotificationPermissionProvider(
+        nextStatus: NotificationPermissionStatus.granted,
+      ),
+      repository: stateRepository,
+      now: () => DateTime.parse('2026-07-06T09:00:00+09:00'),
+    );
+    addTearDown(controller.dispose);
+    final routeRepository =
+        FakeRouteSearchRepository(result: _sampleGetOffAlarmRouteResult())
+          ..refreshResult = RouteRefreshResult(
+            routeSearchId: 'route-1',
+            status: 'UPDATED_ETA',
+            result: _sampleGetOffAlarmRouteResult(
+              realtimeArrivalTimeIso: '2026-07-06T09:40:00+09:00',
+            ),
+            refreshedAt: '2026-07-06T09:01:00+09:00',
+            etaSource: 'REALTIME',
+            etaConfidence: 'HIGH',
+            sourceLabel: '실시간 도착 정보 기준',
+          );
+    await _pumpGetOffAlarmRouteScreen(
+      tester,
+      repository: routeRepository,
+      controller: controller,
+    );
+    await _enableSampleGetOffAlarm(controller);
+    final scheduleError = StateError('station-sadang schedule failed');
+    notifier.scheduleError = scheduleError;
+    final reports = <FlutterErrorDetails>[];
+
+    await runWithMobileErrorReporter(reports.add, () async {
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+      await tester.pump();
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      await tester.pumpAndSettle();
+    });
+
+    expect(reports, hasLength(1));
+    expect(reports.single.exception, same(scheduleError));
+    expect(
+      reports.single.context.toString(),
+      '하차 알림 foreground 재예약 중 예외가 발생했습니다.',
+    );
+    expect(find.text('하차 알림을 새로 맞추지 못했어요. 이전 경로를 유지해요.'), findsOneWidget);
+    expect(find.text('하차 알림을 갱신하지 못해 이전 경로를 유지해요.'), findsOneWidget);
+    expect(find.text('도착·환승 전에 알려드려요.'), findsOneWidget);
+    expect(controller.state.enabled, isTrue);
+    final active = await stateRepository.loadActive();
+    expect(active?.destination.stationName, '사당');
+    expect(
+      active?.destination.arrivalAt.isAtSameMomentAs(
+        DateTime.parse('2026-07-06T09:37:30+09:00'),
+      ),
+      isTrue,
+    );
+    expect(notifier.scheduleCalls, 2);
+    expect(notifier.scheduledAlarms.single.stationName, '사당');
+    expect(
+      notifier.scheduledAlarms.single.arrivalAt.isAtSameMomentAs(
+        DateTime.parse('2026-07-06T09:37:30+09:00'),
+      ),
+      isTrue,
+    );
   });
 
   testWidgets('중복 foreground 하차 알림 refresh는 진행 중 예약을 건너뛴다', (tester) async {
@@ -13091,6 +13470,8 @@ class FakeStationSearchRepository
     this.networkMapError,
     this.searchCompleter,
     StationDetail? stationDetail,
+    this.stationDetails = const {},
+    this.stationDetailCompleters = const {},
     this.stationExits = const [],
     this.stationFacilities = const [],
   }) : stationDetail =
@@ -13106,6 +13487,8 @@ class FakeStationSearchRepository
   final Object? networkMapError;
   final Completer<List<StationSearchResult>>? searchCompleter;
   final StationDetail stationDetail;
+  final Map<String, StationDetail> stationDetails;
+  final Map<String, Completer<StationDetail>> stationDetailCompleters;
   final List<StationExitInfo> stationExits;
   final List<StationFacilityInfo> stationFacilities;
   final requestedQueries = <String>[];
@@ -13160,7 +13543,11 @@ class FakeStationSearchRepository
   @override
   Future<StationDetail> getStationDetail(String stationId) async {
     requestedDetailStationIds.add(stationId);
-    return stationDetail;
+    final completer = stationDetailCompleters[stationId];
+    if (completer != null) {
+      return completer.future;
+    }
+    return stationDetails[stationId] ?? stationDetail;
   }
 
   @override
@@ -13510,13 +13897,14 @@ Future<void> _pumpGetOffAlarmRouteScreen(
   WidgetTester tester, {
   required FakeRouteSearchRepository repository,
   required GetOffAlarmController controller,
+  StationSearchRepository? stationRepository,
   bool simpleViewEnabled = true,
 }) async {
   await tester.pumpWidget(
     MaterialApp(
       home: RouteSearchScreen(
         repository: repository,
-        stationRepository: FakeStationSearchRepository(),
+        stationRepository: stationRepository ?? FakeStationSearchRepository(),
         getOffAlarmController: controller,
         simpleViewEnabled: simpleViewEnabled,
         initialDraft: RouteDraft(
@@ -13604,6 +13992,7 @@ class _RecordingGetOffAlarmNotifier implements GetOffAlarmNotifier {
   List<ScheduledGetOffAlarm> scheduledAlarms = const [];
   GetOffAlarmScheduleMode? scheduledMode;
   Object? cancelError;
+  Object? scheduleError;
 
   void reset() {
     scheduleCalls = 0;
@@ -13630,6 +14019,10 @@ class _RecordingGetOffAlarmNotifier implements GetOffAlarmNotifier {
     required GetOffAlarmScheduleMode mode,
   }) async {
     scheduleCalls += 1;
+    final error = scheduleError;
+    if (error != null) {
+      throw error;
+    }
     scheduledAlarms = alarms;
     scheduledMode = mode;
     return ScheduleDeliveryResult(

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -9350,7 +9350,7 @@ void main() {
         nextStatus: NotificationPermissionStatus.granted,
       ),
       repository: stateRepository,
-      now: () => DateTime(2026, 7, 6, 9, 0),
+      now: () => DateTime.parse('2026-07-06T09:00:00+09:00'),
     );
     addTearDown(controller.dispose);
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -9812,6 +9812,134 @@ void main() {
     },
   );
 
+  testWidgets('중복 foreground 하차 알림 refresh는 진행 중 예약을 건너뛴다', (tester) async {
+    final notifier = _RecordingGetOffAlarmNotifier();
+    final stateRepository = _MemoryGetOffAlarmStateRepository();
+    final controller = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: _StubExactAlarmPermissionGate(),
+      notificationPermissionProvider: FakeNotificationPermissionProvider(
+        nextStatus: NotificationPermissionStatus.granted,
+      ),
+      repository: stateRepository,
+      now: () => DateTime.parse('2026-07-06T09:00:00+09:00'),
+    );
+    addTearDown(controller.dispose);
+    final pendingRefresh = Completer<RouteRefreshResult>();
+    final repository = FakeRouteSearchRepository(
+      result: _sampleRouteSearchResult(
+        steps: const [
+          RouteSearchStep(
+            sequence: 1,
+            stepType: 'ride',
+            title: '상록수에서 사당까지 이동',
+            description: '열차를 이용해 이동합니다.',
+            lineId: 'seoul-4',
+            lineName: '수도권 4호선',
+            fromStationId: 'station-sangnoksu',
+            toStationId: 'station-sadang',
+            estimatedMinutes: 32,
+            distanceMeters: 13500,
+            includesStairs: false,
+            requiresAccessibilityCheck: true,
+            plannedArrivalTimeIso: '2026-07-06T09:37:30+09:00',
+            realtimeArrivalTimeIso: '2026-07-06T09:39:00+09:00',
+          ),
+        ],
+      ),
+    )..pendingRefresh = pendingRefresh;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RouteSearchScreen(
+          repository: repository,
+          stationRepository: FakeStationSearchRepository(),
+          getOffAlarmController: controller,
+          initialDraft: RouteDraft(
+            origin: const RouteDraftStation(
+              id: 'station-sangnoksu',
+              nameKo: '상록수',
+            ),
+            destination: const RouteDraftStation(
+              id: 'station-sadang',
+              nameKo: '사당',
+            ),
+            lastModifiedAt: DateTime(2026, 7, 6),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
+    await tester.pumpAndSettle();
+    await controller.enable(
+      routeId: 'route-1',
+      stops: [
+        GetOffAlarmStop(
+          stationId: 'station-sadang',
+          stationName: '사당',
+          arrivalAt: DateTime.parse('2026-07-06T09:39:00+09:00'),
+          kind: GetOffAlarmKind.destination,
+        ),
+      ],
+      transferAlarmEnabled: false,
+    );
+    notifier.reset();
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+    await tester.pump();
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pump();
+    expect(repository.refreshRouteSearchIds, ['route-1']);
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+    await tester.pump();
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pump();
+    await tester.pump();
+
+    expect(notifier.scheduleCalls, 0);
+
+    pendingRefresh.complete(
+      RouteRefreshResult(
+        routeSearchId: 'route-1',
+        status: 'UPDATED_ETA',
+        result: _sampleRouteSearchResult(
+          steps: const [
+            RouteSearchStep(
+              sequence: 1,
+              stepType: 'ride',
+              title: '상록수에서 사당까지 이동',
+              description: '열차를 이용해 이동합니다.',
+              lineId: 'seoul-4',
+              lineName: '수도권 4호선',
+              fromStationId: 'station-sangnoksu',
+              toStationId: 'station-sadang',
+              estimatedMinutes: 32,
+              distanceMeters: 13500,
+              includesStairs: false,
+              requiresAccessibilityCheck: true,
+              plannedArrivalTimeIso: '2026-07-06T09:37:30+09:00',
+              realtimeArrivalTimeIso: '2026-07-06T09:40:00+09:00',
+            ),
+          ],
+        ),
+        refreshedAt: '2026-07-06T09:01:00+09:00',
+        etaSource: 'REALTIME',
+        etaConfidence: 'HIGH',
+        sourceLabel: '실시간 도착 정보 기준',
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(notifier.scheduleCalls, 1);
+    expect(
+      notifier.scheduledAlarms.single.arrivalAt.isAtSameMomentAs(
+        DateTime.parse('2026-07-06T09:40:00+09:00'),
+      ),
+      isTrue,
+    );
+  });
+
   testWidgets('추천 경로 항목은 스크린리더에서 상세 진입 버튼으로 남는다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
     try {
@@ -12845,6 +12973,7 @@ class FakeRouteSearchRepository implements RouteSearchRepository {
   final refreshRouteSearchIds = <String>[];
   RouteRefreshResult? refreshResult;
   Object? refreshError;
+  Completer<RouteRefreshResult>? pendingRefresh;
 
   @override
   Future<RouteSearchResult> searchRoute(RouteSearchRequest request) async {
@@ -12862,6 +12991,10 @@ class FakeRouteSearchRepository implements RouteSearchRepository {
     final currentError = refreshError;
     if (currentError != null) {
       throw currentError;
+    }
+    final pending = pendingRefresh;
+    if (pending != null) {
+      return pending.future;
     }
     return refreshResult ??
         RouteRefreshResult(

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -9341,13 +9341,15 @@ void main() {
   });
 
   testWidgets('planned 승차 시간이 있는 경로 결과는 하차 알림 토글을 보여준다', (tester) async {
+    final notifier = _RecordingGetOffAlarmNotifier();
+    final stateRepository = _MemoryGetOffAlarmStateRepository();
     final controller = GetOffAlarmController(
-      notifier: _RecordingGetOffAlarmNotifier(),
+      notifier: notifier,
       permissionGate: _StubExactAlarmPermissionGate(),
       notificationPermissionProvider: FakeNotificationPermissionProvider(
         nextStatus: NotificationPermissionStatus.granted,
       ),
-      repository: _MemoryGetOffAlarmStateRepository(),
+      repository: stateRepository,
       now: () => DateTime(2026, 7, 6, 9, 0),
     );
     addTearDown(controller.dispose);
@@ -9414,6 +9416,14 @@ void main() {
 
     expect(find.text('하차 알림'), findsOneWidget);
     expect(find.text('폰을 보지 않아도 내릴 때 알려드려요.'), findsOneWidget);
+
+    await tester.ensureVisible(find.text('하차 알림'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('하차 알림'));
+    await tester.pumpAndSettle();
+
+    expect(notifier.scheduledAlarms.single.stationName, '사당');
+    expect((await stateRepository.loadActive())?.destination.stationName, '사당');
   });
 
   testWidgets('ride 중 하나의 공식 도착이 없으면 부분 하차 알림을 보이지 않는다', (tester) async {
@@ -9640,11 +9650,67 @@ void main() {
     expect(notifier.scheduleCalls, 1);
     expect(notifier.scheduledMode, GetOffAlarmScheduleMode.exact);
     expect(notifier.scheduledAlarms.single.stationId, 'station-sadang');
+    expect(notifier.scheduledAlarms.single.stationName, '사당');
     expect(
       notifier.scheduledAlarms.single.fireAt.isAtSameMomentAs(fireAt),
       isTrue,
     );
     expect((await stateRepository.loadActive())?.transferAlarmEnabled, isFalse);
+    expect((await stateRepository.loadActive())?.destination.stationName, '사당');
+  });
+
+  testWidgets('pull-to-refresh는 활성 하차 알림을 새 ETA로 재예약한다', (tester) async {
+    final notifier = _RecordingGetOffAlarmNotifier();
+    final stateRepository = _MemoryGetOffAlarmStateRepository();
+    final controller = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: _StubExactAlarmPermissionGate(),
+      notificationPermissionProvider: FakeNotificationPermissionProvider(
+        nextStatus: NotificationPermissionStatus.granted,
+      ),
+      repository: stateRepository,
+      now: () => DateTime.parse('2026-07-06T09:00:00+09:00'),
+    );
+    addTearDown(controller.dispose);
+    final repository =
+        FakeRouteSearchRepository(result: _sampleGetOffAlarmRouteResult())
+          ..refreshResult = RouteRefreshResult(
+            routeSearchId: 'route-1',
+            status: 'UPDATED_ETA',
+            result: _sampleGetOffAlarmRouteResult(
+              realtimeArrivalTimeIso: '2026-07-06T09:40:00+09:00',
+            ),
+            refreshedAt: '2026-07-06T09:01:00+09:00',
+            etaSource: 'REALTIME',
+            etaConfidence: 'HIGH',
+            sourceLabel: '실시간 도착 정보 기준',
+          );
+    await _pumpGetOffAlarmRouteScreen(
+      tester,
+      repository: repository,
+      controller: controller,
+    );
+    await _enableSampleGetOffAlarm(controller);
+    notifier.reset();
+
+    await tester.drag(find.byType(ListView).first, const Offset(0, 500));
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    expect(repository.refreshRouteSearchIds, ['route-1']);
+    expect(notifier.scheduleCalls, 1);
+    expect(
+      notifier.scheduledAlarms.single.arrivalAt.isAtSameMomentAs(
+        DateTime.parse('2026-07-06T09:40:00+09:00'),
+      ),
+      isTrue,
+    );
+    expect(
+      notifier.scheduledAlarms.single.fireAt.isAtSameMomentAs(
+        DateTime.parse('2026-07-06T09:38:00+09:00'),
+      ),
+      isTrue,
+    );
   });
 
   testWidgets('새 경로 검색은 활성 하차 알림을 취소한다', (tester) async {
@@ -9779,6 +9845,133 @@ void main() {
     expect(controller.state.enabled, isFalse);
   });
 
+  testWidgets('일반 보기 이동 조건 변경은 활성 하차 알림과 이전 경로 결과를 정리한다', (tester) async {
+    final notifier = _RecordingGetOffAlarmNotifier();
+    final controller = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: _StubExactAlarmPermissionGate(),
+      notificationPermissionProvider: FakeNotificationPermissionProvider(
+        nextStatus: NotificationPermissionStatus.granted,
+      ),
+      repository: _MemoryGetOffAlarmStateRepository(),
+      now: () => DateTime.parse('2026-07-06T09:00:00+09:00'),
+    );
+    addTearDown(controller.dispose);
+    await _pumpGetOffAlarmRouteScreen(
+      tester,
+      repository: FakeRouteSearchRepository(
+        result: _sampleGetOffAlarmRouteResult(),
+      ),
+      controller: controller,
+      simpleViewEnabled: false,
+    );
+    await _enableSampleGetOffAlarm(controller);
+    notifier.reset();
+
+    await tester.tap(find.byType(DropdownButton<String>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('휠체어 이용').last);
+    await tester.pumpAndSettle();
+
+    expect(notifier.cancelCalls, 1);
+    expect(controller.state.enabled, isFalse);
+    expect(find.byKey(const Key('routeResultListItem')), findsNothing);
+    expect(
+      tester
+          .widget<DropdownButton<String>>(find.byType(DropdownButton<String>))
+          .value,
+      'WHEELCHAIR',
+    );
+  });
+
+  testWidgets('계단 없는 길 조건 변경은 활성 하차 알림과 이전 경로 결과를 정리한다', (tester) async {
+    final notifier = _RecordingGetOffAlarmNotifier();
+    final controller = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: _StubExactAlarmPermissionGate(),
+      notificationPermissionProvider: FakeNotificationPermissionProvider(
+        nextStatus: NotificationPermissionStatus.granted,
+      ),
+      repository: _MemoryGetOffAlarmStateRepository(),
+      now: () => DateTime.parse('2026-07-06T09:00:00+09:00'),
+    );
+    addTearDown(controller.dispose);
+    await _pumpGetOffAlarmRouteScreen(
+      tester,
+      repository: FakeRouteSearchRepository(
+        result: _sampleGetOffAlarmRouteResult(),
+      ),
+      controller: controller,
+    );
+    await _enableSampleGetOffAlarm(controller);
+    notifier.reset();
+
+    await tester.ensureVisible(
+      find.byKey(const Key('routeStrictStepFreeSwitch')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('routeStrictStepFreeSwitch')));
+    await tester.pumpAndSettle();
+
+    expect(notifier.cancelCalls, 1);
+    expect(controller.state.enabled, isFalse);
+    expect(find.byKey(const Key('routeResultListItem')), findsNothing);
+    expect(
+      tester
+          .widget<SwitchListTile>(
+            find.byKey(const Key('routeStrictStepFreeSwitch')),
+          )
+          .value,
+      isTrue,
+    );
+  });
+
+  testWidgets('일반 보기 이동 조건 변경은 하차 알림 취소 실패 시 기존 조건과 경로를 유지한다', (tester) async {
+    final notifier = _RecordingGetOffAlarmNotifier();
+    final controller = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: _StubExactAlarmPermissionGate(),
+      notificationPermissionProvider: FakeNotificationPermissionProvider(
+        nextStatus: NotificationPermissionStatus.granted,
+      ),
+      repository: _MemoryGetOffAlarmStateRepository(),
+      now: () => DateTime.parse('2026-07-06T09:00:00+09:00'),
+    );
+    addTearDown(controller.dispose);
+    await _pumpGetOffAlarmRouteScreen(
+      tester,
+      repository: FakeRouteSearchRepository(
+        result: _sampleGetOffAlarmRouteResult(),
+      ),
+      controller: controller,
+      simpleViewEnabled: false,
+    );
+    await _enableSampleGetOffAlarm(controller);
+    notifier.reset();
+    final cancelError = StateError('cancel failed');
+    notifier.cancelError = cancelError;
+    final reports = <FlutterErrorDetails>[];
+
+    await runWithMobileErrorReporter(reports.add, () async {
+      await tester.tap(find.byType(DropdownButton<String>));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('휠체어 이용').last);
+      await tester.pumpAndSettle();
+    });
+
+    expect(reports.single.exception, same(cancelError));
+    expect(find.text('하차 알림을 취소하지 못했어요. 다시 시도해 주세요.'), findsOneWidget);
+    expect(controller.state.enabled, isTrue);
+    expect(find.byKey(const Key('routeResultListItem')), findsOneWidget);
+    expect(
+      tester
+          .widget<DropdownButton<String>>(find.byType(DropdownButton<String>))
+          .value,
+      'SENIOR',
+    );
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets(
     'pending enable 중 shell route exit는 disable 완료 뒤 경로와 하차 알림을 끝낸다',
     (tester) async {
@@ -9864,6 +10057,76 @@ void main() {
       expect(find.byKey(const Key('routeResultListItem')), findsNothing);
     },
   );
+
+  testWidgets('shell route exit는 하차 알림 취소 실패를 보고하고 현재 화면을 유지한다', (
+    tester,
+  ) async {
+    final notifier = _RecordingGetOffAlarmNotifier();
+    final stateRepository = _MemoryGetOffAlarmStateRepository();
+    final controller = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: _StubExactAlarmPermissionGate(),
+      notificationPermissionProvider: FakeNotificationPermissionProvider(
+        nextStatus: NotificationPermissionStatus.granted,
+      ),
+      repository: stateRepository,
+      now: () => DateTime.parse('2026-07-06T09:00:00+09:00'),
+    );
+    addTearDown(controller.dispose);
+    await controller.enable(
+      routeId: 'route-1',
+      stops: [
+        GetOffAlarmStop(
+          stationId: 'station-sadang',
+          stationName: '사당',
+          arrivalAt: DateTime.parse('2026-07-06T09:37:30+09:00'),
+          kind: GetOffAlarmKind.destination,
+        ),
+      ],
+      transferAlarmEnabled: false,
+    );
+    notifier.reset();
+    final cancelError = StateError('cancel failed');
+    notifier.cancelError = cancelError;
+    final reports = <FlutterErrorDetails>[];
+    var exitCount = 0;
+
+    await runWithMobileErrorReporter(reports.add, () async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: RouteSearchScreen(
+            repository: FakeRouteSearchRepository(),
+            stationRepository: FakeStationSearchRepository(),
+            getOffAlarmController: controller,
+            onShellBackToHome: () => exitCount += 1,
+            initialDraft: RouteDraft(
+              origin: const RouteDraftStation(
+                id: 'station-sangnoksu',
+                nameKo: '상록수',
+              ),
+              destination: const RouteDraftStation(
+                id: 'station-sadang',
+                nameKo: '사당',
+              ),
+              lastModifiedAt: DateTime(2026, 7, 6),
+            ),
+          ),
+        ),
+      );
+
+      await tester.binding.handlePopRoute();
+      await tester.pumpAndSettle();
+    });
+
+    expect(reports.single.exception, same(cancelError));
+    expect(reports.single.context.toString(), '하차 알림 취소 중 예외가 발생했습니다.');
+    expect(find.text('하차 알림을 취소하지 못했어요. 다시 시도해 주세요.'), findsOneWidget);
+    expect(exitCount, 0);
+    expect(find.byKey(const Key('routeSearchScreen')), findsOneWidget);
+    expect(controller.state.enabled, isTrue);
+    expect(await stateRepository.loadActive(), isNotNull);
+    expect(tester.takeException(), isNull);
+  });
 
   testWidgets(
     'offline foreground refresh는 stale realtime 대신 PLANNED 하차 알림을 사용한다',
@@ -9971,6 +10234,100 @@ void main() {
       );
     },
   );
+
+  testWidgets('성공한 foreground refresh에 usable ride가 없으면 활성 하차 알림을 취소한다', (
+    tester,
+  ) async {
+    final notifier = _RecordingGetOffAlarmNotifier();
+    final stateRepository = _MemoryGetOffAlarmStateRepository();
+    final controller = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: _StubExactAlarmPermissionGate(),
+      notificationPermissionProvider: FakeNotificationPermissionProvider(
+        nextStatus: NotificationPermissionStatus.granted,
+      ),
+      repository: stateRepository,
+      now: () => DateTime.parse('2026-07-06T09:00:00+09:00'),
+    );
+    addTearDown(controller.dispose);
+    final repository =
+        FakeRouteSearchRepository(
+            result: _sampleRouteSearchResult(
+              steps: const [
+                RouteSearchStep(
+                  sequence: 1,
+                  stepType: 'ride',
+                  title: '상록수에서 사당까지 이동',
+                  description: '열차를 이용해 이동합니다.',
+                  lineId: 'seoul-4',
+                  lineName: '수도권 4호선',
+                  fromStationId: 'station-sangnoksu',
+                  toStationId: 'station-sadang',
+                  estimatedMinutes: 32,
+                  distanceMeters: 13500,
+                  includesStairs: false,
+                  requiresAccessibilityCheck: true,
+                  plannedArrivalTimeIso: '2026-07-06T09:37:30+09:00',
+                ),
+              ],
+            ),
+          )
+          ..refreshResult = RouteRefreshResult(
+            routeSearchId: 'route-1',
+            status: 'UPDATED_ROUTE',
+            result: _sampleRouteSearchResult(steps: const []),
+            refreshedAt: '2026-07-06T09:01:00+09:00',
+            etaSource: 'PLANNED',
+            etaConfidence: 'MEDIUM',
+            sourceLabel: '계획 시간 기준',
+          );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RouteSearchScreen(
+          repository: repository,
+          stationRepository: FakeStationSearchRepository(),
+          getOffAlarmController: controller,
+          initialDraft: RouteDraft(
+            origin: const RouteDraftStation(
+              id: 'station-sangnoksu',
+              nameKo: '상록수',
+            ),
+            destination: const RouteDraftStation(
+              id: 'station-sadang',
+              nameKo: '사당',
+            ),
+            lastModifiedAt: DateTime(2026, 7, 6),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
+    await tester.pumpAndSettle();
+    await controller.enable(
+      routeId: 'route-1',
+      stops: [
+        GetOffAlarmStop(
+          stationId: 'station-sadang',
+          stationName: '사당',
+          arrivalAt: DateTime.parse('2026-07-06T09:37:30+09:00'),
+          kind: GetOffAlarmKind.destination,
+        ),
+      ],
+      transferAlarmEnabled: false,
+    );
+    notifier.reset();
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+    await tester.pump();
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pumpAndSettle();
+
+    expect(repository.refreshRouteSearchIds, ['route-1']);
+    expect(notifier.cancelCalls, 1);
+    expect(controller.state.enabled, isFalse);
+    expect(await stateRepository.loadActive(), isNull);
+  });
 
   testWidgets('중복 foreground 하차 알림 refresh는 진행 중 예약을 건너뛴다', (tester) async {
     final notifier = _RecordingGetOffAlarmNotifier();
@@ -13123,6 +13480,78 @@ class _FakeKakaoMapLauncher implements KakaoMapLauncher {
   }
 }
 
+RouteSearchResult _sampleGetOffAlarmRouteResult({
+  String plannedArrivalTimeIso = '2026-07-06T09:37:30+09:00',
+  String realtimeArrivalTimeIso = '',
+}) {
+  return _sampleRouteSearchResult(
+    steps: [
+      RouteSearchStep(
+        sequence: 1,
+        stepType: 'ride',
+        title: '상록수에서 사당까지 이동',
+        description: '열차를 이용해 이동합니다.',
+        lineId: 'seoul-4',
+        lineName: '수도권 4호선',
+        fromStationId: 'station-sangnoksu',
+        toStationId: 'station-sadang',
+        estimatedMinutes: 32,
+        distanceMeters: 13500,
+        includesStairs: false,
+        requiresAccessibilityCheck: true,
+        plannedArrivalTimeIso: plannedArrivalTimeIso,
+        realtimeArrivalTimeIso: realtimeArrivalTimeIso,
+      ),
+    ],
+  );
+}
+
+Future<void> _pumpGetOffAlarmRouteScreen(
+  WidgetTester tester, {
+  required FakeRouteSearchRepository repository,
+  required GetOffAlarmController controller,
+  bool simpleViewEnabled = true,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: RouteSearchScreen(
+        repository: repository,
+        stationRepository: FakeStationSearchRepository(),
+        getOffAlarmController: controller,
+        simpleViewEnabled: simpleViewEnabled,
+        initialDraft: RouteDraft(
+          origin: const RouteDraftStation(
+            id: 'station-sangnoksu',
+            nameKo: '상록수',
+          ),
+          destination: const RouteDraftStation(
+            id: 'station-sadang',
+            nameKo: '사당',
+          ),
+          lastModifiedAt: DateTime(2026, 7, 6),
+        ),
+      ),
+    ),
+  );
+  await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
+  await tester.pumpAndSettle();
+}
+
+Future<void> _enableSampleGetOffAlarm(GetOffAlarmController controller) {
+  return controller.enable(
+    routeId: 'route-1',
+    stops: [
+      GetOffAlarmStop(
+        stationId: 'station-sadang',
+        stationName: '사당',
+        arrivalAt: DateTime.parse('2026-07-06T09:37:30+09:00'),
+        kind: GetOffAlarmKind.destination,
+      ),
+    ],
+    transferAlarmEnabled: false,
+  );
+}
+
 class FakeRouteSearchRepository implements RouteSearchRepository {
   FakeRouteSearchRepository({RouteSearchResult? result, this.error})
     : result = result ?? _sampleRouteSearchResult();
@@ -13174,6 +13603,7 @@ class _RecordingGetOffAlarmNotifier implements GetOffAlarmNotifier {
   int cancelCalls = 0;
   List<ScheduledGetOffAlarm> scheduledAlarms = const [];
   GetOffAlarmScheduleMode? scheduledMode;
+  Object? cancelError;
 
   void reset() {
     scheduleCalls = 0;
@@ -13185,6 +13615,10 @@ class _RecordingGetOffAlarmNotifier implements GetOffAlarmNotifier {
   @override
   Future<void> cancelAll() async {
     cancelCalls += 1;
+    final error = cancelError;
+    if (error != null) {
+      throw error;
+    }
   }
 
   @override

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -9421,7 +9421,7 @@ void main() {
     final now = DateTime.parse('2026-07-06T09:00:00+09:00');
     final transferArrivalAt = DateTime.parse('2026-07-06T09:20:00+09:00');
     final arrivalAt = DateTime.parse('2026-07-06T09:37:30+09:00');
-    final fireAt = DateTime.parse('2026-07-06T09:35:30+09:00');
+    final fireAt = DateTime.parse('2026-07-06T09:38:00+09:00');
     final stateRepository = _MemoryGetOffAlarmStateRepository();
     final controller = GetOffAlarmController(
       notifier: notifier,
@@ -9503,6 +9503,7 @@ void main() {
             distanceMeters: 7200,
             includesStairs: false,
             requiresAccessibilityCheck: true,
+            realtimeArrivalTimeIso: '2026-07-06T09:40:00+09:00',
           ),
         ],
         etaSource: 'STATIC_BACKEND_ESTIMATE',
@@ -9571,6 +9572,245 @@ void main() {
     );
     expect((await stateRepository.loadActive())?.transferAlarmEnabled, isFalse);
   });
+
+  testWidgets('새 경로 검색은 활성 하차 알림을 취소한다', (tester) async {
+    final notifier = _RecordingGetOffAlarmNotifier();
+    final controller = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: _StubExactAlarmPermissionGate(),
+      notificationPermissionProvider: FakeNotificationPermissionProvider(
+        nextStatus: NotificationPermissionStatus.granted,
+      ),
+      repository: _MemoryGetOffAlarmStateRepository(),
+      now: () => DateTime.parse('2026-07-06T09:00:00+09:00'),
+    );
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RouteSearchScreen(
+          repository: FakeRouteSearchRepository(
+            result: _sampleRouteSearchResult(
+              steps: const [
+                RouteSearchStep(
+                  sequence: 1,
+                  stepType: 'ride',
+                  title: '상록수에서 사당까지 이동',
+                  description: '열차를 이용해 이동합니다.',
+                  lineId: 'seoul-4',
+                  lineName: '수도권 4호선',
+                  fromStationId: 'station-sangnoksu',
+                  toStationId: 'station-sadang',
+                  estimatedMinutes: 32,
+                  distanceMeters: 13500,
+                  includesStairs: false,
+                  requiresAccessibilityCheck: true,
+                  plannedArrivalTimeIso: '2026-07-06T09:37:30+09:00',
+                ),
+              ],
+            ),
+          ),
+          stationRepository: FakeStationSearchRepository(),
+          getOffAlarmController: controller,
+          initialDraft: RouteDraft(
+            origin: const RouteDraftStation(
+              id: 'station-sangnoksu',
+              nameKo: '상록수',
+            ),
+            destination: const RouteDraftStation(
+              id: 'station-sadang',
+              nameKo: '사당',
+            ),
+            lastModifiedAt: DateTime(2026, 7, 6),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
+    await tester.pumpAndSettle();
+    await controller.enable(
+      routeId: 'route-1',
+      stops: [
+        GetOffAlarmStop(
+          stationId: 'station-sadang',
+          stationName: '사당',
+          arrivalAt: DateTime.parse('2026-07-06T09:37:30+09:00'),
+          kind: GetOffAlarmKind.destination,
+        ),
+      ],
+      transferAlarmEnabled: false,
+    );
+    notifier.reset();
+
+    await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
+    await tester.pumpAndSettle();
+
+    expect(notifier.cancelCalls, 1);
+    expect(controller.state.enabled, isFalse);
+  });
+
+  testWidgets('경로 reset은 활성 하차 알림을 취소한다', (tester) async {
+    final notifier = _RecordingGetOffAlarmNotifier();
+    final controller = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: _StubExactAlarmPermissionGate(),
+      notificationPermissionProvider: FakeNotificationPermissionProvider(
+        nextStatus: NotificationPermissionStatus.granted,
+      ),
+      repository: _MemoryGetOffAlarmStateRepository(),
+      now: () => DateTime.parse('2026-07-06T09:00:00+09:00'),
+    );
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RouteSearchScreen(
+          repository: FakeRouteSearchRepository(),
+          stationRepository: FakeStationSearchRepository(),
+          getOffAlarmController: controller,
+          initialDraft: RouteDraft(
+            origin: const RouteDraftStation(
+              id: 'station-sangnoksu',
+              nameKo: '상록수',
+            ),
+            destination: const RouteDraftStation(
+              id: 'station-sadang',
+              nameKo: '사당',
+            ),
+            lastModifiedAt: DateTime(2026, 7, 6),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
+    await tester.pumpAndSettle();
+    await controller.enable(
+      routeId: 'route-1',
+      stops: [
+        GetOffAlarmStop(
+          stationId: 'station-sadang',
+          stationName: '사당',
+          arrivalAt: DateTime.parse('2026-07-06T09:37:30+09:00'),
+          kind: GetOffAlarmKind.destination,
+        ),
+      ],
+      transferAlarmEnabled: false,
+    );
+    notifier.reset();
+
+    await tester.tap(find.byKey(const Key('routeSwapStationsButton')));
+    await tester.pumpAndSettle();
+
+    expect(notifier.cancelCalls, 1);
+    expect(controller.state.enabled, isFalse);
+  });
+
+  testWidgets(
+    'offline foreground refresh는 stale realtime 대신 PLANNED 하차 알림을 사용한다',
+    (tester) async {
+      final previousDebugPrint = debugPrint;
+      final logs = <String>[];
+      debugPrint = (message, {wrapWidth}) {
+        if (message != null) {
+          logs.add(message);
+        }
+      };
+      addTearDown(() => debugPrint = previousDebugPrint);
+
+      final notifier = _RecordingGetOffAlarmNotifier();
+      final stateRepository = _MemoryGetOffAlarmStateRepository();
+      final controller = GetOffAlarmController(
+        notifier: notifier,
+        permissionGate: _StubExactAlarmPermissionGate(),
+        notificationPermissionProvider: FakeNotificationPermissionProvider(
+          nextStatus: NotificationPermissionStatus.granted,
+        ),
+        repository: stateRepository,
+        now: () => DateTime.parse('2026-07-06T09:00:00+09:00'),
+      );
+      addTearDown(controller.dispose);
+      final repository = FakeRouteSearchRepository(
+        result: _sampleRouteSearchResult(
+          steps: const [
+            RouteSearchStep(
+              sequence: 1,
+              stepType: 'ride',
+              title: '상록수에서 사당까지 이동',
+              description: '열차를 이용해 이동합니다.',
+              lineId: 'seoul-4',
+              lineName: '수도권 4호선',
+              fromStationId: 'station-sangnoksu',
+              toStationId: 'station-sadang',
+              estimatedMinutes: 32,
+              distanceMeters: 13500,
+              includesStairs: false,
+              requiresAccessibilityCheck: true,
+              plannedArrivalTimeIso: '2026-07-06T09:37:30+09:00',
+              realtimeArrivalTimeIso: '2026-07-06T09:40:00+09:00',
+            ),
+          ],
+        ),
+      )..refreshError = const RouteSearchException('offline');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: RouteSearchScreen(
+            repository: repository,
+            stationRepository: FakeStationSearchRepository(),
+            getOffAlarmController: controller,
+            initialDraft: RouteDraft(
+              origin: const RouteDraftStation(
+                id: 'station-sangnoksu',
+                nameKo: '상록수',
+              ),
+              destination: const RouteDraftStation(
+                id: 'station-sadang',
+                nameKo: '사당',
+              ),
+              lastModifiedAt: DateTime(2026, 7, 6),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
+      await tester.pumpAndSettle();
+      await controller.enable(
+        routeId: 'route-1',
+        stops: [
+          GetOffAlarmStop(
+            stationId: 'station-sadang',
+            stationName: '사당',
+            arrivalAt: DateTime.parse('2026-07-06T09:40:00+09:00'),
+            kind: GetOffAlarmKind.destination,
+          ),
+        ],
+        transferAlarmEnabled: false,
+      );
+      notifier.reset();
+
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+      await tester.pump();
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      await tester.pumpAndSettle();
+      debugPrint = previousDebugPrint;
+
+      expect(repository.refreshRouteSearchIds, ['route-1']);
+      expect(notifier.scheduleCalls, 1);
+      expect(
+        notifier.scheduledAlarms.single.arrivalAt.isAtSameMomentAs(
+          DateTime.parse('2026-07-06T09:37:30+09:00'),
+        ),
+        isTrue,
+      );
+      expect(
+        logs.singleWhere(
+          (log) => log.startsWith('get_off_alarm foreground_refresh'),
+        ),
+        'get_off_alarm foreground_refresh changed=true '
+        'delta_seconds=-150 source=planned mode=exact scheduled_count=1',
+      );
+    },
+  );
 
   testWidgets('추천 경로 항목은 스크린리더에서 상세 진입 버튼으로 남는다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
@@ -12604,6 +12844,7 @@ class FakeRouteSearchRepository implements RouteSearchRepository {
   final requests = <RouteSearchRequest>[];
   final refreshRouteSearchIds = <String>[];
   RouteRefreshResult? refreshResult;
+  Object? refreshError;
 
   @override
   Future<RouteSearchResult> searchRoute(RouteSearchRequest request) async {
@@ -12618,6 +12859,10 @@ class FakeRouteSearchRepository implements RouteSearchRepository {
   @override
   Future<RouteRefreshResult> refreshRoute(String routeSearchId) async {
     refreshRouteSearchIds.add(routeSearchId);
+    final currentError = refreshError;
+    if (currentError != null) {
+      throw currentError;
+    }
     return refreshResult ??
         RouteRefreshResult(
           routeSearchId: routeSearchId,
@@ -12633,17 +12878,21 @@ class FakeRouteSearchRepository implements RouteSearchRepository {
 
 class _RecordingGetOffAlarmNotifier implements GetOffAlarmNotifier {
   int scheduleCalls = 0;
+  int cancelCalls = 0;
   List<ScheduledGetOffAlarm> scheduledAlarms = const [];
   GetOffAlarmScheduleMode? scheduledMode;
 
   void reset() {
     scheduleCalls = 0;
+    cancelCalls = 0;
     scheduledAlarms = const [];
     scheduledMode = null;
   }
 
   @override
-  Future<void> cancelAll() async {}
+  Future<void> cancelAll() async {
+    cancelCalls += 1;
+  }
 
   @override
   Future<ScheduleDeliveryResult> scheduleAlarms(

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -9344,6 +9344,9 @@ void main() {
     final controller = GetOffAlarmController(
       notifier: _RecordingGetOffAlarmNotifier(),
       permissionGate: _StubExactAlarmPermissionGate(),
+      notificationPermissionProvider: FakeNotificationPermissionProvider(
+        nextStatus: NotificationPermissionStatus.granted,
+      ),
       repository: _MemoryGetOffAlarmStateRepository(),
       now: () => DateTime(2026, 7, 6, 9, 0),
     );
@@ -9423,6 +9426,9 @@ void main() {
     final controller = GetOffAlarmController(
       notifier: notifier,
       permissionGate: _StubExactAlarmPermissionGate(),
+      notificationPermissionProvider: FakeNotificationPermissionProvider(
+        nextStatus: NotificationPermissionStatus.granted,
+      ),
       repository: stateRepository,
       now: () => now,
     );
@@ -12640,13 +12646,17 @@ class _RecordingGetOffAlarmNotifier implements GetOffAlarmNotifier {
   Future<void> cancelAll() async {}
 
   @override
-  Future<void> scheduleAlarms(
+  Future<ScheduleDeliveryResult> scheduleAlarms(
     List<ScheduledGetOffAlarm> alarms, {
     required GetOffAlarmScheduleMode mode,
   }) async {
     scheduleCalls += 1;
     scheduledAlarms = alarms;
     scheduledMode = mode;
+    return ScheduleDeliveryResult(
+      scheduledCount: alarms.length,
+      failedCount: 0,
+    );
   }
 }
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -13188,6 +13188,9 @@ class _RecordingGetOffAlarmNotifier implements GetOffAlarmNotifier {
   }
 
   @override
+  Future<int> pendingAlarmCount() async => scheduledAlarms.length;
+
+  @override
   Future<ScheduleDeliveryResult> scheduleAlarms(
     List<ScheduledGetOffAlarm> alarms, {
     required GetOffAlarmScheduleMode mode,
@@ -13389,6 +13392,15 @@ class FakeNotificationPermissionProvider
   int requestCount = 0;
 
   @override
+  Future<NotificationPermissionStatus> notificationPermissionStatus() async {
+    final currentError = error;
+    if (currentError != null) {
+      throw currentError;
+    }
+    return nextStatus;
+  }
+
+  @override
   Future<NotificationPermissionStatus> requestNotificationPermission() async {
     requestCount++;
     final currentError = error;
@@ -13404,6 +13416,10 @@ class _BlockingNotificationPermissionProvider
   final started = Completer<void>();
   final result = Completer<NotificationPermissionStatus>();
   int requestCount = 0;
+
+  @override
+  Future<NotificationPermissionStatus> notificationPermissionStatus() async =>
+      NotificationPermissionStatus.granted;
 
   @override
   Future<NotificationPermissionStatus> requestNotificationPermission() {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -9416,6 +9416,80 @@ void main() {
     expect(find.text('폰을 보지 않아도 내릴 때 알려드려요.'), findsOneWidget);
   });
 
+  testWidgets('ride 중 하나의 공식 도착이 없으면 부분 하차 알림을 보이지 않는다', (tester) async {
+    final controller = GetOffAlarmController(
+      notifier: _RecordingGetOffAlarmNotifier(),
+      permissionGate: _StubExactAlarmPermissionGate(),
+      notificationPermissionProvider: FakeNotificationPermissionProvider(
+        nextStatus: NotificationPermissionStatus.granted,
+      ),
+      repository: _MemoryGetOffAlarmStateRepository(),
+      now: () => DateTime(2026, 7, 6, 9),
+    );
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RouteSearchScreen(
+          repository: FakeRouteSearchRepository(
+            result: _sampleRouteSearchResult(
+              steps: const [
+                RouteSearchStep(
+                  sequence: 1,
+                  stepType: 'ride',
+                  title: '상록수에서 금정까지 이동',
+                  description: '열차를 이용해 이동합니다.',
+                  lineId: 'seoul-4',
+                  lineName: '수도권 4호선',
+                  fromStationId: 'station-sangnoksu',
+                  toStationId: 'station-geumjeong',
+                  estimatedMinutes: 15,
+                  distanceMeters: 6300,
+                  includesStairs: false,
+                  requiresAccessibilityCheck: true,
+                  plannedArrivalTimeIso: '2026-07-06T09:20:00+09:00',
+                ),
+                RouteSearchStep(
+                  sequence: 2,
+                  stepType: 'ride',
+                  title: '금정에서 사당까지 이동',
+                  description: '열차를 이용해 이동합니다.',
+                  lineId: 'seoul-4',
+                  lineName: '수도권 4호선',
+                  fromStationId: 'station-geumjeong',
+                  toStationId: 'station-sadang',
+                  estimatedMinutes: 17,
+                  distanceMeters: 7200,
+                  includesStairs: false,
+                  requiresAccessibilityCheck: true,
+                ),
+              ],
+            ),
+          ),
+          stationRepository: FakeStationSearchRepository(),
+          getOffAlarmController: controller,
+          initialMobilityType: 'SENIOR',
+          initialDraft: RouteDraft(
+            origin: const RouteDraftStation(
+              id: 'station-sangnoksu',
+              nameKo: '상록수',
+            ),
+            destination: const RouteDraftStation(
+              id: 'station-sadang',
+              nameKo: '사당',
+            ),
+            lastModifiedAt: DateTime(2026, 7, 6),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('하차 알림'), findsNothing);
+  });
+
   testWidgets('foreground 복귀는 활성 하차 알림을 현재 경로 시간으로 재예약한다', (tester) async {
     final notifier = _RecordingGetOffAlarmNotifier();
     final now = DateTime.parse('2026-07-06T09:00:00+09:00');

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -12237,3 +12237,14 @@ test("하차 알림 Android manifest는 예약 receiver만 선언한다", () => 
     /android\.permission\.RECEIVE_BOOT_COMPLETED/,
   );
 });
+
+test("하차 알림 Android 권한 상태 조회는 프롬프트 없이 OS 상태를 결합한다", () => {
+  const mainActivity = read(
+    "apps/mobile/android/app/src/main/kotlin/com/easysubway/easysubway_mobile/MainActivity.kt",
+  );
+
+  assert.match(
+    mainActivity,
+    /"notificationPermissionStatus"\s*->\s*result\.success\(hasNotificationPermission\(\)\s*&&\s*areAppNotificationsEnabled\(\)\)/,
+  );
+});

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -12223,3 +12223,17 @@ test("get-off-alarm policy contract pins the no-location, degrade-ladder invaria
   assert.equal(policy.realtimeCorrection.offlineEtaSource, "PLANNED");
   assert.equal(policy.realtimeCorrection.correctionOverlayIssue, 1416);
 });
+
+test("하차 알림 Android manifest는 예약 receiver만 선언한다", () => {
+  const androidManifest = read("apps/mobile/android/app/src/main/AndroidManifest.xml");
+
+  assert.match(
+    androidManifest,
+    /<receiver\s+android:name="com\.dexterous\.flutterlocalnotifications\.ScheduledNotificationReceiver"\s+android:exported="false"\s*\/>/,
+  );
+  assert.doesNotMatch(androidManifest, /ScheduledNotificationBootReceiver/);
+  assert.doesNotMatch(
+    androidManifest,
+    /android\.permission\.RECEIVE_BOOT_COMPLETED/,
+  );
+});


### PR DESCRIPTION
## 관련 이슈

Closes #1766

## 작업 배경

- 기존 구현은 OS 예약 성공 뒤 앱 상태 저장 실패 시 고아 알림이 남을 수 있었고, 앱 재시작·권한 철회·exact/inexact 모드 변경·동시 경로 변경에서 상태와 실제 예약이 어긋날 수 있었습니다.
- 로컬 공식 시간표 경로는 절대 도착 시각과 열차 운행 패턴 연결이 부족해 운영 경로에서 하차 알림 토글이 노출되지 않는 문제가 있었습니다.

## 작업 내용

- 하차 알림 예약·취소·복원을 단일 mutation queue로 직렬화하고, OS 예약 뒤 영속화 실패 시 소유 알림 취소와 상태 정리를 보상 수행하도록 보강했습니다.
- 앱 시작·포그라운드 복귀 시 알림 권한, 소유 pending 수, exact alarm 모드를 프롬프트 없이 재확인해 권한 철회·예약 유실·모드 변경을 조정합니다.
- 공식 로컬 시간표의 calendar 예외, 03:00 service-day, 24시간 초과 시각, 승하차 제한, 운행 패턴을 반영해 절대 출발·도착 시각을 생성합니다.
- 연결된 동일 노선·동일 운행 패턴 승차 edge를 하나의 사용자 승차 구간으로 묶어 중간역을 환승 또는 별도 알림으로 오인하지 않도록 했습니다.
- multi-leg 환승·도착역 이름은 로컬 공식 station catalog에서 비동기로 해소하며 내부 ID fallback 없이 누락 시 fail-closed 처리합니다.
- 역명 조회가 지연된 사이 경로 종료·외부 disable이 완료되면 generation guard로 오래된 enable을 예약·저장 전에 폐기합니다.
- route refresh의 알림 취소·재예약이 실패하면 현재 result identity를 확인한 뒤 이전 route state를 복원해 새 UI와 stale alarm이 공존하지 않게 합니다.
- 위치 권한·백그라운드 위치·부팅 receiver는 추가하지 않았고, exact alarm 거부 시 inexact 예약과 `±수 분 오차` 고지를 유지합니다.

## 검증

- 실행한 명령과 결과:
  - `env TZ=UTC flutter test --no-pub`: 926 tests passed
  - `flutter analyze --no-pub`: No issues found
  - `node --test tools/ci/repository-contract.test.mjs`: 173/173 passed
  - `./gradlew :app:compileDebugKotlin`: BUILD SUCCESSFUL
  - `git diff --check`: 통과
  - 독립 전체 diff 리뷰: Critical/Important/Minor 없음, APPROVED

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| exact 거부 강등 | Android 16 실기기 SM-A175N | exact app-op deny 후 토글 활성화 및 OS 예약 확인 | `.codex/evidence/1766-get-off-alarm-20260710/retest-inexact-enabled.png`, `retest-inexact-scheduled-fields.txt` | `±수 분 오차` 표시, inexact 예약 성공 |
| 오프라인 PLANNED 유지 | Android 16 실기기 | 예약 후 비행기 모드 `0→1→0`, 예약·권한 확인 | `retest-airplane-inexact-alarm.txt`, `retest-airplane-no-location-dialog.txt` | 예약 유지, 위치 요청 없음 |
| exact 백그라운드 수신 | Android 16 실기기 | HOME 백그라운드에서 실제 예약 시각까지 대기 | `retest-exact-background-delivery.mp4`, `retest-exact-delivery-record.txt` | 14:43:30.005 전달, 예약 대비 5ms; HIGH 알림 게시 |
| 위치 무수집 | 코드 리뷰 + 실기기 | manifest/receiver와 FINE·COARSE grant 및 다이얼로그 확인 | `boot-declaration-check.txt`, `retest-airplane-no-location-dialog.txt` | boot receiver 없음, 위치 권한 false, 다이얼로그 없음 |
| 현 HEAD 일치 | Android 16 실기기 | 최종 커밋 APK 재빌드·설치 후 smoke | `current-head-apk.txt`, `final-head-smoke.png` | `4ad160d2`, APK SHA-256 `08c4e792…45aa`, 정상 기동·crash 없음·active alarm 없음 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 1.0.2 (변경 없음)
- mobile versionCode: 10002 (변경 없음)
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 알림 mutation 직렬화와 저장 실패 보상, startup/foreground 비프롬프트 reconciliation, 동일 servicePattern 승차 병합, 공식 시간표 절대 시각 계산입니다.
- Ponytail 관점 재검토 결과 각 경계는 실제 실패 모드를 닫고 있으며 제거 가능한 추상화나 speculative fallback은 없었습니다.

## 리스크

- Android OS 제조사별 절전 정책이 로컬 알림 전달 시각에 영향을 줄 수 있습니다. exact 권한이 없으면 명시적으로 inexact로 강등하고 사용자에게 오차를 고지합니다.
- rollback은 이 PR revert이며 DB migration·서버 배포·데이터 변환은 없습니다. 앱 소유 notification ID만 취소하므로 다른 알림에는 영향을 주지 않습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행과 최종 HEAD PR Review 객체를 확인해 Codex CLI fallback은 불필요했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)
