### PR TITLE
[Fix] #1701 baseline ingestion 후속 리뷰 보강

### DIFF
--- a/tools/datapack/build-baseline-ingestion-gate-report.mjs
+++ b/tools/datapack/build-baseline-ingestion-gate-report.mjs
@@ -89,7 +89,11 @@ export function buildKricMovementContext({ sourceCandidates, sourceInventory }) 
   if (!candidate) throw new Error(`${KRIC_MOVEMENT_SOURCE_ID} source candidate missing`);
   if (!inventorySource) throw new Error(`${KRIC_MOVEMENT_SOURCE_ID} source inventory entry missing`);
 
-  const sampleUrl = new URL(candidate.evidence?.sampleUrl ?? "");
+  const sampleUrlRaw = candidate.evidence?.sampleUrl;
+  if (typeof sampleUrlRaw !== "string" || sampleUrlRaw.trim() === "") {
+    throw new Error(`${KRIC_MOVEMENT_SOURCE_ID} candidate evidence.sampleUrl missing`);
+  }
+  const sampleUrl = new URL(sampleUrlRaw.trim());
   const requestTuple = Object.fromEntries(
     Object.keys(KRIC_CHUNGMURO_REQUEST_TUPLE).map((key) => [key, sampleUrl.searchParams.get(key)]),
   );

--- a/tools/datapack/build-baseline-ingestion-gate-report.test.mjs
+++ b/tools/datapack/build-baseline-ingestion-gate-report.test.mjs
@@ -5,6 +5,7 @@ import test from "node:test";
 import {
   buildBaselineIngestionGateReport,
   buildGateTimeSourceDistinction,
+  buildKricMovementContext,
   buildRosterFromPack,
 } from "./build-baseline-ingestion-gate-report.mjs";
 
@@ -131,6 +132,17 @@ test("buildRosterFromPack: 짧은 lineNameKo 도출('수도권 2호선'→'2호�
   assert.equal(branch.lineNameKo, "2호선 지선");
   const shinbundang = roster.find((r) => r.lineId === "shinbundang");
   assert.equal(shinbundang.lineNameKo, "신분당선");
+});
+
+test("buildKricMovementContext: candidate sampleUrl 누락을 명확히 거부한다", () => {
+  assert.throws(
+    () =>
+      buildKricMovementContext({
+        sourceCandidates: { candidates: [{ id: "kric-transfer-movement-detailed", evidence: {} }] },
+        sourceInventory: { sources: [{ id: "kric-transfer-movement-detailed" }] },
+      }),
+    /kric-transfer-movement-detailed candidate evidence\.sampleUrl missing/,
+  );
 });
 
 test("게이트③: generated baseline edge도 matching rule과 duration을 대조한다", () => {
@@ -261,6 +273,26 @@ test("게이트①: 양방향 환승 시간이 다르면 secondsMismatch를 기�
 
   assert.equal(sadangPair.hasReverse, true);
   assert.equal(sadangPair.secondsMismatch, true);
+});
+
+test("게이트①: 동일 역·노선 방향의 중복 행을 duplicateReport에 기록한다", () => {
+  const report = buildBaselineIngestionGateReport({
+    roster: buildRosterFromPack(pack),
+    transferRows: [
+      { 연번: 1, 호선: 2, 환승거리: 74, 환승노선: "4호선", 환승소요시간: "01:02", 환승역명: "사당" },
+      { 연번: 2, 호선: 2, 환승거리: 74, 환승노선: "4호선", 환승소요시간: "01:03", 환승역명: "사당" },
+    ],
+    carDoorRows: [],
+    kricMovement: null,
+  });
+  const duplicate = report.gateInternalConsistency.duplicateReport[0];
+
+  assert.equal(report.gateInternalConsistency.duplicateReport.length, 1);
+  assert.equal(duplicate.stationId, "station-sadang");
+  assert.equal(duplicate.fromLineId, "seoul-2");
+  assert.equal(duplicate.toLineId, "seoul-4");
+  assert.equal(duplicate.firstMinTransferSeconds, 62);
+  assert.equal(duplicate.duplicateMinTransferSeconds, 63);
 });
 
 test("리포트: 객체가 아닌 transfer row를 malformed로 계측하고 중단하지 않는다", () => {

--- a/tools/datapack/build-baseline-ingestion-gate-report.test.mjs
+++ b/tools/datapack/build-baseline-ingestion-gate-report.test.mjs
@@ -288,9 +288,9 @@ test("게이트①: 동일 역·노선 방향의 중복 행을 duplicateReport�
     carDoorRows: [],
     kricMovement: null,
   });
-  const duplicate = report.gateInternalConsistency.duplicateReport[0];
-
-  assert.equal(report.gateInternalConsistency.duplicateReport.length, 1);
+  const duplicates = report.gateInternalConsistency.duplicateReport;
+  assert.equal(duplicates.length, 1);
+  const duplicate = duplicates[0];
   assert.equal(duplicate.stationId, "station-sadang");
   assert.equal(duplicate.fromLineId, "seoul-2");
   assert.equal(duplicate.toLineId, "seoul-4");

--- a/tools/datapack/build-baseline-ingestion-gate-report.test.mjs
+++ b/tools/datapack/build-baseline-ingestion-gate-report.test.mjs
@@ -135,14 +135,17 @@ test("buildRosterFromPack: 짧은 lineNameKo 도출('수도권 2호선'→'2호�
 });
 
 test("buildKricMovementContext: candidate sampleUrl 누락을 명확히 거부한다", () => {
-  assert.throws(
-    () =>
-      buildKricMovementContext({
-        sourceCandidates: { candidates: [{ id: "kric-transfer-movement-detailed", evidence: {} }] },
-        sourceInventory: { sources: [{ id: "kric-transfer-movement-detailed" }] },
-      }),
-    /kric-transfer-movement-detailed candidate evidence\.sampleUrl missing/,
-  );
+  for (const sampleUrl of [undefined, " \t", null, 42]) {
+    const evidence = sampleUrl === undefined ? {} : { sampleUrl };
+    assert.throws(
+      () =>
+        buildKricMovementContext({
+          sourceCandidates: { candidates: [{ id: "kric-transfer-movement-detailed", evidence }] },
+          sourceInventory: { sources: [{ id: "kric-transfer-movement-detailed" }] },
+        }),
+      /kric-transfer-movement-detailed candidate evidence\.sampleUrl missing/,
+    );
+  }
 });
 
 test("게이트③: generated baseline edge도 matching rule과 duration을 대조한다", () => {

--- a/tools/datapack/normalize-transfer-distance-duration-rows.mjs
+++ b/tools/datapack/normalize-transfer-distance-duration-rows.mjs
@@ -24,6 +24,7 @@
 //   --rows <in.json> --output <out.json>
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 
 import { parseArgs, readJsonFile, requireArg, requiredArray, sortJson } from "./lib/ledger-admission-cli.mjs";
 
@@ -104,7 +105,7 @@ function parseMinuteSecond(value) {
   return { value: minutes * MINUTE_SECONDS + seconds };
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   try {
     await main();
   } catch (error) {

--- a/tools/datapack/normalize-transfer-distance-duration-rows.test.mjs
+++ b/tools/datapack/normalize-transfer-distance-duration-rows.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -165,6 +165,26 @@ test("CLI 상대경로 실행은 --output 파일을 생성한다", async () => {
       ["tools/datapack/normalize-transfer-distance-duration-rows.mjs", "--rows", rowsPath, "--output", outputPath],
       { cwd: process.cwd() },
     );
+    const result = JSON.parse(await readFile(outputPath, "utf8"));
+    assert.equal(result.normalizedRows[0].환승소요시간, 62);
+  } finally {
+    await rm(outputDir, { recursive: true, force: true });
+  }
+});
+
+test("CLI URL 인코딩 경로 실행도 --output 파일을 생성한다", async () => {
+  const outputDir = await mkdtemp(path.join(tmpdir(), "transfer normalizer-"));
+  const scriptDir = path.join(outputDir, "script path");
+  const scriptPath = path.join(scriptDir, "normalize rows.mjs");
+  const rowsPath = path.join(outputDir, "rows.json");
+  const outputPath = path.join(outputDir, "normalized.json");
+  try {
+    await mkdir(path.join(scriptDir, "lib"), { recursive: true });
+    await copyFile("tools/datapack/normalize-transfer-distance-duration-rows.mjs", scriptPath);
+    await copyFile("tools/datapack/lib/ledger-admission-cli.mjs", path.join(scriptDir, "lib/ledger-admission-cli.mjs"));
+    await writeFile(rowsPath, `${JSON.stringify([transferRow()])}\n`);
+    const canonicalScriptPath = await realpath(scriptPath);
+    await execFileAsync(process.execPath, [canonicalScriptPath, "--rows", rowsPath, "--output", outputPath]);
     const result = JSON.parse(await readFile(outputPath, "utf8"));
     assert.equal(result.normalizedRows[0].환승소요시간, 62);
   } finally {


### PR DESCRIPTION
## 관련 이슈

Closes #1701

## 작업 배경

- PR #2039 병합 직후 fresh review에서 확인된 3건을 후속 처리한다. 기존 PR은 이미 병합되어 사후 변경하지 않고, 최신 `main` 위 최소 diff로 분리했다.
- `evidence.sampleUrl` 누락 진단, URL encoding이 필요한 경로의 normalizer CLI entry, gate① duplicate report 회귀 검증이 남아 있었다.

## 작업 내용

- KRIC candidate의 `evidence.sampleUrl`이 없거나 비어 있으면 source-specific 오류로 fail closed한다.
- normalizer CLI entry 비교를 `pathToFileURL(process.argv[1]).href`로 바꿔 공백·`#`·`%` 등 URL encoding 경로에서도 silent no-op 없이 실행한다.
- 공백 경로의 실제 복사본 CLI 실행과 gate① duplicate report 식별 필드를 테스트로 고정한다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/datapack/*.test.mjs` → 500 pass, 0 fail
  - `node --test tools/ci/*.test.mjs tools/ci/lib/*.test.mjs tools/repo/*.test.mjs` → 261 pass, 0 fail
  - `git diff --check` → PASS

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| sampleUrl 누락 진단 | Node | source context negative test | 전체 datapack test 500/500 | PASS |
| URL encoding CLI 경로 | Node/macOS | 공백 디렉터리에 script/helper 복사 후 실제 CLI 실행 | output JSON 생성·62초 확인 | PASS |
| duplicate report | Node | 동일 사당 2→4 행 2건 입력 | station/line·62/63초 식별 검증 | PASS |
| UI·접근성 | — | UI 코드 변경 없음 | 별도 증거 불필요 | N/A |
| 배포 | — | production publish/deploy 없음 | 별도 증거 불필요 | N/A |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 공백 경로 테스트가 macOS `/var` symlink 차이를 `realpath`로 제거하고 URL encoding만 검증하는지.
  - `sampleUrl` 유효 입력의 기존 URL parse·request tuple mapping이 유지되는지.
  - duplicate report 테스트가 importer 구현을 재작성하지 않고 report 노출 계약만 고정하는지.

## 리스크

- production 데이터·schema·release artifact는 변경하지 않는다. CLI entry와 진단·테스트만 보강한다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)
