### PR TITLE
[Feat] 경로 공유 텍스트 요약 추가 (#1920)

### DIFF
--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -579,7 +579,7 @@ class LocalRouteRepository implements RouteSearchRepository {
       blockedReasons: result.blockedReasonCodes
           .map(_blockedReasonMessage)
           .toList(growable: false),
-      createdAt: DateTime.now().toIso8601String(),
+      createdAt: DateTime.now().toUtc().toIso8601String(),
       etaSource: 'STATIC_LOCAL',
       etaConfidence: 'STATIC',
       sourceUpdatedAt: catalog.sourceUpdatedAt,

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -585,6 +585,7 @@ class LocalRouteRepository implements RouteSearchRepository {
       sourceUpdatedAt: catalog.sourceUpdatedAt,
       officialOdFareQuote: officialOdFareQuote,
       transportScope: request.transportScope,
+      objective: request.objective,
     );
   }
 

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -4926,21 +4926,17 @@ RouteShareSnapshot _routeShareSnapshot(RouteSearchResult result) {
 
   var departureSource = result.departureTimeIso.isNotEmpty
       ? result.departureTimeIso
-      : steps.first.realtimeDepartureTimeIso.isNotEmpty
-      ? steps.first.realtimeDepartureTimeIso
-      : steps.first.plannedDepartureTimeIso;
+      : _firstRouteShareDeparture(steps);
   var arrivalSource = result.arrivalTimeIso.isNotEmpty
       ? result.arrivalTimeIso
-      : steps.last.realtimeArrivalTimeIso.isNotEmpty
-      ? steps.last.realtimeArrivalTimeIso
-      : steps.last.plannedArrivalTimeIso;
+      : _lastRouteShareArrival(steps);
   final durationMinutes = (result.estimatedDurationSeconds / 60).ceil();
-  if (result.isLocalResult) {
-    final duration = Duration(seconds: result.estimatedDurationSeconds);
-    if (departureSource.isEmpty && arrivalSource.isEmpty) {
-      departureSource = _routeShareTime(result.createdAt);
-      arrivalSource = _shiftRouteShareTime(departureSource, duration);
-    } else if (departureSource.isEmpty) {
+  final duration = Duration(seconds: result.estimatedDurationSeconds);
+  if (departureSource.isEmpty && arrivalSource.isEmpty) {
+    departureSource = _routeShareTime(result.createdAt);
+    arrivalSource = _shiftRouteShareTime(departureSource, duration);
+  } else if (result.isLocalResult) {
+    if (departureSource.isEmpty) {
       departureSource = _shiftRouteShareTime(arrivalSource, -duration);
     } else if (arrivalSource.isEmpty) {
       arrivalSource = _shiftRouteShareTime(departureSource, duration);
@@ -4989,6 +4985,30 @@ RouteShareSnapshot _routeShareSnapshot(RouteSearchResult result) {
     legs: legs,
     fare: fare,
   );
+}
+
+String _firstRouteShareDeparture(List<RouteSearchStep> steps) {
+  for (final step in steps) {
+    if (step.realtimeDepartureTimeIso.isNotEmpty) {
+      return step.realtimeDepartureTimeIso;
+    }
+    if (step.plannedDepartureTimeIso.isNotEmpty) {
+      return step.plannedDepartureTimeIso;
+    }
+  }
+  return '';
+}
+
+String _lastRouteShareArrival(List<RouteSearchStep> steps) {
+  for (final step in steps.reversed) {
+    if (step.realtimeArrivalTimeIso.isNotEmpty) {
+      return step.realtimeArrivalTimeIso;
+    }
+    if (step.plannedArrivalTimeIso.isNotEmpty) {
+      return step.plannedArrivalTimeIso;
+    }
+  }
+  return '';
 }
 
 String _routeShareTime(String value, {bool allowEmpty = false}) {

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -4903,20 +4903,31 @@ RouteShareSnapshot _routeShareSnapshot(
             forbiddenIdentifiers.any(description.contains)) {
           throw StateError('Route leg display labels are unavailable');
         }
+        var departureTimeSource = step.realtimeDepartureTimeIso.isNotEmpty
+            ? step.realtimeDepartureTimeIso
+            : step.plannedDepartureTimeIso;
+        var arrivalTimeSource = step.realtimeArrivalTimeIso.isNotEmpty
+            ? step.realtimeArrivalTimeIso
+            : step.plannedArrivalTimeIso;
+        if (result.isLocalResult) {
+          final duration = Duration(minutes: step.estimatedMinutes);
+          if (departureTimeSource.isEmpty && arrivalTimeSource.isNotEmpty) {
+            departureTimeSource = _shiftRouteShareTime(
+              arrivalTimeSource,
+              -duration,
+            );
+          } else if (arrivalTimeSource.isEmpty &&
+              departureTimeSource.isNotEmpty) {
+            arrivalTimeSource = _shiftRouteShareTime(
+              departureTimeSource,
+              duration,
+            );
+          }
+        }
         return RouteShareLeg(
           description: description,
-          departureTime: _routeShareTime(
-            step.realtimeDepartureTimeIso.isNotEmpty
-                ? step.realtimeDepartureTimeIso
-                : step.plannedDepartureTimeIso,
-            allowEmpty: true,
-          ),
-          arrivalTime: _routeShareTime(
-            step.realtimeArrivalTimeIso.isNotEmpty
-                ? step.realtimeArrivalTimeIso
-                : step.plannedArrivalTimeIso,
-            allowEmpty: true,
-          ),
+          departureTime: _routeShareTime(departureTimeSource, allowEmpty: true),
+          arrivalTime: _routeShareTime(arrivalTimeSource, allowEmpty: true),
         );
       })
       .toList(growable: false);
@@ -4932,17 +4943,16 @@ RouteShareSnapshot _routeShareSnapshot(
       ? steps.last.realtimeArrivalTimeIso
       : steps.last.plannedArrivalTimeIso;
   final durationMinutes = (result.estimatedDurationSeconds / 60).ceil();
-  if (result.isLocalResult &&
-      departureSource.isEmpty &&
-      arrivalSource.isEmpty) {
-    final departure = DateTime.tryParse(result.createdAt);
-    if (departure == null) {
-      throw StateError('Local route time is unavailable');
+  if (result.isLocalResult) {
+    final duration = Duration(seconds: result.estimatedDurationSeconds);
+    if (departureSource.isEmpty && arrivalSource.isEmpty) {
+      departureSource = _routeShareTime(result.createdAt);
+      arrivalSource = _shiftRouteShareTime(departureSource, duration);
+    } else if (departureSource.isEmpty) {
+      departureSource = _shiftRouteShareTime(arrivalSource, -duration);
+    } else if (arrivalSource.isEmpty) {
+      arrivalSource = _shiftRouteShareTime(departureSource, duration);
     }
-    departureSource = departure.toIso8601String();
-    arrivalSource = departure
-        .add(Duration(seconds: result.estimatedDurationSeconds))
-        .toIso8601String();
   }
 
   RouteShareFare? fare;
@@ -4997,6 +5007,23 @@ String _routeShareTime(String value, {bool allowEmpty = false}) {
     throw StateError('Route time is unavailable');
   }
   return '${match.group(1)}:${match.group(2)}';
+}
+
+String _shiftRouteShareTime(String value, Duration offset) {
+  final match = RegExp(
+    r'(?:T|^)(\d{2}):(\d{2})(?::(\d{2}))?',
+  ).firstMatch(value.trim());
+  if (match == null) {
+    throw StateError('Route time is unavailable');
+  }
+  final hour = int.parse(match.group(1)!);
+  final minute = int.parse(match.group(2)!);
+  final second = int.parse(match.group(3) ?? '0');
+  if (hour > 23 || minute > 59 || second > 59) {
+    throw StateError('Route time is unavailable');
+  }
+  final shifted = DateTime.utc(2000, 1, 2, hour, minute, second).add(offset);
+  return '${shifted.hour.toString().padLeft(2, '0')}:${shifted.minute.toString().padLeft(2, '0')}';
 }
 
 class _OfficialOdFareSection extends StatelessWidget {

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -222,6 +222,7 @@ class RouteSearchApiRepository implements RouteSearchRepository {
       return RouteSearchResult.fromJson(
         data,
         constraintMode: routeRequest.effectiveConstraintMode,
+        objective: routeRequest.objective,
       );
     } on RouteSearchException {
       rethrow;
@@ -1294,6 +1295,7 @@ class RouteSearchResult {
   factory RouteSearchResult.fromJson(
     Map<String, Object?> json, {
     String? constraintMode,
+    RouteObjective objective = RouteObjective.fastest,
   }) {
     final rawSteps = json['steps'];
     final rawWarnings = json['warnings'];
@@ -1387,6 +1389,7 @@ class RouteSearchResult {
       sourceUpdatedAt: _optionalRouteString(json, 'sourceUpdatedAt'),
       nextServiceTime: _optionalRouteString(json, 'nextServiceTime'),
       transportScope: _routeTransportScopeFromValue(json['transportScope']),
+      objective: objective,
     );
   }
 
@@ -1687,6 +1690,7 @@ class RouteSearchResult {
     List<RouteSearchStep>? steps,
     String? etaSource,
     OfficialOdFareQuote? officialOdFareQuote,
+    RouteObjective? objective,
   }) {
     return RouteSearchResult(
       routeSearchId: routeSearchId,
@@ -1723,7 +1727,7 @@ class RouteSearchResult {
       supportsRefresh: supportsRefresh,
       nextServiceTime: nextServiceTime,
       transportScope: transportScope,
-      objective: objective,
+      objective: objective ?? this.objective,
       departureTimeIso: departureTimeIso,
       arrivalTimeIso: arrivalTimeIso,
       officialFare: officialFare,
@@ -4588,8 +4592,11 @@ RouteSearchResult _preserveGetOffAlarmArrivalTimes({
   required RouteSearchResult next,
   required RouteSearchResult previous,
 }) {
+  final objectivePreserved = next.withDisplayLabels(
+    objective: previous.objective,
+  );
   if (_rideLegArrivalsFromResult(previous).isEmpty) {
-    return next;
+    return objectivePreserved;
   }
   final previousRideSteps = previous.steps
       .where(
@@ -4598,7 +4605,7 @@ RouteSearchResult _preserveGetOffAlarmArrivalTimes({
       )
       .toList(growable: false);
   var changed = false;
-  final steps = next.steps
+  final steps = objectivePreserved.steps
       .map((step) {
         if (step.stepType != 'ride' || step.plannedArrivalTimeIso.isNotEmpty) {
           return step;
@@ -4621,9 +4628,9 @@ RouteSearchResult _preserveGetOffAlarmArrivalTimes({
       })
       .toList(growable: false);
   if (!changed) {
-    return next;
+    return objectivePreserved;
   }
-  return next.withDisplayLabels(steps: steps);
+  return objectivePreserved.withDisplayLabels(steps: steps);
 }
 
 RouteSearchStep? _matchingPreviousRideStep({
@@ -4970,7 +4977,9 @@ RouteShareSnapshot _routeShareSnapshot(
     transferCount: result.transferCount,
     freshness: switch (result.etaSource) {
       'REALTIME' => RouteShareFreshness.realtime,
-      'STATIC_LOCAL' || 'STATIC_ESTIMATE' => RouteShareFreshness.staticData,
+      'STATIC_LOCAL' ||
+      'STATIC_ESTIMATE' ||
+      'STALE' => RouteShareFreshness.staticData,
       _ => RouteShareFreshness.planned,
     },
     legs: legs,

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -222,7 +222,7 @@ class RouteSearchApiRepository implements RouteSearchRepository {
       return RouteSearchResult.fromJson(
         data,
         constraintMode: routeRequest.effectiveConstraintMode,
-        objective: routeRequest.objective,
+        objective: RouteObjective.fastest,
       );
     } on RouteSearchException {
       rethrow;
@@ -4808,17 +4808,24 @@ class _RouteDetailWorkflowView extends StatelessWidget {
   }
 }
 
-class _RouteShareButton extends StatelessWidget {
+class _RouteShareButton extends StatefulWidget {
   const _RouteShareButton({required this.result, required this.invoker});
 
   final RouteSearchResult result;
   final RouteShareInvoker? invoker;
 
   @override
+  State<_RouteShareButton> createState() => _RouteShareButtonState();
+}
+
+class _RouteShareButtonState extends State<_RouteShareButton> {
+  var _isSharing = false;
+
+  @override
   Widget build(BuildContext context) {
     return Builder(
       builder: (buttonContext) {
-        void onShare() => _share(buttonContext);
+        final onShare = _isSharing ? null : () => _share(buttonContext);
         return Semantics(
           button: true,
           label: '경로 요약 공유',
@@ -4836,14 +4843,18 @@ class _RouteShareButton extends StatelessWidget {
   }
 
   Future<void> _share(BuildContext context) async {
+    if (_isSharing) {
+      return;
+    }
+    setState(() => _isSharing = true);
     try {
       final renderBox = context.findRenderObject();
       if (renderBox is! RenderBox || !renderBox.hasSize) {
         throw StateError('Route share trigger is unavailable');
       }
       final origin = renderBox.localToGlobal(Offset.zero) & renderBox.size;
-      final text = buildRouteShareSummary(_routeShareSnapshot(result));
-      final invoke = invoker;
+      final text = buildRouteShareSummary(_routeShareSnapshot(widget.result));
+      final invoke = widget.invoker;
       if (invoke != null) {
         await invoke(text, origin);
       } else {
@@ -4856,6 +4867,10 @@ class _RouteShareButton extends StatelessWidget {
         ScaffoldMessenger.of(
           context,
         ).showSnackBar(const SnackBar(content: Text('경로 요약을 공유하지 못했어요.')));
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _isSharing = false);
       }
     }
   }

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:share_plus/share_plus.dart';
 
 import 'accessible_design.dart';
 import 'ad_slot.dart';
@@ -23,7 +24,11 @@ import 'features/mobility_profile/mobility_preset_labels.dart';
 import 'features/mobility_profile/mobility_preset_picker.dart';
 import 'features/mobility_profile/mobility_profile_policy.dart';
 import 'route_hedge_labels.dart';
+import 'route_share_summary.dart';
 import 'station_search.dart';
+
+typedef RouteShareInvoker =
+    Future<void> Function(String text, Rect sharePositionOrigin);
 
 const _routeSearchTimeout = Duration(seconds: 8);
 const _routeSearchErrorMessage = '경로 정보를 불러오지 못했어요.';
@@ -942,6 +947,7 @@ class RouteSearchV2Itinerary {
     required this.legs,
     required this.commercialEtaEligible,
     this.objectiveTags = const [],
+    this.officialFare,
   });
 
   factory RouteSearchV2Itinerary.fromJson(Map<String, Object?> json) {
@@ -980,6 +986,11 @@ class RouteSearchV2Itinerary {
         json['objectiveTags'] ?? const <Object?>[],
         'route v2 objective tag',
       ),
+      officialFare: switch (json['officialFare']) {
+        null => null,
+        Map<String, Object?> value => RouteSearchOfficialFare.fromJson(value),
+        _ => throw const FormatException('Invalid route v2 official fare'),
+      },
     );
   }
 
@@ -995,6 +1006,7 @@ class RouteSearchV2Itinerary {
   final RouteSearchV2AccessibilityRisk accessibilityRisk;
   final List<RouteSearchV2Leg> legs;
   final bool commercialEtaEligible;
+  final RouteSearchOfficialFare? officialFare;
 
   /// 백엔드가 dual-tag dedupe한 대표 itinerary에 붙이는 objective 태그
   /// (FASTEST·FEWEST_TRANSFERS). 두 objective가 같은 경로면 두 태그를 모두 담는다.
@@ -1002,6 +1014,43 @@ class RouteSearchV2Itinerary {
 
   bool matchesObjective(RouteObjective objective) =>
       objectiveTags.contains(objective.serverValue);
+}
+
+class RouteSearchOfficialFare {
+  const RouteSearchOfficialFare({
+    required this.adultFareWon,
+    required this.currency,
+    required this.policy,
+    required this.sourceIds,
+    required this.sourceSnapshotIds,
+  });
+
+  factory RouteSearchOfficialFare.fromJson(Map<String, Object?> json) {
+    final fare = RouteSearchOfficialFare(
+      adultFareWon: _requiredRouteInt(json, 'adultFareWon'),
+      currency: _requiredRouteString(json, 'currency'),
+      policy: _requiredRouteString(json, 'policy'),
+      sourceIds: _routeStringList(json['sourceIds'], 'official fare source'),
+      sourceSnapshotIds: _routeStringList(
+        json['sourceSnapshotIds'],
+        'official fare source snapshot',
+      ),
+    );
+    if (fare.adultFareWon <= 0 ||
+        fare.currency != 'KRW' ||
+        fare.policy != 'SUM_OF_OFFICIAL_RIDE_OD_FARES' ||
+        fare.sourceIds.isEmpty ||
+        fare.sourceSnapshotIds.isEmpty) {
+      throw const FormatException('Invalid route v2 official fare');
+    }
+    return fare;
+  }
+
+  final int adultFareWon;
+  final String currency;
+  final String policy;
+  final List<String> sourceIds;
+  final List<String> sourceSnapshotIds;
 }
 
 class RouteSearchV2Leg {
@@ -1226,6 +1275,10 @@ class RouteSearchResult {
     this.supportsRefresh = true,
     this.nextServiceTime = '',
     this.transportScope = RouteTransportScope.subway,
+    this.objective = RouteObjective.fastest,
+    this.departureTimeIso = '',
+    this.arrivalTimeIso = '',
+    this.officialFare,
   }) : // `burdenCost`는 API contract 이름이고 저장 필드는 private 값이다.
        // ignore: prefer_initializing_formals
        _accessibilityScore = accessibilityScore,
@@ -1374,6 +1427,8 @@ class RouteSearchResult {
         supportsRefresh: false,
         nextServiceTime: result.nextServiceTime,
         transportScope: RouteTransportScope.subwayAndItxCheongchun,
+        objective: objective,
+        departureTimeIso: result.departureTime,
       );
     }
     final itinerary = _selectRouteV2Itinerary(result.itineraries, objective);
@@ -1431,6 +1486,11 @@ class RouteSearchResult {
       sourceUpdatedAt: result.departureTime,
       supportsRefresh: false,
       transportScope: RouteTransportScope.subwayAndItxCheongchun,
+      objective: objective,
+      departureTimeIso: result.departureTime,
+      arrivalTimeIso:
+          itinerary.realtimeArrivalTime ?? itinerary.plannedArrivalTime,
+      officialFare: itinerary.officialFare,
     );
   }
 
@@ -1467,6 +1527,10 @@ class RouteSearchResult {
   final bool supportsRefresh;
   final String nextServiceTime;
   final RouteTransportScope transportScope;
+  final RouteObjective objective;
+  final String departureTimeIso;
+  final String arrivalTimeIso;
+  final RouteSearchOfficialFare? officialFare;
 
   bool get hasOfficialOdFareQuote => officialOdFareQuote != null;
 
@@ -1659,6 +1723,10 @@ class RouteSearchResult {
       supportsRefresh: supportsRefresh,
       nextServiceTime: nextServiceTime,
       transportScope: transportScope,
+      objective: objective,
+      departureTimeIso: departureTimeIso,
+      arrivalTimeIso: arrivalTimeIso,
+      officialFare: officialFare,
     );
   }
 
@@ -2040,6 +2108,8 @@ class RouteSearchStep {
     this.confidenceLabel = '',
     this.plannedArrivalTimeIso = '',
     this.realtimeArrivalTimeIso = '',
+    this.plannedDepartureTimeIso = '',
+    this.realtimeDepartureTimeIso = '',
     this.carDoorCarNumber,
     this.carDoorDoorNumber,
     this.carDoorFacilityType = '',
@@ -2124,6 +2194,8 @@ class RouteSearchStep {
       confidenceLabel: leg.confidence,
       plannedArrivalTimeIso: leg.plannedArrivalTime,
       realtimeArrivalTimeIso: leg.realtimeArrivalTime ?? '',
+      plannedDepartureTimeIso: leg.plannedDepartureTime,
+      realtimeDepartureTimeIso: leg.realtimeDepartureTime ?? '',
       serviceClass: leg.serviceClass,
       servicePattern: leg.servicePattern,
     );
@@ -2147,6 +2219,8 @@ class RouteSearchStep {
   /// 그 외 경로/step에서는 빈 문자열이다.
   final String plannedArrivalTimeIso;
   final String realtimeArrivalTimeIso;
+  final String plannedDepartureTimeIso;
+  final String realtimeDepartureTimeIso;
   final String actionTitle;
   final String actionDetail;
   final String reason;
@@ -2206,6 +2280,8 @@ class RouteSearchStep {
           plannedArrivalTimeIso ?? this.plannedArrivalTimeIso,
       realtimeArrivalTimeIso:
           realtimeArrivalTimeIso ?? this.realtimeArrivalTimeIso,
+      plannedDepartureTimeIso: plannedDepartureTimeIso,
+      realtimeDepartureTimeIso: realtimeDepartureTimeIso,
       carDoorCarNumber: carDoorCarNumber,
       carDoorDoorNumber: carDoorDoorNumber,
       carDoorFacilityType: carDoorFacilityType,
@@ -2717,6 +2793,7 @@ class RouteSearchScreen extends StatefulWidget {
     this.shellNavigationBar,
     this.onShellBackToHome,
     this.getOffAlarmController,
+    this.routeShareInvoker,
     String? initialMobilityType,
     super.key,
   }) : initialMobilityType = _resolveInitialMobilityType(initialMobilityType);
@@ -2727,6 +2804,7 @@ class RouteSearchScreen extends StatefulWidget {
   final FavoriteRouteRepository? favoriteRouteRepository;
   final AdRepository? adRepository;
   final GetOffAlarmController? getOffAlarmController;
+  final RouteShareInvoker? routeShareInvoker;
   final RouteDraft? initialDraft;
   final RouteTransportScope initialTransportScope;
   final Widget? shellNavigationBar;
@@ -3128,6 +3206,7 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
                           : _endRoute,
                       getOffAlarmController: widget.getOffAlarmController,
                       stationRepository: widget.stationRepository,
+                      routeShareInvoker: widget.routeShareInvoker,
                     ),
                   ],
                 ),
@@ -4072,6 +4151,7 @@ class _RouteSearchBody extends StatelessWidget {
     required this.onShellBackToHome,
     required this.getOffAlarmController,
     required this.stationRepository,
+    required this.routeShareInvoker,
   });
 
   final RouteSearchState state;
@@ -4082,6 +4162,7 @@ class _RouteSearchBody extends StatelessWidget {
   final AsyncCallback? onShellBackToHome;
   final GetOffAlarmController? getOffAlarmController;
   final StationSearchRepository stationRepository;
+  final RouteShareInvoker? routeShareInvoker;
 
   @override
   Widget build(BuildContext context) {
@@ -4111,6 +4192,7 @@ class _RouteSearchBody extends StatelessWidget {
         onShellBackToHome: onShellBackToHome,
         getOffAlarmController: getOffAlarmController,
         stationRepository: stationRepository,
+        routeShareInvoker: routeShareInvoker,
       ),
     };
   }
@@ -4266,6 +4348,7 @@ class _RouteSearchResultCard extends StatefulWidget {
     required this.onShellBackToHome,
     required this.getOffAlarmController,
     required this.stationRepository,
+    required this.routeShareInvoker,
   });
 
   final RouteSearchResult result;
@@ -4277,6 +4360,7 @@ class _RouteSearchResultCard extends StatefulWidget {
   final AsyncCallback? onShellBackToHome;
   final GetOffAlarmController? getOffAlarmController;
   final StationSearchRepository stationRepository;
+  final RouteShareInvoker? routeShareInvoker;
 
   @override
   State<_RouteSearchResultCard> createState() => _RouteSearchResultCardState();
@@ -4366,6 +4450,7 @@ class _RouteSearchResultCardState extends State<_RouteSearchResultCard> {
               )
             : null,
         adRepository: widget.adRepository,
+        routeShareInvoker: widget.routeShareInvoker,
       ),
     );
   }
@@ -4636,6 +4721,7 @@ class _RouteDetailWorkflowView extends StatelessWidget {
     required this.onOpenFeedback,
     required this.favoriteSaveButton,
     required this.adRepository,
+    required this.routeShareInvoker,
   });
 
   final RouteSearchResult result;
@@ -4644,6 +4730,7 @@ class _RouteDetailWorkflowView extends StatelessWidget {
   final VoidCallback? onOpenFeedback;
   final Widget? favoriteSaveButton;
   final AdRepository? adRepository;
+  final RouteShareInvoker? routeShareInvoker;
 
   @override
   Widget build(BuildContext context) {
@@ -4680,6 +4767,8 @@ class _RouteDetailWorkflowView extends StatelessWidget {
           ),
         ],
         const SizedBox(height: 12),
+        _RouteShareButton(result: result, invoker: routeShareInvoker),
+        const SizedBox(height: 10),
         ?favoriteSaveButton,
         if (onStartGuidance != null) ...[
           const SizedBox(height: 10),
@@ -4710,6 +4799,195 @@ class _RouteDetailWorkflowView extends StatelessWidget {
       ],
     );
   }
+}
+
+class _RouteShareButton extends StatelessWidget {
+  const _RouteShareButton({required this.result, required this.invoker});
+
+  final RouteSearchResult result;
+  final RouteShareInvoker? invoker;
+
+  @override
+  Widget build(BuildContext context) {
+    return Builder(
+      builder: (buttonContext) {
+        void onShare() => _share(buttonContext);
+        return Semantics(
+          button: true,
+          label: '경로 요약 공유',
+          onTap: onShare,
+          excludeSemantics: true,
+          child: OutlinedButton.icon(
+            key: const Key('routeShareButton'),
+            onPressed: onShare,
+            icon: const Icon(Icons.share_outlined),
+            label: const Text('공유'),
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _share(BuildContext context) async {
+    try {
+      final renderBox = context.findRenderObject();
+      if (renderBox is! RenderBox || !renderBox.hasSize) {
+        throw StateError('Route share trigger is unavailable');
+      }
+      final origin = renderBox.localToGlobal(Offset.zero) & renderBox.size;
+      final text = buildRouteShareSummary(
+        _routeShareSnapshot(
+          result,
+          View.of(context).platformDispatcher.locale.languageCode,
+        ),
+      );
+      final invoke = invoker;
+      if (invoke != null) {
+        await invoke(text, origin);
+      } else {
+        await SharePlus.instance.share(
+          ShareParams(text: text, sharePositionOrigin: origin),
+        );
+      }
+    } on Object {
+      if (context.mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('경로 요약을 공유하지 못했어요.')));
+      }
+    }
+  }
+}
+
+RouteShareSnapshot _routeShareSnapshot(
+  RouteSearchResult result,
+  String languageCode,
+) {
+  if (result.isBlocked || result.status != 'FOUND') {
+    throw StateError('Route is unavailable');
+  }
+  final originName = result.originStationName.trim();
+  final destinationName = result.destinationStationName.trim();
+  if (originName.isEmpty ||
+      destinationName.isEmpty ||
+      originName == result.originStationId ||
+      destinationName == result.destinationStationId) {
+    throw StateError('Canonical station names are unavailable');
+  }
+
+  final steps = result.movementSteps;
+  if (steps.isEmpty) {
+    throw StateError('Route itinerary is unavailable');
+  }
+  final forbiddenIdentifiers = <String>{
+    result.routeSearchId,
+    result.originStationId,
+    result.destinationStationId,
+    for (final step in steps) ...[
+      step.fromStationId,
+      step.toStationId,
+      step.lineId,
+    ],
+  }.where((value) => value.trim().isNotEmpty).toSet();
+  final legs = steps
+      .map((step) {
+        final description = step.title.trim();
+        if (description.isEmpty ||
+            forbiddenIdentifiers.any(description.contains)) {
+          throw StateError('Route leg display labels are unavailable');
+        }
+        return RouteShareLeg(
+          description: description,
+          departureTime: _routeShareTime(
+            step.realtimeDepartureTimeIso.isNotEmpty
+                ? step.realtimeDepartureTimeIso
+                : step.plannedDepartureTimeIso,
+            allowEmpty: true,
+          ),
+          arrivalTime: _routeShareTime(
+            step.realtimeArrivalTimeIso.isNotEmpty
+                ? step.realtimeArrivalTimeIso
+                : step.plannedArrivalTimeIso,
+            allowEmpty: true,
+          ),
+        );
+      })
+      .toList(growable: false);
+
+  var departureSource = result.departureTimeIso.isNotEmpty
+      ? result.departureTimeIso
+      : steps.first.realtimeDepartureTimeIso.isNotEmpty
+      ? steps.first.realtimeDepartureTimeIso
+      : steps.first.plannedDepartureTimeIso;
+  var arrivalSource = result.arrivalTimeIso.isNotEmpty
+      ? result.arrivalTimeIso
+      : steps.last.realtimeArrivalTimeIso.isNotEmpty
+      ? steps.last.realtimeArrivalTimeIso
+      : steps.last.plannedArrivalTimeIso;
+  final durationMinutes = (result.estimatedDurationSeconds / 60).ceil();
+  if (result.isLocalResult &&
+      departureSource.isEmpty &&
+      arrivalSource.isEmpty) {
+    final departure = DateTime.tryParse(result.createdAt);
+    if (departure == null) {
+      throw StateError('Local route time is unavailable');
+    }
+    departureSource = departure.toIso8601String();
+    arrivalSource = departure
+        .add(Duration(seconds: result.estimatedDurationSeconds))
+        .toIso8601String();
+  }
+
+  RouteShareFare? fare;
+  if (result.officialFare case final officialFare?) {
+    fare = RouteShareFare(
+      adultFareWon: officialFare.adultFareWon,
+      currency: officialFare.currency,
+    );
+  } else if (result.transportScope ==
+      RouteTransportScope.subwayAndItxCheongchun) {
+    throw StateError('Official ITX fare is unavailable');
+  } else if (result.officialOdFareQuote case final quote?) {
+    fare = RouteShareFare(adultFareWon: quote.gnrlCardFare, currency: 'KRW');
+  }
+
+  return RouteShareSnapshot(
+    languageCode: languageCode == 'en' ? 'en' : 'ko',
+    originName: originName,
+    destinationName: destinationName,
+    objective: switch (result.objective) {
+      RouteObjective.fastest => RouteShareObjective.fastest,
+      RouteObjective.fewestTransfers => RouteShareObjective.fewestTransfers,
+    },
+    transportScope: switch (result.transportScope) {
+      RouteTransportScope.subway => RouteShareTransportScope.subway,
+      RouteTransportScope.subwayAndItxCheongchun =>
+        RouteShareTransportScope.subwayAndItxCheongchun,
+    },
+    departureTime: _routeShareTime(departureSource),
+    arrivalTime: _routeShareTime(arrivalSource),
+    durationMinutes: durationMinutes,
+    transferCount: result.transferCount,
+    freshness: switch (result.etaSource) {
+      'REALTIME' => RouteShareFreshness.realtime,
+      'STATIC_LOCAL' || 'STATIC_ESTIMATE' => RouteShareFreshness.staticData,
+      _ => RouteShareFreshness.planned,
+    },
+    legs: legs,
+    fare: fare,
+  );
+}
+
+String _routeShareTime(String value, {bool allowEmpty = false}) {
+  final trimmed = value.trim();
+  if (allowEmpty && trimmed.isEmpty) {
+    return '';
+  }
+  final match = RegExp(r'(?:T|^)(\d{2}):(\d{2})').firstMatch(trimmed);
+  if (match == null) {
+    throw StateError('Route time is unavailable');
+  }
+  return '${match.group(1)}:${match.group(2)}';
 }
 
 class _OfficialOdFareSection extends StatelessWidget {

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -5016,6 +5016,14 @@ String _routeShareTime(String value, {bool allowEmpty = false}) {
   if (allowEmpty && trimmed.isEmpty) {
     return '';
   }
+  if (RegExp(r'(?:[zZ]|[+-]\d{2}:\d{2})$').hasMatch(trimmed)) {
+    final instant = DateTime.tryParse(trimmed);
+    if (instant == null) {
+      throw StateError('Route time is unavailable');
+    }
+    final koreanTime = instant.toUtc().add(const Duration(hours: 9));
+    return '${koreanTime.hour.toString().padLeft(2, '0')}:${koreanTime.minute.toString().padLeft(2, '0')}';
+  }
   final match = RegExp(r'(?:T|^)(\d{2}):(\d{2})').firstMatch(trimmed);
   if (match == null) {
     throw StateError('Route time is unavailable');

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -4842,12 +4842,7 @@ class _RouteShareButton extends StatelessWidget {
         throw StateError('Route share trigger is unavailable');
       }
       final origin = renderBox.localToGlobal(Offset.zero) & renderBox.size;
-      final text = buildRouteShareSummary(
-        _routeShareSnapshot(
-          result,
-          View.of(context).platformDispatcher.locale.languageCode,
-        ),
-      );
+      final text = buildRouteShareSummary(_routeShareSnapshot(result));
       final invoke = invoker;
       if (invoke != null) {
         await invoke(text, origin);
@@ -4866,10 +4861,7 @@ class _RouteShareButton extends StatelessWidget {
   }
 }
 
-RouteShareSnapshot _routeShareSnapshot(
-  RouteSearchResult result,
-  String languageCode,
-) {
+RouteShareSnapshot _routeShareSnapshot(RouteSearchResult result) {
   if (result.isBlocked || result.status != 'FOUND') {
     throw StateError('Route is unavailable');
   }
@@ -4969,7 +4961,8 @@ RouteShareSnapshot _routeShareSnapshot(
   }
 
   return RouteShareSnapshot(
-    languageCode: languageCode == 'en' ? 'en' : 'ko',
+    // 실제 역명과 leg 표시명은 아직 한국어 canonical만 제공한다.
+    languageCode: 'ko',
     originName: originName,
     destinationName: destinationName,
     objective: switch (result.objective) {
@@ -4987,6 +4980,7 @@ RouteShareSnapshot _routeShareSnapshot(
     transferCount: result.transferCount,
     freshness: switch (result.etaSource) {
       'REALTIME' => RouteShareFreshness.realtime,
+      'MIXED' => RouteShareFreshness.mixed,
       'STATIC_LOCAL' ||
       'STATIC_ESTIMATE' ||
       'STALE' => RouteShareFreshness.staticData,

--- a/apps/mobile/lib/route_share_summary.dart
+++ b/apps/mobile/lib/route_share_summary.dart
@@ -2,7 +2,7 @@ enum RouteShareObjective { fastest, fewestTransfers }
 
 enum RouteShareTransportScope { subway, subwayAndItxCheongchun }
 
-enum RouteShareFreshness { realtime, planned, staticData }
+enum RouteShareFreshness { realtime, mixed, planned, staticData }
 
 class RouteShareFare {
   const RouteShareFare({required this.adultFareWon, required this.currency});
@@ -182,19 +182,25 @@ String _scope(RouteShareTransportScope scope, bool ko) => switch (scope) {
     ko ? '지하철 + ITX-청춘' : 'Subway + ITX-Cheongchun',
 };
 
-String _freshness(RouteShareFreshness freshness, bool ko) =>
-    switch (freshness) {
-      RouteShareFreshness.realtime =>
-        ko ? '실시간 정보 기준입니다.' : 'Based on realtime information.',
-      RouteShareFreshness.planned =>
-        ko
-            ? '계획 시간 기준이며 실제 운행과 다를 수 있습니다.'
-            : 'Planned schedule; actual service may differ.',
-      RouteShareFreshness.staticData =>
-        ko
-            ? '저장된 데이터 기준이며 실제 운행과 다를 수 있습니다.'
-            : 'Saved data; actual service may differ.',
-    };
+String _freshness(
+  RouteShareFreshness freshness,
+  bool ko,
+) => switch (freshness) {
+  RouteShareFreshness.realtime =>
+    ko ? '실시간 정보 기준입니다.' : 'Based on realtime information.',
+  RouteShareFreshness.mixed =>
+    ko
+        ? '일부 실시간 정보가 반영됐으며 실제 운행과 다를 수 있습니다.'
+        : 'Some realtime information is included; actual service may differ.',
+  RouteShareFreshness.planned =>
+    ko
+        ? '계획 시간 기준이며 실제 운행과 다를 수 있습니다.'
+        : 'Planned schedule; actual service may differ.',
+  RouteShareFreshness.staticData =>
+    ko
+        ? '저장된 데이터 기준이며 실제 운행과 다를 수 있습니다.'
+        : 'Saved data; actual service may differ.',
+};
 
 String _number(int value) {
   final digits = value.toString();

--- a/apps/mobile/lib/route_share_summary.dart
+++ b/apps/mobile/lib/route_share_summary.dart
@@ -66,13 +66,16 @@ String buildRouteShareSummary(
     return full;
   }
 
-  final selected = <int>[];
-  final priority = <int>[
+  final selected = <int>[
     0,
     if (snapshot.legs.length > 1) snapshot.legs.length - 1,
-    for (var i = 1; i < snapshot.legs.length - 1; i++) i,
   ];
-  for (final index in priority) {
+  if (_compose(snapshot, selected).length > maxLength) {
+    throw StateError(
+      'Route share length budget is too small for essential facts',
+    );
+  }
+  for (var index = 1; index < snapshot.legs.length - 1; index++) {
     final candidate = [...selected, index]..sort();
     if (_compose(snapshot, candidate).length <= maxLength) {
       selected
@@ -111,6 +114,11 @@ void _validate(RouteShareSnapshot snapshot, int maxLength) {
     throw StateError('Route share leg is incomplete');
   }
   final fare = snapshot.fare;
+  if (snapshot.transportScope ==
+          RouteShareTransportScope.subwayAndItxCheongchun &&
+      fare == null) {
+    throw StateError('Official ITX fare is unavailable');
+  }
   if (fare != null && (fare.adultFareWon <= 0 || fare.currency != 'KRW')) {
     throw StateError('Route share fare is invalid');
   }

--- a/apps/mobile/lib/route_share_summary.dart
+++ b/apps/mobile/lib/route_share_summary.dart
@@ -1,0 +1,201 @@
+enum RouteShareObjective { fastest, fewestTransfers }
+
+enum RouteShareTransportScope { subway, subwayAndItxCheongchun }
+
+enum RouteShareFreshness { realtime, planned, staticData }
+
+class RouteShareFare {
+  const RouteShareFare({required this.adultFareWon, required this.currency});
+
+  final int adultFareWon;
+  final String currency;
+}
+
+class RouteShareLeg {
+  const RouteShareLeg({
+    required this.description,
+    required this.departureTime,
+    required this.arrivalTime,
+  });
+
+  final String description;
+  final String departureTime;
+  final String arrivalTime;
+}
+
+class RouteShareSnapshot {
+  const RouteShareSnapshot({
+    required this.languageCode,
+    required this.originName,
+    required this.destinationName,
+    required this.objective,
+    required this.transportScope,
+    required this.departureTime,
+    required this.arrivalTime,
+    required this.durationMinutes,
+    required this.transferCount,
+    required this.freshness,
+    required this.legs,
+    this.fare,
+  });
+
+  final String languageCode;
+  final String originName;
+  final String destinationName;
+  final RouteShareObjective objective;
+  final RouteShareTransportScope transportScope;
+  final String departureTime;
+  final String arrivalTime;
+  final int durationMinutes;
+  final int transferCount;
+  final RouteShareFreshness freshness;
+  final List<RouteShareLeg> legs;
+  final RouteShareFare? fare;
+}
+
+String buildRouteShareSummary(
+  RouteShareSnapshot snapshot, {
+  int maxLength = 1200,
+}) {
+  _validate(snapshot, maxLength);
+  final full = _compose(
+    snapshot,
+    List<int>.generate(snapshot.legs.length, (i) => i),
+  );
+  if (full.length <= maxLength) {
+    return full;
+  }
+
+  final selected = <int>[];
+  final priority = <int>[
+    0,
+    if (snapshot.legs.length > 1) snapshot.legs.length - 1,
+    for (var i = 1; i < snapshot.legs.length - 1; i++) i,
+  ];
+  for (final index in priority) {
+    final candidate = [...selected, index]..sort();
+    if (_compose(snapshot, candidate).length <= maxLength) {
+      selected
+        ..clear()
+        ..addAll(candidate);
+    }
+  }
+  final shortened = _compose(snapshot, selected);
+  if (shortened.length > maxLength) {
+    throw StateError(
+      'Route share length budget is too small for essential facts',
+    );
+  }
+  return shortened;
+}
+
+void _validate(RouteShareSnapshot snapshot, int maxLength) {
+  if (snapshot.languageCode != 'ko' && snapshot.languageCode != 'en') {
+    throw StateError('Unsupported route share language');
+  }
+  if (snapshot.originName.trim().isEmpty ||
+      snapshot.destinationName.trim().isEmpty ||
+      snapshot.departureTime.trim().isEmpty ||
+      snapshot.arrivalTime.trim().isEmpty ||
+      snapshot.durationMinutes <= 0 ||
+      snapshot.transferCount < 0 ||
+      snapshot.legs.isEmpty ||
+      maxLength <= 0) {
+    throw StateError('Route share snapshot is incomplete');
+  }
+  if (snapshot.legs.any(
+    (leg) =>
+        leg.description.trim().isEmpty ||
+        (leg.departureTime.isEmpty != leg.arrivalTime.isEmpty),
+  )) {
+    throw StateError('Route share leg is incomplete');
+  }
+  final fare = snapshot.fare;
+  if (fare != null && (fare.adultFareWon <= 0 || fare.currency != 'KRW')) {
+    throw StateError('Route share fare is invalid');
+  }
+}
+
+String _compose(RouteShareSnapshot snapshot, List<int> selectedIndexes) {
+  final ko = snapshot.languageCode == 'ko';
+  final lines = <String>[
+    '${snapshot.originName.trim()} → ${snapshot.destinationName.trim()}',
+    ko
+        ? '기준: ${_objective(snapshot.objective, ko)}'
+        : 'Objective: ${_objective(snapshot.objective, ko)}',
+    ko
+        ? '교통수단: ${_scope(snapshot.transportScope, ko)}'
+        : 'Transport: ${_scope(snapshot.transportScope, ko)}',
+    ko
+        ? '시간: ${snapshot.departureTime} → ${snapshot.arrivalTime}'
+        : 'Time: ${snapshot.departureTime} → ${snapshot.arrivalTime}',
+    ko
+        ? '총 ${snapshot.durationMinutes}분 · 환승 ${snapshot.transferCount}회'
+        : '${snapshot.durationMinutes} min · ${snapshot.transferCount} transfer${snapshot.transferCount == 1 ? '' : 's'}',
+    if (snapshot.fare case final fare?)
+      ko
+          ? '공식 운임: 성인 ${_number(fare.adultFareWon)}원'
+          : 'Official fare: Adult ${fare.currency} ${_number(fare.adultFareWon)}',
+    ko
+        ? '안내: ${_freshness(snapshot.freshness, ko)}'
+        : 'Notice: ${_freshness(snapshot.freshness, ko)}',
+  ];
+  final selected = selectedIndexes.toSet();
+  lines.add(ko ? '주요 경로:' : 'Main route:');
+  for (var i = 0; i < snapshot.legs.length; i++) {
+    if (selected.contains(i)) {
+      final leg = snapshot.legs[i];
+      final times = leg.departureTime.isEmpty
+          ? ''
+          : ' (${leg.departureTime} → ${leg.arrivalTime})';
+      lines.add('- ${leg.description.trim()}$times');
+    }
+  }
+  final omitted = snapshot.legs.length - selected.length;
+  if (omitted > 0) {
+    lines.add(
+      ko
+          ? '… 중간 경로 $omitted개 생략'
+          : '… $omitted intermediate leg${omitted == 1 ? '' : 's'} omitted',
+    );
+  }
+  return lines.join('\n');
+}
+
+String _objective(RouteShareObjective objective, bool ko) =>
+    switch (objective) {
+      RouteShareObjective.fastest => ko ? '최단시간' : 'Fastest',
+      RouteShareObjective.fewestTransfers => ko ? '최소환승' : 'Fewest transfers',
+    };
+
+String _scope(RouteShareTransportScope scope, bool ko) => switch (scope) {
+  RouteShareTransportScope.subway => ko ? '지하철' : 'Subway',
+  RouteShareTransportScope.subwayAndItxCheongchun =>
+    ko ? '지하철 + ITX-청춘' : 'Subway + ITX-Cheongchun',
+};
+
+String _freshness(RouteShareFreshness freshness, bool ko) =>
+    switch (freshness) {
+      RouteShareFreshness.realtime =>
+        ko ? '실시간 정보 기준입니다.' : 'Based on realtime information.',
+      RouteShareFreshness.planned =>
+        ko
+            ? '계획 시간 기준이며 실제 운행과 다를 수 있습니다.'
+            : 'Planned schedule; actual service may differ.',
+      RouteShareFreshness.staticData =>
+        ko
+            ? '저장된 데이터 기준이며 실제 운행과 다를 수 있습니다.'
+            : 'Saved data; actual service may differ.',
+    };
+
+String _number(int value) {
+  final digits = value.toString();
+  final out = StringBuffer();
+  for (var i = 0; i < digits.length; i++) {
+    if (i > 0 && (digits.length - i) % 3 == 0) {
+      out.write(',');
+    }
+    out.write(digits[i]);
+  }
+  return out.toString();
+}

--- a/apps/mobile/pubspec.lock
+++ b/apps/mobile/pubspec.lock
@@ -807,6 +807,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.0"
+  share_plus:
+    dependency: "direct main"
+    description:
+      name: share_plus
+      sha256: "02180b01c1237b9706b663d9402b2cf2402b3407f48cce99cc19e3200f095b8a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.2.1"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      sha256: "7f7ae28cf400d13f811e297ff37742dba83b79e0a6f5dce14eec0248274e6ce9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.1.0"
   shelf:
     dependency: transitive
     description:
@@ -996,6 +1012,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.5"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      sha256: "9b129329f58692f6e6578329498a8fe9fbe98f090beb764ffbb8ee2eadd01dcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.6.0"
   vector_math:
     dependency: transitive
     description:

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   home_widget: ^0.9.3
   workmanager_android: ^0.9.0+2
   workmanager_platform_interface: ^0.9.1+1
+  share_plus: ^13.2.1
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/apps/mobile/release/post-launch-operations-review-gate.json
+++ b/apps/mobile/release/post-launch-operations-review-gate.json
@@ -95,7 +95,7 @@
           "refreshOn": "fixed-release-procedure-change",
           "files": [
             {"path": "apps/mobile/release/signed-release-artifact-gate.json", "sha256": "42c9f83dca5a1c2c24d921cf6ab748c9be5a901dd1b62212a81055098349fc67"},
-            {"path": "apps/mobile/pubspec.yaml", "sha256": "ec5ef88e660b4841a0e96a1b88076348caa1c70d4e0ee8fe6fbe5a0704690ed3"},
+            {"path": "apps/mobile/pubspec.yaml", "sha256": "1c4918747c4acf22bbe885b7cb01cc34cc311e7e44598ac6b817848712614d42"},
             {"path": ".github/workflows/release-artifacts.yml", "sha256": "2f9b62ddbd00bac86a69d832b9e3cf35dd3c14a1731d6b201f47f04b991c20cb"},
             {"path": ".github/workflows/datapack-release.yml", "sha256": "907aa513c9b2cb0c2002e0c240d7d404c73dc8ed5691ab8d89da68e38251b7bc"},
             {"path": "tools/ci/validate-store-privacy-env.mjs", "sha256": "18bb0dd8b93d6268c8f60f9cc12272d2ff31c03b60fbbafd6c1e8d16957ada2a"},

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -5413,6 +5413,7 @@ void main() {
     expect(fastest.transferCount, 1);
     expect(fewestTransfers.status, 'FOUND');
     expect(fewestTransfers.transferCount, 0);
+    expect(fewestTransfers.objective, RouteObjective.fewestTransfers);
     expect(
       fewestTransfers.steps.expand((step) => step.evidenceSources),
       contains('edge:ride-a-c-direct-test'),

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -686,6 +686,8 @@ void main() {
 
     expect(result.status, 'FOUND');
     expect(result.originStationId, 'station-sangnoksu');
+    expect(result.createdAt, endsWith('Z'));
+    expect(DateTime.parse(result.createdAt).isUtc, isTrue);
   });
 
   test('로컬 경로는 exact official OD 요금을 함께 반환한다', () async {

--- a/apps/mobile/test/route_search_test.dart
+++ b/apps/mobile/test/route_search_test.dart
@@ -1678,6 +1678,67 @@ void main() {
   });
 
   group('#2099 objective-tagged itinerary 보존·선택', () {
+    test('선택 objective와 공식 운임, exact leg 시각을 공유 입력까지 보존한다', () {
+      final itinerary = RouteSearchV2Itinerary.fromJson({
+        'itineraryId': 'route-itx-primary',
+        'status': 'FOUND',
+        'plannedArrivalTime': '2026-06-30T11:42:00+09:00',
+        'realtimeArrivalTime': null,
+        'etaSource': 'PLANNED',
+        'etaConfidence': 'MEDIUM',
+        'durationSeconds': 9120,
+        'transferCount': 1,
+        'walkingDistanceMeters': 180,
+        'accessibilityRisk': <String, Object?>{
+          'stairCount': 0,
+          'unknownAccessibilityCount': 0,
+          'generatedConnectorCount': 0,
+          'staleDataCount': 0,
+          'lowConfidenceCount': 0,
+          'unavailableFacilityCount': 0,
+          'riskLevel': 'LOW',
+          'reasonCodes': <String>[],
+          'level': 'LOW',
+          'reasons': <String>[],
+        },
+        'legs': [
+          _rideLegJson(
+            serviceClass: 'ITX_CHEONGCHUN',
+            servicePattern: 'EXPRESS',
+          ),
+        ],
+        'commercialEtaEligible': true,
+        'objectiveTags': ['FEWEST_TRANSFERS'],
+        'officialFare': <String, Object?>{
+          'adultFareWon': 9800,
+          'currency': 'KRW',
+          'policy': 'SUM_OF_OFFICIAL_RIDE_OD_FARES',
+          'sourceIds': ['tago-train-schedule-fares'],
+          'sourceSnapshotIds': ['itx-20260630'],
+        },
+      });
+      final result = _objectiveResult([itinerary]);
+
+      final display = RouteSearchResult.fromV2(
+        result,
+        objective: RouteObjective.fewestTransfers,
+      );
+
+      expect(display.objective, RouteObjective.fewestTransfers);
+      expect(display.departureTimeIso, '2026-06-30T09:15:00+09:00');
+      expect(display.arrivalTimeIso, '2026-06-30T11:42:00+09:00');
+      expect(display.officialFare?.adultFareWon, 9800);
+      expect(display.officialFare?.currency, 'KRW');
+      expect(
+        display.steps.single.plannedDepartureTimeIso,
+        '2026-06-30T09:17:00+09:00',
+      );
+      expect(
+        display.steps.single.plannedArrivalTimeIso,
+        '2026-06-30T09:42:00+09:00',
+      );
+    });
+
     test('dual-tag dedupe된 대표 itinerary는 두 objective에서 모두 선택된다', () {
       final result = _objectiveResult([
         _taggedItinerary(

--- a/apps/mobile/test/route_search_test.dart
+++ b/apps/mobile/test/route_search_test.dart
@@ -254,6 +254,7 @@ void main() {
         originStationId: 'station-sangnoksu',
         destinationStationId: 'station-sadang',
         mobilityType: 'WHEELCHAIR',
+        objective: RouteObjective.fewestTransfers,
       ),
     );
 
@@ -265,6 +266,7 @@ void main() {
       'constraintMode': 'STRICT_STEP_FREE',
     });
     expect(result.routeSearchId, 'route-1');
+    expect(result.objective, RouteObjective.fewestTransfers);
     expect(result.constraintMode, 'STRICT_STEP_FREE');
     expect(result.summaryTitle, '상록수에서 사당까지');
     expect(result.lineName, '수도권 4호선');
@@ -373,6 +375,9 @@ void main() {
 
   test('경로 검색 컨트롤러는 현재 결과 ETA refresh 상태를 유지해서 표시한다', () async {
     final repository = FakeRouteSearchRepository();
+    repository.searchResult = _sampleRouteSearchResult(
+      objective: RouteObjective.fewestTransfers,
+    );
     final controller = RouteSearchController(repository: repository);
 
     await controller.search(
@@ -405,6 +410,7 @@ void main() {
     expect(repository.refreshRouteSearchIds, ['route-1']);
     expect(controller.state.status, RouteSearchViewStatus.success);
     expect(controller.state.isRefreshing, isFalse);
+    expect(controller.state.result!.objective, RouteObjective.fewestTransfers);
     expect(
       controller.state.refreshMessage,
       '실시간 정보가 늦어 계획 시간으로 안내해요. · 최근 확인 시간이 오래되어 계획 시간으로 안내 · 신뢰도 낮음',
@@ -2100,6 +2106,7 @@ RouteSearchResult _sampleRouteSearchResult({
   String accessibilityRiskLevel = '',
   int? transferSlackSeconds,
   bool hasOutOfStationTransfer = false,
+  RouteObjective objective = RouteObjective.fastest,
 }) {
   return RouteSearchResult(
     routeSearchId: routeSearchId,
@@ -2123,6 +2130,7 @@ RouteSearchResult _sampleRouteSearchResult({
     accessibilityRiskLevel: accessibilityRiskLevel,
     transferSlackSeconds: transferSlackSeconds,
     hasOutOfStationTransfer: hasOutOfStationTransfer,
+    objective: objective,
   );
 }
 

--- a/apps/mobile/test/route_search_test.dart
+++ b/apps/mobile/test/route_search_test.dart
@@ -266,7 +266,7 @@ void main() {
       'constraintMode': 'STRICT_STEP_FREE',
     });
     expect(result.routeSearchId, 'route-1');
-    expect(result.objective, RouteObjective.fewestTransfers);
+    expect(result.objective, RouteObjective.fastest);
     expect(result.constraintMode, 'STRICT_STEP_FREE');
     expect(result.summaryTitle, '상록수에서 사당까지');
     expect(result.lineName, '수도권 4호선');

--- a/apps/mobile/test/route_share_summary_test.dart
+++ b/apps/mobile/test/route_share_summary_test.dart
@@ -74,6 +74,54 @@ void main() {
     expect(text, contains('Planned schedule'));
   });
 
+  test('MIXED ETA는 한국어와 영어에서 일부 실시간 정보 반영으로 안내한다', () {
+    const base = RouteShareSnapshot(
+      languageCode: 'ko',
+      originName: '상록수',
+      destinationName: '사당',
+      objective: RouteShareObjective.fastest,
+      transportScope: RouteShareTransportScope.subway,
+      departureTime: '08:05',
+      arrivalTime: '08:12',
+      durationMinutes: 7,
+      transferCount: 0,
+      freshness: RouteShareFreshness.mixed,
+      legs: [
+        RouteShareLeg(
+          description: '상록수에서 사당까지 이동',
+          departureTime: '08:05',
+          arrivalTime: '08:12',
+        ),
+      ],
+    );
+
+    expect(buildRouteShareSummary(base), contains('일부 실시간 정보가 반영'));
+    expect(
+      buildRouteShareSummary(
+        const RouteShareSnapshot(
+          languageCode: 'en',
+          originName: 'Sangnoksu',
+          destinationName: 'Sadang',
+          objective: RouteShareObjective.fastest,
+          transportScope: RouteShareTransportScope.subway,
+          departureTime: '08:05',
+          arrivalTime: '08:12',
+          durationMinutes: 7,
+          transferCount: 0,
+          freshness: RouteShareFreshness.mixed,
+          legs: [
+            RouteShareLeg(
+              description: 'Ride from Sangnoksu to Sadang',
+              departureTime: '08:05',
+              arrivalTime: '08:12',
+            ),
+          ],
+        ),
+      ),
+      contains('Some realtime information is included'),
+    );
+  });
+
   test('같은 snapshot과 budget은 byte-for-byte 같은 text를 만든다', () {
     const snapshot = RouteShareSnapshot(
       languageCode: 'ko',

--- a/apps/mobile/test/route_share_summary_test.dart
+++ b/apps/mobile/test/route_share_summary_test.dart
@@ -111,7 +111,11 @@ void main() {
       legs: List.generate(
         12,
         (index) => RouteShareLeg(
-          description: '중간 이동 ${index + 1} ${'아주 긴 설명 ' * 4}',
+          description: switch (index) {
+            0 => '출발 구간',
+            11 => '도착 구간',
+            _ => '중간 이동 ${index + 1} ${'아주 긴 설명 ' * 4}',
+          },
           departureTime: '10:00',
           arrivalTime: '10:10',
         ),
@@ -127,7 +131,85 @@ void main() {
     expect(text, contains('09:10 → 11:42'));
     expect(text, contains('총 152분 · 환승 5회'));
     expect(text, contains('계획 시간 기준'));
+    expect(text, contains('- 출발 구간'));
+    expect(text, contains('- 도착 구간'));
     expect(text, contains('중간 경로'));
+  });
+
+  test('필수 마지막 leg가 budget에 안 들어가면 짧은 중간 leg로 대체하지 않는다', () {
+    const first = RouteShareLeg(
+      description: '출발 구간',
+      departureTime: '09:10',
+      arrivalTime: '09:20',
+    );
+    const middle = RouteShareLeg(
+      description: '짧은 중간 구간',
+      departureTime: '09:20',
+      arrivalTime: '09:30',
+    );
+    const last = RouteShareLeg(
+      description:
+          '목적지 마지막 구간은 길더라도 반드시 보존해야 하는 핵심 이동 정보입니다. '
+          '목적지 도착 노선과 하차 지점을 함께 설명합니다.',
+      departureTime: '09:30',
+      arrivalTime: '11:42',
+    );
+    const essentialOnly = RouteShareSnapshot(
+      languageCode: 'ko',
+      originName: '상록수',
+      destinationName: '춘천',
+      objective: RouteShareObjective.fastest,
+      transportScope: RouteShareTransportScope.subwayAndItxCheongchun,
+      departureTime: '09:10',
+      arrivalTime: '11:42',
+      durationMinutes: 152,
+      transferCount: 1,
+      freshness: RouteShareFreshness.planned,
+      legs: [first, last],
+      fare: fare,
+    );
+    const withMiddle = RouteShareSnapshot(
+      languageCode: 'ko',
+      originName: '상록수',
+      destinationName: '춘천',
+      objective: RouteShareObjective.fastest,
+      transportScope: RouteShareTransportScope.subwayAndItxCheongchun,
+      departureTime: '09:10',
+      arrivalTime: '11:42',
+      durationMinutes: 152,
+      transferCount: 1,
+      freshness: RouteShareFreshness.planned,
+      legs: [first, middle, last],
+      fare: fare,
+    );
+    final insufficientForLast =
+        buildRouteShareSummary(essentialOnly).length - 1;
+
+    expect(
+      () => buildRouteShareSummary(withMiddle, maxLength: insufficientForLast),
+      throwsStateError,
+    );
+  });
+
+  test('ITX 범위는 builder 경계에서도 공식 KRW 운임이 필수다', () {
+    expect(
+      () => buildRouteShareSummary(
+        const RouteShareSnapshot(
+          languageCode: 'ko',
+          originName: '상록수',
+          destinationName: '춘천',
+          objective: RouteShareObjective.fastest,
+          transportScope: RouteShareTransportScope.subwayAndItxCheongchun,
+          departureTime: '09:10',
+          arrivalTime: '11:42',
+          durationMinutes: 152,
+          transferCount: 1,
+          freshness: RouteShareFreshness.planned,
+          legs: legs,
+        ),
+      ),
+      throwsStateError,
+    );
   });
 
   test('정상 itinerary가 없으면 빈 공유 text를 만들지 않는다', () {

--- a/apps/mobile/test/route_share_summary_test.dart
+++ b/apps/mobile/test/route_share_summary_test.dart
@@ -1,0 +1,153 @@
+import 'package:easysubway_mobile/route_share_summary.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const fare = RouteShareFare(adultFareWon: 9800, currency: 'KRW');
+  const legs = [
+    RouteShareLeg(
+      description: '상록수역에서 4호선 급행 승차',
+      departureTime: '09:10',
+      arrivalTime: '10:20',
+    ),
+    RouteShareLeg(
+      description: '용산역에서 ITX-청춘 승차',
+      departureTime: '10:30',
+      arrivalTime: '11:42',
+    ),
+  ];
+
+  test('한국어 경로 공유 요약은 선택과 시각, ITX 운임, 계획 시간 안내를 보존한다', () {
+    final text = buildRouteShareSummary(
+      const RouteShareSnapshot(
+        languageCode: 'ko',
+        originName: '상록수',
+        destinationName: '춘천',
+        objective: RouteShareObjective.fastest,
+        transportScope: RouteShareTransportScope.subwayAndItxCheongchun,
+        departureTime: '09:10',
+        arrivalTime: '11:42',
+        durationMinutes: 152,
+        transferCount: 1,
+        freshness: RouteShareFreshness.planned,
+        legs: legs,
+        fare: fare,
+      ),
+    );
+
+    expect(text, contains('상록수 → 춘천'));
+    expect(text, contains('기준: 최단시간'));
+    expect(text, contains('교통수단: 지하철 + ITX-청춘'));
+    expect(text, contains('09:10 → 11:42'));
+    expect(text, contains('총 152분 · 환승 1회'));
+    expect(text, contains('ITX-청춘'));
+    expect(text, contains('공식 운임: 성인 9,800원'));
+    expect(text, contains('계획 시간 기준'));
+  });
+
+  test('영어 경로 공유 요약은 동일 facts를 영어 copy로 만든다', () {
+    final text = buildRouteShareSummary(
+      const RouteShareSnapshot(
+        languageCode: 'en',
+        originName: 'Sangnoksu',
+        destinationName: 'Chuncheon',
+        objective: RouteShareObjective.fewestTransfers,
+        transportScope: RouteShareTransportScope.subwayAndItxCheongchun,
+        departureTime: '09:10',
+        arrivalTime: '11:42',
+        durationMinutes: 152,
+        transferCount: 1,
+        freshness: RouteShareFreshness.planned,
+        legs: [
+          RouteShareLeg(
+            description: 'Take ITX-Cheongchun at Yongsan',
+            departureTime: '10:30',
+            arrivalTime: '11:42',
+          ),
+        ],
+        fare: fare,
+      ),
+    );
+
+    expect(text, contains('Sangnoksu → Chuncheon'));
+    expect(text, contains('Objective: Fewest transfers'));
+    expect(text, contains('Official fare: Adult KRW 9,800'));
+    expect(text, contains('Planned schedule'));
+  });
+
+  test('같은 snapshot과 budget은 byte-for-byte 같은 text를 만든다', () {
+    const snapshot = RouteShareSnapshot(
+      languageCode: 'ko',
+      originName: '상록수',
+      destinationName: '춘천',
+      objective: RouteShareObjective.fastest,
+      transportScope: RouteShareTransportScope.subwayAndItxCheongchun,
+      departureTime: '09:10',
+      arrivalTime: '11:42',
+      durationMinutes: 152,
+      transferCount: 1,
+      freshness: RouteShareFreshness.planned,
+      legs: legs,
+      fare: fare,
+    );
+
+    expect(
+      buildRouteShareSummary(snapshot, maxLength: 400),
+      buildRouteShareSummary(snapshot, maxLength: 400),
+    );
+  });
+
+  test('긴 경로는 optional 중간 leg부터 줄이고 필수 facts와 disclaimer를 보존한다', () {
+    final snapshot = RouteShareSnapshot(
+      languageCode: 'ko',
+      originName: '상록수',
+      destinationName: '춘천',
+      objective: RouteShareObjective.fastest,
+      transportScope: RouteShareTransportScope.subwayAndItxCheongchun,
+      departureTime: '09:10',
+      arrivalTime: '11:42',
+      durationMinutes: 152,
+      transferCount: 5,
+      freshness: RouteShareFreshness.planned,
+      legs: List.generate(
+        12,
+        (index) => RouteShareLeg(
+          description: '중간 이동 ${index + 1} ${'아주 긴 설명 ' * 4}',
+          departureTime: '10:00',
+          arrivalTime: '10:10',
+        ),
+      ),
+      fare: fare,
+    );
+
+    final text = buildRouteShareSummary(snapshot, maxLength: 260);
+
+    expect(text.length, lessThanOrEqualTo(260));
+    expect(text, contains('상록수 → 춘천'));
+    expect(text, contains('기준: 최단시간'));
+    expect(text, contains('09:10 → 11:42'));
+    expect(text, contains('총 152분 · 환승 5회'));
+    expect(text, contains('계획 시간 기준'));
+    expect(text, contains('중간 경로'));
+  });
+
+  test('정상 itinerary가 없으면 빈 공유 text를 만들지 않는다', () {
+    expect(
+      () => buildRouteShareSummary(
+        const RouteShareSnapshot(
+          languageCode: 'ko',
+          originName: '상록수',
+          destinationName: '춘천',
+          objective: RouteShareObjective.fastest,
+          transportScope: RouteShareTransportScope.subway,
+          departureTime: '09:10',
+          arrivalTime: '10:20',
+          durationMinutes: 70,
+          transferCount: 0,
+          freshness: RouteShareFreshness.staticData,
+          legs: [],
+        ),
+      ),
+      throwsStateError,
+    );
+  });
+}

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -11913,6 +11913,121 @@ void main() {
     }
   });
 
+  testWidgets('경로 상세의 공유 버튼은 표시명 요약과 실제 trigger 영역만 OS 공유에 넘긴다', (
+    tester,
+  ) async {
+    tester.binding.platformDispatcher.localeTestValue = const Locale('ko');
+    addTearDown(tester.binding.platformDispatcher.clearLocaleTestValue);
+    String? sharedText;
+    Rect? sharedOrigin;
+    var failShare = false;
+    final result = _sampleRouteSearchResult(
+      routeSearchId: 'local-private-route-id',
+      etaSource: 'STATIC_LOCAL',
+      objective: RouteObjective.fewestTransfers,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RouteSearchScreen(
+          repository: FakeRouteSearchRepository(result: result),
+          stationRepository: FakeStationSearchRepository(),
+          routeShareInvoker: (text, origin) async {
+            sharedText = text;
+            sharedOrigin = origin;
+            if (failShare) {
+              throw StateError('private share failure');
+            }
+          },
+          initialDraft: RouteDraft(
+            origin: const RouteDraftStation(
+              id: 'station-sangnoksu',
+              nameKo: '상록수',
+            ),
+            destination: const RouteDraftStation(
+              id: 'station-sadang',
+              nameKo: '사당',
+            ),
+            lastModifiedAt: DateTime(2026, 7, 18),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await _tapFirstRouteResultListItem(tester);
+    await tester.pumpAndSettle();
+
+    final shareButton = find.byKey(const Key('routeShareButton'));
+    expect(shareButton, findsOneWidget);
+    final shareSemantics = find.bySemanticsLabel('경로 요약 공유');
+    expect(shareSemantics, findsOneWidget);
+    expect(
+      tester
+          .getSemantics(shareSemantics)
+          .getSemanticsData()
+          .hasAction(SemanticsAction.tap),
+      isTrue,
+    );
+    await tester.ensureVisible(shareButton);
+    await tester.tap(shareButton);
+    await tester.pumpAndSettle();
+
+    expect(sharedText, contains('상록수 → 사당'));
+    expect(sharedText, contains('기준: 최소환승'));
+    expect(sharedText, contains('시간: 04:20 → 04:27'));
+    expect(sharedText, contains('저장된 데이터 기준'));
+    expect(sharedText, isNot(contains('local-private-route-id')));
+    expect(sharedText, isNot(contains('station-sangnoksu')));
+    expect(sharedOrigin, tester.getRect(shareButton));
+
+    failShare = true;
+    await tester.tap(shareButton);
+    await tester.pumpAndSettle();
+    expect(find.text('경로 요약을 공유하지 못했어요.'), findsOneWidget);
+    expect(find.textContaining('private share failure'), findsNothing);
+  });
+
+  testWidgets('ITX 공식 운임이 없으면 공유 API를 호출하지 않는다', (tester) async {
+    var shareCalls = 0;
+    final result = _sampleRouteSearchResult(
+      etaSource: 'PLANNED',
+      departureTimeIso: '2026-07-18T09:00:00+09:00',
+      arrivalTimeIso: '2026-07-18T09:07:00+09:00',
+      transportScope: RouteTransportScope.subwayAndItxCheongchun,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RouteSearchScreen(
+          repository: FakeRouteSearchRepository(result: result),
+          stationRepository: FakeStationSearchRepository(),
+          routeShareInvoker: (text, origin) async => shareCalls++,
+          initialDraft: RouteDraft(
+            origin: const RouteDraftStation(
+              id: 'station-sangnoksu',
+              nameKo: '상록수',
+            ),
+            destination: const RouteDraftStation(
+              id: 'station-sadang',
+              nameKo: '사당',
+            ),
+            lastModifiedAt: DateTime(2026, 7, 18),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await _tapFirstRouteResultListItem(tester);
+    await tester.pumpAndSettle();
+    final shareButton = find.byKey(const Key('routeShareButton'));
+    await tester.ensureVisible(shareButton);
+    await tester.tap(shareButton);
+    await tester.pumpAndSettle();
+
+    expect(shareCalls, 0);
+    expect(find.text('경로 요약을 공유하지 못했어요.'), findsOneWidget);
+  });
+
   testWidgets('광고 repository는 경로 결과와 상세에만 같은 placement로 배선된다', (tester) async {
     final apiClient = _NoInventoryAdApiClient();
     final adRepository = AdRepository(apiClient);
@@ -18178,6 +18293,10 @@ RouteSearchResult _sampleRouteSearchResult({
   String etaSource = '',
   String sourceUpdatedAt = '',
   String destinationStationName = '사당',
+  String departureTimeIso = '',
+  String arrivalTimeIso = '',
+  RouteObjective objective = RouteObjective.fastest,
+  RouteTransportScope transportScope = RouteTransportScope.subway,
   OfficialOdFareQuote? officialOdFareQuote,
   List<RouteSearchStep>? steps,
   List<String> recommendationReasons = const [
@@ -18252,6 +18371,10 @@ RouteSearchResult _sampleRouteSearchResult({
     etaSource: etaSource,
     sourceUpdatedAt: sourceUpdatedAt,
     officialOdFareQuote: officialOdFareQuote,
+    departureTimeIso: departureTimeIso,
+    arrivalTimeIso: arrivalTimeIso,
+    objective: objective,
+    transportScope: transportScope,
   );
 }
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -11987,13 +11987,13 @@ void main() {
     expect(find.textContaining('private share failure'), findsNothing);
   });
 
-  testWidgets('도착 시간표만 있는 로컬 경로도 소요시간으로 출발을 보완해 공유한다', (tester) async {
-    tester.binding.platformDispatcher.localeTestValue = const Locale('ko');
+  testWidgets('영어 기기의 MIXED 로컬 경로도 한국어 사실 안내와 보완 시각으로 공유한다', (tester) async {
+    tester.binding.platformDispatcher.localeTestValue = const Locale('en');
     addTearDown(tester.binding.platformDispatcher.clearLocaleTestValue);
     String? sharedText;
     final result = _sampleRouteSearchResult(
       routeSearchId: 'local-planned-arrival-route',
-      etaSource: 'STATIC_LOCAL',
+      etaSource: 'MIXED',
       steps: const [
         RouteSearchStep(
           sequence: 1,
@@ -12043,6 +12043,8 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(sharedText, contains('시간: 08:05 → 08:12'));
+    expect(sharedText, contains('일부 실시간 정보가 반영'));
+    expect(sharedText, isNot(contains('Objective:')));
     expect(find.text('경로 요약을 공유하지 못했어요.'), findsNothing);
   });
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -12254,6 +12254,70 @@ void main() {
     expect(find.text('경로 요약을 공유하지 못했어요.'), findsOneWidget);
   });
 
+  testWidgets('공유 처리 중에는 버튼과 semantics 재진입을 막는다', (tester) async {
+    final shareCompleter = Completer<void>();
+    var shareCalls = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RouteSearchScreen(
+          repository: FakeRouteSearchRepository(
+            result: _sampleRouteSearchResult(),
+          ),
+          stationRepository: FakeStationSearchRepository(),
+          routeShareInvoker: (text, origin) {
+            shareCalls++;
+            return shareCompleter.future;
+          },
+          initialDraft: RouteDraft(
+            origin: const RouteDraftStation(
+              id: 'station-sangnoksu',
+              nameKo: '상록수',
+            ),
+            destination: const RouteDraftStation(
+              id: 'station-sadang',
+              nameKo: '사당',
+            ),
+            lastModifiedAt: DateTime(2026, 7, 18),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await _tapFirstRouteResultListItem(tester);
+    await tester.pumpAndSettle();
+
+    final shareButton = find.byKey(const Key('routeShareButton'));
+    final shareSemantics = find.bySemanticsLabel('경로 요약 공유');
+    await tester.ensureVisible(shareButton);
+    await tester.tap(shareButton);
+    await tester.pump();
+    await tester.tap(shareButton, warnIfMissed: false);
+    await tester.pump();
+
+    expect(shareCalls, 1);
+    expect(tester.widget<OutlinedButton>(shareButton).onPressed, isNull);
+    expect(
+      tester
+          .getSemantics(shareSemantics)
+          .getSemanticsData()
+          .hasAction(SemanticsAction.tap),
+      isFalse,
+    );
+
+    shareCompleter.complete();
+    await tester.pumpAndSettle();
+
+    expect(tester.widget<OutlinedButton>(shareButton).onPressed, isNotNull);
+    expect(
+      tester
+          .getSemantics(shareSemantics)
+          .getSemanticsData()
+          .hasAction(SemanticsAction.tap),
+      isTrue,
+    );
+  });
+
   testWidgets('광고 repository는 경로 결과와 상세에만 같은 placement로 배선된다', (tester) async {
     final apiClient = _NoInventoryAdApiClient();
     final adRepository = AdRepository(apiClient);

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -11987,6 +11987,65 @@ void main() {
     expect(find.textContaining('private share failure'), findsNothing);
   });
 
+  testWidgets('도착 시간표만 있는 로컬 경로도 소요시간으로 출발을 보완해 공유한다', (tester) async {
+    tester.binding.platformDispatcher.localeTestValue = const Locale('ko');
+    addTearDown(tester.binding.platformDispatcher.clearLocaleTestValue);
+    String? sharedText;
+    final result = _sampleRouteSearchResult(
+      routeSearchId: 'local-planned-arrival-route',
+      etaSource: 'STATIC_LOCAL',
+      steps: const [
+        RouteSearchStep(
+          sequence: 1,
+          stepType: 'ride',
+          title: '상록수에서 사당까지 4호선 이동',
+          description: '4호선 열차로 이동합니다.',
+          lineId: 'seoul-4',
+          lineName: '수도권 4호선',
+          fromStationId: 'station-sangnoksu',
+          toStationId: 'station-sadang',
+          estimatedMinutes: 7,
+          distanceMeters: 0,
+          includesStairs: false,
+          requiresAccessibilityCheck: false,
+          plannedArrivalTimeIso: '2026-07-18T08:12:00+09:00',
+          timeSource: 'OFFICIAL_TIMETABLE',
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RouteSearchScreen(
+          repository: FakeRouteSearchRepository(result: result),
+          stationRepository: FakeStationSearchRepository(),
+          routeShareInvoker: (text, origin) async => sharedText = text,
+          initialDraft: RouteDraft(
+            origin: const RouteDraftStation(
+              id: 'station-sangnoksu',
+              nameKo: '상록수',
+            ),
+            destination: const RouteDraftStation(
+              id: 'station-sadang',
+              nameKo: '사당',
+            ),
+            lastModifiedAt: DateTime(2026, 7, 18),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await _tapFirstRouteResultListItem(tester);
+    await tester.pumpAndSettle();
+    final shareButton = find.byKey(const Key('routeShareButton'));
+    await tester.ensureVisible(shareButton);
+    await tester.tap(shareButton);
+    await tester.pumpAndSettle();
+
+    expect(sharedText, contains('시간: 08:05 → 08:12'));
+    expect(find.text('경로 요약을 공유하지 못했어요.'), findsNothing);
+  });
+
   testWidgets('ITX 공식 운임이 없으면 공유 API를 호출하지 않는다', (tester) async {
     var shareCalls = 0;
     final result = _sampleRouteSearchResult(

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -12112,6 +12112,46 @@ void main() {
     expect(find.text('경로 요약을 공유하지 못했어요.'), findsNothing);
   });
 
+  testWidgets('서로 다른 offset의 V2 공유 시각을 한국 시간대로 통일한다', (tester) async {
+    String? sharedText;
+    final result = _sampleRouteSearchResult(
+      departureTimeIso: '2026-07-18T09:00:00Z',
+      arrivalTimeIso: '2026-07-18T18:30:00+09:00',
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RouteSearchScreen(
+          repository: FakeRouteSearchRepository(result: result),
+          stationRepository: FakeStationSearchRepository(),
+          routeShareInvoker: (text, origin) async => sharedText = text,
+          initialDraft: RouteDraft(
+            origin: const RouteDraftStation(
+              id: 'station-sangnoksu',
+              nameKo: '상록수',
+            ),
+            destination: const RouteDraftStation(
+              id: 'station-sadang',
+              nameKo: '사당',
+            ),
+            lastModifiedAt: DateTime(2026, 7, 18),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await _tapFirstRouteResultListItem(tester);
+    await tester.pumpAndSettle();
+    final shareButton = find.byKey(const Key('routeShareButton'));
+    await tester.ensureVisible(shareButton);
+    await tester.tap(shareButton);
+    await tester.pumpAndSettle();
+
+    expect(sharedText, contains('시간: 18:00 → 18:30'));
+    expect(sharedText, isNot(contains('시간: 09:00')));
+    expect(find.text('경로 요약을 공유하지 못했어요.'), findsNothing);
+  });
+
   testWidgets('영어 기기의 MIXED 로컬 경로도 한국어 사실 안내와 보완 시각으로 공유한다', (tester) async {
     tester.binding.platformDispatcher.localeTestValue = const Locale('en');
     addTearDown(tester.binding.platformDispatcher.clearLocaleTestValue);

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -11923,7 +11923,7 @@ void main() {
     var failShare = false;
     final result = _sampleRouteSearchResult(
       routeSearchId: 'local-private-route-id',
-      etaSource: 'STATIC_LOCAL',
+      etaSource: 'STALE',
       objective: RouteObjective.fewestTransfers,
     );
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -11987,6 +11987,131 @@ void main() {
     expect(find.textContaining('private share failure'), findsNothing);
   });
 
+  testWidgets('시각 없는 진입·출구 사이 공식 ride 시각을 전체 공유 시각으로 사용한다', (tester) async {
+    String? sharedText;
+    final result = _sampleRouteSearchResult(
+      routeSearchId: 'local-timed-middle-route',
+      etaSource: 'STATIC_LOCAL',
+      steps: const [
+        RouteSearchStep(
+          sequence: 1,
+          stepType: 'entry',
+          title: '상록수역 승강장으로 이동',
+          description: '승강장으로 이동합니다.',
+          lineId: 'seoul-4',
+          lineName: '수도권 4호선',
+          fromStationId: 'station-sangnoksu',
+          toStationId: 'station-sangnoksu',
+          estimatedMinutes: 2,
+          distanceMeters: 80,
+          includesStairs: false,
+          requiresAccessibilityCheck: false,
+        ),
+        RouteSearchStep(
+          sequence: 2,
+          stepType: 'ride',
+          title: '상록수에서 사당까지 4호선 이동',
+          description: '4호선 열차로 이동합니다.',
+          lineId: 'seoul-4',
+          lineName: '수도권 4호선',
+          fromStationId: 'station-sangnoksu',
+          toStationId: 'station-sadang',
+          estimatedMinutes: 7,
+          distanceMeters: 0,
+          includesStairs: false,
+          requiresAccessibilityCheck: false,
+          plannedDepartureTimeIso: '2026-07-18T08:05:00+09:00',
+          plannedArrivalTimeIso: '2026-07-18T08:12:00+09:00',
+          timeSource: 'OFFICIAL_TIMETABLE',
+        ),
+        RouteSearchStep(
+          sequence: 3,
+          stepType: 'exit',
+          title: '사당역 출구로 이동',
+          description: '출구로 이동합니다.',
+          lineId: 'seoul-4',
+          lineName: '수도권 4호선',
+          fromStationId: 'station-sadang',
+          toStationId: 'station-sadang',
+          estimatedMinutes: 2,
+          distanceMeters: 80,
+          includesStairs: false,
+          requiresAccessibilityCheck: false,
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RouteSearchScreen(
+          repository: FakeRouteSearchRepository(result: result),
+          stationRepository: FakeStationSearchRepository(),
+          routeShareInvoker: (text, origin) async => sharedText = text,
+          initialDraft: RouteDraft(
+            origin: const RouteDraftStation(
+              id: 'station-sangnoksu',
+              nameKo: '상록수',
+            ),
+            destination: const RouteDraftStation(
+              id: 'station-sadang',
+              nameKo: '사당',
+            ),
+            lastModifiedAt: DateTime(2026, 7, 18),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await _tapFirstRouteResultListItem(tester);
+    await tester.pumpAndSettle();
+    final shareButton = find.byKey(const Key('routeShareButton'));
+    await tester.ensureVisible(shareButton);
+    await tester.tap(shareButton);
+    await tester.pumpAndSettle();
+
+    expect(sharedText, contains('시간: 08:05 → 08:12'));
+    expect(sharedText, isNot(contains('시간: 04:20')));
+    expect(find.text('경로 요약을 공유하지 못했어요.'), findsNothing);
+  });
+
+  testWidgets('시각 필드가 없는 V1 온라인 결과도 조회 시각 기반 요약을 공유한다', (tester) async {
+    String? sharedText;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RouteSearchScreen(
+          repository: FakeRouteSearchRepository(
+            result: _sampleRouteSearchResult(),
+          ),
+          stationRepository: FakeStationSearchRepository(),
+          routeShareInvoker: (text, origin) async => sharedText = text,
+          initialDraft: RouteDraft(
+            origin: const RouteDraftStation(
+              id: 'station-sangnoksu',
+              nameKo: '상록수',
+            ),
+            destination: const RouteDraftStation(
+              id: 'station-sadang',
+              nameKo: '사당',
+            ),
+            lastModifiedAt: DateTime(2026, 7, 18),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await _tapFirstRouteResultListItem(tester);
+    await tester.pumpAndSettle();
+    final shareButton = find.byKey(const Key('routeShareButton'));
+    await tester.ensureVisible(shareButton);
+    await tester.tap(shareButton);
+    await tester.pumpAndSettle();
+
+    expect(sharedText, contains('시간: 04:20 → 04:27'));
+    expect(sharedText, contains('계획 시간 기준'));
+    expect(find.text('경로 요약을 공유하지 못했어요.'), findsNothing);
+  });
+
   testWidgets('영어 기기의 MIXED 로컬 경로도 한국어 사실 안내와 보완 시각으로 공유한다', (tester) async {
     tester.binding.platformDispatcher.localeTestValue = const Locale('en');
     addTearDown(tester.binding.platformDispatcher.clearLocaleTestValue);


### PR DESCRIPTION
## 관련 이슈

Closes #1920

## 작업 배경

경로 상세에는 사용자가 현재 선택한 경로를 외부 앱으로 전달할 수 있는 명시적 공유 동작이 없었습니다. 공유 시 내부 route/station ID나 불완전한 ITX 운임을 노출하지 않으면서, 선택 기준·시각·환승·공식 운임·정보 최신성 같은 필수 사실을 결정론적으로 보존해야 했습니다.

## 작업 내용

- 경로 상세에 TalkBack 이름과 tap action이 있는 `경로 요약 공유` 버튼을 추가하고 `SharePlus.instance.share(ShareParams(...))`로 OS 공유 시트를 호출합니다.
- iPad popover를 위해 실제 버튼 `RenderBox`의 global rect를 `sharePositionOrigin`으로 전달합니다.
- 한국어/영어 순수 요약 builder를 추가해 출발·도착, 선택 objective, transport scope, 출도착 시각, 총 시간, 환승, 공식 KRW 운임, ETA freshness, 주요 leg를 결정론적으로 구성합니다.
- 길이 제한에서는 첫·마지막 leg를 필수로 보존하고 중간 leg만 생략하며, 필수 사실 자체가 budget에 들어가지 않으면 fail-closed합니다.
- v1·v2·로컬 경로와 ETA refresh에서 objective를 보존하고, `STALE`/로컬 경로는 저장된 데이터 기준으로 정직하게 표시합니다.
- offset이 있는 ISO 출발·도착 시각은 한국 시간대로 정규화하고, offset 없는 로컬 wall-clock 시각은 그대로 보존합니다.
- V1 경로는 서버가 지원하지 않는 objective를 덧씌우지 않고 기본 `fastest`로 유지하며, 공유 처리 중 버튼과 Semantics 재진입을 함께 차단합니다.
- ITX-청춘 범위는 UI adapter와 builder 양쪽에서 공식 KRW 운임이 없으면 공유를 거부합니다.
- canonical 표시명만 사용하고 raw station/route ID, 예외 message, payload는 공유 text·오류 안내·로그에 넣지 않습니다.

## 검증

- `flutter analyze`: No issues found
- `flutter test`: 1,464 passed (최신 main 재배치 후 재검증)
- focused summary/route/local/widget tests: 통과
- `flutter build apk --debug`: `app-debug.apk` 생성 성공
- `git diff --check origin/main...HEAD`: 통과
- Android/iOS platform permission·manifest 변경: 없음

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 공유 버튼 접근성 | Android 실기기 (Samsung RFKYA01VMQY) | UIAutomator | `content-desc="경로 요약 공유"`, `clickable="true"`, bounds `[45,1688][1035,1845]` | 통과 |
| OS 공유 시트 | Android 실기기 | 버튼 tap 후 chooser 확인 | `com.android.intentresolver`, 제목 `텍스트 공유`; Gmail/Drive/Outlook/Bluetooth/Quick Share 대상 확인 | 통과 |
| 공유 text 사실·식별자 차단 | Android 실기기 | 남영→동작 로컬 경로 preview | 최소 사실·저장 데이터 안내·canonical leg 포함, raw ID 없음 | 통과 |
| 취소 복귀 | Android 실기기 | chooser Back | 경로 상세로 복귀, 공유 버튼 재사용 가능 | 통과 |
| iPad popover origin | Flutter widget | 실제 trigger rect 비교 | `sharedOrigin == tester.getRect(shareButton)` | 통과 |
| 독립 코드 리뷰 | Mobile | CodeRabbit 및 plugin-disabled Codex fallback GitHub Review | 모든 finding 수정·스레드 resolve | 통과 |

실제 연락처·메신저로 전송하는 외부 효과는 수행하지 않았습니다. iPad 실기기 수동 QA 장비는 없었고, 공식 `share_plus` 계약에 따른 실제 trigger rect 전달을 widget test로 검증했습니다.

## Version impact

- [ ] no version change
- [ ] mobile patch
- [x] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 다음 minor release 대상, 이 PR에서 직접 변경하지 않음
- mobile versionCode: 이 PR에서 변경하지 않음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- `route_share_summary.dart`의 first/last 필수 보존과 ITX fare validation을 먼저 확인해 주세요.
- `RouteSearchResult` objective가 v1·로컬·refresh 후에도 유지되는지 확인해 주세요.
- 공유 실패는 generic snackbar만 표시하고 raw payload/exception을 전달하지 않습니다.

## 리스크

- `share_plus` 신규 의존성이 추가됩니다. Android debug build와 전체 테스트로 plugin integration을 확인했습니다.
- iPad 실기기 수동 확인은 수행하지 못했으며 widget에서 실제 버튼 rect 전달을 검증했습니다.
- OS 공유 대상 앱에 실제 전송하지 않아 수신 앱별 렌더링은 확인하지 않았습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
