### PR TITLE
[Refactor] data workflow에 Java 21 API 적용

### DIFF
--- a/backend/src/main/java/com/easysubway/report/application/service/FacilityReportReceiptTokens.java
+++ b/backend/src/main/java/com/easysubway/report/application/service/FacilityReportReceiptTokens.java
@@ -4,6 +4,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.util.Base64;
+import java.util.HexFormat;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 
@@ -11,6 +12,7 @@ class FacilityReportReceiptTokens {
 
 	private static final int TOKEN_BYTES = 32;
 	private static final String HMAC_ALGORITHM = "HmacSHA256";
+	private static final HexFormat HEX = HexFormat.of();
 
 	private final String pepper;
 	private final SecureRandom secureRandom;
@@ -77,11 +79,7 @@ class FacilityReportReceiptTokens {
 	}
 
 	private String hex(byte[] bytes) {
-		StringBuilder builder = new StringBuilder(bytes.length * 2);
-		for (byte value : bytes) {
-			builder.append(String.format("%02x", value & 0xff));
-		}
-		return builder.toString();
+		return HEX.formatHex(bytes);
 	}
 
 	record IssuedReceiptToken(String token, String hash) {

--- a/backend/src/test/java/com/easysubway/datapack/application/service/DatapackReleaseRequestServiceTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/application/service/DatapackReleaseRequestServiceTest.java
@@ -99,7 +99,7 @@ class DatapackReleaseRequestServiceTest {
 		assertThat(status(created.approvalId())).isEqualTo("DISPATCHED");
 		assertThat(dispatchIdempotencyKey(created.approvalId())).isEqualTo(created.approvalId());
 		assertThat(dispatchPort.commands()).hasSize(1);
-		var command = dispatchPort.commands().get(0);
+		var command = dispatchPort.commands().getFirst();
 		assertThat(command.targetChannel()).isEqualTo("staging");
 		assertThat(command.releaseRequestId()).isEqualTo(created.approvalId());
 		assertThat(command.buildSpecPath()).isEqualTo("tools/datapack/fixtures/candidate-build-spec.json");

--- a/backend/src/test/java/com/easysubway/field/adapter/out/persistence/JdbcFieldVerificationChangeHistoryRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/field/adapter/out/persistence/JdbcFieldVerificationChangeHistoryRepositoryTest.java
@@ -81,7 +81,7 @@ class JdbcFieldVerificationChangeHistoryRepositoryTest {
 		assertThat(histories)
 			.extracting(FieldVerificationChangeHistory::id)
 			.containsExactly("history-new", "history-old");
-		assertThat(histories.get(0)).satisfies(history -> {
+		assertThat(histories.getFirst()).satisfies(history -> {
 			assertThat(history.sessionId()).isEqualTo("field-verification-sadang-2026-06");
 			assertThat(history.itemId()).isEqualTo("field-verification-sadang-restroom");
 			assertThat(history.previousStatus()).isEqualTo(FieldVerificationStatus.PLANNED);

--- a/backend/src/test/java/com/easysubway/field/application/service/FieldVerificationServiceTest.java
+++ b/backend/src/test/java/com/easysubway/field/application/service/FieldVerificationServiceTest.java
@@ -139,7 +139,7 @@ class FieldVerificationServiceTest {
 				"field-verification-sadang-restroom",
 				"field-verification-sadang-elevator"
 			);
-		assertThat(histories.get(0)).satisfies(history -> {
+		assertThat(histories.getFirst()).satisfies(history -> {
 			assertThat(history.sessionId()).isEqualTo("field-verification-sadang-2026-06");
 			assertThat(history.stationId()).isEqualTo("station-sadang");
 			assertThat(history.previousStatus()).isEqualTo(FieldVerificationStatus.PLANNED);
@@ -177,8 +177,8 @@ class FieldVerificationServiceTest {
 			"admin-user"
 		));
 
-		String sadangHistoryId = service.listStationChangeHistory("station-sadang").get(0).id();
-		String sangnoksuHistoryId = service.listStationChangeHistory("station-sangnoksu").get(0).id();
+		String sadangHistoryId = service.listStationChangeHistory("station-sadang").getFirst().id();
+		String sangnoksuHistoryId = service.listStationChangeHistory("station-sangnoksu").getFirst().id();
 
 		assertThat(sadangHistoryId).isNotEqualTo(sangnoksuHistoryId);
 	}

--- a/backend/src/test/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportReviewAuditRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportReviewAuditRepositoryTest.java
@@ -80,7 +80,7 @@ class JdbcFacilityReportReviewAuditRepositoryTest {
 		assertThat(audits)
 			.extracting(FacilityReportReviewAudit::id)
 			.containsExactly("audit-old", "audit-new");
-		assertThat(audits.get(0)).satisfies(audit -> {
+		assertThat(audits.getFirst()).satisfies(audit -> {
 			assertThat(audit.reportId()).isEqualTo("report-target");
 			assertThat(audit.reviewerId()).isEqualTo("admin-reviewer");
 			assertThat(audit.decision()).isEqualTo(FacilityReportReviewDecision.ACCEPT);


### PR DESCRIPTION
## 관련 이슈

Refs #2163

## 작업 내용

- 시설 제보 영수증 해시의 수동 16진수 변환을 Java 표준 `HexFormat`으로 교체했습니다.
- datapack·현장 검증·시설 제보 테스트의 명확한 첫 원소 접근을 `getFirst()`로 정리했습니다.
- collection·operator·quality·notification·favorite·profile·user 범위를 함께 점검했으며, 가독성 이득 없는 강제 문법 치환은 제외했습니다.

## 검증

- 실행한 명령과 결과:
  - `cd backend && ./gradlew test --tests 'com.easysubway.report.*' --tests 'com.easysubway.datapack.*' --tests 'com.easysubway.field.*' --no-daemon` — PASS (50s)
  - `cd backend && ./gradlew check --no-daemon` — PASS (3m 1s)
  - `git diff --check` — PASS

## 영향

- [x] 제품/운영 위험 없음 (route/accessibility/mobile UX/backend API/auth/security 아님)
- [x] DB migration 없음
- [x] 배포 영향 없음
- [x] route/realtime/datapack contract 영향 없음
- [x] CI workflow·계약 테스트·release gate JSON 변경 없음 (있으면 full.md로 전환)

## 체크리스트

- [x] 이 PR은 B/C등급 작업이며 full template이 필요 없다.
- [x] CI 결과를 확인했다. (Backend CI 포함 required checks PASS)
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit PR Review 객체가 없어 독립 폴백 리뷰를 단일 PR Review [4706599566](https://github.com/AquilaXk/easysubway/pull/2165#pullrequestreview-4706599566)로 게시했다. (actionable 0건)
