### PR TITLE
[Test] #1988 admin QA matrix 확장 — viewport·text 200%·login 상태·table keyboard

### DIFF
--- a/tools/qa/admin-accessibility-qa.mjs
+++ b/tools/qa/admin-accessibility-qa.mjs
@@ -93,15 +93,29 @@ async function main() {
     loginParity: null,
   };
 
+  const reportPath = path.join(outputDir, "admin-accessibility-qa-report.json");
+  await mkdir(outputDir, { recursive: true });
+  // #1988: 어느 pass가 예외를 던져도 수집분을 보존하도록 report 쓰기를 finally로 감싼다.
+  // 예외 자체는 finally에서 삼키지 않고 그대로 전파돼 exit code로 실패를 표면화한다.
   try {
-    await mkdir(outputDir, { recursive: true });
-    await runJsPass(browser, baseUrl, outputDir, adminUser, adminPassword, operatorUser, operatorPassword, report);
-    await runLoginStatePass(browser, baseUrl, outputDir, report);
-    await runNoJsPass(browser, baseUrl, outputDir, adminUser, adminPassword, operatorUser, operatorPassword, report);
+    try {
+      await runJsPass(browser, baseUrl, outputDir, adminUser, adminPassword, operatorUser, operatorPassword, report);
+      await runLoginStatePass(browser, baseUrl, outputDir, report);
+      await runNoJsPass(browser, baseUrl, outputDir, adminUser, adminPassword, operatorUser, operatorPassword, report);
+    } finally {
+      await browser.close();
+    }
   } finally {
-    await browser.close();
+    finalizeReport(report);
+    await writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`);
   }
+  if (report.blockingViolations.length > 0) {
+    throw new Error(`blocking axe violations: ${JSON.stringify(report.blockingViolations)}`);
+  }
+  console.log(`admin accessibility QA ok: ${reportPath}`);
+}
 
+function finalizeReport(report) {
   const blockingViolations = report.axe.flatMap((entry) =>
     entry.violations
       .filter((violation) => violation.impact === "critical" || violation.impact === "serious")
@@ -127,12 +141,6 @@ async function main() {
     loginParityOk: report.loginParity ? report.loginParity.parity : null,
   };
   report.blockingViolations = blockingViolations;
-  const reportPath = path.join(outputDir, "admin-accessibility-qa-report.json");
-  await writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`);
-  if (blockingViolations.length > 0) {
-    throw new Error(`blocking axe violations: ${JSON.stringify(blockingViolations)}`);
-  }
-  console.log(`admin accessibility QA ok: ${reportPath}`);
 }
 
 async function runJsPass(browser, baseUrl, outputDir, adminUser, adminPassword, operatorUser, operatorPassword, report) {
@@ -260,7 +268,7 @@ async function textScalePass(page, baseUrl, outputDir, report, pages) {
         name,
         viewport: viewport.name,
         factor: TEXT_SCALE_FACTOR,
-        method: "text-only font-size override (px-based admin CSS)",
+        method: "inline font-size ×2 override — 실제 브라우저 텍스트 확대와 다를 수 있는 근사",
         screenshot,
         ...metrics,
       });
@@ -284,13 +292,16 @@ async function runLoginStatePass(browser, baseUrl, outputDir, report) {
 
       await page.fill("input[name=\"username\"]", `qa-nonexistent-${Date.now()}`);
       await page.fill("input[name=\"password\"]", "qa-invalid-credential");
-      const [postResponse] = await Promise.all([
-        page.waitForResponse((response) =>
-          response.url().endsWith(surface.loginPath) && response.request().method() === "POST"),
-        page.click("button[type=\"submit\"]"),
-      ]);
-      const postStatus = postResponse.status();
-      await page.waitForLoadState("networkidle");
+      await page.click("button[type=\"submit\"]");
+      // #1988: 실패 로그인 판정은 POST 응답 가로채기 대신 [role="alert"] 가시화 대기로 한다.
+      // 타임아웃(10s)이면 run을 중단하지 않고 alertVisible=false로 non-blocking 기록한다.
+      let alertVisible = false;
+      try {
+        await page.locator("[role=\"alert\"]").first().waitFor({ state: "visible", timeout: 10000 });
+        alertVisible = true;
+      } catch {
+        alertVisible = false;
+      }
       const warningAlerts = await page.locator("[role=\"alert\"]").count();
       const warningCopy = warningAlerts > 0
         ? (await page.locator("[role=\"alert\"]").first().innerText()).trim()
@@ -298,22 +309,22 @@ async function runLoginStatePass(browser, baseUrl, outputDir, report) {
       const warningShot = path.join(outputDir, `login-${surface.key}-retry-warning.png`);
       await page.screenshot({ path: warningShot, fullPage: true });
 
+      // #1988: RETRY_WARNING copy 일치 여부는 throw 대신 non-blocking 플래그로 기록한다.
+      const retryWarningRendered = Boolean(warningCopy && warningCopy.includes(RETRY_WARNING_COPY));
       const entry = {
         surface: surface.key,
         loginPath: surface.loginPath,
         noneStatus,
         noneAlerts,
         noneScreenshot: noneShot,
-        postStatus,
+        alertVisible,
         warningAlerts,
         warningCopy,
+        retryWarningRendered,
         warningScreenshot: warningShot,
       };
       captured[surface.key] = entry;
       report.loginStates.push(entry);
-      if (!warningCopy || !warningCopy.includes(RETRY_WARNING_COPY)) {
-        throw new Error(`${surface.loginPath} did not render RETRY_WARNING after failed login`);
-      }
     } finally {
       await context.close();
     }
@@ -321,25 +332,42 @@ async function runLoginStatePass(browser, baseUrl, outputDir, report) {
 
   const admin = captured.admin;
   const operator = captured.operator;
-  const statusParity = admin.postStatus === operator.postStatus;
+  // #1988: 한쪽 surface 캡처가 누락되면 parity 계산을 건너뛰고 사유를 기록한다.
+  if (!admin || !operator) {
+    const missing = !admin ? "admin" : "operator";
+    report.loginParity = {
+      parity: false,
+      reason: `login parity 계산 불가: ${missing} surface 캡처 누락`,
+    };
+    return;
+  }
   const noneStatusParity = admin.noneStatus === operator.noneStatus;
   const warningCopyParity = admin.warningCopy === operator.warningCopy;
+  const retryWarningParity = admin.retryWarningRendered === operator.retryWarningRendered;
+  const alertVisibleParity = admin.alertVisible === operator.alertVisible;
   const alertStructureParity = admin.warningAlerts === operator.warningAlerts
     && admin.noneAlerts === operator.noneAlerts;
   report.loginParity = {
-    parity: statusParity && noneStatusParity && warningCopyParity && alertStructureParity,
-    statusParity,
+    parity: noneStatusParity
+      && warningCopyParity
+      && retryWarningParity
+      && alertVisibleParity
+      && alertStructureParity,
     noneStatusParity,
     warningCopyParity,
+    retryWarningParity,
+    alertVisibleParity,
     alertStructureParity,
-    adminPostStatus: admin.postStatus,
-    operatorPostStatus: operator.postStatus,
+    adminRetryWarningRendered: admin.retryWarningRendered,
+    operatorRetryWarningRendered: operator.retryWarningRendered,
     adminWarningCopy: admin.warningCopy,
     operatorWarningCopy: operator.warningCopy,
   };
 }
 
 async function keyboardSmoke(page, baseUrl, report) {
+  // #1988: 게이트 측정 상태였던 mobile-768(768×900)로 명시 고정해 호출 순서 의존을 제거한다.
+  await page.setViewportSize(VIEWPORTS.find((viewport) => viewport.name === "mobile-768"));
   const response = await page.goto(`${baseUrl}/admin/dashboard/page`, { waitUntil: "networkidle" });
   await assertOk(page, "/admin/dashboard/page", response);
   await page.keyboard.press(process.platform === "darwin" ? "Meta+K" : "Control+K");
@@ -426,6 +454,8 @@ async function keyboardTableCheck(page, baseUrl, report) {
 }
 
 async function captureAxTree(page, outputDir, report) {
+  // #1988: AX tree 캡처도 게이트 측정 상태 mobile-768(768×900)로 고정한다.
+  await page.setViewportSize(VIEWPORTS.find((viewport) => viewport.name === "mobile-768"));
   const session = await page.context().newCDPSession(page);
   const tree = await session.send("Accessibility.getFullAXTree");
   const axPath = path.join(outputDir, "dashboard-ax-tree.json");

--- a/tools/qa/admin-accessibility-qa.mjs
+++ b/tools/qa/admin-accessibility-qa.mjs
@@ -9,6 +9,8 @@ export const VIEWPORTS = [
   { name: "desktop-1280", width: 1280, height: 900 },
   { name: "tablet-1024", width: 1024, height: 900 },
   { name: "mobile-768", width: 768, height: 900 },
+  { name: "desktop-1440", width: 1440, height: 900 },
+  { name: "mobile-390", width: 390, height: 844 },
 ];
 
 export const ADMIN_PAGES = [
@@ -34,6 +36,26 @@ export const OPERATOR_PAGES = [
   ["/operator/route-feedback-report/page", "operator-route-feedback"],
   ["/operator/push-notification-report/page", "operator-push"],
 ];
+
+// #1988: text 200% reflow/clipping evidence는 대표 5화면에서만 수집한다.
+export const TEXT_SCALE_FACTOR = 2;
+export const TEXT_SCALE_VIEWPORTS = ["desktop-1440", "mobile-390"];
+export const ADMIN_TEXT_SCALE_PAGES = [
+  ["/admin/dashboard/page", "dashboard"],
+  ["/admin/stations/page", "stations"],
+  ["/admin/stations/station-sangnoksu/page", "station-hub"],
+  ["/admin/datapack/pipeline/page", "datapack-pipeline"],
+];
+export const OPERATOR_TEXT_SCALE_PAGES = [
+  ["/operator/accessibility-report/page", "operator-accessibility"],
+];
+
+// #1988: admin·operator 로그인 공개 상태 parity 캡처 대상.
+export const LOGIN_SURFACES = [
+  { key: "admin", loginPath: "/admin/login" },
+  { key: "operator", loginPath: "/operator/login" },
+];
+export const RETRY_WARNING_COPY = "아이디 또는 비밀번호를 확인하고 다시 시도해 주세요.";
 
 export const MANUAL_REQUIRED = [
   "VoiceOver reading flow for dashboard, reports, station hub, datapack pipeline, and audits",
@@ -66,11 +88,15 @@ async function main() {
     noJs: [],
     charts: [],
     axTree: [],
+    textScale: [],
+    loginStates: [],
+    loginParity: null,
   };
 
   try {
     await mkdir(outputDir, { recursive: true });
     await runJsPass(browser, baseUrl, outputDir, adminUser, adminPassword, operatorUser, operatorPassword, report);
+    await runLoginStatePass(browser, baseUrl, outputDir, report);
     await runNoJsPass(browser, baseUrl, outputDir, adminUser, adminPassword, operatorUser, operatorPassword, report);
   } finally {
     await browser.close();
@@ -95,6 +121,10 @@ async function main() {
     noJsPages: report.noJs.length,
     chartChecks: report.charts.length,
     keyboardChecks: report.keyboard.length,
+    textScaleChecks: report.textScale.length,
+    textScaleReflowFailures: report.textScale.filter((entry) => !entry.noHorizontalScroll).length,
+    loginStateCaptures: report.loginStates.length,
+    loginParityOk: report.loginParity ? report.loginParity.parity : null,
   };
   report.blockingViolations = blockingViolations;
   const reportPath = path.join(outputDir, "admin-accessibility-qa-report.json");
@@ -117,6 +147,8 @@ async function runJsPass(browser, baseUrl, outputDir, adminUser, adminPassword, 
   }
   await keyboardSmoke(page, baseUrl, report);
   await captureAxTree(page, outputDir, report);
+  await keyboardTableCheck(page, baseUrl, report);
+  await textScalePass(page, baseUrl, outputDir, report, ADMIN_TEXT_SCALE_PAGES);
   await context.close();
 
   const operatorContext = await browser.newContext({ viewport: VIEWPORTS[0] });
@@ -128,6 +160,7 @@ async function runJsPass(browser, baseUrl, outputDir, adminUser, adminPassword, 
       await auditPage(operatorPage, baseUrl, outputDir, url, `${name}-${viewport.name}`, report);
     }
   }
+  await textScalePass(operatorPage, baseUrl, outputDir, report, OPERATOR_TEXT_SCALE_PAGES);
   await operatorContext.close();
 }
 
@@ -185,6 +218,127 @@ async function auditPage(page, baseUrl, outputDir, url, name, report) {
   }
 }
 
+// #1988: text-only 200%.
+// admin-v3 CSS는 전부 px 기반 font-size라 CDP Page.setFontSizes(기본 폰트 크기 최소값)로는
+// 명시적 px 텍스트가 스케일되지 않는다. 동등한 text-only 방식으로 모든 요소의 computed
+// font-size를 factor배로 인라인 override해(레이아웃 box는 그대로 유지) reflow/clipping을 압박한다.
+async function textScalePass(page, baseUrl, outputDir, report, pages) {
+  const viewports = TEXT_SCALE_VIEWPORTS.map((name) => VIEWPORTS.find((viewport) => viewport.name === name));
+  for (const viewport of viewports) {
+    await page.setViewportSize(viewport);
+    for (const [url, name] of pages) {
+      const response = await page.goto(`${baseUrl}${url}`, { waitUntil: "networkidle" });
+      await assertOk(page, url, response);
+      const metrics = await page.evaluate((factor) => {
+        const elements = Array.from(document.querySelectorAll("*"));
+        const originals = elements.map((element) => parseFloat(getComputedStyle(element).fontSize) || 0);
+        elements.forEach((element, index) => {
+          if (originals[index] > 0) {
+            element.style.fontSize = `${originals[index] * factor}px`;
+          }
+        });
+        const doc = document.documentElement;
+        const clippedContainers = elements.filter((element) => {
+          const style = getComputedStyle(element);
+          const hiddenX = style.overflowX === "hidden" || style.overflowX === "clip";
+          const hiddenY = style.overflowY === "hidden" || style.overflowY === "clip";
+          const overflowsX = hiddenX && element.scrollWidth > element.clientWidth + 1;
+          const overflowsY = hiddenY && element.scrollHeight > element.clientHeight + 1;
+          return overflowsX || overflowsY;
+        }).length;
+        return {
+          scrollWidth: doc.scrollWidth,
+          clientWidth: doc.clientWidth,
+          noHorizontalScroll: doc.scrollWidth <= doc.clientWidth + 1,
+          clippedContainers,
+        };
+      }, TEXT_SCALE_FACTOR);
+      const screenshot = path.join(outputDir, `text-scale-200-${name}-${viewport.name}.png`);
+      await page.screenshot({ path: screenshot, fullPage: true });
+      report.textScale.push({
+        url,
+        name,
+        viewport: viewport.name,
+        factor: TEXT_SCALE_FACTOR,
+        method: "text-only font-size override (px-based admin CSS)",
+        screenshot,
+        ...metrics,
+      });
+    }
+  }
+}
+
+// #1988: 로그인 공개 상태(NONE·RETRY_WARNING)를 admin·operator 각각 캡처하고 parity를 검사한다.
+// 실제 계정 잠금을 유발하지 않도록 존재하지 않는 사용자명으로 실패를 만든다.
+async function runLoginStatePass(browser, baseUrl, outputDir, report) {
+  const captured = {};
+  for (const surface of LOGIN_SURFACES) {
+    const context = await browser.newContext({ viewport: VIEWPORTS[0] });
+    const page = await context.newPage();
+    try {
+      const noneResponse = await page.goto(`${baseUrl}${surface.loginPath}`, { waitUntil: "domcontentloaded" });
+      const noneStatus = noneResponse ? noneResponse.status() : 0;
+      const noneAlerts = await page.locator("[role=\"alert\"]").count();
+      const noneShot = path.join(outputDir, `login-${surface.key}-none.png`);
+      await page.screenshot({ path: noneShot, fullPage: true });
+
+      await page.fill("input[name=\"username\"]", `qa-nonexistent-${Date.now()}`);
+      await page.fill("input[name=\"password\"]", "qa-invalid-credential");
+      const [postResponse] = await Promise.all([
+        page.waitForResponse((response) =>
+          response.url().endsWith(surface.loginPath) && response.request().method() === "POST"),
+        page.click("button[type=\"submit\"]"),
+      ]);
+      const postStatus = postResponse.status();
+      await page.waitForLoadState("networkidle");
+      const warningAlerts = await page.locator("[role=\"alert\"]").count();
+      const warningCopy = warningAlerts > 0
+        ? (await page.locator("[role=\"alert\"]").first().innerText()).trim()
+        : null;
+      const warningShot = path.join(outputDir, `login-${surface.key}-retry-warning.png`);
+      await page.screenshot({ path: warningShot, fullPage: true });
+
+      const entry = {
+        surface: surface.key,
+        loginPath: surface.loginPath,
+        noneStatus,
+        noneAlerts,
+        noneScreenshot: noneShot,
+        postStatus,
+        warningAlerts,
+        warningCopy,
+        warningScreenshot: warningShot,
+      };
+      captured[surface.key] = entry;
+      report.loginStates.push(entry);
+      if (!warningCopy || !warningCopy.includes(RETRY_WARNING_COPY)) {
+        throw new Error(`${surface.loginPath} did not render RETRY_WARNING after failed login`);
+      }
+    } finally {
+      await context.close();
+    }
+  }
+
+  const admin = captured.admin;
+  const operator = captured.operator;
+  const statusParity = admin.postStatus === operator.postStatus;
+  const noneStatusParity = admin.noneStatus === operator.noneStatus;
+  const warningCopyParity = admin.warningCopy === operator.warningCopy;
+  const alertStructureParity = admin.warningAlerts === operator.warningAlerts
+    && admin.noneAlerts === operator.noneAlerts;
+  report.loginParity = {
+    parity: statusParity && noneStatusParity && warningCopyParity && alertStructureParity,
+    statusParity,
+    noneStatusParity,
+    warningCopyParity,
+    alertStructureParity,
+    adminPostStatus: admin.postStatus,
+    operatorPostStatus: operator.postStatus,
+    adminWarningCopy: admin.warningCopy,
+    operatorWarningCopy: operator.warningCopy,
+  };
+}
+
 async function keyboardSmoke(page, baseUrl, report) {
   const response = await page.goto(`${baseUrl}/admin/dashboard/page`, { waitUntil: "networkidle" });
   await assertOk(page, "/admin/dashboard/page", response);
@@ -203,6 +357,72 @@ async function keyboardSmoke(page, baseUrl, report) {
   if (alertExpanded !== "true") {
     throw new Error("alert center did not expose aria-expanded=true");
   }
+}
+
+// #1988: admin-table-scroll wrapper의 키보드 접근성.
+// 좁은 viewport로 표를 가로 overflow시킨 뒤 Tab focus·ArrowRight/ArrowLeft scrollLeft 변화·
+// focus-visible outline을 검사한다.
+async function keyboardTableCheck(page, baseUrl, report) {
+  await page.setViewportSize(VIEWPORTS.find((viewport) => viewport.name === "mobile-390"));
+  const response = await page.goto(`${baseUrl}/admin/stations/page`, { waitUntil: "networkidle" });
+  await assertOk(page, "/admin/stations/page", response);
+
+  let tabFocusable = false;
+  for (let index = 0; index < 60 && !tabFocusable; index += 1) {
+    await page.keyboard.press("Tab");
+    tabFocusable = await page.evaluate(() =>
+      Boolean(document.activeElement && document.activeElement.classList.contains("admin-table-scroll")));
+  }
+
+  const focusState = await page.evaluate(() => {
+    const element = document.querySelector(".admin-table-scroll");
+    if (!element) {
+      return null;
+    }
+    const style = getComputedStyle(element);
+    const focused = document.activeElement === element;
+    return {
+      maxScrollLeft: element.scrollWidth - element.clientWidth,
+      startScrollLeft: element.scrollLeft,
+      focused,
+      outlineStyle: focused ? style.outlineStyle : null,
+      outlineWidth: focused ? style.outlineWidth : null,
+    };
+  });
+
+  // Chromium 키보드 스크롤은 smooth 애니메이션이라 press 직후 scrollLeft가 아직 0일 수 있다. 정착 대기.
+  await page.keyboard.press("ArrowRight");
+  await page.keyboard.press("ArrowRight");
+  await page.waitForTimeout(300);
+  const afterRight = await page.evaluate(() => {
+    const element = document.querySelector(".admin-table-scroll");
+    return element ? element.scrollLeft : null;
+  });
+  await page.keyboard.press("ArrowLeft");
+  await page.waitForTimeout(300);
+  const afterLeft = await page.evaluate(() => {
+    const element = document.querySelector(".admin-table-scroll");
+    return element ? element.scrollLeft : null;
+  });
+
+  const startScrollLeft = focusState ? focusState.startScrollLeft : null;
+  const outlineVisible = Boolean(
+    focusState
+    && focusState.outlineStyle
+    && focusState.outlineStyle !== "none"
+    && focusState.outlineWidth
+    && parseFloat(focusState.outlineWidth) > 0,
+  );
+  report.keyboard.push({
+    check: "admin-table-scroll-keyboard",
+    tabFocusable,
+    maxScrollLeft: focusState ? focusState.maxScrollLeft : null,
+    scrolledRight: afterRight != null && startScrollLeft != null && afterRight > startScrollLeft,
+    scrolledBackLeft: afterLeft != null && afterRight != null && afterLeft < afterRight,
+    outlineStyle: focusState ? focusState.outlineStyle : null,
+    outlineWidth: focusState ? focusState.outlineWidth : null,
+    outlineVisible,
+  });
 }
 
 async function captureAxTree(page, outputDir, report) {

--- a/tools/qa/admin-accessibility-qa.mjs
+++ b/tools/qa/admin-accessibility-qa.mjs
@@ -126,6 +126,32 @@ function finalizeReport(report) {
         nodes: violation.nodes.length,
       })),
   );
+  // #1988: table keyboard 검사가 전부 false여도 evidence만 남기고 실행은 성공하던 허위 green을 막는다.
+  // axe blocking과 같은 패턴으로 위반 항목에 편입해 exit code로 실패를 표면화한다(report는 이미 기록됨).
+  const tableKeyboard = report.keyboard.find((entry) => entry.check === "admin-table-scroll-keyboard");
+  if (tableKeyboard
+    && !(tableKeyboard.tabFocusable
+      && tableKeyboard.scrolledRight
+      && tableKeyboard.scrolledBackLeft
+      && tableKeyboard.outlineVisible)) {
+    blockingViolations.push({
+      page: "/admin/stations/page",
+      id: "admin-table-scroll-keyboard",
+      impact: "serious",
+      nodes: 0,
+    });
+  }
+  // #1988: 로그인 공개 상태 기대치 미충족(허위 parity의 근원)도 위반으로 편입한다.
+  if (report.loginParity
+    && (report.loginParity.adminExpectedStateOk === false
+      || report.loginParity.operatorExpectedStateOk === false)) {
+    blockingViolations.push({
+      page: "login-parity",
+      id: "login-public-state-expectation",
+      impact: "serious",
+      nodes: 0,
+    });
+  }
   const criticalViolations = blockingViolations.filter((violation) => violation.impact === "critical");
   const seriousViolations = blockingViolations.filter((violation) => violation.impact === "serious");
   report.summary = {
@@ -137,6 +163,9 @@ function finalizeReport(report) {
     keyboardChecks: report.keyboard.length,
     textScaleChecks: report.textScale.length,
     textScaleReflowFailures: report.textScale.filter((entry) => !entry.noHorizontalScroll).length,
+    // #1988: 수평 스크롤만 세면 overflow:hidden/clip으로 잘린 컨테이너 증거가 사라진다.
+    // 각 entry의 clippedContainers를 합산해 clipping 규모를 summary에 보존한다.
+    textScaleClippedContainers: report.textScale.reduce((sum, entry) => sum + (entry.clippedContainers || 0), 0),
     loginStateCaptures: report.loginStates.length,
     loginParityOk: report.loginParity ? report.loginParity.parity : null,
   };
@@ -276,6 +305,16 @@ async function textScalePass(page, baseUrl, outputDir, report, pages) {
   }
 }
 
+// #1988: 각 surface가 기대 공개 상태(NONE 2xx·alert 없음, RETRY_WARNING alert 가시·copy 일치)를
+// 충족하는지 판정한다. parity 비교가 "동일하게 실패"를 green으로 통과시키는 것을 막는다.
+function loginSurfaceMeetsExpectedState(entry) {
+  return entry.noneStatus >= 200
+    && entry.noneStatus < 300
+    && entry.noneAlerts === 0
+    && entry.alertVisible === true
+    && entry.retryWarningRendered === true;
+}
+
 // #1988: 로그인 공개 상태(NONE·RETRY_WARNING)를 admin·operator 각각 캡처하고 parity를 검사한다.
 // 실제 계정 잠금을 유발하지 않도록 존재하지 않는 사용자명으로 실패를 만든다.
 async function runLoginStatePass(browser, baseUrl, outputDir, report) {
@@ -347,17 +386,25 @@ async function runLoginStatePass(browser, baseUrl, outputDir, report) {
   const alertVisibleParity = admin.alertVisible === operator.alertVisible;
   const alertStructureParity = admin.warningAlerts === operator.warningAlerts
     && admin.noneAlerts === operator.noneAlerts;
+  // #1988: 양쪽 surface가 동일하게 실패해도(alert 없음·copy null) 동등성 비교가 모두 참이라
+  // parity=true가 되는 허위 green을 막기 위해, 각 surface가 기대 공개 상태를 충족하는지도 함께 요구한다.
+  const adminExpectedStateOk = loginSurfaceMeetsExpectedState(admin);
+  const operatorExpectedStateOk = loginSurfaceMeetsExpectedState(operator);
   report.loginParity = {
     parity: noneStatusParity
       && warningCopyParity
       && retryWarningParity
       && alertVisibleParity
-      && alertStructureParity,
+      && alertStructureParity
+      && adminExpectedStateOk
+      && operatorExpectedStateOk,
     noneStatusParity,
     warningCopyParity,
     retryWarningParity,
     alertVisibleParity,
     alertStructureParity,
+    adminExpectedStateOk,
+    operatorExpectedStateOk,
     adminRetryWarningRendered: admin.retryWarningRendered,
     operatorRetryWarningRendered: operator.retryWarningRendered,
     adminWarningCopy: admin.warningCopy,

--- a/tools/qa/admin-accessibility-qa.test.mjs
+++ b/tools/qa/admin-accessibility-qa.test.mjs
@@ -15,9 +15,47 @@ test("admin accessibility QA script covers Phase 3 required routes and viewports
   ]) {
     assert.match(source, new RegExp(expected.replaceAll("/", "\\/")));
   }
-  for (const expected of ["desktop-1280", "tablet-1024", "mobile-768"]) {
+  for (const expected of ["desktop-1280", "tablet-1024", "mobile-768", "desktop-1440", "mobile-390"]) {
     assert.match(source, new RegExp(expected));
   }
+});
+
+test("admin accessibility QA script captures text 200 percent reflow evidence on 1440 and 390", () => {
+  assert.match(source, /TEXT_SCALE_FACTOR = 2/);
+  assert.match(source, /TEXT_SCALE_VIEWPORTS = \["desktop-1440", "mobile-390"\]/);
+  for (const expected of [
+    "/admin/dashboard/page",
+    "/admin/stations/page",
+    "/admin/stations/station-sangnoksu/page",
+    "/admin/datapack/pipeline/page",
+    "/operator/accessibility-report/page",
+  ]) {
+    assert.match(source, new RegExp(expected.replaceAll("/", "\\/")));
+  }
+  assert.match(source, /report\.textScale\.push/);
+  assert.match(source, /noHorizontalScroll: doc\.scrollWidth <= doc\.clientWidth/);
+  assert.match(source, /clippedContainers/);
+});
+
+test("admin accessibility QA script captures login NONE and RETRY_WARNING public parity", () => {
+  assert.match(source, /runLoginStatePass/);
+  assert.match(source, /qa-nonexistent-/);
+  assert.match(source, /login-\$\{surface\.key\}-none\.png/);
+  assert.match(source, /login-\$\{surface\.key\}-retry-warning\.png/);
+  assert.match(source, /RETRY_WARNING_COPY/);
+  assert.match(source, /report\.loginParity = \{/);
+  assert.match(source, /warningCopyParity/);
+  assert.match(source, /did not render RETRY_WARNING after failed login/);
+});
+
+test("admin accessibility QA script verifies admin-table-scroll keyboard and focus outline", () => {
+  assert.match(source, /keyboardTableCheck/);
+  assert.match(source, /admin-table-scroll/);
+  assert.match(source, /scrolledRight/);
+  assert.match(source, /scrolledBackLeft/);
+  assert.match(source, /outlineVisible/);
+  assert.match(source, /ArrowRight/);
+  assert.match(source, /ArrowLeft/);
 });
 
 test("admin accessibility QA script records manual-only screen reader and contrast work", () => {

--- a/tools/qa/admin-accessibility-qa.test.mjs
+++ b/tools/qa/admin-accessibility-qa.test.mjs
@@ -35,6 +35,10 @@ test("admin accessibility QA script captures text 200 percent reflow evidence on
   assert.match(source, /report\.textScale\.push/);
   assert.match(source, /noHorizontalScroll: doc\.scrollWidth <= doc\.clientWidth/);
   assert.match(source, /clippedContainers/);
+  // #1988: pass가 실제로 호출되는지, clipping 집계가 summary에 보존되는지 계약으로 고정한다.
+  assert.match(source, /await textScalePass\(page, baseUrl, outputDir, report, ADMIN_TEXT_SCALE_PAGES\)/);
+  assert.match(source, /await textScalePass\(operatorPage, baseUrl, outputDir, report, OPERATOR_TEXT_SCALE_PAGES\)/);
+  assert.match(source, /textScaleClippedContainers: report\.textScale\.reduce/);
 });
 
 test("admin accessibility QA script captures login NONE and RETRY_WARNING public parity", () => {
@@ -49,6 +53,17 @@ test("admin accessibility QA script captures login NONE and RETRY_WARNING public
   assert.match(source, /waitFor\(\{ state: "visible", timeout: 10000 \}\)/);
   assert.match(source, /retryWarningRendered/);
   assert.match(source, /login parity 계산 불가/);
+  // #1988: pass가 실제로 호출되고, 양쪽 동일 실패가 parity를 green으로 통과시키지 않도록
+  // 각 surface 기대 상태 충족을 parity에 포함하는 계약을 고정한다.
+  assert.match(source, /await runLoginStatePass\(browser, baseUrl, outputDir, report\)/);
+  assert.match(source, /function loginSurfaceMeetsExpectedState\(entry\)/);
+  assert.match(source, /entry\.noneStatus >= 200/);
+  assert.match(source, /entry\.noneAlerts === 0/);
+  assert.match(source, /entry\.alertVisible === true/);
+  assert.match(source, /entry\.retryWarningRendered === true/);
+  assert.match(source, /const adminExpectedStateOk = loginSurfaceMeetsExpectedState\(admin\)/);
+  assert.match(source, /const operatorExpectedStateOk = loginSurfaceMeetsExpectedState\(operator\)/);
+  assert.match(source, /&& adminExpectedStateOk\s*\n\s*&& operatorExpectedStateOk/);
 });
 
 test("admin accessibility QA script verifies admin-table-scroll keyboard and focus outline", () => {
@@ -59,6 +74,11 @@ test("admin accessibility QA script verifies admin-table-scroll keyboard and foc
   assert.match(source, /outlineVisible/);
   assert.match(source, /ArrowRight/);
   assert.match(source, /ArrowLeft/);
+  // #1988: pass가 실제로 호출되고, 검사 실패가 blocking 위반으로 표면화되는 계약을 고정한다.
+  assert.match(source, /await keyboardTableCheck\(page, baseUrl, report\)/);
+  assert.match(source, /entry\.check === "admin-table-scroll-keyboard"/);
+  assert.match(source, /id: "admin-table-scroll-keyboard"/);
+  assert.match(source, /id: "login-public-state-expectation"/);
 });
 
 test("admin accessibility QA script records manual-only screen reader and contrast work", () => {

--- a/tools/qa/admin-accessibility-qa.test.mjs
+++ b/tools/qa/admin-accessibility-qa.test.mjs
@@ -45,7 +45,10 @@ test("admin accessibility QA script captures login NONE and RETRY_WARNING public
   assert.match(source, /RETRY_WARNING_COPY/);
   assert.match(source, /report\.loginParity = \{/);
   assert.match(source, /warningCopyParity/);
-  assert.match(source, /did not render RETRY_WARNING after failed login/);
+  // #1988: 실패 로그인은 [role="alert"] 가시화 대기로 판정하고, copy 불일치는 non-blocking 플래그로 기록한다.
+  assert.match(source, /waitFor\(\{ state: "visible", timeout: 10000 \}\)/);
+  assert.match(source, /retryWarningRendered/);
+  assert.match(source, /login parity 계산 불가/);
 });
 
 test("admin accessibility QA script verifies admin-table-scroll keyboard and focus outline", () => {


### PR DESCRIPTION
## 관련 이슈

Refs #1988

## 작업 배경

#1988(관리자 v5 회귀 게이트)는 최종 evidence로 확장된 viewport 매트릭스, text 200% reflow/clipping, 로그인 공개 상태(NONE·RETRY_WARNING) parity, 데이터 표 키보드 접근성을 요구한다. 기존 QA 하네스 `tools/qa/admin-accessibility-qa.mjs`(Playwright+axe)는 1280/1024/768 3개 viewport, JS/no-JS pass, keyboard smoke만 다뤄 이 요구를 충족하지 못했다. 이 PR은 evidence 산출을 자동화할 수 있도록 하네스 자체를 확장한다. evidence 산출물 생성·이슈 갱신은 후속 단계다.

## 작업 내용

- viewport 매트릭스에 `desktop-1440`(1440×900)과 `mobile-390`(390×844)을 추가했다(기존 3개 유지, 기존 index 참조 불변).
- text-only 200% 검증(`textScale` 섹션)을 추가했다. admin-v3 CSS가 전부 px 기반 font-size라 CDP `Page.setFontSizes`(기본 폰트 최소값)로는 명시 px 텍스트가 스케일되지 않으므로, 동등한 text-only 방식으로 모든 요소의 computed font-size를 2배로 인라인 override(레이아웃 box는 유지)한다. 대표 5화면(dashboard·stations·station-hub·datapack-pipeline·operator-accessibility)을 1440·390에서 캡처하고 reflow(`documentElement.scrollWidth <= clientWidth`)와 주요 컨테이너 clipping 수를 axe와 분리해 기록한다.
- 로그인 공개 상태 캡처(`loginStates`·`loginParity`)를 추가했다. admin·operator 각각 NONE(초기)과 RETRY_WARNING(존재하지 않는 사용자명으로 실패 1회 제출 후, 실제 계정 잠금 없음)을 캡처하고, 두 화면의 public 응답 parity(동일 status·동일 안내 문구 구조)를 검사한다.
- 키보드 검증을 확장했다. admin stations 목록에서 `.admin-table-scroll` wrapper가 Tab으로 focus되는지, ArrowRight/ArrowLeft로 `scrollLeft`가 변하는지(Chromium smooth scroll 정착 대기 포함), focus 시 visible focus outline이 있는지를 기존 keyboard 배열에 기록한다.
- `admin-accessibility-qa.test.mjs` 계약을 확장했다. 기존 1280/1024/768 assertion을 유지하면서 1440·390, textScale, login 상태·parity, table keyboard 검사를 계약에 포함시켰다.
- `.github/workflows/ci.yml`의 trigger·required check 이름·필수성과 `admin-qa-gates` job은 변경하지 않았다.

backend identity-state parity matrix(#1988의 unknown·known+wrong·account-locked·disabled·expired 5개 상태가 동일 public status·redirect·body·RETRY_WARNING을 반환)는 이미 `LoginNoticeSecurityTest.identityFailuresShareOneShotPublicResponse`(FailureKind = UNKNOWN·WRONG_PASSWORD·LOCKED·DISABLED·PASSWORD_EXPIRED × admin/operator surface)가 자동화 backend 테스트로 커버하고 있어 신규 테스트를 추가하지 않고 green을 확인했다.

## 검증

- 실행한 명령과 결과:
  - `npm ci --prefix tools/qa` → 정상(3 packages, 0 vulnerabilities).
  - `npm test --prefix tools/qa` → 7 tests pass / 0 fail.
  - `LC_ALL=C.UTF-8 node --test tools/ci/repository-contract.test.mjs` → 217 tests pass / 0 fail(tools/qa 가드 포함).
  - `backend/gradlew test --tests 'com.easysubway.common.security.LoginNoticeSecurityTest'` → BUILD SUCCESSFUL(5개 identity 상태 × 2 surface parity green).
  - 로컬 라이브 스모크: backend dev profile(H2, port 18080) 부팅 후 확장 하네스의 로그인·audit·textScale·table keyboard·login 상태 경로를 축소 구동해 실제 캡처가 생성되는 것을 확인.

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| QA 계약 테스트 | tools/qa | `npm test --prefix tools/qa` | 로그: 7 tests pass | 통과 |
| repository-contract 가드 | tools/ci | `LC_ALL=C.UTF-8 node --test tools/ci/repository-contract.test.mjs` | 로그: 217 tests pass | 통과 |
| backend identity-state parity | backend | `gradlew test --tests LoginNoticeSecurityTest` | 로그: BUILD SUCCESSFUL | 통과(기존 테스트) |
| viewport·textScale·login·table keyboard 라이브 스모크 | tools/qa | dev profile(H2) 부팅 후 축소 구동, 로컬 캡처 11장 생성(로컬 전용 `/private/tmp` scratchpad, 커밋 안 함): dashboard-{desktop-1280,tablet-1024,mobile-768,desktop-1440,mobile-390}.png, text-scale-200-dashboard-{desktop-1440,mobile-390}.png, login-{admin,operator}-{none,retry-warning}.png | keyboard: tabFocusable=true·scrolledRight=true·scrolledBackLeft=true·outline 3px solid, loginParity: status 302/302·warning copy 동일, textScale: 1440·390 noHorizontalScroll=true·clipping 0 | 통과 |
| 최종 evidence bundle | tools/qa | 전체 admin 13·operator 5 페이지 × 5 viewport 완주 | 미첨부 — seed 전제가 필요한 전체 완주는 merge 후 main에서 evidence bundle로 생성 예정(이 PR은 하네스 확장만 다룸) | 후속 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [ ] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [ ] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: text-only 200%를 CDP `Page.setFontSizes` 대신 computed font-size 2배 인라인 override로 구현한 이유(admin-v3 CSS가 px 기반이라 CDP 방식은 no-op)와, table keyboard 검사가 Chromium smooth scroll 정착을 위해 press 후 대기하는 점.
- 이 PR은 하네스 확장만 다루며, `.github/workflows/ci.yml`의 trigger·required check·`admin-qa-gates` job은 변경하지 않았다.

## 리스크

- 라이브 스모크는 dev profile H2에서 축소 경로만 구동했다. seed 데이터가 필요한 전체 admin/operator 페이지 완주와 최종 evidence bundle 생성은 merge 후 main에서 수행한다.
- text 200%·login 상태·table keyboard 검사는 evidence 기록용으로 report JSON에 남기며 axe blocking 게이트와 분리돼 있다. login 상태에서 RETRY_WARNING이 캡처되지 않으면 실패 처리해 evidence 무결성을 보장한다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **접근성 개선**
  * 텍스트 200% 리플로우/클리핑 근거를 추가로 수집해 점검 정확도를 높였습니다.
  * 점검 대상 화면 크기를 데스크톱 1440px·모바일 390px까지 확장했습니다.
  * 모바일 표 영역의 키보드 포커스 이동, 포커스 표시, 가로 스크롤 동작을 확인합니다.
* **로그인 상태 점검**
  * 관리자·운영자 로그인 화면의 공개 상태 패리티와 경고 문구 포함 여부를 함께 비교합니다.
  * 예외가 발생해도 결과가 보고서에 저장되도록 했습니다.
* **QA 및 리포트**
  * 텍스트 확대·표 키보드·로그인 비교 결과 항목을 보고서에 반영하고 검증을 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->