### PR TITLE
[Style] #2089 시그니처 브랜드 색 1차 적용 — 온보딩 강조 행·CTA

### DIFF
--- a/apps/mobile/lib/accessible_design.dart
+++ b/apps/mobile/lib/accessible_design.dart
@@ -51,6 +51,11 @@ class EasySubwayAccessibleColors {
   /// 과거 navy 액센트. 단일 브랜드 액센트로 통일했다. 신규 코드는 [primary] 사용.
   static const brand = primary;
 
+  /// 시그니처 브랜드 색(라이트 단일 모드). 오너 결정(#2089)으로 1차 적용 —
+  /// 온보딩 시작 화면의 강조 행·CTA에만 쓴다. 흰 글자 대비 5.7:1(AA 통과).
+  /// 이 앱은 라이트 단일 모드(#1917 revert)라 다크 변형을 두지 않는다.
+  static const brandSignature = Color(0xFF7C3AED);
+
   /// 다크 히어로 등 짙은 브랜드 표면(레거시). 신규 화면에서는 사용하지 않는다.
   static const brandDark = Color(0xFF071B2F);
 

--- a/apps/mobile/lib/onboarding.dart
+++ b/apps/mobile/lib/onboarding.dart
@@ -223,7 +223,9 @@ class StartScreen extends StatelessWidget {
             final topGap = (constraints.maxHeight * 0.28).clamp(72.0, 200.0);
             // SafeArea(bottom: true) 자손이라 하단 인셋은 SafeArea가 이미 적용한다.
             // viewPadding.bottom을 또 더하면 이중 가산이므로 토큰 여백만 쓴다.
-            const bottomGap = EasySubwaySpacing.xxl;
+            // #2089(오너 실기기 검수): CTA가 화면 최하단에 과하게 붙어 있어
+            // 하단 여백을 xxl의 2배로 늘려 버튼을 세로 리듬 안에서 위로 올린다.
+            const bottomGap = EasySubwaySpacing.xxl * 2;
             return SingleChildScrollView(
               child: ConstrainedBox(
                 constraints: BoxConstraints(minHeight: constraints.maxHeight),
@@ -242,21 +244,21 @@ class StartScreen extends StatelessWidget {
                         Semantics(
                           header: true,
                           child: Text.rich(
-                            // 핵심 가치 카피 3행(#2081). #2089: 2행("갈 수 있는
-                            // 길을")만 시그니처 브랜드 색으로 강조하고 1·3행은
-                            // 기존 잉크 토큰을 유지한다. 스크린리더가 읽는 전체
-                            // 문자열은 그대로 보존된다.
+                            // 핵심 가치 카피 3행(#2081). #2089: 2행 중 "갈 수 있는
+                            // 길"까지만 시그니처 브랜드 색으로 강조하고, 조사 "을"과
+                            // 1·3행은 기존 잉크 토큰을 유지한다(오너 실기기 검수).
+                            // 스크린리더가 읽는 전체 문자열은 그대로 보존된다.
                             const TextSpan(
                               children: [
                                 TextSpan(text: '빠른 길보다\n'),
                                 TextSpan(
-                                  text: '갈 수 있는 길을',
+                                  text: '갈 수 있는 길',
                                   style: TextStyle(
                                     color: EasySubwayAccessibleColors
                                         .brandSignature,
                                   ),
                                 ),
-                                TextSpan(text: '\n안내합니다'),
+                                TextSpan(text: '을\n안내합니다'),
                               ],
                             ),
                             style: const TextStyle(
@@ -281,6 +283,12 @@ class StartScreen extends StatelessWidget {
                               foregroundColor:
                                   EasySubwayAccessibleColors.surface,
                               minimumSize: const Size.fromHeight(58),
+                              // #2089(오너 실기기 검수): 58px 버튼 대비 라벨이 작아
+                              // 보여 글자를 키운다(20/w700, 가독 우선).
+                              textStyle: const TextStyle(
+                                fontSize: 20,
+                                fontWeight: FontWeight.w700,
+                              ),
                               shape: RoundedRectangleBorder(
                                 borderRadius: BorderRadius.circular(
                                   EasySubwayRadius.control,

--- a/apps/mobile/lib/onboarding.dart
+++ b/apps/mobile/lib/onboarding.dart
@@ -241,10 +241,25 @@ class StartScreen extends StatelessWidget {
                         SizedBox(height: topGap),
                         Semantics(
                           header: true,
-                          child: const Text(
-                            // 핵심 가치 카피 3행(#2081). 강조는 무채색 잉크로 통일.
-                            '빠른 길보다\n갈 수 있는 길을\n안내합니다',
-                            style: TextStyle(
+                          child: Text.rich(
+                            // 핵심 가치 카피 3행(#2081). #2089: 2행("갈 수 있는
+                            // 길을")만 시그니처 브랜드 색으로 강조하고 1·3행은
+                            // 기존 잉크 토큰을 유지한다. 스크린리더가 읽는 전체
+                            // 문자열은 그대로 보존된다.
+                            const TextSpan(
+                              children: [
+                                TextSpan(text: '빠른 길보다\n'),
+                                TextSpan(
+                                  text: '갈 수 있는 길을',
+                                  style: TextStyle(
+                                    color: EasySubwayAccessibleColors
+                                        .brandSignature,
+                                  ),
+                                ),
+                                TextSpan(text: '\n안내합니다'),
+                              ],
+                            ),
+                            style: const TextStyle(
                               color: EasySubwayAccessibleColors.text,
                               fontSize: 40,
                               fontWeight: FontWeight.w800,
@@ -259,8 +274,10 @@ class StartScreen extends StatelessWidget {
                             key: const Key('startScreenStartButton'),
                             onPressed: onStart,
                             style: FilledButton.styleFrom(
+                              // #2089: 시작 CTA만 시그니처 브랜드 색 채움 +
+                              // 흰 글자(대비 5.7:1, AA 통과).
                               backgroundColor:
-                                  EasySubwayAccessibleColors.primary,
+                                  EasySubwayAccessibleColors.brandSignature,
                               foregroundColor:
                                   EasySubwayAccessibleColors.surface,
                               minimumSize: const Size.fromHeight(58),

--- a/apps/mobile/lib/onboarding.dart
+++ b/apps/mobile/lib/onboarding.dart
@@ -283,10 +283,10 @@ class StartScreen extends StatelessWidget {
                               foregroundColor:
                                   EasySubwayAccessibleColors.surface,
                               minimumSize: const Size.fromHeight(58),
-                              // #2089(오너 실기기 검수): 58px 버튼 대비 라벨이 작아
-                              // 보여 글자를 키운다(20/w700, 가독 우선).
+                              // #2089(오너 실기기 검수 2차): 58px 버튼 대비 라벨이
+                              // 여전히 작아 보여 글자를 더 키운다(22/w700, 가독 우선).
                               textStyle: const TextStyle(
-                                fontSize: 20,
+                                fontSize: 22,
                                 fontWeight: FontWeight.w700,
                               ),
                               shape: RoundedRectangleBorder(

--- a/apps/mobile/test/onboarding_test.dart
+++ b/apps/mobile/test/onboarding_test.dart
@@ -124,7 +124,7 @@ void main() {
 
   testWidgets('시작 화면 CTA는 시그니처 브랜드 색 채움 + 흰 글자 + 키운 라벨이다', (tester) async {
     // #2089: '시작하기' CTA만 브랜드 색으로 채우고 글자는 흰색(대비 5.7:1, AA).
-    // 오너 실기기 검수로 라벨을 키운다(20/w700).
+    // 오너 실기기 검수 2차로 라벨을 더 키운다(22/w700).
     await tester.pumpWidget(MaterialApp(home: StartScreen(onStart: () {})));
 
     final button = tester.widget<FilledButton>(
@@ -141,7 +141,7 @@ void main() {
     );
     // 라벨을 키워 58px 버튼과 균형을 맞춘다.
     final textStyle = style.textStyle?.resolve(<WidgetState>{});
-    expect(textStyle?.fontSize, 20);
+    expect(textStyle?.fontSize, 22);
     expect(textStyle?.fontWeight, FontWeight.w700);
   });
 

--- a/apps/mobile/test/onboarding_test.dart
+++ b/apps/mobile/test/onboarding_test.dart
@@ -90,12 +90,12 @@ void main() {
     semanticsHandle.dispose();
   });
 
-  testWidgets('시작 화면 타이틀은 2행("갈 수 있는 길을")만 시그니처 브랜드 색이고 1·3행은 잉크 토큰이다', (
+  testWidgets('시작 화면 타이틀은 "갈 수 있는 길"까지만 브랜드 색이고 조사 "을"·1·3행은 잉크 토큰이다', (
     tester,
   ) async {
-    // #2089: 시그니처 브랜드 색 1차 적용 — 강조는 2행 한 행에만 고정한다.
-    // Text.rich 전환 후에도 스크린리더가 읽는 전체 문자열은 그대로 유지되고,
-    // span별 색만 브랜드/잉크로 갈린다.
+    // #2089(오너 실기기 검수): 강조는 2행 중 "갈 수 있는 길"까지로 고정하고
+    // 조사 "을"은 잉크로 남긴다. Text.rich 전환 후에도 스크린리더가 읽는 전체
+    // 문자열은 그대로 유지되고, span별 색만 브랜드/잉크로 갈린다.
     await tester.pumpWidget(MaterialApp(home: StartScreen(onStart: () {})));
 
     final titleWidget = tester.widget<Text>(
@@ -111,19 +111,20 @@ void main() {
     // 1행: 브랜드 색을 쓰지 않는다(루트 스타일의 잉크 토큰 상속).
     expect(children[0].text, '빠른 길보다\n');
     expect(children[0].style?.color, isNull);
-    // 2행: 시그니처 브랜드 색.
-    expect(children[1].text, '갈 수 있는 길을');
+    // 2행 강조: "갈 수 있는 길"까지만 시그니처 브랜드 색.
+    expect(children[1].text, '갈 수 있는 길');
     expect(children[1].style?.color, EasySubwayAccessibleColors.brandSignature);
-    // 3행: 브랜드 색을 쓰지 않는다.
-    expect(children[2].text, '\n안내합니다');
+    // 조사 "을"과 3행: 브랜드 색을 쓰지 않는다.
+    expect(children[2].text, '을\n안내합니다');
     expect(children[2].style?.color, isNull);
 
     // 루트 스타일은 기존 잉크 토큰을 유지한다.
     expect(titleWidget.style?.color, EasySubwayAccessibleColors.text);
   });
 
-  testWidgets('시작 화면 CTA는 시그니처 브랜드 색 채움 + 흰 글자다', (tester) async {
+  testWidgets('시작 화면 CTA는 시그니처 브랜드 색 채움 + 흰 글자 + 키운 라벨이다', (tester) async {
     // #2089: '시작하기' CTA만 브랜드 색으로 채우고 글자는 흰색(대비 5.7:1, AA).
+    // 오너 실기기 검수로 라벨을 키운다(20/w700).
     await tester.pumpWidget(MaterialApp(home: StartScreen(onStart: () {})));
 
     final button = tester.widget<FilledButton>(
@@ -138,6 +139,10 @@ void main() {
       style.foregroundColor?.resolve(<WidgetState>{}),
       EasySubwayAccessibleColors.surface,
     );
+    // 라벨을 키워 58px 버튼과 균형을 맞춘다.
+    final textStyle = style.textStyle?.resolve(<WidgetState>{});
+    expect(textStyle?.fontSize, 20);
+    expect(textStyle?.fontWeight, FontWeight.w700);
   });
 
   testWidgets('시작 화면은 소형 화면(320×568)에서도 카피 3행과 CTA를 오버플로 없이 렌더한다', (
@@ -222,10 +227,11 @@ void main() {
       find.byKey(const Key('startScreenStartButton')),
     );
 
-    // SafeArea 인셋(34) + 앱 토큰 여백(xxl)만 기대한다. 이중 가산 금지.
+    // SafeArea 인셋(34) + 앱 토큰 여백(xxl*2)만 기대한다. 이중 가산 금지.
+    // #2089: 오너 실기기 검수로 CTA 하단 여백을 xxl*2로 올렸다.
     expect(
       screenBottom - buttonRect.bottom,
-      closeTo(34 + EasySubwaySpacing.xxl, 0.5),
+      closeTo(34 + EasySubwaySpacing.xxl * 2, 0.5),
     );
   });
 

--- a/apps/mobile/test/onboarding_test.dart
+++ b/apps/mobile/test/onboarding_test.dart
@@ -90,6 +90,56 @@ void main() {
     semanticsHandle.dispose();
   });
 
+  testWidgets('시작 화면 타이틀은 2행("갈 수 있는 길을")만 시그니처 브랜드 색이고 1·3행은 잉크 토큰이다', (
+    tester,
+  ) async {
+    // #2089: 시그니처 브랜드 색 1차 적용 — 강조는 2행 한 행에만 고정한다.
+    // Text.rich 전환 후에도 스크린리더가 읽는 전체 문자열은 그대로 유지되고,
+    // span별 색만 브랜드/잉크로 갈린다.
+    await tester.pumpWidget(MaterialApp(home: StartScreen(onStart: () {})));
+
+    final titleWidget = tester.widget<Text>(
+      find.text('빠른 길보다\n갈 수 있는 길을\n안내합니다'),
+    );
+    final rootSpan = titleWidget.textSpan! as TextSpan;
+    final children = rootSpan.children!.cast<TextSpan>();
+
+    // 3개 span으로 나뉘고, 합친 평문은 기존 카피 3행과 동일하다.
+    expect(children, hasLength(3));
+    expect(rootSpan.toPlainText(), '빠른 길보다\n갈 수 있는 길을\n안내합니다');
+
+    // 1행: 브랜드 색을 쓰지 않는다(루트 스타일의 잉크 토큰 상속).
+    expect(children[0].text, '빠른 길보다\n');
+    expect(children[0].style?.color, isNull);
+    // 2행: 시그니처 브랜드 색.
+    expect(children[1].text, '갈 수 있는 길을');
+    expect(children[1].style?.color, EasySubwayAccessibleColors.brandSignature);
+    // 3행: 브랜드 색을 쓰지 않는다.
+    expect(children[2].text, '\n안내합니다');
+    expect(children[2].style?.color, isNull);
+
+    // 루트 스타일은 기존 잉크 토큰을 유지한다.
+    expect(titleWidget.style?.color, EasySubwayAccessibleColors.text);
+  });
+
+  testWidgets('시작 화면 CTA는 시그니처 브랜드 색 채움 + 흰 글자다', (tester) async {
+    // #2089: '시작하기' CTA만 브랜드 색으로 채우고 글자는 흰색(대비 5.7:1, AA).
+    await tester.pumpWidget(MaterialApp(home: StartScreen(onStart: () {})));
+
+    final button = tester.widget<FilledButton>(
+      find.byKey(const Key('startScreenStartButton')),
+    );
+    final style = button.style!;
+    expect(
+      style.backgroundColor?.resolve(<WidgetState>{}),
+      EasySubwayAccessibleColors.brandSignature,
+    );
+    expect(
+      style.foregroundColor?.resolve(<WidgetState>{}),
+      EasySubwayAccessibleColors.surface,
+    );
+  });
+
   testWidgets('시작 화면은 소형 화면(320×568)에서도 카피 3행과 CTA를 오버플로 없이 렌더한다', (
     tester,
   ) async {


### PR DESCRIPTION
## 관련 이슈

Closes #2089

## 작업 배경

- 오너 결정(2026-07-13)으로 시그니처 브랜드 색 `#7C3AED`를 1차 도입한다. 확장 리스크를 줄이기 위해 온보딩 시작 화면(강조 행·CTA)에만 한정 적용한다.
- 이 앱은 라이트 단일 모드로 확정됐다(#1917 revert). 따라서 브랜드 색은 라이트 토큰 하나만 정의하고 다크 변형은 두지 않는다.

## 작업 내용

- `EasySubwayAccessibleColors.brandSignature`(`#7C3AED`) 토큰을 추가했다. 화면 로컬 색 상수 금지 가드를 지키려 토큰 정의부(`accessible_design.dart`)에 둔다.
- `StartScreen` 타이틀을 `Text.rich`로 전환해 2행 중 "갈 수 있는 길"까지만 브랜드 색으로 강조하고, 조사 "을"과 1·3행은 기존 잉크 토큰(`text`)을 유지한다. `Semantics(header: true)`와 스크린리더가 읽는 전체 문자열(`빠른 길보다\n갈 수 있는 길을\n안내합니다`)은 그대로 보존된다.
- 시작 CTA(`FilledButton`) 채움을 `primary`에서 `brandSignature`로 전환하고 글자는 흰색을 유지했다.
- 강조 경계·CTA 색·CTA 라벨 크기(20/w700)를 고정하는 위젯 테스트를 추가·갱신하고, CTA 하단 여백 검증 테스트를 새 값으로 갱신했다.
- 범위 밖(다른 화면·활성 상태·탭·온보딩 다른 단계)은 건드리지 않았다.

### 오너 실기기 검수 반영 (2026-07-13, #2089 코멘트 정본)

- 강조 경계 정정: 브랜드 색을 "갈 수 있는 길"까지로 좁히고 조사 "을"은 잉크로 남겼다(TextSpan 분할·스타일 검증 테스트 갱신).
- CTA 라벨 확대: 58px 버튼 대비 작아 보이던 "시작하기"를 `textStyle` 20/w700로 키웠다(디자인 가드에 폰트 크기 예산 없음 확인).
- CTA 위치 상향: 하단 여백을 `EasySubwaySpacing.xxl`에서 `xxl * 2`로 늘려 버튼을 세로 리듬 안에서 위로 올렸다(소형 화면 오버플로 테스트 유지).

## 검증

- 실행한 명령과 결과:
  - `flutter test test/onboarding_test.dart test/onboarding_app_flow_test.dart test/design_guard_test.dart test/design_tokens_test.dart test/widget_test.dart` → All tests passed (304).
  - `flutter analyze` → No issues found.
  - 대비 실측: `#7C3AED` vs 흰색 = 5.65:1(≈5.7:1) — 본문 AA(4.5:1) 및 대형 타이틀 AA(3:1) 통과.

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 온보딩 시작 화면 강조 경계·CTA 렌더(오너 검수 반영본) | Android (SM A175N, debug) | 실기기 재설치·재캡처 | 로컬 evidence: `apps/mobile/docs/2089-qa/2089-start-light.png` (gitignore, 로컬 전용) | "갈 수 있는 길"까지만 브랜드 색·조사 "을" 잉크, CTA 라벨 확대·위치 상향 확인 |
| 강조 경계 정정("을" 잉크) | 단위/위젯 | 위젯 테스트 | `test/onboarding_test.dart`("갈 수 있는 길"까지만 브랜드 색) | 통과 |
| CTA 라벨 확대(20/w700) | 단위/위젯 | 위젯 테스트 | `test/onboarding_test.dart`(CTA 라벨 크기 검증) | 통과 |
| CTA 하단 여백 상향(xxl*2) | 단위/위젯 | 위젯 테스트 | `test/onboarding_test.dart`(버튼 하단 여백 검증) | 통과 |
| 강조 행/CTA 색 회귀 방지 | 단위/위젯 | 위젯 테스트 | `test/onboarding_test.dart`(CTA 브랜드 색·흰 글자) | 통과 |
| 흰 글자 대비(AA) | 산식 | WCAG 대비 계산 | `#7C3AED` vs 흰색 5.7:1 | AA 통과 |
| 다크 모드 대비 | — | — | 앱이 라이트 단일 모드(#1917 revert)라 해당 없음 | N/A |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음 (1.0.3) — 시각 폴리시 한정, #2081 선례와 동일
- mobile versionCode: 변경 없음 (10004)
- datapack version: 영향 없음
- route contract: 영향 없음
- realtime contract: 영향 없음
- backend identity: 영향 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `onboarding.dart` `StartScreen` 타이틀의 `Text.rich` 전환 — 2행 span에만 `brandSignature`가 들어가고 1·3행은 루트 잉크 스타일을 상속하는지.
  - `find.text('빠른 길보다\n갈 수 있는 길을\n안내합니다')`와 header 시맨틱스 매처가 `Text.rich` 전환 후에도 그대로 통과하는지(전체 문자열 보존).
  - `brandSignature` 토큰이 `accessible_design.dart` 정의부에 있어 화면 로컬 색 상수 가드에 걸리지 않는지.

## 리스크

- 브랜드 색 도입 범위를 온보딩 시작 화면으로 한정했으므로 다른 화면/상태 회귀 위험은 없다.
- 라이트 단일 모드라 다크 대비 리스크는 해당 없음.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
