### PR TITLE
[Fix] 광주 노선도 CC BY-SA attribution 배선 + 지도팩 manifest 라이선스 정합화 (#1951)

### DIFF
--- a/apps/mobile/assets/datapacks/metro_map_pack/manifest.json
+++ b/apps/mobile/assets/datapacks/metro_map_pack/manifest.json
@@ -79,9 +79,9 @@
         "attributionRequired": false,
         "commercialUseAllowed": true,
         "derivativeWorkAllowed": false,
-        "redistributionAllowed": false,
-        "reviewStatus": "permission-required",
-        "changes": "File stored unchanged as a bundled offline route-map asset. Bundle redistribution and commercial use remain blocked until operator permission is recorded."
+        "redistributionAllowed": true,
+        "reviewStatus": "self-drawn-fact-based",
+        "changes": "App rendering uses a self-drawn schematic built from factual station coordinates and line topology, not a derivative of the bundled SVG's expressive content. The original SVG is retained only as a coordinate-review reference and is not distributed as the render source."
       }
     },
     {
@@ -154,9 +154,9 @@
         "attributionRequired": false,
         "commercialUseAllowed": true,
         "derivativeWorkAllowed": false,
-        "redistributionAllowed": false,
-        "reviewStatus": "permission-required",
-        "changes": "File stored unchanged as a bundled offline route-map asset. Bundle redistribution and commercial use remain blocked until operator permission is recorded."
+        "redistributionAllowed": true,
+        "reviewStatus": "self-drawn-fact-based",
+        "changes": "App rendering uses a self-drawn schematic built from factual station coordinates and line topology, not a derivative of the bundled SVG's expressive content. The original SVG is retained only as a coordinate-review reference and is not distributed as the render source."
       }
     },
     {
@@ -191,9 +191,9 @@
         "attributionRequired": false,
         "commercialUseAllowed": true,
         "derivativeWorkAllowed": false,
-        "redistributionAllowed": false,
-        "reviewStatus": "permission-required",
-        "changes": "File stored unchanged as a bundled offline route-map asset. Bundle redistribution and commercial use remain blocked until operator permission is recorded."
+        "redistributionAllowed": true,
+        "reviewStatus": "self-drawn-fact-based",
+        "changes": "App rendering uses a self-drawn schematic built from factual station coordinates and line topology, not a derivative of the bundled SVG's expressive content. The original SVG is retained only as a coordinate-review reference and is not distributed as the render source."
       }
     }
   ]

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -4464,6 +4464,7 @@ class _AttributionCard extends StatelessWidget {
       rows: [
         ('제공 기관', _text(license['source'], _text(map['name_ko']))),
         ('라이선스', '${_text(license['name'])} (${_text(license['spdx'])})'),
+        ('작성자', _text(license['authors'])),
         ('라이선스 링크', _text(license['url'])),
         ('표기 필요', _yesNo(license['attributionRequired'])),
         ('가져온 날짜', _text(license['date'])),

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -5,6 +5,7 @@ import 'dart:math' as math;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:flutter/services.dart' show rootBundle;
 
 import 'accessible_design.dart';
 import 'ad_slot.dart';
@@ -2371,6 +2372,65 @@ class _NetworkMapLoadFailure extends StatelessWidget {
   }
 }
 
+// 지도 datapack manifest(assets/datapacks/metro_map_pack/manifest.json)의
+// license 블록에서 지역별 attribution 표기 문자열을 만든다(#1951). 하드코딩
+// 지역 분기 대신 manifest의 `attributionRequired`를 정본으로 삼는다 —
+// attributionRequired가 false면 해당 지역은 맵에서 제외한다.
+const _mapManifestAssetPath = 'assets/datapacks/metro_map_pack/manifest.json';
+
+@visibleForTesting
+Map<String, String> parseNetworkMapAttributionByRegion(String manifestJson) {
+  final manifest = jsonDecode(manifestJson) as Map<String, Object?>;
+  final maps = (manifest['maps'] as List? ?? const [])
+      .cast<Map<String, Object?>>();
+  final result = <String, String>{};
+  for (final map in maps) {
+    final appRegion = map['app_region'] as String?;
+    final license = map['license'] as Map<String, Object?>?;
+    if (appRegion == null || license == null) {
+      continue;
+    }
+    if (license['attributionRequired'] != true) {
+      continue;
+    }
+    final authors = (license['authors'] as List? ?? const [])
+        .whereType<Object>()
+        .map((author) => '$author')
+        .join(', ');
+    final spdx = (license['spdx'] as String?)?.replaceAll('-', ' ').trim();
+    final licenseLabel = (spdx != null && spdx.isNotEmpty)
+        ? spdx
+        : (license['name'] as String? ?? '');
+    final text = [
+      if (authors.isNotEmpty) authors,
+      if (licenseLabel.isNotEmpty) licenseLabel,
+    ].join(', ');
+    if (text.isNotEmpty) {
+      result[appRegion] = text;
+    }
+  }
+  return result;
+}
+
+// manifest는 프로세스 생애주기 동안 바뀌지 않는 번들 asset이라, 노선도 canvas가
+// 새로 마운트될 때마다(지역 전환 등) 매번 asset을 다시 읽지 않도록 1회만 로드해
+// 공유한다. cache:false로 rootBundle의 키 캐시를 우회하는 이유는 DataSourceAttribution
+// Screen도 같은 asset 키를 독립적으로 로드하기 때문에(#1951), rootBundle의 공유 캐시
+// Future를 함께 쓰면 두 로더가 서로 다른 시점에 얽혀 불필요하게 결합되는 것을 피하기
+// 위함이다 — 대신 이 파일 안에서만 쓰는 자체 캐시를 둔다.
+Future<Map<String, String>>? _sharedAttributionTextByRegionFuture;
+
+Future<Map<String, String>> _loadNetworkMapAttributionTextByRegion() {
+  return _sharedAttributionTextByRegionFuture ??= rootBundle
+      .loadString(_mapManifestAssetPath, cache: false)
+      .then(parseNetworkMapAttributionByRegion);
+}
+
+@visibleForTesting
+void resetNetworkMapAttributionCacheForTest() {
+  _sharedAttributionTextByRegionFuture = null;
+}
+
 class _NetworkMapCanvas extends StatefulWidget {
   const _NetworkMapCanvas({
     required this.data,
@@ -2450,6 +2510,9 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
   Map<String, String>? _structuredLabelTextCache;
   Map<String, String>? _structuredLineBadgeLabelCache;
   NetworkMapStation? _selectedStation;
+  // region → attribution 표시 문자열(#1951). manifest 로드 전에는 null로 두고
+  // attribution을 표시하지 않는다(로드 실패 시에도 동일하게 조용히 미표기).
+  Map<String, String>? _attributionTextByRegion;
 
   @override
   void initState() {
@@ -2460,6 +2523,25 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
     // 프레임이 잡히지 않으므로 FrameTiming으로 계측한다. release에는 넣지 않는다.
     if (!kReleaseMode) {
       SchedulerBinding.instance.addTimingsCallback(_logRouteMapFrameTimings);
+    }
+    _loadAttributionText();
+  }
+
+  Future<void> _loadAttributionText() async {
+    try {
+      final byRegion = await _loadNetworkMapAttributionTextByRegion();
+      if (!mounted) {
+        return;
+      }
+      setState(() => _attributionTextByRegion = byRegion);
+    } catch (error, stackTrace) {
+      // asset 로드/파싱 실패는 attribution 미표기로 폴백한다(#1951) — 화면은
+      // 죽지 않되, 원인 파악을 위해 예외는 리포터로 남긴다.
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '지도 datapack manifest에서 attribution 정보를 불러오는 중 예외가 발생했습니다.',
+      );
     }
   }
 
@@ -2824,6 +2906,7 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
       lineColors: _structuredLineColorsCache!,
       labelTextByStationId: _structuredLabelTextCache!,
       lineBadgeLabelByLineId: _structuredLineBadgeLabelCache!,
+      attributionText: _attributionTextByRegion?[widget.data.selectedRegion],
     );
   }
 

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -2413,16 +2413,14 @@ Map<String, String> parseNetworkMapAttributionByRegion(String manifestJson) {
 }
 
 // manifest는 프로세스 생애주기 동안 바뀌지 않는 번들 asset이라, 노선도 canvas가
-// 새로 마운트될 때마다(지역 전환 등) 매번 asset을 다시 읽지 않도록 1회만 로드해
-// 공유한다. cache:false로 rootBundle의 키 캐시를 우회하는 이유는 DataSourceAttribution
-// Screen도 같은 asset 키를 독립적으로 로드하기 때문에(#1951), rootBundle의 공유 캐시
-// Future를 함께 쓰면 두 로더가 서로 다른 시점에 얽혀 불필요하게 결합되는 것을 피하기
-// 위함이다 — 대신 이 파일 안에서만 쓰는 자체 캐시를 둔다.
+// 새로 마운트될 때마다(지역 전환 등) 매번 asset을 다시 읽지 않도록 모듈 캐시
+// (_sharedAttributionTextByRegionFuture)로 1회만 로드해 공유한다. 로드 실패
+// 시에는 캐시를 비워 다음 마운트에서 재시도한다(#1951).
 Future<Map<String, String>>? _sharedAttributionTextByRegionFuture;
 
 Future<Map<String, String>> _loadNetworkMapAttributionTextByRegion() {
   return _sharedAttributionTextByRegionFuture ??= rootBundle
-      .loadString(_mapManifestAssetPath, cache: false)
+      .loadString(_mapManifestAssetPath)
       .then(parseNetworkMapAttributionByRegion);
 }
 
@@ -2535,8 +2533,11 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
       }
       setState(() => _attributionTextByRegion = byRegion);
     } catch (error, stackTrace) {
-      // asset 로드/파싱 실패는 attribution 미표기로 폴백한다(#1951) — 화면은
-      // 죽지 않되, 원인 파악을 위해 예외는 리포터로 남긴다.
+      // asset 로드/파싱 실패는 attribution 미표기로 폴백한다(#1951). 일시 오류가
+      // 영구 미표기로 고정되지 않도록 실패한 Future는 캐시에서 비워 다음 마운트
+      // 때 재시도되게 한다 — 화면은 죽지 않되, 원인 파악을 위해 예외는 리포터로
+      // 남긴다.
+      _sharedAttributionTextByRegionFuture = null;
       reportMobileError(
         error,
         stackTrace,

--- a/apps/mobile/test/features/network_map/presentation/route_map_attribution_test.dart
+++ b/apps/mobile/test/features/network_map/presentation/route_map_attribution_test.dart
@@ -5,11 +5,18 @@
 // structured_route_map_painter.dart 참고). 대신 CustomPaint의 painter를
 // StructuredRouteMapPainter로 캐스팅해 attributionText 필드를 직접
 // assert한다 — 이 방식이 렌더 방식과 가장 정합적이고 신뢰성 있는 검증이다.
+import 'dart:convert';
+
 import 'package:easysubway_mobile/features/network_map/presentation/structured_route_map_painter.dart';
 import 'package:easysubway_mobile/features/route_draft/application/route_draft_controller.dart';
 import 'package:easysubway_mobile/network_map.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+/// #1951 datapack manifest asset의 실제 번들 키. lib/network_map.dart의
+/// `_mapManifestAssetPath`(private)와 동일한 값을 가져야 한다.
+const _mapManifestAssetPath = 'assets/datapacks/metro_map_pack/manifest.json';
 
 class _FakeNetworkMapRepository implements NetworkMapRepository {
   _FakeNetworkMapRepository({required this.selectedRegion});
@@ -140,4 +147,95 @@ void main() {
     final painter = _findRouteMapPainter(tester);
     expect(painter.attributionText, isNull);
   });
+
+  testWidgets(
+    'manifest 로드가 1차 실패해도 캐시가 비워져 재마운트 시 재시도해 attribution을 표시한다(#1951)',
+    (tester) async {
+      // 원래 핸들러(flutter_test가 등록한, 디스크에서 실제 번들 asset을
+      // 읽어오는 핸들러)로 manifest 원본 바이트를 미리 읽어 둔 뒤, 그
+      // 핸들러를 우리 mock으로 교체한다 — manifest 키에 한해 최초 1회만
+      // null(=로드 실패)을 반환하고, 이후 호출은 미리 읽어 둔 원본 바이트를
+      // 그대로 반환해 실제 로드 성공을 재현한다.
+      final manifestBytes = await rootBundle.load(_mapManifestAssetPath);
+      // rootBundle은 loadString(cache:true, 이번 수정의 기본값)을 프로세스
+      // 생애주기 동안 캐시한다. 이전 테스트(#1951 광주 attribution 테스트)가
+      // 이미 이 키를 성공적으로 로드해 rootBundle 자체의 _stringCache에
+      // 남아 있으므로, 이 테스트가 induced failure를 실제로 겪으려면 그
+      // 캐시를 먼저 비워야 한다.
+      rootBundle.evict(_mapManifestAssetPath);
+      addTearDown(() => rootBundle.evict(_mapManifestAssetPath));
+
+      final binaryMessenger =
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+      var manifestLoadAttempts = 0;
+      binaryMessenger.setMockMessageHandler('flutter/assets', (
+        ByteData? message,
+      ) async {
+        final key = utf8.decode(message!.buffer.asUint8List());
+        if (key != _mapManifestAssetPath) {
+          return null;
+        }
+        manifestLoadAttempts += 1;
+        if (manifestLoadAttempts == 1) {
+          return null;
+        }
+        return manifestBytes;
+      });
+      addTearDown(
+        () => binaryMessenger.setMockMessageHandler('flutter/assets', null),
+      );
+
+      resetNetworkMapAttributionCacheForTest();
+      addTearDown(resetNetworkMapAttributionCacheForTest);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: NetworkMapScreen(
+            repository: _FakeNetworkMapRepository(selectedRegion: '광주'),
+            routeDraftController: RouteDraftController(),
+            onOpenStationSearch: () {},
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(Duration.zero);
+      await tester.pumpAndSettle();
+
+      // 1차 시도는 실패했어야 하므로 attribution은 아직 표시되지 않는다.
+      // 실패는 reportMobileError를 거쳐 FlutterError.reportError로 전파되므로
+      // (테스트 바인딩이 기본으로 실패 처리하지 않도록) takeException으로
+      // 소비해 의도된 예외임을 확인한다.
+      expect(find.byType(StructuredRouteMapView), findsOneWidget);
+      expect(_findRouteMapPainter(tester).attributionText, isNull);
+      expect(manifestLoadAttempts, 1);
+      expect(tester.takeException(), isNotNull);
+
+      // 재마운트하면 _sharedAttributionTextByRegionFuture는 비워져 있었으므로
+      // _loadNetworkMapAttributionTextByRegion 자체는 재시도된다. 다만
+      // rootBundle.loadString(cache:true, 이번 수정의 기본값)이 실패한
+      // Future 자체를 자체 _stringCache에 영구 캐시하므로, 그 하위 레이어의
+      // 재시도가 실제로 새 로드를 하려면 여기서도 다시 evict가 필요하다.
+      rootBundle.evict(_mapManifestAssetPath);
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: NetworkMapScreen(
+            repository: _FakeNetworkMapRepository(selectedRegion: '광주'),
+            routeDraftController: RouteDraftController(),
+            onOpenStationSearch: () {},
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(Duration.zero);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(StructuredRouteMapView), findsOneWidget);
+      final painter = _findRouteMapPainter(tester);
+      expect(painter.attributionText, isNotNull);
+      expect(painter.attributionText, contains('kiwitree'));
+      expect(manifestLoadAttempts, 2);
+    },
+  );
 }

--- a/apps/mobile/test/features/network_map/presentation/route_map_attribution_test.dart
+++ b/apps/mobile/test/features/network_map/presentation/route_map_attribution_test.dart
@@ -1,0 +1,143 @@
+// 광주 노선도 CC BY-SA 2.0 KR attribution 배선 회귀(#1951).
+//
+// StructuredRouteMapPainter는 화면 좌하단에 attributionText를 직접
+// Canvas.drawPicture로 그리므로 find.text()로는 찾을 수 없다(#283-347행,
+// structured_route_map_painter.dart 참고). 대신 CustomPaint의 painter를
+// StructuredRouteMapPainter로 캐스팅해 attributionText 필드를 직접
+// assert한다 — 이 방식이 렌더 방식과 가장 정합적이고 신뢰성 있는 검증이다.
+import 'package:easysubway_mobile/features/network_map/presentation/structured_route_map_painter.dart';
+import 'package:easysubway_mobile/features/route_draft/application/route_draft_controller.dart';
+import 'package:easysubway_mobile/network_map.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _FakeNetworkMapRepository implements NetworkMapRepository {
+  _FakeNetworkMapRepository({required this.selectedRegion});
+
+  final String selectedRegion;
+
+  @override
+  Future<NetworkMapData> getNetworkMap({String? region, String? lineId}) async {
+    return NetworkMapData(
+      regions: [NetworkMapRegion(name: selectedRegion)],
+      selectedRegion: selectedRegion,
+      lines: [
+        NetworkMapLine(
+          id: 'line-1',
+          name: '$selectedRegion 1호선',
+          color: '#00A0E0',
+          region: selectedRegion,
+        ),
+      ],
+      stations: [
+        NetworkMapStation(
+          id: 'station-a',
+          nameKo: '가역',
+          nameEn: 'Ga',
+          region: selectedRegion,
+          lineId: 'line-1',
+          stationCode: '101',
+          sequence: 1,
+          position: const NetworkMapPosition(
+            x: 0,
+            y: 0,
+            labelDx: 0,
+            labelDy: 0,
+            upPath: '',
+            downPath: '',
+            sourceId: 'fixture-route-map-attribution-test',
+          ),
+        ),
+        NetworkMapStation(
+          id: 'station-b',
+          nameKo: '나역',
+          nameEn: 'Na',
+          region: selectedRegion,
+          lineId: 'line-1',
+          stationCode: '102',
+          sequence: 2,
+          position: const NetworkMapPosition(
+            x: 100,
+            y: 0,
+            labelDx: 0,
+            labelDy: 0,
+            upPath: '',
+            downPath: 'M 0 0 L 100 0',
+            sourceId: 'fixture-route-map-attribution-test',
+          ),
+        ),
+      ],
+      edges: const [],
+      positionSources: const [
+        NetworkMapPositionSource(
+          id: 'fixture-route-map-attribution-test',
+          name: 'attribution 테스트 fixture 좌표',
+          licenseStatus: 'fixture-only',
+        ),
+      ],
+      stationLineMemberships: const [
+        NetworkMapStationLineMembership(
+          stationId: 'station-a',
+          lineId: 'line-1',
+        ),
+        NetworkMapStationLineMembership(
+          stationId: 'station-b',
+          lineId: 'line-1',
+        ),
+      ],
+    );
+  }
+}
+
+StructuredRouteMapPainter _findRouteMapPainter(WidgetTester tester) {
+  final customPaintFinder = find.descendant(
+    of: find.byType(StructuredRouteMapView),
+    matching: find.byWidgetPredicate(
+      (widget) => widget is CustomPaint && widget.painter is StructuredRouteMapPainter,
+    ),
+  );
+  final painter = tester.widget<CustomPaint>(customPaintFinder).painter;
+  return painter as StructuredRouteMapPainter;
+}
+
+void main() {
+  testWidgets('광주 노선도는 CC BY-SA attribution을 화면에 배선한다(#1951)', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: NetworkMapScreen(
+          repository: _FakeNetworkMapRepository(selectedRegion: '광주'),
+          routeDraftController: RouteDraftController(),
+          onOpenStationSearch: () {},
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(Duration.zero);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(StructuredRouteMapView), findsOneWidget);
+    final painter = _findRouteMapPainter(tester);
+    expect(painter.attributionText, isNotNull);
+    expect(painter.attributionText, contains('kiwitree'));
+    expect(painter.attributionText, contains('CC BY SA'));
+  });
+
+  testWidgets('수도권 노선도는 attribution을 표시하지 않는다(#1951)', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: NetworkMapScreen(
+          repository: _FakeNetworkMapRepository(selectedRegion: '수도권'),
+          routeDraftController: RouteDraftController(),
+          onOpenStationSearch: () {},
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(Duration.zero);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(StructuredRouteMapView), findsOneWidget);
+    final painter = _findRouteMapPainter(tester);
+    expect(painter.attributionText, isNull);
+  });
+}

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -39,6 +39,7 @@ import 'package:easysubway_mobile/user_data_deletion.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart' show rootBundle;
 import 'package:flutter_test/flutter_test.dart';
 
 import 'fake_secure_key_value_storage.dart';
@@ -314,6 +315,16 @@ void main() {
   // 상대 확인 시점을 쓰는 테스트가 기준 시각을 고정한 뒤 항상 원래대로 되돌린다.
   tearDown(() {
     debugStationVerifiedClock = DateTime.now;
+  });
+
+  // #1951: 노선도 canvas와 데이터 출처 화면이 같은 datapack manifest asset을 각각
+  // rootBundle로 로드한다. rootBundle의 문자열 캐시는 테스트 간에 유지되므로, 앞선
+  // 테스트에서 manifest가 캐시에 적재되면 뒤 테스트의 FutureBuilder 완료 스케줄이
+  // 바뀌어(캐시 히트 시 microtask로 즉시 완료) 순서 의존 회귀가 생긴다. 각 테스트가
+  // cold 캐시에서 시작하도록 rootBundle과 모듈 attribution 캐시를 초기화한다.
+  tearDown(() {
+    rootBundle.clear();
+    resetNetworkMapAttributionCacheForTest();
   });
 
   testWidgets('홈에서 내 신고 화면으로 이동한다', (tester) async {


### PR DESCRIPTION
## 관련 이슈

Refs #1951

## 작업 배경

- 광주 노선도 원본 SVG는 CC BY-SA 2.0 KR로 attribution 의무가 있으나, `StructuredRouteMapPainter._paintAttribution` 기능이 있음에도 `network_map.dart`의 `_buildStructuredRouteMapCanvas()`가 `attributionText`를 전달하지 않아 노선도 화면에 출처 표기가 전혀 없었다 (#1951 실측 잔여 작업 1).
- `metro_map_pack/manifest.json`의 부산·대구·대전 항목이 `permission-required`·`redistributionAllowed:false`로 남아 있어, self-drawn-fact-based 승격이 반영된 정본 `tools/route-map/route-map-license-decision.json`과 라이선스 레이어가 불일치했다 (#1951 실측 잔여 작업 2).

## 작업 내용

- **광주 attribution 배선**: `parseNetworkMapAttributionByRegion()`이 번들 asset `metro_map_pack/manifest.json`의 `maps[].license.attributionRequired`/`authors`/`spdx`를 읽어 attribution 표기 문자열(`kiwitree, grafiker, CC BY SA 2.0 KR`)을 조립한다 — 하드코딩 지역 분기 없이 manifest가 정본. `_NetworkMapCanvasState.initState()`에서 1회 로드(모듈 캐시)하고, `_buildStructuredRouteMapCanvas()`가 `attributionText`를 `StructuredRouteMapView`에 전달한다. asset 로드 실패 시 attribution 미표기로 조용히 폴백(예외는 리포터 기록).
- `attributionRequired=false` 지역(수도권·부산·대구·대전)은 `attributionText`가 null → `_paintAttribution` 조기 리턴으로 렌더 출력 무변화.
- `DataSourceAttributionScreen`의 `_AttributionCard.map`에 `('작성자', authors)` 행을 추가해 kiwitree, grafiker가 데이터 출처 화면에도 표시된다.
- **manifest 정합화**: 부산·대구·대전 license 블록의 `reviewStatus`를 `permission-required` → `self-drawn-fact-based`, `redistributionAllowed`를 `false` → `true`로 정본 JSON과 일치시키고, `changes` 서술을 자체 schematic 렌더 전환·SVG 좌표 검수 참조 전용 사실로 갱신. seoul·gwangju 항목 무변경.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/features/network_map/` → 147/147 pass (신규 attribution 테스트 2건 포함, 기존 회귀 없음)
  - `flutter analyze` → No issues found
  - `node --test tools/ci/repository-contract.test.mjs` → 178/178 pass
  - `node tools/ci/check-map-attribution.mjs` → exit 0
  - 모든 검증은 origin/main rebase 후 재실행해 확인

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 광주 선택 시 attribution 표기 존재 | mobile (Flutter) | 위젯 테스트 — `CustomPaint`의 `StructuredRouteMapPainter.attributionText`에 `kiwitree`·`CC BY SA` 포함 assert | `apps/mobile/test/features/network_map/presentation/route_map_attribution_test.dart` | pass |
| 수도권(무표기 지역) attribution 부재 | mobile (Flutter) | 위젯 테스트 — 동일 파일에서 `attributionText` isNull assert | 동일 파일 | pass |
| attribution 불요 지역 렌더 무변화 | mobile (Flutter) | `flutter test test/features/network_map/` 전체(147건) 회귀 없음 — null attributionText는 `_paintAttribution` 조기 리턴 | CI flutter test | pass |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음 (manifest license metadata 정합화만 — pack_version 미변경, production 릴리즈 산출물 아님)
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/lib/network_map.dart`의 `parseNetworkMapAttributionByRegion()` — attribution 요부·문자열이 전부 manifest license 데이터에서 파생되는지(하드코딩 분기 없음), 그리고 `rootBundle.loadString(cache: false)` + 모듈 캐시 선택 사유 주석.
- `manifest.json` diff는 부산·대구·대전 3개 항목의 `reviewStatus`/`redistributionAllowed`/`changes`만 — 정본 `tools/route-map/route-map-license-decision.json`의 `licenseStatus: self-drawn-fact-based`(2026-07-05, #1759 승격)와 대조.

## 리스크

- attribution 로드는 비동기라 최초 프레임 몇 개는 미표기일 수 있다 — 로드 완료 시 setState로 갱신되며, 라이선스 관례상 즉시성 요건은 없다.
- manifest 파싱 실패 시 attribution 미표기 폴백 — 광주 미노출 리스크가 있으나 예외가 리포터로 기록되어 감지 가능하다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 데이터·지도 출처 화면의 지도 라이선스 정보에 작성자 항목을 추가했습니다.
  * 라이선스 표기가 필요한 지역의 구조화 노선도에 저작자 및 라이선스 정보를 표시합니다.
  * 광주 등 일부 지도 데이터의 재배포 및 이용 조건 정보를 업데이트했습니다.

* **버그 수정**
  * 라이선스 정보 로드에 실패해도 다음 화면 진입 시 다시 시도하도록 개선했습니다.

* **테스트**
  * 지역별 라이선스 표기와 로드 실패 후 재시도 동작을 검증했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->