### PR TITLE
[Fix] capacity-evidence 세션 verdict timestamp 순서 버그 수정, 진단 강화 (Refs #2095)

### DIFF
--- a/backend/src/main/java/com/easysubway/route/adapter/out/integrity/CapacityEvidencePlayIntegrityDecoder.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/integrity/CapacityEvidencePlayIntegrityDecoder.java
@@ -4,6 +4,7 @@ import com.easysubway.route.application.port.out.PlayIntegrityDecoder;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.time.Clock;
+import java.time.Duration;
 import java.util.Base64;
 import java.util.HexFormat;
 import java.util.List;
@@ -21,6 +22,16 @@ final class CapacityEvidencePlayIntegrityDecoder implements PlayIntegrityDecoder
 	private static final String PACKAGE_NAME = "com.easysubway.app";
 	private static final Base64.Encoder BASE64_URL = Base64.getUrlEncoder().withoutPadding();
 	private static final Base64.Decoder BASE64_URL_DECODER = Base64.getUrlDecoder();
+	// A genuine Play Integrity verdict's timestamp always precedes the caller's own
+	// "now" snapshot (Google verifies the token before it ever reaches us). This
+	// synthetic decoder must preserve that invariant: RouteV2SessionService.issue()
+	// captures its own `now` BEFORE calling decoder.decode(), so if decode() stamps
+	// the verdict with the current instant, that timestamp is always strictly AFTER
+	// the caller's `now` (real time only moves forward) and
+	// validateVerdict()'s `verdict.requestTimestamp().isAfter(now)` freshness check
+	// rejects every single session — 100% reproducible, unrelated to attestation
+	// crypto. Backdating by a small safety margin restores the natural ordering.
+	private static final Duration TIMESTAMP_SAFETY_MARGIN = Duration.ofMillis(100);
 
 	private final byte[] attestationKey;
 	private final String certificateDigest;
@@ -54,7 +65,7 @@ final class CapacityEvidencePlayIntegrityDecoder implements PlayIntegrityDecoder
 			return new PlayIntegrityVerdict(
 				PACKAGE_NAME,
 				requestHash(parts[0]),
-				clock.instant(),
+				clock.instant().minus(TIMESTAMP_SAFETY_MARGIN),
 				PACKAGE_NAME,
 				"PLAY_RECOGNIZED",
 				List.of(certificateDigest),

--- a/backend/src/main/java/com/easysubway/route/adapter/out/integrity/CapacityEvidencePlayIntegrityDecoder.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/integrity/CapacityEvidencePlayIntegrityDecoder.java
@@ -31,7 +31,7 @@ final class CapacityEvidencePlayIntegrityDecoder implements PlayIntegrityDecoder
 	// validateVerdict()'s `verdict.requestTimestamp().isAfter(now)` freshness check
 	// rejects every single session — 100% reproducible, unrelated to attestation
 	// crypto. Backdating by a small safety margin restores the natural ordering.
-	private static final Duration TIMESTAMP_SAFETY_MARGIN = Duration.ofMillis(100);
+	static final Duration TIMESTAMP_SAFETY_MARGIN = Duration.ofMillis(100);
 
 	private final byte[] attestationKey;
 	private final String certificateDigest;

--- a/backend/src/test/java/com/easysubway/route/adapter/out/integrity/CapacityEvidencePlayIntegrityDecoderTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/out/integrity/CapacityEvidencePlayIntegrityDecoderTest.java
@@ -33,4 +33,31 @@ class CapacityEvidencePlayIntegrityDecoderTest {
 		assertThat(decoder.decode(nonce + "." + signature).appRecognitionVerdict()).isEqualTo("PLAY_RECOGNIZED");
 		assertThat(decoder.decode(nonce + ".invalid").requestPackageName()).isNull();
 	}
+
+	@Test
+	@DisplayName("verdict의 requestTimestamp는 caller now보다 TIMESTAMP_SAFETY_MARGIN만큼 과거다")
+	void verdictTimestampIsBackdatedBySafetyMargin() throws Exception {
+		// RouteV2SessionService.issue()는 decoder.decode() 호출 전에 자신의 now를
+		// 캡처한다. verdict의 requestTimestamp가 그 now보다 뒤처지면(과거가 아니면)
+		// isAfter(now)가 참이 되어 매 세션이 무조건 거부된다(#2095 run 29639318566).
+		// 이 테스트는 그 불변식을 fixed Clock으로 정확히 고정한다 — margin이 0으로
+		// 되돌아가거나 .plus로 뒤집혀도 여기서 즉시 실패해야 한다.
+		String key = "cd".repeat(32);
+		String nonce = "BBBBBBBBBBBBBBBBBBBBBB";
+		Mac mac = Mac.getInstance("HmacSHA256");
+		mac.init(new SecretKeySpec(java.util.HexFormat.of().parseHex(key), "HmacSHA256"));
+		String signature = Base64.getUrlEncoder().withoutPadding()
+			.encodeToString(mac.doFinal(nonce.getBytes(StandardCharsets.UTF_8)));
+		Instant fixedNow = Instant.parse("2026-07-17T03:00:00Z");
+		var decoder = new CapacityEvidencePlayIntegrityDecoder(
+			key,
+			"B".repeat(43),
+			Clock.fixed(fixedNow, ZoneOffset.UTC)
+		);
+
+		Instant requestTimestamp = decoder.decode(nonce + "." + signature).requestTimestamp();
+
+		assertThat(requestTimestamp).isEqualTo(fixedNow.minus(CapacityEvidencePlayIntegrityDecoder.TIMESTAMP_SAFETY_MARGIN));
+		assertThat(requestTimestamp.isAfter(fixedNow)).isFalse();
+	}
 }

--- a/tools/ci/production-route-v2-capacity-evidence-workflow.test.mjs
+++ b/tools/ci/production-route-v2-capacity-evidence-workflow.test.mjs
@@ -206,6 +206,16 @@ test("capacity runner는 동일 candidate·격리 load·privacy·closed ingress�
   // with "No default constructor found" and the isolated backend never
   // becomes ready — see #2095 run 29625986367.
   assert.match(capacityDecoder, /@Autowired\s+CapacityEvidencePlayIntegrityDecoder\(/);
+  // RouteV2SessionService.issue() captures its own `now` BEFORE calling
+  // decoder.decode(). If the synthetic verdict is stamped with the current
+  // instant (as opposed to a real Play Integrity verdict, which is always
+  // already in the past by the time it reaches us), that timestamp is always
+  // strictly after the caller's `now` — real time only moves forward — and
+  // validateVerdict()'s freshness check (`requestTimestamp().isAfter(now)`)
+  // rejects every single session unconditionally. This is unrelated to
+  // attestation crypto and was 100% reproducible — see #2095 run 29639318566.
+  assert.match(capacityDecoder, /TIMESTAMP_SAFETY_MARGIN/);
+  assert.match(capacityDecoder, /clock\.instant\(\)\.minus\(TIMESTAMP_SAFETY_MARGIN\)/);
   assert.match(runner, /dump_readiness_diagnostics\(\) \{/);
   assert.match(runner, /docker logs --tail 40 "\$\{container\}"/);
   assert.match(
@@ -216,6 +226,17 @@ test("capacity runner는 동일 candidate·격리 load·privacy·closed ingress�
   assert.match(runner, /dump_readiness_diagnostics "\$\{clone_curl\}"/);
   assert.match(runner, /dump_readiness_diagnostics "\$\{clone_backend\}"/);
   assert.match(runner, /dump_readiness_diagnostics "\$\{clone_gateway\}"/);
+  // On an unexpected status code during load profiles, dump the actual
+  // response status/headers/body instead of only "did not return exact NNN" —
+  // this is what made the timestamp-ordering bug above tractable to diagnose.
+  assert.match(runner, /dump_request_diagnostics\(\) \{/);
+  assert.equal((runner.match(/dump_request_diagnostics "\$\{last_headers\}" "\$\{last_body\}"/g) ?? []).length, 6);
+  assert.match(runner, /burst_body_files=\(\)/);
+  assert.match(runner, /burst_body_files\+=\("\$\{burst_body\}"\)/);
+  assert.match(
+    runner,
+    /dump_request_diagnostics "\$\{burst_headers_files\[\$\{index\}\]\}" "\$\{burst_body_files\[\$\{index\}\]\}"/,
+  );
   assert.match(runner, /timetable snapshot identity is invalid/);
   assert.match(runner, /normal_state_count_before/);
   assert.match(runner, /normal_state_count_after/);

--- a/tools/ops/verify-production-route-v2-capacity.sh
+++ b/tools/ops/verify-production-route-v2-capacity.sh
@@ -606,6 +606,24 @@ if (identity?.timetableSnapshotSha256 !== expected.timetableSnapshotSha256
 	return 1
 }
 
+# On an unexpected status code, dump the actual response status/headers/body to
+# make the failure self-diagnosing instead of just "did not return exact NNN".
+# Request headers we send (Authorization, CF-Connecting-IP) never appear in the
+# -D output (that only captures response headers), but filter them anyway as a
+# defensive measure since this dumps to CI-visible stderr.
+dump_request_diagnostics() {
+	local headers_file="${1:?headers file is required}"
+	local body_file="${2:?body file is required}"
+	echo "--- request diagnostics: status=${last_status} ---" >&2
+	if [[ -f "${headers_file}" ]]; then
+		grep -iEv 'authorization:|cf-connecting-ip:' "${headers_file}" >&2 || true
+	fi
+	if [[ -f "${body_file}" ]]; then
+		head -c 2000 "${body_file}" >&2 || true
+		echo >&2
+	fi
+}
+
 sample_resources() {
 	local backend_resource gateway_resource sampled_at_ms
 	backend_resource="$(docker stats --no-stream --format '{{.MemPerc}} {{.CPUPerc}}' "${clone_backend}")"
@@ -636,16 +654,19 @@ sample_resources
 unexpected_error_count=0
 for ((index = 0; index < session_rate; index += 1)); do
 	send_session normal "198.51.100.$((index + 101))"
-	[[ "${last_status}" == 200 ]] || { echo 'normal session profile did not return exact 200' >&2; exit 1; }
+	[[ "${last_status}" == 200 ]] \
+		|| { dump_request_diagnostics "${last_headers}" "${last_body}"; echo 'normal session profile did not return exact 200' >&2; exit 1; }
 	capture_issued_session
 done
 for ((index = 0; index <= session_burst; index += 1)); do
 	send_session burst 198.51.100.180
-	[[ "${last_status}" == 200 ]] || { echo 'session limiter rejected before the configured burst was consumed' >&2; exit 1; }
+	[[ "${last_status}" == 200 ]] \
+		|| { dump_request_diagnostics "${last_headers}" "${last_body}"; echo 'session limiter rejected before the configured burst was consumed' >&2; exit 1; }
 	capture_issued_session
 done
 send_session burst 198.51.100.180
-[[ "${last_status}" == 429 ]] || { echo 'session burst profile did not return exact 429' >&2; exit 1; }
+[[ "${last_status}" == 429 ]] \
+	|| { dump_request_diagnostics "${last_headers}" "${last_body}"; echo 'session burst profile did not return exact 429' >&2; exit 1; }
 grep -Eqi '^Retry-After: [1-9][0-9]*' "${last_headers}" || { echo 'session 429 is missing integer Retry-After' >&2; exit 1; }
 
 mapfile -t tokens < <(cut -f 1 "${issued_tokens_file}")
@@ -660,7 +681,8 @@ WHERE origin_station_id = '${origin_station_id}'
 [[ "${normal_state_count_before}" =~ ^[0-9]+$ ]] || { echo 'normal state baseline is invalid' >&2; exit 1; }
 for ((index = 0; index < search_rate; index += 1)); do
 	send_search normal "${tokens[$((index % session_rate))]}" "198.51.100.$((index + 1))"
-	[[ "${last_status}" == 200 ]] || { echo 'normal search profile did not return exact 200' >&2; exit 1; }
+	[[ "${last_status}" == 200 ]] \
+		|| { dump_request_diagnostics "${last_headers}" "${last_body}"; echo 'normal search profile did not return exact 200' >&2; exit 1; }
 	validate_normal_search_body "${last_body}" || exit 1
 done
 normal_state_count_after="$(clone_psql "SELECT COUNT(*) FROM route_v2_states
@@ -676,6 +698,7 @@ WHERE origin_station_id = '${origin_station_id}'
 burst_token="${seeded_tokens[0]}"
 burst_pids=()
 burst_headers_files=()
+burst_body_files=()
 burst_result_files=()
 for ((index = 0; index <= search_burst; index += 1)); do
 	request_index=$((request_index + 1))
@@ -691,6 +714,7 @@ for ((index = 0; index <= search_burst; index += 1)); do
 	) &
 	burst_pids+=("$!")
 	burst_headers_files+=("${burst_headers}")
+	burst_body_files+=("${burst_body}")
 	burst_result_files+=("${burst_result}")
 done
 for index in "${!burst_pids[@]}"; do
@@ -707,10 +731,11 @@ for index in "${!burst_pids[@]}"; do
 	grep -Eqi '^Cache-Control:[[:space:]]*private,[[:space:]]*no-store[[:space:]]*\r?$' "${burst_headers_files[${index}]}" \
 		|| { echo 'concurrent Route V2 response is missing Cache-Control: private, no-store' >&2; exit 1; }
 	[[ "${last_status}" == 200 ]] \
-		|| { echo 'search burst profile did not return exact 200 before rate limiting' >&2; exit 1; }
+		|| { dump_request_diagnostics "${burst_headers_files[${index}]}" "${burst_body_files[${index}]}"; echo 'search burst profile did not return exact 200 before rate limiting' >&2; exit 1; }
 done
 send_search burst "${burst_token}" 198.51.100.200
-[[ "${last_status}" == 429 ]] || { echo 'burst profile did not return exact 429' >&2; exit 1; }
+[[ "${last_status}" == 429 ]] \
+	|| { dump_request_diagnostics "${last_headers}" "${last_body}"; echo 'burst profile did not return exact 429' >&2; exit 1; }
 grep -Eqi '^Retry-After: [1-9][0-9]*' "${last_headers}" || { echo '429 response is missing integer Retry-After' >&2; exit 1; }
 node -e '
 const value = JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8"));
@@ -719,7 +744,8 @@ if (value.code !== "ROUTE_RATE_LIMITED") process.exit(1);
 
 clone_psql "UPDATE timetable_snapshot_history SET fresh_until = TO_CHAR((CURRENT_TIMESTAMP - INTERVAL '1 second') AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') WHERE snapshot_sha256 = (SELECT snapshot_sha256 FROM timetable_snapshot_active WHERE singleton_id = 1);" >/dev/null
 send_search unavailable "${seeded_tokens[1]}" 198.51.100.210
-[[ "${last_status}" == 503 ]] || { echo 'unavailable profile did not return exact 503' >&2; exit 1; }
+[[ "${last_status}" == 503 ]] \
+	|| { dump_request_diagnostics "${last_headers}" "${last_body}"; echo 'unavailable profile did not return exact 503' >&2; exit 1; }
 node -e '
 const value = JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8"));
 if (value.code !== "ITX_TIMETABLE_UNAVAILABLE") process.exit(1);


### PR DESCRIPTION
## 관련 이슈

Refs AquilaXk/easysubway-backend#3

## 작업 배경

[#2266](https://github.com/AquilaXk/easysubway/pull/2266)(curl-write 격리망 수정)이
유효해, run 29639318566(deploy_sha=`2a804451`)에서 backend readiness·격리망 접근을
통과하고 **처음으로 실제 load profile(session 발급) 단계에 진입**했으나
`normal session profile did not return exact 200`으로 실패했다.

이 capacity evidence workflow(#2239)는 정적 테스트만으로 병합돼 production에서 한
번도 완주한 적이 없어, 매 실행마다 새 결함이 드러나는 상황이었다(Spring DI → 격리
network → curl-write → 이번 session 응답). CD/capacity 왕복(각 ~20분)을 매 결함마다
반복하는 대신, **production self-hosted runner(oci-a1-staging)에서 스크립트를 직접
반복 실행**하며 디버깅했다. 운영 컨테이너/DB/shared 상태는 전혀 건드리지 않았다 —
`pg_dump` 읽기와 격리 network 안의 임시 `clone_*` 컨테이너 생성·정리만 반복했다.

## self-contained 여부 확인

스크립트가 필요로 하는 외부 입력은 `DEPLOY_ROOT`(운영 설정 파일 경로)와
`EXPECTED_DEPLOYED_SHA`뿐이다. session/search 요청에 쓰이는 synthetic
token·nonce·secret은 스크립트 자신이 `node crypto`로 생성해 격리 backend env에
주입하므로, 워크플로가 별도로 주입하는 GitHub Secret은 없다. **self-contained
실행이 가능했다** — `DEPLOY_ROOT=/opt/easysubway`, `EXPECTED_DEPLOYED_SHA=<현재
배포 SHA>`, `RUNNER_TEMP`를 지정하고 GH Actions runner의 node 24 toolcache를
PATH에 추가해 runner에서 직접 `bash tools/ops/verify-production-route-v2-capacity.sh`를
실행했다.

## 발견·수정한 결함

### 세션 발급 verdict timestamp 순서 버그 — 수정함

새로 추가한 `dump_request_diagnostics`(이번 PR)로 실제 응답을 확인하니
`403 ROUTE_SESSION_ATTESTATION_REJECTED`였다. HMAC·nonce·certificate digest를
Java-Java, Node-Java 교차 검증(스크래치 JUnit 테스트)으로 바이트 단위까지
확인했지만 모두 일치했다. production runner에서 **라이브 backend의 실제
attestation key로 직접 재구성한 프로브 요청**도 게이트웨이를 통과해 보내면
동일하게 거부됨을 확인해, "스크립트의 `synthetic_secret` 값이 backend가 읽은
값과 다르다"는 가설도 배제했다.

근본 원인은 크립토가 아니라 **순서**였다: `RouteV2SessionService.issue()`는
`decoder.decode()`를 호출하기 *전에* 자신의 `now`를 캡처하는데,
`CapacityEvidencePlayIntegrityDecoder.decode()`는 verdict 생성 시
`clock.instant()`(호출 시점의 현재 시각)를 그대로 찍는다. 실제 Play Integrity
verdict는 Google이 미리 검증한 뒤 우리에게 도달하므로 항상 과거 시각이지만, 이
synthetic decoder는 서비스의 `now` 캡처보다 반드시 *나중에* 시각을 찍는다 — 시간은
앞으로만 흐르므로 `verdict.requestTimestamp().isAfter(now)`가 사실상 항상 참이
되고, `validateVerdict()`의 freshness 검증이 **매 요청마다 무조건 실패**한다.
crypto와 무관하게 100% 재현되는 순서 버그였다.

**수정**: `CapacityEvidencePlayIntegrityDecoder`가 verdict timestamp를
`clock.instant().minus(TIMESTAMP_SAFETY_MARGIN)`(100ms 여유)로 살짝 과거로 찍도록
했다 — 실제 Play Integrity verdict가 자연스럽게 "now"보다 앞서는 것과 동일한
불변식을 복원한다.

**검증**: 로컬 JUnit 스크래치 테스트로 `isAfter(now)=false`를 먼저 확인한 뒤,
production runner에서 (같은 아키텍처=arm64) 로컬 빌드 이미지로 재검증 — 격리 스택
안에서 session 발급이 통과하고 다음 단계(search)로 진행됨을 확인했다.

**로컬 이미지 검증 방법**: production runner에 직접 배포하지 않고, 로컬(mac,
arm64=runner와 동일 아키텍처)에서 수정된 소스로 이미지를 빌드해 `docker save | ssh
... docker load`로 전송한 뒤, 실제 운영 배포 이미지의 digest/revision 검증 로직만
우회하는 **디버그 전용 스크립트 사본**으로 테스트했다(운영 backend 컨테이너 자체는
전혀 건드리지 않고 새 격리 `clone_*` 컨테이너만 사용). 이 우회는 오직 반복 디버깅
속도를 위한 것으로, 커밋되는 실제 스크립트에는 전혀 반영하지 않았다.

### 진단 강화

`dump_readiness_diagnostics`(#2255에서 도입)와 같은 패턴으로
`dump_request_diagnostics()`를 추가해, load profile 단계의 "did not return exact
NNN" 실패 6곳(session normal/burst/429, search normal/burst-200/429/unavailable)에서
실제 상태코드·응답 헤더·바디를 stderr에 남기도록 했다. 이번 조사에서 이 진단이
없었다면 원인을 특정하지 못했을 것이다.

## 미해결 — 다음 결함 (범위 밖, 오너 판단 필요)

session 수정 후 search 단계에서 **새 실패**가 나타났다: `422 ROUTE_SCOPE_INVALID`.
서버 로그(디버그 빌드로 임시 확인, 최종 커밋에는 그 임시 로깅이 없음):
`StationNotFoundException: 역 정보를 찾을 수 없습니다.`

원인을 끝까지 추적한 결과: `RouteSearchService.validateRouteSearch()`가 호출하는
`loadActiveStation()`은 `LoadTransitMasterPort.loadStations()`를 쓰는데, `prod`
프로필에서 활성화되는 구현체(`JdbcTransitMasterOverrideRepository extends
UnavailableTransitMasterRepository`)는 `loadStations()`를 오버라이드하지 않고
부모의 `seedRepository.loadStations()`(`new InMemoryTransitMasterRepository()`)를
그대로 상속한다. 이 in-memory seed는 코드 주석 그대로 **"ponytail: reuse the
existing static seed until a real data-pack adapter exists"**이며, 실제로
`station-sangnoksu`/`station-sadang` **단 2개** 역만 들어 있다. DB 마이그레이션에도
별도 `stations` 마스터 테이블이 없다 —
`tools/datapack/sources/korail-itx-cheongchun-station-sequence-*.json`,
`tools/route-map/major-stations.json` 등 실제 역 데이터 소스는 저장소에 있지만
런타임 station loader에 연결돼 있지 않다.

즉 **capacity-evidence가 사용하는 ITX-청춘 역 쌍뿐 아니라, 이 2개 역을 제외한 모든
역에 대한 `/api/v2/routes/search` 요청이 production에서도 동일하게 실패한다** —
capacity-evidence만의 문제가 아니라 Route V2 전체의 사전 출시 차단 요인이다(현재
`EASYSUBWAY_ROUTE_V2_INGRESS_ENABLED=false`로 공개 ingress가 닫혀 있어 아직
실사용자 영향은 없음 — 이 evidence gate가 정확히 이런 문제를 출시 전에 잡아내려는
목적과 일치한다).

"real data-pack adapter"를 구현하는 것은 실제 역 이름·좌표·접근성 데이터를 다루는
별도의 상당한 기능 작업이라 이번 디버깅 세션 범위를 넘어선다고 판단해 직접
구현하지 않았다. **이 상태로는 capacity-evidence의 search 이후 단계(burst,
unavailable, cache, purge, privacy, ingress-close)를 끝까지 통과시킬 수 없다 —
production runner에서의 exit 0 완주는 이번에는 달성하지 못했다.**

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests CapacityEvidencePlayIntegrityDecoderTest`(기존 테스트) → BUILD SUCCESSFUL, 회귀 없음
  - `./gradlew test --tests "com.easysubway.route.*"`(route 패키지 전체) → BUILD SUCCESSFUL, 회귀 없음
  - production runner 직접 재현·검증: session 발급 timestamp 버그 재현 → 수정 후
    통과 확인(로컬 빌드 디버그 이미지 사용, 운영 상태 무변경)
  - `bash -n tools/ops/verify-production-route-v2-capacity.sh` → OK
  - `git diff --check` → OK
  - `LC_ALL=C node --test tools/ci/production-route-v2-capacity-evidence-workflow.test.mjs tools/ci/repository-contract.test.mjs` → **pass 221 / fail 0**
- 모든 디버깅 잔재(임시 컨테이너·이미지·runner scratch clone·debug 스크립트)는
  세션 종료 시 정리했다.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| timestamp 버그 재현 | production self-hosted runner | 원본 이미지로 session 발급 시도 | `403 ROUTE_SESSION_ATTESTATION_REJECTED`, 크립토 교차검증 일치 확인 | 재현 성공 |
| timestamp 수정 검증 | production self-hosted runner | 로컬 빌드 이미지(디버그 전용 스크립트)로 session 발급 재시도 | session 통과, search 단계로 진행 | PASS |
| 백엔드 단위 테스트 | 로컬 Gradle | `./gradlew test --tests "com.easysubway.route.*"` | BUILD SUCCESSFUL | PASS |
| runner 스크립트 계약 | CI | `node --test` 계약 테스트 2종 | pass 221/fail 0 | PASS |
| capacity evidence 전체 완주(exit 0) | production self-hosted runner | 워크플로 재실행 | **미달성** — station 마스터 데이터 갭에 막힘(위 "미해결" 참고) | 블록됨 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [ ] route-commercialization-gate.json 영향 없음
- [x] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

이 PR 자체는 route ETA/coverage 리포트를 갱신하지 않지만, "미해결" 섹션에서
문서화한 station 마스터 데이터 갭은 **Route V2 상용화 게이트에 직접 영향을
주는 사전 출시 차단 요인**이라 표시했다. 이 갭 자체를 해소하는 작업은 별도
PR/이슈로 다뤄야 한다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] AquilaXk/easysubway#1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

이 PR은 AquilaXk/easysubway-backend#3(capacity evidence) 진행 상황을 갱신하지만, capacity evidence
자체는 아직 완주하지 못했다(위 "미해결" 참고) — release readiness가 완료됐다는
claim은 전혀 하지 않는다. station 마스터 데이터 갭은 AquilaXk/easysubway#1414 계열 release
blocker로 별도 추적이 필요해 보인다(오너 판단 필요).

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: `CapacityEvidencePlayIntegrityDecoder` verdict timestamp 수정(런타임 동작 무변경 — `capacity-evidence` 프로필 전용 synthetic decoder 로직 수정)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `CapacityEvidencePlayIntegrityDecoder.java`의
  `TIMESTAMP_SAFETY_MARGIN` 도입 근거, `tools/ops/verify-production-route-v2-capacity.sh`의
  `dump_request_diagnostics()` 신규 호출 6곳, 그리고 **"미해결" 섹션에서 설명한
  station 마스터 데이터 갭이 이 PR 범위 밖이라는 판단이 타당한지**(별도 이슈로
  분리할지, 이 PR에서 함께 다룰지 오너 결정 필요).

## 리스크

- **이 PR을 병합해도 capacity evidence 워크플로는 여전히 exit 0으로 완주하지
  못한다.** search 단계 이후(burst/unavailable/cache/purge/privacy/ingress-close)는
  station 마스터 데이터 갭이 해소되기 전까지 검증할 수 없다.
- station 마스터 데이터 갭(2개 역만 인식)은 capacity-evidence보다 훨씬 큰 범위의
  발견이다 — `EASYSUBWAY_ROUTE_V2_INGRESS_ENABLED=false`로 아직 실사용자 영향은
  없지만, Route V2 공개 전에 반드시 해소돼야 하는 항목으로 보인다. 이 PR에서는
  고의로 손대지 않았다(실제 역 이름·좌표 데이터를 다루는 별도 설계가 필요).
- 실제 fail-fix 최종 확인(session 이후 단계까지)은 station 마스터 데이터 갭
  해소 후 production runner 재검증이 추가로 필요하다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
