### PR TITLE
[Fix] KRIC station platform live field 계약 수정

### DIFF
--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -6689,8 +6689,12 @@ test("KRIC 역사별 승강장 정보 후보는 상세 페이지 라이선스와
     "sfFotExt",
     "stinCd",
     "stinFlor",
-    "updnDvcd",
+    "updnDvCd",
   ]);
+  assert.equal(
+    candidate.evidence.liveSampleNote,
+    "KRIC 공식 stPlf 문서는 updnDvcd로 표기하지만, 2026-07-11 workflow run 29151697392의 live JSON은 updnDvCd를 반환했다. 검증은 live wire 표기 updnDvCd를 따른다.",
+  );
   assert.deepEqual(candidate.evidence.missingEvidence, ["sampleResponse"]);
 });
 

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -6782,46 +6782,20 @@ test("source candidate sample 검증기는 ambiguous 첫 field에서 missing 진
 
 test("source candidate sample 검증기는 output field 대소문자 불일치를 field name만으로 진단한다", async () => {
   const outputDir = path.join(tmpdir(), `easysubway-source-candidate-field-${Date.now()}`);
-  const samplePath = path.join(outputDir, "sample.json");
-  await rm(outputDir, { recursive: true, force: true });
-  await mkdir(outputDir, { recursive: true });
-  await writeFile(
-    samplePath,
-    `${JSON.stringify(
-      {
-        candidateId: "kric-station-platform",
-        endpoint: "https://openapi.kric.go.kr/openapi/convenientInfo/stPlf",
-        format: "json",
-        fields: [
-          "stinFlor",
-          "updnDvCd",
-          "plfNo",
-          "grndDvCd",
-          "lnCd",
-          "plfCplFlg",
-          "plfTpCd",
-          "plfTpNm",
-          "railOprIsttCd",
-          "runDirTmnStinCd",
-          "scrCharExt",
-          "sfFotExt",
-          "stinCd",
-        ],
-        providerSample: { updnDvCd: "SENTINEL_SAMPLE_VALUE" },
-        observedUrl: "https://provider.invalid/sample?serviceKey=credential-like-secret",
-      },
-      null,
-      2,
-    )}\n`,
-  );
+  const { candidatesPath, samplePath } = await writeFieldDiagnosticFixture(outputDir, {
+    outputFields: ["updnDvcd"],
+    fields: ["updnDvCd"],
+  });
 
   await assert.rejects(
     execFileAsync(
       process.execPath,
       [
         "tools/datapack/validate-source-candidate-sample.mjs",
+        "--candidates",
+        candidatesPath,
         "--candidate",
-        "kric-station-platform",
+        "field-diagnostic-test",
         "--sample",
         samplePath,
       ],
@@ -6832,8 +6806,6 @@ test("source candidate sample 검증기는 output field 대소문자 불일치�
         error.stderr.trim(),
         "output field case mismatch: expected \"updnDvcd\"; actual \"updnDvCd\"",
       );
-      assert.doesNotMatch(error.stderr, /SENTINEL_SAMPLE_VALUE/);
-      assert.doesNotMatch(error.stderr, /credential-like-secret/);
       return true;
     },
   );
@@ -6890,7 +6862,7 @@ test("source candidate sample 검증기는 true missing field를 sorted field na
     (error) => {
       assert.equal(
         error.stderr.trim(),
-        "output field missing: \"updnDvcd\"; available fields: \"aProviderField\", \"grndDvCd\", \"lnCd\", \"plfCplFlg\", \"plfNo\", \"plfTpCd\", \"plfTpNm\", \"railOprIsttCd\", \"runDirTmnStinCd\", \"scrCharExt\", \"sfFotExt\", \"stinCd\", \"stinFlor\", \"zProviderField\"",
+        "output field missing: \"updnDvCd\"; available fields: \"aProviderField\", \"grndDvCd\", \"lnCd\", \"plfCplFlg\", \"plfNo\", \"plfTpCd\", \"plfTpNm\", \"railOprIsttCd\", \"runDirTmnStinCd\", \"scrCharExt\", \"sfFotExt\", \"stinCd\", \"stinFlor\", \"zProviderField\"",
       );
       assert.doesNotMatch(error.stderr, /SENTINEL_SAMPLE_VALUE/);
       assert.doesNotMatch(error.stderr, /credential-like-secret/);
@@ -7081,6 +7053,60 @@ test("source candidate sample evidence builder는 raw JSON response를 validator
       "tools/datapack/validate-source-candidate-sample.mjs",
       "--candidate",
       "kric-train-operation-organ",
+      "--sample",
+      evidencePath,
+    ],
+    { cwd: root },
+  );
+});
+
+test("KRIC 역사별 승강장 live JSON은 tracked candidate metadata로 builder와 validator를 통과한다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-kric-station-platform-live-${Date.now()}`);
+  const responsePath = path.join(outputDir, "response.json");
+  const evidencePath = path.join(outputDir, "evidence.json");
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(
+    responsePath,
+    `${JSON.stringify([{
+      grndDvCd: "G",
+      lnCd: "1",
+      plfCplFlg: "Y",
+      plfNo: "1",
+      plfTpCd: "1",
+      plfTpNm: "상대식",
+      railOprIsttCd: "S1",
+      runDirTmnStinCd: "0152",
+      scrCharExt: "10",
+      sfFotExt: "200",
+      stinCd: "0152",
+      stinFlor: "B2",
+      updnDvCd: "U",
+    }])}\n`,
+  );
+
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    [
+      "tools/datapack/build-source-candidate-sample-evidence.mjs",
+      "--candidate",
+      "kric-station-platform",
+      "--response",
+      responsePath,
+    ],
+    { cwd: root },
+  );
+  await writeFile(evidencePath, stdout);
+  const evidence = JSON.parse(stdout);
+  assert.ok(evidence.fields.includes("updnDvCd"));
+  assert.ok(!evidence.fields.includes("updnDvcd"));
+
+  await execFileAsync(
+    process.execPath,
+    [
+      "tools/datapack/validate-source-candidate-sample.mjs",
+      "--candidate",
+      "kric-station-platform",
       "--sample",
       evidencePath,
     ],

--- a/tools/datapack/source-candidates.json
+++ b/tools/datapack/source-candidates.json
@@ -287,8 +287,9 @@
           "sfFotExt",
           "stinCd",
           "stinFlor",
-          "updnDvcd"
+          "updnDvCd"
         ],
+        "liveSampleNote": "KRIC 공식 stPlf 문서는 updnDvcd로 표기하지만, 2026-07-11 workflow run 29151697392의 live JSON은 updnDvCd를 반환했다. 검증은 live wire 표기 updnDvCd를 따른다.",
         "missingEvidence": [
           "sampleResponse"
         ]


### PR DESCRIPTION
## 관련 이슈

Refs #1397

## 작업 배경

- KRIC 공식 `stPlf` 문서는 승강장 상하행 구분 필드를 `updnDvcd`로 표기합니다.
- 반면 2026-07-11 workflow run `29151697392`의 credential-safe live JSON 진단에서는 실제 wire field가 `updnDvCd`로 확인됐습니다.
- metadata가 공식 문서 표기만 따르면서 정상 live 응답을 case mismatch로 거부한 것이 root cause입니다.

## 작업 내용

- `kric-station-platform`의 필수 output field를 실제 wire contract인 `updnDvCd`로 정정했습니다.
- 공식 문서의 `updnDvcd`와 live JSON의 `updnDvCd`가 다르다는 provenance를 `liveSampleNote`에 남겼습니다.
- strict validation은 유지했습니다. 두 표기를 허용하는 alias나 fallback은 추가하지 않았습니다.
- tracked candidate metadata와 live-shaped fixture가 builder→validator 경로를 통과하는 회귀 테스트를 추가하고, generic case-mismatch 진단 테스트는 synthetic candidate로 계속 고정했습니다.

### 영향

- KRIC 승강장 live JSON이 실제 field spelling으로 검증됩니다.
- validator, collector, workflow, inventory, mobile mirror, runbook, schema, production datapack은 변경하지 않았습니다.

## 검증

- targeted 4개 테스트 — PASS (4/4).
- `NODE_OPTIONS=--disable-warning=ExperimentalWarning node --test tools/datapack/*.test.mjs` — PASS (351/351).
- `NODE_OPTIONS=--disable-warning=ExperimentalWarning node --test tools/ci/repository-contract.test.mjs` — PASS (179/179).
- `node --check tools/ci/repository-contract.test.mjs` — PASS.
- `node --check tools/datapack/datapack-tools.test.mjs` — PASS.
- `JSON.parse`로 `tools/datapack/source-candidates.json` 검증 — PASS.
- `git diff 4c286606a0e71aea646ab7adbcebc900f2fc081f..HEAD --check` — PASS.

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| KRIC live field root cause | GitHub Actions / KRIC | sanitized exact field diagnostic 확인 | workflow run `29151697392`: expected `updnDvcd`, actual `updnDvCd` | 원인 확인 |
| 구현·계약 검증 | local macOS / Node.js | targeted·datapack·repository contract·syntax·JSON·diff 검사 | `/private/tmp/easysubway-1397-platform-field-report.md` | PASS |
| UI·접근성·수동 QA | 해당 없음 | metadata와 Node contract test 3파일만 변경되어 사용자 UI 경로가 없음 | diff 범위 확인 | 불필요 |
| 배포 확인 | 해당 없음 | workflow, production datapack, release object를 변경하지 않음 | diff 범위 확인 | 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 공식 문서 표기와 live wire 표기의 차이가 provenance에 정확히 보존되는지, validator가 alias 없이 `updnDvCd`만 엄격히 요구하는지 확인해 주세요.
- 알려진 finding은 없습니다. 코드리뷰 완료 후 CI를 판정하며, 그 전에는 auto-merge를 활성화하지 않습니다.

## 리스크

- Risk A — 데이터 source evidence 검증 계약을 수정하는 제품·운영 위험 변경입니다.
- 변경은 metadata와 관련 contract/regression test 3파일로 제한했습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향 없음.
