### PR TITLE
[Refactor] demo dependency·접근성 theme 책임 분리

### DIFF
--- a/apps/mobile/lib/app/accessibility_theme.dart
+++ b/apps/mobile/lib/app/accessibility_theme.dart
@@ -1,0 +1,149 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import '../accessible_design.dart';
+import '../onboarding.dart';
+
+class OnboardingPreferenceScope extends StatelessWidget {
+  // ignore: use_key_in_widget_constructors
+  const OnboardingPreferenceScope({
+    required this.preferences,
+    required this.child,
+  });
+
+  final OnboardingViewPreferences preferences;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final mediaQuery = MediaQuery.of(context);
+
+    return MediaQuery(
+      data: mediaQuery.copyWith(
+        highContrast:
+            preferences.highContrastEnabled || mediaQuery.highContrast,
+      ),
+      child: Theme(
+        data: _themeForPlatformAccessibility(
+          _themeForPreferences(Theme.of(context), preferences),
+          mediaQuery,
+        ),
+        child: child,
+      ),
+    );
+  }
+}
+
+ThemeData _themeForPreferences(
+  ThemeData baseTheme,
+  OnboardingViewPreferences preferences,
+) {
+  if (!preferences.highContrastEnabled) {
+    return baseTheme;
+  }
+
+  final colorScheme = baseTheme.colorScheme.copyWith(
+    primary: EasySubwayAccessibleColors.highContrastPrimary,
+    onPrimary: Colors.white,
+    secondary: EasySubwayAccessibleColors.highContrastSecondary,
+    onSecondary: Colors.white,
+    surface: Colors.white,
+    onSurface: EasySubwayAccessibleColors.highContrastText,
+    outline: EasySubwayAccessibleColors.highContrastText,
+  );
+
+  return baseTheme.copyWith(
+    colorScheme: colorScheme,
+    scaffoldBackgroundColor: Colors.white,
+    appBarTheme: baseTheme.appBarTheme.copyWith(
+      backgroundColor: Colors.white,
+      foregroundColor: EasySubwayAccessibleColors.highContrastText,
+      titleTextStyle: baseTheme.appBarTheme.titleTextStyle?.copyWith(
+        color: EasySubwayAccessibleColors.highContrastText,
+      ),
+    ),
+    // 보조 버튼이 중립 보더로 바뀌었으므로 고대비에서 보더·텍스트 대비를 보정.
+    outlinedButtonTheme: OutlinedButtonThemeData(
+      style: baseTheme.outlinedButtonTheme.style?.copyWith(
+        foregroundColor: const WidgetStatePropertyAll(
+          EasySubwayAccessibleColors.highContrastPrimary,
+        ),
+        side: const WidgetStatePropertyAll(
+          BorderSide(
+            color: EasySubwayAccessibleColors.highContrastText,
+            width: 1.5,
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+ThemeData _themeForPlatformAccessibility(
+  ThemeData baseTheme,
+  MediaQueryData mediaQuery,
+) {
+  if (!mediaQuery.boldText) {
+    return baseTheme;
+  }
+
+  return baseTheme.copyWith(
+    textTheme: _boldTextTheme(baseTheme.textTheme),
+    primaryTextTheme: _boldTextTheme(baseTheme.primaryTextTheme),
+    appBarTheme: baseTheme.appBarTheme.copyWith(
+      titleTextStyle: _boldTextStyle(baseTheme.appBarTheme.titleTextStyle),
+      toolbarTextStyle: _boldTextStyle(baseTheme.appBarTheme.toolbarTextStyle),
+    ),
+    filledButtonTheme: FilledButtonThemeData(
+      style: _boldButtonTextStyle(baseTheme.filledButtonTheme.style),
+    ),
+    outlinedButtonTheme: OutlinedButtonThemeData(
+      style: _boldButtonTextStyle(baseTheme.outlinedButtonTheme.style),
+    ),
+    textButtonTheme: TextButtonThemeData(
+      style: _boldButtonTextStyle(baseTheme.textButtonTheme.style),
+    ),
+  );
+}
+
+TextTheme _boldTextTheme(TextTheme textTheme) {
+  return textTheme.copyWith(
+    displayLarge: _boldTextStyle(textTheme.displayLarge),
+    displayMedium: _boldTextStyle(textTheme.displayMedium),
+    displaySmall: _boldTextStyle(textTheme.displaySmall),
+    headlineLarge: _boldTextStyle(textTheme.headlineLarge),
+    headlineMedium: _boldTextStyle(textTheme.headlineMedium),
+    headlineSmall: _boldTextStyle(textTheme.headlineSmall),
+    titleLarge: _boldTextStyle(textTheme.titleLarge),
+    titleMedium: _boldTextStyle(textTheme.titleMedium),
+    titleSmall: _boldTextStyle(textTheme.titleSmall),
+    bodyLarge: _boldTextStyle(textTheme.bodyLarge),
+    bodyMedium: _boldTextStyle(textTheme.bodyMedium),
+    bodySmall: _boldTextStyle(textTheme.bodySmall),
+    labelLarge: _boldTextStyle(textTheme.labelLarge),
+    labelMedium: _boldTextStyle(textTheme.labelMedium),
+    labelSmall: _boldTextStyle(textTheme.labelSmall),
+  );
+}
+
+ButtonStyle _boldButtonTextStyle(ButtonStyle? baseStyle) {
+  return (baseStyle ?? const ButtonStyle()).copyWith(
+    textStyle: WidgetStateProperty.resolveWith((states) {
+      return _boldTextStyle(baseStyle?.textStyle?.resolve(states));
+    }),
+  );
+}
+
+TextStyle _boldTextStyle(TextStyle? style) {
+  final currentWeight = style?.fontWeight ?? FontWeight.w400;
+  final currentIndex = FontWeight.values.indexOf(currentWeight);
+  final minimumBoldIndex = FontWeight.values.indexOf(FontWeight.w700);
+  final nextIndex = math.min(
+    FontWeight.values.length - 1,
+    math.max(currentIndex + 2, minimumBoldIndex),
+  );
+  return (style ?? const TextStyle()).copyWith(
+    fontWeight: FontWeight.values[nextIndex],
+  );
+}

--- a/apps/mobile/lib/app/demo_dependencies.dart
+++ b/apps/mobile/lib/app/demo_dependencies.dart
@@ -1,0 +1,143 @@
+import '../favorite_facility.dart';
+import '../route_search.dart';
+import '../station_search.dart';
+
+class DemoFavoriteStationRepository implements FavoriteStationRepository {
+  const DemoFavoriteStationRepository();
+
+  static const _station = FavoriteStation(
+    userId: 'demo-user',
+    stationId: 'station-sangnoksu',
+    nameKo: '상록수',
+    nameEn: 'Sangnoksu',
+    region: '수도권',
+    dataQualityLevel: 'LEVEL_1',
+    dataSourceType: 'OFFICIAL_FILE',
+    lastVerifiedAt: '2026-06-13',
+    lines: [
+      StationSearchLine(
+        id: 'seoul-4',
+        name: '수도권 4호선',
+        color: '#00A5DE',
+        stationCode: '448',
+      ),
+    ],
+    addedAt: '2026-06-13T10:00:00',
+  );
+
+  @override
+  Future<List<FavoriteStation>> listFavoriteStations() async {
+    return const [_station];
+  }
+
+  @override
+  Future<FavoriteStation> saveFavoriteStation(String stationId) async {
+    return _station;
+  }
+
+  @override
+  Future<void> removeFavoriteStation(String stationId) async {}
+}
+
+class DemoFavoriteFacilityRepository implements FavoriteFacilityRepository {
+  const DemoFavoriteFacilityRepository();
+
+  static const _facility = FavoriteFacility(
+    userId: 'demo-user',
+    facilityId: 'facility-sangnoksu-elevator-3',
+    stationId: 'station-sangnoksu',
+    stationNameKo: '상록수',
+    stationNameEn: 'Sangnoksu',
+    exitId: 'exit-sangnoksu-3',
+    type: 'ELEVATOR',
+    name: '3번 출구 엘리베이터',
+    floorFrom: '1F',
+    floorTo: 'B1',
+    description: '3번 출구 앞',
+    status: 'NEEDS_CHECK',
+    dataConfidence: 'HIGH',
+    dataSourceType: 'OFFICIAL_FILE',
+    lastUpdatedAt: '2026-06-12',
+    addedAt: '2026-06-14T10:00:00',
+  );
+
+  @override
+  Future<List<FavoriteFacility>> listFavoriteFacilities() async {
+    return const [_facility];
+  }
+
+  @override
+  Future<FavoriteFacility> saveFavoriteFacility(String facilityId) async {
+    return _facility;
+  }
+
+  @override
+  Future<void> removeFavoriteFacility(String facilityId) async {}
+}
+
+class DemoFavoriteRouteRepository implements FavoriteRouteRepository {
+  const DemoFavoriteRouteRepository();
+
+  static const _route = FavoriteRoute(
+    userId: 'demo-user',
+    favoriteRouteId: 'route-1',
+    routeSearchId: 'route-1',
+    originStationId: 'station-sangnoksu',
+    originStationName: '상록수',
+    destinationStationId: 'station-sadang',
+    destinationStationName: '사당',
+    mobilityType: 'SENIOR',
+    status: 'FOUND',
+    lineId: 'seoul-4',
+    lineName: '수도권 4호선',
+    score: 92,
+    routeCreatedAt: '2026-06-13T09:00:00',
+    addedAt: '2026-06-14T10:00:00',
+  );
+
+  @override
+  Future<List<FavoriteRoute>> listFavoriteRoutes() async {
+    return const [_route];
+  }
+
+  @override
+  Future<FavoriteRoute> saveFavoriteRoute(
+    String routeSearchId, {
+    RouteSearchResult? result,
+  }) async {
+    return _route;
+  }
+
+  @override
+  Future<void> removeFavoriteRoute(String favoriteRouteId) async {}
+}
+
+class DemoSearchHistoryRepository implements SearchHistoryRepository {
+  final _queries = <String>['상록수', '사당'];
+
+  @override
+  Future<void> recordSearch(String query) async {
+    final trimmed = query.trim();
+    if (trimmed.isEmpty) {
+      return;
+    }
+    _queries
+      ..remove(trimmed)
+      ..insert(0, trimmed);
+  }
+
+  @override
+  Future<List<String>> listRecentQueries() async {
+    return List.unmodifiable(_queries);
+  }
+
+  @override
+  Future<void> removeSearch(String query) async {
+    _queries.remove(query.trim());
+  }
+
+  @override
+  Future<void> clearSearches() async {
+    _queries.clear();
+  }
+}

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -9,9 +8,11 @@ import 'package:flutter/services.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'accessible_design.dart';
+import 'app/accessibility_theme.dart';
 import 'app/app_components.dart';
 import 'app/app_bootstrap.dart';
 import 'app/app_dependencies.dart';
+import 'app/demo_dependencies.dart';
 import 'core/datapack/data_pack_metered_consent_gate.dart';
 import 'core/datapack/bundled_data_pack_freshness.dart';
 import 'core/datapack/data_pack_update_state.dart';
@@ -69,16 +70,16 @@ Future<void> main() async {
   final bootstrap = await AppBootstrap.initialize(
     enablePushNotifications: defaultPushNotificationsEnabled,
     favoriteRepository: defaultDemoHomeDataEnabled
-        ? const _DemoFavoriteStationRepository()
+        ? const DemoFavoriteStationRepository()
         : null,
     favoriteFacilityRepository: defaultDemoHomeDataEnabled
-        ? const _DemoFavoriteFacilityRepository()
+        ? const DemoFavoriteFacilityRepository()
         : null,
     favoriteRouteRepository: defaultDemoHomeDataEnabled
-        ? const _DemoFavoriteRouteRepository()
+        ? const DemoFavoriteRouteRepository()
         : null,
     searchHistoryRepository: defaultDemoHomeDataEnabled
-        ? _DemoSearchHistoryRepository()
+        ? DemoSearchHistoryRepository()
         : null,
   );
   await restoreGetOffAlarmState(bootstrap.dependencies.getOffAlarmController);
@@ -194,146 +195,6 @@ void validateReleaseBuildFlags({
   }
 }
 
-class _DemoFavoriteStationRepository implements FavoriteStationRepository {
-  const _DemoFavoriteStationRepository();
-
-  static const _station = FavoriteStation(
-    userId: 'demo-user',
-    stationId: 'station-sangnoksu',
-    nameKo: '상록수',
-    nameEn: 'Sangnoksu',
-    region: '수도권',
-    dataQualityLevel: 'LEVEL_1',
-    dataSourceType: 'OFFICIAL_FILE',
-    lastVerifiedAt: '2026-06-13',
-    lines: [
-      StationSearchLine(
-        id: 'seoul-4',
-        name: '수도권 4호선',
-        color: '#00A5DE',
-        stationCode: '448',
-      ),
-    ],
-    addedAt: '2026-06-13T10:00:00',
-  );
-
-  @override
-  Future<List<FavoriteStation>> listFavoriteStations() async {
-    return const [_station];
-  }
-
-  @override
-  Future<FavoriteStation> saveFavoriteStation(String stationId) async {
-    return _station;
-  }
-
-  @override
-  Future<void> removeFavoriteStation(String stationId) async {}
-}
-
-class _DemoFavoriteFacilityRepository implements FavoriteFacilityRepository {
-  const _DemoFavoriteFacilityRepository();
-
-  static const _facility = FavoriteFacility(
-    userId: 'demo-user',
-    facilityId: 'facility-sangnoksu-elevator-3',
-    stationId: 'station-sangnoksu',
-    stationNameKo: '상록수',
-    stationNameEn: 'Sangnoksu',
-    exitId: 'exit-sangnoksu-3',
-    type: 'ELEVATOR',
-    name: '3번 출구 엘리베이터',
-    floorFrom: '1F',
-    floorTo: 'B1',
-    description: '3번 출구 앞',
-    status: 'NEEDS_CHECK',
-    dataConfidence: 'HIGH',
-    dataSourceType: 'OFFICIAL_FILE',
-    lastUpdatedAt: '2026-06-12',
-    addedAt: '2026-06-14T10:00:00',
-  );
-
-  @override
-  Future<List<FavoriteFacility>> listFavoriteFacilities() async {
-    return const [_facility];
-  }
-
-  @override
-  Future<FavoriteFacility> saveFavoriteFacility(String facilityId) async {
-    return _facility;
-  }
-
-  @override
-  Future<void> removeFavoriteFacility(String facilityId) async {}
-}
-
-class _DemoFavoriteRouteRepository implements FavoriteRouteRepository {
-  const _DemoFavoriteRouteRepository();
-
-  static const _route = FavoriteRoute(
-    userId: 'demo-user',
-    favoriteRouteId: 'route-1',
-    routeSearchId: 'route-1',
-    originStationId: 'station-sangnoksu',
-    originStationName: '상록수',
-    destinationStationId: 'station-sadang',
-    destinationStationName: '사당',
-    mobilityType: 'SENIOR',
-    status: 'FOUND',
-    lineId: 'seoul-4',
-    lineName: '수도권 4호선',
-    score: 92,
-    routeCreatedAt: '2026-06-13T09:00:00',
-    addedAt: '2026-06-14T10:00:00',
-  );
-
-  @override
-  Future<List<FavoriteRoute>> listFavoriteRoutes() async {
-    return const [_route];
-  }
-
-  @override
-  Future<FavoriteRoute> saveFavoriteRoute(
-    String routeSearchId, {
-    RouteSearchResult? result,
-  }) async {
-    return _route;
-  }
-
-  @override
-  Future<void> removeFavoriteRoute(String favoriteRouteId) async {}
-}
-
-class _DemoSearchHistoryRepository implements SearchHistoryRepository {
-  final _queries = <String>['상록수', '사당'];
-
-  @override
-  Future<void> recordSearch(String query) async {
-    final trimmed = query.trim();
-    if (trimmed.isEmpty) {
-      return;
-    }
-    _queries
-      ..remove(trimmed)
-      ..insert(0, trimmed);
-  }
-
-  @override
-  Future<List<String>> listRecentQueries() async {
-    return List.unmodifiable(_queries);
-  }
-
-  @override
-  Future<void> removeSearch(String query) async {
-    _queries.remove(query.trim());
-  }
-
-  @override
-  Future<void> clearSearches() async {
-    _queries.clear();
-  }
-}
-
 class EasySubwayApp extends StatelessWidget {
   EasySubwayApp({
     required AppDependencies dependencies,
@@ -372,7 +233,7 @@ class EasySubwayApp extends StatelessWidget {
          recentRoutesFuture:
              recentRoutesFuture ??
              (defaultDemoHomeDataEnabled
-                 ? const _DemoFavoriteRouteRepository().listFavoriteRoutes()
+                 ? const DemoFavoriteRouteRepository().listFavoriteRoutes()
                  : null),
          navigatorKey: navigatorKey,
          key: key,
@@ -864,7 +725,7 @@ class _EasySubwayHomeState extends State<_EasySubwayHome>
         onboardingResult?.preferences ??
         const OnboardingViewPreferences.defaults();
 
-    return _OnboardingPreferenceScope(
+    return OnboardingPreferenceScope(
       preferences: preferences,
       child: HomeScreen(
         repository: widget.repository,
@@ -1292,148 +1153,6 @@ FacilityReportLocationLoader _facilityReportLocationLoader(
       longitude: location.longitude,
     );
   };
-}
-
-class _OnboardingPreferenceScope extends StatelessWidget {
-  const _OnboardingPreferenceScope({
-    required this.preferences,
-    required this.child,
-  });
-
-  final OnboardingViewPreferences preferences;
-  final Widget child;
-
-  @override
-  Widget build(BuildContext context) {
-    final mediaQuery = MediaQuery.of(context);
-
-    return MediaQuery(
-      data: mediaQuery.copyWith(
-        highContrast:
-            preferences.highContrastEnabled || mediaQuery.highContrast,
-      ),
-      child: Theme(
-        data: _themeForPlatformAccessibility(
-          _themeForPreferences(Theme.of(context), preferences),
-          mediaQuery,
-        ),
-        child: child,
-      ),
-    );
-  }
-}
-
-ThemeData _themeForPreferences(
-  ThemeData baseTheme,
-  OnboardingViewPreferences preferences,
-) {
-  if (!preferences.highContrastEnabled) {
-    return baseTheme;
-  }
-
-  final colorScheme = baseTheme.colorScheme.copyWith(
-    primary: EasySubwayAccessibleColors.highContrastPrimary,
-    onPrimary: Colors.white,
-    secondary: EasySubwayAccessibleColors.highContrastSecondary,
-    onSecondary: Colors.white,
-    surface: Colors.white,
-    onSurface: EasySubwayAccessibleColors.highContrastText,
-    outline: EasySubwayAccessibleColors.highContrastText,
-  );
-
-  return baseTheme.copyWith(
-    colorScheme: colorScheme,
-    scaffoldBackgroundColor: Colors.white,
-    appBarTheme: baseTheme.appBarTheme.copyWith(
-      backgroundColor: Colors.white,
-      foregroundColor: EasySubwayAccessibleColors.highContrastText,
-      titleTextStyle: baseTheme.appBarTheme.titleTextStyle?.copyWith(
-        color: EasySubwayAccessibleColors.highContrastText,
-      ),
-    ),
-    // 보조 버튼이 중립 보더로 바뀌었으므로 고대비에서 보더·텍스트 대비를 보정.
-    outlinedButtonTheme: OutlinedButtonThemeData(
-      style: baseTheme.outlinedButtonTheme.style?.copyWith(
-        foregroundColor: const WidgetStatePropertyAll(
-          EasySubwayAccessibleColors.highContrastPrimary,
-        ),
-        side: const WidgetStatePropertyAll(
-          BorderSide(
-            color: EasySubwayAccessibleColors.highContrastText,
-            width: 1.5,
-          ),
-        ),
-      ),
-    ),
-  );
-}
-
-ThemeData _themeForPlatformAccessibility(
-  ThemeData baseTheme,
-  MediaQueryData mediaQuery,
-) {
-  if (!mediaQuery.boldText) {
-    return baseTheme;
-  }
-
-  return baseTheme.copyWith(
-    textTheme: _boldTextTheme(baseTheme.textTheme),
-    primaryTextTheme: _boldTextTheme(baseTheme.primaryTextTheme),
-    appBarTheme: baseTheme.appBarTheme.copyWith(
-      titleTextStyle: _boldTextStyle(baseTheme.appBarTheme.titleTextStyle),
-      toolbarTextStyle: _boldTextStyle(baseTheme.appBarTheme.toolbarTextStyle),
-    ),
-    filledButtonTheme: FilledButtonThemeData(
-      style: _boldButtonTextStyle(baseTheme.filledButtonTheme.style),
-    ),
-    outlinedButtonTheme: OutlinedButtonThemeData(
-      style: _boldButtonTextStyle(baseTheme.outlinedButtonTheme.style),
-    ),
-    textButtonTheme: TextButtonThemeData(
-      style: _boldButtonTextStyle(baseTheme.textButtonTheme.style),
-    ),
-  );
-}
-
-TextTheme _boldTextTheme(TextTheme textTheme) {
-  return textTheme.copyWith(
-    displayLarge: _boldTextStyle(textTheme.displayLarge),
-    displayMedium: _boldTextStyle(textTheme.displayMedium),
-    displaySmall: _boldTextStyle(textTheme.displaySmall),
-    headlineLarge: _boldTextStyle(textTheme.headlineLarge),
-    headlineMedium: _boldTextStyle(textTheme.headlineMedium),
-    headlineSmall: _boldTextStyle(textTheme.headlineSmall),
-    titleLarge: _boldTextStyle(textTheme.titleLarge),
-    titleMedium: _boldTextStyle(textTheme.titleMedium),
-    titleSmall: _boldTextStyle(textTheme.titleSmall),
-    bodyLarge: _boldTextStyle(textTheme.bodyLarge),
-    bodyMedium: _boldTextStyle(textTheme.bodyMedium),
-    bodySmall: _boldTextStyle(textTheme.bodySmall),
-    labelLarge: _boldTextStyle(textTheme.labelLarge),
-    labelMedium: _boldTextStyle(textTheme.labelMedium),
-    labelSmall: _boldTextStyle(textTheme.labelSmall),
-  );
-}
-
-ButtonStyle _boldButtonTextStyle(ButtonStyle? baseStyle) {
-  return (baseStyle ?? const ButtonStyle()).copyWith(
-    textStyle: WidgetStateProperty.resolveWith((states) {
-      return _boldTextStyle(baseStyle?.textStyle?.resolve(states));
-    }),
-  );
-}
-
-TextStyle _boldTextStyle(TextStyle? style) {
-  final currentWeight = style?.fontWeight ?? FontWeight.w400;
-  final currentIndex = FontWeight.values.indexOf(currentWeight);
-  final minimumBoldIndex = FontWeight.values.indexOf(FontWeight.w700);
-  final nextIndex = math.min(
-    FontWeight.values.length - 1,
-    math.max(currentIndex + 2, minimumBoldIndex),
-  );
-  return (style ?? const TextStyle()).copyWith(
-    fontWeight: FontWeight.values[nextIndex],
-  );
 }
 
 class HomeScreen extends StatefulWidget {
@@ -2361,7 +2080,7 @@ class _AppSettingsScreenState extends State<AppSettingsScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return _OnboardingPreferenceScope(
+    return OnboardingPreferenceScope(
       preferences: _viewPreferences,
       child: Scaffold(
         key: const Key('settingsScreen'),

--- a/apps/mobile/release/post-launch-operations-review-gate.json
+++ b/apps/mobile/release/post-launch-operations-review-gate.json
@@ -68,7 +68,8 @@
           "files": [
             {"path": "apps/mobile/release/support-incident-response-gate.json", "sha256": "82db73ed9b0e84ed140f8ebc16326844dd2cc58181b918806fa4aba29bfcb4ca"},
             {"path": "apps/mobile/lib/app/app_components.dart", "sha256": "f0a53231cc819a6136049b979334d215968a54f0ce5cf8f17c1952674c926ac5"},
-            {"path": "apps/mobile/lib/main.dart", "sha256": "00ccd2055d853984ed5871b6b45e47a0f4a53595228c13e479f42a1d46b47ec0"}
+            {"path": "apps/mobile/lib/app/accessibility_theme.dart", "sha256": "a13c1ded6008a883060ef34bb52d3e54a83b103d0c0bcfba05fd6e9370e9128a"},
+            {"path": "apps/mobile/lib/main.dart", "sha256": "74f86422ede17b03e85b0ab2a895cfbb6cc5dcd5c8c6622e70342d02d1eb1d2a"}
           ]
         },
         {

--- a/apps/mobile/test/app/demo_dependencies_test.dart
+++ b/apps/mobile/test/app/demo_dependencies_test.dart
@@ -1,0 +1,110 @@
+import 'package:easysubway_mobile/app/demo_dependencies.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('demo 즐겨찾기 역 repository는 고정 fixture와 no-op 변경 계약을 유지한다', () async {
+    const repository = DemoFavoriteStationRepository();
+
+    final stations = await repository.listFavoriteStations();
+    expect(stations, hasLength(1));
+    final station = stations.single;
+    expect(station.userId, 'demo-user');
+    expect(station.stationId, 'station-sangnoksu');
+    expect(station.nameKo, '상록수');
+    expect(station.nameEn, 'Sangnoksu');
+    expect(station.region, '수도권');
+    expect(station.dataQualityLevel, 'LEVEL_1');
+    expect(station.dataSourceType, 'OFFICIAL_FILE');
+    expect(station.lastVerifiedAt, '2026-06-13');
+    expect(station.addedAt, '2026-06-13T10:00:00');
+    expect(station.lines, hasLength(1));
+    expect(station.lines.single.id, 'seoul-4');
+    expect(station.lines.single.name, '수도권 4호선');
+    expect(station.lines.single.color, '#00A5DE');
+    expect(station.lines.single.stationCode, '448');
+
+    expect(
+      (await repository.saveFavoriteStation('ignored')).stationId,
+      'station-sangnoksu',
+    );
+    await repository.removeFavoriteStation('station-sangnoksu');
+    expect(await repository.listFavoriteStations(), hasLength(1));
+  });
+
+  test('demo 즐겨찾기 시설 repository는 고정 fixture와 no-op 변경 계약을 유지한다', () async {
+    const repository = DemoFavoriteFacilityRepository();
+
+    final facilities = await repository.listFavoriteFacilities();
+    expect(facilities, hasLength(1));
+    final facility = facilities.single;
+    expect(facility.userId, 'demo-user');
+    expect(facility.facilityId, 'facility-sangnoksu-elevator-3');
+    expect(facility.stationId, 'station-sangnoksu');
+    expect(facility.stationNameKo, '상록수');
+    expect(facility.stationNameEn, 'Sangnoksu');
+    expect(facility.exitId, 'exit-sangnoksu-3');
+    expect(facility.type, 'ELEVATOR');
+    expect(facility.name, '3번 출구 엘리베이터');
+    expect(facility.floorFrom, '1F');
+    expect(facility.floorTo, 'B1');
+    expect(facility.description, '3번 출구 앞');
+    expect(facility.status, 'NEEDS_CHECK');
+    expect(facility.dataConfidence, 'HIGH');
+    expect(facility.dataSourceType, 'OFFICIAL_FILE');
+    expect(facility.fieldValidationStatus, 'UNKNOWN');
+    expect(facility.lastUpdatedAt, '2026-06-12');
+    expect(facility.addedAt, '2026-06-14T10:00:00');
+
+    expect(
+      (await repository.saveFavoriteFacility('ignored')).facilityId,
+      'facility-sangnoksu-elevator-3',
+    );
+    await repository.removeFavoriteFacility('facility-sangnoksu-elevator-3');
+    expect(await repository.listFavoriteFacilities(), hasLength(1));
+  });
+
+  test('demo 즐겨찾기 경로 repository는 고정 fixture와 no-op 변경 계약을 유지한다', () async {
+    const repository = DemoFavoriteRouteRepository();
+
+    final routes = await repository.listFavoriteRoutes();
+    expect(routes, hasLength(1));
+    final route = routes.single;
+    expect(route.userId, 'demo-user');
+    expect(route.favoriteRouteId, 'route-1');
+    expect(route.routeSearchId, 'route-1');
+    expect(route.originStationId, 'station-sangnoksu');
+    expect(route.originStationName, '상록수');
+    expect(route.destinationStationId, 'station-sadang');
+    expect(route.destinationStationName, '사당');
+    expect(route.mobilityType, 'SENIOR');
+    expect(route.status, 'FOUND');
+    expect(route.lineId, 'seoul-4');
+    expect(route.lineName, '수도권 4호선');
+    expect(route.score, 92);
+    expect(route.routeCreatedAt, '2026-06-13T09:00:00');
+    expect(route.addedAt, '2026-06-14T10:00:00');
+
+    expect(
+      (await repository.saveFavoriteRoute('ignored')).favoriteRouteId,
+      'route-1',
+    );
+    await repository.removeFavoriteRoute('route-1');
+    expect(await repository.listFavoriteRoutes(), hasLength(1));
+  });
+
+  test('demo 검색 기록은 최신순과 중복 제거 및 삭제 계약을 유지한다', () async {
+    final repository = DemoSearchHistoryRepository();
+
+    expect(await repository.listRecentQueries(), ['상록수', '사당']);
+    await repository.recordSearch(' 사당 ');
+    expect(await repository.listRecentQueries(), ['사당', '상록수']);
+    await repository.recordSearch('  ');
+    expect(await repository.listRecentQueries(), ['사당', '상록수']);
+    await repository.recordSearch('강남');
+    expect(await repository.listRecentQueries(), ['강남', '사당', '상록수']);
+    await repository.removeSearch(' 사당 ');
+    expect(await repository.listRecentQueries(), ['강남', '상록수']);
+    await repository.clearSearches();
+    expect(await repository.listRecentQueries(), isEmpty);
+  });
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1742,6 +1742,42 @@ test("모바일 presentation canonical 선언과 기존 public export를 유지�
   );
 });
 
+test("모바일 demo dependency와 접근성 theme는 app canonical 파일이 소유한다", () => {
+  const main = read("apps/mobile/lib/main.dart");
+  const demoDependencies = read("apps/mobile/lib/app/demo_dependencies.dart");
+  const accessibilityTheme = read("apps/mobile/lib/app/accessibility_theme.dart");
+
+  for (const declaration of [
+    "DemoFavoriteStationRepository",
+    "DemoFavoriteFacilityRepository",
+    "DemoFavoriteRouteRepository",
+    "DemoSearchHistoryRepository",
+  ]) {
+    assert.match(demoDependencies, new RegExp(`^class ${declaration}\\b`, "m"));
+    assert.doesNotMatch(main, new RegExp(`^class _?${declaration}\\b`, "m"));
+  }
+  assert.match(main, /^import 'app\/demo_dependencies\.dart';$/m);
+  assert.match(main, /const DemoFavoriteStationRepository\(\)/);
+  assert.match(main, /const DemoFavoriteFacilityRepository\(\)/);
+  assert.match(main, /const DemoFavoriteRouteRepository\(\)/);
+  assert.match(main, /DemoSearchHistoryRepository\(\)/);
+  assert.doesNotMatch(main, /^export 'app\/demo_dependencies\.dart'/m);
+
+  assert.match(accessibilityTheme, /^class OnboardingPreferenceScope extends StatelessWidget/m);
+  assert.match(
+    accessibilityTheme,
+    /class OnboardingPreferenceScope extends StatelessWidget \{[\s\S]*?Widget build\(BuildContext context\) \{[\s\S]*?child: Theme\([\s\S]*?data: _themeForPlatformAccessibility\(\s*_themeForPreferences\(Theme\.of\(context\), preferences\),\s*mediaQuery,\s*\)/,
+  );
+  assert.match(main, /^import 'app\/accessibility_theme\.dart';$/m);
+  assert.match(main, /OnboardingPreferenceScope\(/);
+  assert.doesNotMatch(main, /^class _?OnboardingPreferenceScope\b/m);
+  assert.doesNotMatch(main, /^ThemeData _themeForPreferences\b/m);
+  assert.doesNotMatch(main, /^ThemeData _themeForPlatformAccessibility\b/m);
+  assert.doesNotMatch(main, /^TextTheme _boldTextTheme\b/m);
+  assert.doesNotMatch(main, /^ButtonStyle _boldButtonTextStyle\b/m);
+  assert.doesNotMatch(main, /^TextStyle _boldTextStyle\b/m);
+});
+
 test("프로덕션 모바일 UI 위젯명은 prototype 명칭을 쓰지 않는다", () => {
   const mobileFiles = execFileSync("git", ["ls-files", "apps/mobile/lib/*.dart"], {
     cwd: root,
@@ -2524,6 +2560,7 @@ test("모바일 signed release artifact gate와 광고 counter는 CI 산출물�
   assert.deepEqual(
     supportContactBinding.files.map((file) => file.path).toSorted(),
     [
+      "apps/mobile/lib/app/accessibility_theme.dart",
       "apps/mobile/lib/app/app_components.dart",
       "apps/mobile/lib/main.dart",
       "apps/mobile/release/support-incident-response-gate.json",
@@ -12573,6 +12610,7 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   const envExample = read(".env.example");
   const iosInfoPlist = read("apps/mobile/ios/Runner/Info.plist");
   const main = read("apps/mobile/lib/main.dart");
+  const accessibilityTheme = read("apps/mobile/lib/app/accessibility_theme.dart");
   const appDependencies = read("apps/mobile/lib/app/app_dependencies.dart");
   const authHeaders = read("apps/mobile/lib/auth_headers.dart");
   const secureKeyValueStorage = read("apps/mobile/lib/secure_key_value_storage.dart");
@@ -12669,13 +12707,13 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(widgetTest, /역명으로 검색하면 현재 위치를 쓰지 않아도 계속 이용할 수 있습니다\./);
   assert.match(main, /initialMobilityType: onboardingResult\?\.mobilityType/);
   assert.match(main, /initialMobilityType: initialMobilityType/);
-  assert.match(main, /_OnboardingPreferenceScope/);
-  assert.doesNotMatch(main, /mediaQuery\.textScaler\.clamp\(minScaleFactor: 1\.18\)/);
-  assert.match(main, /highContrast:[\s\S]*preferences\.highContrastEnabled \|\| mediaQuery\.highContrast/);
-  assert.match(main, /mediaQuery\.boldText/);
-  assert.match(main, /_themeForPlatformAccessibility/);
-  assert.match(main, /WidgetStateProperty\.resolveWith/);
-  assert.match(main, /_themeForPreferences/);
+  assert.match(main, /OnboardingPreferenceScope/);
+  assert.doesNotMatch(accessibilityTheme, /mediaQuery\.textScaler\.clamp\(minScaleFactor: 1\.18\)/);
+  assert.match(accessibilityTheme, /highContrast:[\s\S]*preferences\.highContrastEnabled \|\| mediaQuery\.highContrast/);
+  assert.match(accessibilityTheme, /mediaQuery\.boldText/);
+  assert.match(accessibilityTheme, /_themeForPlatformAccessibility/);
+  assert.match(accessibilityTheme, /WidgetStateProperty\.resolveWith/);
+  assert.match(accessibilityTheme, /_themeForPreferences/);
   assert.match(main, /simpleViewEnabled: preferences\.simpleViewEnabled/);
   assert.match(main, /RouteSearchScreen\([\s\S]*simpleViewEnabled: simpleViewEnabled/);
   assert.match(main, /AppBar\(title: const Text\('즐겨찾기'\)\)/);


### PR DESCRIPTION
## 관련 이슈

Refs #2181
Refs #2173

## 작업 배경

- `main.dart`가 앱 조립 책임 외에 demo repository fixture와 접근성 Theme 조립까지 직접 소유해 변경 탐색 범위가 넓었습니다.
- 사용자 동작·UI·API 계약은 그대로 유지하면서 앱 루트의 독립 책임을 canonical 파일로 분리합니다.

## 작업 내용

- demo 즐겨찾기 역·시설·경로 및 검색 기록 repository를 `app/demo_dependencies.dart`로 이동했습니다.
- 고대비·bold text를 결합하는 접근성 Theme scope를 `app/accessibility_theme.dart`로 이동했습니다.
- 기존 fixture와 no-op/검색 기록 동작을 직접 고정하는 회귀 테스트 4개를 추가했습니다.
- canonical 소유권, `main.dart` 조립 경계, release SHA exact binding을 repository contract로 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `flutter test`: 1,306/1,306 통과
  - `flutter analyze`: 이슈 0
  - `node --test tools/ci/repository-contract.test.mjs`: 196/196 통과
  - `dart format --output=none --set-exit-if-changed ...`: 변경 0
  - `git diff --check origin/main...HEAD`: 통과
  - 독립 read-only review: Critical 0 / Important 0 / Minor 0

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 사용자 동작·UI 회귀 | Flutter | 전체 test suite | 1,306/1,306 | 통과 |
| 접근성 Theme 동작 | Flutter | accessibility/widget runtime test 및 canonical contract | 전체 suite와 repository contract | 통과 |
| 수동 UI QA | Android/iOS | 위젯 트리·Theme 값·적용 순서를 변경하지 않은 순수 이동이므로 불필요 | 독립 diff review | 영향 없음 |
| release binding | Repository | exact file-set 및 SHA contract | 196/196 | 통과 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `OnboardingPreferenceScope`의 `MediaQuery → Theme` 중첩과 preferences Theme 후 platform accessibility Theme 적용 순서가 이동 전과 동일한지 확인해 주세요.
- raw diff는 756줄(458 additions / 298 deletions)이며 2,000줄 gate 이내입니다.
- release gate에는 사용자 지원 UI 책임인 `accessibility_theme.dart`만 추가했고 release에서 금지되는 demo dependency는 결속하지 않았습니다.

## 리스크

- 파일 경계 밖 사용을 위해 기존 private class 이름 일부가 library-public으로 바뀌지만 export는 추가하지 않았습니다.
- 구조 이동 중 누락 위험은 전체 Flutter 테스트, demo fixture 테스트, canonical/release exact contract로 차단했습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)
