### PR TITLE
[Style] 신고 panel·제목 밀도 정리 (#2072, #2073)

### DIFF
--- a/backend/src/main/resources/static/css/admin-v3.css
+++ b/backend/src/main/resources/static/css/admin-v3.css
@@ -1442,7 +1442,14 @@ body.admin-v3 {
 	align-items: center;
 	margin-bottom: 18px;
 	padding: 16px 18px;
-	border-left: 3px solid var(--admin-border-strong);
+	border: 0;
+	border-radius: 0;
+	background: transparent;
+	box-shadow: none;
+}
+
+.admin-v3 .surge-alert + .processing-time {
+	border-top: 1px solid var(--admin-border);
 }
 
 .admin-v3 .surge-alert h2,

--- a/backend/src/main/resources/templates/admin/alerts.html
+++ b/backend/src/main/resources/templates/admin/alerts.html
@@ -17,7 +17,6 @@
 	<header class="admin-page-head">
 		<div>
 			<h1>알림 센터</h1>
-			<p>신고 급증·푸시 실패·배치 실패·데이터팩 blocker를 한 곳에서 확인합니다. 권한이 없는 신호는 제외됩니다.</p>
 		</div>
 	</header>
 

--- a/backend/src/main/resources/templates/admin/dashboard.html
+++ b/backend/src/main/resources/templates/admin/dashboard.html
@@ -17,7 +17,6 @@
 	<header class="admin-page-head">
 		<div>
 			<h1>통합 대시보드</h1>
-			<p>지금 급한 것 → 추세 → 상세 순으로 신고·시설·경로·알림·시스템을 모읍니다.</p>
 		</div>
 		<div class="admin-actions">
 			<span th:if="${snapshotStatus == null}" class="admin-status warn">지표 집계 대기</span>

--- a/backend/src/main/resources/templates/admin/reports/list.html
+++ b/backend/src/main/resources/templates/admin/reports/list.html
@@ -19,7 +19,6 @@
 	<header class="admin-page-head">
 		<div>
 			<h1>시설 신고 확인</h1>
-			<p>상태·사진·위치·접수일 기준으로 제보를 확인 대기열에 배치합니다.</p>
 		</div>
 	</header>
 

--- a/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminDashboardPageTest.java
+++ b/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminDashboardPageTest.java
@@ -51,6 +51,8 @@ class AdminDashboardPageTest {
 
 		assertThat(html)
 			.contains("class=\"dashboard-card metric-cell\"")
+			.contains("통합 대시보드")
+			.doesNotContain("지금 급한 것 → 추세 → 상세 순으로 신고·시설·경로·알림·시스템을 모읍니다.")
 			.contains("확인할 제보")
 			.contains("href=\"/admin/reports/page\"")
 			.contains("dashboard-spark")

--- a/backend/src/test/java/com/easysubway/admin/alert/AdminAlertControllerTest.java
+++ b/backend/src/test/java/com/easysubway/admin/alert/AdminAlertControllerTest.java
@@ -40,7 +40,8 @@ class AdminAlertControllerTest {
 		assertThat(html)
 			.contains("<!doctype html>")
 			.contains("알림 센터")
-			.contains("admin-sidebar");
+			.contains("admin-sidebar")
+			.doesNotContain("신고 급증·푸시 실패·배치 실패·데이터팩 blocker를 한 곳에서 확인합니다.");
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/admin/web/AdminDesignGuardTest.java
+++ b/backend/src/test/java/com/easysubway/admin/web/AdminDesignGuardTest.java
@@ -121,6 +121,26 @@ class AdminDesignGuardTest {
 			.isEmpty();
 	}
 
+	@Test
+	@DisplayName("신고 보조 panel은 flat chrome과 단일 divider만 사용한다")
+	void reportSupportPanelsUseFlatChromeWithSingleDivider() throws IOException {
+		String css = read("backend/src/main/resources/static/css/admin-v3.css");
+		Pattern flatPanels = Pattern.compile(
+			"\\.admin-v3 \\.surge-alert,\\s*\\.admin-v3 \\.processing-time \\{"
+				+ "[^}]*border: 0;[^}]*border-radius: 0;[^}]*background: transparent;"
+				+ "[^}]*box-shadow: none;",
+			Pattern.DOTALL
+		);
+		Pattern singleDivider = Pattern.compile(
+			"\\.admin-v3 \\.surge-alert \\+ \\.processing-time \\{"
+				+ "[^}]*border-top: 1px solid var\\(--admin-border\\);",
+			Pattern.DOTALL
+		);
+
+		assertThat(css).containsPattern(flatPanels);
+		assertThat(css).containsPattern(singleDivider);
+	}
+
 	private static String read(String path) throws IOException {
 		return Files.readString(ROOT.resolve(path));
 	}

--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageControllerTest.java
@@ -220,6 +220,8 @@ class FacilityReportAdminPageControllerTest {
 
 		assertThat(html)
 			.contains("신고 급증")
+			.contains("시설 신고 확인")
+			.doesNotContain("상태·사진·위치·접수일 기준으로 제보를 확인 대기열에 배치합니다.")
 			.contains("점검 필요")
 			.contains("신고가 평소보다 많습니다")
 			.containsPattern("최근 24시간 신고 \\d+건");


### PR DESCRIPTION
## 관련 이슈

Closes #2072
Closes #2073

## 작업 내용

- 신고 현황의 급증 알림·처리 시간 panel을 카드 중첩 없이 평면화하고 두 영역 사이 구분선 하나만 유지했습니다.
- 알림·대시보드·신고 목록의 설명형 subtitle 3개를 제거해 모바일 첫 화면의 제목 밀도를 낮췄습니다.
- panel 구조와 제거 대상 copy를 회귀 테스트로 고정했습니다.

## 검증

- `./gradlew test`: 전체 backend suite 통과
- `node --test tools/ci/repository-contract.test.mjs`: 217/217 통과
- `git diff --check`: 통과

## 영향

- [x] 제품/운영 위험 없음 (route/accessibility/mobile UX/backend API/auth/security 아님)
- [x] DB migration 없음
- [x] 배포 영향 없음
- [x] route/realtime/datapack contract 영향 없음
- [x] CI workflow·계약 테스트·release gate JSON 변경 없음 (있으면 full.md로 전환)

## 체크리스트

- [x] 이 PR은 B/C등급 작업이며 full template이 필요 없다.
- [x] CI 결과를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 폴백 리뷰를 단일 PR review로 게시했다.
