### PR TITLE
[Fix] 격리 capacity restore를 postgres init 완료 후로 gate (Refs #2095)

### DIFF
--- a/tools/ops/verify-production-route-v2-capacity.sh
+++ b/tools/ops/verify-production-route-v2-capacity.sh
@@ -268,7 +268,8 @@ docker run -d --name "${clone_db}" --network "${network}" --network-alias postgr
 
 db_ready=false
 for _ in $(seq 1 90); do
-	if docker exec "${clone_db}" sh -lc 'pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"' >/dev/null 2>&1; then
+	if [[ "$(docker exec "${clone_db}" cat /proc/1/comm 2>/dev/null || true)" == postgres ]] \
+		&& docker exec "${clone_db}" sh -lc 'pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"' >/dev/null 2>&1; then
 		db_ready=true
 		break
 	fi


### PR DESCRIPTION
## 관련 이슈

Refs AquilaXk/easysubway-backend#3

## 작업 배경

production self-hosted runner에서 `production-route-v2-capacity-evidence.yml`
([run 29598347931](https://github.com/AquilaXk/easysubway/actions/runs/29598347931),
`EXPECTED_DEPLOYED_SHA=cac3a9b8…`)의 최초 실행이 격리 PostgreSQL restore 단계에서
아래 오류로 실패했다.

```
pg_restore: error: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: FATAL:  database "easysubway" does not exist
```

원인: `tools/ops/verify-production-route-v2-capacity.sh`의 격리 컨테이너 readiness
loop가 `pg_isready`만 확인했다. postgres 이미지의 최초 init은 임시 local-socket
서버를 띄워 init 스크립트를 실행하고 이 단계에서 `POSTGRES_DB`(=`easysubway`)를
생성한다. `pg_isready`는 이 부트스트랩 임시 서버에도 성공을 돌려주므로 loop가
DB 생성 완료 전에 조기 통과했고, 곧바로 실행된 `pg_restore -d "$POSTGRES_DB"`가
아직 대상 DB가 없는 임시 서버에 붙어 실패했다. 운영 DB에는 접근하지 않았고, 격리
컨테이너 자체의 준비 판정만 잘못돼 있었다.

## 작업 내용

- 격리 PostgreSQL readiness gate를 동작 검증된 선례
  `tools/ops/verify-production-timetable-snapshot.sh`(readiness 판정에서
  `cat /proc/1/comm == postgres`와 `pg_isready`를 함께 확인)와 동일한 패턴으로
  맞췄다. `docker exec "${clone_db}" cat /proc/1/comm`이 `postgres`가 될 때만
  준비 완료로 본다 — 이는 entrypoint가 init을 마치고 실서버를 `exec`한 이후에만
  참이므로, `POSTGRES_DB` 생성이 끝난 상태에서만 `pg_restore`로 진행한다.
- 격리 경계(운영 DB 무기록)와 계약 marker(`docker network create --internal`,
  resource cap, 3 profile, privacy counts, cleanup trap, `ingress_closed=true`
  등)는 그대로 유지했다. 로그로 실증되지 않는 다른 리팩토링은 하지 않았다
  (격리 backend의 `jdbc:postgresql://postgres:5432/…` 접속 문자열은 clone_db의
  `--network-alias postgres`와 일치해 정상이라 미변경).

## 검증

- 실행한 명령과 결과:
  - `bash -n tools/ops/verify-production-route-v2-capacity.sh` → OK
  - `shellcheck` → 환경 미설치로 미실행
  - `LC_ALL=C node --test tools/ci/production-route-v2-capacity-evidence-workflow.test.mjs tools/ci/repository-contract.test.mjs` → `pass 219 / fail 0`
  - `git diff --check` → OK

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| runner 스크립트 계약 | CI | `node --test` 계약 테스트 2종 | 위 검증 로그 (pass 219/fail 0) | PASS |
| 스크립트 문법 | CI | `bash -n`, `git diff --check` | 위 검증 로그 | PASS |
| 실제 runner 격리 restore | production self-hosted runner | 워크플로 재실행으로 확인 필요 | run 29598347931(실패)에 대한 후속 재실행 | 병합 후 재실행 예정 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [ ] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] AquilaXk/easysubway#1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [ ] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `tools/ops/verify-production-route-v2-capacity.sh`의
  `db_ready` loop 한 곳. 선례 `verify-production-timetable-snapshot.sh`의
  readiness gate와 동일한지, 그리고 `pg_restore` 대상 DB가 init 완료 후에만
  붙는지 확인.

## 리스크

- 기능 변경 없이 readiness 판정만 강화했다. 실제 fail-fix는 병합 후 production
  runner에서 워크플로를 재실행해 최종 확인해야 한다(에이전트는 production
  호스트에 직접 접근 불가).

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 격리된 PostgreSQL 환경의 준비 상태 확인을 강화했습니다.
  * 실제 PostgreSQL 프로세스가 실행 중인지 추가로 검증하여 비정상 상태를 더욱 정확히 감지합니다.
  * 기존 대기 횟수와 타임아웃 동작은 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->