### PR TITLE
[Backend] 운영 timetable cache·rollback 증빙 추가

### DIFF
--- a/.github/workflows/production-timetable-snapshot-evidence.yml
+++ b/.github/workflows/production-timetable-snapshot-evidence.yml
@@ -1,0 +1,44 @@
+name: Production timetable snapshot evidence
+
+on:
+  workflow_dispatch:
+
+jobs:
+  verify:
+    name: Verify production timetable snapshot
+    permissions:
+      contents: read
+    runs-on:
+      - self-hosted
+      - easysubway-production
+    timeout-minutes: 20
+    environment: production
+    concurrency:
+      group: production-timetable-snapshot-evidence
+      cancel-in-progress: false
+    env:
+      DEPLOY_ROOT: ${{ vars.DEPLOY_ROOT }}
+      EXPECTED_DEPLOYED_SHA: ${{ github.sha }}
+
+    steps:
+      - name: Reject non-main manual execution
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
+            echo "production timetable evidence must run from main" >&2
+            exit 1
+          fi
+
+      - name: Checkout reviewed main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24"
+
+      - name: Verify active identity, cache, freshness, and rollback
+        shell: bash
+        run: bash tools/ops/verify-production-timetable-snapshot.sh

--- a/backend/src/main/java/com/easysubway/EasySubwayBackendApplication.java
+++ b/backend/src/main/java/com/easysubway/EasySubwayBackendApplication.java
@@ -2,14 +2,26 @@ package com.easysubway;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EnableScheduling
 public class EasySubwayBackendApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(EasySubwayBackendApplication.class, args);
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnProperty(
+		prefix = "easysubway.scheduling",
+		name = "enabled",
+		havingValue = "true",
+		matchIfMissing = true
+	)
+	@EnableScheduling
+	static class SchedulingConfiguration {
 	}
 
 }

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
@@ -19,19 +19,26 @@ import com.easysubway.route.domain.RouteNotFoundException;
 import com.easysubway.route.domain.RouteSearchResult;
 import com.easysubway.route.domain.RouteSearchStatus;
 import com.easysubway.route.domain.RouteStep;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.Profiles;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 @Service
 public class RouteV2Planner implements RouteV2SearchUseCase {
 
+	private static final Logger log = LoggerFactory.getLogger(RouteV2Planner.class);
 	private static final String PLANNER_ADR = "tools/routes/route-algorithm-v2-adr.json";
 	private static final int RANKING_CANDIDATE_LIMIT = 3;
 
@@ -40,40 +47,57 @@ public class RouteV2Planner implements RouteV2SearchUseCase {
 	private final RouteTimetableRaptorPlanner timetableRaptorPlanner = new RouteTimetableRaptorPlanner();
 	private final boolean timetableRequired;
 	private final boolean legacyPersistenceAllowed;
+	private final Counter timetableCacheHit;
+	private final Counter timetableCacheMiss;
+	private final AtomicBoolean timetableCacheHitLogged = new AtomicBoolean();
+	private final AtomicBoolean timetableCacheMissLogged = new AtomicBoolean();
 	private volatile TimetableSnapshot cachedTimetableSnapshot;
 
 	public RouteV2Planner(RouteSearchUseCase routeSearchUseCase) {
-		this(routeSearchUseCase, RouteTimetable::empty, false, true);
+		this(routeSearchUseCase, RouteTimetable::empty, false, true, new SimpleMeterRegistry());
 	}
 
 	@Autowired
 	public RouteV2Planner(
 		RouteSearchUseCase routeSearchUseCase,
 		ObjectProvider<LoadRouteTimetablePort> routeTimetablePortProvider,
-		Environment environment
+		Environment environment,
+		MeterRegistry meterRegistry
 	) {
 		this(
 			routeSearchUseCase,
 			routeTimetablePortProvider.getIfAvailable(),
 			true,
-			!environment.acceptsProfiles(Profiles.of("prod", "staging", "release", "prod-like"))
+			!environment.acceptsProfiles(Profiles.of("prod", "staging", "release", "prod-like")),
+			meterRegistry
 		);
 	}
 
 	RouteV2Planner(RouteSearchUseCase routeSearchUseCase, LoadRouteTimetablePort routeTimetablePort) {
-		this(routeSearchUseCase, routeTimetablePort, true, false);
+		this(routeSearchUseCase, routeTimetablePort, true, false, new SimpleMeterRegistry());
+	}
+
+	RouteV2Planner(
+		RouteSearchUseCase routeSearchUseCase,
+		LoadRouteTimetablePort routeTimetablePort,
+		MeterRegistry meterRegistry
+	) {
+		this(routeSearchUseCase, routeTimetablePort, true, false, meterRegistry);
 	}
 
 	private RouteV2Planner(
 		RouteSearchUseCase routeSearchUseCase,
 		LoadRouteTimetablePort routeTimetablePort,
 		boolean timetableRequired,
-		boolean legacyPersistenceAllowed
+		boolean legacyPersistenceAllowed,
+		MeterRegistry meterRegistry
 	) {
 		this.routeSearchUseCase = routeSearchUseCase;
 		this.routeTimetablePort = routeTimetablePort == null ? RouteTimetable::empty : routeTimetablePort;
 		this.timetableRequired = timetableRequired && routeTimetablePort != null;
 		this.legacyPersistenceAllowed = legacyPersistenceAllowed;
+		this.timetableCacheHit = cacheCounter(meterRegistry, "hit");
+		this.timetableCacheMiss = cacheCounter(meterRegistry, "miss");
 	}
 
 	@Override
@@ -189,12 +213,14 @@ public class RouteV2Planner implements RouteV2SearchUseCase {
 		String cacheKey = routeTimetablePort.timetableCacheKey();
 		TimetableSnapshot snapshot = cachedTimetableSnapshot;
 		if (snapshot != null && snapshot.cacheKey().equals(cacheKey)) {
+			recordTimetableCache(timetableCacheHit, timetableCacheHitLogged, "hit", cacheKey);
 			return snapshot;
 		}
 		synchronized (this) {
 			cacheKey = routeTimetablePort.timetableCacheKey();
 			snapshot = cachedTimetableSnapshot;
 			if (snapshot == null || !snapshot.cacheKey().equals(cacheKey)) {
+				recordTimetableCache(timetableCacheMiss, timetableCacheMissLogged, "miss", cacheKey);
 				LoadRouteTimetablePort.RouteTimetableSnapshot loaded = routeTimetablePort.loadRouteTimetableSnapshot();
 				RouteTimetable timetable = loaded.timetable();
 				java.util.Set<String> coveredStationIds = timetable.transitStopTimes().stream()
@@ -208,7 +234,26 @@ public class RouteV2Planner implements RouteV2SearchUseCase {
 				);
 				return cachedTimetableSnapshot;
 			}
+			recordTimetableCache(timetableCacheHit, timetableCacheHitLogged, "hit", cacheKey);
 			return cachedTimetableSnapshot;
+		}
+	}
+
+	private static Counter cacheCounter(MeterRegistry registry, String result) {
+		return Counter.builder("easysubway.route.v2.timetable.cache")
+			.tag("result", result)
+			.register(registry);
+	}
+
+	private static void recordTimetableCache(
+		Counter counter,
+		AtomicBoolean firstLog,
+		String result,
+		String cacheKey
+	) {
+		counter.increment();
+		if (firstLog.compareAndSet(false, true)) {
+			log.info("route V2 timetable cache result={} key={}", result, cacheKey);
 		}
 	}
 

--- a/backend/src/test/java/com/easysubway/SchedulingConfigurationTest.java
+++ b/backend/src/test/java/com/easysubway/SchedulingConfigurationTest.java
@@ -1,0 +1,31 @@
+package com.easysubway;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+@DisplayName("백엔드 scheduling 구성")
+class SchedulingConfigurationTest {
+	private static final String SCHEDULED_PROCESSOR =
+		"org.springframework.context.annotation.internalScheduledAnnotationProcessor";
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withUserConfiguration(EasySubwayBackendApplication.SchedulingConfiguration.class);
+
+	@Test
+	@DisplayName("기본값은 scheduling을 활성화한다")
+	void enablesSchedulingByDefault() {
+		contextRunner.run(context -> assertThat(context).hasBean(SCHEDULED_PROCESSOR));
+	}
+
+	@Test
+	@DisplayName("운영 증거 컨테이너는 scheduling을 비활성화할 수 있다")
+	void disablesSchedulingForEvidenceContainer() {
+		contextRunner
+			.withPropertyValues("easysubway.scheduling.enabled=false")
+			.run(context -> assertThat(context).doesNotHaveBean(SCHEDULED_PROCESSOR));
+	}
+
+}

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -66,6 +66,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -1598,12 +1599,17 @@ class RouteSearchServiceTest {
 		var repository = new InMemoryRouteSearchRepository();
 		var routeSearchService = new RouteSearchService(repository, repository, new RampAccessibleTransitMasterPort(), CLOCK);
 		var timetablePort = new CountingRouteTimetablePort();
-		var planner = new RouteV2Planner(routeSearchService, timetablePort);
+		var registry = new SimpleMeterRegistry();
+		var planner = new RouteV2Planner(routeSearchService, timetablePort, registry);
 
 		planner.search(routeV2Command(ConstraintMode.PREFER_STEP_FREE, MobilityType.SENIOR, 1, 3));
 		planner.search(routeV2Command(ConstraintMode.PREFER_STEP_FREE, MobilityType.SENIOR, 1, 3));
 
 		assertThat(timetablePort.loadCount()).isEqualTo(1);
+		assertThat(registry.get("easysubway.route.v2.timetable.cache")
+			.tag("result", "miss").counter().count()).isEqualTo(1);
+		assertThat(registry.get("easysubway.route.v2.timetable.cache")
+			.tag("result", "hit").counter().count()).isEqualTo(1);
 	}
 
 	@Test

--- a/tools/ci/production-timetable-snapshot-evidence-workflow.test.mjs
+++ b/tools/ci/production-timetable-snapshot-evidence-workflow.test.mjs
@@ -15,6 +15,7 @@ const applicationPath = "backend/src/main/java/com/easysubway/EasySubwayBackendA
 test("production timetable evidence는 exact deploy에서 cache와 격리 rollback을 검증한다", async () => {
   const workflow = await readFile(workflowPath, "utf8");
   const script = await readFile(scriptPath, "utf8");
+  const candidate = await readFile(candidatePath, "utf8");
   const application = await readFile(applicationPath, "utf8");
 
   assert.match(workflow, /workflow_dispatch:/);
@@ -66,6 +67,12 @@ test("production timetable evidence는 exact deploy에서 cache와 격리 rollba
   assert.match(script, /transit_stop_times/);
   assert.match(script, /fingerprint_before[^\n]+!=[^\n]+fingerprint_after/);
   assert.doesNotMatch(script, /docker pull|curl .*(github|aquilaxk\.site)/);
+  assert.match(candidate, /repositoryRoot/);
+  assert.match(candidate, /RUNNER_TEMP/);
+  assert.match(candidate, /tmpdir\(\)/);
+  assert.match(candidate, /realpath/);
+  assert.match(candidate, /path\.relative/);
+  assert.match(candidate, /path escapes allowed root/);
 });
 
 test("rollback 후보는 현재 seed를 다른 immutable identity로 만든다", async () => {

--- a/tools/ci/production-timetable-snapshot-evidence-workflow.test.mjs
+++ b/tools/ci/production-timetable-snapshot-evidence-workflow.test.mjs
@@ -31,6 +31,10 @@ test("production timetable evidence는 exact deploy에서 cache와 격리 rollba
   assert.match(script, /current_sha[^\n]+!=[^\n]+EXPECTED_DEPLOYED_SHA/);
   assert.match(script, /runtime_config_image[^\n]+backend_image/);
   assert.match(script, /runtime_image_id[^\n]+expected_image_id/);
+  assert.match(script, /shared\/current-image-digest/);
+  assert.match(script, /current_image_digest[^\n]+\^sha256:/);
+  assert.match(script, /ghcr\.io\/aquilaxk\/easysubway-backend@\$\{current_image_digest\}/);
+  assert.match(script, /RepoDigests/);
   assert.match(script, /timetable_snapshot_active/);
   assert.match(script, /history\.fresh_until::timestamptz/);
   assert.match(script, /fresh_until::timestamptz > CURRENT_TIMESTAMP/);

--- a/tools/ci/production-timetable-snapshot-evidence-workflow.test.mjs
+++ b/tools/ci/production-timetable-snapshot-evidence-workflow.test.mjs
@@ -63,6 +63,15 @@ test("production timetable evidence는 exact deploy에서 cache와 격리 rollba
   assert.match(script, /curl[^\n]+"\$\{cache_base_url\}/);
   assert.doesNotMatch(script, /docker exec[^\n]+"\$\{cache_app\}"[^\n]+curl/);
   assert.match(application, /@ConditionalOnProperty\([\s\S]*prefix = "easysubway\.scheduling"[\s\S]*matchIfMissing = true[\s\S]*@EnableScheduling/);
+  assert.match(script, /pg_database_size\(current_database\(\)\)/);
+  assert.match(script, /docker info --format '\{\{\.DockerRootDir\}\}'/);
+  assert.match(script, /df -Pk/);
+  assert.match(script, /database_size_bytes \* 4 \+ 2147483648/);
+  assert.match(script, /dump_available_bytes[\s\S]*docker_available_bytes/);
+  const capacityPreflight = script.indexOf('database_size_bytes="$(production_psql');
+  assert.ok(capacityPreflight > 0);
+  assert.ok(capacityPreflight < script.indexOf("pg_dump --format=custom"));
+  assert.ok(capacityPreflight < script.indexOf('docker volume create "${volume}"'));
   assert.match(script, /pg_dump --format=custom/);
   assert.match(script, /pg_restore --clean --if-exists --no-owner --no-privileges/);
   assert.match(script, /issue_2145_reject_trip/);

--- a/tools/ci/production-timetable-snapshot-evidence-workflow.test.mjs
+++ b/tools/ci/production-timetable-snapshot-evidence-workflow.test.mjs
@@ -76,14 +76,15 @@ test("production timetable evidence는 exact deploy에서 cache와 격리 rollba
 });
 
 test("rollback 후보는 현재 seed를 다른 immutable identity로 만든다", async () => {
-  const output = await mkdtemp(path.join(tmpdir(), "issue-2145-candidate-"));
+  const runnerTemp = await mkdtemp(path.join(tmpdir(), "issue-2145-runner-"));
+  const output = path.join(runnerTemp, "candidate");
   try {
     execFileSync("node", [
       candidatePath,
       "backend/src/main/resources/timetable/line4-timetable-seed.sql.gz",
       "backend/src/main/resources/timetable/server-timetable-snapshot-evidence.json",
       output,
-    ]);
+    ], { env: { ...process.env, RUNNER_TEMP: runnerTemp } });
     const original = JSON.parse(await readFile(
       "backend/src/main/resources/timetable/server-timetable-snapshot-evidence.json",
       "utf8",
@@ -117,6 +118,6 @@ test("rollback 후보는 현재 seed를 다른 immutable identity로 만든다",
       { stdio: "pipe" },
     ));
   } finally {
-    await rm(output, { recursive: true, force: true });
+    await rm(runnerTemp, { recursive: true, force: true });
   }
 });

--- a/tools/ci/production-timetable-snapshot-evidence-workflow.test.mjs
+++ b/tools/ci/production-timetable-snapshot-evidence-workflow.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -62,6 +62,10 @@ test("production timetable evidence는 exact deploy에서 cache와 격리 rollba
   assert.match(script, /docker port "\$\{cache_app\}" 8080\/tcp/);
   assert.match(script, /curl[^\n]+"\$\{cache_base_url\}/);
   assert.doesNotMatch(script, /docker exec[^\n]+"\$\{cache_app\}"[^\n]+curl/);
+  assert.match(script, /curl_config="\$\{work_dir\}\/cache-request-\$\{attempt\}\.curl-config"/);
+  assert.match(script, /curl --config "\$\{curl_config\}"/);
+  assert.doesNotMatch(script, /--header "X-EasySubway-Origin-Verify: \$\{origin_secret\}"/);
+  assert.doesNotMatch(script, /--header "Authorization: Bearer \$\{session_tokens/);
   assert.match(application, /@ConditionalOnProperty\([\s\S]*prefix = "easysubway\.scheduling"[\s\S]*matchIfMissing = true[\s\S]*@EnableScheduling/);
   assert.match(script, /pg_database_size\(current_database\(\)\)/);
   assert.match(script, /docker info --format '\{\{\.DockerRootDir\}\}'/);
@@ -118,18 +122,14 @@ test("rollback 후보는 현재 seed를 다른 immutable identity로 만든다",
     assert.equal(candidate.snapshotGzipSha256, createHash("sha256").update(compressed).digest("hex"));
     assert.equal(evidenceHash, createHash("sha256").update(JSON.stringify(withoutHash)).digest("hex"));
 
-    const tamperedEvidence = path.join(output, "tampered-evidence.json");
-    await writeFile(tamperedEvidence, JSON.stringify({ ...original, snapshotSha256: "0".repeat(64) }));
-    assert.throws(() => execFileSync(
-      "node",
-      [
-        candidatePath,
-        "backend/src/main/resources/timetable/line4-timetable-seed.sql.gz",
-        tamperedEvidence,
-        output,
-      ],
-      { stdio: "pipe" },
-    ));
+    const { validateRollbackSourceIntegrity } = await import("../ops/prepare-timetable-rollback-candidate.mjs");
+    assert.throws(
+      () => validateRollbackSourceIntegrity(
+        seed,
+        Buffer.from(JSON.stringify({ ...original, snapshotSha256: "0".repeat(64) })),
+      ),
+      /seed and evidence integrity check failed/,
+    );
   } finally {
     await rm(runnerTemp, { recursive: true, force: true });
   }

--- a/tools/ci/production-timetable-snapshot-evidence-workflow.test.mjs
+++ b/tools/ci/production-timetable-snapshot-evidence-workflow.test.mjs
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { gunzipSync } from "node:zlib";
+
+const workflowPath = ".github/workflows/production-timetable-snapshot-evidence.yml";
+const scriptPath = "tools/ops/verify-production-timetable-snapshot.sh";
+const candidatePath = "tools/ops/prepare-timetable-rollback-candidate.mjs";
+const applicationPath = "backend/src/main/java/com/easysubway/EasySubwayBackendApplication.java";
+
+test("production timetable evidence는 exact deploy에서 cache와 격리 rollback을 검증한다", async () => {
+  const workflow = await readFile(workflowPath, "utf8");
+  const script = await readFile(scriptPath, "utf8");
+  const application = await readFile(applicationPath, "utf8");
+
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.match(workflow, /GITHUB_REF[^\n]+refs\/heads\/main[\s\S]*exit 1/);
+  assert.doesNotMatch(workflow, /if: github\.ref == 'refs\/heads\/main'/);
+  assert.match(workflow, /runs-on:\n\s+- self-hosted\n\s+- easysubway-production/);
+  assert.match(workflow, /environment: production/);
+  assert.match(workflow, /EXPECTED_DEPLOYED_SHA: \$\{\{ github\.sha \}\}/);
+  assert.match(workflow, /bash tools\/ops\/verify-production-timetable-snapshot\.sh/);
+  assert.doesNotMatch(workflow, /pull_request|upload-artifact/);
+
+  assert.match(script, /flock -w 300 9/);
+  assert.match(script, /current_sha[^\n]+!=[^\n]+EXPECTED_DEPLOYED_SHA/);
+  assert.match(script, /runtime_config_image[^\n]+backend_image/);
+  assert.match(script, /runtime_image_id[^\n]+expected_image_id/);
+  assert.match(script, /timetable_snapshot_active/);
+  assert.match(script, /history\.fresh_until::timestamptz/);
+  assert.match(script, /fresh_until::timestamptz > CURRENT_TIMESTAMP/);
+  assert.doesNotMatch(script, /history\.schema_identity, history\.fresh_until/);
+  assert.match(script, /replace\(\/\\\.\\d\{3\}Z\$\/, "Z"\)/);
+  assert.match(script, /active_identity[^\n]+!=[^\n]+expected_identity/);
+  assert.match(script, /history\.source_artifact_sha256/);
+  assert.match(script, /history\.completeness_evidence_sha256/);
+  assert.match(script, /history\.canonical_pack_sha256/);
+  assert.match(script, /history\.canonical_pack_sqlite_sha256/);
+  assert.match(script, /history\.canonical_station_set_sha256/);
+  assert.match(script, /history\.source_lineage_sha256/);
+  assert.match(script, /history\.evidence_hash/);
+  assert.match(script, /routeServiceEvidence/);
+  assert.match(script, /route V2 timetable cache result=miss/);
+  assert.match(script, /route V2 timetable cache result=hit/);
+  assert.match(script, /randomBytes\(32\)\.toString\("base64url"\)/);
+  assert.match(script, /session_hashes/);
+  assert.match(script, /deleted_session_count/);
+  assert.match(script, /route_state_ids/);
+  assert.match(script, /DELETE FROM route_v2_states/);
+  assert.doesNotMatch(script, /printf -v session_token/);
+  assert.match(script, /EASYSUBWAY_SCHEDULING_ENABLED=false/);
+  assert.match(script, /--publish 127\.0\.0\.1::8080/);
+  assert.match(script, /docker port "\$\{cache_app\}" 8080\/tcp/);
+  assert.match(script, /curl[^\n]+"\$\{cache_base_url\}/);
+  assert.doesNotMatch(script, /docker exec[^\n]+"\$\{cache_app\}"[^\n]+curl/);
+  assert.match(application, /@ConditionalOnProperty\([\s\S]*prefix = "easysubway\.scheduling"[\s\S]*matchIfMissing = true[\s\S]*@EnableScheduling/);
+  assert.match(script, /pg_dump --format=custom/);
+  assert.match(script, /pg_restore --clean --if-exists --no-owner --no-privileges/);
+  assert.match(script, /issue_2145_reject_trip/);
+  assert.match(script, /prepare-timetable-rollback-candidate\.mjs/);
+  assert.match(script, /row_to_json/);
+  assert.match(script, /transit_stop_times/);
+  assert.match(script, /fingerprint_before[^\n]+!=[^\n]+fingerprint_after/);
+  assert.doesNotMatch(script, /docker pull|curl .*(github|aquilaxk\.site)/);
+});
+
+test("rollback 후보는 현재 seed를 다른 immutable identity로 만든다", async () => {
+  const output = await mkdtemp(path.join(tmpdir(), "issue-2145-candidate-"));
+  try {
+    execFileSync("node", [
+      candidatePath,
+      "backend/src/main/resources/timetable/line4-timetable-seed.sql.gz",
+      "backend/src/main/resources/timetable/server-timetable-snapshot-evidence.json",
+      output,
+    ]);
+    const original = JSON.parse(await readFile(
+      "backend/src/main/resources/timetable/server-timetable-snapshot-evidence.json",
+      "utf8",
+    ));
+    const candidate = JSON.parse(await readFile(path.join(output, "evidence.json"), "utf8"));
+    const seed = await readFile("backend/src/main/resources/timetable/line4-timetable-seed.sql.gz");
+    const compressed = await readFile(path.join(output, "candidate.sql.gz"));
+    const sqlBytes = gunzipSync(compressed);
+    const expectedSql = Buffer.concat([gunzipSync(seed), Buffer.from("SELECT 1;\n")]);
+    const sql = sqlBytes.toString("utf8");
+    const { evidenceHash, ...withoutHash } = candidate;
+
+    assert.deepEqual(sqlBytes, expectedSql);
+    assert.notEqual(candidate.snapshotSha256, original.snapshotSha256);
+    assert.match(candidate.snapshotId, /^server-timetable-snapshot-[0-9a-f]{16}$/);
+    assert.match(sql, /SELECT 1;\n$/);
+    assert.equal(candidate.snapshotSha256, createHash("sha256").update(sqlBytes).digest("hex"));
+    assert.equal(candidate.snapshotGzipSha256, createHash("sha256").update(compressed).digest("hex"));
+    assert.equal(evidenceHash, createHash("sha256").update(JSON.stringify(withoutHash)).digest("hex"));
+
+    const tamperedEvidence = path.join(output, "tampered-evidence.json");
+    await writeFile(tamperedEvidence, JSON.stringify({ ...original, snapshotSha256: "0".repeat(64) }));
+    assert.throws(() => execFileSync(
+      "node",
+      [
+        candidatePath,
+        "backend/src/main/resources/timetable/line4-timetable-seed.sql.gz",
+        tamperedEvidence,
+        output,
+      ],
+      { stdio: "pipe" },
+    ));
+  } finally {
+    await rm(output, { recursive: true, force: true });
+  }
+});

--- a/tools/ops/prepare-timetable-rollback-candidate.mjs
+++ b/tools/ops/prepare-timetable-rollback-candidate.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { gunzipSync, gzipSync } from "node:zlib";
+
+const sha256 = (value) => createHash("sha256").update(value).digest("hex");
+
+export async function prepareRollbackCandidate(seedPath, evidencePath, outputDirectory) {
+  const [seed, evidenceBytes] = await Promise.all([readFile(seedPath), readFile(evidencePath)]);
+  const evidence = JSON.parse(evidenceBytes);
+  if (evidence.artifactKind !== "server-timetable-snapshot-evidence") {
+    throw new Error("unexpected timetable snapshot evidence");
+  }
+
+  const sourceSql = gunzipSync(seed);
+  const { evidenceHash: sourceEvidenceHash, ...sourceEvidence } = evidence;
+  if (
+    evidence.snapshotSha256 !== sha256(sourceSql) ||
+    evidence.snapshotGzipSha256 !== sha256(seed) ||
+    evidence.snapshotSqlByteSize !== sourceSql.length ||
+    evidence.snapshotGzipByteSize !== seed.length ||
+    sourceEvidenceHash !== sha256(Buffer.from(JSON.stringify(sourceEvidence)))
+  ) {
+    throw new Error("seed and evidence integrity check failed");
+  }
+
+  const sql = Buffer.concat([sourceSql, Buffer.from("SELECT 1;\n")]);
+  const compressed = gzipSync(sql, { level: 9, mtime: 0 });
+  evidence.snapshotSha256 = sha256(sql);
+  evidence.snapshotId = `server-timetable-snapshot-${evidence.snapshotSha256.slice(0, 16)}`;
+  evidence.snapshotSqlByteSize = sql.length;
+  evidence.snapshotGzipSha256 = sha256(compressed);
+  evidence.snapshotGzipByteSize = compressed.length;
+  delete evidence.evidenceHash;
+  evidence.evidenceHash = sha256(Buffer.from(JSON.stringify(evidence)));
+
+  await mkdir(outputDirectory, { recursive: true });
+  await Promise.all([
+    writeFile(path.join(outputDirectory, "candidate.sql.gz"), compressed),
+    writeFile(path.join(outputDirectory, "evidence.json"), `${JSON.stringify(evidence, null, 2)}\n`),
+  ]);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const [, , seedPath, evidencePath, outputDirectory] = process.argv;
+  if (!seedPath || !evidencePath || !outputDirectory) {
+    throw new Error("usage: prepare-timetable-rollback-candidate.mjs <seed.gz> <evidence.json> <output-dir>");
+  }
+  await prepareRollbackCandidate(seedPath, evidencePath, outputDirectory);
+}

--- a/tools/ops/prepare-timetable-rollback-candidate.mjs
+++ b/tools/ops/prepare-timetable-rollback-candidate.mjs
@@ -1,13 +1,50 @@
 #!/usr/bin/env node
 import { createHash } from "node:crypto";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, realpath, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { gunzipSync, gzipSync } from "node:zlib";
 
 const sha256 = (value) => createHash("sha256").update(value).digest("hex");
+const repositoryRoot = path.resolve(import.meta.dirname, "../..");
+const allowedSeedPath = path.join(repositoryRoot, "backend/src/main/resources/timetable/line4-timetable-seed.sql.gz");
+const allowedEvidencePath = path.join(repositoryRoot, "backend/src/main/resources/timetable/server-timetable-snapshot-evidence.json");
+
+function resolveWithinRoot(root, candidate, label) {
+  const resolved = path.resolve(candidate);
+  const relative = path.relative(root, resolved);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`${label} path escapes allowed root`);
+  }
+  return resolved;
+}
 
 export async function prepareRollbackCandidate(seedPath, evidencePath, outputDirectory) {
-  const [seed, evidenceBytes] = await Promise.all([readFile(seedPath), readFile(evidencePath)]);
+  const resolvedSeedPath = resolveWithinRoot(repositoryRoot, seedPath, "seed");
+  const resolvedEvidencePath = resolveWithinRoot(repositoryRoot, evidencePath, "evidence");
+  if (resolvedSeedPath !== allowedSeedPath || resolvedEvidencePath !== allowedEvidencePath) {
+    throw new Error("rollback candidate inputs must use the checked-in timetable snapshot");
+  }
+  const [canonicalSeedPath, canonicalEvidencePath] = await Promise.all([
+    realpath(resolvedSeedPath),
+    realpath(resolvedEvidencePath),
+  ]);
+  if (canonicalSeedPath !== allowedSeedPath || canonicalEvidencePath !== allowedEvidencePath) {
+    throw new Error("rollback candidate inputs must not use symbolic links");
+  }
+  const outputRoot = path.resolve(process.env.RUNNER_TEMP ?? tmpdir());
+  const resolvedOutputDirectory = resolveWithinRoot(outputRoot, outputDirectory, "output");
+  await mkdir(resolvedOutputDirectory, { recursive: true });
+  const [canonicalOutputRoot, canonicalOutputDirectory] = await Promise.all([
+    realpath(outputRoot),
+    realpath(resolvedOutputDirectory),
+  ]);
+  resolveWithinRoot(canonicalOutputRoot, canonicalOutputDirectory, "output");
+
+  const [seed, evidenceBytes] = await Promise.all([
+    readFile(canonicalSeedPath),
+    readFile(canonicalEvidencePath),
+  ]);
   const evidence = JSON.parse(evidenceBytes);
   if (evidence.artifactKind !== "server-timetable-snapshot-evidence") {
     throw new Error("unexpected timetable snapshot evidence");
@@ -35,10 +72,9 @@ export async function prepareRollbackCandidate(seedPath, evidencePath, outputDir
   delete evidence.evidenceHash;
   evidence.evidenceHash = sha256(Buffer.from(JSON.stringify(evidence)));
 
-  await mkdir(outputDirectory, { recursive: true });
   await Promise.all([
-    writeFile(path.join(outputDirectory, "candidate.sql.gz"), compressed),
-    writeFile(path.join(outputDirectory, "evidence.json"), `${JSON.stringify(evidence, null, 2)}\n`),
+    writeFile(path.join(canonicalOutputDirectory, "candidate.sql.gz"), compressed, { flag: "wx" }),
+    writeFile(path.join(canonicalOutputDirectory, "evidence.json"), `${JSON.stringify(evidence, null, 2)}\n`, { flag: "wx" }),
   ]);
 }
 

--- a/tools/ops/prepare-timetable-rollback-candidate.mjs
+++ b/tools/ops/prepare-timetable-rollback-candidate.mjs
@@ -19,6 +19,26 @@ function resolveWithinRoot(root, candidate, label) {
   return resolved;
 }
 
+export function validateRollbackSourceIntegrity(seed, evidenceBytes) {
+  const evidence = JSON.parse(evidenceBytes);
+  if (evidence.artifactKind !== "server-timetable-snapshot-evidence") {
+    throw new Error("unexpected timetable snapshot evidence");
+  }
+
+  const sourceSql = gunzipSync(seed);
+  const { evidenceHash: sourceEvidenceHash, ...sourceEvidence } = evidence;
+  if (
+    evidence.snapshotSha256 !== sha256(sourceSql) ||
+    evidence.snapshotGzipSha256 !== sha256(seed) ||
+    evidence.snapshotSqlByteSize !== sourceSql.length ||
+    evidence.snapshotGzipByteSize !== seed.length ||
+    sourceEvidenceHash !== sha256(Buffer.from(JSON.stringify(sourceEvidence)))
+  ) {
+    throw new Error("seed and evidence integrity check failed");
+  }
+  return { evidence, sourceSql };
+}
+
 export async function prepareRollbackCandidate(seedPath, evidencePath, outputDirectory) {
   const resolvedSeedPath = resolveWithinRoot(repositoryRoot, seedPath, "seed");
   const resolvedEvidencePath = resolveWithinRoot(repositoryRoot, evidencePath, "evidence");
@@ -45,22 +65,7 @@ export async function prepareRollbackCandidate(seedPath, evidencePath, outputDir
     readFile(canonicalSeedPath),
     readFile(canonicalEvidencePath),
   ]);
-  const evidence = JSON.parse(evidenceBytes);
-  if (evidence.artifactKind !== "server-timetable-snapshot-evidence") {
-    throw new Error("unexpected timetable snapshot evidence");
-  }
-
-  const sourceSql = gunzipSync(seed);
-  const { evidenceHash: sourceEvidenceHash, ...sourceEvidence } = evidence;
-  if (
-    evidence.snapshotSha256 !== sha256(sourceSql) ||
-    evidence.snapshotGzipSha256 !== sha256(seed) ||
-    evidence.snapshotSqlByteSize !== sourceSql.length ||
-    evidence.snapshotGzipByteSize !== seed.length ||
-    sourceEvidenceHash !== sha256(Buffer.from(JSON.stringify(sourceEvidence)))
-  ) {
-    throw new Error("seed and evidence integrity check failed");
-  }
+  const { evidence, sourceSql } = validateRollbackSourceIntegrity(seed, evidenceBytes);
 
   const sql = Buffer.concat([sourceSql, Buffer.from("SELECT 1;\n")]);
   const compressed = gzipSync(sql, { level: 9, mtime: 0 });

--- a/tools/ops/verify-production-timetable-snapshot.sh
+++ b/tools/ops/verify-production-timetable-snapshot.sh
@@ -1,0 +1,341 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+umask 077
+
+DEPLOY_ROOT="${DEPLOY_ROOT:-/opt/easysubway}"
+EXPECTED_DEPLOYED_SHA="${EXPECTED_DEPLOYED_SHA:?EXPECTED_DEPLOYED_SHA is required}"
+[[ "${EXPECTED_DEPLOYED_SHA}" =~ ^[0-9a-f]{40}$ ]] || { echo 'expected deployed SHA is invalid' >&2; exit 2; }
+
+exec 9>"${DEPLOY_ROOT}/deploy.lock"
+flock -w 300 9 || { echo 'timed out waiting for deployment lock' >&2; exit 1; }
+
+current_sha="$(<"${DEPLOY_ROOT}/shared/current-sha")"
+if [[ "${current_sha}" != "${EXPECTED_DEPLOYED_SHA}" ]]; then
+	echo 'current_sha != EXPECTED_DEPLOYED_SHA' >&2
+	exit 1
+fi
+
+backend_image="easysubway-backend:${current_sha}"
+image_revision="$(docker image inspect --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' "${backend_image}")"
+[[ "${image_revision}" == "${current_sha}" ]] || { echo 'backend image revision mismatch' >&2; exit 1; }
+expected_image_id="$(docker image inspect --format '{{.Id}}' "${backend_image}")"
+runtime_config_image="$(docker inspect --format '{{.Config.Image}}' easysubway-backend)"
+runtime_image_id="$(docker inspect --format '{{.Image}}' easysubway-backend)"
+[[ "${runtime_config_image}" == "${backend_image}" ]] || { echo 'running backend image tag mismatch' >&2; exit 1; }
+[[ "${runtime_image_id}" == "${expected_image_id}" ]] || { echo 'running backend image ID mismatch' >&2; exit 1; }
+
+production_psql() {
+	local sql="${1:?SQL is required}"
+	docker exec easysubway-postgres sh -lc \
+		'psql -X -v ON_ERROR_STOP=1 -A -t -F "|" -U "$POSTGRES_USER" "$POSTGRES_DB" -c "$1"' sh "${sql}"
+}
+
+identity_sql="
+SELECT active.snapshot_sha256, history.snapshot_id, history.schema_identity,
+  history.source_artifact_id, history.source_artifact_sha256, history.completeness_evidence_sha256,
+  history.canonical_pack_sha256, history.canonical_pack_sqlite_sha256,
+  history.canonical_station_version, history.canonical_station_set_sha256, history.canonical_station_member_count,
+  history.source_lineage_sha256, history.evidence_hash,
+  (SELECT COUNT(*) FROM service_calendars),
+  (SELECT COUNT(*) FROM transit_routes),
+  (SELECT COUNT(*) FROM transit_trips),
+  (SELECT COUNT(*) FROM transit_stop_times),
+  (SELECT COUNT(*) FROM transit_trips WHERE service_class = 'SUBWAY'),
+  (SELECT COUNT(*) FROM transit_stop_times stops JOIN transit_trips trips ON trips.id = stops.trip_id WHERE trips.service_class = 'SUBWAY'),
+  (SELECT COUNT(*) FROM transit_trips WHERE service_class = 'ITX_CHEONGCHUN'),
+  (SELECT COUNT(*) FROM transit_stop_times stops JOIN transit_trips trips ON trips.id = stops.trip_id WHERE trips.service_class = 'ITX_CHEONGCHUN'),
+  (SELECT COUNT(*) FROM route_service_artifact_evidence evidence
+    WHERE evidence.service_class = 'ITX_CHEONGCHUN'
+      AND evidence.timetable_artifact_id = history.source_artifact_id
+      AND evidence.timetable_artifact_sha256 = history.source_artifact_sha256
+      AND evidence.canonical_pack_sha256 = history.canonical_pack_sha256
+      AND evidence.canonical_pack_sqlite_sha256 = history.canonical_pack_sqlite_sha256
+      AND evidence.admission_status = 'ADMITTED' AND evidence.admission_eligible = TRUE
+      AND evidence.fresh_until = history.fresh_until AND evidence.source_issue = 2135),
+  TO_CHAR(history.fresh_until::timestamptz AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"')
+FROM timetable_snapshot_active active
+JOIN timetable_snapshot_history history ON history.snapshot_sha256 = active.snapshot_sha256
+WHERE active.singleton_id = 1 AND history.fresh_until::timestamptz > CURRENT_TIMESTAMP;"
+active_identity="$(production_psql "${identity_sql}")"
+expected_identity="$(node -e '
+const evidence = JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8"));
+const rows = evidence.rowCounts;
+process.stdout.write([
+  evidence.snapshotSha256, evidence.snapshotId, evidence.schemaIdentity,
+  evidence.sourceArtifact.id, evidence.sourceArtifact.sha256, evidence.sourceArtifact.completenessEvidenceSha256,
+  evidence.canonicalPackIdentity.sha256, evidence.canonicalPackIdentity.sqliteSha256,
+  evidence.canonicalStationSet.version, evidence.canonicalStationSet.sha256, evidence.canonicalStationSet.memberCount,
+  evidence.sourceLineageSha256, evidence.evidenceHash,
+  rows.calendars, rows.routes, rows.trips, rows.stopTimes,
+  rows.subwayTrips, rows.subwayStopTimes, rows.itxTrips, rows.itxStopTimes,
+  rows.routeServiceEvidence,
+  new Date(evidence.freshUntil).toISOString().replace(/\.\d{3}Z$/, "Z"),
+].join("|"));
+' backend/src/main/resources/timetable/server-timetable-snapshot-evidence.json)"
+if [[ "${active_identity}" != "${expected_identity}" ]]; then
+	echo 'active timetable snapshot does not match checked-in evidence' >&2
+	exit 1
+fi
+IFS='|' read -r snapshot_sha snapshot_id schema_identity source_artifact_id source_artifact_sha completeness_evidence_sha canonical_pack_sha canonical_pack_sqlite_sha canonical_station_version canonical_station_set_sha canonical_station_member_count source_lineage_sha evidence_hash calendar_count route_count trip_count stop_time_count subway_trip_count subway_stop_time_count itx_trip_count itx_stop_time_count route_service_evidence_count fresh_until <<< "${active_identity}"
+[[ "${snapshot_sha}" =~ ^[0-9a-f]{64}$ && "${snapshot_id}" == server-timetable-snapshot-* ]] \
+	|| { echo 'fresh active timetable snapshot identity is missing' >&2; exit 1; }
+for count in "${calendar_count}" "${route_count}" "${trip_count}" "${stop_time_count}" "${subway_trip_count}" "${subway_stop_time_count}" "${itx_trip_count}" "${itx_stop_time_count}" "${route_service_evidence_count}"; do
+	[[ "${count}" =~ ^[0-9]+$ ]] || { echo 'active timetable row count is invalid' >&2; exit 1; }
+done
+
+run_id="${GITHUB_RUN_ID:-$$}"
+run_attempt="${GITHUB_RUN_ATTEMPT:-1}"
+[[ "${run_id}" =~ ^[0-9]+$ && "${run_attempt}" =~ ^[0-9]+$ ]] || { echo 'run identity is invalid' >&2; exit 2; }
+session_tokens=()
+session_hashes=()
+for _ in 1 2; do
+	session_token="$(node -e 'process.stdout.write(require("node:crypto").randomBytes(32).toString("base64url"))')"
+	[[ "${session_token}" =~ ^[A-Za-z0-9_-]{43}$ ]] || { echo 'session token is invalid' >&2; exit 1; }
+	if command -v sha256sum >/dev/null 2>&1; then
+		session_hash="$(printf '%s' "${session_token}" | sha256sum | cut -d ' ' -f 1)"
+	else
+		session_hash="$(printf '%s' "${session_token}" | shasum -a 256 | cut -d ' ' -f 1)"
+	fi
+	[[ "${session_hash}" =~ ^[0-9a-f]{64}$ ]] || { echo 'session hash is invalid' >&2; exit 1; }
+	session_tokens+=("${session_token}")
+	session_hashes+=("${session_hash}")
+done
+[[ "${session_hashes[0]}" != "${session_hashes[1]}" ]] || { echo 'session hashes must be unique' >&2; exit 1; }
+unset session_token session_hash
+
+work_dir="$(mktemp -d "${RUNNER_TEMP:-/tmp}/issue-2145-evidence.XXXXXX")"
+network="easysubway-2145-${run_id}-${run_attempt}"
+volume="${network}"
+clone_db="${network}-db"
+candidate_app="${network}-candidate"
+cache_app="${network}-cache"
+sessions_created=false
+route_state_ids=()
+cleanup() {
+	if [[ "${sessions_created}" == true ]]; then
+		production_psql "DELETE FROM route_v2_sessions WHERE token_sha256 IN ('${session_hashes[0]}', '${session_hashes[1]}');" >/dev/null 2>&1 || true
+	fi
+	for route_state_id in "${route_state_ids[@]}"; do
+		production_psql "DELETE FROM route_v2_states WHERE route_state_id = '${route_state_id}';" >/dev/null 2>&1 || true
+	done
+	docker rm -f "${cache_app}" "${candidate_app}" "${clone_db}" >/dev/null 2>&1 || true
+	docker volume rm "${volume}" >/dev/null 2>&1 || true
+	docker network rm "${network}" >/dev/null 2>&1 || true
+	rm -rf "${work_dir}"
+}
+trap cleanup EXIT
+
+backend_env="${work_dir}/backend.env"
+docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' easysubway-backend > "${backend_env}"
+chmod 600 "${backend_env}"
+production_network="$(docker inspect --format '{{range $name, $_ := .NetworkSettings.Networks}}{{println $name}}{{end}}' easysubway-backend | head -n 1)"
+[[ "${production_network}" =~ ^[A-Za-z0-9_.-]+$ ]] || { echo 'production Docker network is invalid' >&2; exit 1; }
+
+docker run -d --name "${cache_app}" --network "${production_network}" \
+	--cpus 1 --memory 1g --memory-swap 1g --pids-limit 256 \
+	--publish 127.0.0.1::8080 \
+	--env-file "${backend_env}" \
+	-e EASYSUBWAY_SCHEDULING_ENABLED=false \
+	-e EASYSUBWAY_PUSH_EXTERNAL_ENABLED=false \
+	-e EASYSUBWAY_PUSH_DELIVERY_ENABLED=false \
+	"${backend_image}" >/dev/null
+cache_binding="$(docker port "${cache_app}" 8080/tcp)"
+[[ "${cache_binding}" =~ ^127\.0\.0\.1:[0-9]+$ ]] || { echo 'controlled cache application port binding is invalid' >&2; exit 1; }
+cache_base_url="http://${cache_binding}"
+origin_secret="$(node -e '
+const lines = require("node:fs").readFileSync(process.argv[1], "utf8").split("\n");
+const entry = lines.find((line) => line.startsWith("EASYSUBWAY_ROUTE_V2_ORIGIN_SECRET="));
+if (!entry) throw new Error("route V2 origin secret is missing");
+process.stdout.write(entry.slice(entry.indexOf("=") + 1));
+' "${backend_env}")"
+[[ -n "${origin_secret}" && "${origin_secret}" != *$'\r'* && "${origin_secret}" != *$'\n'* ]] \
+	|| { echo 'route V2 origin secret is invalid' >&2; exit 1; }
+cache_ready=false
+for _ in $(seq 1 90); do
+	if [[ "$(docker inspect --format '{{.State.Running}}' "${cache_app}" 2>/dev/null || true)" != true ]]; then
+		echo 'controlled cache application stopped before readiness' >&2
+		exit 1
+	fi
+	if [[ "$(curl -sS --noproxy '*' --connect-timeout 1 --max-time 2 -o /dev/null -w '%{http_code}' "${cache_base_url}/actuator/health/readiness" 2>/dev/null || true)" == 200 ]]; then
+		cache_ready=true
+		break
+	fi
+	sleep 1
+done
+[[ "${cache_ready}" == true ]] || { echo 'controlled cache application readiness timed out' >&2; exit 1; }
+
+production_psql "
+INSERT INTO route_v2_sessions (token_sha256, scope, issued_at, expires_at, request_count)
+VALUES
+  ('${session_hashes[0]}', 'route:v2:itx', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP + INTERVAL '10 minutes', 0),
+  ('${session_hashes[1]}', 'route:v2:itx', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP + INTERVAL '10 minutes', 0);" >/dev/null
+sessions_created=true
+
+request_body='{"originStationId":"station-sangnoksu","destinationStationId":"station-sadang","departureTime":"2026-07-16T15:00:00+09:00","mobilityType":"SENIOR","constraintMode":"ALLOW_WITH_WARNINGS","useRealtime":false,"maxTransfers":3,"alternativeCount":1}'
+
+for attempt in 0 1; do
+	response_file="${work_dir}/cache-response-${attempt}.json"
+	status="$(curl -sS --noproxy '*' --connect-timeout 2 --max-time 10 --output "${response_file}" --write-out '%{http_code}' \
+		--request POST --header 'content-type: application/json' \
+		--header "X-EasySubway-Origin-Verify: ${origin_secret}" \
+		--header "Authorization: Bearer ${session_tokens[${attempt}]}" \
+		--data-binary "${request_body}" "${cache_base_url}/api/v2/routes/search")"
+	route_state_id="$(node -e '
+const response = JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8"));
+process.stdout.write(response?.data?.itineraries?.[0]?.itineraryId ?? "");
+' "${response_file}")"
+	if [[ -n "${route_state_id}" ]]; then
+		[[ "${route_state_id}" =~ ^route-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}-primary$ ]] \
+			|| { echo 'controlled route state ID is invalid' >&2; exit 1; }
+		route_state_ids+=("${route_state_id}")
+	fi
+	if [[ "${status}" != 503 ]]; then
+		if [[ -n "${route_state_id}" ]]; then
+			deleted_route_state_count="$(production_psql "WITH deleted AS (DELETE FROM route_v2_states WHERE route_state_id = '${route_state_id}' RETURNING 1) SELECT COUNT(*) FROM deleted;")"
+			[[ "${deleted_route_state_count}" == 1 ]] || { echo 'controlled route state was not deleted exactly' >&2; exit 1; }
+			route_state_ids=()
+		fi
+		echo "controlled timetable request returned ${status}, expected 503" >&2
+		exit 1
+	fi
+done
+unset session_tokens origin_secret
+
+session_uses="$(production_psql "SELECT STRING_AGG(request_count::text, ',' ORDER BY token_sha256) FROM route_v2_sessions WHERE token_sha256 IN ('${session_hashes[0]}', '${session_hashes[1]}');")"
+[[ "${session_uses}" == 1,1 ]] || { echo 'controlled timetable sessions were not consumed exactly once each' >&2; exit 1; }
+cache_logs="$(docker logs "${cache_app}" 2>&1)"
+grep -Fq 'route V2 timetable cache result=miss' <<< "${cache_logs}" \
+	|| { echo 'controlled cache miss evidence is missing' >&2; exit 1; }
+grep -Fq 'route V2 timetable cache result=hit' <<< "${cache_logs}" \
+	|| { echo 'controlled cache hit evidence is missing' >&2; exit 1; }
+
+deleted_session_count="$(production_psql "WITH deleted AS (DELETE FROM route_v2_sessions WHERE token_sha256 IN ('${session_hashes[0]}', '${session_hashes[1]}') RETURNING 1) SELECT COUNT(*) FROM deleted;")"
+[[ "${deleted_session_count}" == 2 ]] || { echo 'controlled timetable sessions were not deleted exactly' >&2; exit 1; }
+sessions_created=false
+
+backup_file="${work_dir}/production.dump"
+docker exec easysubway-postgres sh -lc \
+	'pg_dump --format=custom --no-owner --no-privileges -U "$POSTGRES_USER" "$POSTGRES_DB"' > "${backup_file}"
+[[ -s "${backup_file}" ]] || { echo 'production backup is empty' >&2; exit 1; }
+
+postgres_image="$(docker inspect --format '{{.Image}}' easysubway-postgres)"
+[[ "${postgres_image}" =~ ^sha256:[0-9a-f]{64}$ ]] || { echo 'production PostgreSQL image is invalid' >&2; exit 1; }
+docker network create --internal "${network}" >/dev/null
+docker volume create "${volume}" >/dev/null
+docker run -d --name "${clone_db}" --network "${network}" --network-alias db \
+	--cpus 1 --memory 2g --memory-swap 2g --pids-limit 256 \
+	-v "${volume}:/var/lib/postgresql/data" \
+	-e POSTGRES_DB=easysubway_rehearsal -e POSTGRES_USER=rehearsal -e POSTGRES_PASSWORD=rehearsal_local \
+	"${postgres_image}" >/dev/null
+
+ready=false
+for _ in $(seq 1 60); do
+	if [[ "$(docker exec "${clone_db}" cat /proc/1/comm 2>/dev/null || true)" == postgres ]] \
+		&& docker exec "${clone_db}" pg_isready -U rehearsal -d easysubway_rehearsal >/dev/null 2>&1; then
+		ready=true
+		break
+	fi
+	sleep 1
+done
+[[ "${ready}" == true ]] || { echo 'isolated PostgreSQL readiness timed out' >&2; exit 1; }
+
+docker exec -i "${clone_db}" pg_restore --clean --if-exists --no-owner --no-privileges \
+	-U rehearsal -d easysubway_rehearsal < "${backup_file}"
+clone_psql() {
+	docker exec -i "${clone_db}" psql -X -v ON_ERROR_STOP=1 -A -t -F '|' -U rehearsal -d easysubway_rehearsal "$@"
+}
+clone_identity_sql="
+SELECT active.snapshot_sha256, history.evidence_hash
+FROM timetable_snapshot_active active
+JOIN timetable_snapshot_history history ON history.snapshot_sha256 = active.snapshot_sha256
+WHERE active.singleton_id = 1;"
+clone_identity_before="$(clone_psql -c "${clone_identity_sql}")"
+[[ "${clone_identity_before}" == "${snapshot_sha}|"* ]] || { echo 'restored timetable identity mismatch' >&2; exit 1; }
+
+clone_timetable_fingerprint() {
+	local table
+	if command -v sha256sum >/dev/null 2>&1; then
+		{
+			for table in service_calendars service_calendar_dates transit_feed_info transit_routes transit_trips transit_stop_times transit_frequencies route_service_artifact_evidence timetable_snapshot_active timetable_snapshot_history; do
+				printf '%s\n' "${table}"
+				clone_psql -c "SELECT row_json FROM (SELECT row_to_json(row_value)::text AS row_json FROM ${table} row_value) rows ORDER BY row_json COLLATE \"C\";"
+			done
+		} | sha256sum | cut -d ' ' -f 1
+	else
+		{
+			for table in service_calendars service_calendar_dates transit_feed_info transit_routes transit_trips transit_stop_times transit_frequencies route_service_artifact_evidence timetable_snapshot_active timetable_snapshot_history; do
+				printf '%s\n' "${table}"
+				clone_psql -c "SELECT row_json FROM (SELECT row_to_json(row_value)::text AS row_json FROM ${table} row_value) rows ORDER BY row_json COLLATE \"C\";"
+			done
+		} | shasum -a 256 | cut -d ' ' -f 1
+	fi
+}
+fingerprint_before="$(clone_timetable_fingerprint)"
+[[ "${fingerprint_before}" =~ ^[0-9a-f]{64}$ ]] || { echo 'restored timetable fingerprint is invalid' >&2; exit 1; }
+
+clone_psql >/dev/null <<'SQL'
+CREATE FUNCTION issue_2145_reject_trip() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  RAISE EXCEPTION 'issue 2145 injected trip failure';
+END;
+$$;
+CREATE TRIGGER issue_2145_reject_trip BEFORE INSERT ON transit_trips
+FOR EACH ROW EXECUTE FUNCTION issue_2145_reject_trip();
+SQL
+
+candidate_dir="${work_dir}/candidate"
+node tools/ops/prepare-timetable-rollback-candidate.mjs \
+	backend/src/main/resources/timetable/line4-timetable-seed.sql.gz \
+	backend/src/main/resources/timetable/server-timetable-snapshot-evidence.json \
+	"${candidate_dir}"
+chmod 755 "${work_dir}" "${candidate_dir}"
+chmod 644 "${candidate_dir}/candidate.sql.gz" "${candidate_dir}/evidence.json"
+
+set +e
+timeout 120 docker run --name "${candidate_app}" --network "${network}" \
+	--cpus 1 --memory 1g --memory-swap 1g --pids-limit 256 \
+	--env-file "${backend_env}" \
+	-e SPRING_PROFILES_ACTIVE=prod \
+	-e EASYSUBWAY_DATASOURCE_URL=jdbc:postgresql://db:5432/easysubway_rehearsal \
+	-e EASYSUBWAY_DATASOURCE_USERNAME=rehearsal \
+	-e EASYSUBWAY_DATASOURCE_PASSWORD=rehearsal_local \
+	-e EASYSUBWAY_REPORT_OBJECT_STORAGE_INTERNAL_ENDPOINT=http://127.0.0.1:9 \
+	-e EASYSUBWAY_PUSH_EXTERNAL_ENABLED=false \
+	-e EASYSUBWAY_PUSH_DELIVERY_ENABLED=false \
+	-e EASYSUBWAY_TIMETABLE_SEED_ENABLED=true \
+	-e EASYSUBWAY_TIMETABLE_SEED_INCLUDES_ITX=true \
+	-e EASYSUBWAY_TIMETABLE_SEED_RESOURCE=file:/evidence/candidate.sql.gz \
+	-e EASYSUBWAY_TIMETABLE_SEED_EVIDENCE_RESOURCE=file:/evidence/evidence.json \
+	-v "${candidate_dir}:/evidence:ro" \
+	"${backend_image}" > "${work_dir}/candidate.log" 2>&1
+candidate_exit=$?
+set -e
+[[ "${candidate_exit}" != 0 && "${candidate_exit}" != 124 ]] \
+	|| { echo 'injected activation did not fail closed' >&2; exit 1; }
+grep -Fq 'transit timetable snapshot activation failed' "${work_dir}/candidate.log" \
+	|| { echo 'candidate did not reach timetable activation' >&2; exit 1; }
+grep -Fq 'issue 2145 injected trip failure' "${work_dir}/candidate.log" \
+	|| { echo 'candidate did not reach the injected SQL failure' >&2; exit 1; }
+
+clone_identity_after="$(clone_psql -c "${clone_identity_sql}")"
+[[ "${clone_identity_after}" == "${clone_identity_before}" ]] || { echo 'rollback changed active snapshot identity' >&2; exit 1; }
+fingerprint_after="$(clone_timetable_fingerprint)"
+if [[ "${fingerprint_before}" != "${fingerprint_after}" ]]; then
+	echo 'fingerprint_before != fingerprint_after' >&2
+	exit 1
+fi
+
+{
+	echo '### #2145 production timetable snapshot evidence'
+	echo "- deployed SHA: \`${current_sha}\`"
+	echo "- snapshot: \`${snapshot_id}\` / \`${snapshot_sha}\`"
+	echo "- schema/fresh until: \`${schema_identity}\` / \`${fresh_until}\`"
+	echo "- calendar/route/trip/stop-time rows: \`${calendar_count}/${route_count}/${trip_count}/${stop_time_count}\`"
+	echo "- subway/ITX trips and stop times: \`${subway_trip_count}/${subway_stop_time_count}/${itx_trip_count}/${itx_stop_time_count}\`"
+	echo '- controlled cache: `miss=1+, hit=1+`, two random sessions consumed once each, responses `503/503`'
+	echo '- rollback: production backup isolated restore, injected SQL failure, active identity and aggregate fingerprint unchanged'
+	echo '- production mutation: synthetic sessions inserted and removed; any synthetic route state is tracked and removed; timetable rows read-only'
+} >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+echo 'production timetable snapshot evidence completed'

--- a/tools/ops/verify-production-timetable-snapshot.sh
+++ b/tools/ops/verify-production-timetable-snapshot.sh
@@ -155,7 +155,7 @@ const entry = lines.find((line) => line.startsWith("EASYSUBWAY_ROUTE_V2_ORIGIN_S
 if (!entry) throw new Error("route V2 origin secret is missing");
 process.stdout.write(entry.slice(entry.indexOf("=") + 1));
 ' "${backend_env}")"
-[[ -n "${origin_secret}" && "${origin_secret}" != *$'\r'* && "${origin_secret}" != *$'\n'* ]] \
+[[ "${origin_secret}" =~ ^[A-Za-z0-9_-]{43,128}$ ]] \
 	|| { echo 'route V2 origin secret is invalid' >&2; exit 1; }
 cache_ready=false
 for _ in $(seq 1 90); do
@@ -182,11 +182,16 @@ request_body='{"originStationId":"station-sangnoksu","destinationStationId":"sta
 
 for attempt in 0 1; do
 	response_file="${work_dir}/cache-response-${attempt}.json"
-	status="$(curl -sS --noproxy '*' --connect-timeout 2 --max-time 10 --output "${response_file}" --write-out '%{http_code}' \
+	curl_config="${work_dir}/cache-request-${attempt}.curl-config"
+	{
+		printf 'header = "X-EasySubway-Origin-Verify: %s"\n' "${origin_secret}"
+		printf 'header = "Authorization: Bearer %s"\n' "${session_tokens[${attempt}]}"
+	} > "${curl_config}"
+	chmod 600 "${curl_config}"
+	status="$(curl --config "${curl_config}" -sS --noproxy '*' --connect-timeout 2 --max-time 10 --output "${response_file}" --write-out '%{http_code}' \
 		--request POST --header 'content-type: application/json' \
-		--header "X-EasySubway-Origin-Verify: ${origin_secret}" \
-		--header "Authorization: Bearer ${session_tokens[${attempt}]}" \
 		--data-binary "${request_body}" "${cache_base_url}/api/v2/routes/search")"
+	rm -f "${curl_config}"
 	route_state_id="$(node -e '
 const response = JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8"));
 process.stdout.write(response?.data?.itineraries?.[0]?.itineraryId ?? "");

--- a/tools/ops/verify-production-timetable-snapshot.sh
+++ b/tools/ops/verify-production-timetable-snapshot.sh
@@ -17,8 +17,14 @@ if [[ "${current_sha}" != "${EXPECTED_DEPLOYED_SHA}" ]]; then
 fi
 
 backend_image="easysubway-backend:${current_sha}"
+current_image_digest="$(<"${DEPLOY_ROOT}/shared/current-image-digest")"
+[[ "${current_image_digest}" =~ ^sha256:[0-9a-f]{64}$ ]] \
+	|| { echo 'deployed image digest marker is invalid' >&2; exit 1; }
 image_revision="$(docker image inspect --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' "${backend_image}")"
 [[ "${image_revision}" == "${current_sha}" ]] || { echo 'backend image revision mismatch' >&2; exit 1; }
+image_repo_digests="$(docker image inspect --format '{{join .RepoDigests "\n"}}' "${backend_image}")"
+grep -Fxq "ghcr.io/aquilaxk/easysubway-backend@${current_image_digest}" <<< "${image_repo_digests}" \
+	|| { echo 'backend image immutable digest mismatch' >&2; exit 1; }
 expected_image_id="$(docker image inspect --format '{{.Id}}' "${backend_image}")"
 runtime_config_image="$(docker inspect --format '{{.Config.Image}}' easysubway-backend)"
 runtime_image_id="$(docker inspect --format '{{.Image}}' easysubway-backend)"

--- a/tools/ops/verify-production-timetable-snapshot.sh
+++ b/tools/ops/verify-production-timetable-snapshot.sh
@@ -220,6 +220,27 @@ deleted_session_count="$(production_psql "WITH deleted AS (DELETE FROM route_v2_
 [[ "${deleted_session_count}" == 2 ]] || { echo 'controlled timetable sessions were not deleted exactly' >&2; exit 1; }
 sessions_created=false
 
+available_bytes() {
+	local path="${1:?filesystem path is required}"
+	local available_kib
+	available_kib="$(df -Pk "${path}" | awk 'NR == 2 { print $4 }')"
+	[[ "${available_kib}" =~ ^[0-9]+$ ]] || { echo 'filesystem available capacity is invalid' >&2; exit 1; }
+	printf '%s\n' "$((available_kib * 1024))"
+}
+
+database_size_bytes="$(production_psql 'SELECT pg_database_size(current_database());')"
+[[ "${database_size_bytes}" =~ ^[1-9][0-9]*$ ]] || { echo 'production database size is invalid' >&2; exit 1; }
+required_copy_bytes="$((database_size_bytes * 4 + 2147483648))"
+docker_root_dir="$(docker info --format '{{.DockerRootDir}}')"
+[[ "${docker_root_dir}" =~ ^/[A-Za-z0-9._/-]+$ && "${docker_root_dir}" != *..* && -d "${docker_root_dir}" ]] \
+	|| { echo 'Docker data root is invalid' >&2; exit 1; }
+dump_available_bytes="$(available_bytes "${work_dir}")"
+docker_available_bytes="$(available_bytes "${docker_root_dir}")"
+if (( dump_available_bytes < required_copy_bytes || docker_available_bytes < required_copy_bytes )); then
+	echo 'insufficient capacity for production dump and isolated restore' >&2
+	exit 1
+fi
+
 backup_file="${work_dir}/production.dump"
 docker exec easysubway-postgres sh -lc \
 	'pg_dump --format=custom --no-owner --no-privileges -U "$POSTGRES_USER" "$POSTGRES_DB"' > "${backup_file}"


### PR DESCRIPTION
## 관련 이슈

Refs #2145

## 작업 배경

- #2145의 구현·배포만으로는 운영 active snapshot의 immutable identity/freshness, planner cache miss→hit, 실패 시 rollback 불변성을 한 실행에서 증명할 수 없었습니다.
- 이슈는 운영 증빙 성공 후 닫아야 하므로 이 PR은 자동 종료 키워드를 사용하지 않습니다.

## 작업 내용

- `RouteV2Planner`에 timetable cache hit/miss Micrometer counter와 프로세스당 최초 1회 bounded log를 추가했습니다.
- 증빙용 프로세스에서 모든 `@Scheduled` 실행을 명시적으로 끌 수 있도록 scheduling 구성을 조건부로 분리했습니다.
- exact main/deployed SHA와 실행 이미지, active snapshot 전체 lineage·freshness·row counts를 확인하는 수동 production workflow를 추가했습니다.
- 두 개의 random one-shot session으로 cold miss와 warm hit를 확인하고 synthetic 상태를 명시적으로 정리합니다.
- 운영 백업을 내부 isolated PostgreSQL에 복원한 뒤 의도적 SQL 실패를 주입해 active identity와 timetable 전체 fingerprint가 불변인지 확인합니다.

## 검증

- 실행한 명령과 결과:
  - `backend/gradlew -p backend check --rerun-tasks` — `BUILD SUCCESSFUL` (3m 23s)
  - `node --test tools/ci/*.test.mjs tools/ci/lib/*.test.mjs tools/repo/*.test.mjs` — 336 passed, 0 failed
  - `bash -n tools/ops/verify-production-timetable-snapshot.sh` — 통과
  - `node --check tools/ops/prepare-timetable-rollback-candidate.mjs` — 통과
  - `git diff --check` — 통과
  - `codex review --disable plugins --uncommitted` — actionable finding 0건

## 검증 증거

UI 변경은 없습니다. production evidence는 병합 SHA 배포 후 이 PR이 추가한 workflow 실행 링크와 sanitized step summary로 #2145에 첨부합니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| cache miss→hit | production backend | 동일 snapshot/OD를 독립 프로세스에서 2회 요청 | `production-timetable-snapshot-evidence.yml` step summary | 병합 후 실행 예정 |
| active snapshot lineage/freshness | production PostgreSQL | checked-in evidence 전체 identity와 exact 비교 | 동일 workflow step summary | 병합 후 실행 예정 |
| rollback 불변성 | isolated production backup restore | injected SQL failure 전후 active identity·fingerprint 비교 | 동일 workflow step summary | 병합 후 실행 예정 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 응답 계약 변경 없음; 내부 timetable cache 관측만 추가
- realtime contract: 변경 없음
- backend identity: 병합 SHA를 CD와 production evidence workflow가 exact match로 검증

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 운영 이미지에 `curl`이 없으므로 controlled app은 loopback ephemeral port에 publish하고 runner host에서 probe합니다.
  - production timetable 데이터는 읽기 전용입니다. synthetic Route V2 session과 예외적인 route state만 추적해 명시적으로 삭제합니다.
  - rollback rehearsal은 production DB가 아니라 internal network의 isolated restore에서만 수행합니다.

## 리스크

- production 환경에서 수동 workflow가 synthetic session 두 건을 잠시 생성합니다. exact delete count 확인과 EXIT trap으로 정리합니다.
- workflow는 deploy lock, exact deployed SHA/image ID, main ref, fresh checked-in lineage 중 하나라도 다르면 fail closed합니다.
- 운영 backup을 생성하지만 복원·실패 주입은 isolated Docker network/volume 안에서만 수행합니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
