### PR TITLE
[Mobile] ITX 실패 뒤 명시적 지하철 복구 추가

### DIFF
--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -2977,6 +2977,13 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
                     ),
                     _RouteSearchBody(
                       state: _controller.state,
+                      onSearchSubwayOnly:
+                          _selectedTransportScope ==
+                              RouteTransportScope.subwayAndItxCheongchun
+                          ? () => _changeTransportScope(
+                              RouteTransportScope.subway,
+                            )
+                          : null,
                       routeFeedbackRepository: widget.routeFeedbackRepository,
                       favoriteRouteRepository: widget.favoriteRouteRepository,
                       adRepository: widget.adRepository,
@@ -3903,6 +3910,7 @@ class _RouteStationOptionTile extends StatelessWidget {
 class _RouteSearchBody extends StatelessWidget {
   const _RouteSearchBody({
     required this.state,
+    this.onSearchSubwayOnly,
     required this.routeFeedbackRepository,
     required this.favoriteRouteRepository,
     required this.adRepository,
@@ -3912,6 +3920,7 @@ class _RouteSearchBody extends StatelessWidget {
   });
 
   final RouteSearchState state;
+  final AsyncCallback? onSearchSubwayOnly;
   final RouteFeedbackRepository? routeFeedbackRepository;
   final FavoriteRouteRepository? favoriteRouteRepository;
   final AdRepository? adRepository;
@@ -3935,6 +3944,7 @@ class _RouteSearchBody extends StatelessWidget {
       ),
       RouteSearchViewStatus.failure => _RouteSearchFailureMessage(
         message: state.message,
+        onSearchSubwayOnly: onSearchSubwayOnly,
       ),
       RouteSearchViewStatus.success => _RouteSearchResultCard(
         result: state.result!,
@@ -3952,9 +3962,13 @@ class _RouteSearchBody extends StatelessWidget {
 }
 
 class _RouteSearchFailureMessage extends StatelessWidget {
-  const _RouteSearchFailureMessage({required this.message});
+  const _RouteSearchFailureMessage({
+    required this.message,
+    this.onSearchSubwayOnly,
+  });
 
   final String message;
+  final AsyncCallback? onSearchSubwayOnly;
 
   @override
   Widget build(BuildContext context) {
@@ -3966,6 +3980,14 @@ class _RouteSearchFailureMessage extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         _RouteSearchMessage(message: message, liveRegion: true),
+        if (onSearchSubwayOnly != null) ...[
+          const SizedBox(height: 12),
+          OutlinedButton(
+            key: const Key('routeSearchSubwayOnlyAction'),
+            onPressed: onSearchSubwayOnly,
+            child: const Text('지하철만 보기'),
+          ),
+        ],
         if (shouldShowNextAction) ...[
           const SizedBox(height: 8),
           Semantics(

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -8491,6 +8491,61 @@ void main() {
     );
   });
 
+  testWidgets('ITX 실패는 명시적 지하철만 보기 선택 뒤에만 SUBWAY로 재검색한다', (tester) async {
+    final routeRepository = FakeRouteSearchRepository(
+      errorForRequest: (request) =>
+          request.transportScope == RouteTransportScope.subwayAndItxCheongchun
+          ? const RouteSearchOnlineException.unavailable(
+              failureReason: 'ITX_TIMETABLE_UNAVAILABLE',
+              message: 'ITX 시간표를 불러올 수 없어요',
+            )
+          : null,
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RouteSearchScreen(
+          repository: routeRepository,
+          stationRepository: FakeStationSearchRepository(),
+          favoriteRouteRepository: FakeFavoriteRouteRepository(),
+          itxTransportScopeEnabled: true,
+          initialTransportScope: RouteTransportScope.subwayAndItxCheongchun,
+          initialDraft: RouteDraft(
+            origin: const RouteDraftStation(
+              id: 'station-sangnoksu',
+              nameKo: '상록수',
+            ),
+            destination: const RouteDraftStation(
+              id: 'station-sadang',
+              nameKo: '사당',
+            ),
+            lastModifiedAt: DateTime(2026, 7, 16),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(routeRepository.requests, hasLength(1));
+    expect(
+      routeRepository.requests.single.transportScope,
+      RouteTransportScope.subwayAndItxCheongchun,
+    );
+    expect(
+      find.byKey(const Key('routeSearchSubwayOnlyAction')),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byKey(const Key('routeSearchSubwayOnlyAction')));
+    await tester.pumpAndSettle();
+
+    expect(routeRepository.requests, hasLength(2));
+    expect(
+      routeRepository.requests.last.transportScope,
+      RouteTransportScope.subway,
+    );
+    expect(find.byKey(const Key('routeResultListItem')), findsOneWidget);
+  });
+
   testWidgets('즐겨찾기에서 복원한 ITX transport scope로 첫 검색을 시작한다', (tester) async {
     final routeRepository = FakeRouteSearchRepository();
     await tester.pumpWidget(
@@ -16959,11 +17014,15 @@ Future<void> _enableSampleGetOffAlarm(GetOffAlarmController controller) {
 }
 
 class FakeRouteSearchRepository implements RouteSearchRepository {
-  FakeRouteSearchRepository({RouteSearchResult? result, this.error})
-    : result = result ?? _sampleRouteSearchResult();
+  FakeRouteSearchRepository({
+    RouteSearchResult? result,
+    this.error,
+    this.errorForRequest,
+  }) : result = result ?? _sampleRouteSearchResult();
 
   final RouteSearchResult result;
   final Object? error;
+  final Object? Function(RouteSearchRequest request)? errorForRequest;
   final requests = <RouteSearchRequest>[];
   final refreshRouteSearchIds = <String>[];
   RouteRefreshResult? refreshResult;
@@ -16973,7 +17032,7 @@ class FakeRouteSearchRepository implements RouteSearchRepository {
   @override
   Future<RouteSearchResult> searchRoute(RouteSearchRequest request) async {
     requests.add(request);
-    final currentError = error;
+    final currentError = errorForRequest?.call(request) ?? error;
     if (currentError != null) {
       throw currentError;
     }


### PR DESCRIPTION
## 관련 이슈

Refs AquilaXk/easysubway-mobile#7

## 작업 배경

- ITX 시간표 실패 뒤 자동 SUBWAY fallback은 금지되어 있지만, 사용자가 직접 선택할 `지하철만 보기` 복구 동작이 없었습니다.

## 작업 내용

- ITX scope 검색 실패 화면에 명시적 `지하철만 보기` action을 추가했습니다.
- action을 누른 경우에만 기존 transport scope 전환 경로로 새 SUBWAY 검색을 실행합니다.
- 누르기 전 자동 재요청이 없고, 누른 뒤 SUBWAY 요청과 결과가 발생하는 widget 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/widget_test.dart --plain-name 'ITX 실패는 명시적 지하철만 보기 선택 뒤에만 SUBWAY로 재검색한다'`: RED 확인 후 PASS
  - `flutter test test/widget_test.dart --plain-name 'Route V2 transport flag는 explicit ITX 선택에서만 combined 재검색한다'`: PASS
  - `flutter test test/widget_test.dart --plain-name 'transport scope'`: 3/3 PASS
  - `flutter analyze lib/route_search.dart test/widget_test.dart`: PASS
  - `flutter test --reporter compact`: 1,303/1,303 PASS
  - `git diff --check`: PASS

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| ITX 실패 뒤 명시적 SUBWAY 복구 | Flutter widget | 요청 scope와 action 전후 요청 수 검증 | `apps/mobile/test/widget_test.dart` | PASS |
| 자동 fallback 없음 | Flutter widget | action 전 요청이 ITX 1건뿐인지 검증 | `apps/mobile/test/widget_test.dart` | PASS |
| Play-installed offline/backend-down | Android RC | 동일 최종 RC에서 별도 수동 QA 필요 | AquilaXk/easysubway-mobile#7 Required Evidence | 이 PR 범위 밖, 미완료 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] AquilaXk/easysubway#1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: ITX failure의 user-selected SUBWAY recovery action 추가
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: ITX 실패에서 action이 표시되지만, 자동 재검색은 없고 `_changeTransportScope(RouteTransportScope.subway)`를 통해서만 새 요청이 발생하는지 확인해 주세요.

## 리스크

- 최종 Play-installed RC의 airplane mode/backend-down 실기기 증거는 이 코드 변경만으로 충족되지 않습니다. #1016과 최종 RC가 준비된 뒤 AquilaXk/easysubway-mobile#7 QA를 별도로 완료해야 합니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. 배포 변경 없음.
