### PR TITLE
[Fix] 민감 백업 동시 파기 경쟁 조건 제거 (#2231)

### DIFF
--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { execFile, execFileSync } from "node:child_process";
 import { createHash, generateKeyPairSync, sign as signBytes } from "node:crypto";
-import { mkdir, mkdtemp, readFile, rm, symlink, utimes, writeFile } from "node:fs/promises";
+import { lstat as fsLstat, mkdir, mkdtemp, readFile, rm, symlink, utimes, writeFile } from "node:fs/promises";
 import { existsSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -10971,6 +10971,51 @@ test("민감정보 백업 보존 작업은 일일 실행 지연을 포함해 30�
   assert.match(workflow, /--root "\$\{DEPLOY_ROOT\}\/backups"/);
   assert.match(workflow, /--retention-days "30"/);
   assert.match(workflow, /prune-sensitive-backups\.mjs/);
+});
+
+test("민감정보 백업 보존 작업은 동시 파기로 이미 사라진 항목을 건너뛴다", async () => {
+  const pruneScript = path.join(root, "tools/ops/prune-sensitive-backups.mjs");
+  const backupRoot = await mkdtemp(path.join(tmpdir(), "easysubway-sensitive-backup-race-"));
+  const racedDump = path.join(backupRoot, "easysubway-postgres-20260601T000000Z.RACE01.dump");
+  const remainingDump = path.join(backupRoot, "easysubway-postgres-20260601T000001Z.RACE02.dump");
+  await writeFile(racedDump, "removed by concurrent pruner");
+  await writeFile(remainingDump, "removed by this pruner");
+
+  const { pruneSensitiveBackups } = await import(
+    `${pathToFileURL(pruneScript).href}?race=${Date.now()}`
+  );
+  let simulatedRace = false;
+  const pruned = await pruneSensitiveBackups({
+    root: backupRoot,
+    retentionDays: 30,
+    now: Date.parse("2026-07-16T12:00:00Z"),
+    lstat: async (candidate) => {
+      if (!simulatedRace && candidate === racedDump) {
+        simulatedRace = true;
+        await rm(candidate);
+      }
+      return fsLstat(candidate);
+    },
+  });
+
+  assert.equal(simulatedRace, true);
+  assert.equal(pruned, 1);
+  assert.equal(existsSync(racedDump), false);
+  assert.equal(existsSync(remainingDump), false);
+
+  const deniedDump = path.join(backupRoot, "easysubway-postgres-20260601T000002Z.DENIED.dump");
+  await writeFile(deniedDump, "must surface unexpected filesystem errors");
+  await assert.rejects(
+    pruneSensitiveBackups({
+      root: backupRoot,
+      retentionDays: 30,
+      now: Date.parse("2026-07-16T12:00:00Z"),
+      lstat: async () => {
+        throw Object.assign(new Error("metadata access denied"), { code: "EACCES" });
+      },
+    }),
+    /metadata access denied/,
+  );
 });
 
 test("시설 신고 사진 복구 리허설은 manifest와 object 산출물을 검증한다", async () => {

--- a/tools/ops/prune-sensitive-backups.mjs
+++ b/tools/ops/prune-sensitive-backups.mjs
@@ -2,30 +2,10 @@
 
 import { lstat, opendir, rm } from "node:fs/promises";
 import path from "node:path";
-
-const args = new Map();
-for (let index = 2; index < process.argv.length; index += 2) {
-  args.set(process.argv[index], process.argv[index + 1]);
-}
-
-const root = path.resolve(args.get("--root") ?? "");
-const retentionDays = Number(args.get("--retention-days"));
-
-if (!args.get("--root") || root === path.parse(root).root) {
-  throw new Error("--root must be a non-root backup directory");
-}
-if (!Number.isInteger(retentionDays) || retentionDays < 1 || retentionDays > 365) {
-  throw new Error("--retention-days must be an integer from 1 to 365");
-}
+import { fileURLToPath } from "node:url";
 
 const dailySweepIntervalMs = 24 * 60 * 60 * 1000;
-const now = args.has("--now") ? Date.parse(args.get("--now")) : Date.now();
-if (!Number.isFinite(now)) {
-  throw new Error("--now must be a valid ISO-8601 timestamp");
-}
-const cutoff = now - retentionDays * dailySweepIntervalMs + dailySweepIntervalMs;
 const postgresBackup = /^easysubway-postgres-(\d{8}T\d{6}Z)\.[A-Za-z0-9]+\.dump(?:\.sha256)?$/;
-let pruned = 0;
 
 function backupCreatedAt(name, pattern) {
   const match = name.match(pattern);
@@ -41,35 +21,78 @@ function backupCreatedAt(name, pattern) {
   return createdAt;
 }
 
-async function pruneDirectory(directory, required = false) {
-  let entries;
-  try {
-    entries = await opendir(directory);
-  } catch (error) {
-    if (error?.code === "ENOENT" && !required) {
-      return;
+export async function pruneSensitiveBackups({
+  root: rootValue,
+  retentionDays,
+  now = Date.now(),
+  lstat: lstatEntry = lstat,
+}) {
+  const root = path.resolve(rootValue ?? "");
+  if (!rootValue || root === path.parse(root).root) {
+    throw new Error("--root must be a non-root backup directory");
+  }
+  if (!Number.isInteger(retentionDays) || retentionDays < 1 || retentionDays > 365) {
+    throw new Error("--retention-days must be an integer from 1 to 365");
+  }
+  if (!Number.isFinite(now)) {
+    throw new Error("--now must be a valid ISO-8601 timestamp");
+  }
+  const cutoff = now - retentionDays * dailySweepIntervalMs + dailySweepIntervalMs;
+  let pruned = 0;
+
+  async function pruneDirectory(directory, required = false) {
+    let entries;
+    try {
+      entries = await opendir(directory);
+    } catch (error) {
+      if (error?.code === "ENOENT" && !required) {
+        return;
+      }
+      throw error;
     }
-    throw error;
+
+    for await (const entry of entries) {
+      const candidate = path.join(directory, entry.name);
+      let metadata;
+      try {
+        metadata = await lstatEntry(candidate);
+      } catch (error) {
+        if (error?.code === "ENOENT") {
+          continue;
+        }
+        throw error;
+      }
+      if (metadata.isSymbolicLink()) {
+        continue;
+      }
+
+      const createdAt = entry.isFile() ? backupCreatedAt(entry.name, postgresBackup) : null;
+      if (createdAt !== null && createdAt <= cutoff) {
+        await rm(candidate, { force: true });
+        pruned += 1;
+        continue;
+      }
+      if (entry.isDirectory()) {
+        await pruneDirectory(candidate);
+      }
+    }
   }
 
-  for await (const entry of entries) {
-    const candidate = path.join(directory, entry.name);
-    const metadata = await lstat(candidate);
-    if (metadata.isSymbolicLink()) {
-      continue;
-    }
-
-    const createdAt = entry.isFile() ? backupCreatedAt(entry.name, postgresBackup) : null;
-    if (createdAt !== null && createdAt <= cutoff) {
-      await rm(candidate, { force: true });
-      pruned += 1;
-      continue;
-    }
-    if (entry.isDirectory()) {
-      await pruneDirectory(candidate);
-    }
-  }
+  await pruneDirectory(root, true);
+  return pruned;
 }
 
-await pruneDirectory(root, true);
-console.log(`sensitive-backup-retention: pruned=${pruned} retention_days=${retentionDays}`);
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const args = new Map();
+  for (let index = 2; index < process.argv.length; index += 2) {
+    args.set(process.argv[index], process.argv[index + 1]);
+  }
+  const retentionDays = Number(args.get("--retention-days"));
+  const now = args.has("--now") ? Date.parse(args.get("--now")) : Date.now();
+  const pruned = await pruneSensitiveBackups({
+    root: args.get("--root"),
+    retentionDays,
+    now,
+  });
+  console.log(`sensitive-backup-retention: pruned=${pruned} retention_days=${retentionDays}`);
+}


### PR DESCRIPTION
## 관련 이슈

Closes #2231

Refs #2203

## 작업 배경

- PR #2225의 병합 직후 완료된 독립 리뷰에서, 일일 retention workflow와 배포 중 backup pruner가 같은 파일을 동시에 정리할 때 항목별 `lstat`의 `ENOENT`가 작업 전체 실패로 전파되는 경쟁 조건이 확인됐다.
- 법적 고지 PR 자체는 이미 병합됐으므로, 리뷰 finding 수정 2개 파일만 최신 `main`에서 분리했다.

## 작업 내용

- 백업 정리 로직을 import 가능한 함수와 CLI 진입점으로 분리해 동시 삭제 경계를 결정론적으로 검증할 수 있게 했다.
- 항목 열거 후 다른 pruner가 먼저 삭제해 발생한 `ENOENT`만 건너뛰고 남은 항목 정리를 계속한다.
- `EACCES` 등 예상하지 않은 파일시스템 오류는 기존처럼 실패로 전파한다.
- 실제 타이밍에 의존하지 않는 repository contract 회귀 테스트를 추가했다.

## 검증

- RED: `node --test --test-name-pattern '민감정보 백업 보존 작업은 동시 파기로 이미 사라진 항목을 건너뛴다' tools/ci/repository-contract.test.mjs` — 수정 전 실패
- GREEN: 같은 명령 — 1/1 통과
- `node --test tools/ci/repository-contract.test.mjs` — 215/215 통과
- `node --check tools/ops/prune-sensitive-backups.mjs` — 통과
- `git diff --check` — 통과

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 동시 삭제 경쟁 | Node.js 24 | 항목 열거 뒤 대상 파일을 제거하도록 주입 | repository contract test | PASS |
| 비-ENOENT 오류 전파 | Node.js 24 | `EACCES` 주입 후 rejection 확인 | repository contract test | PASS |
| UI·접근성 | 해당 없음 | UI 변경 없음 | 변경 파일 2개가 ops/contract test에 한정 | 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [x] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다. (변경 없음 확인)
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다. (갱신 불필요)
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `tools/ops/prune-sensitive-backups.mjs`의 항목별 `ENOENT` 처리와 `tools/ci/repository-contract.test.mjs`의 결정론적 경쟁·오류 전파 테스트

## 리스크

- CLI 진입점을 분리했으므로 기존 `node tools/ops/prune-sensitive-backups.mjs ...` 출력과 인자 검증이 그대로 유지되는지 전체 계약 테스트로 확인했다.
- `ENOENT` 이외 오류는 숨기지 않아 실제 권한·파일시스템 장애를 정상으로 오판하지 않는다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
