### PR TITLE
[Fix] API 운영 계약 리뷰 후속 보완

### DIFF
--- a/.github/workflows/datapack-expiry-alert.yml
+++ b/.github/workflows/datapack-expiry-alert.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: datapack-expiry-alert-${{ github.workflow }}-${{ github.ref }}
+  group: datapack-expiry-alert-${{ github.workflow }}-${{ github.ref }}-${{ github.event.schedule || github.event_name }}
   cancel-in-progress: true
 
 permissions:

--- a/tools/ci/api-catalog.mjs
+++ b/tools/ci/api-catalog.mjs
@@ -263,8 +263,10 @@ function humanSummary(entry) {
     );
   }
   if (entry.operation?.runner?.command) {
-    lines.push(`runner: ${[entry.operation.runner.command, ...(entry.operation.runner.arguments ?? [])].join(" ")}`);
-    lines.push(`runner env: ${(entry.operation.runner.requiredEnv ?? []).join(", ") || "none"}`);
+    lines.push(
+      `runner: ${[entry.operation.runner.command, ...(entry.operation.runner.arguments ?? [])].join(" ")}`,
+      `runner env: ${(entry.operation.runner.requiredEnv ?? []).join(", ") || "none"}`,
+    );
   }
   if (entry.operation?.auth) lines.push(`auth env: ${entry.operation.auth.env ?? "not required"}`);
   return lines.join("\n");

--- a/tools/ci/api-catalog.mjs
+++ b/tools/ci/api-catalog.mjs
@@ -264,6 +264,7 @@ function humanSummary(entry) {
   }
   if (entry.operation?.runner?.command) {
     lines.push(`runner: ${[entry.operation.runner.command, ...(entry.operation.runner.arguments ?? [])].join(" ")}`);
+    lines.push(`runner env: ${(entry.operation.runner.requiredEnv ?? []).join(", ") || "none"}`);
   }
   if (entry.operation?.auth) lines.push(`auth env: ${entry.operation.auth.env ?? "not required"}`);
   return lines.join("\n");

--- a/tools/ci/api-catalog.test.mjs
+++ b/tools/ci/api-catalog.test.mjs
@@ -335,6 +335,7 @@ test("프로젝트 catalog는 KRIC 승인과 shell 없는 key 전달 양식을 �
     stdout,
     /^runner: node tools\/datapack\/collect-kric-source-candidate-evidence\.mjs --candidate kric-transfer-movement-standard$/m,
   );
+  assert.match(stdout, /^runner env: KRIC_SERVICE_KEY, RUNNER_TEMP$/m);
   assert.match(stdout, /^provider credential: APPROVED$/m);
   assert.match(stdout, /^provider approval scope: API_CREDENTIAL$/m);
   assert.match(stdout, /^provider terms: REVIEW_REQUIRED$/m);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -13945,7 +13945,10 @@ test("데이터팩 만료 감시 workflow는 SLA 임계보다 촘촘한 cron으�
   assert.match(workflow, /schedule:[\s\S]*cron: "41 0 \* \* \*"/);
   assert.match(workflow, /workflow_dispatch:/);
   assert.match(workflow, /permissions:\s*\n\s*contents: read/);
-  assert.match(workflow, /concurrency:\s*\n\s*group: /);
+  assert.match(
+    workflow,
+    /concurrency:\s*\n\s*group: datapack-expiry-alert-\$\{\{ github\.workflow \}\}-\$\{\{ github\.ref \}\}-\$\{\{ github\.event\.schedule \|\| github\.event_name \}\}/,
+  );
 
   // 기존 데이터팩 릴리스 workflow와 동일하게 action SHA를 고정한다.
   const releaseWorkflow = read(".github/workflows/datapack-release.yml");


### PR DESCRIPTION
## 관련 이슈

Closes #2092
Refs #2085
Refs #2088

## 작업 배경

- #2088 병합 직후 current-head fresh review에서 cron concurrency 충돌과 agent runner 환경변수 누락을 확인했다.

## 작업 내용

- 데이터팩 만료 감시와 provider 승인 감시의 concurrency group을 schedule별로 분리했다.
- `workflow_dispatch`에는 `github.event_name` fallback을 사용해 수동 실행 group을 안정적으로 유지했다.
- API catalog human 출력에 runner의 모든 필수 환경변수를 표시했다.
- 두 동작의 회귀 계약 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/api-catalog.test.mjs tools/ci/repository-contract.test.mjs tools/datapack/source-operation.test.mjs` — 224/224 통과
  - `node tools/ci/api-catalog.mjs validate` — 223개 catalog 유효
  - `node tools/datapack/source-operation.mjs validate` — 5개 operation contract 유효
  - `git diff --check origin/main...HEAD` — 통과

## 검증 증거

UI·접근성·수동 QA 변경이 없는 workflow/CLI 계약 수정이며 자동 테스트 결과를 증거로 사용한다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| cron concurrency 분리 | GitHub Actions | repository contract test | 로컬 224/224 테스트 로그 | 통과 |
| runner 필수 env 출력 | Node CLI | API catalog test 및 validator | 로컬 224/224, catalog 223개 유효 | 통과 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 서로 다른 schedule event가 같은 concurrency group을 공유하지 않는지, `requiredEnv`가 human 출력에 모두 노출되는지 확인한다.

## 리스크

- workflow expression의 fallback이 GitHub Actions expression 문법과 맞아야 한다. repository contract와 CI로 고정한다.
- provider key 값은 출력하지 않고 환경변수 이름만 표시한다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
