### PR TITLE
[Refactor] 역 시설 상세 presentation 분리

### DIFF
--- a/apps/mobile/lib/features/stations/presentation/station_facility_detail_screen.dart
+++ b/apps/mobile/lib/features/stations/presentation/station_facility_detail_screen.dart
@@ -1,0 +1,301 @@
+import 'package:flutter/material.dart';
+
+import '../../../accessible_design.dart';
+import '../../../design_tokens.dart';
+import '../../../facility_status.dart';
+import '../application/station_detail_controller.dart';
+import '../domain/station_models.dart';
+import 'station_info_basis_disclosure.dart';
+
+const _stationFacilityDetailPagePadding = EdgeInsets.fromLTRB(20, 20, 20, 32);
+const _stationFacilityDetailCardRadius = BorderRadius.all(
+  Radius.circular(EasySubwayRadius.sheet),
+);
+
+class FacilityDetailScreen extends StatelessWidget {
+  const FacilityDetailScreen({
+    required this.station,
+    required this.facility,
+    required this.onReportTap,
+    super.key,
+  });
+
+  final StationDetail station;
+  final StationFacilityInfo facility;
+  final VoidCallback onReportTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final statusIconColor = _facilityStatusNoticeIconColor(
+      facility.statusPresentation.severity,
+    );
+    final statusIcon = _facilityStatusNoticeIcon(
+      facility.statusPresentation.severity,
+    );
+    return Scaffold(
+      appBar: AppBar(title: const Text('시설 상세')),
+      body: SafeArea(
+        child: ListView(
+          padding: _stationFacilityDetailPagePadding,
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 4),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Icon(
+                    facility.layoutSummaryIcon,
+                    color: EasySubwayAccessibleColors.primary,
+                    size: 28,
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          '${station.nameKo}역',
+                          style: Theme.of(context).textTheme.bodyMedium
+                              ?.copyWith(
+                                color: EasySubwayAccessibleColors.mutedText,
+                                fontWeight: FontWeight.w600,
+                              ),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          facility.name,
+                          style: Theme.of(context).textTheme.titleLarge
+                              ?.copyWith(
+                                color: EasySubwayAccessibleColors.text,
+                                fontWeight: FontWeight.w700,
+                                height: 1.2,
+                              ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 16),
+            Container(
+              key: Key('facilityDetailStatusNotice-${facility.id}'),
+              decoration: BoxDecoration(
+                color: EasySubwayAccessibleColors.surface,
+                borderRadius: _stationFacilityDetailCardRadius,
+                border: Border.all(color: EasySubwayAccessibleColors.line),
+              ),
+              clipBehavior: Clip.antiAlias,
+              child: IntrinsicHeight(
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Container(width: 4, color: statusIconColor),
+                    Expanded(
+                      child: Padding(
+                        padding: const EdgeInsets.all(16),
+                        child: Row(
+                          children: [
+                            Icon(statusIcon, color: statusIconColor, size: 28),
+                            const SizedBox(width: 10),
+                            Expanded(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text(
+                                    _facilityStatusTitle(facility),
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .titleMedium
+                                        ?.copyWith(
+                                          color: statusIconColor,
+                                          fontWeight: FontWeight.w700,
+                                          height: 1.25,
+                                        ),
+                                  ),
+                                  const SizedBox(height: 3),
+                                  Text(
+                                    facilityStatusDisplayLabel(
+                                      statusLabel: facility.statusLabel,
+                                      severityLabel: facility.severityLabel,
+                                    ),
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .bodyMedium
+                                        ?.copyWith(
+                                          color: EasySubwayAccessibleColors
+                                              .mutedText,
+                                          fontWeight: FontWeight.w700,
+                                          height: 1.3,
+                                        ),
+                                  ),
+                                  const SizedBox(height: 3),
+                                  Text(
+                                    _facilityDetailStatusDescription(facility),
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .bodyMedium
+                                        ?.copyWith(
+                                          color: EasySubwayAccessibleColors
+                                              .mutedText,
+                                          fontWeight: FontWeight.w700,
+                                          height: 1.3,
+                                        ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 22),
+            const _StationDetailSectionTitle(title: '위치'),
+            const SizedBox(height: 12),
+            Card(
+              margin: EdgeInsets.zero,
+              color: Colors.white,
+              elevation: 0,
+              shape: const RoundedRectangleBorder(
+                borderRadius: _stationFacilityDetailCardRadius,
+                side: BorderSide(color: EasySubwayAccessibleColors.line),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  children: [
+                    _StationDetailInfoRow(
+                      icon: Icons.stairs_outlined,
+                      text: _facilityFloorLabel(facility),
+                    ),
+                    const SizedBox(height: 10),
+                    _StationDetailInfoRow(
+                      icon: Icons.place_outlined,
+                      text: facility.locationLabel,
+                    ),
+                    const SizedBox(height: 10),
+                    _StationDetailInfoRow(
+                      icon: Icons.event_available,
+                      text: facility.updatedLabel,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+            StationInfoBasisDisclosure(
+              labels: [
+                facility.fieldValidationLabel,
+                facility.confidenceLabel,
+                facility.dataSourceLabel,
+              ],
+            ),
+            const SizedBox(height: 16),
+            FilledButton.icon(
+              key: Key('facilityDetailReportButton-${facility.id}'),
+              onPressed: () {
+                Navigator.of(context).pop();
+                onReportTap();
+              },
+              icon: const Icon(Icons.report_outlined),
+              label: const Text('시설 알려주기'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+String _facilityFloorLabel(StationFacilityInfo facility) {
+  final from = facility.floorFrom.trim();
+  final to = facility.floorTo.trim();
+  if (from.isEmpty && to.isEmpty) {
+    return '연결 위치를 확인하고 있어요';
+  }
+  if (from.isEmpty || to.isEmpty) {
+    return '연결 위치 ${from.isEmpty ? to : from}';
+  }
+  return '연결 위치 $from ↔ $to';
+}
+
+String _facilityDetailStatusDescription(StationFacilityInfo facility) {
+  if (facility.needsAttention) {
+    return '현장 안내와 다르면 시설 알려주기로 알려 주세요.';
+  }
+  return '시설 안내가 다르면 시설 알려주기로 알려 주세요.';
+}
+
+String _facilityStatusTitle(StationFacilityInfo facility) {
+  return facility.statusTitle;
+}
+
+Color _facilityStatusNoticeIconColor(FacilityStatusSeverity severity) {
+  return switch (severity) {
+    FacilityStatusSeverity.blocked => EasySubwayAccessibleColors.red,
+    FacilityStatusSeverity.caution => EasySubwayAccessibleColors.amber,
+    FacilityStatusSeverity.needsInfo => EasySubwayAccessibleColors.brand,
+    FacilityStatusSeverity.normal => EasySubwayAccessibleColors.mint,
+  };
+}
+
+IconData _facilityStatusNoticeIcon(FacilityStatusSeverity severity) {
+  return switch (severity) {
+    FacilityStatusSeverity.blocked => Icons.warning_amber,
+    FacilityStatusSeverity.caution => Icons.report_problem_outlined,
+    FacilityStatusSeverity.needsInfo => Icons.info_outline,
+    FacilityStatusSeverity.normal => Icons.check_circle,
+  };
+}
+
+class _StationDetailInfoRow extends StatelessWidget {
+  const _StationDetailInfoRow({required this.icon, required this.text});
+
+  final IconData icon;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Icon(icon, size: 22, color: EasySubwayAccessibleColors.primary),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Text(
+            text,
+            style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+              color: EasySubwayAccessibleColors.secondaryText,
+              fontWeight: FontWeight.w700,
+              height: 1.3,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _StationDetailSectionTitle extends StatelessWidget {
+  const _StationDetailSectionTitle({required this.title});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      header: true,
+      child: Text(
+        title,
+        style: Theme.of(context).textTheme.titleLarge?.copyWith(
+          color: EasySubwayAccessibleColors.text,
+          fontWeight: FontWeight.w700,
+          height: 1.25,
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/stations/presentation/station_info_basis_disclosure.dart
+++ b/apps/mobile/lib/features/stations/presentation/station_info_basis_disclosure.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+
+import '../../../accessible_design.dart';
+import '../../../design_tokens.dart';
+
+const _stationInfoBasisCardRadius = BorderRadius.all(
+  Radius.circular(EasySubwayRadius.sheet),
+);
+
+class StationInfoBasisDisclosure extends StatefulWidget {
+  const StationInfoBasisDisclosure({required this.labels, super.key});
+
+  final List<String> labels;
+
+  @override
+  State<StationInfoBasisDisclosure> createState() =>
+      _StationInfoBasisDisclosureState();
+}
+
+class _StationInfoBasisDisclosureState
+    extends State<StationInfoBasisDisclosure> {
+  bool _expanded = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final labels = widget.labels
+        .where((label) => label.trim().isNotEmpty)
+        .toList(growable: false);
+    if (labels.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        OutlinedButton.icon(
+          onPressed: () => setState(() => _expanded = !_expanded),
+          icon: Icon(
+            _expanded ? Icons.expand_less : Icons.expand_more,
+            size: 24,
+          ),
+          label: Text(_expanded ? '안내 확인 방법 접기' : '안내 확인 방법 보기'),
+        ),
+        if (_expanded) ...[
+          const SizedBox(height: 10),
+          Card(
+            margin: EdgeInsets.zero,
+            elevation: 0,
+            color: Colors.white,
+            shape: const RoundedRectangleBorder(
+              borderRadius: _stationInfoBasisCardRadius,
+              side: BorderSide(color: EasySubwayAccessibleColors.line),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.all(14),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '안내 확인 방법',
+                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                      color: EasySubwayAccessibleColors.text,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  for (final label in labels) ...[
+                    Text(
+                      label,
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: EasySubwayAccessibleColors.mutedText,
+                        fontWeight: FontWeight.w700,
+                        height: 1.3,
+                      ),
+                    ),
+                    if (label != labels.last) const SizedBox(height: 4),
+                  ],
+                ],
+              ),
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -8,7 +8,6 @@ import 'package:flutter/foundation.dart';
 import 'accessible_design.dart';
 import 'adaptive_layout.dart';
 import 'core/external/kakao_map_launcher.dart';
-import 'facility_status.dart';
 import 'facility_report.dart';
 import 'features/ads/active_ad_banner.dart';
 import 'features/ads/ad_repository.dart';
@@ -21,6 +20,8 @@ import 'features/stations/domain/station_line.dart';
 import 'features/stations/domain/station_models.dart';
 import 'features/stations/domain/station_repositories.dart';
 import 'features/stations/presentation/station_exit_card.dart';
+import 'features/stations/presentation/station_facility_detail_screen.dart';
+import 'features/stations/presentation/station_info_basis_disclosure.dart';
 import 'features/stations/presentation/station_line_badges.dart';
 import 'features/stations/presentation/station_recent_search_section.dart';
 import 'features/stations/presentation/station_search_body.dart';
@@ -43,7 +44,6 @@ const _searchHistoryChangeErrorMessage = '최근 검색을 지우지 못했어�
 const _stationSearchPagePadding = EdgeInsets.fromLTRB(20, 20, 20, 32);
 const _stationSearchLargePagePadding = EdgeInsets.fromLTRB(24, 24, 24, 40);
 const _stationDetailInfoCardRadius = BorderRadius.all(Radius.circular(16));
-const _stationDetailHelpCardRadius = BorderRadius.all(Radius.circular(16));
 const _stationDetailActionButtonRadius = BorderRadius.all(Radius.circular(12));
 const _stationDetailFacilityCardRadius = BorderRadius.all(Radius.circular(16));
 
@@ -1002,7 +1002,7 @@ class _StationDetailContent extends StatelessWidget {
           ),
       const SizedBox(height: 24),
       // 메타 정보(안내 출처·마지막 확인)는 맨 아래로.
-      _InfoBasisDisclosure(
+      StationInfoBasisDisclosure(
         labels: [
           detail.dataSourceLabel,
           '마지막 확인 ${stationVerifiedRelativeLabel(detail.lastVerifiedAt)}',
@@ -1896,82 +1896,6 @@ class _StationDetailInfoRow extends StatelessWidget {
   }
 }
 
-class _InfoBasisDisclosure extends StatefulWidget {
-  const _InfoBasisDisclosure({required this.labels});
-
-  final List<String> labels;
-
-  @override
-  State<_InfoBasisDisclosure> createState() => _InfoBasisDisclosureState();
-}
-
-class _InfoBasisDisclosureState extends State<_InfoBasisDisclosure> {
-  bool _expanded = false;
-
-  @override
-  Widget build(BuildContext context) {
-    final labels = widget.labels
-        .where((label) => label.trim().isNotEmpty)
-        .toList(growable: false);
-    if (labels.isEmpty) {
-      return const SizedBox.shrink();
-    }
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        OutlinedButton.icon(
-          onPressed: () => setState(() => _expanded = !_expanded),
-          icon: Icon(
-            _expanded ? Icons.expand_less : Icons.expand_more,
-            size: 24,
-          ),
-          label: Text(_expanded ? '안내 확인 방법 접기' : '안내 확인 방법 보기'),
-        ),
-        if (_expanded) ...[
-          const SizedBox(height: 10),
-          Card(
-            margin: EdgeInsets.zero,
-            elevation: 0,
-            color: Colors.white,
-            shape: const RoundedRectangleBorder(
-              borderRadius: _stationDetailHelpCardRadius,
-              side: BorderSide(color: EasySubwayAccessibleColors.line),
-            ),
-            child: Padding(
-              padding: const EdgeInsets.all(14),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    '안내 확인 방법',
-                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                      color: EasySubwayAccessibleColors.text,
-                      fontWeight: FontWeight.w700,
-                    ),
-                  ),
-                  const SizedBox(height: 8),
-                  for (final label in labels) ...[
-                    Text(
-                      label,
-                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        color: EasySubwayAccessibleColors.mutedText,
-                        fontWeight: FontWeight.w700,
-                        height: 1.3,
-                      ),
-                    ),
-                    if (label != labels.last) const SizedBox(height: 4),
-                  ],
-                ],
-              ),
-            ),
-          ),
-        ],
-      ],
-    );
-  }
-}
-
 class _StationDetailSectionTitle extends StatelessWidget {
   const _StationDetailSectionTitle({required this.title});
 
@@ -2126,246 +2050,6 @@ class _StationFacilityCard extends StatelessWidget {
       ),
     );
   }
-}
-
-class FacilityDetailScreen extends StatelessWidget {
-  const FacilityDetailScreen({
-    required this.station,
-    required this.facility,
-    required this.onReportTap,
-    super.key,
-  });
-
-  final StationDetail station;
-  final StationFacilityInfo facility;
-  final VoidCallback onReportTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final statusIconColor = _facilityStatusNoticeIconColor(
-      facility.statusPresentation.severity,
-    );
-    final statusIcon = _facilityStatusNoticeIcon(
-      facility.statusPresentation.severity,
-    );
-    return Scaffold(
-      appBar: AppBar(title: const Text('시설 상세')),
-      body: SafeArea(
-        child: ListView(
-          padding: _stationSearchPagePadding,
-          children: [
-            Padding(
-              padding: const EdgeInsets.symmetric(vertical: 4),
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Icon(
-                    facility.layoutSummaryIcon,
-                    color: EasySubwayAccessibleColors.primary,
-                    size: 28,
-                  ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          '${station.nameKo}역',
-                          style: Theme.of(context).textTheme.bodyMedium
-                              ?.copyWith(
-                                color: EasySubwayAccessibleColors.mutedText,
-                                fontWeight: FontWeight.w600,
-                              ),
-                        ),
-                        const SizedBox(height: 4),
-                        Text(
-                          facility.name,
-                          style: Theme.of(context).textTheme.titleLarge
-                              ?.copyWith(
-                                color: EasySubwayAccessibleColors.text,
-                                fontWeight: FontWeight.w700,
-                                height: 1.2,
-                              ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            const SizedBox(height: 16),
-            Container(
-              key: Key('facilityDetailStatusNotice-${facility.id}'),
-              decoration: BoxDecoration(
-                color: EasySubwayAccessibleColors.surface,
-                borderRadius: _stationDetailFacilityCardRadius,
-                border: Border.all(color: EasySubwayAccessibleColors.line),
-              ),
-              clipBehavior: Clip.antiAlias,
-              child: IntrinsicHeight(
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    Container(width: 4, color: statusIconColor),
-                    Expanded(
-                      child: Padding(
-                        padding: const EdgeInsets.all(16),
-                        child: Row(
-                          children: [
-                            Icon(statusIcon, color: statusIconColor, size: 28),
-                            const SizedBox(width: 10),
-                            Expanded(
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  Text(
-                                    _facilityStatusTitle(facility),
-                                    style: Theme.of(context)
-                                        .textTheme
-                                        .titleMedium
-                                        ?.copyWith(
-                                          color: statusIconColor,
-                                          fontWeight: FontWeight.w700,
-                                          height: 1.25,
-                                        ),
-                                  ),
-                                  const SizedBox(height: 3),
-                                  Text(
-                                    facilityStatusDisplayLabel(
-                                      statusLabel: facility.statusLabel,
-                                      severityLabel: facility.severityLabel,
-                                    ),
-                                    style: Theme.of(context)
-                                        .textTheme
-                                        .bodyMedium
-                                        ?.copyWith(
-                                          color: EasySubwayAccessibleColors
-                                              .mutedText,
-                                          fontWeight: FontWeight.w700,
-                                          height: 1.3,
-                                        ),
-                                  ),
-                                  const SizedBox(height: 3),
-                                  Text(
-                                    _facilityDetailStatusDescription(facility),
-                                    style: Theme.of(context)
-                                        .textTheme
-                                        .bodyMedium
-                                        ?.copyWith(
-                                          color: EasySubwayAccessibleColors
-                                              .mutedText,
-                                          fontWeight: FontWeight.w700,
-                                          height: 1.3,
-                                        ),
-                                  ),
-                                ],
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ),
-            const SizedBox(height: 22),
-            const _StationDetailSectionTitle(title: '위치'),
-            const SizedBox(height: 12),
-            Card(
-              margin: EdgeInsets.zero,
-              color: Colors.white,
-              elevation: 0,
-              shape: const RoundedRectangleBorder(
-                borderRadius: _stationDetailFacilityCardRadius,
-                side: BorderSide(color: EasySubwayAccessibleColors.line),
-              ),
-              child: Padding(
-                padding: const EdgeInsets.all(16),
-                child: Column(
-                  children: [
-                    _StationDetailInfoRow(
-                      icon: Icons.stairs_outlined,
-                      text: _facilityFloorLabel(facility),
-                    ),
-                    const SizedBox(height: 10),
-                    _StationDetailInfoRow(
-                      icon: Icons.place_outlined,
-                      text: facility.locationLabel,
-                    ),
-                    const SizedBox(height: 10),
-                    _StationDetailInfoRow(
-                      icon: Icons.event_available,
-                      text: facility.updatedLabel,
-                    ),
-                  ],
-                ),
-              ),
-            ),
-            const SizedBox(height: 16),
-            _InfoBasisDisclosure(
-              labels: [
-                facility.fieldValidationLabel,
-                facility.confidenceLabel,
-                facility.dataSourceLabel,
-              ],
-            ),
-            const SizedBox(height: 16),
-            FilledButton.icon(
-              key: Key('facilityDetailReportButton-${facility.id}'),
-              onPressed: () {
-                Navigator.of(context).pop();
-                onReportTap();
-              },
-              icon: const Icon(Icons.report_outlined),
-              label: const Text('시설 알려주기'),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-String _facilityFloorLabel(StationFacilityInfo facility) {
-  final from = facility.floorFrom.trim();
-  final to = facility.floorTo.trim();
-  if (from.isEmpty && to.isEmpty) {
-    return '연결 위치를 확인하고 있어요';
-  }
-  if (from.isEmpty || to.isEmpty) {
-    return '연결 위치 ${from.isEmpty ? to : from}';
-  }
-  return '연결 위치 $from ↔ $to';
-}
-
-String _facilityDetailStatusDescription(StationFacilityInfo facility) {
-  if (facility.needsAttention) {
-    return '현장 안내와 다르면 시설 알려주기로 알려 주세요.';
-  }
-  return '시설 안내가 다르면 시설 알려주기로 알려 주세요.';
-}
-
-String _facilityStatusTitle(StationFacilityInfo facility) {
-  return facility.statusTitle;
-}
-
-Color _facilityStatusNoticeIconColor(FacilityStatusSeverity severity) {
-  return switch (severity) {
-    FacilityStatusSeverity.blocked => EasySubwayAccessibleColors.red,
-    FacilityStatusSeverity.caution => EasySubwayAccessibleColors.amber,
-    FacilityStatusSeverity.needsInfo => EasySubwayAccessibleColors.brand,
-    FacilityStatusSeverity.normal => EasySubwayAccessibleColors.mint,
-  };
-}
-
-IconData _facilityStatusNoticeIcon(FacilityStatusSeverity severity) {
-  return switch (severity) {
-    FacilityStatusSeverity.blocked => Icons.warning_amber,
-    FacilityStatusSeverity.caution => Icons.report_problem_outlined,
-    FacilityStatusSeverity.needsInfo => Icons.info_outline,
-    FacilityStatusSeverity.normal => Icons.check_circle,
-  };
 }
 
 class _StationDetailTextPill extends StatelessWidget {

--- a/apps/mobile/test/design_guard_test.dart
+++ b/apps/mobile/test/design_guard_test.dart
@@ -333,10 +333,16 @@ void main() {
     // 상한은 내리기만 한다.
     final actual = countPerFile(RegExp(r'\bCard\('));
     expectRatchet(actual, {
-      // 의도 잔존: 역 상세 카드 4곳 — 무박스(행+구분선) 전환 진행 중
-      'lib/station_search.dart': 4,
+      // 의도 잔존: 역 상세 카드 2곳 — 무박스(행+구분선) 전환 진행 중
+      'lib/station_search.dart': 2,
       // 동일 총량 중 출구 카드 1곳은 canonical presentation 경로로 이동했다.
       'lib/features/stations/presentation/station_exit_card.dart': 1,
+      // 동일 총량 중 시설 상세 카드 1곳은 canonical presentation 경로로 이동했다.
+      'lib/features/stations/presentation/station_facility_detail_screen.dart':
+          1,
+      // 안내 확인 방법 카드는 두 화면이 공유하는 canonical component로 이동했다.
+      'lib/features/stations/presentation/station_info_basis_disclosure.dart':
+          1,
       // 동일 총량 중 주변 역 검색 카드 1곳은 canonical presentation 경로로 이동했다.
       'lib/features/stations/presentation/station_search_body.dart': 1,
       // 의도 잔존: AppCard 공용 래퍼·정보 카드 2곳 — 무박스 전환 대상


### PR DESCRIPTION
## 관련 이슈

Refs #2173

## 작업 내용

- `FacilityDetailScreen`과 시설 상세 전용 표현 helper를 stations presentation 경로로 이동했습니다.
- 역 상세와 시설 상세가 함께 쓰는 안내 확인 disclosure를 `StationInfoBasisDisclosure` 하나로 분리해 중복을 제거했습니다.
- 각 새 파일은 공개 진입 Widget 하나만 가지며 기존 문구·Key·Semantics·상태 전이를 그대로 유지합니다.

## 검증

- 실행한 명령과 결과:
  - `dart format --output=none --set-exit-if-changed ...` → 4 files, 0 changed
  - `flutter analyze` → No issues found
  - `flutter test test/widget_test.dart --plain-name "역 상세"` → 19 passed
  - `flutter test test/widget_test.dart --plain-name "시설 상세"` → 1 passed
  - `flutter test test/design_guard_test.dart` → 12 passed
  - `flutter test` → 1,315 passed
  - `node tools/ci/repository-contract.test.mjs` → 207 passed
  - `codex review --disable plugins --base origin/main` → actionable finding 0건

## 영향

- [x] 제품/운영 위험 없음 (동작·Widget·Key·Semantics를 바꾸지 않은 책임 이동)
- [x] DB migration 없음
- [x] 배포 영향 없음
- [x] route/realtime/datapack contract 영향 없음
- [x] CI workflow·계약 테스트·release gate JSON 변경 없음 (있으면 full.md로 전환)

## 체크리스트

- [x] 이 PR은 B/C등급 작업이며 full template이 필요 없다.
- [ ] CI 결과를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 폴백 리뷰를 단일 PR review로 게시했다.
