### PR TITLE
[Fix] clone_curl bind mount을 image-baked /home/ubuntu 충돌 경로에서 분리 (Refs #2095)

### DIFF
--- a/tools/ci/production-route-v2-capacity-evidence-workflow.test.mjs
+++ b/tools/ci/production-route-v2-capacity-evidence-workflow.test.mjs
@@ -96,6 +96,27 @@ test("capacity runner는 동일 candidate·격리 load·privacy·closed ingress�
   assert.doesNotMatch(runner, /--user 0:0/);
   assert.match(runner, /docker exec "\$\{clone_curl\}" curl --version/);
   assert.match(runner, /docker exec "\$\{clone_curl\}" curl/);
+  // -v "${work_dir}:${work_dir}" (identical-path mount) is unsafe: intermediate
+  // path components resolve against the container's OWN filesystem, and the
+  // backend base image ships its own /home/ubuntu at a different, image-baked uid
+  // — this collided with RUNNER_TEMP paths nested under a real /home/<user> on the
+  // production runner and made curl's -D/-o writes fail with exit 23 even though
+  // the runner uid matched the leaf directory's actual host ownership (confirmed
+  // on the production runner: the runner uid could not even `stat` the mount
+  // point, while root could). Mounting at a synthetic top-level container path
+  // avoids the collision entirely.
+  assert.match(runner, /curl_mount="\/capacity-evidence-http"/);
+  assert.match(runner, /to_curl_mount_path\(\) \{/);
+  assert.match(runner, /-v "\$\{work_dir\}:\$\{curl_mount\}"/);
+  assert.equal(
+    (runner.match(/-D "\$\(to_curl_mount_path "\$\{last_headers\}"\)" -o "\$\(to_curl_mount_path "\$\{last_body\}"\)"/g) ?? [])
+      .length,
+    2,
+  );
+  assert.match(
+    runner,
+    /-D "\$\(to_curl_mount_path "\$\{burst_headers\}"\)" -o "\$\(to_curl_mount_path "\$\{burst_body\}"\)"/,
+  );
   assert.match(runner, /--network-alias gateway/);
   assert.match(runner, /gateway_base="http:\/\/gateway:8081"/);
   const gatewayRun = runner.match(/docker run -d --name "\$\{clone_gateway\}"[\s\S]*?nginx -g 'daemon off;' >\/dev\/null/)?.[0] ?? "";

--- a/tools/ops/verify-production-route-v2-capacity.sh
+++ b/tools/ops/verify-production-route-v2-capacity.sh
@@ -391,9 +391,26 @@ dump_readiness_diagnostics() {
 		| grep -iEv '^[A-Za-z_][A-Za-z0-9_.-]*=|password|secret|_key|-key|pepper|attestation|token|credential|private|jdbc:|://[^ ]*@' >&2 || true
 }
 
+# clone_curl runs as the runner's own uid:gid (least privilege — no root), which
+# owns work_dir (umask 077, mode 0700) on the host. Bind-mounting at the SAME path
+# inside the container (-v "${work_dir}:${work_dir}") is unsafe here: intermediate
+# path components are resolved against the CONTAINER's own filesystem, and the
+# backend image (eclipse-temurin) already ships its own /home/ubuntu (a different,
+# image-baked uid, mode 0750, no "other" access) that happens to collide with
+# RUNNER_TEMP paths nested under a real /home/<user> on self-hosted runners — the
+# runner's uid then fails to even traverse into the mount point (confirmed on the
+# production runner: `stat` on the mounted dir returned EACCES for the runner uid,
+# while root could read it fine). Mounting at a synthetic top-level container path
+# instead avoids any collision with the image's own filesystem, so the runner uid
+# only ever needs to satisfy the mount point's own (host-inherited) permissions.
+curl_mount="/capacity-evidence-http"
+to_curl_mount_path() {
+	local host_path="${1:?host path is required}"
+	printf '%s' "${curl_mount}${host_path#"${work_dir}"}"
+}
 docker run -d --name "${clone_curl}" --network "${network}" --user "$(id -u):$(id -g)" --entrypoint sh \
 	--cpus 1 --memory 128m --memory-swap 128m --pids-limit 64 \
-	-v "${work_dir}:${work_dir}" \
+	-v "${work_dir}:${curl_mount}" \
 	"${expected_image_id}" -c 'sleep infinity' >/dev/null
 curl_helper_ready=false
 for _ in $(seq 1 30); do
@@ -500,7 +517,7 @@ const signature = createHmac("sha256", Buffer.from(process.argv[1], "hex")).upda
 process.stdout.write(JSON.stringify({ integrityToken: `${nonce}.${signature}`, clientNonce: nonce }));
 ' "${synthetic_secret}")"
 	result="$(docker exec "${clone_curl}" curl -sS --noproxy '*' --connect-timeout 2 --max-time 10 \
-		-D "${last_headers}" -o "${last_body}" -w '%{http_code} %{time_total}' \
+		-D "$(to_curl_mount_path "${last_headers}")" -o "$(to_curl_mount_path "${last_body}")" -w '%{http_code} %{time_total}' \
 		--request POST --header 'content-type: application/json' \
 		--header "CF-Connecting-IP: ${client_ip}" \
 		--data-binary "${session_request}" \
@@ -537,7 +554,7 @@ send_search() {
 	last_body="${work_dir}/body-${request_index}.json"
 	local result time_seconds latency_ms
 	result="$(docker exec "${clone_curl}" curl -sS --noproxy '*' --connect-timeout 2 --max-time 10 \
-		-D "${last_headers}" -o "${last_body}" -w '%{http_code} %{time_total}' \
+		-D "$(to_curl_mount_path "${last_headers}")" -o "$(to_curl_mount_path "${last_body}")" -w '%{http_code} %{time_total}' \
 		--request POST --header 'content-type: application/json' \
 		--header "CF-Connecting-IP: ${client_ip}" --header "Authorization: Bearer ${token}" \
 		--data-binary "${request_body}" "${gateway_base}/api/v2/routes/search")"
@@ -667,7 +684,7 @@ for ((index = 0; index <= search_burst; index += 1)); do
 	burst_result="${work_dir}/result-${request_index}.txt"
 	(
 		docker exec "${clone_curl}" curl -sS --noproxy '*' --connect-timeout 2 --max-time 10 \
-			-D "${burst_headers}" -o "${burst_body}" -w '%{http_code} %{time_total}' \
+			-D "$(to_curl_mount_path "${burst_headers}")" -o "$(to_curl_mount_path "${burst_body}")" -w '%{http_code} %{time_total}' \
 			--request POST --header 'content-type: application/json' \
 			--header 'CF-Connecting-IP: 198.51.100.200' --header "Authorization: Bearer ${burst_token}" \
 			--data-binary "${request_body}" "${gateway_base}/api/v2/routes/search" > "${burst_result}"


### PR DESCRIPTION
## 관련 이슈

Refs AquilaXk/easysubway-backend#3

## 작업 배경

run 29637711616(deploy_sha=27392409)에서 backend readiness·격리망 접근은
통과했지만(#2255/#2248의 Spring DI·network 수정이 유효했음을 확인) 최초 부하
요청에서 새로 실패했다:

```
curl: Failed to open /home/ubuntu/actions-runner-easysubway/_work/_temp/issue-2095-capacity.XXX/headers-1.txt
curl: (23) Failed writing received data to disk/application
```

## production runner 재현 (읽기·임시 컨테이너만, production 상태 무변경)

`ssh oci-a1-staging`으로 접속해 실제 self-hosted runner(ubuntu, uid 1001)에서
직접 재현했다. 처음 의심됐던 가설("F1의 `--user 0:0` → `--user
\"$(id -u):$(id -g)\"` 변경이 uid를 어긋나게 했다")은 **틀렸다** — runner
uid(1001)와 work_dir 소유 uid(1001)는 정확히 일치했다. 대신:

```
docker exec <clone_curl> stat <work_dir 경로>
→ stat: ... Permission denied (os error 13)   (uid 1001로 실행 시 실패)
→ --user 0:0(root)으로는 동일 경로 stat/write 모두 성공
```

컨테이너 내부에서 `/home/ubuntu`를 직접 `stat`한 결과, 이는 host의
`/home/ubuntu`가 아니라 **backend base 이미지(`eclipse-temurin`)에 이미 구워져
있는 `/home/ubuntu`**였다 — `Uid: 1000`, mode `0750`(other 권한 없음).

Docker가 `-v "${work_dir}:${work_dir}"`(동일 경로 bind mount)를 처리할 때,
마운트 지점 자체는 host의 실제 디렉터리로 대체되지만 **그 상위 경로 구성요소는
컨테이너 자신의 파일시스템을 기준으로 해석된다.** production runner의
`RUNNER_TEMP`(`/home/ubuntu/actions-runner-easysubway/_work/_temp`)가 하필
`/home/ubuntu` 아래에 있고, 이미지에 이미 구워진 `/home/ubuntu`(uid 1000)의
소유자가 runner의 실제 uid(1001)와 다르며 mode 750이라 "other"에게 순회 권한이
전혀 없어, uid 1001 프로세스는 **그 상위 경로를 통과(traverse)조차 못 했다.**
리프 디렉터리 자체의 host 소유권(uid 1001, 0700)은 무관했다 — 거기까지 도달을
못 했기 때문이다.

## 작업 내용

`clone_curl`의 bind mount를 `-v "${work_dir}:${work_dir}"`(동일 경로) 대신
`-v "${work_dir}:${curl_mount}"`(`curl_mount="/capacity-evidence-http"`,
컨테이너 루트 바로 아래 합성 경로)로 바꿨다. 이미지에 이미 존재하는 어떤
경로와도 충돌하지 않으므로, 상위 경로는 Docker가 새로 만드는 `root:root
0755`(모든 uid가 순회 가능)이고, 실제 host 권한은 마운트 지점 자체에서만
적용된다 — 그 지점은 여전히 runner uid가 소유(host work_dir와 동일 inode)한다.

**F1(최소권한, root 회피)과의 양립**: root(0:0) 복귀는 필요 없었다.
`--user "$(id -u):$(id -g)"`을 그대로 유지하면서 문제를 해결했다.

호스트 스크립트 로직(work_dir 경로로 `grep`/`node -e readFileSync` 등)은
그대로 두고, **컨테이너 안에서 실행되는 curl의 `-D`/`-o` 인자만**
`to_curl_mount_path()` 헬퍼로 컨테이너 쪽 경로(`${curl_mount}/...`)로 변환했다.
`send_session()`, `send_search()`, search burst 동시 요청 루프 3곳을 수정했다.
readiness probe(`-o /dev/null`, `curl --version`)는 work_dir를 전혀 참조하지
않아 변경이 필요 없었다.

## production 재검증

같은 재현 패턴을, 실제 스크립트의 `send_session()`과 동일한 형태(POST +
`-D`/`-o` + `-w`)로 production runner에서 다시 돌렸다:

| | 결과 |
| --- | --- |
| 수정 전(동일 경로 마운트) | curl exit 23, "Failed to open" |
| 수정 후(합성 경로 마운트) | curl exit 7(의도적으로 존재하지 않는 포트로 접속 — connection refused), `headers-1.txt`가 host 쪽 work_dir에 정상 생성·읽기 가능(더 이상 쓰기 실패 없음) |

임시 컨테이너·디렉터리는 재현 직후 모두 정리했고(`docker rm -f`, `rm -rf`),
production 컨테이너·DB·shared 상태는 전혀 건드리지 않았다.

## 검증

- 실행한 명령과 결과:
  - production runner 재현(위 표) — 수정 전/후 대조 확인
  - `bash -n tools/ops/verify-production-route-v2-capacity.sh` → OK
  - `git diff --check` → OK
  - `LC_ALL=C node --test tools/ci/production-route-v2-capacity-evidence-workflow.test.mjs tools/ci/repository-contract.test.mjs` → **pass 221 / fail 0**

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 근본 원인 재현 | production self-hosted runner (oci-a1-staging) | 동일 경로 bind mount + uid 1001 exec stat/curl | `Permission denied (os error 13)`, curl exit 23 | 재현 성공 |
| 수정 검증 | production self-hosted runner (oci-a1-staging) | 합성 경로 bind mount + uid 1001 exec curl (send_session 형태) | curl exit 7(연결 거부, 쓰기 성공), headers 파일 host에서 정상 확인 | PASS |
| runner 스크립트 계약 | CI | `node --test` 2종 | pass 221/fail 0 | PASS |
| 실제 capacity evidence 전체 실행 | production self-hosted runner | 워크플로 재실행으로 확인 필요 | 병합 후 재실행 예정 | 병합 후 확인 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [ ] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] AquilaXk/easysubway#1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [ ] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `tools/ops/verify-production-route-v2-capacity.sh`의
  `curl_mount`/`to_curl_mount_path()` 도입부와, `send_session()`/`send_search()`/
  burst 루프에서 `-D`/`-o` 인자가 `to_curl_mount_path()`를 거치는지, `--user
  "$(id -u):$(id -g)"`가 root로 되돌아가지 않았는지.

## 리스크

- 이 수정은 production self-hosted runner의 구체적인 파일시스템 배치
  (`RUNNER_TEMP`가 `/home/<user>` 아래)와 backend base 이미지의 baked-in
  `/home/ubuntu`(uid 1000) 충돌에서 비롯된 문제를 고쳤다. 향후 base 이미지가
  바뀌어 다른 uid/경로를 굽더라도, 합성 top-level 마운트 경로(`/capacity-evidence-http`)는
  어떤 base 이미지의 표준 파일시스템 레이아웃과도 충돌할 가능성이 극히 낮아
  견고하다고 판단했다.
- 실제 fail-fix 최종 확인은 병합 후 production runner에서 capacity evidence
  워크플로 전체 실행으로 필요하다(에이전트는 production 컨테이너/DB/shared
  상태 변경 권한이 없다 — 이번 조사도 읽기·임시 컨테이너로만 수행했다).

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
