### PR TITLE
[Fix] KRIC source field 계약 진단 보강

### DIFF
--- a/tools/datapack/collect-kric-source-candidate-evidence.test.mjs
+++ b/tools/datapack/collect-kric-source-candidate-evidence.test.mjs
@@ -129,7 +129,7 @@ test("KRIC evidence collector는 실패 단계와 무관하게 raw와 uploadable
       fetchImpl: async () => new Response(JSON.stringify([
         { railOprIsttCd: "S1" },
       ]), { status: 200 }),
-      expectedError: /output field missing: railOprIsttNm/,
+      expectedError: /output field missing: "railOprIsttNm"/,
     },
   ];
 

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -6920,6 +6920,7 @@ test("source candidate sample 검증기는 KRIC 이동동선 route graph 자동 
           "mvContDtl",
           "mvPathMgNo",
           "stMovePath",
+          "https://provider.invalid/sample?serviceKey=route-graph-secret",
         ],
         routeGraphEdgeAdmission: "allowed",
       },
@@ -6940,7 +6941,14 @@ test("source candidate sample 검증기는 KRIC 이동동선 route graph 자동 
       ],
       { cwd: root },
     ),
-    /route graph edge admission requires confirmed fields: distanceMeters, durationSeconds/,
+    (error) => {
+      assert.equal(
+        error.stderr.trim(),
+        "route graph edge admission requires confirmed fields: distanceMeters, durationSeconds",
+      );
+      assert.doesNotMatch(error.stderr, /route-graph-secret/);
+      return true;
+    },
   );
 });
 

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -6660,6 +6660,126 @@ test("source candidate sample 검증기는 endpoint mismatch를 거부한다", a
   );
 });
 
+async function writeFieldDiagnosticFixture(outputDir, { outputFields, fields }) {
+  const candidatesPath = path.join(outputDir, "source-candidates.json");
+  const samplePath = path.join(outputDir, "sample.json");
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(candidatesPath, `${JSON.stringify({
+    candidates: [{
+      id: "field-diagnostic-test",
+      evidence: {
+        endpoint: "https://provider.invalid/field-diagnostic",
+        formats: ["JSON"],
+        outputFields,
+      },
+    }],
+  }, null, 2)}\n`);
+  await writeFile(samplePath, `${JSON.stringify({
+    candidateId: "field-diagnostic-test",
+    endpoint: "https://provider.invalid/field-diagnostic",
+    format: "json",
+    fields,
+  }, null, 2)}\n`);
+  return { candidatesPath, samplePath };
+}
+
+test("source candidate sample 검증기는 control과 delimiter field name을 한 줄 JSON string으로 escape한다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-source-field-control-${Date.now()}`);
+  const { candidatesPath, samplePath } = await writeFieldDiagnosticFixture(outputDir, {
+    outputFields: ["expected"],
+    fields: ["line\nbreak", "\u001b[31mred\u001b[0m", "nul\u0000field", "comma,name;next"],
+  });
+
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/validate-source-candidate-sample.mjs",
+        "--candidates",
+        candidatesPath,
+        "--candidate",
+        "field-diagnostic-test",
+        "--sample",
+        samplePath,
+      ],
+      { cwd: root },
+    ),
+    (error) => {
+      const diagnostic = error.stderr.trimEnd();
+      assert.equal(
+        diagnostic,
+        "output field missing: \"expected\"; available fields: \"\\u001b[31mred\\u001b[0m\", \"comma,name;next\", \"line\\nbreak\", \"nul\\u0000field\"",
+      );
+      assert.equal(diagnostic.split("\n").length, 1);
+      assert.doesNotMatch(diagnostic, /\u001b|\u0000/);
+      return true;
+    },
+  );
+});
+
+test("source candidate sample 검증기는 credential-like field name을 generic 오류로 차단한다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-source-field-credential-${Date.now()}`);
+  const credentialLikeField = "https://provider.invalid/sample?serviceKey=credential-like-field-secret";
+  const { candidatesPath, samplePath } = await writeFieldDiagnosticFixture(outputDir, {
+    outputFields: ["expected"],
+    fields: ["safeField", credentialLikeField],
+  });
+
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/validate-source-candidate-sample.mjs",
+        "--candidates",
+        candidatesPath,
+        "--candidate",
+        "field-diagnostic-test",
+        "--sample",
+        samplePath,
+      ],
+      { cwd: root },
+    ),
+    (error) => {
+      assert.equal(error.stderr.trim(), "sample field names must not contain credentials");
+      assert.doesNotMatch(error.stderr, /credential-like-field-secret/);
+      assert.equal(error.stderr.includes(credentialLikeField), false);
+      return true;
+    },
+  );
+});
+
+test("source candidate sample 검증기는 ambiguous 첫 field에서 missing 진단을 즉시 확정한다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-source-field-ambiguous-${Date.now()}`);
+  const { candidatesPath, samplePath } = await writeFieldDiagnosticFixture(outputDir, {
+    outputFields: ["foo", "bar"],
+    fields: ["FOO", "Foo", "BAR"],
+  });
+
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/validate-source-candidate-sample.mjs",
+        "--candidates",
+        candidatesPath,
+        "--candidate",
+        "field-diagnostic-test",
+        "--sample",
+        samplePath,
+      ],
+      { cwd: root },
+    ),
+    (error) => {
+      assert.equal(
+        error.stderr.trim(),
+        "output field missing: \"foo\"; available fields: \"BAR\", \"FOO\", \"Foo\"",
+      );
+      return true;
+    },
+  );
+});
+
 test("source candidate sample 검증기는 output field 대소문자 불일치를 field name만으로 진단한다", async () => {
   const outputDir = path.join(tmpdir(), `easysubway-source-candidate-field-${Date.now()}`);
   const samplePath = path.join(outputDir, "sample.json");
@@ -6710,7 +6830,7 @@ test("source candidate sample 검증기는 output field 대소문자 불일치�
     (error) => {
       assert.equal(
         error.stderr.trim(),
-        "output field case mismatch: expected updnDvcd; actual updnDvCd",
+        "output field case mismatch: expected \"updnDvcd\"; actual \"updnDvCd\"",
       );
       assert.doesNotMatch(error.stderr, /SENTINEL_SAMPLE_VALUE/);
       assert.doesNotMatch(error.stderr, /credential-like-secret/);
@@ -6770,7 +6890,7 @@ test("source candidate sample 검증기는 true missing field를 sorted field na
     (error) => {
       assert.equal(
         error.stderr.trim(),
-        "output field missing: updnDvcd; available fields: aProviderField, grndDvCd, lnCd, plfCplFlg, plfNo, plfTpCd, plfTpNm, railOprIsttCd, runDirTmnStinCd, scrCharExt, sfFotExt, stinCd, stinFlor, zProviderField",
+        "output field missing: \"updnDvcd\"; available fields: \"aProviderField\", \"grndDvCd\", \"lnCd\", \"plfCplFlg\", \"plfNo\", \"plfTpCd\", \"plfTpNm\", \"railOprIsttCd\", \"runDirTmnStinCd\", \"scrCharExt\", \"sfFotExt\", \"stinCd\", \"stinFlor\", \"zProviderField\"",
       );
       assert.doesNotMatch(error.stderr, /SENTINEL_SAMPLE_VALUE/);
       assert.doesNotMatch(error.stderr, /credential-like-secret/);

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -6660,7 +6660,7 @@ test("source candidate sample 검증기는 endpoint mismatch를 거부한다", a
   );
 });
 
-test("source candidate sample 검증기는 output field 누락을 거부한다", async () => {
+test("source candidate sample 검증기는 output field 대소문자 불일치를 field name만으로 진단한다", async () => {
   const outputDir = path.join(tmpdir(), `easysubway-source-candidate-field-${Date.now()}`);
   const samplePath = path.join(outputDir, "sample.json");
   await rm(outputDir, { recursive: true, force: true });
@@ -6669,10 +6669,26 @@ test("source candidate sample 검증기는 output field 누락을 거부한다",
     samplePath,
     `${JSON.stringify(
       {
-        candidateId: "kric-subway-route-info",
-        endpoint: "https://openapi.kric.go.kr/openapi/trainUseInfo/subwayRouteInfo",
+        candidateId: "kric-station-platform",
+        endpoint: "https://openapi.kric.go.kr/openapi/convenientInfo/stPlf",
         format: "json",
-        fields: ["lnCd", "mreaWideCd", "railOprIsttCd", "routCd", "routNm", "stinCd", "stinNm"],
+        fields: [
+          "stinFlor",
+          "updnDvCd",
+          "plfNo",
+          "grndDvCd",
+          "lnCd",
+          "plfCplFlg",
+          "plfTpCd",
+          "plfTpNm",
+          "railOprIsttCd",
+          "runDirTmnStinCd",
+          "scrCharExt",
+          "sfFotExt",
+          "stinCd",
+        ],
+        providerSample: { updnDvCd: "SENTINEL_SAMPLE_VALUE" },
+        observedUrl: "https://provider.invalid/sample?serviceKey=credential-like-secret",
       },
       null,
       2,
@@ -6685,13 +6701,81 @@ test("source candidate sample 검증기는 output field 누락을 거부한다",
       [
         "tools/datapack/validate-source-candidate-sample.mjs",
         "--candidate",
-        "kric-subway-route-info",
+        "kric-station-platform",
         "--sample",
         samplePath,
       ],
       { cwd: root },
     ),
-    /output field missing: stinConsOrdr/,
+    (error) => {
+      assert.equal(
+        error.stderr.trim(),
+        "output field case mismatch: expected updnDvcd; actual updnDvCd",
+      );
+      assert.doesNotMatch(error.stderr, /SENTINEL_SAMPLE_VALUE/);
+      assert.doesNotMatch(error.stderr, /credential-like-secret/);
+      return true;
+    },
+  );
+});
+
+test("source candidate sample 검증기는 true missing field를 sorted field name만으로 진단한다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-source-candidate-missing-field-${Date.now()}`);
+  const samplePath = path.join(outputDir, "sample.json");
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(
+    samplePath,
+    `${JSON.stringify(
+      {
+        candidateId: "kric-station-platform",
+        endpoint: "https://openapi.kric.go.kr/openapi/convenientInfo/stPlf",
+        format: "json",
+        fields: [
+          "zProviderField",
+          "stinFlor",
+          "stinCd",
+          "sfFotExt",
+          "scrCharExt",
+          "runDirTmnStinCd",
+          "railOprIsttCd",
+          "plfTpNm",
+          "plfTpCd",
+          "plfNo",
+          "plfCplFlg",
+          "lnCd",
+          "grndDvCd",
+          "aProviderField",
+        ],
+        providerSample: { updnDvCd: "SENTINEL_SAMPLE_VALUE" },
+        observedUrl: "https://provider.invalid/sample?serviceKey=credential-like-secret",
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/validate-source-candidate-sample.mjs",
+        "--candidate",
+        "kric-station-platform",
+        "--sample",
+        samplePath,
+      ],
+      { cwd: root },
+    ),
+    (error) => {
+      assert.equal(
+        error.stderr.trim(),
+        "output field missing: updnDvcd; available fields: aProviderField, grndDvCd, lnCd, plfCplFlg, plfNo, plfTpCd, plfTpNm, railOprIsttCd, runDirTmnStinCd, scrCharExt, sfFotExt, stinCd, stinFlor, zProviderField",
+      );
+      assert.doesNotMatch(error.stderr, /SENTINEL_SAMPLE_VALUE/);
+      assert.doesNotMatch(error.stderr, /credential-like-secret/);
+      return true;
+    },
   );
 });
 

--- a/tools/datapack/validate-source-candidate-sample.mjs
+++ b/tools/datapack/validate-source-candidate-sample.mjs
@@ -70,6 +70,13 @@ function findCredentialLeak(value, pathParts = []) {
   return null;
 }
 
+function renderFieldName(fieldName) {
+  return JSON.stringify(fieldName).replace(
+    /[\u007f-\u009f\u2028\u2029]/g,
+    (character) => `\\u${character.charCodeAt(0).toString(16).padStart(4, "0")}`,
+  );
+}
+
 function validateSample({ candidate, candidateId, sample }) {
   if (sample.candidateId !== candidateId) {
     throw new Error(`sample candidateId mismatch: expected ${candidateId}`);
@@ -87,6 +94,9 @@ function validateSample({ candidate, candidateId, sample }) {
   if (!Array.isArray(sample.fields)) {
     throw new Error("fields must be an array");
   }
+  if (findCredentialLeak(sample.fields)) {
+    throw new Error("sample field names must not contain credentials");
+  }
 
   const sampleFields = new Set(sample.fields);
   const missingFields = candidate.evidence.outputFields.filter((field) => !sampleFields.has(field));
@@ -100,13 +110,13 @@ function validateSample({ candidate, candidateId, sample }) {
       );
       if (caseInsensitiveMatches.length === 1) {
         throw new Error(
-          `output field case mismatch: expected ${expectedField}; actual ${caseInsensitiveMatches[0]}`,
+          `output field case mismatch: expected ${renderFieldName(expectedField)}; actual ${renderFieldName(caseInsensitiveMatches[0])}`,
         );
       }
+      throw new Error(
+        `output field missing: ${renderFieldName(expectedField)}; available fields: ${availableFields.map(renderFieldName).join(", ")}`,
+      );
     }
-    throw new Error(
-      `output field missing: ${missingFields.join(", ")}; available fields: ${availableFields.join(", ")}`,
-    );
   }
 
   const missingEdgeFields = candidate.evidence.missingConfirmedEdgeFields ?? [];

--- a/tools/datapack/validate-source-candidate-sample.mjs
+++ b/tools/datapack/validate-source-candidate-sample.mjs
@@ -94,13 +94,13 @@ function validateSample({ candidate, candidateId, sample }) {
   if (!Array.isArray(sample.fields)) {
     throw new Error("fields must be an array");
   }
-  if (findCredentialLeak(sample.fields)) {
-    throw new Error("sample field names must not contain credentials");
-  }
 
   const sampleFields = new Set(sample.fields);
   const missingFields = candidate.evidence.outputFields.filter((field) => !sampleFields.has(field));
   if (missingFields.length > 0) {
+    if (findCredentialLeak(sample.fields)) {
+      throw new Error("sample field names must not contain credentials");
+    }
     const availableFields = [...sampleFields]
       .filter((field) => typeof field === "string")
       .sort((left, right) => left < right ? -1 : Number(left !== right));

--- a/tools/datapack/validate-source-candidate-sample.mjs
+++ b/tools/datapack/validate-source-candidate-sample.mjs
@@ -104,19 +104,18 @@ function validateSample({ candidate, candidateId, sample }) {
     const availableFields = [...sampleFields]
       .filter((field) => typeof field === "string")
       .sort((left, right) => left < right ? -1 : Number(left !== right));
-    for (const expectedField of missingFields) {
-      const caseInsensitiveMatches = availableFields.filter(
-        (actualField) => actualField.toLowerCase() === expectedField.toLowerCase(),
-      );
-      if (caseInsensitiveMatches.length === 1) {
-        throw new Error(
-          `output field case mismatch: expected ${renderFieldName(expectedField)}; actual ${renderFieldName(caseInsensitiveMatches[0])}`,
-        );
-      }
+    const expectedField = missingFields[0];
+    const caseInsensitiveMatches = availableFields.filter(
+      (actualField) => actualField.toLowerCase() === expectedField.toLowerCase(),
+    );
+    if (caseInsensitiveMatches.length === 1) {
       throw new Error(
-        `output field missing: ${renderFieldName(expectedField)}; available fields: ${availableFields.map(renderFieldName).join(", ")}`,
+        `output field case mismatch: expected ${renderFieldName(expectedField)}; actual ${renderFieldName(caseInsensitiveMatches[0])}`,
       );
     }
+    throw new Error(
+      `output field missing: ${renderFieldName(expectedField)}; available fields: ${availableFields.map(renderFieldName).join(", ")}`,
+    );
   }
 
   const missingEdgeFields = candidate.evidence.missingConfirmedEdgeFields ?? [];

--- a/tools/datapack/validate-source-candidate-sample.mjs
+++ b/tools/datapack/validate-source-candidate-sample.mjs
@@ -91,7 +91,22 @@ function validateSample({ candidate, candidateId, sample }) {
   const sampleFields = new Set(sample.fields);
   const missingFields = candidate.evidence.outputFields.filter((field) => !sampleFields.has(field));
   if (missingFields.length > 0) {
-    throw new Error(`output field missing: ${missingFields.join(", ")}`);
+    const availableFields = [...sampleFields]
+      .filter((field) => typeof field === "string")
+      .sort((left, right) => left < right ? -1 : Number(left !== right));
+    for (const expectedField of missingFields) {
+      const caseInsensitiveMatches = availableFields.filter(
+        (actualField) => actualField.toLowerCase() === expectedField.toLowerCase(),
+      );
+      if (caseInsensitiveMatches.length === 1) {
+        throw new Error(
+          `output field case mismatch: expected ${expectedField}; actual ${caseInsensitiveMatches[0]}`,
+        );
+      }
+    }
+    throw new Error(
+      `output field missing: ${missingFields.join(", ")}; available fields: ${availableFields.join(", ")}`,
+    );
   }
 
   const missingEdgeFields = candidate.evidence.missingConfirmedEdgeFields ?? [];


### PR DESCRIPTION
## 관련 이슈

Refs #1397

## 작업 배경

- KRIC source candidate evidence workflow 실행 [29150131658](https://github.com/AquilaXk/easysubway/actions/runs/29150131658)에서 공식 문서·candidate 계약의 output field 표기가 `updnDvcd`와 실제 응답의 `updnDvCd`처럼 대소문자 수준에서 모호해, 기존 `output field missing` 오류만으로는 provider contract 차이를 안전하게 진단하기 어려웠습니다.
- raw provider 응답이나 credential을 보존·출력하지 않고도 실제 field contract 차이를 확인할 수 있는 sanitized diagnostic이 필요했습니다.

## 작업 내용

- 누락 expected field마다 case-insensitive match를 확인해 단일 후보이면 expected/actual field name만 포함한 case mismatch를 출력합니다.
- 실제 누락이거나 case-insensitive 후보가 복수이면 첫 missing field와 code-unit 순으로 정렬한 available string field name만 출력합니다.
- field name은 비교·정렬 후 출력 시 JSON string으로 escape하며, control character·DEL/C1·U+2028/U+2029를 한 logical line에 안전하게 표시합니다.
- credential-like field name은 구체 이름을 노출하지 않는 generic 오류로 차단합니다. raw response value, service key, credential value는 diagnostic에 포함하지 않습니다.
- local review finding을 반영해 delimiter/control escaping, credential guard, 복수 후보 ambiguity 처리, 기존 route-graph admission 오류 우선순위를 보강했습니다.
- candidate metadata, workflow, inventory, datapack 산출물은 변경하지 않았습니다.

## 검증

- 실행한 명령과 결과:
  - source field diagnostic focused regression: 6/6 pass
  - `node --test tools/datapack/datapack-tools.test.mjs`: 216/216 pass
  - `node --test tools/datapack/collect-kric-source-candidate-evidence.test.mjs`: 6/6 pass
  - `node --test tools/ci/repository-contract.test.mjs`: 179/179 pass
  - 변경된 3개 `.mjs` 파일 `node --check`: 모두 exit 0
  - `git diff b04209b8...c54389b4 --check`: exit 0

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| source field sanitized diagnostic | Node.js CLI | focused + full automated tests | 위 검증 명령 결과 | 통과 |
| security boundary | Node.js CLI | control/credential/ambiguity/precedence regression | 위 focused 6건 및 collector 6건 | 통과 |
| 수동 QA | 해당 없음 | UI·사용자 상호작용·배포 변경 없음 | 자동화된 stderr exact-match 검증으로 충분 | 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `validate-source-candidate-sample.mjs`의 missing-field branch가 field name만 출력하고 raw value를 출력하지 않는지
  - case-insensitive 복수 후보에서 뒤 field로 넘어가지 않고 첫 missing field로 확정하는지
  - complete-field sample에서 기존 route-graph admission 오류가 credential-like extra field보다 우선하는지

## 리스크

- provider가 case-insensitive 후보를 복수로 반환하면 특정 actual field를 추정하지 않고 missing으로 진단합니다. 이는 잘못된 자동 매핑을 막는 fail-closed 동작입니다.
- diagnostic은 field name만 다루며 raw provider payload, credential, production mutation, 무제한 retry를 추가하지 않습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.