### PR TITLE
[Backend] 광고 소재 운영 콘솔과 활성 lifecycle 추가 (#1947)

### DIFF
--- a/backend/src/main/java/com/easysubway/admin/audit/application/service/AdminAuditWriter.java
+++ b/backend/src/main/java/com/easysubway/admin/audit/application/service/AdminAuditWriter.java
@@ -103,7 +103,7 @@ public class AdminAuditWriter {
 		writeAudit(authentication, request, AdminAuditEventType.INCIDENT_CHANGE, "INCIDENT", targetId, action, outcome, reason);
 	}
 
-	public void datapackCommand(
+	public void adminAction(
 		Authentication authentication,
 		HttpServletRequest request,
 		String targetType,

--- a/backend/src/main/java/com/easysubway/admin/navigation/AdminProgram.java
+++ b/backend/src/main/java/com/easysubway/admin/navigation/AdminProgram.java
@@ -19,6 +19,7 @@ public enum AdminProgram {
 	CODES("a-codes", "운영·분석", "공통코드", "/admin/codes/page", AdminPermission.OPERATIONS_MANAGE),
 	INCIDENTS("a-incidents", "운영·분석", "장애관리", "/admin/incidents/page", AdminPermission.OPERATIONS_MANAGE),
 	SERVICE_NOTICES("a-service-notices", "운영·분석", "운행 공지", "/admin/notices/page", AdminPermission.OPERATIONS_MANAGE),
+	ADS("a-ads", "운영·분석", "광고 소재", "/admin/ads/page", AdminPermission.OPERATIONS_MANAGE),
 	ROUTE_SEARCHES("a-route-searches", "운영·분석", "경로 검색 분석", "/admin/routes/searches/page", AdminPermission.ADMIN_VIEW),
 	ROUTE_FEEDBACK("a-route-feedback", "운영·분석", "경로 피드백 분석", "/admin/routes/feedback/page", AdminPermission.ADMIN_VIEW),
 	DATAPACK_PIPELINE("a-datapack-pipeline", "데이터팩", "파이프라인 개요", "/admin/datapack/pipeline/page", AdminPermission.DATAPACK_READ),

--- a/backend/src/main/java/com/easysubway/ads/adapter/in/web/AdminAdsPageController.java
+++ b/backend/src/main/java/com/easysubway/ads/adapter/in/web/AdminAdsPageController.java
@@ -1,0 +1,137 @@
+package com.easysubway.ads.adapter.in.web;
+
+import com.easysubway.admin.audit.application.service.AdminAuditWriter;
+import com.easysubway.admin.audit.domain.AdminAuditOutcome;
+import com.easysubway.ads.application.service.AdService;
+import com.easysubway.ads.domain.AdCreative;
+import com.easysubway.common.error.InvalidRequestException;
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+@PreAuthorize("hasAuthority('admin.operations.manage')")
+class AdminAdsPageController {
+
+	private final AdService service;
+	private final AdminAuditWriter auditWriter;
+
+	AdminAdsPageController(AdService service, AdminAuditWriter auditWriter) {
+		this.service = service;
+		this.auditWriter = auditWriter;
+	}
+
+	@GetMapping("/admin/ads/page")
+	String page(Model model) {
+		model.addAttribute("creatives", service.creatives());
+		return "admin/ads/list";
+	}
+
+	@PostMapping("/admin/ads")
+	@Transactional
+	String save(
+		@ModelAttribute AdForm form,
+		Authentication authentication,
+		HttpServletRequest request
+	) {
+		String reason = cleanReason(form.reason());
+		AdCreative creative = form.toCreative();
+		AdService.SaveResult result = service.saveCreative(creative);
+		auditWriter.adminAction(
+			authentication, request, "AD_CREATIVE", creative.id(),
+			result == AdService.SaveResult.CREATED ? "CREATE_AD_CREATIVE" : "UPDATE_AD_CREATIVE",
+			AdminAuditOutcome.SUCCESS, reason);
+		return "redirect:/admin/ads/page";
+	}
+
+	@PostMapping("/admin/ads/{id}/enable")
+	@Transactional
+	String enable(
+		@PathVariable String id,
+		@RequestParam String reason,
+		Authentication authentication,
+		HttpServletRequest request
+	) {
+		return setEnabled(id, true, reason, authentication, request);
+	}
+
+	@PostMapping("/admin/ads/{id}/disable")
+	@Transactional
+	String disable(
+		@PathVariable String id,
+		@RequestParam String reason,
+		Authentication authentication,
+		HttpServletRequest request
+	) {
+		return setEnabled(id, false, reason, authentication, request);
+	}
+
+	private String setEnabled(
+		String id,
+		boolean enabled,
+		String reason,
+		Authentication authentication,
+		HttpServletRequest request
+	) {
+		reason = cleanReason(reason);
+		service.setCreativeEnabled(id, enabled);
+		auditWriter.adminAction(
+			authentication, request, "AD_CREATIVE", id,
+			enabled ? "ENABLE_AD_CREATIVE" : "DISABLE_AD_CREATIVE",
+			AdminAuditOutcome.SUCCESS, reason);
+		return "redirect:/admin/ads/page";
+	}
+
+	private static String cleanReason(String reason) {
+		if (reason == null || reason.isBlank()) {
+			throw new InvalidRequestException("변경 사유가 필요합니다.");
+		}
+		String cleaned = reason.trim();
+		if (cleaned.length() > 500) {
+			throw new InvalidRequestException("변경 사유는 500자 이하여야 합니다.");
+		}
+		return cleaned;
+	}
+
+	record AdForm(
+		String id,
+		String placementId,
+		String advertiserName,
+		String imageUrl,
+		String landingUrl,
+		String altText,
+		String startsAt,
+		String endsAt,
+		String reason
+	) {
+		AdCreative toCreative() {
+			return new AdCreative(
+				id, placementId, imageUrl, landingUrl, advertiserName, altText,
+				parseInstant(startsAt, "startsAt"), parseOptionalInstant(endsAt, "endsAt"), false);
+		}
+
+		private static LocalDateTime parseOptionalInstant(String value, String field) {
+			return value == null || value.isBlank() ? null : parseInstant(value, field);
+		}
+
+		private static LocalDateTime parseInstant(String value, String field) {
+			try {
+				return LocalDateTime.ofInstant(Instant.parse(value), ZoneOffset.UTC);
+			} catch (DateTimeParseException | NullPointerException exception) {
+				throw new InvalidRequestException(field + " 형식이 올바르지 않습니다.", exception);
+			}
+		}
+	}
+}

--- a/backend/src/main/java/com/easysubway/ads/adapter/out/persistence/JdbcAdRepository.java
+++ b/backend/src/main/java/com/easysubway/ads/adapter/out/persistence/JdbcAdRepository.java
@@ -7,6 +7,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import javax.sql.DataSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,7 +43,7 @@ class JdbcAdRepository implements AdRepository {
 		try {
 			return Optional.ofNullable(jdbcTemplate.queryForObject("""
 				SELECT c.id, c.placement_id, c.image_url, c.landing_url, c.advertiser_name,
-				       c.alt_text, c.starts_at, c.ends_at
+				       c.alt_text, c.starts_at, c.ends_at, c.enabled
 				FROM ad_creatives c
 				JOIN ad_placements p ON p.id = c.placement_id
 				WHERE c.placement_id = ?
@@ -56,6 +57,107 @@ class JdbcAdRepository implements AdRepository {
 		} catch (EmptyResultDataAccessException exception) {
 			return Optional.empty();
 		}
+	}
+
+	@Override
+	public List<AdCreative> findAll() {
+		return jdbcTemplate.query("""
+			SELECT id, placement_id, image_url, landing_url, advertiser_name,
+			       alt_text, starts_at, ends_at, enabled
+			FROM ad_creatives
+			ORDER BY placement_id, starts_at DESC, id
+			""", CREATIVE_ROW_MAPPER);
+	}
+
+	@Override
+	public Optional<AdCreative> findById(String creativeId) {
+		return findById(creativeId, "");
+	}
+
+	@Override
+	public Optional<AdCreative> findByIdForUpdate(String creativeId) {
+		return findById(creativeId, " FOR UPDATE");
+	}
+
+	private Optional<AdCreative> findById(String creativeId, String lockClause) {
+		try {
+			return Optional.ofNullable(jdbcTemplate.queryForObject("""
+				SELECT id, placement_id, image_url, landing_url, advertiser_name,
+				       alt_text, starts_at, ends_at, enabled
+				FROM ad_creatives
+				WHERE id = ?
+				""" + lockClause, CREATIVE_ROW_MAPPER, creativeId));
+		} catch (EmptyResultDataAccessException exception) {
+			return Optional.empty();
+		}
+	}
+
+	@Override
+	public void lockPlacement(String placementId) {
+		jdbcTemplate.queryForObject(
+			"SELECT id FROM ad_placements WHERE id = ? FOR UPDATE",
+			String.class,
+			placementId);
+	}
+
+	@Override
+	public void insert(AdCreative creative) {
+		insertCreative(creative);
+	}
+
+	@Override
+	public void save(AdCreative creative) {
+		if (updateCreative(creative) > 0) {
+			return;
+		}
+		insertCreative(creative);
+	}
+
+	private void insertCreative(AdCreative creative) {
+		jdbcTemplate.update("""
+			INSERT INTO ad_creatives (
+				id, placement_id, image_url, landing_url, advertiser_name,
+				alt_text, starts_at, ends_at, enabled
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+			""",
+			creative.id(), creative.placementId(), creative.imageUrl(), creative.landingUrl(),
+			creative.advertiserName(), creative.altText(), creative.startsAt(), creative.endsAt(), creative.enabled());
+	}
+
+	@Override
+	public boolean setEnabled(String creativeId, boolean enabled) {
+		return jdbcTemplate.update("UPDATE ad_creatives SET enabled = ? WHERE id = ?", enabled, creativeId) == 1;
+	}
+
+	@Override
+	public boolean hasEnabledOverlap(
+		String placementId,
+		String excludedCreativeId,
+		LocalDateTime startsAt,
+		LocalDateTime endsAt
+	) {
+		Long count;
+		if (endsAt == null) {
+			count = jdbcTemplate.queryForObject("""
+				SELECT COUNT(*)
+				FROM ad_creatives
+				WHERE placement_id = ?
+				  AND id <> ?
+				  AND enabled = TRUE
+				  AND (ends_at IS NULL OR ends_at > ?)
+				""", Long.class, placementId, excludedCreativeId, startsAt);
+		} else {
+			count = jdbcTemplate.queryForObject("""
+				SELECT COUNT(*)
+				FROM ad_creatives
+				WHERE placement_id = ?
+				  AND id <> ?
+				  AND enabled = TRUE
+				  AND starts_at < ?
+				  AND (ends_at IS NULL OR ends_at > ?)
+				""", Long.class, placementId, excludedCreativeId, endsAt, startsAt);
+		}
+		return count != null && count > 0;
 	}
 
 	@Override
@@ -124,6 +226,17 @@ class JdbcAdRepository implements AdRepository {
 		return dialect == null ? DatabaseDialect.POSTGRESQL : dialect;
 	}
 
+	private int updateCreative(AdCreative creative) {
+		return jdbcTemplate.update("""
+			UPDATE ad_creatives
+			SET placement_id = ?, image_url = ?, landing_url = ?, advertiser_name = ?,
+			    alt_text = ?, starts_at = ?, ends_at = ?, enabled = ?
+			WHERE id = ?
+			""",
+			creative.placementId(), creative.imageUrl(), creative.landingUrl(), creative.advertiserName(),
+			creative.altText(), creative.startsAt(), creative.endsAt(), creative.enabled(), creative.id());
+	}
+
 	private static AdCreative mapCreative(ResultSet resultSet, int rowNumber) throws SQLException {
 		return new AdCreative(
 			resultSet.getString("id"),
@@ -133,7 +246,8 @@ class JdbcAdRepository implements AdRepository {
 			resultSet.getString("advertiser_name"),
 			resultSet.getString("alt_text"),
 			resultSet.getTimestamp("starts_at").toLocalDateTime(),
-			resultSet.getTimestamp("ends_at") == null ? null : resultSet.getTimestamp("ends_at").toLocalDateTime());
+			resultSet.getTimestamp("ends_at") == null ? null : resultSet.getTimestamp("ends_at").toLocalDateTime(),
+			resultSet.getBoolean("enabled"));
 	}
 
 	private enum DatabaseDialect {

--- a/backend/src/main/java/com/easysubway/ads/application/port/out/AdRepository.java
+++ b/backend/src/main/java/com/easysubway/ads/application/port/out/AdRepository.java
@@ -4,11 +4,33 @@ import com.easysubway.ads.domain.AdCreative;
 import com.easysubway.ads.domain.AdEventType;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface AdRepository {
 
 	Optional<AdCreative> findActive(String placementId, LocalDateTime now);
+
+	List<AdCreative> findAll();
+
+	Optional<AdCreative> findById(String creativeId);
+
+	Optional<AdCreative> findByIdForUpdate(String creativeId);
+
+	void lockPlacement(String placementId);
+
+	void insert(AdCreative creative);
+
+	void save(AdCreative creative);
+
+	boolean setEnabled(String creativeId, boolean enabled);
+
+	boolean hasEnabledOverlap(
+		String placementId,
+		String excludedCreativeId,
+		LocalDateTime startsAt,
+		LocalDateTime endsAt
+	);
 
 	void incrementEvent(String placementId, String creativeId, AdEventType eventType, LocalDate eventDate);
 }

--- a/backend/src/main/java/com/easysubway/ads/application/service/AdService.java
+++ b/backend/src/main/java/com/easysubway/ads/application/service/AdService.java
@@ -199,6 +199,9 @@ public class AdService {
 		if (value == null || !CREATIVE_ID.matcher(value).matches()) {
 			throw new InvalidRequestException("creative id는 영문자, 숫자, 점, 밑줄, 하이픈 1~64자여야 합니다.");
 		}
+		if (".".equals(value) || "..".equals(value)) {
+			throw new InvalidRequestException("creative id는 URL dot-segment일 수 없습니다.");
+		}
 		return value;
 	}
 

--- a/backend/src/main/java/com/easysubway/ads/application/service/AdService.java
+++ b/backend/src/main/java/com/easysubway/ads/application/service/AdService.java
@@ -21,6 +21,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class AdService {
 
+	public enum SaveResult {
+		CREATED,
+		UPDATED
+	}
+
 	private static final List<String> PLACEMENTS = List.of("route-result-bottom", "station-detail-bottom");
 
 	private final AdRepository repository;
@@ -50,7 +55,7 @@ public class AdService {
 	}
 
 	@Transactional
-	public void saveCreative(AdCreative creative) {
+	public SaveResult saveCreative(AdCreative creative) {
 		AdCreative payload = validate(creative);
 		lockPlacements();
 		Optional<AdCreative> current = repository.findByIdForUpdate(payload.id());
@@ -74,6 +79,7 @@ public class AdService {
 		} catch (DuplicateKeyException exception) {
 			throw new InvalidRequestException("이미 존재하는 광고 creative id입니다.", exception);
 		}
+		return created ? SaveResult.CREATED : SaveResult.UPDATED;
 	}
 
 	@Transactional

--- a/backend/src/main/java/com/easysubway/ads/application/service/AdService.java
+++ b/backend/src/main/java/com/easysubway/ads/application/service/AdService.java
@@ -3,34 +3,198 @@ package com.easysubway.ads.application.service;
 import com.easysubway.ads.application.port.out.AdRepository;
 import com.easysubway.ads.domain.AdCreative;
 import com.easysubway.ads.domain.AdEventType;
+import com.easysubway.common.error.InvalidRequestException;
+import com.easysubway.common.error.ResourceNotFoundException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class AdService {
 
+	private static final List<String> PLACEMENTS = List.of("route-result-bottom", "station-detail-bottom");
+
 	private final AdRepository repository;
 	private final Clock clock;
+	private final String assetOrigin;
 
 	@Autowired
-	public AdService(AdRepository repository) {
-		this(repository, Clock.systemUTC());
+	public AdService(
+		AdRepository repository,
+		@Value("${easysubway.ads.asset-origin:}") String assetOrigin
+	) {
+		this(repository, Clock.systemUTC(), assetOrigin);
 	}
 
-	AdService(AdRepository repository, Clock clock) {
+	AdService(AdRepository repository, Clock clock, String assetOrigin) {
 		this.repository = repository;
 		this.clock = clock;
+		this.assetOrigin = assetOrigin;
 	}
 
 	public Optional<AdCreative> activeCreative(String placementId) {
 		return repository.findActive(placementId, LocalDateTime.now(clock));
 	}
 
+	public List<AdCreative> creatives() {
+		return repository.findAll();
+	}
+
+	@Transactional
+	public void saveCreative(AdCreative creative) {
+		AdCreative payload = validate(creative);
+		lockPlacements();
+		Optional<AdCreative> current = repository.findByIdForUpdate(payload.id());
+		AdCreative saved;
+		boolean created = current.isEmpty();
+		if (created) {
+			saved = withEnabled(payload, false);
+			if (repository.findById(saved.id()).isPresent()) {
+				throw duplicateCreative();
+			}
+		} else {
+			saved = withEnabled(payload, current.orElseThrow().enabled());
+			assertNoEnabledOverlap(saved);
+		}
+		try {
+			if (created) {
+				repository.insert(saved);
+			} else {
+				repository.save(saved);
+			}
+		} catch (DuplicateKeyException exception) {
+			throw new InvalidRequestException("이미 존재하는 광고 creative id입니다.", exception);
+		}
+	}
+
+	@Transactional
+	public void setCreativeEnabled(String creativeId, boolean enabled) {
+		String normalizedId = requireText(creativeId, 64, "creative id");
+		lockPlacements();
+		AdCreative creative = repository.findByIdForUpdate(normalizedId)
+			.orElseThrow(() -> new ResourceNotFoundException("광고 소재를 찾을 수 없습니다: " + normalizedId));
+		if (enabled) {
+			assertNoEnabledOverlap(withEnabled(validate(creative), true));
+		}
+		repository.setEnabled(normalizedId, enabled);
+	}
+
 	public void recordEvent(String placementId, String creativeId, AdEventType eventType) {
 		repository.incrementEvent(placementId, creativeId, eventType, LocalDate.now(clock));
+	}
+
+	private AdCreative validate(AdCreative creative) {
+		if (creative == null) {
+			throw new InvalidRequestException("광고 소재가 필요합니다.");
+		}
+		String id = requireText(creative.id(), 64, "creative id");
+		String placementId = requireText(creative.placementId(), 64, "placement id");
+		if (!PLACEMENTS.contains(placementId)) {
+			throw new InvalidRequestException("지원하지 않는 광고 placement입니다.");
+		}
+		String imageUrl = requireText(creative.imageUrl(), 1000, "image URL");
+		String landingUrl = requireText(creative.landingUrl(), 1000, "landing URL");
+		URI image = httpsUri(imageUrl, "image URL");
+		URI landing = httpsUri(landingUrl, "landing URL");
+		URI configuredOrigin = configuredAssetOrigin();
+		if (!sameOrigin(image, configuredOrigin)) {
+			throw new InvalidRequestException("image URL은 first-party asset origin을 사용해야 합니다.");
+		}
+		String advertiserName = requireText(creative.advertiserName(), 255, "광고주명");
+		String altText = requireText(creative.altText(), 500, "대체텍스트");
+		if (creative.startsAt() == null) {
+			throw new InvalidRequestException("광고 시작 시각이 필요합니다.");
+		}
+		if (creative.endsAt() != null && !creative.startsAt().isBefore(creative.endsAt())) {
+			throw new InvalidRequestException("광고 종료 시각은 시작 시각보다 늦어야 합니다.");
+		}
+		return new AdCreative(
+			id, placementId, image.toString(), landing.toString(), advertiserName, altText,
+			creative.startsAt(), creative.endsAt(), creative.enabled());
+	}
+
+	private URI configuredAssetOrigin() {
+		if (assetOrigin == null || assetOrigin.isBlank()) {
+			throw new IllegalStateException("광고 asset origin 설정이 필요합니다.");
+		}
+		URI origin;
+		try {
+			origin = new URI(assetOrigin.trim());
+		} catch (URISyntaxException exception) {
+			throw new IllegalStateException("광고 asset origin 형식이 올바르지 않습니다.", exception);
+		}
+		if (!"https".equalsIgnoreCase(origin.getScheme())
+			|| origin.getHost() == null
+			|| origin.getUserInfo() != null
+			|| (origin.getPath() != null && !origin.getPath().isEmpty() && !"/".equals(origin.getPath()))
+			|| origin.getQuery() != null
+			|| origin.getFragment() != null) {
+			throw new IllegalStateException("광고 asset origin은 HTTPS origin이어야 합니다.");
+		}
+		return origin;
+	}
+
+	private URI httpsUri(String value, String field) {
+		try {
+			URI uri = new URI(value);
+			if (!"https".equalsIgnoreCase(uri.getScheme()) || uri.getHost() == null || uri.getUserInfo() != null) {
+				throw new InvalidRequestException(field + "은(는) user info 없는 absolute HTTPS URL이어야 합니다.");
+			}
+			return uri;
+		} catch (URISyntaxException exception) {
+			throw new InvalidRequestException(field + " 형식이 올바르지 않습니다.", exception);
+		}
+	}
+
+	private boolean sameOrigin(URI left, URI right) {
+		return left.getScheme().equalsIgnoreCase(right.getScheme())
+			&& left.getHost().equalsIgnoreCase(right.getHost())
+			&& effectivePort(left) == effectivePort(right);
+	}
+
+	private int effectivePort(URI uri) {
+		return uri.getPort() == -1 ? 443 : uri.getPort();
+	}
+
+	private void assertNoEnabledOverlap(AdCreative creative) {
+		if (creative.enabled() && repository.hasEnabledOverlap(
+			creative.placementId(), creative.id(), creative.startsAt(), creative.endsAt())) {
+			throw new InvalidRequestException("같은 광고 placement의 활성 기간이 겹칩니다.");
+		}
+	}
+
+	private void lockPlacements() {
+		// ponytail: two fixed placements; narrow locks if admin mutation throughput ever matters
+		PLACEMENTS.forEach(repository::lockPlacement);
+	}
+
+	private AdCreative withEnabled(AdCreative creative, boolean enabled) {
+		return new AdCreative(
+			creative.id(), creative.placementId(), creative.imageUrl(), creative.landingUrl(),
+			creative.advertiserName(), creative.altText(), creative.startsAt(), creative.endsAt(), enabled);
+	}
+
+	private InvalidRequestException duplicateCreative() {
+		return new InvalidRequestException("이미 존재하는 광고 creative id입니다.");
+	}
+
+	private String requireText(String value, int maxLength, String field) {
+		if (value == null || value.isBlank()) {
+			throw new InvalidRequestException(field + "은(는) 필수입니다.");
+		}
+		String normalized = value.trim();
+		if (normalized.length() > maxLength) {
+			throw new InvalidRequestException(field + "은(는) " + maxLength + "자 이하여야 합니다.");
+		}
+		return normalized;
 	}
 }

--- a/backend/src/main/java/com/easysubway/ads/application/service/AdService.java
+++ b/backend/src/main/java/com/easysubway/ads/application/service/AdService.java
@@ -12,6 +12,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.regex.Pattern;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DuplicateKeyException;
@@ -27,6 +28,7 @@ public class AdService {
 	}
 
 	private static final List<String> PLACEMENTS = List.of("route-result-bottom", "station-detail-bottom");
+	private static final Pattern CREATIVE_ID = Pattern.compile("[A-Za-z0-9._-]{1,64}");
 
 	private final AdRepository repository;
 	private final Clock clock;
@@ -84,7 +86,7 @@ public class AdService {
 
 	@Transactional
 	public void setCreativeEnabled(String creativeId, boolean enabled) {
-		String normalizedId = requireText(creativeId, 64, "creative id");
+		String normalizedId = creativeId(creativeId);
 		lockPlacements();
 		AdCreative creative = repository.findByIdForUpdate(normalizedId)
 			.orElseThrow(() -> new ResourceNotFoundException("광고 소재를 찾을 수 없습니다: " + normalizedId));
@@ -102,7 +104,7 @@ public class AdService {
 		if (creative == null) {
 			throw new InvalidRequestException("광고 소재가 필요합니다.");
 		}
-		String id = requireText(creative.id(), 64, "creative id");
+		String id = creativeId(creative.id());
 		String placementId = requireText(creative.placementId(), 64, "placement id");
 		if (!PLACEMENTS.contains(placementId)) {
 			throw new InvalidRequestException("지원하지 않는 광고 placement입니다.");
@@ -191,6 +193,13 @@ public class AdService {
 
 	private InvalidRequestException duplicateCreative() {
 		return new InvalidRequestException("이미 존재하는 광고 creative id입니다.");
+	}
+
+	private String creativeId(String value) {
+		if (value == null || !CREATIVE_ID.matcher(value).matches()) {
+			throw new InvalidRequestException("creative id는 영문자, 숫자, 점, 밑줄, 하이픈 1~64자여야 합니다.");
+		}
+		return value;
 	}
 
 	private String requireText(String value, int maxLength, String field) {

--- a/backend/src/main/java/com/easysubway/ads/domain/AdCreative.java
+++ b/backend/src/main/java/com/easysubway/ads/domain/AdCreative.java
@@ -10,6 +10,7 @@ public record AdCreative(
 	String advertiserName,
 	String altText,
 	LocalDateTime startsAt,
-	LocalDateTime endsAt
+	LocalDateTime endsAt,
+	boolean enabled
 ) {
 }

--- a/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
@@ -187,7 +187,7 @@ public class SecurityConfig {
 					AdminPermission.DATAPACK_PRODUCTION_APPROVE.authority(),
 					AdminPermission.DATAPACK_ROLLBACK.authority()
 				)
-				.requestMatchers("/admin/codes/**", "/admin/incidents/**", "/admin/notices/**")
+				.requestMatchers("/admin/codes/**", "/admin/incidents/**", "/admin/notices/**", "/admin/ads/**")
 				.hasAuthority(AdminPermission.OPERATIONS_MANAGE.authority())
 				.requestMatchers("/admin/audits/privacy/**")
 				.hasAuthority(AdminPermission.PRIVACY_LOG_READ.authority())

--- a/backend/src/main/java/com/easysubway/datapack/adapter/in/web/AliasQuarantineAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/datapack/adapter/in/web/AliasQuarantineAdminPageController.java
@@ -97,7 +97,7 @@ class AliasQuarantineAdminPageController {
 		HttpServletRequest request
 	) {
 		commandService.reviewAlias(aliasId, form.toCommand("APPROVED", authentication.getName()));
-		auditWriter.datapackCommand(
+		auditWriter.adminAction(
 			authentication,
 			request,
 			"DATAPACK_ALIAS",
@@ -134,7 +134,7 @@ class AliasQuarantineAdminPageController {
 		HttpServletRequest request
 	) {
 		commandService.reviewAlias(aliasId, form.toCommand("REJECTED", authentication.getName()));
-		auditWriter.datapackCommand(
+		auditWriter.adminAction(
 			authentication,
 			request,
 			"DATAPACK_ALIAS",
@@ -155,7 +155,7 @@ class AliasQuarantineAdminPageController {
 		HttpServletRequest request
 	) {
 		commandService.resolveQuarantine(recordId, form.toCommand(authentication.getName()));
-		auditWriter.datapackCommand(
+		auditWriter.adminAction(
 			authentication,
 			request,
 			"DATAPACK_QUARANTINE",

--- a/backend/src/main/java/com/easysubway/datapack/adapter/in/web/DataSourceSnapshotAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/datapack/adapter/in/web/DataSourceSnapshotAdminPageController.java
@@ -108,7 +108,7 @@ class DataSourceSnapshotAdminPageController {
 		HttpServletRequest request
 	) {
 		normalizationRunCommandService.requestRun(snapshotId, form.toCommand());
-		auditWriter.datapackCommand(
+		auditWriter.adminAction(
 			authentication,
 			request,
 			"DATAPACK_NORMALIZATION_RUN",

--- a/backend/src/main/java/com/easysubway/datapack/adapter/in/web/DatapackCandidateAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/datapack/adapter/in/web/DatapackCandidateAdminPageController.java
@@ -97,7 +97,7 @@ class DatapackCandidateAdminPageController {
 		HttpServletRequest request
 	) {
 		commandService.rerunGates(candidateId, form.toCommand());
-		auditWriter.datapackCommand(
+		auditWriter.adminAction(
 			authentication,
 			request,
 			"DATAPACK_CANDIDATE",

--- a/backend/src/main/java/com/easysubway/datapack/adapter/in/web/FacilityEvidenceAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/datapack/adapter/in/web/FacilityEvidenceAdminPageController.java
@@ -81,7 +81,7 @@ class FacilityEvidenceAdminPageController {
 		HttpServletRequest request
 	) {
 		commandService.reviewEvidence(evidenceId, form.toCommand());
-		auditWriter.datapackCommand(
+		auditWriter.adminAction(
 			authentication,
 			request,
 			"DATAPACK_FACILITY_EVIDENCE",

--- a/backend/src/main/java/com/easysubway/datapack/adapter/in/web/ManualOverrideLedgerAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/datapack/adapter/in/web/ManualOverrideLedgerAdminPageController.java
@@ -81,7 +81,7 @@ class ManualOverrideLedgerAdminPageController {
 		HttpServletRequest request
 	) {
 		commandService.request(form.toCommand(authentication.getName()));
-		auditWriter.datapackCommand(
+		auditWriter.adminAction(
 			authentication,
 			request,
 			"DATAPACK_MANUAL_OVERRIDE",
@@ -129,7 +129,7 @@ class ManualOverrideLedgerAdminPageController {
 		HttpServletRequest request
 	) {
 		commandService.approve(overrideId, form.toCommand(authentication.getName()));
-		auditWriter.datapackCommand(
+		auditWriter.adminAction(
 			authentication,
 			request,
 			"DATAPACK_MANUAL_OVERRIDE",
@@ -150,7 +150,7 @@ class ManualOverrideLedgerAdminPageController {
 		HttpServletRequest request
 	) {
 		commandService.expire(overrideId, form.toCommand(authentication.getName()));
-		auditWriter.datapackCommand(
+		auditWriter.adminAction(
 			authentication,
 			request,
 			"DATAPACK_MANUAL_OVERRIDE",

--- a/backend/src/main/resources/db/migration/h2/V48__ad_placements_seed.sql
+++ b/backend/src/main/resources/db/migration/h2/V48__ad_placements_seed.sql
@@ -1,0 +1,8 @@
+-- #1947 관리자 광고 소재 lifecycle에서 사용하는 고정 placement(h2 test dialect).
+INSERT INTO ad_placements (id, display_name, enabled)
+SELECT 'route-result-bottom', '경로 결과 하단', TRUE
+WHERE NOT EXISTS (SELECT 1 FROM ad_placements WHERE id = 'route-result-bottom');
+
+INSERT INTO ad_placements (id, display_name, enabled)
+SELECT 'station-detail-bottom', '역 상세 하단', TRUE
+WHERE NOT EXISTS (SELECT 1 FROM ad_placements WHERE id = 'station-detail-bottom');

--- a/backend/src/main/resources/db/migration/postgresql/V48__ad_placements_seed.sql
+++ b/backend/src/main/resources/db/migration/postgresql/V48__ad_placements_seed.sql
@@ -1,0 +1,5 @@
+-- #1947 관리자 광고 소재 lifecycle에서 사용하는 고정 placement.
+INSERT INTO ad_placements (id, display_name, enabled)
+VALUES ('route-result-bottom', '경로 결과 하단', TRUE),
+       ('station-detail-bottom', '역 상세 하단', TRUE)
+ON CONFLICT (id) DO NOTHING;

--- a/backend/src/main/resources/templates/admin/ads/list.html
+++ b/backend/src/main/resources/templates/admin/ads/list.html
@@ -1,0 +1,102 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>광고 소재</title>
+	<link rel="stylesheet" th:href="@{/css/admin-v3.css}">
+</head>
+<body class="admin-v3">
+<a th:replace="~{admin/fragments/shell :: skipLink}"></a>
+<div class="admin-shell">
+<div th:replace="~{admin/fragments/shell :: sidebar('a-ads')}"></div>
+<main class="admin-main">
+	<div th:replace="~{admin/fragments/shell :: topbar}"></div>
+	<div th:replace="~{admin/fragments/shell :: contentStart}"></div>
+	<header class="admin-page-head">
+		<div>
+			<h1>광고 소재</h1>
+			<p>경로 결과와 역 상세 하단에 노출할 광고 소재를 등록하고 활성화합니다.</p>
+		</div>
+	</header>
+
+	<section class="admin-panel" aria-labelledby="ad-form-title">
+		<h2 id="ad-form-title">소재 등록·수정</h2>
+		<form method="post" th:action="@{/admin/ads}">
+			<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+			<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
+			<label for="creative-id">Creative ID</label>
+			<input id="creative-id" name="id" required maxlength="64">
+			<label for="placement-id">노출 위치</label>
+			<select id="placement-id" name="placementId" required>
+				<option value="route-result-bottom">경로 결과 하단</option>
+				<option value="station-detail-bottom">역 상세 하단</option>
+			</select>
+			<label for="advertiser-name">광고주</label>
+			<input id="advertiser-name" name="advertiserName" required maxlength="255">
+			<label for="image-url">이미지 URL</label>
+			<input id="image-url" name="imageUrl" type="url" required maxlength="1000">
+			<label for="landing-url">랜딩 URL</label>
+			<input id="landing-url" name="landingUrl" type="url" required maxlength="1000">
+			<label for="alt-text">대체텍스트</label>
+			<textarea id="alt-text" name="altText" required maxlength="500" rows="2"></textarea>
+			<label for="starts-at">시작 시각(UTC Instant)</label>
+			<input id="starts-at" name="startsAt" required placeholder="2026-07-11T00:00:00Z">
+			<label for="ends-at">종료 시각(UTC Instant)</label>
+			<input id="ends-at" name="endsAt" placeholder="2026-07-12T00:00:00Z">
+			<label for="save-reason">변경 사유</label>
+			<input id="save-reason" name="reason" required maxlength="500">
+			<button type="submit">저장</button>
+		</form>
+	</section>
+
+	<section class="admin-panel" aria-labelledby="ad-list-title">
+		<h2 id="ad-list-title">등록 소재</h2>
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">Creative ID</th>
+				<th scope="col">노출 위치</th>
+				<th scope="col">광고주</th>
+				<th scope="col">이미지</th>
+				<th scope="col">랜딩</th>
+				<th scope="col">대체텍스트</th>
+				<th scope="col">시작</th>
+				<th scope="col">종료</th>
+				<th scope="col">상태·액션</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:if="${creatives.isEmpty()}">
+				<td colspan="9">등록된 광고 소재가 없습니다.</td>
+			</tr>
+			<tr th:each="creative : ${creatives}">
+				<th scope="row" th:text="${creative.id}">creative-id</th>
+				<td th:text="${creative.placementId}">route-result-bottom</td>
+				<td th:text="${creative.advertiserName}">광고주</td>
+				<td><a th:href="${creative.imageUrl}" rel="noopener noreferrer"
+				       th:aria-label="${creative.id + ' ' + creative.advertiserName + ' 이미지 열기'}">이미지 열기</a></td>
+				<td><a th:href="${creative.landingUrl}" rel="noopener noreferrer"
+				       th:aria-label="${creative.id + ' ' + creative.advertiserName + ' 랜딩 페이지 열기'}">랜딩 열기</a></td>
+				<td th:text="${creative.altText}">대체텍스트</td>
+				<td th:text="${creative.startsAt}">2026-07-11T00:00</td>
+				<td th:text="${creative.endsAt != null ? creative.endsAt : '-'}">-</td>
+				<td>
+					<span th:text="${creative.enabled ? '활성' : '비활성'}">비활성</span>
+					<form method="post"
+					      th:action="${creative.enabled} ? @{/admin/ads/{id}/disable(id=${creative.id})} : @{/admin/ads/{id}/enable(id=${creative.id})}">
+						<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+						<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
+						<label>변경 사유 <input name="reason" required maxlength="500"></label>
+						<button type="submit" th:text="${creative.enabled ? '비활성화' : '활성화'}">활성화</button>
+					</form>
+				</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+</main>
+</div>
+<th:block th:replace="~{admin/fragments/shell :: scripts}"></th:block>
+</body>
+</html>

--- a/backend/src/main/resources/templates/admin/ads/list.html
+++ b/backend/src/main/resources/templates/admin/ads/list.html
@@ -26,7 +26,7 @@
 			<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 			<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 			<label for="creative-id">Creative ID</label>
-			<input id="creative-id" name="id" required maxlength="64" pattern="[A-Za-z0-9._-]{1,64}">
+			<input id="creative-id" name="id" required maxlength="64" pattern="(?!\.{1,2}$)[A-Za-z0-9._-]{1,64}">
 			<label for="placement-id">노출 위치</label>
 			<select id="placement-id" name="placementId" required>
 				<option value="route-result-bottom">경로 결과 하단</option>

--- a/backend/src/main/resources/templates/admin/ads/list.html
+++ b/backend/src/main/resources/templates/admin/ads/list.html
@@ -26,7 +26,7 @@
 			<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 			<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 			<label for="creative-id">Creative ID</label>
-			<input id="creative-id" name="id" required maxlength="64" pattern="(?!\.{1,2}$)[A-Za-z0-9._-]{1,64}">
+			<input id="creative-id" name="id" required maxlength="64" pattern="(?!\.{1,2}$)[A-Za-z0-9._\-]{1,64}">
 			<label for="placement-id">노출 위치</label>
 			<select id="placement-id" name="placementId" required>
 				<option value="route-result-bottom">경로 결과 하단</option>

--- a/backend/src/main/resources/templates/admin/ads/list.html
+++ b/backend/src/main/resources/templates/admin/ads/list.html
@@ -26,7 +26,7 @@
 			<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 			<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 			<label for="creative-id">Creative ID</label>
-			<input id="creative-id" name="id" required maxlength="64">
+			<input id="creative-id" name="id" required maxlength="64" pattern="[A-Za-z0-9._-]{1,64}">
 			<label for="placement-id">노출 위치</label>
 			<select id="placement-id" name="placementId" required>
 				<option value="route-result-bottom">경로 결과 하단</option>

--- a/backend/src/test/java/com/easysubway/ads/adapter/in/web/AdminAdsPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/ads/adapter/in/web/AdminAdsPageControllerTest.java
@@ -95,7 +95,7 @@ class AdminAdsPageControllerTest {
 		assertThat(html)
 			.contains("<h1>광고 소재</h1>")
 			.contains("for=\"creative-id\"")
-			.contains("pattern=\"(?!\\.{1,2}$)[A-Za-z0-9._-]{1,64}\"")
+			.contains("pattern=\"(?!\\.{1,2}$)[A-Za-z0-9._\\-]{1,64}\"")
 			.contains("for=\"placement-id\"")
 			.contains("for=\"advertiser-name\"")
 			.contains("for=\"image-url\"")
@@ -112,11 +112,6 @@ class AdminAdsPageControllerTest {
 			.contains("/admin/ads/disabled-ad/enable")
 			.contains("/admin/ads/enabled-ad/disable")
 			.doesNotContain("event_count", "/api/ads/events", "노출 수", "클릭 수");
-		var formPattern = Pattern.compile("(?!\\.{1,2}$)[A-Za-z0-9._-]{1,64}");
-		assertThat(formPattern.matcher(".").matches()).isFalse();
-		assertThat(formPattern.matcher("..").matches()).isFalse();
-		assertThat(formPattern.matcher(".banner").matches()).isTrue();
-		assertThat(formPattern.matcher("a..b").matches()).isTrue();
 		assertThat(count(html, "name=\"commandToken\"")).isEqualTo(3);
 		assertThat(count(html, "name=\"_csrf\"")).isGreaterThanOrEqualTo(3);
 	}

--- a/backend/src/test/java/com/easysubway/ads/adapter/in/web/AdminAdsPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/ads/adapter/in/web/AdminAdsPageControllerTest.java
@@ -95,6 +95,7 @@ class AdminAdsPageControllerTest {
 		assertThat(html)
 			.contains("<h1>광고 소재</h1>")
 			.contains("for=\"creative-id\"")
+			.contains("pattern=\"[A-Za-z0-9._-]{1,64}\"")
 			.contains("for=\"placement-id\"")
 			.contains("for=\"advertiser-name\"")
 			.contains("for=\"image-url\"")
@@ -209,21 +210,24 @@ class AdminAdsPageControllerTest {
 	@DisplayName("admin create·enable 소재는 public ETag 응답 후 disable 시 204로 사라진다")
 	void adminLifecycleControlsPublicCreative() throws Exception {
 		MockHttpSession session = new MockHttpSession();
+		String id = "route.A_1-";
 		postCreative(
-			session, "creative-1", "광고주", "공개 광고 등록",
+			session, id, "광고주", "공개 광고 등록",
 			"2000-01-01T00:00:00Z", "")
 			.andExpect(status().is3xxRedirection());
-		AdCreative created = repository.findById("creative-1").orElseThrow();
+		AdCreative created = repository.findById(id).orElseThrow();
 		assertThat(created.startsAt()).isEqualTo(LocalDateTime.parse("2000-01-01T00:00:00"));
 		assertThat(created.endsAt()).isNull();
-		postState(session, "enable", "공개 시작")
+		String enableAction = "/admin/ads/" + id + "/enable";
+		assertThat(getAdsHtml(session)).contains("action=\"" + enableAction + "\"");
+		postState(session, enableAction, "공개 시작")
 			.andExpect(status().is3xxRedirection());
 
 		mockMvc.perform(get("/api/ads/active").param("placement", "route-result-bottom"))
 			.andExpect(status().isOk())
 			.andExpect(header().exists("ETag"));
 
-		postState(session, "disable", "공개 종료")
+		postState(session, "/admin/ads/" + id + "/disable", "공개 종료")
 			.andExpect(status().is3xxRedirection());
 		mockMvc.perform(get("/api/ads/active").param("placement", "route-result-bottom"))
 			.andExpect(status().isNoContent());
@@ -278,7 +282,8 @@ class AdminAdsPageControllerTest {
 		String action,
 		String reason
 	) throws Exception {
-		return mockMvc.perform(post("/admin/ads/creative-1/" + action)
+		String path = action.startsWith("/") ? action : "/admin/ads/creative-1/" + action;
+		return mockMvc.perform(post(path)
 			.session(session)
 			.with(csrf())
 			.with(commandToken(session))

--- a/backend/src/test/java/com/easysubway/ads/adapter/in/web/AdminAdsPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/ads/adapter/in/web/AdminAdsPageControllerTest.java
@@ -1,0 +1,349 @@
+package com.easysubway.ads.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.easysubway.admin.audit.adapter.out.persistence.InMemoryAdminAuditEventRepository;
+import com.easysubway.admin.audit.domain.AdminAuditEvent;
+import com.easysubway.admin.audit.domain.AdminAuditEventType;
+import com.easysubway.ads.application.port.out.AdRepository;
+import com.easysubway.ads.domain.AdCreative;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+@SpringBootTest(properties = "easysubway.ads.asset-origin=https://assets.easysubway.example")
+@AutoConfigureMockMvc
+@DisplayName("관리자 광고 소재 화면")
+class AdminAdsPageControllerTest {
+
+	private static final LocalDateTime T0 = LocalDateTime.parse("2026-07-11T00:00:00");
+
+	@Autowired
+	private MockMvc mockMvc;
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+	@Autowired
+	private AdRepository repository;
+	@Autowired
+	private InMemoryAdminAuditEventRepository auditEventRepository;
+
+	@BeforeEach
+	void setUp() {
+		jdbcTemplate.update("DELETE FROM ad_event_daily");
+		jdbcTemplate.update("DELETE FROM ad_creatives");
+		jdbcTemplate.update("""
+			MERGE INTO ad_placements (id, display_name, enabled) KEY(id) VALUES
+			('route-result-bottom', '경로 결과 하단', TRUE),
+			('station-detail-bottom', '역 상세 하단', TRUE)
+			""");
+	}
+
+	@Test
+	@DisplayName("운영 권한만 광고 화면에 접근하고 navigation에서 광고 메뉴를 본다")
+	void adsPageRequiresOperationsManage() throws Exception {
+		RequestPostProcessor viewer = user("viewer")
+			.authorities(new SimpleGrantedAuthority("admin.view"));
+		PreAuthorize permission = AdminAdsPageController.class.getAnnotation(PreAuthorize.class);
+		assertThat(permission).isNotNull();
+		assertThat(permission.value())
+			.isEqualTo("hasAuthority('admin.operations.manage')");
+
+		mockMvc.perform(get("/admin/ads/page").with(viewer))
+			.andExpect(status().isForbidden());
+		mockMvc.perform(post("/admin/ads")
+				.with(csrf())
+				.with(viewer)
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED))
+			.andExpect(status().isForbidden());
+		String viewerDashboard = mockMvc.perform(get("/admin/dashboard/page").with(viewer))
+			.andExpect(status().isOk())
+			.andReturn().getResponse().getContentAsString();
+		assertThat(viewerDashboard).doesNotContain("/admin/ads/page");
+
+		String operationsPage = getAdsHtml(new MockHttpSession());
+		assertThat(operationsPage).contains("href=\"/admin/ads/page\"");
+	}
+
+	@Test
+	@DisplayName("목록과 단일 upsert form은 접근 가능한 labels와 보호 토큰을 렌더링한다")
+	void rendersCreativeListAndProtectedForms() throws Exception {
+		repository.save(creative("disabled-ad", "route-result-bottom", "비활성 광고주", false));
+		repository.save(creative("enabled-ad", "station-detail-bottom", "활성 광고주", true));
+
+		String html = getAdsHtml(new MockHttpSession());
+
+		assertThat(html)
+			.contains("<h1>광고 소재</h1>")
+			.contains("for=\"creative-id\"")
+			.contains("for=\"placement-id\"")
+			.contains("for=\"advertiser-name\"")
+			.contains("for=\"image-url\"")
+			.contains("for=\"landing-url\"")
+			.contains("for=\"alt-text\"")
+			.contains("for=\"starts-at\"")
+			.contains("for=\"ends-at\"")
+			.contains("scope=\"col\"")
+			.contains("비활성 광고주")
+			.contains("활성 광고주")
+			.contains("<th scope=\"row\">disabled-ad</th>")
+			.contains("aria-label=\"disabled-ad 비활성 광고주 이미지 열기\"")
+			.contains("aria-label=\"disabled-ad 비활성 광고주 랜딩 페이지 열기\"")
+			.contains("/admin/ads/disabled-ad/enable")
+			.contains("/admin/ads/enabled-ad/disable")
+			.doesNotContain("event_count", "/api/ads/events", "노출 수", "클릭 수");
+		assertThat(count(html, "name=\"commandToken\"")).isEqualTo(3);
+		assertThat(count(html, "name=\"_csrf\"")).isGreaterThanOrEqualTo(3);
+	}
+
+	@Test
+	@DisplayName("valid upsert는 UTC instant를 저장하고 PRG와 ADMIN_ACTION audit을 남긴다")
+	void upsertsCreativeAndAudits() throws Exception {
+		MockHttpSession session = new MockHttpSession();
+
+		postCreative(session, "광고주", "  최초 등록  ")
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl("/admin/ads/page"));
+		AdCreative created = repository.findById("creative-1").orElseThrow();
+		assertThat(created.advertiserName()).isEqualTo("광고주");
+		assertThat(created.startsAt()).isEqualTo(T0);
+		assertThat(created.enabled()).isFalse();
+		assertThat(auditRecorded("CREATE_AD_CREATIVE", "creative-1", "최초 등록")).isTrue();
+
+		postCreative(session, "수정 광고주", "문구 수정")
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl("/admin/ads/page"));
+		assertThat(repository.findById("creative-1").orElseThrow().advertiserName()).isEqualTo("수정 광고주");
+		assertThat(auditRecorded("UPDATE_AD_CREATIVE", "creative-1", "문구 수정")).isTrue();
+	}
+
+	@Test
+	@DisplayName("enable과 disable은 상태를 바꾸고 각각 audit을 남긴다")
+	void enablesAndDisablesCreativeWithAudit() throws Exception {
+		repository.save(creative("creative-1", "route-result-bottom", "광고주", false));
+		MockHttpSession session = new MockHttpSession();
+
+		postState(session, "enable", "캠페인 시작")
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl("/admin/ads/page"));
+		assertThat(repository.findById("creative-1").orElseThrow().enabled()).isTrue();
+		assertThat(auditRecorded("ENABLE_AD_CREATIVE", "creative-1", "캠페인 시작")).isTrue();
+
+		postState(session, "disable", "캠페인 종료")
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl("/admin/ads/page"));
+		assertThat(repository.findById("creative-1").orElseThrow().enabled()).isFalse();
+		assertThat(auditRecorded("DISABLE_AD_CREATIVE", "creative-1", "캠페인 종료")).isTrue();
+	}
+
+	@Test
+	@DisplayName("잘못된 instant는 400이고 CSRF와 command token 없는 POST는 거부한다")
+	void rejectsInvalidInstantAndUnprotectedPosts() throws Exception {
+		MockHttpSession session = new MockHttpSession();
+		mockMvc.perform(post("/admin/ads")
+				.session(session)
+				.with(csrf())
+				.with(commandToken(session))
+				.with(operationsManager())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("id", "invalid-time")
+				.param("placementId", "route-result-bottom")
+				.param("advertiserName", "광고주")
+				.param("imageUrl", "https://assets.easysubway.example/ads/invalid.png")
+				.param("landingUrl", "https://partner.example/invalid")
+				.param("altText", "광고 대체텍스트")
+				.param("startsAt", "not-an-instant")
+				.param("endsAt", "")
+				.param("reason", "잘못된 시각 검증"))
+			.andExpect(status().isBadRequest());
+		assertThat(repository.findById("invalid-time")).isEmpty();
+
+		mockMvc.perform(post("/admin/ads/creative-1/enable")
+				.with(operationsManager())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("reason", "보호 누락"))
+			.andExpect(status().isForbidden());
+
+		mockMvc.perform(post("/admin/ads/creative-1/enable")
+				.with(csrf())
+				.with(operationsManager())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("reason", "token 누락"))
+			.andExpect(status().isConflict());
+	}
+
+	@Test
+	@DisplayName("blank 또는 500자 초과 reason은 mutation과 audit 전에 400으로 거부한다")
+	void rejectsInvalidReasonsBeforeMutationAndAudit() throws Exception {
+		MockHttpSession session = new MockHttpSession();
+		for (String reason : List.of(" ", "x".repeat(501))) {
+			postCreative(session, "invalid-reason", "광고주", reason)
+				.andExpect(status().isBadRequest());
+		}
+
+		assertThat(repository.findById("invalid-reason")).isEmpty();
+		assertThat(auditRecorded("CREATE_AD_CREATIVE", "invalid-reason", null)).isFalse();
+		assertThat(auditRecorded("UPDATE_AD_CREATIVE", "invalid-reason", null)).isFalse();
+	}
+
+	@Test
+	@DisplayName("admin create·enable 소재는 public ETag 응답 후 disable 시 204로 사라진다")
+	void adminLifecycleControlsPublicCreative() throws Exception {
+		MockHttpSession session = new MockHttpSession();
+		postCreative(
+			session, "creative-1", "광고주", "공개 광고 등록",
+			"2000-01-01T00:00:00Z", "")
+			.andExpect(status().is3xxRedirection());
+		AdCreative created = repository.findById("creative-1").orElseThrow();
+		assertThat(created.startsAt()).isEqualTo(LocalDateTime.parse("2000-01-01T00:00:00"));
+		assertThat(created.endsAt()).isNull();
+		postState(session, "enable", "공개 시작")
+			.andExpect(status().is3xxRedirection());
+
+		mockMvc.perform(get("/api/ads/active").param("placement", "route-result-bottom"))
+			.andExpect(status().isOk())
+			.andExpect(header().exists("ETag"));
+
+		postState(session, "disable", "공개 종료")
+			.andExpect(status().is3xxRedirection());
+		mockMvc.perform(get("/api/ads/active").param("placement", "route-result-bottom"))
+			.andExpect(status().isNoContent());
+	}
+
+	private org.springframework.test.web.servlet.ResultActions postCreative(
+		MockHttpSession session,
+		String advertiserName,
+		String reason
+	) throws Exception {
+		return postCreative(session, "creative-1", advertiserName, reason);
+	}
+
+	private org.springframework.test.web.servlet.ResultActions postCreative(
+		MockHttpSession session,
+		String id,
+		String advertiserName,
+		String reason
+	) throws Exception {
+		return postCreative(
+			session, id, advertiserName, reason,
+			"2026-07-11T00:00:00Z", "2026-07-12T00:00:00Z");
+	}
+
+	private org.springframework.test.web.servlet.ResultActions postCreative(
+		MockHttpSession session,
+		String id,
+		String advertiserName,
+		String reason,
+		String startsAt,
+		String endsAt
+	) throws Exception {
+		return mockMvc.perform(post("/admin/ads")
+			.session(session)
+			.with(csrf())
+			.with(commandToken(session))
+			.with(operationsManager())
+			.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+			.param("id", id)
+			.param("placementId", "route-result-bottom")
+			.param("advertiserName", advertiserName)
+			.param("imageUrl", "https://assets.easysubway.example/ads/" + id + ".png")
+			.param("landingUrl", "https://partner.example/" + id)
+			.param("altText", "광고 대체텍스트")
+			.param("startsAt", startsAt)
+			.param("endsAt", endsAt)
+			.param("reason", reason));
+	}
+
+	private org.springframework.test.web.servlet.ResultActions postState(
+		MockHttpSession session,
+		String action,
+		String reason
+	) throws Exception {
+		return mockMvc.perform(post("/admin/ads/creative-1/" + action)
+			.session(session)
+			.with(csrf())
+			.with(commandToken(session))
+			.with(operationsManager())
+			.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+			.param("reason", reason));
+	}
+
+	private AdCreative creative(String id, String placementId, String advertiser, boolean enabled) {
+		return new AdCreative(
+			id,
+			placementId,
+			"https://assets.easysubway.example/ads/" + id + ".png",
+			"https://partner.example/" + id,
+			advertiser,
+			advertiser + " 대체텍스트",
+			T0,
+			T0.plusDays(1),
+			enabled);
+	}
+
+	private boolean auditRecorded(String action, String targetId, String reason) {
+		List<AdminAuditEvent> events = auditEventRepository.findRecent(AdminAuditEventType.ADMIN_ACTION, 100);
+		return events.stream().anyMatch(event ->
+			"AD_CREATIVE".equals(event.targetType())
+				&& action.equals(event.action())
+				&& targetId.equals(event.targetId())
+				&& "operator".equals(event.actor())
+				&& "admin.operations.manage".equals(event.rolePermission())
+				&& com.easysubway.admin.audit.domain.AdminAuditOutcome.SUCCESS == event.outcome()
+				&& (reason == null || reason.equals(event.reason())));
+	}
+
+	private RequestPostProcessor operationsManager() {
+		return user("operator").authorities(new SimpleGrantedAuthority("admin.operations.manage"));
+	}
+
+	private RequestPostProcessor commandToken(MockHttpSession session) {
+		return request -> {
+			request.addParameter("commandToken", commandTokenFrom(getAdsHtml(session)));
+			return request;
+		};
+	}
+
+	private String getAdsHtml(MockHttpSession session) {
+		try {
+			return mockMvc.perform(get("/admin/ads/page")
+					.session(session)
+					.with(operationsManager()))
+				.andExpect(status().isOk())
+				.andReturn().getResponse().getContentAsString();
+		} catch (Exception exception) {
+			throw new IllegalStateException(exception);
+		}
+	}
+
+	private static String commandTokenFrom(String html) {
+		var matcher = Pattern.compile("name=\"commandToken\" value=\"([^\"]+)\"").matcher(html);
+		if (!matcher.find()) {
+			throw new IllegalStateException("commandToken missing");
+		}
+		return matcher.group(1);
+	}
+
+	private static int count(String value, String needle) {
+		return (value.length() - value.replace(needle, "").length()) / needle.length();
+	}
+}

--- a/backend/src/test/java/com/easysubway/ads/adapter/in/web/AdminAdsPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/ads/adapter/in/web/AdminAdsPageControllerTest.java
@@ -95,7 +95,7 @@ class AdminAdsPageControllerTest {
 		assertThat(html)
 			.contains("<h1>광고 소재</h1>")
 			.contains("for=\"creative-id\"")
-			.contains("pattern=\"[A-Za-z0-9._-]{1,64}\"")
+			.contains("pattern=\"(?!\\.{1,2}$)[A-Za-z0-9._-]{1,64}\"")
 			.contains("for=\"placement-id\"")
 			.contains("for=\"advertiser-name\"")
 			.contains("for=\"image-url\"")
@@ -112,6 +112,11 @@ class AdminAdsPageControllerTest {
 			.contains("/admin/ads/disabled-ad/enable")
 			.contains("/admin/ads/enabled-ad/disable")
 			.doesNotContain("event_count", "/api/ads/events", "노출 수", "클릭 수");
+		var formPattern = Pattern.compile("(?!\\.{1,2}$)[A-Za-z0-9._-]{1,64}");
+		assertThat(formPattern.matcher(".").matches()).isFalse();
+		assertThat(formPattern.matcher("..").matches()).isFalse();
+		assertThat(formPattern.matcher(".banner").matches()).isTrue();
+		assertThat(formPattern.matcher("a..b").matches()).isTrue();
 		assertThat(count(html, "name=\"commandToken\"")).isEqualTo(3);
 		assertThat(count(html, "name=\"_csrf\"")).isGreaterThanOrEqualTo(3);
 	}

--- a/backend/src/test/java/com/easysubway/ads/adapter/out/persistence/JdbcAdRepositoryContainerTest.java
+++ b/backend/src/test/java/com/easysubway/ads/adapter/out/persistence/JdbcAdRepositoryContainerTest.java
@@ -1,0 +1,388 @@
+package com.easysubway.ads.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.easysubway.ads.application.service.AdService;
+import com.easysubway.ads.domain.AdCreative;
+import com.easysubway.common.error.InvalidRequestException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.sql.DataSource;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+@DisplayName("PostgreSQL 광고 소재 저장소")
+class JdbcAdRepositoryContainerTest {
+
+	@Container
+	private static final PostgreSQLContainer<?> POSTGRES =
+		new PostgreSQLContainer<>(DockerImageName.parse("postgres:16-alpine"));
+
+	@Test
+	@DisplayName("V47 schema에서 소재 upsert·활성 전환·기간 겹침 조회가 동작한다")
+	void managesCreativeLifecycleOnPostgresql() {
+		var dataSource = migratedDataSource();
+		var jdbcTemplate = new JdbcTemplate(dataSource);
+		var repository = new JdbcAdRepository(jdbcTemplate);
+		LocalDateTime startsAt = LocalDateTime.parse("2026-07-11T00:00:00");
+		jdbcTemplate.update("""
+			INSERT INTO ad_placements (id, display_name, enabled)
+			VALUES ('route-result-bottom', '경로 결과 하단', TRUE)
+			""");
+		AdCreative creative = new AdCreative(
+			"creative-postgres",
+			"route-result-bottom",
+			"https://assets.easysubway.example/ads/postgres.png",
+			"https://partner.example/postgres",
+			"광고주",
+			"광고 대체텍스트",
+			startsAt,
+			startsAt.plusDays(1),
+			false);
+
+		repository.save(creative);
+		repository.save(new AdCreative(
+			creative.id(), creative.placementId(), creative.imageUrl(), creative.landingUrl(),
+			"수정 광고주", creative.altText(), creative.startsAt(), creative.endsAt(), creative.enabled()));
+		assertThat(repository.setEnabled(creative.id(), true)).isTrue();
+
+		assertThat(repository.findAll()).singleElement()
+			.satisfies(found -> {
+				assertThat(found.advertiserName()).isEqualTo("수정 광고주");
+				assertThat(found.enabled()).isTrue();
+			});
+		assertThat(repository.hasEnabledOverlap(
+			"route-result-bottom", "other", startsAt.plusHours(1), startsAt.plusHours(2))).isTrue();
+		assertThat(repository.hasEnabledOverlap(
+			"route-result-bottom", "other", startsAt.plusDays(1), startsAt.plusDays(2))).isFalse();
+	}
+
+	@Test
+	@DisplayName("같은 id 동시 생성은 한 건만 저장하고 다른 transaction은 duplicate conflict로 끝난다")
+	void concurrentSameIdCreateHasOneSuccessAndOneConflict() throws Exception {
+		var dataSource = migratedDataSource();
+		var jdbcTemplate = new JdbcTemplate(dataSource);
+		jdbcTemplate.update("""
+			INSERT INTO ad_placements (id, display_name, enabled)
+			VALUES ('route-result-bottom', '경로 결과 하단', TRUE)
+			""");
+		var repository = new JdbcAdRepository(new UpdateBarrierJdbcTemplate(dataSource));
+		var transaction = new TransactionTemplate(new DataSourceTransactionManager(dataSource));
+		LocalDateTime startsAt = LocalDateTime.parse("2026-07-11T00:00:00");
+		AdCreative first = creative("동시 광고주 A", startsAt);
+		AdCreative second = creative("동시 광고주 B", startsAt);
+
+		List<Throwable> failures = runConcurrently(
+			() -> save(transaction, repository, first),
+			() -> save(transaction, repository, second)).stream()
+			.filter(result -> result != null)
+			.toList();
+		assertThat(failures).singleElement().isInstanceOf(DuplicateKeyException.class);
+
+		assertThat(repository.findAll()).singleElement()
+			.extracting(AdCreative::advertiserName)
+			.isIn("동시 광고주 A", "동시 광고주 B");
+	}
+
+	@Test
+	@DisplayName("동시 edit와 enable은 잠근 current 일정으로 overlap 우회를 허용하지 않는다")
+	void concurrentEditAndEnableCannotBypassOverlap() throws Exception {
+		var dataSource = migratedDataSource();
+		var jdbcTemplate = new JdbcTemplate(dataSource);
+		jdbcTemplate.update("""
+			INSERT INTO ad_placements (id, display_name, enabled)
+			VALUES ('route-result-bottom', '경로 결과 하단', TRUE),
+			       ('station-detail-bottom', '역 상세 하단', TRUE)
+			""");
+		var repository = new JdbcAdRepository(jdbcTemplate);
+		var service = new AdService(repository, "https://assets.easysubway.example");
+		var transaction = new TransactionTemplate(new DataSourceTransactionManager(dataSource));
+		LocalDateTime startsAt = LocalDateTime.parse("2026-07-11T00:00:00");
+		AdCreative blocking = creative(
+			"blocking", "광고주 B", startsAt, startsAt.plusHours(2), true);
+		AdCreative editable = creative(
+			"editable", "광고주 A", startsAt.plusHours(2), startsAt.plusHours(4), false);
+		repository.save(blocking);
+		repository.save(editable);
+		AdCreative overlappingEdit = creative(
+			"editable", "수정 광고주 A", startsAt.plusHours(1), startsAt.plusHours(3), true);
+
+		List<Throwable> failures = runConcurrently(
+			() -> inTransaction(transaction, () -> service.saveCreative(overlappingEdit)),
+			() -> inTransaction(transaction, () -> service.setCreativeEnabled("editable", true))).stream()
+			.filter(result -> result != null)
+			.toList();
+
+		assertThat(failures).singleElement().isInstanceOf(InvalidRequestException.class);
+		AdCreative found = repository.findById("editable").orElseThrow();
+		if (found.enabled()) {
+			assertThat(found.startsAt()).isEqualTo(startsAt.plusHours(2));
+		} else {
+			assertThat(found.startsAt()).isEqualTo(startsAt.plusHours(1));
+		}
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"enable", "update"})
+	@DisplayName("public event와 admin enable/update 교차 실행은 deadlock 없이 일관된 상태로 끝난다")
+	void publicEventAndAdminMutationDoNotDeadlock(String mutation) throws Exception {
+		var dataSource = migratedDataSource();
+		var jdbcTemplate = new JdbcTemplate(dataSource);
+		jdbcTemplate.update("""
+			INSERT INTO ad_placements (id, display_name, enabled)
+			VALUES ('route-result-bottom', '경로 결과 하단', TRUE),
+			       ('station-detail-bottom', '역 상세 하단', TRUE)
+			""");
+		LocalDateTime startsAt = LocalDateTime.parse("2026-07-11T00:00:00");
+		var regularRepository = new JdbcAdRepository(jdbcTemplate);
+		AdCreative creative = creative(
+			"event-creative", "광고주", startsAt, startsAt.plusHours(2), false);
+		regularRepository.save(creative);
+		var creativeLocked = new CountDownLatch(1);
+		var eventPlacementLocked = new CountDownLatch(1);
+		var adminRepository = new JdbcAdRepository(new AdminLockOrderJdbcTemplate(
+			dataSource, creativeLocked, eventPlacementLocked));
+		var adminService = new AdService(adminRepository, "https://assets.easysubway.example");
+		var transaction = new TransactionTemplate(new DataSourceTransactionManager(dataSource));
+
+		List<Throwable> failures = runConcurrently(
+			() -> inTransaction(transaction, () -> {
+				if ("enable".equals(mutation)) {
+					adminService.setCreativeEnabled(creative.id(), true);
+				} else {
+					adminService.saveCreative(new AdCreative(
+						creative.id(), creative.placementId(), creative.imageUrl(), creative.landingUrl(),
+						"수정 광고주", creative.altText(), creative.startsAt(), creative.endsAt(), true));
+				}
+			}),
+			() -> inTransaction(transaction, () -> {
+				await(creativeLocked, "admin creative lock");
+				jdbcTemplate.queryForObject(
+					"SELECT id FROM ad_placements WHERE id = ? FOR KEY SHARE",
+					String.class,
+					creative.placementId());
+				eventPlacementLocked.countDown();
+				regularRepository.incrementEvent(
+					creative.placementId(), creative.id(), com.easysubway.ads.domain.AdEventType.IMPRESSION,
+					java.time.LocalDate.of(2026, 7, 11));
+			})).stream()
+			.filter(result -> result != null)
+			.toList();
+
+		assertThat(failures).isEmpty();
+		AdCreative found = regularRepository.findById(creative.id()).orElseThrow();
+		if ("enable".equals(mutation)) {
+			assertThat(found.enabled()).isTrue();
+		} else {
+			assertThat(found.advertiserName()).isEqualTo("수정 광고주");
+			assertThat(found.enabled()).isFalse();
+		}
+		assertThat(jdbcTemplate.queryForObject(
+			"SELECT event_count FROM ad_event_daily WHERE creative_id = ?",
+			Integer.class,
+			creative.id())).isEqualTo(1);
+	}
+
+	private Throwable save(
+		TransactionTemplate transaction,
+		JdbcAdRepository repository,
+		AdCreative creative
+	) {
+		try {
+			transaction.executeWithoutResult(status -> repository.save(creative));
+			return null;
+		} catch (RuntimeException exception) {
+			return exception;
+		}
+	}
+
+	private AdCreative creative(String advertiserName, LocalDateTime startsAt) {
+		return creative(
+			"concurrent-creative",
+			advertiserName,
+			startsAt,
+			startsAt.plusDays(1),
+			false);
+	}
+
+	private AdCreative creative(
+		String id,
+		String advertiserName,
+		LocalDateTime startsAt,
+		LocalDateTime endsAt,
+		boolean enabled
+	) {
+		return new AdCreative(
+			id,
+			"route-result-bottom",
+			"https://assets.easysubway.example/ads/" + id + ".png",
+			"https://partner.example/" + id,
+			advertiserName,
+			advertiserName + " 광고",
+			startsAt,
+			endsAt,
+			enabled);
+	}
+
+	private Throwable inTransaction(TransactionTemplate transaction, Runnable command) {
+		try {
+			transaction.executeWithoutResult(status -> command.run());
+			return null;
+		} catch (RuntimeException exception) {
+			return exception;
+		}
+	}
+
+	private List<Throwable> runConcurrently(
+		Callable<Throwable> first,
+		Callable<Throwable> second
+	) throws Exception {
+		var ready = new CountDownLatch(2);
+		var start = new CountDownLatch(1);
+		var executor = Executors.newFixedThreadPool(2);
+		try {
+			var firstFuture = executor.submit(gated(first, ready, start));
+			var secondFuture = executor.submit(gated(second, ready, start));
+			assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+			start.countDown();
+			return java.util.Arrays.asList(
+				firstFuture.get(5, TimeUnit.SECONDS),
+				secondFuture.get(5, TimeUnit.SECONDS));
+		} finally {
+			start.countDown();
+			executor.shutdownNow();
+			assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+		}
+	}
+
+	private Callable<Throwable> gated(
+		Callable<Throwable> task,
+		CountDownLatch ready,
+		CountDownLatch start
+	) {
+		return () -> {
+			ready.countDown();
+			if (!start.await(5, TimeUnit.SECONDS)) {
+				throw new IllegalStateException("concurrency start latch timed out");
+			}
+			return task.call();
+		};
+	}
+
+	private void await(CountDownLatch latch, String name) {
+		try {
+			if (!latch.await(5, TimeUnit.SECONDS)) {
+				throw new IllegalStateException(name + " timed out");
+			}
+		} catch (InterruptedException exception) {
+			Thread.currentThread().interrupt();
+			throw new IllegalStateException(name + " interrupted", exception);
+		}
+	}
+
+	private DriverManagerDataSource migratedDataSource() {
+		var dataSource = new DriverManagerDataSource(
+			POSTGRES.getJdbcUrl(),
+			POSTGRES.getUsername(),
+			POSTGRES.getPassword());
+		Flyway.configure()
+			.dataSource(dataSource)
+			.locations("classpath:db/migration/postgresql")
+			.load()
+			.migrate();
+		var jdbcTemplate = new JdbcTemplate(dataSource);
+		jdbcTemplate.update("DELETE FROM ad_event_daily");
+		jdbcTemplate.update("DELETE FROM ad_creatives");
+		jdbcTemplate.update("DELETE FROM ad_placements");
+		return dataSource;
+	}
+
+	private static final class UpdateBarrierJdbcTemplate extends JdbcTemplate {
+
+		private final CyclicBarrier barrier = new CyclicBarrier(2);
+		private final AtomicInteger creativeUpdateCalls = new AtomicInteger();
+
+		private UpdateBarrierJdbcTemplate(DataSource dataSource) {
+			super(dataSource);
+		}
+
+		@Override
+		public int update(String sql, Object... args) {
+			int updated = super.update(sql, args);
+			if (sql.stripLeading().startsWith("UPDATE ad_creatives")
+				&& creativeUpdateCalls.incrementAndGet() <= 2) {
+				try {
+					barrier.await(5, TimeUnit.SECONDS);
+				} catch (Exception exception) {
+					throw new IllegalStateException(exception);
+				}
+			}
+			return updated;
+		}
+	}
+
+	private static final class AdminLockOrderJdbcTemplate extends JdbcTemplate {
+
+		private final CountDownLatch creativeLocked;
+		private final CountDownLatch eventPlacementLocked;
+		private volatile boolean placementLockedFirst;
+
+		private AdminLockOrderJdbcTemplate(
+			DataSource dataSource,
+			CountDownLatch creativeLocked,
+			CountDownLatch eventPlacementLocked
+		) {
+			super(dataSource);
+			this.creativeLocked = creativeLocked;
+			this.eventPlacementLocked = eventPlacementLocked;
+		}
+
+		@Override
+		public <T> T queryForObject(String sql, Class<T> requiredType, Object... args) {
+			T result = super.queryForObject(sql, requiredType, args);
+			if (sql.contains("FROM ad_placements") && sql.contains("FOR UPDATE")) {
+				placementLockedFirst = true;
+			}
+			return result;
+		}
+
+		@Override
+		public <T> T queryForObject(String sql, RowMapper<T> rowMapper, Object... args) {
+			T result = super.queryForObject(sql, rowMapper, args);
+			if (sql.contains("FROM ad_creatives") && sql.contains("FOR UPDATE")) {
+				creativeLocked.countDown();
+				if (!placementLockedFirst) {
+					try {
+						if (!eventPlacementLocked.await(5, TimeUnit.SECONDS)) {
+							throw new IllegalStateException("event placement lock timed out");
+						}
+					} catch (InterruptedException exception) {
+						Thread.currentThread().interrupt();
+						throw new IllegalStateException("event placement lock interrupted", exception);
+					}
+				}
+			}
+			return result;
+		}
+	}
+}

--- a/backend/src/test/java/com/easysubway/ads/adapter/out/persistence/JdbcAdRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/ads/adapter/out/persistence/JdbcAdRepositoryTest.java
@@ -33,8 +33,6 @@ class JdbcAdRepositoryTest {
 			.load()
 			.migrate();
 		repository = new JdbcAdRepository(jdbcTemplate);
-		insertPlacement("route-result-bottom");
-		insertPlacement("station-detail-bottom");
 	}
 
 	@Test
@@ -100,10 +98,6 @@ class JdbcAdRepositoryTest {
 			startsAt,
 			endsAt,
 			enabled);
-	}
-
-	private void insertPlacement(String id) {
-		jdbcTemplate.update("INSERT INTO ad_placements (id, display_name, enabled) VALUES (?, ?, TRUE)", id, id);
 	}
 
 }

--- a/backend/src/test/java/com/easysubway/ads/adapter/out/persistence/JdbcAdRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/ads/adapter/out/persistence/JdbcAdRepositoryTest.java
@@ -1,0 +1,109 @@
+package com.easysubway.ads.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.easysubway.ads.domain.AdCreative;
+import java.time.LocalDateTime;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+
+@DisplayName("H2 광고 소재 저장소")
+class JdbcAdRepositoryTest {
+
+	private static final LocalDateTime T0 = LocalDateTime.parse("2026-07-11T00:00:00");
+
+	private JdbcTemplate jdbcTemplate;
+	private JdbcAdRepository repository;
+
+	@BeforeEach
+	void setUp() {
+		var dataSource = new EmbeddedDatabaseBuilder()
+			.setType(EmbeddedDatabaseType.H2)
+			.generateUniqueName(true)
+			.build();
+		jdbcTemplate = new JdbcTemplate(dataSource);
+		Flyway.configure()
+			.dataSource(dataSource)
+			.locations("classpath:db/migration/h2")
+			.load()
+			.migrate();
+		repository = new JdbcAdRepository(jdbcTemplate);
+		insertPlacement("route-result-bottom");
+		insertPlacement("station-detail-bottom");
+	}
+
+	@Test
+	@DisplayName("소재를 생성·목록 조회하고 같은 id를 수정한 뒤 활성 상태를 전환한다")
+	void createsUpdatesListsAndTogglesCreative() {
+		repository.save(creative("creative-1", "route-result-bottom", T0, T0.plusDays(1), false));
+
+		assertThat(repository.findAll()).containsExactly(
+			creative("creative-1", "route-result-bottom", T0, T0.plusDays(1), false));
+
+		AdCreative updated = new AdCreative(
+			"creative-1",
+			"station-detail-bottom",
+			"https://assets.easysubway.example/ads/updated.png",
+			"https://partner.example/updated",
+			"수정 광고주",
+			"수정된 광고 대체텍스트",
+			T0.plusHours(1),
+			T0.plusDays(2),
+			false);
+		repository.save(updated);
+
+		assertThat(repository.findById("creative-1")).contains(updated);
+		assertThat(repository.findByIdForUpdate("creative-1")).contains(updated);
+		repository.lockPlacement("station-detail-bottom");
+		assertThat(repository.setEnabled("creative-1", true)).isTrue();
+		assertThat(repository.findById("creative-1")).get()
+			.extracting(AdCreative::enabled)
+			.isEqualTo(true);
+		assertThat(repository.setEnabled("missing", true)).isFalse();
+	}
+
+	@Test
+	@DisplayName("같은 placement의 enabled 반개구간만 겹침으로 판단하고 자기 자신은 제외한다")
+	void detectsEnabledHalfOpenIntervalOverlap() {
+		repository.save(creative("existing", "route-result-bottom", T0, T0.plusHours(2), true));
+		repository.save(creative("disabled", "route-result-bottom", T0, null, false));
+
+		assertThat(repository.hasEnabledOverlap(
+			"route-result-bottom", "new", T0.plusHours(1), T0.plusHours(3))).isTrue();
+		assertThat(repository.hasEnabledOverlap(
+			"route-result-bottom", "new", T0.plusHours(2), T0.plusHours(3))).isFalse();
+		assertThat(repository.hasEnabledOverlap(
+			"route-result-bottom", "existing", T0, T0.plusHours(2))).isFalse();
+		assertThat(repository.hasEnabledOverlap(
+			"station-detail-bottom", "new", T0, null)).isFalse();
+	}
+
+	private AdCreative creative(
+		String id,
+		String placementId,
+		LocalDateTime startsAt,
+		LocalDateTime endsAt,
+		boolean enabled
+	) {
+		return new AdCreative(
+			id,
+			placementId,
+			"https://assets.easysubway.example/ads/" + id + ".png",
+			"https://partner.example/" + id,
+			"광고주",
+			"광고 대체텍스트",
+			startsAt,
+			endsAt,
+			enabled);
+	}
+
+	private void insertPlacement(String id) {
+		jdbcTemplate.update("INSERT INTO ad_placements (id, display_name, enabled) VALUES (?, ?, TRUE)", id, id);
+	}
+
+}

--- a/backend/src/test/java/com/easysubway/ads/application/service/AdServiceTest.java
+++ b/backend/src/test/java/com/easysubway/ads/application/service/AdServiceTest.java
@@ -1,0 +1,214 @@
+package com.easysubway.ads.application.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.easysubway.ads.application.port.out.AdRepository;
+import com.easysubway.ads.domain.AdCreative;
+import com.easysubway.common.error.InvalidRequestException;
+import com.easysubway.common.error.ResourceNotFoundException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DuplicateKeyException;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("광고 소재 lifecycle service")
+class AdServiceTest {
+
+	private static final LocalDateTime T0 = LocalDateTime.parse("2026-07-11T00:00:00");
+	private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-07-11T00:00:00Z"), ZoneOffset.UTC);
+	private static final String PLACEMENT = "route-result-bottom";
+	private static final String IMAGE = "https://assets.easysubway.example/ads/creative-1.png";
+	private static final String LANDING = "https://partner.example/creative-1";
+	private static final String ADVERTISER = "광고주";
+	private static final String ALT = "광고 대체텍스트";
+
+	@Mock
+	private AdRepository repository;
+	private AdService service;
+
+	@BeforeEach
+	void setUp() {
+		service = new AdService(repository, CLOCK, "https://assets.easysubway.example");
+	}
+
+	@Test
+	@DisplayName("create payload의 enabled=true는 무시하고 disabled로 저장한다")
+	void createsDisabledRegardlessOfPayloadEnabled() {
+		AdCreative payload = creative("creative-1", true);
+		AdCreative expected = withEnabled(payload, false);
+		when(repository.findByIdForUpdate(payload.id())).thenReturn(Optional.empty());
+		when(repository.findById(payload.id())).thenReturn(Optional.empty());
+
+		service.saveCreative(payload);
+
+		verify(repository).insert(expected);
+		verify(repository, never()).hasEnabledOverlap(any(), any(), any(), any());
+	}
+
+	@Test
+	@DisplayName("update payload의 enabled=false는 무시하고 잠근 current enabled를 보존한다")
+	void updatesWithCurrentEnabledState() {
+		AdCreative current = creative("creative-1", true);
+		AdCreative payload = new AdCreative(
+			current.id(), "station-detail-bottom", current.imageUrl(), current.landingUrl(),
+			"수정 광고주", current.altText(), T0.plusHours(1), T0.plusDays(2), false);
+		AdCreative expected = withEnabled(payload, true);
+		when(repository.findByIdForUpdate(payload.id())).thenReturn(Optional.of(current));
+
+		service.saveCreative(payload);
+
+		verify(repository).hasEnabledOverlap(
+			expected.placementId(), expected.id(), expected.startsAt(), expected.endsAt());
+		verify(repository).save(expected);
+	}
+
+	@ParameterizedTest
+	@MethodSource("invalidCreatives")
+	@DisplayName("고정 placement·DB 길이·HTTPS·first-party image·기간 순서를 위반하면 저장하지 않는다")
+	void rejectsInvalidCreativeBoundaries(AdCreative creative) {
+		assertThatThrownBy(() -> service.saveCreative(creative))
+			.isInstanceOf(InvalidRequestException.class);
+		verify(repository, never()).save(any());
+		verify(repository, never()).insert(any());
+	}
+
+	private static Stream<Arguments> invalidCreatives() {
+		return Stream.of(
+			invalid(" ", PLACEMENT, IMAGE, LANDING, ADVERTISER, ALT, T0, T0.plusDays(1)),
+			invalid("x".repeat(65), PLACEMENT, IMAGE, LANDING, ADVERTISER, ALT, T0, T0.plusDays(1)),
+			invalid("creative-1", "home-top", IMAGE, LANDING, ADVERTISER, ALT, T0, T0.plusDays(1)),
+			invalid("creative-1", PLACEMENT, " ", LANDING, ADVERTISER, ALT, T0, T0.plusDays(1)),
+			invalid("creative-1", PLACEMENT, "https://assets.easysubway.example/" + "x".repeat(1000), LANDING, ADVERTISER, ALT, T0, T0.plusDays(1)),
+			invalid("creative-1", PLACEMENT, "http://assets.easysubway.example/ad.png", LANDING, ADVERTISER, ALT, T0, T0.plusDays(1)),
+			invalid("creative-1", PLACEMENT, "https://third-party.example/ad.png", LANDING, ADVERTISER, ALT, T0, T0.plusDays(1)),
+			invalid("creative-1", PLACEMENT, IMAGE, " ", ADVERTISER, ALT, T0, T0.plusDays(1)),
+			invalid("creative-1", PLACEMENT, IMAGE, "https://partner.example/" + "x".repeat(1000), ADVERTISER, ALT, T0, T0.plusDays(1)),
+			invalid("creative-1", PLACEMENT, IMAGE, "http://partner.example", ADVERTISER, ALT, T0, T0.plusDays(1)),
+			invalid("creative-1", PLACEMENT, IMAGE, LANDING, " ", ALT, T0, T0.plusDays(1)),
+			invalid("creative-1", PLACEMENT, IMAGE, LANDING, "x".repeat(256), ALT, T0, T0.plusDays(1)),
+			invalid("creative-1", PLACEMENT, IMAGE, LANDING, ADVERTISER, " ", T0, T0.plusDays(1)),
+			invalid("creative-1", PLACEMENT, IMAGE, LANDING, ADVERTISER, "x".repeat(501), T0, T0.plusDays(1)),
+			invalid("creative-1", PLACEMENT, IMAGE, LANDING, ADVERTISER, ALT, null, T0.plusDays(1)),
+			invalid("creative-1", PLACEMENT, IMAGE, LANDING, ADVERTISER, ALT, T0, T0));
+	}
+
+	private static Arguments invalid(
+		String id,
+		String placement,
+		String image,
+		String landing,
+		String advertiser,
+		String alt,
+		LocalDateTime startsAt,
+		LocalDateTime endsAt
+	) {
+		return Arguments.of(new AdCreative(
+			id, placement, image, landing, advertiser, alt, startsAt, endsAt, false));
+	}
+
+	@Test
+	@DisplayName("동시 생성 duplicate는 operator conflict로 매핑하고 SQL 재시도를 맡기지 않는다")
+	void mapsDuplicateCreateToOperatorConflict() {
+		AdCreative creative = creative("creative-1", false);
+		when(repository.findByIdForUpdate(creative.id())).thenReturn(Optional.empty());
+		when(repository.findById(creative.id())).thenReturn(Optional.empty());
+		doThrow(new DuplicateKeyException("duplicate creative id")).when(repository).insert(creative);
+
+		assertThatThrownBy(() -> service.saveCreative(creative))
+			.isInstanceOf(InvalidRequestException.class)
+			.hasMessageContaining("이미 존재");
+		verify(repository).insert(creative);
+	}
+
+	@Test
+	@DisplayName("enabled 소재의 같은 placement 기간 겹침은 저장과 활성화를 거부한다")
+	void rejectsEnabledOverlapOnSaveAndEnable() {
+		AdCreative creative = creative("creative-1", true);
+		when(repository.findByIdForUpdate(creative.id())).thenReturn(Optional.of(creative));
+		when(repository.hasEnabledOverlap(
+			creative.placementId(), creative.id(), creative.startsAt(), creative.endsAt())).thenReturn(true);
+
+		assertThatThrownBy(() -> service.saveCreative(creative))
+			.isInstanceOf(InvalidRequestException.class)
+			.hasMessageContaining("겹칩니다");
+		verify(repository, never()).save(any());
+
+		AdCreative disabled = withEnabled(creative, false);
+		when(repository.findByIdForUpdate(creative.id())).thenReturn(Optional.of(disabled));
+		assertThatThrownBy(() -> service.setCreativeEnabled(creative.id(), true))
+			.isInstanceOf(InvalidRequestException.class)
+			.hasMessageContaining("겹칩니다");
+		verify(repository, never()).setEnabled(creative.id(), true);
+	}
+
+	@Test
+	@DisplayName("disabled 전환은 overlap과 무관하고 없는 소재는 404 경계로 닫는다")
+	void disablesExistingAndRejectsMissingCreative() {
+		AdCreative creative = creative("creative-1", true);
+		when(repository.findByIdForUpdate(creative.id())).thenReturn(Optional.of(creative));
+
+		service.setCreativeEnabled(creative.id(), false);
+
+		verify(repository).setEnabled(creative.id(), false);
+		when(repository.findByIdForUpdate("missing")).thenReturn(Optional.empty());
+		assertThatThrownBy(() -> service.setCreativeEnabled("missing", true))
+			.isInstanceOf(ResourceNotFoundException.class);
+	}
+
+	@Test
+	@DisplayName("configured asset origin 오류는 request validation과 분리해 모두 fail closed한다")
+	void invalidConfiguredAssetOriginsFailClosed() {
+		for (String origin : List.of(
+			"",
+			"not a URI",
+			"http://assets.easysubway.example",
+			"https://user@assets.easysubway.example",
+			"https://assets.easysubway.example/ads",
+			"https://assets.easysubway.example?tenant=ads")) {
+			AdService invalid = new AdService(repository, CLOCK, origin);
+			assertThatThrownBy(() -> invalid.saveCreative(creative("creative-1", false)))
+				.as(origin)
+				.isInstanceOf(IllegalStateException.class)
+				.hasMessageContaining("asset origin");
+		}
+	}
+
+	private AdCreative creative(String id, boolean enabled) {
+		return new AdCreative(
+			id,
+			"route-result-bottom",
+			"https://assets.easysubway.example/ads/" + id + ".png",
+			"https://partner.example/" + id,
+			"광고주",
+			"광고 대체텍스트",
+			T0,
+			T0.plusDays(1),
+			enabled);
+	}
+
+	private AdCreative withEnabled(AdCreative creative, boolean enabled) {
+		return new AdCreative(
+			creative.id(), creative.placementId(), creative.imageUrl(), creative.landingUrl(),
+			creative.advertiserName(), creative.altText(), creative.startsAt(), creative.endsAt(), enabled);
+	}
+
+}

--- a/backend/src/test/java/com/easysubway/ads/application/service/AdServiceTest.java
+++ b/backend/src/test/java/com/easysubway/ads/application/service/AdServiceTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DuplicateKeyException;
@@ -110,6 +111,47 @@ class AdServiceTest {
 			invalid("creative-1", PLACEMENT, IMAGE, LANDING, ADVERTISER, "x".repeat(501), T0, T0.plusDays(1)),
 			invalid("creative-1", PLACEMENT, IMAGE, LANDING, ADVERTISER, ALT, null, T0.plusDays(1)),
 			invalid("creative-1", PLACEMENT, IMAGE, LANDING, ADVERTISER, ALT, T0, T0));
+	}
+
+	@ParameterizedTest
+	@MethodSource("routeUnsafeCreativeIds")
+	@DisplayName("creative id는 단일 route segment에 안전하지 않은 문자를 거부한다")
+	void rejectsRouteUnsafeCreativeIds(String id) {
+		AdCreative payload = new AdCreative(
+			id, PLACEMENT, IMAGE, LANDING, ADVERTISER, ALT, T0, T0.plusDays(1), false);
+
+		assertThatThrownBy(() -> service.saveCreative(payload))
+			.isInstanceOf(InvalidRequestException.class)
+			.hasMessageContaining("creative id");
+		assertThatThrownBy(() -> service.setCreativeEnabled(id, true))
+			.isInstanceOf(InvalidRequestException.class)
+			.hasMessageContaining("creative id");
+		verify(repository, never()).insert(any());
+		verify(repository, never()).setEnabled(id, true);
+	}
+
+	private static Stream<String> routeUnsafeCreativeIds() {
+		return Stream.of(
+			"summer/banner",
+			"summer%2Fbanner",
+			"summer%banner",
+			"summer?banner",
+			"summer#banner",
+			"summer banner",
+			"summer\tbanner",
+			"summer\nbanner");
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"A", "A._-A._-A._-A._-A._-A._-A._-A._-A._-A._-A._-A._-A._-A._-A._-A._-"})
+	@DisplayName("creative id는 route-safe 문자의 1자와 64자 경계를 허용한다")
+	void acceptsRouteSafeCreativeIdBoundaries(String id) {
+		AdCreative payload = creative(id, false);
+		when(repository.findByIdForUpdate(id)).thenReturn(Optional.empty());
+		when(repository.findById(id)).thenReturn(Optional.empty());
+
+		assertThat(service.saveCreative(payload)).isEqualTo(AdService.SaveResult.CREATED);
+		verify(repository).insert(payload);
 	}
 
 	private static Arguments invalid(

--- a/backend/src/test/java/com/easysubway/ads/application/service/AdServiceTest.java
+++ b/backend/src/test/java/com/easysubway/ads/application/service/AdServiceTest.java
@@ -132,6 +132,8 @@ class AdServiceTest {
 
 	private static Stream<String> routeUnsafeCreativeIds() {
 		return Stream.of(
+			".",
+			"..",
 			"summer/banner",
 			"summer%2Fbanner",
 			"summer%banner",
@@ -143,7 +145,12 @@ class AdServiceTest {
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = {"A", "A._-A._-A._-A._-A._-A._-A._-A._-A._-A._-A._-A._-A._-A._-A._-A._-"})
+	@ValueSource(strings = {
+		"A",
+		".banner",
+		"a..b",
+		"A._-A._-A._-A._-A._-A._-A._-A._-A._-A._-A._-A._-A._-A._-A._-A._-"
+	})
 	@DisplayName("creative id는 route-safe 문자의 1자와 64자 경계를 허용한다")
 	void acceptsRouteSafeCreativeIdBoundaries(String id) {
 		AdCreative payload = creative(id, false);

--- a/backend/src/test/java/com/easysubway/ads/application/service/AdServiceTest.java
+++ b/backend/src/test/java/com/easysubway/ads/application/service/AdServiceTest.java
@@ -1,5 +1,6 @@
 package com.easysubway.ads.application.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
@@ -58,7 +59,7 @@ class AdServiceTest {
 		when(repository.findByIdForUpdate(payload.id())).thenReturn(Optional.empty());
 		when(repository.findById(payload.id())).thenReturn(Optional.empty());
 
-		service.saveCreative(payload);
+		assertThat(service.saveCreative(payload)).isEqualTo(AdService.SaveResult.CREATED);
 
 		verify(repository).insert(expected);
 		verify(repository, never()).hasEnabledOverlap(any(), any(), any(), any());
@@ -74,7 +75,7 @@ class AdServiceTest {
 		AdCreative expected = withEnabled(payload, true);
 		when(repository.findByIdForUpdate(payload.id())).thenReturn(Optional.of(current));
 
-		service.saveCreative(payload);
+		assertThat(service.saveCreative(payload)).isEqualTo(AdService.SaveResult.UPDATED);
 
 		verify(repository).hasEnabledOverlap(
 			expected.placementId(), expected.id(), expected.startsAt(), expected.endsAt());

--- a/backend/src/test/java/com/easysubway/common/persistence/DatabaseMigrationContainerTest.java
+++ b/backend/src/test/java/com/easysubway/common/persistence/DatabaseMigrationContainerTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.sql.Timestamp;
 import java.util.List;
 import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.MigrationVersion;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataAccessException;
@@ -64,7 +65,8 @@ class DatabaseMigrationContainerTest {
 				"transit_master_overrides",
 				"transit_master_override_audits"
 			);
-		assertThat(successfulMigrationVersions(jdbcTemplate)).contains("1", "14", "16", "17", "18", "19", "20", "21", "22", "23", "25", "26");
+		assertThat(successfulMigrationVersions(jdbcTemplate)).contains("1", "14", "16", "17", "18", "19", "20", "21", "22", "23", "25", "26", "48");
+		assertAdPlacementsSeeded(jdbcTemplate);
 		assertThat(foreignKeyNames(jdbcTemplate))
 			.contains(
 				"fk_facility_report_review_audits_report",
@@ -134,7 +136,43 @@ class DatabaseMigrationContainerTest {
 			.load()
 			.migrate();
 
-		assertSnapshotSourceForeignKeysRejectMismatch(new JdbcTemplate(dataSource));
+		var jdbcTemplate = new JdbcTemplate(dataSource);
+		assertAdPlacementsSeeded(jdbcTemplate);
+		assertSnapshotSourceForeignKeysRejectMismatch(jdbcTemplate);
+	}
+
+	@Test
+	@DisplayName("PostgreSQL V48은 기존 placement의 운영 표시명과 비활성 상태를 보존한다")
+	void postgresqlAdPlacementSeedPreservesExistingRow() {
+		String schema = "ad_seed_" + System.nanoTime();
+		var dataSource = new DriverManagerDataSource(
+			POSTGRES.getJdbcUrl(),
+			POSTGRES.getUsername(),
+			POSTGRES.getPassword()
+		);
+		migrateToV47(dataSource, "classpath:db/migration/postgresql", schema);
+		var jdbcTemplate = new JdbcTemplate(dataSource);
+		jdbcTemplate.update("INSERT INTO " + schema + ".ad_placements (id, display_name, enabled) VALUES (?, ?, FALSE)",
+			"route-result-bottom", "운영자 지정 경로 슬롯");
+
+		migrate(dataSource, "classpath:db/migration/postgresql", schema);
+
+		assertPreservedPlacement(jdbcTemplate, schema);
+	}
+
+	@Test
+	@DisplayName("H2 V48은 기존 placement의 운영 표시명과 비활성 상태를 보존한다")
+	void h2AdPlacementSeedPreservesExistingRow() {
+		String database = "jdbc:h2:mem:ad-seed-preserve;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE";
+		var dataSource = new DriverManagerDataSource(database, "sa", "");
+		migrateToV47(dataSource, "classpath:db/migration/h2", null);
+		var jdbcTemplate = new JdbcTemplate(dataSource);
+		jdbcTemplate.update("INSERT INTO ad_placements (id, display_name, enabled) VALUES (?, ?, FALSE)",
+			"route-result-bottom", "운영자 지정 경로 슬롯");
+
+		migrate(dataSource, "classpath:db/migration/h2", null);
+
+		assertPreservedPlacement(jdbcTemplate, null);
 	}
 
 	@Test
@@ -231,6 +269,46 @@ class DatabaseMigrationContainerTest {
 			""", String.class);
 	}
 
+	private void assertAdPlacementsSeeded(JdbcTemplate jdbcTemplate) {
+		assertThat(jdbcTemplate.queryForList("""
+			SELECT id
+			FROM ad_placements
+			WHERE enabled = TRUE
+			ORDER BY id
+			""", String.class))
+			.containsExactly("route-result-bottom", "station-detail-bottom");
+	}
+
+	private void assertPreservedPlacement(JdbcTemplate jdbcTemplate, String schema) {
+		String table = schema == null ? "ad_placements" : schema + ".ad_placements";
+		List<Object> placement = jdbcTemplate.queryForObject(
+			"SELECT display_name, enabled FROM " + table + " WHERE id = ?",
+			(resultSet, rowNumber) -> List.of(resultSet.getString("display_name"), resultSet.getBoolean("enabled")),
+			"route-result-bottom");
+		assertThat(placement)
+			.containsExactly("운영자 지정 경로 슬롯", false);
+	}
+
+	private void migrateToV47(javax.sql.DataSource dataSource, String location, String schema) {
+		flyway(dataSource, location, schema)
+			.target(MigrationVersion.fromVersion("47"))
+			.load()
+			.migrate();
+	}
+
+	private void migrate(javax.sql.DataSource dataSource, String location, String schema) {
+		flyway(dataSource, location, schema).load().migrate();
+	}
+
+	private org.flywaydb.core.api.configuration.FluentConfiguration flyway(
+		javax.sql.DataSource dataSource,
+		String location,
+		String schema
+	) {
+		var configuration = Flyway.configure().dataSource(dataSource).locations(location);
+		return schema == null ? configuration : configuration.schemas(schema).defaultSchema(schema);
+	}
+
 	private List<String> successfulMigrationVersions(JdbcTemplate jdbcTemplate) {
 		return jdbcTemplate.queryForList("""
 			SELECT version
@@ -263,12 +341,14 @@ class DatabaseMigrationContainerTest {
 	private void assertPostgresqlSnapshotRawEvidenceConstraintsAreStaged(JdbcTemplate jdbcTemplate) {
 		assertThat(jdbcTemplate.queryForList("""
 			SELECT conname
-			FROM pg_constraint
+			FROM pg_constraint constraint_row
+			JOIN pg_namespace namespace_row ON namespace_row.oid = constraint_row.connamespace
 			WHERE conname IN (
 				'chk_data_source_snapshots_credential_redacted',
 				'chk_data_source_snapshots_raw_object_uri',
 				'chk_data_source_snapshots_raw_retention'
 			)
+				AND namespace_row.nspname = 'public'
 				AND convalidated = false
 			ORDER BY conname
 			""", String.class))

--- a/tools/ci/check-admin-vendor-integrity.test.mjs
+++ b/tools/ci/check-admin-vendor-integrity.test.mjs
@@ -1,10 +1,27 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { checkAdminVendorIntegrity } from "./check-admin-vendor-integrity.mjs";
+
+test("광고 creative ID HTML pattern은 v mode에서 route-safe 경계를 유지한다", async () => {
+  const template = await readFile(
+    path.resolve(import.meta.dirname, "../../backend/src/main/resources/templates/admin/ads/list.html"),
+    "utf8",
+  );
+  const input = template.match(/<input\b[^>]*\bid="creative-id"[^>]*>/)?.[0];
+  const pattern = input?.match(/\bpattern="([^"]+)"/)?.[1];
+  assert.ok(pattern, "creative-id pattern missing");
+  assert.doesNotThrow(() => new RegExp(pattern, "v"));
+
+  const constraint = new RegExp(`^(?:${pattern})$`, "v");
+  for (const value of [".", "..", "a/b"]) assert.equal(constraint.test(value), false, value);
+  for (const value of ["A", ".banner", "a..b", "A._-".repeat(16)]) {
+    assert.equal(constraint.test(value), true, value);
+  }
+});
 
 test("admin vendor integrity check passes matching SHA256SUMS and SRI", async () => {
   const root = await fixtureRoot("console.log('ok');");


### PR DESCRIPTION
## 관련 이슈

Closes #1947

Refs #1771 #1893 #1935 #1943 #1912

## 작업 배경

- 자체 서빙 광고를 운영 환경에서 안전하게 등록·수정·활성화·비활성화하려면 고정 placement, lifecycle 제약, 관리자 권한과 감사 로그를 함께 제공해야 합니다.
- 사용자에게 노출되는 광고와 DB migration, 관리자 보안 경계를 변경하므로 위험도 A 프로세스로 진행합니다.

## 작업 내용

- 2개 커밋, 21개 파일에서 1,715줄을 추가하고 20줄을 삭제했습니다.
- PostgreSQL/H2에 짝을 맞춘 `V48__ad_placements_seed.sql`로 `route-result-bottom`, `station-detail-bottom` placement를 멱등하게 추가합니다.
- domain/service/JDBC에 소재 조회·생성·수정·활성화·비활성화 lifecycle을 추가하고, placement row lock과 creative row lock으로 활성 기간 중복 및 동시 변경을 직렬화합니다.
- 광고 관리 화면과 관리자 navigation/security 경계를 연결하고, CSRF·command token·권한 확인·감사 로그를 유지한 create/update/enable/disable 작업을 제공합니다.
- image URL은 설정된 first-party HTTPS asset origin과 동일 origin만 허용하며 landing URL도 user info 없는 absolute HTTPS URL만 허용합니다.
- 제외 범위: binary upload, hard delete, 광고 event metrics, mobile measurement는 추가하지 않았습니다.

## 검증

- 실행한 명령과 결과:
  - TDD RED: lifecycle·중복 활성 기간·관리자 security/command 계약 테스트가 구현 전 실패함을 확인했습니다.
  - TDD GREEN: phase focused 119/119, ads focused 38/38 통과했습니다.
  - phase 전체 backend: 1,409 tests 통과했습니다.
  - runtime QA: create → enable → 공개 API HTTP 200 및 ETag/JSON 확인 → disable → 공개 API HTTP 204를 확인했고, create/enable/disable 감사 로그가 모두 `outcome=SUCCESS`였습니다.
  - rebase 후 `./gradlew check --no-daemon`: `BUILD SUCCESSFUL`입니다.
  - rebase 후 `node --test tools/ci/*.test.mjs tools/ci/lib/*.test.mjs tools/repo/*.test.mjs`: 235/235 통과했습니다.
  - rebase 후 `node tools/ci/check-boundaries.mjs`: 통과했습니다.
  - `git diff --check origin/main...HEAD` 및 forbidden scan: 통과했습니다.
  - `git range-diff 272062d..cee695596c1458d8c7fd11f58c6951550cf49f70 origin/main..HEAD`: 두 커밋 모두 `=`로 rebase 전후 의미 diff가 동일합니다.

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 관리자 광고 lifecycle | Backend/H2 | 실제 서버와 `curl`로 create/enable/public API/disable 수행 | `/tmp/issue-1947-evidence/report.md` | 성공 |
| 관리자 화면 구조·접근성·보안 | Backend HTML | 렌더링 HTML, a11y, CSP/security, CSRF·command token 테스트 | backend 자동화 테스트 및 `/tmp/issue-1947-evidence/report.md` | 성공 |
| UI screenshot | in-app browser | Node runtime 가용 여부 확인 | in-app browser에 Node runtime이 없어 screenshot을 생성하지 못함. 렌더링 HTML/a11y/CSP/security 테스트와 실제 curl lifecycle 증거로 대체 | 미첨부 사유 확인 |
| 비밀정보 노출 | 로컬 evidence | 보고서와 산출물에 credential/token 원문을 기록하지 않음 | `/tmp/issue-1947-evidence/report.md` | 성공 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [x] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: version bump 없음, backend deploy와 Flyway V48 적용 필요

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `AdService`의 lifecycle validation, first-party image URL 제한, 활성 기간 중복 거부를 확인해 주세요.
  - `JdbcAdRepository`의 placement/creative lock과 PostgreSQL/H2 V48 seed 정합성을 확인해 주세요.
  - 관리자 create/update/enable/disable의 권한, CSRF, command token, 감사 로그 경계를 확인해 주세요.
  - binary upload, hard delete, event metrics, mobile measurement가 범위에 포함되지 않았음을 확인해 주세요.

## 리스크

- 배포 영향: backend 배포 시 PostgreSQL Flyway V48이 두 고정 placement를 멱등하게 seed합니다. 앱 version bump는 없습니다.
- rollout: V48 적용 후 `easysubway.ads.asset-origin`을 first-party HTTPS origin으로 설정하고 관리자 lifecycle 및 공개 API 상태를 확인합니다.
- rollback: 문제가 있으면 모든 소재를 비활성화하고 이전 backend artifact로 되돌립니다. 이미 적용된 Flyway V48은 되돌리거나 삭제하지 않으며, 멱등 seed row는 후속 호환성을 위해 유지합니다.
- 동시 활성화는 DB row lock으로 직렬화하지만, 운영 DB에서 migration과 lock 대기 시간을 post-deploy 확인해야 합니다.
- README와 CLAUDE 문서는 변경하지 않았습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
- [ ] required CI와 리뷰가 완료된 뒤 auto-merge 상태를 확인했다.

CI, 코드리뷰, unresolved thread, auto-merge는 PR 생성 후 확인하며 현재는 완료 처리하지 않았습니다.
