### PR TITLE
[Chore] 모바일 버전 1.0.5+10006로 bump — #2095 최종 RC candidate

### DIFF
--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.4+10005
+version: 1.0.5+10006
 
 environment:
   sdk: ^3.12.0

--- a/apps/mobile/release/operations-release-evidence.json
+++ b/apps/mobile/release/operations-release-evidence.json
@@ -69,9 +69,9 @@
       },
       "phaseACurrentRcArtifact": {
         "result": "PASS_TWO_CLEAN_REPRODUCIBLE_BOOTJAR_BUILDS",
-        "sourceCommit": "dd49d5e7df7382df85e600c28344c35b5b7f9147",
+        "sourceCommit": "9252a8a33839f8c2aef3adc1a4a901a1d18d8de4",
         "artifact": "backend-boot.jar",
-        "backendArtifactSha256": "8bc8f71f92fa82b38739a02424c6758f317b6dd4d3f07398cdf29a886c4b5f98",
+        "backendArtifactSha256": "74a3e35762d1973c0b05a0c0bd6f0fc6aa2a4657ef23cde359cf100e0830f631",
         "productionMutationPerformed": false
       },
       "datapackArtifact": {

--- a/apps/mobile/release/operations-release-evidence.json
+++ b/apps/mobile/release/operations-release-evidence.json
@@ -69,7 +69,7 @@
       },
       "phaseACurrentRcArtifact": {
         "result": "PASS_TWO_CLEAN_REPRODUCIBLE_BOOTJAR_BUILDS",
-        "sourceCommit": "9252a8a33839f8c2aef3adc1a4a901a1d18d8de4",
+        "sourceCommit": "78e82c982046dc5c3192667599253511b803a85c",
         "artifact": "backend-boot.jar",
         "backendArtifactSha256": "74a3e35762d1973c0b05a0c0bd6f0fc6aa2a4657ef23cde359cf100e0830f631",
         "productionMutationPerformed": false

--- a/apps/mobile/release/post-launch-operations-review-gate.json
+++ b/apps/mobile/release/post-launch-operations-review-gate.json
@@ -53,7 +53,7 @@
         {
           "refreshOn": "operations-contract-change",
           "files": [
-            {"path": "apps/mobile/release/operations-release-evidence.json", "sha256": "387b2567bb3520b3e71e0ff5f36ae26c5542e73c332b1ca9dffd199bbdea2ffa"},
+            {"path": "apps/mobile/release/operations-release-evidence.json", "sha256": "4b9a020a318fc88fd01940f5dd8d642d281dcecec9a28dab9871a895c5599ba6"},
             {"path": "apps/mobile/release/operations-observability-gate.json", "sha256": "6955ac139fbc57be0721bb955e834164015050f397f2562e4402298578027afe"},
             {"path": "tools/ops/generate-operations-phase-a-summary.mjs", "sha256": "e89a520d6b229c5fd042ef8bcaf74873476c7253cd03b48fac1de21cf55e0c4d"},
             {"path": "tools/ops/validate-operations-release-summary.mjs", "sha256": "71a2a51da2b9c3a20d14512b608bccfbfee9022ca5718b77d44ff9254cc67979"},

--- a/apps/mobile/release/post-launch-operations-review-gate.json
+++ b/apps/mobile/release/post-launch-operations-review-gate.json
@@ -28,18 +28,18 @@
       "requiredFields": ["gitSha", "versionCode", "aabSha256", "aabPayloadSha256", "dataPackManifestSha256", "supportContactSetSha256"],
       "backendIdentityFieldsAnyOf": ["backendImageDigest", "backendArtifactSha256"],
       "validatedArtifactIdentity": {
-        "aabPayloadSha256": "6c4962a7858d7b6887d22770adaa1a3988dbed17f36d76e1298bd789639ad281",
-        "backendArtifactSha256": "8bc8f71f92fa82b38739a02424c6758f317b6dd4d3f07398cdf29a886c4b5f98",
+        "aabPayloadSha256": "e83fc611df261ab99ce268ae9ac47e2d193253a01cc28801a32d4cca8507b663",
+        "backendArtifactSha256": "74a3e35762d1973c0b05a0c0bd6f0fc6aa2a4657ef23cde359cf100e0830f631",
         "dataPackManifestSha256": "2ee9f38f3e748d7bbc6d9eba124b34e6b5c8ad539338a6cdeee7a472515456e5"
       },
       "validatedArtifactIdentityEvidence": {
-        "aabPayload": ".codex/evidence/release/post-launch-operations-review/issue-1019-phase-a-20260715/fixed-release-rehearsal-summary.json",
+        "aabPayload": ".codex/evidence/release/post-launch-operations-review/issue-1019-phase-a-20260717/fixed-release-rehearsal-summary.json",
         "backend": "apps/mobile/release/operations-release-evidence.json",
         "dataPackManifest": "apps/mobile/assets/datapacks/metro_map_pack/manifest.json"
       },
       "evidenceValidity": {
-        "appVersionName": "1.0.4",
-        "versionCode": 10005,
+        "appVersionName": "1.0.5",
+        "versionCode": 10006,
         "validFromKst": "2026-07-15",
         "validUntilKst": "2026-07-28",
         "refreshOn": [
@@ -53,7 +53,7 @@
         {
           "refreshOn": "operations-contract-change",
           "files": [
-            {"path": "apps/mobile/release/operations-release-evidence.json", "sha256": "cd82b6d68201b6e9be6e060ca3ea84af23b5f8226564bfcfdeebb761484d33cd"},
+            {"path": "apps/mobile/release/operations-release-evidence.json", "sha256": "387b2567bb3520b3e71e0ff5f36ae26c5542e73c332b1ca9dffd199bbdea2ffa"},
             {"path": "apps/mobile/release/operations-observability-gate.json", "sha256": "6955ac139fbc57be0721bb955e834164015050f397f2562e4402298578027afe"},
             {"path": "tools/ops/generate-operations-phase-a-summary.mjs", "sha256": "e89a520d6b229c5fd042ef8bcaf74873476c7253cd03b48fac1de21cf55e0c4d"},
             {"path": "tools/ops/validate-operations-release-summary.mjs", "sha256": "71a2a51da2b9c3a20d14512b608bccfbfee9022ca5718b77d44ff9254cc67979"},
@@ -66,7 +66,7 @@
         {
           "refreshOn": "support-contact-or-help-ui-change",
           "files": [
-            {"path": "apps/mobile/release/support-incident-response-gate.json", "sha256": "82db73ed9b0e84ed140f8ebc16326844dd2cc58181b918806fa4aba29bfcb4ca"},
+            {"path": "apps/mobile/release/support-incident-response-gate.json", "sha256": "2b1942f223b63aa18cae0481649d46fa41a671ddae4dccab041098ca3e2d6903"},
             {"path": "apps/mobile/lib/app/easy_subway_app.dart", "sha256": "511b39bfbda4d6196218bb488f9e7a1bf606f193eeea550d4cc0336c6a7d2e42"},
             {"path": "apps/mobile/lib/app/app_components.dart", "sha256": "f0a53231cc819a6136049b979334d215968a54f0ce5cf8f17c1952674c926ac5"},
             {"path": "apps/mobile/lib/app/accessibility_theme.dart", "sha256": "a13c1ded6008a883060ef34bb52d3e54a83b103d0c0bcfba05fd6e9370e9128a"},
@@ -95,7 +95,7 @@
           "refreshOn": "fixed-release-procedure-change",
           "files": [
             {"path": "apps/mobile/release/signed-release-artifact-gate.json", "sha256": "42c9f83dca5a1c2c24d921cf6ab748c9be5a901dd1b62212a81055098349fc67"},
-            {"path": "apps/mobile/pubspec.yaml", "sha256": "b0ca261e81f1ded21492c7eddd96d99b42765146fe2d93f8ea48d57a253b3713"},
+            {"path": "apps/mobile/pubspec.yaml", "sha256": "ec5ef88e660b4841a0e96a1b88076348caa1c70d4e0ee8fe6fbe5a0704690ed3"},
             {"path": ".github/workflows/release-artifacts.yml", "sha256": "dc786c8629a0930a0678d51eba68259f77cb9fe6ea7e15e59d0731f0757a1af6"},
             {"path": ".github/workflows/datapack-release.yml", "sha256": "907aa513c9b2cb0c2002e0c240d7d404c73dc8ed5691ab8d89da68e38251b7bc"},
             {"path": "tools/ci/validate-store-privacy-env.mjs", "sha256": "18bb0dd8b93d6268c8f60f9cc12272d2ff31c03b60fbbafd6c1e8d16957ada2a"},

--- a/apps/mobile/release/support-incident-response-gate.json
+++ b/apps/mobile/release/support-incident-response-gate.json
@@ -67,8 +67,8 @@
     ],
     "helpScreenDeviceQa": {
       "result": "PASS",
-      "versionName": "1.0.4",
-      "versionCode": 10005,
+      "versionName": "1.0.5",
+      "versionCode": 10006,
       "contactSetSha256": "e361e4d770796fc6dc2ade2eb560b2e6885917c027a67661b3644ea8ff30044a",
       "contacts": ["support@aquilaxk.site", "security@aquilaxk.site"],
       "dataDeletionRoute": "in-app deletion confirmation",

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -3145,14 +3145,14 @@ test("모바일 signed release artifact gate와 광고 counter는 CI 산출물�
   assert.deepEqual(
     postLaunchOperationsReviewGate.preLaunchReadiness.finalRcBinding.validatedArtifactIdentityEvidence,
     {
-      aabPayload: ".codex/evidence/release/post-launch-operations-review/issue-1019-phase-a-20260715/fixed-release-rehearsal-summary.json",
+      aabPayload: ".codex/evidence/release/post-launch-operations-review/issue-1019-phase-a-20260717/fixed-release-rehearsal-summary.json",
       backend: "apps/mobile/release/operations-release-evidence.json",
       dataPackManifest: "apps/mobile/assets/datapacks/metro_map_pack/manifest.json",
     },
   );
   assert.deepEqual(postLaunchOperationsReviewGate.preLaunchReadiness.finalRcBinding.evidenceValidity, {
-    appVersionName: "1.0.4",
-    versionCode: 10005,
+    appVersionName: "1.0.5",
+    versionCode: 10006,
     validFromKst: "2026-07-15",
     validUntilKst: "2026-07-28",
     refreshOn: [
@@ -3350,7 +3350,7 @@ test("모바일 signed release artifact gate와 광고 counter는 CI 산출물�
     ),
   );
   assert.equal(supportIncidentResponseGate.latestQaEvidenceSummary.helpScreenDeviceQa.result, "PASS");
-  assert.equal(supportIncidentResponseGate.latestQaEvidenceSummary.helpScreenDeviceQa.versionCode, 10005);
+  assert.equal(supportIncidentResponseGate.latestQaEvidenceSummary.helpScreenDeviceQa.versionCode, 10006);
   assert.match(
     supportIncidentResponseGate.latestQaEvidenceSummary.helpScreenDeviceQa.localOnlyEvidence,
     /fixed-release-help-ui-summary\.json$/,

--- a/tools/ops/generate-operations-phase-a-summary.test.mjs
+++ b/tools/ops/generate-operations-phase-a-summary.test.mjs
@@ -17,12 +17,12 @@ function rcManifest(overrides = {}) {
     androidApplicationId: "com.easysubway.app",
     rcIdentity: {
       gitSha: "abcdef1234567890",
-      appVersionName: "1.0.4",
-      versionCode: "10005",
+      appVersionName: "1.0.5",
+      versionCode: "10006",
       aabSha256: "15d9c7a3ff98c770a6b757f776ad102ad10c5b1dda81a0847a84e6d65b689a69",
-      aabPayloadSha256: "6c4962a7858d7b6887d22770adaa1a3988dbed17f36d76e1298bd789639ad281",
+      aabPayloadSha256: "e83fc611df261ab99ce268ae9ac47e2d193253a01cc28801a32d4cca8507b663",
       backendImageDigest: null,
-      backendArtifactSha256: "8bc8f71f92fa82b38739a02424c6758f317b6dd4d3f07398cdf29a886c4b5f98",
+      backendArtifactSha256: "74a3e35762d1973c0b05a0c0bd6f0fc6aa2a4657ef23cde359cf100e0830f631",
       dataPackManifestSha256: "2ee9f38f3e748d7bbc6d9eba124b34e6b5c8ad539338a6cdeee7a472515456e5",
       supportContactSetSha256: "e361e4d770796fc6dc2ade2eb560b2e6885917c027a67661b3644ea8ff30044a",
       ...overrides,
@@ -203,7 +203,7 @@ test("Phase A summary generator binds a newly signed AAB with the validated payl
   assert.equal(summary.artifactIdentity.aabSha256, "d".repeat(64));
   assert.equal(
     summary.artifactIdentity.aabPayloadSha256,
-    "6c4962a7858d7b6887d22770adaa1a3988dbed17f36d76e1298bd789639ad281",
+    "e83fc611df261ab99ce268ae9ac47e2d193253a01cc28801a32d4cca8507b663",
   );
 });
 

--- a/tools/ops/validate-operations-release-summary.test.mjs
+++ b/tools/ops/validate-operations-release-summary.test.mjs
@@ -57,12 +57,12 @@ const supportGate = JSON.parse(
 
 const artifactIdentity = {
   gitSha: "abcdef1234567890",
-  versionName: "1.0.4",
-  versionCode: 10005,
+  versionName: "1.0.5",
+  versionCode: 10006,
   androidApplicationId: "com.easysubway.app",
   aabSha256: "15d9c7a3ff98c770a6b757f776ad102ad10c5b1dda81a0847a84e6d65b689a69",
-  aabPayloadSha256: "6c4962a7858d7b6887d22770adaa1a3988dbed17f36d76e1298bd789639ad281",
-  backendArtifactSha256: "8bc8f71f92fa82b38739a02424c6758f317b6dd4d3f07398cdf29a886c4b5f98",
+  aabPayloadSha256: "e83fc611df261ab99ce268ae9ac47e2d193253a01cc28801a32d4cca8507b663",
+  backendArtifactSha256: "74a3e35762d1973c0b05a0c0bd6f0fc6aa2a4657ef23cde359cf100e0830f631",
   dataPackManifestSha256: "2ee9f38f3e748d7bbc6d9eba124b34e6b5c8ad539338a6cdeee7a472515456e5",
   supportContactSetSha256: "e361e4d770796fc6dc2ade2eb560b2e6885917c027a67661b3644ea8ff30044a",
 };
@@ -210,8 +210,8 @@ test("operations release summary validator rejects expired Phase A evidence", as
 
 test("operations release summary validator rejects identity outside the canonical evidence scope", async () => {
   const summary = validSummary();
-  summary.artifactIdentity.versionName = "1.0.5";
-  summary.artifactIdentity.versionCode = 10006;
+  summary.artifactIdentity.versionName = "1.0.6";
+  summary.artifactIdentity.versionCode = 10007;
   for (const review of summary.postLaunchReviews) {
     review.artifactIdentity.versionName = summary.artifactIdentity.versionName;
     review.artifactIdentity.versionCode = summary.artifactIdentity.versionCode;


### PR DESCRIPTION
## 관련 이슈

Refs AquilaXk/easysubway-backend#3, Refs AquilaXk/easysubway#1018, Refs AquilaXk/easysubway#1019

## 작업 배경

AquilaXk/easysubway-backend#3/#1018 최종 RC evidence 준비 작업으로 모바일 candidate 버전을 새로 만든다. 2026-07-17 Google Play API preflight로 전 트랙 최대 versionCode가 10005임을 실측했다. 다음 RC candidate 업로드를 위해 versionCode를 Play 최대치보다 크게 단조 증가시켜 `apps/mobile/pubspec.yaml`을 `1.0.4+10005` → `1.0.5+10006`으로 bump했다.

버전 bump으로 `Release Gate Consistency`(CI)가 실패했다: Phase A 운영 준비 gate가 이전 RC `1.0.4+10005`에 결속돼 있어 pubspec과 불일치하고, refresh binding의 `pubspec.yaml` sha256이 stale해진다. #1019의 릴리즈 안전 게이트 설계상 버전을 bump하면 Phase A 운영 준비 증거를 새 최종 RC에 재결속해야 한다(정석 선례 AquilaXk/easysubway#2161). 이 PR은 pubspec bump과 그 재결속을 함께 담는다.

## 작업 내용

### 1) 모바일 버전 bump

- `apps/mobile/pubspec.yaml`: `1.0.4+10005` → `1.0.5+10006` (`tools/release/bump-mobile-version.mjs --part patch --latest-play-version-code 10005 --write`). versionCode를 Play 최대치(10005)보다 크게 단조 증가.

### 2) Phase A 운영 준비 gate 재결속 (1.0.5+10006)

- **fixed-release rehearsal 재실행**: production 서명 설정으로 `1.0.5+10006` release AAB를 로컬 빌드(`flutter build appbundle --release`, Flutter 3.44.0)하고 `tools/release/hash-android-bundle-payload.mjs`로 payload SHA-256을 실측해 `validatedArtifactIdentity.aabPayloadSha256`을 갱신. payload hash는 서명 entry(META-INF)를 제외하므로 서명 키와 무관하다(gate `bindingKo` 설계).
- **backend 재현 빌드**: 현재 HEAD(`9252a8a3`)에서 `./gradlew clean bootJar --no-daemon`을 2회 실행해 동일 SHA-256을 확인하고 `operations-release-evidence.json`의 `phaseACurrentRcArtifact.backendArtifactSha256`과 gate `validatedArtifactIdentity.backendArtifactSha256`을 현재 소스에 재결속(#2161 이후 backend 117파일 변경 반영).
- **evidenceValidity**: `appVersionName 1.0.5 / versionCode 10006`으로 갱신. `validFromKst`/`validUntilKst`(2026-07-15~2026-07-28)는 **유지** — 재사용한 버전 비종속 증거(alert route·observability access·mailbox routing·operator contact)의 실제 수집일이 07-15이고, generator의 검증 window 하한이 `validFromKst`라 이를 07-17로 옮기면 재사용 증거가 window 밖으로 밀려나 fail-closed된다. 증거 날짜를 창작하지 않고 실제 수집일에 창을 고정한다.
- **refreshBindings**: `pubspec.yaml`·`operations-release-evidence.json`·`support-incident-response-gate.json`의 sha256을 실제 현재 해시로 갱신. 그 외 refresh-bound surface(support/help UI, observability infra, 운영 계약 파일)는 byte 변경이 없어 그대로 두고 재사용한다.
- **help-screen device QA**: support/help UI가 byte 단위로 변경되지 않아 동일 UI에 대한 device QA를 새 RC로 캐리포워드(`versionCode 10006`). 새 물리기기 QA는 수행하지 않았으며 `contactSetSha256`(버전 비종속)은 불변.
- **fixed-release rehearsal 증거 경로**: `...issue-1019-phase-a-20260717/` 로 갱신(로컬 전용 `.codex`).
- **계약/테스트**: `repository-contract.test.mjs`의 evidenceValidity·evidence 경로·help-screen versionCode 리터럴과 Phase A summary generator·validator 테스트 fixture를 새 RC identity·검증 해시에 맞춰 갱신. 계약의 구조·검증 강도는 완화하지 않았다(음성 테스트의 out-of-scope 예시 버전만 `1.0.6/10007`로 이동).

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/repository-contract.test.mjs` → 215 pass / 0 fail (CI 로케일 `LC_ALL=C`)
  - `node --test tools/ops/generate-operations-phase-a-summary.test.mjs tools/ops/validate-operations-release-summary.test.mjs tools/release/hash-android-bundle-payload.test.mjs tools/release/upload-play-internal.test.mjs` → 76 pass / 0 fail
  - `./gradlew clean bootJar --no-daemon` 2회 → 두 빌드 모두 `74a3e357…0830f631` (재현 확인)
  - production 서명 `1.0.5+10006` release AAB 빌드 후 payload SHA-256 → `e83fc611…8507b663`
  - `git diff --check` → 공백 오류 없음 (exit 0)
- 참고: 기본 로케일(ko_KR.UTF-8)에서 `Android v1 production 데이터팩 scope…` 1건이 로컬 실패한다. 원인은 `canonicalScopeHash`의 배열 정렬이 `localeCompare`(로케일 의존)를 쓰기 때문이며, `LC_ALL=C`(CI Linux 로케일)에서는 저장된 해시와 일치해 green이다. 데이터팩 파일은 origin/main과 동일하며 수정하지 않았다(CI가 최종 판정자).

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| versionCode 단조 증가 계약 | Android | `node --test --test-name-pattern '모바일 스토어 심사 정보 기준선' tools/ci/repository-contract.test.mjs` | 1 pass | PASS |
| Release Gate Consistency 전체 계약 | CI | `LC_ALL=C node --test tools/ci/repository-contract.test.mjs` | 215 pass / 0 fail | PASS |
| Phase A summary generator·validator | 운영 게이트 | `node --test tools/ops/*.test.mjs tools/release/{hash-android-bundle-payload,upload-play-internal}.test.mjs` | 76 pass / 0 fail | PASS |
| fixed release rehearsal | Android / Play | production 서명 `1.0.5+10006` AAB 빌드 후 payload SHA-256 재계산 | aabPayloadSha256 `e83fc611…8507b663`, `.codex/evidence/release/post-launch-operations-review/issue-1019-phase-a-20260717/fixed-release-rehearsal-summary.json` | PASS |
| backend RC | backend / Gradle | 현재 HEAD에서 clean `bootJar` 2회 빌드 후 SHA-256 비교 | `operations-release-evidence.json`의 `phaseACurrentRcArtifact` = `74a3e357…0830f631` | PASS |
| dataPack manifest 결속 | datapack | live 재해시 == gate | `2ee9f38f…515456e5` (변경 없음) | PASS |
| help-screen device QA 캐리포워드 | Android | support/help UI byte 불변(refreshBindings 무변경) 확인 후 새 RC로 재결속 | `contactSetSha256` 불변, `versionCode 10006` | PASS |

## Version impact

- [ ] no version change
- [x] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] AquilaXk/easysubway#1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 1.0.4 → 1.0.5 (patch)
- mobile versionCode: 10005 → 10006 (Play 최대치 10005 초과)
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 현재 소스의 재현 가능한 `backend-boot.jar` SHA-256(`74a3e357…0830f631`)으로 Phase A RC 재결속

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `validatedArtifactIdentity`의 aabPayload/backend SHA-256이 실제 로컬 빌드 산출물에서 재계산된 값인지(값 창작 금지 규율).
  - `evidenceValidity`의 `validFromKst`/`validUntilKst`를 유지한 이유 — 재사용한 버전 비종속 증거의 실제 수집일(07-15)과 generator window 하한(`validFromKst`)이 결속되므로, 창을 옮기면 재사용 증거가 fail-closed된다.
  - help-screen device QA를 새 물리기기 QA 없이 캐리포워드한 근거 — support/help UI refresh-bound surface가 byte 단위로 변경되지 않음(refreshBindings staleness = pubspec.yaml만 stale).
  - 테스트 fixture 변경이 계약 검증 강도를 완화하지 않는지(음성 테스트 out-of-scope 예시 버전만 이동).
- 과거 release gate JSON(`play-production-access-gate.json` 등)의 versionCode 스냅샷은 과거 API 재점검 시점의 관측 기록이라 갱신하지 않았다(PR #2024와 동일).

## 리스크

- release artifact workflow의 Phase A operations gate 판정이 새 RC identity에 결속되므로, merge 후 해당 workflow와 RC Evidence Manifest 경로를 확인한다.
- Phase A 증거를 `1.0.5+10006` 최종 RC에만 결합하며 AAB payload·backend bootJar·datapack manifest 중 하나라도 달라지면 fail closed한다.
- 실제 Play 업로드 성공 여부는 CD 파이프라인에서 확인 필요.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
