### PR TITLE
[Fix] 운행 공지 캐시 강등 정합성 보강

### DIFF
--- a/apps/mobile/lib/features/service_notice/data/notice_repository.dart
+++ b/apps/mobile/lib/features/service_notice/data/notice_repository.dart
@@ -1,4 +1,5 @@
 import '../../../core/network/api_client.dart';
+import '../../../mobile_error_reporter.dart';
 import '../domain/service_notice.dart';
 
 /// 활성 공지 조회 결과. [stale]이면 오프라인/오류로 마지막 수신본을 준 것이고,
@@ -77,7 +78,16 @@ class ApiNoticeRepository implements NoticeRepository {
 
   @override
   Future<ActiveNoticesResult> activeNotices() async {
-    final cached = await cacheStore.load();
+    NoticeCacheEntry? cached;
+    try {
+      cached = await cacheStore.load();
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '운행 공지 캐시를 읽는 중 예외가 발생했습니다.',
+      );
+    }
     try {
       final response = await apiClient.getActiveNotices(
         ifNoneMatch: cached?.etag,
@@ -85,15 +95,16 @@ class ApiNoticeRepository implements NoticeRepository {
 
       if (response.isNotModified && cached != null) {
         final fetchedAt = now();
-        await cacheStore.save(
+        final notices = _activeAt(cached.notices, fetchedAt);
+        await _saveCache(
           NoticeCacheEntry(
             etag: cached.etag,
-            notices: cached.notices,
+            notices: notices,
             fetchedAt: fetchedAt,
           ),
         );
         return ActiveNoticesResult(
-          notices: cached.notices,
+          notices: notices,
           stale: false,
           asOf: fetchedAt,
         );
@@ -101,9 +112,12 @@ class ApiNoticeRepository implements NoticeRepository {
 
       if (response.isOk && response.jsonBody is Map<String, Object?>) {
         final data = (response.jsonBody as Map<String, Object?>)['data'];
-        final notices = ServiceNotice.listFromApiData(data);
         final fetchedAt = now();
-        await cacheStore.save(
+        final notices = _activeAt(
+          ServiceNotice.listFromApiData(data),
+          fetchedAt,
+        );
+        await _saveCache(
           NoticeCacheEntry(
             etag: response.etag,
             notices: notices,
@@ -122,11 +136,38 @@ class ApiNoticeRepository implements NoticeRepository {
 
     if (cached != null) {
       return ActiveNoticesResult(
-        notices: cached.notices,
+        notices: _activeAt(cached.notices, now()),
         stale: true,
         asOf: cached.fetchedAt,
       );
     }
     return const ActiveNoticesResult(notices: [], stale: false);
+  }
+
+  Future<void> _saveCache(NoticeCacheEntry entry) async {
+    try {
+      await cacheStore.save(entry);
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '운행 공지 캐시를 저장하는 중 예외가 발생했습니다.',
+      );
+    }
+  }
+
+  List<ServiceNotice> _activeAt(
+    Iterable<ServiceNotice> notices,
+    DateTime instant,
+  ) {
+    return notices
+        .where((notice) {
+          if (notice.publishedAt.isAfter(instant)) {
+            return false;
+          }
+          final expiresAt = notice.expiresAt;
+          return expiresAt == null || expiresAt.isAfter(instant);
+        })
+        .toList(growable: false);
   }
 }

--- a/apps/mobile/lib/features/service_notice/data/notice_repository.dart
+++ b/apps/mobile/lib/features/service_notice/data/notice_repository.dart
@@ -99,7 +99,7 @@ class ApiNoticeRepository implements NoticeRepository {
         await _saveCache(
           NoticeCacheEntry(
             etag: cached.etag,
-            notices: notices,
+            notices: cached.notices,
             fetchedAt: fetchedAt,
           ),
         );
@@ -113,14 +113,12 @@ class ApiNoticeRepository implements NoticeRepository {
       if (response.isOk && response.jsonBody is Map<String, Object?>) {
         final data = (response.jsonBody as Map<String, Object?>)['data'];
         final fetchedAt = now();
-        final notices = _activeAt(
-          ServiceNotice.listFromApiData(data),
-          fetchedAt,
-        );
+        final sourceNotices = ServiceNotice.listFromApiData(data);
+        final notices = _activeAt(sourceNotices, fetchedAt);
         await _saveCache(
           NoticeCacheEntry(
             etag: response.etag,
-            notices: notices,
+            notices: sourceNotices,
             fetchedAt: fetchedAt,
           ),
         );

--- a/apps/mobile/lib/features/service_notice/domain/service_notice.dart
+++ b/apps/mobile/lib/features/service_notice/domain/service_notice.dart
@@ -7,6 +7,8 @@ enum NoticeScope { all, region, line }
 /// 앱이 소비하는 운행 공지 한 건. 공개 API(`GET /api/notices/active`)의 활성
 /// 공지를 표현한다.
 class ServiceNotice {
+  static final _offsetRegExp = RegExp(r'(?:[zZ]|[+-]\d{2}(?::?\d{2})?)$');
+
   const ServiceNotice({
     required this.id,
     required this.scope,
@@ -130,9 +132,7 @@ class ServiceNotice {
     if (timeIndex == -1) {
       return DateTime.tryParse('${value}T00:00:00Z');
     }
-    final hasOffset = RegExp(
-      r'(?:[zZ]|[+-]\d{2}(?::?\d{2})?)$',
-    ).hasMatch(value.substring(timeIndex));
+    final hasOffset = _offsetRegExp.hasMatch(value.substring(timeIndex));
 
     // Backend는 UTC Clock의 LocalDateTime을 offset 없이 직렬화한다. 기기 로컬
     // 시각으로 먼저 해석하면 DST 결손 구간이 보정되므로 처음부터 UTC로 파싱한다.

--- a/apps/mobile/lib/features/service_notice/domain/service_notice.dart
+++ b/apps/mobile/lib/features/service_notice/domain/service_notice.dart
@@ -126,6 +126,22 @@ class ServiceNotice {
     if (value is! String || value.isEmpty) {
       return null;
     }
-    return DateTime.tryParse(value);
+    final parsed = DateTime.tryParse(value);
+    if (parsed == null || parsed.isUtc) {
+      return parsed;
+    }
+
+    // Backend는 UTC Clock의 LocalDateTime을 offset 없이 직렬화한다. Dart는
+    // offset 없는 값을 기기 로컬 시각으로 해석하므로 API 계약에 맞춰 UTC로 고정한다.
+    return DateTime.utc(
+      parsed.year,
+      parsed.month,
+      parsed.day,
+      parsed.hour,
+      parsed.minute,
+      parsed.second,
+      parsed.millisecond,
+      parsed.microsecond,
+    );
   }
 }

--- a/apps/mobile/lib/features/service_notice/domain/service_notice.dart
+++ b/apps/mobile/lib/features/service_notice/domain/service_notice.dart
@@ -126,9 +126,13 @@ class ServiceNotice {
     if (value is! String || value.isEmpty) {
       return null;
     }
+    final timeIndex = value.indexOf('T');
+    if (timeIndex == -1) {
+      return DateTime.tryParse('${value}T00:00:00Z');
+    }
     final hasOffset = RegExp(
       r'(?:[zZ]|[+-]\d{2}(?::?\d{2})?)$',
-    ).hasMatch(value);
+    ).hasMatch(value.substring(timeIndex));
 
     // Backend는 UTC Clock의 LocalDateTime을 offset 없이 직렬화한다. 기기 로컬
     // 시각으로 먼저 해석하면 DST 결손 구간이 보정되므로 처음부터 UTC로 파싱한다.

--- a/apps/mobile/lib/features/service_notice/domain/service_notice.dart
+++ b/apps/mobile/lib/features/service_notice/domain/service_notice.dart
@@ -126,22 +126,12 @@ class ServiceNotice {
     if (value is! String || value.isEmpty) {
       return null;
     }
-    final parsed = DateTime.tryParse(value);
-    if (parsed == null || parsed.isUtc) {
-      return parsed;
-    }
+    final hasOffset = RegExp(
+      r'(?:[zZ]|[+-]\d{2}(?::?\d{2})?)$',
+    ).hasMatch(value);
 
-    // Backend는 UTC Clock의 LocalDateTime을 offset 없이 직렬화한다. Dart는
-    // offset 없는 값을 기기 로컬 시각으로 해석하므로 API 계약에 맞춰 UTC로 고정한다.
-    return DateTime.utc(
-      parsed.year,
-      parsed.month,
-      parsed.day,
-      parsed.hour,
-      parsed.minute,
-      parsed.second,
-      parsed.millisecond,
-      parsed.microsecond,
-    );
+    // Backend는 UTC Clock의 LocalDateTime을 offset 없이 직렬화한다. 기기 로컬
+    // 시각으로 먼저 해석하면 DST 결손 구간이 보정되므로 처음부터 UTC로 파싱한다.
+    return DateTime.tryParse(hasOffset ? value : '${value}Z');
   }
 }

--- a/apps/mobile/test/features/service_notice/notice_repository_test.dart
+++ b/apps/mobile/test/features/service_notice/notice_repository_test.dart
@@ -1,6 +1,7 @@
 import 'package:easysubway_mobile/core/network/api_client.dart';
 import 'package:easysubway_mobile/features/service_notice/data/notice_repository.dart';
 import 'package:easysubway_mobile/features/service_notice/domain/service_notice.dart';
+import 'package:easysubway_mobile/mobile_error_reporter.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class _FakeApiClient implements NoticeApiClient {
@@ -22,11 +23,27 @@ class _FakeApiClient implements NoticeApiClient {
 }
 
 class _InMemoryCache implements NoticeCacheStore {
+  _InMemoryCache({this.loadError, this.saveError});
+
   NoticeCacheEntry? entry;
+  final Object? loadError;
+  final Object? saveError;
+
   @override
-  Future<NoticeCacheEntry?> load() async => entry;
+  Future<NoticeCacheEntry?> load() async {
+    if (loadError != null) {
+      throw loadError!;
+    }
+    return entry;
+  }
+
   @override
-  Future<void> save(NoticeCacheEntry e) async => entry = e;
+  Future<void> save(NoticeCacheEntry e) async {
+    if (saveError != null) {
+      throw saveError!;
+    }
+    entry = e;
+  }
 }
 
 ApiResponse okResponse(List<Map<String, Object?>> data, {String? etag}) {
@@ -37,16 +54,29 @@ ApiResponse okResponse(List<Map<String, Object?>> data, {String? etag}) {
   );
 }
 
-Map<String, Object?> noticeJson(String id, String severity) => {
+Map<String, Object?> noticeJson(
+  String id,
+  String severity, {
+  String publishedAt = '2026-07-06T09:00:00',
+  String? expiresAt,
+}) => {
   'id': id,
   'scope': 'ALL',
   'scopeValue': null,
   'title': '제목 $id',
   'body': '본문',
   'severity': severity,
-  'publishedAt': '2026-07-06T09:00:00',
-  'expiresAt': null,
+  'publishedAt': publishedAt,
+  'expiresAt': expiresAt,
 };
+
+ServiceNotice notice(
+  String id, {
+  String publishedAt = '2026-07-06T09:00:00',
+  String? expiresAt,
+}) => ServiceNotice.fromJson(
+  noticeJson(id, 'DISRUPTION', publishedAt: publishedAt, expiresAt: expiresAt),
+)!;
 
 void main() {
   final now = DateTime(2026, 7, 6, 12, 0, 0);
@@ -110,5 +140,106 @@ void main() {
 
     expect(result.notices, isEmpty);
     expect(result.stale, isFalse);
+  });
+
+  test('캐시 읽기 실패는 보고하고 조건 없는 네트워크 응답을 사용한다', () async {
+    final errors = <Object>[];
+    final client = _FakeApiClient(
+      okResponse([noticeJson('n1', 'DISRUPTION')], etag: '"e2"'),
+    );
+    final cache = _InMemoryCache(loadError: StateError('cache read failed'));
+
+    final result = await runWithMobileErrorReporter(
+      errors.add,
+      () => repo(client, cache).activeNotices(),
+    );
+
+    expect(result.notices.single.id, 'n1');
+    expect(result.stale, isFalse);
+    expect(client.lastIfNoneMatch, isNull);
+    expect(errors, hasLength(1));
+  });
+
+  test('200 응답 캐시 저장 실패는 보고하되 fresh 응답을 유지한다', () async {
+    final errors = <Object>[];
+    final client = _FakeApiClient(
+      okResponse([noticeJson('n1', 'DISRUPTION')], etag: '"e1"'),
+    );
+    final cache = _InMemoryCache(saveError: StateError('cache save failed'));
+
+    final result = await runWithMobileErrorReporter(
+      errors.add,
+      () => repo(client, cache).activeNotices(),
+    );
+
+    expect(result.notices.single.id, 'n1');
+    expect(result.stale, isFalse);
+    expect(result.asOf, now);
+    expect(errors, hasLength(1));
+  });
+
+  test('304 응답 캐시 저장 실패도 검증된 캐시를 fresh로 유지한다', () async {
+    final errors = <Object>[];
+    final cache = _InMemoryCache(saveError: StateError('cache save failed'))
+      ..entry = NoticeCacheEntry(
+        etag: '"e1"',
+        notices: [notice('n1')],
+        fetchedAt: now.subtract(const Duration(hours: 1)),
+      );
+    final client = _FakeApiClient(
+      ApiResponse(statusCode: 304, jsonBody: null, etag: '"e1"'),
+    );
+
+    final result = await runWithMobileErrorReporter(
+      errors.add,
+      () => repo(client, cache).activeNotices(),
+    );
+
+    expect(result.notices.single.id, 'n1');
+    expect(result.stale, isFalse);
+    expect(result.asOf, now);
+    expect(errors, hasLength(1));
+  });
+
+  test('오프라인 캐시는 만료 공지와 미래 게시 공지를 노출하지 않는다', () async {
+    final fetchedAt = now.subtract(const Duration(hours: 3));
+    final cache = _InMemoryCache()
+      ..entry = NoticeCacheEntry(
+        etag: '"e1"',
+        notices: [
+          notice('active', expiresAt: '2026-07-06T12:01:00'),
+          notice('expired', expiresAt: '2026-07-06T12:00:00'),
+          notice('future', publishedAt: '2026-07-06T12:01:00'),
+        ],
+        fetchedAt: fetchedAt,
+      );
+    final client = _FakeApiClient(okResponse(const []), throwError: true);
+
+    final result = await repo(client, cache).activeNotices();
+
+    expect(result.notices.map((entry) => entry.id), ['active']);
+    expect(result.stale, isTrue);
+    expect(result.asOf, fetchedAt);
+  });
+
+  test('304 검증 캐시도 현재 시각 기준 활성 공지만 돌려준다', () async {
+    final cache = _InMemoryCache()
+      ..entry = NoticeCacheEntry(
+        etag: '"e1"',
+        notices: [
+          notice('active'),
+          notice('expired', expiresAt: '2026-07-06T11:59:59'),
+          notice('future', publishedAt: '2026-07-06T12:00:01'),
+        ],
+        fetchedAt: now.subtract(const Duration(hours: 1)),
+      );
+    final client = _FakeApiClient(
+      ApiResponse(statusCode: 304, jsonBody: null, etag: '"e1"'),
+    );
+
+    final result = await repo(client, cache).activeNotices();
+
+    expect(result.notices.map((entry) => entry.id), ['active']);
+    expect(cache.entry!.notices.map((entry) => entry.id), ['active']);
   });
 }

--- a/apps/mobile/test/features/service_notice/notice_repository_test.dart
+++ b/apps/mobile/test/features/service_notice/notice_repository_test.dart
@@ -222,7 +222,7 @@ void main() {
     expect(result.asOf, fetchedAt);
   });
 
-  test('304 검증 캐시도 현재 시각 기준 활성 공지만 돌려준다', () async {
+  test('304 검증 캐시는 원본을 보존하고 현재 활성 공지만 돌려준다', () async {
     final cache = _InMemoryCache()
       ..entry = NoticeCacheEntry(
         etag: '"e1"',
@@ -240,10 +240,14 @@ void main() {
     final result = await repo(client, cache).activeNotices();
 
     expect(result.notices.map((entry) => entry.id), ['active']);
-    expect(cache.entry!.notices.map((entry) => entry.id), ['active']);
+    expect(cache.entry!.notices.map((entry) => entry.id), [
+      'active',
+      'expired',
+      'future',
+    ]);
   });
 
-  test('200 응답도 현재 시각 기준 활성 공지만 결과와 캐시에 저장한다', () async {
+  test('200 응답은 원본을 캐시하고 현재 활성 공지만 결과로 돌려준다', () async {
     final client = _FakeApiClient(
       okResponse([
         noticeJson('active', 'DISRUPTION', expiresAt: '2026-07-06T12:01:00'),
@@ -256,6 +260,10 @@ void main() {
     final result = await repo(client, cache).activeNotices();
 
     expect(result.notices.map((entry) => entry.id), ['active']);
-    expect(cache.entry!.notices.map((entry) => entry.id), ['active']);
+    expect(cache.entry!.notices.map((entry) => entry.id), [
+      'active',
+      'expired',
+      'future',
+    ]);
   });
 }

--- a/apps/mobile/test/features/service_notice/notice_repository_test.dart
+++ b/apps/mobile/test/features/service_notice/notice_repository_test.dart
@@ -79,7 +79,7 @@ ServiceNotice notice(
 )!;
 
 void main() {
-  final now = DateTime(2026, 7, 6, 12, 0, 0);
+  final now = DateTime.utc(2026, 7, 6, 12, 0, 0);
 
   ApiNoticeRepository repo(_FakeApiClient client, _InMemoryCache cache) =>
       ApiNoticeRepository(apiClient: client, cacheStore: cache, now: () => now);
@@ -236,6 +236,22 @@ void main() {
     final client = _FakeApiClient(
       ApiResponse(statusCode: 304, jsonBody: null, etag: '"e1"'),
     );
+
+    final result = await repo(client, cache).activeNotices();
+
+    expect(result.notices.map((entry) => entry.id), ['active']);
+    expect(cache.entry!.notices.map((entry) => entry.id), ['active']);
+  });
+
+  test('200 응답도 현재 시각 기준 활성 공지만 결과와 캐시에 저장한다', () async {
+    final client = _FakeApiClient(
+      okResponse([
+        noticeJson('active', 'DISRUPTION', expiresAt: '2026-07-06T12:01:00'),
+        noticeJson('expired', 'DISRUPTION', expiresAt: '2026-07-06T12:00:00'),
+        noticeJson('future', 'DISRUPTION', publishedAt: '2026-07-06T12:01:00'),
+      ]),
+    );
+    final cache = _InMemoryCache();
 
     final result = await repo(client, cache).activeNotices();
 

--- a/apps/mobile/test/features/service_notice/notice_repository_test.dart
+++ b/apps/mobile/test/features/service_notice/notice_repository_test.dart
@@ -162,10 +162,16 @@ void main() {
 
   test('200 응답 캐시 저장 실패는 보고하되 fresh 응답을 유지한다', () async {
     final errors = <Object>[];
+    final originalFetchedAt = now.subtract(const Duration(hours: 2));
     final client = _FakeApiClient(
       okResponse([noticeJson('n1', 'DISRUPTION')], etag: '"e1"'),
     );
-    final cache = _InMemoryCache(saveError: StateError('cache save failed'));
+    final cache = _InMemoryCache(saveError: StateError('cache save failed'))
+      ..entry = NoticeCacheEntry(
+        etag: '"old"',
+        notices: [notice('old')],
+        fetchedAt: originalFetchedAt,
+      );
 
     final result = await runWithMobileErrorReporter(
       errors.add,
@@ -176,15 +182,19 @@ void main() {
     expect(result.stale, isFalse);
     expect(result.asOf, now);
     expect(errors, hasLength(1));
+    expect(cache.entry!.etag, '"old"');
+    expect(cache.entry!.notices.single.id, 'old');
+    expect(cache.entry!.fetchedAt, originalFetchedAt);
   });
 
   test('304 응답 캐시 저장 실패도 검증된 캐시를 fresh로 유지한다', () async {
     final errors = <Object>[];
+    final originalFetchedAt = now.subtract(const Duration(hours: 1));
     final cache = _InMemoryCache(saveError: StateError('cache save failed'))
       ..entry = NoticeCacheEntry(
         etag: '"e1"',
         notices: [notice('n1')],
-        fetchedAt: now.subtract(const Duration(hours: 1)),
+        fetchedAt: originalFetchedAt,
       );
     final client = _FakeApiClient(
       ApiResponse(statusCode: 304, jsonBody: null, etag: '"e1"'),
@@ -199,6 +209,9 @@ void main() {
     expect(result.stale, isFalse);
     expect(result.asOf, now);
     expect(errors, hasLength(1));
+    expect(cache.entry!.etag, '"e1"');
+    expect(cache.entry!.notices.single.id, 'n1');
+    expect(cache.entry!.fetchedAt, originalFetchedAt);
   });
 
   test('오프라인 캐시는 만료 공지와 미래 게시 공지를 노출하지 않는다', () async {

--- a/apps/mobile/test/features/service_notice/service_notice_test.dart
+++ b/apps/mobile/test/features/service_notice/service_notice_test.dart
@@ -28,8 +28,10 @@ void main() {
       expect(notice.scopeValue, '2');
       expect(notice.severity, NoticeSeverity.disruption);
       expect(notice.isDisruption, isTrue);
-      expect(notice.publishedAt, DateTime.parse('2026-07-06T09:00:00'));
-      expect(notice.expiresAt, DateTime.parse('2026-07-06T18:00:00'));
+      expect(notice.publishedAt, DateTime.utc(2026, 7, 6, 9));
+      expect(notice.expiresAt, DateTime.utc(2026, 7, 6, 18));
+      expect(notice.publishedAt.isUtc, isTrue);
+      expect(notice.expiresAt!.isUtc, isTrue);
     });
 
     test('INFO 심각도·ALL 대상·만료 없음도 파싱한다', () {

--- a/apps/mobile/test/features/service_notice/service_notice_test.dart
+++ b/apps/mobile/test/features/service_notice/service_notice_test.dart
@@ -51,6 +51,7 @@ void main() {
       final notice = ServiceNotice.fromJson(payload)!;
 
       expect(notice.publishedAt, DateTime.utc(2026, 3, 8, 2, 30));
+      expect(notice.publishedAt.isUtc, isTrue);
     });
 
     test('명시적 offset 시각은 같은 UTC instant로 파싱한다', () {
@@ -59,6 +60,7 @@ void main() {
       final notice = ServiceNotice.fromJson(payload)!;
 
       expect(notice.publishedAt, DateTime.utc(2026, 7, 6));
+      expect(notice.publishedAt.isUtc, isTrue);
     });
 
     test('date-only 시각도 숫자 offset으로 오인하지 않고 UTC로 파싱한다', () {

--- a/apps/mobile/test/features/service_notice/service_notice_test.dart
+++ b/apps/mobile/test/features/service_notice/service_notice_test.dart
@@ -61,6 +61,15 @@ void main() {
       expect(notice.publishedAt, DateTime.utc(2026, 7, 6));
     });
 
+    test('date-only 시각도 숫자 offset으로 오인하지 않고 UTC로 파싱한다', () {
+      final payload = json()..['publishedAt'] = '2026-07-06';
+
+      final notice = ServiceNotice.fromJson(payload)!;
+
+      expect(notice.publishedAt, DateTime.utc(2026, 7, 6));
+      expect(notice.publishedAt.isUtc, isTrue);
+    });
+
     test('알 수 없는 severity/scope는 null을 돌려준다(무음 실패 대신 제외)', () {
       expect(ServiceNotice.fromJson(json(severity: 'WARN')), isNull);
       expect(ServiceNotice.fromJson(json(scope: 'CITY')), isNull);

--- a/apps/mobile/test/features/service_notice/service_notice_test.dart
+++ b/apps/mobile/test/features/service_notice/service_notice_test.dart
@@ -45,6 +45,22 @@ void main() {
       expect(notice.isDisruption, isFalse);
     });
 
+    test('offset 없는 UTC 시각은 DST 결손 구간에서도 원문 시각을 보존한다', () {
+      final payload = json()..['publishedAt'] = '2026-03-08T02:30:00';
+
+      final notice = ServiceNotice.fromJson(payload)!;
+
+      expect(notice.publishedAt, DateTime.utc(2026, 3, 8, 2, 30));
+    });
+
+    test('명시적 offset 시각은 같은 UTC instant로 파싱한다', () {
+      final payload = json()..['publishedAt'] = '2026-07-06T09:00:00+09:00';
+
+      final notice = ServiceNotice.fromJson(payload)!;
+
+      expect(notice.publishedAt, DateTime.utc(2026, 7, 6));
+    });
+
     test('알 수 없는 severity/scope는 null을 돌려준다(무음 실패 대신 제외)', () {
       expect(ServiceNotice.fromJson(json(severity: 'WARN')), isNull);
       expect(ServiceNotice.fromJson(json(scope: 'CITY')), isNull);


### PR DESCRIPTION
## 관련 이슈

Closes #1767

## 작업 배경

- 닫힌 #1767 구현을 재감사한 결과, 공지 캐시 읽기·쓰기 예외가 정상 온라인 응답을 막고 오프라인 캐시의 만료·미래 공지가 다시 노출될 수 있었습니다.
- 기존 관리자 발행·공개 API·배너 UI는 유지하면서 모바일 repository 경계만 보완합니다.

## 작업 내용

- 캐시 읽기 실패를 원본 예외·stack과 함께 보고한 뒤 ETag 없는 온라인 조회를 계속합니다.
- 200·304 응답 뒤 캐시 저장 실패를 보고하되 검증된 fresh 응답은 사용자에게 유지합니다.
- 200·304·오프라인 stale 결과 모두 현재 시각 기준으로 미래 게시 공지와 만료 공지를 fail-closed 제외합니다.
- 단말 시계 오차가 원본 ETag 캐시를 영구 손실시키지 않도록 서버 원본을 저장하고 반환 시점에만 활성 공지를 거릅니다.
- offset 없는 backend `LocalDateTime`은 처음부터 UTC로 파싱해 KST·DST 보정 오차를 차단합니다.
- 캐시 I/O·시각 경계·UTC 파싱 회귀 테스트 11건을 추가하고, 반복 사용 정규식은 class-level에서 재사용합니다.

## 검증

- 실행한 명령과 결과:
  - `env TZ=UTC flutter test --no-pub`: 935/935 passed
  - `flutter test --no-pub test/features/service_notice`: 42/42 passed
  - `flutter test --no-pub test/features/service_notice/notice_repository_test.dart test/features/service_notice/service_notice_test.dart`: 19/19 passed
  - `env TZ=America/New_York flutter test --no-pub test/features/service_notice/service_notice_test.dart`: 9/9 passed
  - `flutter analyze --no-pub`: No issues found
  - `node --test tools/ci/repository-contract.test.mjs`: 173/173 passed
  - `git diff --check`: 통과
  - 독립 Codex diff 리뷰: actionable correctness defect 없음
  - CodeRabbit: 정규식 재생성 지적 1건을 `076d4702`로 수정, 원 스레드 해결 및 재확인 완료

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 캐시 읽기 실패 강등 | Flutter unit | load 예외 후 조건 없는 200 응답 검증 | `notice_repository_test.dart` | fresh 공지 유지, 오류 1회 보고 |
| 캐시 저장 실패 격리 | Flutter unit | 200·304 save 예외 주입 및 기존 캐시 불변식 검증 | `notice_repository_test.dart` | fresh 공지와 현재 asOf 유지, 기존 캐시 보존, 오류 보고 |
| 만료·미래 공지 미노출 | Flutter unit | 200·304·오프라인 stale 캐시에 경계 시각 fixture 주입 | `notice_repository_test.dart` | 사용자 결과만 필터링하고 ETag 원본 캐시 보존 |
| UTC·DST 파싱 | Flutter unit | KST·`America/New_York`에서 offset 없음·명시 offset·date-only 검증 | `service_notice_test.dart` | UTC instant와 `isUtc` 보존 |
| 주변 화면 회귀 | Flutter widget/unit | service_notice 전체 및 앱 전체 테스트 | 42/42, 935/935 | 모두 통과 |
| 수동 UI QA | 해당 없음 | 렌더링·문구·navigation 변경 없음 | deterministic repository 테스트로 대체 | 실기기 재촬영 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 1.0.2 (변경 없음)
- mobile versionCode: 10002 (변경 없음)
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `ApiNoticeRepository.activeNotices()`의 cache load/save 예외 격리와 `_activeAt`의 게시·만료 경계입니다.
- Ponytail 관점에서 새 provider·상태·fallback은 추가하지 않았고, 중복 save 예외 처리만 한 helper로 모았습니다.

## 리스크

- 단말 시계가 실제 시각보다 크게 어긋나면 공지 노출 시점도 영향을 받습니다. 미래·만료 데이터는 보수적으로 숨기되 원본 ETag 캐시는 보존해 시계 복구 후 다시 노출할 수 있습니다.
- rollback은 이 PR revert이며 DB migration·서버 배포·데이터 변환은 없습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다. (CodeRabbit Review 객체가 있어 fallback 불필요)
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)
