### PR TITLE
[Refactor] 역 상세 요약 presentation 분리

### DIFF
--- a/apps/mobile/lib/features/stations/presentation/station_detail_header.dart
+++ b/apps/mobile/lib/features/stations/presentation/station_detail_header.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+
+import '../../../accessible_design.dart';
+import '../domain/station_models.dart';
+import 'station_line_badges.dart';
+
+class StationDetailHeader extends StatelessWidget {
+  const StationDetailHeader({required this.detail, super.key});
+
+  final StationDetail detail;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return Semantics(
+      label: detail.semanticLabel,
+      header: true,
+      child: ExcludeSemantics(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 4),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              StationLineBadges(lines: detail.lines, size: 34),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      '${detail.nameKo}역',
+                      style: textTheme.headlineSmall?.copyWith(
+                        color: EasySubwayAccessibleColors.text,
+                        fontWeight: FontWeight.w700,
+                        height: 1.2,
+                      ),
+                    ),
+                    // 부역명은 분리된 값이 있을 때만 역명 아래 보조 표기로 노출한다.
+                    if (detail.nameSub.isNotEmpty) ...[
+                      const SizedBox(height: 2),
+                      Text(
+                        detail.nameSub,
+                        style: textTheme.bodyMedium?.copyWith(
+                          color: EasySubwayAccessibleColors.secondaryText,
+                          fontWeight: FontWeight.w600,
+                          height: 1.2,
+                        ),
+                      ),
+                    ],
+                    const SizedBox(height: 4),
+                    Text(
+                      detail.lineLabel,
+                      style: textTheme.bodyLarge?.copyWith(
+                        color: EasySubwayAccessibleColors.secondaryText,
+                        fontWeight: FontWeight.w600,
+                        height: 1.3,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 12),
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: [
+                  const Text(
+                    '마지막 확인',
+                    style: TextStyle(
+                      color: EasySubwayAccessibleColors.mutedText,
+                      fontSize: 11,
+                      fontWeight: FontWeight.w500,
+                      height: 1.2,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    stationVerifiedRelativeLabel(detail.lastVerifiedAt),
+                    style: const TextStyle(
+                      color: EasySubwayAccessibleColors.mutedText,
+                      fontSize: 12,
+                      fontWeight: FontWeight.w600,
+                      height: 1.2,
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/stations/presentation/station_detail_route_actions.dart
+++ b/apps/mobile/lib/features/stations/presentation/station_detail_route_actions.dart
@@ -1,0 +1,170 @@
+import 'package:flutter/material.dart';
+
+import '../../../accessible_design.dart';
+import '../../../design_tokens.dart';
+import '../../route_draft/application/route_draft_controller.dart';
+import '../../route_draft/domain/route_draft.dart';
+import '../application/station_detail_controller.dart';
+import '../domain/station_models.dart';
+
+const _stationDetailActionButtonRadius = BorderRadius.all(
+  Radius.circular(EasySubwayRadius.card),
+);
+
+class StationDetailRouteActions extends StatelessWidget {
+  const StationDetailRouteActions({
+    required this.detail,
+    required this.routeDraftController,
+    required this.favoriteController,
+    super.key,
+  });
+
+  final StationDetail detail;
+  final RouteDraftController? routeDraftController;
+  final StationFavoriteToggleController? favoriteController;
+
+  @override
+  Widget build(BuildContext context) {
+    // 상용 지도·교통 앱처럼 출발·도착·저장을 한 줄의 동등한 액션으로 묶는다.
+    final draftController = routeDraftController;
+    final favController = favoriteController;
+    final station = RouteDraftStation(id: detail.id, nameKo: detail.nameKo);
+    final buttons = <Widget>[
+      if (draftController != null) ...[
+        _StationPointButton(
+          key: const Key('stationDetailSetOriginButton'),
+          icon: Icons.trip_origin,
+          label: '출발',
+          onPressed: () {
+            draftController.setOrigin(station);
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text('${station.displayName}을 출발역으로 설정했습니다')),
+            );
+          },
+        ),
+        _StationPointButton(
+          key: const Key('stationDetailSetDestinationButton'),
+          icon: Icons.flag_outlined,
+          label: '도착',
+          onPressed: () {
+            draftController.setDestination(station);
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text('${station.displayName}을 도착역으로 설정했습니다')),
+            );
+          },
+        ),
+      ],
+      if (favController != null)
+        _StationFavoriteButton(detail: detail, controller: favController),
+    ];
+    if (buttons.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    return Row(
+      children: [
+        for (var i = 0; i < buttons.length; i++) ...[
+          if (i > 0) const SizedBox(width: 10),
+          Expanded(child: buttons[i]),
+        ],
+      ],
+    );
+  }
+}
+
+class _StationFavoriteButton extends StatelessWidget {
+  const _StationFavoriteButton({
+    required this.detail,
+    required this.controller,
+  });
+
+  final StationDetail detail;
+  final StationFavoriteToggleController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: controller,
+      builder: (context, _) {
+        final state = controller.state;
+        final isFavorite = state.isFavorite;
+        final label = switch (state.status) {
+          StationFavoriteToggleStatus.checking => '확인 중',
+          StationFavoriteToggleStatus.saving => '저장 중',
+          StationFavoriteToggleStatus.removing => '해제 중',
+          StationFavoriteToggleStatus.ready ||
+          StationFavoriteToggleStatus.failure => isFavorite ? '저장됨' : '저장',
+        };
+        final actionLabel = state.status == StationFavoriteToggleStatus.checking
+            ? '즐겨찾기 확인 중'
+            : isFavorite
+            ? '즐겨찾기 해제'
+            : '즐겨찾기 저장';
+        final onPressed = state.isBusy
+            ? null
+            : () async {
+                if (isFavorite) {
+                  await controller.remove();
+                } else {
+                  await controller.save();
+                }
+                if (!context.mounted) {
+                  return;
+                }
+                // 연속 토글에서도 가장 최근 저장·해제 결과만 바로 알린다.
+                final message = controller.state.message;
+                if (message.isNotEmpty) {
+                  ScaffoldMessenger.of(context)
+                    ..clearSnackBars()
+                    ..showSnackBar(SnackBar(content: Text(message)));
+                }
+              };
+        return Semantics(
+          container: true,
+          label: '${detail.nameKo}역 $actionLabel',
+          button: true,
+          onTap: onPressed,
+          child: ExcludeSemantics(
+            child: _StationPointButton(
+              key: const Key('stationFavoriteToggleButton'),
+              icon: isFavorite ? Icons.star : Icons.star_border,
+              label: label,
+              onPressed: onPressed,
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _StationPointButton extends StatelessWidget {
+  const _StationPointButton({
+    required this.icon,
+    required this.label,
+    required this.onPressed,
+    super.key,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return OutlinedButton.icon(
+      onPressed: onPressed,
+      style: OutlinedButton.styleFrom(
+        minimumSize: const Size.fromHeight(EasySubwayTouchTarget.general),
+        backgroundColor: Colors.white,
+        foregroundColor: EasySubwayAccessibleColors.primary,
+        side: const BorderSide(color: EasySubwayAccessibleColors.line),
+        shape: const RoundedRectangleBorder(
+          borderRadius: _stationDetailActionButtonRadius,
+        ),
+        textStyle: const TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
+      ),
+      icon: Icon(icon, size: 22),
+      label: Text(label),
+    );
+  }
+}

--- a/apps/mobile/lib/features/stations/presentation/station_facility_status_summary.dart
+++ b/apps/mobile/lib/features/stations/presentation/station_facility_status_summary.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+
+import '../../../accessible_design.dart';
+import '../../../design_tokens.dart';
+
+const _stationFacilityStatusSummaryRadius = BorderRadius.all(
+  Radius.circular(EasySubwayRadius.sheet),
+);
+
+class StationFacilityStatusSummary extends StatelessWidget {
+  const StationFacilityStatusSummary({
+    required this.text,
+    required this.semanticLabel,
+    super.key,
+  });
+
+  final String text;
+  final String semanticLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: semanticLabel,
+      child: ExcludeSemantics(
+        child: Card(
+          margin: EdgeInsets.zero,
+          color: EasySubwayAccessibleColors.redSoft,
+          elevation: 0,
+          shape: const RoundedRectangleBorder(
+            borderRadius: _stationFacilityStatusSummaryRadius,
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(14),
+            child: Row(
+              children: [
+                const Icon(
+                  Icons.warning_amber,
+                  color: EasySubwayAccessibleColors.red,
+                  size: 24,
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Text(
+                    text,
+                    style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                      color: EasySubwayAccessibleColors.red,
+                      fontWeight: FontWeight.w700,
+                      height: 1.3,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/stations/presentation/station_realtime_summary.dart
+++ b/apps/mobile/lib/features/stations/presentation/station_realtime_summary.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+
+import '../../../accessible_design.dart';
+import '../../../design_tokens.dart';
+import '../../realtime/realtime_repository.dart';
+
+const _stationRealtimeSummaryRadius = BorderRadius.all(
+  Radius.circular(EasySubwayRadius.sheet),
+);
+
+class StationRealtimeSummary extends StatelessWidget {
+  const StationRealtimeSummary({
+    required this.snapshot,
+    required this.onRetry,
+    super.key,
+  });
+
+  final RealtimeSnapshot snapshot;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final title = switch (snapshot.status) {
+      RealtimeSnapshotStatus.fresh => '도착 정보',
+      RealtimeSnapshotStatus.stale => '최근 도착 정보',
+      RealtimeSnapshotStatus.unsupported => '지원 준비 중',
+      RealtimeSnapshotStatus.unavailable => '실시간 정보 확인 불가',
+      RealtimeSnapshotStatus.loading => '실시간 정보 확인 중',
+    };
+    // 실시간 조회가 실패로 끝난 경우에만 다시 시도를 권한다. 미지원 노선은
+    // 재시도해도 결과가 같으므로 버튼을 노출하지 않는다.
+    final canRetry = snapshot.status == RealtimeSnapshotStatus.unavailable;
+    final summary = snapshot.summaryText.trim().isEmpty
+        ? '역 정보와 경로 검색은 계속 이용할 수 있습니다.'
+        : snapshot.summaryText.trim();
+    final updatedLabel = snapshot.receivedAt.trim().isEmpty
+        ? ''
+        : '마지막 갱신 ${snapshot.receivedAt}';
+    final semanticParts = [
+      '실시간 열차',
+      title,
+      summary,
+      if (updatedLabel.isNotEmpty) updatedLabel,
+      if (canRetry) '다시 시도할 수 있어요',
+    ];
+    return Semantics(
+      label: semanticParts.join(', '),
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: _stationRealtimeSummaryRadius,
+          border: Border.all(color: EasySubwayAccessibleColors.line),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Icon(
+                  Icons.schedule,
+                  color: EasySubwayAccessibleColors.primary,
+                  size: 28,
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Text(
+                    title,
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      color: EasySubwayAccessibleColors.text,
+                      fontWeight: FontWeight.w700,
+                      height: 1.25,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text(
+              summary,
+              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                color: EasySubwayAccessibleColors.text,
+                height: 1.35,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            if (updatedLabel.isNotEmpty) ...[
+              const SizedBox(height: 6),
+              Text(
+                updatedLabel,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: EasySubwayAccessibleColors.mutedText,
+                  height: 1.3,
+                ),
+              ),
+            ],
+            if (canRetry) ...[
+              const SizedBox(height: 10),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: OutlinedButton.icon(
+                  key: const Key('stationRealtimeRetryButton'),
+                  onPressed: onRetry,
+                  icon: const Icon(Icons.refresh, size: 20),
+                  label: const Text('다시 시도'),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -19,12 +19,15 @@ import 'features/stations/application/station_search_controller.dart';
 import 'features/stations/domain/station_line.dart';
 import 'features/stations/domain/station_models.dart';
 import 'features/stations/domain/station_repositories.dart';
+import 'features/stations/presentation/station_detail_header.dart';
 import 'features/stations/presentation/station_detail_info_row.dart';
+import 'features/stations/presentation/station_detail_route_actions.dart';
 import 'features/stations/presentation/station_exit_card.dart';
 import 'features/stations/presentation/station_facility_card.dart';
+import 'features/stations/presentation/station_facility_status_summary.dart';
 import 'features/stations/presentation/station_info_basis_disclosure.dart';
-import 'features/stations/presentation/station_line_badges.dart';
 import 'features/stations/presentation/station_recent_search_section.dart';
+import 'features/stations/presentation/station_realtime_summary.dart';
 import 'features/stations/presentation/station_search_body.dart';
 import 'features/stations/presentation/station_timetable_screen.dart';
 import 'internal_route.dart';
@@ -45,8 +48,6 @@ const _searchHistoryChangeErrorMessage = '최근 검색을 지우지 못했어�
 const _stationSearchPagePadding = EdgeInsets.fromLTRB(20, 20, 20, 32);
 const _stationSearchLargePagePadding = EdgeInsets.fromLTRB(24, 24, 24, 40);
 const _stationDetailInfoCardRadius = BorderRadius.all(Radius.circular(16));
-const _stationDetailActionButtonRadius = BorderRadius.all(Radius.circular(12));
-const _stationDetailFacilityCardRadius = BorderRadius.all(Radius.circular(16));
 
 class StationSearchScreen extends StatefulWidget {
   const StationSearchScreen({
@@ -932,10 +933,10 @@ class _StationDetailContent extends StatelessWidget {
     // 행동이 보이도록 실시간을 위로, 메타는 맨 아래로, 중복 "지도 위치 목록"과
     // 상시 안전 안내는 제거, "역 안 이동 안내"+"순서"는 한 섹션으로 통합한다.
     final primaryChildren = <Widget>[
-      _StationDetailHeader(detail: detail),
+      StationDetailHeader(detail: detail),
       const SizedBox(height: 12),
       if (facilityAttentionSummary.isNotEmpty) ...[
-        _StationFacilityStatusSummary(
+        StationFacilityStatusSummary(
           text: facilityAttentionSummary,
           semanticLabel: facilityAttentionSemanticLabel,
         ),
@@ -943,12 +944,12 @@ class _StationDetailContent extends StatelessWidget {
       ],
       const _StationDetailSectionTitle(title: '실시간 열차'),
       const SizedBox(height: 12),
-      _StationRealtimeSummary(
+      StationRealtimeSummary(
         snapshot: realtimeSnapshot,
         onRetry: onRetryRealtime,
       ),
       const SizedBox(height: 20),
-      _StationDetailRouteActions(
+      StationDetailRouteActions(
         detail: detail,
         routeDraftController: routeDraftController,
         favoriteController: favoriteController,
@@ -1237,273 +1238,6 @@ class _StationDetailAdaptiveContent extends StatelessWidget {
   }
 }
 
-class _StationRealtimeSummary extends StatelessWidget {
-  const _StationRealtimeSummary({
-    required this.snapshot,
-    required this.onRetry,
-  });
-
-  final RealtimeSnapshot snapshot;
-  final VoidCallback onRetry;
-
-  @override
-  Widget build(BuildContext context) {
-    final title = switch (snapshot.status) {
-      RealtimeSnapshotStatus.fresh => '도착 정보',
-      RealtimeSnapshotStatus.stale => '최근 도착 정보',
-      RealtimeSnapshotStatus.unsupported => '지원 준비 중',
-      RealtimeSnapshotStatus.unavailable => '실시간 정보 확인 불가',
-      RealtimeSnapshotStatus.loading => '실시간 정보 확인 중',
-    };
-    // 실시간 조회가 실패로 끝난 경우에만 다시 시도를 권한다. 미지원 노선은
-    // 재시도해도 결과가 같으므로 버튼을 노출하지 않는다.
-    final canRetry = snapshot.status == RealtimeSnapshotStatus.unavailable;
-    final summary = snapshot.summaryText.trim().isEmpty
-        ? '역 정보와 경로 검색은 계속 이용할 수 있습니다.'
-        : snapshot.summaryText.trim();
-    final updatedLabel = snapshot.receivedAt.trim().isEmpty
-        ? ''
-        : '마지막 갱신 ${snapshot.receivedAt}';
-    final semanticParts = [
-      '실시간 열차',
-      title,
-      summary,
-      if (updatedLabel.isNotEmpty) updatedLabel,
-      if (canRetry) '다시 시도할 수 있어요',
-    ];
-    return Semantics(
-      label: semanticParts.join(', '),
-      child: Container(
-        width: double.infinity,
-        padding: const EdgeInsets.all(16),
-        decoration: BoxDecoration(
-          color: Colors.white,
-          borderRadius: _stationDetailInfoCardRadius,
-          border: Border.all(color: EasySubwayAccessibleColors.line),
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                const Icon(
-                  Icons.schedule,
-                  color: EasySubwayAccessibleColors.primary,
-                  size: 28,
-                ),
-                const SizedBox(width: 10),
-                Expanded(
-                  child: Text(
-                    title,
-                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                      color: EasySubwayAccessibleColors.text,
-                      fontWeight: FontWeight.w700,
-                      height: 1.25,
-                    ),
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 8),
-            Text(
-              summary,
-              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                color: EasySubwayAccessibleColors.text,
-                height: 1.35,
-                fontWeight: FontWeight.w700,
-              ),
-            ),
-            if (updatedLabel.isNotEmpty) ...[
-              const SizedBox(height: 6),
-              Text(
-                updatedLabel,
-                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: EasySubwayAccessibleColors.mutedText,
-                  height: 1.3,
-                ),
-              ),
-            ],
-            if (canRetry) ...[
-              const SizedBox(height: 10),
-              Align(
-                alignment: Alignment.centerLeft,
-                child: OutlinedButton.icon(
-                  key: const Key('stationRealtimeRetryButton'),
-                  onPressed: onRetry,
-                  icon: const Icon(Icons.refresh, size: 20),
-                  label: const Text('다시 시도'),
-                ),
-              ),
-            ],
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _StationDetailRouteActions extends StatelessWidget {
-  const _StationDetailRouteActions({
-    required this.detail,
-    required this.routeDraftController,
-    required this.favoriteController,
-  });
-
-  final StationDetail detail;
-  final RouteDraftController? routeDraftController;
-  final StationFavoriteToggleController? favoriteController;
-
-  @override
-  Widget build(BuildContext context) {
-    // 상용 지도·교통 앱(카카오맵·구글맵)처럼 출발·도착·저장(즐겨찾기)을 한 줄의
-    // 동등한 액션으로 묶는다. 즐겨찾기는 별도 큰 버튼이 아니라 이 행의 피어다.
-    final draftController = routeDraftController;
-    final favController = favoriteController;
-    final station = RouteDraftStation(id: detail.id, nameKo: detail.nameKo);
-    final buttons = <Widget>[
-      if (draftController != null) ...[
-        _StationPointButton(
-          key: const Key('stationDetailSetOriginButton'),
-          icon: Icons.trip_origin,
-          label: '출발',
-          onPressed: () {
-            draftController.setOrigin(station);
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(content: Text('${station.displayName}을 출발역으로 설정했습니다')),
-            );
-          },
-        ),
-        _StationPointButton(
-          key: const Key('stationDetailSetDestinationButton'),
-          icon: Icons.flag_outlined,
-          label: '도착',
-          onPressed: () {
-            draftController.setDestination(station);
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(content: Text('${station.displayName}을 도착역으로 설정했습니다')),
-            );
-          },
-        ),
-      ],
-      if (favController != null)
-        _StationFavoriteButton(detail: detail, controller: favController),
-    ];
-    if (buttons.isEmpty) {
-      return const SizedBox.shrink();
-    }
-    return Row(
-      children: [
-        for (var i = 0; i < buttons.length; i++) ...[
-          if (i > 0) const SizedBox(width: 10),
-          Expanded(child: buttons[i]),
-        ],
-      ],
-    );
-  }
-}
-
-class _StationFavoriteButton extends StatelessWidget {
-  const _StationFavoriteButton({
-    required this.detail,
-    required this.controller,
-  });
-
-  final StationDetail detail;
-  final StationFavoriteToggleController controller;
-
-  @override
-  Widget build(BuildContext context) {
-    return AnimatedBuilder(
-      animation: controller,
-      builder: (context, _) {
-        final state = controller.state;
-        final isFavorite = state.isFavorite;
-        final label = switch (state.status) {
-          StationFavoriteToggleStatus.checking => '확인 중',
-          StationFavoriteToggleStatus.saving => '저장 중',
-          StationFavoriteToggleStatus.removing => '해제 중',
-          StationFavoriteToggleStatus.ready ||
-          StationFavoriteToggleStatus.failure => isFavorite ? '저장됨' : '저장',
-        };
-        final actionLabel = state.status == StationFavoriteToggleStatus.checking
-            ? '즐겨찾기 확인 중'
-            : isFavorite
-            ? '즐겨찾기 해제'
-            : '즐겨찾기 저장';
-        final onPressed = state.isBusy
-            ? null
-            : () async {
-                if (isFavorite) {
-                  await controller.remove();
-                } else {
-                  await controller.save();
-                }
-                if (!context.mounted) {
-                  return;
-                }
-                // 저장·해제 결과(및 실패 사유)는 상용 앱과 동일하게 스낵바로 알린다.
-                // 직전 스낵바는 지워 연속 토글 시 최신 결과가 바로 보이게 한다.
-                final message = controller.state.message;
-                if (message.isNotEmpty) {
-                  ScaffoldMessenger.of(context)
-                    ..clearSnackBars()
-                    ..showSnackBar(SnackBar(content: Text(message)));
-                }
-              };
-        return Semantics(
-          container: true,
-          label: '${detail.nameKo}역 $actionLabel',
-          button: true,
-          onTap: onPressed,
-          child: ExcludeSemantics(
-            child: _StationPointButton(
-              key: const Key('stationFavoriteToggleButton'),
-              icon: isFavorite ? Icons.star : Icons.star_border,
-              label: label,
-              onPressed: onPressed,
-            ),
-          ),
-        );
-      },
-    );
-  }
-}
-
-class _StationPointButton extends StatelessWidget {
-  const _StationPointButton({
-    required this.icon,
-    required this.label,
-    required this.onPressed,
-    super.key,
-  });
-
-  final IconData icon;
-  final String label;
-  final VoidCallback? onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    // 같은 성격 행동은 화면이 달라도 같은 패턴: 검색 결과의 _StationRoleButton과
-    // 동일하게 아웃라인 아이콘 + 라벨, 단일 primary 계열.
-    return OutlinedButton.icon(
-      onPressed: onPressed,
-      style: OutlinedButton.styleFrom(
-        minimumSize: const Size.fromHeight(EasySubwayTouchTarget.general),
-        backgroundColor: Colors.white,
-        foregroundColor: EasySubwayAccessibleColors.primary,
-        side: const BorderSide(color: EasySubwayAccessibleColors.line),
-        shape: const RoundedRectangleBorder(
-          borderRadius: _stationDetailActionButtonRadius,
-        ),
-        textStyle: const TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
-      ),
-      icon: Icon(icon, size: 22),
-      label: Text(label),
-    );
-  }
-}
-
 class _StationLayoutSummary extends StatelessWidget {
   const _StationLayoutSummary({
     required this.items,
@@ -1579,146 +1313,6 @@ class _StationLayoutStep extends StatelessWidget {
             ),
           ),
         ],
-      ),
-    );
-  }
-}
-
-class _StationFacilityStatusSummary extends StatelessWidget {
-  const _StationFacilityStatusSummary({
-    required this.text,
-    required this.semanticLabel,
-  });
-
-  final String text;
-  final String semanticLabel;
-
-  @override
-  Widget build(BuildContext context) {
-    return Semantics(
-      label: semanticLabel,
-      child: ExcludeSemantics(
-        child: Card(
-          margin: EdgeInsets.zero,
-          color: EasySubwayAccessibleColors.redSoft,
-          elevation: 0,
-          shape: const RoundedRectangleBorder(
-            borderRadius: _stationDetailFacilityCardRadius,
-          ),
-          child: Padding(
-            padding: const EdgeInsets.all(14),
-            child: Row(
-              children: [
-                const Icon(
-                  Icons.warning_amber,
-                  color: EasySubwayAccessibleColors.red,
-                  size: 24,
-                ),
-                const SizedBox(width: 10),
-                Expanded(
-                  child: Text(
-                    text,
-                    style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                      color: EasySubwayAccessibleColors.red,
-                      fontWeight: FontWeight.w700,
-                      height: 1.3,
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _StationDetailHeader extends StatelessWidget {
-  const _StationDetailHeader({required this.detail});
-
-  final StationDetail detail;
-
-  @override
-  Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
-
-    return Semantics(
-      label: detail.semanticLabel,
-      header: true,
-      child: ExcludeSemantics(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(vertical: 4),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              StationLineBadges(lines: detail.lines, size: 34),
-              const SizedBox(width: 12),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      '${detail.nameKo}역',
-                      style: textTheme.headlineSmall?.copyWith(
-                        color: EasySubwayAccessibleColors.text,
-                        fontWeight: FontWeight.w700,
-                        height: 1.2,
-                      ),
-                    ),
-                    // 부역명(#1789 P0.2). name_ko에서 분리한 부역명을 역명 아래
-                    // 보조 표기로 노출한다(있을 때만).
-                    if (detail.nameSub.isNotEmpty) ...[
-                      const SizedBox(height: 2),
-                      Text(
-                        detail.nameSub,
-                        style: textTheme.bodyMedium?.copyWith(
-                          color: EasySubwayAccessibleColors.secondaryText,
-                          fontWeight: FontWeight.w600,
-                          height: 1.2,
-                        ),
-                      ),
-                    ],
-                    const SizedBox(height: 4),
-                    Text(
-                      detail.lineLabel,
-                      style: textTheme.bodyLarge?.copyWith(
-                        color: EasySubwayAccessibleColors.secondaryText,
-                        fontWeight: FontWeight.w600,
-                        height: 1.3,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              const SizedBox(width: 12),
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.end,
-                children: [
-                  const Text(
-                    '마지막 확인',
-                    style: TextStyle(
-                      color: EasySubwayAccessibleColors.mutedText,
-                      fontSize: 11,
-                      fontWeight: FontWeight.w500,
-                      height: 1.2,
-                    ),
-                  ),
-                  const SizedBox(height: 2),
-                  Text(
-                    stationVerifiedRelativeLabel(detail.lastVerifiedAt),
-                    style: const TextStyle(
-                      color: EasySubwayAccessibleColors.mutedText,
-                      fontSize: 12,
-                      fontWeight: FontWeight.w600,
-                      height: 1.2,
-                    ),
-                  ),
-                ],
-              ),
-            ],
-          ),
-        ),
       ),
     );
   }

--- a/apps/mobile/test/design_guard_test.dart
+++ b/apps/mobile/test/design_guard_test.dart
@@ -163,7 +163,8 @@ void main() {
       // 의도 잔존: 시설 상태 카드 blocked/caution — 상태 의미 틴트 (v4 허용 예외)
       'lib/features/notifications/presentation/notification_inbox_screen.dart':
           2,
-      'lib/station_search.dart': 1,
+      'lib/features/stations/presentation/station_facility_status_summary.dart':
+          1,
       // 의도 잔존: 운행 공지 배너 — 운행 중단 상태 의미 (v4 허용 예외)
       'lib/features/service_notice/presentation/service_notice_banner.dart': 1,
     }, rule: '장식 Soft 틴트');
@@ -333,8 +334,9 @@ void main() {
     // 상한은 내리기만 한다.
     final actual = countPerFile(RegExp(r'\bCard\('));
     expectRatchet(actual, {
-      // 의도 잔존: 역 상세 카드 1곳 — 무박스(행+구분선) 전환 진행 중
-      'lib/station_search.dart': 1,
+      // 동일 총량 중 시설 상태 카드 1곳은 canonical presentation 경로로 이동했다.
+      'lib/features/stations/presentation/station_facility_status_summary.dart':
+          1,
       // 동일 총량 중 출구 카드 1곳은 canonical presentation 경로로 이동했다.
       'lib/features/stations/presentation/station_exit_card.dart': 1,
       // 동일 총량 중 시설 상세 카드 1곳은 canonical presentation 경로로 이동했다.

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -13366,6 +13366,9 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   const stationExitCard = read(
     "apps/mobile/lib/features/stations/presentation/station_exit_card.dart",
   );
+  const stationDetailHeader = read(
+    "apps/mobile/lib/features/stations/presentation/station_detail_header.dart",
+  );
   const stationSearchBody = read(
     "apps/mobile/lib/features/stations/presentation/station_search_body.dart",
   );
@@ -13537,7 +13540,7 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(facilityReportTest, /시설 신고 임시 대상 저장소는 secure storage 복원 실패 시 저장값을 지운다/);
   assert.match(facilityReportTest, /시설 신고 임시 대상 저장소는 secure storage 삭제 실패에도 null로 복구한다/);
   assert.ok(existsSync(path.join(root, "apps/mobile/lib/station_search.dart")));
-  assert.match(stationSearch, /features\/stations\/presentation\/station_line_badges\.dart/);
+  assert.match(stationDetailHeader, /station_line_badges\.dart/);
   assert.doesNotMatch(stationSearch, /class StationLineBadges|class StationLineBadge/);
   assert.match(stationLineBadges, /class StationLineBadges extends StatelessWidget/);
   assert.match(stationLineBadges, /class StationLineBadge extends StatelessWidget/);


### PR DESCRIPTION
## 관련 이슈

Refs #2173

## 작업 배경

- 역 검색과 역 상세 UI가 단일 파일에 함께 있어 실시간·액션·상태 요약·헤더 책임의 탐색 비용이 높았습니다.
- 사용자 동작·UI·API 계약을 유지한 채 canonical presentation 경계를 이어서 분리합니다.

## 작업 내용

- 실시간 열차 요약을 station_realtime_summary.dart로 이동
- 출발·도착·즐겨찾기 액션을 station_detail_route_actions.dart로 이동
- 시설 상태 요약과 역 헤더를 각각 canonical presentation 파일로 이동
- StationLineBadges 직접 소비자 계약과 design guard 경로를 실제 소유 구조에 맞게 갱신
- 기존 문구·Key·Semantics·상태 전이와 16/12px 렌더링 값을 유지

## 검증

- 실행한 명령과 결과:
  - flutter analyze: 통과
  - flutter test: 1,315건 통과
  - flutter test test/widget_test.dart --plain-name "역 상세": 19건 통과
  - flutter test test/design_guard_test.dart: 12건 통과
  - node tools/ci/repository-contract.test.mjs: 207건 통과
  - codex review --disable plugins --base origin/main: actionable finding 0건

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 역 상세 동작·UI 회귀 | Flutter 공통 | 기존 역 상세 위젯 테스트 19건 및 전체 테스트 | GitHub Mobile App CI와 위 명령 결과 | 통과 |
| 접근성 계약 | Android/iOS 공통 | 기존 Key·Semantics 코드를 그대로 이동하고 독립 review 대조 | 독립 Review 객체 게시 예정 | 차이 없음 |
| 수동 UI 캡처 | 해당 없음 | widget tree와 표시값을 바꾸지 않는 구조 이동 | 신규 캡처 불필요 | 제외 |
| 배포 | 해당 없음 | 버전·산출물·배포 설정 미변경 | post-merge CI 초기 상태만 확인 | 영향 없음 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 1.0.4 (변경 없음)
- mobile versionCode: 10005 (변경 없음)
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 새 네 presentation 위젯의 Key·Semantics·문구와 기존 station_search.dart 삭제 블록이 동일한지 확인해 주세요.
- repository contract 변경은 StationLineBadges의 직접 consumer가 station_detail_header.dart로 이동한 사실만 반영합니다.

## 리스크

- 코드 이동 과정의 누락 위험은 역 상세 19건, 전체 1,315건, analyzer, design guard, repository contract와 독립 review로 방어했습니다.
- API, DB, 저장 형식, 배포, 사용자 상태 전이 변경은 없습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)