### PR TITLE
[Feat] #2154 하차 알림 재부팅·package replace 자동 복원

### DIFF
--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -6,6 +6,9 @@
     <!-- 하차 알림(#1766) 시간표 기반 정확 예약용. 거부 시 부정확 예약으로 강등한다.
          알람·캘린더 앱 전용인 USE_EXACT_ALARM은 Play 정책상 사용하지 않는다. -->
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>
+    <!-- 하차 알림(#2154) 재부팅·package replace 뒤 예약 자동 복원용. WorkManager(#1768)도
+         같은 권한을 병합한다. normal 권한이라 프롬프트가 없고 데이터를 수집하지 않는다. -->
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <!-- #1768은 regular periodic WorkManager만 사용한다. long-running foreground
          worker를 도입할 때 별도 Play/permission 검토 후 복원한다. -->
     <uses-permission
@@ -69,6 +72,19 @@
         <receiver
             android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationReceiver"
             android:exported="false" />
+        <!-- 하차 알림(#2154) 재부팅·package replace 뒤 예약을 앱 실행 없이 복원한다.
+             flutter_local_notifications 공식 boot receiver를 exported=false로 고정하고
+             네 부팅 계열 action을 명시 선언한다. -->
+        <receiver
+            android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationBootReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+                <action android:name="android.intent.action.QUICKBOOT_POWERON" />
+                <action android:name="com.htc.intent.action.QUICKBOOT_POWERON" />
+            </intent-filter>
+        </receiver>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/apps/mobile/lib/app/app_dependencies.dart
+++ b/apps/mobile/lib/app/app_dependencies.dart
@@ -9,10 +9,12 @@ import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import '../features/favorites/data/drift_favorite_repositories.dart';
 import '../features/fare/official_od_fare_repository.dart';
 import '../features/ads/ad_repository.dart';
+import '../features/get_off_alarm/data/get_off_alarm_recovery_notice_store.dart';
 import '../features/get_off_alarm/data/get_off_alarm_state_repository.dart';
 import '../features/get_off_alarm/exact_alarm_permission.dart';
 import '../features/get_off_alarm/get_off_alarm_controller.dart';
 import '../features/get_off_alarm/get_off_alarm_notifier.dart';
+import '../features/get_off_alarm/get_off_alarm_reconcile_worker.dart';
 import '../features/network_map/data/drift_network_map_viewport_repository.dart';
 import '../features/preferences/data/drift_notification_settings_repository.dart';
 import '../features/realtime/realtime_repository.dart';
@@ -414,6 +416,11 @@ GetOffAlarmController? _resolveGetOffAlarmController(
         notificationPermissionProvider ??
         MethodChannelNotificationPermissionProvider(),
     repository: DriftGetOffAlarmStateRepository(userDatabase: userDatabase),
+    recoveryNoticeStore: DriftGetOffAlarmRecoveryNoticeStore(
+      userDatabase: userDatabase,
+    ),
+    onActivateReconcileWork: registerGetOffAlarmReconcile,
+    onDeactivateReconcileWork: cancelGetOffAlarmReconcile,
   );
 }
 

--- a/apps/mobile/lib/features/get_off_alarm/data/get_off_alarm_recovery_notice_store.dart
+++ b/apps/mobile/lib/features/get_off_alarm/data/get_off_alarm_recovery_notice_store.dart
@@ -1,0 +1,59 @@
+import 'package:drift/drift.dart';
+
+import '../../../core/database/user/user_database.dart' as user_db;
+
+/// 하차 알림이 headless reconcile에서 알림 권한 거부로 정리됐음을 다음 UI init에
+/// 한 번만 알리기 위한 one-shot 복구 안내 플래그.
+///
+/// headless isolate는 UI를 띄울 수 없으므로 정리 시 플래그만 기록하고, 다음
+/// 포그라운드 init이 이를 소비해 안내를 한 번 표시한 뒤 즉시 지운다.
+abstract class GetOffAlarmRecoveryNoticeStore {
+  /// 복구 안내가 필요함을 기록한다(idempotent).
+  Future<void> record();
+
+  /// 플래그가 있으면 지우고 true를, 없으면 false를 돌려준다(one-shot 소비).
+  Future<bool> consume();
+}
+
+/// 기존 `app_preferences`(key/value) 테이블을 재사용하는 구현. 새 테이블·마이그레이션을
+/// 추가하지 않는다(하차 알림 활성 구독 저장과 동일 패턴).
+class DriftGetOffAlarmRecoveryNoticeStore
+    implements GetOffAlarmRecoveryNoticeStore {
+  DriftGetOffAlarmRecoveryNoticeStore({required this.userDatabase});
+
+  final user_db.UserDatabase userDatabase;
+
+  static const String _storageKey = 'get_off_alarm_recovery_notice';
+
+  @override
+  Future<void> record() async {
+    await userDatabase
+        .into(userDatabase.appPreferences)
+        .insertOnConflictUpdate(
+          user_db.AppPreferencesCompanion.insert(
+            key: _storageKey,
+            value: 'true',
+            updatedAt: DateTime.now().toUtc(),
+          ),
+        );
+  }
+
+  @override
+  Future<bool> consume() async {
+    final row = await userDatabase
+        .customSelect(
+          'SELECT value FROM app_preferences WHERE key = ?',
+          variables: [Variable.withString(_storageKey)],
+          readsFrom: {userDatabase.appPreferences},
+        )
+        .getSingleOrNull();
+    if (row == null) {
+      return false;
+    }
+    await userDatabase.customStatement(
+      'DELETE FROM app_preferences WHERE key = ?',
+      [_storageKey],
+    );
+    return row.read<String>('value') == 'true';
+  }
+}

--- a/apps/mobile/lib/features/get_off_alarm/get_off_alarm_controller.dart
+++ b/apps/mobile/lib/features/get_off_alarm/get_off_alarm_controller.dart
@@ -150,11 +150,16 @@ class GetOffAlarmController extends ChangeNotifier {
     );
     // 활성 구독을 복원하므로 남은 복구 안내 플래그는 조용히 소비해 지운다.
     await _consumeRecoveryNotice();
+    // 위에서 만료 판정에 쓴 단일 now 스냅샷 결과를 그대로 넘겨 restore 경로를
+    // 원자화한다. _schedule가 now()로 재계산하면 두 스냅샷 사이에 마지막 발화
+    // 시각이 지날 때 alarms.isEmpty 분기와 달리 복구 안내 소비 없이 off로
+    // 정리되는 계약 분열이 생긴다.
     await _schedule(
       routeId: subscription.routeId,
       stops: stops,
       transferAlarmEnabled: subscription.transferAlarmEnabled,
       resolution: resolution,
+      precomputedAlarms: alarms,
     );
   }
 
@@ -311,20 +316,23 @@ class GetOffAlarmController extends ChangeNotifier {
     return GetOffAlarmRefreshResult.refreshed;
   }
 
+  /// [precomputedAlarms]가 주어지면 그 단일 now 스냅샷 계산 결과를 그대로
+  /// 예약한다(restore 경로 원자화용). 없으면 현재 now()로 새로 계산한다
+  /// (enable/refresh 경로의 기존 동작).
   Future<void> _schedule({
     required String routeId,
     required List<GetOffAlarmStop> stops,
     required bool transferAlarmEnabled,
     required GetOffAlarmScheduleResolution resolution,
+    List<ScheduledGetOffAlarm>? precomputedAlarms,
   }) async {
-    final effectivePolicy = policy.copyWith(
-      transferAlarmEnabled: transferAlarmEnabled,
-    );
-    final alarms = computeGetOffAlarms(
-      stops: stops,
-      policy: effectivePolicy,
-      now: now(),
-    );
+    final alarms =
+        precomputedAlarms ??
+        computeGetOffAlarms(
+          stops: stops,
+          policy: policy.copyWith(transferAlarmEnabled: transferAlarmEnabled),
+          now: now(),
+        );
 
     final delivery = await notifier.scheduleAlarms(
       alarms,

--- a/apps/mobile/lib/features/get_off_alarm/get_off_alarm_controller.dart
+++ b/apps/mobile/lib/features/get_off_alarm/get_off_alarm_controller.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 
 import '../../mobile_error_reporter.dart';
 import '../../notification_settings.dart';
+import 'data/get_off_alarm_recovery_notice_store.dart';
 import 'data/get_off_alarm_state_repository.dart';
 import 'exact_alarm_permission.dart';
 import 'get_off_alarm_notifier.dart';
@@ -53,6 +54,9 @@ class GetOffAlarmController extends ChangeNotifier {
     required this.permissionGate,
     required this.notificationPermissionProvider,
     required this.repository,
+    this.recoveryNoticeStore,
+    this.onActivateReconcileWork,
+    this.onDeactivateReconcileWork,
     this.policy = GetOffAlarmPolicyDefaults.policy,
     this.now = DateTime.now,
   });
@@ -61,6 +65,17 @@ class GetOffAlarmController extends ChangeNotifier {
   final ExactAlarmPermissionGate permissionGate;
   final NotificationPermissionProvider notificationPermissionProvider;
   final GetOffAlarmStateRepository repository;
+
+  /// headless reconcile가 알림 권한 거부로 정리했음을 다음 UI init에 한 번만
+  /// 알리는 one-shot 플래그 저장소(없으면 안내를 건너뛴다).
+  final GetOffAlarmRecoveryNoticeStore? recoveryNoticeStore;
+
+  /// 활성 구독을 저장/재예약할 때 unique periodic reconcile work를 등록/update한다.
+  final Future<void> Function()? onActivateReconcileWork;
+
+  /// off·만료·알림 권한 거부 정리 시 unique periodic reconcile work만 취소한다.
+  final Future<void> Function()? onDeactivateReconcileWork;
+
   final GetOffAlarmPolicy policy;
   final DateTime Function() now;
 
@@ -77,46 +92,120 @@ class GetOffAlarmController extends ChangeNotifier {
   /// 현재 영속 구독에 재조정한다.
   Future<void> reconcile() => _enqueueMutation(_restore);
 
+  /// 재부팅·package replace·포그라운드 복귀 뒤 영속 구독을 OS 상태에 맞춰
+  /// 재조정한다. 포그라운드 restore와 headless reconcile이 공유하는 단일 계약이다.
+  ///
+  /// 분기:
+  /// - 구독 없음(사용자가 끔): 복원하지 않고 잔여 pending만 정리한다.
+  /// - 알림 권한 거부: 관련 pending 취소·구독 삭제 후 복구 안내 플래그를 기록한다.
+  /// - 만료 구독(미래 알림 없음): 관련 pending 취소 후 구독을 삭제한다.
+  /// - 미래 구독: 결정적 ID로 전체 idempotent 재예약한다(중복 0건). 정확 알람
+  ///   권한이 있으면 exact, 없으면 silent failure 없이 inexact로 복원한다.
   Future<void> _restore() async {
     final subscription = await repository.loadActive();
     if (subscription == null) {
-      await _turnOff();
+      final recoveryPending = await _consumeRecoveryNotice();
+      await _turnOff(
+        permissionNotice: recoveryPending
+            ? notificationPermissionDeniedNotice
+            : null,
+      );
       return;
     }
     final notificationPermission = await notificationPermissionProvider
         .notificationPermissionStatus();
     if (notificationPermission != NotificationPermissionStatus.granted) {
-      await _turnOff(permissionNotice: notificationPermissionDeniedNotice);
+      await _cleanUpInactiveSubscription();
+      await _recordRecoveryNotice();
+      _emit(
+        const GetOffAlarmState(
+          permissionNotice: notificationPermissionDeniedNotice,
+        ),
+      );
       return;
     }
-    final pendingCount = await notifier.pendingAlarmCount();
-    if (pendingCount == 0) {
-      await _turnOff();
+    final stops = _stopsFrom(subscription);
+    final alarms = computeGetOffAlarms(
+      stops: stops,
+      policy: policy.copyWith(
+        transferAlarmEnabled: subscription.transferAlarmEnabled,
+      ),
+      now: now(),
+    );
+    if (alarms.isEmpty) {
+      final recoveryPending = await _consumeRecoveryNotice();
+      await _cleanUpInactiveSubscription();
+      _emit(
+        GetOffAlarmState(
+          permissionNotice: recoveryPending
+              ? notificationPermissionDeniedNotice
+              : null,
+        ),
+      );
       return;
     }
     final permitted = await permissionGate.isExactAlarmPermitted();
     final resolution = resolveGetOffAlarmScheduleMode(
       exactAlarmPermitted: permitted,
     );
-    final maxExpectedCount =
-        1 +
-        (subscription.transferAlarmEnabled ? subscription.transfers.length : 0);
-    if (resolution.mode != subscription.scheduleMode ||
-        pendingCount > maxExpectedCount) {
-      await _schedule(
-        routeId: subscription.routeId,
-        stops: _stopsFrom(subscription),
-        transferAlarmEnabled: subscription.transferAlarmEnabled,
-        resolution: resolution,
-      );
+    // 활성 구독을 복원하므로 남은 복구 안내 플래그는 조용히 소비해 지운다.
+    await _consumeRecoveryNotice();
+    await _schedule(
+      routeId: subscription.routeId,
+      stops: stops,
+      transferAlarmEnabled: subscription.transferAlarmEnabled,
+      resolution: resolution,
+    );
+  }
+
+  Future<void> _cleanUpInactiveSubscription() async {
+    await notifier.cancelAll();
+    await repository.clearActive();
+    await _deactivateReconcileWork();
+  }
+
+  Future<bool> _consumeRecoveryNotice() async {
+    final store = recoveryNoticeStore;
+    if (store == null) {
+      return false;
+    }
+    return store.consume();
+  }
+
+  Future<void> _recordRecoveryNotice() async {
+    await recoveryNoticeStore?.record();
+  }
+
+  Future<void> _activateReconcileWork() async {
+    final activate = onActivateReconcileWork;
+    if (activate == null) {
       return;
     }
-    var reconciled = subscription;
-    if (pendingCount != subscription.scheduledCount) {
-      reconciled = _subscriptionWithScheduledCount(subscription, pendingCount);
-      await repository.saveActive(reconciled);
+    try {
+      await activate();
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '하차 알림 reconcile work 등록 중 예외가 발생했습니다.',
+      );
     }
-    _emitSubscription(reconciled);
+  }
+
+  Future<void> _deactivateReconcileWork() async {
+    final deactivate = onDeactivateReconcileWork;
+    if (deactivate == null) {
+      return;
+    }
+    try {
+      await deactivate();
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '하차 알림 reconcile work 취소 중 예외가 발생했습니다.',
+      );
+    }
   }
 
   /// 하차 알림을 켠다: 정확 알람 권한을 확인해 강등 여부를 정하고, 알림을
@@ -243,6 +332,7 @@ class GetOffAlarmController extends ChangeNotifier {
     );
     if (delivery.scheduledCount == 0) {
       await repository.clearActive();
+      await _deactivateReconcileWork();
       _emit(GetOffAlarmState.off);
       return;
     }
@@ -260,6 +350,8 @@ class GetOffAlarmController extends ChangeNotifier {
       await _compensateFailedSave();
       Error.throwWithStackTrace(error, stackTrace);
     }
+    // 활성 구독을 저장했으므로 unique periodic reconcile work를 등록/update한다.
+    await _activateReconcileWork();
 
     _emitSubscription(subscription);
   }
@@ -280,6 +372,7 @@ class GetOffAlarmController extends ChangeNotifier {
   Future<void> _turnOff({String? permissionNotice}) async {
     await notifier.cancelAll();
     await repository.clearActive();
+    await _deactivateReconcileWork();
     _emit(GetOffAlarmState(permissionNotice: permissionNotice));
   }
 
@@ -294,6 +387,7 @@ class GetOffAlarmController extends ChangeNotifier {
     } catch (error, stackTrace) {
       _reportCompensationError(error, stackTrace);
     }
+    await _deactivateReconcileWork();
     _emit(GetOffAlarmState.off);
   }
 
@@ -357,21 +451,6 @@ class GetOffAlarmController extends ChangeNotifier {
         kind: GetOffAlarmKind.destination,
       ),
     ];
-  }
-
-  GetOffAlarmSubscription _subscriptionWithScheduledCount(
-    GetOffAlarmSubscription subscription,
-    int scheduledCount,
-  ) {
-    return GetOffAlarmSubscription(
-      routeId: subscription.routeId,
-      transferAlarmEnabled: subscription.transferAlarmEnabled,
-      scheduledCount: scheduledCount,
-      scheduleMode: subscription.scheduleMode,
-      inexactNotice: subscription.inexactNotice,
-      destination: subscription.destination,
-      transfers: subscription.transfers,
-    );
   }
 
   void _emitSubscription(GetOffAlarmSubscription subscription) {

--- a/apps/mobile/lib/features/get_off_alarm/get_off_alarm_notifier.dart
+++ b/apps/mobile/lib/features/get_off_alarm/get_off_alarm_notifier.dart
@@ -159,12 +159,12 @@ class LocalGetOffAlarmNotifier implements GetOffAlarmNotifier {
     await cancelAll();
     final scheduleMode = androidScheduleModeFor(mode);
     var scheduledCount = 0;
-    final attemptCount = alarms.length < notificationCapacity
-        ? alarms.length
-        : notificationCapacity;
-    for (var index = 0; index < attemptCount; index++) {
-      final alarm = alarms[index];
-      final id = baseNotificationId + index;
+    for (final alarm in alarms) {
+      // slot이 전용 ID capacity를 벗어나면 예약하지 않고 실패로 센다.
+      if (alarm.slot < 0 || alarm.slot >= notificationCapacity) {
+        continue;
+      }
+      final id = baseNotificationId + alarm.slot;
       try {
         await _scheduleAlarm(
           id,

--- a/apps/mobile/lib/features/get_off_alarm/get_off_alarm_reconcile_worker.dart
+++ b/apps/mobile/lib/features/get_off_alarm/get_off_alarm_reconcile_worker.dart
@@ -70,11 +70,33 @@ Future<bool> reconcileGetOffAlarmHeadless({
 
 /// WorkManager headless isolate에서 실행되는 프로덕션 진입점. Drift user DB를 열고
 /// 컨트롤러를 조립해 단일 활성 구독을 재조정한 뒤, finally에서 DB·컨트롤러를 닫는다.
+///
+/// [openUserDatabase]·[createController]는 프로덕션 DB opener·컨트롤러 조립을
+/// 기본값으로 갖는 주입 seam이다(테스트에서 close 경로 — controller.dispose와
+/// userDatabase.close 호출 — 를 성공·예외 양쪽에서 고정하기 위함). 프로덕션
+/// 기본값 동작은 불변이다.
 Future<bool> runGetOffAlarmReconcileTask({
   required void Function(Object error, StackTrace stackTrace) reportError,
+  Future<UserDatabase> Function() openUserDatabase = _openUserDatabase,
+  GetOffAlarmController Function(UserDatabase userDatabase) createController =
+      _createReconcileController,
 }) async {
-  final UserDatabase userDatabase = await _openUserDatabase();
-  final controller = GetOffAlarmController(
+  final UserDatabase userDatabase = await openUserDatabase();
+  final controller = createController(userDatabase);
+  return reconcileGetOffAlarmHeadless(
+    reconcile: controller.reconcile,
+    close: () async {
+      controller.dispose();
+      await userDatabase.close();
+    },
+    reportError: reportError,
+  );
+}
+
+/// headless reconcile용 프로덕션 컨트롤러 조립. [userDatabase]를 공유해 상태
+/// 저장소·복구 안내 저장소를 구성한다.
+GetOffAlarmController _createReconcileController(UserDatabase userDatabase) {
+  return GetOffAlarmController(
     notifier: LocalGetOffAlarmNotifier(FlutterLocalNotificationsPlugin()),
     permissionGate: PluginExactAlarmPermissionGate(
       FlutterLocalNotificationsPlugin(),
@@ -87,14 +109,6 @@ Future<bool> runGetOffAlarmReconcileTask({
     ),
     onActivateReconcileWork: registerGetOffAlarmReconcile,
     onDeactivateReconcileWork: cancelGetOffAlarmReconcile,
-  );
-  return reconcileGetOffAlarmHeadless(
-    reconcile: controller.reconcile,
-    close: () async {
-      controller.dispose();
-      await userDatabase.close();
-    },
-    reportError: reportError,
   );
 }
 

--- a/apps/mobile/lib/features/get_off_alarm/get_off_alarm_reconcile_worker.dart
+++ b/apps/mobile/lib/features/get_off_alarm/get_off_alarm_reconcile_worker.dart
@@ -1,0 +1,106 @@
+import 'dart:io';
+
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import 'package:workmanager_android/workmanager_android.dart';
+import 'package:workmanager_platform_interface/workmanager_platform_interface.dart';
+
+import '../../core/database/user/user_database.dart';
+import '../../core/database/user/user_database_opener.dart';
+import '../../notification_settings.dart';
+import 'data/get_off_alarm_recovery_notice_store.dart';
+import 'data/get_off_alarm_state_repository.dart';
+import 'exact_alarm_permission.dart';
+import 'get_off_alarm_controller.dart';
+import 'get_off_alarm_notifier.dart';
+
+/// unique periodic work 이름과 task 이름. process-wide dispatcher는 하나만
+/// 유지하며(다음 열차 위젯과 공유), 이 task 이름으로 하차 알림 reconcile handler에
+/// 라우팅된다.
+const getOffAlarmReconcileTask = 'getOffAlarmReconcile';
+const getOffAlarmReconcileUniqueName = 'get-off-alarm-reconcile';
+
+/// 재조정 주기. 네트워크 제약은 두지 않는다(순수·위치 미사용 로컬 계산).
+const getOffAlarmReconcileFrequency = Duration(minutes: 15);
+
+/// 활성 구독 저장/재예약 시 unique periodic reconcile work를 등록/update한다.
+///
+/// WorkManager initialize는 여기서 하지 않는다(app bootstrap에서 정확히 1회).
+/// 이미 등록돼 있으면 [ExistingPeriodicWorkPolicy.update]로 갱신만 한다.
+Future<void> registerGetOffAlarmReconcile() async {
+  if (!Platform.isAndroid) {
+    return;
+  }
+  await WorkmanagerAndroid().registerPeriodicTask(
+    getOffAlarmReconcileUniqueName,
+    getOffAlarmReconcileTask,
+    frequency: getOffAlarmReconcileFrequency,
+    existingWorkPolicy: ExistingPeriodicWorkPolicy.update,
+    constraints: Constraints(networkType: NetworkType.notRequired),
+  );
+}
+
+/// off·만료·알림 권한 거부 정리 시 하차 알림 unique work만 취소한다. 다음 열차
+/// 위젯의 periodic work(`next-train-widget-refresh`)는 건드리지 않는다.
+Future<void> cancelGetOffAlarmReconcile() async {
+  if (!Platform.isAndroid) {
+    return;
+  }
+  await WorkmanagerAndroid().cancelByUniqueName(getOffAlarmReconcileUniqueName);
+}
+
+/// headless reconcile의 순수 오케스트레이션. 성공·예외와 무관하게 [close]로
+/// 리소스(DB·notifier)를 반드시 닫고, 예외는 fail-closed로 false를 돌려준다.
+Future<bool> reconcileGetOffAlarmHeadless({
+  required Future<void> Function() reconcile,
+  required Future<void> Function() close,
+  required void Function(Object error, StackTrace stackTrace) reportError,
+}) async {
+  try {
+    await reconcile();
+    return true;
+  } on Object catch (error, stackTrace) {
+    reportError(error, stackTrace);
+    return false;
+  } finally {
+    await close();
+  }
+}
+
+/// WorkManager headless isolate에서 실행되는 프로덕션 진입점. Drift user DB를 열고
+/// 컨트롤러를 조립해 단일 활성 구독을 재조정한 뒤, finally에서 DB·컨트롤러를 닫는다.
+Future<bool> runGetOffAlarmReconcileTask({
+  required void Function(Object error, StackTrace stackTrace) reportError,
+}) async {
+  final UserDatabase userDatabase = await _openUserDatabase();
+  final controller = GetOffAlarmController(
+    notifier: LocalGetOffAlarmNotifier(FlutterLocalNotificationsPlugin()),
+    permissionGate: PluginExactAlarmPermissionGate(
+      FlutterLocalNotificationsPlugin(),
+    ),
+    notificationPermissionProvider:
+        MethodChannelNotificationPermissionProvider(),
+    repository: DriftGetOffAlarmStateRepository(userDatabase: userDatabase),
+    recoveryNoticeStore: DriftGetOffAlarmRecoveryNoticeStore(
+      userDatabase: userDatabase,
+    ),
+    onActivateReconcileWork: registerGetOffAlarmReconcile,
+    onDeactivateReconcileWork: cancelGetOffAlarmReconcile,
+  );
+  return reconcileGetOffAlarmHeadless(
+    reconcile: controller.reconcile,
+    close: () async {
+      controller.dispose();
+      await userDatabase.close();
+    },
+    reportError: reportError,
+  );
+}
+
+Future<UserDatabase> _openUserDatabase() async {
+  final supportDirectory = await getApplicationSupportDirectory();
+  return UserDatabaseOpener(
+    databaseDirectory: Directory(p.join(supportDirectory.path, 'user')),
+  ).open();
+}

--- a/apps/mobile/lib/features/get_off_alarm/get_off_alarm_scheduler.dart
+++ b/apps/mobile/lib/features/get_off_alarm/get_off_alarm_scheduler.dart
@@ -59,6 +59,7 @@ class ScheduledGetOffAlarm {
     required this.kind,
     required this.fireAt,
     required this.arrivalAt,
+    required this.slot,
   });
 
   final String stationId;
@@ -66,6 +67,12 @@ class ScheduledGetOffAlarm {
   final GetOffAlarmKind kind;
   final DateTime fireAt;
   final DateTime arrivalAt;
+
+  /// 결정적 알림 슬롯. 입력 [stops] 목록에서의 위치로 정해지며, 만료된 알림이
+  /// 목록에서 빠져도 값이 바뀌지 않는다. 알림 ID는 `baseNotificationId + slot`으로
+  /// 매핑되어, 재부팅 복원과 WorkManager 재조정이 어떤 순서로 실행되든 같은
+  /// 정차역이 같은 ID로 재예약(idempotent)되어 최종 중복이 생기지 않는다.
+  final int slot;
 }
 
 /// [now]를 기준으로 [policy]에 따라 [stops]에 예약할 알림들을 계산한다. 환승
@@ -78,7 +85,11 @@ List<ScheduledGetOffAlarm> computeGetOffAlarms({
   required DateTime now,
 }) {
   final alarms = <ScheduledGetOffAlarm>[];
-  for (final stop in stops) {
+  for (var index = 0; index < stops.length; index++) {
+    final stop = stops[index];
+    // slot은 필터링 전 원본 위치로 고정한다. 만료된 알림이 빠져 결과 목록이
+    // 짧아져도 남은 정차역의 slot(=알림 ID)은 그대로여서 재예약이 idempotent하다.
+    final slot = index;
     if (stop.kind == GetOffAlarmKind.transfer && !policy.transferAlarmEnabled) {
       continue;
     }
@@ -96,6 +107,7 @@ List<ScheduledGetOffAlarm> computeGetOffAlarms({
         kind: stop.kind,
         fireAt: fireAt,
         arrivalAt: stop.arrivalAt,
+        slot: slot,
       ),
     );
   }

--- a/apps/mobile/lib/features/home_widget/next_train_widget_runtime.dart
+++ b/apps/mobile/lib/features/home_widget/next_train_widget_runtime.dart
@@ -14,6 +14,8 @@ import '../../core/database/catalog/catalog_database_opener.dart';
 import '../../core/database/user/user_database.dart';
 import '../../core/database/user/user_database_opener.dart';
 import '../../core/datapack/emergency_override_repository.dart';
+import '../../mobile_error_reporter.dart';
+import '../get_off_alarm/get_off_alarm_reconcile_worker.dart';
 import 'next_train_widget_configuration_screen.dart';
 import 'next_train_widget_repository.dart';
 import 'next_train_widget_service.dart';
@@ -167,19 +169,36 @@ Future<void> refreshInstalledNextTrainWidgets({
   }
 }
 
-Future<void> initializeNextTrainWidgetRefresh() async {
+/// process-wide WorkManager dispatcher를 초기화한다. app bootstrap에서 정확히
+/// 한 번만 호출한다(다음 열차 위젯·하차 알림 reconcile이 이 단일 dispatcher를
+/// 공유한다). 등록(register*)은 initialize와 분리해 개별적으로 수행한다.
+Future<void> initializeWorkManagerDispatcher() async {
   if (!Platform.isAndroid) {
     return;
   }
-  final workmanager = WorkmanagerAndroid();
-  await workmanager.initialize(nextTrainWidgetCallbackDispatcher);
-  await workmanager.registerPeriodicTask(
+  await WorkmanagerAndroid().initialize(nextTrainWidgetCallbackDispatcher);
+}
+
+/// 다음 열차 위젯 unique periodic work만 등록/update한다(initialize하지 않음).
+Future<void> registerNextTrainWidgetRefresh() async {
+  if (!Platform.isAndroid) {
+    return;
+  }
+  await WorkmanagerAndroid().registerPeriodicTask(
     nextTrainWidgetRefreshUniqueName,
     nextTrainWidgetRefreshTask,
     frequency: const Duration(minutes: 30),
     existingWorkPolicy: ExistingPeriodicWorkPolicy.update,
     constraints: Constraints(networkType: NetworkType.notRequired),
   );
+}
+
+/// 위젯 설정 activity(별도 engine)의 진입점 전용: 그 engine에는 dispatcher가
+/// 초기화돼 있지 않으므로 initialize와 register를 함께 수행한다. main bootstrap은
+/// 이 함수를 쓰지 않고 [initializeWorkManagerDispatcher]로 1회만 초기화한다.
+Future<void> initializeAndRegisterNextTrainWidgetRefresh() async {
+  await initializeWorkManagerDispatcher();
+  await registerNextTrainWidgetRefresh();
 }
 
 Future<void> cancelNextTrainWidgetRefresh() async {
@@ -245,8 +264,21 @@ void nextTrainWidgetCallbackDispatcher() {
 
 // ponytail: the federated public Android API keeps iOS SwiftPM-only; replace
 // this adapter when workmanager ships an official Android-only facade.
+//
+// 단일 process-wide dispatcher가 task 이름으로 각 handler에 라우팅한다. 알 수 없는
+// task는 성공으로 삼키지 않고 fail-closed(false)로 돌려준다(두 번째 dispatcher 금지).
 @visibleForTesting
 class NextTrainWidgetWorkmanagerApi extends WorkmanagerFlutterApi {
+  NextTrainWidgetWorkmanagerApi({
+    Future<bool> Function()? runWidgetRefresh,
+    Future<bool> Function()? runGetOffAlarmReconcile,
+  }) : _runWidgetRefresh = runWidgetRefresh ?? _defaultRunWidgetRefresh,
+       _runGetOffAlarmReconcile =
+           runGetOffAlarmReconcile ?? _defaultRunGetOffAlarmReconcile;
+
+  final Future<bool> Function() _runWidgetRefresh;
+  final Future<bool> Function() _runGetOffAlarmReconcile;
+
   @override
   Future<void> backgroundChannelInitialized() async {}
 
@@ -255,9 +287,17 @@ class NextTrainWidgetWorkmanagerApi extends WorkmanagerFlutterApi {
     String task,
     Map<String?, Object?>? inputData,
   ) async {
-    if (task != nextTrainWidgetRefreshTask) {
-      return true;
+    switch (task) {
+      case nextTrainWidgetRefreshTask:
+        return _runWidgetRefresh();
+      case getOffAlarmReconcileTask:
+        return _runGetOffAlarmReconcile();
+      default:
+        return false;
     }
+  }
+
+  static Future<bool> _defaultRunWidgetRefresh() async {
     WidgetsFlutterBinding.ensureInitialized();
     DartPluginRegistrant.ensureInitialized();
     final databases = await _openWidgetDatabases();
@@ -272,6 +312,18 @@ class NextTrainWidgetWorkmanagerApi extends WorkmanagerFlutterApi {
       await databases.close();
     }
     return true;
+  }
+
+  static Future<bool> _defaultRunGetOffAlarmReconcile() async {
+    WidgetsFlutterBinding.ensureInitialized();
+    DartPluginRegistrant.ensureInitialized();
+    return runGetOffAlarmReconcileTask(
+      reportError: (error, stackTrace) => reportMobileError(
+        error,
+        stackTrace,
+        context: '하차 알림 headless reconcile 중 예외가 발생했습니다.',
+      ),
+    );
   }
 }
 
@@ -309,7 +361,7 @@ Future<void> configureMain() async {
                       now: DateTime.now(),
                     ),
               ),
-              registerRefresh: initializeNextTrainWidgetRefresh,
+              registerRefresh: initializeAndRegisterNextTrainWidgetRefresh,
               finish: HomeWidget.finishHomeWidgetConfigure,
               cancelRefresh: () async {
                 final installedWidgetIds = await installedNextTrainWidgetIds();

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -42,6 +42,9 @@ Future<void> main() async {
         ? DemoSearchHistoryRepository()
         : null,
   );
+  // process-wide WorkManager dispatcher를 app bootstrap에서 정확히 1회 초기화한다.
+  // 이후 하차 알림 복원과 위젯 startup은 각자 등록만 수행한다(재초기화 금지).
+  await next_train_widget_runtime.initializeWorkManagerDispatcher();
   await restoreGetOffAlarmState(bootstrap.dependencies.getOffAlarmController);
   final nextTrainWidgetRepository = NextTrainWidgetRepository(
     catalogDatabase: bootstrap.catalogDatabase,
@@ -49,7 +52,7 @@ Future<void> main() async {
   );
   await next_train_widget_runtime.runNextTrainWidgetStartup(
     installedWidgetIds: next_train_widget_runtime.installedNextTrainWidgetIds,
-    registerRefresh: next_train_widget_runtime.initializeNextTrainWidgetRefresh,
+    registerRefresh: next_train_widget_runtime.registerNextTrainWidgetRefresh,
     cancelRefresh: next_train_widget_runtime.cancelNextTrainWidgetRefresh,
     refresh: (widgetIds) => next_train_widget_runtime.refreshNextTrainWidgets(
       nextTrainWidgetRepository,

--- a/apps/mobile/release/post-launch-operations-review-gate.json
+++ b/apps/mobile/release/post-launch-operations-review-gate.json
@@ -78,7 +78,7 @@
             {"path": "apps/mobile/lib/features/settings/presentation/open_source_licenses_screen.dart", "sha256": "822762b61cd3824340c4e45cf5ffe3079e221d28712dd98d94fd9a03fe5fd591"},
             {"path": "apps/mobile/lib/features/settings/presentation/service_info_screen.dart", "sha256": "62e036e62f5e5ce235d494d5d730a6dd6ea5659e1b53290d94a6c7c954bcdcd9"},
             {"path": "apps/mobile/lib/features/support/presentation/support_access_screen.dart", "sha256": "d407c10fdf20cf821b0273065388885d2511b6eb14b6ef02183f1723d0a83112"},
-            {"path": "apps/mobile/lib/main.dart", "sha256": "0b9370e0f69610bd9cf9a31735898373e89221cc2ee17be02d3b06869fdc8d6b"}
+            {"path": "apps/mobile/lib/main.dart", "sha256": "7acfce0eff73e5bd10d912a2da72a2990db2e2fb87a5d91c7ef907ed0f559de3"}
           ]
         },
         {

--- a/apps/mobile/test/features/get_off_alarm/get_off_alarm_controller_test.dart
+++ b/apps/mobile/test/features/get_off_alarm/get_off_alarm_controller_test.dart
@@ -187,6 +187,21 @@ class _StubNotificationPermissionProvider
   }
 }
 
+/// 호출마다 다음 시각을 돌려주는 주입용 시계. 마지막 원소에 도달하면 그대로
+/// 유지한다. now()가 몇 번 소비됐는지([calls])로 단일 스냅샷 여부를 검증한다.
+class _AdvancingClock {
+  _AdvancingClock(this._instants);
+
+  final List<DateTime> _instants;
+  int calls = 0;
+
+  DateTime now() {
+    final index = calls < _instants.length ? calls : _instants.length - 1;
+    calls += 1;
+    return _instants[index];
+  }
+}
+
 void main() {
   final now = DateTime(2026, 7, 6, 9, 0, 0);
 
@@ -376,6 +391,45 @@ void main() {
     expect(restored.state.enabled, isTrue);
     expect(restored.state.activeRouteId, 'r1');
     expect((await repository.loadActive())?.routeId, 'r1');
+  });
+
+  test('restore는 단일 now 스냅샷으로 계산해 마지막 알림 경계에서 갈라지지 않는다', () async {
+    // 저장: 환승 9:15(fireAt 9:13)·도착 9:30(fireAt 9:28).
+    final first = controller(exactPermitted: true);
+    await first.enable(
+      routeId: 'r1',
+      stops: stops(),
+      transferAlarmEnabled: true,
+    );
+
+    // restore 시점의 두 후보 스냅샷: 첫 스냅샷은 마지막 fireAt(9:28) 직전이라
+    // 도착 알림 1건이 미래이고, 다음 스냅샷은 직후라 0건이다. 원자화 전이라면
+    // _restore의 만료 판정(1건)과 _schedule의 재계산(0건)이 갈려 복구가 조용히
+    // off로 정리됐다. 원자화 후에는 첫 스냅샷 결과로만 예약한다.
+    final clock = _AdvancingClock([
+      DateTime(2026, 7, 6, 9, 27, 59),
+      DateTime(2026, 7, 6, 9, 28, 1),
+    ]);
+    notifier.scheduleCalls = 0;
+    final restored = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: _StubExactAlarmGate(true),
+      notificationPermissionProvider: _StubNotificationPermissionProvider(
+        NotificationPermissionStatus.granted,
+      ),
+      repository: repository,
+      now: clock.now,
+    );
+    addTearDown(restored.dispose);
+
+    await restored.restore();
+
+    // 첫 스냅샷 결과(도착 1건)로 예약되고 켜진 상태를 유지한다.
+    expect(restored.state.enabled, isTrue);
+    expect(notifier.scheduleCalls, 1);
+    expect(notifier.scheduledAlarms, hasLength(1));
+    // restore 경로 전체가 now를 정확히 한 번만 읽어 두 스냅샷 갈림이 불가능하다.
+    expect(clock.calls, 1);
   });
 
   test('restore는 미래 구독을 결정적 재예약하고 실제 예약 수를 저장한다', () async {

--- a/apps/mobile/test/features/get_off_alarm/get_off_alarm_controller_test.dart
+++ b/apps/mobile/test/features/get_off_alarm/get_off_alarm_controller_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:easysubway_mobile/core/database/user/user_database.dart';
+import 'package:easysubway_mobile/features/get_off_alarm/data/get_off_alarm_recovery_notice_store.dart';
 import 'package:easysubway_mobile/features/get_off_alarm/data/get_off_alarm_state_repository.dart';
 import 'package:easysubway_mobile/features/get_off_alarm/exact_alarm_permission.dart';
 import 'package:easysubway_mobile/features/get_off_alarm/get_off_alarm_controller.dart';
@@ -143,6 +144,26 @@ class _BlockingRefreshExactAlarmGate implements ExactAlarmPermissionGate {
 
   @override
   Future<bool> requestExactAlarmPermission() async => true;
+}
+
+class _RecordingRecoveryNoticeStore implements GetOffAlarmRecoveryNoticeStore {
+  bool flag = false;
+  int recordCount = 0;
+  int consumeCount = 0;
+
+  @override
+  Future<void> record() async {
+    recordCount += 1;
+    flag = true;
+  }
+
+  @override
+  Future<bool> consume() async {
+    consumeCount += 1;
+    final current = flag;
+    flag = false;
+    return current;
+  }
 }
 
 class _StubNotificationPermissionProvider
@@ -338,39 +359,44 @@ void main() {
     expect(restored.state.enabled, isFalse);
   });
 
-  test('restore에서 전용 pending이 0건이면 stale 구독을 끄다', () async {
+  test('restore에서 미래 구독은 pending 상태와 무관하게 전체 재예약한다', () async {
     final first = controller(exactPermitted: true);
     await first.enable(
       routeId: 'r1',
       stops: stops(),
       transferAlarmEnabled: true,
     );
-    notifier.pendingCount = 0;
+    notifier.scheduleCalls = 0;
 
     final restored = controller(exactPermitted: true);
     await restored.restore();
 
-    expect(notifier.cancelAllCount, 1);
-    expect(await repository.loadActive(), isNull);
-    expect(restored.state.enabled, isFalse);
+    expect(notifier.scheduleCalls, 1);
+    expect(notifier.scheduledAlarms, hasLength(2));
+    expect(restored.state.enabled, isTrue);
+    expect(restored.state.activeRouteId, 'r1');
+    expect((await repository.loadActive())?.routeId, 'r1');
   });
 
-  test('restore는 OS pending 드리프트를 실제 건수로 저장한다', () async {
+  test('restore는 미래 구독을 결정적 재예약하고 실제 예약 수를 저장한다', () async {
+    notifier.result = const ScheduleDeliveryResult(
+      scheduledCount: 2,
+      failedCount: 0,
+    );
     final first = controller(exactPermitted: true);
     await first.enable(
       routeId: 'r1',
       stops: stops(),
       transferAlarmEnabled: true,
     );
-    notifier.pendingCount = 1;
 
     final restored = controller(exactPermitted: true);
     await restored.restore();
 
     expect(restored.state.enabled, isTrue);
-    expect(restored.state.scheduledCount, 1);
-    expect((await repository.loadActive())!.scheduledCount, 1);
-    expect(notifier.scheduleCalls, 1);
+    expect(restored.state.scheduledCount, 2);
+    expect((await repository.loadActive())!.scheduledCount, 2);
+    expect(notifier.scheduleCalls, 2);
   });
 
   test('restore에서 exact 상태가 바뀌면 저장된 stops로 권한 요청 없이 재예약한다', () async {
@@ -859,5 +885,152 @@ void main() {
     expect(notifier.cancelAllCount, 2);
     expect(stateRepository.active, isNull);
     expect(c.state.enabled, isFalse);
+  });
+
+  test('restore에서 만료 구독은 pending을 취소하고 구독을 삭제한다', () async {
+    final first = controller(exactPermitted: true);
+    await first.enable(
+      routeId: 'r1',
+      stops: stops(),
+      transferAlarmEnabled: true,
+    );
+    // 저장된 도착 시각(9:15/9:30)이 모두 지난 시점으로 복원한다.
+    final expired = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: _StubExactAlarmGate(true),
+      notificationPermissionProvider: _StubNotificationPermissionProvider(
+        NotificationPermissionStatus.granted,
+      ),
+      repository: repository,
+      now: () => DateTime(2026, 7, 6, 10, 0, 0),
+    );
+    addTearDown(expired.dispose);
+    notifier.cancelAllCount = 0;
+    notifier.scheduleCalls = 0;
+
+    await expired.restore();
+
+    expect(notifier.cancelAllCount, 1);
+    expect(notifier.scheduleCalls, 0);
+    expect(await repository.loadActive(), isNull);
+    expect(expired.state.enabled, isFalse);
+  });
+
+  test('알림 권한 거부 정리는 복구 안내 플래그를 기록하고 안내를 표시한다', () async {
+    final store = _RecordingRecoveryNoticeStore();
+    final first = controller(exactPermitted: true);
+    await first.enable(
+      routeId: 'r1',
+      stops: stops(),
+      transferAlarmEnabled: true,
+    );
+    final denied = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: _StubExactAlarmGate(true),
+      notificationPermissionProvider: _StubNotificationPermissionProvider(
+        NotificationPermissionStatus.denied,
+      ),
+      repository: repository,
+      recoveryNoticeStore: store,
+      now: () => now,
+    );
+    addTearDown(denied.dispose);
+
+    await denied.restore();
+
+    expect(store.recordCount, 1);
+    expect(await repository.loadActive(), isNull);
+    expect(denied.state.enabled, isFalse);
+    expect(denied.state.permissionNotice, '휴대전화 알림 권한을 허용해 주세요.');
+  });
+
+  test('다음 UI init은 기록된 복구 안내를 한 번 표시하고 플래그를 지운다', () async {
+    final store = _RecordingRecoveryNoticeStore()..flag = true;
+    final stateRepository = _RecordingStateRepository();
+    final restored = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: _StubExactAlarmGate(true),
+      notificationPermissionProvider: _StubNotificationPermissionProvider(
+        NotificationPermissionStatus.granted,
+      ),
+      repository: stateRepository,
+      recoveryNoticeStore: store,
+      now: () => now,
+    );
+    addTearDown(restored.dispose);
+
+    await restored.restore();
+
+    expect(restored.state.permissionNotice, '휴대전화 알림 권한을 허용해 주세요.');
+    expect(store.flag, isFalse);
+
+    // 두 번째 init은 더 이상 복구 안내를 표시하지 않는다(one-shot).
+    await restored.restore();
+    expect(restored.state.permissionNotice, isNull);
+  });
+
+  test('활성 구독 저장은 reconcile work를 등록하고 취소하지 않는다', () async {
+    var activateCount = 0;
+    var deactivateCount = 0;
+    final c = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: _StubExactAlarmGate(true),
+      notificationPermissionProvider: _StubNotificationPermissionProvider(
+        NotificationPermissionStatus.granted,
+      ),
+      repository: repository,
+      onActivateReconcileWork: () async => activateCount += 1,
+      onDeactivateReconcileWork: () async => deactivateCount += 1,
+      now: () => now,
+    );
+    addTearDown(c.dispose);
+
+    await c.enable(routeId: 'r1', stops: stops(), transferAlarmEnabled: true);
+
+    expect(activateCount, 1);
+    expect(deactivateCount, 0);
+  });
+
+  test('off 정리는 reconcile work를 취소한다', () async {
+    var deactivateCount = 0;
+    final c = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: _StubExactAlarmGate(true),
+      notificationPermissionProvider: _StubNotificationPermissionProvider(
+        NotificationPermissionStatus.granted,
+      ),
+      repository: repository,
+      onActivateReconcileWork: () async {},
+      onDeactivateReconcileWork: () async => deactivateCount += 1,
+      now: () => now,
+    );
+    addTearDown(c.dispose);
+    await c.enable(routeId: 'r1', stops: stops(), transferAlarmEnabled: true);
+
+    await c.disable();
+
+    expect(deactivateCount, greaterThanOrEqualTo(1));
+  });
+
+  test('사용자가 끈 구독(없음)은 복원하지 않는다', () async {
+    final stateRepository = _RecordingStateRepository();
+    var activateCount = 0;
+    final restored = GetOffAlarmController(
+      notifier: notifier,
+      permissionGate: _StubExactAlarmGate(true),
+      notificationPermissionProvider: _StubNotificationPermissionProvider(
+        NotificationPermissionStatus.granted,
+      ),
+      repository: stateRepository,
+      onActivateReconcileWork: () async => activateCount += 1,
+      now: () => now,
+    );
+    addTearDown(restored.dispose);
+
+    await restored.restore();
+
+    expect(activateCount, 0);
+    expect(notifier.scheduleCalls, 0);
+    expect(restored.state.enabled, isFalse);
   });
 }

--- a/apps/mobile/test/features/get_off_alarm/get_off_alarm_notifier_test.dart
+++ b/apps/mobile/test/features/get_off_alarm/get_off_alarm_notifier_test.dart
@@ -14,6 +14,7 @@ void main() {
       kind: GetOffAlarmKind.transfer,
       fireAt: arrivalAt.subtract(const Duration(minutes: 2)),
       arrivalAt: arrivalAt,
+      slot: index,
     );
   }
 
@@ -55,6 +56,7 @@ void main() {
           kind: GetOffAlarmKind.destination,
           fireAt: arrivalAt.subtract(const Duration(minutes: 2)),
           arrivalAt: arrivalAt,
+          slot: 0,
         ),
         ScheduledGetOffAlarm(
           stationId: 'station-geumjeong',
@@ -62,6 +64,7 @@ void main() {
           kind: GetOffAlarmKind.transfer,
           fireAt: arrivalAt.subtract(const Duration(minutes: 5)),
           arrivalAt: arrivalAt,
+          slot: 1,
         ),
       ], mode: GetOffAlarmScheduleMode.exact);
 
@@ -160,6 +163,96 @@ void main() {
 
       expect(result.scheduledCount, 2);
       expect(result.failedCount, 1);
+    });
+
+    test('예약 ID는 slot 기반이며 만료로 목록이 줄어도 같은 ID를 재사용한다', () async {
+      final pending = <int>{};
+      final base = LocalGetOffAlarmNotifier.baseNotificationId;
+      final arrivalAt = DateTime(2026, 7, 10, 10);
+      LocalGetOffAlarmNotifier build() => LocalGetOffAlarmNotifier(
+        FlutterLocalNotificationsPlugin(),
+        isAndroid: true,
+        initializePlugin: () async {},
+        pendingIds: () async => pending.toList(),
+        cancelId: (id) async => pending.remove(id),
+        scheduleAlarm: (id, _, _, _, _) async => pending.add(id),
+      );
+
+      await build().scheduleAlarms([
+        ScheduledGetOffAlarm(
+          stationId: 't',
+          stationName: '환승',
+          kind: GetOffAlarmKind.transfer,
+          fireAt: arrivalAt.subtract(const Duration(minutes: 5)),
+          arrivalAt: arrivalAt,
+          slot: 0,
+        ),
+        ScheduledGetOffAlarm(
+          stationId: 'd',
+          stationName: '목적',
+          kind: GetOffAlarmKind.destination,
+          fireAt: arrivalAt.subtract(const Duration(minutes: 2)),
+          arrivalAt: arrivalAt,
+          slot: 1,
+        ),
+      ], mode: GetOffAlarmScheduleMode.exact);
+      expect(pending, {base, base + 1});
+
+      // 재부팅 후: transfer는 이미 만료돼 목록에서 빠지고 destination만 남지만
+      // slot은 1로 고정. base+1을 재사용해 부팅 복원분과 겹쳐도 중복이 없다.
+      await build().scheduleAlarms([
+        ScheduledGetOffAlarm(
+          stationId: 'd',
+          stationName: '목적',
+          kind: GetOffAlarmKind.destination,
+          fireAt: arrivalAt.subtract(const Duration(minutes: 2)),
+          arrivalAt: arrivalAt,
+          slot: 1,
+        ),
+      ], mode: GetOffAlarmScheduleMode.exact);
+      expect(pending, {base + 1});
+    });
+
+    test('공식 boot receiver와 reconcile은 실행 순서와 무관하게 중복 pending이 없다', () async {
+      final base = LocalGetOffAlarmNotifier.baseNotificationId;
+      final arrivalAt = DateTime(2026, 7, 10, 10);
+
+      for (final reconcileFirst in [true, false]) {
+        final pending = <int>{};
+        LocalGetOffAlarmNotifier build() => LocalGetOffAlarmNotifier(
+          FlutterLocalNotificationsPlugin(),
+          isAndroid: true,
+          initializePlugin: () async {},
+          pendingIds: () async => pending.toList(),
+          cancelId: (id) async => pending.remove(id),
+          scheduleAlarm: (id, _, _, _, _) async => pending.add(id),
+        );
+        // 부팅 전 persisted 상태: destination(slot 1)만 예약돼 있었다.
+        const prebootIds = {1};
+        // 공식 ScheduledNotificationBootReceiver는 persisted ID를 그대로 되살린다.
+        void bootRestore() => pending.addAll(prebootIds.map((s) => base + s));
+        // WorkManager reconcile은 slot 기반으로 destination(slot 1)만 재예약한다.
+        Future<void> reconcile() => build().scheduleAlarms([
+          ScheduledGetOffAlarm(
+            stationId: 'd',
+            stationName: '목적',
+            kind: GetOffAlarmKind.destination,
+            fireAt: arrivalAt.subtract(const Duration(minutes: 2)),
+            arrivalAt: arrivalAt,
+            slot: 1,
+          ),
+        ], mode: GetOffAlarmScheduleMode.exact);
+
+        if (reconcileFirst) {
+          await reconcile();
+          bootRestore();
+        } else {
+          bootRestore();
+          await reconcile();
+        }
+
+        expect(pending, {base + 1});
+      }
     });
 
     test('pending 목록 조회 실패를 취소 성공으로 삼키지 않는다', () async {

--- a/apps/mobile/test/features/get_off_alarm/get_off_alarm_reconcile_worker_test.dart
+++ b/apps/mobile/test/features/get_off_alarm/get_off_alarm_reconcile_worker_test.dart
@@ -1,0 +1,56 @@
+import 'package:easysubway_mobile/features/get_off_alarm/get_off_alarm_reconcile_worker.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('reconcile 성공은 true를 돌려주고 finally에서 리소스를 닫는다', () async {
+    var reconcileCount = 0;
+    var closeCount = 0;
+    final errors = <Object>[];
+
+    final result = await reconcileGetOffAlarmHeadless(
+      reconcile: () async => reconcileCount += 1,
+      close: () async => closeCount += 1,
+      reportError: (error, _) => errors.add(error),
+    );
+
+    expect(result, isTrue);
+    expect(reconcileCount, 1);
+    expect(closeCount, 1);
+    expect(errors, isEmpty);
+  });
+
+  test('reconcile 예외는 fail-closed(false)로 삼키고 리소스를 반드시 닫는다', () async {
+    final failure = StateError('reconcile failed');
+    var closeCount = 0;
+    final errors = <Object>[];
+
+    final result = await reconcileGetOffAlarmHeadless(
+      reconcile: () async => throw failure,
+      close: () async => closeCount += 1,
+      reportError: (error, _) => errors.add(error),
+    );
+
+    expect(result, isFalse);
+    expect(closeCount, 1);
+    expect(errors.single, same(failure));
+  });
+
+  test('close 자체가 실패해도 성공 결과를 유지한 채 예외를 전파한다', () async {
+    final closeFailure = StateError('close failed');
+
+    await expectLater(
+      reconcileGetOffAlarmHeadless(
+        reconcile: () async {},
+        close: () async => throw closeFailure,
+        reportError: (_, _) {},
+      ),
+      throwsA(same(closeFailure)),
+    );
+  });
+
+  test('reconcile work 예약 계약 상수는 15분·전용 unique·task 이름을 고정한다', () {
+    expect(getOffAlarmReconcileFrequency, const Duration(minutes: 15));
+    expect(getOffAlarmReconcileUniqueName, 'get-off-alarm-reconcile');
+    expect(getOffAlarmReconcileTask, 'getOffAlarmReconcile');
+  });
+}

--- a/apps/mobile/test/features/get_off_alarm/get_off_alarm_reconcile_worker_test.dart
+++ b/apps/mobile/test/features/get_off_alarm/get_off_alarm_reconcile_worker_test.dart
@@ -1,5 +1,62 @@
+import 'package:drift/native.dart';
+import 'package:easysubway_mobile/core/database/user/user_database.dart';
+import 'package:easysubway_mobile/features/get_off_alarm/data/get_off_alarm_state_repository.dart';
+import 'package:easysubway_mobile/features/get_off_alarm/exact_alarm_permission.dart';
+import 'package:easysubway_mobile/features/get_off_alarm/get_off_alarm_controller.dart';
+import 'package:easysubway_mobile/features/get_off_alarm/get_off_alarm_notifier.dart';
 import 'package:easysubway_mobile/features/get_off_alarm/get_off_alarm_reconcile_worker.dart';
+import 'package:easysubway_mobile/notification_settings.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+/// 컨트롤러 조립에 필요한 협력자들의 no-op 대역. reconcile을 오버라이드한
+/// 테스트 컨트롤러에서는 실제로 호출되지 않으므로 noSuchMethod로 일괄 대체한다.
+class _NoopDeps
+    implements
+        GetOffAlarmNotifier,
+        ExactAlarmPermissionGate,
+        NotificationPermissionProvider,
+        GetOffAlarmStateRepository {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+final _noopDeps = _NoopDeps();
+
+/// reconcile 동작을 주입받고 dispose 호출을 기록하는 테스트 컨트롤러.
+class _RecordingReconcileController extends GetOffAlarmController {
+  _RecordingReconcileController({required this.onReconcile})
+    : super(
+        notifier: _noopDeps,
+        permissionGate: _noopDeps,
+        notificationPermissionProvider: _noopDeps,
+        repository: _noopDeps,
+      );
+
+  final Future<void> Function() onReconcile;
+  int disposeCount = 0;
+
+  @override
+  Future<void> reconcile() => onReconcile();
+
+  @override
+  void dispose() {
+    disposeCount += 1;
+    super.dispose();
+  }
+}
+
+/// close 호출을 기록하는 인메모리 user DB.
+class _RecordingUserDatabase extends UserDatabase {
+  _RecordingUserDatabase() : super(NativeDatabase.memory());
+
+  int closeCount = 0;
+
+  @override
+  Future<void> close() {
+    closeCount += 1;
+    return super.close();
+  }
+}
 
 void main() {
   test('reconcile 성공은 true를 돌려주고 finally에서 리소스를 닫는다', () async {
@@ -47,6 +104,58 @@ void main() {
       throwsA(same(closeFailure)),
     );
   });
+
+  test(
+    '프로덕션 진입점은 성공 경로에서 열린 DB로 컨트롤러를 조립하고 close에서 dispose·DB close를 부른다',
+    () async {
+      final db = _RecordingUserDatabase();
+      final controller = _RecordingReconcileController(
+        onReconcile: () async {},
+      );
+      UserDatabase? passedToFactory;
+      final errors = <Object>[];
+
+      final result = await runGetOffAlarmReconcileTask(
+        reportError: (error, _) => errors.add(error),
+        openUserDatabase: () async => db,
+        createController: (userDatabase) {
+          passedToFactory = userDatabase;
+          return controller;
+        },
+      );
+
+      expect(result, isTrue);
+      // 컨트롤러 factory는 열린 DB를 그대로 전달받는다.
+      expect(passedToFactory, same(db));
+      // close 경로가 성공 후에도 두 리소스를 모두 닫는다.
+      expect(controller.disposeCount, 1);
+      expect(db.closeCount, 1);
+      expect(errors, isEmpty);
+    },
+  );
+
+  test(
+    '프로덕션 진입점은 예외 경로에서도 close에서 dispose·DB close를 부르고 fail-closed한다',
+    () async {
+      final db = _RecordingUserDatabase();
+      final failure = StateError('reconcile boom');
+      final controller = _RecordingReconcileController(
+        onReconcile: () async => throw failure,
+      );
+      final errors = <Object>[];
+
+      final result = await runGetOffAlarmReconcileTask(
+        reportError: (error, _) => errors.add(error),
+        openUserDatabase: () async => db,
+        createController: (_) => controller,
+      );
+
+      expect(result, isFalse);
+      expect(controller.disposeCount, 1);
+      expect(db.closeCount, 1);
+      expect(errors.single, same(failure));
+    },
+  );
 
   test('reconcile work 예약 계약 상수는 15분·전용 unique·task 이름을 고정한다', () {
     expect(getOffAlarmReconcileFrequency, const Duration(minutes: 15));

--- a/apps/mobile/test/features/get_off_alarm/get_off_alarm_recovery_notice_store_test.dart
+++ b/apps/mobile/test/features/get_off_alarm/get_off_alarm_recovery_notice_store_test.dart
@@ -1,0 +1,36 @@
+import 'package:easysubway_mobile/core/database/user/user_database.dart';
+import 'package:easysubway_mobile/features/get_off_alarm/data/get_off_alarm_recovery_notice_store.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late UserDatabase db;
+  late DriftGetOffAlarmRecoveryNoticeStore store;
+
+  setUp(() {
+    db = UserDatabase.memory();
+    store = DriftGetOffAlarmRecoveryNoticeStore(userDatabase: db);
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  test('기록이 없으면 consume은 false를 돌려준다', () async {
+    expect(await store.consume(), isFalse);
+  });
+
+  test('record 후 첫 consume만 true이고 이후에는 false다(one-shot)', () async {
+    await store.record();
+
+    expect(await store.consume(), isTrue);
+    expect(await store.consume(), isFalse);
+  });
+
+  test('record는 idempotent하며 단일 플래그로 유지된다', () async {
+    await store.record();
+    await store.record();
+
+    expect(await store.consume(), isTrue);
+    expect(await store.consume(), isFalse);
+  });
+}

--- a/apps/mobile/test/features/get_off_alarm/get_off_alarm_scheduler_test.dart
+++ b/apps/mobile/test/features/get_off_alarm/get_off_alarm_scheduler_test.dart
@@ -124,5 +124,46 @@ void main() {
 
       expect(alarms.single.fireAt, DateTime(2026, 7, 7, 0, 1, 0));
     });
+
+    test('모든 정차역이 미래면 slot은 입력 순서와 같다', () {
+      final now = DateTime(2026, 7, 6, 9, 0, 0);
+      final alarms = computeGetOffAlarms(
+        stops: [
+          stop(
+            'transfer',
+            DateTime(2026, 7, 6, 9, 15, 0),
+            kind: GetOffAlarmKind.transfer,
+          ),
+          stop('dest', DateTime(2026, 7, 6, 9, 30, 0)),
+        ],
+        policy: policy,
+        now: now,
+      );
+
+      expect(alarms.map((a) => a.slot), [0, 1]);
+    });
+
+    test('만료된 앞 정차역이 빠져도 남은 정차역 slot은 원본 위치로 고정된다', () {
+      // transfer fireAt=9:13, destination fireAt=9:28. now=9:20이면 transfer만
+      // 만료되어 결과에서 빠지지만, destination의 slot은 앞으로 당겨지지 않고
+      // 입력 위치(1)를 유지해야 재부팅 재예약 ID가 어긋나지 않는다.
+      final now = DateTime(2026, 7, 6, 9, 20, 0);
+      final alarms = computeGetOffAlarms(
+        stops: [
+          stop(
+            'transfer',
+            DateTime(2026, 7, 6, 9, 15, 0),
+            kind: GetOffAlarmKind.transfer,
+          ),
+          stop('dest', DateTime(2026, 7, 6, 9, 30, 0)),
+        ],
+        policy: policy,
+        now: now,
+      );
+
+      expect(alarms, hasLength(1));
+      expect(alarms.single.kind, GetOffAlarmKind.destination);
+      expect(alarms.single.slot, 1);
+    });
   });
 }

--- a/apps/mobile/test/features/home_widget/next_train_widget_service_test.dart
+++ b/apps/mobile/test/features/home_widget/next_train_widget_service_test.dart
@@ -1,3 +1,4 @@
+import 'package:easysubway_mobile/features/get_off_alarm/get_off_alarm_reconcile_worker.dart';
 import 'package:easysubway_mobile/features/home_widget/next_train_widget_repository.dart';
 import 'package:easysubway_mobile/features/home_widget/next_train_widget_runtime.dart';
 import 'package:easysubway_mobile/features/home_widget/next_train_widget_service.dart';
@@ -168,10 +169,41 @@ void main() {
     expect(launched, isFalse);
   });
 
-  test('알 수 없는 WorkManager task는 성공으로 무시한다', () async {
-    final worker = NextTrainWidgetWorkmanagerApi();
+  test('알 수 없는 WorkManager task는 fail-closed로 false를 돌려준다', () async {
+    var widgetRan = false;
+    var reconcileRan = false;
+    final worker = NextTrainWidgetWorkmanagerApi(
+      runWidgetRefresh: () async {
+        widgetRan = true;
+        return true;
+      },
+      runGetOffAlarmReconcile: () async {
+        reconcileRan = true;
+        return true;
+      },
+    );
 
-    expect(await worker.executeTask('other-task', null), isTrue);
+    expect(await worker.executeTask('other-task', null), isFalse);
+    expect(widgetRan, isFalse);
+    expect(reconcileRan, isFalse);
+  });
+
+  test('단일 dispatcher가 task 이름별로 각 handler에 라우팅한다', () async {
+    final calls = <String>[];
+    final worker = NextTrainWidgetWorkmanagerApi(
+      runWidgetRefresh: () async {
+        calls.add('widget');
+        return true;
+      },
+      runGetOffAlarmReconcile: () async {
+        calls.add('reconcile');
+        return true;
+      },
+    );
+
+    expect(await worker.executeTask(nextTrainWidgetRefreshTask, null), isTrue);
+    expect(await worker.executeTask(getOffAlarmReconcileTask, null), isTrue);
+    expect(calls, ['widget', 'reconcile']);
   });
 
   test('configure는 widget id별 시간표 snapshot을 저장하고 provider를 갱신한다', () async {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -17014,6 +17014,29 @@ test("Android 릴리즈 권한은 앱 기능에 필요한 항목만 선언한다
     "android.permission.VIBRATE",
     "android.permission.WAKE_LOCK",
   ]);
+  // #2154: 재부팅·package replace 뒤 예약을 앱 실행 없이 복원하려면 merged
+  // manifest가 공식 boot receiver를 exported=false로 등록하고 네 부팅 계열 action을
+  // 정확히 포함해야 한다. RECEIVE_BOOT_COMPLETED 권한은 위 permissions 목록에서 검증한다.
+  const mergedBootReceiver = androidManifest.match(
+    /<receiver[^>]*android:name="com\.dexterous\.flutterlocalnotifications\.ScheduledNotificationBootReceiver"[\s\S]*?<\/receiver>/,
+  );
+  assert.ok(
+    mergedBootReceiver,
+    "Merged manifest must register ScheduledNotificationBootReceiver for boot restore.",
+  );
+  assert.match(mergedBootReceiver[0], /android:exported="false"/);
+  for (const action of [
+    "android.intent.action.BOOT_COMPLETED",
+    "android.intent.action.MY_PACKAGE_REPLACED",
+    "android.intent.action.QUICKBOOT_POWERON",
+    "com.htc.intent.action.QUICKBOOT_POWERON",
+  ]) {
+    assert.match(
+      mergedBootReceiver[0],
+      new RegExp(`android:name="${action.replace(/\./g, "\\.")}"`),
+      `merged boot receiver must include intent action ${action}`,
+    );
+  }
   // regular periodic worker는 foreground promotion을 사용하지 않으므로 FGS 권한은
   // 제거한다. 향후 long-running worker 도입 시 별도 Play/permission 검토가 필요하다.
   assert.doesNotMatch(androidManifest, /android\.permission\.USE_EXACT_ALARM/);
@@ -17607,19 +17630,38 @@ test("get-off-alarm policy contract pins the no-location, degrade-ladder invaria
   assert.equal(policy.realtimeCorrection.correctionOverlayIssue, 1416);
 });
 
-test("하차 알림 Android source manifest는 boot receiver 없이 예약 receiver만 선언한다", () => {
+test("하차 알림 Android source manifest는 예약·부팅 복원 receiver를 exported=false로 선언한다", () => {
   const androidManifest = read("apps/mobile/android/app/src/main/AndroidManifest.xml");
 
   assert.match(
     androidManifest,
     /<receiver\s+android:name="com\.dexterous\.flutterlocalnotifications\.ScheduledNotificationReceiver"\s+android:exported="false"\s*\/>/,
   );
-  assert.doesNotMatch(androidManifest, /ScheduledNotificationBootReceiver/);
-  // BOOT permission은 #1768 WorkManager의 release merge가 소유하며,
-  // 하차 알림 source manifest가 직접 선언하지 않는다.
-  assert.doesNotMatch(
+  // #2154: 재부팅·package replace 뒤 예약 자동 복원용 공식 boot receiver를
+  // exported=false로 등록하고 네 부팅 계열 action을 명시 선언한다.
+  const bootReceiver = androidManifest.match(
+    /<receiver\s+android:name="com\.dexterous\.flutterlocalnotifications\.ScheduledNotificationBootReceiver"\s+android:exported="false"\s*>([\s\S]*?)<\/receiver>/,
+  );
+  assert.ok(
+    bootReceiver,
+    "ScheduledNotificationBootReceiver must be declared with android:exported=\"false\".",
+  );
+  for (const action of [
+    "android.intent.action.BOOT_COMPLETED",
+    "android.intent.action.MY_PACKAGE_REPLACED",
+    "android.intent.action.QUICKBOOT_POWERON",
+    "com.htc.intent.action.QUICKBOOT_POWERON",
+  ]) {
+    assert.match(
+      bootReceiver[1],
+      new RegExp(`<action\\s+android:name="${action.replace(/\./g, "\\.")}"\\s*/>`),
+      `boot receiver must include intent action ${action}`,
+    );
+  }
+  // #2154: 부팅 복원 권한을 source manifest가 직접 선언한다(WorkManager도 병합).
+  assert.match(
     androidManifest,
-    /android\.permission\.RECEIVE_BOOT_COMPLETED/,
+    /<uses-permission\s+android:name="android\.permission\.RECEIVE_BOOT_COMPLETED"\s*\/>/,
   );
 });
 


### PR DESCRIPTION
## 관련 이슈

Closes AquilaXk/easysubway#2154

## 작업 배경

- 미래 시각의 활성 하차·환승 알림이 기기 재부팅과 app package replace 뒤 복원되지 않았습니다. release manifest에 `RECEIVE_BOOT_COMPLETED`와 공식 boot receiver가 없고, controller의 restore/reconcile이 notification permission 거부 또는 pending 0에서 구독을 재예약하지 않고 off로 정리했습니다.
- Android v1 release blocker(#1021 선행)이며, 취소·만료 알림을 되살리지 않는 fail-closed reconcile이 계약입니다.

## 작업 내용

- source manifest에 `RECEIVE_BOOT_COMPLETED` 권한과 공식 `ScheduledNotificationBootReceiver`(`exported="false"`, `BOOT_COMPLETED`·`MY_PACKAGE_REPLACED`·`QUICKBOOT_POWERON`·`com.htc...QUICKBOOT_POWERON` 네 action)를 선언했습니다.
- 단일 process-wide WorkManager dispatcher(`nextTrainWidgetCallbackDispatcher`)가 task 이름으로 위젯 refresh와 `get-off-alarm-reconcile`을 각 handler에 라우팅하고, 알 수 없는 task는 성공으로 삼키지 않고 fail-closed(false)로 돌려줍니다.
- WorkManager initialize를 app bootstrap 1회로 분리했습니다. 활성 구독 저장/재예약은 unique periodic reconcile work(15분·network 불필요·`ExistingPeriodicWorkPolicy.update`) 등록만 수행하고, off·만료·알림 권한 거부 정리는 그 unique work만 취소해 위젯 periodic work를 보존합니다. 위젯 설정 activity(별도 engine)만 init+register 결합 경로를 유지합니다.
- 포그라운드 restore와 headless reconcile(Drift user DB open→단일 구독 조회→notifier 초기화→reconcile→`finally` close)이 단일 분기 계약을 공유합니다: 미래 구독은 결정적 slot 기반 notification ID로 전체 idempotent 재예약(boot receiver 복원과 실행 순서 무관 중복 0건), 만료·권한 거부는 pending 취소 후 구독 삭제, 사용자가 끈 구독은 복원하지 않습니다.
- 알림 권한 거부 정리는 기존 `app_preferences`에 one-shot 복구 안내 flag를 기록하고, 다음 UI init이 `permissionNotice`를 한 번 표시한 뒤 즉시 지웁니다. exact 허용은 exact, 거부는 silent failure 없이 inexact로 복원하며 기존 오차 안내 계약을 유지합니다.
- merged release manifest contract 테스트에 boot permission·공식 receiver·`exported=false`·네 intent action 검증을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `dart format --output=none --set-exit-if-changed lib test` — 0 changed PASS
  - `flutter analyze` — No issues found
  - `flutter test` — 1385/1385 PASS (분기 계약·dispatcher 라우팅·fail-closed·idempotent 재예약·recovery flag·headless close 신규 테스트 포함)
  - `flutter build apk --config-only` + `android/gradlew :app:processReleaseMainManifest` + `EASYSUBWAY_EXPECT_ANDROID_RELEASE_MANIFEST=true node --test --test-name-pattern "Android 릴리즈 권한" tools/ci/repository-contract.test.mjs` — merged manifest 실생성 후 1/1 PASS

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 재부팅 후 앱 미실행 복원 | Android 실기기(SDK 36) | `adb reboot` 후 앱을 열지 않고 `dumpsys alarm` 판독 | `docs/2154-boot-qa/02-after-reboot.txt`(로컬) | exact alarm 2건(RTC_WAKEUP·window=0) 자동 복원, periodic work 유지 |
| package replace 후 복원 | Android 실기기 | `adb install -r` 후 앱을 열지 않고 `dumpsys alarm`·logcat 판독 | `docs/2154-boot-qa/03-after-replace.txt`(로컬) | force-stop 뒤 알람 2건 신규 객체로 재등록, persisted work 유지 |
| headless reconcile·중복 0건 | Android 실기기 | 복원 경로 전부 통과 후 알람 카운트 | `docs/2154-boot-qa/04-headless-reconcile.txt`(로컬) | secondary process에서 reconcile 실행, 최종 알람 정확히 2건(중복 0) |
| exact allow→exact 복원 | Android 실기기 | 권한 허용 후 `dumpsys alarm` `exactAllowReason=permission` | `docs/2154-boot-qa/01-baseline.txt`(로컬) | exact mode 예약·복원 확인 |
| exact deny→inexact / 알림 권한 거부 / 만료 / 사용자 끔 분기 | Android | Flutter 단위 테스트(controller·notifier·worker) | `apps/mobile/test/features/get_off_alarm/` | 분기별 cancel/delete/non-restore·flag 기록 PASS, 기기 반복 증거는 단위 계약으로 대체 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] AquilaXk/easysubway#1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `get_off_alarm_controller.dart`의 공유 분기 계약(_restore 재작성), `get_off_alarm_scheduler.dart`/`get_off_alarm_notifier.dart`의 slot 기반 결정적 ID(만료로 목록이 줄어도 ID 불변), `next_train_widget_runtime.dart`의 단일 dispatcher 라우팅·initialize/register 분리입니다.
- 기존 "pending 0→off 정리, pending drift 카운트 보정" 최적화는 "미래 구독 전체 idempotent 재예약" 계약으로 대체되어 관련 기존 테스트 2건을 계약대로 갱신했습니다.

## 리스크

- reconcile 주기(15분)와 boot receiver의 실행 순서는 보장되지 않으므로 결정적 ID·idempotent 재예약이 유일한 중복 방지선입니다(순서 조합 테스트로 고정).
- headless isolate에서 DB·notifier close 누락 시 리소스 누수가 가능하나 성공·예외 공통 `finally` close를 테스트로 고정했습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
