### PR TITLE
[CI] #1414 Route 통합 판정 verdict producer·same-RC evidence 배선

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -906,6 +906,22 @@ jobs:
             --phase FINAL \
             --candidate-context release-artifacts/rc/candidate-context.json \
             --output release-artifacts/rc/final-readiness.json
+          # #1414 route/datapack 통합 판정. same-RC identity로 E1~E9 matrix를 결합한다.
+          # planner(#2098)/Mobile(#2099)/route-map(#2068) evidence artifact는 이 job에서
+          # 생성하지 않으므로, evidence가 붙기 전에는 fail-closed NO_GO matrix skeleton을 남긴다.
+          verdict_args=(--rc-manifest release-artifacts/rc/final-readiness.json)
+          if [[ -f release-artifacts/downloaded/route-evidence/planner-success-evidence.json ]]; then
+            verdict_args+=(--planner-evidence release-artifacts/downloaded/route-evidence/planner-success-evidence.json)
+          fi
+          if [[ -f release-artifacts/downloaded/route-evidence/mobile-consumed-identity-evidence.json ]]; then
+            verdict_args+=(--mobile-evidence release-artifacts/downloaded/route-evidence/mobile-consumed-identity-evidence.json)
+          fi
+          if [[ -f release-artifacts/downloaded/route-evidence/route-map-evidence.json ]]; then
+            verdict_args+=(--route-map-evidence release-artifacts/downloaded/route-evidence/route-map-evidence.json)
+          fi
+          node tools/release/generate-route-integration-verdict.mjs \
+            "${verdict_args[@]}" \
+            --output release-artifacts/rc/route-integration-verdict.json
           cp apps/mobile/release/post-launch-operations-review-gate.json release-artifacts/rc/post-launch-operations-review-gate.json
           cp apps/mobile/release/support-incident-response-gate.json release-artifacts/rc/support-incident-response-gate.json
           cp apps/mobile/release/operations-observability-gate.json release-artifacts/rc/operations-observability-gate.json

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -864,6 +864,12 @@ jobs:
               --canary-result release-artifacts/downloaded/backend/planner-canary-result.json \
               --output release-artifacts/rc/planner-success-evidence.json
           fi
+          # #1414 #2099 fragment. Mobile이 실제로 소비한 RC identity와 E1/E7/E8/E9 시나리오
+          # 근거(tracked widget/contract test·request 직렬화 소스)를 같은 candidate-context로 emit한다.
+          node tools/release/build-mobile-consumption-evidence.mjs \
+            --candidate-context release-artifacts/rc/candidate-context.json \
+            --repo-root . \
+            --output release-artifacts/rc/mobile-consumption-evidence.json
           if [[ "${android_artifact_source}" == easysubway-android-production-rc-* ]]; then
             node tools/ops/generate-operations-phase-a-summary.mjs \
               --rc-manifest release-artifacts/rc/candidate-context.json \
@@ -907,17 +913,17 @@ jobs:
             --candidate-context release-artifacts/rc/candidate-context.json \
             --output release-artifacts/rc/final-readiness.json
           # #1414 route/datapack 통합 판정. same-RC identity로 E1~E9 matrix를 결합한다.
-          # planner(#2098)/Mobile(#2099)/route-map(#2068) evidence artifact는 이 job에서
-          # 생성하지 않으므로, evidence가 붙기 전에는 fail-closed NO_GO matrix skeleton을 남긴다.
-          verdict_args=(--rc-manifest release-artifacts/rc/final-readiness.json)
-          if [[ -f release-artifacts/downloaded/route-evidence/planner-success-evidence.json ]]; then
-            verdict_args+=(--planner-evidence release-artifacts/downloaded/route-evidence/planner-success-evidence.json)
-          fi
-          if [[ -f release-artifacts/downloaded/route-evidence/mobile-consumed-identity-evidence.json ]]; then
-            verdict_args+=(--mobile-evidence release-artifacts/downloaded/route-evidence/mobile-consumed-identity-evidence.json)
-          fi
-          if [[ -f release-artifacts/downloaded/route-evidence/route-map-evidence.json ]]; then
-            verdict_args+=(--route-map-evidence release-artifacts/downloaded/route-evidence/route-map-evidence.json)
+          # planner(#2098)/mobile(#2099) evidence는 이 job에서 candidate-context 기준으로 생성해
+          # 바로 연결한다. route-map(#2068) evidence는 아직 identity+provenance+integrationScenarios
+          # 스키마를 emit하는 tracked producer가 없어(route-map-android-evidence는 별개의 프레임/메모리
+          # 성능 evidence 스키마) --route-map-evidence를 연결하지 않는다 — 날조 대신 verdict의 E1을
+          # PENDING으로 남긴다.
+          verdict_args=(
+            --rc-manifest release-artifacts/rc/final-readiness.json
+            --mobile-evidence release-artifacts/rc/mobile-consumption-evidence.json
+          )
+          if [[ -f release-artifacts/rc/planner-success-evidence.json ]]; then
+            verdict_args+=(--planner-evidence release-artifacts/rc/planner-success-evidence.json)
           fi
           node tools/release/generate-route-integration-verdict.mjs \
             "${verdict_args[@]}" \

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -866,10 +866,14 @@ jobs:
           fi
           # #1414 #2099 fragment. Mobile이 실제로 소비한 RC identity와 E1/E7/E8/E9 시나리오
           # 근거(tracked widget/contract test·request 직렬화 소스)를 같은 candidate-context로 emit한다.
-          node tools/release/build-mobile-consumption-evidence.mjs \
-            --candidate-context release-artifacts/rc/candidate-context.json \
-            --repo-root . \
-            --output release-artifacts/rc/mobile-consumption-evidence.json
+          # planner step과 동일하게 입력 artifact 존재를 먼저 확인한다(verdict 단계는 이 파일이
+          # 없어도 fail-closed로 처리하므로 이 job이 강제로 실패하지 않는다).
+          if [[ -f release-artifacts/rc/candidate-context.json ]]; then
+            node tools/release/build-mobile-consumption-evidence.mjs \
+              --candidate-context release-artifacts/rc/candidate-context.json \
+              --repo-root . \
+              --output release-artifacts/rc/mobile-consumption-evidence.json
+          fi
           if [[ "${android_artifact_source}" == easysubway-android-production-rc-* ]]; then
             node tools/ops/generate-operations-phase-a-summary.mjs \
               --rc-manifest release-artifacts/rc/candidate-context.json \
@@ -920,10 +924,12 @@ jobs:
           # PENDING으로 남긴다.
           verdict_args=(
             --rc-manifest release-artifacts/rc/final-readiness.json
-            --mobile-evidence release-artifacts/rc/mobile-consumption-evidence.json
           )
           if [[ -f release-artifacts/rc/planner-success-evidence.json ]]; then
             verdict_args+=(--planner-evidence release-artifacts/rc/planner-success-evidence.json)
+          fi
+          if [[ -f release-artifacts/rc/mobile-consumption-evidence.json ]]; then
+            verdict_args+=(--mobile-evidence release-artifacts/rc/mobile-consumption-evidence.json)
           fi
           node tools/release/generate-route-integration-verdict.mjs \
             "${verdict_args[@]}" \

--- a/apps/mobile/release/post-launch-operations-review-gate.json
+++ b/apps/mobile/release/post-launch-operations-review-gate.json
@@ -96,7 +96,7 @@
           "files": [
             {"path": "apps/mobile/release/signed-release-artifact-gate.json", "sha256": "42c9f83dca5a1c2c24d921cf6ab748c9be5a901dd1b62212a81055098349fc67"},
             {"path": "apps/mobile/pubspec.yaml", "sha256": "b0ca261e81f1ded21492c7eddd96d99b42765146fe2d93f8ea48d57a253b3713"},
-            {"path": ".github/workflows/release-artifacts.yml", "sha256": "dc786c8629a0930a0678d51eba68259f77cb9fe6ea7e15e59d0731f0757a1af6"},
+            {"path": ".github/workflows/release-artifacts.yml", "sha256": "069d1a9dab229398626d7ae8252ab05a952f8376269d1b9e4474fa1d69ae582a"},
             {"path": ".github/workflows/datapack-release.yml", "sha256": "907aa513c9b2cb0c2002e0c240d7d404c73dc8ed5691ab8d89da68e38251b7bc"},
             {"path": "tools/ci/validate-store-privacy-env.mjs", "sha256": "18bb0dd8b93d6268c8f60f9cc12272d2ff31c03b60fbbafd6c1e8d16957ada2a"},
             {"path": "backend/build.gradle", "sha256": "00106be89d1834db166c0c4cfba04674e2a456e7e57648595b74feb933c31273"},

--- a/apps/mobile/release/post-launch-operations-review-gate.json
+++ b/apps/mobile/release/post-launch-operations-review-gate.json
@@ -96,7 +96,7 @@
           "files": [
             {"path": "apps/mobile/release/signed-release-artifact-gate.json", "sha256": "42c9f83dca5a1c2c24d921cf6ab748c9be5a901dd1b62212a81055098349fc67"},
             {"path": "apps/mobile/pubspec.yaml", "sha256": "b0ca261e81f1ded21492c7eddd96d99b42765146fe2d93f8ea48d57a253b3713"},
-            {"path": ".github/workflows/release-artifacts.yml", "sha256": "069d1a9dab229398626d7ae8252ab05a952f8376269d1b9e4474fa1d69ae582a"},
+            {"path": ".github/workflows/release-artifacts.yml", "sha256": "2f9b62ddbd00bac86a69d832b9e3cf35dd3c14a1731d6b201f47f04b991c20cb"},
             {"path": ".github/workflows/datapack-release.yml", "sha256": "907aa513c9b2cb0c2002e0c240d7d404c73dc8ed5691ab8d89da68e38251b7bc"},
             {"path": "tools/ci/validate-store-privacy-env.mjs", "sha256": "18bb0dd8b93d6268c8f60f9cc12272d2ff31c03b60fbbafd6c1e8d16957ada2a"},
             {"path": "backend/build.gradle", "sha256": "00106be89d1834db166c0c4cfba04674e2a456e7e57648595b74feb933c31273"},

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -13,6 +13,11 @@ import { gzipSync, gunzipSync, inflateSync } from "node:zlib";
 import { REQUIRED_STATUS_CHECK_CONTEXTS } from "./apply-main-ruleset-required-checks.mjs";
 import { canonicalScopeHash } from "../datapack/build-launch-denominator-report.mjs";
 import { canonicalJson, withoutSignature } from "../datapack/lib/manifest-validation.mjs";
+import {
+  ROUTE_INTEGRATION_SCENARIOS,
+  ROUTE_SEARCH_CATALOG_ID,
+  buildRouteIntegrationVerdict,
+} from "../release/generate-route-integration-verdict.mjs";
 
 const root = process.cwd();
 const execFileAsync = promisify(execFile);
@@ -416,6 +421,110 @@ test("route release readiness tracker keeps issue 1414 as a release blocker", ()
 
   assert.match(prTemplate, /Route release readiness tracker impact/);
   assert.match(prTemplate, /route-release-readiness-tracker\.json/);
+});
+
+test("route integration verdict producer가 issue 1414 E1~E9 matrix를 실존 evidence에 연결한다", () => {
+  const producer = "tools/release/generate-route-integration-verdict.mjs";
+  assert.equal(existsSync(path.join(root, producer)), true, "route integration verdict producer must exist");
+
+  // E1~E9 전부를 카탈로그로 유지한다.
+  assert.deepEqual(
+    ROUTE_INTEGRATION_SCENARIOS.map((scenario) => scenario.id),
+    ["E1", "E2", "E3", "E4", "E5", "E6", "E7", "E8", "E9"],
+  );
+
+  // request/response 계약은 route search v2 API catalog ID에 연결한다.
+  assert.equal(
+    ROUTE_SEARCH_CATALOG_ID,
+    "internal:POST:/api/v2/routes/search:com.easysubway.route.adapter.in.web.RouteSearchController#searchRouteV2",
+  );
+  const catalogShow = execFileSync(
+    process.execPath,
+    ["tools/ci/api-catalog.mjs", "show", ROUTE_SEARCH_CATALOG_ID],
+    { cwd: root, encoding: "utf8" },
+  );
+  assert.match(catalogShow, /\/api\/v2\/routes\/search/);
+
+  // 각 시나리오는 producer issue와, docs/ 로컬 evidence를 제외한 tracked test 파일에 연결된다.
+  for (const scenario of ROUTE_INTEGRATION_SCENARIOS) {
+    assert.equal(Number.isInteger(scenario.producerIssue), true, `${scenario.id} must reference a producer issue`);
+    assert.ok(scenario.evidenceTests.length > 0, `${scenario.id} must reference evidence tests`);
+    for (const reference of scenario.evidenceTests) {
+      const filePart = reference.split("::")[0];
+      if (filePart.startsWith("docs/")) continue; // docs/2099-qa는 gitignore 로컬 evidence.
+      assert.equal(
+        existsSync(path.join(root, filePart)),
+        true,
+        `${scenario.id} references a missing evidence file: ${filePart}`,
+      );
+    }
+  }
+});
+
+test("route integration verdict는 mixed identity·누락 입력을 fail closed하고 same-RC만 GO한다", () => {
+  const identity = {
+    gitSha: "26d1461210a36d9d969e5a18d5f13725519abdcd",
+    appVersionName: "1.0.4",
+    versionCode: "10005",
+    backendImageDigest: null,
+    backendArtifactSha256: "74a3e35762d1973c0b05a0c0bd6f0fc6aa2a4657ef23cde359cf100e0830f631",
+    dataPackManifestSha256: "2ee9f38f3e748d7bbc6d9eba124b34e6b5c8ad539338a6cdeee7a472515456e5",
+    dataPackArtifactSha256: "7bb4bb68f0642e45377d98b083e93cd8c1c92aaa58dd353f32189e3f325a1562",
+    routeContractVersion: "route-map-contract-v1",
+    realtimeContractVersion: "seoul-topis-schema-v1",
+  };
+  const planner = {
+    sourceIssue: 2098,
+    provenance: "final-candidate",
+    releaseCandidateIdentity: { ...identity },
+    plannerIdentity: { canonicalPackSha256: identity.dataPackArtifactSha256, timetableSnapshotSha256: "a".repeat(64) },
+    checks: { unknownPatternDefaultedToLocal: false },
+    integrationScenarios: { E2: "PASS", E3: "PASS", E4: "PASS", E5: "PASS", E6: "PASS", E9: "PASS" },
+    canaryResult: {
+      plan: {
+        itineraries: [{
+          steps: [
+            { stepType: "ride", serviceClass: "SUBWAY", servicePattern: "LOCAL" },
+            { stepType: "ride", serviceClass: "ITX_CHEONGCHUN", servicePattern: "EXPRESS" },
+          ],
+        }],
+      },
+    },
+  };
+  const mobile = {
+    sourceIssue: 2099,
+    provenance: "manual-observation",
+    releaseCandidateIdentity: { ...identity },
+    integrationScenarios: { E7: "PASS", E8: "PASS" },
+  };
+  const routeMap = {
+    sourceIssue: 2068,
+    provenance: "final-candidate",
+    releaseCandidateIdentity: { ...identity },
+    integrationScenarios: { E1: "PASS" },
+  };
+  const base = {
+    rcManifest: { rcIdentity: { ...identity } },
+    plannerEvidence: planner,
+    mobileEvidence: mobile,
+    routeMapEvidence: routeMap,
+    generatedAt: "2026-07-17T15:00:00.000Z",
+  };
+
+  assert.equal(buildRouteIntegrationVerdict(base).decision, "GO");
+
+  const missing = buildRouteIntegrationVerdict({ ...base, plannerEvidence: null });
+  assert.equal(missing.decision, "NO_GO");
+
+  const mixed = buildRouteIntegrationVerdict({
+    ...base,
+    mobileEvidence: { ...mobile, releaseCandidateIdentity: { ...identity, gitSha: "0".repeat(40) } },
+  });
+  assert.equal(mixed.decision, "NO_GO");
+  assert.equal(
+    mixed.noGoConditions.find((condition) => condition.id === "mixed_rc_or_artifact_identity").triggered,
+    true,
+  );
 });
 
 function currentMobileVersionCode() {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -466,6 +466,8 @@ test("route integration verdict는 mixed identity·누락 입력을 fail closed�
     gitSha: "26d1461210a36d9d969e5a18d5f13725519abdcd",
     appVersionName: "1.0.4",
     versionCode: "10005",
+    aabSha256: "87df6fd89fd8490a8af0d754e48a17288b880f3e918bde87729b79fee88435cc",
+    aabPayloadSha256: "e2b9753619285e685a713e101b996129781f9067de5bc6a90a125c5c9de95758",
     backendImageDigest: null,
     backendArtifactSha256: "74a3e35762d1973c0b05a0c0bd6f0fc6aa2a4657ef23cde359cf100e0830f631",
     dataPackManifestSha256: "2ee9f38f3e748d7bbc6d9eba124b34e6b5c8ad539338a6cdeee7a472515456e5",
@@ -495,7 +497,7 @@ test("route integration verdict는 mixed identity·누락 입력을 fail closed�
     sourceIssue: 2099,
     provenance: "manual-observation",
     releaseCandidateIdentity: { ...identity },
-    integrationScenarios: { E7: "PASS", E8: "PASS" },
+    integrationScenarios: { E7: "PASS", E8: "PASS", E9: "PASS" },
   };
   const routeMap = {
     sourceIssue: 2068,

--- a/tools/release/build-mobile-consumption-evidence.mjs
+++ b/tools/release/build-mobile-consumption-evidence.mjs
@@ -5,9 +5,12 @@
 // 근거를 tracked source·test 참조로 결합한다. UI 렌더링/길찾기 로직을 재구현하지 않고, 이미
 // tracked된 위젯 test 이름과 request 직렬화 소스의 존재·내용만 정적으로 검증한다.
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { gunzipSync } from "node:zlib";
+import { DatabaseSync } from "node:sqlite";
 
 const API_CATALOG_ID = "internal:POST:/api/v2/routes/search:com.easysubway.route.adapter.in.web.RouteSearchController#searchRouteV2";
 
@@ -53,19 +56,87 @@ const MOBILE_SCENARIO_EVIDENCE = {
   },
 };
 
-// E9: 2026-07-18 기준 mobile lib에 ITX_CHEONGCHUN/ITX-청춘 전용 표시 구현이 없다(grep 실측).
-// service_pattern_badge.dart의 isExpress는 serviceClass=='SUBWAY'만 인정해 ITX 승차 leg는
-// generic 급행 배지도 받지 못하고 무배지로 렌더링된다. 날조하지 않고 FAIL로 명시한다.
-const E9_MOBILE_GAP = {
-  result: "FAIL",
-  reasonKo: "mobile lib에 ITX_CHEONGCHUN/ITX-청춘 표시 위젯·테스트가 없음"
-    + " (apps/mobile/lib grep: 'ITX_CHEONGCHUN' 0건, '청춘' 0건; service_pattern_badge.dart의"
-    + " isExpress는 serviceClass=='SUBWAY'만 인정해 ITX ride leg는 배지 없이 렌더링됨)",
-  checkedFiles: [
-    "apps/mobile/lib/features/stations/presentation/service_pattern_badge.dart",
-    "apps/mobile/lib/features/stations/domain/station_models.dart",
-  ],
+// E9: online V2 leg 라벨은 하드코딩이 아니라 데이터 주도다. 코드 경로 실측:
+// RouteSearchV2Leg.fromJson(serviceClass/servicePattern 파싱, route_search.dart:1032)
+// -> RouteSearchStep.fromV2(lineName은 leg.lineId placeholder, route_search.dart:2097)
+// -> OnlineFirstRouteSearchRepository.searchRoute(local_route_repository.dart:1049)가
+// localRepository.resolveDisplayLabels(onlineResult) 호출(local_route_repository.dart:1057)
+// -> resolveDisplayLabels 확장이 catalog.lineName(step.lineId)로 lineName을 실제 채운다
+// (local_route_repository.dart:1093, lineName lookup은 2023행 catalog.lineName).
+// 급행 배지는 serviceClass=='SUBWAY'만 대상이라(service_pattern_badge.dart의 isExpress,
+// route_search.dart:6083 주석이 "ITX-청춘·LOCAL은 배지 없음"을 명시) ITX leg 식별은 이
+// line name 하나에 전적으로 의존한다.
+//
+// 이 line name의 실제 값은 하드코딩이 아니라 번들 datapack(lines.name_ko)에서 나오므로,
+// PASS/FAIL을 정적 문자열이 아니라 tracked datapack 실측으로 판정한다(checkItxLineDisplayIdentity).
+// generic 급행 배지 미부착은 route_search_test.dart:1586(#2099 WP2)로 이미 검증되지만, 그것만으로는
+// "ITX-청춘 표시"를 충족하지 않는다 — line name 식별과 배지 부재를 모두 요구한다.
+const ITX_CANONICAL_LINE_ID = "line-54a7b980b7c3"; // korail-itx-cheongchun-station-sequence-20260713.json의 canonicalLineId
+const BUNDLED_DATAPACK_ASSET = "apps/mobile/assets/datapacks/capital.sqlite.gz";
+const ITX_DISPLAY_CHECK_FILES = [
+  "apps/mobile/lib/route_search.dart",
+  "apps/mobile/lib/features/routes/data/local_route_repository.dart",
+  "apps/mobile/lib/features/stations/presentation/service_pattern_badge.dart",
+];
+// 급행 배지가 SUBWAY/EXPRESS에만 붙고 ITX_CHEONGCHUN에는 generic 배지를 만들지 않음을
+// 검증하는 실존 unit test(route_search_test.dart:1586, #2099 WP2).
+const E9_NO_GENERIC_BADGE_TEST = {
+  testFile: "apps/mobile/test/route_search_test.dart",
+  testNames: ["RIDE ITX_CHEONGCHUN/EXPRESS leg은 generic 급행 배지를 만들지 않는다"],
 };
+
+// 번들 production datapack의 lines.name_ko를 직접 질의해 online ITX leg이 실제로
+// "ITX-청춘"으로 식별되는지 실측한다(문자열 comment가 아니라 tracked 산출물 재질의).
+function checkItxLineDisplayIdentity(repoRoot) {
+  const assetPath = path.join(repoRoot, BUNDLED_DATAPACK_ASSET);
+  if (!existsSync(assetPath)) {
+    return { pass: false, lineId: ITX_CANONICAL_LINE_ID, lineNameKo: null, assetPath: BUNDLED_DATAPACK_ASSET };
+  }
+  const sqliteBytes = gunzipSync(readFileSync(assetPath));
+  const workDir = mkdtempSync(path.join(tmpdir(), "easysubway-mobile-evidence-datapack-"));
+  const sqlitePath = path.join(workDir, "capital.sqlite");
+  writeFileSync(sqlitePath, sqliteBytes);
+  const database = new DatabaseSync(sqlitePath, { readOnly: true });
+  try {
+    const row = database.prepare("SELECT name_ko FROM lines WHERE id = ?").get(ITX_CANONICAL_LINE_ID);
+    const lineNameKo = typeof row?.name_ko === "string" ? row.name_ko : null;
+    const identifiesAsItx = lineNameKo !== null
+      && (lineNameKo.includes("ITX") || lineNameKo.includes("청춘"));
+    return { pass: identifiesAsItx, lineId: ITX_CANONICAL_LINE_ID, lineNameKo, assetPath: BUNDLED_DATAPACK_ASSET };
+  } finally {
+    database.close();
+    rmSync(workDir, { recursive: true, force: true });
+  }
+}
+
+function buildE9MobileAttestation(repoRoot) {
+  const lineDisplay = checkItxLineDisplayIdentity(repoRoot);
+  const noGenericBadge = checkTestNamesExist(
+    repoRoot,
+    E9_NO_GENERIC_BADGE_TEST.testFile,
+    E9_NO_GENERIC_BADGE_TEST.testNames,
+  );
+  // 두 조건 모두 필요하다: (1) online ITX leg의 line name이 실제로 ITX-청춘을 식별하고,
+  // (2) generic 급행 배지가 붙지 않음을 실존 test가 지킨다. (1)이 false면 (2)만으로는
+  // "ITX-청춘으로 표시"를 충족하지 못한다 — 무표시와 무배지를 혼동하지 않는다.
+  const pass = lineDisplay.pass && noGenericBadge.pass;
+  const reasonKo = lineDisplay.pass
+    ? `online ITX leg은 catalog 기반 line name으로 ITX-청춘으로 식별된다(${BUNDLED_DATAPACK_ASSET}의 `
+      + `lines.name_ko='${lineDisplay.lineNameKo}'), generic 급행 배지 미부착은 `
+      + `${E9_NO_GENERIC_BADGE_TEST.testFile}로 검증됨`
+    : `online ITX leg의 line name은 catalog 기반이지만(하드코딩 아님) ITX-청춘을 식별하지 않는다: `
+      + `${BUNDLED_DATAPACK_ASSET}의 lines.id='${lineDisplay.lineId}' name_ko='${lineDisplay.lineNameKo}'. `
+      + `serviceClass=='SUBWAY'만 급행 배지 대상이라(service_pattern_badge.dart, route_search.dart:6083 `
+      + `주석 "ITX-청춘·LOCAL은 배지 없음") ITX leg은 이 line name 외에 보조 표시가 없다 `
+      + `(generic 급행 배지 미부착은 검증되지만 그것만으로 "ITX-청춘 표시"를 충족하지 않음).`;
+  return {
+    result: pass ? "PASS" : "FAIL",
+    reasonKo,
+    checkedFiles: [...ITX_DISPLAY_CHECK_FILES, E9_NO_GENERIC_BADGE_TEST.testFile],
+    lineDisplay,
+    noGenericBadge,
+  };
+}
 
 function checkTestNamesExist(repoRoot, testFile, testNames) {
   const filePath = path.join(repoRoot, testFile);
@@ -115,19 +186,20 @@ export function buildMobileConsumptionEvidence({
     MOBILE_SCENARIO_EVIDENCE.E8.requestClassMarker,
   );
   const e8Pass = e8Tests.pass && e8Fields.pass;
+  const e9 = buildE9MobileAttestation(repoRoot);
 
   const scenarioChecks = {
     E1: e1,
     E7: e7,
     E8: { pass: e8Pass, tests: e8Tests, requestFields: e8Fields },
-    E9: E9_MOBILE_GAP,
+    E9: e9,
   };
 
   const integrationScenarios = {
     E1: e1.pass ? "PASS" : "FAIL",
     E7: e7.pass ? "PASS" : "FAIL",
     E8: e8Pass ? "PASS" : "FAIL",
-    E9: E9_MOBILE_GAP.result,
+    E9: e9.result,
   };
 
   const coreScenariosSatisfied = e1.pass && e7.pass && e8Pass;
@@ -166,8 +238,10 @@ export function buildMobileConsumptionEvidence({
       },
       E9: {
         result: integrationScenarios.E9,
-        reasonKo: E9_MOBILE_GAP.reasonKo,
-        checkedFiles: E9_MOBILE_GAP.checkedFiles,
+        reasonKo: e9.reasonKo,
+        checkedFiles: e9.checkedFiles,
+        lineDisplay: e9.lineDisplay,
+        noGenericBadge: e9.noGenericBadge,
       },
     },
     checks: scenarioChecks,

--- a/tools/release/build-mobile-consumption-evidence.mjs
+++ b/tools/release/build-mobile-consumption-evidence.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+
+// #1414 route/datapack 통합 판정의 #2099 fragment. Mobile이 실제로 소비한 RC identity와
+// E1(노선도 control 부재)/E7(mixed timetable 급행 배지)/E8(request 필드 0건)/E9(ITX 표시) 시나리오
+// 근거를 tracked source·test 참조로 결합한다. UI 렌더링/길찾기 로직을 재구현하지 않고, 이미
+// tracked된 위젯 test 이름과 request 직렬화 소스의 존재·내용만 정적으로 검증한다.
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const API_CATALOG_ID = "internal:POST:/api/v2/routes/search:com.easysubway.route.adapter.in.web.RouteSearchController#searchRouteV2";
+
+// E8: 요청 serialization에 있으면 안 되는 일반/급행 선택 필드 이름.
+const FORBIDDEN_REQUEST_FIELDS = [
+  "servicePattern",
+  "serviceClass",
+  "expressOnly",
+  "localOnly",
+  "expressPreference",
+  "transportPattern",
+  "routePreference",
+];
+
+const MOBILE_SCENARIO_EVIDENCE = {
+  E1: {
+    testFile: "apps/mobile/test/widget_test.dart",
+    testNames: ["노선도 첫 화면은 하단 광고 위에 지도 조작을 유지한다"],
+    localEvidencePaths: [
+      "docs/2099-qa/item4_routemap_no_express_toggle.png",
+      "docs/2099-qa/item5_talkback_dump.xml",
+    ],
+  },
+  E7: {
+    testFile: "apps/mobile/test/widget_test.dart",
+    testNames: [
+      "급행 운행 정보는 선택 UI 없이 시간표와 길찾기에 표시된다",
+      "역 시간표 화면은 일반·급행을 한 목록에 시각순으로 표시하고 급행 행에만 배지를 단다",
+    ],
+    localEvidencePaths: [
+      "docs/2099-qa/item3_express_badge_timetable.png",
+      "docs/2099-qa/item5_talkback_dump.xml",
+    ],
+  },
+  E8: {
+    testFile: "apps/mobile/test/route_search_request_test.dart",
+    testNames: [
+      "toV2Json은 mobilityPreset이 있으면 body에 싣고 mobilityType도 함께 보낸다",
+      "toV2Json은 mobilityPreset이 없으면 키를 넣지 않는다",
+    ],
+    requestSourceFile: "apps/mobile/lib/route_search.dart",
+    requestClassMarker: "class RouteSearchRequest {",
+  },
+};
+
+// E9: 2026-07-18 기준 mobile lib에 ITX_CHEONGCHUN/ITX-청춘 전용 표시 구현이 없다(grep 실측).
+// service_pattern_badge.dart의 isExpress는 serviceClass=='SUBWAY'만 인정해 ITX 승차 leg는
+// generic 급행 배지도 받지 못하고 무배지로 렌더링된다. 날조하지 않고 FAIL로 명시한다.
+const E9_MOBILE_GAP = {
+  result: "FAIL",
+  reasonKo: "mobile lib에 ITX_CHEONGCHUN/ITX-청춘 표시 위젯·테스트가 없음"
+    + " (apps/mobile/lib grep: 'ITX_CHEONGCHUN' 0건, '청춘' 0건; service_pattern_badge.dart의"
+    + " isExpress는 serviceClass=='SUBWAY'만 인정해 ITX ride leg는 배지 없이 렌더링됨)",
+  checkedFiles: [
+    "apps/mobile/lib/features/stations/presentation/service_pattern_badge.dart",
+    "apps/mobile/lib/features/stations/domain/station_models.dart",
+  ],
+};
+
+function checkTestNamesExist(repoRoot, testFile, testNames) {
+  const filePath = path.join(repoRoot, testFile);
+  if (!existsSync(filePath)) {
+    return { pass: false, missing: testNames, filePath: testFile };
+  }
+  const source = readFileSync(filePath, "utf8");
+  const missing = testNames.filter((name) => !source.includes(`'${name}'`));
+  return { pass: missing.length === 0, missing, filePath: testFile };
+}
+
+// E8 소스 레벨 검증: RouteSearchRequest 클래스 본문(다음 top-level class 선언 전까지)에
+// FORBIDDEN_REQUEST_FIELDS 중 어느 것도 quoted map key로 등장하지 않는지 확인한다.
+function checkRequestFieldAbsence(repoRoot, requestSourceFile, requestClassMarker) {
+  const filePath = path.join(repoRoot, requestSourceFile);
+  if (!existsSync(filePath)) {
+    return { pass: false, missing: ["<file-not-found>"], filePath: requestSourceFile };
+  }
+  const source = readFileSync(filePath, "utf8");
+  const classStart = source.indexOf(requestClassMarker);
+  if (classStart === -1) {
+    return { pass: false, missing: ["<class-not-found>"], filePath: requestSourceFile };
+  }
+  const nextClassStart = source.indexOf("\nclass ", classStart + requestClassMarker.length);
+  const classBody = nextClassStart === -1 ? source.slice(classStart) : source.slice(classStart, nextClassStart);
+  const found = FORBIDDEN_REQUEST_FIELDS.filter((field) => classBody.includes(`'${field}'`));
+  return { pass: found.length === 0, found, filePath: requestSourceFile };
+}
+
+export function buildMobileConsumptionEvidence({
+  candidate,
+  repoRoot = process.cwd(),
+  generatedAt = new Date().toISOString(),
+  provenance = "final-candidate",
+}) {
+  const identity = candidate?.releaseCandidateIdentity;
+  if (candidate?.phase !== "CANDIDATE" || candidate?.issue !== 2056 || !identity) {
+    throw new Error("mobile consumption evidence requires the #2056 CANDIDATE context");
+  }
+
+  const e1 = checkTestNamesExist(repoRoot, MOBILE_SCENARIO_EVIDENCE.E1.testFile, MOBILE_SCENARIO_EVIDENCE.E1.testNames);
+  const e7 = checkTestNamesExist(repoRoot, MOBILE_SCENARIO_EVIDENCE.E7.testFile, MOBILE_SCENARIO_EVIDENCE.E7.testNames);
+  const e8Tests = checkTestNamesExist(repoRoot, MOBILE_SCENARIO_EVIDENCE.E8.testFile, MOBILE_SCENARIO_EVIDENCE.E8.testNames);
+  const e8Fields = checkRequestFieldAbsence(
+    repoRoot,
+    MOBILE_SCENARIO_EVIDENCE.E8.requestSourceFile,
+    MOBILE_SCENARIO_EVIDENCE.E8.requestClassMarker,
+  );
+  const e8Pass = e8Tests.pass && e8Fields.pass;
+
+  const scenarioChecks = {
+    E1: e1,
+    E7: e7,
+    E8: { pass: e8Pass, tests: e8Tests, requestFields: e8Fields },
+    E9: E9_MOBILE_GAP,
+  };
+
+  const integrationScenarios = {
+    E1: e1.pass ? "PASS" : "FAIL",
+    E7: e7.pass ? "PASS" : "FAIL",
+    E8: e8Pass ? "PASS" : "FAIL",
+    E9: E9_MOBILE_GAP.result,
+  };
+
+  const coreScenariosSatisfied = e1.pass && e7.pass && e8Pass;
+
+  return {
+    schemaVersion: 1,
+    artifactKind: "route-v2-mobile-consumption-evidence",
+    sourceIssue: 2099,
+    consumerIssue: 2056,
+    generatedAt,
+    provenance,
+    status: coreScenariosSatisfied ? "SATISFIED" : "BLOCKED_MOBILE_SCENARIO_EVIDENCE",
+    releaseCandidateIdentity: identity,
+    apiContract: { catalogId: API_CATALOG_ID, contractVersion: "ROUTE_SEARCH_V2" },
+    integrationScenarios,
+    scenarioEvidence: {
+      E1: {
+        testFile: MOBILE_SCENARIO_EVIDENCE.E1.testFile,
+        testNames: MOBILE_SCENARIO_EVIDENCE.E1.testNames,
+        localEvidencePaths: MOBILE_SCENARIO_EVIDENCE.E1.localEvidencePaths,
+        result: integrationScenarios.E1,
+      },
+      E7: {
+        testFile: MOBILE_SCENARIO_EVIDENCE.E7.testFile,
+        testNames: MOBILE_SCENARIO_EVIDENCE.E7.testNames,
+        localEvidencePaths: MOBILE_SCENARIO_EVIDENCE.E7.localEvidencePaths,
+        result: integrationScenarios.E7,
+      },
+      E8: {
+        testFile: MOBILE_SCENARIO_EVIDENCE.E8.testFile,
+        testNames: MOBILE_SCENARIO_EVIDENCE.E8.testNames,
+        requestSourceFile: MOBILE_SCENARIO_EVIDENCE.E8.requestSourceFile,
+        forbiddenFieldsChecked: FORBIDDEN_REQUEST_FIELDS,
+        forbiddenFieldsFound: e8Fields.found ?? [],
+        result: integrationScenarios.E8,
+      },
+      E9: {
+        result: integrationScenarios.E9,
+        reasonKo: E9_MOBILE_GAP.reasonKo,
+        checkedFiles: E9_MOBILE_GAP.checkedFiles,
+      },
+    },
+    checks: scenarioChecks,
+  };
+}
+
+function argument(name) {
+  const index = process.argv.indexOf(`--${name}`);
+  return index < 0 ? null : process.argv[index + 1];
+}
+
+const entry = process.argv[1] ? path.resolve(process.argv[1]) : null;
+if (entry === fileURLToPath(import.meta.url)) {
+  const candidatePath = argument("candidate-context");
+  const outputPath = argument("output");
+  if (!candidatePath || !outputPath) {
+    throw new Error("--candidate-context and --output are required");
+  }
+  const repoRoot = argument("repo-root") ? path.resolve(argument("repo-root")) : process.cwd();
+  const provenance = argument("provenance") ?? "final-candidate";
+  const evidence = buildMobileConsumptionEvidence({
+    candidate: JSON.parse(readFileSync(candidatePath, "utf8")),
+    repoRoot,
+    provenance,
+  });
+  mkdirSync(path.dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, `${JSON.stringify(evidence, null, 2)}\n`);
+}

--- a/tools/release/build-mobile-consumption-evidence.mjs
+++ b/tools/release/build-mobile-consumption-evidence.mjs
@@ -159,7 +159,9 @@ function checkTestNamesExist(repoRoot, testFile, testNames) {
 }
 
 // E8 소스 레벨 검증: RouteSearchRequest 클래스 본문(다음 top-level class 선언 전까지)에
-// FORBIDDEN_REQUEST_FIELDS 중 어느 것도 quoted map key로 등장하지 않는지 확인한다.
+// FORBIDDEN_REQUEST_FIELDS 중 어느 것도 quoted map key로 등장하지 않는지 확인한다. Dart는
+// single/double quote 문자열을 모두 허용하므로("expressOnly"도 유효한 map key literal)
+// 양쪽 quote 스타일을 모두 검사해야 quote 스타일만 바꿔 우회하는 경우를 막는다.
 function checkRequestFieldAbsence(repoRoot, requestSourceFile, requestClassMarker) {
   const filePath = path.join(repoRoot, requestSourceFile);
   if (!existsSync(filePath)) {
@@ -172,7 +174,9 @@ function checkRequestFieldAbsence(repoRoot, requestSourceFile, requestClassMarke
   }
   const nextClassStart = source.indexOf("\nclass ", classStart + requestClassMarker.length);
   const classBody = nextClassStart === -1 ? source.slice(classStart) : source.slice(classStart, nextClassStart);
-  const found = FORBIDDEN_REQUEST_FIELDS.filter((field) => classBody.includes(`'${field}'`));
+  const found = FORBIDDEN_REQUEST_FIELDS.filter(
+    (field) => classBody.includes(`'${field}'`) || classBody.includes(`"${field}"`),
+  );
   return { pass: found.length === 0, found, filePath: requestSourceFile };
 }
 

--- a/tools/release/build-mobile-consumption-evidence.mjs
+++ b/tools/release/build-mobile-consumption-evidence.mjs
@@ -53,41 +53,66 @@ const MOBILE_SCENARIO_EVIDENCE = {
   },
 };
 
-// E9: ITX-청춘 서비스 식별은 datapack 노선명이 아니라 전용 배지로 구현됐다
-// (#1414 fix/1414-e9-itx-service-display, 551a57ab). 코드 경로 실측:
-// service_pattern_badge.dart에 `ServicePatternBadge.itxCheongchun` 생성자(key
-// `servicePatternItxCheongchunBadge`)가 있고, route_search.dart의
-// `RouteSearchStep.isItxCheongchun`(serviceClass=='ITX_CHEONGCHUN') getter를
-// ride leg 렌더 조건(`step.isItxCheongchun`)으로 연결해 그 배지를 그린다.
-// "ITX-청춘 표시 1회 + generic 급행 배지 0건 + TalkBack semantics 1회"를 검증하는
-// widget test가 함께 있어야 PASS다. 소스·test 중 하나라도 없으면 fail closed FAIL.
+// E9: ITX-청춘 서비스 식별은 datapack 노선명이 아니라 전용 배지로 구현되는 설계다
+// (#1414 fix/1414-e9-itx-service-display, 551a57ab에서 제안됨). 이 브랜치가 아직 병합되지
+// 않았으면 아래 마커가 없어 fail-closed FAIL로 남는 것이 정상이다. fix 병합 후 PASS가
+// 되려면 다음이 모두 성립해야 한다:
+// - service_pattern_badge.dart에 `ServicePatternBadge.itxCheongchun` 생성자(key
+//   `servicePatternItxCheongchunBadge`)가 존재해야 한다.
+// - route_search.dart의 `RouteSearchStep.isItxCheongchun`(serviceClass=='ITX_CHEONGCHUN')
+//   getter가 ride leg 렌더 조건(`step.isItxCheongchun`)에 실제로 연결돼야 한다.
+// - "ITX-청춘 표시 1회 + generic 급행 배지 0건 + TalkBack semantics 1회"를 검증하는
+//   widget test가 존재해야 한다.
+// 소스·test 중 하나라도 없으면 fail closed FAIL이다.
 const E9_BADGE_SOURCE_FILE = "apps/mobile/lib/features/stations/presentation/service_pattern_badge.dart";
+// 각 마커는 "선언 prefix + 핵심 토큰" 결합으로 주석·설명 텍스트만으로는 우연히 매칭되지 않게 한다
+// (완전한 Dart 파서는 과도하므로 만들지 않는다). Key(...)는 실제 소스가 여러 줄로 감싸므로
+// 정규식으로 개행을 허용한다.
 const E9_BADGE_SOURCE_MARKERS = [
-  "ServicePatternBadge.itxCheongchun(",
-  "'servicePatternItxCheongchunBadge'",
+  /const\s+ServicePatternBadge\.itxCheongchun\(/,
+  /Key\(\s*'servicePatternItxCheongchunBadge'/,
 ];
 const E9_STEP_SOURCE_FILE = "apps/mobile/lib/route_search.dart";
 const E9_STEP_SOURCE_MARKERS = [
-  "bool get isItxCheongchun",
-  "serviceClass == 'ITX_CHEONGCHUN'",
-  "step.isItxCheongchun",
-  "ServicePatternBadge.itxCheongchun()",
+  "bool get isItxCheongchun => serviceClass == 'ITX_CHEONGCHUN'",
+  "step.stepType == 'ride' && step.isItxCheongchun",
+  "ServicePatternBadge.itxCheongchun(",
 ];
 const E9_WIDGET_TEST = {
   testFile: "apps/mobile/test/widget_test.dart",
   testNames: ["길찾기 ITX-청춘 승차 leg은 선택 UI 없이 ITX-청춘 서비스 식별을 표시한다"],
 };
 
-// repoRoot/file을 utf8로 읽어 markers 전부가 원문에 등장하는지 확인한다. route_search.dart는
-// 바이너리 오인 바이트가 있어 grep -a가 필요하므로(coordinator 지적), grep 대신 Node
-// readFileSync로 직접 검사해 이 문제를 피한다.
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// //, /* */ 주석을 제거해 "주석에만 선언 문구가 있는" 오탐(예: TODO 주석에 실제 호출
+// syntax를 그대로 적어 둔 경우)을 막는다. 문자열 리터럴 안의 `//`(URL 등)는 못 걸러내는
+// 단순 근사치이지만, 이 저장소가 검사하는 파일들의 관련 문자열에는 `//`가 없어 실무적으로
+// 충분하다 — 완전한 Dart 토크나이저/파서는 만들지 않는다.
+function stripDartComments(source) {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+}
+
+function matchesMarker(source, marker) {
+  return marker instanceof RegExp ? marker.test(source) : source.includes(marker);
+}
+
+function markerLabel(marker) {
+  return marker instanceof RegExp ? marker.source : marker;
+}
+
+// repoRoot/file을 utf8로 읽어 markers 전부가 (주석 제외) 원문에 등장하는지 확인한다.
+// route_search.dart는 바이너리 오인 바이트가 있어 grep -a가 필요하므로(coordinator 지적),
+// grep 대신 Node readFileSync로 직접 검사해 이 문제를 피한다.
 function checkSourceMarkers(repoRoot, file, markers) {
   const filePath = path.join(repoRoot, file);
   if (!existsSync(filePath)) {
-    return { pass: false, missing: markers, filePath: file };
+    return { pass: false, missing: markers.map(markerLabel), filePath: file };
   }
-  const source = readFileSync(filePath, "utf8");
-  const missing = markers.filter((marker) => !source.includes(marker));
+  const source = stripDartComments(readFileSync(filePath, "utf8"));
+  const missing = markers.filter((marker) => !matchesMarker(source, marker)).map(markerLabel);
   return { pass: missing.length === 0, missing, filePath: file };
 }
 
@@ -116,13 +141,20 @@ function buildE9MobileAttestation(repoRoot) {
   };
 }
 
+// test 이름이 실제 test(...)/testWidgets(...) 선언에 쓰였는지 확인한다. 단순
+// `source.includes("'name'")`는 주석·설명 문구에 같은 문자열이 있어도 오탐 PASS를
+// 낸다 — `test(`/`testWidgets(` 선언 prefix와 결합해야만 매칭되도록 강화한다(완전한
+// Dart 파서는 과도하므로 만들지 않는다).
 function checkTestNamesExist(repoRoot, testFile, testNames) {
   const filePath = path.join(repoRoot, testFile);
   if (!existsSync(filePath)) {
     return { pass: false, missing: testNames, filePath: testFile };
   }
-  const source = readFileSync(filePath, "utf8");
-  const missing = testNames.filter((name) => !source.includes(`'${name}'`));
+  const source = stripDartComments(readFileSync(filePath, "utf8"));
+  const missing = testNames.filter((name) => {
+    const declarationPattern = new RegExp(`\\btest(Widgets)?\\(\\s*'${escapeRegExp(name)}'`);
+    return !declarationPattern.test(source);
+  });
   return { pass: missing.length === 0, missing, filePath: testFile };
 }
 

--- a/tools/release/build-mobile-consumption-evidence.mjs
+++ b/tools/release/build-mobile-consumption-evidence.mjs
@@ -5,12 +5,9 @@
 // 근거를 tracked source·test 참조로 결합한다. UI 렌더링/길찾기 로직을 재구현하지 않고, 이미
 // tracked된 위젯 test 이름과 request 직렬화 소스의 존재·내용만 정적으로 검증한다.
 
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { gunzipSync } from "node:zlib";
-import { DatabaseSync } from "node:sqlite";
 
 const API_CATALOG_ID = "internal:POST:/api/v2/routes/search:com.easysubway.route.adapter.in.web.RouteSearchController#searchRouteV2";
 
@@ -56,85 +53,66 @@ const MOBILE_SCENARIO_EVIDENCE = {
   },
 };
 
-// E9: online V2 leg 라벨은 하드코딩이 아니라 데이터 주도다. 코드 경로 실측:
-// RouteSearchV2Leg.fromJson(serviceClass/servicePattern 파싱, route_search.dart:1032)
-// -> RouteSearchStep.fromV2(lineName은 leg.lineId placeholder, route_search.dart:2097)
-// -> OnlineFirstRouteSearchRepository.searchRoute(local_route_repository.dart:1049)가
-// localRepository.resolveDisplayLabels(onlineResult) 호출(local_route_repository.dart:1057)
-// -> resolveDisplayLabels 확장이 catalog.lineName(step.lineId)로 lineName을 실제 채운다
-// (local_route_repository.dart:1093, lineName lookup은 2023행 catalog.lineName).
-// 급행 배지는 serviceClass=='SUBWAY'만 대상이라(service_pattern_badge.dart의 isExpress,
-// route_search.dart:6083 주석이 "ITX-청춘·LOCAL은 배지 없음"을 명시) ITX leg 식별은 이
-// line name 하나에 전적으로 의존한다.
-//
-// 이 line name의 실제 값은 하드코딩이 아니라 번들 datapack(lines.name_ko)에서 나오므로,
-// PASS/FAIL을 정적 문자열이 아니라 tracked datapack 실측으로 판정한다(checkItxLineDisplayIdentity).
-// generic 급행 배지 미부착은 route_search_test.dart:1586(#2099 WP2)로 이미 검증되지만, 그것만으로는
-// "ITX-청춘 표시"를 충족하지 않는다 — line name 식별과 배지 부재를 모두 요구한다.
-const ITX_CANONICAL_LINE_ID = "line-54a7b980b7c3"; // korail-itx-cheongchun-station-sequence-20260713.json의 canonicalLineId
-const BUNDLED_DATAPACK_ASSET = "apps/mobile/assets/datapacks/capital.sqlite.gz";
-const ITX_DISPLAY_CHECK_FILES = [
-  "apps/mobile/lib/route_search.dart",
-  "apps/mobile/lib/features/routes/data/local_route_repository.dart",
-  "apps/mobile/lib/features/stations/presentation/service_pattern_badge.dart",
+// E9: ITX-청춘 서비스 식별은 datapack 노선명이 아니라 전용 배지로 구현됐다
+// (#1414 fix/1414-e9-itx-service-display, 551a57ab). 코드 경로 실측:
+// service_pattern_badge.dart에 `ServicePatternBadge.itxCheongchun` 생성자(key
+// `servicePatternItxCheongchunBadge`)가 있고, route_search.dart의
+// `RouteSearchStep.isItxCheongchun`(serviceClass=='ITX_CHEONGCHUN') getter를
+// ride leg 렌더 조건(`step.isItxCheongchun`)으로 연결해 그 배지를 그린다.
+// "ITX-청춘 표시 1회 + generic 급행 배지 0건 + TalkBack semantics 1회"를 검증하는
+// widget test가 함께 있어야 PASS다. 소스·test 중 하나라도 없으면 fail closed FAIL.
+const E9_BADGE_SOURCE_FILE = "apps/mobile/lib/features/stations/presentation/service_pattern_badge.dart";
+const E9_BADGE_SOURCE_MARKERS = [
+  "ServicePatternBadge.itxCheongchun(",
+  "'servicePatternItxCheongchunBadge'",
 ];
-// 급행 배지가 SUBWAY/EXPRESS에만 붙고 ITX_CHEONGCHUN에는 generic 배지를 만들지 않음을
-// 검증하는 실존 unit test(route_search_test.dart:1586, #2099 WP2).
-const E9_NO_GENERIC_BADGE_TEST = {
-  testFile: "apps/mobile/test/route_search_test.dart",
-  testNames: ["RIDE ITX_CHEONGCHUN/EXPRESS leg은 generic 급행 배지를 만들지 않는다"],
+const E9_STEP_SOURCE_FILE = "apps/mobile/lib/route_search.dart";
+const E9_STEP_SOURCE_MARKERS = [
+  "bool get isItxCheongchun",
+  "serviceClass == 'ITX_CHEONGCHUN'",
+  "step.isItxCheongchun",
+  "ServicePatternBadge.itxCheongchun()",
+];
+const E9_WIDGET_TEST = {
+  testFile: "apps/mobile/test/widget_test.dart",
+  testNames: ["길찾기 ITX-청춘 승차 leg은 선택 UI 없이 ITX-청춘 서비스 식별을 표시한다"],
 };
 
-// 번들 production datapack의 lines.name_ko를 직접 질의해 online ITX leg이 실제로
-// "ITX-청춘"으로 식별되는지 실측한다(문자열 comment가 아니라 tracked 산출물 재질의).
-function checkItxLineDisplayIdentity(repoRoot) {
-  const assetPath = path.join(repoRoot, BUNDLED_DATAPACK_ASSET);
-  if (!existsSync(assetPath)) {
-    return { pass: false, lineId: ITX_CANONICAL_LINE_ID, lineNameKo: null, assetPath: BUNDLED_DATAPACK_ASSET };
+// repoRoot/file을 utf8로 읽어 markers 전부가 원문에 등장하는지 확인한다. route_search.dart는
+// 바이너리 오인 바이트가 있어 grep -a가 필요하므로(coordinator 지적), grep 대신 Node
+// readFileSync로 직접 검사해 이 문제를 피한다.
+function checkSourceMarkers(repoRoot, file, markers) {
+  const filePath = path.join(repoRoot, file);
+  if (!existsSync(filePath)) {
+    return { pass: false, missing: markers, filePath: file };
   }
-  const sqliteBytes = gunzipSync(readFileSync(assetPath));
-  const workDir = mkdtempSync(path.join(tmpdir(), "easysubway-mobile-evidence-datapack-"));
-  const sqlitePath = path.join(workDir, "capital.sqlite");
-  writeFileSync(sqlitePath, sqliteBytes);
-  const database = new DatabaseSync(sqlitePath, { readOnly: true });
-  try {
-    const row = database.prepare("SELECT name_ko FROM lines WHERE id = ?").get(ITX_CANONICAL_LINE_ID);
-    const lineNameKo = typeof row?.name_ko === "string" ? row.name_ko : null;
-    const identifiesAsItx = lineNameKo !== null
-      && (lineNameKo.includes("ITX") || lineNameKo.includes("청춘"));
-    return { pass: identifiesAsItx, lineId: ITX_CANONICAL_LINE_ID, lineNameKo, assetPath: BUNDLED_DATAPACK_ASSET };
-  } finally {
-    database.close();
-    rmSync(workDir, { recursive: true, force: true });
-  }
+  const source = readFileSync(filePath, "utf8");
+  const missing = markers.filter((marker) => !source.includes(marker));
+  return { pass: missing.length === 0, missing, filePath: file };
 }
 
 function buildE9MobileAttestation(repoRoot) {
-  const lineDisplay = checkItxLineDisplayIdentity(repoRoot);
-  const noGenericBadge = checkTestNamesExist(
-    repoRoot,
-    E9_NO_GENERIC_BADGE_TEST.testFile,
-    E9_NO_GENERIC_BADGE_TEST.testNames,
-  );
-  // 두 조건 모두 필요하다: (1) online ITX leg의 line name이 실제로 ITX-청춘을 식별하고,
-  // (2) generic 급행 배지가 붙지 않음을 실존 test가 지킨다. (1)이 false면 (2)만으로는
-  // "ITX-청춘으로 표시"를 충족하지 못한다 — 무표시와 무배지를 혼동하지 않는다.
-  const pass = lineDisplay.pass && noGenericBadge.pass;
-  const reasonKo = lineDisplay.pass
-    ? `online ITX leg은 catalog 기반 line name으로 ITX-청춘으로 식별된다(${BUNDLED_DATAPACK_ASSET}의 `
-      + `lines.name_ko='${lineDisplay.lineNameKo}'), generic 급행 배지 미부착은 `
-      + `${E9_NO_GENERIC_BADGE_TEST.testFile}로 검증됨`
-    : `online ITX leg의 line name은 catalog 기반이지만(하드코딩 아님) ITX-청춘을 식별하지 않는다: `
-      + `${BUNDLED_DATAPACK_ASSET}의 lines.id='${lineDisplay.lineId}' name_ko='${lineDisplay.lineNameKo}'. `
-      + `serviceClass=='SUBWAY'만 급행 배지 대상이라(service_pattern_badge.dart, route_search.dart:6083 `
-      + `주석 "ITX-청춘·LOCAL은 배지 없음") ITX leg은 이 line name 외에 보조 표시가 없다 `
-      + `(generic 급행 배지 미부착은 검증되지만 그것만으로 "ITX-청춘 표시"를 충족하지 않음).`;
+  const badgeSource = checkSourceMarkers(repoRoot, E9_BADGE_SOURCE_FILE, E9_BADGE_SOURCE_MARKERS);
+  const stepSource = checkSourceMarkers(repoRoot, E9_STEP_SOURCE_FILE, E9_STEP_SOURCE_MARKERS);
+  const widgetTest = checkTestNamesExist(repoRoot, E9_WIDGET_TEST.testFile, E9_WIDGET_TEST.testNames);
+  // 세 조건 모두 필요하다: (1) 배지 위젯 소스, (2) ride leg 렌더 연결, (3) 이를 검증하는
+  // widget test. 하나라도 없으면 "ITX-청춘 표시"가 실제로 있다고 단정하지 않는다.
+  const pass = badgeSource.pass && stepSource.pass && widgetTest.pass;
+  const reasonKo = pass
+    ? `ITX-청춘 서비스 식별 배지가 소스에 존재하고(${E9_BADGE_SOURCE_FILE}) `
+      + `ride leg 렌더에 연결되며(${E9_STEP_SOURCE_FILE}), ${E9_WIDGET_TEST.testFile}의 `
+      + `"${E9_WIDGET_TEST.testNames[0]}" 테스트가 표시 1회·급행 0건을 검증한다.`
+    : `ITX-청춘 서비스 식별 배지 구현이 불완전하다: `
+      + `${E9_BADGE_SOURCE_FILE} 누락 마커=${JSON.stringify(badgeSource.missing)}, `
+      + `${E9_STEP_SOURCE_FILE} 누락 마커=${JSON.stringify(stepSource.missing)}, `
+      + `${E9_WIDGET_TEST.testFile} 누락 test=${JSON.stringify(widgetTest.missing)}.`;
   return {
     result: pass ? "PASS" : "FAIL",
     reasonKo,
-    checkedFiles: [...ITX_DISPLAY_CHECK_FILES, E9_NO_GENERIC_BADGE_TEST.testFile],
-    lineDisplay,
-    noGenericBadge,
+    checkedFiles: [E9_BADGE_SOURCE_FILE, E9_STEP_SOURCE_FILE, E9_WIDGET_TEST.testFile],
+    badgeSource,
+    stepSource,
+    widgetTest,
   };
 }
 
@@ -240,8 +218,9 @@ export function buildMobileConsumptionEvidence({
         result: integrationScenarios.E9,
         reasonKo: e9.reasonKo,
         checkedFiles: e9.checkedFiles,
-        lineDisplay: e9.lineDisplay,
-        noGenericBadge: e9.noGenericBadge,
+        badgeSource: e9.badgeSource,
+        stepSource: e9.stepSource,
+        widgetTest: e9.widgetTest,
       },
     },
     checks: scenarioChecks,

--- a/tools/release/build-mobile-consumption-evidence.test.mjs
+++ b/tools/release/build-mobile-consumption-evidence.test.mjs
@@ -3,8 +3,6 @@ import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { gzipSync } from "node:zlib";
-import { DatabaseSync } from "node:sqlite";
 
 import { buildMobileConsumptionEvidence } from "./build-mobile-consumption-evidence.mjs";
 
@@ -14,23 +12,35 @@ const identity = {
   versionCode: "10005",
 };
 
-const ITX_LINE_ID = "line-54a7b980b7c3";
-const NO_GENERIC_BADGE_TEST_NAME = "RIDE ITX_CHEONGCHUN/EXPRESS leg은 generic 급행 배지를 만들지 않는다";
+const ITX_WIDGET_TEST_NAME = "길찾기 ITX-청춘 승차 leg은 선택 UI 없이 ITX-청춘 서비스 식별을 표시한다";
+
+// #1414 fix/1414-e9-itx-service-display(551a57ab)가 실제로 추가한 소스 형태를 재현한 fixture.
+const ITX_BADGE_SOURCE_FULL = `
+class ServicePatternBadge extends StatelessWidget {
+  const ServicePatternBadge.itxCheongchun({super.key})
+    : departure = null,
+      _forcedLabel = 'ITX-청춘',
+      _badgeKey = _itxCheongchunBadgeKey;
+
+  static const Key _itxCheongchunBadgeKey = Key(
+    'servicePatternItxCheongchunBadge',
+  );
+}
+`;
+
+const ITX_STEP_SOURCE_FULL = `
+  bool get isItxCheongchun => serviceClass == 'ITX_CHEONGCHUN';
+
+  Widget _buildItxBadge(RouteSearchStep step) {
+    if (step.stepType == 'ride' && step.isItxCheongchun) {
+      return const ServicePatternBadge.itxCheongchun();
+    }
+    return const SizedBox.shrink();
+  }
+`;
 
 function candidate(overrides = {}) {
   return { phase: "CANDIDATE", issue: 2056, releaseCandidateIdentity: identity, ...overrides };
-}
-
-function writeFixtureDatapack(root, lineNameKo) {
-  const db = new DatabaseSync(":memory:");
-  db.exec("CREATE TABLE lines (id TEXT PRIMARY KEY, name_ko TEXT)");
-  db.prepare("INSERT INTO lines (id, name_ko) VALUES (?, ?)").run(ITX_LINE_ID, lineNameKo);
-  const sqliteBytes = db.serialize();
-  db.close();
-  return writeFile(
-    path.join(root, "apps/mobile/assets/datapacks/capital.sqlite.gz"),
-    gzipSync(Buffer.from(sqliteBytes)),
-  );
 }
 
 async function fixtureRepoRoot({
@@ -44,33 +54,35 @@ async function fixtureRepoRoot({
     "toV2Json은 mobilityPreset이 없으면 키를 넣지 않는다",
   ],
   requestClassBody = "class RouteSearchRequest {\n  Map<String, Object?> toV2Json() => {};\n}\n",
-  routeSearchTestNames = [NO_GENERIC_BADGE_TEST_NAME],
-  itxLineNameKo = null,
+  itxStepSource = "",
+  itxBadgeSource = "",
+  itxWidgetTestNames = [],
 } = {}) {
   const root = await mkdtemp(path.join(tmpdir(), "easysubway-mobile-evidence-"));
   await mkdir(path.join(root, "apps/mobile/test"), { recursive: true });
-  await mkdir(path.join(root, "apps/mobile/lib"), { recursive: true });
-  await mkdir(path.join(root, "apps/mobile/assets/datapacks"), { recursive: true });
+  await mkdir(path.join(root, "apps/mobile/lib/features/stations/presentation"), { recursive: true });
   await writeFile(
     path.join(root, "apps/mobile/test/widget_test.dart"),
-    widgetTestNames.map((name) => `testWidgets('${name}', (tester) async {});\n`).join(""),
+    [...widgetTestNames, ...itxWidgetTestNames]
+      .map((name) => `testWidgets('${name}', (tester) async {});\n`)
+      .join(""),
   );
   await writeFile(
     path.join(root, "apps/mobile/test/route_search_request_test.dart"),
     requestTestNames.map((name) => `test('${name}', () {});\n`).join(""),
   );
   await writeFile(
-    path.join(root, "apps/mobile/test/route_search_test.dart"),
-    routeSearchTestNames.map((name) => `test('${name}', () {});\n`).join(""),
+    path.join(root, "apps/mobile/lib/route_search.dart"),
+    requestClassBody + itxStepSource,
   );
-  await writeFile(path.join(root, "apps/mobile/lib/route_search.dart"), requestClassBody);
-  if (itxLineNameKo !== null) {
-    await writeFixtureDatapack(root, itxLineNameKo);
-  }
+  await writeFile(
+    path.join(root, "apps/mobile/lib/features/stations/presentation/service_pattern_badge.dart"),
+    itxBadgeSource,
+  );
   return root;
 }
 
-test("E1/E7/E8 tracked test·source가 모두 있으면 SATISFIED와 PASS matrix를 산출한다", async () => {
+test("E1/E7/E8 tracked test·source가 모두 있으면 SATISFIED와 PASS matrix를 산출한다(E9는 ITX 배지 미구현 시 FAIL)", async () => {
   const repoRoot = await fixtureRepoRoot();
   const evidence = buildMobileConsumptionEvidence({
     candidate: candidate(),
@@ -87,40 +99,54 @@ test("E1/E7/E8 tracked test·source가 모두 있으면 SATISFIED와 PASS matrix
   assert.equal(evidence.provenance, "final-candidate");
 });
 
-test("E9는 번들 datapack의 line name이 ITX-청춘을 식별하지 않으면 FAIL한다(datapack 없음)", async () => {
-  const repoRoot = await fixtureRepoRoot();
-  const evidence = buildMobileConsumptionEvidence({ candidate: candidate(), repoRoot });
-
-  assert.equal(evidence.integrationScenarios.E9, "FAIL");
-  assert.equal(evidence.scenarioEvidence.E9.lineDisplay.pass, false);
-  assert.match(evidence.scenarioEvidence.E9.reasonKo, /ITX/);
-});
-
-test("E9는 번들 datapack의 line name이 '경춘'처럼 ITX와 무관해도 fail closed한다(과거 false negative 방지)", async () => {
-  const repoRoot = await fixtureRepoRoot({ itxLineNameKo: "수도권 경춘" });
-  const evidence = buildMobileConsumptionEvidence({ candidate: candidate(), repoRoot });
-
-  assert.equal(evidence.integrationScenarios.E9, "FAIL");
-  assert.equal(evidence.scenarioEvidence.E9.lineDisplay.lineNameKo, "수도권 경춘");
-  assert.equal(evidence.scenarioEvidence.E9.lineDisplay.pass, false);
-});
-
-test("E9는 번들 datapack의 line name이 ITX-청춘을 식별하고 generic 배지 회귀 test가 있으면 PASS한다", async () => {
-  const repoRoot = await fixtureRepoRoot({ itxLineNameKo: "ITX-청춘" });
+test("E9는 배지 소스·ride leg 연결·widget test가 모두 있으면 PASS한다", async () => {
+  const repoRoot = await fixtureRepoRoot({
+    itxBadgeSource: ITX_BADGE_SOURCE_FULL,
+    itxStepSource: ITX_STEP_SOURCE_FULL,
+    itxWidgetTestNames: [ITX_WIDGET_TEST_NAME],
+  });
   const evidence = buildMobileConsumptionEvidence({ candidate: candidate(), repoRoot });
 
   assert.equal(evidence.integrationScenarios.E9, "PASS");
-  assert.equal(evidence.scenarioEvidence.E9.lineDisplay.pass, true);
-  assert.equal(evidence.scenarioEvidence.E9.noGenericBadge.pass, true);
+  assert.equal(evidence.scenarioEvidence.E9.badgeSource.pass, true);
+  assert.equal(evidence.scenarioEvidence.E9.stepSource.pass, true);
+  assert.equal(evidence.scenarioEvidence.E9.widgetTest.pass, true);
 });
 
-test("E9는 line name이 ITX-청춘이어도 generic 배지 회귀 test가 없으면 FAIL한다", async () => {
-  const repoRoot = await fixtureRepoRoot({ itxLineNameKo: "ITX-청춘", routeSearchTestNames: ["무관한 테스트"] });
+test("E9는 배지 소스가 없으면 fail closed FAIL한다(getter·widget test만 있어도)", async () => {
+  const repoRoot = await fixtureRepoRoot({
+    itxStepSource: ITX_STEP_SOURCE_FULL,
+    itxWidgetTestNames: [ITX_WIDGET_TEST_NAME],
+  });
   const evidence = buildMobileConsumptionEvidence({ candidate: candidate(), repoRoot });
 
   assert.equal(evidence.integrationScenarios.E9, "FAIL");
-  assert.equal(evidence.scenarioEvidence.E9.lineDisplay.pass, true);
-  assert.equal(evidence.scenarioEvidence.E9.noGenericBadge.pass, false);
+  assert.equal(evidence.scenarioEvidence.E9.badgeSource.pass, false);
+  assert.ok(evidence.scenarioEvidence.E9.badgeSource.missing.length > 0);
+});
+
+test("E9는 ride leg 렌더 연결이 없으면 fail closed FAIL한다(배지·getter만 있어도)", async () => {
+  const repoRoot = await fixtureRepoRoot({
+    itxBadgeSource: ITX_BADGE_SOURCE_FULL,
+    itxStepSource: "\n  bool get isItxCheongchun => serviceClass == 'ITX_CHEONGCHUN';\n",
+    itxWidgetTestNames: [ITX_WIDGET_TEST_NAME],
+  });
+  const evidence = buildMobileConsumptionEvidence({ candidate: candidate(), repoRoot });
+
+  assert.equal(evidence.integrationScenarios.E9, "FAIL");
+  assert.equal(evidence.scenarioEvidence.E9.stepSource.pass, false);
+  assert.ok(evidence.scenarioEvidence.E9.stepSource.missing.includes("step.isItxCheongchun"));
+});
+
+test("E9는 소스가 모두 있어도 widget test가 없으면 fail closed FAIL한다", async () => {
+  const repoRoot = await fixtureRepoRoot({
+    itxBadgeSource: ITX_BADGE_SOURCE_FULL,
+    itxStepSource: ITX_STEP_SOURCE_FULL,
+  });
+  const evidence = buildMobileConsumptionEvidence({ candidate: candidate(), repoRoot });
+
+  assert.equal(evidence.integrationScenarios.E9, "FAIL");
+  assert.equal(evidence.scenarioEvidence.E9.widgetTest.pass, false);
 });
 
 test("E1/E7 test 이름이 tracked 파일에 없으면 FAIL로 fail closed한다", async () => {
@@ -150,14 +176,12 @@ test("CANDIDATE context가 아니면 거부한다", async () => {
   );
 });
 
-test("실제 저장소 tracked source·번들 datapack에 대해 실행하면 E1/E7/E8 PASS, E9 FAIL(line name='수도권 경춘')을 재현한다", () => {
+test("현재 작업 브랜치 tracked source에 대해 실행하면 E1/E7/E8 PASS, E9는 ITX 배지 fix 병합 전이라 FAIL을 재현한다", () => {
   const repoRoot = path.resolve(import.meta.dirname, "../..");
   const evidence = buildMobileConsumptionEvidence({ candidate: candidate(), repoRoot });
 
   assert.equal(evidence.integrationScenarios.E1, "PASS");
   assert.equal(evidence.integrationScenarios.E7, "PASS");
   assert.equal(evidence.integrationScenarios.E8, "PASS");
-  assert.equal(evidence.scenarioEvidence.E9.lineDisplay.lineNameKo, "수도권 경춘");
-  assert.equal(evidence.scenarioEvidence.E9.noGenericBadge.pass, true);
   assert.equal(evidence.integrationScenarios.E9, "FAIL");
 });

--- a/tools/release/build-mobile-consumption-evidence.test.mjs
+++ b/tools/release/build-mobile-consumption-evidence.test.mjs
@@ -3,6 +3,8 @@ import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { gzipSync } from "node:zlib";
+import { DatabaseSync } from "node:sqlite";
 
 import { buildMobileConsumptionEvidence } from "./build-mobile-consumption-evidence.mjs";
 
@@ -12,8 +14,23 @@ const identity = {
   versionCode: "10005",
 };
 
+const ITX_LINE_ID = "line-54a7b980b7c3";
+const NO_GENERIC_BADGE_TEST_NAME = "RIDE ITX_CHEONGCHUN/EXPRESS leg은 generic 급행 배지를 만들지 않는다";
+
 function candidate(overrides = {}) {
   return { phase: "CANDIDATE", issue: 2056, releaseCandidateIdentity: identity, ...overrides };
+}
+
+function writeFixtureDatapack(root, lineNameKo) {
+  const db = new DatabaseSync(":memory:");
+  db.exec("CREATE TABLE lines (id TEXT PRIMARY KEY, name_ko TEXT)");
+  db.prepare("INSERT INTO lines (id, name_ko) VALUES (?, ?)").run(ITX_LINE_ID, lineNameKo);
+  const sqliteBytes = db.serialize();
+  db.close();
+  return writeFile(
+    path.join(root, "apps/mobile/assets/datapacks/capital.sqlite.gz"),
+    gzipSync(Buffer.from(sqliteBytes)),
+  );
 }
 
 async function fixtureRepoRoot({
@@ -27,10 +44,13 @@ async function fixtureRepoRoot({
     "toV2Json은 mobilityPreset이 없으면 키를 넣지 않는다",
   ],
   requestClassBody = "class RouteSearchRequest {\n  Map<String, Object?> toV2Json() => {};\n}\n",
+  routeSearchTestNames = [NO_GENERIC_BADGE_TEST_NAME],
+  itxLineNameKo = null,
 } = {}) {
   const root = await mkdtemp(path.join(tmpdir(), "easysubway-mobile-evidence-"));
   await mkdir(path.join(root, "apps/mobile/test"), { recursive: true });
   await mkdir(path.join(root, "apps/mobile/lib"), { recursive: true });
+  await mkdir(path.join(root, "apps/mobile/assets/datapacks"), { recursive: true });
   await writeFile(
     path.join(root, "apps/mobile/test/widget_test.dart"),
     widgetTestNames.map((name) => `testWidgets('${name}', (tester) async {});\n`).join(""),
@@ -39,7 +59,14 @@ async function fixtureRepoRoot({
     path.join(root, "apps/mobile/test/route_search_request_test.dart"),
     requestTestNames.map((name) => `test('${name}', () {});\n`).join(""),
   );
+  await writeFile(
+    path.join(root, "apps/mobile/test/route_search_test.dart"),
+    routeSearchTestNames.map((name) => `test('${name}', () {});\n`).join(""),
+  );
   await writeFile(path.join(root, "apps/mobile/lib/route_search.dart"), requestClassBody);
+  if (itxLineNameKo !== null) {
+    await writeFixtureDatapack(root, itxLineNameKo);
+  }
   return root;
 }
 
@@ -60,12 +87,40 @@ test("E1/E7/E8 tracked test·source가 모두 있으면 SATISFIED와 PASS matrix
   assert.equal(evidence.provenance, "final-candidate");
 });
 
-test("E9는 mobile ITX-청춘 표시 구현이 없어 항상 FAIL로 정직하게 남는다", async () => {
+test("E9는 번들 datapack의 line name이 ITX-청춘을 식별하지 않으면 FAIL한다(datapack 없음)", async () => {
   const repoRoot = await fixtureRepoRoot();
   const evidence = buildMobileConsumptionEvidence({ candidate: candidate(), repoRoot });
 
   assert.equal(evidence.integrationScenarios.E9, "FAIL");
+  assert.equal(evidence.scenarioEvidence.E9.lineDisplay.pass, false);
   assert.match(evidence.scenarioEvidence.E9.reasonKo, /ITX/);
+});
+
+test("E9는 번들 datapack의 line name이 '경춘'처럼 ITX와 무관해도 fail closed한다(과거 false negative 방지)", async () => {
+  const repoRoot = await fixtureRepoRoot({ itxLineNameKo: "수도권 경춘" });
+  const evidence = buildMobileConsumptionEvidence({ candidate: candidate(), repoRoot });
+
+  assert.equal(evidence.integrationScenarios.E9, "FAIL");
+  assert.equal(evidence.scenarioEvidence.E9.lineDisplay.lineNameKo, "수도권 경춘");
+  assert.equal(evidence.scenarioEvidence.E9.lineDisplay.pass, false);
+});
+
+test("E9는 번들 datapack의 line name이 ITX-청춘을 식별하고 generic 배지 회귀 test가 있으면 PASS한다", async () => {
+  const repoRoot = await fixtureRepoRoot({ itxLineNameKo: "ITX-청춘" });
+  const evidence = buildMobileConsumptionEvidence({ candidate: candidate(), repoRoot });
+
+  assert.equal(evidence.integrationScenarios.E9, "PASS");
+  assert.equal(evidence.scenarioEvidence.E9.lineDisplay.pass, true);
+  assert.equal(evidence.scenarioEvidence.E9.noGenericBadge.pass, true);
+});
+
+test("E9는 line name이 ITX-청춘이어도 generic 배지 회귀 test가 없으면 FAIL한다", async () => {
+  const repoRoot = await fixtureRepoRoot({ itxLineNameKo: "ITX-청춘", routeSearchTestNames: ["무관한 테스트"] });
+  const evidence = buildMobileConsumptionEvidence({ candidate: candidate(), repoRoot });
+
+  assert.equal(evidence.integrationScenarios.E9, "FAIL");
+  assert.equal(evidence.scenarioEvidence.E9.lineDisplay.pass, true);
+  assert.equal(evidence.scenarioEvidence.E9.noGenericBadge.pass, false);
 });
 
 test("E1/E7 test 이름이 tracked 파일에 없으면 FAIL로 fail closed한다", async () => {
@@ -95,12 +150,14 @@ test("CANDIDATE context가 아니면 거부한다", async () => {
   );
 });
 
-test("실제 저장소 tracked source에 대해 실행하면 E1/E7/E8 PASS, E9 FAIL을 재현한다", () => {
+test("실제 저장소 tracked source·번들 datapack에 대해 실행하면 E1/E7/E8 PASS, E9 FAIL(line name='수도권 경춘')을 재현한다", () => {
   const repoRoot = path.resolve(import.meta.dirname, "../..");
   const evidence = buildMobileConsumptionEvidence({ candidate: candidate(), repoRoot });
 
   assert.equal(evidence.integrationScenarios.E1, "PASS");
   assert.equal(evidence.integrationScenarios.E7, "PASS");
   assert.equal(evidence.integrationScenarios.E8, "PASS");
+  assert.equal(evidence.scenarioEvidence.E9.lineDisplay.lineNameKo, "수도권 경춘");
+  assert.equal(evidence.scenarioEvidence.E9.noGenericBadge.pass, true);
   assert.equal(evidence.integrationScenarios.E9, "FAIL");
 });

--- a/tools/release/build-mobile-consumption-evidence.test.mjs
+++ b/tools/release/build-mobile-consumption-evidence.test.mjs
@@ -206,6 +206,18 @@ test("E8은 request 직렬화에 servicePattern/expressOnly 등 금지 필드가
   assert.deepEqual(evidence.scenarioEvidence.E8.forbiddenFieldsFound, ["servicePattern"]);
 });
 
+test("E8은 double-quote로 직렬화된 금지 필드도 우회 없이 FAIL한다(quote 스타일 회귀 가드)", async () => {
+  const repoRoot = await fixtureRepoRoot({
+    // Dart는 single/double quote 문자열 리터럴을 모두 허용한다 — double quote만 써서
+    // single-quote 전용 검사를 우회할 수 있었던 과거 결함의 회귀 가드.
+    requestClassBody: "class RouteSearchRequest {\n  Map<String, Object?> toV2Json() => {\"expressOnly\": true};\n}\n",
+  });
+  const evidence = buildMobileConsumptionEvidence({ candidate: candidate(), repoRoot });
+
+  assert.equal(evidence.integrationScenarios.E8, "FAIL");
+  assert.deepEqual(evidence.scenarioEvidence.E8.forbiddenFieldsFound, ["expressOnly"]);
+});
+
 test("CANDIDATE context가 아니면 거부한다", async () => {
   const repoRoot = await fixtureRepoRoot();
   assert.throws(

--- a/tools/release/build-mobile-consumption-evidence.test.mjs
+++ b/tools/release/build-mobile-consumption-evidence.test.mjs
@@ -135,7 +135,11 @@ test("E9는 ride leg 렌더 연결이 없으면 fail closed FAIL한다(배지·g
 
   assert.equal(evidence.integrationScenarios.E9, "FAIL");
   assert.equal(evidence.scenarioEvidence.E9.stepSource.pass, false);
-  assert.ok(evidence.scenarioEvidence.E9.stepSource.missing.includes("step.isItxCheongchun"));
+  assert.ok(
+    evidence.scenarioEvidence.E9.stepSource.missing.includes(
+      "step.stepType == 'ride' && step.isItxCheongchun",
+    ),
+  );
 });
 
 test("E9는 소스가 모두 있어도 widget test가 없으면 fail closed FAIL한다", async () => {
@@ -156,6 +160,40 @@ test("E1/E7 test 이름이 tracked 파일에 없으면 FAIL로 fail closed한다
   assert.equal(evidence.integrationScenarios.E1, "FAIL");
   assert.equal(evidence.integrationScenarios.E7, "FAIL");
   assert.equal(evidence.status, "BLOCKED_MOBILE_SCENARIO_EVIDENCE");
+});
+
+test("test 이름이 testWidgets(...) 선언이 아니라 주석에만 있으면 FAIL로 fail closed한다(오탐 회귀 가드)", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "easysubway-mobile-evidence-"));
+  await mkdir(path.join(root, "apps/mobile/test"), { recursive: true });
+  await mkdir(path.join(root, "apps/mobile/lib/features/stations/presentation"), { recursive: true });
+  // 실제 testWidgets() 호출이 아니라 코멘트에만 테스트명 문자열이 등장한다 —
+  // 예전 단순 substring 매칭이었다면 이 상태에서도 오탐 PASS했을 것이다.
+  await writeFile(
+    path.join(root, "apps/mobile/test/widget_test.dart"),
+    "// TODO: add testWidgets('노선도 첫 화면은 하단 광고 위에 지도 조작을 유지한다', ...) later\n",
+  );
+  await writeFile(path.join(root, "apps/mobile/test/route_search_request_test.dart"), "");
+  await writeFile(path.join(root, "apps/mobile/lib/route_search.dart"), "class RouteSearchRequest {}\n");
+  await writeFile(path.join(root, "apps/mobile/lib/features/stations/presentation/service_pattern_badge.dart"), "");
+
+  const evidence = buildMobileConsumptionEvidence({ candidate: candidate(), repoRoot: root });
+
+  assert.equal(evidence.integrationScenarios.E1, "FAIL");
+  assert.ok(evidence.scenarioEvidence.E1.testNames.length > 0);
+});
+
+test("E9 배지 마커가 주석에만 있으면 FAIL로 fail closed한다(오탐 회귀 가드)", async () => {
+  const repoRoot = await fixtureRepoRoot({
+    // 실제 생성자 선언이 아니라 설명 주석에만 문자열이 등장한다.
+    itxBadgeSource: "// ServicePatternBadge.itxCheongchun( 생성자를 여기에 추가할 예정\n"
+      + "// key: 'servicePatternItxCheongchunBadge'\n",
+    itxStepSource: ITX_STEP_SOURCE_FULL,
+    itxWidgetTestNames: [ITX_WIDGET_TEST_NAME],
+  });
+  const evidence = buildMobileConsumptionEvidence({ candidate: candidate(), repoRoot });
+
+  assert.equal(evidence.integrationScenarios.E9, "FAIL");
+  assert.equal(evidence.scenarioEvidence.E9.badgeSource.pass, false);
 });
 
 test("E8은 request 직렬화에 servicePattern/expressOnly 등 금지 필드가 있으면 FAIL한다", async () => {

--- a/tools/release/build-mobile-consumption-evidence.test.mjs
+++ b/tools/release/build-mobile-consumption-evidence.test.mjs
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { buildMobileConsumptionEvidence } from "./build-mobile-consumption-evidence.mjs";
+
+const identity = {
+  gitSha: "1".repeat(40),
+  appVersionName: "1.0.4",
+  versionCode: "10005",
+};
+
+function candidate(overrides = {}) {
+  return { phase: "CANDIDATE", issue: 2056, releaseCandidateIdentity: identity, ...overrides };
+}
+
+async function fixtureRepoRoot({
+  widgetTestNames = [
+    "노선도 첫 화면은 하단 광고 위에 지도 조작을 유지한다",
+    "급행 운행 정보는 선택 UI 없이 시간표와 길찾기에 표시된다",
+    "역 시간표 화면은 일반·급행을 한 목록에 시각순으로 표시하고 급행 행에만 배지를 단다",
+  ],
+  requestTestNames = [
+    "toV2Json은 mobilityPreset이 있으면 body에 싣고 mobilityType도 함께 보낸다",
+    "toV2Json은 mobilityPreset이 없으면 키를 넣지 않는다",
+  ],
+  requestClassBody = "class RouteSearchRequest {\n  Map<String, Object?> toV2Json() => {};\n}\n",
+} = {}) {
+  const root = await mkdtemp(path.join(tmpdir(), "easysubway-mobile-evidence-"));
+  await mkdir(path.join(root, "apps/mobile/test"), { recursive: true });
+  await mkdir(path.join(root, "apps/mobile/lib"), { recursive: true });
+  await writeFile(
+    path.join(root, "apps/mobile/test/widget_test.dart"),
+    widgetTestNames.map((name) => `testWidgets('${name}', (tester) async {});\n`).join(""),
+  );
+  await writeFile(
+    path.join(root, "apps/mobile/test/route_search_request_test.dart"),
+    requestTestNames.map((name) => `test('${name}', () {});\n`).join(""),
+  );
+  await writeFile(path.join(root, "apps/mobile/lib/route_search.dart"), requestClassBody);
+  return root;
+}
+
+test("E1/E7/E8 tracked test·source가 모두 있으면 SATISFIED와 PASS matrix를 산출한다", async () => {
+  const repoRoot = await fixtureRepoRoot();
+  const evidence = buildMobileConsumptionEvidence({
+    candidate: candidate(),
+    repoRoot,
+    generatedAt: "2026-07-18T00:00:00.000Z",
+  });
+
+  assert.equal(evidence.schemaVersion, 1);
+  assert.equal(evidence.artifactKind, "route-v2-mobile-consumption-evidence");
+  assert.equal(evidence.sourceIssue, 2099);
+  assert.equal(evidence.status, "SATISFIED");
+  assert.deepEqual(evidence.releaseCandidateIdentity, identity);
+  assert.deepEqual(evidence.integrationScenarios, { E1: "PASS", E7: "PASS", E8: "PASS", E9: "FAIL" });
+  assert.equal(evidence.provenance, "final-candidate");
+});
+
+test("E9는 mobile ITX-청춘 표시 구현이 없어 항상 FAIL로 정직하게 남는다", async () => {
+  const repoRoot = await fixtureRepoRoot();
+  const evidence = buildMobileConsumptionEvidence({ candidate: candidate(), repoRoot });
+
+  assert.equal(evidence.integrationScenarios.E9, "FAIL");
+  assert.match(evidence.scenarioEvidence.E9.reasonKo, /ITX/);
+});
+
+test("E1/E7 test 이름이 tracked 파일에 없으면 FAIL로 fail closed한다", async () => {
+  const repoRoot = await fixtureRepoRoot({ widgetTestNames: ["다른 무관한 테스트"] });
+  const evidence = buildMobileConsumptionEvidence({ candidate: candidate(), repoRoot });
+
+  assert.equal(evidence.integrationScenarios.E1, "FAIL");
+  assert.equal(evidence.integrationScenarios.E7, "FAIL");
+  assert.equal(evidence.status, "BLOCKED_MOBILE_SCENARIO_EVIDENCE");
+});
+
+test("E8은 request 직렬화에 servicePattern/expressOnly 등 금지 필드가 있으면 FAIL한다", async () => {
+  const repoRoot = await fixtureRepoRoot({
+    requestClassBody: "class RouteSearchRequest {\n  Map<String, Object?> toV2Json() => {'servicePattern': 'EXPRESS'};\n}\n",
+  });
+  const evidence = buildMobileConsumptionEvidence({ candidate: candidate(), repoRoot });
+
+  assert.equal(evidence.integrationScenarios.E8, "FAIL");
+  assert.deepEqual(evidence.scenarioEvidence.E8.forbiddenFieldsFound, ["servicePattern"]);
+});
+
+test("CANDIDATE context가 아니면 거부한다", async () => {
+  const repoRoot = await fixtureRepoRoot();
+  assert.throws(
+    () => buildMobileConsumptionEvidence({ candidate: { phase: "FINAL", issue: 2056, releaseCandidateIdentity: identity }, repoRoot }),
+    /CANDIDATE context/,
+  );
+});
+
+test("실제 저장소 tracked source에 대해 실행하면 E1/E7/E8 PASS, E9 FAIL을 재현한다", () => {
+  const repoRoot = path.resolve(import.meta.dirname, "../..");
+  const evidence = buildMobileConsumptionEvidence({ candidate: candidate(), repoRoot });
+
+  assert.equal(evidence.integrationScenarios.E1, "PASS");
+  assert.equal(evidence.integrationScenarios.E7, "PASS");
+  assert.equal(evidence.integrationScenarios.E8, "PASS");
+  assert.equal(evidence.integrationScenarios.E9, "FAIL");
+});

--- a/tools/release/build-mobile-consumption-evidence.test.mjs
+++ b/tools/release/build-mobile-consumption-evidence.test.mjs
@@ -214,12 +214,13 @@ test("CANDIDATE context가 아니면 거부한다", async () => {
   );
 });
 
-test("현재 작업 브랜치 tracked source에 대해 실행하면 E1/E7/E8 PASS, E9는 ITX 배지 fix 병합 전이라 FAIL을 재현한다", () => {
+test("현재 작업 브랜치 tracked source에 대해 실행하면 E1/E7/E8/E9 모두 PASS를 재현한다(ITX 배지 fix #2245가 main에 병합됨, 4c5c93ef)", () => {
   const repoRoot = path.resolve(import.meta.dirname, "../..");
   const evidence = buildMobileConsumptionEvidence({ candidate: candidate(), repoRoot });
 
   assert.equal(evidence.integrationScenarios.E1, "PASS");
   assert.equal(evidence.integrationScenarios.E7, "PASS");
   assert.equal(evidence.integrationScenarios.E8, "PASS");
-  assert.equal(evidence.integrationScenarios.E9, "FAIL");
+  assert.equal(evidence.integrationScenarios.E9, "PASS");
+  assert.equal(evidence.status, "SATISFIED");
 });

--- a/tools/release/build-planner-success-evidence.mjs
+++ b/tools/release/build-planner-success-evidence.mjs
@@ -4,6 +4,7 @@ import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { loadFixtures, runRangeRaptor, runTimeDependentDijkstra } from "../routes/prototype-route-v2.mjs";
+import { buildBackendTimetableSeed } from "../datapack/build-backend-timetable-seed.mjs";
 
 const API_CATALOG_ID = "internal:POST:/api/v2/routes/search:com.easysubway.route.adapter.in.web.RouteSearchController#searchRouteV2";
 const SHA256 = /^[0-9a-f]{64}$/;
@@ -28,14 +29,40 @@ const REGRESSION_1228_FIXTURE_IDS = {
   unmatchedRealtime: "unmatched_realtime_express_does_not_override_planned_local",
 };
 
-// 이슈 #1414 NO_GO #2("final seed의 missing/unknown pattern을 LOCAL로 default함")를 구조적으로
-// 방지하는 backend 증거 참조. TimetableSeedLoader는 로드 시 service_pattern이 LOCAL/EXPRESS가
-// 아닌 trip이 하나라도 있으면 활성화를 fail-closed로 거부한다(defaulting이 아니라 거부).
+// 이슈 #1414 NO_GO #2("final seed의 missing/unknown pattern을 LOCAL로 default함")를 방지하는
+// backend 증거 참조(보조 정보 — 아래 verifySeedRejectsUnknownServicePattern이 실측하는
+// seed-authoring-time guard와는 다른 계층이다). TimetableSeedLoader는 로드 시 service_pattern이
+// LOCAL/EXPRESS가 아닌 trip이 하나라도 있으면 활성화를 fail-closed로 거부한다.
 const SEED_PATTERN_GUARD = {
   assertionSourceFile: "backend/src/main/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoader.java",
   assertionLabel: "trip service pattern identity",
   verifiedByTest: "backend/src/test/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoaderTest.java::trackedCompleteSnapshotLoadsWithExactEvidenceCounts",
 };
+
+// checks.unknownPatternDefaultedToLocal을 하드코딩 주장이 아니라 실제 실행으로 검증한다.
+// tools/datapack/build-backend-timetable-seed.mjs의 buildBackendTimetableSeed는 production
+// backend seed SQL을 만드는 데도 쓰이는 동일 함수이며, 내부 validateTrips가 servicePattern이
+// 명시적으로 LOCAL/EXPRESS가 아니면 예외를 던진다(tools/datapack/build-backend-timetable-seed.test.mjs
+// :91 "final seed는 모든 trip의 explicit LOCAL/EXPRESS servicePattern을 요구한다"가 이를 고정).
+// 여기서는 그 test를 재작성하지 않고, undefined pattern으로 이 tracked 함수를 실제 호출해
+// 예외가 실제로 나는지 동적으로 재현한다.
+export function verifySeedRejectsUnknownServicePattern() {
+  const probeTrip = {
+    id: "evidence-probe-trip",
+    routeId: "evidence-probe-route",
+    serviceId: "evidence-probe-service",
+    tripHeadsign: "evidence-probe-headsign",
+    directionId: "up",
+    servicePattern: undefined,
+  };
+  try {
+    buildBackendTimetableSeed({ transitTrips: [probeTrip] });
+    return { rejected: false, errorMessage: null };
+  } catch (error) {
+    const rejected = /service_pattern must be explicitly LOCAL or EXPRESS/.test(error.message);
+    return { rejected, errorMessage: error.message };
+  }
+}
 
 function fixtureResultMatches(query, result) {
   if (query.expectedArrival === null) return result === null;
@@ -120,6 +147,23 @@ export function buildPlannerSuccessEvidence({
       Object.entries(regressionEvidence.regression1228).map(([key, passed]) => [key, passed ? "SATISFIED" : "FAILED"]),
     )
     : null;
+  const seedPatternGuardProbe = verifySeedRejectsUnknownServicePattern();
+  const checks = {
+    deterministicRepresentativeRanking: "SATISFIED",
+    officialFare: "SATISFIED",
+    exactPlannedTimes: "SATISFIED",
+    typedRideMetadata: "SATISFIED",
+    topologyTimetableLinkage: "SATISFIED",
+    candidateTopologyIdentity: topologyBound ? "SATISFIED" : "BLOCKED",
+    signedReleaseCandidate: signedRcBound ? "SATISFIED" : "BLOCKED",
+  };
+  // seedPatternGuardProbe.rejected가 실제로 true일 때만(즉 tracked seed builder를 방금 실행해
+  // undefined pattern이 실제로 거부됨을 확인했을 때만) false를 채운다. 예상과 다르게 거부되지
+  // 않으면(가드가 깨졌거나 에러 메시지가 바뀜) 안전하다고 단정하지 않고 필드를 비워
+  // verdict가 "attestation 없음"으로 fail-closed 처리하게 한다.
+  if (seedPatternGuardProbe.rejected) {
+    checks.unknownPatternDefaultedToLocal = false;
+  }
   return {
     schemaVersion: 1,
     artifactKind: "route-v2-planner-success-evidence",
@@ -140,19 +184,8 @@ export function buildPlannerSuccessEvidence({
     regression1228: regression1228Checks,
     regressionFixturesSha256: regressionEvidence?.fixturesSha256 ?? null,
     seedPatternGuard: SEED_PATTERN_GUARD,
-    checks: {
-      deterministicRepresentativeRanking: "SATISFIED",
-      officialFare: "SATISFIED",
-      exactPlannedTimes: "SATISFIED",
-      typedRideMetadata: "SATISFIED",
-      topologyTimetableLinkage: "SATISFIED",
-      candidateTopologyIdentity: topologyBound ? "SATISFIED" : "BLOCKED",
-      signedReleaseCandidate: signedRcBound ? "SATISFIED" : "BLOCKED",
-      // canary의 모든 RIDE leg가 LOCAL/EXPRESS 중 하나로 명시된다(validateCanary가 이를 강제하므로
-      // 이 함수에 도달했다는 것 자체가 unknown pattern이 관측되지 않았다는 증거다). backend seed
-      // loader는 이를 defaulting이 아니라 fail-closed 거부로 구조적으로 보장한다(SEED_PATTERN_GUARD).
-      unknownPatternDefaultedToLocal: false,
-    },
+    seedPatternGuardProbe,
+    checks,
   };
 }
 

--- a/tools/release/build-planner-success-evidence.mjs
+++ b/tools/release/build-planner-success-evidence.mjs
@@ -3,11 +3,97 @@ import { createHash } from "node:crypto";
 import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { loadFixtures, runRangeRaptor, runTimeDependentDijkstra } from "../routes/prototype-route-v2.mjs";
 
 const API_CATALOG_ID = "internal:POST:/api/v2/routes/search:com.easysubway.route.adapter.in.web.RouteSearchController#searchRouteV2";
 const SHA256 = /^[0-9a-f]{64}$/;
 
-export function buildPlannerSuccessEvidence({ candidate, canary, generatedAt = new Date().toISOString() }) {
+// #1414 E2~E6 통합 시나리오를 tools/routes/route-v2-fixtures.json의 #1228 회귀 fixture id에 연결한다.
+// prototype-route-v2.mjs(추적된 RAPTOR/Dijkstra 참조 구현)를 재실행해 실제 시나리오 결과를 재검증하며,
+// planner 알고리즘 자체를 재구현하지 않는다.
+const SCENARIO_FIXTURE_IDS = {
+  E2: "express_beats_local",
+  E3: "express_skips_intermediate_stop",
+  E4: "missed_express_makes_local_faster",
+  E5: "provider_realtime_stale",
+  E6: "unmatched_realtime_express_does_not_override_planned_local",
+};
+
+// #1228 회귀 5종(express-skip, express-faster, local-faster-when-waiting, short-turn, unmatched-realtime).
+const REGRESSION_1228_FIXTURE_IDS = {
+  expressSkip: "express_skips_intermediate_stop",
+  expressFaster: "express_beats_local",
+  localFasterWhenWaiting: "missed_express_makes_local_faster",
+  shortTurn: "short_turn_does_not_route_past_terminal",
+  unmatchedRealtime: "unmatched_realtime_express_does_not_override_planned_local",
+};
+
+// 이슈 #1414 NO_GO #2("final seed의 missing/unknown pattern을 LOCAL로 default함")를 구조적으로
+// 방지하는 backend 증거 참조. TimetableSeedLoader는 로드 시 service_pattern이 LOCAL/EXPRESS가
+// 아닌 trip이 하나라도 있으면 활성화를 fail-closed로 거부한다(defaulting이 아니라 거부).
+const SEED_PATTERN_GUARD = {
+  assertionSourceFile: "backend/src/main/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoader.java",
+  assertionLabel: "trip service pattern identity",
+  verifiedByTest: "backend/src/test/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoaderTest.java::trackedCompleteSnapshotLoadsWithExactEvidenceCounts",
+};
+
+function fixtureResultMatches(query, result) {
+  if (query.expectedArrival === null) return result === null;
+  if (!result) return false;
+  if (result.arrival !== query.expectedArrival) return false;
+  if (query.expectedDurationSeconds !== undefined && result.durationSeconds !== query.expectedDurationSeconds) return false;
+  if (result.transferCount !== query.expectedTransfers) return false;
+  if (JSON.stringify(result.tripIds) !== JSON.stringify(query.expectedTripIds)) return false;
+  const rideSteps = (result.path ?? []).filter((step) => step.type === "ride");
+  const checks = [
+    ["expectedServicePatterns", rideSteps.map((step) => step.servicePattern)],
+    ["expectedHeadsigns", rideSteps.map((step) => step.headsign)],
+    ["expectedDirections", rideSteps.map((step) => step.directionId)],
+    ["expectedDestinationStationIds", rideSteps.map((step) => step.destinationStationId)],
+    ["expectedStopPatterns", rideSteps.map((step) => step.stopPattern)],
+    ["expectedRealtimeMatchLevels", rideSteps.map((step) => step.realtimeMatchLevel)],
+  ];
+  for (const [field, actual] of checks) {
+    if (query[field] === undefined) continue;
+    if (JSON.stringify(actual) !== JSON.stringify(query[field])) return false;
+  }
+  return true;
+}
+
+function passesFixture(fixtures, fixtureId) {
+  const query = fixtures.queries.find((candidate) => candidate.id === fixtureId);
+  if (!query) throw new Error(`missing route-v2 regression fixture: ${fixtureId}`);
+  return [runRangeRaptor, runTimeDependentDijkstra].every(
+    (runner) => fixtureResultMatches(query, runner(fixtures, query)[0] ?? null),
+  );
+}
+
+// #2098 fragment의 E2~E6 attestation과 #1228 회귀 checks를 tracked fixture 재실행으로 산출한다.
+export async function evaluateRouteV2RegressionFixtures(fixturesPath) {
+  const fixtures = await loadFixtures(fixturesPath);
+  const scenarios = Object.fromEntries(
+    Object.entries(SCENARIO_FIXTURE_IDS).map(([scenarioId, fixtureId]) => [
+      scenarioId,
+      passesFixture(fixtures, fixtureId),
+    ]),
+  );
+  const regression1228 = Object.fromEntries(
+    Object.entries(REGRESSION_1228_FIXTURE_IDS).map(([key, fixtureId]) => [key, passesFixture(fixtures, fixtureId)]),
+  );
+  return {
+    scenarios,
+    regression1228,
+    fixturesSha256: sha256(Buffer.from(JSON.stringify(fixtures))),
+  };
+}
+
+export function buildPlannerSuccessEvidence({
+  candidate,
+  canary,
+  generatedAt = new Date().toISOString(),
+  provenance = "final-candidate",
+  regressionEvidence = null,
+}) {
   const identity = candidate?.releaseCandidateIdentity;
   if (candidate?.phase !== "CANDIDATE" || candidate?.issue !== 2056 || !identity) {
     throw new Error("planner evidence requires the #2056 CANDIDATE context");
@@ -19,12 +105,28 @@ export function buildPlannerSuccessEvidence({ candidate, canary, generatedAt = n
   const topologyBound = SHA256.test(identity.dataPackArtifactSha256 ?? "")
     && canary.plan.plannerIdentity.canonicalPackSha256 === identity.dataPackArtifactSha256;
   const canarySha256 = sha256(Buffer.from(JSON.stringify(canary)));
+  // #1414 route integration verdict가 소비하는 필드: same-RC provenance와 E2~E6 scenario attestation.
+  const integrationScenarios = regressionEvidence
+    ? Object.fromEntries(
+      Object.entries(regressionEvidence.scenarios).map(([scenarioId, passed]) => [scenarioId, passed ? "PASS" : "FAIL"]),
+    )
+    : {};
+  // E9는 route-v2-fixtures.json에 ITX 시나리오가 없어 regressionEvidence로 attest할 수 없다.
+  // 이미 validateCanary가 강제한 실제 canary RIDE leg 내용에서 ITX_CHEONGCHUN/EXPRESS 존재를
+  // 직접 재확인한다(별도 알고리즘 재구현이 아니라 이미 검증된 canary 데이터의 필드 스캔).
+  integrationScenarios.E9 = hasItxExpressRide(canary) ? "PASS" : "FAIL";
+  const regression1228Checks = regressionEvidence
+    ? Object.fromEntries(
+      Object.entries(regressionEvidence.regression1228).map(([key, passed]) => [key, passed ? "SATISFIED" : "FAILED"]),
+    )
+    : null;
   return {
     schemaVersion: 1,
     artifactKind: "route-v2-planner-success-evidence",
     sourceIssue: 2098,
     consumerIssue: 2056,
     generatedAt,
+    provenance,
     status: signedRcBound && topologyBound
       ? "SATISFIED"
       : signedRcBound ? "BLOCKED_CANDIDATE_TOPOLOGY_IDENTITY" : "BLOCKED_SIGNED_RC_IDENTITY",
@@ -34,6 +136,10 @@ export function buildPlannerSuccessEvidence({ candidate, canary, generatedAt = n
     timetableArtifactId: canary.plan.timetableArtifactId,
     canaryResultSha256: canarySha256,
     canaryResult: canary,
+    integrationScenarios,
+    regression1228: regression1228Checks,
+    regressionFixturesSha256: regressionEvidence?.fixturesSha256 ?? null,
+    seedPatternGuard: SEED_PATTERN_GUARD,
     checks: {
       deterministicRepresentativeRanking: "SATISFIED",
       officialFare: "SATISFIED",
@@ -42,8 +148,19 @@ export function buildPlannerSuccessEvidence({ candidate, canary, generatedAt = n
       topologyTimetableLinkage: "SATISFIED",
       candidateTopologyIdentity: topologyBound ? "SATISFIED" : "BLOCKED",
       signedReleaseCandidate: signedRcBound ? "SATISFIED" : "BLOCKED",
+      // canary의 모든 RIDE leg가 LOCAL/EXPRESS 중 하나로 명시된다(validateCanary가 이를 강제하므로
+      // 이 함수에 도달했다는 것 자체가 unknown pattern이 관측되지 않았다는 증거다). backend seed
+      // loader는 이를 defaulting이 아니라 fail-closed 거부로 구조적으로 보장한다(SEED_PATTERN_GUARD).
+      unknownPatternDefaultedToLocal: false,
     },
   };
+}
+
+function hasItxExpressRide(canary) {
+  return (canary.plan.itineraries ?? []).some((itinerary) =>
+    (itinerary.steps ?? []).some(
+      (step) => step.stepType === "ride" && step.serviceClass === "ITX_CHEONGCHUN" && step.servicePattern === "EXPRESS",
+    ));
 }
 
 function validateCanary(canary) {
@@ -120,9 +237,16 @@ if (entry === fileURLToPath(import.meta.url)) {
   if (!candidatePath || !canaryPath || !outputPath) {
     throw new Error("--candidate-context, --canary-result and --output are required");
   }
+  const provenance = argument("provenance") ?? "final-candidate";
+  const skipRegression = argument("skip-regression-fixtures") === "true";
+  const regressionEvidence = skipRegression
+    ? null
+    : await evaluateRouteV2RegressionFixtures(argument("regression-fixtures") ?? undefined);
   const evidence = buildPlannerSuccessEvidence({
     candidate: JSON.parse(readFileSync(candidatePath, "utf8")),
     canary: JSON.parse(readFileSync(canaryPath, "utf8")),
+    provenance,
+    regressionEvidence,
   });
   writeFileSync(outputPath, `${JSON.stringify(evidence, null, 2)}\n`);
 }

--- a/tools/release/build-planner-success-evidence.test.mjs
+++ b/tools/release/build-planner-success-evidence.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { buildPlannerSuccessEvidence } from "./build-planner-success-evidence.mjs";
+import { buildPlannerSuccessEvidence, evaluateRouteV2RegressionFixtures } from "./build-planner-success-evidence.mjs";
 
 const identity = {
   gitSha: "1".repeat(40),
@@ -94,4 +94,70 @@ test("official fare나 typed ITX RIDE가 없는 canary는 거부한다", () => {
     candidate: { phase: "CANDIDATE", issue: 2056, releaseCandidateIdentity: identity },
     canary: invalid,
   }), /official fare/);
+});
+
+test("provenance는 기본 final-candidate이며 unknownPatternDefaultedToLocal은 false를 명시한다", () => {
+  const evidence = buildPlannerSuccessEvidence({
+    candidate: { phase: "CANDIDATE", issue: 2056, releaseCandidateIdentity: identity },
+    canary: canary(),
+  });
+
+  assert.equal(evidence.provenance, "final-candidate");
+  assert.equal(evidence.checks.unknownPatternDefaultedToLocal, false);
+  // E9는 regressionEvidence 없이도 canary 자체의 ITX_CHEONGCHUN/EXPRESS ride 존재로 attest된다.
+  assert.deepEqual(evidence.integrationScenarios, { E9: "PASS" });
+  assert.equal(evidence.regression1228, null);
+});
+
+test("E9는 canary에 ITX_CHEONGCHUN/EXPRESS ride가 없으면 FAIL로 attest한다", () => {
+  const noItxCanary = canary();
+  noItxCanary.plan.itineraries[0].steps = noItxCanary.plan.itineraries[0].steps.map((step) =>
+    step.serviceClass === "ITX_CHEONGCHUN" ? { ...step, servicePattern: "LOCAL" } : step);
+
+  const evidence = buildPlannerSuccessEvidence({
+    candidate: { phase: "CANDIDATE", issue: 2056, releaseCandidateIdentity: identity },
+    canary: noItxCanary,
+  });
+
+  assert.equal(evidence.integrationScenarios.E9, "FAIL");
+});
+
+test("provenance는 override 가능하다(fixture-only 판정 테스트용)", () => {
+  const evidence = buildPlannerSuccessEvidence({
+    candidate: { phase: "CANDIDATE", issue: 2056, releaseCandidateIdentity: identity },
+    canary: canary(),
+    provenance: "fixture",
+  });
+
+  assert.equal(evidence.provenance, "fixture");
+});
+
+test("regressionEvidence가 주어지면 E2~E6 integrationScenarios와 #1228 checks로 매핑한다", () => {
+  const evidence = buildPlannerSuccessEvidence({
+    candidate: { phase: "CANDIDATE", issue: 2056, releaseCandidateIdentity: identity },
+    canary: canary(),
+    regressionEvidence: {
+      scenarios: { E2: true, E3: true, E4: false, E5: true, E6: true },
+      regression1228: { expressSkip: true, expressFaster: true, localFasterWhenWaiting: false, shortTurn: true, unmatchedRealtime: true },
+      fixturesSha256: "a".repeat(64),
+    },
+  });
+
+  assert.deepEqual(evidence.integrationScenarios, { E2: "PASS", E3: "PASS", E4: "FAIL", E5: "PASS", E6: "PASS", E9: "PASS" });
+  assert.equal(evidence.regression1228.localFasterWhenWaiting, "FAILED");
+  assert.equal(evidence.regressionFixturesSha256, "a".repeat(64));
+});
+
+test("evaluateRouteV2RegressionFixtures는 tracked #1228 fixture를 실제로 재실행해 전부 PASS를 산출한다", async () => {
+  const result = await evaluateRouteV2RegressionFixtures();
+
+  assert.deepEqual(result.scenarios, { E2: true, E3: true, E4: true, E5: true, E6: true });
+  assert.deepEqual(result.regression1228, {
+    expressSkip: true,
+    expressFaster: true,
+    localFasterWhenWaiting: true,
+    shortTurn: true,
+    unmatchedRealtime: true,
+  });
+  assert.match(result.fixturesSha256, /^[0-9a-f]{64}$/);
 });

--- a/tools/release/build-planner-success-evidence.test.mjs
+++ b/tools/release/build-planner-success-evidence.test.mjs
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { buildPlannerSuccessEvidence, evaluateRouteV2RegressionFixtures } from "./build-planner-success-evidence.mjs";
+import {
+  buildPlannerSuccessEvidence,
+  evaluateRouteV2RegressionFixtures,
+  verifySeedRejectsUnknownServicePattern,
+} from "./build-planner-success-evidence.mjs";
 
 const identity = {
   gitSha: "1".repeat(40),
@@ -104,6 +108,13 @@ test("provenance는 기본 final-candidate이며 unknownPatternDefaultedToLocal�
 
   assert.equal(evidence.provenance, "final-candidate");
   assert.equal(evidence.checks.unknownPatternDefaultedToLocal, false);
+  // 하드코딩 주장이 아니라 tracked build-backend-timetable-seed.mjs를 실제로 undefined
+  // pattern으로 호출해 예외가 실제로 발생함을 재현한 결과여야 한다.
+  assert.equal(evidence.seedPatternGuardProbe.rejected, true);
+  assert.match(
+    evidence.seedPatternGuardProbe.errorMessage,
+    /service_pattern must be explicitly LOCAL or EXPRESS/,
+  );
   // E9는 regressionEvidence 없이도 canary 자체의 ITX_CHEONGCHUN/EXPRESS ride 존재로 attest된다.
   assert.deepEqual(evidence.integrationScenarios, { E9: "PASS" });
   assert.equal(evidence.regression1228, null);
@@ -160,4 +171,11 @@ test("evaluateRouteV2RegressionFixtures는 tracked #1228 fixture를 실제로 �
     unmatchedRealtime: true,
   });
   assert.match(result.fixturesSha256, /^[0-9a-f]{64}$/);
+});
+
+test("verifySeedRejectsUnknownServicePattern은 tracked seed builder를 실제로 호출해 undefined pattern 거부를 재현한다", () => {
+  const result = verifySeedRejectsUnknownServicePattern();
+
+  assert.equal(result.rejected, true);
+  assert.match(result.errorMessage, /service_pattern must be explicitly LOCAL or EXPRESS/);
 });

--- a/tools/release/generate-route-integration-verdict.mjs
+++ b/tools/release/generate-route-integration-verdict.mjs
@@ -1,0 +1,535 @@
+#!/usr/bin/env node
+
+// #1414 route/datapack 통합 출시 판정 producer.
+// #2068 route-map, #2098 planner, #2099 Mobile, #1400 topology, #2145 timetable evidence를
+// 같은 RC identity로 결합해 E1~E9 통합 matrix와 same-RC identity 판정을 산출한다.
+// 이 producer는 evidence를 새로 만들지 않고 조합 안전성만 fail-closed로 판정한다.
+
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ISSUE_TRACKER_BASE = "https://github.com/AquilaXk/easysubway/issues";
+export const ROUTE_SEARCH_CATALOG_ID =
+  "internal:POST:/api/v2/routes/search:com.easysubway.route.adapter.in.web.RouteSearchController#searchRouteV2";
+const ROUTE_SEARCH_CONTRACT_VERSION = "ROUTE_SEARCH_V2";
+
+// 같은 RC identity 판정에 사용하는 필드. 서로 다른 producer evidence가 같은 후보를 소비했는지 검증한다.
+const RC_IDENTITY_FIELDS = [
+  "gitSha",
+  "appVersionName",
+  "versionCode",
+  "backendImageDigest",
+  "backendArtifactSha256",
+  "dataPackManifestSha256",
+  "dataPackArtifactSha256",
+  "routeContractVersion",
+  "realtimeContractVersion",
+];
+// 최소한 값이 있어야 하는(fail-closed) 앵커 필드.
+const RC_IDENTITY_ANCHOR_FIELDS = ["gitSha", "versionCode", "dataPackArtifactSha256"];
+
+const VALID_PROVENANCE = new Set(["final-candidate", "production", "manual-observation"]);
+
+// E1~E9 통합 시나리오 카탈로그. 각 시나리오를 실존 producer evidence·test에 연결한다.
+// owner: 시나리오 결과의 attestation을 소유한 evidence 입력.
+export const ROUTE_INTEGRATION_SCENARIOS = [
+  {
+    id: "E1",
+    titleKo: "LOCAL/EXPRESS가 함께 있는 지역 노선도에 일반/급행 control 0건, 전체 topology 표시",
+    producerIssue: 2068,
+    owner: "routeMap",
+    evidenceTests: [
+      "apps/mobile/test/widget_test.dart::노선도는 노선별 보기 우회 sheet를 노출하지 않는다",
+      "docs/2099-qa/item4_routemap_no_express_toggle.png",
+      "docs/2099-qa/item5_talkback_dump.xml",
+    ],
+    guardsNoGo: ["route_map_local_express_control_present"],
+  },
+  {
+    id: "E2",
+    titleKo: "EXPRESS가 OD 모두 정차하고 실제 도착이 더 빠르면 EXPRESS 선택, 급행 정보 표시",
+    producerIssue: 2098,
+    owner: "planner",
+    evidenceTests: [
+      "tools/routes/prototype-route-v2.test.mjs::express_beats_local",
+      "tools/routes/prototype-route-v2.test.mjs::direct_timetable_route",
+    ],
+    guardsNoGo: ["ride_leg_missing_service_metadata"],
+  },
+  {
+    id: "E3",
+    titleKo: "EXPRESS가 목적역 통과 시 EXPRESS 승하차 후보 0건, 유효 LOCAL 선택",
+    producerIssue: 2098,
+    owner: "planner",
+    evidenceTests: [
+      "tools/routes/prototype-route-v2.test.mjs::express_skips_intermediate_stop",
+    ],
+    guardsNoGo: ["express_skip_stop_boardable"],
+  },
+  {
+    id: "E4",
+    titleKo: "EXPRESS 출발 대기로 LOCAL이 먼저 도착하면 LOCAL 선택, 급행 배지 0건",
+    producerIssue: 2098,
+    owner: "planner",
+    evidenceTests: [
+      "tools/routes/prototype-route-v2.test.mjs::missed_express_makes_local_faster",
+      "backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerGoldenOdTest.java::od3_missedExpressAnchorsToNextLocalTrain",
+    ],
+    guardsNoGo: [],
+  },
+  {
+    id: "E5",
+    titleKo: "matched EXPRESS realtime는 같은 trip/direction/pattern 시각만 보정, 급행 배지 유지",
+    producerIssue: 2098,
+    owner: "planner",
+    evidenceTests: [
+      "tools/routes/prototype-route-v2.test.mjs::provider_realtime_stale",
+      "backend/src/test/java/com/easysubway/route/domain/RealtimeEtaOverlayTest.java::freshRealtimeCandidateCanMatchCanonicalServicePattern",
+    ],
+    guardsNoGo: ["realtime_mismatch_overrides_planned"],
+  },
+  {
+    id: "E6",
+    titleKo: "pattern mismatch 또는 unmatched realtime는 planned trip/pattern 보존, 운행종별 치환 0건",
+    producerIssue: 2098,
+    owner: "planner",
+    evidenceTests: [
+      "tools/routes/prototype-route-v2.test.mjs::unmatched_realtime_express_does_not_override_planned_local",
+      "backend/src/test/java/com/easysubway/route/domain/RealtimeEtaOverlayTest.java::freshRealtimeCandidateRequiresMatchingServicePattern",
+    ],
+    guardsNoGo: ["realtime_mismatch_overrides_planned"],
+  },
+  {
+    id: "E7",
+    titleKo: "mixed station timetable에서 LOCAL/EXPRESS 모두 시각순 표시, EXPRESS 행만 급행",
+    producerIssue: 2099,
+    owner: "mobile",
+    evidenceTests: [
+      "backend/src/test/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoaderTest.java",
+      "docs/2099-qa/item3_express_badge_timetable.png",
+      "docs/2099-qa/item5_talkback_dump.xml",
+    ],
+    guardsNoGo: [],
+  },
+  {
+    id: "E8",
+    titleKo: "Route V2 request/network trace에 일반/급행 선택 필드 0건",
+    producerIssue: 2099,
+    owner: "mobile",
+    evidenceTests: [
+      "apps/mobile/test/route_search_request_test.dart",
+    ],
+    guardsNoGo: [],
+  },
+  {
+    id: "E9",
+    titleKo: "ITX_CHEONGCHUN/EXPRESS는 ITX-청춘으로 표시, generic 급행 중복 0건",
+    producerIssue: 2098,
+    owner: "planner",
+    evidenceTests: [
+      "apps/mobile/test/route_v2_ingress_test.dart::ITX_TIMETABLE_UNAVAILABLE을 SUBWAY로 자동 강등하지 않는다",
+    ],
+    guardsNoGo: ["itx_shown_as_generic_or_local_badged"],
+  },
+];
+
+// NO_GO 조건 카탈로그(이슈 본문 7개 + fixture-only fail-closed).
+const NO_GO_CONDITIONS = [
+  "route_map_local_express_control_present",
+  "unknown_pattern_defaulted_to_local",
+  "ride_leg_missing_service_metadata",
+  "express_skip_stop_boardable",
+  "itx_shown_as_generic_or_local_badged",
+  "realtime_mismatch_overrides_planned",
+  "mixed_rc_or_artifact_identity",
+  "fixture_only_evidence",
+];
+
+function issueUrl(issue) {
+  return `${ISSUE_TRACKER_BASE}/${issue}`;
+}
+
+function readIdentity(source) {
+  if (!source || typeof source !== "object") return null;
+  return source.releaseCandidateIdentity ?? source.rcIdentity ?? null;
+}
+
+// 두 identity가 같은 RC를 가리키는지 비교한다. 불일치 필드 목록을 반환한다(빈 배열이면 일치).
+function identityMismatchFields(canonical, candidate) {
+  const mismatches = [];
+  for (const field of RC_IDENTITY_FIELDS) {
+    const left = canonical?.[field] ?? null;
+    const right = candidate?.[field] ?? null;
+    if (left !== right) mismatches.push(field);
+  }
+  return mismatches;
+}
+
+function anchorIncomplete(identity) {
+  return RC_IDENTITY_ANCHOR_FIELDS.filter(
+    (field) => identity?.[field] === undefined || identity?.[field] === null || identity?.[field] === "",
+  );
+}
+
+// planner canary itinerary의 모든 RIDE step이 serviceClass/servicePattern을 갖는지 검사한다(NO_GO #3).
+// 반환: { rideLegs, missingMetadata, expressSkipBoardable, hasItxExpress }
+function inspectPlannerRideMetadata(plannerEvidence) {
+  const result = { rideLegs: 0, missingMetadata: false, hasItxExpress: false };
+  const itineraries = plannerEvidence?.canaryResult?.plan?.itineraries;
+  if (!Array.isArray(itineraries)) {
+    // planner evidence가 있는데 itinerary 구조가 없으면 fail-closed.
+    return { ...result, missingMetadata: true, structureMissing: true };
+  }
+  for (const itinerary of itineraries) {
+    for (const step of itinerary?.steps ?? []) {
+      if (step?.stepType !== "ride") continue;
+      result.rideLegs += 1;
+      const serviceClass = step?.serviceClass ?? null;
+      const servicePattern = step?.servicePattern ?? null;
+      if (!serviceClass || !servicePattern) {
+        result.missingMetadata = true;
+      }
+      if (serviceClass === "ITX_CHEONGCHUN" && servicePattern === "EXPRESS") {
+        result.hasItxExpress = true;
+      }
+    }
+  }
+  return result;
+}
+
+function scenarioAttestation(ownerEvidence, scenarioId) {
+  const attestations = ownerEvidence?.integrationScenarios;
+  if (!attestations || typeof attestations !== "object") return undefined;
+  return attestations[scenarioId];
+}
+
+// 개별 evidence 입력의 identity·provenance를 canonical과 비교한다.
+function evaluateEvidenceInput(name, evidence, canonicalIdentity, allowFixtureProvenance) {
+  if (!evidence) return { name, present: false };
+  const identity = readIdentity(evidence);
+  const mismatchFields = identity ? identityMismatchFields(canonicalIdentity, identity) : RC_IDENTITY_FIELDS;
+  const provenance = evidence.provenance ?? null;
+  const fixtureOnly = provenance === "fixture" || evidence.fixtureOnly === true;
+  const provenanceValid = allowFixtureProvenance ? true : VALID_PROVENANCE.has(provenance);
+  return {
+    name,
+    present: true,
+    identity,
+    identityMatches: identity !== null && mismatchFields.length === 0,
+    mismatchFields,
+    provenance,
+    fixtureOnly,
+    provenanceValid,
+    sourceIssue: evidence.sourceIssue ?? null,
+    testRunUrl: evidence.testRunUrl ?? null,
+  };
+}
+
+export function buildRouteIntegrationVerdict(inputs) {
+  const {
+    rcManifest,
+    plannerEvidence = null,
+    mobileEvidence = null,
+    routeMapEvidence = null,
+    timetableEvidence = null,
+    generatedAt = new Date().toISOString(),
+    allowFixtureProvenance = false,
+  } = inputs;
+
+  if (!rcManifest) throw new Error("rcManifest is required");
+  const canonicalIdentity = readIdentity(rcManifest);
+  if (!canonicalIdentity) throw new Error("rcManifest must expose releaseCandidateIdentity or rcIdentity");
+
+  const evidenceByOwner = {
+    planner: plannerEvidence,
+    mobile: mobileEvidence,
+    routeMap: routeMapEvidence,
+    timetable: timetableEvidence,
+  };
+  const evaluations = Object.fromEntries(
+    Object.entries(evidenceByOwner).map(([name, evidence]) => [
+      name,
+      evaluateEvidenceInput(name, evidence, canonicalIdentity, allowFixtureProvenance),
+    ]),
+  );
+
+  const plannerRide = plannerEvidence ? inspectPlannerRideMetadata(plannerEvidence) : null;
+
+  // NO_GO 조건 판정. triggered=true면 판정을 NO_GO로 만든다. unresolved=증거 부족으로 GO 확정 불가.
+  const noGo = new Map(NO_GO_CONDITIONS.map((id) => [id, { id, triggered: false, unresolved: false, reasons: [] }]));
+  const trip = (id, reason) => {
+    const entry = noGo.get(id);
+    entry.triggered = true;
+    entry.reasons.push(reason);
+  };
+  const unresolved = (id, reason) => {
+    const entry = noGo.get(id);
+    entry.unresolved = true;
+    entry.reasons.push(reason);
+  };
+
+  // #7 mixed RC/artifact identity.
+  for (const evaluation of Object.values(evaluations)) {
+    if (!evaluation.present) continue;
+    if (!evaluation.identityMatches) {
+      trip(
+        "mixed_rc_or_artifact_identity",
+        `${evaluation.name} identity mismatch: ${(evaluation.mismatchFields ?? []).join(", ") || "missing identity"}`,
+      );
+    }
+  }
+  const canonicalAnchorGaps = anchorIncomplete(canonicalIdentity);
+  if (canonicalAnchorGaps.length > 0) {
+    trip("mixed_rc_or_artifact_identity", `canonical identity missing anchor fields: ${canonicalAnchorGaps.join(", ")}`);
+  }
+  // planner artifact identity linkage: canonicalPackSha256이 datapack artifact와 일치해야 한다.
+  if (plannerEvidence) {
+    const canonicalPackSha256 = plannerEvidence?.plannerIdentity?.canonicalPackSha256 ?? null;
+    if (canonicalPackSha256 !== (canonicalIdentity.dataPackArtifactSha256 ?? null)) {
+      trip(
+        "mixed_rc_or_artifact_identity",
+        "planner canonicalPackSha256 does not match RC dataPackArtifactSha256",
+      );
+    }
+  }
+
+  // fixture-only fail-closed.
+  for (const evaluation of Object.values(evaluations)) {
+    if (!evaluation.present) continue;
+    if (evaluation.fixtureOnly && !allowFixtureProvenance) {
+      trip("fixture_only_evidence", `${evaluation.name} evidence is fixture-only`);
+    } else if (!evaluation.provenanceValid) {
+      unresolved(
+        "fixture_only_evidence",
+        `${evaluation.name} evidence provenance is not one of ${[...VALID_PROVENANCE].join(", ")}`,
+      );
+    }
+  }
+
+  // #3 ride leg가 serviceClass/servicePattern 없이 성공 응답.
+  if (plannerEvidence) {
+    if (plannerRide.structureMissing) {
+      unresolved("ride_leg_missing_service_metadata", "planner evidence has no canary itinerary structure");
+    } else if (plannerRide.rideLegs === 0) {
+      unresolved("ride_leg_missing_service_metadata", "planner evidence exposes no RIDE legs");
+    } else if (plannerRide.missingMetadata) {
+      trip("ride_leg_missing_service_metadata", "a planner RIDE leg is missing serviceClass or servicePattern");
+    }
+  } else {
+    unresolved("ride_leg_missing_service_metadata", "planner evidence not provided");
+  }
+
+  // scenario matrix 판정.
+  const scenarioMatrix = ROUTE_INTEGRATION_SCENARIOS.map((scenario) => {
+    const evaluation = evaluations[scenario.owner];
+    const reasons = [];
+    let result;
+    if (!evaluation.present) {
+      result = "PENDING";
+      reasons.push(`${scenario.owner} evidence not provided`);
+    } else if (!evaluation.identityMatches) {
+      result = "FAIL";
+      reasons.push(`${scenario.owner} evidence identity does not match the RC candidate`);
+    } else if (evaluation.fixtureOnly && !allowFixtureProvenance) {
+      result = "FAIL";
+      reasons.push(`${scenario.owner} evidence is fixture-only`);
+    } else if (!evaluation.provenanceValid) {
+      result = "PENDING";
+      reasons.push(`${scenario.owner} evidence provenance is not a releasable source`);
+    } else {
+      const attestation = scenarioAttestation(evidenceByOwner[scenario.owner], scenario.id);
+      if (attestation === "PASS") {
+        result = "PASS";
+      } else if (attestation === "FAIL") {
+        result = "FAIL";
+        reasons.push(`${scenario.owner} evidence attests ${scenario.id} as FAIL`);
+      } else {
+        result = "PENDING";
+        reasons.push(`${scenario.owner} evidence does not attest ${scenario.id}`);
+      }
+    }
+
+    // 구조적 override: E3는 planner ride metadata 결손 시 FAIL(NO_GO #3와 연동).
+    if (scenario.id === "E3" && plannerRide && plannerRide.missingMetadata && result === "PASS") {
+      result = "FAIL";
+      reasons.push("planner RIDE metadata is incomplete");
+    }
+    // 구조적 override: E9는 planner canary에 ITX_CHEONGCHUN/EXPRESS ride가 있어야 PASS 유지.
+    if (scenario.id === "E9" && plannerRide && !plannerRide.hasItxExpress && result === "PASS") {
+      result = "FAIL";
+      reasons.push("planner canary has no ITX_CHEONGCHUN EXPRESS RIDE leg");
+    }
+
+    // scenario 결과를 연결된 NO_GO 조건으로 전파.
+    for (const conditionId of scenario.guardsNoGo) {
+      if (result === "FAIL") {
+        trip(conditionId, `${scenario.id} failed`);
+      } else if (result !== "PASS") {
+        unresolved(conditionId, `${scenario.id} is ${result}`);
+      }
+    }
+
+    return {
+      id: scenario.id,
+      titleKo: scenario.titleKo,
+      producerIssue: scenario.producerIssue,
+      producerIssueUrl: issueUrl(scenario.producerIssue),
+      owner: scenario.owner,
+      evidenceTests: scenario.evidenceTests,
+      testRunUrl: evaluation.present ? evaluation.testRunUrl : null,
+      guardsNoGo: scenario.guardsNoGo,
+      artifactIdentity: evaluation.present ? evaluation.identity : null,
+      result,
+      reasons,
+    };
+  });
+
+  // 판정 조건: seed의 unknown pattern default(#2)는 planner evidence의 명시 attestation을 요구한다.
+  const seedPatternAttestation = plannerEvidence?.checks?.unknownPatternDefaultedToLocal;
+  if (!plannerEvidence) {
+    unresolved("unknown_pattern_defaulted_to_local", "planner evidence not provided");
+  } else if (seedPatternAttestation === true) {
+    trip("unknown_pattern_defaulted_to_local", "planner seed defaults unknown pattern to LOCAL");
+  } else if (seedPatternAttestation !== false) {
+    unresolved("unknown_pattern_defaulted_to_local", "planner evidence does not attest seed pattern handling");
+  }
+
+  const noGoConditions = NO_GO_CONDITIONS.map((id) => noGo.get(id));
+  const blockers = [];
+  for (const condition of noGoConditions) {
+    if (condition.triggered) {
+      blockers.push({ id: `no_go_${condition.id}`, severity: "P0", reasons: condition.reasons });
+    } else if (condition.unresolved) {
+      blockers.push({ id: `unresolved_${condition.id}`, severity: "P0", reasons: condition.reasons });
+    }
+  }
+  for (const scenario of scenarioMatrix) {
+    if (scenario.result !== "PASS") {
+      blockers.push({
+        id: `scenario_${scenario.id.toLowerCase()}_${scenario.result.toLowerCase()}`,
+        severity: "P0",
+        reasons: scenario.reasons,
+      });
+    }
+  }
+
+  const decision = blockers.length === 0 ? "GO" : "NO_GO";
+
+  const verdict = {
+    schemaVersion: 1,
+    releaseGate: "route-integration-verdict",
+    issue: 1414,
+    producerVersion: 1,
+    applicationId: "easysubway",
+    androidApplicationId: "com.easysubway.app",
+    generatedAt,
+    apiContract: {
+      catalogId: ROUTE_SEARCH_CATALOG_ID,
+      contractVersion: ROUTE_SEARCH_CONTRACT_VERSION,
+    },
+    releaseCandidateIdentity: canonicalIdentity,
+    rcIdentity: canonicalIdentity,
+    evidenceInputs: Object.values(evaluations).map((evaluation) => ({
+      name: evaluation.name,
+      present: evaluation.present,
+      sourceIssue: evaluation.present ? evaluation.sourceIssue : null,
+      identityMatches: evaluation.present ? evaluation.identityMatches : false,
+      mismatchFields: evaluation.present ? evaluation.mismatchFields ?? [] : [],
+      provenance: evaluation.present ? evaluation.provenance : null,
+      fixtureOnly: evaluation.present ? evaluation.fixtureOnly : false,
+    })),
+    artifactIdentityLinkage: {
+      backendImageDigest: canonicalIdentity.backendImageDigest ?? null,
+      backendArtifactSha256: canonicalIdentity.backendArtifactSha256 ?? null,
+      dataPackManifestSha256: canonicalIdentity.dataPackManifestSha256 ?? null,
+      topologyPackSha256: canonicalIdentity.dataPackArtifactSha256 ?? null,
+      timetableSnapshotSha256: plannerEvidence?.plannerIdentity?.timetableSnapshotSha256 ?? null,
+      canonicalStationSetSha256: plannerEvidence?.plannerIdentity?.canonicalStationSetSha256 ?? null,
+      sourceLineageSha256: plannerEvidence?.plannerIdentity?.sourceLineageSha256 ?? null,
+    },
+    scenarioMatrix,
+    noGoConditions: noGoConditions.map((condition) => ({
+      id: condition.id,
+      triggered: condition.triggered,
+      unresolved: condition.unresolved,
+      reasons: condition.reasons,
+    })),
+    blockers,
+    decision,
+    readiness: {
+      status: decision,
+      gateStatus: decision === "GO" ? "SATISFIED" : "BLOCKED_ROUTE_INTEGRATION",
+    },
+  };
+
+  verdict.summaryArtifactDigest = createHash("sha256")
+    .update(JSON.stringify(verdict))
+    .digest("hex");
+
+  return verdict;
+}
+
+function parseArgs(argv) {
+  const args = new Map();
+  for (let index = 0; index < argv.length; index += 1) {
+    const name = argv[index];
+    if (!name?.startsWith("--")) throw new Error(`invalid argument: ${name}`);
+    const key = name.slice(2);
+    const next = argv[index + 1];
+    if (key === "allow-fixture-provenance") {
+      args.set(key, "true");
+      continue;
+    }
+    if (next === undefined || next.startsWith("--")) throw new Error(`missing value for --${key}`);
+    args.set(key, next);
+    index += 1;
+  }
+  return args;
+}
+
+function readJsonArg(args, key, { required = false } = {}) {
+  const value = args.get(key);
+  if (!value) {
+    if (required) throw new Error(`--${key} is required`);
+    return null;
+  }
+  const resolved = path.resolve(process.cwd(), value);
+  if (!existsSync(resolved)) {
+    if (required) throw new Error(`--${key} file does not exist: ${value}`);
+    return null;
+  }
+  return JSON.parse(readFileSync(resolved, "utf8"));
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const output = args.get("output");
+  if (!output) throw new Error("--output is required");
+  const verdict = buildRouteIntegrationVerdict({
+    rcManifest: readJsonArg(args, "rc-manifest", { required: true }),
+    plannerEvidence: readJsonArg(args, "planner-evidence"),
+    mobileEvidence: readJsonArg(args, "mobile-evidence"),
+    routeMapEvidence: readJsonArg(args, "route-map-evidence"),
+    timetableEvidence: readJsonArg(args, "timetable-evidence"),
+    generatedAt: args.get("now") ?? new Date().toISOString(),
+    allowFixtureProvenance: args.get("allow-fixture-provenance") === "true",
+  });
+  const outputPath = path.resolve(process.cwd(), output);
+  mkdirSync(path.dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, `${JSON.stringify(verdict, null, 2)}\n`);
+  console.log(`route integration verdict: ${verdict.decision}`);
+  if (args.get("fail-on-no-go") === "true" && verdict.decision !== "GO") {
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/tools/release/generate-route-integration-verdict.mjs
+++ b/tools/release/generate-route-integration-verdict.mjs
@@ -16,10 +16,15 @@ export const ROUTE_SEARCH_CATALOG_ID =
 const ROUTE_SEARCH_CONTRACT_VERSION = "ROUTE_SEARCH_V2";
 
 // 같은 RC identity 판정에 사용하는 필드. 서로 다른 producer evidence가 같은 후보를 소비했는지 검증한다.
+// aabSha256/aabPayloadSha256을 포함해 mobile bundle 자체의 identity도 결속한다 — appVersionName/
+// versionCode만으로는 버전 번호는 같지만 실제 서명된 산출물이 다른 재빌드를 구분하지 못한다.
+// generate-rc-evidence-manifest.mjs도 이 두 필드를 RC identity 필수 항목으로 취급한다(동일 관행).
 const RC_IDENTITY_FIELDS = [
   "gitSha",
   "appVersionName",
   "versionCode",
+  "aabSha256",
+  "aabPayloadSha256",
   "backendImageDigest",
   "backendArtifactSha256",
   "dataPackManifestSha256",
@@ -27,8 +32,10 @@ const RC_IDENTITY_FIELDS = [
   "routeContractVersion",
   "realtimeContractVersion",
 ];
-// 최소한 값이 있어야 하는(fail-closed) 앵커 필드.
-const RC_IDENTITY_ANCHOR_FIELDS = ["gitSha", "versionCode", "dataPackArtifactSha256"];
+// 최소한 값이 있어야 하는(fail-closed) 앵커 필드. aabSha256/aabPayloadSha256은 backend와 달리
+// anyOf가 아니라 둘 다 필수다(Android 빌드 job은 이 저장소의 모든 RC 파이프라인에서 항상 실행되며,
+// 264645ca 실 final-readiness 등 실측 RC artifact에서도 항상 채워져 있었다).
+const RC_IDENTITY_ANCHOR_FIELDS = ["gitSha", "versionCode", "dataPackArtifactSha256", "aabSha256", "aabPayloadSha256"];
 // backend identity는 anyOf 관계다(backendImageDigest 또는 backendArtifactSha256 중 하나만 있으면
 // 된다) — 둘 다 null이면 backend가 어떤 candidate에 묶였는지 anchor할 수 없어 fail-closed blocker.
 const RC_IDENTITY_BACKEND_ANCHOR_FIELDS = ["backendArtifactSha256", "backendImageDigest"];
@@ -239,6 +246,189 @@ function evaluateEvidenceInput(name, evidence, canonicalIdentity, allowFixturePr
   };
 }
 
+// #7 mixed RC/artifact identity NO_GO 판정(evidence identity mismatch + canonical anchor 미완성
+// + planner artifact identity linkage).
+function evaluateIdentityNoGo({ evaluations, canonicalIdentity, plannerEvidence, trip }) {
+  for (const evaluation of Object.values(evaluations)) {
+    if (!evaluation.present) continue;
+    if (!evaluation.identityMatches) {
+      trip(
+        "mixed_rc_or_artifact_identity",
+        `${evaluation.name} identity mismatch: ${(evaluation.mismatchFields ?? []).join(", ") || "missing identity"}`,
+      );
+    }
+  }
+  const canonicalAnchorGaps = anchorIncomplete(canonicalIdentity);
+  if (canonicalAnchorGaps.length > 0) {
+    trip("mixed_rc_or_artifact_identity", `canonical identity missing anchor fields: ${canonicalAnchorGaps.join(", ")}`);
+  }
+  // planner artifact identity linkage: canonicalPackSha256이 datapack artifact와 일치해야 한다.
+  if (plannerEvidence) {
+    const canonicalPackSha256 = plannerEvidence?.plannerIdentity?.canonicalPackSha256 ?? null;
+    if (canonicalPackSha256 !== (canonicalIdentity.dataPackArtifactSha256 ?? null)) {
+      trip(
+        "mixed_rc_or_artifact_identity",
+        "planner canonicalPackSha256 does not match RC dataPackArtifactSha256",
+      );
+    }
+  }
+}
+
+// fixture-only fail-closed 판정.
+function evaluateProvenanceNoGo({ evaluations, allowFixtureProvenance, trip, unresolved }) {
+  for (const evaluation of Object.values(evaluations)) {
+    if (!evaluation.present) continue;
+    if (evaluation.fixtureOnly && !allowFixtureProvenance) {
+      trip("fixture_only_evidence", `${evaluation.name} evidence is fixture-only`);
+    } else if (!evaluation.provenanceValid) {
+      unresolved(
+        "fixture_only_evidence",
+        `${evaluation.name} evidence provenance is not one of ${[...VALID_PROVENANCE].join(", ")}`,
+      );
+    }
+  }
+}
+
+// #3 ride leg가 serviceClass/servicePattern 없이 성공 응답하는지 NO_GO 판정.
+function evaluatePlannerRideMetadataNoGo({ plannerEvidence, plannerRide, trip, unresolved }) {
+  if (plannerEvidence) {
+    if (plannerRide.structureMissing) {
+      unresolved("ride_leg_missing_service_metadata", "planner evidence has no canary itinerary structure");
+    } else if (plannerRide.rideLegs === 0) {
+      unresolved("ride_leg_missing_service_metadata", "planner evidence exposes no RIDE legs");
+    } else if (plannerRide.missingMetadata) {
+      trip("ride_leg_missing_service_metadata", "a planner RIDE leg is missing serviceClass or servicePattern");
+    }
+  } else {
+    unresolved("ride_leg_missing_service_metadata", "planner evidence not provided");
+  }
+}
+
+// #2 final seed의 unknown pattern이 LOCAL로 default되는지 NO_GO 판정(planner evidence의 명시
+// attestation을 요구한다).
+function evaluateSeedPatternNoGo({ plannerEvidence, trip, unresolved }) {
+  const seedPatternAttestation = plannerEvidence?.checks?.unknownPatternDefaultedToLocal;
+  if (!plannerEvidence) {
+    unresolved("unknown_pattern_defaulted_to_local", "planner evidence not provided");
+  } else if (seedPatternAttestation === true) {
+    trip("unknown_pattern_defaulted_to_local", "planner seed defaults unknown pattern to LOCAL");
+  } else if (seedPatternAttestation !== false) {
+    unresolved("unknown_pattern_defaulted_to_local", "planner evidence does not attest seed pattern handling");
+  }
+}
+
+// 단일 시나리오의 base 판정 + 구조적 override(E3/E9) + 연결된 NO_GO 조건 전파를 수행한다.
+function evaluateScenario(scenario, { evaluations, evidenceByOwner, plannerRide, allowFixtureProvenance, mobileEvidence, trip, unresolved }) {
+  const evaluation = evaluations[scenario.owner];
+  const reasons = [];
+  let result;
+  if (!evaluation.present) {
+    result = "PENDING";
+    reasons.push(`${scenario.owner} evidence not provided`);
+  } else if (!evaluation.identityMatches) {
+    result = "FAIL";
+    reasons.push(`${scenario.owner} evidence identity does not match the RC candidate`);
+  } else if (evaluation.fixtureOnly && !allowFixtureProvenance) {
+    result = "FAIL";
+    reasons.push(`${scenario.owner} evidence is fixture-only`);
+  } else if (!evaluation.provenanceValid) {
+    result = "PENDING";
+    reasons.push(`${scenario.owner} evidence provenance is not a releasable source`);
+  } else {
+    const attestation = scenarioAttestation(evidenceByOwner[scenario.owner], scenario.id);
+    if (attestation === "PASS") {
+      result = "PASS";
+    } else if (attestation === "FAIL") {
+      result = "FAIL";
+      reasons.push(`${scenario.owner} evidence attests ${scenario.id} as FAIL`);
+    } else {
+      result = "PENDING";
+      reasons.push(`${scenario.owner} evidence does not attest ${scenario.id}`);
+    }
+  }
+
+  // 구조적 override: E3는 planner ride metadata 결손 시 FAIL(NO_GO #3와 연동).
+  if (scenario.id === "E3" && plannerRide && plannerRide.missingMetadata && result === "PASS") {
+    result = "FAIL";
+    reasons.push("planner RIDE metadata is incomplete");
+  }
+  // 구조적 override: E9는 planner canary에 ITX_CHEONGCHUN/EXPRESS ride가 있어야 PASS 유지.
+  if (scenario.id === "E9" && plannerRide && !plannerRide.hasItxExpress && result === "PASS") {
+    result = "FAIL";
+    reasons.push("planner canary has no ITX_CHEONGCHUN EXPRESS RIDE leg");
+  }
+  // 구조적 override: E9는 backend 표현뿐 아니라 실제 Mobile 표시(ITX-청춘 vs generic 급행)까지
+  // 요구한다. planner 쪽만으로 PASS에 도달했더라도, identity·provenance가 유효한 mobile
+  // evidence가 E9를 명시적으로 PASS attest했을 때만 PASS를 유지한다(fail-closed) — mobile
+  // evidence가 없거나 E9를 attest하지 않으면 PASS를 그대로 두지 않고(fail-open 금지) PENDING으로
+  // 낮춘다. 명시적 FAIL이면 FAIL로 덮어쓴다.
+  if (scenario.id === "E9" && result === "PASS") {
+    const mobileEvaluation = evaluations.mobile;
+    const mobileEvidenceUsable = mobileEvaluation.present
+      && mobileEvaluation.identityMatches
+      && !(mobileEvaluation.fixtureOnly && !allowFixtureProvenance)
+      && mobileEvaluation.provenanceValid;
+    const mobileE9 = mobileEvidenceUsable ? scenarioAttestation(mobileEvidence, "E9") : undefined;
+    if (mobileE9 === "FAIL") {
+      result = "FAIL";
+      reasons.push("mobile evidence attests E9 as FAIL (ITX-청춘 표시 미구현)");
+    } else if (mobileE9 !== "PASS") {
+      result = "PENDING";
+      reasons.push("mobile evidence does not explicitly attest E9 as PASS");
+    }
+  }
+
+  // scenario 결과를 연결된 NO_GO 조건으로 전파.
+  for (const conditionId of scenario.guardsNoGo) {
+    if (result === "FAIL") {
+      trip(conditionId, `${scenario.id} failed`);
+    } else if (result !== "PASS") {
+      unresolved(conditionId, `${scenario.id} is ${result}`);
+    }
+  }
+
+  return {
+    id: scenario.id,
+    titleKo: scenario.titleKo,
+    producerIssue: scenario.producerIssue,
+    producerIssueUrl: issueUrl(scenario.producerIssue),
+    owner: scenario.owner,
+    evidenceTests: scenario.evidenceTests,
+    testRunUrl: evaluation.present ? evaluation.testRunUrl : null,
+    guardsNoGo: scenario.guardsNoGo,
+    artifactIdentity: evaluation.present ? evaluation.identity : null,
+    result,
+    reasons,
+  };
+}
+
+// E1~E9 전체 scenario matrix를 판정한다.
+function evaluateScenarioMatrix(context) {
+  return ROUTE_INTEGRATION_SCENARIOS.map((scenario) => evaluateScenario(scenario, context));
+}
+
+// noGo Map과 scenarioMatrix로부터 blockers 목록을 만든다.
+function buildBlockers(noGoConditions, scenarioMatrix) {
+  const blockers = [];
+  for (const condition of noGoConditions) {
+    if (condition.triggered) {
+      blockers.push({ id: `no_go_${condition.id}`, severity: "P0", reasons: condition.reasons });
+    } else if (condition.unresolved) {
+      blockers.push({ id: `unresolved_${condition.id}`, severity: "P0", reasons: condition.reasons });
+    }
+  }
+  for (const scenario of scenarioMatrix) {
+    if (scenario.result !== "PASS") {
+      blockers.push({
+        id: `scenario_${scenario.id.toLowerCase()}_${scenario.result.toLowerCase()}`,
+        severity: "P0",
+        reasons: scenario.reasons,
+      });
+    }
+  }
+  return blockers;
+}
+
 export function buildRouteIntegrationVerdict(inputs) {
   const {
     rcManifest,
@@ -282,163 +472,24 @@ export function buildRouteIntegrationVerdict(inputs) {
     entry.reasons.push(reason);
   };
 
-  // #7 mixed RC/artifact identity.
-  for (const evaluation of Object.values(evaluations)) {
-    if (!evaluation.present) continue;
-    if (!evaluation.identityMatches) {
-      trip(
-        "mixed_rc_or_artifact_identity",
-        `${evaluation.name} identity mismatch: ${(evaluation.mismatchFields ?? []).join(", ") || "missing identity"}`,
-      );
-    }
-  }
-  const canonicalAnchorGaps = anchorIncomplete(canonicalIdentity);
-  if (canonicalAnchorGaps.length > 0) {
-    trip("mixed_rc_or_artifact_identity", `canonical identity missing anchor fields: ${canonicalAnchorGaps.join(", ")}`);
-  }
-  // planner artifact identity linkage: canonicalPackSha256이 datapack artifact와 일치해야 한다.
-  if (plannerEvidence) {
-    const canonicalPackSha256 = plannerEvidence?.plannerIdentity?.canonicalPackSha256 ?? null;
-    if (canonicalPackSha256 !== (canonicalIdentity.dataPackArtifactSha256 ?? null)) {
-      trip(
-        "mixed_rc_or_artifact_identity",
-        "planner canonicalPackSha256 does not match RC dataPackArtifactSha256",
-      );
-    }
-  }
+  evaluateIdentityNoGo({ evaluations, canonicalIdentity, plannerEvidence, trip });
+  evaluateProvenanceNoGo({ evaluations, allowFixtureProvenance, trip, unresolved });
+  evaluatePlannerRideMetadataNoGo({ plannerEvidence, plannerRide, trip, unresolved });
 
-  // fixture-only fail-closed.
-  for (const evaluation of Object.values(evaluations)) {
-    if (!evaluation.present) continue;
-    if (evaluation.fixtureOnly && !allowFixtureProvenance) {
-      trip("fixture_only_evidence", `${evaluation.name} evidence is fixture-only`);
-    } else if (!evaluation.provenanceValid) {
-      unresolved(
-        "fixture_only_evidence",
-        `${evaluation.name} evidence provenance is not one of ${[...VALID_PROVENANCE].join(", ")}`,
-      );
-    }
-  }
-
-  // #3 ride leg가 serviceClass/servicePattern 없이 성공 응답.
-  if (plannerEvidence) {
-    if (plannerRide.structureMissing) {
-      unresolved("ride_leg_missing_service_metadata", "planner evidence has no canary itinerary structure");
-    } else if (plannerRide.rideLegs === 0) {
-      unresolved("ride_leg_missing_service_metadata", "planner evidence exposes no RIDE legs");
-    } else if (plannerRide.missingMetadata) {
-      trip("ride_leg_missing_service_metadata", "a planner RIDE leg is missing serviceClass or servicePattern");
-    }
-  } else {
-    unresolved("ride_leg_missing_service_metadata", "planner evidence not provided");
-  }
-
-  // scenario matrix 판정.
-  const scenarioMatrix = ROUTE_INTEGRATION_SCENARIOS.map((scenario) => {
-    const evaluation = evaluations[scenario.owner];
-    const reasons = [];
-    let result;
-    if (!evaluation.present) {
-      result = "PENDING";
-      reasons.push(`${scenario.owner} evidence not provided`);
-    } else if (!evaluation.identityMatches) {
-      result = "FAIL";
-      reasons.push(`${scenario.owner} evidence identity does not match the RC candidate`);
-    } else if (evaluation.fixtureOnly && !allowFixtureProvenance) {
-      result = "FAIL";
-      reasons.push(`${scenario.owner} evidence is fixture-only`);
-    } else if (!evaluation.provenanceValid) {
-      result = "PENDING";
-      reasons.push(`${scenario.owner} evidence provenance is not a releasable source`);
-    } else {
-      const attestation = scenarioAttestation(evidenceByOwner[scenario.owner], scenario.id);
-      if (attestation === "PASS") {
-        result = "PASS";
-      } else if (attestation === "FAIL") {
-        result = "FAIL";
-        reasons.push(`${scenario.owner} evidence attests ${scenario.id} as FAIL`);
-      } else {
-        result = "PENDING";
-        reasons.push(`${scenario.owner} evidence does not attest ${scenario.id}`);
-      }
-    }
-
-    // 구조적 override: E3는 planner ride metadata 결손 시 FAIL(NO_GO #3와 연동).
-    if (scenario.id === "E3" && plannerRide && plannerRide.missingMetadata && result === "PASS") {
-      result = "FAIL";
-      reasons.push("planner RIDE metadata is incomplete");
-    }
-    // 구조적 override: E9는 planner canary에 ITX_CHEONGCHUN/EXPRESS ride가 있어야 PASS 유지.
-    if (scenario.id === "E9" && plannerRide && !plannerRide.hasItxExpress && result === "PASS") {
-      result = "FAIL";
-      reasons.push("planner canary has no ITX_CHEONGCHUN EXPRESS RIDE leg");
-    }
-    // 구조적 override: E9는 backend 표현뿐 아니라 실제 Mobile 표시(ITX-청춘 vs generic 급행)까지
-    // 요구한다. mobile evidence가 identity-bound로 존재하고 E9를 FAIL로 attest하면 planner의
-    // PASS를 덮어써 Mobile 미구현을 fail closed로 반영한다.
-    if (scenario.id === "E9" && result === "PASS") {
-      const mobileEvaluation = evaluations.mobile;
-      if (mobileEvaluation.present && mobileEvaluation.identityMatches) {
-        const mobileE9 = scenarioAttestation(mobileEvidence, "E9");
-        if (mobileE9 === "FAIL") {
-          result = "FAIL";
-          reasons.push("mobile evidence attests E9 as FAIL (ITX-청춘 표시 미구현)");
-        }
-      }
-    }
-
-    // scenario 결과를 연결된 NO_GO 조건으로 전파.
-    for (const conditionId of scenario.guardsNoGo) {
-      if (result === "FAIL") {
-        trip(conditionId, `${scenario.id} failed`);
-      } else if (result !== "PASS") {
-        unresolved(conditionId, `${scenario.id} is ${result}`);
-      }
-    }
-
-    return {
-      id: scenario.id,
-      titleKo: scenario.titleKo,
-      producerIssue: scenario.producerIssue,
-      producerIssueUrl: issueUrl(scenario.producerIssue),
-      owner: scenario.owner,
-      evidenceTests: scenario.evidenceTests,
-      testRunUrl: evaluation.present ? evaluation.testRunUrl : null,
-      guardsNoGo: scenario.guardsNoGo,
-      artifactIdentity: evaluation.present ? evaluation.identity : null,
-      result,
-      reasons,
-    };
+  const scenarioMatrix = evaluateScenarioMatrix({
+    evaluations,
+    evidenceByOwner,
+    plannerRide,
+    allowFixtureProvenance,
+    mobileEvidence,
+    trip,
+    unresolved,
   });
 
-  // 판정 조건: seed의 unknown pattern default(#2)는 planner evidence의 명시 attestation을 요구한다.
-  const seedPatternAttestation = plannerEvidence?.checks?.unknownPatternDefaultedToLocal;
-  if (!plannerEvidence) {
-    unresolved("unknown_pattern_defaulted_to_local", "planner evidence not provided");
-  } else if (seedPatternAttestation === true) {
-    trip("unknown_pattern_defaulted_to_local", "planner seed defaults unknown pattern to LOCAL");
-  } else if (seedPatternAttestation !== false) {
-    unresolved("unknown_pattern_defaulted_to_local", "planner evidence does not attest seed pattern handling");
-  }
+  evaluateSeedPatternNoGo({ plannerEvidence, trip, unresolved });
 
   const noGoConditions = NO_GO_CONDITIONS.map((id) => noGo.get(id));
-  const blockers = [];
-  for (const condition of noGoConditions) {
-    if (condition.triggered) {
-      blockers.push({ id: `no_go_${condition.id}`, severity: "P0", reasons: condition.reasons });
-    } else if (condition.unresolved) {
-      blockers.push({ id: `unresolved_${condition.id}`, severity: "P0", reasons: condition.reasons });
-    }
-  }
-  for (const scenario of scenarioMatrix) {
-    if (scenario.result !== "PASS") {
-      blockers.push({
-        id: `scenario_${scenario.id.toLowerCase()}_${scenario.result.toLowerCase()}`,
-        severity: "P0",
-        reasons: scenario.reasons,
-      });
-    }
-  }
+  const blockers = buildBlockers(noGoConditions, scenarioMatrix);
 
   const decision = blockers.length === 0 ? "GO" : "NO_GO";
 

--- a/tools/release/generate-route-integration-verdict.mjs
+++ b/tools/release/generate-route-integration-verdict.mjs
@@ -41,7 +41,7 @@ export const ROUTE_INTEGRATION_SCENARIOS = [
     producerIssue: 2068,
     owner: "routeMap",
     evidenceTests: [
-      "apps/mobile/test/widget_test.dart::노선도는 노선별 보기 우회 sheet를 노출하지 않는다",
+      "apps/mobile/test/widget_test.dart::노선도 첫 화면은 하단 광고 위에 지도 조작을 유지한다",
       "docs/2099-qa/item4_routemap_no_express_toggle.png",
       "docs/2099-qa/item5_talkback_dump.xml",
     ],
@@ -107,7 +107,8 @@ export const ROUTE_INTEGRATION_SCENARIOS = [
     producerIssue: 2099,
     owner: "mobile",
     evidenceTests: [
-      "backend/src/test/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoaderTest.java",
+      "apps/mobile/test/widget_test.dart::급행 운행 정보는 선택 UI 없이 시간표와 길찾기에 표시된다",
+      "apps/mobile/test/widget_test.dart::역 시간표 화면은 일반·급행을 한 목록에 시각순으로 표시하고 급행 행에만 배지를 단다",
       "docs/2099-qa/item3_express_badge_timetable.png",
       "docs/2099-qa/item5_talkback_dump.xml",
     ],
@@ -361,6 +362,19 @@ export function buildRouteIntegrationVerdict(inputs) {
       result = "FAIL";
       reasons.push("planner canary has no ITX_CHEONGCHUN EXPRESS RIDE leg");
     }
+    // 구조적 override: E9는 backend 표현뿐 아니라 실제 Mobile 표시(ITX-청춘 vs generic 급행)까지
+    // 요구한다. mobile evidence가 identity-bound로 존재하고 E9를 FAIL로 attest하면 planner의
+    // PASS를 덮어써 Mobile 미구현을 fail closed로 반영한다.
+    if (scenario.id === "E9" && result === "PASS") {
+      const mobileEvaluation = evaluations.mobile;
+      if (mobileEvaluation.present && mobileEvaluation.identityMatches) {
+        const mobileE9 = scenarioAttestation(mobileEvidence, "E9");
+        if (mobileE9 === "FAIL") {
+          result = "FAIL";
+          reasons.push("mobile evidence attests E9 as FAIL (ITX-청춘 표시 미구현)");
+        }
+      }
+    }
 
     // scenario 결과를 연결된 NO_GO 조건으로 전파.
     for (const conditionId of scenario.guardsNoGo) {
@@ -464,7 +478,7 @@ export function buildRouteIntegrationVerdict(inputs) {
     },
   };
 
-  verdict.summaryArtifactDigest = createHash("sha256")
+  verdict.verdictDigestSha256 = createHash("sha256")
     .update(JSON.stringify(verdict))
     .digest("hex");
 

--- a/tools/release/generate-route-integration-verdict.mjs
+++ b/tools/release/generate-route-integration-verdict.mjs
@@ -29,6 +29,9 @@ const RC_IDENTITY_FIELDS = [
 ];
 // 최소한 값이 있어야 하는(fail-closed) 앵커 필드.
 const RC_IDENTITY_ANCHOR_FIELDS = ["gitSha", "versionCode", "dataPackArtifactSha256"];
+// backend identity는 anyOf 관계다(backendImageDigest 또는 backendArtifactSha256 중 하나만 있으면
+// 된다) — 둘 다 null이면 backend가 어떤 candidate에 묶였는지 anchor할 수 없어 fail-closed blocker.
+const RC_IDENTITY_BACKEND_ANCHOR_FIELDS = ["backendArtifactSha256", "backendImageDigest"];
 
 const VALID_PROVENANCE = new Set(["final-candidate", "production", "manual-observation"]);
 
@@ -169,13 +172,21 @@ function identityMismatchFields(canonical, candidate) {
 }
 
 function anchorIncomplete(identity) {
-  return RC_IDENTITY_ANCHOR_FIELDS.filter(
+  const missing = RC_IDENTITY_ANCHOR_FIELDS.filter(
     (field) => identity?.[field] === undefined || identity?.[field] === null || identity?.[field] === "",
   );
+  const hasBackendAnchor = RC_IDENTITY_BACKEND_ANCHOR_FIELDS.some(
+    (field) => identity?.[field] !== undefined && identity?.[field] !== null && identity?.[field] !== "",
+  );
+  if (!hasBackendAnchor) {
+    missing.push(RC_IDENTITY_BACKEND_ANCHOR_FIELDS.join("|"));
+  }
+  return missing;
 }
 
 // planner canary itinerary의 모든 RIDE step이 serviceClass/servicePattern을 갖는지 검사한다(NO_GO #3).
-// 반환: { rideLegs, missingMetadata, expressSkipBoardable, hasItxExpress }
+// 반환: { rideLegs, missingMetadata, hasItxExpress, structureMissing? }
+// structureMissing은 itineraries 구조 자체가 없을 때만 true로 추가된다(그 외에는 필드가 없음).
 function inspectPlannerRideMetadata(plannerEvidence) {
   const result = { rideLegs: 0, missingMetadata: false, hasItxExpress: false };
   const itineraries = plannerEvidence?.canaryResult?.plan?.itineraries;

--- a/tools/release/generate-route-integration-verdict.test.mjs
+++ b/tools/release/generate-route-integration-verdict.test.mjs
@@ -1,0 +1,244 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  ROUTE_INTEGRATION_SCENARIOS,
+  ROUTE_SEARCH_CATALOG_ID,
+  buildRouteIntegrationVerdict,
+} from "./generate-route-integration-verdict.mjs";
+
+const CANONICAL_IDENTITY = {
+  gitSha: "26d1461210a36d9d969e5a18d5f13725519abdcd",
+  appVersionName: "1.0.4",
+  versionCode: "10005",
+  backendImageDigest: null,
+  backendArtifactSha256: "74a3e35762d1973c0b05a0c0bd6f0fc6aa2a4657ef23cde359cf100e0830f631",
+  dataPackManifestSha256: "2ee9f38f3e748d7bbc6d9eba124b34e6b5c8ad539338a6cdeee7a472515456e5",
+  dataPackArtifactSha256: "7bb4bb68f0642e45377d98b083e93cd8c1c92aaa58dd353f32189e3f325a1562",
+  routeContractVersion: "route-map-contract-v1",
+  realtimeContractVersion: "seoul-topis-schema-v1",
+};
+
+function rcManifest(identity = CANONICAL_IDENTITY) {
+  return { rcIdentity: { ...identity }, releaseCandidateIdentity: { ...identity } };
+}
+
+function plannerEvidence(overrides = {}) {
+  return {
+    sourceIssue: 2098,
+    provenance: "final-candidate",
+    testRunUrl: "https://example.invalid/run/planner",
+    releaseCandidateIdentity: { ...CANONICAL_IDENTITY },
+    plannerIdentity: {
+      canonicalPackSha256: CANONICAL_IDENTITY.dataPackArtifactSha256,
+      timetableSnapshotSha256: "a".repeat(64),
+      canonicalStationSetSha256: "d".repeat(64),
+      sourceLineageSha256: "e".repeat(64),
+    },
+    checks: { unknownPatternDefaultedToLocal: false },
+    integrationScenarios: {
+      E2: "PASS",
+      E3: "PASS",
+      E4: "PASS",
+      E5: "PASS",
+      E6: "PASS",
+      E9: "PASS",
+    },
+    canaryResult: {
+      plan: {
+        itineraries: [
+          {
+            steps: [
+              { stepType: "entry", serviceClass: null, servicePattern: null },
+              { stepType: "ride", serviceClass: "SUBWAY", servicePattern: "LOCAL" },
+              { stepType: "ride", serviceClass: "ITX_CHEONGCHUN", servicePattern: "EXPRESS" },
+              { stepType: "exit", serviceClass: null, servicePattern: null },
+            ],
+          },
+        ],
+      },
+    },
+    ...overrides,
+  };
+}
+
+function mobileEvidence(overrides = {}) {
+  return {
+    sourceIssue: 2099,
+    provenance: "manual-observation",
+    releaseCandidateIdentity: { ...CANONICAL_IDENTITY },
+    integrationScenarios: { E7: "PASS", E8: "PASS" },
+    ...overrides,
+  };
+}
+
+function routeMapEvidence(overrides = {}) {
+  return {
+    sourceIssue: 2068,
+    provenance: "final-candidate",
+    releaseCandidateIdentity: { ...CANONICAL_IDENTITY },
+    integrationScenarios: { E1: "PASS" },
+    ...overrides,
+  };
+}
+
+function goInputs(overrides = {}) {
+  return {
+    rcManifest: rcManifest(),
+    plannerEvidence: plannerEvidence(),
+    mobileEvidence: mobileEvidence(),
+    routeMapEvidence: routeMapEvidence(),
+    generatedAt: "2026-07-17T15:00:00.000Z",
+    ...overrides,
+  };
+}
+
+test("완전히 일치하는 same-RC 증거 조합은 GO로 판정하고 E1~E9를 모두 PASS로 채운다", () => {
+  const verdict = buildRouteIntegrationVerdict(goInputs());
+
+  assert.equal(verdict.schemaVersion, 1);
+  assert.equal(verdict.releaseGate, "route-integration-verdict");
+  assert.equal(verdict.issue, 1414);
+  assert.equal(verdict.apiContract.catalogId, ROUTE_SEARCH_CATALOG_ID);
+  assert.equal(verdict.decision, "GO");
+  assert.equal(verdict.blockers.length, 0);
+  assert.equal(verdict.scenarioMatrix.length, ROUTE_INTEGRATION_SCENARIOS.length);
+  assert.ok(verdict.scenarioMatrix.every((scenario) => scenario.result === "PASS"));
+  assert.ok(verdict.noGoConditions.every((condition) => !condition.triggered && !condition.unresolved));
+  assert.equal(verdict.artifactIdentityLinkage.timetableSnapshotSha256, "a".repeat(64));
+  assert.match(verdict.summaryArtifactDigest, /^[0-9a-f]{64}$/);
+  // 각 시나리오는 실존 producer issue와 test에 연결된다.
+  for (const scenario of verdict.scenarioMatrix) {
+    assert.match(scenario.producerIssueUrl, /github\.com\/.+\/issues\/\d+$/);
+    assert.ok(scenario.evidenceTests.length > 0);
+  }
+});
+
+test("서로 다른 RC identity 증거를 조합하면 mixed identity로 NO_GO한다", () => {
+  const verdict = buildRouteIntegrationVerdict(goInputs({
+    plannerEvidence: plannerEvidence({
+      releaseCandidateIdentity: { ...CANONICAL_IDENTITY, gitSha: "deadbeef".repeat(5) },
+      plannerIdentity: {
+        canonicalPackSha256: CANONICAL_IDENTITY.dataPackArtifactSha256,
+        timetableSnapshotSha256: "a".repeat(64),
+      },
+    }),
+  }));
+
+  assert.equal(verdict.decision, "NO_GO");
+  const mixed = verdict.noGoConditions.find((condition) => condition.id === "mixed_rc_or_artifact_identity");
+  assert.equal(mixed.triggered, true);
+  const plannerScenario = verdict.scenarioMatrix.find((scenario) => scenario.id === "E2");
+  assert.equal(plannerScenario.result, "FAIL");
+});
+
+test("planner artifact identity(canonicalPackSha256) 불일치는 mixed identity로 NO_GO한다", () => {
+  const verdict = buildRouteIntegrationVerdict(goInputs({
+    plannerEvidence: plannerEvidence({
+      plannerIdentity: {
+        canonicalPackSha256: "f".repeat(64),
+        timetableSnapshotSha256: "a".repeat(64),
+      },
+    }),
+  }));
+
+  assert.equal(verdict.decision, "NO_GO");
+  const mixed = verdict.noGoConditions.find((condition) => condition.id === "mixed_rc_or_artifact_identity");
+  assert.equal(mixed.triggered, true);
+});
+
+test("입력 누락은 PASS로 기본하지 않고 scenario PENDING·NO_GO로 fail closed한다", () => {
+  const verdict = buildRouteIntegrationVerdict(goInputs({
+    plannerEvidence: null,
+    mobileEvidence: null,
+    routeMapEvidence: null,
+  }));
+
+  assert.equal(verdict.decision, "NO_GO");
+  assert.ok(verdict.scenarioMatrix.every((scenario) => scenario.result !== "PASS"));
+  const e2 = verdict.scenarioMatrix.find((scenario) => scenario.id === "E2");
+  assert.equal(e2.result, "PENDING");
+});
+
+test("fixture-only 증거는 fixture_only_evidence로 NO_GO한다", () => {
+  const verdict = buildRouteIntegrationVerdict(goInputs({
+    plannerEvidence: plannerEvidence({ provenance: "fixture" }),
+  }));
+
+  assert.equal(verdict.decision, "NO_GO");
+  const fixture = verdict.noGoConditions.find((condition) => condition.id === "fixture_only_evidence");
+  assert.equal(fixture.triggered, true);
+});
+
+test("RIDE leg가 serviceClass/servicePattern 없이 성공 응답되면 NO_GO한다", () => {
+  const verdict = buildRouteIntegrationVerdict(goInputs({
+    plannerEvidence: plannerEvidence({
+      canaryResult: {
+        plan: {
+          itineraries: [{
+            steps: [
+              { stepType: "ride", serviceClass: "SUBWAY", servicePattern: null },
+              { stepType: "ride", serviceClass: "ITX_CHEONGCHUN", servicePattern: "EXPRESS" },
+            ],
+          }],
+        },
+      },
+    }),
+  }));
+
+  assert.equal(verdict.decision, "NO_GO");
+  const rideMeta = verdict.noGoConditions.find((condition) => condition.id === "ride_leg_missing_service_metadata");
+  assert.equal(rideMeta.triggered, true);
+  const e3 = verdict.scenarioMatrix.find((scenario) => scenario.id === "E3");
+  assert.equal(e3.result, "FAIL");
+});
+
+test("planner canary에 ITX_CHEONGCHUN EXPRESS ride가 없으면 E9를 FAIL로 낮춘다", () => {
+  const verdict = buildRouteIntegrationVerdict(goInputs({
+    plannerEvidence: plannerEvidence({
+      canaryResult: {
+        plan: {
+          itineraries: [{
+            steps: [
+              { stepType: "ride", serviceClass: "SUBWAY", servicePattern: "LOCAL" },
+            ],
+          }],
+        },
+      },
+    }),
+  }));
+
+  const e9 = verdict.scenarioMatrix.find((scenario) => scenario.id === "E9");
+  assert.equal(e9.result, "FAIL");
+  const itx = verdict.noGoConditions.find((condition) => condition.id === "itx_shown_as_generic_or_local_badged");
+  assert.equal(itx.triggered, true);
+  assert.equal(verdict.decision, "NO_GO");
+});
+
+test("scenario attestation FAIL은 연결된 NO_GO 조건을 발동한다", () => {
+  const verdict = buildRouteIntegrationVerdict(goInputs({
+    routeMapEvidence: routeMapEvidence({ integrationScenarios: { E1: "FAIL" } }),
+  }));
+
+  const e1 = verdict.scenarioMatrix.find((scenario) => scenario.id === "E1");
+  assert.equal(e1.result, "FAIL");
+  const control = verdict.noGoConditions.find(
+    (condition) => condition.id === "route_map_local_express_control_present",
+  );
+  assert.equal(control.triggered, true);
+  assert.equal(verdict.decision, "NO_GO");
+});
+
+test("seed의 unknown pattern을 LOCAL로 default하면 NO_GO한다", () => {
+  const verdict = buildRouteIntegrationVerdict(goInputs({
+    plannerEvidence: plannerEvidence({ checks: { unknownPatternDefaultedToLocal: true } }),
+  }));
+
+  const seed = verdict.noGoConditions.find((condition) => condition.id === "unknown_pattern_defaulted_to_local");
+  assert.equal(seed.triggered, true);
+  assert.equal(verdict.decision, "NO_GO");
+});
+
+test("rcManifest 없이는 판정하지 않는다", () => {
+  assert.throws(() => buildRouteIntegrationVerdict({}), /rcManifest is required/);
+});

--- a/tools/release/generate-route-integration-verdict.test.mjs
+++ b/tools/release/generate-route-integration-verdict.test.mjs
@@ -106,7 +106,7 @@ test("완전히 일치하는 same-RC 증거 조합은 GO로 판정하고 E1~E9�
   assert.ok(verdict.scenarioMatrix.every((scenario) => scenario.result === "PASS"));
   assert.ok(verdict.noGoConditions.every((condition) => !condition.triggered && !condition.unresolved));
   assert.equal(verdict.artifactIdentityLinkage.timetableSnapshotSha256, "a".repeat(64));
-  assert.match(verdict.summaryArtifactDigest, /^[0-9a-f]{64}$/);
+  assert.match(verdict.verdictDigestSha256, /^[0-9a-f]{64}$/);
   // 각 시나리오는 실존 producer issue와 test에 연결된다.
   for (const scenario of verdict.scenarioMatrix) {
     assert.match(scenario.producerIssueUrl, /github\.com\/.+\/issues\/\d+$/);
@@ -241,4 +241,15 @@ test("seed의 unknown pattern을 LOCAL로 default하면 NO_GO한다", () => {
 
 test("rcManifest 없이는 판정하지 않는다", () => {
   assert.throws(() => buildRouteIntegrationVerdict({}), /rcManifest is required/);
+});
+
+test("planner canary가 ITX EXPRESS ride를 가져도 mobile evidence가 E9를 FAIL로 attest하면 덮어쓴다", () => {
+  const verdict = buildRouteIntegrationVerdict(goInputs({
+    mobileEvidence: mobileEvidence({ integrationScenarios: { E7: "PASS", E8: "PASS", E9: "FAIL" } }),
+  }));
+
+  const e9 = verdict.scenarioMatrix.find((scenario) => scenario.id === "E9");
+  assert.equal(e9.result, "FAIL");
+  assert.ok(e9.reasons.some((reason) => reason.includes("mobile evidence attests E9")));
+  assert.equal(verdict.decision, "NO_GO");
 });

--- a/tools/release/generate-route-integration-verdict.test.mjs
+++ b/tools/release/generate-route-integration-verdict.test.mjs
@@ -11,6 +11,8 @@ const CANONICAL_IDENTITY = {
   gitSha: "26d1461210a36d9d969e5a18d5f13725519abdcd",
   appVersionName: "1.0.4",
   versionCode: "10005",
+  aabSha256: "87df6fd89fd8490a8af0d754e48a17288b880f3e918bde87729b79fee88435cc",
+  aabPayloadSha256: "e2b9753619285e685a713e101b996129781f9067de5bc6a90a125c5c9de95758",
   backendImageDigest: null,
   backendArtifactSha256: "74a3e35762d1973c0b05a0c0bd6f0fc6aa2a4657ef23cde359cf100e0830f631",
   dataPackManifestSha256: "2ee9f38f3e748d7bbc6d9eba124b34e6b5c8ad539338a6cdeee7a472515456e5",
@@ -67,7 +69,7 @@ function mobileEvidence(overrides = {}) {
     sourceIssue: 2099,
     provenance: "manual-observation",
     releaseCandidateIdentity: { ...CANONICAL_IDENTITY },
-    integrationScenarios: { E7: "PASS", E8: "PASS" },
+    integrationScenarios: { E7: "PASS", E8: "PASS", E9: "PASS" },
     ...overrides,
   };
 }
@@ -123,6 +125,29 @@ test("backendArtifactSha256/backendImageDigest가 모두 null이면 anchor 미�
   const mixed = verdict.noGoConditions.find((condition) => condition.id === "mixed_rc_or_artifact_identity");
   assert.equal(mixed.triggered, true);
   assert.ok(mixed.reasons.some((reason) => reason.includes("backendArtifactSha256|backendImageDigest")));
+});
+
+test("aabSha256/aabPayloadSha256이 없으면 mobile bundle anchor 미완성으로 NO_GO한다", () => {
+  const verdict = buildRouteIntegrationVerdict(goInputs({
+    rcManifest: rcManifest({ ...CANONICAL_IDENTITY, aabSha256: null, aabPayloadSha256: null }),
+  }));
+
+  assert.equal(verdict.decision, "NO_GO");
+  const mixed = verdict.noGoConditions.find((condition) => condition.id === "mixed_rc_or_artifact_identity");
+  assert.equal(mixed.triggered, true);
+  assert.ok(mixed.reasons.some((reason) => reason.includes("aabSha256")));
+});
+
+test("서로 다른 aabSha256의 mobile evidence는 mixed identity로 NO_GO한다(같은 버전·다른 재빌드 구분)", () => {
+  const verdict = buildRouteIntegrationVerdict(goInputs({
+    mobileEvidence: mobileEvidence({
+      releaseCandidateIdentity: { ...CANONICAL_IDENTITY, aabSha256: "f".repeat(64) },
+    }),
+  }));
+
+  assert.equal(verdict.decision, "NO_GO");
+  const mixed = verdict.noGoConditions.find((condition) => condition.id === "mixed_rc_or_artifact_identity");
+  assert.equal(mixed.triggered, true);
 });
 
 test("backendImageDigest만 있어도(backendArtifactSha256 null) anchor는 충족된다", () => {
@@ -280,5 +305,42 @@ test("planner canary가 ITX EXPRESS ride를 가져도 mobile evidence가 E9를 F
   const e9 = verdict.scenarioMatrix.find((scenario) => scenario.id === "E9");
   assert.equal(e9.result, "FAIL");
   assert.ok(e9.reasons.some((reason) => reason.includes("mobile evidence attests E9")));
+  assert.equal(verdict.decision, "NO_GO");
+});
+
+test("mobile evidence가 없으면 planner만으로 E9가 fail-open PASS하지 않고 PENDING으로 낮아진다", () => {
+  const verdict = buildRouteIntegrationVerdict(goInputs({ mobileEvidence: null }));
+
+  const e9 = verdict.scenarioMatrix.find((scenario) => scenario.id === "E9");
+  assert.equal(e9.result, "PENDING");
+  assert.equal(verdict.decision, "NO_GO");
+});
+
+test("mobile evidence가 E9를 attest하지 않으면(E7/E8만) fail-open PASS하지 않고 PENDING으로 낮아진다", () => {
+  const verdict = buildRouteIntegrationVerdict(goInputs({
+    mobileEvidence: mobileEvidence({ integrationScenarios: { E7: "PASS", E8: "PASS" } }),
+  }));
+
+  const e9 = verdict.scenarioMatrix.find((scenario) => scenario.id === "E9");
+  assert.equal(e9.result, "PENDING");
+  assert.ok(e9.reasons.some((reason) => reason.includes("does not explicitly attest E9 as PASS")));
+  assert.equal(verdict.decision, "NO_GO");
+});
+
+test("mobile evidence의 identity가 RC와 다르면 E9 PASS attestation을 신뢰하지 않고 PENDING으로 낮아진다", () => {
+  const verdict = buildRouteIntegrationVerdict(goInputs({
+    mobileEvidence: mobileEvidence({ releaseCandidateIdentity: { ...CANONICAL_IDENTITY, gitSha: "0".repeat(40) } }),
+  }));
+
+  // E9의 owner는 planner라 mismatch된 mobile evidence 자체가 E9 base 판정을 FAIL로 만들지는
+  // 않는다 — 대신 fail-open override가 mismatch된 mobile의 E9 PASS를 신뢰하지 않고 PENDING으로
+  // 낮춘다.
+  const e9 = verdict.scenarioMatrix.find((scenario) => scenario.id === "E9");
+  assert.equal(e9.result, "PENDING");
+  // mobile evidence 자체의 identity mismatch는 별도로 mixed identity NO_GO도 발동시킨다.
+  assert.equal(
+    verdict.noGoConditions.find((condition) => condition.id === "mixed_rc_or_artifact_identity").triggered,
+    true,
+  );
   assert.equal(verdict.decision, "NO_GO");
 });

--- a/tools/release/generate-route-integration-verdict.test.mjs
+++ b/tools/release/generate-route-integration-verdict.test.mjs
@@ -114,6 +114,35 @@ test("완전히 일치하는 same-RC 증거 조합은 GO로 판정하고 E1~E9�
   }
 });
 
+test("backendArtifactSha256/backendImageDigest가 모두 null이면 anchor 미완성으로 NO_GO한다", () => {
+  const verdict = buildRouteIntegrationVerdict(goInputs({
+    rcManifest: rcManifest({ ...CANONICAL_IDENTITY, backendArtifactSha256: null, backendImageDigest: null }),
+  }));
+
+  assert.equal(verdict.decision, "NO_GO");
+  const mixed = verdict.noGoConditions.find((condition) => condition.id === "mixed_rc_or_artifact_identity");
+  assert.equal(mixed.triggered, true);
+  assert.ok(mixed.reasons.some((reason) => reason.includes("backendArtifactSha256|backendImageDigest")));
+});
+
+test("backendImageDigest만 있어도(backendArtifactSha256 null) anchor는 충족된다", () => {
+  const verdict = buildRouteIntegrationVerdict(goInputs({
+    rcManifest: rcManifest({ ...CANONICAL_IDENTITY, backendArtifactSha256: null, backendImageDigest: "sha256:" + "1".repeat(64) }),
+    plannerEvidence: plannerEvidence({
+      releaseCandidateIdentity: { ...CANONICAL_IDENTITY, backendArtifactSha256: null, backendImageDigest: "sha256:" + "1".repeat(64) },
+    }),
+    mobileEvidence: mobileEvidence({
+      releaseCandidateIdentity: { ...CANONICAL_IDENTITY, backendArtifactSha256: null, backendImageDigest: "sha256:" + "1".repeat(64) },
+    }),
+    routeMapEvidence: routeMapEvidence({
+      releaseCandidateIdentity: { ...CANONICAL_IDENTITY, backendArtifactSha256: null, backendImageDigest: "sha256:" + "1".repeat(64) },
+    }),
+  }));
+
+  const mixed = verdict.noGoConditions.find((condition) => condition.id === "mixed_rc_or_artifact_identity");
+  assert.equal(mixed.triggered, false);
+});
+
 test("서로 다른 RC identity 증거를 조합하면 mixed identity로 NO_GO한다", () => {
   const verdict = buildRouteIntegrationVerdict(goInputs({
     plannerEvidence: plannerEvidence({


### PR DESCRIPTION
## 관련 이슈

Refs #1414

## 작업 배경

- #1414는 #2068/#2098/#2099 producer evidence를 같은 RC identity로 결합해 E1~E9 통합 시나리오를 판정해야 하지만, 판정을 수행하는 machine producer와 producer evidence의 identity·provenance 결속 배선이 없었습니다.
- 기존 planner evidence(`planner-success-evidence.json`)에는 판정에 필요한 provenance·integrationScenarios 필드가 없고, #2099 mobile 소비 evidence fragment는 생성 경로 자체가 없었습니다.

## 작업 내용

- E1~E9 통합 판정 producer `tools/release/generate-route-integration-verdict.mjs`를 추가했습니다. releaseCandidateIdentity 전 필드 일치(fixture-only·mixed identity·stale 거부), NO_GO 조건 7건의 기계 검사, 입력·attestation 누락 시 PASS 기본 금지(fail-closed)를 구현하고 `route-integration-verdict.json`(versioned, `verdictDigestSha256`)을 산출합니다.
- `tools/release/build-planner-success-evidence.mjs`를 additive로 확장해 `provenance`·`integrationScenarios`(E2~E6 — `prototype-route-v2.test.mjs` 시나리오·`route-v2-fixtures.json`의 express-skip/express-faster/local-faster-when-waiting/short-turn/unmatched-realtime 회귀·canary 결과)를 emit합니다.
- `tools/release/build-mobile-consumption-evidence.mjs`를 신설해 #2099 fragment(E1-mobile/E7/E8/E9)를 emit합니다. E9는 tracked datapack의 `lines.name_ko`를 build 시점에 `node:sqlite`로 실측 질의해 ITX-청춘 표시 여부를 동적 검증합니다(현재 `수도권 경춘` 해석으로 FAIL — 표시 수정은 별도 PR).
- `.github/workflows/release-artifacts.yml`의 rc-evidence-manifest job에 planner/mobile evidence 생성과 verdict 생성·업로드를 배선했습니다(기존 job 구조 유지, evidence 부재 시 fail-closed NO_GO skeleton).
- `tools/ci/repository-contract.test.mjs`에 E1~E9 카탈로그·API catalog 연결(`internal:POST:/api/v2/routes/search:...#searchRouteV2`)·fail-closed 판정 계약 2건을 추가하고, 수정된 workflow 파일의 `post-launch-operations-review-gate.json` refreshBindings sha256을 갱신했습니다.
- route-map(#2068) attestation은 identity-bound evidence producer가 아직 없어 배선하지 않고 PENDING으로 유지합니다(사유는 workflow 주석에 기록).

## 검증

- 실행한 명령과 결과:
  - `node --check` 신규·수정 6개 `.mjs` — 전부 OK
  - `node --test tools/release/*.test.mjs` — 66/66 PASS
  - `node --test tools/ci/repository-contract.test.mjs` — 216/217 PASS (유일 실패는 main 유래 무관 datapack scope 해시 1건, 본 브랜치 미접촉 확인)
  - `node --test tools/ci/datapack-release-workflow.test.mjs tools/ci/provider-security-boundary.test.mjs` — 20/20 PASS
  - 실제 RC artifact(run 29588623403, gitSha 264645ca) end-to-end: (a) 기존 evidence만 → 전 항목 PENDING·NO_GO(fail-closed 기준선 유지), (b) 신규 builder evidence 주입 → E2~E8 PASS, E1 PENDING(#2068 producer 부재), E9 FAIL(ITX 표시 공백 실측), NO_GO — 의도된 정직 판정

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| verdict producer 계약·fail-closed | Node 24 | 전용 node:test 25건 + repository contract | 로컬 66/66·216/217 | PASS |
| workflow 배선 | CI | workflow 텍스트 계약 테스트 20/20 | 로컬 실행 | PASS |
| 실 RC identity 결속 | CI artifact | run 29588623403 rc-evidence-manifest로 CLI 실측 (a)/(b) 두 경로 | 본문 검증 절 | PASS |
| UI/실기기 | - | 본 PR은 판정 tooling·workflow만 변경, 사용자 표시 변경 없음 | 해당 없음 | N/A |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `generate-route-integration-verdict.mjs`의 identity 일치·NO_GO 조건 판정과 fail-closed 기본값, `release-artifacts.yml` 배선이 기존 rc-evidence-manifest job 계약을 깨지 않는지.

## 리스크

- verdict는 producer attestation 충족 전까지 CI에서 NO_GO로 유지됩니다(의도된 fail-closed). E9(ITX-청춘 표시)는 별도 수정 PR로 해소 예정, E1(route-map)은 #2068 identity-bound evidence producer가 생기면 자동 배선 대상입니다.
- workflow 변경은 텍스트 계약 테스트로 검증했고 실제 Actions 실행은 병합 후 main RC cut에서 확인이 필요합니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 모바일 사용 시나리오와 Route v2 회귀 검증 결과를 자동으로 수집합니다.
  * 릴리스 후보의 경로 통합 상태를 여러 검증 증거를 바탕으로 종합 판정합니다.
  * 검증 결과에 시나리오별 상태, 차단 사유 및 아티팩트 연결 정보를 제공합니다.

* **개선 사항**
  * 필수 정보가 누락되거나 릴리스 식별자가 일치하지 않으면 자동으로 안전하게 차단합니다.
  * 경로 검색 및 ITX-청춘 관련 통합 검증 범위를 강화했습니다.

* **테스트**
  * 정상 통과, 누락 정보, 잘못된 입력 및 회귀 시나리오에 대한 검증을 확대했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->