### PR TITLE
[Fix] #2056 production RC Node 24 런타임·Phase A 증거 무효화

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -293,6 +293,11 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Android Production RC Artifact / Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24"
+
       - name: Android Production RC Artifact / Set up Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
         with:
@@ -659,6 +664,11 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
+
+      - name: RC Evidence Manifest / Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24"
 
       - name: RC Evidence Manifest / Download Android artifact
         if: ${{ needs.android-release.result == 'success' }}

--- a/apps/mobile/release/post-launch-operations-review-gate.json
+++ b/apps/mobile/release/post-launch-operations-review-gate.json
@@ -94,7 +94,7 @@
           "files": [
             {"path": "apps/mobile/release/signed-release-artifact-gate.json", "sha256": "42c9f83dca5a1c2c24d921cf6ab748c9be5a901dd1b62212a81055098349fc67"},
             {"path": "apps/mobile/pubspec.yaml", "sha256": "8b831a4108c1c77f718a4b729e7d24f36dc024b83845a4ecfa7d2b99e5ad1971"},
-            {"path": ".github/workflows/release-artifacts.yml", "sha256": "22782918f07180dea67ee545de455018febe70bb9a21186a07649260f5bed30a"},
+            {"path": ".github/workflows/release-artifacts.yml", "sha256": "958d3df941225ce02ad7c0fec5ad7e468bc5dbbfde016afb7c5be2affdb32d23"},
             {"path": ".github/workflows/datapack-release.yml", "sha256": "1c449f274f0486c7de8dbecf771cc6813045309277a7a8123b56bee7c1567008"},
             {"path": "backend/build.gradle", "sha256": "00106be89d1834db166c0c4cfba04674e2a456e7e57648595b74feb933c31273"},
             {"path": "backend/Dockerfile", "sha256": "7d9608f490113e655aeaf9544f061896d20f391d5c309b50a42f6303e5eb676b"},

--- a/apps/mobile/release/post-launch-operations-review-gate.json
+++ b/apps/mobile/release/post-launch-operations-review-gate.json
@@ -10,7 +10,7 @@
   "supportIncidentResponseGate": "apps/mobile/release/support-incident-response-gate.json",
   "evidenceRoot": ".codex/evidence/release/post-launch-operations-review/<rc-or-run>/",
   "preLaunchReadiness": {
-    "status": "PASS",
+    "status": "BLOCKED_EXTERNAL",
     "evidenceDateKst": "2026-07-15",
     "requiredEvidence": [
       "signal-owner-threshold-first-response",
@@ -143,8 +143,8 @@
       },
       {
         "id": "fixed-release-versioncode-build-submit-procedure",
-        "status": "PASS",
-        "evidence": ".codex/evidence/release/post-launch-operations-review/issue-1019-phase-a-20260715/fixed-release-rehearsal-summary.json"
+        "status": "BLOCKED_EXTERNAL",
+        "evidence": "Node 24 runtime 변경 후 fixed-release rehearsal 재실행 필요"
       },
       {
         "id": "post-launch-window-owner-time-checklist-record-location-reservation",
@@ -193,6 +193,7 @@
       "summaryKo": "QA 수동 메일 테스트로 support/security/privacy 주소 routing을 정상 확인했다."
     },
     "remainingExternalBlockers": [
+      "fixed-release-rehearsal-after-node24-runtime-change",
       "play-review-status-summary",
       "crash-anr-vitals-summary",
       "support-ticket-summary-after-public-release",

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -3979,6 +3979,14 @@ test("모바일 signed release artifact gate와 광고 counter는 CI 산출물�
   assert.match(workflow, /android-production-rc/);
   assert.match(workflow, /android-production-rc-release:/);
   assert.match(workflow, /name: Android Production RC Artifact/);
+  const productionRcJob = workflow.slice(
+    workflow.indexOf("  android-production-rc-release:"),
+    workflow.indexOf("  play-internal-upload:"),
+  );
+  assert.match(
+    productionRcJob,
+    /Android Production RC Artifact \/ Set up Node[\s\S]*actions\/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e[\s\S]*node-version: "24"/,
+  );
   assert.match(workflow, /if: \$\{\{ github\.event_name == 'workflow_dispatch' && github\.ref == 'refs\/heads\/main' && inputs\.android_rc_signing_mode == 'production-upload-key' \}\}/);
   assert.match(workflow, /environment:\s*\n\s*name: android-production-rc/);
   assert.match(workflow, /EASYSUBWAY_ANDROID_UPLOAD_KEYSTORE_BASE64: \$\{\{ secrets\.EASYSUBWAY_ANDROID_UPLOAD_KEYSTORE_BASE64 \}\}/);
@@ -4034,6 +4042,14 @@ test("모바일 signed release artifact gate와 광고 counter는 CI 산출물�
   assert.match(workflow, /cp release\/rc-evidence-manifest-contract\.json release-artifacts\/android\/rc-evidence-manifest-contract\.json/);
   assert.match(workflow, /rc-evidence-manifest:/);
   assert.match(workflow, /name: RC Evidence Manifest/);
+  const rcEvidenceManifestJob = workflow.slice(
+    workflow.indexOf("  rc-evidence-manifest:"),
+    workflow.indexOf("  notify-slack-release-result:"),
+  );
+  assert.match(
+    rcEvidenceManifestJob,
+    /RC Evidence Manifest \/ Set up Node[\s\S]*actions\/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e[\s\S]*node-version: "24"/,
+  );
   assert.match(workflow, /uses: actions\/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093/);
   assert.match(workflow, /name: easysubway-android-release-\$\{\{ github\.sha \}\}/);
   assert.match(workflow, /name: easysubway-android-production-rc-\$\{\{ github\.sha \}\}/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -3061,7 +3061,7 @@ test("모바일 signed release artifact gate와 광고 counter는 CI 산출물�
   assert.equal(postLaunchOperationsReviewGate.releaseGate, "post-launch-operations-review");
   assert.equal(postLaunchOperationsReviewGate.issue, 1019);
   assert.equal(postLaunchOperationsReviewGate.status, "IN_PROGRESS");
-  assert.equal(postLaunchOperationsReviewGate.preLaunchReadiness.status, "PASS");
+  assert.equal(postLaunchOperationsReviewGate.preLaunchReadiness.status, "BLOCKED_EXTERNAL");
   const phaseAReleaseVersion = read("apps/mobile/pubspec.yaml").match(/^version:\s*([^+\s]+)\+([0-9]+)\s*$/m);
   assert.ok(phaseAReleaseVersion, "mobile pubspec must contain versionName+versionCode");
   assert.equal(
@@ -3220,6 +3220,7 @@ test("모바일 signed release artifact gate와 광고 counter는 CI 산출물�
     "privacy@aquilaxk.site",
   ]);
   assert.deepEqual(postLaunchOperationsReviewGate.latestQaEvidenceSummary.remainingExternalBlockers, [
+    "fixed-release-rehearsal-after-node24-runtime-change",
     "play-review-status-summary",
     "crash-anr-vitals-summary",
     "support-ticket-summary-after-public-release",
@@ -3229,7 +3230,15 @@ test("모바일 signed release artifact gate와 광고 counter는 CI 산출물�
     postLaunchOperationsReviewGate.preLaunchReadiness.evidenceSummary.map((item) => item.id),
     postLaunchOperationsReviewGate.preLaunchReadiness.requiredEvidence,
   );
-  assert.ok(postLaunchOperationsReviewGate.preLaunchReadiness.evidenceSummary.every((item) => item.status === "PASS"));
+  const fixedReleaseEvidence = postLaunchOperationsReviewGate.preLaunchReadiness.evidenceSummary.find(
+    (item) => item.id === "fixed-release-versioncode-build-submit-procedure",
+  );
+  assert.equal(fixedReleaseEvidence.status, "BLOCKED_EXTERNAL");
+  assert.ok(
+    postLaunchOperationsReviewGate.preLaunchReadiness.evidenceSummary
+      .filter((item) => item.id !== fixedReleaseEvidence.id)
+      .every((item) => item.status === "PASS"),
+  );
   assert.deepEqual(
     postLaunchOperationsReviewGate.reviewWindows.map((window) => window.id),
     ["first_2h", "first_24h", "day_7", "day_30"],

--- a/tools/ops/generate-operations-phase-a-summary.test.mjs
+++ b/tools/ops/generate-operations-phase-a-summary.test.mjs
@@ -40,8 +40,31 @@ async function paths() {
   };
 }
 
+function markFixedReleaseRevalidated(gate) {
+  gate.preLaunchReadiness.status = "PASS";
+  gate.preLaunchReadiness.evidenceSummary.find(
+    (item) => item.id === "fixed-release-versioncode-build-submit-procedure",
+  ).status = "PASS";
+  gate.latestQaEvidenceSummary.remainingExternalBlockers =
+    gate.latestQaEvidenceSummary.remainingExternalBlockers.filter(
+      (item) => item !== "fixed-release-rehearsal-after-node24-runtime-change",
+    );
+  return gate;
+}
+
 async function generate(output, extraArgs = []) {
   const timeArgs = extraArgs.includes("--now") ? [] : ["--now", validPhaseANow];
+  const gateArgs = extraArgs.includes("--post-launch-gate") ? [] : [
+    "--post-launch-gate",
+    path.join(output.dir, "revalidated-post-launch-gate.json"),
+  ];
+  if (gateArgs.length > 0) {
+    const gate = markFixedReleaseRevalidated(JSON.parse(await readFile(
+      path.join(root, "apps/mobile/release/post-launch-operations-review-gate.json"),
+      "utf8",
+    )));
+    await writeFile(gateArgs[1], `${JSON.stringify(gate, null, 2)}\n`);
+  }
   await execFileAsync(process.execPath, [
     "tools/ops/generate-operations-phase-a-summary.mjs",
     "--rc-manifest",
@@ -50,10 +73,31 @@ async function generate(output, extraArgs = []) {
     output.summary,
     "--status-output",
     output.status,
+    ...gateArgs,
     ...timeArgs,
     ...extraArgs,
   ], { cwd: root });
 }
+
+test("canonical Phase A gate blocks until the Node 24 fixed-release rehearsal is refreshed", async () => {
+  const output = await paths();
+  await writeFile(output.manifest, `${JSON.stringify(rcManifest(), null, 2)}\n`);
+
+  await execFileAsync(process.execPath, [
+    "tools/ops/generate-operations-phase-a-summary.mjs",
+    "--rc-manifest",
+    output.manifest,
+    "--summary",
+    output.summary,
+    "--status-output",
+    output.status,
+    "--now",
+    validPhaseANow,
+  ], { cwd: root });
+
+  assert.equal((await readFile(output.status, "utf8")).trim(), "BLOCKED_EXTERNAL");
+  await assert.rejects(readFile(output.summary, "utf8"), /ENOENT/);
+});
 
 test("Phase A summary generator binds a complete RC and validator accepts it", async () => {
   const output = await paths();
@@ -73,6 +117,8 @@ test("Phase A summary generator binds a complete RC and validator accepts it", a
     "tools/ops/validate-operations-release-summary.mjs",
     "--summary",
     output.summary,
+    "--post-launch-gate",
+    path.join(output.dir, "revalidated-post-launch-gate.json"),
     "--rc-manifest",
     output.manifest,
     "--now",
@@ -130,6 +176,7 @@ for (const [field, value] of [
       path.join(root, "apps/mobile/release/post-launch-operations-review-gate.json"),
       "utf8",
     ));
+    markFixedReleaseRevalidated(gate);
     gate.preLaunchReadiness.finalRcBinding.validatedArtifactIdentity = rcManifest().rcIdentity;
     const gatePath = path.join(output.dir, "post-launch-operations-review-gate.json");
     await writeFile(output.manifest, `${JSON.stringify(rcManifest({ [field]: value }), null, 2)}\n`);
@@ -210,6 +257,7 @@ for (const [label, receivedAt] of [
 test("Phase A summary generator requires a PASS summary for every required evidence ID", async () => {
   const output = await paths();
   const gate = JSON.parse(await readFile(path.join(root, "apps/mobile/release/post-launch-operations-review-gate.json"), "utf8"));
+  markFixedReleaseRevalidated(gate);
   gate.preLaunchReadiness.requiredEvidence.push("new-unproven-required-evidence");
   const gatePath = path.join(output.dir, "post-launch-operations-review-gate.json");
   await writeFile(output.manifest, `${JSON.stringify(rcManifest(), null, 2)}\n`);
@@ -260,6 +308,7 @@ test("Phase A summary generator removes a stale PASS summary when a later run is
 test("Phase A summary generator fails closed when a refresh-bound surface changes", async () => {
   const output = await paths();
   const gate = JSON.parse(await readFile(path.join(root, "apps/mobile/release/post-launch-operations-review-gate.json"), "utf8"));
+  markFixedReleaseRevalidated(gate);
   gate.preLaunchReadiness.finalRcBinding.refreshBindings[0].files[0].sha256 = "0".repeat(64);
   const gatePath = path.join(output.dir, "post-launch-operations-review-gate.json");
   await writeFile(output.manifest, `${JSON.stringify(rcManifest(), null, 2)}\n`);

--- a/tools/ops/validate-operations-release-summary.test.mjs
+++ b/tools/ops/validate-operations-release-summary.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
 import { mkdir, rm, writeFile } from "node:fs/promises";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -10,6 +10,7 @@ import test from "node:test";
 const rawExecFileAsync = promisify(execFile);
 const root = path.resolve(import.meta.dirname, "../..");
 const validatorPath = "tools/ops/validate-operations-release-summary.mjs";
+let validatorPostLaunchGatePath;
 
 function execFileAsync(file, args, options) {
   const resolvedArgs = [...args];
@@ -25,6 +26,9 @@ function execFileAsync(file, args, options) {
       );
     }
   }
+  if (args[0] === validatorPath && !resolvedArgs.includes("--post-launch-gate")) {
+    resolvedArgs.push("--post-launch-gate", validatorPostLaunchGatePath);
+  }
   return rawExecFileAsync(file, resolvedArgs, options);
 }
 const observabilityGate = JSON.parse(
@@ -33,6 +37,20 @@ const observabilityGate = JSON.parse(
 const postLaunchGate = JSON.parse(
   readFileSync(path.join(root, "apps/mobile/release/post-launch-operations-review-gate.json"), "utf8"),
 );
+// Validator unit cases exercise a hypothetical gate after the required fixed-release rehearsal.
+postLaunchGate.preLaunchReadiness.status = "PASS";
+postLaunchGate.preLaunchReadiness.evidenceSummary.find(
+  (item) => item.id === "fixed-release-versioncode-build-submit-procedure",
+).status = "PASS";
+postLaunchGate.latestQaEvidenceSummary.remainingExternalBlockers =
+  postLaunchGate.latestQaEvidenceSummary.remainingExternalBlockers.filter(
+    (item) => item !== "fixed-release-rehearsal-after-node24-runtime-change",
+  );
+validatorPostLaunchGatePath = path.join(
+  mkdtempSync(path.join(tmpdir(), "operations-validator-gate-")),
+  "post-launch-operations-review-gate.json",
+);
+writeFileSync(validatorPostLaunchGatePath, `${JSON.stringify(postLaunchGate, null, 2)}\n`);
 const supportGate = JSON.parse(
   readFileSync(path.join(root, "apps/mobile/release/support-incident-response-gate.json"), "utf8"),
 );


### PR DESCRIPTION
## 관련 이슈

Refs #2056

## 작업 배경

- 기존 #2212의 producer core는 먼저 병합된 #2194가 최신 요구사항에 맞춰 완결했으므로 중복 구현을 제거했습니다.
- #2194 병합본을 재검증한 결과, production RC와 RC evidence job이 `node:sqlite` 기반 도구를 실행하면서 Node 버전을 고정하지 않아 runner 기본 런타임에 따라 실패할 수 있었습니다.
- 독립 리뷰에서 workflow checksum만 갱신하면 2026-07-15 fixed-release rehearsal이 새 절차에도 유효한 것처럼 재승인되는 문제를 확인했습니다.

## 작업 내용

- Android production RC job이 첫 Node 명령 전에 Node 24를 설정합니다.
- RC evidence manifest job도 첫 Node 명령 전에 Node 24를 설정합니다.
- 두 job 범위 안의 Node 24 설정을 repository contract로 고정했습니다.
- workflow 변경에 맞춰 Phase A fixed-release-procedure refresh binding hash를 갱신하되, 새 rehearsal 전에는 canonical Phase A와 해당 evidence를 `BLOCKED_EXTERNAL`로 유지합니다.
- 테스트용 PASS fixture는 재검증 상태를 명시적으로 구성하고, 실제 canonical gate가 summary 생성을 차단하는 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/repository-contract.test.mjs` — 212/212 PASS
  - `node --test tools/ci/datapack-release-workflow.test.mjs tools/release/select-rc-datapack-artifact.test.mjs` — 28/28 PASS
  - `node --test tools/ops/generate-operations-phase-a-summary.test.mjs tools/ops/validate-operations-release-summary.test.mjs` — 66/66 PASS
  - `node tools/ci/check-contracts.mjs` — PASS
  - `git diff --check origin/main...HEAD` — PASS
  - `codex review --disable plugins --base origin/main` — finding 0건
  - `node /Users/aquila/.agents/skills/easysubway-review/scripts/validate-review-format.mjs` — PASS

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| production RC Node runtime | GitHub Actions | job 범위 contract와 전체 repository contract | `tools/ci/repository-contract.test.mjs` 212/212 | PASS |
| datapack RC 선택·workflow | Node.js | datapack workflow/selector 회귀 테스트 | 28/28 | PASS |
| Phase A evidence freshness | Node.js | canonical fail-closed·summary generator/validator 회귀 테스트 | 66/66 | PASS |
| release contract 정합성 | Node.js | contract gate 실행 | `node tools/ci/check-contracts.mjs` | PASS |
| UI·접근성·수동 QA | 해당 없음 | 사용자 UI 변경 없음 | workflow/contract 전용 변경 | 불필요 |
| 배포 확인 | 해당 없음 | production 배포는 사용자 요청에 따라 범위 밖 | 코드·CI merge gate만 수행 | 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- production RC와 RC evidence job 안에서 `actions/setup-node`가 첫 Node 실행보다 앞서는지 확인해 주세요.
- pinned action SHA와 `node-version: "24"`가 다른 release job 계약과 같은지 확인해 주세요.
- Phase A refresh binding hash가 변경된 workflow bytes와 일치하면서, 새 fixed-release rehearsal 전에는 canonical gate가 `BLOCKED_EXTERNAL`인지 확인해 주세요.

## 리스크

- release workflow 실행 시간이 Node setup만큼 소폭 늘어납니다.
- Node 24 기준 fixed-release rehearsal을 새로 수행하기 전까지 Phase A summary 생성은 의도적으로 차단됩니다.
- 앱·backend·DB 동작은 변경하지 않습니다.
- #2056은 갱신된 Active DoD와 실제 fragment evidence가 남아 있어 이 PR merge만으로 닫지 않습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다. (head `c7eae0c6`, CI run `29517813738` 성공)
- [x] CodeRabbit·Codex 리뷰를 확인했다. (actionable finding 2건 수정·thread resolved)
- [x] GitHub PR Review 객체가 있는지 확인했다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (production 배포는 요청 범위 밖)
