### PR TITLE
[Chore] 하이브리드 렌더링 계약 전환: 결정문·manifest·계약테스트

### DIFF
--- a/apps/mobile/assets/datapacks/metro_map_pack/manifest.json
+++ b/apps/mobile/assets/datapacks/metro_map_pack/manifest.json
@@ -17,8 +17,8 @@
       "operator": "오너 자작(self-drawn)",
       "source_url": "internal:route-map/route-map-defs/svg-sources/easy-subway-sma-v2.svg",
       "route_map_strategy": {
-        "rendering_strategy": "self-drawn-schematic",
-        "bundled_svg_role": "review-reference-only",
+        "rendering_strategy": "self-drawn-hybrid-basemap",
+        "bundled_svg_role": "hybrid-basemap-source",
         "commercial_production_ready": true,
         "decision_ref": "tools/route-map/route-map-license-decision.json"
       },
@@ -44,7 +44,7 @@
         "derivativeWorkAllowed": true,
         "redistributionAllowed": true,
         "reviewStatus": "self-drawn-confirmed",
-        "changes": "App rendering uses structured coordinates (route_map_positions) derived from the owner's self-drawn 8-linear schematic, not the raw SVG. Line colors follow the official Seoul Metropolitan Government route-color PDF (GTX-A retained from the source SVG). The SVG itself is retained only as a coordinate-review reference and is not distributed as the render source."
+        "changes": "App rendering uses structured coordinates (route_map_positions) derived from the owner's self-drawn 8-linear schematic, not the raw SVG. Line colors follow the official Seoul Metropolitan Government route-color PDF (GTX-A retained from the source SVG). The self-drawn SVG is now the basemap paint source (build-time compiled, hybrid rendering), while interaction (station tap hit-testing, focus camera, popover anchoring, route highlighting) still trusts the structured coordinates. The compiled basemap asset itself is not yet bundled offline (offline.included stays false in this PR) and is scheduled to ship in a follow-up PR."
       }
     },
     {
@@ -54,8 +54,8 @@
       "operator": "부산교통공사",
       "source_url": "https://www2.humetro.busan.kr/homepage/cyberstation/map.do",
       "route_map_strategy": {
-        "rendering_strategy": "self-drawn-schematic",
-        "bundled_svg_role": "review-reference-only",
+        "rendering_strategy": "self-drawn-hybrid-basemap",
+        "bundled_svg_role": "hybrid-basemap-source",
         "commercial_production_ready": true,
         "decision_ref": "tools/route-map/route-map-license-decision.json"
       },
@@ -81,7 +81,7 @@
         "derivativeWorkAllowed": true,
         "redistributionAllowed": true,
         "reviewStatus": "self-drawn-confirmed",
-        "changes": "App rendering uses structured coordinates (route_map_positions) derived from the owner's self-drawn 8-linear Busan schematic (easy-subway-busan-v1), not the raw SVG. The SVG itself is retained only as a coordinate-review reference and is not distributed as the render source."
+        "changes": "App rendering uses structured coordinates (route_map_positions) derived from the owner's self-drawn 8-linear Busan schematic (easy-subway-busan-v1), not the raw SVG. The self-drawn SVG is now the basemap paint source (build-time compiled, hybrid rendering), while interaction (station tap hit-testing, focus camera, popover anchoring, route highlighting) still trusts the structured coordinates. The compiled basemap asset itself is not yet bundled offline (offline.included stays false in this PR) and is scheduled to ship in a follow-up PR."
       }
     },
     {
@@ -91,8 +91,8 @@
       "operator": "오너 자작(self-drawn)",
       "source_url": "internal:route-map/route-map-defs/svg-sources/easy-subway-gwangju-v1.svg",
       "route_map_strategy": {
-        "rendering_strategy": "self-drawn-schematic",
-        "bundled_svg_role": "review-reference-only",
+        "rendering_strategy": "self-drawn-hybrid-basemap",
+        "bundled_svg_role": "hybrid-basemap-source",
         "commercial_production_ready": true,
         "decision_ref": "tools/route-map/route-map-license-decision.json"
       },
@@ -117,7 +117,7 @@
         "derivativeWorkAllowed": true,
         "redistributionAllowed": true,
         "reviewStatus": "self-drawn-confirmed",
-        "changes": "Attribution contract transition (not removal): the previously bundled CC BY-SA 2.0 KR route-map asset (kiwitree, ShareAlike) is superseded by the owner's self-drawn 8-linear Gwangju schematic (easy-subway-gwangju-v1). App rendering uses structured coordinates (route_map_positions) derived from the self-drawn schematic, not the CC BY-SA SVG, so the ShareAlike/attribution chain no longer attaches to the distributed render. Only line-1 catalog stations are mapped; line 2 drawn in the schematic is excluded. The self-drawn SVG is retained only as a coordinate-review reference and is not distributed as the render source."
+        "changes": "Attribution contract transition (not removal): the previously bundled CC BY-SA 2.0 KR route-map asset (kiwitree, ShareAlike) is superseded by the owner's self-drawn 8-linear Gwangju schematic (easy-subway-gwangju-v1). App rendering uses structured coordinates (route_map_positions) derived from the self-drawn schematic, not the CC BY-SA SVG, so the ShareAlike/attribution chain no longer attaches to the distributed render. Only line-1 catalog stations are mapped; line 2 drawn in the schematic is excluded. The self-drawn SVG is now the basemap paint source (build-time compiled, hybrid rendering), while interaction (station tap hit-testing, focus camera, popover anchoring, route highlighting) still trusts the structured coordinates. The compiled basemap asset itself is not yet bundled offline (offline.included stays false in this PR) and is scheduled to ship in a follow-up PR."
       }
     },
     {
@@ -127,8 +127,8 @@
       "operator": "오너 자작(self-drawn)",
       "source_url": "internal:route-map/route-map-defs/svg-sources/easy-subway-daegu-v1.svg",
       "route_map_strategy": {
-        "rendering_strategy": "self-drawn-schematic",
-        "bundled_svg_role": "review-reference-only",
+        "rendering_strategy": "self-drawn-hybrid-basemap",
+        "bundled_svg_role": "hybrid-basemap-source",
         "commercial_production_ready": true,
         "decision_ref": "tools/route-map/route-map-license-decision.json"
       },
@@ -154,7 +154,7 @@
         "derivativeWorkAllowed": true,
         "redistributionAllowed": true,
         "reviewStatus": "self-drawn-confirmed",
-        "changes": "App rendering uses structured coordinates (route_map_positions) derived from the owner's self-drawn 8-linear Daegu schematic (easy-subway-daegu-v1), not the raw SVG. The SVG itself is retained only as a coordinate-review reference and is not distributed as the render source."
+        "changes": "App rendering uses structured coordinates (route_map_positions) derived from the owner's self-drawn 8-linear Daegu schematic (easy-subway-daegu-v1), not the raw SVG. The self-drawn SVG is now the basemap paint source (build-time compiled, hybrid rendering), while interaction (station tap hit-testing, focus camera, popover anchoring, route highlighting) still trusts the structured coordinates. The compiled basemap asset itself is not yet bundled offline (offline.included stays false in this PR) and is scheduled to ship in a follow-up PR."
       }
     },
     {
@@ -164,8 +164,8 @@
       "operator": "오너 자작(self-drawn)",
       "source_url": "internal:route-map/route-map-defs/svg-sources/easy-subway-daejeon-v1.svg",
       "route_map_strategy": {
-        "rendering_strategy": "self-drawn-schematic",
-        "bundled_svg_role": "review-reference-only",
+        "rendering_strategy": "self-drawn-hybrid-basemap",
+        "bundled_svg_role": "hybrid-basemap-source",
         "commercial_production_ready": true,
         "decision_ref": "tools/route-map/route-map-license-decision.json"
       },
@@ -191,7 +191,7 @@
         "derivativeWorkAllowed": true,
         "redistributionAllowed": true,
         "reviewStatus": "self-drawn-confirmed",
-        "changes": "App rendering uses structured coordinates (route_map_positions) derived from the owner's self-drawn 8-linear Daejeon schematic (easy-subway-daejeon-v1), not the raw SVG. Only line-1 catalog stations are mapped; unopened lines drawn in the schematic (circular line 2, Chungcheong regional rail) are excluded. The SVG itself is retained only as a coordinate-review reference and is not distributed as the render source."
+        "changes": "App rendering uses structured coordinates (route_map_positions) derived from the owner's self-drawn 8-linear Daejeon schematic (easy-subway-daejeon-v1), not the raw SVG. Only line-1 catalog stations are mapped; unopened lines drawn in the schematic (circular line 2, Chungcheong regional rail) are excluded. The self-drawn SVG is now the basemap paint source (build-time compiled, hybrid rendering), while interaction (station tap hit-testing, focus camera, popover anchoring, route highlighting) still trusts the structured coordinates. The compiled basemap asset itself is not yet bundled offline (offline.included stays false in this PR) and is scheduled to ship in a follow-up PR."
       }
     }
   ]

--- a/tools/route-map/route-map-license-decision.json
+++ b/tools/route-map/route-map-license-decision.json
@@ -3,8 +3,9 @@
   "artifactKind": "route-map-license-decision",
   "issue": 1637,
   "decidedAt": "2026-07-12",
-  "summary": "부산·대구·대전·광주 노선도는 원본 SVG 이미지를 앱 렌더링 source of truth로 쓰지 않고, 역 좌표·노선 위상(사실 데이터) 기반 자체 schematic layout으로 그린다(대안 A). 원본 SVG는 좌표 검수 기준으로만 사용한다.",
+  "summary": "부산·대구·대전·광주 노선도는 원본 SVG 이미지를 앱 렌더링 source of truth로 쓰지 않고, 역 좌표·노선 위상(사실 데이터) 기반 자체 schematic layout으로 그린다(대안 A). 원본 SVG는 좌표 검수 기준으로만 사용한다. [2026-07-13 #2068] 5권역 전부 오너 자작 SVG로 재제작 완료(#2011)되어 라이선스 리스크가 소멸함에 따라, 자작 SVG를 빌드타임 컴파일(vector_graphics)해 바탕층(basemap)으로 실제 렌더링에 사용하는 하이브리드 전략(self-drawn-hybrid-basemap)으로 전환한다. 역 탭 히트·focus 카메라·팝오버 앵커·경로 강조 등 인터랙션은 여전히 구조화 좌표(route_map_positions)가 진실 출처다 — 바탕 paint 소스(자작 SVG)와 인터랙션 진실 출처(구조화 데이터)는 서로 다른 개념이며 후자만 renderingSourceOfTruth로 고정한다.",
   "renderingSourceOfTruth": "structured-data",
+  "renderingSourceOfTruthNote": "renderingSourceOfTruth는 역 탭 히트·focus 카메라·팝오버 앵커·경로 강조 등 인터랙션 로직이 신뢰하는 데이터 출처를 가리키며, 화면에 그려지는 바탕(basemap) 이미지의 paint 소스와는 다른 축이다. [2026-07-13 #2068] self-drawn-hybrid-basemap 전략에서도 바탕은 자작 SVG(빌드타임 vector_graphics 컴파일)를 렌더하지만, 인터랙션은 그대로 구조화 데이터를 신뢰하므로 이 필드는 structured-data를 유지한다.",
   "reviewStatusValues": [
     "self-drawn-confirmed",
     "self-drawn-fact-based",
@@ -13,11 +14,13 @@
   ],
   "strategyValues": [
     "official-svg",
-    "self-drawn-schematic"
+    "self-drawn-schematic",
+    "self-drawn-hybrid-basemap"
   ],
   "bundledSvgRoleValues": [
     "app-render-source",
-    "review-reference-only"
+    "review-reference-only",
+    "hybrid-basemap-source"
   ],
   "regions": [
     {
@@ -28,8 +31,8 @@
       "retrievedAt": "2026-07-12",
       "originalLicenseSpdx": "LicenseRef-Self-Drawn",
       "originalCommercialUseAllowed": true,
-      "renderingStrategy": "self-drawn-schematic",
-      "bundledSvgRole": "review-reference-only",
+      "renderingStrategy": "self-drawn-hybrid-basemap",
+      "bundledSvgRole": "hybrid-basemap-source",
       "attributionRequired": false,
       "commercialProductionReady": true,
       "redistributionAllowed": true,
@@ -38,7 +41,7 @@
       "selfDrawnSource": "easy-subway-sma-v2.svg",
       "lineColorSource": "서울시 공식 노선 색상값 PDF(공식 지하철 노선도 디자인 페이지 다운로드); GTX-A는 PDF에 없어 원본 SVG 값 유지",
       "provenanceVerifiedAt": "2026-07-12",
-      "notes": "[2026-07-11 #1950] 수도권 렌더 정본을 오너 자작 8선형 완성 도식(easy-subway-sma-v1)으로 교체. 오너가 직접 제작한 창작물이므로 self-drawn 확정 — 상용 허용·attribution 불필요. 앱은 SVG 원본을 통째 렌더하지 않고(#1635 유지) 도식에서 파생한 구조화 좌표(route_map_positions)만 렌더한다. 노선색은 서울시 공식 노선 색상값 PDF 근거(GTX-A만 원본 SVG 유지). 이전 정본은 Wikimedia PD SVG 좌표 감사(qa-wikimedia-seoul-svg-coordinate)였고, 도라산 1역은 오너 도식 미수록으로 카탈로그 유지·위상 보존 명시 예외다. [2026-07-12 #2011] 오너가 재제작한 v2(easy-subway-sma-v2 — 환승 중심 정렬 v4-clean·경의중앙 동농~지평 스무딩)로 정본 교체. #1950 반복 파이프라인 재실행 결과 역 추가/삭제 0·이동 29·노선 변화 0(순수 기하 정제)이며 미매핑 0 유지. 도라산은 v2에도 미수록이라 카탈로그 유지 예외 존속(위상 보존). v1 SVG(easy-subway-sma-v1)는 삭제하지 않고 review-reference로 보관한다 — 반복 파이프라인의 1급 산출물인 v(N)↔v(N+1) 버전 diff 재현용 baseline이며, bundled_svg_role=review-reference-only 정책과 정합이다(앱 렌더 source 아님)."
+      "notes": "[2026-07-11 #1950] 수도권 렌더 정본을 오너 자작 8선형 완성 도식(easy-subway-sma-v1)으로 교체. 오너가 직접 제작한 창작물이므로 self-drawn 확정 — 상용 허용·attribution 불필요. 앱은 SVG 원본을 통째 렌더하지 않고(#1635 유지) 도식에서 파생한 구조화 좌표(route_map_positions)만 렌더한다. 노선색은 서울시 공식 노선 색상값 PDF 근거(GTX-A만 원본 SVG 유지). 이전 정본은 Wikimedia PD SVG 좌표 감사(qa-wikimedia-seoul-svg-coordinate)였고, 도라산 1역은 오너 도식 미수록으로 카탈로그 유지·위상 보존 명시 예외다. [2026-07-12 #2011] 오너가 재제작한 v2(easy-subway-sma-v2 — 환승 중심 정렬 v4-clean·경의중앙 동농~지평 스무딩)로 정본 교체. #1950 반복 파이프라인 재실행 결과 역 추가/삭제 0·이동 29·노선 변화 0(순수 기하 정제)이며 미매핑 0 유지. 도라산은 v2에도 미수록이라 카탈로그 유지 예외 존속(위상 보존). v1 SVG(easy-subway-sma-v1)는 삭제하지 않고 review-reference로 보관한다 — 반복 파이프라인의 1급 산출물인 v(N)↔v(N+1) 버전 diff 재현용 baseline이며, bundled_svg_role=review-reference-only 정책과 정합이다(앱 렌더 source 아님). [2026-07-13 #2068] 자체 라이선스 전환 완료로 라이선스 리스크가 소멸해 하이브리드 렌더링(자작 SVG를 빌드타임 컴파일해 바탕층으로 실제 렌더, 인터랙션은 구조화 좌표 유지)으로 전환 — renderingStrategy=self-drawn-hybrid-basemap, bundledSvgRole=hybrid-basemap-source로 갱신한다. 이 PR은 계약(결정문·manifest·계약테스트)만 갱신하며, 실제 SVG 컴파일 파이프라인·painter 교체는 후속 PR(#2068 2번째)에서 수행한다."
     },
     {
       "id": "busan",
@@ -48,15 +51,15 @@
       "retrievedAt": "2026-07-12",
       "originalLicenseSpdx": "LicenseRef-Self-Drawn",
       "originalCommercialUseAllowed": true,
-      "renderingStrategy": "self-drawn-schematic",
-      "bundledSvgRole": "review-reference-only",
+      "renderingStrategy": "self-drawn-hybrid-basemap",
+      "bundledSvgRole": "hybrid-basemap-source",
       "attributionRequired": false,
       "attributionDropTargetAfterSelfDrawn": true,
       "commercialProductionReady": true,
       "redistributionAllowed": true,
       "reviewStatus": "self-drawn-confirmed",
       "selfDrawnSource": "easy-subway-busan-v1.svg",
-      "notes": "[연혁] 원본은 재배포 권한 미확인(permission-required)이었고, 앱 렌더링을 사실 데이터(역 좌표·노선 위상) 기반 자체 schematic으로 전환해 SVG 표현 파생을 제거하고 attribution을 해제한 상태(reviewStatus=self-drawn-fact-based)였다(#1639/#1640/#1715/#1958). [2026-07-12 #2011/#1951] 오너가 부산 노선도를 직접 재제작(easy-subway-busan-v1 — 8선형 self-contained SVG)해 새 정본으로 반입했다. 오너가 직접 제작한 창작물이므로 self-drawn 확정으로 승격 — #1951 오너 결정(자작 전환 시 임시 evidence를 자작 기록으로 대체) 이행. 앱은 SVG 원본을 통째 렌더하지 않고(#1635 유지) 도식에서 파생한 구조화 좌표(route_map_positions)만 렌더한다. #2011 2단계 반복 파이프라인(권역 파라미터화) 재실행 결과 역 추가/삭제 0·위상 보존 100%(현행 부산 팩 158 (station,line) 쌍 동일)이며 미매핑 0. 원본 SVG는 삭제하지 않고 review-reference로 보관한다(bundled_svg_role=review-reference-only, 앱 렌더 source 아님).",
+      "notes": "[연혁] 원본은 재배포 권한 미확인(permission-required)이었고, 앱 렌더링을 사실 데이터(역 좌표·노선 위상) 기반 자체 schematic으로 전환해 SVG 표현 파생을 제거하고 attribution을 해제한 상태(reviewStatus=self-drawn-fact-based)였다(#1639/#1640/#1715/#1958). [2026-07-12 #2011/#1951] 오너가 부산 노선도를 직접 재제작(easy-subway-busan-v1 — 8선형 self-contained SVG)해 새 정본으로 반입했다. 오너가 직접 제작한 창작물이므로 self-drawn 확정으로 승격 — #1951 오너 결정(자작 전환 시 임시 evidence를 자작 기록으로 대체) 이행. 앱은 SVG 원본을 통째 렌더하지 않고(#1635 유지) 도식에서 파생한 구조화 좌표(route_map_positions)만 렌더한다. #2011 2단계 반복 파이프라인(권역 파라미터화) 재실행 결과 역 추가/삭제 0·위상 보존 100%(현행 부산 팩 158 (station,line) 쌍 동일)이며 미매핑 0. 원본 SVG는 삭제하지 않고 review-reference로 보관한다(bundled_svg_role=review-reference-only, 앱 렌더 source 아님). [2026-07-13 #2068] 자체 라이선스 전환 완료로 라이선스 리스크가 소멸해 하이브리드 렌더링(자작 SVG를 빌드타임 컴파일해 바탕층으로 실제 렌더, 인터랙션은 구조화 좌표 유지)으로 전환 — renderingStrategy=self-drawn-hybrid-basemap, bundledSvgRole=hybrid-basemap-source로 갱신한다. 이 PR은 계약(결정문·manifest·계약테스트)만 갱신하며, 실제 SVG 컴파일 파이프라인·painter 교체는 후속 PR(#2068 2번째)에서 수행한다.",
       "licenseStatus": "self-drawn-confirmed",
       "lineColorSource": "부산 도시철도 1~4호선·동해선·부산김해경전철 공식 노선 색상값(오너 자작 도식에 반영)",
       "provenanceVerifiedAt": "2026-07-12"
@@ -69,15 +72,15 @@
       "retrievedAt": "2026-07-12",
       "originalLicenseSpdx": "LicenseRef-Self-Drawn",
       "originalCommercialUseAllowed": true,
-      "renderingStrategy": "self-drawn-schematic",
-      "bundledSvgRole": "review-reference-only",
+      "renderingStrategy": "self-drawn-hybrid-basemap",
+      "bundledSvgRole": "hybrid-basemap-source",
       "attributionRequired": false,
       "attributionDropTargetAfterSelfDrawn": true,
       "commercialProductionReady": true,
       "redistributionAllowed": true,
       "reviewStatus": "self-drawn-confirmed",
       "selfDrawnSource": "easy-subway-daegu-v1.svg",
-      "notes": "[연혁] 원본은 재배포 권한 미확인(permission-required)이었고, 앱 렌더링을 사실 데이터(역 좌표·노선 위상) 기반 자체 schematic으로 전환해 SVG 표현 파생을 제거하고 attribution을 해제한 상태(reviewStatus=self-drawn-fact-based)였다(#1639/#1640/#1715/#1958). [2026-07-12 #2011/#1951] 오너가 대구 노선도를 직접 재제작(easy-subway-daegu-v1 — 1·2·3호선+대경선 8선형 self-contained SVG)해 새 정본으로 반입했다. 오너가 직접 제작한 창작물이므로 self-drawn 확정으로 승격 — #1951 오너 결정(자작 전환 시 임시 evidence를 자작 기록으로 대체) 이행. 앱은 SVG 원본을 통째 렌더하지 않고(#1635 유지) 도식에서 파생한 구조화 좌표(route_map_positions)만 렌더한다. #2011 3단계 반복 파이프라인(권역 파라미터화) 재실행 결과 역 추가/삭제 0·위상 보존 100%(현행 대구 팩 101 (station,line) 쌍 동일)이며 미매핑 0. 반입 당시 도식 수록 대경선 북삼역은 현행 카탈로그 미수록이라 fail-closed로 명시 제외했으나, [2026-07-13 #2019] 북삼역(2026-02-28 개통)을 대경선 카탈로그에 정식 반영(왜관↔사곡 사이)해 도식 노드와 매핑을 완성했다(현행 대구 팩 102 (station,line) 쌍). 원본 SVG는 삭제하지 않고 review-reference로 보관한다(bundled_svg_role=review-reference-only, 앱 렌더 source 아님).",
+      "notes": "[연혁] 원본은 재배포 권한 미확인(permission-required)이었고, 앱 렌더링을 사실 데이터(역 좌표·노선 위상) 기반 자체 schematic으로 전환해 SVG 표현 파생을 제거하고 attribution을 해제한 상태(reviewStatus=self-drawn-fact-based)였다(#1639/#1640/#1715/#1958). [2026-07-12 #2011/#1951] 오너가 대구 노선도를 직접 재제작(easy-subway-daegu-v1 — 1·2·3호선+대경선 8선형 self-contained SVG)해 새 정본으로 반입했다. 오너가 직접 제작한 창작물이므로 self-drawn 확정으로 승격 — #1951 오너 결정(자작 전환 시 임시 evidence를 자작 기록으로 대체) 이행. 앱은 SVG 원본을 통째 렌더하지 않고(#1635 유지) 도식에서 파생한 구조화 좌표(route_map_positions)만 렌더한다. #2011 3단계 반복 파이프라인(권역 파라미터화) 재실행 결과 역 추가/삭제 0·위상 보존 100%(현행 대구 팩 101 (station,line) 쌍 동일)이며 미매핑 0. 반입 당시 도식 수록 대경선 북삼역은 현행 카탈로그 미수록이라 fail-closed로 명시 제외했으나, [2026-07-13 #2019] 북삼역(2026-02-28 개통)을 대경선 카탈로그에 정식 반영(왜관↔사곡 사이)해 도식 노드와 매핑을 완성했다(현행 대구 팩 102 (station,line) 쌍). 원본 SVG는 삭제하지 않고 review-reference로 보관한다(bundled_svg_role=review-reference-only, 앱 렌더 source 아님). [2026-07-13 #2068] 자체 라이선스 전환 완료로 라이선스 리스크가 소멸해 하이브리드 렌더링(자작 SVG를 빌드타임 컴파일해 바탕층으로 실제 렌더, 인터랙션은 구조화 좌표 유지)으로 전환 — renderingStrategy=self-drawn-hybrid-basemap, bundledSvgRole=hybrid-basemap-source로 갱신한다. 이 PR은 계약(결정문·manifest·계약테스트)만 갱신하며, 실제 SVG 컴파일 파이프라인·painter 교체는 후속 PR(#2068 2번째)에서 수행한다.",
       "licenseStatus": "self-drawn-confirmed",
       "lineColorSource": "대구 도시철도 1·2·3호선·대경선 공식 노선 색상값(오너 자작 도식에 반영)",
       "provenanceVerifiedAt": "2026-07-12"
@@ -90,15 +93,15 @@
       "retrievedAt": "2026-07-12",
       "originalLicenseSpdx": "LicenseRef-Self-Drawn",
       "originalCommercialUseAllowed": true,
-      "renderingStrategy": "self-drawn-schematic",
-      "bundledSvgRole": "review-reference-only",
+      "renderingStrategy": "self-drawn-hybrid-basemap",
+      "bundledSvgRole": "hybrid-basemap-source",
       "attributionRequired": false,
       "attributionDropTargetAfterSelfDrawn": true,
       "commercialProductionReady": true,
       "redistributionAllowed": true,
       "reviewStatus": "self-drawn-confirmed",
       "selfDrawnSource": "easy-subway-daejeon-v1.svg",
-      "notes": "[연혁] 원본은 재배포 권한 미확인(permission-required)이었고, 앱 렌더링을 사실 데이터(역 좌표·노선 위상) 기반 자체 schematic으로 전환해 SVG 표현 파생을 제거하고 attribution을 해제한 상태(reviewStatus=self-drawn-fact-based)였다(#1639/#1640/#1715/#1958). [2026-07-12 #2011/#1951] 오너가 대전 노선도를 직접 재제작(easy-subway-daejeon-v1 — 8선형 self-contained SVG)해 새 정본으로 반입했다. 오너가 직접 제작한 창작물이므로 self-drawn 확정으로 승격 — #1951 오너 결정(자작 전환 시 임시 evidence를 자작 기록으로 대체) 이행. 앱은 SVG 원본을 통째 렌더하지 않고(#1635 유지) 도식에서 파생한 구조화 좌표(route_map_positions)만 렌더한다. #2011 3단계 반복 파이프라인(권역 파라미터화) 재실행 결과 역 추가/삭제 0·위상 보존 100%(현행 대전 팩 22 (station,line) 쌍 동일)이며 미매핑 0. 대전 도식은 카탈로그 밖 미개통 노선(도시철도 순환2호선·충청권 광역철도)까지 그리므로 nodeFilter로 1호선 실역(22)만 정합 대상으로 남기고 나머지는 fail-closed로 배제했다(카탈로그 확장은 별도 이슈). 원본 SVG는 삭제하지 않고 review-reference로 보관한다(bundled_svg_role=review-reference-only, 앱 렌더 source 아님).",
+      "notes": "[연혁] 원본은 재배포 권한 미확인(permission-required)이었고, 앱 렌더링을 사실 데이터(역 좌표·노선 위상) 기반 자체 schematic으로 전환해 SVG 표현 파생을 제거하고 attribution을 해제한 상태(reviewStatus=self-drawn-fact-based)였다(#1639/#1640/#1715/#1958). [2026-07-12 #2011/#1951] 오너가 대전 노선도를 직접 재제작(easy-subway-daejeon-v1 — 8선형 self-contained SVG)해 새 정본으로 반입했다. 오너가 직접 제작한 창작물이므로 self-drawn 확정으로 승격 — #1951 오너 결정(자작 전환 시 임시 evidence를 자작 기록으로 대체) 이행. 앱은 SVG 원본을 통째 렌더하지 않고(#1635 유지) 도식에서 파생한 구조화 좌표(route_map_positions)만 렌더한다. #2011 3단계 반복 파이프라인(권역 파라미터화) 재실행 결과 역 추가/삭제 0·위상 보존 100%(현행 대전 팩 22 (station,line) 쌍 동일)이며 미매핑 0. 대전 도식은 카탈로그 밖 미개통 노선(도시철도 순환2호선·충청권 광역철도)까지 그리므로 nodeFilter로 1호선 실역(22)만 정합 대상으로 남기고 나머지는 fail-closed로 배제했다(카탈로그 확장은 별도 이슈). 원본 SVG는 삭제하지 않고 review-reference로 보관한다(bundled_svg_role=review-reference-only, 앱 렌더 source 아님). [2026-07-13 #2068] 자체 라이선스 전환 완료로 라이선스 리스크가 소멸해 하이브리드 렌더링(자작 SVG를 빌드타임 컴파일해 바탕층으로 실제 렌더, 인터랙션은 구조화 좌표 유지)으로 전환 — renderingStrategy=self-drawn-hybrid-basemap, bundledSvgRole=hybrid-basemap-source로 갱신한다. 이 PR은 계약(결정문·manifest·계약테스트)만 갱신하며, 실제 SVG 컴파일 파이프라인·painter 교체는 후속 PR(#2068 2번째)에서 수행한다.",
       "licenseStatus": "self-drawn-confirmed",
       "lineColorSource": "대전 도시철도 1호선 공식 노선 색상값(오너 자작 도식에 반영)",
       "provenanceVerifiedAt": "2026-07-12"
@@ -111,15 +114,15 @@
       "retrievedAt": "2026-07-12",
       "originalLicenseSpdx": "LicenseRef-Self-Drawn",
       "originalCommercialUseAllowed": true,
-      "renderingStrategy": "self-drawn-schematic",
-      "bundledSvgRole": "review-reference-only",
+      "renderingStrategy": "self-drawn-hybrid-basemap",
+      "bundledSvgRole": "hybrid-basemap-source",
       "attributionRequired": false,
       "attributionDropTargetAfterSelfDrawn": true,
       "commercialProductionReady": true,
       "redistributionAllowed": true,
       "reviewStatus": "self-drawn-confirmed",
       "selfDrawnSource": "easy-subway-gwangju-v1.svg",
-      "notes": "[연혁] 원본은 CC BY-SA 2.0 KR(상용 가능하나 attribution·ShareAlike, kiwitree/grafiker 저작). ShareAlike 전파 리스크 때문에 앱 렌더링을 사실 데이터 기반 자체 schematic으로 두되, 원본 SVG가 번들·법률 검토 대기라 attribution을 유지(=true)·재배포 차단(false)·reviewStatus=legal-review-required였다(#1958). [2026-07-12 #2011/#1951] 오너가 광주 노선도를 직접 재제작(easy-subway-gwangju-v1 — 8선형 self-contained SVG)해 새 정본으로 반입했다. 오너가 직접 제작한 창작물이므로 self-drawn 확정으로 승격 — #1951 오너 결정 이행. 이는 attribution 제거가 아니라 계약 전환이다: 배포 렌더링이 더 이상 CC-BY-SA SVG(kiwitree)의 파생이 아니게 되어 ShareAlike/attribution 체인이 배포물에 부착되지 않으므로, attribution_required를 false로 전환하고(수도권 PD·부산·대구·대전 self-drawn과 동일 상태) 상용 준비·재배포를 허용한다. 앱은 SVG 원본을 통째 렌더하지 않고(#1635 유지) 도식에서 파생한 구조화 좌표(route_map_positions)만 렌더한다. #2011 3단계 반복 파이프라인 재실행 결과 역 추가/삭제 0·위상 보존 100%(현행 광주 팩 20 (station,line) 쌍 동일)이며 미매핑 0. 광주 도식은 카탈로그 밖 미개통 2호선까지 그리므로 nodeFilter로 1호선 실역(20)만 정합 대상으로 남겼다(카탈로그 확장은 별도 이슈). 이전 CC-BY-SA 원본 SVG 및 자작 SVG는 review-reference로만 보관한다(앱 렌더 source 아님). route_map_attribution_test의 kiwitree 배선 계약도 이 전환에 맞춰 자작 기준(광주 attribution 미표시)으로 정합 갱신했다.",
+      "notes": "[연혁] 원본은 CC BY-SA 2.0 KR(상용 가능하나 attribution·ShareAlike, kiwitree/grafiker 저작). ShareAlike 전파 리스크 때문에 앱 렌더링을 사실 데이터 기반 자체 schematic으로 두되, 원본 SVG가 번들·법률 검토 대기라 attribution을 유지(=true)·재배포 차단(false)·reviewStatus=legal-review-required였다(#1958). [2026-07-12 #2011/#1951] 오너가 광주 노선도를 직접 재제작(easy-subway-gwangju-v1 — 8선형 self-contained SVG)해 새 정본으로 반입했다. 오너가 직접 제작한 창작물이므로 self-drawn 확정으로 승격 — #1951 오너 결정 이행. 이는 attribution 제거가 아니라 계약 전환이다: 배포 렌더링이 더 이상 CC-BY-SA SVG(kiwitree)의 파생이 아니게 되어 ShareAlike/attribution 체인이 배포물에 부착되지 않으므로, attribution_required를 false로 전환하고(수도권 PD·부산·대구·대전 self-drawn과 동일 상태) 상용 준비·재배포를 허용한다. 앱은 SVG 원본을 통째 렌더하지 않고(#1635 유지) 도식에서 파생한 구조화 좌표(route_map_positions)만 렌더한다. #2011 3단계 반복 파이프라인 재실행 결과 역 추가/삭제 0·위상 보존 100%(현행 광주 팩 20 (station,line) 쌍 동일)이며 미매핑 0. 광주 도식은 카탈로그 밖 미개통 2호선까지 그리므로 nodeFilter로 1호선 실역(20)만 정합 대상으로 남겼다(카탈로그 확장은 별도 이슈). 이전 CC-BY-SA 원본 SVG 및 자작 SVG는 review-reference로만 보관한다(앱 렌더 source 아님). route_map_attribution_test의 kiwitree 배선 계약도 이 전환에 맞춰 자작 기준(광주 attribution 미표시)으로 정합 갱신했다. [2026-07-13 #2068] 자체 라이선스 전환 완료로 라이선스 리스크가 소멸해 하이브리드 렌더링(자작 SVG를 빌드타임 컴파일해 바탕층으로 실제 렌더, 인터랙션은 구조화 좌표 유지)으로 전환 — renderingStrategy=self-drawn-hybrid-basemap, bundledSvgRole=hybrid-basemap-source로 갱신한다. 이 PR은 계약(결정문·manifest·계약테스트)만 갱신하며, 실제 SVG 컴파일 파이프라인·painter 교체는 후속 PR(#2068 2번째)에서 수행한다.",
       "licenseStatus": "self-drawn-confirmed",
       "lineColorSource": "광주 도시철도 1호선 공식 노선 색상값(오너 자작 도식에 반영)",
       "provenanceVerifiedAt": "2026-07-12"

--- a/tools/route-map/route-map-license-decision.test.mjs
+++ b/tools/route-map/route-map-license-decision.test.mjs
@@ -18,7 +18,14 @@ test("route map license decision pins 대안 A(self-drawn) 전환과 근거", ()
   assert.equal(decision.schemaVersion, 1);
   assert.equal(decision.artifactKind, "route-map-license-decision");
   assert.equal(decision.issue, 1637);
+  // [2026-07-13 #2068] 하이브리드 렌더링(자작 SVG 바탕층) 전환 후에도
+  // renderingSourceOfTruth는 인터랙션(히트·카메라·팝오버·경로 강조)의 진실 출처를
+  // 가리키므로 바탕 paint 소스와 무관하게 structured-data로 고정된다.
   assert.equal(decision.renderingSourceOfTruth, "structured-data");
+  assert.equal(typeof decision.renderingSourceOfTruthNote, "string");
+  assert.ok(decision.renderingSourceOfTruthNote.length > 0);
+  assert.ok(decision.strategyValues.includes("self-drawn-hybrid-basemap"));
+  assert.ok(decision.bundledSvgRoleValues.includes("hybrid-basemap-source"));
 
   const decisionById = new Map(decision.regions.map((r) => [r.id, r]));
   const manifestById = new Map(manifest.maps.map((m) => [m.id, m]));
@@ -117,21 +124,25 @@ test("route map license decision pins 대안 A(self-drawn) 전환과 근거", ()
   }
 
   // 수도권은 #1950으로 오너 자작 8선형 도식(self-drawn) 정본 채택, 상용 준비 완료.
+  // [2026-07-13 #2068] 자작 SVG를 빌드타임 컴파일한 바탕층 + 구조화 좌표 인터랙션의
+  // 하이브리드 렌더링으로 전환.
   const seoul = decisionById.get("seoul");
-  assert.equal(seoul.renderingStrategy, "self-drawn-schematic");
+  assert.equal(seoul.renderingStrategy, "self-drawn-hybrid-basemap");
+  assert.equal(seoul.bundledSvgRole, "hybrid-basemap-source");
   assert.equal(seoul.commercialProductionReady, true);
   assert.equal(seoul.attributionRequired, false);
   assert.equal(seoul.licenseStatus, "self-drawn-confirmed");
 
-  // 부산·대구·대전·광주 모두 self-drawn-schematic 전환(원본 SVG는 좌표 검수 참조만).
+  // 부산·대구·대전·광주 모두 [2026-07-13 #2068] 하이브리드 렌더링(자작 SVG를
+  // 빌드타임 컴파일한 바탕층 + 구조화 좌표 인터랙션)으로 전환됨.
   for (const id of ["busan", "daegu", "daejeon", "gwangju"]) {
     const region = decisionById.get(id);
     assert.equal(
       region.renderingStrategy,
-      "self-drawn-schematic",
-      `${id}는 self-drawn-schematic으로 전환되어야 함`,
+      "self-drawn-hybrid-basemap",
+      `${id}는 self-drawn-hybrid-basemap으로 전환되어야 함`,
     );
-    assert.equal(region.bundledSvgRole, "review-reference-only");
+    assert.equal(region.bundledSvgRole, "hybrid-basemap-source");
   }
 
   // 부산·대구·대전·광주: #2011 오너 자작 도식 정본 반입으로 self-drawn 확정 승격 →


### PR DESCRIPTION
## 관련 이슈

Refs #2068

## 작업 배경

- 5권역(수도권/부산/대구/대전/광주) 노선도가 전부 오너 자작(자체 라이선스) SVG로 재제작 완료됐다(#2011). 그러나 앱은 SVG에서 좌표만 추출해 자체 painter로 재렌더(`rendering_strategy: self-drawn-schematic`, `bundled_svg_role: review-reference-only`)하고 있어, 역 배치는 최신 정본과 일치하지만 시각 스타일이 구형 그대로 남아 있었다.
- `review-reference-only` 결정의 원 근거는 부산/대구/대전 상용 배포 제한·광주 CC BY-SA 출처 문제 등 라이선스 리스크였다(#1635/#1951). 자체 라이선스 전환으로 이 근거가 소멸해, 오너가 자작 SVG를 바탕층(basemap)으로 그대로 렌더하는 하이브리드 전환을 승인했다(2026-07-13, #2068 이슈 본문에 근거 기록).
- 이번 PR은 #2068 PR 분할 계획의 1번째로, **계약(결정문·manifest·계약테스트)만** 하이브리드 전환에 맞게 갱신한다. 실제 SVG 빌드타임 컴파일 파이프라인과 painter 교체는 후속 PR(#2068 2번째)에서 다룬다 — 이번 PR은 렌더 코드(dart)를 전혀 건드리지 않는다.

## 작업 내용

- `tools/route-map/route-map-license-decision.json`: `strategyValues`에 `self-drawn-hybrid-basemap`, `bundledSvgRoleValues`에 `hybrid-basemap-source` 신규 허용값을 추가하고, 5권역의 `renderingStrategy`/`bundledSvgRole`을 각각 이 값으로 갱신했다. 최상위 `renderingSourceOfTruth`는 인터랙션(역 탭 히트·focus 카메라·팝오버 앵커·경로 강조)이 신뢰하는 데이터 출처를 가리키는 별개 축이므로 `structured-data`를 그대로 유지했고, 이 구분을 설명하는 `renderingSourceOfTruthNote` 필드를 신설했다. 각 권역 `notes`에는 기존 `[YYYY-MM-DD #이슈]` 이력 문체를 따라 `[2026-07-13 #2068]` 항목을 append했다.
- `apps/mobile/assets/datapacks/metro_map_pack/manifest.json`: 5권역 `route_map_strategy.rendering_strategy`/`bundled_svg_role`을 결정문과 동일하게 갱신하고, `license.changes` 서술에 바탕 자산이 하이브리드 렌더 소스가 됐음과, 컴파일 자산 자체는 아직 오프라인 번들에 포함되지 않아(`offline.included: false` 유지) 실제 번들링은 후속 PR에서 이뤄질 예정임을 명시했다.
- `tools/route-map/route-map-license-decision.test.mjs`: 신규 허용값을 반영하고, 5권역 `rendering_strategy`/`bundled_svg_role` 기대값을 새 값으로 갱신했다.
- `repository-contract.test.mjs`/`check-map-attribution.test.mjs`는 해당 필드를 하드코딩 검증하지 않아 변경하지 않았다.
- 구 WebView 기반 SVG 확대 렌더러(`_RouteMapViewportRenderer` 등, #1635가 폐기 대상으로 지목) 잔존 여부를 전수 grep으로 재확인했다 — 코드는 이미 완전히 제거되어 있고 대조 설명 주석 2건만 남아 있어 별도 정리가 불필요함을 확인했다(#2068 이슈에 기록).

## 검증

- 실행한 명령과 결과:
  - `node --test tools/route-map/route-map-license-decision.test.mjs` → pass 1 / fail 0
  - `node --test tools/ci/check-map-attribution.test.mjs` → pass 3 / fail 0
  - `node --test tools/ci/repository-contract.test.mjs` → pass 190 / fail 0
  - push 직전 origin/main head 재실측: `e873c1058c3396886277a0db2bda10d47ef45e1d`(변동 없음, rebase 불요)

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 결정문↔manifest 필드 동기화 | Node (contract test) | `route-map-license-decision.test.mjs` 전수 검증 | CI/로컬 재실행 로그(위 검증 항목) | pass |
| 렌더 코드 무변경(이번 PR 범위 확인) | 해당 없음 — 코드 리뷰 | `git show --stat` diff에 `.dart` 파일 없음 확인 | 본 PR diff | pass |
| 실기기/UI 변화 | mobile (Flutter) | 없음 — 이번 PR은 JSON 계약만 변경, 렌더 출력 영향 없음 | 해당 없음 | N/A(사유: 렌더 코드 미변경) |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음(manifest 내 라이선스/전략 필드만 갱신, 팩 콘텐츠·해시 영향 없음)
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `route-map-license-decision.json`의 `renderingSourceOfTruth`가 `structured-data`로 그대로인 것이 의도인지 확인 바람 — 바탕 paint 소스(자작 SVG)와 인터랙션 진실 출처(구조화 데이터)는 별개 축이라는 설계 결정이며, 신설된 `renderingSourceOfTruthNote` 필드에 근거를 남겼다(#2068 이슈 본문 "설계" 섹션 참고).

## 리스크

- 이번 PR은 계약 필드만 갱신하고 실제 렌더 코드/SVG 컴파일 파이프라인은 후속 PR(#2068 2번째) 스코프다. 허용값이 3종으로 늘었으므로, 후속 PR에서 렌더 코드가 `self-drawn-hybrid-basemap` 분기를 실제로 타는지, `manifest.json`의 `offline.included`를 언제 `true`로 전환할지 확정이 필요하다.
- 좌표 정렬 회귀 테스트(SVG viewBox ↔ 구조화 좌표 원점 정합)와 급행 토글 오버레이 재설계 회귀 테스트는 이번 PR 범위가 아니며, #2068 이슈에 명시된 대로 바탕층 렌더 PR(2번째)에 동반될 예정이다.

## 체크리스트

- [ ] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 서울, 부산, 광주, 대구, 대전 노선도의 렌더링 방식이 하이브리드 베이스맵으로 전환되었습니다.
  * 지도 상호작용은 구조화된 좌표 데이터를 기준으로 유지됩니다.
  * 자체 제작 SVG는 빌드 시 베이스맵 렌더링 소스로 활용됩니다.
  * 컴파일된 베이스맵 자산은 후속 업데이트에서 오프라인 번들로 제공될 예정입니다.

* **테스트**
  * 하이브리드 렌더링 전략과 지역별 설정 검증을 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->