### PR TITLE
[Feat] capacity evidence workflow에 deploy_sha input 추가 (Refs #2095)

### DIFF
--- a/.github/workflows/production-route-v2-capacity-evidence.yml
+++ b/.github/workflows/production-route-v2-capacity-evidence.yml
@@ -2,6 +2,11 @@ name: Production Route V2 capacity evidence
 
 on:
   workflow_dispatch:
+    inputs:
+      deploy_sha:
+        description: "capacity evidence를 실행할, 이미 배포된 main 커밋 SHA. 비우면 현재 main head."
+        required: false
+        type: string
 
 jobs:
   verify:
@@ -18,7 +23,7 @@ jobs:
       cancel-in-progress: false
     env:
       DEPLOY_ROOT: ${{ vars.DEPLOY_ROOT }}
-      EXPECTED_DEPLOYED_SHA: ${{ github.sha }}
+      EXPECTED_DEPLOYED_SHA: ${{ inputs.deploy_sha != '' && inputs.deploy_sha || github.sha }}
 
     steps:
       - name: Reject non-main manual execution
@@ -32,7 +37,23 @@ jobs:
       - name: Checkout reviewed main
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
+          fetch-depth: 0
           persist-credentials: false
+
+      - name: Verify deploy SHA is an ancestor of main
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! "${EXPECTED_DEPLOYED_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "invalid deploy sha: ${EXPECTED_DEPLOYED_SHA}" >&2
+            exit 1
+          fi
+          git fetch origin main
+          if ! git merge-base --is-ancestor "${EXPECTED_DEPLOYED_SHA}" origin/main; then
+            echo "deploy target is not on origin/main: ${EXPECTED_DEPLOYED_SHA}" >&2
+            exit 1
+          fi
+          git checkout --detach "${EXPECTED_DEPLOYED_SHA}"
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e

--- a/tools/ci/production-route-v2-capacity-evidence-workflow.test.mjs
+++ b/tools/ci/production-route-v2-capacity-evidence-workflow.test.mjs
@@ -21,13 +21,45 @@ test("Route V2 capacity evidence는 main-only production approval을 강제한�
   assert.match(workflow, /timeout-minutes: 30/);
   assert.match(workflow, /cancel-in-progress: false/);
   assert.match(workflow, /group: production-route-v2-capacity-evidence/);
-  assert.match(workflow, /EXPECTED_DEPLOYED_SHA: \$\{\{ github\.sha \}\}/);
+  // main이 계속 전진해도 이미 배포된 candidate에 대해 capacity evidence를 돌릴 수
+  // 있도록, EXPECTED_DEPLOYED_SHA는 workflow_dispatch.inputs.deploy_sha가 지정되면
+  // 그 값을, 비어 있으면 현재 main head(github.sha)를 사용한다 — CD workflow의
+  // deploy_sha 처리(.github/workflows/cd.yml)와 동형이다.
+  assert.match(
+    workflow,
+    /deploy_sha:\n\s+description: "capacity evidence를 실행할, 이미 배포된 main 커밋 SHA\. 비우면 현재 main head\."\n\s+required: false\n\s+type: string/,
+  );
+  assert.match(
+    workflow,
+    /EXPECTED_DEPLOYED_SHA: \$\{\{ inputs\.deploy_sha != '' && inputs\.deploy_sha \|\| github\.sha \}\}/,
+  );
   assert.match(workflow, /actions\/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e/);
   assert.match(workflow, /node-version: "24"/);
   assert.match(workflow, /bash tools\/ops\/verify-production-route-v2-capacity\.sh/);
   assert.match(
     workflow,
     /if \[\[ "\$\{GITHUB_REF\}" != "refs\/heads\/main" \]\]; then\s+echo "production Route V2 capacity evidence must run from main" >&2\s+exit 1\s+fi/,
+  );
+  // 임의 SHA나 미병합 커밋으로 capacity evidence를 돌리지 못하도록, 체크아웃
+  // 직후 지정된 SHA가 origin/main의 ancestor인지 검증하고 나서야 그 SHA로
+  // working tree를 옮긴다. fetch-depth: 0이 없으면 merge-base가 얕은 클론에서
+  // 실패하므로 함께 고정한다.
+  assert.match(workflow, /fetch-depth: 0/);
+  assert.match(workflow, /name: Verify deploy SHA is an ancestor of main/);
+  assert.match(
+    workflow,
+    /if \[\[ ! "\$\{EXPECTED_DEPLOYED_SHA\}" =~ \^\[0-9a-f\]\{40\}\$ \]\]; then\s+echo "invalid deploy sha: \$\{EXPECTED_DEPLOYED_SHA\}" >&2\s+exit 1\s+fi/,
+  );
+  assert.match(workflow, /git fetch origin main/);
+  assert.match(
+    workflow,
+    /if ! git merge-base --is-ancestor "\$\{EXPECTED_DEPLOYED_SHA\}" origin\/main; then\s+echo "deploy target is not on origin\/main: \$\{EXPECTED_DEPLOYED_SHA\}" >&2\s+exit 1\s+fi/,
+  );
+  assert.match(workflow, /git checkout --detach "\$\{EXPECTED_DEPLOYED_SHA\}"/);
+  // ancestor 검증 스텝은 checkout 다음, Node.js 설정 이전에 실행돼야 이후
+  // 스텝이 올바른 candidate SHA의 트리 내용을 사용한다.
+  assert.ok(
+    workflow.indexOf("Verify deploy SHA is an ancestor of main") < workflow.indexOf("Set up Node.js"),
   );
 });
 


### PR DESCRIPTION
## 관련 이슈

Refs AquilaXk/easysubway-backend#3

## 작업 배경

`production-route-v2-capacity-evidence.yml`은 `EXPECTED_DEPLOYED_SHA`를 항상
`github.sha`(workflow_dispatch 시점의 main head)로 고정해왔다. runner
스크립트(`tools/ops/verify-production-route-v2-capacity.sh` L47)는 production에
실제로 배포된 `current_sha`가 이 값과 정확히 일치해야만 진행하는데, 병렬 세션이
main을 계속 전진시키는 동안에는 "dispatch 시점의 main head"와 "실제 배포된
candidate"가 어긋나기 쉬워 capacity evidence를 아예 돌릴 수 없는 상황이 반복됐다
(#2095 후속 조사 과정에서 실측).

CD workflow(`.github/workflows/cd.yml`)는 이미 동일한 문제를 `workflow_dispatch.inputs.deploy_sha`
+ ancestor 검증 패턴으로 풀고 있어, 그 패턴을 그대로 가져왔다.

## 작업 내용

- `workflow_dispatch.inputs.deploy_sha`(string, optional)를 추가했다. 설명:
  "capacity evidence를 실행할, 이미 배포된 main 커밋 SHA. 비우면 현재 main head."
- `EXPECTED_DEPLOYED_SHA` env를
  `${{ inputs.deploy_sha != '' && inputs.deploy_sha || github.sha }}`로 설정했다 —
  `cd.yml`의 `deploy_sha="${DISPATCH_SHA:-${GITHUB_SHA}}"` 처리와 동형이다.
- 새 스텝 **"Verify deploy SHA is an ancestor of main"**을 checkout 직후, Node.js
  설정 이전에 추가했다:
  - `Checkout reviewed main`의 `fetch-depth`를 `0`으로 바꿨다(기본 얕은 클론에서는
    `git merge-base --is-ancestor`가 동작하지 않는다).
  - 40자리 hex 형식 검증 → `git fetch origin main` → `git merge-base --is-ancestor
    "${EXPECTED_DEPLOYED_SHA}" origin/main` → `git checkout --detach
    "${EXPECTED_DEPLOYED_SHA}"` 순서로, `cd.yml`의 "Resolve deployment target"
    스텝과 동일한 흐름이다.
  - 임의 SHA나 origin/main에 없는(미병합) 커밋을 지정하면 이 스텝에서 즉시
    차단된다.
- 기존 **"Reject non-main manual execution"**(main 브랜치에서만 dispatch 허용)은
  변경 없이 그대로 유지했다.

## 안전 검증 유지 근거 (핵심)

`tools/ops/verify-production-route-v2-capacity.sh`는 **건드리지 않았다.** 이미
정확히 필요한 안전장치를 갖고 있기 때문이다:

- L37: `EXPECTED_DEPLOYED_SHA`가 40자리 hex인지 검증 — 그대로 유지.
- L47: `[[ "${current_sha}" == "${EXPECTED_DEPLOYED_SHA}" ]]` — production에
  **실제로 배포된** SHA와 정확히 일치해야만 통과 — 그대로 유지.

즉 `deploy_sha`를 지정해도 그 값이 **이미 production에 배포된 candidate와
정확히 일치**해야만 진행된다. 배포되지 않은 임의 SHA로는 여전히 capacity
evidence를 돌릴 수 없다 — 이번 변경은 "dispatch 시점의 main head"라는 제약만
풀고, "실제 배포 여부" 제약은 그대로 둔 것이다. 여기에 워크플로 단의 ancestor
검증(임의 SHA/미병합 커밋 차단)이 추가로 앞단에서 방어한다.

## 검증

- 실행한 명령과 결과:
  - `bash -n tools/ops/verify-production-route-v2-capacity.sh` → OK (스크립트
    무변경, 회귀 확인용)
  - `git diff --check` → OK
  - `LC_ALL=C node --test tools/ci/production-route-v2-capacity-evidence-workflow.test.mjs tools/ci/repository-contract.test.mjs` → **pass 221 / fail 0**
  - 워크플로 YAML을 PyYAML로 파싱해 구문 유효성 확인(`on:` → PyYAML의 YAML 1.1
    boolean 키 해석은 GitHub Actions 자체 파서와 무관한 파서 특성이며 실제
    workflow 동작에는 영향 없음).

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 계약 테스트(신규 assertion 포함) | CI | `node --test` 2종 | pass 221/fail 0 | PASS |
| workflow YAML 구문 | 로컬 | PyYAML 파싱 | 예외 없이 파싱 성공 | PASS |
| 실제 deploy_sha dispatch 동작 | production self-hosted runner | 워크플로 dispatch로 확인 필요 | 병합 후 실측 예정 | 병합 후 확인 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [ ] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] AquilaXk/easysubway#1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [ ] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `.github/workflows/production-route-v2-capacity-evidence.yml`의
  `deploy_sha` input과 "Verify deploy SHA is an ancestor of main" 스텝이
  `cd.yml`의 "Resolve deployment target"과 동형인지, `tools/ops/verify-production-route-v2-capacity.sh`
  L37/L47이 정말 무변경인지(git diff 확인).

## 리스크

- `fetch-depth: 0`으로 바뀌어 checkout이 이전보다(얕은 클론 대비) 약간 더 걸릴 수
  있다 — `cd.yml`도 동일하게 `fetch-depth: 0`을 쓰고 있어 이 저장소 규모에서
  허용 가능한 수준으로 판단했다.
- ancestor 검증 스텝은 `origin/main`에 대해서만 검사하므로, `deploy_sha`가
  `main`에서 이미 되돌려진(revert된) 과거 커밋이어도 ancestor 조건 자체는
  통과할 수 있다 — 다만 L47의 `current_sha` 일치 검증이 최종적으로 "실제
  배포된 것"만 허용하므로 실질적 위험은 없다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
