### PR TITLE
[Style] 광고 배너 슬롯 확대 — 표준 배너 규격 (#1931)

### DIFF
--- a/apps/mobile/lib/ad_slot.dart
+++ b/apps/mobile/lib/ad_slot.dart
@@ -2,7 +2,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'accessible_design.dart';
-import 'design_tokens.dart';
 
 /// 표준 배너 규격(아이콘 + 제목/부제 + CTA) 기준 슬롯 높이 (#1931).
 const double kAdBannerSlotStandardHeight = 96;
@@ -67,8 +66,8 @@ class _AdBannerSlotDevPlaceholder extends StatelessWidget {
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.symmetric(
-        horizontal: EasySubwaySpacing.lg,
-        vertical: EasySubwaySpacing.sm,
+        horizontal: 16,
+        vertical: 8,
       ),
       child: Row(
         children: [
@@ -78,7 +77,7 @@ class _AdBannerSlotDevPlaceholder extends StatelessWidget {
             height: 64,
             decoration: BoxDecoration(
               color: EasySubwayAccessibleColors.line,
-              borderRadius: BorderRadius.circular(EasySubwayRadius.control),
+              borderRadius: BorderRadius.circular(12),
             ),
             alignment: Alignment.center,
             child: const Icon(
@@ -86,7 +85,7 @@ class _AdBannerSlotDevPlaceholder extends StatelessWidget {
               color: EasySubwayAccessibleColors.mutedText,
             ),
           ),
-          const SizedBox(width: EasySubwaySpacing.md),
+          const SizedBox(width: 12),
           // 제목/부제 플레이스홀더. 시스템 글자 크기가 커도 슬롯 높이를 넘지 않도록
           // 각 줄을 FittedBox로 축소한다(장식용 자리표시 텍스트, 실제 정보 없음).
           const Expanded(
@@ -107,7 +106,7 @@ class _AdBannerSlotDevPlaceholder extends StatelessWidget {
                     maxLines: 1,
                   ),
                 ),
-                SizedBox(height: EasySubwaySpacing.xs),
+                SizedBox(height: 4),
                 FittedBox(
                   fit: BoxFit.scaleDown,
                   alignment: Alignment.centerLeft,
@@ -123,14 +122,14 @@ class _AdBannerSlotDevPlaceholder extends StatelessWidget {
               ],
             ),
           ),
-          const SizedBox(width: EasySubwaySpacing.md),
+          const SizedBox(width: 12),
           // CTA 버튼 영역 플레이스홀더.
           Container(
             width: 64,
             height: 32,
             decoration: BoxDecoration(
               color: EasySubwayAccessibleColors.line,
-              borderRadius: BorderRadius.circular(EasySubwayRadius.control),
+              borderRadius: BorderRadius.circular(12),
             ),
           ),
         ],

--- a/apps/mobile/lib/ad_slot.dart
+++ b/apps/mobile/lib/ad_slot.dart
@@ -51,7 +51,7 @@ class AdBannerSlot extends StatelessWidget {
                 )
               : null,
         ),
-        child: ad ?? const _AdBannerSlotDevPlaceholder(),
+        child: ad ?? const ExcludeSemantics(child: _AdBannerSlotDevPlaceholder()),
       ),
     );
   }

--- a/apps/mobile/lib/ad_slot.dart
+++ b/apps/mobile/lib/ad_slot.dart
@@ -2,20 +2,26 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'accessible_design.dart';
+import 'design_tokens.dart';
+
+/// 표준 배너 규격(아이콘 + 제목/부제 + CTA) 기준 슬롯 높이 (#1931).
+const double kAdBannerSlotStandardHeight = 96;
 
 /// 실광고 연동 전까지 사용하는 공용 배너 슬롯.
 ///
 /// 노출 규칙(전 화면 공통):
 /// - release 빌드: 로드된 실광고([child])가 없으면 슬롯을 렌더링하지 않는다.
 ///   빈 박스·"광고" 텍스트 플레이스홀더를 release에 상시 노출하지 않는다.
-/// - debug/internal 빌드: 자리 확인용 플레이스홀더만 노출한다.
+/// - debug/internal 빌드: 자리 확인용 플레이스홀더만 노출한다. 표준 배너
+///   규격(아이콘·제목/부제·CTA)을 그대로 반영해 실제 배치 시 크기를 체감할
+///   수 있게 한다.
 ///
 /// 실광고 SDK를 연동하면 로드된 배너를 [child]로 전달한다. 로드 실패·무재고면
 /// 상위에서 이 위젯을 렌더링하지 않거나 [child]를 null로 두면 슬롯이 collapse된다.
 class AdBannerSlot extends StatelessWidget {
   const AdBannerSlot({
     required this.slotKey,
-    this.height = 52,
+    this.height = kAdBannerSlotStandardHeight,
     this.showTopDivider = true,
     this.child,
     super.key,
@@ -38,7 +44,6 @@ class AdBannerSlot extends StatelessWidget {
       child: Container(
         key: slotKey,
         height: height,
-        alignment: Alignment.center,
         decoration: BoxDecoration(
           color: EasySubwayAccessibleColors.surface,
           border: showTopDivider
@@ -47,16 +52,88 @@ class AdBannerSlot extends StatelessWidget {
                 )
               : null,
         ),
-        child:
-            ad ??
-            const Text(
-              '광고 미리보기 (개발용)',
-              style: TextStyle(
-                color: EasySubwayAccessibleColors.mutedText,
-                fontSize: 12,
-                fontWeight: FontWeight.w600,
-              ),
+        child: ad ?? const _AdBannerSlotDevPlaceholder(),
+      ),
+    );
+  }
+}
+
+/// 개발 빌드 전용 플레이스홀더 — 표준 배너 레이아웃(아이콘/제목·부제/CTA)만
+/// 중립 블록으로 보여준다. 실제 광고 콘텐츠·브랜드 요소는 없다.
+class _AdBannerSlotDevPlaceholder extends StatelessWidget {
+  const _AdBannerSlotDevPlaceholder();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: EasySubwaySpacing.lg,
+        vertical: EasySubwaySpacing.sm,
+      ),
+      child: Row(
+        children: [
+          // 아이콘 영역 플레이스홀더.
+          Container(
+            width: 64,
+            height: 64,
+            decoration: BoxDecoration(
+              color: EasySubwayAccessibleColors.line,
+              borderRadius: BorderRadius.circular(EasySubwayRadius.control),
             ),
+            alignment: Alignment.center,
+            child: const Icon(
+              Icons.image_outlined,
+              color: EasySubwayAccessibleColors.mutedText,
+            ),
+          ),
+          const SizedBox(width: EasySubwaySpacing.md),
+          // 제목/부제 플레이스홀더. 시스템 글자 크기가 커도 슬롯 높이를 넘지 않도록
+          // 각 줄을 FittedBox로 축소한다(장식용 자리표시 텍스트, 실제 정보 없음).
+          const Expanded(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                FittedBox(
+                  fit: BoxFit.scaleDown,
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    '광고 미리보기 (개발용)',
+                    style: TextStyle(
+                      color: EasySubwayAccessibleColors.mutedText,
+                      fontSize: 13,
+                      fontWeight: FontWeight.w600,
+                    ),
+                    maxLines: 1,
+                  ),
+                ),
+                SizedBox(height: EasySubwaySpacing.xs),
+                FittedBox(
+                  fit: BoxFit.scaleDown,
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    '표준 배너 규격 자리표시 텍스트',
+                    style: TextStyle(
+                      color: EasySubwayAccessibleColors.mutedText,
+                      fontSize: 12,
+                    ),
+                    maxLines: 1,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: EasySubwaySpacing.md),
+          // CTA 버튼 영역 플레이스홀더.
+          Container(
+            width: 64,
+            height: 32,
+            decoration: BoxDecoration(
+              color: EasySubwayAccessibleColors.line,
+              borderRadius: BorderRadius.circular(EasySubwayRadius.control),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -19,7 +19,6 @@ import 'mobile_error_reporter.dart';
 import 'station_search.dart';
 
 const _networkMapTopBarHeight = 60.0;
-const _networkMapBottomAdHeight = 52.0;
 const _networkMapPillRadius = BorderRadius.all(Radius.circular(28));
 const _networkMapSearchFieldRadius = BorderRadius.all(Radius.circular(12));
 const _networkMapSearchFieldBorderColor = Color(0xFFDBE3E9);
@@ -1917,10 +1916,7 @@ class _NetworkMapBottomAdBanner extends StatelessWidget {
     // 실광고 미연동: release에서는 "광고" 플레이스홀더를 노출하지 않고 슬롯을 숨긴다.
     return const SafeArea(
       top: false,
-      child: AdBannerSlot(
-        slotKey: Key('networkMapBottomAdBanner'),
-        height: _networkMapBottomAdHeight,
-      ),
+      child: AdBannerSlot(slotKey: Key('networkMapBottomAdBanner')),
     );
   }
 }
@@ -2051,10 +2047,7 @@ class _NetworkMapMenuPanel extends StatelessWidget {
               // 패널 최하단 고정 광고 슬롯(항목 스크롤과 분리, release는 collapse).
               const SafeArea(
                 top: false,
-                child: AdBannerSlot(
-                  slotKey: Key('networkMapMenuAdBanner'),
-                  height: 56,
-                ),
+                child: AdBannerSlot(slotKey: Key('networkMapMenuAdBanner')),
               ),
             ],
           ),

--- a/apps/mobile/test/ad_slot_test.dart
+++ b/apps/mobile/test/ad_slot_test.dart
@@ -1,0 +1,38 @@
+import 'package:easysubway_mobile/ad_slot.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('광고 슬롯은 debug 표준 placeholder를 지킨다', (
+    tester,
+  ) async {
+    final semanticsHandle = tester.ensureSemantics();
+    const slotKey = Key('adSlotTest');
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Center(
+          child: SizedBox(
+            width: 400,
+            child: AdBannerSlot(slotKey: slotKey),
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      tester.getSize(find.byKey(slotKey)).height,
+      96,
+    );
+    expect(
+      find.byWidgetPredicate(
+        (widget) => widget is Semantics && widget.properties.label == '광고',
+      ),
+      findsOneWidget,
+    );
+    expect(find.byIcon(Icons.image_outlined), findsOneWidget);
+    expect(find.text('광고 미리보기 (개발용)'), findsOneWidget);
+    expect(find.text('표준 배너 규격 자리표시 텍스트'), findsOneWidget);
+    expect(find.byType(Column), findsOneWidget);
+    semanticsHandle.dispose();
+  });
+}

--- a/apps/mobile/test/ad_slot_test.dart
+++ b/apps/mobile/test/ad_slot_test.dart
@@ -33,6 +33,13 @@ void main() {
     expect(find.text('광고 미리보기 (개발용)'), findsOneWidget);
     expect(find.text('표준 배너 규격 자리표시 텍스트'), findsOneWidget);
     expect(find.byType(Column), findsOneWidget);
+    expect(
+      find.ancestor(
+        of: find.text('광고 미리보기 (개발용)'),
+        matching: find.byType(ExcludeSemantics),
+      ),
+      findsOneWidget,
+    );
     semanticsHandle.dispose();
   });
 }


### PR DESCRIPTION
## 관련 이슈

Closes #1931

Refs #1771

- 상위 수익화 이슈 #1771은 실제 광고 소재·API·관리자 콘솔·무식별 계측을 다루므로 이 PR로 닫지 않고 open 상태를 유지합니다.

## 작업 배경

- 위험도 A: Android v1 사용자 노출 UI와 debug/release 노출 경계를 변경하므로 전체 PR 템플릿과 자동·실기기 증거를 적용합니다.
- 기존 `AdBannerSlot`은 기본 높이 52dp와 단일 debug 텍스트만 제공해 아이콘·제목/부제·CTA가 있는 표준 배너 규격을 검토하기 어려웠습니다.
- #1931 변경은 open 상태인 대형 PR #1926에서 독립된 단기 branch `style/1931-ad-banner-slot`로 추출했습니다. 전용 worktree에서만 작업했으며 root user branch는 건드리지 않았습니다.
- 이 PR은 실제 광고 rendering, 광고 API 연동, 광고 SDK 도입이 아니라 debug 자리표시 UI와 release collapse 경계만 다룹니다.

## 작업 내용

- `AdBannerSlot`의 기본 높이를 52dp에서 96dp로 올리고 아이콘 64dp, 제목·부제, CTA 모양을 갖춘 debug 전용 placeholder를 추가했습니다.
- 바깥 `Semantics`의 `광고` 라벨은 유지하고, 개발용 placeholder의 장식 텍스트·아이콘·CTA 모양은 `ExcludeSemantics`로 제외해 TalkBack이 하나의 `광고` 노드만 읽게 했습니다.
- network map 하단 슬롯의 52dp override와 좌측 menu 하단 슬롯의 56dp override를 제거해 공통 96dp 규격을 사용하게 했습니다.
- network map 하단은 `Scaffold.bottomNavigationBar`, menu 슬롯은 `Expanded(ListView)`의 형제 영역이므로 96dp로 커져도 콘텐츠를 덮지 않습니다. 실기기 UI tree와 screenshot으로 경계를 재확인했습니다.
- `child == null && kReleaseMode`일 때 `SizedBox.shrink()`로 접히는 기존 release 계약은 유지했습니다. release APK에서 빈 띠 없이 96dp가 콘텐츠에 반환되는 것을 확인했습니다.
- 변경은 3파일·3커밋입니다: `apps/mobile/lib/ad_slot.dart`, `apps/mobile/lib/network_map.dart`, `apps/mobile/test/ad_slot_test.dart`.
- 실제 광고 creative, network 요청, 광고 API, 광고 SDK, AD_ID, 식별자·이벤트 계측은 추가하지 않았습니다.
- README 변경은 없습니다.

## 검증

- 실행한 명령과 결과:
  - 전체 `flutter analyze`: PASS, issue 0.
  - 전체 `flutter test`: PASS, 976/976.
  - `node --test tools/ci/repository-contract.test.mjs`: PASS, 175/175.
  - `flutter build apk --debug`: PASS. 실기기 교체 설치와 network map home/menu QA에 사용했습니다.
  - `flutter build apk --release`: PASS. release 필수 값은 로컬 QA용 local example dart-defines를 사용했습니다. 이 APK는 검증용 로컬 산출물이며 deploy·publish·store upload는 수행하지 않았습니다.
  - `git diff --check origin/main...HEAD`: PASS.
  - diff scope: PASS, origin/main 기준 3파일·3커밋이며 worktree clean.
- 리뷰 결과:
  - CodeRabbit 초기 리뷰: Minor 1건. debug placeholder의 하위 semantics가 바깥 `광고` 라벨과 함께 노출될 수 있다는 지적을 수정 전 확인했습니다.
  - 후속 commit `c2bd9923`에서 placeholder를 `ExcludeSemantics`로 감싸고 widget test를 보강했습니다.
  - CodeRabbit 재실행: findings 없음.
  - GitHub CodeRabbit Review 객체: 생성됨. outside-diff 정렬 제안 1건은 Flutter constraint와 실기기 geometry로 false positive 판정하고 PR 댓글에 근거를 남겼습니다.
  - correctness review: READY.
  - Ponytail의 `ListTile` 치환 제안은 skip했습니다. 이 UI는 클릭 가능한 실제 광고가 아니라 96dp 고정 규격을 보여주는 비대화형 debug skeleton입니다. `ListTile`은 암묵적 레이아웃·상호작용·semantics를 추가하고 64dp 아이콘/CTA 자리의 정확한 geometry를 흐리므로, 현재의 작은 `Row` 구성이 범위와 계약에 더 직접적입니다.

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| debug home 96dp·비가림 | Samsung SM-A175N / Android 16 | debug APK `adb install -r`, network map UI tree·screenshot 확인 | `/tmp/issue-1931-evidence/final-debug-home.xml`, `final-debug-home.png`, `final-debug-home-summary.txt` | `광고` bounds 270px = 96dp, map 콘텐츠가 슬롯 시작점에서 끝남, PASS |
| debug menu 96dp·비가림 | Samsung SM-A175N / Android 16 | 좌측 menu UI tree·screenshot 확인 | `/tmp/issue-1931-evidence/final-debug-menu.xml`, `final-debug-menu.png`, `final-debug-menu-summary.txt` | 96dp 슬롯이 menu row 아래 별도 영역에 표시, PASS |
| TalkBack semantics | Samsung SM-A175N / Android 16 + Flutter widget test | UIAutomator semantics와 `ad_slot_test.dart` 확인 | 위 debug XML, `apps/mobile/test/ad_slot_test.dart` | 단일 `광고` 라벨만 노출되고 장식 placeholder 하위 semantics는 제외, PASS |
| release home collapse | Samsung SM-A175N / Android 16 | release APK 교체 설치 후 UI tree·screenshot 비교 | `/tmp/issue-1931-evidence/final-release-home.xml`, `final-release-home.png`, `final-release-home-summary.txt` | 광고/placeholder/빈 띠 없음, 270px = 96dp를 map이 회수, PASS |
| release menu collapse | Samsung SM-A175N / Android 16 | release menu UI tree·screenshot 확인 | `/tmp/issue-1931-evidence/final-release-menu.xml`, `final-release-menu.png`, `final-release-menu-summary.txt` | 별도 banner block·divider·reserved strip 없음, PASS |
| APK identity | Android local build | 산출물 SHA-256 확인 | debug `0dd0754d5b4a1ec06c542a160e21dac41108c8d9ec60abcb2fa757ec9fa394ef`, release `8216a82e5b8f047a954a96c29dac59cc32425aa2f296a9c46895bdfd9d022b92` | HEAD `c2bd9923` QA 산출물 확인 |
| crash·runtime log | Samsung SM-A175N / Android 16 | debug/release crash buffer와 process log 확인 | `/tmp/issue-1931-evidence/final-debug-crash.txt`, `final-release-crash.txt`, `final-debug-logcat.txt`, `final-release-logcat.txt` | crash buffer 0줄, 주요 fatal/runtime/database 오류 match 없음, PASS |
| 자동 회귀 | macOS / Flutter·Node | full analyze/test와 repository contract 실행 | 로컬 command output | analyze 0, Flutter 976/976, repository contract 175/175, PASS |
| 실제 광고/API/SDK | 해당 없음 | diff scope 확인 | 3파일 diff | 이 PR 비범위이며 추가 없음 |

- 실기기 evidence 전체 요약: `/tmp/issue-1931-evidence/report.md`.
- `final-` prefix 파일만 HEAD `c2bd9923`의 최종 증거이며 이전 예비 capture는 사용하지 않습니다.
- 기기 최종 상태: debug APK를 `adb install -r`로 다시 설치해 복원했습니다. app data를 삭제하지 않았고 기기 설정도 변경하지 않았습니다.

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 1.0.2 (변경 없음)
- mobile versionCode: 10002 (변경 없음)
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `ad_slot.dart`의 debug/release 분기와 `ExcludeSemantics`, `network_map.dart`의 bottom/menu height override 제거, `ad_slot_test.dart`의 96dp·단일 semantics 계약입니다.
- 이 branch는 #1926의 큰 시각 언어 diff에서 #1931만 독립 추출한 것입니다. root user branch는 수정·rebase·reset하지 않았습니다.
- #1771은 계속 open입니다. 실제 광고 child/API/SDK/creative/계측을 이 PR의 완료로 해석하지 않습니다.

## 리스크

- debug/internal에서만 표준 배너 placeholder가 보입니다. release에는 실제 광고 child가 아직 없으므로 슬롯은 계속 collapse합니다.
- CTA는 클릭 가능한 광고 버튼이 아니라 debug용 장식 skeleton입니다. 실제 터치 target·랜딩·대체텍스트·광고 API·오프라인/만료 동작은 #1771 범위입니다.
- release APK는 local example dart-defines로 로컬 QA만 수행했습니다. production 배포, CD 실행, store upload, 외부 사용자 노출은 없습니다.
- 광고 SDK·AD_ID·식별자·네트워크 요청·개인정보 수집을 추가하지 않아 Data Safety 범위를 변경하지 않습니다.
- `/tmp/issue-1931-evidence/`는 실기기 screenshot/UI tree/log를 담은 local-only evidence입니다. PR 본문에는 종류·대상·결과와 보관 경로만 기록합니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다. (visible 15 pass, required 6/6 PASS, failure 0, pending 0)
- [x] CodeRabbit 리뷰를 확인했다. (초기 Minor 수정 후 재실행 findings 없음)
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit `COMMENTED` Review 객체와 thread 0/unresolved 0을 확인했다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다. (CodeRabbit Review 객체가 있어 fallback 불필요)
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음, release APK local QA만 수행)
