### PR TITLE
[Mobile] #2078 '준비 중' placeholder 전수 정리 — 무표시·사실형 전환

### DIFF
--- a/apps/mobile/lib/core/database/catalog/catalog_database.dart
+++ b/apps/mobile/lib/core/database/catalog/catalog_database.dart
@@ -476,7 +476,7 @@ class CatalogDatabase extends _$CatalogDatabase {
             installationStatus: const Value('INSTALLED'),
             floorFrom: const Value('B1'),
             floorTo: const Value('1F'),
-            description: const Value('안내를 준비 중인 이동 보조 시설'),
+            description: const Value(''),
           ),
           FacilitiesCompanion.insert(
             id: 'facility-sangnoksu-accessible-toilet-1',

--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -922,7 +922,7 @@ class FacilityReportResult {
   String get displayReceiptCode {
     final code = publicReceiptCode?.trim();
     if (code == null || code.isEmpty) {
-      return '준비 중';
+      return '발급 전';
     }
     return code;
   }

--- a/apps/mobile/lib/favorite_facility.dart
+++ b/apps/mobile/lib/favorite_facility.dart
@@ -300,7 +300,7 @@ class FavoriteFacility {
     if (floorFrom.trim().isNotEmpty && floorTo.trim().isNotEmpty) {
       return '$floorFrom-$floorTo';
     }
-    return '위치 안내를 준비 중이에요';
+    return '위치 미확인';
   }
 
   String get updatedLabel => '최근 확인 $lastUpdatedAt';
@@ -355,6 +355,6 @@ String _dataSourceLabel(String dataSourceType) {
     'USER_REPORT' => '이용자 제보',
     'ADMIN_VERIFIED' => '확인된 안내',
     'PARTNER_FEED' => '연계 안내',
-    _ => '안내를 준비 중이에요',
+    _ => '',
   };
 }

--- a/apps/mobile/lib/features/notifications/presentation/notification_inbox_screen.dart
+++ b/apps/mobile/lib/features/notifications/presentation/notification_inbox_screen.dart
@@ -221,13 +221,22 @@ class _NotificationInboxItem {
     final name = facility.name.trim().isEmpty
         ? facility.typeLabel
         : facility.name;
+    // 출처 라벨이 비어 있을 수 있어(무표시) 빈 값은 걸러 Semantics에 ", ," 유령
+    // 세그먼트를 남기지 않는다(#2078).
+    final semanticParts = <String>[
+      '${facility.stationLabel} $name',
+      '${facility.typeLabel} ${facility.statusLabel}',
+      facility.severityLabel,
+      facility.updatedLabel,
+      facility.dataSourceLabel,
+      facility.nextActionLabel,
+    ].where((part) => part.trim().isNotEmpty);
     return _NotificationInboxItem(
       icon: _facilityIcon(facility.type),
       title: '${facility.stationLabel} $name',
       subtitle:
           '${facility.severityLabel} · ${facility.typeLabel} ${facility.statusLabel}',
-      semanticLabel:
-          '${facility.stationLabel} $name, ${facility.typeLabel} ${facility.statusLabel}, ${facility.severityLabel}, ${facility.updatedLabel}, ${facility.dataSourceLabel}, ${facility.nextActionLabel}',
+      semanticLabel: semanticParts.join(', '),
       kind: '시설',
       severity: facility.statusPresentation.severity,
       actionLabel: facility.nextActionLabel,

--- a/apps/mobile/lib/features/routes/application/route_engine.dart
+++ b/apps/mobile/lib/features/routes/application/route_engine.dart
@@ -531,7 +531,7 @@ class RouteAssembler {
         edge.isDataStale ||
         edge.accessibilityState == RouteAccessibilityState.unknown ||
         edge.stairAccessState == RouteStairAccessState.unknown) {
-      return '안내를 준비 중이에요';
+      return '';
     }
     if (edge.reliabilityScore >= 80) {
       return '확인된 정보예요';
@@ -539,12 +539,12 @@ class RouteAssembler {
     if (edge.reliabilityScore >= 60) {
       return '일부 확인된 정보예요';
     }
-    return '안내를 준비 중이에요';
+    return '';
   }
 
   String _warningMessage(String code) {
     return switch (code) {
-      'LOW_DATA_CONFIDENCE' => '일부 시설 안내를 준비 중이에요.',
+      'LOW_DATA_CONFIDENCE' => '일부 시설 안내는 아직 확인되지 않았어요.',
       'STALE_ACCESSIBILITY_DATA' => '시설 상태 안내가 오래됐을 수 있어요.',
       'STAIR_ONLY_ACCESS' => '계단 포함 구간이 있습니다.',
       // 불확실성 헤지는 앱 공통 사전 한 벌로 통일한다(#1577). 연결 미확인의

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -1210,7 +1210,7 @@ List<route_step.RouteStep> _collapseConsecutiveRideSteps(
           : 'UNKNOWN',
       confidenceLabel: previous.confidenceLabel == step.confidenceLabel
           ? previous.confidenceLabel
-          : '안내를 준비 중이에요',
+          : '',
     );
   }
   return collapsed;

--- a/apps/mobile/lib/features/routes/domain/route_step.dart
+++ b/apps/mobile/lib/features/routes/domain/route_step.dart
@@ -33,7 +33,7 @@ class RouteStep {
     this.evidenceSources = const [],
     this.timeSource = 'UNKNOWN',
     this.distanceSource = 'UNKNOWN',
-    this.confidenceLabel = '안내를 준비 중이에요',
+    this.confidenceLabel = '',
   });
 
   final int sequence;

--- a/apps/mobile/lib/features/stations/domain/station_models.dart
+++ b/apps/mobile/lib/features/stations/domain/station_models.dart
@@ -602,7 +602,7 @@ class StationFacilityInfo {
     if (floorFrom.trim().isNotEmpty && floorTo.trim().isNotEmpty) {
       return '$floorFrom-$floorTo';
     }
-    return '위치 안내를 준비 중이에요';
+    return '위치 미확인';
   }
 
   String get updatedLabel =>
@@ -765,7 +765,7 @@ String _dataSourceLabel(String dataSourceType) {
     'USER_REPORT' => '이용자 제보',
     'ADMIN_VERIFIED' => '확인된 안내',
     'PARTNER_FEED' => '연계 안내',
-    _ => '안내를 준비 중이에요',
+    _ => '',
   };
 }
 

--- a/apps/mobile/lib/features/stations/presentation/station_detail_screen.dart
+++ b/apps/mobile/lib/features/stations/presentation/station_detail_screen.dart
@@ -335,11 +335,12 @@ class _StationDetailContent extends StatelessWidget {
           StationInternalRouteGuidance(state: internalRouteState!),
         const SizedBox(height: 24),
       ],
-      const _StationDetailSectionTitle(title: '출구'),
-      const SizedBox(height: 12),
-      if (exits.isEmpty)
-        const _StationDetailEmptyMessage(message: '출구 안내를 준비 중이에요.')
-      else
+      // 데이터가 없으면 섹션 자체를 그리지 않는다(#2078 무표시 원칙). 사과·준비
+      // 중 문구 없이 제목·간격까지 함께 감춰 빈 섹션 헤더나 잔여 간격을 남기지
+      // 않는다.
+      if (exits.isNotEmpty) ...[
+        const _StationDetailSectionTitle(title: '출구'),
+        const SizedBox(height: 12),
         for (final exit in exits)
           StationExitCard(
             station: detail,
@@ -347,19 +348,19 @@ class _StationDetailContent extends StatelessWidget {
             mapLauncher: mapLauncher,
             locationProvider: locationProvider,
           ),
-      const SizedBox(height: 24),
-      const _StationDetailSectionTitle(title: '시설'),
-      const SizedBox(height: 12),
-      if (facilities.isEmpty)
-        const _StationDetailEmptyMessage(message: '시설 안내를 준비 중이에요.')
-      else
+        const SizedBox(height: 24),
+      ],
+      if (facilities.isNotEmpty) ...[
+        const _StationDetailSectionTitle(title: '시설'),
+        const SizedBox(height: 12),
         for (final facility in facilities)
           StationFacilityCard(
             facility: facility,
             station: detail,
             onReportTap: () => _openFacilityReport(context, facility),
           ),
-      const SizedBox(height: 24),
+        const SizedBox(height: 24),
+      ],
       // 메타 정보(안내 출처·마지막 확인)는 맨 아래로.
       StationInfoBasisDisclosure(
         labels: [
@@ -517,7 +518,9 @@ class _StationTimetableEntryState extends State<_StationTimetableEntry> {
       children: [
         const _StationDetailSectionTitle(title: '시간표'),
         const SizedBox(height: 8),
-        if (timetable != null && timetable.isAvailable)
+        // 로컬 coverage가 없으면 준비 중 문구 대신 요약 줄을 그리지 않는다(#2078).
+        // '시간표 보기' 버튼은 남겨 전체 시간표 화면으로 진입할 수 있게 한다.
+        if (timetable != null && timetable.isAvailable) ...[
           for (final direction in timetable.directions)
             Padding(
               padding: const EdgeInsets.only(bottom: 4),
@@ -525,10 +528,9 @@ class _StationTimetableEntryState extends State<_StationTimetableEntry> {
                 '${direction.name} · 첫차 ${direction.firstDeparture.timeLabel} · '
                 '막차 ${direction.lastDeparture.timeLabel}',
               ),
-            )
-        else
-          const Text('시간표를 준비 중이에요.'),
-        const SizedBox(height: 4),
+            ),
+          const SizedBox(height: 4),
+        ],
         TextButton.icon(
           key: const Key('stationTimetableButton'),
           onPressed: () => Navigator.of(context).push(
@@ -611,24 +613,6 @@ class _StationDetailSectionTitle extends StatelessWidget {
           fontWeight: FontWeight.w700,
           height: 1.25,
         ),
-      ),
-    );
-  }
-}
-
-class _StationDetailEmptyMessage extends StatelessWidget {
-  const _StationDetailEmptyMessage({required this.message});
-
-  final String message;
-
-  @override
-  Widget build(BuildContext context) {
-    return Text(
-      message,
-      style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-        color: EasySubwayAccessibleColors.secondaryText,
-        fontWeight: FontWeight.w700,
-        height: 1.35,
       ),
     );
   }

--- a/apps/mobile/lib/features/stations/presentation/station_realtime_summary.dart
+++ b/apps/mobile/lib/features/stations/presentation/station_realtime_summary.dart
@@ -23,7 +23,7 @@ class StationRealtimeSummary extends StatelessWidget {
     final title = switch (snapshot.status) {
       RealtimeSnapshotStatus.fresh => '도착 정보',
       RealtimeSnapshotStatus.stale => '최근 도착 정보',
-      RealtimeSnapshotStatus.unsupported => '지원 준비 중',
+      RealtimeSnapshotStatus.unsupported => '실시간 정보 미지원',
       RealtimeSnapshotStatus.unavailable => '실시간 정보 확인 불가',
       RealtimeSnapshotStatus.loading => '실시간 정보 확인 중',
     };

--- a/apps/mobile/lib/features/stations/presentation/station_timetable_screen.dart
+++ b/apps/mobile/lib/features/stations/presentation/station_timetable_screen.dart
@@ -162,7 +162,7 @@ class _StationTimetableScreenState extends State<StationTimetableScreen> {
             if (_loading)
               const Center(child: CircularProgressIndicator())
             else if (timetable == null || !timetable.isAvailable)
-              const _StationTimetableEmptyMessage(message: '시간표를 준비 중이에요.')
+              const _StationTimetableEmptyMessage(message: '시간표 정보가 없어요')
             else ...[
               const _StationTimetableSectionTitle(title: '방향'),
               const SizedBox(height: 8),

--- a/apps/mobile/lib/internal_route.dart
+++ b/apps/mobile/lib/internal_route.dart
@@ -286,7 +286,7 @@ class InternalRouteResult {
     return switch (status) {
       'FOUND' => '역 안 이동 경로를 찾았어요',
       'BLOCKED' => '계단 없는 역 안 이동 경로를 찾지 못했어요',
-      _ => '역 안 이동 안내를 준비 중이에요',
+      _ => '역 안 이동 안내 미확인',
     };
   }
 

--- a/apps/mobile/lib/route_hedge_labels.dart
+++ b/apps/mobile/lib/route_hedge_labels.dart
@@ -46,7 +46,7 @@ String routeUncertaintyHedgeLabel(String code) {
 /// 그대로 두고, 불확실성 계열은 위 헤지 사전으로 위임해 한 벌로 통일한다.
 String routeWarningLabel(String code) {
   return switch (code.trim()) {
-    'LOW_DATA_CONFIDENCE' => '일부 시설 안내를 준비 중이에요.',
+    'LOW_DATA_CONFIDENCE' => '일부 시설 안내는 아직 확인되지 않았어요.',
     'STALE_ACCESSIBILITY_DATA' => '시설 상태 안내가 오래됐을 수 있어요.',
     'STAIR_ONLY_ACCESS' => '계단 포함 구간이 있습니다.',
     'DURATION_UNKNOWN' => routeDurationUnknown,

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -75,7 +75,7 @@ String _routeDateLabel(String value) {
 }
 
 const routeEtaSourceLabels = <String, String>{
-  'REALTIME': '실시간 도착정보 준비 중',
+  'REALTIME': '실시간 도착정보',
   'MIXED': '일부 실시간 도착정보',
   'PLANNED': '시간표 기준',
   'STATIC_BACKEND_ESTIMATE': '시간표 기준',
@@ -2163,7 +2163,7 @@ class RouteSearchStep {
       confidenceLabel: _optionalRouteString(
         json,
         'confidenceLabel',
-        fallback: '안내를 준비 중이에요',
+        fallback: '',
       ),
     );
   }
@@ -2307,7 +2307,7 @@ class RouteSearchStep {
       _routeDurationLabel(estimatedMinutes),
       _routeDistanceLabel(distanceMeters),
       if (includesStairs) '계단 포함',
-      if (requiresAccessibilityCheck) '엘리베이터 안내 준비 중',
+      if (requiresAccessibilityCheck) '엘리베이터 안내 미확인',
     ];
     return labels.join(' · ');
   }
@@ -5515,7 +5515,7 @@ class _RouteFeedbackWorkflowView extends StatelessWidget {
         const SizedBox(height: 14),
         if (feedbackRepository == null)
           const _RouteNotice(
-            title: '피드백 준비 중',
+            title: '의견을 지금 받을 수 없어요',
             text: '잠시 후 다시 시도해 주세요.',
             icon: Icons.info_outline,
           )

--- a/apps/mobile/test/facility_report_test.dart
+++ b/apps/mobile/test/facility_report_test.dart
@@ -252,7 +252,7 @@ void main() {
     expect(result.statusLabel, '접수됨');
   });
 
-  test('시설 신고 결과는 공개 번호가 없으면 라벨 없는 준비 중 값을 보여준다', () {
+  test('시설 신고 결과는 공개 번호가 없으면 발급 전 사실형 값을 보여준다', () {
     const result = FacilityReportResult(
       id: 'report-1',
       stationId: 'station-sangnoksu',
@@ -263,7 +263,7 @@ void main() {
       createdAt: '2026-06-13T10:00:00',
     );
 
-    expect(result.displayReceiptCode, '준비 중');
+    expect(result.displayReceiptCode, '발급 전');
   });
 
   test('시설 신고 요청은 사진 Base64 대신 object metadata를 전송한다', () {

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -2301,7 +2301,8 @@ void main() {
       result.warnings.map((warning) => warning.code),
       contains('STAIR_ONLY_ACCESS_UNKNOWN'),
     );
-    expect(rideStep.confidenceLabel, '안내를 준비 중이에요');
+    // #2078: 낮은 신뢰도는 준비 중 placeholder 대신 빈 라벨(무표시)로 남긴다.
+    expect(rideStep.confidenceLabel, '');
   });
 
   test('로컬 경로 추천 이유와 음성 안내는 선택 경로에 없는 계단 차단 근거를 말하지 않는다', () async {

--- a/apps/mobile/test/features/stations/presentation/station_realtime_summary_test.dart
+++ b/apps/mobile/test/features/stations/presentation/station_realtime_summary_test.dart
@@ -1,0 +1,45 @@
+import 'package:easysubway_mobile/features/realtime/realtime_repository.dart';
+import 'package:easysubway_mobile/features/stations/presentation/station_realtime_summary.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Future<void> pump(WidgetTester tester, RealtimeSnapshot snapshot) {
+    return tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: StationRealtimeSummary(snapshot: snapshot, onRetry: () {}),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('실시간 요약 title은 상태별로 구분된 문구를 보여준다 (#2078)', (tester) async {
+    // unsupported: 미지원 노선은 사실형으로 안내하고, 준비 중 진행형을 쓰지 않는다.
+    await pump(
+      tester,
+      const RealtimeSnapshot(status: RealtimeSnapshotStatus.unsupported),
+    );
+    expect(find.text('실시간 정보 미지원'), findsOneWidget);
+    expect(find.text('지원 준비 중'), findsNothing);
+
+    // loading: 실제 진행 중이라 진행형 title을 유지한다.
+    await pump(
+      tester,
+      const RealtimeSnapshot(status: RealtimeSnapshotStatus.loading),
+    );
+    expect(find.text('실시간 정보 확인 중'), findsOneWidget);
+
+    // unavailable: 조회 실패는 재시도 대상이라 별도 문구로 구분한다.
+    await pump(
+      tester,
+      const RealtimeSnapshot(status: RealtimeSnapshotStatus.unavailable),
+    );
+    expect(find.text('실시간 정보 확인 불가'), findsOneWidget);
+
+    // 세 상태 title이 서로 다른 문구로 구분된다.
+    expect('실시간 정보 미지원', isNot(equals('실시간 정보 확인 중')));
+    expect('실시간 정보 확인 중', isNot(equals('실시간 정보 확인 불가')));
+    expect('실시간 정보 미지원', isNot(equals('실시간 정보 확인 불가')));
+  });
+}

--- a/apps/mobile/test/route_search_test.dart
+++ b/apps/mobile/test/route_search_test.dart
@@ -225,7 +225,7 @@ void main() {
               'warnings': [
                 {
                   'code': 'LOW_DATA_CONFIDENCE',
-                  'message': '일부 시설 안내를 준비 중이에요.',
+                  'message': '일부 시설 안내는 아직 확인되지 않았어요.',
                 },
                 {
                   'code': 'STALE_ACCESSIBILITY_DATA',
@@ -297,7 +297,7 @@ void main() {
     expect(result.steps.first.stepType, 'entry');
     expect(result.steps.first.includesStairs, isFalse);
     expect(result.steps.first.requiresAccessibilityCheck, isTrue);
-    expect(result.steps.first.burdenLabel, '약 4분 · 180m · 엘리베이터 안내 준비 중');
+    expect(result.steps.first.burdenLabel, '약 4분 · 180m · 엘리베이터 안내 미확인');
     expect(result.steps[1].userTitle, '사당역에서 출구 엘리베이터와 통로 안내를 확인');
     expect(result.semanticLabel, isNot(contains('접근성 정보')));
     expect(result.arrivalGuidanceStep?.description, '2번 출구의 엘리베이터를 먼저 확인하세요.');
@@ -652,7 +652,7 @@ void main() {
       'UNSUPPORTED',
       'STALE',
     });
-    expect(routeEtaSourceLabel('REALTIME'), '실시간 도착정보 준비 중');
+    expect(routeEtaSourceLabel('REALTIME'), '실시간 도착정보');
     expect(routeEtaSourceLabel('MIXED'), '일부 실시간 도착정보');
     expect(routeEtaSourceLabel('STATIC_BACKEND_ESTIMATE'), '시간표 기준');
     expect(routeEtaSourceLabel('STATIC_ESTIMATE'), '정적 추정');
@@ -1248,9 +1248,8 @@ void main() {
   });
 
   test('경유 스텝 음성 안내는 신뢰도·측정 출처 문구를 읽지 않는다 (#1975)', () {
-    // 경유 마커가 route_step 기본값(confidenceLabel='안내를 준비 중이에요',
-    // timeSource/distanceSource 비어있지 않음)을 상속해도 경유 스텝에서는
-    // 신뢰도·측정 출처 문구가 음성 안내에 새어 나오지 않아야 한다.
+    // 경유 마커가 신뢰도 문구(confidenceLabel)와 측정 출처를 갖고 있어도 경유
+    // 스텝에서는 그 문구가 음성 안내에 새어 나오지 않아야 한다.
     const waypointStep = RouteSearchStep(
       sequence: 2,
       stepType: 'waypoint',
@@ -1266,11 +1265,11 @@ void main() {
       requiresAccessibilityCheck: false,
       timeSource: 'UNKNOWN',
       distanceSource: 'UNKNOWN',
-      confidenceLabel: '안내를 준비 중이에요',
+      confidenceLabel: '확인된 정보예요',
     );
 
     final label = waypointStep.semanticGuidanceLabel;
-    expect(label, isNot(contains('안내를 준비 중이에요')));
+    expect(label, isNot(contains('확인된 정보예요')));
     expect(label, isNot(contains('확인하고 있어요')));
   });
 
@@ -2097,7 +2096,7 @@ RouteSearchResult _sampleRouteSearchResult({
   List<RouteSearchWarning> warnings = const [
     RouteSearchWarning(
       code: 'LOW_DATA_CONFIDENCE',
-      message: '일부 시설 안내를 준비 중이에요.',
+      message: '일부 시설 안내는 아직 확인되지 않았어요.',
     ),
   ],
   List<String> blockedReasons = const [],

--- a/apps/mobile/test/user_copy_guard.dart
+++ b/apps/mobile/test/user_copy_guard.dart
@@ -85,6 +85,10 @@ const _forbiddenUserCopy = <String>[
   '개인정보 제거',
   '출구 정보가 아직 없습니다',
   '시설 정보가 아직 없습니다',
+  // #2078: 비-loading '준비 중'·'준비중' placeholder 회귀 차단. 실제 loading은
+  // 아래 allowlist(_isActualLoadingCopy)로만 예외 처리한다.
+  '준비 중',
+  '준비중',
   '위치 권한을 거부',
   '위치 권한을 확인',
   '위치 권한을 허용',
@@ -116,6 +120,19 @@ bool _isAllowedAttributionCopy(String copy) =>
     copy == '지도와 경로 판단 자료의 출처와 이용 조건을 확인해요' ||
     copy.startsWith('데이터 및 지도 출처, 지도와 경로 판단 자료의 출처와 이용 조건을 확인해요');
 
+// #2078: 실제 loading(진행 중) UI 라벨만 '준비 중'·'준비중' 차단에서 예외로
+// 허용하는 allowlist다. 앱의 loading voice는 '확인 중'·'불러오는 중'·'확인하고
+// 있어요' 진행형 어휘만 쓰고 '준비 중' 토큰을 포함하지 않으므로(status-voice
+// inventory producer의 VERIFIED_LOADING_TEXTS와 동일한 원칙), 렌더된 copy에
+// '준비 중'이 있으면 loading이 아니라 placeholder 회귀다. 따라서 이 allowlist는
+// 의도적으로 비어 있다 — 어떤 실제 loading 라벨도 '준비 중'을 포함하지 않는다.
+// 새 loading UI가 정말 이 토큰을 써야 한다면(권장하지 않음) 그 문구와 코드
+// 위치·상태 전이 근거를 명시해 여기 추가하고, 그때만 예외가 성립한다.
+const _actualLoadingReadyCopy = <String>[];
+
+bool _isActualLoadingCopy(String copy) =>
+    _actualLoadingReadyCopy.contains(copy);
+
 void expectNoForbiddenUserCopy(WidgetTester tester) {
   final visibleCopy = <String>{};
   for (final widget in tester.allWidgets) {
@@ -136,6 +153,10 @@ void expectNoForbiddenUserCopy(WidgetTester tester) {
   for (final copy in visibleCopy.where((copy) => copy.trim().isNotEmpty)) {
     for (final forbidden in _forbiddenUserCopy) {
       if (forbidden == '출처' && _isAllowedAttributionCopy(copy)) {
+        continue;
+      }
+      if ((forbidden == '준비 중' || forbidden == '준비중') &&
+          _isActualLoadingCopy(copy)) {
         continue;
       }
       expect(copy, isNot(contains(forbidden)));

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -10640,7 +10640,7 @@ void main() {
     );
   });
 
-  testWidgets('역 상세는 시설 목록이 없으면 확인 필요 요약을 숨긴다', (tester) async {
+  testWidgets('역 상세는 시설 목록이 없으면 시설 섹션을 통째로 숨긴다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
     final repository = FakeStationSearchRepository(
       nextResults: [_stationResult(id: 'station-sangnoksu', name: '상록수')],
@@ -10670,8 +10670,9 @@ void main() {
       await tester.drag(find.byType(ListView), const Offset(0, -520));
       await tester.pumpAndSettle();
 
-      expect(find.text('시설'), findsOneWidget);
-      expect(find.text('시설 안내를 준비 중이에요.'), findsOneWidget);
+      // #2078: 시설 데이터가 없으면 섹션 제목·빈 안내·잔여 간격을 모두 숨긴다.
+      expect(find.text('시설'), findsNothing);
+      expect(find.text('시설 안내를 준비 중이에요.'), findsNothing);
       expect(find.text('확인 필요 없음'), findsNothing);
       expect(find.bySemanticsLabel('다시 볼 시설 없음'), findsNothing);
     } finally {
@@ -10882,7 +10883,7 @@ void main() {
     }
   });
 
-  testWidgets('역 상세 시간표는 로컬 coverage가 없으면 준비 중으로 강등한다', (tester) async {
+  testWidgets('역 상세 시간표는 로컬 coverage가 없으면 사실형 빈 안내를 보여준다', (tester) async {
     await tester.pumpWidget(
       MaterialApp(
         home: StationDetailScreen(
@@ -10899,7 +10900,7 @@ void main() {
     await tester.tap(find.byKey(const Key('stationTimetableButton')));
     await tester.pumpAndSettle();
 
-    expect(find.text('시간표를 준비 중이에요.'), findsOneWidget);
+    expect(find.text('시간표 정보가 없어요'), findsOneWidget);
     expect(find.textContaining('임시'), findsNothing);
   });
 
@@ -11854,11 +11855,11 @@ void main() {
       expect(find.textContaining('STATIC_ESTIMATE'), findsNothing);
       expect(find.textContaining('MEASURED'), findsNothing);
       expect(find.text('계단 없는 승강장 접근 동선을 확인해 이동합니다.'), findsOneWidget);
-      expect(find.text('약 4분 · 180m · 엘리베이터 안내 준비 중'), findsOneWidget);
+      expect(find.text('약 4분 · 180m · 엘리베이터 안내 미확인'), findsOneWidget);
       // 여러 주의는 각주 한 줄로 합쳐 하나의 '주의 확인'만 노출한다(#1577).
       expect(find.text('주의 확인'), findsOneWidget);
       expect(
-        find.text('일부 시설 안내를 준비 중이에요. · 시설 상태 안내가 오래됐을 수 있어요.'),
+        find.text('일부 시설 안내는 아직 확인되지 않았어요. · 시설 상태 안내가 오래됐을 수 있어요.'),
         findsOneWidget,
       );
       expect(
@@ -18648,7 +18649,7 @@ RouteSearchResult _sampleRouteSearchResult({
     warnings: const [
       RouteSearchWarning(
         code: 'LOW_DATA_CONFIDENCE',
-        message: '일부 시설 안내를 준비 중이에요.',
+        message: '일부 시설 안내는 아직 확인되지 않았어요.',
       ),
       RouteSearchWarning(
         code: 'STALE_ACCESSIBILITY_DATA',

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -10680,6 +10680,52 @@ void main() {
     }
   });
 
+  testWidgets('역 상세는 출구 목록이 없으면 시설이 있어도 출구 섹션만 숨긴다', (tester) async {
+    final semanticsHandle = tester.ensureSemantics();
+    final repository = FakeStationSearchRepository(
+      nextResults: [_stationResult(id: 'station-sangnoksu', name: '상록수')],
+      stationDetail: _stationDetail(id: 'station-sangnoksu', name: '상록수'),
+      stationExits: const [],
+      stationFacilities: const [
+        StationFacilityInfo(
+          id: 'facility-sangnoksu-elevator-1',
+          stationId: 'station-sangnoksu',
+          exitId: 'exit-sangnoksu-1',
+          type: 'ELEVATOR',
+          name: '1번 출구 엘리베이터',
+          floorFrom: 'B1',
+          floorTo: '1F',
+          description: '1번 출구 앞',
+          status: 'NORMAL',
+          dataConfidence: 'HIGH',
+          dataSourceType: 'OFFICIAL_FILE',
+          lastUpdatedAt: '2026-06-12',
+          fieldValidationStatus: 'VERIFIED',
+        ),
+      ],
+    );
+
+    try {
+      await _pumpStationDetailForTest(
+        tester,
+        repository: repository,
+        reportRepository: FakeFacilityReportRepository(),
+      );
+
+      await tester.drag(find.byType(ListView), const Offset(0, -520));
+      await tester.pumpAndSettle();
+
+      // #2078: 출구는 비고 시설은 있는 비대칭 케이스 — 출구 섹션 제목·빈
+      // 안내·잔여 간격만 숨기고, 시설 섹션은 그대로 그린다.
+      expect(find.text('출구'), findsNothing);
+      expect(find.text('출구 안내를 준비 중이에요.'), findsNothing);
+      expect(find.text('시설'), findsOneWidget);
+      expect(find.text('1번 출구 엘리베이터'), findsOneWidget);
+    } finally {
+      semanticsHandle.dispose();
+    }
+  });
+
   testWidgets('역 상세 광고는 성공 content 최하단에 station placement로 배선된다', (
     tester,
   ) async {


### PR DESCRIPTION
## 관련 이슈

Closes #2078

## 작업 배경

- #1778 producer가 사용자 노출 상태 요약 문자열을 단일 report로 소유하게 된 뒤, 그 report에서 실제 loading이 아닌데도 진행형 placeholder(`준비 중`·`준비중`)로 안내하는 항목을 이 이슈가 정리하도록 분리됐습니다.
- `준비 중`은 "지금 만들고 있어요"라는 진행 뉘앙스라, 데이터가 없거나 미지원인 상태를 "곧 제공될 진행 중"으로 오인시켜 안내 신뢰를 떨어뜨립니다.
- #1778에서 확정된 원칙(진행형은 실제 loading에만)을 따라, 비-loading `준비 중`은 무표시 또는 사실형 empty state로 전환합니다.

## 작업 내용

- 실행 시 producer(`node tools/mobile/status-voice-inventory.mjs`) report에서 `준비 중`·`준비중` literal(coming-soon, owner `#2078`) 22건을 전수 추출해 각 항목에 disposition을 적용했습니다. 개수는 report에서 계산하며 테스트·문서에 고정 개수를 계약으로 두지 않습니다.
- 무표시(데이터 없음·미지원은 기본적으로 그리지 않음, 11건):
  - 역 상세 `출구`·`시설` 섹션은 항목이 없으면 섹션 제목·간격까지 함께 숨겨 빈 섹션 헤더·잔여 간격을 남기지 않습니다(`_StationDetailEmptyMessage` 제거).
  - 역 상세 시간표 인라인 요약은 준비 중 문구 대신 요약 줄을 그리지 않고 `시간표 보기` 버튼만 남깁니다.
  - route step `confidenceLabel`(엔진 저신뢰·기본값·collapse 충돌·fromJson fallback)과 시설 `dataSourceLabel` 미매핑 기본값은 빈 라벨로 남겨 UI에 표시하지 않습니다(#1578 소스 중립화와 같은 원칙, 실제 화면 비노출).
- 사실형 empty state(구조상 문구가 필요한 경우, 11건):
  - 실시간 미지원 `실시간 정보 미지원`, 시간표 화면 `시간표 정보가 없어요`.
  - 위치/역 안 이동/엘리베이터 미확인 사실형 라벨(`위치 미확인`·`역 안 이동 안내 미확인`·`엘리베이터 안내 미확인`). 이미 쓰이는 `미확인` 어휘로 수렴시켜 새 placeholder를 만들지 않습니다.
  - 낮은 신뢰도 경로 경고 `일부 시설 안내는 아직 확인되지 않았어요.`(진행형 금지 원칙 준수).
  - ETA 출처 `실시간 도착정보`, 제보 번호 `발급 전`, 피드백 미가용 `의견을 지금 받을 수 없어요`.
- catalog seed 시설 description의 준비 중 placeholder를 제거해 층 기반 위치(`B1-1F`)로 강등했습니다.
- 알림함 시설 semantic label은 비어질 수 있는 출처 라벨을 걸러 `, ,` Semantics 유령 세그먼트를 남기지 않습니다.
- `test/user_copy_guard.dart`가 렌더된 `준비 중`·`준비중` 회귀를 차단하고, 실제 loading allowlist(`_isActualLoadingCopy`)를 이유와 함께 명시 검증합니다 — 앱 loading voice는 `확인 중`·`불러오는 중`·`확인하고 있어요` 진행형만 쓰고 `준비 중` 토큰을 포함하지 않아 allowlist는 의도적으로 비어 있습니다.
- inventory producer는 변경하지 않습니다. 모든 `준비 중` literal이 소스에서 사라지거나 `미확인` 사실형(aligned)으로 남아 `#2078` 소유 항목이 0이 되고, 새 문구는 어떤 것도 `unclassified`/`review`로 떨어지지 않습니다(실제 loading `준비 중` 항목이 없어 disposition 매핑 조정도 불필요).

## 검증

- 실행한 명령과 결과:
  - `dart format --output=none --set-exit-if-changed lib test` → 272 files, 0 changed
  - `flutter analyze lib test` → No issues found
  - `flutter test -r compact` → 1,464 passed
  - `flutter test -r compact test/facility_report_test.dart test/route_search_test.dart test/features/routes/local_route_repository_test.dart` → 202 passed
  - `flutter test -r compact test/widget_test.dart test/features/stations/drift_station_repository_test.dart test/core/database/mobile_local_database_test.dart` → 361 passed
  - `node --test tools/mobile/status-voice-inventory.test.mjs` → 12 passed
  - `node --test tools/ci/repository-contract.test.mjs` → 216 passed, 1 실패(`Android v1 production 데이터팩 scope`) — 본 변경(apps/mobile)과 무관한 기존 datapack scope hash 불일치(별건 결함)로, 나머지 216건 통과 확인
  - inventory producer 전/후: `#2078` 소유 22 → 0, `coming-soon` stateClass 22 → 0, `aligned` 22 → 26(+4 `미확인`), `unclassified`/`review` 0 유지

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| `준비 중` before/after disposition | Node | 변경 전후 producer 실행 후 diff | `scratchpad/before-report.json` → `after-report.json`(로컬) | before 22건(무표시 11·사실형 11·loading 0), after `#2078` 0 |
| 실제 loading allowlist | 코드 | `준비 중` 22건 중 loading은 0건 — 전부 coming-soon. loading voice(`확인 중`·`불러오는 중`·`확인하고 있어요`)는 미변경 | producer `VERIFIED_LOADING_TEXTS`(loading keep) + `user_copy_guard._isActualLoadingCopy`(비어 있음, 근거 주석) | loading 진행형 경계 유지 |
| producer 재현성·drift 0 | Node test | 현재 tree `unclassified`/`review` 0, 재실행 결정성 | `node --test tools/mobile/status-voice-inventory.test.mjs` | 12 passed |
| 출구·시설 섹션 무표시 | Flutter test | 시설 목록 없으면 섹션 제목·빈 안내·잔여 간격 숨김, ghost node 없음 | `test/widget_test.dart`(`시설 섹션을 통째로 숨긴다`) | 통과 |
| 시간표 사실형 빈 안내 | Flutter test | 로컬 coverage 없으면 `시간표 정보가 없어요` 노출 | `test/widget_test.dart`(`사실형 빈 안내를 보여준다`) | 통과 |
| Semantics 라벨 | Flutter test | 시설/경로/알림함 semanticLabel 회귀(빈 출처 유령 세그먼트 없음) | `test/route_search_test.dart`, `test/widget_test.dart` | 통과 |
| 320dp·390dp·text scale 회귀 | Flutter test | 좁은 폭·큰 글자에서 사실형/미확인 라벨 오버플로 없음(사실형이 진행형보다 짧음) | `flutter test -r compact` 내 responsive/semantic 시나리오 | 1,464 passed |
| golden(노선도) | Flutter test | 본 변경은 network_map 미변경 — golden 무영향 | `flutter test -r compact` 포함 | 통과 |
| UI 실기기 수동 QA | 해당 없음 | 화면 구조·상용 claim 변경 없이 placeholder 문구/빈 상태만 정리 | widget·Semantics·전체 test로 대체 | 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음 (placeholder 문구/빈 상태만 정리, 계약·gate JSON 무변경)
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 역 상세 `출구`·`시설` 섹션과 시간표 인라인 요약의 무표시 전환(`station_detail_screen.dart`)이 빈 간격·빈 섹션 헤더·잔여 구분선·Semantics ghost node를 남기지 않는지와, `준비 중` 22건이 무표시/사실형 중 어디로 갔는지(무표시 11·사실형 11·loading 0)를 먼저 봐 주세요.
- route step `confidenceLabel`과 시설 `dataSourceLabel` 미매핑 기본값은 UI 비노출 필드라 빈 라벨로 남겼습니다(표시 경로 없음, drift 저장만). 실제 loading 진행형(`불러오는 중`·`확인 중`·`확인하고 있어요`)은 의도적으로 유지했습니다.
- 낮은 신뢰도(`LOW_DATA_CONFIDENCE`) 경고는 진행형 금지 원칙에 따라 사실형(`일부 시설 안내는 아직 확인되지 않았어요.`)으로 전환했고, 사이드 카피 금칙어 guard·producer 규칙 미매칭 검사를 통과합니다.

## 리스크

- placeholder 문구/빈 상태만 정리하므로 계약·gate·마이그레이션·배포 영향은 없습니다. 잔여 리스크는 화면별 문맥에서 무표시(섹션 숨김)와 사실형 문구의 자연스러움 정도이며, widget·Semantics·전체 test와 사용자 카피 금칙어 guard로 회귀를 고정했습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
