### PR TITLE
[Fix] #2275 V6-03 notice soft-unpublish·audit transaction·PG/H2 정합

### DIFF
--- a/backend/src/main/java/com/easysubway/notice/adapter/in/web/ServiceNoticeAdminApiController.java
+++ b/backend/src/main/java/com/easysubway/notice/adapter/in/web/ServiceNoticeAdminApiController.java
@@ -8,6 +8,7 @@ import com.easysubway.notice.domain.ServiceNotice;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -42,12 +43,13 @@ class ServiceNoticeAdminApiController {
 	}
 
 	@PostMapping("/admin/notices/{id}/unpublish")
+	@Transactional
 	ResponseEntity<ApiResponse<Void>> unpublish(
 		@PathVariable String id,
 		Authentication authentication,
 		HttpServletRequest httpRequest
 	) {
-		service.unpublish(id);
+		service.unpublish(id, authentication.getName());
 		auditWriter.noticeChange(
 			authentication, httpRequest, id, "UNPUBLISH_NOTICE",
 			AdminAuditOutcome.SUCCESS, "service notice unpublished");

--- a/backend/src/main/java/com/easysubway/notice/adapter/in/web/ServiceNoticeAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/notice/adapter/in/web/ServiceNoticeAdminPageController.java
@@ -3,7 +3,6 @@ package com.easysubway.notice.adapter.in.web;
 import com.easysubway.admin.audit.application.service.AdminAuditWriter;
 import com.easysubway.admin.audit.domain.AdminAuditOutcome;
 import com.easysubway.common.error.InvalidRequestException;
-import com.easysubway.common.error.ResourceNotFoundException;
 import com.easysubway.notice.application.port.out.ServiceNoticeRepository;
 import com.easysubway.notice.application.service.PublishNoticeCommand;
 import com.easysubway.notice.application.service.ServiceNoticeService;
@@ -76,10 +75,7 @@ class ServiceNoticeAdminPageController {
 		Authentication authentication,
 		HttpServletRequest request
 	) {
-		if (repository.findById(id).isEmpty()) {
-			throw new ResourceNotFoundException("운행 공지를 찾을 수 없습니다: " + id);
-		}
-		service.unpublish(id);
+		service.unpublish(id, authentication.getName());
 		auditWriter.noticeChange(
 			authentication, request, id, "UNPUBLISH_NOTICE",
 			AdminAuditOutcome.SUCCESS, "service notice unpublished");

--- a/backend/src/main/java/com/easysubway/notice/adapter/out/persistence/JdbcServiceNoticeRepository.java
+++ b/backend/src/main/java/com/easysubway/notice/adapter/out/persistence/JdbcServiceNoticeRepository.java
@@ -25,7 +25,9 @@ public class JdbcServiceNoticeRepository implements ServiceNoticeRepository {
 		ServiceNoticeSeverity.valueOf(rs.getString("severity")),
 		toLdt(rs.getTimestamp("published_at")),
 		toLdt(rs.getTimestamp("expires_at")),
-		rs.getString("published_by"));
+		rs.getString("published_by"),
+		toLdt(rs.getTimestamp("unpublished_at")),
+		rs.getString("unpublished_by"));
 
 	private final JdbcTemplate jdbcTemplate;
 
@@ -37,17 +39,21 @@ public class JdbcServiceNoticeRepository implements ServiceNoticeRepository {
 	public void save(ServiceNotice notice) {
 		int updated = jdbcTemplate.update(
 			"UPDATE service_notice SET scope=?, scope_value=?, title=?, body=?, severity=?,"
-				+ " published_at=?, expires_at=?, published_by=? WHERE id=?",
+				+ " published_at=?, expires_at=?, published_by=?, unpublished_at=?, unpublished_by=?"
+				+ " WHERE id=?",
 			notice.scope().name(), notice.scopeValue(), notice.title(), notice.body(),
 			notice.severity().name(), Timestamp.valueOf(notice.publishedAt()),
-			toTimestamp(notice.expiresAt()), notice.publishedBy(), notice.id());
+			toTimestamp(notice.expiresAt()), notice.publishedBy(),
+			toTimestamp(notice.unpublishedAt()), notice.unpublishedBy(), notice.id());
 		if (updated == 0) {
 			jdbcTemplate.update(
 				"INSERT INTO service_notice (id, scope, scope_value, title, body, severity,"
-					+ " published_at, expires_at, published_by) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+					+ " published_at, expires_at, published_by, unpublished_at, unpublished_by)"
+					+ " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
 				notice.id(), notice.scope().name(), notice.scopeValue(), notice.title(),
 				notice.body(), notice.severity().name(), Timestamp.valueOf(notice.publishedAt()),
-				toTimestamp(notice.expiresAt()), notice.publishedBy());
+				toTimestamp(notice.expiresAt()), notice.publishedBy(),
+				toTimestamp(notice.unpublishedAt()), notice.unpublishedBy());
 		}
 	}
 
@@ -65,7 +71,7 @@ public class JdbcServiceNoticeRepository implements ServiceNoticeRepository {
 	public List<ServiceNotice> findActiveAt(LocalDateTime now) {
 		Timestamp at = Timestamp.valueOf(now);
 		return jdbcTemplate.query(
-			"SELECT * FROM service_notice WHERE published_at <= ?"
+			"SELECT * FROM service_notice WHERE unpublished_at IS NULL AND published_at <= ?"
 				+ " AND (expires_at IS NULL OR expires_at > ?) ORDER BY published_at DESC",
 			ROW_MAPPER, at, at);
 	}
@@ -78,8 +84,12 @@ public class JdbcServiceNoticeRepository implements ServiceNoticeRepository {
 	}
 
 	@Override
-	public void deleteById(String id) {
-		jdbcTemplate.update("DELETE FROM service_notice WHERE id=?", id);
+	public boolean unpublish(String id, LocalDateTime unpublishedAt, String unpublishedBy) {
+		int updated = jdbcTemplate.update(
+			"UPDATE service_notice SET unpublished_at=?, unpublished_by=?"
+				+ " WHERE id=? AND unpublished_at IS NULL",
+			Timestamp.valueOf(unpublishedAt), unpublishedBy, id);
+		return updated == 1;
 	}
 
 	private static Timestamp toTimestamp(LocalDateTime value) {

--- a/backend/src/main/java/com/easysubway/notice/application/port/out/ServiceNoticeRepository.java
+++ b/backend/src/main/java/com/easysubway/notice/application/port/out/ServiceNoticeRepository.java
@@ -15,11 +15,19 @@ public interface ServiceNoticeRepository {
 	Optional<ServiceNotice> findById(String id);
 
 	/**
-	 * {@code now} 기준 활성(게시됨·미만료) 공지 목록.
+	 * {@code now} 기준 활성(게시됨·미만료·미중단) 공지 목록. 게시 중단된 공지는 제외한다.
 	 */
 	List<ServiceNotice> findActiveAt(LocalDateTime now);
 
+	/**
+	 * 게시 중단 여부와 무관하게 최근 공지 목록. 게시 이력 조회에 쓰인다.
+	 */
 	List<ServiceNotice> findRecent(int limit);
 
-	void deleteById(String id);
+	/**
+	 * 아직 게시 중단되지 않은 공지만 게시 중단으로 표시한다(soft-unpublish, compare-and-set).
+	 * row는 삭제하지 않는다. 활성 공지를 실제로 게시 중단했으면 {@code true},
+	 * 대상이 없거나 이미 게시 중단돼 바뀐 row가 없으면 {@code false}를 준다.
+	 */
+	boolean unpublish(String id, LocalDateTime unpublishedAt, String unpublishedBy);
 }

--- a/backend/src/main/java/com/easysubway/notice/application/service/ServiceNoticeService.java
+++ b/backend/src/main/java/com/easysubway/notice/application/service/ServiceNoticeService.java
@@ -1,5 +1,7 @@
 package com.easysubway.notice.application.service;
 
+import com.easysubway.common.error.ConflictException;
+import com.easysubway.common.error.ResourceNotFoundException;
 import com.easysubway.notice.application.port.out.ServiceNoticeRepository;
 import com.easysubway.notice.domain.ServiceNotice;
 import com.easysubway.notice.domain.ServiceNoticeSeverity;
@@ -59,7 +61,18 @@ public class ServiceNoticeService {
 		return notice;
 	}
 
-	public void unpublish(String id) {
-		repository.deleteById(id);
+	/**
+	 * 공지를 게시 중단(soft-unpublish)한다. 원장 row는 보존하고 상태만 바꾼다.
+	 * 대상이 없으면 404, 이미 게시 중단됐거나 그 사이 다른 관리자가 먼저 중단했으면 409다.
+	 */
+	public void unpublish(String id, String unpublishedBy) {
+		ServiceNotice notice = repository.findById(id)
+			.orElseThrow(() -> new ResourceNotFoundException("운행 공지를 찾을 수 없습니다: " + id));
+		if (notice.isUnpublished()) {
+			throw new ConflictException("이미 게시 중단된 공지입니다: " + id);
+		}
+		if (!repository.unpublish(id, LocalDateTime.now(clock), unpublishedBy)) {
+			throw new ConflictException("이미 게시 중단된 공지입니다: " + id);
+		}
 	}
 }

--- a/backend/src/main/java/com/easysubway/notice/domain/ServiceNotice.java
+++ b/backend/src/main/java/com/easysubway/notice/domain/ServiceNotice.java
@@ -8,6 +8,9 @@ import java.time.LocalDateTime;
  * <p>실시간성 데이터이므로 데이터팩이 아닌 온라인 overlay로만 흐른다(#1414 분리 원칙).
  * 공개 API는 {@link #isActiveAt(LocalDateTime)}가 참인 공지만 노출한다 — 만료된 공지는
  * 서버 필터에서 제외되어 앱으로 나가지 않는다.
+ *
+ * <p>게시 중단은 row 삭제가 아니라 {@code unpublishedAt}/{@code unpublishedBy}를 남기는
+ * soft-unpublish다(#2275). 게시 중단된 공지는 활성 조회에서 빠지지만 이력 조회로는 남는다.
  */
 public record ServiceNotice(
 	String id,
@@ -18,7 +21,9 @@ public record ServiceNotice(
 	ServiceNoticeSeverity severity,
 	LocalDateTime publishedAt,
 	LocalDateTime expiresAt,
-	String publishedBy
+	String publishedBy,
+	LocalDateTime unpublishedAt,
+	String unpublishedBy
 ) {
 
 	public ServiceNotice {
@@ -46,17 +51,65 @@ public record ServiceNotice(
 		if (scope == ServiceNoticeScope.ALL) {
 			scopeValue = null;
 		}
+		if ((unpublishedAt == null) != isBlank(unpublishedBy)) {
+			throw new IllegalArgumentException("unpublishedAt과 unpublishedBy는 함께 있거나 함께 없어야 합니다.");
+		}
 	}
 
 	/**
-	 * {@code now}에 이 공지가 활성인지. 게시 시각 이상이고 만료 시각(있다면) 미만이면 활성.
-	 * 만료 시각은 배타적이다.
+	 * 아직 게시 중단되지 않은(활성 후보) 공지를 만든다. 발행·저장 왕복의 기본 형태다.
+	 */
+	public ServiceNotice(
+		String id,
+		ServiceNoticeScope scope,
+		String scopeValue,
+		String title,
+		String body,
+		ServiceNoticeSeverity severity,
+		LocalDateTime publishedAt,
+		LocalDateTime expiresAt,
+		String publishedBy
+	) {
+		this(id, scope, scopeValue, title, body, severity, publishedAt, expiresAt, publishedBy, null, null);
+	}
+
+	/**
+	 * {@code now}에 이 공지가 활성인지. 게시 중단되지 않았고, 게시 시각 이상이며 만료 시각(있다면)
+	 * 미만이면 활성. 만료 시각은 배타적이다.
 	 */
 	public boolean isActiveAt(LocalDateTime now) {
+		if (isUnpublished()) {
+			return false;
+		}
 		if (now.isBefore(publishedAt)) {
 			return false;
 		}
 		return expiresAt == null || now.isBefore(expiresAt);
+	}
+
+	/**
+	 * 게시 중단 여부. {@code unpublishedAt}이 남아 있으면 게시 중단된 상태다.
+	 */
+	public boolean isUnpublished() {
+		return unpublishedAt != null;
+	}
+
+	/**
+	 * {@code at} 시각에 {@code by}가 게시를 중단한 상태의 새 공지를 만든다. 원장 row는 보존하고
+	 * 상태만 바꾼다. 이미 게시 중단된 공지에는 적용할 수 없다.
+	 */
+	public ServiceNotice unpublish(LocalDateTime at, String by) {
+		if (at == null) {
+			throw new IllegalArgumentException("unpublishedAt은 필수입니다.");
+		}
+		if (isBlank(by)) {
+			throw new IllegalArgumentException("unpublishedBy는 필수입니다.");
+		}
+		if (isUnpublished()) {
+			throw new IllegalStateException("이미 게시 중단된 공지입니다.");
+		}
+		return new ServiceNotice(
+			id, scope, scopeValue, title, body, severity, publishedAt, expiresAt, publishedBy, at, by);
 	}
 
 	private static boolean isBlank(String value) {

--- a/backend/src/main/resources/db/migration/h2/V66__service_notice_lifecycle.sql
+++ b/backend/src/main/resources/db/migration/h2/V66__service_notice_lifecycle.sql
@@ -1,0 +1,4 @@
+-- #2275 운행 공지 게시 중단 lifecycle — soft-unpublish(h2 test dialect, compact form).
+-- unpublished_at/unpublished_by로 상태를 남기고 row를 보존한다. 활성 조회는 unpublished 제외.
+ALTER TABLE service_notice ADD COLUMN unpublished_at TIMESTAMP;
+ALTER TABLE service_notice ADD COLUMN unpublished_by VARCHAR(255);

--- a/backend/src/main/resources/db/migration/postgresql/V66__service_notice_lifecycle.sql
+++ b/backend/src/main/resources/db/migration/postgresql/V66__service_notice_lifecycle.sql
@@ -1,0 +1,5 @@
+-- #2275 운행 공지 게시 중단 lifecycle — soft-unpublish.
+-- 게시 중단을 row 삭제로 표현하면 이력 조회·audit 원자성·오류 결과가 어긋난다.
+-- unpublished_at/unpublished_by로 상태를 남기고 row를 보존한다. 활성 조회는 unpublished를 제외한다.
+ALTER TABLE service_notice ADD COLUMN unpublished_at TIMESTAMP;
+ALTER TABLE service_notice ADD COLUMN unpublished_by VARCHAR(255);

--- a/backend/src/test/java/com/easysubway/notice/adapter/in/web/ServiceNoticeAdminApiControllerTest.java
+++ b/backend/src/test/java/com/easysubway/notice/adapter/in/web/ServiceNoticeAdminApiControllerTest.java
@@ -1,6 +1,10 @@
 package com.easysubway.notice.adapter.in.web;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -8,6 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.easysubway.admin.audit.adapter.out.persistence.InMemoryAdminAuditEventRepository;
+import com.easysubway.admin.audit.application.service.AdminAuditWriter;
 import com.easysubway.admin.audit.domain.AdminAuditEvent;
 import com.easysubway.admin.audit.domain.AdminAuditEventType;
 import com.easysubway.notice.application.port.out.ServiceNoticeRepository;
@@ -25,6 +30,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest(properties = {
@@ -43,10 +49,18 @@ class ServiceNoticeAdminApiControllerTest {
 	private JdbcTemplate jdbcTemplate;
 	@Autowired
 	private InMemoryAdminAuditEventRepository auditEventRepository;
+	@MockitoSpyBean
+	private AdminAuditWriter auditWriter;
 
 	@BeforeEach
 	void setUp() {
 		jdbcTemplate.update("DELETE FROM service_notice");
+	}
+
+	private void saveActiveNotice(String id) {
+		repository.save(new ServiceNotice(id, ServiceNoticeScope.ALL, null,
+			"전체 공지", "본문", ServiceNoticeSeverity.INFO,
+			LocalDateTime.now(ZoneOffset.UTC).minusHours(1), null, "operator-a"));
 	}
 
 	private boolean auditRecorded(String action, String targetId) {
@@ -80,19 +94,76 @@ class ServiceNoticeAdminApiControllerTest {
 	}
 
 	@Test
-	@DisplayName("즉시 내리기는 공지를 제거하고 audit에 기록한다")
-	void unpublishRemovesAndAudits() throws Exception {
-		repository.save(new ServiceNotice("n1", ServiceNoticeScope.ALL, null,
-			"전체 공지", "본문", ServiceNoticeSeverity.INFO,
-			LocalDateTime.now(java.time.ZoneOffset.UTC).minusHours(1), null, "operator-a"));
+	@DisplayName("게시 중단은 row를 보존하고 활성에서 제외하며 audit에 기록한다")
+	void unpublishSoftUnpublishesAndAudits() throws Exception {
+		saveActiveNotice("n1");
 
 		mockMvc.perform(post("/admin/notices/n1/unpublish")
 				.with(httpBasic("admin-user", "admin-test-password"))
 				.with(csrf()))
 			.andExpect(status().isOk());
 
-		assertThat(repository.findById("n1")).isEmpty();
+		ServiceNotice stored = repository.findById("n1").orElseThrow();
+		assertThat(stored.isUnpublished()).isTrue();
+		assertThat(stored.unpublishedBy()).isEqualTo("admin-user");
+		assertThat(repository.findActiveAt(LocalDateTime.now(ZoneOffset.UTC)))
+			.extracting(ServiceNotice::id).doesNotContain("n1");
 		assertThat(auditRecorded("UNPUBLISH_NOTICE", "n1")).isTrue();
+	}
+
+	@Test
+	@DisplayName("없는 공지 게시 중단은 404다")
+	void unpublishMissingNoticeNotFound() throws Exception {
+		mockMvc.perform(post("/admin/notices/missing/unpublish")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf()))
+			.andExpect(status().isNotFound());
+
+		assertThat(auditRecorded("UNPUBLISH_NOTICE", "missing")).isFalse();
+	}
+
+	@Test
+	@DisplayName("두 번째 게시 중단은 409이고 audit을 남기지 않는다")
+	void secondUnpublishConflicts() throws Exception {
+		saveActiveNotice("n1");
+
+		mockMvc.perform(post("/admin/notices/n1/unpublish")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf()))
+			.andExpect(status().isOk());
+
+		mockMvc.perform(post("/admin/notices/n1/unpublish")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf()))
+			.andExpect(status().isConflict());
+
+		long unpublishAudits = auditEventRepository
+			.findRecent(AdminAuditEventType.ADMIN_ACTION, 100).stream()
+			.filter(event -> "SERVICE_NOTICE".equals(event.targetType())
+				&& "UNPUBLISH_NOTICE".equals(event.action())
+				&& "n1".equals(event.targetId()))
+			.count();
+		assertThat(unpublishAudits).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("audit append가 실패하면 게시 중단 상태도 함께 rollback된다")
+	void auditFailureRollsBackUnpublish() {
+		saveActiveNotice("n1");
+		doThrow(new RuntimeException("audit down"))
+			.when(auditWriter)
+			.noticeChange(any(), any(), eq("n1"), eq("UNPUBLISH_NOTICE"), any(), any());
+
+		assertThatThrownBy(() -> mockMvc.perform(post("/admin/notices/n1/unpublish")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf()))
+			.andReturn())
+			.hasRootCauseMessage("audit down");
+
+		ServiceNotice stored = repository.findById("n1").orElseThrow();
+		assertThat(stored.isUnpublished()).isFalse();
+		assertThat(repository.findActiveAt(LocalDateTime.now(ZoneOffset.UTC)))
+			.extracting(ServiceNotice::id).contains("n1");
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/notice/adapter/in/web/ServiceNoticeAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/notice/adapter/in/web/ServiceNoticeAdminPageControllerTest.java
@@ -96,8 +96,50 @@ class ServiceNoticeAdminPageControllerTest {
 			.andExpect(status().is3xxRedirection())
 			.andExpect(redirectedUrl("/admin/notices/page"));
 
-		assertThat(repository.findById(noticeId)).isEmpty();
+		var stored = repository.findById(noticeId).orElseThrow();
+		assertThat(stored.isUnpublished()).isTrue();
+		assertThat(repository.findActiveAt(LocalDateTime.now(ZoneOffset.UTC)))
+			.extracting(com.easysubway.notice.domain.ServiceNotice::id)
+			.doesNotContain(noticeId);
 		assertThat(auditRecorded("UNPUBLISH_NOTICE", noticeId)).isTrue();
+
+		String historyPage = mockMvc.perform(get("/admin/notices/page")
+				.with(operationsManager()))
+			.andExpect(status().isOk())
+			.andReturn().getResponse().getContentAsString();
+		assertThat(historyPage).contains("2호선 지연");
+	}
+
+	@Test
+	@DisplayName("두 번째 게시 중단은 409로 닫는다")
+	void secondUnpublishRejectedAsConflict() throws Exception {
+		mockMvc.perform(post("/admin/notices/page")
+				.with(csrf())
+				.with(commandToken())
+				.with(operationsManager())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("scope", "ALL")
+				.param("severity", "INFO")
+				.param("title", "전체 공지")
+				.param("body", "본문"))
+			.andExpect(status().is3xxRedirection());
+
+		String noticeId = repository.findActiveAt(LocalDateTime.now(ZoneOffset.UTC))
+			.getFirst().id();
+
+		mockMvc.perform(post("/admin/notices/{id}/unpublish/page", noticeId)
+				.with(csrf())
+				.with(commandToken())
+				.with(operationsManager())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED))
+			.andExpect(status().is3xxRedirection());
+
+		mockMvc.perform(post("/admin/notices/{id}/unpublish/page", noticeId)
+				.with(csrf())
+				.with(commandToken())
+				.with(operationsManager())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED))
+			.andExpect(status().isConflict());
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/notice/adapter/out/persistence/JdbcServiceNoticeRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/notice/adapter/out/persistence/JdbcServiceNoticeRepositoryTest.java
@@ -76,10 +76,41 @@ class JdbcServiceNoticeRepositoryTest {
 	}
 
 	@Test
-	@DisplayName("deleteById는 공지를 제거한다")
-	void deletes() {
+	@DisplayName("unpublish는 row를 보존하고 게시 중단 상태를 왕복한다")
+	void unpublishKeepsRowAndPersistsState() {
 		repository.save(notice("n3", ServiceNoticeSeverity.INFO, NOW.minusHours(1), null));
-		repository.deleteById("n3");
-		assertThat(repository.findById("n3")).isEmpty();
+
+		boolean flipped = repository.unpublish("n3", NOW, "operator-b");
+
+		assertThat(flipped).isTrue();
+		ServiceNotice stored = repository.findById("n3").orElseThrow();
+		assertThat(stored.isUnpublished()).isTrue();
+		assertThat(stored.unpublishedAt()).isEqualTo(NOW);
+		assertThat(stored.unpublishedBy()).isEqualTo("operator-b");
+	}
+
+	@Test
+	@DisplayName("게시 중단된 공지는 findActiveAt에서 빠지지만 findRecent에는 남는다")
+	void unpublishedExcludedFromActiveButKeptInRecent() {
+		repository.save(notice("n4", ServiceNoticeSeverity.INFO, NOW.minusHours(1), null));
+		repository.unpublish("n4", NOW, "operator-b");
+
+		assertThat(repository.findActiveAt(NOW)).extracting(ServiceNotice::id).doesNotContain("n4");
+		assertThat(repository.findRecent(50)).extracting(ServiceNotice::id).contains("n4");
+	}
+
+	@Test
+	@DisplayName("두 번째 unpublish는 바뀐 row가 없어 false를 준다")
+	void secondUnpublishReturnsFalse() {
+		repository.save(notice("n5", ServiceNoticeSeverity.INFO, NOW.minusHours(1), null));
+
+		assertThat(repository.unpublish("n5", NOW, "operator-b")).isTrue();
+		assertThat(repository.unpublish("n5", NOW.plusHours(1), "operator-c")).isFalse();
+	}
+
+	@Test
+	@DisplayName("없는 공지 unpublish는 false를 준다")
+	void unpublishMissingReturnsFalse() {
+		assertThat(repository.unpublish("missing", NOW, "operator-b")).isFalse();
 	}
 }

--- a/backend/src/test/java/com/easysubway/notice/application/service/ServiceNoticeServiceTest.java
+++ b/backend/src/test/java/com/easysubway/notice/application/service/ServiceNoticeServiceTest.java
@@ -1,7 +1,10 @@
 package com.easysubway.notice.application.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.easysubway.common.error.ConflictException;
+import com.easysubway.common.error.ResourceNotFoundException;
 import com.easysubway.notice.application.port.out.ServiceNoticeRepository;
 import com.easysubway.notice.domain.ServiceNotice;
 import com.easysubway.notice.domain.ServiceNoticeScope;
@@ -53,8 +56,16 @@ class ServiceNoticeServiceTest {
 		}
 
 		@Override
-		public void deleteById(String id) {
-			stored.removeIf(n -> n.id().equals(id));
+		public boolean unpublish(String id, LocalDateTime unpublishedAt, String unpublishedBy) {
+			ServiceNotice existing = stored.stream()
+				.filter(n -> n.id().equals(id))
+				.findFirst()
+				.orElse(null);
+			if (existing == null || existing.isUnpublished()) {
+				return false;
+			}
+			save(existing.unpublish(unpublishedAt, unpublishedBy));
+			return true;
 		}
 	}
 
@@ -95,8 +106,8 @@ class ServiceNoticeServiceTest {
 	}
 
 	@Test
-	@DisplayName("즉시 내리기는 해당 공지를 제거한다")
-	void unpublishRemovesNotice() {
+	@DisplayName("게시 중단은 row를 보존하고 활성 조회에서만 제외한다")
+	void unpublishKeepsRowButHidesFromActive() {
 		ServiceNotice published = service.publish(
 			new PublishNoticeCommand(
 				ServiceNoticeScope.ALL, null, "전체", "본문",
@@ -105,8 +116,52 @@ class ServiceNoticeServiceTest {
 			"operator-a"
 		);
 
-		service.unpublish(published.id());
+		service.unpublish(published.id(), "operator-b");
 
-		assertThat(repository.findById(published.id())).isEmpty();
+		ServiceNotice stored = repository.findById(published.id()).orElseThrow();
+		assertThat(stored.isUnpublished()).isTrue();
+		assertThat(stored.unpublishedBy()).isEqualTo("operator-b");
+		assertThat(stored.unpublishedAt()).isEqualTo(NOW);
+		assertThat(service.activeNotices()).isEmpty();
+	}
+
+	@Test
+	@DisplayName("게시 중단된 공지도 최근 이력 조회에는 남는다")
+	void unpublishedNoticeStaysInHistory() {
+		ServiceNotice published = service.publish(
+			new PublishNoticeCommand(
+				ServiceNoticeScope.ALL, null, "전체", "본문",
+				ServiceNoticeSeverity.INFO, null
+			),
+			"operator-a"
+		);
+
+		service.unpublish(published.id(), "operator-b");
+
+		assertThat(repository.findRecent(50)).extracting(ServiceNotice::id)
+			.contains(published.id());
+	}
+
+	@Test
+	@DisplayName("없는 공지 게시 중단은 404(ResourceNotFoundException)")
+	void unpublishMissingNoticeNotFound() {
+		assertThatThrownBy(() -> service.unpublish("missing", "operator-a"))
+			.isInstanceOf(ResourceNotFoundException.class);
+	}
+
+	@Test
+	@DisplayName("두 번째 게시 중단은 409(ConflictException)")
+	void secondUnpublishConflicts() {
+		ServiceNotice published = service.publish(
+			new PublishNoticeCommand(
+				ServiceNoticeScope.ALL, null, "전체", "본문",
+				ServiceNoticeSeverity.INFO, null
+			),
+			"operator-a"
+		);
+		service.unpublish(published.id(), "operator-b");
+
+		assertThatThrownBy(() -> service.unpublish(published.id(), "operator-c"))
+			.isInstanceOf(ConflictException.class);
 	}
 }

--- a/backend/src/test/java/com/easysubway/notice/domain/ServiceNoticeTest.java
+++ b/backend/src/test/java/com/easysubway/notice/domain/ServiceNoticeTest.java
@@ -77,4 +77,57 @@ class ServiceNoticeTest {
 		);
 		assertThat(notice.scopeValue()).isNull();
 	}
+
+	@Test
+	@DisplayName("새로 만든 공지는 게시 중단 상태가 아니다")
+	void freshNoticeIsNotUnpublished() {
+		ServiceNotice notice = notice(PUBLISHED, EXPIRES);
+		assertThat(notice.isUnpublished()).isFalse();
+		assertThat(notice.unpublishedAt()).isNull();
+		assertThat(notice.unpublishedBy()).isNull();
+	}
+
+	@Test
+	@DisplayName("게시 중단은 상태만 남기고 원장 필드는 보존한다")
+	void unpublishRetainsOriginalFields() {
+		ServiceNotice notice = notice(PUBLISHED, null);
+		LocalDateTime at = LocalDateTime.parse("2026-07-06T13:00:00");
+
+		ServiceNotice unpublished = notice.unpublish(at, "operator-b");
+
+		assertThat(unpublished.isUnpublished()).isTrue();
+		assertThat(unpublished.unpublishedAt()).isEqualTo(at);
+		assertThat(unpublished.unpublishedBy()).isEqualTo("operator-b");
+		assertThat(unpublished.id()).isEqualTo(notice.id());
+		assertThat(unpublished.publishedBy()).isEqualTo(notice.publishedBy());
+		assertThat(unpublished.publishedAt()).isEqualTo(notice.publishedAt());
+	}
+
+	@Test
+	@DisplayName("게시 중단된 공지는 창(window) 안이라도 활성이 아니다")
+	void unpublishedNoticeIsNeverActive() {
+		ServiceNotice notice = notice(PUBLISHED, EXPIRES)
+			.unpublish(LocalDateTime.parse("2026-07-06T13:00:00"), "operator-b");
+		assertThat(notice.isActiveAt(LocalDateTime.parse("2026-07-06T14:00:00"))).isFalse();
+	}
+
+	@Test
+	@DisplayName("이미 게시 중단된 공지는 다시 게시 중단할 수 없다")
+	void doubleUnpublishRejected() {
+		ServiceNotice unpublished = notice(PUBLISHED, null)
+			.unpublish(LocalDateTime.parse("2026-07-06T13:00:00"), "operator-b");
+		assertThatThrownBy(() -> unpublished.unpublish(
+			LocalDateTime.parse("2026-07-06T14:00:00"), "operator-c"))
+			.isInstanceOf(IllegalStateException.class);
+	}
+
+	@Test
+	@DisplayName("unpublishedAt과 unpublishedBy는 함께 있거나 함께 없어야 한다")
+	void unpublishStateMustBeConsistent() {
+		assertThatThrownBy(() -> new ServiceNotice(
+			"n1", ServiceNoticeScope.ALL, null, "제목", "본문",
+			ServiceNoticeSeverity.INFO, PUBLISHED, null, "operator-a",
+			LocalDateTime.parse("2026-07-06T13:00:00"), null))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
 }


### PR DESCRIPTION
## 관련 이슈

close #2275
Refs #2271

## 작업 배경

- 운행 공지 게시 중단을 row 삭제로 표현하면 게시 이력 조회, audit 원자성, API/page 오류 결과가 서로 어긋난다.
- 게시 중단은 원장을 지우지 않고 상태만 바꾸는 soft-unpublish여야 하며, REST와 page가 같은 결과(미존재 404, 이미 중단 409)를 돌려줘야 한다.

## 작업 내용

- `ServiceNotice` 도메인에 `unpublishedAt`·`unpublishedBy`를 추가하고, 게시 중단 상태를 남기되 원장 필드를 보존하는 `unpublish(at, by)` 전이와 `isUnpublished()`를 더했다. 활성 판정(`isActiveAt`)은 게시 중단된 공지를 항상 제외한다. 기존 9-인자 생성자는 보조 생성자로 그대로 유지해 발행·저장 왕복 계약을 깨지 않는다.
- 영속 포트에서 `deleteById`를 compare-and-set 기반 `unpublish(id, at, by)`(활성 row만 갱신, row 삭제 없음)로 교체했다. JDBC 구현은 `unpublished_at IS NULL` 조건으로만 갱신해 두 번째 게시 중단이 0 row를 만들고, `findActiveAt`는 `unpublished_at IS NULL`을 필터하며, `findRecent`는 게시 중단 공지도 이력으로 남긴다.
- `ServiceNoticeService.unpublish(id, unpublishedBy)`가 미존재는 404(`ResourceNotFoundException`), 이미 게시 중단·경합 패배는 409(`ConflictException`)를 던지도록 하고, API/page 컨트롤러가 이 단일 경로를 공유하도록 정리했다.
- 상태 update와 audit append를 같은 transaction으로 묶었다. page 컨트롤러는 기존 `@Transactional`을 유지하고, API 컨트롤러 게시 중단 핸들러에 `@Transactional`을 추가해 audit append 실패 시 게시 중단 상태도 함께 rollback된다.
- Flyway `V66__service_notice_lifecycle.sql`을 postgresql/h2 양쪽에 추가했다. issue는 V65를 예상했으나 착수 시점 postgresql 다음 번호가 V66이라(V65 선점: `V65__train_search_cache.sql`) 두 dialect 모두 V66으로 맞췄다.
- 기존 notice ID, active interval `[start,end)`, public active 조회, 관리자 permission·route·CSRF 계약은 그대로 유지한다.

## 검증

- 실행한 명령과 결과:
  - `node tools/ci/api-catalog.mjs validate` → exit 0 (`API catalog valid: 245`)
  - `LC_ALL=C.UTF-8 node --test tools/ci/repository-contract.test.mjs` → exit 0 (tests 218, fail 0)
  - `npm test --prefix tools/qa` → exit 0 (tests 8, fail 0)
  - `cd backend && ./gradlew test --tests 'com.easysubway.notice.domain.ServiceNoticeTest' --tests 'com.easysubway.notice.application.service.ServiceNoticeServiceTest' --tests 'com.easysubway.notice.adapter.out.persistence.JdbcServiceNoticeRepositoryTest' --tests 'com.easysubway.notice.adapter.in.web.ServiceNoticeAdminApiControllerTest' --tests 'com.easysubway.notice.adapter.in.web.ServiceNoticeAdminPageControllerTest'` → BUILD SUCCESSFUL (H2)
  - `cd backend && ./gradlew test --tests 'com.easysubway.common.persistence.DatabaseMigrationContainerTest'` → BUILD SUCCESSFUL (Testcontainers PostgreSQL 16, postgresql migration 체인 V66 포함 적용)

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 두 번째 게시 중단 409 | H2 (SpringBootTest) | `ServiceNoticeAdminApiControllerTest#secondUnpublishConflicts`, `ServiceNoticeAdminPageControllerTest#secondUnpublishRejectedAsConflict` (tested SHA `b7fd50c2`) | 위 gradle 명령 BUILD SUCCESSFUL | 두 경로 모두 409, audit 1건만 기록 |
| 미존재 게시 중단 404 | H2 (SpringBootTest) | `ServiceNoticeAdminApiControllerTest#unpublishMissingNoticeNotFound`, 기존 `missingUnpublishRejectedAsNotFound` (SHA `b7fd50c2`) | 위 gradle 명령 | API/page 404, 성공 audit 없음 |
| audit 실패 시 상태 rollback | H2 (SpringBootTest) | `ServiceNoticeAdminApiControllerTest#auditFailureRollsBackUnpublish` (MockitoSpyBean로 audit throw) (SHA `b7fd50c2`) | 위 gradle 명령 | 예외 전파 후 공지가 활성으로 잔존(rollback) |
| 게시 이력 조회 가능 | H2 (SpringBootTest) | `ServiceNoticeServiceTest#unpublishedNoticeStaysInHistory`, page 이력 렌더 검증 (SHA `b7fd50c2`) | 위 gradle 명령 | 게시 중단 공지가 findRecent·최근 공지 화면에 잔존 |
| PostgreSQL lifecycle green | PostgreSQL 16 (Testcontainers + 수동 psql) | `DatabaseMigrationContainerTest` + `postgres:16-alpine`에 V45·V66 적용 후 lifecycle SQL 실행 (SHA `b7fd50c2`) | insert 후 active 조회 n1, 1차 CAS `UPDATE 1`, 2차 CAS `UPDATE 0`, active 조회 empty, 이력 조회 `n1\|op-b` 잔존 | H2와 동일 동작 확인 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [x] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음 (스키마 마이그레이션만 추가)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - transaction 경계: 상태 update와 audit append가 컨트롤러 `@Transactional` 하나로 묶여 있고, audit 실패 시 게시 중단이 함께 rollback되는지(`ServiceNoticeAdminApiController#unpublish` + `ServiceNoticeService#unpublish`).
  - 404/409 판정: 미존재→404, 이미 중단·경합 패배→409가 서비스 한 곳에서 결정돼 API/page가 동일 경로를 공유하는지.
  - migration 번호: V65 선점으로 두 dialect 모두 V66로 정합. rollback은 컬럼 추가 되돌리기(`unpublished_at`, `unpublished_by` drop).

## 리스크

- soft-unpublish 전환으로 `service_notice`에 컬럼 2개(`unpublished_at`, `unpublished_by`)가 추가된다. rollback 경계는 두 컬럼 drop이며, 기존 row는 `unpublished_at IS NULL`로 활성 의미가 보존된다.
- 게시 중단 공지가 원장에 누적된다(설계 의도: 이력 보존). 보관 정책 변경은 본 이슈 범위 밖(#12 Non-scope)이다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
