### PR TITLE
[Chore] #1018 개인정보 인벤토리 도보 길안내 공유 예외·신고 rate-limit 항목 등재

### DIFF
--- a/apps/mobile/release/play-store-submission-content.json
+++ b/apps/mobile/release/play-store-submission-content.json
@@ -322,7 +322,7 @@
       },
       {
         "dataType": "Device or other IDs",
-        "inventoryDataIds": ["route_v2_itx_integrity", "route_v2_gateway_abuse_rate_limit_state"],
+        "inventoryDataIds": ["route_v2_itx_integrity", "route_v2_gateway_abuse_rate_limit_state", "facility_report_abuse_rate_limit_state"],
         "containsCollectedData": true,
         "containsRequiredData": false,
         "containsOptionalData": true,

--- a/apps/mobile/release/store-privacy-inventory.json
+++ b/apps/mobile/release/store-privacy-inventory.json
@@ -119,6 +119,63 @@
       }
     },
     {
+      "id": "facility_report_abuse_rate_limit_state",
+      "displayNameKo": "시설 신고 악용 방지 상태",
+      "purposeKo": "공개 시설 신고 endpoint의 과도한 요청과 자동화 악용 방지",
+      "implementationStatus": "backend-collected",
+      "introducedInVersion": "1.0.0",
+      "codeOwner": "report",
+      "collectionTrigger": "사용자가 시설 신고 업로드·제출·상태 조회·확정 요청을 보낼 때 filter가 요청 IP별 요청 제한 상태를 갱신",
+      "backendTableOrService": [
+        "FacilityReportAbuseControl OncePerRequestFilter",
+        "FacilityReportAbuseControlLimiter in-memory ConcurrentHashMap counters",
+        "FacilityReportClientIdentityResolver ip:remoteAddr key"
+      ],
+      "storageLocations": ["backend-jvm-memory"],
+      "retentionKo": "고정 TTL은 없다. 요청 IP별 카운터는 JVM 프로세스 heap의 ConcurrentHashMap에만 존재하며 기본 60초 window 단위로 카운트가 재설정된다. 다음 window의 새 키가 삽입될 때 이전 window 항목이 일괄 제거되고, 최대 키 수(기본 4096)를 넘으면 새 키를 저장하지 않고 요청을 거절한다. 최종적으로 JVM 프로세스 종료 시 모두 사라진다.",
+      "deletionKo": "요청 IP는 사용자 계정 DB나 access log에 저장하지 않으며 이 filter 자체가 IP를 로그로 남기지 않는다. window 롤오버·다음 키 삽입 시 이전 window 항목 제거, 용량 초과 시 거절, JVM 프로세스 종료로 자동 삭제된다. 사용자가 직접 삭제를 요청할 수 있는 영속 저장소가 아니다.",
+      "deletionImplementation": "FacilityReportAbuseControlLimiter가 (ReportAbuseGroup, ip:clientIdentity) 키별 WindowCounter를 JVM heap ConcurrentHashMap에서 관리한다. 새 키 생성 시 이전 window 카운터를 removeIf로 제거하고 maxCounterKeys(기본 4096) 초과 시 저장 대신 요청을 거절한다. DB나 access log에는 기록하지 않는다. store-mode는 local만 허용하며 분산 저장소는 구현되어 있지 않다.",
+      "evidence": [
+        "backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAbuseControl.java",
+        "backend/src/main/resources/application-prod.yml",
+        "backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAbuseControlTest.java"
+      ],
+      "lastVerifiedAt": "2026-07-18",
+      "sharedWithThirdParties": false,
+      "usedForTracking": false,
+      "rateLimitedEndpoints": [
+        "POST /api/v1/report-uploads",
+        "PUT /api/v1/report-uploads/{uploadId}",
+        "POST /api/v1/reports",
+        "GET /api/v1/reports/{reportId}",
+        "POST /api/v1/reports/{reportId}/confirm"
+      ],
+      "clientIdentityKey": "ip:remoteAddr (신뢰 프록시 요청은 X-Forwarded-For에서 해석한 클라이언트 IP)",
+      "storeMode": "local",
+      "persistedToDatabase": false,
+      "includedInAccessLog": false,
+      "retention": {
+        "fixedTtl": false,
+        "windowSeconds": 60,
+        "maxCounterKeys": 4096,
+        "evictionBoundary": "prior-window entries removed on next-window key insertion; over-capacity keys rejected without storage",
+        "finalDeletionBoundary": "JVM process lifecycle end"
+      },
+      "operationReference": "https://docs.spring.io/spring-framework/reference/web/webmvc/filters.html",
+      "googlePlayDataSafety": {
+        "dataType": "Device or other IDs",
+        "collected": true,
+        "collectionType": "optional-user-triggered-report-abuse-control",
+        "purpose": "Fraud prevention, security, and compliance",
+        "linkedToUser": true,
+        "encryptedInTransit": true,
+        "optional": true,
+        "required": false,
+        "deletionSupported": false,
+        "processedEphemerally": false
+      }
+    },
+    {
       "id": "precise_location",
       "displayNameKo": "현재 위치",
       "purposeKo": "가까운 역 검색, 시설 신고 위치 확인, 외부 지도 도보 길안내",
@@ -143,6 +200,18 @@
       "lastVerifiedAt": "2026-07-16",
       "sharedWithThirdParties": true,
       "thirdPartySharingKo": "사용자가 출구 도보 길안내를 명시적으로 누른 경우에만 카카오맵 앱/웹을 연다. 앱에는 현재 위치 시작 좌표와 목적지 좌표를, 웹에는 목적지 좌표만 전달한다. 이 외부 지도 전달 좌표는 운영자 서버로 전송하거나 앱에 저장하지 않고 tracking에 사용하지 않는다.",
+      "userInitiatedSharingException": {
+        "applies": true,
+        "consoleThirdPartySharingDeclared": false,
+        "policyReference": "https://support.google.com/googleplay/android-developer/answer/10787469?hl=en",
+        "policyClause": "user-initiated-action",
+        "rationaleKo": "출구 도보 길안내는 사용자가 도보 길안내 전용 버튼(FilledButton '도보 길안내')을 직접 탭할 때만 _openWalkingRoute가 실행되며, 자동 실행이나 백그라운드 전송은 없다. 버튼 바로 위 개인정보 고지 행이 카카오맵 앱에는 현재 위치와 출구 좌표를, 웹에는 출구 좌표만 카카오에 전달한다고 사전 고지하고, 버튼 semantic 라벨('OO까지 카카오맵 도보 길안내')도 외부 지도 도보 안내임을 알린다. 탭 결과로 외부 지도 앱/웹의 도보 경로가 열리는 것은 사용자의 합리적 기대에 부합하며, 좌표를 운영자 서버로 전송하거나 앱에 저장하지 않는다. 따라서 Play Data Safety의 user-initiated action 공유 예외를 적용해 Console 제3자 공유는 '없음'으로 선언하되, 아래 사실 서술(sharedWithThirdParties, thirdPartySharingKo)은 실제 전달 경계로 유지한다.",
+        "evidence": [
+          "apps/mobile/lib/features/stations/presentation/station_exit_card.dart",
+          "apps/mobile/lib/core/external/kakao_map_launcher.dart",
+          "apps/mobile/release/external-map-deeplink-policy.json"
+        ]
+      },
       "usedForTracking": false,
       "googlePlayDataSafety": {
         "dataType": "Location",

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -16595,6 +16595,7 @@ test("모바일 스토어 개인정보 인벤토리는 앱 동작과 심사 분�
     "route_v2_itx_mobility_preferences",
     "route_v2_itx_request_state",
     "route_v2_gateway_abuse_rate_limit_state",
+    "facility_report_abuse_rate_limit_state",
     "mobility_profile",
     "facility_report_content",
     "facility_report_photo",
@@ -16648,9 +16649,12 @@ test("모바일 스토어 개인정보 인벤토리는 앱 동작과 심사 분�
       "facility_report_photo",
       "facility_report_location",
     ]);
-    const expectedLastVerifiedAt = id.startsWith("route_v2_") || reviewedForLegalDisclosure.has(id)
-      ? "2026-07-16"
-      : "2026-06-19";
+    const auditedForPrivacyInventory = new Set(["facility_report_abuse_rate_limit_state"]);
+    const expectedLastVerifiedAt = auditedForPrivacyInventory.has(id)
+      ? "2026-07-18"
+      : id.startsWith("route_v2_") || reviewedForLegalDisclosure.has(id)
+        ? "2026-07-16"
+        : "2026-06-19";
     assert.equal(item.lastVerifiedAt, expectedLastVerifiedAt, `${id} verification date must be current`);
     const expectedThirdPartySharing = id === "precise_location";
     assert.equal(
@@ -16707,12 +16711,83 @@ test("모바일 스토어 개인정보 인벤토리는 앱 동작과 심사 분�
     } else {
       assert.equal(item.googlePlayDataSafety.required, false, `${id} not-collected Play data must not be required`);
     }
+    const noUserDeletionBoundary = new Set([
+      "route_v2_gateway_abuse_rate_limit_state",
+      "facility_report_abuse_rate_limit_state",
+    ]);
     assert.equal(
       item.googlePlayDataSafety.deletionSupported,
-      id !== "route_v2_gateway_abuse_rate_limit_state",
+      !noUserDeletionBoundary.has(id),
       `${id} must declare the implemented data deletion boundary`,
     );
   }
+
+  const preciseLocationException = items.get("precise_location").userInitiatedSharingException;
+  assert.ok(preciseLocationException, "precise_location must document the user-initiated sharing exception");
+  assert.equal(preciseLocationException.applies, true, "precise_location sharing exception must be applied");
+  assert.equal(
+    preciseLocationException.consoleThirdPartySharingDeclared,
+    false,
+    "precise_location Console third-party sharing must stay declared as none under the exception",
+  );
+  assert.equal(preciseLocationException.policyClause, "user-initiated-action");
+  assert.equal(
+    preciseLocationException.policyReference,
+    "https://support.google.com/googleplay/android-developer/answer/10787469?hl=en",
+  );
+  assert.match(preciseLocationException.rationaleKo, /버튼/, "exception rationale must cite the dedicated user tap");
+  assert.match(preciseLocationException.rationaleKo, /자동 실행이나 백그라운드 전송은 없다/);
+  assert.match(preciseLocationException.rationaleKo, /user-initiated action/);
+  assert.deepEqual(preciseLocationException.evidence, [
+    "apps/mobile/lib/features/stations/presentation/station_exit_card.dart",
+    "apps/mobile/lib/core/external/kakao_map_launcher.dart",
+    "apps/mobile/release/external-map-deeplink-policy.json",
+  ]);
+  for (const evidencePath of preciseLocationException.evidence) {
+    assert.ok(
+      existsSync(path.join(root, evidencePath)),
+      `precise_location exception evidence must exist: ${evidencePath}`,
+    );
+  }
+
+  const reportAbuseState = items.get("facility_report_abuse_rate_limit_state");
+  assert.equal(reportAbuseState.implementationStatus, "backend-collected");
+  assert.equal(reportAbuseState.sharedWithThirdParties, false);
+  assert.equal(reportAbuseState.storeMode, "local");
+  assert.equal(reportAbuseState.persistedToDatabase, false);
+  assert.equal(reportAbuseState.includedInAccessLog, false);
+  assert.deepEqual(reportAbuseState.storageLocations, ["backend-jvm-memory"]);
+  assert.equal(reportAbuseState.retention.fixedTtl, false);
+  assert.equal(reportAbuseState.retention.windowSeconds, 60);
+  assert.equal(reportAbuseState.retention.maxCounterKeys, 4096);
+  assert.equal(reportAbuseState.retention.finalDeletionBoundary, "JVM process lifecycle end");
+  assert.equal(reportAbuseState.googlePlayDataSafety.dataType, "Device or other IDs");
+  assert.equal(reportAbuseState.googlePlayDataSafety.purpose, "Fraud prevention, security, and compliance");
+  assert.equal(reportAbuseState.googlePlayDataSafety.deletionSupported, false);
+  assert.equal(reportAbuseState.googlePlayDataSafety.processedEphemerally, false);
+  assert.equal(reportAbuseState.googlePlayDataSafety.linkedToUser, true);
+  assert.deepEqual(reportAbuseState.rateLimitedEndpoints, [
+    "POST /api/v1/report-uploads",
+    "PUT /api/v1/report-uploads/{uploadId}",
+    "POST /api/v1/reports",
+    "GET /api/v1/reports/{reportId}",
+    "POST /api/v1/reports/{reportId}/confirm",
+  ]);
+  assert.match(reportAbuseState.clientIdentityKey, /ip:remoteAddr/);
+  assert.ok(
+    reportAbuseState.evidence.includes(
+      "backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAbuseControl.java",
+    ),
+  );
+  const reportAbuseControlSource = read(
+    "backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAbuseControl.java",
+  );
+  assert.match(reportAbuseControlSource, /Map<LimiterKey, WindowCounter> counters = new ConcurrentHashMap<>/);
+  assert.match(reportAbuseControlSource, /return "ip:" \+ remoteAddress/);
+  assert.match(
+    reportAbuseControlSource,
+    /report abuse control store mode must be local until distributed store is implemented/,
+  );
 
   const appStoreTypes = [...new Set(
     inventory.dataTypes
@@ -17001,6 +17076,11 @@ test("Route V2 ITX 개인정보와 Data Safety 공개 기준은 실제 전송·�
     playStoreContent.dataSafetyDeclarations.answerMatrix
       .find((item) => item.dataType === "Device or other IDs")
       .inventoryDataIds.includes("route_v2_gateway_abuse_rate_limit_state"),
+  );
+  assert.ok(
+    playStoreContent.dataSafetyDeclarations.answerMatrix
+      .find((item) => item.dataType === "Device or other IDs")
+      .inventoryDataIds.includes("facility_report_abuse_rate_limit_state"),
   );
   assert.equal(
     playStoreContent.dataSafetyDeclarations.routeV2Itx.gatewayRateLimitStateProcessedEphemerally,


### PR DESCRIPTION
## 관련 이슈

Refs #1018

## 작업 배경

Play Console Data Safety 폼 대조와 코드 재감사(#1018) 결과 tracked 개인정보 인벤토리가 구현과 일치함을 확인했고, 오너 결정으로 두 가지 후속 기재를 반영한다. 첫째, 외부 지도 도보 길안내의 위치 전달은 Play Data Safety의 user-initiated action 공유 예외를 적용해 Console 제3자 공유는 "없음"으로 유지한다. 둘째, 시설 신고 endpoint의 IP 기반 rate-limit 상태를 인벤토리 신규 항목으로 등재해 오너가 Console 선언 필요 여부를 판단할 실측 재료를 남긴다.

## 작업 내용

- `apps/mobile/release/store-privacy-inventory.json`
  - `precise_location` 항목에 `userInitiatedSharingException`를 추가해 예외 적용(`applies: true`)·Console 공유 선언 값(`consoleThirdPartySharingDeclared: false`)·정책 참조(answer/10787469, `user-initiated-action`)·한국어 근거·evidence 경로를 기계 판독 가능하게 명시. 기존 사실 서술(`sharedWithThirdParties: true`, `thirdPartySharingKo`)은 실제 전달 경계로 유지.
  - 시설 신고 endpoint IP rate-limit 상태를 `facility_report_abuse_rate_limit_state`로 신규 등재. 실측한 보관 방식(`store-mode: local` = JVM in-memory `ConcurrentHashMap`, 고정 TTL 없음, 60초 window, 최대 4096 키, 초과 시 저장 없이 거절, DB·access log 미기록, JVM 프로세스 종료 시 소멸)을 그대로 기재하고 Play Data Safety는 `Device or other IDs` / `Fraud prevention, security, and compliance`로 매핑(`deletionSupported: false`, `processedEphemerally: false` — 과장하지 않음).
- `apps/mobile/release/play-store-submission-content.json`
  - `dataSafetyDeclarations.answerMatrix`의 `Device or other IDs` 커버리지에 신규 항목 id를 추가(계약 테스트가 데이터 타입별 inventory id 완전 일치를 요구).
- `tools/ci/repository-contract.test.mjs`
  - 신규 항목 id를 `requiredIds`에 추가하고, in-memory rate-limit 항목의 `deletionSupported: false`와 감사일(`2026-07-18`) 기준을 계약으로 고정. 예외 구조·신규 항목의 store-mode/보관/endpoint 필드와 소스 토큰(ConcurrentHashMap, `ip:` 키, store-mode local 강제) 대조 assertion을 추가.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/repository-contract.test.mjs` — 개인정보 인벤토리 관련 테스트 전부 PASS. 유일한 실패는 `수도권 pilot 승인 기준` 데이터팩 scope 해시 테스트로, 본 변경을 stash한 상태에서도 동일하게 실패하는 기존 실패이며 본 작업 파일(개인정보 인벤토리)과 무관하다.
  - `node --test --test-name-pattern="개인정보 인벤토리|Route V2 ITX 개인정보"` — tests 2 / pass 2 / fail 0.
  - `git diff --check` — 통과(공백 오류 없음).
  - JSON parse — 두 릴리즈 JSON 모두 유효.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 개인정보 인벤토리·계약 테스트 정합 | CI | `node --test tools/ci/repository-contract.test.mjs` 개인정보 관련 테스트 | 위 검증 로그 | PASS(무관 데이터팩 해시 1건 기존 실패) |
| rate-limit 보관 방식 실측 | backend | `FacilityReportAbuseControl.java`·`application-prod.yml` 코드 판독 | evidence 경로 인벤토리 기재 | in-memory·비영속 확인 |
| 도보 길안내 사용자 개시 예외 | mobile | `station_exit_card.dart`(_openWalkingRoute·버튼)·`kakao_map_launcher.dart`·`external-map-deeplink-policy.json` | evidence 경로 인벤토리 기재 | 전용 탭·서버 미전송 확인 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [ ] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [ ] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 신규 `facility_report_abuse_rate_limit_state`의 보관 서술이 `FacilityReportAbuseControl`(JVM in-memory ConcurrentHashMap, 고정 TTL 없음, 60초 window, 4096 키 상한, 프로세스 종료 시 소멸)과 정확히 일치하는지. `deletionSupported`/`processedEphemerally`를 과장하지 않았는지.
  - `precise_location` 예외의 근거 서술이 실제 UI(전용 버튼 탭·개인정보 고지 행·서버 미전송)와 일치하는지. Console 공유는 "없음", 사실 서술은 유지라는 이원 구조가 명확한지.

## 리스크

- Console 선언 필요 여부 판단은 오너 몫이며 본 PR은 판단 재료(메모리 전용·비영속·보관 기간)를 기재만 한다. 신규 항목이 `Device or other IDs`로 매핑되면서 answerMatrix 커버리지 계약이 신규 항목을 강제하므로, 이후 항목 추가 시 answerMatrix 동기화가 필요하다.
- `#1018`은 DoD 미완이므로 본 PR은 Refs로만 연결하며 이슈를 닫지 않는다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
