### PR TITLE
[Fix] #1913 PostGIS restore schema 충돌 정리

### DIFF
--- a/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
+++ b/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
@@ -91,7 +91,7 @@ test("production snapshot gate는 main-only runner에서 backup·격리 restore�
   assert.match(purgeSql, /^DELETE FROM route_search_results AS route/m);
   assert.doesNotMatch(purgeSql, /BEGIN|EXPLAIN|ROLLBACK/);
   assert.match(snapshotGate, /tools\/ops\/postgres-backup\.sh/);
-  assert.match(snapshotGate, /pg_restore/);
+  assert.match(snapshotGate, /pg_restore --clean --if-exists --no-owner --no-privileges/);
   assert.match(snapshotGate, /cat \/proc\/1\/comm/);
   assert.match(snapshotGate, /restore_init_process[^\n]+==[^\n]+postgres/);
   assert.match(snapshotGate, /--pull never/);

--- a/tools/ops/route-search-purge-snapshot-gate.sh
+++ b/tools/ops/route-search-purge-snapshot-gate.sh
@@ -263,7 +263,7 @@ if [[ "${ready}" != "true" ]]; then
 fi
 
 docker exec -i "${restore_container}" \
-	pg_restore --no-owner --no-privileges -U snapshot_gate -d easysubway_restore \
+	pg_restore --clean --if-exists --no-owner --no-privileges -U snapshot_gate -d easysubway_restore \
 	< "${backup_file}"
 
 restore_psql() {


### PR DESCRIPTION
## 관련 이슈

Refs #1913

## 작업 배경

- PR #2148에서 restore init race를 차단한 뒤 production snapshot run `29389970364`가 최종 PostgreSQL server까지 정상 대기했습니다.
- 그 다음 `pg_restore`가 PostGIS image bootstrap이 미리 만든 `tiger`, `tiger_data`, `topology` schema와 backup TOC의 동일 schema 생성에서 충돌했습니다.
- production DELETE, V51, data restore는 실행되지 않았고 snapshot success marker도 발행되지 않았습니다.

## 작업 내용

- network-none 격리 restore의 `pg_restore`에 `--clean --if-exists`를 추가해 image bootstrap object를 backup TOC 기준으로 정리한 뒤 복원합니다.
- 같은 옵션 조합을 contract test로 고정했습니다.
- production DB, backup 생성, purge SQL, row/invariant, marker identity 로직은 변경하지 않았습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/production-route-api-closure-evidence-workflow.test.mjs`: RED 2/3 후 GREEN 3/3
  - `node --test tools/ci/*.test.mjs`: 281/281 PASS
  - `bash -n tools/ops/route-search-purge-snapshot-gate.sh`: PASS
  - `git diff --check`: PASS
  - 동일 PostGIS digest의 source/destination network-none 로컬 container restore: 기본 옵션 exit 1, `--clean --if-exists` exit 0

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| production failure | GitHub Actions | snapshot failure log 확인 | https://github.com/AquilaXk/easysubway/actions/runs/29389970364/job/87271049278 | PostGIS bootstrap schema 3개 충돌 확인 |
| restore 옵션 비교 | local Docker | 동일 digest의 source/destination, `--network none` | sanitized status `default=1`, `clean=0` | PASS |
| 회귀 계약 | Node test | `pg_restore --clean --if-exists` 고정 | focused 3/3, 전체 281/281 | PASS |
| production snapshot retry | GitHub Actions | merge 후 승인 범위의 backup·격리 restore·EXPLAIN/ROLLBACK gate | 후속 run URL 기록 예정 | 대기 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: production endpoint exact 403 계약 변경 없음
- realtime contract: 변경 없음
- backend identity: merge SHA로 갱신 예정

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `--clean --if-exists`가 production이 아닌 새 network-none restore volume에만 적용되는지 확인해 주세요.
- backup TOC에 포함된 object만 정리하며 실패 시 marker를 남기지 않고 gate가 중단됩니다.

## 리스크

- backup TOC dependency가 정리할 수 없는 외부 object를 포함하면 restore가 fail closed합니다.
- 이 PR은 snapshot rehearsal만 수정하며 V51, production DELETE, production data restore를 승인하거나 실행하지 않습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
