### PR TITLE
[CI] #2133 datapack emulator 작업 디렉터리 고정

### DIFF
--- a/.github/workflows/datapack-prelaunch-gates.yml
+++ b/.github/workflows/datapack-prelaunch-gates.yml
@@ -78,8 +78,8 @@ jobs:
           target: google_apis
           arch: x86_64
           ram-size: 2048M
+          working-directory: apps/mobile
           script: |
-            cd apps/mobile
             flutter test -d emulator-5554 integration_test/datapack_monotonic_rescue_test.dart \
               --reporter=expanded \
               --file-reporter=json:"${EVIDENCE_DIR}/android-device.jsonl" \

--- a/tools/release/build-datapack-prelaunch-gate-evidence.test.mjs
+++ b/tools/release/build-datapack-prelaunch-gate-evidence.test.mjs
@@ -202,6 +202,17 @@ test("prelaunch Android emulator 실행 전에 KVM 권한을 활성화한다", a
   assert.match(workflow, /sudo udevadm control --reload-rules/);
   assert.match(workflow, /sudo udevadm trigger --name-match=kvm/);
 });
+test("prelaunch Android integration test는 mobile 작업 디렉터리에서 실행한다", async () => {
+  const workflow = await readFile(new URL(
+    "../../.github/workflows/datapack-prelaunch-gates.yml", import.meta.url,
+  ), "utf8");
+  const emulatorStart = workflow.indexOf("      - name: Rehearse monotonic rescue on Android emulator");
+  const nextStep = workflow.indexOf("\n      - name:", emulatorStart + 1);
+  const emulatorStep = workflow.slice(emulatorStart, nextStep);
+
+  assert.match(emulatorStep, /working-directory:\s*apps\/mobile/);
+  assert.doesNotMatch(emulatorStep, /script:\s*\|\s*\n\s*cd apps\/mobile/);
+});
 test("prelaunch workflow는 네 gate를 같은 RC final readiness에 결속한다", async () => {
   const workflow = await readFile(new URL(
     "../../.github/workflows/datapack-prelaunch-gates.yml", import.meta.url,


### PR DESCRIPTION
## 관련 이슈

Refs #2133

## 작업 배경

- KVM 수정 후 `main` Data Pack Prelaunch Gates 실행 #29531544333에서 emulator boot는 39초에 성공했지만 action이 `cd apps/mobile`과 `flutter test`를 별도 shell로 실행해 repo root에서 integration target을 잘못 해석했다.

## 작업 내용

- android-emulator-runner의 공식 `working-directory: apps/mobile` 입력을 사용한다.
- 별도 shell에서 효력이 사라지는 `cd apps/mobile`을 제거했다.
- action 작업 디렉터리 계약을 회귀 테스트로 고정했다.

## 검증

- `node --test tools/release/build-datapack-prelaunch-gate-evidence.test.mjs`: 17/17 통과
- `node --test tools/ci/repository-contract.test.mjs`: 215/215 통과
- `git diff --check`: 통과

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 원인 | GitHub Actions ubuntu-latest | 실패 로그 대조 | https://github.com/AquilaXk/easysubway/actions/runs/29531544333 | emulator boot 성공 후 repo root 실행 오류 확인 |
| 계약 테스트 | Node.js | focused + repository contract | PR CI 및 위 명령 | 로컬 통과 |
| 실제 emulator | GitHub Actions | 병합 후 `main` workflow_dispatch | 병합 후 run 링크 첨부 예정 | 대기 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: action input의 `working-directory`가 mobile root를 정확히 지정하고 script에 상태 의존 `cd`가 남지 않았는지 확인한다.

## 리스크

- action input 계약이 바뀌면 workflow가 fail closed한다. 앱·backend·운영 데이터에는 변경이 없다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)