### PR TITLE
[Fix] Route V2 non-PASS evidence RC 결속

### DIFF
--- a/apps/mobile/release/abuse-penetration-rehearsal-gate.json
+++ b/apps/mobile/release/abuse-penetration-rehearsal-gate.json
@@ -58,7 +58,7 @@
   "androidRcEvidenceManifest": "apps/mobile/release/android-rc-store-evidence.json",
   "securityPrivacyEvidenceManifest": "apps/mobile/release/security-privacy-release-evidence.json",
   "releaseSecurityGate": "apps/mobile/release/release-security-gate.json",
-  "evidenceRoot": ".codex/evidence/security/abuse-penetration-rehearsal/<rc-or-run>/",
+  "evidenceRoot": ".codex/evidence/security/abuse-penetration-rehearsal/<git-sha>/",
   "latestQaEvidenceStatus": {
     "qaEvidenceDateKst": "2026-06-28",
     "playAndStorePreflight": {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -3060,7 +3060,7 @@ test("모바일 signed release artifact gate와 광고 counter는 CI 산출물�
   assert.equal(abusePenetrationRehearsalGate.status, "BLOCKED_EXTERNAL");
   assert.equal(abusePenetrationRehearsalGate.androidRcEvidenceManifest, androidRcEvidencePath);
   assert.equal(abusePenetrationRehearsalGate.securityPrivacyEvidenceManifest, "apps/mobile/release/security-privacy-release-evidence.json");
-  assert.match(abusePenetrationRehearsalGate.evidenceRoot, /\.codex\/evidence\/security\/abuse-penetration-rehearsal\/<rc-or-run>/);
+  assert.equal(abusePenetrationRehearsalGate.evidenceRoot, ".codex/evidence/security/abuse-penetration-rehearsal/<git-sha>/");
   const adGuardrails = abusePenetrationRehearsalGate.adEventAbuseGuardrails;
   assert.equal(adGuardrails.issue, 1912);
   assert.deepEqual(adGuardrails.edge, {

--- a/tools/security/validate-abuse-penetration-summary.mjs
+++ b/tools/security/validate-abuse-penetration-summary.mjs
@@ -142,6 +142,10 @@ function validateV2Semantics(summary, gate, catalog) {
   const pass = summary.status === "PASS";
   if (pass) for (const field of gate.summaryContract.requiredFields.rootAdditionalForPass) if (!(field in summary)) fail("SUMMARY_ID_SET_MISMATCH",`$.${field}`,"pass-required");
   if (summary.artifactIdentity !== undefined) validateIdentity(summary.artifactIdentity,gate,"$.artifactIdentity","SUMMARY_V2_SCHEMA_INVALID");
+  if (summary.artifactIdentity === undefined &&
+      ((summary.evidence?.length ?? 0) > 0 || (summary.productionLikeEvidence?.length ?? 0) > 0)) {
+    fail("SUMMARY_IDENTITY_INVALID","$.artifactIdentity","evidence-root-artifact-identity");
+  }
   const evidencePaths = new Set();
   if (summary.evidence !== undefined) validateEvidence(summary.evidence,catalog.matrixEvidenceIds,"$.evidence",pass,gate,summary.artifactIdentity,evidencePaths);
   if (summary.productionLikeEvidence !== undefined) validateEvidence(summary.productionLikeEvidence,catalog.productionLikeEvidenceIds,"$.productionLikeEvidence",pass,gate,summary.artifactIdentity,evidencePaths);

--- a/tools/security/validate-abuse-penetration-summary.test.mjs
+++ b/tools/security/validate-abuse-penetration-summary.test.mjs
@@ -146,11 +146,23 @@ test("A RED v2 matrix cases are bound to the complete root artifact identity", (
       error.rule === "matrix-case-root-artifact-identity",
   );
 });
+test("A RED v2 evidence collections require the complete root artifact identity", () => {
+  for (const collection of ["evidence", "productionLikeEvidence"]) {
+    const summary = schemaV2Blocked(gate, "FAIL");
+    summary[collection] = [structuredClone(freshV2Pass()[collection][0])];
+    assert.throws(
+      () => validateAbusePenetrationSummary(summary, gate),
+      (error) => error.code === "SUMMARY_IDENTITY_INVALID" &&
+        error.path === "$.artifactIdentity" &&
+        error.rule === "evidence-root-artifact-identity",
+    );
+  }
+});
 test("A RED direct schema rejects every missing required and extra field", () => {
   const requiredByKind = {
     root: ["schemaVersion", "releaseGate", "issue", "status", "rawInvocationStored", "redactionPolicyId"],
     artifactIdentity: ["gitSha", "versionCode", "androidApplicationId", "dataPackManifestSha256"],
-    evidence: ["evidenceId", "result", "localEvidencePath"], matrix: ["matrixId", "result", "findingCounts", "cases"],
+    evidence: ["evidenceId", "result", "localEvidencePath", "artifactIdentitySha256"], matrix: ["matrixId", "result", "findingCounts", "cases"],
     findingCounts: ["critical", "high", "medium", "low"],
     mediumFindingDisposition: ["ownerAlias", "fixPlanEvidencePath"],
     case: ["procedureId", "targetAlias", "expectedStatus", "observedStatus", "redactionResult", "localEvidencePath", "artifactIdentitySha256"],


### PR DESCRIPTION
## 관련 이슈

Refs #1022

## 작업 배경

- #2188 병합 직후 exact head 독립 Review에서 non-PASS evidence의 RC identity 검증 우회와 공개 evidence 경로 계약 불일치가 확인되었습니다.
- 실제 Play/운영 리허설 증거가 다른 RC와 섞이지 않도록 후속 수정을 분리합니다.

## 작업 내용

- `FAIL`·`BLOCKED_EXTERNAL` summary도 `evidence` 또는 `productionLikeEvidence`가 있으면 root `artifactIdentity`를 필수화했습니다.
- 공개 `evidenceRoot`를 validator가 강제하는 `<git-sha>` 규칙과 일치시켰습니다.
- 두 경계와 evidence 필수 digest 필드의 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/security/validate-abuse-penetration-summary.test.mjs tools/ci/repository-contract.test.mjs`: 240/240 PASS
  - `git diff --check origin/main...HEAD`: PASS

## 검증 증거

UI·접근성·배포 동작 변경은 없습니다. 보안 evidence validator와 machine contract만 변경하며 자동 테스트 결과를 증거로 사용합니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| non-PASS evidence root identity | Node contract | validator regression | 240/240 PASS | PASS |
| evidence root 공개 계약 | Repository contract | exact value assertion | 240/240 PASS | PASS |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 보안 QA evidence provenance만 강화
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: root identity가 없는 non-PASS evidence collection이 `SUMMARY_IDENTITY_INVALID`로 fail-closed되는지 확인해 주세요.

## 리스크

- 기존에 `<rc-or-run>` 경로로 만든 로컬 evidence는 새 `<git-sha>` 경로로 이동해야 합니다. 아직 실제 종료 증거가 없으므로 기존 승인 evidence 호환성 영향은 없습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)
