### PR TITLE
[Fix] #2145 운영 증빙 multiline env 전달 수정

### DIFF
--- a/tools/ci/production-timetable-snapshot-evidence-workflow.test.mjs
+++ b/tools/ci/production-timetable-snapshot-evidence-workflow.test.mjs
@@ -59,6 +59,10 @@ test("production timetable evidence는 exact deploy에서 cache와 격리 rollba
   assert.match(script, /DELETE FROM route_v2_states/);
   assert.doesNotMatch(script, /printf -v session_token/);
   assert.match(script, /EASYSUBWAY_SCHEDULING_ENABLED=false/);
+  assert.doesNotMatch(script, /--env-file "\$\{backend_env\}"/);
+  assert.match(script, /backend_env_json="\$\{work_dir\}\/backend-env\.json"/);
+  assert.match(script, /backend_env_args\+=\(--env "\$\{env_name\}"\)/);
+  assert.match(script, /Buffer\.from\(\[0\]\)/);
   assert.match(script, /--publish 127\.0\.0\.1::8080/);
   assert.match(script, /docker port "\$\{cache_app\}" 8080\/tcp/);
   assert.match(script, /curl[^\n]+"\$\{cache_base_url\}/);

--- a/tools/ops/verify-production-timetable-snapshot.sh
+++ b/tools/ops/verify-production-timetable-snapshot.sh
@@ -132,16 +132,48 @@ cleanup() {
 }
 trap cleanup EXIT
 
-backend_env="${work_dir}/backend.env"
-docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' easysubway-backend > "${backend_env}"
-chmod 600 "${backend_env}"
+backend_env_json="${work_dir}/backend-env.json"
+backend_env_nul="${work_dir}/backend-env.nul"
+docker inspect --format '{{json .Config.Env}}' easysubway-backend > "${backend_env_json}"
+chmod 600 "${backend_env_json}"
+node -e '
+const entries = JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8"));
+for (const entry of entries) {
+  const separator = entry.indexOf("=");
+  if (separator < 1) throw new Error("backend environment entry is invalid");
+  process.stdout.write(entry.slice(0, separator));
+  process.stdout.write(Buffer.from([0]));
+  process.stdout.write(entry.slice(separator + 1));
+  process.stdout.write(Buffer.from([0]));
+}
+' "${backend_env_json}" > "${backend_env_nul}"
+chmod 600 "${backend_env_nul}"
+run_backend_clone() (
+	local timeout_seconds="${1:?timeout is required}"
+	shift
+	[[ "${timeout_seconds}" =~ ^[0-9]+$ ]] || { echo 'backend clone timeout is invalid' >&2; exit 2; }
+	local docker_cli timeout_cli env_name env_value
+	local -a backend_env_args=()
+	docker_cli="$(command -v docker)"
+	timeout_cli="$(command -v timeout)"
+	[[ -x "${docker_cli}" && -x "${timeout_cli}" ]] \
+		|| { echo 'backend clone runtime is unavailable' >&2; exit 1; }
+	while IFS= read -r -d '' env_name && IFS= read -r -d '' env_value; do
+		[[ "${env_name}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] \
+			|| { echo 'backend environment name is invalid' >&2; exit 1; }
+		printf -v "${env_name}" '%s' "${env_value}"
+		export "${env_name}"
+		backend_env_args+=(--env "${env_name}")
+	done < "${backend_env_nul}"
+	(( ${#backend_env_args[@]} > 0 )) || { echo 'backend environment is empty' >&2; exit 1; }
+	"${timeout_cli}" "${timeout_seconds}" "${docker_cli}" run "${backend_env_args[@]}" "$@"
+)
 production_network="$(docker inspect --format '{{range $name, $_ := .NetworkSettings.Networks}}{{println $name}}{{end}}' easysubway-backend | head -n 1)"
 [[ "${production_network}" =~ ^[A-Za-z0-9_.-]+$ ]] || { echo 'production Docker network is invalid' >&2; exit 1; }
 
-docker run -d --name "${cache_app}" --network "${production_network}" \
+run_backend_clone 30 -d --name "${cache_app}" --network "${production_network}" \
 	--cpus 1 --memory 1g --memory-swap 1g --pids-limit 256 \
 	--publish 127.0.0.1::8080 \
-	--env-file "${backend_env}" \
 	-e EASYSUBWAY_SCHEDULING_ENABLED=false \
 	-e EASYSUBWAY_PUSH_EXTERNAL_ENABLED=false \
 	-e EASYSUBWAY_PUSH_DELIVERY_ENABLED=false \
@@ -150,11 +182,11 @@ cache_binding="$(docker port "${cache_app}" 8080/tcp)"
 [[ "${cache_binding}" =~ ^127\.0\.0\.1:[0-9]+$ ]] || { echo 'controlled cache application port binding is invalid' >&2; exit 1; }
 cache_base_url="http://${cache_binding}"
 origin_secret="$(node -e '
-const lines = require("node:fs").readFileSync(process.argv[1], "utf8").split("\n");
-const entry = lines.find((line) => line.startsWith("EASYSUBWAY_ROUTE_V2_ORIGIN_SECRET="));
+const entries = JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8"));
+const entry = entries.find((value) => value.startsWith("EASYSUBWAY_ROUTE_V2_ORIGIN_SECRET="));
 if (!entry) throw new Error("route V2 origin secret is missing");
 process.stdout.write(entry.slice(entry.indexOf("=") + 1));
-' "${backend_env}")"
+' "${backend_env_json}")"
 [[ "${origin_secret}" =~ ^[A-Za-z0-9_-]{43,128}$ ]] \
 	|| { echo 'route V2 origin secret is invalid' >&2; exit 1; }
 cache_ready=false
@@ -325,9 +357,8 @@ chmod 755 "${work_dir}" "${candidate_dir}"
 chmod 644 "${candidate_dir}/candidate.sql.gz" "${candidate_dir}/evidence.json"
 
 set +e
-timeout 120 docker run --name "${candidate_app}" --network "${network}" \
+run_backend_clone 120 --name "${candidate_app}" --network "${network}" \
 	--cpus 1 --memory 1g --memory-swap 1g --pids-limit 256 \
-	--env-file "${backend_env}" \
 	-e SPRING_PROFILES_ACTIVE=prod \
 	-e EASYSUBWAY_DATASOURCE_URL=jdbc:postgresql://db:5432/easysubway_rehearsal \
 	-e EASYSUBWAY_DATASOURCE_USERNAME=rehearsal \


### PR DESCRIPTION
## 관련 이슈

Refs #2145

## 작업 배경

- 최신 배포 SHA `abf07e1bb61293fd1b0f49124df9efe4034bafc6`의 운영 증빙 run에서 clone backend 기동 전 Docker가 env file을 거부했다.
- 운영 backend의 multiline public key 환경변수를 줄 단위 `--env-file`로 직렬화하면서 `-----END PUBLIC KEY-----`가 독립 변수명으로 해석된 것이 원인이다.
- 검증은 clone 컨테이너 생성 전에 종료되어 production 데이터 변경은 없었다.

## 작업 내용

- 실행 중인 backend의 환경변수를 JSON으로 읽고 NUL 구분 임시 파일로 변환해 multiline 값을 보존한다.
- clone 컨테이너에는 값이 아닌 환경변수 이름만 `--env`로 전달해 secret이 Docker CLI 명령행에 노출되지 않게 한다.
- cache 검증 컨테이너와 rollback 후보 컨테이너가 같은 전달 함수를 사용하도록 통합한다.
- `--env-file` 회귀를 차단하는 workflow contract test를 추가한다.

## 검증

- 실행한 명령과 결과:
  - 수정 전 `node --test tools/ci/production-timetable-snapshot-evidence-workflow.test.mjs` → 새 `--env-file` 금지 assertion 실패
  - 수정 후 동일 테스트 → 2/2 통과
  - `bash -n tools/ops/verify-production-timetable-snapshot.sh` → 통과
  - `git diff --check` → 통과

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 수정 전 재현 | production evidence | workflow 실패 로그 | https://github.com/AquilaXk/easysubway/actions/runs/29522546661 | Docker multiline env file 거부 재현 |
| 회귀 테스트 | Node 24 | workflow contract test | 로컬 명령 결과 | 2/2 통과 |
| 셸 검증 | Bash | `bash -n` | 로컬 명령 결과 | 통과 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 병합 SHA로 재배포 후 운영 증빙 재실행

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: multiline 값을 NUL 구분으로 보존하는지, secret 값이 Docker CLI argument에 포함되지 않는지 확인해 주세요.

## 리스크

- 운영 timetable 데이터나 DB schema는 변경하지 않는다.
- 임시 JSON/NUL 파일은 권한 600이며 workflow cleanup에서 제거된다.
- 병합·배포 후 동일 SHA의 production evidence workflow를 다시 실행해야 완료된다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
