### PR TITLE
[Fix] #2274 V6-02 incident 상태 전이 compare-and-set·409·history 원자성

### DIFF
--- a/backend/src/main/java/com/easysubway/admin/operations/adapter/out/persistence/JdbcAdminIncidentRepository.java
+++ b/backend/src/main/java/com/easysubway/admin/operations/adapter/out/persistence/JdbcAdminIncidentRepository.java
@@ -102,6 +102,22 @@ public class JdbcAdminIncidentRepository implements AdminIncidentRepository {
 	}
 
 	@Override
+	public boolean compareAndSetStatus(AdminIncident next, AdminIncidentStatus expectedStatus) {
+		int updated = jdbcTemplate.update("""
+			UPDATE admin_incidents
+			SET status = ?, resolved_at = ?, resolution = ?, updated_at = CURRENT_TIMESTAMP
+			WHERE incident_id = ? AND status = ?
+			""",
+			next.status().name(),
+			next.resolvedAt(),
+			next.resolution(),
+			next.incidentId(),
+			expectedStatus.name()
+		);
+		return updated == 1;
+	}
+
+	@Override
 	public void saveTransition(AdminIncidentTransition transition) {
 		jdbcTemplate.update("""
 			INSERT INTO admin_incident_transitions (incident_id, from_status, to_status, changed_at, changed_by, note)

--- a/backend/src/main/java/com/easysubway/admin/operations/application/port/out/AdminIncidentRepository.java
+++ b/backend/src/main/java/com/easysubway/admin/operations/application/port/out/AdminIncidentRepository.java
@@ -1,6 +1,7 @@
 package com.easysubway.admin.operations.application.port.out;
 
 import com.easysubway.admin.operations.domain.AdminIncident;
+import com.easysubway.admin.operations.domain.AdminIncidentStatus;
 import com.easysubway.admin.operations.domain.AdminIncidentTransition;
 import java.util.Collection;
 import java.util.List;
@@ -18,6 +19,23 @@ public interface AdminIncidentRepository {
 	Optional<AdminIncident> findById(String incidentId);
 
 	AdminIncident save(AdminIncident incident);
+
+	/**
+	 * incident_id와 {@code expectedStatus}가 모두 일치하는 행만 {@code next} 상태로 갱신하는 compare-and-set.
+	 * 동시 전이로 기대 상태가 이미 바뀌었으면(영향 행 0) 아무 것도 바꾸지 않고 {@code false}를 돌려준다.
+	 *
+	 * <p>기본 구현은 읽고-검사-쓰기라 단일 스레드 컨텍스트(테스트·인메모리 프로파일)의 의미만 보장한다.
+	 * 실제 운영 동시성 정합은 이 메서드를 원자적 조건부 UPDATE로 override하는 저장소가 책임진다.
+	 */
+	default boolean compareAndSetStatus(AdminIncident next, AdminIncidentStatus expectedStatus) {
+		return findById(next.incidentId())
+			.filter(current -> current.status() == expectedStatus)
+			.map(current -> {
+				save(next);
+				return true;
+			})
+			.orElse(false);
+	}
 
 	void saveTransition(AdminIncidentTransition transition);
 

--- a/backend/src/main/java/com/easysubway/admin/operations/application/service/AdminIncidentService.java
+++ b/backend/src/main/java/com/easysubway/admin/operations/application/service/AdminIncidentService.java
@@ -7,6 +7,7 @@ import com.easysubway.admin.operations.application.port.out.AdminIncidentReposit
 import com.easysubway.admin.operations.domain.AdminIncident;
 import com.easysubway.admin.operations.domain.AdminIncidentStatus;
 import com.easysubway.admin.operations.domain.AdminIncidentTransition;
+import com.easysubway.common.error.ConflictException;
 import com.easysubway.common.error.InvalidRequestException;
 import com.easysubway.health.domain.HealthComponent;
 import com.easysubway.health.domain.HealthStatus;
@@ -114,8 +115,11 @@ public class AdminIncidentService {
 		}
 		AdminIncidentStatus fromStatus = incident.status();
 		LocalDateTime now = LocalDateTime.now(clock);
-		AdminIncident updated = repository.save(
-			incident.transitionTo(target, now, target.isResolved() ? resolution : null));
+		AdminIncident updated = incident.transitionTo(target, now, target.isResolved() ? resolution : null);
+		if (!repository.compareAndSetStatus(updated, fromStatus)) {
+			throw new ConflictException(
+				"다른 담당자가 먼저 상태를 변경했습니다. 최신 상태를 다시 확인한 뒤 전이해 주세요.");
+		}
 		repository.saveTransition(new AdminIncidentTransition(
 			incidentId,
 			fromStatus,

--- a/backend/src/test/java/com/easysubway/admin/operations/adapter/in/web/AdminOperationsPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/admin/operations/adapter/in/web/AdminOperationsPageControllerTest.java
@@ -11,6 +11,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.easysubway.admin.audit.adapter.out.persistence.InMemoryAdminAuditEventRepository;
 import com.easysubway.admin.audit.domain.AdminAuditOutcome;
 import com.easysubway.admin.audit.domain.AdminAuditEventType;
+import com.easysubway.admin.operations.adapter.out.persistence.InMemoryAdminIncidentRepository;
+import com.easysubway.admin.operations.domain.AdminIncident;
+import com.easysubway.admin.operations.domain.AdminIncidentStatus;
 import jakarta.servlet.http.HttpSession;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -20,6 +23,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpSession;
@@ -41,6 +47,9 @@ class AdminOperationsPageControllerTest {
 
 	@Autowired
 	private InMemoryAdminAuditEventRepository auditEventRepository;
+
+	@Autowired
+	private ConflictSimulatingIncidentRepository incidentRepository;
 
 	@Test
 	@DisplayName("공통코드 화면은 group filter와 enabled/disabled code를 표시한다")
@@ -236,6 +245,43 @@ class AdminOperationsPageControllerTest {
 				assertThat(event.reason()).startsWith("resolutionLength=");
 				assertThat(event.reason()).doesNotContain("secret");
 			});
+	}
+
+	@Test
+	@DisplayName("동시 전이 충돌 시 전이 요청은 409와 복구 안내를 반환하고 성공 전이·audit을 남기지 않는다")
+	void incidentTransitionConflictReturns409WithoutSuccessAudit() throws Exception {
+		openIncident("database DOWN");
+		String incidentId = auditEventRepository.findRecent(AdminAuditEventType.INCIDENT_CHANGE, 1)
+			.getFirst()
+			.targetId();
+
+		// 다른 세션이 먼저 상태를 바꾼 것처럼 다음 compare-and-set를 충돌로 만든다.
+		incidentRepository.simulateNextConflict();
+
+		String conflictHtml = mockMvc.perform(post("/admin/incidents/{incidentId}/transition", incidentId)
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.with(commandToken("/admin/incidents/page"))
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("targetStatus", "IN_PROGRESS")
+				.param("note", "재개 시도"))
+			.andExpect(status().isConflict())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(conflictHtml)
+			.contains("요청이 최신 상태와 충돌했습니다")
+			.contains("화면을 새로고침한 뒤 다시 시도해 주세요");
+
+		// 충돌 요청은 성공 전이 audit(TRANSITION_INCIDENT)을 남기지 않는다. OPEN_INCIDENT만 존재한다.
+		assertThat(auditEventRepository.findRecent(AdminAuditEventType.INCIDENT_CHANGE, 10))
+			.extracting(event -> event.action())
+			.containsExactly("OPEN_INCIDENT");
+
+		// 상태는 여전히 접수(RECEIVED)이며 다음 전이 버튼(IN_PROGRESS)이 그대로 노출된다.
+		String html = getAdminHtml("/admin/incidents/page", new MockHttpSession());
+		assertThat(html).contains("name=\"targetStatus\" value=\"IN_PROGRESS\"");
 	}
 
 	@Test
@@ -455,5 +501,37 @@ class AdminOperationsPageControllerTest {
 			return mockHttpSession;
 		}
 		return new MockHttpSession();
+	}
+
+	@TestConfiguration
+	static class ConflictRepositoryConfig {
+
+		@Bean
+		@Primary
+		ConflictSimulatingIncidentRepository conflictSimulatingIncidentRepository() {
+			return new ConflictSimulatingIncidentRepository();
+		}
+	}
+
+	/**
+	 * 다음 compare-and-set 호출을 한 번 충돌(영향 행 0)로 만들어, 다른 세션이 먼저 상태를 바꾼 상황을
+	 * 결정적으로 재현하는 인메모리 저장소.
+	 */
+	static class ConflictSimulatingIncidentRepository extends InMemoryAdminIncidentRepository {
+
+		private volatile boolean conflictNext;
+
+		void simulateNextConflict() {
+			this.conflictNext = true;
+		}
+
+		@Override
+		public boolean compareAndSetStatus(AdminIncident next, AdminIncidentStatus expectedStatus) {
+			if (conflictNext) {
+				conflictNext = false;
+				return false;
+			}
+			return super.compareAndSetStatus(next, expectedStatus);
+		}
 	}
 }

--- a/backend/src/test/java/com/easysubway/admin/operations/adapter/out/persistence/JdbcAdminIncidentRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/admin/operations/adapter/out/persistence/JdbcAdminIncidentRepositoryTest.java
@@ -45,6 +45,54 @@ class JdbcAdminIncidentRepositoryTest {
 	}
 
 	@Test
+	@DisplayName("compare-and-set는 기대 상태가 맞을 때만 갱신하고, 상반된 동시 전이의 뒤늦은 요청은 영향 행 0으로 거부한다")
+	void compareAndSetStatusAppliesOnlyWhenExpectedStatusMatches() {
+		var dataSource = incidentDataSource();
+		var repository = new JdbcAdminIncidentRepository(dataSource);
+		AdminIncident monitoring = repository.save(new AdminIncident(
+			"INC-1", "MAJOR", AdminIncidentStatus.MONITORING, "HEALTH", "database DOWN", "ops",
+			OPENED_AT, null, null, null, null));
+
+		// 운영자 A: MONITORING → RESOLVED compare-and-set 성공
+		boolean resolvedApplied = repository.compareAndSetStatus(
+			monitoring.transitionTo(AdminIncidentStatus.RESOLVED, OPENED_AT.plusMinutes(1), "DB 복구"),
+			AdminIncidentStatus.MONITORING);
+		assertThat(resolvedApplied).isTrue();
+
+		AdminIncident afterResolve = repository.findById("INC-1").orElseThrow();
+		assertThat(afterResolve.status()).isEqualTo(AdminIncidentStatus.RESOLVED);
+		assertThat(afterResolve.resolvedAt()).isEqualTo(OPENED_AT.plusMinutes(1));
+		assertThat(afterResolve.resolution()).isEqualTo("DB 복구");
+
+		// 운영자 B: 여전히 MONITORING인 줄 알고 재개(IN_PROGRESS)를 시도 → 기대 상태 불일치로 거부
+		boolean reopenApplied = repository.compareAndSetStatus(
+			monitoring.transitionTo(AdminIncidentStatus.IN_PROGRESS, OPENED_AT.plusMinutes(2), null),
+			AdminIncidentStatus.MONITORING);
+		assertThat(reopenApplied).isFalse();
+
+		// 거부된 요청은 어떤 필드도 바꾸지 않는다.
+		assertThat(repository.findById("INC-1").orElseThrow())
+			.satisfies(incident -> {
+				assertThat(incident.status()).isEqualTo(AdminIncidentStatus.RESOLVED);
+				assertThat(incident.resolution()).isEqualTo("DB 복구");
+			});
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 incident의 compare-and-set는 새 행을 만들지 않고 거부한다")
+	void compareAndSetStatusDoesNotInsertMissingIncident() {
+		var dataSource = incidentDataSource();
+		var repository = new JdbcAdminIncidentRepository(dataSource);
+
+		boolean applied = repository.compareAndSetStatus(new AdminIncident(
+			"INC-MISSING", "MAJOR", AdminIncidentStatus.IN_PROGRESS, "HEALTH", "database DOWN", "ops",
+			OPENED_AT, null, null, null, null), AdminIncidentStatus.RECEIVED);
+
+		assertThat(applied).isFalse();
+		assertThat(repository.findById("INC-MISSING")).isEmpty();
+	}
+
+	@Test
 	@DisplayName("여러 incident 전이 이력을 단일 벌크 조회로 읽는다")
 	void findsTransitionsInBulk() {
 		var dataSource = incidentDataSource();

--- a/backend/src/test/java/com/easysubway/admin/operations/application/service/AdminIncidentServiceTest.java
+++ b/backend/src/test/java/com/easysubway/admin/operations/application/service/AdminIncidentServiceTest.java
@@ -10,6 +10,7 @@ import com.easysubway.admin.operations.application.service.AdminIncidentService.
 import com.easysubway.admin.operations.domain.AdminIncident;
 import com.easysubway.admin.operations.domain.AdminIncidentStatus;
 import com.easysubway.admin.operations.domain.AdminIncidentTransition;
+import com.easysubway.common.error.ConflictException;
 import com.easysubway.common.error.InvalidRequestException;
 import com.easysubway.health.domain.HealthComponent;
 import com.easysubway.health.domain.HealthStatus;
@@ -59,6 +60,43 @@ class AdminIncidentServiceTest {
 				AdminIncidentStatus.RESOLVED
 			);
 		assertThat(timeline.getFirst().isInitial()).isTrue();
+	}
+
+	@Test
+	@DisplayName("상반된 동시 전이는 compare-and-set로 정확히 하나만 성공하고 나머지는 충돌로 거부된다")
+	void concurrentOpposingTransitionsKeepExactlyOneWinner() {
+		var repository = new RacingIncidentRepository();
+		var service = new AdminIncidentService(
+			repository, new AdminCommonCodeService(new InMemoryAdminCommonCodeRepository()));
+		AdminIncident opened = service.open(
+			new OpenAdminIncidentCommand("MAJOR", "RECEIVED", "HEALTH", "database DOWN", "ops", null, null));
+		String id = opened.incidentId();
+		service.transition(id, "IN_PROGRESS", "ops", null, null);
+		service.transition(id, "MONITORING", "ops", null, null);
+
+		// 운영자 B가 MONITORING을 읽고 조치 중 재개를 시도하는 창(window)에서,
+		// 운영자 A가 먼저 종결(상반된 전이)을 커밋한다.
+		repository.commitInNextCasWindow(() -> service.transition(id, "RESOLVED", "opsA", null, "DB 복구"));
+
+		assertThatThrownBy(() -> service.transition(id, "IN_PROGRESS", "opsB", "재개 시도", null))
+			.isInstanceOf(ConflictException.class)
+			.hasMessageContaining("다른 담당자가 먼저 상태를 변경");
+
+		AdminIncident current = repository.findById(id).orElseThrow();
+		assertThat(current.status()).isEqualTo(AdminIncidentStatus.RESOLVED);
+
+		List<AdminIncidentTransition> timeline = service.listTransitions(id);
+		// 충돌로 거부된 B의 전이(IN_PROGRESS 재개)는 기록되지 않는다.
+		assertThat(timeline)
+			.extracting(AdminIncidentTransition::toStatus)
+			.containsExactly(
+				AdminIncidentStatus.RECEIVED,
+				AdminIncidentStatus.IN_PROGRESS,
+				AdminIncidentStatus.MONITORING,
+				AdminIncidentStatus.RESOLVED
+			);
+		// current 상태는 항상 history 마지막 to_status와 일치한다.
+		assertThat(timeline.getLast().toStatus()).isEqualTo(current.status());
 	}
 
 	@Test
@@ -149,5 +187,28 @@ class AdminIncidentServiceTest {
 
 	private AdminIncident openReceived() {
 		return service.open(new OpenAdminIncidentCommand("MAJOR", "RECEIVED", "HEALTH", "database DOWN", "ops", null, null));
+	}
+
+	/**
+	 * compare-and-set 창에서 상반된 동시 전이를 결정적으로 재현하는 저장소.
+	 * 다음 {@code compareAndSetStatus} 호출 직전에 예약된 경쟁 write를 한 번 실행한다.
+	 */
+	private static final class RacingIncidentRepository extends InMemoryAdminIncidentRepository {
+
+		private Runnable pendingConcurrentCommit;
+
+		void commitInNextCasWindow(Runnable concurrentCommit) {
+			this.pendingConcurrentCommit = concurrentCommit;
+		}
+
+		@Override
+		public boolean compareAndSetStatus(AdminIncident next, AdminIncidentStatus expectedStatus) {
+			if (pendingConcurrentCommit != null) {
+				Runnable concurrentCommit = pendingConcurrentCommit;
+				pendingConcurrentCommit = null;
+				concurrentCommit.run();
+			}
+			return super.compareAndSetStatus(next, expectedStatus);
+		}
 	}
 }


### PR DESCRIPTION
## 관련 이슈

close #2274
Refs #2271

## 작업 배경

- 장애(incident) 상태 전이가 "현재 상태 확인"과 "update"로 분리돼 있어, 두 운영자가 같은 incident를 동시에 상반된 방향으로 전이시키면 마지막 write가 앞선 결과를 조용히 덮어썼다(last-write-wins).
- `AdminIncidentService.transition()`은 `repository.save(updated)`만 호출했고, `JdbcAdminIncidentRepository.save()`의 `UPDATE ... WHERE incident_id = ?`는 상태 조건 없이 무조건 갱신했다. 두 운영자가 같은 상태를 읽고 각자 다른 목표 상태로 전이를 커밋하면 둘 다 성공 처리되어(각각 history 행도 남아) current 상태와 history 마지막 `to_status`가 어긋날 수 있었다.
- issue #2274 §5는 수정 파일을 5개로 제한했으나(`AdminIncidentService`, `JdbcAdminIncidentRepository`, 대응 테스트 3개), compare-and-set을 서비스가 호출하려면 그 연산이 repository port의 멤버여야 했다(port가 아니라 concrete 구현에만 추가하면 `InMemoryAdminIncidentRepository` 프로파일·테스트 경로에서 서비스가 CAS를 호출할 수 없다). 구현 중 이 필요를 issue #2274 본문 §5에 경로·이유·검증과 함께 먼저 추가한 뒤(2026-07-19) 진행했다.

## 작업 내용

- `AdminIncidentRepository.java`(port, §5 외 1개 파일 — 이유는 아래 "§5 외 파일" 참고): `default boolean compareAndSetStatus(AdminIncident next, AdminIncidentStatus expectedStatus)` 추가. incident_id와 expected 현재 상태가 모두 일치하는 행만 갱신하고, 아니면 아무 것도 바꾸지 않고 `false`를 반환하는 compare-and-set 계약을 port 수준에서 명시. 기본 구현은 읽고-검사-쓰기(단일 스레드 의미, 기존 `findRecent(int, int)` default 선례와 동일한 방식)이고, `InMemoryAdminIncidentRepository`는 이 default를 상속만 해서 무수정으로 유지했다.
- `JdbcAdminIncidentRepository.java`: `compareAndSetStatus`를 원자적 단일 UPDATE로 override. `UPDATE admin_incidents SET status = ?, resolved_at = ?, resolution = ?, updated_at = CURRENT_TIMESTAMP WHERE incident_id = ? AND status = ?`(expected status 포함). 영향 행이 정확히 1일 때만 `true`, 0이면 `false`. INSERT fallback·재시도 없음(숨은 fallback 금지).
- `AdminIncidentService.java`: `transition()`이 `repository.save(...)` 대신 `repository.compareAndSetStatus(updated, fromStatus)`를 호출. `false`(영향 행 0)면 `ConflictException("다른 담당자가 먼저 상태를 변경했습니다. 최신 상태를 다시 확인한 뒤 전이해 주세요.")`를 던진다. `saveTransition(...)`(history insert)은 CAS 성공 이후에만 실행되므로, conflict 요청은 성공 transition·audit을 전혀 남기지 않는다. update와 history insert는 controller의 기존 `@PostMapping(".../transition") @Transactional` 안에서 한 트랜잭션으로 유지된다(이 PR에서 트랜잭션 경계를 새로 추가하지 않음 — 기존 경계를 그대로 사용).
- 409 표현: `ConflictException`은 이미 `CommonExceptionHandler`(API, `@ResponseStatus(HttpStatus.CONFLICT)`)와 `AdminHtmlExceptionResolver`(page, 제목 "요청이 최신 상태와 충돌했습니다" + 복구 안내 "화면을 새로고침한 뒤 다시 시도해 주세요.")에 이미 매핑돼 있어, controller/advice 신규 수정 없이 page/API 모두 409 + 복구 안내가 표현된다. 이 부분은 §5 파일만으로 계약을 만족할 수 있음을 구현 전에 확인했다.
- 재현→수정 테스트 3건 추가(아래 검증 참고): 상반된 동시 전이에서 정확히 하나만 성공·나머지는 `ConflictException`/409, current와 history 마지막 `to_status` 항상 일치, conflict 요청은 audit 미기록.

### §5 외 파일

- `backend/src/main/java/com/easysubway/admin/operations/application/port/out/AdminIncidentRepository.java` — issue #2274 §5 본문에 2026-07-19 사전 반영. 이유: 서비스는 repository port 타입에만 의존하는데, 기존 `save(AdminIncident)`는 목표 상태만 받고 expected current status를 전달할 수 없어 compare-and-set을 표현하지 못했다. `default` 메서드로 추가(기존 `findRecent(int, int)` default 선례와 동일 패턴)해 `InMemoryAdminIncidentRepository`는 무수정으로 상속만 하도록 최소화했다.

## 검증

- 실행한 명령과 결과:
  - `node tools/ci/api-catalog.mjs validate` → exit 0 (`API catalog valid: 245`)
  - `LC_ALL=C.UTF-8 node --test tools/ci/repository-contract.test.mjs` → exit 0 (tests 218, pass 218, fail 0)
  - `npm test --prefix tools/qa` → exit 0 (tests 8, pass 8, fail 0)
  - `cd backend && ./gradlew test --tests '...AdminIncidentServiceTest' --tests '...JdbcAdminIncidentRepositoryTest' --tests '...AdminOperationsPageControllerTest'` → BUILD SUCCESSFUL
- 재현 순서 실측: 수정 전 코드는 `repository.save(updated)`만 호출해 상태 무조건 UPDATE였다. `AdminIncidentServiceTest`에 추가한 `concurrentOpposingTransitionsKeepExactlyOneWinner`는 CAS 직전 창(window)에서 경쟁 write를 결정적으로 커밋하는 `RacingIncidentRepository`로 last-write-wins를 재현했다 — 수정 전 코드라면 두 전이가 모두 성공 처리되어 history에 상반된 두 행이 남고 current가 나중 write로 조용히 덮인다. 수정 후에는 뒤늦은 요청이 `ConflictException`으로 거부되고 history는 먼저 커밋된 전이만 남아 green.

## 검증 증거

tested SHA `a9647e15`(push된 커밋), DB: JDBC 테스트=H2 embedded, 서비스/컨트롤러 테스트=InMemory(단일 JVM 프로세스 내 결정적 재현으로 실제 DB 동시 세션을 대신함).

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 상반된 동시 전이에서 정확히 하나만 성공 | backend | `AdminIncidentServiceTest#concurrentOpposingTransitionsKeepExactlyOneWinner` — MONITORING까지 전이 후 운영자 A(`→RESOLVED`)를 CAS 창에서 먼저 커밋, 운영자 B(`→IN_PROGRESS`)는 같은 창에서 뒤이어 시도 | A 성공(현재 상태 RESOLVED), B `ConflictException` | green |
| 실패 요청 409 및 복구 안내 (page) | backend | `AdminOperationsPageControllerTest#incidentTransitionConflictReturns409WithoutSuccessAudit` — `ConflictSimulatingIncidentRepository`(`@Primary` 테스트 빈)로 다음 CAS를 1회 충돌 처리 후 `/admin/incidents/{id}/transition` POST | HTTP 409, 응답 본문에 "요청이 최신 상태와 충돌했습니다"·"화면을 새로고침한 뒤 다시 시도해 주세요" 포함 | green |
| 실패 요청 409 (API 경로 매핑 확인) | backend | `CommonExceptionHandler.handleConflict` 기존 매핑(`ConflictException` → `@ResponseStatus(HttpStatus.CONFLICT)`), 이 PR에서 무수정 확인 | diff 범위(6파일에 controller/advice 없음) | 유지 |
| conflict 요청은 성공 transition·audit 미기록 | backend | 위 컨트롤러 테스트에서 `auditEventRepository.findRecent(INCIDENT_CHANGE, 10)`이 `OPEN_INCIDENT` 1건만 포함하는지 확인(TRANSITION_INCIDENT 없음) | `containsExactly("OPEN_INCIDENT")` 검증 | green |
| current/history 불일치 0 | backend | 서비스 테스트에서 `service.listTransitions(id).getLast().toStatus()`와 `repository.findById(id).status()` 비교 | 둘 다 RESOLVED로 일치 | green |
| JDBC 원자적 CAS true/false·불변성 | backend | `JdbcAdminIncidentRepositoryTest#compareAndSetStatusAppliesOnlyWhenExpectedStatusMatches`(H2, MONITORING→RESOLVED 성공 후 동일 expected로 재시도 시 거부, 거부된 요청은 필드 불변) | CAS 1회 true·1회 false, 필드 미변경 확인 | green |
| 존재하지 않는 incident CAS는 새 행 미생성 | backend | `JdbcAdminIncidentRepositoryTest#compareAndSetStatusDoesNotInsertMissingIncident` | CAS false, `findById` 여전히 empty | green |
| 기존 정상 워크플로 회귀 없음 | backend | 같은 3개 테스트 클래스의 기존 케이스(접수→조치 중→모니터링→종결, 역방향 전이, 단계 건너뛰기 거부 등) | 전량 green | green |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

backend 런타임 동작(incident 상태 전이 update 조건·충돌 처리)만 바뀌며, 반영에는 backend 배포가 필요하다. 스키마 변경(DB migration) 없음 — 기존 `admin_incidents`/`admin_incident_transitions` 컬럼과 PK만 사용.

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [ ] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [ ] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 동작 변경(배포 필요), 버전 문자열 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `AdminIncidentRepository`(port)에 추가한 `compareAndSetStatus` default 구현 — §5 목록에 없는 파일이라 issue #2274 본문 §5에 사전 반영한 근거를 이 PR 본문 "§5 외 파일" 절에도 동일하게 기록했다.
- 409 표현은 기존 `CommonExceptionHandler`/`AdminHtmlExceptionResolver`의 `ConflictException` 매핑을 그대로 재사용했고, 이 PR에서 두 파일을 수정하지 않았다(§5 파일만으로 계약 충족 가능함을 구현 전에 실측 확인).
- `JdbcAdminIncidentRepository.compareAndSetStatus`는 `status` 컬럼만 조건에 걸고 `severity`/`source`/`summary`/`owner`/`station_id`/`line_id`는 손대지 않는다 — 전이와 무관한 필드의 동시 수정 충돌은 이 issue의 scope 밖(§12 Non-scope: optimistic-lock framework 도입 아님, 상태 전이 한정 CAS).

## 리스크

- `transition()`의 update 경로가 "무조건 UPDATE"에서 "expected status 일치 시에만 UPDATE"로 바뀐다. 정상 단일 사용자 흐름(대부분의 실사용)에는 영향이 없고, 오직 동시 상반 전이 경합에서만 뒤늦은 요청이 409로 거부된다(의도된 변경).
- rollback 경계: 단일 revert 가능. 6개 파일 한 커밋(`a9647e15`)으로, `git revert`로 전량 원복되며 스키마·datapack·계약 JSON을 건드리지 않아 backend 배포만 되돌리면 된다.
- gate/tracker(JSON) 영향 없음, CI workflow·계약 테스트 변경 없음, incident ID·허용 상태 전이·history schema·permission·route·CSRF 계약 무변경.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
