### PR TITLE
[Refactor] 알림 presentation 책임 분리

### DIFF
--- a/apps/mobile/lib/app/app_components.dart
+++ b/apps/mobile/lib/app/app_components.dart
@@ -1,0 +1,219 @@
+import 'package:flutter/material.dart';
+
+import '../accessible_design.dart';
+import '../favorite_facility.dart';
+
+const mainPagePadding = EdgeInsets.fromLTRB(20, 20, 20, 32);
+const mainListPagePadding = EdgeInsets.fromLTRB(17, 18, 17, 32);
+const _appSectionTitlePadding = EdgeInsets.fromLTRB(1, 22, 1, 11);
+
+const mainThemeControlRadius = BorderRadius.all(Radius.circular(12));
+
+class AppSectionTitle extends StatelessWidget {
+  // ignore: use_key_in_widget_constructors
+  const AppSectionTitle({required this.title});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: _appSectionTitlePadding,
+      child: Text(
+        title,
+        style: Theme.of(context).textTheme.titleMedium?.copyWith(
+          color: EasySubwayAccessibleColors.text,
+          fontWeight: FontWeight.w700,
+          height: 1.2,
+        ),
+      ),
+    );
+  }
+}
+
+bool isFacilityAlert(FavoriteFacility facility) {
+  return facility.needsAttention;
+}
+
+class HomeStateCard extends StatelessWidget {
+  const HomeStateCard({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    this.actionLabel,
+    this.onAction,
+    super.key,
+  });
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final String? actionLabel;
+  final VoidCallback? onAction;
+
+  @override
+  Widget build(BuildContext context) {
+    final actionLabel = this.actionLabel;
+    return AppCard(
+      showBorder: true,
+      child: AccessibleStateCard(
+        icon: icon,
+        title: title,
+        subtitle: subtitle,
+        actions: [
+          if (actionLabel != null && onAction != null)
+            OutlinedButton.icon(
+              onPressed: onAction,
+              icon: const Icon(Icons.refresh),
+              label: Text(actionLabel),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class AppCard extends StatelessWidget {
+  // ignore: use_key_in_widget_constructors
+  const AppCard({
+    required this.child,
+    this.backgroundColor = Colors.white,
+    this.borderColor = EasySubwayAccessibleColors.line,
+    this.showBorder = true,
+  });
+
+  final Widget child;
+  final Color backgroundColor;
+  final Color borderColor;
+  final bool showBorder;
+
+  @override
+  Widget build(BuildContext context) {
+    // 최소 그림자 원칙: 그림자 대신 얇은 보더로 카드를 구분한다.
+    return Card(
+      margin: EdgeInsets.zero,
+      color: backgroundColor,
+      elevation: 0,
+      shadowColor: EasySubwayAccessibleColors.cardShadow,
+      shape: RoundedRectangleBorder(
+        side: showBorder ? BorderSide(color: borderColor) : BorderSide.none,
+        borderRadius: BorderRadius.circular(20),
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: Padding(padding: const EdgeInsets.all(16), child: child),
+    );
+  }
+}
+
+class AppInfoRow extends StatelessWidget {
+  // ignore: use_key_in_widget_constructors
+  const AppInfoRow({
+    required this.icon,
+    required this.iconColor,
+    required this.title,
+    this.subtitle,
+  });
+
+  final IconData icon;
+  final Color iconColor;
+  final String title;
+  final String? subtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    final subtitle = this.subtitle;
+    final leading = SizedBox(
+      width: 32,
+      height: 32,
+      child: Center(child: Icon(icon, color: iconColor, size: 22)),
+    );
+    final content = Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: const TextStyle(
+            color: EasySubwayAccessibleColors.text,
+            fontSize: 15,
+            fontWeight: FontWeight.w700,
+            height: 1.25,
+          ),
+        ),
+        if (subtitle != null && subtitle.isNotEmpty) ...[
+          const SizedBox(height: 3),
+          Text(
+            subtitle,
+            style: const TextStyle(
+              color: EasySubwayAccessibleColors.mutedText,
+              fontSize: 12,
+              fontWeight: FontWeight.w500,
+              height: 1.4,
+            ),
+          ),
+        ],
+      ],
+    );
+    return Row(
+      children: [
+        leading,
+        const SizedBox(width: 12),
+        Expanded(child: content),
+      ],
+    );
+  }
+}
+
+class FeatureTile extends StatelessWidget {
+  const FeatureTile({
+    required this.icon,
+    required this.title,
+    required this.semanticLabel,
+    super.key,
+  });
+
+  final IconData icon;
+  final String title;
+  final String semanticLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return MergeSemantics(
+      child: Semantics(
+        label: semanticLabel,
+        child: ExcludeSemantics(
+          child: Card(
+            margin: const EdgeInsets.only(bottom: 12),
+            color: Colors.white,
+            elevation: 0,
+            shape: RoundedRectangleBorder(
+              borderRadius: mainThemeControlRadius,
+              side: const BorderSide(color: EasySubwayAccessibleColors.line),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  Icon(icon, color: colorScheme.primary, size: 32),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: Text(
+                      title,
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        color: EasySubwayAccessibleColors.text,
+                        fontWeight: FontWeight.w700,
+                        height: 1.35,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/notifications/presentation/notification_inbox_screen.dart
+++ b/apps/mobile/lib/features/notifications/presentation/notification_inbox_screen.dart
@@ -1,0 +1,444 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../../../accessible_design.dart';
+import '../../../app/app_components.dart';
+import '../../../facility_report.dart';
+import '../../../facility_status.dart';
+import '../../../favorite_facility.dart';
+import '../../../mobile_error_reporter.dart';
+import '../../../notification_settings.dart';
+
+class NotificationInboxScreen extends StatefulWidget {
+  const NotificationInboxScreen({
+    required this.favoriteFacilityRepository,
+    required this.reportRepository,
+    required this.notificationRepository,
+    required this.notificationPermissionProvider,
+    super.key,
+  });
+
+  final FavoriteFacilityRepository? favoriteFacilityRepository;
+  final FacilityReportRepository reportRepository;
+  final NotificationSettingsRepository? notificationRepository;
+  final NotificationPermissionProvider? notificationPermissionProvider;
+
+  @override
+  State<NotificationInboxScreen> createState() =>
+      _NotificationInboxScreenState();
+}
+
+class _NotificationInboxScreenState extends State<NotificationInboxScreen> {
+  late Future<List<_NotificationInboxItem>> _itemsFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _itemsFuture = _loadItemsForDisplay();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('알림'),
+        actions: [
+          if (widget.notificationRepository != null)
+            IconButton(
+              tooltip: '알림 설정',
+              onPressed: _openSettings,
+              icon: const Icon(Icons.settings_outlined),
+            ),
+        ],
+      ),
+      body: SafeArea(
+        child: FutureBuilder<List<_NotificationInboxItem>>(
+          future: _itemsFuture,
+          builder: (context, snapshot) {
+            final items = snapshot.data ?? const <_NotificationInboxItem>[];
+            return RefreshIndicator(
+              onRefresh: () async {
+                final next = _loadItemsForDisplay();
+                setState(() {
+                  _itemsFuture = next;
+                });
+                try {
+                  await next;
+                } catch (error, stackTrace) {
+                  reportMobileError(
+                    error,
+                    stackTrace,
+                    context: '알림함 새로고침 중 예외가 발생했습니다.',
+                  );
+                }
+              },
+              child: ListView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                padding: mainListPagePadding,
+                children: [
+                  if (snapshot.connectionState != ConnectionState.done)
+                    const LinearProgressIndicator(minHeight: 3),
+                  if (snapshot.hasError)
+                    HomeStateCard(
+                      key: const Key('notificationInboxErrorState'),
+                      icon: Icons.error_outline,
+                      title: '알림을 불러오지 못했어요',
+                      subtitle: '잠시 후 다시 시도해 주세요.',
+                      actionLabel: '다시 시도',
+                      onAction: () {
+                        setState(() {
+                          _itemsFuture = _loadItemsForDisplay();
+                        });
+                      },
+                    )
+                  else if (items.isEmpty)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 80),
+                      child: Column(
+                        children: [
+                          const Icon(
+                            Icons.notifications_none,
+                            size: 44,
+                            color: EasySubwayAccessibleColors.mutedText,
+                          ),
+                          const SizedBox(height: 12),
+                          Text(
+                            '새 알림이 없습니다',
+                            textAlign: TextAlign.center,
+                            style: const TextStyle(
+                              color: EasySubwayAccessibleColors.text,
+                              fontSize: 16,
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                          const SizedBox(height: 6),
+                          Text(
+                            '즐겨찾기 시설과 제보 상태가 바뀌면 여기에서 볼 수 있어요.',
+                            textAlign: TextAlign.center,
+                            style: const TextStyle(
+                              color: EasySubwayAccessibleColors.mutedText,
+                              fontSize: 13,
+                              fontWeight: FontWeight.w500,
+                              height: 1.4,
+                            ),
+                          ),
+                        ],
+                      ),
+                    )
+                  else ...[
+                    _NotificationInboxChips(items: items),
+                    for (final item in items) _NotificationInboxRow(item: item),
+                  ],
+                ],
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  Future<List<_NotificationInboxItem>> _loadItemsForDisplay() {
+    final next = _loadItems();
+    unawaited(
+      next.catchError((Object error, StackTrace stackTrace) {
+        return const <_NotificationInboxItem>[];
+      }),
+    );
+    return next;
+  }
+
+  Future<List<_NotificationInboxItem>> _loadItems() async {
+    final items = <_NotificationInboxItem>[];
+    var loadFailed = false;
+    final favoriteFacilityRepository = widget.favoriteFacilityRepository;
+    if (favoriteFacilityRepository != null) {
+      try {
+        final facilities = await favoriteFacilityRepository
+            .listFavoriteFacilities();
+        for (final facility in facilities.where(isFacilityAlert)) {
+          items.add(_NotificationInboxItem.facility(facility));
+        }
+      } catch (error, stackTrace) {
+        loadFailed = true;
+        reportMobileError(
+          error,
+          stackTrace,
+          context: '알림함 즐겨찾기 시설 상태를 불러오는 중 예외가 발생했습니다.',
+        );
+      }
+    }
+
+    try {
+      final reports = await widget.reportRepository.listMyReports();
+      for (final report in reports) {
+        items.add(_NotificationInboxItem.report(report));
+      }
+    } catch (error, stackTrace) {
+      loadFailed = true;
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '알림함 제보 상태를 불러오는 중 예외가 발생했습니다.',
+      );
+    }
+    if (items.isEmpty && loadFailed) {
+      throw StateError('notification inbox load failed');
+    }
+    return items;
+  }
+
+  void _openSettings() {
+    final repository = widget.notificationRepository;
+    if (repository == null) {
+      return;
+    }
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => NotificationSettingsScreen(
+          repository: repository,
+          notificationPermissionProvider: widget.notificationPermissionProvider,
+        ),
+      ),
+    );
+  }
+}
+
+class _NotificationInboxItem {
+  const _NotificationInboxItem({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    required this.semanticLabel,
+    required this.kind,
+    this.report,
+    this.severity = FacilityStatusSeverity.normal,
+    this.actionLabel = '',
+  });
+
+  factory _NotificationInboxItem.facility(FavoriteFacility facility) {
+    final name = facility.name.trim().isEmpty
+        ? facility.typeLabel
+        : facility.name;
+    return _NotificationInboxItem(
+      icon: _facilityIcon(facility.type),
+      title: '${facility.stationLabel} $name',
+      subtitle:
+          '${facility.severityLabel} · ${facility.typeLabel} ${facility.statusLabel}',
+      semanticLabel:
+          '${facility.stationLabel} $name, ${facility.typeLabel} ${facility.statusLabel}, ${facility.severityLabel}, ${facility.updatedLabel}, ${facility.dataSourceLabel}, ${facility.nextActionLabel}',
+      kind: '시설',
+      severity: facility.statusPresentation.severity,
+      actionLabel: facility.nextActionLabel,
+    );
+  }
+
+  factory _NotificationInboxItem.report(FacilityReportResult report) {
+    return _NotificationInboxItem(
+      icon: Icons.report_outlined,
+      title: '제보 ${report.statusLabel}',
+      subtitle: '제보 번호 ${report.displayReceiptCode}',
+      semanticLabel:
+          '제보 ${report.statusLabel}, 제보 번호 ${report.displayReceiptCode}',
+      kind: '제보',
+      report: report,
+    );
+  }
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final String semanticLabel;
+  final String kind;
+  final FacilityReportResult? report;
+  final FacilityStatusSeverity severity;
+  final String actionLabel;
+}
+
+class _NotificationInboxChips extends StatelessWidget {
+  const _NotificationInboxChips({required this.items});
+
+  final List<_NotificationInboxItem> items;
+
+  @override
+  Widget build(BuildContext context) {
+    final facilityCount = items.where((item) => item.kind == '시설').length;
+    final reportCount = items.length - facilityCount;
+    final parts = <String>[
+      '전체 ${items.length}',
+      if (facilityCount > 0) '시설 $facilityCount',
+      if (reportCount > 0) '제보 $reportCount',
+    ];
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 4, top: 4),
+      child: Text(
+        parts.join('  ·  '),
+        style: const TextStyle(
+          color: EasySubwayAccessibleColors.mutedText,
+          fontSize: 13,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+class _NotificationInboxRow extends StatelessWidget {
+  const _NotificationInboxRow({required this.item});
+
+  final _NotificationInboxItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    void open() {
+      final report = item.report;
+      if (report == null) {
+        return;
+      }
+      Navigator.of(context).push(
+        MaterialPageRoute<void>(
+          builder: (_) => MyFacilityReportDetailScreen(report: report),
+        ),
+      );
+    }
+
+    final accent = _facilitySeverityAccent(item.severity);
+    final row = Container(
+      padding: const EdgeInsets.symmetric(vertical: 14),
+      decoration: const BoxDecoration(
+        border: Border(
+          bottom: BorderSide(color: EasySubwayAccessibleColors.line),
+        ),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(top: 1),
+            child: Icon(item.icon, color: accent.iconColor, size: 22),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Expanded(
+                      child: Text(
+                        item.title,
+                        style: const TextStyle(
+                          color: EasySubwayAccessibleColors.text,
+                          fontSize: 15,
+                          fontWeight: FontWeight.w700,
+                          height: 1.25,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Text(
+                      item.kind,
+                      style: const TextStyle(
+                        color: EasySubwayAccessibleColors.mutedText,
+                        fontSize: 12,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 3),
+                Text(
+                  item.subtitle,
+                  style: TextStyle(
+                    color: accent.iconColor,
+                    fontSize: 12,
+                    fontWeight: FontWeight.w500,
+                    height: 1.4,
+                  ),
+                ),
+                if (item.actionLabel.isNotEmpty) ...[
+                  const SizedBox(height: 6),
+                  Text(
+                    item.actionLabel,
+                    style: const TextStyle(
+                      color: EasySubwayAccessibleColors.text,
+                      fontSize: 13,
+                      fontWeight: FontWeight.w600,
+                      height: 1.3,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+    if (item.report == null) {
+      return Semantics(
+        label: item.semanticLabel,
+        child: ExcludeSemantics(child: row),
+      );
+    }
+    return Semantics(
+      button: true,
+      label: item.semanticLabel,
+      onTap: open,
+      child: ExcludeSemantics(
+        child: InkWell(onTap: open, child: row),
+      ),
+    );
+  }
+}
+
+class _FacilitySeverityAccent {
+  const _FacilitySeverityAccent({
+    required this.backgroundColor,
+    required this.borderColor,
+    required this.iconColor,
+  });
+
+  final Color backgroundColor;
+  final Color borderColor;
+  final Color iconColor;
+}
+
+_FacilitySeverityAccent _facilitySeverityAccent(
+  FacilityStatusSeverity severity,
+) {
+  return switch (severity) {
+    FacilityStatusSeverity.blocked => const _FacilitySeverityAccent(
+      backgroundColor: EasySubwayAccessibleColors.redSoft,
+      borderColor: EasySubwayAccessibleColors.red,
+      iconColor: EasySubwayAccessibleColors.red,
+    ),
+    FacilityStatusSeverity.caution => const _FacilitySeverityAccent(
+      backgroundColor: EasySubwayAccessibleColors.amberSoft,
+      borderColor: EasySubwayAccessibleColors.amberBorder,
+      iconColor: EasySubwayAccessibleColors.amber,
+    ),
+    FacilityStatusSeverity.needsInfo => const _FacilitySeverityAccent(
+      backgroundColor: Colors.white,
+      borderColor: EasySubwayAccessibleColors.needsInfo,
+      iconColor: EasySubwayAccessibleColors.needsInfo,
+    ),
+    FacilityStatusSeverity.normal => const _FacilitySeverityAccent(
+      backgroundColor: Colors.white,
+      borderColor: EasySubwayAccessibleColors.line,
+      iconColor: EasySubwayAccessibleColors.mintDark,
+    ),
+  };
+}
+
+IconData _facilityIcon(String type) {
+  return switch (type) {
+    'ELEVATOR' => Icons.elevator_outlined,
+    'ESCALATOR' => Icons.escalator_warning_outlined,
+    'WHEELCHAIR_LIFT' => Icons.accessible_forward,
+    'RAMP' => Icons.accessible,
+    'ACCESSIBLE_TOILET' || 'TOILET' => Icons.wc_outlined,
+    _ => Icons.warning_amber_outlined,
+  };
+}

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:flutter/services.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'accessible_design.dart';
+import 'app/app_components.dart';
 import 'app/app_bootstrap.dart';
 import 'app/app_dependencies.dart';
 import 'core/datapack/data_pack_metered_consent_gate.dart';
@@ -22,7 +23,6 @@ import 'features/home_widget/next_train_widget_repository.dart';
 import 'features/home_widget/next_train_widget_runtime.dart'
     as next_train_widget_runtime;
 import 'facility_report.dart';
-import 'facility_status.dart';
 import 'favorite_facility.dart';
 import 'features/realtime/realtime_repository.dart';
 import 'features/route_draft/application/route_draft_controller.dart';
@@ -30,6 +30,7 @@ import 'features/route_draft/domain/route_draft.dart';
 import 'features/mobility_profile/mobility_preset_labels.dart';
 import 'features/mobility_profile/mobility_preset_picker.dart';
 import 'features/mobility_profile/mobility_profile_policy.dart';
+import 'features/notifications/presentation/notification_inbox_screen.dart';
 import 'internal_route.dart';
 import 'legacy_credential_cleanup.dart';
 import 'network_map.dart';
@@ -44,6 +45,10 @@ import 'station_search.dart';
 import 'mobile_error_reporter.dart';
 import 'user_data_deletion.dart';
 
+export 'app/app_components.dart' show FeatureTile;
+export 'features/notifications/presentation/notification_inbox_screen.dart'
+    show NotificationInboxScreen;
+
 const defaultPushNotificationsEnabled = bool.fromEnvironment(
   'EASYSUBWAY_ENABLE_PUSH_NOTIFICATIONS',
   defaultValue: false,
@@ -52,11 +57,7 @@ const defaultDemoHomeDataEnabled = bool.fromEnvironment(
   'EASYSUBWAY_DEMO_HOME_DATA',
   defaultValue: false,
 );
-const _mainPagePadding = EdgeInsets.fromLTRB(20, 20, 20, 32);
-const _mainListPagePadding = EdgeInsets.fromLTRB(17, 18, 17, 32);
-const _appSectionTitlePadding = EdgeInsets.fromLTRB(1, 22, 1, 11);
 const _settingsPagePadding = EdgeInsets.fromLTRB(20, 16, 20, 32);
-const _mainThemeControlRadius = BorderRadius.all(Radius.circular(12));
 const _mainIconControlRadius = BorderRadius.all(Radius.circular(12));
 
 Future<void> main() async {
@@ -490,7 +491,7 @@ class EasySubwayApp extends StatelessWidget {
           style: FilledButton.styleFrom(
             minimumSize: const Size.fromHeight(EasySubwayTouchTarget.primary),
             shape: const RoundedRectangleBorder(
-              borderRadius: _mainThemeControlRadius,
+              borderRadius: mainThemeControlRadius,
             ),
             textStyle: const TextStyle(
               fontSize: 18,
@@ -509,7 +510,7 @@ class EasySubwayApp extends StatelessWidget {
               width: 1.5,
             ),
             shape: const RoundedRectangleBorder(
-              borderRadius: _mainThemeControlRadius,
+              borderRadius: mainThemeControlRadius,
             ),
             textStyle: const TextStyle(
               fontSize: 16,
@@ -2074,7 +2075,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     if (facilitiesFuture != null) {
       try {
         final facilities = await facilitiesFuture;
-        if (facilities.any(_isFacilityAlert)) {
+        if (facilities.any(isFacilityAlert)) {
           return true;
         }
       } catch (error, stackTrace) {
@@ -2196,502 +2197,6 @@ class _HomeNotificationButton extends StatelessWidget {
   }
 }
 
-class NotificationInboxScreen extends StatefulWidget {
-  const NotificationInboxScreen({
-    required this.favoriteFacilityRepository,
-    required this.reportRepository,
-    required this.notificationRepository,
-    required this.notificationPermissionProvider,
-    super.key,
-  });
-
-  final FavoriteFacilityRepository? favoriteFacilityRepository;
-  final FacilityReportRepository reportRepository;
-  final NotificationSettingsRepository? notificationRepository;
-  final NotificationPermissionProvider? notificationPermissionProvider;
-
-  @override
-  State<NotificationInboxScreen> createState() =>
-      _NotificationInboxScreenState();
-}
-
-class _NotificationInboxScreenState extends State<NotificationInboxScreen> {
-  late Future<List<_NotificationInboxItem>> _itemsFuture;
-
-  @override
-  void initState() {
-    super.initState();
-    _itemsFuture = _loadItemsForDisplay();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('알림'),
-        actions: [
-          if (widget.notificationRepository != null)
-            IconButton(
-              tooltip: '알림 설정',
-              onPressed: _openSettings,
-              icon: const Icon(Icons.settings_outlined),
-            ),
-        ],
-      ),
-      body: SafeArea(
-        child: FutureBuilder<List<_NotificationInboxItem>>(
-          future: _itemsFuture,
-          builder: (context, snapshot) {
-            final items = snapshot.data ?? const <_NotificationInboxItem>[];
-            return RefreshIndicator(
-              onRefresh: () async {
-                final next = _loadItemsForDisplay();
-                setState(() {
-                  _itemsFuture = next;
-                });
-                try {
-                  await next;
-                } catch (error, stackTrace) {
-                  reportMobileError(
-                    error,
-                    stackTrace,
-                    context: '알림함 새로고침 중 예외가 발생했습니다.',
-                  );
-                }
-              },
-              child: ListView(
-                physics: const AlwaysScrollableScrollPhysics(),
-                padding: _mainListPagePadding,
-                children: [
-                  if (snapshot.connectionState != ConnectionState.done)
-                    const LinearProgressIndicator(minHeight: 3),
-                  if (snapshot.hasError)
-                    _HomeStateCard(
-                      key: const Key('notificationInboxErrorState'),
-                      icon: Icons.error_outline,
-                      title: '알림을 불러오지 못했어요',
-                      subtitle: '잠시 후 다시 시도해 주세요.',
-                      actionLabel: '다시 시도',
-                      onAction: () {
-                        setState(() {
-                          _itemsFuture = _loadItemsForDisplay();
-                        });
-                      },
-                    )
-                  else if (items.isEmpty)
-                    Padding(
-                      padding: const EdgeInsets.only(top: 80),
-                      child: Column(
-                        children: [
-                          const Icon(
-                            Icons.notifications_none,
-                            size: 44,
-                            color: EasySubwayAccessibleColors.mutedText,
-                          ),
-                          const SizedBox(height: 12),
-                          Text(
-                            '새 알림이 없습니다',
-                            textAlign: TextAlign.center,
-                            style: const TextStyle(
-                              color: EasySubwayAccessibleColors.text,
-                              fontSize: 16,
-                              fontWeight: FontWeight.w700,
-                            ),
-                          ),
-                          const SizedBox(height: 6),
-                          Text(
-                            '즐겨찾기 시설과 제보 상태가 바뀌면 여기에서 볼 수 있어요.',
-                            textAlign: TextAlign.center,
-                            style: const TextStyle(
-                              color: EasySubwayAccessibleColors.mutedText,
-                              fontSize: 13,
-                              fontWeight: FontWeight.w500,
-                              height: 1.4,
-                            ),
-                          ),
-                        ],
-                      ),
-                    )
-                  else ...[
-                    _NotificationInboxChips(items: items),
-                    for (final item in items) _NotificationInboxRow(item: item),
-                  ],
-                ],
-              ),
-            );
-          },
-        ),
-      ),
-    );
-  }
-
-  Future<List<_NotificationInboxItem>> _loadItemsForDisplay() {
-    final next = _loadItems();
-    unawaited(
-      next.catchError((Object error, StackTrace stackTrace) {
-        return const <_NotificationInboxItem>[];
-      }),
-    );
-    return next;
-  }
-
-  Future<List<_NotificationInboxItem>> _loadItems() async {
-    final items = <_NotificationInboxItem>[];
-    var loadFailed = false;
-    final favoriteFacilityRepository = widget.favoriteFacilityRepository;
-    if (favoriteFacilityRepository != null) {
-      try {
-        final facilities = await favoriteFacilityRepository
-            .listFavoriteFacilities();
-        for (final facility in facilities.where(_isFacilityAlert)) {
-          items.add(_NotificationInboxItem.facility(facility));
-        }
-      } catch (error, stackTrace) {
-        loadFailed = true;
-        reportMobileError(
-          error,
-          stackTrace,
-          context: '알림함 즐겨찾기 시설 상태를 불러오는 중 예외가 발생했습니다.',
-        );
-      }
-    }
-
-    try {
-      final reports = await widget.reportRepository.listMyReports();
-      for (final report in reports) {
-        items.add(_NotificationInboxItem.report(report));
-      }
-    } catch (error, stackTrace) {
-      loadFailed = true;
-      reportMobileError(
-        error,
-        stackTrace,
-        context: '알림함 제보 상태를 불러오는 중 예외가 발생했습니다.',
-      );
-    }
-    if (items.isEmpty && loadFailed) {
-      throw StateError('notification inbox load failed');
-    }
-    return items;
-  }
-
-  void _openSettings() {
-    final repository = widget.notificationRepository;
-    if (repository == null) {
-      return;
-    }
-    Navigator.of(context).push(
-      MaterialPageRoute<void>(
-        builder: (_) => NotificationSettingsScreen(
-          repository: repository,
-          notificationPermissionProvider: widget.notificationPermissionProvider,
-        ),
-      ),
-    );
-  }
-}
-
-class _NotificationInboxItem {
-  const _NotificationInboxItem({
-    required this.icon,
-    required this.title,
-    required this.subtitle,
-    required this.semanticLabel,
-    required this.kind,
-    this.report,
-    this.severity = FacilityStatusSeverity.normal,
-    this.actionLabel = '',
-  });
-
-  factory _NotificationInboxItem.facility(FavoriteFacility facility) {
-    final name = facility.name.trim().isEmpty
-        ? facility.typeLabel
-        : facility.name;
-    return _NotificationInboxItem(
-      icon: _facilityIcon(facility.type),
-      title: '${facility.stationLabel} $name',
-      subtitle:
-          '${facility.severityLabel} · ${facility.typeLabel} ${facility.statusLabel}',
-      semanticLabel:
-          '${facility.stationLabel} $name, ${facility.typeLabel} ${facility.statusLabel}, ${facility.severityLabel}, ${facility.updatedLabel}, ${facility.dataSourceLabel}, ${facility.nextActionLabel}',
-      kind: '시설',
-      severity: facility.statusPresentation.severity,
-      actionLabel: facility.nextActionLabel,
-    );
-  }
-
-  factory _NotificationInboxItem.report(FacilityReportResult report) {
-    return _NotificationInboxItem(
-      icon: Icons.report_outlined,
-      title: '제보 ${report.statusLabel}',
-      subtitle: '제보 번호 ${report.displayReceiptCode}',
-      semanticLabel:
-          '제보 ${report.statusLabel}, 제보 번호 ${report.displayReceiptCode}',
-      kind: '제보',
-      report: report,
-    );
-  }
-
-  final IconData icon;
-  final String title;
-  final String subtitle;
-  final String semanticLabel;
-  final String kind;
-  final FacilityReportResult? report;
-  final FacilityStatusSeverity severity;
-  final String actionLabel;
-}
-
-class _NotificationInboxChips extends StatelessWidget {
-  const _NotificationInboxChips({required this.items});
-
-  final List<_NotificationInboxItem> items;
-
-  @override
-  Widget build(BuildContext context) {
-    final facilityCount = items.where((item) => item.kind == '시설').length;
-    final reportCount = items.length - facilityCount;
-    final parts = <String>[
-      '전체 ${items.length}',
-      if (facilityCount > 0) '시설 $facilityCount',
-      if (reportCount > 0) '제보 $reportCount',
-    ];
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 4, top: 4),
-      child: Text(
-        parts.join('  ·  '),
-        style: const TextStyle(
-          color: EasySubwayAccessibleColors.mutedText,
-          fontSize: 13,
-          fontWeight: FontWeight.w600,
-        ),
-      ),
-    );
-  }
-}
-
-class _NotificationInboxRow extends StatelessWidget {
-  const _NotificationInboxRow({required this.item});
-
-  final _NotificationInboxItem item;
-
-  @override
-  Widget build(BuildContext context) {
-    void open() {
-      final report = item.report;
-      if (report == null) {
-        return;
-      }
-      Navigator.of(context).push(
-        MaterialPageRoute<void>(
-          builder: (_) => MyFacilityReportDetailScreen(report: report),
-        ),
-      );
-    }
-
-    final accent = _facilitySeverityAccent(item.severity);
-    final row = Container(
-      padding: const EdgeInsets.symmetric(vertical: 14),
-      decoration: const BoxDecoration(
-        border: Border(
-          bottom: BorderSide(color: EasySubwayAccessibleColors.line),
-        ),
-      ),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Padding(
-            padding: const EdgeInsets.only(top: 1),
-            child: Icon(item.icon, color: accent.iconColor, size: 22),
-          ),
-          const SizedBox(width: 12),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Expanded(
-                      child: Text(
-                        item.title,
-                        style: const TextStyle(
-                          color: EasySubwayAccessibleColors.text,
-                          fontSize: 15,
-                          fontWeight: FontWeight.w700,
-                          height: 1.25,
-                        ),
-                      ),
-                    ),
-                    const SizedBox(width: 8),
-                    Text(
-                      item.kind,
-                      style: const TextStyle(
-                        color: EasySubwayAccessibleColors.mutedText,
-                        fontSize: 12,
-                        fontWeight: FontWeight.w600,
-                      ),
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 3),
-                Text(
-                  item.subtitle,
-                  style: TextStyle(
-                    color: accent.iconColor,
-                    fontSize: 12,
-                    fontWeight: FontWeight.w500,
-                    height: 1.4,
-                  ),
-                ),
-                if (item.actionLabel.isNotEmpty) ...[
-                  const SizedBox(height: 6),
-                  Text(
-                    item.actionLabel,
-                    style: const TextStyle(
-                      color: EasySubwayAccessibleColors.text,
-                      fontSize: 13,
-                      fontWeight: FontWeight.w600,
-                      height: 1.3,
-                    ),
-                  ),
-                ],
-              ],
-            ),
-          ),
-        ],
-      ),
-    );
-    if (item.report == null) {
-      return Semantics(
-        label: item.semanticLabel,
-        child: ExcludeSemantics(child: row),
-      );
-    }
-    return Semantics(
-      button: true,
-      label: item.semanticLabel,
-      onTap: open,
-      child: ExcludeSemantics(
-        child: InkWell(onTap: open, child: row),
-      ),
-    );
-  }
-}
-
-class _AppSectionTitle extends StatelessWidget {
-  const _AppSectionTitle({required this.title});
-
-  final String title;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: _appSectionTitlePadding,
-      child: Text(
-        title,
-        style: Theme.of(context).textTheme.titleMedium?.copyWith(
-          color: EasySubwayAccessibleColors.text,
-          fontWeight: FontWeight.w700,
-          height: 1.2,
-        ),
-      ),
-    );
-  }
-}
-
-class _FacilitySeverityAccent {
-  const _FacilitySeverityAccent({
-    required this.backgroundColor,
-    required this.borderColor,
-    required this.iconColor,
-  });
-
-  final Color backgroundColor;
-  final Color borderColor;
-  final Color iconColor;
-}
-
-_FacilitySeverityAccent _facilitySeverityAccent(
-  FacilityStatusSeverity severity,
-) {
-  return switch (severity) {
-    FacilityStatusSeverity.blocked => const _FacilitySeverityAccent(
-      backgroundColor: EasySubwayAccessibleColors.redSoft,
-      borderColor: EasySubwayAccessibleColors.red,
-      iconColor: EasySubwayAccessibleColors.red,
-    ),
-    FacilityStatusSeverity.caution => const _FacilitySeverityAccent(
-      backgroundColor: EasySubwayAccessibleColors.amberSoft,
-      borderColor: EasySubwayAccessibleColors.amberBorder,
-      iconColor: EasySubwayAccessibleColors.amber,
-    ),
-    FacilityStatusSeverity.needsInfo => const _FacilitySeverityAccent(
-      backgroundColor: Colors.white,
-      borderColor: EasySubwayAccessibleColors.needsInfo,
-      iconColor: EasySubwayAccessibleColors.needsInfo,
-    ),
-    FacilityStatusSeverity.normal => const _FacilitySeverityAccent(
-      backgroundColor: Colors.white,
-      borderColor: EasySubwayAccessibleColors.line,
-      iconColor: EasySubwayAccessibleColors.mintDark,
-    ),
-  };
-}
-
-bool _isFacilityAlert(FavoriteFacility facility) {
-  return facility.needsAttention;
-}
-
-IconData _facilityIcon(String type) {
-  return switch (type) {
-    'ELEVATOR' => Icons.elevator_outlined,
-    'ESCALATOR' => Icons.escalator_warning_outlined,
-    'WHEELCHAIR_LIFT' => Icons.accessible_forward,
-    'RAMP' => Icons.accessible,
-    'ACCESSIBLE_TOILET' || 'TOILET' => Icons.wc_outlined,
-    _ => Icons.warning_amber_outlined,
-  };
-}
-
-class _HomeStateCard extends StatelessWidget {
-  const _HomeStateCard({
-    required this.icon,
-    required this.title,
-    required this.subtitle,
-    this.actionLabel,
-    this.onAction,
-    super.key,
-  });
-
-  final IconData icon;
-  final String title;
-  final String subtitle;
-  final String? actionLabel;
-  final VoidCallback? onAction;
-
-  @override
-  Widget build(BuildContext context) {
-    final actionLabel = this.actionLabel;
-    return _AppCard(
-      showBorder: true,
-      child: AccessibleStateCard(
-        icon: icon,
-        title: title,
-        subtitle: subtitle,
-        actions: [
-          if (actionLabel != null && onAction != null)
-            OutlinedButton.icon(
-              onPressed: onAction,
-              icon: const Icon(Icons.refresh),
-              label: Text(actionLabel),
-            ),
-        ],
-      ),
-    );
-  }
-}
-
 class _HomeSavedRouteCard extends StatelessWidget {
   const _HomeSavedRouteCard({
     required this.route,
@@ -2756,7 +2261,7 @@ class _HomeSavedRouteCard extends StatelessWidget {
         ),
       ),
     );
-    return _AppCard(
+    return AppCard(
       showBorder: true,
       child: Row(
         children: [
@@ -2809,94 +2314,6 @@ class _HomeMiniBadge extends StatelessWidget {
         height: 1.2,
       ),
       padding: const EdgeInsets.symmetric(horizontal: 2),
-    );
-  }
-}
-
-class _AppCard extends StatelessWidget {
-  const _AppCard({
-    required this.child,
-    this.backgroundColor = Colors.white,
-    this.borderColor = EasySubwayAccessibleColors.line,
-    this.showBorder = true,
-  });
-
-  final Widget child;
-  final Color backgroundColor;
-  final Color borderColor;
-  final bool showBorder;
-
-  @override
-  Widget build(BuildContext context) {
-    // 최소 그림자 원칙: 그림자 대신 얇은 보더로 카드를 구분한다.
-    return Card(
-      margin: EdgeInsets.zero,
-      color: backgroundColor,
-      elevation: 0,
-      shadowColor: EasySubwayAccessibleColors.cardShadow,
-      shape: RoundedRectangleBorder(
-        side: showBorder ? BorderSide(color: borderColor) : BorderSide.none,
-        borderRadius: BorderRadius.circular(20),
-      ),
-      clipBehavior: Clip.antiAlias,
-      child: Padding(padding: const EdgeInsets.all(16), child: child),
-    );
-  }
-}
-
-class _AppInfoRow extends StatelessWidget {
-  const _AppInfoRow({
-    required this.icon,
-    required this.iconColor,
-    required this.title,
-    this.subtitle,
-  });
-
-  final IconData icon;
-  final Color iconColor;
-  final String title;
-  final String? subtitle;
-
-  @override
-  Widget build(BuildContext context) {
-    final subtitle = this.subtitle;
-    final leading = SizedBox(
-      width: 32,
-      height: 32,
-      child: Center(child: Icon(icon, color: iconColor, size: 22)),
-    );
-    final content = Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          title,
-          style: const TextStyle(
-            color: EasySubwayAccessibleColors.text,
-            fontSize: 15,
-            fontWeight: FontWeight.w700,
-            height: 1.25,
-          ),
-        ),
-        if (subtitle != null && subtitle.isNotEmpty) ...[
-          const SizedBox(height: 3),
-          Text(
-            subtitle,
-            style: const TextStyle(
-              color: EasySubwayAccessibleColors.mutedText,
-              fontSize: 12,
-              fontWeight: FontWeight.w500,
-              height: 1.4,
-            ),
-          ),
-        ],
-      ],
-    );
-    return Row(
-      children: [
-        leading,
-        const SizedBox(width: 12),
-        Expanded(child: content),
-      ],
     );
   }
 }
@@ -3345,12 +2762,12 @@ class _FavoriteHomeScreenState extends State<FavoriteHomeScreen> {
               },
               child: ListView(
                 physics: const AlwaysScrollableScrollPhysics(),
-                padding: _mainListPagePadding,
+                padding: mainListPagePadding,
                 children: [
                   if (snapshot.connectionState != ConnectionState.done)
                     const LinearProgressIndicator(minHeight: 3),
                   if (hasError)
-                    _HomeStateCard(
+                    HomeStateCard(
                       key: const Key('favoriteHomeErrorState'),
                       icon: Icons.error_outline,
                       title: '즐겨찾기를 불러오지 못했어요',
@@ -3365,8 +2782,8 @@ class _FavoriteHomeScreenState extends State<FavoriteHomeScreen> {
                   else if (data.isEmpty)
                     const Padding(
                       padding: EdgeInsets.only(top: 16),
-                      child: _AppCard(
-                        child: _AppInfoRow(
+                      child: AppCard(
+                        child: AppInfoRow(
                           icon: Icons.bookmark_border,
                           iconColor: EasySubwayAccessibleColors.mutedText,
                           title: '즐겨찾기한 항목이 없습니다',
@@ -3378,7 +2795,7 @@ class _FavoriteHomeScreenState extends State<FavoriteHomeScreen> {
                     // 카테고리 카드·개수 없이 저장한 항목을 바로 나열한다. 섹션
                     // 헤더는 해당 항목이 있을 때만 보여준다(#1569).
                     if (data.stations.isNotEmpty) ...[
-                      const _AppSectionTitle(title: '역'),
+                      const AppSectionTitle(title: '역'),
                       for (final station in data.stations)
                         _FavoriteHomeStationRow(
                           station: station,
@@ -3388,7 +2805,7 @@ class _FavoriteHomeScreenState extends State<FavoriteHomeScreen> {
                         ),
                     ],
                     if (data.routes.isNotEmpty) ...[
-                      const _AppSectionTitle(title: '경로'),
+                      const AppSectionTitle(title: '경로'),
                       for (final route in data.routes)
                         Padding(
                           padding: const EdgeInsets.only(bottom: 8),
@@ -3402,7 +2819,7 @@ class _FavoriteHomeScreenState extends State<FavoriteHomeScreen> {
                         ),
                     ],
                     if (data.facilities.isNotEmpty) ...[
-                      const _AppSectionTitle(title: '시설'),
+                      const AppSectionTitle(title: '시설'),
                       for (final facility in data.facilities)
                         _FavoriteHomeFacilityRow(
                           facility: facility,
@@ -3722,7 +3139,7 @@ class SupportAccessScreen extends StatelessWidget {
       appBar: AppBar(title: const Text('도움말·문의')),
       body: SafeArea(
         child: ListView(
-          padding: _mainPagePadding,
+          padding: mainPagePadding,
           children: [
             const _SupportSectionTitle(title: '내 정보와 개인정보'),
             _SupportGroupCard(
@@ -4122,7 +3539,7 @@ class _UserDataDeletionScreenState extends State<UserDataDeletionScreen> {
       ),
       body: SafeArea(
         child: ListView(
-          padding: _mainPagePadding,
+          padding: mainPagePadding,
           children: [
             Semantics(
               header: true,
@@ -4259,9 +3676,9 @@ class UserDataDeletionResultScreen extends StatelessWidget {
       ),
       body: SafeArea(
         child: ListView(
-          padding: _mainPagePadding,
+          padding: mainPagePadding,
           children: [
-            _AppCard(
+            AppCard(
               backgroundColor: EasySubwayAccessibleColors.surface,
               borderColor: EasySubwayAccessibleColors.line,
               child: Column(
@@ -4289,9 +3706,9 @@ class UserDataDeletionResultScreen extends StatelessWidget {
               ),
             ),
             const SizedBox(height: 12),
-            const _AppCard(
+            const AppCard(
               showBorder: true,
-              child: _AppInfoRow(
+              child: AppInfoRow(
                 icon: Icons.map_outlined,
                 iconColor: EasySubwayAccessibleColors.primary,
                 title: '노선도와 역 정보는 계속 이용할 수 있어요',
@@ -4556,10 +3973,10 @@ class _DataSourceAttributionScreenState
               builder: (context, snapshot) {
                 if (snapshot.hasError) {
                   return ListView(
-                    padding: _mainPagePadding,
+                    padding: mainPagePadding,
                     children: const [
-                      _AppCard(
-                        child: _AppInfoRow(
+                      AppCard(
+                        child: AppInfoRow(
                           icon: Icons.error_outline,
                           iconColor: EasySubwayAccessibleColors.amber,
                           title: '자료 제공 정보를 불러오지 못했어요',
@@ -4580,10 +3997,10 @@ class _DataSourceAttributionScreenState
                     .cast<Map<String, Object?>>()
                     .toList(growable: false);
                 return ListView(
-                  padding: _mainPagePadding,
+                  padding: mainPagePadding,
                   children: [
-                    const _AppCard(
-                      child: _AppInfoRow(
+                    const AppCard(
+                      child: AppInfoRow(
                         icon: Icons.fact_check_outlined,
                         iconColor: EasySubwayAccessibleColors.amber,
                         title: '현재 앱 표시',
@@ -4593,11 +4010,11 @@ class _DataSourceAttributionScreenState
                             '지도와 길·시설 안내는 공식·공개 자료를 바탕으로 해요. 상록수·사당역은 현장 확인까지 마쳤고, 나머지 역은 자료를 바탕으로 안내해요.',
                       ),
                     ),
-                    const _AppSectionTitle(title: '지도 표시용 asset'),
+                    const AppSectionTitle(title: '지도 표시용 asset'),
                     for (final map in maps) _AttributionCard.map(map, manifest),
-                    const _AppSectionTitle(title: '데이터 품질 Level'),
-                    const _AppCard(
-                      child: _AppInfoRow(
+                    const AppSectionTitle(title: '데이터 품질 Level'),
+                    const AppCard(
+                      child: AppInfoRow(
                         icon: Icons.verified_outlined,
                         iconColor: EasySubwayAccessibleColors.mintDark,
                         title: 'Level 1-4 품질 기준',
@@ -4605,8 +4022,8 @@ class _DataSourceAttributionScreenState
                             'Level 1은 역·노선 수, Level 2는 필수 시설 근거, Level 3은 운행상태와 최신 여부, Level 4는 현장 또는 운영기관이 확인한 쉬운 길을 봐요.',
                       ),
                     ),
-                    const _AppCard(
-                      child: _AppInfoRow(
+                    const AppCard(
+                      child: AppInfoRow(
                         icon: Icons.analytics_outlined,
                         iconColor: EasySubwayAccessibleColors.amber,
                         title: '품질 지표',
@@ -4614,7 +4031,7 @@ class _DataSourceAttributionScreenState
                             '필수 시설 근거 비율, 운행상태 확인 비율, 최신 정보 비율, 확인된 쉬운 길 비율, 현장 확인 경로 비율을 함께 확인해요.',
                       ),
                     ),
-                    const _AppSectionTitle(title: '경로·시설 안내용 데이터'),
+                    const AppSectionTitle(title: '경로·시설 안내용 데이터'),
                     for (final source in sources)
                       _AttributionCard.source(source),
                   ],
@@ -4703,7 +4120,7 @@ class _AttributionCard extends StatelessWidget {
       padding: const EdgeInsets.only(bottom: 12),
       child: Semantics(
         label: semanticLabel,
-        child: _AppCard(
+        child: AppCard(
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
@@ -4944,59 +4361,4 @@ Uri? _mailtoUri(String value, String subject) {
     path: email,
     queryParameters: {'subject': subject},
   );
-}
-
-class FeatureTile extends StatelessWidget {
-  const FeatureTile({
-    required this.icon,
-    required this.title,
-    required this.semanticLabel,
-    super.key,
-  });
-
-  final IconData icon;
-  final String title;
-  final String semanticLabel;
-
-  @override
-  Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-
-    return MergeSemantics(
-      child: Semantics(
-        label: semanticLabel,
-        child: ExcludeSemantics(
-          child: Card(
-            margin: const EdgeInsets.only(bottom: 12),
-            color: Colors.white,
-            elevation: 0,
-            shape: RoundedRectangleBorder(
-              borderRadius: _mainThemeControlRadius,
-              side: const BorderSide(color: EasySubwayAccessibleColors.line),
-            ),
-            child: Padding(
-              padding: const EdgeInsets.all(16),
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  Icon(icon, color: colorScheme.primary, size: 32),
-                  const SizedBox(width: 16),
-                  Expanded(
-                    child: Text(
-                      title,
-                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        color: EasySubwayAccessibleColors.text,
-                        fontWeight: FontWeight.w700,
-                        height: 1.35,
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
 }

--- a/apps/mobile/release/post-launch-operations-review-gate.json
+++ b/apps/mobile/release/post-launch-operations-review-gate.json
@@ -67,7 +67,7 @@
           "refreshOn": "support-contact-or-help-ui-change",
           "files": [
             {"path": "apps/mobile/release/support-incident-response-gate.json", "sha256": "82db73ed9b0e84ed140f8ebc16326844dd2cc58181b918806fa4aba29bfcb4ca"},
-            {"path": "apps/mobile/lib/main.dart", "sha256": "720db583db46f6f88ee6f6b71acccb8d00be1eaf9a3c67739db1d2b613ef2cb7"}
+            {"path": "apps/mobile/lib/main.dart", "sha256": "00ccd2055d853984ed5871b6b45e47a0f4a53595228c13e479f42a1d46b47ec0"}
           ]
         },
         {

--- a/apps/mobile/release/post-launch-operations-review-gate.json
+++ b/apps/mobile/release/post-launch-operations-review-gate.json
@@ -67,6 +67,7 @@
           "refreshOn": "support-contact-or-help-ui-change",
           "files": [
             {"path": "apps/mobile/release/support-incident-response-gate.json", "sha256": "82db73ed9b0e84ed140f8ebc16326844dd2cc58181b918806fa4aba29bfcb4ca"},
+            {"path": "apps/mobile/lib/app/app_components.dart", "sha256": "f0a53231cc819a6136049b979334d215968a54f0ce5cf8f17c1952674c926ac5"},
             {"path": "apps/mobile/lib/main.dart", "sha256": "00ccd2055d853984ed5871b6b45e47a0f4a53595228c13e479f42a1d46b47ec0"}
           ]
         },

--- a/apps/mobile/test/design_guard_test.dart
+++ b/apps/mobile/test/design_guard_test.dart
@@ -161,7 +161,8 @@ void main() {
     );
     expectRatchet(actual, {
       // 의도 잔존: 시설 상태 카드 blocked/caution — 상태 의미 틴트 (v4 허용 예외)
-      'lib/main.dart': 2,
+      'lib/features/notifications/presentation/notification_inbox_screen.dart':
+          2,
       'lib/station_search.dart': 1,
       // 의도 잔존: 운행 공지 배너 — 운행 중단 상태 의미 (v4 허용 예외)
       'lib/features/service_notice/presentation/service_notice_banner.dart': 1,
@@ -306,8 +307,10 @@ void main() {
     expectRatchet(actual, {
       // 의도 잔존: 역 상세 정보/도움/시설 카드·액션 버튼 radius (16/12) — 무박스 전환 진행 중
       'lib/station_search.dart': 4,
-      // 의도 잔존: _AppCard(20)·역 정보 컨테이너(16)·입력 필드(12x2) — v4 정리 대상
-      'lib/main.dart': 4,
+      // 의도 잔존: AppCard(20)·공용 control radius(12) — v4 정리 대상
+      'lib/app/app_components.dart': 2,
+      // 의도 잔존: 역 정보 컨테이너(16)·입력 필드(12) — v4 정리 대상
+      'lib/main.dart': 2,
       // 의도 잔존: 노선 선택 헤더 캡슐(13)·역명 배지(24) — 노선도 룩 불변, 완전 원 아님
       'lib/network_map.dart': 2,
       // 의도 잔존: 시설 신고 카드 radius(16) — 무박스 전환 대상
@@ -330,8 +333,8 @@ void main() {
     expectRatchet(actual, {
       // 의도 잔존: 역 상세/검색 결과 카드 6곳 — 무박스(행+구분선) 전환 진행 중
       'lib/station_search.dart': 6,
-      // 의도 잔존: _AppCard 공용 래퍼·정보 카드 2곳 — 무박스 전환 대상
-      'lib/main.dart': 2,
+      // 의도 잔존: AppCard 공용 래퍼·정보 카드 2곳 — 무박스 전환 대상
+      'lib/app/app_components.dart': 2,
     }, rule: '블록(박스) Card');
   });
 

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -2518,6 +2518,17 @@ test("모바일 signed release artifact gate와 광고 counter는 CI 산출물�
     refreshBindings.map((binding) => binding.refreshOn).sort(),
     postLaunchOperationsReviewGate.preLaunchReadiness.finalRcBinding.evidenceValidity.refreshOn.toSorted(),
   );
+  const supportContactBinding = refreshBindings.find(
+    (binding) => binding.refreshOn === "support-contact-or-help-ui-change",
+  );
+  assert.deepEqual(
+    supportContactBinding.files.map((file) => file.path).toSorted(),
+    [
+      "apps/mobile/lib/app/app_components.dart",
+      "apps/mobile/lib/main.dart",
+      "apps/mobile/release/support-incident-response-gate.json",
+    ],
+  );
   for (const binding of refreshBindings) {
     assert.ok(binding.files.length > 0, `${binding.refreshOn} must bind at least one file`);
     for (const file of binding.files) {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1710,8 +1710,14 @@ test("모바일 공통 상태 카드는 홈 즐겨찾기 노선도에서 사용�
   const networkMap = read("apps/mobile/lib/network_map.dart");
 
   assert.match(accessibleDesign, /class AccessibleStateCard extends StatelessWidget/);
-  assert.match(appComponents, /class HomeStateCard extends StatelessWidget[\s\S]*AccessibleStateCard\(/);
-  assert.match(networkMap, /AccessibleStateCard\([\s\S]*networkMapRetryButton/);
+  assert.match(
+    appComponents,
+    /class HomeStateCard extends StatelessWidget \{[\s\S]*?Widget build\(BuildContext context\) \{[\s\S]*?return AppCard\([\s\S]*?child: AccessibleStateCard\(/,
+  );
+  assert.match(
+    networkMap,
+    /child: AccessibleStateCard\([\s\S]*?key: const Key\('networkMapRetryButton'\)/,
+  );
 });
 
 test("모바일 presentation canonical 선언과 기존 public export를 유지한다", () => {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1714,6 +1714,28 @@ test("모바일 공통 상태 카드는 홈 즐겨찾기 노선도에서 사용�
   assert.match(networkMap, /AccessibleStateCard\([\s\S]*networkMapRetryButton/);
 });
 
+test("모바일 presentation canonical 선언과 기존 public export를 유지한다", () => {
+  const main = read("apps/mobile/lib/main.dart");
+  const appComponents = read("apps/mobile/lib/app/app_components.dart");
+  const notificationInbox = read(
+    "apps/mobile/lib/features/notifications/presentation/notification_inbox_screen.dart",
+  );
+
+  assert.match(notificationInbox, /^class NotificationInboxScreen extends StatefulWidget/m);
+  assert.match(appComponents, /^class FeatureTile extends StatelessWidget/m);
+  assert.match(appComponents, /^class AppSectionTitle extends StatelessWidget/m);
+  assert.match(appComponents, /^class HomeStateCard extends StatelessWidget/m);
+  assert.match(main, /^export 'app\/app_components\.dart' show FeatureTile;$/m);
+  assert.match(
+    main,
+    /^export 'features\/notifications\/presentation\/notification_inbox_screen\.dart'\s+show NotificationInboxScreen;$/m,
+  );
+  assert.doesNotMatch(
+    main,
+    /^class (?:NotificationInboxScreen|FeatureTile|AppSectionTitle|HomeStateCard)\b/m,
+  );
+});
+
 test("프로덕션 모바일 UI 위젯명은 prototype 명칭을 쓰지 않는다", () => {
   const mobileFiles = execFileSync("git", ["ls-files", "apps/mobile/lib/*.dart"], {
     cwd: root,

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1706,11 +1706,11 @@ test("모바일 async 실패는 빈 목록으로 조용히 숨기지 않는다",
 
 test("모바일 공통 상태 카드는 홈 즐겨찾기 노선도에서 사용된다", () => {
   const accessibleDesign = read("apps/mobile/lib/accessible_design.dart");
-  const main = read("apps/mobile/lib/main.dart");
+  const appComponents = read("apps/mobile/lib/app/app_components.dart");
   const networkMap = read("apps/mobile/lib/network_map.dart");
 
   assert.match(accessibleDesign, /class AccessibleStateCard extends StatelessWidget/);
-  assert.match(main, /class _HomeStateCard extends StatelessWidget[\s\S]*AccessibleStateCard\(/);
+  assert.match(appComponents, /class HomeStateCard extends StatelessWidget[\s\S]*AccessibleStateCard\(/);
   assert.match(networkMap, /AccessibleStateCard\([\s\S]*networkMapRetryButton/);
 });
 
@@ -12641,9 +12641,9 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(main, /RouteSearchScreen\([\s\S]*simpleViewEnabled: simpleViewEnabled/);
   assert.match(main, /AppBar\(title: const Text\('즐겨찾기'\)\)/);
   // 즐겨찾기 홈은 #1569에서 카테고리 카드를 없애고 역/경로/시설 인라인 섹션으로 바꿨다.
-  assert.match(main, /_AppSectionTitle\(title: '역'\)/);
-  assert.match(main, /_AppSectionTitle\(title: '시설'\)/);
-  assert.match(main, /_AppSectionTitle\(title: '경로'\)/);
+  assert.match(main, /AppSectionTitle\(title: '역'\)/);
+  assert.match(main, /AppSectionTitle\(title: '시설'\)/);
+  assert.match(main, /AppSectionTitle\(title: '경로'\)/);
   assert.match(main, /FavoriteHomeScreen/);
   // #1569: 하위 목록 화면 진입 대신 즐겨찾기 항목을 인라인 행으로 바로 나열한다.
   // (하위 목록 위젯 클래스는 각 소스 파일에 유지, main에서 진입만 제거)


### PR DESCRIPTION
## 관련 이슈

Refs #2181
Refs #2173

## 작업 배경

- `main.dart`에 알림 presentation과 여러 화면이 공유하는 card·title·padding 선언이 함께 있어 후속 책임 분리를 막고 있었습니다.
- 전체 파일을 한 번에 이동하면 2,000줄 gate를 넘으므로, 의존성이 낮은 Notification과 기존 공유 presentation primitive를 먼저 분리합니다.

## 작업 내용

- `NotificationInboxScreen`과 전용 private widget/helper를 `features/notifications/presentation/notification_inbox_screen.dart`로 이동했습니다.
- 기존 padding·radius·section title·state/card/info row·`FeatureTile`을 `app/app_components.dart`로 이동했습니다.
- cross-library 참조에 필요한 8개 선언만 public name으로 바꾸고, `main.dart`는 기존 public `NotificationInboxScreen`·`FeatureTile`만 호환 export합니다.
- canonical 선언 위치·public export·main 회귀 금지를 repository contract로 고정했습니다.
- 파일 이동 뒤에도 시각 언어 ratchet 총량이 늘지 않도록 `design_guard_test.dart`의 기존 허용량을 새 소유 파일로 이전했습니다.
- 공통 UI 변경이 운영 검토 freshness를 우회하지 않도록 `app_components.dart`를 release binding에 추가하고 파일 집합을 계약으로 고정했습니다.
- 선언 본문, widget tree, 문구, API 호출, constructor·default, 사용자 동작·UI·API 계약은 유지합니다.

## 검증

- baseline focused Flutter tests → 알림 33/33, 홈 36/36, 접근성 3/3
- `dart format` → 3 files, 0 changed
- `flutter analyze` → `No issues found!`
- final focused Flutter tests → 알림 33/33, 홈 36/36, 접근성 3/3
- final `flutter test test/widget_test.dart` → 291/291
- repository contract RED → 191/194 (예상 구조 경로 2건 + main SHA 1건)
- repository contract GREEN → 194/194
- review finding follow-up TDD → focused RED 0/1, GREEN 1/1, final full 195/195
- CodeRabbit CLI trivial finding follow-up → relationship mutation RED 2건, focused GREEN 1/1, final full 195/195
- full `flutter test` → 1,302/1,302
- `flutter test test/design_guard_test.dart --reporter expanded` → 12/12
- design guard 경로 이전 follow-up → RED 3건, GREEN 12/12
- release binding finding follow-up → repository contract RED 194/195, GREEN 195/195
- `git diff --check` → 통과
- independent initial review → Critical/Important/Minor 0건, Approved
- plugin-disabled Codex final review → Review #4710914593, actionable finding 0건
- GitHub CI → required CI, Android release artifact, RC evidence manifest 전체 통과
- raw diff → 755 additions + 687 deletions = 1,442 lines

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 알림 UI·동작 불변 | Flutter | baseline/final focused + full Flutter tests | 33/33, 36/36, 3/3, 1,302/1,302 | PASS |
| 선언 이동 불변 | Dart | base/head body·widget tree 대조 | independent review | PASS |
| canonical ownership | Repository CI | RED/GREEN structure contract | final 195/195 | PASS |
| design guard | Flutter | 파일별 허용량 이전 + 전체 ratchet | 12/12 | PASS |
| release evidence | Repository CI | main·app_components SHA-256 대조 | gate JSON·contract | PASS |
| 수동 UI·접근성 QA | 해당 없음 | rendering·copy·interaction 변경 없음 | 순수 선언/import diff | 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: `1.0.4` (변경 없음)
- mobile versionCode: `10005` (변경 없음)
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: `0.0.1-SNAPSHOT` (변경 없음)

## 리뷰어 메모

- 우선 확인: notification 전용 선언은 notification 파일에 private으로 남았는지, shared 선언의 public 전환이 cross-library 참조에 필요한 범위인지, `main.dart` export가 기존 public 2개로 제한되는지 봐 주세요.

## 리스크

- 대량 선언 이동 회귀는 body/widget tree 대조와 291개 widget test로 완화했습니다.
- private 가시성 확장은 후속 feature가 실제 공유하는 8개로 제한했습니다.
- release evidence 과대 갱신은 `main.dart` SHA를 갱신하고 새 canonical `app_components.dart` SHA만 binding에 추가했으며, 상태·날짜·version·artifact identity·나머지 hash는 유지해 완화했습니다.
- 배포, version, route/realtime/datapack contract 변경은 없습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다. (status 성공, Review 객체 없음)
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다. (Codex Review #4710914593)
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)
