### PR TITLE
[Fix] #1913 snapshot restore 초기화 race 차단

### DIFF
--- a/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
+++ b/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
@@ -92,6 +92,8 @@ test("production snapshot gate는 main-only runner에서 backup·격리 restore�
   assert.doesNotMatch(purgeSql, /BEGIN|EXPLAIN|ROLLBACK/);
   assert.match(snapshotGate, /tools\/ops\/postgres-backup\.sh/);
   assert.match(snapshotGate, /pg_restore/);
+  assert.match(snapshotGate, /cat \/proc\/1\/comm/);
+  assert.match(snapshotGate, /restore_init_process[^\n]+==[^\n]+postgres/);
   assert.match(snapshotGate, /--pull never/);
   assert.match(snapshotGate, /--cpus "\$\{RESTORE_CPU_LIMIT\}"/);
   assert.match(snapshotGate, /--memory "\$\{RESTORE_MEMORY_LIMIT\}"/);
@@ -114,6 +116,10 @@ test("production snapshot gate는 main-only runner에서 backup·격리 restore�
   assert.ok(
     snapshotGate.indexOf("ANALYZE route_search_results") < snapshotGate.indexOf("EXPLAIN (ANALYZE, BUFFERS, WAL)"),
     "restored purge tables must be analyzed before the measured plan",
+  );
+  assert.ok(
+    snapshotGate.indexOf("cat /proc/1/comm") < snapshotGate.indexOf("pg_restore"),
+    "restore must wait for the final PostgreSQL server, not the temporary init server",
   );
   assert.match(snapshotGate, /EXPLAIN \(ANALYZE, BUFFERS, WAL/);
   assert.match(snapshotGate, /ROLLBACK/);

--- a/tools/ops/route-search-purge-snapshot-gate.sh
+++ b/tools/ops/route-search-purge-snapshot-gate.sh
@@ -249,7 +249,9 @@ docker run -d --rm --pull never \
 
 ready=false
 for _ in $(seq 1 60); do
-	if docker exec "${restore_container}" pg_isready -U snapshot_gate -d easysubway_restore >/dev/null 2>&1; then
+	restore_init_process="$(docker exec "${restore_container}" cat /proc/1/comm 2>/dev/null || true)"
+	if [[ "${restore_init_process}" == "postgres" ]] \
+		&& docker exec "${restore_container}" pg_isready -U snapshot_gate -d easysubway_restore >/dev/null 2>&1; then
 		ready=true
 		break
 	fi


### PR DESCRIPTION
## 관련 이슈

Refs #1913

## 작업 배경

- Production snapshot gate run `29388792633`에서 격리 restore가 실패했습니다.
- production과 동일한 PostGIS image는 초기화 중 임시 PostgreSQL server를 띄운 뒤 종료하고 최종 server를 다시 시작합니다. 기존 `pg_isready` 단독 조건은 임시 server도 ready로 판정해 `pg_restore`가 image init과 경쟁했습니다.
- 실패 로그의 `postgis_topology` 중복 생성과 직후 connection 종료가 이 race와 일치하며, production DELETE나 V51 실행은 발생하지 않았습니다.

## 작업 내용

- 격리 restore readiness를 `PID 1 == postgres`와 `pg_isready`의 동시 충족으로 강화했습니다.
- 최종 PostgreSQL server로 전환되기 전에는 `pg_restore`를 시작하지 않는 contract test를 추가했습니다.
- backup, purge SQL, row/invariant, marker identity 계약은 변경하지 않았습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/production-route-api-closure-evidence-workflow.test.mjs`: RED 2/3 후 GREEN 3/3
  - `node --test tools/ci/*.test.mjs`: 281/281 PASS
  - `bash -n tools/ops/route-search-purge-snapshot-gate.sh`: PASS
  - `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/production-route-api-closure-evidence.yml')"`: PASS
  - `git diff --check`: PASS
  - production과 동일한 PostGIS digest의 network-none 로컬 container 관찰: `temporary_ready_seen=true`, `final_ready_seen=true`

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 기존 production failure | GitHub Actions | snapshot job 실패 로그 확인 | https://github.com/AquilaXk/easysubway/actions/runs/29388792633/job/87267503647 | `postgis_topology` init 충돌과 connection 종료 확인 |
| entrypoint 전환 | local Docker | 동일 image digest, `--network none`, PID 1/ready 상태 관찰 | sanitized aggregate `temporary_ready_seen=true`, `final_ready_seen=true` | PASS |
| 회귀 계약 | Node test | final PID 1 확인이 `pg_restore`보다 앞서는지 검증 | 3/3 및 전체 281/281 | PASS |
| 독립 코드리뷰 | GitHub Review | Codex CLI plugin-disabled fresh review | https://github.com/AquilaXk/easysubway/pull/2148#pullrequestreview-4700847143 | actionable 0 |
| PR CI | GitHub Actions | ready 전환 후 current head 전체 required checks | https://github.com/AquilaXk/easysubway/actions/runs/29389392397 | PASS |
| production snapshot retry | GitHub Actions | merge 후 owner 승인 범위의 backup·격리 restore·ROLLBACK gate | 후속 run URL 기록 예정 | 대기 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: production endpoint exact 403 계약 변경 없음
- realtime contract: 변경 없음
- backend identity: merge SHA로 갱신 예정

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `tools/ops/route-search-purge-snapshot-gate.sh`의 readiness loop가 임시 init server를 통과시키지 않으면서 최종 server에서는 정상 진입하는지 확인해 주세요.
- image entrypoint가 바뀌어 PID 1 contract가 달라지면 60초 후 fail closed하며 restore와 production mutation은 시작되지 않습니다.

## 리스크

- 동일 image의 entrypoint가 최종 process를 `postgres`가 아닌 이름으로 바꾸면 snapshot gate가 보수적으로 실패합니다. 이 경우 새 image 계약을 별도 검증해야 합니다.
- 이 PR은 production backup·격리 restore 재시도를 가능하게 하지만 V51, production DELETE, production data restore를 승인하거나 실행하지 않습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
