### PR TITLE
[Style] #2278 V6-06 list toolbar·saved view·table region 공통 contract

### DIFF
--- a/backend/src/main/resources/static/css/admin-data.css
+++ b/backend/src/main/resources/static/css/admin-data.css
@@ -445,3 +445,80 @@
 		padding-top: 4px;
 	}
 }
+
+/* 목록 툴바 공통 계약(#2278 V6-06): 검색·필터·저장된 뷰·보기 설정을 하나의 toolbar 행으로 모은다.
+   list-toolbar.html fragment가 소비하는 데이터/목록 레이아웃 규칙이라 data 레이어가 소유한다(시각 언어 불변). */
+.admin-list-toolbar {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 12px;
+	align-items: center;
+	margin-bottom: 12px;
+}
+
+.admin-list-toolbar-search {
+	display: flex;
+	gap: 8px;
+	align-items: center;
+	margin: 0;
+}
+
+.admin-list-toolbar-search input[type="search"] {
+	flex: 1;
+	min-width: 0;
+}
+
+/* 필터·보기 설정 시트: wide(기본)에서는 인라인 노출, compact에서는 트리거로 여닫는 시트로 접는다.
+   시트 내용은 기본 노출이라 no-JS(트리거 x-cloak 숨김)에서도 form/link가 그대로 동작한다. */
+.admin-toolbar-sheet {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 12px;
+	align-items: center;
+}
+
+/* 시트 트리거는 wide에서 숨긴다(인라인 노출이라 불필요). compact + JS에서만 노출한다. */
+.admin-toolbar-sheet-trigger {
+	display: none;
+}
+
+/* 첫 식별자 열 외에 "필요한 action 열"만 우측 sticky로 고정하는 유틸리티(#2278 §7).
+   wrapper(.admin-table-scroll)만 가로 overflow를 소유한다는 계약을 그대로 따른다. */
+.admin-table-scroll th.cell-sticky-action,
+.admin-table-scroll td.cell-sticky-action:not([colspan]) {
+	position: sticky;
+	right: 0;
+	z-index: 2;
+	background: var(--admin-surface);
+}
+
+.admin-table-scroll thead th.cell-sticky-action {
+	z-index: 3;
+	background: var(--admin-header-bg);
+}
+
+/* compact: 필터·보기 설정을 시트로 접는다. JS가 있을 때만(has-js) 트리거를 노출하고 시트를 접어
+   direct control을 5개 이하로 유지한다. no-JS(has-js 미부착)는 시트 내용이 인라인으로 남는다. */
+@media (max-width: 768px) {
+	.admin-v3.has-js .admin-toolbar-sheet-trigger {
+		display: inline-flex;
+		min-height: 32px;
+		align-items: center;
+		padding: 0 12px;
+		border: 1px solid var(--admin-border);
+		border-radius: var(--admin-radius-control);
+		background: var(--admin-surface);
+		color: var(--admin-ink-2);
+		font-size: 13px;
+		cursor: pointer;
+	}
+
+	.admin-v3.has-js .admin-toolbar-sheet {
+		display: none;
+		flex-basis: 100%;
+	}
+
+	.admin-v3.has-js .admin-toolbar-sheet.is-open {
+		display: flex;
+	}
+}

--- a/backend/src/main/resources/static/css/admin-data.css
+++ b/backend/src/main/resources/static/css/admin-data.css
@@ -497,6 +497,17 @@
 	background: var(--admin-header-bg);
 }
 
+/* 첫 열 sticky와 동일 패턴(admin-components.css)으로 행 hover·선택 배경을 sticky action 열에도
+   동기화한다. 동기화하지 않으면 sticky 열만 hover/선택 배경이 어긋나 보인다(#2301 리뷰). */
+.admin-v3 .admin-table-scroll tbody tr:hover td.cell-sticky-action:not([colspan]) {
+	background: var(--admin-header-bg);
+}
+
+.admin-v3 .admin-table-scroll tbody tr[aria-selected="true"] td.cell-sticky-action:not([colspan]),
+.admin-v3 .admin-table-scroll tbody tr.is-selected td.cell-sticky-action:not([colspan]) {
+	background: var(--admin-accent-soft);
+}
+
 /* compact: 필터·보기 설정을 시트로 접는다. JS가 있을 때만(has-js) 트리거를 노출하고 시트를 접어
    direct control을 5개 이하로 유지한다. no-JS(has-js 미부착)는 시트 내용이 인라인으로 남는다. */
 @media (max-width: 768px) {

--- a/backend/src/main/resources/static/js/admin/app.js
+++ b/backend/src/main/resources/static/js/admin/app.js
@@ -546,4 +546,56 @@ document.addEventListener('alpine:init', function () {
 			},
 		};
 	});
+
+	// 목록 툴바 시트(#2278 V6-06): compact에서 필터·보기 설정을 시트로 여닫는다. 진화형 향상 —
+	// JS가 없으면 시트 트리거(x-cloak)는 숨고 시트 내용은 인라인으로 남아 form/link가 그대로 동작한다.
+	// userMenu와 동일한 포커스 정책: close()는 상태만 닫아 외부 클릭(x-on:click.outside) 시 포커스를
+	// 트리거로 빼앗지 않고(입력 미유실), Esc(closeFromKeyboard)로 닫을 때만 트리거로 포커스를 복원한다.
+	// 리스너는 Alpine 디렉티브(x-on)로만 선언해 컴포넌트가 교체될 때 자동 정리된다 — 수동 addEventListener나
+	// 폴링이 없어 htmx 부분 갱신으로 툴바가 다시 렌더돼도 리스너가 중복 등록되지 않는다.
+	// CSP 빌드 규약: x-on/x-bind에는 메서드·게터 이름만 쓴다.
+	Alpine.data('listToolbar', function () {
+		return {
+			filterOpen: false,
+			viewOpen: false,
+			get filterExpanded() {
+				return this.filterOpen ? 'true' : 'false';
+			},
+			get viewExpanded() {
+				return this.viewOpen ? 'true' : 'false';
+			},
+			get filterSheetClass() {
+				return this.filterOpen ? 'is-open' : '';
+			},
+			get viewSheetClass() {
+				return this.viewOpen ? 'is-open' : '';
+			},
+			toggleFilter: function () {
+				this.filterOpen = !this.filterOpen;
+			},
+			toggleView: function () {
+				this.viewOpen = !this.viewOpen;
+			},
+			closeFilter: function () {
+				this.filterOpen = false;
+			},
+			closeView: function () {
+				this.viewOpen = false;
+			},
+			closeFilterFromKeyboard: function () {
+				if (!this.filterOpen) {
+					return;
+				}
+				this.filterOpen = false;
+				this.$refs.filterTrigger?.focus();
+			},
+			closeViewFromKeyboard: function () {
+				if (!this.viewOpen) {
+					return;
+				}
+				this.viewOpen = false;
+				this.$refs.viewTrigger?.focus();
+			},
+		};
+	});
 });

--- a/backend/src/main/resources/templates/admin/fragments/list-toolbar.html
+++ b/backend/src/main/resources/templates/admin/fragments/list-toolbar.html
@@ -42,7 +42,7 @@
 	        aria-controls="admin-toolbar-filter-sheet">필터</button>
 	<div class="admin-toolbar-sheet admin-toolbar-filter-sheet" id="admin-toolbar-filter-sheet"
 	     role="group" aria-label="필터" x-bind:class="filterSheetClass"
-	     x-on:click.outside="closeFilter" x-on:keydown.escape="closeFilterFromKeyboard">
+	     x-on:click.outside="closeFilter" x-on:keydown.escape.window="closeFilterFromKeyboard">
 		<th:block th:if="${filters}" th:replace="${filters}"></th:block>
 	</div>
 
@@ -52,7 +52,7 @@
 	        aria-controls="admin-toolbar-view-sheet">보기 설정</button>
 	<div class="admin-toolbar-sheet admin-toolbar-view-sheet" id="admin-toolbar-view-sheet"
 	     role="group" aria-label="보기 설정" x-bind:class="viewSheetClass"
-	     x-on:click.outside="closeView" x-on:keydown.escape="closeViewFromKeyboard">
+	     x-on:click.outside="closeView" x-on:keydown.escape.window="closeViewFromKeyboard">
 		<th:block th:if="${viewSettings}" th:replace="${viewSettings}"></th:block>
 	</div>
 </div>

--- a/backend/src/main/resources/templates/admin/fragments/list-toolbar.html
+++ b/backend/src/main/resources/templates/admin/fragments/list-toolbar.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<title>관리자 목록 툴바</title>
+</head>
+<body>
+<!--
+  목록 툴바 공통 계약(V6-06 #2278): 검색·필터·저장된 뷰·보기 설정을 하나의 toolbar로 모은다.
+  - direct control은 5개 이하다: 검색 입력·검색 버튼·저장된 뷰·필터 시트 트리거·보기 설정 시트 트리거.
+  - compact(≤768px)에서는 필터·보기 설정을 시트로 접는다. 시트 트리거는 x-cloak라 JS가 없으면 숨고,
+    시트 내용(.admin-toolbar-sheet)은 그대로 인라인 노출돼 no-JS form/link 폴백이 유지된다.
+  - 시트는 x-on:click.outside(close)로 닫아도 상태만 바꾸고 입력을 버리지 않는다. Esc는 트리거로 포커스를 복원한다.
+  - 검색은 method=get form + hx-get으로 HTMX와 full request가 같은 URL·결과를 만든다. query parameter·sort·page
+    size는 hidden으로 보존해 검색이 다른 필터를 덮어쓰지 않는다.
+  - CSP 빌드 규약: x-on/x-bind에는 listToolbar 컴포넌트의 메서드·게터 이름만 넣는다(인라인 표현식 금지).
+  파라미터: basePath(GET/hx-get URL), resultsId(htmx target id), search(검색 필드 설정 map),
+  savedViews·filters·viewSettings(각 영역 마크업 fragment, 없으면 ~{} 전달).
+-->
+<div class="admin-list-toolbar" x-data="listToolbar" role="search"
+     aria-label="목록 검색·필터·보기 설정"
+     th:fragment="toolbar(basePath, resultsId, search, savedViews, filters, viewSettings)">
+	<!-- 1·2: 검색 입력 + 검색 버튼(항상 direct). keyword live search는 300ms debounce, no-JS는 form GET 제출. -->
+	<form class="admin-list-toolbar-search" method="get" th:action="@{${basePath}}"
+	      th:attr="hx-get=@{${basePath}},hx-target='#' + ${resultsId}"
+	      hx-swap="outerHTML" hx-push-url="true"
+	      hx-trigger="submit, keyup changed delay:300ms">
+		<input type="search" th:name="${search.name}" th:value="${search.value}"
+		       th:placeholder="${search.placeholder}" th:aria-label="${search.label}" autocomplete="off">
+		<th:block th:if="${search.hidden}">
+			<input type="hidden" th:each="param : ${search.hidden}"
+			       th:name="${param.key}" th:value="${param.value}">
+		</th:block>
+		<button type="submit">검색</button>
+	</form>
+
+	<!-- 3: 저장된 뷰(계정별 스냅샷). 적용은 htmx/no-JS 링크, 저장·기본·삭제는 command token + CSRF POST. -->
+	<th:block th:if="${savedViews}" th:replace="${savedViews}"></th:block>
+
+	<!-- 4: 필터 — wide에서는 인라인, compact에서는 시트로 접는다. 트리거는 x-cloak(no-JS 숨김). -->
+	<button type="button" class="admin-toolbar-sheet-trigger admin-toolbar-filter-trigger" x-cloak
+	        x-ref="filterTrigger" x-on:click="toggleFilter" x-bind:aria-expanded="filterExpanded"
+	        aria-controls="admin-toolbar-filter-sheet">필터</button>
+	<div class="admin-toolbar-sheet admin-toolbar-filter-sheet" id="admin-toolbar-filter-sheet"
+	     role="group" aria-label="필터" x-bind:class="filterSheetClass"
+	     x-on:click.outside="closeFilter" x-on:keydown.escape="closeFilterFromKeyboard">
+		<th:block th:if="${filters}" th:replace="${filters}"></th:block>
+	</div>
+
+	<!-- 5: 보기 설정 — 순수 표시 설정이라 검색 form 밖에 둔다. compact에서는 시트로 접는다. -->
+	<button type="button" class="admin-toolbar-sheet-trigger admin-toolbar-view-trigger" x-cloak
+	        x-ref="viewTrigger" x-on:click="toggleView" x-bind:aria-expanded="viewExpanded"
+	        aria-controls="admin-toolbar-view-sheet">보기 설정</button>
+	<div class="admin-toolbar-sheet admin-toolbar-view-sheet" id="admin-toolbar-view-sheet"
+	     role="group" aria-label="보기 설정" x-bind:class="viewSheetClass"
+	     x-on:click.outside="closeView" x-on:keydown.escape="closeViewFromKeyboard">
+		<th:block th:if="${viewSettings}" th:replace="${viewSettings}"></th:block>
+	</div>
+</div>
+</body>
+</html>

--- a/backend/src/main/resources/templates/admin/fragments/table-region.html
+++ b/backend/src/main/resources/templates/admin/fragments/table-region.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<title>관리자 표 영역</title>
+</head>
+<body>
+<!--
+  표 영역 공통 계약(V6-06 #2278): #2071 admin-table-scroll wrapper를 단일 contract로 소비한다.
+  - wrapper(.admin-table-scroll)만 가로 overflow를 소유한다(body·section·card는 overflow-x를 갖지 않는다).
+  - 첫 식별자 열(td/th:first-child)과 필요한 action 열(.cell-sticky-action)만 sticky다. sticky 규칙은
+    admin-components.css(첫 열)와 admin-data.css(action 열)가 소유하고 이 fragment는 마크업만 제공한다.
+  - 화면은 이 fragment에 caption(접근성 이름)·head(thead 행)·rows(tbody 행) 마크업을 넘겨 표를 구성한다.
+    JS/no-JS 모두 동일 마크업이라 진화형 향상과 무관하게 동작한다.
+  aria-label은 admin 표 접근성 가드(AdminDesignGuardTest)가 요구하는 표준 문구로 고정한다.
+-->
+<div class="admin-table-scroll" tabindex="0" role="group"
+     aria-label="가로로 스크롤 가능한 데이터 표" th:fragment="region(caption, head, rows)">
+<table>
+	<caption class="sr-only" th:text="${caption}">데이터 표</caption>
+	<thead th:insert="${head}">
+	<tr>
+		<th scope="col">식별자</th>
+	</tr>
+	</thead>
+	<tbody th:insert="${rows}">
+	<tr>
+		<td>행</td>
+	</tr>
+	</tbody>
+</table>
+</div>
+</body>
+</html>

--- a/backend/src/test/java/com/easysubway/admin/web/AdminDesignGuardTest.java
+++ b/backend/src/test/java/com/easysubway/admin/web/AdminDesignGuardTest.java
@@ -391,8 +391,8 @@ class AdminDesignGuardTest {
 			.contains("aria-controls=\"admin-toolbar-view-sheet\"")
 			.contains("x-on:click.outside=\"closeFilter\"")
 			.contains("x-on:click.outside=\"closeView\"")
-			.contains("x-on:keydown.escape=\"closeFilterFromKeyboard\"")
-			.contains("x-on:keydown.escape=\"closeViewFromKeyboard\"")
+			.contains("x-on:keydown.escape.window=\"closeFilterFromKeyboard\"")
+			.contains("x-on:keydown.escape.window=\"closeViewFromKeyboard\"")
 			.contains("x-bind:class=\"filterSheetClass\"")
 			.contains("x-bind:class=\"viewSheetClass\"");
 

--- a/backend/src/test/java/com/easysubway/admin/web/AdminDesignGuardTest.java
+++ b/backend/src/test/java/com/easysubway/admin/web/AdminDesignGuardTest.java
@@ -327,6 +327,91 @@ class AdminDesignGuardTest {
 			.contains("background: var(--admin-surface);");
 	}
 
+	@Test
+	@DisplayName("표 영역 fragment는 #2071 admin-table-scroll wrapper 계약을 단일 소비한다")
+	void tableRegionFragmentConsumesAccessibleScrollWrapperContract() throws IOException {
+		String fragment = read("backend/src/main/resources/templates/admin/fragments/table-region.html");
+
+		// wrapper·table·close·조건부 table 계약을 admin table 가드와 동일 규칙으로 고정한다.
+		assertThat(count(TABLE_TAG, fragment)).as("table 정확히 1개").isEqualTo(1);
+		assertThat(count(ACCESSIBLE_TABLE_WRAPPER, fragment)).as("접근성 scroll wrapper 1개").isEqualTo(1);
+		assertThat(count(TABLE_WRAPPER_CLOSE, fragment)).as("wrapper close 1개").isEqualTo(1);
+		assertThat(count(CONDITIONAL_TABLE, fragment)).as("table에 th:if 금지").isZero();
+
+		assertThat(fragment)
+			.as("region fragment 시그니처")
+			.contains("th:fragment=\"region(caption, head, rows)\"")
+			// wrapper만 overflow를 소유한다는 계약을 확인하는 표준 aria-label
+			.contains("aria-label=\"가로로 스크롤 가능한 데이터 표\"")
+			// caption·head·rows를 화면이 주입한다
+			.contains("th:text=\"${caption}\"")
+			.contains("th:insert=\"${head}\"")
+			.contains("th:insert=\"${rows}\"");
+	}
+
+	@Test
+	@DisplayName("목록 툴바 fragment는 direct control 5개 이하와 시트·no-JS·포커스 복원 계약을 갖는다")
+	void listToolbarFragmentPinsUnifiedToolbarContract() throws IOException {
+		String fragment = read("backend/src/main/resources/templates/admin/fragments/list-toolbar.html");
+		String appJs = read("backend/src/main/resources/static/js/admin/app.js");
+
+		// 단일 toolbar 루트에 검색·저장된 뷰·필터·보기 설정을 모은다.
+		assertThat(count(Pattern.compile("class=\"admin-list-toolbar\""), fragment))
+			.as("toolbar 루트 1개").isEqualTo(1);
+		assertThat(fragment)
+			.contains("th:fragment=\"toolbar(basePath, resultsId, search, savedViews, filters, viewSettings)\"")
+			.contains("x-data=\"listToolbar\"");
+
+		// direct control ≤5: 검색 입력 1 + 검색 버튼 1 + 저장된 뷰 zone 1 + 필터 트리거 1 + 보기 설정 트리거 1.
+		assertThat(count(Pattern.compile("type=\"search\""), fragment)).as("검색 입력 1개").isEqualTo(1);
+		assertThat(count(Pattern.compile("<button type=\"submit\">검색</button>"), fragment))
+			.as("검색 버튼 1개").isEqualTo(1);
+		assertThat(count(Pattern.compile("class=\"admin-toolbar-sheet-trigger"), fragment))
+			.as("시트 트리거 2개(필터·보기 설정)").isEqualTo(2);
+
+		// HTMX와 full request가 같은 URL·결과: method=get form + hx-get.
+		assertThat(fragment)
+			.contains("method=\"get\"")
+			.contains("hx-get=@{${basePath}}")
+			// query parameter·sort·page size 보존용 hidden
+			.contains("type=\"hidden\"");
+
+		// 저장된 뷰·필터·보기 설정은 화면이 주입하고, 없으면 렌더하지 않는다(no-JS form/link 유지).
+		assertThat(fragment)
+			.contains("th:replace=\"${savedViews}\"")
+			.contains("th:replace=\"${filters}\"")
+			.contains("th:replace=\"${viewSettings}\"");
+
+		// 시트 트리거는 x-cloak라 no-JS에서 숨고, 시트는 outside close(입력 미유실)와 Esc 포커스 복원을 갖는다.
+		assertThat(fragment)
+			.contains("x-cloak")
+			.contains("x-bind:aria-expanded=\"filterExpanded\"")
+			.contains("x-bind:aria-expanded=\"viewExpanded\"")
+			.contains("aria-controls=\"admin-toolbar-filter-sheet\"")
+			.contains("aria-controls=\"admin-toolbar-view-sheet\"")
+			.contains("x-on:click.outside=\"closeFilter\"")
+			.contains("x-on:click.outside=\"closeView\"")
+			.contains("x-on:keydown.escape=\"closeFilterFromKeyboard\"")
+			.contains("x-on:keydown.escape=\"closeViewFromKeyboard\"")
+			.contains("x-bind:class=\"filterSheetClass\"")
+			.contains("x-bind:class=\"viewSheetClass\"");
+
+		// app.js listToolbar 컴포넌트: close는 상태만 닫고(입력 미유실), keyboard close만 포커스를 복원한다.
+		assertThat(appJs)
+			.contains("Alpine.data('listToolbar'")
+			.contains("closeFilterFromKeyboard")
+			.contains("closeViewFromKeyboard")
+			.contains("this.$refs.filterTrigger?.focus();")
+			.contains("this.$refs.viewTrigger?.focus();");
+
+		// listener 중복 등록 0: 시트 로직은 Alpine 디렉티브로만 선언하고 수동 리스너·폴링을 쓰지 않는다.
+		String listToolbarBlock = appJs.substring(appJs.indexOf("Alpine.data('listToolbar'"));
+		assertThat(listToolbarBlock)
+			.as("listToolbar 컴포넌트는 수동 addEventListener·setInterval를 등록하지 않는다")
+			.doesNotContain("addEventListener")
+			.doesNotContain("setInterval");
+	}
+
 	private static int count(Pattern pattern, String source) {
 		int count = 0;
 		Matcher matcher = pattern.matcher(source);

--- a/tools/qa/admin-accessibility-qa.mjs
+++ b/tools/qa/admin-accessibility-qa.mjs
@@ -162,6 +162,21 @@ function finalizeReport(report) {
       nodes: 0,
     });
   }
+  // #2278 V6-06: 목록 툴바 시트 계약을 위반으로 편입한다. body가 가로 overflow를 소유하거나(§9),
+  // 툴바가 있는데 outside close가 입력을 버리거나 Esc가 포커스를 복원하지 못하면 실패를 표면화한다.
+  const listToolbar = report.keyboard.find((entry) => entry.check === "list-toolbar-sheet");
+  if (listToolbar
+    && (listToolbar.bodyOverflowX0 === false
+      || (listToolbar.present === true
+        && listToolbar.sheetPresent === true
+        && (listToolbar.inputPreserved === false || listToolbar.focusRestored === false)))) {
+    blockingViolations.push({
+      page: "/admin/reports/page",
+      id: "list-toolbar-sheet",
+      impact: "serious",
+      nodes: 0,
+    });
+  }
   const criticalViolations = blockingViolations.filter((violation) => violation.impact === "critical");
   const seriousViolations = blockingViolations.filter((violation) => violation.impact === "serious");
   report.summary = {
@@ -196,6 +211,7 @@ async function runJsPass(browser, baseUrl, outputDir, adminUser, adminPassword, 
   await captureAxTree(page, outputDir, report);
   await noCurrentWorkspaceDisclosure(page, baseUrl, report);
   await keyboardTableCheck(page, baseUrl, report);
+  await listToolbarSheetCheck(page, baseUrl, report);
   await textScalePass(page, baseUrl, outputDir, report, ADMIN_TEXT_SCALE_PAGES);
   await context.close();
 
@@ -557,6 +573,76 @@ async function keyboardTableCheck(page, baseUrl, report) {
     outlineStyle: focusState ? focusState.outlineStyle : null,
     outlineWidth: focusState ? focusState.outlineWidth : null,
     outlineVisible,
+  });
+}
+
+// #2278 V6-06: 목록 툴바 시트 계약. compact viewport에서 (1) body가 가로 overflow를 소유하지 않는지(§9),
+// (2) 툴바가 있으면 direct control 수·시트 outside close 입력 미유실·Esc 포커스 복원을 검사한다.
+// 화면 이관(V6-07~10) 전에는 툴바가 아직 없어 present:false로 no-op이며 body overflow만 기록한다.
+// wrapper(.admin-table-scroll)만 가로 overflow를 소유한다는 #2071 계약과 결이 같다.
+async function listToolbarSheetCheck(page, baseUrl, report) {
+  await page.setViewportSize(VIEWPORTS.find((viewport) => viewport.name === "mobile-390"));
+  const response = await page.goto(`${baseUrl}/admin/reports/page`, { waitUntil: "networkidle" });
+  await assertOk(page, "/admin/reports/page", response);
+  await page.waitForSelector("body.has-js-ready", { timeout: 2000 }).catch(() => {});
+
+  const base = await page.evaluate(() => {
+    const doc = document.documentElement;
+    const bodyOverflowX0 = document.body.scrollWidth <= document.body.clientWidth + 1
+      && doc.scrollWidth <= doc.clientWidth + 1;
+    const toolbar = document.querySelector(".admin-list-toolbar");
+    if (!toolbar) {
+      return { present: false, bodyOverflowX0 };
+    }
+    const directControls = Array.from(
+      toolbar.querySelectorAll("input:not([type=\"hidden\"]), button, select, a, textarea"),
+    ).filter((element) => !element.closest(".admin-toolbar-sheet")).length;
+    return { present: true, bodyOverflowX0, directControls };
+  });
+
+  if (!base.present) {
+    report.keyboard.push({ check: "list-toolbar-sheet", ...base });
+    return;
+  }
+
+  // 시트 outside close가 입력을 버리지 않는지: 시트 입력에 값을 넣고 트리거로 열었다 바깥을 눌러 닫은 뒤
+  // 값이 보존되는지 확인한다. Esc는 트리거로 포커스를 복원해야 한다(focus restore).
+  const sheet = await page.evaluate(() => {
+    const trigger = document.querySelector(".admin-toolbar-filter-trigger");
+    const sheetInput = document.querySelector(".admin-toolbar-filter-sheet input, .admin-toolbar-filter-sheet select");
+    if (!trigger || !sheetInput) {
+      return { sheetPresent: false };
+    }
+    if (sheetInput.tagName.toLowerCase() === "input" && sheetInput.type !== "checkbox") {
+      sheetInput.value = "보존-확인";
+    }
+    return { sheetPresent: true, savedValue: sheetInput.value ?? null };
+  });
+
+  let inputPreserved = null;
+  let focusRestored = null;
+  if (sheet.sheetPresent) {
+    await page.click(".admin-toolbar-filter-trigger");
+    await page.click("h1");
+    await page.waitForTimeout(100);
+    inputPreserved = await page.evaluate((expected) => {
+      const sheetInput = document.querySelector(".admin-toolbar-filter-sheet input, .admin-toolbar-filter-sheet select");
+      return sheetInput ? sheetInput.value === expected : false;
+    }, sheet.savedValue);
+    await page.click(".admin-toolbar-filter-trigger");
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(100);
+    focusRestored = await page.evaluate(() =>
+      Boolean(document.activeElement
+        && document.activeElement.classList.contains("admin-toolbar-filter-trigger")));
+  }
+
+  report.keyboard.push({
+    check: "list-toolbar-sheet",
+    ...base,
+    sheetPresent: sheet.sheetPresent,
+    inputPreserved,
+    focusRestored,
   });
 }
 

--- a/tools/qa/admin-accessibility-qa.mjs
+++ b/tools/qa/admin-accessibility-qa.mjs
@@ -163,13 +163,16 @@ function finalizeReport(report) {
     });
   }
   // #2278 V6-06: 목록 툴바 시트 계약을 위반으로 편입한다. body가 가로 overflow를 소유하거나(§9),
-  // 툴바가 있는데 outside close가 입력을 버리거나 Esc가 포커스를 복원하지 못하면 실패를 표면화한다.
+  // 툴바가 있는데 outside close가 입력을 버리거나, Esc(window 스코프, #2301 리뷰)가 시트를 실제로
+  // 닫지 못하거나(is-open 잔존) 포커스를 복원하지 못하면 실패를 표면화한다.
   const listToolbar = report.keyboard.find((entry) => entry.check === "list-toolbar-sheet");
   if (listToolbar
     && (listToolbar.bodyOverflowX0 === false
       || (listToolbar.present === true
         && listToolbar.sheetPresent === true
-        && (listToolbar.inputPreserved === false || listToolbar.focusRestored === false)))) {
+        && (listToolbar.inputPreserved === false
+          || listToolbar.sheetClosed === false
+          || listToolbar.focusRestored === false)))) {
     blockingViolations.push({
       page: "/admin/reports/page",
       id: "list-toolbar-sheet",
@@ -620,6 +623,7 @@ async function listToolbarSheetCheck(page, baseUrl, report) {
   });
 
   let inputPreserved = null;
+  let sheetClosed = null;
   let focusRestored = null;
   if (sheet.sheetPresent) {
     await page.click(".admin-toolbar-filter-trigger");
@@ -630,11 +634,21 @@ async function listToolbarSheetCheck(page, baseUrl, report) {
       return sheetInput ? sheetInput.value === expected : false;
     }, sheet.savedValue);
     await page.click(".admin-toolbar-filter-trigger");
+    // window 스코프 Esc(#2301 리뷰)는 시트 내부 포커스와 무관하게 발화하므로, 시트 내부 컨트롤에
+    // 포커스를 둔 채로 Esc를 눌러도 닫히는지까지 확인한다.
+    await page.evaluate(() => {
+      const sheetInput = document.querySelector(".admin-toolbar-filter-sheet input, .admin-toolbar-filter-sheet select");
+      sheetInput?.focus();
+    });
     await page.keyboard.press("Escape");
     await page.waitForTimeout(100);
-    focusRestored = await page.evaluate(() =>
-      Boolean(document.activeElement
-        && document.activeElement.classList.contains("admin-toolbar-filter-trigger")));
+    const afterEscape = await page.evaluate(() => ({
+      sheetClosed: !document.querySelector(".admin-toolbar-filter-sheet")?.classList.contains("is-open"),
+      focusRestored: Boolean(document.activeElement
+        && document.activeElement.classList.contains("admin-toolbar-filter-trigger")),
+    }));
+    sheetClosed = afterEscape.sheetClosed;
+    focusRestored = afterEscape.focusRestored;
   }
 
   report.keyboard.push({
@@ -642,6 +656,7 @@ async function listToolbarSheetCheck(page, baseUrl, report) {
     ...base,
     sheetPresent: sheet.sheetPresent,
     inputPreserved,
+    sheetClosed,
     focusRestored,
   });
 }

--- a/tools/qa/admin-accessibility-qa.test.mjs
+++ b/tools/qa/admin-accessibility-qa.test.mjs
@@ -128,8 +128,9 @@ test("admin accessibility QA script verifies list toolbar sheet body overflow an
   // body가 가로 overflow를 소유하지 않는지(§9) 측정한다.
   assert.match(source, /bodyOverflowX0/);
   assert.match(source, /document\.body\.scrollWidth <= document\.body\.clientWidth \+ 1/);
-  // 시트 outside close 입력 미유실·Esc 포커스 복원을 검사한다.
+  // 시트 outside close 입력 미유실·Esc 시트 실제 닫힘(is-open 제거)·포커스 복원을 이중 단언으로 검사한다.
   assert.match(source, /inputPreserved/);
+  assert.match(source, /sheetClosed/);
   assert.match(source, /focusRestored/);
   assert.match(source, /admin-toolbar-filter-trigger/);
   // direct control 수를 시트 밖 요소만 세어 기록한다.
@@ -137,6 +138,7 @@ test("admin accessibility QA script verifies list toolbar sheet body overflow an
   // 계약 실패가 blocking 위반으로 표면화되는지 고정한다.
   assert.match(source, /id: "list-toolbar-sheet"/);
   assert.match(source, /listToolbar\.bodyOverflowX0 === false/);
+  assert.match(source, /listToolbar\.sheetClosed === false/);
 });
 
 test("admin accessibility QA script records manual-only screen reader and contrast work", () => {

--- a/tools/qa/admin-accessibility-qa.test.mjs
+++ b/tools/qa/admin-accessibility-qa.test.mjs
@@ -120,6 +120,25 @@ test("admin accessibility QA script verifies admin-table-scroll keyboard and foc
   assert.match(source, /id: "login-public-state-expectation"/);
 });
 
+// #2278 V6-06: 목록 툴바 시트 계약을 QA 하네스가 검사하는지 source로 고정한다.
+test("admin accessibility QA script verifies list toolbar sheet body overflow and focus restore", () => {
+  assert.match(source, /async function listToolbarSheetCheck\(page, baseUrl, report\)/);
+  assert.match(source, /await listToolbarSheetCheck\(page, baseUrl, report\)/);
+  assert.match(source, /check: "list-toolbar-sheet"/);
+  // body가 가로 overflow를 소유하지 않는지(§9) 측정한다.
+  assert.match(source, /bodyOverflowX0/);
+  assert.match(source, /document\.body\.scrollWidth <= document\.body\.clientWidth \+ 1/);
+  // 시트 outside close 입력 미유실·Esc 포커스 복원을 검사한다.
+  assert.match(source, /inputPreserved/);
+  assert.match(source, /focusRestored/);
+  assert.match(source, /admin-toolbar-filter-trigger/);
+  // direct control 수를 시트 밖 요소만 세어 기록한다.
+  assert.match(source, /directControls/);
+  // 계약 실패가 blocking 위반으로 표면화되는지 고정한다.
+  assert.match(source, /id: "list-toolbar-sheet"/);
+  assert.match(source, /listToolbar\.bodyOverflowX0 === false/);
+});
+
 test("admin accessibility QA script records manual-only screen reader and contrast work", () => {
   assert.match(source, /VoiceOver reading flow/);
   assert.match(source, /high-contrast visual inspection/);


### PR DESCRIPTION
## 관련 이슈

close #2278
Refs #2271

## 작업 배경

- 검색·필터·저장된 뷰·보기 설정과 표의 가로 overflow owner가 화면마다 달라 compact 제어와 keyboard 동작이 일관되지 않았다(#2278 §2).
- V6-06은 공통 기반 구축 단계다. 목록 control을 하나의 toolbar로 모으고 #2071 `admin-table-scroll` wrapper를 공통 contract로 소비하는 fragment를 정의·고정한다. 기존 화면 대량 이관은 V6-07~10 몫이라 이번 PR은 fragment 정의와 계약 테스트·QA 고정에 한정하고 기존 화면 렌더 회귀는 0으로 유지한다.

## 작업 내용

- `templates/admin/fragments/list-toolbar.html`(신규): 검색·필터·저장된 뷰·보기 설정을 단일 toolbar로 통합한다. direct control 5개 이하(검색 입력·검색 버튼·저장된 뷰·필터 시트 트리거·보기 설정 시트 트리거)이며, compact(≤768px)에서는 필터·보기 설정을 시트로 접는다. 시트 트리거는 `x-cloak`라 JS가 없으면 숨고 시트 내용은 인라인으로 남아 no-JS form/link 폴백이 유지된다. 검색은 `method=get` form + `hx-get`으로 HTMX와 full request가 동일 URL·결과를 만들고, query parameter는 hidden으로 보존한다.
- `templates/admin/fragments/table-region.html`(신규): #2071 `admin-table-scroll` wrapper를 단일 contract로 소비한다. wrapper만 가로 overflow를 소유하고, 첫 식별자 열과 필요한 action 열(`.cell-sticky-action`)만 sticky다. caption·head·rows를 화면이 주입한다.
- `static/js/admin/app.js`: `listToolbar` Alpine(CSP 빌드) 컴포넌트를 추가한다. 시트 open/close, outside close는 상태만 닫아 입력을 버리지 않고, Esc는 트리거로 포커스를 복원한다. Alpine 디렉티브(x-on)로만 배선해 수동 `addEventListener`·polling 없이 리스너 중복 등록이 0이다.
- `static/css/admin-data.css`(V6-04 data/list 레이어): toolbar·시트 레이아웃, compact 시트 접힘, action 열 우측 sticky 유틸리티를 추가한다. 시각 언어 불변(무채색·각진·그림자 0)이며 4책임 소유권·중복 선언 금지를 준수한다.
- `AdminDesignGuardTest`: 두 fragment의 direct control 수·시트·no-JS·포커스 복원·wrapper 단일 소비 계약을 소스로 고정한다(신규 2 test).
- `tools/qa/admin-accessibility-qa.mjs` / `.test.mjs`: `listToolbarSheetCheck`로 body overflow 0(§9)·시트 outside close 입력 미유실·Esc 포커스 복원을 검사하고 `finalizeReport` blocking gate로 표면화한다. 화면 이관 전에는 toolbar 소비 화면이 없어 런타임은 `present:false` no-op이다.

§5 목록 중 `pagination.html`, `AdminSavedViewControllerTest`, `AdminSavedViewServiceTest`, `AdminPhase3QualityGateTest`, `AdminAccessibilitySmokeTest`는 변경하지 않았다. saved-view CSRF·owner uniqueness 계약과 Phase3/접근성 셸 계약은 기존 테스트가 이미 회귀 0으로 고정하고 있고(모두 green), 이번 fragment 정의를 소비하는 화면 이관이 이 단계 범위 밖이라 rendering 기반 추가 lock을 붙일 대상이 없다.

## 검증

- 실행한 명령과 결과:
  - `node tools/ci/api-catalog.mjs validate` → exit 0 (API catalog valid: 245)
  - `LC_ALL=C.UTF-8 node --test tools/ci/repository-contract.test.mjs` → 218 pass / 0 fail (ko_KR 로케일 오탐 회피용 C.UTF-8)
  - `npm test --prefix tools/qa` → 11 pass / 0 fail (신규 list-toolbar-sheet 계약 test 포함)
  - `./gradlew test --tests AdminSavedViewControllerTest --tests AdminSavedViewServiceTest --tests AdminPhase3QualityGateTest --tests AdminAccessibilitySmokeTest --tests AdminDesignGuardTest` → BUILD SUCCESSFUL (AdminDesignGuardTest 13 test = 기존 11 + 신규 2, 전부 green)

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 자동 검증 5종(§10) | backend/tools | 위 명령 실행 | 명령 출력(위 검증 섹션) | 전부 exit 0 |
| direct control ≤5·시트·no-JS·포커스 복원·wrapper 단일 소비 | backend | AdminDesignGuardTest 신규 2 test(소스 exact lock) | `build/test-results` 13 test green | PASS |
| body overflow 0·outside close 입력 미유실·Esc 포커스 복원 | tools/qa | listToolbarSheetCheck + finalizeReport blocking gate, .test.mjs 소스 계약 | `npm test --prefix tools/qa` green | PASS(이관 전 런타임 present:false no-op) |
| saved view CSRF/owner uniqueness 회귀 0 | backend | AdminSavedViewControllerTest/ServiceTest(변경 없음) | gradle green | 회귀 0 |
| 런타임 자산·렌더·CSP | backend | 로컬 dev/H2(port 18278) 부팅 후 curl | 로컬 evidence `EVIDENCE-2278.txt`(tested SHA 6365279d, /admin/reports·audits·stations 200, CSP 유지, app.js listToolbar·admin-data.css toolbar 규칙 배포 확인, listToolbar 블록 내 addEventListener/setInterval 0) | PASS |
| 320/390/1024/1440 시각 관측 | backend | 시각 관측 | toolbar 소비 화면 부재로 이관 단계(V6-07~10) 몫; 본 단계는 fragment 정의+계약 고정 범위 | N/A(사유 기재) |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [ ] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [ ] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음(관리자 콘솔 fragment·정적 자산·테스트만 추가, 버전 아티팩트·계약 JSON 무변경)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `list-toolbar.html`의 direct control 구성이 §7 "direct control 5개 이하"와 compact 시트 접힘·no-JS 폴백을 만족하는지.
  - `table-region.html`이 #2071 wrapper 계약(wrapper만 overflow 소유, 첫 식별자·필요 action만 sticky)을 그대로 소비하는지, AdminDesignGuardTest admin-table 가드 규칙(wrapper 1:table 1:close 1, 조건부 table 0)에 부합하는지.
  - `app.js` listToolbar가 CSP 빌드 규약(메서드·게터 이름만)과 outside close 입력 미유실·Esc 포커스 복원·리스너 중복 0을 지키는지.
  - `admin-data.css` 추가분이 data/list 레이어 소유권과 시각 언어(무채색·각진·그림자0)를 벗어나지 않는지.

## 리스크

- 이 단계는 공통 기반이라 fragment는 아직 어떤 화면도 소비하지 않는다(추가 전용). CSS/JS/test도 additive다.
- Rollback 경계: 이 PR(단일 커밋 `7236114b`) revert로 완전 원복된다. DB migration·데이터·계약 JSON·배포 게이트 변경이 없어 부작용 없이 되돌릴 수 있다. 신규 fragment 2개는 미소비라 revert 시 참조 끊김도 없다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음 — 버전·계약·migration 무변경)
