### PR TITLE
[Fix] 노선도 오버레이·캔버스 좌표계 origin 불일치 수정 — 임의 카메라에서 히트 rect·팝오버·핀 정합 (#1970)

### DIFF
--- a/apps/mobile/lib/features/network_map/presentation/structured_route_map_painter.dart
+++ b/apps/mobile/lib/features/network_map/presentation/structured_route_map_painter.dart
@@ -285,6 +285,7 @@ class StructuredRouteMapPainter extends CustomPainter {
     required this.picture,
     required this.designScale,
     required this.camera,
+    this.sourceOrigin = Offset.zero,
     this.attributionText,
     this.attributionPainter,
   });
@@ -292,18 +293,36 @@ class StructuredRouteMapPainter extends CustomPainter {
   final ui.Picture picture;
   final double designScale;
   final MapCameraState camera;
+
+  /// Picture는 raw source 좌표(`station.position·k*`)로 녹화되지만, 카메라와
+  /// 오버레이(히트 rect·팝오버·핀)는 origin을 뺀 geometry 공간에서 동작한다(#1970).
+  /// 이 origin을 재생 변환에 반영해 두 좌표계를 하나로 맞춘다. 기본 (0,0)은
+  /// origin이 없는 맵(테스트 등)과의 하위호환을 유지한다.
+  final Offset sourceOrigin;
+
   final String? attributionText;
   final TextPainter? attributionPainter;
+
+  /// design space point(`source·k*`)를 카메라 재생 후 화면(viewport) 좌표로
+  /// 변환한다. paint()의 재생 변환과 동일한 단일 수식이며(#1970 회귀 방지),
+  /// `camera.sourceToViewportPoint(source − sourceOrigin)`와 항등이다.
+  @visibleForTesting
+  Offset designToViewport(Offset designPoint) {
+    final vc = camera.viewportSize.center(Offset.zero);
+    final source = designPoint / designScale;
+    return vc + (source - sourceOrigin - camera.center) * camera.scale;
+  }
 
   @override
   void paint(Canvas canvas, Size size) {
     canvas.save();
     final vc = camera.viewportSize.center(Offset.zero);
-    // viewport = vc + (source − camera.center)·scale, design = source·k*
-    //  → translate 후 scale/k* 배율로 Picture 재생.
+    // viewport = vc + (source − sourceOrigin − camera.center)·scale,
+    // design = source·k* → translate 후 scale/k* 배율로 Picture 재생.
+    // sourceOrigin은 오버레이·카메라의 origin-뺀 공간과 raw picture 공간을 잇는다.
     canvas.translate(
-      vc.dx - camera.center.dx * camera.scale,
-      vc.dy - camera.center.dy * camera.scale,
+      vc.dx - (camera.center.dx + sourceOrigin.dx) * camera.scale,
+      vc.dy - (camera.center.dy + sourceOrigin.dy) * camera.scale,
     );
     canvas.scale(camera.scale / designScale);
     canvas.drawPicture(picture);
@@ -341,6 +360,7 @@ class StructuredRouteMapPainter extends CustomPainter {
     return oldDelegate.camera.revision != camera.revision ||
         !identical(oldDelegate.picture, picture) ||
         oldDelegate.designScale != designScale ||
+        oldDelegate.sourceOrigin != sourceOrigin ||
         oldDelegate.attributionText != attributionText ||
         !identical(oldDelegate.attributionPainter, attributionPainter);
   }
@@ -355,6 +375,7 @@ class StructuredRouteMapView extends StatefulWidget {
     required this.lineColors,
     this.labelTextByStationId = const {},
     this.lineBadgeLabelByLineId = const {},
+    this.sourceOrigin = Offset.zero,
     this.attributionText,
     super.key,
   });
@@ -364,6 +385,11 @@ class StructuredRouteMapView extends StatefulWidget {
   final Map<String, Color> lineColors;
   final Map<String, String> labelTextByStationId;
   final Map<String, String> lineBadgeLabelByLineId;
+
+  /// 오버레이·카메라의 geometry origin. Picture 재생을 origin-뺀 공간으로 맞춰
+  /// 캔버스와 오버레이 좌표계를 일치시킨다(#1970).
+  final Offset sourceOrigin;
+
   final String? attributionText;
 
   @override
@@ -473,6 +499,7 @@ class _StructuredRouteMapViewState extends State<StructuredRouteMapView> {
           picture: _picture!,
           designScale: _design!.designScale,
           camera: widget.camera,
+          sourceOrigin: widget.sourceOrigin,
           attributionText: widget.attributionText,
           attributionPainter: _attributionPainter,
         ),

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -3479,7 +3479,7 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
               Positioned.fill(
                 child: !_routeMapRendererActive
                     ? const _OriginalRouteMapUnavailable()
-                    : _buildStructuredRouteMapCanvas(camera),
+                    : _buildStructuredRouteMapCanvas(camera, geometry.origin),
               ),
               Positioned.fill(
                 child: Semantics(
@@ -3801,7 +3801,10 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
 
   // 구조화 canvas 렌더러(#1641)를 visual camera로 마운트한다. WebView와 달리
   // 명령형 controller 없이 camera prop 변경(setState)으로 갱신된다.
-  Widget _buildStructuredRouteMapCanvas(MapCameraState camera) {
+  Widget _buildStructuredRouteMapCanvas(
+    MapCameraState camera,
+    Offset sourceOrigin,
+  ) {
     _ensureStructuredRouteMap();
     return StructuredRouteMapView(
       map: _structuredRouteMapCache!,
@@ -3809,6 +3812,7 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
       lineColors: _structuredLineColorsCache!,
       labelTextByStationId: _structuredLabelTextCache!,
       lineBadgeLabelByLineId: _structuredLineBadgeLabelCache!,
+      sourceOrigin: sourceOrigin,
       attributionText: _attributionTextByRegion?[widget.data.selectedRegion],
     );
   }

--- a/apps/mobile/test/features/network_map/presentation/route_map_overlay_camera_sync_test.dart
+++ b/apps/mobile/test/features/network_map/presentation/route_map_overlay_camera_sync_test.dart
@@ -1,0 +1,152 @@
+import 'dart:ui' as ui;
+
+import 'package:easysubway_mobile/features/network_map/domain/map_camera.dart';
+import 'package:easysubway_mobile/features/network_map/domain/route_map_design_space.dart';
+import 'package:easysubway_mobile/features/network_map/domain/structured_route_map.dart';
+import 'package:easysubway_mobile/features/network_map/presentation/route_map_label_layout.dart';
+import 'package:easysubway_mobile/features/network_map/presentation/structured_route_map_painter.dart';
+import 'package:flutter/painting.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// #1970 회귀 방지: 캔버스(picture 재생)와 오버레이(히트 rect·팝오버·draft 핀)가
+// 모든 카메라 상태에서 동일한 화면 좌표를 쓰는지 검증한다.
+//
+// - 캔버스 기준 좌표: painter의 실제 재생 변환(`designToViewport`)으로 얻는다.
+//   즉 "캔버스가 실제로 그 픽셀에 노드를 그린다"를 painter 단일 수식으로 표현.
+// - 오버레이 기준 좌표: 히트 rect 중심/팝오버 앵커/핀 앵커가 실제로 쓰는 값인
+//   `camera.sourceToViewportPoint(station.position - origin)`.
+//   (network_map.dart의 `geometry.x/y` = `station.position - origin`을
+//    `camera.sourceToViewportPoint`에 넣는 것과 동일 수식)
+//
+// origin이 (0,0)이 아니어야 버그가 재현된다.
+
+/// 모든 역을 [base] 부근에 두어 비영점 origin이 되도록 구성한 맵.
+StructuredRouteMap _mapAround(Offset base) {
+  final positions = [base, base + const Offset(24, 0), base + const Offset(48, 0)];
+  return StructuredRouteMap(
+    lines: [
+      RouteMapLineGeometry(lineId: 'L1', polylines: [positions]),
+    ],
+    stations: [
+      for (var i = 0; i < 3; i += 1)
+        RouteMapStructuredStation(
+          stationId: 's$i',
+          lineId: 'L1',
+          sequence: i,
+          position: positions[i],
+          labelPolygon: const [],
+          labelClass: RouteMapLabelClass.regular,
+        ),
+    ],
+    transferGroups: const [],
+  );
+}
+
+ui.Picture _picture(StructuredRouteMap map, RouteMapDesignSpace design) {
+  final layout = solveRouteMapLabelLayout(
+    map: map,
+    design: design,
+    labelTextByStationId: const {},
+    badgeLabelByLineId: const {},
+    measureLabel: (text, {required bool bold}) => const Size(10, 13),
+    measureBadge: (text) => const Size(10, 18),
+  );
+  return recordRouteMapPicture(
+    map: map,
+    design: design,
+    layout: layout,
+    lineColors: const {},
+    lineOffsets: const {},
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // 비영점 origin: 모든 역이 (1000,700) 부근 → origin≈(946,646) 유형.
+  final base = const Offset(1000, 700);
+  // 콘텐츠 bounds 기반 origin(network_map.dart _MapGeometry: minXY - 54)을 모사.
+  // 이 값은 오버레이의 geometry.x/y = position - origin과 동일 벡터다.
+  final origin = base - const Offset(54, 54);
+
+  final cameras = <String, MapCameraState>{
+    '기본(초기)': MapCameraState(
+      sourceBounds: const Rect.fromLTWH(0, 0, 200, 200),
+      viewportSize: const Size(400, 800),
+      center: const Offset(100, 100),
+      scale: 3,
+      minScale: 1,
+      maxScale: 20,
+      revision: 0,
+      initialScale: 3,
+    ),
+    '팬 후 center 이동': MapCameraState(
+      sourceBounds: const Rect.fromLTWH(0, 0, 200, 200),
+      viewportSize: const Size(400, 800),
+      center: const Offset(137, 62),
+      scale: 3,
+      minScale: 1,
+      maxScale: 20,
+      revision: 1,
+      initialScale: 3,
+    ),
+    '줌 후 scale 변경': MapCameraState(
+      sourceBounds: const Rect.fromLTWH(0, 0, 200, 200),
+      viewportSize: const Size(400, 800),
+      center: const Offset(100, 100),
+      scale: 7.5,
+      minScale: 1,
+      maxScale: 20,
+      revision: 2,
+      initialScale: 3,
+    ),
+    'initialViewport 복원(비영점 origin center)': MapCameraState(
+      sourceBounds: const Rect.fromLTWH(0, 0, 200, 200),
+      viewportSize: const Size(400, 800),
+      center: const Offset(54, 54),
+      scale: 4.25,
+      minScale: 1,
+      maxScale: 20,
+      revision: 3,
+      initialScale: 4.25,
+    ),
+  };
+
+  final map = _mapAround(base);
+  final design = routeMapDesignSpaceFor(map);
+  final picture = _picture(map, design);
+
+  tearDownAll(picture.dispose);
+
+  for (final entry in cameras.entries) {
+    test('캔버스 노드 == 오버레이 앵커: ${entry.key}', () {
+      final camera = entry.value;
+      // sourceOrigin을 geometry origin으로 넘긴 painter가 실제 렌더 상태.
+      final painter = StructuredRouteMapPainter(
+        picture: picture,
+        designScale: design.designScale,
+        camera: camera,
+        sourceOrigin: origin,
+      );
+
+      for (final station in map.stations) {
+        // 캔버스: painter 재생 변환으로 얻은 노드 화면 좌표.
+        final canvasPoint = painter.designToViewport(
+          design.toDesign(station.position),
+        );
+        // 오버레이: 히트 rect 중심/팝오버/핀이 실제로 쓰는 값.
+        final overlayPoint = camera.sourceToViewportPoint(
+          station.position - origin,
+        );
+        expect(
+          (canvasPoint - overlayPoint).distance,
+          lessThan(1e-6),
+          reason:
+              '${entry.key} / ${station.stationId}: '
+              'canvas=$canvasPoint overlay=$overlayPoint '
+              'delta=${canvasPoint - overlayPoint}',
+        );
+      }
+    });
+  }
+}


### PR DESCRIPTION
## 관련 이슈

close #1970

Refs #1925

## 작업 배경

- 노선도에서 역을 탭해도 팝오버가 열리지 않는 사용자 노출 correctness 버그(#1970). 실기기 배타 접근 재검증에서 히트 rect·팝오버 앵커·draft 핀(오버레이 전체)이 캔버스에 렌더된 역 노드와 카메라 상태에 따라 변동하는 양만큼 어긋남이 재확증됐다(카메라별 약 −125~−280px, 팬 시 rect 불변).
- 노선도 탭은 출발·경유·도착 지정의 핵심 진입 흐름이고 TalkBack 시맨틱 위치도 함께 어긋나므로 A등급 절차로 진행한다.

## 작업 내용

- **근본 원인**: 두 좌표계의 불일치. 캔버스가 재생하는 picture는 raw source 좌표(`station.position·k*`)로 녹화되고 재생 변환도 origin을 빼지 않는 반면, 카메라·히트 rect(`_stationHitRect`)·팝오버·draft 핀은 전부 origin을 뺀 geometry 공간(`position − origin`)에서 동작한다. 즉 **picture만 화면상 `−origin·scale`만큼 어긋나는 outlier**였고, origin은 고정 source 벡터라 어긋남이 scale에 비례해 카메라별로 변동한다. 팬은 scale 불변이라 어긋남 벡터가 고정 → "팬해도 rect 불변" 관측과 정합. 위젯 테스트가 green이었던 이유는 테스트 픽스처의 origin이 0에 수렴해 어긋남이 발생하지 않았기 때문.
- **수정**(`structured_route_map_painter.dart`): `StructuredRouteMapPainter`/`StructuredRouteMapView`에 `sourceOrigin`(기본 `Offset.zero`, 하위호환) 추가 — picture 재생 translate에 origin을 반영해 캔버스를 카메라·오버레이와 동일한 origin-뺀 공간으로 정합. `paint()`와 동일 수식의 순수 변환 `designToViewport`를 `@visibleForTesting`으로 노출해 회귀 검증의 단일 소스로 삼고, `shouldRepaint`에 `sourceOrigin` 비교를 추가.
- `network_map.dart`: `geometry.origin`을 canvas 빌드에 전달 (2곳, 최소 변경).
- 오버레이·히트 rect·팝오버·핀 코드는 무수정 — 이미 `camera.sourceToViewportPoint` 단일 경로를 공유하며 올바랐다.
- **회귀 테스트 신규**(`route_map_overlay_camera_sync_test.dart`): 비영점 origin 맵에서 기본·팬·줌·initialViewport 복원 4개 카메라 상태 각각에 대해 캔버스 노드 화면좌표(`designToViewport`) == `camera.sourceToViewportPoint(position − origin)` 항등을 검증. 수정 전 RED 확인(팬 케이스 scale 3에서 delta (2838, 1938) 등 scale 비례 어긋남 — 진단과 일치), 수정 후 GREEN.
- 시각 스타일 변경 없음(무채색·radius·그림자 원칙 무관 영역).

## 검증

- 실행한 명령과 결과:
  - TDD: 신규 회귀 테스트 4개 카메라 케이스 수정 전 RED(scale 비례 delta 실측) → 수정 후 GREEN
  - `flutter analyze`: No issues found
  - `flutter test`: 1120/1120 All tests passed (design_guard·golden 포함, 시각 회귀 없음)
  - `node --test tools/ci/repository-contract.test.mjs`: fail 0
  - `git merge-tree origin/main HEAD`: 충돌 없음

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 기기 배타 접근 확보 | Android SM-A175N / debug | `am_kill` 이벤트 stale(6시간+ 경과) 확인 · 0.3s×20회 ps 샘플링 외부 adb 0건 · 설치 후 `pm path`→md5 일치(`ac97a6ec…`) | 로컬 evidence(`docs/1970-qa/`) — 공개 저장소 정책상 미커밋 | 확인 |
| 복원 카메라: 히트 rect == 시각 노드 | Android SM-A175N | 스크린샷+uiautomator dump 원자 채증, rect 오버레이 크롭 확대 판독(신도림·수원) | 로컬 캡처 `02/03_*` | 일치 |
| 시각 노드 탭 → 팝오버 열림·앵커 정합 | Android SM-A175N | 시각 노드 좌표 motionevent 탭 → 팝오버 열림, 팝오버 위치가 코드 수식·DPR 2.8125 기준 정확 일치(수원: left 클램프 483.75→관측 484, top 1231.4→관측 1231) | 로컬 캡처 `04/05_*` | 확인 |
| 팬: rect가 캔버스와 동행 이동 | Android SM-A175N | 팬 전후 dump 대조 — 3개 역 rect 균일 (−281,−220) 이동(수정 전 버그: 불변) + 크롭 판독 노드 일치 | 로컬 캡처 `08/09_*` | 확인 |
| 재시작 persisted 카메라 복원 | Android SM-A175N | force-stop→재실행 후 원자 채증, 크롭 판독 rect==노드 | 로컬 캡처 `10/11_*` | 일치 |
| 줌 상태 정합 | Flutter | 기기 핀치는 scale 제스처 선점으로 주입 불가 → 위젯 회귀 테스트 줌 케이스로 검증 | `route_map_overlay_camera_sync_test.dart` | green |
| 접근성(시맨틱 히트 rect 위치) | Android SM-A175N | uiautomator 시맨틱 bounds가 시각 노드와 일치(위 rect 검증과 동일 채증) | 로컬 캡처 | 확인 |
| 시각 원칙(무채색·radius≤8·그림자0) | Flutter | design_guard 가드 | `flutter test` | green |

## Version impact

- [ ] no version change
- [x] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음 (다음 mobile patch release에서 결정)
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `structured_route_map_painter.dart`의 재생 translate 변경(수식 주석)과 `designToViewport`가 `paint()`와 동일 수식인지, `sourceOrigin` 기본값 하위호환이 기존 호출부(테스트 포함)에 회귀를 만들지 않는지.
- 수정 후 캔버스가 `+origin·scale`만큼 이동해 렌더되므로 golden 대조를 확인했다 — 테스트 픽스처는 origin≈0이라 golden 무변화(1120건 green에 포함).

## 리스크

- picture 재생 위치가 origin 보정만큼 이동하므로, origin이 큰 지역 데이터에서 초기 fit 화면 구도가 기존(어긋난) 구도와 달라져 보일 수 있다 — 카메라 fit 자체가 geometry 공간 기준이므로 정합 이후가 의도된 구도다. 실기기 수도권 데이터로 초기·팬·복원 구도를 확인했다.
- `sourceOrigin` 미전달 외부 호출부는 기본값 (0,0)으로 기존 동작 유지.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음 — mobile 코드만)
