### PR TITLE
[Fix] KRIC application envelope 진단 보강

### DIFF
--- a/tools/datapack/collect-kric-source-candidate-evidence.mjs
+++ b/tools/datapack/collect-kric-source-candidate-evidence.mjs
@@ -29,6 +29,8 @@ const ALLOWED_CONTENT_TYPES = new Set(["application/xml", "text/xml"]);
 const SAFE_XML_TAG = /^[A-Za-z_][A-Za-z0-9_.-]{0,39}$/;
 const SENSITIVE_XML_TAG = /(?:authorization|credential|password|secret|servicekey|token)/i;
 const SAFE_RESULT_CODE = /^[A-Za-z0-9._-]{1,32}$/;
+const MAX_XML_DEPTH = 32;
+const MAX_XML_SCALAR_LENGTH = 512;
 
 function requiredText(value, label) {
   if (typeof value !== "string" || value.length === 0) {
@@ -104,15 +106,16 @@ function parseCli(argv) {
 
 function sanitizeErrorMessage(error, serviceKey) {
   let message = error instanceof Error ? error.message : String(error);
-  for (const value of [serviceKey, encodeURIComponent(serviceKey)]) {
+  const formEncodedServiceKey = new URLSearchParams({ serviceKey }).toString().slice("serviceKey=".length);
+  for (const value of [serviceKey, encodeURIComponent(serviceKey), formEncodedServiceKey]) {
     if (value) {
       message = message.replaceAll(value, "[REDACTED]");
     }
   }
   return message
-    .replace(/([?&]serviceKey=)[^&\s]+/gi, "$1[REDACTED]")
+    .replace(/(^|[?&])(serviceKey=)[^&\s]+/gi, "$1$2[REDACTED]")
     .replace(/https?:\/\/[^\s]+/gi, "[REDACTED_URL]")
-    .replace(/[\u0000-\u001f\u007f]/g, " ");
+    .replace(/[\u0000-\u001f\u007f-\u009f]/g, " ");
 }
 
 function safeContentType(response) {
@@ -120,28 +123,142 @@ function safeContentType(response) {
   return contentType && ALLOWED_CONTENT_TYPES.has(contentType) ? contentType : SAFE_PLACEHOLDER;
 }
 
-function xmlScalar(raw, tagName) {
-  const match = raw.match(new RegExp(`<${tagName}\\b[^>]*>([\\s\\S]*?)<\/${tagName}\\s*>`, "i"));
-  return match?.[1].trim() ?? null;
-}
-
-function safeXmlTagSummary(raw) {
+function scanXmlStructure(raw) {
   const tags = [];
   const seen = new Set();
-  for (const match of raw.matchAll(/<\/?\s*([^!?][^\s/>]*)/g)) {
-    const name = match[1];
-    const safeName = SAFE_XML_TAG.test(name) && !SENSITIVE_XML_TAG.test(name)
-      ? name
-      : SAFE_PLACEHOLDER;
-    if (!seen.has(safeName)) {
-      seen.add(safeName);
-      tags.push(safeName);
+  const openTags = [];
+  let overflowDepth = 0;
+  let itemCount = 0;
+  let resultCode = null;
+  let resultMessage = null;
+  let scalar = null;
+
+  const depth = () => openTags.length + overflowDepth;
+  const skipSection = (start, terminator) => {
+    const end = raw.indexOf(terminator, start);
+    return end === -1 ? raw.length : end + terminator.length;
+  };
+  const tagEnd = (start) => {
+    let quote = null;
+    for (let index = start; index < raw.length; index += 1) {
+      const character = raw[index];
+      if (quote) {
+        if (character === quote) quote = null;
+      } else if (character === "\"" || character === "'") {
+        quote = character;
+      } else if (character === ">") {
+        return index;
+      }
     }
-    if (tags.length === 16) {
-      break;
+    return raw.length - 1;
+  };
+  const finishScalar = () => {
+    const value = scalar.text.trim();
+    if (scalar.name === "resultcode") resultCode = value;
+    if (scalar.name === "resultmsg") resultMessage = value;
+    scalar = null;
+  };
+
+  for (let index = 0; index < raw.length;) {
+    if (raw[index] !== "<") {
+      const nextTag = raw.indexOf("<", index);
+      const textEnd = nextTag === -1 ? raw.length : nextTag;
+      if (scalar && depth() === scalar.depth && scalar.text.length < MAX_XML_SCALAR_LENGTH) {
+        scalar.text += raw.slice(index, textEnd).slice(0, MAX_XML_SCALAR_LENGTH - scalar.text.length);
+      }
+      index = textEnd;
+      continue;
     }
+    if (raw.startsWith("<!--", index)) {
+      index = skipSection(index + 4, "-->");
+      continue;
+    }
+    if (raw.startsWith("<![CDATA[", index)) {
+      index = skipSection(index + 9, "]]>");
+      continue;
+    }
+    if (raw.startsWith("<?", index)) {
+      index = skipSection(index + 2, "?>");
+      continue;
+    }
+    if (raw.startsWith("<!", index)) {
+      index = tagEnd(index + 2) + 1;
+      continue;
+    }
+
+    let cursor = index + 1;
+    let closing = false;
+    if (raw[cursor] === "/") {
+      closing = true;
+      cursor += 1;
+    }
+    while (/\s/.test(raw[cursor] ?? "")) cursor += 1;
+    const nameStart = cursor;
+    while (cursor < raw.length && !/[\s/>]/.test(raw[cursor])) cursor += 1;
+    const name = raw.slice(nameStart, cursor);
+    if (!name) {
+      index += 1;
+      continue;
+    }
+    const end = tagEnd(cursor);
+    let beforeEnd = end - 1;
+    while (beforeEnd > cursor && /\s/.test(raw[beforeEnd])) beforeEnd -= 1;
+    const selfClosing = raw[beforeEnd] === "/";
+    const normalizedName = name.toLowerCase();
+
+    if (closing) {
+      if (scalar && normalizedName === scalar.name && depth() === scalar.depth) {
+        finishScalar();
+      }
+      if (overflowDepth > 0) {
+        overflowDepth -= 1;
+      } else if (openTags.at(-1) === normalizedName) {
+        openTags.pop();
+      }
+      index = end + 1;
+      continue;
+    }
+
+    if (!scalar) {
+      const safeName = SAFE_XML_TAG.test(name) && !SENSITIVE_XML_TAG.test(name)
+        ? name
+        : SAFE_PLACEHOLDER;
+      if (!seen.has(safeName) && tags.length < 16) {
+        seen.add(safeName);
+        tags.push(safeName);
+      }
+      if (normalizedName === "item") itemCount += 1;
+    }
+
+    const isEnvelopeScalar = !scalar
+      && openTags.length === 2
+      && overflowDepth === 0
+      && openTags[0] === "root"
+      && openTags[1] === "header"
+      && ((normalizedName === "resultcode" && resultCode == null)
+        || (normalizedName === "resultmsg" && resultMessage == null));
+    if (!selfClosing) {
+      if (openTags.length < MAX_XML_DEPTH) {
+        openTags.push(normalizedName);
+      } else {
+        overflowDepth += 1;
+      }
+      if (isEnvelopeScalar) {
+        scalar = { name: normalizedName, depth: depth(), text: "" };
+      }
+    } else if (isEnvelopeScalar) {
+      scalar = { name: normalizedName, depth: depth(), text: "" };
+      finishScalar();
+    }
+    index = end + 1;
   }
-  return tags.length > 0 ? tags.join(",") : MISSING_PLACEHOLDER;
+
+  return {
+    itemCount,
+    resultCode,
+    resultMessage,
+    tagSummary: tags.length > 0 ? tags.join(",") : MISSING_PLACEHOLDER,
+  };
 }
 
 function classifyXmlFailure({ itemCount, resultCode, resultMessage }) {
@@ -162,9 +279,7 @@ function classifyXmlFailure({ itemCount, resultCode, resultMessage }) {
 }
 
 function kricXmlDiagnostic(response, requestedFormat, raw) {
-  const itemCount = [...raw.matchAll(/<item(?:\s|>)/gi)].length;
-  const resultCode = xmlScalar(raw, "resultCode");
-  const resultMessage = xmlScalar(raw, "resultMsg");
+  const { itemCount, resultCode, resultMessage, tagSummary } = scanXmlStructure(raw);
   const safeResultCode = resultCode == null
     ? MISSING_PLACEHOLDER
     : SAFE_RESULT_CODE.test(resultCode) ? resultCode : SAFE_PLACEHOLDER;
@@ -177,7 +292,7 @@ function kricXmlDiagnostic(response, requestedFormat, raw) {
     `httpStatus=${httpStatus}`,
     `contentType=${safeContentType(response)}`,
     `requestedFormat=${requestedFormat}`,
-    `xmlTags=${safeXmlTagSummary(raw)}`,
+    `xmlTags=${tagSummary}`,
     `itemCount=${itemCount}`,
     `resultCode=${safeResultCode}`,
     `classification=${classification}`,

--- a/tools/datapack/collect-kric-source-candidate-evidence.mjs
+++ b/tools/datapack/collect-kric-source-candidate-evidence.mjs
@@ -23,6 +23,12 @@ const TOOL_DIRECTORY = path.dirname(fileURLToPath(import.meta.url));
 const REPOSITORY_ROOT = path.resolve(TOOL_DIRECTORY, "../..");
 const CANDIDATES_PATH = path.join(TOOL_DIRECTORY, "source-candidates.json");
 const execFileAsync = promisify(execFile);
+const SAFE_PLACEHOLDER = "[unsafe]";
+const MISSING_PLACEHOLDER = "[missing]";
+const ALLOWED_CONTENT_TYPES = new Set(["application/xml", "text/xml"]);
+const SAFE_XML_TAG = /^[A-Za-z_][A-Za-z0-9_.-]{0,39}$/;
+const SENSITIVE_XML_TAG = /(?:authorization|credential|password|secret|servicekey|token)/i;
+const SAFE_RESULT_CODE = /^[A-Za-z0-9._-]{1,32}$/;
 
 function requiredText(value, label) {
   if (typeof value !== "string" || value.length === 0) {
@@ -103,7 +109,79 @@ function sanitizeErrorMessage(error, serviceKey) {
       message = message.replaceAll(value, "[REDACTED]");
     }
   }
-  return message.replace(/([?&]serviceKey=)[^&\s]+/gi, "$1[REDACTED]");
+  return message
+    .replace(/([?&]serviceKey=)[^&\s]+/gi, "$1[REDACTED]")
+    .replace(/https?:\/\/[^\s]+/gi, "[REDACTED_URL]")
+    .replace(/[\u0000-\u001f\u007f]/g, " ");
+}
+
+function safeContentType(response) {
+  const contentType = response.headers.get("content-type")?.split(";", 1)[0].trim().toLowerCase();
+  return contentType && ALLOWED_CONTENT_TYPES.has(contentType) ? contentType : SAFE_PLACEHOLDER;
+}
+
+function xmlScalar(raw, tagName) {
+  const match = raw.match(new RegExp(`<${tagName}\\b[^>]*>([\\s\\S]*?)<\/${tagName}\\s*>`, "i"));
+  return match?.[1].trim() ?? null;
+}
+
+function safeXmlTagSummary(raw) {
+  const tags = [];
+  const seen = new Set();
+  for (const match of raw.matchAll(/<\/?\s*([^!?][^\s/>]*)/g)) {
+    const name = match[1];
+    const safeName = SAFE_XML_TAG.test(name) && !SENSITIVE_XML_TAG.test(name)
+      ? name
+      : SAFE_PLACEHOLDER;
+    if (!seen.has(safeName)) {
+      seen.add(safeName);
+      tags.push(safeName);
+    }
+    if (tags.length === 16) {
+      break;
+    }
+  }
+  return tags.length > 0 ? tags.join(",") : MISSING_PLACEHOLDER;
+}
+
+function classifyXmlFailure({ itemCount, resultCode, resultMessage }) {
+  const classificationText = `${resultCode ?? ""} ${resultMessage ?? ""}`;
+  if (/(?:authorization|auth(?:entication)?|service\s*key|api\s*key|서비스\s*키|인증|권한|등록되지\s*않)/i.test(classificationText)) {
+    return "authorization";
+  }
+  if (/(?:invalid[\s_-]*(?:parameter|param|request)|parameter|param|파라미터|매개변수|요청\s*(?:값|변수).*잘못)/i.test(classificationText)) {
+    return "invalid-parameter";
+  }
+  if (/(?:no[\s_-]*data|데이터.*없|결과.*없|조회.*없)/i.test(classificationText)) {
+    return "no-data";
+  }
+  if (itemCount === 0 && /^(?:0+|ok|success)$/i.test(resultCode ?? "")) {
+    return "no-data";
+  }
+  return itemCount > 0 ? "parser-shape" : "unknown";
+}
+
+function kricXmlDiagnostic(response, requestedFormat, raw) {
+  const itemCount = [...raw.matchAll(/<item(?:\s|>)/gi)].length;
+  const resultCode = xmlScalar(raw, "resultCode");
+  const resultMessage = xmlScalar(raw, "resultMsg");
+  const safeResultCode = resultCode == null
+    ? MISSING_PLACEHOLDER
+    : SAFE_RESULT_CODE.test(resultCode) ? resultCode : SAFE_PLACEHOLDER;
+  const httpStatus = Number.isInteger(response.status) && response.status >= 100 && response.status <= 599
+    ? response.status
+    : SAFE_PLACEHOLDER;
+  const classification = classifyXmlFailure({ itemCount, resultCode, resultMessage });
+  return [
+    "KRIC XML diagnostic:",
+    `httpStatus=${httpStatus}`,
+    `contentType=${safeContentType(response)}`,
+    `requestedFormat=${requestedFormat}`,
+    `xmlTags=${safeXmlTagSummary(raw)}`,
+    `itemCount=${itemCount}`,
+    `resultCode=${safeResultCode}`,
+    `classification=${classification}`,
+  ].join(" ");
 }
 
 async function runEvidenceTool(scriptName, args) {
@@ -157,14 +235,23 @@ export async function collectKricSourceCandidateEvidence({
     if (!response.ok) {
       throw new Error(`KRIC request failed with HTTP ${response.status}`);
     }
-    await writeFile(rawPath, await response.text(), { mode: 0o600 });
+    const rawResponse = await response.text();
+    await writeFile(rawPath, rawResponse, { mode: 0o600 });
 
-    const { stdout: sample } = await runEvidenceTool("build-source-candidate-sample-evidence.mjs", [
-      "--candidate", candidateId,
-      "--candidates", CANDIDATES_PATH,
-      "--response", rawPath,
-      "--format", request.format,
-    ]);
+    let sample;
+    try {
+      ({ stdout: sample } = await runEvidenceTool("build-source-candidate-sample-evidence.mjs", [
+        "--candidate", candidateId,
+        "--candidates", CANDIDATES_PATH,
+        "--response", rawPath,
+        "--format", request.format,
+      ]));
+    } catch (error) {
+      if (request.format === "xml") {
+        throw new Error(`${error instanceof Error ? error.message : String(error)} ${kricXmlDiagnostic(response, request.format, rawResponse)}`);
+      }
+      throw error;
+    }
     JSON.parse(sample);
     await writeFile(stagedSamplePath, sample, { mode: 0o600 });
 

--- a/tools/datapack/collect-kric-source-candidate-evidence.mjs
+++ b/tools/datapack/collect-kric-source-candidate-evidence.mjs
@@ -124,143 +124,170 @@ function safeContentType(response) {
   return contentType && ALLOWED_CONTENT_TYPES.has(contentType) ? contentType : SAFE_PLACEHOLDER;
 }
 
-function scanXmlStructure(raw) {
-  const tags = [];
-  const seen = new Set();
-  const openTags = [];
-  let overflowDepth = 0;
-  let itemCount = 0;
-  let resultCode = null;
-  let resultMessage = null;
-  let scalar = null;
+function xmlScanDepth(state) {
+  return state.openTags.length + state.overflowDepth;
+}
 
-  const depth = () => openTags.length + overflowDepth;
-  const skipSection = (start, terminator) => {
-    const end = raw.indexOf(terminator, start);
-    return end === -1 ? raw.length : end + terminator.length;
-  };
-  const tagEnd = (start) => {
-    let quote = null;
-    for (let index = start; index < raw.length; index += 1) {
-      const character = raw[index];
-      if (quote) {
-        if (character === quote) quote = null;
-      } else if (character === "\"" || character === "'") {
-        quote = character;
-      } else if (character === ">") {
-        return index;
-      }
+function skipXmlSection(raw, start, terminator) {
+  const end = raw.indexOf(terminator, start);
+  return end === -1 ? raw.length : end + terminator.length;
+}
+
+function findXmlTagEnd(raw, start) {
+  let quote = null;
+  for (let index = start; index < raw.length; index += 1) {
+    const character = raw[index];
+    if (quote) {
+      if (character === quote) quote = null;
+    } else if (character === "\"" || character === "'") {
+      quote = character;
+    } else if (character === ">") {
+      return index;
     }
-    return raw.length - 1;
+  }
+  return raw.length - 1;
+}
+
+function skipXmlSpecialSection(raw, index) {
+  if (raw.startsWith("<!--", index)) return skipXmlSection(raw, index + 4, "-->");
+  if (raw.startsWith("<![CDATA[", index)) return skipXmlSection(raw, index + 9, "]]>");
+  if (raw.startsWith("<?", index)) return skipXmlSection(raw, index + 2, "?>");
+  if (raw.startsWith("<!", index)) return findXmlTagEnd(raw, index + 2) + 1;
+  return null;
+}
+
+function readXmlTagToken(raw, index) {
+  let cursor = index + 1;
+  const closing = raw[cursor] === "/";
+  if (closing) cursor += 1;
+  while (/\s/.test(raw[cursor] ?? "")) cursor += 1;
+  const nameStart = cursor;
+  while (cursor < raw.length && !/[\s/>]/.test(raw[cursor])) cursor += 1;
+  const nameLength = cursor - nameStart;
+  if (nameLength === 0) return null;
+
+  const name = nameLength <= MAX_XML_TAG_LENGTH ? raw.slice(nameStart, nameStart + nameLength) : null;
+  const end = findXmlTagEnd(raw, cursor);
+  let beforeEnd = end - 1;
+  while (beforeEnd > cursor && /\s/.test(raw[beforeEnd])) beforeEnd -= 1;
+  return {
+    closing,
+    name,
+    nextIndex: end + 1,
+    normalizedName: name?.toLowerCase() ?? SAFE_PLACEHOLDER,
+    selfClosing: raw[beforeEnd] === "/",
   };
-  const finishScalar = () => {
-    const value = scalar.text.trim();
-    if (scalar.name === "resultcode") resultCode = value;
-    if (scalar.name === "resultmsg") resultMessage = value;
-    scalar = null;
+}
+
+function appendXmlScalarText(raw, index, state) {
+  const nextTag = raw.indexOf("<", index);
+  const textEnd = nextTag === -1 ? raw.length : nextTag;
+  if (state.scalar?.text.length < MAX_XML_SCALAR_LENGTH && xmlScanDepth(state) === state.scalar.depth) {
+    const remaining = MAX_XML_SCALAR_LENGTH - state.scalar.text.length;
+    state.scalar.text += raw.slice(index, Math.min(textEnd, index + remaining));
+  }
+  return textEnd;
+}
+
+function finishXmlScalar(state) {
+  const value = state.scalar.text.trim();
+  if (state.scalar.name === "resultcode") state.resultCode = value;
+  if (state.scalar.name === "resultmsg") state.resultMessage = value;
+  state.scalar = null;
+}
+
+function closeXmlTag(state, token) {
+  if (state.scalar && token.normalizedName === state.scalar.name && xmlScanDepth(state) === state.scalar.depth) {
+    finishXmlScalar(state);
+  }
+  if (state.overflowDepth > 0) {
+    state.overflowDepth -= 1;
+  } else if (state.openTags.at(-1) === token.normalizedName) {
+    state.openTags.pop();
+  }
+}
+
+function safeXmlTagName(name) {
+  if (name && SAFE_XML_TAG.test(name) && !SENSITIVE_XML_TAG.test(name)) return name;
+  return SAFE_PLACEHOLDER;
+}
+
+function recordXmlOpening(state, token) {
+  if (state.scalar) return;
+  const safeName = safeXmlTagName(token.name);
+  if (!state.seen.has(safeName) && state.tags.length < 16) {
+    state.seen.add(safeName);
+    state.tags.push(safeName);
+  }
+  if (token.normalizedName === "item") state.itemCount += 1;
+}
+
+function isEnvelopeScalar(state, normalizedName) {
+  if (state.scalar || state.openTags.length !== 2 || state.overflowDepth !== 0) return false;
+  if (state.openTags[0] !== "root" || state.openTags[1] !== "header") return false;
+  if (normalizedName === "resultcode") return state.resultCode == null;
+  if (normalizedName === "resultmsg") return state.resultMessage == null;
+  return false;
+}
+
+function openXmlTag(state, token) {
+  recordXmlOpening(state, token);
+  const capturesEnvelopeScalar = isEnvelopeScalar(state, token.normalizedName);
+  if (token.selfClosing) {
+    if (capturesEnvelopeScalar) {
+      state.scalar = { name: token.normalizedName, depth: xmlScanDepth(state), text: "" };
+      finishXmlScalar(state);
+    }
+    return;
+  }
+
+  if (state.openTags.length < MAX_XML_DEPTH) {
+    state.openTags.push(token.normalizedName);
+  } else {
+    state.overflowDepth += 1;
+  }
+  if (capturesEnvelopeScalar) {
+    state.scalar = { name: token.normalizedName, depth: xmlScanDepth(state), text: "" };
+  }
+}
+
+function scanXmlStructure(raw) {
+  const state = {
+    tags: [],
+    seen: new Set(),
+    openTags: [],
+    overflowDepth: 0,
+    itemCount: 0,
+    resultCode: null,
+    resultMessage: null,
+    scalar: null,
   };
 
   for (let index = 0; index < raw.length;) {
     if (raw[index] !== "<") {
-      const nextTag = raw.indexOf("<", index);
-      const textEnd = nextTag === -1 ? raw.length : nextTag;
-      if (scalar && depth() === scalar.depth && scalar.text.length < MAX_XML_SCALAR_LENGTH) {
-        const remaining = MAX_XML_SCALAR_LENGTH - scalar.text.length;
-        scalar.text += raw.slice(index, Math.min(textEnd, index + remaining));
-      }
-      index = textEnd;
+      index = appendXmlScalarText(raw, index, state);
       continue;
     }
-    if (raw.startsWith("<!--", index)) {
-      index = skipSection(index + 4, "-->");
+    const specialSectionEnd = skipXmlSpecialSection(raw, index);
+    if (specialSectionEnd != null) {
+      index = specialSectionEnd;
       continue;
     }
-    if (raw.startsWith("<![CDATA[", index)) {
-      index = skipSection(index + 9, "]]>");
-      continue;
-    }
-    if (raw.startsWith("<?", index)) {
-      index = skipSection(index + 2, "?>");
-      continue;
-    }
-    if (raw.startsWith("<!", index)) {
-      index = tagEnd(index + 2) + 1;
-      continue;
-    }
-
-    let cursor = index + 1;
-    let closing = false;
-    if (raw[cursor] === "/") {
-      closing = true;
-      cursor += 1;
-    }
-    while (/\s/.test(raw[cursor] ?? "")) cursor += 1;
-    const nameStart = cursor;
-    while (cursor < raw.length && !/[\s/>]/.test(raw[cursor])) cursor += 1;
-    const nameLength = cursor - nameStart;
-    if (nameLength === 0) {
+    const token = readXmlTagToken(raw, index);
+    if (!token) {
       index += 1;
       continue;
     }
-    const name = nameLength <= MAX_XML_TAG_LENGTH ? raw.slice(nameStart, nameStart + nameLength) : null;
-    const end = tagEnd(cursor);
-    let beforeEnd = end - 1;
-    while (beforeEnd > cursor && /\s/.test(raw[beforeEnd])) beforeEnd -= 1;
-    const selfClosing = raw[beforeEnd] === "/";
-    const normalizedName = name?.toLowerCase() ?? SAFE_PLACEHOLDER;
-
-    if (closing) {
-      if (scalar && normalizedName === scalar.name && depth() === scalar.depth) {
-        finishScalar();
-      }
-      if (overflowDepth > 0) {
-        overflowDepth -= 1;
-      } else if (openTags.at(-1) === normalizedName) {
-        openTags.pop();
-      }
-      index = end + 1;
-      continue;
-    }
-
-    if (!scalar) {
-      const safeName = name && SAFE_XML_TAG.test(name) && !SENSITIVE_XML_TAG.test(name)
-        ? name
-        : SAFE_PLACEHOLDER;
-      if (!seen.has(safeName) && tags.length < 16) {
-        seen.add(safeName);
-        tags.push(safeName);
-      }
-      if (normalizedName === "item") itemCount += 1;
-    }
-
-    const isEnvelopeScalar = !scalar
-      && openTags.length === 2
-      && overflowDepth === 0
-      && openTags[0] === "root"
-      && openTags[1] === "header"
-      && ((normalizedName === "resultcode" && resultCode == null)
-        || (normalizedName === "resultmsg" && resultMessage == null));
-    if (!selfClosing) {
-      if (openTags.length < MAX_XML_DEPTH) {
-        openTags.push(normalizedName);
-      } else {
-        overflowDepth += 1;
-      }
-      if (isEnvelopeScalar) {
-        scalar = { name: normalizedName, depth: depth(), text: "" };
-      }
-    } else if (isEnvelopeScalar) {
-      scalar = { name: normalizedName, depth: depth(), text: "" };
-      finishScalar();
-    }
-    index = end + 1;
+    if (token.closing) closeXmlTag(state, token);
+    else openXmlTag(state, token);
+    index = token.nextIndex;
   }
 
   return {
-    itemCount,
-    resultCode,
-    resultMessage,
-    tagSummary: tags.length > 0 ? tags.join(",") : MISSING_PLACEHOLDER,
+    itemCount: state.itemCount,
+    resultCode: state.resultCode,
+    resultMessage: state.resultMessage,
+    tagSummary: state.tags.length > 0 ? state.tags.join(",") : MISSING_PLACEHOLDER,
   };
 }
 
@@ -283,9 +310,12 @@ function classifyXmlFailure({ itemCount, resultCode, resultMessage }) {
 
 function kricXmlDiagnostic(response, requestedFormat, raw) {
   const { itemCount, resultCode, resultMessage, tagSummary } = scanXmlStructure(raw);
-  const safeResultCode = resultCode == null
-    ? MISSING_PLACEHOLDER
-    : SAFE_RESULT_CODE.test(resultCode) ? resultCode : SAFE_PLACEHOLDER;
+  let safeResultCode = MISSING_PLACEHOLDER;
+  if (resultCode != null && SAFE_RESULT_CODE.test(resultCode)) {
+    safeResultCode = resultCode;
+  } else if (resultCode != null) {
+    safeResultCode = SAFE_PLACEHOLDER;
+  }
   const httpStatus = Number.isInteger(response.status) && response.status >= 100 && response.status <= 599
     ? response.status
     : SAFE_PLACEHOLDER;

--- a/tools/datapack/collect-kric-source-candidate-evidence.mjs
+++ b/tools/datapack/collect-kric-source-candidate-evidence.mjs
@@ -29,6 +29,7 @@ const ALLOWED_CONTENT_TYPES = new Set(["application/xml", "text/xml"]);
 const SAFE_XML_TAG = /^[A-Za-z_][A-Za-z0-9_.-]{0,39}$/;
 const SENSITIVE_XML_TAG = /(?:authorization|credential|password|secret|servicekey|token)/i;
 const SAFE_RESULT_CODE = /^[A-Za-z0-9._-]{1,32}$/;
+const MAX_XML_TAG_LENGTH = 40;
 const MAX_XML_DEPTH = 32;
 const MAX_XML_SCALAR_LENGTH = 512;
 
@@ -164,7 +165,8 @@ function scanXmlStructure(raw) {
       const nextTag = raw.indexOf("<", index);
       const textEnd = nextTag === -1 ? raw.length : nextTag;
       if (scalar && depth() === scalar.depth && scalar.text.length < MAX_XML_SCALAR_LENGTH) {
-        scalar.text += raw.slice(index, textEnd).slice(0, MAX_XML_SCALAR_LENGTH - scalar.text.length);
+        const remaining = MAX_XML_SCALAR_LENGTH - scalar.text.length;
+        scalar.text += raw.slice(index, Math.min(textEnd, index + remaining));
       }
       index = textEnd;
       continue;
@@ -195,16 +197,17 @@ function scanXmlStructure(raw) {
     while (/\s/.test(raw[cursor] ?? "")) cursor += 1;
     const nameStart = cursor;
     while (cursor < raw.length && !/[\s/>]/.test(raw[cursor])) cursor += 1;
-    const name = raw.slice(nameStart, cursor);
-    if (!name) {
+    const nameLength = cursor - nameStart;
+    if (nameLength === 0) {
       index += 1;
       continue;
     }
+    const name = nameLength <= MAX_XML_TAG_LENGTH ? raw.slice(nameStart, nameStart + nameLength) : null;
     const end = tagEnd(cursor);
     let beforeEnd = end - 1;
     while (beforeEnd > cursor && /\s/.test(raw[beforeEnd])) beforeEnd -= 1;
     const selfClosing = raw[beforeEnd] === "/";
-    const normalizedName = name.toLowerCase();
+    const normalizedName = name?.toLowerCase() ?? SAFE_PLACEHOLDER;
 
     if (closing) {
       if (scalar && normalizedName === scalar.name && depth() === scalar.depth) {
@@ -220,7 +223,7 @@ function scanXmlStructure(raw) {
     }
 
     if (!scalar) {
-      const safeName = SAFE_XML_TAG.test(name) && !SENSITIVE_XML_TAG.test(name)
+      const safeName = name && SAFE_XML_TAG.test(name) && !SENSITIVE_XML_TAG.test(name)
         ? name
         : SAFE_PLACEHOLDER;
       if (!seen.has(safeName) && tags.length < 16) {

--- a/tools/datapack/collect-kric-source-candidate-evidence.test.mjs
+++ b/tools/datapack/collect-kric-source-candidate-evidence.test.mjs
@@ -176,6 +176,35 @@ test("KRIC evidence collector는 실패 단계와 무관하게 raw와 uploadable
   }
 });
 
+test("KRIC evidence collector는 URLSearchParams form key와 string-start parameter 및 C1 control을 숨긴다", async () => {
+  const runnerTemp = await mkdtemp(path.join(tmpdir(), "easysubway-kric-form-redaction-"));
+  const serviceKey = "test/key+with space~";
+  const formEncodedKey = new URLSearchParams({ serviceKey }).toString().slice("serviceKey=".length);
+  try {
+    await assert.rejects(
+      collectKricSourceCandidateEvidence({
+        candidateId: candidate.id,
+        candidatesDocument: { candidates: [candidate] },
+        runnerTemp,
+        serviceKey,
+        fetchImpl: async () => {
+          throw new Error(`serviceKey=${formEncodedKey}\u0085\u009f`);
+        },
+      }),
+      (error) => {
+        assert.match(error.message, /^serviceKey=\[REDACTED\]/);
+        assert.doesNotMatch(error.message, new RegExp(serviceKey.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+        assert.doesNotMatch(error.message, new RegExp(formEncodedKey.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+        assert.doesNotMatch(error.message, /[\u0000-\u001f\u007f-\u009f]/);
+        return true;
+      },
+    );
+    await assertCollectorCleanup(runnerTemp);
+  } finally {
+    await rm(runnerTemp, { recursive: true, force: true });
+  }
+});
+
 test("KRIC evidence collector는 HTTP 200 XML application error를 고정된 안전 진단으로 분류한다", async () => {
   const runnerTemp = await mkdtemp(path.join(tmpdir(), "easysubway-kric-envelope-"));
   const serviceKey = "credential-sentinel-application-error";
@@ -242,6 +271,58 @@ test("KRIC evidence collector는 HTTP 200 XML zero-item envelope를 application 
   }
 });
 
+test("KRIC evidence collector는 CDATA/comment/PI의 XML 모양 text를 구조 진단에서 제외한다", async () => {
+  const runnerTemp = await mkdtemp(path.join(tmpdir(), "easysubway-kric-structural-xml-"));
+  const structuralSecret = "credential-sentinel-non-structural-markup";
+  const raw = [
+    "<?xml version=\"1.0\"?>",
+    "<?probe <item><nested><piSafeTag>hidden</piSafeTag></nested></item>?>",
+    "<!DOCTYPE ROOT [<!ENTITY fake \"<item><nested><declarationSafeTag>hidden</declarationSafeTag></nested></item>\">]>",
+    "<ROOT>",
+    `<metadata><![CDATA[<resultCode>AUTHCDATA</resultCode><item><nested><cdataSafeTag>${structuralSecret}</cdataSafeTag></nested></item>]]></metadata>`,
+    "<!-- <resultCode>AUTHCOMMENT</resultCode><item><nested><commentSafeTag>hidden</commentSafeTag></nested></item> -->",
+    `<header><resultCode>00</resultCode><resultMsg><![CDATA[<item><nested><messageSafeTag>${structuralSecret}</messageSafeTag></nested></item>]]></resultMsg></header>`,
+    "<body><items></items></body>",
+    "</ROOT>",
+  ].join("");
+  try {
+    await assert.rejects(
+      collectKricSourceCandidateEvidence({
+        candidateId: xmlCandidate.id,
+        candidatesDocument: { candidates: [xmlCandidate] },
+        runnerTemp,
+        serviceKey: "credential-sentinel-structural-service-key",
+        fetchImpl: async () => new Response(raw, {
+          status: 200,
+          headers: { "content-type": "application/xml" },
+        }),
+      }),
+      (error) => {
+        assert.match(error.message, /xmlTags=ROOT,metadata,header,resultCode,resultMsg,body,items/);
+        assert.match(error.message, /itemCount=0/);
+        assert.match(error.message, /resultCode=00/);
+        assert.match(error.message, /classification=no-data/);
+        for (const nonStructuralValue of [
+          structuralSecret,
+          "AUTHCDATA",
+          "AUTHCOMMENT",
+          "piSafeTag",
+          "cdataSafeTag",
+          "commentSafeTag",
+          "declarationSafeTag",
+          "messageSafeTag",
+        ]) {
+          assert.doesNotMatch(error.message, new RegExp(nonStructuralValue));
+        }
+        return true;
+      },
+    );
+    await assertCollectorCleanup(runnerTemp);
+  } finally {
+    await rm(runnerTemp, { recursive: true, force: true });
+  }
+});
+
 test("KRIC evidence collector는 item이 있지만 leaf row가 없는 XML을 parser-shape drift로 분류한다", async () => {
   const runnerTemp = await mkdtemp(path.join(tmpdir(), "easysubway-kric-parser-shape-"));
   try {
@@ -299,6 +380,36 @@ test("KRIC evidence collector는 unsafe XML code/message/tag와 credential senti
       },
     );
     await assertCollectorCleanup(runnerTemp);
+  } finally {
+    await rm(runnerTemp, { recursive: true, force: true });
+  }
+});
+
+test("KRIC evidence collector는 malformed 반복 item을 scalar count하고 cleanup한다", async () => {
+  const runnerTemp = await mkdtemp(path.join(tmpdir(), "easysubway-kric-repeated-item-"));
+  const repeatedItemCount = 128;
+  try {
+    await assert.rejects(
+      collectKricSourceCandidateEvidence({
+        candidateId: xmlCandidate.id,
+        candidatesDocument: { candidates: [xmlCandidate] },
+        runnerTemp,
+        serviceKey: "credential-sentinel-repeated-item",
+        fetchImpl: async () => new Response(
+          `<ROOT><body><items>${"<item>".repeat(repeatedItemCount)}</items></body></ROOT>`,
+          { status: 200, headers: { "content-type": "application/xml" } },
+        ),
+      }),
+      (error) => {
+        assert.match(error.message, new RegExp(`itemCount=${repeatedItemCount}(?:\\s|$)`));
+        assert.match(error.message, /classification=parser-shape/);
+        return true;
+      },
+    );
+    await assertCollectorCleanup(runnerTemp);
+
+    const collectorSource = await readFile(new URL("./collect-kric-source-candidate-evidence.mjs", import.meta.url), "utf8");
+    assert.doesNotMatch(collectorSource, /\[\s*\.\.\.[^\]]*matchAll/);
   } finally {
     await rm(runnerTemp, { recursive: true, force: true });
   }

--- a/tools/datapack/collect-kric-source-candidate-evidence.test.mjs
+++ b/tools/datapack/collect-kric-source-candidate-evidence.test.mjs
@@ -415,6 +415,41 @@ test("KRIC evidence collector는 malformed 반복 item을 scalar count하고 cle
   }
 });
 
+test("KRIC evidence collector는 초장문 tag와 scalar를 bounded state로 진단하고 cleanup한다", async () => {
+  const runnerTemp = await mkdtemp(path.join(tmpdir(), "easysubway-kric-long-xml-token-"));
+  const longTag = `attacker-tag-${"x".repeat(8_192)}`;
+  const longResultCode = `CODE-${"z".repeat(4_096)}`;
+  const longResultMessage = `scalar-sentinel-${"y".repeat(16_384)}`;
+  try {
+    await assert.rejects(
+      collectKricSourceCandidateEvidence({
+        candidateId: xmlCandidate.id,
+        candidatesDocument: { candidates: [xmlCandidate] },
+        runnerTemp,
+        serviceKey: "credential-sentinel-long-xml-token",
+        fetchImpl: async () => new Response(
+          `<ROOT><header><resultCode>${longResultCode}</resultCode><resultMsg>${longResultMessage}</resultMsg></header><${longTag}>hidden</${longTag}></ROOT>`,
+          { status: 200, headers: { "content-type": "application/xml" } },
+        ),
+      }),
+      (error) => {
+        assert.match(error.message, /xmlTags=ROOT,header,resultCode,resultMsg,\[unsafe\]/);
+        assert.match(error.message, /itemCount=0/);
+        assert.match(error.message, /resultCode=\[unsafe\]/);
+        assert.doesNotMatch(error.message, /attacker-tag|scalar-sentinel|CODE-/);
+        return true;
+      },
+    );
+    await assertCollectorCleanup(runnerTemp);
+
+    const collectorSource = await readFile(new URL("./collect-kric-source-candidate-evidence.mjs", import.meta.url), "utf8");
+    assert.doesNotMatch(collectorSource, /raw\.slice\(nameStart,\s*cursor\)/);
+    assert.doesNotMatch(collectorSource, /raw\.slice\(index,\s*textEnd\)/);
+  } finally {
+    await rm(runnerTemp, { recursive: true, force: true });
+  }
+});
+
 test("KRIC evidence collector는 기존 XML item 성공 경로를 그대로 유지한다", async () => {
   const runnerTemp = await mkdtemp(path.join(tmpdir(), "easysubway-kric-xml-success-"));
   const serviceKey = "credential-sentinel-xml-success";

--- a/tools/datapack/collect-kric-source-candidate-evidence.test.mjs
+++ b/tools/datapack/collect-kric-source-candidate-evidence.test.mjs
@@ -23,6 +23,20 @@ const candidate = {
   },
 };
 
+const xmlCandidate = {
+  ...candidate,
+  evidence: {
+    ...candidate.evidence,
+    sampleUrl: candidate.evidence.sampleUrl.replace("format=json", "format=xml"),
+  },
+};
+
+async function assertCollectorCleanup(runnerTemp) {
+  assert.equal(existsSync(path.join(runnerTemp, "kric-source-candidate-raw")), false);
+  assert.equal(existsSync(path.join(runnerTemp, "kric-source-candidate-staging")), false);
+  assert.equal(existsSync(path.join(runnerTemp, "kric-source-candidate-evidence")), false);
+}
+
 test("KRIC evidence collector는 정확한 10개 allowlist와 tracked endpoint를 강제한다", () => {
   assert.deepEqual(KRIC_SOURCE_CANDIDATE_IDS, [
     "kric-subway-route-info",
@@ -159,5 +173,159 @@ test("KRIC evidence collector는 실패 단계와 무관하게 raw와 uploadable
         await rm(runnerTemp, { recursive: true, force: true });
       }
     });
+  }
+});
+
+test("KRIC evidence collector는 HTTP 200 XML application error를 고정된 안전 진단으로 분류한다", async () => {
+  const runnerTemp = await mkdtemp(path.join(tmpdir(), "easysubway-kric-envelope-"));
+  const serviceKey = "credential-sentinel-application-error";
+  const resultMessage = `등록되지 않은 서비스키입니다: ${serviceKey}`;
+  try {
+    await assert.rejects(
+      collectKricSourceCandidateEvidence({
+        candidateId: xmlCandidate.id,
+        candidatesDocument: { candidates: [xmlCandidate] },
+        runnerTemp,
+        serviceKey,
+        fetchImpl: async () => new Response(
+          `<ROOT><header><resultCode>AUTH001</resultCode><resultMsg>${resultMessage}</resultMsg></header></ROOT>`,
+          { status: 200, headers: { "content-type": "application/xml; charset=UTF-8" } },
+        ),
+      }),
+      (error) => {
+        assert.match(error.message, /KRIC XML diagnostic:/);
+        assert.match(error.message, /httpStatus=200/);
+        assert.match(error.message, /contentType=application\/xml/);
+        assert.match(error.message, /requestedFormat=xml/);
+        assert.match(error.message, /xmlTags=ROOT,header,resultCode,resultMsg/);
+        assert.match(error.message, /itemCount=0/);
+        assert.match(error.message, /resultCode=AUTH001/);
+        assert.match(error.message, /classification=authorization/);
+        assert.doesNotMatch(error.message, /등록되지 않은 서비스키/);
+        assert.doesNotMatch(error.message, new RegExp(serviceKey));
+        return true;
+      },
+    );
+    await assertCollectorCleanup(runnerTemp);
+  } finally {
+    await rm(runnerTemp, { recursive: true, force: true });
+  }
+});
+
+test("KRIC evidence collector는 HTTP 200 XML zero-item envelope를 application error와 구분한다", async () => {
+  const runnerTemp = await mkdtemp(path.join(tmpdir(), "easysubway-kric-zero-item-"));
+  try {
+    await assert.rejects(
+      collectKricSourceCandidateEvidence({
+        candidateId: xmlCandidate.id,
+        candidatesDocument: { candidates: [xmlCandidate] },
+        runnerTemp,
+        serviceKey: "credential-sentinel-zero-item",
+        fetchImpl: async () => new Response(
+          "<ROOT><header><resultCode>00</resultCode><resultMsg>정상 처리되었습니다.</resultMsg></header><body><items></items></body></ROOT>",
+          { status: 200, headers: { "content-type": "text/xml" } },
+        ),
+      }),
+      (error) => {
+        assert.match(error.message, /KRIC XML diagnostic:/);
+        assert.match(error.message, /contentType=text\/xml/);
+        assert.match(error.message, /itemCount=0/);
+        assert.match(error.message, /resultCode=00/);
+        assert.match(error.message, /classification=no-data/);
+        assert.doesNotMatch(error.message, /정상 처리/);
+        return true;
+      },
+    );
+    await assertCollectorCleanup(runnerTemp);
+  } finally {
+    await rm(runnerTemp, { recursive: true, force: true });
+  }
+});
+
+test("KRIC evidence collector는 item이 있지만 leaf row가 없는 XML을 parser-shape drift로 분류한다", async () => {
+  const runnerTemp = await mkdtemp(path.join(tmpdir(), "easysubway-kric-parser-shape-"));
+  try {
+    await assert.rejects(
+      collectKricSourceCandidateEvidence({
+        candidateId: xmlCandidate.id,
+        candidatesDocument: { candidates: [xmlCandidate] },
+        runnerTemp,
+        serviceKey: "credential-sentinel-parser-shape",
+        fetchImpl: async () => new Response(
+          "<ROOT><body><items><item><nested><value>record-value</value></nested></item></items></body></ROOT>",
+          { status: 200, headers: { "content-type": "application/xml" } },
+        ),
+      }),
+      (error) => {
+        assert.match(error.message, /itemCount=1/);
+        assert.match(error.message, /classification=parser-shape/);
+        assert.doesNotMatch(error.message, /record-value/);
+        return true;
+      },
+    );
+    await assertCollectorCleanup(runnerTemp);
+  } finally {
+    await rm(runnerTemp, { recursive: true, force: true });
+  }
+});
+
+test("KRIC evidence collector는 unsafe XML code/message/tag와 credential sentinel을 노출하지 않는다", async () => {
+  const runnerTemp = await mkdtemp(path.join(tmpdir(), "easysubway-kric-unsafe-envelope-"));
+  const serviceKey = "credential-sentinel-unsafe-input";
+  const unsafeTag = `credential-${"x".repeat(80)}`;
+  const unsafeCode = `BAD/CODE-${"y".repeat(80)}`;
+  const unsafeMessage = `provider-secret-message\u0007-${serviceKey}-${encodeURIComponent(serviceKey)}`;
+  try {
+    await assert.rejects(
+      collectKricSourceCandidateEvidence({
+        candidateId: xmlCandidate.id,
+        candidatesDocument: { candidates: [xmlCandidate] },
+        runnerTemp,
+        serviceKey,
+        fetchImpl: async () => new Response(
+          `<ROOT><header><resultCode>${unsafeCode}</resultCode><resultMsg>${unsafeMessage}</resultMsg></header><${unsafeTag}>value-must-not-leak</${unsafeTag}></ROOT>`,
+          { status: 200, headers: { "content-type": "application/problem+xml" } },
+        ),
+      }),
+      (error) => {
+        assert.match(error.message, /contentType=\[unsafe\]/);
+        assert.match(error.message, /xmlTags=ROOT,header,resultCode,resultMsg,\[unsafe\]/);
+        assert.match(error.message, /resultCode=\[unsafe\]/);
+        for (const secret of [serviceKey, encodeURIComponent(serviceKey), unsafeTag, unsafeCode, "provider-secret-message", "value-must-not-leak"]) {
+          assert.doesNotMatch(error.message, new RegExp(secret.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+        }
+        assert.doesNotMatch(error.message, /[\u0000-\u001f\u007f]/);
+        return true;
+      },
+    );
+    await assertCollectorCleanup(runnerTemp);
+  } finally {
+    await rm(runnerTemp, { recursive: true, force: true });
+  }
+});
+
+test("KRIC evidence collector는 기존 XML item 성공 경로를 그대로 유지한다", async () => {
+  const runnerTemp = await mkdtemp(path.join(tmpdir(), "easysubway-kric-xml-success-"));
+  const serviceKey = "credential-sentinel-xml-success";
+  try {
+    const outputs = await collectKricSourceCandidateEvidence({
+      candidateId: xmlCandidate.id,
+      candidatesDocument: { candidates: [xmlCandidate] },
+      runnerTemp,
+      serviceKey,
+      fetchImpl: async () => new Response(
+        "<ROOT><body><items><item><railOprIsttCd>S1</railOprIsttCd><railOprIsttNm>서울교통공사</railOprIsttNm></item></items></body></ROOT>",
+        { status: 200, headers: { "content-type": "application/xml" } },
+      ),
+    });
+
+    const sample = JSON.parse(await readFile(outputs.sample, "utf8"));
+    assert.equal(sample.format, "xml");
+    assert.equal(sample.rowCount, 1);
+    assert.deepEqual(sample.fields, ["railOprIsttCd", "railOprIsttNm"]);
+    assert.equal(existsSync(path.join(runnerTemp, "kric-source-candidate-raw")), false);
+    assert.doesNotMatch(JSON.stringify(sample), new RegExp(serviceKey));
+  } finally {
+    await rm(runnerTemp, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## 관련 이슈

Refs #1397

## 작업 배경

- [KRIC source candidate evidence workflow run 29152843825](https://github.com/AquilaXk/easysubway/actions/runs/29152843825)는 provider가 HTTP 200을 반환했지만 중첩된 XML application envelope의 `resultCode`/구조를 기존 고정 builder 오류가 가려 원인 판별이 불가능했다.
- 전송 계층 실패로 오인해 무작정 retry하거나 blocker 처리하지 않고, 이미 받은 response 안에서 credential-safe 진단을 남겨 provider application 오류와 parser-shape 오류를 구분할 필요가 있었다.

## 작업 내용

- XML failure response를 cleanup 전에 in-memory로 검사해 HTTP status, allowlisted content type, requested format, bounded tag summary, `itemCount`, 안전한 `resultCode`, 고정 classification을 오류에 추가했다.
- `resultMsg` 원문은 출력하지 않고 `authorization`, `invalid-parameter`, `no-data`, `parser-shape`, `unknown` 고정 enum 분류에만 사용한다. service key 원문·URL/form encoding·request URL·control character는 sanitizer가 제거한다.
- regex 대신 bounded single-pass structural scanner를 사용해 CDATA/comment/PI/declaration의 spoof를 제외하고, 직접 `ROOT/header` scalar만 읽는다.
- tag summary 16개, depth 32, scalar 512자, tag name 40자 상한을 두고 긴 tag/scalar를 materialize하지 않는다. `itemCount`는 match 배열 없이 scalar counter로 계산해 O(1) 보조 메모리 경계를 유지한다.
- 실제 `URLSearchParams` form encoding(공백 `+`, `~`의 `%7E` 포함), string-start `serviceKey=`, C0/DEL/C1 제어문자까지 redaction 범위를 보강했다.
- candidate metadata, builder/validator, workflow, inventory, datapack과 성공/error precedence 및 cleanup 동작은 변경하지 않았다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/datapack/collect-kric-source-candidate-evidence.test.mjs`: 15/15 pass
  - `node --test tools/datapack/*.test.mjs`: 360/360 pass
  - `node --test tools/ci/repository-contract.test.mjs`: 179/179 pass
  - `node tools/ci/check-contracts.mjs`: exit 0
  - 두 changed `.mjs`의 `node --check`: exit 0
  - `git diff --check origin/main...HEAD`: exit 0
  - worktree clean, 변경 파일 2개 확인

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| application envelope 진단 | Node.js CLI | focused fixture test | 15/15 pass | PASS |
| datapack 회귀 | Node.js CLI | datapack 전체 test | 360/360 pass | PASS |
| repository contract | Node.js CLI | repository contract test + contract checker | 179/179 pass, exit 0 | PASS |
| 수동 QA | 해당 없음 | UI·production mutation이 없는 CLI 진단 변경이므로 불필요 | fixture 기반 구조·sanitize·cleanup 검증 | 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: nested envelope의 직접 child 판별, CDATA/comment/PI spoof 제외, 초장문 tag/scalar의 bounded allocation, raw·form-encoded secret 및 C1 redaction을 우선 확인해 주세요.
- 이 PR은 실패 원인을 안전하게 노출하는 진단 보강이며 provider live admission 완료나 #1397 종결을 주장하지 않습니다.

## 리스크

- provider가 알려진 문구와 다른 `resultMsg`를 반환하면 classification은 안전하게 `unknown`으로 남는다. 원문은 어떤 경우에도 출력하지 않는다.
- scanner는 진단용 bounded parser이며 builder/validator의 parsing behavior는 바꾸지 않는다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향 없음
