### PR TITLE
[CI] production 경로 API 폐쇄 증거 gate 추가

### DIFF
--- a/.github/workflows/production-route-api-closure-evidence.yml
+++ b/.github/workflows/production-route-api-closure-evidence.yml
@@ -21,8 +21,6 @@ jobs:
     runs-on:
       - self-hosted
       - easysubway-production
-    environment:
-      name: production
     timeout-minutes: 5
     concurrency:
       group: cd-production-deploy

--- a/.github/workflows/production-route-api-closure-evidence.yml
+++ b/.github/workflows/production-route-api-closure-evidence.yml
@@ -59,6 +59,15 @@ jobs:
 
           expected_runtime_image="easysubway-backend:${current_sha}"
           deployed_image_id="$(docker image inspect --format '{{.Id}}' "${expected_runtime_image}")"
+          deployed_image_revision="$(
+            docker image inspect \
+              --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' \
+              "${expected_runtime_image}"
+          )"
+          if [[ "${deployed_image_revision}" != "${current_sha}" ]]; then
+            echo "deployed image revision does not match the committed SHA" >&2
+            exit 1
+          fi
           deployed_repo_digests="$(
             docker image inspect --format '{{join .RepoDigests "\n"}}' "${expected_runtime_image}"
           )"

--- a/.github/workflows/production-route-api-closure-evidence.yml
+++ b/.github/workflows/production-route-api-closure-evidence.yml
@@ -1,0 +1,154 @@
+name: Production route API closure evidence
+
+on:
+  workflow_dispatch:
+    inputs:
+      expected_sha:
+        description: "현재 production에 배포돼 있어야 하는 40자 commit SHA"
+        required: true
+        type: string
+      expected_image_digest:
+        description: "현재 production에 배포돼 있어야 하는 sha256 image digest"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify production route API closure
+    runs-on:
+      - self-hosted
+      - easysubway-production
+    environment:
+      name: production
+    timeout-minutes: 5
+    concurrency:
+      group: production-route-api-closure-evidence
+      cancel-in-progress: false
+    env:
+      EXPECTED_SHA: ${{ inputs.expected_sha }}
+      EXPECTED_IMAGE_DIGEST: ${{ inputs.expected_image_digest }}
+      DEPLOY_ROOT: ${{ vars.DEPLOY_ROOT }}
+
+    steps:
+      - name: Verify deployed revision, origin denial, and row invariance
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ ! "${EXPECTED_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "expected_sha must be a 40-character lowercase commit SHA" >&2
+            exit 1
+          fi
+          if [[ ! "${EXPECTED_IMAGE_DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "expected_image_digest must be a sha256 digest" >&2
+            exit 1
+          fi
+
+          DEPLOY_ROOT="${DEPLOY_ROOT:-/opt/easysubway}"
+          if [[ ! "${DEPLOY_ROOT}" =~ ^/[A-Za-z0-9._/-]+$ || "${DEPLOY_ROOT}" == *..* ]]; then
+            echo "DEPLOY_ROOT is invalid" >&2
+            exit 1
+          fi
+
+          current_sha="$(<"${DEPLOY_ROOT}/shared/current-sha")"
+          current_digest="$(<"${DEPLOY_ROOT}/shared/current-image-digest")"
+          if [[ "${current_sha}" != "${EXPECTED_SHA}" ]]; then
+            echo "deployed SHA does not match the approved PR1 SHA" >&2
+            exit 1
+          fi
+          if [[ "${current_digest}" != "${EXPECTED_IMAGE_DIGEST}" ]]; then
+            echo "deployed image digest does not match the approved PR1 digest" >&2
+            exit 1
+          fi
+
+          expected_runtime_image="easysubway-backend:${EXPECTED_SHA}"
+          for container in easysubway-backend easysubway-back-worker; do
+            runtime_image="$(docker inspect --format '{{.Config.Image}}' "${container}")"
+            if [[ "${runtime_image}" != "${expected_runtime_image}" ]]; then
+              echo "${container} does not use the approved PR1 image tag" >&2
+              exit 1
+            fi
+          done
+
+          backend_port="$(
+            docker inspect \
+              --format '{{(index (index .NetworkSettings.Ports "8080/tcp") 0).HostPort}}' \
+              easysubway-backend
+          )"
+          if [[ ! "${backend_port}" =~ ^[0-9]{1,5}$ ]]; then
+            echo "could not resolve the loopback backend port" >&2
+            exit 1
+          fi
+
+          route_row_count() {
+            docker exec easysubway-postgres sh -lc \
+              'psql -v ON_ERROR_STOP=1 -A -t -U "$POSTGRES_USER" "$POSTGRES_DB" -c "SELECT count(*) FROM route_search_results;"' \
+              | tr -d '[:space:]'
+          }
+
+          origin_status() {
+            local path="${1:?path is required}"
+            local request_body="${2:?request body is required}"
+            local status
+            if ! status="$(
+              curl -sS \
+                --connect-timeout 2 \
+                --max-time 5 \
+                --output /dev/null \
+                --write-out '%{http_code}' \
+                --request POST \
+                --header 'content-type: application/json' \
+                --data-binary "${request_body}" \
+                "http://127.0.0.1:${backend_port}${path}"
+            )"; then
+              status="network-error"
+            fi
+            printf '%s\n' "${status}"
+          }
+
+          row_count_before="$(route_row_count)"
+          if [[ ! "${row_count_before}" =~ ^[0-9]+$ ]]; then
+            echo "route_search_results pre-request count was not numeric" >&2
+            exit 1
+          fi
+
+          v1_status="$(origin_status \
+            /api/v1/routes/search \
+            '{"originStationId":"closure-probe","destinationStationId":"closure-probe","mobilityType":"SENIOR"}')"
+          v2_status="$(origin_status \
+            /api/v2/routes/search \
+            '{"originStationId":"closure-probe","destinationStationId":"closure-probe","departureTime":"2026-07-15T09:15:00+09:00","mobilityType":"SENIOR","constraintMode":"ALLOW_WITH_WARNINGS","useRealtime":false,"maxTransfers":3,"alternativeCount":1}')"
+          refresh_status="$(origin_status \
+            /api/v2/routes/closure-probe/refresh \
+            '{}')"
+
+          row_count_after="$(route_row_count)"
+          if [[ ! "${row_count_after}" =~ ^[0-9]+$ ]]; then
+            echo "route_search_results post-request count was not numeric" >&2
+            exit 1
+          fi
+
+          {
+            echo "### Production route API closure evidence"
+            echo "- deployed SHA: \`${current_sha}\`"
+            echo "- image digest: \`${current_digest}\`"
+            echo "- origin POST /api/v1/routes/search: \`${v1_status}\`"
+            echo "- origin POST /api/v2/routes/search: \`${v2_status}\`"
+            echo "- origin POST /api/v2/routes/closure-probe/refresh: \`${refresh_status}\`"
+            echo "- route_search_results rows before: \`${row_count_before}\`"
+            echo "- route_search_results rows after: \`${row_count_after}\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+          for status in "${v1_status}" "${v2_status}" "${refresh_status}"; do
+            if [[ "${status}" != "403" ]]; then
+              echo "every origin route endpoint must return exactly 403; observed ${status}" >&2
+              exit 1
+            fi
+          done
+          if [[ "${row_count_before}" != "${row_count_after}" ]]; then
+            echo "route_search_results changed during the closure probe" >&2
+            exit 1
+          fi

--- a/.github/workflows/production-route-api-closure-evidence.yml
+++ b/.github/workflows/production-route-api-closure-evidence.yml
@@ -108,6 +108,7 @@ jobs:
             local status
             if ! status="$(
               curl -sS \
+                --noproxy '*' \
                 --connect-timeout 2 \
                 --max-time 5 \
                 --output /dev/null \

--- a/.github/workflows/production-route-api-closure-evidence.yml
+++ b/.github/workflows/production-route-api-closure-evidence.yml
@@ -25,7 +25,7 @@ jobs:
       name: production
     timeout-minutes: 5
     concurrency:
-      group: production-route-api-closure-evidence
+      group: cd-production-deploy
       cancel-in-progress: false
     env:
       EXPECTED_SHA: ${{ inputs.expected_sha }}
@@ -65,10 +65,23 @@ jobs:
           fi
 
           expected_runtime_image="easysubway-backend:${EXPECTED_SHA}"
+          approved_image_id="$(docker image inspect --format '{{.Id}}' "${expected_runtime_image}")"
+          approved_repo_digests="$(
+            docker image inspect --format '{{join .RepoDigests "\n"}}' "${expected_runtime_image}"
+          )"
+          if ! grep -Fxq "ghcr.io/aquilaxk/easysubway-backend@${EXPECTED_IMAGE_DIGEST}" <<< "${approved_repo_digests}"; then
+            echo "approved PR1 image tag is not associated with the approved digest" >&2
+            exit 1
+          fi
           for container in easysubway-backend easysubway-back-worker; do
             runtime_image="$(docker inspect --format '{{.Config.Image}}' "${container}")"
             if [[ "${runtime_image}" != "${expected_runtime_image}" ]]; then
               echo "${container} does not use the approved PR1 image tag" >&2
+              exit 1
+            fi
+            running_image_id="$(docker inspect --format '{{.Image}}' "${container}")"
+            if [[ "${running_image_id}" != "${approved_image_id}" ]]; then
+              echo "${container} does not run the approved PR1 image ID" >&2
               exit 1
             fi
           done

--- a/.github/workflows/production-route-api-closure-evidence.yml
+++ b/.github/workflows/production-route-api-closure-evidence.yml
@@ -1,16 +1,12 @@
 name: Production route API closure evidence
 
 on:
-  workflow_dispatch:
-    inputs:
-      expected_sha:
-        description: "현재 production에 배포돼 있어야 하는 40자 commit SHA"
-        required: true
-        type: string
-      expected_image_digest:
-        description: "현재 production에 배포돼 있어야 하는 sha256 image digest"
-        required: true
-        type: string
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/production-route-api-closure-evidence.yml"
+      - "tools/ci/production-route-api-closure-evidence-workflow.test.mjs"
 
 permissions:
   contents: read
@@ -26,8 +22,8 @@ jobs:
       group: cd-production-deploy
       cancel-in-progress: false
     env:
-      EXPECTED_SHA: ${{ inputs.expected_sha }}
-      EXPECTED_IMAGE_DIGEST: ${{ inputs.expected_image_digest }}
+      EXPECTED_SHA: cba25764de4ed646e398b2141b64fa41767ed3cc
+      EXPECTED_IMAGE_DIGEST: sha256:ef9067f8890e72a5a4cd2fa3ab478d80951e577042e3016bff266b2fd24859e8
       DEPLOY_ROOT: ${{ vars.DEPLOY_ROOT }}
 
     steps:

--- a/.github/workflows/production-route-api-closure-evidence.yml
+++ b/.github/workflows/production-route-api-closure-evidence.yml
@@ -22,8 +22,7 @@ jobs:
       group: cd-production-deploy
       cancel-in-progress: false
     env:
-      EXPECTED_SHA: cba25764de4ed646e398b2141b64fa41767ed3cc
-      EXPECTED_IMAGE_DIGEST: sha256:ef9067f8890e72a5a4cd2fa3ab478d80951e577042e3016bff266b2fd24859e8
+      CLOSURE_BASE_SHA: cba25764de4ed646e398b2141b64fa41767ed3cc
       DEPLOY_ROOT: ${{ vars.DEPLOY_ROOT }}
 
     steps:
@@ -32,12 +31,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [[ ! "${EXPECTED_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "expected_sha must be a 40-character lowercase commit SHA" >&2
-            exit 1
-          fi
-          if [[ ! "${EXPECTED_IMAGE_DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-            echo "expected_image_digest must be a sha256 digest" >&2
+          if [[ ! "${CLOSURE_BASE_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "closure base must be a 40-character lowercase commit SHA" >&2
             exit 1
           fi
 
@@ -49,33 +44,37 @@ jobs:
 
           current_sha="$(<"${DEPLOY_ROOT}/shared/current-sha")"
           current_digest="$(<"${DEPLOY_ROOT}/shared/current-image-digest")"
-          if [[ "${current_sha}" != "${EXPECTED_SHA}" ]]; then
-            echo "deployed SHA does not match the approved PR1 SHA" >&2
+          if [[ ! "${current_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "deployed SHA marker is invalid" >&2
             exit 1
           fi
-          if [[ "${current_digest}" != "${EXPECTED_IMAGE_DIGEST}" ]]; then
-            echo "deployed image digest does not match the approved PR1 digest" >&2
+          if [[ ! "${current_digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "deployed image digest marker is invalid" >&2
+            exit 1
+          fi
+          if ! git -C "${DEPLOY_ROOT}/repository" merge-base --is-ancestor "${CLOSURE_BASE_SHA}" "${current_sha}"; then
+            echo "deployed SHA does not contain the approved PR1 closure" >&2
             exit 1
           fi
 
-          expected_runtime_image="easysubway-backend:${EXPECTED_SHA}"
-          approved_image_id="$(docker image inspect --format '{{.Id}}' "${expected_runtime_image}")"
-          approved_repo_digests="$(
+          expected_runtime_image="easysubway-backend:${current_sha}"
+          deployed_image_id="$(docker image inspect --format '{{.Id}}' "${expected_runtime_image}")"
+          deployed_repo_digests="$(
             docker image inspect --format '{{join .RepoDigests "\n"}}' "${expected_runtime_image}"
           )"
-          if ! grep -Fxq "ghcr.io/aquilaxk/easysubway-backend@${EXPECTED_IMAGE_DIGEST}" <<< "${approved_repo_digests}"; then
-            echo "approved PR1 image tag is not associated with the approved digest" >&2
+          if ! grep -Fxq "ghcr.io/aquilaxk/easysubway-backend@${current_digest}" <<< "${deployed_repo_digests}"; then
+            echo "deployed image tag is not associated with the committed digest" >&2
             exit 1
           fi
           for container in easysubway-backend easysubway-back-worker; do
             runtime_image="$(docker inspect --format '{{.Config.Image}}' "${container}")"
             if [[ "${runtime_image}" != "${expected_runtime_image}" ]]; then
-              echo "${container} does not use the approved PR1 image tag" >&2
+              echo "${container} does not use the deployed image tag" >&2
               exit 1
             fi
             running_image_id="$(docker inspect --format '{{.Image}}' "${container}")"
-            if [[ "${running_image_id}" != "${approved_image_id}" ]]; then
-              echo "${container} does not run the approved PR1 image ID" >&2
+            if [[ "${running_image_id}" != "${deployed_image_id}" ]]; then
+              echo "${container} does not run the deployed image ID" >&2
               exit 1
             fi
           done

--- a/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
+++ b/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
@@ -13,10 +13,13 @@ test("production route API closure evidence는 현재 배포와 origin 403·row 
   assert.match(workflow, /runs-on:\n\s+- self-hosted\n\s+- easysubway-production/);
   assert.match(workflow, /environment:\n\s+name: production/);
   assert.match(workflow, /permissions:\n\s+contents: read/);
+  assert.match(workflow, /group: cd-production-deploy/);
 
   assert.match(workflow, /shared\/current-sha/);
   assert.match(workflow, /shared\/current-image-digest/);
   assert.match(workflow, /\.Config\.Image/);
+  assert.match(workflow, /\.RepoDigests/);
+  assert.match(workflow, /--format '\{\{\.Image\}\}'/);
   assert.match(workflow, /easysubway-backend/);
   assert.match(workflow, /easysubway-back-worker/);
   assert.match(workflow, /\/api\/v1\/routes\/search/);

--- a/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
+++ b/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const workflowPath = ".github/workflows/production-route-api-closure-evidence.yml";
+
+test("production route API closure evidence는 현재 배포와 origin 403·row 불변을 검증한다", async () => {
+  const workflow = await readFile(workflowPath, "utf8");
+
+  assert.match(workflow, /^on:\n  workflow_dispatch:\n/m);
+  assert.match(workflow, /expected_sha:/);
+  assert.match(workflow, /expected_image_digest:/);
+  assert.match(workflow, /runs-on:\n\s+- self-hosted\n\s+- easysubway-production/);
+  assert.match(workflow, /environment:\n\s+name: production/);
+  assert.match(workflow, /permissions:\n\s+contents: read/);
+
+  assert.match(workflow, /shared\/current-sha/);
+  assert.match(workflow, /shared\/current-image-digest/);
+  assert.match(workflow, /\.Config\.Image/);
+  assert.match(workflow, /easysubway-backend/);
+  assert.match(workflow, /easysubway-back-worker/);
+  assert.match(workflow, /\/api\/v1\/routes\/search/);
+  assert.match(workflow, /\/api\/v2\/routes\/search/);
+  assert.match(workflow, /\/api\/v2\/routes\/closure-probe\/refresh/);
+  assert.match(workflow, /status[^\n]+!= "403"/);
+  assert.doesNotMatch(workflow, /retry|acceptedStatuses|404/);
+
+  assert.match(workflow, /SELECT count\(\*\) FROM route_search_results/);
+  assert.match(workflow, /row_count_before/);
+  assert.match(workflow, /row_count_after/);
+  assert.match(workflow, /row_count_before[^\n]+!=[^\n]+row_count_after/);
+});

--- a/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
+++ b/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
@@ -7,9 +7,10 @@ const workflowPath = ".github/workflows/production-route-api-closure-evidence.ym
 test("production route API closure evidence는 현재 배포와 origin 403·row 불변을 검증한다", async () => {
   const workflow = await readFile(workflowPath, "utf8");
 
-  assert.match(workflow, /^on:\n  workflow_dispatch:\n/m);
-  assert.match(workflow, /expected_sha:/);
-  assert.match(workflow, /expected_image_digest:/);
+  assert.match(workflow, /^on:\n  push:\n    branches:\n      - main\n    paths:/m);
+  assert.doesNotMatch(workflow, /workflow_dispatch/);
+  assert.match(workflow, /EXPECTED_SHA: cba25764de4ed646e398b2141b64fa41767ed3cc/);
+  assert.match(workflow, /EXPECTED_IMAGE_DIGEST: sha256:ef9067f8890e72a5a4cd2fa3ab478d80951e577042e3016bff266b2fd24859e8/);
   assert.match(workflow, /runs-on:\n\s+- self-hosted\n\s+- easysubway-production/);
   assert.doesNotMatch(workflow, /environment:\n\s+name: production/);
   assert.match(workflow, /permissions:\n\s+contents: read/);

--- a/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
+++ b/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
@@ -9,8 +9,8 @@ test("production route API closure evidence는 현재 배포와 origin 403·row 
 
   assert.match(workflow, /^on:\n  push:\n    branches:\n      - main\n    paths:/m);
   assert.doesNotMatch(workflow, /workflow_dispatch/);
-  assert.match(workflow, /EXPECTED_SHA: cba25764de4ed646e398b2141b64fa41767ed3cc/);
-  assert.match(workflow, /EXPECTED_IMAGE_DIGEST: sha256:ef9067f8890e72a5a4cd2fa3ab478d80951e577042e3016bff266b2fd24859e8/);
+  assert.match(workflow, /CLOSURE_BASE_SHA: cba25764de4ed646e398b2141b64fa41767ed3cc/);
+  assert.doesNotMatch(workflow, /EXPECTED_IMAGE_DIGEST/);
   assert.match(workflow, /runs-on:\n\s+- self-hosted\n\s+- easysubway-production/);
   assert.doesNotMatch(workflow, /environment:\n\s+name: production/);
   assert.match(workflow, /permissions:\n\s+contents: read/);
@@ -18,6 +18,7 @@ test("production route API closure evidence는 현재 배포와 origin 403·row 
 
   assert.match(workflow, /shared\/current-sha/);
   assert.match(workflow, /shared\/current-image-digest/);
+  assert.match(workflow, /merge-base --is-ancestor "\$\{CLOSURE_BASE_SHA\}" "\$\{current_sha\}"/);
   assert.match(workflow, /\.Config\.Image/);
   assert.match(workflow, /\.RepoDigests/);
   assert.match(workflow, /--format '\{\{\.Image\}\}'/);

--- a/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
+++ b/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
@@ -25,6 +25,7 @@ test("production route API closure evidence는 현재 배포와 origin 403·row 
   assert.match(workflow, /\/api\/v1\/routes\/search/);
   assert.match(workflow, /\/api\/v2\/routes\/search/);
   assert.match(workflow, /\/api\/v2\/routes\/closure-probe\/refresh/);
+  assert.match(workflow, /--noproxy '\*'/);
   assert.match(workflow, /status[^\n]+!= "403"/);
   assert.doesNotMatch(workflow, /retry|acceptedStatuses|404/);
 

--- a/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
+++ b/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
@@ -21,6 +21,8 @@ test("production route API closure evidence는 현재 배포와 origin 403·row 
   assert.match(workflow, /merge-base --is-ancestor "\$\{CLOSURE_BASE_SHA\}" "\$\{current_sha\}"/);
   assert.match(workflow, /\.Config\.Image/);
   assert.match(workflow, /\.RepoDigests/);
+  assert.match(workflow, /org\.opencontainers\.image\.revision/);
+  assert.match(workflow, /image_revision[^\n]+!=[^\n]+current_sha/);
   assert.match(workflow, /--format '\{\{\.Image\}\}'/);
   assert.match(workflow, /easysubway-backend/);
   assert.match(workflow, /easysubway-back-worker/);

--- a/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
+++ b/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
@@ -11,7 +11,7 @@ test("production route API closure evidence는 현재 배포와 origin 403·row 
   assert.match(workflow, /expected_sha:/);
   assert.match(workflow, /expected_image_digest:/);
   assert.match(workflow, /runs-on:\n\s+- self-hosted\n\s+- easysubway-production/);
-  assert.match(workflow, /environment:\n\s+name: production/);
+  assert.doesNotMatch(workflow, /environment:\n\s+name: production/);
   assert.match(workflow, /permissions:\n\s+contents: read/);
   assert.match(workflow, /group: cd-production-deploy/);
 


### PR DESCRIPTION
## 관련 이슈

Refs #1913

## 작업 배경

- PR1 production 배포 후 외부 ingress 403은 확인됐지만, loopback origin의 정확한 403과 요청 전후 저장 row 불변은 기존 CD가 증거로 남기지 않습니다.
- production origin은 loopback에만 bind되어 있어 self-hosted production runner에서만 이 경계를 직접 검증할 수 있습니다.

## 작업 내용

- review·merge된 `main` push에서만 실행되는 read-only production evidence workflow를 추가했습니다.
- 승인된 PR1 closure SHA `cba25764de4ed646e398b2141b64fa41767ed3cc`를 최소 ancestor로 고정하고, 실행 시점의 `current-sha`가 이를 포함하는지 검증합니다.
- 배포 서버의 `current-sha`·`current-image-digest`와 backend/back-worker의 runtime image tag·RepoDigest·local image ID를 대조합니다.
- 세 route endpoint를 proxy 없이 origin loopback에 각각 한 번 호출해 정확히 403을 요구합니다.
- 호출 전후 `route_search_results` aggregate count가 동일한지 확인합니다.
- 실제 CD와 동일한 `cd-production-deploy` concurrency group으로 검증 전체를 직렬화합니다.
- workflow 계약을 고정하는 Node 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/production-route-api-closure-evidence-workflow.test.mjs` — 1/1 통과
  - `node --test tools/ci/*.test.mjs tools/ci/lib/*.test.mjs tools/repo/*.test.mjs` — 287/287 통과
  - `ruby -e 'require "yaml"; YAML.load(File.read(ARGV[0]))' .github/workflows/production-route-api-closure-evidence.yml` — YAML parse 통과
  - `git diff --check` — 통과
  - `codex review --disable plugins --base origin/main` — actionable finding 0건
  - required CI — Android CI, Backend CI, Mobile App CI, Repository CI, Changes 모두 통과

## 검증 증거

UI 변경은 없습니다. production 실행 증거는 이 PR이 `main`에 병합된 직후 자동 생성되며, workflow는 배포·DML 없이 현재 배포 identity, 정확한 origin 403, aggregate row 불변만 확인합니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| workflow 계약 | Node 24 | 전용 회귀 테스트 | 로컬 1/1 통과 | PASS |
| repository 계약 | Node 24 | repository CI 명령 | 로컬 287/287 및 required CI 통과 | PASS |
| 독립 코드리뷰 | Codex CLI | plugins disabled fallback | Review 4699709523 | PASS |
| production origin 폐쇄 | OCI A1 self-hosted runner | main push evidence workflow | merge 후 자동 실행 예정 | PENDING |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: production 공개 route API 폐쇄 계약 유지
- realtime contract: 변경 없음
- backend identity: PR1 closure SHA를 포함하는 CD-committed 현재 배포 identity 검증

## 리뷰어 메모

- branch/tag에서 production runner 코드를 바꿔 실행할 수 없도록 `workflow_dispatch`를 제거했고, review·merge된 `main` push에만 반응합니다.
- read-only evidence가 GitHub production Deployment 기록을 만들지 않도록 `environment: production`을 사용하지 않습니다.
- workflow가 deploy·DML 없이 closure ancestor, current SHA/digest, runtime image, 정확한 origin 403, aggregate row 불변만 검증하는지 확인해 주세요.
- 새 workflow 파일은 `detect-changed-paths.sh`에서 deploy 대상으로 분류되지 않아 merge 자체가 backend 재배포를 유발하지 않습니다.

## 리스크

- production container와 DB를 읽지만 배포·DML·GitHub Deployment 기록은 만들지 않습니다.
- 공개 summary에는 commit SHA, image digest, HTTP status, aggregate row count만 기록하며 raw ID·payload·사용자 데이터는 기록하지 않습니다.
- 배포 SHA가 PR1 closure를 포함하지 않거나 image identity가 일치하지 않거나 endpoint status가 정확한 403이 아니거나 row count가 달라지면 fail closed합니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰 상태를 확인했다. rate-limit으로 review가 unavailable이었다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않았다.
- [x] `codex review --disable plugins --base origin/main` 독립 fallback 결과를 단일 PR Review 4699709523으로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. 이 workflow 파일은 deploy path가 아니며 실행 자체도 read-only다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **검증**
  * 프로덕션 배포본의 커밋과 컨테이너 이미지 일치 여부를 자동으로 확인합니다.
  * 주요 경로 검색 및 점검 API가 승인되지 않은 요청에 정확히 `403`을 반환하는지 검증합니다.
  * 검증 전후 검색 결과 데이터가 변경되지 않았는지 확인합니다.
  * 주요 배포 조건과 검증 로직을 자동 테스트로 점검합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->