### PR TITLE
[Feat] 권역별 실시간 provider 판정 완결

### DIFF
--- a/apps/mobile/release/datapack-release-readiness-gate.json
+++ b/apps/mobile/release/datapack-release-readiness-gate.json
@@ -71,6 +71,7 @@
   "requiredArtifacts": {
     "routeAccuracyReport": "artifacts/route-accuracy-report.json",
     "realtimeProviderCoverageReport": "artifacts/realtime-provider-coverage-report.json",
+    "regionalRealtimeProviderDecisionReport": "tools/realtime/regional-realtime-provider-decision-report.json",
     "routeAccessibilityRegressionReport": "artifacts/route-accessibility-regression-report.json",
     "routeGraphCoverageReport": "artifacts/route-graph-coverage-report.json",
     "routeV2ContractReport": "artifacts/route-v2-contract-report.json",
@@ -86,6 +87,7 @@
     "node --test tools/datapack/*.test.mjs tools/routes/*.test.mjs",
     "node tools/routes/evaluate-eta-accuracy.mjs ...",
     "node tools/routes/build-route-graph-coverage-report.mjs --input artifacts/route-graph-coverage-input.json --output artifacts/route-graph-coverage-report.json",
+    "node tools/routes/build-regional-realtime-provider-decision-report.mjs --targets tools/datapack/nationwide-coverage-targets.json --contract tools/realtime/regional-realtime-provider-decisions.json --output tools/realtime/regional-realtime-provider-decision-report.json",
     "node tools/routes/check-route-commercialization-gate.mjs --gate apps/mobile/release/route-commercialization-gate.json --accuracy artifacts/route-accuracy-report.json --accessibility artifacts/route-accessibility-regression-report.json --coverage artifacts/realtime-provider-coverage-report.json --routeGraphCoverage artifacts/route-graph-coverage-report.json --contract artifacts/route-v2-contract-report.json",
     "node tools/datapack/build-route-graph-topology-report.mjs --manifest ... --root ... --output artifacts/route-graph-topology-report.json",
     "node tools/datapack/report-coverage-gaps.mjs ...",

--- a/apps/mobile/release/route-commercialization-gate.json
+++ b/apps/mobile/release/route-commercialization-gate.json
@@ -23,7 +23,8 @@
   "realtimeCoverage": {
     "supportedStationLinePairsMin": 100,
     "providerFreshnessSecondsMax": 90,
-    "staleFallbackRequired": true
+    "staleFallbackRequired": true,
+    "requireTerminalRegionalResolution": true
   },
   "accessibility": {
     "strictStepFreeKnownStairFalsePositiveAllowed": 0,

--- a/apps/mobile/release/route-release-readiness-tracker.json
+++ b/apps/mobile/release/route-release-readiness-tracker.json
@@ -58,6 +58,7 @@
       "artifacts/route-accuracy-report.json",
       "artifacts/route-accessibility-regression-report.json",
       "artifacts/realtime-provider-coverage-report.json",
+      "tools/realtime/regional-realtime-provider-decision-report.json",
       "artifacts/route-graph-coverage-report.json",
       "artifacts/route-v2-contract-report.json"
     ],

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -228,6 +228,7 @@ test("route commercialization release gate blocks unsupported commercial route c
   assert.equal(gate.realtimeCoverage.supportedStationLinePairsMin, 100);
   assert.equal(gate.realtimeCoverage.providerFreshnessSecondsMax, 90);
   assert.equal(gate.realtimeCoverage.staleFallbackRequired, true);
+  assert.equal(gate.realtimeCoverage.requireTerminalRegionalResolution, true);
   assert.equal(gate.accessibility.strictStepFreeKnownStairFalsePositiveAllowed, 0);
   assert.equal(gate.accessibility.generatedConnectorAsVerifiedAllowed, false);
   assert.equal(gate.accessibility.unknownAccessibilityMustBeLabeled, true);
@@ -302,6 +303,7 @@ test("datapack release readiness gate blocks commercial datapack and realtime ET
   assert.deepEqual(gate.requiredArtifacts, {
     routeAccuracyReport: "artifacts/route-accuracy-report.json",
     realtimeProviderCoverageReport: "artifacts/realtime-provider-coverage-report.json",
+    regionalRealtimeProviderDecisionReport: "tools/realtime/regional-realtime-provider-decision-report.json",
     routeAccessibilityRegressionReport: "artifacts/route-accessibility-regression-report.json",
     routeGraphCoverageReport: "artifacts/route-graph-coverage-report.json",
     routeV2ContractReport: "artifacts/route-v2-contract-report.json",
@@ -319,6 +321,7 @@ test("datapack release readiness gate blocks commercial datapack and realtime ET
   );
   assert.ok(gate.requiredVerificationCommands.some((command) => command.includes("validate-datapack.mjs --require-production")));
   assert.ok(gate.requiredVerificationCommands.some((command) => command.includes("build-route-graph-coverage-report.mjs")));
+  assert.ok(gate.requiredVerificationCommands.some((command) => command.includes("build-regional-realtime-provider-decision-report.mjs")));
   assert.ok(gate.requiredVerificationCommands.some((command) => command.includes("build-route-graph-topology-report.mjs")));
   assert.ok(gate.requiredVerificationCommands.some((command) => command.includes("report-coverage-gaps.mjs")));
   assert.ok(gate.requiredVerificationCommands.some((command) => command.includes("itx-cheongchun-coverage-contract.test.mjs")));
@@ -382,6 +385,7 @@ test("route release readiness tracker keeps issue 1414 as a release blocker", ()
     "artifacts/route-accuracy-report.json",
     "artifacts/route-accessibility-regression-report.json",
     "artifacts/realtime-provider-coverage-report.json",
+    "tools/realtime/regional-realtime-provider-decision-report.json",
     "artifacts/route-graph-coverage-report.json",
     "artifacts/route-v2-contract-report.json",
   ]);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -321,7 +321,11 @@ test("datapack release readiness gate blocks commercial datapack and realtime ET
   );
   assert.ok(gate.requiredVerificationCommands.some((command) => command.includes("validate-datapack.mjs --require-production")));
   assert.ok(gate.requiredVerificationCommands.some((command) => command.includes("build-route-graph-coverage-report.mjs")));
-  assert.ok(gate.requiredVerificationCommands.some((command) => command.includes("build-regional-realtime-provider-decision-report.mjs")));
+  assert.ok(gate.requiredVerificationCommands.some((command) =>
+    command.includes("build-regional-realtime-provider-decision-report.mjs")
+    && command.includes("--targets tools/datapack/nationwide-coverage-targets.json")
+    && command.includes("--contract tools/realtime/regional-realtime-provider-decisions.json")
+    && command.includes("--output tools/realtime/regional-realtime-provider-decision-report.json")));
   assert.ok(gate.requiredVerificationCommands.some((command) => command.includes("build-route-graph-topology-report.mjs")));
   assert.ok(gate.requiredVerificationCommands.some((command) => command.includes("report-coverage-gaps.mjs")));
   assert.ok(gate.requiredVerificationCommands.some((command) => command.includes("itx-cheongchun-coverage-contract.test.mjs")));

--- a/tools/realtime/regional-realtime-provider-decision-report.json
+++ b/tools/realtime/regional-realtime-provider-decision-report.json
@@ -236,6 +236,7 @@
     "targetCount": 12,
     "credentialSafeCallCount": 28,
     "uniqueQueryCount": 14,
+    "supportedCount": 0,
     "explicitNoDataCount": 11,
     "falsePositiveClassifiedCount": 1,
     "boundedRetryCount": 1,

--- a/tools/realtime/regional-realtime-provider-decision-report.json
+++ b/tools/realtime/regional-realtime-provider-decision-report.json
@@ -1,0 +1,472 @@
+{
+  "schemaVersion": 1,
+  "scope": {
+    "excludedRegionIds": [
+      "capital"
+    ],
+    "regionIds": [
+      "busan",
+      "daegu",
+      "daejeon",
+      "gwangju"
+    ],
+    "activeLineOperatorScopeCount": 12
+  },
+  "supportedStationLinePairs": 0,
+  "providerFreshnessSecondsMaxObserved": 0,
+  "staleFallbackRequired": false,
+  "freshness": {
+    "freshCount": 0,
+    "staleCount": 0,
+    "staleAsFreshCount": 0
+  },
+  "mapping": {
+    "attemptedRows": 0,
+    "failedRows": 0,
+    "failureRate": 0,
+    "failuresByReason": {}
+  },
+  "byProvider": [],
+  "byRegion": [],
+  "unsupportedRegions": [
+    {
+      "region": "busan",
+      "reason": "실시간 미지원"
+    },
+    {
+      "region": "daegu",
+      "reason": "실시간 미지원"
+    },
+    {
+      "region": "daejeon",
+      "reason": "실시간 미지원"
+    },
+    {
+      "region": "gwangju",
+      "reason": "실시간 미지원"
+    }
+  ],
+  "coverageResolution": {
+    "requirementCount": 12,
+    "supportedCount": 0,
+    "explicitlyUnsupportedCount": 12,
+    "missingCount": 0,
+    "supportedRatio": 0,
+    "terminalResolutionRatio": 1
+  },
+  "resolutionGate": {
+    "allRequirementsResolved": true,
+    "reasonCode": "ALL_REALTIME_REQUIREMENTS_RESOLVED"
+  },
+  "capabilityMetadata": [
+    {
+      "regionId": "busan",
+      "operatorId": "busan-transportation",
+      "lineId": "line-ab1a041f6266",
+      "sourceDomain": "realtime_arrivals",
+      "state": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+      "fallback": "UNSUPPORTED_REGION",
+      "effectiveCapability": "UNSUPPORTED_REGION",
+      "userMessageKo": "이 지역은 실시간 도착 정보를 아직 제공하지 않아요."
+    },
+    {
+      "regionId": "busan",
+      "operatorId": "busan-transportation",
+      "lineId": "line-d74614a04530",
+      "sourceDomain": "realtime_arrivals",
+      "state": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+      "fallback": "UNSUPPORTED_REGION",
+      "effectiveCapability": "UNSUPPORTED_REGION",
+      "userMessageKo": "이 지역은 실시간 도착 정보를 아직 제공하지 않아요."
+    },
+    {
+      "regionId": "busan",
+      "operatorId": "busan-transportation",
+      "lineId": "line-d812a5bc1e5f",
+      "sourceDomain": "realtime_arrivals",
+      "state": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+      "fallback": "UNSUPPORTED_REGION",
+      "effectiveCapability": "UNSUPPORTED_REGION",
+      "userMessageKo": "이 지역은 실시간 도착 정보를 아직 제공하지 않아요."
+    },
+    {
+      "regionId": "busan",
+      "operatorId": "busan-transportation",
+      "lineId": "line-eb7b47920390",
+      "sourceDomain": "realtime_arrivals",
+      "state": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+      "fallback": "UNSUPPORTED_REGION",
+      "effectiveCapability": "UNSUPPORTED_REGION",
+      "userMessageKo": "이 지역은 실시간 도착 정보를 아직 제공하지 않아요."
+    },
+    {
+      "regionId": "busan",
+      "operatorId": "korail",
+      "lineId": "line-f52eb59d8497",
+      "sourceDomain": "realtime_arrivals",
+      "state": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+      "fallback": "UNSUPPORTED_REGION",
+      "effectiveCapability": "UNSUPPORTED_REGION",
+      "userMessageKo": "이 지역은 실시간 도착 정보를 아직 제공하지 않아요."
+    },
+    {
+      "regionId": "busan",
+      "operatorId": "operator-72566d06475a",
+      "lineId": "line-e4cce88f0d7f",
+      "sourceDomain": "realtime_arrivals",
+      "state": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+      "fallback": "UNSUPPORTED_REGION",
+      "effectiveCapability": "UNSUPPORTED_REGION",
+      "userMessageKo": "이 지역은 실시간 도착 정보를 아직 제공하지 않아요."
+    },
+    {
+      "regionId": "daegu",
+      "operatorId": "daegu-transportation",
+      "lineId": "line-0ffaa95b1b5d",
+      "sourceDomain": "realtime_arrivals",
+      "state": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+      "fallback": "UNSUPPORTED_REGION",
+      "effectiveCapability": "UNSUPPORTED_REGION",
+      "userMessageKo": "이 지역은 실시간 도착 정보를 아직 제공하지 않아요."
+    },
+    {
+      "regionId": "daegu",
+      "operatorId": "daegu-transportation",
+      "lineId": "line-5b8d9b05e7e6",
+      "sourceDomain": "realtime_arrivals",
+      "state": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+      "fallback": "UNSUPPORTED_REGION",
+      "effectiveCapability": "UNSUPPORTED_REGION",
+      "userMessageKo": "이 지역은 실시간 도착 정보를 아직 제공하지 않아요."
+    },
+    {
+      "regionId": "daegu",
+      "operatorId": "daegu-transportation",
+      "lineId": "line-e2938a4cc492",
+      "sourceDomain": "realtime_arrivals",
+      "state": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+      "fallback": "UNSUPPORTED_REGION",
+      "effectiveCapability": "UNSUPPORTED_REGION",
+      "userMessageKo": "이 지역은 실시간 도착 정보를 아직 제공하지 않아요."
+    },
+    {
+      "regionId": "daegu",
+      "operatorId": "korail",
+      "lineId": "line-8f7ed01f290a",
+      "sourceDomain": "realtime_arrivals",
+      "state": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+      "fallback": "UNSUPPORTED_REGION",
+      "effectiveCapability": "UNSUPPORTED_REGION",
+      "userMessageKo": "이 지역은 실시간 도착 정보를 아직 제공하지 않아요."
+    },
+    {
+      "regionId": "daejeon",
+      "operatorId": "daejeon-transportation",
+      "lineId": "line-7051a9c2525c",
+      "sourceDomain": "realtime_arrivals",
+      "state": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+      "fallback": "UNSUPPORTED_REGION",
+      "effectiveCapability": "UNSUPPORTED_REGION",
+      "userMessageKo": "이 지역은 실시간 도착 정보를 아직 제공하지 않아요."
+    },
+    {
+      "regionId": "gwangju",
+      "operatorId": "gwangju-metropolitan-rapid-transit",
+      "lineId": "line-e57a361e8892",
+      "sourceDomain": "realtime_arrivals",
+      "state": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+      "fallback": "UNSUPPORTED_REGION",
+      "effectiveCapability": "UNSUPPORTED_REGION",
+      "userMessageKo": "이 지역은 실시간 도착 정보를 아직 제공하지 않아요."
+    }
+  ],
+  "claimGate": {
+    "nationwideRealtimeSupportAllowed": false,
+    "reasonCode": "REALTIME_REQUIREMENTS_NOT_ALL_SUPPORTED"
+  },
+  "artifactKind": "regional-realtime-provider-decision-report",
+  "issue": 1621,
+  "targetVersion": "2026-07-13",
+  "verifiedAt": "2026-07-13T17:50:29.249Z",
+  "officialSources": [
+    {
+      "id": "public-api-live-search",
+      "url": "https://www.data.go.kr/tcs/dss/selectDataSetList.do",
+      "decision": "CREDENTIAL_SAFE_LIVE_SEARCH_COMPLETED",
+      "notes": "DATA_GO_KR_SERVICE_KEY를 Node process.env에서만 읽는 tracked collector로 12개 active line scope를 검색했다. 비밀 값과 원문 응답은 저장하지 않았다."
+    },
+    {
+      "id": "busan-standard-timetable",
+      "url": "https://www.data.go.kr/data/15000522/openapi.do",
+      "decision": "SCHEDULE_ONLY_NOT_REALTIME",
+      "operations": [
+        "부산 도시철도 열차시각표 조회 서비스"
+      ],
+      "notes": "요일·상하행·검색시각·역코드로 표준 도착시각을 조회하며 공식 설명이 실제 도착시각과 다를 수 있음을 명시한다."
+    },
+    {
+      "id": "tago-subway-information-scope",
+      "url": "https://www.data.go.kr/data/15098554/openapi.do",
+      "decision": "STATION_EXIT_TIMETABLE_ONLY",
+      "operations": [
+        "지하철역 목록",
+        "역별 출구 목록",
+        "출구별 버스노선 목록",
+        "역별 시간표 목록"
+      ]
+    },
+    {
+      "id": "molit-realtime-service-ended",
+      "url": "https://www.data.go.kr/bbs/ntc/selectNotice.do?originId=NOTICE_0000000002723",
+      "decision": "ENDED_WITHOUT_REPLACEMENT",
+      "notes": "국토교통부 지하철실시간정보 서비스는 공식 공지에서 대체 서비스 없이 종료됐다."
+    },
+    {
+      "id": "daejeon-timetable-operations",
+      "url": "https://www.data.go.kr/data/15159278/openapi.do",
+      "decision": "SCHEDULE_ONLY_FALSE_POSITIVE",
+      "operations": [
+        "GET /getAllTimeTable",
+        "GET /getTimeTable"
+      ],
+      "notes": "검색 설명의 활용 예시에 실시간 앱이 포함되지만 제공 operation은 전역·역별 열차시각표뿐이다."
+    }
+  ],
+  "publicApiAudit": {
+    "targetCount": 12,
+    "credentialSafeCallCount": 28,
+    "uniqueQueryCount": 14,
+    "explicitNoDataCount": 11,
+    "falsePositiveClassifiedCount": 1,
+    "boundedRetryCount": 1,
+    "searchPlanSha256": "92d7716ea6c9fd091a0d341b2925848ab99587c667574266c25a9560246fbbd3",
+    "sanitizedResponseSha256": [
+      "2b756f69a7b1c66b1efe76063e3161948bcdfcaed0ed87fea9ef0295406450a5",
+      "53f118273057e81d0e2d9fe4fcaea7a7cbc548327808f696bf4d8fc8d1fbf4c9",
+      "7984e8110a9ac1ad480ac9a8e6b013eda1923ee4279c28901a295845ec5164a1",
+      "8229950dabec9e32c553108514f67a674363165c16dcf6b26722b9347fee9b54"
+    ],
+    "initialTransient": {
+      "reasonCode": "PUBLIC_API_HTTP_FAILURE",
+      "httpStatus": 500,
+      "resolvedByBoundedRetry": true
+    }
+  },
+  "decisionEvidence": [
+    {
+      "regionId": "busan",
+      "operatorId": "busan-transportation",
+      "lineId": "line-ab1a041f6266",
+      "state": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+      "fallback": "UNSUPPORTED_REGION",
+      "routeFallbackCapability": "PLANNED",
+      "userMessageKo": "이 지역은 실시간 도착 정보를 아직 제공하지 않아요.",
+      "evidenceRefs": [
+        "public-api-live-search",
+        "busan-standard-timetable",
+        "molit-realtime-service-ended"
+      ],
+      "evidenceHash": "39e5ac670983dceea3b5ef1be7fce7053834cd0b3651ae9950c5068f68d2521a",
+      "reviewedAt": "2026-07-13T17:50:29.249Z",
+      "nextReviewAt": "2026-10-11T17:50:29.249Z",
+      "reasonCode": "PUBLIC_API_NO_DATA"
+    },
+    {
+      "regionId": "busan",
+      "operatorId": "busan-transportation",
+      "lineId": "line-d74614a04530",
+      "state": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+      "fallback": "UNSUPPORTED_REGION",
+      "routeFallbackCapability": "PLANNED",
+      "userMessageKo": "이 지역은 실시간 도착 정보를 아직 제공하지 않아요.",
+      "evidenceRefs": [
+        "public-api-live-search",
+        "busan-standard-timetable",
+        "molit-realtime-service-ended"
+      ],
+      "evidenceHash": "eaf9ce3f2aa90375b20dc19c4a1355a9bedc2839466c017f3e1a8689949046c6",
+      "reviewedAt": "2026-07-13T17:50:29.249Z",
+      "nextReviewAt": "2026-10-11T17:50:29.249Z",
+      "reasonCode": "PUBLIC_API_NO_DATA"
+    },
+    {
+      "regionId": "busan",
+      "operatorId": "busan-transportation",
+      "lineId": "line-d812a5bc1e5f",
+      "state": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+      "fallback": "UNSUPPORTED_REGION",
+      "routeFallbackCapability": "PLANNED",
+      "userMessageKo": "이 지역은 실시간 도착 정보를 아직 제공하지 않아요.",
+      "evidenceRefs": [
+        "public-api-live-search",
+        "busan-standard-timetable",
+        "molit-realtime-service-ended"
+      ],
+      "evidenceHash": "2ec447f46b42605a8e7c888a272bc09930994358110cae2da1002d03dd908376",
+      "reviewedAt": "2026-07-13T17:50:29.249Z",
+      "nextReviewAt": "2026-10-11T17:50:29.249Z",
+      "reasonCode": "PUBLIC_API_NO_DATA"
+    },
+    {
+      "regionId": "busan",
+      "operatorId": "busan-transportation",
+      "lineId": "line-eb7b47920390",
+      "state": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+      "fallback": "UNSUPPORTED_REGION",
+      "routeFallbackCapability": "PLANNED",
+      "userMessageKo": "이 지역은 실시간 도착 정보를 아직 제공하지 않아요.",
+      "evidenceRefs": [
+        "public-api-live-search",
+        "busan-standard-timetable",
+        "molit-realtime-service-ended"
+      ],
+      "evidenceHash": "df4ddf98d3fa8cd5b64c2d16eee35f72d0af42602992bc3218e524de1b209984",
+      "reviewedAt": "2026-07-13T17:50:29.249Z",
+      "nextReviewAt": "2026-10-11T17:50:29.249Z",
+      "reasonCode": "PUBLIC_API_NO_DATA"
+    },
+    {
+      "regionId": "busan",
+      "operatorId": "korail",
+      "lineId": "line-f52eb59d8497",
+      "state": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+      "fallback": "UNSUPPORTED_REGION",
+      "routeFallbackCapability": "PLANNED",
+      "userMessageKo": "이 지역은 실시간 도착 정보를 아직 제공하지 않아요.",
+      "evidenceRefs": [
+        "public-api-live-search",
+        "tago-subway-information-scope",
+        "molit-realtime-service-ended"
+      ],
+      "evidenceHash": "23aa2d1bb609c95981e1be41ff8ad411fff181d7e4162acbd811e9830e4f3535",
+      "reviewedAt": "2026-07-13T17:50:29.249Z",
+      "nextReviewAt": "2026-10-11T17:50:29.249Z",
+      "reasonCode": "PUBLIC_API_NO_DATA"
+    },
+    {
+      "regionId": "busan",
+      "operatorId": "operator-72566d06475a",
+      "lineId": "line-e4cce88f0d7f",
+      "state": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+      "fallback": "UNSUPPORTED_REGION",
+      "routeFallbackCapability": "PLANNED",
+      "userMessageKo": "이 지역은 실시간 도착 정보를 아직 제공하지 않아요.",
+      "evidenceRefs": [
+        "public-api-live-search",
+        "tago-subway-information-scope",
+        "molit-realtime-service-ended"
+      ],
+      "evidenceHash": "46ac5b59646790e6685b70a8189f3fd9c4499f1e29b0501a46bf58b6e400d68c",
+      "reviewedAt": "2026-07-13T17:50:29.249Z",
+      "nextReviewAt": "2026-10-11T17:50:29.249Z",
+      "reasonCode": "PUBLIC_API_NO_DATA"
+    },
+    {
+      "regionId": "daegu",
+      "operatorId": "daegu-transportation",
+      "lineId": "line-0ffaa95b1b5d",
+      "state": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+      "fallback": "UNSUPPORTED_REGION",
+      "routeFallbackCapability": "PLANNED",
+      "userMessageKo": "이 지역은 실시간 도착 정보를 아직 제공하지 않아요.",
+      "evidenceRefs": [
+        "public-api-live-search",
+        "tago-subway-information-scope",
+        "molit-realtime-service-ended"
+      ],
+      "evidenceHash": "b4a59315d19a0652bfb5ec81ff1bc32e29779fe8af6eee8896f5dfb16361f19d",
+      "reviewedAt": "2026-07-13T17:50:29.249Z",
+      "nextReviewAt": "2026-10-11T17:50:29.249Z",
+      "reasonCode": "PUBLIC_API_NO_DATA"
+    },
+    {
+      "regionId": "daegu",
+      "operatorId": "daegu-transportation",
+      "lineId": "line-5b8d9b05e7e6",
+      "state": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+      "fallback": "UNSUPPORTED_REGION",
+      "routeFallbackCapability": "PLANNED",
+      "userMessageKo": "이 지역은 실시간 도착 정보를 아직 제공하지 않아요.",
+      "evidenceRefs": [
+        "public-api-live-search",
+        "tago-subway-information-scope",
+        "molit-realtime-service-ended"
+      ],
+      "evidenceHash": "86dc342bbbb17039d06d7fbb789e5eda3918f7a343f087aa0613509d293906fe",
+      "reviewedAt": "2026-07-13T17:50:29.249Z",
+      "nextReviewAt": "2026-10-11T17:50:29.249Z",
+      "reasonCode": "PUBLIC_API_NO_DATA"
+    },
+    {
+      "regionId": "daegu",
+      "operatorId": "daegu-transportation",
+      "lineId": "line-e2938a4cc492",
+      "state": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+      "fallback": "UNSUPPORTED_REGION",
+      "routeFallbackCapability": "PLANNED",
+      "userMessageKo": "이 지역은 실시간 도착 정보를 아직 제공하지 않아요.",
+      "evidenceRefs": [
+        "public-api-live-search",
+        "tago-subway-information-scope",
+        "molit-realtime-service-ended"
+      ],
+      "evidenceHash": "7a1b2d0d90cceefa43390311bd78c9ef03accfd04eeda14325025f23e6b63510",
+      "reviewedAt": "2026-07-13T17:50:29.249Z",
+      "nextReviewAt": "2026-10-11T17:50:29.249Z",
+      "reasonCode": "PUBLIC_API_NO_DATA"
+    },
+    {
+      "regionId": "daegu",
+      "operatorId": "korail",
+      "lineId": "line-8f7ed01f290a",
+      "state": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+      "fallback": "UNSUPPORTED_REGION",
+      "routeFallbackCapability": "PLANNED",
+      "userMessageKo": "이 지역은 실시간 도착 정보를 아직 제공하지 않아요.",
+      "evidenceRefs": [
+        "public-api-live-search",
+        "tago-subway-information-scope",
+        "molit-realtime-service-ended"
+      ],
+      "evidenceHash": "b10f2419021585ddeb30a81d13076e6443986655bfe0457fc034a927827bc86e",
+      "reviewedAt": "2026-07-13T17:50:29.249Z",
+      "nextReviewAt": "2026-10-11T17:50:29.249Z",
+      "reasonCode": "PUBLIC_API_NO_DATA"
+    },
+    {
+      "regionId": "daejeon",
+      "operatorId": "daejeon-transportation",
+      "lineId": "line-7051a9c2525c",
+      "state": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+      "fallback": "UNSUPPORTED_REGION",
+      "routeFallbackCapability": "PLANNED",
+      "userMessageKo": "이 지역은 실시간 도착 정보를 아직 제공하지 않아요.",
+      "evidenceRefs": [
+        "public-api-live-search",
+        "daejeon-timetable-operations",
+        "molit-realtime-service-ended"
+      ],
+      "reviewedAt": "2026-07-13T17:50:29.249Z",
+      "nextReviewAt": "2026-10-11T17:50:29.249Z",
+      "reasonCode": "PUBLIC_API_FALSE_POSITIVE_SCHEDULE_ONLY"
+    },
+    {
+      "regionId": "gwangju",
+      "operatorId": "gwangju-metropolitan-rapid-transit",
+      "lineId": "line-e57a361e8892",
+      "state": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+      "fallback": "UNSUPPORTED_REGION",
+      "routeFallbackCapability": "PLANNED",
+      "userMessageKo": "이 지역은 실시간 도착 정보를 아직 제공하지 않아요.",
+      "evidenceRefs": [
+        "public-api-live-search",
+        "tago-subway-information-scope",
+        "molit-realtime-service-ended"
+      ],
+      "evidenceHash": "ed21a8b33890dec5c882307524442431ae23115a699ffba2c8d3723382049d85",
+      "reviewedAt": "2026-07-13T17:50:29.249Z",
+      "nextReviewAt": "2026-10-11T17:50:29.249Z",
+      "reasonCode": "PUBLIC_API_NO_DATA"
+    }
+  ]
+}

--- a/tools/realtime/regional-realtime-provider-decisions.json
+++ b/tools/realtime/regional-realtime-provider-decisions.json
@@ -1,0 +1,293 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "regional-realtime-provider-decisions",
+  "issue": 1621,
+  "targetVersion": "2026-07-13",
+  "verifiedAt": "2026-07-13T17:50:29.249Z",
+  "scope": {
+    "excludedRegionIds": [
+      "capital"
+    ]
+  },
+  "officialSources": [
+    {
+      "id": "public-api-live-search",
+      "url": "https://www.data.go.kr/tcs/dss/selectDataSetList.do",
+      "decision": "CREDENTIAL_SAFE_LIVE_SEARCH_COMPLETED",
+      "notes": "DATA_GO_KR_SERVICE_KEY를 Node process.env에서만 읽는 tracked collector로 12개 active line scope를 검색했다. 비밀 값과 원문 응답은 저장하지 않았다."
+    },
+    {
+      "id": "busan-standard-timetable",
+      "url": "https://www.data.go.kr/data/15000522/openapi.do",
+      "decision": "SCHEDULE_ONLY_NOT_REALTIME",
+      "operations": [
+        "부산 도시철도 열차시각표 조회 서비스"
+      ],
+      "notes": "요일·상하행·검색시각·역코드로 표준 도착시각을 조회하며 공식 설명이 실제 도착시각과 다를 수 있음을 명시한다."
+    },
+    {
+      "id": "tago-subway-information-scope",
+      "url": "https://www.data.go.kr/data/15098554/openapi.do",
+      "decision": "STATION_EXIT_TIMETABLE_ONLY",
+      "operations": [
+        "지하철역 목록",
+        "역별 출구 목록",
+        "출구별 버스노선 목록",
+        "역별 시간표 목록"
+      ]
+    },
+    {
+      "id": "molit-realtime-service-ended",
+      "url": "https://www.data.go.kr/bbs/ntc/selectNotice.do?originId=NOTICE_0000000002723",
+      "decision": "ENDED_WITHOUT_REPLACEMENT",
+      "notes": "국토교통부 지하철실시간정보 서비스는 공식 공지에서 대체 서비스 없이 종료됐다."
+    },
+    {
+      "id": "daejeon-timetable-operations",
+      "url": "https://www.data.go.kr/data/15159278/openapi.do",
+      "decision": "SCHEDULE_ONLY_FALSE_POSITIVE",
+      "operations": [
+        "GET /getAllTimeTable",
+        "GET /getTimeTable"
+      ],
+      "notes": "검색 설명의 활용 예시에 실시간 앱이 포함되지만 제공 operation은 전역·역별 열차시각표뿐이다."
+    }
+  ],
+  "publicApiAudit": {
+    "targetCount": 12,
+    "credentialSafeCallCount": 28,
+    "uniqueQueryCount": 14,
+    "explicitNoDataCount": 11,
+    "falsePositiveClassifiedCount": 1,
+    "boundedRetryCount": 1,
+    "searchPlanSha256": "92d7716ea6c9fd091a0d341b2925848ab99587c667574266c25a9560246fbbd3",
+    "sanitizedResponseSha256": [
+      "2b756f69a7b1c66b1efe76063e3161948bcdfcaed0ed87fea9ef0295406450a5",
+      "53f118273057e81d0e2d9fe4fcaea7a7cbc548327808f696bf4d8fc8d1fbf4c9",
+      "7984e8110a9ac1ad480ac9a8e6b013eda1923ee4279c28901a295845ec5164a1",
+      "8229950dabec9e32c553108514f67a674363165c16dcf6b26722b9347fee9b54"
+    ],
+    "initialTransient": {
+      "reasonCode": "PUBLIC_API_HTTP_FAILURE",
+      "httpStatus": 500,
+      "resolvedByBoundedRetry": true
+    }
+  },
+  "decisions": [
+    {
+      "regionId": "busan",
+      "operatorId": "busan-transportation",
+      "lineId": "line-ab1a041f6266",
+      "state": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+      "fallback": "UNSUPPORTED_REGION",
+      "routeFallbackCapability": "PLANNED",
+      "userMessageKo": "이 지역은 실시간 도착 정보를 아직 제공하지 않아요.",
+      "evidenceRefs": [
+        "public-api-live-search",
+        "busan-standard-timetable",
+        "molit-realtime-service-ended"
+      ],
+      "evidenceHash": "39e5ac670983dceea3b5ef1be7fce7053834cd0b3651ae9950c5068f68d2521a",
+      "reasonCode": "PUBLIC_API_NO_DATA",
+      "reviewedAt": "2026-07-13T17:50:29.249Z",
+      "nextReviewAt": "2026-10-11T17:50:29.249Z"
+    },
+    {
+      "regionId": "busan",
+      "operatorId": "busan-transportation",
+      "lineId": "line-d74614a04530",
+      "state": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+      "fallback": "UNSUPPORTED_REGION",
+      "routeFallbackCapability": "PLANNED",
+      "userMessageKo": "이 지역은 실시간 도착 정보를 아직 제공하지 않아요.",
+      "evidenceRefs": [
+        "public-api-live-search",
+        "busan-standard-timetable",
+        "molit-realtime-service-ended"
+      ],
+      "evidenceHash": "eaf9ce3f2aa90375b20dc19c4a1355a9bedc2839466c017f3e1a8689949046c6",
+      "reasonCode": "PUBLIC_API_NO_DATA",
+      "reviewedAt": "2026-07-13T17:50:29.249Z",
+      "nextReviewAt": "2026-10-11T17:50:29.249Z"
+    },
+    {
+      "regionId": "busan",
+      "operatorId": "busan-transportation",
+      "lineId": "line-d812a5bc1e5f",
+      "state": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+      "fallback": "UNSUPPORTED_REGION",
+      "routeFallbackCapability": "PLANNED",
+      "userMessageKo": "이 지역은 실시간 도착 정보를 아직 제공하지 않아요.",
+      "evidenceRefs": [
+        "public-api-live-search",
+        "busan-standard-timetable",
+        "molit-realtime-service-ended"
+      ],
+      "evidenceHash": "2ec447f46b42605a8e7c888a272bc09930994358110cae2da1002d03dd908376",
+      "reasonCode": "PUBLIC_API_NO_DATA",
+      "reviewedAt": "2026-07-13T17:50:29.249Z",
+      "nextReviewAt": "2026-10-11T17:50:29.249Z"
+    },
+    {
+      "regionId": "busan",
+      "operatorId": "busan-transportation",
+      "lineId": "line-eb7b47920390",
+      "state": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+      "fallback": "UNSUPPORTED_REGION",
+      "routeFallbackCapability": "PLANNED",
+      "userMessageKo": "이 지역은 실시간 도착 정보를 아직 제공하지 않아요.",
+      "evidenceRefs": [
+        "public-api-live-search",
+        "busan-standard-timetable",
+        "molit-realtime-service-ended"
+      ],
+      "evidenceHash": "df4ddf98d3fa8cd5b64c2d16eee35f72d0af42602992bc3218e524de1b209984",
+      "reasonCode": "PUBLIC_API_NO_DATA",
+      "reviewedAt": "2026-07-13T17:50:29.249Z",
+      "nextReviewAt": "2026-10-11T17:50:29.249Z"
+    },
+    {
+      "regionId": "busan",
+      "operatorId": "korail",
+      "lineId": "line-f52eb59d8497",
+      "state": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+      "fallback": "UNSUPPORTED_REGION",
+      "routeFallbackCapability": "PLANNED",
+      "userMessageKo": "이 지역은 실시간 도착 정보를 아직 제공하지 않아요.",
+      "evidenceRefs": [
+        "public-api-live-search",
+        "tago-subway-information-scope",
+        "molit-realtime-service-ended"
+      ],
+      "evidenceHash": "23aa2d1bb609c95981e1be41ff8ad411fff181d7e4162acbd811e9830e4f3535",
+      "reasonCode": "PUBLIC_API_NO_DATA",
+      "reviewedAt": "2026-07-13T17:50:29.249Z",
+      "nextReviewAt": "2026-10-11T17:50:29.249Z"
+    },
+    {
+      "regionId": "busan",
+      "operatorId": "operator-72566d06475a",
+      "lineId": "line-e4cce88f0d7f",
+      "state": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+      "fallback": "UNSUPPORTED_REGION",
+      "routeFallbackCapability": "PLANNED",
+      "userMessageKo": "이 지역은 실시간 도착 정보를 아직 제공하지 않아요.",
+      "evidenceRefs": [
+        "public-api-live-search",
+        "tago-subway-information-scope",
+        "molit-realtime-service-ended"
+      ],
+      "evidenceHash": "46ac5b59646790e6685b70a8189f3fd9c4499f1e29b0501a46bf58b6e400d68c",
+      "reasonCode": "PUBLIC_API_NO_DATA",
+      "reviewedAt": "2026-07-13T17:50:29.249Z",
+      "nextReviewAt": "2026-10-11T17:50:29.249Z"
+    },
+    {
+      "regionId": "daegu",
+      "operatorId": "daegu-transportation",
+      "lineId": "line-0ffaa95b1b5d",
+      "state": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+      "fallback": "UNSUPPORTED_REGION",
+      "routeFallbackCapability": "PLANNED",
+      "userMessageKo": "이 지역은 실시간 도착 정보를 아직 제공하지 않아요.",
+      "evidenceRefs": [
+        "public-api-live-search",
+        "tago-subway-information-scope",
+        "molit-realtime-service-ended"
+      ],
+      "evidenceHash": "b4a59315d19a0652bfb5ec81ff1bc32e29779fe8af6eee8896f5dfb16361f19d",
+      "reasonCode": "PUBLIC_API_NO_DATA",
+      "reviewedAt": "2026-07-13T17:50:29.249Z",
+      "nextReviewAt": "2026-10-11T17:50:29.249Z"
+    },
+    {
+      "regionId": "daegu",
+      "operatorId": "daegu-transportation",
+      "lineId": "line-5b8d9b05e7e6",
+      "state": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+      "fallback": "UNSUPPORTED_REGION",
+      "routeFallbackCapability": "PLANNED",
+      "userMessageKo": "이 지역은 실시간 도착 정보를 아직 제공하지 않아요.",
+      "evidenceRefs": [
+        "public-api-live-search",
+        "tago-subway-information-scope",
+        "molit-realtime-service-ended"
+      ],
+      "evidenceHash": "86dc342bbbb17039d06d7fbb789e5eda3918f7a343f087aa0613509d293906fe",
+      "reasonCode": "PUBLIC_API_NO_DATA",
+      "reviewedAt": "2026-07-13T17:50:29.249Z",
+      "nextReviewAt": "2026-10-11T17:50:29.249Z"
+    },
+    {
+      "regionId": "daegu",
+      "operatorId": "daegu-transportation",
+      "lineId": "line-e2938a4cc492",
+      "state": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+      "fallback": "UNSUPPORTED_REGION",
+      "routeFallbackCapability": "PLANNED",
+      "userMessageKo": "이 지역은 실시간 도착 정보를 아직 제공하지 않아요.",
+      "evidenceRefs": [
+        "public-api-live-search",
+        "tago-subway-information-scope",
+        "molit-realtime-service-ended"
+      ],
+      "evidenceHash": "7a1b2d0d90cceefa43390311bd78c9ef03accfd04eeda14325025f23e6b63510",
+      "reasonCode": "PUBLIC_API_NO_DATA",
+      "reviewedAt": "2026-07-13T17:50:29.249Z",
+      "nextReviewAt": "2026-10-11T17:50:29.249Z"
+    },
+    {
+      "regionId": "daegu",
+      "operatorId": "korail",
+      "lineId": "line-8f7ed01f290a",
+      "state": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+      "fallback": "UNSUPPORTED_REGION",
+      "routeFallbackCapability": "PLANNED",
+      "userMessageKo": "이 지역은 실시간 도착 정보를 아직 제공하지 않아요.",
+      "evidenceRefs": [
+        "public-api-live-search",
+        "tago-subway-information-scope",
+        "molit-realtime-service-ended"
+      ],
+      "evidenceHash": "b10f2419021585ddeb30a81d13076e6443986655bfe0457fc034a927827bc86e",
+      "reasonCode": "PUBLIC_API_NO_DATA",
+      "reviewedAt": "2026-07-13T17:50:29.249Z",
+      "nextReviewAt": "2026-10-11T17:50:29.249Z"
+    },
+    {
+      "regionId": "daejeon",
+      "operatorId": "daejeon-transportation",
+      "lineId": "line-7051a9c2525c",
+      "state": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+      "fallback": "UNSUPPORTED_REGION",
+      "routeFallbackCapability": "PLANNED",
+      "userMessageKo": "이 지역은 실시간 도착 정보를 아직 제공하지 않아요.",
+      "evidenceRefs": [
+        "public-api-live-search",
+        "daejeon-timetable-operations",
+        "molit-realtime-service-ended"
+      ],
+      "reasonCode": "PUBLIC_API_FALSE_POSITIVE_SCHEDULE_ONLY",
+      "reviewedAt": "2026-07-13T17:50:29.249Z",
+      "nextReviewAt": "2026-10-11T17:50:29.249Z"
+    },
+    {
+      "regionId": "gwangju",
+      "operatorId": "gwangju-metropolitan-rapid-transit",
+      "lineId": "line-e57a361e8892",
+      "state": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+      "fallback": "UNSUPPORTED_REGION",
+      "routeFallbackCapability": "PLANNED",
+      "userMessageKo": "이 지역은 실시간 도착 정보를 아직 제공하지 않아요.",
+      "evidenceRefs": [
+        "public-api-live-search",
+        "tago-subway-information-scope",
+        "molit-realtime-service-ended"
+      ],
+      "evidenceHash": "ed21a8b33890dec5c882307524442431ae23115a699ffba2c8d3723382049d85",
+      "reasonCode": "PUBLIC_API_NO_DATA",
+      "reviewedAt": "2026-07-13T17:50:29.249Z",
+      "nextReviewAt": "2026-10-11T17:50:29.249Z"
+    }
+  ]
+}

--- a/tools/realtime/regional-realtime-provider-decisions.json
+++ b/tools/realtime/regional-realtime-provider-decisions.json
@@ -57,6 +57,7 @@
     "targetCount": 12,
     "credentialSafeCallCount": 28,
     "uniqueQueryCount": 14,
+    "supportedCount": 0,
     "explicitNoDataCount": 11,
     "falsePositiveClassifiedCount": 1,
     "boundedRetryCount": 1,

--- a/tools/routes/build-realtime-provider-coverage-report.mjs
+++ b/tools/routes/build-realtime-provider-coverage-report.mjs
@@ -39,6 +39,7 @@ export function buildRealtimeProviderCoverageReport(input) {
   const missingCount = coverageRequirements.filter(({ state }) => state === "MISSING").length;
   const requirementCount = coverageRequirements.length;
   const nationwideRealtimeSupportAllowed = requirementCount > 0 && supportedCount === requirementCount;
+  const allRequirementsResolved = requirementCount > 0 && missingCount === 0;
 
   return {
     schemaVersion: 1,
@@ -67,6 +68,14 @@ export function buildRealtimeProviderCoverageReport(input) {
       missingCount,
       supportedRatio: ratio(supportedCount, requirementCount),
       terminalResolutionRatio: ratio(supportedCount + explicitlyUnsupportedCount, requirementCount),
+    },
+    resolutionGate: {
+      allRequirementsResolved,
+      reasonCode: allRequirementsResolved
+        ? "ALL_REALTIME_REQUIREMENTS_RESOLVED"
+        : requirementCount === 0
+          ? "NO_REALTIME_REQUIREMENTS"
+          : "REALTIME_REQUIREMENTS_MISSING",
     },
     capabilityMetadata: coverageRequirements.map((requirement) => ({
       regionId: requirement.regionId,

--- a/tools/routes/build-realtime-provider-coverage-report.test.mjs
+++ b/tools/routes/build-realtime-provider-coverage-report.test.mjs
@@ -125,6 +125,10 @@ test("3상태 resolution은 지원률과 조사완결률을 분리하고 PLANNED
     supportedRatio: 1 / 3,
     terminalResolutionRatio: 2 / 3,
   });
+  assert.deepEqual(report.resolutionGate, {
+    allRequirementsResolved: false,
+    reasonCode: "REALTIME_REQUIREMENTS_MISSING",
+  });
   assert.equal(report.claimGate.nationwideRealtimeSupportAllowed, false);
   assert.equal(report.claimGate.reasonCode, "REALTIME_REQUIREMENTS_NOT_ALL_SUPPORTED");
   assert.deepEqual(report.capabilityMetadata.map(({ effectiveCapability }) => effectiveCapability), [
@@ -132,6 +136,35 @@ test("3상태 resolution은 지원률과 조사완결률을 분리하고 PLANNED
     "PLANNED",
     "UNKNOWN",
   ]);
+});
+
+test("지원과 공식 미지원만 있으면 실시간 전국 claim과 별개로 조사는 완결된다", () => {
+  const report = buildRealtimeProviderCoverageReport({
+    coverageRequirements: [
+      {
+        regionId: "capital",
+        operatorId: "seoul-metro",
+        lineId: "seoul-2",
+        sourceDomain: "realtime_arrivals",
+        state: "SUPPORTED",
+        fallback: "NONE",
+      },
+      {
+        regionId: "busan",
+        operatorId: "busan-transportation",
+        lineId: "busan-1",
+        sourceDomain: "realtime_arrivals",
+        state: "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+        fallback: "UNSUPPORTED_REGION",
+      },
+    ],
+  });
+
+  assert.deepEqual(report.resolutionGate, {
+    allRequirementsResolved: true,
+    reasonCode: "ALL_REALTIME_REQUIREMENTS_RESOLVED",
+  });
+  assert.equal(report.claimGate.nationwideRealtimeSupportAllowed, false);
 });
 
 test("중복 requirement와 미지원 REALTIME fallback은 거부한다", () => {

--- a/tools/routes/build-regional-realtime-provider-decision-report.mjs
+++ b/tools/routes/build-regional-realtime-provider-decision-report.mjs
@@ -29,7 +29,6 @@ export function buildRegionalRealtimeProviderDecisionReport({ targets, contract 
 
   const sources = validateOfficialSources(contract.officialSources);
   const sourcesById = new Map(sources.map((source) => [source.id, source]));
-  validatePublicApiAudit(contract.publicApiAudit, scopes.length);
 
   const decisionsByKey = new Map();
   for (const [index, decision] of contract.decisions.entries()) {
@@ -49,6 +48,8 @@ export function buildRegionalRealtimeProviderDecisionReport({ targets, contract 
     if (!decision) throw new Error(`missing regional realtime decision: ${key}`);
     return decision;
   });
+  const supportedDecisionCount = decisions.filter(({ state }) => state === "SUPPORTED").length;
+  validatePublicApiAudit(contract.publicApiAudit, scopes.length, supportedDecisionCount);
 
   const regionIds = [...new Set(scopes.map(({ regionId }) => regionId))]
     .sort((left, right) => left.localeCompare(right, "en"));
@@ -130,13 +131,14 @@ function validateOfficialSources(value) {
   });
 }
 
-function validatePublicApiAudit(audit, scopeCount) {
+function validatePublicApiAudit(audit, scopeCount, supportedDecisionCount) {
   if (!audit || typeof audit !== "object" || Array.isArray(audit)) {
     throw new Error("publicApiAudit is required");
   }
   for (const field of [
     "targetCount",
     "credentialSafeCallCount",
+    "supportedCount",
     "explicitNoDataCount",
     "falsePositiveClassifiedCount",
     "boundedRetryCount",
@@ -146,8 +148,11 @@ function validatePublicApiAudit(audit, scopeCount) {
     }
   }
   if (audit.targetCount !== scopeCount
-    || audit.explicitNoDataCount + audit.falsePositiveClassifiedCount !== scopeCount) {
+    || audit.supportedCount + audit.explicitNoDataCount + audit.falsePositiveClassifiedCount !== scopeCount) {
     throw new Error("publicApiAudit counts must resolve every regional scope");
+  }
+  if (audit.supportedCount !== supportedDecisionCount) {
+    throw new Error("publicApiAudit.supportedCount must match supported decisions");
   }
   if (audit.credentialSafeCallCount < audit.targetCount) {
     throw new Error("publicApiAudit credential-safe calls must cover every target");

--- a/tools/routes/build-regional-realtime-provider-decision-report.mjs
+++ b/tools/routes/build-regional-realtime-provider-decision-report.mjs
@@ -138,6 +138,7 @@ function validatePublicApiAudit(audit, scopeCount, supportedDecisionCount) {
   for (const field of [
     "targetCount",
     "credentialSafeCallCount",
+    "uniqueQueryCount",
     "supportedCount",
     "explicitNoDataCount",
     "falsePositiveClassifiedCount",

--- a/tools/routes/build-regional-realtime-provider-decision-report.mjs
+++ b/tools/routes/build-regional-realtime-provider-decision-report.mjs
@@ -1,0 +1,217 @@
+#!/usr/bin/env node
+import { readFile, writeFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+
+import { buildRealtimeProviderCoverageReport } from "./build-realtime-provider-coverage-report.mjs";
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main(process.argv.slice(2)).catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}
+
+export async function main(argv) {
+  const args = parseArgs(argv);
+  const targets = JSON.parse(await readFile(args.targets, "utf8"));
+  const contract = JSON.parse(await readFile(args.contract, "utf8"));
+  const report = buildRegionalRealtimeProviderDecisionReport({ targets, contract });
+  await writeFile(args.output, `${JSON.stringify(report, null, 2)}\n`);
+  return report;
+}
+
+export function buildRegionalRealtimeProviderDecisionReport({ targets, contract } = {}) {
+  validateContractHeader(targets, contract);
+  const excludedRegionIds = uniqueStrings(contract.scope?.excludedRegionIds, "scope.excludedRegionIds");
+  const excluded = new Set(excludedRegionIds);
+  const scopes = targets.activeLineScopes.filter(({ regionId }) => !excluded.has(regionId));
+  if (scopes.length === 0) throw new Error("regional realtime scope must not be empty");
+
+  const sources = validateOfficialSources(contract.officialSources);
+  const sourcesById = new Map(sources.map((source) => [source.id, source]));
+  validatePublicApiAudit(contract.publicApiAudit, scopes.length);
+
+  const decisionsByKey = new Map();
+  for (const [index, decision] of contract.decisions.entries()) {
+    const normalized = validateDecision(decision, index, sourcesById);
+    const key = scopeKey(normalized);
+    if (decisionsByKey.has(key)) throw new Error(`duplicate regional realtime decision: ${key}`);
+    decisionsByKey.set(key, normalized);
+  }
+
+  const scopeKeys = new Set(scopes.map(scopeKey));
+  for (const key of decisionsByKey.keys()) {
+    if (!scopeKeys.has(key)) throw new Error(`unknown regional realtime decision: ${key}`);
+  }
+  const decisions = scopes.map((scope) => {
+    const key = scopeKey(scope);
+    const decision = decisionsByKey.get(key);
+    if (!decision) throw new Error(`missing regional realtime decision: ${key}`);
+    return decision;
+  });
+
+  const regionIds = [...new Set(scopes.map(({ regionId }) => regionId))]
+    .sort((left, right) => left.localeCompare(right, "en"));
+  const scope = {
+    excludedRegionIds,
+    regionIds,
+    activeLineOperatorScopeCount: scopes.length,
+  };
+  const coverageRequirements = decisions.map((decision) => ({
+    regionId: decision.regionId,
+    operatorId: decision.operatorId,
+    lineId: decision.lineId,
+    sourceDomain: "realtime_arrivals",
+    state: decision.state,
+    fallback: decision.fallback,
+    userMessageKo: decision.userMessageKo,
+  }));
+  const coverage = buildRealtimeProviderCoverageReport({
+    scope,
+    stationLinePairs: [],
+    samples: [],
+    coverageRequirements,
+    unsupportedRegions: regionIds.map((region) => ({
+      region,
+      reason: "실시간 미지원",
+    })),
+  });
+
+  return {
+    ...coverage,
+    artifactKind: "regional-realtime-provider-decision-report",
+    issue: contract.issue,
+    targetVersion: contract.targetVersion,
+    verifiedAt: contract.verifiedAt,
+    officialSources: sources,
+    publicApiAudit: contract.publicApiAudit,
+    decisionEvidence: decisions,
+  };
+}
+
+function validateContractHeader(targets, contract) {
+  if (!targets || !Array.isArray(targets.activeLineScopes) || targets.activeLineScopes.length === 0) {
+    throw new Error("nationwide activeLineScopes are required");
+  }
+  if (!contract || contract.schemaVersion !== 1
+    || contract.artifactKind !== "regional-realtime-provider-decisions") {
+    throw new Error("regional realtime provider decision contract is invalid");
+  }
+  if (contract.issue !== 1621) throw new Error("regional realtime provider decision issue must be 1621");
+  if (requiredString(contract.targetVersion, "targetVersion") !== targets.targetVersion) {
+    throw new Error("regional realtime targetVersion must match nationwide targets");
+  }
+  if (!Number.isFinite(Date.parse(requiredString(contract.verifiedAt, "verifiedAt")))) {
+    throw new Error("verifiedAt must be an ISO timestamp");
+  }
+  if (!Array.isArray(contract.decisions) || contract.decisions.length === 0) {
+    throw new Error("regional realtime decisions are required");
+  }
+}
+
+function validateOfficialSources(value) {
+  if (!Array.isArray(value) || value.length === 0) throw new Error("officialSources are required");
+  const seen = new Set();
+  return value.map((source, index) => {
+    const label = `officialSources[${index}]`;
+    const id = requiredString(source?.id, `${label}.id`);
+    if (seen.has(id)) throw new Error(`duplicate official source: ${id}`);
+    seen.add(id);
+    const url = new URL(requiredString(source.url, `${label}.url`));
+    if (url.protocol !== "https:" || url.hostname !== "www.data.go.kr") {
+      throw new Error(`${label}.url must be an official data.go.kr HTTPS URL`);
+    }
+    return {
+      ...source,
+      id,
+      url: url.href,
+      decision: requiredString(source.decision, `${label}.decision`),
+    };
+  });
+}
+
+function validatePublicApiAudit(audit, scopeCount) {
+  if (!audit || typeof audit !== "object" || Array.isArray(audit)) {
+    throw new Error("publicApiAudit is required");
+  }
+  for (const field of [
+    "targetCount",
+    "credentialSafeCallCount",
+    "explicitNoDataCount",
+    "falsePositiveClassifiedCount",
+    "boundedRetryCount",
+  ]) {
+    if (!Number.isInteger(audit[field]) || audit[field] < 0) {
+      throw new Error(`publicApiAudit.${field} must be a non-negative integer`);
+    }
+  }
+  if (audit.targetCount !== scopeCount
+    || audit.explicitNoDataCount + audit.falsePositiveClassifiedCount !== scopeCount) {
+    throw new Error("publicApiAudit counts must resolve every regional scope");
+  }
+  if (audit.credentialSafeCallCount < audit.targetCount) {
+    throw new Error("publicApiAudit credential-safe calls must cover every target");
+  }
+  if (!/^[a-f0-9]{64}$/.test(audit.searchPlanSha256 ?? "")) {
+    throw new Error("publicApiAudit.searchPlanSha256 is invalid");
+  }
+}
+
+function validateDecision(decision, index, sourcesById) {
+  const label = `decisions[${index}]`;
+  const normalized = {};
+  for (const field of ["regionId", "operatorId", "lineId", "state", "fallback", "routeFallbackCapability", "userMessageKo"]) {
+    normalized[field] = requiredString(decision?.[field], `${label}.${field}`);
+  }
+  if (!new Set(["SUPPORTED", "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE"]).has(normalized.state)) {
+    throw new Error(`${label}.state must be terminal`);
+  }
+  if (normalized.state === "SUPPORTED") {
+    normalized.providerId = requiredString(decision.providerId, `${label}.providerId`);
+    if (normalized.fallback !== "NONE") throw new Error(`${label} supported fallback must be NONE`);
+  } else {
+    if (normalized.fallback === "REALTIME") throw new Error(`${label} unsupported fallback must not be REALTIME`);
+    if (normalized.routeFallbackCapability !== "PLANNED") {
+      throw new Error(`${label}.routeFallbackCapability must be PLANNED`);
+    }
+  }
+  if (/(coverage|provider|승격|게이트|검증|pilot)/iu.test(normalized.userMessageKo)) {
+    throw new Error(`${label}.userMessageKo contains internal release vocabulary`);
+  }
+  normalized.evidenceRefs = uniqueStrings(decision.evidenceRefs, `${label}.evidenceRefs`);
+  for (const evidenceRef of normalized.evidenceRefs) {
+    if (!sourcesById.has(evidenceRef)) throw new Error(`${label} has unknown evidence ref: ${evidenceRef}`);
+  }
+  for (const field of ["evidenceHash", "reviewedAt", "nextReviewAt", "reasonCode"]) {
+    if (decision[field] !== undefined) normalized[field] = requiredString(decision[field], `${label}.${field}`);
+  }
+  if (normalized.evidenceHash && !/^[a-f0-9]{64}$/.test(normalized.evidenceHash)) {
+    throw new Error(`${label}.evidenceHash is invalid`);
+  }
+  return normalized;
+}
+
+function uniqueStrings(value, label) {
+  if (!Array.isArray(value) || value.length === 0
+    || value.some((item) => typeof item !== "string" || item.trim() === "")) {
+    throw new Error(`${label} must be a non-empty string array`);
+  }
+  if (new Set(value).size !== value.length) throw new Error(`${label} must not contain duplicates`);
+  return [...value];
+}
+
+function requiredString(value, label) {
+  if (typeof value !== "string" || value.trim() === "") throw new Error(`${label} is required`);
+  return value;
+}
+
+function scopeKey({ regionId, operatorId, lineId }) {
+  return `${regionId}:${operatorId}:${lineId}`;
+}
+
+function parseArgs(argv) {
+  if (argv.length !== 6 || argv[0] !== "--targets" || argv[2] !== "--contract" || argv[4] !== "--output") {
+    throw new Error("usage: build-regional-realtime-provider-decision-report.mjs --targets <targets.json> --contract <decisions.json> --output <report.json>");
+  }
+  return { targets: argv[1], contract: argv[3], output: argv[5] };
+}

--- a/tools/routes/build-regional-realtime-provider-decision-report.mjs
+++ b/tools/routes/build-regional-realtime-provider-decision-report.mjs
@@ -48,8 +48,7 @@ export function buildRegionalRealtimeProviderDecisionReport({ targets, contract 
     if (!decision) throw new Error(`missing regional realtime decision: ${key}`);
     return decision;
   });
-  const supportedDecisionCount = decisions.filter(({ state }) => state === "SUPPORTED").length;
-  validatePublicApiAudit(contract.publicApiAudit, scopes.length, supportedDecisionCount);
+  validatePublicApiAudit(contract.publicApiAudit, scopes.length, decisions);
 
   const regionIds = [...new Set(scopes.map(({ regionId }) => regionId))]
     .sort((left, right) => left.localeCompare(right, "en"));
@@ -131,7 +130,7 @@ function validateOfficialSources(value) {
   });
 }
 
-function validatePublicApiAudit(audit, scopeCount, supportedDecisionCount) {
+function validatePublicApiAudit(audit, scopeCount, decisions) {
   if (!audit || typeof audit !== "object" || Array.isArray(audit)) {
     throw new Error("publicApiAudit is required");
   }
@@ -152,8 +151,19 @@ function validatePublicApiAudit(audit, scopeCount, supportedDecisionCount) {
     || audit.supportedCount + audit.explicitNoDataCount + audit.falsePositiveClassifiedCount !== scopeCount) {
     throw new Error("publicApiAudit counts must resolve every regional scope");
   }
+  const supportedDecisionCount = decisions.filter(({ state }) => state === "SUPPORTED").length;
+  const explicitNoDataDecisionCount = decisions.filter(({ reasonCode }) => reasonCode === "PUBLIC_API_NO_DATA").length;
+  const falsePositiveDecisionCount = decisions.filter(
+    ({ reasonCode }) => reasonCode === "PUBLIC_API_FALSE_POSITIVE_SCHEDULE_ONLY",
+  ).length;
   if (audit.supportedCount !== supportedDecisionCount) {
     throw new Error("publicApiAudit.supportedCount must match supported decisions");
+  }
+  if (audit.explicitNoDataCount !== explicitNoDataDecisionCount) {
+    throw new Error("publicApiAudit.explicitNoDataCount must match no-data decisions");
+  }
+  if (audit.falsePositiveClassifiedCount !== falsePositiveDecisionCount) {
+    throw new Error("publicApiAudit.falsePositiveClassifiedCount must match false-positive decisions");
   }
   if (audit.credentialSafeCallCount < audit.targetCount) {
     throw new Error("publicApiAudit credential-safe calls must cover every target");
@@ -172,23 +182,30 @@ function validateDecision(decision, index, sourcesById) {
   if (!new Set(["SUPPORTED", "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE"]).has(normalized.state)) {
     throw new Error(`${label}.state must be terminal`);
   }
+  normalized.evidenceRefs = uniqueStrings(decision.evidenceRefs, `${label}.evidenceRefs`);
+  for (const evidenceRef of normalized.evidenceRefs) {
+    if (!sourcesById.has(evidenceRef)) throw new Error(`${label} has unknown evidence ref: ${evidenceRef}`);
+  }
   if (normalized.state === "SUPPORTED") {
     normalized.providerId = requiredString(decision.providerId, `${label}.providerId`);
     if (normalized.fallback !== "NONE") throw new Error(`${label} supported fallback must be NONE`);
+    if (normalized.evidenceRefs.some((evidenceRef) => sourcesById.get(evidenceRef).decision !== "REALTIME_SUPPORTED")) {
+      throw new Error(`${label} supported evidence must use realtime-supporting official sources`);
+    }
   } else {
     if (normalized.fallback === "REALTIME") throw new Error(`${label} unsupported fallback must not be REALTIME`);
     if (normalized.routeFallbackCapability !== "PLANNED") {
       throw new Error(`${label}.routeFallbackCapability must be PLANNED`);
     }
+    normalized.reasonCode = requiredString(decision.reasonCode, `${label}.reasonCode`);
+    if (!new Set(["PUBLIC_API_NO_DATA", "PUBLIC_API_FALSE_POSITIVE_SCHEDULE_ONLY"]).has(normalized.reasonCode)) {
+      throw new Error(`${label}.reasonCode is not an allowed unsupported classification`);
+    }
   }
   if (/(coverage|provider|승격|게이트|검증|pilot)/iu.test(normalized.userMessageKo)) {
     throw new Error(`${label}.userMessageKo contains internal release vocabulary`);
   }
-  normalized.evidenceRefs = uniqueStrings(decision.evidenceRefs, `${label}.evidenceRefs`);
-  for (const evidenceRef of normalized.evidenceRefs) {
-    if (!sourcesById.has(evidenceRef)) throw new Error(`${label} has unknown evidence ref: ${evidenceRef}`);
-  }
-  for (const field of ["evidenceHash", "reviewedAt", "nextReviewAt", "reasonCode"]) {
+  for (const field of ["evidenceHash", "reviewedAt", "nextReviewAt"]) {
     if (decision[field] !== undefined) normalized[field] = requiredString(decision[field], `${label}.${field}`);
   }
   if (normalized.evidenceHash && !/^[a-f0-9]{64}$/.test(normalized.evidenceHash)) {

--- a/tools/routes/build-regional-realtime-provider-decision-report.test.mjs
+++ b/tools/routes/build-regional-realtime-provider-decision-report.test.mjs
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import { buildRegionalRealtimeProviderDecisionReport } from "./build-regional-realtime-provider-decision-report.mjs";
+
+const targets = {
+  targetVersion: "2026-07-13",
+  activeLineScopes: [
+    { regionId: "capital", operatorId: "seoul-metro", lineId: "seoul-2" },
+    { regionId: "busan", operatorId: "busan-transportation", lineId: "busan-1" },
+    { regionId: "daejeon", operatorId: "daejeon-transportation", lineId: "daejeon-1" },
+  ],
+};
+
+const officialSources = [
+  {
+    id: "public-api-audit",
+    url: "https://www.data.go.kr/data/15000522/openapi.do",
+    decision: "SCHEDULE_ONLY_NOT_REALTIME",
+  },
+];
+
+function contract(decisions = [
+  decision("busan", "busan-transportation", "busan-1"),
+  decision("daejeon", "daejeon-transportation", "daejeon-1"),
+]) {
+  return {
+    schemaVersion: 1,
+    artifactKind: "regional-realtime-provider-decisions",
+    issue: 1621,
+    targetVersion: "2026-07-13",
+    verifiedAt: "2026-07-13T17:50:29.249Z",
+    scope: { excludedRegionIds: ["capital"] },
+    officialSources,
+    publicApiAudit: {
+      targetCount: 2,
+      credentialSafeCallCount: 2,
+      explicitNoDataCount: 1,
+      falsePositiveClassifiedCount: 1,
+      boundedRetryCount: 1,
+      searchPlanSha256: "a".repeat(64),
+    },
+    decisions,
+  };
+}
+
+function decision(regionId, operatorId, lineId) {
+  return {
+    regionId,
+    operatorId,
+    lineId,
+    state: "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+    fallback: "UNSUPPORTED_REGION",
+    routeFallbackCapability: "PLANNED",
+    userMessageKo: "이 지역은 실시간 도착 정보를 아직 제공하지 않아요.",
+    evidenceRefs: ["public-api-audit"],
+  };
+}
+
+test("비서울 active line 전체를 terminal state로 완결하고 실시간 claim은 열지 않는다", () => {
+  const report = buildRegionalRealtimeProviderDecisionReport({ targets, contract: contract() });
+
+  assert.equal(report.artifactKind, "regional-realtime-provider-decision-report");
+  assert.deepEqual(report.scope, {
+    excludedRegionIds: ["capital"],
+    regionIds: ["busan", "daejeon"],
+    activeLineOperatorScopeCount: 2,
+  });
+  assert.deepEqual(report.coverageResolution, {
+    requirementCount: 2,
+    supportedCount: 0,
+    explicitlyUnsupportedCount: 2,
+    missingCount: 0,
+    supportedRatio: 0,
+    terminalResolutionRatio: 1,
+  });
+  assert.equal(report.resolutionGate.allRequirementsResolved, true);
+  assert.equal(report.claimGate.nationwideRealtimeSupportAllowed, false);
+  assert.deepEqual(report.decisionEvidence.map(({ routeFallbackCapability }) => routeFallbackCapability), [
+    "PLANNED",
+    "PLANNED",
+  ]);
+});
+
+test("target 누락·알 수 없는 evidence·내부 gate 문구를 거부한다", () => {
+  assert.throws(
+    () => buildRegionalRealtimeProviderDecisionReport({ targets, contract: contract([decision("busan", "busan-transportation", "busan-1")]) }),
+    /missing regional realtime decision/,
+  );
+  assert.throws(
+    () => buildRegionalRealtimeProviderDecisionReport({
+      targets,
+      contract: contract([
+        { ...decision("busan", "busan-transportation", "busan-1"), evidenceRefs: ["missing"] },
+        decision("daejeon", "daejeon-transportation", "daejeon-1"),
+      ]),
+    }),
+    /unknown evidence ref/,
+  );
+  assert.throws(
+    () => buildRegionalRealtimeProviderDecisionReport({
+      targets,
+      contract: contract([
+        { ...decision("busan", "busan-transportation", "busan-1"), userMessageKo: "provider gate 미통과" },
+        decision("daejeon", "daejeon-transportation", "daejeon-1"),
+      ]),
+    }),
+    /internal release vocabulary/,
+  );
+});
+
+test("tracked 전국 target과 권역 decision report가 동일하게 재생성된다", async () => {
+  const trackedTargets = JSON.parse(await readFile("tools/datapack/nationwide-coverage-targets.json", "utf8"));
+  const trackedContract = JSON.parse(await readFile("tools/realtime/regional-realtime-provider-decisions.json", "utf8"));
+  const trackedReport = JSON.parse(await readFile("tools/realtime/regional-realtime-provider-decision-report.json", "utf8"));
+
+  assert.deepEqual(
+    buildRegionalRealtimeProviderDecisionReport({ targets: trackedTargets, contract: trackedContract }),
+    trackedReport,
+  );
+});

--- a/tools/routes/build-regional-realtime-provider-decision-report.test.mjs
+++ b/tools/routes/build-regional-realtime-provider-decision-report.test.mjs
@@ -36,6 +36,7 @@ function contract(decisions = [
     publicApiAudit: {
       targetCount: 2,
       credentialSafeCallCount: 2,
+      supportedCount: 0,
       explicitNoDataCount: 1,
       falsePositiveClassifiedCount: 1,
       boundedRetryCount: 1,
@@ -54,6 +55,20 @@ function decision(regionId, operatorId, lineId) {
     fallback: "UNSUPPORTED_REGION",
     routeFallbackCapability: "PLANNED",
     userMessageKo: "이 지역은 실시간 도착 정보를 아직 제공하지 않아요.",
+    evidenceRefs: ["public-api-audit"],
+  };
+}
+
+function supportedDecision(regionId, operatorId, lineId) {
+  return {
+    regionId,
+    operatorId,
+    lineId,
+    state: "SUPPORTED",
+    fallback: "NONE",
+    routeFallbackCapability: "PLANNED",
+    providerId: "approved-provider",
+    userMessageKo: "실시간 도착 정보를 제공해요.",
     evidenceRefs: ["public-api-audit"],
   };
 }
@@ -107,6 +122,44 @@ test("target 누락·알 수 없는 evidence·내부 gate 문구를 거부한다
       ]),
     }),
     /internal release vocabulary/,
+  );
+});
+
+test("SUPPORTED 결정은 providerId와 fallback NONE 계약을 지킨다", () => {
+  const supported = supportedDecision("busan", "busan-transportation", "busan-1");
+  const supportedContract = contract([
+    supported,
+    decision("daejeon", "daejeon-transportation", "daejeon-1"),
+  ]);
+  supportedContract.publicApiAudit = {
+    ...supportedContract.publicApiAudit,
+    supportedCount: 1,
+    explicitNoDataCount: 0,
+  };
+
+  const report = buildRegionalRealtimeProviderDecisionReport({ targets, contract: supportedContract });
+  assert.equal(report.coverageResolution.supportedCount, 1);
+  assert.equal(report.coverageResolution.explicitlyUnsupportedCount, 1);
+  assert.equal(report.resolutionGate.allRequirementsResolved, true);
+  assert.equal(report.claimGate.nationwideRealtimeSupportAllowed, false);
+
+  const { providerId: _providerId, ...missingProvider } = supported;
+  assert.throws(
+    () => buildRegionalRealtimeProviderDecisionReport({
+      targets,
+      contract: { ...supportedContract, decisions: [missingProvider, supportedContract.decisions[1]] },
+    }),
+    /providerId is required/,
+  );
+  assert.throws(
+    () => buildRegionalRealtimeProviderDecisionReport({
+      targets,
+      contract: {
+        ...supportedContract,
+        decisions: [{ ...supported, fallback: "UNSUPPORTED_REGION" }, supportedContract.decisions[1]],
+      },
+    }),
+    /supported fallback must be NONE/,
   );
 });
 

--- a/tools/routes/build-regional-realtime-provider-decision-report.test.mjs
+++ b/tools/routes/build-regional-realtime-provider-decision-report.test.mjs
@@ -36,6 +36,7 @@ function contract(decisions = [
     publicApiAudit: {
       targetCount: 2,
       credentialSafeCallCount: 2,
+      uniqueQueryCount: 2,
       supportedCount: 0,
       explicitNoDataCount: 1,
       falsePositiveClassifiedCount: 1,
@@ -160,6 +161,16 @@ test("SUPPORTED 결정은 providerId와 fallback NONE 계약을 지킨다", () =
       },
     }),
     /supported fallback must be NONE/,
+  );
+});
+
+test("public API 감사의 uniqueQueryCount는 음이 아닌 정수다", () => {
+  const invalidContract = contract();
+  invalidContract.publicApiAudit.uniqueQueryCount = -1;
+
+  assert.throws(
+    () => buildRegionalRealtimeProviderDecisionReport({ targets, contract: invalidContract }),
+    /publicApiAudit.uniqueQueryCount must be a non-negative integer/,
   );
 });
 

--- a/tools/routes/build-regional-realtime-provider-decision-report.test.mjs
+++ b/tools/routes/build-regional-realtime-provider-decision-report.test.mjs
@@ -19,11 +19,16 @@ const officialSources = [
     url: "https://www.data.go.kr/data/15000522/openapi.do",
     decision: "SCHEDULE_ONLY_NOT_REALTIME",
   },
+  {
+    id: "approved-realtime-source",
+    url: "https://www.data.go.kr/data/15000000/openapi.do",
+    decision: "REALTIME_SUPPORTED",
+  },
 ];
 
 function contract(decisions = [
   decision("busan", "busan-transportation", "busan-1"),
-  decision("daejeon", "daejeon-transportation", "daejeon-1"),
+  decision("daejeon", "daejeon-transportation", "daejeon-1", "PUBLIC_API_FALSE_POSITIVE_SCHEDULE_ONLY"),
 ]) {
   return {
     schemaVersion: 1,
@@ -47,7 +52,7 @@ function contract(decisions = [
   };
 }
 
-function decision(regionId, operatorId, lineId) {
+function decision(regionId, operatorId, lineId, reasonCode = "PUBLIC_API_NO_DATA") {
   return {
     regionId,
     operatorId,
@@ -57,6 +62,7 @@ function decision(regionId, operatorId, lineId) {
     routeFallbackCapability: "PLANNED",
     userMessageKo: "이 지역은 실시간 도착 정보를 아직 제공하지 않아요.",
     evidenceRefs: ["public-api-audit"],
+    reasonCode,
   };
 }
 
@@ -70,7 +76,7 @@ function supportedDecision(regionId, operatorId, lineId) {
     routeFallbackCapability: "PLANNED",
     providerId: "approved-provider",
     userMessageKo: "실시간 도착 정보를 제공해요.",
-    evidenceRefs: ["public-api-audit"],
+    evidenceRefs: ["approved-realtime-source"],
   };
 }
 
@@ -130,7 +136,7 @@ test("SUPPORTED 결정은 providerId와 fallback NONE 계약을 지킨다", () =
   const supported = supportedDecision("busan", "busan-transportation", "busan-1");
   const supportedContract = contract([
     supported,
-    decision("daejeon", "daejeon-transportation", "daejeon-1"),
+    decision("daejeon", "daejeon-transportation", "daejeon-1", "PUBLIC_API_FALSE_POSITIVE_SCHEDULE_ONLY"),
   ]);
   supportedContract.publicApiAudit = {
     ...supportedContract.publicApiAudit,
@@ -161,6 +167,53 @@ test("SUPPORTED 결정은 providerId와 fallback NONE 계약을 지킨다", () =
       },
     }),
     /supported fallback must be NONE/,
+  );
+  assert.throws(
+    () => buildRegionalRealtimeProviderDecisionReport({
+      targets,
+      contract: {
+        ...supportedContract,
+        decisions: [{ ...supported, evidenceRefs: ["public-api-audit"] }, supportedContract.decisions[1]],
+      },
+    }),
+    /supported evidence must use realtime-supporting official sources/,
+  );
+  assert.throws(
+    () => buildRegionalRealtimeProviderDecisionReport({
+      targets,
+      contract: {
+        ...supportedContract,
+        publicApiAudit: {
+          ...supportedContract.publicApiAudit,
+          supportedCount: 0,
+          explicitNoDataCount: 1,
+          falsePositiveClassifiedCount: 1,
+        },
+      },
+    }),
+    /supportedCount must match supported decisions/,
+  );
+});
+
+test("public API 감사 분류 수는 decision reasonCode별 실제 수와 일치한다", () => {
+  const mismatchedContract = contract([
+    decision("busan", "busan-transportation", "busan-1"),
+    decision("daejeon", "daejeon-transportation", "daejeon-1"),
+  ]);
+
+  assert.throws(
+    () => buildRegionalRealtimeProviderDecisionReport({ targets, contract: mismatchedContract }),
+    /explicitNoDataCount must match no-data decisions/,
+  );
+  assert.throws(
+    () => buildRegionalRealtimeProviderDecisionReport({
+      targets,
+      contract: contract([
+        { ...decision("busan", "busan-transportation", "busan-1"), reasonCode: "OTHER" },
+        decision("daejeon", "daejeon-transportation", "daejeon-1", "PUBLIC_API_FALSE_POSITIVE_SCHEDULE_ONLY"),
+      ]),
+    }),
+    /reasonCode is not an allowed unsupported classification/,
   );
 });
 

--- a/tools/routes/check-route-commercialization-gate.mjs
+++ b/tools/routes/check-route-commercialization-gate.mjs
@@ -190,6 +190,10 @@ function validateCoverage(gate, report, failures) {
   if (number(report.freshness?.staleAsFreshCount) > 0) {
     failures.push("realtimeCoverage stale-as-fresh count exceeds 0");
   }
+  if (gate.realtimeCoverage.requireTerminalRegionalResolution
+    && report.resolutionGate?.allRequirementsResolved !== true) {
+    failures.push("realtimeCoverage regional requirements must all have terminal decisions");
+  }
   if (!Number.isFinite(Number(report.freshness?.staleCount))) {
     failures.push("realtimeCoverage stale count must be reported");
   }

--- a/tools/routes/check-route-commercialization-gate.test.mjs
+++ b/tools/routes/check-route-commercialization-gate.test.mjs
@@ -730,6 +730,61 @@ test("route commercialization gate requires realtime coverage provider and regio
   );
 });
 
+test("route commercialization gate requires every regional realtime scope to have a terminal decision", async () => {
+  const fixture = await writeFixtureSet({
+    accuracy: {
+      schemaVersion: 1,
+      sampleSize: 120,
+      sampleSourceCounts: { fixture: 0, staticTimetable: 0, realtimeProvider: 120, manualObservation: 120, staleRealtime: 0 },
+      productionSampleSize: 120,
+      metrics: {
+        singleRide: { sampleSize: 60, p50ErrorSeconds: 45, p90ErrorSeconds: 100 },
+        transfer: { sampleSize: 60, p50ErrorSeconds: 90, p90ErrorSeconds: 240 },
+      },
+      failures: [],
+    },
+    accessibility: {
+      schemaVersion: 1,
+      strictStepFreeKnownStairFalsePositiveCount: 0,
+      generatedConnectorVerifiedAccessibilityCount: 0,
+      unknownAccessibilityLabeled: true,
+    },
+    coverage: {
+      schemaVersion: 1,
+      supportedStationLinePairs: 150,
+      providerFreshnessSecondsMaxObserved: 80,
+      staleFallbackRequired: true,
+      freshness: { staleAsFreshCount: 0 },
+      mapping: { failureRate: 0 },
+      resolutionGate: { allRequirementsResolved: false, reasonCode: "REALTIME_REQUIREMENTS_MISSING" },
+    },
+    routeGraphCoverage: {
+      schemaVersion: 1,
+      generatedConnectorVerifiedAccessibilityCount: 0,
+      strictRouteNotFound: { total: 100, notFoundCount: 1, rate: 0.01, byReasonCode: {} },
+    },
+    contract: {
+      schemaVersion: 1,
+      multiTransferSupported: false,
+      outOfStationTransferSupported: false,
+      alternativeItinerariesMinObserved: 2,
+      wrongTransferCount: 0,
+      wrongLineSequence: 0,
+      routeNotFoundRate: 0.01,
+      releaseBlockersSatisfied: ["D-2", "D-3", "H-1"],
+    },
+  });
+
+  await assert.rejects(
+    execChecker(fixture),
+    (error) => {
+      const report = JSON.parse(error.stdout);
+      assert.ok(report.failures.includes("realtimeCoverage regional requirements must all have terminal decisions"));
+      return true;
+    },
+  );
+});
+
 test("route commercialization gate requires out-of-station allowlist evidence", async () => {
   const fixture = await writeFixtureSet({
     gateOverride: {
@@ -870,6 +925,10 @@ function normalizeAccuracyReport(report) {
 function normalizeCoverageReport(report) {
   return {
     ...report,
+    resolutionGate: report.resolutionGate ?? {
+      allRequirementsResolved: true,
+      reasonCode: "ALL_REALTIME_REQUIREMENTS_RESOLVED",
+    },
     freshness: {
       staleCount: 0,
       ...report.freshness,

--- a/tools/routes/check-route-commercialization-gate.test.mjs
+++ b/tools/routes/check-route-commercialization-gate.test.mjs
@@ -779,6 +779,7 @@ test("route commercialization gate requires every regional realtime scope to hav
     execChecker(fixture),
     (error) => {
       const report = JSON.parse(error.stdout);
+      assert.equal(report.status, "FAIL");
       assert.ok(report.failures.includes("realtimeCoverage regional requirements must all have terminal decisions"));
       return true;
     },


### PR DESCRIPTION
## 관련 이슈

close #1621

## 작업 배경

- 비서울 권역에 공개 실시간 도착 API가 없는데도 최소 1개 provider 승격을 강제해 이슈가 영구 미완료로 남는 계약을 바로잡습니다.
- 공식 미제공은 blocker가 아니라 근거가 있는 terminal state이며, 시간표 기반 PLANNED 경로와 실시간 도착 지원 claim을 분리해야 합니다.

## 작업 내용

- 전국 active line scope에서 수도권을 제외한 12개 line/operator를 권역 decision contract로 고정했습니다.
- credential-safe 공공데이터 검색 28회(고유 query 14개, bounded retry 1회)와 공식 operation 문서를 근거로 11개 `NO_DATA`, 대전 1개 시간표 false positive를 분류했습니다.
- coverage report에 전국 실시간 claim과 별개의 terminal resolution gate를 추가했습니다.
- route commercialization gate가 권역별 terminal decision 누락 시 fail-closed하도록 연결했습니다.
- #1414 readiness tracker와 datapack readiness gate가 tracked regional decision report를 필수 증거로 참조하도록 갱신했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/routes/*.test.mjs tools/ci/repository-contract.test.mjs` — 213/213 통과
  - `node --test tools/datapack/*.test.mjs` — 622/622 통과
  - `node --test tools/routes/build-regional-realtime-provider-decision-report.test.mjs` — 3/3 통과
  - credential-safe live audit — 12개 scope 전부 판정, 첫 HTTP 500은 bounded retry로 해소

## 검증 증거

UI 자체를 변경하지 않고 capability metadata와 release gate contract만 변경하므로 스크린샷은 필요하지 않습니다. 사용자 문구는 내부 release 용어 금지 테스트로 검증했습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 비서울 권역 판정 | 공통 | tracked report 재생성 비교 | `tools/realtime/regional-realtime-provider-decision-report.json` | 12/12 terminal, MISSING 0 |
| 공식 API 범위 | backend/data | credential-safe live search + 공식 operation 검토 | decision contract의 source URL·sanitized hash | PASS |
| release gate | 공통 | route/repository contract test | Node test 213개 | PASS |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [ ] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

영향: realtime coverage report의 권역 terminal resolution을 필수로 추가했으며 기존 정확도·접근성 임계값은 변경하지 않았습니다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: regional realtime terminal resolution 필수
- realtime contract: 비서울 12개 scope `EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE`
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `build-regional-realtime-provider-decision-report.mjs`의 exact-set 검증과 과장 claim 분리
  - 대전 검색 false positive를 `getAllTimeTable`/`getTimeTable` 시간표 operation으로 판정한 근거
  - runtime coverage에서 `resolutionGate.allRequirementsResolved`가 false일 때 commercialization gate가 차단되는지

## 리스크

- 공개 API catalog가 이후 변경될 수 있어 90일 재검토 시점을 evidence에 기록했습니다.
- 전국 실시간 지원 claim은 계속 false이며, 공개 provider가 새로 확인되면 별도 admission과 live mapping을 통과해야 `SUPPORTED`로 변경됩니다.
- production 배포나 provider credential 변경은 수행하지 않습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 지역별 실시간 도착 정보 제공 여부를 공식 근거와 함께 확인할 수 있는 검증 리포트를 추가했습니다.
  * 실시간 정보가 제공되지 않는 지역에는 명시적인 지원 불가 상태와 대체 경로를 안내합니다.

* **개선 사항**
  * 배포 준비 및 상용화 검증에서 모든 지역 요구사항이 최종 결정되었는지 확인하도록 강화했습니다.
  * 실시간 지원 범위와 검증 결과의 추적 가능성을 높였습니다.

* **버그 수정**
  * 실시간 제공 범위가 완전히 해소되지 않은 경우 배포 검증이 통과하지 않도록 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->