### PR TITLE
[Chore] #1701 후보 endpoint 확정·KRIC 동선 live sample provenance 기입

### DIFF
--- a/.github/workflows/kric-source-candidate-evidence.yml
+++ b/.github/workflows/kric-source-candidate-evidence.yml
@@ -14,7 +14,6 @@ on:
           - kric-station-movement-standard
           - kric-station-movement-detailed
           - kric-transfer-movement-standard
-          - kric-transfer-movement-detailed
           - kric-station-convenience-standard
 
 jobs:

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -6554,7 +6554,7 @@ test("KRIC source 후보는 상세 근거 완료 상태와 production 분리를 
   );
 
   for (const candidate of kricCandidates) {
-    const hasValidatedSample = ["kric-station-info", "kric-subway-route-info"].includes(candidate.id);
+    const hasValidatedSample = ["kric-station-info", "kric-subway-route-info", "kric-transfer-movement-detailed"].includes(candidate.id);
     assert.equal(candidate.priority, "P0");
     assert.equal(candidate.licenseEvidenceStatus, "confirmed_attribution");
     assert.equal(
@@ -6902,7 +6902,7 @@ test("KRIC 환승 이동경로 후보는 상세 근거가 있어도 route graph 
 
   assert.ok(candidate);
   assert.equal(candidate.licenseEvidenceStatus, "confirmed_attribution");
-  assert.equal(candidate.sampleEvidenceStatus, "sample_url_documented_key_required");
+  assert.equal(candidate.sampleEvidenceStatus, "validated_live_sample");
   assert.equal(candidate.admissionStatus, "evidence_recorded_admin_review_required");
   assert.equal(candidate.automaticRouteGraphEdgeAllowed, false);
   assert.equal(candidate.evidence.detailPageUrl, candidate.detailUrl);
@@ -6924,6 +6924,25 @@ test("KRIC 환승 이동경로 후보는 상세 근거가 있어도 route graph 
     ],
   );
   assert.deepEqual(candidate.evidence.missingConfirmedEdgeFields.sort(), ["distanceMeters", "durationSeconds"]);
+  assert.equal(candidate.serviceKeyHandling, "offline_import_secret_only");
+  assert.equal(candidate.mobileEmbeddingAllowed, false);
+  assert.equal(candidate.evidence.liveSampleFormat, "xml");
+  assert.equal(candidate.evidence.liveSampleRowCount, 8);
+  assert.equal(candidate.evidence.liveSampleRawSha256, "93f75d6049655663ee0f14ca88347b9645781feaf5085cbf5a0013e4d7156a66");
+  assert.equal(candidate.evidence.liveSampleSchemaFingerprint, "47ec5fc575c71e57ae8dac56891097c3e3392103fc7b5b1c385e04518e9fa3f8");
+  assert.equal(candidate.evidence.liveSampleEvidenceHash, "055cda38e2a297d53f3fb7dd0a8c0a6069fd4517d33557bfdf97637728a22743");
+  assert.deepEqual(candidate.evidence.liveSampleFields.slice().sort(), candidate.evidence.outputFields.slice().sort());
+  assert.match(candidate.evidence.liveSampleNote, /2026-07-12.*29190984673 \(head 93afed60a027c215af80039a11e8ee58d8178088\).*credentialRedacted=true.*format=xml.*rowCount=8.*source candidate sample evidence valid/);
+  assert.deepEqual(candidate.evidence.missingConfirmedEdgeFields.slice().sort(), ["distanceMeters", "durationSeconds"]);
+  assert.deepEqual(candidate.evidence.missingEvidence.slice().sort(), [
+    "adminAdmissionEvidence",
+    "credentialFreeRawArchive",
+    "distanceDurationEdgeEvidence",
+    "licenseCommercialRedistributionEvidence",
+    "providerTermsOrQuotaApproval",
+    "rawObjectUri",
+  ]);
+  assert.match(candidate.nextAction, /29190984673/);
 });
 
 test("KRIC 출입구 승강장 이동경로 후보는 상세 근거가 있어도 route graph edge로 자동 승격하지 않는다", () => {
@@ -7017,6 +7036,10 @@ test("KRIC 환승 이동경로 표준 후보는 상세 페이지 라이선스와
     candidate.evidence.liveSampleNote,
     /2026-07-12.*29177451688 \(head 3c3567b524a14f39a0bbe20a774259b7ba405694\).*prevStinCd=132.*chtnNextStinCd=425.*HTTP 200.*application\/xml.*resultCode=03.*classification=no-data.*itemCount=0.*artifactCount=0.*sanitized sample artifact가 생성되지 않음/,
   );
+  assert.match(
+    candidate.evidence.liveSampleNote,
+    /2026-07-12.*29190982462 \(head 93afed60a027c215af80039a11e8ee58d8178088\).*prevStinCd=132.*chtnNextStinCd=425.*HTTP 200.*application\/xml.*resultCode=03.*classification=no-data.*itemCount=0.*artifactCount=0.*sanitized sample artifact가 생성되지 않음/,
+  );
   assert.match(candidate.evidence.liveSampleNote, /resultCode=03의 공식 의미 매핑은 공개 문서에서 확인되지 않음/);
   assert.match(candidate.evidence.liveSampleNote, /공식 상세 페이지 sample URL.*422\/424.*요청변수 표.*132\/425.*불일치/);
   assert.deepEqual(candidate.evidence.formats.sort(), ["JSON", "XML"]);
@@ -7043,6 +7066,50 @@ test("KRIC 환승 이동경로 표준 후보는 상세 페이지 라이선스와
   assert.match(candidate.nextAction, /distance and duration evidence/);
   assert.match(candidate.nextAction, /admin review/);
   assert.match(candidate.nextAction, /automatic route graph edge/);
+});
+
+test("data.go.kr 환승역거리 소요시간 후보는 확정된 odcloud endpoint를 고정한다", () => {
+  const candidates = readJson("tools/datapack/source-candidates.json");
+  const candidate = candidates.candidates.find(({ id }) => id === "seoul-metro-transfer-distance-duration");
+  assert.ok(candidate);
+  assert.equal(candidate.sampleEvidenceStatus, "sample_url_documented_key_required");
+  assert.equal(candidate.admissionStatus, "evidence_recorded_admin_review_required");
+  assert.equal(candidate.serviceKeyHandling, "offline_collection_secret_only");
+  assert.equal(candidate.requestUrl, "https://api.odcloud.kr/api/15044419/v1/uddi:7008c675-928f-41d6-9a01-b3541f78466b");
+  assert.equal(candidate.evidence.endpoint, candidate.requestUrl);
+  const sampleUrl = new URL(candidate.evidence.sampleUrl);
+  assert.equal(sampleUrl.origin + sampleUrl.pathname, candidate.evidence.endpoint);
+  const serviceKeyEntries = [...sampleUrl.searchParams.entries()].filter(([name]) => name.toLowerCase() === "servicekey");
+  assert.deepEqual(serviceKeyEntries, [["serviceKey", "[서비스키값]"]]);
+  assert.equal(sampleUrl.searchParams.get("returnType"), "JSON");
+  assert.deepEqual(candidate.evidence.formats.slice().sort(), ["CSV", "JSON", "XML"]);
+  assert.equal(candidate.evidence.missingEvidence.includes("endpointConfirmation"), false);
+  assert.deepEqual(candidate.evidence.missingEvidence, ["sampleResponse", "credentialFreeSnapshotHash", "adminAdmissionEvidence"]);
+});
+
+test("data.go.kr 빠른하차정보 후보는 확정된 operation path와 유추 파라미터를 구분해 고정한다", () => {
+  const candidates = readJson("tools/datapack/source-candidates.json");
+  const candidate = candidates.candidates.find(({ id }) => id === "seoul-metro-fast-exit-car-door");
+  assert.ok(candidate);
+  assert.equal(candidate.sampleEvidenceStatus, "sample_url_documented_key_required");
+  assert.equal(candidate.admissionStatus, "evidence_recorded_admin_review_required");
+  assert.equal(candidate.serviceKeyHandling, "offline_collection_secret_only");
+  assert.equal(candidate.requestUrl, "https://apis.data.go.kr/B553766/inout/getFstExit");
+  assert.equal(candidate.evidence.endpoint, candidate.requestUrl);
+  const sampleUrl = new URL(candidate.evidence.sampleUrl);
+  assert.equal(sampleUrl.origin + sampleUrl.pathname, candidate.evidence.endpoint);
+  const serviceKeyEntries = [...sampleUrl.searchParams.entries()].filter(([name]) => name.toLowerCase() === "servicekey");
+  assert.deepEqual(serviceKeyEntries, [["serviceKey", "[서비스키값]"]]);
+  assert.equal(sampleUrl.searchParams.get("dataType"), "JSON");
+  assert.deepEqual(candidate.evidence.outputFields.slice().sort(), [
+    "crtrYmd","drtnInfo","elvtrNo","facNo","facPstnNm","fwkPstnNm","lineNm",
+    "plfmCmgFac","qckgffMngNo","qckgffVhclDoorNo","stnCd","stnNm","stnNo","upbdnbSe",
+  ]);
+  assert.match(candidate.evidence.requestParamsProvenance, /getFstExit.*swagger에서 확정/);
+  assert.match(candidate.evidence.requestParamsProvenance, /유추/);
+  assert.equal(candidate.evidence.missingEvidence.includes("endpointConfirmation"), false);
+  assert.equal(candidate.evidence.missingEvidence.includes("outputFieldsConfirmation"), false);
+  assert.deepEqual(candidate.evidence.missingEvidence, ["sampleResponse", "requestParamsConfirmation", "credentialFreeSnapshotHash", "adminAdmissionEvidence"]);
 });
 
 test("KRIC 편의정보 표준 후보는 상세 페이지 라이선스와 출력변수 근거를 기록한다", () => {
@@ -13504,11 +13571,11 @@ test("KRIC source 후보 evidence workflow는 고정 allowlist와 sanitized arti
     "kric-station-movement-standard",
     "kric-station-movement-detailed",
     "kric-transfer-movement-standard",
-    "kric-transfer-movement-detailed",
     "kric-station-convenience-standard",
   ]);
   assert.ok(!candidateOptions.includes("kric-subway-route-info"));
   assert.ok(!candidateOptions.includes("kric-station-info"));
+  assert.ok(!candidateOptions.includes("kric-transfer-movement-detailed"));
   const sourceCandidates = readJson("tools/datapack/source-candidates.json").candidates;
   for (const candidateId of candidateOptions) {
     const candidate = sourceCandidates.find((entry) => entry.id === candidateId);

--- a/tools/datapack/collect-datago-source-candidate-evidence.mjs
+++ b/tools/datapack/collect-datago-source-candidate-evidence.mjs
@@ -68,7 +68,7 @@ export function resolveDatagoCandidateRequest(candidatesDocument, candidateId) {
     throw new Error(`${candidateId} sampleUrl must contain exactly one redacted serviceKey`);
   }
 
-  const formatParam = ["format", "dataType", "_type"]
+  const formatParam = ["format", "dataType", "_type", "returnType"]
     .map((name) => sampleUrl.searchParams.get(name))
     .find((value) => value !== null);
   const format = requiredText(formatParam, `${candidateId} sample format`).toLowerCase();

--- a/tools/datapack/collect-datago-source-candidate-evidence.test.mjs
+++ b/tools/datapack/collect-datago-source-candidate-evidence.test.mjs
@@ -130,6 +130,18 @@ test("Data.go.kr evidence collector는 dataType/_type 쿼리 파라미터도 sam
   );
 });
 
+test("Data.go.kr evidence collector는 odcloud returnType 쿼리 파라미터도 sample format으로 인식한다", () => {
+  const returnTypeCandidate = {
+    ...candidate,
+    evidence: {
+      ...candidate.evidence,
+      sampleUrl: candidate.evidence.sampleUrl.replace("format=json", "returnType=JSON"),
+    },
+  };
+  const request = resolveDatagoCandidateRequest({ candidates: [returnTypeCandidate] }, returnTypeCandidate.id);
+  assert.equal(request.format, "json");
+});
+
 test("Data.go.kr evidence collector는 endpoint 미확정 후보를 수집 전에 게이트한다", () => {
   // 실제 source-candidates.json 신규 2건 형태: evidence에 endpoint/sampleUrl 없음, 최상위 requestUrl 없음.
   const unconfirmed = {

--- a/tools/datapack/source-candidates.json
+++ b/tools/datapack/source-candidates.json
@@ -531,7 +531,7 @@
         "retrievedAt": "2026-06-23",
         "endpoint": "https://openapi.kric.go.kr/openapi/handicapped/transferMovement",
         "sampleUrl": "https://openapi.kric.go.kr/openapi/handicapped/transferMovement?serviceKey=[서비스키값]&format=xml&railOprIsttCd=S1&lnCd=3&stinCd=331&prevStinCd=132&chthTgtLn=4&chtnNextStinCd=425",
-        "liveSampleNote": "KRIC 공식 상세 페이지 sample URL tuple 422/424와 요청변수 표 tuple 132/425는 불일치한다. 132/425는 KRIC 공식 요청변수 표에서 가져온 미검증 tuple이었다. 2026-07-11 workflow run 29155976812 (head 3bbb27594a38ef26f04aad5c5c5f6a423fcf1b5f)은 기존 tuple prevStinCd=422, chtnNextStinCd=424로 HTTP 200, content type application/xml, resultCode=03, classification=no-data, itemCount=0을 확인했다. 이는 sampleResponse evidence가 아님. 2026-07-12 workflow run 29177451688 (head 3c3567b524a14f39a0bbe20a774259b7ba405694)은 요청변수 표 tuple prevStinCd=132, chtnNextStinCd=425로 HTTP 200, content type application/xml, resultCode=03, classification=no-data, itemCount=0, artifactCount=0을 확인했고 sanitized sample artifact가 생성되지 않음. resultCode=03의 공식 의미 매핑은 공개 문서에서 확인되지 않음.",
+        "liveSampleNote": "KRIC 공식 상세 페이지 sample URL tuple 422/424와 요청변수 표 tuple 132/425는 불일치한다. 132/425는 KRIC 공식 요청변수 표에서 가져온 미검증 tuple이었다. 2026-07-11 workflow run 29155976812 (head 3bbb27594a38ef26f04aad5c5c5f6a423fcf1b5f)은 기존 tuple prevStinCd=422, chtnNextStinCd=424로 HTTP 200, content type application/xml, resultCode=03, classification=no-data, itemCount=0을 확인했다. 이는 sampleResponse evidence가 아님. 2026-07-12 workflow run 29177451688 (head 3c3567b524a14f39a0bbe20a774259b7ba405694)은 요청변수 표 tuple prevStinCd=132, chtnNextStinCd=425로 HTTP 200, content type application/xml, resultCode=03, classification=no-data, itemCount=0, artifactCount=0을 확인했고 sanitized sample artifact가 생성되지 않음. 2026-07-12 workflow run 29190982462 (head 93afed60a027c215af80039a11e8ee58d8178088)은 요청변수 표 tuple prevStinCd=132, chtnNextStinCd=425로 HTTP 200, content type application/xml, resultCode=03, classification=no-data, itemCount=0, artifactCount=0을 확인했고 sanitized sample artifact가 생성되지 않음. resultCode=03의 공식 의미 매핑은 공개 문서에서 확인되지 않음.",
         "usePermissionRange": "저작권표시",
         "formats": [
           "JSON",
@@ -590,9 +590,11 @@
       "detailUrl": "https://data.kric.go.kr/rips/M_01_02/detail.do?id=307&operation=transferMovement&service=vulnerableUserInfo",
       "requestUrl": "https://openapi.kric.go.kr/openapi/vulnerableUserInfo/transferMovement",
       "licenseEvidenceStatus": "confirmed_attribution",
-      "sampleEvidenceStatus": "sample_url_documented_key_required",
+      "sampleEvidenceStatus": "validated_live_sample",
       "admissionStatus": "evidence_recorded_admin_review_required",
       "automaticRouteGraphEdgeAllowed": false,
+      "serviceKeyHandling": "offline_import_secret_only",
+      "mobileEmbeddingAllowed": false,
       "evidence": {
         "detailPageUrl": "https://data.kric.go.kr/rips/M_01_02/detail.do?id=307&operation=transferMovement&service=vulnerableUserInfo",
         "retrievedAt": "2026-06-23",
@@ -613,15 +615,37 @@
           "mvPathMgNo",
           "stMovePath"
         ],
+        "liveSampleRetrievedAt": "2026-07-12T00:00:00Z",
+        "liveSampleFormat": "xml",
+        "liveSampleRowCount": 8,
+        "liveSampleRawSha256": "93f75d6049655663ee0f14ca88347b9645781feaf5085cbf5a0013e4d7156a66",
+        "liveSampleSchemaFingerprint": "47ec5fc575c71e57ae8dac56891097c3e3392103fc7b5b1c385e04518e9fa3f8",
+        "liveSampleEvidenceHash": "055cda38e2a297d53f3fb7dd0a8c0a6069fd4517d33557bfdf97637728a22743",
+        "liveSampleFields": [
+          "chtnMvTpOrdr",
+          "edMovePath",
+          "elvtSttCd",
+          "elvtTpCd",
+          "imgPath",
+          "mvContDtl",
+          "mvPathMgNo",
+          "stMovePath"
+        ],
+        "liveSampleNote": "2026-07-12 workflow run 29190984673 (head 93afed60a027c215af80039a11e8ee58d8178088)은 backend-only secret 경로에서 credentialRedacted=true, format=xml, rowCount=8인 sanitized sample artifact를 생성했고 sample↔hashes 정합과 validator를 통과했다(source candidate sample evidence valid). raw/provider-record 독립 재계산은 수행하지 않음. raw response와 credential은 artifact 또는 mobile/offline pack에 포함하지 않음.",
         "missingConfirmedEdgeFields": [
           "distanceMeters",
           "durationSeconds"
         ],
         "missingEvidence": [
-          "sampleResponse"
+          "adminAdmissionEvidence",
+          "credentialFreeRawArchive",
+          "distanceDurationEdgeEvidence",
+          "licenseCommercialRedistributionEvidence",
+          "providerTermsOrQuotaApproval",
+          "rawObjectUri"
         ]
       },
-      "nextAction": "verify live sample response, image redistribution rights, and keep as admin review candidate until distance and duration evidence exists",
+      "nextAction": "live sample provenance 기록 완료(run 29190984673). credential-free raw archive와 approved object URI, owner admin review, commercial/redistribution license evidence, provider terms/quota approval, 그리고 distance·duration edge 근거를 확보하기 전까지 admin review 후보로 유지하고 route graph edge 자동 승격을 막는다",
       "capabilities": {
         "schedule": {
           "status": "UNSUPPORTED",
@@ -1863,6 +1887,7 @@
       "domain": "transfer_walk_duration",
       "displayName": "서울교통공사_환승역거리 소요시간",
       "detailUrl": "https://www.data.go.kr/data/15044419/fileData.do",
+      "requestUrl": "https://api.odcloud.kr/api/15044419/v1/uddi:7008c675-928f-41d6-9a01-b3541f78466b",
       "licenseEvidenceStatus": "confirmed_attribution",
       "sampleEvidenceStatus": "sample_url_documented_key_required",
       "admissionStatus": "evidence_recorded_admin_review_required",
@@ -1871,6 +1896,8 @@
       "evidence": {
         "detailPageUrl": "https://www.data.go.kr/data/15044419/fileData.do",
         "retrievedAt": "2026-07-12",
+        "endpoint": "https://api.odcloud.kr/api/15044419/v1/uddi:7008c675-928f-41d6-9a01-b3541f78466b",
+        "sampleUrl": "https://api.odcloud.kr/api/15044419/v1/uddi:7008c675-928f-41d6-9a01-b3541f78466b?serviceKey=[서비스키값]&page=1&perPage=10&returnType=JSON",
         "usePermissionRange": "이용허락범위 제한 없음",
         "formats": [
           "CSV",
@@ -1889,16 +1916,15 @@
           "환승소요시간은 일반인 보행속도 1.2 m/s 기준 산정(환승거리 단위 m, 환승소요시간 단위 초)",
           "outputFields는 CSV 원본 한국어 컬럼명이며 romanization은 미확정",
           "145개 환승역(2025-12-31 기준) 커버",
-          "파일데이터(CSV) 원본과 오픈 API(XML/JSON)로 제공되나 정확한 odcloud uddi endpoint는 미확정"
+          "파일데이터(CSV) 원본과 odcloud 오픈 API(JSON/XML)로 제공되며, 최신 버전 endpoint는 공개 OAS(namespace 15044419/v1)에서 확정한 uddi:7008c675-928f-41d6-9a01-b3541f78466b(_20251231)이다. odcloud 요청 파라미터는 page/perPage/returnType(기본 JSON)이며 인증은 serviceKey로 한다."
         ],
         "missingEvidence": [
           "sampleResponse",
-          "endpointConfirmation",
           "credentialFreeSnapshotHash",
           "adminAdmissionEvidence"
         ]
       },
-      "nextAction": "data.go.kr odcloud endpoint와 출력 필드를 확정하고, credential-free snapshot 해시와 admin admission 증거를 확보한 뒤 production inventory admission을 진행한다",
+      "nextAction": "odcloud endpoint(uddi:7008c675, _20251231)는 확정됨. credential-free snapshot 해시와 admin admission 증거를 확보한 뒤 production inventory admission을 진행한다",
       "capabilities": {
         "schedule": {
           "status": "UNSUPPORTED",
@@ -1931,6 +1957,7 @@
       "domain": "station_car_door_hints",
       "displayName": "서울교통공사_빠른하차정보",
       "detailUrl": "https://www.data.go.kr/data/15143840/openapi.do",
+      "requestUrl": "https://apis.data.go.kr/B553766/inout/getFstExit",
       "licenseEvidenceStatus": "confirmed_attribution",
       "sampleEvidenceStatus": "sample_url_documented_key_required",
       "admissionStatus": "evidence_recorded_admin_review_required",
@@ -1939,25 +1966,43 @@
       "evidence": {
         "detailPageUrl": "https://www.data.go.kr/data/15143840/openapi.do",
         "retrievedAt": "2026-07-12",
+        "endpoint": "https://apis.data.go.kr/B553766/inout/getFstExit",
+        "sampleUrl": "https://apis.data.go.kr/B553766/inout/getFstExit?serviceKey=[서비스키값]&pageNo=1&numOfRows=10&dataType=JSON",
         "usePermissionRange": "이용허락범위 제한 없음",
         "formats": [
           "JSON",
           "XML"
         ],
+        "outputFields": [
+          "crtrYmd",
+          "drtnInfo",
+          "elvtrNo",
+          "facNo",
+          "facPstnNm",
+          "fwkPstnNm",
+          "lineNm",
+          "plfmCmgFac",
+          "qckgffMngNo",
+          "qckgffVhclDoorNo",
+          "stnCd",
+          "stnNm",
+          "stnNo",
+          "upbdnbSe"
+        ],
+        "requestParamsProvenance": "operation path getFstExit는 공개 swagger에서 확정. 요청 파라미터(serviceKey/pageNo/numOfRows/dataType)는 swagger의 parameters가 비어 있어 확정 불가이며, 동일 기관 B553766 선례(probe-seoul-fare-api.mjs fare2)와 응답 body의 numOfRows/pageNo 필드로 유추한 표준 패턴이다. 확정은 live sample 수집 run에서 한다.",
         "coverageLimitations": [
           "하차역 기준 계단·엘리베이터 등 이동설비와 가장 가까운 열차 칸 출입문 위치를 조회하며, 하차칸(문) 번호와 연결된 이동설비 위치를 제공한다",
-          "정확한 API operation path와 output 필드명은 미확인(Swagger UI 비공개)",
+          "operation path getFstExit와 응답 item 14종 필드명은 공개 swagger에서 확정. 요청 파라미터는 swagger에 비어 있어 유추 기록이며 live sample 수집으로 확정한다.",
           "실시간 제공, 개발계정 트래픽 10,000회/월"
         ],
         "missingEvidence": [
           "sampleResponse",
-          "endpointConfirmation",
-          "outputFieldsConfirmation",
+          "requestParamsConfirmation",
           "credentialFreeSnapshotHash",
           "adminAdmissionEvidence"
         ]
       },
-      "nextAction": "data.go.kr API operation path와 output 필드명을 확정하고, credential-free snapshot 해시와 admin admission 증거를 확보한 뒤 production inventory admission을 진행한다",
+      "nextAction": "operation path getFstExit와 응답 필드는 확정됨. 유추한 요청 파라미터를 live sample 수집 run에서 확정하고, credential-free snapshot 해시와 admin admission 증거를 확보한 뒤 production inventory admission을 진행한다",
       "capabilities": {
         "schedule": {
           "status": "UNSUPPORTED",

--- a/tools/datapack/source-candidates.json
+++ b/tools/datapack/source-candidates.json
@@ -555,7 +555,7 @@
           "durationSeconds"
         ]
       },
-      "nextAction": "run the table-derived tuple and retain admin review with automatic route graph edge disabled until row-bearing evidence plus distance and duration evidence exists",
+      "nextAction": "the table-derived tuple (prevStinCd=132, chtnNextStinCd=425) has been executed twice (runs 29177451688, 29190982462) and repeatedly returned no-data (resultCode=03) with unconfirmed public documentation for that code; next step is provider inquiry or confirming an alternate access path, while retaining admin review with automatic route graph edge disabled until row-bearing evidence plus distance and duration evidence exists",
       "capabilities": {
         "schedule": {
           "status": "UNSUPPORTED",


### PR DESCRIPTION
## 관련 이슈

Refs #1701

이 PR은 #1701 작업 항목 2(live sample 수집·검증)·6(KRIC 동선 후보 동일 절차)의 evidence를 후보 대장에 기입하는 2단계다. #1701은 admission 승격·`station_car_door_hints` 스키마·importer·적재 검증이 남아 있어 닫지 않는다.

## 작업 배경

- PR #2020으로 등록한 data.go.kr 후보 2건은 정확한 endpoint가 미확정(missingEvidence)이라 수집기가 게이트해 live sample 수집이 불가능했다.
- 공공데이터포털의 공개 OAS(`infuser.odcloud.kr`, 무인증)와 데이터셋 페이지 인라인 swagger에서 endpoint·필드 원문을 실측 확정했다.
- KRIC transfer-movement 2건의 live sample 수집 run(main `93afed60`)이 완료됐다: detailed는 sanitized evidence 검증 통과, standard는 3번째 provider-side no-data(#2004와 동일 경계값).

## 작업 내용

- **`seoul-metro-transfer-distance-duration` (15044419) — endpoint 확정 기입**: 공개 OAS 실측으로 최신 버전(`_20251231`) odcloud REST endpoint `https://api.odcloud.kr/api/15044419/v1/uddi:7008c675-928f-41d6-9a01-b3541f78466b`를 `requestUrl`/`evidence.endpoint`/`evidence.sampleUrl`에 기입. 요청 파라미터 page/perPage/returnType, 응답 wrapper·모델 필드 6종(연번/호선/환승역명/환승노선/환승거리/환승소요시간) 원문 기록. `missingEvidence.endpointConfirmation` 해소. JSON REST 수집이 가능해져 CSV 파싱 미지원 게이트에 걸리지 않는다.
- **`seoul-metro-fast-exit-car-door` (15143840) — operation 확정·파라미터는 유추로 구분 기입**: 인라인 swagger 실측으로 `GET https://apis.data.go.kr/B553766/inout/getFstExit`와 응답 item 필드 14종 원문(qckgffVhclDoorNo 하차칸/문 번호, plfmCmgFac 정차위치별 출입설비 등) 기입. 요청 파라미터는 swagger에 미기재라 확정 불가 — B553766 동일 기관 선례 기반 유추임을 `requestParamsProvenance`에 구분 기록하고 `requestParamsConfirmation`을 missingEvidence로 유지(live sample run에서 확정).
- **`kric-transfer-movement-detailed` — `validated_live_sample` 승격**: run 29190984673(head `93afed60`) sanitized artifact의 rowCount 8·rawSha256·schemaFingerprint·evidenceHash·필드 8종을 그대로 옮겨 기입(PR #2009 패턴). admissionStatus는 admin review 전이므로 불변. 검증 완료에 따라 KRIC evidence 워크플로 candidate options에서 제거.
- **`kric-transfer-movement-standard` — 3차 no-data provenance 추가**: run 29190982462(head `93afed60`), HTTP 200 · `application/xml` · `resultCode=03` · `no-data` · itemCount=0 · artifactCount=0 — PR #2004의 append 패턴 그대로 `liveSampleNote`에 기록. `resultCode=03` 의미는 추정 기입하지 않는다. 상태 불변.
- **수집기 format 파라미터 인식에 `returnType` 추가** (`collect-datago-source-candidate-evidence.mjs`): odcloud 계열의 응답 포맷 파라미터 원문. 기존 `format`→`dataType`→`_type` 우선순위 뒤에 추가, 대소문자 무시·supportedFormats 대조·미지원 포맷 에러 동작 불변. 회귀 테스트 추가.
- **`tools/ci/repository-contract.test.mjs`**: 신규 run 2건 provenance·datago 후보 endpoint 기재·워크플로 options 변경을 ordered/run-scoped assertion으로 고정(#1994·#2004 패턴).

## 검증

- 실행한 명령과 결과:
  - `node --test tools/datapack/*.test.mjs` → 397 pass, 0 fail
  - `node --test tools/ci/repository-contract.test.mjs` → 186 pass, 0 fail
  - `source-candidates.json` JSON 파싱 정상
  - detailed 후보 evidence 값은 run 29190984673 artifact 파일에서 그대로 전사(손 계산 없음), `validate-source-candidate-sample` 결과 "evidence valid"

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 15044419 endpoint·필드 실측 | 공공데이터포털 공개 OAS | `https://infuser.odcloud.kr/oas/docs?namespace=15044419/v1` (무인증) | OAS paths에 `_20251231` uddi·모델 필드 6종 원문 | 확정 |
| 15143840 operation·응답 필드 실측 | 공공데이터포털 | 데이터셋 페이지 인라인 swagger | `B553766/inout/getFstExit`·item 필드 14종 원문 | 확정 (요청 파라미터는 유추로 구분 기재) |
| KRIC detailed live sample | GitHub Actions | [run 29190984673](https://github.com/AquilaXk/easysubway/actions/runs/29190984673) sanitized artifact | rowCount 8, evidence valid, 필드 8종 후보 기록과 일치 | PASS |
| KRIC standard no-data 경계값 | GitHub Actions | [run 29190982462](https://github.com/AquilaXk/easysubway/actions/runs/29190982462) | HTTP 200 · resultCode=03 · no-data · itemCount=0 | provenance만 기록; sampleResponse 미확보 |
| contract regression | Node.js | 전체 스위트 재실행 | 397/186 pass, 0 fail | PASS |
| UI·접근성·수동 QA | — | 후보 대장·contract test·수집기 파라미터 인식만 변경, 사용자 UI·runtime 무변경 | — | 추가 증거 불필요 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [x] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

datapack admission 후보 대장·수집기·contract test만 변경하며 데이터팩 아티팩트나 버전은 변경하지 않는다. 실제 적재·버전 영향은 후속 admission 승격·적재 PR에서 발생한다.

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [ ] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [ ] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음 (후보 대장 evidence 기입만)
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - detailed 후보의 live sample 필드(rowCount·해시 3종)가 run 29190984673 artifact 원문과 일치하는지 — 손 전사 오류가 유일한 실질 리스크다.
  - 15143840 요청 파라미터가 확정이 아니라 유추로 구분 기재됐는지(`requestParamsProvenance` + missingEvidence 유지) — 위조 금지 원칙.
  - standard 후보 3차 no-data 기록이 #2004 append 패턴·기존 2개 run 기록과 정합인지.
  - `automaticRouteGraphEdgeAllowed: false`와 `missingConfirmedEdgeFields`(distanceMeters/durationSeconds)가 detailed 승격 후에도 유지되는지 — KRIC은 시간 공급원이 아니라는 #1701 설계 원칙.

## 리스크

- 15143840 요청 파라미터가 유추와 다르면 live sample run이 실패할 수 있다 — 수집기의 sanitized 진단(경계값 로그)으로 원인 확인 후 파라미터만 교정하면 된다(엔드포인트·필드는 확정).
- 15044419는 두 버전 uddi가 공존한다 — 최신(`_20251231`)을 채택했고 구버전은 기입하지 않았다. 공사 측이 새 버전을 올리면 uddi가 또 바뀔 수 있어 수집 시점 검증이 필요하다(수집기 endpoint 대조 게이트가 이를 잡는다).

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **변경 사항**
  - 후보 선택 목록에서 `kric-transfer-movement-detailed` 항목이 제거되었습니다.
  - ODCloud 데이터 요청의 `returnType` 값이 JSON/XML 응답 형식 판별에 반영됩니다.
  - KRIC 및 서울교통공사 데이터 후보의 샘플 검증 상태와 출처 정보가 최신화되었습니다.
  - 일부 데이터 후보에 API 엔드포인트, 요청 형식, 응답 필드 및 샘플 수집 관련 근거가 보강되었습니다.

- **검증**
  - 새로운 응답 형식 판별 및 후보 선택 유효성 검사가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->