### PR TITLE
[Backend] production 경로검색 공개 API 폐쇄

### DIFF
--- a/apps/mobile/release/operations-release-evidence.json
+++ b/apps/mobile/release/operations-release-evidence.json
@@ -202,9 +202,6 @@
         "/api/v1/reports",
         "/api/v1/reports/{reportId}",
         "/api/v1/reports/{reportId}/confirm",
-        "/api/v1/routes/search",
-        "/api/v2/routes/search",
-        "/api/v2/routes/{routeSearchId}/refresh",
         "/api/v1/trains/stations",
         "/api/v1/trains/search",
         "/api/v1/realtime/arrivals",
@@ -219,9 +216,6 @@
         "/api/v1/reports",
         "/api/v1/reports/*",
         "/api/v1/reports/*/confirm",
-        "/api/v1/routes/search",
-        "/api/v2/routes/search",
-        "/api/v2/routes/*/refresh",
         "/api/ads/events",
         "/api/v1/trains/stations",
         "/api/v1/trains/search",
@@ -233,6 +227,16 @@
         "/api/notices/active",
         "/api/ads/active"
       ],
+      "closedProductionEndpoints": [
+        "/api/v1/routes/search",
+        "/api/v2/routes/search",
+        "/api/v2/routes/{routeSearchId}/refresh"
+      ],
+      "closedProductionEndpointPolicy": {
+        "strategy": "NON_PRODUCTION_ONLY",
+        "issue": 1913,
+        "androidRouteMode": "LOCAL_FIRST"
+      },
       "requiredEvidence": [
         "backend-public-api-surface-inventory",
         "default-deny-public-chain-test-output",

--- a/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.env.Environment;
 import org.springframework.http.HttpMethod;
@@ -293,6 +294,29 @@ public class SecurityConfig {
 
 	@Bean
 	@Order(4)
+	@Profile("!prod & !staging & !release & !prod-like")
+	SecurityFilterChain routeSearchSecurityFilterChain(HttpSecurity http) throws Exception {
+		return http
+			.securityMatcher(
+				"/api/v1/routes/search",
+				"/api/v2/routes/search",
+				"/api/v2/routes/*/refresh"
+			)
+			.csrf(AbstractHttpConfigurer::disable)
+			.authorizeHttpRequests(authorize -> authorize
+				.requestMatchers(
+					HttpMethod.POST,
+					"/api/v1/routes/search",
+					"/api/v2/routes/search",
+					"/api/v2/routes/*/refresh"
+				).permitAll()
+				.anyRequest().denyAll()
+			)
+			.build();
+	}
+
+	@Bean
+	@Order(5)
 	SecurityFilterChain publicSecurityFilterChain(HttpSecurity http) throws Exception {
 		// 신고/관리자/운영 matcher 밖의 새 경로가 실수로 공개되지 않도록 기본 차단한다.
 		return http
@@ -300,9 +324,6 @@ public class SecurityConfig {
 			.authorizeHttpRequests(authorize -> authorize
 				.requestMatchers(
 					HttpMethod.POST,
-					"/api/v1/routes/search",
-					"/api/v2/routes/search",
-					"/api/v2/routes/*/refresh",
 					"/api/ads/events"
 				).permitAll()
 				.requestMatchers(

--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
@@ -34,11 +34,13 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+@Profile("!prod & !staging & !release & !prod-like")
 @RestController
 class RouteSearchController {
 

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/ProductionRouteApiClosureTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/ProductionRouteApiClosureTest.java
@@ -1,0 +1,193 @@
+package com.easysubway.route.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.easysubway.profile.domain.MobilityType;
+import com.easysubway.route.application.port.in.RouteSearchUseCase;
+import com.easysubway.route.application.port.in.RouteV2SearchUseCase;
+import com.easysubway.route.application.port.in.RouteV2SearchUseCase.RouteV2Plan;
+import com.easysubway.route.application.port.in.RouteV2SearchUseCase.RouteV2Status;
+import com.easysubway.route.domain.EtaConfidence;
+import com.easysubway.route.domain.EtaSource;
+import com.easysubway.route.domain.RouteRefreshResult;
+import com.easysubway.route.domain.RouteRefreshStatus;
+import com.easysubway.route.domain.RouteSearchResult;
+import com.easysubway.route.domain.RouteSearchStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.context.ApplicationContext;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+@SpringBootTest(properties = {
+	"spring.datasource.url=jdbc:h2:mem:prod-route-closure;MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
+	"spring.datasource.username=sa",
+	"spring.datasource.password=",
+	"spring.datasource.driver-class-name=org.h2.Driver",
+	"spring.flyway.locations=classpath:db/migration/h2",
+	"spring.sql.init.mode=always",
+	"spring.sql.init.continue-on-error=true",
+	"spring.batch.jdbc.initialize-schema=never",
+	"easysubway.admin.username=admin-user",
+	"easysubway.admin.password=admin-password",
+	"easysubway.admin.basic-auth.enabled=false",
+	"easysubway.auth.client-ip.trusted-proxies=",
+	"easysubway.notifications.push.external-enabled=false",
+	"EASYSUBWAY_ADS_EVENT_DAILY_CAP=1000000",
+	"easysubway.report.receipt-token-pepper=prod-test-receipt-token-pepper-with-enough-entropy",
+	"easysubway.report.upload.intent-signing-key=prod-test-upload-intent-signing-key-with-enough-entropy",
+	"easysubway.report.upload.object-storage-endpoint=https://object-storage.example.com",
+	"easysubway.report.upload.public-base-url=https://uploads.easysubway.example",
+	"easysubway.report.upload.bucket=easysubway-report-uploads",
+	"easysubway.report.upload.object-storage-access-key=prod-object-storage-access-key",
+	"easysubway.report.upload.object-storage-secret-key=prod-object-storage-secret-key-with-enough-entropy",
+	"easysubway.report.upload.object-storage-region=ap-northeast-2"
+})
+@ActiveProfiles("prod")
+@AutoConfigureMockMvc
+@ExtendWith(OutputCaptureExtension.class)
+@DisplayName("운영 경로검색 API 폐쇄")
+class ProductionRouteApiClosureTest {
+
+	private static final String PAYLOAD_MARKER = "route-payload-marker-1913";
+	private static final List<String> HEADER_MARKERS = List.of(
+		"198.51.100.41",
+		"198.51.100.42",
+		"198.51.100.43"
+	);
+
+	@Autowired
+	private ApplicationContext applicationContext;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private RouteSearchUseCase routeSearchUseCase;
+
+	@MockitoBean
+	private RouteV2SearchUseCase routeV2SearchUseCase;
+
+	@BeforeEach
+	void setUpCurrentReachableResponses() {
+		RouteSearchResult route = routeSearchResult();
+		when(routeSearchUseCase.searchRoute(any())).thenReturn(route);
+		when(routeV2SearchUseCase.search(any())).thenReturn(
+			new RouteV2Plan(List.of(route), List.of(RouteV2Status.FOUND), "test-planner")
+		);
+		when(routeSearchUseCase.refreshRoute(anyString())).thenReturn(
+			new RouteRefreshResult(
+				route.routeSearchId(),
+				RouteRefreshStatus.UPDATED_ETA,
+				route,
+				LocalDateTime.of(2026, 7, 15, 9, 15),
+				EtaSource.PLANNED,
+				EtaConfidence.LOW,
+				"계획 시간 기준",
+				List.of()
+			)
+		);
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@MethodSource("closedEndpoints")
+	@DisplayName("운영 profile은 route endpoint를 controller 전에 거부한다")
+	void productionRejectsRouteEndpoints(
+		String path,
+		String body,
+		boolean includeMarkers,
+		CapturedOutput output
+	) throws Exception {
+		long before = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM route_search_results", Long.class);
+		MockHttpServletRequestBuilder request = post(path)
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(body);
+		if (includeMarkers) {
+			request.header("Forwarded", "for=" + HEADER_MARKERS.get(0))
+				.header("X-Forwarded-For", HEADER_MARKERS.get(1))
+				.header("X-Real-IP", HEADER_MARKERS.get(2));
+		}
+
+		mockMvc.perform(request)
+			.andExpect(status().isForbidden());
+
+		assertThat(applicationContext.containsBean("routeSearchController")).isFalse();
+		assertThat(jdbcTemplate.queryForObject("SELECT COUNT(*) FROM route_search_results", Long.class))
+			.isEqualTo(before);
+		verifyNoInteractions(routeSearchUseCase, routeV2SearchUseCase);
+		if (includeMarkers) {
+			assertThat(output.getOut())
+				.doesNotContain(PAYLOAD_MARKER)
+				.doesNotContain(HEADER_MARKERS);
+		}
+	}
+
+	private static Stream<Arguments> closedEndpoints() {
+		return Stream.of(
+			Arguments.of("/api/v1/routes/search", """
+				{
+				  "originStationId": "%s",
+				  "destinationStationId": "station-sadang",
+				  "mobilityType": "WHEELCHAIR"
+				}
+				""".formatted(PAYLOAD_MARKER), true),
+			Arguments.of("/api/v2/routes/search", """
+				{
+				  "originStationId": "station-sangnoksu",
+				  "destinationStationId": "station-sadang",
+				  "departureTime": "2026-07-15T09:15:00+09:00",
+				  "mobilityType": "SENIOR",
+				  "constraintMode": "ALLOW_WITH_WARNINGS",
+				  "useRealtime": false,
+				  "maxTransfers": 3,
+				  "alternativeCount": 3
+				}
+				""", false),
+			Arguments.of("/api/v2/routes/route-search-marker/refresh", "{}", false)
+		);
+	}
+
+	private static RouteSearchResult routeSearchResult() {
+		return new RouteSearchResult(
+			"route-search-marker",
+			"station-sangnoksu",
+			"상록수",
+			"station-sadang",
+			"사당",
+			MobilityType.SENIOR,
+			RouteSearchStatus.FOUND,
+			"line-4",
+			"수도권 4호선",
+			1,
+			List.of(),
+			List.of(),
+			List.of(),
+			LocalDateTime.of(2026, 7, 15, 9, 15)
+		);
+	}
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -4186,6 +4186,10 @@ test("운영 관측성과 알림 기준선은 필수 release 신호와 심볼 �
   const releaseArtifactsWorkflow = read(".github/workflows/release-artifacts.yml");
   const applicationProd = read("backend/src/main/resources/application-prod.yml");
   const securityConfig = read("backend/src/main/java/com/easysubway/common/security/SecurityConfig.java");
+  const routeSearchController = read(
+    "backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java",
+  );
+  const internalApiIndex = readJson("contracts/api/internal-api-index.json");
 
   assert.equal(gate.schemaVersion, 1);
   assert.equal(gate.applicationId, "easysubway");
@@ -4480,6 +4484,11 @@ test("운영 관측성과 알림 기준선은 필수 release 신호와 심볼 �
     true,
   );
   assert.equal(operationsEvidence.backendControlPlane.publicApiSurface.securityMatcherComparisonRequired, true);
+  const closedRouteEndpoints = [
+    "/api/v1/routes/search",
+    "/api/v2/routes/search",
+    "/api/v2/routes/{routeSearchId}/refresh",
+  ];
   assert.deepEqual(
     operationsEvidence.backendControlPlane.publicApiSurface.allowedPublicEndpoints,
     [
@@ -4492,9 +4501,6 @@ test("운영 관측성과 알림 기준선은 필수 release 신호와 심볼 �
       "/api/v1/reports",
       "/api/v1/reports/{reportId}",
       "/api/v1/reports/{reportId}/confirm",
-      "/api/v1/routes/search",
-      "/api/v2/routes/search",
-      "/api/v2/routes/{routeSearchId}/refresh",
       "/api/v1/trains/stations",
       "/api/v1/trains/search",
       "/api/v1/realtime/arrivals",
@@ -4512,9 +4518,6 @@ test("운영 관측성과 알림 기준선은 필수 release 신호와 심볼 �
       "/api/v1/reports",
       "/api/v1/reports/*",
       "/api/v1/reports/*/confirm",
-      "/api/v1/routes/search",
-      "/api/v2/routes/search",
-      "/api/v2/routes/*/refresh",
       "/api/ads/events",
       "/api/v1/trains/stations",
       "/api/v1/trains/search",
@@ -4527,13 +4530,47 @@ test("운영 관측성과 알림 기준선은 필수 release 신호와 심볼 �
       "/api/ads/active",
     ],
   );
+  assert.deepEqual(
+    operationsEvidence.backendControlPlane.publicApiSurface.closedProductionEndpoints,
+    closedRouteEndpoints,
+  );
+  assert.deepEqual(
+    operationsEvidence.backendControlPlane.publicApiSurface.closedProductionEndpointPolicy,
+    {
+      strategy: "NON_PRODUCTION_ONLY",
+      issue: 1913,
+      androidRouteMode: "LOCAL_FIRST",
+    },
+  );
+  for (const endpoint of closedRouteEndpoints) {
+    assert.ok(
+      internalApiIndex.operations.some((operation) => operation.method === "POST" && operation.path === endpoint),
+      `internal API source catalog must retain ${endpoint}`,
+    );
+    assert.ok(
+      !operationsEvidence.backendControlPlane.publicApiSurface.allowedPublicEndpoints.includes(endpoint),
+      `production public endpoints must exclude ${endpoint}`,
+    );
+  }
+  assert.match(
+    routeSearchController,
+    /@Profile\("!prod & !staging & !release & !prod-like"\)[\s\S]*@RestController/,
+  );
+  assert.match(
+    securityConfig,
+    /@Profile\("!prod & !staging & !release & !prod-like"\)[\s\S]*SecurityFilterChain routeSearchSecurityFilterChain/,
+  );
+  const reportApiMatcherScope = securityConfig.match(
+    /SecurityFilterChain reportSecurityFilterChain[\s\S]*?\.build\(\)/,
+  );
   const publicApiMatcherScope = securityConfig.match(
-    /reportSecurityFilterChain[\s\S]*?publicSecurityFilterChain[\s\S]*?\.anyRequest\(\)\.denyAll\(\)/,
+    /SecurityFilterChain publicSecurityFilterChain[\s\S]*?\.anyRequest\(\)\.denyAll\(\)/,
   );
+  assert.ok(reportApiMatcherScope, "report API security matcher scope must be readable");
   assert.ok(publicApiMatcherScope, "public API security matcher scope must be readable");
-  const publicApiMatchers = Array.from(publicApiMatcherScope[0].matchAll(/"([^"]+)"/g), (match) => match[1]).filter(
-    (matcher) => matcher.startsWith("/api/") || matcher.startsWith("/actuator/"),
-  );
+  const publicApiMatchers = [reportApiMatcherScope[0], publicApiMatcherScope[0]]
+    .flatMap((scope) => Array.from(scope.matchAll(/"([^"]+)"/g), (match) => match[1]))
+    .filter((matcher) => matcher.startsWith("/api/") || matcher.startsWith("/actuator/"));
   assert.deepEqual(
     publicApiMatchers,
     operationsEvidence.backendControlPlane.publicApiSurface.allowedPublicSecurityMatchers,

--- a/tools/ops/post-deploy-smoke-contract.json
+++ b/tools/ops/post-deploy-smoke-contract.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "gate": "post-deploy-smoke",
   "issue": 1688,
-  "descriptionKo": "매 백엔드 배포 직후 핵심 4축이 배포 URL에서 실제 동작하는지 확인하는 경량 스모크 계약. 대표 OD·필수 응답 필드가 바뀌면 스크립트가 아니라 이 파일만 갱신한다.",
+  "descriptionKo": "매 백엔드 배포 직후 핵심 4축이 배포 URL에서 실제 동작하는지 확인하는 경량 스모크 계약. 경로검색 공개 API는 production에서 폐쇄 상태를 검증한다.",
   "axes": {
     "readiness": {
       "id": "readiness",
@@ -12,29 +12,41 @@
       "expectStatusField": "status",
       "expectStatusValue": "UP"
     },
-    "routeSearch": {
-      "id": "route-search",
-      "titleKo": "경로 탐색 (북극성)",
+    "routeApiClosure": {
+      "id": "route-api-closure",
+      "titleKo": "경로검색 공개 API 폐쇄",
       "deploymentAttributed": true,
-      "method": "POST",
-      "path": "/api/v2/routes/search",
-      "request": {
-        "originStationId": "station-sangnoksu",
-        "destinationStationId": "station-sadang",
-        "mobilityType": "SENIOR",
-        "constraintMode": "ALLOW_WITH_WARNINGS",
-        "useRealtime": false,
-        "maxTransfers": 3,
-        "alternativeCount": 3
-      },
-      "departureLocalTime": "09:15:00",
-      "departureUtcOffset": "+09:00",
-      "expectedContractVersion": "ROUTE_SEARCH_V2",
-      "minItineraries": 1,
-      "legEtaSourceField": "etaSource",
-      "acceptedNoServiceStatuses": ["NO_TIMETABLE_SERVICE"],
-      "noServiceNoteKo": "커버리지 게이트(#1838) 이후: 시간표 미적재/비커버 O/D는 graph 검색으로 폴백(FOUND)하고, NO_TIMETABLE_SERVICE는 커버 코리도의 막차후(현재 서비스 없음)에 국한된다. 스모크는 유효한 V2 응답이면 엔드포인트 건강성으로 PASS하며 두 status 모두 허용, 데이터 완성도는 #1415가 담당한다.",
-      "downgradeLadderNoteKo": "강등 사다리 존중: leg의 etaSource가 REALTIME이 아니어도(PLANNED·STATIC_BACKEND_ESTIMATE 등) 실패로 처리하지 않는다. 실시간 provider 상태에 의존하는 flaky 게이트를 만들지 않기 위해 useRealtime=false로 고정한다."
+      "acceptedStatuses": [403, 404],
+      "endpoints": [
+        {
+          "method": "POST",
+          "path": "/api/v1/routes/search",
+          "request": {
+            "originStationId": "closure-probe",
+            "destinationStationId": "closure-probe",
+            "mobilityType": "SENIOR"
+          }
+        },
+        {
+          "method": "POST",
+          "path": "/api/v2/routes/search",
+          "request": {
+            "originStationId": "closure-probe",
+            "destinationStationId": "closure-probe",
+            "departureTime": "2026-07-15T09:15:00+09:00",
+            "mobilityType": "SENIOR",
+            "constraintMode": "ALLOW_WITH_WARNINGS",
+            "useRealtime": false,
+            "maxTransfers": 3,
+            "alternativeCount": 1
+          }
+        },
+        {
+          "method": "POST",
+          "path": "/api/v2/routes/closure-probe/refresh",
+          "request": {}
+        }
+      ]
     },
     "adminLogin": {
       "id": "admin-login",

--- a/tools/ops/post-deploy-smoke.mjs
+++ b/tools/ops/post-deploy-smoke.mjs
@@ -1,13 +1,9 @@
 #!/usr/bin/env node
-// Post-deploy smoke: verifies that the core user-facing flows actually answer at
-// the deployed URL after a backend deploy (issue #1688). Four axes mirror the
-// service structure: platform health, route search (north star), admin web, and
-// the datapack distribution URL (independent OCI Object Storage infra).
+// Post-deploy smoke: verifies the deployed backend and the independent datapack
+// URL after a deploy (issue #1688). The route axis proves that production route
+// APIs stay closed; it must never retry an observed 2xx into a later PASS.
 //
 // Design constraints (see issue #1688):
-// - Respect the downgrade ladder: a non-realtime eta source (PLANNED/STATIC) is
-//   NOT a failure. useRealtime is fixed to false so the gate never depends on a
-//   flaky realtime provider.
 // - The datapack axis is a DIFFERENT failure domain than the backend deploy; the
 //   report labels each axis with `deploymentAttributed` so an operator can tell a
 //   backend regression apart from an offline-data-supply outage.
@@ -21,18 +17,6 @@ const DEFAULT_CONTRACT = path.join(import.meta.dirname, "post-deploy-smoke-contr
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function buildDepartureTime(axis, now = Date.now()) {
-  const match = /^([+-])(\d{2}):(\d{2})$/.exec(axis.departureUtcOffset);
-  if (!match) throw new Error(`invalid departureUtcOffset: ${axis.departureUtcOffset}`);
-  const sign = match[1] === "-" ? -1 : 1;
-  const offsetSeconds = sign * (Number(match[2]) * 3600 + Number(match[3]) * 60);
-  const local = new Date(now + offsetSeconds * 1000);
-  const year = local.getUTCFullYear();
-  const month = String(local.getUTCMonth() + 1).padStart(2, "0");
-  const day = String(local.getUTCDate()).padStart(2, "0");
-  return `${year}-${month}-${day}T${axis.departureLocalTime}${axis.departureUtcOffset}`;
 }
 
 async function httpRequest(url, { method = "GET", body, headers = {}, timeoutMs }) {
@@ -91,43 +75,16 @@ async function checkReadiness(baseUrl, axis, timeoutMs) {
   }
 }
 
-async function checkRouteSearch(baseUrl, axis, timeoutMs) {
-  const url = joinUrl(baseUrl, axis.path);
-  const requestBody = { ...axis.request, departureTime: buildDepartureTime(axis) };
-  const { status, text } = await httpRequest(url, {
-    method: axis.method ?? "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify(requestBody),
-    timeoutMs,
-  });
-  if (status !== 200) throw new Error(`route search returned HTTP ${status}`);
-  const body = parseJson(text, "route search");
-  if (body.success !== true) throw new Error("route search response.success was not true");
-  const data = body.data;
-  if (!data || data.contractVersion !== axis.expectedContractVersion) {
-    throw new Error(`route search contractVersion was ${data?.contractVersion}, expected ${axis.expectedContractVersion}`);
-  }
-  const itineraries = data.itineraries;
-  const statuses = Array.isArray(data.statuses) ? data.statuses : [];
-  if (!Array.isArray(itineraries) || itineraries.length < axis.minItineraries) {
-    // Endpoint-health gate: a valid ROUTE_SEARCH_V2 response that reports a known
-    // "no service data" status (e.g. NO_TIMETABLE_SERVICE while timetable
-    // ingestion is still pending — #1415) means the API is healthy but the
-    // datapack lacks data for this OD. That is a data-completeness concern, not a
-    // deploy regression, so the smoke passes. A broken endpoint still fails
-    // earlier (non-200, success!=true, wrong contractVersion).
-    const noServiceOk = (axis.acceptedNoServiceStatuses ?? []).some((s) => statuses.includes(s));
-    if (noServiceOk) return;
-    throw new Error(
-      `route search returned ${itineraries?.length ?? 0} itineraries and no accepted no-service status (statuses=${statuses.join(",") || "none"})`,
-    );
-  }
-  const legs = itineraries.flatMap((entry) => (Array.isArray(entry.legs) ? entry.legs : []));
-  if (legs.length < 1) throw new Error("route search itineraries contained no legs");
-  for (const leg of legs) {
-    const label = leg[axis.legEtaSourceField];
-    if (typeof label !== "string" || label.length === 0) {
-      throw new Error(`route search leg is missing a ${axis.legEtaSourceField} label`);
+async function checkRouteApiClosure(baseUrl, axis, timeoutMs) {
+  for (const endpoint of axis.endpoints) {
+    const { status } = await httpRequest(joinUrl(baseUrl, endpoint.path), {
+      method: endpoint.method,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(endpoint.request),
+      timeoutMs,
+    });
+    if (!axis.acceptedStatuses.includes(status)) {
+      throw new Error(`${endpoint.method} ${endpoint.path} returned HTTP ${status}`);
     }
   }
 }
@@ -167,6 +124,32 @@ async function runAxis(axis, check, { maxMs, delayMs }) {
   };
 }
 
+async function runAxisOnce(axis, check, timeoutMs) {
+  const startedAt = Date.now();
+  try {
+    await check(timeoutMs);
+    return {
+      id: axis.id,
+      titleKo: axis.titleKo,
+      deploymentAttributed: axis.deploymentAttributed,
+      result: "PASS",
+      latencyMs: Date.now() - startedAt,
+      attempts: 1,
+      detail: "ok",
+    };
+  } catch (error) {
+    return {
+      id: axis.id,
+      titleKo: axis.titleKo,
+      deploymentAttributed: axis.deploymentAttributed,
+      result: "FAIL",
+      latencyMs: Date.now() - startedAt,
+      attempts: 1,
+      detail: error.message,
+    };
+  }
+}
+
 function renderTable(report) {
   const lines = [
     "| 축 | 결과 | 배포 기인 | latency(ms) | 시도 | 상세 |",
@@ -188,7 +171,7 @@ async function main() {
 
   const contractPath = argValue(args, "--contract", DEFAULT_CONTRACT);
   const contract = JSON.parse(await readFile(contractPath, "utf8"));
-  const { readiness, routeSearch, adminLogin, datapack } = contract.axes;
+  const { readiness, routeApiClosure, adminLogin, datapack } = contract.axes;
 
   const datapackBaseUrl = argValue(args, "--datapack-base-url", datapack.baseUrl);
   const budgetMs = Number(argValue(args, "--timeout-seconds", "90")) * 1000;
@@ -198,10 +181,11 @@ async function main() {
     maxMs: Math.max(6000, budgetMs * 0.55),
     delayMs: 3000,
   }));
-  axes.push(await runAxis(routeSearch, (t) => checkRouteSearch(baseUrl, routeSearch, t), {
-    maxMs: Math.max(3000, budgetMs * 0.2),
-    delayMs: 2000,
-  }));
+  axes.push(await runAxisOnce(
+    routeApiClosure,
+    (t) => checkRouteApiClosure(baseUrl, routeApiClosure, t),
+    Math.min(10000, Math.max(2000, budgetMs * 0.2)),
+  ));
   axes.push(await runAxis(adminLogin, (t) => checkAdminLogin(baseUrl, adminLogin, t), {
     maxMs: Math.max(2000, budgetMs * 0.1),
     delayMs: 2000,

--- a/tools/ops/post-deploy-smoke.mjs
+++ b/tools/ops/post-deploy-smoke.mjs
@@ -76,15 +76,24 @@ async function checkReadiness(baseUrl, axis, timeoutMs) {
 }
 
 async function checkRouteApiClosure(baseUrl, axis, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
   for (const endpoint of axis.endpoints) {
-    const { status } = await httpRequest(joinUrl(baseUrl, endpoint.path), {
-      method: endpoint.method,
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify(endpoint.request),
-      timeoutMs,
-    });
+    const context = `${endpoint.method} ${endpoint.path}`;
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) throw new Error(`${context} check failed: timeout budget exhausted`);
+    let status;
+    try {
+      ({ status } = await httpRequest(joinUrl(baseUrl, endpoint.path), {
+        method: endpoint.method,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(endpoint.request),
+        timeoutMs: remainingMs,
+      }));
+    } catch (error) {
+      throw new Error(`${context} check failed: ${error.message}`, { cause: error });
+    }
     if (!axis.acceptedStatuses.includes(status)) {
-      throw new Error(`${endpoint.method} ${endpoint.path} returned HTTP ${status}`);
+      throw new Error(`${context} returned HTTP ${status}`);
     }
   }
 }

--- a/tools/ops/post-deploy-smoke.test.mjs
+++ b/tools/ops/post-deploy-smoke.test.mjs
@@ -39,8 +39,8 @@ async function withServer(routes, fn) {
     }
     const chunks = [];
     req.on("data", (chunk) => chunks.push(chunk));
-    req.on("end", () => {
-      const out = handler(Buffer.concat(chunks).toString("utf8"));
+    req.on("end", async () => {
+      const out = await handler(Buffer.concat(chunks).toString("utf8"));
       const payload = out.raw ? out.body : JSON.stringify(out.body);
       res.writeHead(out.status, { "content-type": out.raw ? "text/html" : "application/json" }).end(payload);
     });
@@ -129,6 +129,26 @@ test("post-deploy smoke fails immediately when any closed route endpoint returns
     assert.equal(axis(report, "route-api-closure").result, "FAIL");
     assert.equal(axis(report, "route-api-closure").attempts, 1);
     assert.equal(calls, 1);
+  });
+});
+
+test("post-deploy smoke shares one timeout budget across closed route endpoints", async () => {
+  const routes = defaultRoutes();
+  const delayedForbidden = () => new Promise((resolve) => {
+    setTimeout(() => resolve({ status: 403, body: {} }), 900);
+  });
+  routes.routeV1Search = delayedForbidden;
+  routes.routeV2Search = delayedForbidden;
+  routes.routeRefresh = delayedForbidden;
+
+  await withServer(routes, async (baseUrl) => {
+    const { code, report } = await runSmoke(baseUrl);
+    assert.equal(code, 1);
+    assert.equal(axis(report, "route-api-closure").result, "FAIL");
+    assert.match(
+      axis(report, "route-api-closure").detail,
+      /POST \/api\/v2\/routes\/closure-probe\/refresh check failed/,
+    );
   });
 });
 

--- a/tools/ops/post-deploy-smoke.test.mjs
+++ b/tools/ops/post-deploy-smoke.test.mjs
@@ -11,26 +11,12 @@ const execFileAsync = promisify(execFile);
 const root = path.resolve(import.meta.dirname, "../..");
 const script = "tools/ops/post-deploy-smoke.mjs";
 
-function itinerary(overrides = {}) {
-  return {
-    itineraryId: "route-search-1-primary",
-    status: "FOUND",
-    etaSource: "PLANNED",
-    legs: [
-      { legType: "ACCESS", etaSource: "PLANNED" },
-      { legType: "RIDE", etaSource: "STATIC_BACKEND_ESTIMATE" },
-    ],
-    ...overrides,
-  };
-}
-
 function defaultRoutes() {
   return {
     readiness: () => ({ status: 200, body: { status: "UP" } }),
-    routeSearch: () => ({
-      status: 200,
-      body: { success: true, data: { contractVersion: "ROUTE_SEARCH_V2", itineraries: [itinerary()] } },
-    }),
+    routeV1Search: () => ({ status: 403, body: {} }),
+    routeV2Search: () => ({ status: 403, body: {} }),
+    routeRefresh: () => ({ status: 404, body: {} }),
     adminLogin: () => ({ status: 200, body: "<html><body><form method=\"post\">login</form></body></html>", raw: true }),
     datapack: () => ({ status: 200, body: { packs: [{ id: "capital", version: "2026.07.01" }] } }),
   };
@@ -41,7 +27,9 @@ async function withServer(routes, fn) {
     const url = new URL(req.url, "http://localhost");
     let handler;
     if (url.pathname === "/actuator/health/readiness") handler = routes.readiness;
-    else if (url.pathname === "/api/v2/routes/search" && req.method === "POST") handler = routes.routeSearch;
+    else if (url.pathname === "/api/v1/routes/search" && req.method === "POST") handler = routes.routeV1Search;
+    else if (url.pathname === "/api/v2/routes/search" && req.method === "POST") handler = routes.routeV2Search;
+    else if (url.pathname === "/api/v2/routes/closure-probe/refresh" && req.method === "POST") handler = routes.routeRefresh;
     else if (url.pathname === "/admin/login") handler = routes.adminLogin;
     else if (url.pathname === "/catalog/current.json") handler = routes.datapack;
 
@@ -109,7 +97,7 @@ test("post-deploy smoke passes when all four axes respond correctly", async () =
     assert.equal(code, 0);
     assert.equal(report.overall, "PASS");
     assert.equal(report.axes.length, 4);
-    for (const id of ["readiness", "route-search", "admin-login", "datapack"]) {
+    for (const id of ["readiness", "route-api-closure", "admin-login", "datapack"]) {
       assert.equal(axis(report, id).result, "PASS", `${id} should pass`);
     }
     assert.equal(axis(report, "datapack").deploymentAttributed, false);
@@ -117,76 +105,30 @@ test("post-deploy smoke passes when all four axes respond correctly", async () =
   });
 });
 
-test("post-deploy smoke tolerates downgraded (non-realtime) eta sources", async () => {
+test("post-deploy smoke accepts one-shot 403/404 for every closed route endpoint", async () => {
   const routes = defaultRoutes();
-  routes.routeSearch = () => ({
-    status: 200,
-    body: {
-      success: true,
-      data: {
-        contractVersion: "ROUTE_SEARCH_V2",
-        itineraries: [
-          itinerary({
-            etaSource: "PLANNED",
-            legs: [
-              { legType: "ACCESS", etaSource: "PLANNED" },
-              { legType: "RIDE", etaSource: "PLANNED" },
-            ],
-          }),
-        ],
-      },
-    },
-  });
   await withServer(routes, async (baseUrl) => {
     const { code, report } = await runSmoke(baseUrl);
     assert.equal(code, 0);
-    assert.equal(axis(report, "route-search").result, "PASS");
+    assert.equal(axis(report, "route-api-closure").result, "PASS");
+    assert.equal(axis(report, "route-api-closure").attempts, 1);
   });
 });
 
-test("post-deploy smoke fails when route search omits itineraries", async () => {
+test("post-deploy smoke fails immediately when any closed route endpoint returns 2xx", async () => {
   const routes = defaultRoutes();
-  routes.routeSearch = () => ({
-    status: 200,
-    body: { success: true, data: { contractVersion: "ROUTE_SEARCH_V2", itineraries: [] } },
-  });
+  let calls = 0;
+  routes.routeV2Search = () => {
+    calls += 1;
+    return calls === 1 ? { status: 200, body: { success: true } } : { status: 403, body: {} };
+  };
   await withServer(routes, async (baseUrl) => {
     const { code, report } = await runSmoke(baseUrl);
     assert.equal(code, 1);
     assert.equal(report.overall, "FAIL");
-    assert.equal(axis(report, "route-search").result, "FAIL");
-  });
-});
-
-test("post-deploy smoke passes when route search reports NO_TIMETABLE_SERVICE (endpoint healthy, data pending)", async () => {
-  const routes = defaultRoutes();
-  routes.routeSearch = () => ({
-    status: 200,
-    body: { success: true, data: { contractVersion: "ROUTE_SEARCH_V2", statuses: ["NO_TIMETABLE_SERVICE"], itineraries: [] } },
-  });
-  await withServer(routes, async (baseUrl) => {
-    const { code, report } = await runSmoke(baseUrl);
-    assert.equal(code, 0);
-    assert.equal(axis(report, "route-search").result, "PASS");
-  });
-});
-
-test("post-deploy smoke fails when a leg is missing its eta source label", async () => {
-  const routes = defaultRoutes();
-  routes.routeSearch = () => ({
-    status: 200,
-    body: {
-      success: true,
-      data: {
-        contractVersion: "ROUTE_SEARCH_V2",
-        itineraries: [itinerary({ legs: [{ legType: "ACCESS" }] })],
-      },
-    },
-  });
-  await withServer(routes, async (baseUrl) => {
-    const { code, report } = await runSmoke(baseUrl);
-    assert.equal(code, 1);
-    assert.equal(axis(report, "route-search").result, "FAIL");
+    assert.equal(axis(report, "route-api-closure").result, "FAIL");
+    assert.equal(axis(report, "route-api-closure").attempts, 1);
+    assert.equal(calls, 1);
   });
 });
 
@@ -229,27 +171,22 @@ test("post-deploy smoke contract file matches the expected schema", async () => 
   assert.equal(contract.gate, "post-deploy-smoke");
   assert.equal(contract.issue, 1688);
 
-  const { readiness, routeSearch, adminLogin, datapack } = contract.axes;
+  const { readiness, routeApiClosure, adminLogin, datapack } = contract.axes;
   assert.equal(readiness.deploymentAttributed, true);
   assert.equal(readiness.path, "/actuator/health/readiness");
   assert.equal(readiness.expectStatusValue, "UP");
 
-  assert.equal(routeSearch.deploymentAttributed, true);
-  assert.equal(routeSearch.path, "/api/v2/routes/search");
-  assert.equal(routeSearch.expectedContractVersion, "ROUTE_SEARCH_V2");
-  assert.ok(routeSearch.minItineraries >= 1);
-  assert.equal(routeSearch.legEtaSourceField, "etaSource");
-  assert.ok(
-    Array.isArray(routeSearch.acceptedNoServiceStatuses)
-      && routeSearch.acceptedNoServiceStatuses.includes("NO_TIMETABLE_SERVICE"),
-    "route search must accept NO_TIMETABLE_SERVICE as endpoint-healthy",
+  assert.equal(routeApiClosure.deploymentAttributed, true);
+  assert.equal(routeApiClosure.id, "route-api-closure");
+  assert.deepEqual(routeApiClosure.acceptedStatuses, [403, 404]);
+  assert.deepEqual(
+    routeApiClosure.endpoints.map(({ method, path: endpointPath }) => `${method} ${endpointPath}`),
+    [
+      "POST /api/v1/routes/search",
+      "POST /api/v2/routes/search",
+      "POST /api/v2/routes/closure-probe/refresh",
+    ],
   );
-  // useRealtime must stay false so the gate never depends on a flaky provider.
-  assert.equal(routeSearch.request.useRealtime, false);
-  assert.equal(routeSearch.request.originStationId, "station-sangnoksu");
-  assert.equal(routeSearch.request.destinationStationId, "station-sadang");
-  assert.match(routeSearch.departureLocalTime, /^\d{2}:\d{2}:\d{2}$/);
-  assert.match(routeSearch.departureUtcOffset, /^[+-]\d{2}:\d{2}$/);
 
   assert.equal(adminLogin.deploymentAttributed, true);
   assert.equal(adminLogin.path, "/admin/login");


### PR DESCRIPTION
## 관련 이슈

Refs #1913

## 작업 배경

production에서 익명 호출 가능한 세 경로검색 API가 호출마다 검색 결과를 영속화해 DB와 CPU를 무제한 소비할 수 있었습니다. Android production은 이미 catalog DB 기반 local-first 경로검색을 사용하므로 전략 A(endpoint 폐쇄)를 적용합니다.

이 PR은 두 단계 변경 중 PR1입니다. 먼저 폐쇄 image를 production rollback 기준으로 만들기 위한 코드·계약만 포함하며, production 배포와 기존 데이터 purge(V51)는 포함하지 않습니다.

## 작업 내용

- `RouteSearchController`와 전용 permit-all `SecurityFilterChain`을 non-production profile에서만 등록했습니다.
- production 공통 public chain에서는 세 route matcher를 제거하고 default deny를 유지했습니다.
- prod 통합 테스트로 세 endpoint의 정확한 403, controller bean 부재, route use case 미호출, row 변화 없음, application-owned 출력에 payload·원문 IP·proxy header marker 없음까지 고정했습니다.
- 운영 evidence를 `allowedPublicEndpoints`, `closedProductionEndpoints`, 코드상 internal API catalog로 구분했습니다.
- post-deploy smoke는 세 endpoint를 한 번씩만 호출하고 403/404만 허용합니다. 하나라도 2xx이면 재시도 없이 즉시 실패합니다.
- 최신 main의 train-search 공개 계약은 그대로 보존했습니다.

## 검증

- 실행한 명령과 결과:
  - `cd backend && ./gradlew check --no-daemon --rerun-tasks` — PASS, 5 tasks executed
  - `node --test tools/ci/*.test.mjs` — PASS, 268 tests
  - `node --test tools/ops/post-deploy-smoke.test.mjs` — PASS, 8 tests
  - `cd apps/mobile && flutter test test/app_dependencies_test.dart test/features/routes/local_route_repository_test.dart` — PASS, 110 tests
  - `git diff --check origin/main...HEAD` — PASS

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| production route API 폐쇄 | Backend/Spring | prod profile MockMvc 통합 테스트 | `ProductionRouteApiClosureTest` | 세 endpoint 정확히 403 |
| 부작용 차단 | Backend/DB | mock interaction·row count 비교 | 동일 테스트 | use case 0회, row 변화 0 |
| payload/IP 비노출 | Backend log | marker 기반 captured output 검사 | 동일 테스트 | marker 0건 |
| 외부 smoke fail-fast | Node | 2xx 후 403 응답 fixture의 호출 횟수 검사 | `post-deploy-smoke.test.mjs` | 첫 2xx에서 FAIL, 1회 호출 |
| Android local-first 유지 | Flutter | 의존성·local repository 회귀 테스트 | 110 tests | PASS |
| 실제 production ingress | Production | PR1 별도 배포 승인 후 외부 smoke | 이 PR 범위 밖 | 미실행(배포 미승인) |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: production 공개 경로검색 API 3개 폐쇄, internal dev/test catalog 유지
- realtime contract: 변경 없음
- backend identity: PR1 폐쇄 image SHA를 배포 후 rollback latch로 별도 기록

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - profile 표현식과 SecurityFilterChain 우선순위가 prod 및 non-prod에서 의도대로 분리되는지
  - production 403 이전에 controller/use case/persistence가 호출되지 않는지
  - 외부 smoke가 첫 2xx를 후속 403으로 덮어쓰지 않는지
  - internal API catalog와 production 공개 inventory가 분리됐는지

## 리스크

- PR1 배포 전 이전 production image로 rollback하면 route API가 다시 열립니다. 따라서 PR1 자체를 먼저 성공 배포해 rollback 기준으로 만든 뒤에만 purge PR2를 진행합니다.
- 이 PR은 DB row를 삭제하지 않습니다. V51은 production snapshot gate와 별도 배포 승인을 통과한 후 PR2에서 수행합니다.
- V51 commit 후 application readiness 실패 시 PR1 image로만 rollback하며 삭제 데이터는 자동 복원되지 않습니다. 데이터 복원은 별도 승인된 backup restore만 허용합니다.
- PR2 production 배포 승인 전, V51 적용 복원 DB에 정확한 PR1 backend/back-worker image를 연결해 두 container 기동·readiness·세 endpoint 403·Flyway validation 성공을 rehearsal해야 합니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
