### PR TITLE
[Refactor] 역 시설 카드 presentation 분리

### DIFF
--- a/apps/mobile/lib/features/stations/presentation/station_detail_info_row.dart
+++ b/apps/mobile/lib/features/stations/presentation/station_detail_info_row.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+
+import '../../../accessible_design.dart';
+
+class StationDetailInfoRow extends StatelessWidget {
+  const StationDetailInfoRow({
+    required this.icon,
+    required this.text,
+    super.key,
+  });
+
+  final IconData icon;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Icon(icon, size: 22, color: EasySubwayAccessibleColors.primary),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Text(
+            text,
+            style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+              color: EasySubwayAccessibleColors.secondaryText,
+              fontWeight: FontWeight.w700,
+              height: 1.3,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/apps/mobile/lib/features/stations/presentation/station_exit_card.dart
+++ b/apps/mobile/lib/features/stations/presentation/station_exit_card.dart
@@ -8,6 +8,7 @@ import '../../../design_tokens.dart';
 import '../../../mobile_error_reporter.dart';
 import '../domain/station_models.dart';
 import '../domain/station_repositories.dart';
+import 'station_detail_info_row.dart';
 
 const _currentLocationDisabledMessage =
     '휴대전화의 위치 기능을 켜 주세요. 가까운 역을 찾는 데 필요합니다.';
@@ -97,7 +98,7 @@ class _StationExitCardState extends State<StationExitCard> {
                     ),
                     if (exit.lastVerifiedAt.trim().isNotEmpty) ...[
                       const SizedBox(height: 8),
-                      _StationDetailInfoRow(
+                      StationDetailInfoRow(
                         icon: Icons.verified_outlined,
                         text:
                             '최근 확인 ${stationVerifiedRelativeLabel(exit.lastVerifiedAt)}',
@@ -109,14 +110,14 @@ class _StationExitCardState extends State<StationExitCard> {
             ),
             if (mapTarget?.usesStationFallback ?? false) ...[
               const SizedBox(height: 8),
-              const _StationDetailInfoRow(
+              const StationDetailInfoRow(
                 icon: Icons.info_outline,
                 text: '출구 좌표가 없어 역 위치 기준으로 안내합니다.',
               ),
             ],
             if (distanceMeters != null) ...[
               const SizedBox(height: 8),
-              _StationDetailInfoRow(
+              StationDetailInfoRow(
                 icon: Icons.straighten,
                 text: _exitDistanceLabel(
                   distanceMeters,
@@ -128,7 +129,7 @@ class _StationExitCardState extends State<StationExitCard> {
               const SizedBox(height: 8),
               Semantics(
                 liveRegion: true,
-                child: _StationDetailInfoRow(
+                child: StationDetailInfoRow(
                   icon: Icons.info_outline,
                   text: _locationMessage,
                 ),
@@ -475,33 +476,6 @@ int _coordinateDistanceMeters({
 }
 
 double _degreesToRadians(double degrees) => degrees * math.pi / 180;
-
-class _StationDetailInfoRow extends StatelessWidget {
-  const _StationDetailInfoRow({required this.icon, required this.text});
-
-  final IconData icon;
-  final String text;
-
-  @override
-  Widget build(BuildContext context) {
-    return Row(
-      children: [
-        Icon(icon, size: 22, color: EasySubwayAccessibleColors.primary),
-        const SizedBox(width: 8),
-        Expanded(
-          child: Text(
-            text,
-            style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-              color: EasySubwayAccessibleColors.secondaryText,
-              fontWeight: FontWeight.w700,
-              height: 1.3,
-            ),
-          ),
-        ),
-      ],
-    );
-  }
-}
 
 class _StationDetailStatusPill extends StatelessWidget {
   const _StationDetailStatusPill({

--- a/apps/mobile/lib/features/stations/presentation/station_facility_card.dart
+++ b/apps/mobile/lib/features/stations/presentation/station_facility_card.dart
@@ -1,0 +1,158 @@
+import 'package:flutter/material.dart';
+
+import '../../../accessible_design.dart';
+import '../../../design_tokens.dart';
+import '../domain/station_models.dart';
+import 'station_detail_info_row.dart';
+import 'station_facility_detail_screen.dart';
+
+const _stationFacilityCardRadius = BorderRadius.all(
+  Radius.circular(EasySubwayRadius.sheet),
+);
+
+class StationFacilityCard extends StatelessWidget {
+  const StationFacilityCard({
+    required this.facility,
+    required this.station,
+    required this.onReportTap,
+    super.key,
+  });
+
+  final StationFacilityInfo facility;
+  final StationDetail station;
+  final VoidCallback onReportTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return Semantics(
+      container: true,
+      explicitChildNodes: true,
+      label: facility.semanticLabel,
+      button: true,
+      onTap: () => _openFacilityDetail(context),
+      child: Card(
+        margin: const EdgeInsets.only(bottom: 12),
+        color: Colors.white,
+        elevation: 0,
+        shape: const RoundedRectangleBorder(
+          borderRadius: _stationFacilityCardRadius,
+          side: BorderSide(color: EasySubwayAccessibleColors.line),
+        ),
+        child: InkWell(
+          key: Key('stationFacilityCard-${facility.id}'),
+          borderRadius: _stationFacilityCardRadius,
+          onTap: () => _openFacilityDetail(context),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  facility.name,
+                  style: textTheme.titleMedium?.copyWith(
+                    color: EasySubwayAccessibleColors.text,
+                    fontWeight: FontWeight.w700,
+                    height: 1.25,
+                  ),
+                ),
+                // 정상 시설은 필 없이 조용히 표시하고, 문제(고장·공사)일 때만
+                // 상태 필 하나만 노출한다. 시설 종류는 이름에 이미 포함되고,
+                // '이용 가능'='정상' 중복과 종류 필은 제거한다.
+                if (facility.needsAttention) ...[
+                  const SizedBox(height: 10),
+                  _StationDetailTextPill(text: facility.statusTitle),
+                ],
+                const SizedBox(height: 12),
+                StationDetailInfoRow(
+                  icon: Icons.place_outlined,
+                  text: facility.locationLabel,
+                ),
+                const SizedBox(height: 6),
+                StationDetailInfoRow(
+                  icon: Icons.event_available,
+                  text: facility.updatedLabel,
+                ),
+                const SizedBox(height: 8),
+                // 상용 리스트 항목처럼 카드 전체 탭으로 상세에 들어가고(우측 ›로
+                // 암시), 보조 액션 '시설 알려주기'는 텍스트 버튼 수준으로 낮춘다.
+                // 카드 탭과 중복되던 '상세 보기' 텍스트는 제거한다.
+                Row(
+                  children: [
+                    Semantics(
+                      container: true,
+                      label: '${facility.name} 시설 알려주기',
+                      button: true,
+                      onTap: onReportTap,
+                      child: ExcludeSemantics(
+                        child: TextButton.icon(
+                          key: Key('facilityReportButton-${facility.id}'),
+                          onPressed: onReportTap,
+                          style: TextButton.styleFrom(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 8,
+                              vertical: 8,
+                            ),
+                          ),
+                          icon: const Icon(Icons.report_outlined, size: 20),
+                          label: const Text('시설 알려주기'),
+                        ),
+                      ),
+                    ),
+                    const Spacer(),
+                    const Icon(
+                      Icons.chevron_right,
+                      color: EasySubwayAccessibleColors.mutedText,
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _openFacilityDetail(BuildContext context) {
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => FacilityDetailScreen(
+          station: station,
+          facility: facility,
+          onReportTap: onReportTap,
+        ),
+      ),
+    );
+  }
+}
+
+class _StationDetailTextPill extends StatelessWidget {
+  const _StationDetailTextPill({required this.text});
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    // 유형·품질 라벨은 상태 의미가 없으므로 틴트 필 대신 중립 아웃라인으로.
+    return Container(
+      decoration: BoxDecoration(
+        color: EasySubwayAccessibleColors.surface,
+        borderRadius: _stationFacilityCardRadius,
+        border: Border.all(color: EasySubwayAccessibleColors.line),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        child: Text(
+          text,
+          style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+            color: EasySubwayAccessibleColors.secondaryText,
+            fontWeight: FontWeight.w700,
+            height: 1.2,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/stations/presentation/station_facility_detail_screen.dart
+++ b/apps/mobile/lib/features/stations/presentation/station_facility_detail_screen.dart
@@ -5,6 +5,7 @@ import '../../../design_tokens.dart';
 import '../../../facility_status.dart';
 import '../application/station_detail_controller.dart';
 import '../domain/station_models.dart';
+import 'station_detail_info_row.dart';
 import 'station_info_basis_disclosure.dart';
 
 const _stationFacilityDetailPagePadding = EdgeInsets.fromLTRB(20, 20, 20, 32);
@@ -168,17 +169,17 @@ class FacilityDetailScreen extends StatelessWidget {
                 padding: const EdgeInsets.all(16),
                 child: Column(
                   children: [
-                    _StationDetailInfoRow(
+                    StationDetailInfoRow(
                       icon: Icons.stairs_outlined,
                       text: _facilityFloorLabel(facility),
                     ),
                     const SizedBox(height: 10),
-                    _StationDetailInfoRow(
+                    StationDetailInfoRow(
                       icon: Icons.place_outlined,
                       text: facility.locationLabel,
                     ),
                     const SizedBox(height: 10),
-                    _StationDetailInfoRow(
+                    StationDetailInfoRow(
                       icon: Icons.event_available,
                       text: facility.updatedLabel,
                     ),
@@ -250,33 +251,6 @@ IconData _facilityStatusNoticeIcon(FacilityStatusSeverity severity) {
     FacilityStatusSeverity.needsInfo => Icons.info_outline,
     FacilityStatusSeverity.normal => Icons.check_circle,
   };
-}
-
-class _StationDetailInfoRow extends StatelessWidget {
-  const _StationDetailInfoRow({required this.icon, required this.text});
-
-  final IconData icon;
-  final String text;
-
-  @override
-  Widget build(BuildContext context) {
-    return Row(
-      children: [
-        Icon(icon, size: 22, color: EasySubwayAccessibleColors.primary),
-        const SizedBox(width: 8),
-        Expanded(
-          child: Text(
-            text,
-            style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-              color: EasySubwayAccessibleColors.secondaryText,
-              fontWeight: FontWeight.w700,
-              height: 1.3,
-            ),
-          ),
-        ),
-      ],
-    );
-  }
 }
 
 class _StationDetailSectionTitle extends StatelessWidget {

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -19,8 +19,9 @@ import 'features/stations/application/station_search_controller.dart';
 import 'features/stations/domain/station_line.dart';
 import 'features/stations/domain/station_models.dart';
 import 'features/stations/domain/station_repositories.dart';
+import 'features/stations/presentation/station_detail_info_row.dart';
 import 'features/stations/presentation/station_exit_card.dart';
-import 'features/stations/presentation/station_facility_detail_screen.dart';
+import 'features/stations/presentation/station_facility_card.dart';
 import 'features/stations/presentation/station_info_basis_disclosure.dart';
 import 'features/stations/presentation/station_line_badges.dart';
 import 'features/stations/presentation/station_recent_search_section.dart';
@@ -995,7 +996,7 @@ class _StationDetailContent extends StatelessWidget {
         const _StationDetailEmptyMessage(message: '시설 안내를 준비 중이에요.')
       else
         for (final facility in facilities)
-          _StationFacilityCard(
+          StationFacilityCard(
             facility: facility,
             station: detail,
             onReportTap: () => _openFacilityReport(context, facility),
@@ -1734,7 +1735,7 @@ class _StationInternalRouteGuidance extends StatelessWidget {
       InternalRouteViewStatus.loading => Semantics(
         label: '역 안 이동 순서 불러오는 중',
         liveRegion: true,
-        child: const _StationDetailInfoRow(
+        child: const StationDetailInfoRow(
           icon: Icons.sync,
           text: '역 안 이동 순서를 불러오는 중입니다.',
         ),
@@ -1742,7 +1743,7 @@ class _StationInternalRouteGuidance extends StatelessWidget {
       InternalRouteViewStatus.failure => Semantics(
         label: state.message,
         liveRegion: true,
-        child: _StationDetailInfoRow(
+        child: StationDetailInfoRow(
           icon: Icons.error_outline,
           text: state.message,
         ),
@@ -1777,7 +1778,7 @@ class _StationInternalRouteResultCard extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              _StationDetailInfoRow(
+              StationDetailInfoRow(
                 icon: result.statusIcon,
                 text: result.statusLabel,
               ),
@@ -1802,7 +1803,7 @@ class _StationInternalRouteResultCard extends StatelessWidget {
               if (result.warnings.isNotEmpty) ...[
                 const SizedBox(height: 10),
                 for (final warning in result.warnings)
-                  _StationDetailInfoRow(
+                  StationDetailInfoRow(
                     icon: Icons.warning_amber,
                     text: warning.message,
                   ),
@@ -1869,33 +1870,6 @@ class _StationInternalRouteStepTile extends StatelessWidget {
   }
 }
 
-class _StationDetailInfoRow extends StatelessWidget {
-  const _StationDetailInfoRow({required this.icon, required this.text});
-
-  final IconData icon;
-  final String text;
-
-  @override
-  Widget build(BuildContext context) {
-    return Row(
-      children: [
-        Icon(icon, size: 22, color: EasySubwayAccessibleColors.primary),
-        const SizedBox(width: 8),
-        Expanded(
-          child: Text(
-            text,
-            style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-              color: EasySubwayAccessibleColors.secondaryText,
-              fontWeight: FontWeight.w700,
-              height: 1.3,
-            ),
-          ),
-        ),
-      ],
-    );
-  }
-}
-
 class _StationDetailSectionTitle extends StatelessWidget {
   const _StationDetailSectionTitle({required this.title});
 
@@ -1930,152 +1904,6 @@ class _StationDetailEmptyMessage extends StatelessWidget {
         color: EasySubwayAccessibleColors.secondaryText,
         fontWeight: FontWeight.w700,
         height: 1.35,
-      ),
-    );
-  }
-}
-
-class _StationFacilityCard extends StatelessWidget {
-  const _StationFacilityCard({
-    required this.facility,
-    required this.station,
-    required this.onReportTap,
-  });
-
-  final StationFacilityInfo facility;
-  final StationDetail station;
-  final VoidCallback onReportTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
-
-    return Semantics(
-      container: true,
-      explicitChildNodes: true,
-      label: facility.semanticLabel,
-      button: true,
-      onTap: () => _openFacilityDetail(context),
-      child: Card(
-        margin: const EdgeInsets.only(bottom: 12),
-        color: Colors.white,
-        elevation: 0,
-        shape: const RoundedRectangleBorder(
-          borderRadius: _stationDetailFacilityCardRadius,
-          side: BorderSide(color: EasySubwayAccessibleColors.line),
-        ),
-        child: InkWell(
-          key: Key('stationFacilityCard-${facility.id}'),
-          borderRadius: _stationDetailFacilityCardRadius,
-          onTap: () => _openFacilityDetail(context),
-          child: Padding(
-            padding: const EdgeInsets.all(16),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  facility.name,
-                  style: textTheme.titleMedium?.copyWith(
-                    color: EasySubwayAccessibleColors.text,
-                    fontWeight: FontWeight.w700,
-                    height: 1.25,
-                  ),
-                ),
-                // 정상 시설은 필 없이 조용히 표시하고, 문제(고장·공사)일 때만
-                // 상태 필 하나만 노출한다. 시설 종류는 이름에 이미 포함되고,
-                // '이용 가능'='정상' 중복과 종류 필은 제거한다.
-                if (facility.needsAttention) ...[
-                  const SizedBox(height: 10),
-                  _StationDetailTextPill(text: facility.statusTitle),
-                ],
-                const SizedBox(height: 12),
-                _StationDetailInfoRow(
-                  icon: Icons.place_outlined,
-                  text: facility.locationLabel,
-                ),
-                const SizedBox(height: 6),
-                _StationDetailInfoRow(
-                  icon: Icons.event_available,
-                  text: facility.updatedLabel,
-                ),
-                const SizedBox(height: 8),
-                // 상용 리스트 항목처럼 카드 전체 탭으로 상세에 들어가고(우측 ›로
-                // 암시), 보조 액션 '시설 알려주기'는 텍스트 버튼 수준으로 낮춘다.
-                // 카드 탭과 중복되던 '상세 보기' 텍스트는 제거한다.
-                Row(
-                  children: [
-                    Semantics(
-                      container: true,
-                      label: '${facility.name} 시설 알려주기',
-                      button: true,
-                      onTap: onReportTap,
-                      child: ExcludeSemantics(
-                        child: TextButton.icon(
-                          key: Key('facilityReportButton-${facility.id}'),
-                          onPressed: onReportTap,
-                          style: TextButton.styleFrom(
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 8,
-                              vertical: 8,
-                            ),
-                          ),
-                          icon: const Icon(Icons.report_outlined, size: 20),
-                          label: const Text('시설 알려주기'),
-                        ),
-                      ),
-                    ),
-                    const Spacer(),
-                    const Icon(
-                      Icons.chevron_right,
-                      color: EasySubwayAccessibleColors.mutedText,
-                    ),
-                  ],
-                ),
-              ],
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-
-  void _openFacilityDetail(BuildContext context) {
-    Navigator.of(context).push(
-      MaterialPageRoute<void>(
-        builder: (_) => FacilityDetailScreen(
-          station: station,
-          facility: facility,
-          onReportTap: onReportTap,
-        ),
-      ),
-    );
-  }
-}
-
-class _StationDetailTextPill extends StatelessWidget {
-  const _StationDetailTextPill({required this.text});
-
-  final String text;
-
-  @override
-  Widget build(BuildContext context) {
-    // 유형·품질 라벨은 상태 의미가 없으므로 틴트 필 대신 중립 아웃라인으로.
-    return Container(
-      decoration: BoxDecoration(
-        color: EasySubwayAccessibleColors.surface,
-        borderRadius: _stationDetailInfoCardRadius,
-        border: Border.all(color: EasySubwayAccessibleColors.line),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-        child: Text(
-          text,
-          style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-            color: EasySubwayAccessibleColors.secondaryText,
-            fontWeight: FontWeight.w700,
-            height: 1.2,
-          ),
-        ),
       ),
     );
   }

--- a/apps/mobile/test/design_guard_test.dart
+++ b/apps/mobile/test/design_guard_test.dart
@@ -333,13 +333,15 @@ void main() {
     // 상한은 내리기만 한다.
     final actual = countPerFile(RegExp(r'\bCard\('));
     expectRatchet(actual, {
-      // 의도 잔존: 역 상세 카드 2곳 — 무박스(행+구분선) 전환 진행 중
-      'lib/station_search.dart': 2,
+      // 의도 잔존: 역 상세 카드 1곳 — 무박스(행+구분선) 전환 진행 중
+      'lib/station_search.dart': 1,
       // 동일 총량 중 출구 카드 1곳은 canonical presentation 경로로 이동했다.
       'lib/features/stations/presentation/station_exit_card.dart': 1,
       // 동일 총량 중 시설 상세 카드 1곳은 canonical presentation 경로로 이동했다.
       'lib/features/stations/presentation/station_facility_detail_screen.dart':
           1,
+      // 동일 총량 중 시설 목록 카드 1곳은 canonical presentation 경로로 이동했다.
+      'lib/features/stations/presentation/station_facility_card.dart': 1,
       // 안내 확인 방법 카드는 두 화면이 공유하는 canonical component로 이동했다.
       'lib/features/stations/presentation/station_info_basis_disclosure.dart':
           1,


### PR DESCRIPTION
## 관련 이슈

Refs #2173

## 작업 내용

- 역 시설 목록 카드를 stations presentation canonical 컴포넌트로 분리
- 역 상세·출구·시설 상세의 반복 정보 행을 공용 위젯으로 통합
- 사용자 동작·UI·API 계약·Key·Semantics를 유지하고 design guard 경로만 갱신

## 검증

- 실행한 명령과 결과:
  - flutter analyze: 통과
  - flutter test: 1,315건 통과
  - flutter test test/widget_test.dart --plain-name "역 상세": 19건 통과
  - flutter test test/widget_test.dart --plain-name "시설 상세": 1건 통과
  - flutter test test/design_guard_test.dart: 12건 통과
  - node tools/ci/repository-contract.test.mjs: 207건 통과
  - codex review --disable plugins --base origin/main: actionable finding 0건

## 영향

- [x] 제품/운영 위험 없음 (route/accessibility/mobile UX/backend API/auth/security 아님)
- [x] DB migration 없음
- [x] 배포 영향 없음
- [x] route/realtime/datapack contract 영향 없음
- [x] CI workflow·계약 테스트·release gate JSON 변경 없음 (있으면 full.md로 전환)

## 체크리스트

- [x] 이 PR은 B/C등급 작업이며 full template이 필요 없다.
- [ ] CI 결과를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 폴백 리뷰를 단일 PR review로 게시했다.