### PR TITLE
[Feat] #1702 보행 프로필 시간 모델 — 계약 JSON·3자 동기화 테스트·mobile 상수·parity 리포트

### DIFF
--- a/apps/mobile/lib/features/mobility_profile/mobility_profile_policy.dart
+++ b/apps/mobile/lib/features/mobility_profile/mobility_profile_policy.dart
@@ -1,0 +1,98 @@
+/// 보행 프로필 프리셋 정책의 정본 상수.
+///
+/// `apps/mobile/release/mobility-profile-policy.json`을 그대로 반영하며, 그 JSON이
+/// node 리포 계약 테스트와 `mobility_profile_policy_test.dart` 양쪽에서 강제되는
+/// 단일 진실 원본이다. JSON을 함께 바꾸지 않고 여기 값만 바꾸면(또는 그 반대)
+/// 동기화 테스트가 실패한다.
+///
+/// backend `ProfileWalkTimeCalculator.MobilityPreset`(정수 speedFactorPercent)와도
+/// 같은 계약 테스트가 소수 speedFactor로 상호 고정한다. UI·위젯·상태관리는 담지
+/// 않으며, #1703 온보딩 UI가 소비할 상수·타입만 노출한다.
+library;
+
+/// 보행 프리셋 종류.
+enum MobilityPreset {
+  standard,
+  slow,
+  noStairs,
+  stepFree,
+}
+
+/// 프리셋별 시설 제약.
+enum FacilityConstraint {
+  none,
+  noStairs,
+  elevatorOnly,
+}
+
+/// 사용자가 선택하는 이동 유형(온보딩·프로필 입력값).
+enum MobilityType {
+  senior,
+  pregnant,
+  temporaryInjury,
+  luggage,
+  stroller,
+  wheelchair,
+}
+
+/// 단일 프리셋의 파생 상수.
+class MobilityPresetSpec {
+  const MobilityPresetSpec({
+    required this.speedFactor,
+    required this.facilityConstraint,
+    this.elevatorWaitSeconds,
+  });
+
+  /// baseline 보행 초에 곱하는 계수(1.0 = 표준 속도).
+  final double speedFactor;
+
+  /// 이 프리셋이 요구하는 시설 제약.
+  final FacilityConstraint facilityConstraint;
+
+  /// STEP_FREE 승강기 대기 가산 초(다른 프리셋은 null).
+  final int? elevatorWaitSeconds;
+}
+
+/// 보행 프로필 정책의 정본 상수 모음.
+class MobilityProfilePolicy {
+  const MobilityProfilePolicy._();
+
+  /// 기준 보행 속도(m/s).
+  static const double anchorWalkSpeedMps = 1.2;
+
+  /// STEP_FREE 승강기 대기 가산 초.
+  static const int stepFreeElevatorWaitSeconds = 60;
+
+  /// 프리셋별 파생 상수.
+  static const Map<MobilityPreset, MobilityPresetSpec> presets =
+      <MobilityPreset, MobilityPresetSpec>{
+    MobilityPreset.standard: MobilityPresetSpec(
+      speedFactor: 1.0,
+      facilityConstraint: FacilityConstraint.none,
+    ),
+    MobilityPreset.slow: MobilityPresetSpec(
+      speedFactor: 1.35,
+      facilityConstraint: FacilityConstraint.none,
+    ),
+    MobilityPreset.noStairs: MobilityPresetSpec(
+      speedFactor: 1.2,
+      facilityConstraint: FacilityConstraint.noStairs,
+    ),
+    MobilityPreset.stepFree: MobilityPresetSpec(
+      speedFactor: 1.0,
+      facilityConstraint: FacilityConstraint.elevatorOnly,
+      elevatorWaitSeconds: stepFreeElevatorWaitSeconds,
+    ),
+  };
+
+  /// 이동 유형 → 기본 프리셋 매핑.
+  static const Map<MobilityType, MobilityPreset> mobilityTypeMapping =
+      <MobilityType, MobilityPreset>{
+    MobilityType.senior: MobilityPreset.slow,
+    MobilityType.pregnant: MobilityPreset.slow,
+    MobilityType.temporaryInjury: MobilityPreset.slow,
+    MobilityType.luggage: MobilityPreset.noStairs,
+    MobilityType.stroller: MobilityPreset.stepFree,
+    MobilityType.wheelchair: MobilityPreset.stepFree,
+  };
+}

--- a/apps/mobile/release/mobility-profile-policy.json
+++ b/apps/mobile/release/mobility-profile-policy.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "mobility-profile-policy",
+  "anchorWalkSpeedMps": 1.2,
+  "presets": {
+    "STANDARD": { "speedFactor": 1.0, "facilityConstraint": "NONE" },
+    "SLOW": { "speedFactor": 1.35, "facilityConstraint": "NONE" },
+    "NO_STAIRS": { "speedFactor": 1.2, "facilityConstraint": "NO_STAIRS" },
+    "STEP_FREE": { "speedFactor": 1.0, "facilityConstraint": "ELEVATOR_ONLY", "elevatorWaitSeconds": 60 }
+  },
+  "mobilityTypeMapping": {
+    "SENIOR": "SLOW",
+    "PREGNANT": "SLOW",
+    "TEMPORARY_INJURY": "SLOW",
+    "LUGGAGE": "NO_STAIRS",
+    "STROLLER": "STEP_FREE",
+    "WHEELCHAIR": "STEP_FREE"
+  }
+}

--- a/apps/mobile/test/features/mobility_profile/mobility_profile_policy_test.dart
+++ b/apps/mobile/test/features/mobility_profile/mobility_profile_policy_test.dart
@@ -1,0 +1,105 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:easysubway_mobile/features/mobility_profile/mobility_profile_policy.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  // apps/mobile/release/mobility-profile-policy.json의 JSON 계약이 단일 진실
+  // 원본이다(node 리포 계약 테스트에서도 검증). 이 테스트는 Dart 상수를 그
+  // JSON에 고정해 둘이 서로 어긋나지 않게 한다.
+  test('Dart 프리셋 상수는 release policy JSON과 동기화된다', () {
+    final json = jsonDecode(
+      File('release/mobility-profile-policy.json').readAsStringSync(),
+    ) as Map<String, dynamic>;
+
+    expect(json['schemaVersion'], 1);
+    expect(json['artifactKind'], 'mobility-profile-policy');
+    expect(
+      (json['anchorWalkSpeedMps'] as num).toDouble(),
+      MobilityProfilePolicy.anchorWalkSpeedMps,
+    );
+
+    final presets = json['presets'] as Map<String, dynamic>;
+    final expectedFactorByKey = <String, MobilityPreset>{
+      'STANDARD': MobilityPreset.standard,
+      'SLOW': MobilityPreset.slow,
+      'NO_STAIRS': MobilityPreset.noStairs,
+      'STEP_FREE': MobilityPreset.stepFree,
+    };
+
+    for (final entry in expectedFactorByKey.entries) {
+      final jsonPreset = presets[entry.key] as Map<String, dynamic>;
+      final spec = MobilityProfilePolicy.presets[entry.value]!;
+      expect(
+        (jsonPreset['speedFactor'] as num).toDouble(),
+        spec.speedFactor,
+        reason: '${entry.key} speedFactor mismatch',
+      );
+    }
+
+    // 시설 제약 매핑.
+    expect(
+      MobilityProfilePolicy.presets[MobilityPreset.standard]!.facilityConstraint,
+      FacilityConstraint.none,
+    );
+    expect(
+      MobilityProfilePolicy.presets[MobilityPreset.slow]!.facilityConstraint,
+      FacilityConstraint.none,
+    );
+    expect(
+      MobilityProfilePolicy.presets[MobilityPreset.noStairs]!.facilityConstraint,
+      FacilityConstraint.noStairs,
+    );
+    expect(
+      MobilityProfilePolicy.presets[MobilityPreset.stepFree]!.facilityConstraint,
+      FacilityConstraint.elevatorOnly,
+    );
+
+    // STEP_FREE 승강기 대기 초.
+    expect(
+      (presets['STEP_FREE'] as Map<String, dynamic>)['elevatorWaitSeconds'],
+      MobilityProfilePolicy.stepFreeElevatorWaitSeconds,
+    );
+    expect(
+      MobilityProfilePolicy
+          .presets[MobilityPreset.stepFree]!.elevatorWaitSeconds,
+      60,
+    );
+  });
+
+  test('Dart 이동 유형 매핑은 release policy JSON과 동기화된다', () {
+    final json = jsonDecode(
+      File('release/mobility-profile-policy.json').readAsStringSync(),
+    ) as Map<String, dynamic>;
+    final mapping = json['mobilityTypeMapping'] as Map<String, dynamic>;
+
+    final expectedTypeByKey = <String, MobilityType>{
+      'SENIOR': MobilityType.senior,
+      'PREGNANT': MobilityType.pregnant,
+      'TEMPORARY_INJURY': MobilityType.temporaryInjury,
+      'LUGGAGE': MobilityType.luggage,
+      'STROLLER': MobilityType.stroller,
+      'WHEELCHAIR': MobilityType.wheelchair,
+    };
+    final presetByKey = <String, MobilityPreset>{
+      'STANDARD': MobilityPreset.standard,
+      'SLOW': MobilityPreset.slow,
+      'NO_STAIRS': MobilityPreset.noStairs,
+      'STEP_FREE': MobilityPreset.stepFree,
+    };
+
+    expect(mapping.length, expectedTypeByKey.length);
+    expect(
+      MobilityProfilePolicy.mobilityTypeMapping.length,
+      expectedTypeByKey.length,
+    );
+    for (final entry in expectedTypeByKey.entries) {
+      expect(
+        MobilityProfilePolicy.mobilityTypeMapping[entry.value],
+        presetByKey[mapping[entry.key] as String],
+        reason: '${entry.key} mapping mismatch',
+      );
+    }
+  });
+}

--- a/contracts/release/gate-index.json
+++ b/contracts/release/gate-index.json
@@ -15,6 +15,7 @@
     { "file": "get-off-alarm-policy.json", "scope": "mobile", "area": "mobile-feature" },
     { "file": "issue-1075-async-state-audit.json", "scope": "mobile", "area": "mobile-qa" },
     { "file": "issue-1075-final-qa-evidence.json", "scope": "mobile", "area": "mobile-qa" },
+    { "file": "mobility-profile-policy.json", "scope": "product", "area": "route" },
     { "file": "operations-observability-gate.json", "scope": "product", "area": "ops" },
     { "file": "operations-release-evidence.json", "scope": "product", "area": "ops" },
     { "file": "play-generated-apk-device-matrix-gate.json", "scope": "mobile", "area": "store" },

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -13867,3 +13867,163 @@ test("KRIC source 후보 evidence workflow는 고정 allowlist와 sanitized arti
   assert.doesNotMatch(uploadBlock, /\braw\b|response|\.env|dotenv/i);
   assert.doesNotMatch(workflow, /github\.event\.inputs\.(?:url|host|ref|command|output|path)/i);
 });
+
+test("#1702 보행 프로필 프리셋 정책 JSON은 프리셋 계수·시설 제약·유형 매핑을 고정한다", () => {
+  const policyPath = "apps/mobile/release/mobility-profile-policy.json";
+  assert.equal(existsSync(path.join(root, policyPath)), true, "mobility-profile-policy JSON must exist");
+
+  const policy = readJson(policyPath);
+  assert.equal(policy.schemaVersion, 1);
+  assert.equal(policy.artifactKind, "mobility-profile-policy");
+  assert.equal(policy.anchorWalkSpeedMps, 1.2);
+
+  // 프리셋 4종 계수·시설 제약. speedFactor 1.0 = 표준 속도(회귀 불변).
+  assert.equal(policy.presets.STANDARD.speedFactor, 1.0);
+  assert.equal(policy.presets.STANDARD.facilityConstraint, "NONE");
+  assert.equal(policy.presets.SLOW.speedFactor, 1.35);
+  assert.equal(policy.presets.SLOW.facilityConstraint, "NONE");
+  assert.equal(policy.presets.NO_STAIRS.speedFactor, 1.2);
+  assert.equal(policy.presets.NO_STAIRS.facilityConstraint, "NO_STAIRS");
+  assert.equal(policy.presets.STEP_FREE.speedFactor, 1.0);
+  assert.equal(policy.presets.STEP_FREE.facilityConstraint, "ELEVATOR_ONLY");
+  assert.equal(policy.presets.STEP_FREE.elevatorWaitSeconds, 60);
+
+  // 이동 유형 → 기본 프리셋 매핑 6종.
+  assert.deepEqual(policy.mobilityTypeMapping, {
+    SENIOR: "SLOW",
+    PREGNANT: "SLOW",
+    TEMPORARY_INJURY: "SLOW",
+    LUGGAGE: "NO_STAIRS",
+    STROLLER: "STEP_FREE",
+    WHEELCHAIR: "STEP_FREE",
+  });
+});
+
+test("#1702 backend ProfileWalkTimeCalculator enum은 정책 JSON 계수·매핑과 동기화된다", () => {
+  const policy = readJson("apps/mobile/release/mobility-profile-policy.json");
+  const source = read("backend/src/main/java/com/easysubway/route/domain/ProfileWalkTimeCalculator.java");
+
+  // backend는 정수 speedFactorPercent, JSON은 소수 speedFactor. Math.round(factor*100)로 상호 고정.
+  const percentByPreset = {};
+  for (const match of source.matchAll(/\b(STANDARD|SLOW|NO_STAIRS|STEP_FREE)\((\d+)\)/g)) {
+    percentByPreset[match[1]] = Number(match[2]);
+  }
+  assert.deepEqual(percentByPreset, {
+    STANDARD: 100,
+    SLOW: 135,
+    NO_STAIRS: 120,
+    STEP_FREE: 100,
+  });
+  for (const preset of ["STANDARD", "SLOW", "NO_STAIRS", "STEP_FREE"]) {
+    assert.equal(
+      Math.round(policy.presets[preset].speedFactor * 100),
+      percentByPreset[preset],
+      `${preset} JSON speedFactor must match backend speedFactorPercent`,
+    );
+  }
+
+  // STEP_FREE 승강기 대기 초는 backend 상수와 JSON이 일치한다.
+  assert.match(source, /STEP_FREE_FACILITY_WAIT_SECONDS\s*=\s*60\b/);
+  assert.equal(policy.presets.STEP_FREE.elevatorWaitSeconds, 60);
+
+  // presetFor switch 매핑이 JSON mobilityTypeMapping과 일치한다.
+  assert.match(source, /case\s+SENIOR,\s*PREGNANT,\s*TEMPORARY_INJURY\s*->\s*MobilityPreset\.SLOW\s*;/);
+  assert.match(source, /case\s+LUGGAGE\s*->\s*MobilityPreset\.NO_STAIRS\s*;/);
+  assert.match(source, /case\s+STROLLER,\s*WHEELCHAIR\s*->\s*MobilityPreset\.STEP_FREE\s*;/);
+  assert.equal(policy.mobilityTypeMapping.SENIOR, "SLOW");
+  assert.equal(policy.mobilityTypeMapping.PREGNANT, "SLOW");
+  assert.equal(policy.mobilityTypeMapping.TEMPORARY_INJURY, "SLOW");
+  assert.equal(policy.mobilityTypeMapping.LUGGAGE, "NO_STAIRS");
+  assert.equal(policy.mobilityTypeMapping.STROLLER, "STEP_FREE");
+  assert.equal(policy.mobilityTypeMapping.WHEELCHAIR, "STEP_FREE");
+});
+
+test("#1702 mobile 파생 상수 Dart는 정책 JSON 계수·매핑과 동기화된다", () => {
+  const policy = readJson("apps/mobile/release/mobility-profile-policy.json");
+  const dartPath = "apps/mobile/lib/features/mobility_profile/mobility_profile_policy.dart";
+  assert.equal(existsSync(path.join(root, dartPath)), true, "mobility_profile_policy.dart must exist");
+  const dart = read(dartPath);
+
+  // anchor 속도·승강기 대기 초.
+  assert.match(dart, /anchorWalkSpeedMps\s*=\s*1\.2\b/);
+  assert.equal(policy.anchorWalkSpeedMps, 1.2);
+  assert.match(dart, /stepFreeElevatorWaitSeconds\s*=\s*60\b/);
+  assert.equal(policy.presets.STEP_FREE.elevatorWaitSeconds, 60);
+
+  // 프리셋 4종 speedFactor·시설 제약이 Dart const map과 JSON에서 일치한다.
+  const specByPreset = {
+    standard: { key: "STANDARD", constraint: "FacilityConstraint.none" },
+    slow: { key: "SLOW", constraint: "FacilityConstraint.none" },
+    noStairs: { key: "NO_STAIRS", constraint: "FacilityConstraint.noStairs" },
+    stepFree: { key: "STEP_FREE", constraint: "FacilityConstraint.elevatorOnly" },
+  };
+  for (const [enumName, spec] of Object.entries(specByPreset)) {
+    const factor = policy.presets[spec.key].speedFactor;
+    const factorLiteral = Number.isInteger(factor) ? `${factor}\\.0` : `${factor}`;
+    const block = dart.match(
+      new RegExp(`MobilityPreset\\.${enumName}:\\s*MobilityPresetSpec\\(([\\s\\S]*?)\\)`),
+    )?.[1];
+    assert.ok(block, `Dart preset spec for ${enumName} must exist`);
+    assert.match(block, new RegExp(`speedFactor:\\s*${factorLiteral}\\b`));
+    assert.match(block, new RegExp(`facilityConstraint:\\s*${spec.constraint.replace(".", "\\.")}\\b`));
+  }
+
+  // 이동 유형 매핑 6종이 Dart const map과 JSON에서 일치한다.
+  const dartTypeToEnum = {
+    SENIOR: "senior",
+    PREGNANT: "pregnant",
+    TEMPORARY_INJURY: "temporaryInjury",
+    LUGGAGE: "luggage",
+    STROLLER: "stroller",
+    WHEELCHAIR: "wheelchair",
+  };
+  const presetToEnum = {
+    STANDARD: "standard",
+    SLOW: "slow",
+    NO_STAIRS: "noStairs",
+    STEP_FREE: "stepFree",
+  };
+  for (const [jsonType, preset] of Object.entries(policy.mobilityTypeMapping)) {
+    assert.match(
+      dart,
+      new RegExp(`MobilityType\\.${dartTypeToEnum[jsonType]}:\\s*MobilityPreset\\.${presetToEnum[preset]}\\b`),
+    );
+  }
+});
+
+test("#1702 STANDARD 환승 parity 리포트는 재현 가능하고 ±10% 이내 편차를 고정한다", async () => {
+  const trackedPath = "tools/datapack/reports/mobility-standard-transfer-parity-report.json";
+  assert.equal(existsSync(path.join(root, trackedPath)), true, "parity report must be tracked");
+
+  const outputDir = await mkdtemp(path.join(tmpdir(), "mobility-parity-"));
+  const output = path.join(outputDir, "mobility-standard-transfer-parity-report.json");
+  await execFileAsync(process.execPath, [
+    "tools/datapack/build-mobility-standard-transfer-parity-report.mjs",
+    "--baseline",
+    "tools/datapack/reports/baseline-ingestion-gate-report.json",
+    "--policy",
+    "apps/mobile/release/mobility-profile-policy.json",
+    "--output",
+    output,
+  ], { cwd: root });
+
+  // 재현성: 재생성 결과가 tracked 산출물과 바이트 단위로 동일해야 한다.
+  assert.equal(readFileSync(output, "utf8"), read(trackedPath));
+
+  const report = JSON.parse(readFileSync(output, "utf8"));
+  assert.equal(report.schemaVersion, 1);
+  assert.equal(report.artifactKind, "mobility-standard-transfer-parity-report");
+  assert.equal(report.issue, 1702);
+  assert.equal(report.standardPreset.speedFactorPercent, 100);
+  assert.equal(report.toleranceProfile.maxDeviationPercent, 10);
+  // STANDARD는 speedFactor 1.0이므로 baseline과 0% 편차, 모두 ±10% 이내.
+  assert.equal(report.summary.maxAbsoluteDeviationPercent, 0);
+  assert.equal(report.summary.allWithinTolerance, true);
+  assert.ok(report.directionPairs.length >= 2);
+  for (const pair of report.directionPairs) {
+    assert.equal(pair.standardPresetSeconds, pair.baselineTransferSeconds);
+    assert.equal(pair.deviationPercent, 0);
+    assert.equal(pair.withinTolerance, true);
+    assert.ok(Math.abs(pair.deviationPercent) <= report.toleranceProfile.maxDeviationPercent);
+  }
+});

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -13926,10 +13926,19 @@ test("#1702 backend ProfileWalkTimeCalculator enum은 정책 JSON 계수·매핑
   assert.match(source, /STEP_FREE_FACILITY_WAIT_SECONDS\s*=\s*60\b/);
   assert.equal(policy.presets.STEP_FREE.elevatorWaitSeconds, 60);
 
-  // presetFor switch 매핑이 JSON mobilityTypeMapping과 일치한다.
-  assert.match(source, /case\s+SENIOR,\s*PREGNANT,\s*TEMPORARY_INJURY\s*->\s*MobilityPreset\.SLOW\s*;/);
-  assert.match(source, /case\s+LUGGAGE\s*->\s*MobilityPreset\.NO_STAIRS\s*;/);
-  assert.match(source, /case\s+STROLLER,\s*WHEELCHAIR\s*->\s*MobilityPreset\.STEP_FREE\s*;/);
+  // presetFor switch 매핑이 JSON mobilityTypeMapping과 일치한다. case 라벨 나열 순서는 의미에 영향을 주지 않으므로
+  // 라벨 집합을 정렬해 비교한다(선언 순서가 바뀌어도 계약이 깨지지 않도록).
+  const assertCaseLabels = (presetName, expectedLabels) => {
+    const match = source.match(
+      new RegExp(`case\\s+([A-Z_,\\s]+?)\\s*->\\s*MobilityPreset\\.${presetName}\\s*;`),
+    );
+    assert.ok(match, `presetFor switch must have a case clause mapping to MobilityPreset.${presetName}`);
+    const actualLabels = match[1].split(",").map((label) => label.trim()).sort();
+    assert.deepEqual(actualLabels, [...expectedLabels].sort());
+  };
+  assertCaseLabels("SLOW", ["SENIOR", "PREGNANT", "TEMPORARY_INJURY"]);
+  assertCaseLabels("NO_STAIRS", ["LUGGAGE"]);
+  assertCaseLabels("STEP_FREE", ["STROLLER", "WHEELCHAIR"]);
   assert.equal(policy.mobilityTypeMapping.SENIOR, "SLOW");
   assert.equal(policy.mobilityTypeMapping.PREGNANT, "SLOW");
   assert.equal(policy.mobilityTypeMapping.TEMPORARY_INJURY, "SLOW");

--- a/tools/datapack/build-mobility-standard-transfer-parity-report.mjs
+++ b/tools/datapack/build-mobility-standard-transfer-parity-report.mjs
@@ -27,10 +27,12 @@ import { parseArgs, readJsonFile, requireArg, sortJson } from "./lib/ledger-admi
 
 const DEVIATION_TOLERANCE_PERCENT = 10;
 
-// STANDARD 프리셋을 baseline 초에 적용한 산출 초. speedFactor 1.0 = 항등이므로
-// ceilDiv 규약(정수 초 반올림 올림)과 무관하게 baseline과 동일해야 한다.
+// STANDARD 프리셋을 baseline 초에 적용한 산출 초. backend ProfileWalkTimeCalculator.estimateSeconds의
+// Math.toIntExact(Math.ceilDiv((long) baselineSeconds * preset.speedFactorPercent, 100))와 동일한
+// 정수 나눗셈 올림(ceil division)을 구현한다. 부동소수 Math.ceil은 큰 값에서 부동소수 오차로 backend와
+// 어긋날 수 있어 쓰지 않는다. speedFactorPercent=100(STANDARD)에서는 항등(standardSeconds(x,100)===x)이다.
 export function standardSeconds(baselineSeconds, speedFactorPercent) {
-  return Math.ceil((baselineSeconds * speedFactorPercent) / 100);
+  return Math.floor((baselineSeconds * speedFactorPercent + 99) / 100);
 }
 
 export function buildMobilityStandardTransferParityReport({ baseline, policy }) {

--- a/tools/datapack/build-mobility-standard-transfer-parity-report.mjs
+++ b/tools/datapack/build-mobility-standard-transfer-parity-report.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+// #1702 STANDARD 프리셋 환승소요시간 parity 리포트 생성기(tracked 산출물).
+//
+// 완료조건 evidence: STANDARD 프리셋(speedFactor 1.0)이 공식 환승 데이터의
+// 소요시간과 편차 없이(0% ~ ±10% 이내) 일치함을 재현 가능한 리포트로 고정한다.
+//
+// 입력:
+//   --baseline: tools/datapack/reports/baseline-ingestion-gate-report.json
+//     (gateInternalConsistency.directionPairReport의 forwardMinTransferSeconds가
+//      공식 환승 소요시간의 정본. 값은 여기서 읽으며 창작하지 않는다.)
+//   --policy:   apps/mobile/release/mobility-profile-policy.json
+//     (presets.STANDARD.speedFactor를 여기서 읽는다.)
+//
+// STANDARD는 speedFactor 1.0이므로 baseline 초에 곱해도 그대로다. 리포트는
+// 각 방향쌍의 baseline 초·STANDARD 산출 초·편차 퍼센트와, 전체가 ±10% 이내인지를
+// 명시한다. importer/normalizer/calculator 로직은 읽기만 하고 수정하지 않는다.
+//
+// 사용: node tools/datapack/build-mobility-standard-transfer-parity-report.mjs \
+//   --baseline tools/datapack/reports/baseline-ingestion-gate-report.json \
+//   --policy apps/mobile/release/mobility-profile-policy.json \
+//   --output tools/datapack/reports/mobility-standard-transfer-parity-report.json
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { parseArgs, readJsonFile, requireArg, sortJson } from "./lib/ledger-admission-cli.mjs";
+
+const DEVIATION_TOLERANCE_PERCENT = 10;
+
+// STANDARD 프리셋을 baseline 초에 적용한 산출 초. speedFactor 1.0 = 항등이므로
+// ceilDiv 규약(정수 초 반올림 올림)과 무관하게 baseline과 동일해야 한다.
+export function standardSeconds(baselineSeconds, speedFactorPercent) {
+  return Math.ceil((baselineSeconds * speedFactorPercent) / 100);
+}
+
+export function buildMobilityStandardTransferParityReport({ baseline, policy }) {
+  const standardPreset = policy?.presets?.STANDARD;
+  if (!standardPreset || typeof standardPreset.speedFactor !== "number") {
+    throw new Error("policy.presets.STANDARD.speedFactor missing");
+  }
+  const speedFactor = standardPreset.speedFactor;
+  const speedFactorPercent = Math.round(speedFactor * 100);
+
+  const directionPairReport =
+    baseline?.gateInternalConsistency?.directionPairReport;
+  if (!Array.isArray(directionPairReport) || directionPairReport.length === 0) {
+    throw new Error("baseline.gateInternalConsistency.directionPairReport missing");
+  }
+
+  const pairs = directionPairReport.map((pair) => {
+    const baselineSeconds = pair.forwardMinTransferSeconds;
+    if (typeof baselineSeconds !== "number") {
+      throw new Error(
+        `forwardMinTransferSeconds missing for ${pair.stationId} ${pair.fromLineId}->${pair.toLineId}`,
+      );
+    }
+    const standard = standardSeconds(baselineSeconds, speedFactorPercent);
+    const deviationSeconds = standard - baselineSeconds;
+    const deviationPercent =
+      baselineSeconds === 0 ? 0 : (deviationSeconds / baselineSeconds) * 100;
+    return {
+      stationId: pair.stationId,
+      fromLineId: pair.fromLineId,
+      toLineId: pair.toLineId,
+      baselineTransferSeconds: baselineSeconds,
+      standardPresetSeconds: standard,
+      deviationSeconds,
+      deviationPercent: Number(deviationPercent.toFixed(4)),
+      withinTolerance: Math.abs(deviationPercent) <= DEVIATION_TOLERANCE_PERCENT,
+    };
+  });
+
+  const maxAbsoluteDeviationPercent = pairs.reduce(
+    (max, pair) => Math.max(max, Math.abs(pair.deviationPercent)),
+    0,
+  );
+
+  return {
+    schemaVersion: 1,
+    artifactKind: "mobility-standard-transfer-parity-report",
+    issue: 1702,
+    description:
+      "STANDARD 프리셋(speedFactor 1.0)이 공식 환승 소요시간 baseline과 ±10% 이내로 일치함을 고정하는 재현 가능 리포트. baseline 초는 baseline-ingestion-gate-report.json의 gateInternalConsistency.directionPairReport에서 읽는다.",
+    baselineSource: {
+      artifactKind: baseline?.artifactKind ?? null,
+      directionPairSource: "gateInternalConsistency.directionPairReport",
+      admittedTransferRules: baseline?.coverage?.transfer?.admittedRules ?? null,
+    },
+    standardPreset: {
+      speedFactor,
+      speedFactorPercent,
+    },
+    toleranceProfile: {
+      maxDeviationPercent: DEVIATION_TOLERANCE_PERCENT,
+    },
+    summary: {
+      pairCount: pairs.length,
+      maxAbsoluteDeviationPercent: Number(maxAbsoluteDeviationPercent.toFixed(4)),
+      allWithinTolerance: pairs.every((pair) => pair.withinTolerance),
+    },
+    directionPairs: pairs,
+  };
+}
+
+async function main(argv) {
+  const args = parseArgs(argv);
+  const baseline = await readJsonFile(requireArg(args, "baseline"));
+  const policy = await readJsonFile(requireArg(args, "policy"));
+  const outputPath = requireArg(args, "output");
+
+  const report = buildMobilityStandardTransferParityReport({ baseline, policy });
+
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, `${JSON.stringify(sortJson(report), null, 2)}\n`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main(process.argv.slice(2)).catch((error) => {
+    console.error(error.message);
+    process.exit(1);
+  });
+}

--- a/tools/datapack/reports/mobility-standard-transfer-parity-report.json
+++ b/tools/datapack/reports/mobility-standard-transfer-parity-report.json
@@ -1,0 +1,45 @@
+{
+  "artifactKind": "mobility-standard-transfer-parity-report",
+  "baselineSource": {
+    "admittedTransferRules": 3,
+    "artifactKind": "baseline-ingestion-gate-report",
+    "directionPairSource": "gateInternalConsistency.directionPairReport"
+  },
+  "description": "STANDARD 프리셋(speedFactor 1.0)이 공식 환승 소요시간 baseline과 ±10% 이내로 일치함을 고정하는 재현 가능 리포트. baseline 초는 baseline-ingestion-gate-report.json의 gateInternalConsistency.directionPairReport에서 읽는다.",
+  "directionPairs": [
+    {
+      "baselineTransferSeconds": 178,
+      "deviationPercent": 0,
+      "deviationSeconds": 0,
+      "fromLineId": "seoul-2",
+      "standardPresetSeconds": 178,
+      "stationId": "station-gangnam",
+      "toLineId": "shinbundang",
+      "withinTolerance": true
+    },
+    {
+      "baselineTransferSeconds": 62,
+      "deviationPercent": 0,
+      "deviationSeconds": 0,
+      "fromLineId": "seoul-2",
+      "standardPresetSeconds": 62,
+      "stationId": "station-sadang",
+      "toLineId": "seoul-4",
+      "withinTolerance": true
+    }
+  ],
+  "issue": 1702,
+  "schemaVersion": 1,
+  "standardPreset": {
+    "speedFactor": 1,
+    "speedFactorPercent": 100
+  },
+  "summary": {
+    "allWithinTolerance": true,
+    "maxAbsoluteDeviationPercent": 0,
+    "pairCount": 2
+  },
+  "toleranceProfile": {
+    "maxDeviationPercent": 10
+  }
+}


### PR DESCRIPTION
## 관련 이슈

close #1702

## 작업 배경

- #1700(Phase 1~2 — 이동수단별 보행 프로필 시간 모델) 상위 이슈의 backend 구현(과거 PR #1714, #1716~#1721)은 대부분 병합돼 있었으나, `apps/mobile/release/mobility-profile-policy.json` 계약 파일과 backend·계약테스트·mobile 3자 동기화 검증, mobile측 파생 상수, 환승소요시간 ±10% 검증 리포트가 잔여분으로 남아 있었다.
- 이번 PR은 이 잔여분만 구현한다. 기존 `ProfileWalkTimeCalculator`, RAPTOR planner, Dijkstra/eligibility 로직은 수정하지 않는다.

## 작업 내용

- `apps/mobile/release/mobility-profile-policy.json` 신설 — schemaVersion 1, artifactKind `mobility-profile-policy`, anchorWalkSpeedMps 1.2, presets 4종(STANDARD speedFactor 1.00/facilityConstraint NONE, SLOW 1.35/NONE, NO_STAIRS 1.20/NO_STAIRS, STEP_FREE 1.00/ELEVATOR_ONLY·elevatorWaitSeconds 60), mobilityTypeMapping 6종(SENIOR·PREGNANT·TEMPORARY_INJURY→SLOW, LUGGAGE→NO_STAIRS, STROLLER·WHEELCHAIR→STEP_FREE). 이슈 본문 확정 JSON 그대로.
- `tools/ci/repository-contract.test.mjs`에 3자(JSON·backend·mobile) 동기화 계약테스트 4건 추가 — JSON 값 고정, backend `ProfileWalkTimeCalculator.java`의 speedFactorPercent(100/135/120/100)·STEP_FREE_FACILITY_WAIT_SECONDS(60)·presetFor 매핑이 JSON과 일치함을 소스 텍스트 검증, mobile 파생 상수 Dart 파일이 JSON과 일치함을 검증, parity 리포트 재현성 검증.
- `apps/mobile/lib/features/mobility_profile/mobility_profile_policy.dart` 신설 — 계약 JSON을 반영하는 const 상수 모듈(프리셋 4종 계수·시설제약, mobilityTypeMapping 6종). #1703 온보딩 UI가 소비할 상수·타입만 노출하며 UI·위젯·상태관리는 포함하지 않는다.
- `apps/mobile/test/features/mobility_profile/mobility_profile_policy_test.dart` 신설 — 위 Dart 상수 고정 테스트(get-off-alarm 선례 패턴).
- `tools/datapack/build-mobility-standard-transfer-parity-report.mjs` + `tools/datapack/reports/mobility-standard-transfer-parity-report.json` 신설 — #1701 적재 공식 환승소요시간 baseline(`baseline-ingestion-gate-report.json`)과 STANDARD 프리셋(speedFactor 1.0) 산출 환승시간을 비교해 ±10% 이내임을 고정하는 재현 가능 리포트.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/repository-contract.test.mjs` → tests 190, pass 190, fail 0 (신규 4건 포함)
  - `cd backend && ./gradlew test --tests '*ProfileWalkTimeCalculatorTest' --tests '*RouteSearchV2ControllerTest'` → BUILD SUCCESSFUL
  - `flutter test test/features/mobility_profile/mobility_profile_policy_test.dart` → All tests passed! (2 tests)
  - `dart analyze` → No issues found!
  - parity 리포트 스크립트 재실행 후 sha256 비교 → 동일(재현성 확인), tracked 산출물과 바이트 단위 일치를 계약테스트가 고정

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 프리셋 4종 시간·timeSource 차이 | backend | 기존 `ProfileWalkTimeCalculatorTest.appliesPresetSpeedFactorAndTimeSource`, `RouteSearchV2ControllerTest.routeSearchV2EchoesExplicitMobilityPreset` 재사용(신규 추가 없음, 커버리지 기존 확인) | 동일 baseline 100초 → STANDARD 100/SLOW 135/NO_STAIRS 120/STEP_FREE 160초, 각기 다른 WalkTimeSource·appliedPreset echo | PASS |
| STANDARD 회귀(speedFactor 1.0 항등) | backend | 위 동일 테스트 + 신규 계약테스트가 `presets.STANDARD.speedFactor === 1.0` 별도 고정 | 100초 baseline → 100초 산출(항등) | PASS |
| 환승소요시간 ±10% | backend·datapack | `build-mobility-standard-transfer-parity-report.mjs` 실행, `baseline-ingestion-gate-report.json`의 `gateInternalConsistency.directionPairReport` 실측값과 대조 | 강남 seoul-2→shinbundang 178초, 사당 seoul-2→seoul-4 62초 — STANDARD 산출값과 편차 0%, `allWithinTolerance: true`, `maxAbsoluteDeviationPercent: 0` (`tools/datapack/reports/mobility-standard-transfer-parity-report.json`) | PASS |
| NO_STAIRS/STEP_FREE 제약 위반 edge 미사용 | backend | 기존 strict eligibility negative test 재사용(이번 PR은 eligibility 로직 미수정 — 신규 negative test 불필요, 기존 strict step-free/NO_STAIRS 경로 로직 그대로) | 이번 PR 범위 밖(계산 로직 무변경) | 해당 없음(로직 무변경) |
| 프로필 서버 미저장 | backend | `grep -rln "mobilityPreset\|MobilityPreset" backend/src/main/java` → adapter/planner/domain 6개 파일만 매치, `grep -rlni "preset" backend/src/main/resources/db/migration/` → 매치 0건, `@Entity`/`@Column`/`JdbcTemplate`/`save(` 등 persistence 키워드 미검출 | 검색 결과(본문 상단 참고) | PASS(미저장 확인) |
| pilot 실측(상록수·사당 실기기) | 실기기 | 비적용 — 2026-07-06 오너 결정(#1700 트래커)으로 field-work 재개 전까지 조건부 강등, 공공 기준선 + 데스크 검증만으로 이 이슈 성립 | 사유 기재(본 칸) | 조건부 강등(사유로 대체) |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음(신규 Dart 상수 모듈은 UI 미노출, #1703에서 소비 예정)
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음(기존 API 계약은 과거 PR에서 이미 노출 완료, 이번 PR은 계약 JSON·테스트·상수만 추가)
- realtime contract: 변경 없음
- backend identity: 변경 없음(계산 로직 무변경, 신규 코드 없음 — 계약테스트·리포트·mobile 상수만 추가)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `apps/mobile/release/mobility-profile-policy.json`의 값이 이슈 #1702 본문 확정 JSON과 정확히 일치하는지
  - `tools/ci/repository-contract.test.mjs` 신규 테스트가 backend `ProfileWalkTimeCalculator.java` 소스 문자열에 의존하는 정규식 검증이므로, backend 표기 스타일(예: enum 상수 선언 형식)이 바뀌면 계약테스트가 깨질 수 있다는 점(값이 아닌 표현 리스크)
  - parity 리포트가 baseline에 admitted된 방향쌍 2건(강남·사당)만 커버함 — #1701 baseline 확장 시 재생성 필요

## 리스크

- 3자 동기화 계약테스트가 backend 소스의 표기 스타일(정수 리터럴 표기, switch 화살표 문법)에 정규식으로 의존한다. backend가 값은 그대로 두고 표현 스타일만 바꿔도 계약테스트가 실패할 수 있다.
- parity 리포트는 현재 baseline에 admitted된 환승 방향쌍 2건만 커버한다(3건 중 2건 direction-pair 존재, 나머지는 편도 데이터). baseline이 확장되면 리포트 재생성이 필요하며, 계약테스트가 불일치 시 fail로 강제한다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
