### PR TITLE
[Fix] #2171 Route V2 gateway 시작 명령 복구

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -106,6 +106,7 @@ services:
     restart: unless-stopped
     user: "10001:10001"
     entrypoint: ["/bin/sh", "/etc/nginx/route-v2-entrypoint.sh"]
+    command: ["nginx", "-g", "daemon off;"]
     read_only: true
     tmpfs:
       - /tmp:rw,nosuid,nodev

--- a/tools/ci/route-v2-gateway.test.mjs
+++ b/tools/ci/route-v2-gateway.test.mjs
@@ -67,6 +67,7 @@ test("Compose gateway는 loopback 전용 포트와 동일 origin secret을 사�
   assert.match(block, /image: nginx:/);
   assert.match(block, /user: "10001:10001"/);
   assert.match(block, /entrypoint: \["\/bin\/sh", "\/etc\/nginx\/route-v2-entrypoint\.sh"\]/);
+  assert.match(block, /command: \["nginx", "-g", "daemon off;"\]/);
   assert.match(block, /- \/tmp:rw,nosuid,nodev/);
   assert.match(block, /NGINX_ENVSUBST_OUTPUT_DIR: \/tmp\/nginx-conf\.d/);
   assert.match(block, /\.\/nginx\/nginx\.conf:\/etc\/nginx\/nginx\.conf:ro/);


### PR DESCRIPTION
## 관련 이슈

Closes #2171

## 작업 배경

- production CD에서 `route-v2-gateway`가 로그 없이 exit code 0으로 종료되고 restart loop에 들어갔다.
- custom Compose `entrypoint`가 image의 기본 CMD를 제거했지만 service에 `command`가 없었다. 기존 통합 프로브는 Nginx foreground command를 직접 전달해 누락을 가렸다.

## 작업 내용

- `route-v2-gateway` Compose service에 공식 Nginx foreground command를 exec form으로 명시했다.
- 기존 gateway 계약 테스트에 custom entrypoint와 command가 함께 있어야 한다는 회귀 assertion을 추가했다.

## 검증

- 실행한 명령과 결과:
  - RED: `node --test tools/ci/route-v2-gateway.test.mjs` → 4 pass, 1 fail (`command` 누락)
  - GREEN: `node --test tools/ci/route-v2-gateway.test.mjs` → 5 pass
  - `node --test tools/ci/backend-deploy.test.mjs tools/ci/repository-contract.test.mjs tools/ci/route-v2-gateway.test.mjs` → 210 pass
  - `tools/test/run-route-v2-gateway-integration.sh` → pass
  - `docker compose --env-file tools/ci/fixtures/deployment-prod-valid.env -f infra/docker-compose.yml config --format json` → entrypoint와 `command=["nginx","-g","daemon off;"]` 확인
  - CodeRabbit committed diff review → issues 0

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 최초 실패 | production OCI A1 | CD 로그와 container inspect | https://github.com/AquilaXk/easysubway/actions/runs/29463004252 | `Config.Cmd=null`, restart loop 재현 |
| 운영 완화 | production OCI A1 | gateway 중지, rollback backend inspect/readiness | 기존 SHA `01d4a9b7`, readiness HTTP 200 | 정상 |
| Compose 해석 | local ARM64 | `docker compose config --format json` | resolved command 배열 | 정상 |
| gateway runtime | local ARM64 Docker | tracked integration probe | identifier-free limiter 통합 프로브 | 정상 |
| UI/접근성 | 해당 없음 | UI 변경 없음 | Compose 1줄과 계약 assertion만 변경 | 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 병합 SHA 기반 신규 backend image/CD

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: custom `entrypoint` 바로 다음의 explicit foreground `command`와 이를 고정한 assertion.

## 리스크

- 수정은 image 기본 CMD를 Compose에 명시적으로 복원하는 1줄이다.
- production 배포와 post-deploy smoke는 PR required CI와 리뷰 완료 후 확인한다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
