### PR TITLE
[Fix] production 배포·복구 준비 증거 완료

### DIFF
--- a/apps/mobile/release/backup-restore-rehearsal-gate.json
+++ b/apps/mobile/release/backup-restore-rehearsal-gate.json
@@ -48,8 +48,8 @@
       "area": "datapack",
       "ownerKo": "데이터팩 운영 담당자",
       "backupCommand": "tools/ops/data-source-raw-archive.sh",
-      "restoreRehearsalCommand": "node tools/datapack/validate-source-inventory.mjs --inventory tools/datapack/source-inventory.json",
-      "successEvidence": "source archive manifest와 source-inventory validation 통과",
+      "restoreRehearsalCommand": "node tools/ops/data-source-raw-archive-restore-check.mjs \"$EASYSUBWAY_DATA_SOURCE_RESTORE_DIR\" && node tools/datapack/validate-source-inventory.mjs --inventory tools/datapack/source-inventory.json",
+      "successEvidence": "self-contained source archive payload hash·size·ID 검증과 source-inventory validation 통과",
       "failureConditions": [
         "source inventory license 또는 updatedAt 누락",
         "source archive manifest가 비어 있음",
@@ -57,6 +57,8 @@
       ],
       "linkedArtifacts": [
         "tools/ops/data-source-raw-archive.sh",
+        "tools/ops/data-source-raw-archive-materialize.mjs",
+        "tools/ops/data-source-raw-archive-restore-check.mjs",
         "tools/datapack/source-inventory.json",
         "tools/datapack/validate-source-inventory.mjs"
       ]

--- a/apps/mobile/release/backup-restore-rehearsal-gate.json
+++ b/apps/mobile/release/backup-restore-rehearsal-gate.json
@@ -48,7 +48,7 @@
       "area": "datapack",
       "ownerKo": "데이터팩 운영 담당자",
       "backupCommand": "tools/ops/data-source-raw-archive.sh",
-      "restoreRehearsalCommand": "node tools/ops/data-source-raw-archive-restore-check.mjs && node tools/datapack/validate-source-inventory.mjs --inventory tools/datapack/source-inventory.json",
+      "restoreRehearsalCommand": "EASYSUBWAY_DATA_SOURCE_RESTORE_DIR=\"$RESTORED_ARCHIVE_DIR\" node tools/ops/data-source-raw-archive-restore-check.mjs && node tools/datapack/validate-source-inventory.mjs --inventory tools/datapack/source-inventory.json",
       "successEvidence": "self-contained source archive payload hash·size·ID 검증과 source-inventory validation 통과",
       "failureConditions": [
         "source inventory license 또는 updatedAt 누락",

--- a/apps/mobile/release/backup-restore-rehearsal-gate.json
+++ b/apps/mobile/release/backup-restore-rehearsal-gate.json
@@ -48,7 +48,7 @@
       "area": "datapack",
       "ownerKo": "데이터팩 운영 담당자",
       "backupCommand": "tools/ops/data-source-raw-archive.sh",
-      "restoreRehearsalCommand": "node tools/ops/data-source-raw-archive-restore-check.mjs \"$EASYSUBWAY_DATA_SOURCE_RESTORE_DIR\" && node tools/datapack/validate-source-inventory.mjs --inventory tools/datapack/source-inventory.json",
+      "restoreRehearsalCommand": "node tools/ops/data-source-raw-archive-restore-check.mjs && node tools/datapack/validate-source-inventory.mjs --inventory tools/datapack/source-inventory.json",
       "successEvidence": "self-contained source archive payload hash·size·ID 검증과 source-inventory validation 통과",
       "failureConditions": [
         "source inventory license 또는 updatedAt 누락",

--- a/apps/mobile/release/backup-restore-rehearsal-gate.json
+++ b/apps/mobile/release/backup-restore-rehearsal-gate.json
@@ -57,6 +57,7 @@
       ],
       "linkedArtifacts": [
         "tools/ops/data-source-raw-archive.sh",
+        "tools/ops/data-source-raw-archive-csv.mjs",
         "tools/ops/data-source-raw-archive-materialize.mjs",
         "tools/ops/data-source-raw-archive-restore-check.mjs",
         "tools/datapack/source-inventory.json",

--- a/apps/mobile/release/operations-release-evidence.json
+++ b/apps/mobile/release/operations-release-evidence.json
@@ -119,7 +119,7 @@
           "scaleOutProhibitedRunbook": "분산 limiter 구현 전 backend service scale-out 금지; 후속 #1022",
           "owner": "AquilaXk",
           "untilDate": "2026-10-13",
-          "postLaunchAbuseMonitoringThreshold": "report API 429 비율과 duplicate/orphan cleanup 실패를 운영 대시보드에서 감시",
+          "postLaunchAbuseMonitoringThreshold": "최근 5분 report API 요청 중 429 비율이 5%를 초과하거나 duplicate/orphan cleanup 실패가 1회 발생하면 신규 신고 트래픽을 제한하고 운영 담당자에게 즉시 경보",
           "distributedLimiterFollowUpIssue": 1022
         }
       },

--- a/apps/mobile/release/operations-release-evidence.json
+++ b/apps/mobile/release/operations-release-evidence.json
@@ -99,6 +99,13 @@
         "sensitiveValueCapturedInEvidence": false
       },
       "temporaryReleaseDecisions": {
+        "adminAuthTransition": {
+          "owner": "AquilaXk",
+          "untilDate": "2026-10-13",
+          "risk": "OIDC/MFA/SSO 전환 전까지 운영 관리자 인증은 제한된 legacy 경로와 break-glass 절차에 의존한다.",
+          "mitigation": "production Basic auth 기본 비활성화, required reviewer, lockout, credential rotation과 audit를 강제한다.",
+          "followUpIssue": 1020
+        },
         "operatorTenantScope": {
           "scope": "operator-global",
           "owner": "AquilaXk",

--- a/apps/mobile/release/operations-release-evidence.json
+++ b/apps/mobile/release/operations-release-evidence.json
@@ -67,11 +67,18 @@
         "entrypoint": "java -jar /app/app.jar",
         "profile": "prod"
       },
+      "datapackArtifact": {
+        "runUrl": "https://github.com/AquilaXk/easysubway/actions/runs/29271665083",
+        "result": "PASS_SUCCESS",
+        "commit": "c28a1c99b88ccf49bbecb60ca1810775db530813",
+        "artifact": "easysubway-datapacks-c28a1c99b88ccf49bbecb60ca1810775db530813",
+        "manifestRestore": "PASS_DOWNLOADED_ARTIFACT_MANIFEST_AND_SQLITE_VALIDATION"
+      },
       "restoreReadiness": {
         "postgresql": "PASS_ISOLATED_DUMP_RESTORE",
-        "facilityReportPhoto": "PASS_FIXTURE_HASH_SIZE_PATH",
-        "datapackSourceInventory": "PASS_SOURCE_INVENTORY_VALIDATION",
-        "datapackManifest": "PASS_BUNDLED_CHECKSUM_SQLITE_AUDIT"
+        "facilityReportPhoto": "PASS_ACTUAL_BACKUP_MANIFEST_OBJECT_HASH_SIZE_PATH",
+        "datapackSourceInventory": "PASS_ACTUAL_SELF_CONTAINED_RAW_ARCHIVE_RESTORE",
+        "datapackManifest": "PASS_DOWNLOADED_ACTIONS_ARTIFACT_MANIFEST_RESTORE"
       },
       "securityAndAdminReadiness": {
         "publicApiDefaultDenyAndMatcherContract": "PASS_SECURITY_CONFIG_TEST",
@@ -80,7 +87,16 @@
         "adminPagesRoleAndAccessibility": "PASS_PAGE_SMOKE_AND_ACCESSIBILITY_TESTS",
         "trustedProxyNegativeBoundary": "PASS_SECURITY_CONTRACT_TESTS",
         "facilityReportAbuseAndObjectStorage": "PASS_FOCUSED_TESTS",
-        "auditRedaction": "PASS_REPOSITORY_AND_BACKEND_TESTS"
+        "auditRedaction": "PASS_LOCAL_PROD_LIKE_AUDIT_DRILL_AND_TESTS"
+      },
+      "localProdLikeAdminDrill": {
+        "breakGlassFirstUse": "PASS_LOGIN_AND_CREDENTIAL_ROTATION_REQUIRED",
+        "breakGlassSecondCredentialUse": "PASS_LOGIN_AND_CREDENTIAL_ROTATION_REQUIRED",
+        "breakGlassFinalCredential": "PASS_ACTIVE_UNUSED_AFTER_RESTART",
+        "breakGlassLoginAudit": "PASS_SUCCESS_WITH_REASON_NO_SECRET",
+        "reportPhotoReadAudit": "PASS_PRIVACY_READ_WITH_REQUEST_ID_AND_REASON",
+        "adminMutationAudit": "PASS_CSRF_REJECTION_RECORDED_WITH_REQUEST_ID",
+        "sensitiveValueCapturedInEvidence": false
       },
       "temporaryReleaseDecisions": {
         "operatorTenantScope": {
@@ -101,18 +117,40 @@
         }
       },
       "resolvedEvidence": [
+        "backend-public-api-surface-inventory",
+        "default-deny-public-chain-test-output",
+        "security-matcher-contract-test-output",
+        "admin-auth-transition-decision-record",
+        "admin-basic-auth-prod-disabled-test-output",
+        "admin-operator-lockout-test-output",
+        "break-glass-rotation-drill-record",
+        "break-glass-use-immediate-rotation-record",
+        "admin-credential-rotation-cadence-record",
+        "operator-tenant-scope-decision-record",
+        "operator-global-audit-sample",
+        "trusted-proxy-negative-test-output",
+        "multi-instance-rate-limit-test-output-or-single-instance-exception",
+        "abuse-store-mode-release-blocker-record",
         "github-production-environment-required-reviewer-summary",
+        "staging-prod-environment-separation-summary",
         "production-secret-scope-review",
+        "admin-operator-page-smoke-output",
+        "admin-page-accessibility-smoke-output",
+        "admin-role-matrix-test-output",
+        "admin-mutating-action-audit-sample",
+        "privacy-read-audit-sample",
+        "report-photo-read-audit-sample",
+        "break-glass-use-audit-sample",
         "main-release-artifact-run-and-image-inspect",
+        "datapack-release-artifact-manifest-history-restore",
         "prod-like-env-validation-output",
         "local-prod-like-target-readiness-output",
         "local-prod-like-rollback-readiness-output",
         "postgresql-isolated-dump-restore-output",
-        "facility-report-photo-fixture-restore-output",
-        "datapack-source-inventory-validation-output",
-        "bundled-datapack-checksum-sqlite-audit-output",
+        "facility-report-photo-actual-backup-restore-output",
+        "datapack-source-raw-archive-actual-restore-output",
         "public-api-default-deny-and-security-matcher-tests",
-        "admin-lockout-audit-page-accessibility-and-abuse-tests",
+        "local-prod-like-break-glass-and-admin-audit-drill",
         "backend-gradle-check-output"
       ],
       "remainingBlockers": [],

--- a/apps/mobile/release/operations-release-evidence.json
+++ b/apps/mobile/release/operations-release-evidence.json
@@ -92,11 +92,11 @@
           "followUpIssue": 1020
         },
         "singleInstanceAbuseControl": {
-          "backendReplicaCount": 1,
-          "scaleOutPolicy": "분산 limiter 구현 전 backend service scale-out 금지",
+          "backendReplicaCountOneEvidence": "PASS_COMPOSE_BACKEND_SERVICE_SINGLE_REPLICA",
+          "scaleOutProhibitedRunbook": "분산 limiter 구현 전 backend service scale-out 금지; 후속 #1022",
           "owner": "AquilaXk",
           "untilDate": "2026-10-13",
-          "postLaunchMonitoringThreshold": "report API 429 비율과 duplicate/orphan cleanup 실패를 운영 대시보드에서 감시",
+          "postLaunchAbuseMonitoringThreshold": "report API 429 비율과 duplicate/orphan cleanup 실패를 운영 대시보드에서 감시",
           "distributedLimiterFollowUpIssue": 1022
         }
       },

--- a/apps/mobile/release/operations-release-evidence.json
+++ b/apps/mobile/release/operations-release-evidence.json
@@ -37,7 +37,11 @@
   "backendControlPlane": {
     "issue": 1017,
     "latestQaEvidenceStatus": {
-      "qaEvidenceDateKst": "2026-06-28",
+      "qaEvidenceDateKst": "2026-07-14",
+      "status": "SATISFIED",
+      "readinessResult": "PASS",
+      "scope": "production-environment-and-local-prod-like-readiness",
+      "productionMutationPerformed": false,
       "githubEnvironmentProtection": {
         "productionRequiredReviewer": "PASS_REQUIRED_REVIEWER_CONFIGURED",
         "productionEnvironmentSecret": "PASS_ENV_SCOPED_EASYSUBWAY_ENV_PRESENT",
@@ -47,48 +51,85 @@
       "prodLikeLocalValidation": {
         "deploymentEnvValidation": "PASS_VALIDATE_DEPLOYMENT_ENV",
         "backendCheck": "PASS_GRADLE_CHECK",
+        "targetRevision": "95702961b3bc59d1d1e2a3c89131ea242c349353",
+        "targetReadiness": "PASS_UP",
+        "rollbackRevision": "c28a1c99b88ccf49bbecb60ca1810775db530813",
+        "rollbackReadiness": "PASS_UP",
+        "migrationDiff": "PASS_NO_BACKEND_DIFF_BETWEEN_TARGET_AND_ROLLBACK",
         "secretValueCapturedInEvidence": false
+      },
+      "releaseArtifact": {
+        "runUrl": "https://github.com/AquilaXk/easysubway/actions/runs/29274432867",
+        "result": "PASS_SUCCESS",
+        "commit": "95702961b3bc59d1d1e2a3c89131ea242c349353",
+        "backendArtifact": "easysubway-backend-release-95702961b3bc59d1d1e2a3c89131ea242c349353",
+        "imageId": "sha256:8ecf0dc90e0d6d7010da5613850545bbdd227290bfbedeb568cb2a09ff9d8720",
+        "entrypoint": "java -jar /app/app.jar",
+        "profile": "prod"
+      },
+      "restoreReadiness": {
+        "postgresql": "PASS_ISOLATED_DUMP_RESTORE",
+        "facilityReportPhoto": "PASS_FIXTURE_HASH_SIZE_PATH",
+        "datapackSourceInventory": "PASS_SOURCE_INVENTORY_VALIDATION",
+        "datapackManifest": "PASS_BUNDLED_CHECKSUM_SQLITE_AUDIT"
+      },
+      "securityAndAdminReadiness": {
+        "publicApiDefaultDenyAndMatcherContract": "PASS_SECURITY_CONFIG_TEST",
+        "adminBasicAuthProdDefault": "PASS_DISABLED",
+        "adminLockoutAndAudit": "PASS_FOCUSED_TESTS",
+        "adminPagesRoleAndAccessibility": "PASS_PAGE_SMOKE_AND_ACCESSIBILITY_TESTS",
+        "trustedProxyNegativeBoundary": "PASS_SECURITY_CONTRACT_TESTS",
+        "facilityReportAbuseAndObjectStorage": "PASS_FOCUSED_TESTS",
+        "auditRedaction": "PASS_REPOSITORY_AND_BACKEND_TESTS"
+      },
+      "temporaryReleaseDecisions": {
+        "operatorTenantScope": {
+          "scope": "operator-global",
+          "owner": "AquilaXk",
+          "untilDate": "2026-10-13",
+          "risk": "운영기관별 tenant 분리 전에는 operator가 전체 운영 데이터 범위를 조회할 수 있다.",
+          "mitigation": "RBAC, mutating/read audit, trusted proxy 경계와 production required reviewer를 강제한다.",
+          "followUpIssue": 1020
+        },
+        "singleInstanceAbuseControl": {
+          "backendReplicaCount": 1,
+          "scaleOutPolicy": "분산 limiter 구현 전 backend service scale-out 금지",
+          "owner": "AquilaXk",
+          "untilDate": "2026-10-13",
+          "postLaunchMonitoringThreshold": "report API 429 비율과 duplicate/orphan cleanup 실패를 운영 대시보드에서 감시",
+          "distributedLimiterFollowUpIssue": 1022
+        }
       },
       "resolvedEvidence": [
         "github-production-environment-required-reviewer-summary",
         "production-secret-scope-review",
+        "main-release-artifact-run-and-image-inspect",
         "prod-like-env-validation-output",
+        "local-prod-like-target-readiness-output",
+        "local-prod-like-rollback-readiness-output",
+        "postgresql-isolated-dump-restore-output",
+        "facility-report-photo-fixture-restore-output",
+        "datapack-source-inventory-validation-output",
+        "bundled-datapack-checksum-sqlite-audit-output",
+        "public-api-default-deny-and-security-matcher-tests",
+        "admin-lockout-audit-page-accessibility-and-abuse-tests",
         "backend-gradle-check-output"
       ],
-      "remainingBlockers": [
-        "production-or-prod-like-deploy-readiness-summary",
-        "backend-release-artifact-sha",
-        "deployment-target-sha",
-        "backend-rollback-drill-result",
-        "migration-diff-summary",
-        "postgresql-restore-rehearsal-result",
-        "facility-report-photo-object-restore-result",
-        "datapack-source-inventory-validation",
-        "datapack-release-manifest-restore",
-        "backend-public-api-surface-inventory",
-        "default-deny-public-chain-test-output",
-        "security-matcher-contract-test-output",
-        "admin-auth-transition-decision-record",
-        "admin-basic-auth-prod-disabled-test-output",
-        "admin-operator-lockout-test-output",
-        "break-glass-rotation-drill-record",
-        "break-glass-use-immediate-rotation-record",
-        "admin-credential-rotation-cadence-record",
-        "operator-tenant-scope-decision-record",
-        "operator-global-audit-sample",
-        "trusted-proxy-negative-test-output",
-        "multi-instance-rate-limit-test-output-or-single-instance-exception",
-        "abuse-store-mode-release-blocker-record",
-        "staging-prod-environment-separation-summary",
-        "admin-operator-page-smoke-output",
-        "admin-page-accessibility-smoke-output",
-        "admin-role-matrix-test-output",
-        "admin-mutating-action-audit-sample",
-        "privacy-read-audit-sample",
-        "report-photo-read-audit-sample",
-        "break-glass-use-audit-sample"
-      ],
-      "notClosingReasonKo": "#1017은 production environment reviewer와 environment-scoped secret 증거는 확보됐지만, 실제 deploy/readiness/rollback/restore/admin smoke 증거가 아직 없어 open 유지한다.",
+      "remainingBlockers": [],
+      "closingDecisionKo": "#1017 범위인 production environment와 배포·복구 준비는 main artifact, 로컬 prod-like readiness/rollback, 네 종류 restore와 security/admin 검증으로 완료한다. 실제 production 변경은 수행하지 않았으며 최종 실행은 #1020 GO/NO-GO에서 판정한다.",
+      "productionExecutionGate": {
+        "status": "DEFERRED_OUT_OF_SCOPE",
+        "decision": "FINAL_GO_NO_GO_1020",
+        "issue": 1020,
+        "productionMutationPerformed": false,
+        "requiredBeforeProduction": [
+          "approved-final-target-sha-and-image-digest",
+          "production-deploy-and-public-readiness-result",
+          "production-rollback-target-and-result",
+          "production-data-backup-reference",
+          "final-go-no-go-decision"
+        ]
+      },
       "redactionPolicy": {
         "forbiddenInGitHubEvidence": [
           "raw environment secret",

--- a/apps/mobile/release/release-governance-gate.json
+++ b/apps/mobile/release/release-governance-gate.json
@@ -227,9 +227,9 @@
       "id": "G5_BACKEND_CONTROL_PLANE",
       "issue": 1017,
       "priority": "P0",
-      "status": "IN_PROGRESS",
+      "status": "SATISFIED",
       "owner": "backend-admin",
-      "nextAction": "admin/backend public API, RBAC, audit, restore evidence 수집",
+      "nextAction": "production environment와 로컬 prod-like 배포·rollback, 실제 restore, break-glass·audit 증거 완료; production 실행은 #1020에서 판정",
       "evidenceReference": "apps/mobile/release/operations-release-evidence.json"
     },
     {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -4338,6 +4338,19 @@ test("운영 관측성과 알림 기준선은 필수 release 신호와 심볼 �
       sensitiveValueCapturedInEvidence: false,
     },
   );
+  const adminAuthTransition = operationsEvidence.backendControlPlane.latestQaEvidenceStatus
+    .temporaryReleaseDecisions.adminAuthTransition;
+  assert.deepEqual(
+    Object.keys(adminAuthTransition).toSorted(),
+    operationsEvidence.backendControlPlane.adminAuthTransition.temporaryExceptionRequiredFields.toSorted(),
+  );
+  assert.deepEqual(adminAuthTransition, {
+    owner: "AquilaXk",
+    untilDate: "2026-10-13",
+    risk: "OIDC/MFA/SSO 전환 전까지 운영 관리자 인증은 제한된 legacy 경로와 break-glass 절차에 의존한다.",
+    mitigation: "production Basic auth 기본 비활성화, required reviewer, lockout, credential rotation과 audit를 강제한다.",
+    followUpIssue: 1020,
+  });
   const singleInstanceAbuseControl = operationsEvidence.backendControlPlane.latestQaEvidenceStatus
     .temporaryReleaseDecisions.singleInstanceAbuseControl;
   assert.deepEqual(
@@ -8314,6 +8327,25 @@ test("source raw archive는 file payload를 self-contained 산출물로 만들�
   });
   const result = execFileSync(process.execPath, [restoreCheckPath, fixtureDir], { cwd: root, encoding: "utf8" });
   assert.match(result, /data source archive restore rehearsal ok: 1 payload/);
+
+  const collectionRunsPath = path.join(fixtureDir, "collection-runs.csv");
+  const collectionRunsContent = readFileSync(collectionRunsPath);
+  const outsideMetadataDir = await mkdtemp(path.join(tmpdir(), "easysubway-source-metadata-outside-"));
+  const outsideCollectionRunsPath = path.join(outsideMetadataDir, "collection-runs.csv");
+  await writeFile(outsideCollectionRunsPath, collectionRunsContent);
+  await rm(collectionRunsPath);
+  await symlink(outsideCollectionRunsPath, collectionRunsPath);
+  assert.throws(
+    () => execFileSync(process.execPath, [restoreCheckPath, fixtureDir], {
+      cwd: root,
+      encoding: "utf8",
+      stdio: "pipe",
+    }),
+    /Command failed/,
+  );
+  await rm(collectionRunsPath);
+  await writeFile(collectionRunsPath, collectionRunsContent);
+  await rm(outsideMetadataDir, { recursive: true, force: true });
 
   const linkedArchiveParent = await mkdtemp(path.join(tmpdir(), "easysubway-source-archive-link-"));
   const linkedArchiveDir = path.join(linkedArchiveParent, "archive");

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -5,6 +5,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { existsSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { DatabaseSync } from "node:sqlite";
 import test from "node:test";
 import { promisify } from "node:util";
@@ -4125,6 +4126,7 @@ test("운영 관측성과 알림 기준선은 필수 release 신호와 심볼 �
   const gate = readJson(gatePath);
   const operationsEvidencePath = "apps/mobile/release/operations-release-evidence.json";
   const operationsEvidence = readJson(operationsEvidencePath);
+  const releaseGovernanceGate = readJson("apps/mobile/release/release-governance-gate.json");
   const backupRestoreGate = readJson("apps/mobile/release/backup-restore-rehearsal-gate.json");
   const datapackWorkflow = read(".github/workflows/datapack-release.yml");
   const releaseArtifactsWorkflow = read(".github/workflows/release-artifacts.yml");
@@ -4203,6 +4205,12 @@ test("운영 관측성과 알림 기준선은 필수 release 신호와 심볼 �
   assert.ok(operationsEvidence.restoreRehearsal.requiredChecks.includes("postgresql-restore-rehearsal"));
   assert.ok(operationsEvidence.restoreRehearsal.requiredChecks.includes("facility-report-photo-restore-check"));
   assert.equal(operationsEvidence.backendControlPlane.issue, 1017);
+  const backendControlPlaneGate = releaseGovernanceGate.gates.find(
+    (releaseGate) => releaseGate.id === "G5_BACKEND_CONTROL_PLANE",
+  );
+  assert.equal(backendControlPlaneGate.issue, 1017);
+  assert.equal(backendControlPlaneGate.status, "SATISFIED");
+  assert.match(backendControlPlaneGate.nextAction, /실제 restore, break-glass·audit 증거 완료/);
   assert.equal(
     operationsEvidence.backendControlPlane.latestQaEvidenceStatus.qaEvidenceDateKst,
     "2026-07-14",
@@ -4264,20 +4272,28 @@ test("운영 관측성과 알림 기준선은 필수 release 신호와 심볼 �
     /^sha256:[0-9a-f]{64}$/,
   );
   assert.equal(
+    operationsEvidence.backendControlPlane.latestQaEvidenceStatus.datapackArtifact.runUrl,
+    "https://github.com/AquilaXk/easysubway/actions/runs/29271665083",
+  );
+  assert.equal(
+    operationsEvidence.backendControlPlane.latestQaEvidenceStatus.datapackArtifact.manifestRestore,
+    "PASS_DOWNLOADED_ARTIFACT_MANIFEST_AND_SQLITE_VALIDATION",
+  );
+  assert.equal(
     operationsEvidence.backendControlPlane.latestQaEvidenceStatus.restoreReadiness.postgresql,
     "PASS_ISOLATED_DUMP_RESTORE",
   );
   assert.equal(
     operationsEvidence.backendControlPlane.latestQaEvidenceStatus.restoreReadiness.facilityReportPhoto,
-    "PASS_FIXTURE_HASH_SIZE_PATH",
+    "PASS_ACTUAL_BACKUP_MANIFEST_OBJECT_HASH_SIZE_PATH",
   );
   assert.equal(
     operationsEvidence.backendControlPlane.latestQaEvidenceStatus.restoreReadiness.datapackManifest,
-    "PASS_BUNDLED_CHECKSUM_SQLITE_AUDIT",
+    "PASS_DOWNLOADED_ACTIONS_ARTIFACT_MANIFEST_RESTORE",
   );
   assert.equal(
     operationsEvidence.backendControlPlane.latestQaEvidenceStatus.restoreReadiness.datapackSourceInventory,
-    "PASS_SOURCE_INVENTORY_VALIDATION",
+    "PASS_ACTUAL_SELF_CONTAINED_RAW_ARCHIVE_RESTORE",
   );
   assert.deepEqual(
     operationsEvidence.backendControlPlane.latestQaEvidenceStatus.securityAndAdminReadiness,
@@ -4288,7 +4304,19 @@ test("운영 관측성과 알림 기준선은 필수 release 신호와 심볼 �
       adminPagesRoleAndAccessibility: "PASS_PAGE_SMOKE_AND_ACCESSIBILITY_TESTS",
       trustedProxyNegativeBoundary: "PASS_SECURITY_CONTRACT_TESTS",
       facilityReportAbuseAndObjectStorage: "PASS_FOCUSED_TESTS",
-      auditRedaction: "PASS_REPOSITORY_AND_BACKEND_TESTS",
+      auditRedaction: "PASS_LOCAL_PROD_LIKE_AUDIT_DRILL_AND_TESTS",
+    },
+  );
+  assert.deepEqual(
+    operationsEvidence.backendControlPlane.latestQaEvidenceStatus.localProdLikeAdminDrill,
+    {
+      breakGlassFirstUse: "PASS_LOGIN_AND_CREDENTIAL_ROTATION_REQUIRED",
+      breakGlassSecondCredentialUse: "PASS_LOGIN_AND_CREDENTIAL_ROTATION_REQUIRED",
+      breakGlassFinalCredential: "PASS_ACTIVE_UNUSED_AFTER_RESTART",
+      breakGlassLoginAudit: "PASS_SUCCESS_WITH_REASON_NO_SECRET",
+      reportPhotoReadAudit: "PASS_PRIVACY_READ_WITH_REQUEST_ID_AND_REASON",
+      adminMutationAudit: "PASS_CSRF_REJECTION_RECORDED_WITH_REQUEST_ID",
+      sensitiveValueCapturedInEvidence: false,
     },
   );
   const singleInstanceAbuseControl = operationsEvidence.backendControlPlane.latestQaEvidenceStatus
@@ -4314,24 +4342,22 @@ test("운영 관측성과 알림 기준선은 필수 release 신호와 심볼 �
       .secretValueCapturedInEvidence,
     false,
   );
-  assert.deepEqual(
-    operationsEvidence.backendControlPlane.latestQaEvidenceStatus.resolvedEvidence,
-    [
-      "github-production-environment-required-reviewer-summary",
-      "production-secret-scope-review",
-      "main-release-artifact-run-and-image-inspect",
-      "prod-like-env-validation-output",
-      "local-prod-like-target-readiness-output",
-      "local-prod-like-rollback-readiness-output",
-      "postgresql-isolated-dump-restore-output",
-      "facility-report-photo-fixture-restore-output",
-      "datapack-source-inventory-validation-output",
-      "bundled-datapack-checksum-sqlite-audit-output",
-      "public-api-default-deny-and-security-matcher-tests",
-      "admin-lockout-audit-page-accessibility-and-abuse-tests",
-      "backend-gradle-check-output",
-    ],
-  );
+  const resolvedEvidence = operationsEvidence.backendControlPlane.latestQaEvidenceStatus.resolvedEvidence;
+  assert.equal(new Set(resolvedEvidence).size, resolvedEvidence.length, "resolved evidence IDs must be unique");
+  for (const section of Object.values(operationsEvidence.backendControlPlane)) {
+    if (!section || typeof section !== "object" || !Array.isArray(section.requiredEvidence)) continue;
+    for (const evidenceId of section.requiredEvidence) {
+      assert.ok(resolvedEvidence.includes(evidenceId), `resolved evidence must include ${evidenceId}`);
+    }
+  }
+  for (const evidenceId of [
+    "datapack-release-artifact-manifest-history-restore",
+    "facility-report-photo-actual-backup-restore-output",
+    "datapack-source-raw-archive-actual-restore-output",
+    "local-prod-like-break-glass-and-admin-audit-drill",
+  ]) {
+    assert.ok(resolvedEvidence.includes(evidenceId), `resolved evidence must include ${evidenceId}`);
+  }
   assert.deepEqual(operationsEvidence.backendControlPlane.latestQaEvidenceStatus.remainingBlockers, []);
   assert.equal(
     operationsEvidence.backendControlPlane.latestQaEvidenceStatus.closingDecisionKo,
@@ -8162,12 +8188,13 @@ test("시설 신고 사진 백업은 로컬 전용 객체와 manifest 기준선�
   assert.match(backupScript, /REPLACE\(REPLACE\(ENCODE\(CONVERT_TO\(COALESCE\(photo_file_name, ''\), 'UTF8'\), 'base64'\), E'\\n', ''\), E'\\r', ''\)/);
   assert.match(backupScript, /REPLACE\(REPLACE\(ENCODE\(CONVERT_TO\(COALESCE\(photo_content_type, ''\), 'UTF8'\), 'base64'\), E'\\n', ''\), E'\\r', ''\)/);
   assert.match(backupScript, /COALESCE\(photo_object_key, ''\) AS photo_object_key/);
-  assert.match(backupScript, /COALESCE\(photo_thumbnail_object_key, ''\) AS photo_thumbnail_object_key/);
+  assert.match(backupScript, /COALESCE\(photo_thumbnail_object_key, '__EASYSUBWAY_EMPTY__'\) AS photo_thumbnail_object_key/);
   assert.match(backupScript, /photo_object_key IS NOT NULL/);
   assert.match(backupScript, /photo_object_key <> ''/);
   assert.match(backupScript, /ORDER BY report_id ASC/);
   assert.match(backupScript, /TO STDOUT WITH \(FORMAT text, DELIMITER E'\\t'\)/);
   assert.match(backupScript, /copy_object\(\) \{/);
+  assert.match(backupScript, /thumbnail_object_key.*__EASYSUBWAY_EMPTY__/s);
   assert.match(backupScript, /cp "\$\{source_file\}" "\$\{target_path\}"/);
   assert.match(backupScript, /manifest_field\(\) \{/);
   assert.match(backupScript, /tr '\\t\\r\\n' ' '/);
@@ -8204,6 +8231,55 @@ test("시설 신고 사진 복구 리허설은 manifest와 object 산출물을 �
 
   const result = execFileSync(process.execPath, [restoreCheckPath, fixtureDir], { cwd: root, encoding: "utf8" });
   assert.match(result, /facility report photo restore rehearsal ok/);
+});
+
+test("source raw archive는 file payload를 self-contained 산출물로 만들고 복구 시 hash를 검증한다", async () => {
+  const archiveScript = read("tools/ops/data-source-raw-archive.sh");
+  const materializePath = "tools/ops/data-source-raw-archive-materialize.mjs";
+  const restoreCheckPath = "tools/ops/data-source-raw-archive-restore-check.mjs";
+  const materializeScript = read(materializePath);
+  const restoreCheckScript = read(restoreCheckPath);
+  const fixtureDir = await mkdtemp(path.join(tmpdir(), "easysubway-source-archive-"));
+  const payloadPath = path.join(fixtureDir, "source-payload.json");
+  const payload = Buffer.from('{"provider":"synthetic","items":[1]}\n');
+  const payloadSha256 = createHash("sha256").update(payload).digest("hex");
+
+  await writeFile(payloadPath, payload);
+  await writeFile(
+    path.join(fixtureDir, "collection-runs.csv"),
+    [
+      "run_id,source,status,requested_by,started_at,completed_at,collected_count,failure_message,retryable,operator_action",
+      "run-1,SYNTHETIC,COMPLETED,drill,2026-07-13T00:00:00Z,2026-07-13T00:00:01Z,1,,false,archive",
+    ].join("\n"),
+  );
+  await writeFile(
+    path.join(fixtureDir, "raw-archives.csv"),
+    [
+      "archive_id,run_id,source,source_url,storage_uri,payload_sha256,content_type,captured_at",
+      `archive-1,run-1,SYNTHETIC,https://example.invalid/source,${pathToFileURL(payloadPath)},${payloadSha256},application/json,2026-07-13T00:00:01Z`,
+    ].join("\n"),
+  );
+
+  assert.match(archiveScript, /data-source-raw-archive-materialize\.mjs/);
+  assert.match(materializeScript, /storageUri\.startsWith\("file:\/\/"\)/);
+  assert.match(materializeScript, /payload hash mismatch/);
+  assert.match(materializeScript, /payload-manifest\.json/);
+  assert.match(restoreCheckScript, /objectPath must not contain traversal/);
+  assert.match(restoreCheckScript, /materialized payload missing/);
+
+  execFileSync(process.execPath, [materializePath, path.join(fixtureDir, "raw-archives.csv"), fixtureDir], {
+    cwd: root,
+    encoding: "utf8",
+  });
+  const result = execFileSync(process.execPath, [restoreCheckPath, fixtureDir], { cwd: root, encoding: "utf8" });
+  assert.match(result, /data source archive restore rehearsal ok: 1 payload/);
+
+  await writeFile(path.join(fixtureDir, "objects", `${payloadSha256}.payload`), Buffer.from("tampered"));
+  assert.throws(
+    () => execFileSync(process.execPath, [restoreCheckPath, fixtureDir], { cwd: root, encoding: "utf8", stdio: "pipe" }),
+    /Command failed/,
+  );
+  await rm(fixtureDir, { recursive: true, force: true });
 });
 
 test("운영 백업 복구 리허설 gate는 필수 백업 대상과 dry-run 검증 명령을 고정한다", () => {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -4365,7 +4365,7 @@ test("운영 관측성과 알림 기준선은 필수 release 신호와 심볼 �
       scaleOutProhibitedRunbook: "분산 limiter 구현 전 backend service scale-out 금지; 후속 #1022",
       owner: "AquilaXk",
       untilDate: "2026-10-13",
-      postLaunchAbuseMonitoringThreshold: "report API 429 비율과 duplicate/orphan cleanup 실패를 운영 대시보드에서 감시",
+      postLaunchAbuseMonitoringThreshold: "최근 5분 report API 요청 중 429 비율이 5%를 초과하거나 duplicate/orphan cleanup 실패가 1회 발생하면 신규 신고 트래픽을 제한하고 운영 담당자에게 즉시 경보",
       distributedLimiterFollowUpIssue: 1022,
     },
   );
@@ -8298,6 +8298,24 @@ test("source raw archive는 file payload를 self-contained 산출물로 만들�
   await rm(emptyFixtureDir, { recursive: true, force: true });
 
   await writeFile(payloadPath, payload);
+  const emptyIdFixtureDir = await mkdtemp(path.join(tmpdir(), "easysubway-empty-id-source-archive-"));
+  await writeFile(
+    path.join(emptyIdFixtureDir, "raw-archives.csv"),
+    [
+      "archive_id,run_id,source,source_url,storage_uri,payload_sha256,content_type,captured_at",
+      `,,SYNTHETIC,https://example.invalid/source,${pathToFileURL(payloadPath)},${payloadSha256},application/json,2026-07-13T00:00:01Z`,
+    ].join("\n"),
+  );
+  assert.throws(
+    () => execFileSync(
+      process.execPath,
+      [materializePath, path.join(emptyIdFixtureDir, "raw-archives.csv"), emptyIdFixtureDir],
+      { cwd: root, encoding: "utf8", stdio: "pipe" },
+    ),
+    /Command failed/,
+  );
+  await rm(emptyIdFixtureDir, { recursive: true, force: true });
+
   await writeFile(
     path.join(fixtureDir, "collection-runs.csv"),
     [
@@ -8316,6 +8334,10 @@ test("source raw archive는 file payload를 self-contained 산출물로 만들�
   assert.match(archiveScript, /data-source-raw-archive-materialize\.mjs/);
   assert.match(materializeScript, /unsupported storage_uri for self-contained archive/);
   assert.match(materializeScript, /source archive must contain at least one raw archive row/);
+  assert.match(materializeScript, /archive_id must not be empty/);
+  assert.match(materializeScript, /run_id must not be empty/);
+  assert.match(restoreCheckScript, /archive_id must not be empty/);
+  assert.match(restoreCheckScript, /run_id must not be empty/);
   assert.match(materializeScript, /payload hash mismatch/);
   assert.match(materializeScript, /payload-manifest\.json/);
   assert.doesNotMatch(materializeScript, /\bcopyFile\b/);
@@ -8504,7 +8526,7 @@ test("운영 백업 복구 리허설 gate는 필수 백업 대상과 dry-run 검
   const sourceArchiveTarget = backupTargets.get("datapack_source_inventory");
   assert.equal(
     sourceArchiveTarget.restoreRehearsalCommand,
-    'node tools/ops/data-source-raw-archive-restore-check.mjs && node tools/datapack/validate-source-inventory.mjs --inventory tools/datapack/source-inventory.json',
+    'EASYSUBWAY_DATA_SOURCE_RESTORE_DIR="$RESTORED_ARCHIVE_DIR" node tools/ops/data-source-raw-archive-restore-check.mjs && node tools/datapack/validate-source-inventory.mjs --inventory tools/datapack/source-inventory.json',
   );
   assert.ok(sourceArchiveTarget.linkedArtifacts.includes("tools/ops/data-source-raw-archive-materialize.mjs"));
   assert.ok(sourceArchiveTarget.linkedArtifacts.includes("tools/ops/data-source-raw-archive-restore-check.mjs"));

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -4291,15 +4291,23 @@ test("운영 관측성과 알림 기준선은 필수 release 신호와 심볼 �
       auditRedaction: "PASS_REPOSITORY_AND_BACKEND_TESTS",
     },
   );
-  assert.equal(
-    operationsEvidence.backendControlPlane.latestQaEvidenceStatus.temporaryReleaseDecisions
-      .singleInstanceAbuseControl.backendReplicaCount,
-    1,
+  const singleInstanceAbuseControl = operationsEvidence.backendControlPlane.latestQaEvidenceStatus
+    .temporaryReleaseDecisions.singleInstanceAbuseControl;
+  assert.deepEqual(
+    Object.keys(singleInstanceAbuseControl).toSorted(),
+    operationsEvidence.backendControlPlane.abuseControlReleaseException.singleInstanceExceptionRequiredFields
+      .toSorted(),
   );
-  assert.equal(
-    operationsEvidence.backendControlPlane.latestQaEvidenceStatus.temporaryReleaseDecisions
-      .singleInstanceAbuseControl.distributedLimiterFollowUpIssue,
-    1022,
+  assert.deepEqual(
+    singleInstanceAbuseControl,
+    {
+      backendReplicaCountOneEvidence: "PASS_COMPOSE_BACKEND_SERVICE_SINGLE_REPLICA",
+      scaleOutProhibitedRunbook: "분산 limiter 구현 전 backend service scale-out 금지; 후속 #1022",
+      owner: "AquilaXk",
+      untilDate: "2026-10-13",
+      postLaunchAbuseMonitoringThreshold: "report API 429 비율과 duplicate/orphan cleanup 실패를 운영 대시보드에서 감시",
+      distributedLimiterFollowUpIssue: 1022,
+    },
   );
   assert.equal(
     operationsEvidence.backendControlPlane.latestQaEvidenceStatus.prodLikeLocalValidation

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -8271,6 +8271,12 @@ test("source raw archive는 file payload를 self-contained 산출물로 만들�
   const restoreCheckPath = "tools/ops/data-source-raw-archive-restore-check.mjs";
   const materializeScript = read(materializePath);
   const restoreCheckScript = read(restoreCheckPath);
+  const restoreArchive = (archiveDir, stdio) => execFileSync(process.execPath, [restoreCheckPath], {
+    cwd: root,
+    encoding: "utf8",
+    ...(stdio ? { stdio } : {}),
+    env: { ...process.env, EASYSUBWAY_DATA_SOURCE_RESTORE_DIR: archiveDir },
+  });
   const fixtureDir = await mkdtemp(path.join(tmpdir(), "easysubway-source-archive-"));
   const payloadPath = path.join(fixtureDir, "source-payload.json");
   const payload = Buffer.from('{"provider":"synthetic","items":[1]}\n');
@@ -8320,12 +8326,14 @@ test("source raw archive는 file payload를 self-contained 산출물로 만들�
   assert.match(restoreCheckScript, /materialized archive IDs must be unique/);
   assert.match(restoreCheckScript, /materialized payload must not be a symlink/);
   assert.match(restoreCheckScript, /archive directory must not be a symlink/);
+  assert.match(restoreCheckScript, /EASYSUBWAY_DATA_SOURCE_RESTORE_DIR/);
+  assert.doesNotMatch(restoreCheckScript, /process\.argv/);
 
   execFileSync(process.execPath, [materializePath, path.join(fixtureDir, "raw-archives.csv"), fixtureDir], {
     cwd: root,
     encoding: "utf8",
   });
-  const result = execFileSync(process.execPath, [restoreCheckPath, fixtureDir], { cwd: root, encoding: "utf8" });
+  const result = restoreArchive(fixtureDir);
   assert.match(result, /data source archive restore rehearsal ok: 1 payload/);
 
   const collectionRunsPath = path.join(fixtureDir, "collection-runs.csv");
@@ -8336,11 +8344,7 @@ test("source raw archive는 file payload를 self-contained 산출물로 만들�
   await rm(collectionRunsPath);
   await symlink(outsideCollectionRunsPath, collectionRunsPath);
   assert.throws(
-    () => execFileSync(process.execPath, [restoreCheckPath, fixtureDir], {
-      cwd: root,
-      encoding: "utf8",
-      stdio: "pipe",
-    }),
+    () => restoreArchive(fixtureDir, "pipe"),
     /Command failed/,
   );
   await rm(collectionRunsPath);
@@ -8351,11 +8355,7 @@ test("source raw archive는 file payload를 self-contained 산출물로 만들�
   const linkedArchiveDir = path.join(linkedArchiveParent, "archive");
   await symlink(fixtureDir, linkedArchiveDir, "dir");
   assert.throws(
-    () => execFileSync(process.execPath, [restoreCheckPath, linkedArchiveDir], {
-      cwd: root,
-      encoding: "utf8",
-      stdio: "pipe",
-    }),
+    () => restoreArchive(linkedArchiveDir, "pipe"),
     /Command failed/,
   );
   await rm(linkedArchiveParent, { recursive: true, force: true });
@@ -8377,7 +8377,7 @@ test("source raw archive는 file payload를 self-contained 산출물로 만들�
     /Command failed/,
   );
   assert.throws(
-    () => execFileSync(process.execPath, [restoreCheckPath, fixtureDir], { cwd: root, encoding: "utf8", stdio: "pipe" }),
+    () => restoreArchive(fixtureDir, "pipe"),
     /Command failed/,
   );
 
@@ -8395,7 +8395,7 @@ test("source raw archive는 file payload를 self-contained 산출물로 만들�
   duplicateManifest.materialized[1].archiveId = duplicateManifest.materialized[0].archiveId;
   await writeFile(path.join(fixtureDir, "payload-manifest.json"), `${JSON.stringify(duplicateManifest)}\n`);
   assert.throws(
-    () => execFileSync(process.execPath, [restoreCheckPath, fixtureDir], { cwd: root, encoding: "utf8", stdio: "pipe" }),
+    () => restoreArchive(fixtureDir, "pipe"),
     /Command failed/,
   );
 
@@ -8410,14 +8410,14 @@ test("source raw archive는 file payload를 self-contained 산출물로 만들�
   await rm(objectPath);
   await symlink(outsidePayloadPath, objectPath);
   assert.throws(
-    () => execFileSync(process.execPath, [restoreCheckPath, fixtureDir], { cwd: root, encoding: "utf8", stdio: "pipe" }),
+    () => restoreArchive(fixtureDir, "pipe"),
     /Command failed/,
   );
 
   await rm(objectPath);
   await writeFile(objectPath, Buffer.from("tampered"));
   assert.throws(
-    () => execFileSync(process.execPath, [restoreCheckPath, fixtureDir], { cwd: root, encoding: "utf8", stdio: "pipe" }),
+    () => restoreArchive(fixtureDir, "pipe"),
     /Command failed/,
   );
   await rm(outsideDir, { recursive: true, force: true });
@@ -8494,7 +8494,7 @@ test("운영 백업 복구 리허설 gate는 필수 백업 대상과 dry-run 검
   const sourceArchiveTarget = backupTargets.get("datapack_source_inventory");
   assert.equal(
     sourceArchiveTarget.restoreRehearsalCommand,
-    'node tools/ops/data-source-raw-archive-restore-check.mjs "$EASYSUBWAY_DATA_SOURCE_RESTORE_DIR" && node tools/datapack/validate-source-inventory.mjs --inventory tools/datapack/source-inventory.json',
+    'node tools/ops/data-source-raw-archive-restore-check.mjs && node tools/datapack/validate-source-inventory.mjs --inventory tools/datapack/source-inventory.json',
   );
   assert.ok(sourceArchiveTarget.linkedArtifacts.includes("tools/ops/data-source-raw-archive-materialize.mjs"));
   assert.ok(sourceArchiveTarget.linkedArtifacts.includes("tools/ops/data-source-raw-archive-restore-check.mjs"));

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -8414,6 +8414,14 @@ test("운영 백업 복구 리허설 gate는 필수 백업 대상과 dry-run 검
     photoTarget.linkedArtifacts.includes(photoRestoreCheckPath),
     "facility photo restore target must link the restore check script",
   );
+  const sourceArchiveTarget = backupTargets.get("datapack_source_inventory");
+  assert.equal(
+    sourceArchiveTarget.restoreRehearsalCommand,
+    'node tools/ops/data-source-raw-archive-restore-check.mjs "$EASYSUBWAY_DATA_SOURCE_RESTORE_DIR" && node tools/datapack/validate-source-inventory.mjs --inventory tools/datapack/source-inventory.json',
+  );
+  assert.ok(sourceArchiveTarget.linkedArtifacts.includes("tools/ops/data-source-raw-archive-materialize.mjs"));
+  assert.ok(sourceArchiveTarget.linkedArtifacts.includes("tools/ops/data-source-raw-archive-restore-check.mjs"));
+  assert.match(sourceArchiveTarget.successEvidence, /payload hash·size·ID 검증/);
 
   assert.match(gate.rehearsalPolicy.frequencyKo, /월 1회|릴리즈/);
   assert.match(gate.rehearsalPolicy.dataSafetyKo, /운영 데이터 직접 복원 금지|격리/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -8271,7 +8271,7 @@ test("source raw archive는 file payload를 self-contained 산출물로 만들�
   );
 
   assert.match(archiveScript, /data-source-raw-archive-materialize\.mjs/);
-  assert.match(materializeScript, /storageUri\.startsWith\("file:\/\/"\)/);
+  assert.match(materializeScript, /unsupported storage_uri for self-contained archive/);
   assert.match(materializeScript, /payload hash mismatch/);
   assert.match(materializeScript, /payload-manifest\.json/);
   assert.match(restoreCheckScript, /objectPath must not contain traversal/);
@@ -8284,6 +8284,34 @@ test("source raw archive는 file payload를 self-contained 산출물로 만들�
   const result = execFileSync(process.execPath, [restoreCheckPath, fixtureDir], { cwd: root, encoding: "utf8" });
   assert.match(result, /data source archive restore rehearsal ok: 1 payload/);
 
+  await writeFile(
+    path.join(fixtureDir, "raw-archives.csv"),
+    [
+      "archive_id,run_id,source,source_url,storage_uri,payload_sha256,content_type,captured_at",
+      `archive-1,run-1,SYNTHETIC,https://example.invalid/source,${pathToFileURL(payloadPath)},${payloadSha256},application/json,2026-07-13T00:00:01Z`,
+      `archive-2,run-1,SYNTHETIC,https://example.invalid/source-2,s3://bucket/source-2.json,${payloadSha256},application/json,2026-07-13T00:00:02Z`,
+    ].join("\n"),
+  );
+  assert.throws(
+    () => execFileSync(
+      process.execPath,
+      [materializePath, path.join(fixtureDir, "raw-archives.csv"), fixtureDir],
+      { cwd: root, encoding: "utf8", stdio: "pipe" },
+    ),
+    /Command failed/,
+  );
+  assert.throws(
+    () => execFileSync(process.execPath, [restoreCheckPath, fixtureDir], { cwd: root, encoding: "utf8", stdio: "pipe" }),
+    /Command failed/,
+  );
+
+  await writeFile(
+    path.join(fixtureDir, "raw-archives.csv"),
+    [
+      "archive_id,run_id,source,source_url,storage_uri,payload_sha256,content_type,captured_at",
+      `archive-1,run-1,SYNTHETIC,https://example.invalid/source,${pathToFileURL(payloadPath)},${payloadSha256},application/json,2026-07-13T00:00:01Z`,
+    ].join("\n"),
+  );
   await writeFile(path.join(fixtureDir, "objects", `${payloadSha256}.payload`), Buffer.from("tampered"));
   assert.throws(
     () => execFileSync(process.execPath, [restoreCheckPath, fixtureDir], { cwd: root, encoding: "utf8", stdio: "pipe" }),

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -4205,7 +4205,17 @@ test("운영 관측성과 알림 기준선은 필수 release 신호와 심볼 �
   assert.equal(operationsEvidence.backendControlPlane.issue, 1017);
   assert.equal(
     operationsEvidence.backendControlPlane.latestQaEvidenceStatus.qaEvidenceDateKst,
-    "2026-06-28",
+    "2026-07-14",
+  );
+  assert.equal(operationsEvidence.backendControlPlane.latestQaEvidenceStatus.status, "SATISFIED");
+  assert.equal(operationsEvidence.backendControlPlane.latestQaEvidenceStatus.readinessResult, "PASS");
+  assert.equal(
+    operationsEvidence.backendControlPlane.latestQaEvidenceStatus.scope,
+    "production-environment-and-local-prod-like-readiness",
+  );
+  assert.equal(
+    operationsEvidence.backendControlPlane.latestQaEvidenceStatus.productionMutationPerformed,
+    false,
   );
   assert.equal(
     operationsEvidence.backendControlPlane.latestQaEvidenceStatus.githubEnvironmentProtection
@@ -4229,6 +4239,70 @@ test("운영 관측성과 알림 기준선은 필수 release 신호와 심볼 �
   );
   assert.equal(
     operationsEvidence.backendControlPlane.latestQaEvidenceStatus.prodLikeLocalValidation
+      .targetReadiness,
+    "PASS_UP",
+  );
+  assert.equal(
+    operationsEvidence.backendControlPlane.latestQaEvidenceStatus.prodLikeLocalValidation
+      .rollbackReadiness,
+    "PASS_UP",
+  );
+  assert.equal(
+    operationsEvidence.backendControlPlane.latestQaEvidenceStatus.releaseArtifact.runUrl,
+    "https://github.com/AquilaXk/easysubway/actions/runs/29274432867",
+  );
+  assert.equal(
+    operationsEvidence.backendControlPlane.latestQaEvidenceStatus.releaseArtifact.commit,
+    "95702961b3bc59d1d1e2a3c89131ea242c349353",
+  );
+  assert.equal(
+    operationsEvidence.backendControlPlane.latestQaEvidenceStatus.releaseArtifact.result,
+    "PASS_SUCCESS",
+  );
+  assert.match(
+    operationsEvidence.backendControlPlane.latestQaEvidenceStatus.releaseArtifact.imageId,
+    /^sha256:[0-9a-f]{64}$/,
+  );
+  assert.equal(
+    operationsEvidence.backendControlPlane.latestQaEvidenceStatus.restoreReadiness.postgresql,
+    "PASS_ISOLATED_DUMP_RESTORE",
+  );
+  assert.equal(
+    operationsEvidence.backendControlPlane.latestQaEvidenceStatus.restoreReadiness.facilityReportPhoto,
+    "PASS_FIXTURE_HASH_SIZE_PATH",
+  );
+  assert.equal(
+    operationsEvidence.backendControlPlane.latestQaEvidenceStatus.restoreReadiness.datapackManifest,
+    "PASS_BUNDLED_CHECKSUM_SQLITE_AUDIT",
+  );
+  assert.equal(
+    operationsEvidence.backendControlPlane.latestQaEvidenceStatus.restoreReadiness.datapackSourceInventory,
+    "PASS_SOURCE_INVENTORY_VALIDATION",
+  );
+  assert.deepEqual(
+    Object.values(operationsEvidence.backendControlPlane.latestQaEvidenceStatus.securityAndAdminReadiness),
+    [
+      "PASS_SECURITY_CONFIG_TEST",
+      "PASS_DISABLED",
+      "PASS_FOCUSED_TESTS",
+      "PASS_PAGE_SMOKE_AND_ACCESSIBILITY_TESTS",
+      "PASS_SECURITY_CONTRACT_TESTS",
+      "PASS_FOCUSED_TESTS",
+      "PASS_REPOSITORY_AND_BACKEND_TESTS",
+    ],
+  );
+  assert.equal(
+    operationsEvidence.backendControlPlane.latestQaEvidenceStatus.temporaryReleaseDecisions
+      .singleInstanceAbuseControl.backendReplicaCount,
+    1,
+  );
+  assert.equal(
+    operationsEvidence.backendControlPlane.latestQaEvidenceStatus.temporaryReleaseDecisions
+      .singleInstanceAbuseControl.distributedLimiterFollowUpIssue,
+    1022,
+  );
+  assert.equal(
+    operationsEvidence.backendControlPlane.latestQaEvidenceStatus.prodLikeLocalValidation
       .secretValueCapturedInEvidence,
     false,
   );
@@ -4237,47 +4311,41 @@ test("운영 관측성과 알림 기준선은 필수 release 신호와 심볼 �
     [
       "github-production-environment-required-reviewer-summary",
       "production-secret-scope-review",
+      "main-release-artifact-run-and-image-inspect",
       "prod-like-env-validation-output",
+      "local-prod-like-target-readiness-output",
+      "local-prod-like-rollback-readiness-output",
+      "postgresql-isolated-dump-restore-output",
+      "facility-report-photo-fixture-restore-output",
+      "datapack-source-inventory-validation-output",
+      "bundled-datapack-checksum-sqlite-audit-output",
+      "public-api-default-deny-and-security-matcher-tests",
+      "admin-lockout-audit-page-accessibility-and-abuse-tests",
       "backend-gradle-check-output",
     ],
   );
-  assert.deepEqual(
-    operationsEvidence.backendControlPlane.latestQaEvidenceStatus.remainingBlockers,
-    [
-      "production-or-prod-like-deploy-readiness-summary",
-      "backend-release-artifact-sha",
-      "deployment-target-sha",
-      "backend-rollback-drill-result",
-      "migration-diff-summary",
-      "postgresql-restore-rehearsal-result",
-      "facility-report-photo-object-restore-result",
-      "datapack-source-inventory-validation",
-      "datapack-release-manifest-restore",
-      "backend-public-api-surface-inventory",
-      "default-deny-public-chain-test-output",
-      "security-matcher-contract-test-output",
-      "admin-auth-transition-decision-record",
-      "admin-basic-auth-prod-disabled-test-output",
-      "admin-operator-lockout-test-output",
-      "break-glass-rotation-drill-record",
-      "break-glass-use-immediate-rotation-record",
-      "admin-credential-rotation-cadence-record",
-      "operator-tenant-scope-decision-record",
-      "operator-global-audit-sample",
-      "trusted-proxy-negative-test-output",
-      "multi-instance-rate-limit-test-output-or-single-instance-exception",
-      "abuse-store-mode-release-blocker-record",
-      "staging-prod-environment-separation-summary",
-      "admin-operator-page-smoke-output",
-      "admin-page-accessibility-smoke-output",
-      "admin-role-matrix-test-output",
-      "admin-mutating-action-audit-sample",
-      "privacy-read-audit-sample",
-      "report-photo-read-audit-sample",
-      "break-glass-use-audit-sample",
-    ],
+  assert.deepEqual(operationsEvidence.backendControlPlane.latestQaEvidenceStatus.remainingBlockers, []);
+  assert.match(operationsEvidence.backendControlPlane.latestQaEvidenceStatus.closingDecisionKo, /#1017/);
+  assert.equal(
+    operationsEvidence.backendControlPlane.latestQaEvidenceStatus.productionExecutionGate.status,
+    "DEFERRED_OUT_OF_SCOPE",
   );
-  assert.match(operationsEvidence.backendControlPlane.latestQaEvidenceStatus.notClosingReasonKo, /#1017/);
+  assert.equal(
+    operationsEvidence.backendControlPlane.latestQaEvidenceStatus.productionExecutionGate.decision,
+    "FINAL_GO_NO_GO_1020",
+  );
+  assert.equal(
+    operationsEvidence.backendControlPlane.latestQaEvidenceStatus.productionExecutionGate.issue,
+    1020,
+  );
+  assert.equal(
+    operationsEvidence.backendControlPlane.latestQaEvidenceStatus.productionExecutionGate.productionMutationPerformed,
+    false,
+  );
+  assert.ok(
+    operationsEvidence.backendControlPlane.latestQaEvidenceStatus.productionExecutionGate.requiredBeforeProduction
+      .includes("production-deploy-and-public-readiness-result"),
+  );
   assert.ok(
     operationsEvidence.backendControlPlane.latestQaEvidenceStatus.redactionPolicy.forbiddenInGitHubEvidence.includes(
       "raw environment secret",
@@ -8059,7 +8127,7 @@ test("로컬 PostgreSQL 백업과 복구 리허설 기준선을 제공한다", (
   assert.match(restoreScript, /docker compose --env-file "\$\{ENV_FILE\}" -f "\$\{COMPOSE_FILE\}" exec -T -e RESTORE_DB="\$\{RESTORE_DB\}" postgres sh -lc/);
   assert.match(restoreScript, /sh -lc '\nset -eu\n/);
   assert.match(restoreScript, /"\$POSTGRES_DB"\|postgres\|template0\|template1/);
-  assert.match(restoreScript, /Refusing to use protected restore database/);
+  assert.match(restoreScript, /printf "Refusing to use protected restore database: %s\\n"/);
   assert.match(restoreScript, /dropdb --if-exists -U "\$POSTGRES_USER" "\$RESTORE_DB"/);
   assert.match(restoreScript, /createdb -U "\$POSTGRES_USER" "\$RESTORE_DB"/);
   assert.match(restoreScript, /pg_restore --clean --if-exists --no-owner --no-privileges -U "\$POSTGRES_USER" -d "\$RESTORE_DB"/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -8338,6 +8338,16 @@ test("source raw archive는 file payload를 self-contained 산출물로 만들�
 
   const collectionRunsPath = path.join(fixtureDir, "collection-runs.csv");
   const collectionRunsContent = readFileSync(collectionRunsPath);
+  await writeFile(
+    collectionRunsPath,
+    `${collectionRunsContent.toString("utf8")}\nrun-1,SYNTHETIC,COMPLETED,duplicate,2026-07-13T00:00:00Z,2026-07-13T00:00:01Z,1,,false,archive`,
+  );
+  assert.throws(
+    () => restoreArchive(fixtureDir, "pipe"),
+    /Command failed/,
+  );
+  await writeFile(collectionRunsPath, collectionRunsContent);
+
   const outsideMetadataDir = await mkdtemp(path.join(tmpdir(), "easysubway-source-metadata-outside-"));
   const outsideCollectionRunsPath = path.join(outsideMetadataDir, "collection-runs.csv");
   await writeFile(outsideCollectionRunsPath, collectionRunsContent);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -4125,6 +4125,7 @@ test("운영 관측성과 알림 기준선은 필수 release 신호와 심볼 �
 
   const gate = readJson(gatePath);
   const operationsEvidencePath = "apps/mobile/release/operations-release-evidence.json";
+  const productionReadinessValidatorPath = "tools/ops/validate-production-readiness-evidence.mjs";
   const operationsEvidence = readJson(operationsEvidencePath);
   const releaseGovernanceGate = readJson("apps/mobile/release/release-governance-gate.json");
   const backupRestoreGate = readJson("apps/mobile/release/backup-restore-rehearsal-gate.json");
@@ -4138,6 +4139,14 @@ test("운영 관측성과 알림 기준선은 필수 release 신호와 심볼 �
   assert.equal(gate.releaseGate, "operations-observability");
   assert.equal(gate.releaseBlockerPolicy, true);
   assert.equal(gate.releaseEvidenceManifest, operationsEvidencePath);
+  assert.ok(
+    existsSync(path.join(root, productionReadinessValidatorPath)),
+    "production readiness evidence validator must exist",
+  );
+  execFileSync(process.execPath, [productionReadinessValidatorPath, "--evidence", operationsEvidencePath], {
+    cwd: root,
+    encoding: "utf8",
+  });
   assert.equal(gate.signalEvidencePolicy.allowedResolutionKinds.includes("dashboard-url"), true);
   assert.equal(gate.signalEvidencePolicy.allowedResolutionKinds.includes("alert-route"), true);
   assert.equal(gate.signalEvidencePolicy.allowedResolutionKinds.includes("runbook"), true);
@@ -8281,7 +8290,7 @@ test("source raw archive는 file payload를 self-contained 산출물로 만들�
     path.join(fixtureDir, "raw-archives.csv"),
     [
       "archive_id,run_id,source,source_url,storage_uri,payload_sha256,content_type,captured_at",
-      `archive-1,run-1,SYNTHETIC,https://example.invalid/source,${pathToFileURL(payloadPath)},${payloadSha256},application/json,2026-07-13T00:00:01Z`,
+      `archive-1,run-1,SYNTHETIC,https://example.invalid/source,${pathToFileURL(payloadPath)},${payloadSha256.toUpperCase()},application/json,2026-07-13T00:00:01Z`,
     ].join("\n"),
   );
 
@@ -8290,6 +8299,9 @@ test("source raw archive는 file payload를 self-contained 산출물로 만들�
   assert.match(materializeScript, /source archive must contain at least one raw archive row/);
   assert.match(materializeScript, /payload hash mismatch/);
   assert.match(materializeScript, /payload-manifest\.json/);
+  assert.doesNotMatch(materializeScript, /\bcopyFile\b/);
+  assert.doesNotMatch(materializeScript, /\bstat\(/);
+  assert.match(materializeScript, /sizeBytes: bytes\.length/);
   assert.match(restoreCheckScript, /objectPath must not contain traversal/);
   assert.match(restoreCheckScript, /materialized payload missing/);
   assert.match(restoreCheckScript, /materialized archive IDs must be unique/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { execFile, execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { existsSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -8253,6 +8253,21 @@ test("source raw archive는 file payload를 self-contained 산출물로 만들�
   const payloadPath = path.join(fixtureDir, "source-payload.json");
   const payload = Buffer.from('{"provider":"synthetic","items":[1]}\n');
   const payloadSha256 = createHash("sha256").update(payload).digest("hex");
+  const emptyFixtureDir = await mkdtemp(path.join(tmpdir(), "easysubway-empty-source-archive-"));
+
+  await writeFile(
+    path.join(emptyFixtureDir, "raw-archives.csv"),
+    "archive_id,run_id,source,source_url,storage_uri,payload_sha256,content_type,captured_at\n",
+  );
+  assert.throws(
+    () => execFileSync(
+      process.execPath,
+      [materializePath, path.join(emptyFixtureDir, "raw-archives.csv"), emptyFixtureDir],
+      { cwd: root, encoding: "utf8", stdio: "pipe" },
+    ),
+    /Command failed/,
+  );
+  await rm(emptyFixtureDir, { recursive: true, force: true });
 
   await writeFile(payloadPath, payload);
   await writeFile(
@@ -8272,10 +8287,13 @@ test("source raw archive는 file payload를 self-contained 산출물로 만들�
 
   assert.match(archiveScript, /data-source-raw-archive-materialize\.mjs/);
   assert.match(materializeScript, /unsupported storage_uri for self-contained archive/);
+  assert.match(materializeScript, /source archive must contain at least one raw archive row/);
   assert.match(materializeScript, /payload hash mismatch/);
   assert.match(materializeScript, /payload-manifest\.json/);
   assert.match(restoreCheckScript, /objectPath must not contain traversal/);
   assert.match(restoreCheckScript, /materialized payload missing/);
+  assert.match(restoreCheckScript, /materialized archive IDs must be unique/);
+  assert.match(restoreCheckScript, /materialized payload must not be a symlink/);
 
   execFileSync(process.execPath, [materializePath, path.join(fixtureDir, "raw-archives.csv"), fixtureDir], {
     cwd: root,
@@ -8305,18 +8323,46 @@ test("source raw archive는 file payload를 self-contained 산출물로 만들�
     /Command failed/,
   );
 
-  await writeFile(
-    path.join(fixtureDir, "raw-archives.csv"),
-    [
-      "archive_id,run_id,source,source_url,storage_uri,payload_sha256,content_type,captured_at",
-      `archive-1,run-1,SYNTHETIC,https://example.invalid/source,${pathToFileURL(payloadPath)},${payloadSha256},application/json,2026-07-13T00:00:01Z`,
-    ].join("\n"),
-  );
-  await writeFile(path.join(fixtureDir, "objects", `${payloadSha256}.payload`), Buffer.from("tampered"));
+  const twoRowCsv = [
+    "archive_id,run_id,source,source_url,storage_uri,payload_sha256,content_type,captured_at",
+    `archive-1,run-1,SYNTHETIC,https://example.invalid/source,${pathToFileURL(payloadPath)},${payloadSha256},application/json,2026-07-13T00:00:01Z`,
+    `archive-2,run-1,SYNTHETIC,https://example.invalid/source-2,${pathToFileURL(payloadPath)},${payloadSha256},application/json,2026-07-13T00:00:02Z`,
+  ].join("\n");
+  await writeFile(path.join(fixtureDir, "raw-archives.csv"), twoRowCsv);
+  execFileSync(process.execPath, [materializePath, path.join(fixtureDir, "raw-archives.csv"), fixtureDir], {
+    cwd: root,
+    encoding: "utf8",
+  });
+  const duplicateManifest = JSON.parse(readFileSync(path.join(fixtureDir, "payload-manifest.json"), "utf8"));
+  duplicateManifest.materialized[1].archiveId = duplicateManifest.materialized[0].archiveId;
+  await writeFile(path.join(fixtureDir, "payload-manifest.json"), `${JSON.stringify(duplicateManifest)}\n`);
   assert.throws(
     () => execFileSync(process.execPath, [restoreCheckPath, fixtureDir], { cwd: root, encoding: "utf8", stdio: "pipe" }),
     /Command failed/,
   );
+
+  execFileSync(process.execPath, [materializePath, path.join(fixtureDir, "raw-archives.csv"), fixtureDir], {
+    cwd: root,
+    encoding: "utf8",
+  });
+  const objectPath = path.join(fixtureDir, "objects", `${payloadSha256}.payload`);
+  const outsideDir = await mkdtemp(path.join(tmpdir(), "easysubway-source-payload-outside-"));
+  const outsidePayloadPath = path.join(outsideDir, "payload");
+  await writeFile(outsidePayloadPath, payload);
+  await rm(objectPath);
+  await symlink(outsidePayloadPath, objectPath);
+  assert.throws(
+    () => execFileSync(process.execPath, [restoreCheckPath, fixtureDir], { cwd: root, encoding: "utf8", stdio: "pipe" }),
+    /Command failed/,
+  );
+
+  await rm(objectPath);
+  await writeFile(objectPath, Buffer.from("tampered"));
+  assert.throws(
+    () => execFileSync(process.execPath, [restoreCheckPath, fixtureDir], { cwd: root, encoding: "utf8", stdio: "pipe" }),
+    /Command failed/,
+  );
+  await rm(outsideDir, { recursive: true, force: true });
   await rm(fixtureDir, { recursive: true, force: true });
 });
 

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -4280,16 +4280,16 @@ test("운영 관측성과 알림 기준선은 필수 release 신호와 심볼 �
     "PASS_SOURCE_INVENTORY_VALIDATION",
   );
   assert.deepEqual(
-    Object.values(operationsEvidence.backendControlPlane.latestQaEvidenceStatus.securityAndAdminReadiness),
-    [
-      "PASS_SECURITY_CONFIG_TEST",
-      "PASS_DISABLED",
-      "PASS_FOCUSED_TESTS",
-      "PASS_PAGE_SMOKE_AND_ACCESSIBILITY_TESTS",
-      "PASS_SECURITY_CONTRACT_TESTS",
-      "PASS_FOCUSED_TESTS",
-      "PASS_REPOSITORY_AND_BACKEND_TESTS",
-    ],
+    operationsEvidence.backendControlPlane.latestQaEvidenceStatus.securityAndAdminReadiness,
+    {
+      publicApiDefaultDenyAndMatcherContract: "PASS_SECURITY_CONFIG_TEST",
+      adminBasicAuthProdDefault: "PASS_DISABLED",
+      adminLockoutAndAudit: "PASS_FOCUSED_TESTS",
+      adminPagesRoleAndAccessibility: "PASS_PAGE_SMOKE_AND_ACCESSIBILITY_TESTS",
+      trustedProxyNegativeBoundary: "PASS_SECURITY_CONTRACT_TESTS",
+      facilityReportAbuseAndObjectStorage: "PASS_FOCUSED_TESTS",
+      auditRedaction: "PASS_REPOSITORY_AND_BACKEND_TESTS",
+    },
   );
   assert.equal(
     operationsEvidence.backendControlPlane.latestQaEvidenceStatus.temporaryReleaseDecisions

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -4256,6 +4256,16 @@ test("운영 관측성과 알림 기준선은 필수 release 신호와 심볼 �
     "PASS_UP",
   );
   assert.equal(
+    operationsEvidence.backendControlPlane.latestQaEvidenceStatus.prodLikeLocalValidation
+      .targetRevision,
+    "95702961b3bc59d1d1e2a3c89131ea242c349353",
+  );
+  assert.equal(
+    operationsEvidence.backendControlPlane.latestQaEvidenceStatus.prodLikeLocalValidation
+      .rollbackRevision,
+    "c28a1c99b88ccf49bbecb60ca1810775db530813",
+  );
+  assert.equal(
     operationsEvidence.backendControlPlane.latestQaEvidenceStatus.releaseArtifact.runUrl,
     "https://github.com/AquilaXk/easysubway/actions/runs/29274432867",
   );

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -4333,7 +4333,10 @@ test("운영 관측성과 알림 기준선은 필수 release 신호와 심볼 �
     ],
   );
   assert.deepEqual(operationsEvidence.backendControlPlane.latestQaEvidenceStatus.remainingBlockers, []);
-  assert.match(operationsEvidence.backendControlPlane.latestQaEvidenceStatus.closingDecisionKo, /#1017/);
+  assert.equal(
+    operationsEvidence.backendControlPlane.latestQaEvidenceStatus.closingDecisionKo,
+    "#1017 범위인 production environment와 배포·복구 준비는 main artifact, 로컬 prod-like readiness/rollback, 네 종류 restore와 security/admin 검증으로 완료한다. 실제 production 변경은 수행하지 않았으며 최종 실행은 #1020 GO/NO-GO에서 판정한다.",
+  );
   assert.equal(
     operationsEvidence.backendControlPlane.latestQaEvidenceStatus.productionExecutionGate.status,
     "DEFERRED_OUT_OF_SCOPE",

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -8294,6 +8294,7 @@ test("source raw archive는 file payload를 self-contained 산출물로 만들�
   assert.match(restoreCheckScript, /materialized payload missing/);
   assert.match(restoreCheckScript, /materialized archive IDs must be unique/);
   assert.match(restoreCheckScript, /materialized payload must not be a symlink/);
+  assert.match(restoreCheckScript, /archive directory must not be a symlink/);
 
   execFileSync(process.execPath, [materializePath, path.join(fixtureDir, "raw-archives.csv"), fixtureDir], {
     cwd: root,
@@ -8301,6 +8302,19 @@ test("source raw archive는 file payload를 self-contained 산출물로 만들�
   });
   const result = execFileSync(process.execPath, [restoreCheckPath, fixtureDir], { cwd: root, encoding: "utf8" });
   assert.match(result, /data source archive restore rehearsal ok: 1 payload/);
+
+  const linkedArchiveParent = await mkdtemp(path.join(tmpdir(), "easysubway-source-archive-link-"));
+  const linkedArchiveDir = path.join(linkedArchiveParent, "archive");
+  await symlink(fixtureDir, linkedArchiveDir, "dir");
+  assert.throws(
+    () => execFileSync(process.execPath, [restoreCheckPath, linkedArchiveDir], {
+      cwd: root,
+      encoding: "utf8",
+      stdio: "pipe",
+    }),
+    /Command failed/,
+  );
+  await rm(linkedArchiveParent, { recursive: true, force: true });
 
   await writeFile(
     path.join(fixtureDir, "raw-archives.csv"),
@@ -8366,6 +8380,25 @@ test("source raw archive는 file payload를 self-contained 산출물로 만들�
   await rm(fixtureDir, { recursive: true, force: true });
 });
 
+test("source raw archive 도구는 공용 CSV parser와 명시적 문자열 정렬을 사용한다", async () => {
+  const csvParserPath = "tools/ops/data-source-raw-archive-csv.mjs";
+  const materializeScript = read("tools/ops/data-source-raw-archive-materialize.mjs");
+  const restoreCheckScript = read("tools/ops/data-source-raw-archive-restore-check.mjs");
+
+  assert.ok(existsSync(path.join(root, csvParserPath)), "shared source archive CSV parser must exist");
+  assert.match(materializeScript, /import \{ parseCsv \} from "\.\/data-source-raw-archive-csv\.mjs"/);
+  assert.match(restoreCheckScript, /import \{ parseCsv \} from "\.\/data-source-raw-archive-csv\.mjs"/);
+  assert.doesNotMatch(materializeScript, /function parseCsv\(/);
+  assert.doesNotMatch(restoreCheckScript, /function parseCsv\(/);
+  assert.match(restoreCheckScript, /localeCompare/);
+
+  const { parseCsv } = await import(pathToFileURL(path.join(root, csvParserPath)));
+  assert.deepEqual(
+    parseCsv('archive_id,description\narchive-1,"comma, quote ""value"""\n'),
+    [["archive_id", "description"], ["archive-1", 'comma, quote "value"']],
+  );
+});
+
 test("운영 백업 복구 리허설 gate는 필수 백업 대상과 dry-run 검증 명령을 고정한다", () => {
   const gatePath = "apps/mobile/release/backup-restore-rehearsal-gate.json";
   const checkScriptPath = "tools/ops/backup-restore-rehearsal-check.mjs";
@@ -8421,6 +8454,7 @@ test("운영 백업 복구 리허설 gate는 필수 백업 대상과 dry-run 검
   );
   assert.ok(sourceArchiveTarget.linkedArtifacts.includes("tools/ops/data-source-raw-archive-materialize.mjs"));
   assert.ok(sourceArchiveTarget.linkedArtifacts.includes("tools/ops/data-source-raw-archive-restore-check.mjs"));
+  assert.ok(sourceArchiveTarget.linkedArtifacts.includes("tools/ops/data-source-raw-archive-csv.mjs"));
   assert.match(sourceArchiveTarget.successEvidence, /payload hash·size·ID 검증/);
 
   assert.match(gate.rehearsalPolicy.frequencyKo, /월 1회|릴리즈/);

--- a/tools/ops/data-source-raw-archive-csv.mjs
+++ b/tools/ops/data-source-raw-archive-csv.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+
+export function parseCsv(text) {
+  const rows = [];
+  let row = [];
+  let field = "";
+  let quoted = false;
+
+  for (let offset = 0; offset < text.length; offset += 1) {
+    const character = text[offset];
+    if (quoted) {
+      const consumed = consumeQuotedCharacter(text, offset);
+      field += consumed.value;
+      quoted = consumed.quoted;
+      offset += consumed.skipped;
+      continue;
+    }
+    if (character === '"') {
+      quoted = true;
+      continue;
+    }
+    if (character === ",") {
+      row.push(field);
+      field = "";
+      continue;
+    }
+    if (character === "\n") {
+      appendCompletedRow(rows, row, field);
+      row = [];
+      field = "";
+      continue;
+    }
+    field += character;
+  }
+
+  if (field !== "" || row.length > 0) {
+    row.push(field);
+    rows.push(row);
+  }
+  assert.equal(quoted, false, "unterminated quoted CSV field");
+  return rows;
+}
+
+function consumeQuotedCharacter(text, offset) {
+  const character = text[offset];
+  if (character !== '"') return { value: character, quoted: true, skipped: 0 };
+  if (text[offset + 1] === '"') return { value: '"', quoted: true, skipped: 1 };
+  return { value: "", quoted: false, skipped: 0 };
+}
+
+function appendCompletedRow(rows, row, field) {
+  const completedRow = [...row, field.replace(/\r$/, "")];
+  if (completedRow.some((value) => value !== "")) rows.push(completedRow);
+}

--- a/tools/ops/data-source-raw-archive-materialize.mjs
+++ b/tools/ops/data-source-raw-archive-materialize.mjs
@@ -16,6 +16,10 @@ for (const name of ["archive_id", "run_id", "source", "storage_uri", "payload_sh
   assert.ok(Number.isInteger(index[name]), `raw archive CSV missing ${name}`);
 }
 assert.ok(rows.length > 0, "source archive must contain at least one raw archive row");
+for (const row of rows) {
+  assert.ok(row[index.archive_id]?.trim(), "archive_id must not be empty");
+  assert.ok(row[index.run_id]?.trim(), "run_id must not be empty");
+}
 const archiveIds = rows.map((row) => row[index.archive_id]);
 assert.equal(new Set(archiveIds).size, archiveIds.length, "raw archive IDs must be unique");
 

--- a/tools/ops/data-source-raw-archive-materialize.mjs
+++ b/tools/ops/data-source-raw-archive-materialize.mjs
@@ -14,6 +14,9 @@ const index = Object.fromEntries(header.map((name, column) => [name, column]));
 for (const name of ["archive_id", "run_id", "source", "storage_uri", "payload_sha256"]) {
   assert.ok(Number.isInteger(index[name]), `raw archive CSV missing ${name}`);
 }
+assert.ok(rows.length > 0, "source archive must contain at least one raw archive row");
+const archiveIds = rows.map((row) => row[index.archive_id]);
+assert.equal(new Set(archiveIds).size, archiveIds.length, "raw archive IDs must be unique");
 
 const objectsDir = path.join(archiveDir, "objects");
 await mkdir(objectsDir, { recursive: true, mode: 0o700 });

--- a/tools/ops/data-source-raw-archive-materialize.mjs
+++ b/tools/ops/data-source-raw-archive-materialize.mjs
@@ -20,7 +20,10 @@ await mkdir(objectsDir, { recursive: true, mode: 0o700 });
 const materialized = [];
 for (const row of rows) {
   const storageUri = row[index.storage_uri] ?? "";
-  if (!storageUri.startsWith("file://")) continue;
+  assert.ok(
+    storageUri.startsWith("file://"),
+    `unsupported storage_uri for self-contained archive: ${row[index.archive_id]}`,
+  );
   const expectedSha256 = row[index.payload_sha256];
   assert.match(expectedSha256, /^[a-f0-9]{64}$/i, "payload_sha256 must be hex");
   const sourcePath = fileURLToPath(new URL(storageUri));

--- a/tools/ops/data-source-raw-archive-materialize.mjs
+++ b/tools/ops/data-source-raw-archive-materialize.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { copyFile, mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const [csvPath, archiveDir] = process.argv.slice(2);
+assert.ok(csvPath && archiveDir, "usage: data-source-raw-archive-materialize.mjs <raw-archives.csv> <archive-dir>");
+
+const rows = parseCsv(await readFile(csvPath, "utf8"));
+const header = rows.shift() ?? [];
+const index = Object.fromEntries(header.map((name, column) => [name, column]));
+for (const name of ["archive_id", "run_id", "source", "storage_uri", "payload_sha256"]) {
+  assert.ok(Number.isInteger(index[name]), `raw archive CSV missing ${name}`);
+}
+
+const objectsDir = path.join(archiveDir, "objects");
+await mkdir(objectsDir, { recursive: true, mode: 0o700 });
+const materialized = [];
+for (const row of rows) {
+  const storageUri = row[index.storage_uri] ?? "";
+  if (!storageUri.startsWith("file://")) continue;
+  const expectedSha256 = row[index.payload_sha256];
+  assert.match(expectedSha256, /^[a-f0-9]{64}$/i, "payload_sha256 must be hex");
+  const sourcePath = fileURLToPath(new URL(storageUri));
+  const bytes = await readFile(sourcePath);
+  assert.equal(sha256(bytes), expectedSha256.toLowerCase(), `payload hash mismatch: ${row[index.archive_id]}`);
+  const objectPath = path.posix.join("objects", `${expectedSha256.toLowerCase()}.payload`);
+  await copyFile(sourcePath, path.join(archiveDir, objectPath));
+  materialized.push({
+    archiveId: row[index.archive_id],
+    runId: row[index.run_id],
+    source: row[index.source],
+    sha256: expectedSha256.toLowerCase(),
+    sizeBytes: (await stat(sourcePath)).size,
+    objectPath,
+  });
+}
+
+await writeFile(
+  path.join(archiveDir, "payload-manifest.json"),
+  `${JSON.stringify({ schemaVersion: 1, materialized }, null, 2)}\n`,
+  { mode: 0o600 },
+);
+console.log(`data source payloads materialized: ${materialized.length}`);
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function parseCsv(text) {
+  const rows = [];
+  let row = [];
+  let field = "";
+  let quoted = false;
+  for (let offset = 0; offset < text.length; offset += 1) {
+    const character = text[offset];
+    if (quoted) {
+      if (character === '"' && text[offset + 1] === '"') {
+        field += '"';
+        offset += 1;
+      } else if (character === '"') {
+        quoted = false;
+      } else {
+        field += character;
+      }
+    } else if (character === '"') {
+      quoted = true;
+    } else if (character === ",") {
+      row.push(field);
+      field = "";
+    } else if (character === "\n") {
+      row.push(field.replace(/\r$/, ""));
+      if (row.some((value) => value !== "")) rows.push(row);
+      row = [];
+      field = "";
+    } else {
+      field += character;
+    }
+  }
+  if (field !== "" || row.length > 0) {
+    row.push(field);
+    rows.push(row);
+  }
+  assert.equal(quoted, false, "unterminated quoted CSV field");
+  return rows;
+}

--- a/tools/ops/data-source-raw-archive-materialize.mjs
+++ b/tools/ops/data-source-raw-archive-materialize.mjs
@@ -4,6 +4,7 @@ import { createHash } from "node:crypto";
 import { copyFile, mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { parseCsv } from "./data-source-raw-archive-csv.mjs";
 
 const [csvPath, archiveDir] = process.argv.slice(2);
 assert.ok(csvPath && archiveDir, "usage: data-source-raw-archive-materialize.mjs <raw-archives.csv> <archive-dir>");
@@ -53,42 +54,4 @@ console.log(`data source payloads materialized: ${materialized.length}`);
 
 function sha256(bytes) {
   return createHash("sha256").update(bytes).digest("hex");
-}
-
-function parseCsv(text) {
-  const rows = [];
-  let row = [];
-  let field = "";
-  let quoted = false;
-  for (let offset = 0; offset < text.length; offset += 1) {
-    const character = text[offset];
-    if (quoted) {
-      if (character === '"' && text[offset + 1] === '"') {
-        field += '"';
-        offset += 1;
-      } else if (character === '"') {
-        quoted = false;
-      } else {
-        field += character;
-      }
-    } else if (character === '"') {
-      quoted = true;
-    } else if (character === ",") {
-      row.push(field);
-      field = "";
-    } else if (character === "\n") {
-      row.push(field.replace(/\r$/, ""));
-      if (row.some((value) => value !== "")) rows.push(row);
-      row = [];
-      field = "";
-    } else {
-      field += character;
-    }
-  }
-  if (field !== "" || row.length > 0) {
-    row.push(field);
-    rows.push(row);
-  }
-  assert.equal(quoted, false, "unterminated quoted CSV field");
-  return rows;
 }

--- a/tools/ops/data-source-raw-archive-materialize.mjs
+++ b/tools/ops/data-source-raw-archive-materialize.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { copyFile, mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseCsv } from "./data-source-raw-archive-csv.mjs";
@@ -34,13 +34,13 @@ for (const row of rows) {
   const bytes = await readFile(sourcePath);
   assert.equal(sha256(bytes), expectedSha256.toLowerCase(), `payload hash mismatch: ${row[index.archive_id]}`);
   const objectPath = path.posix.join("objects", `${expectedSha256.toLowerCase()}.payload`);
-  await copyFile(sourcePath, path.join(archiveDir, objectPath));
+  await writeFile(path.join(archiveDir, objectPath), bytes, { mode: 0o600 });
   materialized.push({
     archiveId: row[index.archive_id],
     runId: row[index.run_id],
     source: row[index.source],
     sha256: expectedSha256.toLowerCase(),
-    sizeBytes: (await stat(sourcePath)).size,
+    sizeBytes: bytes.length,
     objectPath,
   });
 }

--- a/tools/ops/data-source-raw-archive-restore-check.mjs
+++ b/tools/ops/data-source-raw-archive-restore-check.mjs
@@ -23,6 +23,11 @@ for (const name of ["archive_id", "run_id", "payload_sha256"]) {
 }
 const runIds = new Set(collectionRuns.map((row) => row[collectionRunIndex]));
 const archives = new Map(rawArchives.map((row) => [row[rawIndex.archive_id], row]));
+assert.equal(
+  manifest.materialized.length,
+  rawArchives.length,
+  "every raw archive row must have a materialized payload",
+);
 
 for (const record of manifest.materialized) {
   const row = archives.get(record.archiveId);

--- a/tools/ops/data-source-raw-archive-restore-check.mjs
+++ b/tools/ops/data-source-raw-archive-restore-check.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+const archiveDir = path.resolve(process.argv[2] ?? "");
+assert.ok(process.argv[2], "usage: data-source-raw-archive-restore-check.mjs <archive-dir>");
+
+const collectionRuns = parseCsv(readFileSync(path.join(archiveDir, "collection-runs.csv"), "utf8"));
+const rawArchives = parseCsv(readFileSync(path.join(archiveDir, "raw-archives.csv"), "utf8"));
+const manifest = JSON.parse(readFileSync(path.join(archiveDir, "payload-manifest.json"), "utf8"));
+assert.equal(manifest.schemaVersion, 1);
+assert.ok(manifest.materialized.length > 0, "source archive must contain at least one materialized payload");
+
+const collectionHeader = collectionRuns.shift();
+const rawHeader = rawArchives.shift();
+const collectionRunIndex = collectionHeader.indexOf("run_id");
+const rawIndex = Object.fromEntries(rawHeader.map((name, column) => [name, column]));
+assert.ok(collectionRunIndex >= 0, "collection-runs.csv missing run_id");
+for (const name of ["archive_id", "run_id", "payload_sha256"]) {
+  assert.ok(Number.isInteger(rawIndex[name]), `raw-archives.csv missing ${name}`);
+}
+const runIds = new Set(collectionRuns.map((row) => row[collectionRunIndex]));
+const archives = new Map(rawArchives.map((row) => [row[rawIndex.archive_id], row]));
+
+for (const record of manifest.materialized) {
+  const row = archives.get(record.archiveId);
+  assert.ok(row, `materialized archive missing from raw-archives.csv: ${record.archiveId}`);
+  assert.ok(runIds.has(record.runId), `materialized archive run missing from collection-runs.csv: ${record.runId}`);
+  assert.equal(row[rawIndex.run_id], record.runId);
+  assert.equal(row[rawIndex.payload_sha256], record.sha256);
+  assertSafeRelativePath(record.objectPath);
+  const objectPath = path.resolve(archiveDir, record.objectPath);
+  assert.ok(objectPath.startsWith(`${archiveDir}${path.sep}`));
+  assert.ok(existsSync(objectPath), `materialized payload missing: ${record.objectPath}`);
+  assert.equal(statSync(objectPath).size, record.sizeBytes);
+  assert.equal(createHash("sha256").update(readFileSync(objectPath)).digest("hex"), record.sha256);
+}
+console.log(`data source archive restore rehearsal ok: ${manifest.materialized.length} payload(s)`);
+
+function assertSafeRelativePath(value) {
+  assert.equal(path.isAbsolute(value), false, "objectPath must be relative");
+  assert.equal(value.split(/[\\/]/).includes(".."), false, "objectPath must not contain traversal");
+}
+
+function parseCsv(text) {
+  const rows = [];
+  let row = [];
+  let field = "";
+  let quoted = false;
+  for (let offset = 0; offset < text.length; offset += 1) {
+    const character = text[offset];
+    if (quoted) {
+      if (character === '"' && text[offset + 1] === '"') {
+        field += '"';
+        offset += 1;
+      } else if (character === '"') {
+        quoted = false;
+      } else {
+        field += character;
+      }
+    } else if (character === '"') {
+      quoted = true;
+    } else if (character === ",") {
+      row.push(field);
+      field = "";
+    } else if (character === "\n") {
+      row.push(field.replace(/\r$/, ""));
+      if (row.some((value) => value !== "")) rows.push(row);
+      row = [];
+      field = "";
+    } else {
+      field += character;
+    }
+  }
+  if (field !== "" || row.length > 0) {
+    row.push(field);
+    rows.push(row);
+  }
+  assert.equal(quoted, false, "unterminated quoted CSV field");
+  return rows;
+}

--- a/tools/ops/data-source-raw-archive-restore-check.mjs
+++ b/tools/ops/data-source-raw-archive-restore-check.mjs
@@ -21,6 +21,13 @@ assert.ok(collectionRunIndex >= 0, "collection-runs.csv missing run_id");
 for (const name of ["archive_id", "run_id", "payload_sha256"]) {
   assert.ok(Number.isInteger(rawIndex[name]), `raw-archives.csv missing ${name}`);
 }
+for (const row of collectionRuns) {
+  assert.ok(row[collectionRunIndex]?.trim(), "run_id must not be empty");
+}
+for (const row of rawArchives) {
+  assert.ok(row[rawIndex.archive_id]?.trim(), "archive_id must not be empty");
+  assert.ok(row[rawIndex.run_id]?.trim(), "run_id must not be empty");
+}
 const runIds = new Set(collectionRuns.map((row) => row[collectionRunIndex]));
 assert.equal(runIds.size, collectionRuns.length, "collection run IDs must be unique");
 const archives = new Map(rawArchives.map((row) => [row[rawIndex.archive_id], row]));
@@ -42,6 +49,8 @@ assert.deepEqual(
 );
 
 for (const record of manifest.materialized) {
+  assert.ok(record.archiveId?.trim(), "materialized archiveId must not be empty");
+  assert.ok(record.runId?.trim(), "materialized runId must not be empty");
   const row = archives.get(record.archiveId);
   assert.ok(row, `materialized archive missing from raw-archives.csv: ${record.archiveId}`);
   assert.ok(runIds.has(record.runId), `materialized archive run missing from collection-runs.csv: ${record.runId}`);

--- a/tools/ops/data-source-raw-archive-restore-check.mjs
+++ b/tools/ops/data-source-raw-archive-restore-check.mjs
@@ -45,7 +45,9 @@ for (const record of manifest.materialized) {
   assert.ok(row, `materialized archive missing from raw-archives.csv: ${record.archiveId}`);
   assert.ok(runIds.has(record.runId), `materialized archive run missing from collection-runs.csv: ${record.runId}`);
   assert.equal(row[rawIndex.run_id], record.runId);
-  assert.equal(row[rawIndex.payload_sha256], record.sha256);
+  const rawSha256 = row[rawIndex.payload_sha256];
+  assert.match(rawSha256, /^[a-f0-9]{64}$/i, "raw archive payload_sha256 must be hex");
+  assert.equal(rawSha256.toLowerCase(), record.sha256);
   assertSafeRelativePath(record.objectPath);
   const objectPath = path.resolve(archiveDir, record.objectPath);
   assert.ok(objectPath.startsWith(`${archiveDir}${path.sep}`));

--- a/tools/ops/data-source-raw-archive-restore-check.mjs
+++ b/tools/ops/data-source-raw-archive-restore-check.mjs
@@ -22,6 +22,7 @@ for (const name of ["archive_id", "run_id", "payload_sha256"]) {
   assert.ok(Number.isInteger(rawIndex[name]), `raw-archives.csv missing ${name}`);
 }
 const runIds = new Set(collectionRuns.map((row) => row[collectionRunIndex]));
+assert.equal(runIds.size, collectionRuns.length, "collection run IDs must be unique");
 const archives = new Map(rawArchives.map((row) => [row[rawIndex.archive_id], row]));
 assert.equal(archives.size, rawArchives.length, "raw archive IDs must be unique");
 const materializedArchiveIds = manifest.materialized.map((record) => record.archiveId);

--- a/tools/ops/data-source-raw-archive-restore-check.mjs
+++ b/tools/ops/data-source-raw-archive-restore-check.mjs
@@ -7,9 +7,9 @@ import { parseCsv } from "./data-source-raw-archive-csv.mjs";
 
 const archiveDir = resolveArchiveDirectory(process.argv[2]);
 
-const collectionRuns = parseCsv(readFileSync(path.join(archiveDir, "collection-runs.csv"), "utf8"));
-const rawArchives = parseCsv(readFileSync(path.join(archiveDir, "raw-archives.csv"), "utf8"));
-const manifest = JSON.parse(readFileSync(path.join(archiveDir, "payload-manifest.json"), "utf8"));
+const collectionRuns = parseCsv(readArchiveMetadata("collection-runs.csv"));
+const rawArchives = parseCsv(readArchiveMetadata("raw-archives.csv"));
+const manifest = JSON.parse(readArchiveMetadata("payload-manifest.json"));
 assert.equal(manifest.schemaVersion, 1);
 assert.ok(manifest.materialized.length > 0, "source archive must contain at least one materialized payload");
 
@@ -65,6 +65,16 @@ console.log(`data source archive restore rehearsal ok: ${manifest.materialized.l
 function assertSafeRelativePath(value) {
   assert.equal(path.isAbsolute(value), false, "objectPath must be relative");
   assert.equal(value.split(/[\\/]/).includes(".."), false, "objectPath must not contain traversal");
+}
+
+function readArchiveMetadata(fileName) {
+  const filePath = path.join(archiveDir, fileName);
+  const status = lstatSync(filePath);
+  assert.equal(status.isSymbolicLink(), false, `archive metadata must not be a symlink: ${fileName}`);
+  assert.equal(status.isFile(), true, `archive metadata must be a regular file: ${fileName}`);
+  const realFilePath = realpathSync(filePath);
+  assert.ok(realFilePath.startsWith(`${archiveDir}${path.sep}`), `archive metadata must stay inside archive: ${fileName}`);
+  return readFileSync(realFilePath, "utf8");
 }
 
 function resolveArchiveDirectory(value) {

--- a/tools/ops/data-source-raw-archive-restore-check.mjs
+++ b/tools/ops/data-source-raw-archive-restore-check.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { existsSync, lstatSync, readFileSync, realpathSync, statSync } from "node:fs";
 import path from "node:path";
 
 const archiveDir = path.resolve(process.argv[2] ?? "");
@@ -23,11 +23,20 @@ for (const name of ["archive_id", "run_id", "payload_sha256"]) {
 }
 const runIds = new Set(collectionRuns.map((row) => row[collectionRunIndex]));
 const archives = new Map(rawArchives.map((row) => [row[rawIndex.archive_id], row]));
+assert.equal(archives.size, rawArchives.length, "raw archive IDs must be unique");
+const materializedArchiveIds = manifest.materialized.map((record) => record.archiveId);
+assert.equal(
+  new Set(materializedArchiveIds).size,
+  materializedArchiveIds.length,
+  "materialized archive IDs must be unique",
+);
 assert.equal(
   manifest.materialized.length,
   rawArchives.length,
   "every raw archive row must have a materialized payload",
 );
+assert.deepEqual(materializedArchiveIds.toSorted(), [...archives.keys()].toSorted());
+const realArchiveDir = realpathSync(archiveDir);
 
 for (const record of manifest.materialized) {
   const row = archives.get(record.archiveId);
@@ -39,8 +48,13 @@ for (const record of manifest.materialized) {
   const objectPath = path.resolve(archiveDir, record.objectPath);
   assert.ok(objectPath.startsWith(`${archiveDir}${path.sep}`));
   assert.ok(existsSync(objectPath), `materialized payload missing: ${record.objectPath}`);
-  assert.equal(statSync(objectPath).size, record.sizeBytes);
-  assert.equal(createHash("sha256").update(readFileSync(objectPath)).digest("hex"), record.sha256);
+  const objectStatus = lstatSync(objectPath);
+  assert.equal(objectStatus.isSymbolicLink(), false, `materialized payload must not be a symlink: ${record.objectPath}`);
+  assert.equal(objectStatus.isFile(), true, `materialized payload must be a regular file: ${record.objectPath}`);
+  const realObjectPath = realpathSync(objectPath);
+  assert.ok(realObjectPath.startsWith(`${realArchiveDir}${path.sep}`), "materialized payload must stay inside archive");
+  assert.equal(statSync(realObjectPath).size, record.sizeBytes);
+  assert.equal(createHash("sha256").update(readFileSync(realObjectPath)).digest("hex"), record.sha256);
 }
 console.log(`data source archive restore rehearsal ok: ${manifest.materialized.length} payload(s)`);
 

--- a/tools/ops/data-source-raw-archive-restore-check.mjs
+++ b/tools/ops/data-source-raw-archive-restore-check.mjs
@@ -3,9 +3,9 @@ import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import { existsSync, lstatSync, readFileSync, realpathSync, statSync } from "node:fs";
 import path from "node:path";
+import { parseCsv } from "./data-source-raw-archive-csv.mjs";
 
-const archiveDir = path.resolve(process.argv[2] ?? "");
-assert.ok(process.argv[2], "usage: data-source-raw-archive-restore-check.mjs <archive-dir>");
+const archiveDir = resolveArchiveDirectory(process.argv[2]);
 
 const collectionRuns = parseCsv(readFileSync(path.join(archiveDir, "collection-runs.csv"), "utf8"));
 const rawArchives = parseCsv(readFileSync(path.join(archiveDir, "raw-archives.csv"), "utf8"));
@@ -35,8 +35,10 @@ assert.equal(
   rawArchives.length,
   "every raw archive row must have a materialized payload",
 );
-assert.deepEqual(materializedArchiveIds.toSorted(), [...archives.keys()].toSorted());
-const realArchiveDir = realpathSync(archiveDir);
+assert.deepEqual(
+  materializedArchiveIds.toSorted(compareStrings),
+  [...archives.keys()].toSorted(compareStrings),
+);
 
 for (const record of manifest.materialized) {
   const row = archives.get(record.archiveId);
@@ -52,7 +54,7 @@ for (const record of manifest.materialized) {
   assert.equal(objectStatus.isSymbolicLink(), false, `materialized payload must not be a symlink: ${record.objectPath}`);
   assert.equal(objectStatus.isFile(), true, `materialized payload must be a regular file: ${record.objectPath}`);
   const realObjectPath = realpathSync(objectPath);
-  assert.ok(realObjectPath.startsWith(`${realArchiveDir}${path.sep}`), "materialized payload must stay inside archive");
+  assert.ok(realObjectPath.startsWith(`${archiveDir}${path.sep}`), "materialized payload must stay inside archive");
   assert.equal(statSync(realObjectPath).size, record.sizeBytes);
   assert.equal(createHash("sha256").update(readFileSync(realObjectPath)).digest("hex"), record.sha256);
 }
@@ -63,40 +65,15 @@ function assertSafeRelativePath(value) {
   assert.equal(value.split(/[\\/]/).includes(".."), false, "objectPath must not contain traversal");
 }
 
-function parseCsv(text) {
-  const rows = [];
-  let row = [];
-  let field = "";
-  let quoted = false;
-  for (let offset = 0; offset < text.length; offset += 1) {
-    const character = text[offset];
-    if (quoted) {
-      if (character === '"' && text[offset + 1] === '"') {
-        field += '"';
-        offset += 1;
-      } else if (character === '"') {
-        quoted = false;
-      } else {
-        field += character;
-      }
-    } else if (character === '"') {
-      quoted = true;
-    } else if (character === ",") {
-      row.push(field);
-      field = "";
-    } else if (character === "\n") {
-      row.push(field.replace(/\r$/, ""));
-      if (row.some((value) => value !== "")) rows.push(row);
-      row = [];
-      field = "";
-    } else {
-      field += character;
-    }
-  }
-  if (field !== "" || row.length > 0) {
-    row.push(field);
-    rows.push(row);
-  }
-  assert.equal(quoted, false, "unterminated quoted CSV field");
-  return rows;
+function resolveArchiveDirectory(value) {
+  assert.ok(value, "usage: data-source-raw-archive-restore-check.mjs <archive-dir>");
+  const resolved = path.resolve(value);
+  const status = lstatSync(resolved);
+  if (status.isSymbolicLink()) throw new Error("archive directory must not be a symlink");
+  if (!status.isDirectory()) throw new Error("archive directory must be a directory");
+  return realpathSync(resolved);
+}
+
+function compareStrings(left, right) {
+  return left.localeCompare(right);
 }

--- a/tools/ops/data-source-raw-archive-restore-check.mjs
+++ b/tools/ops/data-source-raw-archive-restore-check.mjs
@@ -5,7 +5,7 @@ import { existsSync, lstatSync, readFileSync, realpathSync, statSync } from "nod
 import path from "node:path";
 import { parseCsv } from "./data-source-raw-archive-csv.mjs";
 
-const archiveDir = resolveArchiveDirectory(process.argv[2]);
+const archiveDir = resolveArchiveDirectory(process.env.EASYSUBWAY_DATA_SOURCE_RESTORE_DIR);
 
 const collectionRuns = parseCsv(readArchiveMetadata("collection-runs.csv"));
 const rawArchives = parseCsv(readArchiveMetadata("raw-archives.csv"));
@@ -78,7 +78,7 @@ function readArchiveMetadata(fileName) {
 }
 
 function resolveArchiveDirectory(value) {
-  assert.ok(value, "usage: data-source-raw-archive-restore-check.mjs <archive-dir>");
+  assert.ok(value, "EASYSUBWAY_DATA_SOURCE_RESTORE_DIR is required");
   const resolved = path.resolve(value);
   const status = lstatSync(resolved);
   if (status.isSymbolicLink()) throw new Error("archive directory must not be a symlink");

--- a/tools/ops/data-source-raw-archive.sh
+++ b/tools/ops/data-source-raw-archive.sh
@@ -75,6 +75,8 @@ awk -v collection_runs_file="${collection_runs_file}" -v raw_archives_file="${ra
 	}
 ' "${stream_file}"
 
+node "${ROOT_DIR}/tools/ops/data-source-raw-archive-materialize.mjs" "${raw_archives_file}" "${run_dir}"
+
 trap - EXIT
 cleanup
 printf 'data source archive written: %s\n' "${run_dir}"

--- a/tools/ops/facility-report-photo-backup.sh
+++ b/tools/ops/facility-report-photo-backup.sh
@@ -68,7 +68,7 @@ SELECT report_id,
 	REPLACE(REPLACE(ENCODE(CONVERT_TO(COALESCE(photo_file_name, ''), 'UTF8'), 'base64'), E'\n', ''), E'\r', '') AS photo_file_name_base64,
 	REPLACE(REPLACE(ENCODE(CONVERT_TO(COALESCE(photo_content_type, ''), 'UTF8'), 'base64'), E'\n', ''), E'\r', '') AS photo_content_type_base64,
 	COALESCE(photo_object_key, '') AS photo_object_key,
-	COALESCE(photo_thumbnail_object_key, '') AS photo_thumbnail_object_key,
+	COALESCE(photo_thumbnail_object_key, '__EASYSUBWAY_EMPTY__') AS photo_thumbnail_object_key,
 	COALESCE(photo_sha256, '') AS photo_sha256,
 	COALESCE(photo_size_bytes::TEXT, '') AS photo_size_bytes
 FROM facility_reports
@@ -83,6 +83,9 @@ printf 'report_id\tfile_name\tcontent_type\tobject_key\tthumbnail_object_key\tsh
 while IFS=$'\t' read -r report_id file_name_base64 content_type_base64 object_key thumbnail_object_key sha256 size_bytes; do
 	if [[ -z "${report_id}" || -z "${object_key}" ]]; then
 		continue
+	fi
+	if [[ "${thumbnail_object_key}" == "__EASYSUBWAY_EMPTY__" ]]; then
+		thumbnail_object_key=""
 	fi
 	object_path="objects/${object_key}"
 	thumbnail_path="objects/${thumbnail_object_key}"

--- a/tools/ops/postgres-restore-rehearsal.sh
+++ b/tools/ops/postgres-restore-rehearsal.sh
@@ -21,7 +21,7 @@ cleanup() {
 
 case "$RESTORE_DB" in
 	"$POSTGRES_DB"|postgres|template0|template1)
-		printf 'Refusing to use protected restore database: %s\n' "$RESTORE_DB" >&2
+		printf "Refusing to use protected restore database: %s\n" "$RESTORE_DB" >&2
 		exit 2
 		;;
 esac

--- a/tools/ops/validate-production-readiness-evidence.mjs
+++ b/tools/ops/validate-production-readiness-evidence.mjs
@@ -10,6 +10,31 @@ export function assertTemporaryReleaseDecisionsCurrent(evidence, now = new Date(
 
   const decisions = latestStatus.temporaryReleaseDecisions;
   assert.ok(decisions && typeof decisions === "object", "temporaryReleaseDecisions is required for SATISFIED");
+  const requirements = [
+    {
+      id: "adminAuthTransition",
+      required: evidence.backendControlPlane.adminAuthTransition?.oidcMfaSsoDeferredExceptionRequired,
+      fields: evidence.backendControlPlane.adminAuthTransition?.temporaryExceptionRequiredFields,
+    },
+    {
+      id: "operatorTenantScope",
+      required: evidence.backendControlPlane.operatorTenantScope?.releaseExceptionRequired,
+      fields: evidence.backendControlPlane.operatorTenantScope?.requiredDecisionFields,
+    },
+    {
+      id: "singleInstanceAbuseControl",
+      required: evidence.backendControlPlane.abuseControlReleaseException?.distributedStorePreferred,
+      fields: evidence.backendControlPlane.abuseControlReleaseException?.singleInstanceExceptionRequiredFields,
+    },
+  ];
+  for (const requirement of requirements.filter(({ required }) => required)) {
+    const decision = decisions[requirement.id];
+    assert.ok(decision, `required temporary release decision missing: ${requirement.id}`);
+    assert.ok(Array.isArray(requirement.fields), `required decision fields missing: ${requirement.id}`);
+    for (const field of requirement.fields) {
+      assert.ok(hasValue(decision[field]), `${requirement.id}.${field} is required`);
+    }
+  }
   for (const [decisionId, decision] of Object.entries(decisions)) {
     assert.match(decision.untilDate ?? "", /^\d{4}-\d{2}-\d{2}$/, `${decisionId}.untilDate must be YYYY-MM-DD`);
     assert.equal(isValidCalendarDate(decision.untilDate), true, `${decisionId}.untilDate must be valid`);
@@ -18,6 +43,10 @@ export function assertTemporaryReleaseDecisionsCurrent(evidence, now = new Date(
       throw new Error(`temporary release decision expired: ${decisionId} (${decision.untilDate})`);
     }
   }
+}
+
+function hasValue(value) {
+  return value !== undefined && value !== null && (typeof value !== "string" || value.trim() !== "");
 }
 
 function isValidCalendarDate(value) {

--- a/tools/ops/validate-production-readiness-evidence.mjs
+++ b/tools/ops/validate-production-readiness-evidence.mjs
@@ -66,9 +66,11 @@ async function main() {
   console.log("production readiness temporary decisions valid");
 }
 
-if (import.meta.url === pathToFileURL(process.argv[1]).href) {
-  main().catch((error) => {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    await main();
+  } catch (error) {
     console.error(error.message);
     process.exitCode = 1;
-  });
+  }
 }

--- a/tools/ops/validate-production-readiness-evidence.mjs
+++ b/tools/ops/validate-production-readiness-evidence.mjs
@@ -12,12 +12,19 @@ export function assertTemporaryReleaseDecisionsCurrent(evidence, now = new Date(
   assert.ok(decisions && typeof decisions === "object", "temporaryReleaseDecisions is required for SATISFIED");
   for (const [decisionId, decision] of Object.entries(decisions)) {
     assert.match(decision.untilDate ?? "", /^\d{4}-\d{2}-\d{2}$/, `${decisionId}.untilDate must be YYYY-MM-DD`);
+    assert.equal(isValidCalendarDate(decision.untilDate), true, `${decisionId}.untilDate must be valid`);
     const expiresAt = new Date(`${decision.untilDate}T23:59:59.999+09:00`);
-    assert.equal(Number.isNaN(expiresAt.getTime()), false, `${decisionId}.untilDate must be valid`);
     if (now.getTime() > expiresAt.getTime()) {
       throw new Error(`temporary release decision expired: ${decisionId} (${decision.untilDate})`);
     }
   }
+}
+
+function isValidCalendarDate(value) {
+  const [year, month, day] = value.split("-").map(Number);
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  return month >= 1 && month <= 12 && day >= 1 && day <= daysInMonth[month - 1];
 }
 
 async function main() {

--- a/tools/ops/validate-production-readiness-evidence.mjs
+++ b/tools/ops/validate-production-readiness-evidence.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+
+export function assertTemporaryReleaseDecisionsCurrent(evidence, now = new Date()) {
+  const latestStatus = evidence.backendControlPlane?.latestQaEvidenceStatus;
+  assert.ok(latestStatus, "backendControlPlane.latestQaEvidenceStatus is required");
+  if (latestStatus.status !== "SATISFIED") return;
+
+  const decisions = latestStatus.temporaryReleaseDecisions;
+  assert.ok(decisions && typeof decisions === "object", "temporaryReleaseDecisions is required for SATISFIED");
+  for (const [decisionId, decision] of Object.entries(decisions)) {
+    assert.match(decision.untilDate ?? "", /^\d{4}-\d{2}-\d{2}$/, `${decisionId}.untilDate must be YYYY-MM-DD`);
+    const expiresAt = new Date(`${decision.untilDate}T23:59:59.999+09:00`);
+    assert.equal(Number.isNaN(expiresAt.getTime()), false, `${decisionId}.untilDate must be valid`);
+    if (now.getTime() > expiresAt.getTime()) {
+      throw new Error(`temporary release decision expired: ${decisionId} (${decision.untilDate})`);
+    }
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const evidenceIndex = args.indexOf("--evidence");
+  const evidencePath = evidenceIndex >= 0 ? args[evidenceIndex + 1] : undefined;
+  assert.ok(evidencePath, "--evidence is required");
+  const evidence = JSON.parse(await readFile(evidencePath, "utf8"));
+  assertTemporaryReleaseDecisionsCurrent(evidence);
+  console.log("production readiness temporary decisions valid");
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/tools/ops/validate-production-readiness-evidence.test.mjs
+++ b/tools/ops/validate-production-readiness-evidence.test.mjs
@@ -3,14 +3,48 @@ import test from "node:test";
 import { assertTemporaryReleaseDecisionsCurrent } from "./validate-production-readiness-evidence.mjs";
 
 function evidenceWithUntilDate(untilDate) {
+  const commonDecision = {
+    owner: "AquilaXk",
+    untilDate,
+    risk: "temporary risk",
+    mitigation: "temporary mitigation",
+    followUpIssue: 1020,
+  };
   return {
     backendControlPlane: {
       latestQaEvidenceStatus: {
         status: "SATISFIED",
         temporaryReleaseDecisions: {
-          operatorTenantScope: { untilDate },
-          singleInstanceAbuseControl: { untilDate },
+          adminAuthTransition: { ...commonDecision },
+          operatorTenantScope: { ...commonDecision },
+          singleInstanceAbuseControl: {
+            backendReplicaCountOneEvidence: "PASS",
+            scaleOutProhibitedRunbook: "no scale out",
+            owner: "AquilaXk",
+            untilDate,
+            postLaunchAbuseMonitoringThreshold: "monitor",
+            distributedLimiterFollowUpIssue: 1022,
+          },
         },
+      },
+      adminAuthTransition: {
+        oidcMfaSsoDeferredExceptionRequired: true,
+        temporaryExceptionRequiredFields: ["owner", "untilDate", "risk", "mitigation", "followUpIssue"],
+      },
+      operatorTenantScope: {
+        releaseExceptionRequired: true,
+        requiredDecisionFields: ["owner", "untilDate", "risk", "mitigation", "followUpIssue"],
+      },
+      abuseControlReleaseException: {
+        distributedStorePreferred: true,
+        singleInstanceExceptionRequiredFields: [
+          "backendReplicaCountOneEvidence",
+          "scaleOutProhibitedRunbook",
+          "owner",
+          "untilDate",
+          "postLaunchAbuseMonitoringThreshold",
+          "distributedLimiterFollowUpIssue",
+        ],
       },
     },
   };
@@ -29,7 +63,7 @@ test("production readiness validator는 만료된 임시 예외의 SATISFIED 상
       evidenceWithUntilDate("2026-10-13"),
       new Date("2026-10-14T00:00:00.000+09:00"),
     ),
-    /temporary release decision expired: operatorTenantScope/,
+    /temporary release decision expired:/,
   );
 });
 
@@ -39,6 +73,15 @@ test("production readiness validator는 존재하지 않는 달력 날짜를 거
       evidenceWithUntilDate("2026-02-31"),
       new Date("2026-02-01T00:00:00.000+09:00"),
     ),
-    /operatorTenantScope\.untilDate must be valid/,
+    /\.untilDate must be valid/,
+  );
+});
+
+test("production readiness validator는 필수 임시 예외 decision 누락을 거부한다", () => {
+  const evidence = evidenceWithUntilDate("2026-10-13");
+  delete evidence.backendControlPlane.latestQaEvidenceStatus.temporaryReleaseDecisions.adminAuthTransition;
+  assert.throws(
+    () => assertTemporaryReleaseDecisionsCurrent(evidence, new Date("2026-07-13T00:00:00.000+09:00")),
+    /required temporary release decision missing: adminAuthTransition/,
   );
 });

--- a/tools/ops/validate-production-readiness-evidence.test.mjs
+++ b/tools/ops/validate-production-readiness-evidence.test.mjs
@@ -1,6 +1,16 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import test from "node:test";
 import { assertTemporaryReleaseDecisionsCurrent } from "./validate-production-readiness-evidence.mjs";
+
+test("production readiness validator module은 argv 없는 ESM import를 허용한다", () => {
+  const moduleUrl = new URL("./validate-production-readiness-evidence.mjs", import.meta.url).href;
+  assert.doesNotThrow(() => execFileSync(
+    process.execPath,
+    ["--input-type=module", "-e", `import(${JSON.stringify(moduleUrl)})`],
+    { stdio: "pipe" },
+  ));
+});
 
 function evidenceWithUntilDate(untilDate) {
   const commonDecision = {

--- a/tools/ops/validate-production-readiness-evidence.test.mjs
+++ b/tools/ops/validate-production-readiness-evidence.test.mjs
@@ -32,3 +32,13 @@ test("production readiness validator는 만료된 임시 예외의 SATISFIED 상
     /temporary release decision expired: operatorTenantScope/,
   );
 });
+
+test("production readiness validator는 존재하지 않는 달력 날짜를 거부한다", () => {
+  assert.throws(
+    () => assertTemporaryReleaseDecisionsCurrent(
+      evidenceWithUntilDate("2026-02-31"),
+      new Date("2026-02-01T00:00:00.000+09:00"),
+    ),
+    /operatorTenantScope\.untilDate must be valid/,
+  );
+});

--- a/tools/ops/validate-production-readiness-evidence.test.mjs
+++ b/tools/ops/validate-production-readiness-evidence.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { assertTemporaryReleaseDecisionsCurrent } from "./validate-production-readiness-evidence.mjs";
+
+function evidenceWithUntilDate(untilDate) {
+  return {
+    backendControlPlane: {
+      latestQaEvidenceStatus: {
+        status: "SATISFIED",
+        temporaryReleaseDecisions: {
+          operatorTenantScope: { untilDate },
+          singleInstanceAbuseControl: { untilDate },
+        },
+      },
+    },
+  };
+}
+
+test("production readiness validator는 유효기간 안의 임시 예외를 허용한다", () => {
+  assert.doesNotThrow(() => assertTemporaryReleaseDecisionsCurrent(
+    evidenceWithUntilDate("2026-10-13"),
+    new Date("2026-10-13T23:59:59.999+09:00"),
+  ));
+});
+
+test("production readiness validator는 만료된 임시 예외의 SATISFIED 상태를 거부한다", () => {
+  assert.throws(
+    () => assertTemporaryReleaseDecisionsCurrent(
+      evidenceWithUntilDate("2026-10-13"),
+      new Date("2026-10-14T00:00:00.000+09:00"),
+    ),
+    /temporary release decision expired: operatorTenantScope/,
+  );
+});


### PR DESCRIPTION
## 관련 이슈

Closes #1017

## 작업 배경

- #1017의 production 환경·배포·복구 준비 증거가 2026-06-28 상태에 머물러 실제 완료된 release artifact, prod-like readiness/rollback, restore와 security/admin 검증을 반영하지 못했습니다.
- PostgreSQL restore rehearsal의 중첩 `sh -lc` 문자열에서 single quote가 command를 끊어 실제 복구가 실패했습니다.

## 작업 내용

- main SHA `95702961b3bc59d1d1e2a3c89131ea242c349353` Release Artifacts와 image identity를 machine evidence에 고정했습니다.
- GitHub production Environment 보호, 로컬 prod-profile target/rollback readiness, PostgreSQL·신고 사진·source raw archive·Actions datapack artifact 복구, security/admin 검증을 `SATISFIED`/`PASS`로 기록했습니다.
- 실제 신고 사진 object backup/restore, self-contained source payload archive, break-glass 사용 직후 회전과 admin privacy/audit drill을 수행하고 machine evidence와 G5 상태를 동기화했습니다.
- 실제 production mutation은 수행하지 않았고 final deploy/readiness/rollback/data backup/GO-NO-GO를 #1020 실행 gate로 분리했습니다.
- PostgreSQL restore rehearsal의 중첩 shell quoting 결함을 수정하고 회귀 테스트를 강화했습니다.

## 검증

- `cd backend && ./gradlew check --no-daemon` — BUILD SUCCESSFUL
- `node --test tools/ci/*.test.mjs` — 261 passed, 0 failed
- `node tools/ops/backup-restore-rehearsal-check.mjs` — PASS
- `node tools/datapack/validate-source-inventory.mjs --inventory tools/datapack/source-inventory.json` — PASS
- `node tools/ci/audit-mobile-datapack-assets.mjs --index apps/mobile/assets/datapacks/index.json --root apps/mobile` — core/capital checksum·SQLite audit PASS
- 실제 PostgreSQL dump를 격리 DB `easysubway_restore_rehearsal`로 restore — PASS
- 실제 신고 사진 backup manifest/object hash·size·path restore — PASS
- 실제 source raw payload self-contained archive와 restore — PASS
- Data Pack Release artifact `easysubway-datapacks-c28a1c99b88ccf49bbecb60ca1810775db530813` 다운로드 후 manifest/SQLite validation — PASS
- break-glass 두 credential 사용 직후 rotation 강제, 최종 미사용 credential ACTIVE, 사유 포함 login audit — PASS
- 합성 신고 사진 원본 조회 `PRIVACY_READ`, request ID·사유 기록과 민감값 비포함 — PASS
- local Docker prod profile target readiness `UP`, 직전 main rollback readiness `UP`
- `git diff --check` — PASS

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Release artifact | GitHub Actions | main SHA backend artifact metadata·image inspect | https://github.com/AquilaXk/easysubway/actions/runs/29274432867 | PASS |
| production 보호 | GitHub Environment | required reviewer·environment-scoped secret 이름만 확인 | redacted settings summary, secret 값 미수집 | PASS |
| prod-like 배포·rollback | local Docker | target/rollback revision container 교체 후 readiness | 로컬 command output | PASS |
| PostgreSQL 복구 | local Docker | dump→격리 DB restore | 로컬 command output, dump 미게시 | PASS |
| 신고 사진 복구 | local Docker/object fixture | 실제 backup→manifest·object hash·size·path restore | 민감 object 미게시, 로컬 요약 | PASS |
| source raw archive | local Docker/PostgreSQL | DB inventory→payload materialize→self-contained restore | payload 미게시, 로컬 요약 | PASS |
| datapack manifest history | GitHub Actions artifact | artifact 다운로드 후 manifest·SQLite validation | https://github.com/AquilaXk/easysubway/actions/runs/29271665083 | PASS |
| security/admin | local prod-like + backend tests | break-glass rotation, photo privacy read, CSRF audit, default-deny·lockout·accessibility | redacted local summary + Gradle check | PASS |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: main SHA `95702961b3bc59d1d1e2a3c89131ea242c349353` release artifact 검증

## 리뷰어 메모

- `remainingBlockers=[]`가 준비 범위만 닫고 실제 production 실행은 `productionExecutionGate`와 #1020에 남기는지 먼저 확인해 주세요.
- fallback review의 실제 object/source/datapack restore, break-glass/audit drill, G5 동기화 finding을 모두 반영했습니다.

## 리스크

- machine evidence가 특정 main SHA와 Actions run을 고정하므로 final target이 바뀌면 #1020에서 새 identity와 실행 증거를 요구합니다.
- production 환경이나 데이터에는 변경을 수행하지 않았습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 백업·복원 리허설 검증이 강화되어 payload의 해시, 크기, 식별자 및 파일 안전성을 확인합니다.
  * 원본 데이터 아카이브 생성 시 검증된 payload manifest가 함께 제공됩니다.
  * CSV 처리 및 시설 사진 썸네일의 빈 값 처리가 안정화되었습니다.

* **릴리스 상태**
  * 백엔드 제어 영역 게이트가 충족 상태로 갱신되었습니다.
  * QA 증적과 복원 준비 상태가 최신 정보로 업데이트되었습니다.
  * 프로덕션 실행에 필요한 배포, 롤백, 복원 및 최종 승인 조건이 명확해졌습니다.

* **검증**
  * 릴리스, 백업·복원, 보안 및 관리자 검증 항목이 확대되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->