### PR TITLE
[Backend] #2250 RAPTOR marked-route·무할당 검색 루프

### DIFF
--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -1219,7 +1219,8 @@ public class RouteSearchService implements RouteSearchUseCase {
 			Comparator.comparing(InternalRouteCandidate::cost)
 		);
 		Map<String, InternalRouteCost> bestCostByNodeId = new HashMap<>();
-		queue.add(new InternalRouteCandidate(fromNodeId, InternalRouteCost.ZERO, List.of()));
+		Map<String, RouteEdge> predecessorByNodeId = new HashMap<>();
+		queue.add(new InternalRouteCandidate(fromNodeId, InternalRouteCost.ZERO));
 		bestCostByNodeId.put(fromNodeId, InternalRouteCost.ZERO);
 
 		while (!queue.isEmpty()) {
@@ -1228,17 +1229,27 @@ public class RouteSearchService implements RouteSearchUseCase {
 				continue;
 			}
 			if (current.nodeId().equals(toNodeId)) {
-				return Optional.of(current.path());
+				List<RouteEdge> path = new ArrayList<>();
+				String nodeId = toNodeId;
+				while (!nodeId.equals(fromNodeId)) {
+					RouteEdge edge = predecessorByNodeId.get(nodeId);
+					if (edge == null) {
+						return Optional.empty();
+					}
+					path.add(edge);
+					nodeId = edge.fromNodeId();
+				}
+				java.util.Collections.reverse(path);
+				return Optional.of(List.copyOf(path));
 			}
 			for (RouteEdge edge : edgesByFromNode.getOrDefault(current.nodeId(), List.of())) {
 				InternalRouteCost nextCost = current.cost().plus(internalEdgeCost(edge));
 				if (nextCost.compareTo(bestCostByNodeId.getOrDefault(edge.toNodeId(), InternalRouteCost.MAX)) >= 0) {
 					continue;
 				}
-				List<RouteEdge> nextPath = new ArrayList<>(current.path());
-				nextPath.add(edge);
 				bestCostByNodeId.put(edge.toNodeId(), nextCost);
-				queue.add(new InternalRouteCandidate(edge.toNodeId(), nextCost, List.copyOf(nextPath)));
+				predecessorByNodeId.put(edge.toNodeId(), edge);
+				queue.add(new InternalRouteCandidate(edge.toNodeId(), nextCost));
 			}
 		}
 		return Optional.empty();
@@ -1769,8 +1780,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 
 	private record InternalRouteCandidate(
 		String nodeId,
-		InternalRouteCost cost,
-		List<RouteEdge> path
+		InternalRouteCost cost
 	) {
 	}
 

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
@@ -360,7 +360,8 @@ class RouteTimetableRaptorPlanner {
 				|| readySeconds < boardingReadySeconds
 				|| candidate.departureSeconds(position) < boardedTrip.departureSeconds(position)
 				|| (candidate != boardedTrip
-					&& candidate.departureSeconds(position) == boardedTrip.departureSeconds(position)))) {
+					&& candidate.departureSeconds(position) == boardedTrip.departureSeconds(position)
+					&& candidate.arrivalSeconds(position) <= boardedTrip.arrivalSeconds(position)))) {
 				boardedTrip = candidate;
 				boardingPosition = position;
 				boardingReadySeconds = readySeconds;

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
@@ -981,7 +981,7 @@ class RouteTimetableRaptorPlanner {
 				for (ScheduledTrip trip : orderedTrips) {
 					List<ScheduledTrip> selectedGroup = null;
 					for (List<ScheduledTrip> group : nonOvertakingGroups) {
-						if (doesNotOvertake(group.getLast(), trip)) {
+						if (canShareScanPattern(group.getLast(), trip)) {
 							selectedGroup = group;
 							break;
 						}
@@ -1004,10 +1004,13 @@ class RouteTimetableRaptorPlanner {
 			return new CompiledRoutePatterns(Map.copyOf(stopsByPattern), Map.copyOf(tripsByPattern));
 		}
 
-		private static boolean doesNotOvertake(ScheduledTrip earlier, ScheduledTrip later) {
+		private static boolean canShareScanPattern(ScheduledTrip earlier, ScheduledTrip later) {
 			for (int stop = 0; stop < earlier.stopTimes().size(); stop += 1) {
 				if (earlier.arrivalSeconds(stop) > later.arrivalSeconds(stop)
-					|| earlier.departureSeconds(stop) > later.departureSeconds(stop)) {
+					|| earlier.departureSeconds(stop) > later.departureSeconds(stop)
+					|| (stop > 0
+						&& earlier.arrivalSeconds(stop) == later.arrivalSeconds(stop)
+						&& later.index() < earlier.index())) {
 					return false;
 				}
 			}

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
@@ -955,7 +955,7 @@ class RouteTimetableRaptorPlanner {
 			Map<String, Integer> routeIndex,
 			Map<String, Integer> stationIndex
 		) {
-			Map<RoutePatternKey, Integer> patternIds = new LinkedHashMap<>();
+			Map<RoutePatternKey, List<ScheduledTrip>> groupedTrips = new LinkedHashMap<>();
 			Map<Integer, int[]> stopsByPattern = new HashMap<>();
 			Map<Integer, List<ScheduledTrip>> tripsByPattern = new HashMap<>();
 			for (ScheduledTrip trip : scheduledTrips) {
@@ -966,18 +966,52 @@ class RouteTimetableRaptorPlanner {
 				List<Integer> stationSequence = trip.stopTimes().stream()
 					.map(stopTime -> stationIndex.get(stopTime.stationId()))
 					.toList();
-				RoutePatternKey key = new RoutePatternKey(denseRoute, stationSequence);
-				int patternId = patternIds.computeIfAbsent(key, ignored -> patternIds.size());
-				stopsByPattern.putIfAbsent(
-					patternId,
-					stationSequence.stream().mapToInt(Integer::intValue).toArray()
-				);
-				tripsByPattern.computeIfAbsent(patternId, ignored -> new ArrayList<>()).add(trip);
+				List<Integer> accessSignature = trip.stopTimes().stream()
+					.map(stopTime -> (stopTime.pickupType() << 16) | (stopTime.dropOffType() & 0xffff))
+					.toList();
+				RoutePatternKey key = new RoutePatternKey(denseRoute, stationSequence, accessSignature);
+				groupedTrips.computeIfAbsent(key, ignored -> new ArrayList<>()).add(trip);
 			}
-			tripsByPattern.replaceAll((ignored, trips) -> trips.stream()
-				.sorted(Comparator.comparingInt(trip -> trip.departureSeconds(0)))
-				.toList());
+			for (Map.Entry<RoutePatternKey, List<ScheduledTrip>> entry : groupedTrips.entrySet()) {
+				List<List<ScheduledTrip>> nonOvertakingGroups = new ArrayList<>();
+				List<ScheduledTrip> orderedTrips = entry.getValue().stream()
+					.sorted(Comparator.comparingInt((ScheduledTrip trip) -> trip.departureSeconds(0))
+						.thenComparingInt(ScheduledTrip::index))
+					.toList();
+				for (ScheduledTrip trip : orderedTrips) {
+					List<ScheduledTrip> selectedGroup = null;
+					for (List<ScheduledTrip> group : nonOvertakingGroups) {
+						if (doesNotOvertake(group.getLast(), trip)) {
+							selectedGroup = group;
+							break;
+						}
+					}
+					if (selectedGroup == null) {
+						selectedGroup = new ArrayList<>();
+						nonOvertakingGroups.add(selectedGroup);
+					}
+					selectedGroup.add(trip);
+				}
+				for (List<ScheduledTrip> group : nonOvertakingGroups) {
+					int patternId = stopsByPattern.size();
+					stopsByPattern.put(
+						patternId,
+						entry.getKey().stationSequence().stream().mapToInt(Integer::intValue).toArray()
+					);
+					tripsByPattern.put(patternId, List.copyOf(group));
+				}
+			}
 			return new CompiledRoutePatterns(Map.copyOf(stopsByPattern), Map.copyOf(tripsByPattern));
+		}
+
+		private static boolean doesNotOvertake(ScheduledTrip earlier, ScheduledTrip later) {
+			for (int stop = 0; stop < earlier.stopTimes().size(); stop += 1) {
+				if (earlier.arrivalSeconds(stop) > later.arrivalSeconds(stop)
+					|| earlier.departureSeconds(stop) > later.departureSeconds(stop)) {
+					return false;
+				}
+			}
+			return true;
 		}
 
 		private static Map<Integer, int[]> invertPatterns(Map<Integer, int[]> stopsByPattern, int stationCount) {
@@ -1223,7 +1257,11 @@ class RouteTimetableRaptorPlanner {
 	record ScanMetrics(int expandedRoutes, int expandedTrips, int workspaceIdentity) {
 	}
 
-	private record RoutePatternKey(int routeIndex, List<Integer> stationSequence) {
+	private record RoutePatternKey(
+		int routeIndex,
+		List<Integer> stationSequence,
+		List<Integer> accessSignature
+	) {
 	}
 
 	private record CompiledRoutePatterns(

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
@@ -333,6 +333,7 @@ class RouteTimetableRaptorPlanner {
 		int[] stops = timetable.stopsByPattern(pattern);
 		ScheduledTrip boardedTrip = null;
 		int boardingPosition = -1;
+		int boardingReadySeconds = UNREACHED;
 		for (int position = firstMarkedPosition; position < stops.length; position += 1) {
 			trips = activeServiceDay.tripsByPattern(pattern, position);
 			int station = stops[position];
@@ -356,9 +357,11 @@ class RouteTimetableRaptorPlanner {
 				readySeconds + accessSeconds + slackSeconds
 			);
 			if (candidate != null && (boardedTrip == null
+				|| readySeconds < boardingReadySeconds
 				|| candidate.departureSeconds(position) < boardedTrip.departureSeconds(position))) {
 				boardedTrip = candidate;
 				boardingPosition = position;
+				boardingReadySeconds = readySeconds;
 				workspace.expandedTrips += 1;
 			}
 		}

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
@@ -351,13 +351,20 @@ class RouteTimetableRaptorPlanner {
 			if (readySeconds == UNREACHED) {
 				continue;
 			}
+			int earliestDepartureSeconds = readySeconds + accessSeconds + slackSeconds;
+			if (boardedTrip != null
+				&& readySeconds < boardingReadySeconds
+				&& boardedTrip.allowsPickup(position)
+				&& boardedTrip.departureSeconds(position) >= earliestDepartureSeconds) {
+				boardingPosition = position;
+				boardingReadySeconds = readySeconds;
+			}
 			ScheduledTrip candidate = earliestBoardableTrip(
 				trips,
 				position,
-				readySeconds + accessSeconds + slackSeconds
+				earliestDepartureSeconds
 			);
 			if (candidate != null && (boardedTrip == null
-				|| readySeconds < boardingReadySeconds
 				|| candidate.departureSeconds(position) < boardedTrip.departureSeconds(position)
 				|| (candidate != boardedTrip
 					&& candidate.departureSeconds(position) == boardedTrip.departureSeconds(position)

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
@@ -912,9 +912,9 @@ class RouteTimetableRaptorPlanner {
 					List<List<ScheduledTrip>> tripsByStop = new ArrayList<>();
 					for (int stop = 0; stop < stopsByPattern.get(entry.getKey()).length; stop += 1) {
 						int stopIndex = stop;
+						// Stable sorting keeps the non-overtaking pattern order when departures tie.
 						tripsByStop.add(patternTrips.stream()
-							.sorted(Comparator.comparingInt((ScheduledTrip trip) -> trip.departureSeconds(stopIndex))
-								.thenComparingInt(ScheduledTrip::index))
+							.sorted(Comparator.comparingInt((ScheduledTrip trip) -> trip.departureSeconds(stopIndex)))
 							.toList());
 					}
 					activeTripsByPattern.put(entry.getKey(), List.copyOf(tripsByStop));

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
@@ -358,7 +358,9 @@ class RouteTimetableRaptorPlanner {
 			);
 			if (candidate != null && (boardedTrip == null
 				|| readySeconds < boardingReadySeconds
-				|| candidate.departureSeconds(position) < boardedTrip.departureSeconds(position))) {
+				|| candidate.departureSeconds(position) < boardedTrip.departureSeconds(position)
+				|| (candidate != boardedTrip
+					&& candidate.departureSeconds(position) == boardedTrip.departureSeconds(position)))) {
 				boardedTrip = candidate;
 				boardingPosition = position;
 				boardingReadySeconds = readySeconds;

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
@@ -1198,7 +1198,13 @@ class RouteTimetableRaptorPlanner {
 			int alightStop
 		) {
 			int candidateSlot = slot(boardings, station);
-			if (arrivalSeconds[candidateSlot] <= candidateArrivalSeconds) {
+			int existingArrivalSeconds = arrivalSeconds[candidateSlot];
+			if (existingArrivalSeconds < candidateArrivalSeconds) {
+				return;
+			}
+			if (existingArrivalSeconds == candidateArrivalSeconds
+				&& (parentTrip[candidateSlot] < trip
+					|| (parentTrip[candidateSlot] == trip && parentBoardStop[candidateSlot] <= boardStop))) {
 				return;
 			}
 			for (int fewerBoardings = 0; fewerBoardings < boardings; fewerBoardings += 1) {

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
@@ -326,7 +326,7 @@ class RouteTimetableRaptorPlanner {
 		int slackSeconds
 	) {
 		workspace.expandedRoutes += 1;
-		List<ScheduledTrip> trips = activeServiceDay.tripsByPattern(pattern, firstMarkedPosition);
+		List<ScheduledTrip> trips = activeServiceDay.tripsByPattern(pattern);
 		if (trips.isEmpty()) {
 			return;
 		}
@@ -335,7 +335,6 @@ class RouteTimetableRaptorPlanner {
 		int boardingPosition = -1;
 		int boardingReadySeconds = UNREACHED;
 		for (int position = firstMarkedPosition; position < stops.length; position += 1) {
-			trips = activeServiceDay.tripsByPattern(pattern, position);
 			int station = stops[position];
 			if (boardedTrip != null && position > boardingPosition && boardedTrip.allowsDropOff(position)) {
 				workspace.relax(
@@ -903,21 +902,13 @@ class RouteTimetableRaptorPlanner {
 			List<ScheduledTrip> activeTrips = scheduledTrips.stream()
 				.filter(trip -> activeServiceIds.contains(trip.trip().serviceId()))
 				.toList();
-			Map<Integer, List<List<ScheduledTrip>>> activeTripsByPattern = new HashMap<>();
+			Map<Integer, List<ScheduledTrip>> activeTripsByPattern = new HashMap<>();
 			for (Map.Entry<Integer, List<ScheduledTrip>> entry : tripsByPattern.entrySet()) {
 				List<ScheduledTrip> patternTrips = entry.getValue().stream()
 					.filter(trip -> activeServiceIds.contains(trip.trip().serviceId()))
 					.toList();
 				if (!patternTrips.isEmpty()) {
-					List<List<ScheduledTrip>> tripsByStop = new ArrayList<>();
-					for (int stop = 0; stop < stopsByPattern.get(entry.getKey()).length; stop += 1) {
-						int stopIndex = stop;
-						// Stable sorting keeps the non-overtaking pattern order when departures tie.
-						tripsByStop.add(patternTrips.stream()
-							.sorted(Comparator.comparingInt((ScheduledTrip trip) -> trip.departureSeconds(stopIndex)))
-							.toList());
-					}
-					activeTripsByPattern.put(entry.getKey(), List.copyOf(tripsByStop));
+					activeTripsByPattern.put(entry.getKey(), patternTrips);
 				}
 			}
 			ActiveServiceDay compiled = new ActiveServiceDay(activeTrips, Map.copyOf(activeTripsByPattern));
@@ -1065,10 +1056,10 @@ class RouteTimetableRaptorPlanner {
 	static final class ActiveServiceDay {
 
 		private final List<ScheduledTrip> trips;
-		private final Map<Integer, List<List<ScheduledTrip>>> tripsByPattern;
+		private final Map<Integer, List<ScheduledTrip>> tripsByPattern;
 		private volatile Map<String, List<BoardingStop>> boardingsByStation;
 
-		private ActiveServiceDay(List<ScheduledTrip> trips, Map<Integer, List<List<ScheduledTrip>>> tripsByPattern) {
+		private ActiveServiceDay(List<ScheduledTrip> trips, Map<Integer, List<ScheduledTrip>> tripsByPattern) {
 			this.trips = List.copyOf(trips);
 			this.tripsByPattern = tripsByPattern;
 		}
@@ -1077,9 +1068,14 @@ class RouteTimetableRaptorPlanner {
 			return trips;
 		}
 
-		private List<ScheduledTrip> tripsByPattern(int pattern, int stopPosition) {
-			List<List<ScheduledTrip>> tripsByStop = tripsByPattern.get(pattern);
-			return tripsByStop == null ? List.of() : tripsByStop.get(stopPosition);
+		private List<ScheduledTrip> tripsByPattern(int pattern) {
+			return tripsByPattern.getOrDefault(pattern, List.of());
+		}
+
+		int routePatternTripLinkCount() {
+			return tripsByPattern.values().stream()
+				.mapToInt(List::size)
+				.sum();
 		}
 
 		boolean boardingIndexInitialized() {

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
@@ -829,7 +829,7 @@ class RouteTimetableRaptorPlanner {
 				compiledTrips.set(index, compiledTrips.get(index).withIndex(index));
 			}
 			scheduledTrips = List.copyOf(compiledTrips);
-			CompiledRoutePatterns routePatterns = compileRoutePatterns(scheduledTrips, routeIndex, stationIndex);
+			CompiledRoutePatterns routePatterns = compileRoutePatterns(scheduledTrips, stationIndex);
 			stopsByPattern = routePatterns.stopsByPattern();
 			patternsByStop = invertPatterns(stopsByPattern, stationIndex.size());
 			tripsByPattern = routePatterns.tripsByPattern();
@@ -965,15 +965,13 @@ class RouteTimetableRaptorPlanner {
 
 		private static CompiledRoutePatterns compileRoutePatterns(
 			List<ScheduledTrip> scheduledTrips,
-			Map<String, Integer> routeIndex,
 			Map<String, Integer> stationIndex
 		) {
 			Map<RoutePatternKey, List<ScheduledTrip>> groupedTrips = new LinkedHashMap<>();
 			Map<Integer, int[]> stopsByPattern = new HashMap<>();
 			Map<Integer, List<ScheduledTrip>> tripsByPattern = new HashMap<>();
 			for (ScheduledTrip trip : scheduledTrips) {
-				Integer denseRoute = routeIndex.get(trip.trip().routeId());
-				if (denseRoute == null || trip.stopTimes().isEmpty()) {
+				if (trip.stopTimes().isEmpty()) {
 					continue;
 				}
 				List<Integer> stationSequence = trip.stopTimes().stream()
@@ -982,7 +980,7 @@ class RouteTimetableRaptorPlanner {
 				List<Integer> accessSignature = trip.stopTimes().stream()
 					.map(stopTime -> (stopTime.pickupType() << 16) | (stopTime.dropOffType() & 0xffff))
 					.toList();
-				RoutePatternKey key = new RoutePatternKey(denseRoute, stationSequence, accessSignature);
+				RoutePatternKey key = new RoutePatternKey(trip.trip().routeId(), stationSequence, accessSignature);
 				groupedTrips.computeIfAbsent(key, ignored -> new ArrayList<>()).add(trip);
 			}
 			for (Map.Entry<RoutePatternKey, List<ScheduledTrip>> entry : groupedTrips.entrySet()) {
@@ -1280,7 +1278,7 @@ class RouteTimetableRaptorPlanner {
 	}
 
 	private record RoutePatternKey(
-		int routeIndex,
+		String routeId,
 		List<Integer> stationSequence,
 		List<Integer> accessSignature
 	) {

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteTimetableRaptorPlanner.java
@@ -26,6 +26,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.HashMap;
@@ -49,6 +50,10 @@ class RouteTimetableRaptorPlanner {
 	private static final int EXIT_DURATION_SECONDS = 180;
 	private static final int EXIT_DISTANCE_METERS = 120;
 	private static final int ACTIVE_SERVICE_DAY_CACHE_SIZE = 8;
+	private static final int LABEL_SLOT_COUNT = PARETO_LIMIT + 1;
+	private static final int UNREACHED = Integer.MAX_VALUE;
+	private static final int[] NO_PATTERNS = new int[0];
+	private final ThreadLocal<ScanWorkspace> scanWorkspaces = ThreadLocal.withInitial(ScanWorkspace::new);
 
 	List<RouteSearchResult> search(SearchRouteV2Command command, RouteTimetable timetable) {
 		return search(command, compile(timetable));
@@ -61,6 +66,15 @@ class RouteTimetableRaptorPlanner {
 			.limit(candidateLimit(command))
 			.map(label -> toRouteSearchResult(command, label, serviceDay, timetable.source()))
 			.toList();
+	}
+
+	ScanMetrics lastScanMetrics() {
+		ScanWorkspace workspace = scanWorkspaces.get();
+		return new ScanMetrics(
+			workspace.expandedRoutes,
+			workspace.expandedTrips,
+			System.identityHashCode(workspace)
+		);
 	}
 
 	boolean isFeedStale(SearchRouteV2Command command, RouteTimetable timetable) {
@@ -232,115 +246,187 @@ class RouteTimetableRaptorPlanner {
 		ServiceDay serviceDay,
 		int startSeconds
 	) {
-		List<ScheduledTrip> trips = timetable.activeServiceDay(serviceDay.date()).trips();
-		if (trips.isEmpty()) {
+		ActiveServiceDay activeServiceDay = timetable.activeServiceDay(serviceDay.date());
+		ScanWorkspace workspace = scanWorkspaces.get();
+		workspace.prepare(timetable.stationCount(), timetable.routePatternCount());
+		if (activeServiceDay.trips().isEmpty()) {
 			return new ScanResult(serviceDay, List.of());
 		}
+		int origin = timetable.stationIndex(command.originStationId());
+		int destination = timetable.stationIndex(command.destinationStationId());
+		if (origin < 0 || destination < 0) {
+			return new ScanResult(serviceDay, List.of());
+		}
+		workspace.arrivalSeconds[workspace.slot(0, origin)] = startSeconds;
+		workspace.mark(origin);
 
-		Map<String, List<Label>> labels = new HashMap<>();
-		labels.put(command.originStationId(), List.of(new Label(
-			command.originStationId(),
-			startSeconds,
-			startSeconds,
-			0,
-			List.of()
-		)));
-
-		for (int round = 0; round <= command.maxTransfers(); round += 1) {
-			for (ScheduledTrip trip : trips) {
-				scanTrip(command, labels, trip, round);
+		int slackSeconds = BoardingSlackPolicy.secondsFor(command.mobilityType());
+		int entrySeconds = profiledWalkSeconds(command, ENTRY_DURATION_SECONDS);
+		int transferSeconds = profiledWalkSeconds(command, TRANSFER_DURATION_SECONDS);
+		for (int round = 0; round <= command.maxTransfers() && workspace.markedStopCount > 0; round += 1) {
+			collectMarkedPatterns(timetable, workspace);
+			Arrays.sort(workspace.markedPatterns, 0, workspace.markedPatternCount);
+			for (int index = 0; index < workspace.markedPatternCount; index += 1) {
+				int pattern = workspace.markedPatterns[index];
+				scanPattern(
+					timetable,
+					activeServiceDay,
+					workspace,
+					pattern,
+					workspace.firstMarkedPosition[pattern],
+					round,
+					round == 0 ? entrySeconds : transferSeconds,
+					slackSeconds
+				);
 			}
+			workspace.finishRound();
 		}
 
-		List<Label> destinationLabels = labels.getOrDefault(command.destinationStationId(), List.of()).stream()
-			.filter(label -> !label.path().isEmpty())
+		List<Label> destinationLabels = destinationLabels(
+			command.destinationStationId(), timetable, workspace, destination, startSeconds)
+			.stream()
 			.sorted(RouteTimetableRaptorPlanner::compareLabels)
 			.limit(candidateLimit(command))
 			.toList();
 		return new ScanResult(serviceDay, destinationLabels);
 	}
 
-	private void scanTrip(
-		SearchRouteV2Command command,
-		Map<String, List<Label>> labels,
-		ScheduledTrip trip,
-		int round
-	) {
-		Boarding boarding = null;
-		List<TransitStopTime> stopTimes = trip.stopTimes();
-		for (int stopIndex = 0; stopIndex < stopTimes.size(); stopIndex += 1) {
-			TransitStopTime stopTime = stopTimes.get(stopIndex);
-			for (Label label : List.copyOf(labels.getOrDefault(stopTime.stationId(), List.of()))) {
-				if (canBoard(command, label, trip, stopIndex, round) && trip.allowsPickup(stopIndex)) {
-					boarding = betterBoarding(boarding, label, stopIndex);
+	private static void collectMarkedPatterns(CompiledTimetable timetable, ScanWorkspace workspace) {
+		for (int index = 0; index < workspace.markedStopCount; index += 1) {
+			int station = workspace.markedStops[index];
+			for (int pattern : timetable.patternsByStop(station)) {
+				int position = indexOf(timetable.stopsByPattern(pattern), station);
+				if (workspace.firstMarkedPosition[pattern] < 0) {
+					workspace.markedPatterns[workspace.markedPatternCount++] = pattern;
+					workspace.firstMarkedPosition[pattern] = position;
+				} else if (position < workspace.firstMarkedPosition[pattern]) {
+					workspace.firstMarkedPosition[pattern] = position;
 				}
 			}
-			if (boarding == null || stopIndex <= boarding.stopIndex() || !trip.allowsDropOff(stopIndex)) {
-				continue;
+		}
+	}
+
+	private static int indexOf(int[] values, int target) {
+		for (int index = 0; index < values.length; index += 1) {
+			if (values[index] == target) {
+				return index;
 			}
-			addLabel(labels, new Label(
-				stopTime.stationId(),
-				trip.arrivalSeconds(stopIndex),
-				boarding.label().startSeconds(),
-				boarding.label().boardings() + 1,
-				withLeg(boarding.label().path(), new RideLeg(trip, boarding.stopIndex(), stopIndex))
-			));
 		}
+		return -1;
 	}
 
-	private boolean canBoard(SearchRouteV2Command command, Label label, ScheduledTrip trip, int stopIndex, int round) {
-		int slackSeconds = BoardingSlackPolicy.secondsFor(command.mobilityType());
-		int accessSeconds = profiledWalkSeconds(
-			command,
-			label.boardings() > 0 ? TRANSFER_DURATION_SECONDS : ENTRY_DURATION_SECONDS
-		);
-		return label.boardings() == round
-			&& trip.departureSeconds(stopIndex) >= label.timeSeconds() + accessSeconds + slackSeconds;
-	}
-
-	private Boarding betterBoarding(Boarding current, Label label, int stopIndex) {
-		if (current == null || label.timeSeconds() < current.label().timeSeconds()) {
-			return new Boarding(label, stopIndex);
-		}
-		return current;
-	}
-
-	private void addLabel(Map<String, List<Label>> labels, Label candidate) {
-		List<Label> stationLabels = labels.getOrDefault(candidate.stationId(), List.of());
-		if (stationLabels.stream().anyMatch(existing -> sameLabel(existing, candidate) || dominates(existing, candidate))) {
+	private static void scanPattern(
+		CompiledTimetable timetable,
+		ActiveServiceDay activeServiceDay,
+		ScanWorkspace workspace,
+		int pattern,
+		int firstMarkedPosition,
+		int round,
+		int accessSeconds,
+		int slackSeconds
+	) {
+		workspace.expandedRoutes += 1;
+		List<ScheduledTrip> trips = activeServiceDay.tripsByPattern(pattern, firstMarkedPosition);
+		if (trips.isEmpty()) {
 			return;
 		}
-		List<Label> kept = new ArrayList<>();
-		for (Label existing : stationLabels) {
-			if (!dominates(candidate, existing)) {
-				kept.add(existing);
+		int[] stops = timetable.stopsByPattern(pattern);
+		ScheduledTrip boardedTrip = null;
+		int boardingPosition = -1;
+		for (int position = firstMarkedPosition; position < stops.length; position += 1) {
+			trips = activeServiceDay.tripsByPattern(pattern, position);
+			int station = stops[position];
+			if (boardedTrip != null && position > boardingPosition && boardedTrip.allowsDropOff(position)) {
+				workspace.relax(
+					station,
+					round + 1,
+					boardedTrip.arrivalSeconds(position),
+					boardedTrip.index(),
+					boardingPosition,
+					position
+				);
+			}
+			int readySeconds = workspace.arrivalSeconds[workspace.slot(round, station)];
+			if (readySeconds == UNREACHED) {
+				continue;
+			}
+			ScheduledTrip candidate = earliestBoardableTrip(
+				trips,
+				position,
+				readySeconds + accessSeconds + slackSeconds
+			);
+			if (candidate != null && (boardedTrip == null
+				|| candidate.departureSeconds(position) < boardedTrip.departureSeconds(position))) {
+				boardedTrip = candidate;
+				boardingPosition = position;
+				workspace.expandedTrips += 1;
 			}
 		}
-		kept.add(candidate);
-		kept.sort(RouteTimetableRaptorPlanner::compareLabels);
-		List<Label> bestByBoardings = new ArrayList<>();
-		for (Label label : kept) {
-			if (bestByBoardings.stream().noneMatch(existing -> existing.boardings() == label.boardings())) {
-				bestByBoardings.add(label);
+	}
+
+	private static ScheduledTrip earliestBoardableTrip(
+		List<ScheduledTrip> trips,
+		int stopPosition,
+		int earliestDepartureSeconds
+	) {
+		int low = 0;
+		int high = trips.size();
+		while (low < high) {
+			int middle = (low + high) >>> 1;
+			if (trips.get(middle).departureSeconds(stopPosition) < earliestDepartureSeconds) {
+				low = middle + 1;
+			} else {
+				high = middle;
 			}
 		}
-		labels.put(candidate.stationId(), List.copyOf(bestByBoardings.stream().limit(PARETO_LIMIT).toList()));
+		while (low < trips.size()) {
+			ScheduledTrip trip = trips.get(low++);
+			if (trip.allowsPickup(stopPosition)) {
+				return trip;
+			}
+		}
+		return null;
+	}
+
+	private static List<Label> destinationLabels(
+		String destinationStationId,
+		CompiledTimetable timetable,
+		ScanWorkspace workspace,
+		int destination,
+		int startSeconds
+	) {
+		List<Label> labels = new ArrayList<>(PARETO_LIMIT);
+		for (int boardings = 1; boardings <= PARETO_LIMIT; boardings += 1) {
+			int slot = workspace.slot(boardings, destination);
+			if (workspace.arrivalSeconds[slot] == UNREACHED) {
+				continue;
+			}
+			List<RideLeg> path = new ArrayList<>(boardings);
+			int station = destination;
+			int currentBoardings = boardings;
+			while (currentBoardings > 0) {
+				int currentSlot = workspace.slot(currentBoardings, station);
+				ScheduledTrip trip = timetable.scheduledTrip(workspace.parentTrip[currentSlot]);
+				int boardingPosition = workspace.parentBoardStop[currentSlot];
+				int alightingPosition = workspace.parentAlightStop[currentSlot];
+				path.add(new RideLeg(trip, boardingPosition, alightingPosition));
+				station = timetable.stationIndex(trip.stopTimes().get(boardingPosition).stationId());
+				currentBoardings -= 1;
+			}
+			java.util.Collections.reverse(path);
+			labels.add(new Label(
+				destinationStationId,
+				workspace.arrivalSeconds[slot],
+				startSeconds,
+				boardings,
+				List.copyOf(path)
+			));
+		}
+		return labels;
 	}
 
 	private static int candidateLimit(SearchRouteV2Command command) {
 		return Math.max(command.alternativeCount(), command.maxTransfers() + 1);
-	}
-
-	private static boolean dominates(Label left, Label right) {
-		return left.timeSeconds() <= right.timeSeconds()
-			&& left.boardings() <= right.boardings()
-			&& (left.timeSeconds() < right.timeSeconds() || left.boardings() < right.boardings());
-	}
-
-	private static boolean sameLabel(Label left, Label right) {
-		return left.timeSeconds() == right.timeSeconds()
-			&& left.boardings() == right.boardings()
-			&& left.path().stream().map(RideLeg::tripId).toList().equals(right.path().stream().map(RideLeg::tripId).toList());
 	}
 
 	private static int compareLabels(Label left, Label right) {
@@ -348,12 +434,6 @@ class RouteTimetableRaptorPlanner {
 			.thenComparingInt(Label::boardings)
 			.thenComparingInt(label -> label.path().size())
 			.compare(left, right);
-	}
-
-	private static List<RideLeg> withLeg(List<RideLeg> path, RideLeg leg) {
-		List<RideLeg> next = new ArrayList<>(path);
-		next.add(leg);
-		return List.copyOf(next);
 	}
 
 	private static RouteSearchResult toRouteSearchResult(
@@ -619,7 +699,7 @@ class RouteTimetableRaptorPlanner {
 		List<TransitFrequency> frequencies
 	) {
 		if (frequencies.isEmpty()) {
-			return List.of(new ScheduledTrip(trip, route, stopTimes, new PrimitiveTripTimes(stopTimes)));
+			return List.of(new ScheduledTrip(-1, trip, route, stopTimes, new PrimitiveTripTimes(stopTimes)));
 		}
 		int firstDepartureSeconds = stopTimes.getFirst().departureSeconds();
 		List<ScheduledTrip> scheduledTrips = new ArrayList<>();
@@ -632,7 +712,7 @@ class RouteTimetableRaptorPlanner {
 				 departureSeconds += frequency.headwaySeconds()) {
 				shiftedStopTimes(stopTimes, departureSeconds - firstDepartureSeconds)
 					.ifPresent(shifted -> scheduledTrips.add(
-						new ScheduledTrip(trip, route, shifted, new PrimitiveTripTimes(shifted))));
+						new ScheduledTrip(-1, trip, route, shifted, new PrimitiveTripTimes(shifted))));
 			}
 		}
 		return List.copyOf(scheduledTrips);
@@ -732,6 +812,9 @@ class RouteTimetableRaptorPlanner {
 			}
 			compiledTrips.sort(Comparator.comparing((ScheduledTrip scheduledTrip) -> scheduledTrip.trip().id())
 				.thenComparingInt(scheduledTrip -> scheduledTrip.departureSeconds(0)));
+			for (int index = 0; index < compiledTrips.size(); index += 1) {
+				compiledTrips.set(index, compiledTrips.get(index).withIndex(index));
+			}
 			scheduledTrips = List.copyOf(compiledTrips);
 			CompiledRoutePatterns routePatterns = compileRoutePatterns(scheduledTrips, routeIndex, stationIndex);
 			stopsByPattern = routePatterns.stopsByPattern();
@@ -754,6 +837,10 @@ class RouteTimetableRaptorPlanner {
 			return stationIndex.size();
 		}
 
+		int stationIndex(String stationId) {
+			return stationIndex.getOrDefault(stationId, -1);
+		}
+
 		Set<String> coveredStationIds() {
 			return stationIndex.keySet();
 		}
@@ -768,6 +855,18 @@ class RouteTimetableRaptorPlanner {
 
 		int routePatternCount() {
 			return stopsByPattern.size();
+		}
+
+		int[] stopsByPattern(int pattern) {
+			return stopsByPattern.get(pattern);
+		}
+
+		int[] patternsByStop(int station) {
+			return patternsByStop.getOrDefault(station, NO_PATTERNS);
+		}
+
+		ScheduledTrip scheduledTrip(int index) {
+			return scheduledTrips.get(index);
 		}
 
 		int routePatternTripLinkCount() {
@@ -791,7 +890,24 @@ class RouteTimetableRaptorPlanner {
 			List<ScheduledTrip> activeTrips = scheduledTrips.stream()
 				.filter(trip -> activeServiceIds.contains(trip.trip().serviceId()))
 				.toList();
-			ActiveServiceDay compiled = new ActiveServiceDay(activeTrips);
+			Map<Integer, List<List<ScheduledTrip>>> activeTripsByPattern = new HashMap<>();
+			for (Map.Entry<Integer, List<ScheduledTrip>> entry : tripsByPattern.entrySet()) {
+				List<ScheduledTrip> patternTrips = entry.getValue().stream()
+					.filter(trip -> activeServiceIds.contains(trip.trip().serviceId()))
+					.toList();
+				if (!patternTrips.isEmpty()) {
+					List<List<ScheduledTrip>> tripsByStop = new ArrayList<>();
+					for (int stop = 0; stop < stopsByPattern.get(entry.getKey()).length; stop += 1) {
+						int stopIndex = stop;
+						tripsByStop.add(patternTrips.stream()
+							.sorted(Comparator.comparingInt((ScheduledTrip trip) -> trip.departureSeconds(stopIndex))
+								.thenComparingInt(ScheduledTrip::index))
+							.toList());
+					}
+					activeTripsByPattern.put(entry.getKey(), List.copyOf(tripsByStop));
+				}
+			}
+			ActiveServiceDay compiled = new ActiveServiceDay(activeTrips, Map.copyOf(activeTripsByPattern));
 			activeServiceDays.put(serviceDate, compiled);
 			if (activeServiceDays.size() > ACTIVE_SERVICE_DAY_CACHE_SIZE) {
 				activeServiceDays.remove(activeServiceDays.sequencedKeySet().getFirst());
@@ -901,14 +1017,21 @@ class RouteTimetableRaptorPlanner {
 	static final class ActiveServiceDay {
 
 		private final List<ScheduledTrip> trips;
+		private final Map<Integer, List<List<ScheduledTrip>>> tripsByPattern;
 		private volatile Map<String, List<BoardingStop>> boardingsByStation;
 
-		private ActiveServiceDay(List<ScheduledTrip> trips) {
+		private ActiveServiceDay(List<ScheduledTrip> trips, Map<Integer, List<List<ScheduledTrip>>> tripsByPattern) {
 			this.trips = List.copyOf(trips);
+			this.tripsByPattern = tripsByPattern;
 		}
 
 		private List<ScheduledTrip> trips() {
 			return trips;
+		}
+
+		private List<ScheduledTrip> tripsByPattern(int pattern, int stopPosition) {
+			List<List<ScheduledTrip>> tripsByStop = tripsByPattern.get(pattern);
+			return tripsByStop == null ? List.of() : tripsByStop.get(stopPosition);
 		}
 
 		boolean boardingIndexInitialized() {
@@ -969,6 +1092,115 @@ class RouteTimetableRaptorPlanner {
 		}
 	}
 
+	private static final class ScanWorkspace {
+
+		private int stationCount;
+		private int[] arrivalSeconds = new int[0];
+		private int[] parentTrip = new int[0];
+		private int[] parentBoardStop = new int[0];
+		private int[] parentAlightStop = new int[0];
+		private int[] markedStops = new int[0];
+		private int[] nextMarkedStops = new int[0];
+		private boolean[] marked = new boolean[0];
+		private boolean[] nextMarked = new boolean[0];
+		private int markedStopCount;
+		private int nextMarkedStopCount;
+		private int[] markedPatterns = new int[0];
+		private int[] firstMarkedPosition = new int[0];
+		private int markedPatternCount;
+		private int expandedRoutes;
+		private int expandedTrips;
+
+		private void prepare(int requiredStationCount, int patternCount) {
+			stationCount = requiredStationCount;
+			int labelSlots = Math.multiplyExact(requiredStationCount, LABEL_SLOT_COUNT);
+			if (arrivalSeconds.length < labelSlots) {
+				arrivalSeconds = new int[labelSlots];
+				parentTrip = new int[labelSlots];
+				parentBoardStop = new int[labelSlots];
+				parentAlightStop = new int[labelSlots];
+			}
+			if (markedStops.length < requiredStationCount) {
+				markedStops = new int[requiredStationCount];
+				nextMarkedStops = new int[requiredStationCount];
+				marked = new boolean[requiredStationCount];
+				nextMarked = new boolean[requiredStationCount];
+			}
+			if (markedPatterns.length < patternCount) {
+				markedPatterns = new int[patternCount];
+				firstMarkedPosition = new int[patternCount];
+			}
+			Arrays.fill(arrivalSeconds, 0, labelSlots, UNREACHED);
+			Arrays.fill(parentTrip, 0, labelSlots, -1);
+			Arrays.fill(parentBoardStop, 0, labelSlots, -1);
+			Arrays.fill(parentAlightStop, 0, labelSlots, -1);
+			Arrays.fill(marked, 0, requiredStationCount, false);
+			Arrays.fill(nextMarked, 0, requiredStationCount, false);
+			Arrays.fill(firstMarkedPosition, 0, patternCount, -1);
+			markedStopCount = 0;
+			nextMarkedStopCount = 0;
+			markedPatternCount = 0;
+			expandedRoutes = 0;
+			expandedTrips = 0;
+		}
+
+		private int slot(int boardings, int station) {
+			return boardings * stationCount + station;
+		}
+
+		private void mark(int station) {
+			if (!marked[station]) {
+				marked[station] = true;
+				markedStops[markedStopCount++] = station;
+			}
+		}
+
+		private void relax(
+			int station,
+			int boardings,
+			int candidateArrivalSeconds,
+			int trip,
+			int boardStop,
+			int alightStop
+		) {
+			int candidateSlot = slot(boardings, station);
+			if (arrivalSeconds[candidateSlot] <= candidateArrivalSeconds) {
+				return;
+			}
+			for (int fewerBoardings = 0; fewerBoardings < boardings; fewerBoardings += 1) {
+				if (arrivalSeconds[slot(fewerBoardings, station)] <= candidateArrivalSeconds) {
+					return;
+				}
+			}
+			arrivalSeconds[candidateSlot] = candidateArrivalSeconds;
+			parentTrip[candidateSlot] = trip;
+			parentBoardStop[candidateSlot] = boardStop;
+			parentAlightStop[candidateSlot] = alightStop;
+			if (!nextMarked[station]) {
+				nextMarked[station] = true;
+				nextMarkedStops[nextMarkedStopCount++] = station;
+			}
+		}
+
+		private void finishRound() {
+			for (int index = 0; index < markedStopCount; index += 1) {
+				marked[markedStops[index]] = false;
+			}
+			for (int index = 0; index < markedPatternCount; index += 1) {
+				firstMarkedPosition[markedPatterns[index]] = -1;
+			}
+			int[] oldMarkedStops = markedStops;
+			markedStops = nextMarkedStops;
+			nextMarkedStops = oldMarkedStops;
+			boolean[] oldMarked = marked;
+			marked = nextMarked;
+			nextMarked = oldMarked;
+			markedStopCount = nextMarkedStopCount;
+			nextMarkedStopCount = 0;
+			markedPatternCount = 0;
+		}
+	}
+
 	private static ServiceDay serviceDay(SearchRouteV2Command command) {
 		ZonedDateTime departure = command.departureTime().atZoneSameInstant(SERVICE_ZONE);
 		LocalDate serviceDate = departure.toLocalDate();
@@ -988,6 +1220,9 @@ class RouteTimetableRaptorPlanner {
 	private record ScanResult(ServiceDay serviceDay, List<Label> labels) {
 	}
 
+	record ScanMetrics(int expandedRoutes, int expandedTrips, int workspaceIdentity) {
+	}
+
 	private record RoutePatternKey(int routeIndex, List<Integer> stationSequence) {
 	}
 
@@ -1000,15 +1235,17 @@ class RouteTimetableRaptorPlanner {
 	private record Label(String stationId, int timeSeconds, int startSeconds, int boardings, List<RideLeg> path) {
 	}
 
-	private record Boarding(Label label, int stopIndex) {
-	}
-
 	private record ScheduledTrip(
+		int index,
 		TransitTrip trip,
 		TransitRoute route,
 		List<TransitStopTime> stopTimes,
 		PrimitiveTripTimes times
 	) {
+		private ScheduledTrip withIndex(int denseIndex) {
+			return new ScheduledTrip(denseIndex, trip, route, stopTimes, times);
+		}
+
 		private int arrivalSeconds(int stopIndex) {
 			return times.arrivalSeconds(stopIndex);
 		}

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -2607,6 +2607,19 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("역 내부 Dijkstra 후보는 경로 리스트를 보관하지 않는다")
+	void internalRouteCandidateDoesNotCarryPathList() {
+		Class<?> candidateType = java.util.Arrays.stream(RouteSearchService.class.getDeclaredClasses())
+			.filter(type -> type.getSimpleName().equals("InternalRouteCandidate"))
+			.findFirst()
+			.orElseThrow();
+
+		assertThat(candidateType.getRecordComponents())
+			.extracting(java.lang.reflect.RecordComponent::getName)
+			.containsExactly("nodeId", "cost");
+	}
+
+	@Test
 	@DisplayName("역 내부 이동 경로는 활성 노드와 간선을 단계로 반환한다")
 	void searchInternalRouteReturnsActiveRouteEdgesAsSteps() {
 		var result = service.searchInternalRoute(new SearchInternalRouteCommand(

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -2620,6 +2620,29 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("역 내부 predecessor는 더 짧은 후속 relax의 전체 경로를 순서대로 복원한다")
+	void internalRouteReconstructsLaterShorterRelaxation() {
+		var repository = new InMemoryRouteSearchRepository();
+		var routeEdgeService = new RouteSearchService(
+			repository,
+			repository,
+			new LaterShorterInternalTransitMasterPort(),
+			CLOCK
+		);
+
+		var result = routeEdgeService.searchInternalRoute(new SearchInternalRouteCommand(
+			"station-a",
+			"node-station-a-entrance",
+			"node-station-a-platform",
+			MobilityType.STROLLER
+		));
+
+		assertThat(result.steps())
+			.extracting("edgeId")
+			.containsExactly("edge-shortcut", "edge-shortcut-to-merge", "edge-merge-to-platform");
+	}
+
+	@Test
 	@DisplayName("역 내부 이동 경로는 활성 노드와 간선을 단계로 반환한다")
 	void searchInternalRouteReturnsActiveRouteEdgesAsSteps() {
 		var result = service.searchInternalRoute(new SearchInternalRouteCommand(
@@ -4817,6 +4840,37 @@ class RouteSearchServiceTest {
 			return List.of(
 				routeNode("node-station-a-entrance", "station-a", RouteNodeType.ENTRANCE, "출입구"),
 				routeNode("node-station-a-landing", "station-a", RouteNodeType.CONCOURSE, "중간 지점"),
+				routeNode("node-station-a-platform", "station-a", RouteNodeType.PLATFORM, "승강장")
+			);
+		}
+	}
+
+	private static class LaterShorterInternalTransitMasterPort extends ExitSummaryAccessibleTransitMasterPort {
+
+		@Override
+		public List<RouteEdge> loadRouteEdges() {
+			return List.of(
+				internalEdge(
+					"edge-long-to-merge", "node-station-a-entrance", "node-station-a-merge",
+					RouteEdgeType.WALKWAY, 100, 100, false),
+				internalEdge(
+					"edge-shortcut", "node-station-a-entrance", "node-station-a-shortcut",
+					RouteEdgeType.WALKWAY, 10, 10, false),
+				internalEdge(
+					"edge-shortcut-to-merge", "node-station-a-shortcut", "node-station-a-merge",
+					RouteEdgeType.WALKWAY, 10, 10, false),
+				internalEdge(
+					"edge-merge-to-platform", "node-station-a-merge", "node-station-a-platform",
+					RouteEdgeType.WALKWAY, 10, 10, false)
+			);
+		}
+
+		@Override
+		public List<RouteNode> loadRouteNodes() {
+			return List.of(
+				routeNode("node-station-a-entrance", "station-a", RouteNodeType.ENTRANCE, "출입구"),
+				routeNode("node-station-a-shortcut", "station-a", RouteNodeType.CONCOURSE, "지름길"),
+				routeNode("node-station-a-merge", "station-a", RouteNodeType.CONCOURSE, "합류점"),
 				routeNode("node-station-a-platform", "station-a", RouteNodeType.PLATFORM, "승강장")
 			);
 		}

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerBenchmarkTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerBenchmarkTest.java
@@ -46,6 +46,9 @@ class RouteTimetableRaptorPlannerBenchmarkTest {
 	private static final int WARMUPS = 20;
 	private static final int MEASUREMENTS = 100;
 	private static RouteV2Planner planner;
+	private static RouteTimetableRaptorPlanner raptorPlanner;
+	private static int legacyExpandedRoutes;
+	private static int legacyExpandedTrips;
 
 	@BeforeAll
 	static void setUpFixture() throws Exception {
@@ -94,6 +97,12 @@ class RouteTimetableRaptorPlannerBenchmarkTest {
 			}
 		};
 		planner = new RouteV2Planner(new NoLegacyRouteSearch(), port);
+		var plannerField = RouteV2Planner.class.getDeclaredField("timetableRaptorPlanner");
+		plannerField.setAccessible(true);
+		raptorPlanner = (RouteTimetableRaptorPlanner) plannerField.get(planner);
+		var compiled = raptorPlanner.compile(timetable);
+		legacyExpandedRoutes = compiled.routePatternCount();
+		legacyExpandedTrips = compiled.activeTripCount(java.time.LocalDate.of(2026, 7, 6));
 	}
 
 	@Test
@@ -161,12 +170,18 @@ class RouteTimetableRaptorPlannerBenchmarkTest {
 		}
 		System.out.printf(
 			"BENCHMARK_RAW {\"fixture\":\"%s\",\"fixtureSha256\":\"%s\",\"scenario\":\"%s\","
-				+ "\"warmups\":%d,\"measurements\":%d,\"nanos\":%s,\"allocatedBytes\":%s}%n",
+				+ "\"warmups\":%d,\"measurements\":%d,\"legacyExpandedRoutes\":%d,\"legacyExpandedTrips\":%d,"
+				+ "\"expandedRoutes\":%d,\"expandedTrips\":%d,"
+				+ "\"nanos\":%s,\"allocatedBytes\":%s}%n",
 			FIXTURE,
 			FIXTURE_SHA256,
 			scenario,
 			WARMUPS,
 			MEASUREMENTS,
+			legacyExpandedRoutes,
+			legacyExpandedTrips,
+			raptorPlanner.lastScanMetrics().expandedRoutes(),
+			raptorPlanner.lastScanMetrics().expandedTrips(),
 			Arrays.toString(nanos),
 			Arrays.toString(allocatedBytes)
 		);

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerCompiledSnapshotTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerCompiledSnapshotTest.java
@@ -236,6 +236,36 @@ class RouteTimetableRaptorPlannerCompiledSnapshotTest {
 	}
 
 	@Test
+	@DisplayName("후속 stop의 동일 출발 trip이 더 빨리 도착하면 해당 trip으로 전환한다")
+	void switchesToFasterTripWithSameDepartureAtLaterStop() {
+		var command = new SearchRouteV2Command(
+			"station-origin",
+			"station-d",
+			OffsetDateTime.parse("2026-07-01T08:40:00+09:00"),
+			MobilityType.SENIOR,
+			ConstraintMode.ALLOW_WITH_WARNINGS,
+			false,
+			1,
+			1
+		);
+
+		var results = planner.search(command, planner.compile(sameDepartureDownstreamTimetable()));
+
+		assertThat(results).hasSize(1);
+		assertThat(results.getFirst().steps())
+			.filteredOn(step -> "ride".equals(step.stepType()))
+			.extracting("tripId")
+			.containsExactly("feeder-b", "a-fast");
+		assertThat(results.getFirst().steps())
+			.filteredOn(step -> "ride".equals(step.stepType()))
+			.extracting("plannedArrivalTime")
+			.containsExactly(
+				"2026-07-01T09:05:00+09:00",
+				"2026-07-01T09:25:00+09:00"
+			);
+	}
+
+	@Test
 	@DisplayName("같은 정차열에서 하차 정책이 다른 후속 trip을 잃지 않는다")
 	void preservesLaterTripWhenEarlierTripBlocksDropOff() {
 		var results = planner.search(
@@ -527,6 +557,54 @@ class RouteTimetableRaptorPlannerCompiledSnapshotTest {
 					"feeder-e", 1, "station-a", "line-e", 32520, 32520, 0, 0),
 				new LoadRouteTimetablePort.TransitStopTime(
 					"feeder-e", 2, "station-e", "line-e", 32640, 32640, 0, 0)
+			),
+			List.of()
+		);
+	}
+
+	private static RouteTimetable sameDepartureDownstreamTimetable() {
+		return new RouteTimetable(
+			List.of(weekday("weekday")),
+			List.of(),
+			List.of(
+				new LoadRouteTimetablePort.TransitRoute(
+					"route-feeder-a", "line-fa", "FA", "A 연결", "A 방면", "Asia/Seoul"),
+				new LoadRouteTimetablePort.TransitRoute(
+					"route-feeder-b", "line-fb", "FB", "B 연결", "B 방면", "Asia/Seoul"),
+				new LoadRouteTimetablePort.TransitRoute(
+					"route-main", "line-main", "M", "본선", "D 방면", "Asia/Seoul")
+			),
+			List.of(
+				new LoadRouteTimetablePort.TransitTrip(
+					"a-fast", "route-main", "weekday", "D", "0", "EXPRESS", 0),
+				new LoadRouteTimetablePort.TransitTrip(
+					"feeder-a", "route-feeder-a", "weekday", "A", "0", "LOCAL", 0),
+				new LoadRouteTimetablePort.TransitTrip(
+					"feeder-b", "route-feeder-b", "weekday", "B", "0", "LOCAL", 0),
+				new LoadRouteTimetablePort.TransitTrip(
+					"z-slow", "route-main", "weekday", "D", "0", "LOCAL", 0)
+			),
+			List.of(
+				new LoadRouteTimetablePort.TransitStopTime(
+					"a-fast", 1, "station-a", "line-main", 32100, 32100, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime(
+					"a-fast", 2, "station-b", "line-main", 33600, 33600, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime(
+					"a-fast", 3, "station-d", "line-main", 33900, 33900, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime(
+					"feeder-a", 1, "station-origin", "line-fa", 31620, 31620, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime(
+					"feeder-a", 2, "station-a", "line-fa", 32400, 32400, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime(
+					"feeder-b", 1, "station-origin", "line-fb", 31680, 31680, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime(
+					"feeder-b", 2, "station-b", "line-fb", 32700, 32700, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime(
+					"z-slow", 1, "station-a", "line-main", 33000, 33000, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime(
+					"z-slow", 2, "station-b", "line-main", 33600, 33600, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime(
+					"z-slow", 3, "station-d", "line-main", 34200, 34200, 0, 0)
 			),
 			List.of()
 		);

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerCompiledSnapshotTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerCompiledSnapshotTest.java
@@ -285,7 +285,7 @@ class RouteTimetableRaptorPlannerCompiledSnapshotTest {
 		assertThat(results.getFirst().steps())
 			.filteredOn(step -> "ride".equals(step.stepType()))
 			.extracting("tripId")
-			.containsExactly("feeder-a", "z-fast");
+			.containsExactly("feeder-b", "z-fast");
 		assertThat(results.getFirst().steps())
 			.filteredOn(step -> "ride".equals(step.stepType()))
 			.extracting("plannedArrivalTime")
@@ -664,7 +664,7 @@ class RouteTimetableRaptorPlannerCompiledSnapshotTest {
 			),
 			List.of(
 				new LoadRouteTimetablePort.TransitStopTime(
-					"a-slow", 1, "station-a", "line-main", 33300, 33300, 0, 0),
+					"a-slow", 1, "station-a", "line-main", 33600, 33600, 0, 0),
 				new LoadRouteTimetablePort.TransitStopTime(
 					"a-slow", 2, "station-b", "line-main", 33900, 34200, 0, 0),
 				new LoadRouteTimetablePort.TransitStopTime(
@@ -672,13 +672,13 @@ class RouteTimetableRaptorPlannerCompiledSnapshotTest {
 				new LoadRouteTimetablePort.TransitStopTime(
 					"feeder-a", 1, "station-origin", "line-fa", 31620, 31620, 0, 0),
 				new LoadRouteTimetablePort.TransitStopTime(
-					"feeder-a", 2, "station-a", "line-fa", 32400, 32400, 0, 0),
+					"feeder-a", 2, "station-a", "line-fa", 32700, 32700, 0, 0),
 				new LoadRouteTimetablePort.TransitStopTime(
 					"feeder-b", 1, "station-origin", "line-fb", 31680, 31680, 0, 0),
 				new LoadRouteTimetablePort.TransitStopTime(
-					"feeder-b", 2, "station-b", "line-fb", 33300, 33300, 0, 0),
+					"feeder-b", 2, "station-b", "line-fb", 32400, 32400, 0, 0),
 				new LoadRouteTimetablePort.TransitStopTime(
-					"z-fast", 1, "station-a", "line-main", 33000, 33000, 0, 0),
+					"z-fast", 1, "station-a", "line-main", 33300, 33300, 0, 0),
 				new LoadRouteTimetablePort.TransitStopTime(
 					"z-fast", 2, "station-b", "line-main", 33600, 34200, 0, 0),
 				new LoadRouteTimetablePort.TransitStopTime(

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerCompiledSnapshotTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerCompiledSnapshotTest.java
@@ -197,6 +197,22 @@ class RouteTimetableRaptorPlannerCompiledSnapshotTest {
 	}
 
 	@Test
+	@DisplayName("후행 trip이 downstream에서 합류해도 기존 trip-id 동률 순서를 유지한다")
+	void preservesLegacyTripOrderWhenLaterTripMergesDownstream() {
+		var results = planner.search(
+			command("station-a", "station-c", "2026-07-01T08:50:00+09:00"),
+			planner.compile(mergingTimetable())
+		);
+
+		assertThat(results).hasSize(1);
+		assertThat(results.getFirst().steps())
+			.filteredOn(step -> "ride".equals(step.stepType()))
+			.extracting("tripId", "plannedArrivalTime")
+			.containsExactly(org.assertj.core.groups.Tuple.tuple(
+				"a-late", "2026-07-01T09:20:00+09:00"));
+	}
+
+	@Test
 	@DisplayName("같은 정차열에서 하차 정책이 다른 후속 trip을 잃지 않는다")
 	void preservesLaterTripWhenEarlierTripBlocksDropOff() {
 		var results = planner.search(
@@ -426,6 +442,28 @@ class RouteTimetableRaptorPlannerCompiledSnapshotTest {
 				stop("a-fast", 1, "station-a", 33000),
 				stop("a-fast", 2, "station-b", 33300),
 				stop("a-fast", 3, "station-c", 34500)
+			),
+			List.of()
+		);
+	}
+
+	private static RouteTimetable mergingTimetable() {
+		return timetable(
+			List.of(weekday("weekday")),
+			List.of(),
+			List.of(
+				new LoadRouteTimetablePort.TransitTrip(
+					"z-early", "route", "weekday", "도착", "0", "LOCAL", 0),
+				new LoadRouteTimetablePort.TransitTrip(
+					"a-late", "route", "weekday", "도착", "0", "LOCAL", 0)
+			),
+			List.of(
+				stop("z-early", 1, "station-a", 32400),
+				stop("z-early", 2, "station-b", 33000),
+				stop("z-early", 3, "station-c", 33600),
+				stop("a-late", 1, "station-a", 32700),
+				stop("a-late", 2, "station-b", 33000),
+				stop("a-late", 3, "station-c", 33600)
 			),
 			List.of()
 		);

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerCompiledSnapshotTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerCompiledSnapshotTest.java
@@ -165,6 +165,37 @@ class RouteTimetableRaptorPlannerCompiledSnapshotTest {
 	}
 
 	@Test
+	@DisplayName("출발 stop에서 함께 탑승 가능한 추월 trip의 더 빠른 downstream 도착을 보존한다")
+	void preservesFasterDownstreamArrivalFromOvertakingTrip() {
+		var results = planner.search(
+			command("station-a", "station-c", "2026-07-01T08:50:00+09:00"),
+			planner.compile(overtakingTimetable())
+		);
+
+		assertThat(results).hasSize(1);
+		assertThat(results.getFirst().steps())
+			.filteredOn(step -> "ride".equals(step.stepType()))
+			.extracting("tripId", "plannedArrivalTime")
+			.containsExactly(org.assertj.core.groups.Tuple.tuple(
+				"trip-fast", "2026-07-01T09:35:00+09:00"));
+	}
+
+	@Test
+	@DisplayName("같은 정차열에서 하차 정책이 다른 후속 trip을 잃지 않는다")
+	void preservesLaterTripWhenEarlierTripBlocksDropOff() {
+		var results = planner.search(
+			command("station-a", "station-b", "2026-07-01T08:50:00+09:00"),
+			planner.compile(dropOffVariantTimetable())
+		);
+
+		assertThat(results).hasSize(1);
+		assertThat(results.getFirst().steps())
+			.filteredOn(step -> "ride".equals(step.stepType()))
+			.extracting("tripId")
+			.containsExactly("trip-usable");
+	}
+
+	@Test
 	@DisplayName("동시 nextServiceTime은 service day boarding index를 안전하게 lazy publish한다")
 	void concurrentNextServiceTimeLazilyPublishesBoardingIndex() throws Exception {
 		var compiled = planner.compile(frequencyTimetable());
@@ -341,6 +372,27 @@ class RouteTimetableRaptorPlannerCompiledSnapshotTest {
 		);
 	}
 
+	private static RouteTimetable dropOffVariantTimetable() {
+		return timetable(
+			List.of(weekday("weekday")),
+			List.of(),
+			List.of(
+				new LoadRouteTimetablePort.TransitTrip(
+					"trip-blocked", "route", "weekday", "도착", "0", "LOCAL", 0),
+				new LoadRouteTimetablePort.TransitTrip(
+					"trip-usable", "route", "weekday", "도착", "0", "LOCAL", 0)
+			),
+			List.of(
+				stop("trip-blocked", 1, "station-a", 32400),
+				new LoadRouteTimetablePort.TransitStopTime(
+					"trip-blocked", 2, "station-b", "line", 33000, 33000, 0, 1),
+				stop("trip-usable", 1, "station-a", 32700),
+				stop("trip-usable", 2, "station-b", 33300)
+			),
+			List.of()
+		);
+	}
+
 	private static LoadRouteTimetablePort.ServiceCalendar weekday(String serviceId) {
 		return new LoadRouteTimetablePort.ServiceCalendar(
 			serviceId, true, true, true, true, true, false, false,
@@ -385,6 +437,19 @@ class RouteTimetableRaptorPlannerCompiledSnapshotTest {
 			false,
 			0,
 			3
+		);
+	}
+
+	private static SearchRouteV2Command command(String origin, String destination, String departureTime) {
+		return new SearchRouteV2Command(
+			origin,
+			destination,
+			OffsetDateTime.parse(departureTime),
+			MobilityType.SENIOR,
+			ConstraintMode.ALLOW_WITH_WARNINGS,
+			false,
+			0,
+			1
 		);
 	}
 

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerCompiledSnapshotTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerCompiledSnapshotTest.java
@@ -141,6 +141,21 @@ class RouteTimetableRaptorPlannerCompiledSnapshotTest {
 	}
 
 	@Test
+	@DisplayName("route 메타데이터가 없어도 stop line fallback으로 경로를 검색한다")
+	void searchesTripWithoutRouteMetadata() {
+		var results = planner.search(
+			command(WEDNESDAY, 8, 50),
+			planner.compile(missingRouteMetadataTimetable())
+		);
+
+		assertThat(results).hasSize(1);
+		assertThat(results.getFirst().steps())
+			.filteredOn(step -> "ride".equals(step.stepType()))
+			.extracting("lineId", "lineName")
+			.containsExactly(org.assertj.core.groups.Tuple.tuple("line-fallback", "line-fallback"));
+	}
+
+	@Test
 	@DisplayName("중간 stop에서 추월한 trip도 해당 stop 출발 시각 순서로 이진 탐색한다")
 	void binarySearchesTripsInDepartureOrderAtEachStop() {
 		var command = new SearchRouteV2Command(
@@ -476,6 +491,23 @@ class RouteTimetableRaptorPlannerCompiledSnapshotTest {
 					"trip-other", 1, "station-x", "line-other", 32400, 32400, 0, 0),
 				new LoadRouteTimetablePort.TransitStopTime(
 					"trip-other", 2, "station-y", "line-other", 33000, 33000, 0, 0)
+			),
+			List.of()
+		);
+	}
+
+	private static RouteTimetable missingRouteMetadataTimetable() {
+		return new RouteTimetable(
+			List.of(weekday("weekday")),
+			List.of(),
+			List.of(),
+			List.of(new LoadRouteTimetablePort.TransitTrip(
+				"trip-missing-route", "route-missing", "weekday", "B", "0", "LOCAL", 0)),
+			List.of(
+				new LoadRouteTimetablePort.TransitStopTime(
+					"trip-missing-route", 1, "station-a", "line-fallback", 32400, 32400, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime(
+					"trip-missing-route", 2, "station-b", "line-fallback", 33000, 33000, 0, 0)
 			),
 			List.of()
 		);

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerCompiledSnapshotTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerCompiledSnapshotTest.java
@@ -213,6 +213,29 @@ class RouteTimetableRaptorPlannerCompiledSnapshotTest {
 	}
 
 	@Test
+	@DisplayName("같은 trip의 후속 stop에 더 일찍 도착한 predecessor로 환승 위치를 갱신한다")
+	void preservesEarlierPredecessorAtLaterBoardingStop() {
+		var command = new SearchRouteV2Command(
+			"station-a",
+			"station-d",
+			OffsetDateTime.parse("2026-07-01T08:50:00+09:00"),
+			MobilityType.SENIOR,
+			ConstraintMode.ALLOW_WITH_WARNINGS,
+			false,
+			1,
+			1
+		);
+
+		var results = planner.search(command, planner.compile(laterBoardingPredecessorTimetable()));
+
+		assertThat(results).hasSize(1);
+		assertThat(results.getFirst().steps())
+			.filteredOn(step -> "ride".equals(step.stepType()))
+			.extracting("tripId")
+			.containsExactly("feeder-e", "connector");
+	}
+
+	@Test
 	@DisplayName("같은 정차열에서 하차 정책이 다른 후속 trip을 잃지 않는다")
 	void preservesLaterTripWhenEarlierTripBlocksDropOff() {
 		var results = planner.search(
@@ -464,6 +487,46 @@ class RouteTimetableRaptorPlannerCompiledSnapshotTest {
 				stop("a-late", 1, "station-a", 32700),
 				stop("a-late", 2, "station-b", 33000),
 				stop("a-late", 3, "station-c", 33600)
+			),
+			List.of()
+		);
+	}
+
+	private static RouteTimetable laterBoardingPredecessorTimetable() {
+		return new RouteTimetable(
+			List.of(weekday("weekday")),
+			List.of(),
+			List.of(
+				new LoadRouteTimetablePort.TransitRoute(
+					"route-b", "line-b", "B", "B 경유", "B 방면", "Asia/Seoul"),
+				new LoadRouteTimetablePort.TransitRoute(
+					"route-e", "line-e", "E", "E 경유", "E 방면", "Asia/Seoul"),
+				new LoadRouteTimetablePort.TransitRoute(
+					"route-connector", "line-c", "C", "연결", "D 방면", "Asia/Seoul")
+			),
+			List.of(
+				new LoadRouteTimetablePort.TransitTrip(
+					"connector", "route-connector", "weekday", "D", "0", "LOCAL", 0),
+				new LoadRouteTimetablePort.TransitTrip(
+					"feeder-b", "route-b", "weekday", "B", "0", "LOCAL", 0),
+				new LoadRouteTimetablePort.TransitTrip(
+					"feeder-e", "route-e", "weekday", "E", "0", "LOCAL", 0)
+			),
+			List.of(
+				new LoadRouteTimetablePort.TransitStopTime(
+					"connector", 1, "station-b", "line-c", 33600, 33600, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime(
+					"connector", 2, "station-e", "line-c", 33900, 33900, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime(
+					"connector", 3, "station-d", "line-c", 34200, 34200, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime(
+					"feeder-b", 1, "station-a", "line-b", 32400, 32400, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime(
+					"feeder-b", 2, "station-b", "line-b", 32700, 32700, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime(
+					"feeder-e", 1, "station-a", "line-e", 32520, 32520, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime(
+					"feeder-e", 2, "station-e", "line-e", 32640, 32640, 0, 0)
 			),
 			List.of()
 		);

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerCompiledSnapshotTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerCompiledSnapshotTest.java
@@ -296,6 +296,22 @@ class RouteTimetableRaptorPlannerCompiledSnapshotTest {
 	}
 
 	@Test
+	@DisplayName("출발 stop의 동일 출발 trip은 non-overtaking pattern 우위 순서를 유지한다")
+	void preservesDominantPatternOrderForSameDepartureAtOrigin() {
+		var results = planner.search(
+			command("station-b", "station-d", "2026-07-01T09:20:00+09:00"),
+			planner.compile(sameDepartureSlowerCandidateTimetable())
+		);
+
+		assertThat(results).hasSize(1);
+		assertThat(results.getFirst().steps())
+			.filteredOn(step -> "ride".equals(step.stepType()))
+			.extracting("tripId", "plannedArrivalTime")
+			.containsExactly(org.assertj.core.groups.Tuple.tuple(
+				"z-fast", "2026-07-01T09:35:00+09:00"));
+	}
+
+	@Test
 	@DisplayName("같은 정차열에서 하차 정책이 다른 후속 trip을 잃지 않는다")
 	void preservesLaterTripWhenEarlierTripBlocksDropOff() {
 		var results = planner.search(

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerCompiledSnapshotTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerCompiledSnapshotTest.java
@@ -181,6 +181,22 @@ class RouteTimetableRaptorPlannerCompiledSnapshotTest {
 	}
 
 	@Test
+	@DisplayName("동률 도착은 기존 exhaustive 전역 trip-id 순서를 유지한다")
+	void preservesLegacyTripOrderForEqualArrival() {
+		var results = planner.search(
+			command("station-a", "station-c", "2026-07-01T08:50:00+09:00"),
+			planner.compile(equalArrivalOvertakingTimetable())
+		);
+
+		assertThat(results).hasSize(1);
+		assertThat(results.getFirst().steps())
+			.filteredOn(step -> "ride".equals(step.stepType()))
+			.extracting("tripId", "plannedArrivalTime")
+			.containsExactly(org.assertj.core.groups.Tuple.tuple(
+				"a-fast", "2026-07-01T09:35:00+09:00"));
+	}
+
+	@Test
 	@DisplayName("같은 정차열에서 하차 정책이 다른 후속 trip을 잃지 않는다")
 	void preservesLaterTripWhenEarlierTripBlocksDropOff() {
 		var results = planner.search(
@@ -388,6 +404,28 @@ class RouteTimetableRaptorPlannerCompiledSnapshotTest {
 					"trip-blocked", 2, "station-b", "line", 33000, 33000, 0, 1),
 				stop("trip-usable", 1, "station-a", 32700),
 				stop("trip-usable", 2, "station-b", 33300)
+			),
+			List.of()
+		);
+	}
+
+	private static RouteTimetable equalArrivalOvertakingTimetable() {
+		return timetable(
+			List.of(weekday("weekday")),
+			List.of(),
+			List.of(
+				new LoadRouteTimetablePort.TransitTrip(
+					"z-slow", "route", "weekday", "도착", "0", "LOCAL", 0),
+				new LoadRouteTimetablePort.TransitTrip(
+					"a-fast", "route", "weekday", "도착", "0", "EXPRESS", 0)
+			),
+			List.of(
+				stop("z-slow", 1, "station-a", 32400),
+				stop("z-slow", 2, "station-b", 33600),
+				stop("z-slow", 3, "station-c", 34500),
+				stop("a-fast", 1, "station-a", 33000),
+				stop("a-fast", 2, "station-b", 33300),
+				stop("a-fast", 3, "station-c", 34500)
 			),
 			List.of()
 		);

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerCompiledSnapshotTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerCompiledSnapshotTest.java
@@ -126,6 +126,45 @@ class RouteTimetableRaptorPlannerCompiledSnapshotTest {
 	}
 
 	@Test
+	@DisplayName("search는 marked stop이 속한 route pattern만 스캔한다")
+	void scansOnlyMarkedRoutePatterns() {
+		var compiled = planner.compile(disconnectedRoutesTimetable());
+
+		assertThat(planner.search(command(WEDNESDAY, 8, 50), compiled)).hasSize(1);
+
+		var metrics = planner.lastScanMetrics();
+		assertThat(metrics.expandedRoutes()).isOne();
+		assertThat(metrics.expandedTrips()).isOne();
+
+		planner.search(command(WEDNESDAY, 8, 50), compiled);
+		assertThat(planner.lastScanMetrics().workspaceIdentity()).isEqualTo(metrics.workspaceIdentity());
+	}
+
+	@Test
+	@DisplayName("중간 stop에서 추월한 trip도 해당 stop 출발 시각 순서로 이진 탐색한다")
+	void binarySearchesTripsInDepartureOrderAtEachStop() {
+		var command = new SearchRouteV2Command(
+			"station-b",
+			"station-c",
+			OffsetDateTime.parse("2026-07-01T09:10:00+09:00"),
+			MobilityType.SENIOR,
+			ConstraintMode.ALLOW_WITH_WARNINGS,
+			false,
+			0,
+			1
+		);
+
+		var results = planner.search(command, planner.compile(overtakingTimetable()));
+
+		assertThat(results).hasSize(1);
+		assertThat(results.getFirst().steps())
+			.filteredOn(step -> "ride".equals(step.stepType()))
+			.extracting("tripId", "plannedDepartureTime")
+			.containsExactly(org.assertj.core.groups.Tuple.tuple(
+				"trip-fast", "2026-07-01T09:20:00+09:00"));
+	}
+
+	@Test
 	@DisplayName("동시 nextServiceTime은 service day boarding index를 안전하게 lazy publish한다")
 	void concurrentNextServiceTimeLazilyPublishesBoardingIndex() throws Exception {
 		var compiled = planner.compile(frequencyTimetable());
@@ -245,6 +284,58 @@ class RouteTimetableRaptorPlannerCompiledSnapshotTest {
 			List.of(
 				stop("trip-weekday", 1, "station-a", 32400), stop("trip-weekday", 2, "station-b", 33000),
 				stop("trip-special", 1, "station-a", 32400), stop("trip-special", 2, "station-b", 33000)
+			),
+			List.of()
+		);
+	}
+
+	private static RouteTimetable disconnectedRoutesTimetable() {
+		return new RouteTimetable(
+			List.of(weekday("weekday")),
+			List.of(),
+			List.of(
+				new LoadRouteTimetablePort.TransitRoute(
+					"route-main", "line-main", "M", "주 경로", "B 방면", "Asia/Seoul"),
+				new LoadRouteTimetablePort.TransitRoute(
+					"route-other", "line-other", "O", "무관 경로", "Y 방면", "Asia/Seoul")
+			),
+			List.of(
+				new LoadRouteTimetablePort.TransitTrip(
+					"trip-main", "route-main", "weekday", "B", "0", "LOCAL", 0),
+				new LoadRouteTimetablePort.TransitTrip(
+					"trip-other", "route-other", "weekday", "Y", "0", "LOCAL", 0)
+			),
+			List.of(
+				new LoadRouteTimetablePort.TransitStopTime(
+					"trip-main", 1, "station-a", "line-main", 32400, 32400, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime(
+					"trip-main", 2, "station-b", "line-main", 33000, 33000, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime(
+					"trip-other", 1, "station-x", "line-other", 32400, 32400, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime(
+					"trip-other", 2, "station-y", "line-other", 33000, 33000, 0, 0)
+			),
+			List.of()
+		);
+	}
+
+	private static RouteTimetable overtakingTimetable() {
+		return timetable(
+			List.of(weekday("weekday")),
+			List.of(),
+			List.of(
+				new LoadRouteTimetablePort.TransitTrip(
+					"trip-slow", "route", "weekday", "도착", "0", "LOCAL", 0),
+				new LoadRouteTimetablePort.TransitTrip(
+					"trip-fast", "route", "weekday", "도착", "0", "EXPRESS", 0)
+			),
+			List.of(
+				stop("trip-slow", 1, "station-a", 32400),
+				stop("trip-slow", 2, "station-b", 34200),
+				stop("trip-slow", 3, "station-c", 34800),
+				stop("trip-fast", 1, "station-a", 33000),
+				stop("trip-fast", 2, "station-b", 33600),
+				stop("trip-fast", 3, "station-c", 34500)
 			),
 			List.of()
 		);

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerCompiledSnapshotTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerCompiledSnapshotTest.java
@@ -266,6 +266,36 @@ class RouteTimetableRaptorPlannerCompiledSnapshotTest {
 	}
 
 	@Test
+	@DisplayName("후속 stop의 동일 출발 후보가 더 늦게 도착하면 현재 trip을 유지한다")
+	void keepsCurrentTripWhenSameDepartureCandidateArrivesLater() {
+		var command = new SearchRouteV2Command(
+			"station-origin",
+			"station-d",
+			OffsetDateTime.parse("2026-07-01T08:40:00+09:00"),
+			MobilityType.SENIOR,
+			ConstraintMode.ALLOW_WITH_WARNINGS,
+			false,
+			1,
+			1
+		);
+
+		var results = planner.search(command, planner.compile(sameDepartureSlowerCandidateTimetable()));
+
+		assertThat(results).hasSize(1);
+		assertThat(results.getFirst().steps())
+			.filteredOn(step -> "ride".equals(step.stepType()))
+			.extracting("tripId")
+			.containsExactly("feeder-a", "z-fast");
+		assertThat(results.getFirst().steps())
+			.filteredOn(step -> "ride".equals(step.stepType()))
+			.extracting("plannedArrivalTime")
+			.containsExactly(
+				"2026-07-01T09:00:00+09:00",
+				"2026-07-01T09:35:00+09:00"
+			);
+	}
+
+	@Test
 	@DisplayName("같은 정차열에서 하차 정책이 다른 후속 trip을 잃지 않는다")
 	void preservesLaterTripWhenEarlierTripBlocksDropOff() {
 		var results = planner.search(
@@ -605,6 +635,54 @@ class RouteTimetableRaptorPlannerCompiledSnapshotTest {
 					"z-slow", 2, "station-b", "line-main", 33600, 33600, 0, 0),
 				new LoadRouteTimetablePort.TransitStopTime(
 					"z-slow", 3, "station-d", "line-main", 34200, 34200, 0, 0)
+			),
+			List.of()
+		);
+	}
+
+	private static RouteTimetable sameDepartureSlowerCandidateTimetable() {
+		return new RouteTimetable(
+			List.of(weekday("weekday")),
+			List.of(),
+			List.of(
+				new LoadRouteTimetablePort.TransitRoute(
+					"route-feeder-a", "line-fa", "FA", "A 연결", "A 방면", "Asia/Seoul"),
+				new LoadRouteTimetablePort.TransitRoute(
+					"route-feeder-b", "line-fb", "FB", "B 연결", "B 방면", "Asia/Seoul"),
+				new LoadRouteTimetablePort.TransitRoute(
+					"route-main", "line-main", "M", "본선", "D 방면", "Asia/Seoul")
+			),
+			List.of(
+				new LoadRouteTimetablePort.TransitTrip(
+					"a-slow", "route-main", "weekday", "D", "0", "LOCAL", 0),
+				new LoadRouteTimetablePort.TransitTrip(
+					"feeder-a", "route-feeder-a", "weekday", "A", "0", "LOCAL", 0),
+				new LoadRouteTimetablePort.TransitTrip(
+					"feeder-b", "route-feeder-b", "weekday", "B", "0", "LOCAL", 0),
+				new LoadRouteTimetablePort.TransitTrip(
+					"z-fast", "route-main", "weekday", "D", "0", "EXPRESS", 0)
+			),
+			List.of(
+				new LoadRouteTimetablePort.TransitStopTime(
+					"a-slow", 1, "station-a", "line-main", 33300, 33300, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime(
+					"a-slow", 2, "station-b", "line-main", 33900, 34200, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime(
+					"a-slow", 3, "station-d", "line-main", 34800, 34800, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime(
+					"feeder-a", 1, "station-origin", "line-fa", 31620, 31620, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime(
+					"feeder-a", 2, "station-a", "line-fa", 32400, 32400, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime(
+					"feeder-b", 1, "station-origin", "line-fb", 31680, 31680, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime(
+					"feeder-b", 2, "station-b", "line-fb", 33300, 33300, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime(
+					"z-fast", 1, "station-a", "line-main", 33000, 33000, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime(
+					"z-fast", 2, "station-b", "line-main", 33600, 34200, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime(
+					"z-fast", 3, "station-d", "line-main", 34500, 34500, 0, 0)
 			),
 			List.of()
 		);

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerCompiledSnapshotTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerCompiledSnapshotTest.java
@@ -116,6 +116,16 @@ class RouteTimetableRaptorPlannerCompiledSnapshotTest {
 	}
 
 	@Test
+	@DisplayName("active service day는 pattern trip을 stop마다 복제하지 않는다")
+	void storesEachActivePatternTripOnce() {
+		var compiled = planner.compile(frequencyTimetable());
+
+		var activeDay = compiled.activeServiceDay(WEDNESDAY);
+
+		assertThat(activeDay.routePatternTripLinkCount()).isEqualTo(compiled.scheduledTripCount());
+	}
+
+	@Test
 	@DisplayName("일반 search는 next-service 전용 boarding index를 생성하지 않는다")
 	void regularSearchDoesNotAllocateBoardingIndex() {
 		var compiled = planner.compile(frequencyTimetable());

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerDifferentialTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerDifferentialTest.java
@@ -41,7 +41,7 @@ class RouteTimetableRaptorPlannerDifferentialTest {
 			String origin = STATIONS.get(random.nextInt(STATIONS.size()));
 			String destination = STATIONS.get(random.nextInt(STATIONS.size()));
 			int minute = random.nextInt(41);
-			int maxTransfers = random.nextInt(3);
+			int maxTransfers = random.nextInt(4);
 			var command = command(origin, destination, minute, maxTransfers);
 
 			assertThat(signatures(planner.search(command, timetable)))

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerDifferentialTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteTimetableRaptorPlannerDifferentialTest.java
@@ -1,0 +1,232 @@
+package com.easysubway.route.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.easysubway.profile.domain.MobilityType;
+import com.easysubway.route.application.port.in.RouteV2SearchUseCase.SearchRouteV2Command;
+import com.easysubway.route.application.port.out.LoadRouteTimetablePort;
+import com.easysubway.route.application.port.out.LoadRouteTimetablePort.RouteTimetable;
+import com.easysubway.route.domain.BoardingSlackPolicy;
+import com.easysubway.route.domain.ConstraintMode;
+import com.easysubway.route.domain.ProfileWalkTimeCalculator;
+import com.easysubway.route.domain.ProfileWalkTimeCalculator.WalkTimeSource;
+import com.easysubway.route.domain.RouteSearchResult;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("#2250 marked-route differential")
+class RouteTimetableRaptorPlannerDifferentialTest {
+
+	private static final LocalDate SERVICE_DATE = LocalDate.of(2026, 7, 6);
+	private static final List<String> STATIONS = List.of("a", "b", "c", "d", "e");
+
+	@Test
+	@DisplayName("고정 seed 무작위 OD 64개가 기존 exhaustive scan과 같은 후보를 반환한다")
+	void matchesExhaustiveScanForRandomOdSamples() {
+		RouteTimetable timetable = timetable();
+		var planner = new RouteTimetableRaptorPlanner();
+		var random = new Random(2250);
+
+		for (int sample = 0; sample < 64; sample += 1) {
+			String origin = STATIONS.get(random.nextInt(STATIONS.size()));
+			String destination = STATIONS.get(random.nextInt(STATIONS.size()));
+			int minute = random.nextInt(41);
+			int maxTransfers = random.nextInt(3);
+			var command = command(origin, destination, minute, maxTransfers);
+
+			assertThat(signatures(planner.search(command, timetable)))
+				.as("sample=%s origin=%s destination=%s minute=%s maxTransfers=%s",
+					sample, origin, destination, minute, maxTransfers)
+				.isEqualTo(exhaustiveSignatures(command, timetable));
+		}
+	}
+
+	private static List<Signature> exhaustiveSignatures(SearchRouteV2Command command, RouteTimetable timetable) {
+		Map<String, LoadRouteTimetablePort.TransitRoute> routes = new HashMap<>();
+		for (var route : timetable.transitRoutes()) {
+			routes.put(route.id(), route);
+		}
+		Map<String, List<LoadRouteTimetablePort.TransitStopTime>> stopTimes = new HashMap<>();
+		for (var stopTime : timetable.transitStopTimes()) {
+			stopTimes.computeIfAbsent(stopTime.tripId(), ignored -> new ArrayList<>()).add(stopTime);
+		}
+		List<ReferenceTrip> trips = timetable.transitTrips().stream()
+			.map(trip -> new ReferenceTrip(
+				trip,
+				routes.get(trip.routeId()),
+				stopTimes.get(trip.id()).stream()
+					.sorted(Comparator.comparingInt(LoadRouteTimetablePort.TransitStopTime::stopSequence))
+					.toList()
+			))
+			.sorted(Comparator.comparing(reference -> reference.trip().id()))
+			.toList();
+		int startSeconds = command.departureTime().toLocalTime().toSecondOfDay();
+		Map<String, List<ReferenceLabel>> labels = new HashMap<>();
+		labels.put(command.originStationId(), List.of(new ReferenceLabel(
+			command.originStationId(), startSeconds, 0, List.of())));
+		int slackSeconds = BoardingSlackPolicy.secondsFor(command.mobilityType());
+		for (int round = 0; round <= command.maxTransfers(); round += 1) {
+			int accessSeconds = walkSeconds(command, round == 0 ? 240 : 360);
+			for (ReferenceTrip trip : trips) {
+				ReferenceBoarding boarding = null;
+				for (int stopIndex = 0; stopIndex < trip.stopTimes().size(); stopIndex += 1) {
+					var stop = trip.stopTimes().get(stopIndex);
+					for (ReferenceLabel label : List.copyOf(labels.getOrDefault(stop.stationId(), List.of()))) {
+						if (label.boardings() == round
+							&& stop.pickupType() != 1
+							&& stop.departureSeconds() >= label.arrivalSeconds() + accessSeconds + slackSeconds
+							&& (boarding == null || label.arrivalSeconds() < boarding.label().arrivalSeconds())) {
+							boarding = new ReferenceBoarding(label, stopIndex);
+						}
+					}
+					if (boarding == null || stopIndex <= boarding.stopIndex() || stop.dropOffType() == 1) {
+						continue;
+					}
+					List<ReferenceLeg> path = new ArrayList<>(boarding.label().path());
+					path.add(new ReferenceLeg(trip, boarding.stopIndex(), stopIndex));
+					addLabel(labels, new ReferenceLabel(
+						stop.stationId(), stop.arrivalSeconds(), round + 1, List.copyOf(path)));
+				}
+			}
+		}
+		return labels.getOrDefault(command.destinationStationId(), List.of()).stream()
+			.filter(label -> !label.path().isEmpty())
+			.sorted(Comparator.comparingInt(ReferenceLabel::arrivalSeconds)
+				.thenComparingInt(ReferenceLabel::boardings)
+				.thenComparingInt(label -> label.path().size()))
+			.limit(Math.max(command.alternativeCount(), command.maxTransfers() + 1))
+			.map(label -> new Signature(
+				label.arrivalSeconds(),
+				label.boardings(),
+				label.path().stream().map(leg -> leg.trip().trip().id()).toList()))
+			.toList();
+	}
+
+	private static void addLabel(Map<String, List<ReferenceLabel>> labels, ReferenceLabel candidate) {
+		List<ReferenceLabel> stationLabels = labels.getOrDefault(candidate.stationId(), List.of());
+		if (stationLabels.stream().anyMatch(existing -> same(existing, candidate) || dominates(existing, candidate))) {
+			return;
+		}
+		List<ReferenceLabel> kept = stationLabels.stream()
+			.filter(existing -> !dominates(candidate, existing))
+			.sorted(Comparator.comparingInt(ReferenceLabel::arrivalSeconds)
+				.thenComparingInt(ReferenceLabel::boardings))
+			.collect(java.util.stream.Collectors.toCollection(ArrayList::new));
+		kept.add(candidate);
+		kept.sort(Comparator.comparingInt(ReferenceLabel::arrivalSeconds)
+			.thenComparingInt(ReferenceLabel::boardings));
+		List<ReferenceLabel> bestByBoardings = new ArrayList<>();
+		for (ReferenceLabel label : kept) {
+			if (bestByBoardings.stream().noneMatch(existing -> existing.boardings() == label.boardings())) {
+				bestByBoardings.add(label);
+			}
+		}
+		labels.put(candidate.stationId(), List.copyOf(bestByBoardings.stream().limit(4).toList()));
+	}
+
+	private static boolean dominates(ReferenceLabel left, ReferenceLabel right) {
+		return left.arrivalSeconds() <= right.arrivalSeconds()
+			&& left.boardings() <= right.boardings()
+			&& (left.arrivalSeconds() < right.arrivalSeconds() || left.boardings() < right.boardings());
+	}
+
+	private static boolean same(ReferenceLabel left, ReferenceLabel right) {
+		return left.arrivalSeconds() == right.arrivalSeconds()
+			&& left.boardings() == right.boardings()
+			&& left.path().stream().map(leg -> leg.trip().trip().id()).toList()
+			.equals(right.path().stream().map(leg -> leg.trip().trip().id()).toList());
+	}
+
+	private static List<Signature> signatures(List<RouteSearchResult> results) {
+		return results.stream().map(result -> {
+			var rides = result.steps().stream().filter(step -> "ride".equals(step.stepType())).toList();
+			OffsetDateTime arrival = OffsetDateTime.parse(rides.getLast().plannedArrivalTime());
+			int arrivalSeconds = Math.toIntExact(Duration.between(
+				SERVICE_DATE.atStartOfDay().atOffset(ZoneOffset.ofHours(9)), arrival).toSeconds());
+			return new Signature(arrivalSeconds, rides.size(), rides.stream().map(step -> step.tripId()).toList());
+		}).toList();
+	}
+
+	private static int walkSeconds(SearchRouteV2Command command, int baselineSeconds) {
+		return ProfileWalkTimeCalculator.estimateSeconds(
+			baselineSeconds, command.mobilityPreset(), WalkTimeSource.OFFICIAL_BASELINE, false).seconds();
+	}
+
+	private static SearchRouteV2Command command(String origin, String destination, int minute, int maxTransfers) {
+		return new SearchRouteV2Command(
+			origin,
+			destination,
+			OffsetDateTime.of(2026, 7, 6, 7, 40, 0, 0, ZoneOffset.ofHours(9)).plusMinutes(minute),
+			MobilityType.SENIOR,
+			ConstraintMode.ALLOW_WITH_WARNINGS,
+			false,
+			maxTransfers,
+			3
+		);
+	}
+
+	private static RouteTimetable timetable() {
+		var daily = new LoadRouteTimetablePort.ServiceCalendar(
+			"daily", true, true, true, true, true, true, true,
+			SERVICE_DATE, SERVICE_DATE.plusDays(1), "Asia/Seoul");
+		List<LoadRouteTimetablePort.TransitRoute> routes = List.of(
+			route("r1", "l1"), route("r2", "l2"), route("r3", "l3"), route("r4", "l4"));
+		List<LoadRouteTimetablePort.TransitTrip> trips = List.of(
+			trip("t1", "r1"), trip("t2", "r1"), trip("t3", "r2"), trip("t4", "r2"),
+			trip("t5", "r3"), trip("t6", "r4"));
+		List<LoadRouteTimetablePort.TransitStopTime> stops = List.of(
+			stop("t1", 1, "a", "l1", 28800), stop("t1", 2, "b", "l1", 29400), stop("t1", 3, "c", "l1", 30000),
+			stop("t2", 1, "a", "l1", 30000), stop("t2", 2, "b", "l1", 30600), stop("t2", 3, "c", "l1", 31200),
+			stop("t3", 1, "b", "l2", 30300), stop("t3", 2, "d", "l2", 30900), stop("t3", 3, "e", "l2", 31500),
+			stop("t4", 1, "b", "l2", 31500), stop("t4", 2, "d", "l2", 32100), stop("t4", 3, "e", "l2", 32700),
+			stop("t5", 1, "c", "l3", 31800), stop("t5", 2, "e", "l3", 32400),
+			stop("t6", 1, "x", "l4", 28800), stop("t6", 2, "y", "l4", 29400));
+		return new RouteTimetable(List.of(daily), List.of(), routes, trips, stops, List.of());
+	}
+
+	private static LoadRouteTimetablePort.TransitRoute route(String id, String lineId) {
+		return new LoadRouteTimetablePort.TransitRoute(id, lineId, id, id, id, "Asia/Seoul");
+	}
+
+	private static LoadRouteTimetablePort.TransitTrip trip(String id, String routeId) {
+		return new LoadRouteTimetablePort.TransitTrip(id, routeId, "daily", id, "0", "LOCAL", 0);
+	}
+
+	private static LoadRouteTimetablePort.TransitStopTime stop(
+		String tripId, int sequence, String stationId, String lineId, int seconds
+	) {
+		return new LoadRouteTimetablePort.TransitStopTime(
+			tripId, sequence, stationId, lineId, seconds, seconds, 0, 0);
+	}
+
+	private record Signature(int arrivalSeconds, int boardings, List<String> tripIds) {
+	}
+
+	private record ReferenceTrip(
+		LoadRouteTimetablePort.TransitTrip trip,
+		LoadRouteTimetablePort.TransitRoute route,
+		List<LoadRouteTimetablePort.TransitStopTime> stopTimes
+	) {
+	}
+
+	private record ReferenceLeg(ReferenceTrip trip, int fromIndex, int toIndex) {
+	}
+
+	private record ReferenceLabel(
+		String stationId, int arrivalSeconds, int boardings, List<ReferenceLeg> path
+	) {
+	}
+
+	private record ReferenceBoarding(ReferenceLabel label, int stopIndex) {
+	}
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -14906,7 +14906,9 @@ test("V2 경로 검색은 production planner 경계를 통해 요청 조건을 �
   assert.match(raptorPlanner, /transitFrequencies\(\)/);
   assert.match(raptorPlanner, /pickupType\(\)/);
   assert.match(raptorPlanner, /dropOffType\(\)/);
-  assert.match(raptorPlanner, /dominates/);
+  assert.match(raptorPlanner, /PARETO_LIMIT/);
+  assert.match(raptorPlanner, /collectMarkedPatterns/);
+  assert.match(raptorPlanner, /private int\[] parentTrip/);
   assert.match(useCase, /record SearchRouteV2Command/);
   assert.match(useCase, /OffsetDateTime departureTime/);
   assert.match(useCase, /boolean useRealtime/);


### PR DESCRIPTION
## 관련 이슈

Closes #2250

## 작업 배경

- compiled timetable 위 검색이 매 요청마다 전체 route pattern과 active trip을 훑고, 각 label이 전체 경로를 복사해 hot path latency·allocation이 커졌습니다.
- #2249 compiled snapshot을 실제 marked-route RAPTOR scan에 연결해 도달 가능한 route만 확장하고 목적지에서만 경로를 복원합니다.

## 작업 내용

- round별 marked stop에서 연결된 route pattern만 수집하고, 최초 marked position부터 scan합니다.
- 같은 정차열·pickup/dropoff 정책을 공유하면서 서로 추월하지 않는 trip을 operational pattern으로 나눠, 정차역별 출발 시각 배열에서 earliest boardable trip을 이진 탐색합니다.
- round×stop 도착·parent 정보를 primitive 배열에 보관하고 `ThreadLocal` workspace를 재사용하며, 목적지 label만 predecessor로 복원합니다.
- 내부 Dijkstra 후보의 누적 path 복사를 제거하고 predecessor edge로 목적지에서 한 번만 복원합니다.
- 기존 exhaustive 결과와 64개 deterministic random OD를 비교하고, 추월·pickup/dropoff·동률 trip 순서를 회귀 테스트로 고정했습니다.
- 이번 범위는 기존 Route V2 계약의 single-departure marked RAPTOR입니다. multi-departure range RAPTOR는 API·랭킹 계약 변경 없이 도입할 수 없어 포함하지 않았습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests 'com.easysubway.route.application.service.RouteTimetableRaptorPlannerCompiledSnapshotTest' --tests 'com.easysubway.route.application.service.RouteTimetableRaptorPlannerDifferentialTest' --tests 'com.easysubway.route.application.service.RouteSearchServiceTest'` — BUILD SUCCESSFUL
  - `EASYSUBWAY_BENCHMARK=true ./gradlew test --tests 'com.easysubway.route.application.service.RouteTimetableRaptorPlannerBenchmarkTest' --rerun-tasks --info` — BUILD SUCCESSFUL
  - `./gradlew test --no-daemon --max-workers=1` — BUILD SUCCESSFUL (fresh full backend suite, 3m 41s)
  - 독립 reviewer — actionable finding 0건, Ready to merge
  - `coderabbit review --agent -t committed --base origin/main -c .coderabbit.yaml` — 1건은 non-overtaking pattern 분리로 이미 방어되는 오탐으로 확인
  - `git diff --check` — 오류 없음
  - full-feed microbenchmark, fixture SHA-256 `06b65fed55e1d07623b0fbc69bf35b98973b22fb25e520d014fba69155d8fd5b`, warmup 20회·measurement 100회
    - morning p50: 891,021 → 165,730 ns/op (-81.4%), allocation: 2,266,288 → 9,920 B/op (-99.6%)
    - after-last p50: 138,876 → 71,000 ns/op (-48.9%), allocation: 596,536 → 20,848 B/op (-96.5%)
    - morning 확장: legacy 71 routes/487 trips → marked 18/12
    - after-last 확장: legacy 71 routes/487 trips → marked 18/0

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| golden·ranking·dominance | Backend | 기존 suite + compiled snapshot 집중 테스트 | CI 및 위 명령 | 통과 |
| marked-route 정확성 | Backend | legacy exhaustive 대비 64 random OD 차등·추월·정책·동률 회귀 | CI 및 위 명령 | 통과 |
| latency·allocation·확장량 | Backend JVM | 동일 fixture·반복 microbenchmark | raw: `/Users/aquila/easysubway/.superpowers/evidence/2250/before.log`, `after-final.log` (작성자 로컬) | 개선 |
| UI/수동 QA | 해당 없음 | 사용자 표시/API contract 변경 없음 | golden 결과 동일 | 불필요 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 코드 배포 SHA만 변경

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - marked stop → pattern 수집과 round primitive workspace 재사용
  - 추월·pickup/dropoff 정책별 operational pattern 분리와 stop별 이진 탐색
  - 목적지 predecessor 복원 및 동일 도착 legacy trip 순서

## 리스크

- operational pattern 분리가 feed에 따라 pattern 수를 늘릴 수 있으나 full-feed benchmark에서 71 pattern이며 marked scan은 query당 18개만 확장했습니다.
- 동일 도착·추월·pickup/dropoff 경계의 선택 순서는 legacy exhaustive 차등 및 집중 회귀 테스트로 방어했습니다.
- `ThreadLocal` workspace는 backend request thread 생명주기 동안 유지되며 snapshot 크기 증가 시 필요한 primitive 배열만 확장합니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
