### PR TITLE
[Fix] #1913 snapshot identity와 anomaly gate 보강

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -367,9 +367,23 @@ jobs:
 
           marker_status="$(marker_value status)"
           marker_request_sha="$(marker_value snapshot_request_sha)"
-          marker_current_sha="$(marker_value current_sha)"
+          marker_deployed_sha="$(marker_value deployed_sha)"
+          marker_image_revision="$(marker_value image_revision)"
+          marker_postgresql_major="$(marker_value postgresql_major)"
+          marker_schema_version="$(marker_value schema_version)"
+          marker_purge_sql_sha="$(marker_value purge_sql_sha256)"
           backup_file="$(marker_value backup_file)"
           marker_backup_sha="$(marker_value backup_sha256)"
+
+          current_image_revision="$(docker image inspect --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' "easysubway-backend:${CURRENT_DEPLOYED_SHA}")"
+          current_postgresql_version_num="$(docker exec easysubway-postgres sh -lc \
+            'psql -X -v ON_ERROR_STOP=1 -A -t -U "$POSTGRES_USER" "$POSTGRES_DB" -c "SHOW server_version_num;"' \
+            | tr -d '[:space:]')"
+          current_postgresql_major="${current_postgresql_version_num:0:2}"
+          current_schema_version="$(docker exec easysubway-postgres sh -lc \
+            'psql -X -v ON_ERROR_STOP=1 -A -t -U "$POSTGRES_USER" "$POSTGRES_DB" -c "SELECT version FROM flyway_schema_history WHERE success ORDER BY installed_rank DESC LIMIT 1;"' \
+            | tr -d '[:space:]')"
+          current_purge_sql_sha="$(sha256sum tools/ops/route-search-purge.sql | awk '{print $1}')"
 
           if [[ "${marker_status}" != "snapshot-complete" ]]; then
             echo "route purge snapshot marker is incomplete" >&2
@@ -379,8 +393,24 @@ jobs:
             echo "snapshot marker request SHA does not match deploy SHA" >&2
             exit 1
           fi
-          if [[ "${marker_current_sha}" != "${CURRENT_DEPLOYED_SHA}" ]]; then
+          if [[ "${marker_deployed_sha}" != "${CURRENT_DEPLOYED_SHA}" ]]; then
             echo "snapshot marker source SHA does not match current production SHA" >&2
+            exit 1
+          fi
+          if [[ "${marker_image_revision}" != "${current_image_revision}" ]]; then
+            echo "snapshot marker image revision does not match current production" >&2
+            exit 1
+          fi
+          if [[ "${marker_postgresql_major}" != "${current_postgresql_major}" ]]; then
+            echo "snapshot marker PostgreSQL major does not match current production" >&2
+            exit 1
+          fi
+          if [[ "${marker_schema_version}" != "${current_schema_version}" ]]; then
+            echo "snapshot marker schema version does not match current production" >&2
+            exit 1
+          fi
+          if [[ "${marker_purge_sql_sha}" != "${current_purge_sql_sha}" ]]; then
+            echo "snapshot marker purge SQL checksum does not match deploy target" >&2
             exit 1
           fi
           case "${backup_file}" in

--- a/.github/workflows/production-route-api-closure-evidence.yml
+++ b/.github/workflows/production-route-api-closure-evidence.yml
@@ -8,6 +8,7 @@ on:
       - ".github/workflows/production-route-api-closure-evidence.yml"
       - "tools/ci/production-route-api-closure-evidence-workflow.test.mjs"
       - "tools/ops/route-search-purge-snapshot-gate.sh"
+      - "tools/ops/route-search-purge.sql"
       - "tools/ops/postgres-backup.sh"
       - "backend/src/main/resources/db/migration/postgresql/V51__*"
       - "backend/src/main/resources/db/migration/h2/V51__*"

--- a/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
+++ b/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
@@ -5,6 +5,7 @@ import test from "node:test";
 const workflowPath = ".github/workflows/production-route-api-closure-evidence.yml";
 const cdWorkflowPath = ".github/workflows/cd.yml";
 const snapshotGatePath = "tools/ops/route-search-purge-snapshot-gate.sh";
+const purgeSqlPath = "tools/ops/route-search-purge.sql";
 
 test("production route API closure evidence는 현재 배포와 origin 403·row 불변을 검증한다", async () => {
   const workflow = await readFile(workflowPath, "utf8");
@@ -48,8 +49,10 @@ test("production route API closure evidence는 현재 배포와 origin 403·row 
 test("production snapshot gate는 main-only runner에서 backup·격리 restore·purge plan만 수집한다", async () => {
   const workflow = await readFile(workflowPath, "utf8");
   const snapshotGate = await readFile(snapshotGatePath, "utf8").catch(() => "");
+  const purgeSql = await readFile(purgeSqlPath, "utf8").catch(() => "");
 
   assert.match(workflow, /tools\/ops\/route-search-purge-snapshot-gate\.sh/);
+  assert.match(workflow, /tools\/ops\/route-search-purge\.sql/);
   assert.match(workflow, /tools\/ops\/postgres-backup\.sh/);
   assert.match(workflow, /backend\/src\/main\/resources\/db\/migration\/postgresql\/V51__/);
   assert.match(workflow, /backend\/src\/main\/resources\/db\/migration\/h2\/V51__/);
@@ -75,6 +78,12 @@ test("production snapshot gate는 main-only runner에서 backup·격리 restore�
   assert.match(snapshotGate, /snapshot-\$\{SNAPSHOT_REQUEST_SHA\}\.env/);
   assert.match(snapshotGate, /rm -f "\$\{MARKER_FILE\}"/);
   assert.match(snapshotGate, /current_sha[^\n]+!=[^\n]+EXPECTED_DEPLOYED_SHA/);
+  assert.match(snapshotGate, /purge_sql_sha256/);
+  assert.match(snapshotGate, /production_schema_version/);
+  assert.match(snapshotGate, /restore_schema_version/);
+  assert.match(snapshotGate, /cmp -s "\$\{PURGE_SQL_FILE\}"/);
+  assert.match(purgeSql, /^DELETE FROM route_search_results AS route/m);
+  assert.doesNotMatch(purgeSql, /BEGIN|EXPLAIN|ROLLBACK/);
   assert.match(snapshotGate, /tools\/ops\/postgres-backup\.sh/);
   assert.match(snapshotGate, /pg_restore/);
   assert.match(snapshotGate, /--pull never/);
@@ -105,6 +114,11 @@ test("production snapshot gate는 main-only runner에서 backup·격리 restore�
   assert.match(snapshotGate, /favorite_routes/);
   assert.match(snapshotGate, /favorite_route_stations/);
   assert.match(snapshotGate, /route_feedbacks/);
+  assert.match(snapshotGate, /favorite_routes_null/);
+  assert.match(snapshotGate, /favorite_route_stations_null/);
+  assert.match(snapshotGate, /route_feedbacks_null/);
+  assert.match(snapshotGate, /route reference NULL anomaly/);
+  assert.match(snapshotGate, /route purge aggregate invariant failed/);
   assert.match(snapshotGate, /org\.opencontainers\.image\.revision/);
   assert.match(snapshotGate, /production_image=.*\{\{\.Image\}\}/);
   assert.doesNotMatch(snapshotGate, /production_image=.*\{\{\.Config\.Image\}\}/);
@@ -114,6 +128,11 @@ test("production snapshot gate는 main-only runner에서 backup·격리 restore�
   assert.match(snapshotGate, /cat "\$\{report_file\}"/);
   assert.match(snapshotGate, /snapshot-complete/);
   assert.match(snapshotGate, /snapshot_request_sha/);
+  assert.match(snapshotGate, /deployed_sha/);
+  assert.match(snapshotGate, /image_revision/);
+  assert.match(snapshotGate, /postgresql_major/);
+  assert.match(snapshotGate, /schema_version/);
+  assert.match(snapshotGate, /purge_sql_sha256/);
   assert.doesNotMatch(snapshotGate, /existing verified backup/);
   assert.doesNotMatch(snapshotGate, /\b(curl|scp)\b|upload-artifact/);
 
@@ -154,7 +173,11 @@ test("V51 CD는 exact SHA의 성공한 snapshot gate 없이는 mutation 전에 �
   assert.match(workflow, /echo "current_sha=\$\{current_sha\}" >> "\$\{GITHUB_OUTPUT\}"/);
   assert.match(workflow, /snapshot-\$\{DEPLOY_SHA\}\.env/);
   assert.match(workflow, /marker_request_sha[^\n]+!=[^\n]+DEPLOY_SHA/);
-  assert.match(workflow, /marker_current_sha[^\n]+!=[^\n]+CURRENT_DEPLOYED_SHA/);
+  assert.match(workflow, /marker_deployed_sha[^\n]+!=[^\n]+CURRENT_DEPLOYED_SHA/);
+  assert.match(workflow, /marker_image_revision[^\n]+!=[^\n]+current_image_revision/);
+  assert.match(workflow, /marker_postgresql_major[^\n]+!=[^\n]+current_postgresql_major/);
+  assert.match(workflow, /marker_schema_version[^\n]+!=[^\n]+current_schema_version/);
+  assert.match(workflow, /marker_purge_sql_sha[^\n]+!=[^\n]+current_purge_sql_sha/);
   assert.match(workflow, /snapshot marker backup checksum mismatch/);
   assert.match(workflow, /snapshot_wait_deadline="\$\(\(SECONDS \+ 3600\)\)"/);
   assert.match(

--- a/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
+++ b/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
@@ -81,7 +81,13 @@ test("production snapshot gate는 main-only runner에서 backup·격리 restore�
   assert.match(snapshotGate, /purge_sql_sha256/);
   assert.match(snapshotGate, /production_schema_version/);
   assert.match(snapshotGate, /restore_schema_version/);
+  assert.match(snapshotGate, /shopt -s nullglob/);
+  assert.match(snapshotGate, /POSTGRES_V51_FILES=\([^\n]+V51__\*\.sql/);
+  assert.match(snapshotGate, /H2_V51_FILES=\([^\n]+V51__\*\.sql/);
+  assert.match(snapshotGate, /#POSTGRES_V51_FILES\[@\][^\n]+!= 1/);
+  assert.match(snapshotGate, /POSTGRES_V51_FILES\[0\][^\n]+!=[^\n]+POSTGRES_V51/);
   assert.match(snapshotGate, /cmp -s "\$\{PURGE_SQL_FILE\}"/);
+  assert.doesNotMatch(snapshotGate, /if \[\[ -e "\$\{POSTGRES_V51\}" \|\| -e "\$\{H2_V51\}" \]\]/);
   assert.match(purgeSql, /^DELETE FROM route_search_results AS route/m);
   assert.doesNotMatch(purgeSql, /BEGIN|EXPLAIN|ROLLBACK/);
   assert.match(snapshotGate, /tools\/ops\/postgres-backup\.sh/);

--- a/tools/ops/route-search-purge-snapshot-gate.sh
+++ b/tools/ops/route-search-purge-snapshot-gate.sh
@@ -14,6 +14,9 @@ RESTORE_PIDS_LIMIT="256"
 WAL_HEADROOM_BYTES="$((256 * 1024 * 1024))"
 MIN_OPERATIONAL_RESERVE_BYTES="$((1024 * 1024 * 1024))"
 SPACE_CLASS='[:space:]'
+PURGE_SQL_FILE="${ROOT_DIR}/tools/ops/route-search-purge.sql"
+POSTGRES_V51="${ROOT_DIR}/backend/src/main/resources/db/migration/postgresql/V51__purge_unreferenced_route_search_results.sql"
+H2_V51="${ROOT_DIR}/backend/src/main/resources/db/migration/h2/V51__purge_unreferenced_route_search_results.sql"
 
 if [[ ! "${DEPLOY_ROOT}" =~ ^/[A-Za-z0-9._/-]+$ || "${DEPLOY_ROOT}" == *..* ]]; then
 	printf 'DEPLOY_ROOT is invalid\n' >&2
@@ -30,6 +33,23 @@ fi
 if [[ ! "${SNAPSHOT_REQUEST_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
 	printf 'SNAPSHOT_REQUEST_SHA is invalid\n' >&2
 	exit 2
+fi
+if [[ ! -f "${PURGE_SQL_FILE}" ]]; then
+	printf 'canonical purge SQL is missing\n' >&2
+	exit 2
+fi
+if [[ -e "${POSTGRES_V51}" || -e "${H2_V51}" ]]; then
+	for migration in "${POSTGRES_V51}" "${H2_V51}"; do
+		if [[ ! -f "${migration}" ]] || ! cmp -s "${PURGE_SQL_FILE}" "${migration}"; then
+			printf 'V51 purge SQL differs from the analyzed canonical SQL\n' >&2
+			exit 1
+		fi
+	done
+fi
+purge_sql_sha256="$(sha256sum "${PURGE_SQL_FILE}" | awk '{print $1}')"
+if [[ ! "${purge_sql_sha256}" =~ ^[0-9a-f]{64}$ ]]; then
+	printf 'purge SQL checksum is invalid\n' >&2
+	exit 1
 fi
 
 SHARED_DIR="${DEPLOY_ROOT}/shared"
@@ -71,6 +91,14 @@ production_version_num="$(docker exec easysubway-postgres sh -lc \
 	| tr -d "${SPACE_CLASS}")"
 if [[ ! "${production_version_num}" =~ ^16[0-9]{4}$ ]]; then
 	printf 'production PostgreSQL major version is not 16\n' >&2
+	exit 1
+fi
+production_postgresql_major="${production_version_num:0:2}"
+production_schema_version="$(docker exec easysubway-postgres sh -lc \
+	'psql -X -v ON_ERROR_STOP=1 -A -t -U "$POSTGRES_USER" "$POSTGRES_DB" -c "SELECT version FROM flyway_schema_history WHERE success ORDER BY installed_rank DESC LIMIT 1;"' \
+	| tr -d "${SPACE_CLASS}")"
+if [[ ! "${production_schema_version}" =~ ^[0-9]+([.][0-9]+)*$ ]]; then
+	printf 'production Flyway schema version is invalid\n' >&2
 	exit 1
 fi
 
@@ -232,6 +260,12 @@ restore_psql() {
 		psql -X -v ON_ERROR_STOP=1 -A -t -U snapshot_gate -d easysubway_restore "$@"
 }
 
+restore_schema_version="$(restore_psql -c 'SELECT version FROM flyway_schema_history WHERE success ORDER BY installed_rank DESC LIMIT 1;' | tr -d "${SPACE_CLASS}")"
+if [[ "${restore_schema_version}" != "${production_schema_version}" ]]; then
+	printf 'restored Flyway schema version does not match production\n' >&2
+	exit 1
+fi
+
 restore_count="$(restore_psql -c 'SELECT count(*) FROM route_search_results;' | tr -d "${SPACE_CLASS}")"
 if [[ "${restore_count}" != "${source_count_before}" ]]; then
 	printf 'restored route row count does not match production backup count\n' >&2
@@ -240,20 +274,23 @@ fi
 
 counts="$(restore_psql -F '|' -c "
 WITH reference_ids AS (
-    SELECT route_search_id FROM favorite_routes
-    UNION SELECT route_search_id FROM favorite_route_stations
-    UNION SELECT route_search_id FROM route_feedbacks
+    SELECT route_search_id FROM favorite_routes WHERE route_search_id IS NOT NULL
+    UNION SELECT route_search_id FROM favorite_route_stations WHERE route_search_id IS NOT NULL
+    UNION SELECT route_search_id FROM route_feedbacks WHERE route_search_id IS NOT NULL
 ), metrics AS (
     SELECT 'route_total' AS key, count(*)::bigint AS value FROM route_search_results
-    UNION ALL SELECT 'favorite_routes_raw', count(DISTINCT route_search_id) FROM favorite_routes
+    UNION ALL SELECT 'favorite_routes_null', count(*) FROM favorite_routes WHERE route_search_id IS NULL
+    UNION ALL SELECT 'favorite_routes_raw', count(DISTINCT route_search_id) FROM favorite_routes WHERE route_search_id IS NOT NULL
     UNION ALL SELECT 'favorite_routes_preserved', count(DISTINCT favorite.route_search_id) FROM favorite_routes favorite JOIN route_search_results route USING (route_search_id)
-    UNION ALL SELECT 'favorite_routes_dangling', count(DISTINCT favorite.route_search_id) FROM favorite_routes favorite LEFT JOIN route_search_results route USING (route_search_id) WHERE route.route_search_id IS NULL
-    UNION ALL SELECT 'favorite_route_stations_raw', count(DISTINCT route_search_id) FROM favorite_route_stations
+    UNION ALL SELECT 'favorite_routes_dangling', count(DISTINCT favorite.route_search_id) FROM favorite_routes favorite LEFT JOIN route_search_results route USING (route_search_id) WHERE favorite.route_search_id IS NOT NULL AND route.route_search_id IS NULL
+    UNION ALL SELECT 'favorite_route_stations_null', count(*) FROM favorite_route_stations WHERE route_search_id IS NULL
+    UNION ALL SELECT 'favorite_route_stations_raw', count(DISTINCT route_search_id) FROM favorite_route_stations WHERE route_search_id IS NOT NULL
     UNION ALL SELECT 'favorite_route_stations_preserved', count(DISTINCT station.route_search_id) FROM favorite_route_stations station JOIN route_search_results route USING (route_search_id)
-    UNION ALL SELECT 'favorite_route_stations_dangling', count(DISTINCT station.route_search_id) FROM favorite_route_stations station LEFT JOIN route_search_results route USING (route_search_id) WHERE route.route_search_id IS NULL
-    UNION ALL SELECT 'route_feedbacks_raw', count(DISTINCT route_search_id) FROM route_feedbacks
+    UNION ALL SELECT 'favorite_route_stations_dangling', count(DISTINCT station.route_search_id) FROM favorite_route_stations station LEFT JOIN route_search_results route USING (route_search_id) WHERE station.route_search_id IS NOT NULL AND route.route_search_id IS NULL
+    UNION ALL SELECT 'route_feedbacks_null', count(*) FROM route_feedbacks WHERE route_search_id IS NULL
+    UNION ALL SELECT 'route_feedbacks_raw', count(DISTINCT route_search_id) FROM route_feedbacks WHERE route_search_id IS NOT NULL
     UNION ALL SELECT 'route_feedbacks_preserved', count(DISTINCT feedback.route_search_id) FROM route_feedbacks feedback JOIN route_search_results route USING (route_search_id)
-    UNION ALL SELECT 'route_feedbacks_dangling', count(DISTINCT feedback.route_search_id) FROM route_feedbacks feedback LEFT JOIN route_search_results route USING (route_search_id) WHERE route.route_search_id IS NULL
+    UNION ALL SELECT 'route_feedbacks_dangling', count(DISTINCT feedback.route_search_id) FROM route_feedbacks feedback LEFT JOIN route_search_results route USING (route_search_id) WHERE feedback.route_search_id IS NOT NULL AND route.route_search_id IS NULL
     UNION ALL SELECT 'reference_union_raw', count(*) FROM reference_ids
     UNION ALL SELECT 'preserved_union', count(*) FROM reference_ids reference JOIN route_search_results route USING (route_search_id)
     UNION ALL SELECT 'dangling_union', count(*) FROM reference_ids reference LEFT JOIN route_search_results route USING (route_search_id) WHERE route.route_search_id IS NULL
@@ -265,9 +302,9 @@ WITH reference_ids AS (
 SELECT key, value FROM metrics ORDER BY key;")"
 
 required_metrics=(
-	route_total favorite_routes_raw favorite_routes_preserved favorite_routes_dangling
-	favorite_route_stations_raw favorite_route_stations_preserved favorite_route_stations_dangling
-	route_feedbacks_raw route_feedbacks_preserved route_feedbacks_dangling
+	route_total favorite_routes_null favorite_routes_raw favorite_routes_preserved favorite_routes_dangling
+	favorite_route_stations_null favorite_route_stations_raw favorite_route_stations_preserved favorite_route_stations_dangling
+	route_feedbacks_null route_feedbacks_raw route_feedbacks_preserved route_feedbacks_dangling
 	reference_union_raw preserved_union dangling_union delete_candidates
 )
 for metric in "${required_metrics[@]}"; do
@@ -278,29 +315,29 @@ for metric in "${required_metrics[@]}"; do
 	fi
 	printf -v "${metric}" '%s' "${value}"
 done
+if (( favorite_routes_null != 0 || favorite_route_stations_null != 0 || route_feedbacks_null != 0 )); then
+	printf 'route reference NULL anomaly\n' >&2
+	exit 1
+fi
+if (( favorite_routes_raw != favorite_routes_preserved + favorite_routes_dangling \
+	|| favorite_route_stations_raw != favorite_route_stations_preserved + favorite_route_stations_dangling \
+	|| route_feedbacks_raw != route_feedbacks_preserved + route_feedbacks_dangling \
+	|| reference_union_raw != preserved_union + dangling_union \
+	|| route_total != preserved_union + delete_candidates \
+	|| preserved_union > route_total )); then
+	printf 'route purge aggregate invariant failed\n' >&2
+	exit 1
+fi
 
 restore_psql -c 'ANALYZE route_search_results, favorite_routes, favorite_route_stations, route_feedbacks;' >/dev/null
 
 plan_file="${EVIDENCE_DIR}/purge-plan-${backup_sha256:0:12}.txt"
 start_ns="$(date +%s%N)"
-restore_psql > "${plan_file}" <<'SQL'
-BEGIN;
-EXPLAIN (ANALYZE, BUFFERS, WAL)
-DELETE FROM route_search_results AS route
-WHERE NOT EXISTS (
-    SELECT 1 FROM favorite_routes AS favorite
-    WHERE favorite.route_search_id = route.route_search_id
-)
-AND NOT EXISTS (
-    SELECT 1 FROM favorite_route_stations AS station
-    WHERE station.route_search_id = route.route_search_id
-)
-AND NOT EXISTS (
-    SELECT 1 FROM route_feedbacks AS feedback
-    WHERE feedback.route_search_id = route.route_search_id
-);
-ROLLBACK;
-SQL
+{
+	printf 'BEGIN;\nEXPLAIN (ANALYZE, BUFFERS, WAL)\n'
+	cat "${PURGE_SQL_FILE}"
+	printf 'ROLLBACK;\n'
+} | restore_psql > "${plan_file}"
 end_ns="$(date +%s%N)"
 chmod 600 "${plan_file}"
 
@@ -351,6 +388,9 @@ snapshot_completed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 	echo "- snapshot request SHA: \`${SNAPSHOT_REQUEST_SHA}\`"
 	echo "- snapshot completed at: \`${snapshot_completed_at}\`"
 	echo "- deployed SHA: \`${current_sha}\`"
+	echo "- image revision: \`${image_revision}\`"
+	echo "- PostgreSQL major/schema: \`${production_postgresql_major}/${production_schema_version}\`"
+	echo "- purge SQL SHA-256: \`${purge_sql_sha256}\`"
 	echo "- backup SHA-256: \`${backup_sha256}\`"
 	echo "- backup bytes: \`${backup_bytes}\`"
 	echo "- source database bytes: \`${source_database_bytes}\`"
@@ -366,7 +406,8 @@ snapshot_completed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 	echo "- storage: root filesystem \`${root_filesystem}\`, Docker \`${docker_storage_driver}\`, IOPS/throughput not independently measured"
 	echo "- production settings: \`${production_settings}\`"
 	echo "- restore settings: \`${restore_settings}\`"
-	echo "- route rows production/restored/after rollback: \`${source_count_before}/${restore_count}/${rollback_count}\`"
+	echo "- route rows production before/after/restored/rollback: \`${source_count_before}/${source_count_after}/${restore_count}/${rollback_count}\`"
+	echo "- NULL references favorite_routes/favorite_route_stations/route_feedbacks: \`${favorite_routes_null}/${favorite_route_stations_null}/${route_feedbacks_null}\`"
 	echo "- favorite_routes raw/preserved/dangling: \`${favorite_routes_raw}/${favorite_routes_preserved}/${favorite_routes_dangling}\`"
 	echo "- favorite_route_stations raw/preserved/dangling: \`${favorite_route_stations_raw}/${favorite_route_stations_preserved}/${favorite_route_stations_dangling}\`"
 	echo "- route_feedbacks raw/preserved/dangling: \`${route_feedbacks_raw}/${route_feedbacks_preserved}/${route_feedbacks_dangling}\`"
@@ -395,7 +436,11 @@ marker_tmp="$(mktemp "${EVIDENCE_DIR}/snapshot.XXXXXX")"
 	printf 'status=snapshot-complete\n'
 	printf 'snapshot_request_sha=%s\n' "${SNAPSHOT_REQUEST_SHA}"
 	printf 'completed_at=%s\n' "${snapshot_completed_at}"
-	printf 'current_sha=%s\n' "${current_sha}"
+	printf 'deployed_sha=%s\n' "${current_sha}"
+	printf 'image_revision=%s\n' "${image_revision}"
+	printf 'postgresql_major=%s\n' "${production_postgresql_major}"
+	printf 'schema_version=%s\n' "${production_schema_version}"
+	printf 'purge_sql_sha256=%s\n' "${purge_sql_sha256}"
 	printf 'backup_file=%s\n' "${backup_file}"
 	printf 'backup_sha256=%s\n' "${backup_sha256}"
 	printf 'backup_bytes=%s\n' "${backup_bytes}"

--- a/tools/ops/route-search-purge-snapshot-gate.sh
+++ b/tools/ops/route-search-purge-snapshot-gate.sh
@@ -38,9 +38,18 @@ if [[ ! -f "${PURGE_SQL_FILE}" ]]; then
 	printf 'canonical purge SQL is missing\n' >&2
 	exit 2
 fi
-if [[ -e "${POSTGRES_V51}" || -e "${H2_V51}" ]]; then
+shopt -s nullglob
+POSTGRES_V51_FILES=("${ROOT_DIR}"/backend/src/main/resources/db/migration/postgresql/V51__*.sql)
+H2_V51_FILES=("${ROOT_DIR}"/backend/src/main/resources/db/migration/h2/V51__*.sql)
+shopt -u nullglob
+if (( ${#POSTGRES_V51_FILES[@]} > 0 || ${#H2_V51_FILES[@]} > 0 )); then
+	if (( ${#POSTGRES_V51_FILES[@]} != 1 || ${#H2_V51_FILES[@]} != 1 )) \
+		|| [[ "${POSTGRES_V51_FILES[0]}" != "${POSTGRES_V51}" || "${H2_V51_FILES[0]}" != "${H2_V51}" ]]; then
+		printf 'unexpected V51 migration set\n' >&2
+		exit 1
+	fi
 	for migration in "${POSTGRES_V51}" "${H2_V51}"; do
-		if [[ ! -f "${migration}" ]] || ! cmp -s "${PURGE_SQL_FILE}" "${migration}"; then
+		if ! cmp -s "${PURGE_SQL_FILE}" "${migration}"; then
 			printf 'V51 purge SQL differs from the analyzed canonical SQL\n' >&2
 			exit 1
 		fi

--- a/tools/ops/route-search-purge.sql
+++ b/tools/ops/route-search-purge.sql
@@ -1,0 +1,13 @@
+DELETE FROM route_search_results AS route
+WHERE NOT EXISTS (
+    SELECT 1 FROM favorite_routes AS favorite
+    WHERE favorite.route_search_id = route.route_search_id
+)
+AND NOT EXISTS (
+    SELECT 1 FROM favorite_route_stations AS station
+    WHERE station.route_search_id = route.route_search_id
+)
+AND NOT EXISTS (
+    SELECT 1 FROM route_feedbacks AS feedback
+    WHERE feedback.route_search_id = route.route_search_id
+);


### PR DESCRIPTION
## 관련 이슈

Refs #1913

## 작업 배경

- #2146 병합 직후 #1913의 완료 계약에 snapshot marker 전체 identity 결합, NULL/dangling anomaly invariant, 분석 DELETE와 V51의 SQL hash drift 차단이 추가되었습니다.
- 갱신 전 계약으로 시작된 production snapshot run은 backup·restore 전에 취소했으며, V51 또는 production DELETE는 실행하지 않았습니다.

## 작업 내용

- 일회성 purge의 정본 SQL을 `tools/ops/route-search-purge.sql`로 분리했습니다.
- snapshot marker를 deployed SHA, image revision, PostgreSQL major/Flyway schema version, backup SHA-256, purge SQL SHA-256에 결합했습니다.
- CD가 marker를 소비하기 전에 production identity와 canonical SQL hash를 모두 다시 계산해 완전 일치를 요구합니다.
- 참조 테이블별 non-null raw/preserved/dangling count와 NULL count를 수집하고, #1913의 모든 aggregate invariant를 fail-closed로 검증합니다.
- 향후 PostgreSQL/H2 V51이 추가되면 두 migration이 canonical SQL과 byte-for-byte 동일해야 snapshot gate가 통과합니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/backend-deploy.test.mjs tools/ci/production-route-api-closure-evidence-workflow.test.mjs tools/ci/require-successful-workflow-run.test.mjs tools/ci/repository-contract.test.mjs` — 208/208 PASS
  - `bash -n tools/ops/route-search-purge-snapshot-gate.sh` — PASS
  - Ruby YAML parse: `.github/workflows/cd.yml`, `.github/workflows/production-route-api-closure-evidence.yml` — PASS
  - `git diff --check` — PASS

## 검증 증거

UI, 접근성, 수동 QA 변경이 없는 운영 gate 변경입니다. production snapshot/backup/restore와 V51은 이 PR 검증에서 실행하지 않았습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| repository/배포 계약 | Node.js | 관련 계약 테스트 | 208/208 PASS | PASS |
| shell/YAML 구문 | macOS runner | `bash -n`, Ruby YAML parse | 명령 exit 0 | PASS |
| 갱신 전 snapshot 중단 | GitHub Actions | run 상태 및 job 미실행 확인 | https://github.com/AquilaXk/easysubway/actions/runs/29387518284 | PASS |
| production DB mutation 없음 | production | V51 부재 및 snapshot job 미실행 확인 | purge migration 미포함 | PASS |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: production public route API exact 403 계약 변경 없음
- realtime contract: 변경 없음
- backend identity: merge SHA 기준으로 새 image가 생성되며 V51은 포함하지 않음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - marker 소비 시 모든 identity를 현재 production에서 재계산하는지
  - NULL/dangling/preserve/delete invariant가 #1913 본문과 정확히 일치하는지
  - canonical SQL과 향후 두 V51 migration의 byte drift가 fail-closed인지

## 리스크

- identity 검증이 누락되면 stale snapshot marker가 다른 image/schema/SQL에 재사용될 수 있습니다.
- count invariant가 잘못되면 보존 대상 삭제 후보를 승인할 수 있으므로 모든 anomaly에서 marker 생성 전 중단합니다.
- rollback: V51이 아직 없으므로 이 PR을 revert하면 코드만 원복됩니다. production data restore는 수행하지 않습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 경로 검색 데이터 정리 작업의 검증을 강화해 이미지, 데이터베이스, 스키마, SQL 무결성을 종합적으로 확인합니다.
  * 정리 작업 전후의 백업·복원 결과와 NULL·고아 참조 등 데이터 이상 징후를 추가로 점검합니다.
  * 정리 작업의 실행 증거와 메타데이터를 더욱 상세히 기록합니다.
  * 관련 SQL 변경 시 운영 검증 워크플로가 자동으로 실행됩니다.
  * 불필요한 경로 검색 결과를 관련 참조가 없는 경우 자동으로 정리합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->