### PR TITLE
[Feat] ITX-청춘 수도권 광역검색 전용 범위 고정

### DIFF
--- a/apps/mobile/lib/core/database/catalog/catalog_database.dart
+++ b/apps/mobile/lib/core/database/catalog/catalog_database.dart
@@ -7,7 +7,7 @@ import 'catalog_tables.dart';
 
 part 'catalog_database.g.dart';
 
-const catalogDatabaseSchemaVersion = 17;
+const catalogDatabaseSchemaVersion = 18;
 
 /// 수도권 통합요금 기본거리(10km) 초과분 요금 단계(#1911).
 ///
@@ -45,6 +45,7 @@ const capitalIntegratedAdditionalStepsJson =
     FareDiscounts,
     StationFareZones,
     OfficialOdFareQuotes,
+    RouteServiceArtifactEvidence,
     RealtimeProviderLineMappings,
     RealtimeProviderStationMappings,
     NetworkEdges,
@@ -154,6 +155,19 @@ class CatalogDatabase extends _$CatalogDatabase {
         }
         if (from < 17) {
           await migrator.createTable(officialOdFareQuotes);
+        }
+        if (from < 18) {
+          await _addColumnIfTableExists(
+            'transit_trips',
+            'service_class',
+            "TEXT NOT NULL DEFAULT 'SUBWAY'",
+          );
+          await _addColumnIfTableExists(
+            'network_edges',
+            'service_class',
+            "TEXT NOT NULL DEFAULT 'SUBWAY'",
+          );
+          await migrator.createTable(routeServiceArtifactEvidence);
         }
       },
       beforeOpen: (_) async {
@@ -1330,6 +1344,21 @@ class CatalogDatabase extends _$CatalogDatabase {
     await customStatement(
       'ALTER TABLE $tableName ADD COLUMN $columnName $definition',
     );
+  }
+
+  Future<void> _addColumnIfTableExists(
+    String tableName,
+    String columnName,
+    String definition,
+  ) async {
+    final table = await customSelect(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?",
+      variables: [Variable<String>(tableName)],
+    ).getSingleOrNull();
+    if (table == null) {
+      return;
+    }
+    await _addColumnIfMissing(tableName, columnName, definition);
   }
 }
 

--- a/apps/mobile/lib/core/database/catalog/catalog_database.g.dart
+++ b/apps/mobile/lib/core/database/catalog/catalog_database.g.dart
@@ -3627,6 +3627,18 @@ class $TransitTripsTable extends TransitTrips
     requiredDuringInsert: false,
     defaultValue: const Constant('LOCAL'),
   );
+  static const VerificationMeta _serviceClassMeta = const VerificationMeta(
+    'serviceClass',
+  );
+  @override
+  late final GeneratedColumn<String> serviceClass = GeneratedColumn<String>(
+    'service_class',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    defaultValue: const Constant('SUBWAY'),
+  );
   static const VerificationMeta _serviceDayStartSecondsMeta =
       const VerificationMeta('serviceDayStartSeconds');
   @override
@@ -3646,6 +3658,7 @@ class $TransitTripsTable extends TransitTrips
     tripHeadsign,
     directionId,
     servicePattern,
+    serviceClass,
     serviceDayStartSeconds,
   ];
   @override
@@ -3708,6 +3721,15 @@ class $TransitTripsTable extends TransitTrips
         ),
       );
     }
+    if (data.containsKey('service_class')) {
+      context.handle(
+        _serviceClassMeta,
+        serviceClass.isAcceptableOrUnknown(
+          data['service_class']!,
+          _serviceClassMeta,
+        ),
+      );
+    }
     if (data.containsKey('service_day_start_seconds')) {
       context.handle(
         _serviceDayStartSecondsMeta,
@@ -3750,6 +3772,10 @@ class $TransitTripsTable extends TransitTrips
         DriftSqlType.string,
         data['${effectivePrefix}service_pattern'],
       )!,
+      serviceClass: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}service_class'],
+      )!,
       serviceDayStartSeconds: attachedDatabase.typeMapping.read(
         DriftSqlType.int,
         data['${effectivePrefix}service_day_start_seconds'],
@@ -3770,6 +3796,7 @@ class TransitTrip extends DataClass implements Insertable<TransitTrip> {
   final String tripHeadsign;
   final String directionId;
   final String servicePattern;
+  final String serviceClass;
   final int serviceDayStartSeconds;
   const TransitTrip({
     required this.id,
@@ -3778,6 +3805,7 @@ class TransitTrip extends DataClass implements Insertable<TransitTrip> {
     required this.tripHeadsign,
     required this.directionId,
     required this.servicePattern,
+    required this.serviceClass,
     required this.serviceDayStartSeconds,
   });
   @override
@@ -3789,6 +3817,7 @@ class TransitTrip extends DataClass implements Insertable<TransitTrip> {
     map['trip_headsign'] = Variable<String>(tripHeadsign);
     map['direction_id'] = Variable<String>(directionId);
     map['service_pattern'] = Variable<String>(servicePattern);
+    map['service_class'] = Variable<String>(serviceClass);
     map['service_day_start_seconds'] = Variable<int>(serviceDayStartSeconds);
     return map;
   }
@@ -3801,6 +3830,7 @@ class TransitTrip extends DataClass implements Insertable<TransitTrip> {
       tripHeadsign: Value(tripHeadsign),
       directionId: Value(directionId),
       servicePattern: Value(servicePattern),
+      serviceClass: Value(serviceClass),
       serviceDayStartSeconds: Value(serviceDayStartSeconds),
     );
   }
@@ -3817,6 +3847,7 @@ class TransitTrip extends DataClass implements Insertable<TransitTrip> {
       tripHeadsign: serializer.fromJson<String>(json['tripHeadsign']),
       directionId: serializer.fromJson<String>(json['directionId']),
       servicePattern: serializer.fromJson<String>(json['servicePattern']),
+      serviceClass: serializer.fromJson<String>(json['serviceClass']),
       serviceDayStartSeconds: serializer.fromJson<int>(
         json['serviceDayStartSeconds'],
       ),
@@ -3832,6 +3863,7 @@ class TransitTrip extends DataClass implements Insertable<TransitTrip> {
       'tripHeadsign': serializer.toJson<String>(tripHeadsign),
       'directionId': serializer.toJson<String>(directionId),
       'servicePattern': serializer.toJson<String>(servicePattern),
+      'serviceClass': serializer.toJson<String>(serviceClass),
       'serviceDayStartSeconds': serializer.toJson<int>(serviceDayStartSeconds),
     };
   }
@@ -3843,6 +3875,7 @@ class TransitTrip extends DataClass implements Insertable<TransitTrip> {
     String? tripHeadsign,
     String? directionId,
     String? servicePattern,
+    String? serviceClass,
     int? serviceDayStartSeconds,
   }) => TransitTrip(
     id: id ?? this.id,
@@ -3851,6 +3884,7 @@ class TransitTrip extends DataClass implements Insertable<TransitTrip> {
     tripHeadsign: tripHeadsign ?? this.tripHeadsign,
     directionId: directionId ?? this.directionId,
     servicePattern: servicePattern ?? this.servicePattern,
+    serviceClass: serviceClass ?? this.serviceClass,
     serviceDayStartSeconds:
         serviceDayStartSeconds ?? this.serviceDayStartSeconds,
   );
@@ -3868,6 +3902,9 @@ class TransitTrip extends DataClass implements Insertable<TransitTrip> {
       servicePattern: data.servicePattern.present
           ? data.servicePattern.value
           : this.servicePattern,
+      serviceClass: data.serviceClass.present
+          ? data.serviceClass.value
+          : this.serviceClass,
       serviceDayStartSeconds: data.serviceDayStartSeconds.present
           ? data.serviceDayStartSeconds.value
           : this.serviceDayStartSeconds,
@@ -3883,6 +3920,7 @@ class TransitTrip extends DataClass implements Insertable<TransitTrip> {
           ..write('tripHeadsign: $tripHeadsign, ')
           ..write('directionId: $directionId, ')
           ..write('servicePattern: $servicePattern, ')
+          ..write('serviceClass: $serviceClass, ')
           ..write('serviceDayStartSeconds: $serviceDayStartSeconds')
           ..write(')'))
         .toString();
@@ -3896,6 +3934,7 @@ class TransitTrip extends DataClass implements Insertable<TransitTrip> {
     tripHeadsign,
     directionId,
     servicePattern,
+    serviceClass,
     serviceDayStartSeconds,
   );
   @override
@@ -3908,6 +3947,7 @@ class TransitTrip extends DataClass implements Insertable<TransitTrip> {
           other.tripHeadsign == this.tripHeadsign &&
           other.directionId == this.directionId &&
           other.servicePattern == this.servicePattern &&
+          other.serviceClass == this.serviceClass &&
           other.serviceDayStartSeconds == this.serviceDayStartSeconds);
 }
 
@@ -3918,6 +3958,7 @@ class TransitTripsCompanion extends UpdateCompanion<TransitTrip> {
   final Value<String> tripHeadsign;
   final Value<String> directionId;
   final Value<String> servicePattern;
+  final Value<String> serviceClass;
   final Value<int> serviceDayStartSeconds;
   final Value<int> rowid;
   const TransitTripsCompanion({
@@ -3927,6 +3968,7 @@ class TransitTripsCompanion extends UpdateCompanion<TransitTrip> {
     this.tripHeadsign = const Value.absent(),
     this.directionId = const Value.absent(),
     this.servicePattern = const Value.absent(),
+    this.serviceClass = const Value.absent(),
     this.serviceDayStartSeconds = const Value.absent(),
     this.rowid = const Value.absent(),
   });
@@ -3937,6 +3979,7 @@ class TransitTripsCompanion extends UpdateCompanion<TransitTrip> {
     this.tripHeadsign = const Value.absent(),
     this.directionId = const Value.absent(),
     this.servicePattern = const Value.absent(),
+    this.serviceClass = const Value.absent(),
     this.serviceDayStartSeconds = const Value.absent(),
     this.rowid = const Value.absent(),
   }) : id = Value(id),
@@ -3949,6 +3992,7 @@ class TransitTripsCompanion extends UpdateCompanion<TransitTrip> {
     Expression<String>? tripHeadsign,
     Expression<String>? directionId,
     Expression<String>? servicePattern,
+    Expression<String>? serviceClass,
     Expression<int>? serviceDayStartSeconds,
     Expression<int>? rowid,
   }) {
@@ -3959,6 +4003,7 @@ class TransitTripsCompanion extends UpdateCompanion<TransitTrip> {
       if (tripHeadsign != null) 'trip_headsign': tripHeadsign,
       if (directionId != null) 'direction_id': directionId,
       if (servicePattern != null) 'service_pattern': servicePattern,
+      if (serviceClass != null) 'service_class': serviceClass,
       if (serviceDayStartSeconds != null)
         'service_day_start_seconds': serviceDayStartSeconds,
       if (rowid != null) 'rowid': rowid,
@@ -3972,6 +4017,7 @@ class TransitTripsCompanion extends UpdateCompanion<TransitTrip> {
     Value<String>? tripHeadsign,
     Value<String>? directionId,
     Value<String>? servicePattern,
+    Value<String>? serviceClass,
     Value<int>? serviceDayStartSeconds,
     Value<int>? rowid,
   }) {
@@ -3982,6 +4028,7 @@ class TransitTripsCompanion extends UpdateCompanion<TransitTrip> {
       tripHeadsign: tripHeadsign ?? this.tripHeadsign,
       directionId: directionId ?? this.directionId,
       servicePattern: servicePattern ?? this.servicePattern,
+      serviceClass: serviceClass ?? this.serviceClass,
       serviceDayStartSeconds:
           serviceDayStartSeconds ?? this.serviceDayStartSeconds,
       rowid: rowid ?? this.rowid,
@@ -4009,6 +4056,9 @@ class TransitTripsCompanion extends UpdateCompanion<TransitTrip> {
     if (servicePattern.present) {
       map['service_pattern'] = Variable<String>(servicePattern.value);
     }
+    if (serviceClass.present) {
+      map['service_class'] = Variable<String>(serviceClass.value);
+    }
     if (serviceDayStartSeconds.present) {
       map['service_day_start_seconds'] = Variable<int>(
         serviceDayStartSeconds.value,
@@ -4029,6 +4079,7 @@ class TransitTripsCompanion extends UpdateCompanion<TransitTrip> {
           ..write('tripHeadsign: $tripHeadsign, ')
           ..write('directionId: $directionId, ')
           ..write('servicePattern: $servicePattern, ')
+          ..write('serviceClass: $serviceClass, ')
           ..write('serviceDayStartSeconds: $serviceDayStartSeconds, ')
           ..write('rowid: $rowid')
           ..write(')'))
@@ -7205,6 +7256,713 @@ class OfficialOdFareQuotesCompanion
   }
 }
 
+class $RouteServiceArtifactEvidenceTable extends RouteServiceArtifactEvidence
+    with
+        TableInfo<
+          $RouteServiceArtifactEvidenceTable,
+          RouteServiceArtifactEvidenceData
+        > {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $RouteServiceArtifactEvidenceTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _serviceClassMeta = const VerificationMeta(
+    'serviceClass',
+  );
+  @override
+  late final GeneratedColumn<String> serviceClass = GeneratedColumn<String>(
+    'service_class',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _timetableArtifactIdMeta =
+      const VerificationMeta('timetableArtifactId');
+  @override
+  late final GeneratedColumn<String> timetableArtifactId =
+      GeneratedColumn<String>(
+        'timetable_artifact_id',
+        aliasedName,
+        false,
+        type: DriftSqlType.string,
+        requiredDuringInsert: true,
+      );
+  static const VerificationMeta _timetableArtifactSha256Meta =
+      const VerificationMeta('timetableArtifactSha256');
+  @override
+  late final GeneratedColumn<String> timetableArtifactSha256 =
+      GeneratedColumn<String>(
+        'timetable_artifact_sha256',
+        aliasedName,
+        false,
+        type: DriftSqlType.string,
+        requiredDuringInsert: true,
+      );
+  static const VerificationMeta _canonicalPackIdMeta = const VerificationMeta(
+    'canonicalPackId',
+  );
+  @override
+  late final GeneratedColumn<String> canonicalPackId = GeneratedColumn<String>(
+    'canonical_pack_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _canonicalPackSha256Meta =
+      const VerificationMeta('canonicalPackSha256');
+  @override
+  late final GeneratedColumn<String> canonicalPackSha256 =
+      GeneratedColumn<String>(
+        'canonical_pack_sha256',
+        aliasedName,
+        false,
+        type: DriftSqlType.string,
+        requiredDuringInsert: true,
+      );
+  static const VerificationMeta _canonicalPackSqliteSha256Meta =
+      const VerificationMeta('canonicalPackSqliteSha256');
+  @override
+  late final GeneratedColumn<String> canonicalPackSqliteSha256 =
+      GeneratedColumn<String>(
+        'canonical_pack_sqlite_sha256',
+        aliasedName,
+        false,
+        type: DriftSqlType.string,
+        requiredDuringInsert: true,
+      );
+  static const VerificationMeta _admissionStatusMeta = const VerificationMeta(
+    'admissionStatus',
+  );
+  @override
+  late final GeneratedColumn<String> admissionStatus = GeneratedColumn<String>(
+    'admission_status',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _admissionEligibleMeta = const VerificationMeta(
+    'admissionEligible',
+  );
+  @override
+  late final GeneratedColumn<bool> admissionEligible = GeneratedColumn<bool>(
+    'admission_eligible',
+    aliasedName,
+    false,
+    type: DriftSqlType.bool,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'CHECK ("admission_eligible" IN (0, 1))',
+    ),
+  );
+  static const VerificationMeta _freshUntilMeta = const VerificationMeta(
+    'freshUntil',
+  );
+  @override
+  late final GeneratedColumn<String> freshUntil = GeneratedColumn<String>(
+    'fresh_until',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _sourceIssueMeta = const VerificationMeta(
+    'sourceIssue',
+  );
+  @override
+  late final GeneratedColumn<int> sourceIssue = GeneratedColumn<int>(
+    'source_issue',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    serviceClass,
+    timetableArtifactId,
+    timetableArtifactSha256,
+    canonicalPackId,
+    canonicalPackSha256,
+    canonicalPackSqliteSha256,
+    admissionStatus,
+    admissionEligible,
+    freshUntil,
+    sourceIssue,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'route_service_artifact_evidence';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<RouteServiceArtifactEvidenceData> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('service_class')) {
+      context.handle(
+        _serviceClassMeta,
+        serviceClass.isAcceptableOrUnknown(
+          data['service_class']!,
+          _serviceClassMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_serviceClassMeta);
+    }
+    if (data.containsKey('timetable_artifact_id')) {
+      context.handle(
+        _timetableArtifactIdMeta,
+        timetableArtifactId.isAcceptableOrUnknown(
+          data['timetable_artifact_id']!,
+          _timetableArtifactIdMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_timetableArtifactIdMeta);
+    }
+    if (data.containsKey('timetable_artifact_sha256')) {
+      context.handle(
+        _timetableArtifactSha256Meta,
+        timetableArtifactSha256.isAcceptableOrUnknown(
+          data['timetable_artifact_sha256']!,
+          _timetableArtifactSha256Meta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_timetableArtifactSha256Meta);
+    }
+    if (data.containsKey('canonical_pack_id')) {
+      context.handle(
+        _canonicalPackIdMeta,
+        canonicalPackId.isAcceptableOrUnknown(
+          data['canonical_pack_id']!,
+          _canonicalPackIdMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_canonicalPackIdMeta);
+    }
+    if (data.containsKey('canonical_pack_sha256')) {
+      context.handle(
+        _canonicalPackSha256Meta,
+        canonicalPackSha256.isAcceptableOrUnknown(
+          data['canonical_pack_sha256']!,
+          _canonicalPackSha256Meta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_canonicalPackSha256Meta);
+    }
+    if (data.containsKey('canonical_pack_sqlite_sha256')) {
+      context.handle(
+        _canonicalPackSqliteSha256Meta,
+        canonicalPackSqliteSha256.isAcceptableOrUnknown(
+          data['canonical_pack_sqlite_sha256']!,
+          _canonicalPackSqliteSha256Meta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_canonicalPackSqliteSha256Meta);
+    }
+    if (data.containsKey('admission_status')) {
+      context.handle(
+        _admissionStatusMeta,
+        admissionStatus.isAcceptableOrUnknown(
+          data['admission_status']!,
+          _admissionStatusMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_admissionStatusMeta);
+    }
+    if (data.containsKey('admission_eligible')) {
+      context.handle(
+        _admissionEligibleMeta,
+        admissionEligible.isAcceptableOrUnknown(
+          data['admission_eligible']!,
+          _admissionEligibleMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_admissionEligibleMeta);
+    }
+    if (data.containsKey('fresh_until')) {
+      context.handle(
+        _freshUntilMeta,
+        freshUntil.isAcceptableOrUnknown(data['fresh_until']!, _freshUntilMeta),
+      );
+    }
+    if (data.containsKey('source_issue')) {
+      context.handle(
+        _sourceIssueMeta,
+        sourceIssue.isAcceptableOrUnknown(
+          data['source_issue']!,
+          _sourceIssueMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_sourceIssueMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {serviceClass};
+  @override
+  RouteServiceArtifactEvidenceData map(
+    Map<String, dynamic> data, {
+    String? tablePrefix,
+  }) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return RouteServiceArtifactEvidenceData(
+      serviceClass: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}service_class'],
+      )!,
+      timetableArtifactId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}timetable_artifact_id'],
+      )!,
+      timetableArtifactSha256: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}timetable_artifact_sha256'],
+      )!,
+      canonicalPackId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}canonical_pack_id'],
+      )!,
+      canonicalPackSha256: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}canonical_pack_sha256'],
+      )!,
+      canonicalPackSqliteSha256: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}canonical_pack_sqlite_sha256'],
+      )!,
+      admissionStatus: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}admission_status'],
+      )!,
+      admissionEligible: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}admission_eligible'],
+      )!,
+      freshUntil: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}fresh_until'],
+      ),
+      sourceIssue: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}source_issue'],
+      )!,
+    );
+  }
+
+  @override
+  $RouteServiceArtifactEvidenceTable createAlias(String alias) {
+    return $RouteServiceArtifactEvidenceTable(attachedDatabase, alias);
+  }
+}
+
+class RouteServiceArtifactEvidenceData extends DataClass
+    implements Insertable<RouteServiceArtifactEvidenceData> {
+  final String serviceClass;
+  final String timetableArtifactId;
+  final String timetableArtifactSha256;
+  final String canonicalPackId;
+  final String canonicalPackSha256;
+  final String canonicalPackSqliteSha256;
+  final String admissionStatus;
+  final bool admissionEligible;
+  final String? freshUntil;
+  final int sourceIssue;
+  const RouteServiceArtifactEvidenceData({
+    required this.serviceClass,
+    required this.timetableArtifactId,
+    required this.timetableArtifactSha256,
+    required this.canonicalPackId,
+    required this.canonicalPackSha256,
+    required this.canonicalPackSqliteSha256,
+    required this.admissionStatus,
+    required this.admissionEligible,
+    this.freshUntil,
+    required this.sourceIssue,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['service_class'] = Variable<String>(serviceClass);
+    map['timetable_artifact_id'] = Variable<String>(timetableArtifactId);
+    map['timetable_artifact_sha256'] = Variable<String>(
+      timetableArtifactSha256,
+    );
+    map['canonical_pack_id'] = Variable<String>(canonicalPackId);
+    map['canonical_pack_sha256'] = Variable<String>(canonicalPackSha256);
+    map['canonical_pack_sqlite_sha256'] = Variable<String>(
+      canonicalPackSqliteSha256,
+    );
+    map['admission_status'] = Variable<String>(admissionStatus);
+    map['admission_eligible'] = Variable<bool>(admissionEligible);
+    if (!nullToAbsent || freshUntil != null) {
+      map['fresh_until'] = Variable<String>(freshUntil);
+    }
+    map['source_issue'] = Variable<int>(sourceIssue);
+    return map;
+  }
+
+  RouteServiceArtifactEvidenceCompanion toCompanion(bool nullToAbsent) {
+    return RouteServiceArtifactEvidenceCompanion(
+      serviceClass: Value(serviceClass),
+      timetableArtifactId: Value(timetableArtifactId),
+      timetableArtifactSha256: Value(timetableArtifactSha256),
+      canonicalPackId: Value(canonicalPackId),
+      canonicalPackSha256: Value(canonicalPackSha256),
+      canonicalPackSqliteSha256: Value(canonicalPackSqliteSha256),
+      admissionStatus: Value(admissionStatus),
+      admissionEligible: Value(admissionEligible),
+      freshUntil: freshUntil == null && nullToAbsent
+          ? const Value.absent()
+          : Value(freshUntil),
+      sourceIssue: Value(sourceIssue),
+    );
+  }
+
+  factory RouteServiceArtifactEvidenceData.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return RouteServiceArtifactEvidenceData(
+      serviceClass: serializer.fromJson<String>(json['serviceClass']),
+      timetableArtifactId: serializer.fromJson<String>(
+        json['timetableArtifactId'],
+      ),
+      timetableArtifactSha256: serializer.fromJson<String>(
+        json['timetableArtifactSha256'],
+      ),
+      canonicalPackId: serializer.fromJson<String>(json['canonicalPackId']),
+      canonicalPackSha256: serializer.fromJson<String>(
+        json['canonicalPackSha256'],
+      ),
+      canonicalPackSqliteSha256: serializer.fromJson<String>(
+        json['canonicalPackSqliteSha256'],
+      ),
+      admissionStatus: serializer.fromJson<String>(json['admissionStatus']),
+      admissionEligible: serializer.fromJson<bool>(json['admissionEligible']),
+      freshUntil: serializer.fromJson<String?>(json['freshUntil']),
+      sourceIssue: serializer.fromJson<int>(json['sourceIssue']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'serviceClass': serializer.toJson<String>(serviceClass),
+      'timetableArtifactId': serializer.toJson<String>(timetableArtifactId),
+      'timetableArtifactSha256': serializer.toJson<String>(
+        timetableArtifactSha256,
+      ),
+      'canonicalPackId': serializer.toJson<String>(canonicalPackId),
+      'canonicalPackSha256': serializer.toJson<String>(canonicalPackSha256),
+      'canonicalPackSqliteSha256': serializer.toJson<String>(
+        canonicalPackSqliteSha256,
+      ),
+      'admissionStatus': serializer.toJson<String>(admissionStatus),
+      'admissionEligible': serializer.toJson<bool>(admissionEligible),
+      'freshUntil': serializer.toJson<String?>(freshUntil),
+      'sourceIssue': serializer.toJson<int>(sourceIssue),
+    };
+  }
+
+  RouteServiceArtifactEvidenceData copyWith({
+    String? serviceClass,
+    String? timetableArtifactId,
+    String? timetableArtifactSha256,
+    String? canonicalPackId,
+    String? canonicalPackSha256,
+    String? canonicalPackSqliteSha256,
+    String? admissionStatus,
+    bool? admissionEligible,
+    Value<String?> freshUntil = const Value.absent(),
+    int? sourceIssue,
+  }) => RouteServiceArtifactEvidenceData(
+    serviceClass: serviceClass ?? this.serviceClass,
+    timetableArtifactId: timetableArtifactId ?? this.timetableArtifactId,
+    timetableArtifactSha256:
+        timetableArtifactSha256 ?? this.timetableArtifactSha256,
+    canonicalPackId: canonicalPackId ?? this.canonicalPackId,
+    canonicalPackSha256: canonicalPackSha256 ?? this.canonicalPackSha256,
+    canonicalPackSqliteSha256:
+        canonicalPackSqliteSha256 ?? this.canonicalPackSqliteSha256,
+    admissionStatus: admissionStatus ?? this.admissionStatus,
+    admissionEligible: admissionEligible ?? this.admissionEligible,
+    freshUntil: freshUntil.present ? freshUntil.value : this.freshUntil,
+    sourceIssue: sourceIssue ?? this.sourceIssue,
+  );
+  RouteServiceArtifactEvidenceData copyWithCompanion(
+    RouteServiceArtifactEvidenceCompanion data,
+  ) {
+    return RouteServiceArtifactEvidenceData(
+      serviceClass: data.serviceClass.present
+          ? data.serviceClass.value
+          : this.serviceClass,
+      timetableArtifactId: data.timetableArtifactId.present
+          ? data.timetableArtifactId.value
+          : this.timetableArtifactId,
+      timetableArtifactSha256: data.timetableArtifactSha256.present
+          ? data.timetableArtifactSha256.value
+          : this.timetableArtifactSha256,
+      canonicalPackId: data.canonicalPackId.present
+          ? data.canonicalPackId.value
+          : this.canonicalPackId,
+      canonicalPackSha256: data.canonicalPackSha256.present
+          ? data.canonicalPackSha256.value
+          : this.canonicalPackSha256,
+      canonicalPackSqliteSha256: data.canonicalPackSqliteSha256.present
+          ? data.canonicalPackSqliteSha256.value
+          : this.canonicalPackSqliteSha256,
+      admissionStatus: data.admissionStatus.present
+          ? data.admissionStatus.value
+          : this.admissionStatus,
+      admissionEligible: data.admissionEligible.present
+          ? data.admissionEligible.value
+          : this.admissionEligible,
+      freshUntil: data.freshUntil.present
+          ? data.freshUntil.value
+          : this.freshUntil,
+      sourceIssue: data.sourceIssue.present
+          ? data.sourceIssue.value
+          : this.sourceIssue,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('RouteServiceArtifactEvidenceData(')
+          ..write('serviceClass: $serviceClass, ')
+          ..write('timetableArtifactId: $timetableArtifactId, ')
+          ..write('timetableArtifactSha256: $timetableArtifactSha256, ')
+          ..write('canonicalPackId: $canonicalPackId, ')
+          ..write('canonicalPackSha256: $canonicalPackSha256, ')
+          ..write('canonicalPackSqliteSha256: $canonicalPackSqliteSha256, ')
+          ..write('admissionStatus: $admissionStatus, ')
+          ..write('admissionEligible: $admissionEligible, ')
+          ..write('freshUntil: $freshUntil, ')
+          ..write('sourceIssue: $sourceIssue')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    serviceClass,
+    timetableArtifactId,
+    timetableArtifactSha256,
+    canonicalPackId,
+    canonicalPackSha256,
+    canonicalPackSqliteSha256,
+    admissionStatus,
+    admissionEligible,
+    freshUntil,
+    sourceIssue,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is RouteServiceArtifactEvidenceData &&
+          other.serviceClass == this.serviceClass &&
+          other.timetableArtifactId == this.timetableArtifactId &&
+          other.timetableArtifactSha256 == this.timetableArtifactSha256 &&
+          other.canonicalPackId == this.canonicalPackId &&
+          other.canonicalPackSha256 == this.canonicalPackSha256 &&
+          other.canonicalPackSqliteSha256 == this.canonicalPackSqliteSha256 &&
+          other.admissionStatus == this.admissionStatus &&
+          other.admissionEligible == this.admissionEligible &&
+          other.freshUntil == this.freshUntil &&
+          other.sourceIssue == this.sourceIssue);
+}
+
+class RouteServiceArtifactEvidenceCompanion
+    extends UpdateCompanion<RouteServiceArtifactEvidenceData> {
+  final Value<String> serviceClass;
+  final Value<String> timetableArtifactId;
+  final Value<String> timetableArtifactSha256;
+  final Value<String> canonicalPackId;
+  final Value<String> canonicalPackSha256;
+  final Value<String> canonicalPackSqliteSha256;
+  final Value<String> admissionStatus;
+  final Value<bool> admissionEligible;
+  final Value<String?> freshUntil;
+  final Value<int> sourceIssue;
+  final Value<int> rowid;
+  const RouteServiceArtifactEvidenceCompanion({
+    this.serviceClass = const Value.absent(),
+    this.timetableArtifactId = const Value.absent(),
+    this.timetableArtifactSha256 = const Value.absent(),
+    this.canonicalPackId = const Value.absent(),
+    this.canonicalPackSha256 = const Value.absent(),
+    this.canonicalPackSqliteSha256 = const Value.absent(),
+    this.admissionStatus = const Value.absent(),
+    this.admissionEligible = const Value.absent(),
+    this.freshUntil = const Value.absent(),
+    this.sourceIssue = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  RouteServiceArtifactEvidenceCompanion.insert({
+    required String serviceClass,
+    required String timetableArtifactId,
+    required String timetableArtifactSha256,
+    required String canonicalPackId,
+    required String canonicalPackSha256,
+    required String canonicalPackSqliteSha256,
+    required String admissionStatus,
+    required bool admissionEligible,
+    this.freshUntil = const Value.absent(),
+    required int sourceIssue,
+    this.rowid = const Value.absent(),
+  }) : serviceClass = Value(serviceClass),
+       timetableArtifactId = Value(timetableArtifactId),
+       timetableArtifactSha256 = Value(timetableArtifactSha256),
+       canonicalPackId = Value(canonicalPackId),
+       canonicalPackSha256 = Value(canonicalPackSha256),
+       canonicalPackSqliteSha256 = Value(canonicalPackSqliteSha256),
+       admissionStatus = Value(admissionStatus),
+       admissionEligible = Value(admissionEligible),
+       sourceIssue = Value(sourceIssue);
+  static Insertable<RouteServiceArtifactEvidenceData> custom({
+    Expression<String>? serviceClass,
+    Expression<String>? timetableArtifactId,
+    Expression<String>? timetableArtifactSha256,
+    Expression<String>? canonicalPackId,
+    Expression<String>? canonicalPackSha256,
+    Expression<String>? canonicalPackSqliteSha256,
+    Expression<String>? admissionStatus,
+    Expression<bool>? admissionEligible,
+    Expression<String>? freshUntil,
+    Expression<int>? sourceIssue,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (serviceClass != null) 'service_class': serviceClass,
+      if (timetableArtifactId != null)
+        'timetable_artifact_id': timetableArtifactId,
+      if (timetableArtifactSha256 != null)
+        'timetable_artifact_sha256': timetableArtifactSha256,
+      if (canonicalPackId != null) 'canonical_pack_id': canonicalPackId,
+      if (canonicalPackSha256 != null)
+        'canonical_pack_sha256': canonicalPackSha256,
+      if (canonicalPackSqliteSha256 != null)
+        'canonical_pack_sqlite_sha256': canonicalPackSqliteSha256,
+      if (admissionStatus != null) 'admission_status': admissionStatus,
+      if (admissionEligible != null) 'admission_eligible': admissionEligible,
+      if (freshUntil != null) 'fresh_until': freshUntil,
+      if (sourceIssue != null) 'source_issue': sourceIssue,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  RouteServiceArtifactEvidenceCompanion copyWith({
+    Value<String>? serviceClass,
+    Value<String>? timetableArtifactId,
+    Value<String>? timetableArtifactSha256,
+    Value<String>? canonicalPackId,
+    Value<String>? canonicalPackSha256,
+    Value<String>? canonicalPackSqliteSha256,
+    Value<String>? admissionStatus,
+    Value<bool>? admissionEligible,
+    Value<String?>? freshUntil,
+    Value<int>? sourceIssue,
+    Value<int>? rowid,
+  }) {
+    return RouteServiceArtifactEvidenceCompanion(
+      serviceClass: serviceClass ?? this.serviceClass,
+      timetableArtifactId: timetableArtifactId ?? this.timetableArtifactId,
+      timetableArtifactSha256:
+          timetableArtifactSha256 ?? this.timetableArtifactSha256,
+      canonicalPackId: canonicalPackId ?? this.canonicalPackId,
+      canonicalPackSha256: canonicalPackSha256 ?? this.canonicalPackSha256,
+      canonicalPackSqliteSha256:
+          canonicalPackSqliteSha256 ?? this.canonicalPackSqliteSha256,
+      admissionStatus: admissionStatus ?? this.admissionStatus,
+      admissionEligible: admissionEligible ?? this.admissionEligible,
+      freshUntil: freshUntil ?? this.freshUntil,
+      sourceIssue: sourceIssue ?? this.sourceIssue,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (serviceClass.present) {
+      map['service_class'] = Variable<String>(serviceClass.value);
+    }
+    if (timetableArtifactId.present) {
+      map['timetable_artifact_id'] = Variable<String>(
+        timetableArtifactId.value,
+      );
+    }
+    if (timetableArtifactSha256.present) {
+      map['timetable_artifact_sha256'] = Variable<String>(
+        timetableArtifactSha256.value,
+      );
+    }
+    if (canonicalPackId.present) {
+      map['canonical_pack_id'] = Variable<String>(canonicalPackId.value);
+    }
+    if (canonicalPackSha256.present) {
+      map['canonical_pack_sha256'] = Variable<String>(
+        canonicalPackSha256.value,
+      );
+    }
+    if (canonicalPackSqliteSha256.present) {
+      map['canonical_pack_sqlite_sha256'] = Variable<String>(
+        canonicalPackSqliteSha256.value,
+      );
+    }
+    if (admissionStatus.present) {
+      map['admission_status'] = Variable<String>(admissionStatus.value);
+    }
+    if (admissionEligible.present) {
+      map['admission_eligible'] = Variable<bool>(admissionEligible.value);
+    }
+    if (freshUntil.present) {
+      map['fresh_until'] = Variable<String>(freshUntil.value);
+    }
+    if (sourceIssue.present) {
+      map['source_issue'] = Variable<int>(sourceIssue.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('RouteServiceArtifactEvidenceCompanion(')
+          ..write('serviceClass: $serviceClass, ')
+          ..write('timetableArtifactId: $timetableArtifactId, ')
+          ..write('timetableArtifactSha256: $timetableArtifactSha256, ')
+          ..write('canonicalPackId: $canonicalPackId, ')
+          ..write('canonicalPackSha256: $canonicalPackSha256, ')
+          ..write('canonicalPackSqliteSha256: $canonicalPackSqliteSha256, ')
+          ..write('admissionStatus: $admissionStatus, ')
+          ..write('admissionEligible: $admissionEligible, ')
+          ..write('freshUntil: $freshUntil, ')
+          ..write('sourceIssue: $sourceIssue, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
 class $RealtimeProviderLineMappingsTable extends RealtimeProviderLineMappings
     with
         TableInfo<
@@ -8566,6 +9324,18 @@ class $NetworkEdgesTable extends NetworkEdges
     requiredDuringInsert: false,
     defaultValue: const Constant(''),
   );
+  static const VerificationMeta _serviceClassMeta = const VerificationMeta(
+    'serviceClass',
+  );
+  @override
+  late final GeneratedColumn<String> serviceClass = GeneratedColumn<String>(
+    'service_class',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    defaultValue: const Constant('SUBWAY'),
+  );
   static const VerificationMeta _includesStairsMeta = const VerificationMeta(
     'includesStairs',
   );
@@ -8721,6 +9491,7 @@ class $NetworkEdgesTable extends NetworkEdges
     distanceMeters,
     edgeType,
     servicePattern,
+    serviceClass,
     includesStairs,
     stairAccessState,
     accessibilityStatus,
@@ -8800,6 +9571,15 @@ class $NetworkEdgesTable extends NetworkEdges
         servicePattern.isAcceptableOrUnknown(
           data['service_pattern']!,
           _servicePatternMeta,
+        ),
+      );
+    }
+    if (data.containsKey('service_class')) {
+      context.handle(
+        _serviceClassMeta,
+        serviceClass.isAcceptableOrUnknown(
+          data['service_class']!,
+          _serviceClassMeta,
         ),
       );
     }
@@ -8942,6 +9722,10 @@ class $NetworkEdgesTable extends NetworkEdges
         DriftSqlType.string,
         data['${effectivePrefix}service_pattern'],
       )!,
+      serviceClass: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}service_class'],
+      )!,
       includesStairs: attachedDatabase.typeMapping.read(
         DriftSqlType.bool,
         data['${effectivePrefix}includes_stairs'],
@@ -9007,6 +9791,7 @@ class NetworkEdge extends DataClass implements Insertable<NetworkEdge> {
   final int distanceMeters;
   final String edgeType;
   final String servicePattern;
+  final String serviceClass;
   final bool includesStairs;
   final String stairAccessState;
   final String accessibilityStatus;
@@ -9027,6 +9812,7 @@ class NetworkEdge extends DataClass implements Insertable<NetworkEdge> {
     required this.distanceMeters,
     required this.edgeType,
     required this.servicePattern,
+    required this.serviceClass,
     required this.includesStairs,
     required this.stairAccessState,
     required this.accessibilityStatus,
@@ -9050,6 +9836,7 @@ class NetworkEdge extends DataClass implements Insertable<NetworkEdge> {
     map['distance_meters'] = Variable<int>(distanceMeters);
     map['edge_type'] = Variable<String>(edgeType);
     map['service_pattern'] = Variable<String>(servicePattern);
+    map['service_class'] = Variable<String>(serviceClass);
     map['includes_stairs'] = Variable<bool>(includesStairs);
     map['stair_access_state'] = Variable<String>(stairAccessState);
     map['accessibility_status'] = Variable<String>(accessibilityStatus);
@@ -9078,6 +9865,7 @@ class NetworkEdge extends DataClass implements Insertable<NetworkEdge> {
       distanceMeters: Value(distanceMeters),
       edgeType: Value(edgeType),
       servicePattern: Value(servicePattern),
+      serviceClass: Value(serviceClass),
       includesStairs: Value(includesStairs),
       stairAccessState: Value(stairAccessState),
       accessibilityStatus: Value(accessibilityStatus),
@@ -9110,6 +9898,7 @@ class NetworkEdge extends DataClass implements Insertable<NetworkEdge> {
       distanceMeters: serializer.fromJson<int>(json['distanceMeters']),
       edgeType: serializer.fromJson<String>(json['edgeType']),
       servicePattern: serializer.fromJson<String>(json['servicePattern']),
+      serviceClass: serializer.fromJson<String>(json['serviceClass']),
       includesStairs: serializer.fromJson<bool>(json['includesStairs']),
       stairAccessState: serializer.fromJson<String>(json['stairAccessState']),
       accessibilityStatus: serializer.fromJson<String>(
@@ -9141,6 +9930,7 @@ class NetworkEdge extends DataClass implements Insertable<NetworkEdge> {
       'distanceMeters': serializer.toJson<int>(distanceMeters),
       'edgeType': serializer.toJson<String>(edgeType),
       'servicePattern': serializer.toJson<String>(servicePattern),
+      'serviceClass': serializer.toJson<String>(serviceClass),
       'includesStairs': serializer.toJson<bool>(includesStairs),
       'stairAccessState': serializer.toJson<String>(stairAccessState),
       'accessibilityStatus': serializer.toJson<String>(accessibilityStatus),
@@ -9164,6 +9954,7 @@ class NetworkEdge extends DataClass implements Insertable<NetworkEdge> {
     int? distanceMeters,
     String? edgeType,
     String? servicePattern,
+    String? serviceClass,
     bool? includesStairs,
     String? stairAccessState,
     String? accessibilityStatus,
@@ -9184,6 +9975,7 @@ class NetworkEdge extends DataClass implements Insertable<NetworkEdge> {
     distanceMeters: distanceMeters ?? this.distanceMeters,
     edgeType: edgeType ?? this.edgeType,
     servicePattern: servicePattern ?? this.servicePattern,
+    serviceClass: serviceClass ?? this.serviceClass,
     includesStairs: includesStairs ?? this.includesStairs,
     stairAccessState: stairAccessState ?? this.stairAccessState,
     accessibilityStatus: accessibilityStatus ?? this.accessibilityStatus,
@@ -9216,6 +10008,9 @@ class NetworkEdge extends DataClass implements Insertable<NetworkEdge> {
       servicePattern: data.servicePattern.present
           ? data.servicePattern.value
           : this.servicePattern,
+      serviceClass: data.serviceClass.present
+          ? data.serviceClass.value
+          : this.serviceClass,
       includesStairs: data.includesStairs.present
           ? data.includesStairs.value
           : this.includesStairs,
@@ -9263,6 +10058,7 @@ class NetworkEdge extends DataClass implements Insertable<NetworkEdge> {
           ..write('distanceMeters: $distanceMeters, ')
           ..write('edgeType: $edgeType, ')
           ..write('servicePattern: $servicePattern, ')
+          ..write('serviceClass: $serviceClass, ')
           ..write('includesStairs: $includesStairs, ')
           ..write('stairAccessState: $stairAccessState, ')
           ..write('accessibilityStatus: $accessibilityStatus, ')
@@ -9288,6 +10084,7 @@ class NetworkEdge extends DataClass implements Insertable<NetworkEdge> {
     distanceMeters,
     edgeType,
     servicePattern,
+    serviceClass,
     includesStairs,
     stairAccessState,
     accessibilityStatus,
@@ -9312,6 +10109,7 @@ class NetworkEdge extends DataClass implements Insertable<NetworkEdge> {
           other.distanceMeters == this.distanceMeters &&
           other.edgeType == this.edgeType &&
           other.servicePattern == this.servicePattern &&
+          other.serviceClass == this.serviceClass &&
           other.includesStairs == this.includesStairs &&
           other.stairAccessState == this.stairAccessState &&
           other.accessibilityStatus == this.accessibilityStatus &&
@@ -9334,6 +10132,7 @@ class NetworkEdgesCompanion extends UpdateCompanion<NetworkEdge> {
   final Value<int> distanceMeters;
   final Value<String> edgeType;
   final Value<String> servicePattern;
+  final Value<String> serviceClass;
   final Value<bool> includesStairs;
   final Value<String> stairAccessState;
   final Value<String> accessibilityStatus;
@@ -9355,6 +10154,7 @@ class NetworkEdgesCompanion extends UpdateCompanion<NetworkEdge> {
     this.distanceMeters = const Value.absent(),
     this.edgeType = const Value.absent(),
     this.servicePattern = const Value.absent(),
+    this.serviceClass = const Value.absent(),
     this.includesStairs = const Value.absent(),
     this.stairAccessState = const Value.absent(),
     this.accessibilityStatus = const Value.absent(),
@@ -9377,6 +10177,7 @@ class NetworkEdgesCompanion extends UpdateCompanion<NetworkEdge> {
     this.distanceMeters = const Value.absent(),
     this.edgeType = const Value.absent(),
     this.servicePattern = const Value.absent(),
+    this.serviceClass = const Value.absent(),
     this.includesStairs = const Value.absent(),
     this.stairAccessState = const Value.absent(),
     this.accessibilityStatus = const Value.absent(),
@@ -9401,6 +10202,7 @@ class NetworkEdgesCompanion extends UpdateCompanion<NetworkEdge> {
     Expression<int>? distanceMeters,
     Expression<String>? edgeType,
     Expression<String>? servicePattern,
+    Expression<String>? serviceClass,
     Expression<bool>? includesStairs,
     Expression<String>? stairAccessState,
     Expression<String>? accessibilityStatus,
@@ -9423,6 +10225,7 @@ class NetworkEdgesCompanion extends UpdateCompanion<NetworkEdge> {
       if (distanceMeters != null) 'distance_meters': distanceMeters,
       if (edgeType != null) 'edge_type': edgeType,
       if (servicePattern != null) 'service_pattern': servicePattern,
+      if (serviceClass != null) 'service_class': serviceClass,
       if (includesStairs != null) 'includes_stairs': includesStairs,
       if (stairAccessState != null) 'stair_access_state': stairAccessState,
       if (accessibilityStatus != null)
@@ -9449,6 +10252,7 @@ class NetworkEdgesCompanion extends UpdateCompanion<NetworkEdge> {
     Value<int>? distanceMeters,
     Value<String>? edgeType,
     Value<String>? servicePattern,
+    Value<String>? serviceClass,
     Value<bool>? includesStairs,
     Value<String>? stairAccessState,
     Value<String>? accessibilityStatus,
@@ -9471,6 +10275,7 @@ class NetworkEdgesCompanion extends UpdateCompanion<NetworkEdge> {
       distanceMeters: distanceMeters ?? this.distanceMeters,
       edgeType: edgeType ?? this.edgeType,
       servicePattern: servicePattern ?? this.servicePattern,
+      serviceClass: serviceClass ?? this.serviceClass,
       includesStairs: includesStairs ?? this.includesStairs,
       stairAccessState: stairAccessState ?? this.stairAccessState,
       accessibilityStatus: accessibilityStatus ?? this.accessibilityStatus,
@@ -9510,6 +10315,9 @@ class NetworkEdgesCompanion extends UpdateCompanion<NetworkEdge> {
     }
     if (servicePattern.present) {
       map['service_pattern'] = Variable<String>(servicePattern.value);
+    }
+    if (serviceClass.present) {
+      map['service_class'] = Variable<String>(serviceClass.value);
     }
     if (includesStairs.present) {
       map['includes_stairs'] = Variable<bool>(includesStairs.value);
@@ -9563,6 +10371,7 @@ class NetworkEdgesCompanion extends UpdateCompanion<NetworkEdge> {
           ..write('distanceMeters: $distanceMeters, ')
           ..write('edgeType: $edgeType, ')
           ..write('servicePattern: $servicePattern, ')
+          ..write('serviceClass: $serviceClass, ')
           ..write('includesStairs: $includesStairs, ')
           ..write('stairAccessState: $stairAccessState, ')
           ..write('accessibilityStatus: $accessibilityStatus, ')
@@ -19098,6 +19907,8 @@ abstract class _$CatalogDatabase extends GeneratedDatabase {
   );
   late final $OfficialOdFareQuotesTable officialOdFareQuotes =
       $OfficialOdFareQuotesTable(this);
+  late final $RouteServiceArtifactEvidenceTable routeServiceArtifactEvidence =
+      $RouteServiceArtifactEvidenceTable(this);
   late final $RealtimeProviderLineMappingsTable realtimeProviderLineMappings =
       $RealtimeProviderLineMappingsTable(this);
   late final $RealtimeProviderStationMappingsTable
@@ -19146,6 +19957,7 @@ abstract class _$CatalogDatabase extends GeneratedDatabase {
     fareDiscounts,
     stationFareZones,
     officialOdFareQuotes,
+    routeServiceArtifactEvidence,
     realtimeProviderLineMappings,
     realtimeProviderStationMappings,
     networkEdges,
@@ -21128,6 +21940,7 @@ typedef $$TransitTripsTableCreateCompanionBuilder =
       Value<String> tripHeadsign,
       Value<String> directionId,
       Value<String> servicePattern,
+      Value<String> serviceClass,
       Value<int> serviceDayStartSeconds,
       Value<int> rowid,
     });
@@ -21139,6 +21952,7 @@ typedef $$TransitTripsTableUpdateCompanionBuilder =
       Value<String> tripHeadsign,
       Value<String> directionId,
       Value<String> servicePattern,
+      Value<String> serviceClass,
       Value<int> serviceDayStartSeconds,
       Value<int> rowid,
     });
@@ -21179,6 +21993,11 @@ class $$TransitTripsTableFilterComposer
 
   ColumnFilters<String> get servicePattern => $composableBuilder(
     column: $table.servicePattern,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get serviceClass => $composableBuilder(
+    column: $table.serviceClass,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -21227,6 +22046,11 @@ class $$TransitTripsTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get serviceClass => $composableBuilder(
+    column: $table.serviceClass,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<int> get serviceDayStartSeconds => $composableBuilder(
     column: $table.serviceDayStartSeconds,
     builder: (column) => ColumnOrderings(column),
@@ -21263,6 +22087,11 @@ class $$TransitTripsTableAnnotationComposer
 
   GeneratedColumn<String> get servicePattern => $composableBuilder(
     column: $table.servicePattern,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get serviceClass => $composableBuilder(
+    column: $table.serviceClass,
     builder: (column) => column,
   );
 
@@ -21311,6 +22140,7 @@ class $$TransitTripsTableTableManager
                 Value<String> tripHeadsign = const Value.absent(),
                 Value<String> directionId = const Value.absent(),
                 Value<String> servicePattern = const Value.absent(),
+                Value<String> serviceClass = const Value.absent(),
                 Value<int> serviceDayStartSeconds = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => TransitTripsCompanion(
@@ -21320,6 +22150,7 @@ class $$TransitTripsTableTableManager
                 tripHeadsign: tripHeadsign,
                 directionId: directionId,
                 servicePattern: servicePattern,
+                serviceClass: serviceClass,
                 serviceDayStartSeconds: serviceDayStartSeconds,
                 rowid: rowid,
               ),
@@ -21331,6 +22162,7 @@ class $$TransitTripsTableTableManager
                 Value<String> tripHeadsign = const Value.absent(),
                 Value<String> directionId = const Value.absent(),
                 Value<String> servicePattern = const Value.absent(),
+                Value<String> serviceClass = const Value.absent(),
                 Value<int> serviceDayStartSeconds = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => TransitTripsCompanion.insert(
@@ -21340,6 +22172,7 @@ class $$TransitTripsTableTableManager
                 tripHeadsign: tripHeadsign,
                 directionId: directionId,
                 servicePattern: servicePattern,
+                serviceClass: serviceClass,
                 serviceDayStartSeconds: serviceDayStartSeconds,
                 rowid: rowid,
               ),
@@ -23057,6 +23890,340 @@ typedef $$OfficialOdFareQuotesTableProcessedTableManager =
       OfficialOdFareQuoteRow,
       PrefetchHooks Function()
     >;
+typedef $$RouteServiceArtifactEvidenceTableCreateCompanionBuilder =
+    RouteServiceArtifactEvidenceCompanion Function({
+      required String serviceClass,
+      required String timetableArtifactId,
+      required String timetableArtifactSha256,
+      required String canonicalPackId,
+      required String canonicalPackSha256,
+      required String canonicalPackSqliteSha256,
+      required String admissionStatus,
+      required bool admissionEligible,
+      Value<String?> freshUntil,
+      required int sourceIssue,
+      Value<int> rowid,
+    });
+typedef $$RouteServiceArtifactEvidenceTableUpdateCompanionBuilder =
+    RouteServiceArtifactEvidenceCompanion Function({
+      Value<String> serviceClass,
+      Value<String> timetableArtifactId,
+      Value<String> timetableArtifactSha256,
+      Value<String> canonicalPackId,
+      Value<String> canonicalPackSha256,
+      Value<String> canonicalPackSqliteSha256,
+      Value<String> admissionStatus,
+      Value<bool> admissionEligible,
+      Value<String?> freshUntil,
+      Value<int> sourceIssue,
+      Value<int> rowid,
+    });
+
+class $$RouteServiceArtifactEvidenceTableFilterComposer
+    extends Composer<_$CatalogDatabase, $RouteServiceArtifactEvidenceTable> {
+  $$RouteServiceArtifactEvidenceTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get serviceClass => $composableBuilder(
+    column: $table.serviceClass,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get timetableArtifactId => $composableBuilder(
+    column: $table.timetableArtifactId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get timetableArtifactSha256 => $composableBuilder(
+    column: $table.timetableArtifactSha256,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get canonicalPackId => $composableBuilder(
+    column: $table.canonicalPackId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get canonicalPackSha256 => $composableBuilder(
+    column: $table.canonicalPackSha256,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get canonicalPackSqliteSha256 => $composableBuilder(
+    column: $table.canonicalPackSqliteSha256,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get admissionStatus => $composableBuilder(
+    column: $table.admissionStatus,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get admissionEligible => $composableBuilder(
+    column: $table.admissionEligible,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get freshUntil => $composableBuilder(
+    column: $table.freshUntil,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get sourceIssue => $composableBuilder(
+    column: $table.sourceIssue,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$RouteServiceArtifactEvidenceTableOrderingComposer
+    extends Composer<_$CatalogDatabase, $RouteServiceArtifactEvidenceTable> {
+  $$RouteServiceArtifactEvidenceTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get serviceClass => $composableBuilder(
+    column: $table.serviceClass,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get timetableArtifactId => $composableBuilder(
+    column: $table.timetableArtifactId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get timetableArtifactSha256 => $composableBuilder(
+    column: $table.timetableArtifactSha256,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get canonicalPackId => $composableBuilder(
+    column: $table.canonicalPackId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get canonicalPackSha256 => $composableBuilder(
+    column: $table.canonicalPackSha256,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get canonicalPackSqliteSha256 => $composableBuilder(
+    column: $table.canonicalPackSqliteSha256,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get admissionStatus => $composableBuilder(
+    column: $table.admissionStatus,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<bool> get admissionEligible => $composableBuilder(
+    column: $table.admissionEligible,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get freshUntil => $composableBuilder(
+    column: $table.freshUntil,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get sourceIssue => $composableBuilder(
+    column: $table.sourceIssue,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$RouteServiceArtifactEvidenceTableAnnotationComposer
+    extends Composer<_$CatalogDatabase, $RouteServiceArtifactEvidenceTable> {
+  $$RouteServiceArtifactEvidenceTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get serviceClass => $composableBuilder(
+    column: $table.serviceClass,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get timetableArtifactId => $composableBuilder(
+    column: $table.timetableArtifactId,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get timetableArtifactSha256 => $composableBuilder(
+    column: $table.timetableArtifactSha256,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get canonicalPackId => $composableBuilder(
+    column: $table.canonicalPackId,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get canonicalPackSha256 => $composableBuilder(
+    column: $table.canonicalPackSha256,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get canonicalPackSqliteSha256 => $composableBuilder(
+    column: $table.canonicalPackSqliteSha256,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get admissionStatus => $composableBuilder(
+    column: $table.admissionStatus,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<bool> get admissionEligible => $composableBuilder(
+    column: $table.admissionEligible,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get freshUntil => $composableBuilder(
+    column: $table.freshUntil,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get sourceIssue => $composableBuilder(
+    column: $table.sourceIssue,
+    builder: (column) => column,
+  );
+}
+
+class $$RouteServiceArtifactEvidenceTableTableManager
+    extends
+        RootTableManager<
+          _$CatalogDatabase,
+          $RouteServiceArtifactEvidenceTable,
+          RouteServiceArtifactEvidenceData,
+          $$RouteServiceArtifactEvidenceTableFilterComposer,
+          $$RouteServiceArtifactEvidenceTableOrderingComposer,
+          $$RouteServiceArtifactEvidenceTableAnnotationComposer,
+          $$RouteServiceArtifactEvidenceTableCreateCompanionBuilder,
+          $$RouteServiceArtifactEvidenceTableUpdateCompanionBuilder,
+          (
+            RouteServiceArtifactEvidenceData,
+            BaseReferences<
+              _$CatalogDatabase,
+              $RouteServiceArtifactEvidenceTable,
+              RouteServiceArtifactEvidenceData
+            >,
+          ),
+          RouteServiceArtifactEvidenceData,
+          PrefetchHooks Function()
+        > {
+  $$RouteServiceArtifactEvidenceTableTableManager(
+    _$CatalogDatabase db,
+    $RouteServiceArtifactEvidenceTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$RouteServiceArtifactEvidenceTableFilterComposer(
+                $db: db,
+                $table: table,
+              ),
+          createOrderingComposer: () =>
+              $$RouteServiceArtifactEvidenceTableOrderingComposer(
+                $db: db,
+                $table: table,
+              ),
+          createComputedFieldComposer: () =>
+              $$RouteServiceArtifactEvidenceTableAnnotationComposer(
+                $db: db,
+                $table: table,
+              ),
+          updateCompanionCallback:
+              ({
+                Value<String> serviceClass = const Value.absent(),
+                Value<String> timetableArtifactId = const Value.absent(),
+                Value<String> timetableArtifactSha256 = const Value.absent(),
+                Value<String> canonicalPackId = const Value.absent(),
+                Value<String> canonicalPackSha256 = const Value.absent(),
+                Value<String> canonicalPackSqliteSha256 = const Value.absent(),
+                Value<String> admissionStatus = const Value.absent(),
+                Value<bool> admissionEligible = const Value.absent(),
+                Value<String?> freshUntil = const Value.absent(),
+                Value<int> sourceIssue = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => RouteServiceArtifactEvidenceCompanion(
+                serviceClass: serviceClass,
+                timetableArtifactId: timetableArtifactId,
+                timetableArtifactSha256: timetableArtifactSha256,
+                canonicalPackId: canonicalPackId,
+                canonicalPackSha256: canonicalPackSha256,
+                canonicalPackSqliteSha256: canonicalPackSqliteSha256,
+                admissionStatus: admissionStatus,
+                admissionEligible: admissionEligible,
+                freshUntil: freshUntil,
+                sourceIssue: sourceIssue,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String serviceClass,
+                required String timetableArtifactId,
+                required String timetableArtifactSha256,
+                required String canonicalPackId,
+                required String canonicalPackSha256,
+                required String canonicalPackSqliteSha256,
+                required String admissionStatus,
+                required bool admissionEligible,
+                Value<String?> freshUntil = const Value.absent(),
+                required int sourceIssue,
+                Value<int> rowid = const Value.absent(),
+              }) => RouteServiceArtifactEvidenceCompanion.insert(
+                serviceClass: serviceClass,
+                timetableArtifactId: timetableArtifactId,
+                timetableArtifactSha256: timetableArtifactSha256,
+                canonicalPackId: canonicalPackId,
+                canonicalPackSha256: canonicalPackSha256,
+                canonicalPackSqliteSha256: canonicalPackSqliteSha256,
+                admissionStatus: admissionStatus,
+                admissionEligible: admissionEligible,
+                freshUntil: freshUntil,
+                sourceIssue: sourceIssue,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$RouteServiceArtifactEvidenceTableProcessedTableManager =
+    ProcessedTableManager<
+      _$CatalogDatabase,
+      $RouteServiceArtifactEvidenceTable,
+      RouteServiceArtifactEvidenceData,
+      $$RouteServiceArtifactEvidenceTableFilterComposer,
+      $$RouteServiceArtifactEvidenceTableOrderingComposer,
+      $$RouteServiceArtifactEvidenceTableAnnotationComposer,
+      $$RouteServiceArtifactEvidenceTableCreateCompanionBuilder,
+      $$RouteServiceArtifactEvidenceTableUpdateCompanionBuilder,
+      (
+        RouteServiceArtifactEvidenceData,
+        BaseReferences<
+          _$CatalogDatabase,
+          $RouteServiceArtifactEvidenceTable,
+          RouteServiceArtifactEvidenceData
+        >,
+      ),
+      RouteServiceArtifactEvidenceData,
+      PrefetchHooks Function()
+    >;
 typedef $$RealtimeProviderLineMappingsTableCreateCompanionBuilder =
     RealtimeProviderLineMappingsCompanion Function({
       required String providerId,
@@ -23697,6 +24864,7 @@ typedef $$NetworkEdgesTableCreateCompanionBuilder =
       Value<int> distanceMeters,
       Value<String> edgeType,
       Value<String> servicePattern,
+      Value<String> serviceClass,
       Value<bool> includesStairs,
       Value<String> stairAccessState,
       Value<String> accessibilityStatus,
@@ -23720,6 +24888,7 @@ typedef $$NetworkEdgesTableUpdateCompanionBuilder =
       Value<int> distanceMeters,
       Value<String> edgeType,
       Value<String> servicePattern,
+      Value<String> serviceClass,
       Value<bool> includesStairs,
       Value<String> stairAccessState,
       Value<String> accessibilityStatus,
@@ -23776,6 +24945,11 @@ class $$NetworkEdgesTableFilterComposer
 
   ColumnFilters<String> get servicePattern => $composableBuilder(
     column: $table.servicePattern,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get serviceClass => $composableBuilder(
+    column: $table.serviceClass,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -23884,6 +25058,11 @@ class $$NetworkEdgesTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get serviceClass => $composableBuilder(
+    column: $table.serviceClass,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<bool> get includesStairs => $composableBuilder(
     column: $table.includesStairs,
     builder: (column) => ColumnOrderings(column),
@@ -23980,6 +25159,11 @@ class $$NetworkEdgesTableAnnotationComposer
 
   GeneratedColumn<String> get servicePattern => $composableBuilder(
     column: $table.servicePattern,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get serviceClass => $composableBuilder(
+    column: $table.serviceClass,
     builder: (column) => column,
   );
 
@@ -24082,6 +25266,7 @@ class $$NetworkEdgesTableTableManager
                 Value<int> distanceMeters = const Value.absent(),
                 Value<String> edgeType = const Value.absent(),
                 Value<String> servicePattern = const Value.absent(),
+                Value<String> serviceClass = const Value.absent(),
                 Value<bool> includesStairs = const Value.absent(),
                 Value<String> stairAccessState = const Value.absent(),
                 Value<String> accessibilityStatus = const Value.absent(),
@@ -24103,6 +25288,7 @@ class $$NetworkEdgesTableTableManager
                 distanceMeters: distanceMeters,
                 edgeType: edgeType,
                 servicePattern: servicePattern,
+                serviceClass: serviceClass,
                 includesStairs: includesStairs,
                 stairAccessState: stairAccessState,
                 accessibilityStatus: accessibilityStatus,
@@ -24126,6 +25312,7 @@ class $$NetworkEdgesTableTableManager
                 Value<int> distanceMeters = const Value.absent(),
                 Value<String> edgeType = const Value.absent(),
                 Value<String> servicePattern = const Value.absent(),
+                Value<String> serviceClass = const Value.absent(),
                 Value<bool> includesStairs = const Value.absent(),
                 Value<String> stairAccessState = const Value.absent(),
                 Value<String> accessibilityStatus = const Value.absent(),
@@ -24147,6 +25334,7 @@ class $$NetworkEdgesTableTableManager
                 distanceMeters: distanceMeters,
                 edgeType: edgeType,
                 servicePattern: servicePattern,
+                serviceClass: serviceClass,
                 includesStairs: includesStairs,
                 stairAccessState: stairAccessState,
                 accessibilityStatus: accessibilityStatus,
@@ -28799,6 +29987,12 @@ class $CatalogDatabaseManager {
       $$StationFareZonesTableTableManager(_db, _db.stationFareZones);
   $$OfficialOdFareQuotesTableTableManager get officialOdFareQuotes =>
       $$OfficialOdFareQuotesTableTableManager(_db, _db.officialOdFareQuotes);
+  $$RouteServiceArtifactEvidenceTableTableManager
+  get routeServiceArtifactEvidence =>
+      $$RouteServiceArtifactEvidenceTableTableManager(
+        _db,
+        _db.routeServiceArtifactEvidence,
+      );
   $$RealtimeProviderLineMappingsTableTableManager
   get realtimeProviderLineMappings =>
       $$RealtimeProviderLineMappingsTableTableManager(

--- a/apps/mobile/lib/core/database/catalog/catalog_tables.dart
+++ b/apps/mobile/lib/core/database/catalog/catalog_tables.dart
@@ -166,6 +166,8 @@ class TransitTrips extends Table {
       text().named('direction_id').withDefault(const Constant(''))();
   TextColumn get servicePattern =>
       text().named('service_pattern').withDefault(const Constant('LOCAL'))();
+  TextColumn get serviceClass =>
+      text().named('service_class').withDefault(const Constant('SUBWAY'))();
   IntColumn get serviceDayStartSeconds => integer()
       .named('service_day_start_seconds')
       .withDefault(const Constant(0))();
@@ -339,6 +341,27 @@ class OfficialOdFareQuotes extends Table {
   ];
 }
 
+class RouteServiceArtifactEvidence extends Table {
+  @override
+  String get tableName => 'route_service_artifact_evidence';
+
+  TextColumn get serviceClass => text().named('service_class')();
+  TextColumn get timetableArtifactId => text().named('timetable_artifact_id')();
+  TextColumn get timetableArtifactSha256 =>
+      text().named('timetable_artifact_sha256')();
+  TextColumn get canonicalPackId => text().named('canonical_pack_id')();
+  TextColumn get canonicalPackSha256 => text().named('canonical_pack_sha256')();
+  TextColumn get canonicalPackSqliteSha256 =>
+      text().named('canonical_pack_sqlite_sha256')();
+  TextColumn get admissionStatus => text().named('admission_status')();
+  BoolColumn get admissionEligible => boolean().named('admission_eligible')();
+  TextColumn get freshUntil => text().named('fresh_until').nullable()();
+  IntColumn get sourceIssue => integer().named('source_issue')();
+
+  @override
+  Set<Column> get primaryKey => {serviceClass};
+}
+
 class RealtimeProviderLineMappings extends Table {
   @override
   String get tableName => 'realtime_provider_line_mappings';
@@ -424,6 +447,8 @@ class NetworkEdges extends Table {
       text().named('edge_type').withDefault(const Constant('WALK'))();
   TextColumn get servicePattern =>
       text().named('service_pattern').withDefault(const Constant(''))();
+  TextColumn get serviceClass =>
+      text().named('service_class').withDefault(const Constant('SUBWAY'))();
   BoolColumn get includesStairs =>
       boolean().named('includes_stairs').withDefault(const Constant(false))();
   TextColumn get stairAccessState => text()

--- a/apps/mobile/lib/core/database/catalog/station_timetable_query.dart
+++ b/apps/mobile/lib/core/database/catalog/station_timetable_query.dart
@@ -160,6 +160,7 @@ class CatalogStationTimetableQuery {
           WHERE st.station_id = ?
             AND st.line_id = ?
             AND st.pickup_type = 0
+            AND t.service_class = 'SUBWAY'
             AND r.line_id = st.line_id
             AND TRIM(r.direction_name) <> ''
             $dayFilter

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -446,6 +446,7 @@ class LocalRouteRepository implements RouteSearchRepository {
               AND removed.date = ?
               AND removed.exception_type = 2
           )
+          AND trip.service_class = 'SUBWAY'
           AND route.line_id = ?
           $servicePatternSql
           AND board.station_id = ?
@@ -1207,8 +1208,10 @@ class _RouteCatalogSnapshot {
           );
     }
     final plannedRows = await database.customSelect('''
-          SELECT DISTINCT station_id, line_id
-          FROM transit_stop_times
+          SELECT DISTINCT stop.station_id, stop.line_id
+          FROM transit_stop_times stop
+          INNER JOIN transit_trips trip ON trip.id = stop.trip_id
+          WHERE trip.service_class = 'SUBWAY'
           ''').get();
     final plannedStationLineKeys = {
       for (final row in plannedRows)
@@ -1324,6 +1327,10 @@ class _RouteCatalogSnapshot {
       'facility_id',
       'NULL',
     );
+    final localPlannerServiceClassFilter =
+        networkEdgeColumnNames.contains('service_class')
+        ? "WHERE service_class = 'SUBWAY'"
+        : '';
     final facilityColumns = await database
         .customSelect('PRAGMA table_info(facilities)')
         .get();
@@ -1423,6 +1430,7 @@ class _RouteCatalogSnapshot {
                  $evidenceHashSql AS evidence_hash,
                  $facilityIdSql AS facility_id
           FROM network_edges
+          $localPlannerServiceClassFilter
           ORDER BY id
           ''').get();
     final networkEdges = networkEdgeRows

--- a/apps/mobile/test/core/database/mobile_local_database_test.dart
+++ b/apps/mobile/test/core/database/mobile_local_database_test.dart
@@ -124,7 +124,7 @@ void main() {
   });
 
   test(
-    'catalog DB migration은 schema 16 station car door hint를 보존하고 official OD fare table을 만든다',
+    'catalog DB migration은 schema 16 station car door hint를 보존하고 v17-v18 table을 만든다',
     () async {
       final directory = await Directory.systemTemp.createTemp(
         'easysubway-catalog-v16-',
@@ -167,14 +167,14 @@ void main() {
           .customSelect('SELECT id FROM station_car_door_hints')
           .getSingle();
 
-      expect(catalogDatabaseSchemaVersion, 17);
+      expect(catalogDatabaseSchemaVersion, 18);
       expect(fareCount.read<int>('count'), 0);
       expect(hint.read<String>('id'), 'kept-hint');
     },
   );
 
   test(
-    'catalog DB migration은 schema 15 데이터를 보존하고 두 v16-v17 table을 만든다',
+    'catalog DB migration은 schema 15 데이터를 보존하고 v16-v18 table을 만든다',
     () async {
       final directory = await Directory.systemTemp.createTemp(
         'easysubway-catalog-v15-',
@@ -199,10 +199,55 @@ void main() {
           .customSelect('SELECT value FROM preserved_rows')
           .getSingle();
 
-      expect(catalogDatabaseSchemaVersion, 17);
+      expect(catalogDatabaseSchemaVersion, 18);
       expect(fareCount.read<int>('count'), 0);
       expect(hintCount.read<int>('count'), 0);
       expect(preserved.read<String>('value'), 'kept');
+    },
+  );
+
+  test(
+    'catalog DB migration은 v17 route row를 보존하고 v18 service identity를 추가한다',
+    () async {
+      final directory = await Directory.systemTemp.createTemp(
+        'easysubway-catalog-v17-',
+      );
+      addTearDown(() => directory.delete(recursive: true));
+      final file = File('${directory.path}/catalog.sqlite');
+      final legacy = sqlite.sqlite3.open(file.path);
+      legacy.execute(
+        'CREATE TABLE transit_trips (id TEXT NOT NULL PRIMARY KEY)',
+      );
+      legacy.execute(
+        'CREATE TABLE network_edges (id TEXT NOT NULL PRIMARY KEY)',
+      );
+      legacy.execute("INSERT INTO transit_trips VALUES ('trip-kept')");
+      legacy.execute("INSERT INTO network_edges VALUES ('edge-kept')");
+      legacy.execute('PRAGMA user_version = 17');
+      legacy.close();
+
+      final database = CatalogDatabase.file(file);
+      addTearDown(database.close);
+      final trip = await database
+          .customSelect(
+            "SELECT id, service_class FROM transit_trips WHERE id = 'trip-kept'",
+          )
+          .getSingle();
+      final edge = await database
+          .customSelect(
+            "SELECT id, service_class FROM network_edges WHERE id = 'edge-kept'",
+          )
+          .getSingle();
+      final evidenceCount = await database
+          .customSelect(
+            'SELECT COUNT(*) AS count FROM route_service_artifact_evidence',
+          )
+          .getSingle();
+
+      expect(catalogDatabaseSchemaVersion, 18);
+      expect(trip.read<String>('service_class'), 'SUBWAY');
+      expect(edge.read<String>('service_class'), 'SUBWAY');
+      expect(evidenceCount.read<int>('count'), 0);
     },
   );
 
@@ -543,37 +588,34 @@ void main() {
     expect((additionalSteps[8] as Map)['distanceMeters'], 8000);
   });
 
-  test(
-    '기존 baseline에 남은 구버전 단일 단계 fare rule을 9단계로 갱신한다(#1911)',
-    () async {
-      final database = CatalogDatabase.memory();
-      addTearDown(database.close);
+  test('기존 baseline에 남은 구버전 단일 단계 fare rule을 9단계로 갱신한다(#1911)', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
 
-      await database.seedBaselineIfEmpty();
-      await database.customStatement('''
+    await database.seedBaselineIfEmpty();
+    await database.customStatement('''
       UPDATE fare_rules
       SET additional_steps_json =
         '[{"distanceMeters":5000,"cardFare":100,"cashFare":100}]'
       WHERE id = 'capital-integrated-standard'
       ''');
 
-      await database.seedBaselineIfEmpty();
+    await database.seedBaselineIfEmpty();
 
-      final fareRule = await database.customSelect('''
+    final fareRule = await database.customSelect('''
       SELECT additional_steps_json
       FROM fare_rules
       WHERE id = 'capital-integrated-standard'
       ''').getSingle();
-      final additionalSteps =
-          jsonDecode(fareRule.read<String>('additional_steps_json')) as List;
+    final additionalSteps =
+        jsonDecode(fareRule.read<String>('additional_steps_json')) as List;
 
-      expect(additionalSteps, hasLength(9));
-      for (var index = 0; index < 8; index += 1) {
-        expect((additionalSteps[index] as Map)['distanceMeters'], 5000);
-      }
-      expect((additionalSteps[8] as Map)['distanceMeters'], 8000);
-    },
-  );
+    expect(additionalSteps, hasLength(9));
+    for (var index = 0; index < 8; index += 1) {
+      expect((additionalSteps[index] as Map)['distanceMeters'], 5000);
+    }
+    expect((additionalSteps[8] as Map)['distanceMeters'], 8000);
+  });
 
   test('내장 데이터팩은 로컬 역 검색 repository에서 역 번호 검색을 제공한다', () async {
     final directory = await Directory.systemTemp.createTemp(

--- a/apps/mobile/test/features/home_widget/next_train_widget_repository_test.dart
+++ b/apps/mobile/test/features/home_widget/next_train_widget_repository_test.dart
@@ -47,6 +47,47 @@ void main() {
     ]);
   });
 
+  test('홈 위젯은 ITX trip을 지하철 출발로 노출하지 않는다', () async {
+    await _seedSchedule(catalogDatabase);
+    await catalogDatabase.customStatement('''
+      INSERT INTO transit_routes (
+        id, line_id, route_short_name, route_long_name, direction_name, timezone
+      ) VALUES (
+        'itx-route', 'seoul-4', 'ITX-청춘', '청량리 → 춘천',
+        'ITX 춘천 방면', 'Asia/Seoul'
+      )
+    ''');
+    await catalogDatabase.customStatement('''
+      INSERT INTO transit_trips (
+        id, route_id, service_id, trip_headsign, direction_id,
+        service_pattern, service_class, service_day_start_seconds
+      ) VALUES (
+        'itx-trip', 'itx-route', 'weekday', '춘천', 'down',
+        'EXPRESS', 'ITX_CHEONGCHUN', 0
+      )
+    ''');
+    await catalogDatabase.customStatement('''
+      INSERT INTO transit_stop_times (
+        trip_id, stop_sequence, station_id, line_id,
+        arrival_seconds, departure_seconds, pickup_type, drop_off_type
+      ) VALUES (
+        'itx-trip', 1, 'station-sadang', 'seoul-4', 18600, 18600, 0, 0
+      )
+    ''');
+
+    final data = await repository.load(
+      _sadangLine4,
+      tz.TZDateTime(tz.getLocation('Asia/Seoul'), 2026, 7, 10, 5),
+    );
+
+    expect(data.status, NextTrainWidgetStatus.available);
+    expect(data.directions.map((item) => item.name), ['상록수 방면', '사당 방면']);
+    expect(data.directions.map((item) => item.departureLabel), [
+      '05:20',
+      '05:25',
+    ]);
+  });
+
   test('흡수 station ID 즐겨찾기도 대표 station-line으로 선택한다', () async {
     await catalogDatabase.customStatement('''
       INSERT INTO station_aliases (station_id, alias, normalized_alias)

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -531,6 +531,95 @@ void main() {
     expect(result.etaSource, 'STATIC_LOCAL');
   });
 
+  test('Mobile 로컬 planner는 ITX topology를 직접 소비하지 않는다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await _seedLineWithoutNetworkEdges(database);
+    await database.customStatement('''
+      INSERT INTO network_edges (
+        id, from_node_id, to_node_id, duration_seconds, edge_type,
+        service_pattern, service_class, stair_access_state,
+        accessibility_status, reliability_score
+      ) VALUES (
+        'itx-edge-a-b', 'station-a:line-test', 'station-b:line-test', 60,
+        'RIDE', 'EXPRESS', 'ITX_CHEONGCHUN', 'STEP_FREE', 'AVAILABLE', 100
+      )
+    ''');
+
+    final result = await LocalRouteRepository(catalogDatabase: database)
+        .searchRoute(
+          const RouteSearchRequest(
+            originStationId: 'station-a',
+            destinationStationId: 'station-b',
+            mobilityType: 'WHEELCHAIR',
+          ),
+        );
+
+    expect(result.status, isNot('FOUND'));
+    expect(
+      result.steps.expand((step) => step.evidenceSources),
+      isNot(contains('edge:itx-edge-a-b')),
+    );
+  });
+
+  test('Mobile 로컬 planner는 ITX timetable row를 직접 소비하지 않는다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await _seedLineWithoutNetworkEdges(database);
+    await _insertVerifiedNetworkEdge(
+      database,
+      id: 'subway-edge-a-b',
+      fromNodeId: 'station-a:line-test',
+      toNodeId: 'station-b:line-test',
+      edgeType: 'RIDE',
+      durationSeconds: 600,
+      servicePattern: 'EXPRESS',
+    );
+    await database.customStatement('''
+      INSERT INTO service_calendars (
+        service_id, monday, tuesday, wednesday, thursday, friday,
+        saturday, sunday, start_date, end_date
+      ) VALUES (
+        'itx-weekday', 1, 1, 1, 1, 1, 0, 0, '20260101', '20261231'
+      )
+    ''');
+    await database.customStatement('''
+      INSERT INTO transit_routes (id, line_id, route_short_name)
+      VALUES ('itx-route', 'line-test', 'ITX-청춘')
+    ''');
+    await database.customStatement('''
+      INSERT INTO transit_trips (
+        id, route_id, service_id, service_pattern, service_class
+      ) VALUES (
+        'itx-trip', 'itx-route', 'itx-weekday', 'EXPRESS', 'ITX_CHEONGCHUN'
+      )
+    ''');
+    await database.customStatement('''
+      INSERT INTO transit_stop_times (
+        trip_id, stop_sequence, station_id, line_id,
+        arrival_seconds, departure_seconds
+      ) VALUES
+        ('itx-trip', 1, 'station-a', 'line-test', 28770, 28800),
+        ('itx-trip', 2, 'station-b', 'line-test', 29400, 29430)
+    ''');
+    final repository = LocalRouteRepository(
+      catalogDatabase: database,
+      now: () => DateTime.parse('2026-07-10T07:58:00+09:00'),
+    );
+
+    final result = await repository.searchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-a',
+        destinationStationId: 'station-b',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
+
+    final ride = result.steps.singleWhere((step) => step.stepType == 'ride');
+    expect(result.status, 'FOUND');
+    expect(ride.plannedArrivalTimeIso, isEmpty);
+  });
+
   test('SLOW 프리셋은 보행 스텝 시간을 늘리고 ride 스텝은 그대로 둔다', () async {
     final database = CatalogDatabase.memory();
     addTearDown(database.close);

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -535,15 +535,30 @@ void main() {
     final database = CatalogDatabase.memory();
     addTearDown(database.close);
     await _seedLineWithoutNetworkEdges(database);
+    await _insertVerifiedNetworkEdge(
+      database,
+      id: 'itx-edge-a-b',
+      fromNodeId: 'station-a:line-test',
+      toNodeId: 'station-b:line-test',
+      edgeType: 'RIDE',
+      durationSeconds: 60,
+      servicePattern: 'EXPRESS',
+    );
+
+    final subwayResult = await LocalRouteRepository(catalogDatabase: database)
+        .searchRoute(
+          const RouteSearchRequest(
+            originStationId: 'station-a',
+            destinationStationId: 'station-b',
+            mobilityType: 'WHEELCHAIR',
+          ),
+        );
+    expect(subwayResult.status, 'FOUND');
+
     await database.customStatement('''
-      INSERT INTO network_edges (
-        id, from_node_id, to_node_id, duration_seconds, edge_type,
-        service_pattern, service_class, stair_access_state,
-        accessibility_status, reliability_score
-      ) VALUES (
-        'itx-edge-a-b', 'station-a:line-test', 'station-b:line-test', 60,
-        'RIDE', 'EXPRESS', 'ITX_CHEONGCHUN', 'STEP_FREE', 'AVAILABLE', 100
-      )
+      UPDATE network_edges
+      SET service_class = 'ITX_CHEONGCHUN'
+      WHERE id = 'itx-edge-a-b'
     ''');
 
     final result = await LocalRouteRepository(catalogDatabase: database)
@@ -4763,6 +4778,7 @@ Future<void> _insertVerifiedNetworkEdge(
   required int durationSeconds,
   int distanceMeters = 0,
   String servicePattern = '',
+  String serviceClass = 'SUBWAY',
   String verificationStatus = 'VERIFIED',
   String provenanceKind = 'OFFICIAL_SOURCE',
   int lastVerifiedAtSeconds = 1781827200,
@@ -4773,11 +4789,11 @@ Future<void> _insertVerifiedNetworkEdge(
     '''
       INSERT INTO network_edges (
         id, from_node_id, to_node_id, duration_seconds, distance_meters, edge_type,
-        service_pattern, stair_access_state, accessibility_status, reliability_score,
+        service_pattern, service_class, stair_access_state, accessibility_status, reliability_score,
         source_id, source_snapshot_id, provider_record_hash, provenance_kind,
         verification_status, last_verified_at, evidence_hash
       )
-      VALUES (?, ?, ?, ?, ?, ?, ?, 'STEP_FREE', 'AVAILABLE', 95, 'test-source',
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'STEP_FREE', 'AVAILABLE', 95, 'test-source',
         'test-source-snapshot',
         'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
         ?, ?, ?, ?)
@@ -4790,6 +4806,7 @@ Future<void> _insertVerifiedNetworkEdge(
       distanceMeters,
       edgeType,
       servicePattern,
+      serviceClass,
       provenanceKind,
       verificationStatus,
       lastVerifiedAtSeconds,

--- a/apps/mobile/test/features/stations/drift_station_repository_test.dart
+++ b/apps/mobile/test/features/stations/drift_station_repository_test.dart
@@ -282,6 +282,51 @@ void main() {
     expect(sadang.lastDeparture.semanticLabel, '사당 방면, 다음 날 00시 25분 출발');
   });
 
+  test('로컬 역 시간표는 ITX trip을 지하철 출발로 노출하지 않는다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await database.seedBaselineIfEmpty();
+    await _seedStationTimetable(database);
+    await database.customStatement('''
+      INSERT INTO transit_routes (
+        id, line_id, route_short_name, route_long_name, direction_name, timezone
+      ) VALUES (
+        'itx-route-1919', 'seoul-4', 'ITX-청춘', '청량리 → 춘천',
+        'ITX 춘천 방면', 'Asia/Seoul'
+      )
+    ''');
+    await database.customStatement('''
+      INSERT INTO transit_trips (
+        id, route_id, service_id, trip_headsign, direction_id,
+        service_pattern, service_class, service_day_start_seconds
+      ) VALUES (
+        'itx-trip-1919', 'itx-route-1919', 'weekday-1919', '춘천', 'down',
+        'EXPRESS', 'ITX_CHEONGCHUN', 0
+      )
+    ''');
+    await database.customStatement('''
+      INSERT INTO transit_stop_times (
+        trip_id, stop_sequence, station_id, line_id,
+        arrival_seconds, departure_seconds, pickup_type, drop_off_type
+      ) VALUES (
+        'itx-trip-1919', 1, 'station-sadang', 'seoul-4', 19140, 19140, 0, 0
+      )
+    ''');
+    final repository = DriftStationRepository(database: database);
+
+    final timetable = await repository.loadStationTimetable(
+      stationId: 'station-sadang',
+      lineId: 'seoul-4',
+      dayType: StationTimetableDayType.weekday,
+      referenceDate: DateTime(2026, 7, 12),
+    );
+
+    expect(
+      timetable.directions.map((direction) => direction.name),
+      isNot(contains('ITX 춘천 방면')),
+    );
+  });
+
   test('흡수된 station ID로도 대표 역 시간표를 반환한다', () async {
     final database = CatalogDatabase.memory();
     addTearDown(database.close);

--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/JdbcRouteTimetableRepository.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/JdbcRouteTimetableRepository.java
@@ -2,10 +2,13 @@ package com.easysubway.route.adapter.out.persistence;
 
 import com.easysubway.route.application.port.out.LoadRouteTimetablePort;
 import com.easysubway.route.application.port.out.LoadRouteTimetablePort.RouteTimetable;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.List;
+import java.util.Optional;
 import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,20 +38,41 @@ public class JdbcRouteTimetableRepository implements LoadRouteTimetablePort {
 
 	@Override
 	public boolean hasRouteTimetable() {
+		String tripFilter = activeItxFreshUntil().isPresent()
+			? ""
+			: "AND t.service_class <> 'ITX_CHEONGCHUN'";
 		return Boolean.TRUE.equals(jdbcTemplate.queryForObject(
 			"""
 				SELECT CASE
-					WHEN EXISTS (SELECT 1 FROM transit_trips)
-						AND EXISTS (SELECT 1 FROM transit_stop_times)
+					WHEN EXISTS (
+						SELECT 1 FROM transit_trips t
+						WHERE EXISTS (SELECT 1 FROM transit_stop_times s WHERE s.trip_id = t.id)
+						%s
+					)
 					THEN TRUE ELSE FALSE
 				END
-				""",
+				""".formatted(tripFilter),
 			Boolean.class
 		));
 	}
 
 	@Override
+	public String timetableCacheKey() {
+		return activeItxFreshUntil()
+			.map(value -> "ITX_CHEONGCHUN:" + value.toInstant())
+			.orElse("SUBWAY_ONLY");
+	}
+
+	@Override
 	public RouteTimetable loadRouteTimetable() {
+		boolean includeItx = activeItxFreshUntil().isPresent();
+		String tripFilter = includeItx ? "" : "WHERE service_class <> 'ITX_CHEONGCHUN'";
+		String childTripFilter = includeItx ? "" : """
+			WHERE EXISTS (
+				SELECT 1 FROM transit_trips t
+				WHERE t.id = trip_id AND t.service_class <> 'ITX_CHEONGCHUN'
+			)
+			""";
 		return new RouteTimetable(
 			jdbcTemplate.query(
 				"""
@@ -102,8 +126,9 @@ public class JdbcRouteTimetableRepository implements LoadRouteTimetablePort {
 				"""
 					SELECT id, route_id, service_id, trip_headsign, direction_id, service_pattern, service_day_start_seconds
 					FROM transit_trips
+					%s
 					ORDER BY id
-					""",
+					""".formatted(tripFilter),
 				(resultSet, rowNumber) -> new TransitTrip(
 					resultSet.getString("id"),
 					resultSet.getString("route_id"),
@@ -119,8 +144,9 @@ public class JdbcRouteTimetableRepository implements LoadRouteTimetablePort {
 					SELECT trip_id, stop_sequence, station_id, line_id, arrival_seconds, departure_seconds,
 						pickup_type, drop_off_type
 					FROM transit_stop_times
+					%s
 					ORDER BY trip_id, stop_sequence
-					""",
+					""".formatted(childTripFilter),
 				(resultSet, rowNumber) -> new TransitStopTime(
 					resultSet.getString("trip_id"),
 					resultSet.getInt("stop_sequence"),
@@ -136,8 +162,9 @@ public class JdbcRouteTimetableRepository implements LoadRouteTimetablePort {
 				"""
 					SELECT trip_id, start_time_seconds, end_time_seconds, headway_seconds, exact_times
 					FROM transit_frequencies
+					%s
 					ORDER BY trip_id, start_time_seconds
-					""",
+					""".formatted(childTripFilter),
 				(resultSet, rowNumber) -> new TransitFrequency(
 					resultSet.getString("trip_id"),
 					resultSet.getInt("start_time_seconds"),
@@ -148,6 +175,35 @@ public class JdbcRouteTimetableRepository implements LoadRouteTimetablePort {
 			),
 			loadFeedEndDate()
 		);
+	}
+
+	private Optional<OffsetDateTime> activeItxFreshUntil() {
+		return jdbcTemplate.query(
+			"""
+				SELECT fresh_until
+				FROM route_service_artifact_evidence
+				WHERE service_class = 'ITX_CHEONGCHUN'
+					AND admission_status = 'ADMITTED'
+					AND admission_eligible = TRUE
+					AND EXISTS (
+						SELECT 1 FROM transit_trips
+						WHERE service_class = 'ITX_CHEONGCHUN'
+					)
+				""",
+			(resultSet, rowNumber) -> resultSet.getString("fresh_until")
+		).stream().findFirst().flatMap(JdbcRouteTimetableRepository::freshOffsetDateTime);
+	}
+
+	private static Optional<OffsetDateTime> freshOffsetDateTime(String value) {
+		if (value == null || value.isBlank()) {
+			return Optional.empty();
+		}
+		try {
+			OffsetDateTime parsed = OffsetDateTime.parse(value);
+			return parsed.toInstant().isAfter(Instant.now()) ? Optional.of(parsed) : Optional.empty();
+		} catch (DateTimeParseException exception) {
+			return Optional.empty();
+		}
 	}
 
 	private LocalDate loadFeedEndDate() {

--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoader.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoader.java
@@ -69,6 +69,10 @@ public class TimetableSeedLoader implements ApplicationRunner {
 				throw new IllegalStateException(
 					"additive ITX timetable seed is not supported while another timetable is present");
 			}
+			if (!includesItxSeed && existingItx) {
+				throw new IllegalStateException(
+					"easysubway.timetable.seed.includes-itx=false cannot activate existing ITX-청춘 rows");
+			}
 			log.info("transit timetable already present; skipping seed load");
 			return;
 		}
@@ -77,18 +81,21 @@ public class TimetableSeedLoader implements ApplicationRunner {
 			transactionTemplate.executeWithoutResult(status -> {
 				executeBatch(statements);
 				boolean loadedItx = validateRouteServiceAdmission();
-				if (includesItxSeed && !loadedItx) {
+				if (includesItxSeed != loadedItx) {
 					throw new IllegalStateException(
-						"easysubway.timetable.seed.includes-itx=true requires ITX-청춘 timetable rows");
+						"easysubway.timetable.seed.includes-itx=" + includesItxSeed
+							+ " must match ITX-청춘 timetable rows");
 				}
 			});
 		} catch (RuntimeException exception) {
 			// 다중 replica 동시 배포 경쟁: 다른 인스턴스가 먼저 적재하면 이 배치는 PK/싱글턴 충돌로 실패한다.
 			// 실패 후 이미 적재됐으면(경쟁 loser) 관용 처리한다(부팅 crash loop 방지). 아니면 실제 오류로 재던진다.
-			if (routeTimetablePort.hasRouteTimetable()
-					&& (!includesItxSeed || validateRouteServiceAdmission())) {
-				log.info("transit timetable was seeded concurrently by another instance; batch failure is benign");
-				return;
+			if (routeTimetablePort.hasRouteTimetable()) {
+				boolean concurrentlyLoadedItx = validateRouteServiceAdmission();
+				if (includesItxSeed == concurrentlyLoadedItx) {
+					log.info("transit timetable was seeded concurrently by another instance; batch failure is benign");
+					return;
+				}
 			}
 			throw exception;
 		}

--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoader.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoader.java
@@ -5,8 +5,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.zip.GZIPInputStream;
 import javax.sql.DataSource;
@@ -62,7 +66,10 @@ public class TimetableSeedLoader implements ApplicationRunner {
 		}
 		List<String> statements = readStatements(seedResource);
 		try {
-			transactionTemplate.executeWithoutResult(status -> executeBatch(statements));
+			transactionTemplate.executeWithoutResult(status -> {
+				executeBatch(statements);
+				validateRouteServiceAdmission();
+			});
 		} catch (RuntimeException exception) {
 			// 다중 replica 동시 배포 경쟁: 다른 인스턴스가 먼저 적재하면 이 배치는 PK/싱글턴 충돌로 실패한다.
 			// 실패 후 이미 적재됐으면(경쟁 loser) 관용 처리한다(부팅 crash loop 방지). 아니면 실제 오류로 재던진다.
@@ -73,6 +80,49 @@ public class TimetableSeedLoader implements ApplicationRunner {
 			throw exception;
 		}
 		log.info("transit timetable seeded from {} ({} statements)", seedResource, statements.size());
+	}
+
+	private void validateRouteServiceAdmission() {
+		Connection connection = DataSourceUtils.getConnection(dataSource);
+		try (Statement statement = connection.createStatement()) {
+			try (ResultSet count = statement.executeQuery("""
+				SELECT COUNT(*) AS row_count
+				FROM transit_trips
+				WHERE service_class = 'ITX_CHEONGCHUN'
+				""")) {
+				count.next();
+				if (count.getInt("row_count") == 0) {
+					return;
+				}
+			}
+			try (ResultSet rows = statement.executeQuery("""
+					SELECT admission_status, admission_eligible, fresh_until
+					FROM route_service_artifact_evidence
+					WHERE service_class = 'ITX_CHEONGCHUN'
+					""")) {
+				if (!rows.next()
+					|| !"ADMITTED".equals(rows.getString("admission_status"))
+					|| !rows.getBoolean("admission_eligible")
+					|| !isFresh(rows.getString("fresh_until"))) {
+					throw new IllegalStateException("ITX-청춘 timetable seed requires ADMITTED evidence with valid freshness");
+				}
+			}
+		} catch (SQLException exception) {
+			throw new IllegalStateException("ITX-청춘 timetable seed admission validation failed", exception);
+		} finally {
+			DataSourceUtils.releaseConnection(connection, dataSource);
+		}
+	}
+
+	private static boolean isFresh(String value) {
+		if (value == null || value.isBlank()) {
+			return false;
+		}
+		try {
+			return OffsetDateTime.parse(value).toInstant().isAfter(Instant.now());
+		} catch (DateTimeParseException exception) {
+			return false;
+		}
 	}
 
 	private void executeBatch(List<String> statements) {

--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoader.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoader.java
@@ -65,6 +65,7 @@ public class TimetableSeedLoader implements ApplicationRunner {
 	public void run(ApplicationArguments args) {
 		boolean existingItx = validateRouteServiceAdmission();
 		if (routeTimetablePort.hasRouteTimetable()) {
+			existingItx = validateRouteServiceAdmission();
 			if (includesItxSeed && !existingItx) {
 				throw new IllegalStateException(
 					"additive ITX timetable seed is not supported while another timetable is present");

--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoader.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoader.java
@@ -60,11 +60,17 @@ public class TimetableSeedLoader implements ApplicationRunner {
 
 	@Override
 	public void run(ApplicationArguments args) {
+		List<String> statements = readStatements(seedResource);
+		boolean includesItx = statements.stream().anyMatch(statement -> statement.contains("'ITX_CHEONGCHUN'"));
 		if (routeTimetablePort.hasRouteTimetable()) {
+			boolean existingItx = validateRouteServiceAdmission();
+			if (includesItx && !existingItx) {
+				throw new IllegalStateException(
+					"additive ITX timetable seed is not supported while another timetable is present");
+			}
 			log.info("transit timetable already present; skipping seed load");
 			return;
 		}
-		List<String> statements = readStatements(seedResource);
 		try {
 			transactionTemplate.executeWithoutResult(status -> {
 				executeBatch(statements);
@@ -73,7 +79,8 @@ public class TimetableSeedLoader implements ApplicationRunner {
 		} catch (RuntimeException exception) {
 			// 다중 replica 동시 배포 경쟁: 다른 인스턴스가 먼저 적재하면 이 배치는 PK/싱글턴 충돌로 실패한다.
 			// 실패 후 이미 적재됐으면(경쟁 loser) 관용 처리한다(부팅 crash loop 방지). 아니면 실제 오류로 재던진다.
-			if (routeTimetablePort.hasRouteTimetable()) {
+			if (routeTimetablePort.hasRouteTimetable()
+					&& (!includesItx || validateRouteServiceAdmission())) {
 				log.info("transit timetable was seeded concurrently by another instance; batch failure is benign");
 				return;
 			}
@@ -82,7 +89,7 @@ public class TimetableSeedLoader implements ApplicationRunner {
 		log.info("transit timetable seeded from {} ({} statements)", seedResource, statements.size());
 	}
 
-	private void validateRouteServiceAdmission() {
+	private boolean validateRouteServiceAdmission() {
 		Connection connection = DataSourceUtils.getConnection(dataSource);
 		try (Statement statement = connection.createStatement()) {
 			try (ResultSet count = statement.executeQuery("""
@@ -90,9 +97,9 @@ public class TimetableSeedLoader implements ApplicationRunner {
 				FROM transit_trips
 				WHERE service_class = 'ITX_CHEONGCHUN'
 				""")) {
-				count.next();
-				if (count.getInt("row_count") == 0) {
-					return;
+					count.next();
+					if (count.getInt("row_count") == 0) {
+						return false;
 				}
 			}
 			try (ResultSet rows = statement.executeQuery("""
@@ -107,6 +114,7 @@ public class TimetableSeedLoader implements ApplicationRunner {
 					throw new IllegalStateException("ITX-청춘 timetable seed requires ADMITTED evidence with valid freshness");
 				}
 			}
+			return true;
 		} catch (SQLException exception) {
 			throw new IllegalStateException("ITX-청춘 timetable seed admission validation failed", exception);
 		} finally {

--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoader.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoader.java
@@ -61,7 +61,7 @@ public class TimetableSeedLoader implements ApplicationRunner {
 	@Override
 	public void run(ApplicationArguments args) {
 		List<String> statements = readStatements(seedResource);
-		boolean includesItx = statements.stream().anyMatch(statement -> statement.contains("'ITX_CHEONGCHUN'"));
+		boolean includesItx = statements.stream().anyMatch(TimetableSeedLoader::isItxTripInsert);
 		if (routeTimetablePort.hasRouteTimetable()) {
 			boolean existingItx = validateRouteServiceAdmission();
 			if (includesItx && !existingItx) {
@@ -87,6 +87,12 @@ public class TimetableSeedLoader implements ApplicationRunner {
 			throw exception;
 		}
 		log.info("transit timetable seeded from {} ({} statements)", seedResource, statements.size());
+	}
+
+	private static boolean isItxTripInsert(String statement) {
+		return statement.startsWith("INSERT INTO transit_trips ")
+			&& statement.contains("service_class")
+			&& statement.contains("'ITX_CHEONGCHUN'");
 	}
 
 	private boolean validateRouteServiceAdmission() {

--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoader.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoader.java
@@ -45,32 +45,34 @@ public class TimetableSeedLoader implements ApplicationRunner {
 	private final DataSource dataSource;
 	private final TransactionTemplate transactionTemplate;
 	private final Resource seedResource;
+	private final boolean includesItxSeed;
 
 	public TimetableSeedLoader(
 		LoadRouteTimetablePort routeTimetablePort,
 		DataSource dataSource,
 		PlatformTransactionManager transactionManager,
-		@Value("${easysubway.timetable.seed.resource:classpath:timetable/line4-timetable-seed.sql.gz}") Resource seedResource
+		@Value("${easysubway.timetable.seed.resource:classpath:timetable/line4-timetable-seed.sql.gz}") Resource seedResource,
+		@Value("${easysubway.timetable.seed.includes-itx:false}") boolean includesItxSeed
 	) {
 		this.routeTimetablePort = routeTimetablePort;
 		this.dataSource = dataSource;
 		this.transactionTemplate = new TransactionTemplate(transactionManager);
 		this.seedResource = seedResource;
+		this.includesItxSeed = includesItxSeed;
 	}
 
 	@Override
 	public void run(ApplicationArguments args) {
-		List<String> statements = readStatements(seedResource);
-		boolean includesItx = statements.stream().anyMatch(TimetableSeedLoader::isItxTripInsert);
 		if (routeTimetablePort.hasRouteTimetable()) {
 			boolean existingItx = validateRouteServiceAdmission();
-			if (includesItx && !existingItx) {
+			if (includesItxSeed && !existingItx) {
 				throw new IllegalStateException(
 					"additive ITX timetable seed is not supported while another timetable is present");
 			}
 			log.info("transit timetable already present; skipping seed load");
 			return;
 		}
+		List<String> statements = readStatements(seedResource);
 		try {
 			transactionTemplate.executeWithoutResult(status -> {
 				executeBatch(statements);
@@ -80,19 +82,13 @@ public class TimetableSeedLoader implements ApplicationRunner {
 			// 다중 replica 동시 배포 경쟁: 다른 인스턴스가 먼저 적재하면 이 배치는 PK/싱글턴 충돌로 실패한다.
 			// 실패 후 이미 적재됐으면(경쟁 loser) 관용 처리한다(부팅 crash loop 방지). 아니면 실제 오류로 재던진다.
 			if (routeTimetablePort.hasRouteTimetable()
-					&& (!includesItx || validateRouteServiceAdmission())) {
+					&& (!includesItxSeed || validateRouteServiceAdmission())) {
 				log.info("transit timetable was seeded concurrently by another instance; batch failure is benign");
 				return;
 			}
 			throw exception;
 		}
 		log.info("transit timetable seeded from {} ({} statements)", seedResource, statements.size());
-	}
-
-	private static boolean isItxTripInsert(String statement) {
-		return statement.startsWith("INSERT INTO transit_trips ")
-			&& statement.contains("service_class")
-			&& statement.contains("'ITX_CHEONGCHUN'");
 	}
 
 	private boolean validateRouteServiceAdmission() {

--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoader.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoader.java
@@ -63,8 +63,8 @@ public class TimetableSeedLoader implements ApplicationRunner {
 
 	@Override
 	public void run(ApplicationArguments args) {
+		boolean existingItx = validateRouteServiceAdmission();
 		if (routeTimetablePort.hasRouteTimetable()) {
-			boolean existingItx = validateRouteServiceAdmission();
 			if (includesItxSeed && !existingItx) {
 				throw new IllegalStateException(
 					"additive ITX timetable seed is not supported while another timetable is present");

--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoader.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoader.java
@@ -76,7 +76,11 @@ public class TimetableSeedLoader implements ApplicationRunner {
 		try {
 			transactionTemplate.executeWithoutResult(status -> {
 				executeBatch(statements);
-				validateRouteServiceAdmission();
+				boolean loadedItx = validateRouteServiceAdmission();
+				if (includesItxSeed && !loadedItx) {
+					throw new IllegalStateException(
+						"easysubway.timetable.seed.includes-itx=true requires ITX-청춘 timetable rows");
+				}
 			});
 		} catch (RuntimeException exception) {
 			// 다중 replica 동시 배포 경쟁: 다른 인스턴스가 먼저 적재하면 이 배치는 PK/싱글턴 충돌로 실패한다.

--- a/backend/src/main/java/com/easysubway/route/application/port/out/LoadRouteTimetablePort.java
+++ b/backend/src/main/java/com/easysubway/route/application/port/out/LoadRouteTimetablePort.java
@@ -9,6 +9,10 @@ public interface LoadRouteTimetablePort {
 
 	RouteTimetable loadRouteTimetable();
 
+	default String timetableCacheKey() {
+		return "STATIC";
+	}
+
 	default boolean hasRouteTimetable() {
 		RouteTimetable timetable = loadRouteTimetable();
 		return !timetable.transitTrips().isEmpty() && !timetable.transitStopTimes().isEmpty();

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
@@ -35,8 +35,7 @@ public class RouteV2Planner implements RouteV2SearchUseCase {
 	private final LoadRouteTimetablePort routeTimetablePort;
 	private final RouteTimetableRaptorPlanner timetableRaptorPlanner = new RouteTimetableRaptorPlanner();
 	private final boolean timetableRequired;
-	private volatile RouteTimetable cachedRouteTimetable;
-	private volatile java.util.Set<String> cachedCoveredStationIds;
+	private volatile TimetableSnapshot cachedTimetableSnapshot;
 
 	public RouteV2Planner(RouteSearchUseCase routeSearchUseCase) {
 		this(routeSearchUseCase, RouteTimetable::empty, false);
@@ -123,16 +122,7 @@ public class RouteV2Planner implements RouteV2SearchUseCase {
 	}
 
 	private RouteTimetable routeTimetable() {
-		RouteTimetable snapshot = cachedRouteTimetable;
-		if (snapshot != null) {
-			return snapshot;
-		}
-		synchronized (this) {
-			if (cachedRouteTimetable == null) {
-				cachedRouteTimetable = routeTimetablePort.loadRouteTimetable();
-			}
-			return cachedRouteTimetable;
-		}
+		return timetableSnapshot().timetable();
 	}
 
 	private boolean timetableCovers(SearchRouteV2Command command) {
@@ -145,18 +135,34 @@ public class RouteV2Planner implements RouteV2SearchUseCase {
 	}
 
 	private java.util.Set<String> coveredStationIds() {
-		java.util.Set<String> snapshot = cachedCoveredStationIds;
-		if (snapshot != null) {
+		return timetableSnapshot().coveredStationIds();
+	}
+
+	private TimetableSnapshot timetableSnapshot() {
+		String cacheKey = routeTimetablePort.timetableCacheKey();
+		TimetableSnapshot snapshot = cachedTimetableSnapshot;
+		if (snapshot != null && snapshot.cacheKey().equals(cacheKey)) {
 			return snapshot;
 		}
 		synchronized (this) {
-			if (cachedCoveredStationIds == null) {
-				cachedCoveredStationIds = routeTimetable().transitStopTimes().stream()
+			cacheKey = routeTimetablePort.timetableCacheKey();
+			snapshot = cachedTimetableSnapshot;
+			if (snapshot == null || !snapshot.cacheKey().equals(cacheKey)) {
+				RouteTimetable timetable = routeTimetablePort.loadRouteTimetable();
+				java.util.Set<String> coveredStationIds = timetable.transitStopTimes().stream()
 					.map(LoadRouteTimetablePort.TransitStopTime::stationId)
 					.collect(java.util.stream.Collectors.toUnmodifiableSet());
+				cachedTimetableSnapshot = new TimetableSnapshot(cacheKey, timetable, coveredStationIds);
 			}
-			return cachedCoveredStationIds;
+			return cachedTimetableSnapshot;
 		}
+	}
+
+	private record TimetableSnapshot(
+		String cacheKey,
+		RouteTimetable timetable,
+		java.util.Set<String> coveredStationIds
+	) {
 	}
 
 	private SearchRouteV2Command rankingCommand(SearchRouteV2Command command) {

--- a/backend/src/main/resources/db/migration/h2/V50__route_service_identity.sql
+++ b/backend/src/main/resources/db/migration/h2/V50__route_service_identity.sql
@@ -1,0 +1,27 @@
+ALTER TABLE transit_trips ADD COLUMN service_class CHARACTER VARYING(40) DEFAULT 'SUBWAY' NOT NULL;
+ALTER TABLE transit_trips ADD CONSTRAINT h2_transit_trips_service_class
+  CHECK (service_class = 'SUBWAY' OR service_class = 'ITX_CHEONGCHUN');
+
+CREATE TABLE route_service_artifact_evidence (
+  service_class CHARACTER VARYING(40) PRIMARY KEY NOT NULL,
+  timetable_artifact_id CHARACTER VARYING(200) NOT NULL,
+  timetable_artifact_sha256 CHAR(64) NOT NULL,
+  canonical_pack_id CHARACTER VARYING(120) NOT NULL,
+  canonical_pack_sha256 CHAR(64) NOT NULL,
+  canonical_pack_sqlite_sha256 CHAR(64) NOT NULL,
+  admission_status CHARACTER VARYING(20) NOT NULL,
+  admission_eligible BOOL NOT NULL,
+  fresh_until CHARACTER VARYING(40),
+  source_issue INT NOT NULL,
+  CONSTRAINT h2_route_service_class CHECK (service_class = 'ITX_CHEONGCHUN'),
+  CONSTRAINT h2_route_service_timetable_hash CHECK (LENGTH(timetable_artifact_sha256) = 64),
+  CONSTRAINT h2_route_service_pack_hash CHECK (LENGTH(canonical_pack_sha256) = 64),
+  CONSTRAINT h2_route_service_pack_sqlite_hash CHECK (LENGTH(canonical_pack_sqlite_sha256) = 64),
+  CONSTRAINT h2_route_service_admission CHECK (
+    (admission_status = 'ADMITTED' AND admission_eligible = TRUE AND fresh_until IS NOT NULL)
+    OR (admission_status = 'MISSING' AND admission_eligible = FALSE)
+  ),
+  CONSTRAINT h2_route_service_source_issue CHECK (source_issue = 2116)
+);
+
+CREATE INDEX idx_transit_trips_service_class ON transit_trips(service_class);

--- a/backend/src/main/resources/db/migration/h2/V50__route_service_identity.sql
+++ b/backend/src/main/resources/db/migration/h2/V50__route_service_identity.sql
@@ -5,18 +5,18 @@ ALTER TABLE transit_trips ADD CONSTRAINT h2_transit_trips_service_class
 CREATE TABLE route_service_artifact_evidence (
   service_class CHARACTER VARYING(40) PRIMARY KEY NOT NULL,
   timetable_artifact_id CHARACTER VARYING(200) NOT NULL,
-  timetable_artifact_sha256 CHAR(64) NOT NULL,
+  timetable_artifact_sha256 CHARACTER VARYING(64) NOT NULL,
   canonical_pack_id CHARACTER VARYING(120) NOT NULL,
-  canonical_pack_sha256 CHAR(64) NOT NULL,
-  canonical_pack_sqlite_sha256 CHAR(64) NOT NULL,
+  canonical_pack_sha256 CHARACTER VARYING(64) NOT NULL,
+  canonical_pack_sqlite_sha256 CHARACTER VARYING(64) NOT NULL,
   admission_status CHARACTER VARYING(20) NOT NULL,
   admission_eligible BOOL NOT NULL,
   fresh_until CHARACTER VARYING(40),
   source_issue INT NOT NULL,
   CONSTRAINT h2_route_service_class CHECK (service_class = 'ITX_CHEONGCHUN'),
-  CONSTRAINT h2_route_service_timetable_hash CHECK (LENGTH(timetable_artifact_sha256) = 64),
-  CONSTRAINT h2_route_service_pack_hash CHECK (LENGTH(canonical_pack_sha256) = 64),
-  CONSTRAINT h2_route_service_pack_sqlite_hash CHECK (LENGTH(canonical_pack_sqlite_sha256) = 64),
+  CONSTRAINT h2_route_service_timetable_hash CHECK (REGEXP_LIKE(timetable_artifact_sha256, '^[0-9a-f]{64}$')),
+  CONSTRAINT h2_route_service_pack_hash CHECK (REGEXP_LIKE(canonical_pack_sha256, '^[0-9a-f]{64}$')),
+  CONSTRAINT h2_route_service_pack_sqlite_hash CHECK (REGEXP_LIKE(canonical_pack_sqlite_sha256, '^[0-9a-f]{64}$')),
   CONSTRAINT h2_route_service_admission CHECK (
     (admission_status = 'ADMITTED' AND admission_eligible = TRUE AND fresh_until IS NOT NULL)
     OR (admission_status = 'MISSING' AND admission_eligible = FALSE)

--- a/backend/src/main/resources/db/migration/postgresql/V50__route_service_identity.sql
+++ b/backend/src/main/resources/db/migration/postgresql/V50__route_service_identity.sql
@@ -5,18 +5,18 @@ ALTER TABLE transit_trips ADD CONSTRAINT chk_transit_trips_service_class
 CREATE TABLE route_service_artifact_evidence (
   service_class VARCHAR(40) NOT NULL PRIMARY KEY,
   timetable_artifact_id VARCHAR(200) NOT NULL,
-  timetable_artifact_sha256 CHAR(64) NOT NULL,
+  timetable_artifact_sha256 VARCHAR(64) NOT NULL,
   canonical_pack_id VARCHAR(120) NOT NULL,
-  canonical_pack_sha256 CHAR(64) NOT NULL,
-  canonical_pack_sqlite_sha256 CHAR(64) NOT NULL,
+  canonical_pack_sha256 VARCHAR(64) NOT NULL,
+  canonical_pack_sqlite_sha256 VARCHAR(64) NOT NULL,
   admission_status VARCHAR(20) NOT NULL,
   admission_eligible BOOLEAN NOT NULL,
   fresh_until VARCHAR(40),
   source_issue INTEGER NOT NULL,
   CONSTRAINT chk_route_service_class CHECK (service_class = 'ITX_CHEONGCHUN'),
-  CONSTRAINT chk_route_service_timetable_hash CHECK (LENGTH(timetable_artifact_sha256) = 64),
-  CONSTRAINT chk_route_service_pack_hash CHECK (LENGTH(canonical_pack_sha256) = 64),
-  CONSTRAINT chk_route_service_pack_sqlite_hash CHECK (LENGTH(canonical_pack_sqlite_sha256) = 64),
+  CONSTRAINT chk_route_service_timetable_hash CHECK (timetable_artifact_sha256 ~ '^[0-9a-f]{64}$'),
+  CONSTRAINT chk_route_service_pack_hash CHECK (canonical_pack_sha256 ~ '^[0-9a-f]{64}$'),
+  CONSTRAINT chk_route_service_pack_sqlite_hash CHECK (canonical_pack_sqlite_sha256 ~ '^[0-9a-f]{64}$'),
   CONSTRAINT chk_route_service_admission CHECK (
     (admission_status = 'ADMITTED' AND admission_eligible = TRUE AND fresh_until IS NOT NULL)
     OR (admission_status = 'MISSING' AND admission_eligible = FALSE)

--- a/backend/src/main/resources/db/migration/postgresql/V50__route_service_identity.sql
+++ b/backend/src/main/resources/db/migration/postgresql/V50__route_service_identity.sql
@@ -1,0 +1,27 @@
+ALTER TABLE transit_trips ADD COLUMN service_class VARCHAR(40) NOT NULL DEFAULT 'SUBWAY';
+ALTER TABLE transit_trips ADD CONSTRAINT chk_transit_trips_service_class
+  CHECK (service_class IN ('SUBWAY', 'ITX_CHEONGCHUN'));
+
+CREATE TABLE route_service_artifact_evidence (
+  service_class VARCHAR(40) NOT NULL PRIMARY KEY,
+  timetable_artifact_id VARCHAR(200) NOT NULL,
+  timetable_artifact_sha256 CHAR(64) NOT NULL,
+  canonical_pack_id VARCHAR(120) NOT NULL,
+  canonical_pack_sha256 CHAR(64) NOT NULL,
+  canonical_pack_sqlite_sha256 CHAR(64) NOT NULL,
+  admission_status VARCHAR(20) NOT NULL,
+  admission_eligible BOOLEAN NOT NULL,
+  fresh_until VARCHAR(40),
+  source_issue INTEGER NOT NULL,
+  CONSTRAINT chk_route_service_class CHECK (service_class = 'ITX_CHEONGCHUN'),
+  CONSTRAINT chk_route_service_timetable_hash CHECK (LENGTH(timetable_artifact_sha256) = 64),
+  CONSTRAINT chk_route_service_pack_hash CHECK (LENGTH(canonical_pack_sha256) = 64),
+  CONSTRAINT chk_route_service_pack_sqlite_hash CHECK (LENGTH(canonical_pack_sqlite_sha256) = 64),
+  CONSTRAINT chk_route_service_admission CHECK (
+    (admission_status = 'ADMITTED' AND admission_eligible = TRUE AND fresh_until IS NOT NULL)
+    OR (admission_status = 'MISSING' AND admission_eligible = FALSE)
+  ),
+  CONSTRAINT chk_route_service_source_issue CHECK (source_issue = 2116)
+);
+
+CREATE INDEX idx_transit_trips_service_class ON transit_trips(service_class);

--- a/backend/src/main/resources/db/migration/postgresql/V50__route_service_identity.sql
+++ b/backend/src/main/resources/db/migration/postgresql/V50__route_service_identity.sql
@@ -1,6 +1,7 @@
 ALTER TABLE transit_trips ADD COLUMN service_class VARCHAR(40) NOT NULL DEFAULT 'SUBWAY';
 ALTER TABLE transit_trips ADD CONSTRAINT chk_transit_trips_service_class
-  CHECK (service_class IN ('SUBWAY', 'ITX_CHEONGCHUN'));
+  CHECK (service_class IN ('SUBWAY', 'ITX_CHEONGCHUN')) NOT VALID;
+ALTER TABLE transit_trips VALIDATE CONSTRAINT chk_transit_trips_service_class;
 
 CREATE TABLE route_service_artifact_evidence (
   service_class VARCHAR(40) NOT NULL PRIMARY KEY,

--- a/backend/src/test/java/com/easysubway/common/persistence/DatabaseMigrationContainerTest.java
+++ b/backend/src/test/java/com/easysubway/common/persistence/DatabaseMigrationContainerTest.java
@@ -120,6 +120,7 @@ class DatabaseMigrationContainerTest {
 		assertManualOverrideProductionGuards(jdbcTemplate);
 		assertRouteEdgeEvidenceStrictRouteGuards(jdbcTemplate);
 		assertDatapackPermissionMatrix(jdbcTemplate);
+		assertRouteServiceIdentityHashGuards(jdbcTemplate);
 	}
 
 	@Test
@@ -851,5 +852,31 @@ class DatabaseMigrationContainerTest {
 			strictRouteEligible,
 			blockerReason
 		);
+	}
+
+	private void assertRouteServiceIdentityHashGuards(JdbcTemplate jdbcTemplate) {
+		String validHash = "a".repeat(64);
+		assertThatThrownBy(() -> insertRouteServiceIdentity(jdbcTemplate, "short", validHash, validHash))
+			.isInstanceOf(DataAccessException.class);
+		assertThatThrownBy(() -> insertRouteServiceIdentity(
+			jdbcTemplate, "g".repeat(64), validHash, validHash))
+			.isInstanceOf(DataAccessException.class);
+	}
+
+	private void insertRouteServiceIdentity(
+		JdbcTemplate jdbcTemplate,
+		String timetableHash,
+		String canonicalPackHash,
+		String canonicalPackSqliteHash
+	) {
+		jdbcTemplate.update("""
+			INSERT INTO route_service_artifact_evidence (
+				service_class, timetable_artifact_id, timetable_artifact_sha256,
+				canonical_pack_id, canonical_pack_sha256, canonical_pack_sqlite_sha256,
+				admission_status, admission_eligible, fresh_until, source_issue
+			)
+			VALUES ('ITX_CHEONGCHUN', 'invalid-hash-test', ?, 'capital', ?, ?,
+				'MISSING', FALSE, NULL, 2116)
+			""", timetableHash, canonicalPackHash, canonicalPackSqliteHash);
 	}
 }

--- a/backend/src/test/java/com/easysubway/common/persistence/DatabaseMigrationContainerTest.java
+++ b/backend/src/test/java/com/easysubway/common/persistence/DatabaseMigrationContainerTest.java
@@ -245,6 +245,23 @@ class DatabaseMigrationContainerTest {
 	}
 
 	@Test
+	@DisplayName("H2 migration도 route service artifact hash 형식을 차단한다")
+	void h2MigrationRejectsUnsafeRouteServiceIdentityHashes() {
+		var dataSource = new DriverManagerDataSource(
+			"jdbc:h2:mem:route-service-identity-hashes;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+			"sa",
+			""
+		);
+		Flyway.configure()
+			.dataSource(dataSource)
+			.locations("classpath:db/migration/h2")
+			.load()
+			.migrate();
+
+		assertRouteServiceIdentityHashGuards(new JdbcTemplate(dataSource));
+	}
+
+	@Test
 	@DisplayName("H2 migration도 normalization run과 output ledger guard를 차단한다")
 	void h2MigrationRejectsUnsafeNormalizationRuns() {
 		var dataSource = new DriverManagerDataSource(
@@ -860,6 +877,16 @@ class DatabaseMigrationContainerTest {
 			.isInstanceOf(DataAccessException.class);
 		assertThatThrownBy(() -> insertRouteServiceIdentity(
 			jdbcTemplate, "g".repeat(64), validHash, validHash))
+			.isInstanceOf(DataAccessException.class);
+		assertThatThrownBy(() -> insertRouteServiceIdentity(jdbcTemplate, validHash, "short", validHash))
+			.isInstanceOf(DataAccessException.class);
+		assertThatThrownBy(() -> insertRouteServiceIdentity(
+			jdbcTemplate, validHash, "g".repeat(64), validHash))
+			.isInstanceOf(DataAccessException.class);
+		assertThatThrownBy(() -> insertRouteServiceIdentity(jdbcTemplate, validHash, validHash, "short"))
+			.isInstanceOf(DataAccessException.class);
+		assertThatThrownBy(() -> insertRouteServiceIdentity(
+			jdbcTemplate, validHash, validHash, "g".repeat(64)))
 			.isInstanceOf(DataAccessException.class);
 	}
 

--- a/backend/src/test/java/com/easysubway/route/adapter/out/persistence/JdbcRouteTimetableRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/out/persistence/JdbcRouteTimetableRepositoryTest.java
@@ -26,6 +26,7 @@ class JdbcRouteTimetableRepositoryTest {
 		jdbcTemplate.execute("DROP ALL OBJECTS");
 		jdbcTemplate.execute("RUNSCRIPT FROM 'src/main/resources/db/migration/h2/V29__canonical_transit_schedule.sql'");
 		jdbcTemplate.execute("RUNSCRIPT FROM 'src/main/resources/db/migration/h2/V37__transit_feed_info.sql'");
+		jdbcTemplate.execute("RUNSCRIPT FROM 'src/main/resources/db/migration/h2/V50__route_service_identity.sql'");
 		repository = new JdbcRouteTimetableRepository(jdbcTemplate);
 	}
 
@@ -55,6 +56,36 @@ class JdbcRouteTimetableRepositoryTest {
 		insertTimetableRows();
 
 		assertThat(repository.hasRouteTimetable()).isTrue();
+	}
+
+	@Test
+	@DisplayName("만료된 ITX admission은 요청 시점 snapshot과 availability에서 제외한다")
+	void excludesExpiredItxRowsAtRequestTime() {
+		insertTimetableRows();
+		insertItxRows("2000-01-01T00:00:00Z");
+
+		var timetable = repository.loadRouteTimetable();
+
+		assertThat(repository.hasRouteTimetable()).isTrue();
+		assertThat(timetable.transitTrips()).extracting("id").containsExactly("trip-seoul-4-0900");
+		assertThat(timetable.transitStopTimes()).extracting("tripId").containsOnly("trip-seoul-4-0900");
+		assertThat(repository.timetableCacheKey()).isEqualTo("SUBWAY_ONLY");
+	}
+
+	@Test
+	@DisplayName("ITX admission freshness 상태가 바뀌면 timetable cache key도 바뀐다")
+	void changesCacheKeyWhenItxAdmissionExpires() {
+		insertItxRows("2999-01-01T00:00:00Z");
+		String freshKey = repository.timetableCacheKey();
+
+		jdbcTemplate.update("""
+			UPDATE route_service_artifact_evidence
+			SET fresh_until = '2000-01-01T00:00:00Z'
+			WHERE service_class = 'ITX_CHEONGCHUN'
+			""");
+
+		assertThat(freshKey).startsWith("ITX_CHEONGCHUN:");
+		assertThat(repository.timetableCacheKey()).isEqualTo("SUBWAY_ONLY");
 	}
 
 	@Test
@@ -118,5 +149,39 @@ class JdbcRouteTimetableRepositoryTest {
 			INSERT INTO transit_frequencies (trip_id, start_time_seconds, headway_seconds, end_time_seconds, exact_times)
 			VALUES ('trip-seoul-4-0900', 32400, 600, 36000, FALSE)
 			""");
+	}
+
+	private void insertItxRows(String freshUntil) {
+		jdbcTemplate.update("""
+			INSERT INTO service_calendars (
+				service_id, start_date, end_date, timezone,
+				monday, tuesday, wednesday, thursday, friday, saturday, sunday
+			) VALUES ('itx-weekday', '20260701', '20991231', 'Asia/Seoul', TRUE, TRUE, TRUE, TRUE, TRUE, FALSE, FALSE)
+			""");
+		jdbcTemplate.update("""
+			INSERT INTO transit_routes (id, timezone, line_id, route_short_name, route_long_name, direction_name)
+			VALUES ('route-itx', 'Asia/Seoul', 'line-k2', 'ITX-청춘', '청량리-춘천', '춘천 방면')
+			""");
+		jdbcTemplate.update("""
+			INSERT INTO transit_trips (
+				id, route_id, service_id, service_pattern, service_class,
+				service_day_start_seconds, trip_headsign, direction_id
+			) VALUES ('trip-itx', 'route-itx', 'itx-weekday', 'EXPRESS', 'ITX_CHEONGCHUN', 0, '춘천', 'down')
+			""");
+		jdbcTemplate.update("""
+			INSERT INTO transit_stop_times (
+				trip_id, stop_sequence, station_id, line_id,
+				pickup_type, drop_off_type, arrival_seconds, departure_seconds
+			) VALUES
+				('trip-itx', 1, 'station-cheongnyangni', 'line-k2', 0, 0, 32400, 32400),
+				('trip-itx', 2, 'station-chuncheon', 'line-k2', 0, 0, 36000, 36000)
+			""");
+		jdbcTemplate.update("""
+			INSERT INTO route_service_artifact_evidence (
+				service_class, timetable_artifact_id, timetable_artifact_sha256,
+				canonical_pack_id, canonical_pack_sha256, canonical_pack_sqlite_sha256,
+				admission_status, admission_eligible, fresh_until, source_issue
+			) VALUES ('ITX_CHEONGCHUN', 'itx-test', ?, 'capital', ?, ?, 'ADMITTED', TRUE, ?, 2116)
+			""", "a".repeat(64), "b".repeat(64), "c".repeat(64), freshUntil);
 	}
 }

--- a/backend/src/test/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoaderTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoaderTest.java
@@ -157,6 +157,16 @@ class TimetableSeedLoaderTest {
 			"SELECT COUNT(*) FROM transit_trips WHERE service_class = 'ITX_CHEONGCHUN'", Integer.class)).isZero();
 	}
 
+	@Test
+	void doesNotTreatMissingEvidenceOnlySeedAsAdditiveItxTrips() {
+		loader(new ClassPathResource("timetable/test-line4-seed.sql")).run(null);
+
+		loader(missingItxEvidenceOnlySeed()).run(null);
+
+		assertThat(jdbc.queryForObject(
+			"SELECT COUNT(*) FROM transit_trips WHERE service_class = 'ITX_CHEONGCHUN'", Integer.class)).isZero();
+	}
+
 	private Resource itxSeed(String admissionStatus, boolean admissionEligible, String freshUntil) {
 		return new ByteArrayResource((
 			"INSERT INTO service_calendars (service_id, start_date, end_date, timezone, monday, tuesday, wednesday, thursday, friday, saturday, sunday) VALUES ('itx-weekday','20260714','20260721','Asia/Seoul',TRUE,TRUE,TRUE,TRUE,TRUE,FALSE,FALSE);\n"
@@ -169,6 +179,17 @@ class TimetableSeedLoaderTest {
 			@Override
 			public String getFilename() {
 				return "itx-seed.sql";
+			}
+		};
+	}
+
+	private Resource missingItxEvidenceOnlySeed() {
+		return new ByteArrayResource((
+			"INSERT INTO route_service_artifact_evidence (service_class, timetable_artifact_id, timetable_artifact_sha256, canonical_pack_id, canonical_pack_sha256, canonical_pack_sqlite_sha256, admission_status, admission_eligible, fresh_until, source_issue) VALUES ('ITX_CHEONGCHUN','missing-itx','aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa','capital','bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb','cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc','MISSING',FALSE,NULL,2116);\n"
+		).getBytes()) {
+			@Override
+			public String getFilename() {
+				return "missing-itx-evidence-only-seed.sql";
 			}
 		};
 	}

--- a/backend/src/test/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoaderTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoaderTest.java
@@ -130,7 +130,7 @@ class TimetableSeedLoaderTest {
 	@Test
 	void acceptsFreshAdmittedItxIdentity() {
 		String freshUntil = OffsetDateTime.now().plusDays(1).toString();
-		loader(itxSeed("ADMITTED", true, freshUntil)).run(null);
+		loader(itxSeed("ADMITTED", true, freshUntil), true).run(null);
 
 		assertThat(jdbc.queryForObject(
 			"SELECT service_class FROM transit_trips WHERE id = 'itx-1'", String.class))
@@ -138,6 +138,16 @@ class TimetableSeedLoaderTest {
 		assertThat(jdbc.queryForObject(
 			"SELECT canonical_pack_id FROM route_service_artifact_evidence", String.class))
 			.isEqualTo("capital");
+	}
+
+	@Test
+	void rejectsIncludesItxConfigurationWhenSeedContainsNoItxRowsAndRollsBack() {
+		var subwayOnlySeed = new ClassPathResource("timetable/test-line4-seed.sql");
+
+		assertThatThrownBy(() -> loader(subwayOnlySeed, true).run(null))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("includes-itx=true");
+		assertThat(jdbc.queryForObject("SELECT COUNT(*) FROM transit_trips", Integer.class)).isZero();
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoaderTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoaderTest.java
@@ -141,6 +141,24 @@ class TimetableSeedLoaderTest {
 	}
 
 	@Test
+	void rejectsItxSeedWhenIncludesItxConfigurationIsDisabled() {
+		assertThatThrownBy(() -> loader(itxSeed(
+			"ADMITTED", true, OffsetDateTime.now().plusDays(1).toString()), false).run(null))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("includes-itx");
+		assertThat(jdbc.queryForObject("SELECT COUNT(*) FROM transit_trips", Integer.class)).isZero();
+	}
+
+	@Test
+	void rejectsExistingItxWhenIncludesItxConfigurationIsDisabled() {
+		loader(itxSeed("ADMITTED", true, OffsetDateTime.now().plusDays(1).toString()), true).run(null);
+
+		assertThatThrownBy(() -> loader(new ClassPathResource("timetable/test-line4-seed.sql"), false).run(null))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("includes-itx");
+	}
+
+	@Test
 	void rejectsIncludesItxConfigurationWhenSeedContainsNoItxRowsAndRollsBack() {
 		var subwayOnlySeed = new ClassPathResource("timetable/test-line4-seed.sql");
 

--- a/backend/src/test/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoaderTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoaderTest.java
@@ -91,6 +91,40 @@ class TimetableSeedLoaderTest {
 	}
 
 	@Test
+	void refreshesItxAdmissionAfterCompetingItxSeedWon() {
+		String freshUntil = OffsetDateTime.now().plusDays(1).toString();
+		var racingPort = new com.easysubway.route.application.port.out.LoadRouteTimetablePort() {
+			private boolean seeded;
+
+			@Override
+			public boolean hasRouteTimetable() {
+				if (!seeded) {
+					seeded = true;
+					loader(itxSeed("ADMITTED", true, freshUntil), true).run(null);
+				}
+				return true;
+			}
+
+			@Override
+			public RouteTimetable loadRouteTimetable() {
+				return RouteTimetable.empty();
+			}
+		};
+		var loser = new TimetableSeedLoader(
+			racingPort,
+			dataSource,
+			new DataSourceTransactionManager(dataSource),
+			itxSeed("ADMITTED", true, freshUntil),
+			true
+		);
+
+		loser.run(null);
+
+		assertThat(jdbc.queryForObject(
+			"SELECT COUNT(*) FROM transit_trips WHERE service_class = 'ITX_CHEONGCHUN'", Integer.class)).isOne();
+	}
+
+	@Test
 	void rollsBackOnMidScriptFailureLeavingNoPartialData() {
 		// trips 성공 후 stop_times FK 위반으로 실패 → all-or-nothing 롤백(부분 적재 없음).
 		var bad = new ByteArrayResource((

--- a/backend/src/test/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoaderTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoaderTest.java
@@ -3,6 +3,7 @@ package com.easysubway.route.adapter.out.persistence;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.time.OffsetDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.io.ByteArrayResource;
@@ -25,6 +26,7 @@ class TimetableSeedLoaderTest {
 		jdbc.execute("DROP ALL OBJECTS");
 		jdbc.execute("RUNSCRIPT FROM 'src/main/resources/db/migration/h2/V29__canonical_transit_schedule.sql'");
 		jdbc.execute("RUNSCRIPT FROM 'src/main/resources/db/migration/h2/V37__transit_feed_info.sql'");
+		jdbc.execute("RUNSCRIPT FROM 'src/main/resources/db/migration/h2/V50__route_service_identity.sql'");
 	}
 
 	private TimetableSeedLoader loader(Resource seed) {
@@ -97,5 +99,53 @@ class TimetableSeedLoaderTest {
 		};
 		assertThatThrownBy(() -> loader(bad).run(null)).isInstanceOf(RuntimeException.class);
 		assertThat(jdbc.queryForObject("SELECT COUNT(*) FROM transit_trips", Integer.class)).isZero();
+	}
+
+	@Test
+	void rejectsItxRowsWithoutAdmittedIdentityAndRollsBack() {
+		var seed = itxSeed("MISSING", false, "2026-07-21T00:00:00.000Z");
+
+		assertThatThrownBy(() -> loader(seed).run(null))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("ITX-청춘 timetable seed requires ADMITTED evidence");
+		assertThat(jdbc.queryForObject("SELECT COUNT(*) FROM transit_trips", Integer.class)).isZero();
+		assertThat(jdbc.queryForObject("SELECT COUNT(*) FROM route_service_artifact_evidence", Integer.class)).isZero();
+	}
+
+	@Test
+	void rejectsStaleAdmittedItxIdentityAndRollsBack() {
+		assertThatThrownBy(() -> loader(itxSeed("ADMITTED", true, "2000-01-01T00:00:00.000Z")).run(null))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("valid freshness");
+		assertThat(jdbc.queryForObject("SELECT COUNT(*) FROM transit_trips", Integer.class)).isZero();
+	}
+
+	@Test
+	void acceptsFreshAdmittedItxIdentity() {
+		String freshUntil = OffsetDateTime.now().plusDays(1).toString();
+		loader(itxSeed("ADMITTED", true, freshUntil)).run(null);
+
+		assertThat(jdbc.queryForObject(
+			"SELECT service_class FROM transit_trips WHERE id = 'itx-1'", String.class))
+			.isEqualTo("ITX_CHEONGCHUN");
+		assertThat(jdbc.queryForObject(
+			"SELECT canonical_pack_id FROM route_service_artifact_evidence", String.class))
+			.isEqualTo("capital");
+	}
+
+	private Resource itxSeed(String admissionStatus, boolean admissionEligible, String freshUntil) {
+		return new ByteArrayResource((
+			"INSERT INTO service_calendars (service_id, start_date, end_date, timezone, monday, tuesday, wednesday, thursday, friday, saturday, sunday) VALUES ('itx-weekday','20260714','20260721','Asia/Seoul',TRUE,TRUE,TRUE,TRUE,TRUE,FALSE,FALSE);\n"
+			+ "INSERT INTO transit_routes (id, timezone, line_id, route_short_name, route_long_name, direction_name) VALUES ('itx-down','Asia/Seoul','line-54a7b980b7c3','ITX-청춘','','down');\n"
+			+ "INSERT INTO route_service_artifact_evidence (service_class, timetable_artifact_id, timetable_artifact_sha256, canonical_pack_id, canonical_pack_sha256, canonical_pack_sqlite_sha256, admission_status, admission_eligible, fresh_until, source_issue) VALUES ('ITX_CHEONGCHUN','test-only-itx','aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa','capital','bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb','cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc','"
+			+ admissionStatus + "'," + admissionEligible + ",'" + freshUntil + "',2116);\n"
+			+ "INSERT INTO transit_trips (id, route_id, service_id, service_pattern, service_class, service_day_start_seconds, trip_headsign, direction_id) VALUES ('itx-1','itx-down','itx-weekday','EXPRESS','ITX_CHEONGCHUN',0,'춘천','down');\n"
+			+ "INSERT INTO transit_stop_times (trip_id, stop_sequence, station_id, line_id, pickup_type, drop_off_type, arrival_seconds, departure_seconds) VALUES ('itx-1',1,'station-b819702fa7d9','line-54a7b980b7c3',0,0,28800,28860);\n"
+		).getBytes()) {
+			@Override
+			public String getFilename() {
+				return "itx-seed.sql";
+			}
+		};
 	}
 }

--- a/backend/src/test/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoaderTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoaderTest.java
@@ -3,6 +3,8 @@ package com.easysubway.route.adapter.out.persistence;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.time.OffsetDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,11 +32,16 @@ class TimetableSeedLoaderTest {
 	}
 
 	private TimetableSeedLoader loader(Resource seed) {
+		return loader(seed, false);
+	}
+
+	private TimetableSeedLoader loader(Resource seed, boolean includesItx) {
 		return new TimetableSeedLoader(
 			new JdbcRouteTimetableRepository(dataSource),
 			dataSource,
 			new DataSourceTransactionManager(dataSource),
-			seed);
+			seed,
+			includesItx);
 	}
 
 	@Test
@@ -77,7 +84,7 @@ class TimetableSeedLoaderTest {
 			}
 		};
 		var loser = new TimetableSeedLoader(
-			racingPort, dataSource, new DataSourceTransactionManager(dataSource), seed);
+			racingPort, dataSource, new DataSourceTransactionManager(dataSource), seed, false);
 		loser.run(null); // 예외 없이 반환해야 한다.
 
 		assertThat(jdbc.queryForObject("SELECT COUNT(*) FROM transit_stop_times", Integer.class)).isEqualTo(2);
@@ -135,12 +142,12 @@ class TimetableSeedLoaderTest {
 
 	@Test
 	void rejectsExpiredExistingItxIdentityOnRestart() {
-		loader(itxSeed("ADMITTED", true, OffsetDateTime.now().plusDays(1).toString())).run(null);
+		loader(itxSeed("ADMITTED", true, OffsetDateTime.now().plusDays(1).toString()), true).run(null);
 		jdbc.update(
 			"UPDATE route_service_artifact_evidence SET fresh_until = '2000-01-01T00:00:00.000Z' WHERE service_class = 'ITX_CHEONGCHUN'");
 
 		assertThatThrownBy(() -> loader(itxSeed(
-			"ADMITTED", true, OffsetDateTime.now().plusDays(1).toString())).run(null))
+			"ADMITTED", true, OffsetDateTime.now().plusDays(1).toString()), true).run(null))
 			.isInstanceOf(IllegalStateException.class)
 			.hasMessageContaining("valid freshness");
 	}
@@ -150,7 +157,7 @@ class TimetableSeedLoaderTest {
 		loader(new ClassPathResource("timetable/test-line4-seed.sql")).run(null);
 
 		assertThatThrownBy(() -> loader(itxSeed(
-			"ADMITTED", true, OffsetDateTime.now().plusDays(1).toString())).run(null))
+			"ADMITTED", true, OffsetDateTime.now().plusDays(1).toString()), true).run(null))
 			.isInstanceOf(IllegalStateException.class)
 			.hasMessageContaining("additive ITX timetable seed is not supported");
 		assertThat(jdbc.queryForObject(
@@ -165,6 +172,21 @@ class TimetableSeedLoaderTest {
 
 		assertThat(jdbc.queryForObject(
 			"SELECT COUNT(*) FROM transit_trips WHERE service_class = 'ITX_CHEONGCHUN'", Integer.class)).isZero();
+	}
+
+	@Test
+	void skipsUnavailableExternalSeedResourceWhenTimetableAlreadyExists() {
+		loader(new ClassPathResource("timetable/test-line4-seed.sql")).run(null);
+		var unavailable = new ByteArrayResource(new byte[0]) {
+			@Override
+			public InputStream getInputStream() throws IOException {
+				throw new IOException("external seed mount unavailable");
+			}
+		};
+
+		loader(unavailable).run(null);
+
+		assertThat(jdbc.queryForObject("SELECT COUNT(*) FROM transit_stop_times", Integer.class)).isEqualTo(2);
 	}
 
 	private Resource itxSeed(String admissionStatus, boolean admissionEligible, String freshUntil) {

--- a/backend/src/test/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoaderTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoaderTest.java
@@ -133,6 +133,30 @@ class TimetableSeedLoaderTest {
 			.isEqualTo("capital");
 	}
 
+	@Test
+	void rejectsExpiredExistingItxIdentityOnRestart() {
+		loader(itxSeed("ADMITTED", true, OffsetDateTime.now().plusDays(1).toString())).run(null);
+		jdbc.update(
+			"UPDATE route_service_artifact_evidence SET fresh_until = '2000-01-01T00:00:00.000Z' WHERE service_class = 'ITX_CHEONGCHUN'");
+
+		assertThatThrownBy(() -> loader(itxSeed(
+			"ADMITTED", true, OffsetDateTime.now().plusDays(1).toString())).run(null))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("valid freshness");
+	}
+
+	@Test
+	void rejectsAdditiveItxSeedWhenSubwayTimetableAlreadyExists() {
+		loader(new ClassPathResource("timetable/test-line4-seed.sql")).run(null);
+
+		assertThatThrownBy(() -> loader(itxSeed(
+			"ADMITTED", true, OffsetDateTime.now().plusDays(1).toString())).run(null))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("additive ITX timetable seed is not supported");
+		assertThat(jdbc.queryForObject(
+			"SELECT COUNT(*) FROM transit_trips WHERE service_class = 'ITX_CHEONGCHUN'", Integer.class)).isZero();
+	}
+
 	private Resource itxSeed(String admissionStatus, boolean admissionEligible, String freshUntil) {
 		return new ByteArrayResource((
 			"INSERT INTO service_calendars (service_id, start_date, end_date, timezone, monday, tuesday, wednesday, thursday, friday, saturday, sunday) VALUES ('itx-weekday','20260714','20260721','Asia/Seoul',TRUE,TRUE,TRUE,TRUE,TRUE,FALSE,FALSE);\n"

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -1549,6 +1549,21 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("V2 planner는 timetable cache key 변경 시 snapshot을 다시 읽는다")
+	void routeV2PlannerReloadsTimetableWhenCacheKeyChanges() {
+		var repository = new InMemoryRouteSearchRepository();
+		var routeSearchService = new RouteSearchService(repository, repository, new RampAccessibleTransitMasterPort(), CLOCK);
+		var timetablePort = new CountingRouteTimetablePort();
+		var planner = new RouteV2Planner(routeSearchService, timetablePort);
+
+		planner.search(routeV2Command(ConstraintMode.PREFER_STEP_FREE, MobilityType.SENIOR, 1, 3));
+		timetablePort.expireItxAdmission();
+		planner.search(routeV2Command(ConstraintMode.PREFER_STEP_FREE, MobilityType.SENIOR, 1, 3));
+
+		assertThat(timetablePort.loadCount()).isEqualTo(2);
+	}
+
+	@Test
 	@DisplayName("V2 planner는 접근성 차단 경로를 BLOCKED_ACCESSIBILITY status로 반환한다")
 	void routeV2PlannerReturnsBlockedAccessibilityStatus() {
 		var planner = routeV2Planner(new StairOnlyTransitMasterPort());
@@ -3015,6 +3030,7 @@ class RouteSearchServiceTest {
 
 	private static class CountingRouteTimetablePort implements LoadRouteTimetablePort {
 		private int loadCount;
+		private String cacheKey = "ITX_CHEONGCHUN:2999-01-01T00:00:00Z";
 
 		@Override
 		public boolean hasRouteTimetable() {
@@ -3025,6 +3041,15 @@ class RouteSearchServiceTest {
 		public LoadRouteTimetablePort.RouteTimetable loadRouteTimetable() {
 			loadCount += 1;
 			return routeTimetablePort().loadRouteTimetable();
+		}
+
+		@Override
+		public String timetableCacheKey() {
+			return cacheKey;
+		}
+
+		void expireItxAdmission() {
+			cacheKey = "SUBWAY_ONLY";
 		}
 
 		int loadCount() {

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerGoldenOdTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerGoldenOdTest.java
@@ -58,6 +58,7 @@ class RouteTimetableRaptorPlannerGoldenOdTest {
 		jdbc.execute("DROP ALL OBJECTS");
 		jdbc.execute("RUNSCRIPT FROM 'src/main/resources/db/migration/h2/V29__canonical_transit_schedule.sql'");
 		jdbc.execute("RUNSCRIPT FROM 'src/main/resources/db/migration/h2/V37__transit_feed_info.sql'");
+		jdbc.execute("RUNSCRIPT FROM 'src/main/resources/db/migration/h2/V50__route_service_identity.sql'");
 		jdbc.execute("RUNSCRIPT FROM 'src/test/resources/timetable/line4-corridor-slice-seed.sql'");
 		timetable = new JdbcRouteTimetableRepository(dataSource).loadRouteTimetable();
 	}

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerLine4PlannedTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerLine4PlannedTest.java
@@ -42,6 +42,7 @@ class RouteTimetableRaptorPlannerLine4PlannedTest {
 		jdbc.execute("DROP ALL OBJECTS");
 		jdbc.execute("RUNSCRIPT FROM 'src/main/resources/db/migration/h2/V29__canonical_transit_schedule.sql'");
 		jdbc.execute("RUNSCRIPT FROM 'src/main/resources/db/migration/h2/V37__transit_feed_info.sql'");
+		jdbc.execute("RUNSCRIPT FROM 'src/main/resources/db/migration/h2/V50__route_service_identity.sql'");
 		jdbc.execute("RUNSCRIPT FROM 'src/test/resources/timetable/line4-corridor-slice-seed.sql'");
 		timetable = new JdbcRouteTimetableRepository(dataSource).loadRouteTimetable();
 	}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -5414,7 +5414,7 @@ test("데이터팩 도구는 앱 manifest 계약과 SQLite 검증 계약을 고�
     "workflowRunUrl",
   ]);
   assert.match(schema, /CREATE TABLE catalog_metadata/);
-  assert.match(schema, /PRAGMA user_version = 16/);
+  assert.match(schema, /PRAGMA user_version = 18/);
   assert.match(schema, /CREATE TABLE stations/);
   assert.match(schema, /CREATE TABLE transit_feed_info/);
   assert.match(schema, /CREATE TABLE station_facility_evidence/);
@@ -6599,7 +6599,7 @@ test("production row provenance는 snapshot/provider/evidence hash gate를 유�
   assert.match(mobileTables, /class FareZones extends Table/);
   assert.match(mobileTables, /class StationFareZones extends Table/);
   assert.match(mobileTables, /class FacilityStatusSnapshots extends Table/);
-  assert.match(mobileDatabase, /const catalogDatabaseSchemaVersion = 17/);
+  assert.match(mobileDatabase, /const catalogDatabaseSchemaVersion = 18/);
   assert.match(mobileDatabase, /int get schemaVersion => catalogDatabaseSchemaVersion/);
   assert.match(mobileDatabase, /_createTransitScheduleIndexes/);
   assert.match(mobileDatabase, /_createStationPathwayIndexes/);
@@ -6615,7 +6615,7 @@ test("production row provenance는 snapshot/provider/evidence hash gate를 유�
   assert.match(mobileTables, /class StationFacilityEvidence extends Table/);
   assert.match(mobileTables, /sourceSnapshotId[\s\S]+source_snapshot_id/);
   assert.match(mobileTables, /providerRecordHash[\s\S]+provider_record_hash/);
-  assert.match(mobileDatabase, /const catalogDatabaseSchemaVersion = 17/);
+  assert.match(mobileDatabase, /const catalogDatabaseSchemaVersion = 18/);
   assert.match(mobileDatabase, /int get schemaVersion => catalogDatabaseSchemaVersion/);
   assert.match(mobileDatabase, /StationFacilityEvidence/);
   assert.match(mobileDatabase, /FacilityStatusSnapshots/);

--- a/tools/datapack/apply-car-door-hints-to-bundled-pack.mjs
+++ b/tools/datapack/apply-car-door-hints-to-bundled-pack.mjs
@@ -118,6 +118,7 @@ function applyHints(sqlitePath, hints) {
   const canonical = canonicalHints(hints);
   const database = new DatabaseSync(sqlitePath);
   try {
+    rejectNewerCatalogVersion(database);
     database.exec("PRAGMA foreign_keys = ON");
     ensureSchema(database);
     if (JSON.stringify(storedHints(database)) === JSON.stringify(canonical)) {
@@ -150,6 +151,15 @@ function applyHints(sqlitePath, hints) {
     assertIntegrity(database);
   } finally {
     database.close();
+  }
+}
+
+function rejectNewerCatalogVersion(database) {
+  const current = database.prepare("PRAGMA user_version").get().user_version;
+  if (current > BUNDLED_CATALOG_USER_VERSION) {
+    throw new Error(
+      `car door hint postprocessor does not support catalog user_version ${current} newer than ${BUNDLED_CATALOG_USER_VERSION}`,
+    );
   }
 }
 

--- a/tools/datapack/apply-official-od-fares-to-bundled-pack.mjs
+++ b/tools/datapack/apply-official-od-fares-to-bundled-pack.mjs
@@ -60,6 +60,7 @@ function validateQuotes(document, admissions) {
 function applyQuotes(sqlitePath, quotes) {
   const database = new DatabaseSync(sqlitePath);
   try {
+    rejectNewerCatalogVersion(database);
     database.exec("PRAGMA foreign_keys = ON");
     database.exec(`
       CREATE TABLE IF NOT EXISTS official_od_fare_quotes (
@@ -112,6 +113,15 @@ function applyQuotes(sqlitePath, quotes) {
     assertIntegrity(database);
   } finally {
     database.close();
+  }
+}
+
+function rejectNewerCatalogVersion(database) {
+  const current = database.prepare("PRAGMA user_version").get().user_version;
+  if (current > BUNDLED_CATALOG_USER_VERSION) {
+    throw new Error(
+      `official OD fare postprocessor does not support catalog user_version ${current} newer than ${BUNDLED_CATALOG_USER_VERSION}`,
+    );
   }
 }
 

--- a/tools/datapack/build-backend-timetable-seed.mjs
+++ b/tools/datapack/build-backend-timetable-seed.mjs
@@ -73,6 +73,7 @@ export function buildBackendTimetableSeed(artifact, options = {}) {
 
 const ALLOWED_SERVICE_PATTERNS = new Set(["LOCAL", "EXPRESS"]);
 const ALLOWED_SERVICE_CLASSES = new Set(["SUBWAY", "ITX_CHEONGCHUN"]);
+const OFFSET_ISO_8601 = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?(?:Z|[+-]\d{2}:\d{2})$/;
 
 // trip 행이 V29 제약(id PK 유일, service_pattern CHECK, service_day_start_seconds 범위)을 만족하는지
 // 생성 단계에서 검증한다(로드-시점 FK/CHECK 실패를 앞당김). trip id 집합을 stop_times FK 검증용으로 반환.
@@ -106,6 +107,14 @@ function validateRouteServiceEvidence(rows, trips, buildNow, timetableArtifactSh
   }
   const hasItxTrips = trips.some(({ serviceClass }) => serviceClass === "ITX_CHEONGCHUN");
   if (!hasItxTrips) {
+    const evidence = rows[0];
+    if (evidence && (
+      evidence.serviceClass !== "ITX_CHEONGCHUN"
+      || evidence.admissionStatus !== "MISSING"
+      || evidence.admissionEligible !== false
+    )) {
+      throw new Error("ADMITTED evidence requires ITX_CHEONGCHUN trips");
+    }
     return rows;
   }
   const evidence = rows[0];
@@ -115,6 +124,9 @@ function validateRouteServiceEvidence(rows, trips, buildNow, timetableArtifactSh
     || evidence.admissionEligible !== true
   ) {
     throw new Error("ITX_CHEONGCHUN seed requires ADMITTED route service evidence");
+  }
+  if (typeof evidence.freshUntil !== "string" || !OFFSET_ISO_8601.test(evidence.freshUntil)) {
+    throw new Error("ITX_CHEONGCHUN freshUntil must be offset ISO-8601");
   }
   const freshUntil = new Date(evidence.freshUntil);
   if (Number.isNaN(freshUntil.getTime()) || freshUntil <= buildNow) {

--- a/tools/datapack/build-backend-timetable-seed.mjs
+++ b/tools/datapack/build-backend-timetable-seed.mjs
@@ -47,12 +47,18 @@ export function buildBackendTimetableSeed(artifact, options = {}) {
 
   const tripIds = validateTrips(trips);
   validateStopTimes(stopTimes, tripIds);
+  const evidence = validateRouteServiceEvidence(
+    artifact?.routeServiceArtifactEvidence ?? [],
+    trips,
+    options.buildNow ?? new Date(),
+  );
 
   const calendars = deriveCalendars(trips, dayMap, startDate, endDate);
   const routes = deriveRoutes(trips, lineId);
 
   const statements = [
     feedInfoInsert(feedEndDate),
+    ...evidence.map(routeServiceEvidenceInsert),
     ...calendars.map(calendarInsert),
     ...routes.map(routeInsert),
     ...trips.map(tripInsert),
@@ -64,6 +70,7 @@ export function buildBackendTimetableSeed(artifact, options = {}) {
 }
 
 const ALLOWED_SERVICE_PATTERNS = new Set(["LOCAL", "EXPRESS"]);
+const ALLOWED_SERVICE_CLASSES = new Set(["SUBWAY", "ITX_CHEONGCHUN"]);
 
 // trip 행이 V29 제약(id PK 유일, service_pattern CHECK, service_day_start_seconds 범위)을 만족하는지
 // 생성 단계에서 검증한다(로드-시점 FK/CHECK 실패를 앞당김). trip id 집합을 stop_times FK 검증용으로 반환.
@@ -79,12 +86,39 @@ function validateTrips(trips) {
     if (!ALLOWED_SERVICE_PATTERNS.has(pattern)) {
       throw new Error(`transit_trips service_pattern must be LOCAL or EXPRESS: ${id}:${pattern}`);
     }
+    const serviceClass = trip.serviceClass ?? "SUBWAY";
+    if (!ALLOWED_SERVICE_CLASSES.has(serviceClass)) {
+      throw new Error(`transit_trips service_class must be SUBWAY or ITX_CHEONGCHUN: ${id}:${serviceClass}`);
+    }
     const dayStart = trip.serviceDayStartSeconds ?? 0;
     if (!Number.isInteger(dayStart) || dayStart < 0 || dayStart >= SECONDS_LIMIT_EXCLUSIVE) {
       throw new Error(`transit_trips service_day_start_seconds out of range [0,${SECONDS_LIMIT_EXCLUSIVE}): ${id}:${dayStart}`);
     }
   }
   return ids;
+}
+
+function validateRouteServiceEvidence(rows, trips, buildNow) {
+  if (!Array.isArray(rows) || rows.length > 1) {
+    throw new Error("routeServiceArtifactEvidence must contain at most one row");
+  }
+  const hasItxTrips = trips.some(({ serviceClass }) => serviceClass === "ITX_CHEONGCHUN");
+  if (!hasItxTrips) {
+    return rows;
+  }
+  const evidence = rows[0];
+  if (
+    evidence?.serviceClass !== "ITX_CHEONGCHUN"
+    || evidence.admissionStatus !== "ADMITTED"
+    || evidence.admissionEligible !== true
+  ) {
+    throw new Error("ITX_CHEONGCHUN seed requires ADMITTED route service evidence");
+  }
+  const freshUntil = new Date(evidence.freshUntil);
+  if (Number.isNaN(freshUntil.getTime()) || freshUntil <= buildNow) {
+    throw new Error("ITX_CHEONGCHUN route service evidence must be fresh");
+  }
+  return rows;
 }
 
 function validateStopTimes(stopTimes, tripIds) {
@@ -183,10 +217,34 @@ function routeInsert(r) {
 
 function tripInsert(t) {
   return (
-    "INSERT INTO transit_trips (id, route_id, service_id, service_pattern, service_day_start_seconds, trip_headsign, direction_id) VALUES (" +
+    "INSERT INTO transit_trips (id, route_id, service_id, service_pattern, service_class, service_day_start_seconds, trip_headsign, direction_id) VALUES (" +
     `${quote(requireString(t.id, "transitTrips.id"))}, ${quote(requireString(t.routeId, "transitTrips.routeId"))}, ` +
     `${quote(requireString(t.serviceId, "transitTrips.serviceId"))}, ${quote(t.servicePattern ?? "LOCAL")}, ` +
-    `${t.serviceDayStartSeconds ?? 0}, ${quote(t.tripHeadsign ?? "")}, ${quote(t.directionId ?? "")});`
+    `${quote(t.serviceClass ?? "SUBWAY")}, ${t.serviceDayStartSeconds ?? 0}, ${quote(t.tripHeadsign ?? "")}, ${quote(t.directionId ?? "")});`
+  );
+}
+
+function routeServiceEvidenceInsert(row) {
+  const hashes = [
+    [row.timetableArtifactSha256, "timetableArtifactSha256"],
+    [row.canonicalPackSha256, "canonicalPackSha256"],
+    [row.canonicalPackSqliteSha256, "canonicalPackSqliteSha256"],
+  ];
+  for (const [value, label] of hashes) {
+    if (typeof value !== "string" || !/^[a-f0-9]{64}$/.test(value)) {
+      throw new Error(`routeServiceArtifactEvidence.${label} must be a lowercase sha256`);
+    }
+  }
+  if (row.sourceIssue !== 2116) {
+    throw new Error("routeServiceArtifactEvidence.sourceIssue must be 2116");
+  }
+  return (
+    "INSERT INTO route_service_artifact_evidence (service_class, timetable_artifact_id, timetable_artifact_sha256, canonical_pack_id, canonical_pack_sha256, canonical_pack_sqlite_sha256, admission_status, admission_eligible, fresh_until, source_issue) VALUES (" +
+    `${quote(requireString(row.serviceClass, "routeServiceArtifactEvidence.serviceClass"))}, ` +
+    `${quote(requireString(row.timetableArtifactId, "routeServiceArtifactEvidence.timetableArtifactId"))}, ` +
+    `${quote(row.timetableArtifactSha256)}, ${quote(requireString(row.canonicalPackId, "routeServiceArtifactEvidence.canonicalPackId"))}, ` +
+    `${quote(row.canonicalPackSha256)}, ${quote(row.canonicalPackSqliteSha256)}, ${quote(row.admissionStatus)}, ` +
+    `${bool(row.admissionEligible)}, ${row.freshUntil == null ? "NULL" : quote(row.freshUntil)}, ${row.sourceIssue});`
   );
 }
 

--- a/tools/datapack/build-backend-timetable-seed.mjs
+++ b/tools/datapack/build-backend-timetable-seed.mjs
@@ -301,12 +301,22 @@ async function main() {
   const args = parseArgs(process.argv.slice(2));
   const artifactBytes = await readFile(args.input);
   const artifact = JSON.parse(artifactBytes.toString("utf8"));
+  if (args["route-service-evidence"]) {
+    if ((artifact.routeServiceArtifactEvidence ?? []).length > 0) {
+      throw new Error("route service evidence must be separate from timetable artifact bytes");
+    }
+    const sidecar = JSON.parse(await readFile(args["route-service-evidence"], "utf8"));
+    artifact.routeServiceArtifactEvidence = Array.isArray(sidecar) ? sidecar : [sidecar];
+  }
   const seed = buildBackendTimetableSeed(artifact, {
     lineId: args["line-id"],
     startDate: args["start-date"],
     endDate: args["end-date"],
     feedEndDate: args["feed-end-date"],
     timetableArtifactSha256: createHash("sha256").update(artifactBytes).digest("hex"),
+    serviceCalendarDayMap: Array.isArray(artifact.serviceCalendars)
+      ? Object.fromEntries(artifact.serviceCalendars.map((calendar) => [calendar.serviceId, calendar]))
+      : undefined,
   });
   if (args.output) {
     await writeFile(args.output, seed.sql);

--- a/tools/datapack/build-backend-timetable-seed.mjs
+++ b/tools/datapack/build-backend-timetable-seed.mjs
@@ -315,7 +315,15 @@ async function main() {
     feedEndDate: args["feed-end-date"],
     timetableArtifactSha256: createHash("sha256").update(artifactBytes).digest("hex"),
     serviceCalendarDayMap: Array.isArray(artifact.serviceCalendars)
-      ? Object.fromEntries(artifact.serviceCalendars.map((calendar) => [calendar.serviceId, calendar]))
+      ? Object.fromEntries(artifact.serviceCalendars.map((calendar) => [calendar.serviceId, {
+        monday: calendar.monday,
+        tuesday: calendar.tuesday,
+        wednesday: calendar.wednesday,
+        thursday: calendar.thursday,
+        friday: calendar.friday,
+        saturday: calendar.saturday,
+        sunday: calendar.sunday,
+      }]))
       : undefined,
   });
   if (args.output) {

--- a/tools/datapack/build-backend-timetable-seed.mjs
+++ b/tools/datapack/build-backend-timetable-seed.mjs
@@ -58,7 +58,7 @@ export function buildBackendTimetableSeed(artifact, options = {}) {
   );
 
   const calendars = deriveCalendars(trips, dayMap, startDate, endDate);
-  const routes = deriveRoutes(trips, lineId);
+  const routes = deriveRoutes(trips, lineId, artifact?.transitRoutes);
 
   const statements = [
     feedInfoInsert(feedEndDate),
@@ -222,18 +222,37 @@ function deriveCalendars(trips, dayMap, startDate, endDate) {
   });
 }
 
-function deriveRoutes(trips, lineId) {
+function deriveRoutes(trips, lineId, routeRows) {
+  if (routeRows !== undefined && !Array.isArray(routeRows)) {
+    throw new Error("transitRoutes must be an array");
+  }
+  const declaredRoutes = new Map();
+  for (const row of routeRows ?? []) {
+    const id = requireString(row.id, "transitRoutes.id");
+    if (declaredRoutes.has(id)) {
+      throw new Error(`transitRoutes duplicate id: ${id}`);
+    }
+    declaredRoutes.set(id, row);
+  }
   const byId = new Map();
   for (const trip of trips) {
     const id = requireString(trip.routeId, "transitTrips.routeId");
+    const declared = declaredRoutes.get(id);
+    if (routeRows !== undefined && !declared) {
+      throw new Error(`transitTrips routeId is missing from transitRoutes: ${id}`);
+    }
     if (!byId.has(id)) {
+      const declaredLineId = declared ? requireString(declared.lineId, `transitRoutes.${id}.lineId`) : null;
+      if (lineId && declaredLineId && lineId !== declaredLineId) {
+        throw new Error(`transitRoutes lineId does not match --line-id: ${id}`);
+      }
       byId.set(id, {
         id,
-        lineId: lineId ?? deriveLineIdFromRouteId(id),
-        directionName: trip.directionId ?? "",
-        shortName: "",
-        longName: "",
-        timezone: DEFAULT_TIMEZONE,
+        lineId: lineId ?? declaredLineId ?? deriveLineIdFromRouteId(id),
+        directionName: optionalString(declared?.directionName, `transitRoutes.${id}.directionName`, trip.directionId ?? ""),
+        shortName: optionalString(declared?.routeShortName, `transitRoutes.${id}.routeShortName`),
+        longName: optionalString(declared?.routeLongName, `transitRoutes.${id}.routeLongName`),
+        timezone: optionalString(declared?.timezone, `transitRoutes.${id}.timezone`, DEFAULT_TIMEZONE),
       });
     }
   }
@@ -323,6 +342,16 @@ function bool(value) {
 function requireString(value, label) {
   if (typeof value !== "string" || value.length === 0) {
     throw new Error(`${label} must be a non-empty string`);
+  }
+  return value;
+}
+
+function optionalString(value, label, fallback = "") {
+  if (value == null) {
+    return fallback;
+  }
+  if (typeof value !== "string") {
+    throw new Error(`${label} must be a string`);
   }
   return value;
 }

--- a/tools/datapack/build-backend-timetable-seed.mjs
+++ b/tools/datapack/build-backend-timetable-seed.mjs
@@ -17,6 +17,7 @@
 // easysubway.timetable.seed.enabled)가 startup(Flyway 이후)에 TransactionTemplate으로 all-or-nothing 적재한다.
 // Flyway 데이터 마이그레이션을 쓰지 않는 이유: 배포 시 자동 적용이라 flag 게이트가 불가하고 ~67개 @SpringBootTest DB를
 // 오염시키며 버전 번호 경합이 있다. feed_end_date는 seed에 포함(--feed-end-date, 기본=--end-date; STALE 안전장치).
+import { createHash } from "node:crypto";
 import { readFile, writeFile } from "node:fs/promises";
 
 const SECONDS_LIMIT_EXCLUSIVE = 108000; // V29 CHECK: arrival/departure BETWEEN 0 AND 107999
@@ -51,6 +52,7 @@ export function buildBackendTimetableSeed(artifact, options = {}) {
     artifact?.routeServiceArtifactEvidence ?? [],
     trips,
     options.buildNow ?? new Date(),
+    options.timetableArtifactSha256,
   );
 
   const calendars = deriveCalendars(trips, dayMap, startDate, endDate);
@@ -98,7 +100,7 @@ function validateTrips(trips) {
   return ids;
 }
 
-function validateRouteServiceEvidence(rows, trips, buildNow) {
+function validateRouteServiceEvidence(rows, trips, buildNow, timetableArtifactSha256) {
   if (!Array.isArray(rows) || rows.length > 1) {
     throw new Error("routeServiceArtifactEvidence must contain at most one row");
   }
@@ -117,6 +119,13 @@ function validateRouteServiceEvidence(rows, trips, buildNow) {
   const freshUntil = new Date(evidence.freshUntil);
   if (Number.isNaN(freshUntil.getTime()) || freshUntil <= buildNow) {
     throw new Error("ITX_CHEONGCHUN route service evidence must be fresh");
+  }
+  if (
+    typeof timetableArtifactSha256 !== "string"
+    || !/^[a-f0-9]{64}$/.test(timetableArtifactSha256)
+    || evidence.timetableArtifactSha256 !== timetableArtifactSha256
+  ) {
+    throw new Error("ITX_CHEONGCHUN timetable artifact SHA-256 identity mismatch");
   }
   return rows;
 }
@@ -290,12 +299,14 @@ function requireInteger(value, label) {
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
-  const artifact = JSON.parse(await readFile(args.input, "utf8"));
+  const artifactBytes = await readFile(args.input);
+  const artifact = JSON.parse(artifactBytes.toString("utf8"));
   const seed = buildBackendTimetableSeed(artifact, {
     lineId: args["line-id"],
     startDate: args["start-date"],
     endDate: args["end-date"],
     feedEndDate: args["feed-end-date"],
+    timetableArtifactSha256: createHash("sha256").update(artifactBytes).digest("hex"),
   });
   if (args.output) {
     await writeFile(args.output, seed.sql);

--- a/tools/datapack/build-backend-timetable-seed.mjs
+++ b/tools/datapack/build-backend-timetable-seed.mjs
@@ -19,6 +19,7 @@
 // 오염시키며 버전 번호 경합이 있다. feed_end_date는 seed에 포함(--feed-end-date, 기본=--end-date; STALE 안전장치).
 import { createHash } from "node:crypto";
 import { readFile, writeFile } from "node:fs/promises";
+import { gunzipSync } from "node:zlib";
 
 const SECONDS_LIMIT_EXCLUSIVE = 108000; // V29 CHECK: arrival/departure BETWEEN 0 AND 107999
 
@@ -53,6 +54,7 @@ export function buildBackendTimetableSeed(artifact, options = {}) {
     trips,
     options.buildNow ?? new Date(),
     options.timetableArtifactSha256,
+    options.canonicalPackIdentity,
   );
 
   const calendars = deriveCalendars(trips, dayMap, startDate, endDate);
@@ -101,7 +103,13 @@ function validateTrips(trips) {
   return ids;
 }
 
-function validateRouteServiceEvidence(rows, trips, buildNow, timetableArtifactSha256) {
+function validateRouteServiceEvidence(
+  rows,
+  trips,
+  buildNow,
+  timetableArtifactSha256,
+  canonicalPackIdentity,
+) {
   if (!Array.isArray(rows) || rows.length > 1) {
     throw new Error("routeServiceArtifactEvidence must contain at most one row");
   }
@@ -114,6 +122,9 @@ function validateRouteServiceEvidence(rows, trips, buildNow, timetableArtifactSh
       || evidence.admissionEligible !== false
     )) {
       throw new Error("ADMITTED evidence requires ITX_CHEONGCHUN trips");
+    }
+    if (evidence) {
+      validateCanonicalPackIdentity(evidence, canonicalPackIdentity);
     }
     return rows;
   }
@@ -139,7 +150,21 @@ function validateRouteServiceEvidence(rows, trips, buildNow, timetableArtifactSh
   ) {
     throw new Error("ITX_CHEONGCHUN timetable artifact SHA-256 identity mismatch");
   }
+  validateCanonicalPackIdentity(evidence, canonicalPackIdentity);
   return rows;
+}
+
+function validateCanonicalPackIdentity(evidence, canonicalPackIdentity) {
+  if (
+    typeof canonicalPackIdentity?.id !== "string"
+    || !/^[a-f0-9]{64}$/.test(canonicalPackIdentity?.sha256 ?? "")
+    || !/^[a-f0-9]{64}$/.test(canonicalPackIdentity?.sqliteSha256 ?? "")
+    || evidence.canonicalPackId !== canonicalPackIdentity.id
+    || evidence.canonicalPackSha256 !== canonicalPackIdentity.sha256
+    || evidence.canonicalPackSqliteSha256 !== canonicalPackIdentity.sqliteSha256
+  ) {
+    throw new Error("ITX_CHEONGCHUN canonical pack identity mismatch");
+  }
 }
 
 function validateStopTimes(stopTimes, tripIds) {
@@ -313,9 +338,31 @@ async function main() {
   const args = parseArgs(process.argv.slice(2));
   const artifactBytes = await readFile(args.input);
   const artifact = JSON.parse(artifactBytes.toString("utf8"));
+  let canonicalPackIdentity;
   if (args["route-service-evidence"]) {
     if ((artifact.routeServiceArtifactEvidence ?? []).length > 0) {
       throw new Error("route service evidence must be separate from timetable artifact bytes");
+    }
+    if (!args["canonical-pack"]) {
+      throw new Error("--canonical-pack is required with --route-service-evidence");
+    }
+    const canonicalPackBytes = await readFile(args["canonical-pack"]);
+    let canonicalSqliteBytes;
+    try {
+      canonicalSqliteBytes = gunzipSync(canonicalPackBytes);
+    } catch {
+      throw new Error("--canonical-pack must be a gzip-compressed SQLite artifact");
+    }
+    canonicalPackIdentity = {
+      id: requireString(artifact.canonicalPackIdentity?.id, "canonicalPackIdentity.id"),
+      sha256: createHash("sha256").update(canonicalPackBytes).digest("hex"),
+      sqliteSha256: createHash("sha256").update(canonicalSqliteBytes).digest("hex"),
+    };
+    if (
+      artifact.canonicalPackIdentity?.sha256 !== canonicalPackIdentity.sha256
+      || artifact.canonicalPackIdentity?.sqliteSha256 !== canonicalPackIdentity.sqliteSha256
+    ) {
+      throw new Error("timetable artifact canonical pack identity mismatch");
     }
     const sidecar = JSON.parse(await readFile(args["route-service-evidence"], "utf8"));
     artifact.routeServiceArtifactEvidence = Array.isArray(sidecar) ? sidecar : [sidecar];
@@ -326,6 +373,7 @@ async function main() {
     endDate: args["end-date"],
     feedEndDate: args["feed-end-date"],
     timetableArtifactSha256: createHash("sha256").update(artifactBytes).digest("hex"),
+    canonicalPackIdentity,
     serviceCalendarDayMap: Array.isArray(artifact.serviceCalendars)
       ? Object.fromEntries(artifact.serviceCalendars.map((calendar) => [calendar.serviceId, {
         monday: calendar.monday,

--- a/tools/datapack/build-backend-timetable-seed.test.mjs
+++ b/tools/datapack/build-backend-timetable-seed.test.mjs
@@ -107,6 +107,7 @@ test("ITX seed는 test-only timetable·canonical pack identity evidence를 같�
     ...OPTIONS,
     lineId: artifact.canonicalLineId,
     timetableArtifactSha256: createHash("sha256").update(artifactBytes).digest("hex"),
+    canonicalPackIdentity: artifact.canonicalPackIdentity,
     serviceCalendarDayMap: Object.fromEntries(artifact.serviceCalendars.map((calendar) => [
       calendar.serviceId,
       calendar,
@@ -177,6 +178,7 @@ test("CLI는 timetable 원본과 분리된 evidence sidecar를 실제 input byte
     "tools/datapack/build-backend-timetable-seed.mjs",
     "--input", inputPath,
     "--route-service-evidence", evidencePath,
+    "--canonical-pack", "apps/mobile/assets/datapacks/capital.sqlite.gz",
     "--line-id", artifact.canonicalLineId,
     "--start-date", "20300101",
     "--end-date", "20300131",
@@ -189,6 +191,33 @@ test("CLI는 timetable 원본과 분리된 evidence sidecar를 실제 input byte
   assert.match(sql, /'ITX_CHEONGCHUN'/);
   assert.match(sql, /'20300101', '20300131', 'Asia\/Seoul'/);
   assert.match(sql, /transit_feed_info \(id, feed_end_date\) VALUES \(1, '20300131'\)/);
+
+  await writeFile(evidencePath, `${JSON.stringify({
+    serviceClass: "ITX_CHEONGCHUN",
+    timetableArtifactId: artifact.timetableArtifactIdentity.id,
+    timetableArtifactSha256,
+    canonicalPackId: artifact.canonicalPackIdentity.id,
+    canonicalPackSha256: "0".repeat(64),
+    canonicalPackSqliteSha256: artifact.canonicalPackIdentity.sqliteSha256,
+    admissionStatus: "ADMITTED",
+    admissionEligible: true,
+    freshUntil: "2999-01-01T00:00:00.000Z",
+    sourceIssue: 2116,
+  })}\n`);
+  await assert.rejects(
+    execFileAsync(process.execPath, [
+      "tools/datapack/build-backend-timetable-seed.mjs",
+      "--input", inputPath,
+      "--route-service-evidence", evidencePath,
+      "--canonical-pack", "apps/mobile/assets/datapacks/capital.sqlite.gz",
+      "--line-id", artifact.canonicalLineId,
+      "--start-date", "20300101",
+      "--end-date", "20300131",
+      "--feed-end-date", "20300131",
+      "--output", outputPath,
+    ], { cwd: root }),
+    /canonical pack identity mismatch/,
+  );
 });
 
 test("stale ITX evidence는 seed 생성 단계에서 거부한다", () => {

--- a/tools/datapack/build-backend-timetable-seed.test.mjs
+++ b/tools/datapack/build-backend-timetable-seed.test.mjs
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
 import { test } from "node:test";
 import { buildBackendTimetableSeed } from "./build-backend-timetable-seed.mjs";
 
@@ -29,7 +31,12 @@ const ARTIFACT = {
   ],
 };
 
-const OPTIONS = { lineId: "seoul-4", startDate: "20260101", endDate: "20261231" };
+const OPTIONS = {
+  lineId: "seoul-4",
+  startDate: "20260101",
+  endDate: "20261231",
+  buildNow: new Date("2026-07-14T00:00:00.000Z"),
+};
 
 test("service_calendar는 토요일을 휴일 다이어로 매핑한다 (holiday-kric=토·일, weekday-kric=월~금)", () => {
   const seed = buildBackendTimetableSeed(ARTIFACT, OPTIONS);
@@ -63,6 +70,60 @@ test("SQL은 FK 순서(calendars→routes→trips→stop_times)로 INSERT를 낸
   const iTrip = sql.indexOf("INSERT INTO transit_trips");
   const iStop = sql.indexOf("INSERT INTO transit_stop_times");
   assert.ok(iCal >= 0 && iRoute > iCal && iTrip > iRoute && iStop > iTrip, `순서 위반: ${[iCal, iRoute, iTrip, iStop]}`);
+});
+
+test("trip seed는 service_class를 명시하고 기본 SUBWAY를 보존한다", () => {
+  const { sql } = buildBackendTimetableSeed(ARTIFACT, OPTIONS);
+  assert.match(
+    sql,
+    /INSERT INTO transit_trips \(id, route_id, service_id, service_pattern, service_class, service_day_start_seconds, trip_headsign, direction_id\)/,
+  );
+  assert.match(sql, /'LOCAL', 'SUBWAY', 0/);
+});
+
+test("ITX seed는 test-only timetable·canonical pack identity evidence를 같은 SQL에 고정한다", async () => {
+  const artifactBytes = await readFile(new URL("./fixtures/test-only-itx-cheongchun-admitted.json", import.meta.url));
+  const artifact = JSON.parse(artifactBytes);
+  artifact.routeServiceArtifactEvidence = [{
+    serviceClass: "ITX_CHEONGCHUN",
+    timetableArtifactId: artifact.timetableArtifactIdentity.id,
+    timetableArtifactSha256: createHash("sha256").update(artifactBytes).digest("hex"),
+    canonicalPackId: artifact.canonicalPackIdentity.id,
+    canonicalPackSha256: artifact.canonicalPackIdentity.sha256,
+    canonicalPackSqliteSha256: artifact.canonicalPackIdentity.sqliteSha256,
+    admissionStatus: "ADMITTED",
+    admissionEligible: true,
+    freshUntil: artifact.freshness.freshUntil,
+    sourceIssue: 2116,
+  }];
+  const { sql } = buildBackendTimetableSeed(artifact, {
+    ...OPTIONS,
+    lineId: artifact.canonicalLineId,
+    serviceCalendarDayMap: Object.fromEntries(artifact.serviceCalendars.map((calendar) => [
+      calendar.serviceId,
+      calendar,
+    ])),
+  });
+
+  assert.match(sql, /INSERT INTO route_service_artifact_evidence/);
+  assert.match(sql, new RegExp(artifact.routeServiceArtifactEvidence[0].timetableArtifactSha256));
+  assert.match(sql, new RegExp(artifact.canonicalPackIdentity.sha256));
+  assert.match(sql, new RegExp(artifact.canonicalPackIdentity.sqliteSha256));
+  assert.match(sql, /'EXPRESS', 'ITX_CHEONGCHUN', 0/);
+});
+
+test("stale ITX evidence는 seed 생성 단계에서 거부한다", () => {
+  const artifact = {
+    ...ARTIFACT,
+    transitTrips: ARTIFACT.transitTrips.map((trip) => ({ ...trip, serviceClass: "ITX_CHEONGCHUN" })),
+    routeServiceArtifactEvidence: [{
+      serviceClass: "ITX_CHEONGCHUN",
+      admissionStatus: "ADMITTED",
+      admissionEligible: true,
+      freshUntil: "2026-07-13T00:00:00.000Z",
+    }],
+  };
+  assert.throws(() => buildBackendTimetableSeed(artifact, OPTIONS), /must be fresh/);
 });
 
 test("stop_time 행을 스키마 컬럼으로 직역한다 (pickup/drop_off 기본 0)", () => {

--- a/tools/datapack/build-backend-timetable-seed.test.mjs
+++ b/tools/datapack/build-backend-timetable-seed.test.mjs
@@ -205,6 +205,59 @@ test("stale ITX evidence는 seed 생성 단계에서 거부한다", () => {
   assert.throws(() => buildBackendTimetableSeed(artifact, OPTIONS), /must be fresh/);
 });
 
+test("ITX trip 0건인 seed에는 ADMITTED evidence를 기록하지 않는다", () => {
+  const artifact = {
+    ...ARTIFACT,
+    routeServiceArtifactEvidence: [{
+      serviceClass: "ITX_CHEONGCHUN",
+      timetableArtifactId: "wrongly-admitted-subway-only",
+      timetableArtifactSha256: "a".repeat(64),
+      canonicalPackId: "capital",
+      canonicalPackSha256: "b".repeat(64),
+      canonicalPackSqliteSha256: "c".repeat(64),
+      admissionStatus: "ADMITTED",
+      admissionEligible: true,
+      freshUntil: "2999-01-01T00:00:00.000Z",
+      sourceIssue: 2116,
+    }],
+  };
+
+  assert.throws(
+    () => buildBackendTimetableSeed(artifact, {
+      ...OPTIONS,
+      timetableArtifactSha256: "a".repeat(64),
+    }),
+    /ADMITTED evidence requires ITX_CHEONGCHUN trips/,
+  );
+});
+
+test("ITX evidence freshUntil은 runtime loader가 읽는 offset ISO-8601 형식이어야 한다", () => {
+  const artifact = {
+    ...ARTIFACT,
+    transitTrips: ARTIFACT.transitTrips.map((trip) => ({ ...trip, serviceClass: "ITX_CHEONGCHUN" })),
+    routeServiceArtifactEvidence: [{
+      serviceClass: "ITX_CHEONGCHUN",
+      timetableArtifactId: "invalid-freshness-format",
+      timetableArtifactSha256: "a".repeat(64),
+      canonicalPackId: "capital",
+      canonicalPackSha256: "b".repeat(64),
+      canonicalPackSqliteSha256: "c".repeat(64),
+      admissionStatus: "ADMITTED",
+      admissionEligible: true,
+      freshUntil: "2999-01-01",
+      sourceIssue: 2116,
+    }],
+  };
+
+  assert.throws(
+    () => buildBackendTimetableSeed(artifact, {
+      ...OPTIONS,
+      timetableArtifactSha256: "a".repeat(64),
+    }),
+    /freshUntil must be offset ISO-8601/,
+  );
+});
+
 test("stop_time 행을 스키마 컬럼으로 직역한다 (pickup/drop_off 기본 0)", () => {
   const { sql } = buildBackendTimetableSeed(ARTIFACT, OPTIONS);
   assert.match(

--- a/tools/datapack/build-backend-timetable-seed.test.mjs
+++ b/tools/datapack/build-backend-timetable-seed.test.mjs
@@ -1,8 +1,15 @@
 import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
-import { readFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { test } from "node:test";
+import { promisify } from "node:util";
 import { buildBackendTimetableSeed } from "./build-backend-timetable-seed.mjs";
+
+const execFileAsync = promisify(execFile);
+const root = path.resolve(import.meta.dirname, "../..");
 
 // 재구성 artifact(수집기 산출물) 축약 — up/down 각 1 trip, weekday/holiday 각 1.
 const ARTIFACT = {
@@ -141,6 +148,42 @@ test("ITX seed evidence hash가 입력 timetable artifact bytes identity와 다�
     }),
     /timetable artifact SHA-256 identity mismatch/,
   );
+});
+
+test("CLI는 timetable 원본과 분리된 evidence sidecar를 실제 input bytes hash에 결합한다", async (context) => {
+  const temporaryDir = await mkdtemp(path.join(tmpdir(), "easysubway-itx-seed-sidecar-"));
+  context.after(() => rm(temporaryDir, { recursive: true, force: true }));
+  const artifactBytes = await readFile(new URL("./fixtures/test-only-itx-cheongchun-admitted.json", import.meta.url));
+  const artifact = JSON.parse(artifactBytes);
+  const inputPath = path.join(temporaryDir, "timetable.json");
+  const evidencePath = path.join(temporaryDir, "evidence.json");
+  const outputPath = path.join(temporaryDir, "seed.sql");
+  const timetableArtifactSha256 = createHash("sha256").update(artifactBytes).digest("hex");
+  await writeFile(inputPath, artifactBytes);
+  await writeFile(evidencePath, `${JSON.stringify({
+    serviceClass: "ITX_CHEONGCHUN",
+    timetableArtifactId: artifact.timetableArtifactIdentity.id,
+    timetableArtifactSha256,
+    canonicalPackId: artifact.canonicalPackIdentity.id,
+    canonicalPackSha256: artifact.canonicalPackIdentity.sha256,
+    canonicalPackSqliteSha256: artifact.canonicalPackIdentity.sqliteSha256,
+    admissionStatus: "ADMITTED",
+    admissionEligible: true,
+    freshUntil: "2999-01-01T00:00:00.000Z",
+    sourceIssue: 2116,
+  })}\n`);
+
+  await execFileAsync(process.execPath, [
+    "tools/datapack/build-backend-timetable-seed.mjs",
+    "--input", inputPath,
+    "--route-service-evidence", evidencePath,
+    "--line-id", artifact.canonicalLineId,
+    "--output", outputPath,
+  ], { cwd: root });
+
+  const sql = await readFile(outputPath, "utf8");
+  assert.match(sql, new RegExp(timetableArtifactSha256));
+  assert.match(sql, /'ITX_CHEONGCHUN'/);
 });
 
 test("stale ITX evidence는 seed 생성 단계에서 거부한다", () => {

--- a/tools/datapack/build-backend-timetable-seed.test.mjs
+++ b/tools/datapack/build-backend-timetable-seed.test.mjs
@@ -178,12 +178,17 @@ test("CLI는 timetable 원본과 분리된 evidence sidecar를 실제 input byte
     "--input", inputPath,
     "--route-service-evidence", evidencePath,
     "--line-id", artifact.canonicalLineId,
+    "--start-date", "20300101",
+    "--end-date", "20300131",
+    "--feed-end-date", "20300131",
     "--output", outputPath,
   ], { cwd: root });
 
   const sql = await readFile(outputPath, "utf8");
   assert.match(sql, new RegExp(timetableArtifactSha256));
   assert.match(sql, /'ITX_CHEONGCHUN'/);
+  assert.match(sql, /'20300101', '20300131', 'Asia\/Seoul'/);
+  assert.match(sql, /transit_feed_info \(id, feed_end_date\) VALUES \(1, '20300131'\)/);
 });
 
 test("stale ITX evidence는 seed 생성 단계에서 거부한다", () => {

--- a/tools/datapack/build-backend-timetable-seed.test.mjs
+++ b/tools/datapack/build-backend-timetable-seed.test.mjs
@@ -119,6 +119,21 @@ test("ITX seed는 test-only timetable·canonical pack identity evidence를 같�
   assert.match(sql, new RegExp(artifact.canonicalPackIdentity.sha256));
   assert.match(sql, new RegExp(artifact.canonicalPackIdentity.sqliteSha256));
   assert.match(sql, /'EXPRESS', 'ITX_CHEONGCHUN', 0/);
+  assert.match(sql, /'ITX-청춘'/);
+  assert.match(sql, /'청량리 → 춘천'/);
+  assert.throws(
+    () => buildBackendTimetableSeed({ ...artifact, transitRoutes: [] }, {
+      ...OPTIONS,
+      lineId: artifact.canonicalLineId,
+      timetableArtifactSha256: createHash("sha256").update(artifactBytes).digest("hex"),
+      canonicalPackIdentity: artifact.canonicalPackIdentity,
+      serviceCalendarDayMap: Object.fromEntries(artifact.serviceCalendars.map((calendar) => [
+        calendar.serviceId,
+        calendar,
+      ])),
+    }),
+    /routeId is missing from transitRoutes/,
+  );
 });
 
 test("ITX seed evidence hash가 입력 timetable artifact bytes identity와 다르면 거부한다", async () => {

--- a/tools/datapack/build-backend-timetable-seed.test.mjs
+++ b/tools/datapack/build-backend-timetable-seed.test.mjs
@@ -99,6 +99,7 @@ test("ITX seed는 test-only timetable·canonical pack identity evidence를 같�
   const { sql } = buildBackendTimetableSeed(artifact, {
     ...OPTIONS,
     lineId: artifact.canonicalLineId,
+    timetableArtifactSha256: createHash("sha256").update(artifactBytes).digest("hex"),
     serviceCalendarDayMap: Object.fromEntries(artifact.serviceCalendars.map((calendar) => [
       calendar.serviceId,
       calendar,
@@ -110,6 +111,36 @@ test("ITX seed는 test-only timetable·canonical pack identity evidence를 같�
   assert.match(sql, new RegExp(artifact.canonicalPackIdentity.sha256));
   assert.match(sql, new RegExp(artifact.canonicalPackIdentity.sqliteSha256));
   assert.match(sql, /'EXPRESS', 'ITX_CHEONGCHUN', 0/);
+});
+
+test("ITX seed evidence hash가 입력 timetable artifact bytes identity와 다르면 거부한다", async () => {
+  const artifactBytes = await readFile(new URL("./fixtures/test-only-itx-cheongchun-admitted.json", import.meta.url));
+  const artifact = JSON.parse(artifactBytes);
+  artifact.routeServiceArtifactEvidence = [{
+    serviceClass: "ITX_CHEONGCHUN",
+    timetableArtifactId: artifact.timetableArtifactIdentity.id,
+    timetableArtifactSha256: createHash("sha256").update(artifactBytes).digest("hex"),
+    canonicalPackId: artifact.canonicalPackIdentity.id,
+    canonicalPackSha256: artifact.canonicalPackIdentity.sha256,
+    canonicalPackSqliteSha256: artifact.canonicalPackIdentity.sqliteSha256,
+    admissionStatus: "ADMITTED",
+    admissionEligible: true,
+    freshUntil: artifact.freshness.freshUntil,
+    sourceIssue: 2116,
+  }];
+
+  assert.throws(
+    () => buildBackendTimetableSeed(artifact, {
+      ...OPTIONS,
+      lineId: artifact.canonicalLineId,
+      timetableArtifactSha256: "0".repeat(64),
+      serviceCalendarDayMap: Object.fromEntries(artifact.serviceCalendars.map((calendar) => [
+        calendar.serviceId,
+        calendar,
+      ])),
+    }),
+    /timetable artifact SHA-256 identity mismatch/,
+  );
 });
 
 test("stale ITX evidence는 seed 생성 단계에서 거부한다", () => {

--- a/tools/datapack/build-datapack.mjs
+++ b/tools/datapack/build-datapack.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { createHash } from "node:crypto";
 import { mkdir, readFile, realpath, rm, writeFile } from "node:fs/promises";
-import { gzipSync } from "node:zlib";
+import { gunzipSync, gzipSync } from "node:zlib";
 import { DatabaseSync } from "node:sqlite";
 import path from "node:path";
 import { tmpdir } from "node:os";
@@ -179,10 +179,21 @@ async function loadBuildInput(args, officialOdFareAdmissions, officialOdFareAdmi
   if (fixtureArg != null) {
     const fixture = JSON.parse(await readFile(path.resolve(root, fixtureArg), "utf8"));
     rejectTestOnlyBuildInput(fixture);
+    if (args["test-only-itx-admission"] != null) {
+      const admissionPath = await resolveBuildInputPath(
+        args["test-only-itx-admission"],
+        "testOnlyItxAdmission",
+      );
+      const admissionBytes = await readFile(admissionPath);
+      await materializeTestOnlyItxAdmission(fixture, JSON.parse(admissionBytes), admissionBytes);
+    }
     return {
       fixture,
       candidateBuild: null,
     };
+  }
+  if (args["test-only-itx-admission"] != null) {
+    throw new Error("--test-only-itx-admission cannot be used with --build-spec");
   }
 
   const buildSpecPath = await resolveBuildInputPath(buildSpecArg, "buildSpec");
@@ -200,6 +211,128 @@ async function loadBuildInput(args, officialOdFareAdmissions, officialOdFareAdmi
     fixture,
     candidateBuild: candidateBuildProvenance(buildSpec, sha256(buildSpecBytes), officialOdFareEvidence),
   };
+}
+
+async function materializeTestOnlyItxAdmission(fixture, admission, admissionBytes) {
+  if (
+    admission?.fixtureClass !== "TEST_ONLY"
+    || admission?.artifactKind !== "deterministic-itx-cheongchun-admission-fixture"
+  ) {
+    throw new Error("--test-only-itx-admission requires the deterministic TEST_ONLY fixture");
+  }
+  if (
+    admission.serviceClass !== "ITX_CHEONGCHUN"
+    || admission.sourceIssue !== 2116
+    || admission.admissionStatus !== "ADMITTED"
+    || admission.admissionEligible !== true
+    || admission.freshness?.status !== "FRESH"
+  ) {
+    throw new Error("test-only ITX admission must be FRESH and ADMITTED by #2116");
+  }
+  const freshUntil = requiredUtcDateString(
+    admission.freshness.freshUntil,
+    "testOnlyItxAdmission.freshness.freshUntil",
+  );
+  if (Date.parse(freshUntil) <= candidateBuildNow().getTime()) {
+    throw new Error("test-only ITX admission freshness must be in the future");
+  }
+  const canonicalIdentity = admission.canonicalPackIdentity;
+  const canonicalGzipBytes = await readFile(
+    path.join(root, "apps/mobile/assets/datapacks/capital.sqlite.gz"),
+  );
+  if (
+    canonicalIdentity?.id !== "capital"
+    || canonicalIdentity.sha256 !== sha256(canonicalGzipBytes)
+    || canonicalIdentity.sqliteSha256 !== sha256(gunzipSync(canonicalGzipBytes))
+  ) {
+    throw new Error("test-only ITX admission canonical pack identity is stale");
+  }
+  if (admission.timetableArtifactIdentity?.sha256Source !== "FIXTURE_FILE_BYTES") {
+    throw new Error("test-only ITX timetable identity must hash fixture file bytes");
+  }
+
+  const pack = fixture.packs?.find(({ id }) => id === canonicalIdentity.id);
+  if (!pack || (pack.artifactKind ?? "fixture") !== "fixture") {
+    throw new Error("test-only ITX admission can materialize only into a fixture pack");
+  }
+  const lineId = requiredString(admission.canonicalLineId, "testOnlyItxAdmission.canonicalLineId");
+  const stationIds = new Set((pack.stations ?? []).map(({ id }) => id));
+  const routeMapMembers = new Set((pack.routeMapPositions ?? [])
+    .filter(({ lineId: memberLineId, region }) => memberLineId === lineId && region === "수도권")
+    .map(({ stationId }) => stationId));
+  const admittedStationIds = new Set((admission.canonicalStations ?? []).map((station) => {
+    if (station.capitalRouteMapMember !== true) {
+      throw new Error(`test-only ITX station is not a capital route-map member: ${station.canonicalStationId}`);
+    }
+    return requiredString(station.canonicalStationId, "testOnlyItxAdmission.canonicalStations[].canonicalStationId");
+  }));
+  for (const stationId of admittedStationIds) {
+    if (!stationIds.has(stationId) || !routeMapMembers.has(stationId)) {
+      throw new Error(`test-only ITX canonical station membership is missing: ${stationId}`);
+    }
+  }
+
+  const timetableHash = sha256(admissionBytes);
+  const trips = admission.transitTrips ?? [];
+  const stopTimes = admission.transitStopTimes ?? [];
+  const edges = [];
+  for (const trip of trips) {
+    if (trip.serviceClass !== "ITX_CHEONGCHUN" || trip.servicePattern !== "EXPRESS") {
+      throw new Error(`test-only ITX trip must be EXPRESS: ${trip.id}`);
+    }
+    const tripStops = stopTimes
+      .filter(({ tripId }) => tripId === trip.id)
+      .sort((left, right) => left.stopSequence - right.stopSequence);
+    if (tripStops.length < 2) {
+      throw new Error(`test-only ITX trip must have at least two stops: ${trip.id}`);
+    }
+    for (const stop of tripStops) {
+      if (stop.lineId !== lineId || !admittedStationIds.has(stop.stationId)) {
+        throw new Error(`test-only ITX stop is outside admitted canonical scope: ${trip.id}`);
+      }
+    }
+    for (let index = 1; index < tripStops.length; index += 1) {
+      const from = tripStops[index - 1];
+      const to = tripStops[index];
+      const durationSeconds = to.arrivalSeconds - from.departureSeconds;
+      if (!Number.isInteger(durationSeconds) || durationSeconds <= 0) {
+        throw new Error(`test-only ITX stop times are not increasing: ${trip.id}`);
+      }
+      edges.push({
+        id: `itx-cheongchun:${trip.id}:${from.stopSequence}-${to.stopSequence}`,
+        fromNodeId: `${from.stationId}:${lineId}`,
+        toNodeId: `${to.stationId}:${lineId}`,
+        durationSeconds,
+        distanceMeters: 0,
+        edgeType: "RIDE",
+        servicePattern: "EXPRESS",
+        serviceClass: "ITX_CHEONGCHUN",
+        evidenceHash: timetableHash,
+        lastVerifiedAt: admission.freshness.observedAt,
+      });
+    }
+  }
+
+  pack.serviceCalendars = [...(pack.serviceCalendars ?? []), ...(admission.serviceCalendars ?? [])];
+  pack.transitRoutes = [...(pack.transitRoutes ?? []), ...(admission.transitRoutes ?? [])];
+  pack.transitTrips = [...(pack.transitTrips ?? []), ...trips];
+  pack.transitStopTimes = [...(pack.transitStopTimes ?? []), ...stopTimes];
+  pack.networkEdges = [...(pack.networkEdges ?? []), ...edges];
+  pack.routeServiceArtifactEvidence = [{
+    serviceClass: "ITX_CHEONGCHUN",
+    timetableArtifactId: requiredString(
+      admission.timetableArtifactIdentity?.id,
+      "testOnlyItxAdmission.timetableArtifactIdentity.id",
+    ),
+    timetableArtifactSha256: timetableHash,
+    canonicalPackId: canonicalIdentity.id,
+    canonicalPackSha256: canonicalIdentity.sha256,
+    canonicalPackSqliteSha256: canonicalIdentity.sqliteSha256,
+    admissionStatus: "ADMITTED",
+    admissionEligible: true,
+    freshUntil,
+    sourceIssue: 2116,
+  }];
 }
 
 function rejectTestOnlyBuildInput(fixture) {

--- a/tools/datapack/build-datapack.mjs
+++ b/tools/datapack/build-datapack.mjs
@@ -1166,6 +1166,7 @@ function buildSqlitePack(sqlitePath, schema, pack, officialOdFareAdmissions) {
           "trip_headsign",
           "direction_id",
           "service_pattern",
+          "service_class",
           "service_day_start_seconds",
         ],
         pack.transitTrips ?? [],
@@ -1176,6 +1177,7 @@ function buildSqlitePack(sqlitePath, schema, pack, officialOdFareAdmissions) {
           row.tripHeadsign ?? "",
           row.directionId ?? "",
           row.servicePattern ?? "LOCAL",
+          row.serviceClass ?? "SUBWAY",
           row.serviceDayStartSeconds ?? 0,
         ],
       );
@@ -1223,6 +1225,35 @@ function buildSqlitePack(sqlitePath, schema, pack, officialOdFareAdmissions) {
         ["id", "feed_end_date"],
         pack.transitFeedInfo ?? [],
         (row) => [1, serviceDate(row.feedEndDate, "transitFeedInfo.feedEndDate")],
+      );
+      insertRows(
+        database,
+        "route_service_artifact_evidence",
+        [
+          "service_class",
+          "timetable_artifact_id",
+          "timetable_artifact_sha256",
+          "canonical_pack_id",
+          "canonical_pack_sha256",
+          "canonical_pack_sqlite_sha256",
+          "admission_status",
+          "admission_eligible",
+          "fresh_until",
+          "source_issue",
+        ],
+        pack.routeServiceArtifactEvidence ?? [],
+        (row) => [
+          requiredString(row.serviceClass, "routeServiceArtifactEvidence.serviceClass"),
+          requiredString(row.timetableArtifactId, "routeServiceArtifactEvidence.timetableArtifactId"),
+          requiredString(row.timetableArtifactSha256, "routeServiceArtifactEvidence.timetableArtifactSha256"),
+          requiredString(row.canonicalPackId, "routeServiceArtifactEvidence.canonicalPackId"),
+          requiredString(row.canonicalPackSha256, "routeServiceArtifactEvidence.canonicalPackSha256"),
+          requiredString(row.canonicalPackSqliteSha256, "routeServiceArtifactEvidence.canonicalPackSqliteSha256"),
+          requiredString(row.admissionStatus, "routeServiceArtifactEvidence.admissionStatus"),
+          boolFlag(row.admissionEligible, "routeServiceArtifactEvidence.admissionEligible"),
+          row.freshUntil ?? null,
+          requiredInteger(row.sourceIssue, "routeServiceArtifactEvidence.sourceIssue"),
+        ],
       );
       insertRows(
         database,
@@ -1354,6 +1385,7 @@ function buildSqlitePack(sqlitePath, schema, pack, officialOdFareAdmissions) {
           "distance_meters",
           "edge_type",
           "service_pattern",
+          "service_class",
           "includes_stairs",
           "stair_access_state",
           "accessibility_status",
@@ -1383,6 +1415,7 @@ function buildSqlitePack(sqlitePath, schema, pack, officialOdFareAdmissions) {
             row.distanceMeters ?? 0,
             row.edgeType ?? "WALKWAY",
             row.servicePattern ?? "",
+            row.serviceClass ?? "SUBWAY",
             stairAccessState === "STAIR_ONLY" ? 1 : 0,
             stairAccessState,
             accessibilityStatus,
@@ -1929,6 +1962,7 @@ function validateFixture(fixture) {
   }
   for (const pack of fixture.packs) {
     validatePackIdentity(pack, "pack");
+    validateRouteServiceAdmission(pack);
     const artifactKind = pack.artifactKind ?? "fixture";
     if (artifactKind !== "fixture" && artifactKind !== "production") {
       throw new Error("pack.artifactKind must be fixture or production");
@@ -1953,6 +1987,18 @@ function validateFixture(fixture) {
       throw new Error(`${pack.id} requiredTables must be a non-empty array`);
     }
     validateMinimumTableRows(pack, artifactKind);
+  }
+}
+
+function validateRouteServiceAdmission(pack) {
+  const evidence = (pack.routeServiceArtifactEvidence ?? [])
+    .find(({ serviceClass }) => serviceClass === "ITX_CHEONGCHUN");
+  const itxRowCount = [
+    ...(pack.transitTrips ?? []),
+    ...(pack.networkEdges ?? []),
+  ].filter(({ serviceClass }) => serviceClass === "ITX_CHEONGCHUN").length;
+  if (itxRowCount > 0 && (evidence?.admissionStatus !== "ADMITTED" || evidence?.admissionEligible !== true)) {
+    throw new Error("ITX_CHEONGCHUN rows require ADMITTED evidence");
   }
 }
 

--- a/tools/datapack/build-datapack.mjs
+++ b/tools/datapack/build-datapack.mjs
@@ -215,6 +215,43 @@ async function loadBuildInput(args, officialOdFareAdmissions, officialOdFareAdmi
 }
 
 async function materializeTestOnlyItxAdmission(fixture, admission, admissionBytes) {
+  const freshUntil = validateTestOnlyItxAdmission(admission);
+  const canonicalIdentity = await validateTestOnlyItxCanonicalIdentity(admission);
+  const pack = testOnlyItxTargetPack(fixture, canonicalIdentity);
+  const lineId = requiredString(admission.canonicalLineId, "testOnlyItxAdmission.canonicalLineId");
+  const admittedStationIds = validateTestOnlyItxStations(pack, admission, lineId);
+  const timetableHash = sha256(admissionBytes);
+  const { trips, stopTimes, edges } = deriveTestOnlyItxRows(
+    admission,
+    lineId,
+    admittedStationIds,
+    timetableHash,
+  );
+
+  pack.serviceCalendars = [...(pack.serviceCalendars ?? []), ...(admission.serviceCalendars ?? [])];
+  pack.transitRoutes = [...(pack.transitRoutes ?? []), ...(admission.transitRoutes ?? [])];
+  pack.transitTrips = [...(pack.transitTrips ?? []), ...trips];
+  pack.transitStopTimes = [...(pack.transitStopTimes ?? []), ...stopTimes];
+  pack.networkEdges = [...(pack.networkEdges ?? []), ...edges];
+  pack.routeServiceArtifactEvidence = [{
+    serviceClass: "ITX_CHEONGCHUN",
+    timetableArtifactId: requiredString(
+      admission.timetableArtifactIdentity?.id,
+      "testOnlyItxAdmission.timetableArtifactIdentity.id",
+    ),
+    timetableArtifactSha256: timetableHash,
+    canonicalPackId: canonicalIdentity.id,
+    canonicalPackSha256: canonicalIdentity.sha256,
+    canonicalPackSqliteSha256: canonicalIdentity.sqliteSha256,
+    admissionStatus: "ADMITTED",
+    admissionEligible: true,
+    freshUntil,
+    sourceIssue: 2116,
+  }];
+  validatedItxAdmissionPacks.add(pack);
+}
+
+function validateTestOnlyItxAdmission(admission) {
   if (
     admission?.fixtureClass !== "TEST_ONLY"
     || admission?.artifactKind !== "deterministic-itx-cheongchun-admission-fixture"
@@ -237,6 +274,10 @@ async function materializeTestOnlyItxAdmission(fixture, admission, admissionByte
   if (Date.parse(freshUntil) <= candidateBuildNow().getTime()) {
     throw new Error("test-only ITX admission freshness must be in the future");
   }
+  return freshUntil;
+}
+
+async function validateTestOnlyItxCanonicalIdentity(admission) {
   const canonicalIdentity = admission.canonicalPackIdentity;
   const canonicalGzipBytes = await readFile(
     path.join(root, "apps/mobile/assets/datapacks/capital.sqlite.gz"),
@@ -251,12 +292,18 @@ async function materializeTestOnlyItxAdmission(fixture, admission, admissionByte
   if (admission.timetableArtifactIdentity?.sha256Source !== "FIXTURE_FILE_BYTES") {
     throw new Error("test-only ITX timetable identity must hash fixture file bytes");
   }
+  return canonicalIdentity;
+}
 
+function testOnlyItxTargetPack(fixture, canonicalIdentity) {
   const pack = fixture.packs?.find(({ id }) => id === canonicalIdentity.id);
   if (!pack || (pack.artifactKind ?? "fixture") !== "fixture") {
     throw new Error("test-only ITX admission can materialize only into a fixture pack");
   }
-  const lineId = requiredString(admission.canonicalLineId, "testOnlyItxAdmission.canonicalLineId");
+  return pack;
+}
+
+function validateTestOnlyItxStations(pack, admission, lineId) {
   const stationIds = new Set((pack.stations ?? []).map(({ id }) => id));
   const routeMapMembers = new Set((pack.routeMapPositions ?? [])
     .filter(({ lineId: memberLineId, region }) => memberLineId === lineId && region === "수도권")
@@ -272,8 +319,10 @@ async function materializeTestOnlyItxAdmission(fixture, admission, admissionByte
       throw new Error(`test-only ITX canonical station membership is missing: ${stationId}`);
     }
   }
+  return admittedStationIds;
+}
 
-  const timetableHash = sha256(admissionBytes);
+function deriveTestOnlyItxRows(admission, lineId, admittedStationIds, timetableHash) {
   const trips = admission.transitTrips ?? [];
   const stopTimes = admission.transitStopTimes ?? [];
   const edges = [];
@@ -313,28 +362,7 @@ async function materializeTestOnlyItxAdmission(fixture, admission, admissionByte
       });
     }
   }
-
-  pack.serviceCalendars = [...(pack.serviceCalendars ?? []), ...(admission.serviceCalendars ?? [])];
-  pack.transitRoutes = [...(pack.transitRoutes ?? []), ...(admission.transitRoutes ?? [])];
-  pack.transitTrips = [...(pack.transitTrips ?? []), ...trips];
-  pack.transitStopTimes = [...(pack.transitStopTimes ?? []), ...stopTimes];
-  pack.networkEdges = [...(pack.networkEdges ?? []), ...edges];
-  pack.routeServiceArtifactEvidence = [{
-    serviceClass: "ITX_CHEONGCHUN",
-    timetableArtifactId: requiredString(
-      admission.timetableArtifactIdentity?.id,
-      "testOnlyItxAdmission.timetableArtifactIdentity.id",
-    ),
-    timetableArtifactSha256: timetableHash,
-    canonicalPackId: canonicalIdentity.id,
-    canonicalPackSha256: canonicalIdentity.sha256,
-    canonicalPackSqliteSha256: canonicalIdentity.sqliteSha256,
-    admissionStatus: "ADMITTED",
-    admissionEligible: true,
-    freshUntil,
-    sourceIssue: 2116,
-  }];
-  validatedItxAdmissionPacks.add(pack);
+  return { trips, stopTimes, edges };
 }
 
 function rejectTestOnlyBuildInput(fixture) {
@@ -2126,12 +2154,19 @@ function validateFixture(fixture) {
 }
 
 function validateRouteServiceAdmission(pack) {
-  const evidence = (pack.routeServiceArtifactEvidence ?? [])
-    .find(({ serviceClass }) => serviceClass === "ITX_CHEONGCHUN");
+  const evidenceRows = (pack.routeServiceArtifactEvidence ?? [])
+    .filter(({ serviceClass }) => serviceClass === "ITX_CHEONGCHUN");
+  if (evidenceRows.length > 1) {
+    throw new Error("pack must contain exactly one ITX_CHEONGCHUN evidence row");
+  }
+  const evidence = evidenceRows[0];
   const itxRowCount = [
     ...(pack.transitTrips ?? []),
     ...(pack.networkEdges ?? []),
   ].filter(({ serviceClass }) => serviceClass === "ITX_CHEONGCHUN").length;
+  if (evidence?.admissionStatus === "ADMITTED" && itxRowCount === 0) {
+    throw new Error("ADMITTED evidence requires ITX_CHEONGCHUN rows");
+  }
   if (itxRowCount > 0 && (evidence?.admissionStatus !== "ADMITTED" || evidence?.admissionEligible !== true)) {
     throw new Error("ITX_CHEONGCHUN rows require ADMITTED evidence");
   }

--- a/tools/datapack/build-datapack.mjs
+++ b/tools/datapack/build-datapack.mjs
@@ -22,6 +22,7 @@ import {
 } from "./lib/official-od-fare-evidence.mjs";
 
 const root = path.resolve(import.meta.dirname, "../..");
+const validatedItxAdmissionPacks = new WeakSet();
 const productionMinimumTableRowNames = [
   "stations",
   "station_lines",
@@ -300,8 +301,8 @@ async function materializeTestOnlyItxAdmission(fixture, admission, admissionByte
       }
       edges.push({
         id: `itx-cheongchun:${trip.id}:${from.stopSequence}-${to.stopSequence}`,
-        fromNodeId: `${from.stationId}:${lineId}`,
-        toNodeId: `${to.stationId}:${lineId}`,
+        fromNodeId: `${from.stationId}:${lineId}:EXPRESS`,
+        toNodeId: `${to.stationId}:${lineId}:EXPRESS`,
         durationSeconds,
         distanceMeters: 0,
         edgeType: "RIDE",
@@ -333,6 +334,7 @@ async function materializeTestOnlyItxAdmission(fixture, admission, admissionByte
     freshUntil,
     sourceIssue: 2116,
   }];
+  validatedItxAdmissionPacks.add(pack);
 }
 
 function rejectTestOnlyBuildInput(fixture) {
@@ -2132,6 +2134,9 @@ function validateRouteServiceAdmission(pack) {
   ].filter(({ serviceClass }) => serviceClass === "ITX_CHEONGCHUN").length;
   if (itxRowCount > 0 && (evidence?.admissionStatus !== "ADMITTED" || evidence?.admissionEligible !== true)) {
     throw new Error("ITX_CHEONGCHUN rows require ADMITTED evidence");
+  }
+  if (itxRowCount > 0 && !validatedItxAdmissionPacks.has(pack)) {
+    throw new Error("ITX_CHEONGCHUN rows require a validated admission artifact materializer");
   }
 }
 

--- a/tools/datapack/build-datapack.mjs
+++ b/tools/datapack/build-datapack.mjs
@@ -177,8 +177,10 @@ async function loadBuildInput(args, officialOdFareAdmissions, officialOdFareAdmi
     throw new Error("exactly one of --fixture or --build-spec is required");
   }
   if (fixtureArg != null) {
+    const fixture = JSON.parse(await readFile(path.resolve(root, fixtureArg), "utf8"));
+    rejectTestOnlyBuildInput(fixture);
     return {
-      fixture: JSON.parse(await readFile(path.resolve(root, fixtureArg), "utf8")),
+      fixture,
       candidateBuild: null,
     };
   }
@@ -187,6 +189,7 @@ async function loadBuildInput(args, officialOdFareAdmissions, officialOdFareAdmi
   const buildSpecBytes = await readFile(buildSpecPath);
   const buildSpec = JSON.parse(buildSpecBytes);
   const fixture = JSON.parse(await readFile(await resolveBuildInputPath(buildSpec.fixturePath, "buildSpec.fixturePath"), "utf8"));
+  rejectTestOnlyBuildInput(fixture);
   const officialOdFareEvidence = await validateCandidateBuildSpec(
     buildSpec,
     fixture,
@@ -197,6 +200,12 @@ async function loadBuildInput(args, officialOdFareAdmissions, officialOdFareAdmi
     fixture,
     candidateBuild: candidateBuildProvenance(buildSpec, sha256(buildSpecBytes), officialOdFareEvidence),
   };
+}
+
+function rejectTestOnlyBuildInput(fixture) {
+  if (fixture?.fixtureClass === "TEST_ONLY") {
+    throw new Error("TEST_ONLY artifact cannot be used as datapack build input");
+  }
 }
 
 async function validateCandidateBuildSpec(buildSpec, fixture, admissions, admissionBytes) {

--- a/tools/datapack/build-route-graph-topology-report.mjs
+++ b/tools/datapack/build-route-graph-topology-report.mjs
@@ -98,10 +98,10 @@ export function buildRouteGraphTopologyReport(sqlitePath, pack = {}) {
     for (const edge of edges) {
       const edgeType = String(edge.edge_type ?? "").toUpperCase();
       const servicePattern = String(edge.service_pattern || "LOCAL").toUpperCase();
+      const serviceClass = String(edge.service_class || "SUBWAY").toUpperCase();
       edgeCountsByType[edgeType] = (edgeCountsByType[edgeType] ?? 0) + 1;
       if (edgeType === "RIDE") {
         rideCountsByServicePattern[servicePattern] = (rideCountsByServicePattern[servicePattern] ?? 0) + 1;
-        const serviceClass = String(edge.service_class || "SUBWAY").toUpperCase();
         rideCountsByServiceClass[serviceClass] = (rideCountsByServiceClass[serviceClass] ?? 0) + 1;
         const speedKmh = speed(edge.distance_meters, edge.duration_seconds);
         if (speedKmh !== null && (speedKmh < 15 || speedKmh > 110)) {
@@ -113,7 +113,13 @@ export function buildRouteGraphTopologyReport(sqlitePath, pack = {}) {
       const from = stationLineByNode.get(fromNode);
       const to = stationLineByNode.get(toNode);
       if (edgeType === "RIDE" && from && to) {
-        if (from.line_id !== to.line_id || Math.abs(from.line_sequence - to.line_sequence) !== 1) {
+        const isItxSkipStop = serviceClass === "ITX_CHEONGCHUN"
+          && servicePattern === "EXPRESS"
+          && from.line_id === to.line_id;
+        if (
+          from.line_id !== to.line_id
+          || (Math.abs(from.line_sequence - to.line_sequence) !== 1 && !isItxSkipStop)
+        ) {
           const violation = {
             edgeId: edge.id,
             fromNode,

--- a/tools/datapack/build-route-graph-topology-report.mjs
+++ b/tools/datapack/build-route-graph-topology-report.mjs
@@ -63,8 +63,18 @@ export function buildRouteGraphTopologyReport(sqlitePath, pack = {}) {
   const database = new DatabaseSync(sqlitePath, { readOnly: true });
   try {
     const stationLines = database.prepare("SELECT station_id, line_id, line_sequence FROM station_lines ORDER BY line_id, line_sequence, station_id").all();
+    const hasServiceClass = database
+      .prepare("PRAGMA table_info(network_edges)")
+      .all()
+      .some(({ name }) => name === "service_class");
     const edges = database
-      .prepare("SELECT id, from_node_id, to_node_id, edge_type, service_pattern, duration_seconds, distance_meters FROM network_edges ORDER BY id")
+      .prepare(`
+        SELECT id, from_node_id, to_node_id, edge_type, service_pattern,
+               ${hasServiceClass ? "service_class" : "'SUBWAY' AS service_class"},
+               duration_seconds, distance_meters
+        FROM network_edges
+        ORDER BY id
+      `)
       .all();
     const stationLineByNode = new Map(
       stationLines.map((row) => [stationLineNodeId(row.station_id, row.line_id), row]),
@@ -82,6 +92,7 @@ export function buildRouteGraphTopologyReport(sqlitePath, pack = {}) {
     };
     const edgeCountsByType = {};
     const rideCountsByServicePattern = {};
+    const rideCountsByServiceClass = {};
 
     addGeneratedStationTransferEdges(stationLines, routeGraphNodes, adjacency, undirected);
     for (const edge of edges) {
@@ -90,6 +101,8 @@ export function buildRouteGraphTopologyReport(sqlitePath, pack = {}) {
       edgeCountsByType[edgeType] = (edgeCountsByType[edgeType] ?? 0) + 1;
       if (edgeType === "RIDE") {
         rideCountsByServicePattern[servicePattern] = (rideCountsByServicePattern[servicePattern] ?? 0) + 1;
+        const serviceClass = String(edge.service_class || "SUBWAY").toUpperCase();
+        rideCountsByServiceClass[serviceClass] = (rideCountsByServiceClass[serviceClass] ?? 0) + 1;
         const speedKmh = speed(edge.distance_meters, edge.duration_seconds);
         if (speedKmh !== null && (speedKmh < 15 || speedKmh > 110)) {
           violations.rideSpeed.push({ edgeId: edge.id, speedKmh });
@@ -147,6 +160,8 @@ export function buildRouteGraphTopologyReport(sqlitePath, pack = {}) {
       networkEdgeCount: edges.length,
       edgeCountsByType,
       rideCountsByServicePattern,
+      rideCountsByServiceClass,
+      itxServiceLayerSegmentCount: rideCountsByServiceClass.ITX_CHEONGCHUN ?? 0,
       violations,
     };
   } finally {

--- a/tools/datapack/build-route-graph-topology-report.mjs
+++ b/tools/datapack/build-route-graph-topology-report.mjs
@@ -134,7 +134,12 @@ export function buildRouteGraphTopologyReport(sqlitePath, pack = {}) {
           }
         }
       }
-      if (!isRouteGraphEdge(edgeType) || !routeGraphNodes.has(fromNode) || !routeGraphNodes.has(toNode)) {
+      if (
+        serviceClass !== "SUBWAY"
+        || !isRouteGraphEdge(edgeType)
+        || !routeGraphNodes.has(fromNode)
+        || !routeGraphNodes.has(toNode)
+      ) {
         continue;
       }
       addEdge(adjacency, fromNode, toNode);

--- a/tools/datapack/build-route-graph-topology-report.test.mjs
+++ b/tools/datapack/build-route-graph-topology-report.test.mjs
@@ -88,7 +88,7 @@ test("route graph topology report는 ITX service layer row를 별도 집계한�
   const sqlitePath = createTopologySqlite({
     stationLines: [
       ["station-a", "line-k2", 1],
-      ["station-b", "line-k2", 2],
+      ["station-b", "line-k2", 24],
     ],
     edges: [
       ["edge-a-b-itx", "station-a:line-k2:EXPRESS", "station-b:line-k2:EXPRESS", "RIDE", "EXPRESS", 300, 6000, "ITX_CHEONGCHUN"],
@@ -103,6 +103,7 @@ test("route graph topology report는 ITX service layer row를 별도 집계한�
 
   assert.deepEqual(report.rideCountsByServiceClass, { ITX_CHEONGCHUN: 1 });
   assert.equal(report.itxServiceLayerSegmentCount, 1);
+  assert.deepEqual(report.violations.nonAdjacentExpressRide, []);
 });
 
 test("route graph topology report CLI writes artifact json", async () => {

--- a/tools/datapack/build-route-graph-topology-report.test.mjs
+++ b/tools/datapack/build-route-graph-topology-report.test.mjs
@@ -106,6 +106,31 @@ test("route graph topology report는 ITX service layer row를 별도 집계한�
   assert.deepEqual(report.violations.nonAdjacentExpressRide, []);
 });
 
+test("route graph topology report는 SUBWAY 연결성을 ITX edge로 보완하지 않는다", () => {
+  const sqlitePath = createTopologySqlite({
+    stationLines: [
+      ["station-a", "line-k2", 1],
+      ["station-b", "line-k2", 2],
+      ["station-c", "line-k2", 3],
+    ],
+    edges: [
+      ["subway-a-b", "station-a:line-k2:LOCAL", "station-b:line-k2:LOCAL", "RIDE", "LOCAL", 120, 1000],
+      ["subway-b-a", "station-b:line-k2:LOCAL", "station-a:line-k2:LOCAL", "RIDE", "LOCAL", 120, 1000],
+      ["itx-b-c", "station-b:line-k2:EXPRESS", "station-c:line-k2:EXPRESS", "RIDE", "EXPRESS", 120, 1000, "ITX_CHEONGCHUN"],
+      ["itx-c-b", "station-c:line-k2:EXPRESS", "station-b:line-k2:EXPRESS", "RIDE", "EXPRESS", 120, 1000, "ITX_CHEONGCHUN"],
+    ],
+  });
+
+  const report = buildRouteGraphTopologyReport(sqlitePath, {
+    id: "capital",
+    version: "1",
+    artifactKind: "fixture",
+  });
+
+  assert.deepEqual(report.violations.disconnectedNodes, ["station-c:line-k2"]);
+  assert.equal(report.violations.unreachableDirectedPairs.length, 4);
+});
+
 test("route graph topology report CLI writes artifact json", async () => {
   const dir = await mkdtemp(path.join(tmpdir(), "route-graph-topology-report-"));
   await mkdir(path.join(dir, "catalog"), { recursive: true });

--- a/tools/datapack/build-route-graph-topology-report.test.mjs
+++ b/tools/datapack/build-route-graph-topology-report.test.mjs
@@ -84,6 +84,27 @@ test("route graph topology report seeds implicit same-station transfers", () => 
   assert.equal(report.violations.unreachableDirectedPairs.length, 0);
 });
 
+test("route graph topology report는 ITX service layer row를 별도 집계한다", () => {
+  const sqlitePath = createTopologySqlite({
+    stationLines: [
+      ["station-a", "line-k2", 1],
+      ["station-b", "line-k2", 2],
+    ],
+    edges: [
+      ["edge-a-b-itx", "station-a:line-k2:EXPRESS", "station-b:line-k2:EXPRESS", "RIDE", "EXPRESS", 300, 6000, "ITX_CHEONGCHUN"],
+    ],
+  });
+
+  const report = buildRouteGraphTopologyReport(sqlitePath, {
+    id: "capital",
+    version: "1",
+    artifactKind: "fixture",
+  });
+
+  assert.deepEqual(report.rideCountsByServiceClass, { ITX_CHEONGCHUN: 1 });
+  assert.equal(report.itxServiceLayerSegmentCount, 1);
+});
+
 test("route graph topology report CLI writes artifact json", async () => {
   const dir = await mkdtemp(path.join(tmpdir(), "route-graph-topology-report-"));
   await mkdir(path.join(dir, "catalog"), { recursive: true });
@@ -153,17 +174,23 @@ function createTopologySqlite({ stationLines, edges }) {
         to_node_id TEXT NOT NULL,
         edge_type TEXT NOT NULL,
         service_pattern TEXT NOT NULL,
+        service_class TEXT NOT NULL DEFAULT 'SUBWAY',
         duration_seconds INTEGER NOT NULL,
         distance_meters INTEGER NOT NULL
       );
     `);
     const insertStationLine = database.prepare("INSERT INTO station_lines VALUES (?, ?, ?)");
-    const insertEdge = database.prepare("INSERT INTO network_edges VALUES (?, ?, ?, ?, ?, ?, ?)");
+    const insertEdge = database.prepare(`
+      INSERT INTO network_edges (
+        id, from_node_id, to_node_id, edge_type, service_pattern,
+        duration_seconds, distance_meters, service_class
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `);
     for (const row of stationLines) {
       insertStationLine.run(...row);
     }
     for (const row of edges) {
-      insertEdge.run(...row);
+      insertEdge.run(...row, ...(row.length === 7 ? ["SUBWAY"] : []));
     }
   } finally {
     database.close();

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -57,6 +57,25 @@ const productionEnv = {
   EASYSUBWAY_DATAPACK_SIGNING_PUBLIC_KEY_PEM: testPublicKeyPem,
 };
 
+test("데이터팩 생성기는 TEST_ONLY admission fixture를 build input으로 거부한다", async (context) => {
+  const outputDir = await mkdtemp(path.join(tmpdir(), "easysubway-itx-test-only-"));
+  context.after(() => rm(outputDir, { recursive: true, force: true }));
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/build-datapack.mjs",
+        "--fixture",
+        "tools/datapack/fixtures/test-only-itx-cheongchun-admitted.json",
+        "--output",
+        outputDir,
+      ],
+      { cwd: root, env: productionEnv },
+    ),
+    /TEST_ONLY artifact cannot be used as datapack build input/,
+  );
+});
+
 test("데이터팩 생성기는 fixture로 원격 manifest와 gzip SQLite pack을 만든다", async () => {
   const outputDir = path.join(tmpdir(), `easysubway-datapack-${Date.now()}`);
   await rm(outputDir, { recursive: true, force: true });

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -16650,6 +16650,38 @@ test("bundled 공식 OD quote no-op도 catalog user_version 16을 강제한다",
   }
 });
 
+test("bundled 공식 OD quote 후처리기는 v18 catalog를 v16으로 낮추지 않는다", async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "bundled-official-od-newer-version-"));
+  const packPath = path.join(directory, "capital.sqlite.gz");
+  const indexPath = path.join(directory, "index.json");
+  const sqlitePath = path.join(directory, "capital.sqlite");
+  try {
+    await writeFile(
+      sqlitePath,
+      gunzipSync(await readFile(path.join(root, "apps/mobile/assets/datapacks/capital.sqlite.gz"))),
+    );
+    const database = new DatabaseSync(sqlitePath);
+    database.exec("PRAGMA user_version = 18");
+    database.close();
+    const inputPack = gzipSync(await readFile(sqlitePath), { level: 9, mtime: 0 });
+    await writeFile(packPath, inputPack);
+    await copyFile(path.join(root, "apps/mobile/assets/datapacks/index.json"), indexPath);
+
+    await assert.rejects(
+      execFileAsync(process.execPath, [
+        "tools/datapack/apply-official-od-fares-to-bundled-pack.mjs",
+        "--pack", packPath,
+        "--index", indexPath,
+      ], { cwd: root }),
+      /does not support catalog user_version 18 newer than 16/,
+    );
+
+    assert.equal(sha256(await readFile(packPath)), sha256(inputPack));
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 test("수도권 bundled datapack은 빠른하차 차량·출입문 힌트 35건을 포함한다", async () => {
   const directory = await mkdtemp(path.join(tmpdir(), "bundled-car-door-hints-"));
   const databasePath = path.join(directory, "capital.sqlite");
@@ -16742,6 +16774,38 @@ test("bundled 차량·출입문 힌트 check는 catalog user_version 16을 요�
       ], { cwd: root }),
       /bundled catalog user_version must be 16/,
     );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("bundled 차량·출입문 힌트 후처리기는 v18 catalog를 v16으로 낮추지 않는다", async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "bundled-car-door-hints-newer-version-"));
+  const packPath = path.join(directory, "capital.sqlite.gz");
+  const indexPath = path.join(directory, "index.json");
+  const sqlitePath = path.join(directory, "capital.sqlite");
+  try {
+    await writeFile(
+      sqlitePath,
+      gunzipSync(await readFile(path.join(root, "apps/mobile/assets/datapacks/capital.sqlite.gz"))),
+    );
+    const database = new DatabaseSync(sqlitePath);
+    database.exec("PRAGMA user_version = 18");
+    database.close();
+    const inputPack = gzipSync(await readFile(sqlitePath), { level: 9, mtime: 0 });
+    await writeFile(packPath, inputPack);
+    await copyFile(path.join(root, "apps/mobile/assets/datapacks/index.json"), indexPath);
+
+    await assert.rejects(
+      execFileAsync(process.execPath, [
+        "tools/datapack/apply-car-door-hints-to-bundled-pack.mjs",
+        "--pack", packPath,
+        "--index", indexPath,
+      ], { cwd: root }),
+      /does not support catalog user_version 18 newer than 16/,
+    );
+
+    assert.equal(sha256(await readFile(packPath)), sha256(inputPack));
   } finally {
     await rm(directory, { recursive: true, force: true });
   }

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -5507,6 +5507,57 @@ test("데이터팩 검증기는 WALKWAY edge를 route graph 연결성으로 인�
   );
 });
 
+test("데이터팩 검증기는 ITX edge를 SUBWAY representative route 연결성으로 인정하지 않는다", async () => {
+  const outputDir = await mkdtemp(path.join(tmpdir(), "easysubway-datapack-itx-only-route-"));
+  try {
+    await execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/build-datapack.mjs",
+        "--fixture",
+        "tools/datapack/fixtures/catalog-fixture.json",
+        "--output",
+        outputDir,
+      ],
+      { cwd: root, env: productionEnv },
+    );
+
+    const manifestPath = path.join(outputDir, "current.json");
+    const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+    const pack = manifest.packs[0];
+    const sqlitePath = path.join(outputDir, "catalog", "capital-v1.sqlite");
+    const database = new DatabaseSync(sqlitePath);
+    try {
+      database.prepare("UPDATE network_edges SET service_class = 'ITX_CHEONGCHUN' WHERE edge_type = 'RIDE'").run();
+    } finally {
+      database.close();
+    }
+    const sqliteBytes = await readFile(sqlitePath);
+    const compressedBytes = gzipSync(sqliteBytes);
+    await writeFile(path.join(outputDir, "catalog", "capital-v1.sqlite.gz"), compressedBytes);
+    pack.sizeBytes = compressedBytes.length;
+    pack.sha256 = sha256(compressedBytes);
+    pack.sqliteSha256 = sha256(sqliteBytes);
+    const fixturePayload = `${pack.id}:${pack.version}:${pack.sha256}:${pack.sqliteSha256}:${pack.sizeBytes}`;
+    pack.signature.value = sha256(Buffer.from(fixturePayload));
+    pack.representativeRouteRegressionSignature.value = sha256(
+      Buffer.from(`${fixturePayload}:${representativeRouteRegressionPayload(pack.representativeRouteRegressions)}`),
+    );
+    await writeFile(manifestPath, JSON.stringify(manifest));
+
+    await assert.rejects(
+      execFileAsync(
+        process.execPath,
+        ["tools/datapack/validate-datapack.mjs", "--manifest", manifestPath, "--root", outputDir],
+        { cwd: root, env: productionEnv },
+      ),
+      /representativeRouteRegressions required edge missing|station-line node is isolated from route graph|route graph has unreachable directed path/,
+    );
+  } finally {
+    await rm(outputDir, { recursive: true, force: true });
+  }
+});
+
 test("데이터팩 검증기는 unknown network edge_type을 거부한다", async () => {
   const outputDir = path.join(tmpdir(), `easysubway-datapack-unknown-edge-type-${Date.now()}`);
   const fixturePath = path.join(outputDir, "fixture.json");

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -230,7 +230,7 @@ test("데이터팩 생성기는 fixture로 원격 manifest와 gzip SQLite pack�
   const database = new DatabaseSync(sqlitePath, { readOnly: true });
   try {
     assert.equal(database.prepare("PRAGMA quick_check").get().quick_check, "ok");
-    assert.equal(database.prepare("PRAGMA user_version").get().user_version, 16);
+    assert.equal(database.prepare("PRAGMA user_version").get().user_version, 18);
     assert.equal(database.prepare("SELECT value FROM catalog_metadata WHERE key = 'schemaVersion'").get().value, "1");
     assert.equal(database.prepare("SELECT updated_at FROM catalog_metadata WHERE key = 'schemaVersion'").get().updated_at, 1781827200);
     assert.equal(database.prepare("SELECT last_verified_at FROM stations WHERE id = 'station-sangnoksu'").get().last_verified_at, 1781827200);
@@ -739,7 +739,7 @@ test("데이터팩 검증기는 공개 채널 user_version 상한을 넘는 pack
       ],
       { cwd: root, env: productionEnv },
     ),
-    /capital@1 catalog user_version 16 exceeds public compatibility maximum 14/,
+    /capital@1 catalog user_version 18 exceeds public compatibility maximum 14/,
   );
 });
 
@@ -766,7 +766,7 @@ test("데이터팩 생성기는 transit_feed_info feed_end_date를 적재하고 
 
   const database = new DatabaseSync(path.join(outputDir, "catalog", "capital-v1.sqlite"), { readOnly: true });
   try {
-    assert.equal(database.prepare("PRAGMA user_version").get().user_version, 16);
+    assert.equal(database.prepare("PRAGMA user_version").get().user_version, 18);
     assert.equal(
       database.prepare("SELECT feed_end_date FROM transit_feed_info").get().feed_end_date,
       "20261231",
@@ -2836,7 +2836,7 @@ test("데이터팩 생성기는 schema v2 실시간 provider mapping을 SQLite�
 
   const database = new DatabaseSync(path.join(outputDir, "catalog", "capital-v2.sqlite"), { readOnly: true });
   try {
-    assert.equal(database.prepare("PRAGMA user_version").get().user_version, 16);
+    assert.equal(database.prepare("PRAGMA user_version").get().user_version, 18);
     assert.deepEqual(
       {
         ...database

--- a/tools/datapack/fixtures/test-only-itx-cheongchun-admitted.json
+++ b/tools/datapack/fixtures/test-only-itx-cheongchun-admitted.json
@@ -10,7 +10,7 @@
   "freshness": {
     "status": "FRESH",
     "observedAt": "2026-07-14T00:00:00.000Z",
-    "freshUntil": "2026-07-21T00:00:00.000Z"
+    "freshUntil": "2099-01-01T00:00:00.000Z"
   },
   "timetableArtifactIdentity": {
     "id": "test-only-itx-cheongchun-admitted-v1",

--- a/tools/datapack/fixtures/test-only-itx-cheongchun-admitted.json
+++ b/tools/datapack/fixtures/test-only-itx-cheongchun-admitted.json
@@ -1,0 +1,65 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "deterministic-itx-cheongchun-admission-fixture",
+  "fixtureClass": "TEST_ONLY",
+  "serviceClass": "ITX_CHEONGCHUN",
+  "sourceIssue": 2116,
+  "admissionStatus": "ADMITTED",
+  "admissionEligible": true,
+  "freshness": {
+    "status": "FRESH",
+    "observedAt": "2026-07-14T00:00:00.000Z",
+    "freshUntil": "2026-07-21T00:00:00.000Z"
+  },
+  "timetableArtifactIdentity": {
+    "id": "test-only-itx-cheongchun-admitted-v1",
+    "sha256Source": "FIXTURE_FILE_BYTES"
+  },
+  "canonicalPackIdentity": {
+    "id": "test-only-capital-canonical-v1",
+    "sha256Source": "GENERATED_TEST_PACK_BYTES"
+  },
+  "canonicalStations": [
+    {
+      "providerStationId": "NAT130126",
+      "canonicalStationId": "station-b819702fa7d9",
+      "nameKo": "청량리",
+      "capitalRouteMapMember": true
+    },
+    {
+      "providerStationId": "NAT140873",
+      "canonicalStationId": "station-dd14cfb89cbc",
+      "nameKo": "춘천",
+      "capitalRouteMapMember": true
+    }
+  ],
+  "transitTrips": [
+    {
+      "id": "test-only-itx-cheongchun-2001",
+      "routeId": "test-only-itx-cheongchun-down",
+      "serviceId": "test-only-weekday",
+      "tripHeadsign": "station-dd14cfb89cbc",
+      "directionId": "down",
+      "servicePattern": "EXPRESS",
+      "serviceClass": "ITX_CHEONGCHUN"
+    }
+  ],
+  "transitStopTimes": [
+    {
+      "tripId": "test-only-itx-cheongchun-2001",
+      "stopSequence": 1,
+      "stationId": "station-b819702fa7d9",
+      "lineId": "line-54a7b980b7c3",
+      "arrivalSeconds": 28800,
+      "departureSeconds": 28860
+    },
+    {
+      "tripId": "test-only-itx-cheongchun-2001",
+      "stopSequence": 2,
+      "stationId": "station-dd14cfb89cbc",
+      "lineId": "line-54a7b980b7c3",
+      "arrivalSeconds": 33000,
+      "departureSeconds": 33060
+    }
+  ]
+}

--- a/tools/datapack/fixtures/test-only-itx-cheongchun-admitted.json
+++ b/tools/datapack/fixtures/test-only-itx-cheongchun-admitted.json
@@ -3,6 +3,7 @@
   "artifactKind": "deterministic-itx-cheongchun-admission-fixture",
   "fixtureClass": "TEST_ONLY",
   "serviceClass": "ITX_CHEONGCHUN",
+  "canonicalLineId": "line-54a7b980b7c3",
   "sourceIssue": 2116,
   "admissionStatus": "ADMITTED",
   "admissionEligible": true,
@@ -16,8 +17,9 @@
     "sha256Source": "FIXTURE_FILE_BYTES"
   },
   "canonicalPackIdentity": {
-    "id": "test-only-capital-canonical-v1",
-    "sha256Source": "GENERATED_TEST_PACK_BYTES"
+    "id": "capital",
+    "sha256": "580814a58ce8d94b174de1ca8753ef7f350ce806dd793f6a7f43e07e7aa155b9",
+    "sqliteSha256": "72b85f941a8cb3a905218287a3e2ff4ce38561397ed5c22d77816576529ffe03"
   },
   "canonicalStations": [
     {
@@ -31,6 +33,31 @@
       "canonicalStationId": "station-dd14cfb89cbc",
       "nameKo": "춘천",
       "capitalRouteMapMember": true
+    }
+  ],
+  "serviceCalendars": [
+    {
+      "serviceId": "test-only-weekday",
+      "monday": true,
+      "tuesday": true,
+      "wednesday": true,
+      "thursday": true,
+      "friday": true,
+      "saturday": false,
+      "sunday": false,
+      "startDate": "20260714",
+      "endDate": "20260721",
+      "timezone": "Asia/Seoul"
+    }
+  ],
+  "transitRoutes": [
+    {
+      "id": "test-only-itx-cheongchun-down",
+      "lineId": "line-54a7b980b7c3",
+      "routeShortName": "ITX-청춘",
+      "routeLongName": "청량리 → 춘천",
+      "directionName": "춘천 방면",
+      "timezone": "Asia/Seoul"
     }
   ],
   "transitTrips": [

--- a/tools/datapack/itx-cheongchun-coverage-contract.json
+++ b/tools/datapack/itx-cheongchun-coverage-contract.json
@@ -152,6 +152,13 @@
       "officialSourceUrl": "https://www.data.go.kr/data/15125762/openapi.do",
       "endpoint": "https://apis.data.go.kr/B551457/run/v2/travelerTrainRunInfo2",
       "observedAt": "2026-07-14T08:35:44.292Z",
+      "artifactId": "itx-cheongchun-completeness-admission-20260714T083544292Z",
+      "canonicalPackIdentity": {
+        "id": "capital",
+        "sourceIssue": 2097,
+        "sha256": "580814a58ce8d94b174de1ca8753ef7f350ce806dd793f6a7f43e07e7aa155b9",
+        "sqliteSha256": "72b85f941a8cb3a905218287a3e2ff4ce38561397ed5c22d77816576529ffe03"
+      },
       "selectedServiceDates": { "8": "20260715", "7": "20260718", "9": "20260719" },
       "admissionStatus": "MISSING",
       "admissionEligible": false,

--- a/tools/datapack/itx-cheongchun-coverage-contract.test.mjs
+++ b/tools/datapack/itx-cheongchun-coverage-contract.test.mjs
@@ -131,6 +131,13 @@ test("ITX-청춘 live admission evidence는 세 service day 전수 결과를 cre
     officialSourceUrl: "https://www.data.go.kr/data/15125762/openapi.do",
     endpoint: "https://apis.data.go.kr/B551457/run/v2/travelerTrainRunInfo2",
     observedAt: "2026-07-14T08:35:44.292Z",
+    artifactId: "itx-cheongchun-completeness-admission-20260714T083544292Z",
+    canonicalPackIdentity: {
+      id: "capital",
+      sourceIssue: 2097,
+      sha256: "580814a58ce8d94b174de1ca8753ef7f350ce806dd793f6a7f43e07e7aa155b9",
+      sqliteSha256: "72b85f941a8cb3a905218287a3e2ff4ce38561397ed5c22d77816576529ffe03",
+    },
     selectedServiceDates: { "8": "20260715", "7": "20260718", "9": "20260719" },
     admissionStatus: "MISSING",
     admissionEligible: false,
@@ -183,6 +190,24 @@ test("ITX-청춘 live admission evidence는 세 service day 전수 결과를 cre
     nextReviewAt: "2026-07-20T00:00:00.000Z",
     credentialRedacted: true,
   });
+});
+
+test("ITX-청춘 admission evidence는 #2097 canonical bundled pack bytes에 결합된다", async () => {
+  const canonicalPackBytes = await readFile(new URL(
+    "../../apps/mobile/assets/datapacks/capital.sqlite.gz",
+    import.meta.url,
+  ));
+  const canonicalPackSha256 = createHash("sha256").update(canonicalPackBytes).digest("hex");
+  assert.deepEqual(contract.officialEvidence.korailCompletenessAdmission.canonicalPackIdentity, {
+    id: "capital",
+    sourceIssue: 2097,
+    sha256: canonicalPackSha256,
+    sqliteSha256: "72b85f941a8cb3a905218287a3e2ff4ce38561397ed5c22d77816576529ffe03",
+  });
+  assert.equal(
+    contract.officialEvidence.korailCompletenessAdmission.artifactId,
+    "itx-cheongchun-completeness-admission-20260714T083544292Z",
+  );
 });
 
 test("ITX-청춘 evidence는 공식 URL·schema/hash·재검토 시점을 갖고 credential을 포함하지 않는다", () => {

--- a/tools/datapack/itx-cheongchun-coverage-contract.test.mjs
+++ b/tools/datapack/itx-cheongchun-coverage-contract.test.mjs
@@ -32,8 +32,9 @@ test("deterministic ADMITTED fixture는 test-only이며 production evidence에 �
     sha256Source: "FIXTURE_FILE_BYTES",
   });
   assert.deepEqual(fixture.canonicalPackIdentity, {
-    id: "test-only-capital-canonical-v1",
-    sha256Source: "GENERATED_TEST_PACK_BYTES",
+    id: "capital",
+    sha256: "580814a58ce8d94b174de1ca8753ef7f350ce806dd793f6a7f43e07e7aa155b9",
+    sqliteSha256: "72b85f941a8cb3a905218287a3e2ff4ce38561397ed5c22d77816576529ffe03",
   });
 
   const forbiddenProductionSurfaces = [

--- a/tools/datapack/itx-cheongchun-coverage-contract.test.mjs
+++ b/tools/datapack/itx-cheongchun-coverage-contract.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 
@@ -9,6 +10,45 @@ const stationSequenceEvidence = JSON.parse(await readFile(
   new URL("./sources/korail-itx-cheongchun-station-sequence-20260713.json", import.meta.url),
   "utf8",
 ));
+const admittedFixtureUrl = new URL("./fixtures/test-only-itx-cheongchun-admitted.json", import.meta.url);
+
+test("deterministic ADMITTED fixture는 test-only이며 production evidence에 연결되지 않는다", async () => {
+  let fixtureBytes = null;
+  try {
+    fixtureBytes = await readFile(admittedFixtureUrl);
+  } catch {
+    // 아래 assertion이 누락된 fixture를 계약 실패로 보고한다.
+  }
+  assert.ok(fixtureBytes, "test-only ITX-청춘 ADMITTED fixture가 필요하다");
+
+  const fixture = JSON.parse(fixtureBytes);
+  const fixtureSha256 = createHash("sha256").update(fixtureBytes).digest("hex");
+  assert.equal(fixture.fixtureClass, "TEST_ONLY");
+  assert.equal(fixture.serviceClass, "ITX_CHEONGCHUN");
+  assert.equal(fixture.admissionStatus, "ADMITTED");
+  assert.equal(fixture.admissionEligible, true);
+  assert.deepEqual(fixture.timetableArtifactIdentity, {
+    id: "test-only-itx-cheongchun-admitted-v1",
+    sha256Source: "FIXTURE_FILE_BYTES",
+  });
+  assert.deepEqual(fixture.canonicalPackIdentity, {
+    id: "test-only-capital-canonical-v1",
+    sha256Source: "GENERATED_TEST_PACK_BYTES",
+  });
+
+  const forbiddenProductionSurfaces = [
+    "./source-inventory.json",
+    "./release/candidate-build-spec.json",
+    "../../apps/mobile/assets/datapacks/source-inventory.json",
+    "../../apps/mobile/assets/datapacks/index.json",
+    "../../apps/mobile/release/production-datapack-scope.json",
+  ];
+  for (const relativePath of forbiddenProductionSurfaces) {
+    const productionText = await readFile(new URL(relativePath, import.meta.url), "utf8");
+    assert.doesNotMatch(productionText, /test-only-itx-cheongchun-admitted\.json/);
+    assert.equal(productionText.includes(fixtureSha256), false, `${relativePath}에 test-only fixture hash가 연결됐다`);
+  }
+});
 
 test("ITX-청춘 coverage contract는 sequence 성공을 timetable 시각 지원으로 과장하지 않는다", () => {
   assert.deepEqual(contract.searchScopePolicy, {

--- a/tools/datapack/itx-cheongchun-coverage-contract.test.mjs
+++ b/tools/datapack/itx-cheongchun-coverage-contract.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
+import { gunzipSync } from "node:zlib";
 
 const contract = JSON.parse(await readFile(new URL("./itx-cheongchun-coverage-contract.json", import.meta.url), "utf8"));
 const targets = JSON.parse(await readFile(new URL("./nationwide-coverage-targets.json", import.meta.url), "utf8"));
@@ -40,6 +41,7 @@ test("deterministic ADMITTED fixture는 test-only이며 production evidence에 �
   const forbiddenProductionSurfaces = [
     "./source-inventory.json",
     "./release/candidate-build-spec.json",
+    "./release/capital-production-reviewed-pack.json",
     "../../apps/mobile/assets/datapacks/source-inventory.json",
     "../../apps/mobile/assets/datapacks/index.json",
     "../../apps/mobile/release/production-datapack-scope.json",
@@ -47,6 +49,8 @@ test("deterministic ADMITTED fixture는 test-only이며 production evidence에 �
   for (const relativePath of forbiddenProductionSurfaces) {
     const productionText = await readFile(new URL(relativePath, import.meta.url), "utf8");
     assert.doesNotMatch(productionText, /test-only-itx-cheongchun-admitted\.json/);
+    assert.equal(productionText.includes(fixture.timetableArtifactIdentity.id), false,
+      `${relativePath}에 test-only fixture artifact ID가 연결됐다`);
     assert.equal(productionText.includes(fixtureSha256), false, `${relativePath}에 test-only fixture hash가 연결됐다`);
   }
 });
@@ -199,11 +203,14 @@ test("ITX-청춘 admission evidence는 #2097 canonical bundled pack bytes에 결
     import.meta.url,
   ));
   const canonicalPackSha256 = createHash("sha256").update(canonicalPackBytes).digest("hex");
+  const canonicalPackSqliteSha256 = createHash("sha256")
+    .update(gunzipSync(canonicalPackBytes))
+    .digest("hex");
   assert.deepEqual(contract.officialEvidence.korailCompletenessAdmission.canonicalPackIdentity, {
     id: "capital",
     sourceIssue: 2097,
     sha256: canonicalPackSha256,
-    sqliteSha256: "72b85f941a8cb3a905218287a3e2ff4ce38561397ed5c22d77816576529ffe03",
+    sqliteSha256: canonicalPackSqliteSha256,
   });
   assert.equal(
     contract.officialEvidence.korailCompletenessAdmission.artifactId,

--- a/tools/datapack/itx-cheongchun-service-layer.test.mjs
+++ b/tools/datapack/itx-cheongchun-service-layer.test.mjs
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import test from "node:test";
+import { promisify } from "node:util";
+import { gunzipSync } from "node:zlib";
+
+const schema = await readFile(new URL("./schema/catalog-schema.sql", import.meta.url), "utf8");
+const root = path.resolve(import.meta.dirname, "../..");
+const execFileAsync = promisify(execFile);
+const missingItxEvidence = () => ({
+  serviceClass: "ITX_CHEONGCHUN",
+  timetableArtifactId: "itx-cheongchun-completeness-admission-20260714T083544292Z",
+  timetableArtifactSha256: "347aec507ec951dde65c10a1c4bff9f94454f762d76a5a74064a40662008336c",
+  canonicalPackId: "capital",
+  canonicalPackSha256: "580814a58ce8d94b174de1ca8753ef7f350ce806dd793f6a7f43e07e7aa155b9",
+  canonicalPackSqliteSha256: "72b85f941a8cb3a905218287a3e2ff4ce38561397ed5c22d77816576529ffe03",
+  admissionStatus: "MISSING",
+  admissionEligible: false,
+  freshUntil: "2026-07-20T00:00:00.000Z",
+  sourceIssue: 2116,
+});
+
+test("production source pack은 #2116 MISSING identity를 기록하고 ITX data row를 포함하지 않는다", async () => {
+  const production = JSON.parse(await readFile(
+    new URL("./release/capital-production-reviewed-pack.json", import.meta.url),
+    "utf8",
+  ));
+  const pack = production.packs.find(({ id }) => id === "capital");
+  assert.deepEqual(pack.routeServiceArtifactEvidence, [{
+    serviceClass: "ITX_CHEONGCHUN",
+    timetableArtifactId: "itx-cheongchun-completeness-admission-20260714T083544292Z",
+    timetableArtifactSha256: "347aec507ec951dde65c10a1c4bff9f94454f762d76a5a74064a40662008336c",
+    canonicalPackId: "capital",
+    canonicalPackSha256: "580814a58ce8d94b174de1ca8753ef7f350ce806dd793f6a7f43e07e7aa155b9",
+    canonicalPackSqliteSha256: "72b85f941a8cb3a905218287a3e2ff4ce38561397ed5c22d77816576529ffe03",
+    admissionStatus: "MISSING",
+    admissionEligible: false,
+    freshUntil: "2026-07-20T00:00:00.000Z",
+    sourceIssue: 2116,
+  }]);
+  assert.equal((pack.transitTrips ?? []).filter(({ serviceClass }) => serviceClass === "ITX_CHEONGCHUN").length, 0);
+  assert.equal((pack.networkEdges ?? []).filter(({ serviceClass }) => serviceClass === "ITX_CHEONGCHUN").length, 0);
+});
+
+test("catalog schema는 service class와 admission evidence identity를 보존한다", () => {
+  const database = new DatabaseSync(":memory:");
+  try {
+    database.exec(schema);
+
+    assert.equal(database.prepare("PRAGMA user_version").get().user_version, 18);
+    for (const table of ["transit_trips", "network_edges"]) {
+      const serviceClass = database
+        .prepare(`PRAGMA table_info(${table})`)
+        .all()
+        .find(({ name }) => name === "service_class");
+      assert.deepEqual(
+        { notNull: serviceClass?.notnull, defaultValue: serviceClass?.dflt_value },
+        { notNull: 1, defaultValue: "'SUBWAY'" },
+      );
+    }
+
+    const evidenceColumns = database
+      .prepare("PRAGMA table_info(route_service_artifact_evidence)")
+      .all()
+      .map(({ name }) => name);
+    assert.deepEqual(evidenceColumns, [
+      "service_class",
+      "timetable_artifact_id",
+      "timetable_artifact_sha256",
+      "canonical_pack_id",
+      "canonical_pack_sha256",
+      "canonical_pack_sqlite_sha256",
+      "admission_status",
+      "admission_eligible",
+      "fresh_until",
+      "source_issue",
+    ]);
+  } finally {
+    database.close();
+  }
+});
+
+test("MISSING admission은 identity row만 적재하고 production ITX row를 0건으로 유지한다", async (context) => {
+  const temporaryDir = await mkdtemp(path.join(tmpdir(), "easysubway-itx-missing-"));
+  context.after(() => rm(temporaryDir, { recursive: true, force: true }));
+  const fixture = JSON.parse(await readFile(new URL("./fixtures/catalog-fixture.json", import.meta.url), "utf8"));
+  fixture.packs[0].routeServiceArtifactEvidence = [missingItxEvidence()];
+  const fixturePath = path.join(temporaryDir, "fixture.json");
+  const outputDir = path.join(temporaryDir, "output");
+  await writeFile(fixturePath, `${JSON.stringify(fixture)}\n`);
+
+  await execFileAsync(process.execPath, [
+    "tools/datapack/build-datapack.mjs",
+    "--fixture",
+    fixturePath,
+    "--output",
+    outputDir,
+  ], { cwd: root });
+
+  const sqlitePath = path.join(temporaryDir, "capital.sqlite");
+  await writeFile(sqlitePath, gunzipSync(await readFile(path.join(outputDir, "catalog/capital-v1.sqlite.gz"))));
+  const database = new DatabaseSync(sqlitePath, { readOnly: true });
+  try {
+    assert.equal(database.prepare("SELECT count(*) AS count FROM transit_trips WHERE service_class = 'ITX_CHEONGCHUN'").get().count, 0);
+    assert.equal(database.prepare("SELECT count(*) AS count FROM network_edges WHERE service_class = 'ITX_CHEONGCHUN'").get().count, 0);
+    assert.deepEqual({ ...database.prepare("SELECT * FROM route_service_artifact_evidence").get() }, {
+      service_class: "ITX_CHEONGCHUN",
+      timetable_artifact_id: "itx-cheongchun-completeness-admission-20260714T083544292Z",
+      timetable_artifact_sha256: "347aec507ec951dde65c10a1c4bff9f94454f762d76a5a74064a40662008336c",
+      canonical_pack_id: "capital",
+      canonical_pack_sha256: "580814a58ce8d94b174de1ca8753ef7f350ce806dd793f6a7f43e07e7aa155b9",
+      canonical_pack_sqlite_sha256: "72b85f941a8cb3a905218287a3e2ff4ce38561397ed5c22d77816576529ffe03",
+      admission_status: "MISSING",
+      admission_eligible: 0,
+      fresh_until: "2026-07-20T00:00:00.000Z",
+      source_issue: 2116,
+    });
+  } finally {
+    database.close();
+  }
+});
+
+test("MISSING admission pack에 ITX data row가 섞이면 build를 거부한다", async (context) => {
+  const temporaryDir = await mkdtemp(path.join(tmpdir(), "easysubway-itx-missing-row-"));
+  context.after(() => rm(temporaryDir, { recursive: true, force: true }));
+  const fixture = JSON.parse(await readFile(new URL("./fixtures/catalog-fixture.json", import.meta.url), "utf8"));
+  fixture.packs[0].routeServiceArtifactEvidence = [missingItxEvidence()];
+  fixture.packs[0].transitTrips[0].serviceClass = "ITX_CHEONGCHUN";
+  const fixturePath = path.join(temporaryDir, "fixture.json");
+  await writeFile(fixturePath, `${JSON.stringify(fixture)}\n`);
+
+  await assert.rejects(
+    execFileAsync(process.execPath, [
+      "tools/datapack/build-datapack.mjs",
+      "--fixture",
+      fixturePath,
+      "--output",
+      path.join(temporaryDir, "output"),
+    ], { cwd: root }),
+    /ITX_CHEONGCHUN rows require ADMITTED evidence/,
+  );
+});

--- a/tools/datapack/itx-cheongchun-service-layer.test.mjs
+++ b/tools/datapack/itx-cheongchun-service-layer.test.mjs
@@ -146,6 +146,31 @@ test("MISSING admission pack에 ITX data row가 섞이면 build를 거부한다"
   );
 });
 
+test("self-declared ADMITTED evidence가 있는 직접 ITX row도 검증된 artifact materializer 없이는 거부한다", async (context) => {
+  const temporaryDir = await mkdtemp(path.join(tmpdir(), "easysubway-itx-self-declared-"));
+  context.after(() => rm(temporaryDir, { recursive: true, force: true }));
+  const fixture = JSON.parse(await readFile(new URL("./fixtures/catalog-fixture.json", import.meta.url), "utf8"));
+  fixture.packs[0].routeServiceArtifactEvidence = [{
+    ...missingItxEvidence(),
+    admissionStatus: "ADMITTED",
+    admissionEligible: true,
+  }];
+  fixture.packs[0].transitTrips[0].serviceClass = "ITX_CHEONGCHUN";
+  const fixturePath = path.join(temporaryDir, "fixture.json");
+  await writeFile(fixturePath, `${JSON.stringify(fixture)}\n`);
+
+  await assert.rejects(
+    execFileAsync(process.execPath, [
+      "tools/datapack/build-datapack.mjs",
+      "--fixture",
+      fixturePath,
+      "--output",
+      path.join(temporaryDir, "output"),
+    ], { cwd: root }),
+    /validated admission artifact materializer/,
+  );
+});
+
 test("test-only ADMITTED timetable은 ITX trip·stop·EXPRESS edge를 materialize한다", async (context) => {
   const temporaryDir = await mkdtemp(path.join(tmpdir(), "easysubway-itx-admitted-"));
   context.after(() => rm(temporaryDir, { recursive: true, force: true }));
@@ -203,7 +228,9 @@ test("test-only ADMITTED timetable은 ITX trip·stop·EXPRESS edge를 materializ
   try {
     assert.equal(database.prepare("SELECT count(*) AS count FROM transit_trips WHERE service_class = 'ITX_CHEONGCHUN' AND service_pattern = 'EXPRESS'").get().count, 1);
     assert.equal(database.prepare("SELECT count(*) AS count FROM transit_stop_times WHERE trip_id = 'test-only-itx-cheongchun-2001'").get().count, 2);
-    assert.deepEqual({ ...database.prepare("SELECT edge_type, service_pattern, service_class, duration_seconds FROM network_edges WHERE service_class = 'ITX_CHEONGCHUN'").get() }, {
+    assert.deepEqual({ ...database.prepare("SELECT from_node_id, to_node_id, edge_type, service_pattern, service_class, duration_seconds FROM network_edges WHERE service_class = 'ITX_CHEONGCHUN'").get() }, {
+      from_node_id: "station-b819702fa7d9:line-54a7b980b7c3:EXPRESS",
+      to_node_id: "station-dd14cfb89cbc:line-54a7b980b7c3:EXPRESS",
       edge_type: "RIDE",
       service_pattern: "EXPRESS",
       service_class: "ITX_CHEONGCHUN",

--- a/tools/datapack/itx-cheongchun-service-layer.test.mjs
+++ b/tools/datapack/itx-cheongchun-service-layer.test.mjs
@@ -80,9 +80,57 @@ test("catalog schema는 service class와 admission evidence identity를 보존�
       "fresh_until",
       "source_issue",
     ]);
+    assert.throws(() => database.prepare(`
+      INSERT INTO route_service_artifact_evidence (
+        service_class, timetable_artifact_id, timetable_artifact_sha256,
+        canonical_pack_id, canonical_pack_sha256, canonical_pack_sqlite_sha256,
+        admission_status, admission_eligible, fresh_until, source_issue
+      ) VALUES ('ITX_CHEONGCHUN', 'test', ?, 'capital', ?, ?, 'ADMITTED', 1, NULL, 2116)
+    `).run("a".repeat(64), "b".repeat(64), "c".repeat(64)));
   } finally {
     database.close();
   }
+});
+
+test("ADMITTED evidence는 ITX row 없이 단독 게시할 수 없다", async (context) => {
+  const temporaryDir = await mkdtemp(path.join(tmpdir(), "easysubway-itx-admitted-without-rows-"));
+  context.after(() => rm(temporaryDir, { recursive: true, force: true }));
+  const fixture = JSON.parse(await readFile(new URL("./fixtures/catalog-fixture.json", import.meta.url), "utf8"));
+  fixture.packs[0].routeServiceArtifactEvidence = [{
+    ...missingItxEvidence(),
+    admissionStatus: "ADMITTED",
+    admissionEligible: true,
+    freshUntil: "2099-01-01T00:00:00.000Z",
+  }];
+  const fixturePath = path.join(temporaryDir, "fixture.json");
+  await writeFile(fixturePath, `${JSON.stringify(fixture)}\n`);
+
+  await assert.rejects(
+    execFileAsync(process.execPath, [
+      "tools/datapack/build-datapack.mjs",
+      "--fixture", fixturePath,
+      "--output", path.join(temporaryDir, "output"),
+    ], { cwd: root }),
+    /ADMITTED evidence requires ITX_CHEONGCHUN rows/,
+  );
+});
+
+test("ITX service evidence는 pack마다 정확히 한 행이어야 한다", async (context) => {
+  const temporaryDir = await mkdtemp(path.join(tmpdir(), "easysubway-itx-duplicate-evidence-"));
+  context.after(() => rm(temporaryDir, { recursive: true, force: true }));
+  const fixture = JSON.parse(await readFile(new URL("./fixtures/catalog-fixture.json", import.meta.url), "utf8"));
+  fixture.packs[0].routeServiceArtifactEvidence = [missingItxEvidence(), missingItxEvidence()];
+  const fixturePath = path.join(temporaryDir, "fixture.json");
+  await writeFile(fixturePath, `${JSON.stringify(fixture)}\n`);
+
+  await assert.rejects(
+    execFileAsync(process.execPath, [
+      "tools/datapack/build-datapack.mjs",
+      "--fixture", fixturePath,
+      "--output", path.join(temporaryDir, "output"),
+    ], { cwd: root }),
+    /exactly one ITX_CHEONGCHUN evidence row/,
+  );
 });
 
 test("MISSING admission은 identity row만 적재하고 production ITX row를 0건으로 유지한다", async (context) => {

--- a/tools/datapack/itx-cheongchun-service-layer.test.mjs
+++ b/tools/datapack/itx-cheongchun-service-layer.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { execFile } from "node:child_process";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -143,4 +144,79 @@ test("MISSING admission pack에 ITX data row가 섞이면 build를 거부한다"
     ], { cwd: root }),
     /ITX_CHEONGCHUN rows require ADMITTED evidence/,
   );
+});
+
+test("test-only ADMITTED timetable은 ITX trip·stop·EXPRESS edge를 materialize한다", async (context) => {
+  const temporaryDir = await mkdtemp(path.join(tmpdir(), "easysubway-itx-admitted-"));
+  context.after(() => rm(temporaryDir, { recursive: true, force: true }));
+  const fixture = JSON.parse(await readFile(new URL("./fixtures/catalog-fixture.json", import.meta.url), "utf8"));
+  const pack = fixture.packs[0];
+  pack.lines.push({
+    id: "line-54a7b980b7c3",
+    operatorId: "korail",
+    nameKo: "경춘선",
+    nameEn: "Gyeongchun Line",
+    color: "#00A3E0",
+  });
+  pack.stations.push(
+    {
+      id: "station-b819702fa7d9",
+      nameKo: "청량리",
+      nameEn: "Cheongnyangni",
+      normalizedName: "청량리",
+      region: "수도권",
+    },
+    {
+      id: "station-dd14cfb89cbc",
+      nameKo: "춘천",
+      nameEn: "Chuncheon",
+      normalizedName: "춘천",
+      region: "수도권",
+    },
+  );
+  pack.stationLines.push(
+    { stationId: "station-b819702fa7d9", lineId: "line-54a7b980b7c3", stationCode: "P117", lineSequence: 1 },
+    { stationId: "station-dd14cfb89cbc", lineId: "line-54a7b980b7c3", stationCode: "P140", lineSequence: 2 },
+  );
+  const routeMapTemplate = pack.routeMapPositions[0];
+  pack.routeMapPositions.push(
+    { ...routeMapTemplate, stationId: "station-b819702fa7d9", lineId: "line-54a7b980b7c3", region: "수도권", x: 100, y: 100 },
+    { ...routeMapTemplate, stationId: "station-dd14cfb89cbc", lineId: "line-54a7b980b7c3", region: "수도권", x: 200, y: 200 },
+  );
+  const fixturePath = path.join(temporaryDir, "fixture.json");
+  const outputDir = path.join(temporaryDir, "output");
+  await writeFile(fixturePath, `${JSON.stringify(fixture)}\n`);
+
+  await execFileAsync(process.execPath, [
+    "tools/datapack/build-datapack.mjs",
+    "--fixture", fixturePath,
+    "--test-only-itx-admission", "tools/datapack/fixtures/test-only-itx-cheongchun-admitted.json",
+    "--output", outputDir,
+  ], {
+    cwd: root,
+    env: { ...process.env, EASYSUBWAY_DATAPACK_BUILD_NOW: "2026-07-14T00:00:00.000Z" },
+  });
+
+  const sqlitePath = path.join(temporaryDir, "capital.sqlite");
+  await writeFile(sqlitePath, gunzipSync(await readFile(path.join(outputDir, "catalog/capital-v1.sqlite.gz"))));
+  const database = new DatabaseSync(sqlitePath, { readOnly: true });
+  try {
+    assert.equal(database.prepare("SELECT count(*) AS count FROM transit_trips WHERE service_class = 'ITX_CHEONGCHUN' AND service_pattern = 'EXPRESS'").get().count, 1);
+    assert.equal(database.prepare("SELECT count(*) AS count FROM transit_stop_times WHERE trip_id = 'test-only-itx-cheongchun-2001'").get().count, 2);
+    assert.deepEqual({ ...database.prepare("SELECT edge_type, service_pattern, service_class, duration_seconds FROM network_edges WHERE service_class = 'ITX_CHEONGCHUN'").get() }, {
+      edge_type: "RIDE",
+      service_pattern: "EXPRESS",
+      service_class: "ITX_CHEONGCHUN",
+      duration_seconds: 4140,
+    });
+    const evidence = database.prepare("SELECT * FROM route_service_artifact_evidence WHERE service_class = 'ITX_CHEONGCHUN'").get();
+    const admissionBytes = await readFile(new URL("./fixtures/test-only-itx-cheongchun-admitted.json", import.meta.url));
+    assert.equal(evidence.admission_status, "ADMITTED");
+    assert.equal(evidence.admission_eligible, 1);
+    assert.equal(evidence.timetable_artifact_sha256, createHash("sha256").update(admissionBytes).digest("hex"));
+    assert.equal(evidence.canonical_pack_sha256, "580814a58ce8d94b174de1ca8753ef7f350ce806dd793f6a7f43e07e7aa155b9");
+    assert.equal(evidence.canonical_pack_sqlite_sha256, "72b85f941a8cb3a905218287a3e2ff4ce38561397ed5c22d77816576529ffe03");
+  } finally {
+    database.close();
+  }
 });

--- a/tools/datapack/release/capital-production-reviewed-pack.json
+++ b/tools/datapack/release/capital-production-reviewed-pack.json
@@ -21003,6 +21003,20 @@
           "updatedAt": "2026-07-09T00:00:00.000Z"
         }
       ],
+      "routeServiceArtifactEvidence": [
+        {
+          "serviceClass": "ITX_CHEONGCHUN",
+          "timetableArtifactId": "itx-cheongchun-completeness-admission-20260714T083544292Z",
+          "timetableArtifactSha256": "347aec507ec951dde65c10a1c4bff9f94454f762d76a5a74064a40662008336c",
+          "canonicalPackId": "capital",
+          "canonicalPackSha256": "580814a58ce8d94b174de1ca8753ef7f350ce806dd793f6a7f43e07e7aa155b9",
+          "canonicalPackSqliteSha256": "72b85f941a8cb3a905218287a3e2ff4ce38561397ed5c22d77816576529ffe03",
+          "admissionStatus": "MISSING",
+          "admissionEligible": false,
+          "freshUntil": "2026-07-20T00:00:00.000Z",
+          "sourceIssue": 2116
+        }
+      ],
       "movementPathCandidates": [
         {
           "id": "movement-sangnoksu-elevator-kric-1",

--- a/tools/datapack/schema/catalog-schema.sql
+++ b/tools/datapack/schema/catalog-schema.sql
@@ -1,5 +1,5 @@
 PRAGMA foreign_keys = ON;
-PRAGMA user_version = 16;
+PRAGMA user_version = 18;
 
 CREATE TABLE catalog_metadata (
   key TEXT NOT NULL PRIMARY KEY,
@@ -94,10 +94,12 @@ CREATE TABLE transit_trips (
   trip_headsign TEXT NOT NULL DEFAULT '',
   direction_id TEXT NOT NULL DEFAULT '',
   service_pattern TEXT NOT NULL DEFAULT 'LOCAL',
+  service_class TEXT NOT NULL DEFAULT 'SUBWAY',
   service_day_start_seconds INTEGER NOT NULL DEFAULT 0,
   FOREIGN KEY (route_id) REFERENCES transit_routes(id),
   FOREIGN KEY (service_id) REFERENCES service_calendars(service_id),
   CHECK (service_pattern IN ('LOCAL', 'EXPRESS')),
+  CHECK (service_class IN ('SUBWAY', 'ITX_CHEONGCHUN')),
   CHECK (service_day_start_seconds >= 0 AND service_day_start_seconds < 108000)
 );
 
@@ -209,6 +211,27 @@ CREATE TABLE transit_feed_info (
   CHECK (feed_end_date GLOB '[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]')
 );
 
+CREATE TABLE route_service_artifact_evidence (
+  service_class TEXT NOT NULL PRIMARY KEY,
+  timetable_artifact_id TEXT NOT NULL,
+  timetable_artifact_sha256 TEXT NOT NULL,
+  canonical_pack_id TEXT NOT NULL,
+  canonical_pack_sha256 TEXT NOT NULL,
+  canonical_pack_sqlite_sha256 TEXT NOT NULL,
+  admission_status TEXT NOT NULL,
+  admission_eligible INTEGER NOT NULL,
+  fresh_until TEXT,
+  source_issue INTEGER NOT NULL,
+  CHECK (service_class = 'ITX_CHEONGCHUN'),
+  CHECK (length(timetable_artifact_sha256) = 64 AND timetable_artifact_sha256 NOT GLOB '*[^0-9a-f]*'),
+  CHECK (length(canonical_pack_sha256) = 64 AND canonical_pack_sha256 NOT GLOB '*[^0-9a-f]*'),
+  CHECK (length(canonical_pack_sqlite_sha256) = 64 AND canonical_pack_sqlite_sha256 NOT GLOB '*[^0-9a-f]*'),
+  CHECK (admission_status IN ('MISSING', 'ADMITTED')),
+  CHECK (admission_eligible IN (0, 1)),
+  CHECK ((admission_status = 'ADMITTED') = (admission_eligible = 1)),
+  CHECK (source_issue = 2116)
+);
+
 CREATE TABLE realtime_provider_line_mappings (
   provider_id TEXT NOT NULL,
   provider_line_id TEXT NOT NULL,
@@ -254,6 +277,7 @@ CREATE TABLE network_edges (
   -- Mobile keeps old TRANSFER rows as inStationTransfer for saved/older packs.
   edge_type TEXT NOT NULL DEFAULT 'WALKWAY',
   service_pattern TEXT NOT NULL DEFAULT '',
+  service_class TEXT NOT NULL DEFAULT 'SUBWAY',
   includes_stairs INTEGER NOT NULL DEFAULT 0,
   stair_access_state TEXT NOT NULL DEFAULT 'UNKNOWN',
   accessibility_status TEXT NOT NULL DEFAULT 'UNKNOWN',
@@ -265,7 +289,8 @@ CREATE TABLE network_edges (
   verification_status TEXT NOT NULL DEFAULT 'UNKNOWN',
   facility_id TEXT,
   last_verified_at INTEGER,
-  evidence_hash TEXT NOT NULL DEFAULT ''
+  evidence_hash TEXT NOT NULL DEFAULT '',
+  CHECK (service_class IN ('SUBWAY', 'ITX_CHEONGCHUN'))
 );
 
 CREATE TABLE out_of_station_transfer_links (

--- a/tools/datapack/schema/catalog-schema.sql
+++ b/tools/datapack/schema/catalog-schema.sql
@@ -228,7 +228,10 @@ CREATE TABLE route_service_artifact_evidence (
   CHECK (length(canonical_pack_sqlite_sha256) = 64 AND canonical_pack_sqlite_sha256 NOT GLOB '*[^0-9a-f]*'),
   CHECK (admission_status IN ('MISSING', 'ADMITTED')),
   CHECK (admission_eligible IN (0, 1)),
-  CHECK ((admission_status = 'ADMITTED') = (admission_eligible = 1)),
+  CHECK (
+    (admission_status = 'ADMITTED' AND admission_eligible = 1 AND fresh_until IS NOT NULL)
+    OR (admission_status = 'MISSING' AND admission_eligible = 0)
+  ),
   CHECK (source_issue = 2116)
 );
 

--- a/tools/datapack/validate-datapack.mjs
+++ b/tools/datapack/validate-datapack.mjs
@@ -884,10 +884,22 @@ function representativeRouteGraph(database) {
     undirectedAdjacency,
   );
 
+  const hasServiceClass = database
+    .prepare("PRAGMA table_info(network_edges)")
+    .all()
+    .some(({ name }) => name === "service_class");
   const edges = database
-    .prepare("SELECT id, from_node_id, to_node_id, edge_type, service_pattern FROM network_edges ORDER BY id")
+    .prepare(`
+      SELECT id, from_node_id, to_node_id, edge_type, service_pattern,
+             ${hasServiceClass ? "service_class" : "'SUBWAY' AS service_class"}
+      FROM network_edges
+      ORDER BY id
+    `)
     .all();
   for (const edge of edges) {
+    if (String(edge.service_class).toUpperCase() !== "SUBWAY") {
+      continue;
+    }
     const routeGraphEdgeType = routeGraphConnectivityEdgeType(edge.edge_type);
     if (routeGraphEdgeType === null) {
       continue;


### PR DESCRIPTION
## 관련 이슈

Refs #1400

## 작업 배경

- #2126에서 확정한 ITX-청춘 수도권 광역검색 전용 범위를 구현한다.
- #2116은 판정 완료 `MISSING`이므로 production ITX topology와 timetable row는 0건을 유지해야 한다.
- 구현 완료와 production release readiness를 분리하고, #2116이 `ADMITTED`가 될 때까지 fail closed한다.

## 작업 내용

- catalog schema v18과 backend V50에 `service_class` 및 admission artifact identity를 추가했다.
- 동일 timetable artifact hash와 #2097 canonical pack identity가 검증된 경우에만 ITX seed/topology를 생성한다.
- deterministic ADMITTED fixture를 `TEST_ONLY`로 격리하고 production inventory·pack·release evidence 유입을 거부한다.
- Route V2는 fresh ADMITTED evidence가 있을 때만 ITX timetable을 읽으며, expiry 이후 SUBWAY-only로 재적재한다.
- Mobile local planner는 SUBWAY edge/trip만 소비하고 ITX는 Route V2 및 route-map layer 경계에만 남긴다.
- topology 연결성은 SUBWAY 기준으로 판정해 ITX edge가 지하철 단절을 숨기지 못하게 했다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/repository-contract.test.mjs tools/datapack/datapack-tools.test.mjs tools/datapack/build-backend-timetable-seed.test.mjs tools/datapack/build-route-graph-topology-report.test.mjs tools/datapack/itx-cheongchun-coverage-contract.test.mjs tools/datapack/itx-cheongchun-service-layer.test.mjs`: 558 passed, 0 failed
  - `./gradlew test --console=plain`: `BUILD SUCCESSFUL`
  - `flutter test test/core/database/mobile_local_database_test.dart test/features/routes/local_route_repository_test.dart --reporter compact`: 132 passed, 0 failed
  - `flutter analyze`: No issues found
  - production candidate build 및 `validate-datapack.mjs --require-production`: PASS, ITX trip/edge 0건, SUBWAY trip 466건
  - `git diff --check origin/main`: PASS

## 검증 증거

UI, 접근성, 수동 QA 변경이 아니라 machine contract와 데이터 경계 변경이므로 자동화된 테스트 및 production candidate 검증을 증거로 사용한다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| production fail-closed | datapack | production candidate SQLite 조회 | `MISSING`, `admission_eligible=0`, ITX trip/edge 0 | PASS |
| runtime seed/planner | backend | 전체 Gradle test | `BUILD SUCCESSFUL` | PASS |
| Mobile 소비 경계 | Flutter | DB + local route test | 132 passed | PASS |
| 독립 코드리뷰 | repository | `codex review --disable plugins --base origin/main` | actionable finding 0 | PASS |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [x] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: `capital@1` 유지, catalog `user_version=18`
- route contract: Route V2 ITX-청춘 fail-closed admission
- realtime contract: 변경 없음
- backend identity: Flyway V50 route service identity

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - production #2116 `MISSING` pack에서 ITX row가 0건인지 확인한다.
  - test-only ADMITTED fixture가 production surface에 연결되지 않는 negative test를 확인한다.
  - timetable artifact hash와 canonical pack identity가 seed/runtime 전 계층에서 동일한지 확인한다.
  - Mobile local planner가 ITX edge/trip을 소비하지 않는지 확인한다.

## 리스크

- #2116이 `ADMITTED`가 되기 전 production ITX 정상 경로는 의도적으로 NO-GO다.
- #1400·#2098·#2099·#2126·#1414는 이 PR 병합 후에도 open으로 유지한다.
- schema v18/V50 적용 뒤 구버전 후처리기가 catalog를 downgrade하지 않도록 명시적으로 거부한다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (실제 배포 없음, Release Artifacts 성공, production readiness NO-GO 유지)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 지하철과 ITX-청춘 서비스를 구분해 경로·시간표 데이터를 관리합니다.
  * ITX-청춘 데이터의 승인 상태, 유효 기간 및 아티팩트 식별 정보를 검증합니다.
  * 데이터 변경 시 최신 시간표를 자동으로 다시 불러옵니다.

* **버그 수정**
  * 로컬 경로 검색에서 ITX-청춘 데이터를 지하철 경로로 잘못 사용하는 문제를 방지했습니다.
  * 만료되거나 검증되지 않은 ITX-청춘 시간표가 경로 결과에 포함되지 않습니다.

* **개선**
  * 기존 카탈로그 데이터가 새 스키마로 안전하게 업그레이드됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
