### PR TITLE
[Fix] production backend bind overlay로 CD 차단 해소

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -331,10 +331,12 @@ jobs:
             BEGIN {
               drop["EASYSUBWAY_ADS_ASSET_ORIGIN"] = 1
               drop["EASYSUBWAY_ADS_EVENT_DAILY_CAP"] = 1
+              drop["EASYSUBWAY_BACKEND_BIND"] = 1
             }
             !($1 in drop)
           ' "${env_file}" > "${filtered_env_file}"
           mv "${filtered_env_file}" "${env_file}"
+          printf 'EASYSUBWAY_BACKEND_BIND=127.0.0.1\n' >> "${env_file}"
           for name in EASYSUBWAY_ADS_ASSET_ORIGIN EASYSUBWAY_ADS_EVENT_DAILY_CAP; do
             value="${!name}"
             printf '%s=%s\n' "${name}" "${value}" >> "${env_file}"

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -928,6 +928,15 @@ test("지속적 배포 준비 상태는 단일 dotenv secret과 배포 설정을
     );
     assert.ok(restoreStep.includes(`drop["${name}"] = 1`), `${name} must replace a stale dotenv value`);
   }
+  assert.ok(
+    restoreStep.includes('drop["EASYSUBWAY_BACKEND_BIND"] = 1'),
+    "CD must replace a stale backend bind",
+  );
+  assert.match(
+    restoreStep,
+    /printf 'EASYSUBWAY_BACKEND_BIND=127\.0\.0\.1\\n' >> "\$\{env_file\}"/,
+    "CD must force the production backend bind to loopback",
+  );
   assert.match(
     restoreStep,
     /for name in EASYSUBWAY_ADS_ASSET_ORIGIN EASYSUBWAY_ADS_EVENT_DAILY_CAP; do\s+value="\$\{!name\}"\s+if \[\[ -z "\$\{value\}" \|\| "\$\{value\}" == \*\$'\\n'\* \|\| "\$\{value\}" == \*\$'\\r'\* \]\]; then[\s\S]*?exit 1\s+fi\s+done[\s\S]*?for name in EASYSUBWAY_ADS_ASSET_ORIGIN EASYSUBWAY_ADS_EVENT_DAILY_CAP; do\s+value="\$\{!name\}"\s+printf '%s=%s\\n' "\$\{name\}" "\$\{value\}" >> "\$\{env_file\}"\s+done/,


### PR DESCRIPTION
## 관련 이슈

Closes #2086

## 작업 배경

- PR #2079 merge SHA `c4fb9514`의 production CD가 split deployment env 준비 단계에서 `backend bind must be 127.0.0.1`로 중단됐다.
- 비밀이 아닌 production bind 상수를 CD가 직접 고정해 stale 또는 잘못된 dotenv 값에 의존하지 않도록 한다.

## 작업 내용

- CD dotenv overlay가 기존 `EASYSUBWAY_BACKEND_BIND`를 제거한다.
- 광고 repo var 검증이 끝난 뒤 `EASYSUBWAY_BACKEND_BIND=127.0.0.1`을 정확히 한 번 기록한다.
- stale bind 제거와 loopback 강제를 repository 계약 테스트로 고정한다.

## 검증

- `node --test --test-name-pattern='지속적 배포 준비 상태는 단일 dotenv secret과 배포 설정을' tools/ci/repository-contract.test.mjs`: 1/1 통과
- `node --test tools/ci/repository-contract.test.mjs`: 190/190 통과
- `node --test tools/ci/backend-deploy.test.mjs`: 9/9 통과
- `git diff --check`: 통과

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 기존 CD 차단 | production CD | 실패 단계 sanitized 로그 확인 | https://github.com/AquilaXk/easysubway/actions/runs/29242471091 | backend bind 계약 위반 재현 |
| workflow 계약 | GitHub Actions | repository contract 실행 | 로컬 190/190 | 통과 |
| split env 계약 | backend deploy | backend deploy contract 실행 | 로컬 9/9 | 통과 |
| 실제 배포 | production | merge 후 CD 및 post-deploy smoke | 후속 run 링크 예정 | 대기 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: merge SHA

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `.github/workflows/cd.yml`에서 repo var 검증 전에 값을 기록하지 않는지, stale bind 제거 후 loopback 값이 정확히 한 번 추가되는지 확인한다.

## 리스크

- CD restore 단계만 변경한다. 잘못되면 split env 준비가 fail-closed되며 서버 배포 전 중단된다.
- 롤백은 이 PR의 workflow 변경을 revert하는 것이다. DB migration과 application code 변경은 없다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
