### PR TITLE
[Mobile] #2099 길찾기 objective 탭·급행 운행 정보 표시

### DIFF
--- a/apps/mobile/lib/core/database/catalog/station_timetable_query.dart
+++ b/apps/mobile/lib/core/database/catalog/station_timetable_query.dart
@@ -10,10 +10,18 @@ class CatalogStationDeparture {
   const CatalogStationDeparture({
     required this.directionName,
     required this.seconds,
+    required this.servicePattern,
+    required this.serviceClass,
   });
 
   final String directionName;
   final int seconds;
+
+  /// 운행종별(예: `LOCAL`·`EXPRESS`). final catalog 값을 손실 없이 전달한다.
+  final String servicePattern;
+
+  /// 운행 클래스(예: `SUBWAY`). 지하철 여부 판정에 쓴다.
+  final String serviceClass;
 }
 
 class CatalogStationDayTimetable {
@@ -152,7 +160,8 @@ class CatalogStationTimetableQuery {
     final rows = await database
         .customSelect(
           '''
-          SELECT DISTINCT r.direction_name, st.departure_seconds
+          SELECT DISTINCT r.direction_name, st.departure_seconds,
+                 t.service_pattern, t.service_class
           FROM transit_stop_times st
           JOIN transit_trips t ON t.id = st.trip_id
           JOIN transit_routes r ON r.id = t.route_id
@@ -185,6 +194,8 @@ class CatalogStationTimetableQuery {
           (row) => CatalogStationDeparture(
             directionName: row.read<String>('direction_name'),
             seconds: row.read<int>('departure_seconds'),
+            servicePattern: row.read<String?>('service_pattern') ?? '',
+            serviceClass: row.read<String?>('service_class') ?? '',
           ),
         )
         .toList(growable: false);

--- a/apps/mobile/lib/core/database/catalog/station_timetable_query.dart
+++ b/apps/mobile/lib/core/database/catalog/station_timetable_query.dart
@@ -169,7 +169,7 @@ class CatalogStationTimetableQuery {
           WHERE st.station_id = ?
             AND st.line_id = ?
             AND st.pickup_type = 0
-            AND t.service_class = 'SUBWAY'
+            AND UPPER(TRIM(t.service_class)) = 'SUBWAY'
             AND r.line_id = st.line_id
             AND TRIM(r.direction_name) <> ''
             $dayFilter

--- a/apps/mobile/lib/features/routes/application/route_engine.dart
+++ b/apps/mobile/lib/features/routes/application/route_engine.dart
@@ -30,6 +30,7 @@ class LocalRouteEngine {
       mobilityType: request.mobilityType,
       constraintMode: request.effectiveConstraintMode,
       searchMode: request.searchMode,
+      objective: request.objective,
     );
     final path = pathResult.path;
     if (path == null) {
@@ -131,6 +132,7 @@ class AccessGraphRouter {
     required MobilityType mobilityType,
     required ConstraintMode constraintMode,
     RouteSearchMode searchMode = RouteSearchMode.stationToStation,
+    RouteObjective objective = RouteObjective.fastest,
   }) {
     if (graph.nodes.isEmpty || graph.edges.isEmpty) {
       return AccessPathResult.noPath(
@@ -147,6 +149,7 @@ class AccessGraphRouter {
       constraintMode,
       RouteTraversalPolicy(searchMode),
       blockedReasonCodes,
+      objective,
     );
     if (edges != null) {
       return AccessPathResult.found(
@@ -199,6 +202,12 @@ class AccessGraphRouter {
     return AccessNoPathReason.blocked;
   }
 
+  /// fewestTransfers 목표에서 환승 edge마다 얹는 큰 사전식(lexicographic) 페널티.
+  /// 어떤 대안 경로의 총 일반화 비용보다도 크게 잡아, 탐색이 환승 수를 1차로
+  /// 최소화하고 동률에서만 일반화 비용(대체로 소요시간)으로 tie-break하게 한다.
+  /// 이 페널티는 경로 선택에만 쓰이고 결과에 보고되는 비용에는 반영되지 않는다.
+  static const int _fewestTransfersEdgePenalty = 100000000;
+
   List<RouteEdge>? _findLowestCostPath(
     String originNodeId,
     String destinationNodeId,
@@ -206,6 +215,7 @@ class AccessGraphRouter {
     ConstraintMode constraintMode,
     RouteTraversalPolicy traversalPolicy,
     Set<String> blockedReasonCodes,
+    RouteObjective objective,
   ) {
     final bestCostByNode = <String, int>{originNodeId: 0};
     final previousNode = <String, String>{};
@@ -249,7 +259,12 @@ class AccessGraphRouter {
           blockedReasonCodes.addAll(edgeCost.warningCodes);
           continue;
         }
-        final nextCost = candidate.cost + edgeCost.cost;
+        var stepCost = edgeCost.cost;
+        if (objective == RouteObjective.fewestTransfers &&
+            isRouteTransferEdgeType(edge.type)) {
+          stepCost += _fewestTransfersEdgePenalty;
+        }
+        final nextCost = candidate.cost + stepCost;
         if (nextCost < (bestCostByNode[edge.toNodeId] ?? 1 << 62)) {
           bestCostByNode[edge.toNodeId] = nextCost;
           previousNode[edge.toNodeId] = candidate.nodeId;

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -352,6 +352,14 @@ class LocalRouteRepository implements RouteSearchRepository {
             carDoorCarNumber: carDoorHint?.carNumber,
             carDoorDoorNumber: carDoorHint?.doorNumber,
             carDoorFacilityType: carDoorHint?.facilityType ?? '',
+            // 오프라인 catalog는 지하철 전용이라 승차 leg의 운행 클래스는 SUBWAY로
+            // 보존한다. 운행종별은 로컬 데이터가 있으면 그대로 싣고, 없으면 null로 둬
+            // 급행 배지를 붙이지 않는다(급행 정보가 없으면 배지 없음이 정상).
+            serviceClass: step.type.name == 'ride' ? 'SUBWAY' : null,
+            servicePattern:
+                step.type.name == 'ride' && step.servicePattern.isNotEmpty
+                ? step.servicePattern
+                : null,
           );
         })
         .toList(growable: false);

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -113,6 +113,7 @@ class LocalRouteRepository implements RouteSearchRepository {
     final request = catalog.canonicalRequest(rawRequest);
     final mobilityType = _mobilityType(request.mobilityType);
     final constraintMode = _constraintMode(request.effectiveConstraintMode);
+    final objective = _localObjective(request.objective);
     // #1975: 경유 요청의 strict 강등 판정은 전역 strict 지원이 아니라 두 구간을
     // 각각 본다(한 구간만 미지원이어도 강등). 경유 없는 단일 구간은 엔진이 이미
     // 구간별 strict 근거를 강제하고 구체 사유를 내므로 전역 pre-filter를 유지한다.
@@ -135,6 +136,7 @@ class LocalRouteRepository implements RouteSearchRepository {
                 searchMode: local
                     .RouteSearchMode
                     .stationToStationWithOutOfStationTransfers,
+                objective: objective,
               ),
             );
     } else if (blocksStairOnly &&
@@ -160,6 +162,7 @@ class LocalRouteRepository implements RouteSearchRepository {
           constraintMode: constraintMode,
           searchMode:
               local.RouteSearchMode.stationToStationWithOutOfStationTransfers,
+          objective: objective,
         ),
       );
       final second = engine.search(
@@ -170,6 +173,7 @@ class LocalRouteRepository implements RouteSearchRepository {
           constraintMode: constraintMode,
           searchMode:
               local.RouteSearchMode.stationToStationWithOutOfStationTransfers,
+          objective: objective,
         ),
       );
       result = mergeWaypointRouteResults(first, second);
@@ -353,13 +357,11 @@ class LocalRouteRepository implements RouteSearchRepository {
             carDoorDoorNumber: carDoorHint?.doorNumber,
             carDoorFacilityType: carDoorHint?.facilityType ?? '',
             // 오프라인 catalog는 지하철 전용이라 승차 leg의 운행 클래스는 SUBWAY로
-            // 보존한다. 운행종별은 로컬 데이터가 있으면 그대로 싣고, 없으면 null로 둬
-            // 급행 배지를 붙이지 않는다(급행 정보가 없으면 배지 없음이 정상).
+            // 보존한다. 운행종별은 온라인 파서와 대칭으로 대문자 enum(LOCAL·EXPRESS)만
+            // 정규화해 싣고, 그 외(공백·미상)는 null로 둬 급행 배지를 붙이지 않는다
+            // (급행 정보가 없으면 배지 없음이 정상).
             serviceClass: step.type.name == 'ride' ? 'SUBWAY' : null,
-            servicePattern:
-                step.type.name == 'ride' && step.servicePattern.isNotEmpty
-                ? step.servicePattern
-                : null,
+            servicePattern: _normalizedRideServicePattern(step),
           );
         })
         .toList(growable: false);
@@ -711,6 +713,31 @@ class LocalRouteRepository implements RouteSearchRepository {
       _ => throw const RouteSearchException('지원하지 않는 이동 제약 조건입니다.'),
     };
   }
+
+  local.RouteObjective _localObjective(RouteObjective objective) {
+    return switch (objective) {
+      RouteObjective.fastest => local.RouteObjective.fastest,
+      RouteObjective.fewestTransfers => local.RouteObjective.fewestTransfers,
+    };
+  }
+}
+
+/// 오프라인 catalog network edge의 운행종별 화이트리스트. 온라인 파서와 대칭으로
+/// 대문자 enum({'LOCAL','EXPRESS'})만 인정한다.
+const Set<String> _localRideServicePatterns = {'LOCAL', 'EXPRESS'};
+
+/// ride 승차 leg의 servicePattern을 정규화한다. datapack 파이프라인은
+/// network_edges.service_pattern에 대문자 enum을 강제하지 않으므로(build-datapack의
+/// 삽입은 `row.servicePattern ?? ''`로 검증 없이 통과), 계약이 불명확한 값은
+/// fail-safe로 null 처리해 급행 배지를 붙이지 않는다(온라인 파서의 fail-closed와
+/// 달리 오프라인은 배지 없음이 정상 — 기존 로컬 정책 유지). ride가 아니거나 공백·
+/// 미상 값도 모두 null.
+String? _normalizedRideServicePattern(route_step.RouteStep step) {
+  if (step.type.name != 'ride') {
+    return null;
+  }
+  final normalized = step.servicePattern.trim().toUpperCase();
+  return _localRideServicePatterns.contains(normalized) ? normalized : null;
 }
 
 /// 경유역 지원 1단계: 출발→경유, 경유→도착 두 구간의 탐색 결과를 하나로 합성한다.
@@ -2007,6 +2034,7 @@ class _RouteCatalogSnapshot {
           : canonicalStationId(waypoint),
       mobilityPreset: request.mobilityPreset,
       transportScope: request.transportScope,
+      objective: request.objective,
     );
   }
 }

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -381,11 +381,23 @@ class LocalRouteRepository implements RouteSearchRepository {
         cursor = cursor.add(Duration(seconds: step.durationSeconds));
         continue;
       }
+      // 시간표 조회는 UI 투영과 같은 정규화 값을 쓴다. edge에 'express '(소문자·
+      // 공백)가 와도 대문자 'EXPRESS' 시간표와 매칭되도록 정규화한 뒤 넘긴다.
+      final rawServicePattern = step.servicePattern.trim();
+      final normalizedServicePattern = _normalizedServicePattern(
+        rawServicePattern,
+      );
+      // non-empty인데 화이트리스트 밖(미상)이면 어떤 시간표와도 신뢰성 있게 매칭할
+      // 수 없으므로 도착 시각 조회를 포기한다(fail-safe: 빈 결과). 빈 값은 종전대로
+      // 운행종별 필터 없이 조회한다(LOCAL/미표기 동작 보존).
+      if (rawServicePattern.isNotEmpty && normalizedServicePattern == null) {
+        return const {};
+      }
       final arrival = await _nextTimetableArrival(
         fromStationId: catalog.stationIdForNode(step.fromNodeId),
         toStationId: catalog.stationIdForNode(step.toNodeId),
         lineId: step.lineId,
-        servicePattern: step.servicePattern,
+        servicePattern: normalizedServicePattern ?? '',
         cursor: cursor,
       );
       if (arrival == null) {
@@ -736,7 +748,13 @@ String? _normalizedRideServicePattern(route_step.RouteStep step) {
   if (step.type.name != 'ride') {
     return null;
   }
-  final normalized = step.servicePattern.trim().toUpperCase();
+  return _normalizedServicePattern(step.servicePattern);
+}
+
+/// raw servicePattern을 화이트리스트({'LOCAL','EXPRESS'}) 대문자 enum으로 정규화한다.
+/// 공백·미상 값은 null. UI 투영과 시간표 조회가 같은 정규화를 쓰도록 공유한다.
+String? _normalizedServicePattern(String raw) {
+  final normalized = raw.trim().toUpperCase();
   return _localRideServicePatterns.contains(normalized) ? normalized : null;
 }
 

--- a/apps/mobile/lib/features/routes/domain/route_request.dart
+++ b/apps/mobile/lib/features/routes/domain/route_request.dart
@@ -23,6 +23,11 @@ enum RouteSearchMode {
   debugAllEdges,
 }
 
+/// 로컬 탐색 최적화 목표. fastest는 기존 일반화 비용 최소화(기본), fewestTransfers는
+/// 환승 수를 우선 최소화하고 동률이면 일반화 비용이 낮은(대체로 소요시간이 짧은)
+/// 경로를 고른다.
+enum RouteObjective { fastest, fewestTransfers }
+
 class RouteRequest {
   const RouteRequest({
     required this.originStationId,
@@ -30,6 +35,7 @@ class RouteRequest {
     required this.mobilityType,
     this.constraintMode,
     this.searchMode = RouteSearchMode.stationToStation,
+    this.objective = RouteObjective.fastest,
   });
 
   final String originStationId;
@@ -37,6 +43,7 @@ class RouteRequest {
   final MobilityType mobilityType;
   final ConstraintMode? constraintMode;
   final RouteSearchMode searchMode;
+  final RouteObjective objective;
 
   ConstraintMode get effectiveConstraintMode =>
       constraintMode ?? mobilityType.defaultConstraintMode;

--- a/apps/mobile/lib/features/stations/data/drift_station_repository.dart
+++ b/apps/mobile/lib/features/stations/data/drift_station_repository.dart
@@ -18,6 +18,9 @@ class DriftStationRepository
         NetworkMapRepository {
   DriftStationRepository({required this.database});
 
+  /// 지하철(`SUBWAY`) 출발에 허용되는 운행종별. 이 외 값은 경계에서 실패시킨다.
+  static const _validSubwayServicePatterns = {'LOCAL', 'EXPRESS'};
+
   final CatalogDatabase database;
   Future<List<_LocalStationSummary>>? _stationSummaryCache;
 
@@ -100,12 +103,25 @@ class DriftStationRepository
     final grouped = <String, List<StationTimetableDeparture>>{};
     for (final row in rows) {
       final directionName = row.directionName;
+      final servicePattern = row.servicePattern.trim().toUpperCase();
+      final serviceClass = row.serviceClass.trim().toUpperCase();
+      // 지하철 운행종별이 LOCAL/EXPRESS가 아니면(공백·미상) 일반으로 추정하지 않고
+      // 경계에서 실패시킨다(fail closed) — 잘못된 급행/일반 표기를 원천 차단한다.
+      if (serviceClass == 'SUBWAY' &&
+          !_validSubwayServicePatterns.contains(servicePattern)) {
+        throw StateError(
+          '알 수 없는 지하철 운행종별입니다: "${row.servicePattern}" '
+          '(station=$stationId, line=$lineId)',
+        );
+      }
       grouped
           .putIfAbsent(directionName, () => <StationTimetableDeparture>[])
           .add(
             StationTimetableDeparture(
               directionName: directionName,
               seconds: row.seconds,
+              servicePattern: servicePattern,
+              serviceClass: serviceClass,
             ),
           );
     }

--- a/apps/mobile/lib/features/stations/domain/station_models.dart
+++ b/apps/mobile/lib/features/stations/domain/station_models.dart
@@ -56,10 +56,21 @@ class StationTimetableDeparture {
   const StationTimetableDeparture({
     required this.directionName,
     required this.seconds,
+    this.servicePattern = 'LOCAL',
+    this.serviceClass = 'SUBWAY',
   });
 
   final String directionName;
   final int seconds;
+
+  /// 운행종별(예: `LOCAL`·`EXPRESS`). 선택 컨트롤이 아니라 실제 운행 정보다.
+  final String servicePattern;
+
+  /// 운행 클래스(예: `SUBWAY`).
+  final String serviceClass;
+
+  /// 지하철 급행 운행 여부. 이 값이 참일 때만 `급행` 배지를 노출한다.
+  bool get isExpress => serviceClass == 'SUBWAY' && servicePattern == 'EXPRESS';
 
   String get timeLabel {
     final prefix = seconds >= Duration.secondsPerDay ? '다음 날 ' : '';
@@ -72,7 +83,9 @@ class StationTimetableDeparture {
     final minute =
         (normalized % Duration.secondsPerHour) ~/ Duration.secondsPerMinute;
     final prefix = seconds >= Duration.secondsPerDay ? '다음 날 ' : '';
-    return '$directionName, $prefix${hour.toString().padLeft(2, '0')}시 '
+    final expressLabel = isExpress ? '급행, ' : '';
+    return '$directionName, $expressLabel$prefix'
+        '${hour.toString().padLeft(2, '0')}시 '
         '${minute.toString().padLeft(2, '0')}분 출발';
   }
 }

--- a/apps/mobile/lib/features/stations/presentation/service_pattern_badge.dart
+++ b/apps/mobile/lib/features/stations/presentation/service_pattern_badge.dart
@@ -15,13 +15,23 @@ import '../domain/station_models.dart';
 /// 바뀌지 않으며 toggle/chip/filter semantics를 갖지 않는다. 배지는 장식이므로
 /// semantics에서 제외하고, TalkBack용 `급행`은 행 semanticLabel이 한 번만 제공한다.
 class ServicePatternBadge extends StatelessWidget {
-  const ServicePatternBadge({required this.departure, super.key});
+  const ServicePatternBadge({required this.departure, super.key})
+    : _alwaysExpress = false;
 
-  final StationTimetableDeparture departure;
+  /// 시간표 출발 행이 아닌 곳(길찾기 승차 leg 등)에서 급행 배지를 재사용하기 위한
+  /// 생성자. 호출부가 `serviceClass=SUBWAY && servicePattern=EXPRESS`를 이미 판정한
+  /// 뒤 항상 배지를 그린다. 시각·semantics 규칙은 시간표 배지와 동일하다.
+  const ServicePatternBadge.express({super.key})
+    : departure = null,
+      _alwaysExpress = true;
+
+  final StationTimetableDeparture? departure;
+  final bool _alwaysExpress;
 
   @override
   Widget build(BuildContext context) {
-    if (!departure.isExpress) {
+    final isExpress = _alwaysExpress || (departure?.isExpress ?? false);
+    if (!isExpress) {
       return const SizedBox.shrink();
     }
     return ExcludeSemantics(

--- a/apps/mobile/lib/features/stations/presentation/service_pattern_badge.dart
+++ b/apps/mobile/lib/features/stations/presentation/service_pattern_badge.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+
+import '../../../accessible_design.dart';
+import '../../../design_tokens.dart';
+import '../domain/station_models.dart';
+
+/// 급행 운행 정보 배지.
+///
+/// 일반/급행은 선택 컨트롤이 아니라 실제 운행 정보다. `serviceClass=SUBWAY`이고
+/// `servicePattern=EXPRESS`인 출발 행에만 `급행` 텍스트 배지를 노출하고,
+/// 일반(LOCAL)에는 아무 배지도 붙이지 않는다. 시간표 화면과 노선도 하단 패널이
+/// 같은 배지를 공유해 표시 규칙을 일치시킨다.
+///
+/// 시각 원칙: 무채색 중립 아웃라인 pill(각진 radius 8, 그림자 0). 눌러도 상태가
+/// 바뀌지 않으며 toggle/chip/filter semantics를 갖지 않는다. 배지는 장식이므로
+/// semantics에서 제외하고, TalkBack용 `급행`은 행 semanticLabel이 한 번만 제공한다.
+class ServicePatternBadge extends StatelessWidget {
+  const ServicePatternBadge({required this.departure, super.key});
+
+  final StationTimetableDeparture departure;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!departure.isExpress) {
+      return const SizedBox.shrink();
+    }
+    return ExcludeSemantics(
+      child: Container(
+        key: const Key('servicePatternExpressBadge'),
+        decoration: BoxDecoration(
+          color: EasySubwayAccessibleColors.surface,
+          borderRadius: BorderRadius.circular(EasySubwayRadius.control),
+          border: Border.all(color: EasySubwayAccessibleColors.line),
+        ),
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+        child: Text(
+          '급행',
+          style: Theme.of(context).textTheme.labelLarge?.copyWith(
+            color: EasySubwayAccessibleColors.secondaryText,
+            fontWeight: FontWeight.w700,
+            height: 1.2,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/stations/presentation/station_timetable_screen.dart
+++ b/apps/mobile/lib/features/stations/presentation/station_timetable_screen.dart
@@ -7,6 +7,7 @@ import '../../../mobile_error_reporter.dart';
 import '../domain/station_line.dart';
 import '../domain/station_models.dart';
 import '../domain/station_repositories.dart';
+import 'service_pattern_badge.dart';
 
 const _stationTimetablePagePadding = EdgeInsets.fromLTRB(20, 20, 20, 32);
 
@@ -201,7 +202,19 @@ class _StationTimetableScreenState extends State<StationTimetableScreen> {
                     child: ExcludeSemantics(
                       child: Padding(
                         padding: const EdgeInsets.symmetric(vertical: 14),
-                        child: Text(direction.departures[index].timeLabel),
+                        // text scale·좁은 폭에서 시각·배지가 겹치지 않게 Wrap으로
+                        // 다음 줄 배치. 급행이 아니면 배지는 빈 위젯이라 시각만 남는다.
+                        child: Wrap(
+                          spacing: 8,
+                          runSpacing: 4,
+                          crossAxisAlignment: WrapCrossAlignment.center,
+                          children: [
+                            Text(direction.departures[index].timeLabel),
+                            ServicePatternBadge(
+                              departure: direction.departures[index],
+                            ),
+                          ],
+                        ),
                       ),
                     ),
                   ),

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -29,6 +29,7 @@ import 'features/network_map/presentation/structured_route_map_painter.dart';
 import 'features/realtime/realtime_repository.dart';
 import 'features/route_draft/application/route_draft_controller.dart';
 import 'features/route_draft/domain/route_draft.dart';
+import 'features/stations/presentation/service_pattern_badge.dart';
 import 'features/stations/presentation/station_search_screen.dart';
 import 'internal_route.dart';
 import 'mobile_error_reporter.dart';
@@ -3140,13 +3141,27 @@ class _SubwayTimetableDepartureView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Text(
+    final time = Text(
       data.departure.timeLabel,
       style: const TextStyle(
         color: Color(0xFFE23D3D),
         fontSize: 15,
         fontWeight: FontWeight.w800,
       ),
+    );
+    if (!data.departure.isExpress) {
+      return time;
+    }
+    // 급행 출발은 시각 옆에 배지를 붙인다. text scale·좁은 폭·landscape에서
+    // 시각과 배지가 겹치지 않게 Wrap으로 다음 줄 배치한다(clipping 금지).
+    return Wrap(
+      spacing: 4,
+      runSpacing: 2,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: [
+        time,
+        ServicePatternBadge(departure: data.departure),
+      ],
     );
   }
 }

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -37,7 +37,6 @@ import 'search_field.dart';
 import 'station_search.dart';
 
 const _networkMapTopBarHeight = 60.0;
-const _networkMapPillRadius = BorderRadius.all(Radius.circular(8));
 
 abstract interface class NetworkMapRepository {
   Future<NetworkMapData> getNetworkMap({String? region, String? lineId});
@@ -471,7 +470,6 @@ class NetworkMapScreen extends StatefulWidget {
 
 class _NetworkMapScreenState extends State<NetworkMapScreen> {
   String? _selectedRegion;
-  bool _expressView = false;
   bool _nearbyPanelVisible = false;
   _NetworkMapNearbyPanelData _nearbyPanelData =
       const _NetworkMapNearbyPanelData.idle();
@@ -750,8 +748,6 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
               return _NetworkMapChrome(
                 regions: const [NetworkMapRegion(name: '수도권')],
                 selectedRegion: _selectedRegion ?? '수도권',
-                expressView: _expressView,
-                showServicePatternToggle: true,
                 notificationAction: widget.notificationAction,
                 disruptionBanner: widget.disruptionBanner,
                 onMenuTap: _openMapMenu,
@@ -764,9 +760,6 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
                 onSearchSubmitted: _submitSearch,
                 onSearchClear: _searchQueryController.clear,
                 onRegionSelected: (region) => _reload(region: region),
-                onExpressViewChanged: (value) {
-                  setState(() => _expressView = value);
-                },
                 nearbyPanelVisible: _nearbyPanelVisible,
                 nearbyPanelData: _nearbyPanelData,
                 realtime: _nearbyRealtime,
@@ -803,8 +796,6 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
               return _NetworkMapChrome(
                 regions: const [NetworkMapRegion(name: '수도권')],
                 selectedRegion: _selectedRegion ?? '수도권',
-                expressView: _expressView,
-                showServicePatternToggle: true,
                 notificationAction: widget.notificationAction,
                 disruptionBanner: widget.disruptionBanner,
                 onMenuTap: _openMapMenu,
@@ -817,9 +808,6 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
                 onSearchSubmitted: _submitSearch,
                 onSearchClear: _searchQueryController.clear,
                 onRegionSelected: (region) => _reload(region: region),
-                onExpressViewChanged: (value) {
-                  setState(() => _expressView = value);
-                },
                 nearbyPanelVisible: _nearbyPanelVisible,
                 nearbyPanelData: _nearbyPanelData,
                 realtime: _nearbyRealtime,
@@ -854,18 +842,10 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
             }
             final loadResult = snapshot.data!;
             final data = loadResult.data;
-            final hasExpressLines = _expressLineIds(data).isNotEmpty;
-            // #1641: 모든 지역이 구조화 canvas로 렌더되므로 express 필터·서비스 패턴
-            // 토글이 전 지역에 균일 적용된다(과거 SVG 지역 예외 제거).
-            final visibleData = hasExpressLines && _expressView
-                ? _expressOnlyMapData(data)
-                : data;
             _startInitialNearbyFocus();
             return _NetworkMapChrome(
               regions: data.regions,
               selectedRegion: data.selectedRegion,
-              expressView: _expressView,
-              showServicePatternToggle: true,
               notificationAction: widget.notificationAction,
               disruptionBanner: widget.disruptionBanner,
               onMenuTap: _openMapMenu,
@@ -878,9 +858,6 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
               onSearchSubmitted: _submitSearch,
               onSearchClear: _searchQueryController.clear,
               onRegionSelected: (region) => _reload(region: region),
-              onExpressViewChanged: (value) {
-                setState(() => _expressView = value);
-              },
               nearbyPanelVisible: _nearbyPanelVisible,
               nearbyPanelData: _nearbyPanelData,
               realtime: _nearbyRealtime,
@@ -918,7 +895,7 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
                 listenable: widget.routeDraftController,
                 builder: (context, _) {
                   return _NetworkMapCanvas(
-                    data: visibleData,
+                    data: data,
                     initialViewport: loadResult.initialViewport,
                     focusedStationId:
                         _searchFanMenuStationId ?? _nearbySelectedStationId,
@@ -1517,14 +1494,11 @@ class _NetworkMapChrome extends StatelessWidget {
   const _NetworkMapChrome({
     required this.regions,
     required this.selectedRegion,
-    required this.expressView,
-    required this.showServicePatternToggle,
     required this.notificationAction,
     required this.disruptionBanner,
     required this.onMenuTap,
     required this.onSearchTap,
     required this.onRegionSelected,
-    required this.onExpressViewChanged,
     required this.nearbyPanelVisible,
     required this.nearbyPanelData,
     required this.realtime,
@@ -1560,14 +1534,11 @@ class _NetworkMapChrome extends StatelessWidget {
 
   final List<NetworkMapRegion> regions;
   final String selectedRegion;
-  final bool expressView;
-  final bool showServicePatternToggle;
   final Widget? notificationAction;
   final Widget? disruptionBanner;
   final VoidCallback onMenuTap;
   final VoidCallback onSearchTap;
   final ValueChanged<String> onRegionSelected;
-  final ValueChanged<bool> onExpressViewChanged;
   final bool nearbyPanelVisible;
   final _NetworkMapNearbyPanelData nearbyPanelData;
   final RealtimeSnapshot realtime;
@@ -1656,15 +1627,6 @@ class _NetworkMapChrome extends StatelessWidget {
             right: 0,
             top: topPadding + _networkMapTopBarHeight,
             child: disruptionBanner!,
-          ),
-        if (showServicePatternToggle && !inSearchMode)
-          Positioned(
-            left: 16,
-            bottom: 26,
-            child: _NetworkMapServicePatternToggle(
-              expressView: expressView,
-              onChanged: onExpressViewChanged,
-            ),
           ),
         if (nearbyPanelVisible && !inSearchMode)
           Positioned(
@@ -2410,52 +2372,6 @@ class _NetworkMapSearchSessionState extends State<_NetworkMapSearchSession> {
   }
 }
 
-class _NetworkMapServicePatternToggle extends StatelessWidget {
-  const _NetworkMapServicePatternToggle({
-    required this.expressView,
-    required this.onChanged,
-  });
-
-  final bool expressView;
-  final ValueChanged<bool> onChanged;
-
-  @override
-  Widget build(BuildContext context) {
-    return Material(
-      key: const Key('networkMapServicePatternToggle'),
-      color: Colors.white,
-      elevation: 0,
-      shape: const RoundedRectangleBorder(
-        borderRadius: _networkMapPillRadius,
-        side: BorderSide(color: EasySubwayAccessibleColors.line),
-      ),
-      child: Container(
-        height: 58,
-        padding: const EdgeInsets.all(3),
-        decoration: BoxDecoration(
-          borderRadius: _networkMapPillRadius,
-          border: Border.all(color: const Color(0xFFE8E8E8)),
-        ),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            _NetworkMapToggleSegment(
-              label: '일반',
-              selected: !expressView,
-              onTap: () => onChanged(false),
-            ),
-            _NetworkMapToggleSegment(
-              label: '급행',
-              selected: expressView,
-              onTap: () => onChanged(true),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
 class _NetworkMapCurrentLocationButton extends StatelessWidget {
   const _NetworkMapCurrentLocationButton({required this.onTap});
 
@@ -3166,49 +3082,6 @@ class _SubwayTimetableDepartureView extends StatelessWidget {
   }
 }
 
-class _NetworkMapToggleSegment extends StatelessWidget {
-  const _NetworkMapToggleSegment({
-    required this.label,
-    required this.selected,
-    required this.onTap,
-  });
-
-  final String label;
-  final bool selected;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    return InkWell(
-      onTap: onTap,
-      borderRadius: _networkMapPillRadius,
-      splashFactory: NoSplash.splashFactory,
-      splashColor: Colors.transparent,
-      highlightColor: Colors.transparent,
-      child: AnimatedContainer(
-        duration: const Duration(milliseconds: 160),
-        height: 52,
-        width: 50,
-        alignment: Alignment.center,
-        decoration: BoxDecoration(
-          color: selected
-              ? EasySubwayAccessibleColors.mapRegionAccent
-              : Colors.transparent,
-          borderRadius: _networkMapPillRadius,
-        ),
-        child: Text(
-          label,
-          style: TextStyle(
-            color: selected ? Colors.white : const Color(0xFF242424),
-            fontSize: 16,
-            fontWeight: FontWeight.w800,
-          ),
-        ),
-      ),
-    );
-  }
-}
-
 class _NetworkMapBottomAdBanner extends StatelessWidget {
   const _NetworkMapBottomAdBanner();
 
@@ -3441,75 +3314,6 @@ class _NetworkMapMenuTile extends StatelessWidget {
       ),
     );
   }
-}
-
-Set<String> _expressLineIds(NetworkMapData data) {
-  return data.lines
-      .where(
-        (line) =>
-            line.name.contains('급행') ||
-            line.shortName.contains('급행') ||
-            line.id.toLowerCase().contains('express'),
-      )
-      .map((line) => line.id)
-      .toSet();
-}
-
-NetworkMapData _expressOnlyMapData(NetworkMapData data) {
-  final lineIds = _expressLineIds(data);
-  final stationIdsFromMemberships = data.stationLineMemberships
-      .where((membership) => lineIds.contains(membership.lineId))
-      .map((membership) => membership.stationId)
-      .toSet();
-  final stations = data.stations
-      .where(
-        (station) =>
-            lineIds.contains(station.lineId) ||
-            stationIdsFromMemberships.contains(station.id),
-      )
-      .toList(growable: false);
-  final stationsById = <String, List<NetworkMapStation>>{};
-  final stationByLineKey = <String, NetworkMapStation>{};
-  for (final station in stations) {
-    stationsById.putIfAbsent(station.id, () => []).add(station);
-    stationByLineKey[_networkMapStationLineKey(station.id, station.lineId)] =
-        station;
-  }
-  bool hasFilteredEndpoint(NetworkMapEdge edge, String endpoint) {
-    return _stationForMapEdgeEndpoint(
-          endpoint,
-          edge.lineId,
-          stationByLineKey,
-          stationsById,
-        ) !=
-        null;
-  }
-
-  return NetworkMapData(
-    regions: data.regions,
-    selectedRegion: data.selectedRegion,
-    lines: data.lines
-        .where((line) => lineIds.contains(line.id))
-        .toList(growable: false),
-    stations: stations,
-    edges: data.edges
-        .where(
-          (edge) =>
-              lineIds.contains(edge.lineId) &&
-              hasFilteredEndpoint(edge, edge.fromStationId) &&
-              hasFilteredEndpoint(edge, edge.toStationId),
-        )
-        .toList(growable: false),
-    positionSources: data.positionSources,
-    stationLineMemberships: data.stationLineMemberships
-        .where((membership) => lineIds.contains(membership.lineId))
-        .toList(growable: false),
-  );
-}
-
-@visibleForTesting
-NetworkMapData networkMapExpressOnlyMapData(NetworkMapData data) {
-  return _expressOnlyMapData(data);
 }
 
 class _NetworkMapLoadFailure extends StatelessWidget {

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -1885,16 +1885,29 @@ class RouteRefreshResult {
 
 /// objective-tagged 대표 itinerary 중 현재 목표에 맞는 것을 고른다. 백엔드가 두
 /// objective를 하나로 dedupe하면 그 하나가 두 태그를 모두 달고 있어 어느 목표에서도
-/// 선택된다. 태그가 없는(레거시) 응답은 첫 FOUND, 그마저 없으면 첫 itinerary로 폴백해
-/// 기존 동작을 보존한다.
+/// 선택된다. FOUND itinerary가 전부 무태그(레거시)일 때만 첫 FOUND, 그마저 없으면 첫
+/// itinerary로 폴백해 기존 동작을 보존한다. 태그가 하나라도 있는데 요청 objective와
+/// 매칭되는 FOUND가 없으면 silent fallback(계약 위반)을 피해 payload 오류로 fail
+/// closed한다(generic unavailable 흐름으로 흐른다).
 RouteSearchV2Itinerary _selectRouteV2Itinerary(
   List<RouteSearchV2Itinerary> itineraries,
   RouteObjective objective,
 ) {
-  for (final itinerary in itineraries) {
-    if (itinerary.status == 'FOUND' && itinerary.matchesObjective(objective)) {
+  final foundItineraries = itineraries
+      .where((itinerary) => itinerary.status == 'FOUND')
+      .toList(growable: false);
+  for (final itinerary in foundItineraries) {
+    if (itinerary.matchesObjective(objective)) {
       return itinerary;
     }
+  }
+  final hasTaggedFound = foundItineraries.any(
+    (itinerary) => itinerary.objectiveTags.isNotEmpty,
+  );
+  if (hasTaggedFound) {
+    throw const FormatException(
+      'Route v2 FOUND itineraries missing requested objective tag',
+    );
   }
   return itineraries.firstWhere(
     (candidate) => candidate.status == 'FOUND',
@@ -3087,6 +3100,9 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
                       objective: _selectedObjective,
                       transportScope: _selectedTransportScope,
                       itxTransportScopeEnabled: _itxTransportScopeAvailable,
+                      loading:
+                          _controller.state.status ==
+                          RouteSearchViewStatus.loading,
                       onChangePreset: _showMobilityPresetPicker,
                       onChangeObjective: _changeObjective,
                       onChangeTransportScope: _changeTransportScope,
@@ -5511,6 +5527,7 @@ class _RouteConditionChips extends StatelessWidget {
     required this.objective,
     required this.transportScope,
     required this.itxTransportScopeEnabled,
+    required this.loading,
     required this.onChangePreset,
     required this.onChangeObjective,
     required this.onChangeTransportScope,
@@ -5520,6 +5537,9 @@ class _RouteConditionChips extends StatelessWidget {
   final RouteObjective objective;
   final RouteTransportScope transportScope;
   final bool itxTransportScopeEnabled;
+  // 재검색 로딩 중에는 objective·교통범위 변경 핸들러가 입력을 조용히 무시하므로,
+  // 해당 칩을 시각·semantics 모두 비활성으로 표기해 활성으로 보이지 않게 한다.
+  final bool loading;
   final VoidCallback onChangePreset;
   final ValueChanged<RouteObjective> onChangeObjective;
   final ValueChanged<RouteTransportScope> onChangeTransportScope;
@@ -5552,6 +5572,7 @@ class _RouteConditionChips extends StatelessWidget {
             label: RouteObjective.fastest.label,
             semanticLabel: '경로 목표, ${RouteObjective.fastest.label}',
             active: objective == RouteObjective.fastest,
+            enabled: !loading,
             onTap: () => onChangeObjective(RouteObjective.fastest),
           ),
           _RouteConditionChipButton(
@@ -5560,6 +5581,7 @@ class _RouteConditionChips extends StatelessWidget {
             label: RouteObjective.fewestTransfers.label,
             semanticLabel: '경로 목표, ${RouteObjective.fewestTransfers.label}',
             active: objective == RouteObjective.fewestTransfers,
+            enabled: !loading,
             onTap: () => onChangeObjective(RouteObjective.fewestTransfers),
           ),
           if (itxTransportScopeEnabled) ...[
@@ -5569,6 +5591,7 @@ class _RouteConditionChips extends StatelessWidget {
               label: '지하철만',
               semanticLabel: '교통 범위, 지하철만',
               active: transportScope == RouteTransportScope.subway,
+              enabled: !loading,
               onTap: () => onChangeTransportScope(RouteTransportScope.subway),
             ),
             _RouteConditionChipButton(
@@ -5578,6 +5601,7 @@ class _RouteConditionChips extends StatelessWidget {
               semanticLabel: '교통 범위, 지하철과 ITX-청춘',
               active:
                   transportScope == RouteTransportScope.subwayAndItxCheongchun,
+              enabled: !loading,
               onTap: () => onChangeTransportScope(
                 RouteTransportScope.subwayAndItxCheongchun,
               ),
@@ -5596,6 +5620,7 @@ class _RouteConditionChipButton extends StatelessWidget {
     required this.label,
     required this.semanticLabel,
     required this.active,
+    this.enabled = true,
     required this.onTap,
   });
 
@@ -5604,34 +5629,43 @@ class _RouteConditionChipButton extends StatelessWidget {
   final String label;
   final String semanticLabel;
   final bool active;
+  final bool enabled;
   final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
-    final foreground = active
+    // 비활성(재검색 로딩 중)일 때는 무채색 원칙 안에서 기존 muted 토큰만 재사용해
+    // 흐리게 표기하고 tap·semantics 모두 막는다(새 색·새 디자인 없음).
+    final foreground = !enabled
+        ? EasySubwayAccessibleColors.iconMuted
+        : active
         ? EasySubwayAccessibleColors.primary
         : EasySubwayAccessibleColors.secondaryText;
+    final tapHandler = enabled ? onTap : null;
     return Semantics(
       button: true,
+      enabled: enabled,
       toggled: active,
       label: semanticLabel,
-      onTap: onTap,
+      onTap: tapHandler,
       child: ExcludeSemantics(
         child: Material(
           color: Colors.transparent,
           child: InkWell(
             key: buttonKey,
-            onTap: onTap,
+            onTap: tapHandler,
             borderRadius: _routeSearchPillRadius,
             child: Ink(
               decoration: BoxDecoration(
                 color: EasySubwayAccessibleColors.surface,
                 borderRadius: _routeSearchPillRadius,
                 border: Border.all(
-                  color: active
+                  color: !enabled
+                      ? EasySubwayAccessibleColors.line
+                      : active
                       ? EasySubwayAccessibleColors.primary
                       : EasySubwayAccessibleColors.line,
-                  width: active ? 2 : 1,
+                  width: active && enabled ? 2 : 1,
                 ),
               ),
               child: Container(
@@ -5655,10 +5689,12 @@ class _RouteConditionChipButton extends StatelessWidget {
                     ),
                     if (active) ...[
                       const SizedBox(width: 6),
-                      const Icon(
+                      Icon(
                         Icons.check,
                         size: 16,
-                        color: EasySubwayAccessibleColors.primary,
+                        color: enabled
+                            ? EasySubwayAccessibleColors.primary
+                            : EasySubwayAccessibleColors.iconMuted,
                       ),
                     ],
                   ],

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -13,6 +13,7 @@ import 'features/ads/active_ad_banner.dart';
 import 'features/ads/ad_repository.dart';
 import 'features/fare/official_od_fare_quote.dart';
 import 'features/route_draft/domain/route_draft.dart';
+import 'features/stations/presentation/service_pattern_badge.dart';
 import 'features/stations/presentation/station_line_badges.dart';
 import 'mobile_error_reporter.dart';
 import 'features/get_off_alarm/get_off_alarm_controller.dart';
@@ -311,7 +312,10 @@ class RouteSearchV2ApiRepository implements RouteSearchRepository {
       if (data is! Map<String, Object?>) {
         throw const RouteSearchOnlineException.unavailable();
       }
-      return RouteSearchResult.fromV2(RouteSearchV2Result.fromJson(data));
+      return RouteSearchResult.fromV2(
+        RouteSearchV2Result.fromJson(data),
+        objective: routeRequest.objective,
+      );
     } on RouteSearchOnlineException {
       rethrow;
     } on ApiException catch (error, stackTrace) {
@@ -405,6 +409,18 @@ RouteTransportScope _routeTransportScopeFromValue(Object? value) {
     'SUBWAY_AND_ITX_CHEONGCHUN' => RouteTransportScope.subwayAndItxCheongchun,
     _ => RouteTransportScope.subway,
   };
+}
+
+/// 길찾기 최적화 목표. 선택 컨트롤이지만 실제 운행 정보(급행 여부)와는 무관한
+/// 별개 차원이다. 서버는 null을 FASTEST로 해석하므로 기본값도 FASTEST다.
+enum RouteObjective {
+  fastest('FASTEST', '최단시간'),
+  fewestTransfers('FEWEST_TRANSFERS', '최소환승');
+
+  const RouteObjective(this.serverValue, this.label);
+
+  final String serverValue;
+  final String label;
 }
 
 class RouteFeedbackApiRepository implements RouteFeedbackRepository {
@@ -791,6 +807,7 @@ class RouteSearchRequest {
     this.waypointStationId,
     this.mobilityPreset,
     this.transportScope = RouteTransportScope.subway,
+    this.objective = RouteObjective.fastest,
   });
 
   final String originStationId;
@@ -802,6 +819,10 @@ class RouteSearchRequest {
   /// v2 요청에만 실리는 보행 프리셋 서버 문자열(하위호환으로 mobilityType도 유지).
   final String? mobilityPreset;
   final RouteTransportScope transportScope;
+
+  /// 최적화 목표(FASTEST·FEWEST_TRANSFERS). 급행 여부와는 무관한 별개 차원이며,
+  /// 요청 serialization에는 이 값만 싣고 servicePattern/expressOnly는 싣지 않는다.
+  final RouteObjective objective;
 
   String get effectiveConstraintMode =>
       constraintMode ?? _defaultConstraintMode(mobilityType);
@@ -815,6 +836,7 @@ class RouteSearchRequest {
       waypointStationId: waypointStationId?.trim(),
       mobilityPreset: mobilityPreset?.trim(),
       transportScope: transportScope,
+      objective: objective,
     );
   }
 
@@ -834,6 +856,7 @@ class RouteSearchRequest {
       ...toJson(),
       if (trimmedPreset != null && trimmedPreset.isNotEmpty)
         'mobilityPreset': trimmedPreset,
+      'objective': objective.serverValue,
       'departureTime': _routeV2DepartureTimeNow(),
       'useRealtime': true,
       'maxTransfers': 3,
@@ -918,6 +941,7 @@ class RouteSearchV2Itinerary {
     required this.accessibilityRisk,
     required this.legs,
     required this.commercialEtaEligible,
+    this.objectiveTags = const [],
   });
 
   factory RouteSearchV2Itinerary.fromJson(Map<String, Object?> json) {
@@ -952,6 +976,10 @@ class RouteSearchV2Itinerary {
           })
           .toList(growable: false),
       commercialEtaEligible: _requiredRouteBool(json, 'commercialEtaEligible'),
+      objectiveTags: _routeStringList(
+        json['objectiveTags'] ?? const <Object?>[],
+        'route v2 objective tag',
+      ),
     );
   }
 
@@ -967,6 +995,13 @@ class RouteSearchV2Itinerary {
   final RouteSearchV2AccessibilityRisk accessibilityRisk;
   final List<RouteSearchV2Leg> legs;
   final bool commercialEtaEligible;
+
+  /// 백엔드가 dual-tag dedupe한 대표 itinerary에 붙이는 objective 태그
+  /// (FASTEST·FEWEST_TRANSFERS). 두 objective가 같은 경로면 두 태그를 모두 담는다.
+  final List<String> objectiveTags;
+
+  bool matchesObjective(RouteObjective objective) =>
+      objectiveTags.contains(objective.serverValue);
 }
 
 class RouteSearchV2Leg {
@@ -990,6 +1025,8 @@ class RouteSearchV2Leg {
     required this.etaSource,
     required this.confidence,
     required this.accessibilityRisk,
+    this.serviceClass,
+    this.servicePattern,
   });
 
   factory RouteSearchV2Leg.fromJson(Map<String, Object?> json) {
@@ -997,8 +1034,14 @@ class RouteSearchV2Leg {
     if (rawAccessibilityRisk is! Map<String, Object?>) {
       throw const FormatException('Invalid route v2 leg payload');
     }
+    final legType = _requiredRouteString(json, 'legType');
+    final (serviceClass, servicePattern) = _routeV2LegServiceFields(
+      legType,
+      json['serviceClass'],
+      json['servicePattern'],
+    );
     return RouteSearchV2Leg(
-      legType: _requiredRouteString(json, 'legType'),
+      legType: legType,
       fromStationId: _optionalRouteString(json, 'fromStationId'),
       toStationId: _optionalRouteString(json, 'toStationId'),
       fromNodeId: _optionalRouteString(json, 'fromNodeId'),
@@ -1025,6 +1068,8 @@ class RouteSearchV2Leg {
       accessibilityRisk: RouteSearchV2AccessibilityRisk.fromJson(
         rawAccessibilityRisk,
       ),
+      serviceClass: serviceClass,
+      servicePattern: servicePattern,
     );
   }
 
@@ -1047,6 +1092,47 @@ class RouteSearchV2Leg {
   final String etaSource;
   final String confidence;
   final RouteSearchV2AccessibilityRisk accessibilityRisk;
+
+  /// 운행 클래스(SUBWAY·ITX_CHEONGCHUN). RIDE leg에서만 채워지고, 그 외에는 null.
+  final String? serviceClass;
+
+  /// 운행종별(LOCAL·EXPRESS). RIDE leg에서만 채워지고, 그 외에는 null.
+  final String? servicePattern;
+
+  /// 지하철 급행 leg 여부. `급행` 배지를 노출하는 유일한 조건이다.
+  bool get isSubwayExpress =>
+      serviceClass == 'SUBWAY' && servicePattern == 'EXPRESS';
+}
+
+const _routeV2ServiceClasses = {'SUBWAY', 'ITX_CHEONGCHUN'};
+const _routeV2ServicePatterns = {'LOCAL', 'EXPRESS'};
+
+/// RIDE leg의 serviceClass·servicePattern을 필수 enum으로 검증하고, non-ride leg은
+/// null만 허용한다. unknown·blank·non-ride 값 존재는 payload error로 처리해
+/// LOCAL 추정 없이 unavailable로 흐르게 한다.
+(String?, String?) _routeV2LegServiceFields(
+  String legType,
+  Object? rawServiceClass,
+  Object? rawServicePattern,
+) {
+  final isRide = legType == 'RIDE';
+  if (!isRide) {
+    if (rawServiceClass != null || rawServicePattern != null) {
+      throw const FormatException(
+        'Non-ride route v2 leg must not carry service fields',
+      );
+    }
+    return (null, null);
+  }
+  if (rawServiceClass is! String ||
+      !_routeV2ServiceClasses.contains(rawServiceClass)) {
+    throw const FormatException('Invalid route v2 ride serviceClass');
+  }
+  if (rawServicePattern is! String ||
+      !_routeV2ServicePatterns.contains(rawServicePattern)) {
+    throw const FormatException('Invalid route v2 ride servicePattern');
+  }
+  return (rawServiceClass, rawServicePattern);
 }
 
 class RouteSearchV2AccessibilityRisk {
@@ -1251,7 +1337,10 @@ class RouteSearchResult {
     );
   }
 
-  factory RouteSearchResult.fromV2(RouteSearchV2Result result) {
+  factory RouteSearchResult.fromV2(
+    RouteSearchV2Result result, {
+    RouteObjective objective = RouteObjective.fastest,
+  }) {
     if (result.itineraries.isEmpty) {
       if (result.statuses.isEmpty) {
         throw const FormatException(
@@ -1287,10 +1376,7 @@ class RouteSearchResult {
         transportScope: RouteTransportScope.subwayAndItxCheongchun,
       );
     }
-    final itinerary = result.itineraries.firstWhere(
-      (candidate) => candidate.status == 'FOUND',
-      orElse: () => result.itineraries.first,
-    );
+    final itinerary = _selectRouteV2Itinerary(result.itineraries, objective);
     final lineId = _routeV2SummaryLineId(itinerary.legs);
     return RouteSearchResult(
       routeSearchId: _routeV2RouteSearchId(itinerary.itineraryId),
@@ -1797,6 +1883,25 @@ class RouteRefreshResult {
   }
 }
 
+/// objective-tagged 대표 itinerary 중 현재 목표에 맞는 것을 고른다. 백엔드가 두
+/// objective를 하나로 dedupe하면 그 하나가 두 태그를 모두 달고 있어 어느 목표에서도
+/// 선택된다. 태그가 없는(레거시) 응답은 첫 FOUND, 그마저 없으면 첫 itinerary로 폴백해
+/// 기존 동작을 보존한다.
+RouteSearchV2Itinerary _selectRouteV2Itinerary(
+  List<RouteSearchV2Itinerary> itineraries,
+  RouteObjective objective,
+) {
+  for (final itinerary in itineraries) {
+    if (itinerary.status == 'FOUND' && itinerary.matchesObjective(objective)) {
+      return itinerary;
+    }
+  }
+  return itineraries.firstWhere(
+    (candidate) => candidate.status == 'FOUND',
+    orElse: () => itineraries.first,
+  );
+}
+
 int _scoreFromRisk(RouteSearchV2AccessibilityRisk risk) {
   final penalty =
       risk.stairCount * 30 +
@@ -1925,6 +2030,8 @@ class RouteSearchStep {
     this.carDoorCarNumber,
     this.carDoorDoorNumber,
     this.carDoorFacilityType = '',
+    this.serviceClass,
+    this.servicePattern,
   });
 
   factory RouteSearchStep.fromJson(Map<String, Object?> json) {
@@ -2004,6 +2111,8 @@ class RouteSearchStep {
       confidenceLabel: leg.confidence,
       plannedArrivalTimeIso: leg.plannedArrivalTime,
       realtimeArrivalTimeIso: leg.realtimeArrivalTime ?? '',
+      serviceClass: leg.serviceClass,
+      servicePattern: leg.servicePattern,
     );
   }
 
@@ -2038,6 +2147,15 @@ class RouteSearchStep {
   final int? carDoorCarNumber;
   final int? carDoorDoorNumber;
   final String carDoorFacilityType;
+
+  /// 승차 leg의 운행 클래스·운행종별(실제 운행 정보). 급행 배지 노출 판단에만 쓰고,
+  /// 선택 컨트롤·요청 identity에는 싣지 않는다. 승차가 아닌 step에서는 null이다.
+  final String? serviceClass;
+  final String? servicePattern;
+
+  /// 승차 정보 영역에 `급행` 배지를 노출하는 유일한 조건.
+  bool get isSubwayExpress =>
+      serviceClass == 'SUBWAY' && servicePattern == 'EXPRESS';
 
   RouteSearchStep withDisplayLabels({
     required String title,
@@ -2074,6 +2192,8 @@ class RouteSearchStep {
       carDoorCarNumber: carDoorCarNumber,
       carDoorDoorNumber: carDoorDoorNumber,
       carDoorFacilityType: carDoorFacilityType,
+      serviceClass: serviceClass,
+      servicePattern: servicePattern,
     );
   }
 
@@ -2626,6 +2746,9 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
   late String _selectedMobilityType;
   late String _selectedConstraintMode;
   late RouteTransportScope _selectedTransportScope;
+  // objective/scope 선택은 현재 검색 화면 lifecycle 동안만 유지하고 app restart에
+  // 영속화하지 않는다. 기본값은 FASTEST(+ SUBWAY).
+  RouteObjective _selectedObjective = RouteObjective.fastest;
   String _validationMessage = '';
 
   /// #1933 C: 출발·도착이 모두 채워진 draft로 진입하면 별도 "길찾기" 버튼을 누르지
@@ -2720,7 +2843,8 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
     final waypoint = _waypointStation;
     final waypointSegment = waypoint == null ? '' : '${waypoint.id} ';
     return '${origin.id} $waypointSegment${destination.id} '
-        '$_selectedMobilityType $_selectedConstraintMode ${_selectedTransportScope.serverValue}';
+        '$_selectedMobilityType $_selectedConstraintMode '
+        '${_selectedTransportScope.serverValue} ${_selectedObjective.serverValue}';
   }
 
   void _maybeAutoSearchFromDraft() {
@@ -2960,9 +3084,11 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
                     // 바꾸면 그 자리에서 바로 재검색한다(별도 폼·버튼 없음).
                     _RouteConditionChips(
                       preset: _selectedPreset,
+                      objective: _selectedObjective,
                       transportScope: _selectedTransportScope,
                       itxTransportScopeEnabled: _itxTransportScopeAvailable,
                       onChangePreset: _showMobilityPresetPicker,
+                      onChangeObjective: _changeObjective,
                       onChangeTransportScope: _changeTransportScope,
                     ),
                     _RouteSearchBody(
@@ -3101,8 +3227,27 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
         waypointStationId: _waypointStation?.id,
         mobilityPreset: mobilityPresetServerString(_selectedPreset),
         transportScope: _selectedTransportScope,
+        objective: _selectedObjective,
       ),
     );
+  }
+
+  Future<void> _changeObjective(RouteObjective objective) async {
+    if (objective == _selectedObjective ||
+        _controller.state.status == RouteSearchViewStatus.loading) {
+      return;
+    }
+    if (!await _disableActiveGetOffAlarm()) {
+      return;
+    }
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _selectedObjective = objective;
+      _autoSearchedSignature = null;
+    });
+    await _submit(alarmAlreadyDisabled: true);
   }
 
   Future<void> _changeTransportScope(RouteTransportScope scope) async {
@@ -5363,21 +5508,27 @@ class _RouteSummaryChip {
 class _RouteConditionChips extends StatelessWidget {
   const _RouteConditionChips({
     required this.preset,
+    required this.objective,
     required this.transportScope,
     required this.itxTransportScopeEnabled,
     required this.onChangePreset,
+    required this.onChangeObjective,
     required this.onChangeTransportScope,
   });
 
   final MobilityPreset preset;
+  final RouteObjective objective;
   final RouteTransportScope transportScope;
   final bool itxTransportScopeEnabled;
   final VoidCallback onChangePreset;
+  final ValueChanged<RouteObjective> onChangeObjective;
   final ValueChanged<RouteTransportScope> onChangeTransportScope;
 
   @override
   Widget build(BuildContext context) {
     final displayName = mobilityPresetDisplayName(preset);
+    // 일반 폭에서는 한 행에 배치되고, 큰 글자·좁은 폭에서는 objective 행 다음으로
+    // scope 행이 자연스럽게 내려가도록 Wrap이 재배치한다.
     return Padding(
       key: const Key('routeConditionChips'),
       padding: const EdgeInsets.only(bottom: 16),
@@ -5392,6 +5543,24 @@ class _RouteConditionChips extends StatelessWidget {
             semanticLabel: '경로 시간 기준, $displayName',
             active: false,
             onTap: onChangePreset,
+          ),
+          // objective 탭: 기존 transport toggle 세그먼트 패턴을 재사용(무채색·radius 8·
+          // 그림자 0). 좌측에 놓고 항상 노출한다(기본값 FASTEST).
+          _RouteConditionChipButton(
+            buttonKey: const Key('routeObjectiveFastestChip'),
+            icon: Icons.bolt,
+            label: RouteObjective.fastest.label,
+            semanticLabel: '경로 목표, ${RouteObjective.fastest.label}',
+            active: objective == RouteObjective.fastest,
+            onTap: () => onChangeObjective(RouteObjective.fastest),
+          ),
+          _RouteConditionChipButton(
+            buttonKey: const Key('routeObjectiveFewestTransfersChip'),
+            icon: Icons.swap_calls,
+            label: RouteObjective.fewestTransfers.label,
+            semanticLabel: '경로 목표, ${RouteObjective.fewestTransfers.label}',
+            active: objective == RouteObjective.fewestTransfers,
+            onTap: () => onChangeObjective(RouteObjective.fewestTransfers),
           ),
           if (itxTransportScopeEnabled) ...[
             _RouteConditionChipButton(
@@ -5871,6 +6040,19 @@ class _RouteStepTile extends StatelessWidget {
                 color: EasySubwayAccessibleColors.secondaryText,
                 fontWeight: FontWeight.w700,
                 height: 1.3,
+              ),
+            ),
+          ],
+          // 승차 정보 영역에만 급행 배지를 붙인다(요약 카드 전체가 아니라 leg별).
+          // SUBWAY/EXPRESS만 대상이고, ITX-청춘·LOCAL은 배지 없음. 배지는 장식이라
+          // ExcludeSemantics로 두고 TalkBack용 `급행`은 이 Semantics가 한 번만 준다.
+          if (step.stepType == 'ride' && step.isSubwayExpress) ...[
+            const SizedBox(height: 6),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: Semantics(
+                label: '급행',
+                child: const ServicePatternBadge.express(),
               ),
             ),
           ],

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -4503,6 +4503,8 @@ Map<String, Object?> _routeV2Payload({
             'distanceMeters': 180,
             'etaSource': 'REALTIME',
             'confidence': 'HIGH',
+            'serviceClass': 'SUBWAY',
+            'servicePattern': 'LOCAL',
             'accessibilityRisk': {
               'stairCount': 0,
               'unknownAccessibilityCount': 0,

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -4411,6 +4411,101 @@ void main() {
     expect(ride.carDoorCarNumber, 3);
     expect(ride.carDoorDoorNumber, 4);
   });
+
+  test('fewestTransfers 요청은 환승이 더 적은 대안을, fastest는 기존 경로를 반환한다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await _seedTwoLegRoute(database);
+    // 환승 없는 직통 대안(비쌈): fastest는 피하고 fewestTransfers만 고른다.
+    await _insertVerifiedNetworkEdge(
+      database,
+      id: 'ride-a-c-direct-test',
+      fromNodeId: 'station-a:line-test',
+      toNodeId: 'station-c:line-test',
+      edgeType: 'RIDE',
+      durationSeconds: 900,
+    );
+    final repository = LocalRouteRepository(catalogDatabase: database);
+
+    final fastest = await repository.searchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-a',
+        destinationStationId: 'station-c',
+        mobilityType: 'STANDARD',
+      ),
+    );
+    final fewestTransfers = await repository.searchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-a',
+        destinationStationId: 'station-c',
+        mobilityType: 'STANDARD',
+        objective: RouteObjective.fewestTransfers,
+      ),
+    );
+
+    expect(fastest.status, 'FOUND');
+    expect(fastest.transferCount, 1);
+    expect(fewestTransfers.status, 'FOUND');
+    expect(fewestTransfers.transferCount, 0);
+    expect(
+      fewestTransfers.steps.expand((step) => step.evidenceSources),
+      contains('edge:ride-a-c-direct-test'),
+    );
+  });
+
+  test('로컬 ride servicePattern은 대문자 enum으로 정규화한다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await _seedLineWithoutNetworkEdges(database);
+    await _insertVerifiedNetworkEdge(
+      database,
+      id: 'ride-a-b-line-test',
+      fromNodeId: 'station-a:line-test',
+      toNodeId: 'station-b:line-test',
+      edgeType: 'RIDE',
+      durationSeconds: 90,
+      servicePattern: 'express',
+    );
+
+    final result = await LocalRouteRepository(catalogDatabase: database)
+        .searchRoute(
+          const RouteSearchRequest(
+            originStationId: 'station-a',
+            destinationStationId: 'station-b',
+            mobilityType: 'WHEELCHAIR',
+          ),
+        );
+
+    final ride = result.steps.firstWhere((s) => s.stepType == 'ride');
+    expect(ride.servicePattern, 'EXPRESS');
+  });
+
+  test('로컬 ride servicePattern이 LOCAL·EXPRESS가 아니면 배지 없이 null로 둔다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await _seedLineWithoutNetworkEdges(database);
+    await _insertVerifiedNetworkEdge(
+      database,
+      id: 'ride-a-b-line-test',
+      fromNodeId: 'station-a:line-test',
+      toNodeId: 'station-b:line-test',
+      edgeType: 'RIDE',
+      durationSeconds: 90,
+      servicePattern: 'RAPID',
+    );
+
+    final result = await LocalRouteRepository(catalogDatabase: database)
+        .searchRoute(
+          const RouteSearchRequest(
+            originStationId: 'station-a',
+            destinationStationId: 'station-b',
+            mobilityType: 'WHEELCHAIR',
+          ),
+        );
+
+    final ride = result.steps.firstWhere((s) => s.stepType == 'ride');
+    expect(ride.servicePattern, isNull);
+  });
 }
 
 Map<String, Object?> _routeV2Payload({

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -643,6 +643,126 @@ void main() {
     expect(ride.plannedArrivalTimeIso, isEmpty);
   });
 
+  test('로컬 경로는 소문자·공백 servicePattern을 정규화해 급행 시간표와 매칭한다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await _seedLineWithoutNetworkEdges(database);
+    // edge에 소문자·공백 'express '가 와도 대문자 'EXPRESS' 시간표를 찾도록
+    // 조회 전 정규화한다(UI 투영과 같은 값).
+    await _insertVerifiedNetworkEdge(
+      database,
+      id: 'express-edge-a-b',
+      fromNodeId: 'station-a:line-test',
+      toNodeId: 'station-b:line-test',
+      edgeType: 'RIDE',
+      durationSeconds: 600,
+      servicePattern: 'express ',
+    );
+    await database.customStatement('''
+      INSERT INTO service_calendars (
+        service_id, monday, tuesday, wednesday, thursday, friday,
+        saturday, sunday, start_date, end_date
+      ) VALUES (
+        'express-weekday', 1, 1, 1, 1, 1, 0, 0, '20260101', '20261231'
+      )
+    ''');
+    await database.customStatement('''
+      INSERT INTO transit_routes (id, line_id, route_short_name)
+      VALUES ('express-route', 'line-test', '4')
+    ''');
+    await database.customStatement('''
+      INSERT INTO transit_trips (
+        id, route_id, service_id, service_pattern, service_class
+      ) VALUES (
+        'express-trip', 'express-route', 'express-weekday', 'EXPRESS', 'SUBWAY'
+      )
+    ''');
+    await database.customStatement('''
+      INSERT INTO transit_stop_times (
+        trip_id, stop_sequence, station_id, line_id,
+        arrival_seconds, departure_seconds
+      ) VALUES
+        ('express-trip', 1, 'station-a', 'line-test', 28770, 28800),
+        ('express-trip', 2, 'station-b', 'line-test', 29400, 29430)
+    ''');
+    final repository = LocalRouteRepository(
+      catalogDatabase: database,
+      now: () => DateTime.parse('2026-07-10T07:58:00+09:00'),
+    );
+
+    final result = await repository.searchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-a',
+        destinationStationId: 'station-b',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
+
+    final ride = result.steps.singleWhere((step) => step.stepType == 'ride');
+    expect(result.status, 'FOUND');
+    expect(ride.plannedArrivalTimeIso, '2026-07-10T08:10:00+09:00');
+  });
+
+  test('로컬 경로는 미상 servicePattern이면 도착 시각 조회를 포기한다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await _seedLineWithoutNetworkEdges(database);
+    // 화이트리스트 밖 값은 어떤 시간표와도 신뢰성 있게 매칭할 수 없으므로 도착
+    // 시각을 비운다(fail-safe). 급행 시간표가 있어도 조회하지 않는다.
+    await _insertVerifiedNetworkEdge(
+      database,
+      id: 'mystery-edge-a-b',
+      fromNodeId: 'station-a:line-test',
+      toNodeId: 'station-b:line-test',
+      edgeType: 'RIDE',
+      durationSeconds: 600,
+      servicePattern: 'MYSTERY',
+    );
+    await database.customStatement('''
+      INSERT INTO service_calendars (
+        service_id, monday, tuesday, wednesday, thursday, friday,
+        saturday, sunday, start_date, end_date
+      ) VALUES (
+        'mystery-weekday', 1, 1, 1, 1, 1, 0, 0, '20260101', '20261231'
+      )
+    ''');
+    await database.customStatement('''
+      INSERT INTO transit_routes (id, line_id, route_short_name)
+      VALUES ('mystery-route', 'line-test', '4')
+    ''');
+    await database.customStatement('''
+      INSERT INTO transit_trips (
+        id, route_id, service_id, service_pattern, service_class
+      ) VALUES (
+        'mystery-trip', 'mystery-route', 'mystery-weekday', 'MYSTERY', 'SUBWAY'
+      )
+    ''');
+    await database.customStatement('''
+      INSERT INTO transit_stop_times (
+        trip_id, stop_sequence, station_id, line_id,
+        arrival_seconds, departure_seconds
+      ) VALUES
+        ('mystery-trip', 1, 'station-a', 'line-test', 28770, 28800),
+        ('mystery-trip', 2, 'station-b', 'line-test', 29400, 29430)
+    ''');
+    final repository = LocalRouteRepository(
+      catalogDatabase: database,
+      now: () => DateTime.parse('2026-07-10T07:58:00+09:00'),
+    );
+
+    final result = await repository.searchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-a',
+        destinationStationId: 'station-b',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
+
+    final ride = result.steps.singleWhere((step) => step.stepType == 'ride');
+    expect(result.status, 'FOUND');
+    expect(ride.plannedArrivalTimeIso, isEmpty);
+  });
+
   test('SLOW 프리셋은 보행 스텝 시간을 늘리고 ride 스텝은 그대로 둔다', () async {
     final database = CatalogDatabase.memory();
     addTearDown(database.close);

--- a/apps/mobile/test/features/routes/route_engine_test.dart
+++ b/apps/mobile/test/features/routes/route_engine_test.dart
@@ -56,6 +56,71 @@ void main() {
       expect(result.includesStairs, isFalse);
     });
 
+    test('fewestTransfers는 환승이 더 적은 대안을 고르고 fastest는 기존 최저비용 경로를 유지한다', () {
+      final engine = LocalRouteEngine(graph: _objectiveTradeoffFixtureGraph());
+
+      final fastest = engine.search(
+        const RouteRequest(
+          originStationId: 'station-a',
+          destinationStationId: 'station-d',
+          mobilityType: MobilityType.senior,
+        ),
+      );
+      final fewestTransfers = engine.search(
+        const RouteRequest(
+          originStationId: 'station-a',
+          destinationStationId: 'station-d',
+          mobilityType: MobilityType.senior,
+          objective: RouteObjective.fewestTransfers,
+        ),
+      );
+
+      // fastest(기본)은 환승 1회지만 총 일반화 비용이 낮은 경로를 유지한다.
+      expect(fastest.status, RouteStatus.found);
+      expect(fastest.edgeIds, [
+        'entry-a-line-1',
+        'ride-a-b-line-1',
+        'transfer-b-line-1-line-2',
+        'ride-b-d-line-2',
+        'exit-d-line-2',
+      ]);
+      expect(fastest.transferStationIds, ['station-b']);
+      expect(fastest.totalCost, 550);
+
+      // fewestTransfers는 더 비싸지만 환승 0회인 직통 경로를 고른다.
+      expect(fewestTransfers.status, RouteStatus.found);
+      expect(fewestTransfers.edgeIds, [
+        'entry-a-line-1',
+        'ride-a-d-direct-line-1',
+        'exit-d-line-1',
+      ]);
+      expect(fewestTransfers.transferStationIds, isEmpty);
+      expect(fewestTransfers.totalCost, 1098);
+    });
+
+    test('fewestTransfers는 환승 수가 같으면 총 비용이 낮은(빠른) 경로로 tie-break한다', () {
+      final engine = LocalRouteEngine(graph: _sameTransferCountFixtureGraph());
+
+      final result = engine.search(
+        const RouteRequest(
+          originStationId: 'station-a',
+          destinationStationId: 'station-d',
+          mobilityType: MobilityType.senior,
+          objective: RouteObjective.fewestTransfers,
+        ),
+      );
+
+      expect(result.status, RouteStatus.found);
+      expect(result.edgeIds, [
+        'entry-a-line-1',
+        'ride-a-b-line-1',
+        'transfer-b-line-1-line-2',
+        'ride-b-d-line-2-cheap',
+        'exit-d-line-2',
+      ]);
+      expect(result.transferStationIds, ['station-b']);
+    });
+
     test('access graph contract는 진입, 환승, 진출 시간을 분리한다', () {
       final router = AccessGraphRouter(graph: _capitalFixtureGraph());
 
@@ -1621,6 +1686,216 @@ NetworkGraph _lowQualityFixtureGraph() {
         type: RouteEdgeType.exit,
         baseCost: 90,
         isDataStale: true,
+        stairAccessState: RouteStairAccessState.stepFree,
+      ),
+    ],
+  );
+}
+
+NetworkGraph _objectiveTradeoffFixtureGraph() {
+  // A→D를 두 방식으로 연결한다: 환승 0회지만 비싼 직통 ride와, 환승 1회지만
+  // 더 저렴한 우회 ride. fastest는 저렴한 우회를, fewestTransfers는 직통을 골라야 한다.
+  return NetworkGraph(
+    nodes: const [
+      RouteNode(
+        id: 'station-a:line-1',
+        stationId: 'station-a',
+        lineId: 'line-1',
+      ),
+      RouteNode(
+        id: 'station-b:line-1',
+        stationId: 'station-b',
+        lineId: 'line-1',
+      ),
+      RouteNode(
+        id: 'station-b:line-2',
+        stationId: 'station-b',
+        lineId: 'line-2',
+      ),
+      RouteNode(
+        id: 'station-d:line-1',
+        stationId: 'station-d',
+        lineId: 'line-1',
+      ),
+      RouteNode(
+        id: 'station-d:line-2',
+        stationId: 'station-d',
+        lineId: 'line-2',
+      ),
+    ],
+    edges: const [
+      RouteEdge(
+        id: 'entry-a-line-1',
+        fromNodeId: 'station-a',
+        toNodeId: 'station-a:line-1',
+        type: RouteEdgeType.entry,
+        baseCost: 90,
+        stairAccessState: RouteStairAccessState.stepFree,
+      ),
+      RouteEdge(
+        id: 'ride-a-d-direct-line-1',
+        fromNodeId: 'station-a:line-1',
+        toNodeId: 'station-d:line-1',
+        type: RouteEdgeType.ride,
+        baseCost: 900,
+        lineId: 'line-1',
+      ),
+      RouteEdge(
+        id: 'exit-d-line-1',
+        fromNodeId: 'station-d:line-1',
+        toNodeId: 'station-d',
+        type: RouteEdgeType.exit,
+        baseCost: 90,
+        stairAccessState: RouteStairAccessState.stepFree,
+      ),
+      RouteEdge(
+        id: 'ride-a-b-line-1',
+        fromNodeId: 'station-a:line-1',
+        toNodeId: 'station-b:line-1',
+        type: RouteEdgeType.ride,
+        baseCost: 100,
+        lineId: 'line-1',
+      ),
+      RouteEdge(
+        id: 'transfer-b-line-1-line-2',
+        fromNodeId: 'station-b:line-1',
+        toNodeId: 'station-b:line-2',
+        type: RouteEdgeType.inStationTransfer,
+        baseCost: 140,
+        stairAccessState: RouteStairAccessState.stepFree,
+      ),
+      RouteEdge(
+        id: 'ride-b-d-line-2',
+        fromNodeId: 'station-b:line-2',
+        toNodeId: 'station-d:line-2',
+        type: RouteEdgeType.ride,
+        baseCost: 100,
+        lineId: 'line-2',
+      ),
+      RouteEdge(
+        id: 'exit-d-line-2',
+        fromNodeId: 'station-d:line-2',
+        toNodeId: 'station-d',
+        type: RouteEdgeType.exit,
+        baseCost: 90,
+        stairAccessState: RouteStairAccessState.stepFree,
+      ),
+    ],
+  );
+}
+
+NetworkGraph _sameTransferCountFixtureGraph() {
+  // A→D를 각각 환승 1회로 잇는 두 경로. fewestTransfers에서 환승 수가 같으므로
+  // 총 비용이 낮은(빠른) line-2 경유 경로로 tie-break되어야 한다.
+  return NetworkGraph(
+    nodes: const [
+      RouteNode(
+        id: 'station-a:line-1',
+        stationId: 'station-a',
+        lineId: 'line-1',
+      ),
+      RouteNode(
+        id: 'station-b:line-1',
+        stationId: 'station-b',
+        lineId: 'line-1',
+      ),
+      RouteNode(
+        id: 'station-b:line-2',
+        stationId: 'station-b',
+        lineId: 'line-2',
+      ),
+      RouteNode(
+        id: 'station-c:line-1',
+        stationId: 'station-c',
+        lineId: 'line-1',
+      ),
+      RouteNode(
+        id: 'station-c:line-3',
+        stationId: 'station-c',
+        lineId: 'line-3',
+      ),
+      RouteNode(
+        id: 'station-d:line-2',
+        stationId: 'station-d',
+        lineId: 'line-2',
+      ),
+      RouteNode(
+        id: 'station-d:line-3',
+        stationId: 'station-d',
+        lineId: 'line-3',
+      ),
+    ],
+    edges: const [
+      RouteEdge(
+        id: 'entry-a-line-1',
+        fromNodeId: 'station-a',
+        toNodeId: 'station-a:line-1',
+        type: RouteEdgeType.entry,
+        baseCost: 90,
+        stairAccessState: RouteStairAccessState.stepFree,
+      ),
+      RouteEdge(
+        id: 'ride-a-b-line-1',
+        fromNodeId: 'station-a:line-1',
+        toNodeId: 'station-b:line-1',
+        type: RouteEdgeType.ride,
+        baseCost: 100,
+        lineId: 'line-1',
+      ),
+      RouteEdge(
+        id: 'transfer-b-line-1-line-2',
+        fromNodeId: 'station-b:line-1',
+        toNodeId: 'station-b:line-2',
+        type: RouteEdgeType.inStationTransfer,
+        baseCost: 140,
+        stairAccessState: RouteStairAccessState.stepFree,
+      ),
+      RouteEdge(
+        id: 'ride-b-d-line-2-cheap',
+        fromNodeId: 'station-b:line-2',
+        toNodeId: 'station-d:line-2',
+        type: RouteEdgeType.ride,
+        baseCost: 100,
+        lineId: 'line-2',
+      ),
+      RouteEdge(
+        id: 'exit-d-line-2',
+        fromNodeId: 'station-d:line-2',
+        toNodeId: 'station-d',
+        type: RouteEdgeType.exit,
+        baseCost: 90,
+        stairAccessState: RouteStairAccessState.stepFree,
+      ),
+      RouteEdge(
+        id: 'ride-a-c-line-1',
+        fromNodeId: 'station-a:line-1',
+        toNodeId: 'station-c:line-1',
+        type: RouteEdgeType.ride,
+        baseCost: 100,
+        lineId: 'line-1',
+      ),
+      RouteEdge(
+        id: 'transfer-c-line-1-line-3',
+        fromNodeId: 'station-c:line-1',
+        toNodeId: 'station-c:line-3',
+        type: RouteEdgeType.inStationTransfer,
+        baseCost: 140,
+        stairAccessState: RouteStairAccessState.stepFree,
+      ),
+      RouteEdge(
+        id: 'ride-c-d-line-3-expensive',
+        fromNodeId: 'station-c:line-3',
+        toNodeId: 'station-d:line-3',
+        type: RouteEdgeType.ride,
+        baseCost: 400,
+        lineId: 'line-3',
+      ),
+      RouteEdge(
+        id: 'exit-d-line-3',
+        fromNodeId: 'station-d:line-3',
+        toNodeId: 'station-d',
+        type: RouteEdgeType.exit,
+        baseCost: 90,
         stairAccessState: RouteStairAccessState.stepFree,
       ),
     ],

--- a/apps/mobile/test/features/stations/drift_station_repository_test.dart
+++ b/apps/mobile/test/features/stations/drift_station_repository_test.dart
@@ -376,6 +376,49 @@ void main() {
     expect(local.serviceClass, 'SUBWAY');
   });
 
+  test('로컬 역 시간표는 소문자·공백 service_class도 지하철 출발로 매칭한다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await database.seedBaselineIfEmpty();
+    await _seedStationTimetable(database);
+    // 저장소 레벨 정규화(trim/upper)와 비대칭인 정확 일치 SQL이 소문자·공백 값을
+    // 조용히 누락하지 않는지 검증한다.
+    await database.customStatement('''
+      INSERT INTO transit_trips (
+        id, route_id, service_id, trip_headsign, direction_id,
+        service_pattern, service_class, service_day_start_seconds
+      ) VALUES (
+        'weekday-down-1919-messy', 'line4-down-1919', 'weekday-1919', '사당', 'down',
+        'LOCAL', '  subway  ', 0
+      )
+    ''');
+    await database.customStatement('''
+      INSERT INTO transit_stop_times (
+        trip_id, stop_sequence, station_id, line_id,
+        arrival_seconds, departure_seconds, pickup_type, drop_off_type
+      ) VALUES (
+        'weekday-down-1919-messy', 1, 'station-sadang', 'seoul-4', 19380, 19380, 0, 0
+      )
+    ''');
+    final repository = DriftStationRepository(database: database);
+
+    final timetable = await repository.loadStationTimetable(
+      stationId: 'station-sadang',
+      lineId: 'seoul-4',
+      dayType: StationTimetableDayType.weekday,
+      referenceDate: DateTime(2026, 7, 12),
+    );
+
+    final sadang = timetable.directions.singleWhere(
+      (direction) => direction.name == '사당 방면',
+    );
+    final messy = sadang.departures.singleWhere(
+      (departure) => departure.timeLabel == '05:23',
+    );
+    expect(messy.serviceClass, 'SUBWAY');
+    expect(messy.servicePattern, 'LOCAL');
+  });
+
   test('로컬 역 시간표는 지하철 미상·공백 운행종별을 경계에서 실패시킨다', () async {
     final database = CatalogDatabase.memory();
     addTearDown(database.close);

--- a/apps/mobile/test/features/stations/drift_station_repository_test.dart
+++ b/apps/mobile/test/features/stations/drift_station_repository_test.dart
@@ -328,6 +328,89 @@ void main() {
     );
   });
 
+  test('로컬 역 시간표는 지하철 급행·일반 운행종별을 손실 없이 전달한다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await database.seedBaselineIfEmpty();
+    await _seedStationTimetable(database);
+    await database.customStatement('''
+      INSERT INTO transit_trips (
+        id, route_id, service_id, trip_headsign, direction_id,
+        service_pattern, service_class, service_day_start_seconds
+      ) VALUES (
+        'weekday-down-1919-express', 'line4-down-1919', 'weekday-1919', '사당', 'down',
+        'EXPRESS', 'SUBWAY', 0
+      )
+    ''');
+    await database.customStatement('''
+      INSERT INTO transit_stop_times (
+        trip_id, stop_sequence, station_id, line_id,
+        arrival_seconds, departure_seconds, pickup_type, drop_off_type
+      ) VALUES (
+        'weekday-down-1919-express', 1, 'station-sadang', 'seoul-4', 19260, 19260, 0, 0
+      )
+    ''');
+    final repository = DriftStationRepository(database: database);
+
+    final timetable = await repository.loadStationTimetable(
+      stationId: 'station-sadang',
+      lineId: 'seoul-4',
+      dayType: StationTimetableDayType.weekday,
+      referenceDate: DateTime(2026, 7, 12),
+    );
+
+    final sadang = timetable.directions.singleWhere(
+      (direction) => direction.name == '사당 방면',
+    );
+    final express = sadang.departures.singleWhere(
+      (departure) => departure.isExpress,
+    );
+    expect(express.timeLabel, '05:21');
+    expect(express.servicePattern, 'EXPRESS');
+    expect(express.serviceClass, 'SUBWAY');
+    final local = sadang.departures.singleWhere(
+      (departure) => departure.timeLabel == '05:20',
+    );
+    expect(local.isExpress, isFalse);
+    expect(local.servicePattern, 'LOCAL');
+    expect(local.serviceClass, 'SUBWAY');
+  });
+
+  test('로컬 역 시간표는 지하철 미상·공백 운행종별을 경계에서 실패시킨다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await database.seedBaselineIfEmpty();
+    await _seedStationTimetable(database);
+    await database.customStatement('''
+      INSERT INTO transit_trips (
+        id, route_id, service_id, trip_headsign, direction_id,
+        service_pattern, service_class, service_day_start_seconds
+      ) VALUES (
+        'weekday-down-1919-unknown', 'line4-down-1919', 'weekday-1919', '사당', 'down',
+        '', 'SUBWAY', 0
+      )
+    ''');
+    await database.customStatement('''
+      INSERT INTO transit_stop_times (
+        trip_id, stop_sequence, station_id, line_id,
+        arrival_seconds, departure_seconds, pickup_type, drop_off_type
+      ) VALUES (
+        'weekday-down-1919-unknown', 1, 'station-sadang', 'seoul-4', 19320, 19320, 0, 0
+      )
+    ''');
+    final repository = DriftStationRepository(database: database);
+
+    await expectLater(
+      repository.loadStationTimetable(
+        stationId: 'station-sadang',
+        lineId: 'seoul-4',
+        dayType: StationTimetableDayType.weekday,
+        referenceDate: DateTime(2026, 7, 12),
+      ),
+      throwsA(isA<StateError>()),
+    );
+  });
+
   test('흡수된 station ID로도 대표 역 시간표를 반환한다', () async {
     final database = CatalogDatabase.memory();
     addTearDown(database.close);

--- a/apps/mobile/test/route_search_request_test.dart
+++ b/apps/mobile/test/route_search_request_test.dart
@@ -55,4 +55,69 @@ void main() {
 
     expect(request.toJson().containsKey('mobilityPreset'), isFalse);
   });
+
+  test('toV2Json은 기본 objective로 FASTEST를 싣는다', () {
+    const request = RouteSearchRequest(
+      originStationId: 'station-a',
+      destinationStationId: 'station-b',
+      mobilityType: 'STANDARD',
+    );
+
+    expect(request.toV2Json()['objective'], 'FASTEST');
+  });
+
+  test('toV2Json은 선택한 objective를 서버 문자열로 싣는다', () {
+    const request = RouteSearchRequest(
+      originStationId: 'station-a',
+      destinationStationId: 'station-b',
+      mobilityType: 'STANDARD',
+      objective: RouteObjective.fewestTransfers,
+    );
+
+    expect(request.toV2Json()['objective'], 'FEWEST_TRANSFERS');
+  });
+
+  test('요청 serialization에는 servicePattern·expressOnly를 싣지 않는다', () {
+    for (final objective in RouteObjective.values) {
+      for (final scope in RouteTransportScope.values) {
+        final request = RouteSearchRequest(
+          originStationId: 'station-a',
+          destinationStationId: 'station-b',
+          mobilityType: 'STANDARD',
+          objective: objective,
+          transportScope: scope,
+        );
+        final body = request.toV2Json();
+        expect(body.containsKey('servicePattern'), isFalse);
+        expect(body.containsKey('expressOnly'), isFalse);
+      }
+    }
+  });
+
+  test('네 조합(objective × scope)은 요청 필드에 그대로 보존된다', () {
+    final expectations = {
+      (RouteObjective.fastest, RouteTransportScope.subway): 'FASTEST',
+      (RouteObjective.fewestTransfers, RouteTransportScope.subway):
+          'FEWEST_TRANSFERS',
+      (RouteObjective.fastest, RouteTransportScope.subwayAndItxCheongchun):
+          'FASTEST',
+      (
+        RouteObjective.fewestTransfers,
+        RouteTransportScope.subwayAndItxCheongchun,
+      ): 'FEWEST_TRANSFERS',
+    };
+    expectations.forEach((combo, expectedObjective) {
+      final (objective, scope) = combo;
+      final request = RouteSearchRequest(
+        originStationId: 'station-a',
+        destinationStationId: 'station-b',
+        mobilityType: 'STANDARD',
+        objective: objective,
+        transportScope: scope,
+      );
+      expect(request.objective.serverValue, expectedObjective);
+      expect(request.transportScope, scope);
+      expect(request.toV2Json()['objective'], expectedObjective);
+    });
+  });
 }

--- a/apps/mobile/test/route_search_test.dart
+++ b/apps/mobile/test/route_search_test.dart
@@ -1562,6 +1562,336 @@ void main() {
       'etaFeedbackOptedIn': true,
     });
   });
+
+  group('#2099 V2 leg 운행 정보 파싱·급행 배지 파생', () {
+    test('RIDE SUBWAY/EXPRESS leg은 급행으로 파생된다', () {
+      final leg = RouteSearchV2Leg.fromJson(
+        _rideLegJson(serviceClass: 'SUBWAY', servicePattern: 'EXPRESS'),
+      );
+      expect(leg.serviceClass, 'SUBWAY');
+      expect(leg.servicePattern, 'EXPRESS');
+      expect(leg.isSubwayExpress, isTrue);
+      final step = RouteSearchStep.fromV2(1, leg);
+      expect(step.isSubwayExpress, isTrue);
+    });
+
+    test('RIDE SUBWAY/LOCAL leg은 급행이 아니다', () {
+      final leg = RouteSearchV2Leg.fromJson(
+        _rideLegJson(serviceClass: 'SUBWAY', servicePattern: 'LOCAL'),
+      );
+      expect(leg.isSubwayExpress, isFalse);
+      expect(RouteSearchStep.fromV2(1, leg).isSubwayExpress, isFalse);
+    });
+
+    test('RIDE ITX_CHEONGCHUN/EXPRESS leg은 generic 급행 배지를 만들지 않는다', () {
+      final leg = RouteSearchV2Leg.fromJson(
+        _rideLegJson(serviceClass: 'ITX_CHEONGCHUN', servicePattern: 'EXPRESS'),
+      );
+      expect(leg.serviceClass, 'ITX_CHEONGCHUN');
+      expect(leg.isSubwayExpress, isFalse);
+      expect(RouteSearchStep.fromV2(1, leg).isSubwayExpress, isFalse);
+    });
+
+    test('non-ride leg의 service 필드는 null만 허용한다', () {
+      final walk = _rideLegJson(legType: 'WALK')
+        ..remove('serviceClass')
+        ..remove('servicePattern');
+      final leg = RouteSearchV2Leg.fromJson(walk);
+      expect(leg.serviceClass, isNull);
+      expect(leg.servicePattern, isNull);
+      expect(leg.isSubwayExpress, isFalse);
+    });
+
+    test('non-ride leg이 service 필드를 실으면 payload error다', () {
+      final walk = _rideLegJson(legType: 'WALK');
+      walk['serviceClass'] = 'SUBWAY';
+      walk['servicePattern'] = 'EXPRESS';
+      expect(
+        () => RouteSearchV2Leg.fromJson(walk),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('RIDE unknown pattern은 LOCAL 추정 없이 payload error다', () {
+      final leg = _rideLegJson(serviceClass: 'SUBWAY', servicePattern: 'RAPID');
+      expect(
+        () => RouteSearchV2Leg.fromJson(leg),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('RIDE blank service 필드는 LOCAL 추정 없이 payload error다', () {
+      final leg = _rideLegJson(serviceClass: '', servicePattern: '');
+      expect(
+        () => RouteSearchV2Leg.fromJson(leg),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('RIDE에 service 필드가 없으면 payload error다', () {
+      final leg = _rideLegJson()
+        ..remove('serviceClass')
+        ..remove('servicePattern');
+      expect(
+        () => RouteSearchV2Leg.fromJson(leg),
+        throwsA(isA<FormatException>()),
+      );
+    });
+  });
+
+  group('#2099 objective-tagged itinerary 보존·선택', () {
+    test('dual-tag dedupe된 대표 itinerary는 두 objective에서 모두 선택된다', () {
+      final result = _objectiveResult([
+        _taggedItinerary(
+          lineId: 'line-shared',
+          objectiveTags: const ['FASTEST', 'FEWEST_TRANSFERS'],
+        ),
+      ]);
+      expect(
+        RouteSearchResult.fromV2(
+          result,
+          objective: RouteObjective.fastest,
+        ).lineId,
+        'line-shared',
+      );
+      expect(
+        RouteSearchResult.fromV2(
+          result,
+          objective: RouteObjective.fewestTransfers,
+        ).lineId,
+        'line-shared',
+      );
+    });
+
+    test('objective별 대표가 다르면 각 objective의 태그된 itinerary를 고른다', () {
+      final result = _objectiveResult([
+        _taggedItinerary(lineId: 'line-fast', objectiveTags: const ['FASTEST']),
+        _taggedItinerary(
+          lineId: 'line-few',
+          objectiveTags: const ['FEWEST_TRANSFERS'],
+        ),
+      ]);
+      expect(
+        RouteSearchResult.fromV2(
+          result,
+          objective: RouteObjective.fastest,
+        ).lineId,
+        'line-fast',
+      );
+      expect(
+        RouteSearchResult.fromV2(
+          result,
+          objective: RouteObjective.fewestTransfers,
+        ).lineId,
+        'line-few',
+      );
+    });
+
+    test('태그 없는 응답은 첫 FOUND로 폴백해 기존 동작을 보존한다', () {
+      final result = _objectiveResult([
+        _taggedItinerary(lineId: 'line-a', objectiveTags: const []),
+      ]);
+      expect(
+        RouteSearchResult.fromV2(
+          result,
+          objective: RouteObjective.fewestTransfers,
+        ).lineId,
+        'line-a',
+      );
+    });
+
+    test('이전 objective 검색의 늦은 응답은 현재 화면을 덮지 않는다', () async {
+      final repository = _ManualRouteSearchRepository();
+      final controller = RouteSearchController(repository: repository);
+      addTearDown(controller.dispose);
+
+      const fastRequest = RouteSearchRequest(
+        originStationId: 'station-a',
+        destinationStationId: 'station-b',
+        mobilityType: 'STANDARD',
+      );
+      const fewRequest = RouteSearchRequest(
+        originStationId: 'station-a',
+        destinationStationId: 'station-b',
+        mobilityType: 'STANDARD',
+        objective: RouteObjective.fewestTransfers,
+      );
+
+      unawaited(controller.search(fastRequest));
+      unawaited(controller.search(fewRequest));
+      await pumpEventQueue();
+
+      // 이전(FASTEST) 검색이 늦게 도착해도 최신(FEWEST_TRANSFERS) 상태를 덮지 못한다.
+      repository.completers[RouteObjective.fastest]!.complete(
+        _routeResult('route-fast'),
+      );
+      await pumpEventQueue();
+      expect(controller.state.result, isNull);
+      expect(controller.state.status, RouteSearchViewStatus.loading);
+
+      repository.completers[RouteObjective.fewestTransfers]!.complete(
+        _routeResult('route-few'),
+      );
+      await pumpEventQueue();
+      expect(controller.state.status, RouteSearchViewStatus.success);
+      expect(controller.state.result?.routeSearchId, 'route-few');
+    });
+  });
+}
+
+class _ManualRouteSearchRepository implements RouteSearchRepository {
+  final requests = <RouteSearchRequest>[];
+  final completers = <RouteObjective, Completer<RouteSearchResult>>{};
+
+  @override
+  Future<RouteSearchResult> searchRoute(RouteSearchRequest request) {
+    requests.add(request);
+    final completer = Completer<RouteSearchResult>();
+    completers[request.objective] = completer;
+    return completer.future;
+  }
+
+  @override
+  Future<RouteRefreshResult> refreshRoute(String routeSearchId) {
+    throw UnimplementedError();
+  }
+}
+
+RouteSearchResult _routeResult(String routeSearchId) {
+  return RouteSearchResult(
+    routeSearchId: routeSearchId,
+    originStationId: 'station-a',
+    originStationName: '상록수',
+    destinationStationId: 'station-b',
+    destinationStationName: '사당',
+    mobilityType: 'STANDARD',
+    constraintMode: 'PREFER_STEP_FREE',
+    status: 'FOUND',
+    lineId: 'seoul-4',
+    lineName: '수도권 4호선',
+    score: 90,
+    burdenCost: 90,
+    steps: const [],
+    warnings: const [],
+    recommendationReasons: const [],
+    blockedReasons: const [],
+    createdAt: '2026-06-30T09:15:00+09:00',
+  );
+}
+
+Map<String, Object?> _rideLegJson({
+  String legType = 'RIDE',
+  Object? serviceClass = 'SUBWAY',
+  Object? servicePattern = 'LOCAL',
+}) {
+  return <String, Object?>{
+    'legType': legType,
+    'fromStationId': 'station-a',
+    'toStationId': 'station-b',
+    'fromNodeId': '',
+    'toNodeId': '',
+    'lineId': 'line-4',
+    'tripId': 'trip-1',
+    'trainNo': '4001',
+    'plannedDepartureTime': '2026-06-30T09:17:00+09:00',
+    'realtimeDepartureTime': null,
+    'plannedArrivalTime': '2026-06-30T09:42:00+09:00',
+    'realtimeArrivalTime': null,
+    'waitTimeSeconds': 0,
+    'slackSeconds': 0,
+    'durationSeconds': 1500,
+    'distanceMeters': 12000,
+    'etaSource': 'PLANNED',
+    'confidence': 'MEDIUM',
+    'accessibilityRisk': <String, Object?>{
+      'stairCount': 0,
+      'unknownAccessibilityCount': 0,
+      'generatedConnectorCount': 0,
+      'staleDataCount': 0,
+      'lowConfidenceCount': 0,
+      'unavailableFacilityCount': 0,
+      'riskLevel': 'LOW',
+      'reasonCodes': <String>[],
+      'level': 'LOW',
+      'reasons': <String>[],
+    },
+    'serviceClass': serviceClass,
+    'servicePattern': servicePattern,
+  };
+}
+
+const _objectiveTestRisk = RouteSearchV2AccessibilityRisk(
+  stairCount: 0,
+  unknownAccessibilityCount: 0,
+  generatedConnectorCount: 0,
+  staleDataCount: 0,
+  lowConfidenceCount: 0,
+  unavailableFacilityCount: 0,
+  riskLevel: 'LOW',
+  reasonCodes: [],
+  level: 'LOW',
+  reasons: [],
+);
+
+RouteSearchV2Itinerary _taggedItinerary({
+  required String lineId,
+  required List<String> objectiveTags,
+}) {
+  return RouteSearchV2Itinerary(
+    itineraryId: 'route-$lineId-primary',
+    status: 'FOUND',
+    plannedArrivalTime: '2026-06-30T09:42:00+09:00',
+    realtimeArrivalTime: null,
+    etaSource: 'PLANNED',
+    etaConfidence: 'MEDIUM',
+    durationSeconds: 1620,
+    transferCount: 0,
+    walkingDistanceMeters: 80,
+    accessibilityRisk: _objectiveTestRisk,
+    commercialEtaEligible: false,
+    objectiveTags: objectiveTags,
+    legs: [
+      RouteSearchV2Leg(
+        legType: 'RIDE',
+        fromStationId: 'station-a',
+        toStationId: 'station-b',
+        fromNodeId: '',
+        toNodeId: '',
+        lineId: lineId,
+        tripId: 'trip-1',
+        trainNo: '4001',
+        plannedDepartureTime: '2026-06-30T09:17:00+09:00',
+        realtimeDepartureTime: null,
+        plannedArrivalTime: '2026-06-30T09:42:00+09:00',
+        realtimeArrivalTime: null,
+        waitTimeSeconds: 60,
+        slackSeconds: 0,
+        durationSeconds: 1500,
+        distanceMeters: 12000,
+        etaSource: 'PLANNED',
+        confidence: 'MEDIUM',
+        accessibilityRisk: _objectiveTestRisk,
+        serviceClass: 'SUBWAY',
+        servicePattern: 'LOCAL',
+      ),
+    ],
+  );
+}
+
+RouteSearchV2Result _objectiveResult(List<RouteSearchV2Itinerary> itineraries) {
+  return RouteSearchV2Result(
+    contractVersion: 'ROUTE_SEARCH_V2',
+    originStationId: 'station-a',
+    destinationStationId: 'station-b',
+    departureTime: '2026-06-30T09:15:00+09:00',
+    mobilityType: 'STANDARD',
+    constraintMode: 'PREFER_STEP_FREE',
+    useRealtime: true,
+    maxTransfers: 3,
+    alternativeCount: 3,
+    statuses: const ['FOUND'],
+    itineraries: itineraries,
+  );
 }
 
 class FakeRouteSearchRepository implements RouteSearchRepository {

--- a/apps/mobile/test/route_search_test.dart
+++ b/apps/mobile/test/route_search_test.dart
@@ -1700,6 +1700,22 @@ void main() {
       );
     });
 
+    test('태그가 있는데 요청 objective와 매칭되는 FOUND가 없으면 fail closed', () {
+      // FASTEST 전용 경로만 있는데 최소환승을 요청하면 silent fallback(계약 위반)을
+      // 피해 payload 오류로 실패시킨다. RouteSearchV2ApiRepository.searchRoute의 generic
+      // catch가 이 FormatException을 unavailable로 흘려보낸다.
+      final result = _objectiveResult([
+        _taggedItinerary(lineId: 'line-fast', objectiveTags: const ['FASTEST']),
+      ]);
+      expect(
+        () => RouteSearchResult.fromV2(
+          result,
+          objective: RouteObjective.fewestTransfers,
+        ),
+        throwsFormatException,
+      );
+    });
+
     test('이전 objective 검색의 늦은 응답은 현재 화면을 덮지 않는다', () async {
       final repository = _ManualRouteSearchRepository();
       final controller = RouteSearchController(repository: repository);

--- a/apps/mobile/test/station_search_test.dart
+++ b/apps/mobile/test/station_search_test.dart
@@ -24,6 +24,67 @@ void main() {
     debugStationVerifiedClock = DateTime.now;
   });
 
+  test('시간표 출발 모델은 일반·급행 운행종별을 시각순으로 유지한다', () {
+    const local = StationTimetableDeparture(
+      directionName: '사당 방면',
+      seconds: 28800, // 08:00
+    );
+    const express = StationTimetableDeparture(
+      directionName: '사당 방면',
+      seconds: 28980, // 08:03
+      servicePattern: 'EXPRESS',
+      serviceClass: 'SUBWAY',
+    );
+    const direction = StationTimetableDirection(
+      name: '사당 방면',
+      departures: [local, express],
+    );
+
+    expect(direction.departures.map((departure) => departure.seconds), [
+      28800,
+      28980,
+    ]);
+    expect(local.timeLabel, '08:00');
+    expect(express.timeLabel, '08:03');
+    expect(local.isExpress, isFalse);
+    expect(express.isExpress, isTrue);
+    expect(direction.firstDeparture.timeLabel, '08:00');
+    expect(direction.lastDeparture.timeLabel, '08:03');
+    expect(express.semanticLabel, contains('급행'));
+    expect(local.semanticLabel, isNot(contains('급행')));
+  });
+
+  test('시간표 방향은 일반·급행 출발을 시각순으로 묶고 첫차·막차를 유지한다', () {
+    // LOCAL 08:00과 EXPRESS 08:03이 한 방향 목록에 시각순으로 함께 놓이고,
+    // 급행 판정은 08:03에만 참이며, 첫차/막차는 목록 양끝을 그대로 가리킨다.
+    // (화면 렌더링 회귀는 widget_test.dart의 역 시간표 화면 테스트가 담당한다.)
+    const direction = StationTimetableDirection(
+      name: '사당 방면',
+      departures: [
+        StationTimetableDeparture(directionName: '사당 방면', seconds: 28800),
+        StationTimetableDeparture(
+          directionName: '사당 방면',
+          seconds: 28980,
+          servicePattern: 'EXPRESS',
+          serviceClass: 'SUBWAY',
+        ),
+      ],
+    );
+
+    expect(
+      direction.departures.map((departure) => departure.timeLabel).toList(),
+      ['08:00', '08:03'],
+    );
+    expect(
+      direction.departures.map((departure) => departure.isExpress).toList(),
+      [false, true],
+    );
+    expect(direction.firstDeparture.timeLabel, '08:00');
+    expect(direction.firstDeparture.isExpress, isFalse);
+    expect(direction.lastDeparture.timeLabel, '08:03');
+    expect(direction.lastDeparture.isExpress, isTrue);
+  });
+
   test('릴리즈 빌드는 API 기본 주소를 반드시 설정해야 한다', () {
     expect(
       () => stationApiBaseUriForEnvironment(

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -4836,6 +4836,135 @@ void main() {
     expect(find.bySemanticsLabel('실시간 선택됨'), findsOneWidget);
   });
 
+  testWidgets('급행 운행 정보는 선택 UI 없이 시간표와 길찾기에 표시된다', (tester) async {
+    tester.view.physicalSize = const Size(320, 1200);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+    final semanticsHandle = tester.ensureSemantics();
+    final now = DateTime.now();
+    final baseSeconds =
+        now.hour * Duration.secondsPerHour +
+        now.minute * Duration.secondsPerMinute +
+        now.second;
+    final localDeparture = StationTimetableDeparture(
+      directionName: '오이도',
+      seconds: baseSeconds + 120,
+    );
+    final expressDeparture = StationTimetableDeparture(
+      directionName: '오이도',
+      seconds: baseSeconds + 300,
+      servicePattern: 'EXPRESS',
+      serviceClass: 'SUBWAY',
+    );
+    final repository = FakeTimetableStationRepository(
+      stationDetail: _stationDetail(id: 'station-sangnoksu', name: '상록수'),
+      networkMapRegionNames: const ['수도권'],
+      nearbyResults: [_stationResult(id: 'station-sangnoksu', name: '상록수')],
+      timetables: {
+        for (final dayType in StationTimetableDayType.values)
+          dayType: _stationTimetable(
+            dayType,
+            directions: [
+              StationTimetableDirection(
+                name: '오이도',
+                departures: [localDeparture, expressDeparture],
+              ),
+            ],
+          ),
+      },
+    );
+
+    try {
+      await _pumpNetworkMapForGpsTest(
+        tester,
+        repository: repository,
+        locationProvider: FakeCurrentLocationProvider(
+          location: _freshCurrentLocation(),
+          needsPermissionRequest: false,
+        ),
+        realtimeRepository: _RecordingRealtimeRepository(),
+      );
+
+      await tester.tap(find.byKey(const Key('nearbyStationButton')));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.descendant(
+          of: find.byKey(const Key('networkMapNearbyDataSourceToggle')),
+          matching: find.text('시간표'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // --- 시간표 부분(#2099 WP1) ---
+      // 인접역 시간표 패널로 범위를 좁힌다. 노선도 자체의 일반/급행 노선 뷰
+      // 전환 컨트롤(networkMapServicePatternToggle)은 시간표 급행 정보와 무관한
+      // 별개 기능이므로 이 검증에 섞이지 않게 한다.
+      final panel = find.byKey(const Key('networkMapNearbyStationPanel'));
+      expect(panel, findsOneWidget);
+      // 급행 출발 행에만 배지 1회, 일반 행에는 배지 없음.
+      expect(
+        find.descendant(
+          of: panel,
+          matching: find.byKey(const Key('servicePatternExpressBadge')),
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(of: panel, matching: find.text('급행')),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(of: panel, matching: find.text('일반')),
+        findsNothing,
+      );
+      // 두 시각 모두 노출.
+      expect(
+        find.descendant(
+          of: panel,
+          matching: find.text(localDeparture.timeLabel),
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(
+          of: panel,
+          matching: find.text(expressDeparture.timeLabel),
+        ),
+        findsOneWidget,
+      );
+      // TalkBack은 급행을 정확히 한 번만 읽는다(배지는 장식이라 semantics 제외).
+      expect(
+        find.descendant(
+          of: panel,
+          matching: find.bySemanticsLabel(RegExp('급행')),
+        ),
+        findsOneWidget,
+      );
+      // 급행/일반은 실제 운행 정보다 — 시간표 패널 안에 toggle/chip/filter 선택
+      // 컨트롤 0건.
+      expect(
+        find.descendant(of: panel, matching: find.byType(ChoiceChip)),
+        findsNothing,
+      );
+      expect(
+        find.descendant(of: panel, matching: find.byType(FilterChip)),
+        findsNothing,
+      );
+      expect(
+        find.descendant(of: panel, matching: find.byType(Switch)),
+        findsNothing,
+      );
+
+      // --- 길찾기 부분(#2099 WP2에서 확장 예정) ---
+      // WP2가 같은 테스트에 길찾기 경로의 급행 표시 검증을 이어서 덧붙인다.
+    } finally {
+      semanticsHandle.dispose();
+    }
+  });
+
   testWidgets('GPS 하단 패널은 열차 정보가 없어도 인접역 두 방면 스켈레톤(제목+대시+구분선)을 유지한다', (
     tester,
   ) async {
@@ -10268,6 +10397,90 @@ void main() {
       );
     } finally {
       semanticsHandle.dispose();
+      debugStationVerifiedClock = DateTime.now;
+    }
+  });
+
+  testWidgets('역 시간표 화면은 일반·급행을 한 목록에 시각순으로 표시하고 급행 행에만 배지를 단다', (
+    tester,
+  ) async {
+    // #2099 WP1: LOCAL 08:00과 EXPRESS 08:03이 한 방향 목록에 시각순으로 함께
+    // 놓이고, 08:03에만 급행 배지가 붙으며 방향·첫차·막차 동작은 유지된다.
+    debugStationVerifiedClock = () => DateTime(2026, 7, 6); // 월요일(평일)
+    const line = StationSearchLine(
+      id: 'seoul-4',
+      name: '수도권 4호선',
+      color: '#00A5DE',
+      stationCode: '433',
+    );
+    final repository = FakeTimetableStationRepository(
+      stationDetail: _stationDetail(id: 'station-sadang', name: '사당'),
+      timetableLineId: 'seoul-4',
+      timetables: {
+        for (final dayType in StationTimetableDayType.values)
+          dayType: _stationTimetable(
+            dayType,
+            stationId: 'station-sadang',
+            lineId: 'seoul-4',
+            directions: const [
+              StationTimetableDirection(
+                name: '사당 방면',
+                departures: [
+                  StationTimetableDeparture(
+                    directionName: '사당 방면',
+                    seconds: 28800, // 08:00 일반
+                  ),
+                  StationTimetableDeparture(
+                    directionName: '사당 방면',
+                    seconds: 28980, // 08:03 급행
+                    servicePattern: 'EXPRESS',
+                    serviceClass: 'SUBWAY',
+                  ),
+                ],
+              ),
+            ],
+          ),
+      },
+    );
+
+    try {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: StationTimetableScreen(
+            stationId: 'station-sadang',
+            stationName: '사당',
+            lines: const [line],
+            repository: repository,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // 두 시각이 한 목록에 시각순으로 함께 노출된다.
+      expect(find.text('08:00'), findsOneWidget);
+      expect(find.text('08:03'), findsOneWidget);
+      expect(
+        tester.getTopLeft(find.text('08:00')).dy,
+        lessThan(tester.getTopLeft(find.text('08:03')).dy),
+      );
+
+      // 첫차·막차 동작 유지.
+      expect(find.text('첫차 08:00'), findsOneWidget);
+      expect(find.text('막차 08:03'), findsOneWidget);
+
+      // 급행 행에만 배지 1회, 일반 행에는 배지 없음.
+      expect(find.text('급행'), findsOneWidget);
+      expect(
+        find.byKey(const Key('servicePatternExpressBadge')),
+        findsOneWidget,
+      );
+      expect(find.text('일반'), findsNothing);
+
+      // 급행/일반은 실제 운행 정보다 — 선택 컨트롤(칩·필터)로 노출하지 않는다.
+      expect(find.widgetWithText(ChoiceChip, '급행'), findsNothing);
+      expect(find.widgetWithText(ChoiceChip, '일반'), findsNothing);
+      expect(find.widgetWithText(FilterChip, '급행'), findsNothing);
+    } finally {
       debugStationVerifiedClock = DateTime.now;
     }
   });

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -832,10 +832,13 @@ void main() {
     expect(find.byKey(const Key('stationSearchButton')), findsOneWidget);
     expect(find.byKey(const Key('nearbyStationButton')), findsOneWidget);
     expect(find.byKey(const Key('networkMapBottomAdBanner')), findsOneWidget);
+    // #2099 DoD: 노선도에 일반/급행 선택 control과 별도 상태는 0건이다. 일반/급행은
+    // 선택 UI가 아니라 실제 운행 정보이므로 노선도 뷰 토글을 두지 않는다.
     expect(
       find.byKey(const Key('networkMapServicePatternToggle')),
-      findsOneWidget,
+      findsNothing,
     );
+    expect(find.widgetWithText(InkWell, '급행'), findsNothing);
   });
 
   testWidgets('온보딩 이동 조건은 경로 검색 기본값으로 이어진다', (tester) async {
@@ -3237,53 +3240,9 @@ void main() {
     );
   });
 
-  test('급행 노선도 필터는 station-line endpoint edge를 유지한다', () {
-    final expressMap = networkMapExpressOnlyMapData(_expressFilterMapData());
-
-    expect(expressMap.lines.map((line) => line.id), ['line-express']);
-    expect(expressMap.stations.map((station) => station.lineId).toSet(), {
-      'line-express',
-    });
-    expect(expressMap.edges, hasLength(1));
-    expect(
-      expressMap.edges.single.fromStationId,
-      'station-express-a:line-express',
-    );
-    expect(
-      expressMap.edges.single.toStationId,
-      'station-express-b:line-express',
-    );
-  });
-
-  testWidgets('노선도 급행 전환은 필터 밖 선택 역 탭을 숨긴다', (tester) async {
-    await tester.pumpWidget(
-      buildEasySubwayTestApp(
-        repository: FakeStationSearchRepository(
-          networkMapData: _expressFilterMapData(),
-        ),
-        reportRepository: FakeFacilityReportRepository(),
-        routeRepository: FakeRouteSearchRepository(),
-        notificationRepository: FakeNotificationSettingsRepository(),
-        initialOnboardingState: _completedOnboardingState(),
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    await tester.tap(
-      find.byKey(const Key('networkMapStation-local-a-line-local')),
-    );
-    await tester.pumpAndSettle();
-    expect(find.byKey(const Key('networkMapStationSheet')), findsOneWidget);
-
-    await tester.tap(find.text('급행'));
-    await tester.pumpAndSettle();
-
-    expect(find.byKey(const Key('networkMapStationSheet')), findsNothing);
-    expect(
-      find.byKey(const Key('networkMapStation-express-a-line-express')),
-      findsOneWidget,
-    );
-  });
+  // #2099 WP2: 노선도의 일반/급행 뷰 토글과 급행 전용 필터 데이터 경로는
+  // 제거됐다(일반/급행은 선택 UI가 아니라 실제 운행 정보). 노선도에 선택 control이
+  // 0건임은 '노선도 첫 화면은 하단 광고 위에 지도 조작을 유지한다' 테스트가 지킨다.
 
   testWidgets('노선도 viewport 밖 station semantics는 생성하지 않는다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
@@ -4958,8 +4917,66 @@ void main() {
         findsNothing,
       );
 
-      // --- 길찾기 부분(#2099 WP2에서 확장 예정) ---
-      // WP2가 같은 테스트에 길찾기 경로의 급행 표시 검증을 이어서 덧붙인다.
+      // --- 길찾기 부분(#2099 WP2) ---
+      // 같은 급행 배지 위젯을 길찾기 경로 타임라인의 승차 leg에서도 쓴다. SUBWAY/
+      // EXPRESS 승차 step에만 `급행` 배지가 1회 붙고, 별도 선택 컨트롤은 없다.
+      final routeRepository = FakeRouteSearchRepository(
+        result: _sampleRouteSearchResult(
+          steps: const [
+            RouteSearchStep(
+              sequence: 1,
+              stepType: 'ride',
+              title: '상록수역에서 오이도행 승차',
+              description: '승강장에서 열차를 타고 이동합니다.',
+              lineId: 'seoul-4',
+              lineName: '수도권 4호선',
+              fromStationId: 'station-sangnoksu',
+              toStationId: 'station-sadang',
+              estimatedMinutes: 18,
+              distanceMeters: 12000,
+              includesStairs: false,
+              requiresAccessibilityCheck: false,
+              actionTitle: '오이도행 열차 승차',
+              serviceClass: 'SUBWAY',
+              servicePattern: 'EXPRESS',
+            ),
+          ],
+        ),
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: RouteSearchScreen(
+            repository: routeRepository,
+            stationRepository: FakeStationSearchRepository(),
+            favoriteRouteRepository: FakeFavoriteRouteRepository(),
+            initialDraft: RouteDraft(
+              origin: const RouteDraftStation(
+                id: 'station-sangnoksu',
+                nameKo: '상록수',
+              ),
+              destination: const RouteDraftStation(
+                id: 'station-sadang',
+                nameKo: '사당',
+              ),
+              lastModifiedAt: DateTime(2026, 7, 17),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // 승차 leg에 급행 배지 1회, 시각 텍스트도 1회.
+      expect(
+        find.byKey(const Key('servicePatternExpressBadge')),
+        findsOneWidget,
+      );
+      expect(find.text('급행'), findsOneWidget);
+      // TalkBack은 급행을 정확히 한 번만 읽는다(배지는 장식, 라벨은 승차 leg가 1회).
+      expect(find.bySemanticsLabel(RegExp('급행')), findsOneWidget);
+      // 급행/일반은 실제 운행 정보다 — 길찾기에도 toggle/chip/filter 선택 컨트롤 0건.
+      expect(find.byType(ChoiceChip), findsNothing);
+      expect(find.byType(FilterChip), findsNothing);
+      expect(find.byType(Switch), findsNothing);
     } finally {
       semanticsHandle.dispose();
     }
@@ -8437,6 +8454,198 @@ void main() {
       routeRepository.requests.last.transportScope,
       RouteTransportScope.subwayAndItxCheongchun,
     );
+  });
+
+  testWidgets('길찾기 기본값은 최단시간(FASTEST)과 지하철(SUBWAY)이다', (tester) async {
+    final routeRepository = FakeRouteSearchRepository();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RouteSearchScreen(
+          repository: routeRepository,
+          stationRepository: FakeStationSearchRepository(),
+          favoriteRouteRepository: FakeFavoriteRouteRepository(),
+          initialDraft: RouteDraft(
+            origin: const RouteDraftStation(
+              id: 'station-sangnoksu',
+              nameKo: '상록수',
+            ),
+            destination: const RouteDraftStation(
+              id: 'station-sadang',
+              nameKo: '사당',
+            ),
+            lastModifiedAt: DateTime(2026, 7, 17),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(routeRepository.requests, hasLength(1));
+    expect(routeRepository.requests.single.objective, RouteObjective.fastest);
+    expect(
+      routeRepository.requests.single.transportScope,
+      RouteTransportScope.subway,
+    );
+    expect(find.byKey(const Key('routeObjectiveFastestChip')), findsOneWidget);
+    expect(
+      find.byKey(const Key('routeObjectiveFewestTransfersChip')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: find.byKey(const Key('routeObjectiveFastestChip')),
+        matching: find.byIcon(Icons.check),
+      ),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('objective 탭을 최소환승으로 바꾸면 scope는 유지한 채 objective만 재검색한다', (
+    tester,
+  ) async {
+    final routeRepository = FakeRouteSearchRepository();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RouteSearchScreen(
+          repository: routeRepository,
+          stationRepository: FakeStationSearchRepository(),
+          favoriteRouteRepository: FakeFavoriteRouteRepository(),
+          initialDraft: RouteDraft(
+            origin: const RouteDraftStation(
+              id: 'station-sangnoksu',
+              nameKo: '상록수',
+            ),
+            destination: const RouteDraftStation(
+              id: 'station-sadang',
+              nameKo: '사당',
+            ),
+            lastModifiedAt: DateTime(2026, 7, 17),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(
+      find.byKey(const Key('routeObjectiveFewestTransfersChip')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(routeRepository.requests, hasLength(2));
+    expect(
+      routeRepository.requests.last.objective,
+      RouteObjective.fewestTransfers,
+    );
+    // objective만 바뀌고 scope는 SUBWAY로 유지된다(로컬-우선 동작 보존).
+    expect(
+      routeRepository.requests.last.transportScope,
+      RouteTransportScope.subway,
+    );
+    expect(
+      routeRepository.requests.every(
+        (request) => request.transportScope == RouteTransportScope.subway,
+      ),
+      isTrue,
+    );
+  });
+
+  testWidgets('같은 objective를 다시 눌러도 재검색하지 않는다', (tester) async {
+    final routeRepository = FakeRouteSearchRepository();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RouteSearchScreen(
+          repository: routeRepository,
+          stationRepository: FakeStationSearchRepository(),
+          favoriteRouteRepository: FakeFavoriteRouteRepository(),
+          initialDraft: RouteDraft(
+            origin: const RouteDraftStation(
+              id: 'station-sangnoksu',
+              nameKo: '상록수',
+            ),
+            destination: const RouteDraftStation(
+              id: 'station-sadang',
+              nameKo: '사당',
+            ),
+            lastModifiedAt: DateTime(2026, 7, 17),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('routeObjectiveFastestChip')));
+    await tester.pumpAndSettle();
+
+    expect(routeRepository.requests, hasLength(1));
+  });
+
+  testWidgets('objective 탭은 TalkBack 라벨·선택 상태·48dp·글자 확대를 지킨다', (tester) async {
+    tester.view.physicalSize = const Size(320, 1200);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+    final semanticsHandle = tester.ensureSemantics();
+    try {
+      await tester.pumpWidget(
+        MaterialApp(
+          builder: (context, child) => MediaQuery(
+            data: MediaQuery.of(
+              context,
+            ).copyWith(textScaler: const TextScaler.linear(2.0)),
+            child: child!,
+          ),
+          home: RouteSearchScreen(
+            repository: FakeRouteSearchRepository(),
+            stationRepository: FakeStationSearchRepository(),
+            favoriteRouteRepository: FakeFavoriteRouteRepository(),
+            initialDraft: RouteDraft(
+              origin: const RouteDraftStation(
+                id: 'station-sangnoksu',
+                nameKo: '상록수',
+              ),
+              destination: const RouteDraftStation(
+                id: 'station-sadang',
+                nameKo: '사당',
+              ),
+              lastModifiedAt: DateTime(2026, 7, 17),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // TalkBack 라벨은 objective 두 탭 모두 정확히 한 번씩.
+      expect(find.bySemanticsLabel('경로 목표, 최단시간'), findsOneWidget);
+      expect(find.bySemanticsLabel('경로 목표, 최소환승'), findsOneWidget);
+      // 글자 2배·320dp에서도 오버플로 없이 렌더된다.
+      expect(tester.takeException(), isNull);
+      // 최소 48dp 터치 타깃.
+      expect(
+        tester
+            .getSize(find.byKey(const Key('routeObjectiveFastestChip')))
+            .height,
+        greaterThanOrEqualTo(48.0),
+      );
+      // 선택 상태(체크 표시)는 현재 objective에만.
+      expect(
+        find.descendant(
+          of: find.byKey(const Key('routeObjectiveFastestChip')),
+          matching: find.byIcon(Icons.check),
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(
+          of: find.byKey(const Key('routeObjectiveFewestTransfersChip')),
+          matching: find.byIcon(Icons.check),
+        ),
+        findsNothing,
+      );
+    } finally {
+      semanticsHandle.dispose();
+    }
   });
 
   testWidgets('ITX 실패는 명시적 지하철만 보기 선택 뒤에만 SUBWAY로 재검색한다', (tester) async {
@@ -16291,127 +16500,6 @@ FavoriteRoute _favoriteRoute({
     routeCreatedAt: '2026-06-13T04:20:00',
     addedAt: '2026-06-14T10:00:00',
     transportScope: transportScope,
-  );
-}
-
-NetworkMapData _expressFilterMapData() {
-  return const NetworkMapData(
-    regions: [NetworkMapRegion(name: '테스트권')],
-    selectedRegion: '테스트권',
-    lines: [
-      NetworkMapLine(
-        id: 'line-local',
-        name: '일반 노선',
-        color: '#444444',
-        region: '테스트권',
-      ),
-      NetworkMapLine(
-        id: 'line-express',
-        name: '급행 노선',
-        color: '#D71920',
-        region: '테스트권',
-      ),
-    ],
-    stations: [
-      NetworkMapStation(
-        id: 'station-local-a',
-        nameKo: '일반A',
-        nameEn: 'Local A',
-        region: '테스트권',
-        lineId: 'line-local',
-        stationCode: 'L01',
-        sequence: 1,
-        position: NetworkMapPosition(
-          x: 100,
-          y: 100,
-          labelDx: 0,
-          labelDy: 0,
-          upPath: '',
-          downPath: '',
-          sourceId: 'fixture-express-filter',
-        ),
-      ),
-      NetworkMapStation(
-        id: 'station-local-b',
-        nameKo: '일반B',
-        nameEn: 'Local B',
-        region: '테스트권',
-        lineId: 'line-local',
-        stationCode: 'L02',
-        sequence: 2,
-        position: NetworkMapPosition(
-          x: 180,
-          y: 100,
-          labelDx: 0,
-          labelDy: 0,
-          upPath: '',
-          downPath: '',
-          sourceId: 'fixture-express-filter',
-        ),
-      ),
-      NetworkMapStation(
-        id: 'station-express-a',
-        nameKo: '급행A',
-        nameEn: 'Express A',
-        region: '테스트권',
-        lineId: 'line-express',
-        stationCode: 'E01',
-        sequence: 1,
-        position: NetworkMapPosition(
-          x: 100,
-          y: 180,
-          labelDx: 0,
-          labelDy: 0,
-          upPath: '',
-          downPath: '',
-          sourceId: 'fixture-express-filter',
-        ),
-      ),
-      NetworkMapStation(
-        id: 'station-express-b',
-        nameKo: '급행B',
-        nameEn: 'Express B',
-        region: '테스트권',
-        lineId: 'line-express',
-        stationCode: 'E02',
-        sequence: 2,
-        position: NetworkMapPosition(
-          x: 180,
-          y: 180,
-          labelDx: 0,
-          labelDy: 0,
-          upPath: '',
-          downPath: '',
-          sourceId: 'fixture-express-filter',
-        ),
-      ),
-    ],
-    edges: [
-      NetworkMapEdge(
-        id: 'edge-local',
-        lineId: 'line-local',
-        fromStationId: 'station-local-a:line-local',
-        toStationId: 'station-local-b:line-local',
-        accessibilityStatus: 'AVAILABLE',
-        reliabilityScore: 100,
-      ),
-      NetworkMapEdge(
-        id: 'edge-express',
-        lineId: 'line-express',
-        fromStationId: 'station-express-a:line-express',
-        toStationId: 'station-express-b:line-express',
-        accessibilityStatus: 'AVAILABLE',
-        reliabilityScore: 100,
-      ),
-    ],
-    positionSources: [
-      NetworkMapPositionSource(
-        id: 'fixture-express-filter',
-        name: '급행 필터 fixture',
-        licenseStatus: 'fixture-only',
-      ),
-    ],
-    stationLineMemberships: [],
   );
 }
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -8648,6 +8648,65 @@ void main() {
     }
   });
 
+  testWidgets('objective 칩은 재검색 로딩 중 비활성이고 완료 후 재활성된다', (tester) async {
+    final semanticsHandle = tester.ensureSemantics();
+    final routeRepository = ControlledRouteSearchRepository();
+    try {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: RouteSearchScreen(
+            repository: routeRepository,
+            stationRepository: FakeStationSearchRepository(),
+            favoriteRouteRepository: FakeFavoriteRouteRepository(),
+            initialDraft: RouteDraft(
+              origin: const RouteDraftStation(
+                id: 'station-sangnoksu',
+                nameKo: '상록수',
+              ),
+              destination: const RouteDraftStation(
+                id: 'station-sadang',
+                nameKo: '사당',
+              ),
+              lastModifiedAt: DateTime(2026, 7, 17),
+            ),
+          ),
+        ),
+      );
+      // 자동 검색이 시작돼 로딩 상태로 멈춘다(응답 미완료).
+      await tester.pump();
+      expect(routeRepository.requests, hasLength(1));
+
+      final chipFinder = find.byKey(
+        const Key('routeObjectiveFewestTransfersChip'),
+      );
+      // 로딩 중: semantics enabled=false, tap 액션 없음.
+      final loadingData = tester.getSemantics(chipFinder).getSemanticsData();
+      expect(loadingData.flagsCollection.isEnabled.toBoolOrNull(), isFalse);
+      expect(loadingData.hasAction(SemanticsAction.tap), isFalse);
+      // TalkBack 라벨 계약은 로딩 중에도 불변.
+      expect(find.bySemanticsLabel('경로 목표, 최소환승'), findsOneWidget);
+      // 로딩 중 tap은 무효 — 재검색이 시작되지 않는다.
+      await tester.tap(chipFinder);
+      await tester.pump();
+      expect(routeRepository.requests, hasLength(1));
+
+      // 검색 완료 → 칩 재활성.
+      routeRepository.complete(_sampleRouteSearchResult());
+      await tester.pumpAndSettle();
+      final readyData = tester.getSemantics(chipFinder).getSemanticsData();
+      expect(readyData.flagsCollection.isEnabled.toBoolOrNull(), isTrue);
+      await tester.tap(chipFinder);
+      await tester.pumpAndSettle();
+      expect(routeRepository.requests.length, greaterThan(1));
+      expect(
+        routeRepository.requests.last.objective,
+        RouteObjective.fewestTransfers,
+      );
+    } finally {
+      semanticsHandle.dispose();
+    }
+  });
+
   testWidgets('ITX 실패는 명시적 지하철만 보기 선택 뒤에만 SUBWAY로 재검색한다', (tester) async {
     final routeRepository = FakeRouteSearchRepository(
       errorForRequest: (request) =>


### PR DESCRIPTION
## 관련 이슈

close #2099

## 작업 배경

- #2098 backend planner가 `FASTEST`/`FEWEST_TRANSFERS` objective, `objectiveTags`, RIDE leg `serviceClass`/`servicePattern`을 반환하지만 Android 화면은 objective 선택 UI가 없고 첫 FOUND만 소비하며, 일반/급행 운행 정보를 시간표·길찾기 어디에도 표시하지 못했습니다.
- 노선도에는 제거 대상인 일반/급행 선택 토글이 남아 있어 "일반/급행은 선택 control이 아니라 실제 운행 정보"라는 제품 계약과 어긋났습니다.

## 작업 내용

- 길찾기 상단에 `최단시간`/`최소환승` objective 탭을 기존 transport toggle 세그먼트 패턴으로 추가했습니다(기본 FASTEST + SUBWAY, text scale에서 Wrap 재배치). objective를 요청 identity와 `toV2Json`의 `objective` 필드에 반영하고, `servicePattern`/`expressOnly`는 요청에 싣지 않습니다.
- 응답에서 첫 FOUND만 남기지 않고 `objectiveTags`로 태깅된 대표 itinerary를 보존해 선택 objective에 맞게 고르며(dual-tag dedupe 대응), stale/previous-scope/previous-OD 응답 거부를 objective 차원까지 확장했습니다.
- `RouteSearchV2Leg`이 `serviceClass`/`servicePattern`을 파싱하고 RIDE leg에서는 필수 enum(`SUBWAY`|`ITX_CHEONGCHUN` × `LOCAL`|`EXPRESS`)으로 검증합니다. unknown/blank는 payload error로 fail closed하고 non-ride는 null만 허용합니다. `RouteSearchStep.fromV2`·`withDisplayLabels`·local route 변환이 두 필드를 보존합니다.
- 시간표 데이터 흐름에 운행종별을 연결했습니다: `CatalogStationTimetableQuery`가 `t.service_pattern`, `t.service_class`를 조회하고 `CatalogStationDeparture` → `StationTimetableDeparture`까지 무손실 전달하며, unknown/blank RIDE pattern은 repository 경계에서 실패합니다.
- nearby 패널·전체 시간표 화면·길찾기 `_RouteStepTile` 승차 정보 영역이 공용 `ServicePatternBadge`로 `serviceClass=SUBWAY && servicePattern=EXPRESS`에만 텍스트 `급행` 배지를 표시합니다. `SUBWAY/LOCAL`은 배지 없음, `ITX_CHEONGCHUN/EXPRESS`는 기존 ITX-청춘 표시 유지(generic 급행 중복 없음), 배지는 비인터랙티브이며 TalkBack `급행` 1회만 제공합니다.
- 노선도의 일반/급행 뷰 토글(`_NetworkMapServicePatternToggle`)과 `_expressView` 상태·급행 전용 필터 데이터 경로를 제거했습니다.

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && dart format --output=none --set-exit-if-changed lib test` — 266 files (0 changed)
  - `cd apps/mobile && flutter analyze` — No issues found!
  - `cd apps/mobile && flutter test test/features/stations/drift_station_repository_test.dart test/station_search_test.dart test/route_search_test.dart test/route_search_request_test.dart` — +120 All tests passed!
  - `cd apps/mobile && flutter test test/widget_test.dart --plain-name "급행 운행 정보는 선택 UI 없이 시간표와 길찾기에 표시된다"` — +1 All tests passed!
  - `cd apps/mobile && flutter test` — +1391 All tests passed!

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| objective 탭 렌더·기본값(최단시간) | Mobile(실기기 SM-A175N) | debug 빌드 설치 후 픽셀 판독·semantics dump | `docs/2099-qa/item1_objective_tabs_fastest.png` 외 | PASS |
| SUBWAY scope 최단시간·최소환승 결과·타임라인 | Mobile(실기기) | 역삼→애오개 검색, 탭 전환 판독 | `docs/2099-qa/item2_*.png` | PASS |
| 시간표 급행 배지(EXPRESS 행만) | Mobile(실기기) | 사당역 4호선 전체 시간표 19:12 급행 행 픽셀 판독(EXPRESS 배지 dark px 1013, 인접 LOCAL 행 0) | `docs/2099-qa/item3_*.png` | PASS |
| 노선도 일반/급행 선택 control 0건 | Mobile(실기기) | 노선도 첫 화면 판독 + 위젯 테스트 findsNothing | `docs/2099-qa/item4_routemap_no_express_toggle.png` | PASS |
| TalkBack 순서·selected semantics | Mobile(실기기) | TalkBack 활성 후 semantics dump(`경로 목표, 최단시간` checked=true) | `docs/2099-qa/item5_talkback_dump.xml` 외 | PASS |
| text scale 2.0 / 320dp(density 540) / landscape | Mobile(실기기) | 각 조건 캡처 — Wrap 재배치, clipping·수평 스크롤 0건 | `docs/2099-qa/item6_*.png` | PASS |
| ITX(지하철+기차) online 조합·401/429/unavailable 상태 | Mobile | debug 빌드는 백엔드 10.0.2.2(에뮬레이터 전용)·online-first 플래그 기본 off로 실기기 수집 불가 — 위젯 테스트로 검증 | `test/route_search_test.dart`, `test/route_search_request_test.dart` | PASS(테스트) |
| 네 조합 request 매핑·SUBWAY network 0·stale 거부·dispose | Mobile | 위젯/컨트롤러 테스트 | `test/route_search_test.dart` 외 | PASS |
| same-RC Android evidence fragment | CI | 이 PR 병합 후 다음 RC cut의 release workflow에서 #2098 fragment와 동일 candidate identity로 생성(#2056 소비) | 후속 RC 산출물 | 병합 후 RC 단계 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음(다음 정기 릴리즈에 포함)
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음(#2240에서 확장된 ROUTE_SEARCH_V2 계약의 mobile 소비)
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `RouteSearchV2Leg.fromJson`의 RIDE 필수 enum 검증(fail closed 파급 — backend `ProductionRouteV2Support`가 production에서 두 필드 non-blank를 보장), `RouteSearchV2Result`의 objectiveTags 대표 선택과 태그 부재 시 첫 FOUND 폴백, request identity의 objective 확장, `network_map.dart` 급행 토글 제거로 폐기된 테스트 2건입니다.
- transport scope toggle 라벨은 기존 병합 카피(`지하철만`/`지하철 + ITX-청춘`)를 유지했습니다. 이슈 원문 표기는 `지하철`/`지하철 + 기차`인데, 카피 변경이 필요하면 별도 지시 바랍니다.
- transport scope toggle·online 경로는 기존 `EASYSUBWAY_ROUTE_V2_ONLINE_FIRST_ENABLED` dart-define 게이트 뒤에 있어 기본 debug 빌드에서는 objective 탭만 노출됩니다(#2153 설계 유지).

## 리스크

- RIDE leg의 serviceClass/servicePattern 필수 검증으로, 두 필드를 싣지 않는 구형 V2 응답은 payload error → generic unavailable로 흐릅니다. production backend는 #2240의 fail-closed 지원으로 두 필드를 항상 싣습니다(coordinated 계약).
- 노선도 급행 뷰 토글 제거는 급행 전용 뷰 데이터 경로를 함께 걷어냅니다. 시간표·길찾기의 급행 정보 표시가 이를 대체합니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 경로 검색에서 ‘최단 시간(최우선)’과 ‘환승 최소’를 기준으로 선택할 수 있습니다.
  - 출발 시간표에 급행 운행 정보가 반영되며, 급행에는 ‘급행’ 배지가 표시됩니다.
- **개선 사항**
  - 일반·급행 출발이 같은 목록에 시각순으로 함께 표시됩니다.
  - 노선도에서 급행 전용 필터/전환 UI는 제거되고, 급행 표시는 배지/라벨 중심으로 정리되었습니다.
  - 운행 정보가 불완전할 때도 동작이 안정적으로 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->