### PR TITLE
[Chore] 모바일 버전 1.0.3+10004로 bump — Play 업로드 차단 해소

### DIFF
--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.2+10002
+version: 1.0.3+10004
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
## 관련 이슈

Refs #2011

## 작업 배경

Play internal 업로드(run 29192116940)가 `versionCode 10002 is not greater than current Play max 10003`으로 실패했다. 현재 `apps/mobile/pubspec.yaml`은 `1.0.2+10002`이며, Play Console에는 이미 versionCode 10003 artifact가 선행 업로드되어 있다. 업로드를 재개하려면 versionCode를 Play 최대치보다 크게 올려야 한다.

## 작업 내용

- `apps/mobile/pubspec.yaml`: `version: 1.0.2+10002` → `1.0.3+10004`
  - versionCode를 10004로 올려 Play 최대치(10003)를 초과하도록 단조 증가.
  - 5권역 자작 노선 도식 반입이 반영된 의미 있는 릴리즈이므로 versionName을 patch 상향(1.0.2 → 1.0.3).

### 앵커 전수 탐색 결과

release gate JSON 전반과 repository-contract 테스트에서 versionCode/versionName 앵커를 grep으로 전수 확인했다.

- **갱신하지 않음** — `play-production-access-gate.json`·`abuse-penetration-rehearsal-gate.json`·`release-governance-gate.json`의 `latestVersionCodeEnv`/`tracksMaxVersionCode`/`uploadedInternalVersionCode`(값 10001)는 2026-06-29 API 재점검 시점의 관측 스냅샷(historical evidence)이다. repository-contract 테스트(2134·2143행)가 이 값을 10001로 고정하므로, 현재 버전 계약이 아니라 검증 시점 기록이다. 손대지 않는다.
- **갱신 불필요** — `rc-evidence-manifest-contract.json`·`store-submission-readiness.json` 및 RC evidence manifest generator는 versionName/versionCode를 pubspec에서 동적으로 파싱하므로 별도 하드코딩 앵커가 없다.
- repository-contract 테스트의 versionCode 계약은 `pubspec.yaml`이 `semver+정수` 형식이고 versionCode가 양수인지만 검증한다 — `1.0.3+10004`가 이를 충족한다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/repository-contract.test.mjs` → 184 pass / 0 fail
  - `node --test tools/release/upload-play-internal.test.mjs tools/ci/check-google-play-api-access.test.mjs tools/ci/check-mobile-release-claims.test.mjs` → 13 pass / 0 fail
  - flutter analyze 무영향(버전 문자열만 변경, dart 소스 미변경).

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| versionCode 단조 증가 계약 | Android | `node --test tools/ci/repository-contract.test.mjs` | 184 pass | PASS |
| Play 업로드 versionCode 비교 로직 | Android | `node --test tools/release/upload-play-internal.test.mjs` | 관련 테스트 pass | PASS |
| release gate 스냅샷 앵커 불변 | - | grep 전수 + 계약 테스트 | 10001 스냅샷 유지 | PASS |

## Version impact

- [ ] no version change
- [x] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 1.0.2 → 1.0.3 (patch)
- mobile versionCode: 10002 → 10004 (Play 최대치 10003 초과)
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: release gate JSON의 10001 스냅샷을 갱신하지 않은 판단 근거(2026-06-29 API 재점검 시점 기록이며 repository-contract 테스트가 10001로 고정). versionCode를 10003이 아닌 10004로 올린 이유(선행 업로드된 10003을 넘겨야 함).

## 리스크

- 낮음. 버전 문자열 1줄 변경. 계약 테스트·Play 업로드 versionCode 비교 로직 검증 완료. 실제 Play 업로드 성공 여부는 CD 파이프라인에서 확인 필요.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)