### PR TITLE
[Fix] KRIC schema fingerprint 정렬 계약 수정

### DIFF
--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -6876,6 +6876,61 @@ test("source candidate sample evidence builder는 raw JSON response를 validator
   );
 });
 
+test("source candidate sample builder와 validator는 code-unit field 정렬을 공유한다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-source-candidate-field-sort-${Date.now()}`);
+  const responsePath = path.join(outputDir, "response.json");
+  const evidencePath = path.join(outputDir, "evidence.json");
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(
+    responsePath,
+    `${JSON.stringify([{
+      stinCd: "312",
+      stLocCont: "3호선 승강장",
+      railOprIsttCd: "S1",
+      lnCd: "3",
+      clsLocCont: "환승 통로",
+      chtnLn: "4",
+      chtnDst: "120",
+    }])}\n`,
+  );
+
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    [
+      "tools/datapack/build-source-candidate-sample-evidence.mjs",
+      "--candidate",
+      "kric-station-transfer-info",
+      "--response",
+      responsePath,
+    ],
+    { cwd: root },
+  );
+  await writeFile(evidencePath, stdout);
+  const evidence = JSON.parse(stdout);
+  assert.deepEqual(evidence.fields, [
+    "chtnDst",
+    "chtnLn",
+    "clsLocCont",
+    "lnCd",
+    "railOprIsttCd",
+    "stLocCont",
+    "stinCd",
+  ]);
+
+  await execFileAsync(
+    process.execPath,
+    [
+      "tools/datapack/validate-source-candidate-sample.mjs",
+      "--candidate",
+      "kric-station-transfer-info",
+      "--sample",
+      evidencePath,
+    ],
+    { cwd: root },
+  );
+});
+
 test("source candidate sample evidence builder는 raw XML response를 validator 입력으로 변환한다", async () => {
   const outputDir = path.join(tmpdir(), `easysubway-source-candidate-xml-evidence-${Date.now()}`);
   const responsePath = path.join(outputDir, "response.xml");

--- a/tools/datapack/validate-source-candidate-sample.mjs
+++ b/tools/datapack/validate-source-candidate-sample.mjs
@@ -127,7 +127,7 @@ function validateEvidenceMetadata(sample) {
   }
 
   const expectedSchemaFingerprint = sha256(JSON.stringify(
-    [...sample.fields].sort((left, right) => left.localeCompare(right)),
+    [...sample.fields].sort(),
   ));
   if (sample.schemaFingerprint !== expectedSchemaFingerprint) {
     throw new Error("schemaFingerprint does not match fields");

--- a/tools/datapack/validate-source-candidate-sample.mjs
+++ b/tools/datapack/validate-source-candidate-sample.mjs
@@ -127,7 +127,7 @@ function validateEvidenceMetadata(sample) {
   }
 
   const expectedSchemaFingerprint = sha256(JSON.stringify(
-    [...sample.fields].sort(),
+    [...sample.fields].sort((left, right) => left < right ? -1 : Number(left !== right)),
   ));
   if (sample.schemaFingerprint !== expectedSchemaFingerprint) {
     throw new Error("schemaFingerprint does not match fields");


### PR DESCRIPTION
## 관련 이슈

Refs #1397

## 작업 배경

- 공식 KRIC `stationTransferInfo` live 수집 run `29148742652`에서 provider 응답 자체는 정상 수신됐지만, evidence builder가 만든 schema fingerprint를 validator가 거부했습니다.
- 원인은 provider schema drift가 아니라 builder의 기본 `.sort()`와 validator의 locale-sensitive `localeCompare`가 `stLocCont`·`stinCd`의 상대 순서를 다르게 계산한 내부 계약 불일치입니다.

## 작업 내용

- validator의 schema fingerprint 정렬을 builder와 같은 JavaScript code-unit 기본 `.sort()`로 맞췄습니다(생산 코드 1줄).
- 실제 `kric-station-transfer-info` 7개 field로 builder→validator CLI 경로를 실행하는 회귀 테스트 1건을 추가했습니다.
- candidate metadata, inventory, fixture, production datapack, workflow, credential 처리에는 손대지 않았습니다.

### 영향

- KRIC live 응답으로 생성한 sanitized evidence가 runtime locale/ICU 차이 없이 동일한 fingerprint 계약으로 검증됩니다.
- 사용자 UI와 mobile/backend 동작에는 변화가 없고, datapack 실무자는 정상 provider 응답을 내부 정렬 차이 때문에 다시 조사하지 않아도 됩니다.

## 검증

- RED: `node --test --test-name-pattern='code-unit field 정렬' tools/datapack/datapack-tools.test.mjs` — 수정 전 exit 1, `schemaFingerprint does not match fields` (1 fail).
- GREEN: 동일 명령 — 수정 후 exit 0 (1/1 pass).
- `node --test tools/datapack/datapack-tools.test.mjs` — PASS (212/212).
- `node --test tools/ci/repository-contract.test.mjs` — PASS (179/179).
- `node --check tools/datapack/build-source-candidate-sample-evidence.mjs && node --check tools/datapack/validate-source-candidate-sample.mjs && node --check tools/datapack/datapack-tools.test.mjs` — PASS.
- `git diff --check origin/main...HEAD` — PASS.

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| KRIC live failure 재현 근거 | GitHub Actions / KRIC | 공식 `stationTransferInfo` 응답 이후 validator failure 확인 | workflow run `29148742652` | 원인 확인 |
| 구현·계약 검증 | local macOS / Node.js | RED/GREEN 및 전체 datapack·repository contract test fresh 실행 | `/private/tmp/easysubway-1397-fingerprint-sort-report.md` | PASS |
| UI·접근성·수동 QA | 해당 없음 | Node datapack tool 2파일만 변경되어 렌더링/UI 경로가 없음 | diff 범위 확인 | 불필요 |
| 배포 확인 | 해당 없음 | production datapack·workflow·release object를 변경하지 않음 | diff 범위 확인 | 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: builder의 기존 code-unit 정렬과 validator의 fingerprint 재계산이 정확히 같은 계약을 사용하는지 확인해 주세요.
- 알려진 finding은 없습니다. 코드리뷰 완료 후 CI를 판정하며, 그 전에는 auto-merge를 활성화하지 않습니다.

## 리스크

- Risk A — 데이터 source evidence 검증 계약을 수정하는 제품·운영 위험 변경입니다.
- 변경은 validator 1줄과 실제 CLI 경로 회귀 테스트 1건으로 제한했고, 기존 211개 datapack test 및 179개 repository contract test가 유지됩니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
