### PR TITLE
[CI] #2133 datapack emulator KVM 권한 활성화

### DIFF
--- a/.github/workflows/datapack-prelaunch-gates.yml
+++ b/.github/workflows/datapack-prelaunch-gates.yml
@@ -64,6 +64,13 @@ jobs:
         shell: bash
         run: cp "${EVIDENCE_DIR}/android-rc-bundle.json" apps/mobile/assets/datapacks/prelaunch/android-rc-bundle.json
 
+      - name: Enable KVM group permissions
+        shell: bash
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
       - name: Rehearse monotonic rescue on Android emulator
         uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d
         with:

--- a/tools/release/build-datapack-prelaunch-gate-evidence.test.mjs
+++ b/tools/release/build-datapack-prelaunch-gate-evidence.test.mjs
@@ -188,6 +188,20 @@ test("backend reconciliation report가 RC와 다르면 fail closed한다", () =>
   input.backendReconciliationReport.manifestSha256 = "0".repeat(64);
   assert.throws(() => buildGateFragments(input), /backend reconciliation evidence/);
 });
+test("prelaunch Android emulator 실행 전에 KVM 권한을 활성화한다", async () => {
+  const workflow = await readFile(new URL(
+    "../../.github/workflows/datapack-prelaunch-gates.yml", import.meta.url,
+  ), "utf8");
+  const kvmStep = workflow.indexOf("      - name: Enable KVM group permissions");
+  const emulatorStep = workflow.indexOf("      - name: Rehearse monotonic rescue on Android emulator");
+
+  assert.notEqual(kvmStep, -1, "KVM 권한 활성화 단계가 필요하다");
+  assert.notEqual(emulatorStep, -1, "Android emulator 단계가 필요하다");
+  assert.ok(kvmStep < emulatorStep, "KVM 권한은 emulator 실행 전에 활성화해야 한다");
+  assert.match(workflow, /KERNEL=="kvm", GROUP="kvm", MODE="0666"/);
+  assert.match(workflow, /sudo udevadm control --reload-rules/);
+  assert.match(workflow, /sudo udevadm trigger --name-match=kvm/);
+});
 test("prelaunch workflow는 네 gate를 같은 RC final readiness에 결속한다", async () => {
   const workflow = await readFile(new URL(
     "../../.github/workflows/datapack-prelaunch-gates.yml", import.meta.url,


### PR DESCRIPTION
## 관련 이슈

Refs #2133

## 작업 배경

- 병합된 `main`의 Data Pack Prelaunch Gates 실행 #29529388011에서 `/dev/kvm` 권한이 없어 hardware acceleration이 비활성화됐고 emulator boot timeout 600초로 실패했다.

## 작업 내용

- Android emulator 실행 직전에 공식 action 문서의 KVM udev 권한 활성화 단계를 추가했다.
- 해당 단계의 존재·명령·실행 순서를 고정하는 회귀 테스트를 추가했다.

## 검증

- `node --test tools/release/build-datapack-prelaunch-gate-evidence.test.mjs`: 16/16 통과
- `node --test tools/ci/repository-contract.test.mjs`: 215/215 통과
- `git diff --check`: 통과

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 원인 | GitHub Actions ubuntu-latest | 실패 로그 대조 | https://github.com/AquilaXk/easysubway/actions/runs/29529388011 | `/dev/kvm` 권한 부재와 boot timeout 확인 |
| 계약 테스트 | Node.js | focused + repository contract | PR CI 및 위 명령 | 로컬 통과 |
| 실제 emulator | GitHub Actions | 병합 후 `main` workflow_dispatch | 병합 후 run 링크 첨부 예정 | 대기 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: KVM 권한 단계가 emulator action보다 앞서며 공식 udev rule 세 명령과 동일한지 확인한다.

## 리스크

- runner에서 `sudo udevadm` 지원이 바뀌면 workflow가 즉시 fail closed한다. 앱·backend·운영 데이터에는 변경이 없다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * Android 에뮬레이터 실행 전 KVM 권한이 자동으로 설정되도록 사전 점검 절차를 강화했습니다.
  * KVM 장치 규칙을 새로고침하고 적용해 에뮬레이터 실행 환경의 안정성을 높였습니다.

* **테스트**
  * KVM 권한 설정이 에뮬레이터 실행보다 먼저 수행되는지 자동으로 검증합니다.
  * 사전 실행 절차와 KVM 규칙 적용 여부를 확인하는 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->