### PR TITLE
[Fix] 공식 요금 계약과 미측정 거리 강등 보강

### DIFF
--- a/.github/workflows/fare-api-probe.yml
+++ b/.github/workflows/fare-api-probe.yml
@@ -1,12 +1,11 @@
 name: Seoul Fare API Probe
 
 on:
-  push:
-    branches:
-      - feat/1769-official-fare-api
-    paths:
-      - .github/workflows/fare-api-probe.yml
-      - tools/datapack/probe-seoul-fare-api.mjs
+  workflow_dispatch:
+
+concurrency:
+  group: seoul-fare-api-probe-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   probe:

--- a/.github/workflows/fare-api-probe.yml
+++ b/.github/workflows/fare-api-probe.yml
@@ -1,0 +1,43 @@
+name: Seoul Fare API Probe
+
+on:
+  push:
+    branches:
+      - feat/1769-official-fare-api
+    paths:
+      - .github/workflows/fare-api-probe.yml
+      - tools/datapack/probe-seoul-fare-api.mjs
+
+jobs:
+  probe:
+    name: Seoul Fare API Probe
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Seoul Fare API Probe / Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Seoul Fare API Probe / Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24"
+
+      - name: Seoul Fare API Probe / Call official endpoint
+        env:
+          DATA_GO_KR_SERVICE_KEY: ${{ secrets.DATA_GO_KR_SERVICE_KEY }}
+          FARE_API_PROBE_OUTPUT: ${{ runner.temp }}/seoul-fare-api-probe.json
+        run: |
+          set -euo pipefail
+          test -n "${DATA_GO_KR_SERVICE_KEY}"
+          node tools/datapack/probe-seoul-fare-api.mjs
+
+      - name: Seoul Fare API Probe / Upload sanitized evidence
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: seoul-fare-api-probe
+          path: ${{ runner.temp }}/seoul-fare-api-probe.json
+          if-no-files-found: error
+          retention-days: 14

--- a/apps/mobile/lib/core/database/catalog/catalog_database.dart
+++ b/apps/mobile/lib/core/database/catalog/catalog_database.dart
@@ -290,7 +290,7 @@ class CatalogDatabase extends _$CatalogDatabase {
             zoneId: 'capital-integrated',
             riderType: 'YOUTH',
             cardFare: const Value(900),
-            cashFare: const Value(1000),
+            cashFare: const Value(1650),
             descriptionKo: const Value('청소년 기준 요금'),
           ),
           FareDiscountsCompanion.insert(
@@ -496,7 +496,8 @@ class CatalogDatabase extends _$CatalogDatabase {
   }
 
   Future<void> _backfillBaselineFareRules() async {
-    if (!await _shouldBackfillBaselineFareRules()) {
+    if (!await _isBaselineFixtureCatalog() ||
+        !await _shouldBackfillBaselineFareRules()) {
       return;
     }
     await transaction(() async {
@@ -528,7 +529,7 @@ class CatalogDatabase extends _$CatalogDatabase {
             zoneId: 'capital-integrated',
             riderType: 'YOUTH',
             cardFare: const Value(900),
-            cashFare: const Value(1000),
+            cashFare: const Value(1650),
             descriptionKo: const Value('청소년 기준 요금'),
           ),
           FareDiscountsCompanion.insert(
@@ -635,11 +636,15 @@ class CatalogDatabase extends _$CatalogDatabase {
          FROM catalog_metadata
          WHERE key = 'activePack') AS active_pack,
         (SELECT COUNT(*) FROM station_lines) AS station_line_count,
-        (SELECT COUNT(*) FROM fare_rules) AS fare_rule_count
+        (SELECT COUNT(*) FROM fare_rules) AS fare_rule_count,
+        (SELECT cash_fare
+         FROM fare_discounts
+         WHERE id = 'capital-integrated-youth') AS youth_cash_fare
     ''').getSingle();
     return row.readNullable<String>('active_pack') == 'capital' &&
         row.read<int>('station_line_count') > 0 &&
-        row.read<int>('fare_rule_count') == 0;
+        (row.read<int>('fare_rule_count') == 0 ||
+            row.readNullable<int>('youth_cash_fare') == 1000);
   }
 
   Future<void> _seedBaselineRouteMapPositions() async {

--- a/apps/mobile/lib/features/fare/fare_calculator.dart
+++ b/apps/mobile/lib/features/fare/fare_calculator.dart
@@ -7,7 +7,7 @@ class FareCalculator {
     required int? distanceMeters,
     required FareRule? rule,
   }) {
-    if (distanceMeters == null || distanceMeters < 0 || rule == null) {
+    if (distanceMeters == null || distanceMeters <= 0 || rule == null) {
       return const FareEstimate.unavailable();
     }
     final extraDistance = math.max(0, distanceMeters - rule.baseDistanceMeters);

--- a/apps/mobile/test/core/database/mobile_local_database_test.dart
+++ b/apps/mobile/test/core/database/mobile_local_database_test.dart
@@ -199,24 +199,14 @@ void main() {
           WHERE station_id = 'station-sangnoksu'
             AND line_id = 'seoul-4'
           ''').getSingle();
-    final fareRule = await database.customSelect('''
-          SELECT zone_id, base_card_fare, base_cash_fare,
-                 base_distance_meters, additional_steps_json
-          FROM fare_rules
-          WHERE id = 'capital-integrated-standard'
-          ''').getSingle();
-    final fareDiscounts = await database.customSelect('''
-          SELECT rider_type
-          FROM fare_discounts
-          WHERE zone_id = 'capital-integrated'
-          ORDER BY rider_type
-          ''').get();
-    final stationFareZoneCoverage = await database.customSelect('''
+    final fareTableCounts = await database.customSelect('''
           SELECT
-            (SELECT COUNT(*) FROM station_lines) AS station_line_count,
+            (SELECT COUNT(*) FROM fare_zones) AS fare_zone_count,
+            (SELECT COUNT(*) FROM fare_rules) AS fare_rule_count,
+            (SELECT COUNT(*) FROM fare_discounts) AS fare_discount_count,
             (SELECT COUNT(*)
              FROM station_fare_zones
-             WHERE zone_id = 'capital-integrated') AS fare_zone_count
+             WHERE zone_id = 'capital-integrated') AS station_fare_zone_count
           ''').getSingle();
 
     expect(metadata.read<String>('value'), '1');
@@ -358,23 +348,10 @@ void main() {
     expect(displayedSourceValues, isNot(contains('fixture')));
     expect(displayedSourceValues, isNot(contains('easysubway.local')));
     expect(displayedSourceValues, isNot(contains('review-required')));
-    expect(fareRule.read<String>('zone_id'), 'capital-integrated');
-    expect(fareRule.read<int>('base_card_fare'), 1550);
-    expect(fareRule.read<int>('base_cash_fare'), 1650);
-    expect(fareRule.read<int>('base_distance_meters'), 10000);
-    expect(
-      fareRule.read<String>('additional_steps_json'),
-      '[{"distanceMeters":5000,"cardFare":100,"cashFare":100}]',
-    );
-    expect(fareDiscounts.map((row) => row.read<String>('rider_type')), [
-      'CHILD',
-      'CONCESSION',
-      'YOUTH',
-    ]);
-    expect(
-      stationFareZoneCoverage.read<int>('fare_zone_count'),
-      stationFareZoneCoverage.read<int>('station_line_count'),
-    );
+    expect(fareTableCounts.read<int>('fare_zone_count'), 0);
+    expect(fareTableCounts.read<int>('fare_rule_count'), 0);
+    expect(fareTableCounts.read<int>('fare_discount_count'), 0);
+    expect(fareTableCounts.read<int>('station_fare_zone_count'), 0);
     expect(
       File('${directory.path}/datapacks/core.sqlite').existsSync(),
       isTrue,
@@ -425,6 +402,27 @@ void main() {
     expect(displayedSourceValues, isNot(contains('fixture')));
     expect(displayedSourceValues, isNot(contains('easysubway.local')));
     expect(displayedSourceValues, isNot(contains('review-required')));
+  });
+
+  test('기존 baseline의 청소년 현금요금 1000원을 공식 1650원으로 보정한다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+
+    await database.seedBaselineIfEmpty();
+    await database.customStatement('''
+      UPDATE fare_discounts
+      SET cash_fare = 1000
+      WHERE id = 'capital-integrated-youth'
+    ''');
+
+    await database.seedBaselineIfEmpty();
+
+    final youthFare = await database.customSelect('''
+      SELECT cash_fare
+      FROM fare_discounts
+      WHERE id = 'capital-integrated-youth'
+    ''').getSingle();
+    expect(youthFare.read<int>('cash_fare'), 1650);
   });
 
   test('내장 데이터팩은 로컬 역 검색 repository에서 역 번호 검색을 제공한다', () async {
@@ -636,7 +634,7 @@ void main() {
   });
 
   test(
-    'catalog opener는 baseline보다 큰 current pack에 access edge를 주입하지 않는다',
+    'catalog opener는 baseline보다 큰 current pack에 baseline access edge와 fare를 주입하지 않는다',
     () async {
       final directory = await Directory.systemTemp.createTemp(
         'easysubway-catalog-current-access-backfill-skip-',
@@ -660,6 +658,7 @@ void main() {
               normalizedName: '추가역',
             ),
           );
+      await updatedDatabase.customStatement('DELETE FROM fare_rules');
       await updatedDatabase.close();
       await File('${catalogDirectory.path}/current.json').writeAsString(
         jsonEncode({
@@ -675,6 +674,7 @@ void main() {
         assetBundle: rootBundle,
       ).open();
       addTearDown(database.close);
+      await database.seedBaselineIfEmpty();
       final accessEdgeCount = await database.customSelect('''
       SELECT COUNT(*) AS count
       FROM network_edges
@@ -685,6 +685,10 @@ void main() {
         'exit-sadang-seoul-4'
       )
     ''').getSingle();
+      final fareRuleCount = await database.customSelect('''
+        SELECT COUNT(*) AS count
+        FROM fare_rules
+      ''').getSingle();
       final route = await LocalRouteRepository(catalogDatabase: database)
           .searchRoute(
             const RouteSearchRequest(
@@ -695,6 +699,7 @@ void main() {
           );
 
       expect(accessEdgeCount.read<int>('count'), 0);
+      expect(fareRuleCount.read<int>('count'), 0);
       expect(route.status, 'UNKNOWN');
     },
   );

--- a/apps/mobile/test/features/fare/fare_calculator_test.dart
+++ b/apps/mobile/test/features/fare/fare_calculator_test.dart
@@ -84,5 +84,16 @@ void main() {
       expect(missingDistance.cardFare, isNull);
       expect(missingRule.cardFare, isNull);
     });
+
+    test('이동 거리 0m는 결측값으로 보고 요금을 만들지 않는다', () {
+      final fare = const FareCalculator().calculate(
+        distanceMeters: 0,
+        rule: rule,
+      );
+
+      expect(fare.status, FareStatus.unavailable);
+      expect(fare.cardFare, isNull);
+      expect(fare.cashFare, isNull);
+    });
   });
 }

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -266,6 +266,20 @@ test("데이터팩 생성기는 fixture로 원격 manifest와 gzip SQLite pack�
         additional_steps_json: '[{"distanceMeters":5000,"cardFare":100,"cashFare":100}]',
       },
     );
+    assert.deepEqual(
+      {
+        ...database
+          .prepare(
+            `
+            SELECT card_fare, cash_fare
+            FROM fare_discounts
+            WHERE id = ?
+          `,
+          )
+          .get("capital-integrated-youth"),
+      },
+      { card_fare: 900, cash_fare: 1650 },
+    );
     assert.equal(
       database
         .prepare("SELECT COUNT(*) AS count FROM station_fare_zones WHERE zone_id = ?")

--- a/tools/datapack/fixtures/catalog-fixture.json
+++ b/tools/datapack/fixtures/catalog-fixture.json
@@ -339,7 +339,7 @@
           "zoneId": "capital-integrated",
           "riderType": "YOUTH",
           "cardFare": 900,
-          "cashFare": 1000,
+          "cashFare": 1650,
           "descriptionKo": "청소년 기준 요금"
         },
         {

--- a/tools/datapack/probe-seoul-fare-api.mjs
+++ b/tools/datapack/probe-seoul-fare-api.mjs
@@ -43,14 +43,14 @@ function decodedServiceKey(value) {
 
 export function validateFareSample(sample) {
   if (!sample || typeof sample !== "object" || Array.isArray(sample)) {
-    throw new Error("fare API sample must be an object");
+    throw new TypeError("fare API sample must be an object");
   }
   for (const [field, expected] of Object.entries(EXPECTED_SAMPLE)) {
     if (!(field in sample)) {
       throw new Error(`fare API field missing: ${field}`);
     }
     if (typeof sample[field] !== typeof expected) {
-      throw new Error(`fare API field type invalid: ${field}`);
+      throw new TypeError(`fare API field type invalid: ${field}`);
     }
     if (sample[field] !== expected) {
       throw new Error(`fare API field value changed: ${field}`);
@@ -90,7 +90,12 @@ async function main() {
   const resultCode = String(envelope?.header?.resultCode ?? "");
   const body = envelope?.body;
   const rawItems = body?.items?.item ?? body?.items ?? body?.item;
-  const items = Array.isArray(rawItems) ? rawItems : rawItems ? [rawItems] : [];
+  let items = [];
+  if (Array.isArray(rawItems)) {
+    items = rawItems;
+  } else if (rawItems) {
+    items = [rawItems];
+  }
   if (resultCode !== "00" || items.length === 0 || !items[0] || typeof items[0] !== "object") {
     throw new Error(`fare API response rejected: resultCode=${resultCode || "missing"}`);
   }
@@ -102,7 +107,7 @@ async function main() {
     request: { dptreStnCd: "0150", dptreStnNm: "서울역", arvlStnCd: "0151", arvlStnNm: "시청" },
     resultCode,
     totalCount: Number(body?.totalCount ?? items.length),
-    fieldNames: Object.keys(sample).sort(),
+    fieldNames: Object.keys(sample).sort((left, right) => left.localeCompare(right)),
     sample: Object.fromEntries(
       Object.entries(sample).filter(
         ([key, value]) => SAFE_REPORT_FIELDS.has(key) && ["string", "number", "boolean"].includes(typeof value),

--- a/tools/datapack/probe-seoul-fare-api.mjs
+++ b/tools/datapack/probe-seoul-fare-api.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+import { writeFile } from "node:fs/promises";
+
+const ENDPOINT = "https://apis.data.go.kr/B553766/fare2/getRltmFare2";
+const SAFE_REPORT_FIELDS = new Set([
+  "dptreStnCd",
+  "dptreStnNm",
+  "arvlStnCd",
+  "arvlStnNm",
+  "gnrlCardFare",
+  "gnrlCashFare",
+  "yungCardFare",
+  "yungCashFare",
+  "childCardFare",
+  "childCashFare",
+  "distFare",
+  "distanceFare",
+]);
+
+function decodedServiceKey(value) {
+  if (!/%[0-9a-f]{2}/i.test(value)) {
+    return value;
+  }
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+async function main() {
+  const serviceKey = process.env.DATA_GO_KR_SERVICE_KEY;
+  const outputPath = process.env.FARE_API_PROBE_OUTPUT;
+  if (!serviceKey || !outputPath) {
+    throw new Error("fare API probe environment is incomplete");
+  }
+
+  const url = new URL(ENDPOINT);
+  url.searchParams.set("serviceKey", decodedServiceKey(serviceKey));
+  url.searchParams.set("pageNo", "1");
+  url.searchParams.set("numOfRows", "10");
+  url.searchParams.set("dataType", "JSON");
+  url.searchParams.set("dptreStnCd", "0150");
+  url.searchParams.set("dptreStnNm", "서울역");
+  url.searchParams.set("arvlStnCd", "0151");
+  url.searchParams.set("arvlStnNm", "시청");
+
+  const response = await fetch(url, { signal: AbortSignal.timeout(30_000) });
+  if (!response.ok) {
+    throw new Error(`fare API HTTP ${response.status}`);
+  }
+  let payload;
+  try {
+    payload = await response.json();
+  } catch {
+    throw new Error("fare API returned invalid JSON");
+  }
+
+  const envelope = payload?.response ?? payload;
+  const resultCode = String(envelope?.header?.resultCode ?? "");
+  const body = envelope?.body;
+  const rawItems = body?.items?.item ?? body?.items ?? body?.item;
+  const items = Array.isArray(rawItems) ? rawItems : rawItems ? [rawItems] : [];
+  if (resultCode !== "00" || items.length === 0 || !items[0] || typeof items[0] !== "object") {
+    throw new Error(`fare API response rejected: resultCode=${resultCode || "missing"}`);
+  }
+
+  const sample = items[0];
+  const report = {
+    endpoint: ENDPOINT,
+    request: { dptreStnCd: "0150", dptreStnNm: "서울역", arvlStnCd: "0151", arvlStnNm: "시청" },
+    resultCode,
+    totalCount: Number(body?.totalCount ?? items.length),
+    fieldNames: Object.keys(sample).sort(),
+    sample: Object.fromEntries(
+      Object.entries(sample).filter(
+        ([key, value]) => SAFE_REPORT_FIELDS.has(key) && ["string", "number", "boolean"].includes(typeof value),
+      ),
+    ),
+  };
+  await writeFile(outputPath, `${JSON.stringify(report, null, 2)}\n`, { mode: 0o600 });
+  process.stdout.write(`${JSON.stringify(report)}\n`);
+}
+
+try {
+  await main();
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : "fare API probe failed"}\n`);
+  process.exitCode = 1;
+}

--- a/tools/datapack/probe-seoul-fare-api.mjs
+++ b/tools/datapack/probe-seoul-fare-api.mjs
@@ -1,7 +1,20 @@
 #!/usr/bin/env node
 import { writeFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
 
 const ENDPOINT = "https://apis.data.go.kr/B553766/fare2/getRltmFare2";
+const EXPECTED_SAMPLE = {
+  dptreStnCd: "0150",
+  dptreStnNm: "서울역",
+  arvlStnCd: "0151",
+  arvlStnNm: "시청",
+  gnrlCardFare: 1550,
+  gnrlCashFare: 1650,
+  yungCardFare: 900,
+  yungCashFare: 1650,
+  childCardFare: 550,
+  childCashFare: 550,
+};
 const SAFE_REPORT_FIELDS = new Set([
   "dptreStnCd",
   "dptreStnNm",
@@ -25,6 +38,23 @@ function decodedServiceKey(value) {
     return decodeURIComponent(value);
   } catch {
     return value;
+  }
+}
+
+export function validateFareSample(sample) {
+  if (!sample || typeof sample !== "object" || Array.isArray(sample)) {
+    throw new Error("fare API sample must be an object");
+  }
+  for (const [field, expected] of Object.entries(EXPECTED_SAMPLE)) {
+    if (!(field in sample)) {
+      throw new Error(`fare API field missing: ${field}`);
+    }
+    if (typeof sample[field] !== typeof expected) {
+      throw new Error(`fare API field type invalid: ${field}`);
+    }
+    if (sample[field] !== expected) {
+      throw new Error(`fare API field value changed: ${field}`);
+    }
   }
 }
 
@@ -66,6 +96,7 @@ async function main() {
   }
 
   const sample = items[0];
+  validateFareSample(sample);
   const report = {
     endpoint: ENDPOINT,
     request: { dptreStnCd: "0150", dptreStnNm: "서울역", arvlStnCd: "0151", arvlStnNm: "시청" },
@@ -82,9 +113,11 @@ async function main() {
   process.stdout.write(`${JSON.stringify(report)}\n`);
 }
 
-try {
-  await main();
-} catch (error) {
-  process.stderr.write(`${error instanceof Error ? error.message : "fare API probe failed"}\n`);
-  process.exitCode = 1;
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    await main();
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : "fare API probe failed"}\n`);
+    process.exitCode = 1;
+  }
 }

--- a/tools/datapack/probe-seoul-fare-api.test.mjs
+++ b/tools/datapack/probe-seoul-fare-api.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { validateFareSample } from "./probe-seoul-fare-api.mjs";
+
+const officialSample = {
+  dptreStnCd: "0150",
+  dptreStnNm: "서울역",
+  arvlStnCd: "0151",
+  arvlStnNm: "시청",
+  gnrlCardFare: 1550,
+  gnrlCashFare: 1650,
+  yungCardFare: 900,
+  yungCashFare: 1650,
+  childCardFare: 550,
+  childCashFare: 550,
+};
+
+test("서울역-시청 공식 요금 응답 계약을 검증한다", () => {
+  assert.doesNotThrow(() => validateFareSample(officialSample));
+  assert.throws(
+    () => validateFareSample({ ...officialSample, yungCashFare: "1650" }),
+    /yungCashFare/,
+  );
+  const { childCashFare: _, ...missingFare } = officialSample;
+  assert.throws(() => validateFareSample(missingFare), /childCashFare/);
+});


### PR DESCRIPTION
## 관련 이슈

Refs #1769

## 작업 배경

- 기존 fare rule 기반 구현은 공식 OD 운임 API와 production 데이터팩의 실제 적재 상태를 검증하지 않은 채 baseline 요금을 주입할 수 있었다.
- production route의 미측정 거리 0m가 기본요금으로 계산되고, 청소년 현금요금이 공식 응답 1,650원 대신 1,000원으로 저장돼 있었다.
- 임시 branch push probe workflow를 PR 전에 durable workflow로 정리해야 했다.

## 작업 내용

- `distanceMeters <= 0`을 결측으로 강등해 미측정 route에서 요금을 만들지 않는다.
- 청소년 카드/현금 계약을 900원/1,650원으로 fixture와 local baseline seed·backfill에 반영했다.
- baseline fixture로 확인된 DB만 fare backfill하고, 운영형 bundled/current pack에는 추정 fare zone/rule을 주입하지 않는다.
- 서울역(0150)→시청(0151) 공식 응답의 OD와 일반·청소년·어린이 카드/현금 값을 strict contract로 검증한다.
- probe workflow를 branch push 전용에서 수동 `workflow_dispatch` + concurrency 제어로 전환했다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/features/fare/fare_calculator_test.dart test/core/database/mobile_local_database_test.dart` → 32 tests 통과
  - `flutter analyze lib/core/database/catalog/catalog_database.dart lib/features/fare/fare_calculator.dart test/core/database/mobile_local_database_test.dart test/features/fare/fare_calculator_test.dart` → 0 issues
  - `node --test tools/datapack/*.test.mjs` → 339 tests 통과
  - `node --test tools/ci/repository-contract.test.mjs` → 173 tests 통과
  - `node --check tools/datapack/probe-seoul-fare-api.mjs` → 통과
  - Ruby YAML parse 및 `git diff --check` → 통과
  - 로컬 `actionlint`는 설치되어 있지 않아 미실행. GitHub Actions/required CI에서 workflow를 확인한다.

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 공식 OD 운임 | GitHub Actions / data.go.kr | 서울역 0150 → 시청 0151 실호출 | https://github.com/AquilaXk/easysubway/actions/runs/29085674167 | 일반 1,550/1,650 · 청소년 900/1,650 · 어린이 550/550 확인 |
| 미측정 거리 강등 | Flutter | RED→GREEN focused test | `fare_calculator_test.dart` 로컬 로그 | 통과 |
| 기존 설치 요금 보정·운영 pack 비주입 | Flutter/SQLite | baseline 1,000원 보정 및 larger current pack 0 fare 계약 | `mobile_local_database_test.dart` 로컬 로그 | 통과 |
| fixture·API 응답 계약 | Node.js | 모든 datapack tests | 339 tests 로컬 로그 | 통과 |
| UI/수동 QA | Mobile | 이번 PR은 fare UI를 연결하지 않고 미확인 구간을 숨기는 fail-closed 보강 | #1769 유지 | 증거 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음(테스트 fixture 계약만 수정)
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `CatalogDatabase._backfillBaselineFareRules`의 baseline fixture guard와 기존 1,000원 보정 조건
  - `validateFareSample`의 공식 OD strict contract
  - bundled/current pack에 fare를 주입하지 않는 회귀 테스트

## 리스크

- 공식 실호출은 서울역→시청 1개 OD만 검증했다. production pilot 상록수→사당과 겹치지 않으므로 `fare_quotes` 적재와 UI 연결을 하지 않았고 #1769는 계속 OPEN으로 둔다.
- 공식 요금이 변경되면 manual probe가 fail-closed로 실패하므로, 새 공식 증거와 함께 fixture/계약을 갱신해야 한다.
- 일반화된 거리 요금 공식을 새로 추정하지 않는다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 서울 요금 API를 수동으로 점검하고 검증 결과를 파일로 저장할 수 있습니다.
  - 점검 결과를 다운로드 가능한 아티팩트로 제공합니다.

- **버그 수정**
  - 이동 거리 0m를 유효한 요금 계산 대상이 아닌 요금 미제공 상태로 처리합니다.
  - 청소년 현금 요금이 공식 기준값으로 정확히 보정됩니다.
  - 최신 데이터팩 적용 시 기존 요금 데이터가 불필요하게 덮어써지지 않습니다.

- **테스트**
  - 요금 계산, 데이터팩 생성 및 API 응답 검증 테스트를 보강했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
