### PR TITLE
[Fix] 대전 역간 소요시간·거리·요금 공식 XML API activation

### DIFF
--- a/tools/ci/api-catalog.test.mjs
+++ b/tools/ci/api-catalog.test.mjs
@@ -312,6 +312,15 @@ test("프로젝트 catalog는 주요 API 종류를 모두 찾고 검증한다", 
     assert.equal(entry.operation.auth.env, authEnv);
     assert.equal(entry.operation.runner.command, "node tools/datapack/probe-daejeon-coverage-api.mjs");
   }
+  const daejeonDistanceFare = findCatalogEntry(catalog, "provider:daejeon-station-distance-fare");
+  assert.equal(daejeonDistanceFare.detailUrl, "https://www.data.go.kr/data/15158794/openapi.do");
+  assert.equal(daejeonDistanceFare.endpoint, "https://apis.data.go.kr/B554695/TimeDistSVC/getTimeDist01");
+  assert.deepEqual(daejeonDistanceFare.operation.requiredParameters, [
+    "serviceKey",
+    "strstnno",
+    "endstnno",
+  ]);
+  assert.deepEqual(daejeonDistanceFare.responseFields, ["distfloat", "fee", "min", "sec"]);
   const daejeonSearchIds = new Set(listCatalog(catalog, { kind: "provider", query: "대전" }).map(({ id }) => id));
   for (const id of [
     "provider:daejeon-braille-guide-map",

--- a/tools/datapack/probe-daejeon-coverage-api.mjs
+++ b/tools/datapack/probe-daejeon-coverage-api.mjs
@@ -53,7 +53,7 @@ export async function probeDaejeonCoverageApi({ sourceId, serviceKey, fetchImpl 
   }
   if (operation.format === "xml" && !new Set(["application/xml", "text/xml"]).has(contentType)) {
     throw new Error(`Daejeon coverage API schema mismatch: content-type ${contentType || "missing"}; `
-      + `observedAt=${now.toISOString()}; httpStatus=${response.status}; contentType=${contentType || "missing"}; `
+      + `observedAt=${now.toISOString()}; httpStatus=${response.status}; `
       + `rawBytes=${Buffer.byteLength(raw)}; rawSha256=${sha256(raw)}`);
   }
   if (operation.format === "json" && contentType !== "application/json") {
@@ -115,7 +115,7 @@ function parseXmlEvidence(raw, expectedFields, validateItem) {
     }
     validateItem?.(values);
   }
-  return { providerResultCode: "00", rowCount: items.length, outputFields: expectedFields };
+  return { providerResultCode: "00", rowCount: items.length, outputFields: [...expectedFields] };
 }
 
 function validateDistanceFareItem({ distfloat, fee, min, sec }) {

--- a/tools/datapack/probe-daejeon-coverage-api.mjs
+++ b/tools/datapack/probe-daejeon-coverage-api.mjs
@@ -13,9 +13,11 @@ export const DAEJEON_COVERAGE_OPERATIONS = Object.freeze({
     expectedFields: ["dayType", "drctType", "stNum", "tmList", "tmZone"],
   }),
   "daejeon-station-distance-fare": Object.freeze({
-    endpoint: "https://api.odcloud.kr/api/15082979/v1/uddi:bdfe4740-2e2b-4663-94af-b86de0e6e9de",
-    format: "json",
-    query: { page: "1", perPage: "100", returnType: "JSON" },
+    endpoint: "https://apis.data.go.kr/B554695/TimeDistSVC/getTimeDist01",
+    format: "xml",
+    query: { strstnno: "111", endstnno: "120" },
+    expectedFields: ["distfloat", "fee", "min", "sec"],
+    validateItem: validateDistanceFareItem,
   }),
   "daejeon-braille-guide-map": Object.freeze({
     endpoint: "https://api.odcloud.kr/api/15044677/v1/uddi:6d7ceef4-f258-47ea-ab28-c3c7ef005c2c",
@@ -33,13 +35,16 @@ export async function probeDaejeonCoverageApi({ sourceId, serviceKey, fetchImpl 
   for (const [name, value] of Object.entries(operation.query ?? {})) url.searchParams.set(name, value);
 
   const response = await fetchWithRetry(url, operation.format, fetchImpl);
-  if (!response.ok) throw new Error(`Daejeon coverage API HTTP ${response.status}`);
   const contentType = response.headers.get("content-type")?.split(";", 1)[0].trim().toLowerCase() ?? "";
   const raw = await response.text();
+  if (!response.ok) {
+    throw new Error(`Daejeon coverage API HTTP ${response.status}; observedAt=${now.toISOString()}; `
+      + `contentType=${contentType || "missing"}; rawBytes=${Buffer.byteLength(raw)}; rawSha256=${sha256(raw)}`);
+  }
   let parsed;
   try {
     parsed = operation.format === "xml"
-      ? parseXmlEvidence(raw, operation.expectedFields)
+      ? parseXmlEvidence(raw, operation.expectedFields, operation.validateItem)
       : parseJsonEvidence(raw);
   } catch (error) {
     const message = error instanceof Error ? error.message : "Daejeon coverage API parse failure";
@@ -47,7 +52,9 @@ export async function probeDaejeonCoverageApi({ sourceId, serviceKey, fetchImpl 
       + `contentType=${contentType || "missing"}; rawBytes=${Buffer.byteLength(raw)}; rawSha256=${sha256(raw)}`);
   }
   if (operation.format === "xml" && !new Set(["application/xml", "text/xml"]).has(contentType)) {
-    throw new Error(`Daejeon coverage API schema mismatch: content-type ${contentType || "missing"}`);
+    throw new Error(`Daejeon coverage API schema mismatch: content-type ${contentType || "missing"}; `
+      + `observedAt=${now.toISOString()}; httpStatus=${response.status}; contentType=${contentType || "missing"}; `
+      + `rawBytes=${Buffer.byteLength(raw)}; rawSha256=${sha256(raw)}`);
   }
   if (operation.format === "json" && contentType !== "application/json") {
     throw new Error(`Daejeon coverage API schema mismatch: content-type ${contentType || "missing"}`);
@@ -63,6 +70,7 @@ export async function probeDaejeonCoverageApi({ sourceId, serviceKey, fetchImpl 
     schemaStatus: "EXPECTED",
     rowCount: parsed.rowCount,
     outputFields: parsed.outputFields,
+    rawBytes: Buffer.byteLength(raw),
     rawSha256: sha256(raw),
     credentialRedacted: true,
   };
@@ -83,7 +91,7 @@ async function fetchWithRetry(url, format, fetchImpl) {
   throw new Error("Daejeon coverage API transport failure");
 }
 
-function parseXmlEvidence(raw, expectedFields) {
+function parseXmlEvidence(raw, expectedFields, validateItem) {
   const parsed = scanXmlStructure(raw);
   const resultCode = xmlScalar(raw, "resultCode");
   if (resultCode !== "00") {
@@ -96,11 +104,39 @@ function parseXmlEvidence(raw, expectedFields) {
   if (!["response", "header", "resultCode", "body"].every((tag) => tags.has(tag))) {
     throw new Error("Daejeon coverage API schema mismatch: XML envelope");
   }
-  const outputFields = expectedFields.filter((field) => tags.has(field));
-  if (parsed.itemCount > 0 && outputFields.length !== expectedFields.length) {
-    throw new Error("Daejeon coverage API schema mismatch: XML item fields");
+  const items = [...raw.matchAll(/<item\b[^>]*>([\s\S]*?)<\/item>/gi)].map((match) => match[1]);
+  if (items.length === 0 || items.length !== parsed.itemCount) {
+    throw new Error("Daejeon coverage API schema mismatch: XML items");
   }
-  return { providerResultCode: "00", rowCount: parsed.itemCount, outputFields };
+  for (const item of items) {
+    const values = Object.fromEntries(expectedFields.map((field) => [field, xmlScalar(item, field)]));
+    if (Object.values(values).some((value) => value == null)) {
+      throw new Error("Daejeon coverage API schema mismatch: XML item fields");
+    }
+    validateItem?.(values);
+  }
+  return { providerResultCode: "00", rowCount: items.length, outputFields: expectedFields };
+}
+
+function validateDistanceFareItem({ distfloat, fee, min, sec }) {
+  const distanceText = distfloat?.trim() ?? "";
+  const fareText = fee?.trim() ?? "";
+  const minutesText = min?.trim() ?? "";
+  const secondsText = sec?.trim() ?? "";
+  const distance = Number(distanceText);
+  const fare = Number(fareText);
+  const minutes = Number(minutesText);
+  const seconds = Number(secondsText);
+  if (!/^\d+(?:\.\d+)?$/.test(distanceText)
+    || !/^\d+$/.test(fareText)
+    || !/^\d+$/.test(minutesText)
+    || !/^\d+$/.test(secondsText)
+    || !Number.isFinite(distance) || distance <= 0
+    || !Number.isInteger(fare) || fare < 0
+    || !Number.isInteger(minutes) || minutes < 0
+    || !Number.isInteger(seconds) || seconds < 0 || seconds > 59) {
+    throw new Error("Daejeon coverage API schema mismatch: distance/fare values");
+  }
 }
 
 function xmlScalar(raw, field) {

--- a/tools/datapack/probe-daejeon-coverage-api.test.mjs
+++ b/tools/datapack/probe-daejeon-coverage-api.test.mjs
@@ -38,28 +38,66 @@ test("대전 coverage probe는 시간표 XML을 검증하고 credential을 제�
   assert.doesNotMatch(JSON.stringify(evidence), new RegExp(secret));
 });
 
-test("대전 coverage probe는 odcloud row schema만 sanitized evidence로 보존한다", async () => {
+test("대전 coverage probe는 공식 역간 거리·시간·요금 XML schema를 검증한다", async () => {
   const evidence = await probeDaejeonCoverageApi({
     sourceId: "daejeon-station-distance-fare",
     serviceKey: "encoded%2Bkey",
+    now: new Date("2026-07-14T10:42:00.000Z"),
     fetchImpl: async (url, init) => {
       assert.equal(new URL(url).searchParams.get("serviceKey"), "encoded+key");
-      assert.equal(init.headers.accept, "application/json");
-      return new Response(JSON.stringify({
-        currentCount: 1,
-        data: [{ "출발역": "반석", "도착역": "지족", "거리(km)": 1.2, "소요시간(분)": 2, "요금(원)": 1550 }],
-        matchCount: 1,
-        page: 1,
-        perPage: 100,
-        totalCount: 1,
-      }), { status: 200, headers: { "content-type": "application/json" } });
+      assert.equal(new URL(url).searchParams.get("strstnno"), "111");
+      assert.equal(new URL(url).searchParams.get("endstnno"), "120");
+      assert.equal(init.headers.accept, "application/xml,text/xml");
+      return new Response(`<?xml version="1.0"?><response><header><resultCode>00</resultCode><resultMsg>NORMAL SERVICE.</resultMsg></header><body><items><item><distfloat>9.8</distfloat><fee>1200</fee><min>19</min><sec>50</sec></item></items><numOfRows>10</numOfRows><pageNo>1</pageNo><totalCount>1</totalCount></body></response>`, {
+        status: 200,
+        headers: { "content-type": "application/xml" },
+      });
     },
   });
 
+  assert.equal(evidence.observedAt, "2026-07-14T10:42:00.000Z");
   assert.equal(evidence.rowCount, 1);
-  assert.deepEqual(evidence.outputFields, ["거리(km)", "도착역", "소요시간(분)", "요금(원)", "출발역"]);
+  assert.equal(evidence.rawBytes > 0, true);
+  assert.deepEqual(evidence.outputFields, ["distfloat", "fee", "min", "sec"]);
   assert.equal(evidence.schemaStatus, "EXPECTED");
-  assert.equal("rows" in evidence, false);
+});
+
+test("대전 역간 XML은 빈 row와 잘못된 수치를 거부한다", async (context) => {
+  const cases = [
+    ["empty", "<items></items>"],
+    ["missing field", "<items><item><distfloat>9.8</distfloat><fee>1200</fee><min>19</min></item></items>"],
+    ["missing field per item", "<items><item><distfloat>9.8</distfloat><min>19</min><sec>50</sec></item><item><distfloat>1.2</distfloat><fee>1200</fee><min>2</min><sec>10</sec></item></items>"],
+    ["distance zero", "<items><item><distfloat>0</distfloat><fee>1200</fee><min>19</min><sec>50</sec></item></items>"],
+    ["distance non-number", "<items><item><distfloat>NaN</distfloat><fee>1200</fee><min>19</min><sec>50</sec></item></items>"],
+    ["distance infinite", "<items><item><distfloat>Infinity</distfloat><fee>1200</fee><min>19</min><sec>50</sec></item></items>"],
+    ["distance exponent", "<items><item><distfloat>9.8e0</distfloat><fee>1200</fee><min>19</min><sec>50</sec></item></items>"],
+    ["distance hex", "<items><item><distfloat>0x10</distfloat><fee>1200</fee><min>19</min><sec>50</sec></item></items>"],
+    ["fee empty", "<items><item><distfloat>9.8</distfloat><fee></fee><min>19</min><sec>50</sec></item></items>"],
+    ["minute whitespace", "<items><item><distfloat>9.8</distfloat><fee>1200</fee><min> </min><sec>50</sec></item></items>"],
+    ["second empty", "<items><item><distfloat>9.8</distfloat><fee>1200</fee><min>19</min><sec></sec></item></items>"],
+    ["fee exponent", "<items><item><distfloat>9.8</distfloat><fee>12e2</fee><min>19</min><sec>50</sec></item></items>"],
+    ["second hex", "<items><item><distfloat>9.8</distfloat><fee>1200</fee><min>19</min><sec>0x10</sec></item></items>"],
+    ["fee negative", "<items><item><distfloat>9.8</distfloat><fee>-1</fee><min>19</min><sec>50</sec></item></items>"],
+    ["fee fractional", "<items><item><distfloat>9.8</distfloat><fee>1.5</fee><min>19</min><sec>50</sec></item></items>"],
+    ["minute negative", "<items><item><distfloat>9.8</distfloat><fee>1200</fee><min>-1</min><sec>50</sec></item></items>"],
+    ["minute fractional", "<items><item><distfloat>9.8</distfloat><fee>1200</fee><min>1.5</min><sec>50</sec></item></items>"],
+    ["second negative", "<items><item><distfloat>9.8</distfloat><fee>1200</fee><min>19</min><sec>-1</sec></item></items>"],
+    ["second overflow", "<items><item><distfloat>9.8</distfloat><fee>1200</fee><min>19</min><sec>60</sec></item></items>"],
+    ["second fractional", "<items><item><distfloat>9.8</distfloat><fee>1200</fee><min>19</min><sec>1.5</sec></item></items>"],
+  ];
+
+  for (const [name, items] of cases) {
+    await context.test(name, async () => {
+      await assert.rejects(probeDaejeonCoverageApi({
+        sourceId: "daejeon-station-distance-fare",
+        serviceKey: "key",
+        fetchImpl: async () => new Response(`<response><header><resultCode>00</resultCode></header><body>${items}</body></response>`, {
+          status: 200,
+          headers: { "content-type": "application/xml" },
+        }),
+      }), /schema mismatch/);
+    });
+  }
 });
 
 test("대전 열차시각표 candidate는 live XML schema만 admission하고 coverage는 계속 fail closed한다", () => {
@@ -78,6 +116,44 @@ test("대전 열차시각표 candidate는 live XML schema만 admission하고 cov
 });
 
 test("대전 coverage probe는 provider/schema 오류를 fail closed한다", async (context) => {
+  await context.test("XML content-type mismatch는 credential 없는 hash 진단을 남긴다", async () => {
+    const secret = "do-not-log-content-type-key";
+    await assert.rejects(probeDaejeonCoverageApi({
+      sourceId: "daejeon-station-distance-fare",
+      serviceKey: secret,
+      now: new Date("2026-07-14T10:43:00.000Z"),
+      fetchImpl: async () => new Response("<response><header><resultCode>00</resultCode></header><body><items><item><distfloat>9.8</distfloat><fee>1200</fee><min>19</min><sec>50</sec></item></items></body></response>", {
+        status: 200,
+        headers: { "content-type": "text/plain" },
+      }),
+    }), (error) => {
+      assert.match(error.message, /schema mismatch: content-type text\/plain/);
+      assert.match(error.message, /observedAt=2026-07-14T10:43:00.000Z/);
+      assert.match(error.message, /rawBytes=\d+; rawSha256=[a-f0-9]{64}/);
+      assert.doesNotMatch(error.message, new RegExp(secret));
+      return true;
+    });
+  });
+
+  await context.test("HTTP failure는 credential 없는 HTTP/hash 진단을 남긴다", async () => {
+    const secret = "do-not-log-http-key";
+    await assert.rejects(probeDaejeonCoverageApi({
+      sourceId: "daejeon-station-distance-fare",
+      serviceKey: secret,
+      now: new Date("2026-07-14T07:20:00.000Z"),
+      fetchImpl: async () => new Response("forbidden", {
+        status: 403,
+        headers: { "content-type": "text/plain" },
+      }),
+    }), (error) => {
+      assert.match(error.message, /HTTP 403/);
+      assert.match(error.message, /observedAt=2026-07-14T07:20:00.000Z/);
+      assert.match(error.message, /contentType=text\/plain; rawBytes=9; rawSha256=[a-f0-9]{64}/);
+      assert.doesNotMatch(error.message, new RegExp(secret));
+      return true;
+    });
+  });
+
   await context.test("XML envelope 누락은 credential 없는 HTTP/hash 진단을 남긴다", async () => {
     const secret = "do-not-log-this-key";
     await assert.rejects(probeDaejeonCoverageApi({

--- a/tools/datapack/probe-daejeon-coverage-api.test.mjs
+++ b/tools/datapack/probe-daejeon-coverage-api.test.mjs
@@ -11,6 +11,9 @@ const sourceCandidates = JSON.parse(await readFile(new URL("./source-candidates.
 const timetableEvidence = JSON.parse(await readFile(
   new URL("./sources/daejeon-train-timetable-20260714.json", import.meta.url), "utf8",
 ));
+const distanceFareEvidence = JSON.parse(await readFile(
+  new URL("./sources/daejeon-station-distance-fare-20260714.json", import.meta.url), "utf8",
+));
 
 test("대전 coverage probe는 시간표 XML을 검증하고 credential을 제거한다", async () => {
   const secret = "never-print-this-key";
@@ -113,6 +116,25 @@ test("대전 열차시각표 candidate는 live XML schema만 admission하고 cov
   assert.equal(timetableEvidence.sourceId, candidate.id);
   assert.equal(timetableEvidence.rawSha256, candidate.evidence.liveValidation.rawSha256);
   assert.deepEqual(timetableEvidence.outputFields, candidate.evidence.outputFields);
+});
+
+test("대전 역간 candidate는 official XML만 active로 admission하고 topology는 MISSING이다", () => {
+  const candidate = sourceCandidates.candidates.find(({ id }) => id === "daejeon-station-distance-fare");
+  assert.equal(candidate.detailUrl, "https://www.data.go.kr/data/15158794/openapi.do");
+  assert.equal(candidate.requestUrl, "https://apis.data.go.kr/B554695/TimeDistSVC/getTimeDist01");
+  assert.equal(candidate.admissionStatus, "validated_live_schema_admitted");
+  assert.equal(candidate.evidence.liveValidation.rowCount > 0, true);
+  assert.equal(candidate.evidence.coverageAssessment.state, "MISSING");
+  assert.equal(candidate.evidence.historicalSources[0].reasonCode, "SUPERSEDED_FOR_LIVE_PROBE");
+  assert.equal(candidate.evidence.historicalSources[0].runtimeEligible, false);
+  assert.equal(candidate.nextAction,
+    "전체 OD와 canonical station mapping을 별도 이슈에서 검증한 뒤 topology materialization을 판정한다.");
+  assert.equal(distanceFareEvidence.rawSha256, candidate.evidence.liveValidation.rawSha256);
+  assert.equal(distanceFareEvidence.rawBytes > 0, true);
+  assert.equal(distanceFareEvidence.observedAt.startsWith("2026-07-14"), true);
+  assert.equal("rows" in distanceFareEvidence, false);
+  assert.equal("raw" in distanceFareEvidence, false);
+  assert.equal("body" in distanceFareEvidence, false);
 });
 
 test("대전 coverage probe는 provider/schema 오류를 fail closed한다", async (context) => {

--- a/tools/datapack/probe-daejeon-coverage-api.test.mjs
+++ b/tools/datapack/probe-daejeon-coverage-api.test.mjs
@@ -62,6 +62,8 @@ test("대전 coverage probe는 공식 역간 거리·시간·요금 XML schema�
   assert.equal(evidence.rowCount, 1);
   assert.equal(evidence.rawBytes > 0, true);
   assert.deepEqual(evidence.outputFields, ["distfloat", "fee", "min", "sec"]);
+  assert.notEqual(evidence.outputFields,
+    DAEJEON_COVERAGE_OPERATIONS["daejeon-station-distance-fare"].expectedFields);
   assert.equal(evidence.schemaStatus, "EXPECTED");
 });
 
@@ -125,6 +127,9 @@ test("대전 역간 candidate는 official XML만 active로 admission하고 topol
   assert.equal(candidate.admissionStatus, "validated_live_schema_admitted");
   assert.equal(candidate.evidence.liveValidation.rowCount > 0, true);
   assert.equal(candidate.evidence.coverageAssessment.state, "MISSING");
+  assert.deepEqual(candidate.evidence.coverageLimitations, [
+    "대전도시철도 1호선의 역간 소요시간·거리·요금 자료",
+  ]);
   assert.equal(candidate.evidence.historicalSources[0].reasonCode, "SUPERSEDED_FOR_LIVE_PROBE");
   assert.equal(candidate.evidence.historicalSources[0].runtimeEligible, false);
   assert.equal(candidate.nextAction,
@@ -150,6 +155,7 @@ test("대전 coverage probe는 provider/schema 오류를 fail closed한다", asy
       }),
     }), (error) => {
       assert.match(error.message, /schema mismatch: content-type text\/plain/);
+      assert.equal(error.message.match(/text\/plain/g)?.length, 1);
       assert.match(error.message, /observedAt=2026-07-14T10:43:00.000Z/);
       assert.match(error.message, /rawBytes=\d+; rawSha256=[a-f0-9]{64}/);
       assert.doesNotMatch(error.message, new RegExp(secret));

--- a/tools/datapack/source-candidates.json
+++ b/tools/datapack/source-candidates.json
@@ -3277,15 +3277,16 @@
         "operatorIds": ["daejeon-transportation"],
         "lineIds": ["line-7051a9c2525c"]
       },
-      "displayName": "대전교통공사_대전도시철도 1호선 역간 소요시간·거리·요금",
-      "detailUrl": "https://www.data.go.kr/data/15082979/fileData.do",
-      "requestUrl": "https://api.odcloud.kr/api/15082979/v1/uddi:bdfe4740-2e2b-4663-94af-b86de0e6e9de",
+      "displayName": "대전교통공사_역간 소요시간/거리/요금 조회 서비스",
+      "detailUrl": "https://www.data.go.kr/data/15158794/openapi.do",
+      "requestUrl": "https://apis.data.go.kr/B554695/TimeDistSVC/getTimeDist01",
       "operation": {
         "method": "GET",
-        "endpoint": "https://api.odcloud.kr/api/15082979/v1/uddi:bdfe4740-2e2b-4663-94af-b86de0e6e9de",
+        "endpoint": "https://apis.data.go.kr/B554695/TimeDistSVC/getTimeDist01",
         "auth": { "env": "DATA_GO_KR_SERVICE_KEY", "placement": "query", "parameter": "serviceKey" },
-        "requiredParameters": ["serviceKey", "page", "perPage", "returnType"],
-        "responseEnvelope": "{currentCount,data[],matchCount,page,perPage,totalCount}",
+        "requiredParameters": ["serviceKey", "strstnno", "endstnno"],
+        "responseEnvelope": "response.header + response.body.items.item",
+        "responseFields": ["distfloat", "fee", "min", "sec"],
         "runner": {
           "command": "node tools/datapack/probe-daejeon-coverage-api.mjs",
           "requiredEnv": ["DATA_GO_KR_SERVICE_KEY", "DAEJEON_API_PROBE_SOURCE_ID", "DAEJEON_API_PROBE_OUTPUT"]
@@ -3293,23 +3294,49 @@
         "secretPolicy": "env-only-redacted-output"
       },
       "licenseEvidenceStatus": "confirmed_free_use",
-      "sampleEvidenceStatus": "application_complete_activation_pending",
-      "admissionStatus": "provider_activation_required_before_schema_admission",
+      "sampleEvidenceStatus": "validated_live_sample",
+      "admissionStatus": "validated_live_schema_admitted",
       "serviceKeyHandling": "offline_probe_secret_only",
       "mobileEmbeddingAllowed": false,
       "evidence": {
         "retrievedAt": "2026-07-14",
-        "endpoint": "https://api.odcloud.kr/api/15082979/v1/uddi:bdfe4740-2e2b-4663-94af-b86de0e6e9de",
+        "endpoint": "https://apis.data.go.kr/B554695/TimeDistSVC/getTimeDist01",
         "usePermissionRange": "이용허락범위 제한 없음",
-        "formats": ["JSON", "XML"],
-        "outputFields": [],
-        "liveValidation": { "attempts": 2, "httpStatus": 401, "admitted": false },
+        "formats": ["XML"],
+        "outputFields": ["distfloat", "fee", "min", "sec"],
+        "liveValidation": {
+          "observedAt": "2026-07-14T11:02:59.086Z",
+          "httpStatus": 200,
+          "providerResultCode": "00",
+          "schemaStatus": "EXPECTED",
+          "rowCount": 1,
+          "outputFields": ["distfloat", "fee", "min", "sec"],
+          "rawBytes": 251,
+          "rawSha256": "2c1fbf407fe70b53b4f1ea9db174b65a245e80e65746078dd0d368bb518cfcb7",
+          "evidenceArtifact": "tools/datapack/sources/daejeon-station-distance-fare-20260714.json",
+          "admitted": true
+        },
+        "coverageAssessment": {
+          "state": "MISSING",
+          "reasonCode": "LIVE_SCHEMA_ADMITTED_FULL_OD_MAPPING_NOT_IMPLEMENTED"
+        },
+        "historicalSources": [
+          {
+            "detailUrl": "https://www.data.go.kr/data/15082979/fileData.do",
+            "endpoint": "https://api.odcloud.kr/api/15082979/v1/uddi:bdfe4740-2e2b-4663-94af-b86de0e6e9de",
+            "observedAt": "2026-07-14",
+            "attempts": 2,
+            "httpStatus": 401,
+            "reasonCode": "SUPERSEDED_FOR_LIVE_PROBE",
+            "runtimeEligible": false
+          }
+        ],
         "coverageLimitations": [
           "대전도시철도 1호선의 역간 소요시간·거리·요금 자료",
           "2026-07-14 credential-safe probe와 bounded retry가 모두 HTTP 401로 종료됨"
         ]
       },
-      "nextAction": "활용신청 전파 후 tracked probe로 실제 row field와 hash를 확보한 뒤 topology source admission을 진행한다"
+      "nextAction": "전체 OD와 canonical station mapping을 별도 이슈에서 검증한 뒤 topology materialization을 판정한다."
     },
     {
       "id": "daejeon-braille-guide-map",

--- a/tools/datapack/source-candidates.json
+++ b/tools/datapack/source-candidates.json
@@ -3332,8 +3332,7 @@
           }
         ],
         "coverageLimitations": [
-          "대전도시철도 1호선의 역간 소요시간·거리·요금 자료",
-          "2026-07-14 credential-safe probe와 bounded retry가 모두 HTTP 401로 종료됨"
+          "대전도시철도 1호선의 역간 소요시간·거리·요금 자료"
         ]
       },
       "nextAction": "전체 OD와 canonical station mapping을 별도 이슈에서 검증한 뒤 topology materialization을 판정한다."

--- a/tools/datapack/sources/daejeon-station-distance-fare-20260714.json
+++ b/tools/datapack/sources/daejeon-station-distance-fare-20260714.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "daejeon-coverage-api-probe-evidence",
+  "sourceId": "daejeon-station-distance-fare",
+  "observedAt": "2026-07-14T11:02:59.086Z",
+  "endpoint": "https://apis.data.go.kr/B554695/TimeDistSVC/getTimeDist01",
+  "httpStatus": 200,
+  "providerResultCode": "00",
+  "schemaStatus": "EXPECTED",
+  "rowCount": 1,
+  "outputFields": [
+    "distfloat",
+    "fee",
+    "min",
+    "sec"
+  ],
+  "rawBytes": 251,
+  "rawSha256": "2c1fbf407fe70b53b4f1ea9db174b65a245e80e65746078dd0d368bb518cfcb7",
+  "credentialRedacted": true
+}


### PR DESCRIPTION
## 관련 이슈

Closes #2118

## 작업 배경

- 대전 역간 소요시간·거리·요금 후보가 재현 가능한 공식 operation 대신 구형 odcloud endpoint를 가리키고 있어, 공공데이터포털의 공식 XML API 계약과 credential-safe live evidence로 갱신합니다.

## 작업 내용

- 공식 `TimeDistSVC/getTimeDist01` endpoint와 `serviceKey`, `strstnno`, `endstnno` 요청 계약을 API catalog에 반영했습니다.
- `distfloat`, `fee`, `min`, `sec` XML row와 provider `resultCode=00`, content-type, 수치 범위를 fail closed로 검증합니다.
- HTTP 200·1 row의 sanitized live evidence를 추가하고 raw body와 credential은 저장하지 않았습니다.
- 구형 odcloud source는 historical evidence로만 남기고 runtime 대상에서 제외했습니다.
- 전체 OD와 canonical station mapping은 구현하지 않아 `route_graph_topology`는 `MISSING`을 유지합니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/datapack/probe-daejeon-coverage-api.test.mjs tools/ci/api-catalog.test.mjs`: 42 pass / 0 fail
  - `node --test tools/ci/repository-contract.test.mjs`: 194 pass / 0 fail
  - `node tools/ci/api-catalog.mjs validate`: 234 entries, provider 41
  - `node --check tools/datapack/probe-daejeon-coverage-api.mjs`: PASS
  - `git diff --check origin/main...HEAD`: PASS
  - 전체 datapack test 파일 개별 실행: 모든 파일 PASS
  - 기본 sandbox 통합 실행의 localhost listener 6건은 `EPERM`으로 제한됐고, 동일 6건을 권한 환경에서 재실행해 6 pass / 0 fail

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 공식 API operation | Node.js | API catalog show/validate | `provider:daejeon-station-distance-fare` | PASS |
| XML live schema | 공공데이터포털 | tracked probe | HTTP 200, `resultCode=00`, 1 row, `distfloat/fee/min/sec` | PASS |
| credential/raw body 제거 | Node.js | evidence contract test | hash·bytes·observedAt만 저장, raw/body/rows 없음 | PASS |
| UI·접근성 | 해당 없음 | production diff 확인 | UI 파일 변경 없음 | 영향 없음 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: `route_graph_topology` MISSING 유지
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: XML row별 필수 field·수치 검증, content-type fail-closed, API catalog의 공식 operation 및 sanitized evidence 계약

## 리스크

- live evidence는 단일 OD schema 검증이며 전체 OD coverage 또는 canonical station mapping을 보장하지 않습니다. 이 범위는 명시적으로 `MISSING` 상태로 유지합니다.
- provider credential, raw response body, fallback, placeholder data, production datapack 변경은 포함하지 않습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다. (해당 없음: CodeRabbit Review 객체 존재)
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 대전 지하철 역간 거리·요금·소요 시간 데이터를 공식 API 기반으로 갱신했습니다.
  - 거리, 요금, 분, 초 정보를 일관된 형식으로 제공하도록 검증을 강화했습니다.
  - 응답 오류나 형식 불일치 발생 시 관측 시각, 응답 크기, 식별 정보를 포함한 진단 정보를 기록합니다.
  - 최신 API 응답에 대한 원본 증거와 검증 결과를 추가해 데이터 신뢰성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->