### PR TITLE
[Mobile] #2253 경로 snapshot·graph 캐시

### DIFF
--- a/apps/mobile/integration_test/route_search_snapshot_cache_benchmark_test.dart
+++ b/apps/mobile/integration_test/route_search_snapshot_cache_benchmark_test.dart
@@ -1,0 +1,78 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:easysubway_mobile/core/database/catalog/catalog_database_opener.dart';
+import 'package:easysubway_mobile/features/routes/data/local_route_repository.dart';
+import 'package:easysubway_mobile/route_search.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+const _warmupCount = 5;
+const _repetitionCount = 40;
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('실기기 local route search snapshot cache latency', (_) async {
+    final directory = await Directory.systemTemp.createTemp(
+      'easysubway-route-search-benchmark-',
+    );
+    final database = await CatalogDatabaseOpener(
+      databaseDirectory: directory,
+      assetBundle: rootBundle,
+    ).open();
+    try {
+      final index =
+          jsonDecode(await rootBundle.loadString('assets/datapacks/index.json'))
+              as Map<String, Object?>;
+      final packs = index['packs']! as List<Object?>;
+      final capital = packs.cast<Map<String, Object?>>().singleWhere(
+        (pack) => pack['id'] == 'capital',
+      );
+      final repository = LocalRouteRepository(catalogDatabase: database);
+      const request = RouteSearchRequest(
+        originStationId: 'station-sangnoksu',
+        destinationStationId: 'station-sadang',
+        mobilityType: 'STANDARD',
+      );
+
+      debugPrint(
+        'ISSUE2253_METADATA '
+        'pack_id=capital sqlite_sha256=${capital['sqliteSha256']} '
+        'warmup=$_warmupCount repetitions=$_repetitionCount mode=profile',
+      );
+      for (var index = 0; index < _warmupCount; index += 1) {
+        final result = await repository.searchRoute(request);
+        expect(result.status, 'FOUND');
+      }
+
+      final samples = <int>[];
+      for (var index = 0; index < _repetitionCount; index += 1) {
+        final stopwatch = Stopwatch()..start();
+        final result = await repository.searchRoute(request);
+        stopwatch.stop();
+        expect(result.status, 'FOUND');
+        samples.add(stopwatch.elapsedMicroseconds);
+        debugPrint(
+          'ISSUE2253_SAMPLE index=$index elapsed_us=${stopwatch.elapsedMicroseconds}',
+        );
+      }
+      final sorted = samples.toList()..sort();
+      debugPrint(
+        'ISSUE2253_SUMMARY repetitions=$_repetitionCount '
+        'p50_us=${_percentile(sorted, 0.50)} '
+        'p95_us=${_percentile(sorted, 0.95)} max_us=${sorted.last}',
+      );
+    } finally {
+      await database.close();
+      await directory.delete(recursive: true);
+    }
+  });
+}
+
+int _percentile(List<int> sorted, double percentile) {
+  final index = (sorted.length * percentile).ceil() - 1;
+  return sorted[index.clamp(0, sorted.length - 1)];
+}

--- a/apps/mobile/lib/app/app_bootstrap.dart
+++ b/apps/mobile/lib/app/app_bootstrap.dart
@@ -162,10 +162,27 @@ class AppBootstrap {
   }
 
   Future<void> close() async {
-    await dataPackUpdate;
-    await localRouteRepository?.close();
-    await catalogDatabase.close();
-    await userDatabase.close();
+    Object? firstError;
+    StackTrace? firstStackTrace;
+
+    Future<void> closeResource(Future<void> Function() close) async {
+      try {
+        await close();
+      } catch (error, stackTrace) {
+        firstError ??= error;
+        firstStackTrace ??= stackTrace;
+      }
+    }
+
+    await closeResource(() => dataPackUpdate);
+    await closeResource(
+      () => localRouteRepository?.close() ?? Future<void>.value(),
+    );
+    await closeResource(catalogDatabase.close);
+    await closeResource(userDatabase.close);
+    if (firstError != null) {
+      Error.throwWithStackTrace(firstError!, firstStackTrace!);
+    }
   }
 }
 

--- a/apps/mobile/lib/app/app_bootstrap.dart
+++ b/apps/mobile/lib/app/app_bootstrap.dart
@@ -105,37 +105,14 @@ class AppBootstrap {
             )
           : null;
 
-      Future<void> runAndActivate(UpdateTrigger trigger) async {
-        await _runDataPackUpdateSafely(
-          supportDirectory: supportDirectory,
-          userDatabase: userDatabase,
-          runner: runner,
-          trigger: trigger,
-        );
-        final local = localRouteRepository;
-        if (local == null) return;
-        try {
-          final opener = CatalogDatabaseOpener(
-            databaseDirectory: supportDirectory,
-            assetBundle: assetBundle ?? rootBundle,
-            emergencyOverrideRepository: emergencyOverrideRepository,
-          );
-          final activatedDatabase = await opener.open();
-          await local.activateDataPack(
-            catalogDatabase: activatedDatabase,
-            artifactIdentity: opener.openedArtifactIdentity,
-            ownsDatabase: true,
-          );
-        } catch (error, stackTrace) {
-          reportMobileError(
-            error,
-            stackTrace,
-            context: '이동 정보 업데이트 적용 중 예외가 발생했습니다.',
-          );
-        }
-      }
-
-      dataPackUpdate = runAndActivate(UpdateTrigger.appStart);
+      // 설치 pointer는 갱신하되, 세션의 catalog 의존성은 다음 bootstrap까지
+      // 함께 열린 동일 DB를 유지해 기능별로 서로 다른 데이터팩을 노출하지 않는다.
+      dataPackUpdate = _runDataPackUpdateSafely(
+        supportDirectory: supportDirectory,
+        userDatabase: userDatabase,
+        runner: runner,
+        trigger: UpdateTrigger.appStart,
+      );
 
       final dependencies = AppDependencies.resolve(
         repository: repository,
@@ -162,10 +139,18 @@ class AppBootstrap {
         catalogDatabase: catalogDatabase,
         userDatabase: userDatabase,
         dataPackUpdate: dataPackUpdate,
-        resumeDataPackUpdate: () =>
-            runAndActivate(UpdateTrigger.foregroundResume),
-        acceptMeteredDataPackUpdate: () =>
-            runAndActivate(UpdateTrigger.userConsent),
+        resumeDataPackUpdate: () => _runDataPackUpdateSafely(
+          supportDirectory: supportDirectory,
+          userDatabase: userDatabase,
+          runner: runner,
+          trigger: UpdateTrigger.foregroundResume,
+        ),
+        acceptMeteredDataPackUpdate: () => _runDataPackUpdateSafely(
+          supportDirectory: supportDirectory,
+          userDatabase: userDatabase,
+          runner: runner,
+          trigger: UpdateTrigger.userConsent,
+        ),
         bundledDataPackFreshness: bundledDataPackFreshness,
         localRouteRepository: localRouteRepository,
       );

--- a/apps/mobile/lib/app/app_bootstrap.dart
+++ b/apps/mobile/lib/app/app_bootstrap.dart
@@ -25,6 +25,7 @@ import '../core/database/catalog/catalog_database.dart';
 import '../core/database/catalog/catalog_database_opener.dart';
 import '../core/database/user/user_database.dart';
 import '../core/database/user/user_database_opener.dart';
+import '../features/routes/data/local_route_repository.dart';
 import 'app_endpoints.dart';
 import 'app_dependencies.dart';
 
@@ -44,6 +45,7 @@ class AppBootstrap {
     required this.resumeDataPackUpdate,
     required this.acceptMeteredDataPackUpdate,
     required this.bundledDataPackFreshness,
+    this.localRouteRepository,
   });
 
   final AppDependencies dependencies;
@@ -53,6 +55,7 @@ class AppBootstrap {
   final Future<void> Function() resumeDataPackUpdate;
   final Future<void> Function() acceptMeteredDataPackUpdate;
   final BundledDataPackFreshness? bundledDataPackFreshness;
+  final LocalRouteRepository? localRouteRepository;
 
   static Future<AppBootstrap> initialize({
     Directory? databaseDirectory,
@@ -95,17 +98,50 @@ class AppBootstrap {
           ? await BundledDataPackFreshness.read(supportDirectory)
           : await _installedDataPackFreshness(userDatabase);
       final runner = dataPackUpdateRunner ?? _defaultDataPackUpdateRunner;
-      dataPackUpdate = _runDataPackUpdateSafely(
-        supportDirectory: supportDirectory,
-        userDatabase: userDatabase,
-        runner: runner,
-        trigger: UpdateTrigger.appStart,
-      );
+      final localRouteRepository = routeRepository == null
+          ? LocalRouteRepository(
+              catalogDatabase: catalogDatabase,
+              artifactIdentity: catalogDatabaseOpener.openedArtifactIdentity,
+            )
+          : null;
+
+      Future<void> runAndActivate(UpdateTrigger trigger) async {
+        await _runDataPackUpdateSafely(
+          supportDirectory: supportDirectory,
+          userDatabase: userDatabase,
+          runner: runner,
+          trigger: trigger,
+        );
+        final local = localRouteRepository;
+        if (local == null) return;
+        try {
+          final opener = CatalogDatabaseOpener(
+            databaseDirectory: supportDirectory,
+            assetBundle: assetBundle ?? rootBundle,
+            emergencyOverrideRepository: emergencyOverrideRepository,
+          );
+          final activatedDatabase = await opener.open();
+          await local.activateDataPack(
+            catalogDatabase: activatedDatabase,
+            artifactIdentity: opener.openedArtifactIdentity,
+            ownsDatabase: true,
+          );
+        } catch (error, stackTrace) {
+          reportMobileError(
+            error,
+            stackTrace,
+            context: '이동 정보 업데이트 적용 중 예외가 발생했습니다.',
+          );
+        }
+      }
+
+      dataPackUpdate = runAndActivate(UpdateTrigger.appStart);
 
       final dependencies = AppDependencies.resolve(
         repository: repository,
         reportRepository: reportRepository,
         routeRepository: routeRepository,
+        localRouteRepository: localRouteRepository,
         routeFeedbackRepository: routeFeedbackRepository,
         favoriteRepository: favoriteRepository,
         favoriteFacilityRepository: favoriteFacilityRepository,
@@ -126,19 +162,12 @@ class AppBootstrap {
         catalogDatabase: catalogDatabase,
         userDatabase: userDatabase,
         dataPackUpdate: dataPackUpdate,
-        resumeDataPackUpdate: () => _runDataPackUpdateSafely(
-          supportDirectory: supportDirectory,
-          userDatabase: userDatabase,
-          runner: runner,
-          trigger: UpdateTrigger.foregroundResume,
-        ),
-        acceptMeteredDataPackUpdate: () => _runDataPackUpdateSafely(
-          supportDirectory: supportDirectory,
-          userDatabase: userDatabase,
-          runner: runner,
-          trigger: UpdateTrigger.userConsent,
-        ),
+        resumeDataPackUpdate: () =>
+            runAndActivate(UpdateTrigger.foregroundResume),
+        acceptMeteredDataPackUpdate: () =>
+            runAndActivate(UpdateTrigger.userConsent),
         bundledDataPackFreshness: bundledDataPackFreshness,
+        localRouteRepository: localRouteRepository,
       );
     } catch (error, stackTrace) {
       await dataPackUpdate;
@@ -149,6 +178,7 @@ class AppBootstrap {
 
   Future<void> close() async {
     await dataPackUpdate;
+    await localRouteRepository?.close();
     await catalogDatabase.close();
     await userDatabase.close();
   }

--- a/apps/mobile/lib/app/app_dependencies.dart
+++ b/apps/mobile/lib/app/app_dependencies.dart
@@ -67,6 +67,7 @@ class AppDependencies {
     StationSearchRepository? repository,
     FacilityReportRepository? reportRepository,
     RouteSearchRepository? routeRepository,
+    LocalRouteRepository? localRouteRepository,
     RouteFeedbackRepository? routeFeedbackRepository,
     FavoriteStationRepository? favoriteRepository,
     FavoriteFacilityRepository? favoriteFacilityRepository,
@@ -148,14 +149,16 @@ class AppDependencies {
     final resolvedRealtimeRepository =
         realtimeRepository ??
         _defaultRealtimeRepository(baseUri: optionalBaseUri);
-    final localRouteRepository = catalogDatabase == null
-        ? null
-        : LocalRouteRepository(
-            catalogDatabase: catalogDatabase,
-            officialOdFareRepository: OfficialOdFareRepository(
-              catalogDatabase: catalogDatabase,
-            ),
-          );
+    final resolvedLocalRouteRepository =
+        localRouteRepository ??
+        (catalogDatabase == null
+            ? null
+            : LocalRouteRepository(
+                catalogDatabase: catalogDatabase,
+                officialOdFareRepository: OfficialOdFareRepository(
+                  catalogDatabase: catalogDatabase,
+                ),
+              ));
 
     return AppDependencies(
       repository: resolvedStationRepository,
@@ -169,20 +172,20 @@ class AppDependencies {
           routeRepository ??
           (() {
             if (!enableRouteV2OnlineFirst) {
-              return localRouteRepository == null
+              return resolvedLocalRouteRepository == null
                   ? RouteSearchApiRepository(baseUri: requireBaseUri())
                   : LocalFirstRouteSearchRepository(
-                      localRepository: localRouteRepository,
+                      localRepository: resolvedLocalRouteRepository,
                     );
             }
-            if (localRouteRepository == null) {
+            if (resolvedLocalRouteRepository == null) {
               throw StateError(
                 'Route V2 online-first requires a local catalog database.',
               );
             }
             final routeV2BaseUri = requireBaseUri();
             final local = LocalFirstRouteSearchRepository(
-              localRepository: localRouteRepository,
+              localRepository: resolvedLocalRouteRepository,
             );
             final sessionProvider = PlayIntegrityRouteV2SessionProvider(
               apiClient: ApiClient(baseUri: routeV2BaseUri),
@@ -197,7 +200,7 @@ class AppDependencies {
                   bearerTokenProvider: sessionProvider.issueToken,
                   bearerTokenInvalidator: sessionProvider.invalidateSession,
                 ),
-                localRepository: localRouteRepository,
+                localRepository: resolvedLocalRouteRepository,
                 metrics: routeSearchOnlineFirstMetrics,
               ),
             );

--- a/apps/mobile/lib/core/database/catalog/catalog_database.dart
+++ b/apps/mobile/lib/core/database/catalog/catalog_database.dart
@@ -70,6 +70,12 @@ const capitalIntegratedAdditionalStepsJson =
 class CatalogDatabase extends _$CatalogDatabase {
   CatalogDatabase(super.executor);
 
+  Set<String> _routeNetworkEdgeColumnNames = const {};
+  Set<String> _routeFacilityColumnNames = const {};
+
+  Set<String> get routeNetworkEdgeColumnNames => _routeNetworkEdgeColumnNames;
+  Set<String> get routeFacilityColumnNames => _routeFacilityColumnNames;
+
   factory CatalogDatabase.file(File file) {
     return CatalogDatabase(NativeDatabase.createInBackground(file));
   }
@@ -172,8 +178,19 @@ class CatalogDatabase extends _$CatalogDatabase {
       },
       beforeOpen: (_) async {
         await customStatement('PRAGMA foreign_keys = ON');
+        await refreshRouteSchemaCapabilities();
       },
     );
+  }
+
+  Future<void> refreshRouteSchemaCapabilities() async {
+    _routeNetworkEdgeColumnNames = await _tableColumnNames('network_edges');
+    _routeFacilityColumnNames = await _tableColumnNames('facilities');
+  }
+
+  Future<Set<String>> _tableColumnNames(String tableName) async {
+    final rows = await customSelect('PRAGMA table_info($tableName)').get();
+    return Set.unmodifiable({for (final row in rows) row.read<String>('name')});
   }
 
   Future<void> seedBaselineIfEmpty() async {

--- a/apps/mobile/lib/core/database/catalog/catalog_database_opener.dart
+++ b/apps/mobile/lib/core/database/catalog/catalog_database_opener.dart
@@ -25,11 +25,14 @@ class CatalogDatabaseOpener {
   final EmergencyOverrideRepository? emergencyOverrideRepository;
   final DateTime Function() _now;
   bool _openedBundledDataPack = false;
+  String _openedArtifactIdentity = '';
 
   bool get openedBundledDataPack => _openedBundledDataPack;
+  String get openedArtifactIdentity => _openedArtifactIdentity;
 
   Future<CatalogDatabase> open() async {
     _openedBundledDataPack = false;
+    _openedArtifactIdentity = '';
     final installedDatabase = await _openInstalledCurrentDataPack();
     if (installedDatabase != null) {
       return installedDatabase;
@@ -47,6 +50,9 @@ class CatalogDatabaseOpener {
     await database.seedBaselineIfEmpty();
     await _writeBundledFreshness(datapackDirectory, index);
     _openedBundledDataPack = true;
+    _openedArtifactIdentity = p.normalize(
+      File(p.join(datapackDirectory.path, 'capital.sqlite')).absolute.path,
+    );
     return database;
   }
 
@@ -253,6 +259,7 @@ class CatalogDatabaseOpener {
     try {
       if (await _isUsableCatalogDatabase(database)) {
         returned = true;
+        _openedArtifactIdentity = p.normalize(file.absolute.path);
         return database;
       }
       return null;

--- a/apps/mobile/lib/features/fare/official_od_fare_repository.dart
+++ b/apps/mobile/lib/features/fare/official_od_fare_repository.dart
@@ -32,8 +32,29 @@ final class OfficialOdFareRepository {
           ],
         )
         .getSingleOrNull();
-    if (row == null) return null;
+    return row == null ? null : _approvedQuote(row);
+  }
 
+  Future<Map<String, OfficialOdFareQuote>> loadAllApproved() async {
+    final rows = await catalogDatabase.customSelect('''
+      SELECT origin_station_id, destination_station_id, source_id, snapshot_id,
+             mapping_ledger_hash, gnrl_card_fare, gnrl_cash_fare,
+             yung_card_fare, yung_cash_fare, child_card_fare, child_cash_fare
+      FROM official_od_fare_quotes
+      ORDER BY origin_station_id, destination_station_id
+      ''').get();
+    final quotes = <String, OfficialOdFareQuote>{};
+    for (final row in rows) {
+      final quote = _approvedQuote(row);
+      if (quote != null) {
+        quotes['${quote.originStationId}->${quote.destinationStationId}'] =
+            quote;
+      }
+    }
+    return Map.unmodifiable(quotes);
+  }
+
+  OfficialOdFareQuote? _approvedQuote(QueryRow row) {
     final sourceId = row.read<String>('source_id');
     final snapshotId = row.read<String>('snapshot_id');
     final mappingLedgerHash = row.read<String>('mapping_ledger_hash');

--- a/apps/mobile/lib/features/routes/application/network_graph.dart
+++ b/apps/mobile/lib/features/routes/application/network_graph.dart
@@ -106,6 +106,7 @@ class RouteEdge {
     required this.toNodeId,
     required this.type,
     required this.baseCost,
+    this.sourceEdgeId = '',
     int? durationSeconds,
     this.distanceMeters = 0,
     this.lineId = '',
@@ -149,6 +150,7 @@ class RouteEdge {
   /// `durationSeconds` may stay 0 when source data has no reliable duration,
   /// but route ordering still needs a positive fallback weight.
   final int baseCost;
+  final String sourceEdgeId;
   final int durationSeconds;
   final int distanceMeters;
   final String lineId;

--- a/apps/mobile/lib/features/routes/application/route_engine.dart
+++ b/apps/mobile/lib/features/routes/application/route_engine.dart
@@ -12,14 +12,17 @@ class LocalRouteEngine {
   LocalRouteEngine({
     required this.graph,
     this.costCalculator = const AccessibilityCostCalculator(),
+    this.edgeResolver,
   }) : accessGraphRouter = AccessGraphRouter(
          graph: graph,
          costCalculator: costCalculator,
+         edgeResolver: edgeResolver,
        ),
        routeAssembler = RouteAssembler(costCalculator: costCalculator);
 
   final NetworkGraph graph;
   final AccessibilityCostCalculator costCalculator;
+  final RouteEdge Function(RouteEdge edge)? edgeResolver;
   final AccessGraphRouter accessGraphRouter;
   final RouteAssembler routeAssembler;
 
@@ -121,10 +124,12 @@ class AccessGraphRouter {
   const AccessGraphRouter({
     required this.graph,
     this.costCalculator = const AccessibilityCostCalculator(),
+    this.edgeResolver,
   });
 
   final NetworkGraph graph;
   final AccessibilityCostCalculator costCalculator;
+  final RouteEdge Function(RouteEdge edge)? edgeResolver;
 
   AccessPathResult findPath({
     required String originNodeId,
@@ -241,7 +246,8 @@ class AccessGraphRouter {
         break;
       }
 
-      for (final edge in graph.edgesFrom(candidate.nodeId)) {
+      for (final storedEdge in graph.edgesFrom(candidate.nodeId)) {
+        final edge = edgeResolver?.call(storedEdge) ?? storedEdge;
         if (!traversalPolicy.canTraverse(
           edge,
           currentNodeId: candidate.nodeId,

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:isolate';
 
 import '../../../core/database/catalog/catalog_database.dart';
+import '../../../mobile_error_reporter.dart';
 import '../../../route_hedge_labels.dart';
 import '../../../route_search.dart';
 import '../../fare/official_od_fare_quote.dart';
@@ -34,12 +35,19 @@ class LocalRouteRepository implements RouteSearchRepository {
   final FutureOr<void> Function(String event)? routeCatalogBuildObserver;
   _RouteCatalogBundle? _activeBundle;
   Future<_RouteCatalogBundle>? _routeCatalogBundleFuture;
+  final Set<Future<void>> _inFlightActivations = {};
+  final Set<_RouteCatalogBundle> _retiredBundles = {};
+  Future<void>? _closeFuture;
+  bool _isClosed = false;
   int _activationSequence = 0;
 
   CatalogDatabase get catalogDatabase =>
       _activeBundle?.catalogDatabase ?? _initialCatalogDatabase;
 
   Future<_RouteCatalogBundle> _routeCatalogBundle() {
+    if (_isClosed) {
+      return Future.error(StateError('LocalRouteRepository is closed.'));
+    }
     final active = _activeBundle;
     if (active != null) {
       return Future.value(active);
@@ -57,8 +65,10 @@ class LocalRouteRepository implements RouteSearchRepository {
               ownsDatabase: false,
             )
             .then((bundle) {
-              _activeBundle ??= bundle;
-              return _activeBundle!;
+              if (!_isClosed) {
+                _activeBundle ??= bundle;
+              }
+              return _activeBundle ?? bundle;
             })
             .onError((Object error, StackTrace stackTrace) {
               if (identical(_routeCatalogBundleFuture, future)) {
@@ -100,6 +110,36 @@ class LocalRouteRepository implements RouteSearchRepository {
     required CatalogDatabase catalogDatabase,
     required String artifactIdentity,
     bool ownsDatabase = false,
+  }) {
+    if (_isClosed) {
+      return _rejectClosedActivation(catalogDatabase, ownsDatabase);
+    }
+    late final Future<void> activation;
+    activation = _activateDataPack(
+      catalogDatabase: catalogDatabase,
+      artifactIdentity: artifactIdentity,
+      ownsDatabase: ownsDatabase,
+    );
+    _inFlightActivations.add(activation);
+    return activation.whenComplete(() {
+      _inFlightActivations.remove(activation);
+    });
+  }
+
+  Future<void> _rejectClosedActivation(
+    CatalogDatabase catalogDatabase,
+    bool ownsDatabase,
+  ) async {
+    if (ownsDatabase) {
+      await catalogDatabase.close();
+    }
+    throw StateError('LocalRouteRepository is closed.');
+  }
+
+  Future<void> _activateDataPack({
+    required CatalogDatabase catalogDatabase,
+    required String artifactIdentity,
+    required bool ownsDatabase,
   }) async {
     final active = _activeBundle;
     final inFlight = _routeCatalogBundleFuture;
@@ -127,10 +167,13 @@ class LocalRouteRepository implements RouteSearchRepository {
         ownsDatabase: ownsDatabase,
       );
     } catch (error, stackTrace) {
-      if (ownsDatabase) {
-        await catalogDatabase.close();
+      try {
+        if (ownsDatabase) {
+          await catalogDatabase.close();
+        }
+      } finally {
+        Error.throwWithStackTrace(error, stackTrace);
       }
-      Error.throwWithStackTrace(error, stackTrace);
     }
     if (activation != _activationSequence) {
       await candidate.dispose();
@@ -138,7 +181,18 @@ class LocalRouteRepository implements RouteSearchRepository {
     }
     final previous = _activeBundle;
     _activeBundle = candidate;
-    await previous?.dispose();
+    if (previous != null) {
+      try {
+        await previous.dispose();
+      } catch (error, stackTrace) {
+        _retiredBundles.add(previous);
+        reportMobileError(
+          error,
+          stackTrace,
+          context: '이전 이동 정보 bundle 정리 중 예외가 발생했습니다.',
+        );
+      }
+    }
   }
 
   Future<void> refreshRuntimeState() async {
@@ -146,10 +200,64 @@ class LocalRouteRepository implements RouteSearchRepository {
     bundle.runtimeState = await _RouteRuntimeState.load(bundle.catalogDatabase);
   }
 
-  Future<void> close() async {
+  Future<void> close() {
+    final existing = _closeFuture;
+    if (existing != null) {
+      return existing;
+    }
+    _isClosed = true;
+    _activationSequence += 1;
+    final future = _closeResources();
+    _closeFuture = future;
+    return future;
+  }
+
+  Future<void> _closeResources() async {
+    Object? firstError;
+    StackTrace? firstStackTrace;
+    _RouteCatalogBundle? completedBuild;
+    final build = _routeCatalogBundleFuture;
+    if (build != null) {
+      try {
+        completedBuild = await build;
+      } catch (error, stackTrace) {
+        firstError = error;
+        firstStackTrace = stackTrace;
+      }
+    }
+    for (final activation in _inFlightActivations.toList(growable: false)) {
+      try {
+        await activation;
+      } catch (error, stackTrace) {
+        firstError ??= error;
+        firstStackTrace ??= stackTrace;
+      }
+    }
+    for (final retired in _retiredBundles.toList(growable: false)) {
+      try {
+        await retired.dispose();
+        _retiredBundles.remove(retired);
+      } catch (error, stackTrace) {
+        firstError ??= error;
+        firstStackTrace ??= stackTrace;
+      }
+    }
     final bundle = _activeBundle;
     _activeBundle = null;
-    await bundle?.dispose();
+    if (completedBuild != null && !identical(completedBuild, bundle)) {
+      await completedBuild.dispose();
+    }
+    if (bundle != null) {
+      try {
+        await bundle.dispose();
+      } catch (error, stackTrace) {
+        firstError ??= error;
+        firstStackTrace ??= stackTrace;
+      }
+    }
+    if (firstError != null) {
+      Error.throwWithStackTrace(firstError, firstStackTrace!);
+    }
   }
 
   Future<RouteSearchRequest> canonicalRequest(
@@ -1247,18 +1355,21 @@ class _RouteCatalogBundle {
     final nowSeconds = at.toUtc().millisecondsSinceEpoch ~/ 1000;
     return (storedEdge) {
       final sourceEdge = _networkEdgesById[storedEdge.sourceEdgeId];
-      if (sourceEdge == null || sourceEdge.facilityId.isEmpty) {
+      if (sourceEdge == null) {
         return storedEdge;
       }
-      final effective = sourceEdge.resolveFacility(
-        state.facilityAt(sourceEdge.facilityId, nowSeconds),
-      );
+      final effective = sourceEdge.facilityId.isEmpty
+          ? sourceEdge
+          : sourceEdge.resolveFacility(
+              state.facilityAt(sourceEdge.facilityId, nowSeconds),
+            );
       return _toGraphRouteEdge(
         effective,
         storedEdge.type,
         id: storedEdge.id,
         fromNodeId: storedEdge.fromNodeId,
         toNodeId: storedEdge.toNodeId,
+        at: at,
       );
     };
   }
@@ -2693,8 +2804,10 @@ graph.RouteEdge _toGraphRouteEdge(
   String? id,
   String? fromNodeId,
   String? toNodeId,
+  DateTime? at,
 }) {
   final effectiveFromNodeId = fromNodeId ?? networkEdge.fromNodeId;
+  final evaluatedAt = at ?? DateTime.now();
 
   // route contract: local metric fallback
   // Source durations of 0 keep `durationSeconds` at 0 so UI can say the time
@@ -2722,10 +2835,10 @@ graph.RouteEdge _toGraphRouteEdge(
         ? graph.RouteStairAccessState.stairOnly
         : networkEdge.routeStairAccessState,
     reliabilityScore: networkEdge.effectiveReliabilityScore,
-    isDataStale: networkEdge.isDataStale,
+    isDataStale: networkEdge.isDataStaleAt(evaluatedAt),
     accessibilityState: networkEdge.accessibilityState,
     isUnderMaintenance: networkEdge.isUnderMaintenance,
-    safetyEvidence: networkEdge.safetyEvidence,
+    safetyEvidence: networkEdge.safetyEvidenceAt(evaluatedAt),
   );
 }
 
@@ -3439,7 +3552,9 @@ class _NetworkEdgeSnapshot {
     return reliabilityScore;
   }
 
-  bool get isDataStale {
+  bool get isDataStale => isDataStaleAt(DateTime.now());
+
+  bool isDataStaleAt(DateTime at) {
     if (_accessibilityStatusUpper == 'UNKNOWN') {
       return true;
     }
@@ -3452,11 +3567,14 @@ class _NetworkEdgeSnapshot {
       isUtc: true,
     );
     return verifiedDate.isBefore(
-      DateTime.now().toUtc().subtract(const Duration(days: 365)),
+      at.toUtc().subtract(const Duration(days: 365)),
     );
   }
 
-  graph.RouteEdgeSafetyEvidence get safetyEvidence {
+  graph.RouteEdgeSafetyEvidence get safetyEvidence =>
+      safetyEvidenceAt(DateTime.now());
+
+  graph.RouteEdgeSafetyEvidence safetyEvidenceAt(DateTime at) {
     final verifiedAt = lastVerifiedAtSeconds == null
         ? null
         : DateTime.fromMillisecondsSinceEpoch(
@@ -3486,7 +3604,7 @@ class _NetworkEdgeSnapshot {
       evidenceHashValid: evidenceHashValid,
       isPlaceholderEvidence: isPlaceholderEvidence,
       lastVerifiedAt: verifiedAt,
-      isStale: isDataStale,
+      isStale: isDataStaleAt(at),
       isGeneratedConnector: false,
       strictRouteEligible: blockerReasons.isEmpty,
       blockerReasons: blockerReasons,

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -22,6 +22,7 @@ class LocalRouteRepository implements RouteSearchRepository {
     this.artifactIdentity = 'initial-artifact',
     DateTime Function()? now,
     this.routeCatalogBuildObserver,
+    this.routeRuntimeRefreshObserver,
   }) : now = now ?? DateTime.now,
        _initialCatalogDatabase = catalogDatabase,
        _initialOfficialOdFareRepository =
@@ -33,9 +34,12 @@ class LocalRouteRepository implements RouteSearchRepository {
   final DateTime Function() now;
   final OfficialOdFareRepository _initialOfficialOdFareRepository;
   final FutureOr<void> Function(String event)? routeCatalogBuildObserver;
+  final FutureOr<void> Function(String event)? routeRuntimeRefreshObserver;
   _RouteCatalogBundle? _activeBundle;
   Future<_RouteCatalogBundle>? _routeCatalogBundleFuture;
+  Future<void> _activationQueue = Future<void>.value();
   final Set<Future<void>> _inFlightActivations = {};
+  final Set<Future<void>> _inFlightRuntimeRefreshes = {};
   final Set<_RouteCatalogBundle> _retiredBundles = {};
   Future<void>? _closeFuture;
   bool _isClosed = false;
@@ -67,6 +71,9 @@ class LocalRouteRepository implements RouteSearchRepository {
             .then((bundle) {
               if (!_isClosed) {
                 _activeBundle ??= bundle;
+              }
+              if (identical(_routeCatalogBundleFuture, future)) {
+                _routeCatalogBundleFuture = null;
               }
               return _activeBundle ?? bundle;
             })
@@ -115,10 +122,16 @@ class LocalRouteRepository implements RouteSearchRepository {
       return _rejectClosedActivation(catalogDatabase, ownsDatabase);
     }
     late final Future<void> activation;
-    activation = _activateDataPack(
-      catalogDatabase: catalogDatabase,
-      artifactIdentity: artifactIdentity,
-      ownsDatabase: ownsDatabase,
+    activation = _activationQueue.then(
+      (_) => _activateDataPack(
+        catalogDatabase: catalogDatabase,
+        artifactIdentity: artifactIdentity,
+        ownsDatabase: ownsDatabase,
+      ),
+    );
+    _activationQueue = activation.then<void>(
+      (_) {},
+      onError: (Object _, StackTrace _) {},
     );
     _inFlightActivations.add(activation);
     return activation.whenComplete(() {
@@ -141,9 +154,17 @@ class LocalRouteRepository implements RouteSearchRepository {
     required String artifactIdentity,
     required bool ownsDatabase,
   }) async {
+    if (_isClosed) {
+      await _disposeIncomingDatabase(catalogDatabase, ownsDatabase);
+      return;
+    }
     final active = _activeBundle;
     final inFlight = _routeCatalogBundleFuture;
     final current = active ?? (inFlight == null ? null : await inFlight);
+    if (_isClosed) {
+      await _disposeIncomingDatabase(catalogDatabase, ownsDatabase);
+      return;
+    }
     if ((current?.artifactIdentity ?? this.artifactIdentity) ==
         artifactIdentity) {
       if (ownsDatabase &&
@@ -179,6 +200,11 @@ class LocalRouteRepository implements RouteSearchRepository {
       await candidate.dispose();
       return;
     }
+    await _waitForRuntimeRefreshes();
+    if (_isClosed || activation != _activationSequence) {
+      await candidate.dispose();
+      return;
+    }
     final previous = _activeBundle;
     _activeBundle = candidate;
     if (previous != null) {
@@ -195,9 +221,46 @@ class LocalRouteRepository implements RouteSearchRepository {
     }
   }
 
-  Future<void> refreshRuntimeState() async {
+  Future<void> _disposeIncomingDatabase(
+    CatalogDatabase catalogDatabase,
+    bool ownsDatabase,
+  ) async {
+    if (ownsDatabase) {
+      await catalogDatabase.close();
+    }
+  }
+
+  Future<void> refreshRuntimeState() {
+    if (_isClosed) {
+      return Future.error(StateError('LocalRouteRepository is closed.'));
+    }
+    late final Future<void> refresh;
+    refresh = _refreshRuntimeState();
+    _inFlightRuntimeRefreshes.add(refresh);
+    return refresh.whenComplete(() {
+      _inFlightRuntimeRefreshes.remove(refresh);
+    });
+  }
+
+  Future<void> _refreshRuntimeState() async {
     final bundle = await _routeCatalogBundle();
+    await routeRuntimeRefreshObserver?.call('load');
     bundle.runtimeState = await _RouteRuntimeState.load(bundle.catalogDatabase);
+  }
+
+  Future<void> _waitForRuntimeRefreshes() async {
+    while (_inFlightRuntimeRefreshes.isNotEmpty) {
+      final pending = _inFlightRuntimeRefreshes.toList(growable: false);
+      await Future.wait(
+        pending.map((refresh) async {
+          try {
+            await refresh;
+          } catch (_) {
+            // 호출자에게 전달되는 refresh 오류가 lifecycle 정리를 막지는 않는다.
+          }
+        }),
+      );
+    }
   }
 
   Future<void> close() {
@@ -233,6 +296,7 @@ class LocalRouteRepository implements RouteSearchRepository {
         firstStackTrace ??= stackTrace;
       }
     }
+    await _waitForRuntimeRefreshes();
     for (final retired in _retiredBundles.toList(growable: false)) {
       try {
         await retired.dispose();

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -95,15 +95,22 @@ class LocalRouteRepository implements RouteSearchRepository {
     );
   }
 
+  /// 세션의 다른 catalog 소비자와 교체가 조정된 뒤 완성된 route bundle을 게시한다.
   Future<void> activateDataPack({
     required CatalogDatabase catalogDatabase,
     required String artifactIdentity,
     bool ownsDatabase = false,
   }) async {
-    final current = await _routeCatalogBundle();
-    if (current.artifactIdentity == artifactIdentity) {
+    final active = _activeBundle;
+    final inFlight = _routeCatalogBundleFuture;
+    final current = active ?? (inFlight == null ? null : await inFlight);
+    if ((current?.artifactIdentity ?? this.artifactIdentity) ==
+        artifactIdentity) {
       if (ownsDatabase &&
-          !identical(catalogDatabase, current.catalogDatabase)) {
+          !identical(
+            catalogDatabase,
+            current?.catalogDatabase ?? _initialCatalogDatabase,
+          )) {
         await catalogDatabase.close();
       }
       return;

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:drift/drift.dart' show Variable;
 
 import '../../../core/database/catalog/canonical_station_id.dart';
@@ -19,6 +21,7 @@ class LocalRouteRepository implements RouteSearchRepository {
     required this.catalogDatabase,
     OfficialOdFareRepository? officialOdFareRepository,
     DateTime Function()? now,
+    this.routeCatalogBuildObserver,
   }) : now = now ?? DateTime.now,
        officialOdFareRepository =
            officialOdFareRepository ??
@@ -27,6 +30,43 @@ class LocalRouteRepository implements RouteSearchRepository {
   final CatalogDatabase catalogDatabase;
   final DateTime Function() now;
   final OfficialOdFareRepository officialOdFareRepository;
+  final FutureOr<void> Function(String event)? routeCatalogBuildObserver;
+  Future<({_RouteCatalogSnapshot catalog, graph.NetworkGraph graph})>?
+  _routeCatalogBundleFuture;
+
+  Future<({_RouteCatalogSnapshot catalog, graph.NetworkGraph graph})>
+  _routeCatalogBundle() {
+    final existing = _routeCatalogBundleFuture;
+    if (existing != null) {
+      return existing;
+    }
+    late final Future<
+      ({_RouteCatalogSnapshot catalog, graph.NetworkGraph graph})
+    >
+    future;
+    future = _buildRouteCatalogBundle().onError((
+      Object error,
+      StackTrace stackTrace,
+    ) {
+      if (identical(_routeCatalogBundleFuture, future)) {
+        _routeCatalogBundleFuture = null;
+      }
+      Error.throwWithStackTrace(error, stackTrace);
+    });
+    _routeCatalogBundleFuture = future;
+    return future;
+  }
+
+  Future<({_RouteCatalogSnapshot catalog, graph.NetworkGraph graph})>
+  _buildRouteCatalogBundle() async {
+    await routeCatalogBuildObserver?.call('snapshot');
+    final catalog = await _RouteCatalogSnapshot.load(
+      catalogDatabase,
+      buildObserver: routeCatalogBuildObserver,
+    );
+    await routeCatalogBuildObserver?.call('graph');
+    return (catalog: catalog, graph: catalog.toGraph());
+  }
 
   Future<RouteSearchRequest> canonicalRequest(
     RouteSearchRequest request,
@@ -52,7 +92,9 @@ class LocalRouteRepository implements RouteSearchRepository {
   Future<RouteCapabilityMetadata> routeCapability(
     RouteSearchRequest request,
   ) async {
-    final catalog = await _RouteCatalogSnapshot.load(catalogDatabase);
+    final bundle = await _routeCatalogBundle();
+    final catalog = bundle.catalog;
+    final searchMode = await _stationSearchMode();
     final stationExists =
         catalog.hasStation(request.originStationId) &&
         catalog.hasStation(request.destinationStationId);
@@ -60,6 +102,8 @@ class LocalRouteRepository implements RouteSearchRepository {
         ? catalog.routeResult(
             request.originStationId,
             request.destinationStationId,
+            routeGraph: bundle.graph,
+            searchMode: searchMode,
             mobilityType: local.MobilityType.luggage,
             constraintMode: local.ConstraintMode.allowWithWarnings,
           )
@@ -73,6 +117,8 @@ class LocalRouteRepository implements RouteSearchRepository {
           catalog.strictEvidenceSupportedFor(
             request.originStationId,
             request.destinationStationId,
+            routeGraph: bundle.graph,
+            searchMode: searchMode,
           ),
       realtimeSupported: catalog.realtimeSupported(
         request.originStationId,
@@ -102,14 +148,16 @@ class LocalRouteRepository implements RouteSearchRepository {
   }
 
   Future<bool> canSearchRoute(RouteSearchRequest request) async {
-    final catalog = await _RouteCatalogSnapshot.load(catalogDatabase);
+    final catalog = (await _routeCatalogBundle()).catalog;
     return catalog.hasStation(request.originStationId) &&
         catalog.hasStation(request.destinationStationId);
   }
 
   @override
   Future<RouteSearchResult> searchRoute(RouteSearchRequest rawRequest) async {
-    final catalog = await _RouteCatalogSnapshot.load(catalogDatabase);
+    final bundle = await _routeCatalogBundle();
+    final catalog = bundle.catalog;
+    final searchMode = await _stationSearchMode();
     final request = catalog.canonicalRequest(rawRequest);
     final mobilityType = _mobilityType(request.mobilityType);
     final constraintMode = _constraintMode(request.effectiveConstraintMode);
@@ -127,15 +175,13 @@ class LocalRouteRepository implements RouteSearchRepository {
           ? local.LocalRouteResult.unknown(const [
               'STRICT_EVIDENCE_UNSUPPORTED',
             ])
-          : LocalRouteEngine(graph: catalog.toGraph()).search(
+          : LocalRouteEngine(graph: bundle.graph).search(
               local.RouteRequest(
                 originStationId: request.originStationId,
                 destinationStationId: request.destinationStationId,
                 mobilityType: mobilityType,
                 constraintMode: constraintMode,
-                searchMode: local
-                    .RouteSearchMode
-                    .stationToStationWithOutOfStationTransfers,
+                searchMode: searchMode,
                 objective: objective,
               ),
             );
@@ -143,25 +189,27 @@ class LocalRouteRepository implements RouteSearchRepository {
         !(catalog.strictEvidenceSupportedFor(
               request.originStationId,
               waypointStationId,
+              routeGraph: bundle.graph,
+              searchMode: searchMode,
             ) &&
             catalog.strictEvidenceSupportedFor(
               waypointStationId,
               request.destinationStationId,
+              routeGraph: bundle.graph,
+              searchMode: searchMode,
             ))) {
       result = local.LocalRouteResult.unknown(const [
         'STRICT_EVIDENCE_UNSUPPORTED',
       ]);
     } else {
-      final graphSnapshot = catalog.toGraph();
-      final engine = LocalRouteEngine(graph: graphSnapshot);
+      final engine = LocalRouteEngine(graph: bundle.graph);
       final first = engine.search(
         local.RouteRequest(
           originStationId: request.originStationId,
           destinationStationId: waypointStationId,
           mobilityType: mobilityType,
           constraintMode: constraintMode,
-          searchMode:
-              local.RouteSearchMode.stationToStationWithOutOfStationTransfers,
+          searchMode: searchMode,
           objective: objective,
         ),
       );
@@ -171,8 +219,7 @@ class LocalRouteRepository implements RouteSearchRepository {
           destinationStationId: request.destinationStationId,
           mobilityType: mobilityType,
           constraintMode: constraintMode,
-          searchMode:
-              local.RouteSearchMode.stationToStationWithOutOfStationTransfers,
+          searchMode: searchMode,
           objective: objective,
         ),
       );
@@ -191,6 +238,18 @@ class LocalRouteRepository implements RouteSearchRepository {
       plannedArrivals: plannedArrivals,
       officialOdFareQuote: quote,
     );
+  }
+
+  Future<local.RouteSearchMode> _stationSearchMode() async {
+    final row = await catalogDatabase.customSelect('''
+      SELECT value
+      FROM catalog_metadata
+      WHERE key = 'route.outOfStationTransfer.runtimeEnabled'
+      LIMIT 1
+    ''').getSingleOrNull();
+    return row?.read<String>('value').toLowerCase() == 'false'
+        ? local.RouteSearchMode.stationToStation
+        : local.RouteSearchMode.stationToStationWithOutOfStationTransfers;
   }
 
   @override
@@ -1210,7 +1269,10 @@ class _RouteCatalogSnapshot {
   /// 로컬 catalog에 station_car_door_hints가 있을 때만 채워진다.
   final Map<String, List<_CarDoorHintSnapshot>> carDoorHintsByStationLine;
 
-  static Future<_RouteCatalogSnapshot> load(CatalogDatabase database) async {
+  static Future<_RouteCatalogSnapshot> load(
+    CatalogDatabase database, {
+    FutureOr<void> Function(String event)? buildObserver,
+  }) async {
     final sourceUpdatedAtRow = await database.customSelect('''
           SELECT MAX(CAST(updated_at AS INTEGER)) AS source_updated_at
           FROM catalog_metadata
@@ -1301,6 +1363,7 @@ class _RouteCatalogSnapshot {
             );
       }
     }
+    await buildObserver?.call('schema');
     final networkEdgeColumns = await database
         .customSelect('PRAGMA table_info(network_edges)')
         .get();
@@ -1385,6 +1448,7 @@ class _RouteCatalogSnapshot {
         networkEdgeColumnNames.contains('service_class')
         ? "WHERE service_class = 'SUBWAY'"
         : '';
+    await buildObserver?.call('schema');
     final facilityColumns = await database
         .customSelect('PRAGMA table_info(facilities)')
         .get();
@@ -1617,33 +1681,38 @@ class _RouteCatalogSnapshot {
   local.LocalRouteResult routeResult(
     String originStationId,
     String destinationStationId, {
+    required graph.NetworkGraph routeGraph,
+    required local.RouteSearchMode searchMode,
     required local.MobilityType mobilityType,
     required local.ConstraintMode constraintMode,
   }) {
     originStationId = canonicalStationId(originStationId);
     destinationStationId = canonicalStationId(destinationStationId);
-    return LocalRouteEngine(graph: toGraph()).search(
+    return LocalRouteEngine(graph: routeGraph).search(
       local.RouteRequest(
         originStationId: originStationId,
         destinationStationId: destinationStationId,
         mobilityType: mobilityType,
         constraintMode: constraintMode,
-        searchMode:
-            local.RouteSearchMode.stationToStationWithOutOfStationTransfers,
+        searchMode: searchMode,
       ),
     );
   }
 
   bool strictEvidenceSupportedFor(
     String originStationId,
-    String destinationStationId,
-  ) {
+    String destinationStationId, {
+    required graph.NetworkGraph routeGraph,
+    required local.RouteSearchMode searchMode,
+  }) {
     if (!strictEvidenceSupported) {
       return false;
     }
     return routeResult(
           originStationId,
           destinationStationId,
+          routeGraph: routeGraph,
+          searchMode: searchMode,
           mobilityType: local.MobilityType.wheelchair,
           constraintMode: local.ConstraintMode.strictStepFree,
         ).status ==

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -1,8 +1,6 @@
 import 'dart:async';
+import 'dart:isolate';
 
-import 'package:drift/drift.dart' show Variable;
-
-import '../../../core/database/catalog/canonical_station_id.dart';
 import '../../../core/database/catalog/catalog_database.dart';
 import '../../../route_hedge_labels.dart';
 import '../../../route_search.dart';
@@ -18,75 +16,139 @@ import '../domain/route_step.dart' as route_step;
 
 class LocalRouteRepository implements RouteSearchRepository {
   LocalRouteRepository({
-    required this.catalogDatabase,
+    required CatalogDatabase catalogDatabase,
     OfficialOdFareRepository? officialOdFareRepository,
+    this.artifactIdentity = 'initial-artifact',
     DateTime Function()? now,
     this.routeCatalogBuildObserver,
   }) : now = now ?? DateTime.now,
-       officialOdFareRepository =
+       _initialCatalogDatabase = catalogDatabase,
+       _initialOfficialOdFareRepository =
            officialOdFareRepository ??
            OfficialOdFareRepository(catalogDatabase: catalogDatabase);
 
-  final CatalogDatabase catalogDatabase;
+  final CatalogDatabase _initialCatalogDatabase;
+  final String artifactIdentity;
   final DateTime Function() now;
-  final OfficialOdFareRepository officialOdFareRepository;
+  final OfficialOdFareRepository _initialOfficialOdFareRepository;
   final FutureOr<void> Function(String event)? routeCatalogBuildObserver;
-  Future<({_RouteCatalogSnapshot catalog, graph.NetworkGraph graph})>?
-  _routeCatalogBundleFuture;
+  _RouteCatalogBundle? _activeBundle;
+  Future<_RouteCatalogBundle>? _routeCatalogBundleFuture;
+  int _activationSequence = 0;
 
-  Future<({_RouteCatalogSnapshot catalog, graph.NetworkGraph graph})>
-  _routeCatalogBundle() {
+  CatalogDatabase get catalogDatabase =>
+      _activeBundle?.catalogDatabase ?? _initialCatalogDatabase;
+
+  Future<_RouteCatalogBundle> _routeCatalogBundle() {
+    final active = _activeBundle;
+    if (active != null) {
+      return Future.value(active);
+    }
     final existing = _routeCatalogBundleFuture;
     if (existing != null) {
       return existing;
     }
-    late final Future<
-      ({_RouteCatalogSnapshot catalog, graph.NetworkGraph graph})
-    >
-    future;
-    future = _buildRouteCatalogBundle().onError((
-      Object error,
-      StackTrace stackTrace,
-    ) {
-      if (identical(_routeCatalogBundleFuture, future)) {
-        _routeCatalogBundleFuture = null;
-      }
-      Error.throwWithStackTrace(error, stackTrace);
-    });
+    late final Future<_RouteCatalogBundle> future;
+    future =
+        _buildRouteCatalogBundle(
+              catalogDatabase: _initialCatalogDatabase,
+              artifactIdentity: artifactIdentity,
+              officialOdFareRepository: _initialOfficialOdFareRepository,
+              ownsDatabase: false,
+            )
+            .then((bundle) {
+              _activeBundle ??= bundle;
+              return _activeBundle!;
+            })
+            .onError((Object error, StackTrace stackTrace) {
+              if (identical(_routeCatalogBundleFuture, future)) {
+                _routeCatalogBundleFuture = null;
+              }
+              Error.throwWithStackTrace(error, stackTrace);
+            });
     _routeCatalogBundleFuture = future;
     return future;
   }
 
-  Future<({_RouteCatalogSnapshot catalog, graph.NetworkGraph graph})>
-  _buildRouteCatalogBundle() async {
+  Future<_RouteCatalogBundle> _buildRouteCatalogBundle({
+    required CatalogDatabase catalogDatabase,
+    required String artifactIdentity,
+    required OfficialOdFareRepository officialOdFareRepository,
+    required bool ownsDatabase,
+  }) async {
     await routeCatalogBuildObserver?.call('snapshot');
-    final catalog = await _RouteCatalogSnapshot.load(
-      catalogDatabase,
-      buildObserver: routeCatalogBuildObserver,
-    );
+    final catalog = await _RouteCatalogSnapshot.load(catalogDatabase);
+    final timetable = await _TimetableSnapshot.load(catalogDatabase);
+    final officialOdFares = await officialOdFareRepository.loadAllApproved();
+    final runtimeState = await _RouteRuntimeState.load(catalogDatabase);
     await routeCatalogBuildObserver?.call('graph');
-    return (catalog: catalog, graph: catalog.toGraph());
+    final routeGraph = await Isolate.run(catalog.toGraph);
+    return _RouteCatalogBundle(
+      artifactIdentity: artifactIdentity,
+      catalogDatabase: catalogDatabase,
+      catalog: catalog,
+      routeGraph: routeGraph,
+      timetable: timetable,
+      officialOdFares: officialOdFares,
+      runtimeState: runtimeState,
+      ownsDatabase: ownsDatabase,
+    );
+  }
+
+  Future<void> activateDataPack({
+    required CatalogDatabase catalogDatabase,
+    required String artifactIdentity,
+    bool ownsDatabase = false,
+  }) async {
+    final current = await _routeCatalogBundle();
+    if (current.artifactIdentity == artifactIdentity) {
+      if (ownsDatabase &&
+          !identical(catalogDatabase, current.catalogDatabase)) {
+        await catalogDatabase.close();
+      }
+      return;
+    }
+    final activation = ++_activationSequence;
+    _RouteCatalogBundle candidate;
+    try {
+      candidate = await _buildRouteCatalogBundle(
+        catalogDatabase: catalogDatabase,
+        artifactIdentity: artifactIdentity,
+        officialOdFareRepository: OfficialOdFareRepository(
+          catalogDatabase: catalogDatabase,
+        ),
+        ownsDatabase: ownsDatabase,
+      );
+    } catch (_) {
+      if (ownsDatabase) {
+        await catalogDatabase.close();
+      }
+      rethrow;
+    }
+    if (activation != _activationSequence) {
+      await candidate.dispose();
+      return;
+    }
+    final previous = _activeBundle;
+    _activeBundle = candidate;
+    await previous?.dispose();
+  }
+
+  Future<void> refreshRuntimeState() async {
+    final bundle = await _routeCatalogBundle();
+    bundle.runtimeState = await _RouteRuntimeState.load(bundle.catalogDatabase);
+  }
+
+  Future<void> close() async {
+    final bundle = _activeBundle;
+    _activeBundle = null;
+    await bundle?.dispose();
   }
 
   Future<RouteSearchRequest> canonicalRequest(
     RouteSearchRequest request,
   ) async {
-    final waypoint = request.waypointStationId?.trim();
-    return RouteSearchRequest(
-      originStationId: await catalogDatabase.resolveCanonicalStationId(
-        request.originStationId.trim(),
-      ),
-      destinationStationId: await catalogDatabase.resolveCanonicalStationId(
-        request.destinationStationId.trim(),
-      ),
-      mobilityType: request.mobilityType,
-      constraintMode: request.constraintMode,
-      waypointStationId: waypoint == null || waypoint.isEmpty
-          ? waypoint
-          : await catalogDatabase.resolveCanonicalStationId(waypoint),
-      mobilityPreset: request.mobilityPreset,
-      transportScope: request.transportScope,
-    );
+    return (await _routeCatalogBundle()).catalog.canonicalRequest(request);
   }
 
   Future<RouteCapabilityMetadata> routeCapability(
@@ -94,7 +156,8 @@ class LocalRouteRepository implements RouteSearchRepository {
   ) async {
     final bundle = await _routeCatalogBundle();
     final catalog = bundle.catalog;
-    final searchMode = await _stationSearchMode();
+    final searchMode = _stationSearchMode(bundle);
+    final edgeResolver = bundle.edgeResolver(now());
     final stationExists =
         catalog.hasStation(request.originStationId) &&
         catalog.hasStation(request.destinationStationId);
@@ -102,8 +165,9 @@ class LocalRouteRepository implements RouteSearchRepository {
         ? catalog.routeResult(
             request.originStationId,
             request.destinationStationId,
-            routeGraph: bundle.graph,
+            routeGraph: bundle.routeGraph,
             searchMode: searchMode,
+            edgeResolver: edgeResolver,
             mobilityType: local.MobilityType.luggage,
             constraintMode: local.ConstraintMode.allowWithWarnings,
           )
@@ -117,8 +181,9 @@ class LocalRouteRepository implements RouteSearchRepository {
           catalog.strictEvidenceSupportedFor(
             request.originStationId,
             request.destinationStationId,
-            routeGraph: bundle.graph,
+            routeGraph: bundle.routeGraph,
             searchMode: searchMode,
+            edgeResolver: edgeResolver,
           ),
       realtimeSupported: catalog.realtimeSupported(
         request.originStationId,
@@ -157,7 +222,8 @@ class LocalRouteRepository implements RouteSearchRepository {
   Future<RouteSearchResult> searchRoute(RouteSearchRequest rawRequest) async {
     final bundle = await _routeCatalogBundle();
     final catalog = bundle.catalog;
-    final searchMode = await _stationSearchMode();
+    final searchMode = _stationSearchMode(bundle);
+    final edgeResolver = bundle.edgeResolver(now());
     final request = catalog.canonicalRequest(rawRequest);
     final mobilityType = _mobilityType(request.mobilityType);
     final constraintMode = _constraintMode(request.effectiveConstraintMode);
@@ -175,7 +241,10 @@ class LocalRouteRepository implements RouteSearchRepository {
           ? local.LocalRouteResult.unknown(const [
               'STRICT_EVIDENCE_UNSUPPORTED',
             ])
-          : LocalRouteEngine(graph: bundle.graph).search(
+          : LocalRouteEngine(
+              graph: bundle.routeGraph,
+              edgeResolver: edgeResolver,
+            ).search(
               local.RouteRequest(
                 originStationId: request.originStationId,
                 destinationStationId: request.destinationStationId,
@@ -189,20 +258,25 @@ class LocalRouteRepository implements RouteSearchRepository {
         !(catalog.strictEvidenceSupportedFor(
               request.originStationId,
               waypointStationId,
-              routeGraph: bundle.graph,
+              routeGraph: bundle.routeGraph,
               searchMode: searchMode,
+              edgeResolver: edgeResolver,
             ) &&
             catalog.strictEvidenceSupportedFor(
               waypointStationId,
               request.destinationStationId,
-              routeGraph: bundle.graph,
+              routeGraph: bundle.routeGraph,
               searchMode: searchMode,
+              edgeResolver: edgeResolver,
             ))) {
       result = local.LocalRouteResult.unknown(const [
         'STRICT_EVIDENCE_UNSUPPORTED',
       ]);
     } else {
-      final engine = LocalRouteEngine(graph: bundle.graph);
+      final engine = LocalRouteEngine(
+        graph: bundle.routeGraph,
+        edgeResolver: edgeResolver,
+      );
       final first = engine.search(
         local.RouteRequest(
           originStationId: request.originStationId,
@@ -226,11 +300,16 @@ class LocalRouteRepository implements RouteSearchRepository {
       result = mergeWaypointRouteResults(first, second);
     }
 
-    final plannedArrivals = await _plannedRideArrivals(result, catalog);
-    final quote = await officialOdFareRepository.findExact(
-      originStationId: request.originStationId,
-      destinationStationId: request.destinationStationId,
+    final plannedArrivals = _plannedRideArrivals(
+      result,
+      catalog,
+      bundle.timetable,
     );
+    final quote =
+        bundle.officialOdFares[_officialFareKey(
+          request.originStationId,
+          request.destinationStationId,
+        )];
     return _toRouteSearchResult(
       request,
       result,
@@ -240,14 +319,8 @@ class LocalRouteRepository implements RouteSearchRepository {
     );
   }
 
-  Future<local.RouteSearchMode> _stationSearchMode() async {
-    final row = await catalogDatabase.customSelect('''
-      SELECT value
-      FROM catalog_metadata
-      WHERE key = 'route.outOfStationTransfer.runtimeEnabled'
-      LIMIT 1
-    ''').getSingleOrNull();
-    return row?.read<String>('value').toLowerCase() == 'false'
+  local.RouteSearchMode _stationSearchMode(_RouteCatalogBundle bundle) {
+    return !bundle.runtimeState.outOfStationTransferRuntimeEnabled
         ? local.RouteSearchMode.stationToStation
         : local.RouteSearchMode.stationToStationWithOutOfStationTransfers;
   }
@@ -426,10 +499,11 @@ class LocalRouteRepository implements RouteSearchRepository {
         .toList(growable: false);
   }
 
-  Future<Map<int, String>> _plannedRideArrivals(
+  Map<int, String> _plannedRideArrivals(
     local.LocalRouteResult result,
     _RouteCatalogSnapshot catalog,
-  ) async {
+    _TimetableSnapshot timetable,
+  ) {
     if (result.status != local.RouteStatus.found) {
       return const {};
     }
@@ -452,7 +526,7 @@ class LocalRouteRepository implements RouteSearchRepository {
       if (rawServicePattern.isNotEmpty && normalizedServicePattern == null) {
         return const {};
       }
-      final arrival = await _nextTimetableArrival(
+      final arrival = timetable.nextArrival(
         fromStationId: catalog.stationIdForNode(step.fromNodeId),
         toStationId: catalog.stationIdForNode(step.toNodeId),
         lineId: step.lineId,
@@ -466,107 +540,6 @@ class LocalRouteRepository implements RouteSearchRepository {
       cursor = arrival;
     }
     return arrivals;
-  }
-
-  Future<DateTime?> _nextTimetableArrival({
-    required String fromStationId,
-    required String toStationId,
-    required String lineId,
-    required String servicePattern,
-    required DateTime cursor,
-  }) async {
-    final koreaNow = cursor.toUtc().add(const Duration(hours: 9));
-    var firstServiceDate = DateTime.utc(
-      koreaNow.year,
-      koreaNow.month,
-      koreaNow.day,
-    );
-    if (koreaNow.hour < 3) {
-      firstServiceDate = firstServiceDate.subtract(const Duration(days: 1));
-    }
-    for (var dayOffset = 0; dayOffset <= 7; dayOffset += 1) {
-      final serviceDate = firstServiceDate.add(Duration(days: dayOffset));
-      final serviceMidnight = serviceDate.subtract(const Duration(hours: 9));
-      final dateKey = _compactDate(serviceDate);
-      final weekdayColumn = _weekdayColumn(serviceDate.weekday);
-      final startMicroseconds = cursor
-          .difference(serviceMidnight)
-          .inMicroseconds;
-      final startSeconds = startMicroseconds <= 0
-          ? 0
-          : (startMicroseconds + Duration.microsecondsPerSecond - 1) ~/
-                Duration.microsecondsPerSecond;
-      final servicePatternSql = servicePattern.isEmpty
-          ? ''
-          : 'AND trip.service_pattern = ?';
-      final row = await catalogDatabase
-          .customSelect(
-            '''
-        SELECT board.departure_seconds, alight.arrival_seconds
-        FROM transit_trips trip
-        INNER JOIN transit_routes route ON route.id = trip.route_id
-        INNER JOIN service_calendars calendar
-          ON calendar.service_id = trip.service_id
-        INNER JOIN transit_stop_times board ON board.trip_id = trip.id
-        INNER JOIN transit_stop_times alight ON alight.trip_id = trip.id
-        WHERE (
-            (
-              calendar.start_date <= ?
-              AND calendar.end_date >= ?
-              AND calendar.$weekdayColumn != 0
-            )
-            OR EXISTS (
-              SELECT 1
-              FROM service_calendar_dates added
-              WHERE added.service_id = trip.service_id
-                AND added.date = ?
-                AND added.exception_type = 1
-            )
-          )
-          AND NOT EXISTS (
-            SELECT 1
-            FROM service_calendar_dates removed
-            WHERE removed.service_id = trip.service_id
-              AND removed.date = ?
-              AND removed.exception_type = 2
-          )
-          AND trip.service_class = 'SUBWAY'
-          AND route.line_id = ?
-          $servicePatternSql
-          AND board.station_id = ?
-          AND board.line_id = ?
-          AND board.pickup_type != 1
-          AND alight.station_id = ?
-          AND alight.line_id = ?
-          AND alight.drop_off_type != 1
-          AND alight.stop_sequence > board.stop_sequence
-          AND board.departure_seconds >= ?
-        ORDER BY board.departure_seconds, alight.arrival_seconds, trip.id
-        LIMIT 1
-      ''',
-            variables: [
-              Variable.withString(dateKey),
-              Variable.withString(dateKey),
-              Variable.withString(dateKey),
-              Variable.withString(dateKey),
-              Variable.withString(lineId),
-              if (servicePattern.isNotEmpty)
-                Variable.withString(servicePattern),
-              Variable.withString(fromStationId),
-              Variable.withString(lineId),
-              Variable.withString(toStationId),
-              Variable.withString(lineId),
-              Variable.withInt(startSeconds),
-            ],
-          )
-          .getSingleOrNull();
-      if (row != null) {
-        return serviceMidnight.add(
-          Duration(seconds: row.read<int>('arrival_seconds')),
-        );
-      }
-    }
-    return null;
   }
 
   int _estimatedDurationSeconds(List<RouteSearchStep> steps) {
@@ -1144,7 +1117,8 @@ extension _OnlineRouteDisplayLabels on LocalRouteRepository {
   Future<RouteSearchResult> resolveDisplayLabels(
     RouteSearchResult result,
   ) async {
-    final catalog = await _RouteCatalogSnapshot.load(catalogDatabase);
+    final bundle = await _routeCatalogBundle();
+    final catalog = bundle.catalog;
     final steps = result.steps
         .map((step) {
           final fromName = catalog.stationName(step.fromStationId);
@@ -1169,10 +1143,10 @@ extension _OnlineRouteDisplayLabels on LocalRouteRepository {
       lineName: catalog.lineName(result.lineId),
       steps: steps,
       officialOdFareQuote: result.transportScope == RouteTransportScope.subway
-          ? await officialOdFareRepository.findExact(
-              originStationId: result.originStationId,
-              destinationStationId: result.destinationStationId,
-            )
+          ? bundle.officialOdFares[_officialFareKey(
+              result.originStationId,
+              result.destinationStationId,
+            )]
           : null,
     );
   }
@@ -1237,6 +1211,400 @@ const Map<String, _SeqDirectionConvention> _carDoorSeqConventionByLine = {
   'seoul-4': _SeqDirectionConvention.ascendingIsDown,
 };
 
+class _RouteCatalogBundle {
+  _RouteCatalogBundle({
+    required this.artifactIdentity,
+    required this.catalogDatabase,
+    required this.catalog,
+    required this.routeGraph,
+    required this.timetable,
+    required this.officialOdFares,
+    required this.runtimeState,
+    required this.ownsDatabase,
+  });
+
+  final String artifactIdentity;
+  final CatalogDatabase catalogDatabase;
+  final _RouteCatalogSnapshot catalog;
+  final graph.NetworkGraph routeGraph;
+  final _TimetableSnapshot timetable;
+  final Map<String, OfficialOdFareQuote> officialOdFares;
+  final bool ownsDatabase;
+  _RouteRuntimeState runtimeState;
+  late final Map<String, _NetworkEdgeSnapshot> _networkEdgesById = {
+    for (final edge in catalog.networkEdges) edge.id: edge,
+  };
+
+  graph.RouteEdge Function(graph.RouteEdge edge) edgeResolver(DateTime at) {
+    final state = runtimeState;
+    final nowSeconds = at.toUtc().millisecondsSinceEpoch ~/ 1000;
+    return (storedEdge) {
+      final sourceEdge = _networkEdgesById[storedEdge.sourceEdgeId];
+      if (sourceEdge == null || sourceEdge.facilityId.isEmpty) {
+        return storedEdge;
+      }
+      final effective = sourceEdge.resolveFacility(
+        state.facilityAt(sourceEdge.facilityId, nowSeconds),
+      );
+      return _toGraphRouteEdge(
+        effective,
+        storedEdge.type,
+        id: storedEdge.id,
+        fromNodeId: storedEdge.fromNodeId,
+        toNodeId: storedEdge.toNodeId,
+      );
+    };
+  }
+
+  Future<void> dispose() async {
+    if (ownsDatabase) {
+      await catalogDatabase.close();
+    }
+  }
+}
+
+class _RouteRuntimeState {
+  const _RouteRuntimeState({
+    required this.outOfStationTransferRuntimeEnabled,
+    required this.facilitiesById,
+    required this.statusSnapshotsByFacilityId,
+  });
+
+  final bool outOfStationTransferRuntimeEnabled;
+  final Map<String, _FacilitySnapshot> facilitiesById;
+  final Map<String, List<_FacilityStatusSnapshot>> statusSnapshotsByFacilityId;
+
+  static Future<_RouteRuntimeState> load(CatalogDatabase database) async {
+    final runtimeRow = await database.customSelect('''
+      SELECT value
+      FROM catalog_metadata
+      WHERE key = 'route.outOfStationTransfer.runtimeEnabled'
+      LIMIT 1
+      ''').getSingleOrNull();
+    final operationalStatusSql = _selectFacilityColumn(
+      database.routeFacilityColumnNames,
+      'operational_status',
+      'NULL',
+    );
+    final hasDataQualityRecords = await _tableExists(
+      database,
+      'data_quality_records',
+    );
+    final rows = await database
+        .customSelect(
+          hasDataQualityRecords
+              ? '''
+          SELECT f.id, f.station_id, f.type, f.status,
+                 $operationalStatusSql AS operational_status,
+                 (
+                   SELECT q.quality_level FROM data_quality_records q
+                   WHERE UPPER(q.target_type) = 'FACILITY' AND q.target_id = f.id
+                   ORDER BY q.checked_at IS NULL, q.checked_at DESC, q.id DESC
+                   LIMIT 1
+                 ) AS quality_level,
+                 (
+                   SELECT q.checked_at FROM data_quality_records q
+                   WHERE UPPER(q.target_type) = 'FACILITY' AND q.target_id = f.id
+                   ORDER BY q.checked_at IS NULL, q.checked_at DESC, q.id DESC
+                   LIMIT 1
+                 ) AS checked_at
+          FROM facilities f ORDER BY f.id
+          '''
+              : '''
+          SELECT f.id, f.station_id, f.type, f.status,
+                 $operationalStatusSql AS operational_status,
+                 NULL AS quality_level, NULL AS checked_at
+          FROM facilities f ORDER BY f.id
+          ''',
+        )
+        .get();
+    return _RouteRuntimeState(
+      outOfStationTransferRuntimeEnabled:
+          runtimeRow?.read<String>('value').toLowerCase() != 'false',
+      facilitiesById: {
+        for (final row in rows)
+          row.read<String>('id'): _FacilitySnapshot(
+            id: row.read<String>('id'),
+            stationId: row.read<String>('station_id'),
+            type: row.read<String>('type'),
+            status: row.read<String>('status'),
+            operationalStatus: row.readNullable<String>('operational_status'),
+            qualityLevel: row.readNullable<String>('quality_level'),
+            checkedAtSeconds: row.readNullable<int>('checked_at'),
+            activeStatusSnapshot: null,
+            expiredStatusSnapshot: null,
+          ),
+      },
+      statusSnapshotsByFacilityId: await _allFacilityStatusSnapshots(database),
+    );
+  }
+
+  _FacilitySnapshot? facilityAt(String facilityId, int nowSeconds) {
+    final base = facilitiesById[facilityId];
+    if (base == null) {
+      return null;
+    }
+    _FacilityStatusSnapshot? active;
+    _FacilityStatusSnapshot? expired;
+    for (final snapshot
+        in statusSnapshotsByFacilityId[facilityId] ??
+            const <_FacilityStatusSnapshot>[]) {
+      if (snapshot.isExpiredAt(nowSeconds)) {
+        if (expired == null ||
+            _compareFacilityStatusSnapshot(snapshot, expired) > 0) {
+          expired = snapshot;
+        }
+      } else if (active == null ||
+          _compareFacilityStatusSnapshot(snapshot, active) > 0) {
+        active = snapshot;
+      }
+    }
+    return base.copyWithStatusSnapshots(
+      activeStatusSnapshot: active,
+      expiredStatusSnapshot: expired,
+    );
+  }
+}
+
+class _TimetableSnapshot {
+  const _TimetableSnapshot({
+    required this.calendarsByServiceId,
+    required this.exceptionsByDate,
+    required this.tripsByBoardStationLine,
+  });
+
+  final Map<String, _ServiceCalendarSnapshot> calendarsByServiceId;
+  final Map<String, Map<String, int>> exceptionsByDate;
+  final Map<String, List<_TimetableTripSnapshot>> tripsByBoardStationLine;
+
+  static Future<_TimetableSnapshot> load(CatalogDatabase database) async {
+    final calendarRows = await database.customSelect('''
+      SELECT service_id, monday, tuesday, wednesday, thursday, friday,
+             saturday, sunday, start_date, end_date
+      FROM service_calendars
+      ''').get();
+    final exceptionRows = await database.customSelect('''
+      SELECT service_id, date, exception_type FROM service_calendar_dates
+      ''').get();
+    final tripRows = await database.customSelect('''
+      SELECT trip.id, trip.service_id, trip.service_pattern, route.line_id
+      FROM transit_trips trip
+      INNER JOIN transit_routes route ON route.id = trip.route_id
+      WHERE trip.service_class = 'SUBWAY'
+      ORDER BY trip.id
+      ''').get();
+    final stopRows = await database.customSelect('''
+      SELECT trip_id, stop_sequence, station_id, line_id, arrival_seconds,
+             departure_seconds, pickup_type, drop_off_type
+      FROM transit_stop_times
+      ORDER BY trip_id, stop_sequence
+      ''').get();
+    final stopsByTripId = <String, List<_TimetableStopSnapshot>>{};
+    for (final row in stopRows) {
+      stopsByTripId
+          .putIfAbsent(row.read<String>('trip_id'), () => [])
+          .add(
+            _TimetableStopSnapshot(
+              stationId: row.read<String>('station_id'),
+              lineId: row.read<String>('line_id'),
+              arrivalSeconds: row.read<int>('arrival_seconds'),
+              departureSeconds: row.read<int>('departure_seconds'),
+              pickupType: row.read<int>('pickup_type'),
+              dropOffType: row.read<int>('drop_off_type'),
+            ),
+          );
+    }
+    final byBoard = <String, List<_TimetableTripSnapshot>>{};
+    for (final row in tripRows) {
+      final trip = _TimetableTripSnapshot(
+        id: row.read<String>('id'),
+        serviceId: row.read<String>('service_id'),
+        lineId: row.read<String>('line_id'),
+        servicePattern: row.read<String>('service_pattern'),
+        stops: List.unmodifiable(
+          stopsByTripId[row.read<String>('id')] ?? const [],
+        ),
+      );
+      final indexedKeys = <String>{};
+      for (final stop in trip.stops) {
+        if (stop.pickupType == 1) continue;
+        final key = _stationLineKey(stop.stationId, stop.lineId);
+        if (indexedKeys.add(key)) {
+          byBoard.putIfAbsent(key, () => []).add(trip);
+        }
+      }
+    }
+    final exceptions = <String, Map<String, int>>{};
+    for (final row in exceptionRows) {
+      exceptions.putIfAbsent(row.read<String>('date'), () => {})[row
+          .read<String>('service_id')] = row.read<int>(
+        'exception_type',
+      );
+    }
+    return _TimetableSnapshot(
+      calendarsByServiceId: {
+        for (final row in calendarRows)
+          row.read<String>('service_id'): _ServiceCalendarSnapshot(
+            weekdays: [
+              row.read<int>('monday') != 0,
+              row.read<int>('tuesday') != 0,
+              row.read<int>('wednesday') != 0,
+              row.read<int>('thursday') != 0,
+              row.read<int>('friday') != 0,
+              row.read<int>('saturday') != 0,
+              row.read<int>('sunday') != 0,
+            ],
+            startDate: row.read<String>('start_date'),
+            endDate: row.read<String>('end_date'),
+          ),
+      },
+      exceptionsByDate: {
+        for (final entry in exceptions.entries)
+          entry.key: Map.unmodifiable(entry.value),
+      },
+      tripsByBoardStationLine: {
+        for (final entry in byBoard.entries)
+          entry.key: List.unmodifiable(entry.value),
+      },
+    );
+  }
+
+  DateTime? nextArrival({
+    required String fromStationId,
+    required String toStationId,
+    required String lineId,
+    required String servicePattern,
+    required DateTime cursor,
+  }) {
+    final koreaNow = cursor.toUtc().add(const Duration(hours: 9));
+    var firstServiceDate = DateTime.utc(
+      koreaNow.year,
+      koreaNow.month,
+      koreaNow.day,
+    );
+    if (koreaNow.hour < 3) {
+      firstServiceDate = firstServiceDate.subtract(const Duration(days: 1));
+    }
+    final candidates =
+        tripsByBoardStationLine[_stationLineKey(fromStationId, lineId)] ??
+        const <_TimetableTripSnapshot>[];
+    for (var dayOffset = 0; dayOffset <= 7; dayOffset += 1) {
+      final serviceDate = firstServiceDate.add(Duration(days: dayOffset));
+      final serviceMidnight = serviceDate.subtract(const Duration(hours: 9));
+      final startMicroseconds = cursor
+          .difference(serviceMidnight)
+          .inMicroseconds;
+      final startSeconds = startMicroseconds <= 0
+          ? 0
+          : (startMicroseconds + Duration.microsecondsPerSecond - 1) ~/
+                Duration.microsecondsPerSecond;
+      int? bestDeparture;
+      int? bestArrival;
+      String? bestTripId;
+      for (final trip in candidates) {
+        if (trip.lineId != lineId ||
+            (servicePattern.isNotEmpty &&
+                trip.servicePattern != servicePattern) ||
+            !_serviceRuns(trip.serviceId, serviceDate)) {
+          continue;
+        }
+        for (var fromIndex = 0; fromIndex < trip.stops.length; fromIndex += 1) {
+          final board = trip.stops[fromIndex];
+          if (board.stationId != fromStationId ||
+              board.lineId != lineId ||
+              board.pickupType == 1 ||
+              board.departureSeconds < startSeconds) {
+            continue;
+          }
+          for (
+            var toIndex = fromIndex + 1;
+            toIndex < trip.stops.length;
+            toIndex += 1
+          ) {
+            final alight = trip.stops[toIndex];
+            if (alight.stationId != toStationId ||
+                alight.lineId != lineId ||
+                alight.dropOffType == 1) {
+              continue;
+            }
+            final isBetter =
+                bestDeparture == null ||
+                board.departureSeconds < bestDeparture ||
+                (board.departureSeconds == bestDeparture &&
+                    (alight.arrivalSeconds < bestArrival! ||
+                        (alight.arrivalSeconds == bestArrival &&
+                            trip.id.compareTo(bestTripId!) < 0)));
+            if (isBetter) {
+              bestDeparture = board.departureSeconds;
+              bestArrival = alight.arrivalSeconds;
+              bestTripId = trip.id;
+            }
+          }
+        }
+      }
+      if (bestArrival != null) {
+        return serviceMidnight.add(Duration(seconds: bestArrival));
+      }
+    }
+    return null;
+  }
+
+  bool _serviceRuns(String serviceId, DateTime serviceDate) {
+    final date = _compactDate(serviceDate);
+    final exception = exceptionsByDate[date]?[serviceId];
+    if (exception == 1) return true;
+    if (exception == 2) return false;
+    final calendar = calendarsByServiceId[serviceId];
+    return calendar != null &&
+        date.compareTo(calendar.startDate) >= 0 &&
+        date.compareTo(calendar.endDate) <= 0 &&
+        calendar.weekdays[serviceDate.weekday - 1];
+  }
+}
+
+class _ServiceCalendarSnapshot {
+  const _ServiceCalendarSnapshot({
+    required this.weekdays,
+    required this.startDate,
+    required this.endDate,
+  });
+  final List<bool> weekdays;
+  final String startDate;
+  final String endDate;
+}
+
+class _TimetableTripSnapshot {
+  const _TimetableTripSnapshot({
+    required this.id,
+    required this.serviceId,
+    required this.lineId,
+    required this.servicePattern,
+    required this.stops,
+  });
+  final String id;
+  final String serviceId;
+  final String lineId;
+  final String servicePattern;
+  final List<_TimetableStopSnapshot> stops;
+}
+
+class _TimetableStopSnapshot {
+  const _TimetableStopSnapshot({
+    required this.stationId,
+    required this.lineId,
+    required this.arrivalSeconds,
+    required this.departureSeconds,
+    required this.pickupType,
+    required this.dropOffType,
+  });
+  final String stationId;
+  final String lineId;
+  final int arrivalSeconds;
+  final int departureSeconds;
+  final int pickupType;
+  final int dropOffType;
+}
+
 class _RouteCatalogSnapshot {
   const _RouteCatalogSnapshot({
     required this.stationsById,
@@ -1269,10 +1637,7 @@ class _RouteCatalogSnapshot {
   /// 로컬 catalog에 station_car_door_hints가 있을 때만 채워진다.
   final Map<String, List<_CarDoorHintSnapshot>> carDoorHintsByStationLine;
 
-  static Future<_RouteCatalogSnapshot> load(
-    CatalogDatabase database, {
-    FutureOr<void> Function(String event)? buildObserver,
-  }) async {
+  static Future<_RouteCatalogSnapshot> load(CatalogDatabase database) async {
     final sourceUpdatedAtRow = await database.customSelect('''
           SELECT MAX(CAST(updated_at AS INTEGER)) AS source_updated_at
           FROM catalog_metadata
@@ -1363,13 +1728,7 @@ class _RouteCatalogSnapshot {
             );
       }
     }
-    await buildObserver?.call('schema');
-    final networkEdgeColumns = await database
-        .customSelect('PRAGMA table_info(network_edges)')
-        .get();
-    final networkEdgeColumnNames = {
-      for (final row in networkEdgeColumns) row.read<String>('name'),
-    };
+    final networkEdgeColumnNames = database.routeNetworkEdgeColumnNames;
     final servicePatternSql = _selectNetworkEdgeColumn(
       networkEdgeColumnNames,
       'service_pattern',
@@ -1448,13 +1807,7 @@ class _RouteCatalogSnapshot {
         networkEdgeColumnNames.contains('service_class')
         ? "WHERE service_class = 'SUBWAY'"
         : '';
-    await buildObserver?.call('schema');
-    final facilityColumns = await database
-        .customSelect('PRAGMA table_info(facilities)')
-        .get();
-    final facilityColumnNames = {
-      for (final row in facilityColumns) row.read<String>('name'),
-    };
+    final facilityColumnNames = database.routeFacilityColumnNames;
     final operationalStatusSql = _selectFacilityColumn(
       facilityColumnNames,
       'operational_status',
@@ -1590,6 +1943,9 @@ class _RouteCatalogSnapshot {
             includesStairs: row.read<int>('includes_stairs') != 0,
             stairAccessState: row.read<String>('stair_access_state'),
             accessibilityStatus: effectiveAccessibilityStatus,
+            rawAccessibilityStatus: accessibilityStatus,
+            facilityId: facility?.id ?? '',
+            facilityHasEligibleEvidence: facilityHasEligibleEvidence,
             isUnderMaintenance: _effectiveIsUnderMaintenance(
               accessibilityStatus,
               effectiveAccessibilityStatus,
@@ -1598,34 +1954,42 @@ class _RouteCatalogSnapshot {
               reliabilityScore,
               facility,
             ),
+            baseReliabilityScore: reliabilityScore,
             lastVerifiedAtSeconds: _effectiveLastVerifiedAtSeconds(
               lastVerifiedAtSeconds,
               facility,
             ),
+            baseLastVerifiedAtSeconds: lastVerifiedAtSeconds,
             sourceId:
                 facility?.activeStatusSnapshot?.sourceId ??
                 row.read<String>('source_id'),
+            baseSourceId: row.read<String>('source_id'),
             sourceSnapshotId:
                 facility?.activeStatusSnapshot?.sourceSnapshotId ??
                 row.read<String>('source_snapshot_id'),
+            baseSourceSnapshotId: row.read<String>('source_snapshot_id'),
             providerRecordHash:
                 facility?.activeStatusSnapshot?.providerRecordHash ??
                 row.read<String>('provider_record_hash'),
+            baseProviderRecordHash: row.read<String>('provider_record_hash'),
             provenanceKind:
                 facility?.activeStatusSnapshot?.provenanceKind ??
                 row.read<String>('provenance_kind'),
+            baseProvenanceKind: row.read<String>('provenance_kind'),
             verificationStatus:
                 facility?.activeStatusSnapshot?.verificationStatus ??
                 row.read<String>('verification_status'),
+            baseVerificationStatus: row.read<String>('verification_status'),
             evidenceHash:
                 facility?.activeStatusSnapshot?.evidenceHash ??
                 row.read<String>('evidence_hash'),
+            baseEvidenceHash: row.read<String>('evidence_hash'),
           );
         })
         .where(
           (edge) =>
               edge.routeEdgeType != graph.RouteEdgeType.outOfStationTransfer ||
-              outOfStationTransferPolicy.allows(edge),
+              outOfStationTransferPolicy.allowsDeployment(edge),
         )
         .toList(growable: false);
     final strictEvidenceSupported =
@@ -1685,10 +2049,14 @@ class _RouteCatalogSnapshot {
     required local.RouteSearchMode searchMode,
     required local.MobilityType mobilityType,
     required local.ConstraintMode constraintMode,
+    graph.RouteEdge Function(graph.RouteEdge edge)? edgeResolver,
   }) {
     originStationId = canonicalStationId(originStationId);
     destinationStationId = canonicalStationId(destinationStationId);
-    return LocalRouteEngine(graph: routeGraph).search(
+    return LocalRouteEngine(
+      graph: routeGraph,
+      edgeResolver: edgeResolver,
+    ).search(
       local.RouteRequest(
         originStationId: originStationId,
         destinationStationId: destinationStationId,
@@ -1704,6 +2072,7 @@ class _RouteCatalogSnapshot {
     String destinationStationId, {
     required graph.NetworkGraph routeGraph,
     required local.RouteSearchMode searchMode,
+    graph.RouteEdge Function(graph.RouteEdge edge)? edgeResolver,
   }) {
     if (!strictEvidenceSupported) {
       return false;
@@ -1713,6 +2082,7 @@ class _RouteCatalogSnapshot {
           destinationStationId,
           routeGraph: routeGraph,
           searchMode: searchMode,
+          edgeResolver: edgeResolver,
           mobilityType: local.MobilityType.wheelchair,
           constraintMode: local.ConstraintMode.strictStepFree,
         ).status ==
@@ -2142,12 +2512,10 @@ String _metadataUpdatedAtIso(int? updatedAtMillis) {
 class _OutOfStationTransferPolicy {
   const _OutOfStationTransferPolicy({
     required this.enabled,
-    required this.runtimeEnabled,
     required this.allowlist,
   });
 
   final bool enabled;
-  final bool runtimeEnabled;
   final Set<String> allowlist;
 
   static Future<_OutOfStationTransferPolicy> load(
@@ -2158,7 +2526,6 @@ class _OutOfStationTransferPolicy {
       FROM catalog_metadata
       WHERE key IN (
         'route.outOfStationTransfer.enabled',
-        'route.outOfStationTransfer.runtimeEnabled',
         'route.outOfStationTransfer.allowlist'
       )
     ''').get();
@@ -2169,18 +2536,14 @@ class _OutOfStationTransferPolicy {
     return _OutOfStationTransferPolicy(
       enabled:
           values['route.outOfStationTransfer.enabled']?.toLowerCase() == 'true',
-      runtimeEnabled:
-          values['route.outOfStationTransfer.runtimeEnabled']?.toLowerCase() !=
-          'false',
       allowlist: _parseOutOfStationTransferAllowlist(
         values['route.outOfStationTransfer.allowlist'] ?? '',
       ),
     );
   }
 
-  bool allows(_NetworkEdgeSnapshot edge) {
+  bool allowsDeployment(_NetworkEdgeSnapshot edge) {
     return enabled &&
-        runtimeEnabled &&
         allowlist.contains(_edgePairKey(edge.fromNodeId, edge.toNodeId));
   }
 }
@@ -2303,6 +2666,10 @@ String _stationLineKey(String stationId, String lineId) {
   return '$stationId:$lineId';
 }
 
+String _officialFareKey(String originStationId, String destinationStationId) {
+  return '$originStationId->$destinationStationId';
+}
+
 int _carDoorFacilityPriority(String facilityType) {
   return switch (facilityType.toUpperCase()) {
     'ELEVATOR' => 0,
@@ -2328,6 +2695,7 @@ graph.RouteEdge _toGraphRouteEdge(
   // weight so the graph remains searchable.
   return graph.RouteEdge(
     id: id ?? networkEdge.id,
+    sourceEdgeId: networkEdge.id,
     fromNodeId: effectiveFromNodeId,
     toNodeId: toNodeId ?? networkEdge.toNodeId,
     type: routeEdgeType,
@@ -2364,19 +2732,6 @@ int _estimatedMinutesFor(int durationSeconds) {
 String _compactDate(DateTime date) {
   String twoDigits(int value) => value.toString().padLeft(2, '0');
   return '${date.year}${twoDigits(date.month)}${twoDigits(date.day)}';
-}
-
-String _weekdayColumn(int weekday) {
-  return switch (weekday) {
-    DateTime.monday => 'monday',
-    DateTime.tuesday => 'tuesday',
-    DateTime.wednesday => 'wednesday',
-    DateTime.thursday => 'thursday',
-    DateTime.friday => 'friday',
-    DateTime.saturday => 'saturday',
-    DateTime.sunday => 'sunday',
-    _ => throw ArgumentError.value(weekday, 'weekday'),
-  };
 }
 
 String _koreaIso(DateTime instant) {
@@ -2724,6 +3079,45 @@ Future<_FacilityStatusSnapshotIndex> _facilityStatusSnapshots(
   );
 }
 
+Future<Map<String, List<_FacilityStatusSnapshot>>> _allFacilityStatusSnapshots(
+  CatalogDatabase database,
+) async {
+  if (!await _tableExists(database, 'facility_status_snapshots')) {
+    return const {};
+  }
+  final rows = await database.customSelect('''
+        SELECT facility_id, provider_id, source_id, source_snapshot_id,
+               provider_record_hash, evidence_hash, provenance_kind,
+               verification_status, status, operational_status, confidence,
+               observed_at, expires_at
+        FROM facility_status_snapshots
+        ORDER BY facility_id
+        ''').get();
+  final byFacilityId = <String, List<_FacilityStatusSnapshot>>{};
+  for (final row in rows) {
+    final snapshot = _FacilityStatusSnapshot(
+      facilityId: row.read<String>('facility_id'),
+      providerId: row.read<String>('provider_id'),
+      sourceId: row.read<String>('source_id'),
+      sourceSnapshotId: row.read<String>('source_snapshot_id'),
+      providerRecordHash: row.read<String>('provider_record_hash'),
+      evidenceHash: row.read<String>('evidence_hash'),
+      provenanceKind: row.read<String>('provenance_kind'),
+      verificationStatus: row.read<String>('verification_status'),
+      status: row.read<String>('status'),
+      operationalStatus: row.read<String>('operational_status'),
+      confidence: row.read<int>('confidence'),
+      observedAtSeconds: row.readNullable<int>('observed_at'),
+      expiresAtSeconds: row.readNullable<int>('expires_at'),
+    );
+    byFacilityId.putIfAbsent(snapshot.facilityId, () => []).add(snapshot);
+  }
+  return {
+    for (final entry in byFacilityId.entries)
+      entry.key: List.unmodifiable(entry.value),
+  };
+}
+
 int _compareFacilityStatusSnapshot(
   _FacilityStatusSnapshot left,
   _FacilityStatusSnapshot right,
@@ -2891,14 +3285,25 @@ class _NetworkEdgeSnapshot {
     required this.includesStairs,
     required this.stairAccessState,
     required this.accessibilityStatus,
+    required this.rawAccessibilityStatus,
+    required this.facilityId,
+    required this.facilityHasEligibleEvidence,
     required this.reliabilityScore,
+    required this.baseReliabilityScore,
     required this.lastVerifiedAtSeconds,
+    required this.baseLastVerifiedAtSeconds,
     required this.sourceId,
+    required this.baseSourceId,
     required this.sourceSnapshotId,
+    required this.baseSourceSnapshotId,
     required this.providerRecordHash,
+    required this.baseProviderRecordHash,
     required this.provenanceKind,
+    required this.baseProvenanceKind,
     required this.verificationStatus,
+    required this.baseVerificationStatus,
     required this.evidenceHash,
+    required this.baseEvidenceHash,
     this.isUnderMaintenance = false,
   });
 
@@ -2912,17 +3317,88 @@ class _NetworkEdgeSnapshot {
   final bool includesStairs;
   final String stairAccessState;
   final String accessibilityStatus;
+  final String rawAccessibilityStatus;
+  final String facilityId;
+  final bool facilityHasEligibleEvidence;
   final int reliabilityScore;
+  final int baseReliabilityScore;
   final int? lastVerifiedAtSeconds;
+  final int? baseLastVerifiedAtSeconds;
   final String sourceId;
+  final String baseSourceId;
   final String sourceSnapshotId;
+  final String baseSourceSnapshotId;
   final String providerRecordHash;
+  final String baseProviderRecordHash;
   final String provenanceKind;
+  final String baseProvenanceKind;
   final String verificationStatus;
+  final String baseVerificationStatus;
   final String evidenceHash;
+  final String baseEvidenceHash;
 
   /// 정직 표시: 이 edge의 비가용이 실측 보수중에서 비롯됐는지(#1996).
   final bool isUnderMaintenance;
+
+  _NetworkEdgeSnapshot resolveFacility(_FacilitySnapshot? facility) {
+    if (facilityId.isEmpty || facility == null) {
+      return this;
+    }
+    final effectiveAccessibilityStatus = _effectiveAccessibilityStatus(
+      rawAccessibilityStatus,
+      facility,
+      facilityHasEligibleEvidence,
+    );
+    return _NetworkEdgeSnapshot(
+      id: id,
+      fromNodeId: fromNodeId,
+      toNodeId: toNodeId,
+      durationSeconds: durationSeconds,
+      distanceMeters: distanceMeters,
+      edgeType: edgeType,
+      servicePattern: servicePattern,
+      includesStairs: includesStairs,
+      stairAccessState: stairAccessState,
+      accessibilityStatus: effectiveAccessibilityStatus,
+      rawAccessibilityStatus: rawAccessibilityStatus,
+      facilityId: facilityId,
+      facilityHasEligibleEvidence: facilityHasEligibleEvidence,
+      reliabilityScore: _effectiveReliabilityScore(
+        baseReliabilityScore,
+        facility,
+      ),
+      baseReliabilityScore: baseReliabilityScore,
+      lastVerifiedAtSeconds: _effectiveLastVerifiedAtSeconds(
+        baseLastVerifiedAtSeconds,
+        facility,
+      ),
+      baseLastVerifiedAtSeconds: baseLastVerifiedAtSeconds,
+      sourceId: facility.activeStatusSnapshot?.sourceId ?? baseSourceId,
+      baseSourceId: baseSourceId,
+      sourceSnapshotId:
+          facility.activeStatusSnapshot?.sourceSnapshotId ??
+          baseSourceSnapshotId,
+      baseSourceSnapshotId: baseSourceSnapshotId,
+      providerRecordHash:
+          facility.activeStatusSnapshot?.providerRecordHash ??
+          baseProviderRecordHash,
+      baseProviderRecordHash: baseProviderRecordHash,
+      provenanceKind:
+          facility.activeStatusSnapshot?.provenanceKind ?? baseProvenanceKind,
+      baseProvenanceKind: baseProvenanceKind,
+      verificationStatus:
+          facility.activeStatusSnapshot?.verificationStatus ??
+          baseVerificationStatus,
+      baseVerificationStatus: baseVerificationStatus,
+      evidenceHash:
+          facility.activeStatusSnapshot?.evidenceHash ?? baseEvidenceHash,
+      baseEvidenceHash: baseEvidenceHash,
+      isUnderMaintenance: _effectiveIsUnderMaintenance(
+        rawAccessibilityStatus,
+        effectiveAccessibilityStatus,
+      ),
+    );
+  }
 
   graph.RouteEdgeType? get routeEdgeType =>
       graph.routeEdgeTypeFromCatalogValue(edgeType);

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -37,7 +37,7 @@ class LocalRouteRepository implements RouteSearchRepository {
   final FutureOr<void> Function(String event)? routeRuntimeRefreshObserver;
   _RouteCatalogBundle? _activeBundle;
   Future<_RouteCatalogBundle>? _routeCatalogBundleFuture;
-  Future<void> _activationQueue = Future<void>.value();
+  Future<void> _lifecycleQueue = Future<void>.value();
   final Set<Future<void>> _inFlightActivations = {};
   final Set<Future<void>> _inFlightRuntimeRefreshes = {};
   final Set<_RouteCatalogBundle> _retiredBundles = {};
@@ -122,16 +122,12 @@ class LocalRouteRepository implements RouteSearchRepository {
       return _rejectClosedActivation(catalogDatabase, ownsDatabase);
     }
     late final Future<void> activation;
-    activation = _activationQueue.then(
-      (_) => _activateDataPack(
+    activation = _enqueueLifecycleOperation(
+      () => _activateDataPack(
         catalogDatabase: catalogDatabase,
         artifactIdentity: artifactIdentity,
         ownsDatabase: ownsDatabase,
       ),
-    );
-    _activationQueue = activation.then<void>(
-      (_) {},
-      onError: (Object _, StackTrace _) {},
     );
     _inFlightActivations.add(activation);
     return activation.whenComplete(() {
@@ -200,7 +196,6 @@ class LocalRouteRepository implements RouteSearchRepository {
       await candidate.dispose();
       return;
     }
-    await _waitForRuntimeRefreshes();
     if (_isClosed || activation != _activationSequence) {
       await candidate.dispose();
       return;
@@ -235,7 +230,10 @@ class LocalRouteRepository implements RouteSearchRepository {
       return Future.error(StateError('LocalRouteRepository is closed.'));
     }
     late final Future<void> refresh;
-    refresh = _refreshRuntimeState();
+    refresh = _enqueueLifecycleOperation(() {
+      if (_isClosed) return Future<void>.value();
+      return _refreshRuntimeState();
+    });
     _inFlightRuntimeRefreshes.add(refresh);
     return refresh.whenComplete(() {
       _inFlightRuntimeRefreshes.remove(refresh);
@@ -248,17 +246,27 @@ class LocalRouteRepository implements RouteSearchRepository {
     bundle.runtimeState = await _RouteRuntimeState.load(bundle.catalogDatabase);
   }
 
+  Future<void> _enqueueLifecycleOperation(Future<void> Function() operation) {
+    final queued = _lifecycleQueue.then((_) => operation());
+    _lifecycleQueue = queued.then<void>(
+      (_) {},
+      onError: (Object _, StackTrace _) {},
+    );
+    return queued;
+  }
+
   Future<void> _waitForRuntimeRefreshes() async {
     while (_inFlightRuntimeRefreshes.isNotEmpty) {
       final pending = _inFlightRuntimeRefreshes.toList(growable: false);
       await Future.wait(
-        pending.map((refresh) async {
-          try {
-            await refresh;
-          } catch (_) {
-            // 호출자에게 전달되는 refresh 오류가 lifecycle 정리를 막지는 않는다.
-          }
-        }),
+        pending.map(
+          (refresh) => refresh.then<void>(
+            (_) {},
+            onError: (Object error, StackTrace stackTrace) {
+              // 호출자에게 전달되는 refresh 오류가 lifecycle 정리를 막지는 않는다.
+            },
+          ),
+        ),
       );
     }
   }

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -126,11 +126,11 @@ class LocalRouteRepository implements RouteSearchRepository {
         ),
         ownsDatabase: ownsDatabase,
       );
-    } catch (_) {
+    } catch (error, stackTrace) {
       if (ownsDatabase) {
         await catalogDatabase.close();
       }
-      rethrow;
+      Error.throwWithStackTrace(error, stackTrace);
     }
     if (activation != _activationSequence) {
       await candidate.dispose();

--- a/apps/mobile/test/core/database/mobile_local_database_test.dart
+++ b/apps/mobile/test/core/database/mobile_local_database_test.dart
@@ -4,7 +4,9 @@ import 'dart:io';
 
 import 'package:crypto/crypto.dart';
 import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
 import 'package:easysubway_mobile/app/app_bootstrap.dart';
+import 'package:easysubway_mobile/app/app_dependencies.dart';
 import 'package:easysubway_mobile/core/database/catalog/catalog_database.dart';
 import 'package:easysubway_mobile/core/database/catalog/catalog_database_opener.dart';
 import 'package:easysubway_mobile/core/database/user/user_database.dart';
@@ -41,6 +43,47 @@ void main() {
 
     await closeCalled.future;
     expect(closeCalled.isCompleted, isTrue);
+  });
+
+  test('route repository close가 실패해도 bootstrap은 나머지 DB를 닫는다', () async {
+    final catalogDatabase = _CloseTrackingCatalogDatabase();
+    final userDatabase = _CloseTrackingUserDatabase();
+    addTearDown(() async {
+      if (catalogDatabase.closeCount == 0) await catalogDatabase.close();
+      if (userDatabase.closeCount == 0) await userDatabase.close();
+    });
+    final localRouteRepository = _AlwaysCloseFailingLocalRouteRepository(
+      catalogDatabase,
+    );
+    final bootstrap = AppBootstrap(
+      dependencies: AppDependencies.resolve(
+        catalogDatabase: catalogDatabase,
+        userDatabase: userDatabase,
+        localRouteRepository: localRouteRepository,
+        enablePushNotifications: false,
+      ),
+      catalogDatabase: catalogDatabase,
+      userDatabase: userDatabase,
+      dataPackUpdate: Future<void>.value(),
+      resumeDataPackUpdate: () async {},
+      acceptMeteredDataPackUpdate: () async {},
+      bundledDataPackFreshness: null,
+      localRouteRepository: localRouteRepository,
+    );
+
+    await expectLater(
+      bootstrap.close(),
+      throwsA(
+        isA<StateError>().having(
+          (error) => error.message,
+          'message',
+          'route repository close failed',
+        ),
+      ),
+    );
+
+    expect(catalogDatabase.closeCount, 1);
+    expect(userDatabase.closeCount, 1);
   });
 
   testWidgets('앱 lifecycle은 resumed에서 데이터팩 foreground update를 요청한다', (
@@ -1757,6 +1800,41 @@ void main() {
     expect(receipts.single.receiptId, 'receipt-migration-1');
     expect(receipts.single.reportId, 'report-migration-1');
   });
+}
+
+final class _CloseTrackingCatalogDatabase extends CatalogDatabase {
+  _CloseTrackingCatalogDatabase() : super(NativeDatabase.memory());
+
+  var closeCount = 0;
+
+  @override
+  Future<void> close() async {
+    closeCount += 1;
+    await super.close();
+  }
+}
+
+final class _CloseTrackingUserDatabase extends UserDatabase {
+  _CloseTrackingUserDatabase() : super(NativeDatabase.memory());
+
+  var closeCount = 0;
+
+  @override
+  Future<void> close() async {
+    closeCount += 1;
+    await super.close();
+  }
+}
+
+final class _AlwaysCloseFailingLocalRouteRepository
+    extends LocalRouteRepository {
+  _AlwaysCloseFailingLocalRouteRepository(CatalogDatabase catalogDatabase)
+    : super(catalogDatabase: catalogDatabase);
+
+  @override
+  Future<void> close() async {
+    throw StateError('route repository close failed');
+  }
 }
 
 class _RequestCountingHttpClient implements HttpClient {

--- a/apps/mobile/test/core/database/mobile_local_database_test.dart
+++ b/apps/mobile/test/core/database/mobile_local_database_test.dart
@@ -1232,11 +1232,12 @@ void main() {
     finishUpdate.complete();
     await bootstrap.dataPackUpdate;
 
-    final activeRouteDatabase = bootstrap.localRouteRepository!.catalogDatabase;
-    final activePack = await activeRouteDatabase.customSelect('''
+    final sessionRouteDatabase =
+        bootstrap.localRouteRepository!.catalogDatabase;
+    final activePack = await sessionRouteDatabase.customSelect('''
       SELECT value FROM catalog_metadata WHERE key = 'activePack'
       ''').getSingle();
-    expect(activePack.read<String>('value'), 'capital-v19');
+    expect(activePack.read<String>('value'), 'capital');
   });
 
   test('앱 부트스트랩은 설치된 current pack의 manifest expiry를 stale 상태로 전달한다', () async {

--- a/apps/mobile/test/core/database/mobile_local_database_test.dart
+++ b/apps/mobile/test/core/database/mobile_local_database_test.dart
@@ -1210,7 +1210,9 @@ void main() {
                 'id': 'capital',
                 'version': '19',
                 'path': updatedPack.path,
-                'sha256': 'bootstrap-fixture',
+                'sha256': sha256
+                    .convert(await updatedPack.readAsBytes())
+                    .toString(),
               }),
             );
           },
@@ -1228,6 +1230,13 @@ void main() {
 
     expect(metadata.read<String>('value'), '1');
     finishUpdate.complete();
+    await bootstrap.dataPackUpdate;
+
+    final activeRouteDatabase = bootstrap.localRouteRepository!.catalogDatabase;
+    final activePack = await activeRouteDatabase.customSelect('''
+      SELECT value FROM catalog_metadata WHERE key = 'activePack'
+      ''').getSingle();
+    expect(activePack.read<String>('value'), 'capital-v19');
   });
 
   test('앱 부트스트랩은 설치된 current pack의 manifest expiry를 stale 상태로 전달한다', () async {

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -372,6 +372,196 @@ void main() {
     await oldDatabase.close();
   });
 
+  test(
+    'cold bundle을 기다리던 activation은 close 뒤 candidate build를 시작하지 않는다',
+    () async {
+      final initialDatabase = CatalogDatabase.memory();
+      final candidateDatabase = CatalogDatabase.memory();
+      await initialDatabase.seedBaselineIfEmpty();
+      await candidateDatabase.seedBaselineIfEmpty();
+      final coldBuildStarted = Completer<void>();
+      final releaseColdBuild = Completer<void>();
+      var snapshotBuildCount = 0;
+      final repository = LocalRouteRepository(
+        catalogDatabase: initialDatabase,
+        artifactIdentity: 'artifact-initial',
+        routeCatalogBuildObserver: (event) async {
+          if (event != 'snapshot') return;
+          snapshotBuildCount += 1;
+          if (snapshotBuildCount == 1) {
+            coldBuildStarted.complete();
+            await releaseColdBuild.future;
+          }
+        },
+      );
+
+      final coldSearch = repository.canSearchRoute(
+        const RouteSearchRequest(
+          originStationId: 'station-sangnoksu',
+          destinationStationId: 'station-sadang',
+          mobilityType: 'STANDARD',
+        ),
+      );
+      await coldBuildStarted.future;
+      final activation = repository.activateDataPack(
+        catalogDatabase: candidateDatabase,
+        artifactIdentity: 'artifact-candidate',
+        ownsDatabase: true,
+      );
+      final closing = repository.close();
+      releaseColdBuild.complete();
+
+      expect(await coldSearch, isTrue);
+      await activation;
+      await closing;
+      expect(snapshotBuildCount, 1);
+      await initialDatabase.close();
+    },
+  );
+
+  test('동일 artifact의 동시 activation은 candidate build 하나를 공유한다', () async {
+    final initialDatabase = CatalogDatabase.memory();
+    final firstCandidateDatabase = CatalogDatabase.memory();
+    final secondCandidateDatabase = CatalogDatabase.memory();
+    await initialDatabase.seedBaselineIfEmpty();
+    await firstCandidateDatabase.seedBaselineIfEmpty();
+    await secondCandidateDatabase.seedBaselineIfEmpty();
+    final candidateGraphStarted = Completer<void>();
+    final releaseCandidateGraph = Completer<void>();
+    var countCandidateBuilds = false;
+    var candidateSnapshotBuildCount = 0;
+    final repository = LocalRouteRepository(
+      catalogDatabase: initialDatabase,
+      artifactIdentity: 'artifact-initial',
+      routeCatalogBuildObserver: (event) async {
+        if (!countCandidateBuilds) return;
+        if (event == 'snapshot') candidateSnapshotBuildCount += 1;
+        if (event == 'graph') {
+          if (!candidateGraphStarted.isCompleted) {
+            candidateGraphStarted.complete();
+          }
+          await releaseCandidateGraph.future;
+        }
+      },
+    );
+    await repository.canSearchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-sangnoksu',
+        destinationStationId: 'station-sadang',
+        mobilityType: 'STANDARD',
+      ),
+    );
+    countCandidateBuilds = true;
+
+    final first = repository.activateDataPack(
+      catalogDatabase: firstCandidateDatabase,
+      artifactIdentity: 'artifact-shared',
+      ownsDatabase: true,
+    );
+    await candidateGraphStarted.future;
+    final second = repository.activateDataPack(
+      catalogDatabase: secondCandidateDatabase,
+      artifactIdentity: 'artifact-shared',
+      ownsDatabase: true,
+    );
+    await Future<void>.delayed(Duration.zero);
+    releaseCandidateGraph.complete();
+
+    await Future.wait([first, second]);
+    expect(candidateSnapshotBuildCount, 1);
+    await repository.close();
+    await initialDatabase.close();
+  });
+
+  test('close는 진행 중인 runtime refresh를 기다린 뒤 owned DB를 닫는다', () async {
+    final initialDatabase = CatalogDatabase.memory();
+    final activeDatabase = CatalogDatabase.memory();
+    await initialDatabase.seedBaselineIfEmpty();
+    await activeDatabase.seedBaselineIfEmpty();
+    final refreshStarted = Completer<void>();
+    final releaseRefresh = Completer<void>();
+    final repository = LocalRouteRepository(
+      catalogDatabase: initialDatabase,
+      artifactIdentity: 'artifact-initial',
+      routeRuntimeRefreshObserver: (event) async {
+        if (event != 'load') return;
+        refreshStarted.complete();
+        await releaseRefresh.future;
+      },
+    );
+    await repository.activateDataPack(
+      catalogDatabase: activeDatabase,
+      artifactIdentity: 'artifact-active',
+      ownsDatabase: true,
+    );
+
+    Object? refreshError;
+    final refresh = repository.refreshRuntimeState().catchError((Object error) {
+      refreshError = error;
+    });
+    await refreshStarted.future;
+    var closeCompleted = false;
+    final closing = repository.close().then((_) => closeCompleted = true);
+    await Future<void>.delayed(Duration.zero);
+    final completedBeforeRelease = closeCompleted;
+    releaseRefresh.complete();
+
+    await refresh;
+    await closing;
+    expect(completedBeforeRelease, isFalse);
+    expect(refreshError, isNull);
+    await initialDatabase.close();
+  });
+
+  test('artifact activation은 이전 owned DB의 runtime refresh를 기다린다', () async {
+    final initialDatabase = CatalogDatabase.memory();
+    final activeDatabase = CatalogDatabase.memory();
+    final candidateDatabase = CatalogDatabase.memory();
+    await initialDatabase.seedBaselineIfEmpty();
+    await activeDatabase.seedBaselineIfEmpty();
+    await candidateDatabase.seedBaselineIfEmpty();
+    final refreshStarted = Completer<void>();
+    final releaseRefresh = Completer<void>();
+    final repository = LocalRouteRepository(
+      catalogDatabase: initialDatabase,
+      artifactIdentity: 'artifact-initial',
+      routeRuntimeRefreshObserver: (event) async {
+        if (event != 'load') return;
+        refreshStarted.complete();
+        await releaseRefresh.future;
+      },
+    );
+    await repository.activateDataPack(
+      catalogDatabase: activeDatabase,
+      artifactIdentity: 'artifact-active',
+      ownsDatabase: true,
+    );
+
+    Object? refreshError;
+    final refresh = repository.refreshRuntimeState().catchError((Object error) {
+      refreshError = error;
+    });
+    await refreshStarted.future;
+    var activationCompleted = false;
+    final activation = repository
+        .activateDataPack(
+          catalogDatabase: candidateDatabase,
+          artifactIdentity: 'artifact-candidate',
+          ownsDatabase: true,
+        )
+        .then((_) => activationCompleted = true);
+    await Future<void>.delayed(Duration.zero);
+    final completedBeforeRelease = activationCompleted;
+    releaseRefresh.complete();
+
+    await refresh;
+    await activation;
+    expect(completedBeforeRelease, isFalse);
+    expect(refreshError, isNull);
+    await repository.close();
+    await initialDatabase.close();
+  });
+
   test('실패한 cold graph build는 부분 publish 없이 다음 호출에서 재시도한다', () async {
     final database = CatalogDatabase.memory();
     addTearDown(database.close);

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -562,6 +562,56 @@ void main() {
     await initialDatabase.close();
   });
 
+  test('activation 중 새 runtime refresh는 candidate 게시 뒤 실행한다', () async {
+    final initialDatabase = CatalogDatabase.memory();
+    final activeDatabase = CatalogDatabase.memory();
+    final candidateDatabase = CatalogDatabase.memory();
+    await initialDatabase.seedBaselineIfEmpty();
+    await activeDatabase.seedBaselineIfEmpty();
+    await candidateDatabase.seedBaselineIfEmpty();
+    final candidateGraphStarted = Completer<void>();
+    final releaseCandidateGraph = Completer<void>();
+    final refreshStarted = Completer<void>();
+    var blockCandidate = false;
+    final repository = LocalRouteRepository(
+      catalogDatabase: initialDatabase,
+      artifactIdentity: 'artifact-initial',
+      routeCatalogBuildObserver: (event) async {
+        if (blockCandidate && event == 'graph') {
+          candidateGraphStarted.complete();
+          await releaseCandidateGraph.future;
+        }
+      },
+      routeRuntimeRefreshObserver: (event) {
+        if (event == 'load') refreshStarted.complete();
+      },
+    );
+    await repository.activateDataPack(
+      catalogDatabase: activeDatabase,
+      artifactIdentity: 'artifact-active',
+      ownsDatabase: true,
+    );
+    blockCandidate = true;
+
+    final activation = repository.activateDataPack(
+      catalogDatabase: candidateDatabase,
+      artifactIdentity: 'artifact-candidate',
+      ownsDatabase: true,
+    );
+    await candidateGraphStarted.future;
+    final refresh = repository.refreshRuntimeState();
+    await Future<void>.delayed(Duration.zero);
+    final startedBeforeCandidatePublish = refreshStarted.isCompleted;
+    releaseCandidateGraph.complete();
+
+    await activation;
+    await refresh;
+    expect(startedBeforeCandidatePublish, isFalse);
+    expect(refreshStarted.isCompleted, isTrue);
+    await repository.close();
+    await initialDatabase.close();
+  });
+
   test('실패한 cold graph build는 부분 publish 없이 다음 호출에서 재시도한다', () async {
     final database = CatalogDatabase.memory();
     addTearDown(database.close);

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -109,6 +109,42 @@ void main() {
     expect((await repository.searchRoute(request)).originStationName, '새 상록수');
   });
 
+  test('cold artifact 교체는 기존 artifact bundle을 먼저 만들지 않는다', () async {
+    final oldDatabase = CatalogDatabase.memory();
+    final newDatabase = CatalogDatabase.memory();
+    addTearDown(oldDatabase.close);
+    addTearDown(newDatabase.close);
+    await oldDatabase.seedBaselineIfEmpty();
+    await newDatabase.seedBaselineIfEmpty();
+    var snapshotBuildCount = 0;
+    var graphBuildCount = 0;
+    final repository = LocalRouteRepository(
+      catalogDatabase: oldDatabase,
+      artifactIdentity: 'artifact-old',
+      routeCatalogBuildObserver: (event) {
+        if (event == 'snapshot') snapshotBuildCount += 1;
+        if (event == 'graph') graphBuildCount += 1;
+      },
+    );
+
+    await repository.activateDataPack(
+      catalogDatabase: newDatabase,
+      artifactIdentity: 'artifact-new',
+    );
+    final result = await repository.searchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-sangnoksu',
+        destinationStationId: 'station-sadang',
+        mobilityType: 'STANDARD',
+      ),
+    );
+
+    expect(result.status, 'FOUND');
+    expect(snapshotBuildCount, 1);
+    expect(graphBuildCount, 1);
+    expect(repository.catalogDatabase, same(newDatabase));
+  });
+
   test('동일 artifact identity의 route API는 snapshot과 graph를 한 번만 빌드한다', () async {
     final database = CatalogDatabase.memory();
     addTearDown(database.close);

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -14,8 +14,10 @@ import 'package:easysubway_mobile/features/fare/official_od_fare_quote.dart';
 import 'package:easysubway_mobile/features/get_off_alarm/get_off_alarm_route_mapping.dart';
 import 'package:easysubway_mobile/features/get_off_alarm/get_off_alarm_scheduler.dart';
 import 'package:easysubway_mobile/features/mobility_profile/mobility_profile_policy.dart';
+import 'package:easysubway_mobile/mobile_error_reporter.dart';
 import 'package:easysubway_mobile/route_search.dart';
 import 'package:easysubway_mobile/route_v2_ingress.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -107,6 +109,82 @@ void main() {
       throwsStateError,
     );
     expect((await repository.searchRoute(request)).originStationName, '새 상록수');
+  });
+
+  test('candidate build 오류는 owned DB close 오류보다 우선해 원본 stack을 보존한다', () async {
+    final oldDatabase = CatalogDatabase.memory();
+    final brokenDatabase = _CloseFailingCatalogDatabase();
+    addTearDown(oldDatabase.close);
+    await oldDatabase.seedBaselineIfEmpty();
+    await brokenDatabase.seedBaselineIfEmpty();
+    final repository = LocalRouteRepository(
+      catalogDatabase: oldDatabase,
+      routeCatalogBuildObserver: (event) {
+        if (event == 'graph') throw StateError('candidate graph failed');
+      },
+    );
+
+    await expectLater(
+      repository.activateDataPack(
+        catalogDatabase: brokenDatabase,
+        artifactIdentity: 'artifact-broken',
+        ownsDatabase: true,
+      ),
+      throwsA(
+        isA<StateError>().having(
+          (error) => error.message,
+          'message',
+          'candidate graph failed',
+        ),
+      ),
+    );
+  });
+
+  test('이전 bundle 정리 실패는 게시된 candidate activation을 실패로 바꾸지 않는다', () async {
+    final initialDatabase = CatalogDatabase.memory();
+    final previousDatabase = _CloseFailingCatalogDatabase();
+    final candidateDatabase = CatalogDatabase.memory();
+    addTearDown(initialDatabase.close);
+    await initialDatabase.seedBaselineIfEmpty();
+    await previousDatabase.seedBaselineIfEmpty();
+    await candidateDatabase.seedBaselineIfEmpty();
+    await candidateDatabase.customStatement(
+      "UPDATE stations SET name_ko = '정리 실패 뒤 새 상록수' "
+      "WHERE id = 'station-sangnoksu'",
+    );
+    final repository = LocalRouteRepository(
+      catalogDatabase: initialDatabase,
+      artifactIdentity: 'artifact-initial',
+    );
+    await repository.activateDataPack(
+      catalogDatabase: previousDatabase,
+      artifactIdentity: 'artifact-previous',
+      ownsDatabase: true,
+    );
+    final reported = <FlutterErrorDetails>[];
+
+    await runWithMobileErrorReporter(
+      reported.add,
+      () => repository.activateDataPack(
+        catalogDatabase: candidateDatabase,
+        artifactIdentity: 'artifact-candidate',
+        ownsDatabase: true,
+      ),
+    );
+
+    expect(reported, hasLength(1));
+    expect(reported.single.exception, isA<StateError>());
+    expect(
+      (await repository.searchRoute(
+        const RouteSearchRequest(
+          originStationId: 'station-sangnoksu',
+          destinationStationId: 'station-sadang',
+          mobilityType: 'STANDARD',
+        ),
+      )).originStationName,
+      '정리 실패 뒤 새 상록수',
+    );
+    await repository.close();
   });
 
   test('cold artifact 교체는 기존 artifact bundle을 먼저 만들지 않는다', () async {
@@ -204,6 +282,94 @@ void main() {
 
     expect(await Future.wait(calls), [isTrue, isTrue, isTrue]);
     expect(snapshotBuildCount, 1);
+  });
+
+  test('close는 진행 중인 cold bundle 생성을 기다리고 종료 뒤 재게시하지 않는다', () async {
+    final database = CatalogDatabase.memory();
+    await database.seedBaselineIfEmpty();
+    final buildStarted = Completer<void>();
+    final releaseBuild = Completer<void>();
+    final repository = LocalRouteRepository(
+      catalogDatabase: database,
+      routeCatalogBuildObserver: (event) async {
+        if (event != 'snapshot') return;
+        buildStarted.complete();
+        await releaseBuild.future;
+      },
+    );
+    const request = RouteSearchRequest(
+      originStationId: 'station-sangnoksu',
+      destinationStationId: 'station-sadang',
+      mobilityType: 'STANDARD',
+    );
+
+    final search = repository.canSearchRoute(request);
+    await buildStarted.future;
+    var closeCompleted = false;
+    final closing = repository.close().then((_) => closeCompleted = true);
+    await Future<void>.delayed(Duration.zero);
+    final completedBeforeRelease = closeCompleted;
+    releaseBuild.complete();
+
+    expect(await search, isTrue);
+    await closing;
+    expect(completedBeforeRelease, isFalse);
+    await expectLater(repository.canSearchRoute(request), throwsStateError);
+    await database.close();
+  });
+
+  test('close는 진행 중인 artifact activation을 기다리고 후보 게시를 취소한다', () async {
+    final oldDatabase = CatalogDatabase.memory();
+    final newDatabase = CatalogDatabase.memory();
+    await oldDatabase.seedBaselineIfEmpty();
+    await newDatabase.seedBaselineIfEmpty();
+    var blockActivation = false;
+    final activationStarted = Completer<void>();
+    final releaseActivation = Completer<void>();
+    final repository = LocalRouteRepository(
+      catalogDatabase: oldDatabase,
+      artifactIdentity: 'artifact-old',
+      routeCatalogBuildObserver: (event) async {
+        if (event != 'graph' || !blockActivation) return;
+        activationStarted.complete();
+        await releaseActivation.future;
+      },
+    );
+    await repository.canSearchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-sangnoksu',
+        destinationStationId: 'station-sadang',
+        mobilityType: 'STANDARD',
+      ),
+    );
+    blockActivation = true;
+
+    final activation = repository.activateDataPack(
+      catalogDatabase: newDatabase,
+      artifactIdentity: 'artifact-new',
+      ownsDatabase: true,
+    );
+    await activationStarted.future;
+    var closeCompleted = false;
+    final closing = repository.close().then((_) => closeCompleted = true);
+    await Future<void>.delayed(Duration.zero);
+    final completedBeforeRelease = closeCompleted;
+    releaseActivation.complete();
+
+    await activation;
+    await closing;
+    expect(completedBeforeRelease, isFalse);
+    await expectLater(
+      repository.canSearchRoute(
+        const RouteSearchRequest(
+          originStationId: 'station-sangnoksu',
+          destinationStationId: 'station-sadang',
+          mobilityType: 'STANDARD',
+        ),
+      ),
+      throwsStateError,
+    );
+    await oldDatabase.close();
   });
 
   test('실패한 cold graph build는 부분 publish 없이 다음 호출에서 재시도한다', () async {
@@ -2485,6 +2651,67 @@ void main() {
     expect(result.steps, isEmpty);
     expect(result.blockedReasons, contains('오래된 안내라 계단 없는 경로로 안내하지 않아요.'));
     expect(result.warnings, isEmpty);
+  });
+
+  test('시설 없는 edge는 graph 재빌드 없이 365일 경계를 넘으면 stale이 된다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await _seedLineWithoutNetworkEdges(database);
+    var current = DateTime.utc(2026, 7, 18, 12);
+    final verifiedAt = current
+        .subtract(const Duration(days: 365))
+        .add(const Duration(seconds: 1));
+    for (final edge in [
+      (
+        id: 'entry-a-fresh-boundary',
+        from: 'station-a',
+        to: 'station-a:line-test',
+        type: 'ENTRY',
+      ),
+      (
+        id: 'ride-a-c-fresh-boundary',
+        from: 'station-a:line-test',
+        to: 'station-c:line-test',
+        type: 'RIDE',
+      ),
+      (
+        id: 'exit-c-fresh-boundary',
+        from: 'station-c:line-test',
+        to: 'station-c',
+        type: 'EXIT',
+      ),
+    ]) {
+      await _insertVerifiedNetworkEdge(
+        database,
+        id: edge.id,
+        fromNodeId: edge.from,
+        toNodeId: edge.to,
+        edgeType: edge.type,
+        durationSeconds: 60,
+        lastVerifiedAtSeconds: verifiedAt.millisecondsSinceEpoch ~/ 1000,
+      );
+    }
+    var graphBuildCount = 0;
+    final repository = LocalRouteRepository(
+      catalogDatabase: database,
+      now: () => current,
+      routeCatalogBuildObserver: (event) {
+        if (event == 'graph') graphBuildCount += 1;
+      },
+    );
+    const request = RouteSearchRequest(
+      originStationId: 'station-a',
+      destinationStationId: 'station-c',
+      mobilityType: 'WHEELCHAIR',
+    );
+
+    expect((await repository.searchRoute(request)).status, 'FOUND');
+    current = current.add(const Duration(seconds: 2));
+    final stale = await repository.searchRoute(request);
+
+    expect(stale.status, 'UNKNOWN');
+    expect(stale.blockedReasons, contains('오래된 안내라 계단 없는 경로로 안내하지 않아요.'));
+    expect(graphBuildCount, 1);
   });
 
   test('잘못된 provenance와 evidence hash는 strict 경로에서 FOUND 근거가 되지 않는다', () async {
@@ -5892,6 +6119,21 @@ Future<void> _addFacilityIdColumnIfMissing(CatalogDatabase database) async {
       'ALTER TABLE network_edges ADD COLUMN facility_id TEXT',
     );
     await database.refreshRouteSchemaCapabilities();
+  }
+}
+
+final class _CloseFailingCatalogDatabase extends CatalogDatabase {
+  _CloseFailingCatalogDatabase() : super(NativeDatabase.memory());
+
+  var _failNextClose = true;
+
+  @override
+  Future<void> close() async {
+    await super.close();
+    if (_failNextClose) {
+      _failNextClose = false;
+      throw StateError('catalog database close failed');
+    }
   }
 }
 

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:drift/drift.dart' hide isNotNull, isNull;
+import 'package:drift/native.dart';
 import 'package:easysubway_mobile/app/app_dependencies.dart';
 import 'package:easysubway_mobile/core/database/catalog/catalog_database.dart';
 import 'package:easysubway_mobile/facility_report.dart';
@@ -17,6 +19,96 @@ import 'package:easysubway_mobile/route_v2_ingress.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('warm searchRoute는 catalog SQL과 graph build를 실행하지 않는다', () async {
+    final queries = _QueryCounter();
+    final database = CatalogDatabase(
+      NativeDatabase.memory().interceptWith(queries),
+    );
+    addTearDown(database.close);
+    await database.seedBaselineIfEmpty();
+    var graphBuildCount = 0;
+    final repository = LocalRouteRepository(
+      catalogDatabase: database,
+      routeCatalogBuildObserver: (event) {
+        if (event == 'graph') graphBuildCount += 1;
+      },
+    );
+    const request = RouteSearchRequest(
+      originStationId: 'station-sangnoksu',
+      destinationStationId: 'station-sadang',
+      mobilityType: 'STANDARD',
+    );
+
+    await repository.searchRoute(request);
+    queries.reset();
+
+    final result = await repository.searchRoute(request);
+
+    expect(result.status, 'FOUND');
+    expect(queries.count, 0);
+    expect(graphBuildCount, 1);
+  });
+
+  test('artifact 교체는 완성된 새 bundle만 게시하고 실패하면 기존 bundle을 유지한다', () async {
+    final oldDatabase = CatalogDatabase.memory();
+    final newDatabase = CatalogDatabase.memory();
+    final brokenDatabase = CatalogDatabase.memory();
+    addTearDown(oldDatabase.close);
+    addTearDown(newDatabase.close);
+    addTearDown(brokenDatabase.close);
+    await oldDatabase.seedBaselineIfEmpty();
+    await newDatabase.seedBaselineIfEmpty();
+    await brokenDatabase.seedBaselineIfEmpty();
+    await newDatabase.customStatement(
+      "UPDATE stations SET name_ko = '새 상록수' WHERE id = 'station-sangnoksu'",
+    );
+    var failBrokenGraph = false;
+    var blockNewGraph = false;
+    final newGraphStarted = Completer<void>();
+    final releaseNewGraph = Completer<void>();
+    final repository = LocalRouteRepository(
+      catalogDatabase: oldDatabase,
+      artifactIdentity: 'artifact-old',
+      routeCatalogBuildObserver: (event) async {
+        if (event == 'graph' && failBrokenGraph) {
+          throw StateError('candidate graph failed');
+        }
+        if (event == 'graph' && blockNewGraph) {
+          newGraphStarted.complete();
+          await releaseNewGraph.future;
+        }
+      },
+    );
+    const request = RouteSearchRequest(
+      originStationId: 'station-sangnoksu',
+      destinationStationId: 'station-sadang',
+      mobilityType: 'STANDARD',
+    );
+
+    expect((await repository.searchRoute(request)).originStationName, '상록수');
+    blockNewGraph = true;
+    final activation = repository.activateDataPack(
+      catalogDatabase: newDatabase,
+      artifactIdentity: 'artifact-new',
+    );
+    await newGraphStarted.future;
+    expect((await repository.searchRoute(request)).originStationName, '상록수');
+    releaseNewGraph.complete();
+    await activation;
+    blockNewGraph = false;
+    expect((await repository.searchRoute(request)).originStationName, '새 상록수');
+
+    failBrokenGraph = true;
+    await expectLater(
+      repository.activateDataPack(
+        catalogDatabase: brokenDatabase,
+        artifactIdentity: 'artifact-broken',
+      ),
+      throwsStateError,
+    );
+    expect((await repository.searchRoute(request)).originStationName, '새 상록수');
+  });
+
   test('동일 artifact identity의 route API는 snapshot과 graph를 한 번만 빌드한다', () async {
     final database = CatalogDatabase.memory();
     addTearDown(database.close);
@@ -107,7 +199,7 @@ void main() {
     expect(graphBuildCount, 2);
   });
 
-  test('warm route API는 PRAGMA table_info를 다시 실행하지 않는다', () async {
+  test('route schema PRAGMA는 DB open에서 끝나고 route build에서 실행하지 않는다', () async {
     final database = CatalogDatabase.memory();
     addTearDown(database.close);
     await database.seedBaselineIfEmpty();
@@ -125,11 +217,11 @@ void main() {
     );
 
     await repository.canSearchRoute(request);
-    expect(schemaDiscoveryCount, 2);
+    expect(schemaDiscoveryCount, 0);
 
     await repository.routeCapability(request);
     await repository.searchRoute(request);
-    expect(schemaDiscoveryCount, 2);
+    expect(schemaDiscoveryCount, 0);
   });
 
   test('흡수된 station ID는 대표 station ID로 정규화해 경로를 검색한다', () async {
@@ -2038,6 +2130,7 @@ void main() {
       ),
     );
     await _setOutOfStationTransferRuntimeEnabled(database, false);
+    await repository.refreshRuntimeState();
     final disabledResult = await repository.searchRoute(
       const RouteSearchRequest(
         originStationId: 'station-b',
@@ -2049,6 +2142,55 @@ void main() {
     expect(enabledResult.status, 'FOUND');
     expect(disabledResult.status, isNot('FOUND'));
   });
+
+  test(
+    '역외 환승 runtime kill switch false에서 true로 복구하면 graph 재빌드 없이 후보가 된다',
+    () async {
+      final database = CatalogDatabase.memory();
+      addTearDown(database.close);
+      await _seedLineWithoutNetworkEdges(database);
+      await _addSecondLineForTransferFixture(database);
+      await _allowOutOfStationTransfer(
+        database,
+        'station-a:line-test->station-c:line-alt',
+      );
+      await _setOutOfStationTransferRuntimeEnabled(database, false);
+      await _insertVerifiedNetworkEdge(
+        database,
+        id: 'edge-b-a-line-test',
+        fromNodeId: 'station-b:line-test',
+        toNodeId: 'station-a:line-test',
+        edgeType: 'RIDE',
+        durationSeconds: 90,
+      );
+      await _insertVerifiedNetworkEdge(
+        database,
+        id: 'out-transfer-a-c',
+        fromNodeId: 'station-a:line-test',
+        toNodeId: 'station-c:line-alt',
+        edgeType: 'OUT_OF_STATION_TRANSFER',
+        durationSeconds: 300,
+      );
+      var graphBuildCount = 0;
+      final repository = LocalRouteRepository(
+        catalogDatabase: database,
+        routeCatalogBuildObserver: (event) {
+          if (event == 'graph') graphBuildCount += 1;
+        },
+      );
+      const request = RouteSearchRequest(
+        originStationId: 'station-b',
+        destinationStationId: 'station-c',
+        mobilityType: 'WHEELCHAIR',
+      );
+
+      expect((await repository.searchRoute(request)).status, isNot('FOUND'));
+      await _setOutOfStationTransferRuntimeEnabled(database, true);
+      await repository.refreshRuntimeState();
+      expect((await repository.searchRoute(request)).status, 'FOUND');
+      expect(graphBuildCount, 1);
+    },
+  );
 
   test('역외 환승 edge는 역방향을 자동으로 열지 않는다', () async {
     final database = CatalogDatabase.memory();
@@ -2543,6 +2685,7 @@ void main() {
         'RIDE'
       )
     ''');
+    await database.refreshRouteSchemaCapabilities();
     final repository = LocalRouteRepository(catalogDatabase: database);
 
     final result = await repository.searchRoute(
@@ -2590,6 +2733,7 @@ void main() {
         'AVAILABLE'
       )
     ''');
+    await database.refreshRouteSchemaCapabilities();
     final repository = LocalRouteRepository(catalogDatabase: database);
 
     final result = await repository.searchRoute(
@@ -3180,6 +3324,89 @@ void main() {
     expect(result.status, 'BLOCKED');
     expect(result.steps, isEmpty);
     expect(result.blockedReasons, contains('꼭 필요한 시설을 지금 이용하기 어려워요.'));
+  });
+
+  test('active 시설 상태가 시간 경과로 만료되면 graph 재빌드 없이 strict 경로가 복구된다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await _seedAvailableFacilityRoute(database);
+    var current = DateTime.utc(2026, 7, 18, 5);
+    final nowSeconds = current.millisecondsSinceEpoch ~/ 1000;
+    await _addFacilityStatusSnapshot(
+      database,
+      id: 'snapshot-facility-a-expiring-unavailable',
+      providerId: 'live-provider',
+      sourceId: 'facility-live-source',
+      sourceSnapshotId: 'facility-live-source-20260718',
+      status: 'BROKEN',
+      operationalStatus: 'OUT_OF_SERVICE',
+      observedAtSeconds: nowSeconds,
+      expiresAtSeconds: nowSeconds + 30,
+    );
+    var graphBuildCount = 0;
+    final repository = LocalRouteRepository(
+      catalogDatabase: database,
+      now: () => current,
+      routeCatalogBuildObserver: (event) {
+        if (event == 'graph') graphBuildCount += 1;
+      },
+    );
+    const request = RouteSearchRequest(
+      originStationId: 'station-a',
+      destinationStationId: 'station-b',
+      mobilityType: 'WHEELCHAIR',
+    );
+
+    expect((await repository.searchRoute(request)).status, 'BLOCKED');
+    current = current.add(const Duration(seconds: 31));
+    expect((await repository.searchRoute(request)).status, 'FOUND');
+    expect(graphBuildCount, 1);
+  });
+
+  test('facility status DB 갱신은 graph 재빌드 없이 다음 검색의 strict 경로에 반영된다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await _seedAvailableFacilityRoute(database);
+    var graphBuildCount = 0;
+    final repository = LocalRouteRepository(
+      catalogDatabase: database,
+      routeCatalogBuildObserver: (event) {
+        if (event == 'graph') graphBuildCount += 1;
+      },
+    );
+    const request = RouteSearchRequest(
+      originStationId: 'station-a',
+      destinationStationId: 'station-b',
+      mobilityType: 'WHEELCHAIR',
+    );
+    expect((await repository.searchRoute(request)).status, 'FOUND');
+    final nowSeconds = DateTime.now().toUtc().millisecondsSinceEpoch ~/ 1000;
+
+    await database.customInsert(
+      '''
+      INSERT INTO facility_status_snapshots (
+        id, facility_id, provider_id, source_id, source_snapshot_id,
+        provider_record_hash, evidence_hash, provenance_kind,
+        verification_status, status, operational_status, confidence,
+        observed_at, expires_at
+      ) VALUES (
+        'snapshot-facility-a-runtime-unavailable', 'facility-a-elevator',
+        'live-provider', 'facility-live-source', 'facility-live-source-20260718',
+        'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+        '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+        'OFFICIAL_SOURCE', 'VERIFIED', 'BROKEN', 'OUT_OF_SERVICE', 100, ?, ?
+      )
+      ''',
+      variables: [
+        Variable.withInt(nowSeconds),
+        Variable.withInt(nowSeconds + 3600),
+      ],
+      updates: {database.facilityStatusSnapshots},
+    );
+    await repository.refreshRuntimeState();
+
+    expect((await repository.searchRoute(request)).status, 'BLOCKED');
+    expect(graphBuildCount, 1);
   });
 
   test('operator override snapshot은 live snapshot보다 우선한다', () async {
@@ -5628,6 +5855,63 @@ Future<void> _addFacilityIdColumnIfMissing(CatalogDatabase database) async {
     await database.customStatement(
       'ALTER TABLE network_edges ADD COLUMN facility_id TEXT',
     );
+    await database.refreshRouteSchemaCapabilities();
+  }
+}
+
+final class _QueryCounter extends QueryInterceptor {
+  int count = 0;
+
+  void reset() => count = 0;
+
+  @override
+  Future<List<Map<String, Object?>>> runSelect(
+    QueryExecutor executor,
+    String statement,
+    List<Object?> args,
+  ) {
+    count += 1;
+    return executor.runSelect(statement, args);
+  }
+
+  @override
+  Future<void> runCustom(
+    QueryExecutor executor,
+    String statement,
+    List<Object?> args,
+  ) {
+    count += 1;
+    return executor.runCustom(statement, args);
+  }
+
+  @override
+  Future<int> runInsert(
+    QueryExecutor executor,
+    String statement,
+    List<Object?> args,
+  ) {
+    count += 1;
+    return executor.runInsert(statement, args);
+  }
+
+  @override
+  Future<int> runUpdate(
+    QueryExecutor executor,
+    String statement,
+    List<Object?> args,
+  ) {
+    count += 1;
+    return executor.runUpdate(statement, args);
+  }
+
+  @override
+  Future<int> runDelete(
+    QueryExecutor executor,
+    String statement,
+    List<Object?> args,
+  ) {
+    count += 1;
+    return executor.runDelete(statement, args);
   }
 }
 
@@ -5642,6 +5926,7 @@ Future<void> _addDistanceMetersColumnIfMissing(CatalogDatabase database) async {
     await database.customStatement(
       'ALTER TABLE network_edges ADD COLUMN distance_meters INTEGER NOT NULL DEFAULT 0',
     );
+    await database.refreshRouteSchemaCapabilities();
   }
 }
 

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -16,6 +17,121 @@ import 'package:easysubway_mobile/route_v2_ingress.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('동일 artifact identity의 route API는 snapshot과 graph를 한 번만 빌드한다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await database.seedBaselineIfEmpty();
+    var snapshotBuildCount = 0;
+    var graphBuildCount = 0;
+    final repository = LocalRouteRepository(
+      catalogDatabase: database,
+      routeCatalogBuildObserver: (event) {
+        if (event == 'snapshot') snapshotBuildCount += 1;
+        if (event == 'graph') graphBuildCount += 1;
+      },
+    );
+    const request = RouteSearchRequest(
+      originStationId: 'station-sangnoksu',
+      destinationStationId: 'station-sadang',
+      mobilityType: 'STANDARD',
+    );
+
+    await repository.routeCapability(request);
+    await repository.canSearchRoute(request);
+    await repository.searchRoute(request);
+
+    expect(snapshotBuildCount, 1);
+    expect(graphBuildCount, 1);
+  });
+
+  test('동시 cold route 호출은 하나의 snapshot build를 공유한다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await database.seedBaselineIfEmpty();
+    final buildStarted = Completer<void>();
+    final releaseBuild = Completer<void>();
+    var snapshotBuildCount = 0;
+    final repository = LocalRouteRepository(
+      catalogDatabase: database,
+      routeCatalogBuildObserver: (event) async {
+        if (event != 'snapshot') return;
+        snapshotBuildCount += 1;
+        if (!buildStarted.isCompleted) buildStarted.complete();
+        await releaseBuild.future;
+      },
+    );
+    const request = RouteSearchRequest(
+      originStationId: 'station-sangnoksu',
+      destinationStationId: 'station-sadang',
+      mobilityType: 'STANDARD',
+    );
+
+    final calls = [
+      repository.canSearchRoute(request),
+      repository.canSearchRoute(request),
+      repository.canSearchRoute(request),
+    ];
+    await buildStarted.future;
+    releaseBuild.complete();
+
+    expect(await Future.wait(calls), [isTrue, isTrue, isTrue]);
+    expect(snapshotBuildCount, 1);
+  });
+
+  test('실패한 cold graph build는 부분 publish 없이 다음 호출에서 재시도한다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await database.seedBaselineIfEmpty();
+    var snapshotBuildCount = 0;
+    var graphBuildCount = 0;
+    final repository = LocalRouteRepository(
+      catalogDatabase: database,
+      routeCatalogBuildObserver: (event) {
+        if (event == 'snapshot') snapshotBuildCount += 1;
+        if (event != 'graph') return;
+        graphBuildCount += 1;
+        if (graphBuildCount != 2) throw StateError('graph build failed');
+      },
+    );
+    const request = RouteSearchRequest(
+      originStationId: 'station-sangnoksu',
+      destinationStationId: 'station-sadang',
+      mobilityType: 'STANDARD',
+    );
+
+    await expectLater(repository.canSearchRoute(request), throwsStateError);
+    expect(await repository.canSearchRoute(request), isTrue);
+    expect(await repository.canSearchRoute(request), isTrue);
+
+    expect(snapshotBuildCount, 2);
+    expect(graphBuildCount, 2);
+  });
+
+  test('warm route API는 PRAGMA table_info를 다시 실행하지 않는다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await database.seedBaselineIfEmpty();
+    var schemaDiscoveryCount = 0;
+    final repository = LocalRouteRepository(
+      catalogDatabase: database,
+      routeCatalogBuildObserver: (event) {
+        if (event == 'schema') schemaDiscoveryCount += 1;
+      },
+    );
+    const request = RouteSearchRequest(
+      originStationId: 'station-sangnoksu',
+      destinationStationId: 'station-sadang',
+      mobilityType: 'STANDARD',
+    );
+
+    await repository.canSearchRoute(request);
+    expect(schemaDiscoveryCount, 2);
+
+    await repository.routeCapability(request);
+    await repository.searchRoute(request);
+    expect(schemaDiscoveryCount, 2);
+  });
+
   test('흡수된 station ID는 대표 station ID로 정규화해 경로를 검색한다', () async {
     final database = CatalogDatabase.memory();
     addTearDown(database.close);

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -12338,6 +12338,15 @@ void main() {
       },
       enablePushNotifications: false,
     );
+    await tester.runAsync(
+      () => dependencies.routeRepository.searchRoute(
+        const RouteSearchRequest(
+          originStationId: 'station-sangnoksu',
+          destinationStationId: 'station-sadang',
+          mobilityType: 'STANDARD',
+        ),
+      ),
+    );
     final semanticsHandle = tester.ensureSemantics();
     try {
       await tester.pumpWidget(

--- a/apps/mobile/test_driver/integration_test.dart
+++ b/apps/mobile/test_driver/integration_test.dart
@@ -1,0 +1,3 @@
+import 'package:integration_test/integration_test_driver.dart';
+
+Future<void> main() => integrationDriver();


### PR DESCRIPTION
## 관련 이슈

Closes #2253

## 작업 배경

- 모바일 오프라인 경로 API가 호출될 때마다 catalog snapshot과 route graph, 시간표·요금 조회를 반복해 실기기 검색 지연이 발생했습니다.
- 활성 데이터팩 artifact별로 완성된 bundle 하나를 공유하고, hot search에서 catalog SQL과 graph build를 모두 제거합니다.

## 작업 내용

- catalog·시간표·승인 요금·route graph를 artifact identity별 bundle로 만들고 동시 cold 호출이 하나의 build를 공유하도록 했습니다.
- graph build를 isolate로 옮기고 완성된 새 artifact만 원자적으로 게시합니다. 교체 중 검색은 완성된 구/신 bundle만 보고, 실패한 후보는 기존 bundle을 보존합니다.
- facility status와 역외 환승 runtime switch를 graph topology와 분리한 overlay로 반영해 전체 graph 재빌드 없이 갱신·만료를 처리합니다.
- schema `PRAGMA table_info`를 DB open/migration 시점으로 옮기고 warm `searchRoute`의 catalog query 0회·graph build 0회를 Drift interceptor로 고정했습니다.
- 세션 중 datapack pointer가 갱신돼도 station/favorite/network-map/route가 같은 열린 DB를 유지하고, 다음 bootstrap에서 새 artifact identity를 함께 사용하도록 했습니다.
- 재현 가능한 Android profile benchmark integration driver와 원자성·실패·cold 교체·runtime overlay 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `dart format --output=none --set-exit-if-changed lib test integration_test test_driver` → 273 files, 0 changed
  - `flutter analyze` → No issues found
  - `flutter test test/features/routes/local_route_repository_test.dart test/features/routes/route_engine_test.dart test/features/routes/canonical_station_pack_test.dart test/features/fare/official_od_fare_repository_test.dart test/core/database/mobile_local_database_test.dart --reporter compact` → 183 passed
  - `flutter test test/features/routes/local_route_repository_test.dart test/core/database/mobile_local_database_test.dart -r compact` → 161 passed
  - `flutter test -r compact` → 1,448 passed
  - repository contract tests → 217 passed
  - `flutter drive --profile --driver=test_driver/integration_test.dart --target=integration_test/route_search_snapshot_cache_benchmark_test.dart -d RFKYA01VMQY` → passed
  - `codex review --disable plugins --base origin/main` → fresh finding 0
  - `node /Users/aquila/.agents/skills/easysubway-review/scripts/validate-review-format.mjs` → canonical OK, 7,096 bytes, SHA-256 `9de21fd1d4d0fc3d3ce10a5536a92cecb7435f3b269b8a8f04e997b5f536f183`

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| warm query invariant | Flutter test | Drift query interceptor + graph build observer | `warm searchRoute는 catalog SQL과 graph build를 실행하지 않는다` | DB query 0, graph build 0 |
| artifact 원자 교체 | Flutter test | 교체 build를 block한 동안 구 bundle 검색, 성공 후 신 bundle 검색, 실패 후보 주입 | `artifact 교체는 완성된 새 bundle만 게시하고 실패하면 기존 bundle을 유지한다` | 통과 |
| cold artifact 교체 | Flutter test | 초기 bundle 미생성 상태에서 새 artifact 활성화 | `cold artifact 교체는 기존 artifact bundle을 먼저 만들지 않는다` | snapshot 1, graph 1 |
| runtime overlay | Flutter test | facility DB 갱신·expiry·역외환승 false→true | 관련 route repository tests | graph build 1 유지 |
| 동일 기기 전/후 latency | Android SM_A175N (`RFKYA01VMQY`) | profile, capital sqlite SHA `ed84a649952cd2ccbb238b3a63265f2bd3144497ae8fd36fab5181ad776542fc`, warmup 5, 40회 | 아래 raw sample | baseline p50/p95/max 115.851/158.225/193.586ms → final 0.780/0.935/6.710ms |
| UI·접근성 수동 QA | 해당 없음 | 화면/문구/상용 claim 변경 없음 | route semantics 회귀 테스트 | 불필요 |

<details>
<summary>실기기 profile raw samples (µs)</summary>

- baseline: `125984, 97648, 109124, 91870, 128579, 92653, 143629, 121433, 109927, 108929, 112974, 151799, 152172, 95180, 99595, 81204, 152121, 149008, 158225, 109059, 98647, 122720, 131520, 115270, 159685, 126563, 145433, 87947, 113122, 107415, 116045, 115851, 114409, 115436, 140328, 89262, 137223, 193586, 130136, 121853`
- final: `901, 6710, 935, 1084, 700, 811, 685, 657, 640, 682, 684, 664, 741, 754, 777, 808, 764, 740, 807, 862, 775, 757, 818, 805, 762, 872, 742, 757, 849, 775, 780, 809, 820, 776, 845, 788, 808, 848, 792, 800`

</details>

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: `1.0.5` (unchanged)
- mobile versionCode: `10006` (unchanged)
- datapack version: unchanged; benchmark `capital` sqlite SHA above
- route contract: unchanged; snapshot·graph cache layer only
- realtime contract: unchanged
- backend identity: N/A

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `LocalRouteRepository`의 shared cold future와 atomic candidate publish, facility edge resolver overlay, bootstrap의 session-wide catalog consistency를 먼저 확인해 주세요.

## 리스크

- timetable과 fare를 메모리에 보관하므로 artifact당 상주 메모리가 늘어납니다. artifact 교체는 완성된 후보만 게시하고 소유 DB를 닫으며, 실기기 profile benchmark와 전체 route 회귀 테스트로 확인했습니다.
- runtime facility 갱신 호출을 누락하면 overlay가 오래될 수 있어 명시적 `refreshRuntimeState()`와 expiry-at-search 테스트로 경계를 고정했습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다. (status check만 있고 bot PR Review 객체는 없음)
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)
