### PR TITLE
[Fix] rollback 승인 provenance를 signed manifest에 결합

### DIFF
--- a/tools/datapack/validate-release-evidence-bundle.mjs
+++ b/tools/datapack/validate-release-evidence-bundle.mjs
@@ -204,6 +204,9 @@ function validateRollbackArtifactBinding(rescue, evidenceRaw, evidence, manifest
     ["failedManifestSha256", rescue.rcManifestSha256],
     ["knownGoodManifestSha256", evidence.knownGood?.manifestSha256],
     ["rollbackApprovalEventId", rescue.rollbackApprovalEventId],
+    ["approvedByRole", evidence.approvedByRole],
+    ["approvedAt", evidence.approvedAt],
+    ["reasonCode", evidence.reasonCode],
   ]) {
     if (provenance?.[field] !== expected) {
       throw new Error(`rollbackRescue manifest rollbackProvenance ${field} mismatch`);

--- a/tools/datapack/validate-release-evidence-bundle.test.mjs
+++ b/tools/datapack/validate-release-evidence-bundle.test.mjs
@@ -294,6 +294,9 @@ test("release evidence bundle validator는 publish gate status와 deferred headw
     schemaVersion: 1,
     artifactKind: "datapack-rollback-rescue-evidence",
     rollbackApprovalEventId: bundle.rollbackRescue.rollbackApprovalEventId,
+    approvedByRole: "admin.datapack.rollback",
+    approvedAt: "2026-07-15T00:30:00.000Z",
+    reasonCode: "ADMIN_APPROVED_ROLLBACK",
     from: { releaseSequence: 115, manifestSha256: bundle.manifestSha256 },
     failed: { releaseSequence: 115, manifestSha256: bundle.manifestSha256 },
     knownGood: {
@@ -331,6 +334,27 @@ test("release evidence bundle validator는 publish gate status와 deferred headw
     "--rollback-manifest", rollbackManifestPath,
   ];
   await execFileAsync(process.execPath, [...rollbackValidatorCommand, "--require-pass"], { cwd: root });
+
+  for (const [field, tampered] of [
+    ["approvedByRole", "admin.datapack.other"],
+    ["approvedAt", "2026-07-15T00:31:00.000Z"],
+    ["reasonCode", "OTHER_REASON"],
+  ]) {
+    const original = rollbackEvidence[field];
+    rollbackEvidence[field] = tampered;
+    const tamperedEvidenceRaw = json(rollbackEvidence);
+    bundle.rollbackRescue.evidenceSha256 = sha256(tamperedEvidenceRaw);
+    await writeFile(rollbackEvidencePath, tamperedEvidenceRaw);
+    await writeFile(bundlePath, json(bundle));
+    await assert.rejects(
+      execFileAsync(process.execPath, [...rollbackValidatorCommand, "--require-pass"], { cwd: root }),
+      new RegExp(`rollbackProvenance ${field} mismatch`),
+    );
+    rollbackEvidence[field] = original;
+  }
+  bundle.rollbackRescue.evidenceSha256 = sha256(boundRollbackEvidenceRaw);
+  await writeFile(rollbackEvidencePath, boundRollbackEvidenceRaw);
+  await writeFile(bundlePath, json(bundle));
 
   const unsignedManifest = JSON.parse(rollbackManifestRaw);
   delete unsignedManifest.signature;


### PR DESCRIPTION
## 관련 이슈

Refs #2051

## 작업 배경

- PR #2160 auto-merge 뒤 fresh Review에서 승인 provenance 일부가 signed rollback manifest와 결합되지 않는 P2를 확인했다.

## 작업 내용

- rollback evidence의 `approvedByRole`, `approvedAt`, `reasonCode`를 signed `rollbackProvenance`와 대조한다.
- 세 필드 변조 후 evidence hash를 다시 계산해도 거부되는 회귀 테스트를 추가한다.

## 검증

- 실행한 명령과 결과: `node --test tools/datapack/validate-release-evidence-bundle.test.mjs` — 1/1 PASS
- 실행한 명령과 결과: `git diff --check origin/main...HEAD` — PASS

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| rollback 승인 provenance 변조 차단 | Node | validator 회귀 테스트 | CI 및 위 검증 명령 | PASS |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `validateRollbackArtifactBinding`의 signed provenance 비교와 세 필드 tamper loop

## 리스크

- evidence producer가 signed manifest와 다른 승인 메타데이터를 내면 이제 fail closed한다. production publish·rollback·deploy는 수행하지 않는다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향 없음.
