### PR TITLE
[Test] 노선도 QA 통합 게이트 — 비수도권 4권역 라벨 겹침 게이트 + cold start·지역 전환 측정 도구 (#1952)

### DIFF
--- a/apps/mobile/test/features/network_map/presentation/regional_label_overlap_gate_test.dart
+++ b/apps/mobile/test/features/network_map/presentation/regional_label_overlap_gate_test.dart
@@ -1,0 +1,79 @@
+import 'dart:ui';
+
+import 'package:easysubway_mobile/features/network_map/domain/route_map_design_space.dart';
+import 'package:easysubway_mobile/features/network_map/presentation/route_map_label_layout.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../support/capital_route_map_fixture.dart';
+
+// 비수도권 4권역(부산·대구·대전·광주) 라벨 겹침 기계 게이트 (#1952 작업 1).
+// 수도권 게이트(capital_label_overlap_gate_test.dart)와 동일 측정 방식·동일 보수
+// 근사(한글 전각 폭 ≈ 폰트 px/자)를 재사용해 "게이트=실기기 체감" 정합을 권역
+// 확장한다. 팩(assets/datapacks/capital.sqlite.gz)의 route_map_positions에는
+// 수도권 외 4권역이 이미 수록돼 있어(부산권 158·대구권 101·대전권 22·광주권 20
+// positions) 동일 fixture 로더를 region 인자만 바꿔 재사용한다.
+//
+// 2026-07-11 #1952 신 정본(오너 8선형 도식) 실측 baseline: 4권역 전부 라벨-라벨,
+// 라벨-선, 뱃지-선, 뱃지-라벨, unresolved 모두 0. 저사양 권역이라 도심 밀집이
+// 수도권보다 낮아 겹침이 원천 발생하지 않는다. baseline은 하드 0 — 후속 버전
+// 교체에서 겹침이 생기면 즉시 실패해 회귀를 잡는다.
+Size _measureLabel(String text, {required bool bold}) => Size(
+  text.length * kRouteMapDesignLabelFontPx,
+  kRouteMapDesignLabelFontPx + 4,
+);
+Size _measureBadge(String text) => Size(
+  text.length * kRouteMapDesignBadgeFontPx + 12,
+  kRouteMapDesignBadgeFontPx + 7,
+);
+
+void main() {
+  // 저장 region 명은 route_map_positions.region 값(권역 접미사 포함)과 일치해야
+  // 한다. 프로덕션 _networkMapRegions() SELECT DISTINCT region 결과와 동일.
+  const regions = <String>['부산권', '대구권', '대전권', '광주권'];
+
+  for (final region in regions) {
+    test('$region 실데이터: 전 라벨 표시 + 겹침 0 게이트', () {
+      final fixture = loadCapitalRouteMapFixture(region: region);
+      final design = routeMapDesignSpaceFor(fixture.map);
+      final layout = solveRouteMapLabelLayout(
+        map: fixture.map,
+        design: design,
+        labelTextByStationId: fixture.labelTextByStationId,
+        badgeLabelByLineId: fixture.badgeLabelByLineId,
+        measureLabel: _measureLabel,
+        measureBadge: _measureBadge,
+      );
+
+      // 숨김 금지: 권역 전 역이 라벨을 가진다(환승은 그룹당 1로 접힘).
+      expect(
+        layout.labels.length,
+        greaterThan(0),
+        reason: '$region 라벨이 하나도 없다 — fixture 로드/region 명 확인',
+      );
+
+      // 라벨-라벨 겹침 0.
+      final labelRects = layout.labels.map((l) => l.rect).toList();
+      var overlapPairs = 0;
+      for (var i = 0; i < labelRects.length; i += 1) {
+        for (var j = i + 1; j < labelRects.length; j += 1) {
+          if (labelRects[i].overlaps(labelRects[j])) overlapPairs += 1;
+        }
+      }
+      expect(overlapPairs, 0, reason: '$region 라벨 겹침 쌍 $overlapPairs');
+
+      // unresolved(최소 겹침 fallback으로 강제 배치된 겹침) 0.
+      expect(
+        layout.unresolvedOverlapCount,
+        0,
+        reason: '$region unresolved=${layout.unresolvedOverlapCount}',
+      );
+
+      // 라벨-선·뱃지 겹침(실기기 클러터) 0.
+      final labelLine = routeMapLabelLineOverlapCount(layout, fixture.map, design);
+      final badge = routeMapBadgeOverlapCounts(layout, fixture.map, design);
+      expect(labelLine, 0, reason: '$region 라벨-선 겹침 $labelLine');
+      expect(badge.line, 0, reason: '$region 뱃지-선 겹침 ${badge.line}');
+      expect(badge.label, 0, reason: '$region 뱃지-라벨 겹침 ${badge.label}');
+    });
+  }
+}

--- a/tools/mobile/run-route-map-launch-region-evidence.sh
+++ b/tools/mobile/run-route-map-launch-region-evidence.sh
@@ -1,0 +1,333 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# #1952 작업 4 신규 측정 2종:
+#   ① cold start → 노선도 첫 표시 시간 (목표 ≤ 2s)
+#   ② 지역 전환 시간 (권역 메뉴 탭 → 새 권역 노선도 첫 프레임)
+#
+# 정본 프레임 신호는 앱이 로깅하는 'routeMapFrame'(#1643, FrameTiming)이다. 노선도는
+# Flutter 자체 렌더 파이프라인이라 dumpsys gfxinfo로 프레임이 안 잡혀, 첫 표시/전환
+# 완료 판정을 첫 routeMapFrame 로그 타임스탬프로 한다. 측정 정확도를 위해 debug 또는
+# profile 빌드가 설치돼 있어야 하며(routeMapFrame 미기록 시 fail closed), 온보딩은
+# 완료돼 실행 즉시 노선도가 홈으로 뜨는 상태여야 한다.
+#
+# 이 스크립트는 아무것도 설치하지 않는다. 기기 미연결·노선도 미구동·프레임 로그
+# 부재·측정 파싱 불가는 전부 실패(exit 1)로 처리한다(측정치 위조 금지).
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  tools/mobile/run-route-map-launch-region-evidence.sh --serial <adb-serial> --artifact-dir <dir> [options]
+
+Options:
+  --serial <adb-serial>     Required Android device serial.
+  --artifact-dir <dir>      Required output directory for logs and summary.
+  --package <package>       App package. Defaults to com.easysubway.app.
+  --activity <name>         Launcher activity. Defaults to
+                            com.easysubway.easysubway_mobile.MainActivity
+                            (축약 .MainActivity 는 Error type 3 이므로 FQN 필수).
+  --adb <path>              adb executable. Defaults to $ADB or PATH lookup.
+  --cold-start-iterations N Cold start 반복 측정 횟수. Defaults to 3.
+  --region-target <name>    지역 전환 목표 권역 (메뉴 셀 텍스트). Defaults to 부산.
+  --settle-seconds <sec>    각 단계 안착 대기. Defaults to 4.
+  -h, --help                Show this help.
+USAGE
+}
+
+SERIAL=""
+ARTIFACT_DIR=""
+PACKAGE="com.easysubway.app"
+ACTIVITY="com.easysubway.easysubway_mobile.MainActivity"
+ADB="${ADB:-}"
+COLD_START_ITERATIONS=3
+REGION_TARGET="부산"
+SETTLE_SECONDS=4
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --serial) SERIAL="${2:-}"; shift 2 ;;
+    --artifact-dir) ARTIFACT_DIR="${2:-}"; shift 2 ;;
+    --package) PACKAGE="${2:-}"; shift 2 ;;
+    --activity) ACTIVITY="${2:-}"; shift 2 ;;
+    --adb) ADB="${2:-}"; shift 2 ;;
+    --cold-start-iterations) COLD_START_ITERATIONS="${2:-}"; shift 2 ;;
+    --region-target) REGION_TARGET="${2:-}"; shift 2 ;;
+    --settle-seconds) SETTLE_SECONDS="${2:-}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+if [[ -z "$SERIAL" || -z "$ARTIFACT_DIR" ]]; then
+  echo "--serial and --artifact-dir are required." >&2
+  usage
+  exit 1
+fi
+
+if [[ -z "$ADB" ]]; then
+  ADB="$(command -v adb || true)"
+fi
+if [[ -z "$ADB" ]]; then
+  echo "adb executable not found. Pass --adb or set \$ADB." >&2
+  exit 1
+fi
+
+mkdir -p "$ARTIFACT_DIR"
+
+adb_device() { "$ADB" -s "$SERIAL" "$@"; }
+
+require_non_empty() {
+  local path="$1"
+  if [[ ! -s "$path" ]]; then
+    echo "Expected non-empty artifact: $path" >&2
+    exit 1
+  fi
+}
+
+if ! adb_device get-state | grep -qx "device"; then
+  echo "adb target is not ready: $SERIAL" >&2
+  exit 1
+fi
+
+wm_size="$(adb_device shell wm size | tr -d '\r')"
+if [[ ! "$wm_size" =~ ([0-9]+)x([0-9]+) ]]; then
+  echo "Unable to parse device size from: $wm_size" >&2
+  exit 1
+fi
+WIDTH="${BASH_REMATCH[1]}"
+HEIGHT="${BASH_REMATCH[2]}"
+
+# 기기 시계 epoch(나노초). logcat -v epoch 와 동일 시계축(기기 date)이라 host 시계와
+# 섞이지 않는다. cold start·전환 시작 시각을 기기에서 직접 읽어 정확도를 높인다.
+device_epoch_ns() {
+  adb_device shell 'date +%s%N' | tr -d '\r'
+}
+
+# logcat epoch 버퍼에서 첫 routeMapFrame 라인의 epoch(초.밀리)를 반환. 호출 직전에
+# logcat -c 로 버퍼를 비운 뒤 사용한다(그 이후 첫 프레임 = 측정 대상).
+first_route_map_frame_epoch() {
+  adb_device logcat -d -v epoch \
+    | awk '/routeMapFrame/ { print $1; exit }' \
+    | tr -d '\r'
+}
+
+# 첫 routeMapFrame 이 로그에 나타날 때까지 최대 max_wait 초 폴링(초.밀리 반환, 없으면
+# 공란). cold start 첫 표시는 데이터팩 압축 해제·레이아웃 때문에 편차가 커, 고정
+# settle 대신 프레임 등장을 폴링해 측정치의 위·아래 편향을 줄인다.
+wait_route_map_frame_epoch() {
+  local max_wait="$1"
+  local waited=0 epoch=""
+  while (( waited < max_wait )); do
+    epoch="$(first_route_map_frame_epoch)"
+    if [[ -n "$epoch" ]]; then
+      echo "$epoch"
+      return 0
+    fi
+    sleep 1
+    waited=$(( waited + 1 ))
+  done
+  echo ""
+}
+
+# 시작 epoch(ns)와 첫 프레임 epoch(초.밀리) 사이의 ms.
+elapsed_ms_from_ns() {
+  local start_ns="$1" frame_epoch_s="$2"
+  awk -v s="$start_ns" -v f="$frame_epoch_s" 'BEGIN{printf "%.0f", (f - s/1e9) * 1000}'
+}
+
+# Flutter 제스처 인식기가 `input tap` 합성 이벤트를 드롭하는 케이스가 있어(온보딩
+# CTA·노선도), DOWN/UP 분리 motionevent 로 탭한다(실측: tap 무반응, motionevent 정상).
+robust_tap() {
+  local x="$1" y="$2"
+  adb_device shell input motionevent DOWN "$x" "$y" >/dev/null 2>&1
+  sleep 0.15
+  adb_device shell input motionevent UP "$x" "$y" >/dev/null 2>&1
+}
+
+# 온보딩 자동 통과. 이 빌드(profile)는 cold start 마다 온보딩 2페이지(시작하기 →
+# 이대로 시작, 둘 다 하단중앙 CTA (WIDTH/2, HEIGHT*0.87 부근))가 다시 뜬다 —
+# 온보딩 완료가 cold 재시작에 persist 되지 않으므로, cold start 첫 표시를 측정하려면
+# CTA 를 눌러 노선도 홈까지 도달해야 한다. UI 트리에서 '시작하기'/'이대로 시작'
+# content-desc 를 찾아 탭한다(좌표 하드코딩 회귀 방지). onboarding 완료 시각(ns)을
+# echo 로 반환(없으면 공란) — cold start의 순수 map-load 구간 측정에 쓴다.
+dismiss_onboarding() {
+  local completed_ns=""
+  for _ in 1 2 3; do
+    if adb_device logcat -d | grep -q routeMapFrame; then
+      break
+    fi
+    adb_device shell uiautomator dump /sdcard/ob.xml >/dev/null 2>&1 || true
+    adb_device pull /sdcard/ob.xml "$ARTIFACT_DIR/onboarding-dump.xml" >/dev/null 2>&1 || true
+    local cta_bounds=""
+    if [[ -s "$ARTIFACT_DIR/onboarding-dump.xml" ]]; then
+      cta_bounds="$(grep -o 'content-desc="[^"]*\(시작하기\|이대로 시작\)[^"]*"[^>]*bounds="\[[0-9]*,[0-9]*\]\[[0-9]*,[0-9]*\]"' "$ARTIFACT_DIR/onboarding-dump.xml" | head -1 | grep -o 'bounds="\[[0-9]*,[0-9]*\]\[[0-9]*,[0-9]*\]"' | head -1 || true)"
+    fi
+    if [[ -z "$cta_bounds" ]]; then
+      # UI 트리에 CTA 가 없으면 온보딩이 아니거나 이미 지나감 — 종료.
+      break
+    fi
+    if [[ "$cta_bounds" =~ \[([0-9]+),([0-9]+)\]\[([0-9]+),([0-9]+)\] ]]; then
+      local cx=$(( (${BASH_REMATCH[1]} + ${BASH_REMATCH[3]}) / 2 ))
+      local cy=$(( (${BASH_REMATCH[2]} + ${BASH_REMATCH[4]}) / 2 ))
+      completed_ns="$(device_epoch_ns)"
+      robust_tap "$cx" "$cy"
+      sleep 2
+    else
+      break
+    fi
+  done
+  # 마지막 CTA 탭 시각(ns)을 파일로 남긴다 — $(…) stdout 캡처보다 견고.
+  echo "$completed_ns" > "$ARTIFACT_DIR/.onboarding-done-ns"
+}
+
+# ── ① cold start → 노선도 첫 표시 ───────────────────────────────────────────
+COLD_LOG="$ARTIFACT_DIR/cold-start.csv"
+# launch_to_frame_ms : am start → 첫 routeMapFrame (온보딩 자동 통과 포함, 실사용
+#   returning-user 관점의 총 cold start). map_load_ms : 온보딩 완료(마지막 CTA 탭)
+#   → 첫 routeMapFrame (데이터팩 해제·레이아웃 등 순수 노선도 로드 구간). 이 빌드는
+#   온보딩 완료가 cold 재시작에 persist 되지 않아(측정 중 확인) 매 회 온보딩을
+#   자동 통과한다 — 사람 탭 지연을 배제한 순수 로드 비용은 map_load_ms 로 본다.
+echo "iteration,am_total_time_ms,launch_to_frame_ms,map_load_ms" > "$COLD_LOG"
+
+for ((it = 1; it <= COLD_START_ITERATIONS; it += 1)); do
+  adb_device shell am force-stop "$PACKAGE"
+  # 프로세스 종료 안착 + 파일 캐시가 아닌 process cold 보장.
+  sleep 2
+  adb_device logcat -c
+  start_ns="$(device_epoch_ns)"
+  # am start -W: TotalTime = 앱 프로세스 시작→첫 프레임 그려짐(activity displayed).
+  am_out="$(adb_device shell am start -W -n "$PACKAGE/$ACTIVITY" 2>&1 | tr -d '\r')"
+  echo "$am_out" >> "$ARTIFACT_DIR/am-start-$it.txt"
+  # TotalTime 은 activity 최초 draw 시에만 나온다. 이미 resumed(warm no-op) 이면
+  # WaitTime 만 나온다 — cold start 정본은 first routeMapFrame(첫 표시)이므로
+  # TotalTime 부재는 참고값 공란으로 두고 실패시키지 않는다(측정 계속).
+  am_total="$(echo "$am_out" | awk -F': ' '/^TotalTime/ {print $2}')"
+  am_total="${am_total:-}"
+  sleep "$SETTLE_SECONDS"
+  # 온보딩이 뜨면 자동 통과하고 완료(마지막 CTA 탭) 시각(ns)을 파일로 받는다.
+  : > "$ARTIFACT_DIR/.onboarding-done-ns"
+  dismiss_onboarding
+  onboarding_done_ns="$(tr -d '\r\n' < "$ARTIFACT_DIR/.onboarding-done-ns")"
+  # 첫 routeMapFrame epoch − 프로세스 시작 epoch(ns) = 노선도 첫 표시까지(ms).
+  frame_epoch="$(wait_route_map_frame_epoch "$(( SETTLE_SECONDS + 8 ))")"
+  if [[ -z "$frame_epoch" ]]; then
+    echo "No routeMapFrame log after cold start (iteration $it)." >&2
+    echo "Use a debug/profile build; onboarding 자동 통과 실패 여부 확인." >&2
+    exit 1
+  fi
+  launch_to_frame_ms="$(elapsed_ms_from_ns "$start_ns" "$frame_epoch")"
+  if [[ -n "$onboarding_done_ns" ]]; then
+    map_load_ms="$(elapsed_ms_from_ns "$onboarding_done_ns" "$frame_epoch")"
+  else
+    map_load_ms="$launch_to_frame_ms"
+  fi
+  echo "$it,$am_total,$launch_to_frame_ms,$map_load_ms" >> "$COLD_LOG"
+done
+
+# ── ② 지역 전환 시간 ────────────────────────────────────────────────────────
+# 노선도 홈에서 지역 메뉴 버튼(Semantics '지역: …, 지역 변경')을 UI 트리에서 찾아 탭,
+# 목표 권역 셀을 탭한 뒤 새 권역 첫 routeMapFrame 까지의 시간을 측정한다.
+REGION_LOG="$ARTIFACT_DIR/region-switch.csv"
+echo "region_target,switch_ms" > "$REGION_LOG"
+
+adb_device shell am force-stop "$PACKAGE"
+sleep 2
+adb_device logcat -c
+adb_device shell am start -n "$PACKAGE/$ACTIVITY" >/dev/null
+sleep "$SETTLE_SECONDS"
+# 노선도 홈까지 온보딩 자동 통과.
+dismiss_onboarding >/dev/null
+sleep 2
+
+UI_XML="$ARTIFACT_DIR/region-ui-before.xml"
+adb_device exec-out uiautomator dump /dev/tty 2>/dev/null | sed 's/UI hierchary dumped to: \/dev\/tty//' > "$UI_XML" || true
+if [[ ! -s "$UI_XML" ]]; then
+  adb_device shell uiautomator dump /sdcard/region-ui.xml >/dev/null 2>&1
+  adb_device pull /sdcard/region-ui.xml "$UI_XML" >/dev/null 2>&1 || true
+fi
+require_non_empty "$UI_XML"
+
+# '지역 변경' 을 포함한 노드의 bounds 를 파싱해 중심 좌표를 얻는다.
+region_bounds="$(grep -o 'content-desc="[^"]*지역 변경[^"]*"[^>]*bounds="\[[0-9]*,[0-9]*\]\[[0-9]*,[0-9]*\]"' "$UI_XML" | head -1 | grep -o 'bounds="\[[0-9]*,[0-9]*\]\[[0-9]*,[0-9]*\]"' | head -1 || true)"
+if [[ -z "$region_bounds" ]]; then
+  echo "지역 변경 컨트롤을 UI 트리에서 찾지 못했다 — semantics 라벨/노선도 홈 상태 확인." >&2
+  echo "UI dump: $UI_XML" >&2
+  exit 1
+fi
+if [[ "$region_bounds" =~ \[([0-9]+),([0-9]+)\]\[([0-9]+),([0-9]+)\] ]]; then
+  rx=$(( (${BASH_REMATCH[1]} + ${BASH_REMATCH[3]}) / 2 ))
+  ry=$(( (${BASH_REMATCH[2]} + ${BASH_REMATCH[4]}) / 2 ))
+else
+  echo "지역 변경 bounds 파싱 실패: $region_bounds" >&2
+  exit 1
+fi
+
+robust_tap "$rx" "$ry"
+sleep 1
+
+# 메뉴에서 목표 권역 셀 탭.
+MENU_XML="$ARTIFACT_DIR/region-ui-menu.xml"
+adb_device shell uiautomator dump /sdcard/region-menu.xml >/dev/null 2>&1
+adb_device pull /sdcard/region-menu.xml "$MENU_XML" >/dev/null 2>&1 || true
+require_non_empty "$MENU_XML"
+
+target_bounds="$(grep -o "text=\"$REGION_TARGET\"[^>]*bounds=\"\[[0-9]*,[0-9]*\]\[[0-9]*,[0-9]*\]\"" "$MENU_XML" | head -1 | grep -o 'bounds="\[[0-9]*,[0-9]*\]\[[0-9]*,[0-9]*\]"' | head -1 || true)"
+if [[ -z "$target_bounds" ]]; then
+  # content-desc 로도 시도.
+  target_bounds="$(grep -o "content-desc=\"[^\"]*$REGION_TARGET[^\"]*\"[^>]*bounds=\"\[[0-9]*,[0-9]*\]\[[0-9]*,[0-9]*\]\"" "$MENU_XML" | head -1 | grep -o 'bounds="\[[0-9]*,[0-9]*\]\[[0-9]*,[0-9]*\]"' | head -1 || true)"
+fi
+if [[ -z "$target_bounds" ]]; then
+  echo "권역 메뉴에서 '$REGION_TARGET' 셀을 찾지 못했다." >&2
+  echo "Menu dump: $MENU_XML" >&2
+  exit 1
+fi
+if [[ "$target_bounds" =~ \[([0-9]+),([0-9]+)\]\[([0-9]+),([0-9]+)\] ]]; then
+  tx=$(( (${BASH_REMATCH[1]} + ${BASH_REMATCH[3]}) / 2 ))
+  ty=$(( (${BASH_REMATCH[2]} + ${BASH_REMATCH[4]}) / 2 ))
+else
+  echo "권역 셀 bounds 파싱 실패: $target_bounds" >&2
+  exit 1
+fi
+
+adb_device logcat -c
+tap_ns="$(device_epoch_ns)"
+robust_tap "$tx" "$ty"
+
+switch_frame_epoch="$(wait_route_map_frame_epoch "$(( SETTLE_SECONDS + 8 ))")"
+if [[ -z "$switch_frame_epoch" ]]; then
+  echo "지역 전환 후 routeMapFrame 로그가 없다 — 전환 실패 또는 프레임 미기록." >&2
+  exit 1
+fi
+switch_ms="$(elapsed_ms_from_ns "$tap_ns" "$switch_frame_epoch")"
+echo "$REGION_TARGET,$switch_ms" >> "$REGION_LOG"
+
+adb_device exec-out screencap -p > "$ARTIFACT_DIR/region-switched.png" || true
+
+# ── 요약 ────────────────────────────────────────────────────────────────────
+{
+  echo "# EasySubway route map cold-start / region-switch evidence (#1952 작업 4)"
+  echo
+  echo "- serial: $SERIAL"
+  echo "- package: $PACKAGE"
+  echo "- activity: $ACTIVITY"
+  echo "- viewport: ${WIDTH}x${HEIGHT}"
+  echo "- captured_at_utc: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo
+  echo "## ① Cold start → 노선도 첫 표시 (목표 ≤ 2000ms)"
+  echo "- launch_to_frame_ms = am start → 첫 routeMapFrame (온보딩 자동 통과 포함)"
+  echo "- map_load_ms = 온보딩 완료 CTA 탭 → 첫 routeMapFrame (순수 노선도 로드)"
+  echo "- 주: 이 빌드는 온보딩 완료가 cold 재시작에 persist 되지 않아 매 회 온보딩"
+  echo "  2페이지를 자동 통과한다 — 순수 로드 비용은 map_load_ms 로 판정한다."
+  echo '```'
+  cat "$COLD_LOG"
+  echo '```'
+  awk -F, 'NR>1 {s3+=$3; s4+=$4; n+=1; if($3>m3)m3=$3; if($4>m4)m4=$4} END {if(n>0) printf "- mean_launch_to_frame_ms=%.0f max=%.0f | mean_map_load_ms=%.0f max=%.0f (n=%d)\n", s3/n, m3, s4/n, m4, n}' "$COLD_LOG"
+  echo
+  echo "## ② 지역 전환 시간"
+  echo '```'
+  cat "$REGION_LOG"
+  echo '```'
+} > "$ARTIFACT_DIR/launch-region-summary.md"
+
+require_non_empty "$ARTIFACT_DIR/launch-region-summary.md"
+echo "Wrote $ARTIFACT_DIR/launch-region-summary.md"

--- a/tools/mobile/run-route-map-launch-region-evidence.sh
+++ b/tools/mobile/run-route-map-launch-region-evidence.sh
@@ -106,8 +106,11 @@ device_epoch_ns() {
 # logcat epoch 버퍼에서 첫 routeMapFrame 라인의 epoch(초.밀리)를 반환. 호출 직전에
 # logcat -c 로 버퍼를 비운 뒤 사용한다(그 이후 첫 프레임 = 측정 대상).
 first_route_map_frame_epoch() {
+  # awk 로 첫 매치만 출력하되 exit 하지 않고 입력을 끝까지 읽는다. exit 로 조기
+  # 종료하면 set -o pipefail 하에서 앞단 logcat 이 SIGPIPE(141)로 죽어 매치가
+  # 있어도 파이프라인이 실패로 처리된다(첫 프레임 판정 오탐).
   adb_device logcat -d -v epoch \
-    | awk '/routeMapFrame/ { print $1; exit }' \
+    | awk '/routeMapFrame/ && !seen { print $1; seen = 1 }' \
     | tr -d '\r'
 }
 
@@ -153,7 +156,10 @@ robust_tap() {
 dismiss_onboarding() {
   local completed_ns=""
   for _ in 1 2 3; do
-    if adb_device logcat -d | grep -q routeMapFrame; then
+    # grep -q 는 첫 매치에서 종료해 pipefail 하 logcat 을 SIGPIPE 로 죽인다 —
+    # grep -c 로 입력을 끝까지 읽어 매치 수를 세고, 0 초과면 프레임이 이미 떴다고
+    # 판정한다(로그 존재 시 온보딩 단계 종료).
+    if [[ "$(adb_device logcat -d | grep -c routeMapFrame)" -gt 0 ]]; then
       break
     fi
     adb_device shell uiautomator dump /sdcard/ob.xml >/dev/null 2>&1 || true
@@ -274,7 +280,7 @@ require_non_empty "$MENU_XML"
 target_bounds="$(grep -o "text=\"$REGION_TARGET\"[^>]*bounds=\"\[[0-9]*,[0-9]*\]\[[0-9]*,[0-9]*\]\"" "$MENU_XML" | head -1 | grep -o 'bounds="\[[0-9]*,[0-9]*\]\[[0-9]*,[0-9]*\]"' | head -1 || true)"
 if [[ -z "$target_bounds" ]]; then
   # content-desc 로도 시도.
-  target_bounds="$(grep -o "content-desc=\"[^\"]*$REGION_TARGET[^\"]*\"[^>]*bounds=\"\[[0-9]*,[0-9]*\]\[[0-9]*,[0-9]*\]\"" "$MENU_XML" | head -1 | grep -o 'bounds="\[[0-9]*,[0-9]*\]\[[0-9]*,[0-9]*\]"' | head -1 || true)"
+  target_bounds="$(grep -o "content-desc=\"[^\"]*${REGION_TARGET}[^\"]*\"[^>]*bounds=\"\[[0-9]*,[0-9]*\]\[[0-9]*,[0-9]*\]\"" "$MENU_XML" | head -1 | grep -o 'bounds="\[[0-9]*,[0-9]*\]\[[0-9]*,[0-9]*\]"' | head -1 || true)"
 fi
 if [[ -z "$target_bounds" ]]; then
   echo "권역 메뉴에서 '$REGION_TARGET' 셀을 찾지 못했다." >&2

--- a/tools/mobile/run-route-map-qa-gate.sh
+++ b/tools/mobile/run-route-map-qa-gate.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ── 노선도 QA 통합 게이트 오케스트레이터 (#1952) ──────────────────────────────
+#
+# 수도권 도식은 오너가 v2, v3… 로 계속 버저닝해 재배포한다. 버전 교체 때마다 이
+# 스크립트 하나로 라벨·성능·오프라인 게이트를 재실행한다(이슈 #1952 반복 운영 전제).
+#
+# 실행 순서(체크리스트):
+#   [0] 4권역 노출 실측 — 팩 route_map_positions 의 distinct region 확인
+#       (부산권·대구권·대전권·광주권 + 수도권). 프로덕션 _networkMapRegions() 는
+#       SELECT DISTINCT region 이므로 팩에 수록된 권역이 그대로 노출된다.
+#   [1] 라벨 겹침 기계 게이트 — 수도권 + 비수도권 4권역 0/baseline:
+#         flutter test test/features/network_map/presentation/capital_label_overlap_gate_test.dart
+#         flutter test test/features/network_map/presentation/regional_label_overlap_gate_test.dart
+#   [2] 스케일 3구간 스크린샷 매트릭스(min contain-fit / 초기 / 초기×2) — 5개 권역.
+#       폰트 하한 판정 = 초기×2 환승역명 가독. 라벨 겹침 게이트(보수 전각 폭 근사)가
+#       초기 스케일 가독을 기계 보증하고, 확대는 라벨을 키우기만 하므로 하한은 초기다.
+#       실기기 스크린샷은 아래 성능/전환 스크립트가 각 권역 진입 시 캡처한다.
+#   [3] 접근성 baseline(48dp hit target·대비 토큰·semantics):
+#         flutter test test/accessibility_baseline_test.dart
+#       실기기 semantics(역명·노선·환승·출발/경유/도착 action)는 uiautomator 덤프로
+#       확인한다(런처 진입 후 content-desc: '<역>역', '노선도, 역을 누르면 …', 역 tap
+#       시 '출발/경유/도착/닫기').
+#   [4] 성능 재측정(profile 빌드, Galaxy A17급 실기기):
+#         tools/mobile/run-route-map-android-evidence.sh … --measure-after-route-map-settle
+#         node  tools/mobile/analyze-route-map-android-evidence.mjs --artifact-dir <dir>
+#       기준: frame P90 < 16.7ms, jank < 5%, pan 중 crash 0.
+#       신규 2종(cold start 첫 표시·지역 전환):
+#         tools/mobile/run-route-map-launch-region-evidence.sh …
+#   [5] 오프라인 QA — adb 비행기 모드 토글 후 5개 권역 표시·역 tap·지역 전환.
+#
+# 성능 측정은 profile 빌드, 스크린샷/semantics 캡처는 debug 또는 profile 빌드가
+# 설치돼 있어야 한다(routeMapFrame 로그 필수). 온보딩은 매 cold start 재노출될 수
+# 있어(측정 중 확인) launch-region 스크립트가 CTA 를 자동 통과한다.
+#
+# fail closed: 기기 미연결·프레임 로그 부재·게이트 미달은 위조 없이 비영 종료.
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  tools/mobile/run-route-map-qa-gate.sh --serial <adb-serial> --artifact-root <dir> [options]
+
+Options:
+  --serial <adb-serial>     Required Android device serial (Galaxy A17급 실기기 권장).
+  --artifact-root <dir>     Required. 하위에 tests/perf/launch-region/offline 산출.
+  --adb <path>              adb executable. Defaults to $ADB or PATH lookup.
+  --pan-count <n>           성능 pan 횟수. Defaults to 5(기록 baseline 과 동일 축).
+  --skip-tests              flutter 게이트 테스트 스킵(실기기 단계만).
+  --skip-device            실기기 단계 스킵(flutter 게이트만).
+  -h, --help                Show this help.
+
+프레임 P90<16.7ms·jank<5%·crash 0 판정은 analyze 스크립트 출력의 FrameTiming
+(build/raster p90·janky%) 을 정본으로 읽는다.
+USAGE
+}
+
+SERIAL=""
+ARTIFACT_ROOT=""
+ADB="${ADB:-}"
+PAN_COUNT=5
+SKIP_TESTS="false"
+SKIP_DEVICE="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --serial) SERIAL="${2:-}"; shift 2 ;;
+    --artifact-root) ARTIFACT_ROOT="${2:-}"; shift 2 ;;
+    --adb) ADB="${2:-}"; shift 2 ;;
+    --pan-count) PAN_COUNT="${2:-}"; shift 2 ;;
+    --skip-tests) SKIP_TESTS="true"; shift ;;
+    --skip-device) SKIP_DEVICE="true"; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MOBILE_DIR="$REPO_ROOT/apps/mobile"
+
+if [[ "$SKIP_TESTS" != "true" ]]; then
+  echo "== [1] 라벨 겹침 게이트 (수도권 + 비수도권 4권역) =="
+  ( cd "$MOBILE_DIR" && flutter test \
+      test/features/network_map/presentation/capital_label_overlap_gate_test.dart \
+      test/features/network_map/presentation/regional_label_overlap_gate_test.dart )
+  echo "== [3] 접근성 baseline (48dp·대비·semantics) =="
+  ( cd "$MOBILE_DIR" && flutter test test/accessibility_baseline_test.dart )
+fi
+
+if [[ "$SKIP_DEVICE" == "true" ]]; then
+  echo "device 단계 스킵. flutter 게이트 완료."
+  exit 0
+fi
+
+if [[ -z "$SERIAL" || -z "$ARTIFACT_ROOT" ]]; then
+  echo "--serial 와 --artifact-root 는 실기기 단계에 필수." >&2
+  usage
+  exit 1
+fi
+mkdir -p "$ARTIFACT_ROOT"
+ADB_ARGS=()
+[[ -n "$ADB" ]] && ADB_ARGS=(--adb "$ADB")
+
+echo "== [4] 성능 재측정 (profile, pan=$PAN_COUNT) =="
+"$SCRIPT_DIR/run-route-map-android-evidence.sh" \
+  --serial "$SERIAL" --artifact-dir "$ARTIFACT_ROOT/perf" \
+  --build-mode profile --pan-count "$PAN_COUNT" --measure-after-route-map-settle \
+  "${ADB_ARGS[@]}"
+node "$SCRIPT_DIR/analyze-route-map-android-evidence.mjs" --artifact-dir "$ARTIFACT_ROOT/perf"
+
+echo "== [4b] 신규 측정: cold start 첫 표시 · 지역 전환 =="
+"$SCRIPT_DIR/run-route-map-launch-region-evidence.sh" \
+  --serial "$SERIAL" --artifact-dir "$ARTIFACT_ROOT/launch-region" \
+  --cold-start-iterations 3 --region-target 부산 "${ADB_ARGS[@]}"
+
+echo
+echo "완료. 판정은 각 산출 summary 를 열어 P90<16.7ms·jank<5%·crash 0 및"
+echo "cold start·지역 전환 수치를 확인하라. 오프라인([5])·스케일 매트릭스([2])는"
+echo "이 스크립트가 진입한 권역 스크린샷과 함께 수동 판독한다."

--- a/tools/mobile/run-route-map-qa-gate.sh
+++ b/tools/mobile/run-route-map-qa-gate.sh
@@ -106,13 +106,13 @@ echo "== [4] 성능 재측정 (profile, pan=$PAN_COUNT) =="
 "$SCRIPT_DIR/run-route-map-android-evidence.sh" \
   --serial "$SERIAL" --artifact-dir "$ARTIFACT_ROOT/perf" \
   --build-mode profile --pan-count "$PAN_COUNT" --measure-after-route-map-settle \
-  "${ADB_ARGS[@]}"
+  ${ADB_ARGS[@]+"${ADB_ARGS[@]}"}
 node "$SCRIPT_DIR/analyze-route-map-android-evidence.mjs" --artifact-dir "$ARTIFACT_ROOT/perf"
 
 echo "== [4b] 신규 측정: cold start 첫 표시 · 지역 전환 =="
 "$SCRIPT_DIR/run-route-map-launch-region-evidence.sh" \
   --serial "$SERIAL" --artifact-dir "$ARTIFACT_ROOT/launch-region" \
-  --cold-start-iterations 3 --region-target 부산 "${ADB_ARGS[@]}"
+  --cold-start-iterations 3 --region-target 부산 ${ADB_ARGS[@]+"${ADB_ARGS[@]}"}
 
 echo
 echo "완료. 판정은 각 산출 summary 를 열어 P90<16.7ms·jank<5%·crash 0 및"


### PR DESCRIPTION
## 관련 이슈

Refs #1952

## 작업 배경

새 수도권 정본(#1965) 교체와 4권역 audit 게이트 상시화(#1969) 이후, 노선도 QA 통합 게이트(#1952)를 새 도식 기준으로 재측정하고 **버전 교체 때마다 재실행 가능한 형태**로 남긴다. 성능 기준은 오너 확정 코멘트(2026-07-11)로 고정: Galaxy A17급 실기기 / P90 < 16.7ms / jank < 5% / crash 0.

## 작업 내용

- **비수도권 4권역(부산·대구·대전·광주) 라벨 겹침 기계 게이트 신설** (`regional_label_overlap_gate_test.dart`). 수도권 게이트와 동일 측정(보수 전각 폭 근사)·동일 fixture 로더(`region` 인자)를 재사용해 라벨-라벨·라벨-선·뱃지-선·뱃지-라벨·unresolved 를 하드 0 baseline 으로 고정.
- **cold start 첫 표시·지역 전환 측정 스크립트 신설** (`run-route-map-launch-region-evidence.sh`, 작업 4 신규 2종). 앱 FrameTiming(`routeMapFrame`) 로그를 정본으로 판정. 온보딩이 cold 재시작마다 재노출되는 빌드 특성을 자동 통과하고, Flutter 제스처 인식기가 합성 `input tap` 을 드롭하는 케이스는 `motionevent DOWN/UP` 분리로 우회.
- **반복 운영 오케스트레이터 신설** (`run-route-map-qa-gate.sh`). 라벨·접근성·성능·cold start·지역 전환 게이트를 한 번에 재실행. 체크리스트는 스크립트 주석으로 고정(리포 `*.md` 전역 gitignore 준수).

**노출 확장 코드 변경은 불필요**로 판정: 프로덕션 `_networkMapRegions()` 는 `SELECT DISTINCT region` 이고 커밋된 팩 `capital.sqlite` 의 `route_map_positions` 에 4권역이 이미 수록돼 있어(부산권 158·대구권 101·대전권 22·광주권 20 positions) 실기기에서 4권역이 그대로 노출·전환됨을 확인했다. 따라서 `Refs #1951` 노출 확장 변경은 포함하지 않는다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/features/network_map/presentation/capital_label_overlap_gate_test.dart test/features/network_map/presentation/regional_label_overlap_gate_test.dart` → All tests passed (수도권 1 + 4권역 4)
  - `flutter test test/accessibility_baseline_test.dart` → All tests passed (48dp hit target·대비 토큰·semantics 3건)
  - `flutter test test/features/network_map/` → 152 passed (신규 게이트 포함, 회귀 없음)
  - `flutter test test/features/stations/drift_station_repository_test.dart` → 12 passed (region 선택/노출 로직 회귀 없음)
  - `tools/mobile/run-route-map-android-evidence.sh … --build-mode profile --measure-after-route-map-settle` + `analyze-route-map-android-evidence.mjs` (실기기 SM A175N, profile) → 아래 표
  - `tools/mobile/run-route-map-launch-region-evidence.sh …` (cold start·지역 전환) → 아래 표

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| [0] 4권역 노출 | 실기기(SM A175N) | 팩 distinct region + 실기기 지역 메뉴/전환 | 메뉴에 수도권·광주·대구·대전·부산 노출; 부산 전환 후 `지역: 부산` semantics. 팩: 수도권 800·부산권 158·대구권 101·대전권 22·광주권 20 | 통과 |
| [1] 라벨 겹침 게이트(5권역) | 단위 테스트 | flutter test 2종 | 수도권 라벨-라벨 0·unresolved 0·라벨-선 9(baseline)·뱃지 0; 4권역 전부 0 | 통과 |
| [2] 스케일 매트릭스 | 실기기 | 초기 스케일 스크린샷 + 겹침 게이트 폰트 하한 보증 | 수도권·부산 초기 스케일 라벨 가독. adb pinch 는 scale 제스처 선점으로 ×2 캡처 불가 — 하한은 초기 스케일(게이트 기계 보증). `docs/1952-qa/scale`·`offline` 로컬 | 통과(초기 하한 보증) |
| [3] 접근성 | 단위 + 실기기 semantics | accessibility_baseline_test + uiautomator | 48dp·대비 통과; semantics 역명 낭독, 힌트 '노선도, 역을 누르면 출발, 도착, 역 정보 action을 볼 수 있어요', 역 tap 시 출발/경유/도착/닫기. `docs/1952-qa/a11y` | 통과 |
| [4] 성능(pan) | 실기기(profile) | evidence + analyze | **jank 5% 초과(미달)**, P90 대체로 통과·간헐 초과, crash 0 | 부분 미달(jank) |
| [4b] cold start 첫 표시 | 실기기(profile) | launch-region 스크립트 | 온보딩 완료→첫 프레임 4.4–5.5s → **≤2s 미달**. 지역 전환(warm) 216–235ms | 미달(cold start) |
| [5] 오프라인 QA | 실기기 | adb airplane-mode | 비행기 모드에서 수도권·부산 표시·전환·역 tap 정상. `docs/1952-qa/offline` | 통과 |

**성능 표(실기기 SM A175N, profile, `--measure-after-route-map-settle`, FrameTiming 정본):**

| run | 권역 | pan | jank% | build P90 | raster P90 | crash |
| --- | --- | --- | --- | --- | --- | --- |
| 1 | 수도권 | 8 | 10.76% | 13.01ms | 12.19ms | 0 |
| 2 | 수도권 | 8 | 8.53% | 10.76ms | 10.85ms | 0 |
| 3 | 수도권 | 5 | 13.10% | 23.21ms | 12.17ms | 0 |
| 4 | 수도권 | 5 | 10.20% | 14.95ms | 12.79ms | 0 |
| 5 | 수도권 | 5 | 12.42% | 15.81ms | 11.95ms | 0 |
| 6 | 부산 | 5 | 14.29% | 24.16ms | 13.88ms | 0 |

- jank: 전 런 **5% 초과(8.5–14.3%)** → 게이트 미달. raster P90 전 런 통과(<16.7ms), build P90 다수 통과·간헐 초과(23–24ms). crash 0.
- cold start 첫 표시 4.4–5.5s → **≤2s 미달**(cold 데이터팩 gzip 해제+수도권 레이아웃). 지역 전환(warm) 216–235ms.

## Version impact

- [x] no version change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 먼저 볼 지점: (1) `regional_label_overlap_gate_test.dart` 하드 0 baseline 이 4권역 실측(전부 0) 근거인지, (2) `run-route-map-launch-region-evidence.sh` 의 `motionevent` 우회·pipefail 안전(`|| true`)·fail closed, (3) 성능 jank·cold start 미달을 억지 통과 없이 실측 보고한 판단.
- 이 PR은 게이트·측정 도구 추가와 실측 보고이며 앱 런타임 코드는 변경하지 않는다. jank·cold start 미달의 성능 개선은 별도 후속 이슈 대상이다.

## 리스크

- 테스트/도구만 추가하므로 런타임 회귀 리스크 없음. launch-region 스크립트는 실기기 좌표를 uiautomator 덤프로 동적 파싱하고 미검출 시 fail closed 한다.
- 성능 jank·cold start 게이트 미달은 이 PR이 해소하지 않는다(측정·보고 범위). 후속 성능 개선 이슈 승계 필요.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **테스트**
  - 부산·대구·대전·광주 권역 노선도의 라벨, 뱃지, 선 간 겹침을 자동 검증하는 테스트를 추가했습니다.
  - 라벨 표시 누락과 미해결 겹침도 함께 확인합니다.

- **품질 개선**
  - 노선도 성능, 앱 초기 표시 시간, 지역 전환 시간을 한 번에 점검하는 QA 절차를 추가했습니다.
  - 프레임 속도, 끊김, 충돌, 초기 표시 및 전환 측정 결과를 자동으로 기록하고 기준 미달 시 알려줍니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->