### PR TITLE
[Chore] 대구·대전 노선도 admission evidence 첨부 — 공공데이터포털 개방 지정 표기 (#1951)

### DIFF
--- a/tools/route-map/route-map-license-decision.json
+++ b/tools/route-map/route-map-license-decision.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "artifactKind": "route-map-license-decision",
   "issue": 1637,
-  "decidedAt": "2026-07-11",
+  "decidedAt": "2026-07-12",
   "summary": "부산·대구·대전·광주 노선도는 원본 SVG 이미지를 앱 렌더링 source of truth로 쓰지 않고, 역 좌표·노선 위상(사실 데이터) 기반 자체 schematic layout으로 그린다(대안 A). 원본 SVG는 좌표 검수 기준으로만 사용한다.",
   "renderingSourceOfTruth": "structured-data",
   "reviewStatusValues": [
@@ -74,7 +74,7 @@
       "commercialProductionReady": true,
       "redistributionAllowed": true,
       "reviewStatus": "self-drawn-fact-based",
-      "notes": "원본 SVG는 재배포 권한 미확인(permission-required). 앱 렌더링은 자체 schematic으로 전환, 원본 SVG는 좌표 검수 참조로만 쓴다. SVG 번들 유지 중에는 attribution 유지, 자체 도식 전환 후 해제 가능. 상용 준비 완료는 #1640 좌표·#1641 렌더러에서 판정한다. [2026-07-05 #1639/#1640] 좌표 provenance(qa-official-svg-coordinate=역 좌표·위상 사실 데이터, Feist/OSM 선례) 재검증 완료. line_tracks를 SVG stroke(표현)에서 down_path(역-역 위상=사실)로 재빌드해 SVG 표현 파생 제거. SVG 번들 제거(#1715)·자체 도식 전환 완료 → commercial_use_allowed=1·attribution 해제 승격. [2026-07-11 #1958] 자체 도식 산출물은 SVG 표현 파생이 아니므로 재배포 허용(redistributionAllowed=true), 사실 데이터 재검증 완료 상태로 reviewStatus=self-drawn-fact-based. 두 필드를 정본에 명시해 manifest와 교차 검증한다.",
+      "notes": "원본 SVG는 재배포 권한 미확인(permission-required). 앱 렌더링은 자체 schematic으로 전환, 원본 SVG는 좌표 검수 참조로만 쓴다. SVG 번들 유지 중에는 attribution 유지, 자체 도식 전환 후 해제 가능. 상용 준비 완료는 #1640 좌표·#1641 렌더러에서 판정한다. [2026-07-05 #1639/#1640] 좌표 provenance(qa-official-svg-coordinate=역 좌표·위상 사실 데이터, Feist/OSM 선례) 재검증 완료. line_tracks를 SVG stroke(표현)에서 down_path(역-역 위상=사실)로 재빌드해 SVG 표현 파생 제거. SVG 번들 제거(#1715)·자체 도식 전환 완료 → commercial_use_allowed=1·attribution 해제 승격. [2026-07-11 #1958] 자체 도식 산출물은 SVG 표현 파생이 아니므로 재배포 허용(redistributionAllowed=true), 사실 데이터 재검증 완료 상태로 reviewStatus=self-drawn-fact-based. 두 필드를 정본에 명시해 manifest와 교차 검증한다. [2026-07-12 #1951] admission evidence로 대구교통공사 역별 승하차 현황 데이터셋 공공데이터포털 페이지(https://www.data.go.kr/data/15002503/fileData.do)에서 \"이용허락범위: 제한 없음\"(상업 이용 허용) 표기 확인(확인일 2026-07-11). 단, 해당 데이터셋은 승하차 현황이며 노선도 데이터셋이 아니므로 노선도 evidence로는 대상이 어긋나는 한계가 있다 — 이 한계를 명기한 채 오너 결정(2026-07-12, 선택지 ①: 공공데이터포털 정식 개방 지정 표기를 admission evidence로 인정)에 따라 보조 evidence로만 인용한다. 현행 플래그(self-drawn-fact-based 등)의 1차 근거는 여전히 #1759 사실 데이터 법리(역 좌표·노선 위상 사실 데이터 기반 자체 도식)이며, 이번 evidence 첨부는 그 근거를 대체하지 않는다. 임시 evidence 전제: 출시 후 오너 자작 도식(self-drawn) 전환 시 evidence는 자작 기록으로 대체 예정(수도권 #1950 선례와 동일 경로). 플래그 변경 없음.",
       "licenseStatus": "self-drawn-fact-based",
       "provenanceVerifiedAt": "2026-07-05"
     },
@@ -93,7 +93,7 @@
       "commercialProductionReady": true,
       "redistributionAllowed": true,
       "reviewStatus": "self-drawn-fact-based",
-      "notes": "원본 SVG는 재배포 권한 미확인(permission-required). 앱 렌더링은 자체 schematic으로 전환, 원본 SVG는 좌표 검수 참조로만 쓴다. SVG 번들 유지 중에는 attribution 유지, 자체 도식 전환 후 해제 가능. 상용 준비 완료는 #1640 좌표·#1641 렌더러에서 판정한다. [2026-07-05 #1639/#1640] 좌표 provenance(qa-official-svg-coordinate=역 좌표·위상 사실 데이터, Feist/OSM 선례) 재검증 완료. line_tracks를 SVG stroke(표현)에서 down_path(역-역 위상=사실)로 재빌드해 SVG 표현 파생 제거. SVG 번들 제거(#1715)·자체 도식 전환 완료 → commercial_use_allowed=1·attribution 해제 승격. [2026-07-11 #1958] 자체 도식 산출물은 SVG 표현 파생이 아니므로 재배포 허용(redistributionAllowed=true), 사실 데이터 재검증 완료 상태로 reviewStatus=self-drawn-fact-based. 두 필드를 정본에 명시해 manifest와 교차 검증한다.",
+      "notes": "원본 SVG는 재배포 권한 미확인(permission-required). 앱 렌더링은 자체 schematic으로 전환, 원본 SVG는 좌표 검수 참조로만 쓴다. SVG 번들 유지 중에는 attribution 유지, 자체 도식 전환 후 해제 가능. 상용 준비 완료는 #1640 좌표·#1641 렌더러에서 판정한다. [2026-07-05 #1639/#1640] 좌표 provenance(qa-official-svg-coordinate=역 좌표·위상 사실 데이터, Feist/OSM 선례) 재검증 완료. line_tracks를 SVG stroke(표현)에서 down_path(역-역 위상=사실)로 재빌드해 SVG 표현 파생 제거. SVG 번들 제거(#1715)·자체 도식 전환 완료 → commercial_use_allowed=1·attribution 해제 승격. [2026-07-11 #1958] 자체 도식 산출물은 SVG 표현 파생이 아니므로 재배포 허용(redistributionAllowed=true), 사실 데이터 재검증 완료 상태로 reviewStatus=self-drawn-fact-based. 두 필드를 정본에 명시해 manifest와 교차 검증한다. [2026-07-12 #1951] admission evidence로 대전교통공사 노선도 파일데이터 공공데이터포털 페이지(https://www.data.go.kr/data/15050368/fileData.do)에서 \"이용허락범위: 제한 없음\"(상업 이용 허용) 표기 확인(확인일 2026-07-11), 오너 결정(2026-07-12, 선택지 ①: 공공데이터포털 정식 개방 지정 표기를 admission evidence로 인정)에 따라 admission evidence로 인정한다. 임시 evidence 전제: 출시 후 오너 자작 도식(self-drawn) 전환 시 evidence는 자작 기록으로 대체 예정(수도권 #1950 선례와 동일 경로). 기존 플래그(self-drawn-fact-based·commercial_use_allowed=1 등) 변경 없음 — #1759 사실 데이터 법리가 여전히 1차 근거다.",
       "licenseStatus": "self-drawn-fact-based",
       "provenanceVerifiedAt": "2026-07-05"
     },


### PR DESCRIPTION
## 관련 이슈

Refs #1951

## 작업 배경

- #1951 잔여 작업 "대구·대전 admission evidence 첨부"의 오너 결정(2026-07-12, 선택지 ①)이 확정되었다: 공공데이터포털의 정식 개방 지정 표기("이용허락범위: 제한 없음", 상업 이용 허용) 페이지를 admission evidence로 인정한다.
- 임시 evidence 전제(오너 명시): 출시 후 전 권역 노선도를 오너 자작 도식으로 전환할 계획이므로 현 evidence는 그 전환까지의 임시 근거이며, self-drawn 승격 시 자작 기록으로 대체된다(수도권 #1950 선례와 동일 경로).

## 작업 내용

- `tools/route-map/route-map-license-decision.json` 대전(daejeon) notes에 evidence 첨부: 대전교통공사 노선도 파일데이터 공공데이터포털 페이지(https://www.data.go.kr/data/15050368/fileData.do)의 "이용허락범위: 제한 없음"(상업 이용 허용) 표기 확인(확인일 2026-07-11), 오너 결정에 따라 admission evidence로 인정. 임시 evidence 전제 병기.
- 동일 파일 대구(daegu) notes에 evidence 첨부: 대구교통공사 역별 승하차 현황 데이터셋 페이지(https://www.data.go.kr/data/15002503/fileData.do)의 동일 표기 확인(확인일 2026-07-11)을 인용하되, 해당 데이터셋이 승하차 현황이라 노선도 evidence로는 대상이 어긋나는 한계를 명기하고 보조 evidence로만 기록. 현행 플래그의 1차 근거는 #1759 사실 데이터 법리(self-drawn-fact-based)임을 병기.
- 최상위 `decidedAt`을 2026-07-11 → 2026-07-12로 갱신(직전 #1958 notes 갱신 시에도 decidedAt이 함께 갱신된 관례와 동일).
- **플래그 값 무변경**: commercialProductionReady / attributionRequired / redistributionAllowed / reviewStatus / licenseStatus / renderingStrategy 전부 기존 값 유지. `metro_map_pack/manifest.json` 등 다른 파일 변경 없음(diff는 정본 JSON 1개 파일, 3 라인 교체).

## 검증

- 실행한 명령과 결과:
  - `node --test tools/route-map/route-map-license-decision.test.mjs` → 1 pass / 0 fail
  - `node --test tools/ci/check-map-attribution.test.mjs` → 3 pass / 0 fail
  - `node --test tools/ci/repository-contract.test.mjs` → 179 pass / 0 fail
  - `node -e "JSON.parse(require('fs').readFileSync('tools/route-map/route-map-license-decision.json','utf8'))"` → 파싱 정상

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 대전 개방 지정 표기 | 공공데이터포털(웹) | 데이터셋 페이지 실측(2026-07-11) | https://www.data.go.kr/data/15050368/fileData.do | "이용허락범위: 제한 없음" 확인 |
| 대구 개방 지정 표기 | 공공데이터포털(웹) | 데이터셋 페이지 실측(2026-07-11) | https://www.data.go.kr/data/15002503/fileData.do | "이용허락범위: 제한 없음" 확인(대상 정합 한계 명기) |
| 계약 테스트 정합 | 로컬(node --test) | 위 검증 명령 3건 | 본문 검증 섹션 | 전부 pass |
| UI/접근성/배포 | 해당 없음 | 데이터 기록(notes/decidedAt)만 변경, 렌더링·플래그·배포 산출물 무변경 | 사유 기재 | 증거 불요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음(팩 산출물 무변경, 정본 기록 JSON만 갱신)
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 대구·대전 notes에 추가된 `[2026-07-12 #1951]` 단락이 오너 결정 코멘트(2026-07-12)의 적용 지시(대전 evidence 인정 / 대구 대상 정합 한계 명기 + #1759 법리 병기 / 임시 evidence 전제)와 일치하는지, 그리고 플래그 필드가 전부 무변경인지(diff에서 boolean/enum 변경 0건).

## 리스크

- 라이선스 플래그·계약 로직 무변경이므로 기능 리스크 없음. 서술 기록의 정확성(URL·확인일·한계 명기)이 유일한 품질 축이며, 계약 테스트 3종 green으로 스키마 정합을 확인했다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
