### PR TITLE
[Style] 목록·상세 화면 v5 정합 ① 코어 도메인

### DIFF
--- a/backend/src/main/resources/templates/admin/codes/list.html
+++ b/backend/src/main/resources/templates/admin/codes/list.html
@@ -21,9 +21,9 @@
 		</div>
 	</header>
 
-	<section>
+	<section class="admin-panel">
 		<h2>Group</h2>
-		<form method="get" th:action="@{/admin/codes/page}">
+		<form class="admin-form" method="get" th:action="@{/admin/codes/page}">
 			<label for="code-group-filter">Group</label>
 			<select id="code-group-filter" name="groupCode">
 				<option th:each="group : ${groups}"
@@ -49,6 +49,11 @@
 			</tr>
 			</thead>
 			<tbody>
+			<tr th:if="${codes.isEmpty()}">
+				<td class="empty" colspan="6">
+					<div th:replace="~{admin/fragments/empty-state :: panel('등록된 코드가 없습니다.', 'Group을 선택하거나 아래에서 코드를 추가하세요.')}"></div>
+				</td>
+			</tr>
 			<tr th:each="code : ${codes}">
 				<td th:text="${code.code}">DUPLICATE</td>
 				<td th:text="${code.displayName}">중복 제보</td>
@@ -68,9 +73,9 @@
 		<div th:replace="~{admin/fragments/pagination :: pager('공통코드 목록 페이지', ${page}, ${paginationLinks})}"></div>
 	</section>
 
-	<section>
+	<section class="admin-panel">
 		<h2>Code 추가·수정</h2>
-		<form method="post" th:action="@{/admin/codes}">
+		<form class="admin-form" method="post" th:action="@{/admin/codes}">
 			<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 			<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 			<input type="hidden" name="groupCode" th:value="${selectedGroup}">

--- a/backend/src/main/resources/templates/admin/codes/list.html
+++ b/backend/src/main/resources/templates/admin/codes/list.html
@@ -51,7 +51,7 @@
 			<tbody>
 			<tr th:if="${codes.isEmpty()}">
 				<td class="empty" colspan="6">
-					<div th:replace="~{admin/fragments/empty-state :: panel('등록된 코드가 없습니다.', 'Group을 선택하거나 아래에서 코드를 추가하세요.')}"></div>
+					<div th:replace="~{admin/fragments/empty-state :: panel('등록된 코드가 없습니다.', '선택한 Group에 코드가 없습니다. 아래에서 코드를 추가하세요.')}"></div>
 				</td>
 			</tr>
 			<tr th:each="code : ${codes}">

--- a/backend/src/main/resources/templates/admin/incidents/list.html
+++ b/backend/src/main/resources/templates/admin/incidents/list.html
@@ -21,7 +21,7 @@
 		</div>
 	</header>
 
-	<section>
+	<section class="admin-panel">
 		<h2>Health 연결</h2>
 		<p th:text="${'현재 health: ' + healthStatus}">현재 health: UP</p>
 		<form th:if="${healthStatus != 'UP'}" method="post" th:action="@{/admin/incidents/health}">
@@ -31,9 +31,9 @@
 		</form>
 	</section>
 
-	<section>
+	<section class="admin-panel">
 		<h2>Incident 생성</h2>
-		<form method="post" th:action="@{/admin/incidents}">
+		<form class="admin-form" method="post" th:action="@{/admin/incidents}">
 			<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 			<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 			<label>심각도
@@ -81,7 +81,9 @@
 			</thead>
 			<tbody>
 			<tr th:if="${incidents.isEmpty()}">
-				<td colspan="9">최근 incident가 없습니다.</td>
+				<td class="empty" colspan="9">
+					<div th:replace="~{admin/fragments/empty-state :: panel('최근 incident가 없습니다.', '접수되면 여기에 표시됩니다.')}"></div>
+				</td>
 			</tr>
 			<tr th:each="incident : ${incidents}">
 				<td th:text="${incident.incidentId}">INC-1</td>

--- a/backend/src/main/resources/templates/admin/notifications/push.html
+++ b/backend/src/main/resources/templates/admin/notifications/push.html
@@ -21,44 +21,49 @@
 		</div>
 	</header>
 
-	<div class="metric-grid" aria-label="푸시 알림 outbox 요약">
-		<div class="metric">
-			<span>전체 알림</span>
-			<strong th:text="${summary.totalCount}">0</strong>
+	<section class="admin-panel" aria-labelledby="push-metric-panel-title">
+		<div class="admin-panel-head">
+			<h2 id="push-metric-panel-title">푸시 알림 outbox 요약</h2>
 		</div>
-		<div class="metric">
-			<span>대기 중</span>
-			<strong th:text="${summary.pendingCount}">0</strong>
+		<div class="metric-grid">
+			<div class="metric metric-cell">
+				<span>전체 알림</span>
+				<strong class="cell-num" th:text="${summary.totalCount}">0</strong>
+			</div>
+			<div class="metric metric-cell">
+				<span>대기 중</span>
+				<strong class="cell-num" th:text="${summary.pendingCount}">0</strong>
+			</div>
+			<div class="metric metric-cell">
+				<span>발송 완료</span>
+				<strong class="cell-num" th:text="${summary.sentCount}">0</strong>
+			</div>
+			<div class="metric metric-cell">
+				<span>발송 실패</span>
+				<strong class="cell-num" th:text="${summary.failedCount}">0</strong>
+				<svg th:if="${failedSparkline != ''}" class="card-sparkline" viewBox="0 0 100 24"
+				     preserveAspectRatio="none" role="img" aria-label="발송 실패 최근 7일 추이">
+					<polyline th:attr="points=${failedSparkline}" fill="none"></polyline>
+				</svg>
+			</div>
+			<div class="metric metric-cell">
+				<span>발송 시도</span>
+				<strong class="cell-num" th:text="${summary.deliveryAttemptCount}">0</strong>
+				<svg th:if="${attemptedSparkline != ''}" class="card-sparkline" viewBox="0 0 100 24"
+				     preserveAspectRatio="none" role="img" aria-label="발송 시도 최근 7일 추이">
+					<polyline th:attr="points=${attemptedSparkline}" fill="none"></polyline>
+				</svg>
+			</div>
+			<div class="metric metric-cell">
+				<span>발송 성공률</span>
+				<strong class="cell-num" th:text="${summary.successRateLabel}">0.0%</strong>
+			</div>
+			<div class="metric metric-cell">
+				<span>발송 실패율</span>
+				<strong class="cell-num" th:text="${summary.failureRateLabel}">0.0%</strong>
+			</div>
 		</div>
-		<div class="metric">
-			<span>발송 완료</span>
-			<strong th:text="${summary.sentCount}">0</strong>
-		</div>
-		<div class="metric">
-			<span>발송 실패</span>
-			<strong th:text="${summary.failedCount}">0</strong>
-			<svg th:if="${failedSparkline != ''}" class="card-sparkline" viewBox="0 0 100 24"
-			     preserveAspectRatio="none" role="img" aria-label="발송 실패 최근 7일 추이">
-				<polyline th:attr="points=${failedSparkline}" fill="none"></polyline>
-			</svg>
-		</div>
-		<div class="metric">
-			<span>발송 시도</span>
-			<strong th:text="${summary.deliveryAttemptCount}">0</strong>
-			<svg th:if="${attemptedSparkline != ''}" class="card-sparkline" viewBox="0 0 100 24"
-			     preserveAspectRatio="none" role="img" aria-label="발송 시도 최근 7일 추이">
-				<polyline th:attr="points=${attemptedSparkline}" fill="none"></polyline>
-			</svg>
-		</div>
-		<div class="metric">
-			<span>발송 성공률</span>
-			<strong th:text="${summary.successRateLabel}">0.0%</strong>
-		</div>
-		<div class="metric">
-			<span>발송 실패율</span>
-			<strong th:text="${summary.failureRateLabel}">0.0%</strong>
-		</div>
-	</div>
+	</section>
 
 	<p th:class="'delivery-alert ' + ${summary.failureAlertClass}"
 	   th:text="${summary.failureAlertLabel} + ': ' + ${summary.failureAlertDescription}">
@@ -88,13 +93,18 @@
 			   download>CSV 내보내기</a>
 		</p>
 
-		<div class="metric-grid" aria-label="전 기간 대비 증감">
-			<div th:each="card : ${comparisons}" class="metric" th:classappend="${'tone-' + card.tone}">
-				<span th:text="${card.label}">지표</span>
-				<strong th:text="${card.currentLabel}">0</strong>
-				<em th:text="${'직전 ' + card.previousLabel + ' · ' + card.deltaPercentLabel}">직전 대비</em>
+		<section class="admin-panel" aria-labelledby="push-comparison-panel-title">
+			<div class="admin-panel-head">
+				<h2 id="push-comparison-panel-title">전 기간 대비 증감</h2>
 			</div>
-		</div>
+			<div class="metric-grid">
+				<div th:each="card : ${comparisons}" class="metric metric-cell" th:classappend="${'tone-' + card.tone}">
+					<span th:text="${card.label}">지표</span>
+					<strong class="cell-num" th:text="${card.currentLabel}">0</strong>
+					<em th:text="${'직전 ' + card.previousLabel + ' · ' + card.deltaPercentLabel}">직전 대비</em>
+				</div>
+			</div>
+		</section>
 
 		<div class="trend-charts">
 			<section class="admin-panel trend-chart-panel">

--- a/backend/src/main/resources/templates/admin/routes/feedback.html
+++ b/backend/src/main/resources/templates/admin/routes/feedback.html
@@ -21,24 +21,29 @@
 		</div>
 	</header>
 
-	<div class="metric-grid" aria-label="경로 피드백 요약">
-		<div class="metric">
-			<span>전체 피드백</span>
-			<strong th:text="${summary.totalCount}">0</strong>
+	<section class="admin-panel" aria-labelledby="route-feedback-metric-title">
+		<div class="admin-panel-head">
+			<h2 id="route-feedback-metric-title">경로 피드백 요약</h2>
 		</div>
-		<div class="metric">
-			<span>도움이 됨</span>
-			<strong th:text="${summary.helpfulCount}">0</strong>
+		<div class="metric-grid">
+			<div class="metric metric-cell">
+				<span>전체 피드백</span>
+				<strong class="cell-num" th:text="${summary.totalCount}">0</strong>
+			</div>
+			<div class="metric metric-cell">
+				<span>도움이 됨</span>
+				<strong class="cell-num" th:text="${summary.helpfulCount}">0</strong>
+			</div>
+			<div class="metric metric-cell">
+				<span>도움이 안 됨</span>
+				<strong class="cell-num" th:text="${summary.notHelpfulCount}">0</strong>
+			</div>
+			<div class="metric metric-cell">
+				<span>현장 차단</span>
+				<strong class="cell-num" th:text="${summary.blockedByRealWorldCount}">0</strong>
+			</div>
 		</div>
-		<div class="metric">
-			<span>도움이 안 됨</span>
-			<strong th:text="${summary.notHelpfulCount}">0</strong>
-		</div>
-		<div class="metric">
-			<span>현장 차단</span>
-			<strong th:text="${summary.blockedByRealWorldCount}">0</strong>
-		</div>
-	</div>
+	</section>
 
 	<div id="route-feedback-trends" th:fragment="trends" class="dashboard-trends-section">
 		<div class="trend-periods" role="group" aria-label="추이 기간 선택">
@@ -55,13 +60,18 @@
 			   download>CSV 내보내기</a>
 		</p>
 
-		<div class="metric-grid" aria-label="전 기간 대비 증감">
-			<div th:each="card : ${comparisons}" class="metric" th:classappend="${'tone-' + card.tone}">
-				<span th:text="${card.label}">지표</span>
-				<strong th:text="${card.currentLabel}">0</strong>
-				<em th:text="${'직전 ' + card.previousLabel + ' · ' + card.deltaPercentLabel}">직전 대비</em>
+		<section class="admin-panel" aria-labelledby="route-feedback-comparison-title">
+			<div class="admin-panel-head">
+				<h2 id="route-feedback-comparison-title">전 기간 대비 증감</h2>
 			</div>
-		</div>
+			<div class="metric-grid">
+				<div th:each="card : ${comparisons}" class="metric metric-cell" th:classappend="${'tone-' + card.tone}">
+					<span th:text="${card.label}">지표</span>
+					<strong class="cell-num" th:text="${card.currentLabel}">0</strong>
+					<em th:text="${'직전 ' + card.previousLabel + ' · ' + card.deltaPercentLabel}">직전 대비</em>
+				</div>
+			</div>
+		</section>
 
 		<div class="trend-charts">
 			<section class="admin-panel trend-chart-panel">

--- a/backend/src/main/resources/templates/admin/routes/searches.html
+++ b/backend/src/main/resources/templates/admin/routes/searches.html
@@ -21,30 +21,35 @@
 		</div>
 	</header>
 
-	<div class="metric-grid" aria-label="경로 검색 요약">
-		<div class="metric">
-			<span>전체 검색</span>
-			<strong th:text="${summary.totalCount}">0</strong>
+	<section class="admin-panel" aria-labelledby="route-search-metric-title">
+		<div class="admin-panel-head">
+			<h2 id="route-search-metric-title">경로 검색 요약</h2>
 		</div>
-		<div class="metric">
-			<span>경로 찾음</span>
-			<strong th:text="${summary.foundCount}">0</strong>
+		<div class="metric-grid">
+			<div class="metric metric-cell">
+				<span>전체 검색</span>
+				<strong class="cell-num" th:text="${summary.totalCount}">0</strong>
+			</div>
+			<div class="metric metric-cell">
+				<span>경로 찾음</span>
+				<strong class="cell-num" th:text="${summary.foundCount}">0</strong>
+			</div>
+			<div class="metric metric-cell">
+				<span>경로 차단</span>
+				<strong class="cell-num" th:text="${summary.blockedCount}">0</strong>
+			</div>
+			<div class="metric metric-cell">
+				<span>경로 차단율</span>
+				<strong class="cell-num" th:text="${summary.blockedRateLabel}">0.0%</strong>
+				<em>전체 검색 중 차단 비율</em>
+			</div>
+			<div class="metric metric-cell">
+				<span>route_not_found_rate</span>
+				<strong class="cell-num" th:text="${summary.routeNotFoundRateLabel}">0.0%</strong>
+				<em>route graph·strict 접근성 차단 비율</em>
+			</div>
 		</div>
-		<div class="metric">
-			<span>경로 차단</span>
-			<strong th:text="${summary.blockedCount}">0</strong>
-		</div>
-		<div class="metric">
-			<span>경로 차단율</span>
-			<strong th:text="${summary.blockedRateLabel}">0.0%</strong>
-			<em>전체 검색 중 차단 비율</em>
-		</div>
-		<div class="metric">
-			<span>route_not_found_rate</span>
-			<strong th:text="${summary.routeNotFoundRateLabel}">0.0%</strong>
-			<em>route graph·strict 접근성 차단 비율</em>
-		</div>
-	</div>
+	</section>
 
 	<div class="alert" th:classappend="${summary.blockedAlertClass}">
 		<strong>운영 상태: <span th:text="${summary.blockedAlertLabel}">정상</span></strong>
@@ -66,13 +71,18 @@
 			   download>CSV 내보내기</a>
 		</p>
 
-		<div class="metric-grid" aria-label="전 기간 대비 증감">
-			<div th:each="card : ${comparisons}" class="metric" th:classappend="${'tone-' + card.tone}">
-				<span th:text="${card.label}">지표</span>
-				<strong th:text="${card.currentLabel}">0</strong>
-				<em th:text="${'직전 ' + card.previousLabel + ' · ' + card.deltaPercentLabel}">직전 대비</em>
+		<section class="admin-panel" aria-labelledby="route-search-comparison-title">
+			<div class="admin-panel-head">
+				<h2 id="route-search-comparison-title">전 기간 대비 증감</h2>
 			</div>
-		</div>
+			<div class="metric-grid">
+				<div th:each="card : ${comparisons}" class="metric metric-cell" th:classappend="${'tone-' + card.tone}">
+					<span th:text="${card.label}">지표</span>
+					<strong class="cell-num" th:text="${card.currentLabel}">0</strong>
+					<em th:text="${'직전 ' + card.previousLabel + ' · ' + card.deltaPercentLabel}">직전 대비</em>
+				</div>
+			</div>
+		</section>
 
 		<div class="trend-charts">
 			<section class="admin-panel trend-chart-panel">

--- a/backend/src/main/resources/templates/admin/stations/detail.html
+++ b/backend/src/main/resources/templates/admin/stations/detail.html
@@ -48,12 +48,17 @@
 		<div class="hub-panel">
 			<!-- 개요 -->
 			<th:block th:if="${activeTab == 'overview'}">
-				<div class="metric-grid">
-					<div class="metric"><span>데이터 품질</span><strong th:text="${station.qualityLabel}">정보 확인 중</strong></div>
-					<div class="metric"><span>접근성 시설</span><strong th:text="${facilityCount}">0</strong></div>
-					<div class="metric"><span>구조 자료</span><strong th:text="${layoutSourceCount}">0</strong></div>
-					<div class="metric"><span>노드 / 간선</span><strong th:text="|${routeNodeCount} / ${routeEdgeCount}|">0 / 0</strong></div>
-				</div>
+				<section class="admin-panel" aria-labelledby="station-overview-metric-title">
+					<div class="admin-panel-head">
+						<h2 id="station-overview-metric-title">역 요약</h2>
+					</div>
+					<div class="metric-grid">
+						<div class="metric metric-cell"><span>데이터 품질</span><strong th:text="${station.qualityLabel}">정보 확인 중</strong></div>
+						<div class="metric metric-cell"><span>접근성 시설</span><strong class="cell-num" th:text="${facilityCount}">0</strong></div>
+						<div class="metric metric-cell"><span>구조 자료</span><strong class="cell-num" th:text="${layoutSourceCount}">0</strong></div>
+						<div class="metric metric-cell"><span>노드 / 간선</span><strong th:text="|${routeNodeCount} / ${routeEdgeCount}|">0 / 0</strong></div>
+					</div>
+				</section>
 
 				<section class="admin-panel">
 					<h2>역 주요 정보</h2>

--- a/backend/src/main/resources/templates/admin/system.html
+++ b/backend/src/main/resources/templates/admin/system.html
@@ -21,12 +21,17 @@
 		</div>
 	</header>
 
-	<div class="metric-grid">
-		<div class="metric"><span>애플리케이션</span><strong th:text="${health.status}">UP</strong><em th:text="${health.service}">service</em></div>
-		<div class="metric"><span>푸시 대기</span><strong th:text="${push.pendingCount}">0</strong><em th:text="|실패 ${push.failedCount}건|">실패 0건</em></div>
-		<div class="metric"><span>API 요청</span><strong th:text="${usage.totalApiRequests}">0</strong><em th:text="|오류율 ${usage.apiErrorRatePercent()}|">오류율 0.0%</em></div>
-		<div class="metric"><span>평균 응답</span><strong th:text="${usage.averageApiResponseTimeLabel()}">0ms</strong><em>최근 활동 집계 기준</em></div>
-	</div>
+	<section class="admin-panel" aria-labelledby="system-metric-panel-title">
+		<div class="admin-panel-head">
+			<h2 id="system-metric-panel-title">시스템 요약</h2>
+		</div>
+		<div class="metric-grid">
+			<div class="metric metric-cell"><span>애플리케이션</span><strong th:text="${health.status}">UP</strong><em th:text="${health.service}">service</em></div>
+			<div class="metric metric-cell"><span>푸시 대기</span><strong class="cell-num" th:text="${push.pendingCount}">0</strong><em th:text="|실패 ${push.failedCount}건|">실패 0건</em></div>
+			<div class="metric metric-cell"><span>API 요청</span><strong class="cell-num" th:text="${usage.totalApiRequests}">0</strong><em th:text="|오류율 ${usage.apiErrorRatePercent()}|">오류율 0.0%</em></div>
+			<div class="metric metric-cell"><span>평균 응답</span><strong th:text="${usage.averageApiResponseTimeLabel()}">0ms</strong><em>최근 활동 집계 기준</em></div>
+		</div>
+	</section>
 
 	<section>
 		<h2>컴포넌트 상태</h2>
@@ -68,7 +73,9 @@
 			</thead>
 			<tbody>
 			<tr th:if="${runs.isEmpty()}">
-				<td colspan="8">최근 데이터 수집 실행이 없습니다.</td>
+				<td class="empty" colspan="8">
+					<div th:replace="~{admin/fragments/empty-state :: panel('최근 데이터 수집 실행이 없습니다.', '수집이 실행되면 여기에 표시됩니다.')}"></div>
+				</td>
 			</tr>
 			<tr th:each="run : ${runs}">
 				<td th:text="${run.runId}">run-id</td>


### PR DESCRIPTION
## 관련 이슈

Closes #1984

## 작업 내용

- 코어 도메인 템플릿(stations, facilities, incidents, reports, codes, audits, routes, collections, notifications, alerts, system, search) 전수를 카드/패널 사용처 기준 "표(구분선 전환)/폼(그룹 여백)/지표(패널)"로 분류해 점검
- 이미 #1982/#1983에서 확정된 표준 컴포넌트(`.admin-panel`+`.metric-cell`, 표준 폼 그룹 여백)로 미정합 화면만 전환. 신규 CSS 규칙 추가 없음(`admin-v3.css` 무수정)
- stations/detail: 개요 탭 지표(데이터 품질/접근성 시설/구조 자료/노드·간선) 개별 카드 → `.admin-panel`+`.metric-cell` 패널
- incidents/list: Health 연결·Incident 생성 폼 → `.admin-panel`+`.admin-form`, 빈 상태 → empty-state fragment
- codes/list: Group 필터·Code 추가·수정 폼 → `.admin-panel`+`.admin-form`, 빈 상태 추가
- routes/searches, routes/feedback: 요약·전 기간 대비 metric-grid(각 2개) → 패널 전환
- notifications/push: outbox 요약·전 기간 대비 metric-grid(2개) → 패널 전환
- system: 요약 metric-grid → 패널 전환, 빈 상태 → empty-state fragment
- 전수 검토한 나머지 화면(stations/list·layouts, facilities/list·editor, reports/list·detail, audits/list·detail, collections/list, alerts, search)은 이미 #1982/#1983 표준 컴포넌트로 정합되어 있어 변경 없음 — 후속 범위로 넘긴 화면 없음

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests "*AdminDesignGuard*" --tests "*Admin*" ...` 등 관련 컨트롤러/스모크 테스트 23개 클래스 실행, 전부 `BUILD SUCCESSFUL` (failures=0, errors=0). `AdminDesignGuardTest` 포함 green.
  - 전/후 스크린샷: dev 프로필로 before(origin/main, 18080)·after(본 브랜치, 18081) 서버를 각각 기동해 관리자 로그인 후 대표 화면 4개(stations 상세, incidents 목록, codes 목록, routes 검색 분석) 캡처·직접 판독. `docs/evidence/1984/`에 저장(커밋 대상 아님, 로컬 전용).
    - stations 상세: 개요 지표 4종이 개별 카드 → 단일 패널 내 세로 구분선 구조로 전환 확인
    - incidents 목록: Incident 생성 폼이 가로 나열 → 단일 컬럼 그룹 여백 구조로 전환, 빈 상태 보조문구 추가 확인
    - codes 목록: Code 추가·수정 폼이 가로 나열 → 단일 컬럼 그룹 여백 구조로 전환 확인
    - routes 검색 분석: 상단 5지표·전기간대비 2지표가 개별 카드 → 패널+구분선 구조로 전환 확인
    - 모든 화면에서 이모지 장식·둥근 콜아웃형 알림·초록색 사용 없음을 육안 확인

## 영향

- [x] 제품/운영 위험 없음 (route/accessibility/mobile UX/backend API/auth/security 아님)
- [x] DB migration 없음
- [x] 배포 영향 없음
- [x] route/realtime/datapack contract 영향 없음
- [x] CI workflow·계약 테스트·release gate JSON 변경 없음 (있으면 full.md로 전환)

## 체크리스트

- [x] 이 PR은 B/C등급 작업이며 full template이 필요 없다.
- [ ] CI 결과를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 폴백 리뷰를 단일 PR review로 게시했다.