### PR TITLE
[CI] #2133 datapack emulator 단일 명령 고정

### DIFF
--- a/.github/workflows/datapack-prelaunch-gates.yml
+++ b/.github/workflows/datapack-prelaunch-gates.yml
@@ -81,10 +81,10 @@ jobs:
           working-directory: apps/mobile
           script: >-
             flutter test -d emulator-5554 integration_test/datapack_monotonic_rescue_test.dart
-              --reporter=expanded
-              --file-reporter=json:"${EVIDENCE_DIR}/android-device.jsonl"
-              --dart-define=EASYSUBWAY_RC_MANIFEST_SHA256=${{ steps.prepare.outputs.manifestSha256 }}
-              --dart-define=EASYSUBWAY_RC_RELEASE_SEQUENCE=${{ steps.prepare.outputs.releaseSequence }}
+            --reporter=expanded
+            --file-reporter=json:"${EVIDENCE_DIR}/android-device.jsonl"
+            --dart-define=EASYSUBWAY_RC_MANIFEST_SHA256=${{ steps.prepare.outputs.manifestSha256 }}
+            --dart-define=EASYSUBWAY_RC_RELEASE_SEQUENCE=${{ steps.prepare.outputs.releaseSequence }}
 
       - name: Validate launch source snapshot set at the fixed clock
         run: |

--- a/.github/workflows/datapack-prelaunch-gates.yml
+++ b/.github/workflows/datapack-prelaunch-gates.yml
@@ -79,11 +79,11 @@ jobs:
           arch: x86_64
           ram-size: 2048M
           working-directory: apps/mobile
-          script: |
-            flutter test -d emulator-5554 integration_test/datapack_monotonic_rescue_test.dart \
-              --reporter=expanded \
-              --file-reporter=json:"${EVIDENCE_DIR}/android-device.jsonl" \
-              --dart-define=EASYSUBWAY_RC_MANIFEST_SHA256=${{ steps.prepare.outputs.manifestSha256 }} \
+          script: >-
+            flutter test -d emulator-5554 integration_test/datapack_monotonic_rescue_test.dart
+              --reporter=expanded
+              --file-reporter=json:"${EVIDENCE_DIR}/android-device.jsonl"
+              --dart-define=EASYSUBWAY_RC_MANIFEST_SHA256=${{ steps.prepare.outputs.manifestSha256 }}
               --dart-define=EASYSUBWAY_RC_RELEASE_SEQUENCE=${{ steps.prepare.outputs.releaseSequence }}
 
       - name: Validate launch source snapshot set at the fixed clock

--- a/tools/release/build-datapack-prelaunch-gate-evidence.test.mjs
+++ b/tools/release/build-datapack-prelaunch-gate-evidence.test.mjs
@@ -213,6 +213,17 @@ test("prelaunch Android integration test는 mobile 작업 디렉터리에서 실
   assert.match(emulatorStep, /working-directory:\s*apps\/mobile/);
   assert.doesNotMatch(emulatorStep, /script:\s*\|\s*\n\s*cd apps\/mobile/);
 });
+test("prelaunch Android integration 명령은 하나의 shell invocation으로 전달한다", async () => {
+  const workflow = await readFile(new URL(
+    "../../.github/workflows/datapack-prelaunch-gates.yml", import.meta.url,
+  ), "utf8");
+  const emulatorStart = workflow.indexOf("      - name: Rehearse monotonic rescue on Android emulator");
+  const nextStep = workflow.indexOf("\n      - name:", emulatorStart + 1);
+  const emulatorStep = workflow.slice(emulatorStart, nextStep);
+
+  assert.match(emulatorStep, /script:\s*>-/);
+  assert.doesNotMatch(emulatorStep, /\\\s*$/m);
+});
 test("prelaunch workflow는 네 gate를 같은 RC final readiness에 결속한다", async () => {
   const workflow = await readFile(new URL(
     "../../.github/workflows/datapack-prelaunch-gates.yml", import.meta.url,

--- a/tools/release/build-datapack-prelaunch-gate-evidence.test.mjs
+++ b/tools/release/build-datapack-prelaunch-gate-evidence.test.mjs
@@ -223,6 +223,15 @@ test("prelaunch Android integration 명령은 하나의 shell invocation으로 �
 
   assert.match(emulatorStep, /script:\s*>-/);
   assert.doesNotMatch(emulatorStep, /\\\s*$/m);
+  const commandLines = emulatorStep
+    .slice(emulatorStep.indexOf("          script: >-") + "          script: >-\n".length)
+    .trimEnd()
+    .split("\n");
+  assert.deepEqual(
+    commandLines.map((line) => line.match(/^ */)[0].length),
+    commandLines.map(() => 12),
+    "folded scalar의 모든 줄은 같은 깊이여야 하나의 shell 명령으로 접힌다",
+  );
 });
 test("prelaunch workflow는 네 gate를 같은 RC final readiness에 결속한다", async () => {
   const workflow = await readFile(new URL(


### PR DESCRIPTION
## 관련 이슈

Refs #2133

## 작업 배경

`datapack-prelaunch-gates`의 Android emulator 단계는 `ReactiveCircus/android-emulator-runner`가 multiline `script`를 줄별 shell invocation으로 실행해 첫 줄의 `flutter test ... \\`만 별도 명령으로 처리했습니다. 그 결과 실제 RC 검증 integration test와 unit test 대상으로 해석된 후속 토큰이 섞여 main 실행이 실패했습니다.

## 작업 내용

- emulator action의 `script`를 YAML folded scalar(`>-`)로 변경해 전체 Flutter 명령을 단일 shell invocation으로 전달합니다.
- 줄 끝 backslash가 다시 들어가 action에서 분리되지 않도록 workflow 계약 테스트를 추가합니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/release/build-datapack-prelaunch-gate-evidence.test.mjs` — 18/18 통과
  - `node --test tools/ci/repository-contract.test.mjs` — 215/215 통과
  - `git diff --check` — 통과

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| workflow 계약 | Node.js | 집중 테스트 및 저장소 계약 테스트 | 위 검증 명령 | 통과 |
| 기존 실패 재현 근거 | GitHub Actions | main 실행 로그에서 첫 줄만 실행된 명령 확인 | https://github.com/AquilaXk/easysubway/actions/runs/29532402677 | 원인 확인 |
| 실제 Android RC 검증 | GitHub Actions / Android emulator | 병합 후 main workflow 연속 2회 실행 | 병합 후 실행 링크 첨부 예정 | 대기 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `script: >-`가 action 입력을 하나의 명령으로 접고, 계약 테스트가 multiline backslash 회귀를 차단하는지 확인해 주세요.

## 리스크

- YAML folding 또는 shell quoting이 잘못되면 Android 실제 RC 검증이 다시 실행되지 않을 수 있습니다. 병합 후 main workflow를 서로 다른 run으로 연속 2회 성공시켜 확인합니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)
