### PR TITLE
[Refactor] routing backend에 Java 21 API 적용

### DIFF
--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
@@ -287,7 +287,7 @@ class RouteSearchController {
 			List<LegDto> legs = LegDto.fromSteps(result.steps(), departureTime, result.mobilityType(), mobilityPreset);
 			OffsetDateTime plannedArrivalTime = legs.isEmpty()
 				? departureTime
-				: OffsetDateTime.parse(legs.get(legs.size() - 1).plannedArrivalTime());
+				: OffsetDateTime.parse(legs.getLast().plannedArrivalTime());
 			int durationSeconds = Math.toIntExact(Duration.between(departureTime, plannedArrivalTime).toSeconds());
 			return new ItineraryDto(
 				result.routeSearchId() + "-primary",

--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/InMemoryRouteSearchRepository.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/InMemoryRouteSearchRepository.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.SequencedMap;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
@@ -41,8 +42,8 @@ public class InMemoryRouteSearchRepository
 	private static final String DELETED_USER_ID = "deleted-user";
 	private static final String DELETED_COMMENT = "사용자 데이터 삭제로 경로 피드백 내용이 삭제되었습니다.";
 
-	private final Map<String, RouteSearchResult> routeSearches = new LinkedHashMap<>();
-	private final Map<String, RouteFeedback> routeFeedbacks = new LinkedHashMap<>();
+	private final SequencedMap<String, RouteSearchResult> routeSearches = new LinkedHashMap<>();
+	private final SequencedMap<String, RouteFeedback> routeFeedbacks = new LinkedHashMap<>();
 
 	@Override
 	public Optional<RouteSearchResult> loadRouteSearch(String routeSearchId) {
@@ -281,16 +282,14 @@ public class InMemoryRouteSearchRepository
 	private void evictOldestRouteSearches() {
 		// 공개 API 요청으로 생성되는 임시 결과가 프로세스 메모리에 무한히 쌓이지 않게 한다.
 		while (routeSearches.size() > MAX_STORED_ROUTE_SEARCHES) {
-			String oldestRouteSearchId = routeSearches.keySet().iterator().next();
-			routeSearches.remove(oldestRouteSearchId);
+			routeSearches.pollFirstEntry();
 		}
 	}
 
 	private void evictOldestRouteFeedbacks() {
 		// 피드백은 운영 DB 전환 전까지 임시 보관하되 공개 요청으로 메모리가 무한 증가하지 않게 한다.
 		while (routeFeedbacks.size() > MAX_STORED_ROUTE_FEEDBACKS) {
-			String oldestFeedbackId = routeFeedbacks.keySet().iterator().next();
-			routeFeedbacks.remove(oldestFeedbackId);
+			routeFeedbacks.pollFirstEntry();
 		}
 	}
 

--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/InMemoryRouteSearchRepository.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/InMemoryRouteSearchRepository.java
@@ -42,6 +42,7 @@ public class InMemoryRouteSearchRepository
 	private static final String DELETED_USER_ID = "deleted-user";
 	private static final String DELETED_COMMENT = "사용자 데이터 삭제로 경로 피드백 내용이 삭제되었습니다.";
 
+	// LinkedHashMap의 삽입 순서를 저장 순서로 삼아, 한도 초과 시 가장 먼저 저장된 항목부터 제거한다.
 	private final SequencedMap<String, RouteSearchResult> routeSearches = new LinkedHashMap<>();
 	private final SequencedMap<String, RouteFeedback> routeFeedbacks = new LinkedHashMap<>();
 

--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/JdbcRouteTimetableRepository.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/JdbcRouteTimetableRepository.java
@@ -211,7 +211,7 @@ public class JdbcRouteTimetableRepository implements LoadRouteTimetablePort {
 			"SELECT feed_end_date FROM transit_feed_info LIMIT 1",
 			(resultSet, rowNumber) -> parseFeedEndDate(resultSet.getString("feed_end_date"))
 		);
-		return rows.isEmpty() ? null : rows.get(0);
+		return rows.isEmpty() ? null : rows.getFirst();
 	}
 
 	private static LocalDate parseFeedEndDate(String value) {

--- a/backend/src/test/java/com/easysubway/realtime/application/RealtimeGatewayServiceTest.java
+++ b/backend/src/test/java/com/easysubway/realtime/application/RealtimeGatewayServiceTest.java
@@ -76,7 +76,7 @@ class RealtimeGatewayServiceTest {
 		RealtimeArrivalResult result = service.arrivals(sangnoksuQuery());
 
 		assertThat(result.arrivals()).hasSize(1);
-		RealtimeArrival arrival = result.arrivals().get(0);
+		RealtimeArrival arrival = result.arrivals().getFirst();
 		// 하류(resolver)가 Instant.parse 가능한 ISO로 정규화 → drop 버그의 근본(포맷 누출) 차단.
 		assertThat(Instant.parse(arrival.providerReceivedAt())).isEqualTo(Instant.parse("2026-06-26T08:00:00Z"));
 		// v1 표시용 수신지연 보정은 유지: 150 - 20초 delay = 130.
@@ -378,8 +378,8 @@ class RealtimeGatewayServiceTest {
 		RealtimeArrivalResult result = service.arrivals(sangnoksuQuery());
 
 		assertThat(result.status()).hasToString("FRESH");
-		assertThat(result.arrivals().get(0).etaSeconds()).isEqualTo(150);
-		assertThat(result.arrivals().get(0).message()).isEqualTo("3분 후");
+		assertThat(result.arrivals().getFirst().etaSeconds()).isEqualTo(150);
+		assertThat(result.arrivals().getFirst().message()).isEqualTo("3분 후");
 	}
 
 	@Test
@@ -1041,8 +1041,8 @@ class RealtimeGatewayServiceTest {
 			List<RealtimeArrival> arrivals = provider.arrivals(sangnoksuQuery());
 
 			assertThat(arrivals).hasSize(1);
-			assertThat(arrivals.get(0).stationName()).isEqualTo("상록수");
-			assertThat(arrivals.get(0).message()).isEqualTo("3분 후");
+			assertThat(arrivals.getFirst().stationName()).isEqualTo("상록수");
+			assertThat(arrivals.getFirst().message()).isEqualTo("3분 후");
 		} finally {
 			if (previous == null) {
 				System.clearProperty("spring.profiles.active");
@@ -1068,7 +1068,7 @@ class RealtimeGatewayServiceTest {
 		List<RealtimeArrival> arrivals = provider.arrivals(sangnoksuQuery());
 
 		assertThat(arrivals).hasSize(1);
-		assertThat(arrivals.get(0).stationName()).isEqualTo("상록수");
+		assertThat(arrivals.getFirst().stationName()).isEqualTo("상록수");
 	}
 
 	@Test
@@ -1160,8 +1160,8 @@ class RealtimeGatewayServiceTest {
 		);
 
 		assertThat(arrivals).hasSize(1);
-		assertThat(arrivals.get(0).destination()).isEqualTo("오이도행 - 중앙방면");
-		assertThat(arrivals.get(0).servicePattern()).isEqualTo("급행");
+		assertThat(arrivals.getFirst().destination()).isEqualTo("오이도행 - 중앙방면");
+		assertThat(arrivals.getFirst().servicePattern()).isEqualTo("급행");
 	}
 
 	private RealtimeQuery sangnoksuQuery() {

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/ProductionRouteApiClosureTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/ProductionRouteApiClosureTest.java
@@ -128,7 +128,7 @@ class ProductionRouteApiClosureTest {
 			.contentType(MediaType.APPLICATION_JSON)
 			.content(body);
 		if (includeMarkers) {
-			request.header("Forwarded", "for=" + HEADER_MARKERS.get(0))
+			request.header("Forwarded", "for=" + HEADER_MARKERS.getFirst())
 				.header("X-Forwarded-For", HEADER_MARKERS.get(1))
 				.header("X-Real-IP", HEADER_MARKERS.get(2));
 		}

--- a/backend/src/test/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoaderTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoaderTest.java
@@ -252,14 +252,13 @@ class TimetableSeedLoaderTest {
 	}
 
 	private Resource itxSeed(String admissionStatus, boolean admissionEligible, String freshUntil) {
-		return new ByteArrayResource((
-			"INSERT INTO service_calendars (service_id, start_date, end_date, timezone, monday, tuesday, wednesday, thursday, friday, saturday, sunday) VALUES ('itx-weekday','20260714','20260721','Asia/Seoul',TRUE,TRUE,TRUE,TRUE,TRUE,FALSE,FALSE);\n"
-			+ "INSERT INTO transit_routes (id, timezone, line_id, route_short_name, route_long_name, direction_name) VALUES ('itx-down','Asia/Seoul','line-54a7b980b7c3','ITX-청춘','','down');\n"
-			+ "INSERT INTO route_service_artifact_evidence (service_class, timetable_artifact_id, timetable_artifact_sha256, canonical_pack_id, canonical_pack_sha256, canonical_pack_sqlite_sha256, admission_status, admission_eligible, fresh_until, source_issue) VALUES ('ITX_CHEONGCHUN','test-only-itx','aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa','capital','bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb','cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc','"
-			+ admissionStatus + "'," + admissionEligible + ",'" + freshUntil + "',2116);\n"
-			+ "INSERT INTO transit_trips (id, route_id, service_id, service_pattern, service_class, service_day_start_seconds, trip_headsign, direction_id) VALUES ('itx-1','itx-down','itx-weekday','EXPRESS','ITX_CHEONGCHUN',0,'춘천','down');\n"
-			+ "INSERT INTO transit_stop_times (trip_id, stop_sequence, station_id, line_id, pickup_type, drop_off_type, arrival_seconds, departure_seconds) VALUES ('itx-1',1,'station-b819702fa7d9','line-54a7b980b7c3',0,0,28800,28860);\n"
-		).getBytes()) {
+		return new ByteArrayResource("""
+			INSERT INTO service_calendars (service_id, start_date, end_date, timezone, monday, tuesday, wednesday, thursday, friday, saturday, sunday) VALUES ('itx-weekday','20260714','20260721','Asia/Seoul',TRUE,TRUE,TRUE,TRUE,TRUE,FALSE,FALSE);
+			INSERT INTO transit_routes (id, timezone, line_id, route_short_name, route_long_name, direction_name) VALUES ('itx-down','Asia/Seoul','line-54a7b980b7c3','ITX-청춘','','down');
+			INSERT INTO route_service_artifact_evidence (service_class, timetable_artifact_id, timetable_artifact_sha256, canonical_pack_id, canonical_pack_sha256, canonical_pack_sqlite_sha256, admission_status, admission_eligible, fresh_until, source_issue) VALUES ('ITX_CHEONGCHUN','test-only-itx','aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa','capital','bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb','cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc','%s',%s,'%s',2116);
+			INSERT INTO transit_trips (id, route_id, service_id, service_pattern, service_class, service_day_start_seconds, trip_headsign, direction_id) VALUES ('itx-1','itx-down','itx-weekday','EXPRESS','ITX_CHEONGCHUN',0,'춘천','down');
+			INSERT INTO transit_stop_times (trip_id, stop_sequence, station_id, line_id, pickup_type, drop_off_type, arrival_seconds, departure_seconds) VALUES ('itx-1',1,'station-b819702fa7d9','line-54a7b980b7c3',0,0,28800,28860);
+			""".formatted(admissionStatus, admissionEligible, freshUntil).getBytes()) {
 			@Override
 			public String getFilename() {
 				return "itx-seed.sql";

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -113,11 +113,11 @@ class RouteSearchServiceTest {
 		assertThat(result.steps())
 			.extracting("stepType")
 			.containsExactly("entry", "ride", "exit");
-		assertThat(result.steps().get(0).estimatedMinutes()).isEqualTo(5);
-		assertThat(result.steps().get(0).distanceMeters()).isEqualTo(180);
-		assertThat(result.steps().get(0).includesStairs()).isFalse();
-		assertThat(result.steps().get(0).stairAccessState()).isEqualTo("UNKNOWN");
-		assertThat(result.steps().get(0).requiresAccessibilityCheck()).isTrue();
+		assertThat(result.steps().getFirst().estimatedMinutes()).isEqualTo(5);
+		assertThat(result.steps().getFirst().distanceMeters()).isEqualTo(180);
+		assertThat(result.steps().getFirst().includesStairs()).isFalse();
+		assertThat(result.steps().getFirst().stairAccessState()).isEqualTo("UNKNOWN");
+		assertThat(result.steps().getFirst().requiresAccessibilityCheck()).isTrue();
 		assertThat(result.steps().get(1).estimatedMinutes()).isGreaterThan(0);
 		assertThat(result.steps().get(1).requiresAccessibilityCheck()).isFalse();
 		assertThat(result.warnings())
@@ -134,7 +134,7 @@ class RouteSearchServiceTest {
 			MobilityType.STROLLER
 		));
 
-		String warningJson = new ObjectMapper().writeValueAsString(result.warnings().get(0));
+		String warningJson = new ObjectMapper().writeValueAsString(result.warnings().getFirst());
 
 		assertThat(warningJson).contains("\"code\":\"LOW_DATA_CONFIDENCE\"");
 		assertThat(warningJson).doesNotContain("message");
@@ -647,7 +647,7 @@ class RouteSearchServiceTest {
 		assertThat(results)
 			.extracting(RouteSearchResult::transferCount)
 			.containsExactly(1, 0);
-		assertThat(results.get(0).steps())
+		assertThat(results.getFirst().steps())
 			.filteredOn(step -> "transfer".equals(step.stepType()))
 			.extracting("fromStationId")
 			.containsExactly("station-transfer");
@@ -732,7 +732,7 @@ class RouteSearchServiceTest {
 		assertThat(results)
 			.extracting(RouteSearchResult::routeSearchId)
 			.doesNotHaveDuplicates();
-		assertThat(results.get(0).steps())
+		assertThat(results.getFirst().steps())
 			.filteredOn(step -> "transfer".equals(step.stepType()))
 			.extracting("fromStationId")
 			.containsExactly("station-step-free-transfer");
@@ -1850,7 +1850,7 @@ class RouteSearchServiceTest {
 		assertThat(stairOnlyResult.warnings())
 			.extracting("code")
 			.contains(RouteWarningCode.STAIR_ONLY_ACCESS);
-		assertThat(stairOnlyResult.steps().get(0).includesStairs()).isTrue();
+		assertThat(stairOnlyResult.steps().getFirst().includesStairs()).isTrue();
 		assertThat(stairOnlyResult.steps().get(1).includesStairs()).isFalse();
 		assertThat(stairOnlyResult.steps().get(2).includesStairs()).isTrue();
 		assertThat(stairOnlyResult.steps())


### PR DESCRIPTION
## 관련 이슈

Closes #2163

## 작업 내용

- route in-memory 저장소의 insertion-order eviction을 Java 21 `SequencedMap.pollFirstEntry()`로 직접 표현했습니다.
- non-empty가 보장된 route/realtime production·test 접근을 `getFirst()`·`getLast()`로 정리했습니다.
- 여러 줄 ITX timetable SQL fixture를 text block과 `formatted()`로 바꿔 원문 구조를 드러냈습니다.
- `realtime`, `route`, `train`, `transit`, test-only `architecture`·`contract`·`support`를 점검했으며, 계산 index·locale 고정 formatting·side-effect switch는 의미 보존을 위해 유지했습니다.

## 검증

- 실행한 명령과 결과:
  - `cd backend && ./gradlew test --tests 'com.easysubway.realtime.*' --tests 'com.easysubway.route.*' --tests 'com.easysubway.train.*' --tests 'com.easysubway.transit.*' --tests 'com.easysubway.architecture.*' --tests 'com.easysubway.contract.*' --tests 'com.easysubway.support.*' --no-daemon` — PASS (52s)
  - `cd backend && ./gradlew test --tests 'com.easysubway.route.adapter.out.persistence.InMemoryRouteSearchRepositoryTest' --no-daemon` — PASS (5s)
  - `cd backend && ./gradlew check --no-daemon` — PASS (3m 5s, 최종 head)
  - `git diff --check` — PASS

## 영향

- [x] 제품/운영 위험 없음 (route/accessibility/mobile UX/backend API/auth/security 동작 변경 없음)
- [x] DB migration 없음
- [x] 배포 영향 없음
- [x] route/realtime/datapack contract 영향 없음
- [x] CI workflow·계약 테스트·release gate JSON 변경 없음 (있으면 full.md로 전환)

## 체크리스트

- [x] 이 PR은 B등급 동작 보존 리팩터링이며 full template이 필요 없다.
- [x] CI 결과를 확인했다. (Backend CI 포함 required checks PASS)
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit PR Review 객체가 없어 독립 폴백 리뷰를 단일 PR Review [4706819386](https://github.com/AquilaXk/easysubway/pull/2166#pullrequestreview-4706819386)로 게시했다. (actionable 0건)
