### PR TITLE
[Refactor] admin backend에 Java 21 문법 적용

### DIFF
--- a/backend/src/main/java/com/easysubway/admin/adapter/in/web/AdminOverviewPageController.java
+++ b/backend/src/main/java/com/easysubway/admin/adapter/in/web/AdminOverviewPageController.java
@@ -142,7 +142,7 @@ class AdminOverviewPageController {
 		}
 		if (visible.contains(AdminProgram.ROUTE_SEARCHES)) {
 			cards.add(dashboardCardService.card("경로 차단률", AdminProgram.ROUTE_SEARCHES.path(),
-				AdminMetricKeys.ROUTE_BLOCKED_RATE, blockedRate, String.format("%.1f%%", blockedRate)));
+				AdminMetricKeys.ROUTE_BLOCKED_RATE, blockedRate, "%.1f%%".formatted(blockedRate)));
 		}
 		if (visible.contains(AdminProgram.PUSH)) {
 			cards.add(dashboardCardService.card("푸시 실패", AdminProgram.PUSH.path(),
@@ -178,7 +178,7 @@ class AdminOverviewPageController {
 				List.of(AdminMetricKeys.ROUTE_BLOCKED_RATE, AdminMetricKeys.API_ERROR_RATE), days));
 		model.addAttribute("trends", trends);
 		// 정규화된 실제 기간(허용 밖 입력은 서비스가 7로 되돌리므로 첫 차트에서 읽는다).
-		model.addAttribute("trendDays", trends.get(0).data().days());
+		model.addAttribute("trendDays", trends.getFirst().data().days());
 	}
 
 	private TrendChart trendChart(String id, String title, List<String> keys, int days) {
@@ -235,7 +235,7 @@ class AdminOverviewPageController {
 		if (summary.totalCount() == 0) {
 			return "0.0%";
 		}
-		return String.format("%.1f%%", (double) summary.blockedCount() * 100 / summary.totalCount());
+		return "%.1f%%".formatted((double) summary.blockedCount() * 100 / summary.totalCount());
 	}
 
 	record DashboardView(

--- a/backend/src/main/java/com/easysubway/admin/metric/application/service/AdminDashboardCardService.java
+++ b/backend/src/main/java/com/easysubway/admin/metric/application/service/AdminDashboardCardService.java
@@ -26,7 +26,7 @@ public class AdminDashboardCardService {
 
 	public DashboardCard card(String title, String href, String metricKey, double currentValue, String valueLabel) {
 		AdminMetricChart chart = metricQueryService.chart(List.of(metricKey), SPARK_DAYS);
-		List<Double> values = chart.series().isEmpty() ? List.of() : chart.series().get(0).values();
+		List<Double> values = chart.series().isEmpty() ? List.of() : chart.series().getFirst().values();
 		String sparkPoints = AdminMetricSparkline.points(values, SPARK_WIDTH, SPARK_HEIGHT);
 		Delta delta = delta(values, currentValue);
 		return new DashboardCard(
@@ -59,7 +59,7 @@ public class AdminDashboardCardService {
 		if (magnitude == Math.rint(magnitude)) {
 			return String.valueOf((long) magnitude);
 		}
-		return String.format("%.1f", magnitude);
+		return "%.1f".formatted(magnitude);
 	}
 
 	/**

--- a/backend/src/main/java/com/easysubway/admin/navigation/AdminNavigationAdvice.java
+++ b/backend/src/main/java/com/easysubway/admin/navigation/AdminNavigationAdvice.java
@@ -63,7 +63,7 @@ class AdminNavigationAdvice {
 		if (profiles.contains("prod")) {
 			return "PRODUCTION";
 		}
-		return profiles.isEmpty() ? "DEV" : profiles.get(0).toUpperCase(java.util.Locale.ROOT);
+		return profiles.isEmpty() ? "DEV" : profiles.getFirst().toUpperCase(java.util.Locale.ROOT);
 	}
 
 	private String environmentTone() {

--- a/backend/src/main/java/com/easysubway/admin/operations/adapter/in/web/AdminOperationsPageController.java
+++ b/backend/src/main/java/com/easysubway/admin/operations/adapter/in/web/AdminOperationsPageController.java
@@ -247,7 +247,7 @@ class AdminOperationsPageController {
 		if (requested != null && groups.stream().anyMatch(group -> group.groupCode().equals(requested))) {
 			return requested;
 		}
-		return groups.isEmpty() ? "" : groups.get(0).groupCode();
+		return groups.isEmpty() ? "" : groups.getFirst().groupCode();
 	}
 
 	private static String ownerOrPrincipal(String owner, Principal principal) {

--- a/backend/src/main/java/com/easysubway/admin/web/AdminCommandTokenService.java
+++ b/backend/src/main/java/com/easysubway/admin/web/AdminCommandTokenService.java
@@ -23,7 +23,7 @@ public class AdminCommandTokenService {
 			String token = UUID.randomUUID().toString();
 			tokens.add(token);
 			while (tokens.size() > MAX_TOKENS_PER_SESSION) {
-				tokens.remove(tokens.iterator().next());
+				tokens.removeFirst();
 			}
 			return token;
 		}

--- a/backend/src/main/java/com/easysubway/admin/web/AdminHtmlExceptionResolver.java
+++ b/backend/src/main/java/com/easysubway/admin/web/AdminHtmlExceptionResolver.java
@@ -45,53 +45,50 @@ class AdminHtmlExceptionResolver implements HandlerExceptionResolver, Ordered {
 	private record AdminHtmlError(int status, String title, String message, String detail) {
 
 		static AdminHtmlError from(Exception exception) {
-			if (exception instanceof MasterDataWriteNotAllowedException) {
-				return new AdminHtmlError(
+			return switch (exception) {
+				case MasterDataWriteNotAllowedException error -> new AdminHtmlError(
 					HttpStatus.LOCKED.value(),
 					"읽기 전용 마스터 데이터",
 					"현재 운영 마스터 데이터는 저장할 수 없습니다.",
-					exception.getMessage()
+					error.getMessage()
 				);
-			}
-			if (exception instanceof ResourceNotFoundException) {
-				return new AdminHtmlError(
+				case ResourceNotFoundException error -> new AdminHtmlError(
 					HttpStatus.NOT_FOUND.value(),
 					"대상을 찾을 수 없습니다",
-					exception.getMessage(),
+					error.getMessage(),
 					"목록으로 돌아가 최신 상태를 다시 확인해 주세요."
 				);
-			}
-			if (exception instanceof ConflictException) {
-				return new AdminHtmlError(
+				case ConflictException error -> new AdminHtmlError(
 					HttpStatus.CONFLICT.value(),
 					"요청이 최신 상태와 충돌했습니다",
-					exception.getMessage(),
+					error.getMessage(),
 					"화면을 새로고침한 뒤 다시 시도해 주세요."
 				);
-			}
-			if (exception instanceof InvalidRequestException
-				|| exception instanceof MethodArgumentTypeMismatchException) {
-				return new AdminHtmlError(
+				case InvalidRequestException error -> new AdminHtmlError(
 					HttpStatus.BAD_REQUEST.value(),
 					"입력값을 확인해야 합니다",
-					exception.getMessage(),
+					error.getMessage(),
 					"입력한 값을 확인한 뒤 다시 제출해 주세요."
 				);
-			}
-			if (exception instanceof ErrorResponse errorResponse) {
-				return new AdminHtmlError(
+				case MethodArgumentTypeMismatchException error -> new AdminHtmlError(
+					HttpStatus.BAD_REQUEST.value(),
+					"입력값을 확인해야 합니다",
+					error.getMessage(),
+					"입력한 값을 확인한 뒤 다시 제출해 주세요."
+				);
+				case ErrorResponse errorResponse -> new AdminHtmlError(
 					errorResponse.getStatusCode().value(),
 					errorTitle(errorResponse.getStatusCode().value()),
 					"관리자 요청 형식이 올바르지 않습니다.",
 					exception.getMessage()
 				);
-			}
-			return new AdminHtmlError(
-				HttpStatus.INTERNAL_SERVER_ERROR.value(),
-				"요청을 처리하지 못했습니다",
-				"관리자 요청 처리 중 오류가 발생했습니다.",
-				"잠시 후 다시 시도하고, 문제가 반복되면 운영 로그를 확인해 주세요."
-			);
+				default -> new AdminHtmlError(
+					HttpStatus.INTERNAL_SERVER_ERROR.value(),
+					"요청을 처리하지 못했습니다",
+					"관리자 요청 처리 중 오류가 발생했습니다.",
+					"잠시 후 다시 시도하고, 문제가 반복되면 운영 로그를 확인해 주세요."
+				);
+			};
 		}
 
 		private static String errorTitle(int status) {

--- a/backend/src/test/java/com/easysubway/admin/audit/adapter/in/web/AdminAuditPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/admin/audit/adapter/in/web/AdminAuditPageControllerTest.java
@@ -220,7 +220,7 @@ class AdminAuditPageControllerTest {
 		Long privacyId = auditEventRepository.search(
 				new com.easysubway.admin.audit.application.AdminAuditQuery(
 					null, "alice", null, null, null, null, false, 0, 10))
-			.get(0)
+			.getFirst()
 			.id();
 
 		// 개인정보 조회 로그 화면(상세 포함)은 개인정보 로그 권한을 요구한다 — AUDIT_READ로는 접근 불가.

--- a/backend/src/test/java/com/easysubway/admin/audit/adapter/out/persistence/InMemoryAdminAuditEventRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/admin/audit/adapter/out/persistence/InMemoryAdminAuditEventRepositoryTest.java
@@ -63,7 +63,7 @@ class InMemoryAdminAuditEventRepositoryTest {
 		repository.save(event(AdminAuditEventType.ADMIN_ACTION, "admin-a", AdminAuditOutcome.SUCCESS,
 			"REPORT", "report-1", "업무 맥락", base));
 		AdminAuditEvent stored = repository.search(
-			new AdminAuditQuery(null, null, null, null, null, null, false, 0, 10)).get(0);
+			new AdminAuditQuery(null, null, null, null, null, null, false, 0, 10)).getFirst();
 
 		assertThat(repository.findById(stored.id(), null, false)).isPresent();
 		assertThat(repository.findById(stored.id(), AdminAuditEventType.PRIVACY_READ, false)).isEmpty();

--- a/backend/src/test/java/com/easysubway/admin/audit/adapter/out/persistence/JdbcAdminAuditEventRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/admin/audit/adapter/out/persistence/JdbcAdminAuditEventRepositoryTest.java
@@ -117,7 +117,7 @@ class JdbcAdminAuditEventRepositoryTest {
 
 		AdminAuditEvent pivot = repository.search(
 				new AdminAuditQuery(null, "admin-a", null, "a-3", null, null, false, 0, 10))
-			.get(0);
+			.getFirst();
 
 		assertThat(repository.findById(pivot.id(), null, false)).isPresent();
 		assertThat(repository.findById(pivot.id(), AdminAuditEventType.PRIVACY_READ, false)).isEmpty();

--- a/backend/src/test/java/com/easysubway/admin/batch/application/service/AdminBatchOperationServiceTest.java
+++ b/backend/src/test/java/com/easysubway/admin/batch/application/service/AdminBatchOperationServiceTest.java
@@ -73,7 +73,7 @@ class AdminBatchOperationServiceTest {
 			.containsExactly("COMPLETED", "FAILED");
 		assertThat(master.successCount()).isEqualTo(1);
 		assertThat(master.failureCount()).isEqualTo(1);
-		assertThat(master.executions().get(0).durationMillis()).isEqualTo(60_000L);
+		assertThat(master.executions().getFirst().durationMillis()).isEqualTo(60_000L);
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/admin/metric/application/service/AdminMetricQueryServiceTest.java
+++ b/backend/src/test/java/com/easysubway/admin/metric/application/service/AdminMetricQueryServiceTest.java
@@ -34,7 +34,7 @@ class AdminMetricQueryServiceTest {
 		// 직전 7일 [06-23, 06-29]: 06-29=60, 나머지 결측 → 60
 		save(AdminMetricKeys.ROUTE_SEARCHES, TODAY.minusDays(7), 60);
 
-		AdminMetricComparison comparison = service.compare(List.of(AdminMetricKeys.ROUTE_SEARCHES), 7).get(0);
+		AdminMetricComparison comparison = service.compare(List.of(AdminMetricKeys.ROUTE_SEARCHES), 7).getFirst();
 
 		assertThat(comparison.current()).isEqualTo(150.0);
 		assertThat(comparison.previous()).isEqualTo(60.0);
@@ -52,7 +52,7 @@ class AdminMetricQueryServiceTest {
 		save(AdminMetricKeys.ROUTE_BLOCKED_RATE, TODAY.minusDays(2), 20);
 		save(AdminMetricKeys.ROUTE_BLOCKED_RATE, TODAY.minusDays(7), 10);
 
-		AdminMetricComparison comparison = service.compare(List.of(AdminMetricKeys.ROUTE_BLOCKED_RATE), 7).get(0);
+		AdminMetricComparison comparison = service.compare(List.of(AdminMetricKeys.ROUTE_BLOCKED_RATE), 7).getFirst();
 
 		assertThat(comparison.current()).isCloseTo(25.0, within(0.001));
 		assertThat(comparison.previous()).isCloseTo(10.0, within(0.001));
@@ -64,7 +64,7 @@ class AdminMetricQueryServiceTest {
 	void undefinedPercentWhenPreviousIsZero() {
 		save(AdminMetricKeys.USERS_ACTIVE, TODAY, 30);
 
-		AdminMetricComparison comparison = service.compare(List.of(AdminMetricKeys.USERS_ACTIVE), 7).get(0);
+		AdminMetricComparison comparison = service.compare(List.of(AdminMetricKeys.USERS_ACTIVE), 7).getFirst();
 
 		assertThat(comparison.current()).isEqualTo(30.0);
 		assertThat(comparison.previous()).isEqualTo(0.0);

--- a/backend/src/test/java/com/easysubway/admin/operations/adapter/in/web/AdminOperationsPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/admin/operations/adapter/in/web/AdminOperationsPageControllerTest.java
@@ -214,7 +214,7 @@ class AdminOperationsPageControllerTest {
 		openIncident("database DOWN");
 
 		String incidentId = auditEventRepository.findRecent(AdminAuditEventType.INCIDENT_CHANGE, 1)
-			.get(0)
+			.getFirst()
 			.targetId();
 
 		assertThat(incidentId).startsWith("INC-");

--- a/backend/src/test/java/com/easysubway/admin/operations/application/service/AdminIncidentServiceTest.java
+++ b/backend/src/test/java/com/easysubway/admin/operations/application/service/AdminIncidentServiceTest.java
@@ -58,7 +58,7 @@ class AdminIncidentServiceTest {
 				AdminIncidentStatus.MONITORING,
 				AdminIncidentStatus.RESOLVED
 			);
-		assertThat(timeline.get(0).isInitial()).isTrue();
+		assertThat(timeline.getFirst().isInitial()).isTrue();
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/admin/savedview/application/service/AdminSavedViewServiceTest.java
+++ b/backend/src/test/java/com/easysubway/admin/savedview/application/service/AdminSavedViewServiceTest.java
@@ -38,8 +38,8 @@ class AdminSavedViewServiceTest {
 
 		var views = service.listViews("admin-1", "a-reports");
 		assertThat(views).hasSize(1);
-		assertThat(views.get(0).viewId()).isEqualTo("view-1");
-		assertThat(views.get(0).queryParams()).isEqualTo("status=SUBMITTED&sort=created_at,asc");
+		assertThat(views.getFirst().viewId()).isEqualTo("view-1");
+		assertThat(views.getFirst().queryParams()).isEqualTo("status=SUBMITTED&sort=created_at,asc");
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/common/web/pagination/EgovPaginationViewTest.java
+++ b/backend/src/test/java/com/easysubway/common/web/pagination/EgovPaginationViewTest.java
@@ -28,7 +28,7 @@ class EgovPaginationViewTest {
 				org.assertj.core.groups.Tuple.tuple(3, "4"),
 				org.assertj.core.groups.Tuple.tuple(4, "5")
 			);
-		assertThat(view.pageLinks().get(0).current()).isTrue();
+		assertThat(view.pageLinks().getFirst().current()).isTrue();
 	}
 
 	@Test
@@ -54,7 +54,7 @@ class EgovPaginationViewTest {
 		assertThat(view.hasPrevious()).isTrue();
 		assertThat(view.hasNext()).isFalse();
 		assertThat(view.nextPage()).isEqualTo(4);
-		assertThat(view.pageLinks().get(view.pageLinks().size() - 1).current()).isTrue();
+		assertThat(view.pageLinks().getLast().current()).isTrue();
 	}
 
 	@Test
@@ -76,7 +76,7 @@ class EgovPaginationViewTest {
 
 		assertThat(view.page()).isEqualTo(4);
 		assertThat(view.hasNext()).isFalse();
-		assertThat(view.pageLinks().get(view.pageLinks().size() - 1).page()).isEqualTo(4);
+		assertThat(view.pageLinks().getLast().page()).isEqualTo(4);
 	}
 
 	@Test
@@ -139,7 +139,7 @@ class EgovPaginationViewTest {
 		assertThat(view.hasPrevious()).isTrue();
 		assertThat(view.hasNext()).isFalse();
 		assertThat(view.previousPage()).isEqualTo(2);
-		assertThat(view.pageLinks().get(view.pageLinks().size() - 1).current()).isTrue();
+		assertThat(view.pageLinks().getLast().current()).isTrue();
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/notice/adapter/in/web/ServiceNoticeAdminApiControllerTest.java
+++ b/backend/src/test/java/com/easysubway/notice/adapter/in/web/ServiceNoticeAdminApiControllerTest.java
@@ -76,7 +76,7 @@ class ServiceNoticeAdminApiControllerTest {
 
 		List<ServiceNotice> active = repository.findActiveAt(LocalDateTime.now(ZoneOffset.UTC));
 		assertThat(active).hasSize(1);
-		assertThat(auditRecorded("PUBLISH_NOTICE", active.get(0).id())).isTrue();
+		assertThat(auditRecorded("PUBLISH_NOTICE", active.getFirst().id())).isTrue();
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/notice/adapter/in/web/ServiceNoticeAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/notice/adapter/in/web/ServiceNoticeAdminPageControllerTest.java
@@ -76,7 +76,7 @@ class ServiceNoticeAdminPageControllerTest {
 
 		var notices = repository.findActiveAt(LocalDateTime.now(ZoneOffset.UTC));
 		assertThat(notices).hasSize(1);
-		String noticeId = notices.get(0).id();
+		String noticeId = notices.getFirst().id();
 		assertThat(auditRecorded("PUBLISH_NOTICE", noticeId)).isTrue();
 
 		String populatedPage = mockMvc.perform(get("/admin/notices/page")


### PR DESCRIPTION
## 관련 이슈

Refs #2163

## 작업 내용

- admin HTML 예외 분기를 Java 21 pattern `switch`로 정리했습니다.
- non-empty가 보장된 목록과 `LinkedHashSet`에 Sequenced Collections API를 적용했습니다.
- default locale을 그대로 사용하는 숫자 표시는 `String.formatted()`로 간결하게 만들었습니다.
- admin/common/notice 테스트의 첫·마지막 원소 접근을 `getFirst()`·`getLast()`로 정리했습니다.
- `ads`, `legal`, `health`, `usage`는 후보를 검토했으며 의미 보존 또는 가독성 이득이 없는 변환은 하지 않았습니다.

## 검증

- `cd backend && ./gradlew test --tests 'com.easysubway.admin.*' --tests 'com.easysubway.common.*' --tests 'com.easysubway.notice.*' --no-daemon` — PASS
- `cd backend && ./gradlew check --no-daemon` — PASS (`BUILD SUCCESSFUL in 3m 2s`)
- `git diff --check` — PASS

## 영향

- [x] 제품/운영 위험 없음 (backend 내부 동작 유지 리팩터링)
- [x] DB migration 없음
- [x] 배포 영향 없음
- [x] route/realtime/datapack contract 영향 없음
- [x] CI workflow·계약 테스트·release gate JSON 변경 없음

## 체크리스트

- [x] 이 PR은 B등급 작업이며 short template 범위다.
- [ ] CI 결과를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다.
- [ ] actionable finding과 review thread를 모두 해결했다.
