### PR TITLE
[Fix] #1908 하차 알림 foreground 경로 정체성 방어

### DIFF
--- a/apps/mobile/lib/features/get_off_alarm/get_off_alarm_controller.dart
+++ b/apps/mobile/lib/features/get_off_alarm/get_off_alarm_controller.dart
@@ -36,6 +36,8 @@ class GetOffAlarmState {
   static const GetOffAlarmState off = GetOffAlarmState();
 }
 
+enum GetOffAlarmRefreshResult { refreshed, routeMismatch, skipped }
+
 /// 하차 알림 엔진을 화면·수명주기와 연결하는 오케스트레이션 컨트롤러.
 ///
 /// 순수 계산([computeGetOffAlarms])·강등 판정([resolveGetOffAlarmScheduleMode])·
@@ -164,32 +166,41 @@ class GetOffAlarmController extends ChangeNotifier {
   }
 
   /// 실시간 보정(#1416)·포그라운드 복귀 시 갱신된 도착 시각으로 재예약한다.
-  Future<void> refresh({
+  Future<GetOffAlarmRefreshResult> refresh({
+    required String routeId,
     required List<GetOffAlarmStop> stops,
-    required bool transferAlarmEnabled,
-  }) => _enqueueMutation(
-    () => _refresh(stops: stops, transferAlarmEnabled: transferAlarmEnabled),
-  );
+  }) => _enqueueMutation(() => _refresh(routeId: routeId, stops: stops));
 
-  Future<void> _refresh({
+  Future<GetOffAlarmRefreshResult> _refresh({
+    required String routeId,
     required List<GetOffAlarmStop> stops,
-    required bool transferAlarmEnabled,
   }) async {
-    final routeId = _state.activeRouteId;
-    if (!_state.enabled || routeId == null) {
-      return;
+    if (!_state.enabled) {
+      return GetOffAlarmRefreshResult.skipped;
+    }
+    final activeRouteId = _state.activeRouteId;
+    final subscription = await repository.loadActive();
+    if (subscription == null ||
+        activeRouteId == null ||
+        subscription.routeId != activeRouteId ||
+        activeRouteId != routeId) {
+      return GetOffAlarmRefreshResult.routeMismatch;
+    }
+    if (stops.isEmpty) {
+      await _turnOff();
+      return GetOffAlarmRefreshResult.refreshed;
     }
     final hasDestination = stops.any(
       (stop) => stop.kind == GetOffAlarmKind.destination,
     );
     if (!hasDestination) {
-      return;
+      return GetOffAlarmRefreshResult.skipped;
     }
     final notificationPermission = await notificationPermissionProvider
         .notificationPermissionStatus();
     if (notificationPermission != NotificationPermissionStatus.granted) {
       await _turnOff(permissionNotice: notificationPermissionDeniedNotice);
-      return;
+      return GetOffAlarmRefreshResult.refreshed;
     }
     final permitted = await permissionGate.isExactAlarmPermitted();
     final resolution = resolveGetOffAlarmScheduleMode(
@@ -198,9 +209,10 @@ class GetOffAlarmController extends ChangeNotifier {
     await _schedule(
       routeId: routeId,
       stops: stops,
-      transferAlarmEnabled: transferAlarmEnabled,
+      transferAlarmEnabled: subscription.transferAlarmEnabled,
       resolution: resolution,
     );
+    return GetOffAlarmRefreshResult.refreshed;
   }
 
   Future<void> _schedule({
@@ -249,7 +261,7 @@ class GetOffAlarmController extends ChangeNotifier {
   /// 경로 탐색 시 호출한다.
   Future<void> disable() => _enqueueMutation(_turnOff);
 
-  Future<void> _enqueueMutation(Future<void> Function() mutation) {
+  Future<T> _enqueueMutation<T>(Future<T> Function() mutation) {
     final result = _mutationTail.then((_) => mutation());
     _mutationTail = result.then<void>(
       (_) {},

--- a/apps/mobile/lib/features/get_off_alarm/get_off_alarm_controller.dart
+++ b/apps/mobile/lib/features/get_off_alarm/get_off_alarm_controller.dart
@@ -184,6 +184,13 @@ class GetOffAlarmController extends ChangeNotifier {
         activeRouteId == null ||
         subscription.routeId != activeRouteId ||
         activeRouteId != routeId) {
+      if (kDebugMode) {
+        debugPrint(
+          'get_off_alarm refresh route_mismatch '
+          'subscription_route_id=${subscription?.routeId} '
+          'active_route_id=$activeRouteId input_route_id=$routeId',
+        );
+      }
       return GetOffAlarmRefreshResult.routeMismatch;
     }
     if (stops.isEmpty) {

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -2719,8 +2719,8 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
           : destination.arrivalAt.difference(previousArrivalAt).inSeconds;
       final changed = previousArrivalAt != null && deltaSeconds != 0;
       await getOffAlarmController.refresh(
+        routeId: result.routeSearchId,
         stops: stops,
-        transferAlarmEnabled: activeSubscription?.transferAlarmEnabled ?? true,
       );
       if (kDebugMode && getOffAlarmController.state.enabled) {
         debugPrint(

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -2653,6 +2653,9 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
         result == null) {
       return;
     }
+    if (getOffAlarmController.state.activeRouteId != result.routeSearchId) {
+      return;
+    }
     final rideLegs = _rideLegArrivalsFromResult(result);
     final source =
         outcome.refreshed &&
@@ -2662,7 +2665,10 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
     try {
       final activeSubscription = await getOffAlarmController.repository
           .loadActive();
-      if (!mounted) {
+      if (!mounted ||
+          !getOffAlarmController.state.enabled ||
+          getOffAlarmController.state.activeRouteId != result.routeSearchId ||
+          activeSubscription?.routeId != result.routeSearchId) {
         return;
       }
       final activeStationNames = <String, String>{

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -2654,18 +2654,6 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
       return;
     }
     final rideLegs = _rideLegArrivalsFromResult(result);
-    if (rideLegs.isEmpty) {
-      if (outcome.refreshed) {
-        final disabled = await _disableActiveGetOffAlarm();
-        if (!disabled) {
-          _rollbackRouteAfterAlarmFailure(
-            previousState: previousState,
-            expectedCurrentResult: result,
-          );
-        }
-      }
-      return;
-    }
     final source =
         outcome.refreshed &&
             rideLegs.any((leg) => leg.realtimeArrivalIso?.isNotEmpty ?? false)
@@ -2712,16 +2700,19 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
         stationName: (id) => stationNames[id]!,
         source: source,
       );
-      final destination = stops.last;
       final previousArrivalAt = activeSubscription?.destination.arrivalAt;
-      final deltaSeconds = previousArrivalAt == null
+      final deltaSeconds = previousArrivalAt == null || stops.isEmpty
           ? 0
-          : destination.arrivalAt.difference(previousArrivalAt).inSeconds;
-      final changed = previousArrivalAt != null && deltaSeconds != 0;
-      await getOffAlarmController.refresh(
+          : stops.last.arrivalAt.difference(previousArrivalAt).inSeconds;
+      final changed =
+          previousArrivalAt != null && stops.isNotEmpty && deltaSeconds != 0;
+      final refreshResult = await getOffAlarmController.refresh(
         routeId: result.routeSearchId,
         stops: stops,
       );
+      if (refreshResult == GetOffAlarmRefreshResult.routeMismatch) {
+        return;
+      }
       if (kDebugMode && getOffAlarmController.state.enabled) {
         debugPrint(
           'get_off_alarm foreground_refresh changed=$changed '

--- a/apps/mobile/test/features/get_off_alarm/get_off_alarm_controller_test.dart
+++ b/apps/mobile/test/features/get_off_alarm/get_off_alarm_controller_test.dart
@@ -60,6 +60,7 @@ class _RecordingStateRepository implements GetOffAlarmStateRepository {
   Object? saveError;
   Object? clearError;
   int clearCount = 0;
+  int saveCount = 0;
 
   @override
   Future<void> clearActive() async {
@@ -82,12 +83,28 @@ class _RecordingStateRepository implements GetOffAlarmStateRepository {
 
   @override
   Future<void> saveActive(GetOffAlarmSubscription subscription) async {
+    saveCount += 1;
     final error = saveError;
     if (error != null) {
       throw error;
     }
     active = subscription;
   }
+}
+
+GetOffAlarmSubscription _withRouteId(
+  GetOffAlarmSubscription subscription,
+  String routeId,
+) {
+  return GetOffAlarmSubscription(
+    routeId: routeId,
+    transferAlarmEnabled: subscription.transferAlarmEnabled,
+    scheduledCount: subscription.scheduledCount,
+    scheduleMode: subscription.scheduleMode,
+    inexactNotice: subscription.inexactNotice,
+    destination: subscription.destination,
+    transfers: subscription.transfers,
+  );
 }
 
 class _StubExactAlarmGate implements ExactAlarmPermissionGate {
@@ -392,7 +409,7 @@ void main() {
     expect(exactAlarmGate.isPermittedCalls, 0);
 
     exactAlarmGate.permitted = false;
-    await c.refresh(stops: stops(), transferAlarmEnabled: true);
+    await c.refresh(routeId: 'r1', stops: stops());
 
     expect(exactAlarmGate.requestCalls, 1);
     expect(exactAlarmGate.isPermittedCalls, 1);
@@ -416,7 +433,7 @@ void main() {
     await c.enable(routeId: 'r1', stops: stops(), transferAlarmEnabled: true);
     permission.status = NotificationPermissionStatus.denied;
 
-    await c.refresh(stops: stops(), transferAlarmEnabled: true);
+    await c.refresh(routeId: 'r1', stops: stops());
 
     expect(permission.requestCalls, 1);
     expect(permission.statusCalls, 1);
@@ -446,6 +463,7 @@ void main() {
     final cancelCallsBeforeRefresh = notifier.cancelAllCount;
 
     await c.refresh(
+      routeId: 'r1',
       stops: [
         GetOffAlarmStop(
           stationId: 'transfer',
@@ -454,7 +472,6 @@ void main() {
           kind: GetOffAlarmKind.transfer,
         ),
       ],
-      transferAlarmEnabled: true,
     );
 
     expect(notifier.scheduleCalls, scheduleCallsBeforeRefresh);
@@ -462,6 +479,111 @@ void main() {
     expect(c.state, same(stateBeforeRefresh));
     expect(stateRepository.active, same(subscriptionBeforeRefresh));
     expect(gate.isPermittedCalls, 0);
+  });
+
+  for (final mismatch in [
+    (
+      name: 'persisted route만 다르면',
+      controllerRouteId: 'r1',
+      persistedRouteId: 'r2',
+      inputRouteId: 'r1',
+    ),
+    (
+      name: 'controller route만 다르면',
+      controllerRouteId: 'r2',
+      persistedRouteId: 'r1',
+      inputRouteId: 'r1',
+    ),
+    (
+      name: '입력 route만 다르면',
+      controllerRouteId: 'r1',
+      persistedRouteId: 'r1',
+      inputRouteId: 'r2',
+    ),
+  ]) {
+    test('refresh는 ${mismatch.name} routeMismatch로 기존 알림과 구독을 보존한다', () async {
+      final stateRepository = _RecordingStateRepository();
+      final c = GetOffAlarmController(
+        notifier: notifier,
+        permissionGate: _StubExactAlarmGate(true),
+        notificationPermissionProvider: _StubNotificationPermissionProvider(
+          NotificationPermissionStatus.granted,
+        ),
+        repository: stateRepository,
+        now: () => now,
+      );
+      addTearDown(c.dispose);
+      await c.enable(
+        routeId: mismatch.controllerRouteId,
+        stops: stops(),
+        transferAlarmEnabled: true,
+      );
+      stateRepository.active = _withRouteId(
+        stateRepository.active!,
+        mismatch.persistedRouteId,
+      );
+      final subscriptionBefore = stateRepository.active;
+      final pendingBefore = List<ScheduledGetOffAlarm>.of(
+        notifier.scheduledAlarms!,
+      );
+      final scheduleCallsBefore = notifier.scheduleCalls;
+      final cancelCallsBefore = notifier.cancelAllCount;
+      final saveCallsBefore = stateRepository.saveCount;
+      final clearCallsBefore = stateRepository.clearCount;
+
+      final result = await c.refresh(
+        routeId: mismatch.inputRouteId,
+        stops: stops(),
+      );
+
+      expect(result, GetOffAlarmRefreshResult.routeMismatch);
+      expect(notifier.scheduleCalls, scheduleCallsBefore);
+      expect(notifier.cancelAllCount, cancelCallsBefore);
+      expect(stateRepository.saveCount, saveCallsBefore);
+      expect(stateRepository.clearCount, clearCallsBefore);
+      expect(stateRepository.active, same(subscriptionBefore));
+      expect(notifier.scheduledAlarms, pendingBefore);
+    });
+  }
+
+  test('route 전환 뒤 queued된 이전 route refresh는 routeMismatch로 거부한다', () async {
+    final gate = _BlockingRefreshExactAlarmGate();
+    final stateRepository = _RecordingStateRepository();
+    final c = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: gate,
+      notificationPermissionProvider: _StubNotificationPermissionProvider(
+        NotificationPermissionStatus.granted,
+      ),
+      repository: stateRepository,
+      now: () => now,
+    );
+    addTearDown(c.dispose);
+    await c.enable(routeId: 'r1', stops: stops(), transferAlarmEnabled: true);
+
+    final inFlight = c.refresh(routeId: 'r1', stops: stops());
+    await gate.isPermittedStarted.future;
+    final transition = c.enable(
+      routeId: 'r2',
+      stops: stops(),
+      transferAlarmEnabled: false,
+    );
+    final stale = c.refresh(routeId: 'r1', stops: stops());
+    gate.permitted.complete(true);
+
+    expect(await inFlight, GetOffAlarmRefreshResult.refreshed);
+    await transition;
+    final scheduleCallsBeforeStale = notifier.scheduleCalls;
+    final saveCallsBeforeStale = stateRepository.saveCount;
+    expect(await stale, GetOffAlarmRefreshResult.routeMismatch);
+
+    expect(notifier.scheduleCalls, scheduleCallsBeforeStale);
+    expect(notifier.cancelAllCount, 0);
+    expect(stateRepository.saveCount, saveCallsBeforeStale);
+    expect(stateRepository.clearCount, 0);
+    expect(stateRepository.active?.routeId, 'r2');
+    expect(stateRepository.active?.transferAlarmEnabled, isFalse);
+    expect(c.state.activeRouteId, 'r2');
   });
 
   test('예약 성공이 0건이면 enabled와 활성 구독을 저장하지 않는다', () async {
@@ -676,7 +798,7 @@ void main() {
     addTearDown(c.dispose);
     await c.enable(routeId: 'r1', stops: stops(), transferAlarmEnabled: true);
 
-    final refresh = c.refresh(stops: stops(), transferAlarmEnabled: true);
+    final refresh = c.refresh(routeId: 'r1', stops: stops());
     await gate.isPermittedStarted.future;
     final disable = c.disable();
     gate.permitted.complete(true);
@@ -706,7 +828,7 @@ void main() {
 
     final disable = c.disable();
     await Future<void>.delayed(Duration.zero);
-    final refresh = c.refresh(stops: stops(), transferAlarmEnabled: true);
+    final refresh = c.refresh(routeId: 'r1', stops: stops());
     await Future<void>.delayed(Duration.zero);
     notifier.cancelBarrier!.complete();
     await Future.wait([disable, refresh]);

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -13291,6 +13291,56 @@ void main() {
     },
   );
 
+  testWidgets('빈 rideLegs mismatch는 기존 하차 알림과 구독을 보존한다', (tester) async {
+    final notifier = _RecordingGetOffAlarmNotifier();
+    final stateRepository = _MemoryGetOffAlarmStateRepository();
+    final controller = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: _StubExactAlarmPermissionGate(),
+      notificationPermissionProvider: FakeNotificationPermissionProvider(
+        nextStatus: NotificationPermissionStatus.granted,
+      ),
+      repository: stateRepository,
+      now: () => DateTime.parse('2026-07-06T09:00:00+09:00'),
+    );
+    addTearDown(controller.dispose);
+    final repository =
+        FakeRouteSearchRepository(
+            result: _sampleRouteSearchResult(routeSearchId: 'route-2'),
+          )
+          ..refreshResult = RouteRefreshResult(
+            routeSearchId: 'route-2',
+            status: 'UPDATED_ROUTE',
+            result: _sampleRouteSearchResult(
+              routeSearchId: 'route-2',
+              steps: const [],
+            ),
+            refreshedAt: '2026-07-06T09:01:00+09:00',
+            etaSource: 'PLANNED',
+            etaConfidence: 'MEDIUM',
+            sourceLabel: '계획 시간 기준',
+          );
+    await _pumpGetOffAlarmRouteScreen(
+      tester,
+      repository: repository,
+      controller: controller,
+    );
+    await _enableSampleGetOffAlarm(controller);
+    final subscriptionBefore = await stateRepository.loadActive();
+    notifier.reset();
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+    await tester.pump();
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pumpAndSettle();
+
+    expect(repository.refreshRouteSearchIds, ['route-2']);
+    expect(notifier.scheduleCalls, 0);
+    expect(notifier.cancelCalls, 0);
+    expect(await stateRepository.loadActive(), same(subscriptionBefore));
+    expect(controller.state.activeRouteId, 'route-1');
+  });
+
   testWidgets('성공한 foreground refresh에 usable ride가 없으면 활성 하차 알림을 취소한다', (
     tester,
   ) async {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -13341,6 +13341,90 @@ void main() {
     expect(controller.state.activeRouteId, 'route-1');
   });
 
+  testWidgets('경로 mismatch는 새 경로 역명 조회 전에 종료한다', (tester) async {
+    final notifier = _RecordingGetOffAlarmNotifier();
+    final stateRepository = _MemoryGetOffAlarmStateRepository();
+    final controller = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: _StubExactAlarmPermissionGate(),
+      notificationPermissionProvider: FakeNotificationPermissionProvider(
+        nextStatus: NotificationPermissionStatus.granted,
+      ),
+      repository: stateRepository,
+      now: () => DateTime.parse('2026-07-06T09:00:00+09:00'),
+    );
+    addTearDown(controller.dispose);
+    final repository =
+        FakeRouteSearchRepository(
+            result: _sampleRouteSearchResult(routeSearchId: 'route-2'),
+          )
+          ..refreshResult = RouteRefreshResult(
+            routeSearchId: 'route-2',
+            status: 'UPDATED_ROUTE',
+            result: _sampleRouteSearchResult(
+              routeSearchId: 'route-2',
+              steps: const [
+                RouteSearchStep(
+                  sequence: 1,
+                  stepType: 'ride',
+                  title: '상록수에서 환승역까지 이동',
+                  description: '열차를 이용해 이동합니다.',
+                  lineId: 'seoul-4',
+                  lineName: '수도권 4호선',
+                  fromStationId: 'station-sangnoksu',
+                  toStationId: 'station-new-transfer',
+                  estimatedMinutes: 20,
+                  distanceMeters: 9000,
+                  includesStairs: false,
+                  requiresAccessibilityCheck: true,
+                  plannedArrivalTimeIso: '2026-07-06T09:20:00+09:00',
+                ),
+                RouteSearchStep(
+                  sequence: 2,
+                  stepType: 'ride',
+                  title: '환승역에서 사당까지 이동',
+                  description: '열차를 이용해 이동합니다.',
+                  lineId: 'seoul-2',
+                  lineName: '수도권 2호선',
+                  fromStationId: 'station-new-transfer',
+                  toStationId: 'station-sadang',
+                  estimatedMinutes: 15,
+                  distanceMeters: 4500,
+                  includesStairs: false,
+                  requiresAccessibilityCheck: true,
+                  plannedArrivalTimeIso: '2026-07-06T09:37:30+09:00',
+                ),
+              ],
+            ),
+            refreshedAt: '2026-07-06T09:01:00+09:00',
+            etaSource: 'PLANNED',
+            etaConfidence: 'MEDIUM',
+            sourceLabel: '계획 시간 기준',
+          );
+    await _pumpGetOffAlarmRouteScreen(
+      tester,
+      repository: repository,
+      controller: controller,
+    );
+    await _enableSampleGetOffAlarm(controller);
+    final subscriptionBefore = await stateRepository.loadActive();
+    notifier.reset();
+    final reports = <FlutterErrorDetails>[];
+
+    await runWithMobileErrorReporter(reports.add, () async {
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+      await tester.pump();
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      await tester.pumpAndSettle();
+    });
+
+    expect(reports, isEmpty);
+    expect(notifier.scheduleCalls, 0);
+    expect(notifier.cancelCalls, 0);
+    expect(await stateRepository.loadActive(), same(subscriptionBefore));
+    expect(controller.state.activeRouteId, 'route-1');
+  });
+
   testWidgets('성공한 foreground refresh에 usable ride가 없으면 활성 하차 알림을 취소한다', (
     tester,
   ) async {


### PR DESCRIPTION
## 관련 이슈

Closes #1908

## 작업 배경

- foreground 경로 갱신이 활성 하차 알림과 다른 경로 결과를 늦게 전달하면 기존 alarm과 영속 구독을 덮어쓰거나 빈 경로에서 직접 해제할 수 있었습니다.

## 작업 내용

- `GetOffAlarmController.refresh`가 필수 `routeId`를 받고 persisted/controller/input route ID를 mutation 실행 시 비교합니다.
- 결과를 `refreshed`, `routeMismatch`, `skipped`로 구분하고 mismatch에서는 schedule/cancel/save/clear를 호출하지 않습니다.
- transfer 설정은 controller가 새로 읽은 활성 구독에서 사용합니다.
- 빈 ride 결과도 화면에서 직접 해제하지 않고 controller guard 아래로 전달합니다.
- 세 단일 불일치, route 전환 뒤 queued stale completion, 빈 ride mismatch와 역명 조회 전 mismatch 종료 회귀를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `flutter analyze`: No issues found
  - `flutter test test/features/get_off_alarm`: 72 tests passed
  - `flutter test test/widget_test.dart`: 285 tests passed
  - `coderabbit review --agent --base origin/main -c .coderabbit.yaml`: 4 files reviewed, 0 issues
  - GitHub CodeRabbit/Codex fallback Review: finding 각 1건 수정·검증 후 thread resolved

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| three-way route identity | Flutter unit | persisted/controller/input 단일 불일치 및 queued stale completion 자동 테스트 | `get_off_alarm_controller_test.dart` | PASS |
| 빈 ride mismatch 보존 | Flutter widget | route-2 빈 결과가 route-1 alarm의 schedule/cancel 및 구독을 변경하지 않는 자동 테스트 | `widget_test.dart` | PASS |
| UI·수동 QA | Android | 표시 문구·레이아웃 변경이 없고 controller/widget 자동 테스트가 실제 lifecycle 흐름을 재현하므로 별도 screenshot·수동 QA 불필요 | 위 자동 테스트 | 불필요 |

## Version impact

- [ ] no version change
- [x] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `GetOffAlarmController._refresh`의 side effect 전 three-way 비교와 `RouteSearchScreen._refreshCurrentRouteAndAlarm`의 빈 stops 전달 흐름

## 리스크

- 동일 경로의 빈 ride 결과는 기존 정책대로 alarm을 정상 해제합니다. 다른 경로 결과는 기존 alarm과 영속 구독을 그대로 보존합니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)
