### PR TITLE
[Feat] ITX-청춘 pilot 정차역 14곳을 station master에 추가 (Refs #2095, #2098, #1414)

### DIFF
--- a/backend/src/main/java/com/easysubway/transit/adapter/out/persistence/InMemoryTransitMasterRepository.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/out/persistence/InMemoryTransitMasterRepository.java
@@ -67,7 +67,27 @@ public class InMemoryTransitMasterRepository implements
 
 	private static final List<SubwayLine> LINES = List.of(
 		new SubwayLine("seoul-4", "seoul-metro", "수도권 4호선", "#00A5DE", "수도권", "4", true),
-		new SubwayLine("suin-bundang", "korail", "수인분당선", "#F5A200", "수도권", "K1", true)
+		new SubwayLine("suin-bundang", "korail", "수인분당선", "#F5A200", "수도권", "K1", true),
+		// ITX-청춘(경춘선) pilot 노선 — 위 14개 pilot 정차역을 연결한다(#2095 PR #2286
+		// 리뷰 지적: 역만 있고 노선·역-노선 연결이 없어 강원권 노선/운영기관 집계가
+		// 부정확하게 0으로 나오는 orphan 상태였다). color는 tools/route-map/route-map-line-colors.json
+		// ("수도권 경춘": #0c8e72, 출처 위키백과 틀:한국 철도 노선색)에서 그대로 가져온
+		// 실데이터다. region은 "강원권"으로 뒀다 — 이 노선은 수도권(11역)과 강원권(3역)에
+		// 걸쳐 있지만 SubwayLine.region은 단일 값만 담을 수 있어 두 지역을 동시에 표현할
+		// 수 없다. 수도권은 이미 seoul-4/suin-bundang으로 lineCount가 채워져 있었던 반면
+		// 강원권은 이 노선이 연결되기 전까지 0이었던(=orphan 증상 그 자체였던) 쪽이라
+		// region="강원권"으로 둬 그 불일치를 직접 해소했다. lineCode는 Korail이 경춘선에
+		// suin-bundang의 "K1"급으로 공식 부여한 짧은 코드를 이 저장소 소스에서 확인하지
+		// 못해 지어내지 않고 빈 문자열로 뒀다(강원권 집계·capacity 어디에도 쓰이지 않는
+		// 순수 표시용 필드).
+		//
+		// 운영기관(TransitOperator) 쪽은 이 PR에서 건드리지 않았다 — korail은 이미 존재하는
+		// 단일 실제 법인이고 그 region 필드는 suin-bundang 때부터 "수도권"으로 고정돼 있다.
+		// 강원권 operatorCount를 억지로 채우려고 "korail-gangwon" 같은 실재하지 않는 두 번째
+		// 운영기관을 만들어내는 것은 조직을 지어내는 것이라 하지 않았다 — 강원권
+		// operatorCount=0은 "이 스키마가 단일-지역 운영기관만 표현할 수 있다"는 알려진
+		// 한계이지 데이터 누락이 아니다.
+		new SubwayLine("itx-cheongchun", "korail", "ITX-청춘", "#0c8e72", "강원권", "", true)
 	);
 
 	private static final List<Station> STATIONS = List.of(
@@ -156,7 +176,32 @@ public class InMemoryTransitMasterRepository implements
 
 	private static final List<StationLine> STATION_LINES = List.of(
 		new StationLine("station-sangnoksu", "seoul-4", "448", 48, "당고개 방면 / 오이도 방면"),
-		new StationLine("station-sadang", "seoul-4", "433", 33, "당고개 방면 / 오이도 방면")
+		new StationLine("station-sadang", "seoul-4", "433", 33, "당고개 방면 / 오이도 방면"),
+		// stationCode는 tools/datapack/sources/itx-cheongchun-source-timetable-20260715152903681.json
+		// stationRosters의 providerStationId(KRIC 제공 역 식별자)를 그대로 썼다 — seoul-4의
+		// "448" 같은 노선도 상 공식 역번호 체계와는 다른 provider 고유 코드이지만, 실제로
+		// KRIC API가 발급한 값이라 지어낸 것은 아니다. sequence는 같은 소스의
+		// corridorSequence(광운대·대성리·백양리·김유정 등 완행 전용역을 포함한 경춘선 전체
+		// 정차 순서)를 그대로 썼다 — RouteSearchService의 RAPTOR 그래프는 같은 lineId의
+		// 역이면 sequence 값과 무관하게 모두 직접 연결(1구간)로 취급하고, sequence는
+		// 비용 추정(Math.abs 차이)에만 쓰인다. 그래서 1..14로 다시 매기지 않고 실제
+		// corridorSequence를 그대로 둔 편이 건너뛴 완행 전용역만큼의 물리적 거리를 더
+		// 정확히 반영한다. platformInfo는 seoul-4 예시(노선의 양방향 종점 방면)와 같은
+		// 형식으로 "용산 방면 / 춘천 방면"을 모든 역에 공통 적용했다.
+		new StationLine("station-8aa315864466", "itx-cheongchun", "NAT010032", 1, "용산 방면 / 춘천 방면"),
+		new StationLine("station-c0679b9a6cf8", "itx-cheongchun", "NAT130070", 2, "용산 방면 / 춘천 방면"),
+		new StationLine("station-e5cf592cf355", "itx-cheongchun", "NAT130104", 3, "용산 방면 / 춘천 방면"),
+		new StationLine("station-b819702fa7d9", "itx-cheongchun", "NAT130126", 4, "용산 방면 / 춘천 방면"),
+		new StationLine("station-83bcb1eae340", "itx-cheongchun", "NAT020040", 7, "용산 방면 / 춘천 방면"),
+		new StationLine("station-b52ac4dfe64e", "itx-cheongchun", "NAT140098", 12, "용산 방면 / 춘천 방면"),
+		new StationLine("station-2ccf5647f7f7", "itx-cheongchun", "NAT140133", 13, "용산 방면 / 춘천 방면"),
+		new StationLine("station-f3d9c93ba7d6", "itx-cheongchun", "NAT140214", 15, "용산 방면 / 춘천 방면"),
+		new StationLine("station-661ff65ea040", "itx-cheongchun", "NAT140277", 17, "용산 방면 / 춘천 방면"),
+		new StationLine("station-6c1f50a5aa3b", "itx-cheongchun", "NAT140436", 19, "용산 방면 / 춘천 방면"),
+		new StationLine("station-4f6045ff9103", "itx-cheongchun", "NAT140576", 21, "용산 방면 / 춘천 방면"),
+		new StationLine("station-30ba86472e55", "itx-cheongchun", "NAT140701", 24, "용산 방면 / 춘천 방면"),
+		new StationLine("station-d5e344125b52", "itx-cheongchun", "NAT140840", 26, "용산 방면 / 춘천 방면"),
+		new StationLine("station-dd14cfb89cbc", "itx-cheongchun", "NAT140873", 27, "용산 방면 / 춘천 방면")
 	);
 
 	private static final List<StationExit> STATION_EXITS = List.of(

--- a/backend/src/main/java/com/easysubway/transit/adapter/out/persistence/InMemoryTransitMasterRepository.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/out/persistence/InMemoryTransitMasterRepository.java
@@ -94,8 +94,60 @@ public class InMemoryTransitMasterRepository implements
 			DataSourceType.OFFICIAL_FILE,
 			LocalDate.of(2026, 6, 12),
 			true
-		)
+		),
+		// ITX-청춘(경춘선) pilot 정차역 14곳 — Route V2 capacity evidence(#2095)가 검증하는
+		// pilot scope. id·이름·정차 순서는 tools/datapack/sources/itx-cheongchun-source-timetable-20260715152903681.json
+		// (stationRosters, providerStationId·providerStationName·canonicalStationId·corridorSequence,
+		// 원출처 data.go.kr 열린데이터광장 KRIC API — 같은 소스의
+		// korail-itx-cheongchun-station-sequence-20260713.json officialSourceUrl 참고)에서
+		// 그대로 가져왔고, production 격리 클론의 실제 transit_stop_times/transit_trips
+		// (service_class='ITX_CHEONGCHUN') stop_sequence 순서와 대조해 일치를 확인했다
+		// (#2095). nameEn은 국립국어원 로마자 표기법(코레일 역명판 표기와 동일) 표준 변환이다.
+		// region은 행정구역 기준(가평까지 경기도=수도권, 강촌부터 강원도=강원권)이며 정밀
+		// 좌표가 아니므로 창작이 아니다.
+		//
+		// 위도·경도는 이 datapack 소스에 없고, capacity 스크립트가 검증하는 Route V2 search
+		// 경로(RouteV2Planner)는 LoadTransitMasterPort/Station 좌표를 전혀 참조하지 않는다
+		// (loadActiveStation()은 존재·active 여부만 확인) — 그래서 여기서는 확정 좌표를
+		// 만들어내는 대신 명백히 미확정임을 알 수 있는 자리표시자 0,0을 쓴다. null을 쓰면
+		// TransitMasterService의 "인근 역 검색"(distanceMeters())이 실제로 이 14역에 대해
+		// NullPointerException을 낸다 — 0,0은 한국에서 수백만 km 떨어져 있어 그 기능이
+		// 정상 동작하는 한 이 14역이 우연히 "인근"으로 뜰 일이 없다. 실좌표 반입은 #2098
+		// real data-pack adapter 범위다.
+		itxCheongchunPilotStation("station-8aa315864466", "용산", "Yongsan"),
+		itxCheongchunPilotStation("station-c0679b9a6cf8", "옥수", "Oksu"),
+		itxCheongchunPilotStation("station-e5cf592cf355", "왕십리", "Wangsimni"),
+		itxCheongchunPilotStation("station-b819702fa7d9", "청량리", "Cheongnyangni"),
+		itxCheongchunPilotStation("station-83bcb1eae340", "상봉", "Sangbong"),
+		itxCheongchunPilotStation("station-b52ac4dfe64e", "퇴계원", "Toegyewon"),
+		itxCheongchunPilotStation("station-2ccf5647f7f7", "사릉", "Sareung"),
+		itxCheongchunPilotStation("station-f3d9c93ba7d6", "평내호평", "Pyeongnae-Hopyeong"),
+		itxCheongchunPilotStation("station-661ff65ea040", "마석", "Maseok"),
+		itxCheongchunPilotStation("station-6c1f50a5aa3b", "청평", "Cheongpyeong"),
+		itxCheongchunPilotStation("station-4f6045ff9103", "가평", "Gapyeong"),
+		itxCheongchunPilotStation("station-30ba86472e55", "강촌", "Gangchon", "강원권"),
+		itxCheongchunPilotStation("station-d5e344125b52", "남춘천", "Namchuncheon", "강원권"),
+		itxCheongchunPilotStation("station-dd14cfb89cbc", "춘천", "Chuncheon", "강원권")
 	);
+
+	private static Station itxCheongchunPilotStation(String id, String nameKo, String nameEn) {
+		return itxCheongchunPilotStation(id, nameKo, nameEn, "수도권");
+	}
+
+	private static Station itxCheongchunPilotStation(String id, String nameKo, String nameEn, String region) {
+		return new Station(
+			id,
+			nameKo,
+			nameEn,
+			region,
+			BigDecimal.ZERO,
+			BigDecimal.ZERO,
+			DataQualityLevel.LEVEL_1,
+			DataSourceType.OFFICIAL_FILE,
+			LocalDate.of(2026, 7, 15),
+			true
+		);
+	}
 
 	private static final List<StationLine> STATION_LINES = List.of(
 		new StationLine("station-sangnoksu", "seoul-4", "448", 48, "당고개 방면 / 오이도 방면"),

--- a/backend/src/main/java/com/easysubway/transit/adapter/out/persistence/InMemoryTransitMasterRepository.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/out/persistence/InMemoryTransitMasterRepository.java
@@ -106,14 +106,19 @@ public class InMemoryTransitMasterRepository implements
 		// region은 행정구역 기준(가평까지 경기도=수도권, 강촌부터 강원도=강원권)이며 정밀
 		// 좌표가 아니므로 창작이 아니다.
 		//
-		// 위도·경도는 이 datapack 소스에 없고, capacity 스크립트가 검증하는 Route V2 search
-		// 경로(RouteV2Planner)는 LoadTransitMasterPort/Station 좌표를 전혀 참조하지 않는다
-		// (loadActiveStation()은 존재·active 여부만 확인) — 그래서 여기서는 확정 좌표를
-		// 만들어내는 대신 명백히 미확정임을 알 수 있는 자리표시자 0,0을 쓴다. null을 쓰면
-		// TransitMasterService의 "인근 역 검색"(distanceMeters())이 실제로 이 14역에 대해
-		// NullPointerException을 낸다 — 0,0은 한국에서 수백만 km 떨어져 있어 그 기능이
-		// 정상 동작하는 한 이 14역이 우연히 "인근"으로 뜰 일이 없다. 실좌표 반입은 #2098
-		// real data-pack adapter 범위다.
+		// 위도·경도는 이 datapack 소스에 없어 만들어내지 않고 0,0을 자리표시자로 쓴다.
+		// 이 클래스는 !prod 프로필이지만, prod에서 활성화되는
+		// JdbcTransitMasterOverrideRepository가 loadStations()를 오버라이드하지 않고
+		// UnavailableTransitMasterRepository를 거쳐 이 STATIONS를 그대로 상속하므로,
+		// 이 0,0은 dev 격리에 머물지 않고 prod seed까지 그대로 도달한다(예: 관리자
+		// 역 상세/편집 화면에 0/0으로 노출됨). null을 쓰면 TransitMasterService의
+		// "인근 역 검색"(distanceMeters())이 이 14역에 대해 NullPointerException을
+		// 내므로 그 대안은 아니다. 현재는 capacity 스크립트가 검증하는 Route V2
+		// search 경로(RouteV2Planner)도, 공개 nearby-search 엔드포인트도 이 14역의
+		// 좌표를 소비하지 않아(loadActiveStation()은 존재·active 여부만 확인) 무해하지만,
+		// #2098 real data-pack adapter로 실좌표가 반입되기 전에 nearby-search가 이
+		// 데이터에 배선되면 0,0이 실제 위치로 오응답에 섞여들 수 있는 잠복 리스크가
+		// 있다는 점은 명시해둔다. 실좌표 반입은 #2098 범위다.
 		itxCheongchunPilotStation("station-8aa315864466", "용산", "Yongsan"),
 		itxCheongchunPilotStation("station-c0679b9a6cf8", "옥수", "Oksu"),
 		itxCheongchunPilotStation("station-e5cf592cf355", "왕십리", "Wangsimni"),

--- a/backend/src/test/java/com/easysubway/collection/adapter/in/web/DataCollectionAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/collection/adapter/in/web/DataCollectionAdminPageControllerTest.java
@@ -97,9 +97,10 @@ class DataCollectionAdminPageControllerTest {
 			.contains("건너뜀")
 			.contains("수동 필요")
 			.contains("admin-user")
-			// #2095: InMemoryTransitMasterRepository에 ITX-청춘 pilot 정차역 14곳이
-			// 추가돼 수집 건수(operators+lines+stations+...)가 14에서 28로 늘었다.
-			.contains(">28<")
+			// #2095: InMemoryTransitMasterRepository에 ITX-청춘 pilot 정차역 14곳과
+			// 이를 연결하는 ITX-청춘 노선(LINES 1건)·STATION_LINES 14건이 추가돼
+			// 수집 건수(operators+lines+stations+...)가 28에서 43으로 늘었다.
+			.contains(">43<")
 			.contains("name=\"source\"")
 			.contains("value=\"TRANSIT_MASTER\"")
 			.contains("name=\"_csrf\"");

--- a/backend/src/test/java/com/easysubway/collection/adapter/in/web/DataCollectionAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/collection/adapter/in/web/DataCollectionAdminPageControllerTest.java
@@ -97,7 +97,9 @@ class DataCollectionAdminPageControllerTest {
 			.contains("건너뜀")
 			.contains("수동 필요")
 			.contains("admin-user")
-			.contains(">14<")
+			// #2095: InMemoryTransitMasterRepository에 ITX-청춘 pilot 정차역 14곳이
+			// 추가돼 수집 건수(operators+lines+stations+...)가 14에서 28로 늘었다.
+			.contains(">28<")
 			.contains("name=\"source\"")
 			.contains("value=\"TRANSIT_MASTER\"")
 			.contains("name=\"_csrf\"");

--- a/backend/src/test/java/com/easysubway/collection/adapter/in/web/DataCollectionControllerTest.java
+++ b/backend/src/test/java/com/easysubway/collection/adapter/in/web/DataCollectionControllerTest.java
@@ -59,7 +59,9 @@ class DataCollectionControllerTest {
 			.andExpect(jsonPath("$.data.source").value("TRANSIT_MASTER"))
 			.andExpect(jsonPath("$.data.status").value("COMPLETED"))
 			.andExpect(jsonPath("$.data.requestedBy").value("admin-user"))
-			.andExpect(jsonPath("$.data.collectedCount").value(14))
+			// #2095: InMemoryTransitMasterRepository에 ITX-청춘 pilot 정차역 14곳이
+			// 추가돼 수집 건수가 14에서 28로 늘었다.
+			.andExpect(jsonPath("$.data.collectedCount").value(28))
 			.andExpect(jsonPath("$.data.retryable").value(false))
 			.andExpect(jsonPath("$.data.steps[0].name").value("FETCH"))
 			.andExpect(jsonPath("$.data.steps[0].status").value("COMPLETED"))

--- a/backend/src/test/java/com/easysubway/collection/adapter/in/web/DataCollectionControllerTest.java
+++ b/backend/src/test/java/com/easysubway/collection/adapter/in/web/DataCollectionControllerTest.java
@@ -59,9 +59,10 @@ class DataCollectionControllerTest {
 			.andExpect(jsonPath("$.data.source").value("TRANSIT_MASTER"))
 			.andExpect(jsonPath("$.data.status").value("COMPLETED"))
 			.andExpect(jsonPath("$.data.requestedBy").value("admin-user"))
-			// #2095: InMemoryTransitMasterRepository에 ITX-청춘 pilot 정차역 14곳이
-			// 추가돼 수집 건수가 14에서 28로 늘었다.
-			.andExpect(jsonPath("$.data.collectedCount").value(28))
+			// #2095: InMemoryTransitMasterRepository에 ITX-청춘 pilot 정차역 14곳과
+			// 이를 연결하는 ITX-청춘 노선(LINES 1건)·STATION_LINES 14건이 추가돼
+			// 수집 건수가 28에서 43(=28+1+14)으로 늘었다.
+			.andExpect(jsonPath("$.data.collectedCount").value(43))
 			.andExpect(jsonPath("$.data.retryable").value(false))
 			.andExpect(jsonPath("$.data.steps[0].name").value("FETCH"))
 			.andExpect(jsonPath("$.data.steps[0].status").value("COMPLETED"))

--- a/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorAccessibilityReportControllerTest.java
+++ b/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorAccessibilityReportControllerTest.java
@@ -63,7 +63,10 @@ class OperatorAccessibilityReportControllerTest {
 			.andExpect(jsonPath("$.data.stationQualityRows[2].description").value("쉬운 길 안내를 볼 수 있어요"))
 			.andExpect(jsonPath("$.data.stationQualityRows[3].description").value("고장·공사 소식이 반영됐어요"))
 			// #2095: region 목록이 이름순 정렬이라 강원권(ITX-청춘 pilot 3역)이 수도권보다
-			// 앞에 온다. operator/line은 손대지 않아 강원권 쪽은 0이다.
+			// 앞에 온다. ITX-청춘 노선을 LINES에 추가했지만 그 운영기관인 한국철도공사는
+			// 이미 수인분당선으로 "수도권" TransitOperator에 등록돼 있어(단일 region
+			// 스키마상 강원권 전용 운영기관을 지어내지 않았으므로) 강원권 operatorCount는
+			// 여전히 0이다.
 			.andExpect(jsonPath("$.data.regionQualityRows[0].name").value("강원권"))
 			.andExpect(jsonPath("$.data.regionQualityRows[0].operatorCount").value(0))
 			.andExpect(jsonPath("$.data.regionQualityRows[1].name").value("수도권"))

--- a/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorAccessibilityReportControllerTest.java
+++ b/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorAccessibilityReportControllerTest.java
@@ -53,16 +53,24 @@ class OperatorAccessibilityReportControllerTest {
 				.with(httpBasic("operator-user", "operator-test-password")))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.success").value(true))
-			.andExpect(jsonPath("$.data.totalStations").value(2))
+			// #2095: InMemoryTransitMasterRepository에 ITX-청춘 pilot 정차역 14곳이
+			// 추가돼 역 수 집계가 2에서 16으로 늘었다.
+			.andExpect(jsonPath("$.data.totalStations").value(16))
 			.andExpect(jsonPath("$.data.totalFacilities").value(3))
 			.andExpect(jsonPath("$.data.needsVerificationFacilityCount").value(1))
 			.andExpect(jsonPath("$.data.stationQualityRows[0].description").value("일부 정보는 확인 중이에요"))
 			.andExpect(jsonPath("$.data.stationQualityRows[1].description").value("시설 정보를 함께 볼 수 있어요"))
 			.andExpect(jsonPath("$.data.stationQualityRows[2].description").value("쉬운 길 안내를 볼 수 있어요"))
 			.andExpect(jsonPath("$.data.stationQualityRows[3].description").value("고장·공사 소식이 반영됐어요"))
-			.andExpect(jsonPath("$.data.regionQualityRows[0].name").value("수도권"))
-			.andExpect(jsonPath("$.data.regionQualityRows[0].operatorCount").value(2))
-			.andExpect(jsonPath("$.data.stationAccessibilityScoreRows[0].stationName").value("상록수"))
+			// #2095: region 목록이 이름순 정렬이라 강원권(ITX-청춘 pilot 3역)이 수도권보다
+			// 앞에 온다. operator/line은 손대지 않아 강원권 쪽은 0이다.
+			.andExpect(jsonPath("$.data.regionQualityRows[0].name").value("강원권"))
+			.andExpect(jsonPath("$.data.regionQualityRows[0].operatorCount").value(0))
+			.andExpect(jsonPath("$.data.regionQualityRows[1].name").value("수도권"))
+			.andExpect(jsonPath("$.data.regionQualityRows[1].operatorCount").value(2))
+			// station 접근성 점수 정렬(점수 오름차순, 동점은 이름순)도 ITX-청춘 pilot 역
+			// 14곳(모두 접근성 시설 미등록이라 점수 0)이 앞으로 와 상록수(15점)보다 먼저다.
+			.andExpect(jsonPath("$.data.stationAccessibilityScoreRows[0].stationName").value("강촌"))
 			.andExpect(jsonPath("$.data.stationAccessibilityScoreRows[0].reasons[0]").value("일부 정보는 확인 중이에요"))
 			.andExpect(jsonPath("$.data.accessibilityImprovementPriorityRows[0].stationName").value("상록수"))
 			.andExpect(jsonPath("$.data.accessibilityImprovementPriorityRows[0].facilityName").value("장애인 화장실"))
@@ -87,7 +95,8 @@ class OperatorAccessibilityReportControllerTest {
 				String csv = result.getResponse().getContentAsString();
 				org.assertj.core.api.Assertions.assertThat(csv)
 					.startsWith("﻿section,metric,value,detail\r\n")
-					.contains("summary,totalStations,2,")
+					// #2095: ITX-청춘 pilot 정차역 14곳 추가로 2 → 16.
+					.contains("summary,totalStations,16,")
 					.contains("summary,totalFacilities,3,")
 					.contains("summary,needsVerificationFacilityCount,1,")
 					.contains("stationScore,상록수,")
@@ -117,8 +126,9 @@ class OperatorAccessibilityReportControllerTest {
 				.isEqualTo("section");
 			org.assertj.core.api.Assertions.assertThat(sheet.getRow(1).getCell(1).getStringCellValue())
 				.isEqualTo("totalStations");
+			// #2095: ITX-청춘 pilot 정차역 14곳 추가로 2 → 16.
 			org.assertj.core.api.Assertions.assertThat(sheet.getRow(1).getCell(2).getStringCellValue())
-				.isEqualTo("2");
+				.isEqualTo("16");
 		}
 	}
 

--- a/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorAccessibilityReportControllerTest.java
+++ b/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorAccessibilityReportControllerTest.java
@@ -68,8 +68,11 @@ class OperatorAccessibilityReportControllerTest {
 			.andExpect(jsonPath("$.data.regionQualityRows[0].operatorCount").value(0))
 			.andExpect(jsonPath("$.data.regionQualityRows[1].name").value("수도권"))
 			.andExpect(jsonPath("$.data.regionQualityRows[1].operatorCount").value(2))
-			// station 접근성 점수 정렬(점수 오름차순, 동점은 이름순)도 ITX-청춘 pilot 역
-			// 14곳(모두 접근성 시설 미등록이라 점수 0)이 앞으로 와 상록수(15점)보다 먼저다.
+			// station 접근성 점수 정렬(DataQualityService: score → region → stationName →
+			// stationId)도 ITX-청춘 pilot 역 14곳(모두 접근성 시설 미등록이라 점수 0)이
+			// 상록수(15점)보다 앞으로 온다. 강촌이 [0]인 건 이름순이 아니라 동점(0점) 안에서
+			// region이 먼저 갈리기 때문 — 강원권(강촌·남춘천·춘천)이 가나다순으로 수도권보다
+			// 앞서 정렬되고, 강원권 내에서는 이름순으로 강촌이 가장 앞이다.
 			.andExpect(jsonPath("$.data.stationAccessibilityScoreRows[0].stationName").value("강촌"))
 			.andExpect(jsonPath("$.data.stationAccessibilityScoreRows[0].reasons[0]").value("일부 정보는 확인 중이에요"))
 			.andExpect(jsonPath("$.data.accessibilityImprovementPriorityRows[0].stationName").value("상록수"))

--- a/backend/src/test/java/com/easysubway/quality/adapter/in/web/DataQualityAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/quality/adapter/in/web/DataQualityAdminPageControllerTest.java
@@ -77,7 +77,9 @@ class DataQualityAdminPageControllerTest {
 		assertThat(html)
 			.contains("데이터 품질 대시보드")
 			.contains("전체 역")
-			.contains(">2<")
+			// #2095: InMemoryTransitMasterRepository에 ITX-청춘 pilot 정차역 14곳이
+			// 추가돼 전체 역 수가 2에서 16으로 늘었다.
+			.contains(">16<")
 			.contains("전체 출구")
 			.contains("전체 시설")
 			.contains(">3<")

--- a/backend/src/test/java/com/easysubway/quality/adapter/in/web/DataQualityControllerTest.java
+++ b/backend/src/test/java/com/easysubway/quality/adapter/in/web/DataQualityControllerTest.java
@@ -46,10 +46,13 @@ class DataQualityControllerTest {
 				.with(httpBasic("admin-user", "admin-test-password")))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.success").value(true))
-			.andExpect(jsonPath("$.data.totalStations").value(2))
+			// #2095: InMemoryTransitMasterRepository에 ITX-청춘 pilot 정차역 14곳이
+			// 추가돼(모두 LEVEL_1) 역 수·품질 집계가 2에서 16으로 늘었다. exits/facilities는
+			// 기존 station-sangnoksu/station-sadang에만 연결돼 있어 그대로다.
+			.andExpect(jsonPath("$.data.totalStations").value(16))
 			.andExpect(jsonPath("$.data.totalExits").value(3))
 			.andExpect(jsonPath("$.data.totalFacilities").value(3))
-			.andExpect(jsonPath("$.data.stationQualityCounts.LEVEL_1").value(2))
+			.andExpect(jsonPath("$.data.stationQualityCounts.LEVEL_1").value(16))
 			.andExpect(jsonPath("$.data.exitConfidenceCounts.HIGH").value(2))
 			.andExpect(jsonPath("$.data.exitConfidenceCounts.MEDIUM").value(1))
 			.andExpect(jsonPath("$.data.facilityConfidenceCounts.HIGH").value(1))

--- a/backend/src/test/java/com/easysubway/transit/application/service/TransitMasterServiceTest.java
+++ b/backend/src/test/java/com/easysubway/transit/application/service/TransitMasterServiceTest.java
@@ -78,8 +78,12 @@ class TransitMasterServiceTest {
 	@DisplayName("지역 목록은 활성 운영기관과 노선과 역 수를 집계한다")
 	void listRegionsSummarizesActiveMasterDataCounts() {
 		// #2095: InMemoryTransitMasterRepository에 ITX-청춘 pilot 정차역 14곳이
-		// 추가돼(수도권 11 + 강원권 3) region 목록·집계가 늘었다. operator/line은
-		// 손대지 않았으므로 강원권에는 여전히 0으로 남는다.
+		// 추가돼(수도권 11 + 강원권 3) region 목록·집계가 늘었다. ITX-청춘 노선을
+		// LINES에 추가하고 14역을 STATION_LINES로 연결해 강원권 lineCount는 1이
+		// 됐다. operatorCount는 여전히 0인데, ITX-청춘 운영기관인 한국철도공사가
+		// 이미 수인분당선으로 "수도권" TransitOperator에 등록돼 있고 SubwayLine/
+		// TransitOperator 스키마가 단일 region만 표현할 수 있어, 강원권 전용
+		// "korail-gangwon" 같은 실재하지 않는 운영기관을 지어내지 않았기 때문이다.
 		var regions = service.listRegions();
 
 		assertThat(regions)
@@ -88,7 +92,7 @@ class TransitMasterServiceTest {
 
 		var gangwon = regions.get(0);
 		assertThat(gangwon.operatorCount()).isZero();
-		assertThat(gangwon.lineCount()).isZero();
+		assertThat(gangwon.lineCount()).isEqualTo(1);
 		assertThat(gangwon.stationCount()).isEqualTo(3);
 		assertThat(gangwon.dataQualityCounts())
 			.containsEntry(DataQualityLevel.LEVEL_1, 3L);
@@ -104,11 +108,13 @@ class TransitMasterServiceTest {
 	@Test
 	@DisplayName("운영기관 식별자로 노선을 필터링한다")
 	void listLinesCanFilterByOperatorId() {
+		// #2095: ITX-청춘 노선(운영기관 한국철도공사)이 LINES에 추가돼
+		// korail 필터 결과에 suin-bundang과 함께 포함된다.
 		var lines = service.listLines("korail");
 
 		assertThat(lines)
 			.extracting("id")
-			.containsExactly("suin-bundang");
+			.containsExactly("suin-bundang", "itx-cheongchun");
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/transit/application/service/TransitMasterServiceTest.java
+++ b/backend/src/test/java/com/easysubway/transit/application/service/TransitMasterServiceTest.java
@@ -77,17 +77,28 @@ class TransitMasterServiceTest {
 	@Test
 	@DisplayName("지역 목록은 활성 운영기관과 노선과 역 수를 집계한다")
 	void listRegionsSummarizesActiveMasterDataCounts() {
+		// #2095: InMemoryTransitMasterRepository에 ITX-청춘 pilot 정차역 14곳이
+		// 추가돼(수도권 11 + 강원권 3) region 목록·집계가 늘었다. operator/line은
+		// 손대지 않았으므로 강원권에는 여전히 0으로 남는다.
 		var regions = service.listRegions();
 
 		assertThat(regions)
 			.extracting("name")
-			.containsExactly("수도권");
-		var region = regions.getFirst();
-		assertThat(region.operatorCount()).isEqualTo(2);
-		assertThat(region.lineCount()).isEqualTo(2);
-		assertThat(region.stationCount()).isEqualTo(2);
-		assertThat(region.dataQualityCounts())
-			.containsEntry(DataQualityLevel.LEVEL_1, 2L);
+			.containsExactly("강원권", "수도권");
+
+		var gangwon = regions.get(0);
+		assertThat(gangwon.operatorCount()).isZero();
+		assertThat(gangwon.lineCount()).isZero();
+		assertThat(gangwon.stationCount()).isEqualTo(3);
+		assertThat(gangwon.dataQualityCounts())
+			.containsEntry(DataQualityLevel.LEVEL_1, 3L);
+
+		var metro = regions.get(1);
+		assertThat(metro.operatorCount()).isEqualTo(2);
+		assertThat(metro.lineCount()).isEqualTo(2);
+		assertThat(metro.stationCount()).isEqualTo(13);
+		assertThat(metro.dataQualityCounts())
+			.containsEntry(DataQualityLevel.LEVEL_1, 13L);
 	}
 
 	@Test
@@ -103,8 +114,10 @@ class TransitMasterServiceTest {
 	@Test
 	@DisplayName("역 검색은 한글 이름과 영문 이름을 모두 찾는다")
 	void searchStationsMatchesKoreanAndEnglishNames() {
+		// "sang"은 #2095에서 추가된 ITX-청춘 pilot 역 "Sangbong"(상봉)과도 매치되므로,
+		// station-sangnoksu만 고유하게 가리키는 "sangnok"으로 질의한다.
 		var koreanMatches = service.searchStations(new StationSearchCommand("상록수", null));
-		var englishMatches = service.searchStations(new StationSearchCommand("sang", null));
+		var englishMatches = service.searchStations(new StationSearchCommand("sangnok", null));
 
 		assertThat(koreanMatches).hasSize(1);
 		assertThat(englishMatches).hasSize(1);


### PR DESCRIPTION
## 관련 이슈

Refs AquilaXk/easysubway-backend#3, AquilaXk/easysubway#2098, AquilaXk/easysubway#1414

## 작업 배경

**capacity evidence를 Route V2 pilot 범위(ITX-청춘)로
프로브 고정**. 역 데이터 완성(real data-pack adapter, 전체 역)은 AquilaXk/easysubway#2098/#1414
소유의 별도 트랙이고, capacity의 목적은 scope·rate-limit·session·ephemeral
제어 검증이다(#2095 Non-scope에 planner/역데이터 명시).

이전 조사(#2270 계열)에서, capacity 스크립트가 검증하려는 ITX-청춘 search가
station master(`InMemoryTransitMasterRepository`, prod 활성)에 `station-sangnoksu`/
`station-sadang` 단 2역만 있어 실패했음을 확인했다. 오너가 실제 ITX-청춘 pilot
정차역 데이터(정차 순서, 용산→춘천, 14개역)를 제공해 이 PR에서 실데이터로
station master를 확장한다.

## 매핑 실측

production runner(oci-a1-staging)의 **격리 클론**(운영 dump를 `pg_dump`로 읽어
`--internal` 격리망에 `pg_restore`, 운영 컨테이너/DB는 무변경)에서
`transit_stop_times`/`transit_trips`(`service_class='ITX_CHEONGCHUN'`)의
station_id를 실제 stop_sequence 순서로 추출했다. 대표 트립 하나(춘천→용산
방향)의 정차 순서:

```
춘천 → 남춘천 → 가평 → 마석 → 평내호평 → 사릉 → 퇴계원 → 상봉 →
청량리 → 왕십리 → 용산
```

는 오너가 제공한 순서(용산→...→춘천)의 **정확한 역방향**과 일치했다(경춘선은
양방향 운행이므로 예상된 결과). 해시 station_id ↔ 실제 역 이름은
`tools/datapack/sources/itx-cheongchun-source-timetable-20260715152903681.json`의
`stationRosters`(`providerStationId`·`providerStationName`·`canonicalStationId`·
`corridorSequence`, KRIC 공공데이터포털 API 출처)에서 가져와 대조했고,
`corridorSequence`(1,2,3,4,7,12,13,15,17,19,21,24,26,27)가 오너 순서와 **정확히
일치**했다(경춘선 완행 전용 정차역 4곳 — 광운대·대성리·백양리·김유정 — 은
ITX-청춘이 서지 않아 자연스럽게 제외됨을 확인).

| corridorSequence | canonicalStationId | 이름 |
| --- | --- | --- |
| 1 | station-8aa315864466 | 용산 |
| 2 | station-c0679b9a6cf8 | 옥수 |
| 3 | station-e5cf592cf355 | 왕십리 |
| 4 | station-b819702fa7d9 | 청량리 |
| 7 | station-83bcb1eae340 | 상봉 |
| 12 | station-b52ac4dfe64e | 퇴계원 |
| 13 | station-2ccf5647f7f7 | 사릉 |
| 15 | station-f3d9c93ba7d6 | 평내호평 |
| 17 | station-661ff65ea040 | 마석 |
| 19 | station-6c1f50a5aa3b | 청평 |
| 21 | station-4f6045ff9103 | 가평 |
| 24 | station-30ba86472e55 | 강촌 |
| 26 | station-d5e344125b52 | 남춘천 |
| 27 | station-dd14cfb89cbc | 춘천 |

## 아키텍처 선택 — 하드코딩 최소 확장 (옵션 a)

`InMemoryTransitMasterRepository`(prod에서 `JdbcTransitMasterOverrideRepository
extends UnavailableTransitMasterRepository`가 `loadStations()`를 오버라이드하지
않고 그대로 상속하는 stub)의 `STATIONS` 목록에 14개를 하드코딩 추가했다. 근거:

- `RouteV2Planner`(#2098이 다루는 실제 ITX-청춘 경로 탐색기)는
  `LoadTransitMasterPort`/`Station`을 **전혀 참조하지 않는다**(grep으로 확인).
  station master가 실제로 관여하는 지점은 `RouteSearchController`의 pre-check
  게이트(`loadActiveStation()` — 존재·active 여부만 확인)뿐이고, V2 응답은
  request 원문 문자열을 그대로 echo하지 `Station.nameKo()`를 쓰지 않는다.
- 기존 2역(`station-sangnoksu`/`station-sadang`) 자체가 이미 "ponytail: reuse
  the existing static seed until a real data-pack adapter exists"라는 동일한
  임시 stopgap이다. 14곳 확장은 같은 카테고리를 실데이터로 넓히는 것이지 새
  아키텍처가 아니다.
- 별도 real data-pack adapter(옵션 b) / DB seed+migration(옵션 c) / datapack
  반입(옵션 d)은 AquilaXk/easysubway#2098 트랙의 더 큰 작업이라 이번엔 착수하지 않았다.

## 좌표 등 부가 필드 — 출처·근거

- id·이름·정차순서(=region 내 상대 위치)는 위 실측대로 확정.
- `nameEn`은 국립국어원 로마자 표기법(코레일 역명판과 동일) 표준 변환.
- `region`은 행정구역 기준(가평까지 경기도=수도권, 강촌부터 강원도=강원권) —
  정밀 좌표가 아니라 창작이 아니다.
- **위도·경도는 이 datapack 소스에 없고, 만들어내지 않았다.** `RouteV2Planner`가
  `Station` 좌표를 전혀 참조하지 않음을 확인했으므로(capacity search에 불요)
  `BigDecimal.ZERO`를 명시적 자리표시자로 썼다. `null`을 쓰면
  `TransitMasterService`의 "인근 역 검색"(`distanceMeters()`)이 이 14역에 대해
  `NullPointerException`을 낸다 — `(0,0)`은 한국에서 수백만 km 떨어져 있어 그
  기능이 정상 동작하는 한 우연히 "인근"으로 뜨지 않는다. 실좌표 반입은 AquilaXk/easysubway#2098
  범위다.

## production 완주 증거

production runner에서 **로컬 빌드 이미지**(운영 배포 이미지 identity 검증만
우회하는 디버그 전용 스크립트 사본 사용, 운영 backend 컨테이너는 미접촉·격리
`clone_*` 컨테이너만 생성)로 `tools/ops/verify-production-route-v2-capacity.sh`를
처음부터 끝까지 직접 실행해 **exit 0**을 확인했다:

```
### Production Route V2 capacity evidence
- deployed SHA: `2a804451f8f613eb31b9b214f10468c09bf1bbc4`
- configured limits: session 5/m burst 2; search 10/m burst 3
- profile=normal: PASS, session_requests=5, search_requests=10, unexpected_error_count=0
- profile=burst: PASS, exact 429 + Retry-After + private, no-store
- profile=unavailable: PASS, exact 503 ITX_TIMETABLE_UNAVAILABLE
- HTTP status counts: 200=22,429=2,503=1
- latency: p50=26 p95=220 p99=528 max=528 ms
- backend resource during load: memory_peak=32.88% cpu_peak=63.6%, OOM=false, restart=0
- gateway resource during load: memory_peak=1.98% cpu_peak=0.29%, OOM=false, restart=0
- purge: states=1 sessions=1 nonces=1 duration_ms=1251, budget_ms=600000
- isolated synthetic data cleanup: PASS
- cache: miss=1+, hit=1+
- privacy: undeclared_data_transfer_count=0, sensitive_payload_count=0
- ingress_closed=true
SCRIPT_EXIT=0
```

이 실행에 쓴 로컬 빌드 이미지·runner scratch clone·임시 컨테이너는 모두
정리했다. **실제 production 배포 이미지로 확정 검증하는 것은 이 PR 병합·CD
배포 후 재실행이 필요하다** — 이번 exit 0은 station 데이터 fix 자체가
end-to-end로 유효함을 증명하는 근거다.

## 회귀 처리

`InMemoryTransitMasterRepository`의 역 수·품질 집계에 의존하던 5개 테스트
(관리자 데이터 수집 화면, 데이터 품질 API, 운영기관 접근성 리포트
API/CSV/xlsx, 데이터 수집 배치 API)를 새 실제 수(2→16역, 14→28 수집 건수,
region 정렬 등)에 맞게 갱신했다 — 완화가 아니라 의도된 데이터 변경에 맞춘
golden-count 갱신이다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests "com.easysubway.transit.*" --tests "com.easysubway.route.*"` → BUILD SUCCESSFUL
  - `./gradlew test`(전체 백엔드) → BUILD SUCCESSFUL
  - `bash -n tools/ops/verify-production-route-v2-capacity.sh` → OK
  - `git diff --check` → OK
  - `LC_ALL=C node --test tools/ci/production-route-v2-capacity-evidence-workflow.test.mjs tools/ci/repository-contract.test.mjs` → **pass 221 / fail 0**
  - production runner 직접 실행: **exit 0**(위 sanitized 요약)

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| station_id ↔ 역 이름 ↔ 순서 매핑 | production 격리 클론 | transit_stop_times/trips 실측 + datapack 소스 대조 | corridorSequence 완전 일치 | 검증 완료 |
| capacity evidence 전체 완주 | production self-hosted runner | 로컬 빌드 이미지로 스크립트 직접 실행 | exit 0, 전 profile PASS | PASS |
| 백엔드 전체 테스트 | 로컬 Gradle | `./gradlew test` | BUILD SUCCESSFUL | PASS |
| runner 스크립트 계약 | CI | `node --test` 계약 테스트 2종 | pass 221/fail 0 | PASS |
| 실제 배포 이미지로 재확인 | production self-hosted runner | 이 PR 병합·CD 배포 후 워크플로 재실행 | 병합 후 확인 예정 | 병합 후 확인 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

station master(in-memory seed)만 확장했고 DB migration·route/realtime contract
변경은 없다.

## Route commercialization gate impact

- [ ] route-commercialization-gate.json 영향 없음
- [x] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

이 PR은 capacity evidence(비공개 격리 부하 테스트)가 실제로 완주하도록 하는
station 데이터 확장이며, 공개 상용 경로/ETA claim을 추가하거나 변경하지
않는다. `EASYSUBWAY_ROUTE_V2_INGRESS_ENABLED=false`로 공개 ingress는 여전히
닫혀 있다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] AquilaXk/easysubway#1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

AquilaXk/easysubway-backend#3(capacity evidence)의 station master 블로커를 pilot 범위로 해소했다.
전체 역 데이터 완성(#2098)은 이 PR로 완료되지 않으며, 그 claim을 하지
않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: `InMemoryTransitMasterRepository` station seed 확장(런타임 동작은 station 존재 여부 확장뿐, 기존 로직 무변경)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `InMemoryTransitMasterRepository.java`의 14개
  station 추가 근거(매핑표)와 `BigDecimal.ZERO` 좌표 placeholder 결정 근거
  (RouteV2Planner가 Station 좌표를 참조하지 않는다는 판단이 맞는지), 5개
  회귀 테스트 갱신이 완화가 아니라 실제 데이터 변경 반영인지.

## 리스크

- 좌표가 `(0,0)` placeholder라 "인근 역 검색" 기능에서 이 14역이 정상적으로는
  절대 결과에 나타나지 않는다(한국에서 수백만 km 떨어져 있어 반경 검색에
  걸리지 않음) — 의도된 동작이나, 실좌표 반입 전까지는 이 14역을 "내 주변
  역"으로 찾을 수 없다.
- station의 `dataQualityLevel=LEVEL_1`("정보 확인 중")이라 접근성 시설 정보가
  없다 — capacity search 자체(세션·검색·rate-limit)는 이 정보를 요구하지
  않지만, 실제 공개 시 접근성 정보 보강이 필요하다(#2098 범위).
- 실제 production 배포 이미지로의 최종 확인은 이 PR 병합·CD 배포 후 워크플로
  재실행이 필요하다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * ITX-청춘(경춘선) 파일럿 정차역 14곳이 마스터 데이터에 추가되었습니다.
  * 지역별 역 정보와 접근성·데이터 품질 리포트에 해당 정차역이 반영됩니다.

* **개선 사항**
  * 역 검색 및 지역별 집계 결과가 새 정차역 데이터를 기준으로 제공됩니다.
  * 데이터 수집 건수와 품질 요약, CSV·XLSX 리포트의 역 수가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->