### PR TITLE
[Backend] #2249 timetable compiled snapshot 캐시

### DIFF
--- a/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
@@ -18,6 +18,7 @@ import com.easysubway.route.domain.RouteSearchStatus;
 import com.easysubway.route.domain.RouteStep;
 import com.easysubway.route.domain.RouteSearchResult.OfficialFare;
 import java.time.Duration;
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
@@ -26,10 +27,13 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -44,22 +48,35 @@ class RouteTimetableRaptorPlanner {
 	private static final int TRANSFER_DISTANCE_METERS = 260;
 	private static final int EXIT_DURATION_SECONDS = 180;
 	private static final int EXIT_DISTANCE_METERS = 120;
+	private static final int ACTIVE_SERVICE_DAY_CACHE_SIZE = 8;
 
 	List<RouteSearchResult> search(SearchRouteV2Command command, RouteTimetable timetable) {
+		return search(command, compile(timetable));
+	}
+
+	List<RouteSearchResult> search(SearchRouteV2Command command, CompiledTimetable timetable) {
 		ServiceDay serviceDay = serviceDay(command);
 		return scanDestinationLabels(command, timetable, serviceDay, serviceDay.departureSeconds()).labels().stream()
 			.sorted(RouteTimetableRaptorPlanner::compareLabels)
 			.limit(candidateLimit(command))
-			.map(label -> toRouteSearchResult(command, label, serviceDay, timetable))
+			.map(label -> toRouteSearchResult(command, label, serviceDay, timetable.source()))
 			.toList();
 	}
 
 	boolean isFeedStale(SearchRouteV2Command command, RouteTimetable timetable) {
-		LocalDate feedEndDate = timetable.feedEndDate();
+		return isFeedStale(command, compile(timetable));
+	}
+
+	boolean isFeedStale(SearchRouteV2Command command, CompiledTimetable timetable) {
+		LocalDate feedEndDate = timetable.source().feedEndDate();
 		return feedEndDate != null && serviceDay(command).date().isAfter(feedEndDate);
 	}
 
 	Optional<OffsetDateTime> nextServiceTime(SearchRouteV2Command command, RouteTimetable timetable) {
+		return nextServiceTime(command, compile(timetable));
+	}
+
+	Optional<OffsetDateTime> nextServiceTime(SearchRouteV2Command command, CompiledTimetable timetable) {
 		ServiceDay serviceDay = serviceDay(command);
 		for (int dayOffset = 0; dayOffset <= 7; dayOffset += 1) {
 			LocalDate candidateServiceDate = serviceDay.date().plusDays(dayOffset);
@@ -92,12 +109,11 @@ class RouteTimetableRaptorPlanner {
 
 	private Optional<Integer> firstFeasibleDepartureSeconds(
 		SearchRouteV2Command command,
-		RouteTimetable timetable,
+		CompiledTimetable timetable,
 		LocalDate serviceDate,
 		int startSeconds
 	) {
-		List<ScheduledTrip> trips = activeScheduledTrips(timetable, serviceDate);
-		Map<String, List<BoardingStop>> boardingsByStation = boardingsByStation(trips);
+		Map<String, List<BoardingStop>> boardingsByStation = timetable.activeServiceDay(serviceDate).boardingsByStation();
 		Map<ReachabilityState, Boolean> reachabilityCache = new HashMap<>();
 		Integer firstDepartureSeconds = null;
 		int entrySeconds = profiledWalkSeconds(command, ENTRY_DURATION_SECONDS);
@@ -209,11 +225,11 @@ class RouteTimetableRaptorPlanner {
 
 	private ScanResult scanDestinationLabels(
 		SearchRouteV2Command command,
-		RouteTimetable timetable,
+		CompiledTimetable timetable,
 		ServiceDay serviceDay,
 		int startSeconds
 	) {
-		List<ScheduledTrip> trips = activeScheduledTrips(timetable, serviceDay.date());
+		List<ScheduledTrip> trips = timetable.activeServiceDay(serviceDay.date()).trips();
 		if (trips.isEmpty()) {
 			return new ScanResult(serviceDay, List.of());
 		}
@@ -565,6 +581,10 @@ class RouteTimetableRaptorPlanner {
 		return Integer.toUnsignedString(key.toString().hashCode(), 36);
 	}
 
+	CompiledTimetable compile(RouteTimetable timetable) {
+		return new CompiledTimetable(timetable);
+	}
+
 	private static Map<String, TransitRoute> routesById(RouteTimetable timetable) {
 		Map<String, TransitRoute> routes = new HashMap<>();
 		for (TransitRoute route : timetable.transitRoutes()) {
@@ -601,7 +621,7 @@ class RouteTimetableRaptorPlanner {
 		List<TransitFrequency> frequencies
 	) {
 		if (frequencies.isEmpty()) {
-			return List.of(new ScheduledTrip(trip, route, stopTimes));
+			return List.of(new ScheduledTrip(trip, route, stopTimes, new PrimitiveTripTimes(stopTimes)));
 		}
 		int firstDepartureSeconds = stopTimes.getFirst().departureSeconds();
 		List<ScheduledTrip> scheduledTrips = new ArrayList<>();
@@ -613,7 +633,8 @@ class RouteTimetableRaptorPlanner {
 				 departureSeconds < frequency.endTimeSeconds();
 				 departureSeconds += frequency.headwaySeconds()) {
 				shiftedStopTimes(stopTimes, departureSeconds - firstDepartureSeconds)
-					.ifPresent(shifted -> scheduledTrips.add(new ScheduledTrip(trip, route, shifted)));
+					.ifPresent(shifted -> scheduledTrips.add(
+						new ScheduledTrip(trip, route, shifted, new PrimitiveTripTimes(shifted))));
 			}
 		}
 		return List.copyOf(scheduledTrips);
@@ -644,24 +665,7 @@ class RouteTimetableRaptorPlanner {
 		return java.util.Optional.of(List.copyOf(shifted));
 	}
 
-	private List<ScheduledTrip> activeScheduledTrips(RouteTimetable timetable, LocalDate serviceDate) {
-		Set<String> activeServiceIds = activeServiceIds(timetable, serviceDate);
-		if (activeServiceIds.isEmpty()) {
-			return List.of();
-		}
-		Map<String, TransitRoute> routesById = routesById(timetable);
-		Map<String, List<TransitStopTime>> stopTimesByTrip = stopTimesByTrip(timetable);
-		Map<String, List<TransitFrequency>> frequenciesByTrip = frequenciesByTrip(timetable);
-		return timetable.transitTrips().stream()
-			.filter(trip -> activeServiceIds.contains(trip.serviceId()))
-			.filter(trip -> stopTimesByTrip.getOrDefault(trip.id(), List.of()).size() > 1)
-			.flatMap(trip -> scheduledTrips(trip, routesById.get(trip.routeId()), stopTimesByTrip.get(trip.id()), frequenciesByTrip.getOrDefault(trip.id(), List.of())).stream())
-			.sorted(Comparator.comparing((ScheduledTrip scheduledTrip) -> scheduledTrip.trip().id())
-				.thenComparingInt(scheduledTrip -> scheduledTrip.stopTimes().getFirst().departureSeconds()))
-			.toList();
-	}
-
-	private Map<String, List<BoardingStop>> boardingsByStation(List<ScheduledTrip> trips) {
+	private static Map<String, List<BoardingStop>> boardingsByStation(List<ScheduledTrip> trips) {
 		Map<String, List<BoardingStop>> boardings = new HashMap<>();
 		for (ScheduledTrip trip : trips) {
 			List<TransitStopTime> stopTimes = trip.stopTimes();
@@ -679,30 +683,8 @@ class RouteTimetableRaptorPlanner {
 		return Map.copyOf(boardings);
 	}
 
-	private static Set<String> activeServiceIds(RouteTimetable timetable, LocalDate serviceDate) {
-		Set<String> active = new HashSet<>();
-		for (ServiceCalendar calendar : timetable.serviceCalendars()) {
-			if (!serviceDate.isBefore(calendar.startDate())
-				&& !serviceDate.isAfter(calendar.endDate())
-				&& runsOn(calendar, serviceDate)) {
-				active.add(calendar.serviceId());
-			}
-		}
-		for (ServiceCalendarDate exception : timetable.serviceCalendarDates()) {
-			if (!serviceDate.equals(exception.date())) {
-				continue;
-			}
-			if (exception.exceptionType() == 1) {
-				active.add(exception.serviceId());
-			} else {
-				active.remove(exception.serviceId());
-			}
-		}
-		return active;
-	}
-
-	private static boolean runsOn(ServiceCalendar calendar, LocalDate serviceDate) {
-		return switch (serviceDate.getDayOfWeek()) {
+	private static boolean runsOn(ServiceCalendar calendar, DayOfWeek dayOfWeek) {
+		return switch (dayOfWeek) {
 			case MONDAY -> calendar.monday();
 			case TUESDAY -> calendar.tuesday();
 			case WEDNESDAY -> calendar.wednesday();
@@ -711,6 +693,257 @@ class RouteTimetableRaptorPlanner {
 			case SATURDAY -> calendar.saturday();
 			case SUNDAY -> calendar.sunday();
 		};
+	}
+
+	static final class CompiledTimetable {
+
+		private final RouteTimetable source;
+		private final Map<String, Integer> stationIndex;
+		private final Map<String, Integer> routeIndex;
+		private final Map<String, Integer> tripIndex;
+		private final Map<Integer, int[]> stopsByRoute;
+		private final Map<Integer, int[]> routesByStop;
+		private final Map<Integer, List<ScheduledTrip>> tripsByRoute;
+		private final Map<DayOfWeek, List<ServiceCalendar>> calendarsByDay;
+		private final Map<LocalDate, List<ServiceCalendarDate>> exceptionsByDate;
+		private final List<ScheduledTrip> scheduledTrips;
+		private final LinkedHashMap<LocalDate, ActiveServiceDay> activeServiceDays = new LinkedHashMap<>(16, 0.75f, true);
+
+		private CompiledTimetable(RouteTimetable source) {
+			this.source = Objects.requireNonNull(source, "timetable must not be null");
+			stationIndex = denseIndex(source.transitStopTimes().stream().map(TransitStopTime::stationId).toList());
+			routeIndex = denseIndex(source.transitRoutes().stream().map(TransitRoute::id).toList());
+			tripIndex = denseIndex(source.transitTrips().stream().map(TransitTrip::id).toList());
+
+			Map<String, TransitRoute> routesById = routesById(source);
+			Map<String, List<TransitStopTime>> stopTimesByTrip = stopTimesByTrip(source);
+			Map<String, List<TransitFrequency>> frequenciesByTrip = frequenciesByTrip(source);
+			List<ScheduledTrip> compiledTrips = new ArrayList<>();
+			for (TransitTrip trip : source.transitTrips()) {
+				List<TransitStopTime> stopTimes = stopTimesByTrip.getOrDefault(trip.id(), List.of());
+				if (stopTimes.size() < 2) {
+					continue;
+				}
+				compiledTrips.addAll(scheduledTrips(
+					trip,
+					routesById.get(trip.routeId()),
+					stopTimes,
+					frequenciesByTrip.getOrDefault(trip.id(), List.of())
+				));
+			}
+			compiledTrips.sort(Comparator.comparing((ScheduledTrip scheduledTrip) -> scheduledTrip.trip().id())
+				.thenComparingInt(scheduledTrip -> scheduledTrip.stopTimes().getFirst().departureSeconds()));
+			scheduledTrips = List.copyOf(compiledTrips);
+			stopsByRoute = compileStopsByRoute(source, stopTimesByTrip, routeIndex, stationIndex);
+			routesByStop = invertPatterns(stopsByRoute, stationIndex.size());
+			tripsByRoute = compileTripsByRoute(scheduledTrips, routeIndex);
+			calendarsByDay = compileCalendarsByDay(source.serviceCalendars());
+			exceptionsByDate = Map.copyOf(source.serviceCalendarDates().stream().collect(
+				java.util.stream.Collectors.groupingBy(
+					ServiceCalendarDate::date,
+					java.util.stream.Collectors.collectingAndThen(java.util.stream.Collectors.toList(), List::copyOf)
+				)
+			));
+		}
+
+		RouteTimetable source() {
+			return source;
+		}
+
+		int stationCount() {
+			return stationIndex.size();
+		}
+
+		Set<String> coveredStationIds() {
+			return stationIndex.keySet();
+		}
+
+		int routeCount() {
+			return routeIndex.size();
+		}
+
+		int tripCount() {
+			return tripIndex.size();
+		}
+
+		int routePatternCount() {
+			return stopsByRoute.size();
+		}
+
+		int scheduledTripCount() {
+			return scheduledTrips.size();
+		}
+
+		int primitiveTimeArrayCount() {
+			return Math.toIntExact(scheduledTrips.stream().filter(trip -> trip.times() != null).count());
+		}
+
+		synchronized ActiveServiceDay activeServiceDay(LocalDate serviceDate) {
+			ActiveServiceDay cached = activeServiceDays.get(serviceDate);
+			if (cached != null) {
+				return cached;
+			}
+			Set<String> activeServiceIds = activeServiceIds(serviceDate);
+			List<ScheduledTrip> activeTrips = scheduledTrips.stream()
+				.filter(trip -> activeServiceIds.contains(trip.trip().serviceId()))
+				.toList();
+			ActiveServiceDay compiled = new ActiveServiceDay(activeTrips, boardingsByStation(activeTrips));
+			activeServiceDays.put(serviceDate, compiled);
+			if (activeServiceDays.size() > ACTIVE_SERVICE_DAY_CACHE_SIZE) {
+				activeServiceDays.remove(activeServiceDays.sequencedKeySet().getFirst());
+			}
+			return compiled;
+		}
+
+		synchronized int activeServiceDayCacheSize() {
+			return activeServiceDays.size();
+		}
+
+		synchronized boolean isServiceDayCached(LocalDate serviceDate) {
+			return activeServiceDays.containsKey(serviceDate);
+		}
+
+		int activeTripCount(LocalDate serviceDate) {
+			return activeServiceDay(serviceDate).trips().size();
+		}
+
+		private Set<String> activeServiceIds(LocalDate serviceDate) {
+			Set<String> active = new HashSet<>();
+			for (ServiceCalendar calendar : calendarsByDay.getOrDefault(serviceDate.getDayOfWeek(), List.of())) {
+				if (!serviceDate.isBefore(calendar.startDate()) && !serviceDate.isAfter(calendar.endDate())) {
+					active.add(calendar.serviceId());
+				}
+			}
+			for (ServiceCalendarDate exception : exceptionsByDate.getOrDefault(serviceDate, List.of())) {
+				if (exception.exceptionType() == 1) {
+					active.add(exception.serviceId());
+				} else {
+					active.remove(exception.serviceId());
+				}
+			}
+			return active;
+		}
+
+		private static Map<String, Integer> denseIndex(List<String> ids) {
+			Map<String, Integer> index = new HashMap<>();
+			ids.stream().distinct().sorted().forEach(id -> index.put(id, index.size()));
+			return Map.copyOf(index);
+		}
+
+		private static Map<Integer, int[]> compileStopsByRoute(
+			RouteTimetable source,
+			Map<String, List<TransitStopTime>> stopTimesByTrip,
+			Map<String, Integer> routeIndex,
+			Map<String, Integer> stationIndex
+		) {
+			Map<String, List<TransitStopTime>> longestByRoute = new HashMap<>();
+			for (TransitTrip trip : source.transitTrips()) {
+				List<TransitStopTime> candidate = stopTimesByTrip.getOrDefault(trip.id(), List.of());
+				List<TransitStopTime> current = longestByRoute.get(trip.routeId());
+				if (current == null || candidate.size() > current.size()) {
+					longestByRoute.put(trip.routeId(), candidate);
+				}
+			}
+			Map<Integer, int[]> patterns = new HashMap<>();
+			for (Map.Entry<String, List<TransitStopTime>> entry : longestByRoute.entrySet()) {
+				Integer denseRoute = routeIndex.get(entry.getKey());
+				if (denseRoute == null || entry.getValue().isEmpty()) {
+					continue;
+				}
+				patterns.put(denseRoute, entry.getValue().stream()
+					.mapToInt(stopTime -> stationIndex.get(stopTime.stationId()))
+					.toArray());
+			}
+			return Map.copyOf(patterns);
+		}
+
+		private static Map<Integer, int[]> invertPatterns(Map<Integer, int[]> stopsByRoute, int stationCount) {
+			List<List<Integer>> routeLists = new ArrayList<>(stationCount);
+			for (int index = 0; index < stationCount; index += 1) {
+				routeLists.add(new ArrayList<>());
+			}
+			for (Map.Entry<Integer, int[]> entry : stopsByRoute.entrySet()) {
+				for (int station : entry.getValue()) {
+					List<Integer> routes = routeLists.get(station);
+					if (!routes.contains(entry.getKey())) {
+						routes.add(entry.getKey());
+					}
+				}
+			}
+			Map<Integer, int[]> routesByStop = new HashMap<>();
+			for (int index = 0; index < routeLists.size(); index += 1) {
+				if (!routeLists.get(index).isEmpty()) {
+					routesByStop.put(index, routeLists.get(index).stream().mapToInt(Integer::intValue).sorted().toArray());
+				}
+			}
+			return Map.copyOf(routesByStop);
+		}
+
+		private static Map<Integer, List<ScheduledTrip>> compileTripsByRoute(
+			List<ScheduledTrip> scheduledTrips,
+			Map<String, Integer> routeIndex
+		) {
+			Map<Integer, List<ScheduledTrip>> byRoute = new HashMap<>();
+			for (ScheduledTrip trip : scheduledTrips) {
+				Integer denseRoute = routeIndex.get(trip.trip().routeId());
+				if (denseRoute != null) {
+					byRoute.computeIfAbsent(denseRoute, ignored -> new ArrayList<>()).add(trip);
+				}
+			}
+			byRoute.replaceAll((ignored, trips) -> trips.stream()
+				.sorted(Comparator.comparingInt(trip -> trip.stopTimes().getFirst().departureSeconds()))
+				.toList());
+			return Map.copyOf(byRoute);
+		}
+
+		private static Map<DayOfWeek, List<ServiceCalendar>> compileCalendarsByDay(List<ServiceCalendar> calendars) {
+			Map<DayOfWeek, List<ServiceCalendar>> byDay = new EnumMap<>(DayOfWeek.class);
+			for (DayOfWeek day : DayOfWeek.values()) {
+				byDay.put(day, calendars.stream().filter(calendar -> runsOn(calendar, day)).toList());
+			}
+			return Map.copyOf(byDay);
+		}
+	}
+
+	static final class ActiveServiceDay {
+
+		private final List<ScheduledTrip> trips;
+		private final Map<String, List<BoardingStop>> boardingsByStation;
+
+		private ActiveServiceDay(List<ScheduledTrip> trips, Map<String, List<BoardingStop>> boardingsByStation) {
+			this.trips = List.copyOf(trips);
+			this.boardingsByStation = Map.copyOf(boardingsByStation);
+		}
+
+		private List<ScheduledTrip> trips() {
+			return trips;
+		}
+
+		private Map<String, List<BoardingStop>> boardingsByStation() {
+			return boardingsByStation;
+		}
+	}
+
+	private static final class PrimitiveTripTimes {
+
+		private final int[] arrivalSeconds;
+		private final int[] departureSeconds;
+		private final byte[] pickupTypes;
+		private final byte[] dropOffTypes;
+
+		private PrimitiveTripTimes(List<TransitStopTime> stopTimes) {
+			arrivalSeconds = new int[stopTimes.size()];
+			departureSeconds = new int[stopTimes.size()];
+			pickupTypes = new byte[stopTimes.size()];
+			dropOffTypes = new byte[stopTimes.size()];
+			for (int index = 0; index < stopTimes.size(); index += 1) {
+				TransitStopTime stopTime = stopTimes.get(index);
+				arrivalSeconds[index] = stopTime.arrivalSeconds();
+				departureSeconds[index] = stopTime.departureSeconds();
+				pickupTypes[index] = (byte) stopTime.pickupType();
+				dropOffTypes[index] = (byte) stopTime.dropOffType();
+			}
+		}
 	}
 
 	private static ServiceDay serviceDay(SearchRouteV2Command command) {
@@ -738,7 +971,12 @@ class RouteTimetableRaptorPlanner {
 	private record Boarding(Label label, TransitStopTime stopTime) {
 	}
 
-	private record ScheduledTrip(TransitTrip trip, TransitRoute route, List<TransitStopTime> stopTimes) {
+	private record ScheduledTrip(
+		TransitTrip trip,
+		TransitRoute route,
+		List<TransitStopTime> stopTimes,
+		PrimitiveTripTimes times
+	) {
 	}
 
 	private record BoardingStop(ScheduledTrip trip, int stopIndex, TransitStopTime stopTime) {

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
@@ -700,9 +700,9 @@ class RouteTimetableRaptorPlanner {
 		private final Map<String, Integer> stationIndex;
 		private final Map<String, Integer> routeIndex;
 		private final Map<String, Integer> tripIndex;
-		private final Map<Integer, int[]> stopsByRoute;
-		private final Map<Integer, int[]> routesByStop;
-		private final Map<Integer, List<ScheduledTrip>> tripsByRoute;
+		private final Map<Integer, int[]> stopsByPattern;
+		private final Map<Integer, int[]> patternsByStop;
+		private final Map<Integer, List<ScheduledTrip>> tripsByPattern;
 		private final Map<DayOfWeek, List<ServiceCalendar>> calendarsByDay;
 		private final Map<LocalDate, List<ServiceCalendarDate>> exceptionsByDate;
 		private final List<ScheduledTrip> scheduledTrips;
@@ -733,9 +733,10 @@ class RouteTimetableRaptorPlanner {
 			compiledTrips.sort(Comparator.comparing((ScheduledTrip scheduledTrip) -> scheduledTrip.trip().id())
 				.thenComparingInt(scheduledTrip -> scheduledTrip.departureSeconds(0)));
 			scheduledTrips = List.copyOf(compiledTrips);
-			stopsByRoute = compileStopsByRoute(source, stopTimesByTrip, routeIndex, stationIndex);
-			routesByStop = invertPatterns(stopsByRoute, stationIndex.size());
-			tripsByRoute = compileTripsByRoute(scheduledTrips, routeIndex);
+			CompiledRoutePatterns routePatterns = compileRoutePatterns(scheduledTrips, routeIndex, stationIndex);
+			stopsByPattern = routePatterns.stopsByPattern();
+			patternsByStop = invertPatterns(stopsByPattern, stationIndex.size());
+			tripsByPattern = routePatterns.tripsByPattern();
 			calendarsByDay = compileCalendarsByDay(source.serviceCalendars());
 			exceptionsByDate = Map.copyOf(source.serviceCalendarDates().stream().collect(
 				java.util.stream.Collectors.groupingBy(
@@ -766,7 +767,11 @@ class RouteTimetableRaptorPlanner {
 		}
 
 		int routePatternCount() {
-			return stopsByRoute.size();
+			return stopsByPattern.size();
+		}
+
+		int routePatternTripLinkCount() {
+			return tripsByPattern.values().stream().mapToInt(List::size).sum();
 		}
 
 		int scheduledTripCount() {
@@ -829,70 +834,59 @@ class RouteTimetableRaptorPlanner {
 			return Map.copyOf(index);
 		}
 
-		private static Map<Integer, int[]> compileStopsByRoute(
-			RouteTimetable source,
-			Map<String, List<TransitStopTime>> stopTimesByTrip,
+		private static CompiledRoutePatterns compileRoutePatterns(
+			List<ScheduledTrip> scheduledTrips,
 			Map<String, Integer> routeIndex,
 			Map<String, Integer> stationIndex
 		) {
-			Map<String, List<TransitStopTime>> longestByRoute = new HashMap<>();
-			for (TransitTrip trip : source.transitTrips()) {
-				List<TransitStopTime> candidate = stopTimesByTrip.getOrDefault(trip.id(), List.of());
-				List<TransitStopTime> current = longestByRoute.get(trip.routeId());
-				if (current == null || candidate.size() > current.size()) {
-					longestByRoute.put(trip.routeId(), candidate);
-				}
-			}
-			Map<Integer, int[]> patterns = new HashMap<>();
-			for (Map.Entry<String, List<TransitStopTime>> entry : longestByRoute.entrySet()) {
-				Integer denseRoute = routeIndex.get(entry.getKey());
-				if (denseRoute == null || entry.getValue().isEmpty()) {
+			Map<RoutePatternKey, Integer> patternIds = new LinkedHashMap<>();
+			Map<Integer, int[]> stopsByPattern = new HashMap<>();
+			Map<Integer, List<ScheduledTrip>> tripsByPattern = new HashMap<>();
+			for (ScheduledTrip trip : scheduledTrips) {
+				Integer denseRoute = routeIndex.get(trip.trip().routeId());
+				if (denseRoute == null || trip.stopTimes().isEmpty()) {
 					continue;
 				}
-				patterns.put(denseRoute, entry.getValue().stream()
-					.mapToInt(stopTime -> stationIndex.get(stopTime.stationId()))
-					.toArray());
+				List<Integer> stationSequence = trip.stopTimes().stream()
+					.map(stopTime -> stationIndex.get(stopTime.stationId()))
+					.toList();
+				RoutePatternKey key = new RoutePatternKey(denseRoute, stationSequence);
+				int patternId = patternIds.computeIfAbsent(key, ignored -> patternIds.size());
+				stopsByPattern.putIfAbsent(
+					patternId,
+					stationSequence.stream().mapToInt(Integer::intValue).toArray()
+				);
+				tripsByPattern.computeIfAbsent(patternId, ignored -> new ArrayList<>()).add(trip);
 			}
-			return Map.copyOf(patterns);
+			tripsByPattern.replaceAll((ignored, trips) -> trips.stream()
+				.sorted(Comparator.comparingInt(trip -> trip.departureSeconds(0)))
+				.toList());
+			return new CompiledRoutePatterns(Map.copyOf(stopsByPattern), Map.copyOf(tripsByPattern));
 		}
 
-		private static Map<Integer, int[]> invertPatterns(Map<Integer, int[]> stopsByRoute, int stationCount) {
-			List<List<Integer>> routeLists = new ArrayList<>(stationCount);
+		private static Map<Integer, int[]> invertPatterns(Map<Integer, int[]> stopsByPattern, int stationCount) {
+			List<List<Integer>> patternLists = new ArrayList<>(stationCount);
 			for (int index = 0; index < stationCount; index += 1) {
-				routeLists.add(new ArrayList<>());
+				patternLists.add(new ArrayList<>());
 			}
-			for (Map.Entry<Integer, int[]> entry : stopsByRoute.entrySet()) {
+			for (Map.Entry<Integer, int[]> entry : stopsByPattern.entrySet()) {
 				for (int station : entry.getValue()) {
-					List<Integer> routes = routeLists.get(station);
-					if (!routes.contains(entry.getKey())) {
-						routes.add(entry.getKey());
+					List<Integer> patterns = patternLists.get(station);
+					if (!patterns.contains(entry.getKey())) {
+						patterns.add(entry.getKey());
 					}
 				}
 			}
-			Map<Integer, int[]> routesByStop = new HashMap<>();
-			for (int index = 0; index < routeLists.size(); index += 1) {
-				if (!routeLists.get(index).isEmpty()) {
-					routesByStop.put(index, routeLists.get(index).stream().mapToInt(Integer::intValue).sorted().toArray());
+			Map<Integer, int[]> patternsByStop = new HashMap<>();
+			for (int index = 0; index < patternLists.size(); index += 1) {
+				if (!patternLists.get(index).isEmpty()) {
+					patternsByStop.put(
+						index,
+						patternLists.get(index).stream().mapToInt(Integer::intValue).sorted().toArray()
+					);
 				}
 			}
-			return Map.copyOf(routesByStop);
-		}
-
-		private static Map<Integer, List<ScheduledTrip>> compileTripsByRoute(
-			List<ScheduledTrip> scheduledTrips,
-			Map<String, Integer> routeIndex
-		) {
-			Map<Integer, List<ScheduledTrip>> byRoute = new HashMap<>();
-			for (ScheduledTrip trip : scheduledTrips) {
-				Integer denseRoute = routeIndex.get(trip.trip().routeId());
-				if (denseRoute != null) {
-					byRoute.computeIfAbsent(denseRoute, ignored -> new ArrayList<>()).add(trip);
-				}
-			}
-			byRoute.replaceAll((ignored, trips) -> trips.stream()
-				.sorted(Comparator.comparingInt(trip -> trip.departureSeconds(0)))
-				.toList());
-			return Map.copyOf(byRoute);
+			return Map.copyOf(patternsByStop);
 		}
 
 		private static Map<DayOfWeek, List<ServiceCalendar>> compileCalendarsByDay(List<ServiceCalendar> calendars) {
@@ -992,6 +986,15 @@ class RouteTimetableRaptorPlanner {
 	}
 
 	private record ScanResult(ServiceDay serviceDay, List<Label> labels) {
+	}
+
+	private record RoutePatternKey(int routeIndex, List<Integer> stationSequence) {
+	}
+
+	private record CompiledRoutePatterns(
+		Map<Integer, int[]> stopsByPattern,
+		Map<Integer, List<ScheduledTrip>> tripsByPattern
+	) {
 	}
 
 	private record Label(String stationId, int timeSeconds, int startSeconds, int boardings, List<RideLeg> path) {

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
@@ -119,23 +119,25 @@ class RouteTimetableRaptorPlanner {
 		int entrySeconds = profiledWalkSeconds(command, ENTRY_DURATION_SECONDS);
 		int slackSeconds = BoardingSlackPolicy.secondsFor(command.mobilityType());
 		for (BoardingStop boardingStop : boardingsByStation.getOrDefault(command.originStationId(), List.of())) {
-			TransitStopTime stopTime = boardingStop.stopTime();
-			if (!allowsPickup(stopTime)
-				|| stopTime.departureSeconds() < startSeconds + entrySeconds + slackSeconds) {
+			ScheduledTrip trip = boardingStop.trip();
+			int stopIndex = boardingStop.stopIndex();
+			int departureSeconds = trip.departureSeconds(stopIndex);
+			if (!trip.allowsPickup(stopIndex)
+				|| departureSeconds < startSeconds + entrySeconds + slackSeconds) {
 				continue;
 			}
 			if (canReachDestinationAfterBoarding(
 				command,
 				boardingsByStation,
-				boardingStop.trip(),
-				boardingStop.stopIndex(),
+				trip,
+				stopIndex,
 				0,
 				new HashSet<>(),
 				reachabilityCache
 			)) {
 				firstDepartureSeconds = firstDepartureSeconds == null
-					? stopTime.departureSeconds()
-					: Math.min(firstDepartureSeconds, stopTime.departureSeconds());
+					? departureSeconds
+					: Math.min(firstDepartureSeconds, departureSeconds);
 			}
 		}
 		return Optional.ofNullable(firstDepartureSeconds);
@@ -153,7 +155,7 @@ class RouteTimetableRaptorPlanner {
 		List<TransitStopTime> stopTimes = trip.stopTimes();
 		for (int stopIndex = boardingStopIndex + 1; stopIndex < stopTimes.size(); stopIndex += 1) {
 			TransitStopTime stopTime = stopTimes.get(stopIndex);
-			if (!allowsDropOff(stopTime)) {
+			if (!trip.allowsDropOff(stopIndex)) {
 				continue;
 			}
 			if (command.destinationStationId().equals(stopTime.stationId())) {
@@ -163,7 +165,7 @@ class RouteTimetableRaptorPlanner {
 				command,
 				boardingsByStation,
 				stopTime.stationId(),
-				stopTime.arrivalSeconds(),
+				trip.arrivalSeconds(stopIndex),
 				transfersUsed,
 				visiting,
 				reachabilityCache
@@ -198,16 +200,17 @@ class RouteTimetableRaptorPlanner {
 		int slackSeconds = BoardingSlackPolicy.secondsFor(command.mobilityType());
 		try {
 			for (BoardingStop boardingStop : boardingsByStation.getOrDefault(stationId, List.of())) {
-				TransitStopTime stopTime = boardingStop.stopTime();
-				if (!allowsPickup(stopTime)
-					|| stopTime.departureSeconds() < readySeconds + transferSeconds + slackSeconds) {
+				ScheduledTrip trip = boardingStop.trip();
+				int stopIndex = boardingStop.stopIndex();
+				if (!trip.allowsPickup(stopIndex)
+					|| trip.departureSeconds(stopIndex) < readySeconds + transferSeconds + slackSeconds) {
 					continue;
 				}
 				if (canReachDestinationAfterBoarding(
 					command,
 					boardingsByStation,
-					boardingStop.trip(),
-					boardingStop.stopIndex(),
+					trip,
+					stopIndex,
 					transfersUsed + 1,
 					visiting,
 					reachabilityCache
@@ -264,47 +267,42 @@ class RouteTimetableRaptorPlanner {
 		int round
 	) {
 		Boarding boarding = null;
-		for (TransitStopTime stopTime : trip.stopTimes()) {
+		List<TransitStopTime> stopTimes = trip.stopTimes();
+		for (int stopIndex = 0; stopIndex < stopTimes.size(); stopIndex += 1) {
+			TransitStopTime stopTime = stopTimes.get(stopIndex);
 			for (Label label : List.copyOf(labels.getOrDefault(stopTime.stationId(), List.of()))) {
-				if (canBoard(command, label, stopTime, round) && allowsPickup(stopTime)) {
-					boarding = betterBoarding(boarding, label, stopTime);
+				if (canBoard(command, label, trip, stopIndex, round) && trip.allowsPickup(stopIndex)) {
+					boarding = betterBoarding(boarding, label, stopIndex);
 				}
 			}
-			if (boarding == null || stopTime.stopSequence() <= boarding.stopTime().stopSequence() || !allowsDropOff(stopTime)) {
+			if (boarding == null || stopIndex <= boarding.stopIndex() || !trip.allowsDropOff(stopIndex)) {
 				continue;
 			}
 			addLabel(labels, new Label(
 				stopTime.stationId(),
-				stopTime.arrivalSeconds(),
+				trip.arrivalSeconds(stopIndex),
 				boarding.label().startSeconds(),
 				boarding.label().boardings() + 1,
-				withLeg(boarding.label().path(), new RideLeg(trip.trip(), trip.route(), boarding.stopTime(), stopTime))
+				withLeg(boarding.label().path(), new RideLeg(trip, boarding.stopIndex(), stopIndex))
 			));
 		}
 	}
 
-	private boolean canBoard(SearchRouteV2Command command, Label label, TransitStopTime stopTime, int round) {
+	private boolean canBoard(SearchRouteV2Command command, Label label, ScheduledTrip trip, int stopIndex, int round) {
 		int slackSeconds = BoardingSlackPolicy.secondsFor(command.mobilityType());
 		int accessSeconds = profiledWalkSeconds(
 			command,
 			label.boardings() > 0 ? TRANSFER_DURATION_SECONDS : ENTRY_DURATION_SECONDS
 		);
-		return label.boardings() == round && stopTime.departureSeconds() >= label.timeSeconds() + accessSeconds + slackSeconds;
+		return label.boardings() == round
+			&& trip.departureSeconds(stopIndex) >= label.timeSeconds() + accessSeconds + slackSeconds;
 	}
 
-	private Boarding betterBoarding(Boarding current, Label label, TransitStopTime stopTime) {
+	private Boarding betterBoarding(Boarding current, Label label, int stopIndex) {
 		if (current == null || label.timeSeconds() < current.label().timeSeconds()) {
-			return new Boarding(label, stopTime);
+			return new Boarding(label, stopIndex);
 		}
 		return current;
-	}
-
-	private boolean allowsPickup(TransitStopTime stopTime) {
-		return stopTime.pickupType() != 1;
-	}
-
-	private boolean allowsDropOff(TransitStopTime stopTime) {
-		return stopTime.dropOffType() != 1;
 	}
 
 	private void addLabel(Map<String, List<Label>> labels, Label candidate) {
@@ -380,11 +378,11 @@ class RouteTimetableRaptorPlanner {
 			firstLeg.from().stationId(),
 			firstLeg.lineId(),
 			firstLeg.lineName(),
-			waitMinutesBeforeBoarding(label.startSeconds(), firstLeg.from().departureSeconds(), entryDurationSeconds, boardingSlackSeconds),
+			waitMinutesBeforeBoarding(label.startSeconds(), firstLeg.departureSeconds(), entryDurationSeconds, boardingSlackSeconds),
 			ENTRY_DISTANCE_METERS,
 			entryDurationSeconds,
 			serviceTime(serviceDay, label.startSeconds()),
-			serviceTime(serviceDay, firstLeg.from().departureSeconds())
+			serviceTime(serviceDay, firstLeg.departureSeconds())
 		));
 		sequence += 1;
 		for (int index = 0; index < path.size(); index += 1) {
@@ -398,11 +396,11 @@ class RouteTimetableRaptorPlanner {
 					leg.from().stationId(),
 					leg.lineId(),
 					leg.lineName(),
-					waitMinutesBeforeBoarding(previousLeg.to().arrivalSeconds(), leg.from().departureSeconds(), transferDurationSeconds, boardingSlackSeconds),
+					waitMinutesBeforeBoarding(previousLeg.arrivalSeconds(), leg.departureSeconds(), transferDurationSeconds, boardingSlackSeconds),
 					TRANSFER_DISTANCE_METERS,
 					transferDurationSeconds,
-					serviceTime(serviceDay, previousLeg.to().arrivalSeconds()),
-					serviceTime(serviceDay, leg.from().departureSeconds())
+					serviceTime(serviceDay, previousLeg.arrivalSeconds()),
+					serviceTime(serviceDay, leg.departureSeconds())
 				));
 				sequence += 1;
 			}
@@ -416,7 +414,7 @@ class RouteTimetableRaptorPlanner {
 				lineName,
 				leg.from().stationId(),
 				leg.to().stationId(),
-				Math.max(1, (int) Math.ceil((leg.to().arrivalSeconds() - leg.from().departureSeconds()) / 60.0)),
+				Math.max(1, (int) Math.ceil((leg.arrivalSeconds() - leg.departureSeconds()) / 60.0)),
 				0,
 				false,
 				"UNKNOWN",
@@ -434,8 +432,8 @@ class RouteTimetableRaptorPlanner {
 				leg.trip().trainNo(),
 				leg.trip().serviceClass(),
 				leg.trip().servicePattern(),
-				serviceTime(serviceDay, leg.from().departureSeconds()),
-				serviceTime(serviceDay, leg.to().arrivalSeconds())
+				serviceTime(serviceDay, leg.departureSeconds()),
+				serviceTime(serviceDay, leg.arrivalSeconds())
 			));
 			sequence += 1;
 		}
@@ -449,8 +447,8 @@ class RouteTimetableRaptorPlanner {
 			(int) Math.ceil(exitDurationSeconds / 60.0),
 			EXIT_DISTANCE_METERS,
 			exitDurationSeconds,
-			serviceTime(serviceDay, lastLeg.to().arrivalSeconds()),
-			serviceTime(serviceDay, lastLeg.to().arrivalSeconds() + exitDurationSeconds)
+			serviceTime(serviceDay, lastLeg.arrivalSeconds()),
+			serviceTime(serviceDay, lastLeg.arrivalSeconds() + exitDurationSeconds)
 		));
 		return new RouteSearchResult(
 			"route-v2-raptor-" + serviceDay.date() + "-" + command.originStationId() + "-" + command.destinationStationId()
@@ -574,9 +572,9 @@ class RouteTimetableRaptorPlanner {
 			}
 			key.append(leg.tripId())
 				.append('@')
-				.append(leg.from().departureSeconds())
+				.append(leg.departureSeconds())
 				.append('-')
-				.append(leg.to().arrivalSeconds());
+				.append(leg.arrivalSeconds());
 		}
 		return Integer.toUnsignedString(key.toString().hashCode(), 36);
 	}
@@ -677,7 +675,8 @@ class RouteTimetableRaptorPlanner {
 		}
 		for (Map.Entry<String, List<BoardingStop>> entry : boardings.entrySet()) {
 			entry.setValue(entry.getValue().stream()
-				.sorted(Comparator.comparingInt(boarding -> boarding.stopTime().departureSeconds()))
+				.sorted(Comparator.comparingInt(
+					boarding -> boarding.trip().departureSeconds(boarding.stopIndex())))
 				.toList());
 		}
 		return Map.copyOf(boardings);
@@ -732,7 +731,7 @@ class RouteTimetableRaptorPlanner {
 				));
 			}
 			compiledTrips.sort(Comparator.comparing((ScheduledTrip scheduledTrip) -> scheduledTrip.trip().id())
-				.thenComparingInt(scheduledTrip -> scheduledTrip.stopTimes().getFirst().departureSeconds()));
+				.thenComparingInt(scheduledTrip -> scheduledTrip.departureSeconds(0)));
 			scheduledTrips = List.copyOf(compiledTrips);
 			stopsByRoute = compileStopsByRoute(source, stopTimesByTrip, routeIndex, stationIndex);
 			routesByStop = invertPatterns(stopsByRoute, stationIndex.size());
@@ -891,7 +890,7 @@ class RouteTimetableRaptorPlanner {
 				}
 			}
 			byRoute.replaceAll((ignored, trips) -> trips.stream()
-				.sorted(Comparator.comparingInt(trip -> trip.stopTimes().getFirst().departureSeconds()))
+				.sorted(Comparator.comparingInt(trip -> trip.departureSeconds(0)))
 				.toList());
 			return Map.copyOf(byRoute);
 		}
@@ -958,6 +957,22 @@ class RouteTimetableRaptorPlanner {
 				dropOffTypes[index] = (byte) stopTime.dropOffType();
 			}
 		}
+
+		private int arrivalSeconds(int stopIndex) {
+			return arrivalSeconds[stopIndex];
+		}
+
+		private int departureSeconds(int stopIndex) {
+			return departureSeconds[stopIndex];
+		}
+
+		private boolean allowsPickup(int stopIndex) {
+			return pickupTypes[stopIndex] != 1;
+		}
+
+		private boolean allowsDropOff(int stopIndex) {
+			return dropOffTypes[stopIndex] != 1;
+		}
 	}
 
 	private static ServiceDay serviceDay(SearchRouteV2Command command) {
@@ -982,7 +997,7 @@ class RouteTimetableRaptorPlanner {
 	private record Label(String stationId, int timeSeconds, int startSeconds, int boardings, List<RideLeg> path) {
 	}
 
-	private record Boarding(Label label, TransitStopTime stopTime) {
+	private record Boarding(Label label, int stopIndex) {
 	}
 
 	private record ScheduledTrip(
@@ -991,6 +1006,21 @@ class RouteTimetableRaptorPlanner {
 		List<TransitStopTime> stopTimes,
 		PrimitiveTripTimes times
 	) {
+		private int arrivalSeconds(int stopIndex) {
+			return times.arrivalSeconds(stopIndex);
+		}
+
+		private int departureSeconds(int stopIndex) {
+			return times.departureSeconds(stopIndex);
+		}
+
+		private boolean allowsPickup(int stopIndex) {
+			return times.allowsPickup(stopIndex);
+		}
+
+		private boolean allowsDropOff(int stopIndex) {
+			return times.allowsDropOff(stopIndex);
+		}
 	}
 
 	private record BoardingStop(ScheduledTrip trip, int stopIndex, TransitStopTime stopTime) {
@@ -999,18 +1029,39 @@ class RouteTimetableRaptorPlanner {
 	private record ReachabilityState(String stationId, int readySeconds, int transfersUsed) {
 	}
 
-	private record RideLeg(TransitTrip trip, TransitRoute route, TransitStopTime from, TransitStopTime to) {
+	private record RideLeg(ScheduledTrip scheduledTrip, int fromIndex, int toIndex) {
+		TransitTrip trip() {
+			return scheduledTrip.trip();
+		}
+
+		TransitStopTime from() {
+			return scheduledTrip.stopTimes().get(fromIndex);
+		}
+
+		TransitStopTime to() {
+			return scheduledTrip.stopTimes().get(toIndex);
+		}
+
+		int departureSeconds() {
+			return scheduledTrip.departureSeconds(fromIndex);
+		}
+
+		int arrivalSeconds() {
+			return scheduledTrip.arrivalSeconds(toIndex);
+		}
+
 		String tripId() {
-			return trip.id();
+			return trip().id();
 		}
 
 		String lineId() {
-			return route == null ? from.lineId() : route.lineId();
+			return scheduledTrip.route() == null ? from().lineId() : scheduledTrip.route().lineId();
 		}
 
 		String lineName() {
+			TransitRoute route = scheduledTrip.route();
 			if (route == null) {
-				return from.lineId();
+				return from().lineId();
 			}
 			String routeLongName = route.routeLongName();
 			if (routeLongName != null && !routeLongName.isBlank()) {

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
@@ -787,7 +787,7 @@ class RouteTimetableRaptorPlanner {
 			List<ScheduledTrip> activeTrips = scheduledTrips.stream()
 				.filter(trip -> activeServiceIds.contains(trip.trip().serviceId()))
 				.toList();
-			ActiveServiceDay compiled = new ActiveServiceDay(activeTrips, boardingsByStation(activeTrips));
+			ActiveServiceDay compiled = new ActiveServiceDay(activeTrips);
 			activeServiceDays.put(serviceDate, compiled);
 			if (activeServiceDays.size() > ACTIVE_SERVICE_DAY_CACHE_SIZE) {
 				activeServiceDays.remove(activeServiceDays.sequencedKeySet().getFirst());
@@ -908,19 +908,33 @@ class RouteTimetableRaptorPlanner {
 	static final class ActiveServiceDay {
 
 		private final List<ScheduledTrip> trips;
-		private final Map<String, List<BoardingStop>> boardingsByStation;
+		private volatile Map<String, List<BoardingStop>> boardingsByStation;
 
-		private ActiveServiceDay(List<ScheduledTrip> trips, Map<String, List<BoardingStop>> boardingsByStation) {
+		private ActiveServiceDay(List<ScheduledTrip> trips) {
 			this.trips = List.copyOf(trips);
-			this.boardingsByStation = Map.copyOf(boardingsByStation);
 		}
 
 		private List<ScheduledTrip> trips() {
 			return trips;
 		}
 
+		boolean boardingIndexInitialized() {
+			return boardingsByStation != null;
+		}
+
 		private Map<String, List<BoardingStop>> boardingsByStation() {
-			return boardingsByStation;
+			Map<String, List<BoardingStop>> snapshot = boardingsByStation;
+			if (snapshot != null) {
+				return snapshot;
+			}
+			synchronized (this) {
+				snapshot = boardingsByStation;
+				if (snapshot == null) {
+					snapshot = RouteTimetableRaptorPlanner.boardingsByStation(trips);
+					boardingsByStation = snapshot;
+				}
+				return snapshot;
+			}
 		}
 	}
 

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
@@ -14,6 +14,7 @@ import com.easysubway.route.application.port.in.RouteV2SearchUseCase.RouteObject
 import com.easysubway.route.application.port.in.RouteV2SearchUseCase.RouteTransportScope;
 import com.easysubway.route.application.port.out.LoadRouteTimetablePort;
 import com.easysubway.route.application.port.out.LoadRouteTimetablePort.RouteTimetable;
+import com.easysubway.route.application.service.RouteTimetableRaptorPlanner.CompiledTimetable;
 import com.easysubway.route.domain.ConstraintMode;
 import com.easysubway.route.domain.EtaSource;
 import com.easysubway.route.domain.ProfileWalkTimeCalculator;
@@ -114,14 +115,14 @@ public class RouteV2Planner implements RouteV2SearchUseCase {
 				? timetableSnapshot()
 				: null;
 			if (snapshot != null && timetableCovers(command, snapshot)) {
-				if (timetableRaptorPlanner.isFeedStale(command, snapshot.timetable())) {
+				if (timetableRaptorPlanner.isFeedStale(command, snapshot.compiledTimetable())) {
 					return timetablePlan(List.of(), List.of(RouteV2Status.STALE_TIMETABLE), snapshot);
 				}
 				SearchRouteCommand searchRouteCommand = toSearchRouteCommand(command);
 				routeSearchUseCase.validateRouteSearch(searchRouteCommand);
 				List<RouteSearchResult> timetableItineraries = timetableRaptorPlanner.search(
 					rankingCommand(command),
-					snapshot.timetable()
+					snapshot.compiledTimetable()
 				);
 				if (timetableItineraries.isEmpty()) {
 					return noTimetableServicePlan(command, snapshot);
@@ -179,7 +180,10 @@ public class RouteV2Planner implements RouteV2SearchUseCase {
 	}
 
 	private RouteV2Plan noTimetableServicePlan(SearchRouteV2Command command, TimetableSnapshot snapshot) {
-		OffsetDateTime nextServiceTime = timetableRaptorPlanner.nextServiceTime(command, snapshot.timetable()).orElse(null);
+		OffsetDateTime nextServiceTime = timetableRaptorPlanner.nextServiceTime(
+			command,
+			snapshot.compiledTimetable()
+		).orElse(null);
 		return new RouteV2Plan(
 			List.of(),
 			List.of(RouteV2Status.NO_TIMETABLE_SERVICE),
@@ -238,17 +242,16 @@ public class RouteV2Planner implements RouteV2SearchUseCase {
 				recordTimetableCache(timetableCacheMiss, timetableCacheMissLogged, "miss", cacheKey);
 				LoadRouteTimetablePort.RouteTimetableSnapshot loaded = routeTimetablePort.loadRouteTimetableSnapshot();
 				RouteTimetable timetable = loaded.timetable();
-				java.util.Set<String> coveredStationIds = timetable.transitStopTimes().stream()
-					.map(LoadRouteTimetablePort.TransitStopTime::stationId)
-					.collect(java.util.stream.Collectors.toUnmodifiableSet());
-				cachedTimetableSnapshot = new TimetableSnapshot(
+				CompiledTimetable compiledTimetable = timetableRaptorPlanner.compile(timetable);
+				TimetableSnapshot replacement = new TimetableSnapshot(
 					loaded.cacheKey(),
-					timetable,
-					coveredStationIds,
+					compiledTimetable,
+					compiledTimetable.coveredStationIds(),
 					loaded.timetableArtifactId(),
 					loaded.plannerIdentity()
 				);
-				return cachedTimetableSnapshot;
+				cachedTimetableSnapshot = replacement;
+				return replacement;
 			}
 			recordTimetableCache(timetableCacheHit, timetableCacheHitLogged, "hit", cacheKey);
 			return cachedTimetableSnapshot;
@@ -275,7 +278,7 @@ public class RouteV2Planner implements RouteV2SearchUseCase {
 
 	private record TimetableSnapshot(
 		String cacheKey,
-		RouteTimetable timetable,
+		CompiledTimetable compiledTimetable,
 		java.util.Set<String> coveredStationIds,
 		String timetableArtifactId,
 		LoadRouteTimetablePort.PlannerIdentity plannerIdentity

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -73,6 +73,10 @@ import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
@@ -1370,6 +1374,49 @@ class RouteSearchServiceTest {
 		assertThat(plan.timetableArtifactId()).isEqualTo("snapshot-b");
 		assertThat(port.atomicLoadCount()).isOne();
 		assertThat(port.legacyLoadCount()).isZero();
+	}
+
+	@Test
+	@DisplayName("V2 planner는 concurrent artifact 교체 중 구·신 snapshot을 섞지 않는다")
+	void routeV2PlannerPublishesOnlyCompleteOldOrNewCompiledSnapshotDuringReplacement() throws Exception {
+		var port = new ConcurrentSwitchingRouteTimetablePort();
+		var planner = new RouteV2Planner(legacySearchMustNotBeCalled(), port);
+		var observed = new ConcurrentLinkedQueue<List<String>>();
+		var start = new CountDownLatch(1);
+
+		try (var executor = Executors.newFixedThreadPool(4)) {
+			var writer = executor.submit(() -> {
+				start.await();
+				for (int index = 0; index < 80; index += 1) {
+					port.use(index % 2 == 0 ? "b" : "a");
+				}
+				return null;
+			});
+			var readers = java.util.stream.IntStream.range(0, 3).mapToObj(ignored -> executor.submit(() -> {
+				start.await();
+				for (int index = 0; index < 100; index += 1) {
+					var plan = planner.search(routeV2Command(
+						ConstraintMode.PREFER_STEP_FREE, MobilityType.SENIOR, 1, 3));
+					String tripId = plan.itineraries().getFirst().steps().stream()
+						.filter(step -> "ride".equals(step.stepType()))
+						.findFirst()
+						.orElseThrow()
+						.tripId();
+					observed.add(List.of(plan.timetableArtifactId(), tripId));
+				}
+				return null;
+			})).toList();
+			start.countDown();
+			writer.get(10, TimeUnit.SECONDS);
+			for (var reader : readers) {
+				reader.get(10, TimeUnit.SECONDS);
+			}
+		}
+
+		assertThat(observed).hasSize(300).allSatisfy(pair -> assertThat(pair).isIn(
+			List.of("artifact-a", "trip-a"),
+			List.of("artifact-b", "trip-b")
+		));
 	}
 
 	@Test
@@ -3388,6 +3435,52 @@ class RouteSearchServiceTest {
 
 		int legacyLoadCount() {
 			return legacyLoadCount;
+		}
+	}
+
+	private static class ConcurrentSwitchingRouteTimetablePort implements LoadRouteTimetablePort {
+
+		private volatile RouteTimetableSnapshot active = snapshot("a");
+
+		@Override
+		public boolean hasRouteTimetable() {
+			return true;
+		}
+
+		@Override
+		public RouteTimetable loadRouteTimetable() {
+			return active.timetable();
+		}
+
+		@Override
+		public RouteTimetableSnapshot loadRouteTimetableSnapshot() {
+			return active;
+		}
+
+		@Override
+		public String timetableCacheKey() {
+			return active.cacheKey();
+		}
+
+		void use(String version) {
+			active = snapshot(version);
+		}
+
+		private static RouteTimetableSnapshot snapshot(String version) {
+			String tripId = "trip-" + version;
+			return new RouteTimetableSnapshot(
+				"cache-" + version,
+				"artifact-" + version,
+				routeTimetable(
+					List.of(
+						new LoadRouteTimetablePort.TransitStopTime(
+							tripId, 1, "station-a", "seoul-4", 32820, 32820, 0, 0),
+						new LoadRouteTimetablePort.TransitStopTime(
+							tripId, 2, "station-b", "seoul-4", 33420, 33420, 0, 0)
+					),
+					List.of()
+				)
+			);
 		}
 	}
 

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -11,6 +11,7 @@ import com.easysubway.route.application.port.in.RouteSearchUseCase;
 import com.easysubway.route.application.port.in.SearchInternalRouteCommand;
 import com.easysubway.route.application.port.in.SearchRouteCommand;
 import com.easysubway.route.application.port.in.RouteV2SearchUseCase;
+import com.easysubway.route.application.port.in.RouteV2SearchUseCase.RouteV2Plan;
 import com.easysubway.route.application.port.in.RouteV2SearchUseCase.RouteV2Status;
 import com.easysubway.route.application.port.in.RouteV2SearchUseCase.RouteV2PlanSource;
 import com.easysubway.route.application.port.in.SubmitRouteFeedbackCommand;
@@ -73,7 +74,6 @@ import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -1381,42 +1381,31 @@ class RouteSearchServiceTest {
 	void routeV2PlannerPublishesOnlyCompleteOldOrNewCompiledSnapshotDuringReplacement() throws Exception {
 		var port = new ConcurrentSwitchingRouteTimetablePort();
 		var planner = new RouteV2Planner(legacySearchMustNotBeCalled(), port);
-		var observed = new ConcurrentLinkedQueue<List<String>>();
-		var start = new CountDownLatch(1);
 
-		try (var executor = Executors.newFixedThreadPool(4)) {
-			var writer = executor.submit(() -> {
-				start.await();
-				for (int index = 0; index < 80; index += 1) {
-					port.use(index % 2 == 0 ? "b" : "a");
-				}
-				return null;
-			});
-			var readers = java.util.stream.IntStream.range(0, 3).mapToObj(ignored -> executor.submit(() -> {
-				start.await();
-				for (int index = 0; index < 100; index += 1) {
-					var plan = planner.search(routeV2Command(
-						ConstraintMode.PREFER_STEP_FREE, MobilityType.SENIOR, 1, 3));
-					String tripId = plan.itineraries().getFirst().steps().stream()
-						.filter(step -> "ride".equals(step.stepType()))
-						.findFirst()
-						.orElseThrow()
-						.tripId();
-					observed.add(List.of(plan.timetableArtifactId(), tripId));
-				}
-				return null;
-			})).toList();
-			start.countDown();
-			writer.get(10, TimeUnit.SECONDS);
-			for (var reader : readers) {
-				reader.get(10, TimeUnit.SECONDS);
-			}
+		List<RouteV2Plan> plans;
+		try (var executor = Executors.newFixedThreadPool(2)) {
+			var oldPlan = executor.submit(() -> planner.search(routeV2Command(
+				ConstraintMode.PREFER_STEP_FREE, MobilityType.SENIOR, 1, 3)));
+			assertThat(port.awaitOldLoadStarted()).isTrue();
+			port.use("b");
+			var newPlan = executor.submit(() -> planner.search(routeV2Command(
+				ConstraintMode.PREFER_STEP_FREE, MobilityType.SENIOR, 1, 3)));
+			port.releaseOldLoad();
+			plans = List.of(oldPlan.get(10, TimeUnit.SECONDS), newPlan.get(10, TimeUnit.SECONDS));
 		}
 
-		assertThat(observed).hasSize(300).allSatisfy(pair -> assertThat(pair).isIn(
+		var observed = plans.stream().map(plan -> List.of(
+			plan.timetableArtifactId(),
+			plan.itineraries().getFirst().steps().stream()
+				.filter(step -> "ride".equals(step.stepType()))
+				.findFirst()
+				.orElseThrow()
+				.tripId()
+		)).toList();
+		assertThat(observed).containsExactlyInAnyOrder(
 			List.of("artifact-a", "trip-a"),
 			List.of("artifact-b", "trip-b")
-		));
+		);
 	}
 
 	@Test
@@ -3441,6 +3430,9 @@ class RouteSearchServiceTest {
 	private static class ConcurrentSwitchingRouteTimetablePort implements LoadRouteTimetablePort {
 
 		private volatile RouteTimetableSnapshot active = snapshot("a");
+		private final CountDownLatch oldLoadStarted = new CountDownLatch(1);
+		private final CountDownLatch releaseOldLoad = new CountDownLatch(1);
+		private final AtomicInteger oldLoadBlocksRemaining = new AtomicInteger(1);
 
 		@Override
 		public boolean hasRouteTimetable() {
@@ -3454,7 +3446,20 @@ class RouteSearchServiceTest {
 
 		@Override
 		public RouteTimetableSnapshot loadRouteTimetableSnapshot() {
-			return active;
+			RouteTimetableSnapshot loaded = active;
+			if ("artifact-a".equals(loaded.timetableArtifactId())
+				&& oldLoadBlocksRemaining.compareAndSet(1, 0)) {
+				oldLoadStarted.countDown();
+				try {
+					if (!releaseOldLoad.await(5, TimeUnit.SECONDS)) {
+						throw new AssertionError("old timetable load release timed out");
+					}
+				} catch (InterruptedException exception) {
+					Thread.currentThread().interrupt();
+					throw new AssertionError("old timetable load interrupted", exception);
+				}
+			}
+			return loaded;
 		}
 
 		@Override
@@ -3464,6 +3469,14 @@ class RouteSearchServiceTest {
 
 		void use(String version) {
 			active = snapshot(version);
+		}
+
+		boolean awaitOldLoadStarted() throws InterruptedException {
+			return oldLoadStarted.await(5, TimeUnit.SECONDS);
+		}
+
+		void releaseOldLoad() {
+			releaseOldLoad.countDown();
 		}
 
 		private static RouteTimetableSnapshot snapshot(String version) {

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerBenchmarkTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerBenchmarkTest.java
@@ -1,0 +1,192 @@
+package com.easysubway.route.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.easysubway.profile.domain.MobilityType;
+import com.easysubway.route.application.port.in.RouteSearchUseCase;
+import com.easysubway.route.application.port.in.RouteV2SearchUseCase.RouteV2Plan;
+import com.easysubway.route.application.port.in.RouteV2SearchUseCase.RouteV2Status;
+import com.easysubway.route.application.port.in.RouteV2SearchUseCase.SearchRouteV2Command;
+import com.easysubway.route.application.port.in.SearchInternalRouteCommand;
+import com.easysubway.route.application.port.in.SearchRouteCommand;
+import com.easysubway.route.application.port.in.SubmitRouteFeedbackCommand;
+import com.easysubway.route.application.port.out.LoadRouteTimetablePort;
+import com.easysubway.route.domain.ConstraintMode;
+import com.easysubway.route.domain.InternalRouteResult;
+import com.easysubway.route.domain.RouteFeedback;
+import com.easysubway.route.domain.RouteRefreshResult;
+import com.easysubway.route.domain.RouteSearchResult;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.InputStreamReader;
+import java.lang.management.ManagementFactory;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.HexFormat;
+import java.util.function.Supplier;
+import java.util.zip.GZIPInputStream;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+@DisplayName("#2249 timetable compiled snapshot microbenchmark")
+@EnabledIfEnvironmentVariable(named = "EASYSUBWAY_BENCHMARK", matches = "true")
+class RouteTimetableRaptorPlannerBenchmarkTest {
+
+	private static final String FIXTURE = "timetable/line4-timetable-seed.sql.gz";
+	private static final String FIXTURE_SHA256 = "06b65fed55e1d07623b0fbc69bf35b98973b22fb25e520d014fba69155d8fd5b";
+	private static final int WARMUPS = 20;
+	private static final int MEASUREMENTS = 100;
+	private static RouteV2Planner planner;
+
+	@BeforeAll
+	static void setUpFixture() throws Exception {
+		byte[] fixture = RouteTimetableRaptorPlannerBenchmarkTest.class.getClassLoader()
+			.getResourceAsStream(FIXTURE)
+			.readAllBytes();
+		assertThat(HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(fixture)))
+			.isEqualTo(FIXTURE_SHA256);
+
+		DataSource dataSource = new DriverManagerDataSource(
+			"jdbc:h2:mem:route-timetable-benchmark;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+			"sa",
+			""
+		);
+		var jdbc = new JdbcTemplate(dataSource);
+		jdbc.execute("RUNSCRIPT FROM 'src/main/resources/db/migration/h2/V29__canonical_transit_schedule.sql'");
+		jdbc.execute("RUNSCRIPT FROM 'src/main/resources/db/migration/h2/V37__transit_feed_info.sql'");
+		jdbc.execute("RUNSCRIPT FROM 'src/main/resources/db/migration/h2/V50__route_service_identity.sql'");
+		jdbc.execute("RUNSCRIPT FROM 'src/main/resources/db/migration/h2/V61__timetable_snapshot_state.sql'");
+		jdbc.execute("RUNSCRIPT FROM 'src/main/resources/db/migration/h2/V62__route_v2_planner_identity.sql'");
+		try (var reader = new BufferedReader(new InputStreamReader(
+			new GZIPInputStream(new ByteArrayInputStream(fixture)), StandardCharsets.UTF_8))) {
+			reader.lines().filter(line -> !line.isBlank()).forEach(jdbc::execute);
+		}
+		var timetable = new com.easysubway.route.adapter.out.persistence.JdbcRouteTimetableRepository(dataSource)
+			.loadRouteTimetable();
+		LoadRouteTimetablePort port = new LoadRouteTimetablePort() {
+			@Override
+			public RouteTimetable loadRouteTimetable() {
+				return timetable;
+			}
+
+			@Override
+			public boolean hasRouteTimetable() {
+				return true;
+			}
+
+			@Override
+			public RouteTimetableSnapshot loadRouteTimetableSnapshot() {
+				return new RouteTimetableSnapshot(FIXTURE_SHA256, "issue-2249-full-feed", timetable);
+			}
+
+			@Override
+			public String timetableCacheKey() {
+				return FIXTURE_SHA256;
+			}
+		};
+		planner = new RouteV2Planner(new NoLegacyRouteSearch(), port);
+	}
+
+	@Test
+	@DisplayName("full-feed hot query latency와 allocation raw sample을 기록한다")
+	void recordsHotQueryLatencyAndAllocation() {
+		var morning = command("2026-07-06T06:50:00+09:00");
+		var afterLast = command("2026-07-07T02:59:00+09:00");
+
+		Measurement morningResult = measure("morning-hot-search", () -> planner.search(morning));
+		Measurement afterLastResult = measure("after-last-search-next-service", () -> planner.search(afterLast));
+
+		assertThat(morningResult.lastPlan().statuses()).contains(RouteV2Status.FOUND);
+		assertThat(afterLastResult.lastPlan().statuses()).contains(RouteV2Status.NO_TIMETABLE_SERVICE);
+		assertThat(afterLastResult.lastPlan().nextServiceTime()).isNotNull();
+	}
+
+	private static Measurement measure(String scenario, Supplier<RouteV2Plan> query) {
+		for (int index = 0; index < WARMUPS; index += 1) {
+			query.get();
+		}
+		long[] nanos = new long[MEASUREMENTS];
+		long[] allocatedBytes = new long[MEASUREMENTS];
+		var bean = (com.sun.management.ThreadMXBean) ManagementFactory.getThreadMXBean();
+		if (!bean.isThreadAllocatedMemoryEnabled()) {
+			bean.setThreadAllocatedMemoryEnabled(true);
+		}
+		long threadId = Thread.currentThread().threadId();
+		RouteV2Plan lastPlan = null;
+		for (int index = 0; index < MEASUREMENTS; index += 1) {
+			long allocatedBefore = bean.getThreadAllocatedBytes(threadId);
+			long startedAt = System.nanoTime();
+			lastPlan = query.get();
+			nanos[index] = System.nanoTime() - startedAt;
+			allocatedBytes[index] = bean.getThreadAllocatedBytes(threadId) - allocatedBefore;
+		}
+		System.out.printf(
+			"BENCHMARK_RAW {\"fixture\":\"%s\",\"fixtureSha256\":\"%s\",\"scenario\":\"%s\","
+				+ "\"warmups\":%d,\"measurements\":%d,\"nanos\":%s,\"allocatedBytes\":%s}%n",
+			FIXTURE,
+			FIXTURE_SHA256,
+			scenario,
+			WARMUPS,
+			MEASUREMENTS,
+			Arrays.toString(nanos),
+			Arrays.toString(allocatedBytes)
+		);
+		return new Measurement(lastPlan);
+	}
+
+	private static SearchRouteV2Command command(String departureTime) {
+		return new SearchRouteV2Command(
+			"station-sangnoksu",
+			"station-sadang",
+			OffsetDateTime.parse(departureTime),
+			MobilityType.SENIOR,
+			ConstraintMode.ALLOW_WITH_WARNINGS,
+			false,
+			0,
+			3
+		);
+	}
+
+	private record Measurement(RouteV2Plan lastPlan) {
+	}
+
+	private static final class NoLegacyRouteSearch implements RouteSearchUseCase {
+		@Override
+		public RouteSearchResult searchRoute(SearchRouteCommand command) {
+			throw new AssertionError("legacy route search must not be called");
+		}
+
+		@Override
+		public List<RouteSearchResult> searchRouteAlternatives(SearchRouteCommand command, int alternativeCount) {
+			throw new AssertionError("legacy route search must not be called");
+		}
+
+		@Override
+		public InternalRouteResult searchInternalRoute(SearchInternalRouteCommand command) {
+			throw new AssertionError("legacy route search must not be called");
+		}
+
+		@Override
+		public RouteSearchResult getRouteSearch(String routeSearchId) {
+			throw new AssertionError("legacy route search must not be called");
+		}
+
+		@Override
+		public RouteRefreshResult refreshRoute(String routeSearchId) {
+			throw new AssertionError("legacy route search must not be called");
+		}
+
+		@Override
+		public RouteFeedback submitRouteFeedback(SubmitRouteFeedbackCommand command) {
+			throw new AssertionError("legacy route search must not be called");
+		}
+	}
+}

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerBenchmarkTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerBenchmarkTest.java
@@ -1,6 +1,7 @@
 package com.easysubway.route.application.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.easysubway.profile.domain.MobilityType;
 import com.easysubway.route.application.port.in.RouteSearchUseCase;
@@ -109,13 +110,43 @@ class RouteTimetableRaptorPlannerBenchmarkTest {
 		assertThat(afterLastResult.lastPlan().nextServiceTime()).isNotNull();
 	}
 
+	@Test
+	@DisplayName("allocation benchmark는 com.sun.management ThreadMXBean이 아니면 명확히 실패한다")
+	void rejectsThreadMxBeanWithoutAllocationApi() {
+		var bean = java.lang.management.ThreadMXBean.class.cast(java.lang.reflect.Proxy.newProxyInstance(
+			getClass().getClassLoader(),
+			new Class<?>[] { java.lang.management.ThreadMXBean.class },
+			(proxy, method, arguments) -> {
+				throw new AssertionError("standard ThreadMXBean method must not be called");
+			}
+		));
+
+		assertThatThrownBy(() -> requireThreadAllocationBean(bean))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessage("benchmark requires com.sun.management.ThreadMXBean");
+	}
+
+	@Test
+	@DisplayName("allocation benchmark는 thread allocation 측정 미지원 JVM에서 명확히 실패한다")
+	void rejectsThreadMxBeanWithoutAllocationSupport() {
+		var bean = com.sun.management.ThreadMXBean.class.cast(java.lang.reflect.Proxy.newProxyInstance(
+			getClass().getClassLoader(),
+			new Class<?>[] { com.sun.management.ThreadMXBean.class },
+			(proxy, method, arguments) -> false
+		));
+
+		assertThatThrownBy(() -> requireThreadAllocationBean(bean))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessage("benchmark requires thread allocation measurement support");
+	}
+
 	private static Measurement measure(String scenario, Supplier<RouteV2Plan> query) {
 		for (int index = 0; index < WARMUPS; index += 1) {
 			query.get();
 		}
 		long[] nanos = new long[MEASUREMENTS];
 		long[] allocatedBytes = new long[MEASUREMENTS];
-		var bean = (com.sun.management.ThreadMXBean) ManagementFactory.getThreadMXBean();
+		var bean = requireThreadAllocationBean(ManagementFactory.getThreadMXBean());
 		if (!bean.isThreadAllocatedMemoryEnabled()) {
 			bean.setThreadAllocatedMemoryEnabled(true);
 		}
@@ -140,6 +171,18 @@ class RouteTimetableRaptorPlannerBenchmarkTest {
 			Arrays.toString(allocatedBytes)
 		);
 		return new Measurement(lastPlan);
+	}
+
+	private static com.sun.management.ThreadMXBean requireThreadAllocationBean(
+		java.lang.management.ThreadMXBean platformBean
+	) {
+		if (!(platformBean instanceof com.sun.management.ThreadMXBean allocationBean)) {
+			throw new IllegalStateException("benchmark requires com.sun.management.ThreadMXBean");
+		}
+		if (!allocationBean.isThreadAllocatedMemorySupported()) {
+			throw new IllegalStateException("benchmark requires thread allocation measurement support");
+		}
+		return allocationBean;
 	}
 
 	private static SearchRouteV2Command command(String departureTime) {

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerCompiledSnapshotTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerCompiledSnapshotTest.java
@@ -36,6 +36,16 @@ class RouteTimetableRaptorPlannerCompiledSnapshotTest {
 	}
 
 	@Test
+	@DisplayName("같은 route의 branch·short-turn station sequence를 distinct pattern으로 compile한다")
+	void compilesBranchAndShortTurnTripsAsDistinctPatterns() {
+		var compiled = planner.compile(branchAndShortTurnTimetable());
+
+		assertThat(compiled.routePatternCount()).isEqualTo(3);
+		assertThat(compiled.scheduledTripCount()).isEqualTo(4);
+		assertThat(compiled.routePatternTripLinkCount()).isEqualTo(compiled.scheduledTripCount());
+	}
+
+	@Test
 	@DisplayName("compiled frequency 출발은 반복 검색에서도 기존 시각을 유지한다")
 	void preservesFrequencyDeparturesAcrossRepeatedSearches() {
 		var compiled = planner.compile(frequencyTimetable());
@@ -159,7 +169,8 @@ class RouteTimetableRaptorPlannerCompiledSnapshotTest {
 		var compiled = planner.compile(calendarExceptionTimetable());
 
 		assertThat(compiled.activeTripCount(WEDNESDAY)).isOne();
-		assertThat(compiled.activeTripCount(WEDNESDAY.plusDays(3))).isZero();
+		assertThat(compiled.activeTripCount(WEDNESDAY.plusDays(1))).isZero();
+		assertThat(compiled.activeTripCount(WEDNESDAY.plusDays(2))).isOne();
 		assertThat(compiled.activeTripCount(WEDNESDAY.plusDays(4))).isOne();
 	}
 
@@ -175,6 +186,35 @@ class RouteTimetableRaptorPlannerCompiledSnapshotTest {
 			),
 			List.of(new LoadRouteTimetablePort.TransitFrequency(
 				"trip-frequency", 32400, 34200, 600, false))
+		);
+	}
+
+	private static RouteTimetable branchAndShortTurnTimetable() {
+		return timetable(
+			List.of(weekday("weekday")),
+			List.of(),
+			List.of(
+				new LoadRouteTimetablePort.TransitTrip(
+					"trip-full", "route", "weekday", "도착", "0", "LOCAL", 0),
+				new LoadRouteTimetablePort.TransitTrip(
+					"trip-branch", "route", "weekday", "분기", "0", "LOCAL", 0),
+				new LoadRouteTimetablePort.TransitTrip(
+					"trip-short", "route", "weekday", "단축", "0", "LOCAL", 0)
+			),
+			List.of(
+				stop("trip-full", 1, "station-a", 32400),
+				stop("trip-full", 2, "station-b", 32500),
+				stop("trip-full", 3, "station-c", 32600),
+				stop("trip-full", 4, "station-d", 32700),
+				stop("trip-branch", 1, "station-a", 33000),
+				stop("trip-branch", 2, "station-b", 33100),
+				stop("trip-branch", 3, "station-e", 33200),
+				stop("trip-short", 1, "station-a", 33600),
+				stop("trip-short", 2, "station-b", 33700),
+				stop("trip-short", 3, "station-c", 33800)
+			),
+			List.of(new LoadRouteTimetablePort.TransitFrequency(
+				"trip-full", 32400, 33600, 600, false))
 		);
 	}
 
@@ -195,7 +235,7 @@ class RouteTimetableRaptorPlannerCompiledSnapshotTest {
 		return timetable(
 			List.of(weekday("weekday")),
 			List.of(
-				new LoadRouteTimetablePort.ServiceCalendarDate("weekday", WEDNESDAY.plusDays(3), 2),
+				new LoadRouteTimetablePort.ServiceCalendarDate("weekday", WEDNESDAY.plusDays(1), 2),
 				new LoadRouteTimetablePort.ServiceCalendarDate("special", WEDNESDAY.plusDays(4), 1)
 			),
 			List.of(

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerCompiledSnapshotTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerCompiledSnapshotTest.java
@@ -1,0 +1,184 @@
+package com.easysubway.route.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.easysubway.profile.domain.MobilityType;
+import com.easysubway.route.application.port.in.RouteV2SearchUseCase.SearchRouteV2Command;
+import com.easysubway.route.application.port.out.LoadRouteTimetablePort;
+import com.easysubway.route.application.port.out.LoadRouteTimetablePort.RouteTimetable;
+import com.easysubway.route.domain.ConstraintMode;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("#2249 timetable compiled snapshot")
+class RouteTimetableRaptorPlannerCompiledSnapshotTest {
+
+	private static final LocalDate WEDNESDAY = LocalDate.of(2026, 7, 1);
+	private final RouteTimetableRaptorPlanner planner = new RouteTimetableRaptorPlanner();
+
+	@Test
+	@DisplayName("feed grouping·정렬·frequency 전개 결과를 한 번 compile한다")
+	void compilesDenseIndexesPatternsAndFrequencyTrips() {
+		var compiled = planner.compile(frequencyTimetable());
+
+		assertThat(compiled.stationCount()).isEqualTo(2);
+		assertThat(compiled.routeCount()).isOne();
+		assertThat(compiled.tripCount()).isOne();
+		assertThat(compiled.routePatternCount()).isOne();
+		assertThat(compiled.scheduledTripCount()).isEqualTo(3);
+		assertThat(compiled.primitiveTimeArrayCount()).isEqualTo(3);
+	}
+
+	@Test
+	@DisplayName("compiled frequency 출발은 반복 검색에서도 기존 시각을 유지한다")
+	void preservesFrequencyDeparturesAcrossRepeatedSearches() {
+		var compiled = planner.compile(frequencyTimetable());
+		var command = command(WEDNESDAY, 9, 5);
+
+		var first = planner.search(command, compiled);
+		var second = planner.search(command, compiled);
+
+		assertThat(first).hasSize(1);
+		assertThat(second).extracting("estimatedDurationSeconds")
+			.containsExactly(first.getFirst().estimatedDurationSeconds());
+		assertThat(first.getFirst().steps())
+			.filteredOn(step -> "ride".equals(step.stepType()))
+			.extracting("plannedDepartureTime")
+			.containsExactly("2026-07-01T09:20:00+09:00");
+	}
+
+	@Test
+	@DisplayName("같은 service day의 immutable active snapshot을 재사용한다")
+	void reusesSameActiveServiceDay() {
+		var compiled = planner.compile(frequencyTimetable());
+
+		var first = compiled.activeServiceDay(WEDNESDAY);
+		var second = compiled.activeServiceDay(WEDNESDAY);
+
+		assertThat(second).isSameAs(first);
+		assertThat(compiled.activeServiceDayCacheSize()).isOne();
+	}
+
+	@Test
+	@DisplayName("active service day cache는 access-order 최근 8일만 유지한다")
+	void evictsLeastRecentlyUsedServiceDayAfterEightEntries() {
+		var compiled = planner.compile(everyDayTimetable());
+		for (int offset = 0; offset < 9; offset += 1) {
+			compiled.activeServiceDay(WEDNESDAY.plusDays(offset));
+		}
+
+		assertThat(compiled.activeServiceDayCacheSize()).isEqualTo(8);
+		assertThat(compiled.isServiceDayCached(WEDNESDAY)).isFalse();
+		compiled.activeServiceDay(WEDNESDAY.plusDays(1));
+		compiled.activeServiceDay(WEDNESDAY.plusDays(9));
+		assertThat(compiled.isServiceDayCached(WEDNESDAY.plusDays(1))).isTrue();
+		assertThat(compiled.isServiceDayCached(WEDNESDAY.plusDays(2))).isFalse();
+	}
+
+	@Test
+	@DisplayName("평일·주말과 calendar exception add/remove semantics를 보존한다")
+	void preservesCalendarAndExceptionSemantics() {
+		var compiled = planner.compile(calendarExceptionTimetable());
+
+		assertThat(compiled.activeTripCount(WEDNESDAY)).isOne();
+		assertThat(compiled.activeTripCount(WEDNESDAY.plusDays(3))).isZero();
+		assertThat(compiled.activeTripCount(WEDNESDAY.plusDays(4))).isOne();
+	}
+
+	private static RouteTimetable frequencyTimetable() {
+		return timetable(
+			List.of(weekday("weekday")),
+			List.of(),
+			List.of(new LoadRouteTimetablePort.TransitTrip(
+				"trip-frequency", "route", "weekday", "도착", "0", "LOCAL", 0)),
+			List.of(
+				stop("trip-frequency", 1, "station-a", 32400),
+				stop("trip-frequency", 2, "station-b", 33300)
+			),
+			List.of(new LoadRouteTimetablePort.TransitFrequency(
+				"trip-frequency", 32400, 34200, 600, false))
+		);
+	}
+
+	private static RouteTimetable everyDayTimetable() {
+		return timetable(
+			List.of(new LoadRouteTimetablePort.ServiceCalendar(
+				"daily", true, true, true, true, true, true, true,
+				WEDNESDAY, WEDNESDAY.plusDays(30), "Asia/Seoul")),
+			List.of(),
+			List.of(new LoadRouteTimetablePort.TransitTrip(
+				"trip-daily", "route", "daily", "도착", "0", "LOCAL", 0)),
+			List.of(stop("trip-daily", 1, "station-a", 32400), stop("trip-daily", 2, "station-b", 33000)),
+			List.of()
+		);
+	}
+
+	private static RouteTimetable calendarExceptionTimetable() {
+		return timetable(
+			List.of(weekday("weekday")),
+			List.of(
+				new LoadRouteTimetablePort.ServiceCalendarDate("weekday", WEDNESDAY.plusDays(3), 2),
+				new LoadRouteTimetablePort.ServiceCalendarDate("special", WEDNESDAY.plusDays(4), 1)
+			),
+			List.of(
+				new LoadRouteTimetablePort.TransitTrip("trip-weekday", "route", "weekday", "도착", "0", "LOCAL", 0),
+				new LoadRouteTimetablePort.TransitTrip("trip-special", "route", "special", "도착", "0", "LOCAL", 0)
+			),
+			List.of(
+				stop("trip-weekday", 1, "station-a", 32400), stop("trip-weekday", 2, "station-b", 33000),
+				stop("trip-special", 1, "station-a", 32400), stop("trip-special", 2, "station-b", 33000)
+			),
+			List.of()
+		);
+	}
+
+	private static LoadRouteTimetablePort.ServiceCalendar weekday(String serviceId) {
+		return new LoadRouteTimetablePort.ServiceCalendar(
+			serviceId, true, true, true, true, true, false, false,
+			WEDNESDAY, WEDNESDAY.plusDays(30), "Asia/Seoul");
+	}
+
+	private static RouteTimetable timetable(
+		List<LoadRouteTimetablePort.ServiceCalendar> calendars,
+		List<LoadRouteTimetablePort.ServiceCalendarDate> exceptions,
+		List<LoadRouteTimetablePort.TransitTrip> trips,
+		List<LoadRouteTimetablePort.TransitStopTime> stopTimes,
+		List<LoadRouteTimetablePort.TransitFrequency> frequencies
+	) {
+		return new RouteTimetable(
+			calendars,
+			exceptions,
+			List.of(new LoadRouteTimetablePort.TransitRoute(
+				"route", "line", "L", "테스트", "도착 방면", "Asia/Seoul")),
+			trips,
+			stopTimes,
+			frequencies
+		);
+	}
+
+	private static LoadRouteTimetablePort.TransitStopTime stop(
+		String tripId,
+		int sequence,
+		String stationId,
+		int seconds
+	) {
+		return new LoadRouteTimetablePort.TransitStopTime(
+			tripId, sequence, stationId, "line", seconds, seconds, 0, 0);
+	}
+
+	private static SearchRouteV2Command command(LocalDate date, int hour, int minute) {
+		return new SearchRouteV2Command(
+			"station-a",
+			"station-b",
+			OffsetDateTime.parse("%sT%02d:%02d:00+09:00".formatted(date, hour, minute)),
+			MobilityType.SENIOR,
+			ConstraintMode.ALLOW_WITH_WARNINGS,
+			false,
+			0,
+			3
+		);
+	}
+}

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerCompiledSnapshotTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerCompiledSnapshotTest.java
@@ -10,6 +10,9 @@ import com.easysubway.route.domain.ConstraintMode;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -60,6 +63,38 @@ class RouteTimetableRaptorPlannerCompiledSnapshotTest {
 
 		assertThat(second).isSameAs(first);
 		assertThat(compiled.activeServiceDayCacheSize()).isOne();
+	}
+
+	@Test
+	@DisplayName("일반 search는 next-service 전용 boarding index를 생성하지 않는다")
+	void regularSearchDoesNotAllocateBoardingIndex() {
+		var compiled = planner.compile(frequencyTimetable());
+
+		assertThat(planner.search(command(WEDNESDAY, 9, 5), compiled)).hasSize(1);
+
+		assertThat(compiled.activeServiceDay(WEDNESDAY).boardingIndexInitialized()).isFalse();
+	}
+
+	@Test
+	@DisplayName("동시 nextServiceTime은 service day boarding index를 안전하게 lazy publish한다")
+	void concurrentNextServiceTimeLazilyPublishesBoardingIndex() throws Exception {
+		var compiled = planner.compile(frequencyTimetable());
+		var activeDay = compiled.activeServiceDay(WEDNESDAY);
+		var start = new CountDownLatch(1);
+
+		assertThat(activeDay.boardingIndexInitialized()).isFalse();
+		try (var executor = Executors.newFixedThreadPool(8)) {
+			var attempts = java.util.stream.IntStream.range(0, 8).mapToObj(ignored -> executor.submit(() -> {
+				start.await();
+				return planner.nextServiceTime(command(WEDNESDAY, 8, 0), compiled);
+			})).toList();
+			start.countDown();
+			for (var attempt : attempts) {
+				assertThat(attempt.get(5, TimeUnit.SECONDS))
+					.contains(OffsetDateTime.parse("2026-07-01T09:00:00+09:00"));
+			}
+		}
+		assertThat(activeDay.boardingIndexInitialized()).isTrue();
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerCompiledSnapshotTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerCompiledSnapshotTest.java
@@ -54,6 +54,46 @@ class RouteTimetableRaptorPlannerCompiledSnapshotTest {
 	}
 
 	@Test
+	@DisplayName("search의 비교와 결과 시각은 compiled primitive 배열을 사용한다")
+	void usesPrimitiveTimesForSearchAndResultTimes() throws Exception {
+		var compiled = planner.compile(everyDayTimetable());
+		primitiveIntArray(compiled, "departureSeconds")[0] = 32520;
+		primitiveIntArray(compiled, "arrivalSeconds")[1] = 33120;
+
+		var results = planner.search(command(WEDNESDAY, 8, 50), compiled);
+
+		assertThat(results).hasSize(1);
+		assertThat(results.getFirst().steps())
+			.filteredOn(step -> "ride".equals(step.stepType()))
+			.extracting("plannedDepartureTime", "plannedArrivalTime")
+			.containsExactly(org.assertj.core.groups.Tuple.tuple(
+				"2026-07-01T09:02:00+09:00",
+				"2026-07-01T09:12:00+09:00"));
+	}
+
+	@Test
+	@DisplayName("search의 승하차 허용 판단은 compiled primitive 배열을 사용한다")
+	void usesPrimitivePickupAndDropOffTypesForSearch() throws Exception {
+		var pickupBlocked = planner.compile(everyDayTimetable());
+		primitiveByteArray(pickupBlocked, "pickupTypes")[0] = 1;
+		var dropOffBlocked = planner.compile(everyDayTimetable());
+		primitiveByteArray(dropOffBlocked, "dropOffTypes")[1] = 1;
+
+		assertThat(planner.search(command(WEDNESDAY, 8, 50), pickupBlocked)).isEmpty();
+		assertThat(planner.search(command(WEDNESDAY, 8, 50), dropOffBlocked)).isEmpty();
+	}
+
+	@Test
+	@DisplayName("nextServiceTime 비교는 compiled primitive 출발 시각을 사용한다")
+	void usesPrimitiveDepartureTimeForNextServiceTime() throws Exception {
+		var compiled = planner.compile(everyDayTimetable());
+		primitiveIntArray(compiled, "departureSeconds")[0] = 32700;
+
+		assertThat(planner.nextServiceTime(command(WEDNESDAY, 8, 50), compiled))
+			.contains(OffsetDateTime.parse("2026-07-01T09:05:00+09:00"));
+	}
+
+	@Test
 	@DisplayName("같은 service day의 immutable active snapshot을 재사용한다")
 	void reusesSameActiveServiceDay() {
 		var compiled = planner.compile(frequencyTimetable());
@@ -215,5 +255,34 @@ class RouteTimetableRaptorPlannerCompiledSnapshotTest {
 			0,
 			3
 		);
+	}
+
+	private static int[] primitiveIntArray(
+		RouteTimetableRaptorPlanner.CompiledTimetable compiled,
+		String fieldName
+	) throws Exception {
+		return (int[]) primitiveArray(compiled, fieldName);
+	}
+
+	private static byte[] primitiveByteArray(
+		RouteTimetableRaptorPlanner.CompiledTimetable compiled,
+		String fieldName
+	) throws Exception {
+		return (byte[]) primitiveArray(compiled, fieldName);
+	}
+
+	private static Object primitiveArray(
+		RouteTimetableRaptorPlanner.CompiledTimetable compiled,
+		String fieldName
+	) throws Exception {
+		var scheduledTripsField = compiled.getClass().getDeclaredField("scheduledTrips");
+		scheduledTripsField.setAccessible(true);
+		var scheduledTrip = ((List<?>) scheduledTripsField.get(compiled)).getFirst();
+		var timesField = scheduledTrip.getClass().getDeclaredField("times");
+		timesField.setAccessible(true);
+		var times = timesField.get(scheduledTrip);
+		var primitiveArrayField = times.getClass().getDeclaredField(fieldName);
+		primitiveArrayField.setAccessible(true);
+		return primitiveArrayField.get(times);
 	}
 }

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -14797,7 +14797,7 @@ test("V2 경로 검색은 production planner 경계를 통해 요청 조건을 �
   assert.match(planner, /loadRouteTimetableSnapshot\(\)/);
   assert.match(planner, /RouteTimetableRaptorPlanner/);
   assert.match(planner, /noTimetableServicePlan/);
-  assert.match(planner, /nextServiceTime\(command, snapshot\.timetable\(\)\)/);
+  assert.match(planner, /nextServiceTime\(\s*command,\s*snapshot\.compiledTimetable\(\)\s*\)/);
   assert.match(planner, /searchRouteAlternatives/);
   assert.match(planner, /statusesOf/);
   assert.match(raptorPlanner, /class RouteTimetableRaptorPlanner/);


### PR DESCRIPTION
## 관련 이슈

Closes #2249

## 작업 배경

- Route V2 timetable 검색마다 반복되던 grouping·정렬·frequency 전개를 feed artifact 단위 compile로 이동합니다.
- 심야·막차 이후 검색에서 반복되던 service-day 활성 trip 계산과 next-service boarding index 생성을 재사용합니다.

## 작업 내용

- immutable compiled timetable snapshot에 dense stop/route/trip index, route pattern, route별 trip 정렬, primitive 시각 배열, calendar/exception index, frequency 전개 결과를 보관합니다.
- 최근 8개 service day를 access-order LRU로 캐시하고, next-service 전용 boarding index는 최초 필요 시 thread-safe하게 생성합니다.
- cacheKey 전환 시 완성된 구·신 snapshot 중 하나만 관측하도록 기존 atomic 교체 semantics를 유지합니다.
- 기존 검색 루프는 유지하면서 시각·pickup/dropoff hot-path가 primitive 배열을 실제로 사용하도록 연결합니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test` — BUILD SUCCESSFUL (fresh full backend suite, 3m 4s)
  - `./gradlew test --rerun-tasks --tests 'com.easysubway.route.application.service.RouteTimetableRaptorPlanner*' --tests com.easysubway.route.application.service.RouteSearchServiceTest` — BUILD SUCCESSFUL
  - `codex review --disable plugins --base origin/main` — actionable finding 0건
  - `git diff --check origin/main...HEAD` — 오류 없음
  - 동등 microbenchmark, fixture SHA-256 `06b65...`, warmup 20회·measurement 100회
    - morning: 1,775,275 → 1,464,805 ns/op (-17.5%), 3,710,674 → 2,530,470 B/op (-31.8%)
    - after-last: 2,977,578 → 202,709 ns/op (-93.2%), 6,240,616 → 596,536 B/op (-90.4%)

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| compiled snapshot·golden·동시 교체 | Backend | 관련 Gradle suite fresh 실행 | CI 및 위 명령 | 통과 |
| latency·allocation | Backend JVM | 동일 fixture·반복 microbenchmark | raw: `/tmp/issue-2249-baseline.log`, `/tmp/issue-2249-compiled.log` (작성자 로컬) | 개선 |
| UI/수동 QA | 해당 없음 | 사용자 표시/API contract 변경 없음 | golden OD 결과 동일 | 불필요 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 코드 배포 SHA만 변경

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `RouteV2Planner`의 cacheKey double-check와 compiled snapshot atomic publish
  - service-day LRU 및 lazy boarding index 동시성
  - primitive 시각 배열이 검색·next-service에서 실제 소비되는 경계

## 리스크

- compiled feed의 상주 메모리가 늘 수 있어 benchmark allocation과 lazy boarding index 테스트로 방어했습니다.
- calendar exception·frequency·막차 이후 동작 회귀는 기존 golden 및 신규 집중 테스트로 방어했습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다. Backend·Mobile·Android·Repository 및 release artifact 통과.
- [x] CodeRabbit 리뷰를 확인했다. 지적 4건 수정 후 bot 재확인 및 thread resolve 완료.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 후속 수정 head를 Codex CLI로 독립 재검토하고 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. pre-merge Backend Release Image 통과, 실제 post-merge deploy는 완료 대기 범위 아님.
