### PR TITLE
[Chore] backend 컨테이너 하드닝 (#1914)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,11 @@ updates:
       time: "06:23"
       timezone: "Asia/Seoul"
     open-pull-requests-limit: 3
+  - package-ecosystem: "docker"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "06:23"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 3

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -144,6 +144,7 @@ jobs:
         run: |
           set -euo pipefail
           tag="${IMAGE}:sha-${DEPLOY_SHA}"
+          metadata_file="${RUNNER_TEMP}/backend-build-metadata.json"
 
           # Idempotent re-deploy: reuse the existing digest if this SHA tag was
           # already pushed (e.g. a workflow_dispatch redeploy) — issue #1686.
@@ -152,30 +153,54 @@ jobs:
             echo "reusing existing digest ${digest} for ${tag}"
           else
             # Native arm64 build on the ubuntu-24.04-arm runner (OCI A1 target).
-            docker build \
+            docker buildx create --use
+            docker buildx build \
+              --platform linux/arm64 \
               -f backend/Dockerfile \
               --label "org.opencontainers.image.revision=${DEPLOY_SHA}" \
               --label "org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY}" \
+              --attest type=sbom \
+              --provenance=true \
+              --metadata-file "${metadata_file}" \
+              --push \
               -t "${tag}" \
               backend
 
             # An amd64 image would not even start on the aarch64 server, so gate
             # the architecture before publishing.
-            arch="$(docker image inspect "${tag}" --format '{{.Os}}/{{.Architecture}}')"
+            arch="$(docker buildx imagetools inspect "${tag}" --format '{{range .Manifest.manifests}}{{if eq .platform.os "linux"}}{{.platform.os}}/{{.platform.architecture}}{{end}}{{end}}')"
             if [[ "${arch}" != "linux/arm64" ]]; then
               echo "built image arch ${arch}, expected linux/arm64" >&2
               exit 1
             fi
 
-            docker push "${tag}"
-            # RepoDigests is populated by the push; take the digest after the '@'.
-            repo_digest="$(docker image inspect "${tag}" --format '{{index .RepoDigests 0}}')"
-            digest="${repo_digest##*@}"
+            digest="$(docker buildx imagetools inspect "${tag}" --format '{{.Manifest.digest}}')"
+            if ! grep -Eq '"containerimage\.digest"[[:space:]]*:[[:space:]]*"'"${digest}"'"' "${metadata_file}"; then
+              echo "Buildx metadata digest does not match the pushed manifest" >&2
+              exit 1
+            fi
           fi
 
           if [[ ! "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
             echo "failed to resolve pushed image digest" >&2
             exit 1
+          fi
+          evidence_dir="${RUNNER_TEMP}/backend-image-evidence"
+          mkdir -p "${evidence_dir}"
+          base_image="$(sed -n 's/^FROM //p' backend/Dockerfile)"
+          if [[ ! "${base_image}" =~ ^eclipse-temurin:21-jre@sha256:[0-9a-f]{64}$ ]]; then
+            echo "backend runtime base image is not digest-pinned" >&2
+            exit 1
+          fi
+          docker buildx imagetools inspect "${tag}" --raw > "${evidence_dir}/image-index.json"
+          {
+            printf 'git_sha=%s\n' "${DEPLOY_SHA}"
+            printf 'base_image=%s\n' "${base_image}"
+            printf 'image_tag=%s\n' "${tag}"
+            printf 'image_digest=%s\n' "${digest}"
+          } > "${evidence_dir}/identity.env"
+          if [[ -f "${metadata_file}" ]]; then
+            cp "${metadata_file}" "${evidence_dir}/build-metadata.json"
           fi
           echo "digest=${digest}" >> "${GITHUB_OUTPUT}"
           {
@@ -184,6 +209,14 @@ jobs:
             echo "- digest: \`${digest}\`"
             echo "- arch: linux/arm64"
           } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: CD Build image / Upload immutable identity evidence
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: backend-image-identity-${{ needs.plan.outputs.sha }}
+          path: ${{ runner.temp }}/backend-image-evidence
+          if-no-files-found: error
+          retention-days: 14
 
   deploy:
     name: CD Deploy

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -166,19 +166,19 @@ jobs:
               -t "${tag}" \
               backend
 
-            # An amd64 image would not even start on the aarch64 server, so gate
-            # the architecture before publishing.
-            arch="$(docker buildx imagetools inspect "${tag}" --format '{{range .Manifest.manifests}}{{if eq .platform.os "linux"}}{{.platform.os}}/{{.platform.architecture}}{{end}}{{end}}')"
-            if [[ "${arch}" != "linux/arm64" ]]; then
-              echo "built image arch ${arch}, expected linux/arm64" >&2
-              exit 1
-            fi
-
             digest="$(docker buildx imagetools inspect "${tag}" --format '{{.Manifest.digest}}')"
             if ! grep -Eq '"containerimage\.digest"[[:space:]]*:[[:space:]]*"'"${digest}"'"' "${metadata_file}"; then
               echo "Buildx metadata digest does not match the pushed manifest" >&2
               exit 1
             fi
+          fi
+
+          # A failed build may leave its SHA tag in GHCR. Gate both new and
+          # reused tags before accepting their digest for deployment.
+          arch="$(docker buildx imagetools inspect "${tag}" --format '{{range .Manifest.manifests}}{{if eq .platform.os "linux"}}{{.platform.os}}/{{.platform.architecture}}{{end}}{{end}}')"
+          if [[ "${arch}" != "linux/arm64" ]]; then
+            echo "built image arch ${arch}, expected linux/arm64" >&2
+            exit 1
           fi
 
           if [[ ! "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then

--- a/apps/mobile/release/abuse-penetration-rehearsal-gate.json
+++ b/apps/mobile/release/abuse-penetration-rehearsal-gate.json
@@ -87,7 +87,8 @@
       "deployed-distributed-or-multi-node-rate-limit-rehearsal",
       "deployed-ad-event-edge-rate-limit",
       "deployed-ad-event-origin-bypass-denial",
-      "deployed-ad-event-privacy-redaction"
+      "deployed-ad-event-privacy-redaction",
+      "container-hardening-negative-controls"
     ],
     "notClosingReasonKo": "#1022는 Play credential/store preflight와 local/backend 자동 검증은 확보됐지만, Play-generated/Play-installed artifact 및 deployed production-like rehearsal evidence가 아직 없어 open 유지한다.",
     "redactionPolicy": {
@@ -114,7 +115,8 @@
       "distributed-or-waived-rate-limit-rehearsal",
       "deployed-ad-event-edge-rate-limit",
       "deployed-ad-event-origin-bypass-denial",
-      "deployed-ad-event-privacy-redaction"
+      "deployed-ad-event-privacy-redaction",
+      "container-hardening-negative-controls"
     ],
     "forbiddenClosureEvidence": [
       "static gate JSON",
@@ -127,7 +129,7 @@
     "policyKo": "#1022는 Play-generated/Play-installed artifact와 deployed production-like backend/object-storage rehearsal 증거가 없으면 preflight, local selected test, static contract만으로 완료 처리하지 않는다."
   },
   "buildIdentityPolicy": {
-    "requiredIssueLinks": ["#1015", "#1016", "#1020"],
+    "requiredIssueLinks": ["#1015", "#1016", "#1020", "#1914"],
     "acceptedArtifactSources": ["rc-aab", "play-generated-apk", "play-installed-build", "backend-release-image"],
     "requiredIdentityFields": [
       "gitSha",

--- a/apps/mobile/release/rc-evidence-manifest-contract.json
+++ b/apps/mobile/release/rc-evidence-manifest-contract.json
@@ -5,7 +5,7 @@
   "releaseGate": "rc-evidence-manifest",
   "issue": 1020,
   "parentIssues": [1014, 1020],
-  "linkedEvidenceIssues": [547, 571, 1015, 1016, 1017, 1018, 1019, 1021, 1022],
+  "linkedEvidenceIssues": [547, 571, 1015, 1016, 1017, 1018, 1019, 1021, 1022, 1914],
   "androidRcEvidenceManifest": "apps/mobile/release/android-rc-store-evidence.json",
   "signedReleaseArtifactGate": "apps/mobile/release/signed-release-artifact-gate.json",
   "releaseGovernanceGate": "apps/mobile/release/release-governance-gate.json",
@@ -80,6 +80,11 @@
     {
       "id": "abuse_penetration_rehearsal",
       "sourceIssue": 1022,
+      "expiresAfterDays": 14
+    },
+    {
+      "id": "container_hardening",
+      "sourceIssue": 1914,
       "expiresAfterDays": 14
     }
   ],

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,11 +1,16 @@
-FROM eclipse-temurin:21-jre
+FROM eclipse-temurin:21-jre@sha256:d2b9f8f12212cadcfdf889461531784e8fd097feade954d65b31ee7a71c473ec
+
+RUN groupadd --system --gid 10001 app && \
+    useradd --uid 10001 --gid 10001 --no-create-home --home-dir /nonexistent --shell /usr/sbin/nologin app
 
 WORKDIR /app
 
-COPY build/libs/*.jar app.jar
+COPY --chown=10001:10001 build/libs/*.jar app.jar
 
 EXPOSE 8080
 
 ENV SPRING_PROFILES_ACTIVE=prod
+
+USER 10001:10001
 
 ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -41,6 +41,14 @@ services:
     container_name: easysubway-backend
     restart: unless-stopped
     stop_grace_period: 30s
+    user: "10001:10001"
+    read_only: true
+    tmpfs:
+      - /tmp:rw,nosuid,nodev
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
     env_file:
       - ${EASYSUBWAY_BACKEND_ENV_FILE:-../.env.example}
     environment:
@@ -66,6 +74,14 @@ services:
     container_name: easysubway-back-worker
     restart: unless-stopped
     stop_grace_period: 30s
+    user: "10001:10001"
+    read_only: true
+    tmpfs:
+      - /tmp:rw,nosuid,nodev
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
     env_file:
       - ${EASYSUBWAY_BACKEND_ENV_FILE:-../.env.example}
     environment:

--- a/tools/ci/backend-deploy.test.mjs
+++ b/tools/ci/backend-deploy.test.mjs
@@ -406,6 +406,7 @@ test("백엔드 SSH 배포 스크립트는 상태, drift, 백업, readiness 롤�
   assert.match(deploy, /fail_backend_deployment "backend_start_failed"/);
   assert.match(deploy, /fail_backend_deployment "observability_start_failed"/);
   assert.match(deploy, /verify_runtime_hardening\(\)/);
+  assert.match(deploy, /runtime_services_hardened\(\)/);
   assert.match(deploy, /docker inspect --format '\{\{\.Config\.User\}\}\|\{\{\.HostConfig\.ReadonlyRootfs\}\}\|\{\{json \.HostConfig\.Tmpfs\}\}\|\{\{json \.HostConfig\.CapDrop\}\}\|\{\{json \.HostConfig\.SecurityOpt\}\}'/);
   assert.match(deploy, /docker exec "\$\{container_id\}" id -u/);
   assert.match(deploy, /docker exec "\$\{container_id\}" id -g/);
@@ -414,8 +415,13 @@ test("백엔드 SSH 배포 스크립트는 상태, drift, 백업, readiness 롤�
   assert.match(deploy, /docker exec "\$\{container_id\}" cat \/proc\/1\/status/);
   assert.match(deploy, /CapEff:/);
   assert.match(deploy, /NoNewPrivs:/);
-  assert.match(deploy, /for service in "\$\{RUNTIME_SERVICES\[@\]\}"; do[\s\S]*verify_runtime_hardening "\$\{service\}"/);
-  assert.match(deploy, /fail_backend_deployment "\$\{service\}_hardening_failed"/);
+  assert.ok(
+    deploy.indexOf("runtime_services_hardened()") < deploy.indexOf('if [[ "${current_sha}" == "${DEPLOY_SHA}"'),
+    "runtime hardening helper must be available to the same-SHA no-op path",
+  );
+  assert.match(deploy, /compose_services_running[\s\S]*&& runtime_services_hardened; then/);
+  assert.match(deploy, /if ! runtime_services_hardened; then/);
+  assert.match(deploy, /fail_backend_deployment "runtime_hardening_failed"/);
   assert.ok(
     deploy.indexOf('verify_runtime_hardening "${service}"') < deploy.indexOf('ready=0'),
     "runtime hardening must pass before readiness completes the deployment",

--- a/tools/ci/backend-deploy.test.mjs
+++ b/tools/ci/backend-deploy.test.mjs
@@ -405,6 +405,21 @@ test("백엔드 SSH 배포 스크립트는 상태, drift, 백업, readiness 롤�
   assert.match(deploy, /fail_backend_deployment\(\)/);
   assert.match(deploy, /fail_backend_deployment "backend_start_failed"/);
   assert.match(deploy, /fail_backend_deployment "observability_start_failed"/);
+  assert.match(deploy, /verify_runtime_hardening\(\)/);
+  assert.match(deploy, /docker inspect --format '\{\{\.Config\.User\}\}\|\{\{\.HostConfig\.ReadonlyRootfs\}\}\|\{\{json \.HostConfig\.Tmpfs\}\}\|\{\{json \.HostConfig\.CapDrop\}\}\|\{\{json \.HostConfig\.SecurityOpt\}\}'/);
+  assert.match(deploy, /docker exec "\$\{container_id\}" id -u/);
+  assert.match(deploy, /docker exec "\$\{container_id\}" id -g/);
+  assert.match(deploy, /docker exec "\$\{container_id\}" touch \/app\/app\.jar/);
+  assert.match(deploy, /docker exec "\$\{container_id\}" sh -c 'probe="\$\(mktemp \/tmp\/easysubway-hardening\.XXXXXX\)" && rm -f "\$probe"'/);
+  assert.match(deploy, /docker exec "\$\{container_id\}" cat \/proc\/1\/status/);
+  assert.match(deploy, /CapEff:/);
+  assert.match(deploy, /NoNewPrivs:/);
+  assert.match(deploy, /for service in "\$\{RUNTIME_SERVICES\[@\]\}"; do[\s\S]*verify_runtime_hardening "\$\{service\}"/);
+  assert.match(deploy, /fail_backend_deployment "\$\{service\}_hardening_failed"/);
+  assert.ok(
+    deploy.indexOf('verify_runtime_hardening "${service}"') < deploy.indexOf('ready=0'),
+    "runtime hardening must pass before readiness completes the deployment",
+  );
   assert.match(deploy, /observability_ready=0/);
   assert.match(deploy, /compose_services_running "\$\{SHARED_DIR\}\/current-env\/backend\.env" "\$\{SHARED_DIR\}\/current-env\/compose\.env" "\$\{DEPLOY_SHA\}" "\$\{RUNTIME_SERVICES\[@\]\}" "\$\{OBSERVABILITY_SERVICES\[@\]\}"/);
   assert.match(deploy, /mktemp "\$\{DIAGNOSTICS_DIR\}\/\$\{DEPLOY_SHA\}-observability-\$\(date -u \+%Y%m%dT%H%M%SZ\)\.XXXXXX\.log"/);
@@ -465,4 +480,13 @@ test("Compose backend 서비스는 bootJar 기반 이미지와 제한된 바인�
   assert.match(compose, /max-size: "10m"/);
   assert.match(compose, /postgres:\s*\n\s*condition: service_healthy/);
   assert.match(compose, /object-storage:\s*\n\s*condition: service_healthy/);
+
+  for (const service of ["backend", "back-worker"]) {
+    const block = compose.match(new RegExp(`\\n  ${service}:\\n[\\s\\S]*?(?=\\n  [a-z0-9-]+:\\n|\\nvolumes:)`))?.[0] ?? "";
+    assert.match(block, /^    user: "10001:10001"$/m, `${service} numeric user`);
+    assert.match(block, /^    read_only: true$/m, `${service} read-only rootfs`);
+    assert.match(block, /^    tmpfs:\s*\n      - \/tmp:rw,nosuid,nodev$/m, `${service} tmpfs`);
+    assert.match(block, /^    cap_drop:\s*\n      - ALL$/m, `${service} capabilities`);
+    assert.match(block, /^    security_opt:\s*\n      - no-new-privileges:true$/m, `${service} no-new-privileges`);
+  }
 });

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -996,6 +996,10 @@ test("지속적 배포 준비 상태는 단일 dotenv secret과 배포 설정을
   assert.match(workflow, /printf 'base_image=%s\\n' "\$\{base_image\}"/);
   assert.match(workflow, /printf 'image_digest=%s\\n' "\$\{digest\}"/);
   assert.match(workflow, /name: backend-image-identity-\$\{\{ needs\.plan\.outputs\.sha \}\}/);
+  assert.match(
+    workflow,
+    /if digest="\$\(docker buildx imagetools inspect[\s\S]*?else[\s\S]*?docker buildx build[\s\S]*?^          fi[\s\S]*?arch="\$\(docker buildx imagetools inspect/m,
+  );
   assert.match(workflow, /if \[\[ "\$\{arch\}" != "linux\/arm64" \]\]; then/);
   assert.match(workflow, /CD Deploy \/ Pull backend image by digest/);
   assert.match(workflow, /docker tag "\$\{IMAGE\}@\$\{DEPLOY_IMAGE_DIGEST\}" "easysubway-backend:\$\{DEPLOY_SHA\}"/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -982,6 +982,20 @@ test("지속적 배포 준비 상태는 단일 dotenv secret과 배포 설정을
   // on the runner or on the server (issue #1686).
   assert.match(workflow, /CD Build image \/ Build and push arm64 image/);
   assert.match(workflow, /ghcr\.io\/aquilaxk\/easysubway-backend/);
+  assert.match(workflow, /docker buildx create --use/);
+  assert.match(workflow, /docker buildx build \\/);
+  assert.match(workflow, /--platform linux\/arm64 \\/);
+  assert.match(workflow, /--attest type=sbom \\/);
+  assert.match(workflow, /--provenance=true \\/);
+  assert.match(workflow, /--metadata-file "\$\{metadata_file\}" \\/);
+  assert.match(workflow, /--push \\/);
+  assert.match(workflow, /backend-build-metadata\.json/);
+  assert.match(workflow, /Buildx metadata digest does not match the pushed manifest/);
+  assert.match(workflow, /backend-image-evidence/);
+  assert.match(workflow, /docker buildx imagetools inspect "\$\{tag\}" --raw/);
+  assert.match(workflow, /printf 'base_image=%s\\n' "\$\{base_image\}"/);
+  assert.match(workflow, /printf 'image_digest=%s\\n' "\$\{digest\}"/);
+  assert.match(workflow, /name: backend-image-identity-\$\{\{ needs\.plan\.outputs\.sha \}\}/);
   assert.match(workflow, /if \[\[ "\$\{arch\}" != "linux\/arm64" \]\]; then/);
   assert.match(workflow, /CD Deploy \/ Pull backend image by digest/);
   assert.match(workflow, /docker tag "\$\{IMAGE\}@\$\{DEPLOY_IMAGE_DIGEST\}" "easysubway-backend:\$\{DEPLOY_SHA\}"/);
@@ -2640,6 +2654,7 @@ test("모바일 signed release artifact gate와 광고 counter는 CI 산출물�
     "deployed-ad-event-edge-rate-limit",
     "deployed-ad-event-origin-bypass-denial",
     "deployed-ad-event-privacy-redaction",
+    "container-hardening-negative-controls",
   ]);
   assert.match(abusePenetrationRehearsalGate.latestQaEvidenceStatus.notClosingReasonKo, /#1022/);
   assert.equal(abusePenetrationRehearsalGate.latestQaEvidenceStatus.redactionPolicy.secretValuesPrinted, false);
@@ -2648,7 +2663,12 @@ test("모바일 signed release artifact gate와 광고 counter는 CI 산출물�
       "raw signed URL",
     ),
   );
-  assert.deepEqual(abusePenetrationRehearsalGate.buildIdentityPolicy.requiredIssueLinks, ["#1015", "#1016", "#1020"]);
+  assert.deepEqual(abusePenetrationRehearsalGate.buildIdentityPolicy.requiredIssueLinks, ["#1015", "#1016", "#1020", "#1914"]);
+  assert.ok(
+    abusePenetrationRehearsalGate.productionLikeEvidencePolicy.requiredForClosing.includes(
+      "container-hardening-negative-controls",
+    ),
+  );
   assert.deepEqual(abusePenetrationRehearsalGate.buildIdentityPolicy.acceptedArtifactSources, [
     "rc-aab",
     "play-generated-apk",
@@ -2938,7 +2958,7 @@ test("모바일 signed release artifact gate와 광고 counter는 CI 산출물�
   assert.equal(rcEvidenceManifestContract.releaseGate, "rc-evidence-manifest");
   assert.equal(rcEvidenceManifestContract.issue, 1020);
   assert.deepEqual(rcEvidenceManifestContract.parentIssues, [1014, 1020]);
-  assert.deepEqual(rcEvidenceManifestContract.linkedEvidenceIssues, [547, 571, 1015, 1016, 1017, 1018, 1019, 1021, 1022]);
+  assert.deepEqual(rcEvidenceManifestContract.linkedEvidenceIssues, [547, 571, 1015, 1016, 1017, 1018, 1019, 1021, 1022, 1914]);
   assert.equal(rcEvidenceManifestContract.androidRcEvidenceManifest, androidRcEvidencePath);
   assert.equal(rcEvidenceManifestContract.signedReleaseArtifactGate, gatePath);
   assert.equal(rcEvidenceManifestContract.releaseGovernanceGate, "apps/mobile/release/release-governance-gate.json");
@@ -2973,6 +2993,7 @@ test("모바일 signed release artifact gate와 광고 counter는 CI 산출물�
       { id: "post_launch_operations", sourceIssue: 1019 },
       { id: "android_release_quality", sourceIssue: 1021 },
       { id: "abuse_penetration_rehearsal", sourceIssue: 1022 },
+      { id: "container_hardening", sourceIssue: 1914 },
     ],
   );
   assert.equal(rcEvidenceManifestContract.readinessPolicy.openAndroidP0BlocksGo, true);
@@ -3505,6 +3526,7 @@ test("RC evidence manifest generator는 RC identity와 No-Go blocker를 생성�
       { id: "post_launch_operations", sourceIssue: 1019 },
       { id: "android_release_quality", sourceIssue: 1021 },
       { id: "abuse_penetration_rehearsal", sourceIssue: 1022 },
+      { id: "container_hardening", sourceIssue: 1914 },
     ],
   );
   assert.ok(manifest.evidenceEntries.every((entry) => entry.device === "local_android_emulator"));
@@ -8205,11 +8227,17 @@ test("backend release image는 bootJar 산출물만 포함하는 runtime image�
   const dockerfile = read("backend/Dockerfile");
   const dockerignore = read("backend/.dockerignore");
 
-  assert.match(dockerfile, /^FROM eclipse-temurin:21-jre$/m);
+  assert.match(
+    dockerfile,
+    /^FROM eclipse-temurin:21-jre@sha256:[0-9a-f]{64}$/m,
+  );
+  assert.match(dockerfile, /^RUN groupadd --system --gid 10001 app && \\$/m);
+  assert.match(dockerfile, /useradd --uid 10001 --gid 10001 --no-create-home --home-dir \/nonexistent --shell \/usr\/sbin\/nologin app/);
   assert.match(dockerfile, /^WORKDIR \/app$/m);
-  assert.match(dockerfile, /^COPY build\/libs\/\*\.jar app\.jar$/m);
+  assert.match(dockerfile, /^COPY --chown=10001:10001 build\/libs\/\*\.jar app\.jar$/m);
   assert.match(dockerfile, /^EXPOSE 8080$/m);
   assert.match(dockerfile, /^ENV SPRING_PROFILES_ACTIVE=prod$/m);
+  assert.match(dockerfile, /^USER 10001:10001$/m);
   assert.match(dockerfile, /^ENTRYPOINT \["java", "-jar", "\/app\/app\.jar"\]$/m);
   assert.doesNotMatch(dockerfile, /EASYSUBWAY_/);
   assert.doesNotMatch(dockerfile, /COPY \. \./);
@@ -8218,6 +8246,12 @@ test("backend release image는 bootJar 산출물만 포함하는 runtime image�
   assert.match(dockerignore, /^!build\/libs$/m);
   assert.match(dockerignore, /^!build\/libs\/\*\.jar$/m);
   assert.doesNotMatch(dockerignore, /^!\.env/m);
+
+  const dependabot = read(".github/dependabot.yml");
+  assert.match(
+    dependabot,
+    /package-ecosystem: "docker"\s+directory: "\/backend"\s+schedule:\s+interval: "weekly"\s+day: "tuesday"\s+time: "06:23"\s+timezone: "Asia\/Seoul"/,
+  );
 });
 
 test("OSV baseline은 기존 취약점 ID를 lockfile 위치별로 좁게 예외 처리한다", () => {

--- a/tools/deploy/deploy-backend.sh
+++ b/tools/deploy/deploy-backend.sh
@@ -557,6 +557,38 @@ fail_backend_deployment() {
 	printf '%s\n' "${DEPLOY_SHA}" > "${SHARED_DIR}/failed-sha"
 }
 
+verify_runtime_hardening() {
+	local service="$1"
+	local container_id=""
+	local runtime_config=""
+	local uid=""
+	local gid=""
+	local process_status=""
+	local cap_eff=""
+	local no_new_privs=""
+
+	container_id="$(compose "${SHARED_DIR}/current-env/backend.env" "${SHARED_DIR}/current-env/compose.env" "${DEPLOY_SHA}" ps -q "${service}" 2>/dev/null || true)"
+	[[ -n "${container_id}" ]] || return 1
+	runtime_config="$(docker inspect --format '{{.Config.User}}|{{.HostConfig.ReadonlyRootfs}}|{{json .HostConfig.Tmpfs}}|{{json .HostConfig.CapDrop}}|{{json .HostConfig.SecurityOpt}}' "${container_id}")"
+	[[ "${runtime_config}" == '10001:10001|true|{"/tmp":"rw,nosuid,nodev"}|["ALL"]|["no-new-privileges:true"]' ]] || return 1
+
+	uid="$(docker exec "${container_id}" id -u)"
+	gid="$(docker exec "${container_id}" id -g)"
+	[[ "${uid}:${gid}" == "10001:10001" ]] || return 1
+	if docker exec "${container_id}" touch /app/app.jar >/dev/null 2>&1; then
+		return 1
+	fi
+	docker exec "${container_id}" sh -c 'probe="$(mktemp /tmp/easysubway-hardening.XXXXXX)" && rm -f "$probe"' || return 1
+
+	process_status="$(docker exec "${container_id}" cat /proc/1/status)"
+	cap_eff="$(awk '$1 == "CapEff:" { print $2 }' <<<"${process_status}")"
+	no_new_privs="$(awk '$1 == "NoNewPrivs:" { print $2 }' <<<"${process_status}")"
+	[[ "${cap_eff}" == "0000000000000000" && "${no_new_privs}" == "1" ]] || return 1
+
+	printf 'runtime_hardening service=%s uid=%s gid=%s rootfs=read-only tmpfs=/tmp cap_eff=%s no_new_privs=%s image_digest=%s\n' \
+		"${service}" "${uid}" "${gid}" "${cap_eff}" "${no_new_privs}" "${DEPLOY_IMAGE_DIGEST}"
+}
+
 write_phase "restarting"
 if ! compose "${SHARED_DIR}/current-env/backend.env" "${SHARED_DIR}/current-env/compose.env" "${DEPLOY_SHA}" up -d --no-deps --no-build "${RUNTIME_SERVICES[@]}"; then
 	fail_backend_deployment "backend_start_failed"
@@ -566,6 +598,12 @@ if ! start_observability_services "${SHARED_DIR}/current-env/backend.env" "${SHA
 	fail_backend_deployment "observability_start_failed"
 	exit 1
 fi
+for service in "${RUNTIME_SERVICES[@]}"; do
+	if ! verify_runtime_hardening "${service}"; then
+		fail_backend_deployment "${service}_hardening_failed"
+		exit 1
+	fi
+done
 
 observability_ready=0
 for _ in $(seq 1 12); do

--- a/tools/deploy/deploy-backend.sh
+++ b/tools/deploy/deploy-backend.sh
@@ -272,6 +272,45 @@ start_observability_services() {
 	fi
 }
 
+verify_runtime_hardening() {
+	local service="$1"
+	local container_id=""
+	local runtime_config=""
+	local uid=""
+	local gid=""
+	local process_status=""
+	local cap_eff=""
+	local no_new_privs=""
+
+	container_id="$(compose "${SHARED_DIR}/current-env/backend.env" "${SHARED_DIR}/current-env/compose.env" "${DEPLOY_SHA}" ps -q "${service}" 2>/dev/null || true)"
+	[[ -n "${container_id}" ]] || return 1
+	runtime_config="$(docker inspect --format '{{.Config.User}}|{{.HostConfig.ReadonlyRootfs}}|{{json .HostConfig.Tmpfs}}|{{json .HostConfig.CapDrop}}|{{json .HostConfig.SecurityOpt}}' "${container_id}")"
+	[[ "${runtime_config}" == '10001:10001|true|{"/tmp":"rw,nosuid,nodev"}|["ALL"]|["no-new-privileges:true"]' ]] || return 1
+
+	uid="$(docker exec "${container_id}" id -u)"
+	gid="$(docker exec "${container_id}" id -g)"
+	[[ "${uid}:${gid}" == "10001:10001" ]] || return 1
+	if docker exec "${container_id}" touch /app/app.jar >/dev/null 2>&1; then
+		return 1
+	fi
+	docker exec "${container_id}" sh -c 'probe="$(mktemp /tmp/easysubway-hardening.XXXXXX)" && rm -f "$probe"' || return 1
+
+	process_status="$(docker exec "${container_id}" cat /proc/1/status)"
+	cap_eff="$(awk '$1 == "CapEff:" { print $2 }' <<<"${process_status}")"
+	no_new_privs="$(awk '$1 == "NoNewPrivs:" { print $2 }' <<<"${process_status}")"
+	[[ "${cap_eff}" == "0000000000000000" && "${no_new_privs}" == "1" ]] || return 1
+
+	printf 'runtime_hardening service=%s uid=%s gid=%s rootfs=read-only tmpfs=/tmp cap_eff=%s no_new_privs=%s image_digest=%s\n' \
+		"${service}" "${uid}" "${gid}" "${cap_eff}" "${no_new_privs}" "${DEPLOY_IMAGE_DIGEST}"
+}
+
+runtime_services_hardened() {
+	local service
+	for service in "${RUNTIME_SERVICES[@]}"; do
+		verify_runtime_hardening "${service}" || return 1
+	done
+}
+
 compose "${BACKEND_ENV}" "${COMPOSE_ENV}" "${DEPLOY_SHA}" config --quiet
 
 LEGACY_BACKEND_UNIT="easysubway-backend.service"
@@ -439,7 +478,8 @@ fi
 
 if [[ "${current_sha}" == "${DEPLOY_SHA}" && "${current_env_hash}" == "${target_env_hash}" ]]; then
 	if curl -fsS --connect-timeout 2 --max-time 5 "http://127.0.0.1:${backend_port}/actuator/health/readiness" >/dev/null 2>&1 \
-		&& compose_services_running "${BACKEND_ENV}" "${COMPOSE_ENV}" "${DEPLOY_SHA}" "${RUNTIME_SERVICES[@]}" "${OBSERVABILITY_SERVICES[@]}"; then
+		&& compose_services_running "${BACKEND_ENV}" "${COMPOSE_ENV}" "${DEPLOY_SHA}" "${RUNTIME_SERVICES[@]}" "${OBSERVABILITY_SERVICES[@]}" \
+		&& runtime_services_hardened; then
 		write_phase "completed"
 		write_result "noop" "same_sha_same_env_services_ready"
 		exit 0
@@ -557,38 +597,6 @@ fail_backend_deployment() {
 	printf '%s\n' "${DEPLOY_SHA}" > "${SHARED_DIR}/failed-sha"
 }
 
-verify_runtime_hardening() {
-	local service="$1"
-	local container_id=""
-	local runtime_config=""
-	local uid=""
-	local gid=""
-	local process_status=""
-	local cap_eff=""
-	local no_new_privs=""
-
-	container_id="$(compose "${SHARED_DIR}/current-env/backend.env" "${SHARED_DIR}/current-env/compose.env" "${DEPLOY_SHA}" ps -q "${service}" 2>/dev/null || true)"
-	[[ -n "${container_id}" ]] || return 1
-	runtime_config="$(docker inspect --format '{{.Config.User}}|{{.HostConfig.ReadonlyRootfs}}|{{json .HostConfig.Tmpfs}}|{{json .HostConfig.CapDrop}}|{{json .HostConfig.SecurityOpt}}' "${container_id}")"
-	[[ "${runtime_config}" == '10001:10001|true|{"/tmp":"rw,nosuid,nodev"}|["ALL"]|["no-new-privileges:true"]' ]] || return 1
-
-	uid="$(docker exec "${container_id}" id -u)"
-	gid="$(docker exec "${container_id}" id -g)"
-	[[ "${uid}:${gid}" == "10001:10001" ]] || return 1
-	if docker exec "${container_id}" touch /app/app.jar >/dev/null 2>&1; then
-		return 1
-	fi
-	docker exec "${container_id}" sh -c 'probe="$(mktemp /tmp/easysubway-hardening.XXXXXX)" && rm -f "$probe"' || return 1
-
-	process_status="$(docker exec "${container_id}" cat /proc/1/status)"
-	cap_eff="$(awk '$1 == "CapEff:" { print $2 }' <<<"${process_status}")"
-	no_new_privs="$(awk '$1 == "NoNewPrivs:" { print $2 }' <<<"${process_status}")"
-	[[ "${cap_eff}" == "0000000000000000" && "${no_new_privs}" == "1" ]] || return 1
-
-	printf 'runtime_hardening service=%s uid=%s gid=%s rootfs=read-only tmpfs=/tmp cap_eff=%s no_new_privs=%s image_digest=%s\n' \
-		"${service}" "${uid}" "${gid}" "${cap_eff}" "${no_new_privs}" "${DEPLOY_IMAGE_DIGEST}"
-}
-
 write_phase "restarting"
 if ! compose "${SHARED_DIR}/current-env/backend.env" "${SHARED_DIR}/current-env/compose.env" "${DEPLOY_SHA}" up -d --no-deps --no-build "${RUNTIME_SERVICES[@]}"; then
 	fail_backend_deployment "backend_start_failed"
@@ -598,12 +606,10 @@ if ! start_observability_services "${SHARED_DIR}/current-env/backend.env" "${SHA
 	fail_backend_deployment "observability_start_failed"
 	exit 1
 fi
-for service in "${RUNTIME_SERVICES[@]}"; do
-	if ! verify_runtime_hardening "${service}"; then
-		fail_backend_deployment "${service}_hardening_failed"
-		exit 1
-	fi
-done
+if ! runtime_services_hardened; then
+	fail_backend_deployment "runtime_hardening_failed"
+	exit 1
+fi
 
 observability_ready=0
 for _ in $(seq 1 12); do

--- a/tools/ops/post-deploy-smoke-contract.json
+++ b/tools/ops/post-deploy-smoke-contract.json
@@ -2,8 +2,16 @@
   "schemaVersion": 1,
   "gate": "post-deploy-smoke",
   "issue": 1688,
-  "descriptionKo": "매 백엔드 배포 직후 핵심 4축이 배포 URL에서 실제 동작하는지 확인하는 경량 스모크 계약. 경로검색 공개 API는 production에서 폐쇄 상태를 검증한다.",
+  "descriptionKo": "매 백엔드 배포 직후 핵심 5축이 배포 URL에서 실제 동작하는지 확인하는 경량 스모크 계약. 경로검색 공개 API는 production에서 폐쇄 상태를 검증한다.",
   "axes": {
+    "liveness": {
+      "id": "liveness",
+      "titleKo": "헬스 (프로세스)",
+      "deploymentAttributed": true,
+      "path": "/actuator/health/liveness",
+      "expectStatusField": "status",
+      "expectStatusValue": "UP"
+    },
     "readiness": {
       "id": "readiness",
       "titleKo": "헬스 (플랫폼)",

--- a/tools/ops/post-deploy-smoke.mjs
+++ b/tools/ops/post-deploy-smoke.mjs
@@ -65,13 +65,13 @@ function joinUrl(base, pathname) {
   return `${base.replace(/\/+$/, "")}${pathname}`;
 }
 
-async function checkReadiness(baseUrl, axis, timeoutMs) {
+async function checkHealth(baseUrl, axis, timeoutMs) {
   const url = joinUrl(baseUrl, axis.path);
   const { status, text } = await httpRequest(url, { timeoutMs });
-  if (status !== 200) throw new Error(`readiness returned HTTP ${status}`);
-  const body = parseJson(text, "readiness");
+  if (status !== 200) throw new Error(`${axis.id} returned HTTP ${status}`);
+  const body = parseJson(text, axis.id);
   if (body[axis.expectStatusField] !== axis.expectStatusValue) {
-    throw new Error(`readiness ${axis.expectStatusField} was ${body[axis.expectStatusField]}, expected ${axis.expectStatusValue}`);
+    throw new Error(`${axis.id} ${axis.expectStatusField} was ${body[axis.expectStatusField]}, expected ${axis.expectStatusValue}`);
   }
 }
 
@@ -180,14 +180,18 @@ async function main() {
 
   const contractPath = argValue(args, "--contract", DEFAULT_CONTRACT);
   const contract = JSON.parse(await readFile(contractPath, "utf8"));
-  const { readiness, routeApiClosure, adminLogin, datapack } = contract.axes;
+  const { liveness, readiness, routeApiClosure, adminLogin, datapack } = contract.axes;
 
   const datapackBaseUrl = argValue(args, "--datapack-base-url", datapack.baseUrl);
   const budgetMs = Number(argValue(args, "--timeout-seconds", "90")) * 1000;
 
   const axes = [];
-  axes.push(await runAxis(readiness, (t) => checkReadiness(baseUrl, readiness, t), {
-    maxMs: Math.max(6000, budgetMs * 0.55),
+  axes.push(await runAxis(liveness, (t) => checkHealth(baseUrl, liveness, t), {
+    maxMs: Math.max(2000, budgetMs * 0.1),
+    delayMs: 2000,
+  }));
+  axes.push(await runAxis(readiness, (t) => checkHealth(baseUrl, readiness, t), {
+    maxMs: Math.max(6000, budgetMs * 0.45),
     delayMs: 3000,
   }));
   axes.push(await runAxisOnce(

--- a/tools/ops/post-deploy-smoke.test.mjs
+++ b/tools/ops/post-deploy-smoke.test.mjs
@@ -13,6 +13,7 @@ const script = "tools/ops/post-deploy-smoke.mjs";
 
 function defaultRoutes() {
   return {
+    liveness: () => ({ status: 200, body: { status: "UP" } }),
     readiness: () => ({ status: 200, body: { status: "UP" } }),
     routeV1Search: () => ({ status: 403, body: {} }),
     routeV2Search: () => ({ status: 403, body: {} }),
@@ -26,7 +27,8 @@ async function withServer(routes, fn) {
   const server = http.createServer((req, res) => {
     const url = new URL(req.url, "http://localhost");
     let handler;
-    if (url.pathname === "/actuator/health/readiness") handler = routes.readiness;
+    if (url.pathname === "/actuator/health/liveness") handler = routes.liveness;
+    else if (url.pathname === "/actuator/health/readiness") handler = routes.readiness;
     else if (url.pathname === "/api/v1/routes/search" && req.method === "POST") handler = routes.routeV1Search;
     else if (url.pathname === "/api/v2/routes/search" && req.method === "POST") handler = routes.routeV2Search;
     else if (url.pathname === "/api/v2/routes/closure-probe/refresh" && req.method === "POST") handler = routes.routeRefresh;
@@ -91,17 +93,27 @@ function axis(report, id) {
   return report.axes.find((entry) => entry.id === id);
 }
 
-test("post-deploy smoke passes when all four axes respond correctly", async () => {
+test("post-deploy smoke passes when all five axes respond correctly", async () => {
   await withServer(defaultRoutes(), async (baseUrl) => {
     const { code, report } = await runSmoke(baseUrl);
     assert.equal(code, 0);
     assert.equal(report.overall, "PASS");
-    assert.equal(report.axes.length, 4);
-    for (const id of ["readiness", "route-api-closure", "admin-login", "datapack"]) {
+    assert.equal(report.axes.length, 5);
+    for (const id of ["liveness", "readiness", "route-api-closure", "admin-login", "datapack"]) {
       assert.equal(axis(report, id).result, "PASS", `${id} should pass`);
     }
     assert.equal(axis(report, "datapack").deploymentAttributed, false);
     assert.equal(axis(report, "readiness").deploymentAttributed, true);
+  });
+});
+
+test("post-deploy smoke fails when liveness is not UP", async () => {
+  const routes = defaultRoutes();
+  routes.liveness = () => ({ status: 503, body: { status: "DOWN" } });
+  await withServer(routes, async (baseUrl) => {
+    const { code, report } = await runSmoke(baseUrl);
+    assert.equal(code, 1);
+    assert.equal(axis(report, "liveness").result, "FAIL");
   });
 });
 
@@ -191,7 +203,10 @@ test("post-deploy smoke contract file matches the expected schema", async () => 
   assert.equal(contract.gate, "post-deploy-smoke");
   assert.equal(contract.issue, 1688);
 
-  const { readiness, routeApiClosure, adminLogin, datapack } = contract.axes;
+  const { liveness, readiness, routeApiClosure, adminLogin, datapack } = contract.axes;
+  assert.equal(liveness.deploymentAttributed, true);
+  assert.equal(liveness.path, "/actuator/health/liveness");
+  assert.equal(liveness.expectStatusValue, "UP");
   assert.equal(readiness.deploymentAttributed, true);
   assert.equal(readiness.path, "/actuator/health/readiness");
   assert.equal(readiness.expectStatusValue, "UP");

--- a/tools/release/generate-rc-evidence-manifest.mjs
+++ b/tools/release/generate-rc-evidence-manifest.mjs
@@ -219,6 +219,7 @@ function requiredEvidenceEntries(baseTestedAt, rootPath, device, androidVersion)
     ["post_launch_operations", 1019],
     ["android_release_quality", 1021],
     ["abuse_penetration_rehearsal", 1022],
+    ["container_hardening", 1914],
   ];
   return sourceEntries.map(([id, sourceIssue]) => ({
     id,


### PR DESCRIPTION
## 관련 이슈

Closes #1914

## 작업 배경

- backend runtime image가 tag-only Temurin 21 JRE와 기본 root 실행에 의존해 Android v1 보안·운영 release gate를 차단했습니다.
- #1022 abuse rehearsal과 #1020 same-RC GO/NO_GO가 동일한 container hardening evidence를 소비할 수 있어야 합니다.

## 작업 내용

- Temurin 21 JRE base를 승인 digest로 고정하고 shell/home 없는 `10001:10001` 사용자로 최종 실행합니다.
- backend와 back-worker에 read-only rootfs, `/tmp` tmpfs, `cap_drop: ALL`, `no-new-privileges`를 적용합니다.
- 배포 중 두 runtime service의 UID/GID, 쓰기 음성·양성 검사, capability, NoNewPrivs를 readiness 전에 검증하고 실패 시 기존 rollback 경로로 전환합니다.
- CD image build를 arm64 Buildx SBOM/provenance 방식으로 전환하고 immutable identity artifact를 남깁니다.
- post-deploy smoke에 liveness를 추가하고 #1022/#1020 기존 evidence 계약에 `container_hardening` 소비 경로를 연결합니다.
- Docker base digest 갱신은 Dependabot 주간 PR로 관리합니다.

## 검증

- `node --test tools/ci/repository-contract.test.mjs tools/ci/backend-deploy.test.mjs tools/ops/post-deploy-smoke.test.mjs tools/security/validate-abuse-penetration-summary.test.mjs` — 247/247 PASS
- `./backend/gradlew test --no-daemon` — BUILD SUCCESSFUL
- `bash -n tools/deploy/deploy-backend.sh` — PASS
- `docker compose --env-file tools/ci/fixtures/deployment-prod-valid.env -f infra/docker-compose.yml config --quiet` — PASS
- `git diff --check` — PASS
- arm64 Buildx OCI build with `--attest type=sbom --provenance=true` — PASS, image index/SBOM attestation/provenance metadata 생성 확인
- production-equivalent local Compose — backend/back-worker `10001:10001`, rootfs 쓰기 실패, `/tmp` 쓰기 성공, `CapEff=0`, `NoNewPrivs=1`, liveness/readiness UP 확인
- 동일 local image graceful stop — graceful shutdown 완료, exit 143, OOMKilled=false 확인 후 동일 image 재기동/readiness UP 확인

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| image build/SBOM | linux/arm64 OCI | Buildx local OCI build | `/private/tmp/issue-1914-build-metadata.json` (로컬 전용) | PASS |
| runtime hardening | Docker Compose | 두 runtime container inspect/exec | 위 검증 명령 결과와 배포 스크립트 machine line | PASS |
| startup/health/shutdown | Docker Compose | startup, liveness, readiness, graceful stop/restart | 로컬 실행 로그 | PASS |
| immutable production identity | GitHub Actions CD | build identity artifact → deploy digest → post-deploy smoke | merge 후 `backend-image-identity-<git-sha>` artifact와 CD run URL 확인 예정 | PENDING_CD |
| rollback | GitHub Actions CD | 기존 digest rollback 경로와 rollback health | merge 후 CD run의 rollback-capable 배포 로그 확인 예정 | PENDING_CD |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: PR head SHA의 GHCR image digest; CD artifact에서 확정

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `verify_runtime_hardening`이 readiness보다 먼저 실패 닫힘/rollback되는지, Buildx digest와 identity artifact가 같은 manifest를 가리키는지 확인해 주세요.

## 리스크

- read-only rootfs/non-root 전환으로 숨은 runtime 쓰기가 있으면 배포가 실패할 수 있습니다. 배포 직후 음성·양성 검사와 기존 자동 rollback이 이를 차단합니다.
- base digest 갱신은 자동 반영하지 않고 Dependabot PR 검증·승인을 거칩니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
