### PR TITLE
[Style] 로그인 notice와 카피 정리 (#2074)

### DIFF
--- a/backend/src/main/java/com/easysubway/admin/adapter/in/web/AdminLoginPageController.java
+++ b/backend/src/main/java/com/easysubway/admin/adapter/in/web/AdminLoginPageController.java
@@ -1,13 +1,23 @@
 package com.easysubway.admin.adapter.in.web;
 
+import com.easysubway.common.security.LoginNoticeFlash;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
 class AdminLoginPageController {
 
+	private final LoginNoticeFlash loginNoticeFlash;
+
+	AdminLoginPageController(LoginNoticeFlash loginNoticeFlash) {
+		this.loginNoticeFlash = loginNoticeFlash;
+	}
+
 	@GetMapping("/admin/login")
-	String loginPage() {
+	String loginPage(HttpServletRequest request, Model model) {
+		model.addAttribute("loginNotice", loginNoticeFlash.consume(request));
 		return "admin/login";
 	}
 }

--- a/backend/src/main/java/com/easysubway/common/security/LoginNotice.java
+++ b/backend/src/main/java/com/easysubway/common/security/LoginNotice.java
@@ -1,0 +1,6 @@
+package com.easysubway.common.security;
+
+public enum LoginNotice {
+	NONE,
+	RETRY_WARNING
+}

--- a/backend/src/main/java/com/easysubway/common/security/LoginNoticeFlash.java
+++ b/backend/src/main/java/com/easysubway/common/security/LoginNoticeFlash.java
@@ -1,0 +1,36 @@
+package com.easysubway.common.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import java.io.IOException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+
+public final class LoginNoticeFlash implements AuthenticationFailureHandler {
+
+	private static final String SESSION_ATTRIBUTE = LoginNoticeFlash.class.getName() + ".notice";
+
+	@Override
+	public void onAuthenticationFailure(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		AuthenticationException exception
+	) throws IOException, ServletException {
+		request.getSession().setAttribute(SESSION_ATTRIBUTE, LoginNotice.RETRY_WARNING);
+		String requestPath = request.getRequestURI().substring(request.getContextPath().length());
+		String loginPath = "/operator/login".equals(requestPath) ? "/operator/login" : "/admin/login";
+		response.sendRedirect(request.getContextPath() + loginPath);
+	}
+
+	public LoginNotice consume(HttpServletRequest request) {
+		HttpSession session = request.getSession(false);
+		if (session == null) {
+			return LoginNotice.NONE;
+		}
+		Object notice = session.getAttribute(SESSION_ATTRIBUTE);
+		session.removeAttribute(SESSION_ATTRIBUTE);
+		return notice == LoginNotice.RETRY_WARNING ? LoginNotice.RETRY_WARNING : LoginNotice.NONE;
+	}
+}

--- a/backend/src/main/java/com/easysubway/common/security/LoginNoticeFlash.java
+++ b/backend/src/main/java/com/easysubway/common/security/LoginNoticeFlash.java
@@ -18,9 +18,8 @@ public final class LoginNoticeFlash implements AuthenticationFailureHandler {
 		HttpServletResponse response,
 		AuthenticationException exception
 	) throws IOException, ServletException {
-		request.getSession().setAttribute(SESSION_ATTRIBUTE, LoginNotice.RETRY_WARNING);
-		String requestPath = request.getRequestURI().substring(request.getContextPath().length());
-		String loginPath = "/operator/login".equals(requestPath) ? "/operator/login" : "/admin/login";
+		String loginPath = loginPath(request);
+		request.getSession().setAttribute(sessionAttribute(loginPath), LoginNotice.RETRY_WARNING);
 		response.sendRedirect(request.getContextPath() + loginPath);
 	}
 
@@ -29,8 +28,18 @@ public final class LoginNoticeFlash implements AuthenticationFailureHandler {
 		if (session == null) {
 			return LoginNotice.NONE;
 		}
-		Object notice = session.getAttribute(SESSION_ATTRIBUTE);
-		session.removeAttribute(SESSION_ATTRIBUTE);
+		String sessionAttribute = sessionAttribute(loginPath(request));
+		Object notice = session.getAttribute(sessionAttribute);
+		session.removeAttribute(sessionAttribute);
 		return notice == LoginNotice.RETRY_WARNING ? LoginNotice.RETRY_WARNING : LoginNotice.NONE;
+	}
+
+	private static String loginPath(HttpServletRequest request) {
+		String requestPath = request.getRequestURI().substring(request.getContextPath().length());
+		return "/operator/login".equals(requestPath) ? "/operator/login" : "/admin/login";
+	}
+
+	private static String sessionAttribute(String loginPath) {
+		return SESSION_ATTRIBUTE + loginPath;
 	}
 }

--- a/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
@@ -74,6 +74,11 @@ public class SecurityConfig {
 	}
 
 	@Bean
+	LoginNoticeFlash loginNoticeFlash() {
+		return new LoginNoticeFlash();
+	}
+
+	@Bean
 	@Order(0)
 	SecurityFilterChain datapackWorkflowApiSecurityFilterChain(
 		HttpSecurity http,
@@ -104,6 +109,7 @@ public class SecurityConfig {
 		HttpSecurity http,
 		AdminOperatorAuditFilter auditFilter,
 		AdminHtmlAccessDeniedHandler adminHtmlAccessDeniedHandler,
+		LoginNoticeFlash loginNoticeFlash,
 		@Value("${easysubway.admin.basic-auth.enabled:true}") boolean basicAuthEnabled
 	) throws Exception {
 		// 관리자 확인 화면에는 상태 변경 form이 있으므로 CSRF 보호를 유지한다.
@@ -230,6 +236,7 @@ public class SecurityConfig {
 			)
 			.formLogin(form -> form
 				.loginPage("/admin/login")
+				.failureHandler(loginNoticeFlash)
 				.defaultSuccessUrl("/admin/dashboard/page", true)
 				.permitAll()
 			)
@@ -249,6 +256,7 @@ public class SecurityConfig {
 	SecurityFilterChain operatorSecurityFilterChain(
 		HttpSecurity http,
 		AdminOperatorAuditFilter auditFilter,
+		LoginNoticeFlash loginNoticeFlash,
 		@Value("${easysubway.admin.basic-auth.enabled:true}") boolean basicAuthEnabled
 	) throws Exception {
 		// 운영기관 전용 화면은 전역 관리자와 별도 역할로 분리해 이후 기관별 범위 제한을 붙일 수 있게 한다.
@@ -276,6 +284,7 @@ public class SecurityConfig {
 			)
 			.formLogin(form -> form
 				.loginPage("/operator/login")
+				.failureHandler(loginNoticeFlash)
 				.defaultSuccessUrl("/operator/accessibility-report/page", true)
 				.permitAll()
 			)

--- a/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorLoginPageController.java
+++ b/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorLoginPageController.java
@@ -1,13 +1,23 @@
 package com.easysubway.operator.adapter.in.web;
 
+import com.easysubway.common.security.LoginNoticeFlash;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
 class OperatorLoginPageController {
 
+	private final LoginNoticeFlash loginNoticeFlash;
+
+	OperatorLoginPageController(LoginNoticeFlash loginNoticeFlash) {
+		this.loginNoticeFlash = loginNoticeFlash;
+	}
+
 	@GetMapping("/operator/login")
-	String loginPage() {
+	String loginPage(HttpServletRequest request, Model model) {
+		model.addAttribute("loginNotice", loginNoticeFlash.consume(request));
 		return "operator/login";
 	}
 }

--- a/backend/src/main/resources/templates/admin/login.html
+++ b/backend/src/main/resources/templates/admin/login.html
@@ -13,7 +13,6 @@
 			<div><strong>쉬운 지하철</strong><span>통합 관리자 콘솔</span></div>
 		</div>
 		<h1>관리자 로그인</h1>
-		<p>역·시설 데이터와 사용자 제보를 안전하게 관리합니다.</p>
 		<input th:if="${_csrf != null}" type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 		<div class="login-field">
 			<label for="username">아이디</label>
@@ -23,8 +22,10 @@
 			<label for="password">비밀번호</label>
 			<input id="password" name="password" type="password" autocomplete="current-password" required>
 		</div>
-		<button class="login-submit" type="submit">안전하게 로그인</button>
-		<div class="login-note">로그인 실패가 반복되면 15분 동안 접속이 제한됩니다. 계정 공유 없이 개인 계정을 사용해 주세요.</div>
+		<button class="login-submit" type="submit">로그인</button>
+		<div class="login-note"
+		     role="alert"
+		     th:if="${loginNotice == T(com.easysubway.common.security.LoginNotice).RETRY_WARNING}">아이디 또는 비밀번호를 확인하고 다시 시도해 주세요.</div>
 	</form>
 </main>
 </body>

--- a/backend/src/main/resources/templates/operator/login.html
+++ b/backend/src/main/resources/templates/operator/login.html
@@ -13,7 +13,6 @@
 			<div><strong>쉬운 지하철</strong><span>운영기관 포털</span></div>
 		</div>
 		<h1>운영기관 로그인</h1>
-		<p>기관 담당자에게 발급된 계정으로 접근성 보고서를 확인하세요.</p>
 		<input th:if="${_csrf != null}" type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 		<div class="login-field">
 			<label for="username">아이디</label>
@@ -23,8 +22,10 @@
 			<label for="password">비밀번호</label>
 			<input id="password" name="password" type="password" autocomplete="current-password" required>
 		</div>
-		<button class="login-submit" type="submit">안전하게 로그인</button>
-		<div class="login-note">로그인 실패가 반복되면 15분 동안 접속이 제한됩니다. 계정 공유 없이 개인 계정을 사용해 주세요.</div>
+		<button class="login-submit" type="submit">로그인</button>
+		<div class="login-note"
+		     role="alert"
+		     th:if="${loginNotice == T(com.easysubway.common.security.LoginNotice).RETRY_WARNING}">아이디 또는 비밀번호를 확인하고 다시 시도해 주세요.</div>
 	</form>
 </main>
 </body>

--- a/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminE2EFlowTest.java
+++ b/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminE2EFlowTest.java
@@ -101,17 +101,17 @@ class AdminE2EFlowTest {
 				.user("admin-user")
 				.password("wrong-password"))
 			.andExpect(status().is3xxRedirection())
-			.andExpect(redirectedUrl("/admin/login?error"));
+			.andExpect(redirectedUrl("/admin/login"));
 		mockMvc.perform(formLogin("/admin/login")
 				.user("admin-user")
 				.password("wrong-password"))
 			.andExpect(status().is3xxRedirection())
-			.andExpect(redirectedUrl("/admin/login?error"));
+			.andExpect(redirectedUrl("/admin/login"));
 		mockMvc.perform(formLogin("/admin/login")
 				.user("admin-user")
 				.password("admin-test-password"))
 			.andExpect(status().is3xxRedirection())
-			.andExpect(redirectedUrl("/admin/login?error"));
+			.andExpect(redirectedUrl("/admin/login"));
 
 		assertThat(identityRepository.findByLoginId("admin-user").orElseThrow().failedLoginCount()).isEqualTo(2);
 		assertThat(identityRepository.audits())

--- a/backend/src/test/java/com/easysubway/common/security/LoginNoticeSecurityTest.java
+++ b/backend/src/test/java/com/easysubway/common/security/LoginNoticeSecurityTest.java
@@ -1,0 +1,227 @@
+package com.easysubway.common.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.easysubway.admin.identity.adapter.out.persistence.InMemoryAdminIdentityRepository;
+import com.easysubway.admin.identity.domain.AdminIdentity;
+import com.easysubway.admin.identity.domain.AdminIdentityAuthMethod;
+import com.easysubway.admin.identity.domain.AdminIdentityRole;
+import com.easysubway.admin.identity.domain.AdminIdentityStatus;
+import java.time.LocalDateTime;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest(properties = {
+	"easysubway.admin.username=admin-user",
+	"easysubway.admin.password=admin-test-password",
+	"easysubway.operator.username=operator-user",
+	"easysubway.operator.password=operator-test-password"
+})
+@AutoConfigureMockMvc
+@DisplayName("관리자·운영기관 로그인 공개 notice")
+class LoginNoticeSecurityTest {
+
+	private static final String RETRY_WARNING_COPY = "아이디 또는 비밀번호를 확인하고 다시 시도해 주세요.";
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private InMemoryAdminIdentityRepository identityRepository;
+
+	@Autowired
+	private PasswordEncoder passwordEncoder;
+
+	@Test
+	@DisplayName("정상 화면은 동일한 로그인 카피만 제공한다")
+	void normalPagesKeepCopyParity() throws Exception {
+		String adminHtml = normalLoginHtml(LoginSurface.ADMIN);
+		String operatorHtml = normalLoginHtml(LoginSurface.OPERATOR);
+
+		assertThat(adminHtml)
+			.contains(">로그인</button>")
+			.doesNotContain("안전하게 로그인", "역·시설 데이터와 사용자 제보를 안전하게 관리합니다.", RETRY_WARNING_COPY);
+		assertThat(operatorHtml)
+			.contains(">로그인</button>")
+			.doesNotContain("안전하게 로그인", "기관 담당자에게 발급된 계정으로 접근성 보고서를 확인하세요.", RETRY_WARNING_COPY);
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@EnumSource(LoginSurface.class)
+	@DisplayName("GET과 query parameter는 경고 상태를 주입할 수 없다")
+	void getAndQueryCannotInjectWarning(LoginSurface surface) throws Exception {
+		String html = mockMvc.perform(get(surface.loginPath)
+				.param("loginNotice", "RETRY_WARNING")
+				.param("error", "locked"))
+			.andExpect(status().isOk())
+			.andExpect(model().attribute("loginNotice", LoginNotice.NONE))
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html).doesNotContain(RETRY_WARNING_COPY, "role=\"alert\"");
+	}
+
+	@ParameterizedTest(name = "{0} {1}")
+	@MethodSource("failureMatrix")
+	@DisplayName("모든 backend identity 실패는 동일한 one-shot 경고로 응답한다")
+	void identityFailuresShareOneShotPublicResponse(LoginSurface surface, FailureKind failure) throws Exception {
+		String username = surface.name().toLowerCase() + "-" + failure.name().toLowerCase();
+		String password = "correct-password";
+		if (failure != FailureKind.UNKNOWN) {
+			identityRepository.save(identity(username, password, surface.role, failure.status));
+		}
+
+		MockHttpSession session = new MockHttpSession();
+		MvcResult failureResult = mockMvc.perform(post(surface.loginPath)
+				.session(session)
+				.with(csrf())
+				.param("username", username)
+				.param("password", failure == FailureKind.WRONG_PASSWORD ? "wrong-password" : password))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl(surface.loginPath))
+			.andExpect(content().string(""))
+			.andReturn();
+
+		String warningHtml = mockMvc.perform(get(surface.loginPath).session(sessionFrom(failureResult)))
+			.andExpect(status().isOk())
+			.andExpect(model().attribute("loginNotice", LoginNotice.RETRY_WARNING))
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+		assertThat(warningHtml)
+			.contains(RETRY_WARNING_COPY, "role=\"alert\"")
+			.doesNotContain(username, failure.publicForbiddenCopy);
+
+		String refreshedHtml = mockMvc.perform(get(surface.loginPath).session(sessionFrom(failureResult)))
+			.andExpect(status().isOk())
+			.andExpect(model().attribute("loginNotice", LoginNotice.NONE))
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+		assertThat(refreshedHtml).doesNotContain(RETRY_WARNING_COPY, "role=\"alert\"");
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@EnumSource(LoginSurface.class)
+	@DisplayName("missing·invalid CSRF는 403이고 경고 flash를 만들지 않는다")
+	void csrfFailuresDoNotCreateNotice(LoginSurface surface) throws Exception {
+		assertCsrfFailureHasNoNotice(surface, false);
+		assertCsrfFailureHasNoNotice(surface, true);
+	}
+
+	private String normalLoginHtml(LoginSurface surface) throws Exception {
+		return mockMvc.perform(get(surface.loginPath))
+			.andExpect(status().isOk())
+			.andExpect(model().attribute("loginNotice", LoginNotice.NONE))
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+	}
+
+	private void assertCsrfFailureHasNoNotice(LoginSurface surface, boolean invalidToken) throws Exception {
+		MockHttpSession session = new MockHttpSession();
+		var request = post(surface.loginPath)
+			.session(session)
+			.param("username", "unknown-user")
+			.param("password", "wrong-password");
+		if (invalidToken) {
+			request.param("_csrf", "invalid-token");
+		}
+		mockMvc.perform(request)
+			.andExpect(status().isForbidden());
+
+		String html = mockMvc.perform(get(surface.loginPath).session(session))
+			.andExpect(status().isOk())
+			.andExpect(model().attribute("loginNotice", LoginNotice.NONE))
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+		assertThat(html).doesNotContain(RETRY_WARNING_COPY, "role=\"alert\"");
+	}
+
+	private AdminIdentity identity(
+		String username,
+		String password,
+		AdminIdentityRole role,
+		AdminIdentityStatus status
+	) {
+		LocalDateTime now = LocalDateTime.now().minusDays(1);
+		return new AdminIdentity(
+			username,
+			"테스트 관리자",
+			null,
+			passwordEncoder.encode(password),
+			AdminIdentityAuthMethod.LOCAL,
+			role,
+			status,
+			0,
+			null,
+			now,
+			null,
+			false,
+			null,
+			false,
+			now,
+			now
+		);
+	}
+
+	private MockHttpSession sessionFrom(MvcResult result) {
+		return (MockHttpSession) result.getRequest().getSession(false);
+	}
+
+	private static Stream<Arguments> failureMatrix() {
+		return Stream.of(LoginSurface.values())
+			.flatMap(surface -> Stream.of(FailureKind.values())
+				.map(failure -> Arguments.of(surface, failure)));
+	}
+
+	private enum LoginSurface {
+		ADMIN("/admin/login", AdminIdentityRole.ADMIN),
+		OPERATOR("/operator/login", AdminIdentityRole.OPERATOR_ADMIN);
+
+		private final String loginPath;
+		private final AdminIdentityRole role;
+
+		LoginSurface(String loginPath, AdminIdentityRole role) {
+			this.loginPath = loginPath;
+			this.role = role;
+		}
+	}
+
+	private enum FailureKind {
+		UNKNOWN(AdminIdentityStatus.ACTIVE, "UNKNOWN"),
+		WRONG_PASSWORD(AdminIdentityStatus.ACTIVE, "wrong-password"),
+		LOCKED(AdminIdentityStatus.LOCKED, "LOCKED"),
+		DISABLED(AdminIdentityStatus.DISABLED, "DISABLED"),
+		EXPIRED(AdminIdentityStatus.PASSWORD_EXPIRED, "PASSWORD_EXPIRED");
+
+		private final AdminIdentityStatus status;
+		private final String publicForbiddenCopy;
+
+		FailureKind(AdminIdentityStatus status, String publicForbiddenCopy) {
+			this.status = status;
+			this.publicForbiddenCopy = publicForbiddenCopy;
+		}
+	}
+}

--- a/backend/src/test/java/com/easysubway/common/security/LoginNoticeSecurityTest.java
+++ b/backend/src/test/java/com/easysubway/common/security/LoginNoticeSecurityTest.java
@@ -123,6 +123,38 @@ class LoginNoticeSecurityTest {
 
 	@ParameterizedTest(name = "{0}")
 	@EnumSource(LoginSurface.class)
+	@DisplayName("실패 warning은 다른 로그인 surface가 먼저 열려도 교차 소비되지 않는다")
+	void warningIsScopedToLoginSurface(LoginSurface surface) throws Exception {
+		MockHttpSession session = new MockHttpSession();
+		MvcResult failureResult = mockMvc.perform(post(surface.loginPath)
+				.session(session)
+				.with(csrf())
+				.param("username", "unknown-user")
+				.param("password", "wrong-password"))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl(surface.loginPath))
+			.andReturn();
+		MockHttpSession failureSession = sessionFrom(failureResult);
+
+		String otherSurfaceHtml = mockMvc.perform(get(surface.other().loginPath).session(failureSession))
+			.andExpect(status().isOk())
+			.andExpect(model().attribute("loginNotice", LoginNotice.NONE))
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+		assertThat(otherSurfaceHtml).doesNotContain(RETRY_WARNING_COPY, "role=\"alert\"");
+
+		String originalSurfaceHtml = mockMvc.perform(get(surface.loginPath).session(failureSession))
+			.andExpect(status().isOk())
+			.andExpect(model().attribute("loginNotice", LoginNotice.RETRY_WARNING))
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+		assertThat(originalSurfaceHtml).contains(RETRY_WARNING_COPY, "role=\"alert\"");
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@EnumSource(LoginSurface.class)
 	@DisplayName("missing·invalid CSRF는 403이고 경고 flash를 만들지 않는다")
 	void csrfFailuresDoNotCreateNotice(LoginSurface surface) throws Exception {
 		assertCsrfFailureHasNoNotice(surface, false);
@@ -206,6 +238,10 @@ class LoginNoticeSecurityTest {
 		LoginSurface(String loginPath, AdminIdentityRole role) {
 			this.loginPath = loginPath;
 			this.role = role;
+		}
+
+		LoginSurface other() {
+			return this == ADMIN ? OPERATOR : ADMIN;
 		}
 	}
 

--- a/backend/src/test/java/com/easysubway/common/security/LoginNoticeTest.java
+++ b/backend/src/test/java/com/easysubway/common/security/LoginNoticeTest.java
@@ -1,0 +1,17 @@
+package com.easysubway.common.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("공개 로그인 notice")
+class LoginNoticeTest {
+
+	@Test
+	@DisplayName("공개 상태는 NONE과 RETRY_WARNING만 제공한다")
+	void exposesOnlyNoneAndRetryWarning() {
+		assertThat(LoginNotice.values())
+			.containsExactly(LoginNotice.NONE, LoginNotice.RETRY_WARNING);
+	}
+}

--- a/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorLoginPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorLoginPageControllerTest.java
@@ -41,8 +41,10 @@ class OperatorLoginPageControllerTest {
 			.contains("운영기관 포털")
 			.contains("아이디")
 			.contains("비밀번호")
-			.contains("안전하게 로그인")
-			.contains("name=\"_csrf\"");
+			.contains(">로그인</button>")
+			.contains("name=\"_csrf\"")
+			.doesNotContain("안전하게 로그인")
+			.doesNotContain("기관 담당자에게 발급된 계정으로 접근성 보고서를 확인하세요.");
 	}
 
 	@Test


### PR DESCRIPTION
## 관련 이슈

Closes #2074

## 작업 배경

관리자·운영기관 로그인 화면이 계정 상태와 무관한 잠금 안내를 상시 노출하고, Spring Security 기본 실패 query에 의존해 backend identity 상태가 public surface로 확장될 여지가 있었습니다. 두 화면이 같은 server-owned one-shot notice만 사용하도록 경계를 고정합니다.

## 작업 내용

- public `LoginNotice` enum을 `NONE`, `RETRY_WARNING` 두 값으로만 정의했습니다.
- 공통 `AuthenticationFailureHandler`가 실패 notice를 session에 기록하고 다음 login GET이 한 번만 consume하도록 했습니다.
- admin/operator notice 세션 키를 surface별로 격리해 다중 탭의 반대 로그인 화면이 warning을 교차 소비하지 못하게 했습니다.
- unknown account, wrong password, locked, disabled, expired를 동일 redirect·빈 body·경고 copy로 매핑하고 query/GET injection을 차단했습니다.
- admin/operator promotional subtitle과 상시 잠금 안내를 제거하고 버튼을 `로그인`으로 통일했습니다.
- missing/invalid CSRF는 기존 403을 유지하며 flash를 만들지 않도록 회귀 테스트를 추가했습니다.

## 검증

- `./gradlew test`: surface 격리 fix 후 전체 backend suite `BUILD SUCCESSFUL in 3m 32s`
- focused login enum/security/admin/operator tests: `BUILD SUCCESSFUL in 11s`
- `node --test tools/ci/repository-contract.test.mjs`: 217/217 통과
- `git diff --check`: 통과

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| identity-state public parity | Backend/MockMvc | admin/operator × unknown/wrong/locked/disabled/expired matrix | `LoginNoticeSecurityTest` | 통과 |
| one-shot·surface 격리·injection·CSRF | Backend/MockMvc | warning 1회 소비, admin/operator 교차 소비 차단, query 무시, missing/invalid CSRF 403 | `LoginNoticeSecurityTest` | 통과 |
| login copy·Semantics | Thymeleaf/MockMvc | 정상/경고 rendering, `role="alert"`, label·CSRF 유지 | security/controller tests | 통과 |
| 최종 screenshot·WCAG | #1988 소유 | 이 이슈는 자동화 결과만 evidence 입력으로 제공 | #1988 final evidence manifest에서 수행 | 이 PR 비대상 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: public login notice 2-state mapping 추가, account state·lockout 정책 변경 없음

## 리뷰어 메모

- `LoginNoticeFlash`의 surface별 redirect와 session consume lifecycle을 먼저 확인해 주세요.
- `LoginNoticeSecurityTest`가 backend identity state별 내부 동작은 유지하면서 public response만 동일화하는지 확인해 주세요.

## 리스크

- authentication failure handler를 공통 교체합니다. 기존 account-specific provider와 audit은 변경하지 않았고 admin/operator 전체 failure matrix 및 전체 backend suite로 검증했습니다.
- session notice는 동일 session의 같은 login surface에서 다음 GET에 제거됩니다. 반대 surface, query parameter와 CSRF 실패는 notice 소비·생성 경계에 들어오지 않습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
