### PR TITLE
[Backend] #2094 기차검색 공유 cache·quota 기반 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/train/adapter/out/persistence/JdbcTrainSearchCache.java
+++ b/backend/src/main/java/com/easysubway/train/adapter/out/persistence/JdbcTrainSearchCache.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +19,7 @@ public class JdbcTrainSearchCache implements TrainSearchCache {
 
 	private final JdbcTemplate jdbcTemplate;
 
+	@Autowired
 	public JdbcTrainSearchCache(DataSource dataSource) {
 		this(new JdbcTemplate(dataSource));
 	}
@@ -121,11 +123,14 @@ public class JdbcTrainSearchCache implements TrainSearchCache {
 			"""
 				UPDATE train_search_cache
 				SET lease_owner = ?, lease_expires_at = ?
-				WHERE cache_key = ? AND (lease_owner IS NULL OR lease_expires_at <= ?)
+				WHERE cache_key = ?
+					AND (lease_owner IS NULL OR lease_expires_at <= ?)
+					AND (payload_json IS NULL OR expires_at <= ?)
 				""",
 			owner,
 			Timestamp.from(databaseNow.plus(ttl)),
 			key,
+			Timestamp.from(databaseNow),
 			Timestamp.from(databaseNow)
 		) == 1;
 	}
@@ -226,7 +231,13 @@ public class JdbcTrainSearchCache implements TrainSearchCache {
 	public int purgeExpiredBefore(Instant cutoff) {
 		Objects.requireNonNull(cutoff, "cutoff must not be null");
 		return jdbcTemplate.update(
-			"DELETE FROM train_search_cache WHERE expires_at IS NOT NULL AND expires_at < ? AND lease_owner IS NULL",
+			"""
+				DELETE FROM train_search_cache
+				WHERE ((expires_at IS NOT NULL AND expires_at < ?)
+						OR (expires_at IS NULL AND last_access_at < ?))
+					AND (lease_owner IS NULL OR lease_expires_at <= CURRENT_TIMESTAMP)
+				""",
+			Timestamp.from(cutoff),
 			Timestamp.from(cutoff)
 		);
 	}

--- a/backend/src/main/java/com/easysubway/train/adapter/out/persistence/JdbcTrainSearchCache.java
+++ b/backend/src/main/java/com/easysubway/train/adapter/out/persistence/JdbcTrainSearchCache.java
@@ -36,7 +36,7 @@ public class JdbcTrainSearchCache implements TrainSearchCache {
 			"""
 				SELECT catalog_kind, payload_json, payload_sha256, observed_at, expires_at
 				FROM train_catalog_cache
-				WHERE catalog_kind = ? AND expires_at > ?
+				WHERE catalog_kind = ? AND expires_at > CURRENT_TIMESTAMP
 				""",
 			(rs, rowNum) -> new CachedCatalog(
 				rs.getString("catalog_kind"),
@@ -45,8 +45,7 @@ public class JdbcTrainSearchCache implements TrainSearchCache {
 				rs.getTimestamp("observed_at").toInstant(),
 				rs.getTimestamp("expires_at").toInstant()
 			),
-			kind,
-			Timestamp.from(now)
+			kind
 		).stream().findFirst();
 	}
 
@@ -80,7 +79,7 @@ public class JdbcTrainSearchCache implements TrainSearchCache {
 			"""
 				SELECT cache_key, normalized_query_json, payload_json, payload_sha256, observed_at, expires_at
 				FROM train_search_cache
-				WHERE cache_key = ? AND payload_json IS NOT NULL AND expires_at > ?
+				WHERE cache_key = ? AND payload_json IS NOT NULL AND expires_at > CURRENT_TIMESTAMP
 				""",
 			(rs, rowNum) -> new CachedLeg(
 				rs.getString("cache_key"),
@@ -90,12 +89,8 @@ public class JdbcTrainSearchCache implements TrainSearchCache {
 				rs.getTimestamp("observed_at").toInstant(),
 				rs.getTimestamp("expires_at").toInstant()
 			),
-			key,
-			Timestamp.from(now)
+			key
 		);
-		if (!rows.isEmpty()) {
-			jdbcTemplate.update("UPDATE train_search_cache SET last_access_at = CURRENT_TIMESTAMP WHERE cache_key = ?", key);
-		}
 		return rows.stream().findFirst();
 	}
 
@@ -152,6 +147,9 @@ public class JdbcTrainSearchCache implements TrainSearchCache {
 	@Transactional(timeout = 2)
 	public boolean storeLegAndRelease(String key, String owner, CachedLeg leg) {
 		Objects.requireNonNull(leg, "leg must not be null");
+		if (!Objects.equals(key, leg.key())) {
+			throw new IllegalArgumentException("leg key must match lease key");
+		}
 		return jdbcTemplate.update(
 			"""
 				UPDATE train_search_cache

--- a/backend/src/main/java/com/easysubway/train/adapter/out/persistence/JdbcTrainSearchCache.java
+++ b/backend/src/main/java/com/easysubway/train/adapter/out/persistence/JdbcTrainSearchCache.java
@@ -1,0 +1,241 @@
+package com.easysubway.train.adapter.out.persistence;
+
+import com.easysubway.train.application.TrainSearchCache;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+public class JdbcTrainSearchCache implements TrainSearchCache {
+
+	private final JdbcTemplate jdbcTemplate;
+
+	public JdbcTrainSearchCache(DataSource dataSource) {
+		this(new JdbcTemplate(dataSource));
+	}
+
+	JdbcTrainSearchCache(JdbcTemplate jdbcTemplate) {
+		this.jdbcTemplate = jdbcTemplate;
+	}
+
+	@Override
+	public Optional<CachedCatalog> freshCatalog(String kind, Instant now) {
+		Objects.requireNonNull(kind, "kind must not be null");
+		Objects.requireNonNull(now, "now must not be null");
+		return jdbcTemplate.query(
+			"""
+				SELECT catalog_kind, payload_json, payload_sha256, observed_at, expires_at
+				FROM train_catalog_cache
+				WHERE catalog_kind = ? AND expires_at > ?
+				""",
+			(rs, rowNum) -> new CachedCatalog(
+				rs.getString("catalog_kind"),
+				rs.getString("payload_json"),
+				rs.getString("payload_sha256"),
+				rs.getTimestamp("observed_at").toInstant(),
+				rs.getTimestamp("expires_at").toInstant()
+			),
+			kind,
+			Timestamp.from(now)
+		).stream().findFirst();
+	}
+
+	@Override
+	@Transactional(timeout = 2)
+	public void replaceCatalog(List<CachedCatalog> catalogs) {
+		Objects.requireNonNull(catalogs, "catalogs must not be null");
+		jdbcTemplate.update("DELETE FROM train_catalog_cache");
+		for (CachedCatalog catalog : catalogs) {
+			jdbcTemplate.update(
+				"""
+					INSERT INTO train_catalog_cache
+					(catalog_kind, payload_json, payload_sha256, observed_at, expires_at)
+					VALUES (?, ?, ?, ?, ?)
+					""",
+				catalog.kind(),
+				catalog.payloadJson(),
+				catalog.payloadSha256(),
+				Timestamp.from(catalog.observedAt()),
+				Timestamp.from(catalog.expiresAt())
+			);
+		}
+	}
+
+	@Override
+	@Transactional(timeout = 2)
+	public Optional<CachedLeg> freshLeg(String key, Instant now) {
+		Objects.requireNonNull(key, "key must not be null");
+		Objects.requireNonNull(now, "now must not be null");
+		List<CachedLeg> rows = jdbcTemplate.query(
+			"""
+				SELECT cache_key, normalized_query_json, payload_json, payload_sha256, observed_at, expires_at
+				FROM train_search_cache
+				WHERE cache_key = ? AND payload_json IS NOT NULL AND expires_at > ?
+				""",
+			(rs, rowNum) -> new CachedLeg(
+				rs.getString("cache_key"),
+				rs.getString("normalized_query_json"),
+				rs.getString("payload_json"),
+				rs.getString("payload_sha256"),
+				rs.getTimestamp("observed_at").toInstant(),
+				rs.getTimestamp("expires_at").toInstant()
+			),
+			key,
+			Timestamp.from(now)
+		);
+		if (!rows.isEmpty()) {
+			jdbcTemplate.update("UPDATE train_search_cache SET last_access_at = CURRENT_TIMESTAMP WHERE cache_key = ?", key);
+		}
+		return rows.stream().findFirst();
+	}
+
+	@Override
+	@Transactional(timeout = 2)
+	public boolean tryAcquireLease(String key, String owner, Instant now, Duration ttl) {
+		Objects.requireNonNull(key, "key must not be null");
+		Objects.requireNonNull(owner, "owner must not be null");
+		Objects.requireNonNull(now, "now must not be null");
+		Objects.requireNonNull(ttl, "ttl must not be null");
+		if (ttl.isZero() || ttl.isNegative()) {
+			throw new IllegalArgumentException("ttl must be positive");
+		}
+		Instant databaseNow = databaseNow();
+		jdbcTemplate.update(
+			"""
+				INSERT INTO train_search_cache (cache_key, last_access_at)
+				VALUES (?, ?)
+				ON CONFLICT DO NOTHING
+				""",
+			key,
+			Timestamp.from(databaseNow)
+		);
+		return jdbcTemplate.update(
+			"""
+				UPDATE train_search_cache
+				SET lease_owner = ?, lease_expires_at = ?
+				WHERE cache_key = ? AND (lease_owner IS NULL OR lease_expires_at <= ?)
+				""",
+			owner,
+			Timestamp.from(databaseNow.plus(ttl)),
+			key,
+			Timestamp.from(databaseNow)
+		) == 1;
+	}
+
+	@Override
+	@Transactional(timeout = 2)
+	public void releaseLease(String key, String owner) {
+		jdbcTemplate.update(
+			"""
+				UPDATE train_search_cache SET lease_owner = NULL, lease_expires_at = NULL
+				WHERE cache_key = ? AND lease_owner = ?
+				""",
+			key,
+			owner
+		);
+	}
+
+	@Override
+	@Transactional(timeout = 2)
+	public boolean storeLegAndRelease(String key, String owner, CachedLeg leg) {
+		Objects.requireNonNull(leg, "leg must not be null");
+		return jdbcTemplate.update(
+			"""
+				UPDATE train_search_cache
+				SET normalized_query_json = ?, payload_json = ?, payload_sha256 = ?, observed_at = ?, expires_at = ?,
+					last_access_at = CURRENT_TIMESTAMP, lease_owner = NULL, lease_expires_at = NULL
+				WHERE cache_key = ? AND lease_owner = ?
+				""",
+			leg.normalizedQueryJson(),
+			leg.payloadJson(),
+			leg.payloadSha256(),
+			Timestamp.from(leg.observedAt()),
+			Timestamp.from(leg.expiresAt()),
+			key,
+			owner
+		) == 1;
+	}
+
+	@Override
+	@Transactional(timeout = 2)
+	public boolean tryAcquireProviderCall(String providerId, ZoneId providerZone, int minuteLimit, int dayLimit) {
+		Objects.requireNonNull(providerId, "providerId must not be null");
+		Objects.requireNonNull(providerZone, "providerZone must not be null");
+		if (minuteLimit <= 0 || dayLimit <= 0) {
+			throw new IllegalArgumentException("quota limits must be positive");
+		}
+		Instant databaseNow = databaseNow();
+		long minuteWindow = databaseNow.getEpochSecond() / 60;
+		long dayWindow = databaseNow.atZone(providerZone).toLocalDate().toEpochDay();
+		jdbcTemplate.update(
+			"""
+				INSERT INTO train_provider_call_quota_state
+				(provider_id, minute_window, minute_calls, day_window, daily_calls, updated_at)
+				VALUES (?, ?, 0, ?, 0, ?)
+				ON CONFLICT DO NOTHING
+				""",
+			providerId,
+			minuteWindow,
+			dayWindow,
+			Timestamp.from(databaseNow)
+		);
+		QuotaState state = jdbcTemplate.queryForObject(
+			"""
+				SELECT minute_window, minute_calls, day_window, daily_calls
+				FROM train_provider_call_quota_state WHERE provider_id = ? FOR UPDATE
+				""",
+			(rs, rowNum) -> new QuotaState(
+				rs.getLong("minute_window"),
+				rs.getInt("minute_calls"),
+				rs.getLong("day_window"),
+				rs.getInt("daily_calls")
+			),
+			providerId
+		);
+		int minuteCalls = state.minuteWindow() == minuteWindow ? state.minuteCalls() : 0;
+		int dailyCalls = state.dayWindow() == dayWindow ? state.dailyCalls() : 0;
+		if (minuteCalls >= minuteLimit || dailyCalls >= dayLimit) {
+			return false;
+		}
+		jdbcTemplate.update(
+			"""
+				UPDATE train_provider_call_quota_state
+				SET minute_window = ?, minute_calls = ?, day_window = ?, daily_calls = ?, updated_at = ?
+				WHERE provider_id = ?
+				""",
+			minuteWindow,
+			minuteCalls + 1,
+			dayWindow,
+			dailyCalls + 1,
+			Timestamp.from(databaseNow),
+			providerId
+		);
+		return true;
+	}
+
+	@Override
+	@Transactional(timeout = 2)
+	public int purgeExpiredBefore(Instant cutoff) {
+		Objects.requireNonNull(cutoff, "cutoff must not be null");
+		return jdbcTemplate.update(
+			"DELETE FROM train_search_cache WHERE expires_at IS NOT NULL AND expires_at < ? AND lease_owner IS NULL",
+			Timestamp.from(cutoff)
+		);
+	}
+
+	private Instant databaseNow() {
+		return Objects.requireNonNull(
+			jdbcTemplate.queryForObject("SELECT CURRENT_TIMESTAMP", Timestamp.class)
+		).toInstant();
+	}
+
+	private record QuotaState(long minuteWindow, int minuteCalls, long dayWindow, int dailyCalls) {}
+}

--- a/backend/src/main/java/com/easysubway/train/application/TrainSearchCache.java
+++ b/backend/src/main/java/com/easysubway/train/application/TrainSearchCache.java
@@ -1,0 +1,43 @@
+package com.easysubway.train.application;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+
+public interface TrainSearchCache {
+
+	Optional<CachedCatalog> freshCatalog(String kind, Instant now);
+
+	void replaceCatalog(List<CachedCatalog> catalogs);
+
+	Optional<CachedLeg> freshLeg(String key, Instant now);
+
+	boolean tryAcquireLease(String key, String owner, Instant now, Duration ttl);
+
+	void releaseLease(String key, String owner);
+
+	boolean storeLegAndRelease(String key, String owner, CachedLeg leg);
+
+	boolean tryAcquireProviderCall(String providerId, ZoneId providerZone, int minuteLimit, int dayLimit);
+
+	int purgeExpiredBefore(Instant cutoff);
+
+	record CachedCatalog(
+		String kind,
+		String payloadJson,
+		String payloadSha256,
+		Instant observedAt,
+		Instant expiresAt
+	) {}
+
+	record CachedLeg(
+		String key,
+		String normalizedQueryJson,
+		String payloadJson,
+		String payloadSha256,
+		Instant observedAt,
+		Instant expiresAt
+	) {}
+}

--- a/backend/src/main/resources/db/migration/h2/V64__train_search_cache.sql
+++ b/backend/src/main/resources/db/migration/h2/V64__train_search_cache.sql
@@ -1,0 +1,46 @@
+CREATE TABLE train_catalog_cache (
+    catalog_kind VARCHAR(32) PRIMARY KEY,
+    payload_json CLOB NOT NULL,
+    payload_sha256 CHAR(64) NOT NULL,
+    observed_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    CONSTRAINT chk_train_catalog_cache_hash CHECK (CHAR_LENGTH(payload_sha256) = 64),
+    CONSTRAINT chk_train_catalog_cache_expiry CHECK (expires_at > observed_at)
+);
+
+CREATE TABLE train_search_cache (
+    cache_key VARCHAR(200) PRIMARY KEY,
+    normalized_query_json CLOB,
+    payload_json CLOB,
+    payload_sha256 CHAR(64),
+    observed_at TIMESTAMP WITH TIME ZONE,
+    expires_at TIMESTAMP WITH TIME ZONE,
+    last_access_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    lease_owner VARCHAR(100),
+    lease_expires_at TIMESTAMP WITH TIME ZONE,
+    CONSTRAINT chk_train_search_cache_payload CHECK (
+        (normalized_query_json IS NULL AND payload_json IS NULL AND payload_sha256 IS NULL
+            AND observed_at IS NULL AND expires_at IS NULL)
+        OR
+        (normalized_query_json IS NOT NULL AND payload_json IS NOT NULL AND payload_sha256 IS NOT NULL
+            AND observed_at IS NOT NULL AND expires_at IS NOT NULL
+            AND CHAR_LENGTH(payload_sha256) = 64 AND expires_at > observed_at)
+    ),
+    CONSTRAINT chk_train_search_cache_lease CHECK (
+        (lease_owner IS NULL AND lease_expires_at IS NULL)
+        OR (lease_owner IS NOT NULL AND lease_expires_at IS NOT NULL)
+    )
+);
+
+CREATE INDEX idx_train_search_cache_expiry ON train_search_cache (expires_at);
+CREATE INDEX idx_train_search_cache_last_access ON train_search_cache (last_access_at);
+
+CREATE TABLE train_provider_call_quota_state (
+    provider_id VARCHAR(100) PRIMARY KEY,
+    minute_window BIGINT NOT NULL,
+    minute_calls INTEGER NOT NULL,
+    day_window BIGINT NOT NULL,
+    daily_calls INTEGER NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT chk_train_provider_call_quota_counts CHECK (minute_calls >= 0 AND daily_calls >= 0)
+);

--- a/backend/src/main/resources/db/migration/postgresql/V65__train_search_cache.sql
+++ b/backend/src/main/resources/db/migration/postgresql/V65__train_search_cache.sql
@@ -1,0 +1,46 @@
+CREATE TABLE train_catalog_cache (
+    catalog_kind VARCHAR(32) PRIMARY KEY,
+    payload_json TEXT NOT NULL,
+    payload_sha256 CHAR(64) NOT NULL,
+    observed_at TIMESTAMPTZ NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    CONSTRAINT chk_train_catalog_cache_hash CHECK (CHAR_LENGTH(payload_sha256) = 64),
+    CONSTRAINT chk_train_catalog_cache_expiry CHECK (expires_at > observed_at)
+);
+
+CREATE TABLE train_search_cache (
+    cache_key VARCHAR(200) PRIMARY KEY,
+    normalized_query_json TEXT,
+    payload_json TEXT,
+    payload_sha256 CHAR(64),
+    observed_at TIMESTAMPTZ,
+    expires_at TIMESTAMPTZ,
+    last_access_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    lease_owner VARCHAR(100),
+    lease_expires_at TIMESTAMPTZ,
+    CONSTRAINT chk_train_search_cache_payload CHECK (
+        (normalized_query_json IS NULL AND payload_json IS NULL AND payload_sha256 IS NULL
+            AND observed_at IS NULL AND expires_at IS NULL)
+        OR
+        (normalized_query_json IS NOT NULL AND payload_json IS NOT NULL AND payload_sha256 IS NOT NULL
+            AND observed_at IS NOT NULL AND expires_at IS NOT NULL
+            AND CHAR_LENGTH(payload_sha256) = 64 AND expires_at > observed_at)
+    ),
+    CONSTRAINT chk_train_search_cache_lease CHECK (
+        (lease_owner IS NULL AND lease_expires_at IS NULL)
+        OR (lease_owner IS NOT NULL AND lease_expires_at IS NOT NULL)
+    )
+);
+
+CREATE INDEX idx_train_search_cache_expiry ON train_search_cache (expires_at);
+CREATE INDEX idx_train_search_cache_last_access ON train_search_cache (last_access_at);
+
+CREATE TABLE train_provider_call_quota_state (
+    provider_id VARCHAR(100) PRIMARY KEY,
+    minute_window BIGINT NOT NULL,
+    minute_calls INTEGER NOT NULL,
+    day_window BIGINT NOT NULL,
+    daily_calls INTEGER NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT chk_train_provider_call_quota_counts CHECK (minute_calls >= 0 AND daily_calls >= 0)
+);

--- a/backend/src/test/java/com/easysubway/common/persistence/DatabaseMigrationContainerTest.java
+++ b/backend/src/test/java/com/easysubway/common/persistence/DatabaseMigrationContainerTest.java
@@ -83,9 +83,12 @@ class DatabaseMigrationContainerTest {
 				"transit_master_override_audits",
 				"timetable_snapshot_lock",
 				"timetable_snapshot_history",
-				"timetable_snapshot_active"
+				"timetable_snapshot_active",
+				"train_catalog_cache",
+				"train_search_cache",
+				"train_provider_call_quota_state"
 			);
-		assertThat(successfulMigrationVersions(jdbcTemplate)).contains("1", "14", "16", "17", "18", "19", "20", "21", "22", "23", "25", "26", "48", "51", "52", "53", "54", "55", "56", "57", "59", "60", "61");
+		assertThat(successfulMigrationVersions(jdbcTemplate)).contains("1", "14", "16", "17", "18", "19", "20", "21", "22", "23", "25", "26", "48", "51", "52", "53", "54", "55", "56", "57", "59", "60", "61", "65");
 		assertThat(jdbcTemplate.queryForObject("""
 			SELECT COUNT(*)
 			FROM pg_index i
@@ -154,7 +157,12 @@ class DatabaseMigrationContainerTest {
 				"chk_datapack_release_channel_events_operation",
 				"chk_timetable_snapshot_lock_singleton",
 				"chk_timetable_snapshot_counts",
-				"chk_timetable_snapshot_active_singleton"
+				"chk_timetable_snapshot_active_singleton",
+				"chk_train_catalog_cache_hash",
+				"chk_train_catalog_cache_expiry",
+				"chk_train_search_cache_payload",
+				"chk_train_search_cache_lease",
+				"chk_train_provider_call_quota_counts"
 			);
 		assertNormalizationRunGuards(jdbcTemplate);
 		assertSnapshotSourceForeignKeysRejectMismatch(jdbcTemplate);

--- a/backend/src/test/java/com/easysubway/common/persistence/DatabaseMigrationContainerTest.java
+++ b/backend/src/test/java/com/easysubway/common/persistence/DatabaseMigrationContainerTest.java
@@ -10,23 +10,31 @@ import com.easysubway.datapack.domain.DatapackReleaseDelivery;
 import com.easysubway.route.adapter.out.persistence.JdbcRouteV2AccessStore;
 import com.easysubway.route.application.port.out.RouteV2AccessStore.RouteV2Session;
 import com.easysubway.route.application.port.out.RouteV2AccessStore.SessionStatus;
+import com.easysubway.train.adapter.out.persistence.JdbcTrainSearchCache;
+import com.easysubway.train.application.TrainSearchCache.CachedLeg;
 import com.zaxxer.hikari.HikariDataSource;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.time.Duration;
+import java.time.ZoneId;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.MigrationVersion;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataAccessException;
+import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.transaction.annotation.AnnotationTransactionAttributeSource;
+import org.springframework.transaction.interceptor.TransactionInterceptor;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -205,6 +213,87 @@ class DatabaseMigrationContainerTest {
 				assertThat(jdbcTemplate.queryForObject(
 					"SELECT COUNT(*) FROM datapack_release_deliveries", Integer.class)).isEqualTo(1);
 			});
+		}
+	}
+
+	@Test
+	@DisplayName("PostgreSQL 기차검색 cache는 lease 경쟁과 KST quota window를 원자적으로 조정한다")
+	void postgresqlTrainSearchCacheCoordinatesLeaseAndQuota() throws Exception {
+		String schema = "train_search_cache_" + System.nanoTime();
+		var migrationDataSource = new DriverManagerDataSource(
+			POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword());
+		migrate(migrationDataSource, "classpath:db/migration/postgresql", schema);
+		try (var dataSource = new HikariDataSource()) {
+			dataSource.setJdbcUrl(POSTGRES.getJdbcUrl());
+			dataSource.setUsername(POSTGRES.getUsername());
+			dataSource.setPassword(POSTGRES.getPassword());
+			dataSource.setSchema(schema);
+			var target = new JdbcTrainSearchCache(dataSource);
+			var factory = new ProxyFactory(target);
+			factory.setProxyTargetClass(true);
+			factory.addAdvice(new TransactionInterceptor(
+				new DataSourceTransactionManager(dataSource),
+				new AnnotationTransactionAttributeSource()
+			));
+			var repository = (JdbcTrainSearchCache) factory.getProxy();
+			var jdbcTemplate = new JdbcTemplate(dataSource);
+
+			int callers = 8;
+			var ready = new CountDownLatch(callers);
+			var start = new CountDownLatch(1);
+			var acquired = new AtomicInteger();
+			var failed = new AtomicInteger();
+			var executor = Executors.newFixedThreadPool(callers);
+			try {
+				for (int index = 0; index < callers; index++) {
+					String owner = "owner-" + index;
+					executor.submit(() -> {
+						ready.countDown();
+						start.await();
+						try {
+							if (repository.tryAcquireLease("shared", owner, Instant.EPOCH, Duration.ofSeconds(15))) {
+								acquired.incrementAndGet();
+							}
+						} catch (RuntimeException exception) {
+							failed.incrementAndGet();
+						}
+						return null;
+					});
+				}
+				assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+				start.countDown();
+				executor.shutdown();
+				assertThat(executor.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
+				assertThat(failed).hasValue(0);
+				assertThat(acquired).hasValue(1);
+			} finally {
+				executor.shutdownNow();
+			}
+
+			ZoneId korea = ZoneId.of("Asia/Seoul");
+			assertThat(repository.tryAcquireProviderCall("tago-train", korea, 1, 1)).isTrue();
+			assertThat(repository.tryAcquireProviderCall("tago-train", korea, 1, 1)).isFalse();
+			jdbcTemplate.update("""
+				UPDATE train_provider_call_quota_state
+				SET minute_window = minute_window - 1, minute_calls = 99,
+					day_window = day_window - 1, daily_calls = 99
+				WHERE provider_id = 'tago-train'
+				""");
+			assertThat(repository.tryAcquireProviderCall("tago-train", korea, 1, 1)).isTrue();
+			assertThat(jdbcTemplate.queryForMap("""
+				SELECT minute_calls, daily_calls FROM train_provider_call_quota_state
+				WHERE provider_id = 'tago-train'
+				"""))
+				.containsEntry("minute_calls", 1)
+				.containsEntry("daily_calls", 1);
+
+			Instant observedAt = Instant.parse("2026-07-19T00:00:00Z");
+			var leg = new CachedLeg(
+				"owned", "{}", "[]", "a".repeat(64), observedAt, observedAt.plusSeconds(300));
+			assertThat(repository.tryAcquireLease("owned", "owner-a", observedAt, Duration.ofSeconds(15))).isTrue();
+			assertThat(repository.storeLegAndRelease("owned", "owner-b", leg)).isFalse();
+			assertThat(repository.storeLegAndRelease("owned", "owner-a", leg)).isTrue();
+			assertThat(repository.freshLeg("owned", observedAt.plusSeconds(1))).contains(leg);
 		}
 	}
 

--- a/backend/src/test/java/com/easysubway/common/persistence/DatabaseMigrationContainerTest.java
+++ b/backend/src/test/java/com/easysubway/common/persistence/DatabaseMigrationContainerTest.java
@@ -294,6 +294,7 @@ class DatabaseMigrationContainerTest {
 			assertThat(repository.storeLegAndRelease("owned", "owner-b", leg)).isFalse();
 			assertThat(repository.storeLegAndRelease("owned", "owner-a", leg)).isTrue();
 			assertThat(repository.freshLeg("owned", observedAt.plusSeconds(1))).contains(leg);
+			assertThat(repository.tryAcquireLease("owned", "owner-c", observedAt, Duration.ofSeconds(15))).isFalse();
 		}
 	}
 

--- a/backend/src/test/java/com/easysubway/train/adapter/out/persistence/JdbcTrainSearchCacheTest.java
+++ b/backend/src/test/java/com/easysubway/train/adapter/out/persistence/JdbcTrainSearchCacheTest.java
@@ -74,6 +74,16 @@ class JdbcTrainSearchCacheTest {
 	}
 
 	@Test
+	void doesNotAcquireLeaseAfterAnotherNodeStoredFreshPayload() {
+		Instant databaseNow = jdbcTemplate.queryForObject("SELECT CURRENT_TIMESTAMP", java.sql.Timestamp.class).toInstant();
+		var fresh = leg("filled", databaseNow.minusSeconds(1), databaseNow.plus(Duration.ofHours(1)));
+		assertThat(repository.tryAcquireLease("filled", "owner-a", databaseNow, Duration.ofSeconds(15))).isTrue();
+		assertThat(repository.storeLegAndRelease("filled", "owner-a", fresh)).isTrue();
+
+		assertThat(repository.tryAcquireLease("filled", "owner-b", databaseNow, Duration.ofSeconds(15))).isFalse();
+	}
+
+	@Test
 	void concurrentLeaseAttemptsHaveExactlyOneOwner() throws InterruptedException {
 		int callers = 8;
 		var ready = new CountDownLatch(callers);
@@ -131,6 +141,27 @@ class JdbcTrainSearchCacheTest {
 		assertThat(repository.purgeExpiredBefore(observedAt.plusSeconds(61))).isEqualTo(1);
 		assertThat(jdbcTemplate.queryForObject("SELECT COUNT(*) FROM train_search_cache", Integer.class))
 			.isEqualTo(1);
+	}
+
+	@Test
+	void purgeRemovesOldFailedAndOrphanPlaceholdersButKeepsActiveLease() {
+		Instant databaseNow = jdbcTemplate.queryForObject("SELECT CURRENT_TIMESTAMP", java.sql.Timestamp.class).toInstant();
+		Instant old = databaseNow.minus(Duration.ofHours(3));
+		Instant cutoff = databaseNow.minus(Duration.ofHours(2));
+
+		assertThat(repository.tryAcquireLease("failed", "owner", databaseNow, Duration.ofMinutes(1))).isTrue();
+		repository.releaseLease("failed", "owner");
+		assertThat(repository.tryAcquireLease("orphan", "owner", databaseNow, Duration.ofMinutes(1))).isTrue();
+		assertThat(repository.tryAcquireLease("active", "owner", databaseNow, Duration.ofHours(1))).isTrue();
+		jdbcTemplate.update("UPDATE train_search_cache SET last_access_at = ?", java.sql.Timestamp.from(old));
+		jdbcTemplate.update(
+			"UPDATE train_search_cache SET lease_expires_at = ? WHERE cache_key = 'orphan'",
+			java.sql.Timestamp.from(databaseNow.minusSeconds(1))
+		);
+
+		assertThat(repository.purgeExpiredBefore(cutoff)).isEqualTo(2);
+		assertThat(jdbcTemplate.queryForList("SELECT cache_key FROM train_search_cache", String.class))
+			.containsExactly("active");
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/train/adapter/out/persistence/JdbcTrainSearchCacheTest.java
+++ b/backend/src/test/java/com/easysubway/train/adapter/out/persistence/JdbcTrainSearchCacheTest.java
@@ -1,0 +1,163 @@
+package com.easysubway.train.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.easysubway.train.application.TrainSearchCache.CachedCatalog;
+import com.easysubway.train.application.TrainSearchCache.CachedLeg;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.annotation.AnnotationTransactionAttributeSource;
+import org.springframework.transaction.interceptor.TransactionInterceptor;
+
+class JdbcTrainSearchCacheTest {
+
+	private JdbcTrainSearchCache repository;
+	private JdbcTemplate jdbcTemplate;
+	private DriverManagerDataSource dataSource;
+
+	@BeforeEach
+	void setUp() {
+		dataSource = new DriverManagerDataSource(
+			"jdbc:h2:mem:train-search-cache-" + UUID.randomUUID()
+				+ ";MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+			"sa",
+			""
+		);
+		Flyway.configure()
+			.dataSource(dataSource)
+			.locations("classpath:db/migration/h2")
+			.load()
+			.migrate();
+		jdbcTemplate = new JdbcTemplate(dataSource);
+		repository = proxiedRepository();
+	}
+
+	@Test
+	void replacesCatalogAtomicallyAndReadsOnlyFreshRows() {
+		Instant observedAt = Instant.parse("2026-07-19T00:00:00Z");
+		Instant expiresAt = observedAt.plus(Duration.ofHours(24));
+		var stations = new CachedCatalog("stations", "[{\"id\":\"NAT010000\"}]", hash('a'), observedAt, expiresAt);
+		var trainTypes = new CachedCatalog("train-types", "[{\"code\":\"KTX\"}]", hash('b'), observedAt, expiresAt);
+
+		repository.replaceCatalog(List.of(stations, trainTypes));
+
+		assertThat(repository.freshCatalog("stations", observedAt.plusSeconds(1))).contains(stations);
+		assertThat(repository.freshCatalog("stations", expiresAt)).isEmpty();
+		assertThat(jdbcTemplate.queryForObject("SELECT COUNT(*) FROM train_catalog_cache", Integer.class))
+			.isEqualTo(2);
+	}
+
+	@Test
+	void leaseHasSingleOwnerAndOnlyOwnerCanRelease() {
+		Instant now = Instant.parse("2026-07-19T00:00:00Z");
+		assertThat(repository.tryAcquireLease("key", "owner-a", now, Duration.ofSeconds(15))).isTrue();
+		assertThat(repository.tryAcquireLease("key", "owner-b", now, Duration.ofSeconds(15))).isFalse();
+
+		repository.releaseLease("key", "owner-b");
+		assertThat(repository.tryAcquireLease("key", "owner-b", now, Duration.ofSeconds(15))).isFalse();
+		repository.releaseLease("key", "owner-a");
+		assertThat(repository.tryAcquireLease("key", "owner-b", now, Duration.ofSeconds(15))).isTrue();
+	}
+
+	@Test
+	void concurrentLeaseAttemptsHaveExactlyOneOwner() throws InterruptedException {
+		int callers = 8;
+		var ready = new CountDownLatch(callers);
+		var start = new CountDownLatch(1);
+		var acquired = new AtomicInteger();
+		var failed = new AtomicInteger();
+		var completed = new AtomicInteger();
+		var executor = Executors.newFixedThreadPool(callers);
+		try {
+			for (int index = 0; index < callers; index++) {
+				String owner = "owner-" + index;
+				executor.submit(() -> {
+					ready.countDown();
+					start.await();
+					try {
+						if (repository.tryAcquireLease(
+							"shared-key",
+							owner,
+							Instant.parse("2026-07-19T00:00:00Z"),
+							Duration.ofSeconds(15)
+						)) {
+							acquired.incrementAndGet();
+						}
+					} catch (RuntimeException exception) {
+						failed.incrementAndGet();
+					}
+					completed.incrementAndGet();
+					return null;
+				});
+			}
+			assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+			start.countDown();
+			executor.shutdown();
+			assertThat(executor.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
+			assertThat(completed).hasValue(callers);
+			assertThat(failed).hasValue(0);
+			assertThat(acquired).hasValue(1);
+		} finally {
+			executor.shutdownNow();
+		}
+	}
+
+	@Test
+	void ownerStoresFreshLegAndPurgeRemovesOnlyOldExpiredRows() {
+		Instant observedAt = Instant.parse("2026-07-19T00:00:00Z");
+		var expired = leg("expired", observedAt, observedAt.plusSeconds(60));
+		var fresh = leg("fresh", observedAt, observedAt.plus(Duration.ofHours(6)));
+		assertThat(repository.tryAcquireLease("expired", "owner", observedAt, Duration.ofSeconds(15))).isTrue();
+		assertThat(repository.storeLegAndRelease("expired", "owner", expired)).isTrue();
+		assertThat(repository.tryAcquireLease("fresh", "owner", observedAt, Duration.ofSeconds(15))).isTrue();
+		assertThat(repository.storeLegAndRelease("fresh", "owner", fresh)).isTrue();
+
+		assertThat(repository.freshLeg("expired", observedAt.plusSeconds(60))).isEmpty();
+		assertThat(repository.freshLeg("fresh", observedAt.plusSeconds(60))).contains(fresh);
+		assertThat(repository.purgeExpiredBefore(observedAt.plusSeconds(61))).isEqualTo(1);
+		assertThat(jdbcTemplate.queryForObject("SELECT COUNT(*) FROM train_search_cache", Integer.class))
+			.isEqualTo(1);
+	}
+
+	@Test
+	void enforcesSharedMinuteAndDayQuotaPerProvider() {
+		ZoneId providerZone = ZoneId.of("Asia/Seoul");
+		assertThat(repository.tryAcquireProviderCall("tago-train", providerZone, 2, 2)).isTrue();
+		assertThat(repository.tryAcquireProviderCall("tago-train", providerZone, 2, 2)).isTrue();
+		assertThat(repository.tryAcquireProviderCall("tago-train", providerZone, 2, 2)).isFalse();
+		assertThat(repository.tryAcquireProviderCall("other", providerZone, 1, 1)).isTrue();
+	}
+
+	private CachedLeg leg(String key, Instant observedAt, Instant expiresAt) {
+		return new CachedLeg(key, "{\"key\":\"" + key + "\"}", "{\"outbound\":[]}", hash('c'), observedAt, expiresAt);
+	}
+
+	private String hash(char value) {
+		return String.valueOf(value).repeat(64);
+	}
+
+	private JdbcTrainSearchCache proxiedRepository() {
+		var target = new JdbcTrainSearchCache(jdbcTemplate);
+		var proxyFactory = new ProxyFactory(target);
+		proxyFactory.setProxyTargetClass(true);
+		proxyFactory.addAdvice(new TransactionInterceptor(
+			new DataSourceTransactionManager(dataSource),
+			new AnnotationTransactionAttributeSource()
+		));
+		return (JdbcTrainSearchCache) proxyFactory.getProxy();
+	}
+}

--- a/backend/src/test/java/com/easysubway/train/adapter/out/persistence/JdbcTrainSearchCacheTest.java
+++ b/backend/src/test/java/com/easysubway/train/adapter/out/persistence/JdbcTrainSearchCacheTest.java
@@ -1,6 +1,7 @@
 package com.easysubway.train.adapter.out.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.easysubway.train.application.TrainSearchCache.CachedCatalog;
 import com.easysubway.train.application.TrainSearchCache.CachedLeg;
@@ -47,16 +48,22 @@ class JdbcTrainSearchCacheTest {
 	}
 
 	@Test
-	void replacesCatalogAtomicallyAndReadsOnlyFreshRows() {
-		Instant observedAt = Instant.parse("2026-07-19T00:00:00Z");
-		Instant expiresAt = observedAt.plus(Duration.ofHours(24));
+	void replacesCatalogAtomicallyAndUsesDatabaseTimeForFreshness() {
+		Instant databaseNow = databaseNow();
+		Instant observedAt = databaseNow.minus(Duration.ofHours(2));
+		Instant expiresAt = databaseNow.plus(Duration.ofHours(1));
 		var stations = new CachedCatalog("stations", "[{\"id\":\"NAT010000\"}]", hash('a'), observedAt, expiresAt);
 		var trainTypes = new CachedCatalog("train-types", "[{\"code\":\"KTX\"}]", hash('b'), observedAt, expiresAt);
 
 		repository.replaceCatalog(List.of(stations, trainTypes));
 
-		assertThat(repository.freshCatalog("stations", observedAt.plusSeconds(1))).contains(stations);
-		assertThat(repository.freshCatalog("stations", expiresAt)).isEmpty();
+		assertThat(repository.freshCatalog("stations", databaseNow.plus(Duration.ofDays(1)))).contains(stations);
+		jdbcTemplate.update(
+			"UPDATE train_catalog_cache SET observed_at = ?, expires_at = ? WHERE catalog_kind = 'stations'",
+			java.sql.Timestamp.from(databaseNow.minus(Duration.ofHours(2))),
+			java.sql.Timestamp.from(databaseNow.minus(Duration.ofHours(1)))
+		);
+		assertThat(repository.freshCatalog("stations", databaseNow.minus(Duration.ofDays(1)))).isEmpty();
 		assertThat(jdbcTemplate.queryForObject("SELECT COUNT(*) FROM train_catalog_cache", Integer.class))
 			.isEqualTo(2);
 	}
@@ -128,19 +135,44 @@ class JdbcTrainSearchCacheTest {
 
 	@Test
 	void ownerStoresFreshLegAndPurgeRemovesOnlyOldExpiredRows() {
-		Instant observedAt = Instant.parse("2026-07-19T00:00:00Z");
-		var expired = leg("expired", observedAt, observedAt.plusSeconds(60));
-		var fresh = leg("fresh", observedAt, observedAt.plus(Duration.ofHours(6)));
+		Instant databaseNow = databaseNow();
+		Instant observedAt = databaseNow.minus(Duration.ofMinutes(2));
+		var expired = leg("expired", observedAt, databaseNow.minus(Duration.ofMinutes(1)));
+		var fresh = leg("fresh", observedAt, databaseNow.plus(Duration.ofHours(6)));
 		assertThat(repository.tryAcquireLease("expired", "owner", observedAt, Duration.ofSeconds(15))).isTrue();
 		assertThat(repository.storeLegAndRelease("expired", "owner", expired)).isTrue();
 		assertThat(repository.tryAcquireLease("fresh", "owner", observedAt, Duration.ofSeconds(15))).isTrue();
 		assertThat(repository.storeLegAndRelease("fresh", "owner", fresh)).isTrue();
 
-		assertThat(repository.freshLeg("expired", observedAt.plusSeconds(60))).isEmpty();
-		assertThat(repository.freshLeg("fresh", observedAt.plusSeconds(60))).contains(fresh);
-		assertThat(repository.purgeExpiredBefore(observedAt.plusSeconds(61))).isEqualTo(1);
+		assertThat(repository.freshLeg("expired", databaseNow.minus(Duration.ofDays(1)))).isEmpty();
+		assertThat(repository.freshLeg("fresh", databaseNow.plus(Duration.ofDays(1)))).contains(fresh);
+		assertThat(repository.purgeExpiredBefore(databaseNow)).isEqualTo(1);
 		assertThat(jdbcTemplate.queryForObject("SELECT COUNT(*) FROM train_search_cache", Integer.class))
 			.isEqualTo(1);
+	}
+
+	@Test
+	void freshLegReadIsReadOnlyAndRejectsMismatchedStoredKey() {
+		Instant databaseNow = databaseNow();
+		var fresh = leg("leased", databaseNow.minusSeconds(1), databaseNow.plus(Duration.ofHours(1)));
+		assertThat(repository.tryAcquireLease("leased", "owner", databaseNow, Duration.ofSeconds(15))).isTrue();
+		assertThatThrownBy(() -> repository.storeLegAndRelease(
+			"leased", "owner", leg("different", databaseNow.minusSeconds(1), databaseNow.plus(Duration.ofHours(1)))))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("leg key must match lease key");
+		assertThat(jdbcTemplate.queryForObject(
+			"SELECT payload_json IS NULL FROM train_search_cache WHERE cache_key = 'leased'", Boolean.class)).isTrue();
+		assertThat(repository.storeLegAndRelease("leased", "owner", fresh)).isTrue();
+
+		Instant lastAccessAt = databaseNow.minus(Duration.ofHours(3));
+		jdbcTemplate.update(
+			"UPDATE train_search_cache SET last_access_at = ? WHERE cache_key = 'leased'",
+			java.sql.Timestamp.from(lastAccessAt)
+		);
+		assertThat(repository.freshLeg("leased", databaseNow.plus(Duration.ofDays(1)))).contains(fresh);
+		assertThat(jdbcTemplate.queryForObject(
+			"SELECT last_access_at FROM train_search_cache WHERE cache_key = 'leased'", java.sql.Timestamp.class).toInstant())
+			.isEqualTo(lastAccessAt);
 	}
 
 	@Test
@@ -190,5 +222,9 @@ class JdbcTrainSearchCacheTest {
 			new AnnotationTransactionAttributeSource()
 		));
 		return (JdbcTrainSearchCache) proxyFactory.getProxy();
+	}
+
+	private Instant databaseNow() {
+		return jdbcTemplate.queryForObject("SELECT CURRENT_TIMESTAMP", java.sql.Timestamp.class).toInstant();
 	}
 }


### PR DESCRIPTION
## 관련 이슈

Refs #2094

## 작업 배경

- 전국 여객열차 검색 결과를 여러 backend 인스턴스에서 동일하게 재사용하고 provider 호출을 조정할 공유 저장소가 필요합니다.

## 작업 내용

- station catalog와 검색 결과의 fresh-only cache, lease, atomic replace 계약을 추가했습니다.
- PostgreSQL/H2 migration에 cache 및 provider quota 상태 테이블을 추가했습니다.
- lease 소유권, 분당/일일 quota, window reset을 실제 PostgreSQL 동시성 테스트로 고정했습니다.

## 검증

- 실행한 명령과 결과: `./backend/gradlew -p backend test --tests com.easysubway.train.adapter.out.persistence.JdbcTrainSearchCacheTest --tests com.easysubway.common.persistence.DatabaseMigrationContainerTest` — BUILD SUCCESSFUL
- 실행한 명령과 결과: `git diff --check` — 통과

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| cache/lease/quota | PostgreSQL + H2 | repository 및 migration 자동 테스트 | PR checks | 통과 |
| UI/접근성 | 해당 없음 | persistence-only 변경 | UI 변경 없음 | 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [x] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: migration V65 추가, 애플리케이션 API 미노출

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `JdbcTrainSearchCache`의 lease 소유권 조건과 quota 원자성, PostgreSQL migration 제약을 우선 확인해 주세요.

## 리스크

- migration이 먼저 적용되지만 현재 API에서는 아직 사용하지 않습니다. 후속 provider/API PR이 이 저장소를 사용합니다.
- stale row는 읽기 경로에서 반환하지 않으며 lease owner만 결과를 저장할 수 있습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
