### PR TITLE
[Chore] #1945 리뷰 지적 후속 — .gitignore 중복 제거·계약 앵커 주석 1줄 축약 (#1944)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,4 +107,3 @@ apps/mobile/ios/DerivedData/
 !**/terraform.tfvars.example
 
 .worktrees/
-/CLAUDE.md

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1544,9 +1544,7 @@ test("모바일 홈 shell과 주요 상태 UI 회귀 테스트는 유지된다",
   assert.doesNotMatch(main, /homeBottomNavigationBar/);
   assert.match(widgetTest, /기본 앱은 저장소가 없어도 노선도 중심 첫 화면을 보여준다/);
   assert.match(widgetTest, /노선도 첫 화면은 하단 광고 위에 지도 조작을 유지한다/);
-  // #1933: 별도 길찾기 폼 페이지를 없애며 "노선도 메뉴 길찾기는 길찾기 화면으로 전환한다"
-  // 테스트가 사라졌다. 노선도 홈에서 출발·도착 지정 시 길찾기 화면으로 전환되는
-  // 현행 테스트로 앵커를 갱신해 계약(길찾기 화면 전환 보증)을 유지한다.
+  // #1933: 폼 페이지 제거로 대체된 현행 전환 테스트 앵커
   assert.match(widgetTest, /노선도에서 출발·도착을 정하면 길찾기 결과 화면으로 전환한다/);
   assert.match(widgetTest, /find\.byKey\(const Key\('homeBottomNavigationBar'\)\), findsNothing/);
   assert.match(widgetTest, /find\.byKey\(const Key\('bottomNavHome'\)\), findsNothing/);
@@ -10140,9 +10138,7 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(onboarding, /class OnboardingResult/);
   assert.match(onboarding, /class OnboardingState/);
   assert.match(onboarding, /class OnboardingScreen extends StatefulWidget/);
-  // #1936: 온보딩 전면 재설계로 "먼저 이동 조건을 골라 주세요" 설명 문구가 삭제되고
-  // 질문형 헤더 카피로 대체되었다. 현행 canonical 카피로 앵커를 갱신해 계약(이동
-  // 조건 선택 안내 카피 존재 보증)을 유지한다.
+  // #1936: 온보딩 재설계로 대체된 현행 이동 조건 선택 안내 카피
   assert.match(onboarding, /어떻게 이동하세요\?/);
   assert.doesNotMatch(onboarding, /큰 글자/);
   assert.match(onboarding, /고대비/);
@@ -10152,9 +10148,7 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(routeSearch, /final bool simpleViewEnabled/);
   assert.match(routeSearch, /_resolveInitialMobilityType/);
   assert.match(routeSearch, /_selectedMobilityType = widget\.initialMobilityType/);
-  // #1933 D: 결과-우선 정리로 이동 조건 요약 위젯(_RouteMobilityTypeSummary)과
-  // 간편 보기 버튼 키(routeSimpleMobilityTypeButton)가 조건 칩(_RouteConditionChips)
-  // 구조로 대체됐다. 이동 조건 변경 진입점 보증 계약을 현행 앵커로 유지한다.
+  // #1933: 결과-우선 정리로 대체된 현행 이동 조건 변경 진입점
   assert.match(routeSearch, /_RouteConditionChips\([\s\S]*mobilityType: _selectedMobilityType[\s\S]*onChangeMobility: _showMobilityTypePicker/);
   assert.match(routeSearch, /routeConditionMobilityChip/);
   assert.match(routeSearch, /routeMobilityOption-\$\{option\.mobilityType\}/);


### PR DESCRIPTION
## 관련 이슈

Refs #1944

## 작업 배경

- PR #1945의 폴백 리뷰 actionable 2건이 automerge 처리 직후 push되어 병합에 포함되지 못함 — 후속 반영.

## 작업 내용

- `.gitignore`: 루트 `/CLAUDE.md` 줄 제거(기존 30행 `CLAUDE.md` 패턴이 이미 커버 — 중복)
- `tools/ci/repository-contract.test.mjs`: #1945에서 추가된 앵커 주석 3곳을 리포 1줄 관례로 축약(내용 변화 없음, 주석만)

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/repository-contract.test.mjs` → tests 176 / pass 176 / fail 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 계약 테스트 무회귀 | CI(node) | node --test 로컬 실행 | 검증 섹션 출력 | 176/176 pass |
| UI/접근성 영향 | - | 주석·gitignore만 변경(로직 무변경) | 증거 불요 사유: 실행 경로 무변경 | 해당 없음 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 계약 파일 변경이 주석 3줄뿐인지(assert 무변경).

## 리스크

- 없음(주석·gitignore만). 계약 테스트 전체 통과로 확인.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 프로젝트 내 `CLAUDE.md` 파일이 위치와 관계없이 일관되게 제외되도록 파일 관리 설정을 개선했습니다.

* **Tests**
  * 모바일 화면 관련 회귀 테스트의 설명과 기준 안내를 최신 상태로 정리했습니다.
  * 테스트 검증 로직과 기대 결과에는 변경이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->