### PR TITLE
[Fix] #2273 V6-01 metric kind 의미·snapshot transaction·원자 upsert 정합

### DIFF
--- a/backend/src/main/java/com/easysubway/admin/metric/adapter/in/web/AnalyticsComparisonCard.java
+++ b/backend/src/main/java/com/easysubway/admin/metric/adapter/in/web/AnalyticsComparisonCard.java
@@ -24,10 +24,21 @@ public record AnalyticsComparisonCard(
 			comparison.label(),
 			formatValue(comparison.current()),
 			formatValue(comparison.previous()),
-			comparison.deltaPercent() == null ? "직전 없음" : "%+.1f%%".formatted(comparison.deltaPercent()),
+			deltaPercentLabel(comparison),
 			tone,
 			comparison.delta() > 0
 		);
+	}
+
+	/**
+	 * 증감률 표시 문구. 직전 기간에 스냅샷이 없으면 "직전 없음", 직전 실측값이 0이라 증감률이 정의
+	 * 불가하면 "기준 0 — 증가율 산정 불가"로 구분한다(#2273: 실측 0과 스냅샷 부재 구분).
+	 */
+	private static String deltaPercentLabel(AdminMetricComparison comparison) {
+		if (comparison.deltaPercent() != null) {
+			return "%+.1f%%".formatted(comparison.deltaPercent());
+		}
+		return comparison.previousPresent() ? "기준 0 — 증가율 산정 불가" : "직전 없음";
 	}
 
 	private static String formatValue(double value) {

--- a/backend/src/main/java/com/easysubway/admin/metric/adapter/out/persistence/JdbcAdminMetricDailyRepository.java
+++ b/backend/src/main/java/com/easysubway/admin/metric/adapter/out/persistence/JdbcAdminMetricDailyRepository.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 import javax.sql.DataSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.core.ConnectionCallback;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
@@ -19,6 +20,7 @@ import org.springframework.stereotype.Repository;
 public class JdbcAdminMetricDailyRepository implements AdminMetricDailyRepository {
 
 	private final JdbcTemplate jdbcTemplate;
+	private final DatabaseDialect databaseDialect;
 
 	@Autowired
 	JdbcAdminMetricDailyRepository(DataSource dataSource) {
@@ -27,27 +29,49 @@ public class JdbcAdminMetricDailyRepository implements AdminMetricDailyRepositor
 
 	JdbcAdminMetricDailyRepository(JdbcTemplate jdbcTemplate) {
 		this.jdbcTemplate = jdbcTemplate;
+		this.databaseDialect = detectDatabaseDialect(jdbcTemplate);
 	}
 
 	@Override
 	public void save(AdminMetricDaily metric) {
-		// dialect 무관 upsert: 먼저 UPDATE, 없으면 INSERT. (지표 키, 날짜) 재실행이 멱등하다.
-		int updated = jdbcTemplate.update(
-			"UPDATE admin_metric_daily SET metric_value = ?, dimensions = ? WHERE metric_key = ? AND metric_date = ?",
-			metric.value(),
-			metric.dimensions(),
-			metric.metricKey(),
-			metric.metricDate()
-		);
-		if (updated == 0) {
-			jdbcTemplate.update(
-				"INSERT INTO admin_metric_daily (metric_key, metric_date, metric_value, dimensions) VALUES (?, ?, ?, ?)",
-				metric.metricKey(),
-				metric.metricDate(),
-				metric.value(),
-				metric.dimensions()
-			);
+		// 원자적 upsert(#2273): 한 문장으로 처리해 (지표 키, 날짜) 동시 저장 경합에도 PK 충돌 없이 한 행만
+		// 남기고, 재실행은 값을 덮어써 멱등하다. ON CONFLICT(PostgreSQL)/MERGE KEY(H2)는 방언별 표기만
+		// 다를 뿐 같은 원자 동작을 보장한다. H2는 ON CONFLICT 문법을 파싱하지 못해 방언으로 분기한다.
+		if (databaseDialect == DatabaseDialect.POSTGRESQL) {
+			upsertWithOnConflict(metric);
+			return;
 		}
+		upsertWithMergeKey(metric);
+	}
+
+	private void upsertWithOnConflict(AdminMetricDaily metric) {
+		jdbcTemplate.update(
+			"""
+				INSERT INTO admin_metric_daily (metric_key, metric_date, metric_value, dimensions)
+				VALUES (?, ?, ?, ?)
+				ON CONFLICT (metric_key, metric_date) DO UPDATE
+				SET metric_value = EXCLUDED.metric_value,
+					dimensions = EXCLUDED.dimensions
+				""",
+			metric.metricKey(),
+			metric.metricDate(),
+			metric.value(),
+			metric.dimensions()
+		);
+	}
+
+	private void upsertWithMergeKey(AdminMetricDaily metric) {
+		jdbcTemplate.update(
+			"""
+				MERGE INTO admin_metric_daily (metric_key, metric_date, metric_value, dimensions)
+				KEY (metric_key, metric_date)
+				VALUES (?, ?, ?, ?)
+				""",
+			metric.metricKey(),
+			metric.metricDate(),
+			metric.value(),
+			metric.dimensions()
+		);
 	}
 
 	@Override
@@ -91,5 +115,19 @@ public class JdbcAdminMetricDailyRepository implements AdminMetricDailyRepositor
 			rs.getDouble("metric_value"),
 			rs.getString("dimensions")
 		);
+	}
+
+	// 원자적 upsert 문법이 방언별로 달라(ON CONFLICT vs MERGE KEY) 저장 시 분기하기 위해 감지한다.
+	private static DatabaseDialect detectDatabaseDialect(JdbcTemplate jdbcTemplate) {
+		DatabaseDialect dialect = jdbcTemplate.execute((ConnectionCallback<DatabaseDialect>) connection -> {
+			String productName = connection.getMetaData().getDatabaseProductName();
+			return "H2".equalsIgnoreCase(productName) ? DatabaseDialect.H2 : DatabaseDialect.POSTGRESQL;
+		});
+		return dialect == null ? DatabaseDialect.POSTGRESQL : dialect;
+	}
+
+	private enum DatabaseDialect {
+		POSTGRESQL,
+		H2
 	}
 }

--- a/backend/src/main/java/com/easysubway/admin/metric/application/service/AdminMetricQueryService.java
+++ b/backend/src/main/java/com/easysubway/admin/metric/application/service/AdminMetricQueryService.java
@@ -3,6 +3,7 @@ package com.easysubway.admin.metric.application.service;
 import com.easysubway.admin.metric.application.port.out.AdminMetricDailyRepository;
 import com.easysubway.admin.metric.domain.AdminMetricDaily;
 import com.easysubway.admin.metric.domain.AdminMetricKeys;
+import com.easysubway.admin.metric.domain.AdminMetricKeys.AdminMetricKind;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.util.Collection;
@@ -67,10 +68,14 @@ public class AdminMetricQueryService {
 	}
 
 	/**
-	 * 지표 키별로 최근 기간과 직전 동일 기간의 합계를 비교해 증감을 계산한다("어제보다 나빠졌는가"에 즉답).
+	 * 지표 키별로 최근 기간과 직전 동일 기간을 비교해 증감을 계산한다("어제보다 나빠졌는가"에 즉답).
 	 *
-	 * <p>기간은 7/30/90일로 정규화한다. 스냅샷이 없는 날은 0으로 본다(경계 안정). 증감률은
-	 * 직전 기간 합계가 0이면 정의하지 않는다(null): 0에서의 증가는 비율로 표현할 수 없다.
+	 * <p>집계 의미는 지표 종류가 정한다(#2273): {@code DAILY_COUNTER}만 {@code [from, to]} 기간
+	 * 합계로 비교하고, {@code GAUGE}·{@code RATE}·{@code ROLLING_WINDOW}는 누계·비율·이동 기간이라
+	 * 합산이 중복이므로 기간 내 최신 스냅샷끼리 비교한다.
+	 *
+	 * <p>기간은 7/30/90일로 정규화한다. 증감률은 직전 기간 값이 0이면 정의하지 않는다(null):
+	 * 0에서의 증가는 비율로 표현할 수 없다.
 	 */
 	public List<AdminMetricComparison> compare(Collection<String> requestedKeys, int requestedDays) {
 		int days = ALLOWED_DAYS.contains(requestedDays) ? requestedDays : DEFAULT_DAYS;
@@ -88,9 +93,9 @@ public class AdminMetricQueryService {
 		return keys.stream()
 			.map(key -> {
 				Map<LocalDate, Double> valuesByDate = byKey.getOrDefault(key, Map.of());
-				boolean rate = AdminMetricKeys.isRate(key);
-				double current = aggregate(valuesByDate, currentFrom, today, rate);
-				double previous = aggregate(valuesByDate, previousFrom, previousTo, rate);
+				AdminMetricKind kind = AdminMetricKeys.kind(key);
+				double current = aggregate(valuesByDate, currentFrom, today, kind);
+				double previous = aggregate(valuesByDate, previousFrom, previousTo, kind);
 				Double deltaPercent = previous == 0.0 ? null : (current - previous) * 100 / previous;
 				return new AdminMetricComparison(
 					key, AdminMetricKeys.label(key), days, current, previous, current - previous, deltaPercent);
@@ -99,27 +104,28 @@ public class AdminMetricQueryService {
 	}
 
 	/**
-	 * 기간 집계: 건수 지표는 합계(결측일 0), 비율·평균 지표는 값이 있는 날의 평균(결측일 제외)으로 모은다.
-	 * 비율을 합산하면(예: 7일 차단률 합) 무의미하므로 평균으로 본다.
+	 * 지표 종류별 기간 집계(#2273). 일별 counter만 기간 합계(결측일 0)로 모으고, 누계·비율·이동
+	 * 기간 지표는 기간 내 최신 스냅샷 값을 그대로 쓴다(스냅샷이 하나도 없으면 0).
 	 */
-	private static double aggregate(Map<LocalDate, Double> valuesByDate, LocalDate from, LocalDate to, boolean rate) {
-		if (!rate) {
-			return from.datesUntil(to.plusDays(1))
+	private static double aggregate(
+		Map<LocalDate, Double> valuesByDate, LocalDate from, LocalDate to, AdminMetricKind kind) {
+		return switch (kind) {
+			case DAILY_COUNTER -> from.datesUntil(to.plusDays(1))
 				.mapToDouble(date -> valuesByDate.getOrDefault(date, 0.0))
 				.sum();
+			case GAUGE, RATE, ROLLING_WINDOW -> latestSnapshot(valuesByDate, from, to);
+		};
+	}
+
+	/** 기간 {@code [from, to]} 안에서 가장 최근 날짜의 스냅샷 값. 값이 하나도 없으면 0. */
+	private static double latestSnapshot(Map<LocalDate, Double> valuesByDate, LocalDate from, LocalDate to) {
+		for (LocalDate date = to; !date.isBefore(from); date = date.minusDays(1)) {
+			Double value = valuesByDate.get(date);
+			if (value != null) {
+				return value;
+			}
 		}
-		double[] present = from.datesUntil(to.plusDays(1))
-			.filter(valuesByDate::containsKey)
-			.mapToDouble(valuesByDate::get)
-			.toArray();
-		if (present.length == 0) {
-			return 0.0;
-		}
-		double sum = 0.0;
-		for (double value : present) {
-			sum += value;
-		}
-		return sum / present.length;
+		return 0.0;
 	}
 
 	private static List<String> normalizeKeys(Collection<String> requestedKeys) {
@@ -152,8 +158,8 @@ public class AdminMetricQueryService {
 	 * @param key          지표 키
 	 * @param label        한글 표시 라벨
 	 * @param days         비교 기간(일)
-	 * @param current      최근 기간 합계(결측일 0)
-	 * @param previous     직전 동일 기간 합계(결측일 0)
+	 * @param current      최근 기간 집계(일별 counter는 합계, 그 외는 기간 내 최신 스냅샷)
+	 * @param previous     직전 동일 기간 집계(집계 방식은 current와 동일)
 	 * @param delta        current - previous
 	 * @param deltaPercent 증감률(%), 직전 기간이 0이면 null(정의 불가)
 	 */

--- a/backend/src/main/java/com/easysubway/admin/metric/application/service/AdminMetricQueryService.java
+++ b/backend/src/main/java/com/easysubway/admin/metric/application/service/AdminMetricQueryService.java
@@ -96,9 +96,11 @@ public class AdminMetricQueryService {
 				AdminMetricKind kind = AdminMetricKeys.kind(key);
 				double current = aggregate(valuesByDate, currentFrom, today, kind);
 				double previous = aggregate(valuesByDate, previousFrom, previousTo, kind);
+				boolean previousPresent = hasSnapshot(valuesByDate, previousFrom, previousTo);
 				Double deltaPercent = previous == 0.0 ? null : (current - previous) * 100 / previous;
 				return new AdminMetricComparison(
-					key, AdminMetricKeys.label(key), days, current, previous, current - previous, deltaPercent);
+					key, AdminMetricKeys.label(key), days, current, previous, current - previous, deltaPercent,
+					previousPresent);
 			})
 			.toList();
 	}
@@ -126,6 +128,19 @@ public class AdminMetricQueryService {
 			}
 		}
 		return 0.0;
+	}
+
+	/**
+	 * 기간 {@code [from, to]} 안에 스냅샷이 하나라도 있는지 여부. 집계값이 0.0이어도 실측된 0인지
+	 * 스냅샷 자체가 없어 0으로 채운 것인지 구분한다(#2273: "실측 0"과 "직전 없음" 구분).
+	 */
+	private static boolean hasSnapshot(Map<LocalDate, Double> valuesByDate, LocalDate from, LocalDate to) {
+		for (LocalDate date = from; !date.isAfter(to); date = date.plusDays(1)) {
+			if (valuesByDate.containsKey(date)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private static List<String> normalizeKeys(Collection<String> requestedKeys) {
@@ -158,10 +173,12 @@ public class AdminMetricQueryService {
 	 * @param key          지표 키
 	 * @param label        한글 표시 라벨
 	 * @param days         비교 기간(일)
-	 * @param current      최근 기간 집계(일별 counter는 합계, 그 외는 기간 내 최신 스냅샷)
-	 * @param previous     직전 동일 기간 집계(집계 방식은 current와 동일)
-	 * @param delta        current - previous
-	 * @param deltaPercent 증감률(%), 직전 기간이 0이면 null(정의 불가)
+	 * @param current         최근 기간 집계(일별 counter는 합계, 그 외는 기간 내 최신 스냅샷)
+	 * @param previous        직전 동일 기간 집계(집계 방식은 current와 동일)
+	 * @param delta           current - previous
+	 * @param deltaPercent    증감률(%), 직전 기간이 0이면 null(정의 불가)
+	 * @param previousPresent 직전 기간에 스냅샷이 하나라도 있었는지. previous가 0.0일 때 실측된 0인지
+	 *                        (true) 스냅샷 부재로 0으로 채운 것인지(false)를 구분한다(#2273)
 	 */
 	public record AdminMetricComparison(
 		String key,
@@ -170,7 +187,8 @@ public class AdminMetricQueryService {
 		double current,
 		double previous,
 		double delta,
-		Double deltaPercent
+		Double deltaPercent,
+		boolean previousPresent
 	) {
 
 		public boolean improved(boolean higherIsBetter) {

--- a/backend/src/main/java/com/easysubway/admin/metric/application/service/AdminMetricSnapshotService.java
+++ b/backend/src/main/java/com/easysubway/admin/metric/application/service/AdminMetricSnapshotService.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * 일별 지표 스냅샷 집계(#1739). 대시보드가 즉석 계산하던 값과 <b>같은 use case</b>에서 뽑아
@@ -92,7 +93,13 @@ public class AdminMetricSnapshotService {
 		this.clock = clock;
 	}
 
-	/** 오늘 날짜로 스냅샷을 집계한다(스케줄러·수동 재실행 진입점). */
+	/**
+	 * 오늘 날짜로 스냅샷을 집계한다(스케줄러·수동 재실행 진입점).
+	 *
+	 * <p>{@link #snapshot(LocalDate)}를 내부 호출하므로, 프록시 자기호출로 트랜잭션이 새지 않도록
+	 * 이 진입점에도 {@link Transactional}을 둔다(#2273). 한 실행의 모든 지표 write가 한 트랜잭션이다.
+	 */
+	@Transactional
 	public void snapshotToday() {
 		snapshot(LocalDate.now(clock));
 	}
@@ -100,7 +107,11 @@ public class AdminMetricSnapshotService {
 	/**
 	 * 주어진 날짜로 지표를 집계해 upsert한다. 실패는 상태 홀더에 기록하고 예외를 다시 던진다
 	 * (스케줄러·엔드포인트가 로깅/응답을 처리).
+	 *
+	 * <p>한 실행의 모든 지표 write를 한 트랜잭션으로 묶어, 한 지표 저장이 실패하면 같은 실행에서
+	 * 앞서 저장한 지표까지 전부 rollback한다(#2273). 상태 홀더 기록은 DB 밖이라 rollback되지 않는다.
 	 */
+	@Transactional
 	public void snapshot(LocalDate date) {
 		try {
 			Map<FacilityReportStatus, Long> reportCounts = facilityReportUseCase.countReportsByStatus();

--- a/backend/src/main/java/com/easysubway/admin/metric/domain/AdminMetricKeys.java
+++ b/backend/src/main/java/com/easysubway/admin/metric/domain/AdminMetricKeys.java
@@ -3,14 +3,34 @@ package com.easysubway.admin.metric.domain;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * 일별 지표 스냅샷(#1739) 키. 대시보드 즉석 계산과 같은 소스에서 뽑아 "정합"을 보장한다.
  *
  * <p>값 단위: 건수는 개수, 소요는 분, 비율은 퍼센트(0~100).
+ *
+ * <p>기간 비교 의미는 지표 종류({@link AdminMetricKind})가 정한다. 누계·비율·롤링 윈도는 기간
+ * 합산이 무의미하므로 기간 내 최신 스냅샷끼리 비교하고, 일별 counter만 기간 합계로 비교한다(#2273).
  */
 public final class AdminMetricKeys {
+
+	/**
+	 * 지표 종류. 기간 비교(전 기간 대비 증감)에서 값을 어떻게 모을지 결정한다.
+	 *
+	 * <ul>
+	 *   <li>{@link #GAUGE}: 시점 상태·누계 총량(대기 건수, 누적 검색 수 등). 기간 내 최신 스냅샷을 비교한다.
+	 *   <li>{@link #RATE}: 비율·평균(차단률, 오류율, 평균 처리 시간). 기간 내 최신 스냅샷을 비교한다.
+	 *   <li>{@link #DAILY_COUNTER}: 그날 하루치 증가분만 담는 지표. 이 종류만 기간 합계로 비교한다.
+	 *   <li>{@link #ROLLING_WINDOW}: 이동 기간(24시간 접수, 7일 활성 사용자 등). 스냅샷이 겹쳐
+	 *       합산하면 중복되므로 기간 내 최신 스냅샷을 비교한다.
+	 * </ul>
+	 */
+	public enum AdminMetricKind {
+		GAUGE,
+		RATE,
+		DAILY_COUNTER,
+		ROLLING_WINDOW
+	}
 
 	public static final String REPORTS_RECENT_24H = "reports.recent_24h";
 	public static final String REPORTS_PENDING = "reports.pending";
@@ -45,6 +65,7 @@ public final class AdminMetricKeys {
 	);
 
 	private static final Map<String, String> LABELS = labels();
+	private static final Map<String, AdminMetricKind> KINDS = kinds();
 
 	private AdminMetricKeys() {
 	}
@@ -53,19 +74,16 @@ public final class AdminMetricKeys {
 		return ALL;
 	}
 
-	private static final Set<String> RATE_METRICS = Set.of(
-		ROUTE_BLOCKED_RATE, API_ERROR_RATE, REPORTS_PROCESSING_AVG_MINUTES);
-
 	public static boolean isKnown(String metricKey) {
 		return ALL.contains(metricKey);
 	}
 
 	/**
-	 * 비율·평균 지표인지 여부. 기간 비교에서 이런 지표는 합계가 무의미하므로(예: 7일 차단률 합 = 175%)
-	 * 값이 있는 날의 평균으로 집계한다. 건수 지표는 합계로 집계한다.
+	 * 지표 종류. 기간 비교에서 값을 어떻게 모을지 결정한다. 미등록 키는 합산하면 위험하므로 최신
+	 * 스냅샷만 비교하는 {@link AdminMetricKind#GAUGE}로 본다(안전 기본값).
 	 */
-	public static boolean isRate(String metricKey) {
-		return RATE_METRICS.contains(metricKey);
+	public static AdminMetricKind kind(String metricKey) {
+		return KINDS.getOrDefault(metricKey, AdminMetricKind.GAUGE);
 	}
 
 	/** 차트·표에 쓰는 한글 표시 라벨. 미등록 키는 키 자체를 돌려준다. */
@@ -90,5 +108,26 @@ public final class AdminMetricKeys {
 		labels.put(API_ERROR_RATE, "API 오류율(%)");
 		labels.put(USERS_ACTIVE, "활성 사용자");
 		return labels;
+	}
+
+	// 각 지표 스냅샷이 담는 값의 성격에 따라 종류를 고정한다. 대시보드 요약 use case가 돌려주는 값이
+	// 그날 하루치 증가분이 아니라 시점 상태·누계 총량·비율·이동 기간이므로, 일별 합산 대상은 없다(#2273).
+	private static Map<String, AdminMetricKind> kinds() {
+		Map<String, AdminMetricKind> kinds = new LinkedHashMap<>();
+		kinds.put(REPORTS_RECENT_24H, AdminMetricKind.ROLLING_WINDOW); // 스냅샷 시점 기준 최근 24시간 접수
+		kinds.put(REPORTS_PENDING, AdminMetricKind.GAUGE); // 현재 확인 대기 건수
+		kinds.put(REPORTS_PROCESSING_AVG_MINUTES, AdminMetricKind.RATE); // 평균 처리 시간(분)
+		kinds.put(FACILITIES_NEEDS_VERIFICATION, AdminMetricKind.GAUGE); // 현재 확인 필요 시설 수
+		kinds.put(FACILITIES_DELAYED, AdminMetricKind.GAUGE); // 현재 지연 시설 상태 수
+		kinds.put(ROUTE_SEARCHES, AdminMetricKind.GAUGE); // 누적 경로 검색 총량(all-time COUNT)
+		kinds.put(ROUTE_BLOCKED_RATE, AdminMetricKind.RATE); // 차단률(%)
+		kinds.put(ROUTE_FEEDBACK_HELPFUL, AdminMetricKind.GAUGE); // 누적 도움됨 피드백 총량
+		kinds.put(ROUTE_FEEDBACK_NOT_HELPFUL, AdminMetricKind.GAUGE); // 누적 도움 안 됨 피드백 총량
+		kinds.put(ROUTE_FEEDBACK_BLOCKED, AdminMetricKind.GAUGE); // 누적 현장 차단 신고 총량
+		kinds.put(PUSH_ATTEMPTED, AdminMetricKind.GAUGE); // 누적 푸시 시도 총량
+		kinds.put(PUSH_FAILED, AdminMetricKind.GAUGE); // 누적 푸시 실패 총량
+		kinds.put(API_ERROR_RATE, AdminMetricKind.RATE); // API 오류율(%)
+		kinds.put(USERS_ACTIVE, AdminMetricKind.ROLLING_WINDOW); // 최근 7일 활성 사용자(이동 기간)
+		return kinds;
 	}
 }

--- a/backend/src/test/java/com/easysubway/admin/metric/adapter/out/persistence/JdbcAdminMetricDailyRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/admin/metric/adapter/out/persistence/JdbcAdminMetricDailyRepositoryTest.java
@@ -6,6 +6,11 @@ import com.easysubway.admin.metric.domain.AdminMetricDaily;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -77,5 +82,40 @@ class JdbcAdminMetricDailyRepositoryTest {
 		assertThat(range)
 			.extracting(AdminMetricDaily::metricDate)
 			.containsExactly(LocalDate.of(2026, 7, 4));
+	}
+
+	@Test
+	@DisplayName("같은 키·날짜를 여러 스레드가 동시에 저장해도 원자적 upsert로 한 행만 남는다")
+	void concurrentSaveKeepsSingleRow() throws InterruptedException {
+		LocalDate date = LocalDate.of(2026, 7, 5);
+		int threadCount = 8;
+		ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+		CountDownLatch ready = new CountDownLatch(threadCount);
+		CountDownLatch start = new CountDownLatch(1);
+		CountDownLatch done = new CountDownLatch(threadCount);
+		CopyOnWriteArrayList<Throwable> errors = new CopyOnWriteArrayList<>();
+
+		for (int i = 0; i < threadCount; i++) {
+			double value = i;
+			pool.execute(() -> {
+				ready.countDown();
+				try {
+					start.await();
+					repository.save(AdminMetricDaily.scalar("route.searches", date, value));
+				} catch (Throwable throwable) {
+					errors.add(throwable);
+				} finally {
+					done.countDown();
+				}
+			});
+		}
+
+		assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+		start.countDown();
+		assertThat(done.await(10, TimeUnit.SECONDS)).isTrue();
+		pool.shutdownNow();
+
+		assertThat(errors).isEmpty();
+		assertThat(repository.findByKeysAndDateRange(List.of("route.searches"), date, date)).hasSize(1);
 	}
 }

--- a/backend/src/test/java/com/easysubway/admin/metric/application/service/AdminMetricQueryServiceTest.java
+++ b/backend/src/test/java/com/easysubway/admin/metric/application/service/AdminMetricQueryServiceTest.java
@@ -26,41 +26,69 @@ class AdminMetricQueryServiceTest {
 		repository, Clock.fixed(TODAY.atStartOfDay(ZONE).toInstant(), ZONE));
 
 	@Test
-	@DisplayName("최근 기간과 직전 동일 기간 합계를 비교하고 결측일을 0으로 본다")
-	void comparesCurrentAndPreviousPeriodSums() {
-		// 최근 7일 [06-30, 07-06]: 07-06=100, 07-04=50, 나머지 결측 → 150
-		save(AdminMetricKeys.ROUTE_SEARCHES, TODAY, 100);
-		save(AdminMetricKeys.ROUTE_SEARCHES, TODAY.minusDays(2), 50);
-		// 직전 7일 [06-23, 06-29]: 06-29=60, 나머지 결측 → 60
-		save(AdminMetricKeys.ROUTE_SEARCHES, TODAY.minusDays(7), 60);
+	@DisplayName("누계(GAUGE) 지표는 기간 합산이 아니라 기간 내 최신 스냅샷끼리 비교한다")
+	void cumulativeGaugeComparesLatestSnapshotNotSum() {
+		// route.searches는 all-time 누적 총량 스냅샷이라 일별 합산은 중복 합산(#2273 결함).
+		// 최근 7일 [06-30, 07-06] 누적 스냅샷: 07-02=100, 07-05=150, 07-06=175 → 최신 175(합산이면 425).
+		save(AdminMetricKeys.ROUTE_SEARCHES, TODAY.minusDays(4), 100);
+		save(AdminMetricKeys.ROUTE_SEARCHES, TODAY.minusDays(1), 150);
+		save(AdminMetricKeys.ROUTE_SEARCHES, TODAY, 175);
+		// 직전 7일 [06-23, 06-29] 누적 스냅샷: 06-28=80, 06-29=90 → 최신 90(합산이면 170).
+		save(AdminMetricKeys.ROUTE_SEARCHES, TODAY.minusDays(8), 80);
+		save(AdminMetricKeys.ROUTE_SEARCHES, TODAY.minusDays(7), 90);
 
 		AdminMetricComparison comparison = service.compare(List.of(AdminMetricKeys.ROUTE_SEARCHES), 7).getFirst();
 
-		assertThat(comparison.current()).isEqualTo(150.0);
-		assertThat(comparison.previous()).isEqualTo(60.0);
-		assertThat(comparison.delta()).isEqualTo(90.0);
-		assertThat(comparison.deltaPercent()).isCloseTo(150.0, within(0.001));
-		assertThat(comparison.days()).isEqualTo(7);
+		assertThat(comparison.current()).isEqualTo(175.0);
+		assertThat(comparison.previous()).isEqualTo(90.0);
+		assertThat(comparison.delta()).isEqualTo(85.0);
+		assertThat(comparison.deltaPercent()).isCloseTo(94.444, within(0.001));
 		assertThat(comparison.label()).isEqualTo("경로 검색");
 	}
 
 	@Test
-	@DisplayName("비율 지표는 합계 대신 값이 있는 날의 평균으로 비교한다")
-	void ratesAreComparedByAverageOfPresentDays() {
-		// 최근 7일 차단률: 07-06=30, 07-04=20 (present 2일 평균 25). 직전 7일: 06-29=10 (평균 10).
-		save(AdminMetricKeys.ROUTE_BLOCKED_RATE, TODAY, 30);
-		save(AdminMetricKeys.ROUTE_BLOCKED_RATE, TODAY.minusDays(2), 20);
-		save(AdminMetricKeys.ROUTE_BLOCKED_RATE, TODAY.minusDays(7), 10);
+	@DisplayName("이동 기간(ROLLING_WINDOW) 지표는 스냅샷이 겹치므로 합산하지 않고 최신 스냅샷을 비교한다")
+	void rollingWindowComparesLatestSnapshotNotSum() {
+		// users.active는 최근 7일 이동 활성 사용자라 스냅샷이 겹친다. 합산하면 중복(#2273 결함).
+		save(AdminMetricKeys.USERS_ACTIVE, TODAY.minusDays(2), 20);
+		save(AdminMetricKeys.USERS_ACTIVE, TODAY, 25);
+		save(AdminMetricKeys.USERS_ACTIVE, TODAY.minusDays(7), 10);
 
-		AdminMetricComparison comparison = service.compare(List.of(AdminMetricKeys.ROUTE_BLOCKED_RATE), 7).getFirst();
+		AdminMetricComparison comparison = service.compare(List.of(AdminMetricKeys.USERS_ACTIVE), 7).getFirst();
 
-		assertThat(comparison.current()).isCloseTo(25.0, within(0.001));
-		assertThat(comparison.previous()).isCloseTo(10.0, within(0.001));
+		assertThat(comparison.current()).isEqualTo(25.0); // 최신 스냅샷(합산이면 45)
+		assertThat(comparison.previous()).isEqualTo(10.0);
 		assertThat(comparison.deltaPercent()).isCloseTo(150.0, within(0.001));
 	}
 
 	@Test
-	@DisplayName("직전 기간 합계가 0이면 증감률은 정의하지 않는다(null)")
+	@DisplayName("비율(RATE) 지표는 합계·평균이 아니라 기간 내 최신 스냅샷을 비교한다")
+	void rateComparesLatestSnapshot() {
+		// 최근 7일 차단률 스냅샷: 07-04=20, 07-06=30 → 최신 30(합산 50·평균 25 아님).
+		save(AdminMetricKeys.ROUTE_BLOCKED_RATE, TODAY.minusDays(2), 20);
+		save(AdminMetricKeys.ROUTE_BLOCKED_RATE, TODAY, 30);
+		save(AdminMetricKeys.ROUTE_BLOCKED_RATE, TODAY.minusDays(7), 10);
+
+		AdminMetricComparison comparison = service.compare(List.of(AdminMetricKeys.ROUTE_BLOCKED_RATE), 7).getFirst();
+
+		assertThat(comparison.current()).isEqualTo(30.0);
+		assertThat(comparison.previous()).isEqualTo(10.0);
+		assertThat(comparison.deltaPercent()).isCloseTo(200.0, within(0.001));
+	}
+
+	@Test
+	@DisplayName("스냅샷이 없는 기간의 최신 스냅샷은 0으로 본다(경계 안정)")
+	void latestSnapshotIsZeroWhenPeriodEmpty() {
+		save(AdminMetricKeys.REPORTS_PENDING, TODAY, 8);
+
+		AdminMetricComparison comparison = service.compare(List.of(AdminMetricKeys.REPORTS_PENDING), 7).getFirst();
+
+		assertThat(comparison.current()).isEqualTo(8.0);
+		assertThat(comparison.previous()).isEqualTo(0.0);
+	}
+
+	@Test
+	@DisplayName("직전 기간 값이 0이면 증감률은 정의하지 않는다(null)")
 	void undefinedPercentWhenPreviousIsZero() {
 		save(AdminMetricKeys.USERS_ACTIVE, TODAY, 30);
 
@@ -69,6 +97,16 @@ class AdminMetricQueryServiceTest {
 		assertThat(comparison.current()).isEqualTo(30.0);
 		assertThat(comparison.previous()).isEqualTo(0.0);
 		assertThat(comparison.deltaPercent()).isNull();
+	}
+
+	@Test
+	@DisplayName("기간 label(days)은 요청 기간을 그대로 보존한다")
+	void preservesRequestedPeriodLabel() {
+		save(AdminMetricKeys.ROUTE_SEARCHES, TODAY, 100);
+
+		AdminMetricComparison comparison = service.compare(List.of(AdminMetricKeys.ROUTE_SEARCHES), 30).getFirst();
+
+		assertThat(comparison.days()).isEqualTo(30);
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/admin/metric/application/service/AdminMetricQueryServiceTest.java
+++ b/backend/src/test/java/com/easysubway/admin/metric/application/service/AdminMetricQueryServiceTest.java
@@ -3,6 +3,7 @@ package com.easysubway.admin.metric.application.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
 
+import com.easysubway.admin.metric.adapter.in.web.AnalyticsComparisonCard;
 import com.easysubway.admin.metric.adapter.out.persistence.InMemoryAdminMetricDailyRepository;
 import com.easysubway.admin.metric.application.service.AdminMetricQueryService.AdminMetricComparison;
 import com.easysubway.admin.metric.domain.AdminMetricDaily;
@@ -97,6 +98,40 @@ class AdminMetricQueryServiceTest {
 		assertThat(comparison.current()).isEqualTo(30.0);
 		assertThat(comparison.previous()).isEqualTo(0.0);
 		assertThat(comparison.deltaPercent()).isNull();
+	}
+
+	@Test
+	@DisplayName("직전 기간에 스냅샷이 없으면 부재로 보고 카드에 '직전 없음'으로 표기한다")
+	void previousAbsentRendersNoPreviousLabel() {
+		// 직전 7일 [06-23, 06-29]에 스냅샷이 하나도 없음 → previous는 0으로 채우지만 실측이 아니다.
+		save(AdminMetricKeys.USERS_ACTIVE, TODAY, 30);
+
+		AdminMetricComparison comparison = service.compare(List.of(AdminMetricKeys.USERS_ACTIVE), 7).getFirst();
+
+		assertThat(comparison.previous()).isEqualTo(0.0);
+		assertThat(comparison.previousPresent()).isFalse();
+		assertThat(comparison.deltaPercent()).isNull();
+
+		AnalyticsComparisonCard card = AnalyticsComparisonCard.from(comparison, true);
+		assertThat(card.deltaPercentLabel()).isEqualTo("직전 없음");
+	}
+
+	@Test
+	@DisplayName("직전 기간 실측값이 0이면 부재와 구분해 '기준 0 — 증가율 산정 불가'로 표기한다")
+	void previousMeasuredZeroRendersUndefinedGrowthLabel() {
+		// 직전 7일 [06-23, 06-29]에 실측 0 스냅샷 존재 → 부재가 아니라 실측된 0이다.
+		save(AdminMetricKeys.USERS_ACTIVE, TODAY.minusDays(8), 0);
+		save(AdminMetricKeys.USERS_ACTIVE, TODAY, 30);
+
+		AdminMetricComparison comparison = service.compare(List.of(AdminMetricKeys.USERS_ACTIVE), 7).getFirst();
+
+		assertThat(comparison.current()).isEqualTo(30.0);
+		assertThat(comparison.previous()).isEqualTo(0.0);
+		assertThat(comparison.previousPresent()).isTrue();
+		assertThat(comparison.deltaPercent()).isNull();
+
+		AnalyticsComparisonCard card = AnalyticsComparisonCard.from(comparison, true);
+		assertThat(card.deltaPercentLabel()).isEqualTo("기준 0 — 증가율 산정 불가");
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/admin/metric/application/service/AdminMetricSnapshotServiceTest.java
+++ b/backend/src/test/java/com/easysubway/admin/metric/application/service/AdminMetricSnapshotServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.easysubway.admin.metric.adapter.out.persistence.InMemoryAdminMetricDailyRepository;
+import com.easysubway.admin.metric.application.port.out.AdminMetricDailyRepository;
 import com.easysubway.admin.metric.domain.AdminMetricDaily;
 import com.easysubway.admin.metric.domain.AdminMetricKeys;
 import com.easysubway.quality.application.port.in.DataQualityUseCase;
@@ -28,11 +29,19 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.springframework.transaction.annotation.AnnotationTransactionAttributeSource;
+import org.springframework.transaction.interceptor.TransactionInterceptor;
 
 @DisplayName("일별 지표 스냅샷 집계 서비스")
 class AdminMetricSnapshotServiceTest {
@@ -102,6 +111,139 @@ class AdminMetricSnapshotServiceTest {
 			assertThat(s.success()).isFalse();
 			assertThat(s.message()).contains("집계 실패");
 		});
+	}
+
+	@Test
+	@DisplayName("스냅샷 중간 저장이 실패하면 같은 실행의 앞선 write까지 전부 rollback한다")
+	void partialFailureRollsBackWholeSnapshot() {
+		stubHappyPath();
+		DriverManagerDataSource dataSource = new DriverManagerDataSource(
+			"jdbc:h2:mem:admin-metric-rollback;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+			"sa",
+			""
+		);
+		JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+		jdbcTemplate.execute("DROP TABLE IF EXISTS admin_metric_daily");
+		jdbcTemplate.execute("""
+			CREATE TABLE admin_metric_daily (
+				metric_key VARCHAR(80) NOT NULL,
+				metric_date DATE NOT NULL,
+				metric_value DOUBLE PRECISION NOT NULL,
+				dimensions VARCHAR(2000),
+				PRIMARY KEY (metric_key, metric_date)
+			)
+			""");
+		JdbcTemplateBackedRepository jdbcRepository = new JdbcTemplateBackedRepository(jdbcTemplate);
+		// 6번째 저장에서 실패시켜, 앞서 커밋되지 않은 5건이 rollback되는지 확인한다.
+		FailOnNthSaveRepository failingRepository = new FailOnNthSaveRepository(jdbcRepository, 6);
+		AdminMetricSnapshotService transactionalService = transactionalProxy(
+			new AdminMetricSnapshotService(
+				reportUseCase, qualityUseCase, routeUseCase, feedbackUseCase, pushUseCase, usageUseCase,
+				failingRepository, statusHolder, fixedClock()),
+			dataSource);
+
+		assertThatThrownBy(() -> transactionalService.snapshot(DATE)).isInstanceOf(IllegalStateException.class);
+
+		assertThat(jdbcRepository.findByKeysAndDateRange(AdminMetricKeys.all(), DATE, DATE)).isEmpty();
+		assertThat(statusHolder.isFailing()).isTrue();
+	}
+
+	private static AdminMetricSnapshotService transactionalProxy(
+		AdminMetricSnapshotService target, DriverManagerDataSource dataSource) {
+		TransactionInterceptor interceptor = new TransactionInterceptor(
+			new DataSourceTransactionManager(dataSource), new AnnotationTransactionAttributeSource());
+		ProxyFactory proxyFactory = new ProxyFactory(target);
+		proxyFactory.setProxyTargetClass(true);
+		proxyFactory.addAdvice(interceptor);
+		return (AdminMetricSnapshotService) proxyFactory.getProxy();
+	}
+
+	/** N번째 save에서 실패시켜 트랜잭션 rollback 경계를 검증하는 저장소 데코레이터. 나머지는 위임한다. */
+	private static final class FailOnNthSaveRepository implements AdminMetricDailyRepository {
+
+		private final AdminMetricDailyRepository delegate;
+		private final int failOnCall;
+		private final AtomicInteger saveCalls = new AtomicInteger();
+
+		private FailOnNthSaveRepository(AdminMetricDailyRepository delegate, int failOnCall) {
+			this.delegate = delegate;
+			this.failOnCall = failOnCall;
+		}
+
+		@Override
+		public void save(AdminMetricDaily metric) {
+			if (saveCalls.incrementAndGet() == failOnCall) {
+				throw new IllegalStateException("스냅샷 저장 실패(테스트 주입)");
+			}
+			delegate.save(metric);
+		}
+
+		@Override
+		public Optional<AdminMetricDaily> find(String metricKey, LocalDate metricDate) {
+			return delegate.find(metricKey, metricDate);
+		}
+
+		@Override
+		public List<AdminMetricDaily> findByKeysAndDateRange(
+			Collection<String> metricKeys, LocalDate fromInclusive, LocalDate toInclusive) {
+			return delegate.findByKeysAndDateRange(metricKeys, fromInclusive, toInclusive);
+		}
+	}
+
+	/**
+	 * 공유 dataSource 위에서 동작하는 최소 JDBC 저장소. save는 단순 INSERT라 Spring이 관리하는
+	 * 트랜잭션에 참여하며, 실패 시 rollback 여부를 SELECT로 관찰할 수 있다.
+	 */
+	private static final class JdbcTemplateBackedRepository implements AdminMetricDailyRepository {
+
+		private final JdbcTemplate jdbcTemplate;
+
+		private JdbcTemplateBackedRepository(JdbcTemplate jdbcTemplate) {
+			this.jdbcTemplate = jdbcTemplate;
+		}
+
+		@Override
+		public void save(AdminMetricDaily metric) {
+			jdbcTemplate.update(
+				"INSERT INTO admin_metric_daily (metric_key, metric_date, metric_value, dimensions) "
+					+ "VALUES (?, ?, ?, ?)",
+				metric.metricKey(),
+				metric.metricDate(),
+				metric.value(),
+				metric.dimensions()
+			);
+		}
+
+		@Override
+		public Optional<AdminMetricDaily> find(String metricKey, LocalDate metricDate) {
+			return findByKeysAndDateRange(List.of(metricKey), metricDate, metricDate).stream().findFirst();
+		}
+
+		@Override
+		public List<AdminMetricDaily> findByKeysAndDateRange(
+			Collection<String> metricKeys, LocalDate fromInclusive, LocalDate toInclusive) {
+			if (metricKeys.isEmpty()) {
+				return List.of();
+			}
+			String placeholders = String.join(", ", metricKeys.stream().map(key -> "?").toList());
+			Object[] args = new Object[metricKeys.size() + 2];
+			int index = 0;
+			for (String key : metricKeys) {
+				args[index++] = key;
+			}
+			args[index++] = fromInclusive;
+			args[index] = toInclusive;
+			return jdbcTemplate.query(
+				"SELECT metric_key, metric_date, metric_value, dimensions FROM admin_metric_daily "
+					+ "WHERE metric_key IN (" + placeholders + ") AND metric_date BETWEEN ? AND ?",
+				(rs, rowNum) -> new AdminMetricDaily(
+					rs.getString("metric_key"),
+					rs.getObject("metric_date", LocalDate.class),
+					rs.getDouble("metric_value"),
+					rs.getString("dimensions")),
+				args
+			);
+		}
 	}
 
 	private void stubHappyPath() {


### PR DESCRIPTION
## 관련 이슈

close #2273
Refs #2271

## 작업 배경

- Dashboard 기간 비교(전 기간 대비 증감)가 지표 종류를 구분하지 않고 비율만 평균, 나머지는 전부 기간 합산했다. 그 결과 누계(all-time 누적 총량)·이동 기간(rolling window) 스냅샷이 일별 counter처럼 중복 합산돼 값이 부풀려졌다. 예로 `route.searches`는 매일 누적 총량을 적재하는데 7일 합산은 총량을 7배 가까이 부풀린다.
- snapshot 실행이 트랜잭션으로 묶여 있지 않아, 한 지표 저장이 실패하면 앞서 저장한 지표가 부분 반영된 채로 남았다.
- upsert가 `UPDATE` 후 없으면 `INSERT`하는 2문장이라, 같은 날짜·metric key를 수동 실행과 scheduler가 동시에 쓰면 경합으로 중복 INSERT/PK 충돌이 날 수 있었다.

## 작업 내용

- `AdminMetricKeys`: 지표 종류 `AdminMetricKind`(`GAUGE`/`RATE`/`DAILY_COUNTER`/`ROLLING_WINDOW`)를 명시하고 14개 키를 분류(`kind`). 대시보드 요약 use case가 돌려주는 값의 실제 성격(시점 상태·누계 총량·비율·이동 기간)에 맞췄다. `isRate`/`RATE_METRICS`는 `kind`로 대체.
- `AdminMetricQueryService.compare`: 종류별 집계로 전환. `DAILY_COUNTER`만 기간 합계(결측일 0), `GAUGE`·`RATE`·`ROLLING_WINDOW`는 기간 내 최신 스냅샷끼리 비교(exhaustive switch). `chart`(시계열/스파크라인)·`compare` record 형태·기간 label(days)·공개 단위는 그대로 유지.
- `AdminMetricSnapshotService`: snapshot 실행 전체를 한 트랜잭션으로 묶도록 진입점(`snapshotToday`)과 실제 write 메서드(`snapshot`)에 `@Transactional`을 배치(프록시 자기호출로 트랜잭션이 새지 않게 진입점에도 부착). 한 지표 저장 실패 시 같은 실행의 모든 write가 rollback되고, 상태 홀더 기록은 DB 밖이라 보존된다.
- `JdbcAdminMetricDailyRepository`: 원자적 단일 문장 upsert로 교체. PostgreSQL은 `INSERT ... ON CONFLICT (metric_key, metric_date) DO UPDATE`, H2는 원자 `MERGE ... KEY(...)`로 방언 분기(코드베이스 선례인 `JdbcNotificationPreferenceRepository`의 dialect 감지 패턴 재사용). H2 2.3.232는 `ON CONFLICT` 문법을 파싱하지 못함을 실측해 분기가 필요했다. DB migration은 이 PR에 포함하지 않으며 기존 PK로 충분하다.
- 재현→수정 테스트 추가: 누계(GAUGE)·이동 기간(ROLLING_WINDOW) 중복 합산 재현(최신 스냅샷 비교로 green), 비율 최신 스냅샷 비교, 중간 실패 rollback(Spring 트랜잭션 프록시+H2), 동시 저장 경합 단일 행.

## 검증

- 실행한 명령과 결과:
  - `node tools/ci/api-catalog.mjs validate` → exit 0 (`API catalog valid: 245`)
  - `LC_ALL=C.UTF-8 node --test tools/ci/repository-contract.test.mjs` → exit 0 (tests 218, pass 218, fail 0)
  - `npm test --prefix tools/qa` → exit 0 (tests 8, pass 8, fail 0)
  - `cd backend && ./gradlew test --tests '...AdminMetricSnapshotServiceTest' --tests '...AdminMetricQueryServiceTest' --tests '...JdbcAdminMetricDailyRepositoryTest'` → BUILD SUCCESSFUL (fail 0)
  - 회귀 확인: `--tests 'com.easysubway.admin.metric.*' --tests '...UserActivityAdminPageControllerTest'` → BUILD SUCCESSFUL
  - 재현 순서 실측: 수정 코드에 기존(합산 가정) 테스트를 돌리면 `route.searches` current=175(구 합산 425)·`route.blocked_rate` current=30(구 평균 25)로 fail → 종류별 최신 스냅샷 의미로 테스트 갱신 후 green.

## 검증 증거

고정 seed(`AdminMetricQueryServiceTest`, TODAY=2026-07-06, days=7, InMemory 저장소) 및 H2(MODE=PostgreSQL) 저장소 테스트 기준, Dashboard 공개 label·단위·기간과 repository query 집계 의미 대조. tested SHA `61cc3c14`.

| 지표 키 | 공개 label | 단위 | 종류 | seed 스냅샷 | current | previous | query 의미 일치 |
| --- | --- | --- | --- | --- | --- | --- | --- |
| route.searches | 경로 검색 | 개수 | GAUGE(누계) | 07-02=100,07-05=150,07-06=175 / 06-28=80,06-29=90 | 175 | 90 | 최신 스냅샷 비교(합산 425 아님) |
| users.active | 활성 사용자 | 개수 | ROLLING_WINDOW | 07-04=20,07-06=25 / 06-29=10 | 25 | 10 | 최신 스냅샷 비교(합산 45 아님) |
| route.blocked_rate | 경로 차단률(%) | % | RATE | 07-04=20,07-06=30 / 06-29=10 | 30 | 10 | 최신 스냅샷 비교(합·평균 아님) |
| reports.pending | 확인 대기 제보 | 개수 | GAUGE | 07-06=8 | 8 | 0 | 최신 스냅샷, 빈 기간=0 |
| 기간 label 보존 | days | — | — | days=30 요청 | days=30 | — | 요청 기간 그대로 |

- 항목별 확인 방법·증거·결과:

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 종류별 집계 의미(누계·rolling 중복 합산 제거) | backend | `AdminMetricQueryServiceTest` (H2 불요, InMemory, fixed clock 2026-07-06) | 위 대조표, `./gradlew test` 로그 | green |
| snapshot 중간 실패 rollback | backend | `AdminMetricSnapshotServiceTest.partialFailureRollsBackWholeSnapshot` (Spring 트랜잭션 프록시 + H2 mem MODE=PostgreSQL, 6번째 save 실패 주입) | rollback 후 0행, `isFailing`=true | green |
| 동시 upsert 단일 행 | backend | `JdbcAdminMetricDailyRepositoryTest.concurrentSaveKeepsSingleRow` (H2 mem MODE=PostgreSQL, 8 threads 동일 key·date) | 예외 0건, 조회 1행 | green |
| H2/PostgreSQL upsert 호환 실측 | backend | H2 2.3.232에서 `ON CONFLICT` 문법 오류 확인 → H2 `MERGE KEY`, PostgreSQL `ON CONFLICT` 분기 | 저장소 테스트 3건 green | green |
| Dashboard/분석 화면 소비 계약 무변경 | backend | `AdminAnalyticsMetricController`·`AnalyticsComparisonCard`·`AdminDashboardCardService` 미변경, `compare` record·`chart`·기간 label 유지 | diff 범위(7파일) | 유지 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

backend 런타임 동작(기간 비교 집계·snapshot 트랜잭션·upsert SQL)만 바뀌며, 반영에는 backend 배포가 필요하다. 스키마 변경(DB migration) 없음(기존 PK 사용).

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [ ] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [ ] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 동작 변경(배포 필요), 버전 문자열 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `AdminMetricKeys.kinds()`의 종류 분류 근거 — 대시보드 요약 use case(`summarizeRouteSearches`·`summarizePushNotifications` 등)는 date 필터 없는 all-time `COUNT(*)`라 누계(GAUGE)로 분류했다. 그래서 현재 키 중 `DAILY_COUNTER`는 없고, 종류 계약과 합계 경로는 exhaustive switch로 보존해 두었다(진짜 일별 counter가 생기면 이 종류를 부여).
- `compare`의 `GAUGE`/`RATE`/`ROLLING_WINDOW`는 모두 "기간 내 최신 스냅샷" 한 경로로 처리한다(값을 합치지 않는다는 계약).

## 리스크

- 기간 비교의 current/previous 표시 값 의미가 "기간 합계"에서 "기간 내 최신 스냅샷"으로 바뀐다(누계·비율·이동 기간). 이는 중복 합산 결함을 없애는 의도된 변경이며 공개 단위·기간 label·record 형태·route/CSV export는 그대로다.
- rollback 경계: 단일 revert 가능. 7개 파일 한 커밋(`61cc3c14`)으로, `git revert`로 전량 원복되며 스키마·datapack·계약 JSON을 건드리지 않아 배포만 되돌리면 된다.
- gate/tracker(JSON) 영향 없음, CI workflow·계약 테스트 변경 없음.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
