### PR TITLE
[Fix] 대전 열차시각표 XML schema admission

### DIFF
--- a/tools/datapack/probe-daejeon-coverage-api.mjs
+++ b/tools/datapack/probe-daejeon-coverage-api.mjs
@@ -24,7 +24,7 @@ export const DAEJEON_COVERAGE_OPERATIONS = Object.freeze({
   }),
 });
 
-export async function probeDaejeonCoverageApi({ sourceId, serviceKey, fetchImpl = fetch } = {}) {
+export async function probeDaejeonCoverageApi({ sourceId, serviceKey, fetchImpl = fetch, now = new Date() } = {}) {
   const operation = DAEJEON_COVERAGE_OPERATIONS[sourceId];
   if (!operation) throw new Error(`unsupported Daejeon coverage source: ${sourceId ?? "missing"}`);
   const key = decodedServiceKey(requiredString(serviceKey, "DATA_GO_KR_SERVICE_KEY"));
@@ -32,13 +32,20 @@ export async function probeDaejeonCoverageApi({ sourceId, serviceKey, fetchImpl 
   url.searchParams.set("serviceKey", key);
   for (const [name, value] of Object.entries(operation.query ?? {})) url.searchParams.set(name, value);
 
-  const response = await fetchWithRetry(url, fetchImpl);
+  const response = await fetchWithRetry(url, operation.format, fetchImpl);
   if (!response.ok) throw new Error(`Daejeon coverage API HTTP ${response.status}`);
   const contentType = response.headers.get("content-type")?.split(";", 1)[0].trim().toLowerCase() ?? "";
   const raw = await response.text();
-  const parsed = operation.format === "xml"
-    ? parseXmlEvidence(raw, operation.expectedFields)
-    : parseJsonEvidence(raw);
+  let parsed;
+  try {
+    parsed = operation.format === "xml"
+      ? parseXmlEvidence(raw, operation.expectedFields)
+      : parseJsonEvidence(raw);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Daejeon coverage API parse failure";
+    throw new Error(`${message}; observedAt=${now.toISOString()}; httpStatus=${response.status}; `
+      + `contentType=${contentType || "missing"}; rawBytes=${Buffer.byteLength(raw)}; rawSha256=${sha256(raw)}`);
+  }
   if (operation.format === "xml" && !new Set(["application/xml", "text/xml"]).has(contentType)) {
     throw new Error(`Daejeon coverage API schema mismatch: content-type ${contentType || "missing"}`);
   }
@@ -49,6 +56,7 @@ export async function probeDaejeonCoverageApi({ sourceId, serviceKey, fetchImpl 
     schemaVersion: 1,
     artifactKind: "daejeon-coverage-api-probe-evidence",
     sourceId,
+    observedAt: now.toISOString(),
     endpoint: operation.endpoint,
     httpStatus: response.status,
     providerResultCode: parsed.providerResultCode,
@@ -60,13 +68,13 @@ export async function probeDaejeonCoverageApi({ sourceId, serviceKey, fetchImpl 
   };
 }
 
-async function fetchWithRetry(url, fetchImpl) {
+async function fetchWithRetry(url, format, fetchImpl) {
   for (let attempt = 0; attempt < 2; attempt += 1) {
     try {
       return await fetchImpl(url, {
         redirect: "error",
         signal: AbortSignal.timeout(15_000),
-        headers: { accept: "application/json,application/xml,text/xml" },
+        headers: { accept: format === "xml" ? "application/xml,text/xml" : "application/json" },
       });
     } catch (error) {
       if (attempt === 1) throw new Error("Daejeon coverage API transport failure", { cause: error });

--- a/tools/datapack/probe-daejeon-coverage-api.test.mjs
+++ b/tools/datapack/probe-daejeon-coverage-api.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 import {
@@ -6,14 +7,21 @@ import {
   probeDaejeonCoverageApi,
 } from "./probe-daejeon-coverage-api.mjs";
 
+const sourceCandidates = JSON.parse(await readFile(new URL("./source-candidates.json", import.meta.url), "utf8"));
+const timetableEvidence = JSON.parse(await readFile(
+  new URL("./sources/daejeon-train-timetable-20260714.json", import.meta.url), "utf8",
+));
+
 test("대전 coverage probe는 시간표 XML을 검증하고 credential을 제거한다", async () => {
   const secret = "never-print-this-key";
   let requestedUrl;
   const evidence = await probeDaejeonCoverageApi({
     sourceId: "daejeon-train-timetable",
     serviceKey: secret,
-    fetchImpl: async (url) => {
+    now: new Date("2026-07-14T07:00:00.000Z"),
+    fetchImpl: async (url, init) => {
       requestedUrl = url;
+      assert.equal(init.headers.accept, "application/xml,text/xml");
       return new Response(`<?xml version="1.0"?><response><header><resultCode>00</resultCode><resultMsg>OK</resultMsg></header><body><items><item><dayType>평일</dayType><drctType>상행</drctType><stNum>101</stNum><tmList>0530</tmList><tmZone>05</tmZone></item></items></body></response>`, {
         status: 200,
         headers: { "content-type": "application/xml" },
@@ -23,6 +31,7 @@ test("대전 coverage probe는 시간표 XML을 검증하고 credential을 제�
 
   assert.equal(new URL(requestedUrl).searchParams.get("serviceKey"), secret);
   assert.equal(evidence.providerResultCode, "00");
+  assert.equal(evidence.observedAt, "2026-07-14T07:00:00.000Z");
   assert.equal(evidence.rowCount, 1);
   assert.deepEqual(evidence.outputFields, ["dayType", "drctType", "stNum", "tmList", "tmZone"]);
   assert.equal(evidence.credentialRedacted, true);
@@ -33,8 +42,9 @@ test("대전 coverage probe는 odcloud row schema만 sanitized evidence로 보�
   const evidence = await probeDaejeonCoverageApi({
     sourceId: "daejeon-station-distance-fare",
     serviceKey: "encoded%2Bkey",
-    fetchImpl: async (url) => {
+    fetchImpl: async (url, init) => {
       assert.equal(new URL(url).searchParams.get("serviceKey"), "encoded+key");
+      assert.equal(init.headers.accept, "application/json");
       return new Response(JSON.stringify({
         currentCount: 1,
         data: [{ "출발역": "반석", "도착역": "지족", "거리(km)": 1.2, "소요시간(분)": 2, "요금(원)": 1550 }],
@@ -52,7 +62,41 @@ test("대전 coverage probe는 odcloud row schema만 sanitized evidence로 보�
   assert.equal("rows" in evidence, false);
 });
 
+test("대전 열차시각표 candidate는 live XML schema만 admission하고 coverage는 계속 fail closed한다", () => {
+  const candidate = sourceCandidates.candidates.find(({ id }) => id === "daejeon-train-timetable");
+  assert.equal(candidate.sampleEvidenceStatus, "validated_live_sample");
+  assert.equal(candidate.admissionStatus, "validated_live_schema_admitted");
+  assert.equal(candidate.evidence.liveValidation.providerResultCode, "00");
+  assert.equal(candidate.evidence.liveValidation.rowCount, 1628);
+  assert.equal(candidate.evidence.liveValidation.observedAt, "2026-07-14T07:02:58.606Z");
+  assert.equal(candidate.evidence.coverageAssessment.state, "MISSING");
+  assert.equal(candidate.evidence.liveValidation.evidenceArtifact,
+    "tools/datapack/sources/daejeon-train-timetable-20260714.json");
+  assert.equal(timetableEvidence.sourceId, candidate.id);
+  assert.equal(timetableEvidence.rawSha256, candidate.evidence.liveValidation.rawSha256);
+  assert.deepEqual(timetableEvidence.outputFields, candidate.evidence.outputFields);
+});
+
 test("대전 coverage probe는 provider/schema 오류를 fail closed한다", async (context) => {
+  await context.test("XML envelope 누락은 credential 없는 HTTP/hash 진단을 남긴다", async () => {
+    const secret = "do-not-log-this-key";
+    await assert.rejects(probeDaejeonCoverageApi({
+      sourceId: "daejeon-train-timetable",
+      serviceKey: secret,
+      now: new Date("2026-07-14T07:10:00.000Z"),
+      fetchImpl: async () => new Response("", {
+        status: 200,
+        headers: { "content-type": "text/plain" },
+      }),
+    }), (error) => {
+      assert.match(error.message, /provider resultCode UNKNOWN/);
+      assert.match(error.message, /observedAt=2026-07-14T07:10:00.000Z/);
+      assert.match(error.message, /httpStatus=200; contentType=text\/plain; rawBytes=0; rawSha256=[a-f0-9]{64}/);
+      assert.doesNotMatch(error.message, new RegExp(secret));
+      return true;
+    });
+  });
+
   await context.test("XML provider failure", async () => {
     await assert.rejects(probeDaejeonCoverageApi({
       sourceId: "daejeon-train-timetable",

--- a/tools/datapack/source-candidates.json
+++ b/tools/datapack/source-candidates.json
@@ -3209,8 +3209,8 @@
         "secretPolicy": "env-only-redacted-output"
       },
       "licenseEvidenceStatus": "confirmed_free_use",
-      "sampleEvidenceStatus": "application_complete_activation_pending",
-      "admissionStatus": "provider_activation_required_before_schema_admission",
+      "sampleEvidenceStatus": "validated_live_sample",
+      "admissionStatus": "validated_live_schema_admitted",
       "serviceKeyHandling": "offline_probe_secret_only",
       "mobileEmbeddingAllowed": false,
       "evidence": {
@@ -3221,17 +3221,25 @@
         "outputFields": ["dayType", "drctType", "stNum", "tmList", "tmZone"],
         "officialSwaggerOperationId": "getAllTimeTable",
         "liveValidation": {
-          "attempts": 2,
-          "outcome": "PROVIDER_ENVELOPE_MISSING",
-          "providerResultCode": "UNKNOWN",
-          "admitted": false
+          "observedAt": "2026-07-14T07:02:58.606Z",
+          "httpStatus": 200,
+          "providerResultCode": "00",
+          "schemaStatus": "EXPECTED",
+          "rowCount": 1628,
+          "rawSha256": "af47a698e7770e8fc709bb3dfa05b525f836b57b37cb9b716d6ca768e6723dbd",
+          "evidenceArtifact": "tools/datapack/sources/daejeon-train-timetable-20260714.json",
+          "admitted": true
+        },
+        "coverageAssessment": {
+          "state": "MISSING",
+          "reasonCode": "LIVE_SCHEMA_ADMITTED_MATERIALIZATION_NOT_IMPLEMENTED"
         },
         "coverageLimitations": [
           "대전도시철도 1호선 계획 시각표이며 실시간 도착 정보가 아님",
-          "2026-07-14 credential-safe probe와 bounded retry가 모두 provider envelope 없는 응답으로 종료됨"
+          "live XML schema 1628행은 검증됐지만 production transit trip/stop_time materialization은 아직 구현하지 않음"
         ]
       },
-      "nextAction": "활용신청 전파 후 tracked probe를 재실행하고 provider resultCode 00·expected item schema를 확보한다"
+      "nextAction": "검증된 1628행을 대전도시철도 1호선 schedule_timetable transformer로 materialize하고 production pack 검증을 수행한다"
     },
     {
       "id": "daejeon-station-distance-fare",

--- a/tools/datapack/sources/daejeon-train-timetable-20260714.json
+++ b/tools/datapack/sources/daejeon-train-timetable-20260714.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "daejeon-coverage-api-probe-evidence",
+  "sourceId": "daejeon-train-timetable",
+  "observedAt": "2026-07-14T07:02:58.606Z",
+  "endpoint": "https://apis.data.go.kr/B554695/TimeTableSVC/getAllTimeTable",
+  "httpStatus": 200,
+  "providerResultCode": "00",
+  "schemaStatus": "EXPECTED",
+  "rowCount": 1628,
+  "outputFields": [
+    "dayType",
+    "drctType",
+    "stNum",
+    "tmList",
+    "tmZone"
+  ],
+  "rawSha256": "af47a698e7770e8fc709bb3dfa05b525f836b57b37cb9b716d6ca768e6723dbd",
+  "credentialRedacted": true
+}


### PR DESCRIPTION
## 관련 이슈

Closes #2117

## 작업 배경

대전교통공사 `getAllTimeTable`은 공식 문서상 XML operation인데 공용 probe가 JSON을 우선한 `Accept`를 보내 provider envelope가 없는 것으로 오판하고 있었다. activation 이후 공식 response contract를 다시 확인하고 실제 schema를 admission한다.

## 작업 내용

- operation format에 따라 XML과 JSON `Accept`를 분리했다.
- parse 실패에도 credential 없는 `observedAt`·HTTP status·content type·raw byte/hash 진단을 남긴다.
- live XML 1,628행과 `dayType`·`drctType`·`stNum`·`tmList`·`tmZone` field를 검증했다.
- sanitized evidence artifact를 추가하고 source candidate를 `validated_live_schema_admitted`로 갱신했다.
- production trip/stop_time materialization 전이므로 `schedule_timetable` coverage는 `MISSING`으로 유지했다.

## 검증

- `node --test tools/datapack/probe-daejeon-coverage-api.test.mjs tools/ci/api-catalog.test.mjs`: 18 passed
- `node --test --test-reporter=dot tools/datapack/*.test.mjs`: 통과
- `node tools/ci/api-catalog.mjs validate`: 234 API valid
- `node --check tools/datapack/probe-daejeon-coverage-api.mjs`: 통과
- `git diff --check`: 통과

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 공식 operation | 공공데이터포털 | `B554695/TimeTableSVC/getAllTimeTable`, XML | 공식 Base URL·operation·5개 field | 통과 |
| live schema | tracked Node probe | HTTP/provider/schema 동시 검증 | `observedAt=2026-07-14T07:02:58.606Z`, HTTP 200, provider `00`, 1,628행 | 통과 |
| raw 무결성 | sanitized evidence | body 미저장, SHA-256만 추적 | `af47a698e7770e8fc709bb3dfa05b525f836b57b37cb9b716d6ca768e6723dbd` | 통과 |
| credential 제거 | test/API catalog | evidence·error secret scan | `credentialRedacted=true`, 234 API valid | 통과 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- XML operation이 JSON 우선 `Accept`를 다시 사용하지 않는지 확인해 주세요.
- schema admission이 production schedule support claim으로 과장되지 않는지 확인해 주세요.

## 리스크

- 1,628행은 공식 계획 시각표이며 실시간 도착 정보가 아니다. transformer와 production pack 검증 전에는 앱에 적재하지 않는다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 대전 열차 시간표 데이터의 실시간 스키마 검증이 완료되어 1,628개 행을 확인했습니다.
  - 데이터 관측 시각과 원본 무결성 정보가 기록되어 결과를 더욱 쉽게 추적하고 재현할 수 있습니다.
  - XML 및 JSON 응답 형식에 맞는 검증이 적용되었습니다.
  - 오류 발생 시 HTTP 상태, 응답 형식, 데이터 크기 등 진단 정보가 제공됩니다.
  - 인증 정보는 오류 메시지와 증거 데이터에서 안전하게 마스킹됩니다.

- **알려진 제한**
  - 검증된 데이터를 서비스용 형식으로 변환하는 작업은 아직 지원되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->