### PR TITLE
[CI] #1913 purge snapshot gate 추가

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -321,21 +321,25 @@ jobs:
           snapshot_runs_file="${RUNNER_TEMP}/route-purge-snapshot-runs.json"
           snapshot_wait_deadline="$((SECONDS + 3600))"
           while true; do
-            curl -fsS \
+            if curl -fsS \
+              --connect-timeout 5 \
+              --max-time 20 \
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer ${GITHUB_TOKEN}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               --output "${snapshot_runs_file}" \
-              "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/production-route-api-closure-evidence.yml/runs?head_sha=${DEPLOY_SHA}&branch=main&status=success&per_page=20"
-
-            if node tools/ci/require-successful-workflow-run.mjs \
-              "${snapshot_runs_file}" \
-              "${DEPLOY_SHA}" \
-              "Production route API closure evidence" \
-              "push,workflow_dispatch" \
-              main \
-              3600; then
-              break
+              "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/production-route-api-closure-evidence.yml/runs?head_sha=${DEPLOY_SHA}&branch=main&status=success&per_page=20"; then
+              if node tools/ci/require-successful-workflow-run.mjs \
+                "${snapshot_runs_file}" \
+                "${DEPLOY_SHA}" \
+                "Production route API closure evidence" \
+                "push,workflow_dispatch" \
+                main \
+                3600; then
+                break
+              fi
+            else
+              echo "snapshot evidence query failed; retrying within bounded deadline" >&2
             fi
             if (( SECONDS >= snapshot_wait_deadline )); then
               echo "timed out waiting for route purge snapshot evidence" >&2

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -84,18 +84,50 @@ jobs:
         run: |
           set -euo pipefail
 
+          if git rev-parse "${DEPLOY_SHA}^" >/dev/null 2>&1; then
+            git diff --name-only "${DEPLOY_SHA}^" "${DEPLOY_SHA}" > changed-files.txt
+          else
+            git diff-tree --root --name-only "${DEPLOY_SHA}" > changed-files.txt
+          fi
+
+          route_purge_snapshot_required=false
+          if grep -Eq '^backend/src/main/resources/db/migration/(postgresql|h2)/V51__' changed-files.txt; then
+            route_purge_snapshot_required=true
+          fi
+          echo "route_purge_snapshot_required=${route_purge_snapshot_required}" >> "${GITHUB_OUTPUT}"
+
           if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
             echo "deploy=true" >> "${GITHUB_OUTPUT}"
             echo "manual dispatch deploys the requested main SHA" >> "${GITHUB_STEP_SUMMARY}"
             exit 0
           fi
 
-          if git rev-parse "${DEPLOY_SHA}^" >/dev/null 2>&1; then
-            git diff --name-only "${DEPLOY_SHA}^" "${DEPLOY_SHA}" > changed-files.txt
-          else
-            git diff-tree --root --name-only "${DEPLOY_SHA}" > changed-files.txt
-          fi
           bash tools/ci/detect-changed-paths.sh changed-files.txt
+
+      - name: CD Plan / Require route purge snapshot evidence
+        if: ${{ steps.changes.outputs.route_purge_snapshot_required == 'true' }}
+        shell: bash
+        env:
+          DEPLOY_SHA: ${{ steps.target.outputs.sha }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          snapshot_runs_file="${RUNNER_TEMP}/route-purge-snapshot-runs.json"
+          curl -fsS \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            --output "${snapshot_runs_file}" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/production-route-api-closure-evidence.yml/runs?head_sha=${DEPLOY_SHA}&branch=main&event=push&status=success&per_page=20"
+
+          node tools/ci/require-successful-workflow-run.mjs \
+            "${snapshot_runs_file}" \
+            "${DEPLOY_SHA}" \
+            "Production route API closure evidence" \
+            push \
+            main
+          echo "validated_route_purge_snapshot_sha=${DEPLOY_SHA}" >> "${GITHUB_STEP_SUMMARY}"
 
   build-image:
     name: CD Build image

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -290,14 +290,27 @@ jobs:
             required=true
           fi
           echo "required=${required}" >> "${GITHUB_OUTPUT}"
+          echo "current_sha=${current_sha}" >> "${GITHUB_OUTPUT}"
 
       - name: CD Deploy / Require route purge snapshot evidence
         if: ${{ steps.route-purge.outputs.required == 'true' }}
         shell: bash
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          DEPLOY_ROOT: ${{ vars.DEPLOY_ROOT }}
+          CURRENT_DEPLOYED_SHA: ${{ steps.route-purge.outputs.current_sha }}
         run: |
           set -euo pipefail
+
+          DEPLOY_ROOT="${DEPLOY_ROOT:-/opt/easysubway}"
+          if [[ ! "${DEPLOY_ROOT}" =~ ^/[A-Za-z0-9._/-]+$ || "${DEPLOY_ROOT}" == *..* ]]; then
+            echo "DEPLOY_ROOT is invalid" >&2
+            exit 1
+          fi
+          if [[ ! "${CURRENT_DEPLOYED_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "snapshot source deployed SHA is invalid" >&2
+            exit 1
+          fi
 
           snapshot_runs_file="${RUNNER_TEMP}/route-purge-snapshot-runs.json"
           curl -fsS \
@@ -305,15 +318,71 @@ jobs:
             -H "Authorization: Bearer ${GITHUB_TOKEN}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             --output "${snapshot_runs_file}" \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/production-route-api-closure-evidence.yml/runs?head_sha=${DEPLOY_SHA}&branch=main&event=push&status=success&per_page=20"
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/production-route-api-closure-evidence.yml/runs?head_sha=${DEPLOY_SHA}&branch=main&status=success&per_page=20"
 
           node tools/ci/require-successful-workflow-run.mjs \
             "${snapshot_runs_file}" \
             "${DEPLOY_SHA}" \
             "Production route API closure evidence" \
-            push \
+            "push,workflow_dispatch" \
             main \
             3600
+
+          marker_file="${DEPLOY_ROOT}/shared/1913-route-purge-snapshot/snapshot-${DEPLOY_SHA}.env"
+          if [[ ! -f "${marker_file}" ]]; then
+            echo "route purge snapshot marker is missing" >&2
+            exit 1
+          fi
+
+          marker_value() {
+            local key="${1:?marker key is required}"
+            local value
+            value="$(sed -n "s/^${key}=//p" "${marker_file}")"
+            if [[ -z "${value}" || "${value}" == *$'\n'* ]]; then
+              echo "snapshot marker field ${key} is missing or duplicated" >&2
+              exit 1
+            fi
+            printf '%s\n' "${value}"
+          }
+
+          marker_status="$(marker_value status)"
+          marker_request_sha="$(marker_value snapshot_request_sha)"
+          marker_current_sha="$(marker_value current_sha)"
+          backup_file="$(marker_value backup_file)"
+          marker_backup_sha="$(marker_value backup_sha256)"
+
+          if [[ "${marker_status}" != "snapshot-complete" ]]; then
+            echo "route purge snapshot marker is incomplete" >&2
+            exit 1
+          fi
+          if [[ "${marker_request_sha}" != "${DEPLOY_SHA}" ]]; then
+            echo "snapshot marker request SHA does not match deploy SHA" >&2
+            exit 1
+          fi
+          if [[ "${marker_current_sha}" != "${CURRENT_DEPLOYED_SHA}" ]]; then
+            echo "snapshot marker source SHA does not match current production SHA" >&2
+            exit 1
+          fi
+          case "${backup_file}" in
+            "${DEPLOY_ROOT}/backups/postgres/1913-route-purge/"*.dump) ;;
+            *)
+              echo "snapshot marker backup path is invalid" >&2
+              exit 1
+              ;;
+          esac
+          if [[ ! -f "${backup_file}" || ! -f "${backup_file}.sha256" ]]; then
+            echo "snapshot marker backup is missing" >&2
+            exit 1
+          fi
+          if [[ ! "${marker_backup_sha}" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "snapshot marker backup checksum is invalid" >&2
+            exit 1
+          fi
+          actual_backup_sha="$(sha256sum "${backup_file}" | awk '{print $1}')"
+          if [[ "${marker_backup_sha}" != "${actual_backup_sha}" ]]; then
+            echo "snapshot marker backup checksum mismatch" >&2
+            exit 1
+          fi
           echo "validated_route_purge_snapshot_sha=${DEPLOY_SHA}" >> "${GITHUB_STEP_SUMMARY}"
 
       - name: CD Deploy / Validate manual dispatch CI

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -84,50 +84,18 @@ jobs:
         run: |
           set -euo pipefail
 
-          if git rev-parse "${DEPLOY_SHA}^" >/dev/null 2>&1; then
-            git diff --name-only "${DEPLOY_SHA}^" "${DEPLOY_SHA}" > changed-files.txt
-          else
-            git diff-tree --root --name-only "${DEPLOY_SHA}" > changed-files.txt
-          fi
-
-          route_purge_snapshot_required=false
-          if grep -Eq '^backend/src/main/resources/db/migration/(postgresql|h2)/V51__' changed-files.txt; then
-            route_purge_snapshot_required=true
-          fi
-          echo "route_purge_snapshot_required=${route_purge_snapshot_required}" >> "${GITHUB_OUTPUT}"
-
           if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
             echo "deploy=true" >> "${GITHUB_OUTPUT}"
             echo "manual dispatch deploys the requested main SHA" >> "${GITHUB_STEP_SUMMARY}"
             exit 0
           fi
 
+          if git rev-parse "${DEPLOY_SHA}^" >/dev/null 2>&1; then
+            git diff --name-only "${DEPLOY_SHA}^" "${DEPLOY_SHA}" > changed-files.txt
+          else
+            git diff-tree --root --name-only "${DEPLOY_SHA}" > changed-files.txt
+          fi
           bash tools/ci/detect-changed-paths.sh changed-files.txt
-
-      - name: CD Plan / Require route purge snapshot evidence
-        if: ${{ steps.changes.outputs.route_purge_snapshot_required == 'true' }}
-        shell: bash
-        env:
-          DEPLOY_SHA: ${{ steps.target.outputs.sha }}
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-
-          snapshot_runs_file="${RUNNER_TEMP}/route-purge-snapshot-runs.json"
-          curl -fsS \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            --output "${snapshot_runs_file}" \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/production-route-api-closure-evidence.yml/runs?head_sha=${DEPLOY_SHA}&branch=main&event=push&status=success&per_page=20"
-
-          node tools/ci/require-successful-workflow-run.mjs \
-            "${snapshot_runs_file}" \
-            "${DEPLOY_SHA}" \
-            "Production route API closure evidence" \
-            push \
-            main
-          echo "validated_route_purge_snapshot_sha=${DEPLOY_SHA}" >> "${GITHUB_STEP_SUMMARY}"
 
   build-image:
     name: CD Build image
@@ -281,6 +249,72 @@ jobs:
           echo "sha=${deploy_sha}" >> "${GITHUB_OUTPUT}"
           echo "mode=${mode}" >> "${GITHUB_OUTPUT}"
           echo "DEPLOY_SHA=${deploy_sha}" >> "${GITHUB_ENV}"
+
+      - name: CD Deploy / Detect route purge migration
+        id: route-purge
+        shell: bash
+        env:
+          DEPLOY_ROOT: ${{ vars.DEPLOY_ROOT }}
+        run: |
+          set -euo pipefail
+
+          DEPLOY_ROOT="${DEPLOY_ROOT:-/opt/easysubway}"
+          if [[ ! "${DEPLOY_ROOT}" =~ ^/[A-Za-z0-9._/-]+$ || "${DEPLOY_ROOT}" == *..* ]]; then
+            echo "DEPLOY_ROOT is invalid" >&2
+            exit 1
+          fi
+          current_sha="$(<"${DEPLOY_ROOT}/shared/current-sha")"
+          if [[ ! "${current_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "deployed SHA marker is invalid" >&2
+            exit 1
+          fi
+          if ! git cat-file -e "${current_sha}^{commit}"; then
+            echo "deployed SHA is unavailable in the repository" >&2
+            exit 1
+          fi
+
+          route_purge_changes="${RUNNER_TEMP}/route-purge-migration-changes.txt"
+          git diff --name-only "${current_sha}" "${DEPLOY_SHA}" -- \
+            backend/src/main/resources/db/migration/postgresql \
+            backend/src/main/resources/db/migration/h2 \
+            > "${route_purge_changes}"
+          target_migrations="${RUNNER_TEMP}/target-migrations.txt"
+          git ls-tree -r --name-only "${DEPLOY_SHA}" -- \
+            backend/src/main/resources/db/migration/postgresql \
+            backend/src/main/resources/db/migration/h2 \
+            > "${target_migrations}"
+
+          required=false
+          if grep -Eq '^backend/src/main/resources/db/migration/(postgresql|h2)/V51__' "${route_purge_changes}" && \
+             grep -Eq '^backend/src/main/resources/db/migration/(postgresql|h2)/V51__' "${target_migrations}"; then
+            required=true
+          fi
+          echo "required=${required}" >> "${GITHUB_OUTPUT}"
+
+      - name: CD Deploy / Require route purge snapshot evidence
+        if: ${{ steps.route-purge.outputs.required == 'true' }}
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          snapshot_runs_file="${RUNNER_TEMP}/route-purge-snapshot-runs.json"
+          curl -fsS \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            --output "${snapshot_runs_file}" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/production-route-api-closure-evidence.yml/runs?head_sha=${DEPLOY_SHA}&branch=main&event=push&status=success&per_page=20"
+
+          node tools/ci/require-successful-workflow-run.mjs \
+            "${snapshot_runs_file}" \
+            "${DEPLOY_SHA}" \
+            "Production route API closure evidence" \
+            push \
+            main \
+            3600
+          echo "validated_route_purge_snapshot_sha=${DEPLOY_SHA}" >> "${GITHUB_STEP_SUMMARY}"
 
       - name: CD Deploy / Validate manual dispatch CI
         if: ${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -263,6 +263,12 @@ jobs:
             echo "DEPLOY_ROOT is invalid" >&2
             exit 1
           fi
+          if [[ ! -f "${DEPLOY_ROOT}/shared/current-sha" ]]; then
+            echo "required=false" >> "${GITHUB_OUTPUT}"
+            echo "current_sha=" >> "${GITHUB_OUTPUT}"
+            echo "route purge snapshot is not required without a managed deployment baseline" >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
           current_sha="$(<"${DEPLOY_ROOT}/shared/current-sha")"
           if [[ ! "${current_sha}" =~ ^[0-9a-f]{40}$ ]]; then
             echo "deployed SHA marker is invalid" >&2
@@ -313,20 +319,30 @@ jobs:
           fi
 
           snapshot_runs_file="${RUNNER_TEMP}/route-purge-snapshot-runs.json"
-          curl -fsS \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            --output "${snapshot_runs_file}" \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/production-route-api-closure-evidence.yml/runs?head_sha=${DEPLOY_SHA}&branch=main&status=success&per_page=20"
+          snapshot_wait_deadline="$((SECONDS + 3600))"
+          while true; do
+            curl -fsS \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              --output "${snapshot_runs_file}" \
+              "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/production-route-api-closure-evidence.yml/runs?head_sha=${DEPLOY_SHA}&branch=main&status=success&per_page=20"
 
-          node tools/ci/require-successful-workflow-run.mjs \
-            "${snapshot_runs_file}" \
-            "${DEPLOY_SHA}" \
-            "Production route API closure evidence" \
-            "push,workflow_dispatch" \
-            main \
-            3600
+            if node tools/ci/require-successful-workflow-run.mjs \
+              "${snapshot_runs_file}" \
+              "${DEPLOY_SHA}" \
+              "Production route API closure evidence" \
+              "push,workflow_dispatch" \
+              main \
+              3600; then
+              break
+            fi
+            if (( SECONDS >= snapshot_wait_deadline )); then
+              echo "timed out waiting for route purge snapshot evidence" >&2
+              exit 1
+            fi
+            sleep 15
+          done
 
           marker_file="${DEPLOY_ROOT}/shared/1913-route-purge-snapshot/snapshot-${DEPLOY_SHA}.env"
           if [[ ! -f "${marker_file}" ]]; then

--- a/.github/workflows/production-route-api-closure-evidence.yml
+++ b/.github/workflows/production-route-api-closure-evidence.yml
@@ -193,6 +193,7 @@ jobs:
       DEPLOY_ROOT: ${{ vars.DEPLOY_ROOT }}
       DEPLOY_COMPOSE_PROJECT: ${{ vars.DEPLOY_COMPOSE_PROJECT }}
       EXPECTED_DEPLOYED_SHA: ${{ needs.verify.outputs.deployed_sha }}
+      SNAPSHOT_REQUEST_SHA: ${{ github.sha }}
 
     steps:
       - name: Snapshot gate / Checkout reviewed main

--- a/.github/workflows/production-route-api-closure-evidence.yml
+++ b/.github/workflows/production-route-api-closure-evidence.yml
@@ -8,6 +8,7 @@ on:
       - ".github/workflows/production-route-api-closure-evidence.yml"
       - "tools/ci/production-route-api-closure-evidence-workflow.test.mjs"
       - "tools/ops/route-search-purge-snapshot-gate.sh"
+      - "tools/ops/postgres-backup.sh"
       - "backend/src/main/resources/db/migration/postgresql/V51__*"
       - "backend/src/main/resources/db/migration/h2/V51__*"
 

--- a/.github/workflows/production-route-api-closure-evidence.yml
+++ b/.github/workflows/production-route-api-closure-evidence.yml
@@ -25,12 +25,15 @@ jobs:
     concurrency:
       group: cd-production-deploy
       cancel-in-progress: false
+    outputs:
+      deployed_sha: ${{ steps.closure.outputs.deployed_sha }}
     env:
       CLOSURE_BASE_SHA: cba25764de4ed646e398b2141b64fa41767ed3cc
       DEPLOY_ROOT: ${{ vars.DEPLOY_ROOT }}
 
     steps:
       - name: Verify deployed revision, origin denial, and row invariance
+        id: closure
         shell: bash
         run: |
           set -euo pipefail
@@ -172,6 +175,7 @@ jobs:
             echo "route_search_results changed during the closure probe" >&2
             exit 1
           fi
+          printf 'deployed_sha=%s\n' "${current_sha}" >> "${GITHUB_OUTPUT}"
 
   snapshot-gate:
     name: Verify route purge snapshot gate
@@ -187,6 +191,7 @@ jobs:
     env:
       DEPLOY_ROOT: ${{ vars.DEPLOY_ROOT }}
       DEPLOY_COMPOSE_PROJECT: ${{ vars.DEPLOY_COMPOSE_PROJECT }}
+      EXPECTED_DEPLOYED_SHA: ${{ needs.verify.outputs.deployed_sha }}
 
     steps:
       - name: Snapshot gate / Checkout reviewed main

--- a/.github/workflows/production-route-api-closure-evidence.yml
+++ b/.github/workflows/production-route-api-closure-evidence.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - ".github/workflows/production-route-api-closure-evidence.yml"
       - "tools/ci/production-route-api-closure-evidence-workflow.test.mjs"
+      - "tools/ops/route-search-purge-snapshot-gate.sh"
+      - "backend/src/main/resources/db/migration/postgresql/V51__*"
+      - "backend/src/main/resources/db/migration/h2/V51__*"
 
 permissions:
   contents: read
@@ -168,3 +171,27 @@ jobs:
             echo "route_search_results changed during the closure probe" >&2
             exit 1
           fi
+
+  snapshot-gate:
+    name: Verify route purge snapshot gate
+    needs: verify
+    runs-on:
+      - self-hosted
+      - easysubway-production
+    timeout-minutes: 15
+    concurrency:
+      group: cd-production-deploy
+      cancel-in-progress: false
+    env:
+      DEPLOY_ROOT: ${{ vars.DEPLOY_ROOT }}
+      DEPLOY_COMPOSE_PROJECT: ${{ vars.DEPLOY_COMPOSE_PROJECT }}
+
+    steps:
+      - name: Snapshot gate / Checkout reviewed main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Snapshot gate / Backup, restore, and analyze purge
+        shell: bash
+        run: bash tools/ops/route-search-purge-snapshot-gate.sh

--- a/.github/workflows/production-route-api-closure-evidence.yml
+++ b/.github/workflows/production-route-api-closure-evidence.yml
@@ -179,6 +179,7 @@ jobs:
       - self-hosted
       - easysubway-production
     timeout-minutes: 15
+    environment: production
     concurrency:
       group: cd-production-deploy
       cancel-in-progress: false

--- a/.github/workflows/production-route-api-closure-evidence.yml
+++ b/.github/workflows/production-route-api-closure-evidence.yml
@@ -23,7 +23,7 @@ jobs:
       - easysubway-production
     timeout-minutes: 5
     concurrency:
-      group: cd-production-deploy
+      group: production-route-api-closure-evidence
       cancel-in-progress: false
     outputs:
       deployed_sha: ${{ steps.closure.outputs.deployed_sha }}
@@ -193,7 +193,7 @@ jobs:
     timeout-minutes: 15
     environment: production
     concurrency:
-      group: cd-production-deploy
+      group: production-route-api-closure-evidence
       cancel-in-progress: false
     env:
       DEPLOY_ROOT: ${{ vars.DEPLOY_ROOT }}

--- a/.github/workflows/production-route-api-closure-evidence.yml
+++ b/.github/workflows/production-route-api-closure-evidence.yml
@@ -12,12 +12,11 @@ on:
       - "backend/src/main/resources/db/migration/postgresql/V51__*"
       - "backend/src/main/resources/db/migration/h2/V51__*"
 
-permissions:
-  contents: read
-
 jobs:
   verify:
     name: Verify production route API closure
+    permissions:
+      contents: read
     runs-on:
       - self-hosted
       - easysubway-production
@@ -180,6 +179,8 @@ jobs:
   snapshot-gate:
     name: Verify route purge snapshot gate
     needs: verify
+    permissions:
+      contents: read
     runs-on:
       - self-hosted
       - easysubway-production

--- a/.github/workflows/production-route-api-closure-evidence.yml
+++ b/.github/workflows/production-route-api-closure-evidence.yml
@@ -11,6 +11,7 @@ on:
       - "tools/ops/postgres-backup.sh"
       - "backend/src/main/resources/db/migration/postgresql/V51__*"
       - "backend/src/main/resources/db/migration/h2/V51__*"
+  workflow_dispatch:
 
 jobs:
   verify:
@@ -36,6 +37,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" && "${GITHUB_REF}" != "refs/heads/main" ]]; then
+            echo "manual snapshot revalidation must run from main" >&2
+            exit 1
+          fi
 
           if [[ ! "${CLOSURE_BASE_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
             echo "closure base must be a 40-character lowercase commit SHA" >&2

--- a/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
+++ b/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
@@ -50,6 +50,7 @@ test("production snapshot gate는 main-only runner에서 backup·격리 restore�
   assert.match(workflow, /snapshot-gate:[\s\S]*runs-on:\n\s+- self-hosted\n\s+- easysubway-production/);
   assert.match(workflow, /snapshot-gate:[\s\S]*environment: production/);
   assert.match(workflow, /snapshot-gate:[\s\S]*group: cd-production-deploy/);
+  assert.match(workflow, /snapshot-gate:[\s\S]*Checkout reviewed main[\s\S]*persist-credentials: false/);
   assert.doesNotMatch(workflow, /upload-artifact|workflow_dispatch/);
 
   assert.match(snapshotGate, /^set -euo pipefail$/m);
@@ -61,6 +62,11 @@ test("production snapshot gate는 main-only runner에서 backup·격리 restore�
   assert.match(snapshotGate, /tools\/ops\/postgres-backup\.sh/);
   assert.match(snapshotGate, /pg_restore/);
   assert.match(snapshotGate, /--pull never/);
+  assert.match(snapshotGate, /--cpus "\$\{RESTORE_CPU_LIMIT\}"/);
+  assert.match(snapshotGate, /--memory "\$\{RESTORE_MEMORY_LIMIT\}"/);
+  assert.match(snapshotGate, /--memory-swap "\$\{RESTORE_MEMORY_LIMIT\}"/);
+  assert.match(snapshotGate, /--pids-limit "\$\{RESTORE_PIDS_LIMIT\}"/);
+  assert.match(snapshotGate, /restore resource limits/);
   assert.match(snapshotGate, /EXPLAIN \(ANALYZE, BUFFERS, WAL/);
   assert.match(snapshotGate, /ROLLBACK/);
   assert.match(snapshotGate, /favorite_routes/);

--- a/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
+++ b/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
@@ -10,7 +10,7 @@ test("production route API closure evidence는 현재 배포와 origin 403·row 
   const workflow = await readFile(workflowPath, "utf8");
 
   assert.match(workflow, /^on:\n  push:\n    branches:\n      - main\n    paths:/m);
-  assert.doesNotMatch(workflow, /workflow_dispatch/);
+  assert.match(workflow, /workflow_dispatch:/);
   assert.match(workflow, /CLOSURE_BASE_SHA: cba25764de4ed646e398b2141b64fa41767ed3cc/);
   assert.doesNotMatch(workflow, /EXPECTED_IMAGE_DIGEST/);
   assert.match(workflow, /runs-on:\n\s+- self-hosted\n\s+- easysubway-production/);
@@ -58,10 +58,11 @@ test("production snapshot gate는 main-only runner에서 backup·격리 restore�
   assert.match(workflow, /snapshot-gate:[\s\S]*environment: production/);
   assert.match(workflow, /snapshot-gate:[\s\S]*?permissions:\n\s+contents: read[\s\S]*?steps:/);
   assert.match(workflow, /snapshot-gate:[\s\S]*group: cd-production-deploy/);
+  assert.match(workflow, /manual snapshot revalidation must run from main/);
   assert.match(workflow, /EXPECTED_DEPLOYED_SHA: \$\{\{ needs\.verify\.outputs\.deployed_sha \}\}/);
   assert.match(workflow, /SNAPSHOT_REQUEST_SHA: \$\{\{ github\.sha \}\}/);
   assert.match(workflow, /snapshot-gate:[\s\S]*Checkout reviewed main[\s\S]*persist-credentials: false/);
-  assert.doesNotMatch(workflow, /upload-artifact|workflow_dispatch/);
+  assert.doesNotMatch(workflow, /upload-artifact/);
 
   assert.match(snapshotGate, /^set -euo pipefail$/m);
   assert.match(snapshotGate, /^umask 077$/m);
@@ -138,12 +139,17 @@ test("V51 CD는 exact SHA의 성공한 snapshot gate 없이는 mutation 전에 �
   );
   assert.match(
     workflow,
-    /actions\/workflows\/production-route-api-closure-evidence\.yml\/runs\?head_sha=\$\{DEPLOY_SHA\}&branch=main&event=push&status=success&per_page=20/,
+    /actions\/workflows\/production-route-api-closure-evidence\.yml\/runs\?head_sha=\$\{DEPLOY_SHA\}&branch=main&status=success&per_page=20/,
   );
   assert.match(
     workflow,
-    /node tools\/ci\/require-successful-workflow-run\.mjs[\s\S]*?"\$\{snapshot_runs_file\}"[\s\S]*?"\$\{DEPLOY_SHA\}"[\s\S]*?"Production route API closure evidence"[\s\S]*?push[\s\S]*?main[\s\S]*?3600/,
+    /node tools\/ci\/require-successful-workflow-run\.mjs[\s\S]*?"\$\{snapshot_runs_file\}"[\s\S]*?"\$\{DEPLOY_SHA\}"[\s\S]*?"Production route API closure evidence"[\s\S]*?"push,workflow_dispatch"[\s\S]*?main[\s\S]*?3600/,
   );
+  assert.match(workflow, /echo "current_sha=\$\{current_sha\}" >> "\$\{GITHUB_OUTPUT\}"/);
+  assert.match(workflow, /snapshot-\$\{DEPLOY_SHA\}\.env/);
+  assert.match(workflow, /marker_request_sha[^\n]+!=[^\n]+DEPLOY_SHA/);
+  assert.match(workflow, /marker_current_sha[^\n]+!=[^\n]+CURRENT_DEPLOYED_SHA/);
+  assert.match(workflow, /snapshot marker backup checksum mismatch/);
 
   const rangeDetectionIndex = workflow.indexOf('git diff --name-only "${current_sha}" "${DEPLOY_SHA}"');
   const latchIndex = workflow.indexOf("CD Deploy / Require route purge snapshot evidence");

--- a/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
+++ b/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
@@ -14,7 +14,8 @@ test("production route API closure evidence는 현재 배포와 origin 403·row 
   assert.doesNotMatch(workflow, /EXPECTED_IMAGE_DIGEST/);
   assert.match(workflow, /runs-on:\n\s+- self-hosted\n\s+- easysubway-production/);
   assert.doesNotMatch(workflow, /environment:\n\s+name: production/);
-  assert.match(workflow, /permissions:\n\s+contents: read/);
+  assert.doesNotMatch(workflow, /^permissions:/m);
+  assert.match(workflow, /verify:[\s\S]*?permissions:\n\s+contents: read[\s\S]*?steps:/);
   assert.match(workflow, /group: cd-production-deploy/);
 
   assert.match(workflow, /shared\/current-sha/);
@@ -54,6 +55,7 @@ test("production snapshot gate는 main-only runner에서 backup·격리 restore�
   assert.match(workflow, /snapshot-gate:[\s\S]*needs: verify/);
   assert.match(workflow, /snapshot-gate:[\s\S]*runs-on:\n\s+- self-hosted\n\s+- easysubway-production/);
   assert.match(workflow, /snapshot-gate:[\s\S]*environment: production/);
+  assert.match(workflow, /snapshot-gate:[\s\S]*?permissions:\n\s+contents: read[\s\S]*?steps:/);
   assert.match(workflow, /snapshot-gate:[\s\S]*group: cd-production-deploy/);
   assert.match(workflow, /EXPECTED_DEPLOYED_SHA: \$\{\{ needs\.verify\.outputs\.deployed_sha \}\}/);
   assert.match(workflow, /snapshot-gate:[\s\S]*Checkout reviewed main[\s\S]*persist-credentials: false/);
@@ -78,6 +80,8 @@ test("production snapshot gate는 main-only runner에서 backup·격리 restore�
   assert.match(snapshotGate, /--pids-limit "\$\{RESTORE_PIDS_LIMIT\}"/);
   assert.match(snapshotGate, /restore resource limits/);
   assert.match(snapshotGate, /source_database_bytes/);
+  assert.match(snapshotGate, /SPACE_CLASS='\[:space:\]'/);
+  assert.doesNotMatch(snapshotGate, /tr -d '\[:space:\]'/);
   assert.match(snapshotGate, /storage_probe/);
   assert.match(snapshotGate, /--mount type=volume,target=\/probe\/docker/);
   assert.doesNotMatch(snapshotGate, /df -PB1 "\$\{docker_root_dir\}"/);

--- a/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
+++ b/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 const workflowPath = ".github/workflows/production-route-api-closure-evidence.yml";
+const cdWorkflowPath = ".github/workflows/cd.yml";
 const snapshotGatePath = "tools/ops/route-search-purge-snapshot-gate.sh";
 
 test("production route API closure evidence는 현재 배포와 origin 403·row 불변을 검증한다", async () => {
@@ -116,4 +117,45 @@ test("production snapshot gate는 main-only runner에서 backup·격리 restore�
   assert.notEqual(reportAppend, -1);
   assert.notEqual(markerPublish, -1);
   assert.ok(reportAppend < markerPublish, "success marker must be published after required evidence");
+});
+
+test("V51 CD는 exact SHA의 성공한 snapshot gate 없이는 mutation 전에 중단한다", async () => {
+  const workflow = await readFile(cdWorkflowPath, "utf8");
+
+  assert.match(
+    workflow,
+    /echo "route_purge_snapshot_required=\$\{route_purge_snapshot_required\}" >> "\$\{GITHUB_OUTPUT\}"/,
+  );
+  assert.match(
+    workflow,
+    /backend\/src\/main\/resources\/db\/migration\/\(postgresql\|h2\)\/V51__/,
+  );
+  assert.match(workflow, /CD Plan \/ Require route purge snapshot evidence/);
+  assert.match(
+    workflow,
+    /if: \$\{\{ steps\.changes\.outputs\.route_purge_snapshot_required == 'true' \}\}/,
+  );
+  assert.match(
+    workflow,
+    /actions\/workflows\/production-route-api-closure-evidence\.yml\/runs\?head_sha=\$\{DEPLOY_SHA\}&branch=main&event=push&status=success&per_page=20/,
+  );
+  assert.match(
+    workflow,
+    /node tools\/ci\/require-successful-workflow-run\.mjs[\s\S]*?"\$\{snapshot_runs_file\}"[\s\S]*?"\$\{DEPLOY_SHA\}"[\s\S]*?"Production route API closure evidence"[\s\S]*?push[\s\S]*?main/,
+  );
+
+  const changedFilesIndex = workflow.indexOf('git diff --name-only "${DEPLOY_SHA}^"');
+  const manualDispatchIndex = workflow.indexOf('if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]');
+  const latchIndex = workflow.indexOf("CD Plan / Require route purge snapshot evidence");
+  const buildIndex = workflow.indexOf("CD Build image / Checkout target SHA");
+  const mutationPreparationIndex = workflow.indexOf("CD Deploy / Restore GitHub Actions dotenv secret");
+
+  assert.notEqual(changedFilesIndex, -1);
+  assert.notEqual(manualDispatchIndex, -1);
+  assert.ok(changedFilesIndex < manualDispatchIndex, "manual dispatch must inspect the target commit");
+  assert.notEqual(latchIndex, -1);
+  assert.notEqual(buildIndex, -1);
+  assert.notEqual(mutationPreparationIndex, -1);
+  assert.ok(latchIndex < buildIndex, "snapshot evidence must gate image build");
+  assert.ok(latchIndex < mutationPreparationIndex, "snapshot evidence must gate production mutation");
 });

--- a/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
+++ b/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
@@ -17,7 +17,7 @@ test("production route API closure evidence는 현재 배포와 origin 403·row 
   assert.doesNotMatch(workflow, /environment:\n\s+name: production/);
   assert.doesNotMatch(workflow, /^permissions:/m);
   assert.match(workflow, /verify:[\s\S]*?permissions:\n\s+contents: read[\s\S]*?steps:/);
-  assert.match(workflow, /group: cd-production-deploy/);
+  assert.match(workflow, /group: production-route-api-closure-evidence/);
 
   assert.match(workflow, /shared\/current-sha/);
   assert.match(workflow, /shared\/current-image-digest/);
@@ -57,7 +57,9 @@ test("production snapshot gate는 main-only runner에서 backup·격리 restore�
   assert.match(workflow, /snapshot-gate:[\s\S]*runs-on:\n\s+- self-hosted\n\s+- easysubway-production/);
   assert.match(workflow, /snapshot-gate:[\s\S]*environment: production/);
   assert.match(workflow, /snapshot-gate:[\s\S]*?permissions:\n\s+contents: read[\s\S]*?steps:/);
-  assert.match(workflow, /snapshot-gate:[\s\S]*group: cd-production-deploy/);
+  assert.match(workflow, /verify:[\s\S]*group: production-route-api-closure-evidence/);
+  assert.match(workflow, /snapshot-gate:[\s\S]*group: production-route-api-closure-evidence/);
+  assert.doesNotMatch(workflow, /group: cd-production-deploy/);
   assert.match(workflow, /manual snapshot revalidation must run from main/);
   assert.match(workflow, /EXPECTED_DEPLOYED_SHA: \$\{\{ needs\.verify\.outputs\.deployed_sha \}\}/);
   assert.match(workflow, /SNAPSHOT_REQUEST_SHA: \$\{\{ github\.sha \}\}/);
@@ -126,6 +128,10 @@ test("V51 CD는 exact SHA의 성공한 snapshot gate 없이는 mutation 전에 �
   const workflow = await readFile(cdWorkflowPath, "utf8");
 
   assert.match(workflow, /CD Deploy \/ Detect route purge migration/);
+  assert.match(
+    workflow,
+    /if \[\[ ! -f "\$\{DEPLOY_ROOT\}\/shared\/current-sha" \]\]; then[\s\S]*?echo "required=false"[\s\S]*?exit 0/,
+  );
   assert.match(workflow, /current_sha="\$\(<"\$\{DEPLOY_ROOT\}\/shared\/current-sha"\)"/);
   assert.match(workflow, /git diff --name-only "\$\{current_sha\}" "\$\{DEPLOY_SHA\}"/);
   assert.match(
@@ -150,6 +156,8 @@ test("V51 CD는 exact SHA의 성공한 snapshot gate 없이는 mutation 전에 �
   assert.match(workflow, /marker_request_sha[^\n]+!=[^\n]+DEPLOY_SHA/);
   assert.match(workflow, /marker_current_sha[^\n]+!=[^\n]+CURRENT_DEPLOYED_SHA/);
   assert.match(workflow, /snapshot marker backup checksum mismatch/);
+  assert.match(workflow, /snapshot_wait_deadline="\$\(\(SECONDS \+ 3600\)\)"/);
+  assert.match(workflow, /while true; do[\s\S]*?require-successful-workflow-run\.mjs[\s\S]*?break[\s\S]*?sleep 15[\s\S]*?done/);
 
   const rangeDetectionIndex = workflow.indexOf('git diff --name-only "${current_sha}" "${DEPLOY_SHA}"');
   const latchIndex = workflow.indexOf("CD Deploy / Require route purge snapshot evidence");

--- a/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
+++ b/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
@@ -38,6 +38,9 @@ test("production route API closure evidence는 현재 배포와 origin 403·row 
   assert.match(workflow, /row_count_before/);
   assert.match(workflow, /row_count_after/);
   assert.match(workflow, /row_count_before[^\n]+!=[^\n]+row_count_after/);
+  assert.match(workflow, /outputs:\n\s+deployed_sha: \$\{\{ steps\.closure\.outputs\.deployed_sha \}\}/);
+  assert.match(workflow, /id: closure/);
+  assert.match(workflow, /deployed_sha=%s\\n[^\n]+GITHUB_OUTPUT/);
 });
 
 test("production snapshot gate는 main-only runner에서 backup·격리 restore·purge plan만 수집한다", async () => {
@@ -46,11 +49,13 @@ test("production snapshot gate는 main-only runner에서 backup·격리 restore�
 
   assert.match(workflow, /tools\/ops\/route-search-purge-snapshot-gate\.sh/);
   assert.match(workflow, /tools\/ops\/postgres-backup\.sh/);
-  assert.match(workflow, /backend\/src\/main\/resources\/db\/migration\/(postgresql|h2)\/V51__/);
+  assert.match(workflow, /backend\/src\/main\/resources\/db\/migration\/postgresql\/V51__/);
+  assert.match(workflow, /backend\/src\/main\/resources\/db\/migration\/h2\/V51__/);
   assert.match(workflow, /snapshot-gate:[\s\S]*needs: verify/);
   assert.match(workflow, /snapshot-gate:[\s\S]*runs-on:\n\s+- self-hosted\n\s+- easysubway-production/);
   assert.match(workflow, /snapshot-gate:[\s\S]*environment: production/);
   assert.match(workflow, /snapshot-gate:[\s\S]*group: cd-production-deploy/);
+  assert.match(workflow, /EXPECTED_DEPLOYED_SHA: \$\{\{ needs\.verify\.outputs\.deployed_sha \}\}/);
   assert.match(workflow, /snapshot-gate:[\s\S]*Checkout reviewed main[\s\S]*persist-credentials: false/);
   assert.doesNotMatch(workflow, /upload-artifact|workflow_dispatch/);
 
@@ -60,6 +65,10 @@ test("production snapshot gate는 main-only runner에서 backup·격리 restore�
   assert.match(snapshotGate, /could not acquire deploy lock within timeout/);
   assert.match(snapshotGate, /existing snapshot backup or checksum file is missing/);
   assert.match(snapshotGate, /existing snapshot backup checksum mismatch/);
+  assert.match(snapshotGate, /EXPECTED_DEPLOYED_SHA/);
+  assert.match(snapshotGate, /marker_sha/);
+  assert.match(snapshotGate, /current_sha[^\n]+!=[^\n]+EXPECTED_DEPLOYED_SHA/);
+  assert.match(snapshotGate, /marker_sha[^\n]+!=[^\n]+EXPECTED_DEPLOYED_SHA/);
   assert.match(snapshotGate, /tools\/ops\/postgres-backup\.sh/);
   assert.match(snapshotGate, /pg_restore/);
   assert.match(snapshotGate, /--pull never/);

--- a/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
+++ b/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
@@ -68,6 +68,9 @@ test("production snapshot gate는 main-only runner에서 backup·격리 restore�
   assert.match(snapshotGate, /--memory-swap "\$\{RESTORE_MEMORY_LIMIT\}"/);
   assert.match(snapshotGate, /--pids-limit "\$\{RESTORE_PIDS_LIMIT\}"/);
   assert.match(snapshotGate, /restore resource limits/);
+  assert.match(snapshotGate, /source_database_bytes/);
+  assert.match(snapshotGate, /docker_available_after_backup/);
+  assert.match(snapshotGate, /insufficient Docker filesystem headroom/);
   assert.match(snapshotGate, /EXPLAIN \(ANALYZE, BUFFERS, WAL/);
   assert.match(snapshotGate, /ROLLBACK/);
   assert.match(snapshotGate, /favorite_routes/);
@@ -82,4 +85,10 @@ test("production snapshot gate는 main-only runner에서 backup·격리 restore�
   assert.match(snapshotGate, /cat "\$\{report_file\}"/);
   assert.match(snapshotGate, /snapshot-complete/);
   assert.doesNotMatch(snapshotGate, /\b(curl|scp)\b|upload-artifact/);
+
+  const reportAppend = snapshotGate.indexOf('cat "${report_file}" >> "${SUMMARY_FILE}"');
+  const markerPublish = snapshotGate.lastIndexOf('mv "${marker_tmp}" "${MARKER_FILE}"');
+  assert.notEqual(reportAppend, -1);
+  assert.notEqual(markerPublish, -1);
+  assert.ok(reportAppend < markerPublish, "success marker must be published after required evidence");
 });

--- a/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
+++ b/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
@@ -45,6 +45,7 @@ test("production snapshot gate는 main-only runner에서 backup·격리 restore�
   const snapshotGate = await readFile(snapshotGatePath, "utf8").catch(() => "");
 
   assert.match(workflow, /tools\/ops\/route-search-purge-snapshot-gate\.sh/);
+  assert.match(workflow, /tools\/ops\/postgres-backup\.sh/);
   assert.match(workflow, /backend\/src\/main\/resources\/db\/migration\/(postgresql|h2)\/V51__/);
   assert.match(workflow, /snapshot-gate:[\s\S]*needs: verify/);
   assert.match(workflow, /snapshot-gate:[\s\S]*runs-on:\n\s+- self-hosted\n\s+- easysubway-production/);
@@ -75,6 +76,8 @@ test("production snapshot gate는 main-only runner에서 backup·격리 restore�
   assert.match(snapshotGate, /org\.opencontainers\.image\.revision/);
   assert.match(snapshotGate, /production_image=.*\{\{\.Image\}\}/);
   assert.doesNotMatch(snapshotGate, /production_image=.*\{\{\.Config\.Image\}\}/);
+  assert.match(snapshotGate, /production_settings_sql=/);
+  assert.match(snapshotGate, /-c "\$1"' sh/);
   assert.match(snapshotGate, /report_file/);
   assert.match(snapshotGate, /cat "\$\{report_file\}"/);
   assert.match(snapshotGate, /snapshot-complete/);

--- a/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
+++ b/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 const workflowPath = ".github/workflows/production-route-api-closure-evidence.yml";
+const snapshotGatePath = "tools/ops/route-search-purge-snapshot-gate.sh";
 
 test("production route API closure evidence는 현재 배포와 origin 403·row 불변을 검증한다", async () => {
   const workflow = await readFile(workflowPath, "utf8");
@@ -37,4 +38,33 @@ test("production route API closure evidence는 현재 배포와 origin 403·row 
   assert.match(workflow, /row_count_before/);
   assert.match(workflow, /row_count_after/);
   assert.match(workflow, /row_count_before[^\n]+!=[^\n]+row_count_after/);
+});
+
+test("production snapshot gate는 main-only runner에서 backup·격리 restore·purge plan만 수집한다", async () => {
+  const workflow = await readFile(workflowPath, "utf8");
+  const snapshotGate = await readFile(snapshotGatePath, "utf8").catch(() => "");
+
+  assert.match(workflow, /tools\/ops\/route-search-purge-snapshot-gate\.sh/);
+  assert.match(workflow, /backend\/src\/main\/resources\/db\/migration\/(postgresql|h2)\/V51__/);
+  assert.match(workflow, /snapshot-gate:[\s\S]*needs: verify/);
+  assert.match(workflow, /snapshot-gate:[\s\S]*runs-on:\n\s+- self-hosted\n\s+- easysubway-production/);
+  assert.match(workflow, /snapshot-gate:[\s\S]*group: cd-production-deploy/);
+  assert.doesNotMatch(workflow, /upload-artifact|workflow_dispatch/);
+
+  assert.match(snapshotGate, /^set -euo pipefail$/m);
+  assert.match(snapshotGate, /^umask 077$/m);
+  assert.match(snapshotGate, /flock 9/);
+  assert.match(snapshotGate, /tools\/ops\/postgres-backup\.sh/);
+  assert.match(snapshotGate, /pg_restore/);
+  assert.match(snapshotGate, /--pull never/);
+  assert.match(snapshotGate, /EXPLAIN \(ANALYZE, BUFFERS, WAL/);
+  assert.match(snapshotGate, /ROLLBACK/);
+  assert.match(snapshotGate, /favorite_routes/);
+  assert.match(snapshotGate, /favorite_route_stations/);
+  assert.match(snapshotGate, /route_feedbacks/);
+  assert.match(snapshotGate, /org\.opencontainers\.image\.revision/);
+  assert.match(snapshotGate, /report_file/);
+  assert.match(snapshotGate, /cat "\$\{report_file\}"/);
+  assert.match(snapshotGate, /snapshot-complete/);
+  assert.doesNotMatch(snapshotGate, /\b(curl|scp)\b|upload-artifact/);
 });

--- a/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
+++ b/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
@@ -59,6 +59,7 @@ test("production snapshot gate는 main-only runner에서 backup·격리 restore�
   assert.match(workflow, /snapshot-gate:[\s\S]*?permissions:\n\s+contents: read[\s\S]*?steps:/);
   assert.match(workflow, /snapshot-gate:[\s\S]*group: cd-production-deploy/);
   assert.match(workflow, /EXPECTED_DEPLOYED_SHA: \$\{\{ needs\.verify\.outputs\.deployed_sha \}\}/);
+  assert.match(workflow, /SNAPSHOT_REQUEST_SHA: \$\{\{ github\.sha \}\}/);
   assert.match(workflow, /snapshot-gate:[\s\S]*Checkout reviewed main[\s\S]*persist-credentials: false/);
   assert.doesNotMatch(workflow, /upload-artifact|workflow_dispatch/);
 
@@ -66,12 +67,11 @@ test("production snapshot gate는 main-only runner에서 backup·격리 restore�
   assert.match(snapshotGate, /^umask 077$/m);
   assert.match(snapshotGate, /if ! flock -w 300 9/);
   assert.match(snapshotGate, /could not acquire deploy lock within timeout/);
-  assert.match(snapshotGate, /existing snapshot backup or checksum file is missing/);
-  assert.match(snapshotGate, /existing snapshot backup checksum mismatch/);
   assert.match(snapshotGate, /EXPECTED_DEPLOYED_SHA/);
-  assert.match(snapshotGate, /marker_sha/);
+  assert.match(snapshotGate, /SNAPSHOT_REQUEST_SHA/);
+  assert.match(snapshotGate, /snapshot-\$\{SNAPSHOT_REQUEST_SHA\}\.env/);
+  assert.match(snapshotGate, /rm -f "\$\{MARKER_FILE\}"/);
   assert.match(snapshotGate, /current_sha[^\n]+!=[^\n]+EXPECTED_DEPLOYED_SHA/);
-  assert.match(snapshotGate, /marker_sha[^\n]+!=[^\n]+EXPECTED_DEPLOYED_SHA/);
   assert.match(snapshotGate, /tools\/ops\/postgres-backup\.sh/);
   assert.match(snapshotGate, /pg_restore/);
   assert.match(snapshotGate, /--pull never/);
@@ -110,6 +110,8 @@ test("production snapshot gate는 main-only runner에서 backup·격리 restore�
   assert.match(snapshotGate, /report_file/);
   assert.match(snapshotGate, /cat "\$\{report_file\}"/);
   assert.match(snapshotGate, /snapshot-complete/);
+  assert.match(snapshotGate, /snapshot_request_sha/);
+  assert.doesNotMatch(snapshotGate, /existing verified backup/);
   assert.doesNotMatch(snapshotGate, /\b(curl|scp)\b|upload-artifact/);
 
   const reportAppend = snapshotGate.indexOf('cat "${report_file}" >> "${SUMMARY_FILE}"');
@@ -122,18 +124,17 @@ test("production snapshot gate는 main-only runner에서 backup·격리 restore�
 test("V51 CD는 exact SHA의 성공한 snapshot gate 없이는 mutation 전에 중단한다", async () => {
   const workflow = await readFile(cdWorkflowPath, "utf8");
 
-  assert.match(
-    workflow,
-    /echo "route_purge_snapshot_required=\$\{route_purge_snapshot_required\}" >> "\$\{GITHUB_OUTPUT\}"/,
-  );
+  assert.match(workflow, /CD Deploy \/ Detect route purge migration/);
+  assert.match(workflow, /current_sha="\$\(<"\$\{DEPLOY_ROOT\}\/shared\/current-sha"\)"/);
+  assert.match(workflow, /git diff --name-only "\$\{current_sha\}" "\$\{DEPLOY_SHA\}"/);
   assert.match(
     workflow,
     /backend\/src\/main\/resources\/db\/migration\/\(postgresql\|h2\)\/V51__/,
   );
-  assert.match(workflow, /CD Plan \/ Require route purge snapshot evidence/);
+  assert.match(workflow, /CD Deploy \/ Require route purge snapshot evidence/);
   assert.match(
     workflow,
-    /if: \$\{\{ steps\.changes\.outputs\.route_purge_snapshot_required == 'true' \}\}/,
+    /if: \$\{\{ steps\.route-purge\.outputs\.required == 'true' \}\}/,
   );
   assert.match(
     workflow,
@@ -141,21 +142,15 @@ test("V51 CD는 exact SHA의 성공한 snapshot gate 없이는 mutation 전에 �
   );
   assert.match(
     workflow,
-    /node tools\/ci\/require-successful-workflow-run\.mjs[\s\S]*?"\$\{snapshot_runs_file\}"[\s\S]*?"\$\{DEPLOY_SHA\}"[\s\S]*?"Production route API closure evidence"[\s\S]*?push[\s\S]*?main/,
+    /node tools\/ci\/require-successful-workflow-run\.mjs[\s\S]*?"\$\{snapshot_runs_file\}"[\s\S]*?"\$\{DEPLOY_SHA\}"[\s\S]*?"Production route API closure evidence"[\s\S]*?push[\s\S]*?main[\s\S]*?3600/,
   );
 
-  const changedFilesIndex = workflow.indexOf('git diff --name-only "${DEPLOY_SHA}^"');
-  const manualDispatchIndex = workflow.indexOf('if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]');
-  const latchIndex = workflow.indexOf("CD Plan / Require route purge snapshot evidence");
-  const buildIndex = workflow.indexOf("CD Build image / Checkout target SHA");
+  const rangeDetectionIndex = workflow.indexOf('git diff --name-only "${current_sha}" "${DEPLOY_SHA}"');
+  const latchIndex = workflow.indexOf("CD Deploy / Require route purge snapshot evidence");
   const mutationPreparationIndex = workflow.indexOf("CD Deploy / Restore GitHub Actions dotenv secret");
 
-  assert.notEqual(changedFilesIndex, -1);
-  assert.notEqual(manualDispatchIndex, -1);
-  assert.ok(changedFilesIndex < manualDispatchIndex, "manual dispatch must inspect the target commit");
+  assert.notEqual(rangeDetectionIndex, -1);
   assert.notEqual(latchIndex, -1);
-  assert.notEqual(buildIndex, -1);
   assert.notEqual(mutationPreparationIndex, -1);
-  assert.ok(latchIndex < buildIndex, "snapshot evidence must gate image build");
   assert.ok(latchIndex < mutationPreparationIndex, "snapshot evidence must gate production mutation");
 });

--- a/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
+++ b/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
@@ -157,6 +157,11 @@ test("V51 CD는 exact SHA의 성공한 snapshot gate 없이는 mutation 전에 �
   assert.match(workflow, /marker_current_sha[^\n]+!=[^\n]+CURRENT_DEPLOYED_SHA/);
   assert.match(workflow, /snapshot marker backup checksum mismatch/);
   assert.match(workflow, /snapshot_wait_deadline="\$\(\(SECONDS \+ 3600\)\)"/);
+  assert.match(
+    workflow,
+    /if curl -fsS[\s\S]*?--connect-timeout 5[\s\S]*?--max-time 20[\s\S]*?then[\s\S]*?require-successful-workflow-run\.mjs/,
+  );
+  assert.match(workflow, /snapshot evidence query failed; retrying within bounded deadline/);
   assert.match(workflow, /while true; do[\s\S]*?require-successful-workflow-run\.mjs[\s\S]*?break[\s\S]*?sleep 15[\s\S]*?done/);
 
   const rangeDetectionIndex = workflow.indexOf('git diff --name-only "${current_sha}" "${DEPLOY_SHA}"');

--- a/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
+++ b/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
@@ -48,12 +48,16 @@ test("production snapshot gate는 main-only runner에서 backup·격리 restore�
   assert.match(workflow, /backend\/src\/main\/resources\/db\/migration\/(postgresql|h2)\/V51__/);
   assert.match(workflow, /snapshot-gate:[\s\S]*needs: verify/);
   assert.match(workflow, /snapshot-gate:[\s\S]*runs-on:\n\s+- self-hosted\n\s+- easysubway-production/);
+  assert.match(workflow, /snapshot-gate:[\s\S]*environment: production/);
   assert.match(workflow, /snapshot-gate:[\s\S]*group: cd-production-deploy/);
   assert.doesNotMatch(workflow, /upload-artifact|workflow_dispatch/);
 
   assert.match(snapshotGate, /^set -euo pipefail$/m);
   assert.match(snapshotGate, /^umask 077$/m);
-  assert.match(snapshotGate, /flock 9/);
+  assert.match(snapshotGate, /if ! flock -w 300 9/);
+  assert.match(snapshotGate, /could not acquire deploy lock within timeout/);
+  assert.match(snapshotGate, /existing snapshot backup or checksum file is missing/);
+  assert.match(snapshotGate, /existing snapshot backup checksum mismatch/);
   assert.match(snapshotGate, /tools\/ops\/postgres-backup\.sh/);
   assert.match(snapshotGate, /pg_restore/);
   assert.match(snapshotGate, /--pull never/);
@@ -63,6 +67,8 @@ test("production snapshot gate는 main-only runner에서 backup·격리 restore�
   assert.match(snapshotGate, /favorite_route_stations/);
   assert.match(snapshotGate, /route_feedbacks/);
   assert.match(snapshotGate, /org\.opencontainers\.image\.revision/);
+  assert.match(snapshotGate, /production_image=.*\{\{\.Image\}\}/);
+  assert.doesNotMatch(snapshotGate, /production_image=.*\{\{\.Config\.Image\}\}/);
   assert.match(snapshotGate, /report_file/);
   assert.match(snapshotGate, /cat "\$\{report_file\}"/);
   assert.match(snapshotGate, /snapshot-complete/);

--- a/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
+++ b/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
@@ -69,8 +69,20 @@ test("production snapshot gate는 main-only runner에서 backup·격리 restore�
   assert.match(snapshotGate, /--pids-limit "\$\{RESTORE_PIDS_LIMIT\}"/);
   assert.match(snapshotGate, /restore resource limits/);
   assert.match(snapshotGate, /source_database_bytes/);
+  assert.match(snapshotGate, /storage_probe/);
+  assert.match(snapshotGate, /--mount type=volume,target=\/probe\/docker/);
+  assert.doesNotMatch(snapshotGate, /df -PB1 "\$\{docker_root_dir\}"/);
+  assert.match(snapshotGate, /backup_required_before/);
+  assert.match(snapshotGate, /operational_reserve_bytes/);
+  assert.match(snapshotGate, /restore_cluster_reserve_bytes/);
+  assert.match(snapshotGate, /restore_wal_reserve_bytes/);
   assert.match(snapshotGate, /docker_available_after_backup/);
   assert.match(snapshotGate, /insufficient Docker filesystem headroom/);
+  assert.match(snapshotGate, /ANALYZE route_search_results, favorite_routes, favorite_route_stations, route_feedbacks/);
+  assert.ok(
+    snapshotGate.indexOf("ANALYZE route_search_results") < snapshotGate.indexOf("EXPLAIN (ANALYZE, BUFFERS, WAL)"),
+    "restored purge tables must be analyzed before the measured plan",
+  );
   assert.match(snapshotGate, /EXPLAIN \(ANALYZE, BUFFERS, WAL/);
   assert.match(snapshotGate, /ROLLBACK/);
   assert.match(snapshotGate, /favorite_routes/);

--- a/tools/ci/require-successful-workflow-run.mjs
+++ b/tools/ci/require-successful-workflow-run.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+
+const [responsePath, expectedSha, expectedName, expectedEvent, expectedBranch] =
+  process.argv.slice(2);
+
+if (
+  !responsePath ||
+  !/^[0-9a-f]{40}$/.test(expectedSha ?? "") ||
+  !expectedName ||
+  !expectedEvent ||
+  !expectedBranch
+) {
+  console.error(
+    "usage: require-successful-workflow-run.mjs <response.json> <sha> <name> <event> <branch>",
+  );
+  process.exit(2);
+}
+
+let payload;
+try {
+  payload = JSON.parse(await readFile(responsePath, "utf8"));
+} catch {
+  console.error("workflow runs response is not valid JSON");
+  process.exit(1);
+}
+
+if (!Array.isArray(payload?.workflow_runs)) {
+  console.error("workflow runs response is missing workflow_runs");
+  process.exit(1);
+}
+
+const matchingRun = payload.workflow_runs.find(
+  (run) =>
+    run?.name === expectedName &&
+    run?.head_sha === expectedSha &&
+    run?.head_branch === expectedBranch &&
+    run?.event === expectedEvent &&
+    run?.status === "completed" &&
+    run?.conclusion === "success" &&
+    Number.isSafeInteger(run?.id),
+);
+
+if (!matchingRun) {
+  console.error("required successful workflow run was not found");
+  process.exit(1);
+}
+
+console.log(`validated_workflow_run_id=${matchingRun.id}`);

--- a/tools/ci/require-successful-workflow-run.mjs
+++ b/tools/ci/require-successful-workflow-run.mjs
@@ -6,23 +6,25 @@ const [
   responsePath,
   expectedSha,
   expectedName,
-  expectedEvent,
+  expectedEventsInput,
   expectedBranch,
   maxAgeSecondsInput,
 ] = process.argv.slice(2);
 const maxAgeSeconds = Number(maxAgeSecondsInput);
+const expectedEvents = expectedEventsInput?.split(",") ?? [];
 
 if (
   !responsePath ||
   !/^[0-9a-f]{40}$/.test(expectedSha ?? "") ||
   !expectedName ||
-  !expectedEvent ||
+  expectedEvents.length === 0 ||
+  expectedEvents.some((event) => !/^[a-z_]+$/.test(event)) ||
   !expectedBranch ||
   !Number.isSafeInteger(maxAgeSeconds) ||
   maxAgeSeconds <= 0
 ) {
   console.error(
-    "usage: require-successful-workflow-run.mjs <response.json> <sha> <name> <event> <branch> <max-age-seconds>",
+    "usage: require-successful-workflow-run.mjs <response.json> <sha> <name> <events> <branch> <max-age-seconds>",
   );
   process.exit(2);
 }
@@ -49,7 +51,7 @@ const matchingRun = payload.workflow_runs.find((run) => {
     run?.name === expectedName &&
     run?.head_sha === expectedSha &&
     run?.head_branch === expectedBranch &&
-    run?.event === expectedEvent &&
+    expectedEvents.includes(run?.event) &&
     run?.status === "completed" &&
     run?.conclusion === "success" &&
     Number.isSafeInteger(run?.id) &&

--- a/tools/ci/require-successful-workflow-run.mjs
+++ b/tools/ci/require-successful-workflow-run.mjs
@@ -2,18 +2,27 @@
 
 import { readFile } from "node:fs/promises";
 
-const [responsePath, expectedSha, expectedName, expectedEvent, expectedBranch] =
-  process.argv.slice(2);
+const [
+  responsePath,
+  expectedSha,
+  expectedName,
+  expectedEvent,
+  expectedBranch,
+  maxAgeSecondsInput,
+] = process.argv.slice(2);
+const maxAgeSeconds = Number(maxAgeSecondsInput);
 
 if (
   !responsePath ||
   !/^[0-9a-f]{40}$/.test(expectedSha ?? "") ||
   !expectedName ||
   !expectedEvent ||
-  !expectedBranch
+  !expectedBranch ||
+  !Number.isSafeInteger(maxAgeSeconds) ||
+  maxAgeSeconds <= 0
 ) {
   console.error(
-    "usage: require-successful-workflow-run.mjs <response.json> <sha> <name> <event> <branch>",
+    "usage: require-successful-workflow-run.mjs <response.json> <sha> <name> <event> <branch> <max-age-seconds>",
   );
   process.exit(2);
 }
@@ -31,16 +40,24 @@ if (!Array.isArray(payload?.workflow_runs)) {
   process.exit(1);
 }
 
-const matchingRun = payload.workflow_runs.find(
-  (run) =>
+const now = Date.now();
+const maxFutureSkewMs = 5 * 60 * 1000;
+const matchingRun = payload.workflow_runs.find((run) => {
+  const updatedAt = Date.parse(run?.updated_at ?? "");
+  const ageMs = now - updatedAt;
+  return (
     run?.name === expectedName &&
     run?.head_sha === expectedSha &&
     run?.head_branch === expectedBranch &&
     run?.event === expectedEvent &&
     run?.status === "completed" &&
     run?.conclusion === "success" &&
-    Number.isSafeInteger(run?.id),
-);
+    Number.isSafeInteger(run?.id) &&
+    Number.isFinite(updatedAt) &&
+    ageMs >= -maxFutureSkewMs &&
+    ageMs <= maxAgeSeconds * 1000
+  );
+});
 
 if (!matchingRun) {
   console.error("required successful workflow run was not found");

--- a/tools/ci/require-successful-workflow-run.test.mjs
+++ b/tools/ci/require-successful-workflow-run.test.mjs
@@ -33,7 +33,15 @@ async function invoke(workflowRuns) {
   try {
     return await execFileAsync(
       "node",
-      [scriptPath, responsePath, expectedSha, expectedName, "push", "main", "3600"],
+      [
+        scriptPath,
+        responsePath,
+        expectedSha,
+        expectedName,
+        "push,workflow_dispatch",
+        "main",
+        "3600",
+      ],
       { cwd: root, encoding: "utf8" },
     );
   } finally {
@@ -42,10 +50,13 @@ async function invoke(workflowRuns) {
 }
 
 test("exact SHA의 completed/success workflow run만 승인한다", async () => {
-  const result = await invoke([successfulRun()]);
+  const pushResult = await invoke([successfulRun()]);
+  const dispatchResult = await invoke([successfulRun({ event: "workflow_dispatch" })]);
 
-  assert.equal(result.stdout, "validated_workflow_run_id=123456\n");
-  assert.equal(result.stderr, "");
+  assert.equal(pushResult.stdout, "validated_workflow_run_id=123456\n");
+  assert.equal(pushResult.stderr, "");
+  assert.equal(dispatchResult.stdout, "validated_workflow_run_id=123456\n");
+  assert.equal(dispatchResult.stderr, "");
 });
 
 test("workflow identity나 성공 상태가 다르면 fail closed한다", async () => {
@@ -53,7 +64,7 @@ test("workflow identity나 성공 상태가 다르면 fail closed한다", async 
     { head_sha: "b".repeat(40) },
     { name: "CI" },
     { head_branch: "release" },
-    { event: "workflow_dispatch" },
+    { event: "pull_request" },
     { status: "in_progress" },
     { conclusion: "failure" },
     { updated_at: new Date(Date.now() - 3_601_000).toISOString() },

--- a/tools/ci/require-successful-workflow-run.test.mjs
+++ b/tools/ci/require-successful-workflow-run.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const root = process.cwd();
+const scriptPath = "tools/ci/require-successful-workflow-run.mjs";
+const expectedSha = "a".repeat(40);
+const expectedName = "Production route API closure evidence";
+
+function successfulRun(overrides = {}) {
+  return {
+    id: 123456,
+    name: expectedName,
+    head_sha: expectedSha,
+    head_branch: "main",
+    event: "push",
+    status: "completed",
+    conclusion: "success",
+    ...overrides,
+  };
+}
+
+async function invoke(workflowRuns) {
+  const dir = await mkdtemp(path.join(tmpdir(), "easysubway-workflow-run-"));
+  const responsePath = path.join(dir, "response.json");
+  await writeFile(responsePath, JSON.stringify({ workflow_runs: workflowRuns }));
+  try {
+    return await execFileAsync(
+      "node",
+      [scriptPath, responsePath, expectedSha, expectedName, "push", "main"],
+      { cwd: root, encoding: "utf8" },
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test("exact SHA의 completed/success workflow run만 승인한다", async () => {
+  const result = await invoke([successfulRun()]);
+
+  assert.equal(result.stdout, "validated_workflow_run_id=123456\n");
+  assert.equal(result.stderr, "");
+});
+
+test("workflow identity나 성공 상태가 다르면 fail closed한다", async () => {
+  for (const mismatch of [
+    { head_sha: "b".repeat(40) },
+    { name: "CI" },
+    { head_branch: "release" },
+    { event: "workflow_dispatch" },
+    { status: "in_progress" },
+    { conclusion: "failure" },
+  ]) {
+    await assert.rejects(
+      invoke([successfulRun(mismatch)]),
+      /required successful workflow run was not found/,
+    );
+  }
+});

--- a/tools/ci/require-successful-workflow-run.test.mjs
+++ b/tools/ci/require-successful-workflow-run.test.mjs
@@ -21,6 +21,7 @@ function successfulRun(overrides = {}) {
     event: "push",
     status: "completed",
     conclusion: "success",
+    updated_at: new Date().toISOString(),
     ...overrides,
   };
 }
@@ -32,7 +33,7 @@ async function invoke(workflowRuns) {
   try {
     return await execFileAsync(
       "node",
-      [scriptPath, responsePath, expectedSha, expectedName, "push", "main"],
+      [scriptPath, responsePath, expectedSha, expectedName, "push", "main", "3600"],
       { cwd: root, encoding: "utf8" },
     );
   } finally {
@@ -55,6 +56,8 @@ test("workflow identity나 성공 상태가 다르면 fail closed한다", async 
     { event: "workflow_dispatch" },
     { status: "in_progress" },
     { conclusion: "failure" },
+    { updated_at: new Date(Date.now() - 3_601_000).toISOString() },
+    { updated_at: "not-a-timestamp" },
   ]) {
     await assert.rejects(
       invoke([successfulRun(mismatch)]),

--- a/tools/ops/route-search-purge-snapshot-gate.sh
+++ b/tools/ops/route-search-purge-snapshot-gate.sh
@@ -12,6 +12,7 @@ RESTORE_MEMORY_LIMIT="2g"
 RESTORE_PIDS_LIMIT="256"
 WAL_HEADROOM_BYTES="$((256 * 1024 * 1024))"
 MIN_OPERATIONAL_RESERVE_BYTES="$((1024 * 1024 * 1024))"
+SPACE_CLASS='[:space:]'
 
 if [[ ! "${DEPLOY_ROOT}" =~ ^/[A-Za-z0-9._/-]+$ || "${DEPLOY_ROOT}" == *..* ]]; then
 	printf 'DEPLOY_ROOT is invalid\n' >&2
@@ -87,7 +88,7 @@ fi
 production_image="$(docker inspect --format '{{.Image}}' easysubway-postgres)"
 production_version_num="$(docker exec easysubway-postgres sh -lc \
 	'psql -X -v ON_ERROR_STOP=1 -A -t -U "$POSTGRES_USER" "$POSTGRES_DB" -c "SHOW server_version_num;"' \
-	| tr -d '[:space:]')"
+	| tr -d "${SPACE_CLASS}")"
 if [[ ! "${production_version_num}" =~ ^16[0-9]{4}$ ]]; then
 	printf 'production PostgreSQL major version is not 16\n' >&2
 	exit 1
@@ -96,7 +97,7 @@ fi
 production_count() {
 	docker exec easysubway-postgres sh -lc \
 		'psql -X -v ON_ERROR_STOP=1 -A -t -U "$POSTGRES_USER" "$POSTGRES_DB" -c "SELECT count(*) FROM route_search_results;"' \
-		| tr -d '[:space:]'
+		| tr -d "${SPACE_CLASS}"
 }
 
 storage_probe() {
@@ -122,7 +123,7 @@ printf "%s|%s|%s|%s\n" \
 source_count_before="$(production_count)"
 source_database_bytes="$(docker exec easysubway-postgres sh -lc \
 	'psql -X -v ON_ERROR_STOP=1 -A -t -U "$POSTGRES_USER" "$POSTGRES_DB" -c "SELECT pg_database_size(current_database());"' \
-	| tr -d '[:space:]')"
+	| tr -d "${SPACE_CLASS}")"
 IFS='|' read -r backup_device_before backup_available_before docker_device_before docker_available_before <<< "$(storage_probe)"
 if [[ ! "${source_count_before}" =~ ^[0-9]+$ || ! "${source_database_bytes}" =~ ^[0-9]+$ \
 	|| ! "${backup_device_before}" =~ ^[0-9]+$ || ! "${backup_available_before}" =~ ^[0-9]+$ \
@@ -251,7 +252,7 @@ restore_psql() {
 		psql -X -v ON_ERROR_STOP=1 -A -t -U snapshot_gate -d easysubway_restore "$@"
 }
 
-restore_count="$(restore_psql -c 'SELECT count(*) FROM route_search_results;' | tr -d '[:space:]')"
+restore_count="$(restore_psql -c 'SELECT count(*) FROM route_search_results;' | tr -d "${SPACE_CLASS}")"
 if [[ "${restore_count}" != "${source_count_before}" ]]; then
 	printf 'restored route row count does not match production backup count\n' >&2
 	exit 1
@@ -343,7 +344,7 @@ if [[ ! "${execution_ms}" =~ ^[0-9]+([.][0-9]+)?$ || ! "${wall_ms}" =~ ^[0-9]+$ 
 	exit 1
 fi
 
-rollback_count="$(restore_psql -c 'SELECT count(*) FROM route_search_results;' | tr -d '[:space:]')"
+rollback_count="$(restore_psql -c 'SELECT count(*) FROM route_search_results;' | tr -d "${SPACE_CLASS}")"
 if [[ "${rollback_count}" != "${restore_count}" ]]; then
 	printf 'route row count was not restored after rollback\n' >&2
 	exit 1

--- a/tools/ops/route-search-purge-snapshot-gate.sh
+++ b/tools/ops/route-search-purge-snapshot-gate.sh
@@ -6,6 +6,9 @@ umask 077
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 DEPLOY_ROOT="${DEPLOY_ROOT:-/opt/easysubway}"
 DEPLOY_COMPOSE_PROJECT="${DEPLOY_COMPOSE_PROJECT:-easysubway}"
+RESTORE_CPU_LIMIT="1"
+RESTORE_MEMORY_LIMIT="2g"
+RESTORE_PIDS_LIMIT="256"
 
 if [[ ! "${DEPLOY_ROOT}" =~ ^/[A-Za-z0-9._/-]+$ || "${DEPLOY_ROOT}" == *..* ]]; then
 	printf 'DEPLOY_ROOT is invalid\n' >&2
@@ -129,6 +132,10 @@ docker volume create "${restore_volume}" >/dev/null
 docker run -d --rm --pull never \
 	--name "${restore_container}" \
 	--network none \
+	--cpus "${RESTORE_CPU_LIMIT}" \
+	--memory "${RESTORE_MEMORY_LIMIT}" \
+	--memory-swap "${RESTORE_MEMORY_LIMIT}" \
+	--pids-limit "${RESTORE_PIDS_LIMIT}" \
 	--volume "${restore_volume}:/var/lib/postgresql/data" \
 	-e POSTGRES_DB=easysubway_restore \
 	-e POSTGRES_USER=snapshot_gate \
@@ -303,6 +310,7 @@ report_file="${EVIDENCE_DIR}/report-${backup_sha256:0:12}.md"
 	echo "- 2x safety execution/wall: \`${adjusted_execution_ms} ms/${adjusted_wall_ms} ms\`"
 	echo "- WAL bytes: \`${wal_bytes}\`"
 	echo '- restore isolation: same host/image/storage driver, separate Docker volume, no network or published port'
+	echo "- restore resource limits: \`${RESTORE_CPU_LIMIT} CPU, ${RESTORE_MEMORY_LIMIT} memory/no swap, ${RESTORE_PIDS_LIMIT} pids\`"
 	echo '- budget decision: pending explicit owner approval of 30 seconds and 256 MiB'
 	echo
 	echo '<details><summary>Sanitized EXPLAIN plan</summary>'

--- a/tools/ops/route-search-purge-snapshot-gate.sh
+++ b/tools/ops/route-search-purge-snapshot-gate.sh
@@ -26,7 +26,10 @@ mkdir -p "${BACKUP_DIR}" "${EVIDENCE_DIR}"
 chmod 700 "${BACKUP_DIR}" "${EVIDENCE_DIR}"
 
 exec 9>"${DEPLOY_ROOT}/deploy.lock"
-flock 9
+if ! flock -w 300 9; then
+	printf 'could not acquire deploy lock within timeout\n' >&2
+	exit 1
+fi
 
 if [[ -f "${MARKER_FILE}" ]] && grep -qx 'status=snapshot-complete' "${MARKER_FILE}"; then
 	backup_file="$(sed -n 's/^backup_file=//p' "${MARKER_FILE}")"
@@ -34,8 +37,14 @@ if [[ -f "${MARKER_FILE}" ]] && grep -qx 'status=snapshot-complete' "${MARKER_FI
 		"${BACKUP_DIR}"/*.dump) ;;
 		*) printf 'snapshot marker backup path is invalid\n' >&2; exit 1 ;;
 	esac
-	test -f "${backup_file}" -a -f "${backup_file}.sha256"
-	sha256sum -c "${backup_file}.sha256" >/dev/null
+	if [[ ! -f "${backup_file}" || ! -f "${backup_file}.sha256" ]]; then
+		printf 'existing snapshot backup or checksum file is missing\n' >&2
+		exit 1
+	fi
+	if ! sha256sum -c "${backup_file}.sha256" >/dev/null; then
+		printf 'existing snapshot backup checksum mismatch\n' >&2
+		exit 1
+	fi
 	{
 		echo '### #1913 route purge snapshot gate'
 		echo '- status: `snapshot-complete` (existing verified backup)'
@@ -56,7 +65,7 @@ if [[ "${image_revision}" != "${current_sha}" ]]; then
 	exit 1
 fi
 
-production_image="$(docker inspect --format '{{.Config.Image}}' easysubway-postgres)"
+production_image="$(docker inspect --format '{{.Image}}' easysubway-postgres)"
 production_version_num="$(docker exec easysubway-postgres sh -lc \
 	'psql -X -v ON_ERROR_STOP=1 -A -t -U "$POSTGRES_USER" "$POSTGRES_DB" -c "SHOW server_version_num;"' \
 	| tr -d '[:space:]')"

--- a/tools/ops/route-search-purge-snapshot-gate.sh
+++ b/tools/ops/route-search-purge-snapshot-gate.sh
@@ -10,6 +10,7 @@ RESTORE_CPU_LIMIT="1"
 RESTORE_MEMORY_LIMIT="2g"
 RESTORE_PIDS_LIMIT="256"
 WAL_HEADROOM_BYTES="$((256 * 1024 * 1024))"
+MIN_OPERATIONAL_RESERVE_BYTES="$((1024 * 1024 * 1024))"
 
 if [[ ! "${DEPLOY_ROOT}" =~ ^/[A-Za-z0-9._/-]+$ || "${DEPLOY_ROOT}" == *..* ]]; then
 	printf 'DEPLOY_ROOT is invalid\n' >&2
@@ -84,18 +85,62 @@ production_count() {
 		| tr -d '[:space:]'
 }
 
+storage_probe() {
+	docker run --rm --pull never \
+		--network none \
+		--read-only \
+		--user 0:0 \
+		--mount "type=bind,src=${BACKUP_DIR},dst=/probe/backup,readonly" \
+		--mount type=volume,target=/probe/docker \
+		--entrypoint sh \
+		"${production_image}" -c '
+set -eu
+set -- $(df -PB1 /probe/backup | tail -n 1)
+backup_available="$4"
+set -- $(df -PB1 /probe/docker | tail -n 1)
+docker_available="$4"
+printf "%s|%s|%s|%s\n" \
+  "$(stat -c %d /probe/backup)" "${backup_available}" \
+  "$(stat -c %d /probe/docker)" "${docker_available}"
+'
+}
+
 source_count_before="$(production_count)"
 source_database_bytes="$(docker exec easysubway-postgres sh -lc \
 	'psql -X -v ON_ERROR_STOP=1 -A -t -U "$POSTGRES_USER" "$POSTGRES_DB" -c "SELECT pg_database_size(current_database());"' \
 	| tr -d '[:space:]')"
-docker_root_dir="$(docker info --format '{{.DockerRootDir}}')"
-backup_available_before="$(df -PB1 "${BACKUP_DIR}" | awk 'NR == 2 {print $4}')"
-if [[ ! "${source_count_before}" =~ ^[0-9]+$ || ! "${source_database_bytes}" =~ ^[0-9]+$ || ! "${backup_available_before}" =~ ^[0-9]+$ ]]; then
+IFS='|' read -r backup_device_before backup_available_before docker_device_before docker_available_before <<< "$(storage_probe)"
+if [[ ! "${source_count_before}" =~ ^[0-9]+$ || ! "${source_database_bytes}" =~ ^[0-9]+$ \
+	|| ! "${backup_device_before}" =~ ^[0-9]+$ || ! "${backup_available_before}" =~ ^[0-9]+$ \
+	|| ! "${docker_device_before}" =~ ^[0-9]+$ || ! "${docker_available_before}" =~ ^[0-9]+$ ]]; then
 	printf 'production snapshot preflight metrics are invalid\n' >&2
 	exit 1
 fi
-if (( backup_available_before < source_database_bytes )); then
+
+operational_reserve_bytes="${MIN_OPERATIONAL_RESERVE_BYTES}"
+if (( source_database_bytes > operational_reserve_bytes )); then
+	operational_reserve_bytes="${source_database_bytes}"
+fi
+backup_reserve_bytes="$((source_database_bytes * 2))"
+restore_cluster_reserve_bytes="$((source_database_bytes * 2))"
+restore_wal_reserve_bytes="$((source_database_bytes * 2))"
+if (( restore_wal_reserve_bytes < WAL_HEADROOM_BYTES )); then
+	restore_wal_reserve_bytes="${WAL_HEADROOM_BYTES}"
+fi
+restore_required_bytes="$((restore_cluster_reserve_bytes + restore_wal_reserve_bytes + operational_reserve_bytes))"
+backup_required_before="$((backup_reserve_bytes + operational_reserve_bytes))"
+storage_shared_before=false
+if [[ "${backup_device_before}" == "${docker_device_before}" ]]; then
+	storage_shared_before=true
+	backup_required_before="$((backup_reserve_bytes + restore_required_bytes))"
+fi
+
+if (( backup_available_before < backup_required_before )); then
 	printf 'insufficient backup filesystem headroom\n' >&2
+	exit 1
+fi
+if (( docker_available_before < restore_required_bytes )); then
+	printf 'insufficient Docker filesystem headroom before backup\n' >&2
 	exit 1
 fi
 
@@ -123,9 +168,21 @@ if [[ ! "${backup_sha256}" =~ ^[0-9a-f]{64}$ || ! "${backup_bytes}" =~ ^[0-9]+$ 
 	printf 'backup identity is invalid\n' >&2
 	exit 1
 fi
-docker_available_after_backup="$(df -PB1 "${docker_root_dir}" | awk 'NR == 2 {print $4}')"
-restore_required_bytes="$((source_database_bytes + WAL_HEADROOM_BYTES))"
-if [[ ! "${docker_available_after_backup}" =~ ^[0-9]+$ ]] || (( docker_available_after_backup < restore_required_bytes )); then
+IFS='|' read -r backup_device_after backup_available_after docker_device_after docker_available_after_backup <<< "$(storage_probe)"
+if [[ ! "${backup_device_after}" =~ ^[0-9]+$ || ! "${backup_available_after}" =~ ^[0-9]+$ \
+	|| ! "${docker_device_after}" =~ ^[0-9]+$ || ! "${docker_available_after_backup}" =~ ^[0-9]+$ ]]; then
+	printf 'post-backup filesystem metrics are invalid\n' >&2
+	exit 1
+fi
+if [[ "${backup_device_after}" != "${backup_device_before}" || "${docker_device_after}" != "${docker_device_before}" ]]; then
+	printf 'snapshot filesystem layout changed during backup\n' >&2
+	exit 1
+fi
+if (( backup_available_after < operational_reserve_bytes )); then
+	printf 'insufficient operational reserve after backup\n' >&2
+	exit 1
+fi
+if (( docker_available_after_backup < restore_required_bytes )); then
 	printf 'insufficient Docker filesystem headroom\n' >&2
 	exit 1
 fi
@@ -227,6 +284,8 @@ for metric in "${required_metrics[@]}"; do
 	printf -v "${metric}" '%s' "${value}"
 done
 
+restore_psql -c 'ANALYZE route_search_results, favorite_routes, favorite_route_stations, route_feedbacks;' >/dev/null
+
 plan_file="${EVIDENCE_DIR}/purge-plan-${backup_sha256:0:12}.txt"
 start_ns="$(date +%s%N)"
 restore_psql > "${plan_file}" <<'SQL'
@@ -297,8 +356,12 @@ report_file="${EVIDENCE_DIR}/report-${backup_sha256:0:12}.md"
 	echo "- backup SHA-256: \`${backup_sha256}\`"
 	echo "- backup bytes: \`${backup_bytes}\`"
 	echo "- source database bytes: \`${source_database_bytes}\`"
-	echo "- backup filesystem available before: \`${backup_available_before}\`"
-	echo "- Docker available after backup/required restore headroom: \`${docker_available_after_backup}/${restore_required_bytes}\`"
+	echo "- backup filesystem available/required before: \`${backup_available_before}/${backup_required_before}\`"
+	echo "- backup filesystem available after: \`${backup_available_after}\`"
+	echo "- Docker available before/after backup: \`${docker_available_before}/${docker_available_after_backup}\`"
+	echo "- storage shared before backup: \`${storage_shared_before}\`"
+	echo "- operational reserve bytes: \`${operational_reserve_bytes}\`"
+	echo "- restore cluster/WAL/total reserve bytes: \`${restore_cluster_reserve_bytes}/${restore_wal_reserve_bytes}/${restore_required_bytes}\`"
 	echo "- PostgreSQL image: \`${production_image}\`"
 	echo "- CPU: \`${cpu_model}\`, cores \`${cpu_cores}\`"
 	echo "- memory KiB: \`${memory_kib}\`"

--- a/tools/ops/route-search-purge-snapshot-gate.sh
+++ b/tools/ops/route-search-purge-snapshot-gate.sh
@@ -1,0 +1,310 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+umask 077
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DEPLOY_ROOT="${DEPLOY_ROOT:-/opt/easysubway}"
+DEPLOY_COMPOSE_PROJECT="${DEPLOY_COMPOSE_PROJECT:-easysubway}"
+
+if [[ ! "${DEPLOY_ROOT}" =~ ^/[A-Za-z0-9._/-]+$ || "${DEPLOY_ROOT}" == *..* ]]; then
+	printf 'DEPLOY_ROOT is invalid\n' >&2
+	exit 2
+fi
+if [[ ! "${DEPLOY_COMPOSE_PROJECT}" =~ ^[A-Za-z0-9][A-Za-z0-9_-]*$ ]]; then
+	printf 'DEPLOY_COMPOSE_PROJECT is invalid\n' >&2
+	exit 2
+fi
+
+SHARED_DIR="${DEPLOY_ROOT}/shared"
+BACKUP_DIR="${DEPLOY_ROOT}/backups/postgres/1913-route-purge"
+EVIDENCE_DIR="${SHARED_DIR}/1913-route-purge-snapshot"
+MARKER_FILE="${EVIDENCE_DIR}/snapshot.env"
+SUMMARY_FILE="${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+mkdir -p "${BACKUP_DIR}" "${EVIDENCE_DIR}"
+chmod 700 "${BACKUP_DIR}" "${EVIDENCE_DIR}"
+
+exec 9>"${DEPLOY_ROOT}/deploy.lock"
+flock 9
+
+if [[ -f "${MARKER_FILE}" ]] && grep -qx 'status=snapshot-complete' "${MARKER_FILE}"; then
+	backup_file="$(sed -n 's/^backup_file=//p' "${MARKER_FILE}")"
+	case "${backup_file}" in
+		"${BACKUP_DIR}"/*.dump) ;;
+		*) printf 'snapshot marker backup path is invalid\n' >&2; exit 1 ;;
+	esac
+	test -f "${backup_file}" -a -f "${backup_file}.sha256"
+	sha256sum -c "${backup_file}.sha256" >/dev/null
+	{
+		echo '### #1913 route purge snapshot gate'
+		echo '- status: `snapshot-complete` (existing verified backup)'
+	} >> "${SUMMARY_FILE}"
+	exit 0
+fi
+
+current_sha="$(<"${SHARED_DIR}/current-sha")"
+if [[ ! "${current_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+	printf 'deployed SHA marker is invalid\n' >&2
+	exit 1
+fi
+
+expected_image="easysubway-backend:${current_sha}"
+image_revision="$(docker image inspect --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' "${expected_image}")"
+if [[ "${image_revision}" != "${current_sha}" ]]; then
+	printf 'deployed image revision does not match current SHA\n' >&2
+	exit 1
+fi
+
+production_image="$(docker inspect --format '{{.Config.Image}}' easysubway-postgres)"
+production_version_num="$(docker exec easysubway-postgres sh -lc \
+	'psql -X -v ON_ERROR_STOP=1 -A -t -U "$POSTGRES_USER" "$POSTGRES_DB" -c "SHOW server_version_num;"' \
+	| tr -d '[:space:]')"
+if [[ ! "${production_version_num}" =~ ^16[0-9]{4}$ ]]; then
+	printf 'production PostgreSQL major version is not 16\n' >&2
+	exit 1
+fi
+
+production_count() {
+	docker exec easysubway-postgres sh -lc \
+		'psql -X -v ON_ERROR_STOP=1 -A -t -U "$POSTGRES_USER" "$POSTGRES_DB" -c "SELECT count(*) FROM route_search_results;"' \
+		| tr -d '[:space:]'
+}
+
+source_count_before="$(production_count)"
+if [[ ! "${source_count_before}" =~ ^[0-9]+$ ]]; then
+	printf 'production route row count is invalid\n' >&2
+	exit 1
+fi
+
+backup_file="$(
+	EASYSUBWAY_ENV_FILE="${SHARED_DIR}/current-env/compose.env" \
+	EASYSUBWAY_COMPOSE_FILE="${DEPLOY_ROOT}/repository/infra/docker-compose.yml" \
+	EASYSUBWAY_COMPOSE_PROJECT="${DEPLOY_COMPOSE_PROJECT}" \
+	EASYSUBWAY_BACKUP_DIR="${BACKUP_DIR}" \
+		bash "${ROOT_DIR}/tools/ops/postgres-backup.sh"
+)"
+case "${backup_file}" in
+	"${BACKUP_DIR}"/*.dump) ;;
+	*) printf 'backup script returned an invalid path\n' >&2; exit 1 ;;
+esac
+
+source_count_after="$(production_count)"
+if [[ "${source_count_before}" != "${source_count_after}" ]]; then
+	printf 'production route rows changed during backup\n' >&2
+	exit 1
+fi
+
+backup_sha256="$(sha256sum "${backup_file}" | awk '{print $1}')"
+backup_bytes="$(stat -c '%s' "${backup_file}")"
+if [[ ! "${backup_sha256}" =~ ^[0-9a-f]{64}$ || ! "${backup_bytes}" =~ ^[0-9]+$ ]]; then
+	printf 'backup identity is invalid\n' >&2
+	exit 1
+fi
+
+run_suffix="${GITHUB_RUN_ID:-$$}-${GITHUB_RUN_ATTEMPT:-1}"
+if [[ ! "${run_suffix}" =~ ^[0-9]+-[0-9]+$ ]]; then
+	printf 'snapshot run identity is invalid\n' >&2
+	exit 1
+fi
+restore_container="easysubway-1913-restore-${run_suffix}"
+restore_volume="easysubway-1913-restore-${run_suffix}"
+
+cleanup() {
+	docker rm -f "${restore_container}" >/dev/null 2>&1 || true
+	docker volume rm "${restore_volume}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+docker volume create "${restore_volume}" >/dev/null
+docker run -d --rm --pull never \
+	--name "${restore_container}" \
+	--network none \
+	--volume "${restore_volume}:/var/lib/postgresql/data" \
+	-e POSTGRES_DB=easysubway_restore \
+	-e POSTGRES_USER=snapshot_gate \
+	-e POSTGRES_PASSWORD=snapshot_gate_local \
+	"${production_image}" >/dev/null
+
+ready=false
+for _ in $(seq 1 60); do
+	if docker exec "${restore_container}" pg_isready -U snapshot_gate -d easysubway_restore >/dev/null 2>&1; then
+		ready=true
+		break
+	fi
+	sleep 1
+done
+if [[ "${ready}" != "true" ]]; then
+	printf 'isolated restore PostgreSQL did not become ready\n' >&2
+	exit 1
+fi
+
+docker exec -i "${restore_container}" \
+	pg_restore --no-owner --no-privileges -U snapshot_gate -d easysubway_restore \
+	< "${backup_file}"
+
+restore_psql() {
+	docker exec -i "${restore_container}" \
+		psql -X -v ON_ERROR_STOP=1 -A -t -U snapshot_gate -d easysubway_restore "$@"
+}
+
+restore_count="$(restore_psql -c 'SELECT count(*) FROM route_search_results;' | tr -d '[:space:]')"
+if [[ "${restore_count}" != "${source_count_before}" ]]; then
+	printf 'restored route row count does not match production backup count\n' >&2
+	exit 1
+fi
+
+counts="$(restore_psql -F '|' -c "
+WITH reference_ids AS (
+    SELECT route_search_id FROM favorite_routes
+    UNION SELECT route_search_id FROM favorite_route_stations
+    UNION SELECT route_search_id FROM route_feedbacks
+), metrics AS (
+    SELECT 'route_total' AS key, count(*)::bigint AS value FROM route_search_results
+    UNION ALL SELECT 'favorite_routes_raw', count(DISTINCT route_search_id) FROM favorite_routes
+    UNION ALL SELECT 'favorite_routes_preserved', count(DISTINCT favorite.route_search_id) FROM favorite_routes favorite JOIN route_search_results route USING (route_search_id)
+    UNION ALL SELECT 'favorite_routes_dangling', count(DISTINCT favorite.route_search_id) FROM favorite_routes favorite LEFT JOIN route_search_results route USING (route_search_id) WHERE route.route_search_id IS NULL
+    UNION ALL SELECT 'favorite_route_stations_raw', count(DISTINCT route_search_id) FROM favorite_route_stations
+    UNION ALL SELECT 'favorite_route_stations_preserved', count(DISTINCT station.route_search_id) FROM favorite_route_stations station JOIN route_search_results route USING (route_search_id)
+    UNION ALL SELECT 'favorite_route_stations_dangling', count(DISTINCT station.route_search_id) FROM favorite_route_stations station LEFT JOIN route_search_results route USING (route_search_id) WHERE route.route_search_id IS NULL
+    UNION ALL SELECT 'route_feedbacks_raw', count(DISTINCT route_search_id) FROM route_feedbacks
+    UNION ALL SELECT 'route_feedbacks_preserved', count(DISTINCT feedback.route_search_id) FROM route_feedbacks feedback JOIN route_search_results route USING (route_search_id)
+    UNION ALL SELECT 'route_feedbacks_dangling', count(DISTINCT feedback.route_search_id) FROM route_feedbacks feedback LEFT JOIN route_search_results route USING (route_search_id) WHERE route.route_search_id IS NULL
+    UNION ALL SELECT 'reference_union_raw', count(*) FROM reference_ids
+    UNION ALL SELECT 'preserved_union', count(*) FROM reference_ids reference JOIN route_search_results route USING (route_search_id)
+    UNION ALL SELECT 'dangling_union', count(*) FROM reference_ids reference LEFT JOIN route_search_results route USING (route_search_id) WHERE route.route_search_id IS NULL
+    UNION ALL SELECT 'delete_candidates', count(*) FROM route_search_results route
+      WHERE NOT EXISTS (SELECT 1 FROM favorite_routes favorite WHERE favorite.route_search_id = route.route_search_id)
+        AND NOT EXISTS (SELECT 1 FROM favorite_route_stations station WHERE station.route_search_id = route.route_search_id)
+        AND NOT EXISTS (SELECT 1 FROM route_feedbacks feedback WHERE feedback.route_search_id = route.route_search_id)
+)
+SELECT key, value FROM metrics ORDER BY key;")"
+
+required_metrics=(
+	route_total favorite_routes_raw favorite_routes_preserved favorite_routes_dangling
+	favorite_route_stations_raw favorite_route_stations_preserved favorite_route_stations_dangling
+	route_feedbacks_raw route_feedbacks_preserved route_feedbacks_dangling
+	reference_union_raw preserved_union dangling_union delete_candidates
+)
+for metric in "${required_metrics[@]}"; do
+	value="$(awk -F '|' -v key="${metric}" '$1 == key {print $2}' <<< "${counts}")"
+	if [[ ! "${value}" =~ ^[0-9]+$ ]]; then
+		printf 'missing aggregate metric: %s\n' "${metric}" >&2
+		exit 1
+	fi
+	printf -v "${metric}" '%s' "${value}"
+done
+
+plan_file="${EVIDENCE_DIR}/purge-plan-${backup_sha256:0:12}.txt"
+start_ns="$(date +%s%N)"
+restore_psql > "${plan_file}" <<'SQL'
+BEGIN;
+EXPLAIN (ANALYZE, BUFFERS, WAL)
+DELETE FROM route_search_results AS route
+WHERE NOT EXISTS (
+    SELECT 1 FROM favorite_routes AS favorite
+    WHERE favorite.route_search_id = route.route_search_id
+)
+AND NOT EXISTS (
+    SELECT 1 FROM favorite_route_stations AS station
+    WHERE station.route_search_id = route.route_search_id
+)
+AND NOT EXISTS (
+    SELECT 1 FROM route_feedbacks AS feedback
+    WHERE feedback.route_search_id = route.route_search_id
+);
+ROLLBACK;
+SQL
+end_ns="$(date +%s%N)"
+chmod 600 "${plan_file}"
+
+wall_ms="$(( (end_ns - start_ns) / 1000000 ))"
+execution_ms="$(sed -n 's/.*Execution Time: \([0-9.]*\) ms.*/\1/p' "${plan_file}" | tail -n 1)"
+wal_bytes="$(awk '
+  /WAL:/ {
+    for (i = 1; i <= NF; i++) {
+      if ($i ~ /^bytes=/) {
+        value = $i
+        sub(/^bytes=/, "", value)
+        sub(/,$/, "", value)
+        total += value
+      }
+    }
+  }
+  END { print total + 0 }
+' "${plan_file}")"
+if [[ ! "${execution_ms}" =~ ^[0-9]+([.][0-9]+)?$ || ! "${wall_ms}" =~ ^[0-9]+$ || ! "${wal_bytes}" =~ ^[0-9]+$ ]]; then
+	printf 'purge plan metrics are invalid\n' >&2
+	exit 1
+fi
+
+rollback_count="$(restore_psql -c 'SELECT count(*) FROM route_search_results;' | tr -d '[:space:]')"
+if [[ "${rollback_count}" != "${restore_count}" ]]; then
+	printf 'route row count was not restored after rollback\n' >&2
+	exit 1
+fi
+
+cpu_model="$(lscpu | sed -n 's/^Model name:[[:space:]]*//p' | head -n 1)"
+cpu_cores="$(nproc)"
+memory_kib="$(awk '/^MemTotal:/ {print $2}' /proc/meminfo)"
+root_filesystem="$(findmnt -n -o FSTYPE /)"
+docker_storage_driver="$(docker info --format '{{.Driver}}')"
+production_settings="$(docker exec easysubway-postgres sh -lc \
+	'psql -X -v ON_ERROR_STOP=1 -A -t -F "|" -U "$POSTGRES_USER" "$POSTGRES_DB" -c "SELECT current_setting('\''server_version'\''), current_setting('\''shared_buffers'\''), current_setting('\''work_mem'\''), current_setting('\''maintenance_work_mem'\''), current_setting('\''effective_cache_size'\''), current_setting('\''max_wal_size'\''), current_setting('\''checkpoint_timeout'\''), current_setting('\''synchronous_commit'\'');"')"
+restore_settings="$(restore_psql -F '|' -c "SELECT current_setting('server_version'), current_setting('shared_buffers'), current_setting('work_mem'), current_setting('maintenance_work_mem'), current_setting('effective_cache_size'), current_setting('max_wal_size'), current_setting('checkpoint_timeout'), current_setting('synchronous_commit');")"
+
+adjusted_execution_ms="$(awk -v value="${execution_ms}" 'BEGIN { printf "%.3f", value * 2 }')"
+adjusted_wall_ms="$(( wall_ms * 2 ))"
+
+marker_tmp="$(mktemp "${EVIDENCE_DIR}/snapshot.XXXXXX")"
+{
+	printf 'status=snapshot-complete\n'
+	printf 'current_sha=%s\n' "${current_sha}"
+	printf 'backup_file=%s\n' "${backup_file}"
+	printf 'backup_sha256=%s\n' "${backup_sha256}"
+	printf 'backup_bytes=%s\n' "${backup_bytes}"
+	printf 'route_total=%s\n' "${route_total}"
+	printf 'delete_candidates=%s\n' "${delete_candidates}"
+	printf 'execution_ms=%s\n' "${execution_ms}"
+	printf 'wall_ms=%s\n' "${wall_ms}"
+	printf 'wal_bytes=%s\n' "${wal_bytes}"
+} > "${marker_tmp}"
+chmod 600 "${marker_tmp}"
+mv "${marker_tmp}" "${MARKER_FILE}"
+
+report_file="${EVIDENCE_DIR}/report-${backup_sha256:0:12}.md"
+{
+	echo '### #1913 route purge snapshot gate'
+	echo "- deployed SHA: \`${current_sha}\`"
+	echo "- backup SHA-256: \`${backup_sha256}\`"
+	echo "- backup bytes: \`${backup_bytes}\`"
+	echo "- PostgreSQL image: \`${production_image}\`"
+	echo "- CPU: \`${cpu_model}\`, cores \`${cpu_cores}\`"
+	echo "- memory KiB: \`${memory_kib}\`"
+	echo "- storage: root filesystem \`${root_filesystem}\`, Docker \`${docker_storage_driver}\`, IOPS/throughput not independently measured"
+	echo "- production settings: \`${production_settings}\`"
+	echo "- restore settings: \`${restore_settings}\`"
+	echo "- route rows production/restored/after rollback: \`${source_count_before}/${restore_count}/${rollback_count}\`"
+	echo "- favorite_routes raw/preserved/dangling: \`${favorite_routes_raw}/${favorite_routes_preserved}/${favorite_routes_dangling}\`"
+	echo "- favorite_route_stations raw/preserved/dangling: \`${favorite_route_stations_raw}/${favorite_route_stations_preserved}/${favorite_route_stations_dangling}\`"
+	echo "- route_feedbacks raw/preserved/dangling: \`${route_feedbacks_raw}/${route_feedbacks_preserved}/${route_feedbacks_dangling}\`"
+	echo "- reference union raw/preserved/dangling: \`${reference_union_raw}/${preserved_union}/${dangling_union}\`"
+	echo "- delete candidates: \`${delete_candidates}\`"
+	echo "- EXPLAIN execution/wall: \`${execution_ms} ms/${wall_ms} ms\`"
+	echo "- 2x safety execution/wall: \`${adjusted_execution_ms} ms/${adjusted_wall_ms} ms\`"
+	echo "- WAL bytes: \`${wal_bytes}\`"
+	echo '- restore isolation: same host/image/storage driver, separate Docker volume, no network or published port'
+	echo '- budget decision: pending explicit owner approval of 30 seconds and 256 MiB'
+	echo
+	echo '<details><summary>Sanitized EXPLAIN plan</summary>'
+	echo
+	echo '```text'
+	cat "${plan_file}"
+	echo '```'
+	echo '</details>'
+} > "${report_file}"
+chmod 600 "${report_file}"
+cat "${report_file}" >> "${SUMMARY_FILE}"
+cat "${report_file}"
+
+printf 'route purge snapshot gate completed: %s\n' "${backup_sha256}"

--- a/tools/ops/route-search-purge-snapshot-gate.sh
+++ b/tools/ops/route-search-purge-snapshot-gate.sh
@@ -265,8 +265,10 @@ cpu_cores="$(nproc)"
 memory_kib="$(awk '/^MemTotal:/ {print $2}' /proc/meminfo)"
 root_filesystem="$(findmnt -n -o FSTYPE /)"
 docker_storage_driver="$(docker info --format '{{.Driver}}')"
+production_settings_sql="SELECT current_setting('server_version'), current_setting('shared_buffers'), current_setting('work_mem'), current_setting('maintenance_work_mem'), current_setting('effective_cache_size'), current_setting('max_wal_size'), current_setting('checkpoint_timeout'), current_setting('synchronous_commit');"
 production_settings="$(docker exec easysubway-postgres sh -lc \
-	'psql -X -v ON_ERROR_STOP=1 -A -t -F "|" -U "$POSTGRES_USER" "$POSTGRES_DB" -c "SELECT current_setting('\''server_version'\''), current_setting('\''shared_buffers'\''), current_setting('\''work_mem'\''), current_setting('\''maintenance_work_mem'\''), current_setting('\''effective_cache_size'\''), current_setting('\''max_wal_size'\''), current_setting('\''checkpoint_timeout'\''), current_setting('\''synchronous_commit'\'');"')"
+	'psql -X -v ON_ERROR_STOP=1 -A -t -F "|" -U "$POSTGRES_USER" "$POSTGRES_DB" -c "$1"' sh \
+	"${production_settings_sql}")"
 restore_settings="$(restore_psql -F '|' -c "SELECT current_setting('server_version'), current_setting('shared_buffers'), current_setting('work_mem'), current_setting('maintenance_work_mem'), current_setting('effective_cache_size'), current_setting('max_wal_size'), current_setting('checkpoint_timeout'), current_setting('synchronous_commit');")"
 
 adjusted_execution_ms="$(awk -v value="${execution_ms}" 'BEGIN { printf "%.3f", value * 2 }')"

--- a/tools/ops/route-search-purge-snapshot-gate.sh
+++ b/tools/ops/route-search-purge-snapshot-gate.sh
@@ -7,6 +7,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 DEPLOY_ROOT="${DEPLOY_ROOT:-/opt/easysubway}"
 DEPLOY_COMPOSE_PROJECT="${DEPLOY_COMPOSE_PROJECT:-easysubway}"
 EXPECTED_DEPLOYED_SHA="${EXPECTED_DEPLOYED_SHA:-}"
+SNAPSHOT_REQUEST_SHA="${SNAPSHOT_REQUEST_SHA:-}"
 RESTORE_CPU_LIMIT="1"
 RESTORE_MEMORY_LIMIT="2g"
 RESTORE_PIDS_LIMIT="256"
@@ -26,11 +27,15 @@ if [[ ! "${EXPECTED_DEPLOYED_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
 	printf 'EXPECTED_DEPLOYED_SHA is invalid\n' >&2
 	exit 2
 fi
+if [[ ! "${SNAPSHOT_REQUEST_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+	printf 'SNAPSHOT_REQUEST_SHA is invalid\n' >&2
+	exit 2
+fi
 
 SHARED_DIR="${DEPLOY_ROOT}/shared"
 BACKUP_DIR="${DEPLOY_ROOT}/backups/postgres/1913-route-purge"
 EVIDENCE_DIR="${SHARED_DIR}/1913-route-purge-snapshot"
-MARKER_FILE="${EVIDENCE_DIR}/snapshot.env"
+MARKER_FILE="${EVIDENCE_DIR}/snapshot-${SNAPSHOT_REQUEST_SHA}.env"
 SUMMARY_FILE="${GITHUB_STEP_SUMMARY:-/dev/null}"
 
 mkdir -p "${BACKUP_DIR}" "${EVIDENCE_DIR}"
@@ -41,6 +46,7 @@ if ! flock -w 300 9; then
 	printf 'could not acquire deploy lock within timeout\n' >&2
 	exit 1
 fi
+rm -f "${MARKER_FILE}"
 
 current_sha="$(<"${SHARED_DIR}/current-sha")"
 if [[ ! "${current_sha}" =~ ^[0-9a-f]{40}$ ]]; then
@@ -50,32 +56,6 @@ fi
 if [[ "${current_sha}" != "${EXPECTED_DEPLOYED_SHA}" ]]; then
 	printf 'deployed SHA changed after closure verification\n' >&2
 	exit 1
-fi
-
-if [[ -f "${MARKER_FILE}" ]] && grep -qx 'status=snapshot-complete' "${MARKER_FILE}"; then
-	marker_sha="$(sed -n 's/^current_sha=//p' "${MARKER_FILE}")"
-	if [[ "${marker_sha}" != "${EXPECTED_DEPLOYED_SHA}" ]]; then
-		printf 'snapshot marker SHA does not match verified deployment\n' >&2
-		exit 1
-	fi
-	backup_file="$(sed -n 's/^backup_file=//p' "${MARKER_FILE}")"
-	case "${backup_file}" in
-		"${BACKUP_DIR}"/*.dump) ;;
-		*) printf 'snapshot marker backup path is invalid\n' >&2; exit 1 ;;
-	esac
-	if [[ ! -f "${backup_file}" || ! -f "${backup_file}.sha256" ]]; then
-		printf 'existing snapshot backup or checksum file is missing\n' >&2
-		exit 1
-	fi
-	if ! sha256sum -c "${backup_file}.sha256" >/dev/null; then
-		printf 'existing snapshot backup checksum mismatch\n' >&2
-		exit 1
-	fi
-	{
-		echo '### #1913 route purge snapshot gate'
-		echo '- status: `snapshot-complete` (existing verified backup)'
-	} >> "${SUMMARY_FILE}"
-	exit 0
 fi
 
 expected_image="easysubway-backend:${current_sha}"
@@ -365,8 +345,11 @@ adjusted_execution_ms="$(awk -v value="${execution_ms}" 'BEGIN { printf "%.3f", 
 adjusted_wall_ms="$(( wall_ms * 2 ))"
 
 report_file="${EVIDENCE_DIR}/report-${backup_sha256:0:12}.md"
+snapshot_completed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 {
 	echo '### #1913 route purge snapshot gate'
+	echo "- snapshot request SHA: \`${SNAPSHOT_REQUEST_SHA}\`"
+	echo "- snapshot completed at: \`${snapshot_completed_at}\`"
 	echo "- deployed SHA: \`${current_sha}\`"
 	echo "- backup SHA-256: \`${backup_sha256}\`"
 	echo "- backup bytes: \`${backup_bytes}\`"
@@ -410,6 +393,8 @@ cat "${report_file}"
 marker_tmp="$(mktemp "${EVIDENCE_DIR}/snapshot.XXXXXX")"
 {
 	printf 'status=snapshot-complete\n'
+	printf 'snapshot_request_sha=%s\n' "${SNAPSHOT_REQUEST_SHA}"
+	printf 'completed_at=%s\n' "${snapshot_completed_at}"
 	printf 'current_sha=%s\n' "${current_sha}"
 	printf 'backup_file=%s\n' "${backup_file}"
 	printf 'backup_sha256=%s\n' "${backup_sha256}"

--- a/tools/ops/route-search-purge-snapshot-gate.sh
+++ b/tools/ops/route-search-purge-snapshot-gate.sh
@@ -6,6 +6,7 @@ umask 077
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 DEPLOY_ROOT="${DEPLOY_ROOT:-/opt/easysubway}"
 DEPLOY_COMPOSE_PROJECT="${DEPLOY_COMPOSE_PROJECT:-easysubway}"
+EXPECTED_DEPLOYED_SHA="${EXPECTED_DEPLOYED_SHA:-}"
 RESTORE_CPU_LIMIT="1"
 RESTORE_MEMORY_LIMIT="2g"
 RESTORE_PIDS_LIMIT="256"
@@ -18,6 +19,10 @@ if [[ ! "${DEPLOY_ROOT}" =~ ^/[A-Za-z0-9._/-]+$ || "${DEPLOY_ROOT}" == *..* ]]; 
 fi
 if [[ ! "${DEPLOY_COMPOSE_PROJECT}" =~ ^[A-Za-z0-9][A-Za-z0-9_-]*$ ]]; then
 	printf 'DEPLOY_COMPOSE_PROJECT is invalid\n' >&2
+	exit 2
+fi
+if [[ ! "${EXPECTED_DEPLOYED_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+	printf 'EXPECTED_DEPLOYED_SHA is invalid\n' >&2
 	exit 2
 fi
 
@@ -36,7 +41,22 @@ if ! flock -w 300 9; then
 	exit 1
 fi
 
+current_sha="$(<"${SHARED_DIR}/current-sha")"
+if [[ ! "${current_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+	printf 'deployed SHA marker is invalid\n' >&2
+	exit 1
+fi
+if [[ "${current_sha}" != "${EXPECTED_DEPLOYED_SHA}" ]]; then
+	printf 'deployed SHA changed after closure verification\n' >&2
+	exit 1
+fi
+
 if [[ -f "${MARKER_FILE}" ]] && grep -qx 'status=snapshot-complete' "${MARKER_FILE}"; then
+	marker_sha="$(sed -n 's/^current_sha=//p' "${MARKER_FILE}")"
+	if [[ "${marker_sha}" != "${EXPECTED_DEPLOYED_SHA}" ]]; then
+		printf 'snapshot marker SHA does not match verified deployment\n' >&2
+		exit 1
+	fi
 	backup_file="$(sed -n 's/^backup_file=//p' "${MARKER_FILE}")"
 	case "${backup_file}" in
 		"${BACKUP_DIR}"/*.dump) ;;
@@ -55,12 +75,6 @@ if [[ -f "${MARKER_FILE}" ]] && grep -qx 'status=snapshot-complete' "${MARKER_FI
 		echo '- status: `snapshot-complete` (existing verified backup)'
 	} >> "${SUMMARY_FILE}"
 	exit 0
-fi
-
-current_sha="$(<"${SHARED_DIR}/current-sha")"
-if [[ ! "${current_sha}" =~ ^[0-9a-f]{40}$ ]]; then
-	printf 'deployed SHA marker is invalid\n' >&2
-	exit 1
 fi
 
 expected_image="easysubway-backend:${current_sha}"

--- a/tools/ops/route-search-purge-snapshot-gate.sh
+++ b/tools/ops/route-search-purge-snapshot-gate.sh
@@ -9,6 +9,7 @@ DEPLOY_COMPOSE_PROJECT="${DEPLOY_COMPOSE_PROJECT:-easysubway}"
 RESTORE_CPU_LIMIT="1"
 RESTORE_MEMORY_LIMIT="2g"
 RESTORE_PIDS_LIMIT="256"
+WAL_HEADROOM_BYTES="$((256 * 1024 * 1024))"
 
 if [[ ! "${DEPLOY_ROOT}" =~ ^/[A-Za-z0-9._/-]+$ || "${DEPLOY_ROOT}" == *..* ]]; then
 	printf 'DEPLOY_ROOT is invalid\n' >&2
@@ -84,8 +85,17 @@ production_count() {
 }
 
 source_count_before="$(production_count)"
-if [[ ! "${source_count_before}" =~ ^[0-9]+$ ]]; then
-	printf 'production route row count is invalid\n' >&2
+source_database_bytes="$(docker exec easysubway-postgres sh -lc \
+	'psql -X -v ON_ERROR_STOP=1 -A -t -U "$POSTGRES_USER" "$POSTGRES_DB" -c "SELECT pg_database_size(current_database());"' \
+	| tr -d '[:space:]')"
+docker_root_dir="$(docker info --format '{{.DockerRootDir}}')"
+backup_available_before="$(df -PB1 "${BACKUP_DIR}" | awk 'NR == 2 {print $4}')"
+if [[ ! "${source_count_before}" =~ ^[0-9]+$ || ! "${source_database_bytes}" =~ ^[0-9]+$ || ! "${backup_available_before}" =~ ^[0-9]+$ ]]; then
+	printf 'production snapshot preflight metrics are invalid\n' >&2
+	exit 1
+fi
+if (( backup_available_before < source_database_bytes )); then
+	printf 'insufficient backup filesystem headroom\n' >&2
 	exit 1
 fi
 
@@ -111,6 +121,12 @@ backup_sha256="$(sha256sum "${backup_file}" | awk '{print $1}')"
 backup_bytes="$(stat -c '%s' "${backup_file}")"
 if [[ ! "${backup_sha256}" =~ ^[0-9a-f]{64}$ || ! "${backup_bytes}" =~ ^[0-9]+$ ]]; then
 	printf 'backup identity is invalid\n' >&2
+	exit 1
+fi
+docker_available_after_backup="$(df -PB1 "${docker_root_dir}" | awk 'NR == 2 {print $4}')"
+restore_required_bytes="$((source_database_bytes + WAL_HEADROOM_BYTES))"
+if [[ ! "${docker_available_after_backup}" =~ ^[0-9]+$ ]] || (( docker_available_after_backup < restore_required_bytes )); then
+	printf 'insufficient Docker filesystem headroom\n' >&2
 	exit 1
 fi
 
@@ -274,28 +290,15 @@ restore_settings="$(restore_psql -F '|' -c "SELECT current_setting('server_versi
 adjusted_execution_ms="$(awk -v value="${execution_ms}" 'BEGIN { printf "%.3f", value * 2 }')"
 adjusted_wall_ms="$(( wall_ms * 2 ))"
 
-marker_tmp="$(mktemp "${EVIDENCE_DIR}/snapshot.XXXXXX")"
-{
-	printf 'status=snapshot-complete\n'
-	printf 'current_sha=%s\n' "${current_sha}"
-	printf 'backup_file=%s\n' "${backup_file}"
-	printf 'backup_sha256=%s\n' "${backup_sha256}"
-	printf 'backup_bytes=%s\n' "${backup_bytes}"
-	printf 'route_total=%s\n' "${route_total}"
-	printf 'delete_candidates=%s\n' "${delete_candidates}"
-	printf 'execution_ms=%s\n' "${execution_ms}"
-	printf 'wall_ms=%s\n' "${wall_ms}"
-	printf 'wal_bytes=%s\n' "${wal_bytes}"
-} > "${marker_tmp}"
-chmod 600 "${marker_tmp}"
-mv "${marker_tmp}" "${MARKER_FILE}"
-
 report_file="${EVIDENCE_DIR}/report-${backup_sha256:0:12}.md"
 {
 	echo '### #1913 route purge snapshot gate'
 	echo "- deployed SHA: \`${current_sha}\`"
 	echo "- backup SHA-256: \`${backup_sha256}\`"
 	echo "- backup bytes: \`${backup_bytes}\`"
+	echo "- source database bytes: \`${source_database_bytes}\`"
+	echo "- backup filesystem available before: \`${backup_available_before}\`"
+	echo "- Docker available after backup/required restore headroom: \`${docker_available_after_backup}/${restore_required_bytes}\`"
 	echo "- PostgreSQL image: \`${production_image}\`"
 	echo "- CPU: \`${cpu_model}\`, cores \`${cpu_cores}\`"
 	echo "- memory KiB: \`${memory_kib}\`"
@@ -325,5 +328,21 @@ report_file="${EVIDENCE_DIR}/report-${backup_sha256:0:12}.md"
 chmod 600 "${report_file}"
 cat "${report_file}" >> "${SUMMARY_FILE}"
 cat "${report_file}"
+
+marker_tmp="$(mktemp "${EVIDENCE_DIR}/snapshot.XXXXXX")"
+{
+	printf 'status=snapshot-complete\n'
+	printf 'current_sha=%s\n' "${current_sha}"
+	printf 'backup_file=%s\n' "${backup_file}"
+	printf 'backup_sha256=%s\n' "${backup_sha256}"
+	printf 'backup_bytes=%s\n' "${backup_bytes}"
+	printf 'route_total=%s\n' "${route_total}"
+	printf 'delete_candidates=%s\n' "${delete_candidates}"
+	printf 'execution_ms=%s\n' "${execution_ms}"
+	printf 'wall_ms=%s\n' "${wall_ms}"
+	printf 'wal_bytes=%s\n' "${wal_bytes}"
+} > "${marker_tmp}"
+chmod 600 "${marker_tmp}"
+mv "${marker_tmp}" "${MARKER_FILE}"
 
 printf 'route purge snapshot gate completed: %s\n' "${backup_sha256}"


### PR DESCRIPTION
## 관련 이슈

Refs #1913

## 작업 배경

- PR1에서 production 공개 route API를 폐쇄하고 rollback latch를 확보했지만, V51 purge 설계 승인 전에 production snapshot 기반 row 규모·참조 보존·실행 계획·WAL·복구 가능성 증거가 필요합니다.
- production host는 외부 SSH가 아니라 self-hosted runner 경로로만 안전하게 접근 가능하므로, review·merge된 main workflow에서 기존 backup 도구를 재사용합니다.
- 오너는 이 PR 병합 후 production snapshot 생성, 격리 restore, count/EXPLAIN/WAL/environment evidence 수집을 승인했습니다. production V51 실행과 production DB restore는 승인 범위가 아닙니다.

## 작업 내용

- 기존 main-only production closure evidence workflow에 snapshot gate job을 추가했습니다.
- 기존 deploy lock과 동일한 cd-production-deploy concurrency를 사용해 deploy/rollback과 snapshot을 직렬화합니다.
- 현재 배포 SHA와 backend image OCI revision을 대조하고 production PostgreSQL major version 16을 확인합니다.
- 기존 tools/ops/postgres-backup.sh로 custom-format backup과 SHA-256을 생성하며, production row count가 backup 전후 동일한지 확인합니다.
- production과 동일한 PostgreSQL image를 --pull never, --network none, 무포트 임시 container/volume에서 실행하고 backup을 restore합니다.
- favorite_routes, favorite_route_stations, route_feedbacks별 raw distinct ID·실제 보존 ID·dangling ID, union 집계, 최종 삭제 후보를 aggregate count로만 수집합니다.
- 실제 purge SQL을 EXPLAIN (ANALYZE, BUFFERS, WAL) 안에서 실행한 뒤 ROLLBACK하고 row count 불변을 검증합니다.
- CPU·memory·storage 유형·PostgreSQL 주요 설정, 실행 시간, 2배 safety margin, WAL bytes를 private evidence file과 sanitized Actions log/summary에 기록합니다.
- 성공 marker와 backup checksum으로 재실행을 idempotent하게 만들고, 임시 restore container/volume은 항상 정리합니다.

## 검증

- node --test tools/ci/backend-deploy.test.mjs tools/ci/production-route-api-closure-evidence-workflow.test.mjs — 11/11 통과
- bash -n tools/ops/route-search-purge-snapshot-gate.sh — 통과
- Ruby YAML safe_load — 통과
- git diff --check — 통과
- PostgreSQL 16 production 동일 image의 로컬 fixture에서 aggregate count, 삭제 후보 2건, EXPLAIN WAL, ROLLBACK 후 4 rows 복구 확인
- shellcheck/actionlint — 로컬 실행 파일이 없어 미실행; 전용 정적 계약 테스트와 실제 PostgreSQL 16 fixture로 보완

## 검증 증거

UI 변경은 없습니다. production evidence는 이 PR이 main에 병합되면 승인 범위 안에서 자동 수집됩니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| workflow 계약 | Node | 전용 회귀 테스트 | 로컬 2/2 통과 | PASS |
| 배포 회귀 계약 | Node | backend deploy 테스트 포함 | 로컬 합계 11/11 통과 | PASS |
| SQL 의미 계약 | PostgreSQL 16 | aggregate fixture와 EXPLAIN/ROLLBACK | 삭제 후보 2, rollback 후 4 rows | PASS |
| production snapshot/restore | A1 self-hosted runner | main push snapshot gate | merge 후 자동 실행 | PENDING |
| owner 운영 예산 | 운영 승인 | 30초·256 MiB 근거 판정 | snapshot evidence 후 별도 확인 | PENDING |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName/versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: production 공개 route API 폐쇄 유지
- realtime contract: 변경 없음
- backend identity: 현재 배포 SHA와 image revision을 snapshot 시점에 검증

## 리뷰어 메모

- workflow_dispatch와 artifact upload가 없어 review되지 않은 branch 실행이나 backup 외부 전송이 불가능한지 확인해 주세요.
- backup은 production host의 권한 제한 경로에만 남고 raw ID·payload·사용자 데이터는 Actions evidence에 기록하지 않습니다.
- DELETE는 격리 restore DB의 명시적 transaction 안에서 EXPLAIN ANALYZE 후 ROLLBACK만 수행합니다.
- 이 PR은 V51 migration을 포함하지 않으며 owner budget 승인 전에는 V51을 확정하지 않습니다.
- V51 commit 후 PR1 backend/back-worker rollback rehearsal은 후속 PR2 완료 조건입니다.

## 리스크

- 병합 후 production DB의 논리 backup을 새로 생성하므로 I/O·disk 사용이 발생합니다. 기존 검증된 backup script와 deploy lock을 재사용하고 15분 timeout으로 제한합니다.
- 격리 restore와 EXPLAIN DELETE는 같은 host의 별도 Docker volume에서 실행되므로 CPU·I/O 부하가 발생하지만 production DB에는 DML을 실행하지 않습니다.
- production V51 실행과 production data restore는 이 PR 및 현재 승인 범위에 포함되지 않습니다.
- snapshot gate가 실패하면 marker를 완료 처리하지 않고 fail closed하며, V51 구현·승인 단계로 진행하지 않습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] 코드리뷰 결과를 확인했다.
- [ ] required CI 결과를 확인했다.
- [ ] unresolved review thread를 해소했다.
- [ ] auto-merge 후 issue 상태와 post-merge workflow를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 프로덕션 route API 검증에 퍼지 스냅샷 게이트를 추가하고, 관련 증거 검증 출력(배포 SHA)을 노출합니다.
  * 배포(CD) 시 V51 route purge 관련 마이그레이션에 대해 성공한 스냅샷 증거를 사전 확인합니다.
* **버그 수정**
  * 스냅샷 게이트 실행 중 데이터 변경을 방지하고, 백업/복원 및 리소스·여유 조건을 엄격히 검증합니다.
* **테스트**
  * 스냅샷 게이트 및 성공 워크플로우 런 검증 흐름에 대한 테스트를 확장했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->