### PR TITLE
[Test] EasySubwayApp 테스트 조립점 추가

### DIFF
--- a/apps/mobile/test/easy_subway_app_defaults_test.dart
+++ b/apps/mobile/test/easy_subway_app_defaults_test.dart
@@ -1,15 +1,16 @@
 import 'package:easysubway_mobile/facility_report.dart';
 import 'package:easysubway_mobile/features/mobility_profile/mobility_profile_policy.dart';
-import 'package:easysubway_mobile/main.dart';
 import 'package:easysubway_mobile/onboarding.dart';
 import 'package:easysubway_mobile/route_search.dart';
 import 'package:easysubway_mobile/station_search.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'support/easy_subway_app_fixture.dart';
+
 void main() {
   test('기본 앱은 출시 범위에서 원격 개인 데이터 저장소를 만들지 않는다', () {
-    final app = EasySubwayApp(
+    final app = buildEasySubwayTestApp(
       repository: _UnusedStationSearchRepository(),
       reportRepository: _UnusedFacilityReportRepository(),
       routeRepository: _UnusedRouteSearchRepository(),
@@ -23,7 +24,7 @@ void main() {
   });
 
   test('푸시 알림을 명시적으로 켜도 인증 없는 원격 저장소는 만들지 않는다', () {
-    final app = EasySubwayApp(
+    final app = buildEasySubwayTestApp(
       repository: _UnusedStationSearchRepository(),
       reportRepository: _UnusedFacilityReportRepository(),
       routeRepository: _UnusedRouteSearchRepository(),
@@ -37,7 +38,7 @@ void main() {
 
   testWidgets('인증 저장소가 없으면 홈 즐겨찾기를 노출하지 않는다', (tester) async {
     await tester.pumpWidget(
-      EasySubwayApp(
+      buildEasySubwayTestApp(
         repository: _UnusedStationSearchRepository(),
         reportRepository: _UnusedFacilityReportRepository(),
         routeRepository: _UnusedRouteSearchRepository(),

--- a/apps/mobile/test/support/easy_subway_app_fixture.dart
+++ b/apps/mobile/test/support/easy_subway_app_fixture.dart
@@ -1,0 +1,98 @@
+import 'package:easysubway_mobile/app/app_dependencies.dart';
+import 'package:easysubway_mobile/core/datapack/bundled_data_pack_freshness.dart';
+import 'package:easysubway_mobile/core/datapack/data_pack_update_state.dart';
+import 'package:easysubway_mobile/facility_report.dart';
+import 'package:easysubway_mobile/favorite_facility.dart';
+import 'package:easysubway_mobile/features/ads/ad_repository.dart';
+import 'package:easysubway_mobile/features/realtime/realtime_repository.dart';
+import 'package:easysubway_mobile/features/service_notice/data/notice_repository.dart';
+import 'package:easysubway_mobile/internal_route.dart';
+import 'package:easysubway_mobile/legacy_credential_cleanup.dart';
+import 'package:easysubway_mobile/main.dart';
+import 'package:easysubway_mobile/network_map.dart';
+import 'package:easysubway_mobile/notification_settings.dart';
+import 'package:easysubway_mobile/onboarding.dart';
+import 'package:easysubway_mobile/route_search.dart';
+import 'package:easysubway_mobile/station_search.dart';
+import 'package:easysubway_mobile/user_data_deletion.dart';
+import 'package:flutter/material.dart';
+
+EasySubwayApp buildEasySubwayTestApp({
+  AppDependencies? dependencies,
+  StationSearchRepository? repository,
+  FacilityReportRepository? reportRepository,
+  RouteSearchRepository? routeRepository,
+  RouteFeedbackRepository? routeFeedbackRepository,
+  FavoriteStationRepository? favoriteRepository,
+  FavoriteFacilityRepository? favoriteFacilityRepository,
+  FavoriteRouteRepository? favoriteRouteRepository,
+  AdRepository? adRepository,
+  Future<List<FavoriteRoute>>? recentRoutesFuture,
+  SearchHistoryRepository? searchHistoryRepository,
+  InternalRouteRepository? internalRouteRepository,
+  NetworkMapRepository? networkMapRepository,
+  NetworkMapViewportRepository? networkMapViewportRepository,
+  RealtimeRepository? realtimeRepository,
+  NotificationSettingsRepository? notificationRepository,
+  NotificationPermissionProvider? notificationPermissionProvider,
+  CurrentLocationProvider? locationProvider,
+  UserDataDeletionRepository? userDataDeletionRepository,
+  NoticeRepository? noticeRepository,
+  LegacyCredentialCleaner legacyCredentialCleaner =
+      const NoLegacyCredentialCleaner(),
+  OnboardingResultStore? onboardingStore,
+  FacilityReportDraftTargetStore? facilityReportDraftTargetStore,
+  FacilityReportLostPhotoRestorer? facilityReportLostPhotoRestorer,
+  SupportAccessInfo supportAccessInfo =
+      const SupportAccessInfo.fromEnvironment(),
+  SupportAccessLauncher supportAccessLauncher =
+      const UrlLauncherSupportAccessLauncher(),
+  DataPackUpdateStateRepository? dataPackUpdateStateRepository,
+  Future<void> Function()? onDataPackMeteredConsent,
+  Future<void>? dataPackUpdate,
+  BundledDataPackFreshness? bundledDataPackFreshness,
+  OnboardingState initialOnboardingState = const OnboardingState.initial(),
+  bool enablePushNotifications = false,
+  GlobalKey<NavigatorState>? navigatorKey,
+  Key? key,
+}) {
+  return EasySubwayApp(
+    dependencies:
+        dependencies ??
+        AppDependencies.resolve(
+          repository: repository,
+          reportRepository: reportRepository,
+          routeRepository: routeRepository,
+          routeFeedbackRepository: routeFeedbackRepository,
+          favoriteRepository: favoriteRepository,
+          favoriteFacilityRepository: favoriteFacilityRepository,
+          favoriteRouteRepository: favoriteRouteRepository,
+          adRepository: adRepository,
+          searchHistoryRepository: searchHistoryRepository,
+          internalRouteRepository: internalRouteRepository,
+          networkMapRepository: networkMapRepository,
+          networkMapViewportRepository: networkMapViewportRepository,
+          realtimeRepository: realtimeRepository,
+          notificationRepository: notificationRepository,
+          notificationPermissionProvider: notificationPermissionProvider,
+          locationProvider: locationProvider,
+          userDataDeletionRepository: userDataDeletionRepository,
+          noticeRepository: noticeRepository,
+          enablePushNotifications: enablePushNotifications,
+        ),
+    recentRoutesFuture: recentRoutesFuture,
+    legacyCredentialCleaner: legacyCredentialCleaner,
+    onboardingStore: onboardingStore,
+    facilityReportDraftTargetStore: facilityReportDraftTargetStore,
+    facilityReportLostPhotoRestorer: facilityReportLostPhotoRestorer,
+    supportAccessInfo: supportAccessInfo,
+    supportAccessLauncher: supportAccessLauncher,
+    dataPackUpdateStateRepository: dataPackUpdateStateRepository,
+    onDataPackMeteredConsent: onDataPackMeteredConsent,
+    dataPackUpdate: dataPackUpdate,
+    bundledDataPackFreshness: bundledDataPackFreshness,
+    initialOnboardingState: initialOnboardingState,
+    navigatorKey: navigatorKey,
+    key: key,
+  );
+}


### PR DESCRIPTION
## 관련 이슈

Refs #2173

## 작업 내용

- `EasySubwayApp` 테스트 조립을 담당하는 test-only `buildEasySubwayTestApp` fixture를 추가했습니다.
- 기존 defaults test 3곳을 fixture 호출로 전환했으며 assertion, constructor 기본값과 dependency override 우선순위는 그대로 유지합니다.
- production 코드, 사용자 동작, UI와 API 계약은 변경하지 않습니다.

## 검증

- 기존 `flutter test test/easy_subway_app_defaults_test.dart` → baseline `3 tests passed`
- fixture 미구현 상태 focused test → 예상한 missing helper RED 확인
- `dart format test/support/easy_subway_app_fixture.dart test/easy_subway_app_defaults_test.dart` → 통과
- `flutter analyze` → `No issues found!`
- `flutter test test/easy_subway_app_defaults_test.dart` → 최종 `3 tests passed`
- `git diff --check` → 통과
- 독립 task review → Critical/Important/Minor 지적 없음, 승인
- CodeRabbit Review → 2건을 Task 4 계약과 대조해 적용 시 회귀로 판정, 원 thread 답변·resolved 처리

## 영향

- [x] 제품/운영 위험 없음 (route/accessibility/mobile UX/backend API/auth/security 아님)
- [x] DB migration 없음
- [x] 배포 영향 없음
- [x] route/realtime/datapack contract 영향 없음
- [x] CI workflow·계약 테스트·release gate JSON 변경 없음 (있으면 full.md로 전환)

## 체크리스트

- [x] 이 PR은 B/C등급 작업이며 full template이 필요 없다.
- [x] CI 결과를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 폴백 리뷰를 단일 PR review로 게시했다. (CodeRabbit Review 객체가 있어 폴백 불필요)
