### PR TITLE
[Fix] 최신 CD 광고 환경값 안전 overlay

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -277,6 +277,8 @@ jobs:
         shell: bash
         env:
           EASYSUBWAY_ENV_SECRET: ${{ secrets.EASYSUBWAY_ENV }}
+          EASYSUBWAY_ADS_ASSET_ORIGIN: ${{ vars.EASYSUBWAY_ADS_ASSET_ORIGIN }}
+          EASYSUBWAY_ADS_EVENT_DAILY_CAP: ${{ vars.EASYSUBWAY_ADS_EVENT_DAILY_CAP }}
           EASYSUBWAY_SEOUL_TOPIS_SERVICE_KEY_SECRET: ${{ secrets.EASYSUBWAY_SEOUL_TOPIS_SERVICE_KEY }}
         run: |
           set -euo pipefail
@@ -315,6 +317,28 @@ jobs:
             echo "source=example" >> "${GITHUB_OUTPUT}"
             echo "::notice title=CD env secret::EASYSUBWAY_ENV secret is not configured; deployment will not start."
           fi
+
+          for name in EASYSUBWAY_ADS_ASSET_ORIGIN EASYSUBWAY_ADS_EVENT_DAILY_CAP; do
+            value="${!name}"
+            if [[ -z "${value}" || "${value}" == *$'\n'* || "${value}" == *$'\r'* ]]; then
+              echo "${name} repository variable must be a non-empty single line" >&2
+              exit 1
+            fi
+          done
+
+          filtered_env_file="${RUNNER_TEMP}/easysubway.ads-overlay.env"
+          awk -F= '
+            BEGIN {
+              drop["EASYSUBWAY_ADS_ASSET_ORIGIN"] = 1
+              drop["EASYSUBWAY_ADS_EVENT_DAILY_CAP"] = 1
+            }
+            !($1 in drop)
+          ' "${env_file}" > "${filtered_env_file}"
+          mv "${filtered_env_file}" "${env_file}"
+          for name in EASYSUBWAY_ADS_ASSET_ORIGIN EASYSUBWAY_ADS_EVENT_DAILY_CAP; do
+            value="${!name}"
+            printf '%s=%s\n' "${name}" "${value}" >> "${env_file}"
+          done
 
           chmod 600 "${env_file}"
           echo "EASYSUBWAY_ENV_FILE=${env_file}" >> "${GITHUB_ENV}"

--- a/tools/ci/detect-changed-paths.sh
+++ b/tools/ci/detect-changed-paths.sh
@@ -55,6 +55,11 @@ while IFS= read -r file; do
       ios=true
       datapack=true
       ;;
+    .github/workflows/cd.yml)
+      ci=true
+      repository=true
+      deploy=true
+      ;;
     .github/workflows/*.yml|tools/ci/**|tools/repo/**|tools/qa/**)
       ci=true
       repository=true

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -928,10 +928,11 @@ test("지속적 배포 준비 상태는 단일 dotenv secret과 배포 설정을
     );
     assert.ok(restoreStep.includes(`drop["${name}"] = 1`), `${name} must replace a stale dotenv value`);
   }
-  assert.match(restoreStep, /for name in EASYSUBWAY_ADS_ASSET_ORIGIN EASYSUBWAY_ADS_EVENT_DAILY_CAP; do/);
-  assert.match(restoreStep, /value="\$\{!name\}"/);
-  assert.match(restoreStep, /\[\[ -z "\$\{value\}" \|\| "\$\{value\}" == \*\$'\\n'\* \|\| "\$\{value\}" == \*\$'\\r'\* \]\]/);
-  assert.match(restoreStep, /printf '%s=%s\\n' "\$\{name\}" "\$\{value\}" >> "\$\{env_file\}"/);
+  assert.match(
+    restoreStep,
+    /for name in EASYSUBWAY_ADS_ASSET_ORIGIN EASYSUBWAY_ADS_EVENT_DAILY_CAP; do\s+value="\$\{!name\}"\s+if \[\[ -z "\$\{value\}" \|\| "\$\{value\}" == \*\$'\\n'\* \|\| "\$\{value\}" == \*\$'\\r'\* \]\]; then[\s\S]*?exit 1\s+fi\s+done[\s\S]*?for name in EASYSUBWAY_ADS_ASSET_ORIGIN EASYSUBWAY_ADS_EVENT_DAILY_CAP; do\s+value="\$\{!name\}"\s+printf '%s=%s\\n' "\$\{name\}" "\$\{value\}" >> "\$\{env_file\}"\s+done/,
+    "invalid repository variables must exit before any approved value is written",
+  );
   assert.match(workflow, /CD Deploy \/ Validate deployment dotenv contract/);
   assert.match(workflow, /CD Plan \/ Detect deployment changes/);
   assert.match(workflow, /bash tools\/ci\/detect-changed-paths\.sh changed-files\.txt/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -465,7 +465,7 @@ function workflowFiles() {
 
 function assertActionsEnvSecretPolicy(file, source) {
   const secretAccess = /secrets(?:\.([A-Z0-9_]+)|\[['"]([A-Z0-9_]+)['"]\])/g;
-  const disallowedVarsAccess = /vars(?:\.EASYSUBWAY_[A-Z0-9_]+|\[['"]EASYSUBWAY_[A-Z0-9_]+['"]\])/;
+  const appVariableAccess = /vars(?:\.(EASYSUBWAY_[A-Z0-9_]+)|\[['"](EASYSUBWAY_[A-Z0-9_]+)['"]\])/g;
   const allowedExtraSecretsByFile = {
     ".github/workflows/cd.yml": new Set([
       "EASYSUBWAY_SEOUL_TOPIS_SERVICE_KEY",
@@ -483,6 +483,13 @@ function assertActionsEnvSecretPolicy(file, source) {
     ]),
   };
   const allowedExtraSecrets = allowedExtraSecretsByFile[file] ?? new Set();
+  const allowedAppVariablesByFile = {
+    ".github/workflows/cd.yml": new Set([
+      "EASYSUBWAY_ADS_ASSET_ORIGIN",
+      "EASYSUBWAY_ADS_EVENT_DAILY_CAP",
+    ]),
+  };
+  const allowedAppVariables = allowedAppVariablesByFile[file] ?? new Set();
 
   for (const match of source.matchAll(secretAccess)) {
     const secretName = match[1] ?? match[2];
@@ -494,7 +501,14 @@ function assertActionsEnvSecretPolicy(file, source) {
       assert.fail(`${file} must use only secrets.EASYSUBWAY_ENV or approved scoped secrets`);
     }
   }
-  assert.doesNotMatch(source, disallowedVarsAccess, `${file} must not use GitHub Actions vars for app env`);
+  const appVariables = new Set(
+    [...source.matchAll(appVariableAccess)].map((match) => match[1] ?? match[2]),
+  );
+  assert.deepEqual(
+    [...appVariables].sort(),
+    [...allowedAppVariables].sort(),
+    `${file} must not use GitHub Actions vars for app env except the approved allowlist`,
+  );
 }
 
 function assertMobileCatchPolicy(file, source) {
@@ -899,6 +913,25 @@ test("지속적 배포 준비 상태는 단일 dotenv secret과 배포 설정을
   assert.match(workflow, /CD Deploy \/ Restore GitHub Actions dotenv secret[\s\S]*?env:\s*\n\s*EASYSUBWAY_ENV_SECRET: \$\{\{ secrets\.EASYSUBWAY_ENV \}\}/);
   assert.match(workflow, /printf '%s' "\$\{EASYSUBWAY_ENV_SECRET\}" > "\$\{env_file\}"/);
   assert.doesNotMatch(workflow, /printf '%s\\n' "\$\{EASYSUBWAY_ENV_SECRET\}"/);
+  const restoreStep = workflow.slice(
+    workflow.indexOf("CD Deploy / Restore GitHub Actions dotenv secret"),
+    workflow.indexOf("CD Deploy / Validate deployment dotenv contract"),
+  );
+  const adVariableNames = [
+    "EASYSUBWAY_ADS_ASSET_ORIGIN",
+    "EASYSUBWAY_ADS_EVENT_DAILY_CAP",
+  ];
+  for (const name of adVariableNames) {
+    assert.ok(
+      restoreStep.includes(`${name}: $` + `{{ vars.${name} }}`),
+      `${name} must come from a repository variable`,
+    );
+    assert.ok(restoreStep.includes(`drop["${name}"] = 1`), `${name} must replace a stale dotenv value`);
+  }
+  assert.match(restoreStep, /for name in EASYSUBWAY_ADS_ASSET_ORIGIN EASYSUBWAY_ADS_EVENT_DAILY_CAP; do/);
+  assert.match(restoreStep, /value="\$\{!name\}"/);
+  assert.match(restoreStep, /\[\[ -z "\$\{value\}" \|\| "\$\{value\}" == \*\$'\\n'\* \|\| "\$\{value\}" == \*\$'\\r'\* \]\]/);
+  assert.match(restoreStep, /printf '%s=%s\\n' "\$\{name\}" "\$\{value\}" >> "\$\{env_file\}"/);
   assert.match(workflow, /CD Deploy \/ Validate deployment dotenv contract/);
   assert.match(workflow, /CD Plan \/ Detect deployment changes/);
   assert.match(workflow, /bash tools\/ci\/detect-changed-paths\.sh changed-files\.txt/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -13233,6 +13233,11 @@ test("경로 분류기는 저장소, 백엔드, 모바일, Android, iOS 변경�
   assert.equal(ci.repository, "true");
   assert.equal(ci.ci, "true");
 
+  const cd = await classifyChangedFiles([".github/workflows/cd.yml"]);
+  assert.equal(cd.repository, "true");
+  assert.equal(cd.ci, "true");
+  assert.equal(cd.deploy, "true");
+
   const repoTool = await classifyChangedFiles(["tools/repo/check-split-readiness.mjs"]);
   assert.equal(repoTool.repository, "true");
   assert.equal(repoTool.ci, "true");


### PR DESCRIPTION
## 관련 이슈

close #2077

## 작업 배경

- 최신 backend CD가 배포용 dotenv 계약 검증에서 광고 환경값 2개 누락으로 중단됐다.
- 전체 dotenv secret을 다시 업로드하지 않고, 비밀이 아닌 승인값만 별도 repository variable로 주입할 필요가 있다.

## 작업 내용

- CD의 dotenv 복원 직후 승인된 광고 환경값 2개를 repository variable에서 안전하게 overlay한다.
- 빈 값과 줄바꿈을 거부하고, 기존 dotenv의 같은 키를 제거한 뒤 각 키를 정확히 한 번만 기록한다.
- GitHub Actions app env variable 정책을 `cd.yml`의 이 두 키에만 좁게 허용하고 다른 우회는 계속 차단한다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/repository-contract.test.mjs`: 190/190 통과
  - `node --test tools/ci/backend-deploy.test.mjs`: 9/9 통과
  - `node tools/ci/check-contracts.mjs`: 통과
  - `git diff --check`: 통과

## 검증 증거

UI 변경은 없으며, 배포 확인은 병합 후 production CD와 공개 readiness/API smoke 결과로 보강한다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| CD dotenv overlay 계약 | GitHub Actions | repository 계약 테스트 | 로컬 190/190 | 통과 |
| backend 배포 계약 | Linux/GitHub Actions | backend 배포 테스트 | 로컬 9/9 | 통과 |
| production 배포 | OCI production | 병합 후 CD 및 공개 smoke | 예정 | 대기 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 병합 commit의 GHCR digest

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `cd.yml`의 overlay가 기존 키를 제거하고 정확히 한 번 기록하는지, repository variable allowlist가 두 키로만 제한되는지 확인해 주세요.

## 리스크

- repository variable이 없거나 줄바꿈을 포함하면 배포 전에 fail closed한다.
- 기존 dotenv에 같은 키가 있어도 새 승인값으로 교체되며, 비밀값 전체를 GitHub로 재전송하지 않는다.
- DB migration, 사용자 데이터 변경, 모바일 산출물 변경은 없다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **배포 안정성 개선**
  * 배포 환경 복원 시 광고 관련 설정이 저장소 변수의 최신 값으로 일관되게 적용됩니다.
  * 광고 설정이 비어 있거나 잘못된 형식이면 배포 준비가 중단되어 잘못된 구성의 배포를 방지합니다.
  * 승인된 환경 설정만 사용되도록 배포 구성 검증이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->