### PR TITLE
[Fix] #1909 하차 알림 canonical 역명·카피 고정

### DIFF
--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -2791,14 +2791,6 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
           activeSubscription?.routeId != result.routeSearchId) {
         return;
       }
-      final activeStationNames = <String, String>{
-        if (activeSubscription != null)
-          for (final transfer in activeSubscription.transfers)
-            transfer.stationId: transfer.stationName,
-        if (activeSubscription != null)
-          activeSubscription.destination.stationId:
-              activeSubscription.destination.stationName,
-      };
       final stationNames = <String, String>{};
       for (final leg in rideLegs) {
         final stationId = leg.toStationId;
@@ -2807,9 +2799,7 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
         }
         final stationName = await _resolveGetOffAlarmStationName(
           stationId: stationId,
-          result: result,
           stationRepository: widget.stationRepository,
-          preferredStationNames: activeStationNames,
         );
         if (stationName == null) {
           throw StateError('하차 알림 역명을 확인하지 못했습니다.');
@@ -4297,7 +4287,6 @@ class _GetOffAlarmEntryPoint extends StatelessWidget {
         rideLegs: rideLegs,
         stationName: (id) => _resolveGetOffAlarmStationName(
           stationId: id,
-          result: result,
           stationRepository: stationRepository,
         ),
       ),
@@ -4307,23 +4296,8 @@ class _GetOffAlarmEntryPoint extends StatelessWidget {
 
 Future<String?> _resolveGetOffAlarmStationName({
   required String stationId,
-  required RouteSearchResult result,
   required StationSearchRepository stationRepository,
-  Map<String, String> preferredStationNames = const {},
 }) async {
-  final preferredName = _usableGetOffAlarmStationName(
-    preferredStationNames[stationId],
-    stationId,
-  );
-  if (preferredName != null) {
-    return preferredName;
-  }
-  if (stationId == result.destinationStationId) {
-    return _usableGetOffAlarmStationName(
-      result.destinationStationName,
-      stationId,
-    );
-  }
   final detail = await stationRepository.getStationDetail(stationId);
   if (detail.id != stationId) {
     return null;

--- a/apps/mobile/test/features/get_off_alarm/get_off_alarm_notifier_test.dart
+++ b/apps/mobile/test/features/get_off_alarm/get_off_alarm_notifier_test.dart
@@ -34,6 +34,43 @@ void main() {
   });
 
   group('LocalGetOffAlarmNotifier', () {
+    test('목적지와 환승 알림은 canonical 한국어 역명 카피를 plugin에 전달한다', () async {
+      final delivered = <({String title, String body})>[];
+      final arrivalAt = DateTime(2026, 7, 10, 10);
+      final notifier = LocalGetOffAlarmNotifier(
+        FlutterLocalNotificationsPlugin(),
+        isAndroid: true,
+        initializePlugin: () async {},
+        pendingIds: () async => const [],
+        cancelId: (_) async {},
+        scheduleAlarm: (_, title, body, _, _) async {
+          delivered.add((title: title, body: body));
+        },
+      );
+
+      await notifier.scheduleAlarms([
+        ScheduledGetOffAlarm(
+          stationId: 'station-sangnoksu',
+          stationName: '상록수',
+          kind: GetOffAlarmKind.destination,
+          fireAt: arrivalAt.subtract(const Duration(minutes: 2)),
+          arrivalAt: arrivalAt,
+        ),
+        ScheduledGetOffAlarm(
+          stationId: 'station-geumjeong',
+          stationName: '금정',
+          kind: GetOffAlarmKind.transfer,
+          fireAt: arrivalAt.subtract(const Duration(minutes: 5)),
+          arrivalAt: arrivalAt,
+        ),
+      ], mode: GetOffAlarmScheduleMode.exact);
+
+      expect(delivered, [
+        (title: '곧 상록수 도착', body: '내릴 준비를 하세요.'),
+        (title: '곧 금정 환승', body: '환승할 준비를 하세요.'),
+      ]);
+    });
+
     test('대기 건수는 전용 ID 범위만 세고 다른 알림을 취소하지 않는다', () async {
       final canceledIds = <int>[];
       final first = LocalGetOffAlarmNotifier.baseNotificationId;

--- a/apps/mobile/test/features/get_off_alarm/get_off_alarm_toggle_test.dart
+++ b/apps/mobile/test/features/get_off_alarm/get_off_alarm_toggle_test.dart
@@ -213,7 +213,59 @@ void main() {
     expect(active?.destination.stationName, '사당');
   });
 
-  testWidgets('역명이 비어 있으면 하차 알림을 예약하거나 저장하지 않는다', (tester) async {
+  for (final invalidName in <({String label, String? value})>[
+    (label: 'null', value: null),
+    (label: 'blank', value: '   '),
+    (label: 'raw ID', value: 'sadang'),
+  ]) {
+    testWidgets('${invalidName.label} 역명은 하차 알림을 예약하거나 저장하지 않는다', (
+      tester,
+    ) async {
+      final notifier = _RecordingNotifier();
+      final repository = _FakeRepo();
+      final controller = GetOffAlarmController(
+        notifier: notifier,
+        permissionGate: _StubGate(true),
+        notificationPermissionProvider:
+            const _StubNotificationPermissionProvider(),
+        repository: repository,
+        now: () => DateTime(2026, 7, 6, 9, 0),
+      );
+      addTearDown(controller.dispose);
+      final reports = <FlutterErrorDetails>[];
+
+      await runWithMobileErrorReporter(reports.add, () async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: GetOffAlarmToggle(
+                controller: controller,
+                routeId: 'r1',
+                rideLegs: const [
+                  RideLegArrival(
+                    toStationId: 'sadang',
+                    plannedArrivalIso: '2026-07-06T09:30:00',
+                  ),
+                ],
+                stationName: (_) async => invalidName.value,
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(find.byType(Switch));
+        await tester.pumpAndSettle();
+      });
+
+      expect(reports, hasLength(1));
+      expect(find.text('하차 알림을 바꾸지 못했어요. 다시 시도해 주세요.'), findsOneWidget);
+      expect(notifier.scheduled, isNull);
+      expect(await repository.loadActive(), isNull);
+      expect(controller.state.enabled, isFalse);
+    });
+  }
+
+  testWidgets('새 경로의 raw ID 역명은 기존 하차 알림과 구독을 보존한다', (tester) async {
     final notifier = _RecordingNotifier();
     final repository = _FakeRepo();
     final controller = GetOffAlarmController(
@@ -222,9 +274,23 @@ void main() {
       notificationPermissionProvider:
           const _StubNotificationPermissionProvider(),
       repository: repository,
-      now: () => DateTime(2026, 7, 6, 9, 0),
+      now: () => DateTime(2026, 7, 6, 9),
     );
     addTearDown(controller.dispose);
+    await controller.enable(
+      routeId: 'existing-route',
+      stops: [
+        GetOffAlarmStop(
+          stationId: 'existing-station',
+          stationName: '기존역',
+          arrivalAt: DateTime(2026, 7, 6, 9, 30),
+          kind: GetOffAlarmKind.destination,
+        ),
+      ],
+      transferAlarmEnabled: false,
+    );
+    final subscriptionBefore = await repository.loadActive();
+    final scheduledBefore = notifier.scheduled;
     final reports = <FlutterErrorDetails>[];
 
     await runWithMobileErrorReporter(reports.add, () async {
@@ -233,28 +299,27 @@ void main() {
           home: Scaffold(
             body: GetOffAlarmToggle(
               controller: controller,
-              routeId: 'r1',
+              routeId: 'new-route',
               rideLegs: const [
                 RideLegArrival(
-                  toStationId: 'sadang',
-                  plannedArrivalIso: '2026-07-06T09:30:00',
+                  toStationId: 'station-sadang',
+                  plannedArrivalIso: '2026-07-06T09:40:00',
                 ),
               ],
-              stationName: (_) async => '   ',
+              stationName: (_) async => 'station-sadang',
             ),
           ),
         ),
       );
-
       await tester.tap(find.byType(Switch));
       await tester.pumpAndSettle();
     });
 
     expect(reports, hasLength(1));
-    expect(find.text('하차 알림을 바꾸지 못했어요. 다시 시도해 주세요.'), findsOneWidget);
-    expect(notifier.scheduled, isNull);
-    expect(await repository.loadActive(), isNull);
-    expect(controller.state.enabled, isFalse);
+    expect(notifier.cancelCount, 0);
+    expect(notifier.scheduled, same(scheduledBefore));
+    expect(await repository.loadActive(), same(subscriptionBefore));
+    expect(controller.state.activeRouteId, 'existing-route');
   });
 
   testWidgets('역명 해소가 실패하면 하차 알림을 예약하거나 저장하지 않는다', (tester) async {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -12215,6 +12215,173 @@ void main() {
     expect((await stateRepository.loadActive())?.destination.stationName, '사당');
   });
 
+  testWidgets('최초 하차 알림은 route 표시명 대신 repository canonical 역명을 저장한다', (
+    tester,
+  ) async {
+    final notifier = _RecordingGetOffAlarmNotifier();
+    final stateRepository = _MemoryGetOffAlarmStateRepository();
+    final controller = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: _StubExactAlarmPermissionGate(),
+      notificationPermissionProvider: FakeNotificationPermissionProvider(
+        nextStatus: NotificationPermissionStatus.granted,
+      ),
+      repository: stateRepository,
+      now: () => DateTime.parse('2026-07-06T09:00:00+09:00'),
+    );
+    addTearDown(controller.dispose);
+    final stationRepository = FakeStationSearchRepository(
+      stationDetails: {
+        'station-sadang': _stationDetail(id: 'station-sadang', name: '사당'),
+      },
+    );
+
+    await _pumpGetOffAlarmRouteScreen(
+      tester,
+      repository: FakeRouteSearchRepository(
+        result: _sampleGetOffAlarmRouteResult(
+          destinationStationName: '경로가 가진 오래된 사당 이름',
+        ),
+      ),
+      controller: controller,
+      stationRepository: stationRepository,
+    );
+    await tester.ensureVisible(find.text('하차 알림'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('하차 알림'));
+    await tester.pumpAndSettle();
+
+    expect(stationRepository.requestedDetailStationIds, ['station-sadang']);
+    expect(notifier.scheduledAlarms.single.stationName, '사당');
+    expect(
+      notifier.scheduledAlarms.single.stationName,
+      isNot('station-sadang'),
+    );
+    expect((await stateRepository.loadActive())?.destination.stationName, '사당');
+  });
+
+  for (final badName in ['station-sadang', '   ']) {
+    final badNameKind = badName.trim().isEmpty ? 'blank' : 'raw ID';
+    testWidgets(
+      'foreground refresh는 저장된 $badNameKind 역명을 repository canonical 역명으로 치유한다',
+      (tester) async {
+        final notifier = _RecordingGetOffAlarmNotifier();
+        final stateRepository = _MemoryGetOffAlarmStateRepository();
+        final controller = GetOffAlarmController(
+          notifier: notifier,
+          permissionGate: _StubExactAlarmPermissionGate(),
+          notificationPermissionProvider: FakeNotificationPermissionProvider(
+            nextStatus: NotificationPermissionStatus.granted,
+          ),
+          repository: stateRepository,
+          now: () => DateTime.parse('2026-07-06T09:00:00+09:00'),
+        );
+        addTearDown(controller.dispose);
+        final stationRepository = FakeStationSearchRepository(
+          stationDetails: {
+            'station-sadang': _stationDetail(id: 'station-sadang', name: '사당'),
+          },
+        );
+        final routeRepository = FakeRouteSearchRepository(
+          result: _sampleGetOffAlarmRouteResult(
+            destinationStationName: '경로가 가진 오래된 사당 이름',
+          ),
+        );
+        await _pumpGetOffAlarmRouteScreen(
+          tester,
+          repository: routeRepository,
+          controller: controller,
+          stationRepository: stationRepository,
+        );
+        await controller.enable(
+          routeId: 'route-1',
+          stops: [
+            GetOffAlarmStop(
+              stationId: 'station-sadang',
+              stationName: badName,
+              arrivalAt: DateTime.parse('2026-07-06T09:37:30+09:00'),
+              kind: GetOffAlarmKind.destination,
+            ),
+          ],
+          transferAlarmEnabled: false,
+        );
+        notifier.reset();
+
+        tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+        await tester.pump();
+        tester.binding.handleAppLifecycleStateChanged(
+          AppLifecycleState.resumed,
+        );
+        await tester.pumpAndSettle();
+
+        expect(stationRepository.requestedDetailStationIds, ['station-sadang']);
+        expect(notifier.scheduledAlarms.single.stationName, '사당');
+        expect(
+          (await stateRepository.loadActive())?.destination.stationName,
+          '사당',
+        );
+      },
+    );
+  }
+
+  testWidgets('foreground 역명 조회 실패는 기존 하차 알림과 구독을 보존한다', (tester) async {
+    final notifier = _RecordingGetOffAlarmNotifier();
+    final stateRepository = _MemoryGetOffAlarmStateRepository();
+    final controller = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: _StubExactAlarmPermissionGate(),
+      notificationPermissionProvider: FakeNotificationPermissionProvider(
+        nextStatus: NotificationPermissionStatus.granted,
+      ),
+      repository: stateRepository,
+      now: () => DateTime.parse('2026-07-06T09:00:00+09:00'),
+    );
+    addTearDown(controller.dispose);
+    final routeRepository =
+        FakeRouteSearchRepository(result: _sampleGetOffAlarmRouteResult())
+          ..refreshResult = RouteRefreshResult(
+            routeSearchId: 'route-1',
+            status: 'UPDATED_ETA',
+            result: _sampleGetOffAlarmRouteResult(
+              realtimeArrivalTimeIso: '2026-07-06T09:40:00+09:00',
+            ),
+            refreshedAt: '2026-07-06T09:01:00+09:00',
+            etaSource: 'REALTIME',
+            etaConfidence: 'HIGH',
+            sourceLabel: '실시간 도착 정보 기준',
+          );
+    await _pumpGetOffAlarmRouteScreen(
+      tester,
+      repository: routeRepository,
+      controller: controller,
+      stationRepository: FakeStationSearchRepository(
+        stationDetails: {
+          'station-sadang': _stationDetail(
+            id: 'station-sadang',
+            name: 'station-sadang',
+          ),
+        },
+      ),
+    );
+    await _enableSampleGetOffAlarm(controller);
+    final subscriptionBefore = await stateRepository.loadActive();
+    notifier.reset();
+    final reports = <FlutterErrorDetails>[];
+
+    await runWithMobileErrorReporter(reports.add, () async {
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+      await tester.pump();
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      await tester.pumpAndSettle();
+    });
+
+    expect(reports, hasLength(1));
+    expect(find.text('하차 알림을 새로 맞추지 못했어요. 이전 경로를 유지해요.'), findsOneWidget);
+    expect(notifier.scheduleCalls, 0);
+    expect(notifier.cancelCalls, 0);
+    expect(await stateRepository.loadActive(), same(subscriptionBefore));
+  });
+
   testWidgets('여러 승차 구간 최초 하차 알림은 공식 환승역과 도착역 이름을 저장한다', (tester) async {
     final notifier = _RecordingGetOffAlarmNotifier();
     final stateRepository = _MemoryGetOffAlarmStateRepository();
@@ -12291,7 +12458,10 @@ void main() {
     final active = await stateRepository.loadActive();
     expect(active?.transfers.map((stop) => stop.stationName), ['금정']);
     expect(active?.destination.stationName, '사당');
-    expect(stationRepository.requestedDetailStationIds, ['station-geumjeong']);
+    expect(stationRepository.requestedDetailStationIds, [
+      'station-geumjeong',
+      'station-sadang',
+    ]);
   });
 
   testWidgets('ride 중 하나의 공식 도착이 없으면 부분 하차 알림을 보이지 않는다', (tester) async {
@@ -12470,7 +12640,18 @@ void main() {
       MaterialApp(
         home: RouteSearchScreen(
           repository: repository,
-          stationRepository: FakeStationSearchRepository(),
+          stationRepository: FakeStationSearchRepository(
+            stationDetails: {
+              'station-geumjeong': _stationDetail(
+                id: 'station-geumjeong',
+                name: '금정',
+              ),
+              'station-sadang': _stationDetail(
+                id: 'station-sadang',
+                name: '사당',
+              ),
+            },
+          ),
           getOffAlarmController: controller,
           initialDraft: RouteDraft(
             origin: const RouteDraftStation(
@@ -12628,7 +12809,10 @@ void main() {
     final active = await stateRepository.loadActive();
     expect(active?.transfers.map((stop) => stop.stationName), ['금정']);
     expect(active?.destination.stationName, '사당');
-    expect(stationRepository.requestedDetailStationIds, ['station-geumjeong']);
+    expect(stationRepository.requestedDetailStationIds, [
+      'station-geumjeong',
+      'station-sadang',
+    ]);
   });
 
   testWidgets('pull-to-refresh는 활성 하차 알림을 새 ETA로 재예약한다', (tester) async {
@@ -16184,7 +16368,12 @@ class FakeStationSearchRepository
     if (completer != null) {
       return completer.future;
     }
-    return stationDetails[stationId] ?? stationDetail;
+    return stationDetails[stationId] ??
+        (stationDetail.id == stationId
+            ? stationDetail
+            : stationId == 'station-sadang'
+            ? _stationDetail(id: stationId, name: '사당')
+            : stationDetail);
   }
 
   @override
@@ -16574,8 +16763,10 @@ class _FakeKakaoMapLauncher implements KakaoMapLauncher {
 RouteSearchResult _sampleGetOffAlarmRouteResult({
   String plannedArrivalTimeIso = '2026-07-06T09:37:30+09:00',
   String realtimeArrivalTimeIso = '',
+  String destinationStationName = '사당',
 }) {
   return _sampleRouteSearchResult(
+    destinationStationName: destinationStationName,
     steps: [
       RouteSearchStep(
         sequence: 1,
@@ -17488,6 +17679,7 @@ RouteSearchResult _sampleRouteSearchResult({
   String mobilityType = 'SENIOR',
   String etaSource = '',
   String sourceUpdatedAt = '',
+  String destinationStationName = '사당',
   OfficialOdFareQuote? officialOdFareQuote,
   List<RouteSearchStep>? steps,
   List<String> recommendationReasons = const [
@@ -17501,7 +17693,7 @@ RouteSearchResult _sampleRouteSearchResult({
     originStationId: 'station-sangnoksu',
     originStationName: '상록수',
     destinationStationId: 'station-sadang',
-    destinationStationName: '사당',
+    destinationStationName: destinationStationName,
     mobilityType: mobilityType,
     status: status,
     lineId: 'seoul-4',


### PR DESCRIPTION
## 관련 이슈

Closes #1909

## 작업 배경

하차·환승 알림의 사용자 표시 역명은 route 결과나 저장된 과거 이름이 아니라 station repository의 canonical 한국어 `nameKo`를 사용해야 합니다. 저장값이 blank/raw ID인 경우 다음 정상 refresh에서 치유하고, 조회 실패 시 기존 alarm과 subscription을 보존해야 합니다.

## 작업 내용

- 결과 화면 toggle과 foreground refresh의 역명 resolver를 station repository 단일 경로로 고정했습니다.
- repository가 다른 ID, blank, raw station ID를 반환하면 fail closed하도록 기존 검증 경계를 유지했습니다.
- 저장된 blank/raw-ID 역명의 정상 refresh 치유와 실패 rollback을 widget 테스트로 고정했습니다.
- destination·transfer 제목/본문 카피를 notifier 테스트로 고정했습니다.

## 검증

- `cd apps/mobile && flutter test --no-pub --reporter compact`: 1,367건 통과
- `cd apps/mobile && flutter analyze --no-pub`: No issues found
- `node --test tools/ci/repository-contract.test.mjs`: 215건 통과
- `git diff --check`: 통과
- Galaxy A17(Android 16) 실제 앱 UI에서 상록수→사당 하차 알림 예약 및 notification 표시 확인

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| canonical 역명 resolver·치유·rollback | Flutter | unit/widget/full test | PR 테스트 diff, 1,367건 통과 | PASS |
| notification 제목·본문 | Android | 동일 APK가 저장한 payload를 동일 receiver로 즉시 발화 | `/Users/aquila/easysubway/.superpowers/evidence/1909-20260717/android-notification.png` | PASS |
| artifact identity | Android | APK SHA-256 | `e27f910384f335abd18b0ab91a1410085ef45b31e4fb4dae0a08f97fcb993cf3` | PASS |
| redacted 실행 기록 | Android | notification manager·UI hierarchy·사용자 수신 확인 | `/Users/aquila/easysubway/.superpowers/evidence/1909-20260717/android-notification-redacted.log` | PASS |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 1.0.4 (변경 없음)
- mobile versionCode: 10005 (변경 없음)
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `_resolveGetOffAlarmStationName`의 route/stored fallback 제거가 destination·transfer·foreground 모두 repository canonical 이름을 강제하는지, 조회 실패 시 기존 alarm 보존 assertion이 충분한지 확인해 주세요.

## 리스크

- foreground refresh마다 ride 도착역 상세 조회가 수행됩니다. 조회 실패는 기존 alarm/subscription을 유지하고 사용자 오류로 명시됩니다.
- production 변경은 fallback 26줄 제거이며 새 의존성·DB migration·배포 변경이 없습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 없어 CD 확인이 필요하지 않다.
