### PR TITLE
[Style] #1983 관리자 대시보드·차트 패널 규격 통일

### DIFF
--- a/backend/src/main/resources/static/css/admin-v3.css
+++ b/backend/src/main/resources/static/css/admin-v3.css
@@ -1935,6 +1935,7 @@ body.admin-v3 {
 	font-weight: var(--admin-w-strong);
 }
 
+.batch-history-charts,
 .trend-charts {
 	display: grid;
 	grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
@@ -1942,30 +1943,14 @@ body.admin-v3 {
 	margin-bottom: 20px;
 }
 
+.batch-history-canvas-wrap,
 .trend-canvas-wrap {
 	position: relative;
 	height: 240px;
 }
 
+.batch-history-canvas,
 .trend-canvas {
-	width: 100%;
-	height: 100%;
-}
-
-/* 배치 실행 이력 차트(#1742) — 추이 패널과 동일한 그리드·캔버스 높이 규격(#1983 정합). */
-.batch-history-charts {
-	display: grid;
-	grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-	gap: 16px;
-	margin-bottom: 20px;
-}
-
-.batch-history-canvas-wrap {
-	position: relative;
-	height: 240px;
-}
-
-.batch-history-canvas {
 	width: 100%;
 	height: 100%;
 }

--- a/backend/src/main/resources/static/css/admin-v3.css
+++ b/backend/src/main/resources/static/css/admin-v3.css
@@ -487,6 +487,40 @@ body.admin-v3 {
 	line-height: 1.45;
 }
 
+/* 전 기간 대비 증감 카드(#1744)의 tone — 상태 3색(#1983)으로 델타를 표시한다. */
+.admin-v3 .metric.tone-good em {
+	color: var(--admin-good);
+}
+
+.admin-v3 .metric.tone-bad em {
+	color: var(--admin-danger);
+}
+
+.admin-v3 .metric.tone-neutral em {
+	color: var(--admin-ink-3);
+}
+
+/* 패널 안의 지표 셀(#1983): .admin-panel 안 .metric-grid는 카드 개별 보더 대신
+   .metric-cell 상단 1px 구분선으로만 나뉜다(auto-fit 그리드는 열 수가 가변적이라
+   좌측 구분선 기반 "행의 첫 열" 판정이 불가능하므로 상단 구분선 방식을 쓴다). */
+.admin-v3 .admin-panel .metric-grid {
+	gap: 0;
+}
+
+.admin-v3 .admin-panel .metric.metric-cell {
+	border: 0;
+	border-top: 1px solid var(--admin-border);
+	border-radius: 0;
+	box-shadow: none;
+	background: transparent;
+	padding: 14px 18px;
+}
+
+.admin-v3 .admin-panel .metric.metric-cell:first-child {
+	border-top: 0;
+	padding-top: 4px;
+}
+
 .admin-v3 .alert {
 	border-left: 3px solid var(--admin-border-strong);
 }
@@ -1024,7 +1058,8 @@ body.admin-v3 {
 	padding: 18px;
 }
 
-.admin-panel h2 {
+.admin-panel h2,
+.admin-panel h3 {
 	margin: 0 0 12px;
 	padding: 0;
 	background: transparent;
@@ -1801,28 +1836,36 @@ body.admin-v3 {
 	font-size: 12px;
 }
 
+/* 핵심 지표 그리드(#1983): .admin-panel 하나 안에서 3열 반응형(최대 3열)으로 배치하고,
+   카드 자체는 보더·그림자 없이 .metric-cell 좌측 1px 구분선으로만 나뉜다(패널 보더 중복 방지).
+   좁은 화면에서는 하단 미디어쿼리로 2열 → 1열로 줄어든다(각 행 첫 열은 구분선 제외). */
 .dashboard-cards {
 	display: grid;
-	grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-	gap: 14px;
-	margin-bottom: 20px;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	gap: 0;
 }
 
 .dashboard-card {
 	display: flex;
 	flex-direction: column;
 	gap: 6px;
-	padding: 16px 18px;
-	border: 1px solid var(--admin-border);
-	border-radius: var(--admin-radius-card);
-	background: var(--admin-surface);
-	box-shadow: var(--admin-shadow-card);
+	padding: 4px 18px;
 	text-decoration: none;
 	color: var(--admin-ink);
 }
 
-.dashboard-card:hover {
-	border-color: var(--admin-border-strong);
+.dashboard-card.metric-cell {
+	border-left: 1px solid var(--admin-border);
+	padding-left: 18px;
+}
+
+/* 각 행의 첫 열(3열 그리드 기준 3n+1)은 좌측 구분선 없이 패널 안쪽 여백만 유지. */
+.dashboard-card.metric-cell:nth-child(3n+1) {
+	border-left: 0;
+}
+
+.dashboard-card:hover .dashboard-card-title {
+	color: var(--admin-accent);
 }
 
 .dashboard-card-title {
@@ -1905,6 +1948,24 @@ body.admin-v3 {
 }
 
 .trend-canvas {
+	width: 100%;
+	height: 100%;
+}
+
+/* 배치 실행 이력 차트(#1742) — 추이 패널과 동일한 그리드·캔버스 높이 규격(#1983 정합). */
+.batch-history-charts {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+	gap: 16px;
+	margin-bottom: 20px;
+}
+
+.batch-history-canvas-wrap {
+	position: relative;
+	height: 240px;
+}
+
+.batch-history-canvas {
 	width: 100%;
 	height: 100%;
 }
@@ -2105,4 +2166,37 @@ body.admin-v3 {
 	background: var(--admin-accent-soft);
 	border-radius: 0 var(--admin-radius-control) var(--admin-radius-control) 0;
 	font-weight: var(--admin-w-medium);
+}
+
+/* 핵심 지표 그리드 반응형(#1983): 900px 이하 2열, 768px 이하 1열. 각 행의 첫 열은
+   좌측 구분선을 빼고, 1열에서는 상단 구분선으로 전환한다. */
+@media (max-width: 900px) {
+	.dashboard-cards {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+
+	.dashboard-card.metric-cell:nth-child(3n+1) {
+		border-left: 1px solid var(--admin-border);
+	}
+
+	.dashboard-card.metric-cell:nth-child(2n+1) {
+		border-left: 0;
+	}
+}
+
+@media (max-width: 768px) {
+	.dashboard-cards {
+		grid-template-columns: 1fr;
+	}
+
+	.dashboard-card.metric-cell {
+		border-left: 0;
+		border-top: 1px solid var(--admin-border);
+		padding-top: 12px;
+	}
+
+	.dashboard-card.metric-cell:first-child {
+		border-top: 0;
+		padding-top: 4px;
+	}
 }

--- a/backend/src/main/resources/static/js/admin/batch-history-charts.js
+++ b/backend/src/main/resources/static/js/admin/batch-history-charts.js
@@ -19,7 +19,8 @@
 	};
 
 	function barColor(status) {
-		return COLORS[status] || tokenColor('--admin-chart-series', '#2f6f9f');
+		// 상태 매핑 밖(알 수 없는 상태)은 장식적 색 대신 무채색 잉크 톤으로 폴백한다(#1983).
+		return COLORS[status] || tokenColor('--admin-ink-3', '#466467');
 	}
 
 	function renderChart(canvas) {

--- a/backend/src/main/resources/static/js/admin/dashboard-charts.js
+++ b/backend/src/main/resources/static/js/admin/dashboard-charts.js
@@ -11,11 +11,13 @@
 		return value || fallback;
 	}
 
+	// 팔레트(#1983): 무채색(잉크 계열) + 파랑 액센트 + 상태 3색만 사용한다. 장식적 초록·빨강
+	// 조합 대신 1번 시리즈는 파랑(주 지표), 2번은 잉크 톤(보조 지표)으로 구분한다.
 	var PALETTE = [
-		tokenColor('--admin-good', '#0a705a'),
-		tokenColor('--admin-danger', '#b42318'),
-		tokenColor('--admin-chart-series', '#2f6f9f'),
-		tokenColor('--admin-warn', '#9a5600')
+		tokenColor('--admin-accent', '#006fd6'),
+		tokenColor('--admin-ink-2', '#29484b'),
+		tokenColor('--admin-ink-3', '#466467'),
+		tokenColor('--admin-danger', '#b42318')
 	];
 
 	function renderChart(canvas) {

--- a/backend/src/main/resources/templates/admin/dashboard.html
+++ b/backend/src/main/resources/templates/admin/dashboard.html
@@ -44,21 +44,28 @@
 		</a>
 	</section>
 
-	<!-- 핵심 카드: 숫자 + 7일 스파크라인 + 전일 대비. 카드 전체가 해당 화면으로 이동. -->
-	<div class="dashboard-cards">
-		<a th:each="card : ${cards}" class="dashboard-card" th:href="@{${card.href}}">
-			<span class="dashboard-card-title" th:text="${card.title}">제목</span>
-			<strong class="dashboard-card-value" th:text="${card.value}">0</strong>
-			<svg th:if="${!card.sparkPoints.isEmpty()}" class="dashboard-spark"
-			     viewBox="0 0 100 24" preserveAspectRatio="none" role="img"
-			     aria-label="최근 7일 추이" focusable="false">
-				<polyline th:attr="points=${card.sparkPoints}" fill="none"
-				          stroke="currentColor" stroke-width="1.5"></polyline>
-			</svg>
-			<span class="dashboard-card-delta" th:classappend="${' is-' + card.deltaTone}"
-			      th:text="${card.deltaLabel}">전일 대비</span>
-		</a>
-	</div>
+	<!-- 핵심 지표 패널: 1px 보더 플랫 패널(#1983) 하나 안에 지표 셀을 1px 내부 구분선으로 분할.
+	     각 셀 = 흐린 라벨 + 큰 숫자(tabular-nums) + 파랑 스파크라인 + 상태 3색 델타.
+	     셀 전체가 해당 화면으로 이동(a 태그 유지). -->
+	<section class="admin-panel dashboard-metric-panel" aria-labelledby="dashboard-metric-panel-title">
+		<div class="admin-panel-head">
+			<h2 id="dashboard-metric-panel-title">핵심 지표</h2>
+		</div>
+		<div class="dashboard-cards">
+			<a th:each="card : ${cards}" class="dashboard-card metric-cell" th:href="@{${card.href}}">
+				<span class="dashboard-card-title" th:text="${card.title}">제목</span>
+				<strong class="dashboard-card-value cell-num" th:text="${card.value}">0</strong>
+				<svg th:if="${!card.sparkPoints.isEmpty()}" class="dashboard-spark"
+				     viewBox="0 0 100 24" preserveAspectRatio="none" role="img"
+				     aria-label="최근 7일 추이" focusable="false">
+					<polyline th:attr="points=${card.sparkPoints}" fill="none"
+					          stroke="currentColor" stroke-width="1.5"></polyline>
+				</svg>
+				<span class="dashboard-card-delta" th:classappend="${' is-' + card.deltaTone}"
+				      th:text="${card.deltaLabel}">전일 대비</span>
+			</a>
+		</div>
+	</section>
 
 	<!-- 추이 섹션: 기간(7/30/90) 라인 차트 2개. 기간 버튼이 이 컨테이너를 htmx로 부분 갱신한다. -->
 	<div id="dashboard-trends">
@@ -109,12 +116,16 @@
 
 	<div class="admin-grid-2">
 		<section class="admin-panel" th:if="${adminProgramIds.contains('a-reports')}">
-			<h2>먼저 확인할 제보</h2>
+			<div class="admin-panel-head">
+				<h2>먼저 확인할 제보</h2>
+			</div>
 			<p class="summary">확인할 제보는 제보 확인 대기열에서 상태·사진·위치를 함께 확인합니다.</p>
 			<a class="admin-btn" th:href="@{/admin/reports/page}">제보 확인 대기열 열기</a>
 		</section>
 		<section class="admin-panel" tabindex="0" aria-labelledby="dashboard-health-title">
-			<h2 id="dashboard-health-title">운영 이상 신호</h2>
+			<div class="admin-panel-head">
+				<h2 id="dashboard-health-title">운영 이상 신호</h2>
+			</div>
 			<table>
 				<tbody>
 				<tr><th scope="row">서비스 상태</th><td th:text="|${dashboard.healthStatus} (${dashboard.serviceName})|">UP</td></tr>

--- a/backend/src/main/resources/templates/admin/fragments/dashboard-trends.html
+++ b/backend/src/main/resources/templates/admin/fragments/dashboard-trends.html
@@ -23,7 +23,9 @@
 
 	<div class="trend-charts">
 		<section th:each="trend : ${trends}" class="admin-panel trend-chart-panel">
-			<h2 th:text="${trend.title}">추이</h2>
+			<div class="admin-panel-head">
+				<h2 th:text="${trend.title}">추이</h2>
+			</div>
 			<div class="trend-canvas-wrap">
 				<canvas th:id="${trend.id}" class="trend-canvas" role="img"
 				        th:attr="aria-label=|${trend.title} 최근 ${trendDays}일 추이|,data-chart=${trend.json}"></canvas>

--- a/backend/src/main/resources/templates/admin/quality/dashboard.html
+++ b/backend/src/main/resources/templates/admin/quality/dashboard.html
@@ -21,48 +21,53 @@
 		</div>
 	</header>
 
-	<div class="metric-grid" aria-label="전체 데이터 품질 요약">
-		<div class="metric">
-			<span>전체 역</span>
-			<strong th:text="${summary.totalStations}">0</strong>
+	<section class="admin-panel quality-metric-panel" aria-labelledby="quality-metric-panel-title">
+		<div class="admin-panel-head">
+			<h2 id="quality-metric-panel-title">전체 데이터 품질 요약</h2>
 		</div>
-		<div class="metric">
-			<span>전체 출구</span>
-			<strong th:text="${summary.totalExits}">0</strong>
+		<div class="metric-grid">
+			<div class="metric metric-cell">
+				<span>전체 역</span>
+				<strong class="cell-num" th:text="${summary.totalStations}">0</strong>
+			</div>
+			<div class="metric metric-cell">
+				<span>전체 출구</span>
+				<strong class="cell-num" th:text="${summary.totalExits}">0</strong>
+			</div>
+			<div class="metric metric-cell">
+				<span>전체 시설</span>
+				<strong class="cell-num" th:text="${summary.totalFacilities}">0</strong>
+			</div>
+			<div class="metric metric-cell">
+				<span>확인 필요한 시설</span>
+				<strong class="cell-num" th:text="${summary.needsVerificationFacilityCount}">0</strong>
+			</div>
+			<div class="metric metric-cell">
+				<span>갱신 지연 시설</span>
+				<strong class="cell-num" th:text="${summary.delayedFacilityStatusCount}">0</strong>
+			</div>
+			<div class="metric metric-cell">
+				<span>확인일 없는 역</span>
+				<strong class="cell-num" th:text="${summary.missingStationVerificationDateCount}">0</strong>
+			</div>
+			<div class="metric metric-cell">
+				<span>전체 제보</span>
+				<strong class="cell-num" th:text="${summary.totalReportCount}">0</strong>
+			</div>
+			<div class="metric metric-cell">
+				<span>확인 완료</span>
+				<strong class="cell-num" th:text="${summary.verifiedReportCount}">0</strong>
+			</div>
+			<div class="metric metric-cell">
+				<span>확인 대기</span>
+				<strong class="cell-num" th:text="${summary.pendingReportCount}">0</strong>
+			</div>
+			<div class="metric metric-cell">
+				<span>제보 확인률</span>
+				<strong class="cell-num" th:text="|${summary.reportVerificationRatePercent}%|">0%</strong>
+			</div>
 		</div>
-		<div class="metric">
-			<span>전체 시설</span>
-			<strong th:text="${summary.totalFacilities}">0</strong>
-		</div>
-		<div class="metric">
-			<span>확인 필요한 시설</span>
-			<strong th:text="${summary.needsVerificationFacilityCount}">0</strong>
-		</div>
-		<div class="metric">
-			<span>갱신 지연 시설</span>
-			<strong th:text="${summary.delayedFacilityStatusCount}">0</strong>
-		</div>
-		<div class="metric">
-			<span>확인일 없는 역</span>
-			<strong th:text="${summary.missingStationVerificationDateCount}">0</strong>
-		</div>
-		<div class="metric">
-			<span>전체 제보</span>
-			<strong th:text="${summary.totalReportCount}">0</strong>
-		</div>
-		<div class="metric">
-			<span>확인 완료</span>
-			<strong th:text="${summary.verifiedReportCount}">0</strong>
-		</div>
-		<div class="metric">
-			<span>확인 대기</span>
-			<strong th:text="${summary.pendingReportCount}">0</strong>
-		</div>
-		<div class="metric">
-			<span>제보 확인률</span>
-			<strong th:text="|${summary.reportVerificationRatePercent}%|">0%</strong>
-		</div>
-	</div>
+	</section>
 
 	<section th:if="${datapackReleaseSummary != null}">
 		<h2>데이터팩 Release readiness</h2>

--- a/backend/src/main/resources/templates/admin/usage/activity.html
+++ b/backend/src/main/resources/templates/admin/usage/activity.html
@@ -21,28 +21,33 @@
 		</div>
 	</header>
 
-	<div class="metric-grid" aria-label="사용자 활동 요약">
-		<div class="metric">
-			<span>최근 7일 활성 사용자</span>
-			<strong th:text="${summary.totalActiveUsers}">0</strong>
+	<section class="admin-panel usage-metric-panel" aria-labelledby="usage-metric-panel-title">
+		<div class="admin-panel-head">
+			<h2 id="usage-metric-panel-title">사용자 활동 요약</h2>
 		</div>
-		<div class="metric">
-			<span>API 요청</span>
-			<strong th:text="${summary.totalApiRequests}">0</strong>
+		<div class="metric-grid">
+			<div class="metric metric-cell">
+				<span>최근 7일 활성 사용자</span>
+				<strong class="cell-num" th:text="${summary.totalActiveUsers}">0</strong>
+			</div>
+			<div class="metric metric-cell">
+				<span>API 요청</span>
+				<strong class="cell-num" th:text="${summary.totalApiRequests}">0</strong>
+			</div>
+			<div class="metric metric-cell">
+				<span>오류 응답</span>
+				<strong class="cell-num" th:text="${summary.totalApiErrors}">0</strong>
+			</div>
+			<div class="metric metric-cell">
+				<span>API 오류율</span>
+				<strong class="cell-num" th:text="${summary.apiErrorRatePercent}">0.0%</strong>
+			</div>
+			<div class="metric metric-cell">
+				<span>평균 응답 시간</span>
+				<strong class="cell-num" th:text="${summary.averageApiResponseTimeLabel}">0ms</strong>
+			</div>
 		</div>
-		<div class="metric">
-			<span>오류 응답</span>
-			<strong th:text="${summary.totalApiErrors}">0</strong>
-		</div>
-		<div class="metric">
-			<span>API 오류율</span>
-			<strong th:text="${summary.apiErrorRatePercent}">0.0%</strong>
-		</div>
-		<div class="metric">
-			<span>평균 응답 시간</span>
-			<strong th:text="${summary.averageApiResponseTimeLabel}">0ms</strong>
-		</div>
-	</div>
+	</section>
 
 	<div class="api-error-alert" th:classappend="${summary.apiErrorAlertClass}">
 		<strong>API 오류율 상태: <span th:text="${summary.apiErrorAlertLabel}">정상</span></strong>
@@ -65,17 +70,24 @@
 			   download>CSV 내보내기</a>
 		</p>
 
-		<div class="metric-grid" aria-label="전 기간 대비 증감">
-			<div th:each="card : ${comparisons}" class="metric" th:classappend="${'tone-' + card.tone}">
-				<span th:text="${card.label}">지표</span>
-				<strong th:text="${card.currentLabel}">0</strong>
-				<em th:text="${'직전 ' + card.previousLabel + ' · ' + card.deltaPercentLabel}">직전 대비</em>
+		<section class="admin-panel usage-comparison-panel" aria-labelledby="usage-comparison-panel-title">
+			<div class="admin-panel-head">
+				<h2 id="usage-comparison-panel-title">전 기간 대비 증감</h2>
 			</div>
-		</div>
+			<div class="metric-grid">
+				<div th:each="card : ${comparisons}" class="metric metric-cell" th:classappend="${'tone-' + card.tone}">
+					<span th:text="${card.label}">지표</span>
+					<strong class="cell-num" th:text="${card.currentLabel}">0</strong>
+					<em th:text="${'직전 ' + card.previousLabel + ' · ' + card.deltaPercentLabel}">직전 대비</em>
+				</div>
+			</div>
+		</section>
 
 		<div class="trend-charts">
 			<section class="admin-panel trend-chart-panel">
-				<h2 th:text="|활성 사용자·API 오류율 최근 ${trendDays}일 추이|">활성 사용자·API 오류율 추이</h2>
+				<div class="admin-panel-head">
+					<h2 th:text="|활성 사용자·API 오류율 최근 ${trendDays}일 추이|">활성 사용자·API 오류율 추이</h2>
+				</div>
 				<div class="trend-canvas-wrap">
 					<canvas id="user-activity-trend-canvas" class="trend-canvas" role="img"
 					        th:attr="aria-label=|사용 현황 최근 ${trendDays}일 추이|,data-chart=${trendJson}"></canvas>

--- a/backend/src/main/resources/templates/admin/usage/activity.html
+++ b/backend/src/main/resources/templates/admin/usage/activity.html
@@ -84,9 +84,9 @@
 		</section>
 
 		<div class="trend-charts">
-			<section class="admin-panel trend-chart-panel">
+			<section class="admin-panel trend-chart-panel" aria-labelledby="usage-trend-panel-title">
 				<div class="admin-panel-head">
-					<h2 th:text="|활성 사용자·API 오류율 최근 ${trendDays}일 추이|">활성 사용자·API 오류율 추이</h2>
+					<h2 id="usage-trend-panel-title" th:text="|활성 사용자·API 오류율 최근 ${trendDays}일 추이|">활성 사용자·API 오류율 추이</h2>
 				</div>
 				<div class="trend-canvas-wrap">
 					<canvas id="user-activity-trend-canvas" class="trend-canvas" role="img"

--- a/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminDashboardPageTest.java
+++ b/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminDashboardPageTest.java
@@ -50,7 +50,7 @@ class AdminDashboardPageTest {
 			.getContentAsString();
 
 		assertThat(html)
-			.contains("class=\"dashboard-card\"")
+			.contains("class=\"dashboard-card metric-cell\"")
 			.contains("확인할 제보")
 			.contains("href=\"/admin/reports/page\"")
 			.contains("dashboard-spark")


### PR DESCRIPTION
## 관련 이슈

Closes #1983

## 작업 내용

- 핵심 지표(통합 대시보드)·데이터 품질 요약·사용자 활동 요약(요약/전 기간 대비 증감) 카드 그리드를 `.admin-panel` 1px 보더 플랫 패널 하나로 통합하고, 개별 지표는 카드형 보더·그림자 대신 `.metric-cell` 내부 1px 구분선으로만 분리
- Chart.js 팔레트를 무채색(잉크 계열)+파랑 액센트+상태 3색(`--admin-good`/`--admin-danger`/`--admin-warn`)만 사용하도록 정리(장식적 초록·다색 조합 제거), 배치 이력 차트의 알 수 없는 상태 폴백 색도 무채색 톤으로 변경
- 배치 실행 이력 차트 그리드·캔버스 높이 규격을 추이 패널과 동일하게 정렬
- 관련 회귀 테스트 어서션(`AdminDashboardPageTest`)을 변경된 클래스명(`dashboard-card metric-cell`)에 맞게 갱신

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests "*AdminDesignGuardTest*" --tests "*AdminDashboardPageTest*" --tests "*DataQualityAdminPageControllerTest*" --tests "*AdminBatchPageControllerTest*" --tests "*UserActivityAdminPageControllerTest*"` → `BUILD SUCCESSFUL`, 25건 전체 통과(failures=0, errors=0)
  - 전/후 스크린샷 비교(Chrome DevTools MCP, dev 프로필, before=origin/main e8e4cfc8 18080 / after=본 브랜치 18081): `/admin/dashboard/page`(7일·30일 기간 전환 포함), `/admin/data-quality/page`, `/admin/batches/page`, `/admin/usage/activity/page` 각각 캡처(로컬 `docs/evidence/1983/`, 저장소 미포함)
  - 판독 결과: ① 차트 파랑+무채색 톤만 사용(초록 장식 없음) ② 지표 패널 1px 보더·그림자 0 플랫 패널로 통합 ③ blocker/API 오류율 알림이 각진 사각 박스로 표시 ④ 패널 헤더 이모지 없음(텍스트 타이틀만)

## 영향

- [x] 제품/운영 위험 없음 (route/accessibility/mobile UX/backend API/auth/security 아님)
- [x] DB migration 없음
- [x] 배포 영향 없음
- [x] route/realtime/datapack contract 영향 없음
- [x] CI workflow·계약 테스트·release gate JSON 변경 없음 (있으면 full.md로 전환)

## 체크리스트

- [x] 이 PR은 B/C등급 작업이며 full template이 필요 없다.
- [ ] CI 결과를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 폴백 리뷰를 단일 PR review로 게시했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 관리자 대시보드와 데이터 품질·사용자 활동 화면의 지표 패널 디자인을 일관되게 개선했습니다.
  * 핵심 지표 카드와 차트 레이아웃을 화면 크기에 맞게 3열·2열·1열로 조정했습니다.
  * 지표 증감 상태와 차트 색상을 더 명확하고 일관된 색상 체계로 정비했습니다.
  * 대시보드 패널 제목과 구조를 개선해 화면 구분 및 접근성을 향상했습니다.
  * 배치 실행 이력 차트의 크기와 배치를 대시보드 차트와 통일했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->