### PR TITLE
[CI] KRIC 후보 근거 수집 workflow 추가

### DIFF
--- a/.github/workflows/kric-source-candidate-evidence.yml
+++ b/.github/workflows/kric-source-candidate-evidence.yml
@@ -22,6 +22,7 @@ on:
 jobs:
   collect:
     name: KRIC Source Candidate Evidence
+    if: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -33,7 +34,7 @@ jobs:
       - name: KRIC Source Candidate Evidence / Checkout default branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ github.sha }}
           persist-credentials: false
 
       - name: KRIC Source Candidate Evidence / Set up Node.js

--- a/.github/workflows/kric-source-candidate-evidence.yml
+++ b/.github/workflows/kric-source-candidate-evidence.yml
@@ -1,0 +1,67 @@
+name: KRIC Source Candidate Evidence
+
+on:
+  workflow_dispatch:
+    inputs:
+      candidate:
+        description: KRIC source candidate to collect
+        required: true
+        type: choice
+        options:
+          - kric-subway-route-info
+          - kric-station-info
+          - kric-train-operation-organ
+          - kric-station-transfer-info
+          - kric-station-platform
+          - kric-station-movement-standard
+          - kric-station-movement-detailed
+          - kric-transfer-movement-standard
+          - kric-transfer-movement-detailed
+          - kric-station-convenience-standard
+
+jobs:
+  collect:
+    name: KRIC Source Candidate Evidence
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      NODE_OPTIONS: --disable-warning=ExperimentalWarning
+      KRIC_CANDIDATE_ID: ${{ inputs.candidate }}
+
+    steps:
+      - name: KRIC Source Candidate Evidence / Checkout default branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: KRIC Source Candidate Evidence / Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24"
+
+      - name: KRIC Source Candidate Evidence / Collect and validate sanitized evidence
+        env:
+          KRIC_SERVICE_KEY: ${{ secrets.KRIC_SERVICE_KEY }}
+        run: |
+          set -euo pipefail
+          test -n "${KRIC_SERVICE_KEY}"
+          node tools/datapack/collect-kric-source-candidate-evidence.mjs \
+            --candidate "${KRIC_CANDIDATE_ID}"
+          test -s "${RUNNER_TEMP}/kric-source-candidate-evidence/${KRIC_CANDIDATE_ID}.sample.json"
+          test -s "${RUNNER_TEMP}/kric-source-candidate-evidence/${KRIC_CANDIDATE_ID}.report.txt"
+          test -s "${RUNNER_TEMP}/kric-source-candidate-evidence/${KRIC_CANDIDATE_ID}.hashes.json"
+
+      - name: KRIC Source Candidate Evidence / Upload sanitized evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: kric-source-candidate-evidence
+          path: |
+            ${{ runner.temp }}/kric-source-candidate-evidence/*.sample.json
+            ${{ runner.temp }}/kric-source-candidate-evidence/*.report.txt
+            ${{ runner.temp }}/kric-source-candidate-evidence/*.hashes.json
+          if-no-files-found: error
+          include-hidden-files: false
+          retention-days: 14

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -12726,3 +12726,67 @@ test("데이터팩 만료 감시 workflow는 SLA 임계보다 촘촘한 cron으�
     assertActionsEnvSecretPolicy(file, source);
   }
 });
+
+test("KRIC source 후보 evidence workflow는 고정 allowlist와 sanitized artifact 경계를 유지한다", () => {
+  const workflowPath = ".github/workflows/kric-source-candidate-evidence.yml";
+  assert.ok(existsSync(path.join(root, workflowPath)), "KRIC evidence workflow must exist");
+
+  const workflow = read(workflowPath);
+  const triggerBlock = workflow.match(/^on:\s*\n([\s\S]*?)^jobs:/m)?.[1] ?? "";
+  const triggers = [...triggerBlock.matchAll(/^ {2}([a-z_]+): *$/gm)].map((match) => match[1]);
+  const inputBlock = triggerBlock.match(/workflow_dispatch:\s*\n\s+inputs:\s*\n([\s\S]*)/)?.[1] ?? "";
+  const inputNames = [...inputBlock.matchAll(/^ {6}([A-Za-z][A-Za-z0-9_-]*): *$/gm)]
+    .map((match) => match[1]);
+  const candidateBlock = inputBlock.match(/^ {6}candidate: *\n([\s\S]*)/m)?.[1] ?? "";
+  const optionsBlock = candidateBlock.match(/^ {8}options: *\n((?:^ {10}- [^\n]+\n?)+)/m)?.[1] ?? "";
+  const candidateOptions = [...optionsBlock.matchAll(/^ {10}- ([a-z0-9-]+) *$/gm)]
+    .map((match) => match[1]);
+
+  assert.deepEqual(triggers, ["workflow_dispatch"]);
+  assert.deepEqual(inputNames, ["candidate"]);
+  assert.match(candidateBlock, /^ {8}type: choice$/m);
+  assert.deepEqual(candidateOptions, [
+    "kric-subway-route-info",
+    "kric-station-info",
+    "kric-train-operation-organ",
+    "kric-station-transfer-info",
+    "kric-station-platform",
+    "kric-station-movement-standard",
+    "kric-station-movement-detailed",
+    "kric-transfer-movement-standard",
+    "kric-transfer-movement-detailed",
+    "kric-station-convenience-standard",
+  ]);
+  const permissions = workflow.match(/^ {4}permissions: *\n((?:^ {6}[^\n]+\n?)+)/m)?.[1]
+    .trim()
+    .split("\n")
+    .map((line) => line.trim());
+  assert.deepEqual(permissions, ["contents: read"]);
+
+  const secretNames = [...workflow.matchAll(/secrets\.([A-Z0-9_]+)/g)].map((match) => match[1]);
+  assert.deepEqual([...new Set(secretNames)], ["KRIC_SERVICE_KEY"]);
+  assert.match(workflow, /ref: \$\{\{ github\.event\.repository\.default_branch \}\}/);
+  assert.equal((workflow.match(/\$\{\{ inputs\.candidate \}\}/g) ?? []).length, 1);
+  assert.match(workflow, /KRIC_CANDIDATE_ID: \$\{\{ inputs\.candidate \}\}/);
+  assert.match(workflow, /collect-kric-source-candidate-evidence\.mjs/);
+  const collector = read("tools/datapack/collect-kric-source-candidate-evidence.mjs");
+  assert.match(collector, /build-source-candidate-sample-evidence\.mjs/);
+  assert.match(collector, /validate-source-candidate-sample\.mjs/);
+  assert.match(workflow, /retention-days: 14/);
+  assert.match(workflow, /include-hidden-files: false/);
+  assert.match(workflow, /if-no-files-found: error/);
+
+  const referenceWorkflow = read(".github/workflows/tago-schedule-collection.yml");
+  for (const action of ["actions/checkout", "actions/setup-node", "actions/upload-artifact"]) {
+    const pinnedSha = referenceWorkflow.match(new RegExp(`${action}@([0-9a-f]{40})`))?.[1];
+    assert.ok(pinnedSha, `${action} reference pin must exist`);
+    assert.match(workflow, new RegExp(`${action}@${pinnedSha}`));
+  }
+
+  const uploadBlock = workflow.match(/uses: actions\/upload-artifact@[0-9a-f]{40}[\s\S]*$/)?.[0] ?? "";
+  assert.match(uploadBlock, /sample\.json/);
+  assert.match(uploadBlock, /report\.txt/);
+  assert.match(uploadBlock, /hashes\.json/);
+  assert.doesNotMatch(uploadBlock, /\braw\b|response|\.env|dotenv/i);
+  assert.doesNotMatch(workflow, /github\.event\.inputs\.(?:url|host|ref|command|output|path)/i);
+});

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -12765,7 +12765,12 @@ test("KRIC source 후보 evidence workflow는 고정 allowlist와 sanitized arti
 
   const secretNames = [...workflow.matchAll(/secrets\.([A-Z0-9_]+)/g)].map((match) => match[1]);
   assert.deepEqual([...new Set(secretNames)], ["KRIC_SERVICE_KEY"]);
-  assert.match(workflow, /ref: \$\{\{ github\.event\.repository\.default_branch \}\}/);
+  assert.match(
+    workflow,
+    /if: \$\{\{ github\.ref == format\('refs\/heads\/\{0\}', github\.event\.repository\.default_branch\) \}\}/,
+  );
+  assert.match(workflow, /ref: \$\{\{ github\.sha \}\}/);
+  assert.doesNotMatch(workflow, /ref: \$\{\{ github\.event\.repository\.default_branch \}\}/);
   assert.equal((workflow.match(/\$\{\{ inputs\.candidate \}\}/g) ?? []).length, 1);
   assert.match(workflow, /KRIC_CANDIDATE_ID: \$\{\{ inputs\.candidate \}\}/);
   assert.match(workflow, /collect-kric-source-candidate-evidence\.mjs/);

--- a/tools/datapack/collect-kric-source-candidate-evidence.mjs
+++ b/tools/datapack/collect-kric-source-candidate-evidence.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { execFile } from "node:child_process";
-import { readFile, mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { promisify } from "node:util";
@@ -129,17 +129,23 @@ export async function collectKricSourceCandidateEvidence({
   const document = candidatesDocument ?? JSON.parse(await readFile(CANDIDATES_PATH, "utf8"));
   const request = resolveKricCandidateRequest(document, candidateId);
   const outputDirectory = path.join(runnerTemp, "kric-source-candidate-evidence");
+  const stagingDirectory = path.join(runnerTemp, "kric-source-candidate-staging");
   const rawDirectory = path.join(runnerTemp, "kric-source-candidate-raw");
   const rawPath = path.join(rawDirectory, `${candidateId}.response`);
-  const samplePath = path.join(outputDirectory, `${candidateId}.sample.json`);
-  const reportPath = path.join(outputDirectory, `${candidateId}.report.txt`);
-  const hashesPath = path.join(outputDirectory, `${candidateId}.hashes.json`);
+  const stagedSamplePath = path.join(stagingDirectory, `${candidateId}.sample.json`);
+  const stagedReportPath = path.join(stagingDirectory, `${candidateId}.report.txt`);
+  const stagedHashesPath = path.join(stagingDirectory, `${candidateId}.hashes.json`);
+  const samplePath = path.join(outputDirectory, path.basename(stagedSamplePath));
+  const reportPath = path.join(outputDirectory, path.basename(stagedReportPath));
+  const hashesPath = path.join(outputDirectory, path.basename(stagedHashesPath));
 
   await rm(outputDirectory, { recursive: true, force: true });
+  await rm(stagingDirectory, { recursive: true, force: true });
   await rm(rawDirectory, { recursive: true, force: true });
-  await mkdir(outputDirectory, { recursive: true, mode: 0o700 });
+  await mkdir(stagingDirectory, { recursive: true, mode: 0o700 });
   await mkdir(rawDirectory, { recursive: true, mode: 0o700 });
 
+  let completed = false;
   try {
     const liveUrl = new URL(request.sampleUrl);
     liveUrl.searchParams.set("serviceKey", serviceKey);
@@ -160,14 +166,14 @@ export async function collectKricSourceCandidateEvidence({
       "--format", request.format,
     ]);
     JSON.parse(sample);
-    await writeFile(samplePath, sample, { mode: 0o600 });
+    await writeFile(stagedSamplePath, sample, { mode: 0o600 });
 
     const { stdout: report } = await runEvidenceTool("validate-source-candidate-sample.mjs", [
       "--candidate", candidateId,
       "--candidates", CANDIDATES_PATH,
-      "--sample", samplePath,
+      "--sample", stagedSamplePath,
     ]);
-    await writeFile(reportPath, report, { mode: 0o600 });
+    await writeFile(stagedReportPath, report, { mode: 0o600 });
 
     const evidence = JSON.parse(sample);
     const hashes = {
@@ -177,16 +183,28 @@ export async function collectKricSourceCandidateEvidence({
       evidenceHash: evidence.evidenceHash,
       providerRecordHashes: evidence.providerRecordHashes,
     };
-    await writeFile(hashesPath, `${JSON.stringify(hashes, null, 2)}\n`, { mode: 0o600 });
+    await writeFile(stagedHashesPath, `${JSON.stringify(hashes, null, 2)}\n`, { mode: 0o600 });
 
-    for (const outputPath of [samplePath, reportPath, hashesPath]) {
+    for (const outputPath of [stagedSamplePath, stagedReportPath, stagedHashesPath]) {
       if (!(await readFile(outputPath, "utf8")).trim()) {
         throw new Error(`sanitized evidence output is empty: ${path.basename(outputPath)}`);
       }
     }
+
+    await mkdir(outputDirectory, { recursive: true, mode: 0o700 });
+    await rename(stagedSamplePath, samplePath);
+    await rename(stagedReportPath, reportPath);
+    await rename(stagedHashesPath, hashesPath);
+    completed = true;
     return { sample: samplePath, report: reportPath, hashes: hashesPath };
+  } catch (error) {
+    throw new Error(sanitizeErrorMessage(error, serviceKey));
   } finally {
     await rm(rawDirectory, { recursive: true, force: true });
+    await rm(stagingDirectory, { recursive: true, force: true });
+    if (!completed) {
+      await rm(outputDirectory, { recursive: true, force: true });
+    }
   }
 }
 

--- a/tools/datapack/collect-kric-source-candidate-evidence.mjs
+++ b/tools/datapack/collect-kric-source-candidate-evidence.mjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+import { execFile } from "node:child_process";
+import { readFile, mkdir, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+
+export const KRIC_SOURCE_CANDIDATE_IDS = Object.freeze([
+  "kric-subway-route-info",
+  "kric-station-info",
+  "kric-train-operation-organ",
+  "kric-station-transfer-info",
+  "kric-station-platform",
+  "kric-station-movement-standard",
+  "kric-station-movement-detailed",
+  "kric-transfer-movement-standard",
+  "kric-transfer-movement-detailed",
+  "kric-station-convenience-standard",
+]);
+
+const KRIC_ORIGIN = "https://openapi.kric.go.kr";
+const TOOL_DIRECTORY = path.dirname(fileURLToPath(import.meta.url));
+const REPOSITORY_ROOT = path.resolve(TOOL_DIRECTORY, "../..");
+const CANDIDATES_PATH = path.join(TOOL_DIRECTORY, "source-candidates.json");
+const execFileAsync = promisify(execFile);
+
+function requiredText(value, label) {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${label} is required`);
+  }
+  return value;
+}
+
+function assertKricUrl(url, label) {
+  if (url.origin !== KRIC_ORIGIN) {
+    throw new Error(`${label} provider origin must be ${KRIC_ORIGIN}`);
+  }
+  if (!url.pathname.startsWith("/openapi/") || url.username || url.password || url.hash) {
+    throw new Error(`${label} must be a credential-free KRIC OpenAPI URL`);
+  }
+}
+
+export function resolveKricCandidateRequest(candidatesDocument, candidateId) {
+  if (!KRIC_SOURCE_CANDIDATE_IDS.includes(candidateId)) {
+    throw new Error(`candidate is not allowed: ${candidateId}`);
+  }
+
+  const candidate = candidatesDocument.candidates?.find((entry) => entry.id === candidateId);
+  if (!candidate) {
+    throw new Error(`tracked candidate metadata is missing: ${candidateId}`);
+  }
+  if (candidate.sampleEvidenceStatus !== "sample_url_documented_key_required") {
+    throw new Error(`${candidateId} sample evidence status is not pending`);
+  }
+  if (candidate.admissionStatus !== "evidence_recorded_admin_review_required") {
+    throw new Error(`${candidateId} admission status no longer requires admin review`);
+  }
+
+  const endpoint = new URL(requiredText(candidate.evidence?.endpoint, `${candidateId}.evidence.endpoint`));
+  const requestUrl = new URL(requiredText(candidate.requestUrl, `${candidateId}.requestUrl`));
+  const sampleUrl = new URL(requiredText(candidate.evidence?.sampleUrl, `${candidateId}.evidence.sampleUrl`));
+  assertKricUrl(endpoint, `${candidateId}.evidence.endpoint`);
+  assertKricUrl(requestUrl, `${candidateId}.requestUrl`);
+  assertKricUrl(sampleUrl, `${candidateId}.evidence.sampleUrl`);
+
+  if (requestUrl.href !== endpoint.href) {
+    throw new Error(`${candidateId} requestUrl must match evidence endpoint`);
+  }
+  if (sampleUrl.origin !== endpoint.origin || sampleUrl.pathname !== endpoint.pathname) {
+    throw new Error(`${candidateId} sampleUrl must use the tracked evidence endpoint`);
+  }
+  const serviceKeys = [...sampleUrl.searchParams.entries()]
+    .filter(([name]) => name.toLowerCase() === "servicekey");
+  if (serviceKeys.length !== 1 || serviceKeys[0][0] !== "serviceKey" || serviceKeys[0][1] !== "[서비스키값]") {
+    throw new Error(`${candidateId} sampleUrl must contain exactly one redacted serviceKey`);
+  }
+
+  const format = requiredText(sampleUrl.searchParams.get("format"), `${candidateId} sample format`).toLowerCase();
+  const supportedFormats = new Set((candidate.evidence?.formats ?? []).map((value) => String(value).toLowerCase()));
+  if (!new Set(["json", "xml"]).has(format) || !supportedFormats.has(format)) {
+    throw new Error(`${candidateId} sample format is not supported: ${format}`);
+  }
+
+  return {
+    candidateId,
+    endpoint: endpoint.href,
+    format,
+    sampleUrl,
+  };
+}
+
+function parseCli(argv) {
+  if (argv.length !== 2 || argv[0] !== "--candidate" || !argv[1] || argv[1].startsWith("--")) {
+    throw new Error("usage: collect-kric-source-candidate-evidence.mjs --candidate <fixed-candidate-id>");
+  }
+  return { candidateId: argv[1] };
+}
+
+function sanitizeErrorMessage(error, serviceKey) {
+  let message = error instanceof Error ? error.message : String(error);
+  for (const value of [serviceKey, encodeURIComponent(serviceKey)]) {
+    if (value) {
+      message = message.replaceAll(value, "[REDACTED]");
+    }
+  }
+  return message.replace(/([?&]serviceKey=)[^&\s]+/gi, "$1[REDACTED]");
+}
+
+async function runEvidenceTool(scriptName, args) {
+  return execFileAsync(process.execPath, [path.join(TOOL_DIRECTORY, scriptName), ...args], {
+    cwd: REPOSITORY_ROOT,
+    encoding: "utf8",
+    maxBuffer: 20 * 1024 * 1024,
+  });
+}
+
+export async function collectKricSourceCandidateEvidence({
+  candidateId,
+  candidatesDocument,
+  fetchImpl = fetch,
+  runnerTemp = process.env.RUNNER_TEMP,
+  serviceKey = process.env.KRIC_SERVICE_KEY,
+} = {}) {
+  requiredText(serviceKey, "KRIC_SERVICE_KEY");
+  if (!path.isAbsolute(requiredText(runnerTemp, "RUNNER_TEMP"))) {
+    throw new Error("RUNNER_TEMP must be an absolute path");
+  }
+
+  const document = candidatesDocument ?? JSON.parse(await readFile(CANDIDATES_PATH, "utf8"));
+  const request = resolveKricCandidateRequest(document, candidateId);
+  const outputDirectory = path.join(runnerTemp, "kric-source-candidate-evidence");
+  const rawDirectory = path.join(runnerTemp, "kric-source-candidate-raw");
+  const rawPath = path.join(rawDirectory, `${candidateId}.response`);
+  const samplePath = path.join(outputDirectory, `${candidateId}.sample.json`);
+  const reportPath = path.join(outputDirectory, `${candidateId}.report.txt`);
+  const hashesPath = path.join(outputDirectory, `${candidateId}.hashes.json`);
+
+  await rm(outputDirectory, { recursive: true, force: true });
+  await rm(rawDirectory, { recursive: true, force: true });
+  await mkdir(outputDirectory, { recursive: true, mode: 0o700 });
+  await mkdir(rawDirectory, { recursive: true, mode: 0o700 });
+
+  try {
+    const liveUrl = new URL(request.sampleUrl);
+    liveUrl.searchParams.set("serviceKey", serviceKey);
+    const response = await fetchImpl(liveUrl, {
+      redirect: "error",
+      signal: AbortSignal.timeout(30_000),
+      headers: { accept: request.format === "json" ? "application/json" : "application/xml,text/xml" },
+    });
+    if (!response.ok) {
+      throw new Error(`KRIC request failed with HTTP ${response.status}`);
+    }
+    await writeFile(rawPath, await response.text(), { mode: 0o600 });
+
+    const { stdout: sample } = await runEvidenceTool("build-source-candidate-sample-evidence.mjs", [
+      "--candidate", candidateId,
+      "--candidates", CANDIDATES_PATH,
+      "--response", rawPath,
+      "--format", request.format,
+    ]);
+    JSON.parse(sample);
+    await writeFile(samplePath, sample, { mode: 0o600 });
+
+    const { stdout: report } = await runEvidenceTool("validate-source-candidate-sample.mjs", [
+      "--candidate", candidateId,
+      "--candidates", CANDIDATES_PATH,
+      "--sample", samplePath,
+    ]);
+    await writeFile(reportPath, report, { mode: 0o600 });
+
+    const evidence = JSON.parse(sample);
+    const hashes = {
+      candidateId,
+      rawSha256: evidence.rawSha256,
+      schemaFingerprint: evidence.schemaFingerprint,
+      evidenceHash: evidence.evidenceHash,
+      providerRecordHashes: evidence.providerRecordHashes,
+    };
+    await writeFile(hashesPath, `${JSON.stringify(hashes, null, 2)}\n`, { mode: 0o600 });
+
+    for (const outputPath of [samplePath, reportPath, hashesPath]) {
+      if (!(await readFile(outputPath, "utf8")).trim()) {
+        throw new Error(`sanitized evidence output is empty: ${path.basename(outputPath)}`);
+      }
+    }
+    return { sample: samplePath, report: reportPath, hashes: hashesPath };
+  } finally {
+    await rm(rawDirectory, { recursive: true, force: true });
+  }
+}
+
+async function main() {
+  const { candidateId } = parseCli(process.argv.slice(2));
+  await collectKricSourceCandidateEvidence({ candidateId });
+  console.log(`sanitized KRIC source candidate evidence ready: ${candidateId}`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  main().catch((error) => {
+    console.error(sanitizeErrorMessage(error, process.env.KRIC_SERVICE_KEY ?? ""));
+    process.exitCode = 1;
+  });
+}

--- a/tools/datapack/collect-kric-source-candidate-evidence.test.mjs
+++ b/tools/datapack/collect-kric-source-candidate-evidence.test.mjs
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  collectKricSourceCandidateEvidence,
+  KRIC_SOURCE_CANDIDATE_IDS,
+  resolveKricCandidateRequest,
+} from "./collect-kric-source-candidate-evidence.mjs";
+
+const candidate = {
+  id: "kric-train-operation-organ",
+  requestUrl: "https://openapi.kric.go.kr/openapi/convenientInfo/trainOperationOrgan",
+  sampleEvidenceStatus: "sample_url_documented_key_required",
+  admissionStatus: "evidence_recorded_admin_review_required",
+  evidence: {
+    endpoint: "https://openapi.kric.go.kr/openapi/convenientInfo/trainOperationOrgan",
+    sampleUrl: "https://openapi.kric.go.kr/openapi/convenientInfo/trainOperationOrgan?serviceKey=[서비스키값]&format=json&railOprIsttCd=DJ",
+    formats: ["JSON", "XML"],
+    outputFields: ["railOprIsttCd", "railOprIsttNm"],
+  },
+};
+
+test("KRIC evidence collector는 정확한 10개 allowlist와 tracked endpoint를 강제한다", () => {
+  assert.deepEqual(KRIC_SOURCE_CANDIDATE_IDS, [
+    "kric-subway-route-info",
+    "kric-station-info",
+    "kric-train-operation-organ",
+    "kric-station-transfer-info",
+    "kric-station-platform",
+    "kric-station-movement-standard",
+    "kric-station-movement-detailed",
+    "kric-transfer-movement-standard",
+    "kric-transfer-movement-detailed",
+    "kric-station-convenience-standard",
+  ]);
+
+  const request = resolveKricCandidateRequest({ candidates: [candidate] }, candidate.id);
+  assert.equal(request.candidateId, candidate.id);
+  assert.equal(request.endpoint, candidate.evidence.endpoint);
+  assert.equal(request.format, "json");
+
+  assert.throws(
+    () => resolveKricCandidateRequest({ candidates: [candidate] }, "kric-subway-timetable"),
+    /candidate is not allowed/,
+  );
+  assert.throws(
+    () => resolveKricCandidateRequest({
+      candidates: [{
+        ...candidate,
+        requestUrl: "https://openapi.kric.go.kr/openapi/convenientInfo/stationInfo",
+      }],
+    }, candidate.id),
+    /requestUrl must match evidence endpoint/,
+  );
+  assert.throws(
+    () => resolveKricCandidateRequest({
+      candidates: [{
+        ...candidate,
+        requestUrl: "https://example.com/source",
+        evidence: {
+          ...candidate.evidence,
+          endpoint: "https://example.com/source",
+          sampleUrl: "https://example.com/source?serviceKey=[서비스키값]&format=json",
+        },
+      }],
+    }, candidate.id),
+    /provider origin must be https:\/\/openapi\.kric\.go\.kr/,
+  );
+});
+
+test("KRIC evidence collector는 raw를 제거하고 sanitized sample/report/hashes만 남긴다", async () => {
+  const runnerTemp = await mkdtemp(path.join(tmpdir(), "easysubway-kric-evidence-"));
+  const serviceKey = "test-kric-service-key";
+  try {
+    const outputs = await collectKricSourceCandidateEvidence({
+      candidateId: candidate.id,
+      candidatesDocument: { candidates: [candidate] },
+      runnerTemp,
+      serviceKey,
+      fetchImpl: async (url, options) => {
+        assert.equal(options.redirect, "error");
+        assert.equal(url.searchParams.get("serviceKey"), serviceKey);
+        return new Response(JSON.stringify([
+          { railOprIsttCd: "S1", railOprIsttNm: "서울교통공사" },
+        ]), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    });
+
+    assert.equal(existsSync(path.join(runnerTemp, "kric-source-candidate-raw")), false);
+    assert.deepEqual(Object.keys(outputs).sort(), ["hashes", "report", "sample"]);
+    const sample = JSON.parse(await readFile(outputs.sample, "utf8"));
+    const report = await readFile(outputs.report, "utf8");
+    const hashes = JSON.parse(await readFile(outputs.hashes, "utf8"));
+    assert.equal(sample.candidateId, candidate.id);
+    assert.match(report, /source candidate sample evidence valid/);
+    assert.equal(hashes.candidateId, candidate.id);
+    assert.equal(hashes.rawSha256, sample.rawSha256);
+    assert.equal(hashes.evidenceHash, sample.evidenceHash);
+    assert.doesNotMatch(`${JSON.stringify(sample)}\n${report}\n${JSON.stringify(hashes)}`, new RegExp(serviceKey));
+  } finally {
+    await rm(runnerTemp, { recursive: true, force: true });
+  }
+});

--- a/tools/datapack/collect-kric-source-candidate-evidence.test.mjs
+++ b/tools/datapack/collect-kric-source-candidate-evidence.test.mjs
@@ -107,3 +107,57 @@ test("KRIC evidence collector는 raw를 제거하고 sanitized sample/report/has
     await rm(runnerTemp, { recursive: true, force: true });
   }
 });
+
+test("KRIC evidence collector는 실패 단계와 무관하게 raw와 uploadable output을 제거하고 key를 숨긴다", async (t) => {
+  const serviceKey = "test/key+with space";
+  const encodedServiceKey = encodeURIComponent(serviceKey);
+  const cases = [
+    {
+      name: "fetch failure",
+      fetchImpl: async () => {
+        throw new Error(`request failed for ${serviceKey} and ${encodedServiceKey}`);
+      },
+      expectedError: /request failed for \[REDACTED\] and \[REDACTED\]/,
+    },
+    {
+      name: "builder failure",
+      fetchImpl: async () => new Response(JSON.stringify({ serviceKey }), { status: 200 }),
+      expectedError: /raw sample response must not contain serviceKey credentials/,
+    },
+    {
+      name: "validator failure",
+      fetchImpl: async () => new Response(JSON.stringify([
+        { railOprIsttCd: "S1" },
+      ]), { status: 200 }),
+      expectedError: /output field missing: railOprIsttNm/,
+    },
+  ];
+
+  for (const failureCase of cases) {
+    await t.test(failureCase.name, async () => {
+      const runnerTemp = await mkdtemp(path.join(tmpdir(), "easysubway-kric-evidence-failure-"));
+      try {
+        await assert.rejects(
+          collectKricSourceCandidateEvidence({
+            candidateId: candidate.id,
+            candidatesDocument: { candidates: [candidate] },
+            runnerTemp,
+            serviceKey,
+            fetchImpl: failureCase.fetchImpl,
+          }),
+          (error) => {
+            assert.match(error.message, failureCase.expectedError);
+            assert.doesNotMatch(error.message, new RegExp(serviceKey.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+            assert.doesNotMatch(error.message, new RegExp(encodedServiceKey.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+            return true;
+          },
+        );
+        assert.equal(existsSync(path.join(runnerTemp, "kric-source-candidate-raw")), false);
+        assert.equal(existsSync(path.join(runnerTemp, "kric-source-candidate-staging")), false);
+        assert.equal(existsSync(path.join(runnerTemp, "kric-source-candidate-evidence")), false);
+      } finally {
+        await rm(runnerTemp, { recursive: true, force: true });
+      }
+    });
+  }
+});


### PR DESCRIPTION
## 관련 이슈

Refs #1397

## 작업 배경

### 목적

- 활용신청 승인을 기다리는 KRIC source candidate 10개의 실제 응답 근거를, source admission 전에 안전하게 수집·검증할 수 있는 수동 workflow를 마련합니다.
- 수집 결과가 곧 production source 승인이나 inventory 반영으로 오해되지 않도록 evidence 수집 경계만 추가합니다.

## 작업 내용

- `workflow_dispatch`의 고정 `choice` 입력만 받는 KRIC 후보 근거 수집 workflow를 추가했습니다.
- tracked `source-candidates.json`과 고정 allowlist를 함께 검증하고, KRIC OpenAPI URL·후보 상태·redacted `serviceKey` 계약이 어긋나면 fail-closed 처리하는 collector를 추가했습니다.
- provider raw response는 `${RUNNER_TEMP}`의 mode `0600` 임시 파일로만 다루고 `finally`에서 제거하며, 기존 builder와 validator를 통과한 sanitized sample/report/hash만 14일 artifact로 남깁니다.
- workflow trigger, action SHA pin, least privilege, secret·artifact 경계와 collector 동작을 고정하는 계약 테스트 및 단위 테스트를 추가했습니다.

### 영향

- GitHub Actions의 수동 evidence 수집 경로와 repository contract test에만 영향을 줍니다.
- mobile/backend 동작, DB schema, route/realtime contract, datapack version·inventory·release object는 변경하지 않습니다.
- 자동 실행 trigger가 없어 merge 자체로 provider 호출이나 production publish가 발생하지 않습니다.

### 보안 경계

- job permission은 `contents: read`만 사용하고 checkout credential persistence를 비활성화했습니다.
- `secrets.KRIC_SERVICE_KEY` 하나만 참조하며 key를 shell argument나 artifact에 기록하지 않습니다.
- dispatcher가 URL, host, ref, command, output path를 주입할 수 없고, checkout은 repository default branch로 고정합니다.
- raw response는 업로드하지 않고 검증된 sanitized output만 고정 glob으로 업로드합니다.

## 검증

- `node --test --test-name-pattern='KRIC source 후보 evidence workflow' tools/ci/repository-contract.test.mjs` — PASS (1/1)
- `node --test tools/datapack/collect-kric-source-candidate-evidence.test.mjs` — PASS (2/2)
- `node --test tools/datapack/datapack-tools.test.mjs` — PASS (211/211)
- `node --test tools/ci/repository-contract.test.mjs` — PASS (179/179)
- `node --check tools/datapack/collect-kric-source-candidate-evidence.mjs` — PASS
- `ruby -e 'require "yaml"; YAML.parse_file(ARGV.fetch(0))' .github/workflows/kric-source-candidate-evidence.yml` — PASS
- 실제 `source-candidates.json`의 allowlist 10개에 `resolveKricCandidateRequest` 실행 — PASS (10/10)
- `git diff --check`, `git diff --cached --check`, `git show --check --oneline HEAD` — PASS
- `actionlint`/`yamllint`는 local executable이 없어 실행하지 않았습니다. repository contract, Ruby YAML parser, Node syntax check로 대체 검증했습니다.

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 구현·계약 검증 | local macOS / Node.js | 위 자동화 명령 fresh 실행 | `/private/tmp/easysubway-1397-kric-workflow-report.md` | PASS |
| UI 수동 QA | 해당 없음 | UI 변경이 없어 수동 QA 불필요 | 변경 파일이 workflow·Node tool·test로 한정됨 | 불필요 |
| KRIC live dispatch | GitHub Actions / KRIC | 실제 secret 및 provider 호출이 필요한 운영 검증 | 이번 PR 생성 범위에서는 workflow dispatch 금지 | 미실행 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: dispatcher 입력·secret·raw response가 artifact 또는 process argument 경계를 넘지 않는지, 그리고 기존 builder/validator를 통과한 output만 남는지 확인이 필요합니다.
- 현재 local reviewer가 확인한 finding은 아직 이 head에 반영하지 않았습니다. review-first 순서로 PR review를 먼저 게시한 뒤, current code에서 유효성을 재검증하고 별도 follow-up commit으로 수정할 예정입니다. 그 전에는 auto-merge를 활성화하지 않습니다.
- live KRIC workflow dispatch는 review 및 후속 수정 완료 후 별도 운영 승인 범위에서 확인합니다.

## 리스크

- Risk A — CI workflow와 secret/provider 응답 처리 경계를 추가하는 제품·운영 위험 변경입니다.
- 잘못된 candidate metadata나 URL은 evidence 수집 실패로 이어질 수 있으며, 이를 allowlist·origin/path·metadata 일치 검증으로 fail-closed 처리합니다.
- 실제 provider 응답 형식과 secret 유효성은 live dispatch를 실행하지 않아 아직 검증되지 않았습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * KRIC 소스 후보를 선택해 증거 자료를 수집·검증하는 수동 실행 워크플로우를 추가했습니다.
  * 수집 결과로 샘플, 검증 리포트, 해시 정보를 제공하며 14일간 아티팩트로 보관합니다.
  * 민감한 인증 정보와 원본 응답은 결과에서 제외하거나 마스킹합니다.

* **테스트**
  * 허용된 후보 목록, 요청 유효성, 결과 파일 구성 및 민감 정보 제거 여부를 자동 검증합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->