### PR TITLE
[Feat] #1919 역 상세 로컬 시간표·첫차/막차 표시

### DIFF
--- a/apps/mobile/lib/core/database/catalog/station_timetable_query.dart
+++ b/apps/mobile/lib/core/database/catalog/station_timetable_query.dart
@@ -1,4 +1,6 @@
 import 'package:drift/drift.dart';
+import 'package:timezone/data/latest.dart' as tz_data;
+import 'package:timezone/timezone.dart' as tz;
 
 import 'catalog_database.dart';
 
@@ -34,8 +36,9 @@ class CatalogStationTimetableQuery {
     required String lineId,
     required DateTime date,
   }) async {
-    final dateKey = _dateKey(date);
-    final weekdayColumn = _weekdayColumn(date.weekday);
+    final serviceDate = tz.TZDateTime.from(date, _seoulLocation);
+    final dateKey = _dateKey(serviceDate);
+    final weekdayColumn = _weekdayColumn(serviceDate.weekday);
     final calendarRows = await database
         .customSelect(
           '''
@@ -86,7 +89,7 @@ class CatalogStationTimetableQuery {
       }
     }
     final dayType = _dayTypeForDate(
-      date,
+      serviceDate,
       weekdayColumn: weekdayColumn,
       addedServiceIds: addedServiceIds,
       calendarsById: calendarsById,
@@ -105,10 +108,14 @@ class CatalogStationTimetableQuery {
     required String stationId,
     required String lineId,
     CatalogTimetableDayType? dayType,
+    DateTime? referenceDate,
     Set<String>? serviceIds,
   }) async {
     if (serviceIds != null && serviceIds.isEmpty) {
       return const [];
+    }
+    if (dayType != null && referenceDate == null) {
+      throw ArgumentError.notNull('referenceDate');
     }
     final sortedServiceIds = serviceIds == null
         ? null
@@ -116,6 +123,9 @@ class CatalogStationTimetableQuery {
     final calendarJoin = dayType == null
         ? ''
         : 'JOIN service_calendars c ON c.service_id = t.service_id';
+    final referenceDateKey = dayType == null
+        ? null
+        : _dateKey(tz.TZDateTime.from(referenceDate!, _seoulLocation));
     final dayFilter = switch (dayType) {
       CatalogTimetableDayType.weekday =>
         'AND (c.monday = 1 OR c.tuesday = 1 OR c.wednesday = 1 '
@@ -124,6 +134,17 @@ class CatalogStationTimetableQuery {
       CatalogTimetableDayType.sundayHoliday => 'AND c.sunday = 1',
       null => '',
     };
+    final validityFilter = dayType == null
+        ? ''
+        : '''
+            AND c.start_date <= ?
+            AND c.end_date >= ?
+            AND EXISTS (
+              SELECT 1
+              FROM transit_feed_info feed
+              WHERE feed.feed_end_date >= ?
+            )
+          ''';
     final serviceFilter = sortedServiceIds == null
         ? ''
         : 'AND t.service_id IN '
@@ -142,12 +163,18 @@ class CatalogStationTimetableQuery {
             AND r.line_id = st.line_id
             AND TRIM(r.direction_name) <> ''
             $dayFilter
+            $validityFilter
             $serviceFilter
           ORDER BY r.direction_name, st.departure_seconds
           ''',
           variables: [
             Variable.withString(stationId),
             Variable.withString(lineId),
+            if (referenceDateKey != null) ...[
+              Variable.withString(referenceDateKey),
+              Variable.withString(referenceDateKey),
+              Variable.withString(referenceDateKey),
+            ],
             ...?sortedServiceIds?.map(Variable.withString),
           ],
         )
@@ -203,3 +230,10 @@ String _dateKey(DateTime date) {
 }
 
 bool _isEnabled(Object? value) => value == true || value == 1;
+
+final tz.Location _seoulLocation = _loadSeoulLocation();
+
+tz.Location _loadSeoulLocation() {
+  tz_data.initializeTimeZones();
+  return tz.getLocation('Asia/Seoul');
+}

--- a/apps/mobile/lib/core/database/catalog/station_timetable_query.dart
+++ b/apps/mobile/lib/core/database/catalog/station_timetable_query.dart
@@ -1,0 +1,205 @@
+import 'package:drift/drift.dart';
+
+import 'catalog_database.dart';
+
+enum CatalogTimetableDayType { weekday, saturday, sundayHoliday }
+
+class CatalogStationDeparture {
+  const CatalogStationDeparture({
+    required this.directionName,
+    required this.seconds,
+  });
+
+  final String directionName;
+  final int seconds;
+}
+
+class CatalogStationDayTimetable {
+  const CatalogStationDayTimetable({
+    required this.dayType,
+    required this.departures,
+  });
+
+  final CatalogTimetableDayType dayType;
+  final List<CatalogStationDeparture> departures;
+}
+
+class CatalogStationTimetableQuery {
+  const CatalogStationTimetableQuery(this.database);
+
+  final CatalogDatabase database;
+
+  Future<CatalogStationDayTimetable> loadDeparturesForDate({
+    required String stationId,
+    required String lineId,
+    required DateTime date,
+  }) async {
+    final dateKey = _dateKey(date);
+    final weekdayColumn = _weekdayColumn(date.weekday);
+    final calendarRows = await database
+        .customSelect(
+          '''
+          SELECT *
+          FROM service_calendars
+          WHERE (start_date <= ? AND end_date >= ?)
+             OR service_id IN (
+               SELECT service_id
+               FROM service_calendar_dates
+               WHERE date = ? AND exception_type = 1
+             )
+          ''',
+          variables: [
+            Variable.withString(dateKey),
+            Variable.withString(dateKey),
+            Variable.withString(dateKey),
+          ],
+        )
+        .get();
+    final calendarsById = {
+      for (final row in calendarRows) row.read<String>('service_id'): row,
+    };
+    final activeServiceIds = <String>{
+      for (final row in calendarRows)
+        if (row.read<String>('start_date').compareTo(dateKey) <= 0 &&
+            row.read<String>('end_date').compareTo(dateKey) >= 0 &&
+            _isEnabled(row.data[weekdayColumn]))
+          row.read<String>('service_id'),
+    };
+    final addedServiceIds = <String>{};
+    final exceptionRows = await database
+        .customSelect(
+          '''
+          SELECT service_id, exception_type
+          FROM service_calendar_dates
+          WHERE date = ?
+          ''',
+          variables: [Variable.withString(dateKey)],
+        )
+        .get();
+    for (final row in exceptionRows) {
+      final serviceId = row.read<String>('service_id');
+      if (row.read<int>('exception_type') == 1) {
+        activeServiceIds.add(serviceId);
+        addedServiceIds.add(serviceId);
+      } else {
+        activeServiceIds.remove(serviceId);
+      }
+    }
+    final dayType = _dayTypeForDate(
+      date,
+      weekdayColumn: weekdayColumn,
+      addedServiceIds: addedServiceIds,
+      calendarsById: calendarsById,
+    );
+    return CatalogStationDayTimetable(
+      dayType: dayType,
+      departures: await loadDepartures(
+        stationId: stationId,
+        lineId: lineId,
+        serviceIds: activeServiceIds,
+      ),
+    );
+  }
+
+  Future<List<CatalogStationDeparture>> loadDepartures({
+    required String stationId,
+    required String lineId,
+    CatalogTimetableDayType? dayType,
+    Set<String>? serviceIds,
+  }) async {
+    if (serviceIds != null && serviceIds.isEmpty) {
+      return const [];
+    }
+    final sortedServiceIds = serviceIds == null
+        ? null
+        : (serviceIds.toList(growable: false)..sort());
+    final calendarJoin = dayType == null
+        ? ''
+        : 'JOIN service_calendars c ON c.service_id = t.service_id';
+    final dayFilter = switch (dayType) {
+      CatalogTimetableDayType.weekday =>
+        'AND (c.monday = 1 OR c.tuesday = 1 OR c.wednesday = 1 '
+            'OR c.thursday = 1 OR c.friday = 1)',
+      CatalogTimetableDayType.saturday => 'AND c.saturday = 1',
+      CatalogTimetableDayType.sundayHoliday => 'AND c.sunday = 1',
+      null => '',
+    };
+    final serviceFilter = sortedServiceIds == null
+        ? ''
+        : 'AND t.service_id IN '
+              '(${List.filled(sortedServiceIds.length, '?').join(',')})';
+    final rows = await database
+        .customSelect(
+          '''
+          SELECT DISTINCT r.direction_name, st.departure_seconds
+          FROM transit_stop_times st
+          JOIN transit_trips t ON t.id = st.trip_id
+          JOIN transit_routes r ON r.id = t.route_id
+          $calendarJoin
+          WHERE st.station_id = ?
+            AND st.line_id = ?
+            AND st.pickup_type = 0
+            AND r.line_id = st.line_id
+            AND TRIM(r.direction_name) <> ''
+            $dayFilter
+            $serviceFilter
+          ORDER BY r.direction_name, st.departure_seconds
+          ''',
+          variables: [
+            Variable.withString(stationId),
+            Variable.withString(lineId),
+            ...?sortedServiceIds?.map(Variable.withString),
+          ],
+        )
+        .get();
+    return rows
+        .map(
+          (row) => CatalogStationDeparture(
+            directionName: row.read<String>('direction_name'),
+            seconds: row.read<int>('departure_seconds'),
+          ),
+        )
+        .toList(growable: false);
+  }
+}
+
+CatalogTimetableDayType _dayTypeForDate(
+  DateTime date, {
+  required String weekdayColumn,
+  required Set<String> addedServiceIds,
+  required Map<String, QueryRow> calendarsById,
+}) {
+  if (date.weekday == DateTime.sunday) {
+    return CatalogTimetableDayType.sundayHoliday;
+  }
+  final hasHolidayException = addedServiceIds.any((serviceId) {
+    final row = calendarsById[serviceId];
+    return row != null &&
+        _isEnabled(row.data['sunday']) &&
+        !_isEnabled(row.data[weekdayColumn]);
+  });
+  if (hasHolidayException) {
+    return CatalogTimetableDayType.sundayHoliday;
+  }
+  return date.weekday == DateTime.saturday
+      ? CatalogTimetableDayType.saturday
+      : CatalogTimetableDayType.weekday;
+}
+
+String _weekdayColumn(int weekday) => switch (weekday) {
+  DateTime.monday => 'monday',
+  DateTime.tuesday => 'tuesday',
+  DateTime.wednesday => 'wednesday',
+  DateTime.thursday => 'thursday',
+  DateTime.friday => 'friday',
+  DateTime.saturday => 'saturday',
+  _ => 'sunday',
+};
+
+String _dateKey(DateTime date) {
+  return '${date.year.toString().padLeft(4, '0')}'
+      '${date.month.toString().padLeft(2, '0')}'
+      '${date.day.toString().padLeft(2, '0')}';
+}
+
+bool _isEnabled(Object? value) => value == true || value == 1;

--- a/apps/mobile/lib/features/home_widget/next_train_widget_repository.dart
+++ b/apps/mobile/lib/features/home_widget/next_train_widget_repository.dart
@@ -4,6 +4,7 @@ import 'package:timezone/data/latest.dart' as tz_data;
 import 'package:timezone/timezone.dart' as tz;
 
 import '../../core/database/catalog/catalog_database.dart';
+import '../../core/database/catalog/station_timetable_query.dart';
 import '../../core/database/user/user_database.dart';
 
 enum NextTrainWidgetStatus { available, serviceEnded, timetableUnavailable }
@@ -136,14 +137,18 @@ class NextTrainWidgetRepository {
       if (serviceDate.isAfter(feedEndDate)) {
         break;
       }
-      final serviceIds = await _activeServiceIds(serviceDate);
-      if (serviceIds.isEmpty) {
+      final departures =
+          (await CatalogStationTimetableQuery(
+                catalogDatabase,
+              ).loadDeparturesForDate(
+                stationId: selection.stationId,
+                lineId: selection.lineId,
+                date: serviceDate,
+              ))
+              .departures;
+      if (departures.isEmpty) {
         continue;
       }
-      final departures = await _departures(
-        selection: selection,
-        serviceIds: serviceIds,
-      );
       for (final departure in departures) {
         final departureAt = serviceDate.add(
           Duration(seconds: departure.seconds),
@@ -222,103 +227,16 @@ class NextTrainWidgetRepository {
     return _parseServiceDate(row.read<String>('feed_end_date'));
   }
 
-  Future<Set<String>> _activeServiceIds(DateTime date) async {
-    final dateKey = _dateKey(date);
-    final calendarRows = await catalogDatabase
-        .customSelect(
-          '''
-          SELECT *
-          FROM service_calendars
-          WHERE start_date <= ? AND end_date >= ?
-          ''',
-          variables: [
-            Variable.withString(dateKey),
-            Variable.withString(dateKey),
-          ],
-        )
-        .get();
-    final weekdayColumn = switch (date.weekday) {
-      DateTime.monday => 'monday',
-      DateTime.tuesday => 'tuesday',
-      DateTime.wednesday => 'wednesday',
-      DateTime.thursday => 'thursday',
-      DateTime.friday => 'friday',
-      DateTime.saturday => 'saturday',
-      _ => 'sunday',
-    };
-    final active = <String>{
-      for (final row in calendarRows)
-        if (_isEnabled(row.data[weekdayColumn])) row.read<String>('service_id'),
-    };
-    final exceptionRows = await catalogDatabase
-        .customSelect(
-          '''
-          SELECT service_id, exception_type
-          FROM service_calendar_dates
-          WHERE date = ?
-          ''',
-          variables: [Variable.withString(dateKey)],
-        )
-        .get();
-    for (final row in exceptionRows) {
-      final serviceId = row.read<String>('service_id');
-      if (row.read<int>('exception_type') == 1) {
-        active.add(serviceId);
-      } else {
-        active.remove(serviceId);
-      }
-    }
-    return active;
-  }
-
-  Future<List<_StopTimeDeparture>> _departures({
+  Future<List<CatalogStationDeparture>> _departures({
     required WidgetStationSelection selection,
     Set<String>? serviceIds,
-  }) async {
-    final serviceFilter = serviceIds == null
-        ? ''
-        : 'AND t.service_id IN (${List.filled(serviceIds.length, '?').join(',')})';
-    final rows = await catalogDatabase
-        .customSelect(
-          '''
-          SELECT r.direction_name, st.departure_seconds
-          FROM transit_stop_times st
-          JOIN transit_trips t ON t.id = st.trip_id
-          JOIN transit_routes r ON r.id = t.route_id
-          WHERE st.station_id = ?
-            AND st.line_id = ?
-            AND st.pickup_type = 0
-            AND r.line_id = st.line_id
-            AND TRIM(r.direction_name) <> ''
-            $serviceFilter
-          ORDER BY st.departure_seconds
-          ''',
-          variables: [
-            Variable.withString(selection.stationId),
-            Variable.withString(selection.lineId),
-            ...?serviceIds?.map(Variable.withString),
-          ],
-        )
-        .get();
-    return rows
-        .map(
-          (row) => _StopTimeDeparture(
-            directionName: row.read<String>('direction_name'),
-            seconds: row.read<int>('departure_seconds'),
-          ),
-        )
-        .toList(growable: false);
+  }) {
+    return CatalogStationTimetableQuery(catalogDatabase).loadDepartures(
+      stationId: selection.stationId,
+      lineId: selection.lineId,
+      serviceIds: serviceIds,
+    );
   }
-}
-
-class _StopTimeDeparture {
-  const _StopTimeDeparture({
-    required this.directionName,
-    required this.seconds,
-  });
-
-  final String directionName;
-  final int seconds;
 }
 
 class _Departure {
@@ -331,14 +249,6 @@ class _Departure {
   final String directionName;
   final DateTime serviceDate;
   final DateTime departureAt;
-}
-
-bool _isEnabled(Object? value) => value == true || value == 1;
-
-String _dateKey(DateTime date) {
-  return '${date.year.toString().padLeft(4, '0')}'
-      '${date.month.toString().padLeft(2, '0')}'
-      '${date.day.toString().padLeft(2, '0')}';
 }
 
 tz.TZDateTime? _parseServiceDate(String value) {

--- a/apps/mobile/lib/features/stations/data/drift_station_repository.dart
+++ b/apps/mobile/lib/features/stations/data/drift_station_repository.dart
@@ -41,6 +41,7 @@ class DriftStationRepository
     required String stationId,
     required String lineId,
     required StationTimetableDayType dayType,
+    required DateTime referenceDate,
   }) async {
     final catalogDayType = switch (dayType) {
       StationTimetableDayType.weekday => CatalogTimetableDayType.weekday,
@@ -52,6 +53,7 @@ class DriftStationRepository
       stationId: stationId,
       lineId: lineId,
       dayType: catalogDayType,
+      referenceDate: referenceDate,
     );
     return _stationTimetable(
       stationId: stationId,

--- a/apps/mobile/lib/features/stations/data/drift_station_repository.dart
+++ b/apps/mobile/lib/features/stations/data/drift_station_repository.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'package:drift/drift.dart';
 
 import '../../../core/database/catalog/catalog_database.dart';
+import '../../../core/database/catalog/station_timetable_query.dart';
 import '../../../network_map.dart';
 import '../../../station_search.dart';
 
@@ -10,6 +11,7 @@ class DriftStationRepository
     implements
         StationSearchRepository,
         StationLineFilterRepository,
+        StationTimetableRepository,
         NetworkMapRepository {
   DriftStationRepository({required this.database});
 
@@ -32,6 +34,86 @@ class DriftStationRepository
         .where((station) => station.matches(trimmedQuery))
         .map((station) => station.toSearchResult())
         .toList(growable: false);
+  }
+
+  @override
+  Future<StationTimetable> loadStationTimetable({
+    required String stationId,
+    required String lineId,
+    required StationTimetableDayType dayType,
+  }) async {
+    final catalogDayType = switch (dayType) {
+      StationTimetableDayType.weekday => CatalogTimetableDayType.weekday,
+      StationTimetableDayType.saturday => CatalogTimetableDayType.saturday,
+      StationTimetableDayType.sundayHoliday =>
+        CatalogTimetableDayType.sundayHoliday,
+    };
+    final rows = await CatalogStationTimetableQuery(database).loadDepartures(
+      stationId: stationId,
+      lineId: lineId,
+      dayType: catalogDayType,
+    );
+    return _stationTimetable(
+      stationId: stationId,
+      lineId: lineId,
+      dayType: dayType,
+      rows: rows,
+    );
+  }
+
+  @override
+  Future<StationTimetable> loadStationTimetableForDate({
+    required String stationId,
+    required String lineId,
+    required DateTime date,
+  }) async {
+    final timetable = await CatalogStationTimetableQuery(
+      database,
+    ).loadDeparturesForDate(stationId: stationId, lineId: lineId, date: date);
+    final dayType = switch (timetable.dayType) {
+      CatalogTimetableDayType.weekday => StationTimetableDayType.weekday,
+      CatalogTimetableDayType.saturday => StationTimetableDayType.saturday,
+      CatalogTimetableDayType.sundayHoliday =>
+        StationTimetableDayType.sundayHoliday,
+    };
+    return _stationTimetable(
+      stationId: stationId,
+      lineId: lineId,
+      dayType: dayType,
+      rows: timetable.departures,
+    );
+  }
+
+  StationTimetable _stationTimetable({
+    required String stationId,
+    required String lineId,
+    required StationTimetableDayType dayType,
+    required List<CatalogStationDeparture> rows,
+  }) {
+    final grouped = <String, List<StationTimetableDeparture>>{};
+    for (final row in rows) {
+      final directionName = row.directionName;
+      grouped
+          .putIfAbsent(directionName, () => <StationTimetableDeparture>[])
+          .add(
+            StationTimetableDeparture(
+              directionName: directionName,
+              seconds: row.seconds,
+            ),
+          );
+    }
+    return StationTimetable(
+      stationId: stationId,
+      lineId: lineId,
+      dayType: dayType,
+      directions: [
+        for (final entry in grouped.entries)
+          StationTimetableDirection(
+            name: entry.key,
+            departures: List.unmodifiable(entry.value),
+          ),
+      ],
+    );
   }
 
   @override

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -88,6 +88,94 @@ abstract class StationLineFilterRepository {
   );
 }
 
+enum StationTimetableDayType {
+  weekday('평일'),
+  saturday('토요일'),
+  sundayHoliday('일요일·공휴일');
+
+  const StationTimetableDayType(this.label);
+
+  final String label;
+}
+
+abstract class StationTimetableRepository {
+  Future<StationTimetable> loadStationTimetable({
+    required String stationId,
+    required String lineId,
+    required StationTimetableDayType dayType,
+  });
+
+  Future<StationTimetable> loadStationTimetableForDate({
+    required String stationId,
+    required String lineId,
+    required DateTime date,
+  });
+}
+
+class StationTimetable {
+  const StationTimetable({
+    required this.stationId,
+    required this.lineId,
+    required this.dayType,
+    required this.directions,
+  });
+
+  final String stationId;
+  final String lineId;
+  final StationTimetableDayType dayType;
+  final List<StationTimetableDirection> directions;
+
+  bool get isAvailable => directions.isNotEmpty;
+}
+
+class StationTimetableDirection {
+  const StationTimetableDirection({
+    required this.name,
+    required this.departures,
+  });
+
+  final String name;
+  final List<StationTimetableDeparture> departures;
+
+  StationTimetableDeparture get firstDeparture => departures.first;
+
+  StationTimetableDeparture get lastDeparture => departures.last;
+}
+
+class StationTimetableDeparture {
+  const StationTimetableDeparture({
+    required this.directionName,
+    required this.seconds,
+  });
+
+  final String directionName;
+  final int seconds;
+
+  String get timeLabel {
+    final prefix = seconds >= Duration.secondsPerDay ? '다음 날 ' : '';
+    return '$prefix${_clockLabel(seconds)}';
+  }
+
+  String get semanticLabel {
+    final normalized = seconds % Duration.secondsPerDay;
+    final hour = normalized ~/ Duration.secondsPerHour;
+    final minute =
+        (normalized % Duration.secondsPerHour) ~/ Duration.secondsPerMinute;
+    final prefix = seconds >= Duration.secondsPerDay ? '다음 날 ' : '';
+    return '$directionName, $prefix${hour.toString().padLeft(2, '0')}시 '
+        '${minute.toString().padLeft(2, '0')}분 출발';
+  }
+}
+
+String _clockLabel(int seconds) {
+  final normalized = seconds % Duration.secondsPerDay;
+  final hour = normalized ~/ Duration.secondsPerHour;
+  final minute =
+      (normalized % Duration.secondsPerHour) ~/ Duration.secondsPerMinute;
+  return '${hour.toString().padLeft(2, '0')}:'
+      '${minute.toString().padLeft(2, '0')}';
+}
+
 enum LocationPermissionPrecision { precise, approximate, unknown }
 
 enum CurrentLocationQualityStatus {
@@ -2926,6 +3014,205 @@ class StationDetailScreen extends StatefulWidget {
   State<StationDetailScreen> createState() => _StationDetailScreenState();
 }
 
+class StationTimetableScreen extends StatefulWidget {
+  const StationTimetableScreen({
+    required this.stationId,
+    required this.stationName,
+    required this.lines,
+    this.repository,
+    super.key,
+  });
+
+  final String stationId;
+  final String stationName;
+  final List<StationSearchLine> lines;
+  final StationTimetableRepository? repository;
+
+  @override
+  State<StationTimetableScreen> createState() => _StationTimetableScreenState();
+}
+
+class _StationTimetableScreenState extends State<StationTimetableScreen> {
+  late String? _lineId;
+  late StationTimetableDayType _dayType;
+  StationTimetable? _timetable;
+  String? _directionName;
+  var _loading = false;
+  var _requestId = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _lineId = widget.lines.firstOrNull?.id;
+    _dayType = _todayTimetableDayType(debugStationVerifiedClock());
+    if (widget.repository != null && _lineId != null) {
+      unawaited(_load(date: debugStationVerifiedClock()));
+    }
+  }
+
+  Future<void> _load({DateTime? date}) async {
+    final repository = widget.repository;
+    final lineId = _lineId;
+    if (repository == null || lineId == null) {
+      return;
+    }
+    final requestId = ++_requestId;
+    setState(() => _loading = true);
+    try {
+      final timetable = date == null
+          ? await repository.loadStationTimetable(
+              stationId: widget.stationId,
+              lineId: lineId,
+              dayType: _dayType,
+            )
+          : await repository.loadStationTimetableForDate(
+              stationId: widget.stationId,
+              lineId: lineId,
+              date: date,
+            );
+      if (!mounted || requestId != _requestId) {
+        return;
+      }
+      final directionNames = timetable.directions
+          .map((direction) => direction.name)
+          .toSet();
+      setState(() {
+        _timetable = timetable;
+        _dayType = timetable.dayType;
+        _directionName = directionNames.contains(_directionName)
+            ? _directionName
+            : timetable.directions.firstOrNull?.name;
+        _loading = false;
+      });
+    } catch (error, stackTrace) {
+      reportMobileError(error, stackTrace, context: '역 시간표 조회 중 예외가 발생했습니다.');
+      if (!mounted || requestId != _requestId) {
+        return;
+      }
+      setState(() {
+        _timetable = null;
+        _directionName = null;
+        _loading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final timetable = _timetable;
+    final direction = timetable?.directions
+        .where((item) => item.name == _directionName)
+        .firstOrNull;
+    return Scaffold(
+      appBar: AppBar(title: Text('${widget.stationName} 시간표')),
+      body: SafeArea(
+        child: ListView(
+          padding: _stationSearchPagePadding,
+          children: [
+            if (widget.lines.length > 1) ...[
+              const _StationDetailSectionTitle(title: '노선'),
+              const SizedBox(height: 8),
+              Wrap(
+                spacing: 8,
+                children: [
+                  for (final line in widget.lines)
+                    ChoiceChip(
+                      key: Key('stationTimetableLine-${line.id}'),
+                      label: Text(line.name),
+                      selected: _lineId == line.id,
+                      onSelected: (_) {
+                        setState(() => _lineId = line.id);
+                        unawaited(_load());
+                      },
+                    ),
+                ],
+              ),
+              const SizedBox(height: 20),
+            ],
+            const _StationDetailSectionTitle(title: '운행일'),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                for (final dayType in StationTimetableDayType.values)
+                  ChoiceChip(
+                    key: Key('stationTimetableDay-${dayType.name}'),
+                    label: Text(dayType.label),
+                    selected: _dayType == dayType,
+                    onSelected: (_) {
+                      setState(() => _dayType = dayType);
+                      unawaited(_load());
+                    },
+                  ),
+              ],
+            ),
+            const SizedBox(height: 20),
+            if (_loading)
+              const Center(child: CircularProgressIndicator())
+            else if (timetable == null || !timetable.isAvailable)
+              const _StationDetailEmptyMessage(message: '시간표를 준비 중이에요.')
+            else ...[
+              const _StationDetailSectionTitle(title: '방향'),
+              const SizedBox(height: 8),
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  for (final item in timetable.directions)
+                    ChoiceChip(
+                      key: Key('stationTimetableDirection-${item.name}'),
+                      label: Text(item.name),
+                      selected: _directionName == item.name,
+                      onSelected: (_) =>
+                          setState(() => _directionName = item.name),
+                    ),
+                ],
+              ),
+              if (direction != null) ...[
+                const SizedBox(height: 20),
+                Wrap(
+                  spacing: 20,
+                  runSpacing: 8,
+                  children: [
+                    Text('첫차 ${direction.firstDeparture.timeLabel}'),
+                    Text('막차 ${direction.lastDeparture.timeLabel}'),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                for (
+                  var index = 0;
+                  index < direction.departures.length;
+                  index++
+                ) ...[
+                  if (index > 0) const Divider(height: 1),
+                  Semantics(
+                    label: direction.departures[index].semanticLabel,
+                    child: ExcludeSemantics(
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 14),
+                        child: Text(direction.departures[index].timeLabel),
+                      ),
+                    ),
+                  ),
+                ],
+              ],
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+StationTimetableDayType _todayTimetableDayType(DateTime now) {
+  return switch (now.weekday) {
+    DateTime.saturday => StationTimetableDayType.saturday,
+    DateTime.sunday => StationTimetableDayType.sundayHoliday,
+    _ => StationTimetableDayType.weekday,
+  };
+}
+
 class _StationDetailScreenState extends State<StationDetailScreen> {
   late final StationDetailController _controller;
   StationFavoriteToggleController? _favoriteController;
@@ -3002,6 +3289,10 @@ class _StationDetailScreenState extends State<StationDetailScreen> {
                 mapLauncher: widget.mapLauncher,
                 facilityReportDraftTargetStore:
                     widget.facilityReportDraftTargetStore,
+                timetableRepository:
+                    widget.repository is StationTimetableRepository
+                    ? widget.repository as StationTimetableRepository
+                    : null,
               );
             },
           ),
@@ -3023,6 +3314,7 @@ class _StationDetailBody extends StatelessWidget {
     required this.locationProvider,
     required this.mapLauncher,
     required this.facilityReportDraftTargetStore,
+    required this.timetableRepository,
   });
 
   final StationDetailState state;
@@ -3035,6 +3327,7 @@ class _StationDetailBody extends StatelessWidget {
   final CurrentLocationProvider? locationProvider;
   final KakaoMapLauncher mapLauncher;
   final FacilityReportDraftTargetStore? facilityReportDraftTargetStore;
+  final StationTimetableRepository? timetableRepository;
 
   @override
   Widget build(BuildContext context) {
@@ -3066,6 +3359,7 @@ class _StationDetailBody extends StatelessWidget {
         locationProvider: locationProvider,
         mapLauncher: mapLauncher,
         facilityReportDraftTargetStore: facilityReportDraftTargetStore,
+        timetableRepository: timetableRepository,
       ),
     };
   }
@@ -3090,6 +3384,7 @@ class _StationDetailContent extends StatelessWidget {
     required this.locationProvider,
     required this.mapLauncher,
     required this.facilityReportDraftTargetStore,
+    required this.timetableRepository,
   });
 
   final StationDetail detail;
@@ -3109,6 +3404,7 @@ class _StationDetailContent extends StatelessWidget {
   final CurrentLocationProvider? locationProvider;
   final KakaoMapLauncher mapLauncher;
   final FacilityReportDraftTargetStore? facilityReportDraftTargetStore;
+  final StationTimetableRepository? timetableRepository;
 
   @override
   Widget build(BuildContext context) {
@@ -3137,6 +3433,8 @@ class _StationDetailContent extends StatelessWidget {
         routeDraftController: routeDraftController,
         favoriteController: favoriteController,
       ),
+      const SizedBox(height: 20),
+      _StationTimetableEntry(detail: detail, repository: timetableRepository),
     ];
     // 데이터 부재(unavailable) 상태는 화면에 아무것도 그리지 않으므로
     // 역 안 이동 섹션 노출 여부·간격 계산에서도 빈 안내로 취급한다(#1577).
@@ -3285,6 +3583,91 @@ class _StationDetailContent extends StatelessWidget {
       return null;
     }
     return provider.openLocationSettings;
+  }
+}
+
+class _StationTimetableEntry extends StatefulWidget {
+  const _StationTimetableEntry({required this.detail, this.repository});
+
+  final StationDetail detail;
+  final StationTimetableRepository? repository;
+
+  @override
+  State<_StationTimetableEntry> createState() => _StationTimetableEntryState();
+}
+
+class _StationTimetableEntryState extends State<_StationTimetableEntry> {
+  StationTimetable? _timetable;
+
+  @override
+  void initState() {
+    super.initState();
+    final repository = widget.repository;
+    final line = widget.detail.lines.firstOrNull;
+    if (repository != null && line != null) {
+      unawaited(_load(repository, line.id));
+    }
+  }
+
+  Future<void> _load(
+    StationTimetableRepository repository,
+    String lineId,
+  ) async {
+    try {
+      final timetable = await repository.loadStationTimetableForDate(
+        stationId: widget.detail.id,
+        lineId: lineId,
+        date: debugStationVerifiedClock(),
+      );
+      if (mounted) {
+        setState(() => _timetable = timetable);
+      }
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '역 상세 시간표 요약 조회 중 예외가 발생했습니다.',
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final timetable = _timetable;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const _StationDetailSectionTitle(title: '시간표'),
+        const SizedBox(height: 8),
+        if (timetable != null && timetable.isAvailable)
+          for (final direction in timetable.directions)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 4),
+              child: Text(
+                '${direction.name} · 첫차 ${direction.firstDeparture.timeLabel} · '
+                '막차 ${direction.lastDeparture.timeLabel}',
+              ),
+            )
+        else
+          const Text('시간표를 준비 중이에요.'),
+        const SizedBox(height: 4),
+        TextButton.icon(
+          key: const Key('stationTimetableButton'),
+          onPressed: () => Navigator.of(context).push(
+            MaterialPageRoute<void>(
+              builder: (_) => StationTimetableScreen(
+                stationId: widget.detail.id,
+                stationName: widget.detail.nameKo,
+                lines: widget.detail.lines,
+                repository: widget.repository,
+              ),
+            ),
+          ),
+          icon: const Icon(Icons.schedule),
+          label: const Text('시간표 보기'),
+        ),
+      ],
+    );
   }
 }
 

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -103,6 +103,7 @@ abstract class StationTimetableRepository {
     required String stationId,
     required String lineId,
     required StationTimetableDayType dayType,
+    required DateTime referenceDate,
   });
 
   Future<StationTimetable> loadStationTimetableForDate({
@@ -3044,13 +3045,14 @@ class _StationTimetableScreenState extends State<StationTimetableScreen> {
   void initState() {
     super.initState();
     _lineId = widget.lines.firstOrNull?.id;
-    _dayType = _todayTimetableDayType(debugStationVerifiedClock());
+    final now = debugStationVerifiedClock();
+    _dayType = _todayTimetableDayType(now);
     if (widget.repository != null && _lineId != null) {
-      unawaited(_load(date: debugStationVerifiedClock()));
+      unawaited(_load(date: now, findCoverage: true));
     }
   }
 
-  Future<void> _load({DateTime? date}) async {
+  Future<void> _load({DateTime? date, bool findCoverage = false}) async {
     final repository = widget.repository;
     final lineId = _lineId;
     if (repository == null || lineId == null) {
@@ -3059,11 +3061,19 @@ class _StationTimetableScreenState extends State<StationTimetableScreen> {
     final requestId = ++_requestId;
     setState(() => _loading = true);
     try {
-      final timetable = date == null
+      final timetable = findCoverage
+          ? await _loadFirstAvailableStationTimetable(
+              stationId: widget.stationId,
+              lines: widget.lines,
+              repository: repository,
+              date: date!,
+            )
+          : date == null
           ? await repository.loadStationTimetable(
               stationId: widget.stationId,
               lineId: lineId,
               dayType: _dayType,
+              referenceDate: debugStationVerifiedClock(),
             )
           : await repository.loadStationTimetableForDate(
               stationId: widget.stationId,
@@ -3073,11 +3083,16 @@ class _StationTimetableScreenState extends State<StationTimetableScreen> {
       if (!mounted || requestId != _requestId) {
         return;
       }
+      if (timetable == null) {
+        setState(() => _loading = false);
+        return;
+      }
       final directionNames = timetable.directions
           .map((direction) => direction.name)
           .toSet();
       setState(() {
         _timetable = timetable;
+        _lineId = timetable.lineId;
         _dayType = timetable.dayType;
         _directionName = directionNames.contains(_directionName)
             ? _directionName
@@ -3211,6 +3226,27 @@ StationTimetableDayType _todayTimetableDayType(DateTime now) {
     DateTime.sunday => StationTimetableDayType.sundayHoliday,
     _ => StationTimetableDayType.weekday,
   };
+}
+
+Future<StationTimetable?> _loadFirstAvailableStationTimetable({
+  required String stationId,
+  required List<StationSearchLine> lines,
+  required StationTimetableRepository repository,
+  required DateTime date,
+}) async {
+  StationTimetable? firstResult;
+  for (final line in lines) {
+    final timetable = await repository.loadStationTimetableForDate(
+      stationId: stationId,
+      lineId: line.id,
+      date: date,
+    );
+    firstResult ??= timetable;
+    if (timetable.isAvailable) {
+      return timetable;
+    }
+  }
+  return firstResult;
 }
 
 class _StationDetailScreenState extends State<StationDetailScreen> {
@@ -3603,23 +3639,23 @@ class _StationTimetableEntryState extends State<_StationTimetableEntry> {
   void initState() {
     super.initState();
     final repository = widget.repository;
-    final line = widget.detail.lines.firstOrNull;
-    if (repository != null && line != null) {
-      unawaited(_load(repository, line.id));
+    if (repository != null && widget.detail.lines.isNotEmpty) {
+      unawaited(_load(repository, widget.detail.lines));
     }
   }
 
   Future<void> _load(
     StationTimetableRepository repository,
-    String lineId,
+    List<StationSearchLine> lines,
   ) async {
     try {
-      final timetable = await repository.loadStationTimetableForDate(
+      final timetable = await _loadFirstAvailableStationTimetable(
         stationId: widget.detail.id,
-        lineId: lineId,
+        lines: lines,
+        repository: repository,
         date: debugStationVerifiedClock(),
       );
-      if (mounted) {
+      if (mounted && timetable != null) {
         setState(() => _timetable = timetable);
       }
     } catch (error, stackTrace) {

--- a/apps/mobile/test/features/stations/drift_station_repository_test.dart
+++ b/apps/mobile/test/features/stations/drift_station_repository_test.dart
@@ -240,6 +240,7 @@ void main() {
       stationId: 'station-sadang',
       lineId: 'seoul-4',
       dayType: StationTimetableDayType.weekday,
+      referenceDate: DateTime(2026, 7, 12),
     );
 
     expect(timetable.isAvailable, isTrue);
@@ -271,16 +272,19 @@ void main() {
       stationId: 'station-sadang',
       lineId: 'seoul-4',
       dayType: StationTimetableDayType.saturday,
+      referenceDate: DateTime(2026, 7, 12),
     );
     final holiday = await repository.loadStationTimetable(
       stationId: 'station-sadang',
       lineId: 'seoul-4',
       dayType: StationTimetableDayType.sundayHoliday,
+      referenceDate: DateTime(2026, 7, 12),
     );
     final unavailable = await repository.loadStationTimetable(
       stationId: 'station-sangnoksu',
       lineId: 'seoul-4',
       dayType: StationTimetableDayType.weekday,
+      referenceDate: DateTime(2026, 7, 12),
     );
 
     expect(saturday.directions.single.departures.single.timeLabel, '09:12');
@@ -309,6 +313,46 @@ void main() {
 
     expect(timetable.dayType, StationTimetableDayType.sundayHoliday);
     expect(timetable.directions.single.departures.single.timeLabel, '10:30');
+  });
+
+  test('로컬 역 시간표는 Asia/Seoul service date로 요일을 선택한다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await database.seedBaselineIfEmpty();
+    await _seedStationTimetable(database);
+    final repository = DriftStationRepository(database: database);
+
+    final timetable = await repository.loadStationTimetableForDate(
+      stationId: 'station-sadang',
+      lineId: 'seoul-4',
+      date: DateTime.utc(2026, 7, 6, 15, 30),
+    );
+
+    expect(timetable.dayType, StationTimetableDayType.weekday);
+    expect(
+      timetable.directions
+          .singleWhere((direction) => direction.name == '사당 방면')
+          .firstDeparture
+          .timeLabel,
+      '05:20',
+    );
+  });
+
+  test('로컬 역 요일 시간표는 feed 만료 뒤 출발을 반환하지 않는다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await database.seedBaselineIfEmpty();
+    await _seedStationTimetable(database);
+    final repository = DriftStationRepository(database: database);
+
+    final timetable = await repository.loadStationTimetable(
+      stationId: 'station-sadang',
+      lineId: 'seoul-4',
+      dayType: StationTimetableDayType.weekday,
+      referenceDate: DateTime(2027, 1, 1),
+    );
+
+    expect(timetable.isAvailable, isFalse);
   });
 
   test('앱 기본 의존성은 catalog DB가 있으면 로컬 역 repository를 사용한다', () async {
@@ -354,6 +398,15 @@ void main() {
 }
 
 Future<void> _seedStationTimetable(CatalogDatabase database) async {
+  await database.customStatement('''
+    CREATE TABLE transit_feed_info (
+      id INTEGER PRIMARY KEY,
+      feed_end_date TEXT NOT NULL
+    )
+  ''');
+  await database.customStatement(
+    "INSERT INTO transit_feed_info (id, feed_end_date) VALUES (1, '20261231')",
+  );
   await database.customStatement('''
     INSERT INTO service_calendars (
       service_id, monday, tuesday, wednesday, thursday, friday,

--- a/apps/mobile/test/features/stations/drift_station_repository_test.dart
+++ b/apps/mobile/test/features/stations/drift_station_repository_test.dart
@@ -229,6 +229,88 @@ void main() {
     );
   });
 
+  test('로컬 역 시간표는 요일 유형별 출발을 방향으로 묶고 첫차와 막차를 보존한다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await database.seedBaselineIfEmpty();
+    await _seedStationTimetable(database);
+    final repository = DriftStationRepository(database: database);
+
+    final timetable = await repository.loadStationTimetable(
+      stationId: 'station-sadang',
+      lineId: 'seoul-4',
+      dayType: StationTimetableDayType.weekday,
+    );
+
+    expect(timetable.isAvailable, isTrue);
+    expect(timetable.dayType.label, '평일');
+    expect(
+      timetable.directions.map((direction) => direction.name),
+      unorderedEquals(['상록수 방면', '사당 방면']),
+    );
+    final sadang = timetable.directions.singleWhere(
+      (direction) => direction.name == '사당 방면',
+    );
+    expect(sadang.departures.map((departure) => departure.timeLabel), [
+      '05:20',
+      '다음 날 00:25',
+    ]);
+    expect(sadang.firstDeparture.timeLabel, '05:20');
+    expect(sadang.lastDeparture.timeLabel, '다음 날 00:25');
+    expect(sadang.lastDeparture.semanticLabel, '사당 방면, 다음 날 00시 25분 출발');
+  });
+
+  test('로컬 역 시간표는 토요일과 일요일·공휴일 calendar를 분리하고 미지원 역을 강등한다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await database.seedBaselineIfEmpty();
+    await _seedStationTimetable(database);
+    final repository = DriftStationRepository(database: database);
+
+    final saturday = await repository.loadStationTimetable(
+      stationId: 'station-sadang',
+      lineId: 'seoul-4',
+      dayType: StationTimetableDayType.saturday,
+    );
+    final holiday = await repository.loadStationTimetable(
+      stationId: 'station-sadang',
+      lineId: 'seoul-4',
+      dayType: StationTimetableDayType.sundayHoliday,
+    );
+    final unavailable = await repository.loadStationTimetable(
+      stationId: 'station-sangnoksu',
+      lineId: 'seoul-4',
+      dayType: StationTimetableDayType.weekday,
+    );
+
+    expect(saturday.directions.single.departures.single.timeLabel, '09:12');
+    expect(holiday.directions.single.departures.single.timeLabel, '10:30');
+    expect(unavailable.isAvailable, isFalse);
+    expect(unavailable.directions, isEmpty);
+  });
+
+  test('로컬 역 시간표는 평일 공휴일 exception을 일요일·공휴일로 자동 선택한다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await database.seedBaselineIfEmpty();
+    await _seedStationTimetable(database);
+    await database.customStatement('''
+      INSERT INTO service_calendar_dates (service_id, date, exception_type)
+      VALUES ('weekday-1919', '20260817', 2),
+             ('holiday-1919', '20260817', 1)
+    ''');
+    final repository = DriftStationRepository(database: database);
+
+    final timetable = await repository.loadStationTimetableForDate(
+      stationId: 'station-sadang',
+      lineId: 'seoul-4',
+      date: DateTime(2026, 8, 17),
+    );
+
+    expect(timetable.dayType, StationTimetableDayType.sundayHoliday);
+    expect(timetable.directions.single.departures.single.timeLabel, '10:30');
+  });
+
   test('앱 기본 의존성은 catalog DB가 있으면 로컬 역 repository를 사용한다', () async {
     final database = CatalogDatabase.memory();
     addTearDown(database.close);
@@ -269,4 +351,51 @@ void main() {
 
     expect(track.paths, ['M 0 0 L 10 0', 'M 20 0 L 30 0']);
   });
+}
+
+Future<void> _seedStationTimetable(CatalogDatabase database) async {
+  await database.customStatement('''
+    INSERT INTO service_calendars (
+      service_id, monday, tuesday, wednesday, thursday, friday,
+      saturday, sunday, start_date, end_date, timezone
+    ) VALUES
+      ('weekday-1919', 0, 1, 0, 0, 0, 0, 0, '20260101', '20261231', 'Asia/Seoul'),
+      ('saturday-1919', 0, 0, 0, 0, 0, 1, 0, '20260101', '20261231', 'Asia/Seoul'),
+      ('holiday-1919', 0, 0, 0, 0, 0, 0, 1, '20260101', '20261231', 'Asia/Seoul')
+  ''');
+  await database.customStatement('''
+    INSERT INTO transit_routes (
+      id, line_id, route_short_name, route_long_name, direction_name, timezone
+    ) VALUES
+      ('line4-up-1919', 'seoul-4', '4', '상록수 방면', '상록수 방면', 'Asia/Seoul'),
+      ('line4-down-1919', 'seoul-4', '4', '사당 방면', '사당 방면', 'Asia/Seoul')
+  ''');
+  await database.customStatement('''
+    INSERT INTO transit_trips (
+      id, route_id, service_id, trip_headsign, direction_id,
+      service_pattern, service_day_start_seconds
+    ) VALUES
+      ('weekday-up-1919', 'line4-up-1919', 'weekday-1919', '상록수', 'up', 'LOCAL', 0),
+      ('weekday-down-1919-a', 'line4-down-1919', 'weekday-1919', '사당', 'down', 'LOCAL', 0),
+      ('weekday-down-1919-b', 'line4-down-1919', 'weekday-1919', '사당', 'down', 'LOCAL', 0),
+      ('saturday-down-1919', 'line4-down-1919', 'saturday-1919', '사당', 'down', 'LOCAL', 0),
+      ('holiday-down-1919', 'line4-down-1919', 'holiday-1919', '사당', 'down', 'LOCAL', 0)
+  ''');
+  for (final row in <(String, int)>[
+    ('weekday-up-1919', 19500),
+    ('weekday-down-1919-a', 19200),
+    ('weekday-down-1919-b', 87900),
+    ('saturday-down-1919', 33120),
+    ('holiday-down-1919', 37800),
+  ]) {
+    await database.customStatement(
+      '''
+      INSERT INTO transit_stop_times (
+        trip_id, stop_sequence, station_id, line_id,
+        arrival_seconds, departure_seconds, pickup_type, drop_off_type
+      ) VALUES (?, 1, 'station-sadang', 'seoul-4', ?, ?, 0, 0)
+      ''',
+      [row.$1, row.$2, row.$2],
+    );
+  }
 }

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -9035,6 +9035,74 @@ void main() {
     expect(find.textContaining('임시'), findsNothing);
   });
 
+  testWidgets('환승역 시간표는 coverage가 있는 첫 노선을 기본 선택한다', (tester) async {
+    debugStationVerifiedClock = () => DateTime(2026, 7, 6);
+    const lines = [
+      StationSearchLine(
+        id: 'seoul-2',
+        name: '수도권 2호선',
+        color: '#00A84D',
+        stationCode: '226',
+      ),
+      StationSearchLine(
+        id: 'seoul-4',
+        name: '수도권 4호선',
+        color: '#00A5DE',
+        stationCode: '433',
+      ),
+    ];
+    final repository = FakeTimetableStationRepository(
+      stationDetail: _stationDetail(
+        id: 'station-sadang',
+        name: '사당',
+        lines: lines,
+      ),
+      timetableLineId: 'seoul-4',
+      timetables: {
+        StationTimetableDayType.weekday: _stationTimetable(
+          StationTimetableDayType.weekday,
+          stationId: 'station-sadang',
+          lineId: 'seoul-4',
+          directions: const [
+            StationTimetableDirection(
+              name: '상록수 방면',
+              departures: [
+                StationTimetableDeparture(
+                  directionName: '상록수 방면',
+                  seconds: 19500,
+                ),
+              ],
+            ),
+          ],
+        ),
+      },
+    );
+
+    try {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: StationDetailScreen(
+            repository: repository,
+            reportRepository: FakeFacilityReportRepository(),
+            stationId: 'station-sadang',
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('상록수 방면 · 첫차 05:25 · 막차 05:25'), findsOneWidget);
+      await tester.tap(find.byKey(const Key('stationTimetableButton')));
+      await tester.pumpAndSettle();
+
+      final selectedLine = tester.widget<ChoiceChip>(
+        find.byKey(const Key('stationTimetableLine-seoul-4')),
+      );
+      expect(selectedLine.selected, isTrue);
+    } finally {
+      debugStationVerifiedClock = DateTime.now;
+    }
+  });
+
   testWidgets('역 상세는 좌표 있는 출구에만 카카오맵 버튼을 보여준다', (tester) async {
     debugStationVerifiedClock = () => DateTime(2026, 7, 9);
     final semanticsHandle = tester.ensureSemantics();
@@ -14893,9 +14961,11 @@ class FakeTimetableStationRepository extends FakeStationSearchRepository
   FakeTimetableStationRepository({
     required super.stationDetail,
     required this.timetables,
+    this.timetableLineId = 'seoul-2',
   });
 
   final Map<StationTimetableDayType, StationTimetable> timetables;
+  final String timetableLineId;
   final requestedDayTypes = <StationTimetableDayType>[];
 
   @override
@@ -14903,8 +14973,17 @@ class FakeTimetableStationRepository extends FakeStationSearchRepository
     required String stationId,
     required String lineId,
     required StationTimetableDayType dayType,
+    required DateTime referenceDate,
   }) async {
     requestedDayTypes.add(dayType);
+    if (lineId != timetableLineId) {
+      return StationTimetable(
+        stationId: stationId,
+        lineId: lineId,
+        dayType: dayType,
+        directions: const [],
+      );
+    }
     return timetables[dayType] ??
         StationTimetable(
           stationId: stationId,
@@ -14929,6 +15008,7 @@ class FakeTimetableStationRepository extends FakeStationSearchRepository
       stationId: stationId,
       lineId: lineId,
       dayType: dayType,
+      referenceDate: date,
     );
   }
 }
@@ -15893,6 +15973,7 @@ StationDetail _stationDetail({
   required String name,
   double? latitude,
   double? longitude,
+  List<StationSearchLine>? lines,
 }) {
   return StationDetail(
     id: id,
@@ -15904,24 +15985,28 @@ StationDetail _stationDetail({
     dataQualityLevel: 'LEVEL_1',
     dataSourceType: 'OFFICIAL_FILE',
     lastVerifiedAt: '2026-06-13',
-    lines: const [
-      StationSearchLine(
-        id: 'seoul-2',
-        name: '수도권 2호선',
-        color: '#00A84D',
-        stationCode: '222',
-      ),
-    ],
+    lines:
+        lines ??
+        const [
+          StationSearchLine(
+            id: 'seoul-2',
+            name: '수도권 2호선',
+            color: '#00A84D',
+            stationCode: '222',
+          ),
+        ],
   );
 }
 
 StationTimetable _stationTimetable(
   StationTimetableDayType dayType, {
   required List<StationTimetableDirection> directions,
+  String stationId = 'station-sangnoksu',
+  String lineId = 'seoul-2',
 }) {
   return StationTimetable(
-    stationId: 'station-sangnoksu',
-    lineId: 'seoul-2',
+    stationId: stationId,
+    lineId: lineId,
     dayType: dayType,
     directions: directions,
   );

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -8924,6 +8924,117 @@ void main() {
     expect(banner.placement, AdPlacement.stationDetailBottom);
   });
 
+  testWidgets('역 상세 시간표는 요일과 방향을 바꾸며 첫차·막차와 출발 시각을 읽는다', (tester) async {
+    debugStationVerifiedClock = () => DateTime(2026, 7, 6);
+    final semanticsHandle = tester.ensureSemantics();
+    final repository = FakeTimetableStationRepository(
+      stationDetail: _stationDetail(id: 'station-sangnoksu', name: '상록수'),
+      timetables: {
+        StationTimetableDayType.weekday: _stationTimetable(
+          StationTimetableDayType.weekday,
+          directions: const [
+            StationTimetableDirection(
+              name: '사당 방면',
+              departures: [
+                StationTimetableDeparture(
+                  directionName: '사당 방면',
+                  seconds: 19200,
+                ),
+                StationTimetableDeparture(
+                  directionName: '사당 방면',
+                  seconds: 87900,
+                ),
+              ],
+            ),
+            StationTimetableDirection(
+              name: '오이도 방면',
+              departures: [
+                StationTimetableDeparture(
+                  directionName: '오이도 방면',
+                  seconds: 21000,
+                ),
+              ],
+            ),
+          ],
+        ),
+        StationTimetableDayType.saturday: _stationTimetable(
+          StationTimetableDayType.saturday,
+          directions: const [
+            StationTimetableDirection(
+              name: '사당 방면',
+              departures: [
+                StationTimetableDeparture(
+                  directionName: '사당 방면',
+                  seconds: 33120,
+                ),
+              ],
+            ),
+          ],
+        ),
+      },
+    );
+
+    try {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: StationDetailScreen(
+            repository: repository,
+            reportRepository: FakeFacilityReportRepository(),
+            stationId: 'station-sangnoksu',
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('stationTimetableButton')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('상록수 시간표'), findsOneWidget);
+      expect(find.text('첫차 05:20'), findsOneWidget);
+      expect(find.text('막차 다음 날 00:25'), findsOneWidget);
+      expect(find.bySemanticsLabel('사당 방면, 다음 날 00시 25분 출발'), findsOneWidget);
+
+      await tester.tap(
+        find.byKey(const Key('stationTimetableDirection-오이도 방면')),
+      );
+      await tester.pump();
+      expect(find.text('05:50'), findsOneWidget);
+      expect(find.text('다음 날 00:25'), findsNothing);
+
+      await tester.tap(find.byKey(const Key('stationTimetableDay-saturday')));
+      await tester.pumpAndSettle();
+      expect(find.text('첫차 09:12'), findsOneWidget);
+      expect(
+        repository.requestedDayTypes,
+        contains(StationTimetableDayType.saturday),
+      );
+    } finally {
+      semanticsHandle.dispose();
+      debugStationVerifiedClock = DateTime.now;
+    }
+  });
+
+  testWidgets('역 상세 시간표는 로컬 coverage가 없으면 준비 중으로 강등한다', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: StationDetailScreen(
+          repository: FakeStationSearchRepository(
+            stationDetail: _stationDetail(id: 'station-sangnoksu', name: '상록수'),
+          ),
+          reportRepository: FakeFacilityReportRepository(),
+          stationId: 'station-sangnoksu',
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('stationTimetableButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('시간표를 준비 중이에요.'), findsOneWidget);
+    expect(find.textContaining('임시'), findsNothing);
+  });
+
   testWidgets('역 상세는 좌표 있는 출구에만 카카오맵 버튼을 보여준다', (tester) async {
     debugStationVerifiedClock = () => DateTime(2026, 7, 9);
     final semanticsHandle = tester.ensureSemantics();
@@ -8970,6 +9081,11 @@ void main() {
       );
       await tester.pumpAndSettle();
 
+      await tester.scrollUntilVisible(
+        find.byKey(const Key('stationExitMapButton-exit-sangnoksu-1')),
+        500,
+      );
+      await tester.pumpAndSettle();
       expect(
         find.byKey(const Key('stationExitMapButton-exit-sangnoksu-1')),
         findsOneWidget,
@@ -8982,12 +9098,6 @@ void main() {
         find.bySemanticsLabel('1번 출구, 엘리베이터 연결, 계단 없는 이동 가능, 최근 확인 2주 전'),
         findsOneWidget,
       );
-
-      await tester.scrollUntilVisible(
-        find.byKey(const Key('stationExitMapButton-exit-sangnoksu-1')),
-        500,
-      );
-      await tester.pumpAndSettle();
       expect(
         find.bySemanticsLabel('1번 출구 카카오맵에서 보기, 새 앱이 열립니다'),
         findsOneWidget,
@@ -14778,6 +14888,51 @@ class FakeStationSearchRepository
   }
 }
 
+class FakeTimetableStationRepository extends FakeStationSearchRepository
+    implements StationTimetableRepository {
+  FakeTimetableStationRepository({
+    required super.stationDetail,
+    required this.timetables,
+  });
+
+  final Map<StationTimetableDayType, StationTimetable> timetables;
+  final requestedDayTypes = <StationTimetableDayType>[];
+
+  @override
+  Future<StationTimetable> loadStationTimetable({
+    required String stationId,
+    required String lineId,
+    required StationTimetableDayType dayType,
+  }) async {
+    requestedDayTypes.add(dayType);
+    return timetables[dayType] ??
+        StationTimetable(
+          stationId: stationId,
+          lineId: lineId,
+          dayType: dayType,
+          directions: const [],
+        );
+  }
+
+  @override
+  Future<StationTimetable> loadStationTimetableForDate({
+    required String stationId,
+    required String lineId,
+    required DateTime date,
+  }) {
+    final dayType = switch (date.weekday) {
+      DateTime.saturday => StationTimetableDayType.saturday,
+      DateTime.sunday => StationTimetableDayType.sundayHoliday,
+      _ => StationTimetableDayType.weekday,
+    };
+    return loadStationTimetable(
+      stationId: stationId,
+      lineId: lineId,
+      dayType: dayType,
+    );
+  }
+}
+
 class FakeSearchHistoryRepository implements SearchHistoryRepository {
   FakeSearchHistoryRepository(List<String> queries) : queries = [...queries];
 
@@ -15757,6 +15912,18 @@ StationDetail _stationDetail({
         stationCode: '222',
       ),
     ],
+  );
+}
+
+StationTimetable _stationTimetable(
+  StationTimetableDayType dayType, {
+  required List<StationTimetableDirection> directions,
+}) {
+  return StationTimetable(
+    stationId: 'station-sangnoksu',
+    lineId: 'seoul-2',
+    dayType: dayType,
+    directions: directions,
   );
 }
 


### PR DESCRIPTION
## 관련 이슈

Closes #1919

## 작업 배경

- #1415로 적재된 로컬 시간표를 역 상세에서 직접 열람할 수 있게 한다.
- #1768 홈 위젯과 중복되던 station-line 출발 조회를 공용 catalog query로 합친다.
- coverage 밖 역은 값을 만들지 않고 시간표 준비 중 상태로 강등한다.

## 작업 내용

- 역 상세에 오늘 첫차·막차 요약과 시간표 화면 진입점을 추가했다.
- 노선, 평일·토요일·일요일·공휴일, 방향별 전체 출발 시각을 구분선 목록으로 표시한다.
- 자정 이후 시각은 다음 날 라벨과 TalkBack 행 단위 낭독 라벨을 제공한다.
- service_calendar_dates 예외를 적용해 평일 공휴일에도 일요일·공휴일 시간표를 자동 선택한다.
- station timetable query를 공용화하고 기존 Android 다음 열차 위젯이 같은 조회 경로를 사용하게 했다.
- 길찾기 결과의 막차 임박 경고는 #1704 결과 화면 개편과 함께 판단하도록 이번 범위에서 구현하지 않는다.

## 검증

- 실행한 명령과 결과:
  - flutter analyze — No issues found
  - flutter test — 1,127 tests passed
  - rebase 후 시간표·홈 위젯·역 상세 회귀 테스트 — 8 tests passed
  - node --test tools/ci/repository-contract.test.mjs — 186 tests passed
  - git diff --check — 통과

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 역 상세 → 시간표 → 요일·방향 전환 | Android/Flutter | widget test | 역 상세 시간표는 요일과 방향을 바꾸며 첫차·막차와 출발 시각을 읽는다 | 통과 |
| coverage 밖 강등 | Android/Flutter | widget test | 역 상세 시간표는 로컬 coverage가 없으면 준비 중으로 강등한다 | 통과 |
| 자정 넘김·평일 공휴일 | catalog | repository test | 다음 날 00:25, 2026-08-17 holiday exception | 통과 |
| TalkBack | Android/Flutter | Semantics finder + 전체 접근성 baseline | 사당 방면, 다음 날 00시 25분 출발 | 통과 |
| 실기기 시각·비행기 모드·공식 시각 대조 | Android | 오너가 직접 확인하기로 결정 | 이 PR에는 자동 증거만 포함 | 오너 확인 예정 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [x] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 다음 mobile minor release에서 반영
- mobile versionCode: release build에서 단조 증가
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - station_timetable_query.dart의 calendar date exception과 service 범위 처리
  - station_search.dart의 비동기 요청 순서 보호와 coverage 강등
  - next_train_widget_repository.dart의 공용 query 전환 회귀 여부

## 리스크

- 현재 KRIC pilot coverage 밖에서는 의도적으로 시간표 준비 중으로 표시된다.
- 수동 day chip은 feed의 요일 유형을 보여주며, 오늘 자동 선택만 실제 calendar date exception을 적용한다.
- 서버 API, 네트워크 호출, DB schema, production datapack publish 변경은 없다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향 없음.