### PR TITLE
[Style] #2075 #2076 모바일 topbar·alert 정합성 정리

### DIFF
--- a/backend/src/main/resources/static/css/admin-v3.css
+++ b/backend/src/main/resources/static/css/admin-v3.css
@@ -218,6 +218,10 @@ body.admin-v3 {
 	gap: 10px;
 }
 
+.admin-topbar-logout-form {
+	margin: 0;
+}
+
 /* 상태 스트립: 정적·무채색·비인터랙티브. 각 항목은 라벨 + 값으로 의미를 드러내고, title 툴팁으로
    상세를 설명한다. 버튼처럼 보이지 않도록 배경·보더 없이 얇은 구분선(·) 만으로 구분한다. */
 .admin-status-strip {
@@ -318,6 +322,11 @@ body.admin-v3 {
 	flex-wrap: wrap;
 	gap: 8px;
 	justify-content: flex-end;
+}
+
+.admin-dashboard-snapshot-actions {
+	align-items: center;
+	min-height: 44px;
 }
 
 .admin-btn,
@@ -1602,7 +1611,22 @@ body.admin-v3 {
 	}
 
 	.admin-topbar-row {
-		display: grid;
+		display: flex;
+		padding: 0 0 10px;
+		border: 0;
+		border-bottom: 1px solid var(--admin-border);
+		border-radius: 0;
+		background: transparent;
+		box-shadow: none;
+	}
+
+	.admin-topbar-context {
+		flex: 1 1 190px;
+		align-items: center;
+	}
+
+	.admin-topbar-actions {
+		flex: 0 1 auto;
 	}
 
 	.admin-grid-2,
@@ -1614,6 +1638,14 @@ body.admin-v3 {
 	   뒤에 있어 동일 명시도면 base가 이긴다. nav-control을 끼워 명시도를 (0,3,0)으로 올려 노출한다. */
 	.admin-v3 .admin-sidebar-nav-control .admin-sidebar-toggle {
 		display: inline-flex;
+		border: 0;
+		border-radius: 0;
+		background: transparent;
+	}
+
+	.admin-dashboard-snapshot-actions {
+		margin-top: 10px;
+		justify-content: flex-start;
 	}
 
 	/* JS 있으면 오프캔버스: 사이드바를 화면 밖에 두고 토글로 연다(body.sidebar-open). */
@@ -1781,8 +1813,8 @@ body.admin-v3 {
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
-	width: 36px;
-	height: 36px;
+	width: 44px;
+	height: 44px;
 	border: 1px solid var(--admin-border);
 	border-radius: var(--admin-radius-control);
 	background: var(--admin-surface);
@@ -1882,7 +1914,7 @@ body.admin-v3 {
 	border: 0;
 }
 
-/* 사용자 메뉴 드롭다운(#2047): 상단바 우측 트리거 + 계정/로그아웃 패널. alert-center와 동일한
+/* 사용자 메뉴 드롭다운(#2047): 상단바 우측 트리거 + 계정 정보 패널. alert-center와 동일한
    앵커드 드롭다운 규격(1px 보더·그림자 0·radius ≤8). 트리거는 무채색이고, 활성(열림) 표시는
    보더를 액센트로 바꿔 파랑을 주 상호작용에만 쓴다는 원칙을 지킨다. */
 .admin-user-menu {
@@ -1897,7 +1929,7 @@ body.admin-v3 {
 	flex-direction: column;
 	align-items: flex-end;
 	gap: 1px;
-	min-height: 36px;
+	min-height: 44px;
 	padding: 4px 10px;
 	border: 1px solid var(--admin-border);
 	border-radius: var(--admin-radius-control);
@@ -1945,7 +1977,7 @@ body.admin-v3 {
 
 /* no-JS 폴백(#2049 리뷰): x-cloak 대신 has-js 초기화 창에서만 패널을 숨긴다. JS가 있으면
    alpine:initialized 이후 x-show(open)의 인라인 display가 전담하고, JS가 없으면(has-js 미부착)
-   이 규칙이 걸리지 않아 계정 정보·로그아웃 폼이 그대로 노출된다(bulk-actionbar와 동일 패턴). */
+   이 규칙이 걸리지 않아 계정 정보가 그대로 노출된다. */
 .admin-v3.has-js:not(.has-js-ready) .admin-user-menu-panel {
 	display: none;
 }
@@ -1954,9 +1986,8 @@ body.admin-v3 {
 	display: grid;
 	grid-template-columns: max-content 1fr;
 	gap: 6px 12px;
-	margin: 0 0 12px;
-	padding: 0 0 12px;
-	border-bottom: 1px solid var(--admin-border);
+	margin: 0;
+	padding: 0;
 	font-size: 13px;
 }
 
@@ -1971,16 +2002,25 @@ body.admin-v3 {
 	font-weight: var(--admin-w-strong);
 }
 
-/* 로그아웃은 주 액션이 아니므로 파랑 채움을 벗기고 고스트(무채색 surface·1px 보더·잉크색)로 둔다. */
-.admin-v3 .admin-user-menu-logout {
-	width: 100%;
+/* topbar 로그아웃은 독립 neutral action이며 account dialog와 별개로 항상 접근 가능하다. */
+.admin-v3 .admin-topbar-logout {
+	min-width: 44px;
+	min-height: 44px;
 	background: var(--admin-surface);
 	border: 1px solid var(--admin-border);
 	color: var(--admin-ink);
 }
 
-.admin-v3 .admin-user-menu-logout:hover {
+.admin-v3 .admin-topbar-logout:hover {
 	background: var(--admin-bg);
+}
+
+.admin-v3 .admin-sidebar-toggle,
+.admin-v3 .admin-alert-bell,
+.admin-v3 .admin-user-menu-trigger,
+.admin-v3 .admin-topbar-logout {
+	min-width: 44px;
+	min-height: 44px;
 }
 
 /* 반응형 사이드바 토글(#1738, 명시도 버그 수정 #2047): 데스크톱(>1024px)에서는 숨긴다.
@@ -1995,8 +2035,8 @@ body.admin-v3 {
 	display: none;
 	align-items: center;
 	justify-content: center;
-	width: 36px;
-	height: 36px;
+	width: 44px;
+	height: 44px;
 	border: 1px solid var(--admin-border);
 	border-radius: var(--admin-radius-control);
 	background: var(--admin-surface);

--- a/backend/src/main/resources/templates/admin/alerts.html
+++ b/backend/src/main/resources/templates/admin/alerts.html
@@ -37,7 +37,7 @@
 <th:block th:fragment="panel">
 	<span class="admin-alert-badge" aria-hidden="true"
 	      th:if="${alertSummary.hasAlerts()}" th:text="${alertSummary.count()}">0</span>
-	<div class="admin-alert-panel" role="region" aria-label="알림 센터">
+	<div class="admin-alert-panel">
 		<p class="admin-alert-panel-head">알림 <span th:text="${alertSummary.count()}">0</span>건</p>
 		<div th:unless="${alertSummary.hasAlerts()}">
 			<div th:replace="~{admin/fragments/empty-state :: panel('확인할 알림이 없습니다.', '새 신호가 생기면 여기에 표시됩니다.')}"></div>

--- a/backend/src/main/resources/templates/admin/dashboard.html
+++ b/backend/src/main/resources/templates/admin/dashboard.html
@@ -18,7 +18,7 @@
 		<div>
 			<h1>통합 대시보드</h1>
 		</div>
-		<div class="admin-actions">
+		<div class="admin-actions admin-dashboard-snapshot-actions">
 			<span th:if="${snapshotStatus == null}" class="admin-status warn">지표 집계 대기</span>
 			<span th:if="${snapshotStatus != null and snapshotStatus.success}" class="admin-status good">지표 집계 정상</span>
 			<span th:if="${snapshotStatus != null and !snapshotStatus.success}" class="admin-status bad">지표 집계 실패</span>

--- a/backend/src/main/resources/templates/admin/fragments/shell.html
+++ b/backend/src/main/resources/templates/admin/fragments/shell.html
@@ -93,14 +93,14 @@
 				<div id="admin-alert-live" class="admin-alert-live" role="region" aria-label="알림 센터"></div>
 			</div>
 			<!--
-			  사용자 메뉴 드롭다운(#2047): 이름·권한 요약을 트리거로 계정 정보를 보여준다.
+			  사용자 메뉴 disclosure(#2047): 이름·권한 요약을 트리거로 계정 정보를 보여준다.
 			  로그아웃은 다음 형제 action의 CSRF POST form이 소유한다. CSP 빌드라 디렉티브에는
 			  메서드·게터 이름만 넣고, no-JS에서도 계정 정보와 로그아웃 action을 모두 유지한다.
 			-->
 			<div class="admin-user-menu" x-data="userMenu"
 			     x-on:keydown.escape.window="closeFromKeyboard" x-on:click.outside="close">
 				<button type="button" class="admin-user-menu-trigger" x-ref="trigger"
-				        x-on:click="toggle" aria-haspopup="dialog"
+				        x-on:click="toggle"
 				        x-bind:aria-expanded="ariaExpanded" aria-controls="admin-user-menu-panel"
 				        aria-label="사용자 메뉴">
 					<span class="admin-user-menu-name" th:text="${adminShell != null ? adminShell.username : 'anonymous'}">admin</span>
@@ -108,7 +108,7 @@
 					<span class="admin-user-menu-caret" aria-hidden="true"></span>
 				</button>
 				<div id="admin-user-menu-panel" class="admin-user-menu-panel" x-show="open"
-				     role="dialog" aria-label="사용자 메뉴">
+				     role="region" aria-label="사용자 메뉴">
 					<dl class="admin-user-menu-info">
 						<dt>계정</dt>
 						<dd th:text="${adminShell != null ? adminShell.username : 'anonymous'}">admin</dd>

--- a/backend/src/main/resources/templates/admin/fragments/shell.html
+++ b/backend/src/main/resources/templates/admin/fragments/shell.html
@@ -58,25 +58,21 @@
 <a th:fragment="skipLink" class="skip-link" href="#admin-content">본문으로 건너뛰기</a>
 <div th:fragment="topbar" class="admin-topbar">
 	<!--
-	  반응형 사이드바 토글(#1738): ≤1024px에서만 보인다. 누르면 사이드바를 오프캔버스로 연다
-	  (body.sidebar-open + 백드롭). nav 바깥(topbar)에 둬야 한다 — .has-js .admin-sidebar가
-	  transform: translateX(-100%)로 화면 밖에 있을 때도 이 토글은 항상 화면에 남아야 열 수 있다.
-	-->
-	<div class="admin-sidebar-nav-control" x-data="sidebarToggle"
-	     x-on:keydown.escape.window="close">
-		<button type="button" class="admin-sidebar-toggle" x-on:click="toggle"
-		        x-bind:aria-expanded="ariaExpanded" aria-controls="admin-primary-nav"
-		        aria-label="주 메뉴 열기·닫기">
-			<span aria-hidden="true">☰</span>
-		</button>
-		<div class="admin-sidebar-backdrop" x-cloak x-show="open" x-on:click="close"></div>
-	</div>
-	<!--
 	  상단바 상단 행(#2047): 좌측 컨텍스트(브랜드 + 통합 관리자) / 우측 알림 벨 + 사용자 메뉴 드롭다운.
 	  aria-label과 클래스는 접근성 스모크 테스트가 고정한다(관리자 실행 환경).
 	-->
 	<div class="admin-topbar-row" aria-label="관리자 실행 환경">
 		<div class="admin-topbar-context">
+			<!-- 모바일 off-canvas nav의 leading control. sidebar target·Esc·backdrop 계약은 유지한다. -->
+			<div class="admin-sidebar-nav-control" x-data="sidebarToggle"
+			     x-on:keydown.escape.window="close">
+				<button type="button" class="admin-sidebar-toggle" x-on:click="toggle"
+				        x-bind:aria-expanded="ariaExpanded" aria-controls="admin-primary-nav"
+				        aria-label="주 메뉴 열기·닫기">
+					<span aria-hidden="true">☰</span>
+				</button>
+				<div class="admin-sidebar-backdrop" x-cloak x-show="open" x-on:click="close"></div>
+			</div>
 			<strong class="admin-topbar-brand">쉬운 지하철</strong>
 			<span class="admin-topbar-sep" aria-hidden="true">/</span>
 			<span class="admin-topbar-scope">통합 관리자</span>
@@ -90,17 +86,16 @@
 			<div class="admin-alert-center" x-data="alertCenter"
 			     x-bind:class="rootClass" x-on:keydown.escape.window="hide">
 				<a class="admin-alert-bell" th:href="@{/admin/alerts}" x-on:click.prevent="toggle"
-				   aria-haspopup="dialog" x-bind:aria-expanded="ariaExpanded"
+				   x-bind:aria-expanded="ariaExpanded"
 				   aria-controls="admin-alert-live" aria-label="알림 센터">
 					<span class="admin-alert-bell-icon" aria-hidden="true">🔔</span>
 				</a>
-				<div id="admin-alert-live" class="admin-alert-live"></div>
+				<div id="admin-alert-live" class="admin-alert-live" role="region" aria-label="알림 센터"></div>
 			</div>
 			<!--
-			  사용자 메뉴 드롭다운(#2047): 이름·권한 요약을 트리거로, 열면 계정 정보와 로그아웃 폼을 담는다.
-			  로그아웃은 CSRF POST 폼이라 폼·토큰을 그대로 드롭다운 안으로 옮겼다(접근성 테스트가
-			  aria-label·action·_csrf를 고정). CSP 빌드라 디렉티브에는 메서드·게터 이름만 넣는다.
-			  no-JS: 트리거는 계정 링크로 동작하고 폼은 항상 렌더되어 접근 가능하다.
+			  사용자 메뉴 드롭다운(#2047): 이름·권한 요약을 트리거로 계정 정보를 보여준다.
+			  로그아웃은 다음 형제 action의 CSRF POST form이 소유한다. CSP 빌드라 디렉티브에는
+			  메서드·게터 이름만 넣고, no-JS에서도 계정 정보와 로그아웃 action을 모두 유지한다.
 			-->
 			<div class="admin-user-menu" x-data="userMenu"
 			     x-on:keydown.escape.window="closeFromKeyboard" x-on:click.outside="close">
@@ -120,15 +115,16 @@
 						<dt>권한</dt>
 						<dd th:text="${adminShell != null ? adminShell.rolesLabel : '권한 없음'}">admin.view</dd>
 					</dl>
-					<form th:if="${adminShell != null && adminShell.username != 'anonymous'}"
-					      th:action="@{/admin/logout}"
-					      method="post"
-					      aria-label="관리자 로그아웃">
-						<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
-						<button type="submit" class="admin-user-menu-logout">로그아웃</button>
-					</form>
 				</div>
 			</div>
+			<form th:if="${adminShell != null && adminShell.username != 'anonymous'}"
+			      class="admin-topbar-logout-form"
+			      th:action="@{/admin/logout}"
+			      method="post"
+			      aria-label="관리자 로그아웃">
+				<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+				<button type="submit" class="admin-topbar-logout" aria-label="로그아웃">로그아웃</button>
+			</form>
 		</div>
 	</div>
 	<!--

--- a/backend/src/main/resources/templates/admin/reports/list.html
+++ b/backend/src/main/resources/templates/admin/reports/list.html
@@ -249,7 +249,7 @@
 			<div class="bulk-actionbar" x-show="hasSelection">
 				<span class="bulk-count" x-text="selectionLabel">선택한 신고 일괄 처리</span>
 				<button type="submit" name="decision" value="ACCEPT">선택 승인</button>
-				<button type="submit" name="decision" value="REJECT">선택 반려</button>
+				<button class="danger" type="submit" name="decision" value="REJECT">선택 반려</button>
 			</div>
 			</form>
 			<!--

--- a/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminAccessibilitySmokeTest.java
+++ b/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminAccessibilitySmokeTest.java
@@ -155,11 +155,20 @@ class AdminAccessibilitySmokeTest {
 			.contains("<main class=\"admin-main\">")
 			.contains("<h1>" + expectedHeading + "</h1>")
 			.contains("aria-label=\"관리자 로그아웃\"")
+			.contains("class=\"admin-topbar-logout-form\"")
 			.contains("action=\"/admin/logout\"")
 			.contains("name=\"_csrf\"")
 			.doesNotContain("<main id=\"admin-content\"");
 		assertThat(html.indexOf("href=\"#admin-content\"")).isLessThan(html.indexOf("class=\"admin-shell\""));
 		assertThat(html.indexOf("class=\"admin-topbar-row\"")).isLessThan(html.indexOf("id=\"admin-content\""));
+		assertThat(html.indexOf("class=\"admin-sidebar-nav-control\""))
+			.isLessThan(html.indexOf("class=\"admin-topbar-brand\""));
+		assertThat(html.indexOf("class=\"admin-topbar-brand\""))
+			.isLessThan(html.indexOf("class=\"admin-alert-center\""));
+		assertThat(html.indexOf("class=\"admin-alert-center\""))
+			.isLessThan(html.indexOf("class=\"admin-user-menu\""));
+		assertThat(html.indexOf("class=\"admin-user-menu\""))
+			.isLessThan(html.indexOf("class=\"admin-topbar-logout-form\""));
 		assertThat(html.indexOf("id=\"admin-content\"")).isLessThan(html.indexOf("<header class=\"admin-page-head\">"));
 	}
 

--- a/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminDashboardPageTest.java
+++ b/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminDashboardPageTest.java
@@ -53,6 +53,7 @@ class AdminDashboardPageTest {
 			.contains("class=\"dashboard-card metric-cell\"")
 			.contains("통합 대시보드")
 			.doesNotContain("지금 급한 것 → 추세 → 상세 순으로 신고·시설·경로·알림·시스템을 모읍니다.")
+			.contains("class=\"admin-actions admin-dashboard-snapshot-actions\"")
 			.contains("확인할 제보")
 			.contains("href=\"/admin/reports/page\"")
 			.contains("dashboard-spark")

--- a/backend/src/test/java/com/easysubway/admin/alert/AdminAlertControllerTest.java
+++ b/backend/src/test/java/com/easysubway/admin/alert/AdminAlertControllerTest.java
@@ -74,9 +74,12 @@ class AdminAlertControllerTest {
 		assertThat(html)
 			.contains("class=\"admin-alert-center\"")
 			.contains("x-data=\"alertCenter\"")
-			.contains("id=\"admin-alert-live\"")
+			.contains("aria-controls=\"admin-alert-live\"")
+			.contains("id=\"admin-alert-live\" class=\"admin-alert-live\" role=\"region\" aria-label=\"알림 센터\"")
+			.doesNotContain("class=\"admin-alert-bell\" aria-haspopup=\"dialog\"")
 			// no-JS fallback: 벨은 알림 전용 페이지로 이동
 			.contains("href=\"/admin/alerts\"");
+		assertThat(html).containsOnlyOnce("role=\"region\" aria-label=\"알림 센터\"");
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/admin/web/AdminDesignGuardTest.java
+++ b/backend/src/test/java/com/easysubway/admin/web/AdminDesignGuardTest.java
@@ -141,6 +141,43 @@ class AdminDesignGuardTest {
 		assertThat(css).containsPattern(singleDivider);
 	}
 
+	@Test
+	@DisplayName("mobile topbar는 flat chrome과 44px action target을 유지한다")
+	void mobileTopbarUsesFlatChromeAndAccessibleTargets() throws IOException {
+		String css = read("backend/src/main/resources/static/css/admin-v3.css");
+		String shell = read("backend/src/main/resources/templates/admin/fragments/shell.html");
+
+		assertThat(css)
+			.contains(".admin-v3 .admin-sidebar-toggle,")
+			.contains(".admin-v3 .admin-alert-bell,")
+			.contains(".admin-v3 .admin-user-menu-trigger,")
+			.contains(".admin-v3 .admin-topbar-logout {")
+			.contains("min-width: 44px;")
+			.contains("min-height: 44px;")
+			.contains("border-radius: 0;")
+			.contains("background: transparent;")
+			.contains("box-shadow: none;");
+		assertThat(shell)
+			.contains("class=\"admin-topbar-logout-form\"")
+			.contains("class=\"admin-topbar-logout\" aria-label=\"로그아웃\"");
+		Matcher alertTrigger = Pattern.compile("<a class=\"admin-alert-bell\"[^>]*>").matcher(shell);
+		assertThat(alertTrigger.find()).as("alert bell trigger가 존재한다").isTrue();
+		assertThat(alertTrigger.group()).doesNotContain("aria-haspopup");
+	}
+
+	@Test
+	@DisplayName("기존 mobile metric divider는 1열에서 단일 top border를 유지한다")
+	void mobileMetricDividerKeepsSingleTopBorder() throws IOException {
+		String css = read("backend/src/main/resources/static/css/admin-v3.css");
+
+		assertThat(css)
+			.contains(".dashboard-card.metric-cell {")
+			.contains("border-left: 0;")
+			.contains("border-top: 1px solid var(--admin-border);")
+			.contains(".dashboard-card.metric-cell:first-child {")
+			.contains("border-top: 0;");
+	}
+
 	private static String read(String path) throws IOException {
 		return Files.readString(ROOT.resolve(path));
 	}

--- a/backend/src/test/java/com/easysubway/admin/web/AdminDesignGuardTest.java
+++ b/backend/src/test/java/com/easysubway/admin/web/AdminDesignGuardTest.java
@@ -163,6 +163,15 @@ class AdminDesignGuardTest {
 		Matcher alertTrigger = Pattern.compile("<a class=\"admin-alert-bell\"[^>]*>").matcher(shell);
 		assertThat(alertTrigger.find()).as("alert bell trigger가 존재한다").isTrue();
 		assertThat(alertTrigger.group()).doesNotContain("aria-haspopup");
+		Matcher userTrigger = Pattern.compile("<button[^>]*class=\"admin-user-menu-trigger\"[^>]*>")
+			.matcher(shell);
+		assertThat(userTrigger.find()).as("user menu trigger가 존재한다").isTrue();
+		assertThat(userTrigger.group()).doesNotContain("aria-haspopup");
+		Matcher userPanel = Pattern.compile("<div[^>]*id=\"admin-user-menu-panel\"[^>]*>").matcher(shell);
+		assertThat(userPanel.find()).as("user menu panel이 존재한다").isTrue();
+		assertThat(userPanel.group())
+			.contains("role=\"region\"")
+			.doesNotContain("role=\"dialog\"");
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageControllerTest.java
@@ -222,6 +222,7 @@ class FacilityReportAdminPageControllerTest {
 			.contains("신고 급증")
 			.contains("시설 신고 확인")
 			.doesNotContain("상태·사진·위치·접수일 기준으로 제보를 확인 대기열에 배치합니다.")
+			.contains("class=\"danger\" type=\"submit\" name=\"decision\" value=\"REJECT\">선택 반려")
 			.contains("점검 필요")
 			.contains("신고가 평소보다 많습니다")
 			.containsPattern("최근 24시간 신고 \\d+건");


### PR DESCRIPTION
## 관련 이슈

Closes #2075
Closes #2076

## 작업 내용

- 모바일 topbar의 햄버거·제목·알림·계정·로그아웃 순서를 한 행에 정렬하고 각 action의 44px target을 보장했습니다.
- 알림 trigger와 live panel의 ARIA 역할을 정리해 중복 region과 잘못된 dialog popup 의미를 제거했습니다.
- 대시보드 snapshot 상태와 신고 일괄 반려 action의 시각적 우선순위를 정리했습니다.
- shell 순서, ARIA, flat chrome, 기존 metric divider를 회귀 테스트로 고정했습니다.

## 검증

- 재배이스 결합부 focused 5개 test class: 통과 (19초)
- `./gradlew check`: 전체 backend suite 통과 (3분 37초)
- `node --test tools/ci/*.test.mjs tools/ci/lib/*.test.mjs tools/repo/*.test.mjs`: 357/357 통과
- `git diff --check`: 통과

## 영향

- [ ] 제품/운영 위험 없음 (admin mobile UX·접근성 변경이므로 해당 없음)
- [x] DB migration 없음
- [x] 배포 영향 없음
- [x] route/realtime/datapack contract 영향 없음
- [x] CI workflow·계약 테스트·release gate JSON 변경 없음 (있으면 full.md로 전환)

## 체크리스트

- [x] 이 PR은 B/C등급 작업이며 full template이 필요 없다.
- [ ] CI 결과를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 폴백 리뷰를 단일 PR review로 게시했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 관리자 대시보드 상단바와 모바일 레이아웃을 개선했습니다.
  * 사이드바, 알림, 사용자 메뉴, 로그아웃 컨트롤의 터치 영역을 44px로 확대했습니다.
  * 알림 센터와 사용자 메뉴의 접근성을 개선했습니다.
  * 대시보드 스냅샷 액션 영역의 정렬과 표시를 보완했습니다.
  * 모바일 화면에서 상단바와 사이드바 토글 배치를 개선했습니다.
  * 신고 일괄 처리 시 ‘선택 반려’ 버튼을 위험 작업으로 명확히 표시했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->