### PR TITLE
[Fix] #2057 callback evidence workflow context 오류 수정

### DIFF
--- a/.github/workflows/datapack-callback-reconciliation-evidence.yml
+++ b/.github/workflows/datapack-callback-reconciliation-evidence.yml
@@ -27,10 +27,6 @@ jobs:
     permissions:
       actions: read
       contents: read
-    env:
-      EVIDENCE_DIR: ${{ runner.temp }}/datapack-callback-reconciliation-evidence
-      RAW_REHEARSAL_PATH: ${{ runner.temp }}/datapack-callback-reconciliation-raw-input.json
-      RAW_CALLBACK_OUTAGE_PATH: ${{ runner.temp }}/datapack-callback-backend-outage.json
 
     steps:
       - name: Callback reconciliation / Checkout default branch
@@ -99,6 +95,8 @@ jobs:
 
       - name: Callback reconciliation / Inject callback backend outage through production sender
         shell: bash
+        env:
+          RAW_CALLBACK_OUTAGE_PATH: ${{ runner.temp }}/datapack-callback-backend-outage.json
         run: |
           set -euo pipefail
           node tools/datapack/run-callback-backend-outage-rehearsal.mjs \
@@ -108,8 +106,8 @@ jobs:
         working-directory: backend
         shell: bash
         env:
-          EASYSUBWAY_CALLBACK_REHEARSAL_OUTPUT: ${{ env.RAW_REHEARSAL_PATH }}
-          EASYSUBWAY_CALLBACK_OUTAGE_ARTIFACT: ${{ env.RAW_CALLBACK_OUTAGE_PATH }}
+          EASYSUBWAY_CALLBACK_REHEARSAL_OUTPUT: ${{ runner.temp }}/datapack-callback-reconciliation-raw-input.json
+          EASYSUBWAY_CALLBACK_OUTAGE_ARTIFACT: ${{ runner.temp }}/datapack-callback-backend-outage.json
         run: |
           set -euo pipefail
           ./gradlew test \
@@ -130,6 +128,9 @@ jobs:
 
       - name: Callback reconciliation / Build and validate sanitized evidence
         shell: bash
+        env:
+          EVIDENCE_DIR: ${{ runner.temp }}/datapack-callback-reconciliation-evidence
+          RAW_REHEARSAL_PATH: ${{ runner.temp }}/datapack-callback-reconciliation-raw-input.json
         run: |
           set -euo pipefail
           node tools/datapack/build-callback-reconciliation-evidence.mjs \

--- a/tools/ci/datapack-callback-reconciliation-evidence-workflow.test.mjs
+++ b/tools/ci/datapack-callback-reconciliation-evidence-workflow.test.mjs
@@ -18,7 +18,12 @@ test("callback reconciliation evidence는 default branch 수동 실행과 세 id
 });
 
 test("job-level env는 runner가 배정되기 전 runner context를 참조하지 않는다", () => {
-  const jobPrelude = workflow.slice(workflow.indexOf("  rehearse:"), workflow.indexOf("\n    steps:"));
+  const jobStart = workflow.indexOf("  rehearse:");
+  const stepsStart = workflow.indexOf("\n    steps:", jobStart);
+  assert.notEqual(jobStart, -1);
+  assert.notEqual(stepsStart, -1);
+  assert.ok(jobStart < stepsStart);
+  const jobPrelude = workflow.slice(jobStart, stepsStart);
   assert.doesNotMatch(jobPrelude, /\$\{\{\s*runner\./);
 });
 

--- a/tools/ci/datapack-callback-reconciliation-evidence-workflow.test.mjs
+++ b/tools/ci/datapack-callback-reconciliation-evidence-workflow.test.mjs
@@ -17,6 +17,11 @@ test("callback reconciliation evidence는 default branch 수동 실행과 세 id
     /github\.ref\s*==\s*format\('refs\/heads\/\{0\}',\s*github\.event\.repository\.default_branch\)/);
 });
 
+test("job-level env는 runner가 배정되기 전 runner context를 참조하지 않는다", () => {
+  const jobPrelude = workflow.slice(workflow.indexOf("  rehearse:"), workflow.indexOf("\n    steps:"));
+  assert.doesNotMatch(jobPrelude, /\$\{\{\s*runner\./);
+});
+
 test("pinned Node 24·Java 21과 동일 SHA의 final RC·publish binding을 사용한다", () => {
   assert.match(workflow, /actions\/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e/);
   assert.match(workflow, /node-version:\s*["']24["']/);
@@ -43,7 +48,7 @@ test("실제 H2 rehearsal과 canonical regression tests를 실행한다", () => 
   assert.match(workflow,
     /node tools\/datapack\/run-callback-backend-outage-rehearsal\.mjs[\s\S]*?--output "\$\{RAW_CALLBACK_OUTAGE_PATH\}"/);
   assert.match(workflow,
-    /EASYSUBWAY_CALLBACK_OUTAGE_ARTIFACT:\s*\$\{\{ env\.RAW_CALLBACK_OUTAGE_PATH \}\}/);
+    /EASYSUBWAY_CALLBACK_OUTAGE_ARTIFACT:\s*\$\{\{ runner\.temp \}\}\/datapack-callback-backend-outage\.json/);
   for (const testClass of [
     "DatapackCallbackReconciliationRehearsalTest",
     "DatapackReleaseCallbackServiceTest",


### PR DESCRIPTION
## 관련 이슈

Refs #2057

## 작업 배경

- PR #2228 병합 직후 callback reconciliation evidence workflow run #29526224640이 job과 log 없이 parser 단계에서 실패했다.
- job-level `env`는 runner 배정 전에 평가되므로 `${{ runner.temp }}` context를 사용할 수 없다.

## 작업 내용

- 임시 경로 세 개를 job-level `env`에서 제거하고 실제 runner가 존재하는 각 step-level `env`로 이동했다.
- callback outage artifact, H2 rehearsal output, sanitized evidence 경로의 기존 파일 identity는 유지했다.
- job prelude에서 `runner` context 사용을 거부하는 workflow contract regression test를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/datapack-callback-reconciliation-evidence-workflow.test.mjs tools/ci/datapack-release-workflow.test.mjs tools/datapack/build-callback-reconciliation-evidence.test.mjs tools/datapack/run-callback-backend-outage-rehearsal.test.mjs` — 40/40 PASS
  - `node --test tools/ci/repository-contract.test.mjs` — 214/214 PASS
  - `node tools/ci/check-contracts.mjs` — PASS
  - `git diff --check` — PASS

## 검증 증거

UI·접근성·수동 QA 변경은 없다. GitHub Actions parser context 경계와 기존 데이터팩 evidence 회귀 테스트로 검증한다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| workflow context | GitHub Actions | job prelude의 `runner` context 금지 contract | workflow test 6/6 | PASS |
| callback evidence 회귀 | Node 24 contract | 관련 Node tests | 40/40 | PASS |
| 저장소 계약 | Node 24 | repository contract | 214/214 | PASS |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: job-level `env` 제거와 step-level 경로 전달이 GitHub context availability 계약에 맞는지 확인해 주세요.

## 리스크

- 임시 경로를 사용하는 step이 추가될 때 다시 job-level `runner` context를 넣으면 parser 실패가 재발할 수 있으며 regression test가 이를 차단한다.
- production publish나 배포 동작은 변경하지 않는다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 없어 CD 확인이 필요하지 않다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * CI 검증 단계에서 실행 환경에 따라 경로가 잘못 해석될 수 있는 문제를 수정했습니다.
  * 각 단계가 필요한 입력 및 산출물 경로를 안정적으로 사용하도록 개선했습니다.

* **테스트**
  * 워크플로우 실행 전 환경 변수의 잘못된 실행기 참조를 감지하는 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->