### PR TITLE
[Style] #2081 온보딩 시작 화면 — 브랜드 심볼 제거·가치 카피 3행 개편·타이틀 확대

### DIFF
--- a/apps/mobile/lib/onboarding.dart
+++ b/apps/mobile/lib/onboarding.dart
@@ -201,12 +201,11 @@ class OnboardingState {
   bool get isCompleted => result != null;
 }
 
-/// 화면 1 — 시작. 상단 브랜드 심볼(무채색 라인) + 핵심 가치 큰 타이틀 + 단일 CTA.
+/// 화면 1 — 시작. 핵심 가치 카피 3행 + 단일 CTA만 둔 카피 중심 화면.
 ///
-/// #1936(프리미엄 다듬기): 텍스트+버튼만이라 밋밋하다는 판정에 대응해, 상단에
-/// 무채색 라인 아트 브랜드 심볼/워드마크를 둔다. 색·그림자·블록 없이 심볼만으로
-/// 브랜딩을 세우고, 심볼–타이틀–여백–CTA의 세로 리듬을 균형 있게 구성한다.
-/// 상단 여백을 크게 비운 뒤 심볼→타이틀, Spacer로 CTA를 하단에 고정한다.
+/// #2081: 상단 브랜드 심볼/워드마크를 걷어내고 카피만으로 화면을 세운다.
+/// 가치 카피 3행을 크게 두고 Spacer로 CTA를 하단에 고정하며, 상단 여백을 비워
+/// 타이틀이 화면 상단 1/4~1/3 지점에서 시작하는 세로 리듬을 유지한다.
 class StartScreen extends StatelessWidget {
   const StartScreen({required this.onStart, super.key});
 
@@ -219,9 +218,9 @@ class StartScreen extends StatelessWidget {
       body: SafeArea(
         child: LayoutBuilder(
           builder: (context, constraints) {
-            // 상단 여백을 비워 심볼이 화면 상단 1/4 지점에서 시작하게 한다.
-            // 이전(~35%)보다 살짝 줄여 심볼–타이틀 묶음이 화면 중앙 위로 앉는다.
-            final topGap = (constraints.maxHeight * 0.22).clamp(64.0, 168.0);
+            // 상단 여백을 비워 타이틀이 화면 상단 1/4~1/3 지점에서 시작하게 한다.
+            // 심볼 제거(#2081)로 세로 여백을 조금 넉넉히 잡아 타이틀 묶음을 앉힌다.
+            final topGap = (constraints.maxHeight * 0.28).clamp(72.0, 200.0);
             // SafeArea(bottom: true) 자손이라 하단 인셋은 SafeArea가 이미 적용한다.
             // viewPadding.bottom을 또 더하면 이중 가산이므로 토큰 여백만 쓴다.
             const bottomGap = EasySubwaySpacing.xxl;
@@ -240,20 +239,16 @@ class StartScreen extends StatelessWidget {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         SizedBox(height: topGap),
-                        // 브랜드 심볼(무채색 라인 아트) + 워드마크. 밋밋함 해소(#1936).
-                        const _BrandMark(),
-                        const SizedBox(height: EasySubwaySpacing.xxl),
                         Semantics(
                           header: true,
                           child: const Text(
-                            // 핵심 가치 한 줄. 부연 설명("먼저 안내해요") 삭제(#1936).
-                            // 강조도 무채색 잉크로 통일(초록/민트 금지).
-                            '빠른 길보다,\n갈 수 있는 길',
+                            // 핵심 가치 카피 3행(#2081). 강조는 무채색 잉크로 통일.
+                            '빠른 길보다\n갈 수 있는 길을\n안내합니다',
                             style: TextStyle(
                               color: EasySubwayAccessibleColors.text,
-                              fontSize: 36,
+                              fontSize: 40,
                               fontWeight: FontWeight.w800,
-                              height: 1.16,
+                              height: 1.18,
                             ),
                           ),
                         ),
@@ -289,92 +284,6 @@ class StartScreen extends StatelessWidget {
       ),
     );
   }
-}
-
-/// #1936: 미니멀 무채색 브랜드 심볼 + 워드마크.
-///
-/// 심볼은 노선·경로를 은유하는 라인 아트(두 정거장을 잇는 route 글리프)로,
-/// 색·그림자·블록 없이 잉크 라인과 점만으로 그린다. 워드마크는 앱 이름을
-/// 무채색 잉크로 둔다(w800은 화면 타이틀 예산 밖으로 두어 w700 + 자간). 브랜드
-/// 부재로 인한 "텍스트+버튼만" 밋밋함을 해소하는 시각 앵커다.
-class _BrandMark extends StatelessWidget {
-  const _BrandMark();
-
-  @override
-  Widget build(BuildContext context) {
-    return Semantics(
-      label: '쉬운 지하철',
-      image: true,
-      child: ExcludeSemantics(
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            CustomPaint(
-              size: const Size(40, 40),
-              painter: _RouteGlyphPainter(
-                color: EasySubwayAccessibleColors.text,
-              ),
-            ),
-            const SizedBox(width: EasySubwaySpacing.md),
-            Text(
-              '쉬운 지하철',
-              style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                color: EasySubwayAccessibleColors.text,
-                fontWeight: FontWeight.w700,
-                fontSize: 19,
-                letterSpacing: -0.2,
-                height: 1.0,
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-/// 노선/경로 글리프 — 두 정거장을 잇는 무채색 라인 아트.
-///
-/// 굵은 라인 1개 + 양끝 정거장 노드(속이 빈 원)로 "이동 경로"를 은유한다.
-/// 색 없이 잉크 선만 쓰고, 그림자·채움 블록은 두지 않는다(#1936 제약).
-class _RouteGlyphPainter extends CustomPainter {
-  const _RouteGlyphPainter({required this.color});
-
-  final Color color;
-
-  @override
-  void paint(Canvas canvas, Size size) {
-    final stroke = size.width * 0.11;
-    final cy = size.height * 0.5;
-    final line = Paint()
-      ..color = color
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = stroke
-      ..strokeCap = StrokeCap.round;
-
-    final nodeRadius = size.width * 0.17;
-    final left = Offset(nodeRadius + stroke * 0.5, cy);
-    final right = Offset(size.width - nodeRadius - stroke * 0.5, cy);
-
-    // 두 정거장을 잇는 경로 라인.
-    canvas.drawLine(
-      Offset(left.dx + nodeRadius, cy),
-      Offset(right.dx - nodeRadius, cy),
-      line,
-    );
-
-    // 양끝 정거장 노드(속 빈 원 = 라인 아트).
-    final node = Paint()
-      ..color = color
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = stroke;
-    canvas.drawCircle(left, nodeRadius, node);
-    canvas.drawCircle(right, nodeRadius, node);
-  }
-
-  @override
-  bool shouldRepaint(_RouteGlyphPainter oldDelegate) =>
-      oldDelegate.color != color;
 }
 
 /// 진행 인디케이터 — 아주 작은 점 2개(애플식). 블록/박스 아님(#1936).

--- a/apps/mobile/test/onboarding_app_flow_test.dart
+++ b/apps/mobile/test/onboarding_app_flow_test.dart
@@ -38,9 +38,9 @@ void main() {
 
     await tester.pumpAndSettle();
 
-    // 복원이 끝나면 로딩은 사라지고 시작 화면이 뜬다(#1936: 핵심 가치 한 줄).
+    // 복원이 끝나면 로딩은 사라지고 시작 화면이 뜬다(#2081: 핵심 가치 카피 3행).
     expect(find.byKey(const Key('startupLoadingScreen')), findsNothing);
-    expect(find.text('빠른 길보다,\n갈 수 있는 길'), findsOneWidget);
+    expect(find.text('빠른 길보다\n갈 수 있는 길을\n안내합니다'), findsOneWidget);
   });
 
   testWidgets('앱 시작 로딩 스피너는 온보딩 복원이 300ms 넘게 걸릴 때만 나타난다', (
@@ -89,7 +89,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('빠른 길보다,\n갈 수 있는 길'), findsOneWidget);
+    expect(find.text('빠른 길보다\n갈 수 있는 길을\n안내합니다'), findsOneWidget);
     expect(find.text('이동약자를 위한 지하철 안내'), findsNothing);
     expect(find.text('계단과 고장 시설을 미리 확인하고'), findsNothing);
     expect(find.text('로그인 없이도 이용할 수 있어요'), findsNothing);

--- a/apps/mobile/test/onboarding_test.dart
+++ b/apps/mobile/test/onboarding_test.dart
@@ -45,9 +45,9 @@ void main() {
     expect(storage.deletedKeys, isEmpty);
   });
 
-  testWidgets('시작 화면은 부연 설명 문장 없이 핵심 가치 한 줄과 단일 CTA만 둔다', (tester) async {
-    // #1936: 장황한 중간 소개 화면(OnboardingIntroScreen)을 제거하고, 시작 화면은
-    // 가치 카피 한 줄 + "시작하기" CTA만 남겼다.
+  testWidgets('시작 화면은 부연 설명 문장 없이 핵심 가치 카피 3행과 단일 CTA만 둔다', (tester) async {
+    // #2081: 브랜드 심볼/워드마크를 걷어내고, 시작 화면은 가치 카피 3행 +
+    // "시작하기" CTA만 남긴다(카피 중심).
     tester.view.physicalSize = const Size(1080, 2400);
     tester.view.devicePixelRatio = 1;
     addTearDown(tester.view.resetPhysicalSize);
@@ -55,36 +55,57 @@ void main() {
 
     await tester.pumpWidget(MaterialApp(home: StartScreen(onStart: () {})));
 
-    expect(find.text('빠른 길보다,\n갈 수 있는 길'), findsOneWidget);
+    expect(find.text('빠른 길보다\n갈 수 있는 길을\n안내합니다'), findsOneWidget);
     expect(find.byKey(const Key('startScreenStartButton')), findsOneWidget);
     expect(find.text('시작하기'), findsOneWidget);
-    // #1936(프리미엄 다듬기): 상단 무채색 브랜드 심볼/워드마크로 밋밋함을 해소한다.
-    expect(find.text('쉬운 지하철'), findsOneWidget);
+    // #2081: 상단 브랜드 심볼/워드마크는 제거됐다 — 시작 화면에는 워드마크가 없다.
+    expect(find.text('쉬운 지하철'), findsNothing);
+    expect(find.bySemanticsLabel('쉬운 지하철'), findsNothing);
     // 부연 설명 문장은 전면 삭제됐다(#1936).
     expect(find.textContaining('먼저 안내해요'), findsNothing);
     expect(find.textContaining('엘리베이터와 출구까지'), findsNothing);
     expect(find.text('계단 없는 길을\n먼저 찾습니다'), findsNothing);
   });
 
-  testWidgets('시작 화면 브랜드 심볼은 무채색 잉크 라인으로 그리고 워드마크와 함께 온다', (tester) async {
-    // #1936(프리미엄 다듬기): 텍스트+버튼만이라는 밋밋함을 해소하는 상단 앵커.
-    // 심볼은 색 없는 라인 아트(CustomPaint)로, 워드마크는 잉크 텍스트로 둔다.
+  testWidgets('시작 화면 가치 타이틀은 header 시맨틱스로 노출되는 카피 3행이다', (tester) async {
+    // #2081: 심볼 제거 후에도 가치 타이틀은 header 시맨틱스를 유지한다.
     tester.view.physicalSize = const Size(1080, 2400);
     tester.view.devicePixelRatio = 1;
     addTearDown(tester.view.resetPhysicalSize);
     addTearDown(tester.view.resetDevicePixelRatio);
 
+    final semanticsHandle = tester.ensureSemantics();
+
     await tester.pumpWidget(MaterialApp(home: StartScreen(onStart: () {})));
 
-    // 라인 아트 심볼(CustomPaint)이 워드마크 위/좌측에 존재한다.
-    expect(find.byType(CustomPaint), findsWidgets);
-    // 워드마크는 심볼 앵커로 노출되고, 스크린리더에는 '쉬운 지하철'로 읽힌다.
-    expect(find.bySemanticsLabel('쉬운 지하철'), findsOneWidget);
+    // 가치 타이틀은 header 시맨틱스로 노출된다.
+    expect(
+      tester.getSemantics(find.text('빠른 길보다\n갈 수 있는 길을\n안내합니다')),
+      matchesSemantics(
+        label: '빠른 길보다\n갈 수 있는 길을\n안내합니다',
+        isHeader: true,
+      ),
+    );
 
-    // 심볼(워드마크)이 가치 타이틀보다 위에 배치되는 여백 리듬을 확인한다.
-    final markBottom = tester.getRect(find.text('쉬운 지하철')).bottom;
-    final titleTop = tester.getRect(find.text('빠른 길보다,\n갈 수 있는 길')).top;
-    expect(markBottom, lessThan(titleTop));
+    semanticsHandle.dispose();
+  });
+
+  testWidgets('시작 화면은 소형 화면(320×568)에서도 카피 3행과 CTA를 오버플로 없이 렌더한다', (
+    tester,
+  ) async {
+    // #2081: 타이틀 확대(40)·카피 3행이 소형 화면에서 레이아웃 예외를 일으키지
+    // 않는지 확인한다(SingleChildScrollView 구조가 오버플로를 흡수한다).
+    tester.view.physicalSize = const Size(320, 568);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(MaterialApp(home: StartScreen(onStart: () {})));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('빠른 길보다\n갈 수 있는 길을\n안내합니다'), findsOneWidget);
+    expect(find.byKey(const Key('startScreenStartButton')), findsOneWidget);
   });
 
   testWidgets('온보딩 시작 버튼은 Android 시스템 내비게이션 바와 여백을 둔다', (tester) async {

--- a/apps/mobile/test/onboarding_test.dart
+++ b/apps/mobile/test/onboarding_test.dart
@@ -108,6 +108,54 @@ void main() {
     expect(find.byKey(const Key('startScreenStartButton')), findsOneWidget);
   });
 
+  testWidgets('시작 화면은 소형 화면(320×568)+확대 텍스트에서도 스크롤로 CTA에 닿는다', (
+    tester,
+  ) async {
+    // #2081 리뷰 finding: 기본 배율(320×568)에서는 콘텐츠가 화면에 다 들어가
+    // maxScrollExtent가 0이라 SingleChildScrollView 구조가 제거돼도 이전
+    // 테스트가 green일 수 있었다. textScaler를 키워 실제로 오버플로가
+    // 발생하는 조건을 만든 뒤, Scrollable이 그 초과분을 흡수해 CTA까지
+    // 스크롤·탭할 수 있음을 직접 검증한다.
+    tester.view.physicalSize = const Size(320, 568);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    var tapped = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MediaQuery(
+          data: const MediaQueryData(textScaler: TextScaler.linear(1.6)),
+          child: StartScreen(onStart: () => tapped = true),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+
+    // 확대된 텍스트가 화면 높이를 넘어서 스크롤이 실제로 필요한 상태인지
+    // 먼저 확인한다(회귀 시 이 값이 0으로 떨어져 아래 단언들이 무의미해지는
+    // 것을 방지).
+    final scrollPosition = tester
+        .state<ScrollableState>(find.byType(Scrollable))
+        .position;
+    expect(scrollPosition.maxScrollExtent, greaterThan(0));
+
+    // ensureVisible로 스크롤해야 CTA를 탭할 수 있고, 탭이 실제로 콜백을
+    // 호출한다 — SingleChildScrollView 구조가 제거되면 오버플로 예외로
+    // 이 흐름 자체가 실패한다.
+    await tester.ensureVisible(
+      find.byKey(const Key('startScreenStartButton')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('startScreenStartButton')));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(tapped, isTrue);
+  });
+
   testWidgets('온보딩 시작 버튼은 Android 시스템 내비게이션 바와 여백을 둔다', (tester) async {
     tester.view.devicePixelRatio = 1;
     tester.view.viewPadding = const FakeViewPadding(bottom: 34);


### PR DESCRIPTION
## 관련 이슈

close #2081

## 작업 배경

- 온보딩 시작 화면(StartScreen)이 상단 브랜드 심볼/워드마크 + 가치 카피 한 줄 + CTA 구성이었다. 오너 지시로 심볼을 걷어내고 카피 중심으로 간결화한다.
- 가치 문구를 한 줄에서 3행으로 확장하고 타이틀을 키워, 첫 화면에서 서비스 가치가 카피만으로 또렷이 전달되도록 한다.

## 작업 내용

- 상단 브랜드 심볼/워드마크(`_BrandMark`)와 노선 글리프 페인터(`_RouteGlyphPainter`)를 제거했다. 미사용이 된 두 클래스를 삭제했다.
- 심볼 제거로 비는 세로 리듬을 재조정했다(topGap 계수 0.22→0.28, 상·하한 완화). 타이틀이 화면 상단 1/4~1/3 지점에서 시작하는 감각을 유지한다.
- 가치 카피를 3행으로 교체했다: `빠른 길보다\n갈 수 있는 길을\n안내합니다` (오너 확정 카피).
- 타이틀 `fontSize` 36→40으로 확대했다(w800 유지, `height` 1.16→1.18). 색은 무채색 잉크(`EasySubwayAccessibleColors.text`) 그대로.
- 타이틀의 `Semantics(header: true)`는 유지했다. 사라진 워드마크 시맨틱스 라벨('쉬운 지하철')을 기대하던 참조 테스트를 새 상태 기준으로 갱신했다.
- 소형 화면(320×568) 오버플로 부재를 위젯 테스트로 추가 검증했다.

## 검증

- 실행한 명령과 결과:
  - `flutter analyze` (apps/mobile) → `No issues found!`
  - `flutter test test/onboarding_test.dart test/onboarding_app_flow_test.dart test/design_guard_test.dart test/design_tokens_test.dart test/widget_test.dart` → `All tests passed!` (300건). w800 예산 ratchet(`lib/onboarding.dart` 상한 4, 실제 3) green.
  - `flutter test test/accessibility_baseline_test.dart` → `All tests passed!`

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 시작 화면 렌더(심볼 제거·카피 3행·타이틀 확대) | Android 실기기 | 데뷔 빌드 설치 후 앱 데이터 초기화로 온보딩 시작 화면 진입, 실기기 캡처 | 로컬 evidence: `docs/2081-qa/after-start-screen.png` (docs/ gitignore, 로컬 전용) | 심볼/워드마크 없음, 카피 3행·CTA 오버플로 없이 렌더 확인 |
| 소형 화면(320×568) 레이아웃 예외 | 위젯 테스트 | `test/onboarding_test.dart` 신규 케이스로 예외·오버플로 부재 검증 | `flutter test test/onboarding_test.dart` green | pass |
| 타이틀 header 시맨틱스 유지 | 위젯 테스트 | `matchesSemantics(isHeader: true)` 검증 | `flutter test test/onboarding_test.dart` green | pass |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 1.0.3 (변경 없음 — 시작 화면 카피/레이아웃 정비만)
- mobile versionCode: 10004 (변경 없음)
- datapack version: 영향 없음
- route contract: 영향 없음
- realtime contract: 영향 없음
- backend identity: 영향 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `apps/mobile/lib/onboarding.dart` StartScreen 세로 리듬 재조정(topGap 계수·클램프)과 3행 카피·타이틀 40 확대.
  - 제거한 `_BrandMark`/`_RouteGlyphPainter`에 대한 참조 테스트 갱신이 새 상태(워드마크 없음, 카피 3행)와 일치하는지.
  - `OnboardingScreen` AppBar 타이틀 '쉬운 지하철'(onboarding.dart 502행)은 다른 화면 요소로, 시작 화면 워드마크 제거와 무관하게 그대로 유지된다.

## 리스크

- 시작 화면 세로 리듬 상수(topGap)만 조정 — 다른 온보딩 단계·홈 화면에는 영향 없음. w800 타이틀 예산 증가 없음(3건, 상한 4).

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.