### PR TITLE
[Fix] #2288 활성 세그먼트 링크 대비 AA 정합 — accent-ink 토큰

### DIFF
--- a/backend/src/main/resources/static/css/admin-tokens.css
+++ b/backend/src/main/resources/static/css/admin-tokens.css
@@ -14,6 +14,8 @@
 	/* 브랜드 액센트 1계열 + 의미 상태색 */
 	--admin-accent: #006FD6;
 	--admin-accent-soft: rgba(0, 111, 214, 0.08);
+	/* accent-soft 배경 위 텍스트용 어둠 파생(#2288): hue 유지, accent-soft 렌더 배경(#e2edf6) 위 4.5:1 이상 AA 충족 */
+	--admin-accent-ink: color-mix(in srgb, var(--admin-accent) 90%, #000);
 	--admin-sidebar-bg: #FFFFFF;
 	--admin-sidebar-accent: #F6F8F9;
 	--admin-primary: #006FD6;

--- a/backend/src/main/resources/static/css/admin-v3.css
+++ b/backend/src/main/resources/static/css/admin-v3.css
@@ -2271,7 +2271,7 @@ body.admin-v3 {
 .trend-periods a.is-active {
 	border-color: var(--admin-accent);
 	background: var(--admin-accent-soft);
-	color: var(--admin-accent);
+	color: var(--admin-accent-ink);
 	font-weight: var(--admin-w-strong);
 }
 


### PR DESCRIPTION
## 관련 이슈

close #2288

Refs #1988

## 작업 배경

- #1988 최종 라이브 axe 스윕(main `466a1855`)에서 color-contrast serious 15건이 남아 있었다: dashboard·routes/searches·routes/feedback 3페이지 × 5 viewport.
- 원인은 활성 추이 기간 선택 링크(`.trend-periods a.is-active`, `aria-current="true"`)가 전경 `--admin-accent`(#006FD6)와 배경 `--admin-accent-soft`(흰 배경 위 렌더 결과 #e2edf6)를 함께 써 대비 4.16:1로 WCAG AA 4.5:1을 미달한 것이다.
- 이 요소는 dashboard(추이 fragment), routes/searches, routes/feedback 세 화면에 공통으로 렌더되어 3페이지 × 5 viewport = 15건으로 계상됐다.
- #2071~#2076 스타일 작업이 유발한 것이 아닌 pre-existing이며, accent 색의 제한적 사용 원칙(#1979)과 무채색·기존 토큰 체계는 유지한다.

## 작업 내용

- `admin-tokens.css`에 accent hue를 유지한 어둠 파생 토큰 `--admin-accent-ink`를 추가했다: `color-mix(in srgb, var(--admin-accent) 90%, #000)`(렌더 색 #0064c1). 기존 `--admin-primary-hover`의 color-mix 관용을 그대로 따른다.
- `.trend-periods a.is-active`의 전경만 `--admin-accent` → `--admin-accent-ink`로 교체했다. 배경(`--admin-accent-soft`)·보더·다른 accent 사용처는 불변이다.
- 대비 미달 조합의 전경만 조정하는 최소 변경으로, accent 색 체계 재설계나 세그먼트 컴포넌트 구조 변경은 하지 않았다.
- operator CSS(`operator-v3.css`)에는 동일 패턴(accent-soft 배경 + accent 전경 활성 링크)이 없어 변경 대상이 아니다(실측 확인).

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.admin.web.AdminDesignGuardTest` → BUILD SUCCESSFUL(금지 색·box-shadow·border-radius 가드 통과, 신규 토큰은 color-mix라 리터럴 hex 미추가).
  - `LC_ALL=C.UTF-8 node --test tools/ci/repository-contract.test.mjs` → pass 217 / fail 0.
  - 라이브 axe 재스윕: backend dev/H2 부팅(임의 포트) 후 main의 `tools/qa/admin-accessibility-qa.mjs` 실행 → `criticalAxeViolations: 0`, `seriousAxeViolations: 0`, `blockingViolations: []`, exit 0. color-contrast 위반 0건(수정 전 15건).

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 대비 측정(수정 전) | 관리자 웹 | `#006FD6` 전경 × `#e2edf6`(accent-soft 렌더) 배경 WCAG 상대휘도 | 4.16:1 | AA 4.5:1 미달 |
| 대비 측정(수정 후) | 관리자 웹 | `#0064c1`(accent-ink) 전경 × `#e2edf6` 배경 | 4.93:1 | AA 충족 |
| 대비 측정(흰 배경 교차확인) | 관리자 웹 | `#0064c1` 전경 × `#ffffff` 배경 | 5.86:1 | AA 충족 |
| 라이브 axe 스윕 | 관리자 웹 | dev/H2 부팅 후 `tools/qa/admin-accessibility-qa.mjs`(3페이지 × 5 viewport 포함) | 로컬 `/private/tmp/.../admin-accessibility-qa-report.json`, `seriousAxeViolations: 0`·`blockingViolations: []`·exit 0 | color-contrast 15→0, 신규 위반 0 |
| 정적 가드 | backend | `AdminDesignGuardTest` | BUILD SUCCESSFUL | 통과 |
| 계약 테스트 | 리포 | `node --test tools/ci/repository-contract.test.mjs` | pass 217 / fail 0 | 통과 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `admin-tokens.css`의 신규 토큰 `--admin-accent-ink` 정의와 `admin-v3.css` `.trend-periods a.is-active` 전경 교체 1줄. 배경·보더는 손대지 않아 시각적 톤은 유지되고 활성 텍스트만 약간 짙어진다.

## 리스크

- accent hue를 유지한 최소 어둡힘(90% 혼합)이라 브랜드 톤 이탈은 없다. 흰 배경·accent-soft 배경 양쪽에서 AA를 충족(각 5.86:1·4.93:1)해 다른 사용처로 확장돼도 안전하다.
- 배경·보더·다른 accent 사용처는 불변이라 회귀 표면이 활성 추이 기간 링크 텍스트 색으로 한정된다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (해당 없음: CSS 토큰 변경, 배포 계약·마이그레이션 영향 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
