### PR TITLE
[Style] 콘솔 tone-pending 배지 색 잔여를 정본 warn 값으로 정합

### DIFF
--- a/backend/src/main/resources/static/css/admin-v3.css
+++ b/backend/src/main/resources/static/css/admin-v3.css
@@ -1861,7 +1861,7 @@ body.admin-v3 {
 
 .admin-v3 .status-badge.tone-pending {
 	background: #fff2da;
-	color: #8a5a00;
+	color: #9a5600;
 }
 
 .admin-v3 .row-detail summary {


### PR DESCRIPTION
<!-- B/C등급(일반 코드 변경·낮은 위험 maintenance) 전용. A등급(제품/운영 위험, CI/계약 테스트/release gate 변경)은 full.md를 사용합니다. -->

## 관련 이슈

Refs #1869

## 작업 내용

- `admin-v3.css:1864` `.status-badge.tone-pending`의 색이 #1927 콘솔 재정합 이전의 구 warn 값(`#8a5a00`)으로 남아 있던 잔여를 정본값(`#9a5600`, admin-tokens.css `--admin-warn`)으로 교체 (#2012 리뷰에서 발견된 소품).
- 인접 배지 규칙(tone-ok/tone-failure)이 리터럴 hex 관례라 var() 대신 동일 관례의 리터럴로 교체.
- 구 팔레트 잔여 전수 재검(`#8a5a00`/`#b3402c`/`#0f6b52`/`#1f6b45`, admin·operator CSS): 이 1건 외 잔여 0. 참고: `.tone-ok #1f7a44`·`.tone-failure #b3261e`는 구 팔레트 목록에 없는 별개 음영이라 이번 범위에서 유지(변경 없음).

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/repository-contract.test.mjs`: 183/183 pass, fail 0
  - 구 팔레트 grep 재검: 잔여 0건
  - `git merge-tree origin/main HEAD`: 충돌 없음

## 영향

- [x] 제품/운영 위험 없음 (route/accessibility/mobile UX/backend API/auth/security 아님 — 내부 콘솔 배지 색 1건)
- [x] DB migration 없음
- [x] 배포 영향 없음
- [x] route/realtime/datapack contract 영향 없음
- [x] CI workflow·계약 테스트·release gate JSON 변경 없음 (있으면 full.md로 전환)

## 체크리스트

- [x] 이 PR은 B/C등급 작업이며 full template이 필요 없다.
- [ ] CI 결과를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 폴백 리뷰를 단일 PR review로 게시했다.
