### PR TITLE
[Refactor] 역 검색 결과 presentation 분리

### DIFF
--- a/apps/mobile/lib/features/stations/presentation/station_search_body.dart
+++ b/apps/mobile/lib/features/stations/presentation/station_search_body.dart
@@ -1,0 +1,542 @@
+import 'package:flutter/material.dart';
+
+import '../../../accessible_design.dart';
+import '../../../design_tokens.dart';
+import '../application/station_search_controller.dart';
+import '../domain/station_line.dart';
+import '../domain/station_models.dart';
+import 'station_line_badges.dart';
+
+const _currentLocationDisabledMessage =
+    '휴대전화의 위치 기능을 켜 주세요. 가까운 역을 찾는 데 필요합니다.';
+const _currentLocationPermissionMessage = '현재 위치를 사용할 수 없어요.';
+const _stationSearchFailureNextAction =
+    '역명으로 검색하면 현재 위치를 쓰지 않아도 계속 이용할 수 있습니다.';
+const _stationRoleActionPadding = EdgeInsets.fromLTRB(12, 0, 12, 12);
+const _stationSearchFacilityCardRadius = BorderRadius.all(
+  Radius.circular(EasySubwayRadius.sheet),
+);
+
+class StationSearchBody extends StatelessWidget {
+  const StationSearchBody({
+    super.key,
+    required this.state,
+    required this.onResultTap,
+    required this.isOpeningLocationSettings,
+    required this.onOpenLocationSettings,
+    this.onSetOrigin,
+    this.onSetDestination,
+  });
+
+  final StationSearchState state;
+  final ValueChanged<StationSearchResult> onResultTap;
+  final bool isOpeningLocationSettings;
+  final VoidCallback onOpenLocationSettings;
+  final ValueChanged<StationSearchResult>? onSetOrigin;
+  final ValueChanged<StationSearchResult>? onSetDestination;
+
+  @override
+  Widget build(BuildContext context) {
+    return switch (state.status) {
+      StationSearchStatus.idle => const SizedBox.shrink(),
+      StationSearchStatus.loading => Semantics(
+        label: '역 검색 중',
+        liveRegion: true,
+        child: const Center(
+          child: Padding(
+            padding: EdgeInsets.symmetric(vertical: 24),
+            child: CircularProgressIndicator(),
+          ),
+        ),
+      ),
+      StationSearchStatus.empty ||
+      StationSearchStatus.failure => _StationSearchFailureMessage(
+        message: state.message,
+        isOpeningLocationSettings: isOpeningLocationSettings,
+        onOpenLocationSettings: onOpenLocationSettings,
+      ),
+      StationSearchStatus.success => Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Semantics(
+            container: true,
+            label: state.source == StationSearchResultSource.nearby
+                ? '주변 역 ${state.results.length}개'
+                : '검색 결과 ${state.results.length}개',
+            liveRegion: true,
+            child: const SizedBox(width: 1, height: 1),
+          ),
+          if (state.source == StationSearchResultSource.nearby) ...[
+            if (state.results.isEmpty)
+              _StationSearchFailureMessage(
+                message: '주변 역을 찾지 못했어요.',
+                isOpeningLocationSettings: isOpeningLocationSettings,
+                onOpenLocationSettings: onOpenLocationSettings,
+              )
+            else ...[
+              _NearbyStationOverview(
+                result: state.results.first,
+                onTap: () => onResultTap(state.results.first),
+                onSetOrigin: onSetOrigin == null
+                    ? null
+                    : () => onSetOrigin!(state.results.first),
+                onSetDestination: onSetDestination == null
+                    ? null
+                    : () => onSetDestination!(state.results.first),
+              ),
+              if (state.results.length > 1) ...[
+                const SizedBox(height: 18),
+                const _StationSearchSectionTitle(title: '다른 주변 역'),
+                const SizedBox(height: 12),
+              ],
+            ],
+          ],
+          for (final result
+              in state.source == StationSearchResultSource.nearby
+                  ? state.results.skip(1)
+                  : state.results)
+            _StationSearchResultTile(
+              result: result,
+              onTap: () => onResultTap(result),
+            ),
+        ],
+      ),
+    };
+  }
+}
+
+class _NearbyStationOverview extends StatelessWidget {
+  const _NearbyStationOverview({
+    required this.result,
+    required this.onTap,
+    this.onSetOrigin,
+    this.onSetDestination,
+  });
+
+  final StationSearchResult result;
+  final VoidCallback onTap;
+  final VoidCallback? onSetOrigin;
+  final VoidCallback? onSetDestination;
+
+  @override
+  Widget build(BuildContext context) {
+    final stationName = _stationResultDisplayName(result.nameKo);
+    return Card(
+      margin: EdgeInsets.zero,
+      color: EasySubwayAccessibleColors.surface,
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: _stationSearchFacilityCardRadius,
+        side: const BorderSide(color: EasySubwayAccessibleColors.line),
+      ),
+      child: Column(
+        children: [
+          Semantics(
+            container: true,
+            button: true,
+            label: '가장 가까운 역, ${_stationResultSemanticLabel(result)}',
+            onTap: onTap,
+            child: ExcludeSemantics(
+              child: InkWell(
+                key: const Key('nearbyStationPrimaryCard'),
+                borderRadius: _stationSearchFacilityCardRadius,
+                onTap: onTap,
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              '가장 가까운 역',
+                              style: Theme.of(context).textTheme.bodyMedium
+                                  ?.copyWith(
+                                    color: EasySubwayAccessibleColors.mutedText,
+                                    fontWeight: FontWeight.w700,
+                                    height: 1.25,
+                                  ),
+                            ),
+                            const SizedBox(height: 5),
+                            Text(
+                              stationName,
+                              style: Theme.of(context).textTheme.headlineSmall
+                                  ?.copyWith(
+                                    color: EasySubwayAccessibleColors.text,
+                                    fontWeight: FontWeight.w700,
+                                    height: 1.2,
+                                  ),
+                            ),
+                            const SizedBox(height: 6),
+                            Text(
+                              result.distanceLabel.isEmpty
+                                  ? result.lineLabel
+                                  : '${result.distanceLabel} · ${result.lineLabel}',
+                              style: Theme.of(context).textTheme.bodyLarge
+                                  ?.copyWith(
+                                    color: EasySubwayAccessibleColors.mutedText,
+                                    fontWeight: FontWeight.w700,
+                                    height: 1.3,
+                                  ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      StationLineBadges(
+                        lines: result.lines,
+                        size: 38,
+                        maxBadgeCount: 1,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+          if (onSetOrigin != null || onSetDestination != null)
+            _StationRoleActionBar(
+              stationId: result.id,
+              stationName: stationName,
+              onSetOrigin: onSetOrigin,
+              onSetDestination: onSetDestination,
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StationSearchFailureMessage extends StatelessWidget {
+  const _StationSearchFailureMessage({
+    required this.message,
+    required this.isOpeningLocationSettings,
+    required this.onOpenLocationSettings,
+  });
+
+  final String message;
+  final bool isOpeningLocationSettings;
+  final VoidCallback onOpenLocationSettings;
+
+  @override
+  Widget build(BuildContext context) {
+    final shouldShowLocationSettings =
+        message == _currentLocationDisabledMessage;
+    final shouldShowStationSearchNextAction =
+        _shouldShowStationSearchFailureNextAction(message);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _StationSearchMessage(message: message, liveRegion: true),
+        if (shouldShowStationSearchNextAction) ...[
+          const SizedBox(height: 8),
+          Semantics(
+            key: const Key('stationSearchFailureNextAction'),
+            container: true,
+            excludeSemantics: true,
+            label: '도움말, $_stationSearchFailureNextAction',
+            child: Text(
+              _stationSearchFailureNextAction,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: EasySubwayAccessibleColors.mutedText,
+                fontWeight: FontWeight.w700,
+                height: 1.35,
+              ),
+            ),
+          ),
+        ],
+        if (shouldShowLocationSettings) ...[
+          const SizedBox(height: 12),
+          OutlinedButton.icon(
+            key: const Key('stationSearchOpenLocationSettingsButton'),
+            onPressed: isOpeningLocationSettings
+                ? null
+                : onOpenLocationSettings,
+            icon: isOpeningLocationSettings
+                ? const SizedBox(
+                    width: 22,
+                    height: 22,
+                    child: CircularProgressIndicator(strokeWidth: 2.5),
+                  )
+                : const Icon(Icons.settings),
+            label: const Text('위치 설정 열기'),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+bool _shouldShowStationSearchFailureNextAction(String message) {
+  return message == _currentLocationPermissionMessage ||
+      message == _currentLocationDisabledMessage ||
+      message == '현재 위치를 확인하지 못했어요.' ||
+      message == '주변 역을 찾지 못했어요.';
+}
+
+class _StationSearchMessage extends StatelessWidget {
+  const _StationSearchMessage({required this.message, this.liveRegion = false});
+
+  final String message;
+  final bool liveRegion;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      container: true,
+      liveRegion: liveRegion,
+      child: Text(
+        message,
+        style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+          color: EasySubwayAccessibleColors.secondaryText,
+          fontWeight: FontWeight.w700,
+          height: 1.35,
+        ),
+      ),
+    );
+  }
+}
+
+class _StationSearchResultTile extends StatelessWidget {
+  const _StationSearchResultTile({required this.result, required this.onTap});
+
+  final StationSearchResult result;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final stationName = _stationResultDisplayName(result.nameKo);
+    // 역이 지나는 노선마다 한 행씩 표시한다. 각 행은 하단 구분선만 두고
+    // 좌측에 무채색 역명, 우측에 해당 노선 배지를 둔다(추가 텍스트·화살표 없음).
+    final lines = result.lines;
+    if (lines.isEmpty) {
+      return _StationSearchResultLineRow(
+        key: Key('stationSearchResult-${result.id}'),
+        stationName: stationName,
+        line: null,
+        semanticLabel: '$stationName, 선택',
+        onTap: onTap,
+      );
+    }
+    return Column(
+      children: [
+        for (var i = 0; i < lines.length; i++)
+          // 한 역이 여러 노선을 지나면 시각적으로는 노선마다 한 행씩 펼치지만,
+          // 각 행이 "역명, 노선명, 선택" 버튼 시맨틱을 노출하면 스크린리더에 같은
+          // 선택 버튼이 노선 수만큼 뜬다. 첫 행만 시맨틱 버튼으로 남기고 이후
+          // 행들은 ExcludeSemantics 로 감싸 시각 렌더만 유지한다.
+          if (i == 0)
+            _StationSearchResultLineRow(
+              // 첫 행에만 대표 키를 두어 기존 테스트가 단일 위젯을 찾도록 한다.
+              key: Key('stationSearchResult-${result.id}'),
+              stationName: stationName,
+              line: lines[i],
+              semanticLabel: '$stationName, ${lines[i].name}, 선택',
+              onTap: onTap,
+            )
+          else
+            ExcludeSemantics(
+              child: _StationSearchResultLineRow(
+                stationName: stationName,
+                line: lines[i],
+                semanticLabel: '$stationName, ${lines[i].name}, 선택',
+                onTap: onTap,
+              ),
+            ),
+      ],
+    );
+  }
+}
+
+class _StationSearchResultLineRow extends StatelessWidget {
+  const _StationSearchResultLineRow({
+    required this.stationName,
+    required this.line,
+    required this.semanticLabel,
+    required this.onTap,
+    super.key,
+  });
+
+  final String stationName;
+  final StationSearchLine? line;
+  final String semanticLabel;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final line = this.line;
+    return DecoratedBox(
+      decoration: const BoxDecoration(
+        color: Colors.white,
+        border: Border(
+          bottom: BorderSide(color: EasySubwayAccessibleColors.line),
+        ),
+      ),
+      child: MergeSemantics(
+        child: Semantics(
+          label: semanticLabel,
+          button: true,
+          onTap: onTap,
+          child: ExcludeSemantics(
+            child: InkWell(
+              onTap: onTap,
+              splashColor: Colors.transparent,
+              highlightColor: Colors.transparent,
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(minHeight: 56),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: 8,
+                  ),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      Expanded(
+                        child: Text(
+                          stationName,
+                          style: const TextStyle(
+                            color: EasySubwayAccessibleColors.text,
+                            fontSize: 17,
+                            fontWeight: FontWeight.w600,
+                            height: 1.2,
+                          ),
+                        ),
+                      ),
+                      if (line != null) ...[
+                        const SizedBox(width: 12),
+                        StationLineBadge(line: line, size: 32),
+                      ],
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _StationRoleActionBar extends StatelessWidget {
+  const _StationRoleActionBar({
+    required this.stationId,
+    required this.stationName,
+    this.onSetOrigin,
+    this.onSetDestination,
+  });
+
+  final String stationId;
+  final String stationName;
+  final VoidCallback? onSetOrigin;
+  final VoidCallback? onSetDestination;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: _stationRoleActionPadding,
+      child: Row(
+        children: [
+          Expanded(
+            child: _StationRoleButton(
+              key: Key('stationRoleOrigin-$stationId'),
+              icon: Icons.trip_origin,
+              label: '출발',
+              semanticLabel: '$stationName을 출발역으로 설정',
+              onPressed: onSetOrigin,
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: _StationRoleButton(
+              key: Key('stationRoleDestination-$stationId'),
+              icon: Icons.flag_outlined,
+              label: '도착',
+              semanticLabel: '$stationName을 도착역으로 설정',
+              onPressed: onSetDestination,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StationRoleButton extends StatelessWidget {
+  const _StationRoleButton({
+    required this.icon,
+    required this.label,
+    required this.semanticLabel,
+    required this.onPressed,
+    super.key,
+  });
+
+  final IconData icon;
+  final String label;
+  final String semanticLabel;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      button: true,
+      enabled: onPressed != null,
+      label: semanticLabel,
+      onTap: onPressed,
+      child: ExcludeSemantics(
+        child: OutlinedButton.icon(
+          onPressed: onPressed,
+          style: OutlinedButton.styleFrom(
+            minimumSize: const Size.fromHeight(EasySubwayTouchTarget.iconOnly),
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+            textStyle: const TextStyle(fontWeight: FontWeight.w700),
+          ),
+          icon: Icon(icon, size: 20),
+          label: Text(label, textAlign: TextAlign.center),
+        ),
+      ),
+    );
+  }
+}
+
+String _stationResultDisplayName(String name) {
+  final trimmedName = name.trim();
+  // 백엔드 역 이름은 접미사 없이 내려올 수 있어 검색 결과 화면에서만 보정한다.
+  if (trimmedName.endsWith('역')) {
+    return trimmedName;
+  }
+  return '$trimmedName역';
+}
+
+String _stationResultSemanticLabel(StationSearchResult result) {
+  final stationName = _stationResultDisplayName(result.nameKo);
+  final distance = result.distanceLabel;
+  if (distance.isEmpty) {
+    return '$stationName, ${result.lineLabel}, ${result.region}';
+  }
+  return '$stationName, $distance, ${result.lineLabel}, ${result.region}';
+}
+
+class _StationSearchSectionTitle extends StatelessWidget {
+  const _StationSearchSectionTitle({required this.title});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      header: true,
+      child: Text(
+        title,
+        style: Theme.of(context).textTheme.titleLarge?.copyWith(
+          color: EasySubwayAccessibleColors.text,
+          fontWeight: FontWeight.w700,
+          height: 1.25,
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -22,6 +22,7 @@ import 'features/stations/domain/station_models.dart';
 import 'features/stations/domain/station_repositories.dart';
 import 'features/stations/presentation/station_line_badges.dart';
 import 'features/stations/presentation/station_recent_search_section.dart';
+import 'features/stations/presentation/station_search_body.dart';
 import 'internal_route.dart';
 import 'mobile_error_reporter.dart';
 import 'search_field.dart';
@@ -33,16 +34,13 @@ export 'features/stations/domain/station_line.dart';
 export 'features/stations/domain/station_models.dart';
 export 'features/stations/domain/station_repositories.dart';
 export 'features/stations/presentation/station_recent_search_section.dart';
+export 'features/stations/presentation/station_search_body.dart';
 
 const _currentLocationDisabledMessage =
     '휴대전화의 위치 기능을 켜 주세요. 가까운 역을 찾는 데 필요합니다.';
-const _currentLocationPermissionMessage = '현재 위치를 사용할 수 없어요.';
-const _stationSearchFailureNextAction =
-    '역명으로 검색하면 현재 위치를 쓰지 않아도 계속 이용할 수 있습니다.';
 const _searchHistoryChangeErrorMessage = '최근 검색을 지우지 못했어요.';
 const _stationSearchPagePadding = EdgeInsets.fromLTRB(20, 20, 20, 32);
 const _stationSearchLargePagePadding = EdgeInsets.fromLTRB(24, 24, 24, 40);
-const _stationRoleActionPadding = EdgeInsets.fromLTRB(12, 0, 12, 12);
 const _stationDetailInfoCardRadius = BorderRadius.all(Radius.circular(16));
 const _stationDetailHelpCardRadius = BorderRadius.all(Radius.circular(16));
 const _stationDetailActionButtonRadius = BorderRadius.all(Radius.circular(12));
@@ -672,509 +670,6 @@ class _StationSearchAdaptiveContent extends StatelessWidget {
   }
 }
 
-class StationSearchBody extends StatelessWidget {
-  const StationSearchBody({
-    super.key,
-    required this.state,
-    required this.onResultTap,
-    required this.isOpeningLocationSettings,
-    required this.onOpenLocationSettings,
-    this.onSetOrigin,
-    this.onSetDestination,
-  });
-
-  final StationSearchState state;
-  final ValueChanged<StationSearchResult> onResultTap;
-  final bool isOpeningLocationSettings;
-  final VoidCallback onOpenLocationSettings;
-  final ValueChanged<StationSearchResult>? onSetOrigin;
-  final ValueChanged<StationSearchResult>? onSetDestination;
-
-  @override
-  Widget build(BuildContext context) {
-    return switch (state.status) {
-      StationSearchStatus.idle => const SizedBox.shrink(),
-      StationSearchStatus.loading => Semantics(
-        label: '역 검색 중',
-        liveRegion: true,
-        child: const Center(
-          child: Padding(
-            padding: EdgeInsets.symmetric(vertical: 24),
-            child: CircularProgressIndicator(),
-          ),
-        ),
-      ),
-      StationSearchStatus.empty ||
-      StationSearchStatus.failure => _StationSearchFailureMessage(
-        message: state.message,
-        isOpeningLocationSettings: isOpeningLocationSettings,
-        onOpenLocationSettings: onOpenLocationSettings,
-      ),
-      StationSearchStatus.success => Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Semantics(
-            container: true,
-            label: state.source == StationSearchResultSource.nearby
-                ? '주변 역 ${state.results.length}개'
-                : '검색 결과 ${state.results.length}개',
-            liveRegion: true,
-            child: const SizedBox(width: 1, height: 1),
-          ),
-          if (state.source == StationSearchResultSource.nearby) ...[
-            if (state.results.isEmpty)
-              _StationSearchFailureMessage(
-                message: '주변 역을 찾지 못했어요.',
-                isOpeningLocationSettings: isOpeningLocationSettings,
-                onOpenLocationSettings: onOpenLocationSettings,
-              )
-            else ...[
-              _NearbyStationOverview(
-                result: state.results.first,
-                onTap: () => onResultTap(state.results.first),
-                onSetOrigin: onSetOrigin == null
-                    ? null
-                    : () => onSetOrigin!(state.results.first),
-                onSetDestination: onSetDestination == null
-                    ? null
-                    : () => onSetDestination!(state.results.first),
-              ),
-              if (state.results.length > 1) ...[
-                const SizedBox(height: 18),
-                const _StationDetailSectionTitle(title: '다른 주변 역'),
-                const SizedBox(height: 12),
-              ],
-            ],
-          ],
-          for (final result
-              in state.source == StationSearchResultSource.nearby
-                  ? state.results.skip(1)
-                  : state.results)
-            _StationSearchResultTile(
-              result: result,
-              onTap: () => onResultTap(result),
-            ),
-        ],
-      ),
-    };
-  }
-}
-
-class _NearbyStationOverview extends StatelessWidget {
-  const _NearbyStationOverview({
-    required this.result,
-    required this.onTap,
-    this.onSetOrigin,
-    this.onSetDestination,
-  });
-
-  final StationSearchResult result;
-  final VoidCallback onTap;
-  final VoidCallback? onSetOrigin;
-  final VoidCallback? onSetDestination;
-
-  @override
-  Widget build(BuildContext context) {
-    final stationName = _stationResultDisplayName(result.nameKo);
-    return Card(
-      margin: EdgeInsets.zero,
-      color: EasySubwayAccessibleColors.surface,
-      elevation: 0,
-      shape: RoundedRectangleBorder(
-        borderRadius: _stationDetailFacilityCardRadius,
-        side: const BorderSide(color: EasySubwayAccessibleColors.line),
-      ),
-      child: Column(
-        children: [
-          Semantics(
-            container: true,
-            button: true,
-            label: '가장 가까운 역, ${_stationResultSemanticLabel(result)}',
-            onTap: onTap,
-            child: ExcludeSemantics(
-              child: InkWell(
-                key: const Key('nearbyStationPrimaryCard'),
-                borderRadius: _stationDetailFacilityCardRadius,
-                onTap: onTap,
-                child: Padding(
-                  padding: const EdgeInsets.all(16),
-                  child: Row(
-                    children: [
-                      Expanded(
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              '가장 가까운 역',
-                              style: Theme.of(context).textTheme.bodyMedium
-                                  ?.copyWith(
-                                    color: EasySubwayAccessibleColors.mutedText,
-                                    fontWeight: FontWeight.w700,
-                                    height: 1.25,
-                                  ),
-                            ),
-                            const SizedBox(height: 5),
-                            Text(
-                              stationName,
-                              style: Theme.of(context).textTheme.headlineSmall
-                                  ?.copyWith(
-                                    color: EasySubwayAccessibleColors.text,
-                                    fontWeight: FontWeight.w700,
-                                    height: 1.2,
-                                  ),
-                            ),
-                            const SizedBox(height: 6),
-                            Text(
-                              result.distanceLabel.isEmpty
-                                  ? result.lineLabel
-                                  : '${result.distanceLabel} · ${result.lineLabel}',
-                              style: Theme.of(context).textTheme.bodyLarge
-                                  ?.copyWith(
-                                    color: EasySubwayAccessibleColors.mutedText,
-                                    fontWeight: FontWeight.w700,
-                                    height: 1.3,
-                                  ),
-                            ),
-                          ],
-                        ),
-                      ),
-                      const SizedBox(width: 12),
-                      StationLineBadges(
-                        lines: result.lines,
-                        size: 38,
-                        maxBadgeCount: 1,
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-            ),
-          ),
-          if (onSetOrigin != null || onSetDestination != null)
-            _StationRoleActionBar(
-              stationId: result.id,
-              stationName: stationName,
-              onSetOrigin: onSetOrigin,
-              onSetDestination: onSetDestination,
-            ),
-        ],
-      ),
-    );
-  }
-}
-
-class _StationSearchFailureMessage extends StatelessWidget {
-  const _StationSearchFailureMessage({
-    required this.message,
-    required this.isOpeningLocationSettings,
-    required this.onOpenLocationSettings,
-  });
-
-  final String message;
-  final bool isOpeningLocationSettings;
-  final VoidCallback onOpenLocationSettings;
-
-  @override
-  Widget build(BuildContext context) {
-    final shouldShowLocationSettings =
-        message == _currentLocationDisabledMessage;
-    final shouldShowStationSearchNextAction =
-        _shouldShowStationSearchFailureNextAction(message);
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        _StationSearchMessage(message: message, liveRegion: true),
-        if (shouldShowStationSearchNextAction) ...[
-          const SizedBox(height: 8),
-          Semantics(
-            key: const Key('stationSearchFailureNextAction'),
-            container: true,
-            excludeSemantics: true,
-            label: '도움말, $_stationSearchFailureNextAction',
-            child: Text(
-              _stationSearchFailureNextAction,
-              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                color: EasySubwayAccessibleColors.mutedText,
-                fontWeight: FontWeight.w700,
-                height: 1.35,
-              ),
-            ),
-          ),
-        ],
-        if (shouldShowLocationSettings) ...[
-          const SizedBox(height: 12),
-          OutlinedButton.icon(
-            key: const Key('stationSearchOpenLocationSettingsButton'),
-            onPressed: isOpeningLocationSettings
-                ? null
-                : onOpenLocationSettings,
-            icon: isOpeningLocationSettings
-                ? const SizedBox(
-                    width: 22,
-                    height: 22,
-                    child: CircularProgressIndicator(strokeWidth: 2.5),
-                  )
-                : const Icon(Icons.settings),
-            label: const Text('위치 설정 열기'),
-          ),
-        ],
-      ],
-    );
-  }
-}
-
-bool _shouldShowStationSearchFailureNextAction(String message) {
-  return message == _currentLocationPermissionMessage ||
-      message == _currentLocationDisabledMessage ||
-      message == '현재 위치를 확인하지 못했어요.' ||
-      message == '주변 역을 찾지 못했어요.';
-}
-
-class _StationSearchMessage extends StatelessWidget {
-  const _StationSearchMessage({required this.message, this.liveRegion = false});
-
-  final String message;
-  final bool liveRegion;
-
-  @override
-  Widget build(BuildContext context) {
-    return Semantics(
-      container: true,
-      liveRegion: liveRegion,
-      child: Text(
-        message,
-        style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-          color: EasySubwayAccessibleColors.secondaryText,
-          fontWeight: FontWeight.w700,
-          height: 1.35,
-        ),
-      ),
-    );
-  }
-}
-
-class _StationSearchResultTile extends StatelessWidget {
-  const _StationSearchResultTile({required this.result, required this.onTap});
-
-  final StationSearchResult result;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final stationName = _stationResultDisplayName(result.nameKo);
-    // 역이 지나는 노선마다 한 행씩 표시한다. 각 행은 하단 구분선만 두고
-    // 좌측에 무채색 역명, 우측에 해당 노선 배지를 둔다(추가 텍스트·화살표 없음).
-    final lines = result.lines;
-    if (lines.isEmpty) {
-      return _StationSearchResultLineRow(
-        key: Key('stationSearchResult-${result.id}'),
-        stationName: stationName,
-        line: null,
-        semanticLabel: '$stationName, 선택',
-        onTap: onTap,
-      );
-    }
-    return Column(
-      children: [
-        for (var i = 0; i < lines.length; i++)
-          // 한 역이 여러 노선을 지나면 시각적으로는 노선마다 한 행씩 펼치지만,
-          // 각 행이 "역명, 노선명, 선택" 버튼 시맨틱을 노출하면 스크린리더에 같은
-          // 선택 버튼이 노선 수만큼 뜬다. 첫 행만 시맨틱 버튼으로 남기고 이후
-          // 행들은 ExcludeSemantics 로 감싸 시각 렌더만 유지한다.
-          if (i == 0)
-            _StationSearchResultLineRow(
-              // 첫 행에만 대표 키를 두어 기존 테스트가 단일 위젯을 찾도록 한다.
-              key: Key('stationSearchResult-${result.id}'),
-              stationName: stationName,
-              line: lines[i],
-              semanticLabel: '$stationName, ${lines[i].name}, 선택',
-              onTap: onTap,
-            )
-          else
-            ExcludeSemantics(
-              child: _StationSearchResultLineRow(
-                stationName: stationName,
-                line: lines[i],
-                semanticLabel: '$stationName, ${lines[i].name}, 선택',
-                onTap: onTap,
-              ),
-            ),
-      ],
-    );
-  }
-}
-
-class _StationSearchResultLineRow extends StatelessWidget {
-  const _StationSearchResultLineRow({
-    required this.stationName,
-    required this.line,
-    required this.semanticLabel,
-    required this.onTap,
-    super.key,
-  });
-
-  final String stationName;
-  final StationSearchLine? line;
-  final String semanticLabel;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final line = this.line;
-    return DecoratedBox(
-      decoration: const BoxDecoration(
-        color: Colors.white,
-        border: Border(
-          bottom: BorderSide(color: EasySubwayAccessibleColors.line),
-        ),
-      ),
-      child: MergeSemantics(
-        child: Semantics(
-          label: semanticLabel,
-          button: true,
-          onTap: onTap,
-          child: ExcludeSemantics(
-            child: InkWell(
-              onTap: onTap,
-              splashColor: Colors.transparent,
-              highlightColor: Colors.transparent,
-              child: ConstrainedBox(
-                constraints: const BoxConstraints(minHeight: 56),
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 16,
-                    vertical: 8,
-                  ),
-                  child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    children: [
-                      Expanded(
-                        child: Text(
-                          stationName,
-                          style: const TextStyle(
-                            color: EasySubwayAccessibleColors.text,
-                            fontSize: 17,
-                            fontWeight: FontWeight.w600,
-                            height: 1.2,
-                          ),
-                        ),
-                      ),
-                      if (line != null) ...[
-                        const SizedBox(width: 12),
-                        StationLineBadge(line: line, size: 32),
-                      ],
-                    ],
-                  ),
-                ),
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _StationRoleActionBar extends StatelessWidget {
-  const _StationRoleActionBar({
-    required this.stationId,
-    required this.stationName,
-    this.onSetOrigin,
-    this.onSetDestination,
-  });
-
-  final String stationId;
-  final String stationName;
-  final VoidCallback? onSetOrigin;
-  final VoidCallback? onSetDestination;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: _stationRoleActionPadding,
-      child: Row(
-        children: [
-          Expanded(
-            child: _StationRoleButton(
-              key: Key('stationRoleOrigin-$stationId'),
-              icon: Icons.trip_origin,
-              label: '출발',
-              semanticLabel: '$stationName을 출발역으로 설정',
-              onPressed: onSetOrigin,
-            ),
-          ),
-          const SizedBox(width: 8),
-          Expanded(
-            child: _StationRoleButton(
-              key: Key('stationRoleDestination-$stationId'),
-              icon: Icons.flag_outlined,
-              label: '도착',
-              semanticLabel: '$stationName을 도착역으로 설정',
-              onPressed: onSetDestination,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _StationRoleButton extends StatelessWidget {
-  const _StationRoleButton({
-    required this.icon,
-    required this.label,
-    required this.semanticLabel,
-    required this.onPressed,
-    super.key,
-  });
-
-  final IconData icon;
-  final String label;
-  final String semanticLabel;
-  final VoidCallback? onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    return Semantics(
-      button: true,
-      enabled: onPressed != null,
-      label: semanticLabel,
-      onTap: onPressed,
-      child: ExcludeSemantics(
-        child: OutlinedButton.icon(
-          onPressed: onPressed,
-          style: OutlinedButton.styleFrom(
-            minimumSize: const Size.fromHeight(EasySubwayTouchTarget.iconOnly),
-            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
-            textStyle: const TextStyle(fontWeight: FontWeight.w700),
-          ),
-          icon: Icon(icon, size: 20),
-          label: Text(label, textAlign: TextAlign.center),
-        ),
-      ),
-    );
-  }
-}
-
-String _stationResultDisplayName(String name) {
-  final trimmedName = name.trim();
-  // 백엔드 역 이름은 접미사 없이 내려올 수 있어 검색 결과 화면에서만 보정한다.
-  if (trimmedName.endsWith('역')) {
-    return trimmedName;
-  }
-  return '$trimmedName역';
-}
-
-String _stationResultSemanticLabel(StationSearchResult result) {
-  final stationName = _stationResultDisplayName(result.nameKo);
-  final distance = result.distanceLabel;
-  if (distance.isEmpty) {
-    return '$stationName, ${result.lineLabel}, ${result.region}';
-  }
-  return '$stationName, $distance, ${result.lineLabel}, ${result.region}';
-}
-
 class StationDetailScreen extends StatefulWidget {
   const StationDetailScreen({
     required this.repository,
@@ -1573,7 +1068,7 @@ class _StationDetailBody extends StatelessWidget {
       ),
       StationDetailStatus.failure => Padding(
         padding: const EdgeInsets.all(20),
-        child: _StationSearchMessage(message: state.message, liveRegion: true),
+        child: _StationDetailMessage(message: state.message, liveRegion: true),
       ),
       StationDetailStatus.success => _StationDetailContent(
         detail: state.detail!,
@@ -1596,6 +1091,29 @@ class _StationDetailBody extends StatelessWidget {
         timetableRepository: timetableRepository,
       ),
     };
+  }
+}
+
+class _StationDetailMessage extends StatelessWidget {
+  const _StationDetailMessage({required this.message, this.liveRegion = false});
+
+  final String message;
+  final bool liveRegion;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      container: true,
+      liveRegion: liveRegion,
+      child: Text(
+        message,
+        style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+          color: EasySubwayAccessibleColors.secondaryText,
+          fontWeight: FontWeight.w700,
+          height: 1.35,
+        ),
+      ),
+    );
   }
 }
 

--- a/apps/mobile/test/design_guard_test.dart
+++ b/apps/mobile/test/design_guard_test.dart
@@ -333,8 +333,10 @@ void main() {
     // 상한은 내리기만 한다.
     final actual = countPerFile(RegExp(r'\bCard\('));
     expectRatchet(actual, {
-      // 의도 잔존: 역 상세/검색 결과 카드 6곳 — 무박스(행+구분선) 전환 진행 중
-      'lib/station_search.dart': 6,
+      // 의도 잔존: 역 상세 카드 5곳 — 무박스(행+구분선) 전환 진행 중
+      'lib/station_search.dart': 5,
+      // 동일 총량 중 주변 역 검색 카드 1곳은 canonical presentation 경로로 이동했다.
+      'lib/features/stations/presentation/station_search_body.dart': 1,
       // 의도 잔존: AppCard 공용 래퍼·정보 카드 2곳 — 무박스 전환 대상
       'lib/app/app_components.dart': 2,
     }, rule: '블록(박스) Card');

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -2391,9 +2391,11 @@ test("모바일 홈 shell과 주요 상태 UI 회귀 테스트는 유지된다",
 });
 
 test("모바일 역 검색 결과 시스템 글자 크기 문구 회귀 테스트는 유지된다", () => {
-  const stationSearch = read("apps/mobile/lib/station_search.dart");
+  const stationSearchBody = read(
+    "apps/mobile/lib/features/stations/presentation/station_search_body.dart",
+  );
   const widgetTest = read("apps/mobile/test/widget_test.dart");
-  const resultTileMatch = stationSearch.match(
+  const resultTileMatch = stationSearchBody.match(
     /class _StationSearchResultTile[\s\S]*?class _StationRoleActionBar/,
   );
   const largeTextTestMatch = widgetTest.match(
@@ -13361,6 +13363,9 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   const onboardingTest = read("apps/mobile/test/onboarding_test.dart");
   const routeSearch = read("apps/mobile/lib/route_search.dart");
   const stationSearch = read("apps/mobile/lib/station_search.dart");
+  const stationSearchBody = read(
+    "apps/mobile/lib/features/stations/presentation/station_search_body.dart",
+  );
   const stationModels = read(
     "apps/mobile/lib/features/stations/domain/station_models.dart",
   );
@@ -13449,8 +13454,8 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(onboardingAppFlowTest, /첫 실행 앱은 알림 권한 제공자가 직접 주입되면 온보딩 알림 권한을 요청한다/);
   assert.match(onboardingAppFlowTest, /앱은 저장된 온보딩 설정으로 홈을 바로 보여준다/);
   assert.match(onboardingAppFlowTest, /앱은 온보딩 저장소를 읽지 못하면 다시 설정을 고르게 한다/);
-  assert.match(stationSearch, /stationSearchFailureNextAction/);
-  assert.match(stationSearch, /역명으로 검색하면 현재 위치를 쓰지 않아도 계속 이용할 수 있습니다\./);
+  assert.match(stationSearchBody, /stationSearchFailureNextAction/);
+  assert.match(stationSearchBody, /역명으로 검색하면 현재 위치를 쓰지 않아도 계속 이용할 수 있습니다\./);
   assert.match(widgetTest, /역명으로 검색하면 현재 위치를 쓰지 않아도 계속 이용할 수 있습니다\./);
   assert.match(appRoot, /initialMobilityType: onboardingResult\?\.mobilityType/);
   assert.match(homeScreen, /initialMobilityType: initialMobilityType/);


### PR DESCRIPTION
## 관련 이슈

Refs #2173

## 작업 배경

- 검색 결과·주변 역·오류 안내가 root station 파일에 남아 presentation 책임을 찾기 어려웠습니다.
- 기존 저장소 계약도 해당 선언의 root 소유권을 직접 읽고 있어 canonical 경로와 함께 갱신해야 했습니다.

## 작업 내용

- `StationSearchBody`와 search 전용 private helper를 stations presentation 경로로 이동했습니다.
- detail 전용 제목·메시지 helper와의 결합을 끊되 동일 Widget 구조를 유지했습니다.
- 16px 카드 radius는 동일 값의 `EasySubwayRadius.sheet` 토큰을 사용했습니다.
- design guard의 Card 총량 상한은 6건 그대로 두고 root 5건·canonical 파일 1건으로 경로만 재배분했습니다.
- repository contract가 결과 tile과 실패 안내를 새 canonical 파일에서 검증하도록 소유 경로만 갱신했습니다.

## 검증

- 실행한 명령과 결과:
  - `dart format ...` → 0 changed
  - `flutter analyze` → No issues found
  - `flutter test test/design_guard_test.dart` → 12 passed
  - `flutter test` → 1,315 passed
  - `node --test tools/ci/repository-contract.test.mjs` → 207 passed
  - `codex review --disable plugins --base origin/main` → actionable finding 0건

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 검색·주변 역 UI | Flutter 공통 | 기존 Widget/문구/Key/Semantics 동일성과 전체 테스트 | 로컬 1,315 tests | 통과 |
| 디자인 guard | Flutter 공통 | Card 총량과 radius 규칙 검사 | 12 tests | 통과 |
| canonical 계약 | 저장소 공통 | 새 소유 파일에서 기존 assertion 실행 | 207 tests | 통과 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 기존 결과 본문과 새 canonical 파일의 Widget 구조 동일성, design guard 총량 불변, repository contract의 읽기 경로 변경입니다.

## 리스크

- 사용자 동작은 바꾸지 않았습니다. import 누락·UI 회귀·계약 경로 누락은 analyzer, 전체 Flutter 테스트와 repository contract로 검증합니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)
