### PR TITLE
[CI] automerge 큐 — labeled 이벤트 PR 직접 합류로 라벨 인덱싱 레이스 정지 방지 (#2010)

### DIFF
--- a/.github/workflows/automerge-queue.yml
+++ b/.github/workflows/automerge-queue.yml
@@ -6,6 +6,7 @@ name: Automerge Queue
 # 병합이 일어나면 push 이벤트가 이 워크플로우를 다시 실행해 다음 PR을 처리한다.
 # 라벨은 merge-workflow 규약 4단계(코드리뷰 게이트) 완료 후에만 붙인다.
 # 코디네이터는 review 객체가 없는 PR을 큐에서 제외해 규약을 재검증한다.
+# labeled 이벤트의 라벨 검색 인덱싱 지연(빈 큐 오검출)은 이벤트 PR 직접 합류 + REST 재확인으로 보정한다 (#2010).
 
 on:
   push:
@@ -40,6 +41,8 @@ jobs:
           GH_TOKEN: ${{ secrets.AUTOMERGE_PAT != '' && secrets.AUTOMERGE_PAT || github.token }}
           HAS_PAT: ${{ secrets.AUTOMERGE_PAT != '' }}
           REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
         run: |
           set -euo pipefail
 
@@ -64,12 +67,33 @@ jobs:
           fi
           rm -f "${ruleset_err}"
 
-          queue=$(gh pr list --repo "${REPO}" --label automerge --base main --state open \
-            --json number,createdAt,isDraft \
-            --jq 'sort_by(.createdAt) | map(select(.isDraft | not)) | .[].number')
+          # search 인덱스 기반 조회 — labeled 이벤트 직후엔 인덱싱 지연으로 빈 결과가 날 수 있다(#2010).
+          search_candidates=$(gh pr list --repo "${REPO}" --label automerge --base main --state open \
+            --json number --jq '.[].number')
+
+          # 이벤트 PR을 무조건 후보에 합류시키고(라벨 인덱싱 지연 보정) search 결과와 union·중복 제거한다.
+          candidates=$(printf '%s\n%s\n' "${search_candidates}" "${EVENT_PR}" \
+            | grep -E '^[0-9]+$' | sort -un || true)
+
+          # 각 후보를 REST로 재확인해(search 인덱스 비의존) 라벨 실재·open·non-draft·base=main만 남기고,
+          # createdAt 오름차순(FIFO)으로 최종 큐를 만든다.
+          candidate_objs="[]"
+          for cand in ${candidates}; do
+            info=$(gh pr view "${cand}" --repo "${REPO}" \
+              --json number,createdAt,isDraft,state,baseRefName,labels 2>/dev/null) \
+              || { echo "::warning::PR #${cand} 조회 실패 — 후보에서 건너뛴다."; continue; }
+            candidate_objs=$(jq -c --argjson obj "${info}" '. + [$obj]' <<<"${candidate_objs}")
+          done
+
+          queue=$(jq -r '[.[]
+            | select(.state == "OPEN")
+            | select(.isDraft == false)
+            | select(.baseRefName == "main")
+            | select([.labels[].name] | index("automerge") != null)]
+            | sort_by(.createdAt) | .[].number' <<<"${candidate_objs}")
 
           if [ -z "${queue}" ]; then
-            echo "automerge 큐가 비어 있다."
+            echo "automerge 큐가 비어 있다. (trigger=${EVENT_NAME}, event_pr=${EVENT_PR:-없음})"
             exit 0
           fi
 

--- a/.github/workflows/automerge-queue.yml
+++ b/.github/workflows/automerge-queue.yml
@@ -69,7 +69,7 @@ jobs:
 
           # search 인덱스 기반 조회 — labeled 이벤트 직후엔 인덱싱 지연으로 빈 결과가 날 수 있다(#2010).
           search_candidates=$(gh pr list --repo "${REPO}" --label automerge --base main --state open \
-            --json number --jq '.[].number')
+            --json number --jq '.[].number' || true)
 
           # 이벤트 PR을 무조건 후보에 합류시키고(라벨 인덱싱 지연 보정) search 결과와 union·중복 제거한다.
           candidates=$(printf '%s\n%s\n' "${search_candidates}" "${EVENT_PR}" \


### PR DESCRIPTION
## 관련 이슈

close #2010

Refs #1925

## 작업 배경

- automerge 라벨을 부착해도 큐가 30분 schedule까지 정지하는 사례가 발생 (2026-07-12 PR #2007 실측). 이슈 본문의 초기 진단(AUTOMERGE_PAT 부재)은 로그 실측으로 정정됨 — secret은 설정돼 있었고(`HAS_PAT: true`), 실제 원인은 **`pull_request: labeled` 이벤트 직후 GitHub search 인덱싱 지연**으로 큐 조회(`gh pr list --label automerge`)가 빈 결과를 반환해 "큐가 비어 있다"로 success 종료하는 레이스 (run 29180593552).

## 작업 내용

- `.github/workflows/automerge-queue.yml` 큐 구성 로직 보강 (+28/−4, 최소 diff):
  - `pull_request` 이벤트 run에서는 이벤트 페이로드의 PR 번호(`EVENT_PR`)를 search 결과와 union·중복 제거해 후보에 직접 합류.
  - 각 후보를 REST(`gh pr view`)로 재확인 — `state=OPEN`·`isDraft=false`·`baseRefName=main`·`automerge` 라벨 실재를 만족하는 것만 채택 (search 인덱스 비의존).
  - FIFO(createdAt 오름차순) 정렬 유지 — 이벤트 PR이 무조건 head가 되지 않음.
  - 빈 큐 종료 시 트리거 종류·이벤트 PR 번호를 로그에 병기해 레이스/정상 빈 큐를 로그만으로 구분 가능.
- required checks 도출·derail·auto-merge 예약·BEHIND update-branch·권한·트리거·concurrency는 무변경.

## 검증

- 실행한 명령과 결과:
  - YAML 파싱(js-yaml): OK
  - 임베디드 스크립트 추출 후 `bash -n`: 통과
  - 큐 구성 로직 로컬 시뮬레이션 4케이스(push+search 정상 / labeled+search 빈 결과+이벤트 PR 합류 / 중복 제거 / REST 재확인 탈락): 전부 기대치 일치
  - `node --test tools/ci/repository-contract.test.mjs`: 183/183 pass (required_checks 트립와이어 보존 확인)
  - `git merge-tree origin/main HEAD`: 충돌 없음
  - actionlint: 러너 미설치로 생략 (YAML 파싱+bash 문법 검사로 대체)

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 실패 메커니즘 확정 | GitHub Actions | 실패 run 29180593552 로그("automerge 큐가 비어 있다")·성공 run 29181115276 로그 대조 | #2010 정정 코멘트에 타임스탬프 인용 | 확정 |
| 큐 구성 로직 정합 | 로컬 | gh 호출 mock 시뮬레이션 4케이스 | 일회성 시뮬레이션 (본문 검증 절 참조) | 통과 |
| 라이브 동작 | GitHub Actions | 이 PR 자체는 구(main) 워크플로로 병합되므로, 병합 후 다음 automerge PR의 labeled run 로그로 확인 예정 | 병합 후 후속 확인 | 예정 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 후보 union·REST 재확인 루프가 기존 derail/merge 로직에 넘기는 후보 형식(번호 목록·정렬)이 기존과 동일한지, `EVENT_PR` 미존재(schedule/push run)에서 무해한지.

## 리스크

- 후보 수만큼 `gh pr view` 호출 증가 — 큐 규모가 소수라 rate-limit 영향 미미, 조회 실패 후보는 warning 후 skip.
- `concurrency: automerge-queue`(cancel-in-progress: false)로 run 직렬화 유지 — 이벤트 PR 직접 합류로 인한 중복 처리 없음.
- 이 PR 자체의 병합은 구 워크플로가 처리하므로 동일 레이스가 재현될 수 있음 — 재현 시 #2010에 기록된 수동 해소 절차(라벨 재부착)로 처리.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음 — CI 워크플로만)
