### PR TITLE
[Fix] Play internal 업로드 에러 원문 노출 + draft 앱 커밋 폴백

### DIFF
--- a/tools/ci/lib/google-play-auth.mjs
+++ b/tools/ci/lib/google-play-auth.mjs
@@ -122,8 +122,13 @@ export function readResponseBody(text, label, response) {
   }
 }
 
-// Mask anything that looks like a bearer/access token so a raw body echoed back
-// by the server never leaks a credential into logs.
+// Mask anything that looks like a credential so a raw body / echoed request
+// header never leaks a secret into logs. Defense in depth: beyond the primary
+// Bearer/access_token/ya29 leak paths, cover credentials that a
+// misconfiguration or verbose error could surface — a bare (non-Bearer)
+// authorization header value, a Google OAuth refresh token, a client_secret,
+// and a PEM private-key block. Patterns stay conservative (anchored on a
+// distinctive prefix/marker) so ordinary response fields are not clobbered.
 export function maskSecrets(text) {
   if (typeof text !== "string") {
     return text;
@@ -131,7 +136,20 @@ export function maskSecrets(text) {
   return text
     .replace(/(Bearer\s+)[A-Za-z0-9._~+/-]+=*/gi, "$1***")
     .replace(/("?access_token"?\s*[:=]\s*"?)[A-Za-z0-9._~+/-]+=*/gi, "$1***")
-    .replace(/(ya29\.)[A-Za-z0-9._~+/-]+/g, "$1***");
+    .replace(/(ya29\.)[A-Za-z0-9._~+/-]+/g, "$1***")
+    // Bare `authorization: <value>` header (no Bearer scheme). Only fires when a
+    // value follows the header name and it is not already a masked Bearer.
+    // Handles both `authorization: value` and JSON `"authorization":"value"`.
+    .replace(/("?authorization"?\s*[:=]\s*"?)(?!Bearer\b)[A-Za-z0-9._~+/-]+=*/gi, "$1***")
+    // Google OAuth refresh token — always prefixed with the distinctive `1//`.
+    .replace(/(1\/\/)[A-Za-z0-9._-]+/g, "$1***")
+    // OAuth client secret value.
+    .replace(/("?client_secret"?\s*[:=]\s*"?)[A-Za-z0-9._~+/-]+=*/gi, "$1***")
+    // PEM private-key block (RSA/EC/PKCS#8), body redacted between the markers.
+    .replace(
+      /(-----BEGIN (?:[A-Z ]+ )?PRIVATE KEY-----)[\s\S]*?(-----END (?:[A-Z ]+ )?PRIVATE KEY-----)/g,
+      "$1***$2",
+    );
 }
 
 export function apiErrorSummary(parsed, rawBody) {

--- a/tools/ci/lib/google-play-auth.mjs
+++ b/tools/ci/lib/google-play-auth.mjs
@@ -66,9 +66,9 @@ export async function requestJson(url, { method, token, body }, fetchImpl = fetc
     return {};
   }
   const text = await response.text();
-  const parsed = text.length === 0 ? {} : JSON.parse(text);
+  const parsed = readResponseBody(text, `google play api ${method}`, response);
   if (!response.ok) {
-    throw new Error(`google play api ${method} failed: ${response.status} ${apiErrorSummary(parsed)}`);
+    throw new PlayApiError(`google play api ${method} failed`, response.status, text, parsed);
   }
   return parsed;
 }
@@ -81,20 +81,75 @@ export async function uploadMedia(url, { token, contentType, data }, fetchImpl =
     body: data,
   });
   const text = await response.text();
-  const parsed = text.length === 0 ? {} : JSON.parse(text);
+  const parsed = readResponseBody(text, "google play upload", response);
   if (!response.ok) {
-    throw new Error(`google play upload failed: ${response.status} ${apiErrorSummary(parsed)}`);
+    throw new PlayApiError("google play upload failed", response.status, text, parsed);
   }
   return parsed;
 }
 
-export function apiErrorSummary(parsed) {
-  const error = parsed.error;
+// Error carrying the HTTP status plus the *raw* (masked) response body. The raw
+// body is the load-bearing diagnostic: Google occasionally returns a plaintext
+// error (e.g. "Could not commit changes for edit ... app is in draft status")
+// instead of JSON, and the previous unconditional JSON.parse discarded it —
+// leaving only the useless "... is not valid JSON" (issue #2011).
+export class PlayApiError extends Error {
+  constructor(label, status, rawBody, parsed) {
+    super(`${label}: ${status} ${apiErrorSummary(parsed, rawBody)}`);
+    this.name = "PlayApiError";
+    this.status = status;
+    this.rawBody = rawBody;
+    this.parsed = parsed;
+  }
+}
+
+// Parse a response body as JSON when it *is* JSON; when it is not (a 2xx is
+// still expected to be JSON, but a plaintext error must not blow up parsing),
+// return the raw text under `_raw` so callers/summaries can surface it verbatim.
+export function readResponseBody(text, label, response) {
+  if (!text || text.length === 0) {
+    return {};
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    // Non-JSON body. On a successful status this is unexpected and must still
+    // fail loudly; on an error status the caller emits the raw body.
+    if (response && response.ok) {
+      throw new PlayApiError(`${label} returned non-JSON on success`, response.status, text, { _raw: text });
+    }
+    return { _raw: text };
+  }
+}
+
+// Mask anything that looks like a bearer/access token so a raw body echoed back
+// by the server never leaks a credential into logs.
+export function maskSecrets(text) {
+  if (typeof text !== "string") {
+    return text;
+  }
+  return text
+    .replace(/(Bearer\s+)[A-Za-z0-9._~+/-]+=*/gi, "$1***")
+    .replace(/("?access_token"?\s*[:=]\s*"?)[A-Za-z0-9._~+/-]+=*/gi, "$1***")
+    .replace(/(ya29\.)[A-Za-z0-9._~+/-]+/g, "$1***");
+}
+
+export function apiErrorSummary(parsed, rawBody) {
+  const error = parsed?.error;
   if (!error || typeof error !== "object") {
+    // No structured error object — surface the raw body verbatim (masked,
+    // whitespace-collapsed, capped) so plaintext errors are diagnosable at a
+    // glance instead of being reduced to "status=unknown".
+    const raw = typeof rawBody === "string" && rawBody.length > 0
+      ? rawBody
+      : (typeof parsed?._raw === "string" ? parsed._raw : "");
+    if (raw) {
+      return `status=unknown body=${maskSecrets(raw).replace(/\s+/g, " ").trim().slice(0, 400)}`;
+    }
     return "status=unknown";
   }
   const status = typeof error.status === "string" ? error.status : "unknown";
-  const message = typeof error.message === "string" ? error.message.replace(/\s+/g, " ").slice(0, 180) : "none";
+  const message = typeof error.message === "string" ? maskSecrets(error.message).replace(/\s+/g, " ").slice(0, 180) : "none";
   return `status=${status} message=${message}`;
 }
 

--- a/tools/ci/lib/google-play-auth.test.mjs
+++ b/tools/ci/lib/google-play-auth.test.mjs
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  apiErrorSummary,
+  maskSecrets,
+  PlayApiError,
+  readResponseBody,
+} from "./google-play-auth.mjs";
+
+test("maskSecrets redacts bearer tokens and access_token values", () => {
+  assert.equal(maskSecrets("authorization: Bearer ya29.abcDEF-123_xyz"), "authorization: Bearer ***");
+  assert.equal(maskSecrets('{"access_token":"ya29.secretValue-123"}'), '{"access_token":"***"}');
+  assert.equal(maskSecrets("token=ya29.longsecretstring"), "token=ya29.***");
+  // Ordinary text is untouched.
+  assert.equal(maskSecrets("app is in draft status"), "app is in draft status");
+  assert.equal(maskSecrets(undefined), undefined);
+});
+
+test("readResponseBody parses JSON and passes through empty bodies", () => {
+  assert.deepEqual(readResponseBody("", "label", { ok: true }), {});
+  assert.deepEqual(readResponseBody('{"a":1}', "label", { ok: true }), { a: 1 });
+});
+
+test("readResponseBody returns raw text for a non-JSON error body without throwing", () => {
+  const raw = "Could not commit changes for edit ... app is in draft status.";
+  const result = readResponseBody(raw, "google play api POST", { ok: false, status: 400 });
+  assert.equal(result._raw, raw);
+});
+
+test("readResponseBody throws when a successful response is unexpectedly non-JSON", () => {
+  assert.throws(
+    () => readResponseBody("not json", "google play upload", { ok: true, status: 200 }),
+    (error) => {
+      assert.ok(error instanceof PlayApiError);
+      assert.match(error.message, /non-JSON on success/);
+      return true;
+    },
+  );
+});
+
+test("apiErrorSummary surfaces the raw plaintext body when there is no structured error", () => {
+  const raw = "Could not commit changes for edit edit-1 because the app is in draft status.";
+  const summary = apiErrorSummary({ _raw: raw }, raw);
+  assert.match(summary, /status=unknown/);
+  assert.match(summary, /draft status/);
+});
+
+test("apiErrorSummary formats a structured error and masks secrets in the message", () => {
+  const summary = apiErrorSummary(
+    { error: { status: "PERMISSION_DENIED", message: "denied Bearer ya29.leaked-token here" } },
+  );
+  assert.match(summary, /status=PERMISSION_DENIED/);
+  assert.match(summary, /Bearer \*\*\*/);
+  assert.doesNotMatch(summary, /ya29\.leaked-token/);
+});
+
+test("apiErrorSummary caps an overlong raw body", () => {
+  const raw = "x".repeat(1000);
+  const summary = apiErrorSummary({ _raw: raw }, raw);
+  assert.ok(summary.length < 450, "raw body must be capped");
+});
+
+test("PlayApiError carries status, raw body, and parsed payload", () => {
+  const error = new PlayApiError("google play upload failed", 500, "boom", { _raw: "boom" });
+  assert.equal(error.name, "PlayApiError");
+  assert.equal(error.status, 500);
+  assert.equal(error.rawBody, "boom");
+  assert.match(error.message, /google play upload failed: 500/);
+});

--- a/tools/ci/lib/google-play-auth.test.mjs
+++ b/tools/ci/lib/google-play-auth.test.mjs
@@ -17,6 +17,46 @@ test("maskSecrets redacts bearer tokens and access_token values", () => {
   assert.equal(maskSecrets(undefined), undefined);
 });
 
+test("maskSecrets redacts a bare (non-Bearer) authorization header value", () => {
+  assert.equal(maskSecrets("authorization: rawTokenValue-123_abc"), "authorization: ***");
+  assert.equal(maskSecrets('{"authorization":"rawTokenValue-123"}'), '{"authorization":"***"}');
+  // A Bearer scheme is still handled by the Bearer rule, not double-masked.
+  assert.equal(maskSecrets("authorization: Bearer ya29.abc-123"), "authorization: Bearer ***");
+  // Not a credential-bearing field: an unrelated word after "authorization" text
+  // (no `:`/`=` separator) is left alone.
+  assert.equal(maskSecrets("authorization failed for user"), "authorization failed for user");
+});
+
+test("maskSecrets redacts a Google OAuth refresh token", () => {
+  assert.equal(
+    maskSecrets('{"refresh_token":"1//0abcDEF-123_ghi.jkl"}'),
+    '{"refresh_token":"1//***"}',
+  );
+  assert.equal(maskSecrets("token=1//longRefreshValue-xyz"), "token=1//***");
+  // A plain "1//" not followed by token characters is untouched.
+  assert.equal(maskSecrets("ratio is 1// or so"), "ratio is 1// or so");
+});
+
+test("maskSecrets redacts a client_secret value", () => {
+  assert.equal(
+    maskSecrets('{"client_secret":"GOCSPX-secretValue123"}'),
+    '{"client_secret":"***"}',
+  );
+  assert.equal(maskSecrets("client_secret=GOCSPX-abcdef"), "client_secret=***");
+  // A field merely mentioning the term without a value separator is untouched.
+  assert.equal(maskSecrets("the client_secret is missing"), "the client_secret is missing");
+});
+
+test("maskSecrets redacts a PEM private-key block", () => {
+  const pem = "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBg\nkqhkiG9w0B\n-----END PRIVATE KEY-----";
+  assert.equal(maskSecrets(pem), "-----BEGIN PRIVATE KEY-----***-----END PRIVATE KEY-----");
+  const rsaPem = "-----BEGIN RSA PRIVATE KEY-----\nAAAA\nBBBB\n-----END RSA PRIVATE KEY-----";
+  assert.equal(maskSecrets(rsaPem), "-----BEGIN RSA PRIVATE KEY-----***-----END RSA PRIVATE KEY-----");
+  // A public-key block is not a secret and stays intact.
+  const pub = "-----BEGIN PUBLIC KEY-----\nAAAA\n-----END PUBLIC KEY-----";
+  assert.equal(maskSecrets(pub), pub);
+});
+
 test("readResponseBody parses JSON and passes through empty bodies", () => {
   assert.deepEqual(readResponseBody("", "label", { ok: true }), {});
   assert.deepEqual(readResponseBody('{"a":1}', "label", { ok: true }), { a: 1 });

--- a/tools/release/upload-play-internal.mjs
+++ b/tools/release/upload-play-internal.mjs
@@ -14,7 +14,9 @@ import {
   defaultApiBaseUrl,
   encodePath,
   fetchAccessToken,
+  maskSecrets,
   parseDotenv,
+  PlayApiError,
   readServiceAccount,
   requestJson,
   requireJsonString,
@@ -40,6 +42,51 @@ function maxTrackVersionCode(tracks) {
 
 function sha256OfBuffer(buffer) {
   return createHash("sha256").update(buffer).digest("hex");
+}
+
+function commitUrl(editsBase, editId, changesNotSentForReview) {
+  return `${editsBase}/${encodePath(editId)}:commit?changesNotSentForReview=${changesNotSentForReview ? "true" : "false"}`;
+}
+
+// The Android Publisher edits.commit contract is asymmetric (issue #2011):
+//   - A never-published app (draft status) rejects commit unless
+//     changesNotSentForReview=true, with a plaintext body like
+//     "Could not commit changes for edit ... app is in draft status".
+//   - A published app whose changes are auto-sent for review rejects commit
+//     WITH changesNotSentForReview=true, with "Changes are sent for review
+//     automatically. The query parameter changesNotSentForReview must not be
+//     set."
+// So blindly forcing true is unsafe. We commit with the requested flag (default
+// false), and only when the failure explicitly signals the draft/not-sent
+// condition do we retry once with true. This keeps the normal review flow of an
+// already-published app intact while unblocking the first-ever draft upload.
+// Refs: developers.google.com/android-publisher/api-ref/rest/v3/edits/commit
+function isDraftCommitError(error) {
+  if (!(error instanceof PlayApiError)) {
+    return false;
+  }
+  const haystack = `${error.parsed?.error?.message ?? ""} ${error.rawBody ?? ""}`.toLowerCase();
+  return haystack.includes("draft status")
+    || (haystack.includes("could not commit") && haystack.includes("draft"))
+    || haystack.includes("not been reviewed")
+    || haystack.includes("changes cannot be sent for review");
+}
+
+async function commitEdit({ editsBase, editId, token, changesNotSentForReview }, fetchImpl) {
+  try {
+    await requestJson(commitUrl(editsBase, editId, changesNotSentForReview), { method: "POST", token }, fetchImpl);
+    return { changesNotSentForReview, retried: false };
+  } catch (error) {
+    // Already asked not to send for review, or a non-draft failure — surface it.
+    if (changesNotSentForReview || !isDraftCommitError(error)) {
+      throw error;
+    }
+    process.stderr.write(
+      `play internal commit rejected as draft; retrying once with changesNotSentForReview=true — ${error.message}\n`,
+    );
+    await requestJson(commitUrl(editsBase, editId, true), { method: "POST", token }, fetchImpl);
+    return { changesNotSentForReview: true, retried: true };
+  }
 }
 
 export async function runUploadPlayInternal({
@@ -124,9 +171,8 @@ export async function runUploadPlayInternal({
     fetchImpl,
   );
 
-  await requestJson(
-    `${editsBase}/${encodePath(editId)}:commit?changesNotSentForReview=${changesNotSentForReview ? "true" : "false"}`,
-    { method: "POST", token },
+  const commit = await commitEdit(
+    { editsBase, editId, token, changesNotSentForReview },
     fetchImpl,
   );
 
@@ -140,7 +186,10 @@ export async function runUploadPlayInternal({
     versionCode: String(versionCode),
     aabSha256,
     mappingSha256: mappingSha256 ?? null,
-    changesNotSentForReview,
+    // Reflect the value actually used to commit — the draft-status fallback can
+    // escalate false -> true, and the evidence must record what really happened.
+    changesNotSentForReview: commit.changesNotSentForReview,
+    changesNotSentForReviewRetried: commit.retried,
     uploadedAt: new Date().toISOString(),
   };
   if (reportPath) {
@@ -192,6 +241,15 @@ async function main() {
 if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   main().catch((error) => {
     console.error(error.message);
+    // On a Play API failure, dump the HTTP status and the *raw* response body
+    // (secret-masked) verbatim so a plaintext error (e.g. draft status) is
+    // diagnosable in a single run instead of being swallowed by JSON parsing.
+    if (error instanceof PlayApiError) {
+      console.error(`play api status: ${error.status}`);
+      if (typeof error.rawBody === "string" && error.rawBody.length > 0) {
+        console.error(`play api raw body: ${maskSecrets(error.rawBody)}`);
+      }
+    }
     process.exitCode = 1;
   });
 }

--- a/tools/release/upload-play-internal.test.mjs
+++ b/tools/release/upload-play-internal.test.mjs
@@ -29,9 +29,24 @@ function jsonResponse(status, body) {
   };
 }
 
+// A response whose body is plain text (not JSON) — mirrors Google returning a
+// bare error string that the previous unconditional JSON.parse would choke on.
+function textResponse(status, text) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => {
+      throw new SyntaxError("Unexpected token");
+    },
+    text: async () => text,
+  };
+}
+
 // Builds a mock Android Publisher API. `tracks` is the existing track list, and
-// `overrides` can force specific endpoints (e.g. an auth failure).
-function mockPlay({ tracks = [], uploadedVersionCode = "10005", overrides = {} } = {}) {
+// `overrides` can force specific endpoints (e.g. an auth failure). `commit` may
+// override the commit response: pass a single response applied to every commit
+// call, or a function `(changesNotSentForReview) => response` to vary by flag.
+function mockPlay({ tracks = [], uploadedVersionCode = "10005", overrides = {}, commit } = {}) {
   const requests = [];
   const fetchImpl = async (url, options = {}) => {
     const method = options.method ?? "GET";
@@ -43,7 +58,11 @@ function mockPlay({ tracks = [], uploadedVersionCode = "10005", overrides = {} }
     if (url.includes("/bundles?uploadType=media")) return jsonResponse(200, { versionCode: uploadedVersionCode });
     if (url.includes("/deobfuscationFiles/")) return jsonResponse(200, {});
     if (url.includes("/tracks/") && method === "PUT") return jsonResponse(200, { track: "internal" });
-    if (url.includes(":commit")) return jsonResponse(200, {});
+    if (url.includes(":commit")) {
+      if (typeof commit === "function") return commit(url.includes("changesNotSentForReview=true"));
+      if (commit) return commit;
+      return jsonResponse(200, {});
+    }
     return jsonResponse(404, { error: { status: "NOT_FOUND", message: url } });
   };
   return { fetchImpl, requests };
@@ -147,6 +166,93 @@ test("fails when the uploaded bundle versionCode does not match the expected one
       }),
       /does not match expected 10005/,
     );
+  });
+});
+
+test("surfaces the raw plaintext body when Play returns a non-JSON error (issue #2011)", async () => {
+  await withFiles(async ({ envFile, aabPath, mappingPath, reportPath }) => {
+    // Google occasionally returns a bare plaintext error instead of JSON; the
+    // old code JSON.parse'd it unconditionally and lost the original message.
+    const raw = "Could not commit changes for edit edit-1 because the app is in draft status.";
+    const { fetchImpl } = mockPlay({ tracks: [], commit: textResponse(400, raw) });
+    await assert.rejects(
+      runUploadPlayInternal({
+        envFile,
+        aabPath,
+        mappingPath,
+        versionCode: "10005",
+        reportPath,
+        // changesNotSentForReview already true => no draft retry, error surfaces.
+        changesNotSentForReview: true,
+        apiBaseUrl: "https://api.example/v3",
+        uploadBaseUrl: "https://upload.example/v3",
+        fetchImpl,
+      }),
+      (error) => {
+        assert.equal(error.name, "PlayApiError");
+        assert.equal(error.status, 400);
+        assert.equal(error.rawBody, raw);
+        // The raw body must appear verbatim in the message, not "is not valid JSON".
+        assert.match(error.message, /draft status/);
+        assert.doesNotMatch(error.message, /is not valid JSON/);
+        return true;
+      },
+    );
+  });
+});
+
+test("retries commit once with changesNotSentForReview=true on a draft-status rejection", async () => {
+  await withFiles(async ({ envFile, aabPath, mappingPath, reportPath }) => {
+    const raw = "Could not commit changes for edit edit-1 because the app is in draft status.";
+    // First commit (false) is rejected as draft; the retry (true) succeeds.
+    const { fetchImpl, requests } = mockPlay({
+      tracks: [],
+      commit: (notSent) => (notSent ? jsonResponse(200, {}) : textResponse(400, raw)),
+    });
+    const evidence = await runUploadPlayInternal({
+      envFile,
+      aabPath,
+      mappingPath,
+      versionCode: "10005",
+      reportPath,
+      apiBaseUrl: "https://api.example/v3",
+      uploadBaseUrl: "https://upload.example/v3",
+      fetchImpl,
+    });
+
+    // Evidence records the escalated flag and that a retry occurred.
+    assert.equal(evidence.changesNotSentForReview, true);
+    assert.equal(evidence.changesNotSentForReviewRetried, true);
+
+    const commits = requests.filter((request) => request.url.includes(":commit"));
+    assert.equal(commits.length, 2);
+    assert.ok(commits[0].url.includes("changesNotSentForReview=false"));
+    assert.ok(commits[1].url.includes("changesNotSentForReview=true"));
+  });
+});
+
+test("does not retry when a non-draft commit error occurs", async () => {
+  await withFiles(async ({ envFile, aabPath, mappingPath, reportPath }) => {
+    // A generic server error must NOT be masked by a draft retry.
+    const { fetchImpl, requests } = mockPlay({
+      tracks: [],
+      commit: jsonResponse(500, { error: { status: "INTERNAL", message: "backend unavailable" } }),
+    });
+    await assert.rejects(
+      runUploadPlayInternal({
+        envFile,
+        aabPath,
+        mappingPath,
+        versionCode: "10005",
+        reportPath,
+        apiBaseUrl: "https://api.example/v3",
+        uploadBaseUrl: "https://upload.example/v3",
+        fetchImpl,
+      }),
+      /backend unavailable/,
+    );
+    const commits = requests.filter((request) => request.url.includes(":commit"));
+    assert.equal(commits.length, 1, "a non-draft failure must not trigger a retry");
   });
 });
 


### PR DESCRIPTION
## 관련 이슈

Refs #2011 #1689

## 작업 배경

Play internal 트랙 3차 업로드(run 29192944863)가 versionCode 정책·빌드·서명을 모두 통과한 뒤 실제 Play API의 `edits.commit` 단계에서 실패했다. 그런데 실패 로그에는 `Unexpected token 'C', "Could not "... is not valid JSON`만 남았다. 원인은 `tools/ci/lib/google-play-auth.mjs`의 응답 처리가 본문을 **무조건 `JSON.parse`** 하도록 되어 있어, 구글이 반환한 평문 에러 원문("Could not …")이 파싱 예외에 덮여 소실됐기 때문이다.

정황상 앱이 Play Console에서 아직 미게시(draft) 상태라 `edits.commit`에 `changesNotSentForReview=true`가 필요한 전형적 케이스로 추정된다(`Could not commit changes for edit … app is in draft status`). 하지만 원문이 없어 한 번에 진단되지 않았다.

`edits.commit` 계약은 비대칭이다.
- 미게시(draft) 앱: `changesNotSentForReview=true` 없이 커밋하면 draft status로 거부.
- 이미 게시된 앱: 변경이 자동 리뷰로 넘어가므로 `true`를 붙이면 `Changes are sent for review automatically. The query parameter changesNotSentForReview must not be set.`로 거부.

따라서 무조건 `true`는 게시된 앱의 정상 리뷰 플로우를 깨므로 위험하다.

근거: developers.google.com/android-publisher/api-ref/rest/v3/edits/commit, 공개 이슈(gradle-play-publisher #960 — 미게시 앱 internal 트랙 업로드 버그), Codemagic "Common Google Play errors" 문서.

## 작업 내용

- **에러 원문 노출**: `google-play-auth.mjs`의 `requestJson`·`uploadMedia`가 응답을 안전 파싱하도록 변경(`readResponseBody`). 비JSON 본문은 `JSON.parse`로 터뜨리지 않고 원문을 보존하며, 성공 응답이 예외적으로 비JSON이면 여전히 실패한다.
- `PlayApiError`(신규)가 HTTP status·원문 본문(비밀 마스킹)·파싱 결과를 실어 나른다. CLI 실패 시 `play api status`/`play api raw body`를 stderr로 그대로 출력해 재발 시 한 번에 진단된다.
- `maskSecrets`로 `Bearer`/`access_token`/`ya29.` 계열 토큰을 로그 노출 전에 가린다. `apiErrorSummary`도 구조화 에러가 없으면 원문을 마스킹·정규화·400자 캡으로 요약에 노출한다.
- **draft 대응**: 요청 플래그(기본 `false`)로 커밋하고, 실패 본문이 draft/not-sent 조건을 명시할 때만 `changesNotSentForReview=true`로 **1회 재시도**한다(`commitEdit`). 게시된 앱의 정상 리뷰 플로우는 그대로 두고 최초 draft 업로드만 뚫는다. evidence에 실제 사용된 플래그(`changesNotSentForReview`)와 재시도 여부(`changesNotSentForReviewRetried`)를 기록한다.
- 계약 테스트가 요구하는 `:commit?changesNotSentForReview=` URL 리터럴은 그대로 유지.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/*.test.mjs tools/ci/lib/*.test.mjs tools/release/*.test.mjs` → tests 263 / pass 263 / fail 0
  - `node --test tools/release/upload-play-internal.test.mjs` → 8/8 green (신규 3종: 비JSON 에러 노출·draft 재시도·비draft 미재시도 포함)
  - `node --test tools/ci/lib/google-play-auth.test.mjs` → 8/8 green (신규: maskSecrets·readResponseBody·apiErrorSummary·PlayApiError)
  - `node --check` 4개 파일 전부 SYNTAX OK

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 비JSON 에러 원문 노출 | Android/CI | 단위 테스트 | `tools/release/upload-play-internal.test.mjs` (surfaces the raw plaintext body …) | pass |
| draft 커밋 폴백 1회 재시도 | Android/CI | 단위 테스트 | `tools/release/upload-play-internal.test.mjs` (retries commit once …) | pass |
| 비draft 실패 미재시도 | Android/CI | 단위 테스트 | `tools/release/upload-play-internal.test.mjs` (does not retry …) | pass |
| 비밀 마스킹 | CI | 단위 테스트 | `tools/ci/lib/google-play-auth.test.mjs` (maskSecrets …) | pass |
| 실기기 업로드 성공 | Android | Play Console 업로드 재실행 | (후속 release run에서 확인) | 대기 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `google-play-auth.mjs`의 `readResponseBody`/`PlayApiError`/`apiErrorSummary`(에러 원문·마스킹 경로)와 `upload-play-internal.mjs`의 `commitEdit`/`isDraftCommitError`(draft 폴백 판정). draft 재시도가 게시된 앱의 정상 리뷰 플로우를 우회하지 않는지(오직 draft/not-sent 에러에서만 false→true 승격) 확인 부탁.

## 리스크

- draft 판정을 에러 문구 substring 매칭으로 한다. 구글이 문구를 바꾸면 폴백이 트리거되지 않을 수 있으나, 이 경우에도 원문이 그대로 노출되므로 진단 가능하고 안전 실패(재시도 없이 실패)한다.
- 마스킹은 알려진 토큰 패턴(`Bearer`/`access_token`/`ya29.`) 기준이며 응답 본문에 예상치 못한 형태의 비밀이 있으면 놓칠 수 있다. 다만 Play API 에러 응답에 자격증명이 담기는 사례는 알려져 있지 않다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
