### PR TITLE
[Fix] Buildx manifest 조회 호환성 수정 (#1914)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -148,8 +148,8 @@ jobs:
 
           # Idempotent re-deploy: reuse the existing digest if this SHA tag was
           # already pushed (e.g. a workflow_dispatch redeploy) — issue #1686.
-          # {{.Manifest.digest}} is the documented descriptor digest accessor.
-          if digest="$(docker buildx imagetools inspect "${tag}" --format '{{.Manifest.digest}}' 2>/dev/null)" && [[ -n "${digest}" ]]; then
+          # Buildx templates expose OCI descriptor fields with Go field names.
+          if digest="$(docker buildx imagetools inspect "${tag}" --format '{{.Manifest.Digest}}' 2>/dev/null)" && [[ -n "${digest}" ]]; then
             echo "reusing existing digest ${digest} for ${tag}"
           else
             # Native arm64 build on the ubuntu-24.04-arm runner (OCI A1 target).
@@ -166,7 +166,7 @@ jobs:
               -t "${tag}" \
               backend
 
-            digest="$(docker buildx imagetools inspect "${tag}" --format '{{.Manifest.digest}}')"
+            digest="$(docker buildx imagetools inspect "${tag}" --format '{{.Manifest.Digest}}')"
             if ! grep -Eq '"containerimage\.digest"[[:space:]]*:[[:space:]]*"'"${digest}"'"' "${metadata_file}"; then
               echo "Buildx metadata digest does not match the pushed manifest" >&2
               exit 1
@@ -175,7 +175,7 @@ jobs:
 
           # A failed build may leave its SHA tag in GHCR. Gate both new and
           # reused tags before accepting their digest for deployment.
-          arch="$(docker buildx imagetools inspect "${tag}" --format '{{range .Manifest.manifests}}{{if eq .platform.os "linux"}}{{.platform.os}}/{{.platform.architecture}}{{end}}{{end}}')"
+          arch="$(docker buildx imagetools inspect "${tag}" --format '{{range .Manifest.Manifests}}{{if eq .Platform.OS "linux"}}{{.Platform.OS}}/{{.Platform.Architecture}}{{end}}{{end}}')"
           if [[ "${arch}" != "linux/arm64" ]]; then
             echo "built image arch ${arch}, expected linux/arm64" >&2
             exit 1

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -993,6 +993,12 @@ test("지속적 배포 준비 상태는 단일 dotenv secret과 배포 설정을
   assert.match(workflow, /Buildx metadata digest does not match the pushed manifest/);
   assert.match(workflow, /backend-image-evidence/);
   assert.match(workflow, /docker buildx imagetools inspect "\$\{tag\}" --raw/);
+  assert.match(workflow, /--format '\{\{\.Manifest\.Digest\}\}'/);
+  assert.match(
+    workflow,
+    /--format '\{\{range \.Manifest\.Manifests\}\}\{\{if eq \.Platform\.OS "linux"\}\}\{\{\.Platform\.OS\}\}\/\{\{\.Platform\.Architecture\}\}/,
+  );
+  assert.doesNotMatch(workflow, /\.Manifest\.digest|\.Manifest\.manifests|\.platform\.(?:os|architecture)/);
   assert.match(workflow, /printf 'base_image=%s\\n' "\$\{base_image\}"/);
   assert.match(workflow, /printf 'image_digest=%s\\n' "\$\{digest\}"/);
   assert.match(workflow, /name: backend-image-identity-\$\{\{ needs\.plan\.outputs\.sha \}\}/);


### PR DESCRIPTION
## 관련 이슈

Closes #1914

## 작업 배경

- PR #2157 병합 후 CD run #29419981464에서 arm64 image push와 SBOM/provenance 생성은 성공했지만, digest 조회 템플릿이 runner Buildx의 Go field 이름과 맞지 않아 `CD Build image`가 실패했습니다.
- 배포와 post-deploy smoke는 실패 닫힘으로 건너뛰어졌고 #1914를 다시 열었습니다.

## 작업 내용

- `imagetools inspect --format`의 OCI descriptor 필드를 `.Manifest.Digest`로 수정했습니다.
- 플랫폼 열거 필드를 `.Manifest.Manifests`, `.Platform.OS`, `.Platform.Architecture`로 수정했습니다.
- 소문자 JSON 키 형태가 다시 들어오지 못하도록 repository contract 회귀 검사를 추가했습니다.

## 검증

- `node --test tools/ci/repository-contract.test.mjs` — 194/194 PASS
- `git diff --check` — PASS
- 공개 GHCR image `sha-ef0084147f0c89c872328b4acbfc040f6db5d0a2` 대상 실측:
  - `{{.Manifest.Digest}}` → `sha256:7c99da7566eb550f47a4489ca86d625c02ebfc513cd3d637dae538b483bd65c2`
  - 대문자 platform field template → `linux/arm64`

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 최초 실패 | GitHub Actions CD | 실패 step log | https://github.com/AquilaXk/easysubway/actions/runs/29419981464 | FAIL_CLOSED |
| digest/arch 조회 | Docker Buildx | 공개 GHCR tag에 수정 template 실행 | 위 검증 결과 | PASS |
| 운영 배포 | GitHub Actions CD | 병합 후 build → deploy → smoke | 후속 CD run URL 확인 예정 | PENDING_CD |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 후속 merge SHA의 GHCR image digest

## 리뷰어 메모

- Buildx format template가 JSON key가 아닌 exported Go field 이름을 사용하는지 확인해 주세요.
- 실패 run에서 이미 push된 SHA tag는 후속 CD에서 reuse 경로로 들어가므로, digest와 linux/arm64 검증이 build 여부와 무관하게 통과하는지 확인해 주세요.

## 리스크

- 템플릿 필드가 다시 잘못되면 CD build job에서 실패 닫히며 production deploy는 실행되지 않습니다.
- runtime container 동작과 애플리케이션 코드는 변경하지 않습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
