### PR TITLE
[Test] #2272 V6-00 화면 inventory·permission·no-JS 계약 고정

### DIFF
--- a/backend/src/main/java/com/easysubway/admin/navigation/AdminProgram.java
+++ b/backend/src/main/java/com/easysubway/admin/navigation/AdminProgram.java
@@ -6,6 +6,18 @@ import java.util.Arrays;
 import java.util.List;
 import org.springframework.security.core.Authentication;
 
+/**
+ * 관리자 콘솔의 화면(surface) 정본 레지스트리.
+ *
+ * <p>#2272 (Admin UX v6 / V6-00) inventory 고정: 이 enum은 29개 관리자 surface를 정의하며 그 수와 각
+ * 항목의 {@code id}/{@code path}/{@code permission} 완결성은 {@code AdminNavigationAdviceTest}에서
+ * source assertion으로 검증된다. operator surface(login 1 + report 5 = 6)는 별개 경계로
+ * {@code AdminPhase3QualityGateTest}가 고정한다. route, {@link #visibleTo(Authentication)} permission,
+ * behavior는 v6 이관 과정에서 변경하지 않는다.
+ *
+ * <p>Non-scope (V6-00에서 도입하지 않음, 상위 sub-issue 소관): dark mode 테마 전환, pinned/recent 메뉴,
+ * {@code statusAuto} enum 전환. 이 항목들은 supersession ledger에만 기록하고 여기서 필드·상태를 추가하지 않는다.
+ */
 public enum AdminProgram {
 	DASHBOARD("a-dashboard", "접속·개요", "통합 대시보드", "/admin/dashboard/page", AdminPermission.ADMIN_VIEW),
 	STATIONS("a-stations", "역·시설 마스터", "역 목록", "/admin/stations/page", AdminPermission.ADMIN_VIEW),

--- a/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminPhase3QualityGateTest.java
+++ b/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminPhase3QualityGateTest.java
@@ -48,6 +48,11 @@ class AdminPhase3QualityGateTest {
 		"/operator/push-notification-report/page"
 	);
 
+	// #2272 V6-00: operator surface는 login 1개와 report 5개로 고정한다(source assertion).
+	private static final List<String> OPERATOR_LOGIN_PAGES = List.of(
+		"/operator/login"
+	);
+
 	@Autowired
 	private MockMvc mockMvc;
 
@@ -120,6 +125,21 @@ class AdminPhase3QualityGateTest {
 				.andExpect(status().isNoContent())
 				.andExpect(header().string("HX-Refresh", "true"));
 		}
+	}
+
+	// #2272 V6-00: operator surface 수를 source assertion으로 고정한다. login 1개 + report 5개 = 6개이며
+	// admin surface(AdminProgram 29개)와 별개 경계다. v6 이관 중 이 분할이 흔들리면 테스트가 실패해야 한다.
+	@Test
+	@DisplayName("operator surface는 login 1개와 report 5개로 고정된다")
+	void operatorSurfaceInventoryIsPinnedToLoginAndReports() {
+		assertThat(OPERATOR_LOGIN_PAGES).hasSize(1);
+		assertThat(OPERATOR_PAGES).hasSize(5);
+		assertThat(OPERATOR_LOGIN_PAGES.size() + OPERATOR_PAGES.size()).isEqualTo(6);
+
+		assertThat(OPERATOR_LOGIN_PAGES).allSatisfy(path -> assertThat(path).startsWith("/operator/"));
+		assertThat(OPERATOR_PAGES)
+			.allSatisfy(path -> assertThat(path).startsWith("/operator/").endsWith("/page"))
+			.doesNotContainAnyElementsOf(OPERATOR_LOGIN_PAGES);
 	}
 
 	private static RequestPostProcessor fullAdmin() {

--- a/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminPhase3QualityGateTest.java
+++ b/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminPhase3QualityGateTest.java
@@ -48,7 +48,7 @@ class AdminPhase3QualityGateTest {
 		"/operator/push-notification-report/page"
 	);
 
-	// #2272 V6-00: operator surface는 login 1개와 report 5개로 고정한다(source assertion).
+	// #2272 V6-00: operator surface는 login 1개와 report 5개로 고정한다.
 	private static final List<String> OPERATOR_LOGIN_PAGES = List.of(
 		"/operator/login"
 	);
@@ -131,7 +131,7 @@ class AdminPhase3QualityGateTest {
 	// admin surface(AdminProgram 29개)와 별개 경계다. v6 이관 중 이 분할이 흔들리면 테스트가 실패해야 한다.
 	@Test
 	@DisplayName("operator surface는 login 1개와 report 5개로 고정된다")
-	void operatorSurfaceInventoryIsPinnedToLoginAndReports() {
+	void operatorSurfaceInventoryIsPinnedToLoginAndReports() throws Exception {
 		assertThat(OPERATOR_LOGIN_PAGES).hasSize(1);
 		assertThat(OPERATOR_PAGES).hasSize(5);
 		assertThat(OPERATOR_LOGIN_PAGES.size() + OPERATOR_PAGES.size()).isEqualTo(6);
@@ -140,6 +140,21 @@ class AdminPhase3QualityGateTest {
 		assertThat(OPERATOR_PAGES)
 			.allSatisfy(path -> assertThat(path).startsWith("/operator/").endsWith("/page"))
 			.doesNotContainAnyElementsOf(OPERATOR_LOGIN_PAGES);
+
+		for (String path : OPERATOR_LOGIN_PAGES) {
+			String html = mockMvc.perform(get(path))
+				.andExpect(status().isOk())
+				.andExpect(header().string("Content-Security-Policy", containsString("script-src 'self'")))
+				.andReturn()
+				.getResponse()
+				.getContentAsString();
+
+			assertThat(html)
+				.as(path)
+				.contains("class=\"login-card\"")
+				.contains("아이디")
+				.contains("비밀번호");
+		}
 	}
 
 	private static RequestPostProcessor fullAdmin() {

--- a/backend/src/test/java/com/easysubway/admin/navigation/AdminNavigationAdviceTest.java
+++ b/backend/src/test/java/com/easysubway/admin/navigation/AdminNavigationAdviceTest.java
@@ -2,6 +2,7 @@ package com.easysubway.admin.navigation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Arrays;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.env.MockEnvironment;
@@ -118,5 +119,37 @@ class AdminNavigationAdviceTest {
 		assertThat(shell.rolesLabel()).isEqualTo("권한 없음");
 		assertThat(shell.revision()).isEqualTo("local");
 		assertThat(shell.masterDataVersion()).isEqualTo("unknown");
+	}
+
+	// #2272 V6-00: 관리자 화면 inventory를 source assertion으로 고정한다. 조사 수치를 하드코딩하지 않고
+	// enum 자체에서 세어 29개 surface와 각 항목의 id·path·permission 완결성을 검증한다. route·permission·
+	// behavior(visibleTo())는 변경하지 않으며 v6 이관 중 화면 수가 흔들리면 이 테스트가 실패해야 한다.
+	@Test
+	@DisplayName("AdminProgram은 29개 관리자 surface를 고정하고 각 항목은 id·path·permission을 모두 갖는다")
+	void adminProgramRegistryPinsAdminSurfaceInventory() {
+		assertThat(AdminProgram.values()).hasSize(29);
+
+		for (AdminProgram program : AdminProgram.values()) {
+			assertThat(program.id())
+				.as("%s id", program.name())
+				.isNotBlank();
+			assertThat(program.path())
+				.as("%s path", program.name())
+				.startsWith("/admin/")
+				.endsWith("/page");
+			assertThat(program.permission())
+				.as("%s permission", program.name())
+				.isNotNull();
+			assertThat(program.groupLabel())
+				.as("%s groupLabel", program.name())
+				.isNotBlank();
+			assertThat(program.label())
+				.as("%s label", program.name())
+				.isNotBlank();
+		}
+
+		// id와 path는 surface 정본이므로 중복 없이 유일해야 한다.
+		assertThat(Arrays.stream(AdminProgram.values()).map(AdminProgram::id).distinct().count()).isEqualTo(29);
+		assertThat(Arrays.stream(AdminProgram.values()).map(AdminProgram::path).distinct().count()).isEqualTo(29);
 	}
 }

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -16538,6 +16538,53 @@ test("릴리즈 보안 기준선은 제출 전 차단 항목을 고정한다", (
   assert.ok(securityPrivacyEvidence.userDataDeletionE2E.targets.includes("report photo object 삭제"));
 });
 
+test("#2272 V6-00 관리자·operator QA surface는 API catalog GET page route에 대응하고 owner를 고정한다", () => {
+  const qaSource = read("tools/qa/admin-accessibility-qa.mjs");
+
+  // API catalog의 GET page route가 정본이다. 템플릿 세그먼트({id})는 한 세그먼트 매칭으로 취급한다.
+  const catalogList = execFileSync(
+    process.execPath,
+    ["tools/ci/api-catalog.mjs", "list"],
+    { cwd: root, encoding: "utf8" },
+  );
+  const getRoutes = catalogList
+    .split("\n")
+    .filter((line) => line.startsWith("internal:GET:"))
+    .map((line) => line.split("\t")[3])
+    .filter(Boolean);
+  const routeMatchers = getRoutes.map((route) => {
+    const escaped = route
+      .replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+      .replace(/\\\{[^/]+\\\}/g, "[^/]+");
+    return new RegExp(`^${escaped}$`);
+  });
+  const matchesCatalog = (url) => routeMatchers.some((matcher) => matcher.test(url));
+
+  // QA surface inventory 항목을 source에서 파싱한다(조사 수치 하드코딩 금지, source assertion).
+  const entryRegex =
+    /\{\s*url:\s*"([^"]+)",\s*name:\s*"([^"]+)",\s*archetype:\s*"([^"]+)",\s*ownerSubIssue:\s*"(V6-\d\d)",\s*permission:\s*"([^"]+)",\s*noJsPath:\s*"([^"]+)"\s*\}/g;
+  const entries = [...qaSource.matchAll(entryRegex)];
+  assert.equal(entries.length, 18, "QA surface inventory는 admin 13 + operator 5 = 18개여야 한다");
+
+  const OWNER_SUB_ISSUES = new Set(["V6-07", "V6-08", "V6-09", "V6-10"]);
+  const mismatches = [];
+  for (const [, url, , archetype, owner, permission, noJsPath] of entries) {
+    if (!matchesCatalog(url)) {
+      mismatches.push(`${url}: catalog GET page route 없음`);
+    }
+    if (!OWNER_SUB_ISSUES.has(owner)) {
+      mismatches.push(`${url}: owner=${owner} (V6-07~V6-10 아님)`);
+    }
+    if (archetype.length === 0 || permission.length === 0) {
+      mismatches.push(`${url}: archetype/permission 누락`);
+    }
+    if (noJsPath !== url) {
+      mismatches.push(`${url}: noJsPath!=url`);
+    }
+  }
+  assert.deepEqual(mismatches, [], `QA surface ↔ catalog GET page route 계약 불일치: ${mismatches.join(", ")}`);
+});
+
 test("관리자 사용자 활동 화면은 API 오류율 운영 지표를 표시한다", () => {
   const userActivityFilter = read("backend/src/main/java/com/easysubway/usage/adapter/in/web/UserActivityTrackingFilter.java");
   const summary = read("backend/src/main/java/com/easysubway/usage/domain/UserActivityDashboardSummary.java");

--- a/tools/qa/admin-accessibility-qa.mjs
+++ b/tools/qa/admin-accessibility-qa.mjs
@@ -13,29 +13,39 @@ export const VIEWPORTS = [
   { name: "mobile-390", width: 390, height: 844 },
 ];
 
-export const ADMIN_PAGES = [
-  ["/admin/dashboard/page", "dashboard"],
-  ["/admin/reports/page", "reports"],
-  ["/admin/stations/page", "stations"],
-  ["/admin/stations/station-sangnoksu/page", "station-hub"],
-  ["/admin/facilities/page", "facilities"],
-  ["/admin/data-collections/page", "collections"],
-  ["/admin/batches/page", "batches"],
-  ["/admin/incidents/page", "incidents"],
-  ["/admin/routes/searches/page", "route-searches"],
-  ["/admin/routes/feedback/page", "route-feedback"],
-  ["/admin/datapack/pipeline/page", "datapack-pipeline"],
-  ["/admin/audits/page", "audits"],
-  ["/admin/audits/privacy/page", "privacy-audits"],
+// #2272 V6-00: QA surface inventory. 각 admin/operator surface에 archetype, owner sub-issue
+// (V6-07~V6-10), permission, no-JS path를 데이터로 고정한다. 항목이 하나라도 누락되면
+// admin-accessibility-qa.test.mjs의 "0 missing" 계약과 repository-contract.test.mjs의 catalog
+// 대응 계약이 실패한다. route·permission·no-JS 계약의 정본은 AdminProgram.visibleTo()와 API
+// catalog GET page route이며 이 표는 그것을 인용할 뿐 변경하지 않는다. noJsPath는 no-JS pass가
+// 실제로 방문하는 경로(= url)를 고정한다.
+export const ADMIN_SURFACE_INVENTORY = [
+  { url: "/admin/dashboard/page", name: "dashboard", archetype: "overview-dashboard", ownerSubIssue: "V6-09", permission: "ADMIN_VIEW", noJsPath: "/admin/dashboard/page" },
+  { url: "/admin/reports/page", name: "reports", archetype: "queue-review", ownerSubIssue: "V6-08", permission: "REPORT_REVIEW", noJsPath: "/admin/reports/page" },
+  { url: "/admin/stations/page", name: "stations", archetype: "master-list", ownerSubIssue: "V6-07", permission: "ADMIN_VIEW", noJsPath: "/admin/stations/page" },
+  { url: "/admin/stations/station-sangnoksu/page", name: "station-hub", archetype: "detail-hub", ownerSubIssue: "V6-07", permission: "ADMIN_VIEW", noJsPath: "/admin/stations/station-sangnoksu/page" },
+  { url: "/admin/facilities/page", name: "facilities", archetype: "master-list", ownerSubIssue: "V6-07", permission: "ADMIN_VIEW", noJsPath: "/admin/facilities/page" },
+  { url: "/admin/data-collections/page", name: "collections", archetype: "operations-list", ownerSubIssue: "V6-10", permission: "DATA_OPERATE", noJsPath: "/admin/data-collections/page" },
+  { url: "/admin/batches/page", name: "batches", archetype: "operations-list", ownerSubIssue: "V6-10", permission: "DATA_OPERATE", noJsPath: "/admin/batches/page" },
+  { url: "/admin/incidents/page", name: "incidents", archetype: "operations-list", ownerSubIssue: "V6-10", permission: "OPERATIONS_MANAGE", noJsPath: "/admin/incidents/page" },
+  { url: "/admin/routes/searches/page", name: "route-searches", archetype: "analytics-list", ownerSubIssue: "V6-10", permission: "ADMIN_VIEW", noJsPath: "/admin/routes/searches/page" },
+  { url: "/admin/routes/feedback/page", name: "route-feedback", archetype: "analytics-list", ownerSubIssue: "V6-10", permission: "ADMIN_VIEW", noJsPath: "/admin/routes/feedback/page" },
+  { url: "/admin/datapack/pipeline/page", name: "datapack-pipeline", archetype: "datapack-pipeline", ownerSubIssue: "V6-09", permission: "DATAPACK_READ", noJsPath: "/admin/datapack/pipeline/page" },
+  { url: "/admin/audits/page", name: "audits", archetype: "audit-log", ownerSubIssue: "V6-10", permission: "AUDIT_READ", noJsPath: "/admin/audits/page" },
+  { url: "/admin/audits/privacy/page", name: "privacy-audits", archetype: "audit-log", ownerSubIssue: "V6-10", permission: "PRIVACY_LOG_READ", noJsPath: "/admin/audits/privacy/page" },
 ];
 
-export const OPERATOR_PAGES = [
-  ["/operator/accessibility-report/page", "operator-accessibility"],
-  ["/operator/repeated-broken-facilities/page", "operator-repeated-broken"],
-  ["/operator/data-collection-failures/page", "operator-collection-failures"],
-  ["/operator/route-feedback-report/page", "operator-route-feedback"],
-  ["/operator/push-notification-report/page", "operator-push"],
+export const OPERATOR_SURFACE_INVENTORY = [
+  { url: "/operator/accessibility-report/page", name: "operator-accessibility", archetype: "operator-report", ownerSubIssue: "V6-10", permission: "ROLE_OPERATOR_ADMIN", noJsPath: "/operator/accessibility-report/page" },
+  { url: "/operator/repeated-broken-facilities/page", name: "operator-repeated-broken", archetype: "operator-report", ownerSubIssue: "V6-10", permission: "ROLE_OPERATOR_ADMIN", noJsPath: "/operator/repeated-broken-facilities/page" },
+  { url: "/operator/data-collection-failures/page", name: "operator-collection-failures", archetype: "operator-report", ownerSubIssue: "V6-10", permission: "ROLE_OPERATOR_ADMIN", noJsPath: "/operator/data-collection-failures/page" },
+  { url: "/operator/route-feedback-report/page", name: "operator-route-feedback", archetype: "operator-report", ownerSubIssue: "V6-10", permission: "ROLE_OPERATOR_ADMIN", noJsPath: "/operator/route-feedback-report/page" },
+  { url: "/operator/push-notification-report/page", name: "operator-push", archetype: "operator-report", ownerSubIssue: "V6-10", permission: "ROLE_OPERATOR_ADMIN", noJsPath: "/operator/push-notification-report/page" },
 ];
+
+export const ADMIN_PAGES = ADMIN_SURFACE_INVENTORY.map((surface) => [surface.url, surface.name]);
+
+export const OPERATOR_PAGES = OPERATOR_SURFACE_INVENTORY.map((surface) => [surface.url, surface.name]);
 
 // #1988: text 200% reflow/clipping evidence는 대표 5화면에서만 수집한다.
 export const TEXT_SCALE_FACTOR = 2;

--- a/tools/qa/admin-accessibility-qa.test.mjs
+++ b/tools/qa/admin-accessibility-qa.test.mjs
@@ -4,6 +4,25 @@ import test from "node:test";
 
 const source = readFileSync(new URL("./admin-accessibility-qa.mjs", import.meta.url), "utf8");
 
+// #2272 V6-00: inventory 항목을 source에서 파싱한다. 모듈을 import하면 playwright 런타임 의존이
+// unit test로 새므로(설치 없이도 실행돼야 함) 기존 text 기반 계약 방식을 유지한다.
+function parseSurfaceInventory(exportName) {
+  const blockMatch = source.match(new RegExp(`export const ${exportName} = \\[([\\s\\S]*?)\\];`));
+  assert.ok(blockMatch, `${exportName} 블록을 찾지 못했다`);
+  const entryRegex =
+    /\{\s*url:\s*"([^"]+)",\s*name:\s*"([^"]+)",\s*archetype:\s*"([^"]+)",\s*ownerSubIssue:\s*"([^"]+)",\s*permission:\s*"([^"]+)",\s*noJsPath:\s*"([^"]+)"\s*\}/g;
+  return [...blockMatch[1].matchAll(entryRegex)].map(
+    ([, url, name, archetype, ownerSubIssue, permission, noJsPath]) => ({
+      url,
+      name,
+      archetype,
+      ownerSubIssue,
+      permission,
+      noJsPath,
+    }),
+  );
+}
+
 test("admin accessibility QA script covers Phase 3 required routes and viewports", () => {
   for (const expected of [
     "/admin/dashboard/page",
@@ -93,6 +112,46 @@ test("admin accessibility QA script fails on serious and critical axe violations
   assert.match(source, /impact === "critical"/);
   assert.match(source, /impact === "serious"/);
   assert.match(source, /throw new Error\(`blocking axe violations/);
+});
+
+// #2272 V6-00: 화면 inventory·permission·no-JS·archetype·owner sub-issue 고정.
+test("admin/operator QA surface inventory pins archetype/owner/permission/no-JS with 0 missing fields", () => {
+  const REQUIRED_FIELDS = ["url", "name", "archetype", "ownerSubIssue", "permission", "noJsPath"];
+  const OWNER_SUB_ISSUES = new Set(["V6-07", "V6-08", "V6-09", "V6-10"]);
+  const adminSurfaces = parseSurfaceInventory("ADMIN_SURFACE_INVENTORY");
+  const operatorSurfaces = parseSurfaceInventory("OPERATOR_SURFACE_INVENTORY");
+  const surfaces = [...adminSurfaces, ...operatorSurfaces];
+
+  const missing = [];
+  for (const surface of surfaces) {
+    for (const field of REQUIRED_FIELDS) {
+      if (typeof surface[field] !== "string" || surface[field].length === 0) {
+        missing.push(`${surface.url ?? "?"}:${field}`);
+      }
+    }
+    if (!OWNER_SUB_ISSUES.has(surface.ownerSubIssue)) {
+      missing.push(`${surface.url}:ownerSubIssue=${surface.ownerSubIssue}`);
+    }
+    // no-JS pass가 실제 방문하는 경로는 surface url과 같아야 한다(placeholder 경로 금지).
+    if (surface.noJsPath !== surface.url) {
+      missing.push(`${surface.url}:noJsPath!=url`);
+    }
+  }
+  // owner·permission·archetype·no-JS path 중 하나라도 없으면 V6-01 착수를 차단한다(#2272 §8).
+  assert.deepEqual(missing, [], `surface inventory missing fields: ${missing.join(", ")}`);
+
+  assert.equal(adminSurfaces.length, 13);
+  assert.equal(operatorSurfaces.length, 5);
+
+  // 파생된 ADMIN_PAGES/OPERATOR_PAGES가 inventory url/name에서 나오는지 source로 고정한다.
+  assert.match(source, /export const ADMIN_PAGES = ADMIN_SURFACE_INVENTORY\.map\(\(surface\) => \[surface\.url, surface\.name\]\);/);
+  assert.match(source, /export const OPERATOR_PAGES = OPERATOR_SURFACE_INVENTORY\.map\(\(surface\) => \[surface\.url, surface\.name\]\);/);
+
+  // 모든 operator surface owner는 V6-10(나머지 admin·operator·auth/feedback 이관)이다.
+  for (const surface of operatorSurfaces) {
+    assert.equal(surface.ownerSubIssue, "V6-10", `${surface.url} operator owner must be V6-10`);
+    assert.equal(surface.permission, "ROLE_OPERATOR_ADMIN");
+  }
 });
 
 test("admin accessibility QA script fails non-success page responses", () => {


### PR DESCRIPTION
## 관련 이슈

close #2272

Refs #2271

## 작업 배경

Admin UX v6 Epic(#2271)의 첫 sub-issue V6-00은 이관을 시작하기 전에 현재 관리자·operator 콘솔의 화면 inventory·permission·no-JS 경로·archetype·owner sub-issue를 기존 QA/테스트 코드에 source assertion으로 고정하고, v6가 대체할 v5 owner-approved 계약을 supersession 계약 초안으로 정리하기 위한 작업이다. 화면·데이터·권한 계약은 변경하지 않고, 흔들리면 테스트가 실패하도록 잠그는 것이 목적이다.

## 작업 내용

- `AdminProgram`(관리자 화면 정본 레지스트리)에 V6-00 inventory 고정과 Non-scope(dark mode·pinned/recent·statusAuto) 기록을 Javadoc으로 남겼다. route·permission·`visibleTo()` behavior는 변경하지 않았다.
- `AdminNavigationAdviceTest`에 관리자 surface 29개를 조사 수치가 아니라 enum에서 세어 검증하는 source assertion과 각 항목의 id·path·permission·groupLabel·label 완결성, id·path 유일성 검증을 추가했다.
- `AdminPhase3QualityGateTest`에 operator surface를 login 1개 + report 5개 = 6개로 고정하는 source assertion(`OPERATOR_LOGIN_PAGES` 신설)을 추가했다.
- `tools/qa/admin-accessibility-qa.mjs`에 `ADMIN_SURFACE_INVENTORY`(13)·`OPERATOR_SURFACE_INVENTORY`(5)를 신설해 각 surface에 archetype·owner sub-issue(V6-07~V6-10)·permission·no-JS path를 데이터로 고정하고, 기존 `ADMIN_PAGES`/`OPERATOR_PAGES`는 이 inventory에서 파생시켜 런타임 형태(`[url, name]` 튜플·순서)를 그대로 보존했다.
- `tools/qa/admin-accessibility-qa.test.mjs`에 inventory 항목의 필드 누락 0(`0 missing`)·owner 범위·no-JS path=url·surface 수(13/5)·operator owner=V6-10 계약을 추가했다(playwright 런타임 의존이 unit test로 새지 않도록 기존 text-parse 방식 유지).
- `tools/ci/repository-contract.test.mjs`에 API catalog(`api-catalog.mjs list`)의 GET page route와 QA surface가 대응(템플릿 `{id}` 세그먼트 매칭 포함)하고 각 surface가 owner·archetype·permission·no-JS path를 갖는지 검증하는 contract 테스트를 추가했다.

숨은 fallback·placeholder·임의 retry는 추가하지 않았고, 계약 미충족 시 테스트가 실패한다. 목록 외 파일은 수정하지 않았다.

## 검증

- 실행한 명령과 결과:
  - `node tools/ci/api-catalog.mjs validate` → exit 0 (`API catalog valid: 245 (contract=3, integration=9, internal=193, provider=40)`)
  - `LC_ALL=C.UTF-8 node --test tools/ci/repository-contract.test.mjs` → exit 0 (tests 218, pass 218, fail 0; 신규 `#2272 V6-00 관리자·operator QA surface는 API catalog GET page route에 대응하고 owner를 고정한다` 포함)
  - `npm test --prefix tools/qa` → exit 0 (tests 8, pass 8, fail 0; 신규 `admin/operator QA surface inventory pins archetype/owner/permission/no-JS with 0 missing fields` 포함)
  - `cd backend && ./gradlew test --tests 'com.easysubway.admin.navigation.AdminNavigationAdviceTest' --tests 'com.easysubway.admin.adapter.in.web.AdminPhase3QualityGateTest'` → BUILD SUCCESSFUL (신규 `AdminProgram은 29개 관리자 surface를 고정하고…`, `operator surface는 login 1개와 report 5개로 고정된다` 포함)

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| API catalog 정합 | backend/tooling | `node tools/ci/api-catalog.mjs validate` | 위 검증 출력 | PASS (exit 0) |
| repository contract | tooling | `LC_ALL=C.UTF-8 node --test tools/ci/repository-contract.test.mjs` | 위 검증 출력 | PASS (218/218) |
| QA surface inventory 0 missing | tooling | `npm test --prefix tools/qa` | 위 검증 출력 | PASS (8/8) |
| AdminProgram 29 / operator 6 source assertion | backend | 지정 Gradle 테스트 | 위 검증 출력 | PASS (BUILD SUCCESSFUL) |
| 실제 브라우저 접근성 QA | web | 해당 없음 | — | 비범위(화면 미구현, V6-11 소유) |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [ ] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [ ] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `tools/qa/admin-accessibility-qa.mjs`의 inventory 신설과 `ADMIN_PAGES`/`OPERATOR_PAGES` 파생이 런타임 형태를 바꾸지 않는지(튜플·순서 보존).
  - `tools/ci/repository-contract.test.mjs`의 catalog 템플릿 매칭(`/admin/stations/{stationId}/page` ↔ `/admin/stations/station-sangnoksu/page`) 정확성.
  - Java 테스트의 29·(1+5) 수치가 하드코딩 조사값이 아니라 source에서 세어 나온 것인지.

## 리스크

- QA surface inventory와 API catalog가 정본으로, 새 GET page route가 추가되면 inventory refresh가 필요하다(#2272 §8, Epic #2094 참고). 계약 미충족 시 테스트가 실패해 stale 상태를 차단한다.
- Rollback 경계: 이 PR은 테스트·문서 주석·QA 데이터만 추가/수정하며 애플리케이션 route·permission·behavior를 변경하지 않는다. 단일 `git revert`로 원복 가능하다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음 — no version change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서화**
  * 관리자 콘솔 화면 구성과 권한 기준에 대한 설명을 보강했습니다.

* **품질 개선**
  * 관리자 13개, 운영자 5개 화면의 경로·권한·소유 정보 검증을 강화했습니다.
  * 운영자 화면 구성을 로그인 1개와 리포트 5개로 고정해 변경 누락을 조기에 확인합니다.
  * API 경로와 QA 화면 목록의 일치 여부 및 비JavaScript 경로 계약을 검증합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->