### PR TITLE
[Chore] #1397 원장 해시 producer + admin review record 생성기

### DIFF
--- a/tools/datapack/build-admin-review-record.mjs
+++ b/tools/datapack/build-admin-review-record.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+// admin review record 생성기 — source-admission-runbook.json requiredAdminReviewFields를
+// 채운 admin review record를 만든다. run-source-admission-pipeline.mjs의
+// validateAdminReview 계약과 100% 일치한다.
+//
+// 위조 방지:
+//   - hash 6종(licenseEvidenceHash·aliasLedgerHash·operatorMappingLedgerHash·
+//     facilityEvidenceLedgerHash·routeEvidenceLedgerHash·overrideHash)은
+//     export-ledger-hashes.mjs가 낸 JSON 산출물 파일에서만 읽는다.
+//     인자로 직접 hex를 받지 않는다 → 손으로 hash를 끼워넣을 수 없다.
+//   - sampleEvidenceHash는 sample evidence 파일의 evidenceHash에서 읽는다.
+//   - approvedBy·approvedAt·decision은 입력 인자(승인 결정 기록).
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const root = path.resolve(import.meta.dirname, "../..");
+const quotaEvidenceKeys = ["defaultDailyLimit", "portal", "productionUseAllowed", "unlockStatus"];
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const record = await buildAdminReviewRecord(args);
+  console.log(JSON.stringify(record, null, 2));
+}
+
+async function buildAdminReviewRecord(args) {
+  const candidateId = requireArg(args, "candidate");
+  const sourceId = requireArg(args, "source-id");
+  const snapshotId = requireArg(args, "snapshot-id");
+  const decision = requireArg(args, "decision");
+  if (decision !== "APPROVED") {
+    throw new Error("--decision must be APPROVED (거부/보류는 admission 대상이 아니다)");
+  }
+
+  const sampleEvidenceHash = await readSampleEvidenceHash(args);
+
+  const licenseEvidenceHash = await readLedgerHash(args, "license-hash", "license");
+  const aliasLedgerHash = await readLedgerHash(args, "alias-hash", "alias");
+  const operatorMappingLedgerHash = await readLedgerHash(args, "operator-mapping-hash", "operator-mapping");
+  const facilityEvidenceLedgerHash = await readLedgerHash(args, "facility-evidence-hash", "facility-evidence");
+  const routeEvidenceLedgerHash = await readLedgerHash(args, "route-evidence-hash", "route-evidence");
+  const overrideHash = await readLedgerHash(args, "override-hash", "override");
+
+  const quotaEvidence = await readQuotaEvidence(args);
+  const productionSource = await readProductionSource(args, sourceId, quotaEvidence, sampleEvidenceHash);
+
+  return {
+    schemaVersion: 1,
+    artifactKind: "source-admission-admin-review",
+    candidateId,
+    sourceId,
+    snapshotId,
+    sampleEvidenceHash,
+    decision,
+    approvedBy: requireArg(args, "approved-by"),
+    approvedAt: requireArg(args, "approved-at"),
+    licenseEvidenceHash,
+    aliasLedgerHash,
+    operatorMappingLedgerHash,
+    facilityEvidenceLedgerHash,
+    routeEvidenceLedgerHash,
+    overrideHash,
+    quotaEvidence,
+    productionSource,
+  };
+}
+
+// exporter JSON 산출물 파일에서 ledgerHash만 읽는다. kind가 일치하지 않으면 거부.
+async function readLedgerHash(args, argName, expectedKind) {
+  const filePath = path.resolve(root, requireArg(args, argName));
+  const parsed = JSON.parse(await readFile(filePath, "utf8"));
+  if (parsed.kind !== expectedKind) {
+    throw new Error(`--${argName} kind must be ${expectedKind}, got ${parsed.kind}`);
+  }
+  return assertSha256(parsed.ledgerHash, `--${argName}.ledgerHash`);
+}
+
+async function readSampleEvidenceHash(args) {
+  const filePath = path.resolve(root, requireArg(args, "sample-evidence"));
+  const parsed = JSON.parse(await readFile(filePath, "utf8"));
+  return assertSha256(parsed.evidenceHash, "sample-evidence.evidenceHash");
+}
+
+async function readQuotaEvidence(args) {
+  const filePath = path.resolve(root, requireArg(args, "quota-evidence"));
+  const parsed = JSON.parse(await readFile(filePath, "utf8"));
+  validateQuotaEvidence(parsed, "quota-evidence");
+  return parsed;
+}
+
+async function readProductionSource(args, sourceId, quotaEvidence, sampleEvidenceHash) {
+  const filePath = path.resolve(root, requireArg(args, "production-source"));
+  const productionSource = JSON.parse(await readFile(filePath, "utf8"));
+  if (!productionSource || typeof productionSource !== "object" || Array.isArray(productionSource)) {
+    throw new Error("production-source must be an object");
+  }
+  if (productionSource.id !== sourceId) {
+    throw new Error("production-source.id must match --source-id");
+  }
+  // admissionEvidence.quotaEvidence가 있으면 admin review quotaEvidence와 일치해야 한다
+  // (pipeline validateAdminReview 계약). 미리 검증해 실행 전에 실패시킨다.
+  const admissionEvidence = productionSource.admissionEvidence;
+  if (admissionEvidence != null) {
+    if (typeof admissionEvidence !== "object" || Array.isArray(admissionEvidence)) {
+      throw new Error("production-source.admissionEvidence must be an object");
+    }
+    validateQuotaEvidence(admissionEvidence.quotaEvidence, "production-source.admissionEvidence.quotaEvidence");
+    if (JSON.stringify(sortJson(admissionEvidence.quotaEvidence)) !== JSON.stringify(sortJson(quotaEvidence))) {
+      throw new Error("production-source.admissionEvidence.quotaEvidence must match --quota-evidence");
+    }
+  }
+  return productionSource;
+}
+
+function validateQuotaEvidence(quotaEvidence, label) {
+  if (!quotaEvidence || typeof quotaEvidence !== "object" || Array.isArray(quotaEvidence)) {
+    throw new Error(`${label} must be an object`);
+  }
+  const keys = Object.keys(quotaEvidence).sort((left, right) => (left < right ? -1 : left > right ? 1 : 0));
+  if (JSON.stringify(keys) !== JSON.stringify(quotaEvidenceKeys)) {
+    throw new Error(`${label} must only include ${quotaEvidenceKeys.join(", ")}`);
+  }
+  requiredString(quotaEvidence.portal, `${label}.portal`);
+  if (
+    quotaEvidence.defaultDailyLimit !== "unlimited" &&
+    (!Number.isInteger(quotaEvidence.defaultDailyLimit) || quotaEvidence.defaultDailyLimit < 0)
+  ) {
+    throw new Error(`${label}.defaultDailyLimit must be a non-negative integer or unlimited`);
+  }
+  requiredString(quotaEvidence.unlockStatus, `${label}.unlockStatus`);
+  if (typeof quotaEvidence.productionUseAllowed !== "boolean") {
+    throw new Error(`${label}.productionUseAllowed must be a boolean`);
+  }
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (!flag?.startsWith("--")) throw new Error(`unexpected argument: ${flag}`);
+    if (value == null || value.startsWith("--")) throw new Error(`${flag} requires a value`);
+    args[flag.slice(2)] = value;
+    index += 1;
+  }
+  return args;
+}
+
+function requireArg(args, name) {
+  return requiredString(args[name], `--${name}`);
+}
+
+function requiredString(value, label) {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`${label} is required`);
+  }
+  return value;
+}
+
+function assertSha256(value, label) {
+  if (typeof value !== "string" || !/^[0-9a-f]{64}$/.test(value)) {
+    throw new Error(`${label} must be a sha256 hex string`);
+  }
+  return value;
+}
+
+function sortJson(value) {
+  if (Array.isArray(value)) return value.map(sortJson);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.entries(value)
+      .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+      .map(([key, entry]) => [key, sortJson(entry)]),
+  );
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    await main();
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}
+
+export { buildAdminReviewRecord };

--- a/tools/datapack/build-admin-review-record.mjs
+++ b/tools/datapack/build-admin-review-record.mjs
@@ -10,9 +10,16 @@
 //     인자로 직접 hex를 받지 않는다 → 손으로 hash를 끼워넣을 수 없다.
 //   - sampleEvidenceHash는 sample evidence 파일의 evidenceHash에서 읽는다.
 //   - approvedBy·approvedAt·decision은 입력 인자(승인 결정 기록).
-import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import {
+  compareStrings,
+  parseArgs,
+  readJsonFile,
+  requireArg,
+  requiredString,
+  sortJson,
+} from "./lib/ledger-admission-cli.mjs";
 
 const root = path.resolve(import.meta.dirname, "../..");
 const quotaEvidenceKeys = ["defaultDailyLimit", "portal", "productionUseAllowed", "unlockStatus"];
@@ -68,7 +75,7 @@ async function buildAdminReviewRecord(args) {
 // exporter JSON 산출물 파일에서 ledgerHash만 읽는다. kind가 일치하지 않으면 거부.
 async function readLedgerHash(args, argName, expectedKind) {
   const filePath = path.resolve(root, requireArg(args, argName));
-  const parsed = JSON.parse(await readFile(filePath, "utf8"));
+  const parsed = await readJsonFile(filePath);
   if (parsed.kind !== expectedKind) {
     throw new Error(`--${argName} kind must be ${expectedKind}, got ${parsed.kind}`);
   }
@@ -77,22 +84,22 @@ async function readLedgerHash(args, argName, expectedKind) {
 
 async function readSampleEvidenceHash(args) {
   const filePath = path.resolve(root, requireArg(args, "sample-evidence"));
-  const parsed = JSON.parse(await readFile(filePath, "utf8"));
+  const parsed = await readJsonFile(filePath);
   return assertSha256(parsed.evidenceHash, "sample-evidence.evidenceHash");
 }
 
 async function readQuotaEvidence(args) {
   const filePath = path.resolve(root, requireArg(args, "quota-evidence"));
-  const parsed = JSON.parse(await readFile(filePath, "utf8"));
+  const parsed = await readJsonFile(filePath);
   validateQuotaEvidence(parsed, "quota-evidence");
   return parsed;
 }
 
 async function readProductionSource(args, sourceId, quotaEvidence, sampleEvidenceHash) {
   const filePath = path.resolve(root, requireArg(args, "production-source"));
-  const productionSource = JSON.parse(await readFile(filePath, "utf8"));
+  const productionSource = await readJsonFile(filePath);
   if (!productionSource || typeof productionSource !== "object" || Array.isArray(productionSource)) {
-    throw new Error("production-source must be an object");
+    throw new TypeError("production-source must be an object");
   }
   if (productionSource.id !== sourceId) {
     throw new Error("production-source.id must match --source-id");
@@ -102,7 +109,7 @@ async function readProductionSource(args, sourceId, quotaEvidence, sampleEvidenc
   const admissionEvidence = productionSource.admissionEvidence;
   if (admissionEvidence != null) {
     if (typeof admissionEvidence !== "object" || Array.isArray(admissionEvidence)) {
-      throw new Error("production-source.admissionEvidence must be an object");
+      throw new TypeError("production-source.admissionEvidence must be an object");
     }
     validateQuotaEvidence(admissionEvidence.quotaEvidence, "production-source.admissionEvidence.quotaEvidence");
     if (JSON.stringify(sortJson(admissionEvidence.quotaEvidence)) !== JSON.stringify(sortJson(quotaEvidence))) {
@@ -114,9 +121,9 @@ async function readProductionSource(args, sourceId, quotaEvidence, sampleEvidenc
 
 function validateQuotaEvidence(quotaEvidence, label) {
   if (!quotaEvidence || typeof quotaEvidence !== "object" || Array.isArray(quotaEvidence)) {
-    throw new Error(`${label} must be an object`);
+    throw new TypeError(`${label} must be an object`);
   }
-  const keys = Object.keys(quotaEvidence).sort((left, right) => (left < right ? -1 : left > right ? 1 : 0));
+  const keys = Object.keys(quotaEvidence).sort(compareStrings);
   if (JSON.stringify(keys) !== JSON.stringify(quotaEvidenceKeys)) {
     throw new Error(`${label} must only include ${quotaEvidenceKeys.join(", ")}`);
   }
@@ -129,49 +136,15 @@ function validateQuotaEvidence(quotaEvidence, label) {
   }
   requiredString(quotaEvidence.unlockStatus, `${label}.unlockStatus`);
   if (typeof quotaEvidence.productionUseAllowed !== "boolean") {
-    throw new Error(`${label}.productionUseAllowed must be a boolean`);
+    throw new TypeError(`${label}.productionUseAllowed must be a boolean`);
   }
-}
-
-function parseArgs(argv) {
-  const args = {};
-  for (let index = 0; index < argv.length; index += 1) {
-    const flag = argv[index];
-    const value = argv[index + 1];
-    if (!flag?.startsWith("--")) throw new Error(`unexpected argument: ${flag}`);
-    if (value == null || value.startsWith("--")) throw new Error(`${flag} requires a value`);
-    args[flag.slice(2)] = value;
-    index += 1;
-  }
-  return args;
-}
-
-function requireArg(args, name) {
-  return requiredString(args[name], `--${name}`);
-}
-
-function requiredString(value, label) {
-  if (typeof value !== "string" || value.trim() === "") {
-    throw new Error(`${label} is required`);
-  }
-  return value;
 }
 
 function assertSha256(value, label) {
   if (typeof value !== "string" || !/^[0-9a-f]{64}$/.test(value)) {
-    throw new Error(`${label} must be a sha256 hex string`);
+    throw new TypeError(`${label} must be a sha256 hex string`);
   }
   return value;
-}
-
-function sortJson(value) {
-  if (Array.isArray(value)) return value.map(sortJson);
-  if (!value || typeof value !== "object") return value;
-  return Object.fromEntries(
-    Object.entries(value)
-      .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
-      .map(([key, entry]) => [key, sortJson(entry)]),
-  );
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -13562,6 +13562,113 @@ test("원장 해시 exporter는 license source-id가 inventory에 없으면 거�
   await assert.rejects(runLedgerExporter(["--kind", "license", "--source-id", "does-not-exist"]));
 });
 
+test("원장 해시 exporter는 stationFacilityEvidence primary 분기를 쓰고 evidenceSource를 표기한다", async () => {
+  const fixture = JSON.parse(await readFile(path.join(root, catalogFixtureArg), "utf8"));
+  const evidenceRows = [
+    {
+      stationId: "station-b",
+      lineId: "line-2",
+      facilityType: "ELEVATOR",
+      evidenceHash: "b".repeat(64),
+      providerRecordHash: "2".repeat(64),
+    },
+    {
+      stationId: "station-a",
+      lineId: "line-1",
+      facilityType: "ESCALATOR",
+      evidenceHash: "a".repeat(64),
+      providerRecordHash: "1".repeat(64),
+    },
+  ];
+
+  const workspace = await mkdtemp(path.join(tmpdir(), "ledger-evidence-"));
+  try {
+    const primary = structuredClone(fixture);
+    primary.packs[0].stationFacilityEvidence = structuredClone(evidenceRows);
+    const primaryPath = path.join(workspace, "primary-fixture.json");
+    await writeFile(primaryPath, JSON.stringify(primary));
+
+    const primaryArgs = ["--kind", "facility-evidence", "--fixture", path.relative(root, primaryPath)];
+    const primaryOut = JSON.parse((await runLedgerExporter(primaryArgs)).stdout);
+    assert.equal(primaryOut.evidenceSource, "stationFacilityEvidence");
+    assert.match(primaryOut.ledgerHash, /^[0-9a-f]{64}$/);
+    assert.equal(primaryOut.rowCount, evidenceRows.length);
+
+    const primaryRepeat = JSON.parse((await runLedgerExporter(primaryArgs)).stdout);
+    assert.equal(primaryRepeat.ledgerHash, primaryOut.ledgerHash);
+
+    const fallback = structuredClone(primary);
+    delete fallback.packs[0].stationFacilityEvidence;
+    const fallbackPath = path.join(workspace, "fallback-fixture.json");
+    await writeFile(fallbackPath, JSON.stringify(fallback));
+    const fallbackOut = JSON.parse(
+      (await runLedgerExporter(["--kind", "facility-evidence", "--fixture", path.relative(root, fallbackPath)])).stdout,
+    );
+    assert.equal(fallbackOut.evidenceSource, "facilities");
+    assert.notEqual(fallbackOut.ledgerHash, primaryOut.ledgerHash);
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test("원장 해시 exporter는 facility-evidence source 혼합을 거부한다", async () => {
+  const fixture = JSON.parse(await readFile(path.join(root, catalogFixtureArg), "utf8"));
+  const workspace = await mkdtemp(path.join(tmpdir(), "ledger-mixed-"));
+  try {
+    const mixed = structuredClone(fixture);
+    mixed.packs[0].stationFacilityEvidence = [
+      {
+        stationId: "station-a",
+        lineId: "line-1",
+        facilityType: "ELEVATOR",
+        evidenceHash: "a".repeat(64),
+        providerRecordHash: "1".repeat(64),
+      },
+    ];
+    // 두 번째 pack은 stationFacilityEvidence 없이 facilities만 → facilities 폴백 source.
+    mixed.packs.push(structuredClone(fixture.packs[0]));
+    const mixedPath = path.join(workspace, "mixed-fixture.json");
+    await writeFile(mixedPath, JSON.stringify(mixed));
+    await assert.rejects(
+      runLedgerExporter(["--kind", "facility-evidence", "--fixture", path.relative(root, mixedPath)]),
+    );
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test("override 해시는 facilityStatusUpdates 배열 순서에 민감하다", async () => {
+  const overrides = JSON.parse(await readFile(path.join(root, overrideLedgerArg), "utf8"));
+  const base = structuredClone(overrides);
+  if (!Array.isArray(base.facilityStatusUpdates)) {
+    base.facilityStatusUpdates = [];
+  }
+  while (base.facilityStatusUpdates.length < 2) {
+    base.facilityStatusUpdates.push({ facilityId: `facility-${base.facilityStatusUpdates.length}` });
+  }
+
+  const workspace = await mkdtemp(path.join(tmpdir(), "ledger-override-order-"));
+  try {
+    const baselinePath = path.join(workspace, "baseline-overrides.json");
+    await writeFile(baselinePath, JSON.stringify(base));
+    const hash1 = JSON.parse(
+      (await runLedgerExporter(["--kind", "override", "--overrides", path.relative(root, baselinePath)])).stdout,
+    ).ledgerHash;
+
+    const reversed = structuredClone(base);
+    reversed.facilityStatusUpdates.reverse();
+    const reversedPath = path.join(workspace, "reversed-overrides.json");
+    await writeFile(reversedPath, JSON.stringify(reversed));
+    const hash2 = JSON.parse(
+      (await runLedgerExporter(["--kind", "override", "--overrides", path.relative(root, reversedPath)])).stdout,
+    ).ledgerHash;
+
+    assert.notEqual(hash1, hash2);
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
 test("admin review record 생성기는 runbook 필수 필드를 exporter 해시로 채운다", async () => {
   const workspace = await mkdtemp(path.join(tmpdir(), "admin-review-"));
   try {

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -13494,3 +13494,334 @@ test("publish-rollout (③): --dry-run → current.json 수정 없이 exit 0 + �
     storage.server.close();
   }
 });
+
+// --- #1397 원장 해시 exporter + admin review record 생성기 ---
+
+async function runLedgerExporter(args) {
+  return execFileAsync(process.execPath, ["tools/datapack/export-ledger-hashes.mjs", ...args], { cwd: root });
+}
+
+async function runAdminReviewBuilder(args) {
+  return execFileAsync(process.execPath, ["tools/datapack/build-admin-review-record.mjs", ...args], { cwd: root });
+}
+
+const catalogFixtureArg = "tools/datapack/fixtures/catalog-fixture.json";
+const overrideLedgerArg = "tools/datapack/fixtures/admin-review-overrides.json";
+
+test("원장 해시 exporter는 fixture 원장 5종 + license를 sha256으로 산출한다", async () => {
+  const kinds = [
+    ["alias", ["--fixture", catalogFixtureArg]],
+    ["operator-mapping", ["--fixture", catalogFixtureArg]],
+    ["facility-evidence", ["--fixture", catalogFixtureArg]],
+    ["route-evidence", ["--fixture", catalogFixtureArg]],
+    ["override", ["--overrides", overrideLedgerArg]],
+    ["license", ["--source-id", "seoulmetro-station-line-info"]],
+  ];
+  for (const [kind, extra] of kinds) {
+    const { stdout } = await runLedgerExporter(["--kind", kind, ...extra]);
+    const parsed = JSON.parse(stdout);
+    assert.equal(parsed.kind, kind, `${kind} kind`);
+    assert.match(parsed.ledgerHash, /^[0-9a-f]{64}$/, `${kind} ledgerHash`);
+    assert.equal(parsed.schemaVersion, 1);
+  }
+});
+
+test("원장 해시 exporter는 결정적이다 (같은 입력 = 같은 해시)", async () => {
+  const first = JSON.parse((await runLedgerExporter(["--kind", "alias", "--fixture", catalogFixtureArg])).stdout);
+  const second = JSON.parse((await runLedgerExporter(["--kind", "alias", "--fixture", catalogFixtureArg])).stdout);
+  assert.equal(first.ledgerHash, second.ledgerHash);
+});
+
+test("원장 해시 exporter는 레코드 순서가 바뀌어도 같은 해시를 낸다", async () => {
+  const fixture = JSON.parse(await readFile(path.join(root, catalogFixtureArg), "utf8"));
+  const baseline = JSON.parse((await runLedgerExporter(["--kind", "alias", "--fixture", catalogFixtureArg])).stdout);
+
+  const workspace = await mkdtemp(path.join(tmpdir(), "ledger-order-"));
+  try {
+    const reordered = structuredClone(fixture);
+    reordered.packs[0].stationAliases.reverse();
+    const reorderedPath = path.join(workspace, "reordered-fixture.json");
+    await writeFile(reorderedPath, JSON.stringify(reordered));
+    const { stdout } = await runLedgerExporter([
+      "--kind",
+      "alias",
+      "--fixture",
+      path.relative(root, reorderedPath),
+    ]);
+    assert.equal(JSON.parse(stdout).ledgerHash, baseline.ledgerHash);
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test("원장 해시 exporter는 알 수 없는 kind를 거부한다", async () => {
+  await assert.rejects(runLedgerExporter(["--kind", "unknown", "--fixture", catalogFixtureArg]));
+});
+
+test("원장 해시 exporter는 license source-id가 inventory에 없으면 거부한다", async () => {
+  await assert.rejects(runLedgerExporter(["--kind", "license", "--source-id", "does-not-exist"]));
+});
+
+test("admin review record 생성기는 runbook 필수 필드를 exporter 해시로 채운다", async () => {
+  const workspace = await mkdtemp(path.join(tmpdir(), "admin-review-"));
+  try {
+    const files = {};
+    for (const [name, kind, extra] of [
+      ["license", "license", ["--source-id", "seoulmetro-station-line-info"]],
+      ["alias", "alias", ["--fixture", catalogFixtureArg]],
+      ["operator", "operator-mapping", ["--fixture", catalogFixtureArg]],
+      ["facility", "facility-evidence", ["--fixture", catalogFixtureArg]],
+      ["route", "route-evidence", ["--fixture", catalogFixtureArg]],
+      ["override", "override", ["--overrides", overrideLedgerArg]],
+    ]) {
+      const { stdout } = await runLedgerExporter(["--kind", kind, ...extra]);
+      files[name] = path.join(workspace, `${name}.json`);
+      await writeFile(files[name], stdout);
+    }
+    const sampleEvidenceHash = "a".repeat(64);
+    const samplePath = path.join(workspace, "sample.json");
+    await writeFile(samplePath, JSON.stringify({ evidenceHash: sampleEvidenceHash }));
+    const quotaPath = path.join(workspace, "quota.json");
+    const quota = {
+      defaultDailyLimit: 1000,
+      portal: "data.seoul.go.kr",
+      productionUseAllowed: true,
+      unlockStatus: "granted",
+    };
+    await writeFile(quotaPath, JSON.stringify(quota));
+    const prodPath = path.join(workspace, "prod.json");
+    await writeFile(prodPath, JSON.stringify({ id: "seoulmetro-station-line-info", displayName: "테스트" }));
+
+    const { stdout } = await runAdminReviewBuilder([
+      "--candidate", "seoulmetro-station-line-info",
+      "--source-id", "seoulmetro-station-line-info",
+      "--snapshot-id", "snap-1",
+      "--decision", "APPROVED",
+      "--approved-by", "owner",
+      "--approved-at", "2026-07-12T00:00:00Z",
+      "--sample-evidence", path.relative(root, samplePath),
+      "--license-hash", path.relative(root, files.license),
+      "--alias-hash", path.relative(root, files.alias),
+      "--operator-mapping-hash", path.relative(root, files.operator),
+      "--facility-evidence-hash", path.relative(root, files.facility),
+      "--route-evidence-hash", path.relative(root, files.route),
+      "--override-hash", path.relative(root, files.override),
+      "--quota-evidence", path.relative(root, quotaPath),
+      "--production-source", path.relative(root, prodPath),
+    ]);
+    const record = JSON.parse(stdout);
+    assert.equal(record.artifactKind, "source-admission-admin-review");
+    assert.equal(record.decision, "APPROVED");
+    assert.equal(record.sampleEvidenceHash, sampleEvidenceHash);
+    for (const field of [
+      "licenseEvidenceHash",
+      "aliasLedgerHash",
+      "operatorMappingLedgerHash",
+      "facilityEvidenceLedgerHash",
+      "routeEvidenceLedgerHash",
+      "overrideHash",
+    ]) {
+      assert.match(record[field], /^[0-9a-f]{64}$/, field);
+    }
+    // exporter 산출 해시와 record 값이 일치 (위조 불가 경로 확인)
+    assert.equal(record.aliasLedgerHash, JSON.parse(await readFile(files.alias, "utf8")).ledgerHash);
+    assert.equal(record.overrideHash, JSON.parse(await readFile(files.override, "utf8")).ledgerHash);
+    // runbook requiredAdminReviewFields 전수 존재
+    const runbook = JSON.parse(
+      await readFile(path.join(root, "tools/datapack/source-admission-runbook.json"), "utf8"),
+    );
+    for (const field of runbook.requiredAdminReviewFields) {
+      assert.ok(field in record, `record missing runbook field: ${field}`);
+    }
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test("admin review record 생성기는 kind가 틀린 해시 파일을 거부한다 (위조 방지)", async () => {
+  const workspace = await mkdtemp(path.join(tmpdir(), "admin-review-forge-"));
+  try {
+    // alias 자리에 override 산출물을 넣어 손으로 갈아끼우려는 시도 → kind mismatch 거부
+    const { stdout: overrideOut } = await runLedgerExporter(["--kind", "override", "--overrides", overrideLedgerArg]);
+    const forgedAlias = path.join(workspace, "forged-alias.json");
+    await writeFile(forgedAlias, overrideOut);
+
+    const files = {};
+    for (const [name, kind, extra] of [
+      ["license", "license", ["--source-id", "seoulmetro-station-line-info"]],
+      ["operator", "operator-mapping", ["--fixture", catalogFixtureArg]],
+      ["facility", "facility-evidence", ["--fixture", catalogFixtureArg]],
+      ["route", "route-evidence", ["--fixture", catalogFixtureArg]],
+      ["override", "override", ["--overrides", overrideLedgerArg]],
+    ]) {
+      const { stdout } = await runLedgerExporter(["--kind", kind, ...extra]);
+      files[name] = path.join(workspace, `${name}.json`);
+      await writeFile(files[name], stdout);
+    }
+    const samplePath = path.join(workspace, "sample.json");
+    await writeFile(samplePath, JSON.stringify({ evidenceHash: "a".repeat(64) }));
+    const quotaPath = path.join(workspace, "quota.json");
+    await writeFile(
+      quotaPath,
+      JSON.stringify({ defaultDailyLimit: 1000, portal: "p", productionUseAllowed: true, unlockStatus: "granted" }),
+    );
+    const prodPath = path.join(workspace, "prod.json");
+    await writeFile(prodPath, JSON.stringify({ id: "seoulmetro-station-line-info" }));
+
+    await assert.rejects(
+      runAdminReviewBuilder([
+        "--candidate", "seoulmetro-station-line-info",
+        "--source-id", "seoulmetro-station-line-info",
+        "--snapshot-id", "snap-1",
+        "--decision", "APPROVED",
+        "--approved-by", "owner",
+        "--approved-at", "2026-07-12T00:00:00Z",
+        "--sample-evidence", path.relative(root, samplePath),
+        "--license-hash", path.relative(root, files.license),
+        "--alias-hash", path.relative(root, forgedAlias),
+        "--operator-mapping-hash", path.relative(root, files.operator),
+        "--facility-evidence-hash", path.relative(root, files.facility),
+        "--route-evidence-hash", path.relative(root, files.route),
+        "--override-hash", path.relative(root, files.override),
+        "--quota-evidence", path.relative(root, quotaPath),
+        "--production-source", path.relative(root, prodPath),
+      ]),
+    );
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test("admin review record 생성기는 APPROVED가 아닌 decision을 거부한다", async () => {
+  await assert.rejects(
+    runAdminReviewBuilder([
+      "--candidate", "x", "--source-id", "x", "--snapshot-id", "s",
+      "--decision", "REJECTED", "--approved-by", "o", "--approved-at", "t",
+      "--sample-evidence", "x", "--license-hash", "x", "--alias-hash", "x",
+      "--operator-mapping-hash", "x", "--facility-evidence-hash", "x",
+      "--route-evidence-hash", "x", "--override-hash", "x",
+      "--quota-evidence", "x", "--production-source", "x",
+    ]),
+  );
+});
+
+test("build-admin-review-record 산출물은 run-source-admission-pipeline을 그대로 통과한다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-ledger-e2e-${Date.now()}`);
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+  const rawPath = path.join(outputDir, "kric-train-operation-organ.raw.json");
+  await writeFile(rawPath, `${JSON.stringify([{ railOprIsttCd: "S1", railOprIsttNm: "서울교통공사" }])}\n`);
+
+  // sample evidence는 pipeline이 소비하는 것과 동일하게 실 도구로 생성
+  const { stdout: sampleStdout } = await execFileAsync(
+    process.execPath,
+    ["tools/datapack/build-source-candidate-sample-evidence.mjs", "--candidate", "kric-train-operation-organ", "--response", rawPath],
+    { cwd: root },
+  );
+  const samplePath = path.join(outputDir, "sample.json");
+  await writeFile(samplePath, sampleStdout);
+
+  // 6종 원장 해시를 exporter로 산출
+  const ledgerFiles = {};
+  for (const [name, kind, extra] of [
+    ["license", "license", ["--source-id", "seoulmetro-station-line-info"]],
+    ["alias", "alias", ["--fixture", catalogFixtureArg]],
+    ["operator", "operator-mapping", ["--fixture", catalogFixtureArg]],
+    ["facility", "facility-evidence", ["--fixture", catalogFixtureArg]],
+    ["route", "route-evidence", ["--fixture", catalogFixtureArg]],
+    ["override", "override", ["--overrides", overrideLedgerArg]],
+  ]) {
+    const { stdout } = await runLedgerExporter(["--kind", kind, ...extra]);
+    ledgerFiles[name] = path.join(outputDir, `${name}.json`);
+    await writeFile(ledgerFiles[name], stdout);
+  }
+
+  const quotaPath = path.join(outputDir, "quota.json");
+  await writeFile(
+    quotaPath,
+    JSON.stringify({ defaultDailyLimit: "unlimited", portal: "KRIC 레일포털", productionUseAllowed: true, unlockStatus: "not_required" }),
+  );
+  const prodPath = path.join(outputDir, "prod.json");
+  await writeFile(
+    prodPath,
+    JSON.stringify({
+      id: "kric-train-operation-organ",
+      displayName: "열차운영기관정보",
+      owner: "국가철도공단",
+      provider: "국가철도공단",
+      sourceSystem: "KRIC OpenAPI",
+      datasetUrl: "https://data.kric.go.kr/rips/M_01_02/detail.do?id=266",
+      requiredForProductionPack: false,
+      updateFrequency: "provider-documented",
+      observedDataUpdatedAt: "2026-07-02",
+      retrievedAt: "2026-07-02",
+      license: {
+        type: "KOGL-1",
+        name: "공공누리 1유형",
+        attribution: "공공누리 제1유형: 출처표시",
+        commercialUseAllowed: true,
+        derivativeWorkAllowed: true,
+        redistributionAllowed: true,
+        evidenceUrl: "https://data.kric.go.kr/rips/M_01_02/detail.do?id=266",
+      },
+      coverageScope: { regionIds: ["capital"], operatorIds: ["seoul-metro"], sourceDomains: ["station_line_membership"] },
+      fieldsProvided: ["railOprIsttCd", "railOprIsttNm"],
+      capabilities: {
+        schedule: { status: "UNSUPPORTED", productionUseAllowed: false, coverageStatus: "NOT_PROVIDED_BY_SOURCE", updateFrequency: "provider-documented", unsupportedNotes: "x" },
+        realtime: { status: "UNSUPPORTED", productionUseAllowed: false, liveEtaEligible: false, rateLimitStatus: "NOT_APPLICABLE", coverageStatus: "NOT_PROVIDED_BY_SOURCE", updateFrequency: "provider-documented", unsupportedNotes: "x" },
+        facility: { status: "UNSUPPORTED", productionUseAllowed: false, coverageStatus: "NOT_PROVIDED_BY_SOURCE", updateFrequency: "provider-documented", unsupportedNotes: "x" },
+      },
+    }),
+  );
+
+  // 생성기로 admin review record 작성
+  const { stdout: recordStdout } = await runAdminReviewBuilder([
+    "--candidate", "kric-train-operation-organ",
+    "--source-id", "kric-train-operation-organ",
+    "--snapshot-id", "kric-train-operation-organ-snapshot-20260702",
+    "--decision", "APPROVED",
+    "--approved-by", "owner",
+    "--approved-at", "2026-07-12T00:00:00Z",
+    "--sample-evidence", path.relative(root, samplePath),
+    "--license-hash", path.relative(root, ledgerFiles.license),
+    "--alias-hash", path.relative(root, ledgerFiles.alias),
+    "--operator-mapping-hash", path.relative(root, ledgerFiles.operator),
+    "--facility-evidence-hash", path.relative(root, ledgerFiles.facility),
+    "--route-evidence-hash", path.relative(root, ledgerFiles.route),
+    "--override-hash", path.relative(root, ledgerFiles.override),
+    "--quota-evidence", path.relative(root, quotaPath),
+    "--production-source", path.relative(root, prodPath),
+  ]);
+  const adminReviewPath = path.join(outputDir, "admin-review.json");
+  await writeFile(adminReviewPath, recordStdout);
+
+  const summaryPath = path.join(outputDir, "admission-summary.json");
+  const outputInventoryPath = path.join(outputDir, "source-inventory.admitted.json");
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    [
+      "tools/datapack/run-source-admission-pipeline.mjs",
+      "--candidate", "kric-train-operation-organ",
+      "--raw-input", rawPath,
+      "--evidence-dir", outputDir,
+      "--snapshot-id", "kric-train-operation-organ-snapshot-20260702",
+      "--source-id", "kric-train-operation-organ",
+      "--provider", "국가철도공단",
+      "--retrieved-at", "2026-07-02T00:00:00Z",
+      "--source-updated-at", "2026-07-02T00:00:00Z",
+      "--raw-object-uri", "s3://easysubway-datapack-sources/kric-train-operation-organ/20260702.json",
+      "--freshness-expires-at", "2099-08-01T00:00:00Z",
+      "--raw-retention-expires-at", "2099-10-01T00:00:00Z",
+      "--admin-review", adminReviewPath,
+      "--output-inventory", outputInventoryPath,
+      "--output", summaryPath,
+    ],
+    { cwd: root },
+  );
+  assert.match(stdout, /source admission pipeline evidence written/);
+  const summary = JSON.parse(await readFile(summaryPath, "utf8"));
+  // pipeline summary가 exporter 산출 원장 해시를 그대로 옮겨야 한다
+  assert.equal(summary.aliasLedgerHash, JSON.parse(await readFile(ledgerFiles.alias, "utf8")).ledgerHash);
+  assert.equal(summary.overrideHash, JSON.parse(await readFile(ledgerFiles.override, "utf8")).ledgerHash);
+  assert.equal(summary.licenseEvidenceHash, JSON.parse(await readFile(ledgerFiles.license, "utf8")).ledgerHash);
+});

--- a/tools/datapack/export-ledger-hashes.mjs
+++ b/tools/datapack/export-ledger-hashes.mjs
@@ -19,6 +19,7 @@
 //   - facilityEvidenceLedger: fixture pack.stationFacilityEvidence(있으면) → 없으면 pack.facilities
 //   - routeEvidenceLedger:   fixture pack.networkEdges
 //   - override:              manual override ledger 파일(apply-admin-review-overrides.mjs 계약)
+//                            — fixture 원장과 달리 배열(facilityStatusUpdates) 순서를 보존한다(순서가 의미를 갖는 데이터).
 //   - licenseEvidence:       source-inventory.json 해당 source.license 블록
 import { createHash } from "node:crypto";
 import path from "node:path";
@@ -64,6 +65,10 @@ async function exportFixtureLedgerHash(kind, args) {
   const fixture = await readJsonFile(fixturePath);
   const packs = requiredArray(fixture.packs, "fixture.packs");
 
+  if (kind === "facility-evidence") {
+    return exportFacilityEvidenceLedgerHash({ packs, fixturePath });
+  }
+
   const rows = [];
   for (const pack of packs) {
     rows.push(...ledgerRowsForPack(kind, pack));
@@ -73,6 +78,34 @@ async function exportFixtureLedgerHash(kind, args) {
     schemaVersion: 1,
     artifactKind: `datapack-${kind}-ledger-hash`,
     kind,
+    fixturePath: path.relative(root, fixturePath),
+    rowCount: canonicalRows.length,
+    ledgerHash: sha256(JSON.stringify(canonicalRows)),
+  };
+}
+
+// facility-evidence 전용 exporter — pack별 source(stationFacilityEvidence/facilities)를 수집하고
+// pack 간 source 혼합을 거부한다. 단일 source면 그 값을 evidenceSource로 표기한다.
+function exportFacilityEvidenceLedgerHash({ packs, fixturePath }) {
+  const rows = [];
+  const sources = new Set();
+  for (const pack of packs) {
+    const { source, rows: packRows } = facilityEvidenceRowsForPack(pack);
+    sources.add(source);
+    rows.push(...packRows);
+  }
+  if (sources.size > 1) {
+    throw new Error(
+      `facility-evidence source mixing is not allowed across packs: ${[...sources].join(" vs ")}`,
+    );
+  }
+  const [evidenceSource] = sources.size > 0 ? [...sources] : ["facilities"];
+  const canonicalRows = canonicalizeRows(rows);
+  return {
+    schemaVersion: 1,
+    artifactKind: "datapack-facility-evidence-ledger-hash",
+    kind: "facility-evidence",
+    evidenceSource,
     fixturePath: path.relative(root, fixturePath),
     rowCount: canonicalRows.length,
     ledgerHash: sha256(JSON.stringify(canonicalRows)),
@@ -93,24 +126,8 @@ function ledgerRowsForPack(kind, pack) {
         nameKo: requiredString(row.nameKo, "operators.nameKo"),
         nameEn: requiredString(row.nameEn, "operators.nameEn"),
       }));
-    case "facility-evidence": {
-      const evidence = pack.stationFacilityEvidence;
-      if (Array.isArray(evidence) && evidence.length > 0) {
-        return evidence.map((row) => ({
-          stationId: requiredString(row.stationId, "stationFacilityEvidence.stationId"),
-          lineId: requiredString(row.lineId, "stationFacilityEvidence.lineId"),
-          facilityType: requiredString(row.facilityType, "stationFacilityEvidence.facilityType"),
-          evidenceHash: requiredString(row.evidenceHash, "stationFacilityEvidence.evidenceHash"),
-          providerRecordHash: requiredString(row.providerRecordHash, "stationFacilityEvidence.providerRecordHash"),
-        }));
-      }
-      return requiredArray(pack.facilities ?? [], "pack.facilities").map((row) => ({
-        id: requiredString(row.id, "facilities.id"),
-        stationId: requiredString(row.stationId, "facilities.stationId"),
-        type: requiredString(row.type, "facilities.type"),
-        status: requiredString(row.status, "facilities.status"),
-      }));
-    }
+    case "facility-evidence":
+      return facilityEvidenceRowsForPack(pack).rows;
     case "route-evidence":
       return requiredArray(pack.networkEdges ?? [], "pack.networkEdges").map((row) => ({
         id: requiredString(row.id, "networkEdges.id"),
@@ -121,6 +138,33 @@ function ledgerRowsForPack(kind, pack) {
     default:
       throw new Error(`unsupported fixture ledger kind: ${kind}`);
   }
+}
+
+// facility-evidence 전용 매핑 — source(stationFacilityEvidence primary → facilities fallback) 판정을
+// 이 한 곳에만 둔다(매핑 중복 금지). { source, rows }를 반환한다.
+function facilityEvidenceRowsForPack(pack) {
+  const evidence = pack.stationFacilityEvidence;
+  if (Array.isArray(evidence) && evidence.length > 0) {
+    return {
+      source: "stationFacilityEvidence",
+      rows: evidence.map((row) => ({
+        stationId: requiredString(row.stationId, "stationFacilityEvidence.stationId"),
+        lineId: requiredString(row.lineId, "stationFacilityEvidence.lineId"),
+        facilityType: requiredString(row.facilityType, "stationFacilityEvidence.facilityType"),
+        evidenceHash: requiredString(row.evidenceHash, "stationFacilityEvidence.evidenceHash"),
+        providerRecordHash: requiredString(row.providerRecordHash, "stationFacilityEvidence.providerRecordHash"),
+      })),
+    };
+  }
+  return {
+    source: "facilities",
+    rows: requiredArray(pack.facilities ?? [], "pack.facilities").map((row) => ({
+      id: requiredString(row.id, "facilities.id"),
+      stationId: requiredString(row.stationId, "facilities.stationId"),
+      type: requiredString(row.type, "facilities.type"),
+      status: requiredString(row.status, "facilities.status"),
+    })),
+  };
 }
 
 // license evidence hash — source-inventory.json 해당 source의 license 블록.
@@ -147,6 +191,13 @@ async function exportLicenseEvidenceHash(args) {
 }
 
 // override hash — manual override ledger(apply-admin-review-overrides.mjs 계약과 동일 파일).
+//
+// fixture 원장(canonical row 정렬)과 달리, override 원장은 facilityStatusUpdates 배열의
+// "순서가 의미를 갖는" 데이터다: apply-admin-review-overrides.mjs가 latestFacilityUpdates를
+// 계산할 때 reviewedAt 동률(tie)이면 배열 인덱스를 tiebreaker(sequence)로 사용한다.
+// 따라서 override 해시는 sortJson으로 객체 key만 사전순 정렬하고 배열 순서는 파일 원본
+// 그대로 보존하며, fixture 원장처럼 canonical row 재정렬을 적용하지 않는 것이 계약이다.
+// (배열을 canonical 정렬하면 override의 tiebreaker 의미가 깨지므로 정렬하지 않는다.)
 async function exportOverrideHash(args) {
   const overridesPath = path.resolve(root, requireArg(args, "overrides"));
   const overrides = await readJsonFile(overridesPath);

--- a/tools/datapack/export-ledger-hashes.mjs
+++ b/tools/datapack/export-ledger-hashes.mjs
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+// 원장 해시 exporter — admission admin review 필수 필드 6종 hash의 producer.
+//
+// source-admission-runbook.json의 requiredAdminReviewFields 중 hash 6종
+// (licenseEvidenceHash, aliasLedgerHash, operatorMappingLedgerHash,
+//  facilityEvidenceLedgerHash, routeEvidenceLedgerHash, overrideHash)을
+// 리포에 실존하는 canonical 원장 데이터에서 결정적으로 산출한다.
+//
+// 결정성 규칙:
+//   - 모든 객체 key를 재귀적으로 사전순 정렬(sortJson)한 뒤 JSON.stringify.
+//   - 배열(레코드 집합)은 canonical row 문자열로 직렬화한 뒤 사전순 정렬하여
+//     입력 순서와 무관하게 동일 해시를 낸다.
+//   - 공백 없는 JSON.stringify(기본) 사용 — 구분자·들여쓰기 없음.
+//   - sha256 hex(소문자 64자).
+//
+// canonical 원장 소스(실측):
+//   - aliasLedger:           fixture pack.stationAliases
+//   - operatorMappingLedger: fixture pack.operators
+//   - facilityEvidenceLedger: fixture pack.stationFacilityEvidence(있으면) → 없으면 pack.facilities
+//   - routeEvidenceLedger:   fixture pack.networkEdges
+//   - override:              manual override ledger 파일(apply-admin-review-overrides.mjs 계약)
+//   - licenseEvidence:       source-inventory.json 해당 source.license 블록
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const root = path.resolve(import.meta.dirname, "../..");
+
+const ledgerKinds = new Set(["alias", "operator-mapping", "facility-evidence", "route-evidence", "override", "license"]);
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const kind = requireArg(args, "kind");
+  if (!ledgerKinds.has(kind)) {
+    throw new Error(`--kind must be one of ${[...ledgerKinds].join(", ")}`);
+  }
+
+  const result = await exportLedgerHash(kind, args);
+  console.log(JSON.stringify(result, null, 2));
+}
+
+async function exportLedgerHash(kind, args) {
+  if (kind === "license") {
+    return exportLicenseEvidenceHash(args);
+  }
+  if (kind === "override") {
+    return exportOverrideHash(args);
+  }
+  return exportFixtureLedgerHash(kind, args);
+}
+
+// fixture pack에서 원장 레코드 집합을 뽑아 canonical 해시를 낸다.
+async function exportFixtureLedgerHash(kind, args) {
+  const fixturePath = path.resolve(root, requireArg(args, "fixture"));
+  const fixture = JSON.parse(await readFile(fixturePath, "utf8"));
+  const packs = requiredArray(fixture.packs, "fixture.packs");
+
+  const rows = [];
+  for (const pack of packs) {
+    rows.push(...ledgerRowsForPack(kind, pack));
+  }
+  const canonicalRows = canonicalizeRows(rows);
+  return {
+    schemaVersion: 1,
+    artifactKind: `datapack-${kind}-ledger-hash`,
+    kind,
+    fixturePath: path.relative(root, fixturePath),
+    rowCount: canonicalRows.length,
+    ledgerHash: sha256(JSON.stringify(canonicalRows)),
+  };
+}
+
+function ledgerRowsForPack(kind, pack) {
+  switch (kind) {
+    case "alias":
+      return requiredArray(pack.stationAliases ?? [], "pack.stationAliases").map((row) => ({
+        stationId: requiredString(row.stationId, "stationAliases.stationId"),
+        alias: requiredString(row.alias, "stationAliases.alias"),
+        normalizedAlias: requiredString(row.normalizedAlias, "stationAliases.normalizedAlias"),
+      }));
+    case "operator-mapping":
+      return requiredArray(pack.operators ?? [], "pack.operators").map((row) => ({
+        id: requiredString(row.id, "operators.id"),
+        nameKo: requiredString(row.nameKo, "operators.nameKo"),
+        nameEn: requiredString(row.nameEn, "operators.nameEn"),
+      }));
+    case "facility-evidence": {
+      const evidence = pack.stationFacilityEvidence;
+      if (Array.isArray(evidence) && evidence.length > 0) {
+        return evidence.map((row) => ({
+          stationId: requiredString(row.stationId, "stationFacilityEvidence.stationId"),
+          lineId: requiredString(row.lineId, "stationFacilityEvidence.lineId"),
+          facilityType: requiredString(row.facilityType, "stationFacilityEvidence.facilityType"),
+          evidenceHash: requiredString(row.evidenceHash, "stationFacilityEvidence.evidenceHash"),
+          providerRecordHash: requiredString(row.providerRecordHash, "stationFacilityEvidence.providerRecordHash"),
+        }));
+      }
+      return requiredArray(pack.facilities ?? [], "pack.facilities").map((row) => ({
+        id: requiredString(row.id, "facilities.id"),
+        stationId: requiredString(row.stationId, "facilities.stationId"),
+        type: requiredString(row.type, "facilities.type"),
+        status: requiredString(row.status, "facilities.status"),
+      }));
+    }
+    case "route-evidence":
+      return requiredArray(pack.networkEdges ?? [], "pack.networkEdges").map((row) => ({
+        id: requiredString(row.id, "networkEdges.id"),
+        fromNodeId: requiredString(row.fromNodeId, "networkEdges.fromNodeId"),
+        toNodeId: requiredString(row.toNodeId, "networkEdges.toNodeId"),
+        edgeType: requiredString(row.edgeType, "networkEdges.edgeType"),
+      }));
+    default:
+      throw new Error(`unsupported fixture ledger kind: ${kind}`);
+  }
+}
+
+// license evidence hash — source-inventory.json 해당 source의 license 블록.
+async function exportLicenseEvidenceHash(args) {
+  const inventoryPath = path.resolve(root, args.inventory ?? "tools/datapack/source-inventory.json");
+  const sourceId = requireArg(args, "source-id");
+  const inventory = JSON.parse(await readFile(inventoryPath, "utf8"));
+  const source = requiredArray(inventory.sources, "inventory.sources").find((entry) => entry.id === sourceId);
+  if (!source) {
+    throw new Error(`source-id not found in inventory: ${sourceId}`);
+  }
+  const license = source.license;
+  if (!license || typeof license !== "object" || Array.isArray(license)) {
+    throw new Error(`inventory source ${sourceId} has no license block`);
+  }
+  return {
+    schemaVersion: 1,
+    artifactKind: "datapack-license-evidence-hash",
+    kind: "license",
+    inventoryPath: path.relative(root, inventoryPath),
+    sourceId,
+    ledgerHash: sha256(JSON.stringify(sortJson(license))),
+  };
+}
+
+// override hash — manual override ledger(apply-admin-review-overrides.mjs 계약과 동일 파일).
+async function exportOverrideHash(args) {
+  const overridesPath = path.resolve(root, requireArg(args, "overrides"));
+  const overrides = JSON.parse(await readFile(overridesPath, "utf8"));
+  if (overrides.artifactKind !== "datapack-manual-override-ledger") {
+    throw new Error("override ledger artifactKind must be datapack-manual-override-ledger");
+  }
+  if (overrides.ledgerSource !== "manual_overrides") {
+    throw new Error("override ledger ledgerSource must be manual_overrides");
+  }
+  return {
+    schemaVersion: 1,
+    artifactKind: "datapack-override-ledger-hash",
+    kind: "override",
+    overridesPath: path.relative(root, overridesPath),
+    rowCount: Array.isArray(overrides.facilityStatusUpdates) ? overrides.facilityStatusUpdates.length : 0,
+    ledgerHash: sha256(JSON.stringify(sortJson(overrides))),
+  };
+}
+
+// row 집합을 canonical 문자열로 직렬화한 뒤 사전순 정렬 — 입력 순서 불변.
+function canonicalizeRows(rows) {
+  return rows
+    .map((row) => JSON.stringify(sortJson(row)))
+    .sort((left, right) => (left < right ? -1 : left > right ? 1 : 0));
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (!flag?.startsWith("--")) throw new Error(`unexpected argument: ${flag}`);
+    if (value == null || value.startsWith("--")) throw new Error(`${flag} requires a value`);
+    args[flag.slice(2)] = value;
+    index += 1;
+  }
+  return args;
+}
+
+function requireArg(args, name) {
+  return requiredString(args[name], `--${name}`);
+}
+
+function requiredString(value, label) {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`${label} is required`);
+  }
+  return value;
+}
+
+function requiredArray(value, label) {
+  if (!Array.isArray(value)) {
+    throw new Error(`${label} must be an array`);
+  }
+  return value;
+}
+
+function sortJson(value) {
+  if (Array.isArray(value)) return value.map(sortJson);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.entries(value)
+      .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+      .map(([key, entry]) => [key, sortJson(entry)]),
+  );
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    await main();
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}
+
+export { exportLedgerHash, canonicalizeRows, sortJson, sha256 };

--- a/tools/datapack/export-ledger-hashes.mjs
+++ b/tools/datapack/export-ledger-hashes.mjs
@@ -21,9 +21,17 @@
 //   - override:              manual override ledger 파일(apply-admin-review-overrides.mjs 계약)
 //   - licenseEvidence:       source-inventory.json 해당 source.license 블록
 import { createHash } from "node:crypto";
-import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import {
+  compareStrings,
+  parseArgs,
+  readJsonFile,
+  requireArg,
+  requiredArray,
+  requiredString,
+  sortJson,
+} from "./lib/ledger-admission-cli.mjs";
 
 const root = path.resolve(import.meta.dirname, "../..");
 
@@ -53,7 +61,7 @@ async function exportLedgerHash(kind, args) {
 // fixture pack에서 원장 레코드 집합을 뽑아 canonical 해시를 낸다.
 async function exportFixtureLedgerHash(kind, args) {
   const fixturePath = path.resolve(root, requireArg(args, "fixture"));
-  const fixture = JSON.parse(await readFile(fixturePath, "utf8"));
+  const fixture = await readJsonFile(fixturePath);
   const packs = requiredArray(fixture.packs, "fixture.packs");
 
   const rows = [];
@@ -119,7 +127,7 @@ function ledgerRowsForPack(kind, pack) {
 async function exportLicenseEvidenceHash(args) {
   const inventoryPath = path.resolve(root, args.inventory ?? "tools/datapack/source-inventory.json");
   const sourceId = requireArg(args, "source-id");
-  const inventory = JSON.parse(await readFile(inventoryPath, "utf8"));
+  const inventory = await readJsonFile(inventoryPath);
   const source = requiredArray(inventory.sources, "inventory.sources").find((entry) => entry.id === sourceId);
   if (!source) {
     throw new Error(`source-id not found in inventory: ${sourceId}`);
@@ -141,7 +149,7 @@ async function exportLicenseEvidenceHash(args) {
 // override hash — manual override ledger(apply-admin-review-overrides.mjs 계약과 동일 파일).
 async function exportOverrideHash(args) {
   const overridesPath = path.resolve(root, requireArg(args, "overrides"));
-  const overrides = JSON.parse(await readFile(overridesPath, "utf8"));
+  const overrides = await readJsonFile(overridesPath);
   if (overrides.artifactKind !== "datapack-manual-override-ledger") {
     throw new Error("override ledger artifactKind must be datapack-manual-override-ledger");
   }
@@ -160,50 +168,7 @@ async function exportOverrideHash(args) {
 
 // row 집합을 canonical 문자열로 직렬화한 뒤 사전순 정렬 — 입력 순서 불변.
 function canonicalizeRows(rows) {
-  return rows
-    .map((row) => JSON.stringify(sortJson(row)))
-    .sort((left, right) => (left < right ? -1 : left > right ? 1 : 0));
-}
-
-function parseArgs(argv) {
-  const args = {};
-  for (let index = 0; index < argv.length; index += 1) {
-    const flag = argv[index];
-    const value = argv[index + 1];
-    if (!flag?.startsWith("--")) throw new Error(`unexpected argument: ${flag}`);
-    if (value == null || value.startsWith("--")) throw new Error(`${flag} requires a value`);
-    args[flag.slice(2)] = value;
-    index += 1;
-  }
-  return args;
-}
-
-function requireArg(args, name) {
-  return requiredString(args[name], `--${name}`);
-}
-
-function requiredString(value, label) {
-  if (typeof value !== "string" || value.trim() === "") {
-    throw new Error(`${label} is required`);
-  }
-  return value;
-}
-
-function requiredArray(value, label) {
-  if (!Array.isArray(value)) {
-    throw new Error(`${label} must be an array`);
-  }
-  return value;
-}
-
-function sortJson(value) {
-  if (Array.isArray(value)) return value.map(sortJson);
-  if (!value || typeof value !== "object") return value;
-  return Object.fromEntries(
-    Object.entries(value)
-      .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
-      .map(([key, entry]) => [key, sortJson(entry)]),
-  );
+  return rows.map((row) => JSON.stringify(sortJson(row))).sort(compareStrings);
 }
 
 function sha256(value) {

--- a/tools/datapack/lib/ledger-admission-cli.mjs
+++ b/tools/datapack/lib/ledger-admission-cli.mjs
@@ -1,0 +1,63 @@
+// #1397 원장 해시 exporter / admin review record 생성기 공유 헬퍼.
+//
+// export-ledger-hashes.mjs와 build-admin-review-record.mjs가 공유하는
+// CLI 인자 파싱·타입 검증·canonical 직렬화·JSON 파일 읽기 헬퍼를 한곳에 모은다.
+// 두 도구의 CLI 인터페이스·출력 계약·위조 방지 로직은 불변이다.
+import { readFile } from "node:fs/promises";
+
+// `--flag value` 반복 형식만 허용하는 엄격한 인자 파서.
+// 값 없는 플래그, `--`로 시작하지 않는 토큰은 거부한다.
+export function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (!flag?.startsWith("--")) throw new TypeError(`unexpected argument: ${flag}`);
+    if (value == null || value.startsWith("--")) throw new Error(`${flag} requires a value`);
+    args[flag.slice(2)] = value;
+    index += 1;
+  }
+  return args;
+}
+
+// 필수 인자를 non-empty 문자열로 강제한다.
+export function requireArg(args, name) {
+  return requiredString(args[name], `--${name}`);
+}
+
+export function requiredString(value, label) {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new TypeError(`${label} is required`);
+  }
+  return value;
+}
+
+export function requiredArray(value, label) {
+  if (!Array.isArray(value)) {
+    throw new TypeError(`${label} must be an array`);
+  }
+  return value;
+}
+
+// 사전순 비교자 — 문자열 key/값 정렬에 재사용.
+export function compareStrings(left, right) {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+// 객체 key를 재귀적으로 사전순 정렬 — 결정적 canonical 직렬화의 기반.
+export function sortJson(value) {
+  if (Array.isArray(value)) return value.map(sortJson);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.entries(value)
+      .sort(([left], [right]) => compareStrings(left, right))
+      .map(([key, entry]) => [key, sortJson(entry)]),
+  );
+}
+
+// root 기준 상대 경로 JSON 파일을 읽어 파싱한다.
+export async function readJsonFile(filePath) {
+  return JSON.parse(await readFile(filePath, "utf8"));
+}

--- a/tools/datapack/run-source-admission-pipeline.mjs
+++ b/tools/datapack/run-source-admission-pipeline.mjs
@@ -5,6 +5,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { promisify } from "node:util";
+import { sortJson, compareStrings } from "./lib/ledger-admission-cli.mjs";
 
 const execFileAsync = promisify(execFile);
 const root = path.resolve(import.meta.dirname, "../..");
@@ -222,7 +223,7 @@ function validateQuotaEvidence(quotaEvidence, label) {
   if (!quotaEvidence || typeof quotaEvidence !== "object" || Array.isArray(quotaEvidence)) {
     throw new Error(`${label} must be an object`);
   }
-  const keys = Object.keys(quotaEvidence).sort((left, right) => left.localeCompare(right));
+  const keys = Object.keys(quotaEvidence).sort(compareStrings);
   if (JSON.stringify(keys) !== JSON.stringify(quotaEvidenceKeys)) {
     throw new Error(`${label} must only include ${quotaEvidenceKeys.join(", ")}`);
   }
@@ -242,7 +243,7 @@ function validateQuotaEvidence(quotaEvidence, label) {
 function admitSource({ inventory, productionSource }) {
   const sources = inventory.sources.filter((source) => source.id !== productionSource.id);
   sources.push(productionSource);
-  sources.sort((left, right) => left.id.localeCompare(right.id));
+  sources.sort((left, right) => compareStrings(left.id, right.id));
   return { ...inventory, sources };
 }
 
@@ -279,15 +280,6 @@ function requiredText(value, label) {
 
 function requireArg(args, name) {
   return requiredText(args[name], `--${name}`);
-}
-
-function sortJson(value) {
-  if (Array.isArray(value)) return value.map(sortJson);
-  if (!value || typeof value !== "object") return value;
-  return Object.fromEntries(Object.entries(value).sort(([left], [right]) => left.localeCompare(right)).map(([key, entry]) => [
-    key,
-    sortJson(entry),
-  ]));
 }
 
 function sha256(value) {


### PR DESCRIPTION
## 관련 이슈

Refs #1397

이 PR은 #1397 DoD 중 "build-spec에 sourceSnapshotSetHash, alias ledger hash, facility/route evidence ledger hash, override hash가 연결된다"와 "admin review 승인 record 생성"의 선행 도구를 채운다. #1397은 1차 승격 실행(live sample 수집·inventory 승격)이 남아 있어 닫지 않는다.

## 작업 배경

- 수도권 신 도식 데이터팩의 첫 production 게시(#1950 작업 8)가 admission summary의 해시 6종에 걸려 있다.
- 정본 계약 `tools/datapack/source-admission-runbook.json`의 `requiredAdminReviewFields`는 licenseEvidenceHash·aliasLedgerHash·operatorMappingLedgerHash·facilityEvidenceLedgerHash·routeEvidenceLedgerHash·overrideHash를 요구하지만, 지금까지 이 해시들의 **consumer만 존재**했다(`run-source-admission-pipeline.mjs`의 형식 검증). producer가 없어 admin review record의 원장 해시를 손으로 채워야 했고, 이는 위조 가능한 경로였다.

## 작업 내용

- **`tools/datapack/export-ledger-hashes.mjs`** — 원장 해시 exporter. 6종(alias·operator-mapping·facility-evidence·route-evidence·override·license)의 canonical 직렬화 + sha256을 산출한다.
  - 결정성 규칙: 객체 key 재귀 사전순 정렬 → 공백 없는 `JSON.stringify` → sha256 hex. 레코드 집합은 canonical row 문자열로 직렬화 후 사전순 정렬 → 입력 순서와 무관하게 동일 해시.
  - canonical 소스(실측): fixture pack의 `stationAliases`(alias)/`operators`(operator-mapping)/`stationFacilityEvidence`(있으면) 또는 `facilities`(facility-evidence)/`networkEdges`(route-evidence), manual override ledger 파일(override), `source-inventory.json`의 source `license` 블록(license).
- **`tools/datapack/build-admin-review-record.mjs`** — admin review record 생성기. runbook `requiredAdminReviewFields`를 채운다.
  - 위조 방지: hash 6종은 exporter의 JSON 산출물 파일에서만 읽고 `kind`를 검증한다(손으로 hex를 인자로 끼워넣을 수 없다). `sampleEvidenceHash`는 sample evidence의 `evidenceHash`에서, 승인자·결정은 입력 인자.
  - `run-source-admission-pipeline.mjs`의 `validateAdminReview` 계약(필드 집합·quotaEvidence 키·productionSource 규칙)과 일치.
- 신규 도구는 기존 consumer(`run-source-admission-pipeline.mjs`)를 변경하지 않고 그 입력을 생성만 한다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/datapack/datapack-tools.test.mjs` → 226 pass, 0 fail (신규 9 테스트 포함)
  - `node --test tools/ci/repository-contract.test.mjs` → 179 pass, 0 fail
  - `git diff --cached --check` → clean
  - end-to-end: exporter → 생성기 → 실 `run-source-admission-pipeline.mjs` 통과, summary가 exporter 원장 해시를 그대로 옮기는 것을 확인

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| exporter 6종 산출·결정성·순서 불변 | tools/datapack | `node --test --test-name-pattern "원장 해시"` | datapack-tools.test.mjs 신규 테스트 | PASS |
| 생성기 필수 필드·위조 방지·decision | tools/datapack | `node --test --test-name-pattern "admin review record"` | datapack-tools.test.mjs 신규 테스트 | PASS |
| exporter→생성기→실 pipeline e2e | tools/datapack | `node --test --test-name-pattern "그대로 통과"` | datapack-tools.test.mjs 신규 테스트 | PASS |
| 미승인 admission negative gate 유지 | tools/datapack | `node --test --test-name-pattern "admin 승인 없는"` | 기존 테스트 green | PASS |
| 기존 계약 회귀 없음 | tools/ci | `node --test tools/ci/repository-contract.test.mjs` | 179 pass | PASS |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [x] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

datapack admission 도구만 추가하며 데이터팩 아티팩트나 버전 자체는 이 PR에서 변경하지 않는다. 실제 datapack version bump는 후속 1차 승격·게시(#1950 작업 8)에서 발생한다.

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [ ] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [ ] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음 (도구 추가만, 아티팩트 미생성)
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `export-ledger-hashes.mjs`의 canonical 직렬화·정렬 규칙(`canonicalizeRows`, `sortJson`)이 결정적이고 순서 불변인지.
  - `build-admin-review-record.mjs`의 위조 방지 경로: hash가 exporter 산출물 파일에서만 읽히고 `kind`가 검증되는지(`readLedgerHash`).
  - 생성기 출력이 `run-source-admission-pipeline.mjs`의 `validateAdminReview` 계약과 필드·quotaEvidence 키까지 일치하는지 — e2e 테스트로 고정했다.

## 리스크

- facility-evidence 원장은 fixture에 `stationFacilityEvidence`가 없으면 `facilities`로 폴백한다. capital 팩이 evidence row를 실제로 갖게 되면 exporter가 자동으로 evidence row 기준으로 전환되므로 해시가 바뀐다(의도된 provenance 반영). 후속 게시에서 실 데이터로 재산출 필요.
- 승인자·결정은 인자로 받으므로 운영자가 실제 승인 결정을 정확히 입력할 책임이 남는다(도구는 형식·위조만 막는다).

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
