### PR TITLE
[Style] 콘솔 차트 JS 상태색을 admin 토큰 참조로 정합 — 하드코딩 잔여 제거

### DIFF
--- a/backend/src/main/resources/static/css/admin-tokens.css
+++ b/backend/src/main/resources/static/css/admin-tokens.css
@@ -21,6 +21,7 @@
 	--admin-good: #0a705a;
 	--admin-warn: #9a5600;
 	--admin-danger: #b42318;
+	--admin-chart-series: #2f6f9f; /* 차트 보조 시리즈색(상태 의미 없음) */
 
 	/* radius — 2단계 토큰(컨트롤/카드) */
 	--admin-radius-control: 8px;

--- a/backend/src/main/resources/static/js/admin/batch-history-charts.js
+++ b/backend/src/main/resources/static/js/admin/batch-history-charts.js
@@ -4,10 +4,22 @@
 // htmx 부분 갱신(자동 갱신 폴링)으로 새 canvas가 들어오면 afterSwap에서 다시 그린다.
 // Chart.js가 없거나 JSON이 없으면 조용히 넘어가고 details 안 데이터 표가 대체한다.
 (function () {
-	var COLORS = { COMPLETED: '#0f6b52', FAILED: '#b3402c', RUNNING: '#8a5a00' };
+	function tokenColor(name, fallback) {
+		if (typeof getComputedStyle !== 'function') {
+			return fallback;
+		}
+		var value = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+		return value || fallback;
+	}
+
+	var COLORS = {
+		COMPLETED: tokenColor('--admin-good', '#0a705a'),
+		FAILED: tokenColor('--admin-danger', '#b42318'),
+		RUNNING: tokenColor('--admin-warn', '#9a5600')
+	};
 
 	function barColor(status) {
-		return COLORS[status] || '#2f6f9f';
+		return COLORS[status] || tokenColor('--admin-chart-series', '#2f6f9f');
 	}
 
 	function renderChart(canvas) {

--- a/backend/src/main/resources/static/js/admin/dashboard-charts.js
+++ b/backend/src/main/resources/static/js/admin/dashboard-charts.js
@@ -3,7 +3,20 @@
 // 기간 버튼이 htmx로 #dashboard-trends를 부분 갱신하면 새 canvas가 들어오므로 afterSwap에서
 // 다시 그린다. Chart.js가 없거나 JSON이 없으면 조용히 넘어가고 details 안 데이터 표가 대체한다.
 (function () {
-	var PALETTE = ['#0f6b52', '#b3402c', '#2f6f9f', '#8a5a00'];
+	function tokenColor(name, fallback) {
+		if (typeof getComputedStyle !== 'function') {
+			return fallback;
+		}
+		var value = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+		return value || fallback;
+	}
+
+	var PALETTE = [
+		tokenColor('--admin-good', '#0a705a'),
+		tokenColor('--admin-danger', '#b42318'),
+		tokenColor('--admin-chart-series', '#2f6f9f'),
+		tokenColor('--admin-warn', '#9a5600')
+	];
 
 	function renderChart(canvas) {
 		if (!window.Chart) {

--- a/backend/src/main/resources/static/js/operator/report-charts.js
+++ b/backend/src/main/resources/static/js/operator/report-charts.js
@@ -1,6 +1,19 @@
 // Operator report charts read the adjacent fallback table, so no inline JSON is needed.
 (function () {
-	var COLORS = ['#0f6b52', '#b3402c', '#2f6f9f', '#8a5a00'];
+	function tokenColor(name, fallback) {
+		if (typeof getComputedStyle !== 'function') {
+			return fallback;
+		}
+		var value = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+		return value || fallback;
+	}
+
+	var COLORS = [
+		tokenColor('--admin-good', '#0a705a'),
+		tokenColor('--admin-danger', '#b42318'),
+		tokenColor('--admin-chart-series', '#2f6f9f'),
+		tokenColor('--admin-warn', '#9a5600')
+	];
 
 	function tableData(canvas) {
 		var tableId = canvas.getAttribute('data-operator-chart-table');


### PR DESCRIPTION
<!-- B/C등급(일반 코드 변경·낮은 위험 maintenance) 전용. A등급(제품/운영 위험, CI/계약 테스트/release gate 변경)은 full.md를 사용합니다. -->

## 관련 이슈

Refs #1925

## 작업 내용

- 콘솔 차트 JS 3파일(admin `dashboard-charts.js`·`batch-history-charts.js`, operator `report-charts.js`)이 #1927 콘솔 무채색 재정합 이전의 상태색을 하드코딩(`#0f6b52`/`#b3402c`/`#8a5a00`)한 채 남아 CSS 토큰(`--admin-good #0a705a`/`--admin-danger #b42318`/`--admin-warn #9a5600`)과 어긋나던 잔여 정합.
- **단일 원본화 + 정합**: 각 파일에 `tokenColor(name, fallback)` 헬퍼(getComputedStyle로 CSS 변수 읽기)를 추가하고 PALETTE/COLORS를 토큰 참조로 전환. 이에 따라 **상태색 3종의 실제 렌더값도 구 하드코딩 값에서 정본 토큰값으로 변경**된다(#1927 정합 취지의 의도된 변경). fallback 리터럴은 현재 정본 토큰값과 동일.
- 토큰 대응이 없던 차트 보조 시리즈색 `#2f6f9f`는 값 불변으로 `--admin-chart-series` 토큰으로 승격(admin-tokens.css 1줄 추가) 후 JS가 참조.
- 상태 의미 매핑: COMPLETED/성공→good, FAILED/실패→danger, RUNNING/대기→warn.

## 검증

- 실행한 명령과 결과:
  - `node --check` × 3파일: 통과
  - `node --test tools/ci/repository-contract.test.mjs`: 183/183 pass, fail 0
  - backend targeted gradle 테스트: BUILD SUCCESSFUL (콘솔 정적 리소스 관련)
  - `git merge-tree origin/main HEAD`: 충돌 없음

## 영향

- [x] 제품/운영 위험 없음 (route/accessibility/mobile UX/backend API/auth/security 아님 — 내부 콘솔 차트 표시색 정합)
- [x] DB migration 없음
- [x] 배포 영향 없음
- [x] route/realtime/datapack contract 영향 없음
- [x] CI workflow·계약 테스트·release gate JSON 변경 없음 (있으면 full.md로 전환)

## 체크리스트

- [x] 이 PR은 B/C등급 작업이며 full template이 필요 없다.
- [ ] CI 결과를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 폴백 리뷰를 단일 PR review로 게시했다.

