### PR TITLE
[CI] Temurin major 자동 업데이트 차단

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,7 @@ updates:
       time: "06:23"
       timezone: "Asia/Seoul"
     open-pull-requests-limit: 3
+    ignore:
+      - dependency-name: "eclipse-temurin"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
## 관련 이슈

이슈 없음(C등급)

## 작업 내용

- backend Docker Dependabot에서 `eclipse-temurin`의 semver major 업데이트를 무시합니다.
- Java 21 계열의 digest 갱신은 계속 허용합니다.

## 검증

- `node --test tools/ci/repository-contract.test.mjs` — 194/194 PASS
- `ruby -e 'require "yaml"; abort unless YAML.safe_load(File.read(ARGV.fetch(0))).fetch("version") == 2' .github/dependabot.yml` — PASS
- `git diff --check` — PASS

## 영향

- [x] 제품/운영 위험 없음 (route/accessibility/mobile UX/backend API/auth/security 아님)
- [x] DB migration 없음
- [x] 배포 영향 없음
- [x] route/realtime/datapack contract 영향 없음
- [x] CI workflow·계약 테스트·release gate JSON 변경 없음 (있으면 full.md로 전환)

## 체크리스트

- [x] 이 PR은 B/C등급 작업이며 full template이 필요 없다.
- [x] CI 결과를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 폴백 리뷰를 단일 PR review로 게시했다.
