### PR TITLE
[Refactor] 최근 역 검색 목록 presentation 분리

### DIFF
--- a/apps/mobile/lib/features/stations/presentation/station_recent_search_section.dart
+++ b/apps/mobile/lib/features/stations/presentation/station_recent_search_section.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/material.dart';
+
+import '../../../accessible_design.dart';
+import '../../../design_tokens.dart';
+
+class StationRecentSearchSection extends StatelessWidget {
+  const StationRecentSearchSection({
+    super.key,
+    required this.queries,
+    required this.enabled,
+    required this.onQuerySelected,
+    required this.onQueryRemoved,
+    required this.onClearAll,
+  });
+
+  final List<String> queries;
+  final bool enabled;
+  final ValueChanged<String> onQuerySelected;
+  final ValueChanged<String> onQueryRemoved;
+  final VoidCallback onClearAll;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      key: const Key('stationRecentSearchSection'),
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: Text(
+                '최근 검색',
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  color: EasySubwayAccessibleColors.text,
+                  fontWeight: FontWeight.w700,
+                  height: 1.25,
+                ),
+              ),
+            ),
+            TextButton.icon(
+              key: const Key('stationRecentSearchClearAllButton'),
+              style: TextButton.styleFrom(
+                foregroundColor: EasySubwayAccessibleColors.mutedText,
+              ),
+              onPressed: enabled ? onClearAll : null,
+              icon: const Icon(Icons.delete_sweep_outlined, size: 18),
+              label: const Text('전체 삭제'),
+            ),
+          ],
+        ),
+        const Divider(
+          height: EasySubwaySpacing.lg,
+          color: EasySubwayAccessibleColors.line,
+        ),
+        Column(
+          children: [
+            for (final entry in queries.indexed) ...[
+              if (entry.$1 > 0)
+                const Divider(
+                  height: 1,
+                  color: EasySubwayAccessibleColors.line,
+                ),
+              _StationRecentSearchItem(
+                query: entry.$2,
+                order: entry.$1 + 1,
+                enabled: enabled,
+                onQuerySelected: onQuerySelected,
+                onQueryRemoved: onQueryRemoved,
+              ),
+            ],
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _StationRecentSearchItem extends StatelessWidget {
+  const _StationRecentSearchItem({
+    required this.query,
+    required this.order,
+    required this.enabled,
+    required this.onQuerySelected,
+    required this.onQueryRemoved,
+  });
+
+  final String query;
+  final int order;
+  final bool enabled;
+  final ValueChanged<String> onQuerySelected;
+  final ValueChanged<String> onQueryRemoved;
+
+  @override
+  Widget build(BuildContext context) {
+    return ConstrainedBox(
+      constraints: const BoxConstraints(minHeight: 56),
+      child: Row(
+        children: [
+          Expanded(
+            child: Semantics(
+              label: '최근 검색어 $query 검색, 최근 사용 $order번째',
+              button: true,
+              enabled: enabled,
+              onTap: enabled ? () => onQuerySelected(query) : null,
+              child: ExcludeSemantics(
+                child: InkWell(
+                  key: Key('stationRecentSearchQuery-$query'),
+                  onTap: enabled ? () => onQuerySelected(query) : null,
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      vertical: EasySubwaySpacing.md,
+                    ),
+                    child: Row(
+                      children: [
+                        const Icon(
+                          Icons.history,
+                          color: EasySubwayAccessibleColors.iconMuted,
+                        ),
+                        const SizedBox(width: EasySubwaySpacing.md),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                query,
+                                style: Theme.of(context).textTheme.titleMedium
+                                    ?.copyWith(
+                                      color: EasySubwayAccessibleColors.text,
+                                      fontWeight: FontWeight.w700,
+                                      height: 1.25,
+                                    ),
+                              ),
+                              Text(
+                                '최근 사용 $order번째',
+                                style: Theme.of(context).textTheme.bodySmall
+                                    ?.copyWith(
+                                      color: EasySubwayAccessibleColors.caption,
+                                      height: 1.3,
+                                    ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+          IconButton(
+            key: Key('stationRecentSearchRemove-$query'),
+            tooltip: '$query 최근 검색 삭제',
+            onPressed: enabled ? () => onQueryRemoved(query) : null,
+            icon: const Icon(Icons.close),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -8,7 +8,6 @@ import 'package:flutter/foundation.dart';
 import 'accessible_design.dart';
 import 'adaptive_layout.dart';
 import 'core/external/kakao_map_launcher.dart';
-import 'design_tokens.dart';
 import 'facility_status.dart';
 import 'facility_report.dart';
 import 'features/ads/active_ad_banner.dart';
@@ -22,6 +21,7 @@ import 'features/stations/domain/station_line.dart';
 import 'features/stations/domain/station_models.dart';
 import 'features/stations/domain/station_repositories.dart';
 import 'features/stations/presentation/station_line_badges.dart';
+import 'features/stations/presentation/station_recent_search_section.dart';
 import 'internal_route.dart';
 import 'mobile_error_reporter.dart';
 import 'search_field.dart';
@@ -32,6 +32,7 @@ export 'features/stations/data/current_location_provider.dart';
 export 'features/stations/domain/station_line.dart';
 export 'features/stations/domain/station_models.dart';
 export 'features/stations/domain/station_repositories.dart';
+export 'features/stations/presentation/station_recent_search_section.dart';
 
 const _currentLocationDisabledMessage =
     '휴대전화의 위치 기능을 켜 주세요. 가까운 역을 찾는 데 필요합니다.';
@@ -611,163 +612,6 @@ class _StationSearchRegionIndicator extends StatelessWidget {
             ),
           ),
         ),
-      ),
-    );
-  }
-}
-
-class StationRecentSearchSection extends StatelessWidget {
-  const StationRecentSearchSection({
-    super.key,
-    required this.queries,
-    required this.enabled,
-    required this.onQuerySelected,
-    required this.onQueryRemoved,
-    required this.onClearAll,
-  });
-
-  final List<String> queries;
-  final bool enabled;
-  final ValueChanged<String> onQuerySelected;
-  final ValueChanged<String> onQueryRemoved;
-  final VoidCallback onClearAll;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      key: const Key('stationRecentSearchSection'),
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Row(
-          children: [
-            Expanded(
-              child: Text(
-                '최근 검색',
-                style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                  color: EasySubwayAccessibleColors.text,
-                  fontWeight: FontWeight.w700,
-                  height: 1.25,
-                ),
-              ),
-            ),
-            TextButton.icon(
-              key: const Key('stationRecentSearchClearAllButton'),
-              style: TextButton.styleFrom(
-                foregroundColor: EasySubwayAccessibleColors.mutedText,
-              ),
-              onPressed: enabled ? onClearAll : null,
-              icon: const Icon(Icons.delete_sweep_outlined, size: 18),
-              label: const Text('전체 삭제'),
-            ),
-          ],
-        ),
-        const Divider(
-          height: EasySubwaySpacing.lg,
-          color: EasySubwayAccessibleColors.line,
-        ),
-        Column(
-          children: [
-            for (final entry in queries.indexed) ...[
-              if (entry.$1 > 0)
-                const Divider(
-                  height: 1,
-                  color: EasySubwayAccessibleColors.line,
-                ),
-              _StationRecentSearchItem(
-                query: entry.$2,
-                order: entry.$1 + 1,
-                enabled: enabled,
-                onQuerySelected: onQuerySelected,
-                onQueryRemoved: onQueryRemoved,
-              ),
-            ],
-          ],
-        ),
-      ],
-    );
-  }
-}
-
-class _StationRecentSearchItem extends StatelessWidget {
-  const _StationRecentSearchItem({
-    required this.query,
-    required this.order,
-    required this.enabled,
-    required this.onQuerySelected,
-    required this.onQueryRemoved,
-  });
-
-  final String query;
-  final int order;
-  final bool enabled;
-  final ValueChanged<String> onQuerySelected;
-  final ValueChanged<String> onQueryRemoved;
-
-  @override
-  Widget build(BuildContext context) {
-    return ConstrainedBox(
-      constraints: const BoxConstraints(minHeight: 56),
-      child: Row(
-        children: [
-          Expanded(
-            child: Semantics(
-              label: '최근 검색어 $query 검색, 최근 사용 $order번째',
-              button: true,
-              enabled: enabled,
-              onTap: enabled ? () => onQuerySelected(query) : null,
-              child: ExcludeSemantics(
-                child: InkWell(
-                  key: Key('stationRecentSearchQuery-$query'),
-                  onTap: enabled ? () => onQuerySelected(query) : null,
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(
-                      vertical: EasySubwaySpacing.md,
-                    ),
-                    child: Row(
-                      children: [
-                        const Icon(
-                          Icons.history,
-                          color: EasySubwayAccessibleColors.iconMuted,
-                        ),
-                        const SizedBox(width: EasySubwaySpacing.md),
-                        Expanded(
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text(
-                                query,
-                                style: Theme.of(context).textTheme.titleMedium
-                                    ?.copyWith(
-                                      color: EasySubwayAccessibleColors.text,
-                                      fontWeight: FontWeight.w700,
-                                      height: 1.25,
-                                    ),
-                              ),
-                              Text(
-                                '최근 사용 $order번째',
-                                style: Theme.of(context).textTheme.bodySmall
-                                    ?.copyWith(
-                                      color: EasySubwayAccessibleColors.caption,
-                                      height: 1.3,
-                                    ),
-                              ),
-                            ],
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          ),
-          IconButton(
-            key: Key('stationRecentSearchRemove-$query'),
-            tooltip: '$query 최근 검색 삭제',
-            onPressed: enabled ? () => onQueryRemoved(query) : null,
-            icon: const Icon(Icons.close),
-          ),
-        ],
       ),
     );
   }


### PR DESCRIPTION
## 관련 이슈

Refs #2173

## 작업 내용

- 역 검색과 노선도 검색이 함께 사용하는 `StationRecentSearchSection`을 stations presentation 경로로 이동했습니다.
- public entry widget은 하나만 유지하고 최근 검색 행 helper는 private로 남겼습니다.
- 기존 `station_search.dart` export를 유지해 사용자 동작과 공개 import 호환성을 보존했습니다.

## 검증

- 실행한 명령과 결과:
  - `dart format --output=none --set-exit-if-changed ...` → 2 files, 0 changed
  - `flutter analyze` → No issues found
  - `flutter test test/widget_test.dart --plain-name "역 검색"` → 21 passed
  - `flutter test test/widget_test.dart --plain-name "노선도 검색"` → 1 passed
  - `flutter test` → 1,315 passed
  - `codex review --disable plugins --base origin/main` → actionable finding 0건

## 영향

- [x] 제품/운영 위험 없음 (동작·Widget·Key·Semantics를 바꾸지 않은 파일 이동)
- [x] DB migration 없음
- [x] 배포 영향 없음
- [x] route/realtime/datapack contract 영향 없음
- [x] CI workflow·계약 테스트·release gate JSON 변경 없음 (있으면 full.md로 전환)

## 체크리스트

- [x] 이 PR은 B/C등급 작업이며 full template이 필요 없다.
- [ ] CI 결과를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 폴백 리뷰를 단일 PR review로 게시했다.
