### PR TITLE
[Style] 다크 모드 1단계 — 화면 정적 팔레트 참조를 토큰 조회로 마이그레이션 (#1917)

### DIFF
--- a/apps/mobile/lib/ad_slot.dart
+++ b/apps/mobile/lib/ad_slot.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
-import 'accessible_design.dart';
 import 'design_tokens.dart';
 
 /// 표준 배너 규격(아이콘 + 제목/부제 + CTA) 기준 슬롯 높이 (#1931).
@@ -34,6 +33,7 @@ class AdBannerSlot extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     final ad = child;
     // 실광고가 없는 상태에서 release면 슬롯 자체를 숨긴다(collapse).
     if (ad == null && kReleaseMode) {
@@ -45,10 +45,10 @@ class AdBannerSlot extends StatelessWidget {
         key: slotKey,
         height: height,
         decoration: BoxDecoration(
-          color: EasySubwayAccessibleColors.surface,
+          color: tokens.surface,
           border: showTopDivider
-              ? const Border(
-                  top: BorderSide(color: EasySubwayAccessibleColors.line),
+              ? Border(
+                  top: BorderSide(color: tokens.line),
                 )
               : null,
         ),
@@ -65,6 +65,7 @@ class _AdBannerSlotDevPlaceholder extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Padding(
       padding: const EdgeInsets.symmetric(
         horizontal: EasySubwaySpacing.lg,
@@ -77,19 +78,19 @@ class _AdBannerSlotDevPlaceholder extends StatelessWidget {
             width: 64,
             height: 64,
             decoration: BoxDecoration(
-              color: EasySubwayAccessibleColors.line,
+              color: tokens.line,
               borderRadius: BorderRadius.circular(EasySubwayRadius.control),
             ),
             alignment: Alignment.center,
-            child: const Icon(
+            child: Icon(
               Icons.image_outlined,
-              color: EasySubwayAccessibleColors.mutedText,
+              color: tokens.inkMuted,
             ),
           ),
           const SizedBox(width: EasySubwaySpacing.md),
           // 제목/부제 플레이스홀더. 시스템 글자 크기가 커도 슬롯 높이를 넘지 않도록
           // 각 줄을 FittedBox로 축소한다(장식용 자리표시 텍스트, 실제 정보 없음).
-          const Expanded(
+          Expanded(
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -100,21 +101,21 @@ class _AdBannerSlotDevPlaceholder extends StatelessWidget {
                   child: Text(
                     '광고 미리보기 (개발용)',
                     style: TextStyle(
-                      color: EasySubwayAccessibleColors.mutedText,
+                      color: tokens.inkMuted,
                       fontSize: 13,
                       fontWeight: FontWeight.w600,
                     ),
                     maxLines: 1,
                   ),
                 ),
-                SizedBox(height: EasySubwaySpacing.xs),
+                const SizedBox(height: EasySubwaySpacing.xs),
                 FittedBox(
                   fit: BoxFit.scaleDown,
                   alignment: Alignment.centerLeft,
                   child: Text(
                     '표준 배너 규격 자리표시 텍스트',
                     style: TextStyle(
-                      color: EasySubwayAccessibleColors.mutedText,
+                      color: tokens.inkMuted,
                       fontSize: 12,
                     ),
                     maxLines: 1,
@@ -129,7 +130,7 @@ class _AdBannerSlotDevPlaceholder extends StatelessWidget {
             width: 64,
             height: 32,
             decoration: BoxDecoration(
-              color: EasySubwayAccessibleColors.line,
+              color: tokens.line,
               borderRadius: BorderRadius.circular(EasySubwayRadius.control),
             ),
           ),

--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -50,7 +50,7 @@ const _facilityReportCardRadius = BorderRadius.all(Radius.circular(16));
 Color _reportStatusColor(BuildContext context, String status) {
   final tokens = EasySubwayTokens.of(context);
   return switch (status) {
-    'SUBMITTED' => EasySubwayAccessibleColors.needsInfo,
+    'SUBMITTED' => tokens.accent,
     'UNDER_REVIEW' => tokens.warn,
     'ACCEPTED' || 'RESOLVED' => EasySubwayAccessibleColors.mintDark,
     'REJECTED' => tokens.danger,

--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -12,6 +12,7 @@ import 'accessible_design.dart';
 import 'auth_headers.dart';
 import 'core/database/user/user_database.dart' as user_db;
 import 'core/network/api_client.dart';
+import 'design_tokens.dart';
 import 'mobile_error_reporter.dart';
 import 'secure_key_value_storage.dart';
 
@@ -46,14 +47,15 @@ const _facilityReportCardRadius = BorderRadius.all(Radius.circular(16));
 
 /// 제보 상태(FacilityReportStatus)를 상태색으로 매핑한다. 박스 대신 색 점·색
 /// 텍스트로 상태를 구분하기 위한 전경색만 돌려준다.
-Color _reportStatusColor(String status) {
+Color _reportStatusColor(BuildContext context, String status) {
+  final tokens = EasySubwayTokens.of(context);
   return switch (status) {
     'SUBMITTED' => EasySubwayAccessibleColors.needsInfo,
-    'UNDER_REVIEW' => EasySubwayAccessibleColors.amber,
+    'UNDER_REVIEW' => tokens.warn,
     'ACCEPTED' || 'RESOLVED' => EasySubwayAccessibleColors.mintDark,
-    'REJECTED' => EasySubwayAccessibleColors.red,
-    'DUPLICATE' => EasySubwayAccessibleColors.mutedText,
-    _ => EasySubwayAccessibleColors.mutedText,
+    'REJECTED' => tokens.danger,
+    'DUPLICATE' => tokens.inkMuted,
+    _ => tokens.inkMuted,
   };
 }
 
@@ -1462,23 +1464,24 @@ class _MyReportEmpty extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Center(
       child: Padding(
         padding: const EdgeInsets.all(24),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            const Icon(
+            Icon(
               Icons.receipt_long_outlined,
               size: 40,
-              color: EasySubwayAccessibleColors.mutedText,
+              color: tokens.inkMuted,
             ),
             const SizedBox(height: 14),
             Text(
               '접수한 제보가 없습니다.',
               textAlign: TextAlign.center,
               style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                color: EasySubwayAccessibleColors.text,
+                color: tokens.ink,
                 fontWeight: FontWeight.w700,
                 height: 1.3,
               ),
@@ -1497,6 +1500,7 @@ class _MyReportError extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Center(
       child: Padding(
         padding: const EdgeInsets.all(24),
@@ -1507,7 +1511,7 @@ class _MyReportError extends StatelessWidget {
               _facilityReportListErrorMessage,
               textAlign: TextAlign.center,
               style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                color: EasySubwayAccessibleColors.text,
+                color: tokens.ink,
                 fontWeight: FontWeight.w700,
                 height: 1.3,
               ),
@@ -1534,6 +1538,7 @@ class _MyReportListItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
+    final tokens = EasySubwayTokens.of(context);
     final description = report.description.isEmpty
         ? report.reportTypeLabel
         : report.description;
@@ -1553,10 +1558,10 @@ class _MyReportListItem extends StatelessWidget {
       onTap: openReportDetail,
       child: ExcludeSemantics(
         child: Material(
-          color: EasySubwayAccessibleColors.surface,
+          color: tokens.surface,
           shape: RoundedRectangleBorder(
             borderRadius: _facilityReportCardRadius,
-            side: const BorderSide(color: EasySubwayAccessibleColors.line),
+            side: BorderSide(color: tokens.line),
           ),
           child: InkWell(
             key: Key('myReport-${report.id}'),
@@ -1574,7 +1579,7 @@ class _MyReportListItem extends StatelessWidget {
                         child: Text(
                           report.reportTypeLabel,
                           style: textTheme.titleMedium?.copyWith(
-                            color: EasySubwayAccessibleColors.text,
+                            color: tokens.ink,
                             fontWeight: FontWeight.w700,
                             height: 1.25,
                           ),
@@ -1591,7 +1596,7 @@ class _MyReportListItem extends StatelessWidget {
                   Text(
                     description,
                     style: textTheme.bodyLarge?.copyWith(
-                      color: EasySubwayAccessibleColors.text,
+                      color: tokens.ink,
                       fontWeight: FontWeight.w700,
                       height: 1.35,
                     ),
@@ -1625,6 +1630,7 @@ class MyFacilityReportDetailScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     final description = report.description.isEmpty
         ? report.reportTypeLabel
         : report.description;
@@ -1642,7 +1648,7 @@ class MyFacilityReportDetailScreen extends StatelessWidget {
               Text(
                 report.reportTypeLabel,
                 style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                  color: EasySubwayAccessibleColors.text,
+                  color: tokens.ink,
                   fontWeight: FontWeight.w700,
                   height: 1.25,
                 ),
@@ -1677,7 +1683,7 @@ class _MyReportDetailStatus extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final color = _reportStatusColor(status);
+    final color = _reportStatusColor(context, status);
     return Align(
       alignment: Alignment.centerLeft,
       child: Row(
@@ -1711,13 +1717,14 @@ class _MyReportDetailRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
           label,
           style: Theme.of(context).textTheme.labelLarge?.copyWith(
-            color: EasySubwayAccessibleColors.mutedText,
+            color: tokens.inkMuted,
             fontWeight: FontWeight.w700,
             height: 1.2,
           ),
@@ -1726,7 +1733,7 @@ class _MyReportDetailRow extends StatelessWidget {
         Text(
           value,
           style: Theme.of(context).textTheme.titleLarge?.copyWith(
-            color: EasySubwayAccessibleColors.text,
+            color: tokens.ink,
             fontWeight: FontWeight.w700,
             height: 1.3,
           ),
@@ -1744,7 +1751,7 @@ class _MyReportStatusLabel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final color = _reportStatusColor(status);
+    final color = _reportStatusColor(context, status);
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
@@ -1775,10 +1782,11 @@ class _MyReportMetaText extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Text(
       '$label $value',
       style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-        color: EasySubwayAccessibleColors.mutedText,
+        color: tokens.inkMuted,
         fontWeight: FontWeight.w700,
         height: 1.3,
       ),
@@ -1839,6 +1847,7 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     final state = _controller.state;
     final isLoading = state.status == FacilityReportViewStatus.loading;
     final reportResult = state.result;
@@ -1929,17 +1938,17 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
               if (_attachedLocation != null)
                 Row(
                   children: [
-                    const Icon(
+                    Icon(
                       Icons.location_on_outlined,
-                      color: EasySubwayAccessibleColors.primary,
+                      color: tokens.accent,
                       size: 24,
                     ),
                     const SizedBox(width: 8),
-                    const Expanded(
+                    Expanded(
                       child: Text(
                         '현재 위치를 첨부했어요',
                         style: TextStyle(
-                          color: EasySubwayAccessibleColors.text,
+                          color: tokens.ink,
                           fontWeight: FontWeight.w700,
                         ),
                       ),
@@ -2448,11 +2457,12 @@ class _FacilityReportStatusPanel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Container(
       decoration: BoxDecoration(
-        color: EasySubwayAccessibleColors.surface,
+        color: tokens.surface,
         borderRadius: _facilityReportCardRadius,
-        border: Border.all(color: EasySubwayAccessibleColors.line),
+        border: Border.all(color: tokens.line),
       ),
       child: Padding(
         padding: const EdgeInsets.all(16),
@@ -2504,13 +2514,14 @@ class _FacilityReportStatusRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
+    final tokens = EasySubwayTokens.of(context);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
           label,
           style: textTheme.labelLarge?.copyWith(
-            color: EasySubwayAccessibleColors.mutedText,
+            color: tokens.inkMuted,
             fontWeight: FontWeight.w700,
           ),
         ),
@@ -2518,7 +2529,7 @@ class _FacilityReportStatusRow extends StatelessWidget {
         Text(
           value,
           style: textTheme.titleMedium?.copyWith(
-            color: EasySubwayAccessibleColors.text,
+            color: tokens.ink,
             fontWeight: FontWeight.w700,
             height: 1.25,
           ),
@@ -2536,6 +2547,7 @@ class _FacilityReportHeader extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
+    final tokens = EasySubwayTokens.of(context);
 
     return Semantics(
       label:
@@ -2548,7 +2560,7 @@ class _FacilityReportHeader extends StatelessWidget {
             Text(
               '${target.stationName}역',
               style: textTheme.headlineSmall?.copyWith(
-                color: EasySubwayAccessibleColors.text,
+                color: tokens.ink,
                 fontWeight: FontWeight.w700,
                 height: 1.2,
               ),
@@ -2557,7 +2569,7 @@ class _FacilityReportHeader extends StatelessWidget {
             Text(
               target.facilityName,
               style: textTheme.titleLarge?.copyWith(
-                color: EasySubwayAccessibleColors.text,
+                color: tokens.ink,
                 fontWeight: FontWeight.w700,
                 height: 1.25,
               ),
@@ -2566,7 +2578,7 @@ class _FacilityReportHeader extends StatelessWidget {
             Text(
               '${target.facilityTypeLabel} · ${target.facilityStatusLabel}',
               style: textTheme.bodyLarge?.copyWith(
-                color: EasySubwayAccessibleColors.mutedText,
+                color: tokens.inkMuted,
                 fontWeight: FontWeight.w700,
                 height: 1.3,
               ),
@@ -2585,12 +2597,13 @@ class _FacilityReportSectionTitle extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Semantics(
       header: true,
       child: Text(
         title,
         style: Theme.of(context).textTheme.titleLarge?.copyWith(
-          color: EasySubwayAccessibleColors.text,
+          color: tokens.ink,
           fontWeight: FontWeight.w700,
           height: 1.25,
         ),
@@ -2612,12 +2625,9 @@ class _FacilityReportTypeCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final color = selected
-        ? EasySubwayAccessibleColors.primary
-        : EasySubwayAccessibleColors.line;
-    final textColor = selected
-        ? EasySubwayAccessibleColors.surface
-        : EasySubwayAccessibleColors.text;
+    final tokens = EasySubwayTokens.of(context);
+    final color = selected ? tokens.accent : tokens.line;
+    final textColor = selected ? tokens.surface : tokens.ink;
     final semanticsLabel = '${option.label} ${selected ? '선택됨' : '선택 가능'}';
 
     return Semantics(
@@ -2627,7 +2637,7 @@ class _FacilityReportTypeCard extends StatelessWidget {
       onTap: onTap,
       child: ExcludeSemantics(
         child: Material(
-          color: selected ? color : EasySubwayAccessibleColors.surface,
+          color: selected ? color : tokens.surface,
           shape: RoundedRectangleBorder(
             borderRadius: _facilityReportCardRadius,
             side: BorderSide(color: color, width: 1.5),
@@ -2676,10 +2686,9 @@ class _FacilityReportMessage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     final isFailure = state.status == FacilityReportViewStatus.failure;
-    final color = isFailure
-        ? EasySubwayAccessibleColors.red
-        : EasySubwayAccessibleColors.primary;
+    final color = isFailure ? tokens.danger : tokens.accent;
     final icon = isFailure ? Icons.error_outline : Icons.check_circle_outline;
     final shouldShowNextAction = _shouldShowFacilityReportFailureNextAction(
       state,
@@ -2701,7 +2710,7 @@ class _FacilityReportMessage extends StatelessWidget {
                   child: Text(
                     state.message,
                     style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                      color: EasySubwayAccessibleColors.text,
+                      color: tokens.ink,
                       fontWeight: FontWeight.w700,
                       height: 1.3,
                     ),
@@ -2722,7 +2731,7 @@ class _FacilityReportMessage extends StatelessWidget {
             child: Text(
               _facilityReportFailureNextAction,
               style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                color: EasySubwayAccessibleColors.mutedText,
+                color: tokens.inkMuted,
                 fontWeight: FontWeight.w700,
                 height: 1.35,
               ),
@@ -2750,9 +2759,8 @@ class _FacilityReportLocationMessage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final color = isFailure
-        ? EasySubwayAccessibleColors.red
-        : EasySubwayAccessibleColors.primary;
+    final tokens = EasySubwayTokens.of(context);
+    final color = isFailure ? tokens.danger : tokens.accent;
     final icon = isFailure ? Icons.error_outline : Icons.check_circle_outline;
 
     return Semantics(
@@ -2767,7 +2775,7 @@ class _FacilityReportLocationMessage extends StatelessWidget {
               child: Text(
                 message,
                 style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                  color: EasySubwayAccessibleColors.text,
+                  color: tokens.ink,
                   fontWeight: FontWeight.w700,
                   height: 1.3,
                 ),

--- a/apps/mobile/lib/features/service_notice/presentation/service_notice_banner.dart
+++ b/apps/mobile/lib/features/service_notice/presentation/service_notice_banner.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../../accessible_design.dart';
+import '../../../design_tokens.dart';
 import 'notice_controller.dart';
 
 /// 노선도 홈 상단에 얹는 disruption 공지 1줄 배너.
@@ -25,6 +26,7 @@ class ServiceNoticeBanner extends StatelessWidget {
     return ListenableBuilder(
       listenable: controller,
       builder: (context, _) {
+        final tokens = EasySubwayTokens.of(context);
         final notice = controller.topDisruption;
         if (notice == null) {
           return const SizedBox.shrink();
@@ -40,10 +42,10 @@ class ServiceNoticeBanner extends StatelessWidget {
               padding: const EdgeInsets.only(left: 14, right: 4),
               child: Row(
                 children: [
-                  const Icon(
+                  Icon(
                     Icons.warning_amber_rounded,
                     size: 20,
-                    color: EasySubwayAccessibleColors.amber,
+                    color: tokens.warn,
                   ),
                   const SizedBox(width: 10),
                   Expanded(
@@ -62,8 +64,8 @@ class ServiceNoticeBanner extends StatelessWidget {
                                   notice.title,
                                   maxLines: 1,
                                   overflow: TextOverflow.ellipsis,
-                                  style: const TextStyle(
-                                    color: EasySubwayAccessibleColors.amber,
+                                  style: TextStyle(
+                                    color: tokens.warn,
                                     fontSize: 15,
                                     fontWeight: FontWeight.w700,
                                     height: 1.2,
@@ -75,8 +77,8 @@ class ServiceNoticeBanner extends StatelessWidget {
                                 Text(
                                   staleLabel,
                                   maxLines: 1,
-                                  style: const TextStyle(
-                                    color: EasySubwayAccessibleColors.mutedText,
+                                  style: TextStyle(
+                                    color: tokens.inkMuted,
                                     fontSize: 12,
                                     fontWeight: FontWeight.w600,
                                   ),
@@ -92,7 +94,7 @@ class ServiceNoticeBanner extends StatelessWidget {
                     key: const Key('serviceNoticeBannerDismiss'),
                     onPressed: () => controller.dismissBanner(notice.id),
                     iconSize: 20,
-                    color: EasySubwayAccessibleColors.amber,
+                    color: tokens.warn,
                     visualDensity: VisualDensity.compact,
                     tooltip: '공지 닫기',
                     icon: const Icon(Icons.close_rounded),

--- a/apps/mobile/lib/features/service_notice/presentation/service_notice_list_screen.dart
+++ b/apps/mobile/lib/features/service_notice/presentation/service_notice_list_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import '../../../accessible_design.dart';
+import '../../../design_tokens.dart';
 import '../domain/service_notice.dart';
 import 'notice_controller.dart';
 
@@ -18,11 +18,12 @@ class ServiceNoticeListScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Scaffold(
-      backgroundColor: EasySubwayAccessibleColors.surface,
+      backgroundColor: tokens.surface,
       appBar: AppBar(
         title: const Text('운행 공지'),
-        backgroundColor: EasySubwayAccessibleColors.surface,
+        backgroundColor: tokens.surface,
         surfaceTintColor: Colors.transparent,
         elevation: 0,
       ),
@@ -49,11 +50,11 @@ class ServiceNoticeListScreen extends StatelessWidget {
                     physics: const AlwaysScrollableScrollPhysics(),
                     padding: const EdgeInsets.symmetric(vertical: 8),
                     itemCount: notices.length,
-                    separatorBuilder: (context, index) => const Divider(
+                    separatorBuilder: (context, index) => Divider(
                       height: 1,
                       indent: 20,
                       endIndent: 20,
-                      color: EasySubwayAccessibleColors.line,
+                      color: tokens.line,
                     ),
                     itemBuilder: (context, index) =>
                         _NoticeItem(notice: notices[index]),
@@ -75,27 +76,28 @@ class _StaleBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Container(
       key: const Key('serviceNoticeStaleBar'),
       margin: const EdgeInsets.fromLTRB(16, 8, 16, 12),
       padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
       decoration: BoxDecoration(
-        color: EasySubwayAccessibleColors.scaffoldSurface,
+        color: tokens.scaffold,
         borderRadius: BorderRadius.circular(12),
       ),
       child: Row(
         children: [
-          const Icon(
+          Icon(
             Icons.cloud_off_rounded,
             size: 18,
-            color: EasySubwayAccessibleColors.mutedText,
+            color: tokens.inkMuted,
           ),
           const SizedBox(width: 8),
           Expanded(
             child: Text(
               '오프라인 · $label',
-              style: const TextStyle(
-                color: EasySubwayAccessibleColors.mutedText,
+              style: TextStyle(
+                color: tokens.inkMuted,
                 fontSize: 13,
                 fontWeight: FontWeight.w600,
               ),
@@ -114,10 +116,11 @@ class _NoticeItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     final isDisruption = notice.isDisruption;
     final accent = isDisruption
-        ? EasySubwayAccessibleColors.amber
-        : EasySubwayAccessibleColors.primary;
+        ? tokens.warn
+        : tokens.accent;
     return Padding(
       padding: const EdgeInsets.fromLTRB(20, 16, 20, 18),
       child: Column(
@@ -146,8 +149,8 @@ class _NoticeItem extends StatelessWidget {
               const Spacer(),
               Text(
                 _formatPublishedAt(notice.publishedAt),
-                style: const TextStyle(
-                  color: EasySubwayAccessibleColors.mutedText,
+                style: TextStyle(
+                  color: tokens.inkMuted,
                   fontSize: 12,
                   fontWeight: FontWeight.w500,
                 ),
@@ -157,8 +160,8 @@ class _NoticeItem extends StatelessWidget {
           const SizedBox(height: 8),
           Text(
             notice.title,
-            style: const TextStyle(
-              color: EasySubwayAccessibleColors.text,
+            style: TextStyle(
+              color: tokens.ink,
               fontSize: 16,
               fontWeight: FontWeight.w700,
               height: 1.3,
@@ -168,8 +171,8 @@ class _NoticeItem extends StatelessWidget {
             const SizedBox(height: 6),
             Text(
               notice.body,
-              style: const TextStyle(
-                color: EasySubwayAccessibleColors.secondaryText,
+              style: TextStyle(
+                color: tokens.inkSecondary,
                 fontSize: 14,
                 fontWeight: FontWeight.w500,
                 height: 1.4,
@@ -189,32 +192,33 @@ class _EmptyNotices extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return ListView(
       physics: const AlwaysScrollableScrollPhysics(),
       children: [
         if (staleLabel != null) _StaleBar(label: staleLabel!),
         SizedBox(height: MediaQuery.sizeOf(context).height * 0.22),
-        const Icon(
+        Icon(
           Icons.check_circle_outline_rounded,
           size: 44,
-          color: EasySubwayAccessibleColors.mutedText,
+          color: tokens.inkMuted,
         ),
         const SizedBox(height: 14),
-        const Text(
+        Text(
           '지금은 운행 공지가 없어요',
           textAlign: TextAlign.center,
           style: TextStyle(
-            color: EasySubwayAccessibleColors.text,
+            color: tokens.ink,
             fontSize: 17,
             fontWeight: FontWeight.w700,
           ),
         ),
         const SizedBox(height: 6),
-        const Text(
+        Text(
           '운행 장애나 안내가 생기면 여기에 표시돼요',
           textAlign: TextAlign.center,
           style: TextStyle(
-            color: EasySubwayAccessibleColors.mutedText,
+            color: tokens.inkMuted,
             fontSize: 14,
             fontWeight: FontWeight.w500,
           ),

--- a/apps/mobile/lib/features/stations/presentation/station_line_badges.dart
+++ b/apps/mobile/lib/features/stations/presentation/station_line_badges.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import '../../../accessible_design.dart';
+import '../../../design_tokens.dart';
 import '../domain/station_line.dart';
 
 class StationLineBadges extends StatelessWidget {
@@ -108,21 +108,22 @@ class _StationLineOverflowBadge extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Container(
       key: const Key('stationLineBadgeOverflow'),
       width: size,
       height: size,
       alignment: Alignment.center,
       decoration: BoxDecoration(
-        color: EasySubwayAccessibleColors.scaffoldSurface,
+        color: tokens.scaffold,
         shape: BoxShape.circle,
-        border: Border.all(color: EasySubwayAccessibleColors.line),
+        border: Border.all(color: tokens.line),
       ),
       child: Text(
         '+$count',
         textAlign: TextAlign.center,
         style: Theme.of(context).textTheme.labelLarge?.copyWith(
-          color: EasySubwayAccessibleColors.mutedText,
+          color: tokens.inkMuted,
           fontSize: 13 * (size / 32),
           fontWeight: FontWeight.w800,
           height: 1.0,

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -671,9 +671,10 @@ class _StartupLoadingScreenState extends State<_StartupLoadingScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Scaffold(
       key: const Key('startupLoadingScreen'),
-      backgroundColor: EasySubwayAccessibleColors.surface,
+      backgroundColor: tokens.surface,
       body: SafeArea(
         child: Center(
           child: Semantics(
@@ -684,10 +685,10 @@ class _StartupLoadingScreenState extends State<_StartupLoadingScreen> {
                 width: 26,
                 height: 26,
                 child: _showSpinner
-                    ? const CircularProgressIndicator(
+                    ? CircularProgressIndicator(
                         strokeWidth: 2.5,
                         valueColor: AlwaysStoppedAnimation<Color>(
-                          EasySubwayAccessibleColors.mutedText,
+                          tokens.inkMuted,
                         ),
                       )
                     : null,
@@ -1970,6 +1971,7 @@ class _HomeNotificationButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Semantics(
       button: true,
       label: hasNotificationItems ? '알림, 확인할 알림 있음' : '알림, 새 알림이 없어요',
@@ -1980,7 +1982,7 @@ class _HomeNotificationButton extends StatelessWidget {
           child: Badge(
             isLabelVisible: hasNotificationItems,
             smallSize: 10,
-            backgroundColor: EasySubwayAccessibleColors.red,
+            backgroundColor: tokens.danger,
             offset: const Offset(-10, 10),
             child: IconButton.filledTonal(
               onPressed: onPressed,
@@ -1988,9 +1990,9 @@ class _HomeNotificationButton extends StatelessWidget {
               style: IconButton.styleFrom(
                 minimumSize: const Size.square(48),
                 backgroundColor: Colors.white,
-                foregroundColor: EasySubwayAccessibleColors.secondaryText,
-                side: const BorderSide(
-                  color: EasySubwayAccessibleColors.line,
+                foregroundColor: tokens.inkSecondary,
+                side: BorderSide(
+                  color: tokens.line,
                   width: 1.5,
                 ),
                 shape: RoundedRectangleBorder(
@@ -2036,6 +2038,7 @@ class _NotificationInboxScreenState extends State<NotificationInboxScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Scaffold(
       appBar: AppBar(
         title: const Text('알림'),
@@ -2093,17 +2096,17 @@ class _NotificationInboxScreenState extends State<NotificationInboxScreen> {
                       padding: const EdgeInsets.only(top: 80),
                       child: Column(
                         children: [
-                          const Icon(
+                          Icon(
                             Icons.notifications_none,
                             size: 44,
-                            color: EasySubwayAccessibleColors.mutedText,
+                            color: tokens.inkMuted,
                           ),
                           const SizedBox(height: 12),
                           Text(
                             '새 알림이 없습니다',
                             textAlign: TextAlign.center,
-                            style: const TextStyle(
-                              color: EasySubwayAccessibleColors.text,
+                            style: TextStyle(
+                              color: tokens.ink,
                               fontSize: 16,
                               fontWeight: FontWeight.w700,
                             ),
@@ -2112,8 +2115,8 @@ class _NotificationInboxScreenState extends State<NotificationInboxScreen> {
                           Text(
                             '즐겨찾기 시설과 제보 상태가 바뀌면 여기에서 볼 수 있어요.',
                             textAlign: TextAlign.center,
-                            style: const TextStyle(
-                              color: EasySubwayAccessibleColors.mutedText,
+                            style: TextStyle(
+                              color: tokens.inkMuted,
                               fontSize: 13,
                               fontWeight: FontWeight.w500,
                               height: 1.4,
@@ -2259,6 +2262,7 @@ class _NotificationInboxChips extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     final facilityCount = items.where((item) => item.kind == '시설').length;
     final reportCount = items.length - facilityCount;
     final parts = <String>[
@@ -2270,8 +2274,8 @@ class _NotificationInboxChips extends StatelessWidget {
       padding: const EdgeInsets.only(bottom: 4, top: 4),
       child: Text(
         parts.join('  ·  '),
-        style: const TextStyle(
-          color: EasySubwayAccessibleColors.mutedText,
+        style: TextStyle(
+          color: tokens.inkMuted,
           fontSize: 13,
           fontWeight: FontWeight.w600,
         ),
@@ -2287,6 +2291,7 @@ class _NotificationInboxRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     void open() {
       final report = item.report;
       if (report == null) {
@@ -2302,9 +2307,9 @@ class _NotificationInboxRow extends StatelessWidget {
     final accent = _facilitySeverityAccent(item.severity);
     final row = Container(
       padding: const EdgeInsets.symmetric(vertical: 14),
-      decoration: const BoxDecoration(
+      decoration: BoxDecoration(
         border: Border(
-          bottom: BorderSide(color: EasySubwayAccessibleColors.line),
+          bottom: BorderSide(color: tokens.line),
         ),
       ),
       child: Row(
@@ -2325,8 +2330,8 @@ class _NotificationInboxRow extends StatelessWidget {
                     Expanded(
                       child: Text(
                         item.title,
-                        style: const TextStyle(
-                          color: EasySubwayAccessibleColors.text,
+                        style: TextStyle(
+                          color: tokens.ink,
                           fontSize: 15,
                           fontWeight: FontWeight.w700,
                           height: 1.25,
@@ -2336,8 +2341,8 @@ class _NotificationInboxRow extends StatelessWidget {
                     const SizedBox(width: 8),
                     Text(
                       item.kind,
-                      style: const TextStyle(
-                        color: EasySubwayAccessibleColors.mutedText,
+                      style: TextStyle(
+                        color: tokens.inkMuted,
                         fontSize: 12,
                         fontWeight: FontWeight.w600,
                       ),
@@ -2358,8 +2363,8 @@ class _NotificationInboxRow extends StatelessWidget {
                   const SizedBox(height: 6),
                   Text(
                     item.actionLabel,
-                    style: const TextStyle(
-                      color: EasySubwayAccessibleColors.text,
+                    style: TextStyle(
+                      color: tokens.ink,
                       fontSize: 13,
                       fontWeight: FontWeight.w600,
                       height: 1.3,
@@ -2396,12 +2401,13 @@ class _AppSectionTitle extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Padding(
       padding: _appSectionTitlePadding,
       child: Text(
         title,
         style: Theme.of(context).textTheme.titleMedium?.copyWith(
-          color: EasySubwayAccessibleColors.text,
+          color: tokens.ink,
           fontWeight: FontWeight.w700,
           height: 1.2,
         ),
@@ -2516,6 +2522,7 @@ class _HomeSavedRouteCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     final originName = _stationNameWithSuffix(route.originStationName);
     final destinationName = _stationNameWithSuffix(
       route.destinationStationName,
@@ -2530,9 +2537,9 @@ class _HomeSavedRouteCard extends StatelessWidget {
           onTap: onTap,
           child: Row(
             children: [
-              const Icon(
+              Icon(
                 Icons.route_outlined,
-                color: EasySubwayAccessibleColors.primary,
+                color: tokens.accent,
                 size: 30,
               ),
               const SizedBox(width: 12),
@@ -2542,8 +2549,8 @@ class _HomeSavedRouteCard extends StatelessWidget {
                   children: [
                     Text(
                       '$originName → $destinationName',
-                      style: const TextStyle(
-                        color: EasySubwayAccessibleColors.text,
+                      style: TextStyle(
+                        color: tokens.ink,
                         fontSize: 16,
                         fontWeight: FontWeight.w700,
                         height: 1.25,
@@ -2576,9 +2583,9 @@ class _HomeSavedRouteCard extends StatelessWidget {
             IconButton(
               key: Key('favoriteRouteRemoveButton-${route.favoriteRouteId}'),
               onPressed: onRemove,
-              icon: const Icon(
+              icon: Icon(
                 Icons.delete_outline,
-                color: EasySubwayAccessibleColors.mutedText,
+                color: tokens.inkMuted,
               ),
               tooltip: '즐겨찾기 경로 삭제',
             )
@@ -2604,16 +2611,17 @@ class _HomeMiniBadge extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Chip(
       label: Text(label),
       visualDensity: VisualDensity.compact,
-      backgroundColor: EasySubwayAccessibleColors.surface,
-      side: const BorderSide(color: EasySubwayAccessibleColors.line),
+      backgroundColor: tokens.surface,
+      side: BorderSide(color: tokens.line),
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.all(Radius.circular(8)),
       ),
-      labelStyle: const TextStyle(
-        color: EasySubwayAccessibleColors.secondaryText,
+      labelStyle: TextStyle(
+        color: tokens.inkSecondary,
         fontSize: 11,
         fontWeight: FontWeight.w700,
         height: 1.2,
@@ -2669,6 +2677,7 @@ class _AppInfoRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     final subtitle = this.subtitle;
     final leading = SizedBox(
       width: 32,
@@ -2680,8 +2689,8 @@ class _AppInfoRow extends StatelessWidget {
       children: [
         Text(
           title,
-          style: const TextStyle(
-            color: EasySubwayAccessibleColors.text,
+          style: TextStyle(
+            color: tokens.ink,
             fontSize: 15,
             fontWeight: FontWeight.w700,
             height: 1.25,
@@ -2691,8 +2700,8 @@ class _AppInfoRow extends StatelessWidget {
           const SizedBox(height: 3),
           Text(
             subtitle,
-            style: const TextStyle(
-              color: EasySubwayAccessibleColors.mutedText,
+            style: TextStyle(
+              color: tokens.inkMuted,
               fontSize: 12,
               fontWeight: FontWeight.w500,
               height: 1.4,
@@ -2913,6 +2922,7 @@ class _AppSettingsSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     final textTheme = Theme.of(context).textTheme;
     return Padding(
       padding: const EdgeInsets.only(bottom: 18),
@@ -2924,7 +2934,7 @@ class _AppSettingsSection extends StatelessWidget {
             child: Text(
               title,
               style: textTheme.titleMedium?.copyWith(
-                color: EasySubwayAccessibleColors.text,
+                color: tokens.ink,
                 fontWeight: FontWeight.w700,
                 height: 1.25,
               ),
@@ -2955,6 +2965,7 @@ class _AppSettingsActionTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     final subtitle = this.subtitle;
     return Semantics(
       button: true,
@@ -2965,11 +2976,11 @@ class _AppSettingsActionTile extends StatelessWidget {
           onTap: onTap,
           minVerticalPadding: 12,
           minLeadingWidth: 32,
-          leading: Icon(icon, color: EasySubwayAccessibleColors.primary),
+          leading: Icon(icon, color: tokens.accent),
           title: Text(
             title,
             style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-              color: EasySubwayAccessibleColors.text,
+              color: tokens.ink,
               fontWeight: FontWeight.w700,
               height: 1.25,
             ),
@@ -2979,7 +2990,7 @@ class _AppSettingsActionTile extends StatelessWidget {
               : Text(
                   subtitle,
                   style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                    color: EasySubwayAccessibleColors.mutedText,
+                    color: tokens.inkMuted,
                     height: 1.3,
                   ),
                 ),
@@ -3013,6 +3024,7 @@ class _AppSettingsPreferenceTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     final value = enabled ? '켜짐' : '꺼짐';
     final action = enabled ? '끄기' : '켜기';
     return Semantics(
@@ -3024,11 +3036,11 @@ class _AppSettingsPreferenceTile extends StatelessWidget {
           onTap: () => onChanged(!enabled),
           minVerticalPadding: 12,
           minLeadingWidth: 32,
-          leading: Icon(icon, color: EasySubwayAccessibleColors.primary),
+          leading: Icon(icon, color: tokens.accent),
           title: Text(
             title,
             style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-              color: EasySubwayAccessibleColors.text,
+              color: tokens.ink,
               fontWeight: FontWeight.w700,
               height: 1.25,
             ),
@@ -3036,7 +3048,7 @@ class _AppSettingsPreferenceTile extends StatelessWidget {
           subtitle: Text(
             subtitle,
             style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-              color: EasySubwayAccessibleColors.mutedText,
+              color: tokens.inkMuted,
               height: 1.3,
             ),
           ),
@@ -3046,7 +3058,7 @@ class _AppSettingsPreferenceTile extends StatelessWidget {
               Text(
                 value,
                 style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: EasySubwayAccessibleColors.text,
+                  color: tokens.ink,
                   fontWeight: FontWeight.w700,
                 ),
               ),
@@ -3382,6 +3394,7 @@ class _FavoriteHomeStationRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     final name = _stationNameWithSuffix(station.nameKo);
     final lineLabel = station.lineLabel;
     return Semantics(
@@ -3394,17 +3407,17 @@ class _FavoriteHomeStationRow extends StatelessWidget {
           key: Key('favoriteHomeStationRow-${station.stationId}'),
           onTap: onTap,
           child: Container(
-            decoration: const BoxDecoration(
+            decoration: BoxDecoration(
               border: Border(
-                bottom: BorderSide(color: EasySubwayAccessibleColors.line),
+                bottom: BorderSide(color: tokens.line),
               ),
             ),
             padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 12),
             child: Row(
               children: [
-                const Icon(
+                Icon(
                   Icons.train_outlined,
-                  color: EasySubwayAccessibleColors.primary,
+                  color: tokens.accent,
                   size: 26,
                 ),
                 const SizedBox(width: 12),
@@ -3414,8 +3427,8 @@ class _FavoriteHomeStationRow extends StatelessWidget {
                     children: [
                       Text(
                         name,
-                        style: const TextStyle(
-                          color: EasySubwayAccessibleColors.text,
+                        style: TextStyle(
+                          color: tokens.ink,
                           fontSize: 16,
                           fontWeight: FontWeight.w700,
                           height: 1.25,
@@ -3453,18 +3466,19 @@ class _FavoriteHomeFacilityRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Container(
-      decoration: const BoxDecoration(
+      decoration: BoxDecoration(
         border: Border(
-          bottom: BorderSide(color: EasySubwayAccessibleColors.line),
+          bottom: BorderSide(color: tokens.line),
         ),
       ),
       padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 12),
       child: Row(
         children: [
-          const Icon(
+          Icon(
             Icons.elevator_outlined,
-            color: EasySubwayAccessibleColors.primary,
+            color: tokens.accent,
             size: 26,
           ),
           const SizedBox(width: 12),
@@ -3474,8 +3488,8 @@ class _FavoriteHomeFacilityRow extends StatelessWidget {
               children: [
                 Text(
                   facility.name,
-                  style: const TextStyle(
-                    color: EasySubwayAccessibleColors.text,
+                  style: TextStyle(
+                    color: tokens.ink,
                     fontSize: 16,
                     fontWeight: FontWeight.w700,
                     height: 1.25,
@@ -3484,8 +3498,8 @@ class _FavoriteHomeFacilityRow extends StatelessWidget {
                 const SizedBox(height: 3),
                 Text(
                   facility.stationLabel,
-                  style: const TextStyle(
-                    color: EasySubwayAccessibleColors.mutedText,
+                  style: TextStyle(
+                    color: tokens.inkMuted,
                     fontSize: 13,
                     fontWeight: FontWeight.w700,
                     height: 1.3,
@@ -3631,6 +3645,7 @@ class _SupportSectionTitle extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Padding(
       padding: const EdgeInsets.only(bottom: 10),
       child: Semantics(
@@ -3638,7 +3653,7 @@ class _SupportSectionTitle extends StatelessWidget {
         child: Text(
           title,
           style: Theme.of(context).textTheme.titleMedium?.copyWith(
-            color: EasySubwayAccessibleColors.text,
+            color: tokens.ink,
             fontWeight: FontWeight.w700,
             height: 1.25,
           ),
@@ -3655,6 +3670,7 @@ class _SupportGroupCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     // 연결 가능한 항목이 없으면(전 항목 숨김) 빈 테두리 카드를 그리지 않는다.
     if (children.isEmpty) {
       return const SizedBox.shrink();
@@ -3664,14 +3680,14 @@ class _SupportGroupCard extends StatelessWidget {
       rows.add(children[i]);
       if (i != children.length - 1) {
         rows.add(
-          const Divider(height: 1, color: EasySubwayAccessibleColors.line),
+          Divider(height: 1, color: tokens.line),
         );
       }
     }
     return Container(
       decoration: BoxDecoration(
-        color: EasySubwayAccessibleColors.surface,
-        border: Border.all(color: EasySubwayAccessibleColors.line),
+        color: tokens.surface,
+        border: Border.all(color: tokens.line),
         borderRadius: const BorderRadius.all(Radius.circular(16)),
       ),
       child: Padding(
@@ -3699,6 +3715,7 @@ class _SupportNavRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Semantics(
       button: true,
       label: title,
@@ -3711,13 +3728,13 @@ class _SupportNavRow extends StatelessWidget {
             padding: const EdgeInsets.symmetric(vertical: 14),
             child: Row(
               children: [
-                Icon(icon, size: 24, color: EasySubwayAccessibleColors.primary),
+                Icon(icon, size: 24, color: tokens.accent),
                 const SizedBox(width: 14),
                 Expanded(
                   child: Text(
                     title,
-                    style: const TextStyle(
-                      color: EasySubwayAccessibleColors.text,
+                    style: TextStyle(
+                      color: tokens.ink,
                       fontSize: 16,
                       fontWeight: FontWeight.w700,
                       height: 1.25,
@@ -3725,9 +3742,9 @@ class _SupportNavRow extends StatelessWidget {
                   ),
                 ),
                 const SizedBox(width: 8),
-                const Icon(
+                Icon(
                   Icons.chevron_right,
-                  color: EasySubwayAccessibleColors.mutedText,
+                  color: tokens.inkMuted,
                   size: 22,
                 ),
               ],
@@ -3752,6 +3769,7 @@ class _UserDataDeletionAccessItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     final copy = _UserDataDeletionCopy.forScope(deletionScope);
     void openDeletionScreen() {
       Navigator.of(context).push(
@@ -3778,11 +3796,11 @@ class _UserDataDeletionAccessItem extends StatelessWidget {
             padding: const EdgeInsets.symmetric(vertical: 14),
             child: Row(
               children: [
-                const Padding(
-                  padding: EdgeInsets.only(top: 1),
+                Padding(
+                  padding: const EdgeInsets.only(top: 1),
                   child: Icon(
                     Icons.delete_outline,
-                    color: EasySubwayAccessibleColors.red,
+                    color: tokens.danger,
                     size: 24,
                   ),
                 ),
@@ -3790,17 +3808,17 @@ class _UserDataDeletionAccessItem extends StatelessWidget {
                 Expanded(
                   child: Text(
                     copy.title,
-                    style: const TextStyle(
-                      color: EasySubwayAccessibleColors.text,
+                    style: TextStyle(
+                      color: tokens.ink,
                       fontSize: 16,
                       fontWeight: FontWeight.w700,
                       height: 1.25,
                     ),
                   ),
                 ),
-                const Icon(
+                Icon(
                   Icons.chevron_right,
-                  color: EasySubwayAccessibleColors.mutedText,
+                  color: tokens.inkMuted,
                 ),
               ],
             ),
@@ -3902,6 +3920,7 @@ class _UserDataDeletionScreenState extends State<UserDataDeletionScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     final textTheme = Theme.of(context).textTheme;
     final copy = _UserDataDeletionCopy.forScope(widget.deletionScope);
     return Scaffold(
@@ -3920,8 +3939,8 @@ class _UserDataDeletionScreenState extends State<UserDataDeletionScreen> {
               : const Icon(Icons.delete_forever_outlined),
           label: Text(_isDeleting ? '삭제 중' : copy.title),
           style: FilledButton.styleFrom(
-            backgroundColor: EasySubwayAccessibleColors.red,
-            foregroundColor: EasySubwayAccessibleColors.surface,
+            backgroundColor: tokens.danger,
+            foregroundColor: tokens.surface,
           ),
         ),
       ),
@@ -3934,7 +3953,7 @@ class _UserDataDeletionScreenState extends State<UserDataDeletionScreen> {
               child: Text(
                 '삭제 전에 확인해 주세요',
                 style: textTheme.headlineSmall?.copyWith(
-                  color: EasySubwayAccessibleColors.text,
+                  color: tokens.ink,
                   fontWeight: FontWeight.w700,
                   height: 1.25,
                 ),
@@ -3944,7 +3963,7 @@ class _UserDataDeletionScreenState extends State<UserDataDeletionScreen> {
             Text(
               copy.deletedSummary,
               style: textTheme.bodyLarge?.copyWith(
-                color: EasySubwayAccessibleColors.text,
+                color: tokens.ink,
                 height: 1.4,
               ),
             ),
@@ -3952,7 +3971,7 @@ class _UserDataDeletionScreenState extends State<UserDataDeletionScreen> {
             Text(
               _UserDataDeletionCopy.irreversibleLine,
               style: textTheme.bodyLarge?.copyWith(
-                color: EasySubwayAccessibleColors.red,
+                color: tokens.danger,
                 fontWeight: FontWeight.w700,
                 height: 1.4,
               ),
@@ -3962,7 +3981,7 @@ class _UserDataDeletionScreenState extends State<UserDataDeletionScreen> {
               Text(
                 copy.exceptionNote!,
                 style: textTheme.bodyMedium?.copyWith(
-                  color: EasySubwayAccessibleColors.mutedText,
+                  color: tokens.inkMuted,
                   height: 1.4,
                 ),
               ),
@@ -3976,27 +3995,30 @@ class _UserDataDeletionScreenState extends State<UserDataDeletionScreen> {
   Future<void> _confirmAndDelete() async {
     final confirmed = await showDialog<bool>(
       context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('정말 삭제할까요?'),
-        content: Text(
-          _UserDataDeletionCopy.forScope(widget.deletionScope).confirmText,
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(false),
-            child: const Text('취소'),
+      builder: (context) {
+        final tokens = EasySubwayTokens.of(context);
+        return AlertDialog(
+          title: const Text('정말 삭제할까요?'),
+          content: Text(
+            _UserDataDeletionCopy.forScope(widget.deletionScope).confirmText,
           ),
-          FilledButton(
-            key: const Key('dataDeletionConfirmButton'),
-            onPressed: () => Navigator.of(context).pop(true),
-            style: FilledButton.styleFrom(
-              backgroundColor: EasySubwayAccessibleColors.red,
-              foregroundColor: EasySubwayAccessibleColors.surface,
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('취소'),
             ),
-            child: const Text('삭제'),
-          ),
-        ],
-      ),
+            FilledButton(
+              key: const Key('dataDeletionConfirmButton'),
+              onPressed: () => Navigator.of(context).pop(true),
+              style: FilledButton.styleFrom(
+                backgroundColor: tokens.danger,
+                foregroundColor: tokens.surface,
+              ),
+              child: const Text('삭제'),
+            ),
+          ],
+        );
+      },
     );
     if (confirmed == true) {
       await _deleteCurrentUserData();
@@ -4048,6 +4070,7 @@ class UserDataDeletionResultScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Scaffold(
       appBar: AppBar(
         title: const Text('삭제 완료'),
@@ -4067,8 +4090,8 @@ class UserDataDeletionResultScreen extends StatelessWidget {
           padding: _mainPagePadding,
           children: [
             _AppCard(
-              backgroundColor: EasySubwayAccessibleColors.surface,
-              borderColor: EasySubwayAccessibleColors.line,
+              backgroundColor: tokens.surface,
+              borderColor: tokens.line,
               child: Column(
                 children: [
                   const Icon(
@@ -4080,7 +4103,7 @@ class UserDataDeletionResultScreen extends StatelessWidget {
                   Text(
                     '내 정보가 삭제됐어요',
                     style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                      color: EasySubwayAccessibleColors.text,
+                      color: tokens.ink,
                       fontWeight: FontWeight.w700,
                     ),
                     textAlign: TextAlign.center,
@@ -4118,6 +4141,7 @@ class _SecurityContactNotice extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     final textTheme = Theme.of(context).textTheme;
     return Semantics(
       key: const Key('securityContactNotice'),
@@ -4125,9 +4149,9 @@ class _SecurityContactNotice extends StatelessWidget {
       label: '$_title, $_contactNotice $_scopeNotice',
       child: ExcludeSemantics(
         child: Container(
-          decoration: const BoxDecoration(
+          decoration: BoxDecoration(
             border: Border(
-              top: BorderSide(color: EasySubwayAccessibleColors.line),
+              top: BorderSide(color: tokens.line),
             ),
           ),
           child: Padding(
@@ -4148,7 +4172,7 @@ class _SecurityContactNotice extends StatelessWidget {
                       child: Text(
                         _title,
                         style: textTheme.titleMedium?.copyWith(
-                          color: EasySubwayAccessibleColors.text,
+                          color: tokens.ink,
                           fontWeight: FontWeight.w700,
                           height: 1.25,
                         ),
@@ -4175,6 +4199,7 @@ class _SecurityContactNoticeLine extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Padding(
       padding: const EdgeInsets.only(bottom: 8),
       child: Row(
@@ -4193,7 +4218,7 @@ class _SecurityContactNoticeLine extends StatelessWidget {
             child: Text(
               text,
               style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                color: EasySubwayAccessibleColors.text,
+                color: tokens.ink,
                 height: 1.35,
               ),
             ),
@@ -4214,6 +4239,7 @@ class _SafetyDataNotice extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     final textTheme = Theme.of(context).textTheme;
     return Semantics(
       key: const Key('safetyDataNotice'),
@@ -4221,9 +4247,9 @@ class _SafetyDataNotice extends StatelessWidget {
       label: '$_title, $_referenceNotice $_fieldNotice $_limitationNotice',
       child: ExcludeSemantics(
         child: Container(
-          decoration: const BoxDecoration(
+          decoration: BoxDecoration(
             border: Border(
-              top: BorderSide(color: EasySubwayAccessibleColors.line),
+              top: BorderSide(color: tokens.line),
             ),
           ),
           child: Padding(
@@ -4234,9 +4260,9 @@ class _SafetyDataNotice extends StatelessWidget {
                 Row(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    const Icon(
+                    Icon(
                       Icons.info_outline,
-                      color: EasySubwayAccessibleColors.amber,
+                      color: tokens.warn,
                       size: 24,
                     ),
                     const SizedBox(width: 10),
@@ -4244,7 +4270,7 @@ class _SafetyDataNotice extends StatelessWidget {
                       child: Text(
                         _title,
                         style: textTheme.titleMedium?.copyWith(
-                          color: EasySubwayAccessibleColors.text,
+                          color: tokens.ink,
                           fontWeight: FontWeight.w700,
                           height: 1.25,
                         ),
@@ -4272,17 +4298,18 @@ class _SafetyDataNoticeLine extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Padding(
       padding: const EdgeInsets.only(bottom: 8),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Padding(
-            padding: EdgeInsets.only(top: 7),
+          Padding(
+            padding: const EdgeInsets.only(top: 7),
             child: Icon(
               Icons.circle,
               size: 7,
-              color: EasySubwayAccessibleColors.amber,
+              color: tokens.warn,
             ),
           ),
           const SizedBox(width: 10),
@@ -4290,7 +4317,7 @@ class _SafetyDataNoticeLine extends StatelessWidget {
             child: Text(
               text,
               style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                color: EasySubwayAccessibleColors.text,
+                color: tokens.ink,
                 height: 1.35,
               ),
             ),
@@ -4499,6 +4526,7 @@ class _AttributionCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     final semanticLabel = [
       title,
       subtitle,
@@ -4515,7 +4543,7 @@ class _AttributionCard extends StatelessWidget {
               Text(
                 title,
                 style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                  color: EasySubwayAccessibleColors.text,
+                  color: tokens.ink,
                   fontWeight: FontWeight.w700,
                   height: 1.25,
                 ),
@@ -4524,7 +4552,7 @@ class _AttributionCard extends StatelessWidget {
               Text(
                 subtitle,
                 style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: EasySubwayAccessibleColors.mutedText,
+                  color: tokens.inkMuted,
                   fontWeight: FontWeight.w700,
                   height: 1.3,
                 ),
@@ -4580,6 +4608,7 @@ class _AttributionRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Padding(
       padding: const EdgeInsets.only(bottom: 7),
       child: Column(
@@ -4588,7 +4617,7 @@ class _AttributionRow extends StatelessWidget {
           Text(
             label,
             style: Theme.of(context).textTheme.labelLarge?.copyWith(
-              color: EasySubwayAccessibleColors.secondaryText,
+              color: tokens.inkSecondary,
               fontWeight: FontWeight.w700,
               height: 1.25,
             ),
@@ -4597,7 +4626,7 @@ class _AttributionRow extends StatelessWidget {
           Text(
             value,
             style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-              color: EasySubwayAccessibleColors.text,
+              color: tokens.ink,
               fontWeight: FontWeight.w700,
               height: 1.3,
             ),
@@ -4628,6 +4657,7 @@ class _SupportAccessItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     final targetUri = uri;
     final targetText = value.trim();
     final displayValue = this.displayValue ?? targetText;
@@ -4659,8 +4689,8 @@ class _SupportAccessItem extends StatelessWidget {
                     icon,
                     size: 24,
                     color: targetUri == null
-                        ? EasySubwayAccessibleColors.mutedText
-                        : EasySubwayAccessibleColors.primary,
+                        ? tokens.inkMuted
+                        : tokens.accent,
                   ),
                 ),
                 const SizedBox(width: 14),
@@ -4671,8 +4701,8 @@ class _SupportAccessItem extends StatelessWidget {
                     children: [
                       Text(
                         title,
-                        style: const TextStyle(
-                          color: EasySubwayAccessibleColors.text,
+                        style: TextStyle(
+                          color: tokens.ink,
                           fontSize: 16,
                           fontWeight: FontWeight.w700,
                           height: 1.25,
@@ -4682,7 +4712,7 @@ class _SupportAccessItem extends StatelessWidget {
                       Text(
                         displayValue,
                         style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                          color: EasySubwayAccessibleColors.secondaryText,
+                          color: tokens.inkSecondary,
                           height: 1.3,
                         ),
                       ),
@@ -4691,9 +4721,9 @@ class _SupportAccessItem extends StatelessWidget {
                 ),
                 if (targetUri != null) ...[
                   const SizedBox(width: 8),
-                  const Icon(
+                  Icon(
                     Icons.chevron_right,
-                    color: EasySubwayAccessibleColors.mutedText,
+                    color: tokens.inkMuted,
                     size: 22,
                   ),
                 ],
@@ -4765,6 +4795,7 @@ class FeatureTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     final colorScheme = Theme.of(context).colorScheme;
 
     return MergeSemantics(
@@ -4777,7 +4808,7 @@ class FeatureTile extends StatelessWidget {
             elevation: 0,
             shape: RoundedRectangleBorder(
               borderRadius: _mainThemeControlRadius,
-              side: const BorderSide(color: EasySubwayAccessibleColors.line),
+              side: BorderSide(color: tokens.line),
             ),
             child: Padding(
               padding: const EdgeInsets.all(16),
@@ -4790,7 +4821,7 @@ class FeatureTile extends StatelessWidget {
                     child: Text(
                       title,
                       style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        color: EasySubwayAccessibleColors.text,
+                        color: tokens.ink,
                         fontWeight: FontWeight.w700,
                         height: 1.35,
                       ),

--- a/apps/mobile/lib/mobility_profile.dart
+++ b/apps/mobile/lib/mobility_profile.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'accessible_design.dart';
+import 'design_tokens.dart';
 
 const _mobilityProfilePagePadding = EdgeInsets.fromLTRB(20, 20, 20, 32);
 const _mobilityProfileCardRadius = BorderRadius.all(Radius.circular(16));
@@ -204,10 +205,11 @@ class _MobilityProfileCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
+    final tokens = EasySubwayTokens.of(context);
     final borderColor = selected
         ? colorScheme.primary
-        : EasySubwayAccessibleColors.line;
-    final backgroundColor = EasySubwayAccessibleColors.surface;
+        : tokens.line;
+    final backgroundColor = tokens.surface;
 
     return Padding(
       padding: const EdgeInsets.only(bottom: 12),
@@ -244,7 +246,7 @@ class _MobilityProfileCard extends StatelessWidget {
                               option.title,
                               style: Theme.of(context).textTheme.titleMedium
                                   ?.copyWith(
-                                    color: EasySubwayAccessibleColors.text,
+                                    color: tokens.ink,
                                     fontWeight: FontWeight.w700,
                                     height: 1.25,
                                   ),
@@ -254,7 +256,7 @@ class _MobilityProfileCard extends StatelessWidget {
                               option.summary,
                               style: Theme.of(context).textTheme.bodyLarge
                                   ?.copyWith(
-                                    color: EasySubwayAccessibleColors.mutedText,
+                                    color: tokens.inkMuted,
                                     fontWeight: FontWeight.w700,
                                     height: 1.3,
                                   ),

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -1415,13 +1415,14 @@ class _NetworkMapTopBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Material(
-      color: EasySubwayAccessibleColors.surface,
+      color: tokens.surface,
       elevation: 0,
       child: DecoratedBox(
-        decoration: const BoxDecoration(
+        decoration: BoxDecoration(
           border: Border(
-            bottom: BorderSide(color: EasySubwayAccessibleColors.line),
+            bottom: BorderSide(color: tokens.line),
           ),
         ),
         child: SafeArea(
@@ -1635,6 +1636,7 @@ class _NetworkMapRegionMenuOverlay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     final rows = <Widget>[];
     for (var i = 0; i < availableRegions.length; i++) {
       final region = availableRegions[i];
@@ -1676,9 +1678,9 @@ class _NetworkMapRegionMenuOverlay extends StatelessWidget {
                     ),
                     if (isSelected) ...[
                       const SizedBox(width: 12),
-                      const Icon(
+                      Icon(
                         Icons.check,
-                        color: EasySubwayAccessibleColors.mutedText,
+                        color: tokens.inkMuted,
                         size: 20,
                       ),
                     ],
@@ -1700,10 +1702,10 @@ class _NetworkMapRegionMenuOverlay extends StatelessWidget {
       child: IntrinsicWidth(
         child: Material(
           elevation: 0,
-          color: EasySubwayAccessibleColors.surface,
+          color: tokens.surface,
           surfaceTintColor: Colors.transparent,
           shape: RoundedRectangleBorder(
-            side: const BorderSide(color: EasySubwayAccessibleColors.line),
+            side: BorderSide(color: tokens.line),
             borderRadius: BorderRadius.only(
               topLeft: Radius.circular(EasySubwayRadius.control),
               bottomLeft: Radius.circular(EasySubwayRadius.control),
@@ -1723,14 +1725,15 @@ class _NetworkMapRegionMenuDivider extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     // full-width 절단형은 행을 과하게 분리해 보이게 하므로, 텍스트 시작선
     // (좌 16)부터 우 16 전까지의 인셋 구분선으로 둔다. 색·두께는 유지.
-    return const Padding(
-      key: Key('networkMapRegionMenuDivider'),
-      padding: EdgeInsets.symmetric(horizontal: 16),
+    return Padding(
+      key: const Key('networkMapRegionMenuDivider'),
+      padding: const EdgeInsets.symmetric(horizontal: 16),
       child: SizedBox(
         height: 1,
-        child: ColoredBox(color: EasySubwayAccessibleColors.line),
+        child: ColoredBox(color: tokens.line),
       ),
     );
   }
@@ -1743,6 +1746,7 @@ class _NetworkMapSearchField extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Semantics(
       button: true,
       label: '지하철역 검색',
@@ -1765,9 +1769,9 @@ class _NetworkMapSearchField extends StatelessWidget {
                     key: const Key('heroStationSearchButton'),
                     height: _searchFieldVisualHeight,
                     decoration: BoxDecoration(
-                      color: EasySubwayAccessibleColors.surface,
+                      color: tokens.surface,
                       border: Border.all(
-                        color: EasySubwayAccessibleColors.line,
+                        color: tokens.line,
                         width: _searchFieldBorderWidth,
                       ),
                       borderRadius: _networkMapSearchFieldRadius,
@@ -1839,6 +1843,7 @@ class _NetworkMapSearchInputField extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     final editController = controller;
     return SizedBox(
       // 터치 타겟(≥48, 실제로는 56)을 만족시키기 위해 필드 자체가 전체 높이를
@@ -1855,9 +1860,9 @@ class _NetworkMapSearchInputField extends StatelessWidget {
             key: const Key('heroStationSearchInputBox'),
             height: _searchFieldVisualHeight,
             decoration: BoxDecoration(
-              color: EasySubwayAccessibleColors.surface,
+              color: tokens.surface,
               border: Border.all(
-                color: EasySubwayAccessibleColors.line,
+                color: tokens.line,
                 width: _searchFieldBorderWidth,
               ),
               borderRadius: _networkMapSearchFieldRadius,
@@ -2147,8 +2152,9 @@ class _NetworkMapSearchSessionState extends State<_NetworkMapSearchSession> {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return ColoredBox(
-      color: EasySubwayAccessibleColors.scaffoldSurface,
+      color: tokens.scaffold,
       child: SafeArea(
         top: false,
         child: Semantics(
@@ -2204,13 +2210,14 @@ class _NetworkMapServicePatternToggle extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Material(
       key: const Key('networkMapServicePatternToggle'),
       color: Colors.white,
       elevation: 0,
-      shape: const RoundedRectangleBorder(
+      shape: RoundedRectangleBorder(
         borderRadius: _networkMapPillRadius,
-        side: BorderSide(color: EasySubwayAccessibleColors.line),
+        side: BorderSide(color: tokens.line),
       ),
       child: Container(
         height: 58,
@@ -2322,6 +2329,7 @@ class _NetworkMapNearbyStationPanel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     final primary = data.results.isEmpty ? null : data.results.first;
     final primaryLine = primary == null || primary.lines.isEmpty
         ? null
@@ -2363,10 +2371,10 @@ class _NetworkMapNearbyStationPanel extends StatelessWidget {
                             ),
                             borderRadius: BorderRadius.circular(3),
                           ),
-                          child: const Text(
+                          child: Text(
                             '실시간',
                             style: TextStyle(
-                              color: EasySubwayAccessibleColors.mint,
+                              color: tokens.good,
                               fontSize: 12,
                               fontWeight: FontWeight.w800,
                             ),
@@ -2467,6 +2475,7 @@ class _NetworkMapNearbySuccessList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     final primary = results.first;
     final leftName = adjacentStations.leftName;
     final rightName = adjacentStations.rightName;
@@ -2478,7 +2487,7 @@ class _NetworkMapNearbySuccessList extends StatelessWidget {
           child: Container(
             height: 26,
             decoration: BoxDecoration(
-              color: EasySubwayAccessibleColors.mapSelectionAccent,
+              color: tokens.mapSelectionAccent,
               borderRadius: BorderRadius.circular(13),
             ),
             child: Row(
@@ -2505,7 +2514,7 @@ class _NetworkMapNearbySuccessList extends StatelessWidget {
                     color: Colors.white,
                     borderRadius: BorderRadius.circular(24),
                     border: Border.all(
-                      color: EasySubwayAccessibleColors.mapSelectionAccent,
+                      color: tokens.mapSelectionAccent,
                       width: 3,
                     ),
                   ),
@@ -2614,6 +2623,7 @@ class _SubwayArrivalPanel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     switch (snapshot.status) {
       case RealtimeSnapshotStatus.loading:
         return const SizedBox(
@@ -2669,8 +2679,8 @@ class _SubwayArrivalPanel extends StatelessWidget {
                   snapshot.receivedAt.trim().isEmpty
                       ? '최근 도착 정보'
                       : '최근 도착 정보 · ${snapshot.receivedAt.trim()}',
-                  style: const TextStyle(
-                    color: EasySubwayAccessibleColors.mutedText,
+                  style: TextStyle(
+                    color: tokens.inkMuted,
                     fontSize: 12,
                     fontWeight: FontWeight.w600,
                   ),
@@ -2707,6 +2717,7 @@ class _SubwayArrivalNotice extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return SizedBox(
       height: 46,
       child: Center(
@@ -2715,8 +2726,8 @@ class _SubwayArrivalNotice extends StatelessWidget {
           textAlign: TextAlign.center,
           maxLines: 2,
           overflow: TextOverflow.ellipsis,
-          style: const TextStyle(
-            color: EasySubwayAccessibleColors.mutedText,
+          style: TextStyle(
+            color: tokens.inkMuted,
             fontSize: 13,
             height: 1.3,
             fontWeight: FontWeight.w600,
@@ -2734,6 +2745,7 @@ class _SubwayArrivalColumn extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     final visible = arrivals.take(2).toList(growable: false);
     final directionLabel = visible.isEmpty
         ? ''
@@ -2749,8 +2761,8 @@ class _SubwayArrivalColumn extends StatelessWidget {
               directionLabel,
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
-              style: const TextStyle(
-                color: EasySubwayAccessibleColors.primary,
+              style: TextStyle(
+                color: tokens.accent,
                 fontSize: 12,
                 fontWeight: FontWeight.w800,
               ),
@@ -2769,6 +2781,7 @@ class _SubwayArrivalRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     final destination = arrival.destination.trim();
     final eta = _formatArrivalEta(arrival);
     return Padding(
@@ -2792,8 +2805,8 @@ class _SubwayArrivalRow extends StatelessWidget {
               eta,
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
-              style: const TextStyle(
-                color: EasySubwayAccessibleColors.secondaryText,
+              style: TextStyle(
+                color: tokens.inkSecondary,
                 fontSize: 12,
                 height: 1.3,
                 fontWeight: FontWeight.w600,
@@ -2818,6 +2831,7 @@ class _NetworkMapToggleSegment extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return InkWell(
       onTap: onTap,
       borderRadius: _networkMapPillRadius,
@@ -2831,7 +2845,7 @@ class _NetworkMapToggleSegment extends StatelessWidget {
         alignment: Alignment.center,
         decoration: BoxDecoration(
           color: selected
-              ? EasySubwayAccessibleColors.mapRegionAccent
+              ? tokens.mapRegionAccent
               : Colors.transparent,
           borderRadius: _networkMapPillRadius,
         ),
@@ -3051,6 +3065,7 @@ class _NetworkMapMenuTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Semantics(
       button: true,
       label: label,
@@ -3070,7 +3085,7 @@ class _NetworkMapMenuTile extends StatelessWidget {
                   Icon(
                     icon,
                     size: 22,
-                    color: EasySubwayAccessibleColors.mutedText,
+                    color: tokens.inkMuted,
                   ),
                   const SizedBox(width: 18),
                   Expanded(
@@ -3397,6 +3412,7 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Container(
       key: const Key('networkMapSurface'),
       decoration: const BoxDecoration(color: Colors.white),
@@ -3547,7 +3563,7 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
                   geometry: geometry,
                   camera: camera,
                   label: '출발',
-                  surfaceColor: EasySubwayAccessibleColors.primary,
+                  surfaceColor: tokens.accent,
                   semanticSuffix: '출발 지정됨',
                 ),
               if (!_gestureActive && waypointStation != null)
@@ -3567,7 +3583,7 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
                   geometry: geometry,
                   camera: camera,
                   label: '도착',
-                  surfaceColor: EasySubwayAccessibleColors.primary,
+                  surfaceColor: tokens.accent,
                   semanticSuffix: '도착 지정됨',
                 ),
               if (!_gestureActive && selectedStation != null)
@@ -4924,6 +4940,7 @@ class _NetworkMapTopBarRouteDraft extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     final canSwap = draft.origin != null || draft.destination != null;
     // #1985: 현재 렌더 중인 행 슬롯 순서. 경유가 있으면 출발·경유·도착 3행.
     final visibleSlots = <RouteDraftSlot>[
@@ -4992,7 +5009,7 @@ class _NetworkMapTopBarRouteDraft extends StatelessWidget {
                 tooltip: '출발 도착 바꾸기',
                 onPressed: canSwap ? onSwapDraft : null,
                 icon: const Icon(Icons.swap_vert, size: 22),
-                color: EasySubwayAccessibleColors.mutedText,
+                color: tokens.inkMuted,
                 constraints: const BoxConstraints(minWidth: 48, minHeight: 48),
                 padding: EdgeInsets.zero,
               ),
@@ -5029,6 +5046,7 @@ class _NetworkMapRouteDraftAddWaypoint extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Semantics(
       button: true,
       label: '경유역 추가',
@@ -5041,22 +5059,22 @@ class _NetworkMapRouteDraftAddWaypoint extends StatelessWidget {
           child: Container(
             constraints: const BoxConstraints(minHeight: 48),
             decoration: BoxDecoration(
-              color: EasySubwayAccessibleColors.scaffoldSurface,
+              color: tokens.scaffold,
               borderRadius: BorderRadius.circular(8),
             ),
             padding: const EdgeInsets.symmetric(horizontal: 14),
             child: Row(
               children: [
-                const Icon(
+                Icon(
                   Icons.add,
                   size: 18,
-                  color: EasySubwayAccessibleColors.mutedText,
+                  color: tokens.inkMuted,
                 ),
                 const SizedBox(width: 8),
                 Text(
                   '경유 추가',
                   style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                    color: EasySubwayAccessibleColors.mutedText,
+                    color: tokens.inkMuted,
                     fontWeight: FontWeight.w700,
                   ),
                 ),
@@ -5130,6 +5148,7 @@ class _NetworkMapRouteDraftField extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     final label = _label;
     final filled = station != null;
     // #1985: 빈 행은 placeholder 문구('출발역'/'경유역'/'도착역')를 표시한다.
@@ -5149,9 +5168,7 @@ class _NetworkMapRouteDraftField extends StatelessWidget {
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
             style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-              color: filled
-                  ? EasySubwayAccessibleColors.text
-                  : EasySubwayAccessibleColors.mutedText,
+              color: filled ? tokens.ink : tokens.inkMuted,
             ),
           ),
         ),
@@ -5185,7 +5202,7 @@ class _NetworkMapRouteDraftField extends StatelessWidget {
     final rowContainer = Container(
       constraints: const BoxConstraints(minHeight: 54),
       decoration: BoxDecoration(
-        color: EasySubwayAccessibleColors.scaffoldSurface,
+        color: tokens.scaffold,
         borderRadius: BorderRadius.circular(8),
       ),
       child: Padding(
@@ -5255,7 +5272,7 @@ class _NetworkMapRouteDraftField extends StatelessWidget {
             child: Container(
               constraints: const BoxConstraints(minHeight: 54),
               decoration: BoxDecoration(
-                color: EasySubwayAccessibleColors.scaffoldSurface,
+                color: tokens.scaffold,
                 borderRadius: BorderRadius.circular(8),
               ),
               alignment: Alignment.centerLeft,
@@ -5265,7 +5282,7 @@ class _NetworkMapRouteDraftField extends StatelessWidget {
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
                 style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: EasySubwayAccessibleColors.text,
+                  color: tokens.ink,
                 ),
               ),
             ),
@@ -5529,15 +5546,16 @@ class _NetworkMapStationActionTab extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     // 팝오버 배경(0xE8404445)은 이미 짙은 무채색이라 primary(0xFF2A2F31) 같은
     // 어두운 잉크로 채우면 배경과 구분되지 않는다. 대비를 위해 강조 시에는
     // 흰 배경 + 짙은 잉크(text)로 반전한다.
     final iconColor = !enabled
-        ? EasySubwayAccessibleColors.mutedText
-        : (emphasized ? EasySubwayAccessibleColors.text : Colors.white);
+        ? tokens.inkMuted
+        : (emphasized ? tokens.ink : Colors.white);
     final textColor = !enabled
-        ? EasySubwayAccessibleColors.mutedText
-        : (emphasized ? EasySubwayAccessibleColors.text : Colors.white);
+        ? tokens.inkMuted
+        : (emphasized ? tokens.ink : Colors.white);
     final content = Column(
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
@@ -5571,7 +5589,7 @@ class _NetworkMapStationActionTab extends StatelessWidget {
                 margin: const EdgeInsets.symmetric(vertical: 5, horizontal: 4),
                 padding: const EdgeInsets.symmetric(horizontal: 2),
                 decoration: BoxDecoration(
-                  color: EasySubwayAccessibleColors.surface,
+                  color: tokens.surface,
                   borderRadius: BorderRadius.circular(4),
                 ),
                 child: content,

--- a/apps/mobile/lib/notification_settings.dart
+++ b/apps/mobile/lib/notification_settings.dart
@@ -5,7 +5,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-import 'accessible_design.dart';
+import 'design_tokens.dart';
 import 'auth_headers.dart';
 import 'mobile_error_reporter.dart';
 
@@ -888,6 +888,7 @@ class _NotificationSettingsMessage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     final shouldShowNextAction =
         _shouldShowNotificationRegistrationFailureNextAction(message);
 
@@ -903,7 +904,7 @@ class _NotificationSettingsMessage extends StatelessWidget {
             message,
             key: const Key('notificationSettingsMessage'),
             style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-              color: EasySubwayAccessibleColors.text,
+              color: tokens.ink,
               fontWeight: FontWeight.w700,
               height: 1.35,
             ),
@@ -920,7 +921,7 @@ class _NotificationSettingsMessage extends StatelessWidget {
             child: Text(
               _notificationRegistrationFailureNextAction,
               style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                color: EasySubwayAccessibleColors.mutedText,
+                color: tokens.inkMuted,
                 fontWeight: FontWeight.w700,
                 height: 1.35,
               ),
@@ -954,6 +955,7 @@ class _NotificationSwitchTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
+    final tokens = EasySubwayTokens.of(context);
 
     return Semantics(
       container: true,
@@ -971,7 +973,7 @@ class _NotificationSwitchTile extends StatelessWidget {
         title: Text(
           title,
           style: Theme.of(context).textTheme.titleMedium?.copyWith(
-            color: EasySubwayAccessibleColors.text,
+            color: tokens.ink,
             fontWeight: FontWeight.w700,
             height: 1.35,
           ),
@@ -991,22 +993,23 @@ class _NotificationSwitchGroup extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Material(
       color: Colors.white,
       clipBehavior: Clip.antiAlias,
-      shape: const RoundedRectangleBorder(
+      shape: RoundedRectangleBorder(
         borderRadius: _notificationSwitchTileRadius,
-        side: BorderSide(color: EasySubwayAccessibleColors.line),
+        side: BorderSide(color: tokens.line),
       ),
       child: Column(
         children: [
           for (var i = 0; i < tiles.length; i++) ...[
             if (i > 0)
-              const Divider(
+              Divider(
                 height: 1,
                 indent: 16,
                 endIndent: 16,
-                color: EasySubwayAccessibleColors.line,
+                color: tokens.line,
               ),
             tiles[i],
           ],
@@ -1042,6 +1045,7 @@ class _NotificationSettingsFailure extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return ListView(
       padding: _notificationSettingsFailurePadding,
       children: [
@@ -1051,7 +1055,7 @@ class _NotificationSettingsFailure extends StatelessWidget {
           child: Text(
             message,
             style: Theme.of(context).textTheme.titleMedium?.copyWith(
-              color: EasySubwayAccessibleColors.text,
+              color: tokens.ink,
               fontWeight: FontWeight.w700,
               height: 1.35,
             ),

--- a/apps/mobile/lib/notification_settings.dart
+++ b/apps/mobile/lib/notification_settings.dart
@@ -995,7 +995,7 @@ class _NotificationSwitchGroup extends StatelessWidget {
   Widget build(BuildContext context) {
     final tokens = EasySubwayTokens.of(context);
     return Material(
-      color: Colors.white,
+      color: tokens.surface,
       clipBehavior: Clip.antiAlias,
       shape: RoundedRectangleBorder(
         borderRadius: _notificationSwitchTileRadius,

--- a/apps/mobile/lib/onboarding.dart
+++ b/apps/mobile/lib/onboarding.dart
@@ -192,8 +192,9 @@ class StartScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Scaffold(
-      backgroundColor: EasySubwayAccessibleColors.surface,
+      backgroundColor: tokens.surface,
       body: SafeArea(
         child: LayoutBuilder(
           builder: (context, constraints) {
@@ -223,12 +224,12 @@ class StartScreen extends StatelessWidget {
                         const SizedBox(height: EasySubwaySpacing.xxl),
                         Semantics(
                           header: true,
-                          child: const Text(
+                          child: Text(
                             // 핵심 가치 한 줄. 부연 설명("먼저 안내해요") 삭제(#1936).
                             // 강조도 무채색 잉크로 통일(초록/민트 금지).
                             '빠른 길보다,\n갈 수 있는 길',
                             style: TextStyle(
-                              color: EasySubwayAccessibleColors.text,
+                              color: tokens.ink,
                               fontSize: 36,
                               fontWeight: FontWeight.w800,
                               height: 1.16,
@@ -242,10 +243,8 @@ class StartScreen extends StatelessWidget {
                             key: const Key('startScreenStartButton'),
                             onPressed: onStart,
                             style: FilledButton.styleFrom(
-                              backgroundColor:
-                                  EasySubwayAccessibleColors.primary,
-                              foregroundColor:
-                                  EasySubwayAccessibleColors.surface,
+                              backgroundColor: tokens.accent,
+                              foregroundColor: tokens.surface,
                               minimumSize: const Size.fromHeight(58),
                               shape: RoundedRectangleBorder(
                                 borderRadius: BorderRadius.circular(
@@ -280,6 +279,7 @@ class _BrandMark extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Semantics(
       label: '쉬운 지하철',
       image: true,
@@ -290,14 +290,14 @@ class _BrandMark extends StatelessWidget {
             CustomPaint(
               size: const Size(40, 40),
               painter: _RouteGlyphPainter(
-                color: EasySubwayAccessibleColors.text,
+                color: tokens.ink,
               ),
             ),
             const SizedBox(width: EasySubwaySpacing.md),
             Text(
               '쉬운 지하철',
               style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                color: EasySubwayAccessibleColors.text,
+                color: tokens.ink,
                 fontWeight: FontWeight.w700,
                 fontSize: 19,
                 letterSpacing: -0.2,
@@ -367,6 +367,7 @@ class _OnboardingStepDots extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return ExcludeSemantics(
       child: Row(
         children: [
@@ -375,8 +376,8 @@ class _OnboardingStepDots extends StatelessWidget {
               decoration: BoxDecoration(
                 shape: BoxShape.circle,
                 color: step <= currentStep
-                    ? EasySubwayAccessibleColors.primary
-                    : EasySubwayAccessibleColors.line,
+                    ? tokens.accent
+                    : tokens.line,
               ),
               child: const SizedBox(width: 7, height: 7),
             ),
@@ -411,6 +412,7 @@ class _PermissionInfoList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Column(
       children: [
         _PermissionInfoRow(
@@ -421,10 +423,10 @@ class _PermissionInfoList extends StatelessWidget {
           onChanged: onLocationChanged,
         ),
         if (notificationAvailable) ...[
-          const Divider(
+          Divider(
             height: 1,
             thickness: 1,
-            color: EasySubwayAccessibleColors.line,
+            color: tokens.line,
           ),
           _PermissionInfoRow(
             icon: Icons.notifications_none,
@@ -461,6 +463,7 @@ class _PermissionInfoRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
+    final tokens = EasySubwayTokens.of(context);
     return ConstrainedBox(
       constraints: const BoxConstraints(minHeight: 60),
       child: Padding(
@@ -468,7 +471,7 @@ class _PermissionInfoRow extends StatelessWidget {
         child: Row(
           children: [
             // 무채색 라인 아이콘 — 프로필 리스트와 같은 시각 리듬(색 없음).
-            Icon(icon, color: EasySubwayAccessibleColors.mutedText, size: 24),
+            Icon(icon, color: tokens.inkMuted, size: 24),
             const SizedBox(width: EasySubwaySpacing.lg),
             Expanded(
               child: Column(
@@ -478,7 +481,7 @@ class _PermissionInfoRow extends StatelessWidget {
                   Text(
                     title,
                     style: textTheme.bodyLarge?.copyWith(
-                      color: EasySubwayAccessibleColors.text,
+                      color: tokens.ink,
                       fontWeight: FontWeight.w700,
                       fontSize: 18,
                       height: 1.25,
@@ -488,7 +491,7 @@ class _PermissionInfoRow extends StatelessWidget {
                   Text(
                     subtitle,
                     style: textTheme.bodyMedium?.copyWith(
-                      color: EasySubwayAccessibleColors.mutedText,
+                      color: tokens.inkMuted,
                       fontWeight: FontWeight.w600,
                       height: 1.3,
                     ),
@@ -554,6 +557,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
   Widget build(BuildContext context) {
     final selectedProfile = _selectedProfile;
     final textTheme = Theme.of(context).textTheme;
+    final tokens = EasySubwayTokens.of(context);
     // 알림 기능 가용 여부의 단일 소스: 알림 권한 provider가 주입됐는지(#1579).
     // 더보기 알림 섹션(notificationRepository)과 함께 켜지고 꺼진다.
     final notificationAvailable = widget.notificationPermissionProvider != null;
@@ -597,8 +601,8 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                 key: const Key('onboardingDoneButton'),
                 onPressed: onNext,
                 style: FilledButton.styleFrom(
-                  backgroundColor: EasySubwayAccessibleColors.primary,
-                  foregroundColor: EasySubwayAccessibleColors.surface,
+                  backgroundColor: tokens.accent,
+                  foregroundColor: tokens.surface,
                   minimumSize: const Size.fromHeight(58),
                   shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(
@@ -628,7 +632,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                       // 질문 한 줄, 설명 문장 없음(#1936).
                       '어떻게 이동하세요?',
                       style: textTheme.titleLarge?.copyWith(
-                        color: EasySubwayAccessibleColors.text,
+                        color: tokens.ink,
                         fontWeight: FontWeight.w800,
                         fontSize: 26,
                         height: 1.2,
@@ -638,10 +642,10 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                   const SizedBox(height: EasySubwaySpacing.xl),
                   for (var i = 0; i < profileOptions.length; i++) ...[
                     if (i != 0)
-                      const Divider(
+                      Divider(
                         height: 1,
                         thickness: 1,
-                        color: EasySubwayAccessibleColors.line,
+                        color: tokens.line,
                       ),
                     _OnboardingProfileRow(
                       profile: profileOptions[i],
@@ -692,7 +696,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                                       : '위치는 나중에도 켤 수 있어요',
                                   // 프로필 질문과 같은 타이포 위계(titleLarge)로 통일(#1936 일관성).
                                   style: textTheme.titleLarge?.copyWith(
-                                    color: EasySubwayAccessibleColors.text,
+                                    color: tokens.ink,
                                     fontWeight: FontWeight.w800,
                                     fontSize: 26,
                                     height: 1.2,
@@ -726,8 +730,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                                   child: Text(
                                     _onboardingNotificationFailureNextAction,
                                     style: textTheme.bodyMedium?.copyWith(
-                                      color:
-                                          EasySubwayAccessibleColors.mutedText,
+                                      color: tokens.inkMuted,
                                       fontWeight: FontWeight.w700,
                                       height: 1.35,
                                     ),
@@ -747,10 +750,8 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                                     : null,
                                 style: FilledButton.styleFrom(
                                   // 시작·프로필 CTA와 같은 무채색 잉크 fill + 각진(≤8)로 통일.
-                                  backgroundColor:
-                                      EasySubwayAccessibleColors.primary,
-                                  foregroundColor:
-                                      EasySubwayAccessibleColors.surface,
+                                  backgroundColor: tokens.accent,
+                                  foregroundColor: tokens.surface,
                                   minimumSize: const Size.fromHeight(58),
                                   shape: RoundedRectangleBorder(
                                     borderRadius: BorderRadius.circular(
@@ -768,10 +769,9 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                                 onPressed: _completeOnboarding,
                                 style: OutlinedButton.styleFrom(
                                   // "나중에" skip — 무채색 잉크 텍스트 + 얇은 라인 테두리(각진).
-                                  foregroundColor:
-                                      EasySubwayAccessibleColors.text,
-                                  side: const BorderSide(
-                                    color: EasySubwayAccessibleColors.line,
+                                  foregroundColor: tokens.ink,
+                                  side: BorderSide(
+                                    color: tokens.line,
                                   ),
                                   minimumSize: const Size.fromHeight(58),
                                   shape: RoundedRectangleBorder(
@@ -909,6 +909,7 @@ class _OnboardingProfileRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
+    final tokens = EasySubwayTokens.of(context);
     return Semantics(
       label: profile.semanticsLabel(selected),
       selected: selected,
@@ -930,9 +931,7 @@ class _OnboardingProfileRow extends StatelessWidget {
                   Icon(
                     profile.icon,
                     size: 24,
-                    color: selected
-                        ? EasySubwayAccessibleColors.text
-                        : EasySubwayAccessibleColors.mutedText,
+                    color: selected ? tokens.ink : tokens.inkMuted,
                   ),
                   const SizedBox(width: EasySubwaySpacing.lg),
                   Expanded(
@@ -940,7 +939,7 @@ class _OnboardingProfileRow extends StatelessWidget {
                       // 라벨만 노출한다. 상세 요약은 홈 설정에서 확인(#1936).
                       profile.title,
                       style: textTheme.bodyLarge?.copyWith(
-                        color: EasySubwayAccessibleColors.text,
+                        color: tokens.ink,
                         fontWeight: selected
                             ? FontWeight.w700
                             : FontWeight.w600,
@@ -951,10 +950,10 @@ class _OnboardingProfileRow extends StatelessWidget {
                   ),
                   const SizedBox(width: EasySubwaySpacing.md),
                   if (selected)
-                    const Icon(
+                    Icon(
                       Icons.check,
                       size: 22,
-                      color: EasySubwayAccessibleColors.primary,
+                      color: tokens.accent,
                     )
                   else
                     const SizedBox(width: 22),

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -1813,6 +1813,7 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     final isNearbyEntry = widget.entryMode == StationSearchEntryMode.nearby;
     final showNearbyRetryButton = isNearbyEntry && !_hasSearchQuery;
     final searchInputField = TextField(
@@ -1843,7 +1844,7 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
               )
             : null,
         filled: true,
-        fillColor: EasySubwayAccessibleColors.scaffoldSurface,
+        fillColor: tokens.scaffold,
         border: OutlineInputBorder(
           borderRadius: _stationSearchInputRadius,
           borderSide: BorderSide.none,
@@ -1854,7 +1855,7 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
         ),
         focusedBorder: OutlineInputBorder(
           borderRadius: _stationSearchInputRadius,
-          borderSide: const BorderSide(color: EasySubwayAccessibleColors.line),
+          borderSide: BorderSide(color: tokens.line),
         ),
       ),
       onSubmitted: _submit,
@@ -1902,7 +1903,7 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
               return TextButton.icon(
                 key: const Key('nearbyStationSearchButton'),
                 style: TextButton.styleFrom(
-                  foregroundColor: EasySubwayAccessibleColors.text,
+                  foregroundColor: tokens.ink,
                   alignment: Alignment.centerLeft,
                   minimumSize: const Size.fromHeight(56),
                 ),
@@ -1918,7 +1919,7 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
             return TextButton.icon(
               key: const Key('nearbyStationSearchButton'),
               style: TextButton.styleFrom(
-                foregroundColor: EasySubwayAccessibleColors.text,
+                foregroundColor: tokens.ink,
                 alignment: Alignment.centerLeft,
                 minimumSize: const Size.fromHeight(56),
               ),
@@ -2184,6 +2185,7 @@ class StationRecentSearchSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Column(
       key: const Key('stationRecentSearchSection'),
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -2194,7 +2196,7 @@ class StationRecentSearchSection extends StatelessWidget {
               child: Text(
                 '최근 검색',
                 style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                  color: EasySubwayAccessibleColors.text,
+                  color: tokens.ink,
                   fontWeight: FontWeight.w700,
                   height: 1.25,
                 ),
@@ -2203,7 +2205,7 @@ class StationRecentSearchSection extends StatelessWidget {
             TextButton.icon(
               key: const Key('stationRecentSearchClearAllButton'),
               style: TextButton.styleFrom(
-                foregroundColor: EasySubwayAccessibleColors.mutedText,
+                foregroundColor: tokens.inkMuted,
               ),
               onPressed: enabled ? onClearAll : null,
               icon: const Icon(Icons.delete_sweep_outlined, size: 18),
@@ -2211,17 +2213,17 @@ class StationRecentSearchSection extends StatelessWidget {
             ),
           ],
         ),
-        const Divider(
+        Divider(
           height: EasySubwaySpacing.lg,
-          color: EasySubwayAccessibleColors.line,
+          color: tokens.line,
         ),
         Column(
           children: [
             for (final entry in queries.indexed) ...[
               if (entry.$1 > 0)
-                const Divider(
+                Divider(
                   height: 1,
-                  color: EasySubwayAccessibleColors.line,
+                  color: tokens.line,
                 ),
               _StationRecentSearchItem(
                 query: entry.$2,
@@ -2255,6 +2257,7 @@ class _StationRecentSearchItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return ConstrainedBox(
       constraints: const BoxConstraints(minHeight: 56),
       child: Row(
@@ -2288,7 +2291,7 @@ class _StationRecentSearchItem extends StatelessWidget {
                                 query,
                                 style: Theme.of(context).textTheme.titleMedium
                                     ?.copyWith(
-                                      color: EasySubwayAccessibleColors.text,
+                                      color: tokens.ink,
                                       fontWeight: FontWeight.w700,
                                       height: 1.25,
                                     ),
@@ -2481,14 +2484,15 @@ class _NearbyStationOverview extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     final stationName = _stationResultDisplayName(result.nameKo);
     return Card(
       margin: EdgeInsets.zero,
-      color: EasySubwayAccessibleColors.surface,
+      color: tokens.surface,
       elevation: 0,
       shape: RoundedRectangleBorder(
         borderRadius: _stationDetailFacilityCardRadius,
-        side: const BorderSide(color: EasySubwayAccessibleColors.line),
+        side: BorderSide(color: tokens.line),
       ),
       child: Column(
         children: [
@@ -2514,7 +2518,7 @@ class _NearbyStationOverview extends StatelessWidget {
                               '가장 가까운 역',
                               style: Theme.of(context).textTheme.bodyMedium
                                   ?.copyWith(
-                                    color: EasySubwayAccessibleColors.mutedText,
+                                    color: tokens.inkMuted,
                                     fontWeight: FontWeight.w700,
                                     height: 1.25,
                                   ),
@@ -2524,7 +2528,7 @@ class _NearbyStationOverview extends StatelessWidget {
                               stationName,
                               style: Theme.of(context).textTheme.headlineSmall
                                   ?.copyWith(
-                                    color: EasySubwayAccessibleColors.text,
+                                    color: tokens.ink,
                                     fontWeight: FontWeight.w700,
                                     height: 1.2,
                                   ),
@@ -2536,7 +2540,7 @@ class _NearbyStationOverview extends StatelessWidget {
                                   : '${result.distanceLabel} · ${result.lineLabel}',
                               style: Theme.of(context).textTheme.bodyLarge
                                   ?.copyWith(
-                                    color: EasySubwayAccessibleColors.mutedText,
+                                    color: tokens.inkMuted,
                                     fontWeight: FontWeight.w700,
                                     height: 1.3,
                                   ),
@@ -2582,6 +2586,7 @@ class _StationSearchFailureMessage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     final shouldShowLocationSettings =
         message == _currentLocationDisabledMessage;
     final shouldShowStationSearchNextAction =
@@ -2601,7 +2606,7 @@ class _StationSearchFailureMessage extends StatelessWidget {
             child: Text(
               _stationSearchFailureNextAction,
               style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                color: EasySubwayAccessibleColors.mutedText,
+                color: tokens.inkMuted,
                 fontWeight: FontWeight.w700,
                 height: 1.35,
               ),
@@ -2652,13 +2657,14 @@ class _StationSearchMessage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Semantics(
       container: true,
       liveRegion: liveRegion,
       child: Text(
         message,
         style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-          color: EasySubwayAccessibleColors.secondaryText,
+          color: tokens.inkSecondary,
           fontWeight: FontWeight.w700,
           height: 1.35,
         ),
@@ -2734,12 +2740,13 @@ class _StationSearchResultLineRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     final line = this.line;
     return DecoratedBox(
-      decoration: const BoxDecoration(
+      decoration: BoxDecoration(
         color: Colors.white,
         border: Border(
-          bottom: BorderSide(color: EasySubwayAccessibleColors.line),
+          bottom: BorderSide(color: tokens.line),
         ),
       ),
       child: MergeSemantics(
@@ -2765,8 +2772,8 @@ class _StationSearchResultLineRow extends StatelessWidget {
                       Expanded(
                         child: Text(
                           stationName,
-                          style: const TextStyle(
-                            color: EasySubwayAccessibleColors.text,
+                          style: TextStyle(
+                            color: tokens.ink,
                             fontSize: 17,
                             fontWeight: FontWeight.w600,
                             height: 1.2,
@@ -3345,6 +3352,7 @@ class _StationRealtimeSummary extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     final title = switch (snapshot.status) {
       RealtimeSnapshotStatus.fresh => '도착 정보',
       RealtimeSnapshotStatus.stale => '최근 도착 정보',
@@ -3376,7 +3384,7 @@ class _StationRealtimeSummary extends StatelessWidget {
         decoration: BoxDecoration(
           color: Colors.white,
           borderRadius: _stationDetailInfoCardRadius,
-          border: Border.all(color: EasySubwayAccessibleColors.line),
+          border: Border.all(color: tokens.line),
         ),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -3384,9 +3392,9 @@ class _StationRealtimeSummary extends StatelessWidget {
             Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                const Icon(
+                Icon(
                   Icons.schedule,
-                  color: EasySubwayAccessibleColors.primary,
+                  color: tokens.accent,
                   size: 28,
                 ),
                 const SizedBox(width: 10),
@@ -3394,7 +3402,7 @@ class _StationRealtimeSummary extends StatelessWidget {
                   child: Text(
                     title,
                     style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                      color: EasySubwayAccessibleColors.text,
+                      color: tokens.ink,
                       fontWeight: FontWeight.w700,
                       height: 1.25,
                     ),
@@ -3406,7 +3414,7 @@ class _StationRealtimeSummary extends StatelessWidget {
             Text(
               summary,
               style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                color: EasySubwayAccessibleColors.text,
+                color: tokens.ink,
                 height: 1.35,
                 fontWeight: FontWeight.w700,
               ),
@@ -3416,7 +3424,7 @@ class _StationRealtimeSummary extends StatelessWidget {
               Text(
                 updatedLabel,
                 style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: EasySubwayAccessibleColors.mutedText,
+                  color: tokens.inkMuted,
                   height: 1.3,
                 ),
               ),
@@ -3581,6 +3589,7 @@ class _StationPointButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     // 같은 성격 행동은 화면이 달라도 같은 패턴: 검색 결과의 _StationRoleButton과
     // 동일하게 아웃라인 아이콘 + 라벨, 단일 primary 계열.
     return OutlinedButton.icon(
@@ -3588,8 +3597,8 @@ class _StationPointButton extends StatelessWidget {
       style: OutlinedButton.styleFrom(
         minimumSize: const Size.fromHeight(EasySubwayTouchTarget.general),
         backgroundColor: Colors.white,
-        foregroundColor: EasySubwayAccessibleColors.primary,
-        side: const BorderSide(color: EasySubwayAccessibleColors.line),
+        foregroundColor: tokens.accent,
+        side: BorderSide(color: tokens.line),
         shape: const RoundedRectangleBorder(
           borderRadius: _stationDetailActionButtonRadius,
         ),
@@ -3651,25 +3660,26 @@ class _StationLayoutStep extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     // 상용 앱 리스트 밀도에 맞춰 세로 타일을 아이콘+텍스트 가로 행으로 낮춰
     // 높이를 줄인다(고정 minHeight 제거).
     return Container(
       width: width,
       padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
       decoration: BoxDecoration(
-        color: EasySubwayAccessibleColors.surface,
+        color: tokens.surface,
         borderRadius: _stationDetailInfoCardRadius,
-        border: Border.all(color: EasySubwayAccessibleColors.line),
+        border: Border.all(color: tokens.line),
       ),
       child: Row(
         children: [
-          Icon(item.icon, color: EasySubwayAccessibleColors.primary, size: 22),
+          Icon(item.icon, color: tokens.accent, size: 22),
           const SizedBox(width: 10),
           Expanded(
             child: Text(
               item.text,
               style: textTheme.bodyLarge?.copyWith(
-                color: EasySubwayAccessibleColors.text,
+                color: tokens.ink,
                 fontWeight: FontWeight.w700,
                 height: 1.2,
               ),
@@ -3692,6 +3702,7 @@ class _StationFacilityStatusSummary extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Semantics(
       label: semanticLabel,
       child: ExcludeSemantics(
@@ -3706,9 +3717,9 @@ class _StationFacilityStatusSummary extends StatelessWidget {
             padding: const EdgeInsets.all(14),
             child: Row(
               children: [
-                const Icon(
+                Icon(
                   Icons.warning_amber,
-                  color: EasySubwayAccessibleColors.red,
+                  color: tokens.danger,
                   size: 24,
                 ),
                 const SizedBox(width: 10),
@@ -3716,7 +3727,7 @@ class _StationFacilityStatusSummary extends StatelessWidget {
                   child: Text(
                     text,
                     style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                      color: EasySubwayAccessibleColors.red,
+                      color: tokens.danger,
                       fontWeight: FontWeight.w700,
                       height: 1.3,
                     ),
@@ -3738,6 +3749,7 @@ class _StationDetailHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     final textTheme = Theme.of(context).textTheme;
 
     return Semantics(
@@ -3758,7 +3770,7 @@ class _StationDetailHeader extends StatelessWidget {
                     Text(
                       '${detail.nameKo}역',
                       style: textTheme.headlineSmall?.copyWith(
-                        color: EasySubwayAccessibleColors.text,
+                        color: tokens.ink,
                         fontWeight: FontWeight.w700,
                         height: 1.2,
                       ),
@@ -3770,7 +3782,7 @@ class _StationDetailHeader extends StatelessWidget {
                       Text(
                         detail.nameSub,
                         style: textTheme.bodyMedium?.copyWith(
-                          color: EasySubwayAccessibleColors.secondaryText,
+                          color: tokens.inkSecondary,
                           fontWeight: FontWeight.w600,
                           height: 1.2,
                         ),
@@ -3780,7 +3792,7 @@ class _StationDetailHeader extends StatelessWidget {
                     Text(
                       detail.lineLabel,
                       style: textTheme.bodyLarge?.copyWith(
-                        color: EasySubwayAccessibleColors.secondaryText,
+                        color: tokens.inkSecondary,
                         fontWeight: FontWeight.w600,
                         height: 1.3,
                       ),
@@ -3792,10 +3804,10 @@ class _StationDetailHeader extends StatelessWidget {
               Column(
                 crossAxisAlignment: CrossAxisAlignment.end,
                 children: [
-                  const Text(
+                  Text(
                     '마지막 확인',
                     style: TextStyle(
-                      color: EasySubwayAccessibleColors.mutedText,
+                      color: tokens.inkMuted,
                       fontSize: 11,
                       fontWeight: FontWeight.w500,
                       height: 1.2,
@@ -3804,8 +3816,8 @@ class _StationDetailHeader extends StatelessWidget {
                   const SizedBox(height: 2),
                   Text(
                     stationVerifiedRelativeLabel(detail.lastVerifiedAt),
-                    style: const TextStyle(
-                      color: EasySubwayAccessibleColors.mutedText,
+                    style: TextStyle(
+                      color: tokens.inkMuted,
                       fontSize: 12,
                       fontWeight: FontWeight.w600,
                       height: 1.2,
@@ -3861,6 +3873,7 @@ class _StationInternalRouteResultCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Semantics(
       container: true,
       label: result.semanticLabel,
@@ -3868,9 +3881,9 @@ class _StationInternalRouteResultCard extends StatelessWidget {
         child: Container(
           padding: const EdgeInsets.all(16),
           decoration: BoxDecoration(
-            color: EasySubwayAccessibleColors.surface,
+            color: tokens.surface,
             borderRadius: _stationDetailInfoCardRadius,
-            border: Border.all(color: EasySubwayAccessibleColors.line),
+            border: Border.all(color: tokens.line),
           ),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -3883,7 +3896,7 @@ class _StationInternalRouteResultCard extends StatelessWidget {
               Text(
                 result.summaryLabel,
                 style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                  color: EasySubwayAccessibleColors.text,
+                  color: tokens.ink,
                   fontWeight: FontWeight.w700,
                   height: 1.25,
                 ),
@@ -3892,7 +3905,7 @@ class _StationInternalRouteResultCard extends StatelessWidget {
               Text(
                 result.totalBurdenLabel,
                 style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                  color: EasySubwayAccessibleColors.secondaryText,
+                  color: tokens.inkSecondary,
                   fontWeight: FontWeight.w700,
                   height: 1.3,
                 ),
@@ -3925,6 +3938,7 @@ class _StationInternalRouteStepTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Semantics(
       container: true,
       label: step.semanticLabel,
@@ -3937,7 +3951,7 @@ class _StationInternalRouteStepTile extends StatelessWidget {
               Text(
                 step.title,
                 style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                  color: EasySubwayAccessibleColors.text,
+                  color: tokens.ink,
                   fontWeight: FontWeight.w700,
                   height: 1.3,
                 ),
@@ -3946,7 +3960,7 @@ class _StationInternalRouteStepTile extends StatelessWidget {
               Text(
                 step.burdenLabel,
                 style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: EasySubwayAccessibleColors.secondaryText,
+                  color: tokens.inkSecondary,
                   fontWeight: FontWeight.w700,
                   height: 1.3,
                 ),
@@ -3955,7 +3969,7 @@ class _StationInternalRouteStepTile extends StatelessWidget {
               Text(
                 step.guidance,
                 style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: EasySubwayAccessibleColors.text,
+                  color: tokens.ink,
                   height: 1.35,
                 ),
               ),
@@ -3975,15 +3989,16 @@ class _StationDetailInfoRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Row(
       children: [
-        Icon(icon, size: 22, color: EasySubwayAccessibleColors.primary),
+        Icon(icon, size: 22, color: tokens.accent),
         const SizedBox(width: 8),
         Expanded(
           child: Text(
             text,
             style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-              color: EasySubwayAccessibleColors.secondaryText,
+              color: tokens.inkSecondary,
               fontWeight: FontWeight.w700,
               height: 1.3,
             ),
@@ -4008,6 +4023,7 @@ class _InfoBasisDisclosureState extends State<_InfoBasisDisclosure> {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     final labels = widget.labels
         .where((label) => label.trim().isNotEmpty)
         .toList(growable: false);
@@ -4032,9 +4048,9 @@ class _InfoBasisDisclosureState extends State<_InfoBasisDisclosure> {
             margin: EdgeInsets.zero,
             elevation: 0,
             color: Colors.white,
-            shape: const RoundedRectangleBorder(
+            shape: RoundedRectangleBorder(
               borderRadius: _stationDetailHelpCardRadius,
-              side: BorderSide(color: EasySubwayAccessibleColors.line),
+              side: BorderSide(color: tokens.line),
             ),
             child: Padding(
               padding: const EdgeInsets.all(14),
@@ -4044,7 +4060,7 @@ class _InfoBasisDisclosureState extends State<_InfoBasisDisclosure> {
                   Text(
                     '안내 확인 방법',
                     style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                      color: EasySubwayAccessibleColors.text,
+                      color: tokens.ink,
                       fontWeight: FontWeight.w700,
                     ),
                   ),
@@ -4053,7 +4069,7 @@ class _InfoBasisDisclosureState extends State<_InfoBasisDisclosure> {
                     Text(
                       label,
                       style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        color: EasySubwayAccessibleColors.mutedText,
+                        color: tokens.inkMuted,
                         fontWeight: FontWeight.w700,
                         height: 1.3,
                       ),
@@ -4077,12 +4093,13 @@ class _StationDetailSectionTitle extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Semantics(
       header: true,
       child: Text(
         title,
         style: Theme.of(context).textTheme.titleLarge?.copyWith(
-          color: EasySubwayAccessibleColors.text,
+          color: tokens.ink,
           fontWeight: FontWeight.w700,
           height: 1.25,
         ),
@@ -4098,10 +4115,11 @@ class _StationDetailEmptyMessage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     return Text(
       message,
       style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-        color: EasySubwayAccessibleColors.secondaryText,
+        color: tokens.inkSecondary,
         fontWeight: FontWeight.w700,
         height: 1.35,
       ),
@@ -4134,6 +4152,7 @@ class _StationExitCardState extends State<_StationExitCard> {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     final textTheme = Theme.of(context).textTheme;
     final station = widget.station;
     final exit = widget.exit;
@@ -4152,9 +4171,9 @@ class _StationExitCardState extends State<_StationExitCard> {
       margin: const EdgeInsets.only(bottom: 12),
       color: Colors.white,
       elevation: 0,
-      shape: const RoundedRectangleBorder(
+      shape: RoundedRectangleBorder(
         borderRadius: _stationDetailInfoCardRadius,
-        side: BorderSide(color: EasySubwayAccessibleColors.line),
+        side: BorderSide(color: tokens.line),
       ),
       child: Padding(
         padding: const EdgeInsets.all(16),
@@ -4171,7 +4190,7 @@ class _StationExitCardState extends State<_StationExitCard> {
                     Text(
                       exit.name,
                       style: textTheme.titleMedium?.copyWith(
-                        color: EasySubwayAccessibleColors.text,
+                        color: tokens.ink,
                         fontWeight: FontWeight.w700,
                         height: 1.25,
                       ),
@@ -4582,6 +4601,7 @@ class _StationFacilityCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     final textTheme = Theme.of(context).textTheme;
 
     return Semantics(
@@ -4594,9 +4614,9 @@ class _StationFacilityCard extends StatelessWidget {
         margin: const EdgeInsets.only(bottom: 12),
         color: Colors.white,
         elevation: 0,
-        shape: const RoundedRectangleBorder(
+        shape: RoundedRectangleBorder(
           borderRadius: _stationDetailFacilityCardRadius,
-          side: BorderSide(color: EasySubwayAccessibleColors.line),
+          side: BorderSide(color: tokens.line),
         ),
         child: InkWell(
           key: Key('stationFacilityCard-${facility.id}'),
@@ -4610,7 +4630,7 @@ class _StationFacilityCard extends StatelessWidget {
                 Text(
                   facility.name,
                   style: textTheme.titleMedium?.copyWith(
-                    color: EasySubwayAccessibleColors.text,
+                    color: tokens.ink,
                     fontWeight: FontWeight.w700,
                     height: 1.25,
                   ),
@@ -4659,9 +4679,9 @@ class _StationFacilityCard extends StatelessWidget {
                       ),
                     ),
                     const Spacer(),
-                    const Icon(
+                    Icon(
                       Icons.chevron_right,
-                      color: EasySubwayAccessibleColors.mutedText,
+                      color: tokens.inkMuted,
                     ),
                   ],
                 ),
@@ -4706,6 +4726,7 @@ class FacilityDetailScreen extends StatelessWidget {
     final statusIcon = _facilityStatusNoticeIcon(
       facility.statusPresentation.severity,
     );
+    final tokens = EasySubwayTokens.of(context);
     return Scaffold(
       appBar: AppBar(title: const Text('시설 상세')),
       body: SafeArea(
@@ -4719,7 +4740,7 @@ class FacilityDetailScreen extends StatelessWidget {
                 children: [
                   Icon(
                     facility.layoutSummaryIcon,
-                    color: EasySubwayAccessibleColors.primary,
+                    color: tokens.accent,
                     size: 28,
                   ),
                   const SizedBox(width: 12),
@@ -4731,7 +4752,7 @@ class FacilityDetailScreen extends StatelessWidget {
                           '${station.nameKo}역',
                           style: Theme.of(context).textTheme.bodyMedium
                               ?.copyWith(
-                                color: EasySubwayAccessibleColors.mutedText,
+                                color: tokens.inkMuted,
                                 fontWeight: FontWeight.w600,
                               ),
                         ),
@@ -4740,7 +4761,7 @@ class FacilityDetailScreen extends StatelessWidget {
                           facility.name,
                           style: Theme.of(context).textTheme.titleLarge
                               ?.copyWith(
-                                color: EasySubwayAccessibleColors.text,
+                                color: tokens.ink,
                                 fontWeight: FontWeight.w700,
                                 height: 1.2,
                               ),
@@ -4755,9 +4776,9 @@ class FacilityDetailScreen extends StatelessWidget {
             Container(
               key: Key('facilityDetailStatusNotice-${facility.id}'),
               decoration: BoxDecoration(
-                color: EasySubwayAccessibleColors.surface,
+                color: tokens.surface,
                 borderRadius: _stationDetailFacilityCardRadius,
-                border: Border.all(color: EasySubwayAccessibleColors.line),
+                border: Border.all(color: tokens.line),
               ),
               clipBehavior: Clip.antiAlias,
               child: IntrinsicHeight(
@@ -4797,8 +4818,7 @@ class FacilityDetailScreen extends StatelessWidget {
                                         .textTheme
                                         .bodyMedium
                                         ?.copyWith(
-                                          color: EasySubwayAccessibleColors
-                                              .mutedText,
+                                          color: tokens.inkMuted,
                                           fontWeight: FontWeight.w700,
                                           height: 1.3,
                                         ),
@@ -4810,8 +4830,7 @@ class FacilityDetailScreen extends StatelessWidget {
                                         .textTheme
                                         .bodyMedium
                                         ?.copyWith(
-                                          color: EasySubwayAccessibleColors
-                                              .mutedText,
+                                          color: tokens.inkMuted,
                                           fontWeight: FontWeight.w700,
                                           height: 1.3,
                                         ),
@@ -4834,9 +4853,9 @@ class FacilityDetailScreen extends StatelessWidget {
               margin: EdgeInsets.zero,
               color: Colors.white,
               elevation: 0,
-              shape: const RoundedRectangleBorder(
+              shape: RoundedRectangleBorder(
                 borderRadius: _stationDetailFacilityCardRadius,
-                side: BorderSide(color: EasySubwayAccessibleColors.line),
+                side: BorderSide(color: tokens.line),
               ),
               child: Padding(
                 padding: const EdgeInsets.all(16),
@@ -4939,9 +4958,8 @@ class _StationDetailStatusPill extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final color = positive
-        ? EasySubwayAccessibleColors.primary
-        : EasySubwayAccessibleColors.amber;
+    final tokens = EasySubwayTokens.of(context);
+    final color = positive ? tokens.accent : tokens.warn;
 
     return Row(
       children: [
@@ -4951,7 +4969,7 @@ class _StationDetailStatusPill extends StatelessWidget {
           child: Text(
             text,
             style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-              color: EasySubwayAccessibleColors.text,
+              color: tokens.ink,
               fontWeight: FontWeight.w700,
               height: 1.3,
             ),
@@ -4969,19 +4987,20 @@ class _StationDetailTextPill extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tokens = EasySubwayTokens.of(context);
     // 유형·품질 라벨은 상태 의미가 없으므로 틴트 필 대신 중립 아웃라인으로.
     return Container(
       decoration: BoxDecoration(
-        color: EasySubwayAccessibleColors.surface,
+        color: tokens.surface,
         borderRadius: _stationDetailInfoCardRadius,
-        border: Border.all(color: EasySubwayAccessibleColors.line),
+        border: Border.all(color: tokens.line),
       ),
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
         child: Text(
           text,
           style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-            color: EasySubwayAccessibleColors.secondaryText,
+            color: tokens.inkSecondary,
             fontWeight: FontWeight.w700,
             height: 1.2,
           ),

--- a/apps/mobile/test/design_guard_test.dart
+++ b/apps/mobile/test/design_guard_test.dart
@@ -382,7 +382,7 @@ void main() {
       // 의도 잔존: _searchFieldTextStyle(top-level const) — context 미가용
       // 보류 1건 포함 (#1917)
       'lib/network_map.dart': 11,
-      'lib/facility_report.dart': 2,
+      'lib/facility_report.dart': 1,
       'lib/onboarding.dart': 2,
       'lib/features/service_notice/presentation/service_notice_banner.dart': 1,
     }, rule: 'EasySubwayAccessibleColors 잔존 참조');

--- a/apps/mobile/test/design_guard_test.dart
+++ b/apps/mobile/test/design_guard_test.dart
@@ -330,6 +330,64 @@ void main() {
     }, rule: '블록(박스) Card');
   });
 
+  test('EasySubwayAccessibleColors 정적 팔레트 직접 참조 ratchet — 12개 대응 상수 (#1917)', () {
+    // #1917 다크 모드 1단계: 화면 코드는 정적 팔레트(EasySubwayAccessibleColors)를
+    // 직접 참조하지 않고 EasySubwayTokens.of(context)를 통해 참조해야 다크 테마
+    // 전환 시 값이 갈아끼워진다. 아래 12개 대응 상수는 원칙적으로 0건이 목표다.
+    // \b(단어 경계) 필수 — mintDark/amberSoft/redSoft/highContrastText/listRowText
+    // 등 치환 대상이 아닌 형제 상수가 오탐되지 않도록 한다.
+    // route_search.dart는 #1917 1단계 마이그레이션 대상 11개 파일에 포함되지
+    // 않아 이번 작업에서 손대지 않았다 — 후속 단계에서 별도로 마이그레이션한다.
+    // 상한은 내리기만 한다(기존 ratchet 관례).
+    final offenders = countPerFile(
+      RegExp(
+        r'EasySubwayAccessibleColors\.(?:text|secondaryText|mutedText|line|surface|scaffoldSurface|primary|mint|amber|red|mapSelectionAccent|mapRegionAccent)\b',
+      ),
+      exclude: {'accessible_design.dart', 'design_tokens.dart', 'route_search.dart'},
+    );
+    expectRatchet(offenders, {
+      // 의도 잔존(context 미가용 보류, #1917): _FacilitySeverityAccent(혼합 const
+      // 상수 객체, .red/.amber/.line)·_AppCard 기본 파라미터(.line)·_AppInfoRow
+      // const 트리(.mutedText/.primary) — 시그니처 전면 변경 없이는 안전하게
+      // 전환 불가.
+      'lib/main.dart': 10,
+      // 의도 잔존(context 미가용 보류, #1917): _facilityStatusNoticeIconColor —
+      // BuildContext를 받지 않는 top-level 함수(.red/.amber/.mint).
+      'lib/station_search.dart': 3,
+      // 의도 잔존(context 미가용 보류, #1917): _searchFieldTextStyle —
+      // top-level const(.mutedText), context 없음.
+      'lib/network_map.dart': 1,
+    }, rule: 'EasySubwayAccessibleColors 12개 대응 상수 직접 참조');
+  });
+
+  test('EasySubwayAccessibleColors 잔존 상수 ratchet — 나머지 정적 참조 축소 (#1917)', () {
+    // #1917 1단계에서 치환하지 않은 나머지 정적 팔레트 상수(highContrastText,
+    // brand, mintSoft, needsInfo, iconMuted, switchInactiveTrack/ActiveTrack,
+    // redSoft, listRowText, caption, amberSoft/Border, disclosure, cardShadow,
+    // skySoft 등)와, context 미가용으로 보류한 12개 대응 상수 사이트의 파일별
+    // 총량을 현재값으로 상한 고정한다. 상한은 내리기만 한다(기존 ratchet 관례).
+    // route_search.dart는 #1917 1단계 대상 파일이 아니라 이번 ratchet 범위에서
+    // 제외한다(위 하드밴 테스트와 동일 사유).
+    final actual = countPerFile(
+      RegExp(r'EasySubwayAccessibleColors\.'),
+      exclude: {'accessible_design.dart', 'design_tokens.dart', 'route_search.dart'},
+    );
+    expectRatchet(actual, {
+      // 의도 잔존: _FacilitySeverityAccent(혼합 const 상수 객체)·_AppCard 기본
+      // 파라미터·_AppInfoRow const 트리 — context 미가용 보류 10건 포함 (#1917)
+      'lib/main.dart': 33,
+      // 의도 잔존: _facilityStatusNoticeIconColor(context 없는 top-level 함수) —
+      // context 미가용 보류 3건 포함 (#1917)
+      'lib/station_search.dart': 8,
+      // 의도 잔존: _searchFieldTextStyle(top-level const) — context 미가용
+      // 보류 1건 포함 (#1917)
+      'lib/network_map.dart': 11,
+      'lib/facility_report.dart': 2,
+      'lib/onboarding.dart': 2,
+      'lib/features/service_notice/presentation/service_notice_banner.dart': 1,
+    }, rule: 'EasySubwayAccessibleColors 잔존 참조');
+  });
+
   test('탭 splash/highlight 하드 밴 — 리플 재유입 금지 (0건 유지)', () {
     // splashColor/highlightColor 가 Colors.transparent 가 아니거나,
     // InkSplash/InkRipple 팩토리를 명시하면 위반.


### PR DESCRIPTION
<!-- B/C등급(일반 코드 변경·낮은 위험 maintenance) 전용. A등급(제품/운영 위험, CI/계약 테스트/release gate 변경)은 full.md를 사용합니다. -->

## 관련 이슈

Refs #1917

## 작업 내용

- 다크 모드 1단계(#1928 기반의 잔여 마이그레이션): 화면 코드 11개 파일의 `EasySubwayAccessibleColors.*` 정적 팔레트 직접 참조 282건을 `EasySubwayTokens.of(context)` 기반으로 치환 (main.dart·station_search.dart·network_map.dart·facility_report.dart·onboarding.dart·service_notice 2파일·ad_slot·notification_settings·mobility_profile·station_line_badges).
- `EasySubwayTokens.light` 12개 필드가 정적 상수와 1:1 동일함이 `design_tokens_test.dart`로 보증되므로 **라이트 모드 시각 결과 무변화** (`themeMode`는 여전히 light 고정 — 다크 활성화는 후속 A급 PR).
- const 컨텍스트였던 `BorderSide`/`Divider`(line 색) 지점은 const를 해제하고 토큰 사용으로 전환.
- 값 치환 외 리팩토링 없음. `design_tokens.dart`/`accessible_design.dart`(정의 파일)는 미변경.
- **보류분을 ratchet으로 고정**: 토큰 대응이 없는 상수(highContrast*, brand, mintDark, needsInfo 등)와 context 미가용 helper/const 14곳은 그대로 두고, `design_guard_test.dart`에 재유입 방지 ratchet 2건을 추가해 잔존 수를 상한으로 고정 (12개 대응 상수 잔존: main 10·station_search 3·network_map 1 / 미대응 상수 총량 상한). 해당 지점의 context 관통은 다크 활성화 PR에서 처리.

## 검증

- 실행한 명령과 결과:
  - `flutter analyze`: No issues found
  - `flutter test`: 1122/1122 All tests passed (golden 포함 — 라이트 시각 무변화 확인, design_guard 신규 ratchet 2건 포함)
  - `node --test tools/ci/repository-contract.test.mjs`: 183/183 pass, fail 0
  - `git merge-tree origin/main HEAD`: 충돌 없음

## 영향

- [x] 제품/운영 위험 없음 (route/accessibility/mobile UX/backend API/auth/security 아님)
- [x] DB migration 없음
- [x] 배포 영향 없음
- [x] route/realtime/datapack contract 영향 없음
- [x] CI workflow·계약 테스트·release gate JSON 변경 없음 (있으면 full.md로 전환)

## 체크리스트

- [x] 이 PR은 B/C등급 작업이며 full template이 필요 없다.
- [ ] CI 결과를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 폴백 리뷰를 단일 PR review로 게시했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 모바일 앱 전반의 색상, 배경, 테두리, 아이콘 및 텍스트 스타일을 일관된 디자인 토큰 기반으로 개선했습니다.
  * 광고 영역, 온보딩, 알림, 역 검색·상세, 네트워크 지도, 설정, 즐겨찾기, 제보 화면 등의 시각적 일관성과 테마 대응을 강화했습니다.

* **테스트**
  * 기존 색상 팔레트의 직접 사용이 증가하지 않도록 디자인 가드 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->