### PR TITLE
[Fix] #1999 coverage gap 게이트 scope 인식 — 파일럿 게시 영구 차단 해소

### DIFF
--- a/.github/workflows/datapack-release.yml
+++ b/.github/workflows/datapack-release.yml
@@ -420,6 +420,13 @@ jobs:
             --provenance "${EASYSUBWAY_DATAPACK_OUTPUT}/current.provenance.json"
             --output "${EASYSUBWAY_COVERAGE_GAP_REPORT}"
           )
+          # release 모드(release-candidate/production-publish)는 게시 차단 판정을 게시 범위(production-datapack-scope.json의
+          # pilot region/operator × capitalPilotTargets.requiredSourceDomains) 내 gap만 대상으로 한다. 전국 gap은 전량
+          # 산출·evidence 기록(은폐 금지 — nationwide/in-scope 분리 수치). --allow-gaps 금지(release 모드)는 불변이며
+          # scope 내 gap은 여전히 하드 차단한다. exploratory 모드는 기존 nationwide 전량 평가 동작을 유지한다.
+          if [[ "${EASYSUBWAY_DATAPACK_RELEASE_MODE}" =~ ^(release-candidate|production-publish)$ ]]; then
+            coverage_args+=(--release-scope apps/mobile/release/production-datapack-scope.json)
+          fi
           if [[ "${EASYSUBWAY_DATAPACK_ALLOW_GAPS}" == "true" ]]; then
             coverage_args+=(--allow-gaps)
           fi

--- a/tools/ci/datapack-release-workflow.test.mjs
+++ b/tools/ci/datapack-release-workflow.test.mjs
@@ -59,6 +59,20 @@ test("production-publish는 release request 조회 스텝과 !cancelled() 콜백
   assert.doesNotMatch(yml, /steps\.evidence-bundle\.outputs\.manifestSha256/);
 });
 
+test("coverage gap 스텝은 release 모드에서만 release-scope 평가를 배선하고 --allow-gaps 금지를 유지한다", () => {
+  // release-scope 게이트는 게시 범위(pilot region/operator × capitalPilotTargets domains) 내 gap만 차단한다(#1999).
+  assert.match(yml, /--release-scope apps\/mobile\/release\/production-datapack-scope\.json/);
+  // release 모드에서만 --release-scope를 붙인다 — exploratory는 nationwide 전량 평가 유지.
+  assert.match(
+    yml,
+    /EASYSUBWAY_DATAPACK_RELEASE_MODE\}" =~ \^\(release-candidate\|production-publish\)\$ \]\]; then\s*\n\s*coverage_args\+=\(--release-scope/,
+  );
+  // 전국 gap 산출은 유지 — nationwide-coverage-targets.json을 계속 targets로 쓴다.
+  assert.match(yml, /--targets tools\/datapack\/nationwide-coverage-targets\.json/);
+  // release 모드 --allow-gaps 금지 로직은 불변이어야 한다.
+  assert.match(yml, /release mode cannot use --allow-gaps/);
+});
+
 test("워크플로는 rollout-update 모드·publish-rollout 스텝을 가지고 빌드 스텝을 pointer-only로 게이트한다", () => {
   assert.match(yml, /rollout-update/);
   assert.match(yml, /publish-rollout\.mjs/);

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -10695,6 +10695,34 @@ test("수도권 pilot production source input은 검증된 접근성 상태로 �
   );
   assert.equal(injectedGap.inReleaseScope, true);
   assert.equal(injectedGap.status, "missing");
+
+  // #2000: scope의 region/operator id가 pilot targets와 하나도 매칭되지 않으면 in-scope requirement가 0개가 되어
+  // missingRequirements === 0으로 공허 통과할 위험이 있다. fail closed — 존재하지 않는 regionId scope는 exit 1로 실패한다.
+  const emptyScope = JSON.parse(await readFile("apps/mobile/release/production-datapack-scope.json", "utf8"));
+  emptyScope.supportScope.regionIds = ["nonexistent-region"];
+  const emptyScopePath = path.join(outputDir, "empty-release-scope.json");
+  await writeFile(emptyScopePath, `${JSON.stringify(emptyScope, null, 2)}\n`);
+  const emptyScopeReportPath = path.join(outputDir, "empty-scope-coverage-gap-report.json");
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/report-coverage-gaps.mjs",
+        "--targets",
+        "tools/datapack/nationwide-coverage-targets.json",
+        "--inventory",
+        "tools/datapack/source-inventory.json",
+        "--provenance",
+        path.join(packOutputDir, "current.provenance.json"),
+        "--release-scope",
+        emptyScopePath,
+        "--output",
+        emptyScopeReportPath,
+      ],
+      { cwd: root },
+    ),
+    /release scope matched zero coverage requirements/,
+  );
 });
 
 test("관리자 검수 NORMAL override는 production 시설 provenance와 validator를 통과한다", async () => {

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -10604,6 +10604,97 @@ test("수도권 pilot production source input은 검증된 접근성 상태로 �
   );
   assert.equal(capitalRouteMapCoverage.status, "covered");
   assert.deepEqual(capitalRouteMapCoverage.missingFields, []);
+
+  // #1999: release-scope 평가 모드는 게시 차단을 게시 범위(capital·seoul-metro × capitalPilotTargets domains) 내 gap만
+  // 기준으로 판정한다. 현행 인벤토리는 전국 gap 다수 + scope 내 gap 0이므로, --allow-gaps 없이도 exit 0으로 통과하되
+  // 전국 gap 수치는 은폐 없이 그대로 기록해야 한다.
+  const releaseScopeReportPath = path.join(outputDir, "release-scope-coverage-gap-report.json");
+  await execFileAsync(
+    process.execPath,
+    [
+      "tools/datapack/report-coverage-gaps.mjs",
+      "--targets",
+      "tools/datapack/nationwide-coverage-targets.json",
+      "--inventory",
+      "tools/datapack/source-inventory.json",
+      "--provenance",
+      path.join(packOutputDir, "current.provenance.json"),
+      "--release-scope",
+      "apps/mobile/release/production-datapack-scope.json",
+      "--output",
+      releaseScopeReportPath,
+    ],
+    { cwd: root },
+  );
+  const releaseScopeReport = JSON.parse(await readFile(releaseScopeReportPath, "utf8"));
+  // 게시 범위(in-scope) gap은 0 → 게시 게이트 통과.
+  assert.equal(releaseScopeReport.summary.releaseScope.coverageComplete, true);
+  assert.equal(releaseScopeReport.summary.releaseScope.missingRequirements, 0);
+  assert.equal(releaseScopeReport.summary.releaseScope.scopeId, "capital_pilot_android_v1");
+  assert.deepEqual(releaseScopeReport.summary.releaseScope.regionIds, ["capital"]);
+  assert.deepEqual(releaseScopeReport.summary.releaseScope.operatorIds, ["seoul-metro"]);
+  assert.deepEqual(releaseScopeReport.summary.releaseScope.sourceDomains, [
+    "accessibility_facilities",
+    "schedule_timetable",
+    "station_line_membership",
+  ]);
+  // 전국 gap은 은폐 금지 — nationwide 수치가 그대로 기록되고 여전히 다수의 gap이 존재한다.
+  assert.ok(releaseScopeReport.summary.missingRequirements > 0);
+  assert.equal(
+    releaseScopeReport.summary.nationwide.missingRequirements,
+    releaseScopeReport.summary.missingRequirements,
+  );
+  // in-scope requirement는 정확히 3개(capital·seoul-metro × 3 pilot domain)로 태깅된다.
+  const inScopeRequirements = releaseScopeReport.releaseScopeRequirements;
+  assert.equal(inScopeRequirements.length, 3);
+  assert.ok(inScopeRequirements.every((entry) => entry.inReleaseScope === true));
+  assert.ok(inScopeRequirements.every((entry) => entry.status === "covered"));
+
+  // Negative 증명: 워크플로와 동일하게 provenance-backed 상태에서 scope 내 gap을 주입한다. 게시 pack의 provenance에서
+  // station_line_membership OFFICIAL 레코드를 제거하면 in-scope gap이 생겨 release-scope 게이트가 exit 1로 실패한다.
+  const scopeGapProvenance = JSON.parse(
+    await readFile(path.join(packOutputDir, "current.provenance.json"), "utf8"),
+  );
+  for (const pack of scopeGapProvenance.packs) {
+    pack.records = pack.records.filter(
+      (record) => !["line", "station_name", "station_code"].includes(record.field),
+    );
+  }
+  const scopeGapProvenancePath = path.join(outputDir, "scope-gap-provenance.json");
+  await writeFile(scopeGapProvenancePath, `${JSON.stringify(scopeGapProvenance, null, 2)}\n`);
+  const scopeGapReportPath = path.join(outputDir, "scope-gap-coverage-gap-report.json");
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/report-coverage-gaps.mjs",
+        "--targets",
+        "tools/datapack/nationwide-coverage-targets.json",
+        "--inventory",
+        "tools/datapack/source-inventory.json",
+        "--provenance",
+        scopeGapProvenancePath,
+        "--release-scope",
+        "apps/mobile/release/production-datapack-scope.json",
+        "--output",
+        scopeGapReportPath,
+      ],
+      { cwd: root },
+    ),
+    /in-scope coverage gaps remain/,
+  );
+  const scopeGapReport = JSON.parse(await readFile(scopeGapReportPath, "utf8"));
+  assert.ok(scopeGapReport.summary.releaseScope.missingRequirements > 0);
+  assert.equal(scopeGapReport.summary.releaseScope.coverageComplete, false);
+  // 주입한 station_line_membership gap이 in-scope requirement로 정확히 missing 처리된다.
+  const injectedGap = scopeGapReport.releaseScopeRequirements.find(
+    (entry) =>
+      entry.regionId === "capital" &&
+      entry.operatorId === "seoul-metro" &&
+      entry.sourceDomain === "station_line_membership",
+  );
+  assert.equal(injectedGap.inReleaseScope, true);
+  assert.equal(injectedGap.status, "missing");
 });
 
 test("관리자 검수 NORMAL override는 production 시설 provenance와 validator를 통과한다", async () => {

--- a/tools/datapack/report-coverage-gaps.mjs
+++ b/tools/datapack/report-coverage-gaps.mjs
@@ -2,30 +2,116 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 
+// 게시 범위(capital pilot)의 domain/field 계약 정본. --release-scope 평가는 이 targets로 in-scope gap을 판정한다.
+const DEFAULT_RELEASE_SCOPE_TARGETS = "tools/datapack/capital-pilot-coverage-targets.json";
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const targets = JSON.parse(await readFile(requireArg(args, "targets"), "utf8"));
   const inventory = JSON.parse(await readFile(requireArg(args, "inventory"), "utf8"));
   const provenance = args.provenance ? JSON.parse(await readFile(args.provenance, "utf8")) : null;
+  const releaseScope = args.releaseScope ? JSON.parse(await readFile(args.releaseScope, "utf8")) : null;
+  // 게시 범위 domain/field 계약은 capital pilot targets가 정본이다. --release-scope가 켜지면 pilot targets를 로드해
+  // scope 내 gap을 pilot field 계약으로 평가한다(전국 계약보다 좁은 pilot deferred domain·field가 반영됨).
+  const releaseScopeTargets = args.releaseScope
+    ? JSON.parse(await readFile(args.releaseTargets ?? DEFAULT_RELEASE_SCOPE_TARGETS, "utf8"))
+    : null;
   const outputPath = requireArg(args, "output");
-  const report = buildCoverageGapReport(targets, inventory, provenance);
+  const report = buildCoverageGapReport(targets, inventory, provenance, releaseScope, releaseScopeTargets);
 
   await mkdir(path.dirname(outputPath), { recursive: true });
   await writeFile(outputPath, `${JSON.stringify(report, null, 2)}\n`);
+
+  // release-scope 평가: 전국 gap은 전량 산출·기록하되 게시 차단 판정은 게시 범위(pilot region/operator ×
+  // capitalPilotTargets.requiredSourceDomains) 내 gap만 대상으로 한다. 전국 gap 은폐 금지 — summary에 양쪽 수치를 남긴다.
+  if (releaseScope) {
+    if (!args.allowGaps && report.summary.releaseScope.missingRequirements > 0) {
+      throw new Error(
+        `in-scope coverage gaps remain: ${report.summary.releaseScope.missingRequirements} missing requirements ` +
+          `(nationwide gaps recorded: ${report.summary.missingRequirements})`,
+      );
+    }
+    return;
+  }
 
   if (!args.allowGaps && !report.summary.coverageComplete) {
     throw new Error(`nationwide coverage gaps remain: ${report.summary.missingRequirements} missing requirements`);
   }
 }
 
-function buildCoverageGapReport(targets, inventory, provenance = null) {
+function buildCoverageGapReport(targets, inventory, provenance = null, releaseScope = null, releaseScopeTargets = null) {
   validateTargets(targets);
   const targetIndex = coverageTargetIndex(targets);
   validateInventory(inventory);
   const sources = inventory.sources.map((source) => normalizeSource(source, targetIndex));
   const provenanceIndex = provenance ? provenanceFieldIndex(provenance) : null;
-  const requirements = [];
 
+  // 전국 requirement는 nationwide targets 전량으로 산출한다(은폐 금지 — 전국 gap은 그대로 기록).
+  const requirements = evaluateRequirements(targets, sources, provenanceIndex);
+  const coveredRequirements = requirements.filter((entry) => entry.status === "covered").length;
+  const totalRequirements = requirements.length;
+  const missingRequirements = totalRequirements - coveredRequirements;
+  const summary = {
+    totalRequirements,
+    coveredRequirements,
+    missingRequirements,
+    coverageRatio: totalRequirements === 0 ? 0 : Number((coveredRequirements / totalRequirements).toFixed(4)),
+    coverageComplete: missingRequirements === 0,
+  };
+
+  const report = {
+    schemaVersion: 1,
+    artifactKind: "nationwide-coverage-gap-report",
+    targetVersion: targets.targetVersion,
+    inventoryRetrievedAt: inventory.retrievedAt,
+    candidate: provenanceIndex?.candidate ?? null,
+    summary,
+    requirements,
+  };
+
+  if (releaseScope) {
+    const scopeFilter = resolveReleaseScope(releaseScope);
+    // 게시 범위 gap은 pilot targets(capital-pilot-coverage-targets.json)의 domain/field 계약으로 별도 평가한다.
+    // pilot 계약은 전국 계약보다 좁다(예: accessibility_facilities에서 status 필드 제외, route_graph 등 deferred domain 제외).
+    const pilotTargets = releaseScopeTargets ?? targets;
+    validateTargets(pilotTargets);
+    const pilotTargetIndex = coverageTargetIndex(pilotTargets);
+    const pilotSources = inventory.sources.map((source) => normalizeSource(source, pilotTargetIndex));
+    const scopeRequirements = evaluateRequirements(pilotTargets, pilotSources, provenanceIndex).filter(
+      (entry) => scopeFilter.regionIds.has(entry.regionId) && scopeFilter.operatorIds.has(entry.operatorId),
+    );
+    for (const entry of scopeRequirements) {
+      entry.inReleaseScope = true;
+    }
+    const inScopeCovered = scopeRequirements.filter((entry) => entry.status === "covered").length;
+    const inScopeTotal = scopeRequirements.length;
+    const inScopeMissing = inScopeTotal - inScopeCovered;
+    // 전국 gap은 은폐 금지 — nationwide/in-scope 수치를 분리 기록한다. 게시 차단은 releaseScope.missingRequirements만 본다.
+    summary.nationwide = {
+      totalRequirements,
+      coveredRequirements,
+      missingRequirements,
+    };
+    summary.releaseScope = {
+      scopeId: scopeFilter.scopeId,
+      targetVersion: pilotTargets.targetVersion,
+      regionIds: [...scopeFilter.regionIds].sort(),
+      operatorIds: [...scopeFilter.operatorIds].sort(),
+      sourceDomains: [...new Set(scopeRequirements.map((entry) => entry.sourceDomain))].sort(),
+      totalRequirements: inScopeTotal,
+      coveredRequirements: inScopeCovered,
+      missingRequirements: inScopeMissing,
+      coverageRatio: inScopeTotal === 0 ? 0 : Number((inScopeCovered / inScopeTotal).toFixed(4)),
+      coverageComplete: inScopeMissing === 0,
+    };
+    report.releaseScopeRequirements = scopeRequirements;
+  }
+
+  return report;
+}
+
+function evaluateRequirements(targets, sources, provenanceIndex) {
+  const requirements = [];
   for (const region of targets.regions) {
     for (const operatorId of region.operatorIds) {
       for (const domain of targets.requiredSourceDomains) {
@@ -58,24 +144,27 @@ function buildCoverageGapReport(targets, inventory, provenance = null) {
       }
     }
   }
+  return requirements;
+}
 
-  const coveredRequirements = requirements.filter((entry) => entry.status === "covered").length;
-  const totalRequirements = requirements.length;
-  const missingRequirements = totalRequirements - coveredRequirements;
+function resolveReleaseScope(releaseScope) {
+  if (!releaseScope || typeof releaseScope !== "object" || Array.isArray(releaseScope)) {
+    throw new Error("release scope must be an object");
+  }
+  const supportScope = releaseScope.supportScope;
+  if (!supportScope || typeof supportScope !== "object" || Array.isArray(supportScope)) {
+    throw new Error("release scope supportScope must be an object");
+  }
+  const scopeId = requiredString(supportScope.id, "release scope supportScope.id");
+  const regionIds = requiredStringArray(supportScope.regionIds, "release scope supportScope.regionIds");
+  const operatorIds = requiredStringArray(
+    supportScope.includedOperatorIds,
+    "release scope supportScope.includedOperatorIds",
+  );
   return {
-    schemaVersion: 1,
-    artifactKind: "nationwide-coverage-gap-report",
-    targetVersion: targets.targetVersion,
-    inventoryRetrievedAt: inventory.retrievedAt,
-    candidate: provenanceIndex?.candidate ?? null,
-    summary: {
-      totalRequirements,
-      coveredRequirements,
-      missingRequirements,
-      coverageRatio: totalRequirements === 0 ? 0 : Number((coveredRequirements / totalRequirements).toFixed(4)),
-      coverageComplete: missingRequirements === 0,
-    },
-    requirements,
+    scopeId,
+    regionIds: new Set(regionIds),
+    operatorIds: new Set(operatorIds),
   };
 }
 
@@ -323,10 +412,10 @@ function parseArgs(argv) {
     if (!arg.startsWith("--")) {
       throw new Error(`unexpected argument: ${arg}`);
     }
-    const key = arg.slice(2);
+    const key = arg.slice(2).replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
     const value = argv[index + 1];
     if (!value || value.startsWith("--")) {
-      throw new Error(`missing value for --${key}`);
+      throw new Error(`missing value for --${arg.slice(2)}`);
     }
     args[key] = value;
     index += 1;

--- a/tools/datapack/report-coverage-gaps.mjs
+++ b/tools/datapack/report-coverage-gaps.mjs
@@ -25,6 +25,16 @@ async function main() {
   // release-scope 평가: 전국 gap은 전량 산출·기록하되 게시 차단 판정은 게시 범위(pilot region/operator ×
   // capitalPilotTargets.requiredSourceDomains) 내 gap만 대상으로 한다. 전국 gap 은폐 금지 — summary에 양쪽 수치를 남긴다.
   if (releaseScope) {
+    // scope의 region/operator id가 pilot targets와 하나도 매칭되지 않으면 in-scope requirement가 0개가 되어
+    // missingRequirements === 0으로 공허 통과(게이트 무력화)한다. fail closed — 0 매칭은 scope/targets id 불일치로 본다.
+    if (report.summary.releaseScope.totalRequirements === 0) {
+      throw new Error(
+        "release scope matched zero coverage requirements — scope/targets id 불일치 의심 " +
+          `(scopeId: ${report.summary.releaseScope.scopeId}, ` +
+          `regionIds: ${report.summary.releaseScope.regionIds.join(",") || "-"}, ` +
+          `operatorIds: ${report.summary.releaseScope.operatorIds.join(",") || "-"})`,
+      );
+    }
     if (!args.allowGaps && report.summary.releaseScope.missingRequirements > 0) {
       throw new Error(
         `in-scope coverage gaps remain: ${report.summary.releaseScope.missingRequirements} missing requirements ` +

--- a/tools/datapack/report-coverage-gaps.mjs
+++ b/tools/datapack/report-coverage-gaps.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { compareStrings } from "./lib/ledger-admission-cli.mjs";
 
 // 게시 범위(capital pilot)의 domain/field 계약 정본. --release-scope 평가는 이 targets로 in-scope gap을 판정한다.
 const DEFAULT_RELEASE_SCOPE_TARGETS = "tools/datapack/capital-pilot-coverage-targets.json";
@@ -105,9 +106,9 @@ function buildCoverageGapReport(targets, inventory, provenance = null, releaseSc
     summary.releaseScope = {
       scopeId: scopeFilter.scopeId,
       targetVersion: pilotTargets.targetVersion,
-      regionIds: [...scopeFilter.regionIds].sort(),
-      operatorIds: [...scopeFilter.operatorIds].sort(),
-      sourceDomains: [...new Set(scopeRequirements.map((entry) => entry.sourceDomain))].sort(),
+      regionIds: [...scopeFilter.regionIds].sort(compareStrings),
+      operatorIds: [...scopeFilter.operatorIds].sort(compareStrings),
+      sourceDomains: [...new Set(scopeRequirements.map((entry) => entry.sourceDomain))].sort(compareStrings),
       totalRequirements: inScopeTotal,
       coveredRequirements: inScopeCovered,
       missingRequirements: inScopeMissing,


### PR DESCRIPTION
## 관련 이슈

close #1999

Refs #1996 #1950

## 작업 배경

`datapack-release.yml`의 coverage gap evidence 단계가 `report-coverage-gaps.mjs`를 전국 target(`nationwide-coverage-targets.json`) 기준으로 실행하며, gap이 1건이라도 있으면 실패한다. 동시에 release 모드(release-candidate/production-publish)는 `--allow-gaps`를 금지한다.

- 첫 production-publish 실행이 `nationwide coverage gaps remain: 116 missing requirements`로 실패.
- 전국 116 gap은 결함이 아니라 설계된 현재 상태다 — 전국 지원 claim은 claimLedger에서 NO-GO로 별도 관리되고, 이번 게시 범위는 capital 파일럿(SCOPE_LOCKED)이다.
- 결과: 이대로면 전국 커버리지 100% 달성 전까지 어떤 production 게시도 불가능 — 파일럿 범위 게시와 전국 claim을 분리한 아키텍처(claimLedger)와 모순.

#1996 오너 승인 원칙 "게시와 claim의 분리"의 연장으로, 게시 차단 판정을 게시 범위 내 gap만 대상으로 인식하도록 수정한다.

## 작업 내용

- `tools/datapack/report-coverage-gaps.mjs`: `--release-scope <scope파일>` 평가 모드 추가.
  - **scope 판정 정의(in-scope)**: `production-datapack-scope.json`의 `supportScope.regionIds`(capital) × `supportScope.includedOperatorIds`(seoul-metro) 조합에, 게시 대상 domain/field 계약 정본인 `capital-pilot-coverage-targets.json`을 교차한 requirement만 in-scope다. pilot 계약은 전국 계약보다 좁다(예: accessibility_facilities에서 nationwide는 `status` 필드를 요구하지만 pilot 계약은 제외; route_graph_topology 등 deferred domain 제외).
  - 게시 차단 판정은 in-scope gap만 대상으로 한다. 전국 gap은 전량 산출·evidence 기록(은폐 금지) — `summary.nationwide`(전국 수치)와 `summary.releaseScope`(게시 범위 수치)를 분리 기록하고, in-scope requirement는 `releaseScopeRequirements`에 상세 첨부한다.
  - `--allow-gaps` 없이도 in-scope gap 0이면 exit 0, in-scope gap 존재 시 exit 1로 하드 차단.
- `.github/workflows/datapack-release.yml`: release 모드(release-candidate/production-publish)에서 coverage 단계가 `--release-scope apps/mobile/release/production-datapack-scope.json`를 사용하도록 배선. exploratory는 기존 nationwide 전량 평가 동작 유지, release 모드 `--allow-gaps` 금지 로직 불변.
- 계약 테스트:
  - `datapack-tools.test.mjs`: 현행 상태(전국 gap 116, scope 내 gap 0) → release-scope 게이트 통과 + nationwide/in-scope 양쪽 수치 기록. 워크플로와 동일하게 게시 pack provenance에서 station_line_membership OFFICIAL 레코드를 제거해 in-scope gap을 주입하면 exit 1로 실패.
  - `datapack-release-workflow.test.mjs`: release 모드에서만 `--release-scope` 배선, exploratory 유지, `--allow-gaps` 금지 로직 불변 계약.

### 전후 동작 비교

| 상황 | 이전(nationwide 전량) | 이후(release-scope) |
| --- | --- | --- |
| 현행 파일럿 상태(전국 gap 116, scope 내 0), release 모드 | exit 1 (게시 영구 차단) | exit 0 (게시 허용, 전국 116 gap은 evidence에 그대로 기록) |
| scope 내 gap 주입 | exit 1 | exit 1 (하드 차단 유지) |
| exploratory 모드 | exit 1 (전량 평가) | exit 1 (전량 평가 유지, 변화 없음) |

## 검증

- 실행한 명령과 결과:
  - `node --test tools/datapack/datapack-tools.test.mjs` → 233 pass / 0 fail
  - `node --test tools/ci/*.test.mjs` → 238 pass / 0 fail (repository-contract·datapack-release-workflow 포함)
  - 워크플로 coverage 단계 로직 로컬 재현(게시 pack 빌드 후 실제 provenance로 coverage 단계 실행):

```
=== 1) PASS: release-scope, 현행 inventory + production provenance (--allow-gaps 없이) ===
exit=0
summary.nationwide: {"totalRequirements":119,"coveredRequirements":3,"missingRequirements":116}
summary.releaseScope: {"scopeId":"capital_pilot_android_v1","targetVersion":"2026-06-29",
  "regionIds":["capital"],"operatorIds":["seoul-metro"],
  "sourceDomains":["accessibility_facilities","schedule_timetable","station_line_membership"],
  "totalRequirements":3,"coveredRequirements":3,"missingRequirements":0,
  "coverageRatio":1,"coverageComplete":true}

=== 2) FAIL(negative 증명): provenance에서 station_line_membership OFFICIAL 레코드 제거로 in-scope gap 주입 ===
in-scope coverage gaps remain: 1 missing requirements (nationwide gaps recorded: 117)
exit=1
```

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| coverage 게이트 scope 인식 | CI/datapack | `node --test tools/datapack/datapack-tools.test.mjs` | 233 pass | PASS |
| 워크플로 배선 계약 | CI | `node --test tools/ci/*.test.mjs` | 238 pass | PASS |
| negative 증명(scope 내 gap 주입 시 차단) | datapack | 위 로컬 재현 출력 | exit 1 | PASS |
| 전국 gap 은폐 없음 | datapack | summary.nationwide.missingRequirements=116 기록 | 위 출력 | PASS |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [x] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음 (게이트 로직만 수정, datapack 산출물 미변경)
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `report-coverage-gaps.mjs`의 `buildCoverageGapReport`에서 nationwide requirement는 nationwide targets 전량으로 산출하고, in-scope 평가는 `capital-pilot-coverage-targets.json`(pilot field 계약)으로 별도 산출해 scope 파일 region/operator로 필터한다. provenance가 있으면 coverage 판정이 provenance officialFieldScopes 기준이므로 negative 주입도 provenance에서 해야 한다는 점.

## 리스크

- release 모드 게이트가 게시 범위 gap만 차단하므로, 게시 범위 정의(scope 파일 region/operator × pilot targets domain/field)가 실제 지원 claim보다 넓어지면 미검증 범위가 게시될 위험. → 게시 범위는 SCOPE_LOCKED된 `production-datapack-scope.json`과 pilot 계약 정본에 고정되며, 전국 gap은 은폐 없이 evidence에 그대로 기록된다. 전국 claim NO-GO 게이트(claimLedger)는 불변.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 릴리스 범위에 해당하는 데이터팩 커버리지를 별도로 평가합니다.
  * 전국 단위 커버리지 현황과 릴리스 범위 내 현황을 구분해 리포트합니다.
  * 릴리스 범위 내 누락 항목이 있으면 릴리스를 차단합니다.

* **버그 수정**
  * 전국 단위 누락 항목이 릴리스 범위 평가에 잘못 반영되지 않도록 개선했습니다.

* **테스트**
  * 릴리스 및 탐색 모드의 커버리지 검증과 누락 항목 처리에 대한 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->