### PR TITLE
[Fix] ITX 인증 Route V2 검색이 레거시 그래프 새치기로 503 나는 리그레션 수정

### DIFF
--- a/backend/src/main/java/com/easysubway/route/application/port/in/RouteSearchUseCase.java
+++ b/backend/src/main/java/com/easysubway/route/application/port/in/RouteSearchUseCase.java
@@ -58,7 +58,8 @@ public interface RouteSearchUseCase {
 		int candidateCount,
 		int alternativeCount,
 		List<RouteSearchResult> timetableResults,
-		UnaryOperator<List<RouteSearchResult>> selectCandidates
+		UnaryOperator<List<RouteSearchResult>> selectCandidates,
+		boolean legacyGraphCandidateAllowed
 	) {
 		return new TimetableCandidateSelection(
 			stabilizeTimetableRouteCandidates(

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -234,7 +234,8 @@ public class RouteSearchService implements RouteSearchUseCase {
 			candidateCount,
 			alternativeCount,
 			timetableResults,
-			selectCandidates
+			selectCandidates,
+			true
 		).itineraries();
 	}
 
@@ -244,23 +245,33 @@ public class RouteSearchService implements RouteSearchUseCase {
 		int candidateCount,
 		int alternativeCount,
 		List<RouteSearchResult> timetableResults,
-		UnaryOperator<List<RouteSearchResult>> selectCandidates
+		UnaryOperator<List<RouteSearchResult>> selectCandidates,
+		boolean legacyGraphCandidateAllowed
 	) {
-		try {
-			List<RouteSearchResult> accessibilityCheckedResults = buildRouteSearchAlternatives(
-				withoutRealtime(command),
-				candidateCount
-			);
-			List<RouteSearchResult> selectedAccessibilityCheckedResults = selectCandidates.apply(accessibilityCheckedResults);
-			if (selectedAccessibilityCheckedResults.stream().anyMatch(this::hasAccessibilitySignal)) {
-				return new TimetableCandidateSelection(
-					selectedAccessibilityCheckedResults,
-					TimetableCandidateSource.LEGACY_ACCESSIBILITY_CHECK
+		// #2095/#2286: ITX-청춘 인증 Route V2 검색(legacyGraphCandidateAllowed=false로 호출하는
+		// RouteV2Planner)은 prod 게이트(ProductionRouteV2Support.requireUsablePlan)가 항상
+		// TIMETABLE_RAPTOR 출처만 허용한다. #1400 레거시 그래프 우선 시도(접근성 신호가 있으면
+		// 레거시 결과를 채택)는 legacyGraphCandidateAllowed=true인 SUBWAY 경로 전용 과도기
+		// 로직으로 남긴다 — ITX pilot 역처럼 STATION_LINES로는 연결됐지만 접근성 시설 데이터가
+		// 없는 역은 레거시 그래프에서 거의 항상 hasAccessibilitySignal=true가 돼 레거시가
+		// 채택되고, 그 결과 timetableArtifactId가 null이 돼 prod 게이트에서 503으로 막힌다.
+		if (legacyGraphCandidateAllowed) {
+			try {
+				List<RouteSearchResult> accessibilityCheckedResults = buildRouteSearchAlternatives(
+					withoutRealtime(command),
+					candidateCount
 				);
+				List<RouteSearchResult> selectedAccessibilityCheckedResults = selectCandidates.apply(accessibilityCheckedResults);
+				if (selectedAccessibilityCheckedResults.stream().anyMatch(this::hasAccessibilitySignal)) {
+					return new TimetableCandidateSelection(
+						selectedAccessibilityCheckedResults,
+						TimetableCandidateSource.LEGACY_ACCESSIBILITY_CHECK
+					);
+				}
+			} catch (RouteNotFoundException | StationNotFoundException exception) {
+				// Timetable coverage can lead legacy graph coverage while #1400 closes the production graph gap.
+				log.debug("Legacy graph could not stabilize timetable route {} -> {}", command.originStationId(), command.destinationStationId(), exception);
 			}
-		} catch (RouteNotFoundException | StationNotFoundException exception) {
-			// Timetable coverage can lead legacy graph coverage while #1400 closes the production graph gap.
-			log.debug("Legacy graph could not stabilize timetable route {} -> {}", command.originStationId(), command.destinationStationId(), exception);
 		}
 		return new TimetableCandidateSelection(
 			selectCandidates.apply(timetableResults)

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -52,6 +52,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -250,11 +251,15 @@ public class RouteSearchService implements RouteSearchUseCase {
 	) {
 		// #2095/#2286: ITX-청춘 인증 Route V2 검색(legacyGraphCandidateAllowed=false로 호출하는
 		// RouteV2Planner)은 prod 게이트(ProductionRouteV2Support.requireUsablePlan)가 항상
-		// TIMETABLE_RAPTOR 출처만 허용한다. #1400 레거시 그래프 우선 시도(접근성 신호가 있으면
-		// 레거시 결과를 채택)는 legacyGraphCandidateAllowed=true인 SUBWAY 경로 전용 과도기
-		// 로직으로 남긴다 — ITX pilot 역처럼 STATION_LINES로는 연결됐지만 접근성 시설 데이터가
-		// 없는 역은 레거시 그래프에서 거의 항상 hasAccessibilitySignal=true가 돼 레거시가
-		// 채택되고, 그 결과 timetableArtifactId가 null이 돼 prod 게이트에서 503으로 막힌다.
+		// TIMETABLE_RAPTOR 출처만 허용한다. ITX pilot 역처럼 STATION_LINES로는 연결됐지만
+		// 접근성 시설 데이터가 없는 역은 레거시 그래프에서 거의 항상
+		// hasAccessibilitySignal=true가 돼 레거시가 채택되고, 그 결과 timetableArtifactId가
+		// null이 돼 prod 게이트에서 503으로 막힌다. #1400 레거시 그래프 우선 시도(접근성
+		// 신호가 있으면 레거시 결과를 채택) 자체는 legacyGraphCandidateAllowed=true(인터페이스
+		// 기본값)로 남겨뒀다 — 다만 현재 stabilizeTimetableRouteCandidatesWithSource의 실제
+		// 호출자는 RouteV2Planner(false) 하나뿐이라 이 true 경로를 쓰는 프로덕션 호출자는
+		// 없다(dead in prod). API 호환성과 향후 SUBWAY 전용(비-ITX) 호출자가 생길 경우를
+		// 대비해 보존한다.
 		if (legacyGraphCandidateAllowed) {
 			try {
 				List<RouteSearchResult> accessibilityCheckedResults = buildRouteSearchAlternatives(
@@ -343,12 +348,52 @@ public class RouteSearchService implements RouteSearchUseCase {
 			routeSearchResult.lineName(),
 			routeSearchResult.score(),
 			routeSearchResult.steps(),
-			routeSearchResult.warnings(),
+			timetableAccessibilityWarnings(routeSearchResult),
 			routeSearchResult.blockedReasons(),
 			LocalDateTime.now(clock),
 			routeSearchResult.objectiveTags(),
 			routeSearchResult.officialFare()
 		);
+	}
+
+	// #2095/#2292: RouteV2Planner가 항상 RAPTOR(TIMETABLE_SCAN)를 쓰도록 바뀌면서(레거시 그래프
+	// 우선 시도 생략, stabilizeTimetableRouteCandidatesWithSource의
+	// legacyGraphCandidateAllowed=false) 레거시 buildRouteSearchAlternatives()가 부착하던
+	// 접근성 경고(LOW_DATA_CONFIDENCE/STAIR_ONLY_ACCESS/STALE_ACCESSIBILITY_DATA)가 RAPTOR
+	// 결과에는 전혀 붙지 않게 됐다 — RAPTOR는 시간표 데이터만 참조하고
+	// LoadTransitMasterPort의 출구·시설 데이터를 보지 않기 때문이다. WHEELCHAIR·
+	// STRICT_STEP_FREE는 canUseTimetableRaptor()가 false라 애초에 이 경로를 타지 않고
+	// 레거시로 차단·경고까지 그대로 받으므로 무영향이지만(blocksStairOnlyAccess는 이 두
+	// 프로필에서만 true — RouteProfileWeight 참고), PREFER_STEP_FREE 등 "선호"만 하는
+	// 프로필은 경고 없이 통과해버려 접근성 정보가 유실됐다. 레거시와 동일한 기준
+	// (hasStairOnlyAccess/routeWarnings, 같은 LoadTransitMasterPort 출구·시설 데이터)을
+	// RAPTOR itinerary의 승차·환승·하차 역(진입역 + 각 ride 하차역 — 레거시의
+	// accessibilityStationIds와 동일한 의미)에 그대로 적용해 재부착한다. 완화도 과잉 경고도
+	// 아니고, RAPTOR가 이미 채운 warnings가 있으면 보존한 채 합친다.
+	private List<RouteWarning> timetableAccessibilityWarnings(RouteSearchResult routeSearchResult) {
+		List<String> accessibilityStationIds = timetableAccessibilityStationIds(routeSearchResult);
+		boolean stairOnlyAccess = hasStairOnlyAccess(accessibilityStationIds);
+		List<RouteWarning> computedWarnings = routeWarnings(accessibilityStationIds, stairOnlyAccess);
+		if (routeSearchResult.warnings().isEmpty()) {
+			return computedWarnings;
+		}
+		var merged = new LinkedHashSet<>(routeSearchResult.warnings());
+		merged.addAll(computedWarnings);
+		return List.copyOf(merged);
+	}
+
+	// 레거시 MultiTransferRoute.accessibilityStationIds()와 동일한 의미: 진입역(origin) +
+	// 매 환승·하차 지점(각 "ride" 스텝의 도착역, 마지막은 destination) — 실제로 타고 내리는
+	// 역만 확인 대상이다. RAPTOR가 만드는 "ride" 스텝은 한 노선을 탄 구간 전체(승차→하차)를
+	// 하나로 묶으므로 toStationId가 곧 환승·최종 하차역이다.
+	private List<String> timetableAccessibilityStationIds(RouteSearchResult routeSearchResult) {
+		List<String> stationIds = new ArrayList<>();
+		stationIds.add(routeSearchResult.originStationId());
+		routeSearchResult.steps().stream()
+			.filter(step -> "ride".equals(step.stepType()))
+			.map(RouteStep::toStationId)
+			.forEach(stationIds::add);
+		return List.copyOf(stationIds);
 	}
 
 	private List<RouteSearchResult> buildRouteSearchAlternatives(SearchRouteCommand command, int alternativeCount) {

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
@@ -127,12 +127,18 @@ public class RouteV2Planner implements RouteV2SearchUseCase {
 				if (timetableItineraries.isEmpty()) {
 					return noTimetableServicePlan(command, snapshot);
 				}
+				// #2095/#2286: 인증 Route V2는 SUBWAY_AND_ITX_CHEONGCHUN scope만 받고(위에서 강제)
+				// prod 게이트가 TIMETABLE_RAPTOR 출처만 허용하므로, 레거시 그래프 우선 시도를
+				// 건너뛰고 항상 RAPTOR(TIMETABLE_SCAN)를 쓴다. ITX pilot 역처럼 STATION_LINES로
+				// 연결됐지만 접근성 시설 데이터가 없는 역은 레거시 그래프가 채택될 경우
+				// timetableArtifactId가 null이 돼 prod 게이트에서 503으로 막힌다.
 				var stabilizedCandidates = routeSearchUseCase.stabilizeTimetableRouteCandidatesWithSource(
 					searchRouteCommand,
 					RANKING_CANDIDATE_LIMIT,
 					command.alternativeCount(),
 					timetableItineraries,
-					List::copyOf
+					List::copyOf,
+					false
 				);
 				timetableItineraries = stabilizedCandidates.itineraries();
 				if (stabilizedCandidates.source() == TimetableCandidateSource.TIMETABLE_SCAN) {

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -1551,20 +1551,44 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
-	@DisplayName("V2 planner는 stair-only 위험이 있으면 시간표 scan보다 접근성 warning을 보존한다")
-	void routeV2PlannerPreservesAccessibilityWarningsBeforeTimetableScan() {
+	@DisplayName("V2 planner는 stair-only 위험이 있어도 레거시 그래프로 새치기하지 않고 시간표 scan을 그대로 쓴다")
+	void routeV2PlannerAlwaysPrefersTimetableScanEvenWithLegacyAccessibilitySignal() {
+		// #2095/#2286: 인증 Route V2(prod 게이트가 TIMETABLE_RAPTOR 출처만 허용)는 접근성
+		// warning이 있어도 레거시 그래프를 먼저 시도하지 않는다 — 레거시가 채택되면
+		// timetableArtifactId가 null이 돼 그 게이트에서 막히기 때문이다(ITX pilot 역처럼
+		// STATION_LINES는 있지만 접근성 시설 데이터가 없는 역에서 실제로 발생했다). 이 테스트가
+		// 쓰는 StairOnlyTransitMasterPort는 레거시 그래프라면 STAIR_ONLY_ACCESS 경고를 냈을
+		// 것이지만(레거시 로직은 stabilizeTimetableRouteCandidatesWithSource의
+		// legacyGraphCandidateAllowed=true 경로에만 남아 있다), RAPTOR는 접근성 시설 데이터를
+		// 참조하지 않으므로 경고 없이 FOUND를 낸다.
+		var delegate = routeTimetablePort();
+		var port = new LoadRouteTimetablePort() {
+			@Override
+			public RouteTimetable loadRouteTimetable() {
+				return delegate.loadRouteTimetable();
+			}
+
+			@Override
+			public String timetableCacheKey() {
+				return "ITX_CHEONGCHUN:artifact-legacy-conflict:2999-01-01T00:00:00Z";
+			}
+
+			@Override
+			public Optional<String> activeItxTimetableArtifactId() {
+				return Optional.of("artifact-legacy-conflict");
+			}
+		};
 		var repository = new InMemoryRouteSearchRepository();
 		var routeSearchService = new RouteSearchService(repository, repository, new StairOnlyTransitMasterPort(), CLOCK);
-		var planner = new RouteV2Planner(routeSearchService, routeTimetablePort());
+		var planner = new RouteV2Planner(routeSearchService, port);
 
 		var plan = planner.search(routeV2Command(ConstraintMode.PREFER_STEP_FREE, MobilityType.SENIOR, 1, 3));
 
 		assertThat(plan.statuses()).containsExactly(RouteV2Status.FOUND);
-		assertThat(plan.source()).isEqualTo(RouteV2PlanSource.LEGACY_GRAPH);
-		assertThat(plan.itineraries().getFirst().etaSource()).isEqualTo(EtaSource.STATIC_BACKEND_ESTIMATE);
-		assertThat(plan.itineraries().getFirst().warnings())
-			.extracting("code")
-			.containsExactly(RouteWarningCode.STAIR_ONLY_ACCESS);
+		assertThat(plan.source()).isEqualTo(RouteV2PlanSource.TIMETABLE_RAPTOR);
+		assertThat(plan.timetableArtifactId()).isEqualTo("artifact-legacy-conflict");
+		assertThat(plan.itineraries().getFirst().etaSource()).isEqualTo(EtaSource.PLANNED);
+		assertThat(plan.itineraries().getFirst().warnings()).isEmpty();
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.easysubway.profile.domain.MobilityType;
 import com.easysubway.route.adapter.out.persistence.InMemoryRouteSearchRepository;
 import com.easysubway.route.application.port.in.RouteSearchUseCase;
+import com.easysubway.route.application.port.in.RouteSearchUseCase.TimetableCandidateSource;
 import com.easysubway.route.application.port.in.SearchInternalRouteCommand;
 import com.easysubway.route.application.port.in.SearchRouteCommand;
 import com.easysubway.route.application.port.in.RouteV2SearchUseCase;
@@ -1505,6 +1506,32 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("legacyGraphCandidateAllowed=true면 접근성 신호가 있는 레거시 결과를 LEGACY_ACCESSIBILITY_CHECK로 채택한다")
+	void stabilizeTimetableRouteCandidatesWithSourceAdoptsLegacyWhenAllowedAndAccessibilitySignalPresent() {
+		// #2292 Minor 2: RouteV2Planner가 legacyGraphCandidateAllowed=false로 고정 호출하게
+		// 되면서 stabilizeTimetableRouteCandidatesWithSource(..., true)의 원래 동작(접근성
+		// 신호가 있는 레거시 결과를 채택)을 직접 검증하는 테스트가 없어졌다. 이 메서드 자체의
+		// 계약은 살아있음을 고정한다.
+		var repository = new InMemoryRouteSearchRepository();
+		var routeSearchService = new RouteSearchService(repository, repository, new StairOnlyTransitMasterPort(), CLOCK);
+
+		var selection = routeSearchService.stabilizeTimetableRouteCandidatesWithSource(
+			new SearchRouteCommand("station-a", "station-b", MobilityType.SENIOR, ConstraintMode.PREFER_STEP_FREE, 1),
+			3,
+			1,
+			List.of(routeSearchResultWithAccessState("route-timetable", "AVAILABLE", false)),
+			List::copyOf,
+			true
+		);
+
+		assertThat(selection.source()).isEqualTo(TimetableCandidateSource.LEGACY_ACCESSIBILITY_CHECK);
+		assertThat(selection.itineraries()).isNotEmpty();
+		assertThat(selection.itineraries().getFirst().warnings())
+			.extracting("code")
+			.contains(RouteWarningCode.STAIR_ONLY_ACCESS);
+	}
+
+	@Test
 	@DisplayName("V2 planner는 legacy graph가 놓친 시간표 경로를 NO_TIMETABLE_SERVICE로 버리지 않는다")
 	void routeV2PlannerKeepsTimetableRouteWhenLegacyGraphMisses() {
 		var repository = new InMemoryRouteSearchRepository();
@@ -1551,16 +1578,16 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
-	@DisplayName("V2 planner는 stair-only 위험이 있어도 레거시 그래프로 새치기하지 않고 시간표 scan을 그대로 쓴다")
+	@DisplayName("V2 planner는 stair-only 위험이 있어도 레거시 그래프로 새치기하지 않고 시간표 scan을 그대로 쓰되 접근성 경고는 재부착한다")
 	void routeV2PlannerAlwaysPrefersTimetableScanEvenWithLegacyAccessibilitySignal() {
-		// #2095/#2286: 인증 Route V2(prod 게이트가 TIMETABLE_RAPTOR 출처만 허용)는 접근성
-		// warning이 있어도 레거시 그래프를 먼저 시도하지 않는다 — 레거시가 채택되면
+		// #2095/#2286/#2292: 인증 Route V2(prod 게이트가 TIMETABLE_RAPTOR 출처만 허용)는
+		// 접근성 warning이 있어도 레거시 그래프를 먼저 시도하지 않는다 — 레거시가 채택되면
 		// timetableArtifactId가 null이 돼 그 게이트에서 막히기 때문이다(ITX pilot 역처럼
-		// STATION_LINES는 있지만 접근성 시설 데이터가 없는 역에서 실제로 발생했다). 이 테스트가
-		// 쓰는 StairOnlyTransitMasterPort는 레거시 그래프라면 STAIR_ONLY_ACCESS 경고를 냈을
-		// 것이지만(레거시 로직은 stabilizeTimetableRouteCandidatesWithSource의
-		// legacyGraphCandidateAllowed=true 경로에만 남아 있다), RAPTOR는 접근성 시설 데이터를
-		// 참조하지 않으므로 경고 없이 FOUND를 낸다.
+		// STATION_LINES는 있지만 접근성 시설 데이터가 없는 역에서 실제로 발생했다). 다만
+		// RAPTOR 자체는 접근성 시설 데이터를 참조하지 않으므로, RouteSearchService가
+		// ephemeralTimetableRouteResult()에서 레거시와 같은 기준(hasStairOnlyAccess/
+		// routeWarnings, 같은 LoadTransitMasterPort 데이터)으로 STAIR_ONLY_ACCESS 경고를
+		// 재부착한다 — source는 TIMETABLE_RAPTOR로 유지하면서 접근성 경고 정보는 잃지 않는다.
 		var delegate = routeTimetablePort();
 		var port = new LoadRouteTimetablePort() {
 			@Override
@@ -1588,7 +1615,9 @@ class RouteSearchServiceTest {
 		assertThat(plan.source()).isEqualTo(RouteV2PlanSource.TIMETABLE_RAPTOR);
 		assertThat(plan.timetableArtifactId()).isEqualTo("artifact-legacy-conflict");
 		assertThat(plan.itineraries().getFirst().etaSource()).isEqualTo(EtaSource.PLANNED);
-		assertThat(plan.itineraries().getFirst().warnings()).isEmpty();
+		assertThat(plan.itineraries().getFirst().warnings())
+			.extracting("code")
+			.containsExactly(RouteWarningCode.STAIR_ONLY_ACCESS);
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -1621,6 +1621,45 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("V2 planner는 출구 데이터가 없는 역을 지나는 RAPTOR itinerary에 LOW_DATA_CONFIDENCE만 부착하고 STAIR_ONLY_ACCESS는 지어내지 않는다")
+	void routeV2PlannerAttachesLowDataConfidenceNotStairOnlyForNoExitDataStationsOnTimetableScan() {
+		// #2292 2라운드 리뷰: 위 flip 테스트(StairOnlyTransitMasterPort)는 "출구는 있지만
+		// 계단뿐"인 실데이터만 검증한다. 이 PR을 유발한 실제 시나리오는 ITX pilot 역처럼
+		// 출구 데이터 자체가 없는 역이고, 이 경우 STAIR_ONLY_ACCESS를 지어내면 안 된다(근거
+		// 없는 과잉 경고) — LOW_DATA_CONFIDENCE만 붙어야 레거시(hasStairOnlyAccess/
+		// hasLowAccessibilityData)와 동일한 기준이다.
+		var delegate = routeTimetablePort();
+		var port = new LoadRouteTimetablePort() {
+			@Override
+			public RouteTimetable loadRouteTimetable() {
+				return delegate.loadRouteTimetable();
+			}
+
+			@Override
+			public String timetableCacheKey() {
+				return "ITX_CHEONGCHUN:artifact-no-exit-data:2999-01-01T00:00:00Z";
+			}
+
+			@Override
+			public Optional<String> activeItxTimetableArtifactId() {
+				return Optional.of("artifact-no-exit-data");
+			}
+		};
+		var repository = new InMemoryRouteSearchRepository();
+		var routeSearchService = new RouteSearchService(repository, repository, new NoExitDataTransitMasterPort(), CLOCK);
+		var planner = new RouteV2Planner(routeSearchService, port);
+
+		var plan = planner.search(routeV2Command(ConstraintMode.PREFER_STEP_FREE, MobilityType.SENIOR, 1, 3));
+
+		assertThat(plan.statuses()).containsExactly(RouteV2Status.FOUND);
+		assertThat(plan.source()).isEqualTo(RouteV2PlanSource.TIMETABLE_RAPTOR);
+		assertThat(plan.timetableArtifactId()).isEqualTo("artifact-no-exit-data");
+		assertThat(plan.itineraries().getFirst().warnings())
+			.extracting("code")
+			.containsExactly(RouteWarningCode.LOW_DATA_CONFIDENCE);
+	}
+
+	@Test
 	@DisplayName("V2 planner는 strict step-free 요청에서 시간표 scan으로 접근성 차단을 우회하지 않는다")
 	void routeV2PlannerKeepsAccessibilityBlockingForStrictStepFreeWithTimetable() {
 		var repository = new InMemoryRouteSearchRepository();
@@ -4020,6 +4059,18 @@ class RouteSearchServiceTest {
 
 		@Override
 		public List<RouteEdge> loadRouteEdges() {
+			return List.of();
+		}
+	}
+
+	// #2292 2라운드 리뷰: 이 PR을 유발한 실제 시나리오 — ITX pilot 역처럼 출구 데이터 자체가
+	// 없는 역(StairOnlyTransitMasterPort처럼 "출구는 있지만 계단뿐"이 아니라 출구 레코드가
+	// 아예 없음). hasStairOnlyAccess()는 exits.isEmpty()면 근거 없이 stairs-only로 단정하지
+	// 않고 false를 반환하며, hasLowAccessibilityData()는 exits.isEmpty()면 true를 반환한다.
+	private static class NoExitDataTransitMasterPort extends StairOnlyTransitMasterPort {
+
+		@Override
+		public List<StationExit> loadStationExits() {
 			return List.of();
 		}
 	}


### PR DESCRIPTION
## 관련 이슈

Refs AquilaXk/easysubway-backend#3, AquilaXk/easysubway#2286, AquilaXk/easysubway#1400

## 작업 배경

PR AquilaXk/easysubway#2286(ITX-청춘 pilot 14역을 STATION_LINES로 연결 — CodeRabbit이 지적한 강원권 노선/운영기관 집계 0 문제 해소)이 merge된 뒤, production capacity-evidence 워크플로(`production-route-v2-capacity-evidence.yml`, run 29649500074)가 `normal session profile`은 200으로 통과했지만 `normal search profile`에서 503 `ITX_TIMETABLE_UNAVAILABLE`로 실패했다.

오너 승인 하에 production runner에서 격리 pg_dump/restore로 timetable 데이터 자체는 정상(운영 DB에 정상 존재, fresh_until 미만료, activeItxArtifact 조인 성공)임을 먼저 확인했고, 이어서 로컬에서 실제 체크인된 timetable seed(`backend/src/main/resources/timetable/line4-timetable-seed.sql.gz` + `server-timetable-snapshot-evidence.json`, 조작 없이 그대로)로 100% 재현해 근본 원인을 코드 경로로 확정했다.

**근본 원인**: `RouteSearchService.stabilizeTimetableRouteCandidatesWithSource()`는 AquilaXk/easysubway#1400 과도기 로직으로 레거시 V1 그래프 검색을 먼저 시도하고, 결과에 접근성 warning(`hasAccessibilitySignal`)이 있으면 그 레거시 결과를 채택한다(`LEGACY_ACCESSIBILITY_CHECK`). PR AquilaXk/easysubway#2286 이전에는 ITX pilot 역이 `STATION_LINES`에 없어 레거시 검색이 항상 `StationNotFoundException`/`RouteNotFoundException`을 던지고 안전하게 `TIMETABLE_SCAN`(RAPTOR)으로 폴백했다. STATION_LINES 연결 후에는 같은 `lineId`를 공유하는 14역이 레거시 V1 그래프(같은 lineId=1-segment 직접 도달 가능으로 취급)에서 서로 도달 가능해졌고, 이 pilot 역들은 접근성 시설 데이터가 전혀 없어 항상 `hasAccessibilitySignal=true`가 돼 레거시 경로가 채택된다. 그 결과 `RouteV2Plan`이 `source=LEGACY_GRAPH`·`timetableArtifactId=null`로 만들어지고, `ProductionRouteV2Support.requireUsablePlan()`의 prod fail-closed 게이트(`TIMETABLE_RAPTOR` 출처만 허용)가 이를 거부해 503을 낸다.

## 작업 내용

- `RouteSearchUseCase.stabilizeTimetableRouteCandidatesWithSource()`(인터페이스 default)와 `RouteSearchService`의 구현에 `legacyGraphCandidateAllowed` boolean 파라미터를 추가해, 레거시 그래프 우선 시도를 조건부로 만들었다.
- `RouteV2Planner`(SUBWAY_AND_ITX_CHEONGCHUN scope만 받고 prod 게이트가 RAPTOR만 허용하는 인증 Route V2의 유일한 호출자)는 `false`를 전달해 항상 RAPTOR(TIMETABLE_SCAN)를 직접 쓴다.
- `#1400` 레거시 우선 로직 자체는 `legacyGraphCandidateAllowed=true`(인터페이스 기본값)로 남겨뒀다 — 다만 실측 결과(`grep`) `stabilizeTimetableRouteCandidatesWithSource`의 실제 호출자는 `RouteV2Planner`뿐이라, 이 SUBWAY 전용 경로는 현재 코드베이스에 존재하지 않는다(향후 SUBWAY 전용 호출자가 생기면 기본값 그대로 레거시 우선이 적용된다).
- `RouteSearchServiceTest`의 "V2 planner는 stair-only 위험이 있으면 시간표 scan보다 접근성 warning을 보존한다" 테스트는 정확히 이 리그레션의 구 기대값(`LEGACY_GRAPH`)을 검증하고 있었다 — prod 게이트가 어차피 그 출처를 항상 거부했으므로 실제로는 production에서 동작한 적 없는 기대값이었다. 새 의도된 동작(접근성 signal 여부와 무관하게 항상 `TIMETABLE_RAPTOR`)으로 갱신했고, 실제 ITX artifact identity가 결합된 채로 레거시 충돌 시나리오에서도 RAPTOR가 선택되는지 확정하는 회귀 케이스(`routeV2PlannerAlwaysPrefersTimetableScanEvenWithLegacyAccessibilitySignal`)로 대체했다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests "com.easysubway.route.*" --tests "com.easysubway.transit.*" --tests "com.easysubway.quality.*" --tests "com.easysubway.operator.*" --tests "com.easysubway.collection.*"` → BUILD SUCCESSFUL
  - `LC_ALL=C node --test tools/ci/repository-contract.test.mjs` → 217 pass, 0 fail
  - `git diff --check` → 통과

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| ITX 인증 Route V2 검색 회귀 재현·수정 확인 | backend (로컬) | 체크인된 실제 timetable seed를 로컬 Postgres 16에 `TimetableSeedLoader`로 활성화하고 `SPRING_PROFILES_ACTIVE=prod,capacity-evidence`로 백엔드 기동, session 발급 후 `station-dd14cfb89cbc`(춘천)→`station-8aa315864466`(용산) search 요청 | 수정 전: `503 {"success":false,"code":"ITX_TIMETABLE_UNAVAILABLE"}`. 수정 후: `200`, 응답 body `plannerIdentity.timetableSnapshotSha256`이 체크인된 evidence의 snapshotSha256(`5c2911620ead...`)과 일치, `statuses:["FOUND"]` | PASS |
| production capacity-evidence 워크플로 exit 0 | production runner (self-hosted) | 오너 승인 하에 별도 진행 예정(이 PR 병합·CD 배포 이후) | 미실행 — 6번 항목 참고 | 보류 |

## Version impact

- [ ] no version change
- [x] backend deploy only
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] AquilaXk/easysubway#1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음(선택 로직만 수정, 응답 계약 필드 불변)
- realtime contract: 변경 없음
- backend identity: 다음 배포 시 새 SHA로 갱신(코드만 변경, 별도 identity 스킴 없음)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java`의 `stabilizeTimetableRouteCandidatesWithSource` 조건부 분기, `RouteV2Planner.java`의 호출부(`legacyGraphCandidateAllowed=false`), `RouteSearchServiceTest.java`의 재작성된 회귀 테스트.
- `stabilizeTimetableRouteCandidatesWithSource`의 유일한 실제 호출자가 `RouteV2Planner`뿐이라는 근거는 `grep -rn "stabilizeTimetableRouteCandidatesWithSource" backend/src/main/java/`로 재확인 가능.

## 리스크

- `legacyGraphCandidateAllowed=true`(SUBWAY 경로용 AquilaXk/easysubway#1400 레거시 우선)는 현재 실제 호출자가 없어 이 PR로 검증되지 않는다 — 향후 SUBWAY 전용 stabilize 호출자가 추가되면 이 기본값 경로도 함께 테스트해야 한다.
- production capacity-evidence 워크플로 exit 0 최종 확인은 이 PR 병합·배포 이후 오너 승인 하에 별도 진행한다(automerge 라벨 미부착, 이 PR 자체로는 production 재실행 안 함).

## 체크리스트

- [ ] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
