### PR TITLE
[Chore] datapack release request를 현행 build spec에 재결속 (재승인 2026-07-18)

### DIFF
--- a/tools/datapack/release/hash-evidence.json
+++ b/tools/datapack/release/hash-evidence.json
@@ -62,7 +62,7 @@
       "note": "파일 기반 경로는 backend candidate 행을 우회하므로 리포에 고정 명명 계약 없음. fixture 선례(capital-pilot-candidate-fixture)+snapshot 날짜 관례로 명명. release-request.candidateId와 동일(자체 정합)."
     },
     "approvalId": {
-      "value": "release-request-2026-07-12-01",
+      "value": "release-request-2026-07-18-01",
       "note": "파일 기반 경로 임의 고유 문자열 허용(workflow 183행은 modeArgs.releaseRequestId와 일치만 강제). 선행 조사 문서의 날짜+연번 관례."
     }
   },

--- a/tools/datapack/release/release-request.json
+++ b/tools/datapack/release/release-request.json
@@ -3,11 +3,11 @@
   "artifactKind": "datapack-release-request",
   "candidateId": "capital-pilot-candidate-20260712",
   "scopeId": "capital_pilot_android_v1",
-  "buildSpecSha256": "8627ec0721ff30942cb708a4380fb558140ebc9d9e566754916d6a94692ab14d",
+  "buildSpecSha256": "3856b5d2b9afe913b3d6e17a5aeb1ff72c430ab6c4b1568a6752240ee04b221d",
   "sourceSnapshotSetHash": "722d5bb834c56ac408f6babcdc21d471144defdfc66bd88e92216fab3c7e67e0",
   "approvedLedgerHash": "9a74e31d64e53f38ab575d6a7731f72138523dd34f1f6756dbed8573e3bdeabc",
   "requestedBy": "claude-fable-orchestrator",
   "approvedBy": "aquilaXk10",
-  "approvalId": "release-request-2026-07-12-01",
+  "approvalId": "release-request-2026-07-18-01",
   "targetChannel": "production"
 }


### PR DESCRIPTION
## 관련 이슈

Refs AquilaXk/easysubway-backend#3, Refs AquilaXk/easysubway#1018

## 작업 배경

datapack production 게시가 CHANGE_BLOCKED(`MATERIAL_CHANGE_UNAPPROVED` + `PUBLISH_SEQUENCE_NOT_INCREASING`) 상태였다. `release-request.json`의 승인이 기록한 `buildSpecSha256`(`8627ec07…`)이, 이후 AquilaXk/easysubway#2187 ITX topology 반입과 AquilaXk/easysubway#2226·#2234 prelaunch gate 자동화가 `candidate-build-spec.json`을 재생성하면서 현행 build spec 해시(`3856b5d2…`)와 어긋났기 때문이다. 그 결과 `decide-datapack-release.mjs`의 `validApproval()`이 승인을 무효로 판정한다.

2026-07-18 오너 세션 승인 게이트에서 datapack release request 재승인·production publish를 명시 승인했다. 새 approvalId `release-request-2026-07-18-01`로 request를 현행 build spec에 재결속한다. 선례: 커밋 `84975245`(#2155)가 같은 파일을 build spec 변경에 맞춰 재결속한 방식.

## 작업 내용

- `tools/datapack/release/release-request.json`
  - `buildSpecSha256`: `8627ec07…` → `3856b5d2b9afe913b3d6e17a5aeb1ff72c430ab6c4b1568a6752240ee04b221d` (현행 `candidate-build-spec.json`의 `shasum -a 256` 실측)
  - `approvalId`: `release-request-2026-07-12-01` → `release-request-2026-07-18-01`
- `tools/datapack/release/hash-evidence.json`
  - `identifiers.approvalId.value`를 새 approvalId로 동기화(evidence 문서 정합·truthfulness 유지)
- 불변 항목: `sourceSnapshotSetHash`(`722d5bb8…`)·`approvedLedgerHash`(`9a74e31d…`)·`candidateId`는 build spec의 `sourceSnapshotSetHash`·`approvedAliasLedgerHash`·`candidateId`와 이미 일치하여 변경 없음.
- `releaseSequence`는 candidate manifest 빌드 시점에 자동 산출되며 `tools/datapack/release/`에 tracked 원본이 없어 미변경(`git grep releaseSequence`로 확인). `validApproval` 복원으로 material-change 승인이 유효화되면 gate가 재평가된다.

## 검증

- 실행한 명령과 결과:
  - `validApproval` 술어 실측 재현: `buildSpecSha256`/`candidateId`/`sourceSnapshotSetHash`/`approvedLedgerHash` 모두 build spec과 일치, `targetChannel=production`, `requestedBy≠approvedBy` → 전부 PASS
  - `LC_ALL=C node --test tools/ci/repository-contract.test.mjs` → 215 pass / 0 fail
  - `node --test tools/datapack/decide-datapack-release.test.mjs` → 15 pass / 0 fail
  - `node --test tools/datapack/datapack-tools.test.mjs` → 328 pass / 0 fail (hash-evidence.json 소비 테스트)
  - JSON parse 2종 OK, `git diff --check` clean

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| validApproval 술어 재결속 | tooling | node 실측 재현 스크립트 | buildSpecSha256=3856b5d2…, 4개 매칭 필드 전부 true | PASS |
| release gate 계약 회귀 | tooling | `node --test` 3개 스위트 | 215+15+328 pass / 0 fail | PASS |
| JSON 유효성 | tooling | JSON.parse | release-request.json·hash-evidence.json 파싱 OK | PASS |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [x] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] AquilaXk/easysubway#1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: capital@1 (재게시 대상, pack 버전 불변)
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `release-request.json`의 `buildSpecSha256`가 현행 `candidate-build-spec.json`의 `shasum -a 256` 실측값(`3856b5d2…`)과 일치하는지, `sourceSnapshotSetHash`/`approvedLedgerHash`/`candidateId`가 build spec과 정합인지.
- 값은 전부 실측이며 임의 합성값 없음. `hash-evidence.json`은 approvalId 문자열만 동기화했고 파일 내 어떤 recorded hash에도 approvalId가 입력되지 않아 cascade 없음.

## 리스크

- 낮음. 데이터 원천(fixture·snapshot·pack)·datapack 콘텐츠는 불변이고, 승인 식별자와 build spec 바인딩 해시만 현행값으로 재결속했다. 잘못된 해시는 `validApproval`이 fail-closed로 차단하므로 오결속 위험이 게이트에서 방어된다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)