### PR TITLE
[Style] #1778 상태 요약 factual voice 정렬 — 사용자 문구 inventory producer 도입

### DIFF
--- a/apps/mobile/lib/facility_status.dart
+++ b/apps/mobile/lib/facility_status.dart
@@ -40,8 +40,8 @@ const _cautionPresentation = FacilityStatusPresentation(
 
 const _needsInfoPresentation = FacilityStatusPresentation(
   severity: FacilityStatusSeverity.needsInfo,
-  severityLabel: '확인 중',
-  statusTitle: '상태를 확인하고 있어요',
+  severityLabel: '미확인',
+  statusTitle: '상태 미확인',
   nextActionLabel: '자세히 보기',
   nextActionDescription: '상태를 확인하고, 이동 전 현장 안내도 함께 봐 주세요.',
   priority: 30,
@@ -49,7 +49,7 @@ const _needsInfoPresentation = FacilityStatusPresentation(
 
 const _unknownPresentation = FacilityStatusPresentation(
   severity: FacilityStatusSeverity.needsInfo,
-  severityLabel: '확인 중',
+  severityLabel: '미확인',
   statusTitle: '설치 확인 · 운행상태 미확인',
   nextActionLabel: '자세히 보기',
   nextActionDescription: '설치 여부는 확인됐어요. 운행 상태는 현장 안내도 함께 봐 주세요.',

--- a/apps/mobile/lib/favorite_facility.dart
+++ b/apps/mobile/lib/favorite_facility.dart
@@ -263,8 +263,8 @@ class FavoriteFacility {
       'USER_REPORTED' => '제보됨',
       'ADMIN_VERIFIED' => '확인 완료',
       'NEEDS_REPORT' => '알려 주세요',
-      'NEEDS_CHECK' => '상태를 확인하고 있어요',
-      _ => '상태를 확인하고 있어요',
+      'NEEDS_CHECK' => '상태 미확인',
+      _ => '상태 미확인',
     };
   }
 

--- a/apps/mobile/lib/features/routes/application/route_engine.dart
+++ b/apps/mobile/lib/features/routes/application/route_engine.dart
@@ -556,7 +556,7 @@ class RouteAssembler {
       'BLOCKED_PLACEHOLDER_EVIDENCE_HASH' => '임시 근거만 있는 경로는 안내하지 않아요.',
       'BLOCKED_UNSUPPORTED_SCOPE' => '지원 범위 밖 경로는 안내하지 않아요.',
       'STRICT_EVIDENCE_UNSUPPORTED' => '검증 근거가 부족해 계단 없는 경로로 안내하지 않아요.',
-      'DURATION_UNKNOWN' => '소요 시간을 확인하고 있어요.',
+      'DURATION_UNKNOWN' => routeDurationUnknown,
       'ACCESSIBILITY_STATE_UNKNOWN' => routeHedgeAccessibilityUnknown,
       'FACILITY_UNDER_MAINTENANCE' => routeFacilityUnderMaintenance,
       'FACILITY_UNAVAILABLE' => routeFacilityUnavailable,

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -2635,7 +2635,7 @@ class _RouteCatalogSnapshot {
   }
 
   String stationName(String stationId) {
-    return stationsById[canonicalStationId(stationId)] ?? '역 이름을 확인하고 있어요';
+    return stationsById[canonicalStationId(stationId)] ?? '역 이름 미확인';
   }
 
   bool hasStation(String stationId) {

--- a/apps/mobile/lib/features/stations/domain/station_models.dart
+++ b/apps/mobile/lib/features/stations/domain/station_models.dart
@@ -228,7 +228,7 @@ class FavoriteStation {
 
   String get lineLabel {
     if (lines.isEmpty) {
-      return '노선을 확인하고 있어요';
+      return '노선 미확인';
     }
     return lines.map((line) => line.name).join(', ');
   }
@@ -298,7 +298,7 @@ class StationSearchResult {
 
   String get lineLabel {
     if (lines.isEmpty) {
-      return '노선을 확인하고 있어요';
+      return '노선 미확인';
     }
     return lines.map((line) => line.name).join(', ');
   }
@@ -386,7 +386,7 @@ class StationDetail {
 
   String get lineLabel {
     if (lines.isEmpty) {
-      return '노선을 확인하고 있어요';
+      return '노선 미확인';
     }
     return lines.map((line) => line.name).join(', ');
   }
@@ -450,7 +450,7 @@ class StationExitInfo {
   bool get hasCoordinate => latitude != null && longitude != null;
 
   String get elevatorConnectionLabel {
-    return hasElevatorConnection ? '엘리베이터 연결' : '엘리베이터 연결을 확인하고 있어요';
+    return hasElevatorConnection ? '엘리베이터 연결' : '엘리베이터 연결 미확인';
   }
 
   String get stairPathLabel {
@@ -562,8 +562,8 @@ class StationFacilityInfo {
       'USER_REPORTED' => '제보됨',
       'ADMIN_VERIFIED' => '확인 완료',
       'NEEDS_REPORT' => '알려 주세요',
-      'NEEDS_CHECK' => '상태를 확인하고 있어요',
-      _ => '상태를 확인하고 있어요',
+      'NEEDS_CHECK' => '상태 미확인',
+      _ => '상태 미확인',
     };
   }
 

--- a/apps/mobile/lib/features/stations/presentation/station_facility_detail_screen.dart
+++ b/apps/mobile/lib/features/stations/presentation/station_facility_detail_screen.dart
@@ -216,7 +216,7 @@ String _facilityFloorLabel(StationFacilityInfo facility) {
   final from = facility.floorFrom.trim();
   final to = facility.floorTo.trim();
   if (from.isEmpty && to.isEmpty) {
-    return '연결 위치를 확인하고 있어요';
+    return '연결 위치 미확인';
   }
   if (from.isEmpty || to.isEmpty) {
     return '연결 위치 ${from.isEmpty ? to : from}';

--- a/apps/mobile/lib/internal_route.dart
+++ b/apps/mobile/lib/internal_route.dart
@@ -395,7 +395,7 @@ class InternalRouteStep {
       _internalRouteDistanceLabel(distanceMeters),
       if (includesStairs) '계단 포함',
       if (requiresElevator) '엘리베이터를 이용해요',
-      if (requiresEscalator) '에스컬레이터 안내를 확인하고 있어요',
+      if (requiresEscalator) '에스컬레이터를 이용해요',
     ];
     return labels.join(' · ');
   }

--- a/apps/mobile/lib/route_hedge_labels.dart
+++ b/apps/mobile/lib/route_hedge_labels.dart
@@ -19,6 +19,9 @@ const routeHedgeConnectivityUnknown = '길이 이어지는지 확인하고 있�
 /// 세부 원인을 특정할 수 없는 일반 불확실성.
 const routeHedgeGenericUnknown = '일부 안내를 확인하고 있어요.';
 
+/// 소요 시간을 아직 계산하지 못한 불확실성(경로 warning·engine 공통 한 벌).
+const routeDurationUnknown = '소요 시간을 확인하고 있어요.';
+
 /// 실측된 보수중/점검/중지/공사 상태(#1996). 확인 불가와 달리 '지금은 이용
 /// 어려움'을 정직하게 알린다. 숨기지 않되 가용으로 오인되지 않게 구분한다.
 const routeFacilityUnderMaintenance = '지금은 보수중이라 이용하기 어려워요.';
@@ -46,7 +49,7 @@ String routeWarningLabel(String code) {
     'LOW_DATA_CONFIDENCE' => '일부 시설 안내를 준비 중이에요.',
     'STALE_ACCESSIBILITY_DATA' => '시설 상태 안내가 오래됐을 수 있어요.',
     'STAIR_ONLY_ACCESS' => '계단 포함 구간이 있습니다.',
-    'DURATION_UNKNOWN' => '소요 시간을 확인하고 있어요.',
+    'DURATION_UNKNOWN' => routeDurationUnknown,
     'FACILITY_UNDER_MAINTENANCE' => routeFacilityUnderMaintenance,
     'FACILITY_UNAVAILABLE' => routeFacilityUnavailable,
     _ => routeUncertaintyHedgeLabel(code),

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -76,7 +76,7 @@ String _routeDateLabel(String value) {
 
 const routeEtaSourceLabels = <String, String>{
   'REALTIME': '실시간 도착정보 준비 중',
-  'MIXED': '일부 도착정보를 확인하고 있어요',
+  'MIXED': '일부 실시간 도착정보',
   'PLANNED': '시간표 기준',
   'STATIC_BACKEND_ESTIMATE': '시간표 기준',
   'STATIC_BACKEND_V1': '시간표 기준',
@@ -1622,7 +1622,7 @@ class RouteSearchResult {
 
   String get scoreLabel => burdenLevelLabel;
 
-  String get lineLabel => lineName.isEmpty ? '노선을 확인하고 있어요' : lineName;
+  String get lineLabel => lineName.isEmpty ? '노선 미확인' : lineName;
 
   bool get isBlocked => status == 'BLOCKED';
 
@@ -1859,10 +1859,10 @@ class RouteSearchResult {
 
   String get burdenLevelLabel {
     if (isBlocked) {
-      return '이동 부담을 확인하고 있어요';
+      return '이동 부담 미확인';
     }
     if (movementSteps.isEmpty) {
-      return '이동 부담을 확인하고 있어요';
+      return '이동 부담 미확인';
     }
     if (_hasHighBurdenFact) {
       return '이동 부담 높음';
@@ -2375,7 +2375,7 @@ class RouteSearchStep {
       return '예상 시간·거리예요';
     }
     if (timeSource == 'UNKNOWN' || distanceSource == 'UNKNOWN') {
-      return '시간 또는 거리를 확인하고 있어요';
+      return '시간·거리 정보 미확인';
     }
     if (timeSource == 'REALTIME') {
       return '실시간 도착 정보 기준이에요';
@@ -2389,14 +2389,14 @@ class RouteSearchStep {
 
 String _routeDurationLabel(int estimatedMinutes) {
   if (estimatedMinutes <= 0) {
-    return '시간을 확인하고 있어요';
+    return '시간 미확인';
   }
   return '약 $estimatedMinutes분';
 }
 
 String _routeDistanceLabel(int distanceMeters) {
   if (distanceMeters <= 0) {
-    return '거리를 확인하고 있어요';
+    return '거리 미확인';
   }
   if (distanceMeters < 1000) {
     return '${distanceMeters}m';

--- a/apps/mobile/test/favorite_facility_test.dart
+++ b/apps/mobile/test/favorite_facility_test.dart
@@ -99,7 +99,7 @@ void main() {
     expect(unavailable.nextActionLabel, '대체 출구 보기');
     expect(reported.severityLabel, '가기 전 살펴보기');
     expect(reported.nextActionLabel, '역무원 도움 요청');
-    expect(unknown.severityLabel, '확인 중');
+    expect(unknown.severityLabel, '미확인');
     expect(unknown.nextActionLabel, '자세히 보기');
     expect(operationalUnknown.statusLabel, '설치 확인 · 운행상태 미확인');
     expect(operationalUnknown.statusTitle, '설치 확인 · 운행상태 미확인');

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -2363,7 +2363,7 @@ void main() {
     );
 
     expect(result.status, 'UNKNOWN');
-    expect(result.destinationStationName, '역 이름을 확인하고 있어요');
+    expect(result.destinationStationName, '역 이름 미확인');
     expect(result.isLocalResult, isTrue);
   });
 

--- a/apps/mobile/test/route_search_test.dart
+++ b/apps/mobile/test/route_search_test.dart
@@ -291,7 +291,7 @@ void main() {
     expect(result.steps.first.title, '상록수역에서 4호선 승강장으로 이동');
     expect(result.steps.first.actionTitle, isEmpty);
     expect(result.steps.first.hasMetricSourceMetadata, isTrue);
-    expect(result.steps.first.metricSourceLabel, '시간 또는 거리를 확인하고 있어요');
+    expect(result.steps.first.metricSourceLabel, '시간·거리 정보 미확인');
     expect(result.steps.first.estimatedMinutes, 4);
     expect(result.steps.first.distanceMeters, 180);
     expect(result.steps.first.stepType, 'entry');
@@ -309,7 +309,7 @@ void main() {
       result.warnings.map((warning) => warning.userMessage),
       contains('시설 상태 안내가 오래됐을 수 있어요.'),
     );
-    expect(result.semanticLabel, contains('시간 또는 거리를 확인하고 있어요'));
+    expect(result.semanticLabel, contains('시간·거리 정보 미확인'));
   });
 
   test('경로 검색 컨트롤러는 빈 입력과 실패 상태를 쉬운 문구로 표시한다', () async {
@@ -653,7 +653,7 @@ void main() {
       'STALE',
     });
     expect(routeEtaSourceLabel('REALTIME'), '실시간 도착정보 준비 중');
-    expect(routeEtaSourceLabel('MIXED'), '일부 도착정보를 확인하고 있어요');
+    expect(routeEtaSourceLabel('MIXED'), '일부 실시간 도착정보');
     expect(routeEtaSourceLabel('STATIC_BACKEND_ESTIMATE'), '시간표 기준');
     expect(routeEtaSourceLabel('STATIC_ESTIMATE'), '정적 추정');
     expect(routeEtaSourceLabel('UNSUPPORTED'), '실시간 미지원');
@@ -1307,7 +1307,7 @@ void main() {
       requiresAccessibilityCheck: false,
     );
 
-    expect(step.burdenLabel, '약 30분 · 거리를 확인하고 있어요');
+    expect(step.burdenLabel, '약 30분 · 거리 미확인');
   });
 
   test('경로 단계 이동 부담은 측정 시간 없음 상태를 0분으로 표시하지 않는다', () {
@@ -1325,7 +1325,7 @@ void main() {
       requiresAccessibilityCheck: false,
     );
 
-    expect(step.burdenLabel, '시간을 확인하고 있어요 · 180m');
+    expect(step.burdenLabel, '시간 미확인 · 180m');
   });
 
   test('경로 계단 상태는 unknown을 계단 없음으로 올리지 않는다', () {

--- a/apps/mobile/test/station_search_test.dart
+++ b/apps/mobile/test/station_search_test.dart
@@ -1367,10 +1367,10 @@ void main() {
       '비상벨',
       '1번 출구 엘리베이터',
     ]);
-    expect(state.facilityAttentionSummary, '고장·폐쇄 1개 · 가기 전 살펴보기 1개 · 확인 중 1개');
+    expect(state.facilityAttentionSummary, '고장·폐쇄 1개 · 가기 전 살펴보기 1개 · 미확인 1개');
     expect(
       state.facilityAttentionSemanticLabel,
-      '살펴볼 시설, 고장·폐쇄 1개, 가기 전 살펴보기 1개, 확인 중 1개',
+      '살펴볼 시설, 고장·폐쇄 1개, 가기 전 살펴보기 1개, 미확인 1개',
     );
   });
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -9545,8 +9545,8 @@ void main() {
     expect(find.byKey(const Key('routeStepNumber-3')), findsOneWidget);
 
     // #1948: 경유 스텝은 0값 placeholder burdenLabel을 렌더하지 않는다.
-    expect(find.text('시간을 확인하고 있어요 · 거리를 확인하고 있어요'), findsNothing);
-    expect(find.textContaining('시간을 확인하고 있어요'), findsNothing);
+    expect(find.text('시간 미확인 · 거리 미확인'), findsNothing);
+    expect(find.textContaining('시간 미확인'), findsNothing);
     // #1948: 경유 스텝은 보일러플레이트 기본 안내 문장 대신 간결 카피를 쓴다.
     expect(find.text('안내된 순서대로 이동합니다.'), findsNothing);
     expect(find.text('내리지 않고 이 역을 지나가요'), findsOneWidget);
@@ -10460,14 +10460,14 @@ void main() {
         find.byKey(const Key('stationDetailLargeScreenLayout')),
         findsNothing,
       );
-      // 정상 시설은 상태 필 없이 이름으로 조용히, 문제(고장·확인 중)만 상태 필로 렌더링.
+      // 정상 시설은 상태 필 없이 이름으로 조용히, 문제(고장·미확인)만 상태 필로 렌더링.
       var sawNormalQuiet = false;
       var sawBroken = false;
       var sawNeedsCheck = false;
       for (var index = 0; index < 8; index += 1) {
         sawNormalQuiet |= find.text('1번 출구 엘리베이터').evaluate().isNotEmpty;
         sawBroken |= find.text('이용할 수 없어요').evaluate().isNotEmpty;
-        sawNeedsCheck |= find.text('상태를 확인하고 있어요').evaluate().isNotEmpty;
+        sawNeedsCheck |= find.text('상태 미확인').evaluate().isNotEmpty;
         if (sawNormalQuiet && sawBroken && sawNeedsCheck) {
           break;
         }

--- a/tools/mobile/status-voice-inventory.mjs
+++ b/tools/mobile/status-voice-inventory.mjs
@@ -1,0 +1,385 @@
+#!/usr/bin/env node
+// 상태 요약 라벨 voice 인벤토리 producer (#1778 단일 소유).
+//
+// apps/mobile/lib 의 사용자 노출 상태 요약 문자열을 현재 tree에서 재생성하고,
+// 각 항목을 상태 분류(stateClass)·소유 이슈(owner)·처리(disposition)로 분류한
+// machine-readable JSON report를 만든다. 같은 tree에서 재실행하면 동일한 결과를
+// 낸다(결정적). 다른 카피 이슈는 이 report를 소비한다.
+//
+// 사용법:
+//   node tools/mobile/status-voice-inventory.mjs            # JSON을 stdout으로
+//   node tools/mobile/status-voice-inventory.mjs --pretty   # 들여쓴 JSON
+//   node tools/mobile/status-voice-inventory.mjs --summary  # disposition 분포만
+//   node tools/mobile/status-voice-inventory.mjs --root <dir>
+//
+// stateClass:
+//   loading          실제 로딩/진행 중 — 진행형이 올바른 voice
+//   no-data          데이터가 비어 있음(빈 목록·빈 값·조회 실패 fallback)
+//   unsupported      기능/데이터 미지원
+//   stale-unknown    상태가 미확인·오래됨(진행 중 아님)
+//   static-label     정해진 사실(불리언 플래그·확정 분류)
+//   uncertainty-hedge 헤지 사전(#1577)이 소유한 불확실성 문구 — 진행형 유지
+//   coming-soon      '준비 중' 계열
+//   diagnostic       운영/진단 로그(context:) — 사용자 비노출
+//   unclassified     신호는 잡혔으나 규칙 미매칭 — drift 감시용
+//
+// disposition:
+//   keep            현재 voice 유지(실제 로딩·헤지 등)
+//   reword          사실형 문구로 정렬 대상(#1778)
+//   aligned         이미 사실형으로 정렬됨
+//   reuse-catalog   헤지 사전 공용 문구 재사용 대상(#1778)
+//   out-of-scope    타 이슈 소유 또는 비노출
+//   review          규칙 미매칭 — 사람이 판단 필요
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = fileURLToPath(new URL('.', import.meta.url));
+const DEFAULT_ROOT = join(HERE, '..', '..');
+
+// 상태 요약 voice 신호. 이 중 하나라도 포함한 리터럴만 인벤토리 후보다.
+const SIGNAL = /확인하고 있어요|확인 중|불러오는 중|조회 중|준비\s?중|미확인/;
+
+// 규칙 카탈로그. 위에서부터 첫 매칭이 이긴다. 각 규칙은 리터럴 text(정규식)와
+// 선택적으로 파일 경로 조건(fileRe)·원본 라인 포함 조건(lineHas)을 본다.
+const RULES = [
+  // 운영/진단 로그: context: 인자로 넘어가는 문자열은 사용자 비노출.
+  {
+    lineHas: 'context:',
+    stateClass: 'diagnostic',
+    owner: 'none',
+    disposition: 'out-of-scope',
+    note: '예외 로그 context — 사용자 비노출',
+  },
+
+  // '준비 중' 계열은 #2078가 소유(빈 상태 layout·ghost node 정리와 함께).
+  {
+    text: /준비\s?중/,
+    stateClass: 'coming-soon',
+    owner: '#2078',
+    disposition: 'out-of-scope',
+    note: '준비 중 문구 — #2078 소유',
+  },
+
+  // 헤지 사전(#1577) 소유 불확실성 문구. 진행형 유지, 공용 catalog가 소유.
+  {
+    text: /^(계단 없는 길인지|엘리베이터·통로 상태를|길이 이어지는지|일부 안내를) 확인하고 있어요\.$/,
+    stateClass: 'uncertainty-hedge',
+    owner: '#1778',
+    disposition: 'keep',
+    note: 'route_hedge_labels 공용 헤지 — #1577 확정',
+  },
+  {
+    text: /^소요 시간을 확인하고 있어요\.$/,
+    fileRe: /route_engine\.dart$/,
+    stateClass: 'uncertainty-hedge',
+    owner: '#1778',
+    disposition: 'reuse-catalog',
+    note: 'catalog DURATION_UNKNOWN와 중복 리터럴 — 공용 문구 재사용',
+  },
+  {
+    text: /^소요 시간을 확인하고 있어요\.$/,
+    stateClass: 'uncertainty-hedge',
+    owner: '#1778',
+    disposition: 'keep',
+    note: 'catalog DURATION_UNKNOWN 헤지',
+  },
+
+  // 실제 로딩/진행 중: 진행형이 올바른 voice.
+  {
+    text: /불러오는 중/,
+    stateClass: 'loading',
+    owner: '#1778',
+    disposition: 'keep',
+    note: '실제 데이터 로딩 라벨',
+  },
+  {
+    text: /^도착 시간을 확인하고 있어요\.$/,
+    stateClass: 'loading',
+    owner: '#1778',
+    disposition: 'keep',
+    note: '실시간 새로고침 진행 중',
+  },
+  {
+    text: /^계단 여부를 확인하고 있어요$/,
+    stateClass: 'uncertainty-hedge',
+    owner: '#1778',
+    disposition: 'keep',
+    note: '계단 상태 불확실성 — 헤지 voice 유지',
+  },
+  {
+    text: /^경로 상태를 확인하고 있어요$/,
+    stateClass: 'uncertainty-hedge',
+    owner: '#1778',
+    disposition: 'keep',
+    note: '경로 상태 불확실성(REVIEW/UNKNOWN) — 헤지 voice 유지',
+  },
+  {
+    text: /^도착 정보를 확인하고 있어요$/,
+    stateClass: 'loading',
+    owner: '#1778',
+    disposition: 'keep',
+    note: '도착 정보 출처 미도착 — 진행 중',
+  },
+
+  // #1778 정렬 대상: 진행형이 사실(플래그/빈 데이터/미확인)을 진행 중으로 오인시킴.
+  {
+    text: /^에스컬레이터 안내를 확인하고 있어요$/,
+    stateClass: 'static-label',
+    owner: '#1778',
+    disposition: 'reword',
+    note: 'requiresEscalator=참(사실) → 사실형',
+  },
+  {
+    text: /^상태를 확인하고 있어요$/,
+    stateClass: 'stale-unknown',
+    owner: '#1778',
+    disposition: 'reword',
+    note: '시설 상태 미확인 → 사실형',
+  },
+  {
+    text: /^확인 중$/,
+    fileRe: /facility_status\.dart$/,
+    stateClass: 'stale-unknown',
+    owner: '#1778',
+    disposition: 'reword',
+    note: '시설 상태 severity 미확인 → 사실형',
+  },
+  {
+    text: /^노선을 확인하고 있어요$/,
+    stateClass: 'no-data',
+    owner: '#1778',
+    disposition: 'reword',
+    note: '노선 목록 비어 있음(no-data) → 사실형',
+  },
+  {
+    text: /^엘리베이터 연결을 확인하고 있어요$/,
+    stateClass: 'stale-unknown',
+    owner: '#1778',
+    disposition: 'reword',
+    note: '엘리베이터 연결 미확인 → 사실형',
+  },
+  {
+    text: /^연결 위치를 확인하고 있어요$/,
+    stateClass: 'no-data',
+    owner: '#1778',
+    disposition: 'reword',
+    note: '연결 위치 정보 비어 있음 → 사실형',
+  },
+  {
+    text: /^역 이름을 확인하고 있어요$/,
+    stateClass: 'no-data',
+    owner: '#1778',
+    disposition: 'reword',
+    note: '역 이름 조회 실패 fallback → 사실형',
+  },
+  {
+    text: /^일부 도착정보를 확인하고 있어요$/,
+    stateClass: 'static-label',
+    owner: '#1778',
+    disposition: 'reword',
+    note: 'ETA 출처 MIXED(사실) → 사실형',
+  },
+  {
+    text: /^이동 부담을 확인하고 있어요$/,
+    stateClass: 'no-data',
+    owner: '#1778',
+    disposition: 'reword',
+    note: '차단/무경로로 이동 부담 없음 → 사실형',
+  },
+  {
+    text: /^시간 또는 거리를 확인하고 있어요$/,
+    stateClass: 'stale-unknown',
+    owner: '#1778',
+    disposition: 'reword',
+    note: '시간·거리 출처 UNKNOWN → 사실형',
+  },
+  {
+    text: /^시간을 확인하고 있어요$/,
+    stateClass: 'no-data',
+    owner: '#1778',
+    disposition: 'reword',
+    note: '소요 시간 값 없음 → 사실형',
+  },
+  {
+    text: /^거리를 확인하고 있어요$/,
+    stateClass: 'no-data',
+    owner: '#1778',
+    disposition: 'reword',
+    note: '거리 값 없음 → 사실형',
+  },
+
+  // 이미 사실형으로 정렬된 문구('미확인' 어휘)는 aligned로 남긴다.
+  {
+    text: /미확인/,
+    stateClass: 'stale-unknown',
+    owner: '#1778',
+    disposition: 'aligned',
+    note: '사실형 미확인 voice',
+  },
+
+  // 남은 진행 중/확인 중 라벨은 실제 진행 상태로 본다.
+  {
+    text: /확인 중/,
+    stateClass: 'loading',
+    owner: '#1778',
+    disposition: 'keep',
+    note: '진행 중 상태 라벨',
+  },
+];
+
+function listDartFiles(dir, acc) {
+  for (const entry of readdirSync(dir).sort()) {
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      listDartFiles(full, acc);
+    } else if (entry.endsWith('.dart')) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+// 한 줄에서 홑따옴표 문자열 리터럴을 추출한다. 이스케이프된 홑따옴표(\')는
+// 문자열 내부로 보고 이어 붙인다. 상태 라벨은 단순 리터럴이라 이 정도로 충분하다.
+function extractSingleQuoted(line) {
+  const out = [];
+  let i = 0;
+  while (i < line.length) {
+    if (line[i] !== "'") {
+      i += 1;
+      continue;
+    }
+    let j = i + 1;
+    let buf = '';
+    let closed = false;
+    while (j < line.length) {
+      const ch = line[j];
+      if (ch === '\\' && j + 1 < line.length) {
+        buf += line[j + 1];
+        j += 2;
+        continue;
+      }
+      if (ch === "'") {
+        closed = true;
+        break;
+      }
+      buf += ch;
+      j += 1;
+    }
+    if (!closed) {
+      break;
+    }
+    out.push(buf);
+    i = j + 1;
+  }
+  return out;
+}
+
+function classify(text, relFile, rawLine) {
+  for (const rule of RULES) {
+    if (rule.lineHas && !rawLine.includes(rule.lineHas)) {
+      continue;
+    }
+    if (rule.text && !rule.text.test(text)) {
+      continue;
+    }
+    if (rule.fileRe && !rule.fileRe.test(relFile)) {
+      continue;
+    }
+    return {
+      stateClass: rule.stateClass,
+      owner: rule.owner,
+      disposition: rule.disposition,
+      note: rule.note,
+    };
+  }
+  return {
+    stateClass: 'unclassified',
+    owner: 'none',
+    disposition: 'review',
+    note: '상태 신호 감지, 규칙 미매칭 — 사람 판단 필요',
+  };
+}
+
+export function buildInventory(root = DEFAULT_ROOT) {
+  const libDir = join(root, 'apps', 'mobile', 'lib');
+  const files = listDartFiles(libDir, []);
+  const entries = [];
+  for (const file of files) {
+    // NUL 바이트가 섞인 소스도 있어(route_search.dart) 제거 후 읽는다.
+    const content = readFileSync(file, 'utf8').replace(/\x00/g, '');
+    const relFile = relative(root, file).split(sep).join('/');
+    const lines = content.split('\n');
+    for (let idx = 0; idx < lines.length; idx += 1) {
+      const rawLine = lines[idx];
+      for (const text of extractSingleQuoted(rawLine)) {
+        if (!SIGNAL.test(text)) {
+          continue;
+        }
+        const verdict = classify(text, relFile, rawLine);
+        entries.push({ file: relFile, line: idx + 1, text, ...verdict });
+      }
+    }
+  }
+  entries.sort((a, b) =>
+    a.file === b.file
+      ? a.line === b.line
+        ? a.text.localeCompare(b.text)
+        : a.line - b.line
+      : a.file.localeCompare(b.file),
+  );
+  const byDisposition = {};
+  const byStateClass = {};
+  const byOwner = {};
+  for (const e of entries) {
+    byDisposition[e.disposition] = (byDisposition[e.disposition] ?? 0) + 1;
+    byStateClass[e.stateClass] = (byStateClass[e.stateClass] ?? 0) + 1;
+    byOwner[e.owner] = (byOwner[e.owner] ?? 0) + 1;
+  }
+  return {
+    schema: 'easysubway/mobile-status-voice-inventory@1',
+    producer: 'tools/mobile/status-voice-inventory.mjs',
+    ownerIssue: '#1778',
+    total: entries.length,
+    byDisposition,
+    byStateClass,
+    byOwner,
+    entries,
+  };
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  let root = DEFAULT_ROOT;
+  const rootIdx = argv.indexOf('--root');
+  if (rootIdx !== -1) {
+    root = argv[rootIdx + 1];
+  }
+  const report = buildInventory(root);
+  if (argv.includes('--summary')) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          total: report.total,
+          byDisposition: report.byDisposition,
+          byStateClass: report.byStateClass,
+          byOwner: report.byOwner,
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+    return;
+  }
+  const pretty = argv.includes('--pretty');
+  process.stdout.write(
+    JSON.stringify(report, null, pretty ? 2 : 0) + '\n',
+  );
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/tools/mobile/status-voice-inventory.mjs
+++ b/tools/mobile/status-voice-inventory.mjs
@@ -41,8 +41,26 @@ const DEFAULT_ROOT = join(HERE, '..', '..');
 // 상태 요약 voice 신호. 이 중 하나라도 포함한 리터럴만 인벤토리 후보다.
 const SIGNAL = /확인하고 있어요|확인 중|불러오는 중|조회 중|준비\s?중|미확인/;
 
-// 규칙 카탈로그. 위에서부터 첫 매칭이 이긴다. 각 규칙은 리터럴 text(정규식)와
-// 선택적으로 파일 경로 조건(fileRe)·원본 라인 포함 조건(lineHas)을 본다.
+// route_search.dart 등 일부 소스에 섞인 NUL 바이트 제거용. 정규식 리터럴에
+// 제어문자 코드포인트를 직접 담지 않도록 String.fromCharCode로 만든다.
+const NUL_CHARACTER = String.fromCharCode(0);
+
+// 실측을 거쳐 실제 loading으로 확인된 문구만 여기 명시적으로 나열한다. 새
+// '확인 중'류 문자열이 발견되면 이 목록에 없는 한 review로 떨어져야 한다
+// (CodeRabbit finding: 포괄 정규식은 drift 감시 계약을 깨뜨린다).
+const VERIFIED_LOADING_TEXTS = new Set([
+  '확인 중',
+  '제보 진행 상황 확인 중',
+  '즐겨찾기 확인 중',
+  '현재 위치 확인 중',
+  '실시간 정보 확인 중',
+  '알림 확인 중',
+  '신뢰도 확인 중',
+]);
+
+// 규칙 카탈로그. 위에서부터 첫 매칭이 이긴다. 각 규칙은 리터럴 text(정규식)·
+// 정확히 일치하는 문자열 집합(oneOf)과 선택적으로 파일 경로 조건(fileRe)·
+// 원본 라인 포함 조건(lineHas)을 본다.
 const RULES = [
   // 운영/진단 로그: context: 인자로 넘어가는 문자열은 사용자 비노출.
   {
@@ -219,13 +237,16 @@ const RULES = [
     note: '사실형 미확인 voice',
   },
 
-  // 남은 진행 중/확인 중 라벨은 실제 진행 상태로 본다.
+  // 검증된 실제 loading 문구만 명시적으로 열거한다(포괄 '확인 중' 정규식 금지).
+  // 이 allowlist에 없는 새 진행형/'확인 중' 계열 문자열은 아래 fallback을 타
+  // review로 떨어지므로, drift는 사람이 판단하기 전까지 자동 loading으로
+  // 확정되지 않는다.
   {
-    text: /확인 중/,
+    oneOf: VERIFIED_LOADING_TEXTS,
     stateClass: 'loading',
     owner: '#1778',
     disposition: 'keep',
-    note: '진행 중 상태 라벨',
+    note: '검증된 진행 중 상태 라벨(allowlist)',
   },
 ];
 
@@ -278,12 +299,27 @@ function extractSingleQuoted(line) {
   return out;
 }
 
+// entries 정렬 비교자. 중첩 삼항 대신 독립 조건문으로 file → line → text
+// 우선순위를 판정한다.
+function compareEntries(a, b) {
+  if (a.file !== b.file) {
+    return a.file.localeCompare(b.file);
+  }
+  if (a.line !== b.line) {
+    return a.line - b.line;
+  }
+  return a.text.localeCompare(b.text);
+}
+
 function classify(text, relFile, rawLine) {
   for (const rule of RULES) {
     if (rule.lineHas && !rawLine.includes(rule.lineHas)) {
       continue;
     }
     if (rule.text && !rule.text.test(text)) {
+      continue;
+    }
+    if (rule.oneOf && !rule.oneOf.has(text)) {
       continue;
     }
     if (rule.fileRe && !rule.fileRe.test(relFile)) {
@@ -309,8 +345,9 @@ export function buildInventory(root = DEFAULT_ROOT) {
   const files = listDartFiles(libDir, []);
   const entries = [];
   for (const file of files) {
-    // NUL 바이트가 섞인 소스도 있어(route_search.dart) 제거 후 읽는다.
-    const content = readFileSync(file, 'utf8').replace(/\x00/g, '');
+    // NUL 바이트가 섞인 소스도 있어(route_search.dart) 제거 후 읽는다. 정규식에
+    // 제어문자를 담지 않도록 String.fromCharCode로 문자를 만들어 전역 치환한다.
+    const content = readFileSync(file, 'utf8').replaceAll(NUL_CHARACTER, '');
     const relFile = relative(root, file).split(sep).join('/');
     const lines = content.split('\n');
     for (let idx = 0; idx < lines.length; idx += 1) {
@@ -324,13 +361,7 @@ export function buildInventory(root = DEFAULT_ROOT) {
       }
     }
   }
-  entries.sort((a, b) =>
-    a.file === b.file
-      ? a.line === b.line
-        ? a.text.localeCompare(b.text)
-        : a.line - b.line
-      : a.file.localeCompare(b.file),
-  );
+  entries.sort(compareEntries);
   const byDisposition = {};
   const byStateClass = {};
   const byOwner = {};

--- a/tools/mobile/status-voice-inventory.test.mjs
+++ b/tools/mobile/status-voice-inventory.test.mjs
@@ -1,0 +1,144 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+import { buildInventory } from './status-voice-inventory.mjs';
+
+const REPO_ROOT = join(fileURLToPath(new URL('.', import.meta.url)), '..', '..');
+
+function withFixture(dartByFile, run) {
+  const root = mkdtempSync(join(tmpdir(), 'status-voice-'));
+  try {
+    const libDir = join(root, 'apps', 'mobile', 'lib');
+    for (const [rel, content] of Object.entries(dartByFile)) {
+      const full = join(libDir, rel);
+      mkdirSync(join(full, '..'), { recursive: true });
+      writeFileSync(full, content, 'utf8');
+    }
+    return run(buildInventory(root));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function entryFor(report, text) {
+  return report.entries.find((e) => e.text === text);
+}
+
+test('진행형 시설 상태는 reword/stale-unknown으로 분류한다', () => {
+  withFixture(
+    { 'facility_status.dart': "const x = '상태를 확인하고 있어요';\n" },
+    (report) => {
+      const e = entryFor(report, '상태를 확인하고 있어요');
+      assert.equal(e.disposition, 'reword');
+      assert.equal(e.stateClass, 'stale-unknown');
+      assert.equal(e.owner, '#1778');
+    },
+  );
+});
+
+test('facility_status의 확인 중 severity는 reword, 그 외 확인 중은 keep', () => {
+  withFixture(
+    {
+      'facility_status.dart': "const s = '확인 중';\n",
+      'notification_settings.dart': "final t = isBusy ? '확인 중' : 'x';\n",
+    },
+    (report) => {
+      const facility = report.entries.find(
+        (e) => e.file.endsWith('facility_status.dart') && e.text === '확인 중',
+      );
+      const other = report.entries.find(
+        (e) =>
+          e.file.endsWith('notification_settings.dart') && e.text === '확인 중',
+      );
+      assert.equal(facility.disposition, 'reword');
+      assert.equal(other.disposition, 'keep');
+      assert.equal(other.stateClass, 'loading');
+    },
+  );
+});
+
+test("'준비 중'은 #2078 out-of-scope로 소유권만 표시한다", () => {
+  withFixture(
+    { 'route_search.dart': "const p = '실시간 도착정보 준비 중';\n" },
+    (report) => {
+      const e = entryFor(report, '실시간 도착정보 준비 중');
+      assert.equal(e.owner, '#2078');
+      assert.equal(e.disposition, 'out-of-scope');
+      assert.equal(e.stateClass, 'coming-soon');
+    },
+  );
+});
+
+test('context: 진단 로그는 사용자 비노출 out-of-scope로 분류한다', () => {
+  withFixture(
+    {
+      'network_map.dart':
+        "reporter.log(context: 'manifest를 불러오는 중 예외가 발생했습니다.');\n",
+    },
+    (report) => {
+      const e = report.entries.find((x) => x.text.includes('불러오는 중'));
+      assert.equal(e.stateClass, 'diagnostic');
+      assert.equal(e.disposition, 'out-of-scope');
+      assert.equal(e.owner, 'none');
+    },
+  );
+});
+
+test("사용자 노출 '불러오는 중' 라벨은 loading keep", () => {
+  withFixture(
+    { 'app.dart': "const label = '쉬운 지하철을 불러오는 중';\n" },
+    (report) => {
+      const e = entryFor(report, '쉬운 지하철을 불러오는 중');
+      assert.equal(e.stateClass, 'loading');
+      assert.equal(e.disposition, 'keep');
+    },
+  );
+});
+
+test('헤지 사전 공용 문구는 uncertainty-hedge keep', () => {
+  withFixture(
+    {
+      'route_hedge_labels.dart':
+        "const h = '엘리베이터·통로 상태를 확인하고 있어요.';\n",
+    },
+    (report) => {
+      const e = entryFor(report, '엘리베이터·통로 상태를 확인하고 있어요.');
+      assert.equal(e.stateClass, 'uncertainty-hedge');
+      assert.equal(e.disposition, 'keep');
+    },
+  );
+});
+
+test('사실형 미확인 문구는 aligned로 분류한다', () => {
+  withFixture(
+    { 'facility_status.dart': "const a = '상태 미확인';\n" },
+    (report) => {
+      const e = entryFor(report, '상태 미확인');
+      assert.equal(e.disposition, 'aligned');
+      assert.equal(e.stateClass, 'stale-unknown');
+    },
+  );
+});
+
+test('같은 tree에서 재실행하면 결정적으로 동일한 report를 낸다', () => {
+  const a = buildInventory(REPO_ROOT);
+  const b = buildInventory(REPO_ROOT);
+  assert.deepEqual(a, b);
+});
+
+test('현재 tree에는 분류 불가(unclassified/review) 항목이 없다', () => {
+  const report = buildInventory(REPO_ROOT);
+  const stray = report.entries.filter(
+    (e) => e.stateClass === 'unclassified' || e.disposition === 'review',
+  );
+  assert.deepEqual(
+    stray,
+    [],
+    `미분류 상태 문자열이 있습니다: ${JSON.stringify(stray)}`,
+  );
+  assert.ok(report.total > 0);
+});

--- a/tools/mobile/status-voice-inventory.test.mjs
+++ b/tools/mobile/status-voice-inventory.test.mjs
@@ -61,6 +61,53 @@ test('facility_status의 확인 중 severity는 reword, 그 외 확인 중은 ke
   );
 });
 
+test('allowlist에 있는 검증된 loading 문구는 여전히 keep/loading이다', () => {
+  const verifiedTexts = [
+    '확인 중',
+    '제보 진행 상황 확인 중',
+    '즐겨찾기 확인 중',
+    '현재 위치 확인 중',
+    '실시간 정보 확인 중',
+    '알림 확인 중',
+    '신뢰도 확인 중',
+  ];
+  const files = Object.fromEntries(
+    verifiedTexts.map((text, i) => [
+      `allowlist_${i}.dart`,
+      `const x = '${text}';\n`,
+    ]),
+  );
+  withFixture(files, (report) => {
+    for (const text of verifiedTexts) {
+      const e = entryFor(report, text);
+      assert.equal(e.stateClass, 'loading', `${text} stateClass`);
+      assert.equal(e.disposition, 'keep', `${text} disposition`);
+    }
+  });
+});
+
+test('allowlist에 없는 새 진행형/확인 중 문구는 review로 떨어진다(drift 회귀)', () => {
+  withFixture(
+    { 'new_screen.dart': "const label = '새 기능 확인 중';\n" },
+    (report) => {
+      const e = entryFor(report, '새 기능 확인 중');
+      assert.equal(e.stateClass, 'unclassified');
+      assert.equal(e.disposition, 'review');
+    },
+  );
+});
+
+test('allowlist에 없는 새 확인하고 있어요 계열도 review로 떨어진다(drift 회귀)', () => {
+  withFixture(
+    { 'new_screen.dart': "const label = '새 항목을 확인하고 있어요';\n" },
+    (report) => {
+      const e = entryFor(report, '새 항목을 확인하고 있어요');
+      assert.equal(e.stateClass, 'unclassified');
+      assert.equal(e.disposition, 'review');
+    },
+  );
+});
+
 test("'준비 중'은 #2078 out-of-scope로 소유권만 표시한다", () => {
   withFixture(
     { 'route_search.dart': "const p = '실시간 도착정보 준비 중';\n" },


### PR DESCRIPTION
## 관련 이슈

Closes #1778

## 작업 배경

- 헤지 사전(#1577)이 불확실성 문구를 한 벌로 통일한 뒤에도, 사전 밖에는 진행 중이 아닌 상태(데이터 없음·미확인·확정 사실)를 부드러운 진행형("…확인하고 있어요")으로 표현하는 상태 요약 라벨이 여러 화면에 흩어져 있었습니다.
- 진행형은 실제 loading에만 맞는 voice라, 미확인/데이터 없음 상태를 "지원됨" 또는 "진행 중"으로 오인시켜 안내 신뢰를 떨어뜨립니다.
- 사용자 노출 상태 요약 문자열 inventory를 이 이슈가 단일 producer로 소유하도록 하고, 그 위에서 사전 밖 factual voice를 정렬합니다.

## 작업 내용

- 사용자 노출 상태 요약 문자열을 현재 tree에서 재생성해 상태 분류·소유 이슈·disposition을 담은 machine-readable JSON report를 결정적으로 만드는 producer(`tools/mobile/status-voice-inventory.mjs`)와 `node --test` 회귀를 추가했습니다. 다른 카피 이슈(`#2078`의 `준비 중`·빈 상태 등)는 소유권만 표시하고 이 report를 소비합니다.
- 시설 상태 미확인(needsInfo·`UNKNOWN`) severity·title, 즐겨찾기/검색 시설 상태 라벨을 `미확인` 어휘로 정렬했습니다. 이미 쓰이던 `설치 확인 · 운행상태 미확인`과 같은 voice로 수렴시켜 새 placeholder를 만들지 않습니다.
- 노선/연결 위치/역 이름 조회 빈 값 fallback, 엘리베이터 연결 미확인, 경로 ETA 출처(`MIXED`·`UNKNOWN`)·소요 시간/거리 미산정, 이동 부담 미산정을 사실형으로 정렬했습니다.
- 확정 사실인 `requiresEscalator`는 엘리베이터(`엘리베이터를 이용해요`)와 대칭인 사실형(`에스컬레이터를 이용해요`)으로 바꿨습니다.
- `route_engine`의 `DURATION_UNKNOWN` 중복 리터럴을 헤지 사전 공용 상수(`routeDurationUnknown`)로 재사용해 화면별 중복을 제거했습니다.
- 실제 새로고침·로딩 진행형, catalog 헤지 문구, `준비 중`(#2078 소유)은 그대로 두어 실제 loading만 진행형을 쓰도록 경계를 지켰습니다.

## 검증

- 실행한 명령과 결과:
  - `dart format --output=none --set-exit-if-changed lib test` → 272 files, 0 changed
  - `flutter analyze` → No issues found
  - `flutter test -r compact` → 1,464 passed
  - `flutter test -r compact test/route_search_test.dart test/station_search_test.dart test/favorite_facility_test.dart test/features/routes/local_route_repository_test.dart test/features/internal_route/local_internal_route_repository_test.dart` → 230 passed
  - `flutter test -r compact test/features/network_map/presentation/s0_spike_route_map_golden_test.dart` → 2 passed
  - `node --test tools/mobile/status-voice-inventory.test.mjs` → 9 passed
  - `node --test tools/ci/repository-contract.test.mjs` → 216 passed, 1 실패(`Android v1 production 데이터팩 scope`) — 본 변경(apps/mobile·tools/mobile)과 무관한 기존 datapack scope hash 불일치로, 해당 변경을 stash하고 재실행해도 동일하게 실패함을 확인
  - inventory producer 전/후: `reword` 21 + `reuse-catalog` 1 → `reword`/`reuse-catalog` 0, `aligned` 3 → 22, `unclassified`/`review` 0 유지

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| inventory report 재현성·drift 0 | Node test | producer 2회 결과 동일 + 현재 tree `unclassified`/`review` 0 | `node --test tools/mobile/status-voice-inventory.test.mjs` | 9 passed |
| report 전/후 disposition diff | Node | 변경 전후 producer 실행 후 diff | `scratchpad/inventory-before.json` → `inventory-after.json` (로컬) | `reword` 21+`reuse-catalog` 1 → 0, `aligned` 3 → 22 |
| catalog unit | Flutter test | 헤지 사전 문구 회귀(공용 상수 재사용 포함) | `test/route_hedge_labels_test.dart` | 통과 (`flutter test -r compact` 포함) |
| widget golden(노선도) | Flutter test | 라벨 정렬 후 s0_spike golden 무회귀 | `test/features/network_map/presentation/s0_spike_route_map_golden_test.dart` | 2 passed |
| Semantics 라벨 | Flutter test | 시설/경로 semanticLabel·시설 요약 semantic 회귀 | `test/route_search_test.dart`, `test/station_search_test.dart`, `test/widget_test.dart` | 통과 |
| 320dp·390dp·text scale 회귀 | Flutter test | 좁은 폭·큰 글자에서 미확인/미산정 라벨 오버플로 없음(사실형이 진행형보다 짧음) | `flutter test -r compact` 내 responsive/semantic 시나리오 | 1,464 passed |
| UI 실기기 수동 QA | 해당 없음 | 화면 구조·상용 claim 변경 없이 라벨 문구만 정렬 | golden·Semantics 회귀로 대체 | 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음 (표시 문구만 정렬, 계약·gate JSON 무변경)
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: producer의 규칙 카탈로그(`tools/mobile/status-voice-inventory.mjs`)가 각 문자열을 loading/no-data/stale-unknown/static-label/헤지/`준비 중`(#2078)로 어떻게 분기하는지와, 사전 밖 정렬 대상(`disposition: reword`)이 모두 `미확인`/사실형 또는 공용 상수 재사용으로 수렴하는지 먼저 봐 주세요.
- 실제 loading 진행형(`불러오는 중`·새로고침), catalog 헤지, `경로 상태를 확인하고 있어요`(REVIEW/UNKNOWN 불확실성), `계단 여부를 확인하고 있어요`(계단 상태 불확실성)는 의도적으로 유지했습니다.

## 리스크

- 상태 요약 라벨 문구만 정렬하므로 계약·gate·마이그레이션·배포 영향은 없습니다. 잔여 리스크는 화면별 문맥에서 `미확인`/사실형 문구의 자연스러움 정도이며, golden·Semantics·전체 test와 사용자 카피 금칙어 guard로 회귀를 고정했습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 시설, 역, 노선 및 이동 정보의 미확인 상태를 “확인 중” 대신 “미확인”으로 명확하게 표시합니다.
  * 경로 안내에서 시간·거리·노선·이동 부담 정보를 더 일관된 표현으로 제공합니다.
  * 일부 실시간 도착정보 및 에스컬레이터 이용 안내 문구를 개선했습니다.
  * 역 이름, 연결 위치, 엘리베이터 연결 정보가 없을 때의 안내 문구를 명확히 했습니다.

* **테스트**
  * 변경된 상태 및 경로 안내 문구에 대한 검증을 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->