### PR TITLE
[Test] 지도 라이선스 정본↔manifest redistributionAllowed·reviewStatus 교차 검증 계약 신설 (#1958)

### DIFF
--- a/tools/ci/check-map-attribution.mjs
+++ b/tools/ci/check-map-attribution.mjs
@@ -18,6 +18,14 @@ const requiredLicenseFields = [
   "reviewStatus",
 ];
 
+// reviewStatus 허용 enum — 정본(route-map-license-decision.json)의 reviewStatusValues와 정합.
+const allowedReviewStatus = [
+  "self-drawn-confirmed",
+  "self-drawn-fact-based",
+  "legal-review-required",
+  "permission-required",
+];
+
 export function validateMapAttributionManifest(manifest) {
   const maps = Array.isArray(manifest.maps) ? manifest.maps : [];
   const failures = [];
@@ -40,6 +48,16 @@ export function validateMapAttributionManifest(manifest) {
       if (typeof map.license[field] !== "boolean") {
         failures.push(`${id}: license.${field} must be boolean`);
       }
+    }
+    if (
+      map.license.reviewStatus !== undefined &&
+      map.license.reviewStatus !== null &&
+      map.license.reviewStatus !== "" &&
+      !allowedReviewStatus.includes(map.license.reviewStatus)
+    ) {
+      failures.push(
+        `${id}: license.reviewStatus must be one of ${allowedReviewStatus.join(", ")}`,
+      );
     }
   }
   return failures;

--- a/tools/ci/check-map-attribution.mjs
+++ b/tools/ci/check-map-attribution.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { readFileSync } from "node:fs";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const requiredLicenseFields = [
@@ -18,13 +19,14 @@ const requiredLicenseFields = [
   "reviewStatus",
 ];
 
-// reviewStatus 허용 enum — 정본(route-map-license-decision.json)의 reviewStatusValues와 정합.
-const allowedReviewStatus = [
-  "self-drawn-confirmed",
-  "self-drawn-fact-based",
-  "legal-review-required",
-  "permission-required",
-];
+// reviewStatus 허용 enum — 정본(route-map-license-decision.json)의 reviewStatusValues에서
+// 파생한다. 리터럴 복사(이중 정의)는 정본과 이 게이트가 어긋나도(enum drift) 잡지 못하므로
+// 정본을 단일 출처로 읽는다. 스크립트 위치 기준으로 리포 루트를 산출해 cwd에 의존하지 않는다.
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const licenseDecision = JSON.parse(
+  readFileSync(path.join(repoRoot, "tools/route-map/route-map-license-decision.json"), "utf8"),
+);
+const allowedReviewStatus = licenseDecision.reviewStatusValues;
 
 export function validateMapAttributionManifest(manifest) {
   const maps = Array.isArray(manifest.maps) ? manifest.maps : [];
@@ -64,7 +66,9 @@ export function validateMapAttributionManifest(manifest) {
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  const manifest = JSON.parse(readFileSync("apps/mobile/assets/datapacks/metro_map_pack/manifest.json", "utf8"));
+  const manifest = JSON.parse(
+    readFileSync(path.join(repoRoot, "apps/mobile/assets/datapacks/metro_map_pack/manifest.json"), "utf8"),
+  );
   const failures = validateMapAttributionManifest(manifest);
   if (failures.length > 0) {
     console.error(failures.join("\n"));

--- a/tools/route-map/route-map-license-decision.json
+++ b/tools/route-map/route-map-license-decision.json
@@ -2,9 +2,15 @@
   "schemaVersion": 1,
   "artifactKind": "route-map-license-decision",
   "issue": 1637,
-  "decidedAt": "2026-07-04",
+  "decidedAt": "2026-07-11",
   "summary": "부산·대구·대전·광주 노선도는 원본 SVG 이미지를 앱 렌더링 source of truth로 쓰지 않고, 역 좌표·노선 위상(사실 데이터) 기반 자체 schematic layout으로 그린다(대안 A). 원본 SVG는 좌표 검수 기준으로만 사용한다.",
   "renderingSourceOfTruth": "structured-data",
+  "reviewStatusValues": [
+    "self-drawn-confirmed",
+    "self-drawn-fact-based",
+    "legal-review-required",
+    "permission-required"
+  ],
   "strategyValues": [
     "official-svg",
     "self-drawn-schematic"
@@ -26,6 +32,8 @@
       "bundledSvgRole": "review-reference-only",
       "attributionRequired": false,
       "commercialProductionReady": true,
+      "redistributionAllowed": true,
+      "reviewStatus": "self-drawn-confirmed",
       "licenseStatus": "self-drawn-confirmed",
       "selfDrawnSource": "easy-subway-sma-v1.svg",
       "lineColorSource": "서울시 공식 노선 색상값 PDF(공식 지하철 노선도 디자인 페이지 다운로드); GTX-A는 PDF에 없어 원본 SVG 값 유지",
@@ -45,7 +53,9 @@
       "attributionRequired": false,
       "attributionDropTargetAfterSelfDrawn": true,
       "commercialProductionReady": true,
-      "notes": "원본 SVG는 재배포 권한 미확인(permission-required). 앱 렌더링은 사실 데이터 기반 자체 schematic으로 전환하고, 원본 SVG는 좌표 검수 참조로만 쓴다. 원본 SVG가 아직 번들되어 있는 동안에는 attribution을 유지하며(=true), 자체 도식 전환 + SVG 제거 + 좌표 provenance 확정(#1639/#1641) 후 attribution 해제 가능(attributionDropTargetAfterSelfDrawn). [2026-07-05 #1639/#1640] 좌표 provenance(qa-official-svg-coordinate=역 좌표·위상 사실 데이터, Feist/OSM 선례) 재검증 완료. line_tracks를 SVG stroke(표현)에서 down_path(역-역 위상=사실)로 재빌드해 SVG 표현 파생 제거. SVG 번들 제거(#1715)·자체 도식 전환 완료 → commercial_use_allowed=1·attribution 해제 승격.",
+      "redistributionAllowed": true,
+      "reviewStatus": "self-drawn-fact-based",
+      "notes": "원본 SVG는 재배포 권한 미확인(permission-required). 앱 렌더링은 사실 데이터 기반 자체 schematic으로 전환하고, 원본 SVG는 좌표 검수 참조로만 쓴다. 원본 SVG가 아직 번들되어 있는 동안에는 attribution을 유지하며(=true), 자체 도식 전환 + SVG 제거 + 좌표 provenance 확정(#1639/#1641) 후 attribution 해제 가능(attributionDropTargetAfterSelfDrawn). [2026-07-05 #1639/#1640] 좌표 provenance(qa-official-svg-coordinate=역 좌표·위상 사실 데이터, Feist/OSM 선례) 재검증 완료. line_tracks를 SVG stroke(표현)에서 down_path(역-역 위상=사실)로 재빌드해 SVG 표현 파생 제거. SVG 번들 제거(#1715)·자체 도식 전환 완료 → commercial_use_allowed=1·attribution 해제 승격. [2026-07-11 #1958] 자체 도식 산출물은 SVG 표현 파생이 아니므로 재배포 허용(redistributionAllowed=true), 사실 데이터 재검증 완료 상태로 reviewStatus=self-drawn-fact-based. 두 필드를 정본에 명시해 manifest와 교차 검증한다.",
       "licenseStatus": "self-drawn-fact-based",
       "provenanceVerifiedAt": "2026-07-05"
     },
@@ -62,7 +72,9 @@
       "attributionRequired": false,
       "attributionDropTargetAfterSelfDrawn": true,
       "commercialProductionReady": true,
-      "notes": "원본 SVG는 재배포 권한 미확인(permission-required). 앱 렌더링은 자체 schematic으로 전환, 원본 SVG는 좌표 검수 참조로만 쓴다. SVG 번들 유지 중에는 attribution 유지, 자체 도식 전환 후 해제 가능. 상용 준비 완료는 #1640 좌표·#1641 렌더러에서 판정한다. [2026-07-05 #1639/#1640] 좌표 provenance(qa-official-svg-coordinate=역 좌표·위상 사실 데이터, Feist/OSM 선례) 재검증 완료. line_tracks를 SVG stroke(표현)에서 down_path(역-역 위상=사실)로 재빌드해 SVG 표현 파생 제거. SVG 번들 제거(#1715)·자체 도식 전환 완료 → commercial_use_allowed=1·attribution 해제 승격.",
+      "redistributionAllowed": true,
+      "reviewStatus": "self-drawn-fact-based",
+      "notes": "원본 SVG는 재배포 권한 미확인(permission-required). 앱 렌더링은 자체 schematic으로 전환, 원본 SVG는 좌표 검수 참조로만 쓴다. SVG 번들 유지 중에는 attribution 유지, 자체 도식 전환 후 해제 가능. 상용 준비 완료는 #1640 좌표·#1641 렌더러에서 판정한다. [2026-07-05 #1639/#1640] 좌표 provenance(qa-official-svg-coordinate=역 좌표·위상 사실 데이터, Feist/OSM 선례) 재검증 완료. line_tracks를 SVG stroke(표현)에서 down_path(역-역 위상=사실)로 재빌드해 SVG 표현 파생 제거. SVG 번들 제거(#1715)·자체 도식 전환 완료 → commercial_use_allowed=1·attribution 해제 승격. [2026-07-11 #1958] 자체 도식 산출물은 SVG 표현 파생이 아니므로 재배포 허용(redistributionAllowed=true), 사실 데이터 재검증 완료 상태로 reviewStatus=self-drawn-fact-based. 두 필드를 정본에 명시해 manifest와 교차 검증한다.",
       "licenseStatus": "self-drawn-fact-based",
       "provenanceVerifiedAt": "2026-07-05"
     },
@@ -79,7 +91,9 @@
       "attributionRequired": false,
       "attributionDropTargetAfterSelfDrawn": true,
       "commercialProductionReady": true,
-      "notes": "원본 SVG는 재배포 권한 미확인(permission-required). 앱 렌더링은 자체 schematic으로 전환, 원본 SVG는 좌표 검수 참조로만 쓴다. SVG 번들 유지 중에는 attribution 유지, 자체 도식 전환 후 해제 가능. 상용 준비 완료는 #1640 좌표·#1641 렌더러에서 판정한다. [2026-07-05 #1639/#1640] 좌표 provenance(qa-official-svg-coordinate=역 좌표·위상 사실 데이터, Feist/OSM 선례) 재검증 완료. line_tracks를 SVG stroke(표현)에서 down_path(역-역 위상=사실)로 재빌드해 SVG 표현 파생 제거. SVG 번들 제거(#1715)·자체 도식 전환 완료 → commercial_use_allowed=1·attribution 해제 승격.",
+      "redistributionAllowed": true,
+      "reviewStatus": "self-drawn-fact-based",
+      "notes": "원본 SVG는 재배포 권한 미확인(permission-required). 앱 렌더링은 자체 schematic으로 전환, 원본 SVG는 좌표 검수 참조로만 쓴다. SVG 번들 유지 중에는 attribution 유지, 자체 도식 전환 후 해제 가능. 상용 준비 완료는 #1640 좌표·#1641 렌더러에서 판정한다. [2026-07-05 #1639/#1640] 좌표 provenance(qa-official-svg-coordinate=역 좌표·위상 사실 데이터, Feist/OSM 선례) 재검증 완료. line_tracks를 SVG stroke(표현)에서 down_path(역-역 위상=사실)로 재빌드해 SVG 표현 파생 제거. SVG 번들 제거(#1715)·자체 도식 전환 완료 → commercial_use_allowed=1·attribution 해제 승격. [2026-07-11 #1958] 자체 도식 산출물은 SVG 표현 파생이 아니므로 재배포 허용(redistributionAllowed=true), 사실 데이터 재검증 완료 상태로 reviewStatus=self-drawn-fact-based. 두 필드를 정본에 명시해 manifest와 교차 검증한다.",
       "licenseStatus": "self-drawn-fact-based",
       "provenanceVerifiedAt": "2026-07-05"
     },
@@ -96,7 +110,9 @@
       "attributionRequired": true,
       "attributionDropTargetAfterSelfDrawn": true,
       "commercialProductionReady": false,
-      "notes": "원본 SVG는 CC BY-SA 2.0 KR(상용 가능하나 attribution·ShareAlike). ShareAlike 전파 리스크를 없애기 위해 앱 렌더링을 CC-BY-SA SVG 파생이 아닌 사실 데이터 기반 자체 schematic으로 전환한다. 원본 SVG가 아직 번들되어 있으므로 CC-BY-SA attribution을 유지하며(=true), SVG 제거 + 사실 출처 provenance 확정(#1640) 후 해제 가능. 원본 SVG는 좌표 검수 참조로만 쓴다."
+      "redistributionAllowed": false,
+      "reviewStatus": "legal-review-required",
+      "notes": "원본 SVG는 CC BY-SA 2.0 KR(상용 가능하나 attribution·ShareAlike). ShareAlike 전파 리스크를 없애기 위해 앱 렌더링을 CC-BY-SA SVG 파생이 아닌 사실 데이터 기반 자체 schematic으로 전환한다. 원본 SVG가 아직 번들되어 있으므로 CC-BY-SA attribution을 유지하며(=true), SVG 제거 + 사실 출처 provenance 확정(#1640) 후 해제 가능. 원본 SVG는 좌표 검수 참조로만 쓴다. [2026-07-11 #1958] ShareAlike 파생 체인이 법률 검토 대기이므로 재배포 차단(redistributionAllowed=false)·reviewStatus=legal-review-required 유지. 두 필드를 정본에 명시해 manifest와 교차 검증한다."
     }
   ],
   "gwangjuShareAlikeConclusion": {

--- a/tools/route-map/route-map-license-decision.test.mjs
+++ b/tools/route-map/route-map-license-decision.test.mjs
@@ -57,6 +57,27 @@ test("route map license decision pins 대안 A(self-drawn) 전환과 근거", ()
       region.attributionRequired,
       `${region.id} attributionRequired가 manifest license와 일치해야 함`,
     );
+    // [#1958] redistributionAllowed·reviewStatus 교차 검증(drift 방지, 모든 지역).
+    // 정본에 두 필드가 존재하고, 허용 enum 안이며, manifest license와 정확히 일치한다.
+    assert.equal(
+      typeof region.redistributionAllowed,
+      "boolean",
+      `${region.id} 정본 redistributionAllowed는 boolean이어야 함`,
+    );
+    assert.ok(
+      decision.reviewStatusValues.includes(region.reviewStatus),
+      `${region.id} 정본 reviewStatus 값이 허용 목록에 있어야 함`,
+    );
+    assert.equal(
+      map.license.redistributionAllowed,
+      region.redistributionAllowed,
+      `${region.id} redistributionAllowed가 manifest license와 일치해야 함`,
+    );
+    assert.equal(
+      map.license.reviewStatus,
+      region.reviewStatus,
+      `${region.id} reviewStatus가 manifest license와 일치해야 함`,
+    );
   }
 
   // 수도권은 #1950으로 오너 자작 8선형 도식(self-drawn) 정본 채택, 상용 준비 완료.


### PR DESCRIPTION
## 관련 이슈

close #1958

## 작업 배경

PR #1956 리뷰(Review 4677153222)에서 실측된 계약 공백을 메운다. 기존
`route-map-license-decision.test.mjs`는 attributionRequired·commercialUseAllowed 등만 정본과
manifest를 대조하고, **redistributionAllowed·reviewStatus 두 필드는 어떤 게이트도 값을 검증하지
않았다**(`check-map-attribution.mjs`는 존재/타입만 검사 — 값을 반대로 적어도 통과). 실제로 #1759
승격 때 이 두 필드가 방치되어 6일간 drift 상태였고 #1956이 수동으로 catch-up했다. 계약이 없으면
재발하므로 교차 검증 계약을 신설한다.

## 작업 내용

- 정본 `tools/route-map/route-map-license-decision.json`
  - 각 region에 `redistributionAllowed`(boolean)·`reviewStatus` 필드를 신설하고 현행 manifest 값으로 채움
    - seoul: `true` / `self-drawn-confirmed`
    - busan·daegu·daejeon: `true` / `self-drawn-fact-based`
    - gwangju: `false` / `legal-review-required`
  - 허용 enum 목록 `reviewStatusValues`를 정본 최상위에 명시
  - `decidedAt`를 2026-07-11로 갱신, 지역별 `notes`에 #1958 근거 서술 추가(광주는 신규 필드 추가)
- `tools/route-map/route-map-license-decision.test.mjs`
  - per-region 루프에 두 필드의 정본↔manifest 교차 검증 추가(타입·enum·값 일치)
- `tools/ci/check-map-attribution.mjs`
  - `reviewStatus`를 존재/타입 검사에서 허용 enum 검증으로 강화

## 검증

- 실행한 명령과 결과:
  - `node --test tools/route-map/route-map-license-decision.test.mjs tools/ci/check-map-attribution.test.mjs` → pass 4 / fail 0
  - `node --test tools/ci/repository-contract.test.mjs` → pass 179 / fail 0 (앵커 파일 무손상 확인)
  - **red 증명(의도적 drift 후 원복)**:
    - manifest `gwangju.redistributionAllowed`를 false→true로 drift → 계약 테스트 fail 1: `gwangju redistributionAllowed가 manifest license와 일치해야 함`
    - manifest `busan.reviewStatus`를 `totally-bogus`로 drift →
      - `check-map-attribution.mjs` exit=1: `busan: license.reviewStatus must be one of self-drawn-confirmed, self-drawn-fact-based, legal-review-required, permission-required`
      - 계약 테스트 fail 1: `busan reviewStatus가 manifest license와 일치해야 함`
    - 원복 후 재실행 → pass 4 / fail 0 (green)

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 계약 테스트 green | CI/local | `node --test route-map-license-decision.test.mjs check-map-attribution.test.mjs` | 본문 검증 섹션 | pass 4 / fail 0 |
| 계약 테스트 red 증명 | local | manifest 값 의도적 drift → 실패 확인 후 원복 | 본문 검증 섹션 | fail 재현·원복 후 green |
| 앵커 무손상 | CI/local | `node --test tools/ci/repository-contract.test.mjs` | 본문 검증 섹션 | pass 179 / fail 0 |

## Version impact

- [x] no version change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음(정본 라이선스 결정 문서·계약 테스트만 변경, pack 릴리즈 아님)
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 정본 각 region의 두 신규 필드 값이 manifest license 블록과 정확히 일치하는지, 그리고 test 루프의 교차 검증 assertion. reviewStatus 허용 enum은 정본 `reviewStatusValues`와 `check-map-attribution.mjs`의 `allowedReviewStatus`가 동일 집합이다(fixture의 `permission-required` 포함).

## 리스크

- 정본과 manifest 값 매핑이 현행값을 잘못 반영하면 green 계약이 잘못된 상태를 고정할 수 있어, 커밋 전 manifest 현행값(#1965 base 반영)과 1:1 대조해 채웠다. enum 집합은 코드(check)·정본(test) 두 곳에 중복 정의되므로, 향후 상태값 추가 시 두 곳을 함께 갱신해야 한다(주석으로 정합 명시).

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 지도 라이선스 검증이 지역별 허용된 검토 상태를 기준으로 수행되도록 개선되었습니다.
  * 검증 실행 위치와 관계없이 관련 라이선스 정보를 안정적으로 불러옵니다.

* **문서**
  * 지도별 재배포 가능 여부와 검토 상태가 최신 기준으로 갱신되었습니다.
  * 일부 지역의 법률 검토 필요 상태와 재배포 제한 사항이 명확해졌습니다.

* **테스트**
  * 지역별 재배포 권한과 라이선스 검토 상태의 일관성 검증이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->