### PR TITLE
[Fix] V51 배포 전에 Node 설치

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -215,6 +215,11 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: CD Deploy / Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24"
+
       - name: CD Deploy / Resolve deployment target
         id: target
         shell: bash

--- a/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
+++ b/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
@@ -201,6 +201,11 @@ test("production snapshot gate는 main-only runner에서 backup·격리 restore�
 test("V51 CD는 exact SHA의 성공한 snapshot gate 없이는 mutation 전에 중단한다", async () => {
   const workflow = await readFile(cdWorkflowPath, "utf8");
 
+  assert.match(workflow, /CD Deploy \/ Set up Node\.js/);
+  assert.match(
+    workflow,
+    /CD Deploy \/ Set up Node\.js[\s\S]*?actions\/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e[\s\S]*?node-version: "24"/,
+  );
   assert.match(workflow, /CD Deploy \/ Detect route purge migration/);
   assert.match(
     workflow,
@@ -243,12 +248,15 @@ test("V51 CD는 exact SHA의 성공한 snapshot gate 없이는 mutation 전에 �
   assert.match(workflow, /while true; do[\s\S]*?require-successful-workflow-run\.mjs[\s\S]*?break[\s\S]*?sleep 15[\s\S]*?done/);
 
   const rangeDetectionIndex = workflow.indexOf('git diff --name-only "${current_sha}" "${DEPLOY_SHA}"');
+  const nodeSetupIndex = workflow.indexOf("CD Deploy / Set up Node.js");
   const latchIndex = workflow.indexOf("CD Deploy / Require route purge snapshot evidence");
   const mutationPreparationIndex = workflow.indexOf("CD Deploy / Restore GitHub Actions dotenv secret");
 
   assert.notEqual(rangeDetectionIndex, -1);
+  assert.notEqual(nodeSetupIndex, -1);
   assert.notEqual(latchIndex, -1);
   assert.notEqual(mutationPreparationIndex, -1);
+  assert.ok(nodeSetupIndex < latchIndex, "Node.js must be available before the snapshot evidence gate");
   assert.ok(latchIndex < mutationPreparationIndex, "snapshot evidence must gate production mutation");
 });
 

--- a/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
+++ b/tools/ci/production-route-api-closure-evidence-workflow.test.mjs
@@ -201,11 +201,15 @@ test("production snapshot gate는 main-only runner에서 backup·격리 restore�
 test("V51 CD는 exact SHA의 성공한 snapshot gate 없이는 mutation 전에 중단한다", async () => {
   const workflow = await readFile(cdWorkflowPath, "utf8");
 
-  assert.match(workflow, /CD Deploy \/ Set up Node\.js/);
+  const nodeSetupStep = workflow.match(
+    /- name: CD Deploy \/ Set up Node\.js[\s\S]*?(?=\n\s+- name:)/,
+  )?.[0] ?? "";
+  assert.notEqual(nodeSetupStep, "", "the CD Deploy Node.js setup step must exist");
   assert.match(
-    workflow,
-    /CD Deploy \/ Set up Node\.js[\s\S]*?actions\/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e[\s\S]*?node-version: "24"/,
+    nodeSetupStep,
+    /uses: actions\/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e/,
   );
+  assert.match(nodeSetupStep, /node-version: "24"/);
   assert.match(workflow, /CD Deploy \/ Detect route purge migration/);
   assert.match(
     workflow,


### PR DESCRIPTION
## 관련 이슈

Refs #1913

## 작업 배경

- V51 배포 run `29399988349`가 production mutation 이전의 snapshot evidence gate에서 중단되었습니다.
- self-hosted production runner에 `node`가 없어 `require-successful-workflow-run.mjs`를 실행하지 못했고, 반복 대기 후 run을 안전하게 취소했습니다. V51 실행, row 삭제, container 교체는 발생하지 않았습니다.

## 작업 내용

- `CD Deploy` job에 pinned `actions/setup-node`와 Node.js 24 설치 단계를 추가했습니다.
- Node 설치가 route purge snapshot evidence gate보다 먼저 실행되는지 workflow 계약 테스트로 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/production-route-api-closure-evidence-workflow.test.mjs` — 수정 전 신규 assertion 실패, 수정 후 PASS
  - `node --test tools/ci/production-route-api-closure-evidence-workflow.test.mjs tools/ci/repository-contract.test.mjs` — 198/198 PASS
  - `git diff --check` — PASS

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| production mutation 선행 여부 | GitHub Actions / production runner | 실패 run의 job·step 상태와 로그 확인 | run `29399988349`: snapshot evidence gate에서 실패, rehearsal/local/remote deploy 미실행 | PASS — production 변경 없음 |
| Node 설치 순서 | Node.js workflow contract | setup action/version 및 snapshot gate 선행 순서 assertion | `production-route-api-closure-evidence-workflow.test.mjs` | PASS |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: production route API exact 403 계약 변경 없음
- realtime contract: 변경 없음
- backend identity: 병합 SHA 기반 새 deployment image 생성 예정

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `CD Deploy / Set up Node.js`가 `CD Deploy / Require route purge snapshot evidence`보다 먼저 실행되고 action SHA와 Node major가 저장소의 기존 post-deploy 기준과 같은지 확인해 주세요.

## 리스크

- workflow-only 최소 수정입니다. setup action 실패 시 snapshot gate와 production mutation 전에 fail closed합니다.
- 병합 후 새 main SHA에 결합된 snapshot marker를 다시 생성해야 하며, 그 전에는 V51 배포가 진행되지 않습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 배포 과정에서 Node.js 24 실행 환경을 자동으로 준비하도록 개선했습니다.
  * 배포 전 검증 단계가 필요한 런타임을 안정적으로 사용할 수 있도록 실행 순서를 보완했습니다.
* **테스트**
  * Node.js 설정 단계의 버전, 인증된 액션 사용 여부 및 검증 단계보다 먼저 실행되는지를 확인하도록 테스트를 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->