### PR TITLE
[Style] 목록·상세 화면 v5 정합 ② 데이터팩 파이프라인

### DIFF
--- a/backend/src/main/resources/static/css/admin-v3.css
+++ b/backend/src/main/resources/static/css/admin-v3.css
@@ -1096,7 +1096,7 @@ body.admin-v3 {
 	border-top: 0;
 }
 
-.admin-form-section-title {
+.admin-panel .admin-form-section-title {
 	margin: 0;
 	font-size: 13px;
 	font-weight: var(--admin-w-strong);

--- a/backend/src/main/resources/static/css/admin-v3.css
+++ b/backend/src/main/resources/static/css/admin-v3.css
@@ -1082,6 +1082,44 @@ body.admin-v3 {
 	justify-self: start;
 }
 
+/* 폼 섹션 그룹핑(#1986, 오너 지시 2026-07-13) — 긴 폼을 논리 섹션으로 분리.
+   단일 컬럼 원칙 유지, 섹션 소제목 + 상단 구분선으로 그룹을 나눈다. */
+.admin-form-section {
+	display: grid;
+	gap: 14px;
+	padding-top: 20px;
+	border-top: 1px solid var(--admin-border);
+}
+
+.admin-form-section:first-child {
+	padding-top: 0;
+	border-top: 0;
+}
+
+.admin-form-section-title {
+	margin: 0;
+	font-size: 13px;
+	font-weight: var(--admin-w-strong);
+	color: var(--admin-ink-2);
+	text-transform: uppercase;
+	letter-spacing: 0.02em;
+}
+
+/* 값이 짧은 필드를 2열로 묶는 옵션(오너 지시: select 등 짧은 필드는 2열 그리드 허용).
+   라벨 상단 정렬 유지, 좁은 화면에서는 1열 폴백. */
+.admin-form-row-2 {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 12px;
+	align-items: start;
+}
+
+@media (max-width: 720px) {
+	.admin-form-row-2 {
+		grid-template-columns: 1fr;
+	}
+}
+
 .login-screen {
 	display: grid;
 	min-height: 100vh;

--- a/backend/src/main/resources/templates/admin/datapack/alias-quarantine/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/alias-quarantine/list.html
@@ -52,7 +52,7 @@
 
 	<section class="admin-panel">
 		<h2>Alias 검수 큐</h2>
-		<table>
+		<table class="static-table">
 			<thead>
 			<tr>
 				<th scope="col">id</th>
@@ -91,7 +91,7 @@
 				</td>
 				<td><span th:title="${alias.evidenceHash}" th:text="${#strings.abbreviate(alias.evidenceHash, 11)}">sha256</span></td>
 				<td>
-					<form method="post" th:action="@{'/admin/datapack/alias-approvals/' + ${alias.id} + '/approve'}">
+					<form class="admin-form" method="post" th:action="@{'/admin/datapack/alias-approvals/' + ${alias.id} + '/approve'}">
 						<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 						<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 						<input type="hidden" name="idempotencyKey" th:value="${'alias-approve-' + alias.id}">
@@ -101,7 +101,7 @@
 						</label>
 						<button type="submit">승인 저장</button>
 					</form>
-					<form method="post" th:action="@{'/admin/datapack/alias-approvals/' + ${alias.id} + '/reject'}">
+					<form class="admin-form" method="post" th:action="@{'/admin/datapack/alias-approvals/' + ${alias.id} + '/reject'}">
 						<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 						<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 						<input type="hidden" name="idempotencyKey" th:value="${'alias-reject-' + alias.id}">
@@ -119,7 +119,7 @@
 
 	<section class="admin-panel">
 		<h2>격리 큐</h2>
-		<table>
+		<table class="static-table">
 			<thead>
 			<tr>
 				<th scope="col">id</th>
@@ -158,7 +158,7 @@
 				</td>
 				<td th:text="${record.redactedExcerpt}">redacted excerpt</td>
 				<td>
-					<form method="post" th:action="@{'/admin/datapack/quarantine-records/' + ${record.id} + '/resolve'}">
+					<form class="admin-form" method="post" th:action="@{'/admin/datapack/quarantine-records/' + ${record.id} + '/resolve'}">
 						<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 						<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 						<input type="hidden" name="idempotencyKey" th:value="${'quarantine-resolve-' + record.id}">

--- a/backend/src/main/resources/templates/admin/datapack/candidates/detail.html
+++ b/backend/src/main/resources/templates/admin/datapack/candidates/detail.html
@@ -28,7 +28,7 @@
 	<section class="admin-panel">
 		<h2>게이트 체크리스트</h2>
 		<p class="summary" th:text="${evidenceBundle.productionPromoteReason()}">production promote 상태</p>
-		<table>
+		<table class="static-table">
 			<thead>
 			<tr>
 				<th scope="col">게이트</th>
@@ -100,7 +100,7 @@
 		</dl>
 		<details>
 			<summary>sha 원문 보기</summary>
-			<table>
+			<table class="static-table">
 				<tbody>
 				<tr><th scope="row">buildSpec</th><td th:text="${candidate.buildSpecSha256}">sha</td></tr>
 				<tr><th scope="row">sourceInventory</th><td th:text="${candidate.sourceInventorySha256}">sha</td></tr>
@@ -115,7 +115,7 @@
 
 	<section class="admin-panel">
 		<h2>입력 원장</h2>
-		<table>
+		<table class="static-table">
 			<tbody>
 			<tr><th scope="row">원천 스냅샷 ids</th><td th:text="${candidateInput.sourceSnapshotIds}">snapshot ids</td></tr>
 			<tr><th scope="row">승인 별칭 원장 hash</th><td><span th:title="${candidateInput.approvedAliasLedgerHash}" th:text="${candidateInput.approvedAliasLedgerHashShort()}">sha</span></td></tr>
@@ -128,7 +128,7 @@
 
 	<section class="admin-panel">
 		<h2>게이트 재실행</h2>
-		<form method="post" th:action="@{'/admin/datapack/candidates/' + ${candidate.id} + '/rerun-gates'}">
+		<form class="admin-form" method="post" th:action="@{'/admin/datapack/candidates/' + ${candidate.id} + '/rerun-gates'}">
 			<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 			<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 			<input type="hidden" name="idempotencyKey" th:value="${'candidate-rerun-' + candidate.id}">

--- a/backend/src/main/resources/templates/admin/datapack/candidates/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/candidates/list.html
@@ -51,7 +51,7 @@
 				<span class="filter-chip" th:if="${filter.hasQuery()}" th:text="${'검색 ' + filter.queryValue}">검색</span>
 			</div>
 		</div>
-		<table>
+		<table class="static-table">
 			<thead>
 			<tr>
 				<th scope="col">후보</th>

--- a/backend/src/main/resources/templates/admin/datapack/facility-evidence/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/facility-evidence/list.html
@@ -48,7 +48,7 @@
 				<span class="filter-chip" th:if="${filter.hasQuery()}" th:text="${'검색 ' + filter.queryValue}">검색</span>
 			</div>
 		</div>
-		<table>
+		<table class="static-table">
 			<thead>
 			<tr>
 				<th scope="col">station</th>
@@ -100,7 +100,7 @@
 				<td th:text="${row.conflictStatus}">NONE</td>
 				<td th:text="${row.manualOverrideId}">-</td>
 				<td>
-					<form method="post" th:action="@{'/admin/datapack/facility-evidence/' + ${row.id} + '/review'}">
+					<form class="admin-form" method="post" th:action="@{'/admin/datapack/facility-evidence/' + ${row.id} + '/review'}">
 						<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 						<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 						<input type="hidden" name="idempotencyKey" th:value="${'facility-review-' + row.id}">

--- a/backend/src/main/resources/templates/admin/datapack/manual-overrides/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/manual-overrides/list.html
@@ -23,23 +23,41 @@
 
 	<section class="admin-panel">
 		<h2>Override 요청</h2>
-		<form method="post" th:action="@{/admin/datapack/manual-overrides}">
+		<form class="admin-form" method="post" th:action="@{/admin/datapack/manual-overrides}">
 			<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 			<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 			<input type="hidden" name="idempotencyKey" th:value="${overrideForm.idempotencyKey != null ? overrideForm.idempotencyKey : 'manual-override-request'}">
-			<label>id <input name="id" th:value="${overrideForm.id}" required></label>
-			<label>entityType <input name="entityType" th:value="${overrideForm.entityType != null ? overrideForm.entityType : 'FACILITY'}" required></label>
-			<label>entityId <input name="entityId" th:value="${overrideForm.entityId}" required></label>
-			<label>fieldName <input name="fieldName" th:value="${overrideForm.fieldName}" required></label>
-			<label>beforeValue <input name="beforeValue" th:value="${overrideForm.beforeValue}"></label>
-			<label>afterValue <input name="afterValue" th:value="${overrideForm.afterValue}" required></label>
-			<label>reasonCode <input name="reasonCode" th:value="${overrideForm.reasonCode != null ? overrideForm.reasonCode : 'FIELD_CHECK'}" required></label>
-			<label>reason <input name="reason" th:value="${overrideForm.reason}" required></label>
-			<label>evidenceUri <input name="evidenceUri" th:value="${overrideForm.evidenceUri}" required></label>
-			<label>evidenceHash <input name="evidenceHash" th:value="${overrideForm.evidenceHash}" required></label>
-			<label>strictRouteEligible <input type="checkbox" name="strictRouteEligible" value="true" th:checked="${overrideForm.strictRouteEligible}"></label>
-			<label>effectiveFrom <input type="datetime-local" name="effectiveFrom" th:value="${overrideForm.effectiveFrom}" required></label>
-			<label>expiresAt <input type="datetime-local" name="expiresAt" th:value="${overrideForm.expiresAt}" required></label>
+			<div class="admin-form-section">
+				<h3 class="admin-form-section-title">대상</h3>
+				<label>id <input name="id" th:value="${overrideForm.id}" required></label>
+				<div class="admin-form-row-2">
+					<label>entityType <input name="entityType" th:value="${overrideForm.entityType != null ? overrideForm.entityType : 'FACILITY'}" required></label>
+					<label>entityId <input name="entityId" th:value="${overrideForm.entityId}" required></label>
+				</div>
+				<label>fieldName <input name="fieldName" th:value="${overrideForm.fieldName}" required></label>
+			</div>
+			<div class="admin-form-section">
+				<h3 class="admin-form-section-title">변경</h3>
+				<div class="admin-form-row-2">
+					<label>beforeValue <input name="beforeValue" th:value="${overrideForm.beforeValue}"></label>
+					<label>afterValue <input name="afterValue" th:value="${overrideForm.afterValue}" required></label>
+				</div>
+			</div>
+			<div class="admin-form-section">
+				<h3 class="admin-form-section-title">근거</h3>
+				<label>reasonCode <input name="reasonCode" th:value="${overrideForm.reasonCode != null ? overrideForm.reasonCode : 'FIELD_CHECK'}" required></label>
+				<label>reason <input name="reason" th:value="${overrideForm.reason}" required></label>
+				<label>evidenceUri <input name="evidenceUri" th:value="${overrideForm.evidenceUri}" required></label>
+				<label>evidenceHash <input name="evidenceHash" th:value="${overrideForm.evidenceHash}" required></label>
+			</div>
+			<div class="admin-form-section">
+				<h3 class="admin-form-section-title">유효 기간</h3>
+				<label>strictRouteEligible <input type="checkbox" name="strictRouteEligible" value="true" th:checked="${overrideForm.strictRouteEligible}"></label>
+				<div class="admin-form-row-2">
+					<label>effectiveFrom <input type="datetime-local" name="effectiveFrom" th:value="${overrideForm.effectiveFrom}" required></label>
+					<label>expiresAt <input type="datetime-local" name="expiresAt" th:value="${overrideForm.expiresAt}" required></label>
+				</div>
+			</div>
 			<button type="submit">요청 저장</button>
 		</form>
 	</section>
@@ -74,7 +92,7 @@
 				<span class="filter-chip" th:if="${filter.hasQuery()}" th:text="${'검색 ' + filter.queryValue}">검색</span>
 			</div>
 		</div>
-		<table>
+		<table class="static-table">
 			<thead>
 			<tr>
 				<th scope="col">id</th>
@@ -136,7 +154,7 @@
 				<td th:text="${row.supersededBy}">-</td>
 				<td th:text="${row.productionStatus}">candidate 가능</td>
 				<td>
-					<form method="post" th:action="@{'/admin/datapack/manual-overrides/' + ${row.id} + '/approve'}">
+					<form class="admin-form" method="post" th:action="@{'/admin/datapack/manual-overrides/' + ${row.id} + '/approve'}">
 						<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 						<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 						<input type="hidden" name="idempotencyKey" th:value="${'manual-override-approve-' + row.id}">
@@ -146,7 +164,7 @@
 						</label>
 						<button type="submit">승인 저장</button>
 					</form>
-					<form method="post" th:action="@{'/admin/datapack/manual-overrides/' + ${row.id} + '/expire'}">
+					<form class="admin-form" method="post" th:action="@{'/admin/datapack/manual-overrides/' + ${row.id} + '/expire'}">
 						<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 						<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 						<input type="hidden" name="idempotencyKey" th:value="${'manual-override-expire-' + row.id}">

--- a/backend/src/main/resources/templates/admin/datapack/pipeline/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/pipeline/list.html
@@ -21,30 +21,30 @@
 		</div>
 	</header>
 
-	<section>
+	<section class="admin-panel">
 		<h2>현재 후보</h2>
 		<div class="metric-grid" aria-label="현재 후보 요약">
-			<div class="metric">
+			<div class="metric metric-cell">
 				<span>후보</span>
 				<strong><span th:title="${pipeline.candidateId}" th:text="${pipeline.candidateIdShort}">-</span></strong>
 				<em th:text="${'scope ' + pipeline.scopeId}">scope</em>
 			</div>
-			<div class="metric">
+			<div class="metric metric-cell">
 				<span>상태</span>
 				<strong><span th:replace="~{admin/fragments/shell :: status(${pipeline.status}, ${pipeline.statusTone})}">확인 필요</span></strong>
 				<em th:text="${pipeline.productionPromoteReason}">production promote</em>
 			</div>
-			<div class="metric" th:classappend="${pipeline.totalBlockers > 0} ? ' tone-bad'">
+			<div class="metric metric-cell" th:classappend="${pipeline.totalBlockers > 0} ? ' tone-bad'">
 				<span>총 blocker</span>
-				<strong th:text="${pipeline.totalBlockers}">0</strong>
+				<strong class="cell-num" th:text="${pipeline.totalBlockers}">0</strong>
 				<em th:text="${'생성 ' + pipeline.candidateCreatedAt}">생성 시각</em>
 			</div>
-			<div class="metric">
+			<div class="metric metric-cell">
 				<span>후보 입력 스냅샷</span>
 				<strong><span th:title="${pipeline.sourceSnapshotIds}" th:text="${pipeline.firstSourceSnapshotId}">-</span></strong>
 				<em th:text="${pipeline.sourceSnapshotIds}">snapshot ids</em>
 			</div>
-			<div class="metric">
+			<div class="metric metric-cell">
 				<span>production / rollback</span>
 				<strong th:text="${pipeline.productionCandidateId}">-</strong>
 				<em th:text="${'rollback ' + pipeline.rollbackCandidateId}">rollback</em>
@@ -52,7 +52,7 @@
 		</div>
 	</section>
 
-	<section>
+	<section class="admin-panel">
 		<h2>파이프라인 단계</h2>
 		<p>단계 노드를 눌러 해당 화면으로 이동합니다. blocker가 있는 단계는 강조됩니다.</p>
 		<ol class="datapack-pipeline" aria-label="데이터팩 파이프라인 단계">
@@ -69,9 +69,9 @@
 		</ol>
 	</section>
 
-	<section>
+	<section class="admin-panel">
 		<h2>단계별 blocker (표)</h2>
-		<table>
+		<table class="static-table">
 			<thead>
 			<tr>
 				<th scope="col">단계</th>
@@ -89,9 +89,9 @@
 		</table>
 	</section>
 
-	<section>
+	<section class="admin-panel">
 		<h2>게이트 6종 + 서명</h2>
-		<table>
+		<table class="static-table">
 			<thead>
 			<tr>
 				<th scope="col">게이트</th>
@@ -111,7 +111,7 @@
 		</table>
 	</section>
 
-	<section>
+	<section class="admin-panel">
 		<h2>서명·증거</h2>
 		<dl class="admin-meta-list">
 			<dt>원천 스냅샷 세트</dt>

--- a/backend/src/main/resources/templates/admin/datapack/release-channels/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/release-channels/list.html
@@ -53,7 +53,7 @@
 				<span class="filter-chip" th:if="${filter.hasQuery()}" th:text="${'검색 ' + filter.queryValue}">검색</span>
 			</div>
 		</div>
-		<table>
+		<table class="static-table">
 			<thead>
 			<tr>
 				<th scope="col">channel</th>
@@ -96,7 +96,7 @@
 						<summary th:text="${'승격 승인 (' + channel.channel + ')'}">승격 승인</summary>
 						<p class="meta"
 						   th:text="${'대상 채널 ' + channel.channel + ' · 현재 후보 ' + channel.candidateId + '. 확인하면 승격 요청이 접수됩니다(게시 워크플로 자동 트리거는 #1694 범위).'}">영향</p>
-						<form method="post" th:action="@{/admin/datapack/release-channels/{channel}/promote(channel=${channel.channel})}">
+						<form class="admin-form" method="post" th:action="@{/admin/datapack/release-channels/{channel}/promote(channel=${channel.channel})}">
 						<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 						<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 						<input type="hidden" name="previousCandidateId" th:value="${channel.candidateId}">
@@ -136,7 +136,7 @@
 						<summary th:text="${'rollback (' + channel.channel + ')'}">rollback</summary>
 						<p class="meta"
 						   th:text="${'대상 채널 ' + channel.channel + ' · rollback 대상 ' + channel.previousStableCandidateId + '. 확인하면 이전 안정 후보로 되돌립니다.'}">영향</p>
-						<form method="post" th:action="@{/admin/datapack/release-channels/{channel}/rollback(channel=${channel.channel})}">
+						<form class="admin-form" method="post" th:action="@{/admin/datapack/release-channels/{channel}/rollback(channel=${channel.channel})}">
 						<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 						<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 						<input type="hidden" name="previousCandidateId" th:value="${channel.candidateId}">
@@ -176,7 +176,7 @@
 
 	<section class="admin-panel">
 		<h2>채널 이벤트</h2>
-		<table>
+		<table class="static-table">
 			<thead>
 			<tr>
 				<th scope="col">event</th>

--- a/backend/src/main/resources/templates/admin/datapack/release-requests/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/release-requests/list.html
@@ -34,7 +34,7 @@
 
 	<section class="admin-panel">
 		<h2>release request 생성</h2>
-		<form method="post" th:action="@{/admin/datapack/release-requests}">
+		<form class="admin-form" method="post" th:action="@{/admin/datapack/release-requests}">
 			<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 			<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 			<label>
@@ -59,7 +59,7 @@
 
 	<section class="admin-panel">
 		<h2>release request 목록</h2>
-		<table>
+		<table class="static-table">
 			<thead>
 			<tr>
 				<th scope="col">approval</th>
@@ -76,7 +76,7 @@
 			</thead>
 			<tbody>
 			<tr th:if="${requests.isEmpty()}">
-				<td colspan="10">release request가 없습니다.</td>
+				<td colspan="10"><div th:replace="~{admin/fragments/empty-state :: panel('release request가 없습니다.', '후보를 선택해 release request를 생성해 보세요.')}"></div></td>
 			</tr>
 			<tr th:each="request : ${requests}">
 				<td th:text="${request.approvalId}">approval</td>

--- a/backend/src/main/resources/templates/admin/datapack/source-snapshots/detail.html
+++ b/backend/src/main/resources/templates/admin/datapack/source-snapshots/detail.html
@@ -69,106 +69,123 @@
 
 	<section class="admin-panel">
 		<h2>LOCKED snapshot 저장</h2>
-		<form method="post" th:action="@{/admin/datapack/source-snapshots}">
+		<form class="admin-form" method="post" th:action="@{/admin/datapack/source-snapshots}">
 			<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 			<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
-			<label>
-				snapshot id
-				<input name="snapshotId" required>
-			</label>
-			<label>
-				source id
-				<input name="sourceId" th:value="${snapshot.sourceId}" required>
-			</label>
-			<label>
-				provider
-				<input name="provider" th:value="${snapshot.provider}" required>
-			</label>
-			<label>
-				retrieved at
-				<input name="retrievedAt" type="datetime-local" required>
-			</label>
-			<label>
-				source updated at
-				<input name="sourceUpdatedAt" type="datetime-local">
-			</label>
-			<label>
-				row count
-				<input name="rowCount" type="number" min="0" required>
-			</label>
-			<label>
-				raw sha256
-				<input name="rawSha256" minlength="64" maxlength="64" required>
-			</label>
-			<label>
-				raw object uri
-				<input name="rawObjectUri" required>
-			</label>
-			<label>
-				request fingerprint
-				<input name="redactedRequestFingerprint" minlength="64" maxlength="64" required>
-			</label>
-			<label>
-				schema fingerprint
-				<input name="schemaFingerprint" minlength="64" maxlength="64" required>
-			</label>
-			<label>
-				schema status
-				<input name="schemaStatus" value="PASS" required>
-			</label>
-			<label>
-				license status
-				<input name="licenseStatus" value="PASS" required>
-			</label>
-			<label>
-				fetch status
-				<input name="fetchStatus" value="SUCCESS" required>
-			</label>
-			<label>
-				redistribution allowed
-				<select name="redistributionAllowed" required>
-					<option value="true">true</option>
-					<option value="false">false</option>
-				</select>
-			</label>
-			<label>
-				credential redacted
-				<select name="credentialRedacted" required>
-					<option value="true">true</option>
-					<option value="false">false</option>
-				</select>
-			</label>
-			<label>
-				previous snapshot id
-				<input name="previousSnapshotId" th:value="${snapshot.snapshotId}">
-			</label>
-			<label>
-				diff summary
-				<input name="diffSummary" required>
-			</label>
-			<label>
-				freshness expires at
-				<input name="freshnessExpiresAt" type="datetime-local" required>
-			</label>
-			<label>
-				raw retention expires at
-				<input name="rawRetentionExpiresAt" type="datetime-local" required>
-			</label>
-			<label>
-				reason
-				<input name="reason" required>
-			</label>
-			<label>
-				idempotency key
-				<input name="idempotencyKey" required>
-			</label>
+			<div class="admin-form-section">
+				<h3 class="admin-form-section-title">스냅샷 식별</h3>
+				<label>
+					snapshot id
+					<input name="snapshotId" required>
+				</label>
+				<label>
+					source id
+					<input name="sourceId" th:value="${snapshot.sourceId}" required>
+				</label>
+				<label>
+					provider
+					<input name="provider" th:value="${snapshot.provider}" required>
+				</label>
+			</div>
+			<div class="admin-form-section">
+				<h3 class="admin-form-section-title">수집 시각</h3>
+				<label>
+					retrieved at
+					<input name="retrievedAt" type="datetime-local" required>
+				</label>
+				<label>
+					source updated at
+					<input name="sourceUpdatedAt" type="datetime-local">
+				</label>
+				<label>
+					row count
+					<input name="rowCount" type="number" min="0" required>
+				</label>
+			</div>
+			<div class="admin-form-section">
+				<h3 class="admin-form-section-title">무결성 근거</h3>
+				<label>
+					raw sha256
+					<input name="rawSha256" minlength="64" maxlength="64" required>
+				</label>
+				<label>
+					raw object uri
+					<input name="rawObjectUri" required>
+				</label>
+				<label>
+					request fingerprint
+					<input name="redactedRequestFingerprint" minlength="64" maxlength="64" required>
+				</label>
+				<label>
+					schema fingerprint
+					<input name="schemaFingerprint" minlength="64" maxlength="64" required>
+				</label>
+			</div>
+			<div class="admin-form-section">
+				<h3 class="admin-form-section-title">상태</h3>
+				<label>
+					schema status
+					<input name="schemaStatus" value="PASS" required>
+				</label>
+				<label>
+					license status
+					<input name="licenseStatus" value="PASS" required>
+				</label>
+				<label>
+					fetch status
+					<input name="fetchStatus" value="SUCCESS" required>
+				</label>
+				<div class="admin-form-row-2">
+					<label>
+						redistribution allowed
+						<select name="redistributionAllowed" required>
+							<option value="true">true</option>
+							<option value="false">false</option>
+						</select>
+					</label>
+					<label>
+						credential redacted
+						<select name="credentialRedacted" required>
+							<option value="true">true</option>
+							<option value="false">false</option>
+						</select>
+					</label>
+				</div>
+			</div>
+			<div class="admin-form-section">
+				<h3 class="admin-form-section-title">보존·후속</h3>
+				<label>
+					previous snapshot id
+					<input name="previousSnapshotId" th:value="${snapshot.snapshotId}">
+				</label>
+				<label>
+					diff summary
+					<input name="diffSummary" required>
+				</label>
+				<label>
+					freshness expires at
+					<input name="freshnessExpiresAt" type="datetime-local" required>
+				</label>
+				<label>
+					raw retention expires at
+					<input name="rawRetentionExpiresAt" type="datetime-local" required>
+				</label>
+				<label>
+					reason
+					<input name="reason" required>
+				</label>
+				<label>
+					idempotency key
+					<input name="idempotencyKey" required>
+				</label>
+			</div>
 			<button type="submit">LOCKED snapshot 저장</button>
 		</form>
 	</section>
 
 	<section class="admin-panel">
 		<h2>Normalization run 요청</h2>
-		<form method="post" th:action="@{'/admin/datapack/source-snapshots/' + ${snapshot.snapshotId} + '/normalization-runs'}">
+		<form class="admin-form" method="post" th:action="@{'/admin/datapack/source-snapshots/' + ${snapshot.snapshotId} + '/normalization-runs'}">
 			<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 			<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 			<label>

--- a/backend/src/main/resources/templates/admin/datapack/source-snapshots/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/source-snapshots/list.html
@@ -21,7 +21,7 @@
 		</div>
 	</header>
 
-	<section>
+	<section class="admin-panel">
 		<form class="table-toolbar" method="get" th:action="@{/admin/datapack/source-snapshots/page}"
 		      role="search" aria-label="원천 스냅샷 검색">
 			<input type="search" name="query" th:value="${filter.queryValue}"
@@ -52,7 +52,7 @@
 				<span class="filter-chip" th:if="${filter.hasQuery()}" th:text="${'검색 ' + filter.queryValue}">검색</span>
 			</div>
 		</div>
-		<table>
+		<table class="static-table">
 			<thead>
 			<tr>
 				<th scope="col">스냅샷</th>


### PR DESCRIPTION
## 관련 이슈

Closes #1986

## 작업 내용

- datapack 파이프라인 관련 9종 화면(candidates, release-channels, pipeline, release-requests, route-gates, alias-quarantine, source-snapshots, facility-evidence, manual-overrides) 템플릿을 #1982/#1983에서 확정된 표준 컴포넌트로 정합. `.admin-panel`(패널 컨테이너), `.static-table`(read-only 표 밀도 규격), `.admin-form`(폼 그리드), `.metric-cell`/`.cell-num`(지표 셀·숫자 우정렬), empty-state fragment를 기존 마크업에 적용. `admin-v3.css`의 기존 규칙은 무수정으로 재사용만 했다.
- `route-gates/list.html`은 사전 점검 결과 이미 완전 정합 상태라 변경 없음(diff 0).
- `pipeline/list.html` 지표 그리드에서 후보 ID·스냅샷 ID 등 문자열 필드에 `cell-num`(숫자 우정렬)이 잘못 붙는 것을 배제하고, 실제 숫자 값(총 blocker)에만 적용했다.
- 오너 추가 지시(2026-07-13): `manual-overrides`의 "Override 요청", `source-snapshots/detail`의 "LOCKED snapshot 저장"처럼 필드가 많은 폼이 라벨·입력이 밀집해 스캔하기 어렵다는 지적에 따라, `admin-v3.css`에 `.admin-form-section`(섹션 소제목 + 상단 1px 구분선)과 `.admin-form-row-2`(짧은 필드 2열 그리드, 모바일 1열 폴백) 유틸을 추가하고 두 폼을 의미 단위 섹션(대상/변경/근거/유효 기간 등)으로 그룹핑했다. 단일 컬럼 원칙은 유지, 필드명·값·검증·HTMX 계약은 불변.
- route gate matrix 등 고밀도 표는 `.static-table`(hover·고정 행높이 opt-out)과 sticky header(전역 규칙)를 적용해 정보 밀도를 유지·강화했다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests "com.easysubway.admin.web.AdminDesignGuardTest" --tests "com.easysubway.datapack.adapter.in.web.AliasQuarantineAdminPageControllerTest" --tests "com.easysubway.datapack.adapter.in.web.FacilityEvidenceAdminPageControllerTest" --tests "com.easysubway.datapack.adapter.in.web.ManualOverrideLedgerAdminPageControllerTest" --tests "com.easysubway.datapack.adapter.in.web.DatapackReleaseRequestAdminPageControllerTest" --tests "com.easysubway.datapack.adapter.in.web.RouteGateMatrixAdminPageControllerTest" --tests "com.easysubway.datapack.adapter.in.web.DatapackPipelineAdminPageControllerTest" --tests "com.easysubway.datapack.adapter.in.web.DatapackCandidateAdminPageControllerTest" --tests "com.easysubway.datapack.adapter.in.web.DatapackReleaseChannelAdminPageControllerTest" --tests "com.easysubway.datapack.adapter.in.web.DataSourceSnapshotAdminPageControllerTest"` → BUILD SUCCESSFUL
  - `./gradlew test --tests "com.easysubway.datapack.*" --tests "com.easysubway.admin.*"` → BUILD SUCCESSFUL(회귀 없음)
  - 전/후 스크린샷: dev 프로필 두 서버(전 origin/main, 후 이 브랜치)로 로그인 후 pipeline·candidates 목록·route-gates·source-snapshots·manual-overrides 5개 화면 캡처, 로컬 확인 후 삭제(저장소에는 커밋하지 않음). 표 구분선·밀도 유지, 이모지 없음, 초록색 없음, manual-overrides 폼 섹션 그룹핑·2열 배치 확인.

## 영향

- [x] 제품/운영 위험 없음 (route/accessibility/mobile UX/backend API/auth/security 아님)
- [x] DB migration 없음
- [x] 배포 영향 없음
- [x] route/realtime/datapack contract 영향 없음
- [x] CI workflow·계약 테스트·release gate JSON 변경 없음 (있으면 full.md로 전환)

## 체크리스트

- [x] 이 PR은 B/C등급 작업이며 full template이 필요 없다.
- [x] CI 결과를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 폴백 리뷰를 단일 PR review로 게시했다.