### PR TITLE
[Fix] release-artifacts production RC job datapack audit env 미정의 수정 (#2021)

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -395,6 +395,14 @@ jobs:
             --dart-define=EASYSUBWAY_DATAPACK_CHANNEL="${EASYSUBWAY_DATAPACK_CHANNEL}" \
             --dart-define=EASYSUBWAY_ENABLE_PUSH_NOTIFICATIONS=false
 
+      - name: Android Production RC Artifact / Audit bundled datapacks
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/release-gate"
+          node tools/ci/audit-mobile-datapack-assets.mjs --index apps/mobile/assets/datapacks/index.json --root apps/mobile > "${RUNNER_TEMP}/release-gate/mobile-datapack-asset-audit.json"
+          echo "EASYSUBWAY_MOBILE_DATAPACK_ASSET_AUDIT=${RUNNER_TEMP}/release-gate/mobile-datapack-asset-audit.json" >> "${GITHUB_ENV}"
+
       - name: Android Production RC Artifact / Collect production metadata
         working-directory: apps/mobile
         shell: bash

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -2894,6 +2894,11 @@ test("모바일 signed release artifact gate와 광고 counter는 CI 산출물�
   assert.match(workflow, /EASYSUBWAY_ANDROID_UPLOAD_KEY_SHA256/);
   assert.match(workflow, /EASYSUBWAY_PLAY_APP_SIGNING_KEY_SHA256/);
   assert.match(workflow, /--require-android-rc-production/);
+  assert.match(
+    workflow,
+    /Android Production RC Artifact \/ Audit bundled datapacks[\s\S]*node tools\/ci\/audit-mobile-datapack-assets\.mjs --index apps\/mobile\/assets\/datapacks\/index\.json --root apps\/mobile > "\$\{RUNNER_TEMP\}\/release-gate\/mobile-datapack-asset-audit\.json"[\s\S]*EASYSUBWAY_MOBILE_DATAPACK_ASSET_AUDIT=\$\{RUNNER_TEMP\}\/release-gate\/mobile-datapack-asset-audit\.json[\s\S]*Android Production RC Artifact \/ Collect production metadata/,
+    "Production RC job must self-audit datapacks before consuming EASYSUBWAY_MOBILE_DATAPACK_ASSET_AUDIT (GITHUB_ENV does not cross job boundaries)",
+  );
   assert.match(workflow, /base64 --decode > "\$\{EASYSUBWAY_ANDROID_KEYSTORE_PATH\}"/);
   assert.match(workflow, /rm -f "\$\{RUNNER_TEMP\}\/easysubway-ci-release\.jks" "\$\{RUNNER_TEMP\}\/easysubway-upload-key\.jks" "\$\{RUNNER_TEMP\}\/easysubway-release\.env"/);
   assert.match(workflow, /gitSha=\$\{GITHUB_SHA\}/);


### PR DESCRIPTION
## 관련 이슈

close #2021

Refs #2011

## 작업 배경

- `.github/workflows/release-artifacts.yml`의 `Android Production RC Artifact` job "Collect production metadata" 단계가 `EASYSUBWAY_MOBILE_DATAPACK_ASSET_AUDIT` env를 참조한다.
- 이 env는 별도 job인 `Android Release Artifact`의 "Audit bundled datapacks" 단계가 `GITHUB_ENV`로 설정하는 값이다. `GITHUB_ENV`는 job 경계를 넘지 않는다.
- 첫 production-upload-key + internal dispatch(run 29190306772)에서 production RC job이 해당 env를 참조하다 `set -u`의 `EASYSUBWAY_MOBILE_DATAPACK_ASSET_AUDIT: unbound variable`로 실패했다. audit 단계 도입(843fe14a, #1938) 이후 production RC 경로가 처음 실행되며 드러난 결함이다.

## 작업 내용

- `Android Production RC Artifact` job에 동일한 "Audit bundled datapacks" 단계(mkdir → `audit-mobile-datapack-assets.mjs` → `GITHUB_ENV` 설정)를 "Collect production metadata"(cp 사용 지점) 이전에 추가해, audit gate를 production RC 경로에도 독립 재실행한다. 산출물 신뢰성 관점에서도 재실행이 옳다.
- `tools/ci/repository-contract.test.mjs`에 production RC audit 단계가 metadata 수집 이전에 존재하는지 검증하는 계약 assertion을 추가했다.
- 전수 점검: production RC job이 참조하는 나머지 env(`EASYSUBWAY_PRIVACY_POLICY_URL`, `EASYSUBWAY_DATA_PACK_BASE_URL`, `EASYSUBWAY_DATAPACK_SIGNING_*`, `EASYSUBWAY_DATAPACK_CHANNEL`, `EASYSUBWAY_PLAY_APP_SIGNING_KEY_SHA256`, `EASYSUBWAY_ANDROID_UPLOAD_KEY_SHA256` 등)는 모두 같은 job의 "Restore release environment"/"Restore production upload key" 단계가 `GITHUB_ENV`로 설정한다. 동일 유형의 cross-job env 참조 결함은 이 한 건뿐이다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/repository-contract.test.mjs` → tests 184, pass 184, fail 0
  - `node --test tools/ci/datapack-release-workflow.test.mjs` → tests 6, pass 6, fail 0
  - 새 계약 assertion을 origin/main(미수정) 워크플로에 대해 실행 → 의도대로 FAIL(non-vacuous 확인)
  - audit 단계 스크립트를 RUNNER_TEMP/GITHUB_ENV 모의로 로컬 재현 → audit json 생성, GITHUB_ENV 기록, `set -u`에서 변수 bound 확인(cp 성공 조건 충족)
  - `ruby -ryaml -e "YAML.load_file(...)"` → YAML OK (actionlint 미설치 환경)

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 워크플로 계약 테스트 | CI | `node --test tools/ci/repository-contract.test.mjs` | 로컬 실행 로그 pass 184/184 | 통과 |
| datapack release workflow 테스트 | CI | `node --test tools/ci/datapack-release-workflow.test.mjs` | 로컬 실행 로그 pass 6/6 | 통과 |
| audit 단계 스크립트 재현 | CI | RUNNER_TEMP/GITHUB_ENV 모의 후 스크립트 실행 | 로컬 재현 로그(var bound, 파일 존재) | 통과 |
| production RC dispatch 실경로 재실행 | Android | workflow_dispatch(production-upload-key+internal) | 병합 후 dispatch 필요(외부 secret/environment 승인 게이트) | 병합 후 확인 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `Android Production RC Artifact / Audit bundled datapacks` 단계가 `Collect production metadata`의 cp보다 앞에 위치하는지, 첫 job의 audit 단계(명령·index/root 인자·GITHUB_ENV 키)와 동일한지.
- production RC job의 다른 env는 모두 같은 job 내부에서 `GITHUB_ENV`로 설정됨을 확인했고, cross-job 참조 결함은 이 한 건뿐이다.

## 리스크

- 낮음. RC job에 build-only audit 단계 1개 추가로, 산출물·서명·업로드 로직 변경 없음. audit 명령 자체는 이미 첫 job에서 매 실행 통과 중인 검증된 스크립트다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
