### PR TITLE
[Docs] 광고 포함 스토어·개인정보 계약 정합 (#1943)

### DIFF
--- a/apps/mobile/release/play-store-submission-content.json
+++ b/apps/mobile/release/play-store-submission-content.json
@@ -36,7 +36,7 @@
     ]
   },
   "appContentDeclarations": {
-    "ads": false,
+    "ads": true,
     "appAccessRequiresSignIn": false,
     "publicUserSignIn": false,
     "accountCreation": false,
@@ -45,7 +45,7 @@
     "cameraOrPhoto": "optional_user_triggered_report_attachment_only",
     "restrictedContent": false,
     "targetAudience": "all_users_not_child_directed",
-    "reviewerAccessNotesKo": "로그인 없는 앱입니다. 위치 권한은 주변 역 찾기, 신고 위치 확인, 출구 도보 길안내에서만 선택적으로 사용합니다."
+    "reviewerAccessNotesKo": "로그인 없는 앱입니다. 위치 권한은 주변 역 찾기, 신고 위치 확인, 출구 도보 길안내에서만 선택적으로 사용합니다. 자체 서빙 비개인화 광고 landing은 사용자가 명시적으로 누를 때만 외부 브라우저로 엽니다."
   },
   "requiredScreenshotSet": [
     {
@@ -428,7 +428,7 @@
     "recommendedCategoryKo": "Maps & Navigation 또는 Travel & Local 중 대중교통 접근성 이동 보조 설명과 가장 일치하는 항목",
     "requiredTagsKo": ["대중교통", "접근성", "지하철", "경로 안내"],
     "reviewerNotesMustIncludeKo": ["로그인 없음", "위치 권한은 선택적 사용", "시설 신고 사진은 사용자가 직접 첨부할 때만 전송", "카카오맵 앱/웹 공유는 사용자가 지도 또는 도보 길안내를 누를 때만 실행"],
-    "contentRatingBasisKo": "대중교통 정보, 사용자 시설 신고 입력, 광고 없음, 외부 지도 앱/웹은 사용자가 지도 또는 길안내를 누를 때만 열리는 범위와 일치"
+    "contentRatingBasisKo": "대중교통 정보, 사용자 시설 신고 입력, 자체 서빙 비개인화 광고, 외부 지도 앱/웹은 사용자가 지도 또는 길안내를 명시적으로 누를 때만 열리고 광고 landing은 사용자가 광고를 명시적으로 누를 때만 외부 브라우저로 열리는 범위와 일치"
   },
   "crashAnrProviderDecision": {
     "separateCrashProvider": false,

--- a/apps/mobile/release/store-privacy-inventory.json
+++ b/apps/mobile/release/store-privacy-inventory.json
@@ -2,6 +2,17 @@
   "schemaVersion": 1,
   "applicationId": "easysubway",
   "tracking": false,
+  "advertising": {
+    "included": true,
+    "servingModel": "first-party-self-served",
+    "personalized": false,
+    "adId": false,
+    "thirdPartyAdSdk": false,
+    "tracking": false,
+    "measurementEvents": false,
+    "collectedDataTypeIds": [],
+    "lastVerifiedAt": "2026-07-11"
+  },
   "sharesDataWithThirdParties": true,
   "encryptionInTransitRequired": true,
   "userDataDeletionSupported": true,

--- a/apps/mobile/release/store-submission-readiness.json
+++ b/apps/mobile/release/store-submission-readiness.json
@@ -80,9 +80,9 @@
       "category": "app-content",
       "titleKo": "Play 콘텐츠 등급 설문",
       "decisionOwnerKo": "제품/운영 담당",
-      "readyWhenKo": "대중교통 접근성 정보 앱 특성, 사용자 생성 신고 내용, 외부 웹 열람 없음, 광고 없음 기준으로 콘텐츠 등급 설문을 완료한다.",
-      "evidence": ["content-rating-certificate", "questionnaire-export"],
-      "linkedArtifacts": ["apps/mobile/lib/facility_report.dart"],
+      "readyWhenKo": "대중교통 접근성 정보 앱 특성, 사용자 생성 신고 내용, 자체 서빙 비개인화 광고와 사용자가 명시적으로 누를 때만 여는 외부 landing 기준으로 콘텐츠 등급 설문을 완료한다.",
+      "evidence": ["content-rating-certificate", "questionnaire-export", "ad-request-contract-test"],
+      "linkedArtifacts": ["apps/mobile/lib/facility_report.dart", "apps/mobile/lib/features/ads/active_ad_banner.dart", "apps/mobile/lib/features/ads/ad_repository.dart"],
       "configurationSources": ["product scope", "facility report moderation policy"]
     },
     {
@@ -102,10 +102,10 @@
       "category": "app-content",
       "titleKo": "Play 광고 포함 여부",
       "decisionOwnerKo": "제품/사업 담당",
-      "readyWhenKo": "앱 코드와 출시 계획에 광고 SDK와 광고 지면이 없음을 확인하고 Play Console 광고 포함 여부를 아니오로 제출한다.",
-      "evidence": ["dependency-review", "business-model-review"],
-      "linkedArtifacts": ["apps/mobile/lib/main.dart"],
-      "configurationSources": ["no ad SDK dependency", "no in-app ad placement"]
+      "readyWhenKo": "자체 서빙 비개인화 하우스/제휴 배너를 포함하므로 Play Console 광고 포함 여부를 예로 제출한다. AD_ID, 제3자 광고 SDK, tracking, event 계측을 사용하지 않고 광고 landing은 사용자가 명시적으로 누를 때만 외부 브라우저로 연다.",
+      "evidence": ["dependency-review", "business-model-review", "ad-request-contract-test"],
+      "linkedArtifacts": ["apps/mobile/lib/features/ads/ad_repository.dart", "apps/mobile/lib/features/ads/active_ad_banner.dart"],
+      "configurationSources": ["first-party self-served in-app ad placement", "no third-party ad SDK dependency", "no AD_ID permission", "no ad tracking or event measurement"]
     },
     {
       "id": "play_app_category",
@@ -201,9 +201,9 @@
       "category": "app-information",
       "titleKo": "App Store 연령 등급",
       "decisionOwnerKo": "제품/운영 담당",
-      "readyWhenKo": "대중교통 정보, 사용자 신고 입력, 외부 웹 열람 없음, 광고 없음 기준으로 App Store Connect 연령 등급 설문을 완료한다.",
-      "evidence": ["age-rating-result", "questionnaire-review"],
-      "linkedArtifacts": ["apps/mobile/lib/facility_report.dart"],
+      "readyWhenKo": "대중교통 정보, 사용자 신고 입력, 자체 서빙 비개인화 광고와 사용자가 명시적으로 누를 때만 여는 외부 landing 기준으로 App Store Connect 연령 등급 설문을 완료한다.",
+      "evidence": ["age-rating-result", "questionnaire-review", "ad-request-contract-test"],
+      "linkedArtifacts": ["apps/mobile/lib/facility_report.dart", "apps/mobile/lib/features/ads/active_ad_banner.dart", "apps/mobile/lib/features/ads/ad_repository.dart"],
       "configurationSources": ["product scope", "facility report moderation policy"]
     },
     {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -2014,7 +2014,7 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   assert.equal(playStoreSubmissionContent.issue, 1018);
   assert.equal(playStoreSubmissionContent.androidRcEvidenceManifest, androidRcEvidencePath);
   assert.equal(playStoreSubmissionContent.storePrivacyInventory, "apps/mobile/release/store-privacy-inventory.json");
-  assert.equal(playStoreSubmissionContent.appContentDeclarations.ads, false);
+  assert.equal(playStoreSubmissionContent.appContentDeclarations.ads, true);
   assert.equal(playStoreSubmissionContent.appContentDeclarations.publicUserSignIn, false);
   assert.equal(playStoreSubmissionContent.appContentDeclarations.accountCreation, false);
   assert.equal(playStoreSubmissionContent.appContentDeclarations.backgroundLocation, false);
@@ -2708,6 +2708,81 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   assert.doesNotMatch(workflow, /testflight_evidence=blocked_missing_testflight_or_signed_device_install/);
   assert.doesNotMatch(workflow, /cp release\/signed-release-artifact-gate\.json release-artifacts\/ios\/signed-release-artifact-gate\.json/);
 
+});
+
+test("자체 서빙 광고 store 계약은 광고 포함과 무추적·무계측 경계를 함께 고정한다", () => {
+  const readiness = readJson("apps/mobile/release/store-submission-readiness.json");
+  const playStoreContent = readJson("apps/mobile/release/play-store-submission-content.json");
+  const privacyInventory = readJson("apps/mobile/release/store-privacy-inventory.json");
+  const androidMainManifest = read("apps/mobile/android/app/src/main/AndroidManifest.xml");
+
+  assert.equal(playStoreContent.appContentDeclarations.ads, true);
+  assert.equal(privacyInventory.advertising.included, true);
+  assert.equal(privacyInventory.advertising.servingModel, "first-party-self-served");
+  for (const field of ["personalized", "adId", "thirdPartyAdSdk", "tracking", "measurementEvents"]) {
+    assert.equal(privacyInventory.advertising[field], false, `advertising.${field} must remain false`);
+  }
+  assert.deepEqual(privacyInventory.advertising.collectedDataTypeIds, []);
+  assert.equal(privacyInventory.tracking, false);
+  assert.ok(privacyInventory.dataTypes.every((item) => item.usedForTracking === false));
+  assert.ok(
+    privacyInventory.dataTypes.every(
+      (item) => !/Advertising|Marketing/.test(item.googlePlayDataSafety.purpose),
+    ),
+  );
+
+  const readinessItems = new Map(readiness.items.map((item) => [item.id, item]));
+  const adDisclosure = readinessItems.get("play_ads_declaration");
+  for (const id of ["play_content_rating", "appstore_age_rating"]) {
+    const item = readinessItems.get(id);
+    assert.ok(item.evidence.includes("ad-request-contract-test"), `${id} must link ad request contract evidence`);
+    assert.ok(
+      item.linkedArtifacts.includes("apps/mobile/lib/features/ads/active_ad_banner.dart"),
+      `${id} must link the rendered ad slot`,
+    );
+    assert.ok(
+      item.linkedArtifacts.includes("apps/mobile/lib/features/ads/ad_repository.dart"),
+      `${id} must link the ad request boundary`,
+    );
+    assert.match(item.readyWhenKo, /자체 서빙 비개인화 광고/);
+    assert.match(item.readyWhenKo, /명시적으로 누를 때만.*외부/);
+  }
+  for (const copy of [
+    adDisclosure.readyWhenKo,
+    readinessItems.get("play_content_rating").readyWhenKo,
+    readinessItems.get("appstore_age_rating").readyWhenKo,
+    playStoreContent.storeMetadataRequirements.contentRatingBasisKo,
+  ]) {
+    assert.doesNotMatch(copy, /광고 없음|광고 지면이 없|외부 웹 열람 없음/);
+  }
+  const contentRatingBasis = playStoreContent.storeMetadataRequirements.contentRatingBasisKo;
+  assert.match(
+    contentRatingBasis,
+    /외부 지도 앱\/웹은 사용자가 지도 또는 길안내를 명시적으로 누를 때만 열/,
+  );
+  assert.match(
+    contentRatingBasis,
+    /광고 landing은 사용자가 광고를 명시적으로 누를 때만 외부 브라우저로 열/,
+  );
+  assert.match(adDisclosure.readyWhenKo, /자체 서빙/);
+  assert.match(adDisclosure.readyWhenKo, /비개인화/);
+  assert.match(adDisclosure.readyWhenKo, /명시적으로 누를 때만.*외부 브라우저/);
+
+  for (const dependencyPath of ["apps/mobile/pubspec.yaml", "apps/mobile/pubspec.lock"]) {
+    assert.doesNotMatch(
+      read(dependencyPath),
+      /google_mobile_ads|play-services-ads|com\.google\.android\.gms\.ads/i,
+      `${dependencyPath} must not add a third-party ad SDK`,
+    );
+  }
+  assert.doesNotMatch(androidMainManifest, /android\.permission\.AD_ID/);
+  for (const sourcePath of mobileProductionDartFiles()) {
+    assert.doesNotMatch(
+      read(sourcePath),
+      /\/api\/ads\/events/,
+      `${sourcePath} must not send ad measurement events`,
+    );
+  }
 });
 
 test("RC evidence manifest generator는 RC identity와 No-Go blocker를 생성한다", async () => {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -29,6 +29,28 @@ function mobileProductionDartFiles() {
   }).trim().split("\n").filter((file) => file.endsWith(".dart") && !file.endsWith(".g.dart"));
 }
 
+function assertNoNativeAdIdentityOrMeasurement({
+  dependencySources = [],
+  nativeSources = [],
+  mergedManifest,
+}) {
+  const adSdk = /google_mobile_ads|play-services-ads|com\.google\.android\.gms\.ads|Google-Mobile-Ads-SDK|GoogleMobileAds|GADMobileAds|AppLovinSDK|UnityAds|IronSource|FBAudienceNetwork|AmazonPublisherServices|ChartboostSDK|VungleAds/i;
+  const adEventPost = /\/api\/ads\/events|\b(?:post|send|record)_?ad(?:vertising)?_?event\b|\bPOST\b[^\n]{0,120}\b(?:ad|advertising)[_-]?events?\b|\b(?:ad|advertising)[_-]?events?\b[^\n]{0,120}\bPOST\b/i;
+  for (const [file, source] of dependencySources) {
+    assert.doesNotMatch(source, adSdk, `${file} must not add a native ad SDK`);
+  }
+  for (const [file, source] of nativeSources) {
+    assert.doesNotMatch(source, adEventPost, `${file} must not post native ad events`);
+  }
+  if (mergedManifest) {
+    assert.doesNotMatch(
+      mergedManifest[1],
+      /android\.permission\.AD_ID/,
+      `${mergedManifest[0]} must not contain AD_ID`,
+    );
+  }
+}
+
 function readJson(relativePath) {
   return JSON.parse(read(relativePath));
 }
@@ -2783,6 +2805,74 @@ test("자체 서빙 광고 store 계약은 광고 포함과 무추적·무계측
       `${sourcePath} must not send ad measurement events`,
     );
   }
+});
+
+test("자체 서빙 광고 native 경계는 SDK·AD_ID·event POST를 release 산출물까지 차단한다", () => {
+  const dependencyPaths = execFileSync("git", [
+    "ls-files",
+    "apps/mobile/android/**/*.gradle",
+    "apps/mobile/android/**/*.gradle.kts",
+    "apps/mobile/android/**/gradle.lockfile",
+    "apps/mobile/android/**/libs.versions.toml",
+    "apps/mobile/ios/Podfile.lock",
+    "apps/mobile/ios/**/*.pbxproj",
+    "apps/mobile/ios/**/Package.resolved",
+  ], { cwd: root, encoding: "utf8" }).trim().split("\n").filter(Boolean);
+  const nativeSourcePaths = execFileSync("git", [
+    "ls-files",
+    "apps/mobile/android/app/src/main/**/*.kt",
+    "apps/mobile/android/app/src/main/**/*.java",
+    "apps/mobile/ios/Runner/**/*.swift",
+    "apps/mobile/ios/Runner/**/*.m",
+    "apps/mobile/ios/Runner/**/*.mm",
+    "apps/mobile/ios/Runner/**/*.h",
+  ], { cwd: root, encoding: "utf8" }).trim().split("\n").filter(Boolean);
+
+  assertNoNativeAdIdentityOrMeasurement({
+    dependencySources: dependencyPaths.map((file) => [file, read(file)]),
+    nativeSources: nativeSourcePaths.map((file) => [file, read(file)]),
+  });
+
+  assert.throws(
+    () => assertNoNativeAdIdentityOrMeasurement({
+      dependencySources: [["native-gradle-sentinel", 'implementation("com.google.android.gms:play-services-ads:1.0")']],
+      nativeSources: [],
+    }),
+    /native-gradle-sentinel/,
+  );
+  assert.throws(
+    () => assertNoNativeAdIdentityOrMeasurement({
+      dependencySources: [],
+      nativeSources: [],
+      mergedManifest: ["merged-manifest-sentinel", '<uses-permission android:name="android.permission.AD_ID" />'],
+    }),
+    /merged-manifest-sentinel/,
+  );
+  assert.throws(
+    () => assertNoNativeAdIdentityOrMeasurement({
+      dependencySources: [],
+      nativeSources: [["native-event-sentinel.swift", "func postAdEvent() {}"]],
+    }),
+    /native-event-sentinel\.swift/,
+  );
+
+  const repositoryContract = read("tools/ci/repository-contract.test.mjs");
+  const mobileJob = jobBlock(read(".github/workflows/ci.yml"), "mobile-app", "android");
+  assert.match(mobileJob, /Mobile App CI \/ Generate Android release merged manifest/);
+  assert.match(mobileJob, /android\/gradlew -p android :app:processReleaseMainManifest --no-daemon/);
+  assert.match(mobileJob, /EASYSUBWAY_EXPECT_ANDROID_RELEASE_MANIFEST: "true"/);
+  assert.match(mobileJob, /test-name-pattern "[^"]*Android 릴리즈 권한/);
+  assert.match(
+    repositoryContract,
+    /test\("Android 릴리즈 권한은 앱 기능에 필요한 항목만 선언한다"[\s\S]*assertNoNativeAdIdentityOrMeasurement\(\{[\s\S]*mergedManifest:/,
+  );
+
+  const adRepositoryTest = read("apps/mobile/test/features/ads/ad_repository_test.dart");
+  assert.match(adRepositoryTest, /test\('GET active 요청의 method, path, query가 정확하고 event 요청은 없다'/);
+  assert.match(adRepositoryTest, /AdPlacement\.routeResultBottom[\s\S]*AdPlacement\.stationDetailBottom/);
+  assert.match(adRepositoryTest, /expect\(requests, hasLength\(2\)\)/);
+  assert.match(adRepositoryTest, /requests\.map\(\(request\) => request\.method\), everyElement\('GET'\)/);
+  assert.match(adRepositoryTest, /request\.uri\.path == '\/api\/ads\/events'[\s\S]*isEmpty/);
 });
 
 test("RC evidence manifest generator는 RC identity와 No-Go blocker를 생성한다", async () => {
@@ -12005,6 +12095,9 @@ test("Android 릴리즈 권한은 앱 기능에 필요한 항목만 선언한다
 
   const androidManifest = read(mergedManifestPath);
   const permissions = androidManifestPermissions(androidManifest);
+  assertNoNativeAdIdentityOrMeasurement({
+    mergedManifest: [mergedManifestPath, androidManifest],
+  });
 
   // 하차 알림(#1766)이 flutter_local_notifications를 도입하며 알림 표시용
   // POST_NOTIFICATIONS·VIBRATE와 시간표 기반 정확 예약용 SCHEDULE_EXACT_ALARM이

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -34,13 +34,57 @@ function assertNoNativeAdIdentityOrMeasurement({
   nativeSources = [],
   mergedManifest,
 }) {
-  const adSdk = /google_mobile_ads|play-services-ads|com\.google\.android\.gms\.ads|Google-Mobile-Ads-SDK|GoogleMobileAds|GADMobileAds|AppLovinSDK|UnityAds|IronSource|FBAudienceNetwork|AmazonPublisherServices|ChartboostSDK|VungleAds/i;
-  const adEventPost = /\/api\/ads\/events|\b(?:post|send|record)_?ad(?:vertising)?_?event\b|\bPOST\b[^\n]{0,120}\b(?:ad|advertising)[_-]?events?\b|\b(?:ad|advertising)[_-]?events?\b[^\n]{0,120}\bPOST\b/i;
+  const normalizeDependency = (value) => value.toLowerCase().replace(/[^a-z0-9]+/g, "");
+  const deniedDependencies = new Set([
+    "com.google.android.gms:play-services-ads",
+    "com.google.android.gms:play-services-ads-lite",
+    "Google-Mobile-Ads-SDK",
+    "GoogleMobileAds",
+    "GADMobileAds",
+    "com.applovin:applovin-sdk",
+    "AppLovinSDK",
+    "com.unity3d.ads:unity-ads",
+    "UnityAds",
+    "com.chartboost:chartboost-sdk",
+    "ChartboostSDK",
+    "com.vungle:vungle-ads",
+    "VungleAds",
+    "com.facebook.android:audience-network-sdk",
+    "FBAudienceNetwork",
+    "com.ironsource.sdk:mediationsdk",
+    "IronSource",
+    "IronSourceSDK",
+    "com.amazon.android:aps-sdk",
+    "AmazonPublisherServices",
+    "AmazonPublisherServicesSDK",
+  ].map((dependency) => {
+    const [group, name] = dependency.split(":");
+    return name
+      ? `${normalizeDependency(group)}:${normalizeDependency(name)}`
+      : normalizeDependency(group);
+  }));
   for (const [file, source] of dependencySources) {
-    assert.doesNotMatch(source, adSdk, `${file} must not add a native ad SDK`);
+    for (const token of source.match(/[A-Za-z0-9._-]+(?::[A-Za-z0-9._-]+){0,2}/g) ?? []) {
+      const [group, name] = token.split(":");
+      const dependency = name
+        ? `${normalizeDependency(group)}:${normalizeDependency(name)}`
+        : normalizeDependency(group);
+      assert.ok(!deniedDependencies.has(dependency), `${file} must not add a native ad SDK`);
+    }
   }
   for (const [file, source] of nativeSources) {
-    assert.doesNotMatch(source, adEventPost, `${file} must not post native ad events`);
+    let collapsed = source;
+    let previous;
+    do {
+      previous = collapsed;
+      collapsed = collapsed.replace(
+        /(["'])([^"'\\]*)\1\s*\+\s*(["'])([^"'\\]*)\3/g,
+        (_match, _leftQuote, left, _rightQuote, right) => `"${left}${right}"`,
+      );
+    } while (collapsed !== previous);
+    const hasAdEventEndpoint = /\/api\/ads\/events\b/.test(collapsed);
+    const hasPostRequest = /\.post\s*\(|\.(?:method)\s*\(\s*["']POST["']|\b(?:httpMethod|method)\s*[:=]\s*(?:["']POST["']|\.?HttpMethod\.POST|\.post\b)/i.test(collapsed);
+    assert.ok(!(hasAdEventEndpoint && hasPostRequest), `${file} must not post native ad events`);
   }
   if (mergedManifest) {
     assert.doesNotMatch(
@@ -2833,28 +2877,67 @@ test("자체 서빙 광고 native 경계는 SDK·AD_ID·event POST를 release �
     nativeSources: nativeSourcePaths.map((file) => [file, read(file)]),
   });
 
+  for (const [name, dependency] of [
+    ["google-android", "com.google.android.gms:play-services-ads:24.0.0"],
+    ["google-ios", "Google-Mobile-Ads-SDK"],
+    ["applovin-android", "com.applovin:applovin-sdk:13.0.0"],
+    ["applovin-ios", "AppLovinSDK"],
+    ["unity-android", "com.unity3d.ads:unity-ads:4.0.0"],
+    ["unity-ios", "UnityAds"],
+    ["chartboost-android", "com.chartboost:chartboost-sdk:9.0.0"],
+    ["chartboost-ios", "ChartboostSDK"],
+    ["vungle-android", "com.vungle:vungle-ads:7.0.0"],
+    ["vungle-ios", "VungleAds"],
+    ["meta-android", "com.facebook.android:audience-network-sdk:6.0.0"],
+    ["meta-ios", "FBAudienceNetwork"],
+    ["ironsource-android", "com.ironsource.sdk:mediationsdk:8.0.0"],
+    ["ironsource-ios", "IronSourceSDK"],
+    ["amazon-android", "com.amazon.android:aps-sdk:9.0.0"],
+    ["amazon-ios", "AmazonPublisherServicesSDK"],
+  ]) {
+    assert.throws(
+      () => assertNoNativeAdIdentityOrMeasurement({
+        dependencySources: [[`native-sdk-${name}`, dependency]],
+      }),
+      new RegExp(`native-sdk-${name}`),
+    );
+  }
+  for (const dependency of [
+    "com.google.android.gms:play-services-base:18.0.0",
+    "com.example:ads-reporting:1.0.0",
+    "GoogleUtilities",
+  ]) {
+    assert.doesNotThrow(() => assertNoNativeAdIdentityOrMeasurement({
+      dependencySources: [["harmless-native-dependency", dependency]],
+    }));
+  }
   assert.throws(
     () => assertNoNativeAdIdentityOrMeasurement({
-      dependencySources: [["native-gradle-sentinel", 'implementation("com.google.android.gms:play-services-ads:1.0")']],
-      nativeSources: [],
-    }),
-    /native-gradle-sentinel/,
-  );
-  assert.throws(
-    () => assertNoNativeAdIdentityOrMeasurement({
-      dependencySources: [],
-      nativeSources: [],
       mergedManifest: ["merged-manifest-sentinel", '<uses-permission android:name="android.permission.AD_ID" />'],
     }),
     /merged-manifest-sentinel/,
   );
-  assert.throws(
-    () => assertNoNativeAdIdentityOrMeasurement({
-      dependencySources: [],
-      nativeSources: [["native-event-sentinel.swift", "func postAdEvent() {}"]],
-    }),
-    /native-event-sentinel\.swift/,
-  );
+  for (const source of [
+    'client.post("/api/ads/events")',
+    'client.post("/api/" + "ads/events")',
+    'request.httpMethod = "POST"\nrequest.url = URL(string: "/api/ads/events")',
+    'Request.Builder().url("/api/ads/events").post(body)',
+  ]) {
+    assert.throws(
+      () => assertNoNativeAdIdentityOrMeasurement({
+        nativeSources: [["native-event-sentinel.swift", source]],
+      }),
+      /native-event-sentinel\.swift/,
+    );
+  }
+  for (const source of [
+    "func postAdEvent() {}",
+    'client.get("/api/ads/events")',
+  ]) {
+    assert.doesNotThrow(() => assertNoNativeAdIdentityOrMeasurement({
+      nativeSources: [["harmless-native-source.swift", source]],
+    }));
+  }
 
   const repositoryContract = read("tools/ci/repository-contract.test.mjs");
   const mobileJob = jobBlock(read(".github/workflows/ci.yml"), "mobile-app", "android");


### PR DESCRIPTION
## 관련 이슈

Closes #1943

Refs #1771 #1935 #1912 #1018 #1893 #1931

## 작업 배경

- #1938에서 자체 서빙 광고 renderer가 병합되어 앱에 실제 광고 지면이 생겼지만, 스토어 제출 계약에는 `ads: false`와 `광고 없음` 문구가 남아 있었습니다.
- Play Console·App Store Connect 답변이 실제 앱과 어긋나지 않도록 광고 포함 여부를 바로잡되, 현재 구현의 무추적·무계측 경계를 함께 고정해야 합니다.

## 작업 내용

- `apps/mobile/release/play-store-submission-content.json`: 광고 포함 여부를 `true`로 바꾸고 자체 서빙 비개인화 광고와 명시적 landing 진입 기준을 반영했습니다.
- `apps/mobile/release/store-privacy-inventory.json`: first-party self-served 광고 inventory를 추가하고 personalized advertising, AD_ID, third-party ad SDK, tracking, measurement event, 광고 목적 수집이 모두 없음을 명시했습니다.
- `apps/mobile/release/store-submission-readiness.json`: Play 광고 선언과 양 스토어 콘텐츠·연령 등급 증거를 실제 광고 renderer/request boundary에 연결했습니다.
- `tools/ci/repository-contract.test.mjs`: 광고 포함 선언과 무추적·무계측·무 SDK·무 AD_ID·무 event 경계를 함께 검증하는 계약 테스트를 추가했습니다.
- `backend/src/main/resources/templates/legal/privacy.html`은 수정하지 않았습니다. 이번 변경은 새 개인정보 수집을 추가하지 않는 스토어 제출 정합화이며, 공개 정책은 이미 이동 조건을 광고·추적 목적으로 사용하지 않고 광고 목적 tracking을 하지 않는다고 고지해 현재 무추적 자체 서빙 구현과 일치합니다.
- README와 CLAUDE.md는 수정하지 않았습니다.

## 검증

- RED: 새 store 계약 테스트를 먼저 적용했을 때 기존 `ads: false`, 광고 inventory 부재, `광고 없음` 콘텐츠 등급 문구 때문에 실패했습니다.
- GREEN: `node --test --test-name-pattern='자체 서빙 광고 store 계약' tools/ci/repository-contract.test.mjs` — 1/1 통과
- `node --test tools/ci/repository-contract.test.mjs` — 177/177 통과
- `node -e "...JSON.parse..."` — 변경 JSON 3개 파싱 통과
- `flutter test test/features/ads/ad_repository_test.dart` — 11/11 통과
- `flutter analyze` — 문제 없음
- `flutter test` — 1,034/1,034 통과
- `git diff --check origin/main...HEAD` 및 conflict marker 검사 — 통과
- `origin/main` 기준 1개 commit, 의도한 4개 파일만 변경됨을 확인했습니다.

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 스토어 광고·개인정보 계약 | 공통 | focused 및 전체 repository contract | 로컬 명령 출력: 1/1, 177/177 | 통과 |
| 광고 request 무계측 경계 | Flutter | 광고 repository test | 로컬 명령 출력: 11/11 | 통과 |
| 모바일 전체 회귀 | Flutter | analyze 및 전체 test | 로컬 명령 출력: analyze 0건, test 1,034/1,034 | 통과 |
| UI·접근성·수동 QA | 해당 없음 | runtime Dart/UI 변경 없음, JSON 3개와 계약 테스트 1개만 변경 | diff 4개 파일 | 증거 불필요 |
| 배포 | 해당 없음 | version·artifact·workflow·runtime 설정 변경 없음 | diff 감사 | 확인 대상 없음 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `ads: true` 선언과 동시에 `personalized`, `adId`, `thirdPartyAdSdk`, `tracking`, `measurementEvents`가 모두 `false`이고 `collectedDataTypeIds`가 빈 배열로 고정되는지 확인해 주세요.
- store readiness의 Play/App Store 문구가 자체 서빙 비개인화 광고와 사용자의 명시적 landing 진입만 설명하며, 광고 SDK나 event endpoint를 암시하지 않는지 확인해 주세요.

## 리스크

- 스토어 광고 포함 여부를 잘못 제출하면 심사 반려 또는 앱 동작과 제출 답변 불일치가 발생할 수 있습니다.
- 반대로 자체 서빙 광고를 일반 광고 SDK처럼 과대 신고하면 불필요한 AD_ID·tracking·데이터 수집 선언이 생길 수 있습니다. 계약 테스트가 양쪽 오신고를 함께 차단합니다.
- runtime UI, API, DB, version, deploy 동작은 변경하지 않습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 없음을 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 비개인화 광고가 앱에 포함됩니다.
  - 광고를 눌렀을 때만 외부 랜딩 페이지가 열립니다.
- **개인정보 보호**
  - 광고 식별자, 추적 및 광고 성과 측정을 사용하지 않습니다.
  - 제3자 광고 SDK 없이 광고를 제공합니다.
- **버그 수정**
  - 앱 스토어 제출 정보와 광고·개인정보 보호 관련 안내를 실제 앱 동작에 맞게 업데이트했습니다.
  - Android 및 iOS 출시 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->