### PR TITLE
[Fix] TAGO catalog pagination 계약 분리

### DIFF
--- a/tools/datapack/collect-tago-itx-cheongchun-od.mjs
+++ b/tools/datapack/collect-tago-itx-cheongchun-od.mjs
@@ -225,9 +225,12 @@ async function fetchAll(operation, query, key, fetchImpl) {
   const all = [];
   const rawHashes = [];
   let totalCount = null;
-  for (let pageNo = 1; pageNo <= 100; pageNo += 1) {
+  const paginated = operation === "GetCtyAcctoTrainSttnList" || operation === "GetStrtpntAlocFndTrainInfo";
+  for (let pageNo = 1; pageNo <= (paginated ? 100 : 1); pageNo += 1) {
     const url = new URL(`${BASE}/${operation}`);
-    for (const [name, value] of Object.entries({ serviceKey: key, _type: "json", pageNo: String(pageNo), numOfRows: "100", ...query })) {
+    for (const [name, value] of Object.entries({
+      serviceKey: key, _type: "json", ...(paginated ? { pageNo: String(pageNo), numOfRows: "100" } : {}), ...query,
+    })) {
       url.searchParams.set(name, String(value));
     }
     const response = await fetchWithRetry(url, fetchImpl);
@@ -247,6 +250,11 @@ async function fetchAll(operation, query, key, fetchImpl) {
     const rows = items == null ? [] : Array.isArray(items) ? items : [items];
     if (rows.some((row) => !row || typeof row !== "object" || Array.isArray(row))) {
       throw new Error(`TAGO ${operation} schema mismatch: item`);
+    }
+    if (!paginated) {
+      all.push(...rows);
+      totalCount = rows.length;
+      break;
     }
     if (body.totalCount === undefined || body.totalCount === null || body.totalCount === "") {
       throw new Error(`TAGO ${operation} schema mismatch: totalCount`);

--- a/tools/datapack/collect-tago-itx-cheongchun-od.test.mjs
+++ b/tools/datapack/collect-tago-itx-cheongchun-od.test.mjs
@@ -18,6 +18,15 @@ function tagoResponse(items, totalCount = items.length) {
   } }), { status: 200, headers: { "content-type": "application/json" } });
 }
 
+async function withoutTotalCount(response) {
+  const payload = await response.json();
+  delete payload.response.body.totalCount;
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
 test("ITX admission 날짜는 KST 오늘~6일과 dayCd 요일을 검증한다", () => {
   const serviceDates = { "8": "20260715", "7": "20260718", "9": "20260719" };
   assert.deepEqual(validateItxServiceDates(serviceDates, {
@@ -72,6 +81,41 @@ test("ITX OD matrix hash는 정렬된 date·depStationId·arrStationId tuple 직
   assert.equal(matrix.expectedOdCount, 2);
   assert.equal(matrix.stationSetHash, sha256(JSON.stringify(["A", "B"])));
   assert.equal(matrix.odMatrixHash, sha256(JSON.stringify(tuples)));
+});
+
+test("TAGO catalog operation은 pagination field와 totalCount를 요구하지 않는다", async (context) => {
+  for (const operation of ["GetVhcleKndList", "GetCtyCodeList"]) {
+    await context.test(`${operation} totalCount 없음`, async () => {
+      const fallback = validFetch();
+      const artifact = await collectTagoItxCheongchunOd({
+        serviceKey: "key",
+        departureDate: "2026-07-14",
+        kricServiceDayCode: "8",
+        fetchImpl: async (url) => {
+          const response = await fallback(url);
+          return new URL(url).pathname.endsWith(operation) ? withoutTotalCount(response) : response;
+        },
+      });
+      assert.deepEqual(artifact.trainNumbers, ["2001"]);
+    });
+  }
+
+  await context.test("pagination query 없음", async () => {
+    const fallback = validFetch();
+    await collectTagoItxCheongchunOd({
+      serviceKey: "key",
+      departureDate: "2026-07-14",
+      kricServiceDayCode: "8",
+      fetchImpl: async (url) => {
+        const parsed = new URL(url);
+        if (parsed.pathname.endsWith("GetVhcleKndList") || parsed.pathname.endsWith("GetCtyCodeList")) {
+          assert.equal(parsed.searchParams.has("pageNo"), false);
+          assert.equal(parsed.searchParams.has("numOfRows"), false);
+        }
+        return fallback(url);
+      },
+    });
+  });
 });
 
 test("TAGO ITX roster는 canonical 역의 양방향 OD 전체를 수집한다", async () => {


### PR DESCRIPTION
## 관련 이슈

Refs #2135

## 작업 배경

TAGO 차량종류·도시코드 catalog operation은 공식 API catalog상 pagination parameter와 `totalCount`가 없는 단일 응답이다. 기존 collector가 모든 TAGO operation에 `pageNo`·`numOfRows`를 보내고 `totalCount`를 강제해 live ROSTER가 catalog 단계에서 실패했다.

## 작업 내용

- `GetVhcleKndList`·`GetCtyCodeList`는 단일 응답 row 수를 evidence count로 사용한다.
- `GetCtyAcctoTrainSttnList`·`GetStrtpntAlocFndTrainInfo`는 기존 `totalCount`·pagination completeness 검증을 유지한다.
- catalog의 `totalCount` 누락 2건과 pagination query 금지 1건을 regression test로 고정했다.

## 검증

- `node --test tools/datapack/collect-tago-itx-cheongchun-od.test.mjs tools/datapack/collect-korail-itx-cheongchun-timetable.test.mjs`: 69 pass, 0 fail
- `node --test --test-reporter=dot tools/datapack/*.test.mjs`: exit 0
- `node tools/ci/api-catalog.mjs validate`: 233 entries valid
- `git diff --check`: 통과
- credential-safe live call: catalog schema failure 해소, 전체 OD 630건 중 629건 완료. dayCd 7·9 ROSTER는 210/210, dayCd 8은 `NAT140840 → NAT140873` 1건 실패로 209/210이며 fail closed했다. KORAIL은 `OFFICIAL_RUN_INFO_EMPTY`라 최종 `MISSING / NO_GO`다.

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| TAGO catalog 계약 | Node.js | regression test·API catalog validation | test output·233 entries valid | PASS |
| TAGO ROSTER | data.go.kr live | tracked credential-safe collector | `/tmp/issue-2135-itx-roster-after-total-count.json` | PARTIAL, 629/630, fail closed |
| KORAIL admission | data.go.kr live | 동일 collector의 timetable 단계 | sanitized summary | MISSING / NO_GO |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: non-paginated allowlist가 API catalog의 두 operation과 일치하는지, paginated station/OD의 `totalCount` fail-closed가 유지되는지 확인해 주세요.

## 리스크

- provider가 catalog operation에 pagination을 도입하면 API catalog와 regression test를 함께 갱신해야 한다.
- 이 PR은 #2135 admission 계약을 변경하지 않으며 #2135·#2137을 OPEN, `MISSING / NO_GO`로 유지한다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)
