### PR TITLE
[Chore] API 인벤토리를 repository 정본으로 전환

### DIFF
--- a/.github/workflows/datapack-expiry-alert.yml
+++ b/.github/workflows/datapack-expiry-alert.yml
@@ -35,6 +35,9 @@ jobs:
         with:
           node-version: "24"
 
+      - name: Provider Approval Expiry / Check repository approvals
+        run: node tools/datapack/source-operation.mjs check-approvals
+
       - name: Data Pack Expiry Alert / Configure temp paths
         run: |
           set -euo pipefail

--- a/.github/workflows/datapack-expiry-alert.yml
+++ b/.github/workflows/datapack-expiry-alert.yml
@@ -3,6 +3,7 @@ name: Data Pack Expiry Alert
 on:
   schedule:
     - cron: "23 */4 * * *"
+    - cron: "41 0 * * *"
   workflow_dispatch:
 
 concurrency:
@@ -14,6 +15,7 @@ permissions:
 
 jobs:
   provider-approval-expiry:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.schedule == '41 0 * * *' }}
     name: Provider Approval Expiry
     runs-on: ubuntu-latest
     permissions:
@@ -36,11 +38,11 @@ jobs:
         run: node tools/datapack/source-operation.mjs check-approvals --github-output "${GITHUB_OUTPUT}"
 
       - name: Provider Approval Expiry / Skip missing Slack webhook
-        if: ${{ steps.check.outputs.status == 'WARNING' && (github.event_name == 'workflow_dispatch' || steps.check.outputs.notification_due == 'true') && env.SLACK_RELEASE_WEBHOOK_URL == '' }}
+        if: ${{ steps.check.outputs.status == 'WARNING' && env.SLACK_RELEASE_WEBHOOK_URL == '' }}
         run: echo "::notice title=Provider approval notification::SLACK_RELEASE_WEBHOOK_URL is not configured."
 
       - name: Provider Approval Expiry / Notify Slack on renewal window
-        if: ${{ steps.check.outputs.status == 'WARNING' && (github.event_name == 'workflow_dispatch' || steps.check.outputs.notification_due == 'true') && env.SLACK_RELEASE_WEBHOOK_URL != '' }}
+        if: ${{ steps.check.outputs.status == 'WARNING' && env.SLACK_RELEASE_WEBHOOK_URL != '' }}
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c
         with:
           webhook: ${{ env.SLACK_RELEASE_WEBHOOK_URL }}
@@ -58,6 +60,7 @@ jobs:
                     • run: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|GitHub Actions 열기>
 
   datapack-expiry-alert:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.schedule == '23 */4 * * *' }}
     name: Data Pack Expiry Alert
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/datapack-expiry-alert.yml
+++ b/.github/workflows/datapack-expiry-alert.yml
@@ -13,6 +13,25 @@ permissions:
   contents: read
 
 jobs:
+  provider-approval-expiry:
+    name: Provider Approval Expiry
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Provider Approval Expiry / Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Provider Approval Expiry / Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24"
+
+      - name: Provider Approval Expiry / Check repository approvals
+        run: node tools/datapack/source-operation.mjs check-approvals
+
   datapack-expiry-alert:
     name: Data Pack Expiry Alert
     runs-on: ubuntu-latest
@@ -34,9 +53,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: "24"
-
-      - name: Provider Approval Expiry / Check repository approvals
-        run: node tools/datapack/source-operation.mjs check-approvals
 
       - name: Data Pack Expiry Alert / Configure temp paths
         run: |

--- a/.github/workflows/datapack-expiry-alert.yml
+++ b/.github/workflows/datapack-expiry-alert.yml
@@ -36,11 +36,11 @@ jobs:
         run: node tools/datapack/source-operation.mjs check-approvals --github-output "${GITHUB_OUTPUT}"
 
       - name: Provider Approval Expiry / Skip missing Slack webhook
-        if: ${{ steps.check.outputs.status == 'WARNING' && env.SLACK_RELEASE_WEBHOOK_URL == '' }}
+        if: ${{ steps.check.outputs.status == 'WARNING' && (github.event_name == 'workflow_dispatch' || steps.check.outputs.notification_due == 'true') && env.SLACK_RELEASE_WEBHOOK_URL == '' }}
         run: echo "::notice title=Provider approval notification::SLACK_RELEASE_WEBHOOK_URL is not configured."
 
       - name: Provider Approval Expiry / Notify Slack on renewal window
-        if: ${{ steps.check.outputs.status == 'WARNING' && env.SLACK_RELEASE_WEBHOOK_URL != '' }}
+        if: ${{ steps.check.outputs.status == 'WARNING' && (github.event_name == 'workflow_dispatch' || steps.check.outputs.notification_due == 'true') && env.SLACK_RELEASE_WEBHOOK_URL != '' }}
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c
         with:
           webhook: ${{ env.SLACK_RELEASE_WEBHOOK_URL }}

--- a/.github/workflows/datapack-expiry-alert.yml
+++ b/.github/workflows/datapack-expiry-alert.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      SLACK_RELEASE_WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_WEBHOOK_URL }}
     steps:
       - name: Provider Approval Expiry / Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -30,7 +32,30 @@ jobs:
           node-version: "24"
 
       - name: Provider Approval Expiry / Check repository approvals
-        run: node tools/datapack/source-operation.mjs check-approvals
+        id: check
+        run: node tools/datapack/source-operation.mjs check-approvals --github-output "${GITHUB_OUTPUT}"
+
+      - name: Provider Approval Expiry / Skip missing Slack webhook
+        if: ${{ steps.check.outputs.status == 'WARNING' && env.SLACK_RELEASE_WEBHOOK_URL == '' }}
+        run: echo "::notice title=Provider approval notification::SLACK_RELEASE_WEBHOOK_URL is not configured."
+
+      - name: Provider Approval Expiry / Notify Slack on renewal window
+        if: ${{ steps.check.outputs.status == 'WARNING' && env.SLACK_RELEASE_WEBHOOK_URL != '' }}
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c
+        with:
+          webhook: ${{ env.SLACK_RELEASE_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "EasySubway provider approval renewal window"
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: |
+                    *EasySubway Provider Approval Renewal Window*
+                    • approved contracts: `${{ steps.check.outputs.approved_count }}`
+                    • repo: `${{ github.repository }}`
+                    • run: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|GitHub Actions 열기>
 
   datapack-expiry-alert:
     name: Data Pack Expiry Alert

--- a/tools/ci/api-catalog.mjs
+++ b/tools/ci/api-catalog.mjs
@@ -253,6 +253,15 @@ function humanSummary(entry) {
   if (entry.source) lines.push(`source: ${entry.source}`);
   if (entry.documentationStatus) lines.push(`documentation: ${entry.documentationStatus}`);
   if (entry.responseFields?.length) lines.push(`response fields: ${entry.responseFields.join(", ")}`);
+  if (entry.providerApproval) {
+    lines.push(
+      `provider credential: ${entry.providerApproval.status}`,
+      `provider approval scope: ${entry.providerApproval.approvalScope}`,
+      `provider terms: ${entry.providerApproval.termsStatus}`,
+      `provider quota: ${entry.providerApproval.quotaStatus}`,
+      `provider production use: ${entry.providerApproval.productionUseAllowed ? "allowed" : "not allowed"}`,
+    );
+  }
   if (entry.operation?.runner?.command) {
     lines.push(`runner: ${[entry.operation.runner.command, ...(entry.operation.runner.arguments ?? [])].join(" ")}`);
   }

--- a/tools/ci/api-catalog.mjs
+++ b/tools/ci/api-catalog.mjs
@@ -142,6 +142,12 @@ export function validateCatalog(catalog) {
     }
     if (entry.kind === "provider") {
       if (!httpUrl(entry.endpoint)) throw new Error(`${entry.id}: invalid provider endpoint`);
+      if (entry.operationValidationError) {
+        throw new Error(`${entry.id}: provider operation contract is invalid: ${entry.operationValidationError}`);
+      }
+      if (entry.providerApprovalValidationError) {
+        throw new Error(`${entry.id}: provider approval contract is invalid: ${entry.providerApprovalValidationError}`);
+      }
       if (entry.sampleUrl != null && (!httpUrl(entry.sampleUrl)
         || hasConcretePathCredential(entry.endpoint, entry.sampleUrl))) {
         throw new Error(`${entry.id}: secret-like values are forbidden`);
@@ -247,7 +253,9 @@ function humanSummary(entry) {
   if (entry.source) lines.push(`source: ${entry.source}`);
   if (entry.documentationStatus) lines.push(`documentation: ${entry.documentationStatus}`);
   if (entry.responseFields?.length) lines.push(`response fields: ${entry.responseFields.join(", ")}`);
-  if (entry.operation?.runner?.command) lines.push(`runner: ${entry.operation.runner.command}`);
+  if (entry.operation?.runner?.command) {
+    lines.push(`runner: ${[entry.operation.runner.command, ...(entry.operation.runner.arguments ?? [])].join(" ")}`);
+  }
   if (entry.operation?.auth) lines.push(`auth env: ${entry.operation.auth.env ?? "not required"}`);
   return lines.join("\n");
 }

--- a/tools/ci/api-catalog.test.mjs
+++ b/tools/ci/api-catalog.test.mjs
@@ -306,12 +306,19 @@ test("프로젝트 catalog는 KRIC 승인과 shell 없는 key 전달 양식을 �
 
   assert.deepEqual(entry.providerApproval, {
     status: "APPROVED",
+    approvalScope: "API_CREDENTIAL",
+    termsStatus: "REVIEW_REQUIRED",
+    quotaStatus: "REVIEW_REQUIRED",
+    productionUseAllowed: false,
     serviceId: "handicapped",
     operationId: "transferMovement",
     validFrom: "2026-07-06",
     validTo: "2027-07-06",
     renewalNoticeDays: 30,
-    evidenceSource: "owner-confirmed",
+    evidenceReferences: [{
+      type: "OWNER_CONFIRMATION",
+      url: "https://github.com/AquilaXk/easysubway/issues/1397#issuecomment-4956908695",
+    }],
     recordedAt: "2026-07-13",
   });
   assert.equal(entry.operation.auth.env, "KRIC_SERVICE_KEY");

--- a/tools/ci/api-catalog.test.mjs
+++ b/tools/ci/api-catalog.test.mjs
@@ -210,6 +210,19 @@ test("validate는 secret 값과 runtime catalog endpoint를 거부한다", () =>
   }
 });
 
+test("validate는 격리된 provider operation 오류를 거부한다", () => {
+  assert.throws(
+    () => validateCatalog([{
+      id: "provider:invalid-operation",
+      kind: "provider",
+      endpoint: "https://provider.example/invalid",
+      operation: { method: "GET" },
+      operationValidationError: "invalid-operation.operation.auth must be an object",
+    }]),
+    /provider operation contract is invalid/,
+  );
+});
+
 test("integration auth는 credential reference 표현만 허용한다", () => {
   for (const auth of [
     "Basic dXNlcjpwYXNzd29yZA==",
@@ -305,6 +318,16 @@ test("프로젝트 catalog는 KRIC 승인과 shell 없는 key 전달 양식을 �
   assert.equal(entry.operation.auth.parameter, "serviceKey");
   assert.equal(entry.operation.auth.valueEncoding, "url-search-params-once");
   assert.equal(entry.operation.auth.loadPolicy, "process-env-no-shell-parsing");
+  assert.deepEqual(entry.operation.runner.arguments, ["--candidate", "kric-transfer-movement-standard"]);
+  const { stdout } = await execFileAsync(process.execPath, [
+    "tools/ci/api-catalog.mjs",
+    "show",
+    "provider:kric-transfer-movement-standard",
+  ]);
+  assert.match(
+    stdout,
+    /^runner: node tools\/datapack\/collect-kric-source-candidate-evidence\.mjs --candidate kric-transfer-movement-standard$/m,
+  );
 });
 
 test("catalog 운영 계약은 repository-local 전용과 source-of-truth 경계를 고정한다", async () => {

--- a/tools/ci/api-catalog.test.mjs
+++ b/tools/ci/api-catalog.test.mjs
@@ -287,6 +287,25 @@ test("프로젝트 catalog는 주요 API 종류를 모두 찾고 검증한다", 
   );
 });
 
+test("프로젝트 catalog는 KRIC 승인과 shell 없는 key 전달 양식을 제공한다", async () => {
+  const catalog = await loadProjectCatalog();
+  const entry = findCatalogEntry(catalog, "provider:kric-transfer-movement-standard");
+
+  assert.deepEqual(entry.providerApproval, {
+    status: "APPROVED",
+    serviceId: "handicapped",
+    operationId: "transferMovement",
+    validFrom: "2026-07-06",
+    validTo: "2027-07-06",
+    evidenceSource: "owner-confirmed",
+    recordedAt: "2026-07-13",
+  });
+  assert.equal(entry.operation.auth.env, "KRIC_SERVICE_KEY");
+  assert.equal(entry.operation.auth.parameter, "serviceKey");
+  assert.equal(entry.operation.auth.valueEncoding, "url-search-params-once");
+  assert.equal(entry.operation.auth.loadPolicy, "process-env-no-shell-parsing");
+});
+
 test("catalog 운영 계약은 repository-local 전용과 source-of-truth 경계를 고정한다", async () => {
   const policy = await loadCatalogPolicy();
 

--- a/tools/ci/api-catalog.test.mjs
+++ b/tools/ci/api-catalog.test.mjs
@@ -335,6 +335,11 @@ test("프로젝트 catalog는 KRIC 승인과 shell 없는 key 전달 양식을 �
     stdout,
     /^runner: node tools\/datapack\/collect-kric-source-candidate-evidence\.mjs --candidate kric-transfer-movement-standard$/m,
   );
+  assert.match(stdout, /^provider credential: APPROVED$/m);
+  assert.match(stdout, /^provider approval scope: API_CREDENTIAL$/m);
+  assert.match(stdout, /^provider terms: REVIEW_REQUIRED$/m);
+  assert.match(stdout, /^provider quota: REVIEW_REQUIRED$/m);
+  assert.match(stdout, /^provider production use: not allowed$/m);
 });
 
 test("catalog 운영 계약은 repository-local 전용과 source-of-truth 경계를 고정한다", async () => {

--- a/tools/ci/api-catalog.test.mjs
+++ b/tools/ci/api-catalog.test.mjs
@@ -297,6 +297,7 @@ test("프로젝트 catalog는 KRIC 승인과 shell 없는 key 전달 양식을 �
     operationId: "transferMovement",
     validFrom: "2026-07-06",
     validTo: "2027-07-06",
+    renewalNoticeDays: 30,
     evidenceSource: "owner-confirmed",
     recordedAt: "2026-07-13",
   });

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -7228,15 +7228,26 @@ test("KRIC 환승 이동경로 표준 후보는 상세 페이지 라이선스와
     evidenceSource: "owner-confirmed",
     recordedAt: "2026-07-13",
   });
-  assert.deepEqual(candidate.operation.auth, {
-    env: "KRIC_SERVICE_KEY",
-    placement: "query",
-    parameter: "serviceKey",
-    valueEncoding: "url-search-params-once",
-    loadPolicy: "process-env-no-shell-parsing",
+  assert.deepEqual(candidate.operation, {
+    method: "GET",
+    endpoint: "https://openapi.kric.go.kr/openapi/handicapped/transferMovement",
+    auth: {
+      env: "KRIC_SERVICE_KEY",
+      placement: "query",
+      parameter: "serviceKey",
+      valueEncoding: "url-search-params-once",
+      loadPolicy: "process-env-no-shell-parsing",
+    },
+    requiredParameters: [
+      "serviceKey", "format", "railOprIsttCd", "lnCd", "stinCd", "prevStinCd", "chthTgtLn", "chtnNextStinCd",
+    ],
+    responseEnvelope: "root.body.items.item",
+    runner: {
+      command: "node tools/datapack/collect-kric-source-candidate-evidence.mjs",
+      requiredEnv: ["KRIC_SERVICE_KEY", "RUNNER_TEMP"],
+    },
+    secretPolicy: "env-only-redacted-output",
   });
-  assert.equal(candidate.operation.runner.command, "node tools/datapack/collect-kric-source-candidate-evidence.mjs");
-  assert.deepEqual(candidate.operation.runner.requiredEnv, ["KRIC_SERVICE_KEY", "RUNNER_TEMP"]);
   assert.equal(candidate.detailUrl, "https://data.kric.go.kr/rips/M_01_02/detail.do?id=428&service=handicapped&operation=transferMovement&page=2");
   assert.equal(candidate.evidence.detailPageUrl, candidate.detailUrl);
   assert.equal(candidate.evidence.usePermissionRange, "저작권표시");

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -13834,6 +13834,7 @@ test("데이터팩 만료 감시 workflow는 SLA 임계보다 촘촘한 cron으�
 
   assert.match(workflow, /^name: Data Pack Expiry Alert$/m);
   assert.match(workflow, /schedule:[\s\S]*cron: "23 \*\/4 \* \* \*"/);
+  assert.match(workflow, /schedule:[\s\S]*cron: "41 0 \* \* \*"/);
   assert.match(workflow, /workflow_dispatch:/);
   assert.match(workflow, /permissions:\s*\n\s*contents: read/);
   assert.match(workflow, /concurrency:\s*\n\s*group: /);
@@ -13864,8 +13865,9 @@ test("데이터팩 만료 감시 workflow는 SLA 임계보다 촘촘한 cron으�
   assert.match(workflow, /^  provider-approval-expiry:\s*$/m);
   assert.match(workflow, /^    name: Provider Approval Expiry$/m);
   assert.match(workflow, /provider-approval-expiry:[\s\S]*id:\s*check[\s\S]*GITHUB_OUTPUT/);
-  assert.match(workflow, /provider-approval-expiry:[\s\S]*notification_due/);
-  assert.match(workflow, /provider-approval-expiry:[\s\S]*github\.event_name == 'workflow_dispatch'/);
+  assert.match(workflow, /provider-approval-expiry:[\s\S]*github\.event\.schedule == '41 0 \* \* \*'/);
+  assert.match(workflow, /datapack-expiry-alert:[\s\S]*github\.event\.schedule == '23 \*\/4 \* \* \*'/);
+  assert.doesNotMatch(workflow, /notification_due/);
   assert.match(workflow, /provider-approval-expiry:[\s\S]*steps\.check\.outputs\.status == 'WARNING'[\s\S]*slackapi\/slack-github-action@/);
   assert.match(workflow, /--manifest\s+"/);
   assert.match(workflow, /--output\s+"/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -6640,7 +6640,8 @@ test("KRIC source 후보는 상세 근거 완료 상태와 production 분리를 
 
   assert.equal(candidates.schemaVersion, 1);
   assert.equal(candidates.artifactKind, "production-source-candidates");
-  assert.equal(candidates.source, "easysubway_public_subway_api_inventory.xlsx");
+  assert.equal(candidates.source, "tools/datapack/source-candidates.json");
+  assert.equal(candidates.updatedAt, "2026-07-13");
   assert.deepEqual(
     kricCandidates.map((candidate) => candidate.id).sort(),
     [
@@ -7218,6 +7219,24 @@ test("KRIC 환승 이동경로 표준 후보는 상세 페이지 라이선스와
   assert.equal(candidate.sampleEvidenceStatus, "sample_url_documented_key_required");
   assert.equal(candidate.admissionStatus, "evidence_recorded_admin_review_required");
   assert.equal(candidate.automaticRouteGraphEdgeAllowed, false);
+  assert.deepEqual(candidate.providerApproval, {
+    status: "APPROVED",
+    serviceId: "handicapped",
+    operationId: "transferMovement",
+    validFrom: "2026-07-06",
+    validTo: "2027-07-06",
+    evidenceSource: "owner-confirmed",
+    recordedAt: "2026-07-13",
+  });
+  assert.deepEqual(candidate.operation.auth, {
+    env: "KRIC_SERVICE_KEY",
+    placement: "query",
+    parameter: "serviceKey",
+    valueEncoding: "url-search-params-once",
+    loadPolicy: "process-env-no-shell-parsing",
+  });
+  assert.equal(candidate.operation.runner.command, "node tools/datapack/collect-kric-source-candidate-evidence.mjs");
+  assert.deepEqual(candidate.operation.runner.requiredEnv, ["KRIC_SERVICE_KEY", "RUNNER_TEMP"]);
   assert.equal(candidate.detailUrl, "https://data.kric.go.kr/rips/M_01_02/detail.do?id=428&service=handicapped&operation=transferMovement&page=2");
   assert.equal(candidate.evidence.detailPageUrl, candidate.detailUrl);
   assert.equal(candidate.evidence.usePermissionRange, "저작권표시");

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -7221,12 +7221,19 @@ test("KRIC 환승 이동경로 표준 후보는 상세 페이지 라이선스와
   assert.equal(candidate.automaticRouteGraphEdgeAllowed, false);
   assert.deepEqual(candidate.providerApproval, {
     status: "APPROVED",
+    approvalScope: "API_CREDENTIAL",
+    termsStatus: "REVIEW_REQUIRED",
+    quotaStatus: "REVIEW_REQUIRED",
+    productionUseAllowed: false,
     serviceId: "handicapped",
     operationId: "transferMovement",
     validFrom: "2026-07-06",
     validTo: "2027-07-06",
     renewalNoticeDays: 30,
-    evidenceSource: "owner-confirmed",
+    evidenceReferences: [{
+      type: "OWNER_CONFIRMATION",
+      url: "https://github.com/AquilaXk/easysubway/issues/1397#issuecomment-4956908695",
+    }],
     recordedAt: "2026-07-13",
   });
   assert.deepEqual(candidate.operation, {
@@ -13856,6 +13863,8 @@ test("데이터팩 만료 감시 workflow는 SLA 임계보다 촘촘한 cron으�
   assert.match(workflow, /node tools\/datapack\/source-operation\.mjs check-approvals/);
   assert.match(workflow, /^  provider-approval-expiry:\s*$/m);
   assert.match(workflow, /^    name: Provider Approval Expiry$/m);
+  assert.match(workflow, /provider-approval-expiry:[\s\S]*id:\s*check[\s\S]*GITHUB_OUTPUT/);
+  assert.match(workflow, /provider-approval-expiry:[\s\S]*steps\.check\.outputs\.status == 'WARNING'[\s\S]*slackapi\/slack-github-action@/);
   assert.match(workflow, /--manifest\s+"/);
   assert.match(workflow, /--output\s+"/);
 

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -7225,6 +7225,7 @@ test("KRIC 환승 이동경로 표준 후보는 상세 페이지 라이선스와
     operationId: "transferMovement",
     validFrom: "2026-07-06",
     validTo: "2027-07-06",
+    renewalNoticeDays: 30,
     evidenceSource: "owner-confirmed",
     recordedAt: "2026-07-13",
   });
@@ -13851,6 +13852,7 @@ test("데이터팩 만료 감시 workflow는 SLA 임계보다 촘촘한 cron으�
   // manifest 다운로드와 스크립트 호출부.
   assert.match(workflow, /curl -fsS --connect-timeout 10 --max-time 30 "\$\{[A-Z_]*BASE_URL[A-Z_]*\}\/catalog\/current\.json"/);
   assert.match(workflow, /node tools\/datapack\/check-datapack-expiry-alert\.mjs/);
+  assert.match(workflow, /node tools\/datapack\/source-operation\.mjs check-approvals/);
   assert.match(workflow, /--manifest\s+"/);
   assert.match(workflow, /--output\s+"/);
 

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -13864,6 +13864,8 @@ test("데이터팩 만료 감시 workflow는 SLA 임계보다 촘촘한 cron으�
   assert.match(workflow, /^  provider-approval-expiry:\s*$/m);
   assert.match(workflow, /^    name: Provider Approval Expiry$/m);
   assert.match(workflow, /provider-approval-expiry:[\s\S]*id:\s*check[\s\S]*GITHUB_OUTPUT/);
+  assert.match(workflow, /provider-approval-expiry:[\s\S]*notification_due/);
+  assert.match(workflow, /provider-approval-expiry:[\s\S]*github\.event_name == 'workflow_dispatch'/);
   assert.match(workflow, /provider-approval-expiry:[\s\S]*steps\.check\.outputs\.status == 'WARNING'[\s\S]*slackapi\/slack-github-action@/);
   assert.match(workflow, /--manifest\s+"/);
   assert.match(workflow, /--output\s+"/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -7245,6 +7245,7 @@ test("KRIC 환승 이동경로 표준 후보는 상세 페이지 라이선스와
     responseEnvelope: "root.body.items.item",
     runner: {
       command: "node tools/datapack/collect-kric-source-candidate-evidence.mjs",
+      arguments: ["--candidate", "kric-transfer-movement-standard"],
       requiredEnv: ["KRIC_SERVICE_KEY", "RUNNER_TEMP"],
     },
     secretPolicy: "env-only-redacted-output",
@@ -13853,6 +13854,8 @@ test("데이터팩 만료 감시 workflow는 SLA 임계보다 촘촘한 cron으�
   assert.match(workflow, /curl -fsS --connect-timeout 10 --max-time 30 "\$\{[A-Z_]*BASE_URL[A-Z_]*\}\/catalog\/current\.json"/);
   assert.match(workflow, /node tools\/datapack\/check-datapack-expiry-alert\.mjs/);
   assert.match(workflow, /node tools\/datapack\/source-operation\.mjs check-approvals/);
+  assert.match(workflow, /^  provider-approval-expiry:\s*$/m);
+  assert.match(workflow, /^    name: Provider Approval Expiry$/m);
   assert.match(workflow, /--manifest\s+"/);
   assert.match(workflow, /--output\s+"/);
 

--- a/tools/datapack/source-candidates.json
+++ b/tools/datapack/source-candidates.json
@@ -1,8 +1,9 @@
 {
   "schemaVersion": 1,
   "artifactKind": "production-source-candidates",
-  "source": "easysubway_public_subway_api_inventory.xlsx",
+  "source": "tools/datapack/source-candidates.json",
   "retrievedAt": "2026-06-22",
+  "updatedAt": "2026-07-13",
   "candidates": [
     {
       "id": "kric-subway-route-info",
@@ -646,6 +647,47 @@
       "sampleEvidenceStatus": "sample_url_documented_key_required",
       "admissionStatus": "evidence_recorded_admin_review_required",
       "automaticRouteGraphEdgeAllowed": false,
+      "serviceKeyHandling": "offline_import_secret_only",
+      "mobileEmbeddingAllowed": false,
+      "providerApproval": {
+        "status": "APPROVED",
+        "serviceId": "handicapped",
+        "operationId": "transferMovement",
+        "validFrom": "2026-07-06",
+        "validTo": "2027-07-06",
+        "evidenceSource": "owner-confirmed",
+        "recordedAt": "2026-07-13"
+      },
+      "operation": {
+        "method": "GET",
+        "endpoint": "https://openapi.kric.go.kr/openapi/handicapped/transferMovement",
+        "auth": {
+          "env": "KRIC_SERVICE_KEY",
+          "placement": "query",
+          "parameter": "serviceKey",
+          "valueEncoding": "url-search-params-once",
+          "loadPolicy": "process-env-no-shell-parsing"
+        },
+        "requiredParameters": [
+          "serviceKey",
+          "format",
+          "railOprIsttCd",
+          "lnCd",
+          "stinCd",
+          "prevStinCd",
+          "chthTgtLn",
+          "chtnNextStinCd"
+        ],
+        "responseEnvelope": "root.body.items.item",
+        "runner": {
+          "command": "node tools/datapack/collect-kric-source-candidate-evidence.mjs",
+          "requiredEnv": [
+            "KRIC_SERVICE_KEY",
+            "RUNNER_TEMP"
+          ]
+        },
+        "secretPolicy": "env-only-redacted-output"
+      },
       "evidence": {
         "listPageUrl": "https://data.kric.go.kr/rips/M_01_02/intro.do?page=2",
         "detailPageUrl": "https://data.kric.go.kr/rips/M_01_02/detail.do?id=428&service=handicapped&operation=transferMovement&page=2",

--- a/tools/datapack/source-candidates.json
+++ b/tools/datapack/source-candidates.json
@@ -651,12 +651,21 @@
       "mobileEmbeddingAllowed": false,
       "providerApproval": {
         "status": "APPROVED",
+        "approvalScope": "API_CREDENTIAL",
+        "termsStatus": "REVIEW_REQUIRED",
+        "quotaStatus": "REVIEW_REQUIRED",
+        "productionUseAllowed": false,
         "serviceId": "handicapped",
         "operationId": "transferMovement",
         "validFrom": "2026-07-06",
         "validTo": "2027-07-06",
         "renewalNoticeDays": 30,
-        "evidenceSource": "owner-confirmed",
+        "evidenceReferences": [
+          {
+            "type": "OWNER_CONFIRMATION",
+            "url": "https://github.com/AquilaXk/easysubway/issues/1397#issuecomment-4956908695"
+          }
+        ],
         "recordedAt": "2026-07-13"
       },
       "operation": {

--- a/tools/datapack/source-candidates.json
+++ b/tools/datapack/source-candidates.json
@@ -682,6 +682,10 @@
         "responseEnvelope": "root.body.items.item",
         "runner": {
           "command": "node tools/datapack/collect-kric-source-candidate-evidence.mjs",
+          "arguments": [
+            "--candidate",
+            "kric-transfer-movement-standard"
+          ],
           "requiredEnv": [
             "KRIC_SERVICE_KEY",
             "RUNNER_TEMP"

--- a/tools/datapack/source-candidates.json
+++ b/tools/datapack/source-candidates.json
@@ -655,6 +655,7 @@
         "operationId": "transferMovement",
         "validFrom": "2026-07-06",
         "validTo": "2027-07-06",
+        "renewalNoticeDays": 30,
         "evidenceSource": "owner-confirmed",
         "recordedAt": "2026-07-13"
       },

--- a/tools/datapack/source-operation.mjs
+++ b/tools/datapack/source-operation.mjs
@@ -221,6 +221,13 @@ export function providerApprovalExpirySummary(document, { today = new Date().toI
   };
 }
 
+export function providerApprovalNotificationDue(summary, { now = new Date() } = {}) {
+  if (!(now instanceof Date) || Number.isNaN(now.valueOf())) {
+    throw new Error("provider approval notification time must be a valid Date");
+  }
+  return summary?.status === "WARNING" && now.getUTCHours() === 0;
+}
+
 export function validateOperation(candidate, { allowMissing = false } = {}) {
   const requestUrl = requiredHttpUrl(candidate?.requestUrl, `${candidate?.id ?? "candidate"}.requestUrl`);
   if (hasCredentialValue(candidate.requestUrl)) {
@@ -437,7 +444,11 @@ async function main(args = process.argv.slice(2)) {
       }
     }
     if (githubOutput) {
-      await appendFile(githubOutput, `status=${summary.status}\napproved_count=${summary.approvals.length}\n`);
+      const notificationDue = providerApprovalNotificationDue(summary);
+      await appendFile(
+        githubOutput,
+        `status=${summary.status}\napproved_count=${summary.approvals.length}\nnotification_due=${notificationDue}\n`,
+      );
     }
     console.log(`provider approval expiry: ${summary.status} (${summary.approvals.length} approved)`);
     return;

--- a/tools/datapack/source-operation.mjs
+++ b/tools/datapack/source-operation.mjs
@@ -119,11 +119,15 @@ export function validateProviderApproval(candidate) {
   if (validTo < validFrom) {
     throw new Error(`${candidate.id}.providerApproval.validTo must not precede validFrom`);
   }
-  if (approval.status === "APPROVED" && validTo < new Date().toISOString().slice(0, 10)) {
-    throw new Error(`${candidate.id}.providerApproval.status is APPROVED but validTo has expired`);
-  }
   requiredText(approval.evidenceSource, `${candidate.id}.providerApproval.evidenceSource`);
   requiredDate(approval.recordedAt, `${candidate.id}.providerApproval.recordedAt`);
+  const today = new Date().toISOString().slice(0, 10);
+  if (approval.status === "APPROVED" && validTo < today) {
+    throw new Error(`${candidate.id}.providerApproval.status is APPROVED but validTo has expired`);
+  }
+  if (approval.status === "APPROVED" && validFrom > today) {
+    throw new Error(`${candidate.id}.providerApproval.status is APPROVED but validFrom is in the future`);
+  }
   return approval;
 }
 
@@ -247,7 +251,13 @@ export function validateOperation(candidate, { allowMissing = false } = {}) {
 }
 
 export function operationSummary(candidate) {
-  validateOperation(candidate, { allowMissing: true });
+  let operationValidationError = null;
+  try {
+    validateOperation(candidate, { allowMissing: true });
+  } catch (error) {
+    if (error instanceof Error && /credential values are forbidden/.test(error.message)) throw error;
+    operationValidationError = error instanceof Error ? error.message : "operation is invalid";
+  }
   let providerApprovalValidationError = null;
   try {
     validateProviderApproval(candidate);
@@ -263,6 +273,7 @@ export function operationSummary(candidate) {
     providerApproval: candidate.providerApproval ?? null,
     providerApprovalValidationError,
     operation: candidate.operation ?? null,
+    operationValidationError,
   };
 }
 
@@ -306,6 +317,9 @@ export function operationHumanSummary(summary) {
     );
   } else {
     lines.push("operation: not documented");
+  }
+  if (summary.operationValidationError) {
+    lines.push(`operation validation: ${summary.operationValidationError}`);
   }
   return lines.join("\n");
 }

--- a/tools/datapack/source-operation.mjs
+++ b/tools/datapack/source-operation.mjs
@@ -97,7 +97,7 @@ function requiredDate(value, label) {
   return text;
 }
 
-export function validateProviderApproval(candidate) {
+export function validateProviderApproval(candidate, { today = new Date().toISOString().slice(0, 10) } = {}) {
   const approval = candidate?.providerApproval;
   if (approval == null) return null;
   if (typeof approval !== "object" || Array.isArray(approval)) {
@@ -107,7 +107,7 @@ export function validateProviderApproval(candidate) {
     throw new Error(`${candidate.id}.providerApproval secret-like values are forbidden`);
   }
   requireAllowedKeys(approval, new Set([
-    "status", "serviceId", "operationId", "validFrom", "validTo", "evidenceSource", "recordedAt",
+    "status", "serviceId", "operationId", "validFrom", "validTo", "renewalNoticeDays", "evidenceSource", "recordedAt",
   ]), `${candidate.id}.providerApproval`);
   if (!new Set(["APPROVED", "EXPIRED", "REVOKED"]).has(approval.status)) {
     throw new Error(`${candidate.id}.providerApproval.status is invalid`);
@@ -123,12 +123,16 @@ export function validateProviderApproval(candidate) {
   }
   const validFrom = requiredDate(approval.validFrom, `${candidate.id}.providerApproval.validFrom`);
   const validTo = requiredDate(approval.validTo, `${candidate.id}.providerApproval.validTo`);
+  if (approval.renewalNoticeDays != null
+    && (!Number.isInteger(approval.renewalNoticeDays) || approval.renewalNoticeDays < 1)) {
+    throw new Error(`${candidate.id}.providerApproval.renewalNoticeDays must be a positive integer`);
+  }
   if (validTo < validFrom) {
     throw new Error(`${candidate.id}.providerApproval.validTo must not precede validFrom`);
   }
   requiredText(approval.evidenceSource, `${candidate.id}.providerApproval.evidenceSource`);
   requiredDate(approval.recordedAt, `${candidate.id}.providerApproval.recordedAt`);
-  const today = new Date().toISOString().slice(0, 10);
+  requiredDate(today, "provider approval current date");
   if (approval.status === "APPROVED" && validTo < today) {
     throw new Error(`${candidate.id}.providerApproval.status is APPROVED but validTo has expired`);
   }
@@ -138,7 +142,7 @@ export function validateProviderApproval(candidate) {
   return approval;
 }
 
-export function validateSourceCandidateDocument(document) {
+export function validateSourceCandidateDocument(document, options = {}) {
   if (!document || typeof document !== "object" || Array.isArray(document)) {
     throw new Error("source candidate document must be an object");
   }
@@ -155,9 +159,31 @@ export function validateSourceCandidateDocument(document) {
     const id = requiredText(candidate?.id, "candidate.id");
     if (ids.has(id)) throw new Error(`duplicate candidate id: ${id}`);
     ids.add(id);
-    validateProviderApproval(candidate);
+    validateProviderApproval(candidate, options);
   }
   return document;
+}
+
+export function providerApprovalExpirySummary(document, { today = new Date().toISOString().slice(0, 10) } = {}) {
+  validateSourceCandidateDocument(document, { today });
+  const todayMillis = Date.parse(`${today}T00:00:00Z`);
+  const approvals = document.candidates
+    .filter((candidate) => candidate.providerApproval?.status === "APPROVED")
+    .map((candidate) => {
+      const approval = candidate.providerApproval;
+      return {
+        candidateId: candidate.id,
+        validTo: approval.validTo,
+        daysUntilExpiry: Math.floor((Date.parse(`${approval.validTo}T00:00:00Z`) - todayMillis) / 86_400_000),
+        renewalNoticeDays: approval.renewalNoticeDays ?? 30,
+      };
+    });
+  return {
+    status: approvals.some((approval) => approval.daysUntilExpiry <= approval.renewalNoticeDays)
+      ? "WARNING"
+      : "OK",
+    approvals,
+  };
 }
 
 export function validateOperation(candidate, { allowMissing = false } = {}) {
@@ -358,7 +384,17 @@ async function main(args = process.argv.slice(2)) {
     console.log(`source operation contracts valid: ${candidates.length}`);
     return;
   }
-  throw new Error("usage: source-operation.mjs list [--json] | show <source-id> [--json] | validate");
+  if (command === "check-approvals" && !sourceId) {
+    const summary = providerApprovalExpirySummary(document);
+    for (const approval of summary.approvals) {
+      if (approval.daysUntilExpiry <= approval.renewalNoticeDays) {
+        console.log(`::warning title=Provider approval expiry::${approval.candidateId} expires in ${approval.daysUntilExpiry} days (${approval.validTo})`);
+      }
+    }
+    console.log(`provider approval expiry: ${summary.status} (${summary.approvals.length} approved)`);
+    return;
+  }
+  throw new Error("usage: source-operation.mjs list [--json] | show <source-id> [--json] | validate | check-approvals");
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/tools/datapack/source-operation.mjs
+++ b/tools/datapack/source-operation.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { readFile } from "node:fs/promises";
+import { appendFile, readFile } from "node:fs/promises";
 import { pathToFileURL } from "node:url";
 
 const CANDIDATES_URL = new URL("./source-candidates.json", import.meta.url);
@@ -107,10 +107,28 @@ export function validateProviderApproval(candidate, { today = new Date().toISOSt
     throw new Error(`${candidate.id}.providerApproval secret-like values are forbidden`);
   }
   requireAllowedKeys(approval, new Set([
-    "status", "serviceId", "operationId", "validFrom", "validTo", "renewalNoticeDays", "evidenceSource", "recordedAt",
+    "status", "approvalScope", "termsStatus", "quotaStatus", "productionUseAllowed",
+    "serviceId", "operationId", "validFrom", "validTo", "renewalNoticeDays", "evidenceReferences", "recordedAt",
   ]), `${candidate.id}.providerApproval`);
   if (!new Set(["APPROVED", "EXPIRED", "REVOKED"]).has(approval.status)) {
     throw new Error(`${candidate.id}.providerApproval.status is invalid`);
+  }
+  if (approval.approvalScope !== "API_CREDENTIAL") {
+    throw new Error(`${candidate.id}.providerApproval.approvalScope must be API_CREDENTIAL`);
+  }
+  const conditionStatuses = new Set(["APPROVED", "REVIEW_REQUIRED", "REJECTED", "NOT_APPLICABLE"]);
+  for (const field of ["termsStatus", "quotaStatus"]) {
+    if (!conditionStatuses.has(approval[field])) {
+      throw new Error(`${candidate.id}.providerApproval.${field} is invalid`);
+    }
+  }
+  if (typeof approval.productionUseAllowed !== "boolean") {
+    throw new Error(`${candidate.id}.providerApproval.productionUseAllowed must be a boolean`);
+  }
+  const productionUseAllowed = approval.status === "APPROVED"
+    && [approval.termsStatus, approval.quotaStatus].every((status) => new Set(["APPROVED", "NOT_APPLICABLE"]).has(status));
+  if (approval.productionUseAllowed !== productionUseAllowed) {
+    throw new Error(`${candidate.id}.providerApproval.productionUseAllowed must match credential, terms, and quota decisions`);
   }
   const serviceId = requiredText(approval.serviceId, `${candidate.id}.providerApproval.serviceId`);
   const operationId = requiredText(approval.operationId, `${candidate.id}.providerApproval.operationId`);
@@ -130,7 +148,24 @@ export function validateProviderApproval(candidate, { today = new Date().toISOSt
   if (validTo < validFrom) {
     throw new Error(`${candidate.id}.providerApproval.validTo must not precede validFrom`);
   }
-  requiredText(approval.evidenceSource, `${candidate.id}.providerApproval.evidenceSource`);
+  if (!Array.isArray(approval.evidenceReferences) || approval.evidenceReferences.length === 0) {
+    throw new Error(`${candidate.id}.providerApproval.evidenceReferences must be a non-empty array`);
+  }
+  const evidenceUrls = new Set();
+  for (const [index, evidence] of approval.evidenceReferences.entries()) {
+    if (evidence == null || typeof evidence !== "object" || Array.isArray(evidence)) {
+      throw new Error(`${candidate.id}.providerApproval.evidenceReferences[${index}] must be an object`);
+    }
+    requireAllowedKeys(evidence, new Set(["type", "url"]), `${candidate.id}.providerApproval.evidenceReferences[${index}]`);
+    if (!new Set(["OWNER_CONFIRMATION", "PROVIDER_PORTAL", "PROVIDER_DOCUMENT"]).has(evidence.type)) {
+      throw new Error(`${candidate.id}.providerApproval.evidenceReferences[${index}].type is invalid`);
+    }
+    const url = requiredHttpUrl(evidence.url, `${candidate.id}.providerApproval.evidenceReferences[${index}].url`).href;
+    if (evidenceUrls.has(url)) {
+      throw new Error(`${candidate.id}.providerApproval.evidenceReferences must not contain duplicate URLs`);
+    }
+    evidenceUrls.add(url);
+  }
   requiredDate(approval.recordedAt, `${candidate.id}.providerApproval.recordedAt`);
   requiredDate(today, "provider approval current date");
   if (approval.status === "APPROVED" && validTo < today) {
@@ -331,6 +366,10 @@ export function operationHumanSummary(summary) {
   if (summary.providerApproval) {
     lines.push(
       `provider approval: ${summary.providerApproval.status}`,
+      `provider approval scope: ${summary.providerApproval.approvalScope}`,
+      `provider terms: ${summary.providerApproval.termsStatus}`,
+      `provider quota: ${summary.providerApproval.quotaStatus}`,
+      `provider production use: ${summary.providerApproval.productionUseAllowed ? "allowed" : "not allowed"}`,
       `provider operation: ${summary.providerApproval.serviceId}/${summary.providerApproval.operationId}`,
       `approval valid: ${summary.providerApproval.validFrom}..${summary.providerApproval.validTo}`,
     );
@@ -361,7 +400,11 @@ export function operationHumanSummary(summary) {
 }
 
 async function main(args = process.argv.slice(2)) {
-  const [command, sourceId] = args.filter((arg) => arg !== "--json");
+  const githubOutputIndex = args.indexOf("--github-output");
+  const githubOutput = githubOutputIndex === -1 ? null : requiredText(args[githubOutputIndex + 1], "--github-output");
+  const positional = args.filter((arg, index) => arg !== "--json"
+    && (githubOutputIndex === -1 || (index !== githubOutputIndex && index !== githubOutputIndex + 1)));
+  const [command, sourceId] = positional;
   const json = args.includes("--json");
   const document = JSON.parse(await readFile(CANDIDATES_URL, "utf8"));
   const operations = listOperations(document);
@@ -393,10 +436,13 @@ async function main(args = process.argv.slice(2)) {
         console.log(`::warning title=Provider approval expiry::${approval.candidateId} expires in ${approval.daysUntilExpiry} days (${approval.validTo})`);
       }
     }
+    if (githubOutput) {
+      await appendFile(githubOutput, `status=${summary.status}\napproved_count=${summary.approvals.length}\n`);
+    }
     console.log(`provider approval expiry: ${summary.status} (${summary.approvals.length} approved)`);
     return;
   }
-  throw new Error("usage: source-operation.mjs list [--json] | show <source-id> [--json] | validate | check-approvals");
+  throw new Error("usage: source-operation.mjs list [--json] | show <source-id> [--json] | validate | check-approvals [--github-output <path>]");
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/tools/datapack/source-operation.mjs
+++ b/tools/datapack/source-operation.mjs
@@ -260,11 +260,12 @@ export function validateOperation(candidate, { allowMissing = false } = {}) {
   if (!runner || typeof runner !== "object" || Array.isArray(runner)) {
     throw new Error(`${candidate.id}.operation.runner must be an object`);
   }
-  requireAllowedKeys(runner, new Set(["command", "requiredEnv"]), `${candidate.id}.operation.runner`);
+  requireAllowedKeys(runner, new Set(["command", "arguments", "requiredEnv"]), `${candidate.id}.operation.runner`);
   const command = requiredText(runner.command, `${candidate.id}.operation.runner.command`);
   if (!/^node tools\/[A-Za-z0-9_./-]+\.mjs$/.test(command)) {
     throw new Error(`${candidate.id}.operation.runner.command must be a literal repository Node command`);
   }
+  stringList(runner.arguments ?? [], `${candidate.id}.operation.runner.arguments`, { allowEmpty: true });
   const requiredEnv = stringList(
     runner.requiredEnv,
     `${candidate.id}.operation.runner.requiredEnv`,
@@ -339,17 +340,18 @@ export function operationHumanSummary(summary) {
   if (summary.providerApprovalValidationError) {
     lines.push(`provider approval validation: ${summary.providerApprovalValidationError}`);
   }
-  if (summary.operation) {
+  if (summary.operation && !summary.operationValidationError) {
+    const runner = [summary.operation.runner.command, ...(summary.operation.runner.arguments ?? [])].join(" ");
     lines.push(
       `auth env: ${summary.operation.auth.env ?? "not required"}`,
       `auth value encoding: ${summary.operation.auth.valueEncoding ?? "provider default"}`,
       `auth load policy: ${summary.operation.auth.loadPolicy ?? "runtime default"}`,
       `required params: ${summary.operation.requiredParameters.join(", ")}`,
       `response envelope: ${summary.operation.responseEnvelope}`,
-      `runner: ${summary.operation.runner.command}`,
+      `runner: ${runner}`,
       `runner env: ${summary.operation.runner.requiredEnv.join(", ")}`,
     );
-  } else {
+  } else if (!summary.operation) {
     lines.push("operation: not documented");
   }
   if (summary.operationValidationError) {

--- a/tools/datapack/source-operation.mjs
+++ b/tools/datapack/source-operation.mjs
@@ -112,8 +112,15 @@ export function validateProviderApproval(candidate) {
   if (!new Set(["APPROVED", "EXPIRED", "REVOKED"]).has(approval.status)) {
     throw new Error(`${candidate.id}.providerApproval.status is invalid`);
   }
-  requiredText(approval.serviceId, `${candidate.id}.providerApproval.serviceId`);
-  requiredText(approval.operationId, `${candidate.id}.providerApproval.operationId`);
+  const serviceId = requiredText(approval.serviceId, `${candidate.id}.providerApproval.serviceId`);
+  const operationId = requiredText(approval.operationId, `${candidate.id}.providerApproval.operationId`);
+  if (candidate.operation?.endpoint != null) {
+    const endpoint = requiredHttpUrl(candidate.operation.endpoint, `${candidate.id}.operation.endpoint`);
+    const path = endpoint.pathname.split("/").filter(Boolean).map(decodeURIComponent);
+    if (path.at(-2) !== serviceId || path.at(-1) !== operationId) {
+      throw new Error(`${candidate.id}.providerApproval serviceId/operationId must match operation endpoint path`);
+    }
+  }
   const validFrom = requiredDate(approval.validFrom, `${candidate.id}.providerApproval.validFrom`);
   const validTo = requiredDate(approval.validTo, `${candidate.id}.providerApproval.validTo`);
   if (validTo < validFrom) {
@@ -262,6 +269,7 @@ export function operationSummary(candidate) {
   try {
     validateProviderApproval(candidate);
   } catch (error) {
+    if (error instanceof Error && /secret-like values are forbidden/.test(error.message)) throw error;
     providerApprovalValidationError = error instanceof Error ? error.message : "provider approval is invalid";
   }
   return {

--- a/tools/datapack/source-operation.mjs
+++ b/tools/datapack/source-operation.mjs
@@ -248,7 +248,12 @@ export function validateOperation(candidate, { allowMissing = false } = {}) {
 
 export function operationSummary(candidate) {
   validateOperation(candidate, { allowMissing: true });
-  validateProviderApproval(candidate);
+  let providerApprovalValidationError = null;
+  try {
+    validateProviderApproval(candidate);
+  } catch (error) {
+    providerApprovalValidationError = error instanceof Error ? error.message : "provider approval is invalid";
+  }
   return {
     id: requiredText(candidate.id, "candidate.id"),
     status: candidate.admissionStatus ?? null,
@@ -256,6 +261,7 @@ export function operationSummary(candidate) {
     sampleUrl: candidate.evidence?.sampleUrl ?? null,
     responseFields: candidate.evidence?.outputFields ?? [],
     providerApproval: candidate.providerApproval ?? null,
+    providerApprovalValidationError,
     operation: candidate.operation ?? null,
   };
 }
@@ -285,6 +291,9 @@ export function operationHumanSummary(summary) {
   } else {
     lines.push("provider approval: none");
   }
+  if (summary.providerApprovalValidationError) {
+    lines.push(`provider approval validation: ${summary.providerApprovalValidationError}`);
+  }
   if (summary.operation) {
     lines.push(
       `auth env: ${summary.operation.auth.env ?? "not required"}`,
@@ -305,7 +314,6 @@ async function main(args = process.argv.slice(2)) {
   const [command, sourceId] = args.filter((arg) => arg !== "--json");
   const json = args.includes("--json");
   const document = JSON.parse(await readFile(CANDIDATES_URL, "utf8"));
-  validateSourceCandidateDocument(document);
   const operations = listOperations(document);
   if (command === "list") {
     console.log(
@@ -322,6 +330,7 @@ async function main(args = process.argv.slice(2)) {
     return;
   }
   if (command === "validate" && !sourceId) {
+    validateSourceCandidateDocument(document);
     const candidates = document.candidates.filter((candidate) => candidate.operation != null);
     for (const candidate of candidates) validateOperation(candidate);
     console.log(`source operation contracts valid: ${candidates.length}`);

--- a/tools/datapack/source-operation.mjs
+++ b/tools/datapack/source-operation.mjs
@@ -221,13 +221,6 @@ export function providerApprovalExpirySummary(document, { today = new Date().toI
   };
 }
 
-export function providerApprovalNotificationDue(summary, { now = new Date() } = {}) {
-  if (!(now instanceof Date) || Number.isNaN(now.valueOf())) {
-    throw new Error("provider approval notification time must be a valid Date");
-  }
-  return summary?.status === "WARNING" && now.getUTCHours() === 0;
-}
-
 export function validateOperation(candidate, { allowMissing = false } = {}) {
   const requestUrl = requiredHttpUrl(candidate?.requestUrl, `${candidate?.id ?? "candidate"}.requestUrl`);
   if (hasCredentialValue(candidate.requestUrl)) {
@@ -307,7 +300,17 @@ export function validateOperation(candidate, { allowMissing = false } = {}) {
   if (!/^node tools\/[A-Za-z0-9_./-]+\.mjs$/.test(command)) {
     throw new Error(`${candidate.id}.operation.runner.command must be a literal repository Node command`);
   }
-  stringList(runner.arguments ?? [], `${candidate.id}.operation.runner.arguments`, { allowEmpty: true });
+  const runnerArguments = stringList(
+    runner.arguments ?? [],
+    `${candidate.id}.operation.runner.arguments`,
+    { allowEmpty: true },
+  );
+  if (runnerArguments.some((argument) => {
+    const option = /^--([^=]+)(?:=|$)/.exec(argument);
+    return option && CREDENTIAL_NAME.test(normalizedName(option[1]));
+  })) {
+    throw new Error(`${candidate.id}.operation.runner.arguments must not include credential options`);
+  }
   const requiredEnv = stringList(
     runner.requiredEnv,
     `${candidate.id}.operation.runner.requiredEnv`,
@@ -444,10 +447,9 @@ async function main(args = process.argv.slice(2)) {
       }
     }
     if (githubOutput) {
-      const notificationDue = providerApprovalNotificationDue(summary);
       await appendFile(
         githubOutput,
-        `status=${summary.status}\napproved_count=${summary.approvals.length}\nnotification_due=${notificationDue}\n`,
+        `status=${summary.status}\napproved_count=${summary.approvals.length}\n`,
       );
     }
     console.log(`provider approval expiry: ${summary.status} (${summary.approvals.length} approved)`);

--- a/tools/datapack/source-operation.mjs
+++ b/tools/datapack/source-operation.mjs
@@ -119,6 +119,9 @@ export function validateProviderApproval(candidate) {
   if (validTo < validFrom) {
     throw new Error(`${candidate.id}.providerApproval.validTo must not precede validFrom`);
   }
+  if (approval.status === "APPROVED" && validTo < new Date().toISOString().slice(0, 10)) {
+    throw new Error(`${candidate.id}.providerApproval.status is APPROVED but validTo has expired`);
+  }
   requiredText(approval.evidenceSource, `${candidate.id}.providerApproval.evidenceSource`);
   requiredDate(approval.recordedAt, `${candidate.id}.providerApproval.recordedAt`);
   return approval;

--- a/tools/datapack/source-operation.mjs
+++ b/tools/datapack/source-operation.mjs
@@ -4,6 +4,7 @@ import { pathToFileURL } from "node:url";
 
 const CANDIDATES_URL = new URL("./source-candidates.json", import.meta.url);
 const CREDENTIAL_NAME = /^(?:accesskey|accesstoken|apikey|authorization|clientsecret|credential|key|password|privatekey|refreshtoken|secret|servicekey|signature|token|xamzcredential|xamzsecuritytoken|xamzsignature|xapikey)$/;
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 
 function normalizedName(value) {
   return value.replace(/[^A-Za-z0-9]/g, "").toLowerCase();
@@ -87,6 +88,64 @@ function requireAllowedKeys(value, allowed, label) {
   if (unknown.length > 0) throw new Error(`${label} has unsupported fields: ${unknown.join(", ")}`);
 }
 
+function requiredDate(value, label) {
+  const text = requiredText(value, label);
+  const parsed = new Date(`${text}T00:00:00Z`);
+  if (!ISO_DATE.test(text) || Number.isNaN(parsed.valueOf()) || parsed.toISOString().slice(0, 10) !== text) {
+    throw new Error(`${label} must be an ISO date`);
+  }
+  return text;
+}
+
+export function validateProviderApproval(candidate) {
+  const approval = candidate?.providerApproval;
+  if (approval == null) return null;
+  if (typeof approval !== "object" || Array.isArray(approval)) {
+    throw new Error(`${candidate.id}.providerApproval must be an object`);
+  }
+  if (hasCredentialValue(approval)) {
+    throw new Error(`${candidate.id}.providerApproval secret-like values are forbidden`);
+  }
+  requireAllowedKeys(approval, new Set([
+    "status", "serviceId", "operationId", "validFrom", "validTo", "evidenceSource", "recordedAt",
+  ]), `${candidate.id}.providerApproval`);
+  if (!new Set(["APPROVED", "EXPIRED", "REVOKED"]).has(approval.status)) {
+    throw new Error(`${candidate.id}.providerApproval.status is invalid`);
+  }
+  requiredText(approval.serviceId, `${candidate.id}.providerApproval.serviceId`);
+  requiredText(approval.operationId, `${candidate.id}.providerApproval.operationId`);
+  const validFrom = requiredDate(approval.validFrom, `${candidate.id}.providerApproval.validFrom`);
+  const validTo = requiredDate(approval.validTo, `${candidate.id}.providerApproval.validTo`);
+  if (validTo < validFrom) {
+    throw new Error(`${candidate.id}.providerApproval.validTo must not precede validFrom`);
+  }
+  requiredText(approval.evidenceSource, `${candidate.id}.providerApproval.evidenceSource`);
+  requiredDate(approval.recordedAt, `${candidate.id}.providerApproval.recordedAt`);
+  return approval;
+}
+
+export function validateSourceCandidateDocument(document) {
+  if (!document || typeof document !== "object" || Array.isArray(document)) {
+    throw new Error("source candidate document must be an object");
+  }
+  if (document.schemaVersion !== 1 || document.artifactKind !== "production-source-candidates") {
+    throw new Error("source candidate document identity is invalid");
+  }
+  if (document.source !== "tools/datapack/source-candidates.json") {
+    throw new Error("source candidate document source must be repository-local");
+  }
+  requiredDate(document.updatedAt, "source candidate document.updatedAt");
+  if (!Array.isArray(document.candidates)) throw new Error("source candidate document.candidates must be an array");
+  const ids = new Set();
+  for (const candidate of document.candidates) {
+    const id = requiredText(candidate?.id, "candidate.id");
+    if (ids.has(id)) throw new Error(`duplicate candidate id: ${id}`);
+    ids.add(id);
+    validateProviderApproval(candidate);
+  }
+  return document;
+}
+
 export function validateOperation(candidate, { allowMissing = false } = {}) {
   const requestUrl = requiredHttpUrl(candidate?.requestUrl, `${candidate?.id ?? "candidate"}.requestUrl`);
   if (hasCredentialValue(candidate.requestUrl)) {
@@ -130,7 +189,9 @@ export function validateOperation(candidate, { allowMissing = false } = {}) {
   const credentialFree = auth.placement === "none";
   requireAllowedKeys(
     auth,
-    credentialFree ? new Set(["placement"]) : new Set(["env", "placement", "parameter"]),
+    credentialFree
+      ? new Set(["placement"])
+      : new Set(["env", "placement", "parameter", "valueEncoding", "loadPolicy"]),
     `${candidate.id}.operation.auth`,
   );
   const authEnv = credentialFree ? null : requiredText(auth.env, `${candidate.id}.operation.auth.env`);
@@ -140,6 +201,12 @@ export function validateOperation(candidate, { allowMissing = false } = {}) {
   const authParameter = credentialFree
     ? null
     : requiredText(auth.parameter, `${candidate.id}.operation.auth.parameter`);
+  if (auth.valueEncoding != null && auth.valueEncoding !== "url-search-params-once") {
+    throw new Error(`${candidate.id}.operation.auth.valueEncoding is invalid`);
+  }
+  if (auth.loadPolicy != null && auth.loadPolicy !== "process-env-no-shell-parsing") {
+    throw new Error(`${candidate.id}.operation.auth.loadPolicy is invalid`);
+  }
   const requiredParameters = stringList(
     operation.requiredParameters,
     `${candidate.id}.operation.requiredParameters`,
@@ -178,12 +245,14 @@ export function validateOperation(candidate, { allowMissing = false } = {}) {
 
 export function operationSummary(candidate) {
   validateOperation(candidate, { allowMissing: true });
+  validateProviderApproval(candidate);
   return {
     id: requiredText(candidate.id, "candidate.id"),
     status: candidate.admissionStatus ?? null,
     endpoint: requiredText(candidate.requestUrl, `${candidate.id}.requestUrl`),
     sampleUrl: candidate.evidence?.sampleUrl ?? null,
     responseFields: candidate.evidence?.outputFields ?? [],
+    providerApproval: candidate.providerApproval ?? null,
     operation: candidate.operation ?? null,
   };
 }
@@ -204,9 +273,20 @@ export function operationHumanSummary(summary) {
     `sample: ${summary.sampleUrl ?? "not documented"}`,
     `response fields: ${summary.responseFields.join(", ") || "not documented"}`,
   ];
+  if (summary.providerApproval) {
+    lines.push(
+      `provider approval: ${summary.providerApproval.status}`,
+      `provider operation: ${summary.providerApproval.serviceId}/${summary.providerApproval.operationId}`,
+      `approval valid: ${summary.providerApproval.validFrom}..${summary.providerApproval.validTo}`,
+    );
+  } else {
+    lines.push("provider approval: none");
+  }
   if (summary.operation) {
     lines.push(
       `auth env: ${summary.operation.auth.env ?? "not required"}`,
+      `auth value encoding: ${summary.operation.auth.valueEncoding ?? "provider default"}`,
+      `auth load policy: ${summary.operation.auth.loadPolicy ?? "runtime default"}`,
       `required params: ${summary.operation.requiredParameters.join(", ")}`,
       `response envelope: ${summary.operation.responseEnvelope}`,
       `runner: ${summary.operation.runner.command}`,
@@ -222,6 +302,7 @@ async function main(args = process.argv.slice(2)) {
   const [command, sourceId] = args.filter((arg) => arg !== "--json");
   const json = args.includes("--json");
   const document = JSON.parse(await readFile(CANDIDATES_URL, "utf8"));
+  validateSourceCandidateDocument(document);
   const operations = listOperations(document);
   if (command === "list") {
     console.log(

--- a/tools/datapack/source-operation.test.mjs
+++ b/tools/datapack/source-operation.test.mjs
@@ -185,6 +185,27 @@ test("승인된 provider의 human 요약은 승인 범위와 기간을 표시한
   assert.match(sourceOperation.operationHumanSummary(summary), /^approval valid: 2026-07-06\.\.2027-07-06$/m);
 });
 
+test("list는 만료 상태 오류를 candidate에 남기고 다른 provider를 계속 반환한다", () => {
+  const expired = candidate("expired", {
+    providerApproval: {
+      status: "APPROVED",
+      serviceId: "handicapped",
+      operationId: "transferMovement",
+      validFrom: "2020-01-01",
+      validTo: "2020-12-31",
+      evidenceSource: "owner-confirmed",
+      recordedAt: "2020-01-01",
+    },
+  });
+
+  const rows = listOperations({ candidates: [candidate("active"), expired] });
+
+  assert.deepEqual(rows.map(({ id }) => id), ["active", "expired"]);
+  assert.equal(rows[0].providerApprovalValidationError, null);
+  assert.match(rows[1].providerApprovalValidationError, /status is APPROVED but validTo has expired/);
+  assert.match(sourceOperation.operationHumanSummary(rows[1]), /^provider approval validation: .*has expired$/m);
+});
+
 test("show는 operation이 없어도 sample URL credential을 출력 전에 거부한다", () => {
   for (const sampleUrl of [
     "https://provider.example/actual-secret/items",

--- a/tools/datapack/source-operation.test.mjs
+++ b/tools/datapack/source-operation.test.mjs
@@ -124,6 +124,24 @@ test("provider 승인은 잘못된 기간과 secret-like field를 거부한다",
     }),
     /recordedAt must be an ISO date/,
   );
+  const expiredApproval = {
+    ...approval,
+    validFrom: "2020-01-01",
+    validTo: "2020-12-31",
+  };
+  assert.throws(
+    () => validateSourceCandidateDocument({
+      ...base,
+      candidates: [candidate("a", { providerApproval: expiredApproval })],
+    }),
+    /status is APPROVED but validTo has expired/,
+  );
+  const historical = { ...expiredApproval, status: "EXPIRED" };
+  assert.equal(
+    validateSourceCandidateDocument({ ...base, candidates: [candidate("a", { providerApproval: historical })] })
+      .candidates[0].providerApproval,
+    historical,
+  );
 });
 
 test("KRIC key 계약은 URLSearchParams 1회 인코딩과 shell parsing 금지를 고정한다", () => {

--- a/tools/datapack/source-operation.test.mjs
+++ b/tools/datapack/source-operation.test.mjs
@@ -157,6 +157,66 @@ test("provider 승인은 잘못된 기간과 secret-like field를 거부한다",
   );
 });
 
+test("summary는 provider 승인에 secret-like 값이 있으면 출력 전에 거부한다", () => {
+  assert.throws(
+    () => operationSummary(candidate("a", {
+      providerApproval: {
+        status: "APPROVED",
+        serviceId: "handicapped",
+        operationId: "transferMovement",
+        validFrom: "2020-01-01",
+        validTo: FUTURE_APPROVAL_DATE,
+        evidenceSource: "owner-confirmed",
+        recordedAt: "2026-07-13",
+        serviceKey: "actual-secret-value",
+      },
+    })),
+    /secret-like values are forbidden/,
+  );
+});
+
+test("provider 승인은 service와 operation이 endpoint 경로와 일치해야 한다", () => {
+  const endpoint = "https://provider.example/handicapped/transferMovement";
+  const approval = {
+    status: "APPROVED",
+    serviceId: "handicapped",
+    operationId: "transferMovement",
+    validFrom: "2020-01-01",
+    validTo: FUTURE_APPROVAL_DATE,
+    evidenceSource: "owner-confirmed",
+    recordedAt: "2026-07-13",
+  };
+  const approvedCandidate = candidate("approved", {
+    requestUrl: endpoint,
+    operation: validOperation({ endpoint }),
+    providerApproval: approval,
+  });
+
+  assert.equal(validateSourceCandidateDocument({
+    schemaVersion: 1,
+    artifactKind: "production-source-candidates",
+    source: "tools/datapack/source-candidates.json",
+    updatedAt: "2026-07-13",
+    candidates: [approvedCandidate],
+  }).candidates[0], approvedCandidate);
+
+  for (const providerApproval of [
+    { ...approval, serviceId: "different-service" },
+    { ...approval, operationId: "different-operation" },
+  ]) {
+    assert.throws(
+      () => validateSourceCandidateDocument({
+        schemaVersion: 1,
+        artifactKind: "production-source-candidates",
+        source: "tools/datapack/source-candidates.json",
+        updatedAt: "2026-07-13",
+        candidates: [{ ...approvedCandidate, providerApproval }],
+      }),
+      /providerApproval serviceId\/operationId must match operation endpoint path/,
+    );
+  }
+});
+
 test("KRIC key 계약은 URLSearchParams 1회 인코딩과 shell parsing 금지를 고정한다", () => {
   const operation = validOperation({
     auth: {

--- a/tools/datapack/source-operation.test.mjs
+++ b/tools/datapack/source-operation.test.mjs
@@ -6,6 +6,7 @@ import {
   listOperations,
   operationSummary,
   validateOperation,
+  validateSourceCandidateDocument,
 } from "./source-operation.mjs";
 import * as sourceOperation from "./source-operation.mjs";
 
@@ -63,6 +64,107 @@ test("show는 operation이 없어도 기존 endpoint와 response fields를 반�
   );
   assert.deepEqual(summary.responseFields, ["fieldA"]);
   assert.equal(summary.operation, null);
+});
+
+test("source candidate 정본은 repository 경로와 구조화된 provider 승인을 검증한다", () => {
+  const document = {
+    schemaVersion: 1,
+    artifactKind: "production-source-candidates",
+    source: "tools/datapack/source-candidates.json",
+    updatedAt: "2026-07-13",
+    candidates: [candidate("a", {
+      providerApproval: {
+        status: "APPROVED",
+        serviceId: "handicapped",
+        operationId: "transferMovement",
+        validFrom: "2026-07-06",
+        validTo: "2027-07-06",
+        evidenceSource: "owner-confirmed",
+        recordedAt: "2026-07-13",
+      },
+    })],
+  };
+
+  assert.equal(validateSourceCandidateDocument(document), document);
+  assert.deepEqual(operationSummary(document.candidates[0]).providerApproval, document.candidates[0].providerApproval);
+});
+
+test("provider 승인은 잘못된 기간과 secret-like field를 거부한다", () => {
+  const base = {
+    schemaVersion: 1,
+    artifactKind: "production-source-candidates",
+    source: "tools/datapack/source-candidates.json",
+    updatedAt: "2026-07-13",
+  };
+  const approval = {
+    status: "APPROVED",
+    serviceId: "handicapped",
+    operationId: "transferMovement",
+    validFrom: "2027-07-06",
+    validTo: "2026-07-06",
+    evidenceSource: "owner-confirmed",
+    recordedAt: "2026-07-13",
+  };
+
+  assert.throws(
+    () => validateSourceCandidateDocument({ ...base, candidates: [candidate("a", { providerApproval: approval })] }),
+    /validTo must not precede validFrom/,
+  );
+  assert.throws(
+    () => validateSourceCandidateDocument({
+      ...base,
+      candidates: [candidate("a", { providerApproval: { ...approval, validTo: "2028-07-06", serviceKey: "secret" } })],
+    }),
+    /secret-like values are forbidden/,
+  );
+  assert.throws(
+    () => validateSourceCandidateDocument({
+      ...base,
+      candidates: [candidate("a", { providerApproval: { ...approval, validTo: "2028-07-06", recordedAt: "2026-02-31" } })],
+    }),
+    /recordedAt must be an ISO date/,
+  );
+});
+
+test("KRIC key 계약은 URLSearchParams 1회 인코딩과 shell parsing 금지를 고정한다", () => {
+  const operation = validOperation({
+    auth: {
+      env: "KRIC_SERVICE_KEY",
+      placement: "query",
+      parameter: "serviceKey",
+      valueEncoding: "url-search-params-once",
+      loadPolicy: "process-env-no-shell-parsing",
+    },
+    runner: {
+      command: "node tools/datapack/probe-provider.mjs",
+      requiredEnv: ["KRIC_SERVICE_KEY"],
+    },
+  });
+
+  assert.equal(validateOperation(candidate("a", { operation })), operation);
+  const summary = operationSummary(candidate("a", { operation }));
+  assert.match(summary.operation.auth.loadPolicy, /no-shell-parsing/);
+  assert.match(sourceOperation.operationHumanSummary(summary), /^provider approval: none$/m);
+  assert.match(sourceOperation.operationHumanSummary(summary), /^auth value encoding: url-search-params-once$/m);
+  assert.match(sourceOperation.operationHumanSummary(summary), /^auth load policy: process-env-no-shell-parsing$/m);
+});
+
+test("승인된 provider의 human 요약은 승인 범위와 기간을 표시한다", () => {
+  const summary = operationSummary(candidate("a", {
+    providerApproval: {
+      status: "APPROVED",
+      serviceId: "handicapped",
+      operationId: "transferMovement",
+      validFrom: "2026-07-06",
+      validTo: "2027-07-06",
+      evidenceSource: "owner-confirmed",
+      recordedAt: "2026-07-13",
+    },
+  }));
+
+  assert.match(sourceOperation.operationHumanSummary(summary), /^provider approval: APPROVED$/m);
+  assert.match(sourceOperation.operationHumanSummary(summary), /^provider operation: handicapped\/transferMovement$/m);
+  assert.match(sourceOperation.operationHumanSummary(summary), /^approval valid: 2026-07-06\.\.2027-07-06$/m);
 });
 
 test("show는 operation이 없어도 sample URL credential을 출력 전에 거부한다", () => {

--- a/tools/datapack/source-operation.test.mjs
+++ b/tools/datapack/source-operation.test.mjs
@@ -6,7 +6,6 @@ import {
   listOperations,
   operationSummary,
   providerApprovalExpirySummary,
-  providerApprovalNotificationDue,
   validateOperation,
   validateSourceCandidateDocument,
 } from "./source-operation.mjs";
@@ -263,14 +262,6 @@ test("provider 승인 만료 요약은 갱신 window부터 경고한다", () => 
   );
 });
 
-test("provider 승인 갱신 알림은 scheduled 실행에서 UTC 하루 한 번만 허용한다", () => {
-  const warning = { status: "WARNING" };
-
-  assert.equal(providerApprovalNotificationDue(warning, { now: new Date("2027-06-06T00:23:00Z") }), true);
-  assert.equal(providerApprovalNotificationDue(warning, { now: new Date("2027-06-06T04:23:00Z") }), false);
-  assert.equal(providerApprovalNotificationDue({ status: "OK" }, { now: new Date("2027-06-06T00:23:00Z") }), false);
-});
-
 test("KRIC key 계약은 URLSearchParams 1회 인코딩과 shell parsing 금지를 고정한다", () => {
   const operation = validOperation({
     auth: {
@@ -417,6 +408,27 @@ test("validate는 endpoint URL과 runner 문자열의 credential을 거부한다
     assert.throws(
       () => validateOperation(candidate("a", { requestUrl: operation.endpoint, operation })),
       /credential values are forbidden|literal repository Node command/,
+    );
+  }
+});
+
+test("validate는 structured runner 인수의 credential option을 거부한다", () => {
+  for (const arguments_ of [
+    ["--token", "actual-secret-value"],
+    ["--service-key=actual-secret-value"],
+    ["--client_secret", "actual-secret-value"],
+  ]) {
+    assert.throws(
+      () => validateOperation(candidate("a", {
+        operation: validOperation({
+          runner: {
+            command: "node tools/datapack/probe-provider.mjs",
+            arguments: arguments_,
+            requiredEnv: ["PROVIDER_SERVICE_KEY"],
+          },
+        }),
+      })),
+      /runner\.arguments must not include credential options/,
     );
   }
 });

--- a/tools/datapack/source-operation.test.mjs
+++ b/tools/datapack/source-operation.test.mjs
@@ -10,6 +10,8 @@ import {
 } from "./source-operation.mjs";
 import * as sourceOperation from "./source-operation.mjs";
 
+const FUTURE_APPROVAL_DATE = new Date(Date.now() + (366 * 24 * 60 * 60 * 1000)).toISOString().slice(0, 10);
+
 function candidate(id, overrides = {}) {
   return {
     id,
@@ -77,8 +79,8 @@ test("source candidate 정본은 repository 경로와 구조화된 provider 승�
         status: "APPROVED",
         serviceId: "handicapped",
         operationId: "transferMovement",
-        validFrom: "2026-07-06",
-        validTo: "2027-07-06",
+        validFrom: "2020-01-01",
+        validTo: FUTURE_APPROVAL_DATE,
         evidenceSource: "owner-confirmed",
         recordedAt: "2026-07-13",
       },
@@ -142,6 +144,17 @@ test("provider 승인은 잘못된 기간과 secret-like field를 거부한다",
       .candidates[0].providerApproval,
     historical,
   );
+  const futureStart = new Date(Date.now() + (366 * 24 * 60 * 60 * 1000)).toISOString().slice(0, 10);
+  const futureEnd = new Date(Date.now() + (732 * 24 * 60 * 60 * 1000)).toISOString().slice(0, 10);
+  assert.throws(
+    () => validateSourceCandidateDocument({
+      ...base,
+      candidates: [candidate("a", {
+        providerApproval: { ...approval, validFrom: futureStart, validTo: futureEnd },
+      })],
+    }),
+    /status is APPROVED but validFrom is in the future/,
+  );
 });
 
 test("KRIC key 계약은 URLSearchParams 1회 인코딩과 shell parsing 금지를 고정한다", () => {
@@ -173,8 +186,8 @@ test("승인된 provider의 human 요약은 승인 범위와 기간을 표시한
       status: "APPROVED",
       serviceId: "handicapped",
       operationId: "transferMovement",
-      validFrom: "2026-07-06",
-      validTo: "2027-07-06",
+      validFrom: "2020-01-01",
+      validTo: FUTURE_APPROVAL_DATE,
       evidenceSource: "owner-confirmed",
       recordedAt: "2026-07-13",
     },
@@ -182,7 +195,10 @@ test("승인된 provider의 human 요약은 승인 범위와 기간을 표시한
 
   assert.match(sourceOperation.operationHumanSummary(summary), /^provider approval: APPROVED$/m);
   assert.match(sourceOperation.operationHumanSummary(summary), /^provider operation: handicapped\/transferMovement$/m);
-  assert.match(sourceOperation.operationHumanSummary(summary), /^approval valid: 2026-07-06\.\.2027-07-06$/m);
+  assert.match(
+    sourceOperation.operationHumanSummary(summary),
+    new RegExp(`^approval valid: 2020-01-01\\.\\.${FUTURE_APPROVAL_DATE}$`, "m"),
+  );
 });
 
 test("list는 만료 상태 오류를 candidate에 남기고 다른 provider를 계속 반환한다", () => {
@@ -198,12 +214,17 @@ test("list는 만료 상태 오류를 candidate에 남기고 다른 provider를 
     },
   });
 
-  const rows = listOperations({ candidates: [candidate("active"), expired] });
+  const invalidOperation = candidate("invalid-operation", {
+    operation: validOperation({ endpoint: "https://provider.example/wrong" }),
+  });
+  const rows = listOperations({ candidates: [candidate("active"), expired, invalidOperation] });
 
-  assert.deepEqual(rows.map(({ id }) => id), ["active", "expired"]);
+  assert.deepEqual(rows.map(({ id }) => id), ["active", "expired", "invalid-operation"]);
   assert.equal(rows[0].providerApprovalValidationError, null);
   assert.match(rows[1].providerApprovalValidationError, /status is APPROVED but validTo has expired/);
   assert.match(sourceOperation.operationHumanSummary(rows[1]), /^provider approval validation: .*has expired$/m);
+  assert.match(rows[2].operationValidationError, /endpoint must match requestUrl/);
+  assert.match(sourceOperation.operationHumanSummary(rows[2]), /^operation validation: .*endpoint must match requestUrl$/m);
 });
 
 test("show는 operation이 없어도 sample URL credential을 출력 전에 거부한다", () => {

--- a/tools/datapack/source-operation.test.mjs
+++ b/tools/datapack/source-operation.test.mjs
@@ -327,6 +327,19 @@ test("list는 만료 상태 오류를 candidate에 남기고 다른 provider를 
   assert.match(sourceOperation.operationHumanSummary(rows[2]), /^operation validation: .*endpoint must match requestUrl$/m);
 });
 
+test("잘못된 operation human 요약은 TypeError 대신 validation 오류를 표시한다", () => {
+  const endpoint = "https://provider.example/invalid";
+  const summary = operationSummary(candidate("invalid", {
+    operation: validOperation({ endpoint, auth: null }),
+  }));
+
+  assert.doesNotThrow(() => sourceOperation.operationHumanSummary(summary));
+  assert.match(
+    sourceOperation.operationHumanSummary(summary),
+    /^operation validation: invalid\.operation\.auth must be an object$/m,
+  );
+});
+
 test("show는 operation이 없어도 sample URL credential을 출력 전에 거부한다", () => {
   for (const sampleUrl of [
     "https://provider.example/actual-secret/items",

--- a/tools/datapack/source-operation.test.mjs
+++ b/tools/datapack/source-operation.test.mjs
@@ -6,6 +6,7 @@ import {
   listOperations,
   operationSummary,
   providerApprovalExpirySummary,
+  providerApprovalNotificationDue,
   validateOperation,
   validateSourceCandidateDocument,
 } from "./source-operation.mjs";
@@ -260,6 +261,14 @@ test("provider 승인 만료 요약은 갱신 window부터 경고한다", () => 
     () => providerApprovalExpirySummary(document, { today: "2027-07-07" }),
     /status is APPROVED but validTo has expired/,
   );
+});
+
+test("provider 승인 갱신 알림은 scheduled 실행에서 UTC 하루 한 번만 허용한다", () => {
+  const warning = { status: "WARNING" };
+
+  assert.equal(providerApprovalNotificationDue(warning, { now: new Date("2027-06-06T00:23:00Z") }), true);
+  assert.equal(providerApprovalNotificationDue(warning, { now: new Date("2027-06-06T04:23:00Z") }), false);
+  assert.equal(providerApprovalNotificationDue({ status: "OK" }, { now: new Date("2027-06-06T00:23:00Z") }), false);
 });
 
 test("KRIC key 계약은 URLSearchParams 1회 인코딩과 shell parsing 금지를 고정한다", () => {

--- a/tools/datapack/source-operation.test.mjs
+++ b/tools/datapack/source-operation.test.mjs
@@ -46,6 +46,27 @@ function validOperation(overrides = {}) {
   };
 }
 
+function providerApproval(overrides = {}) {
+  return {
+    status: "APPROVED",
+    approvalScope: "API_CREDENTIAL",
+    termsStatus: "REVIEW_REQUIRED",
+    quotaStatus: "REVIEW_REQUIRED",
+    productionUseAllowed: false,
+    serviceId: "handicapped",
+    operationId: "transferMovement",
+    validFrom: "2020-01-01",
+    validTo: FUTURE_APPROVAL_DATE,
+    renewalNoticeDays: 30,
+    evidenceReferences: [{
+      type: "OWNER_CONFIRMATION",
+      url: "https://github.com/AquilaXk/easysubway/issues/1397#issuecomment-4956908695",
+    }],
+    recordedAt: "2026-07-13",
+    ...overrides,
+  };
+}
+
 test("list는 requestUrl이 있는 source를 ID 순으로 반환한다", () => {
   const document = {
     candidates: [candidate("b"), { id: "local-file" }, candidate("a")],
@@ -76,15 +97,7 @@ test("source candidate 정본은 repository 경로와 구조화된 provider 승�
     source: "tools/datapack/source-candidates.json",
     updatedAt: "2026-07-13",
     candidates: [candidate("a", {
-      providerApproval: {
-        status: "APPROVED",
-        serviceId: "handicapped",
-        operationId: "transferMovement",
-        validFrom: "2020-01-01",
-        validTo: FUTURE_APPROVAL_DATE,
-        evidenceSource: "owner-confirmed",
-        recordedAt: "2026-07-13",
-      },
+      providerApproval: providerApproval(),
     })],
   };
 
@@ -99,15 +112,10 @@ test("provider 승인은 잘못된 기간과 secret-like field를 거부한다",
     source: "tools/datapack/source-candidates.json",
     updatedAt: "2026-07-13",
   };
-  const approval = {
-    status: "APPROVED",
-    serviceId: "handicapped",
-    operationId: "transferMovement",
+  const approval = providerApproval({
     validFrom: "2027-07-06",
     validTo: "2026-07-06",
-    evidenceSource: "owner-confirmed",
-    recordedAt: "2026-07-13",
-  };
+  });
 
   assert.throws(
     () => validateSourceCandidateDocument({ ...base, candidates: [candidate("a", { providerApproval: approval })] }),
@@ -126,6 +134,24 @@ test("provider 승인은 잘못된 기간과 secret-like field를 거부한다",
       candidates: [candidate("a", { providerApproval: { ...approval, validTo: "2028-07-06", recordedAt: "2026-02-31" } })],
     }),
     /recordedAt must be an ISO date/,
+  );
+  assert.throws(
+    () => validateSourceCandidateDocument({
+      ...base,
+      candidates: [candidate("a", {
+        providerApproval: providerApproval({ termsStatus: "APPROVED", quotaStatus: "APPROVED" }),
+      })],
+    }),
+    /productionUseAllowed must match credential, terms, and quota decisions/,
+  );
+  assert.throws(
+    () => validateSourceCandidateDocument({
+      ...base,
+      candidates: [candidate("a", {
+        providerApproval: providerApproval({ evidenceReferences: [{ type: "OWNER_CONFIRMATION", url: "chat-only" }] }),
+      })],
+    }),
+    /evidenceReferences\[0\]\.url must be a valid HTTP\(S\) URL/,
   );
   const expiredApproval = {
     ...approval,
@@ -161,16 +187,9 @@ test("provider 승인은 잘못된 기간과 secret-like field를 거부한다",
 test("summary는 provider 승인에 secret-like 값이 있으면 출력 전에 거부한다", () => {
   assert.throws(
     () => operationSummary(candidate("a", {
-      providerApproval: {
-        status: "APPROVED",
-        serviceId: "handicapped",
-        operationId: "transferMovement",
-        validFrom: "2020-01-01",
-        validTo: FUTURE_APPROVAL_DATE,
-        evidenceSource: "owner-confirmed",
-        recordedAt: "2026-07-13",
+      providerApproval: providerApproval({
         serviceKey: "actual-secret-value",
-      },
+      }),
     })),
     /secret-like values are forbidden/,
   );
@@ -178,15 +197,7 @@ test("summary는 provider 승인에 secret-like 값이 있으면 출력 전에 �
 
 test("provider 승인은 service와 operation이 endpoint 경로와 일치해야 한다", () => {
   const endpoint = "https://provider.example/handicapped/transferMovement";
-  const approval = {
-    status: "APPROVED",
-    serviceId: "handicapped",
-    operationId: "transferMovement",
-    validFrom: "2020-01-01",
-    validTo: FUTURE_APPROVAL_DATE,
-    evidenceSource: "owner-confirmed",
-    recordedAt: "2026-07-13",
-  };
+  const approval = providerApproval();
   const approvedCandidate = candidate("approved", {
     requestUrl: endpoint,
     operation: validOperation({ endpoint }),
@@ -228,16 +239,10 @@ test("provider 승인 만료 요약은 갱신 window부터 경고한다", () => 
     candidates: [candidate("approved", {
       requestUrl: endpoint,
       operation: validOperation({ endpoint }),
-      providerApproval: {
-        status: "APPROVED",
-        serviceId: "handicapped",
-        operationId: "transferMovement",
+      providerApproval: providerApproval({
         validFrom: "2026-07-06",
         validTo: "2027-07-06",
-        renewalNoticeDays: 30,
-        evidenceSource: "owner-confirmed",
-        recordedAt: "2026-07-13",
-      },
+      }),
     })],
   };
 
@@ -282,15 +287,7 @@ test("KRIC key 계약은 URLSearchParams 1회 인코딩과 shell parsing 금지�
 
 test("승인된 provider의 human 요약은 승인 범위와 기간을 표시한다", () => {
   const summary = operationSummary(candidate("a", {
-    providerApproval: {
-      status: "APPROVED",
-      serviceId: "handicapped",
-      operationId: "transferMovement",
-      validFrom: "2020-01-01",
-      validTo: FUTURE_APPROVAL_DATE,
-      evidenceSource: "owner-confirmed",
-      recordedAt: "2026-07-13",
-    },
+    providerApproval: providerApproval(),
   }));
 
   assert.match(sourceOperation.operationHumanSummary(summary), /^provider approval: APPROVED$/m);
@@ -303,15 +300,11 @@ test("승인된 provider의 human 요약은 승인 범위와 기간을 표시한
 
 test("list는 만료 상태 오류를 candidate에 남기고 다른 provider를 계속 반환한다", () => {
   const expired = candidate("expired", {
-    providerApproval: {
-      status: "APPROVED",
-      serviceId: "handicapped",
-      operationId: "transferMovement",
+    providerApproval: providerApproval({
       validFrom: "2020-01-01",
       validTo: "2020-12-31",
-      evidenceSource: "owner-confirmed",
       recordedAt: "2020-01-01",
-    },
+    }),
   });
 
   const invalidOperation = candidate("invalid-operation", {

--- a/tools/datapack/source-operation.test.mjs
+++ b/tools/datapack/source-operation.test.mjs
@@ -5,6 +5,7 @@ import test from "node:test";
 import {
   listOperations,
   operationSummary,
+  providerApprovalExpirySummary,
   validateOperation,
   validateSourceCandidateDocument,
 } from "./source-operation.mjs";
@@ -215,6 +216,45 @@ test("provider 승인은 service와 operation이 endpoint 경로와 일치해야
       /providerApproval serviceId\/operationId must match operation endpoint path/,
     );
   }
+});
+
+test("provider 승인 만료 요약은 갱신 window부터 경고한다", () => {
+  const endpoint = "https://provider.example/handicapped/transferMovement";
+  const document = {
+    schemaVersion: 1,
+    artifactKind: "production-source-candidates",
+    source: "tools/datapack/source-candidates.json",
+    updatedAt: "2026-07-13",
+    candidates: [candidate("approved", {
+      requestUrl: endpoint,
+      operation: validOperation({ endpoint }),
+      providerApproval: {
+        status: "APPROVED",
+        serviceId: "handicapped",
+        operationId: "transferMovement",
+        validFrom: "2026-07-06",
+        validTo: "2027-07-06",
+        renewalNoticeDays: 30,
+        evidenceSource: "owner-confirmed",
+        recordedAt: "2026-07-13",
+      },
+    })],
+  };
+
+  assert.equal(providerApprovalExpirySummary(document, { today: "2027-06-05" }).status, "OK");
+  assert.deepEqual(providerApprovalExpirySummary(document, { today: "2027-06-06" }), {
+    status: "WARNING",
+    approvals: [{
+      candidateId: "approved",
+      validTo: "2027-07-06",
+      daysUntilExpiry: 30,
+      renewalNoticeDays: 30,
+    }],
+  });
+  assert.throws(
+    () => providerApprovalExpirySummary(document, { today: "2027-07-07" }),
+    /status is APPROVED but validTo has expired/,
+  );
 });
 
 test("KRIC key 계약은 URLSearchParams 1회 인코딩과 shell parsing 금지를 고정한다", () => {


### PR DESCRIPTION
## 관련 이슈

Closes #2085
Refs #1397
Refs #1416
Refs #1621

## 작업 배경

- 외부 Downloads XLSX가 source 후보의 정본처럼 참조되어 agent와 CI가 최신 승인·API key 전달 양식을 독립적으로 판정하기 어려웠습니다.
- KRIC key는 shell parsing 경로를 사용하면 안 된다는 오너 결정을 계약에 반영해야 했습니다.

## 작업 내용

- `tools/datapack/source-candidates.json`을 repository-local 정본으로 선언했습니다.
- KRIC `handicapped/transferMovement` 승인기간과 operation 계약을 구조화했습니다.
- key 값 대신 env 이름, query parameter, 1회 URL 인코딩, shell parsing 금지, 필수 parameter, runner를 API catalog에 노출했습니다.
- 승인 날짜·기간·secret-like field·중복 ID를 검증하는 contract를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/datapack/source-operation.test.mjs tools/ci/api-catalog.test.mjs tools/ci/repository-contract.test.mjs` — 223 tests, 223 pass
  - `node --test tools/datapack/*.test.mjs` — 534 tests, 534 pass
  - `node tools/datapack/source-operation.mjs validate` — 5 operation contracts valid
  - `node tools/ci/api-catalog.mjs show provider:kric-transfer-movement-standard --json` — 승인·auth·runner 계약 출력 확인
  - `git diff --check` — 통과

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| source candidate 계약 | Node.js | contract test | PR CI 및 위 명령 | PASS |
| KRIC key 전달 양식 | API catalog | JSON/human 출력 | secret 값 없이 env·parameter·load policy 확인 | PASS |
| UI·접근성·배포 | 해당 없음 | 제품 동작·배포 변경 없음 | evidence 불필요 | N/A |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `providerApproval`이 API access 승인만 표현하고 production admission을 자동 승격하지 않는지, `process-env-no-shell-parsing`이 secret 노출 없이 catalog에 유지되는지 확인해 주세요.

## 리스크

- 기존 consumer가 `source` 문자열을 외부 XLSX 파일명으로 고정했다면 실패합니다. repository contract와 source-operation validator가 새 경계를 고정합니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 소스 후보 문서에 제공자 승인 상태, 유효 기간, 증거 정보가 추가되었습니다.
  - API 호출 방식, 인증 키 전달 형식, 필수 파라미터, 응답 구조와 실행 정책이 더욱 구체적으로 문서화되었습니다.
  - 승인 정보와 운영 설정의 형식 및 날짜 유효성이 강화되었습니다.
  - 검증 명령이 문서 전체와 제공자 승인 정보를 함께 검사합니다.
  - 요약 결과에 승인 상태, 유효 기간 및 인증 설정이 표시됩니다.

- **테스트**
  - 승인 정보, 키 전달 형식, 만료·미래 승인일 등 다양한 검증 시나리오가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->