### PR TITLE
[CI] Route V2 gateway readiness flake 완화

### DIFF
--- a/tools/ci/route-v2-gateway.test.mjs
+++ b/tools/ci/route-v2-gateway.test.mjs
@@ -99,4 +99,8 @@ test("Route V2 gateway runtime integration probe는 privacy·bucket·identifier-
   assert.match(probe, /start_gateway ""/);
   assert.match(probe, /originVerified.*false/);
   assert.match(probe, /\{"requests":13\}/);
+  assert.match(probe, /GATEWAY_READY_ATTEMPTS="\$\{GATEWAY_READY_ATTEMPTS:-100\}"/);
+  assert.match(probe, /gateway readiness timed out/);
+  assert.match(probe, /docker logs "\$GATEWAY" >&2/);
+  assert.match(probe, /docker logs "\$BACKEND" >&2/);
 });

--- a/tools/test/run-route-v2-gateway-integration.sh
+++ b/tools/test/run-route-v2-gateway-integration.sh
@@ -5,6 +5,13 @@ ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
 NETWORK="easysubway-route-v2-gateway-test-$$"
 BACKEND="route-v2-test-backend-$$"
 GATEWAY="route-v2-test-gateway-$$"
+GATEWAY_READY_ATTEMPTS="${GATEWAY_READY_ATTEMPTS:-100}"
+case "$GATEWAY_READY_ATTEMPTS" in
+	''|*[!0-9]*|0)
+		echo "GATEWAY_READY_ATTEMPTS must be a positive integer" >&2
+		exit 2
+		;;
+esac
 
 cleanup() {
 	docker rm -f "$GATEWAY" "$BACKEND" >/dev/null 2>&1 || true
@@ -45,15 +52,22 @@ set_gateway_base() {
 
 wait_gateway() {
 	ready=false
-	for attempt in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+	attempt=1
+	while [ "$attempt" -le "$GATEWAY_READY_ATTEMPTS" ]; do
 		if docker exec "$BACKEND" wget -qO- http://127.0.0.1:8080/probe >/dev/null 2>&1 \
 			&& curl -sS -o /dev/null "$BASE/"; then
 			ready=true
 			break
 		fi
 		sleep 0.2
+		attempt=$((attempt + 1))
 	done
-	[ "$ready" = true ]
+	if [ "$ready" != true ]; then
+		echo "gateway readiness timed out after $GATEWAY_READY_ATTEMPTS attempts" >&2
+		docker logs "$GATEWAY" >&2 || true
+		docker logs "$BACKEND" >&2 || true
+		return 1
+	fi
 }
 
 start_gateway ""


### PR DESCRIPTION
## 관련 이슈

Refs #2145

## 작업 배경

- #2145 운영 증적 수정 병합 후 CI에서 Route V2 gateway 통합 검사가 cold Docker image pull 직후 반복 실패해 CD가 차단됐다.
- 기존 readiness 창은 20회 × 0.2초로 최대 4초이며, backend가 그 안에 준비되지 않으면 원인 로그 없이 종료했다.

## 작업 내용

- gateway/backend readiness 대기를 기본 100회 × 0.2초(최대 20초)로 늘렸다.
- 대기 횟수 입력을 양의 정수로 검증한다.
- timeout 시 gateway와 backend container 로그를 stderr로 남긴다.
- readiness와 실패 진단 계약 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/route-v2-gateway.test.mjs` → 5/5 통과
  - `sh -n tools/test/run-route-v2-gateway-integration.sh` → 통과
  - `tools/test/run-route-v2-gateway-integration.sh` → 로컬 Docker 통합 검사 통과
  - `git diff --check` → 통과

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 반복 flake | GitHub Actions | post-merge CI 재실행 | https://github.com/AquilaXk/easysubway/actions/runs/29519607130 | cold pull 후 gateway 단계 무출력 실패 |
| readiness 계약 | Node 24 | contract test | 로컬 명령 결과 | 5/5 통과 |
| runtime probe | Docker | gateway 통합 script | 로컬 명령 결과 | 통과 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: readiness 상한이 cold runner를 수용하면서 무한 대기가 아니며 timeout 진단에 테스트용 container 로그만 포함하는지 확인해 주세요.

## 리스크

- 실패 감지까지 최대 시간이 4초에서 20초로 늘어난다.
- 제품 runtime, API, DB, 배포 구성은 변경하지 않는다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
