### PR TITLE
[Fix] capacity-evidence Play Integrity decoder 생성자 자동 배선 실패 수정 (Refs #2095)

### DIFF
--- a/backend/src/main/java/com/easysubway/route/adapter/out/integrity/CapacityEvidencePlayIntegrityDecoder.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/integrity/CapacityEvidencePlayIntegrityDecoder.java
@@ -9,6 +9,7 @@ import java.util.HexFormat;
 import java.util.List;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
@@ -25,6 +26,7 @@ final class CapacityEvidencePlayIntegrityDecoder implements PlayIntegrityDecoder
 	private final String certificateDigest;
 	private final Clock clock;
 
+	@Autowired
 	CapacityEvidencePlayIntegrityDecoder(
 		@Value("${easysubway.route-v2.capacity-evidence.attestation-key:}") String attestationKey,
 		@Value("${easysubway.route-v2.play-integrity.certificate-sha256:}") String certificateDigest

--- a/tools/ci/production-route-v2-capacity-evidence-workflow.test.mjs
+++ b/tools/ci/production-route-v2-capacity-evidence-workflow.test.mjs
@@ -147,6 +147,17 @@ test("capacity runner는 동일 candidate·격리 load·privacy·closed ingress�
   assert.match(capacityDecoder, /@Profile\("capacity-evidence"\)/);
   assert.match(capacityDecoder, /MessageDigest\.isEqual/);
   assert.match(capacityDecoder, /MEETS_DEVICE_INTEGRITY/);
+  // Spring cannot implicitly resolve which of this class's two constructors to
+  // autowire (neither is a lone/no-arg constructor), so the @Value-based
+  // constructor must be explicitly marked. Without this, bean creation fails
+  // with "No default constructor found" and the isolated backend never
+  // becomes ready — see #2095 run 29625986367.
+  assert.match(capacityDecoder, /@Autowired\s+CapacityEvidencePlayIntegrityDecoder\(/);
+  assert.match(runner, /dump_readiness_diagnostics\(\) \{/);
+  assert.match(runner, /docker logs --tail 40 "\$\{container\}"/);
+  assert.match(runner, /grep -Ev '\^\[A-Za-z_\]\[A-Za-z0-9_\]\*=\|PASSWORD\|SECRET\|_KEY\|PEPPER\|ATTESTATION'/);
+  assert.match(runner, /dump_readiness_diagnostics "\$\{clone_backend\}"/);
+  assert.match(runner, /dump_readiness_diagnostics "\$\{clone_gateway\}"/);
   assert.match(runner, /timetable snapshot identity is invalid/);
   assert.match(runner, /normal_state_count_before/);
   assert.match(runner, /normal_state_count_after/);

--- a/tools/ci/production-route-v2-capacity-evidence-workflow.test.mjs
+++ b/tools/ci/production-route-v2-capacity-evidence-workflow.test.mjs
@@ -155,7 +155,12 @@ test("capacity runner는 동일 candidate·격리 load·privacy·closed ingress�
   assert.match(capacityDecoder, /@Autowired\s+CapacityEvidencePlayIntegrityDecoder\(/);
   assert.match(runner, /dump_readiness_diagnostics\(\) \{/);
   assert.match(runner, /docker logs --tail 40 "\$\{container\}"/);
-  assert.match(runner, /grep -Ev '\^\[A-Za-z_\]\[A-Za-z0-9_\]\*=\|PASSWORD\|SECRET\|_KEY\|PEPPER\|ATTESTATION'/);
+  assert.match(
+    runner,
+    /grep -iEv '\^\[A-Za-z_\]\[A-Za-z0-9_\.-\]\*=\|password\|secret\|_key\|-key\|pepper\|attestation\|token\|credential\|private\|jdbc:\|:\/\/\[\^ \]\*@'/,
+  );
+  assert.ok(runner.indexOf("dump_readiness_diagnostics() {") < runner.indexOf('docker run -d --name "${clone_curl}"'));
+  assert.match(runner, /dump_readiness_diagnostics "\$\{clone_curl\}"/);
   assert.match(runner, /dump_readiness_diagnostics "\$\{clone_backend\}"/);
   assert.match(runner, /dump_readiness_diagnostics "\$\{clone_gateway\}"/);
   assert.match(runner, /timetable snapshot identity is invalid/);

--- a/tools/ops/verify-production-route-v2-capacity.sh
+++ b/tools/ops/verify-production-route-v2-capacity.sh
@@ -377,6 +377,20 @@ docker run -d --name "${clone_backend}" --network "${network}" --network-alias b
 # helper for that purpose — built from the already-pulled backend image (which ships
 # curl), kept out of docker_stats/OOM/restart sampling so load-generation traffic
 # never taints the backend/gateway resource-peak evidence.
+#
+# On a readiness timeout (curl helper, backend, or gateway), tail the failing
+# container's own log to surface the actual boot failure (e.g. a Spring bean
+# creation error) instead of only the generic "timed out" message. Filter out
+# anything shaped like a raw KEY=VALUE env dump line or an obviously
+# secret/credential/DB-URL-bearing line, since these clones are started from
+# files containing synthetic credentials and a production DB URL.
+dump_readiness_diagnostics() {
+	local container="${1:?container name is required}"
+	echo "--- ${container} last log lines (tail 40, env-dump/secret lines filtered) ---" >&2
+	docker logs --tail 40 "${container}" 2>&1 \
+		| grep -iEv '^[A-Za-z_][A-Za-z0-9_.-]*=|password|secret|_key|-key|pepper|attestation|token|credential|private|jdbc:|://[^ ]*@' >&2 || true
+}
+
 docker run -d --name "${clone_curl}" --network "${network}" --user "$(id -u):$(id -g)" --entrypoint sh \
 	--cpus 1 --memory 128m --memory-swap 128m --pids-limit 64 \
 	-v "${work_dir}:${work_dir}" \
@@ -389,19 +403,11 @@ for _ in $(seq 1 30); do
 	fi
 	sleep 1
 done
-[[ "${curl_helper_ready}" == true ]] || { echo 'isolated curl helper is missing curl or failed to start' >&2; exit 1; }
-
-# On a readiness timeout, tail the failing container's own log to surface the
-# actual boot failure (e.g. a Spring bean creation error) instead of only the
-# generic "timed out" message. Filter out anything shaped like a raw KEY=VALUE
-# env dump line or an obviously secret-labeled line, since these clones are
-# started from files containing synthetic credentials and a production DB URL.
-dump_readiness_diagnostics() {
-	local container="${1:?container name is required}"
-	echo "--- ${container} last log lines (tail 40, env-dump/secret lines filtered) ---" >&2
-	docker logs --tail 40 "${container}" 2>&1 \
-		| grep -Ev '^[A-Za-z_][A-Za-z0-9_]*=|PASSWORD|SECRET|_KEY|PEPPER|ATTESTATION' >&2 || true
-}
+if [[ "${curl_helper_ready}" != true ]]; then
+	echo 'isolated curl helper is missing curl or failed to start' >&2
+	dump_readiness_diagnostics "${clone_curl}"
+	exit 1
+fi
 
 backend_ready=false
 for _ in $(seq 1 120); do

--- a/tools/ops/verify-production-route-v2-capacity.sh
+++ b/tools/ops/verify-production-route-v2-capacity.sh
@@ -391,6 +391,18 @@ for _ in $(seq 1 30); do
 done
 [[ "${curl_helper_ready}" == true ]] || { echo 'isolated curl helper is missing curl or failed to start' >&2; exit 1; }
 
+# On a readiness timeout, tail the failing container's own log to surface the
+# actual boot failure (e.g. a Spring bean creation error) instead of only the
+# generic "timed out" message. Filter out anything shaped like a raw KEY=VALUE
+# env dump line or an obviously secret-labeled line, since these clones are
+# started from files containing synthetic credentials and a production DB URL.
+dump_readiness_diagnostics() {
+	local container="${1:?container name is required}"
+	echo "--- ${container} last log lines (tail 40, env-dump/secret lines filtered) ---" >&2
+	docker logs --tail 40 "${container}" 2>&1 \
+		| grep -Ev '^[A-Za-z_][A-Za-z0-9_]*=|PASSWORD|SECRET|_KEY|PEPPER|ATTESTATION' >&2 || true
+}
+
 backend_ready=false
 for _ in $(seq 1 120); do
 	if [[ "$(docker exec "${clone_curl}" curl -sS --noproxy '*' --connect-timeout 1 --max-time 2 -o /dev/null -w '%{http_code}' "http://backend:8080/actuator/health/readiness" 2>/dev/null || true)" == 200 ]]; then
@@ -399,7 +411,11 @@ for _ in $(seq 1 120); do
 	fi
 	sleep 1
 done
-[[ "${backend_ready}" == true ]] || { echo 'isolated backend readiness timed out' >&2; exit 1; }
+if [[ "${backend_ready}" != true ]]; then
+	echo 'isolated backend readiness timed out' >&2
+	dump_readiness_diagnostics "${clone_backend}"
+	exit 1
+fi
 
 docker run -d --name "${clone_gateway}" --network "${network}" --network-alias gateway --user 10001:10001 --read-only \
 	--tmpfs /tmp:rw,nosuid,nodev \
@@ -420,7 +436,11 @@ for _ in $(seq 1 60); do
 	fi
 	sleep 1
 done
-[[ "${gateway_ready}" == true ]] || { echo 'isolated gateway readiness timed out' >&2; exit 1; }
+if [[ "${gateway_ready}" != true ]]; then
+	echo 'isolated gateway readiness timed out' >&2
+	dump_readiness_diagnostics "${clone_gateway}"
+	exit 1
+fi
 
 node -e '
 const { createHash, randomBytes } = require("node:crypto");


### PR DESCRIPTION
## 관련 이슈

Refs AquilaXk/easysubway-backend#3

## 작업 배경

[#2247](https://github.com/AquilaXk/easysubway/pull/2247)(restore readiness gate),
[#2248](https://github.com/AquilaXk/easysubway/pull/2248)(격리망 curl helper·최소권한)이
병합·CD 재배포(`5af05efb`)된 뒤에도
[run 29625986367](https://github.com/AquilaXk/easysubway/actions/runs/29625986367)가
`isolated backend readiness timed out`으로 3차 실패했다(01:51:47 시작 → 01:54:40 실패,
총 ~173초). `clone_curl` 프로브(#2248의 F2 수정)는 정상 통과해, curl helper가 아니라
backend 자체가 준비되지 않았다는 신호였다.

## 로컬 재현으로 확정한 근본 원인

배포와 동일한 이미지
`ghcr.io/aquilaxk/easysubway-backend:sha-5af05efbc13d1e5ba0dbbb6092f22648f1844892`를
GHCR에서 pull(`gh auth token | docker login ghcr.io -u AquilaXk --password-stdin`)해,
스크립트와 동일한 격리 토폴로지(`--internal` network, postgres `POSTGRES_DB=easysubway`,
backend `--cpus 1 --memory 1g --memory-swap 1g --pids-limit 256`, 스크립트가 주입하는
env 그대로)로 기동했다. **backend가 기동 ~7초 만에 exit code 1로 죽었다.**
`docker logs` 근본 원인:

```
BeanCreationException: Error creating bean with name 'capacityEvidencePlayIntegrityDecoder'
... Failed to instantiate [...CapacityEvidencePlayIntegrityDecoder]: No default constructor found
Caused by: NoSuchMethodException: ...CapacityEvidencePlayIntegrityDecoder.<init>()
```

`CapacityEvidencePlayIntegrityDecoder`에는 생성자가 2개 있다 — `@Value` 기반 2-인자
생성자(Spring 주입용)와, 고정 `Clock`을 받는 3-인자 생성자(단위테스트 전용,
`CapacityEvidencePlayIntegrityDecoderTest`에서만 직접 호출). 어느 쪽도 `@Autowired`가
없어 Spring이 어느 생성자를 쓸지 암묵적으로 결정하지 못하고 무인자 기본 생성자를
찾다가 실패한다.

**이 결함은 순수 Spring bean 배선 문제라 하드웨어 속도·복원 데이터 크기와 무관하게
`capacity-evidence` 프로필을 켤 때마다 100% 재현된다.** readiness가 "느린" 게 아니라
backend가 아예 뜨지 않았던 것이다. 기존 계약 테스트(`CapacityEvidencePlayIntegrityDecoder.java`
대상)는 `@Profile("capacity-evidence")`, `MessageDigest.isEqual` 같은 정적 문자열만
검사하고 실제 Spring 컨텍스트를 부팅하지 않으므로 이 결함이 그동안 CI에서 드러나지
않았다.

## 작업 내용

- **수정**: Spring이 주입해야 할 2-인자 생성자에 `@Autowired`를 명시했다
  (`backend/src/main/java/com/easysubway/route/adapter/out/integrity/CapacityEvidencePlayIntegrityDecoder.java`).
  3-인자(테스트 전용) 생성자는 그대로 두어 기존 단위 테스트에 영향이 없다.
- **로컬 재검증**: 수정된 소스로 `./gradlew bootJar` → `docker build`로 이미지를
  다시 만들어 동일 토폴로지로 재기동했다. 애플리케이션 자체 기동
  `6.737초`, readiness 200까지 총 `24초`(기존 120초 예산 대비 20%) — **별도의
  timeout 상향은 불필요하다는 근거**로 삼아 적용하지 않았다.
- **진단성 추가**: readiness timeout 시 실패한 컨테이너(backend/gateway 각각)의
  `docker logs --tail 40`을 출력하는 `dump_readiness_diagnostics()`를 추가했다.
  다음에 같은 계열 문제가 나면 뭉뚱그린 "timed out" 메시지 대신 실제 원인 로그가
  CI 출력에 즉시 남는다. 이 클론들은 synthetic secret과 운영 DB URL을 담은 env
  file로 기동되므로, `KEY=VALUE` 형태의 env dump 라인과
  `PASSWORD`/`SECRET`/`_KEY`/`PEPPER`/`ATTESTATION`이 포함된 라인은 `grep -v`로
  방어했다.
- 계약 테스트(`tools/ci/production-route-v2-capacity-evidence-workflow.test.mjs`)에
  `@Autowired` 존재, `dump_readiness_diagnostics()` 정의·필터 패턴·양쪽 호출
  지점(backend/gateway)을 검증하는 assertion을 완화 없이 추가했다. 기존
  `docker network create --internal`, resource cap, 3 profile, privacy counts,
  cleanup trap, `ingress_closed=true` 등 marker는 변경하지 않았다.

## 검증

- 실행한 명령과 결과:
  - 로컬 Docker 재현: 수정 전 backend crash(exit 1, 기동 ~7초 후) → 수정 후
    readiness 200까지 24초(애플리케이션 자체 기동 6.737초) 재현·확인.
  - `cd backend && ./gradlew bootJar -x test` → BUILD SUCCESSFUL
  - `cd backend && ./gradlew test --tests CapacityEvidencePlayIntegrityDecoderTest` → BUILD SUCCESSFUL
  - `bash -n tools/ops/verify-production-route-v2-capacity.sh` → OK
  - `git diff --check` → OK
  - `LC_ALL=C node --test tools/ci/production-route-v2-capacity-evidence-workflow.test.mjs tools/ci/repository-contract.test.mjs` → **pass 221 / fail 0**

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 근본 원인 재현 | 로컬 Docker | 배포 이미지(수정 전)를 동일 토폴로지로 기동 | `docker logs`: `NoSuchMethodException: ...<init>()`, exit 1 ~7초 | 재현 성공 |
| 수정 검증 | 로컬 Docker | 수정 소스로 재빌드한 이미지를 동일 토폴로지로 기동 | readiness 200까지 24초, 애플리케이션 기동 6.737초 | PASS |
| 백엔드 단위 테스트 | 로컬 Gradle | `./gradlew test --tests CapacityEvidencePlayIntegrityDecoderTest` | BUILD SUCCESSFUL | PASS |
| runner 스크립트 계약 | CI | `node --test` 계약 테스트 2종 | 위 검증 로그 (pass 221/fail 0) | PASS |
| 실제 runner 격리 부하 테스트 | production self-hosted runner | 워크플로 재실행으로 확인 필요 | run 29625986367(실패)에 대한 후속 재실행 | 병합 후 재실행 예정 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [ ] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] AquilaXk/easysubway#1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [ ] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: `CapacityEvidencePlayIntegrityDecoder` 생성자 `@Autowired` 추가(런타임 동작 무변경, `capacity-evidence` 프로필 전용 bean 배선 수정)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `CapacityEvidencePlayIntegrityDecoder.java`의
  `@Autowired` 추가 위치(2-인자 생성자만, 3-인자 테스트 전용 생성자는 그대로),
  `verify-production-route-v2-capacity.sh`의 `dump_readiness_diagnostics()`와
  그 필터 정규식, 로컬 재현 수치(24초 vs 기존 120초 예산)가 timeout 상향을
  적용하지 않은 근거로 타당한지.

## 리스크

- 이 결함은 `capacity-evidence` Spring profile이 활성화될 때만(즉 이 격리
  평가 스크립트 안에서만) 트리거된다 — 운영 backend는 이 profile을 켜지
  않으므로 실제 운영 트래픽에는 영향이 없었다.
- `docker logs --tail 40` 필터는 알려진 패턴(`PASSWORD`/`SECRET`/`_KEY` 등)
  기반이라 완전 무결하지 않을 수 있으나, 이 클론은 synthetic 값만 사용하고
  ephemeral·cleanup 대상이라 실질 노출 위험은 낮다.
- 실제 fail-fix는 병합 후 production runner에서 워크플로 재실행으로 최종
  확인이 필요하다(에이전트는 production 호스트에 직접 접근 불가).

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 서비스 준비 상태 확인이 시간 초과될 때 백엔드와 게이트웨이의 최근 로그를 자동으로 수집해 문제 원인을 더 쉽게 파악할 수 있습니다.
  * 진단 로그에서 환경 변수와 민감 정보로 보이는 항목을 제외해 정보 노출 위험을 줄였습니다.
  * 구성 요소 초기화 및 준비 상태 검증이 더욱 안정적으로 동작하도록 점검 항목을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->