### PR TITLE
[CI] #2133 #2056 source admission·readiness 정합

### DIFF
--- a/.github/workflows/datapack-prelaunch-gates.yml
+++ b/.github/workflows/datapack-prelaunch-gates.yml
@@ -78,8 +78,8 @@ jobs:
           target: google_apis
           arch: x86_64
           ram-size: 2048M
+          working-directory: apps/mobile
           script: |
-            cd apps/mobile
             flutter test -d emulator-5554 \
               --reporter=expanded \
               --file-reporter=json:"${EVIDENCE_DIR}/android-device.jsonl" \

--- a/.github/workflows/datapack-prelaunch-gates.yml
+++ b/.github/workflows/datapack-prelaunch-gates.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: read
     env:
-      REQUIRED_GATE_IDS: source_governance,freshness_conditional_publish,rollback_rescue,callback_reconciliation
+      REQUIRED_GATE_IDS: source_admission,source_governance,freshness_conditional_publish,rollback_rescue,callback_reconciliation
 
     steps:
       - name: Configure rehearsal paths
@@ -134,7 +134,7 @@ jobs:
             test/core/datapack/data_pack_update_state_test.dart \
             | tee "${EVIDENCE_DIR}/android.txt"
 
-      - name: Bind four gate fragments to one final RC identity
+      - name: Bind five gate fragments to one final RC identity
         run: |
           node tools/release/build-datapack-prelaunch-gate-evidence.mjs --mode collect \
             --repo-root . \

--- a/.github/workflows/datapack-prelaunch-gates.yml
+++ b/.github/workflows/datapack-prelaunch-gates.yml
@@ -80,11 +80,12 @@ jobs:
           ram-size: 2048M
           script: |
             cd apps/mobile
-            flutter test -d emulator-5554 integration_test/datapack_monotonic_rescue_test.dart \
+            flutter test -d emulator-5554 \
               --reporter=expanded \
               --file-reporter=json:"${EVIDENCE_DIR}/android-device.jsonl" \
               --dart-define=EASYSUBWAY_RC_MANIFEST_SHA256=${{ steps.prepare.outputs.manifestSha256 }} \
-              --dart-define=EASYSUBWAY_RC_RELEASE_SEQUENCE=${{ steps.prepare.outputs.releaseSequence }}
+              --dart-define=EASYSUBWAY_RC_RELEASE_SEQUENCE=${{ steps.prepare.outputs.releaseSequence }} \
+              integration_test/datapack_monotonic_rescue_test.dart
 
       - name: Validate launch source snapshot set at the fixed clock
         run: |

--- a/.github/workflows/datapack-prelaunch-gates.yml
+++ b/.github/workflows/datapack-prelaunch-gates.yml
@@ -64,6 +64,13 @@ jobs:
         shell: bash
         run: cp "${EVIDENCE_DIR}/android-rc-bundle.json" apps/mobile/assets/datapacks/prelaunch/android-rc-bundle.json
 
+      - name: Enable KVM group perms
+        shell: bash
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
       - name: Rehearse monotonic rescue on Android emulator
         uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d
         with:

--- a/.github/workflows/datapack-prelaunch-gates.yml
+++ b/.github/workflows/datapack-prelaunch-gates.yml
@@ -79,13 +79,13 @@ jobs:
           arch: x86_64
           ram-size: 2048M
           working-directory: apps/mobile
-          script: |
-            flutter test -d emulator-5554 \
-              --reporter=expanded \
-              --file-reporter=json:"${EVIDENCE_DIR}/android-device.jsonl" \
-              --dart-define=EASYSUBWAY_RC_MANIFEST_SHA256=${{ steps.prepare.outputs.manifestSha256 }} \
-              --dart-define=EASYSUBWAY_RC_RELEASE_SEQUENCE=${{ steps.prepare.outputs.releaseSequence }} \
-              integration_test/datapack_monotonic_rescue_test.dart
+          script: >-
+            flutter test -d emulator-5554
+            --reporter=expanded
+            --file-reporter=json:"${EVIDENCE_DIR}/android-device.jsonl"
+            --dart-define=EASYSUBWAY_RC_MANIFEST_SHA256=${{ steps.prepare.outputs.manifestSha256 }}
+            --dart-define=EASYSUBWAY_RC_RELEASE_SEQUENCE=${{ steps.prepare.outputs.releaseSequence }}
+            integration_test/datapack_monotonic_rescue_test.dart
 
       - name: Validate launch source snapshot set at the fixed clock
         run: |

--- a/.github/workflows/datapack-release.yml
+++ b/.github/workflows/datapack-release.yml
@@ -1011,15 +1011,17 @@ jobs:
           EXPECTED_OUTCOME="${expected_outcome}" node -e "const d=require(process.env.EASYSUBWAY_DATAPACK_FINAL_RELEASE_DECISION); if (d.outcome !== process.env.EXPECTED_OUTCOME || d.remoteValidationPassed !== true) process.exit(1);"
 
       - name: Data Pack Release / Publish finalized release request binding
-        if: ${{ !cancelled() && steps.remote-validation.outcome == 'success' && (steps.final-release-decision.outputs.outcome == 'PUBLISHED_AND_VERIFIED' || steps.final-release-decision.outputs.outcome == 'NO_CHANGE_VALID') }}
+        if: ${{ !cancelled() && steps.remote-validation.outcome == 'success' && steps.final-release-decision.outcome == 'success' && (steps.final-release-decision.outputs.outcome == 'PUBLISHED_AND_VERIFIED' || steps.final-release-decision.outputs.outcome == 'NO_CHANGE_VALID') }}
         id: release-request-binding
+        env:
+          FINAL_RELEASE_OUTCOME: ${{ steps.final-release-decision.outputs.outcome }}
         run: |
           set -euo pipefail
           release_manifest="${EASYSUBWAY_DATAPACK_STAGE}/catalog/current.json"
-          if [[ "${{ steps.final-release-decision.outputs.outcome }}" == "NO_CHANGE_VALID" ]]; then
+          if [[ "${FINAL_RELEASE_OUTCOME}" == "NO_CHANGE_VALID" ]]; then
             release_manifest="${EASYSUBWAY_DATAPACK_CURRENT_MANIFEST}"
           fi
-          release_outcome="${{ steps.final-release-decision.outputs.outcome }}"
+          release_outcome="${FINAL_RELEASE_OUTCOME}"
           node tools/datapack/build-release-request-binding.mjs \
             --manifest "${release_manifest}" \
             --release-request-id "${EASYSUBWAY_DATAPACK_RELEASE_REQUEST_ID}" \

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -871,6 +871,10 @@ jobs:
           operations_evidence_args=(--evidence-status "post_launch_operations=${operations_status}")
           operations_gate_args=(--gate-status "postLaunchOperations=${operations_status}")
           final_readiness_args=()
+          if [[ "${PLAY_UPLOAD}" == internal && "${operations_status}" != "SATISFIED" ]]; then
+            echo "Play internal upload requires SATISFIED operations Phase A evidence" >&2
+            exit 1
+          fi
           if [[ "${PLAY_UPLOAD}" == internal ]]; then
             final_readiness_args+=(--require-pre-play-upload-ready true)
           fi

--- a/apps/mobile/release/post-launch-operations-review-gate.json
+++ b/apps/mobile/release/post-launch-operations-review-gate.json
@@ -106,6 +106,7 @@
             {"path": "tools/datapack/decide-datapack-release.mjs", "sha256": "19df0719c5c030db1981bd34622a42b98e610ac35851a4d0219c70c51dda675c"},
             {"path": "tools/datapack/validate-remote-datapack-artifact.mjs", "sha256": "153a5888903c503fb572b5596afac58d1b0ac1ae973f3e8fda5806948d168b26"},
             {"path": "tools/release/generate-rc-evidence-manifest.mjs", "sha256": "d4dcae15ee381ce16463ad4a8235353327b53adce6fb4d56f25dd6db8c0547c4"},
+            {"path": "tools/release/count-gzip-uncompressed-bytes.mjs", "sha256": "e44ccdd89af5260c6a8027b6b03fdd660640bc52c99be9ba5d024a629d24dbb9"},
             {"path": "tools/release/select-rc-datapack-artifact.mjs", "sha256": "06b1d4e60c041e7cd44e461722a7e5519c515e1135612a16429845bdeac32287"},
             {"path": "tools/release/upload-play-internal.mjs", "sha256": "7bc41b1fb3ce86b2e24043a9a43e47e91577ab33c5170535c8e8c85c09b5c5eb"}
           ]

--- a/apps/mobile/release/post-launch-operations-review-gate.json
+++ b/apps/mobile/release/post-launch-operations-review-gate.json
@@ -96,8 +96,8 @@
           "files": [
             {"path": "apps/mobile/release/signed-release-artifact-gate.json", "sha256": "42c9f83dca5a1c2c24d921cf6ab748c9be5a901dd1b62212a81055098349fc67"},
             {"path": "apps/mobile/pubspec.yaml", "sha256": "b0ca261e81f1ded21492c7eddd96d99b42765146fe2d93f8ea48d57a253b3713"},
-            {"path": ".github/workflows/release-artifacts.yml", "sha256": "568299ac1e3eb2728908b89aacca9b0f95113a26e53f4eaf5d0bfd4fbfeec454"},
-            {"path": ".github/workflows/datapack-release.yml", "sha256": "77398afcd58935ff3bf305a8c01ea9d9229a0708c505e43a2b9dab2e7808d74b"},
+            {"path": ".github/workflows/release-artifacts.yml", "sha256": "63eccd92158367d2b62abeea3f3e540673397245add853e2119112a9f1a24d9e"},
+            {"path": ".github/workflows/datapack-release.yml", "sha256": "907aa513c9b2cb0c2002e0c240d7d404c73dc8ed5691ab8d89da68e38251b7bc"},
             {"path": "tools/ci/validate-store-privacy-env.mjs", "sha256": "18bb0dd8b93d6268c8f60f9cc12272d2ff31c03b60fbbafd6c1e8d16957ada2a"},
             {"path": "backend/build.gradle", "sha256": "00106be89d1834db166c0c4cfba04674e2a456e7e57648595b74feb933c31273"},
             {"path": "backend/Dockerfile", "sha256": "7d9608f490113e655aeaf9544f061896d20f391d5c309b50a42f6303e5eb676b"},
@@ -105,7 +105,7 @@
             {"path": "tools/datapack/lib/manifest-validation.mjs", "sha256": "8ac183f1aa33864a5fc309efe6089961e1dbcd7a0ed7c9b0aff138961e8845ac"},
             {"path": "tools/datapack/decide-datapack-release.mjs", "sha256": "19df0719c5c030db1981bd34622a42b98e610ac35851a4d0219c70c51dda675c"},
             {"path": "tools/datapack/validate-remote-datapack-artifact.mjs", "sha256": "153a5888903c503fb572b5596afac58d1b0ac1ae973f3e8fda5806948d168b26"},
-            {"path": "tools/release/generate-rc-evidence-manifest.mjs", "sha256": "1358e9577b777e01d29f98986030492dc0c9605896c268e88465c24717aee5ef"},
+            {"path": "tools/release/generate-rc-evidence-manifest.mjs", "sha256": "d0765b031462359758bf9c3c258210daaddde7ff0a0f5952a29eed7ff06680af"},
             {"path": "tools/release/select-rc-datapack-artifact.mjs", "sha256": "06b1d4e60c041e7cd44e461722a7e5519c515e1135612a16429845bdeac32287"},
             {"path": "tools/release/upload-play-internal.mjs", "sha256": "7bc41b1fb3ce86b2e24043a9a43e47e91577ab33c5170535c8e8c85c09b5c5eb"}
           ]

--- a/apps/mobile/release/post-launch-operations-review-gate.json
+++ b/apps/mobile/release/post-launch-operations-review-gate.json
@@ -105,7 +105,7 @@
             {"path": "tools/datapack/lib/manifest-validation.mjs", "sha256": "8ac183f1aa33864a5fc309efe6089961e1dbcd7a0ed7c9b0aff138961e8845ac"},
             {"path": "tools/datapack/decide-datapack-release.mjs", "sha256": "19df0719c5c030db1981bd34622a42b98e610ac35851a4d0219c70c51dda675c"},
             {"path": "tools/datapack/validate-remote-datapack-artifact.mjs", "sha256": "153a5888903c503fb572b5596afac58d1b0ac1ae973f3e8fda5806948d168b26"},
-            {"path": "tools/release/generate-rc-evidence-manifest.mjs", "sha256": "d0765b031462359758bf9c3c258210daaddde7ff0a0f5952a29eed7ff06680af"},
+            {"path": "tools/release/generate-rc-evidence-manifest.mjs", "sha256": "d4dcae15ee381ce16463ad4a8235353327b53adce6fb4d56f25dd6db8c0547c4"},
             {"path": "tools/release/select-rc-datapack-artifact.mjs", "sha256": "06b1d4e60c041e7cd44e461722a7e5519c515e1135612a16429845bdeac32287"},
             {"path": "tools/release/upload-play-internal.mjs", "sha256": "7bc41b1fb3ce86b2e24043a9a43e47e91577ab33c5170535c8e8c85c09b5c5eb"}
           ]

--- a/tools/ci/datapack-release-workflow.test.mjs
+++ b/tools/ci/datapack-release-workflow.test.mjs
@@ -155,7 +155,12 @@ test("NO_CHANGE_VALID 재실행은 current manifest binding과 callback을 복�
     /- name: Data Pack Release \/ Publish finalized release request binding[\s\S]*?\n\s+- name:/,
   )?.[0];
   assert.ok(binding, "release request binding 스텝을 찾지 못함");
+  assert.match(binding, /steps\.final-release-decision\.outcome == 'success'/);
   assert.match(binding, /steps\.final-release-decision\.outputs\.outcome == 'NO_CHANGE_VALID'/);
+  assert.match(binding, /FINAL_RELEASE_OUTCOME: \$\{\{ steps\.final-release-decision\.outputs\.outcome \}\}/);
+  assert.match(binding, /if \[\[ "\$\{FINAL_RELEASE_OUTCOME\}" == "NO_CHANGE_VALID" \]\]/);
+  assert.match(binding, /release_outcome="\$\{FINAL_RELEASE_OUTCOME\}"/);
+  assert.doesNotMatch(binding.match(/run: \|[\s\S]*/)?.[0] ?? "", /\$\{\{ steps\.final-release-decision/);
   assert.match(binding, /EASYSUBWAY_DATAPACK_CURRENT_MANIFEST/);
   assert.match(binding, /--release-outcome/);
   assert.match(binding, /NO_CHANGE_VALID/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -4560,6 +4560,19 @@ test("RC evidence manifest generator는 RC identity와 No-Go blocker를 생성�
   const androidReleaseMetadataPath = path.join(tempDir, "release-metadata.txt");
   const phaseASummaryPath = path.join(tempDir, "operations-phase-a-summary.json");
   const outputPath = path.join(tempDir, "rc-evidence-manifest.json");
+  const runFinalGenerator = async (generatorArgs, options) => {
+    const outputIndex = generatorArgs.indexOf("--output");
+    assert.notEqual(outputIndex, -1, "generator test invocation requires --output");
+    const finalOutput = generatorArgs[outputIndex + 1];
+    const withoutOutput = generatorArgs.filter((_, index) => index !== outputIndex && index !== outputIndex + 1);
+    const candidateOutput = `${finalOutput}.candidate-context.json`;
+    await execFileAsync(process.execPath, [
+      ...withoutOutput, "--phase", "CANDIDATE", "--output", candidateOutput,
+    ], options);
+    return execFileAsync(process.execPath, [
+      ...withoutOutput, "--phase", "FINAL", "--candidate-context", candidateOutput, "--output", finalOutput,
+    ], options);
+  };
   const appVersion = read("apps/mobile/pubspec.yaml").match(/^version:\s*([^+\s]+)\+([0-9]+)\s*$/m);
   assert.ok(appVersion, "mobile pubspec must contain versionName+versionCode");
 
@@ -4583,7 +4596,7 @@ test("RC evidence manifest generator는 RC identity와 No-Go blocker를 생성�
     JSON.stringify([{ RepoDigests: ["ghcr.io/aquilaxk/easysubway-backend@sha256:abcdef"] }]),
   );
 
-  await execFileAsync(process.execPath, [
+  await runFinalGenerator([
     "tools/release/generate-rc-evidence-manifest.mjs",
     "--repo-root",
     ".",
@@ -4677,7 +4690,7 @@ test("RC evidence manifest generator는 RC identity와 No-Go blocker를 생성�
   assert.ok(manifest.evidenceEntries.every((entry) => entry.expiresWhen === "2026-07-10T00:00:00.000Z"));
 
   const outsideCwdOutputPath = path.join(tempDir, "outside-cwd.json");
-  await execFileAsync(process.execPath, [
+  await runFinalGenerator([
     path.join(root, "tools/release/generate-rc-evidence-manifest.mjs"),
     "--repo-root", root,
     "--app-root", path.join(root, "apps/mobile"),
@@ -4696,7 +4709,7 @@ test("RC evidence manifest generator는 RC identity와 No-Go blocker를 생성�
     },
   }));
   await assert.rejects(
-    execFileAsync(process.execPath, [
+    runFinalGenerator([
       "tools/release/generate-rc-evidence-manifest.mjs",
       "--repo-root", ".",
       "--app-root", "apps/mobile",
@@ -4722,7 +4735,7 @@ test("RC evidence manifest generator는 RC identity와 No-Go blocker를 생성�
     },
   }));
   await assert.rejects(
-    execFileAsync(process.execPath, [
+    runFinalGenerator([
       "tools/release/generate-rc-evidence-manifest.mjs",
       "--repo-root", ".",
       "--app-root", "apps/mobile",
@@ -4748,7 +4761,7 @@ test("RC evidence manifest generator는 RC identity와 No-Go blocker를 생성�
     },
   }));
   await assert.rejects(
-    execFileAsync(process.execPath, [
+    runFinalGenerator([
       "tools/release/generate-rc-evidence-manifest.mjs",
       "--repo-root", ".",
       "--app-root", "apps/mobile",
@@ -4766,7 +4779,7 @@ test("RC evidence manifest generator는 RC identity와 No-Go blocker를 생성�
 
   await writeFile(phaseASummaryPath, "{}");
   await assert.rejects(
-    execFileAsync(process.execPath, [
+    runFinalGenerator([
       "tools/release/generate-rc-evidence-manifest.mjs",
       "--repo-root", ".",
       "--app-root", "apps/mobile",
@@ -4791,7 +4804,7 @@ test("RC evidence manifest generator는 RC identity와 No-Go blocker를 생성�
     },
   }));
   await assert.rejects(
-    execFileAsync(process.execPath, [
+    runFinalGenerator([
       "tools/release/generate-rc-evidence-manifest.mjs",
       "--repo-root", ".",
       "--app-root", "apps/mobile",
@@ -4831,7 +4844,7 @@ test("RC evidence manifest generator는 RC identity와 No-Go blocker를 생성�
       evidenceReferences: [{ artifactId: "rc-device-qa-report", sha256: "1".repeat(64) }],
     },
   }));
-  await execFileAsync(process.execPath, [
+  await runFinalGenerator([
     "tools/release/generate-rc-evidence-manifest.mjs",
     "--repo-root", ".",
     "--app-root", "apps/mobile",
@@ -4864,7 +4877,7 @@ test("RC evidence manifest generator는 RC identity와 No-Go blocker를 생성�
     },
   }));
   await assert.rejects(
-    execFileAsync(process.execPath, [
+    runFinalGenerator([
       "tools/release/generate-rc-evidence-manifest.mjs",
       "--repo-root", ".",
       "--app-root", "apps/mobile",
@@ -4890,7 +4903,7 @@ test("RC evidence manifest generator는 RC identity와 No-Go blocker를 생성�
   );
   const incompleteRepoGitSha = await initializeFixtureGitRepo(incompleteRepo);
   await assert.rejects(
-    execFileAsync(process.execPath, [
+    runFinalGenerator([
       "tools/release/generate-rc-evidence-manifest.mjs",
       "--repo-root", incompleteRepo,
       "--app-root", path.join(root, "apps/mobile"),
@@ -4910,7 +4923,7 @@ test("RC evidence manifest generator는 RC identity와 No-Go blocker를 생성�
     localImageInspectPath,
     JSON.stringify([{ RepoDigests: [], Id: "sha256:2076c88dbc6590b239f6762e9c209d7ae189f2bc53725ca94d42c81c5d8e4521" }]),
   );
-  await execFileAsync(process.execPath, [
+  await runFinalGenerator([
     "tools/release/generate-rc-evidence-manifest.mjs",
     "--repo-root",
     ".",
@@ -4944,7 +4957,7 @@ test("RC evidence manifest generator는 RC identity와 No-Go blocker를 생성�
   const metadataOnlyInspect = JSON.stringify([{ RepoDigests: [], Size: 367184804 }]);
   const metadataOnlyInspectSha256 = createHash("sha256").update(metadataOnlyInspect).digest("hex");
   await writeFile(metadataOnlyInspectPath, metadataOnlyInspect);
-  await execFileAsync(process.execPath, [
+  await runFinalGenerator([
     "tools/release/generate-rc-evidence-manifest.mjs",
     "--repo-root",
     ".",
@@ -4971,7 +4984,7 @@ test("RC evidence manifest generator는 RC identity와 No-Go blocker를 생성�
   );
 
   await assert.rejects(
-    execFileAsync(process.execPath, [
+    runFinalGenerator([
       "tools/release/generate-rc-evidence-manifest.mjs",
       "--repo-root",
       ".",
@@ -4998,7 +5011,7 @@ test("RC evidence manifest generator는 RC identity와 No-Go blocker를 생성�
   const corruptAabPath = path.join(tempDir, "corrupt.aab");
   const corruptManifestPath = path.join(tempDir, "corrupt-aab-manifest.json");
   await writeFile(corruptAabPath, "not-a-zip");
-  await execFileAsync(process.execPath, [
+  await runFinalGenerator([
     "tools/release/generate-rc-evidence-manifest.mjs",
     "--repo-root", ".",
     "--app-root", "apps/mobile",
@@ -5024,6 +5037,14 @@ test("datapack readiness producer는 required gate를 동일 final identity로 �
   const producerFiles = execFileSync("git", ["grep", "-l", "summaryArtifactDigest", "--", "tools", "apps", ".github"],
     { cwd: root, encoding: "utf8" }).trim().split("\n").filter((file) => !file.includes(".test."));
   assert.deepEqual(producerFiles, ["tools/release/generate-rc-evidence-manifest.mjs"]);
+  const producerSource = read("tools/release/generate-rc-evidence-manifest.mjs");
+  assert.doesNotMatch(producerSource, /gunzipSync/);
+  assert.match(producerSource, /count-gzip-uncompressed-bytes\.mjs/);
+  assert.ok(
+    producerSource.indexOf("compressed artifact exceeds the 250 MiB cap")
+      < producerSource.indexOf("count-gzip-uncompressed-bytes.mjs"),
+    "compressed size cap must be checked before streaming decompression",
+  );
 
   const tempDir = await mkdtemp(path.join(tmpdir(), "easysubway-datapack-readiness-"));
   const validationRepo = path.join(tempDir, "validation-repo");
@@ -5032,6 +5053,7 @@ test("datapack readiness producer는 required gate를 동일 final identity로 �
   }
   await symlink(path.join(root, "apps/mobile/release/production-datapack-scope.json"), path.join(validationRepo, "apps/mobile/release/production-datapack-scope.json"));
   await symlink(path.join(root, "tools/release/hash-android-bundle-payload.mjs"), path.join(validationRepo, "tools/release/hash-android-bundle-payload.mjs"));
+  await symlink(path.join(root, "tools/release/count-gzip-uncompressed-bytes.mjs"), path.join(validationRepo, "tools/release/count-gzip-uncompressed-bytes.mjs"));
   await writeFile(path.join(validationRepo, "tools/ops/validate-operations-release-summary.mjs"), `import { readFileSync } from "node:fs";
 const value = (name) => process.argv[process.argv.indexOf(name) + 1];
 const summary = JSON.parse(readFileSync(value("--summary"), "utf8"));
@@ -5250,6 +5272,10 @@ if (!existsSync(value("--summary")) || !process.argv.includes("--require-pass"))
   assert.doesNotMatch(JSON.stringify(candidateManifest), /\b(?:GO|NO_GO)\b/);
   assert.equal(candidateManifest.releaseCandidateIdentity.releaseSequence, 102);
   assert.equal(candidateManifest.releaseCandidateIdentity.sourceSnapshotSetHash, snapshotSetIdentity);
+  await assert.rejects(
+    execFileAsync(process.execPath, [...args, "--output", path.join(tempDir, "default-final-without-candidate.json")], generatorOptions),
+    /FINAL phase requires --candidate-context/,
+  );
   await assert.rejects(execFileAsync(process.execPath, [...args, "--release-sequence", "2026.07.12",
     "--phase", "CANDIDATE", "--output", path.join(tempDir, "invalid-release-sequence.json")], generatorOptions),
   /--release-sequence must be a positive safe integer/);
@@ -5260,6 +5286,15 @@ if (!existsSync(value("--summary")) || !process.argv.includes("--require-pass"))
     "--candidate-context", invalidCandidatePath, "--output", path.join(tempDir, "invalid-final.json")], generatorOptions),
   /without readiness or decision fields/);
   args.push("--phase", "FINAL", "--candidate-context", baselineOutput);
+  for (const invalidCount of ["1abc", "1.5", "-0.5"]) {
+    await assert.rejects(execFileAsync(process.execPath, [
+      ...args, "--open-android-p0-count", invalidCount,
+      "--output", path.join(tempDir, `invalid-p0-${invalidCount}.json`),
+    ], generatorOptions), /--open-android-p0-count must be a non-negative integer/);
+  }
+  await assert.rejects(execFileAsync(process.execPath, [
+    ...args, "--fail-on-blocked", "TRUE", "--output", path.join(tempDir, "invalid-fail-on-blocked.json"),
+  ], generatorOptions), /--fail-on-blocked must be true or false/);
   const prePlayMetadataPath = path.join(tempDir, "pre-play-release-metadata.txt");
   const prePlayOutputPath = path.join(tempDir, "pre-play-final-readiness.json");
   await writeFile(prePlayMetadataPath, [
@@ -5282,6 +5317,16 @@ if (!existsSync(value("--summary")) || !process.argv.includes("--require-pass"))
     "--output", prePlayOutputPath,
   ], generatorOptions);
   assert.equal(JSON.parse(readFileSync(prePlayOutputPath, "utf8")).decision, "NO_GO");
+  const prePlayBindingFlagIndex = args.indexOf("--require-production-data-pack-binding");
+  const implicitlyBoundArgs = args.filter((_, index) => (
+    index !== prePlayBindingFlagIndex && index !== prePlayBindingFlagIndex + 1
+  ));
+  await execFileAsync(process.execPath, [
+    ...implicitlyBoundArgs,
+    "--android-release-metadata", prePlayMetadataPath,
+    "--require-pre-play-upload-ready", "true",
+    "--output", path.join(tempDir, "implicit-production-binding.json"),
+  ], generatorOptions);
   await writeFile(prePlayMetadataPath, readFileSync(prePlayMetadataPath, "utf8")
     .replace("signingKeyType=production-upload-key", "signingKeyType=ci-ephemeral"));
   await assert.rejects(execFileAsync(process.execPath, [
@@ -5663,8 +5708,21 @@ test("datapack readiness producer는 unknown·mixed identity·expired evidence�
     "--repo-root", ".", "--app-root", "apps/mobile", "--git-sha", gitSha,
     "--now", now, "--output", outputPath,
   ];
+  const runFinalGenerator = async (generatorArgs, options = { cwd: root }) => {
+    const outputIndex = generatorArgs.indexOf("--output");
+    assert.notEqual(outputIndex, -1, "generator test invocation requires --output");
+    const finalOutput = generatorArgs[outputIndex + 1];
+    const withoutOutput = generatorArgs.filter((_, index) => index !== outputIndex && index !== outputIndex + 1);
+    const candidateOutput = `${finalOutput}.candidate-context.json`;
+    await execFileAsync(process.execPath, [
+      ...withoutOutput, "--phase", "CANDIDATE", "--output", candidateOutput,
+    ], options);
+    return execFileAsync(process.execPath, [
+      ...withoutOutput, "--phase", "FINAL", "--candidate-context", candidateOutput, "--output", finalOutput,
+    ], options);
+  };
   const rejects = (extraArgs, expected) => assert.rejects(
-    execFileAsync(process.execPath, [...baseArgs, ...extraArgs], { cwd: root }), expected,
+    runFinalGenerator([...baseArgs, ...extraArgs]), expected,
   );
   const contractArgs = async (name, mutate) => {
     const app = path.join(tempDir, name);
@@ -5678,7 +5736,7 @@ test("datapack readiness producer는 unknown·mixed identity·expired evidence�
     return [...result, "--data-pack-manifest", path.join(root, "apps/mobile/assets/datapacks/metro_map_pack/manifest.json")];
   };
 
-  await execFileAsync(process.execPath, baseArgs, { cwd: root });
+  await runFinalGenerator(baseArgs);
   const blockedManifest = JSON.parse(readFileSync(outputPath, "utf8"));
   assert.ok(blockedManifest.datapackGates.every(({ status }) => status === "BLOCKED_EXTERNAL"));
   assert.equal(blockedManifest.identityLinkage.status, "BLOCKED_EXTERNAL");
@@ -5729,7 +5787,7 @@ test("datapack readiness producer는 unknown·mixed identity·expired evidence�
       evidenceReferences: [{ artifactId: "scope-coverage-report", sha256: "2".repeat(64) }],
     },
   }));
-  await execFileAsync(process.execPath, [
+  await runFinalGenerator([
     ...baseArgs,
     "--gate-status", "scopeCoverage=SATISFIED",
     "--gate-evidence", `scopeCoverage=${genericGateEvidencePath}`,
@@ -5742,7 +5800,7 @@ test("datapack readiness producer는 unknown·mixed identity·expired evidence�
   const p0OutputPath = path.join(tempDir, "p0-manifest.json");
   const p0Args = [...baseArgs];
   p0Args[p0Args.indexOf("--output") + 1] = p0OutputPath;
-  await execFileAsync(process.execPath, [...p0Args, "--open-android-p0-count", "1"], { cwd: root });
+  await runFinalGenerator([...p0Args, "--open-android-p0-count", "1"]);
   const p0Manifest = JSON.parse(readFileSync(p0OutputPath, "utf8"));
   assert.deepEqual(p0Manifest.releaseCandidateIdentity, blockedManifest.releaseCandidateIdentity);
   assert.notEqual(p0Manifest.summaryArtifactDigest, blockedManifest.summaryArtifactDigest);
@@ -5750,7 +5808,7 @@ test("datapack readiness producer는 unknown·mixed identity·expired evidence�
   const evidenceStatusOutputPath = path.join(tempDir, "evidence-status-manifest.json");
   const evidenceStatusArgs = [...baseArgs];
   evidenceStatusArgs[evidenceStatusArgs.indexOf("--output") + 1] = evidenceStatusOutputPath;
-  await execFileAsync(process.execPath, [
+  await runFinalGenerator([
     ...evidenceStatusArgs,
     "--evidence-status", "rc_device_qa=BLOCKED_EXTERNAL",
   ], { cwd: root });
@@ -5814,7 +5872,7 @@ test("datapack readiness producer는 unknown·mixed identity·expired evidence�
     contract.requiredDatapackGates.push(contract.requiredDatapackGates[0]);
   });
   await assert.rejects(
-    execFileAsync(process.execPath, duplicateContractArgs, { cwd: root }),
+    runFinalGenerator(duplicateContractArgs),
     /Duplicate datapack gate in contract: source_admission/,
   );
 
@@ -5824,12 +5882,12 @@ test("datapack readiness producer는 unknown·mixed identity·expired evidence�
     );
   });
   await assert.rejects(
-    execFileAsync(process.execPath, missingFinalFragmentArgs, { cwd: root }),
+    runFinalGenerator(missingFinalFragmentArgs),
     /requiredFinalFragmentIssues must exactly match required evidence entries/,
   );
 
   await assert.rejects(
-    execFileAsync(process.execPath, [
+    runFinalGenerator([
       ...baseArgs.slice(0, baseArgs.indexOf("--git-sha") + 1),
       "0".repeat(40),
       ...baseArgs.slice(baseArgs.indexOf("--git-sha") + 2),
@@ -5838,7 +5896,7 @@ test("datapack readiness producer는 unknown·mixed identity·expired evidence�
   );
 
   await assert.rejects(
-    execFileAsync(process.execPath, [...baseArgs, "--verify-github-sha", "true"], {
+    runFinalGenerator([...baseArgs, "--verify-github-sha", "true"], {
       cwd: root,
       env: { ...process.env, GITHUB_SHA: "f".repeat(40) },
     }),
@@ -5848,14 +5906,14 @@ test("datapack readiness producer는 unknown·mixed identity·expired evidence�
   const closedBlockerArgs = await contractArgs("closed-blocker-app", (contract) => {
     contract.activeBlockerIssues = [2133];
   });
-  await execFileAsync(process.execPath, [
+  await runFinalGenerator([
     ...closedBlockerArgs,
     "--issue-state", "2133=OPEN",
   ], { cwd: root });
   const openBlockerManifest = JSON.parse(readFileSync(outputPath, "utf8"));
   assert.ok(openBlockerManifest.readiness.blockers.some(({ id }) => id === "active_blocker_issue_2133"));
   await assert.rejects(
-    execFileAsync(process.execPath, [
+    runFinalGenerator([
       ...closedBlockerArgs,
       "--issue-state", "2133=CLOSED",
     ], { cwd: root }),
@@ -7632,6 +7690,10 @@ test("Play internal track 업로드는 versionCode 정책·mapping·evidence를 
   assert.match(
     workflow,
     /PLAY_UPLOAD: \$\{\{ inputs\.play_upload \}\}[\s\S]*\[\[ "\$\{PLAY_UPLOAD\}" == internal \]\][\s\S]*--require-pre-play-upload-ready true/,
+  );
+  assert.match(
+    workflow,
+    /if \[\[ "\$\{PLAY_UPLOAD\}" == internal && "\$\{operations_status\}" != "SATISFIED" \]\]; then[\s\S]*exit 1/,
   );
   assert.doesNotMatch(workflow, /final_readiness_args\+\=\(--fail-on-blocked true\)/);
   assert.match(workflow, /inputs\.play_upload == 'internal'/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -3207,6 +3207,7 @@ test("모바일 signed release artifact gate와 광고 counter는 CI 산출물�
     "tools/release/summary-validation-utils.mjs",
     "tools/release/hash-android-bundle-payload.mjs",
     "tools/release/generate-rc-evidence-manifest.mjs",
+    "tools/release/count-gzip-uncompressed-bytes.mjs",
     "tools/datapack/run-emergency-datapack-drill.mjs",
     "tools/release/upload-play-internal.mjs",
     "apps/mobile/release/route-commercialization-gate.json",

--- a/tools/datapack/release/candidate-build-spec.json
+++ b/tools/datapack/release/candidate-build-spec.json
@@ -160,7 +160,7 @@
       "rawObjectUri": "s3://easysubway-datapack-sources/seoul-metro-accessibility/20260712.json",
       "rawSha256": "8a1fbdfbc55f2cd4bc8f54e616f515133f00ee528d078ab21cdd0c1de7ad6814",
       "redactedRequestFingerprint": "57e7d275b103eb14ee1320eb947da5d4120c2b296b9b32b00593b2eb2b7529e8",
-      "schemaFingerprint": "4f0066bdb9b24d5be35b39c1f15b5dce5e84bd5087773301542efc04156f7a99",
+      "schemaFingerprint": "d26d4f55806083f067207948ce977e0ae3d5e84df796d58441909de2c247c170",
       "licenseStatus": "PASS",
       "redistributionAllowed": true,
       "adminReviewRecordHash": "9ccbf78e88d905207134ca3ad08ef7e99fbbdff16c4503b13c4ed925a99b5303",

--- a/tools/datapack/validate-source-snapshot-freshness.mjs
+++ b/tools/datapack/validate-source-snapshot-freshness.mjs
@@ -22,6 +22,7 @@ const buildProvenanceStringFields = [
   "sourceId",
   "rawObjectUri",
   "redactedRequestFingerprint",
+  "schemaFingerprint",
   "licenseStatus",
   "snapshotStatus",
 ];
@@ -156,7 +157,10 @@ export function validateSourceSnapshotFreshness({
     const reasonCodes = [...new Set(governanceResults.flatMap((result) => result.reasonCodes))].sort();
     if (reasonCodes.length > 0) throw new Error(reasonCodes.join(","));
   }
-  return { snapshotSetHash, results, governanceResults };
+  const schemaFingerprintSetHash = sha256(JSON.stringify(selectedSnapshots
+    .map(({ snapshotId, schemaFingerprint }) => ({ snapshotId, schemaFingerprint }))
+    .sort((left, right) => left.snapshotId.localeCompare(right.snapshotId))));
+  return { snapshotSetHash, schemaFingerprintSetHash, results, governanceResults };
 }
 
 async function main(argv) {
@@ -253,6 +257,7 @@ async function main(argv) {
   process.stdout.write(`${JSON.stringify({
     status: "PASS",
     sourceSnapshotSetHash: result.snapshotSetHash,
+    schemaFingerprintSetHash: result.schemaFingerprintSetHash,
     snapshotCount: result.results.length,
     governanceDecision: result.governanceResults.length > 0 ? "GO" : "NOT_EVALUATED",
   })}\n`);

--- a/tools/datapack/validate-source-snapshot-freshness.test.mjs
+++ b/tools/datapack/validate-source-snapshot-freshness.test.mjs
@@ -700,12 +700,12 @@ test("build provenance와 검증 evidence의 snapshot 내용이 다르면 fail c
   );
 });
 
-test("build admission hash와 canonical snapshot hash는 의미가 달라도 freshness를 검증한다", () => {
+test("build admission schema hash가 actual snapshot evidence와 다르면 fail closed한다", () => {
   const value = input();
-  value.buildSpec.sourceSnapshots[0].rawSha256 = "d".repeat(64);
   value.buildSpec.sourceSnapshots[0].schemaFingerprint = "e".repeat(64);
 
-  const result = validateSourceSnapshotFreshness(value);
-
-  assert.equal(result.results[0].status, "FRESH");
+  assert.throws(
+    () => validateSourceSnapshotFreshness(value),
+    /source snapshot provenance/,
+  );
 });

--- a/tools/ops/generate-operations-phase-a-summary.test.mjs
+++ b/tools/ops/generate-operations-phase-a-summary.test.mjs
@@ -320,6 +320,28 @@ test("Phase A summary generator fails closed when a refresh-bound surface change
   await assert.rejects(readFile(output.summary, "utf8"), /ENOENT/);
 });
 
+test("Phase A summary generator rejects a changed gzip evidence helper", async () => {
+  const output = await paths();
+  const gate = JSON.parse(await readFile(path.join(root, "apps/mobile/release/post-launch-operations-review-gate.json"), "utf8"));
+  markFixedReleaseRevalidated(gate);
+  const fixedReleaseBinding = gate.preLaunchReadiness.finalRcBinding.refreshBindings.find(
+    (binding) => binding.refreshOn === "fixed-release-procedure-change",
+  );
+  const helper = fixedReleaseBinding.files.find(
+    (file) => file.path === "tools/release/count-gzip-uncompressed-bytes.mjs",
+  );
+  assert.ok(helper, "gzip evidence helper must invalidate Phase A evidence");
+  helper.sha256 = "0".repeat(64);
+  const gatePath = path.join(output.dir, "post-launch-operations-review-gate.json");
+  await writeFile(output.manifest, `${JSON.stringify(rcManifest(), null, 2)}\n`);
+  await writeFile(gatePath, `${JSON.stringify(gate, null, 2)}\n`);
+
+  await generate(output, ["--post-launch-gate", gatePath]);
+
+  assert.equal((await readFile(output.status, "utf8")).trim(), "BLOCKED_EXTERNAL");
+  await assert.rejects(readFile(output.summary, "utf8"), /ENOENT/);
+});
+
 test("Phase A summary generator rejects a noncanonical Android application ID", async () => {
   const output = await paths();
   const manifest = rcManifest();

--- a/tools/release/build-datapack-prelaunch-gate-evidence.mjs
+++ b/tools/release/build-datapack-prelaunch-gate-evidence.mjs
@@ -26,6 +26,9 @@ export function buildGateFragments({
   if (candidate?.phase !== "CANDIDATE" || !identity || candidate.rcIdentity && !same(identity, candidate.rcIdentity)) {
     throw new Error("candidate context identity is invalid");
   }
+  if (JSON.stringify(candidate.consumerIssues) !== JSON.stringify([2058, 1393])) {
+    throw new Error("candidate context consumers are invalid");
+  }
   for (const field of ["dataPackManifestSha256", "dataPackArtifactSha256", "sourceSnapshotSetHash"]) {
     requiredSha(identity[field], `RC ${field}`);
   }
@@ -39,6 +42,7 @@ export function buildGateFragments({
     if (!verifiedSuites?.has(suite)) throw new Error(`missing verified suite: ${suite}`);
     validateReference(references?.[suite], suite);
   }
+  validateReference(references?.candidateContext, "candidate context");
   validateSourceInputs(buildSpec, sourceReport, identity, evaluatedMillis);
   validateRollbackReport(rollbackReport, identity);
   validateCallbackReport(callbackReport, identity);
@@ -69,6 +73,11 @@ export function buildGateFragments({
     idempotencyKeySha256: sha256(callbackReport.payload.idempotencyKey),
   };
   return {
+    source_admission: {
+      ...envelope("source_admission", 2133,
+        sourceAdmissionResult(snapshotSetIdentity, [references.candidateContext, references.source]), sourceExpiresAt),
+      snapshotSetIdentity,
+    },
     source_governance: {
       ...envelope("source_governance", 2133,
         sourceResult(snapshotSetIdentity, [references.source, references.backend]), sourceExpiresAt),
@@ -115,6 +124,16 @@ export function buildGateFragments({
       ]),
       evidenceReferences: [references.callbackExecution, references.callback, references.backend],
     }),
+  };
+}
+function sourceAdmissionResult(snapshotSetIdentity, evidenceReferences) {
+  return {
+    schemaVersion: 1, snapshotSetIdentity,
+    checks: passing([
+      "schemaValidated", "licenseApproved", "redistributionApproved", "credentialRedacted",
+      "snapshotLocked",
+    ]),
+    evidenceReferences,
   };
 }
 function sourceResult(snapshotSetIdentity, evidenceReferences) {
@@ -599,6 +618,7 @@ async function collect(args) {
     "conditional-publish-report", files["conditional-publish-report"],
   );
   references.androidDevice = await evidenceReference("android-device-report", files["android-device-report"]);
+  references.candidateContext = await evidenceReference("candidate-context", files.candidate);
   const fragments = buildGateFragments({
     candidate, buildSpec, sourceReport, rollbackReport, callbackReport, conditionalPublishReport,
     androidDeviceReport, backendReconciliationReport,

--- a/tools/release/build-datapack-prelaunch-gate-evidence.mjs
+++ b/tools/release/build-datapack-prelaunch-gate-evidence.mjs
@@ -75,7 +75,11 @@ export function buildGateFragments({
   return {
     source_admission: {
       ...envelope("source_admission", 2133,
-        sourceAdmissionResult(snapshotSetIdentity, [references.candidateContext, references.source]), sourceExpiresAt),
+        sourceAdmissionResult(
+          snapshotSetIdentity,
+          sourceReport.schemaFingerprintSetHash,
+          [references.candidateContext, references.source],
+        ), sourceExpiresAt),
       snapshotSetIdentity,
     },
     source_governance: {
@@ -126,9 +130,9 @@ export function buildGateFragments({
     }),
   };
 }
-function sourceAdmissionResult(snapshotSetIdentity, evidenceReferences) {
+function sourceAdmissionResult(snapshotSetIdentity, schemaFingerprintSetHash, evidenceReferences) {
   return {
-    schemaVersion: 1, snapshotSetIdentity,
+    schemaVersion: 1, snapshotSetIdentity, schemaFingerprintSetHash,
     checks: passing([
       "schemaValidated", "licenseApproved", "redistributionApproved", "credentialRedacted",
       "snapshotLocked",
@@ -274,8 +278,15 @@ function validateSourceInputs(buildSpec, report, identity, evaluatedMillis) {
       throw new Error("source inventory contains an unapproved or stale snapshot");
     }
     requiredSha(snapshot.rawSha256, "snapshot rawSha256");
+    requiredSha(snapshot.schemaFingerprint, "snapshot schemaFingerprint");
     requiredSha(snapshot.governancePolicySha256, "snapshot governancePolicySha256");
     sourceIds.add(snapshot.sourceId);
+  }
+  const schemaFingerprintSetHash = sha256(JSON.stringify(buildSpec.sourceSnapshots
+    .map(({ snapshotId, schemaFingerprint }) => ({ snapshotId, schemaFingerprint }))
+    .sort((left, right) => left.snapshotId.localeCompare(right.snapshotId))));
+  if (report.schemaFingerprintSetHash !== schemaFingerprintSetHash) {
+    throw new Error("source admission schema fingerprint evidence mismatch");
   }
 }
 function validateRollbackReport(report, identity) {

--- a/tools/release/build-datapack-prelaunch-gate-evidence.test.mjs
+++ b/tools/release/build-datapack-prelaunch-gate-evidence.test.mjs
@@ -244,6 +244,11 @@ test("prelaunch workflow는 다섯 gate를 같은 RC final readiness에 결속�
     /flutter test -d emulator-5554 \\\n\s+--reporter=expanded \\\n\s+--file-reporter=json:"\$\{EVIDENCE_DIR\}\/android-device\.jsonl" \\\n\s+--dart-define=EASYSUBWAY_RC_MANIFEST_SHA256=.* \\\n\s+--dart-define=EASYSUBWAY_RC_RELEASE_SEQUENCE=.* \\\n\s+integration_test\/datapack_monotonic_rescue_test\.dart/,
     "flutter test options must precede the positional integration test path",
   );
+  const emulatorStep = workflow.match(
+    /- name: Rehearse monotonic rescue on Android emulator[\s\S]*?\n\s+- name:/,
+  )?.[0] ?? "";
+  assert.match(emulatorStep, /working-directory: apps\/mobile/);
+  assert.doesNotMatch(emulatorStep, /script: \|\n\s+cd apps\/mobile/);
   const enableKvm = workflow.indexOf("- name: Enable KVM group perms");
   const emulatorRunner = workflow.indexOf("reactivecircus/android-emulator-runner@");
   assert.ok(enableKvm !== -1 && enableKvm < emulatorRunner, "KVM permissions must be enabled before emulator boot");

--- a/tools/release/build-datapack-prelaunch-gate-evidence.test.mjs
+++ b/tools/release/build-datapack-prelaunch-gate-evidence.test.mjs
@@ -241,12 +241,13 @@ test("prelaunch workflow는 다섯 gate를 같은 RC final readiness에 결속�
   assert.match(workflow, /integration_test\/datapack_monotonic_rescue_test\.dart/);
   assert.match(
     workflow,
-    /flutter test -d emulator-5554 \\\n\s+--reporter=expanded \\\n\s+--file-reporter=json:"\$\{EVIDENCE_DIR\}\/android-device\.jsonl" \\\n\s+--dart-define=EASYSUBWAY_RC_MANIFEST_SHA256=.* \\\n\s+--dart-define=EASYSUBWAY_RC_RELEASE_SEQUENCE=.* \\\n\s+integration_test\/datapack_monotonic_rescue_test\.dart/,
-    "flutter test options must precede the positional integration test path",
+    /script: >-\n\s+flutter test -d emulator-5554\n\s+--reporter=expanded\n\s+--file-reporter=json:"\$\{EVIDENCE_DIR\}\/android-device\.jsonl"\n\s+--dart-define=EASYSUBWAY_RC_MANIFEST_SHA256=.*\n\s+--dart-define=EASYSUBWAY_RC_RELEASE_SEQUENCE=.*\n\s+integration_test\/datapack_monotonic_rescue_test\.dart/,
+    "the action must fold the script into one shell command with options before the positional path",
   );
   const emulatorStep = workflow.match(
     /- name: Rehearse monotonic rescue on Android emulator[\s\S]*?\n\s+- name:/,
   )?.[0] ?? "";
+  assert.doesNotMatch(emulatorStep, /script: \|[\s\S]*?\\\n/);
   assert.match(emulatorStep, /working-directory: apps\/mobile/);
   assert.doesNotMatch(emulatorStep, /script: \|\n\s+cd apps\/mobile/);
   const enableKvm = workflow.indexOf("- name: Enable KVM group permissions");

--- a/tools/release/build-datapack-prelaunch-gate-evidence.test.mjs
+++ b/tools/release/build-datapack-prelaunch-gate-evidence.test.mjs
@@ -239,6 +239,11 @@ test("prelaunch workflow는 다섯 gate를 같은 RC final readiness에 결속�
   assert.match(workflow, /build-datapack-prelaunch-gate-evidence\.mjs --mode collect/);
   assert.match(workflow, /--callback-execution-report/);
   assert.match(workflow, /integration_test\/datapack_monotonic_rescue_test\.dart/);
+  assert.match(
+    workflow,
+    /flutter test -d emulator-5554 \\\n\s+--reporter=expanded \\\n\s+--file-reporter=json:"\$\{EVIDENCE_DIR\}\/android-device\.jsonl" \\\n\s+--dart-define=EASYSUBWAY_RC_MANIFEST_SHA256=.* \\\n\s+--dart-define=EASYSUBWAY_RC_RELEASE_SEQUENCE=.* \\\n\s+integration_test\/datapack_monotonic_rescue_test\.dart/,
+    "flutter test options must precede the positional integration test path",
+  );
   const enableKvm = workflow.indexOf("- name: Enable KVM group perms");
   const emulatorRunner = workflow.indexOf("reactivecircus/android-emulator-runner@");
   assert.ok(enableKvm !== -1 && enableKvm < emulatorRunner, "KVM permissions must be enabled before emulator boot");

--- a/tools/release/build-datapack-prelaunch-gate-evidence.test.mjs
+++ b/tools/release/build-datapack-prelaunch-gate-evidence.test.mjs
@@ -22,6 +22,7 @@ function fixture() {
   };
   const sources = ["source-a", "source-b"].map((sourceId, index) => ({
     sourceId, snapshotId: `${sourceId}-snapshot`, rawSha256: String(index + 2).repeat(64),
+    schemaFingerprint: String(index + 4).repeat(64),
     licenseStatus: "PASS", redistributionAllowed: true, snapshotStatus: "LOCKED",
     credentialRedacted: true, freshnessExpiresAt: "2026-08-16T00:00:00.000Z",
     rawRetentionExpiresAt: "2026-10-16T00:00:00.000Z",
@@ -31,10 +32,16 @@ function fixture() {
     "source", "freshness", "rollback", "android", "callback", "backend", "callbackExecution",
     "androidDevice", "conditionalPublish", "candidateContext",
   ].map((id, index) => [id, { artifactId: `${id}-report`, sha256: String((index % 8) + 2).repeat(64) }]));
+  const schemaFingerprintSetHash = sha(JSON.stringify(sources.map(({ snapshotId, schemaFingerprint }) => ({
+    snapshotId, schemaFingerprint,
+  }))));
   return {
     candidate: { phase: "CANDIDATE", releaseCandidateIdentity: rcIdentity, consumerIssues: [2058, 1393] },
     buildSpec: { sourceSnapshotSetHash: snapshotSetIdentity, sourceSnapshots: sources },
-    sourceReport: { status: "PASS", governanceDecision: "GO", snapshotCount: 2, sourceSnapshotSetHash: snapshotSetIdentity },
+    sourceReport: {
+      status: "PASS", governanceDecision: "GO", snapshotCount: 2,
+      sourceSnapshotSetHash: snapshotSetIdentity, schemaFingerprintSetHash,
+    },
     rollbackReport: {
       from: { releaseSequence: 2 }, failed: { releaseSequence: 2, manifestSha256: "6".repeat(64) },
       knownGood: { releaseSequence: 1, manifestSha256: "7".repeat(64), packs: [{ sha256: packSha256 }] },
@@ -121,6 +128,7 @@ test("동일 RC의 다섯 prelaunch gate fragment를 생성한다", () => {
     credentialRedacted: true,
     snapshotLocked: true,
   });
+  assert.match(fragments.source_admission.result.schemaFingerprintSetHash, /^[0-9a-f]{64}$/);
   assert.equal(
     fragments.source_admission.result.evidenceReferences[0].artifactId,
     "candidateContext-report",
@@ -133,6 +141,11 @@ test("#2058 consumer binding이 없는 candidate-context는 source admission을 
   const input = fixture();
   input.candidate.consumerIssues = [1393];
   assert.throws(() => buildGateFragments(input), /candidate context consumers/);
+});
+test("actual admission schema fingerprint와 build spec이 다르면 source admission을 생성하지 않는다", () => {
+  const input = fixture();
+  input.buildSpec.sourceSnapshots[0].schemaFingerprint = "f".repeat(64);
+  assert.throws(() => buildGateFragments(input), /schema fingerprint evidence mismatch/);
 });
 test("snapshot identity가 RC와 다르면 fail closed한다", () => {
   const input = fixture();

--- a/tools/release/build-datapack-prelaunch-gate-evidence.test.mjs
+++ b/tools/release/build-datapack-prelaunch-gate-evidence.test.mjs
@@ -239,6 +239,12 @@ test("prelaunch workflow는 다섯 gate를 같은 RC final readiness에 결속�
   assert.match(workflow, /build-datapack-prelaunch-gate-evidence\.mjs --mode collect/);
   assert.match(workflow, /--callback-execution-report/);
   assert.match(workflow, /integration_test\/datapack_monotonic_rescue_test\.dart/);
+  const enableKvm = workflow.indexOf("- name: Enable KVM group perms");
+  const emulatorRunner = workflow.indexOf("reactivecircus/android-emulator-runner@");
+  assert.ok(enableKvm !== -1 && enableKvm < emulatorRunner, "KVM permissions must be enabled before emulator boot");
+  assert.match(workflow, /KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS\+="static_node=kvm"/);
+  assert.match(workflow, /sudo udevadm control --reload-rules/);
+  assert.match(workflow, /sudo udevadm trigger --name-match=kvm/);
   assert.match(workflow, /android-rc-bundle\.json/);
   assert.match(workflow, /--android-device-report/);
   assert.match(workflow, /--conditional-publish-report/);

--- a/tools/release/build-datapack-prelaunch-gate-evidence.test.mjs
+++ b/tools/release/build-datapack-prelaunch-gate-evidence.test.mjs
@@ -29,10 +29,10 @@ function fixture() {
   }));
   const references = Object.fromEntries([
     "source", "freshness", "rollback", "android", "callback", "backend", "callbackExecution",
-    "androidDevice", "conditionalPublish",
+    "androidDevice", "conditionalPublish", "candidateContext",
   ].map((id, index) => [id, { artifactId: `${id}-report`, sha256: String((index % 8) + 2).repeat(64) }]));
   return {
-    candidate: { phase: "CANDIDATE", releaseCandidateIdentity: rcIdentity },
+    candidate: { phase: "CANDIDATE", releaseCandidateIdentity: rcIdentity, consumerIssues: [2058, 1393] },
     buildSpec: { sourceSnapshotSetHash: snapshotSetIdentity, sourceSnapshots: sources },
     sourceReport: { status: "PASS", governanceDecision: "GO", snapshotCount: 2, sourceSnapshotSetHash: snapshotSetIdentity },
     rollbackReport: {
@@ -101,10 +101,11 @@ function fixture() {
     evaluatedAt,
   };
 }
-test("동일 RC의 네 prelaunch gate fragment를 생성한다", () => {
+test("동일 RC의 다섯 prelaunch gate fragment를 생성한다", () => {
   const fragments = buildGateFragments(fixture());
   assert.deepEqual(Object.keys(fragments).sort(), [
-    "callback_reconciliation", "freshness_conditional_publish", "rollback_rescue", "source_governance",
+    "callback_reconciliation", "freshness_conditional_publish", "rollback_rescue", "source_admission",
+    "source_governance",
   ]);
   for (const [gateId, fragment] of Object.entries(fragments)) {
     assert.equal(fragment.gateId, gateId);
@@ -113,9 +114,25 @@ test("동일 RC의 네 prelaunch gate fragment를 생성한다", () => {
     assert.equal(fragment.rcIdentity.dataPackManifestSha256, manifestSha256);
   }
   assert.equal(fragments.source_governance.sourceInventory.statusCounts.APPROVED, 2);
+  assert.deepEqual(fragments.source_admission.result.checks, {
+    schemaValidated: true,
+    licenseApproved: true,
+    redistributionApproved: true,
+    credentialRedacted: true,
+    snapshotLocked: true,
+  });
+  assert.equal(
+    fragments.source_admission.result.evidenceReferences[0].artifactId,
+    "candidateContext-report",
+  );
   assert.equal(fragments.rollback_rescue.result.rescueReleaseSequence, 3);
   assert.equal(fragments.callback_reconciliation.result.deliveryIdentity.idempotencyKeySha256,
     sha(`prelaunch-${manifestSha256}:3:${manifestSha256}`));
+});
+test("#2058 consumer binding이 없는 candidate-context는 source admission을 생성하지 않는다", () => {
+  const input = fixture();
+  input.candidate.consumerIssues = [1393];
+  assert.throws(() => buildGateFragments(input), /candidate context consumers/);
 });
 test("snapshot identity가 RC와 다르면 fail closed한다", () => {
   const input = fixture();
@@ -188,7 +205,7 @@ test("backend reconciliation report가 RC와 다르면 fail closed한다", () =>
   input.backendReconciliationReport.manifestSha256 = "0".repeat(64);
   assert.throws(() => buildGateFragments(input), /backend reconciliation evidence/);
 });
-test("prelaunch workflow는 네 gate를 같은 RC final readiness에 결속한다", async () => {
+test("prelaunch workflow는 다섯 gate를 같은 RC final readiness에 결속한다", async () => {
   const workflow = await readFile(new URL(
     "../../.github/workflows/datapack-prelaunch-gates.yml", import.meta.url,
   ), "utf8");
@@ -214,7 +231,8 @@ test("prelaunch workflow는 네 gate를 같은 RC final readiness에 결속한�
   assert.match(workflow, /--conditional-publish-report/);
   assert.match(producer, /tools\/datapack\/publish-object-storage\.mjs/);
   for (const gateId of [
-    "source_governance", "freshness_conditional_publish", "rollback_rescue", "callback_reconciliation",
+    "source_admission", "source_governance", "freshness_conditional_publish", "rollback_rescue",
+    "callback_reconciliation",
   ]) {
     assert.match(workflow, new RegExp(gateId));
   }

--- a/tools/release/count-gzip-uncompressed-bytes.mjs
+++ b/tools/release/count-gzip-uncompressed-bytes.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+
+import { createReadStream } from "node:fs";
+import { pipeline } from "node:stream/promises";
+import { Writable } from "node:stream";
+import { createGunzip } from "node:zlib";
+
+const artifactPath = process.argv[2];
+if (!artifactPath || process.argv.length !== 3) {
+  process.stderr.write("usage: count-gzip-uncompressed-bytes.mjs <artifact.gz>\n");
+  process.exit(1);
+}
+
+let bytes = 0;
+const counter = new Writable({
+  write(chunk, _encoding, callback) {
+    bytes += chunk.length;
+    if (!Number.isSafeInteger(bytes)) {
+      callback(new Error("uncompressed byte count exceeds the safe integer range"));
+      return;
+    }
+    callback();
+  },
+});
+
+await pipeline(createReadStream(artifactPath), createGunzip(), counter);
+process.stdout.write(`${bytes}\n`);

--- a/tools/release/count-gzip-uncompressed-bytes.mjs
+++ b/tools/release/count-gzip-uncompressed-bytes.mjs
@@ -1,13 +1,11 @@
 #!/usr/bin/env node
 
-import { createReadStream } from "node:fs";
 import { pipeline } from "node:stream/promises";
 import { Writable } from "node:stream";
 import { createGunzip } from "node:zlib";
 
-const artifactPath = process.argv[2];
-if (!artifactPath || process.argv.length !== 3) {
-  process.stderr.write("usage: count-gzip-uncompressed-bytes.mjs <artifact.gz>\n");
+if (process.argv.length !== 2) {
+  process.stderr.write("usage: count-gzip-uncompressed-bytes.mjs < artifact.gz\n");
   process.exit(1);
 }
 
@@ -23,5 +21,5 @@ const counter = new Writable({
   },
 });
 
-await pipeline(createReadStream(artifactPath), createGunzip(), counter);
+await pipeline(process.stdin, createGunzip(), counter);
 process.stdout.write(`${bytes}\n`);

--- a/tools/release/count-gzip-uncompressed-bytes.test.mjs
+++ b/tools/release/count-gzip-uncompressed-bytes.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+import { gzipSync } from "node:zlib";
+
+const execFileAsync = promisify(execFile);
+const tool = new URL("./count-gzip-uncompressed-bytes.mjs", import.meta.url);
+
+test("gzip payload를 메모리에 모으지 않고 uncompressed byte count만 출력한다", async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "easysubway-gzip-count-"));
+  const artifact = path.join(directory, "pack.sqlite.gz");
+  const payload = Buffer.alloc(1024 * 1024, 7);
+  await writeFile(artifact, gzipSync(payload));
+
+  const { stdout } = await execFileAsync(process.execPath, [tool.pathname, artifact]);
+  assert.equal(stdout.trim(), String(payload.length));
+});
+
+test("invalid gzip은 성공 byte count로 처리하지 않는다", async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "easysubway-gzip-count-invalid-"));
+  const artifact = path.join(directory, "pack.sqlite.gz");
+  await writeFile(artifact, "not-gzip");
+
+  await assert.rejects(execFileAsync(process.execPath, [tool.pathname, artifact]));
+});

--- a/tools/release/count-gzip-uncompressed-bytes.test.mjs
+++ b/tools/release/count-gzip-uncompressed-bytes.test.mjs
@@ -1,14 +1,25 @@
 import assert from "node:assert/strict";
-import { execFile } from "node:child_process";
+import { execFileSync } from "node:child_process";
+import { closeSync, openSync } from "node:fs";
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { promisify } from "node:util";
 import { gzipSync } from "node:zlib";
 
-const execFileAsync = promisify(execFile);
 const tool = new URL("./count-gzip-uncompressed-bytes.mjs", import.meta.url);
+
+function countFromFile(artifact) {
+  const descriptor = openSync(artifact, "r");
+  try {
+    return execFileSync(process.execPath, [tool.pathname], {
+      encoding: "utf8",
+      stdio: [descriptor, "pipe", "pipe"],
+    });
+  } finally {
+    closeSync(descriptor);
+  }
+}
 
 test("gzip payload를 메모리에 모으지 않고 uncompressed byte count만 출력한다", async () => {
   const directory = await mkdtemp(path.join(tmpdir(), "easysubway-gzip-count-"));
@@ -16,8 +27,7 @@ test("gzip payload를 메모리에 모으지 않고 uncompressed byte count만 �
   const payload = Buffer.alloc(1024 * 1024, 7);
   await writeFile(artifact, gzipSync(payload));
 
-  const { stdout } = await execFileAsync(process.execPath, [tool.pathname, artifact]);
-  assert.equal(stdout.trim(), String(payload.length));
+  assert.equal(countFromFile(artifact).trim(), String(payload.length));
 });
 
 test("invalid gzip은 성공 byte count로 처리하지 않는다", async () => {
@@ -25,5 +35,9 @@ test("invalid gzip은 성공 byte count로 처리하지 않는다", async () => 
   const artifact = path.join(directory, "pack.sqlite.gz");
   await writeFile(artifact, "not-gzip");
 
-  await assert.rejects(execFileAsync(process.execPath, [tool.pathname, artifact]));
+  assert.throws(() => countFromFile(artifact));
+});
+
+test("filesystem path argument를 받지 않는다", () => {
+  assert.throws(() => execFileSync(process.execPath, [tool.pathname, "/tmp/untrusted.gz"]));
 });

--- a/tools/release/generate-rc-evidence-manifest.mjs
+++ b/tools/release/generate-rc-evidence-manifest.mjs
@@ -2,7 +2,9 @@
 
 import { createHash } from "node:crypto";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import {
+  closeSync, existsSync, mkdirSync, mkdtempSync, openSync, readFileSync, rmSync, statSync, writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { canonicalScopeHash } from "../datapack/build-launch-denominator-report.mjs";
@@ -1108,16 +1110,19 @@ function dataPackUncompressedBytes(artifactPath, gateId) {
   if (!artifactPath || !existsSync(artifactPath)) {
     fail(`${gateId} requires an existing data pack artifact`);
   }
+  let descriptor;
   try {
+    descriptor = openSync(artifactPath, "r");
     const output = execFileSync(process.execPath, [
       path.join(repoRoot, "tools/release/count-gzip-uncompressed-bytes.mjs"),
-      artifactPath,
-    ], { encoding: "utf8", maxBuffer: 64 * 1024, stdio: ["ignore", "pipe", "pipe"] }).trim();
+    ], { encoding: "utf8", maxBuffer: 64 * 1024, stdio: [descriptor, "pipe", "pipe"] }).trim();
     const bytes = Number(output);
     if (!/^(?:0|[1-9]\d*)$/.test(output) || !Number.isSafeInteger(bytes)) throw new Error("invalid byte count");
     return bytes;
   } catch {
     fail(`${gateId} data pack artifact must be valid gzip data`);
+  } finally {
+    if (descriptor !== undefined) closeSync(descriptor);
   }
 }
 
@@ -1632,8 +1637,7 @@ function gateStatusBlockers(statuses) {
     }));
 }
 
-function requiredOpenP0Count(value) {
-  const raw = value ?? "0";
+function requiredOpenP0Count(raw = "0") {
   const count = Number(raw);
   if (!/^(?:0|[1-9]\d*)$/.test(raw) || !Number.isSafeInteger(count)) {
     fail("--open-android-p0-count must be a non-negative integer");

--- a/tools/release/generate-rc-evidence-manifest.mjs
+++ b/tools/release/generate-rc-evidence-manifest.mjs
@@ -5,7 +5,6 @@ import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { gunzipSync } from "node:zlib";
 import { canonicalScopeHash } from "../datapack/build-launch-denominator-report.mjs";
 import { selectEffectiveDataPack, selectFallbackDataPack, validateManifest } from "../datapack/lib/manifest-validation.mjs";
 
@@ -63,6 +62,7 @@ const requirePrePlayUploadReady = booleanArg(
   "requirePrePlayUploadReady",
   "require-pre-play-upload-ready",
 );
+const failOnBlocked = booleanArg("failOnBlocked", "fail-on-blocked");
 const dataPackReleaseDecisionPath = arg("dataPackReleaseDecision", "data-pack-release-decision");
 const requireProductionDataPackBinding = requestedProductionDataPackBinding
   || (requestedPhase === "FINAL" && Boolean(dataPackReleaseDecisionPath));
@@ -199,7 +199,7 @@ if (requirePrePlayUploadReady) {
   validatePrePlayUploadReadiness(
     identity,
     androidReleaseMetadata,
-    requestedProductionDataPackBinding,
+    requireProductionDataPackBinding,
     dataPackReleaseDecision,
   );
 }
@@ -230,7 +230,7 @@ if (requestedPhase === "CANDIDATE") {
 }
 
 const candidateContextPath = arg("candidateContext", "candidate-context");
-if (arg("phase") === "FINAL" && !candidateContextPath) {
+if (requestedPhase === "FINAL" && !candidateContextPath) {
   fail("FINAL phase requires --candidate-context");
 }
 if (candidateContextPath) {
@@ -330,7 +330,7 @@ const manifest = {
 
 writeManifest(outputPath, manifest);
 
-if (arg("failOnBlocked", "fail-on-blocked") === "true" && blockers.length > 0) {
+if (failOnBlocked && blockers.length > 0) {
   fail(`RC evidence manifest is blocked: ${blockers.map((blocker) => blocker.id).join(", ")}`);
 }
 
@@ -1045,12 +1045,12 @@ function normalizeDevicePerformanceResult(
   if (artifact.compressedBytes !== dataPackArtifactBytes) {
     fail(`${gateId} compressedBytes does not match the supplied data pack artifact`);
   }
+  if (artifact.compressedBytes > 250 * 1024 * 1024) {
+    fail(`${gateId} compressed artifact exceeds the 250 MiB cap`);
+  }
   const actualUncompressedBytes = dataPackUncompressedBytes(dataPackArtifactPath, gateId);
   if (artifact.uncompressedBytes !== actualUncompressedBytes) {
     fail(`${gateId} uncompressedBytes does not match the supplied data pack artifact`);
-  }
-  if (artifact.compressedBytes > 250 * 1024 * 1024) {
-    fail(`${gateId} compressed artifact exceeds the 250 MiB cap`);
   }
   const metrics = result.metrics;
   const metricLimits = {
@@ -1109,7 +1109,13 @@ function dataPackUncompressedBytes(artifactPath, gateId) {
     fail(`${gateId} requires an existing data pack artifact`);
   }
   try {
-    return gunzipSync(readFileSync(artifactPath)).length;
+    const output = execFileSync(process.execPath, [
+      path.join(repoRoot, "tools/release/count-gzip-uncompressed-bytes.mjs"),
+      artifactPath,
+    ], { encoding: "utf8", maxBuffer: 64 * 1024, stdio: ["ignore", "pipe", "pipe"] }).trim();
+    const bytes = Number(output);
+    if (!/^(?:0|[1-9]\d*)$/.test(output) || !Number.isSafeInteger(bytes)) throw new Error("invalid byte count");
+    return bytes;
   } catch {
     fail(`${gateId} data pack artifact must be valid gzip data`);
   }
@@ -1627,8 +1633,9 @@ function gateStatusBlockers(statuses) {
 }
 
 function requiredOpenP0Count(value) {
-  const count = Number.parseInt(value ?? "0", 10);
-  if (Number.isNaN(count) || count < 0) {
+  const raw = value ?? "0";
+  const count = Number(raw);
+  if (!/^(?:0|[1-9]\d*)$/.test(raw) || !Number.isSafeInteger(count)) {
     fail("--open-android-p0-count must be a non-negative integer");
   }
   return count;


### PR DESCRIPTION
## 관련 이슈

Closes #2133
Closes #2056

## 작업 배경

- PR #2155와 #2226으로 source governance 구현·리허설이 갖춰졌지만 정본 RC 계약의 필수 `source_admission` fragment가 pre-launch producer에서 누락돼 있었습니다.
- PR #2194 merge 뒤 CodeRabbit이 남긴 readiness producer의 late actionable findings도 모두 후속 수정해야 했습니다.
- #2058/#1393이 소비하는 `candidate-context`와 동일한 snapshot-set identity에 admission 결과를 결속하고, FINAL 경계를 fail closed해야 두 이슈의 갱신된 계약이 완결됩니다.

## 작업 내용

- pre-launch producer에 `source_admission` fragment와 candidate-context hash reference를 추가하고 required gate를 다섯 개로 갱신했습니다.
- build spec과 actual source evidence의 schema fingerprint set을 독립 계산·대조해 `schemaValidated`를 실제 증거에 결속했습니다.
- candidate consumer가 정확히 #2058/#1393인지, CANDIDATE/FINAL phase와 candidate-context 경계가 지켜지는지 fail closed합니다.
- final release decision step 성공·안전한 output 전달, strict boolean/P0 count, 자동 production binding과 Play Phase A gate를 보강했습니다.
- gzip artifact는 compressed cap을 먼저 검사하고 streaming byte counter로 uncompressed size를 검증합니다.
- gzip helper는 filesystem path 인자를 받지 않고 parent가 연 read-only descriptor만 stdin으로 소비해 Sonar path traversal 경계를 제거했습니다.
- Linux prelaunch emulator 전에 action 공식 KVM udev permission step을 실행해 실제 리허설 runner의 boot timeout을 해소했습니다.
- PR #2194의 late inline review 7건에 수정 커밋과 검증 결과를 답변하고 모두 resolve했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/repository-contract.test.mjs` — 215/215 PASS
  - `node --test tools/ci/datapack-release-workflow.test.mjs tools/datapack/validate-source-snapshot-freshness.test.mjs tools/release/build-datapack-prelaunch-gate-evidence.test.mjs tools/release/count-gzip-uncompressed-bytes.test.mjs` — 63/63 PASS
  - `node tools/ci/check-contracts.mjs` — PASS
  - `git diff --check` — PASS

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| source admission | Node | schema/license/redistribution/credential/snapshot lock과 schema fingerprint 결속 | focused positive/negative tests | PASS |
| phase·consumer binding | RC producer | CANDIDATE/FINAL identity, #2058/#1393 consumer, candidate-context 필수 조건 | repository contract 215/215 | PASS |
| readiness review 보강 | Workflow/Node | PR #2194 late findings와 Sonar security boundary 회귀 단언 | focused suite 63/63 | PASS |
| production 영향 | GitHub Actions | isolated prelaunch workflow, production write 비활성 | static contract + 별도 rehearsal | production deploy 없음 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음 (`1.0.4`)
- mobile versionCode: 변경 없음 (`10005`)
- datapack version: public version 변경 없음; isolated pre-launch evidence만 갱신
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- `source_admission.schemaValidated`가 build spec의 선언만 신뢰하지 않고 actual snapshot evidence의 fingerprint set과 대조되는지 확인해 주세요.
- FINAL 기본 phase, production binding, Play Phase A, gzip streaming 경계를 중심으로 확인해 주세요.

## 리스크

- source admission과 governance는 같은 source suite를 참조하지만 fragment별 required check와 candidate-context reference를 분리했습니다.
- workflow는 public pointer, production object storage, provider credential을 사용하지 않습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향 없음; production deploy/CD 확인 대상이 아니다.
