### PR TITLE
[Style] #1982 관리자 표준 컴포넌트 규격 — 테이블·폼·버튼·뱃지·페이지네이션·empty state

### DIFF
--- a/backend/src/main/resources/static/css/admin-tokens.css
+++ b/backend/src/main/resources/static/css/admin-tokens.css
@@ -26,9 +26,10 @@
 	--admin-danger-soft: #FFE8E6;
 	--admin-chart-series: #2f6f9f; /* 차트 보조 시리즈색(상태 의미 없음) */
 
-	/* radius — 2단계 토큰(컨트롤/카드) */
+	/* radius — 2단계 토큰(컨트롤/카드) + 뱃지·칩 전용 */
 	--admin-radius-control: 8px;
 	--admin-radius-card: 8px;
+	--admin-radius-badge: 4px;
 
 	/* 그림자 — 사용 안 함(플랫) */
 	--admin-shadow-card: none;

--- a/backend/src/main/resources/static/css/admin-v3.css
+++ b/backend/src/main/resources/static/css/admin-v3.css
@@ -322,12 +322,22 @@ body.admin-v3 {
 .admin-v3 textarea {
 	min-height: 40px;
 	padding: 0 11px;
-	border: 1px solid var(--admin-border-strong);
+	border: 1px solid var(--admin-border);
 	border-radius: var(--admin-radius-control);
 	background: var(--admin-surface);
 	color: var(--admin-ink);
 	font: inherit;
 	font-weight: var(--admin-w-body);
+}
+
+/* 포커스 시에만 액센트 테두리 — 기본 테두리는 무채색(#1982) */
+.admin-v3 input:focus,
+.admin-v3 select:focus,
+.admin-v3 textarea:focus,
+.admin-v3 input:focus-visible,
+.admin-v3 select:focus-visible,
+.admin-v3 textarea:focus-visible {
+	border-color: var(--admin-border-strong);
 }
 
 .admin-v3 textarea {
@@ -372,6 +382,9 @@ body.admin-v3 {
 }
 
 .admin-v3 th {
+	position: sticky;
+	top: 0;
+	z-index: 1;
 	background: var(--admin-header-bg);
 	color: var(--admin-ink-2);
 	font-size: 13px;
@@ -383,8 +396,39 @@ body.admin-v3 {
 	font-weight: var(--admin-w-body);
 }
 
+.admin-v3 tbody tr {
+	height: 44px;
+}
+
+/* 행 hover·선택 — radius 0 사각 풀블리드(#1982, 오너 확정 2026-07-13) */
+.admin-v3 tbody tr:hover {
+	background: var(--admin-header-bg);
+}
+
+.admin-v3 tbody tr[aria-selected="true"],
+.admin-v3 tbody tr.is-selected {
+	background: var(--admin-accent-soft);
+}
+
 .admin-v3 tbody tr:last-child td {
 	border-bottom: 0;
+}
+
+/* 숫자 셀 우정렬 유틸리티(#1982) — 텍스트 셀은 기본 좌정렬 유지 */
+.admin-v3 td.cell-num,
+.admin-v3 th.cell-num {
+	text-align: right;
+	font-variant-numeric: tabular-nums;
+}
+
+/* 행 액션 노출 유틸리티(#1982) — hover·focus 시에만 표시 */
+.admin-v3 .row-actions {
+	visibility: hidden;
+}
+
+.admin-v3 tbody tr:hover .row-actions,
+.admin-v3 tbody tr:focus-within .row-actions {
+	visibility: visible;
 }
 
 .admin-v3 .metric-grid {
@@ -531,7 +575,7 @@ body.admin-v3 {
 	gap: 6px;
 	padding: 2px 10px;
 	border: 1px solid var(--admin-border);
-	border-radius: 999px;
+	border-radius: var(--admin-radius-badge);
 	font-size: 12px;
 	color: var(--admin-ink-2);
 	text-decoration: none;
@@ -761,7 +805,7 @@ body.admin-v3 {
 	min-width: 22px;
 	height: 20px;
 	padding: 0 7px;
-	border-radius: var(--admin-radius-card);
+	border-radius: var(--admin-radius-badge);
 	background: var(--admin-accent);
 	color: #fff;
 	font-size: 12px;
@@ -955,6 +999,7 @@ body.admin-v3 {
 	padding: 0;
 	background: transparent;
 	font-size: 18px;
+	font-weight: var(--admin-w-strong);
 }
 
 .admin-form {
@@ -1154,7 +1199,7 @@ body.admin-v3 {
 	align-items: center;
 	min-height: 38px;
 	padding: 0 14px;
-	border: 1px solid var(--admin-border-strong);
+	border: 1px solid var(--admin-border);
 	border-radius: var(--admin-radius-control);
 	background: var(--admin-surface);
 	color: var(--admin-ink);
@@ -1671,6 +1716,19 @@ body.admin-v3 {
 	align-items: baseline;
 	justify-content: space-between;
 	gap: 12px;
+	padding-bottom: 12px;
+	margin-bottom: 16px;
+	border-bottom: 1px solid var(--admin-border);
+}
+
+/* 지표 셀 분할용 1px 구분선 유틸리티(#1982) — .metric-grid 내부 셀 경계 */
+.admin-v3 .admin-panel-divider {
+	border-top: 1px solid var(--admin-border);
+}
+
+.admin-v3 .metric-cell + .metric-cell {
+	border-left: 1px solid var(--admin-border);
+	padding-left: 16px;
 }
 
 .admin-v3 .admin-link {
@@ -1864,7 +1922,7 @@ body.admin-v3 {
 .admin-v3 .status-badge {
 	display: inline-block;
 	padding: 2px 8px;
-	border-radius: var(--admin-radius-card);
+	border-radius: var(--admin-radius-badge);
 	font-size: 12px;
 	background: var(--admin-header-bg);
 	color: var(--admin-ink);

--- a/backend/src/main/resources/static/css/admin-v3.css
+++ b/backend/src/main/resources/static/css/admin-v3.css
@@ -846,8 +846,15 @@ body.admin-v3 {
 	border-top: 1px solid var(--admin-border);
 }
 
-/* JS 실행 환경에서는 Alpine x-show 평가 전 플래시 방지(#1982 리뷰 반영). no-JS는 has-js 미부착이라 계속 노출 */
-.admin-v3.has-js .bulk-actionbar {
+/*
+ * JS 실행 환경에서는 Alpine이 x-show를 최초 평가하기 전 짧은 순간 플래시가 생긴다(#1982 리뷰 반영).
+ * has-js-ready(app.js가 alpine:initialized 시점에 부착)가 아직 없는 동안만 숨겨 그 틈을 가린다.
+ * has-js-ready가 붙은 뒤로는 이 규칙이 매치되지 않으므로, x-show가 설정하는 인라인 style이
+ * 전담한다 — Alpine의 x-show 구현(_x_doShow)은 인라인 display를 제거만 할 뿐 값을 넣지 않아,
+ * 이 규칙을 has-js에만 걸어두면 선택 후에도 계속 이겨서 bar가 영원히 숨겨지는 회귀가 생긴다.
+ * no-JS는 has-js 자체가 없어 이 규칙이 걸리지 않으므로 계속 노출된다(기존 폴백 유지).
+ */
+.admin-v3.has-js:not(.has-js-ready) .bulk-actionbar {
 	display: none;
 }
 

--- a/backend/src/main/resources/static/css/admin-v3.css
+++ b/backend/src/main/resources/static/css/admin-v3.css
@@ -410,6 +410,24 @@ body.admin-v3 {
 	background: var(--admin-accent-soft);
 }
 
+/* empty-state/colspan 안내 행은 hover·고정 높이 제외(#1982 리뷰 반영) */
+.admin-v3 tbody tr:has(td[colspan]) {
+	height: auto;
+}
+
+.admin-v3 tbody tr:has(td[colspan]):hover {
+	background: transparent;
+}
+
+/* 완전 비상호작용(순수 조회) 표는 hover·고정 높이 opt-out(#1982 리뷰 반영) */
+.admin-v3 table.static-table tbody tr {
+	height: auto;
+}
+
+.admin-v3 table.static-table tbody tr:hover {
+	background: transparent;
+}
+
 .admin-v3 tbody tr:last-child td {
 	border-bottom: 0;
 }
@@ -826,6 +844,11 @@ body.admin-v3 {
 	padding: 10px 12px;
 	background: var(--admin-surface);
 	border-top: 1px solid var(--admin-border);
+}
+
+/* JS 실행 환경에서는 Alpine x-show 평가 전 플래시 방지(#1982 리뷰 반영). no-JS는 has-js 미부착이라 계속 노출 */
+.admin-v3.has-js .bulk-actionbar {
+	display: none;
 }
 
 .admin-v3 .bulk-count {

--- a/backend/src/main/resources/static/js/admin/app.js
+++ b/backend/src/main/resources/static/js/admin/app.js
@@ -13,6 +13,15 @@
 // app.js는 defer라 이 시점에 document.body가 존재한다.
 document.body.classList.add('has-js');
 
+// x-show FOUC 방지(#1982 리뷰 반영): has-js 스코프 CSS로 Alpine 초기화 전 순간을 가려두고,
+// Alpine이 실제로 모든 x-show를 최초 평가한 뒤(alpine:initialized) 이 클래스를 붙여 CSS 숨김을
+// 해제한다. 그 시점부터는 x-show가 설정하는 인라인 style이 표시 여부를 전담한다.
+// 이 훅이 없으면 Alpine의 x-show 구현(_x_doShow)이 인라인 display만 제거하고 값을 넣지 않아,
+// CSS의 has-js 규칙이 계속 이겨 선택 후에도 bulk bar가 영원히 숨겨지는 회귀가 생긴다.
+document.addEventListener('alpine:initialized', function () {
+	document.body.classList.add('has-js-ready');
+});
+
 document.addEventListener('alpine:init', function () {
 	// 반응형 사이드바 토글(#1738): ≤1024px에서 사이드바를 오프캔버스로 여닫는다.
 	// 사이드바 표시는 body.sidebar-open 클래스가, 백드롭은 open 프로퍼티(x-show)가 함께 반영한다.

--- a/backend/src/main/resources/templates/admin/datapack/route-gates/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/route-gates/list.html
@@ -48,7 +48,7 @@
 				<span class="filter-chip" th:if="${filter.hasQuery()}" th:text="${'검색 ' + filter.queryValue}">검색</span>
 			</div>
 		</div>
-		<table>
+		<table class="static-table">
 			<thead>
 			<tr>
 				<th scope="col">station</th>

--- a/backend/src/main/resources/templates/admin/datapack/source-snapshots/detail.html
+++ b/backend/src/main/resources/templates/admin/datapack/source-snapshots/detail.html
@@ -26,7 +26,7 @@
 
 	<section class="admin-panel">
 		<h2>기본 정보</h2>
-		<table>
+		<table class="static-table">
 			<tbody>
 			<tr><th scope="row">source id</th><td th:text="${snapshot.sourceId}">source-id</td></tr>
 			<tr><th scope="row">provider</th><td th:text="${snapshot.provider}">provider</td></tr>
@@ -41,7 +41,7 @@
 
 	<section class="admin-panel">
 		<h2>상태</h2>
-		<table>
+		<table class="static-table">
 			<tbody>
 			<tr><th scope="row">snapshot status</th><td th:text="${snapshot.snapshotStatus}">LOCKED</td></tr>
 			<tr><th scope="row">schema status</th><td th:text="${snapshot.schemaStatus}">PASS</td></tr>
@@ -57,7 +57,7 @@
 
 	<section class="admin-panel">
 		<h2>Evidence</h2>
-		<table>
+		<table class="static-table">
 			<tbody>
 			<tr><th scope="row">raw sha256</th><td th:text="${snapshot.rawSha256}">sha256</td></tr>
 			<tr><th scope="row">raw object uri</th><td th:text="${snapshot.rawObjectUri}">s3://bucket/object.json</td></tr>

--- a/backend/src/main/resources/templates/admin/fragments/dashboard-trends.html
+++ b/backend/src/main/resources/templates/admin/fragments/dashboard-trends.html
@@ -30,7 +30,7 @@
 			</div>
 			<details class="dashboard-details">
 				<summary>데이터 표로 보기</summary>
-				<table>
+				<table class="static-table">
 					<thead>
 					<tr>
 						<th scope="col">날짜</th>

--- a/backend/src/main/resources/templates/admin/reports/list.html
+++ b/backend/src/main/resources/templates/admin/reports/list.html
@@ -247,7 +247,7 @@
 				</tr>
 				</tbody>
 			</table>
-			<div class="bulk-actionbar">
+			<div class="bulk-actionbar" x-show="hasSelection">
 				<span class="bulk-count" x-text="selectionLabel">선택한 신고 일괄 처리</span>
 				<button type="submit" name="decision" value="ACCEPT">선택 승인</button>
 				<button type="submit" name="decision" value="REJECT">선택 반려</button>

--- a/backend/src/main/resources/templates/admin/routes/feedback.html
+++ b/backend/src/main/resources/templates/admin/routes/feedback.html
@@ -72,7 +72,7 @@
 				</div>
 				<details class="dashboard-details">
 					<summary>데이터 표로 보기</summary>
-					<table>
+					<table class="static-table">
 						<thead>
 						<tr>
 							<th scope="col">날짜</th>
@@ -94,7 +94,7 @@
 
 	<section>
 		<h2>평점별 피드백</h2>
-		<table>
+		<table class="static-table">
 			<thead>
 			<tr>
 				<th scope="col">평점</th>
@@ -114,7 +114,7 @@
 
 	<section>
 		<h2>최근 현장 차단 신고</h2>
-		<table>
+		<table class="static-table">
 			<thead>
 			<tr>
 				<th scope="col">신고 시각</th>
@@ -139,7 +139,7 @@
 
 	<section>
 		<h2>ETA 보정 bucket</h2>
-		<table>
+		<table class="static-table">
 			<thead>
 			<tr>
 				<th scope="col">이동 프로필</th>

--- a/backend/src/main/resources/templates/admin/routes/searches.html
+++ b/backend/src/main/resources/templates/admin/routes/searches.html
@@ -83,7 +83,7 @@
 				</div>
 				<details class="dashboard-details">
 					<summary>데이터 표로 보기</summary>
-					<table>
+					<table class="static-table">
 						<thead>
 						<tr>
 							<th scope="col">날짜</th>
@@ -129,7 +129,7 @@
 
 	<section>
 		<h2>이동 프로필별 검색</h2>
-		<table>
+		<table class="static-table">
 			<thead>
 			<tr>
 				<th scope="col">이동 프로필</th>
@@ -147,7 +147,7 @@
 
 	<section>
 		<h2>지역별 사용량</h2>
-		<table>
+		<table class="static-table">
 			<thead>
 			<tr>
 				<th scope="col">지역</th>
@@ -167,7 +167,7 @@
 
 	<section>
 		<h2>차단 사유별 현황</h2>
-		<table>
+		<table class="static-table">
 			<thead>
 			<tr>
 				<th scope="col">차단 사유</th>
@@ -185,7 +185,7 @@
 
 	<section>
 		<h2>ETA source 현황</h2>
-		<table>
+		<table class="static-table">
 			<thead>
 			<tr>
 				<th scope="col">ETA source</th>
@@ -205,7 +205,7 @@
 
 	<section>
 		<h2>fallback 사유별 현황</h2>
-		<table>
+		<table class="static-table">
 			<thead>
 			<tr>
 				<th scope="col">fallback 사유</th>
@@ -225,7 +225,7 @@
 
 	<section>
 		<h2>품질 신호 구분</h2>
-		<table>
+		<table class="static-table">
 			<thead>
 			<tr>
 				<th scope="col">신호</th>
@@ -245,7 +245,7 @@
 
 	<section>
 		<h2>알림 기준</h2>
-		<table>
+		<table class="static-table">
 			<thead>
 			<tr>
 				<th scope="col">metric</th>

--- a/backend/src/main/resources/templates/admin/usage/activity.html
+++ b/backend/src/main/resources/templates/admin/usage/activity.html
@@ -82,7 +82,7 @@
 				</div>
 				<details class="dashboard-details">
 					<summary>데이터 표로 보기</summary>
-					<table>
+					<table class="static-table">
 						<thead>
 						<tr>
 							<th scope="col">날짜</th>
@@ -104,7 +104,7 @@
 
 	<section>
 		<h2>일별 활성 사용자</h2>
-		<table>
+		<table class="static-table">
 			<thead>
 			<tr>
 				<th scope="col">날짜</th>


### PR DESCRIPTION
<!-- B/C등급(일반 코드 변경·낮은 위험 maintenance) 전용. A등급(제품/운영 위험, CI/계약 테스트/release gate 변경)은 full.md를 사용합니다. -->

## 관련 이슈

Refs #1982

## 작업 내용

- `admin-v3.css`, `admin-tokens.css`의 공용 컴포넌트 계층(테이블·폼·버튼·뱃지·칩·페이지네이션·empty state·패널)에 오너 확정 규격(#1979, #1982) 반영
- 뱃지·칩(`.status-badge`, `.count-badge`, `.filter-chip`) radius를 전용 토큰 `--admin-radius-badge: 4px`로 통일 — `.filter-chip`의 `border-radius: 999px`(pill) 제거
- 상태 필터 칩(`.status-filter a`)·페이지네이션(`.pagination a`)·입력 필드(`input/select/textarea`)의 **기본(비선택·비포커스) 테두리를 무채색(`--admin-border`)으로 환원** — 선택된 상태 필터 칩·현재 페이지만 파랑 유지, 입력 필드는 `:focus`/`:focus-visible`에서만 `border-color: --admin-border-strong`(`#006FD6`) 적용
- 데이터 테이블: `th`에 `position: sticky` + 배경 `--admin-header-bg`(`#F6F8F9`), 행 높이 44px, hover 배경(`--admin-header-bg`) 및 선택 행 배경(`--admin-accent-soft`) — **radius 0 사각 풀블리드**로 표현(오너 확정 2026-07-13), 숫자 셀 우정렬+`tabular-nums` 유틸리티 `.cell-num`, 행 액션 hover/focus 노출 유틸리티 `.row-actions` 신설
- 1px 보더 플랫 패널 공용 규격: `.admin-panel-head` 하단 1px 구분선, 지표 셀 분할용 구분선 유틸리티(`.admin-panel-divider`, `.metric-cell`) 신설
- `pagination.html`/`form-errors.html`/`empty-state.html` 프래그먼트는 기존 마크업이 이미 신규 CSS 계층과 호환되어 구조 변경 없음(공용 클래스만 정합)

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests "com.easysubway.admin.web.AdminDesignGuardTest"` → BUILD SUCCESSFUL, 3 tests / 0 failures / 0 errors
  - `./gradlew test --tests "com.easysubway.admin.*"` → BUILD SUCCESSFUL, admin 테스트 클래스 38개 / 186 tests / 0 failures / 0 errors
  - WCAG AA 대비(4.5:1) 검산(실제 hex, 상대휘도 공식):
    | 조합 | 대비 | 판정 |
    |---|---|---|
    | good 텍스트 `#0A705A` on soft `#F0FBF7` | 5.71:1 | PASS |
    | warn 텍스트 `#9A5600` on soft `#FFF0D1` | 5.03:1 | PASS |
    | danger 텍스트 `#B42318` on soft `#FFE8E6` | 5.62:1 | PASS |
    | 주 버튼 흰 텍스트 on 액센트 `#006FD6` | 4.95:1 | PASS |
    | 포커스 테두리 `#006FD6` on surface `#FFFFFF` | 4.95:1 | PASS |
    | 포커스 테두리 `#006FD6` on bg `#F6F8F9` | 4.64:1 | PASS |
    | count-badge 흰 텍스트 on 액센트 `#006FD6` | 4.95:1 | PASS |
    | status-badge 기본 텍스트 `#102A2C` on `#F6F8F9` | 14.19:1 | PASS |
  - 전/후 스크린샷(로컬, `docs/`는 gitignore라 PR에는 미첨부): 신고 목록(`/admin/reports/page`), 관리자 감사 empty state(`/admin/audits/page`), 공통코드(`/admin/codes/page`) 각 전/후 1440×full page. before는 `origin/main`(#1980·#1981 반영 상태) 포트 18080, after는 본 브랜치 포트 18081에서 캡처. 상태 필터 칩·입력 필드 기본 테두리가 파랑→무채색으로, `.filter-chip`이 pill→radius 4px 사각으로 바뀐 것을 육안 확인함.

## 영향

- [x] 제품/운영 위험 없음 (route/accessibility/mobile UX/backend API/auth/security 아님)
- [x] DB migration 없음
- [x] 배포 영향 없음
- [x] route/realtime/datapack contract 영향 없음
- [x] CI workflow·계약 테스트·release gate JSON 변경 없음 (있으면 full.md로 전환)

## 체크리스트

- [x] 이 PR은 B/C등급 작업이며 full template이 필요 없다.
- [ ] CI 결과를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 폴백 리뷰를 단일 PR review로 게시했다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 관리자 화면의 표 가독성과 일관된 표시 스타일을 개선했습니다.
  * 표 헤더가 스크롤 시 상단에 고정됩니다.
  * 행의 hover·선택 상태와 숫자 셀 정렬을 개선했습니다.
  * 입력 필드는 기본 테두리를 완화하고, 포커스 시 강조되도록 변경했습니다.
  * 배지와 칩의 모서리 스타일을 통일했습니다.
  * 항목을 선택했을 때만 일괄 작업 도구가 표시됩니다.
  * 대시보드 패널과 지표 구분선의 시각적 구성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->