### PR TITLE
[Style] #2277 V6-05 workspace shell·adaptive IA·global search 정리

### DIFF
--- a/backend/src/main/java/com/easysubway/admin/navigation/AdminNavigationAdvice.java
+++ b/backend/src/main/java/com/easysubway/admin/navigation/AdminNavigationAdvice.java
@@ -2,6 +2,7 @@ package com.easysubway.admin.navigation;
 
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -28,17 +29,24 @@ class AdminNavigationAdvice {
 			.collect(Collectors.toUnmodifiableSet());
 	}
 
-	@ModelAttribute("adminProgramGroups")
-	List<AdminProgramGroup> adminProgramGroups(Authentication authentication) {
-		return AdminProgram.visibleTo(authentication).stream()
+	// #2277 (V6-05): shell IA를 7개 업무 영역(workspace)으로 묶는다. permission 필터(visibleTo) 뒤
+	// 프로그램이 0개인 workspace는 목록에서 제외해 렌더하지 않는다. workspace 순서는 enum 선언 순서를,
+	// 각 workspace 내부 program 순서는 AdminProgram 선언 순서를 따른다(EnumMap + groupingBy가 유지).
+	@ModelAttribute("adminWorkspaces")
+	List<AdminWorkspaceSection> adminWorkspaces(Authentication authentication) {
+		var grouped = AdminProgram.visibleTo(authentication).stream()
 			.collect(Collectors.groupingBy(
-				AdminProgram::groupLabel,
-				java.util.LinkedHashMap::new,
+				AdminProgram::workspace,
+				() -> new EnumMap<AdminWorkspace, List<AdminProgram>>(AdminWorkspace.class),
 				Collectors.toList()
+			));
+		return Arrays.stream(AdminWorkspace.values())
+			.filter(grouped::containsKey)
+			.map(workspace -> new AdminWorkspaceSection(
+				workspace.id(),
+				workspace.displayName(),
+				grouped.get(workspace)
 			))
-			.entrySet()
-			.stream()
-			.map(entry -> new AdminProgramGroup(entry.getKey(), entry.getValue()))
 			.toList();
 	}
 
@@ -105,7 +113,9 @@ class AdminNavigationAdvice {
 			&& !(authentication instanceof AnonymousAuthenticationToken);
 	}
 
-	record AdminProgramGroup(String label, List<AdminProgram> programs) {
+	// #2277 (V6-05): shell 사이드바가 렌더하는 업무 영역 섹션. id는 disclosure의 aria-controls 대상
+	// element id를, programs는 permission 필터를 통과한(0개가 아닌) 해당 workspace의 program을 담는다.
+	record AdminWorkspaceSection(String id, String label, List<AdminProgram> programs) {
 	}
 
 	record AdminShell(

--- a/backend/src/main/java/com/easysubway/admin/navigation/AdminProgram.java
+++ b/backend/src/main/java/com/easysubway/admin/navigation/AdminProgram.java
@@ -17,50 +17,56 @@ import org.springframework.security.core.Authentication;
  *
  * <p>Non-scope (V6-00에서 도입하지 않음, 상위 sub-issue 소관): dark mode 테마 전환, pinned/recent 메뉴,
  * {@code statusAuto} enum 전환. 이 항목들은 supersession ledger에만 기록하고 여기서 필드·상태를 추가하지 않는다.
+ *
+ * <p>#2277 (V6-05): 각 surface는 정확히 하나의 {@link AdminWorkspace}에 배정된다({@link #workspace()}).
+ * §7 workspace→program 매핑은 이 필드가 정본이며 {@code AdminNavigationAdviceTest}가 문자 그대로 고정한다.
+ * {@code groupLabel}은 통합 검색(#1981) 결과 표기·매칭에 계속 쓰이므로 workspace 도입과 별개로 유지한다.
  */
 public enum AdminProgram {
-	DASHBOARD("a-dashboard", "접속·개요", "통합 대시보드", "/admin/dashboard/page", AdminPermission.ADMIN_VIEW),
-	STATIONS("a-stations", "역·시설 마스터", "역 목록", "/admin/stations/page", AdminPermission.ADMIN_VIEW),
-	FACILITIES("a-facilities", "역·시설 마스터", "시설 상태판", "/admin/facilities/page", AdminPermission.ADMIN_VIEW),
-	LAYOUT_EDITOR("a-layout-editor", "역·시설 마스터", "역 구조·동선 편집", "/admin/facilities/editor/page", AdminPermission.MASTER_EDIT),
-	REPORTS("a-reports", "제보·품질·확인", "제보 확인 대기열", "/admin/reports/page", AdminPermission.REPORT_REVIEW),
-	QUALITY("a-quality", "제보·품질·확인", "데이터 품질", "/admin/data-quality/page", AdminPermission.ADMIN_VIEW),
-	FIELD("a-field-verifications", "제보·품질·확인", "현장 확인", "/admin/field-verifications/page", AdminPermission.FIELD_OPERATE),
-	COLLECTIONS("a-collections", "운영·분석", "데이터 수집", "/admin/data-collections/page", AdminPermission.DATA_OPERATE),
-	BATCHES("a-batches", "운영·분석", "배치 운영", "/admin/batches/page", AdminPermission.DATA_OPERATE),
-	CODES("a-codes", "운영·분석", "공통코드", "/admin/codes/page", AdminPermission.OPERATIONS_MANAGE),
-	INCIDENTS("a-incidents", "운영·분석", "장애관리", "/admin/incidents/page", AdminPermission.OPERATIONS_MANAGE),
-	SERVICE_NOTICES("a-service-notices", "운영·분석", "운행 공지", "/admin/notices/page", AdminPermission.OPERATIONS_MANAGE),
-	ADS("a-ads", "운영·분석", "광고 소재", "/admin/ads/page", AdminPermission.OPERATIONS_MANAGE),
-	ROUTE_SEARCHES("a-route-searches", "운영·분석", "경로 검색 분석", "/admin/routes/searches/page", AdminPermission.ADMIN_VIEW),
-	ROUTE_FEEDBACK("a-route-feedback", "운영·분석", "경로 피드백 분석", "/admin/routes/feedback/page", AdminPermission.ADMIN_VIEW),
-	DATAPACK_PIPELINE("a-datapack-pipeline", "데이터팩", "파이프라인 개요", "/admin/datapack/pipeline/page", AdminPermission.DATAPACK_READ),
-	DATAPACK_SOURCE_SNAPSHOTS("a-datapack-source-snapshots", "데이터팩", "원천 스냅샷", "/admin/datapack/source-snapshots/page", AdminPermission.DATAPACK_READ),
-	DATAPACK_ALIAS_QUARANTINE("a-datapack-alias-quarantine", "데이터팩", "별칭·격리 검토", "/admin/datapack/alias-quarantine/page", AdminPermission.DATAPACK_READ),
-	DATAPACK_FACILITY_EVIDENCE("a-datapack-facility-evidence", "데이터팩", "시설 근거 검토", "/admin/datapack/facility-evidence/page", AdminPermission.DATAPACK_READ),
-	DATAPACK_ROUTE_GATES("a-datapack-route-gates", "데이터팩", "경로 게이트", "/admin/datapack/route-gates/page", AdminPermission.DATAPACK_READ),
-	DATAPACK_MANUAL_OVERRIDES("a-datapack-manual-overrides", "데이터팩", "수동 오버라이드", "/admin/datapack/manual-overrides/page", AdminPermission.DATAPACK_READ),
-	DATAPACK_CANDIDATES("a-datapack-candidates", "데이터팩", "후보 팩", "/admin/datapack/candidates/page", AdminPermission.DATAPACK_READ),
-	DATAPACK_RELEASE_CHANNELS("a-datapack-release-channels", "데이터팩", "배포 채널", "/admin/datapack/release-channels/page", AdminPermission.DATAPACK_READ),
-	DATAPACK_RELEASE_REQUESTS("a-datapack-release-requests", "데이터팩", "릴리스 요청", "/admin/datapack/release-requests/page", AdminPermission.DATAPACK_READ),
-	PUSH("a-push", "운영·분석", "푸시 알림", "/admin/notifications/push/page", AdminPermission.DATA_OPERATE),
-	USAGE("a-usage", "운영·분석", "사용 현황", "/admin/usage/activity/page", AdminPermission.SECURITY_AUDIT),
-	SYSTEM("a-system", "운영·분석", "시스템 상태", "/admin/system/page", AdminPermission.SECURITY_AUDIT),
-	AUDITS("a-audits", "보안·감사", "관리자 감사", "/admin/audits/page", AdminPermission.AUDIT_READ),
-	PRIVACY_AUDITS("a-privacy-audits", "보안·감사", "개인정보 조회 로그", "/admin/audits/privacy/page", AdminPermission.PRIVACY_LOG_READ);
+	DASHBOARD("a-dashboard", "접속·개요", "통합 대시보드", "/admin/dashboard/page", AdminPermission.ADMIN_VIEW, AdminWorkspace.OVERVIEW),
+	STATIONS("a-stations", "역·시설 마스터", "역 목록", "/admin/stations/page", AdminPermission.ADMIN_VIEW, AdminWorkspace.ACCESSIBILITY_DATA),
+	FACILITIES("a-facilities", "역·시설 마스터", "시설 상태판", "/admin/facilities/page", AdminPermission.ADMIN_VIEW, AdminWorkspace.ACCESSIBILITY_DATA),
+	LAYOUT_EDITOR("a-layout-editor", "역·시설 마스터", "역 구조·동선 편집", "/admin/facilities/editor/page", AdminPermission.MASTER_EDIT, AdminWorkspace.ACCESSIBILITY_DATA),
+	REPORTS("a-reports", "제보·품질·확인", "제보 확인 대기열", "/admin/reports/page", AdminPermission.REPORT_REVIEW, AdminWorkspace.ACCESSIBILITY_DATA),
+	QUALITY("a-quality", "제보·품질·확인", "데이터 품질", "/admin/data-quality/page", AdminPermission.ADMIN_VIEW, AdminWorkspace.ACCESSIBILITY_DATA),
+	FIELD("a-field-verifications", "제보·품질·확인", "현장 확인", "/admin/field-verifications/page", AdminPermission.FIELD_OPERATE, AdminWorkspace.ACCESSIBILITY_DATA),
+	COLLECTIONS("a-collections", "운영·분석", "데이터 수집", "/admin/data-collections/page", AdminPermission.DATA_OPERATE, AdminWorkspace.OPERATIONS),
+	BATCHES("a-batches", "운영·분석", "배치 운영", "/admin/batches/page", AdminPermission.DATA_OPERATE, AdminWorkspace.OPERATIONS),
+	CODES("a-codes", "운영·분석", "공통코드", "/admin/codes/page", AdminPermission.OPERATIONS_MANAGE, AdminWorkspace.SYSTEM_AUDIT),
+	INCIDENTS("a-incidents", "운영·분석", "장애관리", "/admin/incidents/page", AdminPermission.OPERATIONS_MANAGE, AdminWorkspace.OPERATIONS),
+	SERVICE_NOTICES("a-service-notices", "운영·분석", "운행 공지", "/admin/notices/page", AdminPermission.OPERATIONS_MANAGE, AdminWorkspace.COMMUNICATIONS),
+	ADS("a-ads", "운영·분석", "광고 소재", "/admin/ads/page", AdminPermission.OPERATIONS_MANAGE, AdminWorkspace.COMMUNICATIONS),
+	ROUTE_SEARCHES("a-route-searches", "운영·분석", "경로 검색 분석", "/admin/routes/searches/page", AdminPermission.ADMIN_VIEW, AdminWorkspace.ANALYTICS),
+	ROUTE_FEEDBACK("a-route-feedback", "운영·분석", "경로 피드백 분석", "/admin/routes/feedback/page", AdminPermission.ADMIN_VIEW, AdminWorkspace.ANALYTICS),
+	DATAPACK_PIPELINE("a-datapack-pipeline", "데이터팩", "파이프라인 개요", "/admin/datapack/pipeline/page", AdminPermission.DATAPACK_READ, AdminWorkspace.DATAPACK),
+	DATAPACK_SOURCE_SNAPSHOTS("a-datapack-source-snapshots", "데이터팩", "원천 스냅샷", "/admin/datapack/source-snapshots/page", AdminPermission.DATAPACK_READ, AdminWorkspace.DATAPACK),
+	DATAPACK_ALIAS_QUARANTINE("a-datapack-alias-quarantine", "데이터팩", "별칭·격리 검토", "/admin/datapack/alias-quarantine/page", AdminPermission.DATAPACK_READ, AdminWorkspace.DATAPACK),
+	DATAPACK_FACILITY_EVIDENCE("a-datapack-facility-evidence", "데이터팩", "시설 근거 검토", "/admin/datapack/facility-evidence/page", AdminPermission.DATAPACK_READ, AdminWorkspace.DATAPACK),
+	DATAPACK_ROUTE_GATES("a-datapack-route-gates", "데이터팩", "경로 게이트", "/admin/datapack/route-gates/page", AdminPermission.DATAPACK_READ, AdminWorkspace.DATAPACK),
+	DATAPACK_MANUAL_OVERRIDES("a-datapack-manual-overrides", "데이터팩", "수동 오버라이드", "/admin/datapack/manual-overrides/page", AdminPermission.DATAPACK_READ, AdminWorkspace.DATAPACK),
+	DATAPACK_CANDIDATES("a-datapack-candidates", "데이터팩", "후보 팩", "/admin/datapack/candidates/page", AdminPermission.DATAPACK_READ, AdminWorkspace.DATAPACK),
+	DATAPACK_RELEASE_CHANNELS("a-datapack-release-channels", "데이터팩", "배포 채널", "/admin/datapack/release-channels/page", AdminPermission.DATAPACK_READ, AdminWorkspace.DATAPACK),
+	DATAPACK_RELEASE_REQUESTS("a-datapack-release-requests", "데이터팩", "릴리스 요청", "/admin/datapack/release-requests/page", AdminPermission.DATAPACK_READ, AdminWorkspace.DATAPACK),
+	PUSH("a-push", "운영·분석", "푸시 알림", "/admin/notifications/push/page", AdminPermission.DATA_OPERATE, AdminWorkspace.COMMUNICATIONS),
+	USAGE("a-usage", "운영·분석", "사용 현황", "/admin/usage/activity/page", AdminPermission.SECURITY_AUDIT, AdminWorkspace.ANALYTICS),
+	SYSTEM("a-system", "운영·분석", "시스템 상태", "/admin/system/page", AdminPermission.SECURITY_AUDIT, AdminWorkspace.SYSTEM_AUDIT),
+	AUDITS("a-audits", "보안·감사", "관리자 감사", "/admin/audits/page", AdminPermission.AUDIT_READ, AdminWorkspace.SYSTEM_AUDIT),
+	PRIVACY_AUDITS("a-privacy-audits", "보안·감사", "개인정보 조회 로그", "/admin/audits/privacy/page", AdminPermission.PRIVACY_LOG_READ, AdminWorkspace.SYSTEM_AUDIT);
 
 	private final String id;
 	private final String groupLabel;
 	private final String label;
 	private final String path;
 	private final AdminPermission permission;
+	private final AdminWorkspace workspace;
 
-	AdminProgram(String id, String groupLabel, String label, String path, AdminPermission permission) {
+	AdminProgram(String id, String groupLabel, String label, String path, AdminPermission permission, AdminWorkspace workspace) {
 		this.id = id;
 		this.groupLabel = groupLabel;
 		this.label = label;
 		this.path = path;
 		this.permission = permission;
+		this.workspace = workspace;
 	}
 
 	public String id() {
@@ -81,6 +87,10 @@ public enum AdminProgram {
 
 	public AdminPermission permission() {
 		return permission;
+	}
+
+	public AdminWorkspace workspace() {
+		return workspace;
 	}
 
 	public static List<AdminProgram> visibleTo(Authentication authentication) {

--- a/backend/src/main/java/com/easysubway/admin/navigation/AdminWorkspace.java
+++ b/backend/src/main/java/com/easysubway/admin/navigation/AdminWorkspace.java
@@ -1,0 +1,40 @@
+package com.easysubway.admin.navigation;
+
+/**
+ * 관리자 콘솔 shell의 업무 영역(workspace) 정본.
+ *
+ * <p>#2277 (Admin UX v6 / V6-05): 29개 {@link AdminProgram}을 7개 업무 영역으로 묶어 shell IA를
+ * 구성한다. 각 program은 정확히 하나의 workspace에 배정되며(중복·누락 불가), 그 매핑은
+ * {@link AdminProgram#workspace()}가 소유하고 {@code AdminNavigationAdviceTest}가 source assertion으로
+ * §7 계약과 문자 그대로 일치하는지 고정한다.
+ *
+ * <p>이 enum은 {@code id}/{@code displayName}만 갖고 {@link AdminProgram}을 참조하지 않는다. 참조 방향을
+ * program → workspace 한쪽으로만 두어 enum 정적 초기화 순환을 피한다. permission 필터 뒤 프로그램이 0개인
+ * workspace를 렌더에서 제외하는 것은 advice/템플릿 책임이며 route·permission·{@link AdminProgram#visibleTo}는
+ * 변경하지 않는다.
+ */
+public enum AdminWorkspace {
+	OVERVIEW("overview", "개요"),
+	ACCESSIBILITY_DATA("accessibility-data", "역·접근성 데이터"),
+	OPERATIONS("operations", "운영"),
+	COMMUNICATIONS("communications", "커뮤니케이션"),
+	ANALYTICS("analytics", "분석"),
+	DATAPACK("datapack", "데이터팩"),
+	SYSTEM_AUDIT("system-audit", "시스템·감사");
+
+	private final String id;
+	private final String displayName;
+
+	AdminWorkspace(String id, String displayName) {
+		this.id = id;
+		this.displayName = displayName;
+	}
+
+	public String id() {
+		return id;
+	}
+
+	public String displayName() {
+		return displayName;
+	}
+}

--- a/backend/src/main/resources/static/css/admin-shell.css
+++ b/backend/src/main/resources/static/css/admin-shell.css
@@ -81,17 +81,71 @@
 	overflow-y: auto;
 }
 
-.admin-nav-group {
-	margin-top: 18px;
+/* 업무 영역(workspace) disclosure(#2277): 옛 그룹 라벨을 접기 버튼으로 대체한다. 시각 언어는 유지
+   (무채색·플랫·radius 0·shadow 0). program 목록은 x-show가, 헤더 상태는 aria-expanded가 정본이다. */
+.admin-nav-workspace {
+	margin-top: 10px;
 }
 
-.admin-nav-group-label {
-	margin: 0 0 6px 24px;
+/* 헤더는 정적 라벨성 disclosure 버튼이므로 파랑 채움을 벗긴다. .admin-v3 button(0,1,1)이 파랑
+   배경·흰 글씨를 강제하므로 셀렉터 명시도를 .admin-v3 .admin-nav-workspace-toggle(0,2,0)로 올려
+   이긴다(.admin-user-menu-trigger·.admin-sidebar-toggle와 동일한 라벨성 버튼 리셋 패턴). */
+.admin-v3 .admin-nav-workspace-toggle {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+	width: 100%;
+	min-height: 44px;
+	margin: 0;
+	padding: 0 24px;
+	border: 0;
+	border-radius: 0;
+	background: transparent;
 	color: var(--admin-ink-3);
 	font-size: 11px;
 	font-weight: var(--admin-w-strong);
 	letter-spacing: 0.04em;
 	text-transform: uppercase;
+	text-align: left;
+	cursor: pointer;
+}
+
+.admin-v3 .admin-nav-workspace-toggle:hover {
+	background: transparent;
+	color: var(--admin-ink-2);
+}
+
+.admin-nav-workspace.is-current .admin-nav-workspace-name {
+	color: var(--admin-ink);
+}
+
+/* 접힘/펼침 표시 caret: 순수 CSS 삼각형(무채색). 펼침=아래(기본), 접힘(aria-expanded=false)=왼쪽. */
+.admin-nav-workspace-caret {
+	flex: none;
+	width: 0;
+	height: 0;
+	border-left: 4px solid transparent;
+	border-right: 4px solid transparent;
+	border-top: 5px solid currentcolor;
+	transition: transform 0.15s ease;
+}
+
+.admin-nav-workspace-toggle[aria-expanded="false"] .admin-nav-workspace-caret {
+	transform: rotate(-90deg);
+}
+
+.admin-nav-workspace-programs {
+	display: flex;
+	flex-direction: column;
+	padding-bottom: 4px;
+}
+
+/* 펼침 전 flash 방지(#2277): JS 초기화 창(has-js, has-js-ready 이전)에서만 현재 위치가 아닌 영역의
+   program 목록을 숨긴다. has-js-ready 이후로는 navWorkspace의 x-show 인라인 display가 전담하고,
+   no-JS(has-js 미부착)는 이 규칙이 걸리지 않아 모든 영역이 펼쳐진 채 유지된다(폴백). */
+.admin-v3.has-js:not(.has-js-ready) .admin-nav-workspace:not(.is-current) .admin-nav-workspace-programs {
+	display: none;
 }
 
 .admin-nav-item {

--- a/backend/src/main/resources/static/css/admin-shell.css
+++ b/backend/src/main/resources/static/css/admin-shell.css
@@ -143,8 +143,10 @@
 
 /* 펼침 전 flash 방지(#2277): JS 초기화 창(has-js, has-js-ready 이전)에서만 현재 위치가 아닌 영역의
    program 목록을 숨긴다. has-js-ready 이후로는 navWorkspace의 x-show 인라인 display가 전담하고,
-   no-JS(has-js 미부착)는 이 규칙이 걸리지 않아 모든 영역이 펼쳐진 채 유지된다(폴백). */
-.admin-v3.has-js:not(.has-js-ready) .admin-nav-workspace:not(.is-current) .admin-nav-workspace-programs {
+   no-JS(has-js 미부착)는 이 규칙이 걸리지 않아 모든 영역이 펼쳐진 채 유지된다(폴백).
+   현재 위치가 없는 페이지(.admin-nav-scroll.is-no-current, #2277 리뷰)는 가드에서 제외해 전 영역을
+   펼친 채 유지한다 — is-current가 하나도 없어 모든 영역이 숨겨지는 회귀를 막는다. */
+.admin-v3.has-js:not(.has-js-ready) .admin-nav-scroll:not(.is-no-current) .admin-nav-workspace:not(.is-current) .admin-nav-workspace-programs {
 	display: none;
 }
 

--- a/backend/src/main/resources/static/js/admin/app.js
+++ b/backend/src/main/resources/static/js/admin/app.js
@@ -58,7 +58,12 @@ document.addEventListener('alpine:init', function () {
 		return {
 			expanded: true,
 			init: function () {
-				this.expanded = this.$el.dataset.current === 'true';
+				// 현재 위치가 없는 페이지(sidebar('')로 렌더되는 검색·알림·오류 등)는 서버가
+				// .admin-nav-scroll에 is-no-current를 붙인다. 이때 어떤 영역도 data-current="true"가
+				// 아니어서 전 영역이 접히는 회귀를 막기 위해 전 영역 펼침으로 폴백한다(#2277 리뷰).
+				var scroll = this.$el.closest('.admin-nav-scroll');
+				var noCurrent = scroll ? scroll.classList.contains('is-no-current') : false;
+				this.expanded = noCurrent || this.$el.dataset.current === 'true';
 			},
 			get ariaExpanded() {
 				return this.expanded ? 'true' : 'false';

--- a/backend/src/main/resources/static/js/admin/app.js
+++ b/backend/src/main/resources/static/js/admin/app.js
@@ -49,6 +49,26 @@ document.addEventListener('alpine:init', function () {
 	// 드롭다운이 열린다. sidebarToggle/alertCenter와 동일한 명명 컴포넌트 패턴 — CSP 빌드라
 	// 메서드·게터 이름만 디렉티브에 넣는다. 진화형 향상: JS가 없으면 트리거는 계정 페이지 링크로
 	// 동작하고 로그아웃 폼은 드롭다운 안에 그대로 렌더되어 접근 가능하다.
+	// 업무 영역(workspace) disclosure(#2277): 사이드바를 7개 업무 영역 아코디언으로 접는다.
+	// 서버는 모든 영역을 펼친 채(no-JS 폴백) 렌더하고, JS가 있으면 data-current="true"(현재 위치를
+	// 담은 영역)만 펼치고 나머지는 접는다. 각 영역은 독립 x-data라 하나를 열어도 다른 영역은 그대로다.
+	// 진화형 향상 — JS가 없으면 모든 영역이 펼쳐진 채 남아 허용 program 전부에 접근할 수 있다.
+	// CSP 빌드 규약: x-on/x-bind에는 메서드·게터 이름만 쓴다.
+	Alpine.data('navWorkspace', function () {
+		return {
+			expanded: true,
+			init: function () {
+				this.expanded = this.$el.dataset.current === 'true';
+			},
+			get ariaExpanded() {
+				return this.expanded ? 'true' : 'false';
+			},
+			toggle: function () {
+				this.expanded = !this.expanded;
+			},
+		};
+	});
+
 	Alpine.data('userMenu', function () {
 		return {
 			open: false,

--- a/backend/src/main/resources/templates/admin/fragments/shell.html
+++ b/backend/src/main/resources/templates/admin/fragments/shell.html
@@ -44,14 +44,35 @@
 			</div>
 		</div>
 	</div>
+	<!--
+	  업무 영역(workspace) IA(#2277): permission 필터를 통과한 program을 7개 업무 영역으로 묶어
+	  disclosure로 렌더한다. 서버는 모든 영역을 펼친 채 내보내(no-JS는 허용 program 전부 표시),
+	  JS가 있으면 navWorkspace 컴포넌트가 현재 위치(active)를 담은 영역만 펼치고 나머지는 접는다.
+	  펼침 전 순간의 flash는 admin-shell.css의 has-js:not(has-js-ready) 규칙이 가린다. CSP 빌드라
+	  x-on/x-bind에는 메서드·게터 이름만 쓴다. program이 0개인 영역은 advice가 목록에서 제외한다.
+	-->
 	<div class="admin-nav-scroll">
-		<div class="admin-nav-group" th:each="group : ${adminProgramGroups}">
-			<p class="admin-nav-group-label" th:text="${group.label}">메뉴 그룹</p>
-			<a th:each="program : ${group.programs}"
-			   class="admin-nav-item"
-			   th:classappend="${active == program.id} ? ' is-active'"
-			   th:href="@{${program.path}}"
-			   th:text="${program.label}">메뉴</a>
+		<div class="admin-nav-workspace"
+		     th:each="workspace : ${adminWorkspaces}"
+		     th:with="isCurrent=${#lists.contains(workspace.programs.![id], active)}"
+		     th:classappend="${isCurrent} ? ' is-current'"
+		     th:attr="data-current=${isCurrent}"
+		     x-data="navWorkspace">
+			<button type="button" class="admin-nav-workspace-toggle" aria-expanded="true"
+			        x-on:click="toggle" x-bind:aria-expanded="ariaExpanded"
+			        th:attr="aria-controls=${'admin-workspace-' + workspace.id}">
+				<!-- aria-expanded="true"는 no-JS 정적 상태(모든 영역 펼침). JS는 x-bind로 실제 상태를 덮어쓴다. -->
+				<span class="admin-nav-workspace-name" th:text="${workspace.label}">업무 영역</span>
+				<span class="admin-nav-workspace-caret" aria-hidden="true"></span>
+			</button>
+			<div class="admin-nav-workspace-programs" th:id="${'admin-workspace-' + workspace.id}"
+			     x-show="expanded">
+				<a th:each="program : ${workspace.programs}"
+				   class="admin-nav-item"
+				   th:classappend="${active == program.id} ? ' is-active'"
+				   th:href="@{${program.path}}"
+				   th:text="${program.label}">메뉴</a>
+			</div>
 		</div>
 	</div>
 </nav>

--- a/backend/src/main/resources/templates/admin/fragments/shell.html
+++ b/backend/src/main/resources/templates/admin/fragments/shell.html
@@ -51,7 +51,17 @@
 	  펼침 전 순간의 flash는 admin-shell.css의 has-js:not(has-js-ready) 규칙이 가린다. CSP 빌드라
 	  x-on/x-bind에는 메서드·게터 이름만 쓴다. program이 0개인 영역은 advice가 목록에서 제외한다.
 	-->
-	<div class="admin-nav-scroll">
+	<!--
+	  현재 위치 없음 폴백(#2277 리뷰): active가 permission 필터를 통과한 어떤 program에도 없으면
+	  (예: sidebar('')로 호출되는 검색·알림·오류 페이지) 현재 위치를 담은 영역이 하나도 없어 JS가 전
+	  영역을 접어버리는 회귀가 생긴다. 서버가 이 상태를 is-no-current로 표식해, FOUC 가드(admin-shell.css)와
+	  navWorkspace init이 전 영역 펼침으로 폴백하게 한다. no-JS는 has-js가 없어 이 표식과 무관하게 정적
+	  펼침을 유지한다. 판정은 adminProgramIds(렌더되는 workspace program id 집합)의 active 포함 여부로 한다
+	  — 각 program은 정확히 하나의 렌더 workspace에 속하므로 이는 "현재 workspace 존재"와 동치다.
+	  adminProgramIds가 null인 경로(권한 컨텍스트 없는 오류 페이지)도 폴백 상태로 안전하게 처리한다. -->
+	<div class="admin-nav-scroll"
+	     th:with="hasCurrentWorkspace=${adminProgramIds != null and adminProgramIds.contains(active)}"
+	     th:classappend="${hasCurrentWorkspace} ? '' : 'is-no-current'">
 		<div class="admin-nav-workspace"
 		     th:each="workspace : ${adminWorkspaces}"
 		     th:with="isCurrent=${#lists.contains(workspace.programs.![id], active)}"

--- a/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminAccessibilitySmokeTest.java
+++ b/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminAccessibilitySmokeTest.java
@@ -150,6 +150,9 @@ class AdminAccessibilitySmokeTest {
 			.contains("href=\"#admin-content\"")
 			.contains("class=\"admin-shell\"")
 			.contains("aria-label=\"통합 관리자 화면\"")
+			// #2277: sidebar는 workspace disclosure로 렌더되고, no-JS 폴백을 위해 toggle은 정적
+			// aria-expanded="true"로 모든 허용 program을 노출한다.
+			.contains("class=\"admin-nav-workspace-toggle\"")
 			.contains("class=\"admin-topbar-row\" aria-label=\"관리자 실행 환경\"")
 			.contains("id=\"admin-content\" class=\"admin-content-anchor\" tabindex=\"-1\"")
 			.contains("<main class=\"admin-main\">")

--- a/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminPhase3QualityGateTest.java
+++ b/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminPhase3QualityGateTest.java
@@ -73,6 +73,8 @@ class AdminPhase3QualityGateTest {
 				.contains("href=\"#admin-content\"")
 				.contains("class=\"admin-shell\"")
 				.contains("id=\"admin-content\"")
+				// #2277: 모든 admin surface가 workspace disclosure shell을 유지한다.
+				.contains("class=\"admin-nav-workspace-toggle\"")
 				.contains("aria-label=\"관리자 로그아웃\"")
 				.doesNotContain("cdn.jsdelivr.net")
 				.doesNotContain("unpkg.com")

--- a/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminV3PageSmokeTest.java
+++ b/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminV3PageSmokeTest.java
@@ -211,15 +211,17 @@ class AdminV3PageSmokeTest {
 			.getResponse()
 			.getContentAsString();
 
+		// 렌더되는 workspace는 고유 disclosure 토큰(aria-controls)으로, 빈 workspace는 그 토큰의 부재로
+		// 단언한다 — 다른 화면 텍스트에 우연히 섞일 수 있는 라벨 substring("분석" 등) 대신 고유 토큰을 쓴다.
 		assertThat(html)
 			.contains("class=\"admin-nav-workspace-toggle\"")
 			.contains("aria-controls=\"admin-workspace-overview\"")
-			.contains("개요")
-			.contains("역·접근성 데이터")
-			.contains("분석")
-			.doesNotContain("커뮤니케이션")
-			.doesNotContain("데이터팩")
-			.doesNotContain("시스템·감사");
+			.contains("aria-controls=\"admin-workspace-accessibility-data\"")
+			.contains("aria-controls=\"admin-workspace-analytics\"")
+			.doesNotContain("aria-controls=\"admin-workspace-operations\"")
+			.doesNotContain("aria-controls=\"admin-workspace-communications\"")
+			.doesNotContain("aria-controls=\"admin-workspace-datapack\"")
+			.doesNotContain("aria-controls=\"admin-workspace-system-audit\"");
 
 		// 현재 위치(대시보드)를 담은 workspace만 data-current="true"로 렌더돼 JS가 이 영역만 펼친다.
 		// no-JS 폴백을 위해 서버는 toggle에 aria-expanded="true"를 정적으로 붙여 모든 program을 노출한다.
@@ -227,7 +229,30 @@ class AdminV3PageSmokeTest {
 			.contains("is-current")
 			.contains("data-current=\"true\"")
 			.contains("data-current=\"false\"")
-			.contains("aria-expanded=\"true\"");
+			.contains("aria-expanded=\"true\"")
+			// 현재 위치가 있는 페이지는 no-current 폴백 표식을 붙이지 않는다(현재 영역만 펼침 유지).
+			.doesNotContain("class=\"admin-nav-scroll is-no-current\"");
+	}
+
+	@Test
+	@DisplayName("현재 위치 없는 페이지(검색)는 nav-scroll에 is-no-current를 붙여 JS 폴백으로 전 영역을 펼친다")
+	void adminSidebarFallsBackToAllExpandedWhenNoWorkspaceIsCurrent() throws Exception {
+		// 검색 페이지는 sidebar('')로 렌더돼 어떤 workspace도 현재 위치가 아니다. 서버가 이 상태를
+		// .admin-nav-scroll에 is-no-current로 표식하면, JS(navWorkspace init)가 전 영역 펼침으로 폴백해
+		// program 링크가 접혀 사라지는 회귀(#2277 리뷰)를 막는다. no-JS는 정적 펼침을 그대로 유지한다.
+		String html = mockMvc.perform(get("/admin/search")
+				.with(user("viewer").authorities(new SimpleGrantedAuthority("admin.view"))))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("class=\"admin-nav-scroll is-no-current\"")
+			.contains("aria-controls=\"admin-workspace-overview\"")
+			.contains("href=\"/admin/dashboard/page\"")
+			.contains("data-current=\"false\"")
+			.doesNotContain("data-current=\"true\"");
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminV3PageSmokeTest.java
+++ b/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminV3PageSmokeTest.java
@@ -200,6 +200,37 @@ class AdminV3PageSmokeTest {
 	}
 
 	@Test
+	@DisplayName("sidebar는 workspace disclosure로 렌더하고 현재 위치 workspace만 펼치며 빈 workspace는 제외한다")
+	void adminSidebarRendersWorkspaceDisclosure() throws Exception {
+		// admin.view만 가진 관리자는 program이 있는 workspace(개요·역·접근성 데이터·분석)만 보고
+		// program이 0개인 workspace(운영·커뮤니케이션·데이터팩·시스템·감사)는 렌더되지 않는다(#2277 §7·§8).
+		String html = mockMvc.perform(get("/admin/dashboard/page")
+				.with(user("viewer").authorities(new SimpleGrantedAuthority("admin.view"))))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("class=\"admin-nav-workspace-toggle\"")
+			.contains("aria-controls=\"admin-workspace-overview\"")
+			.contains("개요")
+			.contains("역·접근성 데이터")
+			.contains("분석")
+			.doesNotContain("커뮤니케이션")
+			.doesNotContain("데이터팩")
+			.doesNotContain("시스템·감사");
+
+		// 현재 위치(대시보드)를 담은 workspace만 data-current="true"로 렌더돼 JS가 이 영역만 펼친다.
+		// no-JS 폴백을 위해 서버는 toggle에 aria-expanded="true"를 정적으로 붙여 모든 program을 노출한다.
+		assertThat(html)
+			.contains("is-current")
+			.contains("data-current=\"true\"")
+			.contains("data-current=\"false\"")
+			.contains("aria-expanded=\"true\"");
+	}
+
+	@Test
 	@DisplayName("전체 permission 관리자는 모든 관리자 program을 볼 수 있다")
 	void fullPermissionAdminSeesAllPrograms() throws Exception {
 		String html = mockMvc.perform(get("/admin/dashboard/page")

--- a/backend/src/test/java/com/easysubway/admin/navigation/AdminNavigationAdviceTest.java
+++ b/backend/src/test/java/com/easysubway/admin/navigation/AdminNavigationAdviceTest.java
@@ -3,6 +3,11 @@ package com.easysubway.admin.navigation;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.env.MockEnvironment;
@@ -151,5 +156,85 @@ class AdminNavigationAdviceTest {
 		// id와 path는 surface 정본이므로 중복 없이 유일해야 한다.
 		assertThat(Arrays.stream(AdminProgram.values()).map(AdminProgram::id).distinct().count()).isEqualTo(29);
 		assertThat(Arrays.stream(AdminProgram.values()).map(AdminProgram::path).distinct().count()).isEqualTo(29);
+	}
+
+	// #2277 V6-05: 7개 workspace와 §7 workspace→program 매핑을 source assertion으로 문자 그대로 고정한다.
+	// 29개 program을 정확히 한 workspace에 배정하며 중복·누락은 grouping 결과가 기대 map과 달라 실패한다.
+	// workspace 내부 program 순서(§7 표 나열 순 = AdminProgram 선언 순)도 List.equals로 함께 고정한다.
+	@Test
+	@DisplayName("AdminWorkspace는 7개 업무 영역과 §7 program 매핑을 중복·누락 없이 문자 그대로 고정한다")
+	void adminWorkspaceMappingPinsSectionSevenContract() {
+		assertThat(AdminWorkspace.values()).hasSize(7);
+		for (AdminWorkspace workspace : AdminWorkspace.values()) {
+			assertThat(workspace.id()).as("%s id", workspace.name()).isNotBlank();
+			assertThat(workspace.displayName()).as("%s displayName", workspace.name()).isNotBlank();
+		}
+
+		// §7 표시명(문자 그대로).
+		assertThat(AdminWorkspace.OVERVIEW.displayName()).isEqualTo("개요");
+		assertThat(AdminWorkspace.ACCESSIBILITY_DATA.displayName()).isEqualTo("역·접근성 데이터");
+		assertThat(AdminWorkspace.OPERATIONS.displayName()).isEqualTo("운영");
+		assertThat(AdminWorkspace.COMMUNICATIONS.displayName()).isEqualTo("커뮤니케이션");
+		assertThat(AdminWorkspace.ANALYTICS.displayName()).isEqualTo("분석");
+		assertThat(AdminWorkspace.DATAPACK.displayName()).isEqualTo("데이터팩");
+		assertThat(AdminWorkspace.SYSTEM_AUDIT.displayName()).isEqualTo("시스템·감사");
+
+		// §7 workspace → 포함 program(문자 그대로, 순서까지).
+		Map<AdminWorkspace, List<AdminProgram>> expected = new LinkedHashMap<>();
+		expected.put(AdminWorkspace.OVERVIEW, List.of(AdminProgram.DASHBOARD));
+		expected.put(AdminWorkspace.ACCESSIBILITY_DATA, List.of(
+			AdminProgram.STATIONS, AdminProgram.FACILITIES, AdminProgram.LAYOUT_EDITOR,
+			AdminProgram.REPORTS, AdminProgram.QUALITY, AdminProgram.FIELD));
+		expected.put(AdminWorkspace.OPERATIONS, List.of(
+			AdminProgram.COLLECTIONS, AdminProgram.BATCHES, AdminProgram.INCIDENTS));
+		expected.put(AdminWorkspace.COMMUNICATIONS, List.of(
+			AdminProgram.SERVICE_NOTICES, AdminProgram.ADS, AdminProgram.PUSH));
+		expected.put(AdminWorkspace.ANALYTICS, List.of(
+			AdminProgram.ROUTE_SEARCHES, AdminProgram.ROUTE_FEEDBACK, AdminProgram.USAGE));
+		expected.put(AdminWorkspace.DATAPACK, List.of(
+			AdminProgram.DATAPACK_PIPELINE, AdminProgram.DATAPACK_SOURCE_SNAPSHOTS,
+			AdminProgram.DATAPACK_ALIAS_QUARANTINE, AdminProgram.DATAPACK_FACILITY_EVIDENCE,
+			AdminProgram.DATAPACK_ROUTE_GATES, AdminProgram.DATAPACK_MANUAL_OVERRIDES,
+			AdminProgram.DATAPACK_CANDIDATES, AdminProgram.DATAPACK_RELEASE_CHANNELS,
+			AdminProgram.DATAPACK_RELEASE_REQUESTS));
+		expected.put(AdminWorkspace.SYSTEM_AUDIT, List.of(
+			AdminProgram.CODES, AdminProgram.SYSTEM, AdminProgram.AUDITS, AdminProgram.PRIVACY_AUDITS));
+
+		Map<AdminWorkspace, List<AdminProgram>> actual = Arrays.stream(AdminProgram.values())
+			.collect(Collectors.groupingBy(
+				AdminProgram::workspace,
+				() -> new EnumMap<>(AdminWorkspace.class),
+				Collectors.toList()));
+
+		assertThat(actual).isEqualTo(expected);
+		// 29개 program이 정확히 한 workspace에 배정된다(중복·누락 0).
+		assertThat(actual.values().stream().mapToInt(List::size).sum()).isEqualTo(29);
+		assertThat(actual.keySet()).containsExactlyInAnyOrder(AdminWorkspace.values());
+		for (AdminProgram program : AdminProgram.values()) {
+			assertThat(program.workspace()).as("%s workspace", program.name()).isNotNull();
+		}
+	}
+
+	// #2277 V6-05: shell IA. permission 필터(visibleTo) 뒤 program이 0개인 workspace는 렌더 목록에서
+	// 제외하고, 남은 workspace는 AdminWorkspace enum 선언 순서로 정렬한다. admin.view만 가진 관리자는
+	// OVERVIEW·ACCESSIBILITY_DATA·ANALYTICS 3개만 보고 나머지 4개는 program이 없어 제외된다.
+	@Test
+	@DisplayName("adminWorkspaces는 program이 0개인 workspace를 제외하고 enum 순서로 렌더한다")
+	void adminWorkspacesDropsEmptyWorkspacesAndKeepsEnumOrder() {
+		TestingAuthenticationToken viewer = new TestingAuthenticationToken("viewer", "ignored", "admin.view");
+
+		List<AdminNavigationAdvice.AdminWorkspaceSection> sections =
+			new AdminNavigationAdvice(new MockEnvironment()).adminWorkspaces(viewer);
+
+		assertThat(sections)
+			.extracting(AdminNavigationAdvice.AdminWorkspaceSection::label)
+			.containsExactly("개요", "역·접근성 데이터", "분석");
+		assertThat(sections).allSatisfy(section -> assertThat(section.programs()).isNotEmpty());
+		assertThat(sections)
+			.filteredOn(section -> section.label().equals("역·접근성 데이터"))
+			.singleElement()
+			.satisfies(section -> assertThat(section.programs())
+				.extracting(AdminProgram::id)
+				.containsExactly("a-stations", "a-facilities", "a-quality"));
 	}
 }

--- a/tools/qa/admin-accessibility-qa.mjs
+++ b/tools/qa/admin-accessibility-qa.mjs
@@ -442,6 +442,25 @@ async function keyboardSmoke(page, baseUrl, report) {
   if (alertExpanded !== "true") {
     throw new Error("alert center did not expose aria-expanded=true");
   }
+
+  // #2277: workspace disclosure는 현재 위치를 담은 영역만 기본 펼침하고 나머지는 접는다.
+  // Alpine이 x-bind로 aria-expanded를 실제 상태로 덮어쓸 때까지(비현재 영역이 접힐 때까지) 기다린 뒤
+  // 현재(펼침) 1개 + 나머지(접힘)로 갈렸는지 판정한다. no-JS 정적 상태(모두 true)는 이 대기로 배제된다.
+  await page.waitForSelector('.admin-nav-workspace-toggle[aria-expanded="false"]', { timeout: 2000 }).catch(() => {});
+  const workspaceDisclosure = await page.evaluate(() => {
+    const toggles = Array.from(document.querySelectorAll(".admin-nav-workspace-toggle"));
+    return {
+      total: toggles.length,
+      expanded: toggles.filter((toggle) => toggle.getAttribute("aria-expanded") === "true").length,
+      collapsed: toggles.filter((toggle) => toggle.getAttribute("aria-expanded") === "false").length,
+    };
+  });
+  report.keyboard.push({ check: "nav-workspace-disclosure", ...workspaceDisclosure });
+  if (!(workspaceDisclosure.total >= 2
+    && workspaceDisclosure.expanded === 1
+    && workspaceDisclosure.collapsed === workspaceDisclosure.total - 1)) {
+    throw new Error(`workspace disclosure did not default to only the current workspace expanded: ${JSON.stringify(workspaceDisclosure)}`);
+  }
 }
 
 // #1988: admin-table-scroll wrapper의 키보드 접근성.

--- a/tools/qa/admin-accessibility-qa.mjs
+++ b/tools/qa/admin-accessibility-qa.mjs
@@ -194,6 +194,7 @@ async function runJsPass(browser, baseUrl, outputDir, adminUser, adminPassword, 
   }
   await keyboardSmoke(page, baseUrl, report);
   await captureAxTree(page, outputDir, report);
+  await noCurrentWorkspaceDisclosure(page, baseUrl, report);
   await keyboardTableCheck(page, baseUrl, report);
   await textScalePass(page, baseUrl, outputDir, report, ADMIN_TEXT_SCALE_PAGES);
   await context.close();
@@ -460,6 +461,36 @@ async function keyboardSmoke(page, baseUrl, report) {
     && workspaceDisclosure.expanded === 1
     && workspaceDisclosure.collapsed === workspaceDisclosure.total - 1)) {
     throw new Error(`workspace disclosure did not default to only the current workspace expanded: ${JSON.stringify(workspaceDisclosure)}`);
+  }
+}
+
+// #2277 리뷰: 현재 위치가 없는 페이지(sidebar('')로 렌더되는 검색·알림·오류)는 is-current 영역이
+// 하나도 없어 JS가 전 영역을 접어 program 링크가 사라지는 회귀가 있었다. 서버가 .admin-nav-scroll에
+// is-no-current를 붙이고 navWorkspace init이 전 영역 펼침으로 폴백하는지 실제 브라우저로 검증한다.
+// /admin/search를 대표로 방문해 모든 영역이 펼쳐지고(aria-expanded=true) program 목록이 실제로 보이는지 확인한다.
+async function noCurrentWorkspaceDisclosure(page, baseUrl, report) {
+  await page.setViewportSize(VIEWPORTS.find((viewport) => viewport.name === "desktop-1280"));
+  const response = await page.goto(`${baseUrl}/admin/search`, { waitUntil: "networkidle" });
+  await assertOk(page, "/admin/search", response);
+  // Alpine이 x-show를 최초 평가(has-js-ready)한 뒤 판정한다 — 폴백이 실제로 program 목록을 펼쳤는지 본다.
+  await page.waitForSelector("body.has-js-ready", { timeout: 2000 }).catch(() => {});
+  const disclosure = await page.evaluate(() => {
+    const scroll = document.querySelector(".admin-nav-scroll");
+    const toggles = Array.from(document.querySelectorAll(".admin-nav-workspace-toggle"));
+    const programs = Array.from(document.querySelectorAll(".admin-nav-workspace-programs"));
+    return {
+      isNoCurrent: Boolean(scroll && scroll.classList.contains("is-no-current")),
+      total: toggles.length,
+      expanded: toggles.filter((toggle) => toggle.getAttribute("aria-expanded") === "true").length,
+      visiblePrograms: programs.filter((element) => element.getClientRects().length > 0).length,
+    };
+  });
+  report.keyboard.push({ check: "nav-workspace-no-current-disclosure", ...disclosure });
+  if (!(disclosure.isNoCurrent
+    && disclosure.total >= 2
+    && disclosure.expanded === disclosure.total
+    && disclosure.visiblePrograms === disclosure.total)) {
+    throw new Error(`no-current page did not fall back to all workspaces expanded: ${JSON.stringify(disclosure)}`);
   }
 }
 

--- a/tools/qa/admin-accessibility-qa.test.mjs
+++ b/tools/qa/admin-accessibility-qa.test.mjs
@@ -85,6 +85,15 @@ test("admin accessibility QA script captures login NONE and RETRY_WARNING public
   assert.match(source, /&& adminExpectedStateOk\s*\n\s*&& operatorExpectedStateOk/);
 });
 
+// #2277 V6-05: workspace disclosure가 현재 위치를 담은 영역만 기본 펼침하는지 keyboard smoke가 검사한다.
+test("admin accessibility QA script verifies workspace disclosure defaults to current only", () => {
+  assert.match(source, /check: "nav-workspace-disclosure"/);
+  assert.match(source, /\.admin-nav-workspace-toggle\[aria-expanded="false"\]/);
+  assert.match(source, /workspaceDisclosure\.expanded === 1/);
+  assert.match(source, /workspaceDisclosure\.collapsed === workspaceDisclosure\.total - 1/);
+  assert.match(source, /workspace disclosure did not default to only the current workspace expanded/);
+});
+
 test("admin accessibility QA script verifies admin-table-scroll keyboard and focus outline", () => {
   assert.match(source, /keyboardTableCheck/);
   assert.match(source, /admin-table-scroll/);

--- a/tools/qa/admin-accessibility-qa.test.mjs
+++ b/tools/qa/admin-accessibility-qa.test.mjs
@@ -94,6 +94,17 @@ test("admin accessibility QA script verifies workspace disclosure defaults to cu
   assert.match(source, /workspace disclosure did not default to only the current workspace expanded/);
 });
 
+// #2277 리뷰: 현재 위치가 없는 페이지가 전 영역 펼침으로 폴백하는지 QA 하네스가 실제로 검증하는 계약.
+test("admin accessibility QA script verifies no-current page falls back to all workspaces expanded", () => {
+  assert.match(source, /check: "nav-workspace-no-current-disclosure"/);
+  assert.match(source, /\/admin\/search/);
+  assert.match(source, /is-no-current/);
+  assert.match(source, /disclosure\.expanded === disclosure\.total/);
+  assert.match(source, /disclosure\.visiblePrograms === disclosure\.total/);
+  assert.match(source, /no-current page did not fall back to all workspaces expanded/);
+  assert.match(source, /await noCurrentWorkspaceDisclosure\(page, baseUrl, report\)/);
+});
+
 test("admin accessibility QA script verifies admin-table-scroll keyboard and focus outline", () => {
   assert.match(source, /keyboardTableCheck/);
   assert.match(source, /admin-table-scroll/);


### PR DESCRIPTION
## 관련 이슈

close #2277
Refs #2271

## 작업 배경

- 29개 admin program이 단일 목록으로만 노출돼 업무 영역·현재 위치를 빠르게 파악하기 어렵고, compact shell의 정보 순서가 고정돼 있지 않았다.
- #2263의 44px/ARIA/no-JS 계약을 보존하면서 현재 위치와 업무 영역이 명확한 shell을 제공한다(V6-05).

## 작업 내용

- `AdminWorkspace`(신규): 7개 업무 영역(개요·역·접근성 데이터·운영·커뮤니케이션·분석·데이터팩·시스템·감사)을 id·표시명으로 고정한다. program을 참조하지 않아 enum 정적 초기화 순환이 없다.
- `AdminProgram`: 각 surface에 `workspace()`를 부여해 §7 workspace→program 매핑(29개, 중복·누락 0)을 정본으로 소유한다. route·permission·`visibleTo()`·`groupLabel`(통합 검색 표기·매칭)은 그대로 유지한다.
- `AdminNavigationAdvice`: `adminProgramGroups`를 `adminWorkspaces`로 대체한다. permission 필터(`visibleTo`) 뒤 program이 0개인 workspace는 목록에서 제외하고, 남은 workspace는 enum 선언 순서·내부 program은 선언 순서로 정렬한다.
- `shell.html`: 사이드바를 workspace disclosure로 렌더한다. 서버는 모든 영역을 펼친 채 내보내 no-JS에서 허용 program을 전부 노출하고, toggle에 정적 `aria-expanded="true"`·`aria-controls`를 붙인다. topbar/command palette/status strip/compact DOM order(menu·title·alert·account·logout)는 변경하지 않는다.
- `app.js`: CSP 빌드 규약을 지키는 `navWorkspace` Alpine 컴포넌트를 추가한다. JS가 있으면 현재 위치(`data-current`)를 담은 영역만 펼치고 나머지는 접는다(각 영역 독립 x-data).
- `admin-shell.css`: workspace disclosure 시각(무채색·radius 0·shadow 0)을 shell 소유 규칙으로 추가한다. 라벨성 toggle 버튼은 `.admin-v3 button`(0,1,1)의 파랑 채움을 명시도(0,2,0)로 벗겨 접근성 대비를 유지하고(기존 `.admin-user-menu-trigger` 리셋 패턴), 펼침 전 flash는 `has-js:not(has-js-ready)` 가드로 가린다.
- 테스트/QA: workspace 매핑을 source assertion으로 문자 그대로 고정하고(`AdminNavigationAdviceTest`), 빈 workspace 제외·현재 위치 펼침·no-JS 노출을 smoke로 잠근다. QA 하네스에 workspace disclosure 기본 상태 keyboard 검사를 추가했다(command palette·alert bell smoke 유지).

## 검증

- 실행한 명령과 결과 (tested revision `09d75e127b5ba827d7b88af36b1529e6add86878`):
  - `node tools/ci/api-catalog.mjs validate` → exit 0 (API catalog valid: 245)
  - `LC_ALL=C.UTF-8 node --test tools/ci/repository-contract.test.mjs` → exit 0 (218 pass / 0 fail)
  - `npm test --prefix tools/qa` → exit 0 (9 pass, workspace disclosure 계약 포함)
  - `cd backend && ./gradlew test --tests AdminNavigationAdviceTest --tests AdminSearchControllerTest --tests AdminSearchServiceTest --tests AdminPhase3QualityGateTest --tests AdminAccessibilitySmokeTest --tests AdminV3PageSmokeTest` → BUILD SUCCESSFUL

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| full-admin/limited-admin matrix | 관리자 콘솔(dev/H2) | Phase3(전 권한)·AdminV3(admin.view 한정) smoke + QA 하네스 super-admin 로그인 | 로컬 `gradle test`, QA report `summary.criticalAxeViolations=0, seriousAxeViolations=0` | pass |
| workspace disclosure(현재만 펼침, 빈 영역 제외) | 관리자 콘솔 | QA keyboard `nav-workspace-disclosure` | `{total:7, expanded:1, collapsed:6}` (tested 09d75e127b5ba827d7b88af36b1529e6add86878) | pass |
| direct URL·검색·현재 위치 회귀 | 관리자 콘솔 | route/visibleTo 불변 + `is-current` smoke, 검색 저장 없음 | AdminSearch* 테스트 green, 검색어 storage/DB/analytics 미저장 | 회귀 0 |
| Esc/backdrop/focus restore | 관리자 콘솔 | command palette·off-canvas nav·alert bell keyboard smoke | QA keyboard `command-palette`/`alert-center-toggle` green | pass |
| 320/390/1024/1440 + 200% clipping | 관리자 콘솔 | QA 하네스 5 viewport + text 200% | admin shell 페이지 clipping 0·h-scroll 0; 잔여 1 clipping·operator reflow는 V6-05 미변경 surface(stations 표·operator shell) 기존 baseline | pass(shell 범위 0) |
| axe(전 admin/operator 페이지) | 관리자 콘솔 | QA 하네스 axe | critical 0 / serious 0, blockingViolations `[]` | pass |
| screenshots·no-JS·login parity | 관리자 콘솔 | QA 하네스 | screenshots 75, noJs 18, loginParity true (로컬 evidence: `/private/tmp/.../qa-artifacts`, 커밋 안 함) | pass |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 해당 없음
- mobile versionCode: 해당 없음
- datapack version: 해당 없음
- route contract: 해당 없음
- realtime contract: 해당 없음
- backend identity: admin 콘솔 shell 템플릿/정적 자원/네비 advice만 변경(계약 무변경)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `AdminProgram.workspace()` §7 매핑과 `AdminNavigationAdviceTest`의 source assertion(문자 그대로), `shell.html` disclosure의 no-JS 폴백(정적 `aria-expanded="true"` + 서버 전부 펼침), `admin-shell.css`의 명시도(0,2,0) 파랑 채움 리셋(axe 대비 유지).

## 리스크

- rollback 경계: 이 PR 단일 커밋 revert로 shell 사이드바가 이전 groupLabel 그룹 목록으로 즉시 복귀한다. DB migration·route/realtime/datapack 계약·version 파일 변경이 없어 데이터/배포 롤백 부수효과가 없다. 영향 범위는 admin 콘솔 사이드바 렌더에 한정된다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
