### PR TITLE
[Mobile] 노선도 팬 성능 게이트 재통과 — raster 레이어 격리·per-frame 할당 제거 (#1973)

### DIFF
--- a/apps/mobile/lib/features/network_map/presentation/structured_route_map_painter.dart
+++ b/apps/mobile/lib/features/network_map/presentation/structured_route_map_painter.dart
@@ -286,12 +286,14 @@ class StructuredRouteMapPainter extends CustomPainter {
     required this.designScale,
     required this.camera,
     this.attributionText,
+    this.attributionPainter,
   });
 
   final ui.Picture picture;
   final double designScale;
   final MapCameraState camera;
   final String? attributionText;
+  final TextPainter? attributionPainter;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -311,13 +313,11 @@ class StructuredRouteMapPainter extends CustomPainter {
 
   void _paintAttribution(Canvas canvas, Size size) {
     final text = attributionText;
-    if (text == null || text.isEmpty) {
+    final painter = attributionPainter;
+    // painter는 State가 소유·재사용하는 캐시라 여기서 dispose하지 않는다(#1973).
+    if (text == null || text.isEmpty || painter == null) {
       return;
     }
-    final painter = TextPainter(
-      text: TextSpan(text: text, style: _attributionStyle),
-      textDirection: TextDirection.ltr,
-    )..layout();
     const padding = 4.0;
     final origin = Offset(
       padding + 2,
@@ -334,7 +334,6 @@ class StructuredRouteMapPainter extends CustomPainter {
       Paint()..color = const Color(0xCCFFFFFF),
     );
     painter.paint(canvas, origin);
-    painter.dispose();
   }
 
   @override
@@ -342,7 +341,8 @@ class StructuredRouteMapPainter extends CustomPainter {
     return oldDelegate.camera.revision != camera.revision ||
         !identical(oldDelegate.picture, picture) ||
         oldDelegate.designScale != designScale ||
-        oldDelegate.attributionText != attributionText;
+        oldDelegate.attributionText != attributionText ||
+        !identical(oldDelegate.attributionPainter, attributionPainter);
   }
 }
 
@@ -374,6 +374,10 @@ class _StructuredRouteMapViewState extends State<StructuredRouteMapView> {
   StructuredRouteMap? _sourceMap;
   RouteMapDesignSpace? _design;
   ui.Picture? _picture;
+  // attribution TextPainter는 region(텍스트) 변경 시에만 재생성한다. 매 pan 프레임의
+  // TextPainter 생성·layout 할당을 제거하기 위한 캐시(#1973). State가 dispose를 소유한다.
+  TextPainter? _attributionPainter;
+  String? _attributionPainterText;
 
   void _ensurePicture() {
     if (identical(_sourceMap, widget.map) && _picture != null) {
@@ -426,22 +430,52 @@ class _StructuredRouteMapViewState extends State<StructuredRouteMapView> {
     );
   }
 
+  void _ensureAttributionPainter() {
+    final text = widget.attributionText;
+    if (text == null || text.isEmpty) {
+      if (_attributionPainter != null) {
+        _attributionPainter!.dispose();
+        _attributionPainter = null;
+        _attributionPainterText = null;
+      }
+      return;
+    }
+    if (_attributionPainterText == text && _attributionPainter != null) {
+      return;
+    }
+    _attributionPainter?.dispose();
+    _attributionPainter = TextPainter(
+      text: TextSpan(text: text, style: _attributionStyle),
+      textDirection: TextDirection.ltr,
+    )..layout();
+    _attributionPainterText = text;
+  }
+
   @override
   void dispose() {
     _picture?.dispose();
+    _attributionPainter?.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
     _ensurePicture();
-    return CustomPaint(
-      size: widget.camera.viewportSize,
-      painter: StructuredRouteMapPainter(
-        picture: _picture!,
-        designScale: _design!.designScale,
-        camera: widget.camera,
-        attributionText: widget.attributionText,
+    _ensureAttributionPainter();
+    // RepaintBoundary로 지도 레이어를 부모 Stack의 형제 오버레이 rebuild와 분리한다.
+    // isComplex/willChange 힌트로 정적 Picture 재생 레이어의 raster 캐싱을 돕는다(#1973).
+    return RepaintBoundary(
+      child: CustomPaint(
+        size: widget.camera.viewportSize,
+        isComplex: true,
+        willChange: true,
+        painter: StructuredRouteMapPainter(
+          picture: _picture!,
+          designScale: _design!.designScale,
+          camera: widget.camera,
+          attributionText: widget.attributionText,
+          attributionPainter: _attributionPainter,
+        ),
       ),
     );
   }

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -3261,6 +3261,10 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
   // region → attribution 표시 문자열(#1951). manifest 로드 전에는 null로 두고
   // attribution을 표시하지 않는다(로드 실패 시에도 동일하게 조용히 미표기).
   Map<String, String>? _attributionTextByRegion;
+  // onTapUp 경로에서만 쓰는 stationLinesById를 매 build(팬 프레임)마다 재계산하지 않도록
+  // region·stations identity로 캐시한다(#1973). 800역/24노선 재계산이 build 스파이크 원인.
+  Map<String, List<NetworkMapLine>>? _stationLinesByIdCache;
+  String? _stationLinesByIdCacheKey;
 
   @override
   void initState() {
@@ -3308,7 +3312,6 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
 
   @override
   Widget build(BuildContext context) {
-    final stationLinesById = _stationLinesById(widget.data);
     return Container(
       key: const Key('networkMapSurface'),
       decoration: const BoxDecoration(color: Colors.white),
@@ -3408,7 +3411,7 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
                       onTapUp: (details) {
                         _openNearestStation(
                           details.localPosition,
-                          stationLinesById,
+                          _stationLinesByIdCached(widget.data),
                           geometry,
                           camera,
                         );
@@ -3461,6 +3464,21 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
         },
       ),
     );
+  }
+
+  Map<String, List<NetworkMapLine>> _stationLinesByIdCached(
+    NetworkMapData data,
+  ) {
+    final key =
+        '${data.selectedRegion}:${identityHashCode(data.stations)}:${data.stations.length}';
+    final cached = _stationLinesByIdCache;
+    if (_stationLinesByIdCacheKey == key && cached != null) {
+      return cached;
+    }
+    final computed = _stationLinesById(data);
+    _stationLinesByIdCacheKey = key;
+    _stationLinesByIdCache = computed;
+    return computed;
   }
 
   _MapGeometry _geometryFor(NetworkMapData data) {

--- a/apps/mobile/test/features/network_map/presentation/structured_route_map_painter_test.dart
+++ b/apps/mobile/test/features/network_map/presentation/structured_route_map_painter_test.dart
@@ -103,6 +103,73 @@ void main() {
     picture.dispose();
   });
 
+  test('painter는 attribution 텍스트·painter 무효화 분기에서 repaint', () {
+    final map = _map();
+    final design = routeMapDesignSpaceFor(map);
+    final layout = solveRouteMapLabelLayout(
+      map: map,
+      design: design,
+      labelTextByStationId: const {},
+      badgeLabelByLineId: const {},
+      measureLabel: (text, {required bool bold}) => const Size(10, 13),
+      measureBadge: (text) => const Size(10, 18),
+    );
+    final picture = recordRouteMapPicture(
+      map: map,
+      design: design,
+      layout: layout,
+      lineColors: const {},
+      lineOffsets: const {},
+    );
+    const camera = MapCameraState(
+      sourceBounds: Rect.fromLTWH(0, 0, 48, 48),
+      viewportSize: Size(400, 800),
+      center: Offset(24, 24),
+      scale: 8,
+      minScale: 8,
+      maxScale: 20,
+      revision: 1,
+      initialScale: 8,
+    );
+    final attributionPainter = TextPainter(
+      text: const TextSpan(text: '© 출처'),
+      textDirection: TextDirection.ltr,
+    )..layout();
+    final otherPainter = TextPainter(
+      text: const TextSpan(text: '© 출처'),
+      textDirection: TextDirection.ltr,
+    )..layout();
+
+    StructuredRouteMapPainter painterWith({
+      String? attributionText = '© 출처',
+      TextPainter? withPainter,
+    }) => StructuredRouteMapPainter(
+      picture: picture,
+      designScale: design.designScale,
+      camera: camera,
+      attributionText: attributionText,
+      attributionPainter: withPainter ?? attributionPainter,
+    );
+
+    final base = painterWith();
+    // 동일 attribution → repaint 없음(기존 무효화 조건 유지 확인).
+    expect(base.shouldRepaint(painterWith()), isFalse);
+    // attributionText 값이 다르면 repaint.
+    expect(
+      base.shouldRepaint(painterWith(attributionText: '© 다른 출처')),
+      isTrue,
+    );
+    // attributionPainter identity만 달라도 repaint.
+    expect(
+      base.shouldRepaint(painterWith(withPainter: otherPainter)),
+      isTrue,
+    );
+
+    attributionPainter.dispose();
+    otherPainter.dispose();
+    picture.dispose();
+  });
+
   test('routeMapStationLabel은 괄호 부역명을 축약한다', () {
     expect(routeMapStationLabel('굴봉산(제이드가든)'), '굴봉산');
     expect(routeMapStationLabel('신금호'), '신금호');


### PR DESCRIPTION
## 관련 이슈

close #1973

## 작업 배경

신 수도권 정본 도식(#1950, positions 800·24노선)에서 노선도 팬 jank가 오너 확정 게이트(#1952: Galaxy A17급 / P90 <16.7ms / jank <5% / crash 0, cold start 첫 표시 ≤2s)를 초과했다(수도권 8.5~13.1%, 부산 14.29%). 이전 도식(jank 3.29%) 대비 회귀로, 도식 데이터 특성과 렌더 경로(ui.Picture 1회 녹화 + transform 재생, #1789) 사이의 병목 프로파일링이 선행 과제였다.

실기기 SM A175N(profile) FrameTiming 정본으로 수도권 pan 259프레임을 분해한 결과:

- 전체 janky 13.51% 중 **raster 초과 30프레임**(raster p90 17.37ms > 16.7)이 지배적, **build 초과 10프레임**(build p50 2.31ms이나 36~45ms 간헐 스파이크).
- raster: 정적 Picture를 매 프레임 full replay하는 비용이 예산 근처에 상주.
- build 스파이크: 팬 setState마다 캔버스 전체 rebuild + 프레임당 할당(attribution TextPainter 생성·layout, onTapUp 전용 stationLinesById 재계산).

## 작업 내용

시각 결과를 바꾸지 않는 범위(golden·라벨 겹침·attribution 무회귀)로 두 병목을 개선했다.

- **raster 레이어 격리**: 지도 `CustomPaint`를 `RepaintBoundary`로 감싸 부모 Stack 형제 오버레이 rebuild에서 지도 레이어를 분리하고, `isComplex: true`·`willChange: true` 힌트로 정적 Picture 재생 레이어의 raster 캐싱을 돕는다.
- **attribution TextPainter 캐시**: 매 팬 프레임마다 생성·layout하던 TextPainter를 State가 소유해 region(텍스트) 변경 시에만 재생성하도록 전환(빈 텍스트/dispose 정리 포함). 배경 rrect·패딩·색·위치 계산은 전부 동일.
- **stationLinesById 재계산 제거**: onTapUp 경로에서만 쓰는 파생 맵을 매 build(팬 프레임)마다 재계산하던 것을 region·stations identity 캐시로 전환.

변경 파일: `apps/mobile/lib/features/network_map/presentation/structured_route_map_painter.dart`, `apps/mobile/lib/network_map.dart`.

## 검증

- 실행한 명령과 결과:
  - `flutter analyze lib/network_map.dart lib/features/network_map/presentation/structured_route_map_painter.dart` → No issues found!
  - `flutter test test/features/network_map/` → 152/152 통과 (S0 스파이크 golden, attribution, 수도권/비수도권 라벨 겹침 게이트 포함 → 시각 불변 확인).
  - `flutter test .../capital_label_overlap_gate_test.dart .../regional_label_overlap_gate_test.dart test/accessibility_baseline_test.dart` → 통과.
  - 실기기 게이트: `run-route-map-android-evidence.sh --measure-after-route-map-settle` + `analyze-route-map-android-evidence.mjs`, `run-route-map-launch-region-evidence.sh` (SM A175N RFKYA01VMQY, profile, 설치본 md5 검증 1e8754a3…).

### 게이트 전후 비교 (실기기 SM A175N, profile, FrameTiming 정본)

| 항목 | 기준 | before(신 도식) | after | 판정 |
| --- | --- | --- | --- | --- |
| pan jank (수도권) | <5% | 13.51% | **3.31%** | 통과 |
| raster P90 (수도권 pan) | <16.7ms | 17.39ms | **10.32ms** | 통과 |
| build P90 (수도권 pan) | <16.7ms | 3.36ms | **2.84ms** | 통과 |
| cold start→첫 표시(map_load) | ≤2000ms | 1882~1963ms | **1859~1880ms** | 통과 |
| 지역 전환(warm, 부산) | (참고) | 214ms | 214ms | 양호 |
| crash | 0 | 0 | 0 | 통과 |

주: cold start map_load(온보딩 완료 CTA→첫 routeMapFrame)는 profile 빌드에서 온보딩이 cold 재시작에 persist되지 않아 스크립트가 자동 통과 후 측정하는 순수 로드 구간이다. 이슈의 4.4~5.5s는 총 launch(온보딩 탭 지연 포함) 관점이며, 순수 로드 구간은 게이트(≤2s)를 통과한다.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| pan jank <5% (수도권) | Android profile 실기기 | run-route-map-android-evidence + analyze | 로컬 evidence: qa-after/perf-seoul (302프레임, 3.31%) | 통과 |
| P90 <16.7ms (build·raster) | Android profile 실기기 | analyze FrameTiming | before 17.39 → after 10.32ms raster | 통과 |
| cold start ≤2s | Android profile 실기기 | run-route-map-launch-region-evidence | qa-after/launch-region cold-start.csv (1859~1880ms) | 통과 |
| crash 0 | Android profile 실기기 | logcat crash 시그니처 grep | renderer-crashes.log 0줄 | 통과 |
| 시각 불변(golden·라벨·attribution) | flutter test | test/features/network_map/ | 152/152 통과 | 통과 |

로컬 evidence 경로(gitignore, 커밋 제외): 전/후 perf·launch-region 산출은 로컬 scratchpad에 보관.

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 1.0.2 (변경 없음)
- mobile versionCode: 10002 (변경 없음)
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: (1) RepaintBoundary + isComplex/willChange가 정적 Picture 재생 레이어에 대해 올바른 힌트인지, (2) attribution TextPainter 캐시의 dispose 수명(빈 텍스트·텍스트 변경·State dispose)과 shouldRepaint identity 비교, (3) stationLinesById 캐시 키가 기존 _geometryFor 캐시 패턴과 동일 identity를 쓰는지.
- 드로잉/레이아웃/색/라벨 배치/Picture 녹화 로직은 전혀 바꾸지 않았다(격리·캐시만). golden 152/152 통과가 시각 불변의 기계 증거.

## 리스크

- RepaintBoundary는 별도 레이어를 만들어 메모리를 소폭 늘릴 수 있으나, 정적 Picture 1장 레이어라 무시 가능(총 PSS 209MB 수준 유지). attribution 캐시는 텍스트 변경 시 재생성·dispose하므로 누수 없음. stationLinesById 캐시는 tap 정확도에 영향 없음(동일 결과, identity 키로 무효화).

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
