### PR TITLE
[Mobile] #1414 길찾기 ITX-청춘 leg 서비스 식별 배지 추가

### DIFF
--- a/apps/mobile/lib/features/stations/presentation/service_pattern_badge.dart
+++ b/apps/mobile/lib/features/stations/presentation/service_pattern_badge.dart
@@ -4,39 +4,61 @@ import '../../../accessible_design.dart';
 import '../../../design_tokens.dart';
 import '../domain/station_models.dart';
 
-/// 급행 운행 정보 배지.
+/// 운행 정보 배지.
 ///
 /// 일반/급행은 선택 컨트롤이 아니라 실제 운행 정보다. `serviceClass=SUBWAY`이고
 /// `servicePattern=EXPRESS`인 출발 행에만 `급행` 텍스트 배지를 노출하고,
 /// 일반(LOCAL)에는 아무 배지도 붙이지 않는다. 시간표 화면과 노선도 하단 패널이
 /// 같은 배지를 공유해 표시 규칙을 일치시킨다.
 ///
+/// 같은 중립 pill을 길찾기 승차 leg의 서비스 식별에도 재사용한다. `급행`(SUBWAY/
+/// EXPRESS) 외에 `ITX-청춘`(serviceClass=ITX_CHEONGCHUN)처럼 별도 운임의 좌석 지정
+/// 서비스를 일반 전동차와 구분해 표시한다. 배지 텍스트만 다르고 시각·semantics
+/// 규칙은 동일하다.
+///
 /// 시각 원칙: 무채색 중립 아웃라인 pill(각진 radius 8, 그림자 0). 눌러도 상태가
 /// 바뀌지 않으며 toggle/chip/filter semantics를 갖지 않는다. 배지는 장식이므로
-/// semantics에서 제외하고, TalkBack용 `급행`은 행 semanticLabel이 한 번만 제공한다.
+/// semantics에서 제외하고, TalkBack용 라벨은 행/leg semanticLabel이 한 번만 제공한다.
 class ServicePatternBadge extends StatelessWidget {
   const ServicePatternBadge({required this.departure, super.key})
-    : _alwaysExpress = false;
+    : _forcedLabel = null,
+      _badgeKey = _expressBadgeKey;
 
   /// 시간표 출발 행이 아닌 곳(길찾기 승차 leg 등)에서 급행 배지를 재사용하기 위한
   /// 생성자. 호출부가 `serviceClass=SUBWAY && servicePattern=EXPRESS`를 이미 판정한
   /// 뒤 항상 배지를 그린다. 시각·semantics 규칙은 시간표 배지와 동일하다.
   const ServicePatternBadge.express({super.key})
     : departure = null,
-      _alwaysExpress = true;
+      _forcedLabel = '급행',
+      _badgeKey = _expressBadgeKey;
+
+  /// 길찾기 승차 leg에서 ITX-청춘 좌석 지정 서비스를 같은 중립 pill로 식별 표시하는
+  /// 생성자. 호출부가 `serviceClass=ITX_CHEONGCHUN`을 이미 판정한 뒤 항상 배지를
+  /// 그린다. 일반 전동차와 화면상 구분되지 않으면 오인 위험이 있어 별도 표시한다.
+  const ServicePatternBadge.itxCheongchun({super.key})
+    : departure = null,
+      _forcedLabel = 'ITX-청춘',
+      _badgeKey = _itxCheongchunBadgeKey;
+
+  static const Key _expressBadgeKey = Key('servicePatternExpressBadge');
+  static const Key _itxCheongchunBadgeKey = Key(
+    'servicePatternItxCheongchunBadge',
+  );
 
   final StationTimetableDeparture? departure;
-  final bool _alwaysExpress;
+  final String? _forcedLabel;
+  final Key _badgeKey;
 
   @override
   Widget build(BuildContext context) {
-    final isExpress = _alwaysExpress || (departure?.isExpress ?? false);
-    if (!isExpress) {
+    final label =
+        _forcedLabel ?? ((departure?.isExpress ?? false) ? '급행' : null);
+    if (label == null) {
       return const SizedBox.shrink();
     }
     return ExcludeSemantics(
       child: Container(
-        key: const Key('servicePatternExpressBadge'),
+        key: _badgeKey,
         decoration: BoxDecoration(
           color: EasySubwayAccessibleColors.surface,
           borderRadius: BorderRadius.circular(EasySubwayRadius.control),
@@ -44,7 +66,7 @@ class ServicePatternBadge extends StatelessWidget {
         ),
         padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
         child: Text(
-          '급행',
+          label,
           style: Theme.of(context).textTheme.labelLarge?.copyWith(
             color: EasySubwayAccessibleColors.secondaryText,
             fontWeight: FontWeight.w700,

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -2170,6 +2170,10 @@ class RouteSearchStep {
   bool get isSubwayExpress =>
       serviceClass == 'SUBWAY' && servicePattern == 'EXPRESS';
 
+  /// 승차 정보 영역에 `ITX-청춘` 서비스 식별 배지를 노출하는 유일한 조건. 별도
+  /// 운임의 좌석 지정 서비스라 같은 노선의 일반 전동차와 구분해 표시한다.
+  bool get isItxCheongchun => serviceClass == 'ITX_CHEONGCHUN';
+
   RouteSearchStep withDisplayLabels({
     required String title,
     required String lineName,
@@ -6089,6 +6093,20 @@ class _RouteStepTile extends StatelessWidget {
               child: Semantics(
                 label: '급행',
                 child: const ServicePatternBadge.express(),
+              ),
+            ),
+          ],
+          // ITX-청춘 승차 leg는 별도 운임의 좌석 지정 서비스라 같은 노선 일반 전동차와
+          // 구분해 표시한다. serviceClass=SUBWAY와 상호 배타라 급행 배지와 동시에
+          // 붙지 않는다. 배지는 장식이라 ExcludeSemantics로 두고 TalkBack용
+          // `ITX-청춘`은 이 Semantics가 한 번만 준다.
+          if (step.stepType == 'ride' && step.isItxCheongchun) ...[
+            const SizedBox(height: 6),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: Semantics(
+                label: 'ITX-청춘',
+                child: const ServicePatternBadge.itxCheongchun(),
               ),
             ),
           ],

--- a/apps/mobile/test/route_search_test.dart
+++ b/apps/mobile/test/route_search_test.dart
@@ -1602,6 +1602,17 @@ void main() {
       expect(step.isSubwayExpress, isFalse);
     });
 
+    test('RIDE ITX_CHEONGCHUN/LOCAL leg도 ITX-청춘 서비스 식별을 유지한다', () {
+      // isItxCheongchun은 servicePattern과 무관하게 serviceClass만 본다(의도 동작).
+      // EXPRESS 케이스만 고정되어 있으면 LOCAL 회귀를 못 잡으므로 별도로 고정한다.
+      final leg = RouteSearchV2Leg.fromJson(
+        _rideLegJson(serviceClass: 'ITX_CHEONGCHUN', servicePattern: 'LOCAL'),
+      );
+      final step = RouteSearchStep.fromV2(1, leg);
+      expect(step.isItxCheongchun, isTrue);
+      expect(step.isSubwayExpress, isFalse);
+    });
+
     test('RIDE SUBWAY leg은 ITX-청춘이 아니다', () {
       final local = RouteSearchStep.fromV2(
         1,

--- a/apps/mobile/test/route_search_test.dart
+++ b/apps/mobile/test/route_search_test.dart
@@ -1592,6 +1592,33 @@ void main() {
       expect(RouteSearchStep.fromV2(1, leg).isSubwayExpress, isFalse);
     });
 
+    test('RIDE ITX_CHEONGCHUN leg은 ITX-청춘 서비스 식별로 파생된다', () {
+      final leg = RouteSearchV2Leg.fromJson(
+        _rideLegJson(serviceClass: 'ITX_CHEONGCHUN', servicePattern: 'EXPRESS'),
+      );
+      final step = RouteSearchStep.fromV2(1, leg);
+      expect(step.isItxCheongchun, isTrue);
+      // ITX-청춘은 급행 배지와 상호 배타다.
+      expect(step.isSubwayExpress, isFalse);
+    });
+
+    test('RIDE SUBWAY leg은 ITX-청춘이 아니다', () {
+      final local = RouteSearchStep.fromV2(
+        1,
+        RouteSearchV2Leg.fromJson(
+          _rideLegJson(serviceClass: 'SUBWAY', servicePattern: 'LOCAL'),
+        ),
+      );
+      final express = RouteSearchStep.fromV2(
+        1,
+        RouteSearchV2Leg.fromJson(
+          _rideLegJson(serviceClass: 'SUBWAY', servicePattern: 'EXPRESS'),
+        ),
+      );
+      expect(local.isItxCheongchun, isFalse);
+      expect(express.isItxCheongchun, isFalse);
+    });
+
     test('non-ride leg의 service 필드는 null만 허용한다', () {
       final walk = _rideLegJson(legType: 'WALK')
         ..remove('serviceClass')

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -4982,6 +4982,135 @@ void main() {
     }
   });
 
+  testWidgets('길찾기 ITX-청춘 승차 leg은 선택 UI 없이 ITX-청춘 서비스 식별을 표시한다', (
+    tester,
+  ) async {
+    // #1414/#2099: ITX-청춘은 별도 운임의 좌석 지정 서비스라 같은 노선의 일반
+    // 전동차와 화면에서 구분되어야 한다. serviceClass=ITX_CHEONGCHUN 승차 step에만
+    // `ITX-청춘` 배지가 1회 붙고, generic 급행 배지·선택 컨트롤은 없다.
+    final semanticsHandle = tester.ensureSemantics();
+    final routeRepository = FakeRouteSearchRepository(
+      result: _sampleRouteSearchResult(
+        steps: const [
+          RouteSearchStep(
+            sequence: 1,
+            stepType: 'ride',
+            title: '상록수역에서 춘천행 승차',
+            description: '승강장에서 열차를 타고 이동합니다.',
+            lineId: 'gyeongchun',
+            lineName: '수도권 경춘',
+            fromStationId: 'station-sangnoksu',
+            toStationId: 'station-sadang',
+            estimatedMinutes: 40,
+            distanceMeters: 30000,
+            includesStairs: false,
+            requiresAccessibilityCheck: false,
+            actionTitle: '춘천행 열차 승차',
+            serviceClass: 'ITX_CHEONGCHUN',
+            servicePattern: 'EXPRESS',
+          ),
+        ],
+      ),
+    );
+    try {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: RouteSearchScreen(
+            repository: routeRepository,
+            stationRepository: FakeStationSearchRepository(),
+            favoriteRouteRepository: FakeFavoriteRouteRepository(),
+            initialDraft: RouteDraft(
+              origin: const RouteDraftStation(
+                id: 'station-sangnoksu',
+                nameKo: '상록수',
+              ),
+              destination: const RouteDraftStation(
+                id: 'station-sadang',
+                nameKo: '사당',
+              ),
+              lastModifiedAt: DateTime(2026, 7, 17),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // 승차 leg에 ITX-청춘 배지 1회, 텍스트도 1회.
+      expect(
+        find.byKey(const Key('servicePatternItxCheongchunBadge')),
+        findsOneWidget,
+      );
+      expect(find.text('ITX-청춘'), findsOneWidget);
+      // TalkBack은 ITX-청춘을 정확히 한 번만 읽는다(배지는 장식, 라벨은 leg가 1회).
+      expect(find.bySemanticsLabel(RegExp('ITX-청춘')), findsOneWidget);
+      // generic 급행 배지·라벨은 ITX leg에 0건.
+      expect(find.byKey(const Key('servicePatternExpressBadge')), findsNothing);
+      expect(find.text('급행'), findsNothing);
+      expect(find.bySemanticsLabel(RegExp('급행')), findsNothing);
+      // 서비스 식별은 실제 운행 정보다 — toggle/chip/filter 선택 컨트롤 0건.
+      expect(find.byType(ChoiceChip), findsNothing);
+      expect(find.byType(FilterChip), findsNothing);
+      expect(find.byType(Switch), findsNothing);
+    } finally {
+      semanticsHandle.dispose();
+    }
+  });
+
+  testWidgets('길찾기 SUBWAY 승차 leg에는 ITX-청춘 표시가 붙지 않는다', (tester) async {
+    // ITX-청춘 식별은 serviceClass=ITX_CHEONGCHUN 승차 leg에만 붙는다. SUBWAY
+    // 일반/급행 leg에는 ITX-청춘 배지·텍스트가 0건이어야 한다.
+    final routeRepository = FakeRouteSearchRepository(
+      result: _sampleRouteSearchResult(
+        steps: const [
+          RouteSearchStep(
+            sequence: 1,
+            stepType: 'ride',
+            title: '상록수역에서 오이도행 승차',
+            description: '승강장에서 열차를 타고 이동합니다.',
+            lineId: 'seoul-4',
+            lineName: '수도권 4호선',
+            fromStationId: 'station-sangnoksu',
+            toStationId: 'station-sadang',
+            estimatedMinutes: 18,
+            distanceMeters: 12000,
+            includesStairs: false,
+            requiresAccessibilityCheck: false,
+            actionTitle: '오이도행 열차 승차',
+            serviceClass: 'SUBWAY',
+            servicePattern: 'LOCAL',
+          ),
+        ],
+      ),
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RouteSearchScreen(
+          repository: routeRepository,
+          stationRepository: FakeStationSearchRepository(),
+          favoriteRouteRepository: FakeFavoriteRouteRepository(),
+          initialDraft: RouteDraft(
+            origin: const RouteDraftStation(
+              id: 'station-sangnoksu',
+              nameKo: '상록수',
+            ),
+            destination: const RouteDraftStation(
+              id: 'station-sadang',
+              nameKo: '사당',
+            ),
+            lastModifiedAt: DateTime(2026, 7, 17),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const Key('servicePatternItxCheongchunBadge')),
+      findsNothing,
+    );
+    expect(find.text('ITX-청춘'), findsNothing);
+  });
+
   testWidgets('GPS 하단 패널은 열차 정보가 없어도 인접역 두 방면 스켈레톤(제목+대시+구분선)을 유지한다', (
     tester,
   ) async {


### PR DESCRIPTION
## 관련 이슈

Refs #1414

## 작업 배경

- 길찾기 RIDE leg 표시는 catalog `lines.name_ko` 노선명 렌더이며, ITX-청춘 canonical line은 production datapack에서 `수도권 경춘`으로 해석됩니다. `serviceClass=ITX_CHEONGCHUN` leg에 서비스 식별을 표시하는 코드 경로가 없어 같은 노선의 일반 전동차와 화면에서 구분되지 않았습니다.
- ITX-청춘은 별도 운임의 좌석 지정 서비스라 사용자 오인 위험이 있고, #2099 계약("ITX_CHEONGCHUN/EXPRESS는 ITX-청춘 표시 유지, generic 급행 중복 0건")의 표시 절반이 미충족이었습니다. #1414 E9 통합 판정의 FAIL 사유입니다.

## 작업 내용

- `ServicePatternBadge`를 최소 일반화해 `ServicePatternBadge.itxCheongchun()` 형제 생성자를 추가했습니다(key `servicePatternItxCheongchunBadge`). 기존 급행 배지의 무채색 아웃라인 pill·radius 8·그림자 0 토큰과 `ExcludeSemantics` 규칙을 그대로 재사용하고 새 색상 체계·위젯 계층을 만들지 않았습니다. 기존 `.express()` 동작·key는 불변입니다.
- `RouteSearchStep.isItxCheongchun` getter(`serviceClass == 'ITX_CHEONGCHUN'`)를 추가하고 승차 정보 영역에 ride leg 한정 ITX-청춘 배지를 렌더합니다. SUBWAY 전용 급행 배지와 상호 배타라 동시 노출이 없고, `Semantics` label로 TalkBack `ITX-청춘` 1회만 제공합니다.
- 시간표 화면·request identity·노선도는 변경하지 않습니다.

## 검증

- 실행한 명령과 결과 (apps/mobile, Flutter 3.44.0):
  - `dart format --output=none --set-exit-if-changed lib test` — Formatted 270 files (0 changed)
  - `flutter analyze` — No issues found!
  - `flutter test test/route_search_test.dart test/route_search_request_test.dart` — All tests passed! (route_search 56 tests)
  - `flutter test test/widget_test.dart` — All tests passed! (+295, 신규 ITX 위젯 테스트 2건·기존 급행 통합 테스트 포함)

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| ITX leg 배지·텍스트·semantics 각 1회 | Mobile | widget test (ITX_CHEONGCHUN/EXPRESS leg 렌더) | `test/widget_test.dart` 신규 테스트 | PASS |
| ITX leg에 급행 배지/텍스트/semantics 0건 | Mobile | widget test + 기존 회귀 `route_search_test.dart` | 위와 동일 + 기존 1586행 회귀 | PASS |
| SUBWAY leg에 ITX-청춘 0건 | Mobile | widget test | `test/widget_test.dart` 신규 테스트 | PASS |
| text scale·소폭·landscape 레이아웃 | Mobile | 기존 급행 배지와 동일 단일 Align 레이아웃·토큰 재사용으로 코드 경로 동일 — 실기기 debug 빌드 교체는 사전 승인 대상이라 미실행 | 사유 기재 | N/A |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `ServicePatternBadge` 일반화가 기존 급행 배지 key·semantics 계약을 바꾸지 않는지, ITX 배지 렌더 조건이 ride leg + `ITX_CHEONGCHUN`에만 한정되는지.

## 리스크

- 렌더 조건은 `serviceClass == 'ITX_CHEONGCHUN'`에만 의존하며, 백엔드가 ITX-청춘 RIDE leg에 해당 serviceClass를 싣는 계약은 #2098에서 검증된 기존 계약입니다.
- 실기기 육안 검증은 미실행(기존 급행 배지와 동일 레이아웃 재사용) — 필요 시 오너 승인 후 수행 가능합니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
