### PR TITLE
[Style] #2071 관리자 table 모바일 scroll 정리

### DIFF
--- a/backend/src/main/resources/static/css/admin-v3.css
+++ b/backend/src/main/resources/static/css/admin-v3.css
@@ -467,13 +467,16 @@ body.admin-v3 {
 }
 
 .admin-v3 th {
-	position: sticky;
-	top: 0;
-	z-index: 1;
 	background: var(--admin-header-bg);
 	color: var(--admin-ink-2);
 	font-size: 13px;
 	font-weight: var(--admin-w-medium);
+}
+
+.admin-v3 thead th {
+	position: sticky;
+	top: 0;
+	z-index: 1;
 }
 
 .admin-v3 td {

--- a/backend/src/main/resources/static/css/admin-v3.css
+++ b/backend/src/main/resources/static/css/admin-v3.css
@@ -432,7 +432,8 @@ body.admin-v3 {
 
 .admin-table-scroll {
 	max-width: 100%;
-	overflow-x: auto;
+	max-block-size: min(70vh, 640px);
+	overflow: auto;
 	overscroll-behavior-inline: contain;
 	scrollbar-gutter: stable;
 	isolation: isolate;
@@ -1719,7 +1720,7 @@ body.admin-v3 {
 	}
 }
 
-/* ≤768px: 표준 테이블 밀도를 좁힌다(가로 스크롤은 table min-width + section overflow-x가 담당). */
+/* ≤768px: 표준 테이블 밀도를 좁힌다(table min-width + admin-table-scroll이 scroll을 담당). */
 @media (max-width: 768px) {
 	.admin-v3 th,
 	.admin-v3 td {

--- a/backend/src/main/resources/static/css/admin-v3.css
+++ b/backend/src/main/resources/static/css/admin-v3.css
@@ -4,6 +4,11 @@
 	box-sizing: border-box;
 }
 
+html,
+body.admin-v3 {
+	overflow-x: hidden;
+}
+
 body.admin-v3 {
 	margin: 0;
 	background: var(--admin-bg);
@@ -164,7 +169,7 @@ body.admin-v3 {
 	max-width: none;
 	margin: 0;
 	padding: 28px 30px 48px;
-	overflow-x: auto;
+	overflow-x: visible;
 }
 
 .admin-topbar {
@@ -415,7 +420,6 @@ body.admin-v3 {
 }
 
 .admin-v3 table {
-	overflow: hidden;
 	width: 100%;
 	min-width: 620px;
 	border-collapse: collapse;
@@ -423,7 +427,20 @@ body.admin-v3 {
 
 .admin-v3 section,
 .admin-card {
+	overflow-x: visible;
+}
+
+.admin-table-scroll {
+	max-width: 100%;
 	overflow-x: auto;
+	overscroll-behavior-inline: contain;
+	scrollbar-gutter: stable;
+	isolation: isolate;
+}
+
+.admin-v3 .admin-table-scroll:focus-visible {
+	outline: 3px solid #ffbf47;
+	outline-offset: 3px;
 }
 
 /* 플랫 섹션(#2047, 오너 확정 2026-07-13): 1px 보더 패널은 핵심 지표 묶음·데이터 표·폼에만 두고,
@@ -463,6 +480,19 @@ body.admin-v3 {
 	font-weight: var(--admin-w-body);
 }
 
+.admin-table-scroll th:first-child,
+.admin-table-scroll td:first-child:not([colspan]) {
+	position: sticky;
+	left: 0;
+	z-index: 2;
+	background: var(--admin-surface);
+}
+
+.admin-table-scroll thead th:first-child {
+	z-index: 3;
+	background: var(--admin-header-bg);
+}
+
 .admin-v3 tbody tr {
 	height: 44px;
 }
@@ -472,8 +502,17 @@ body.admin-v3 {
 	background: var(--admin-header-bg);
 }
 
+.admin-v3 .admin-table-scroll tbody tr:hover td:first-child:not([colspan]) {
+	background: var(--admin-header-bg);
+}
+
 .admin-v3 tbody tr[aria-selected="true"],
 .admin-v3 tbody tr.is-selected {
+	background: var(--admin-accent-soft);
+}
+
+.admin-v3 .admin-table-scroll tbody tr[aria-selected="true"] td:first-child:not([colspan]),
+.admin-v3 .admin-table-scroll tbody tr.is-selected td:first-child:not([colspan]) {
 	background: var(--admin-accent-soft);
 }
 

--- a/backend/src/main/resources/static/css/admin-v3.css
+++ b/backend/src/main/resources/static/css/admin-v3.css
@@ -534,6 +534,10 @@ body.admin-v3 {
 	background: transparent;
 }
 
+.admin-v3 .admin-table-scroll table.static-table tbody tr:hover td:first-child:not([colspan]) {
+	background: var(--admin-surface);
+}
+
 .admin-v3 tbody tr:last-child td {
 	border-bottom: 0;
 }

--- a/backend/src/main/resources/templates/admin/ads/list.html
+++ b/backend/src/main/resources/templates/admin/ads/list.html
@@ -52,6 +52,8 @@
 
 	<section class="admin-panel" aria-labelledby="ad-list-title">
 		<h2 id="ad-list-title">등록 소재</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table>
 			<thead>
 			<tr>
@@ -94,6 +96,7 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 </main>
 </div>

--- a/backend/src/main/resources/templates/admin/audits/list.html
+++ b/backend/src/main/resources/templates/admin/audits/list.html
@@ -87,7 +87,9 @@
 				   download>JSON 내보내기</a>
 			</p>
 
-			<table th:if="${!events.isEmpty()}">
+			<div class="admin-table-scroll" tabindex="0" role="group"
+			     aria-label="가로로 스크롤 가능한 데이터 표" th:if="${!events.isEmpty()}">
+			<table>
 				<caption class="sr-only" th:text="${title}">감사 이벤트</caption>
 				<thead>
 				<tr>
@@ -125,6 +127,7 @@
 				</tr>
 				</tbody>
 			</table>
+			</div>
 
 			<div th:if="${events.isEmpty()}"
 			     th:replace="~{admin/fragments/empty-state :: panel('조건에 맞는 감사 이벤트가 없습니다.', '필터를 변경하거나 기간을 넓혀 보세요.')}"></div>

--- a/backend/src/main/resources/templates/admin/batches/list.html
+++ b/backend/src/main/resources/templates/admin/batches/list.html
@@ -24,6 +24,8 @@
 
 	<section>
 		<h2>허용된 배치 작업</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table>
 			<thead>
 			<tr>
@@ -55,6 +57,7 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 
 	<div id="batch-live" th:fragment="live">
@@ -75,6 +78,8 @@
 				<p th:if="${history.isEmpty()}">실행 이력이 없습니다.</p>
 				<details class="batch-history-details" th:if="${!history.isEmpty()}">
 					<summary>데이터 표로 보기</summary>
+					<div class="admin-table-scroll" tabindex="0" role="group"
+					     aria-label="가로로 스크롤 가능한 데이터 표">
 					<table>
 						<thead>
 						<tr>
@@ -91,6 +96,7 @@
 						</tr>
 						</tbody>
 					</table>
+					</div>
 				</details>
 			</section>
 		</div>
@@ -98,6 +104,8 @@
 
 	<section>
 		<h2>최근 배치 실행</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table>
 			<thead>
 			<tr>
@@ -153,6 +161,7 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 		<div th:replace="~{admin/fragments/pagination :: pager('배치 실행 목록 페이지', ${page}, ${paginationLinks})}"></div>
 	</section>
 	</div>

--- a/backend/src/main/resources/templates/admin/codes/list.html
+++ b/backend/src/main/resources/templates/admin/codes/list.html
@@ -37,6 +37,8 @@
 
 	<section>
 		<h2>Code</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table>
 			<thead>
 			<tr>
@@ -70,6 +72,7 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 		<div th:replace="~{admin/fragments/pagination :: pager('공통코드 목록 페이지', ${page}, ${paginationLinks})}"></div>
 	</section>
 

--- a/backend/src/main/resources/templates/admin/collections/list.html
+++ b/backend/src/main/resources/templates/admin/collections/list.html
@@ -39,6 +39,8 @@
 		<div class="admin-auto-refresh" hidden x-data="autoRefresh"
 		     data-refresh-url="/admin/data-collections/page/live" data-refresh-target="#collection-live"
 		     data-refresh-interval="10000" th:attr="data-refresh-active=${hasRunning} ? 'true' : 'false'"></div>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table>
 			<thead>
 			<tr>
@@ -96,6 +98,7 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 		<div th:replace="~{admin/fragments/pagination :: pager('데이터 수집 실행 목록 페이지', ${page}, ${paginationLinks})}"></div>
 	</section>
 </main>

--- a/backend/src/main/resources/templates/admin/dashboard.html
+++ b/backend/src/main/resources/templates/admin/dashboard.html
@@ -94,6 +94,8 @@
 		<!-- sha·workflow 상세 13행은 기본 접힘으로 격하(추세·요약을 앞세운다). -->
 		<details class="dashboard-details">
 			<summary>상세 해시·워크플로 보기</summary>
+			<div class="admin-table-scroll" tabindex="0" role="group"
+			     aria-label="가로로 스크롤 가능한 데이터 표">
 			<table>
 				<tbody>
 				<tr><th scope="row">scope</th><td th:text="${datapackReleaseSummary.scopeId}">scope</td></tr>
@@ -112,6 +114,7 @@
 				<tr><th scope="row">manifest signature</th><td th:text="${datapackReleaseSummary.manifestBlockers}">0</td></tr>
 				</tbody>
 			</table>
+			</div>
 		</details>
 	</section>
 
@@ -127,6 +130,8 @@
 			<div class="admin-panel-head">
 				<h2 id="dashboard-health-title">운영 이상 신호</h2>
 			</div>
+			<div class="admin-table-scroll" tabindex="0" role="group"
+			     aria-label="가로로 스크롤 가능한 데이터 표">
 			<table>
 				<tbody>
 				<tr><th scope="row">서비스 상태</th><td th:text="|${dashboard.healthStatus} (${dashboard.serviceName})|">UP</td></tr>
@@ -134,6 +139,7 @@
 				<tr><th scope="row">API 오류율</th><td th:text="${dashboard.apiErrorRate}">0.0%</td></tr>
 				</tbody>
 			</table>
+			</div>
 		</section>
 	</div>
 </main>

--- a/backend/src/main/resources/templates/admin/datapack/alias-quarantine/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/alias-quarantine/list.html
@@ -52,6 +52,8 @@
 
 	<section class="admin-panel">
 		<h2>Alias 검수 큐</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table class="static-table">
 			<thead>
 			<tr>
@@ -115,10 +117,13 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 
 	<section class="admin-panel">
 		<h2>격리 큐</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table class="static-table">
 			<thead>
 			<tr>
@@ -182,6 +187,7 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 </main>
 </div>

--- a/backend/src/main/resources/templates/admin/datapack/candidates/detail.html
+++ b/backend/src/main/resources/templates/admin/datapack/candidates/detail.html
@@ -28,6 +28,8 @@
 	<section class="admin-panel">
 		<h2>게이트 체크리스트</h2>
 		<p class="summary" th:text="${evidenceBundle.productionPromoteReason()}">production promote 상태</p>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table class="static-table">
 			<thead>
 			<tr>
@@ -62,6 +64,7 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 
 	<section class="admin-panel">
@@ -100,6 +103,8 @@
 		</dl>
 		<details>
 			<summary>sha 원문 보기</summary>
+			<div class="admin-table-scroll" tabindex="0" role="group"
+			     aria-label="가로로 스크롤 가능한 데이터 표">
 			<table class="static-table">
 				<tbody>
 				<tr><th scope="row">buildSpec</th><td th:text="${candidate.buildSpecSha256}">sha</td></tr>
@@ -110,11 +115,14 @@
 				<tr><th scope="row">evidenceBundle</th><td th:text="${evidenceBundle.evidenceBundleSha256}">sha</td></tr>
 				</tbody>
 			</table>
+			</div>
 		</details>
 	</section>
 
 	<section class="admin-panel">
 		<h2>입력 원장</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table class="static-table">
 			<tbody>
 			<tr><th scope="row">원천 스냅샷 ids</th><td th:text="${candidateInput.sourceSnapshotIds}">snapshot ids</td></tr>
@@ -124,6 +132,7 @@
 			<tr><th scope="row">승인 오버라이드 세트 hash</th><td><span th:title="${candidateInput.approvedOverrideSetHash}" th:text="${candidateInput.approvedOverrideSetHashShort()}">sha</span></td></tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 
 	<section class="admin-panel">

--- a/backend/src/main/resources/templates/admin/datapack/candidates/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/candidates/list.html
@@ -51,6 +51,8 @@
 				<span class="filter-chip" th:if="${filter.hasQuery()}" th:text="${'검색 ' + filter.queryValue}">검색</span>
 			</div>
 		</div>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table class="static-table">
 			<thead>
 			<tr>
@@ -91,6 +93,7 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 </main>
 </div>

--- a/backend/src/main/resources/templates/admin/datapack/candidates/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/candidates/list.html
@@ -52,7 +52,7 @@
 			</div>
 		</div>
 		<div class="admin-table-scroll" tabindex="0" role="group"
-		     aria-label="가로로 스크롤 가능한 데이터 표">
+		     aria-label="가로로 스크롤 가능한 후보 팩 표">
 		<table class="static-table">
 			<thead>
 			<tr>

--- a/backend/src/main/resources/templates/admin/datapack/facility-evidence/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/facility-evidence/list.html
@@ -49,7 +49,7 @@
 			</div>
 		</div>
 		<div class="admin-table-scroll" tabindex="0" role="group"
-		     aria-label="가로로 스크롤 가능한 데이터 표">
+		     aria-label="가로로 스크롤 가능한 시설 근거 표">
 		<table class="static-table">
 			<thead>
 			<tr>

--- a/backend/src/main/resources/templates/admin/datapack/facility-evidence/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/facility-evidence/list.html
@@ -48,6 +48,8 @@
 				<span class="filter-chip" th:if="${filter.hasQuery()}" th:text="${'검색 ' + filter.queryValue}">검색</span>
 			</div>
 		</div>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table class="static-table">
 			<thead>
 			<tr>
@@ -133,6 +135,7 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 </main>
 </div>

--- a/backend/src/main/resources/templates/admin/datapack/manual-overrides/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/manual-overrides/list.html
@@ -92,6 +92,8 @@
 				<span class="filter-chip" th:if="${filter.hasQuery()}" th:text="${'검색 ' + filter.queryValue}">검색</span>
 			</div>
 		</div>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table class="static-table">
 			<thead>
 			<tr>
@@ -178,6 +180,7 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 </main>
 </div>

--- a/backend/src/main/resources/templates/admin/datapack/manual-overrides/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/manual-overrides/list.html
@@ -93,7 +93,7 @@
 			</div>
 		</div>
 		<div class="admin-table-scroll" tabindex="0" role="group"
-		     aria-label="가로로 스크롤 가능한 데이터 표">
+		     aria-label="가로로 스크롤 가능한 수동 오버라이드 표">
 		<table class="static-table">
 			<thead>
 			<tr>

--- a/backend/src/main/resources/templates/admin/datapack/pipeline/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/pipeline/list.html
@@ -71,6 +71,8 @@
 
 	<section class="admin-panel">
 		<h2>단계별 blocker (표)</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table class="static-table">
 			<thead>
 			<tr>
@@ -87,10 +89,13 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 
 	<section class="admin-panel">
 		<h2>게이트 6종 + 서명</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table class="static-table">
 			<thead>
 			<tr>
@@ -109,6 +114,7 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 
 	<section class="admin-panel">

--- a/backend/src/main/resources/templates/admin/datapack/release-channels/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/release-channels/list.html
@@ -54,7 +54,7 @@
 			</div>
 		</div>
 		<div class="admin-table-scroll" tabindex="0" role="group"
-		     aria-label="가로로 스크롤 가능한 데이터 표">
+		     aria-label="가로로 스크롤 가능한 배포 채널 표">
 		<table class="static-table">
 			<thead>
 			<tr>
@@ -180,7 +180,7 @@
 	<section class="admin-panel">
 		<h2>채널 이벤트</h2>
 		<div class="admin-table-scroll" tabindex="0" role="group"
-		     aria-label="가로로 스크롤 가능한 데이터 표">
+		     aria-label="가로로 스크롤 가능한 채널 이벤트 표">
 		<table class="static-table">
 			<thead>
 			<tr>

--- a/backend/src/main/resources/templates/admin/datapack/release-channels/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/release-channels/list.html
@@ -53,6 +53,8 @@
 				<span class="filter-chip" th:if="${filter.hasQuery()}" th:text="${'검색 ' + filter.queryValue}">검색</span>
 			</div>
 		</div>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table class="static-table">
 			<thead>
 			<tr>
@@ -172,10 +174,13 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 
 	<section class="admin-panel">
 		<h2>채널 이벤트</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table class="static-table">
 			<thead>
 			<tr>
@@ -217,6 +222,7 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 </main>
 </div>

--- a/backend/src/main/resources/templates/admin/datapack/release-requests/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/release-requests/list.html
@@ -59,6 +59,8 @@
 
 	<section class="admin-panel">
 		<h2>release request 목록</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table class="static-table">
 			<thead>
 			<tr>
@@ -120,10 +122,13 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 
 	<section class="admin-panel">
 		<h2>callback delivery / reconciliation</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table class="static-table">
 			<thead><tr>
 				<th scope="col">request / sequence</th><th scope="col">channel / state</th>
@@ -152,6 +157,7 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 </main>
 </div>

--- a/backend/src/main/resources/templates/admin/datapack/route-gates/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/route-gates/list.html
@@ -49,7 +49,7 @@
 			</div>
 		</div>
 		<div class="admin-table-scroll" tabindex="0" role="group"
-		     aria-label="가로로 스크롤 가능한 데이터 표">
+		     aria-label="가로로 스크롤 가능한 경로 게이트 표">
 		<table class="static-table">
 			<thead>
 			<tr>

--- a/backend/src/main/resources/templates/admin/datapack/route-gates/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/route-gates/list.html
@@ -48,6 +48,8 @@
 				<span class="filter-chip" th:if="${filter.hasQuery()}" th:text="${'검색 ' + filter.queryValue}">검색</span>
 			</div>
 		</div>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table class="static-table">
 			<thead>
 			<tr>
@@ -90,6 +92,7 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 </main>
 </div>

--- a/backend/src/main/resources/templates/admin/datapack/source-snapshots/detail.html
+++ b/backend/src/main/resources/templates/admin/datapack/source-snapshots/detail.html
@@ -26,6 +26,8 @@
 
 	<section class="admin-panel">
 		<h2>기본 정보</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table class="static-table">
 			<tbody>
 			<tr><th scope="row">source id</th><td th:text="${snapshot.sourceId}">source-id</td></tr>
@@ -41,10 +43,13 @@
 			<tr><th scope="row">diff summary JSON</th><td th:text="${snapshot.diffSummaryJson}">-</td></tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 
 	<section class="admin-panel">
 		<h2>상태</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table class="static-table">
 			<tbody>
 			<tr><th scope="row">snapshot status</th><td th:text="${snapshot.snapshotStatus}">LOCKED</td></tr>
@@ -59,10 +64,13 @@
 			<tr><th scope="row">governance policy sha256</th><td th:text="${snapshot.governancePolicySha256}">-</td></tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 
 	<section class="admin-panel">
 		<h2>Evidence</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table class="static-table">
 			<tbody>
 			<tr><th scope="row">raw sha256</th><td th:text="${snapshot.rawSha256}">sha256</td></tr>
@@ -71,6 +79,7 @@
 			<tr><th scope="row">schema fingerprint</th><td th:text="${snapshot.schemaFingerprint}">sha256</td></tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 
 	<section class="admin-panel">

--- a/backend/src/main/resources/templates/admin/datapack/source-snapshots/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/source-snapshots/list.html
@@ -53,7 +53,7 @@
 			</div>
 		</div>
 		<div class="admin-table-scroll" tabindex="0" role="group"
-		     aria-label="가로로 스크롤 가능한 데이터 표">
+		     aria-label="가로로 스크롤 가능한 원천 스냅샷 표">
 		<table class="static-table">
 			<thead>
 			<tr>

--- a/backend/src/main/resources/templates/admin/datapack/source-snapshots/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/source-snapshots/list.html
@@ -52,6 +52,8 @@
 				<span class="filter-chip" th:if="${filter.hasQuery()}" th:text="${'검색 ' + filter.queryValue}">검색</span>
 			</div>
 		</div>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table class="static-table">
 			<thead>
 			<tr>
@@ -93,6 +95,7 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 		<div th:replace="~{admin/fragments/pagination :: pager('원천 스냅샷 목록 페이지', ${page}, ${paginationLinks})}"></div>
 	</section>
 </main>

--- a/backend/src/main/resources/templates/admin/facilities/editor.html
+++ b/backend/src/main/resources/templates/admin/facilities/editor.html
@@ -50,6 +50,8 @@
 				<button type="submit">역 시설 보기</button>
 			</form>
 
+			<div class="admin-table-scroll" tabindex="0" role="group"
+			     aria-label="가로로 스크롤 가능한 데이터 표">
 			<table>
 				<thead>
 				<tr>
@@ -69,6 +71,7 @@
 				</tr>
 				</tbody>
 			</table>
+			</div>
 		</section>
 
 		<section class="admin-panel">

--- a/backend/src/main/resources/templates/admin/facilities/list.html
+++ b/backend/src/main/resources/templates/admin/facilities/list.html
@@ -68,6 +68,8 @@
 			<button type="submit">검색</button>
 		</form>
 
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table>
 			<thead>
 			<tr>
@@ -126,6 +128,7 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 		<div th:replace="~{admin/fragments/pagination :: pager('시설 상태 목록 페이지', ${page}, ${paginationLinks})}"></div>
 	</div>
 </main>

--- a/backend/src/main/resources/templates/admin/field/detail.html
+++ b/backend/src/main/resources/templates/admin/field/detail.html
@@ -40,6 +40,8 @@
 	<div class="admin-grid-2">
 		<section class="admin-panel">
 			<h2>확인 항목</h2>
+			<div class="admin-table-scroll" tabindex="0" role="group"
+			     aria-label="가로로 스크롤 가능한 데이터 표">
 			<table>
 				<thead>
 				<tr>
@@ -88,11 +90,14 @@
 				</tr>
 				</tbody>
 			</table>
+			</div>
 		</section>
 	</div>
 
 	<section>
 		<h2>변경 이력</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table>
 			<thead>
 			<tr>
@@ -113,6 +118,7 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 </main>
 </div>

--- a/backend/src/main/resources/templates/admin/field/list.html
+++ b/backend/src/main/resources/templates/admin/field/list.html
@@ -21,6 +21,8 @@
 		</div>
 	</header>
 
+	<div class="admin-table-scroll" tabindex="0" role="group"
+	     aria-label="가로로 스크롤 가능한 데이터 표">
 	<table>
 		<thead>
 		<tr>
@@ -53,6 +55,7 @@
 		</tr>
 		</tbody>
 	</table>
+	</div>
 		<div th:replace="~{admin/fragments/pagination :: pager('현장 확인 목록 페이지', ${page}, ${paginationLinks})}"></div>
 </main>
 </div>

--- a/backend/src/main/resources/templates/admin/fragments/dashboard-trends.html
+++ b/backend/src/main/resources/templates/admin/fragments/dashboard-trends.html
@@ -32,6 +32,8 @@
 			</div>
 			<details class="dashboard-details">
 				<summary>데이터 표로 보기</summary>
+				<div class="admin-table-scroll" tabindex="0" role="group"
+				     aria-label="가로로 스크롤 가능한 데이터 표">
 				<table class="static-table">
 					<thead>
 					<tr>
@@ -47,6 +49,7 @@
 					</tr>
 					</tbody>
 				</table>
+				</div>
 			</details>
 		</section>
 	</div>

--- a/backend/src/main/resources/templates/admin/incidents/list.html
+++ b/backend/src/main/resources/templates/admin/incidents/list.html
@@ -65,6 +65,8 @@
 		<div class="admin-auto-refresh" hidden x-data="autoRefresh"
 		     data-refresh-url="/admin/incidents/page/live" data-refresh-target="#incident-live"
 		     data-refresh-interval="60000" data-refresh-active="true"></div>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table>
 			<thead>
 			<tr>
@@ -134,6 +136,7 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 		<div th:replace="~{admin/fragments/pagination :: pager('Incident 목록 페이지', ${page}, ${paginationLinks})}"></div>
 	</section>
 </main>

--- a/backend/src/main/resources/templates/admin/notices/list.html
+++ b/backend/src/main/resources/templates/admin/notices/list.html
@@ -59,6 +59,8 @@
 
 	<section class="admin-panel">
 		<h2>최근 공지</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table>
 			<thead>
 			<tr>
@@ -95,6 +97,7 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 </main>
 </div>

--- a/backend/src/main/resources/templates/admin/notifications/push.html
+++ b/backend/src/main/resources/templates/admin/notifications/push.html
@@ -115,6 +115,8 @@
 				</div>
 				<details class="dashboard-details">
 					<summary>데이터 표로 보기</summary>
+					<div class="admin-table-scroll" tabindex="0" role="group"
+					     aria-label="가로로 스크롤 가능한 데이터 표">
 					<table>
 						<thead>
 						<tr>
@@ -130,6 +132,7 @@
 						</tr>
 						</tbody>
 					</table>
+					</div>
 				</details>
 			</section>
 		</div>
@@ -137,6 +140,8 @@
 
 	<section>
 		<h2>상태별 알림</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table>
 			<thead>
 			<tr>
@@ -153,6 +158,7 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 
 	<section aria-labelledby="push-history-heading">
@@ -230,6 +236,8 @@
 				<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 				<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 				<input type="hidden" name="returnTo" th:value="${currentListHref}">
+				<div class="admin-table-scroll" tabindex="0" role="group"
+				     aria-label="가로로 스크롤 가능한 데이터 표">
 				<table>
 					<caption class="sr-only">푸시 발송 이력</caption>
 					<thead>
@@ -277,6 +285,7 @@
 					</tr>
 					</tbody>
 				</table>
+				</div>
 
 				<details class="resend-confirm">
 					<summary><span x-text="selectionLabel">선택한 실패 건 재발송</span></summary>

--- a/backend/src/main/resources/templates/admin/quality/dashboard.html
+++ b/backend/src/main/resources/templates/admin/quality/dashboard.html
@@ -71,6 +71,8 @@
 
 	<section th:if="${datapackReleaseSummary != null}">
 		<h2>데이터팩 Release readiness</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table>
 			<thead>
 			<tr>
@@ -89,10 +91,13 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 
 	<section>
 		<h2>역 품질 등급</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table>
 			<thead>
 			<tr>
@@ -109,10 +114,13 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 
 	<section>
 		<h2>지역별 데이터 품질</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table>
 			<thead>
 			<tr>
@@ -139,10 +147,13 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 
 	<section>
 		<h2>출구 확인 상태</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table>
 			<thead>
 			<tr>
@@ -157,10 +168,13 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 
 	<section>
 		<h2>시설 확인 상태</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table>
 			<thead>
 			<tr>
@@ -175,10 +189,13 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 
 	<section>
 		<h2>시설 상태 갱신 지연</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table>
 			<thead>
 			<tr>
@@ -193,10 +210,13 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 
 	<section>
 		<h2>사용자 제보 확인률</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table>
 			<thead>
 			<tr>
@@ -211,10 +231,13 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 
 	<section>
 		<h2>역별 접근성 점수</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table>
 			<thead>
 			<tr>
@@ -233,10 +256,13 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 
 	<section>
 		<h2>접근성 개선 우선순위</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table>
 			<thead>
 			<tr>
@@ -255,10 +281,13 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 
 	<section>
 		<h2>반복 고장 신고 시설</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table>
 			<thead>
 			<tr>
@@ -277,6 +306,7 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 </main>
 </div>

--- a/backend/src/main/resources/templates/admin/reports/detail.html
+++ b/backend/src/main/resources/templates/admin/reports/detail.html
@@ -97,7 +97,9 @@
 	<section>
 		<h2>감사 이력</h2>
 		<p th:if="${reviewAudits.isEmpty()}">없음</p>
-		<table th:if="${!reviewAudits.isEmpty()}">
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표" th:if="${!reviewAudits.isEmpty()}">
+		<table>
 			<thead>
 			<tr>
 				<th>확인한 사람</th>
@@ -117,13 +119,16 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 
 	<section>
 		<h2>같은 시설 신고</h2>
 		<!-- 같은 역·시설의 다른 신고(#1740): 판정 전 반복 신고 맥락을 준다. 읽기 전용 목록으로 #1163 병합과 독립. -->
 		<p th:if="${sameFacilityReports.isEmpty()}">같은 시설의 다른 신고가 없습니다.</p>
-		<table th:if="${!sameFacilityReports.isEmpty()}">
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표" th:if="${!sameFacilityReports.isEmpty()}">
+		<table>
 			<thead>
 			<tr>
 				<th scope="col">상태</th>
@@ -143,6 +148,7 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 
 	<form class="review-form"

--- a/backend/src/main/resources/templates/admin/reports/list.html
+++ b/backend/src/main/resources/templates/admin/reports/list.html
@@ -171,6 +171,8 @@
 				<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 				<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 				<input type="hidden" name="returnTo" th:value="${currentListHref}">
+				<div class="admin-table-scroll" tabindex="0" role="group"
+				     aria-label="가로로 스크롤 가능한 데이터 표">
 				<table x-bind:class="tableClass">
 				<thead>
 				<tr>
@@ -246,6 +248,7 @@
 				</tr>
 				</tbody>
 			</table>
+				</div>
 			<div class="bulk-actionbar" x-show="hasSelection">
 				<span class="bulk-count" x-text="selectionLabel">선택한 신고 일괄 처리</span>
 				<button type="submit" name="decision" value="ACCEPT">선택 승인</button>

--- a/backend/src/main/resources/templates/admin/routes/feedback.html
+++ b/backend/src/main/resources/templates/admin/routes/feedback.html
@@ -82,6 +82,8 @@
 				</div>
 				<details class="dashboard-details">
 					<summary>데이터 표로 보기</summary>
+					<div class="admin-table-scroll" tabindex="0" role="group"
+					     aria-label="가로로 스크롤 가능한 데이터 표">
 					<table class="static-table">
 						<thead>
 						<tr>
@@ -97,6 +99,7 @@
 						</tr>
 						</tbody>
 					</table>
+					</div>
 				</details>
 			</section>
 		</div>
@@ -104,6 +107,8 @@
 
 	<section>
 		<h2>평점별 피드백</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table class="static-table">
 			<thead>
 			<tr>
@@ -120,10 +125,13 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 
 	<section>
 		<h2>최근 현장 차단 신고</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table class="static-table">
 			<thead>
 			<tr>
@@ -145,10 +153,13 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 
 	<section>
 		<h2>ETA 보정 bucket</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table class="static-table">
 			<thead>
 			<tr>
@@ -174,6 +185,7 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 </main>
 </div>

--- a/backend/src/main/resources/templates/admin/routes/searches.html
+++ b/backend/src/main/resources/templates/admin/routes/searches.html
@@ -93,6 +93,8 @@
 				</div>
 				<details class="dashboard-details">
 					<summary>데이터 표로 보기</summary>
+					<div class="admin-table-scroll" tabindex="0" role="group"
+					     aria-label="가로로 스크롤 가능한 데이터 표">
 					<table class="static-table">
 						<thead>
 						<tr>
@@ -108,6 +110,7 @@
 						</tr>
 						</tbody>
 					</table>
+					</div>
 				</details>
 			</section>
 		</div>
@@ -116,6 +119,8 @@
 	<section>
 		<h2>차단 상위 역</h2>
 		<p>차단된 경로 검색에 가장 많이 얽힌 역입니다. 최다 차단 역은 강조됩니다. 역을 눌러 허브로 이동합니다.</p>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table>
 			<thead>
 			<tr>
@@ -135,10 +140,13 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 
 	<section>
 		<h2>이동 프로필별 검색</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table class="static-table">
 			<thead>
 			<tr>
@@ -153,10 +161,13 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 
 	<section>
 		<h2>지역별 사용량</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table class="static-table">
 			<thead>
 			<tr>
@@ -173,10 +184,13 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 
 	<section>
 		<h2>차단 사유별 현황</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table class="static-table">
 			<thead>
 			<tr>
@@ -191,10 +205,13 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 
 	<section>
 		<h2>ETA source 현황</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table class="static-table">
 			<thead>
 			<tr>
@@ -211,10 +228,13 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 
 	<section>
 		<h2>fallback 사유별 현황</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table class="static-table">
 			<thead>
 			<tr>
@@ -231,10 +251,13 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 
 	<section>
 		<h2>품질 신호 구분</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table class="static-table">
 			<thead>
 			<tr>
@@ -251,10 +274,13 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 
 	<section>
 		<h2>알림 기준</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table class="static-table">
 			<thead>
 			<tr>
@@ -271,6 +297,7 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 </main>
 </div>

--- a/backend/src/main/resources/templates/admin/stations/detail.html
+++ b/backend/src/main/resources/templates/admin/stations/detail.html
@@ -62,6 +62,8 @@
 
 				<section class="admin-panel">
 					<h2>역 주요 정보</h2>
+					<div class="admin-table-scroll" tabindex="0" role="group"
+					     aria-label="가로로 스크롤 가능한 데이터 표">
 					<table>
 						<tbody>
 						<tr><th scope="row">한글 역명</th><td th:text="${station.stationName}">상록수</td></tr>
@@ -72,6 +74,7 @@
 						<tr><th scope="row">마지막 확인</th><td th:text="${station.lastVerifiedAt}">2026-06-20</td></tr>
 						</tbody>
 					</table>
+					</div>
 				</section>
 
 				<section th:if="${stationReleaseSummary != null}">
@@ -80,6 +83,8 @@
 					<p class="summary">
 						<strong th:text="|${stationReleaseSummary.status} ${stationReleaseSummary.totalBlockers}건|">확인 필요 0건</strong>
 					</p>
+					<div class="admin-table-scroll" tabindex="0" role="group"
+					     aria-label="가로로 스크롤 가능한 데이터 표">
 					<table>
 						<thead>
 						<tr>
@@ -96,6 +101,7 @@
 						</tr>
 						</tbody>
 					</table>
+					</div>
 				</section>
 			</th:block>
 
@@ -103,7 +109,9 @@
 			<th:block th:if="${activeTab == 'facilities'}">
 				<section>
 					<h2>출구</h2>
-					<table th:if="${!exits.isEmpty()}">
+					<div class="admin-table-scroll" tabindex="0" role="group"
+					     aria-label="가로로 스크롤 가능한 데이터 표" th:if="${!exits.isEmpty()}">
+					<table>
 						<thead>
 						<tr>
 							<th scope="col">출구</th>
@@ -123,12 +131,15 @@
 						</tr>
 						</tbody>
 					</table>
+					</div>
 					<p th:if="${exits.isEmpty()}">등록된 출구가 없습니다.</p>
 				</section>
 
 				<section>
 					<h2>접근성 시설</h2>
-					<table th:if="${!facilities.isEmpty()}">
+					<div class="admin-table-scroll" tabindex="0" role="group"
+					     aria-label="가로로 스크롤 가능한 데이터 표" th:if="${!facilities.isEmpty()}">
+					<table>
 						<thead>
 						<tr>
 							<th scope="col">시설</th>
@@ -154,6 +165,7 @@
 						</tr>
 						</tbody>
 					</table>
+					</div>
 					<div th:if="${facilities.isEmpty()}"
 					     th:replace="~{admin/fragments/empty-state :: panel('등록된 접근성 시설이 없습니다.', '구조·동선 편집에서 시설을 추가하세요.')}"></div>
 				</section>
@@ -166,7 +178,9 @@
 						<h2>제보 이력</h2>
 						<a class="admin-btn" th:href="@{${stationReportsHref}}">전체 제보 보기</a>
 					</div>
-					<table th:if="${!stationReports.isEmpty()}">
+					<div class="admin-table-scroll" tabindex="0" role="group"
+					     aria-label="가로로 스크롤 가능한 데이터 표" th:if="${!stationReports.isEmpty()}">
+					<table>
 						<thead>
 						<tr>
 							<th scope="col">상태</th>
@@ -188,6 +202,7 @@
 						</tr>
 						</tbody>
 					</table>
+					</div>
 					<div th:if="${stationReports.isEmpty()}"
 					     th:replace="~{admin/fragments/empty-state :: panel('이 역의 제보가 없습니다.', '접수되면 여기와 제보 대기열에 함께 표시됩니다.')}"></div>
 				</section>
@@ -203,6 +218,8 @@
 					<div th:if="${fieldSession == null}"
 					     th:replace="~{admin/fragments/empty-state :: panel('현장 확인 세션이 없습니다.', '현장 확인 화면에서 확인 일정을 등록하세요.')}"></div>
 					<div th:if="${fieldSession != null}">
+						<div class="admin-table-scroll" tabindex="0" role="group"
+						     aria-label="가로로 스크롤 가능한 데이터 표">
 						<table>
 							<tbody>
 							<tr><th scope="row">확인 상태</th><td th:text="${fieldSession.statusLabel}">확인 완료</td></tr>
@@ -212,8 +229,11 @@
 							<tr th:if="${fieldSession.note != null}"><th scope="row">메모</th><td th:text="${fieldSession.note}">-</td></tr>
 							</tbody>
 						</table>
+						</div>
 						<h3>최근 상태 변경</h3>
-						<table th:if="${!fieldHistory.isEmpty()}">
+						<div class="admin-table-scroll" tabindex="0" role="group"
+						     aria-label="가로로 스크롤 가능한 데이터 표" th:if="${!fieldHistory.isEmpty()}">
+						<table>
 							<thead>
 							<tr>
 								<th scope="col">항목</th>
@@ -233,6 +253,7 @@
 							</tr>
 							</tbody>
 						</table>
+						</div>
 						<p th:if="${fieldHistory.isEmpty()}">상태 변경 이력이 없습니다.</p>
 					</div>
 				</section>
@@ -246,7 +267,9 @@
 						<a class="admin-btn" th:href="@{${layoutEditorHref}}">구조·동선 편집</a>
 					</div>
 					<h3>구조 자료</h3>
-					<table th:if="${!layoutSources.isEmpty()}">
+					<div class="admin-table-scroll" tabindex="0" role="group"
+					     aria-label="가로로 스크롤 가능한 데이터 표" th:if="${!layoutSources.isEmpty()}">
+					<table>
 						<thead>
 						<tr>
 							<th scope="col">자료명</th>
@@ -262,10 +285,13 @@
 						</tr>
 						</tbody>
 					</table>
+					</div>
 					<p th:if="${layoutSources.isEmpty()}">등록된 구조 자료가 없습니다.</p>
 
 					<h3>동선 노드 / 간선</h3>
-					<table th:if="${!routeNodes.isEmpty()}">
+					<div class="admin-table-scroll" tabindex="0" role="group"
+					     aria-label="가로로 스크롤 가능한 데이터 표" th:if="${!routeNodes.isEmpty()}">
+					<table>
 						<thead>
 						<tr>
 							<th scope="col">노드</th>
@@ -281,8 +307,11 @@
 						</tr>
 						</tbody>
 					</table>
+					</div>
 					<p th:if="${routeNodes.isEmpty()}">등록된 동선 노드가 없습니다.</p>
-					<table th:if="${!routeEdges.isEmpty()}">
+					<div class="admin-table-scroll" tabindex="0" role="group"
+					     aria-label="가로로 스크롤 가능한 데이터 표" th:if="${!routeEdges.isEmpty()}">
+					<table>
 						<thead>
 						<tr>
 							<th scope="col">간선</th>
@@ -298,6 +327,7 @@
 						</tr>
 						</tbody>
 					</table>
+					</div>
 				</section>
 			</th:block>
 		</div>

--- a/backend/src/main/resources/templates/admin/stations/layouts.html
+++ b/backend/src/main/resources/templates/admin/stations/layouts.html
@@ -40,7 +40,9 @@
 	<section>
 		<h2>구조도 기준 자료</h2>
 		<p class="empty" th:if="${layoutSources.isEmpty()}">등록된 구조도 기준 자료가 없습니다.</p>
-		<table th:if="${!layoutSources.isEmpty()}">
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표" th:if="${!layoutSources.isEmpty()}">
+		<table>
 			<thead>
 			<tr>
 				<th scope="col">자료</th>
@@ -106,12 +108,15 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 
 	<section>
 		<h2>쉬운 내부 구조도</h2>
 		<p class="empty" th:if="${layouts.isEmpty()}">등록된 쉬운 내부 구조도가 없습니다.</p>
-		<table th:if="${!layouts.isEmpty()}">
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표" th:if="${!layouts.isEmpty()}">
+		<table>
 			<thead>
 			<tr>
 				<th scope="col">구조도</th>
@@ -150,12 +155,15 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 
 	<section>
 		<h2>내부 이동 노드</h2>
 		<p class="empty" th:if="${routeNodes.isEmpty()}">등록된 내부 이동 노드가 없습니다.</p>
-		<table th:if="${!routeNodes.isEmpty()}">
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표" th:if="${!routeNodes.isEmpty()}">
+		<table>
 			<thead>
 			<tr>
 				<th scope="col">노드</th>
@@ -198,12 +206,15 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 
 	<section>
 		<h2>내부 이동 간선</h2>
 		<p class="empty" th:if="${routeEdges.isEmpty()}">등록된 내부 이동 간선이 없습니다.</p>
-		<table th:if="${!routeEdges.isEmpty()}">
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표" th:if="${!routeEdges.isEmpty()}">
+		<table>
 			<thead>
 			<tr>
 				<th scope="col">간선</th>
@@ -277,6 +288,7 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 </main>
 </div>

--- a/backend/src/main/resources/templates/admin/stations/list.html
+++ b/backend/src/main/resources/templates/admin/stations/list.html
@@ -50,6 +50,8 @@
 			<button type="submit">검색</button>
 		</form>
 
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table>
 			<thead>
 			<tr>
@@ -104,6 +106,7 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 		<div th:replace="~{admin/fragments/pagination :: pager('역 목록 페이지', ${page}, ${paginationLinks})}"></div>
 	</div>
 </main>

--- a/backend/src/main/resources/templates/admin/system.html
+++ b/backend/src/main/resources/templates/admin/system.html
@@ -35,6 +35,8 @@
 
 	<section>
 		<h2>컴포넌트 상태</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table>
 			<thead>
 			<tr>
@@ -54,10 +56,13 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 
 	<section>
 		<h2>최근 데이터 수집</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table>
 			<thead>
 			<tr>
@@ -89,6 +94,7 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 </main>
 </div>

--- a/backend/src/main/resources/templates/admin/usage/activity.html
+++ b/backend/src/main/resources/templates/admin/usage/activity.html
@@ -94,6 +94,8 @@
 				</div>
 				<details class="dashboard-details">
 					<summary>데이터 표로 보기</summary>
+					<div class="admin-table-scroll" tabindex="0" role="group"
+					     aria-label="가로로 스크롤 가능한 데이터 표">
 					<table class="static-table">
 						<thead>
 						<tr>
@@ -109,6 +111,7 @@
 						</tr>
 						</tbody>
 					</table>
+					</div>
 				</details>
 			</section>
 		</div>
@@ -116,6 +119,8 @@
 
 	<section>
 		<h2>일별 활성 사용자</h2>
+		<div class="admin-table-scroll" tabindex="0" role="group"
+		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table class="static-table">
 			<thead>
 			<tr>
@@ -138,6 +143,7 @@
 			</tr>
 			</tbody>
 		</table>
+		</div>
 	</section>
 </main>
 </div>

--- a/backend/src/test/java/com/easysubway/admin/web/AdminDesignGuardTest.java
+++ b/backend/src/test/java/com/easysubway/admin/web/AdminDesignGuardTest.java
@@ -243,6 +243,10 @@ class AdminDesignGuardTest {
 		assertThat(rule(css, "\\.admin-main")).doesNotContain("overflow-x: auto;");
 		assertThat(rule(css, "\\.admin-v3 section,\\s*\\.admin-card"))
 			.doesNotContain("overflow-x: auto;");
+		assertThat(rule(css,
+			"\\.admin-v3 \\.admin-table-scroll table\\.static-table tbody tr:hover "
+				+ "td:first-child:not\\(\\[colspan\\]\\)"))
+			.contains("background: var(--admin-surface);");
 	}
 
 	private static int count(Pattern pattern, String source) {

--- a/backend/src/test/java/com/easysubway/admin/web/AdminDesignGuardTest.java
+++ b/backend/src/test/java/com/easysubway/admin/web/AdminDesignGuardTest.java
@@ -54,7 +54,7 @@ class AdminDesignGuardTest {
 	private static final Pattern CONDITIONAL_TABLE = Pattern.compile("<table\\b[^>]*\\bth:if=");
 	private static final Pattern ACCESSIBLE_TABLE_WRAPPER = Pattern.compile(
 		"<div class=\"admin-table-scroll\" tabindex=\"0\" role=\"group\"\\s+"
-			+ "aria-label=\"가로로 스크롤 가능한 데이터 표\"[^>]*>\\s*<table\\b",
+			+ "aria-label=\"가로로 스크롤 가능한 [^\"]*표\"[^>]*>\\s*<table\\b",
 		Pattern.DOTALL);
 	private static final Pattern TABLE_WRAPPER_CLOSE = Pattern.compile("</table>\\s*</div>");
 

--- a/backend/src/test/java/com/easysubway/admin/web/AdminDesignGuardTest.java
+++ b/backend/src/test/java/com/easysubway/admin/web/AdminDesignGuardTest.java
@@ -244,6 +244,12 @@ class AdminDesignGuardTest {
 		assertThat(rule(css, "\\.admin-main")).doesNotContain("overflow-x: auto;");
 		assertThat(rule(css, "\\.admin-v3 section,\\s*\\.admin-card"))
 			.doesNotContain("overflow-x: auto;");
+		assertThat(rule(css, "\\.admin-v3 th"))
+			.doesNotContain("position: sticky;")
+			.doesNotContain("top: 0;");
+		assertThat(rule(css, "\\.admin-v3 thead th"))
+			.contains("position: sticky;")
+			.contains("top: 0;");
 		assertThat(rule(css,
 			"\\.admin-v3 \\.admin-table-scroll table\\.static-table tbody tr:hover "
 				+ "td:first-child:not\\(\\[colspan\\]\\)"))

--- a/backend/src/test/java/com/easysubway/admin/web/AdminDesignGuardTest.java
+++ b/backend/src/test/java/com/easysubway/admin/web/AdminDesignGuardTest.java
@@ -232,7 +232,8 @@ class AdminDesignGuardTest {
 
 		assertThat(css)
 			.contains(".admin-table-scroll {")
-			.contains("overflow-x: auto;")
+			.contains("max-block-size: min(70vh, 640px);")
+			.contains("overflow: auto;")
 			.contains(".admin-v3 .admin-table-scroll:focus-visible {")
 			.contains(".admin-table-scroll th:first-child,")
 			.contains(".admin-table-scroll td:first-child:not([colspan]) {")

--- a/backend/src/test/java/com/easysubway/admin/web/AdminDesignGuardTest.java
+++ b/backend/src/test/java/com/easysubway/admin/web/AdminDesignGuardTest.java
@@ -50,6 +50,13 @@ class AdminDesignGuardTest {
 	private static final Pattern BORDER_RADIUS_PX = Pattern.compile(
 		"border-radius\\s*:\\s*([^;]*)", Pattern.CASE_INSENSITIVE);
 	private static final Pattern PX_LITERAL = Pattern.compile("(\\d+)px");
+	private static final Pattern TABLE_TAG = Pattern.compile("<table\\b");
+	private static final Pattern CONDITIONAL_TABLE = Pattern.compile("<table\\b[^>]*\\bth:if=");
+	private static final Pattern ACCESSIBLE_TABLE_WRAPPER = Pattern.compile(
+		"<div class=\"admin-table-scroll\" tabindex=\"0\" role=\"group\"\\s+"
+			+ "aria-label=\"가로로 스크롤 가능한 데이터 표\"[^>]*>\\s*<table\\b",
+		Pattern.DOTALL);
+	private static final Pattern TABLE_WRAPPER_CLOSE = Pattern.compile("</table>\\s*</div>");
 
 	@Test
 	@DisplayName("금지된 초록·청록 계열 hex가 없다")
@@ -185,6 +192,72 @@ class AdminDesignGuardTest {
 			.contains("border-top: 1px solid var(--admin-border);")
 			.contains(".dashboard-card.metric-cell:first-child {")
 			.contains("border-top: 0;");
+	}
+
+	@Test
+	@DisplayName("모든 admin table은 조건과 접근성 이름을 소유한 명시적 scroll wrapper를 사용한다")
+	void adminTablesUseExplicitAccessibleScrollWrappers() throws IOException {
+		Path templates = ROOT.resolve("backend/src/main/resources/templates/admin");
+		List<String> violations = new ArrayList<>();
+		int totalTables = 0;
+		try (var paths = Files.walk(templates)) {
+			for (Path path : paths.filter(file -> file.toString().endsWith(".html")).toList()) {
+				String html = Files.readString(path);
+				int tables = count(TABLE_TAG, html);
+				if (tables == 0) {
+					continue;
+				}
+				totalTables += tables;
+				int wrappers = count(ACCESSIBLE_TABLE_WRAPPER, html);
+				int wrapperCloses = count(TABLE_WRAPPER_CLOSE, html);
+				int conditionalTables = count(CONDITIONAL_TABLE, html);
+				if (tables != wrappers || tables != wrapperCloses || conditionalTables != 0) {
+					violations.add(ROOT.relativize(path) + ": tables=" + tables
+						+ ", wrappers=" + wrappers + ", closes=" + wrapperCloses
+						+ ", conditionalTables=" + conditionalTables);
+				}
+			}
+		}
+
+		assertThat(totalTables).as("admin table inventory가 비어 있지 않다").isPositive();
+		assertThat(violations)
+			.as("wrapper 없는 admin table 또는 wrapper 밖 th:if: %s", violations)
+			.isEmpty();
+	}
+
+	@Test
+	@DisplayName("table wrapper만 horizontal scroll을 소유하고 sticky header·첫 열을 유지한다")
+	void tableWrapperOwnsHorizontalScrollAndStickyCells() throws IOException {
+		String css = read("backend/src/main/resources/static/css/admin-v3.css");
+
+		assertThat(css)
+			.contains(".admin-table-scroll {")
+			.contains("overflow-x: auto;")
+			.contains(".admin-v3 .admin-table-scroll:focus-visible {")
+			.contains(".admin-table-scroll th:first-child,")
+			.contains(".admin-table-scroll td:first-child:not([colspan]) {")
+			.contains("position: sticky;")
+			.contains("left: 0;")
+			.contains(".admin-table-scroll thead th:first-child {");
+		assertThat(rule(css, "html,\\s*body\\.admin-v3")).contains("overflow-x: hidden;");
+		assertThat(rule(css, "\\.admin-main")).doesNotContain("overflow-x: auto;");
+		assertThat(rule(css, "\\.admin-v3 section,\\s*\\.admin-card"))
+			.doesNotContain("overflow-x: auto;");
+	}
+
+	private static int count(Pattern pattern, String source) {
+		int count = 0;
+		Matcher matcher = pattern.matcher(source);
+		while (matcher.find()) {
+			count++;
+		}
+		return count;
+	}
+
+	private static String rule(String css, String selectorPattern) {
+		Matcher matcher = Pattern.compile(selectorPattern + "\\s*\\{([^}]*)}", Pattern.DOTALL).matcher(css);
+		assertThat(matcher.find()).as("CSS rule이 존재한다: %s", selectorPattern).isTrue();
+		return matcher.group(1);
 	}
 
 	private static String read(String path) throws IOException {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -12724,10 +12724,18 @@ test("관리자 v3 공통 shell은 접근성 chrome과 inline style 제한을 �
   assert.match(adminCss, /\.admin-v3 a:focus-visible/);
   assert.match(adminCss, /outline: 3px solid #ffbf47/);
   assert.match(adminCss, /\.admin-topbar-row/);
-  assert.match(adminCss, /\.admin-main[\s\S]*min-width: 0[\s\S]*overflow-x: auto/);
+  // #2071 scroll 소유권 계약: 관리자 table의 horizontal scroll은 .admin-table-scroll wrapper가 단독 소유한다.
+  // .admin-main / .admin-v3 section / .admin-card 는 scroll을 소유하지 않는다(overflow-x: visible).
+  assert.match(adminCss, /\.admin-main[\s\S]*?min-width: 0[\s\S]*?overflow-x: visible/);
   assert.match(adminCss, /\.admin-sidebar[\s\S]*overflow-y: auto/);
   assert.match(adminCss, /\.admin-v3 table[\s\S]*min-width: 620px/);
-  assert.match(adminCss, /\.admin-v3 section,[\s\S]*\.admin-card[\s\S]*overflow-x: auto/);
+  assert.match(adminCss, /\.admin-v3 section,[\s\S]*?\.admin-card[\s\S]*?overflow-x: visible/);
+  // .admin-table-scroll 이 유일한 scroll 소유자: overflow: auto + bounded viewport(max-block-size) + inline overscroll 격리.
+  assert.match(adminCss, /\.admin-table-scroll \{[\s\S]*?max-block-size: min\(70vh, 640px\)[\s\S]*?overflow: auto[\s\S]*?overscroll-behavior-inline: contain/);
+  // vertical sticky 는 thead th 에만 적용한다(#2071 리뷰: row header td 는 vertical sticky 제외).
+  assert.match(adminCss, /\.admin-v3 thead th \{[\s\S]*?position: sticky[\s\S]*?top: 0/);
+  // 첫 열 horizontal sticky 는 scroll wrapper 안에서만: th:first-child / td:first-child:not([colspan]).
+  assert.match(adminCss, /\.admin-table-scroll th:first-child,[\s\S]*?\.admin-table-scroll td:first-child:not\(\[colspan\]\) \{[\s\S]*?position: sticky[\s\S]*?left: 0/);
   assert.match(navigationAdvice, /@ModelAttribute\("adminShell"\)/);
   assert.match(navigationAdvice, /return "PRODUCTION"/);
   assert.match(navigationAdvice, /return "STAGING"/);


### PR DESCRIPTION
## 관련 이슈

close #2071

## 작업 배경

- 관리자 table의 모바일 horizontal scroll을 정리한다(#2071). 좁은 화면에서 넓은 표가 페이지 전체를 밀어내지 않고 표 영역 안에서만 스크롤되도록 소유권을 정돈한다.
- 리뷰 지적 3건을 반영하는 과정에서 horizontal scroll 소유권이 페이지 컨테이너에서 표 wrapper(`.admin-table-scroll`)로 이동했다.
- 소유권 이전에 따라 기존 계약 테스트(구 소유권 `.admin-main` / `.admin-v3 section`·`.admin-card`의 `overflow-x: auto`를 고정)가 실제 CSS와 어긋나 Repository CI와 Release Gate Consistency가 같은 assertion에서 실패했다. 이를 새 소유권 계약으로 갱신한다.

## 작업 내용

- 관리자 table 84개를 scroll wrapper(`.admin-table-scroll`)로 감싸고, `th:if` 기반 헤더 셀 렌더링을 wrapper 구조에 맞춰 이동, sticky 규칙을 고정, source guard로 wrapper 누락을 방지한다(기존 커밋).
- 리뷰 반영 3건:
  - `1957dc09` static-table hover 복원 — static table의 sticky 첫 열 hover 스타일 유지.
  - `0a4a161d` bounded vertical scrollport — `.admin-table-scroll`에 `max-block-size: min(70vh, 640px)`로 vertical scrollport를 제한하고 thead sticky viewport를 보존.
  - `1da74f45` row header vertical sticky 제외 — vertical sticky는 `thead th`에만 두고 row header `td`에는 적용하지 않는다.
- 계약 테스트 scroll-ownership 갱신(`tools/ci/repository-contract.test.mjs`): horizontal scroll 소유자를 `.admin-table-scroll` wrapper로 고정하고, `.admin-main`/`.admin-v3 section`/`.admin-card`는 `overflow-x: visible`로 scroll 비소유임을 고정한다. thead sticky·첫 열 sticky 계약도 함께 명문화한다.
- `origin/main`을 merge하여 브랜치를 최신화한다(rebase·force-push 없이 history 보존).

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/repository-contract.test.mjs` → tests 217 / pass 217 / fail 0
  - `node --test tools/ci/*.test.mjs tools/ci/lib/*.test.mjs tools/repo/*.test.mjs` → tests 357 / pass 357 / fail 0
  - 두 명령 모두 CI와 동일한 로케일(C.UTF-8)에서 실행했다. 계약 산출물 해시(`canonicalScopeHash`)의 배열 정렬이 `localeCompare` 기반이라 CI(ubuntu, C 계열 로케일)와 동일 환경에서 재현해야 결과가 일치한다.
  - backend Java·템플릿은 merge·본 변경에서 건드리지 않아 `AdminDesignGuardTest`는 별도 실행하지 않았다.

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 관리자 table scroll UX | 관리자 웹(모바일) | 계약 테스트(`repository-contract.test.mjs`) 및 `AdminDesignGuardTest` 회귀로 scroll 소유권·sticky 계약 고정. 390×844·text 200% screenshot과 clipping 0 최종 판정은 별도 수행 예정. | 계약 테스트 결과(위 검증). 시각 최종 evidence는 #1988 final evidence manifest에서 수집 예정. | 계약 회귀 PASS / 시각 최종 판정은 #1988 manifest에서 수행 예정 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 계약 테스트가 고정하는 새 scroll-ownership 계약. `tools/ci/repository-contract.test.mjs`
  - L12727~ scroll 소유권 계약 주석 블록
  - L12734 `.admin-table-scroll` 단독 scroll 소유자(`overflow: auto` + `max-block-size: min(70vh, 640px)` + `overscroll-behavior-inline: contain`)
  - L12736 vertical sticky는 `thead th`에만
  - L12738 첫 열 horizontal sticky는 wrapper 안 `th:first-child`/`td:first-child:not([colspan])`
- CSS와 테스트가 함께 움직였는지(구 계약 잔재 없는지) 확인 바람.

## 리스크

- 계약 테스트 갱신이 구 계약(`overflow-x: auto` on `.admin-main`/`.admin-v3 section`/`.admin-card`)을 대체한다. CSS의 실제 scroll 소유권 이전과 테스트의 계약 갱신이 함께 움직였는지가 유일한 리스크 포인트다. 테스트는 `admin-v3.css`의 실제 규칙에 매칭되도록 작성했고, 존재하지 않는 규칙은 assert하지 않는다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
