### PR TITLE
[Style] #2279 V6-07 역·시설 목록 정보 우선순위·공통 contract 이관

### DIFF
--- a/backend/src/main/resources/static/css/admin-data.css
+++ b/backend/src/main/resources/static/css/admin-data.css
@@ -508,6 +508,63 @@
 	background: var(--admin-accent-soft);
 }
 
+/* 시트 안 필터·정렬 form(V6-07 #2279): 시트가 소유하는 no-JS/HTMX form의 컨트롤을 인라인으로 배치한다.
+   시각 언어(무채색·flat·radius≤8)는 기존 폼 컨트롤 토큰을 그대로 상속한다. */
+.admin-toolbar-form {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	align-items: center;
+	margin: 0;
+}
+
+/* 목록 상태 셀(V6-07 #2279): 상태를 텍스트 + 아이콘 + 색으로 함께 전한다(색 단독 표현 금지).
+   아이콘은 프로젝트 sprite(check·warning·error·info)를 currentColor로 그리므로 tone class의 색을
+   그대로 물려받는다. 시각 언어는 기존 상태색 토큰 범위 안에서만 쓴다. */
+.admin-v3 .data-status {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 13px;
+	color: var(--admin-ink);
+	white-space: nowrap;
+}
+
+.admin-v3 .data-status .admin-icon {
+	width: 16px;
+	height: 16px;
+	flex: none;
+}
+
+.admin-v3 .data-status.tone-good {
+	color: var(--admin-good);
+}
+
+.admin-v3 .data-status.tone-warn {
+	color: var(--admin-warn);
+}
+
+.admin-v3 .data-status.tone-bad {
+	color: var(--admin-danger);
+}
+
+.admin-v3 .data-status.tone-info {
+	color: var(--admin-ink-2);
+}
+
+/* 마지막 확인/갱신일 셀(V6-07 #2279): 상대 시간을 위, 정확한 날짜를 아래(meta)로 병기한다.
+   상대 시간에는 정확한 날짜를 title로도 달아 hover·스크린리더에서 절대 시각을 확인할 수 있다. */
+.admin-v3 .data-verified {
+	display: inline-flex;
+	flex-direction: column;
+	line-height: 1.3;
+}
+
+.admin-v3 .data-verified-relative {
+	color: var(--admin-ink);
+	font-variant-numeric: tabular-nums;
+}
+
 /* compact: 필터·보기 설정을 시트로 접는다. JS가 있을 때만(has-js) 트리거를 노출하고 시트를 접어
    direct control을 5개 이하로 유지한다. no-JS(has-js 미부착)는 시트 내용이 인라인으로 남는다. */
 @media (max-width: 768px) {

--- a/backend/src/main/resources/templates/admin/facilities/list.html
+++ b/backend/src/main/resources/templates/admin/facilities/list.html
@@ -46,13 +46,13 @@
 
 		<!-- V6-06 공통 툴바: 검색은 항상 direct, 유형·상태·역 필터는 필터 시트, 정렬은 보기 설정 시트로 접힌다.
 		     각 영역 form은 나머지 파라미터를 hidden으로 보존한다. -->
-		<!-- NOTE(#2279): 검색 form의 필터 보존용 hidden(search.hidden)은 보류. list-toolbar.html의
-		     th:each="param" 이 Thymeleaf 예약어 param을 loop 변수로 써 non-empty hidden 전달 시 500이 난다.
-		     해당 fragment는 §5 수정 파일 밖이라 수정하지 않고 보고한다. 필터→필터·정렬·페이지네이션 보존은
-		     아래 자체 form(hidden th:value)이 담당하므로 정상 동작하고, 키워드 검색 시 필터 유지만 보류된다. -->
+		<!-- 검색 form의 필터·정렬 보존용 hidden(search.hidden, #2279 리뷰 반영): list-toolbar.html이
+		     ${search.get('hidden')} 메서드 호출로 null-safe하게 읽고 hiddenParam으로 반복하므로, 여기서 유형·
+		     상태·역·정렬을 그대로 전달해 키워드 검색이 활성 필터를 덮어쓰지 않게 한다(§7 filter binding 불변). -->
 		<div th:replace="~{admin/fragments/list-toolbar :: toolbar(
 		         '/admin/facilities/page', 'facility-results',
-		         ${ {'name':'query','value':searchKeyword,'placeholder':'시설·역 이름 검색','label':'시설·역 이름 검색','hidden':{}} },
+		         ${ {'name':'query','value':searchKeyword,'placeholder':'시설·역 이름 검색','label':'시설·역 이름 검색',
+		            'hidden': {'type':selectedType,'status':selectedStatus,'stationId':selectedStationFilter,'sort':selectedSort}} },
 		         ~{}, ~{::facilityFilters}, ~{::facilityView})}">
 			<form th:fragment="facilityFilters" class="admin-toolbar-form" method="get"
 			      th:action="@{/admin/facilities/page}" role="group" aria-label="유형·상태·역 필터"

--- a/backend/src/main/resources/templates/admin/facilities/list.html
+++ b/backend/src/main/resources/templates/admin/facilities/list.html
@@ -35,99 +35,151 @@
 	<div th:replace="~{admin/fragments/form-errors :: summary}"></div>
 
 	<!--
-	  시설 상태판 표준 테이블(#1741): 검색·유형·상태·역 필터 툴바 + 표 + 페이지네이션을 facilityResults로 묶는다.
+	  시설 상태판 표준 테이블(#1741, V6-07 #2279 이관): 검색·필터·정렬을 V6-06 공통 툴바(list-toolbar)로,
+	  표는 공통 표 영역(table-region)으로 소비한다. 390px 첫 화면에서 sticky 첫 식별자 열(시설)과 바로 뒤
+	  현재 상태(주의)·역·확인 상태(데이터 품질)가 즉시 보이고, 나머지 열은 가로 스크롤로 접근한다.
+	  상태 변경 form 열만 우측 sticky(action)로 고정한다.
 	  JS 있으면 htmx가 이 컨테이너만 교체하고 URL을 push, 없으면 form GET·링크가 전체 페이지로 동작한다.
 	-->
 	<div id="facility-results" th:fragment="facilityResults"
 	     hx-target="#facility-results" hx-swap="outerHTML" hx-push-url="true">
-		<form class="table-toolbar" method="get" th:action="@{/admin/facilities/page}"
-		      role="search" aria-label="시설 검색"
-		      hx-target="#facility-results" hx-swap="outerHTML" hx-push-url="true"
-		      th:attr="hx-get=@{/admin/facilities/page}"
-		      hx-trigger="submit, change, keyup changed delay:300ms">
-			<input type="search" name="query" th:value="${searchKeyword}"
-			       placeholder="시설·역 이름 검색" aria-label="시설·역 이름 검색" autocomplete="off">
-			<select name="type" aria-label="유형 필터">
-				<option th:each="opt : ${typeOptions}" th:value="${opt.value}"
-				        th:text="${opt.label}" th:selected="${opt.selected}">전체 유형</option>
-			</select>
-			<select name="status" aria-label="상태 필터">
-				<option value="" th:selected="${selectedStatus == null}">전체 상태</option>
-				<option th:each="option : ${statusOptions}" th:value="${option.value}"
-				        th:text="${option.label}" th:selected="${option.value == selectedStatus}">정상</option>
-			</select>
-			<select name="stationId" aria-label="역 필터">
-				<option th:each="opt : ${stationFilterOptions}" th:value="${opt.value}"
-				        th:text="${opt.label}" th:selected="${opt.selected}">전체 역</option>
-			</select>
-			<select name="sort" aria-label="정렬">
-				<option value="" th:selected="${selectedSort == null}">역명순</option>
-				<option value="attention" th:selected="${selectedSort == 'attention'}">확인 필요 먼저</option>
-				<option value="updated" th:selected="${selectedSort == 'updated'}">갱신일 최신순</option>
-			</select>
-			<button type="submit">검색</button>
-		</form>
 
-		<div class="admin-table-scroll" tabindex="0" role="group"
-		     aria-label="가로로 스크롤 가능한 데이터 표">
-		<table>
-			<thead>
-			<tr>
-				<th scope="col">시설</th>
-				<th scope="col">역</th>
-				<th scope="col">현재 상태</th>
-				<th scope="col">확인 상태</th>
-				<th scope="col">갱신일</th>
-				<th scope="col">제보</th>
-				<th scope="col">상태 변경</th>
-			</tr>
-			</thead>
-			<tbody>
-			<tr th:if="${facilities.isEmpty()}">
-				<td colspan="7">
-					<div th:replace="~{admin/fragments/empty-state :: panel('조건에 맞는 시설이 없습니다.', '검색어·유형·상태·역 필터를 조정해 보세요.')}"></div>
-				</td>
-			</tr>
-			<tr th:each="facility : ${facilities}">
-				<td>
-					<span th:text="${facility.facilityName}">1번 출구 엘리베이터</span>
-					<span class="meta" th:text="${facility.typeLabel}">엘리베이터</span>
-				</td>
-				<td>
-					<a th:href="@{/admin/stations/{stationId}/page(stationId=${facility.stationId},tab='facilities')}"
-					   th:text="${facility.stationName}">상록수</a>
-				</td>
-				<td><span th:replace="~{admin/fragments/shell :: statusAuto(${facility.statusLabel})}">정상</span></td>
-				<td>
-					<span th:text="${facility.confidenceLabel}">최근 확인된 정보</span>
-					<span class="meta" th:text="${facility.sourceLabel}">공식 안내</span>
-				</td>
-				<td th:text="${facility.lastUpdatedAt}">2026-06-12</td>
-				<td>
-					<!-- 관련 제보: 이 시설의 역으로 필터된 제보 대기열(#1740)로 이동한다. -->
-					<a th:href="@{/admin/reports/page(station=${facility.stationId})}"
-					   th:attr="aria-label=|${facility.stationName} 제보 보기|">제보 보기</a>
-				</td>
-				<td>
-					<form th:action="@{/admin/facilities/{facilityId}/page/status(facilityId=${facility.facilityId})}"
-					      method="post">
-						<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
-						<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
-						<label>
-							<span class="meta">변경할 상태</span>
-							<select name="status">
-								<option th:each="option : ${statusOptions}"
-								        th:value="${option.value}"
-								        th:selected="${option.value == facility.status}"
-								        th:text="${option.label}">정상</option>
-							</select>
-						</label>
-						<button type="submit" th:disabled="${!masterDataWritable}">저장</button>
-					</form>
-				</td>
-			</tr>
-			</tbody>
-		</table>
+		<!-- V6-06 공통 툴바: 검색은 항상 direct, 유형·상태·역 필터는 필터 시트, 정렬은 보기 설정 시트로 접힌다.
+		     각 영역 form은 나머지 파라미터를 hidden으로 보존한다. -->
+		<!-- NOTE(#2279): 검색 form의 필터 보존용 hidden(search.hidden)은 보류. list-toolbar.html의
+		     th:each="param" 이 Thymeleaf 예약어 param을 loop 변수로 써 non-empty hidden 전달 시 500이 난다.
+		     해당 fragment는 §5 수정 파일 밖이라 수정하지 않고 보고한다. 필터→필터·정렬·페이지네이션 보존은
+		     아래 자체 form(hidden th:value)이 담당하므로 정상 동작하고, 키워드 검색 시 필터 유지만 보류된다. -->
+		<div th:replace="~{admin/fragments/list-toolbar :: toolbar(
+		         '/admin/facilities/page', 'facility-results',
+		         ${ {'name':'query','value':searchKeyword,'placeholder':'시설·역 이름 검색','label':'시설·역 이름 검색','hidden':{}} },
+		         ~{}, ~{::facilityFilters}, ~{::facilityView})}">
+			<form th:fragment="facilityFilters" class="admin-toolbar-form" method="get"
+			      th:action="@{/admin/facilities/page}" role="group" aria-label="유형·상태·역 필터"
+			      th:attr="hx-get=@{/admin/facilities/page}" hx-target="#facility-results"
+			      hx-swap="outerHTML" hx-push-url="true" hx-trigger="change, submit">
+				<input type="hidden" name="query" th:value="${searchKeyword}">
+				<input type="hidden" name="sort" th:value="${selectedSort}">
+				<select name="type" aria-label="유형 필터">
+					<option th:each="opt : ${typeOptions}" th:value="${opt.value}"
+					        th:text="${opt.label}" th:selected="${opt.selected}">전체 유형</option>
+				</select>
+				<select name="status" aria-label="상태 필터">
+					<option value="" th:selected="${selectedStatus == null}">전체 상태</option>
+					<option th:each="option : ${statusOptions}" th:value="${option.value}"
+					        th:text="${option.label}" th:selected="${option.value == selectedStatus}">정상</option>
+				</select>
+				<select name="stationId" aria-label="역 필터">
+					<option th:each="opt : ${stationFilterOptions}" th:value="${opt.value}"
+					        th:text="${opt.label}" th:selected="${opt.selected}">전체 역</option>
+				</select>
+				<button type="submit">필터 적용</button>
+			</form>
+			<form th:fragment="facilityView" class="admin-toolbar-form" method="get"
+			      th:action="@{/admin/facilities/page}" role="group" aria-label="정렬"
+			      th:attr="hx-get=@{/admin/facilities/page}" hx-target="#facility-results"
+			      hx-swap="outerHTML" hx-push-url="true" hx-trigger="change, submit">
+				<input type="hidden" name="query" th:value="${searchKeyword}">
+				<input type="hidden" name="type" th:value="${selectedType}">
+				<input type="hidden" name="status" th:value="${selectedStatus}">
+				<input type="hidden" name="stationId" th:value="${selectedStationFilter}">
+				<select name="sort" aria-label="정렬">
+					<option value="" th:selected="${selectedSort == null}">역명순</option>
+					<option value="attention" th:selected="${selectedSort == 'attention'}">확인 필요 먼저</option>
+					<option value="updated" th:selected="${selectedSort == 'updated'}">갱신일 최신순</option>
+				</select>
+				<button type="submit">정렬 적용</button>
+			</form>
+		</div>
+
+		<!-- V6-06 공통 표 영역: wrapper(.admin-table-scroll)만 가로 overflow를 소유하고, 첫 식별자 열은
+		     sticky, 상태 변경 form 열은 우측 sticky(action)다. head·rows 마크업만 주입한다. -->
+		<div th:replace="~{admin/fragments/table-region :: region(
+		         '시설 상태 표', ~{::facilityTableHead}, ~{::facilityTableRows})}">
+			<th:block th:fragment="facilityTableHead">
+				<tr>
+					<th scope="col">시설</th>
+					<th scope="col">현재 상태</th>
+					<th scope="col">역</th>
+					<th scope="col">확인 상태</th>
+					<th scope="col">갱신일</th>
+					<th scope="col">제보</th>
+					<th scope="col" class="cell-sticky-action">상태 변경</th>
+				</tr>
+			</th:block>
+			<th:block th:fragment="facilityTableRows">
+				<tr th:if="${facilities.isEmpty()}">
+					<td colspan="7">
+						<div th:replace="~{admin/fragments/empty-state :: panel('조건에 맞는 시설이 없습니다.', '검색어·유형·상태·역 필터를 조정해 보세요.')}"></div>
+					</td>
+				</tr>
+				<tr th:each="facility : ${facilities}">
+					<td>
+						<span th:text="${facility.facilityName}">1번 출구 엘리베이터</span>
+						<span class="meta" th:text="${facility.typeLabel}">엘리베이터</span>
+					</td>
+					<td>
+						<!-- 현재 상태: 텍스트 + 아이콘 + 색으로 상태를 전한다(색 단독 표현 금지). -->
+						<th:block th:with="ftone=${facility.status.name() == 'NORMAL' or facility.status.name() == 'ADMIN_VERIFIED' ? 'good'
+						                     : (facility.status.name() == 'BROKEN' or facility.status.name() == 'CLOSED' ? 'bad' : 'warn')},
+						                   ficon=${facility.status.name() == 'NORMAL' or facility.status.name() == 'ADMIN_VERIFIED' ? 'check'
+						                     : (facility.status.name() == 'BROKEN' or facility.status.name() == 'CLOSED' ? 'error' : 'warning')}">
+							<span class="data-status" th:classappend="|tone-${ftone}|">
+								<svg th:replace="~{admin/fragments/icon :: icon(${ficon})}"></svg>
+								<span th:text="${facility.statusLabel}">정상</span>
+							</span>
+						</th:block>
+					</td>
+					<td>
+						<a th:href="@{/admin/stations/{stationId}/page(stationId=${facility.stationId},tab='facilities')}"
+						   th:text="${facility.stationName}">상록수</a>
+					</td>
+					<td>
+						<!-- 확인 상태: 데이터 품질(신뢰도)과 출처를 함께 보여준다. -->
+						<span th:text="${facility.confidenceLabel}">최근 확인된 정보</span>
+						<span class="meta" th:text="${facility.sourceLabel}">공식 안내</span>
+					</td>
+					<td>
+						<!-- 갱신일: 상대 시간 + 정확한 날짜 병기. lastUpdatedAt은 LocalDate라 표시 계층에서
+						     상대 시간을 계산한다. 값이 없으면 '기록 없음'으로만 표기한다(placeholder 데이터 없음). -->
+						<th:block th:if="${facility.lastUpdatedAt != null}"
+						          th:with="daysAgo=${T(java.time.temporal.ChronoUnit).DAYS.between(facility.lastUpdatedAt, T(java.time.LocalDate).now())}">
+							<span class="data-verified">
+								<span class="data-verified-relative"
+								      th:title="${#temporals.format(facility.lastUpdatedAt, 'yyyy-MM-dd')}"
+								      th:text="${daysAgo le 0 ? '오늘' : (daysAgo == 1 ? '어제'
+								        : (daysAgo lt 7 ? daysAgo + '일 전'
+								        : (daysAgo lt 31 ? daysAgo / 7 + '주 전'
+								        : (daysAgo lt 365 ? daysAgo / 30 + '개월 전' : daysAgo / 365 + '년 전'))))}">3일 전</span>
+								<span class="meta" th:text="${#temporals.format(facility.lastUpdatedAt, 'yyyy-MM-dd')}">2026-06-12</span>
+							</span>
+						</th:block>
+						<span th:unless="${facility.lastUpdatedAt != null}" class="meta">기록 없음</span>
+					</td>
+					<td>
+						<!-- 관련 제보: 이 시설의 역으로 필터된 제보 대기열(#1740)로 이동한다. -->
+						<a th:href="@{/admin/reports/page(station=${facility.stationId})}"
+						   th:attr="aria-label=|${facility.stationName} 제보 보기|">제보 보기</a>
+					</td>
+					<td class="cell-sticky-action">
+						<form th:action="@{/admin/facilities/{facilityId}/page/status(facilityId=${facility.facilityId})}"
+						      method="post">
+							<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+							<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
+							<label>
+								<span class="meta">변경할 상태</span>
+								<select name="status">
+									<option th:each="option : ${statusOptions}"
+									        th:value="${option.value}"
+									        th:selected="${option.value == facility.status}"
+									        th:text="${option.label}">정상</option>
+								</select>
+							</label>
+							<button type="submit" th:disabled="${!masterDataWritable}">저장</button>
+						</form>
+					</td>
+				</tr>
+			</th:block>
 		</div>
 		<div th:replace="~{admin/fragments/pagination :: pager('시설 상태 목록 페이지', ${page}, ${paginationLinks})}"></div>
 	</div>

--- a/backend/src/main/resources/templates/admin/fragments/list-toolbar.html
+++ b/backend/src/main/resources/templates/admin/fragments/list-toolbar.html
@@ -13,6 +13,11 @@
   - 검색은 method=get form + hx-get으로 HTMX와 full request가 같은 URL·결과를 만든다. query parameter·sort·page
     size는 hidden으로 보존해 검색이 다른 필터를 덮어쓰지 않는다.
   - CSP 빌드 규약: x-on/x-bind에는 listToolbar 컴포넌트의 메서드·게터 이름만 넣는다(인라인 표현식 금지).
+  - hidden 보존 맵(search.hidden)은 항상 ${search.get('hidden')} 메서드 호출로 읽는다(#2279 리뷰 수정). 점(.)
+    프로퍼티 접근(${search.hidden})은 Spring MapAccessor.read()가 "값이 null이고 키도 없음"을 MapAccessException으로
+    던지는 케이스라 caller가 hidden 키를 아예 안 넣으면 500이 난다. get('hidden')은 Map 인터페이스의 평범한
+    public 메서드 호출이라 키 부재·null 모두 예외 없이 null을 돌려준다(null-safe). 반복 변수명은 Thymeleaf가
+    자동 부여하는 웹 변수 'param'과 충돌하지 않도록 hiddenParam으로 둔다("such name is a reserved word" 방지).
   파라미터: basePath(GET/hx-get URL), resultsId(htmx target id), search(검색 필드 설정 map),
   savedViews·filters·viewSettings(각 영역 마크업 fragment, 없으면 ~{} 전달).
 -->
@@ -26,9 +31,9 @@
 	      hx-trigger="submit, keyup changed delay:300ms">
 		<input type="search" th:name="${search.name}" th:value="${search.value}"
 		       th:placeholder="${search.placeholder}" th:aria-label="${search.label}" autocomplete="off">
-		<th:block th:if="${search.hidden}">
-			<input type="hidden" th:each="param : ${search.hidden}"
-			       th:name="${param.key}" th:value="${param.value}">
+		<th:block th:if="${search.get('hidden')}">
+			<input type="hidden" th:each="hiddenParam : ${search.get('hidden')}"
+			       th:name="${hiddenParam.key}" th:value="${hiddenParam.value}">
 		</th:block>
 		<button type="submit">검색</button>
 	</form>

--- a/backend/src/main/resources/templates/admin/stations/list.html
+++ b/backend/src/main/resources/templates/admin/stations/list.html
@@ -33,13 +33,13 @@
 
 		<!-- V6-06 공통 툴바: 검색은 항상 direct, 지역·노선 필터와 정렬(보기 설정)은 compact에서 시트로 접힌다.
 		     각 영역은 자기 form을 소유하고 나머지 파라미터를 hidden으로 보존해 필터가 서로를 덮어쓰지 않는다. -->
-		<!-- NOTE(#2279): 검색 form의 필터 보존용 hidden(search.hidden)은 보류. list-toolbar.html의
-		     th:each="param" 이 Thymeleaf 예약어 param을 loop 변수로 써 non-empty hidden 전달 시 500이 난다.
-		     해당 fragment는 §5 수정 파일 밖이라 수정하지 않고 보고한다. 필터→필터·정렬·페이지네이션 보존은
-		     아래 자체 form(hidden th:value)이 담당하므로 정상 동작하고, 키워드 검색 시 필터 유지만 보류된다. -->
+		<!-- 검색 form의 필터·정렬 보존용 hidden(search.hidden, #2279 리뷰 반영): list-toolbar.html이
+		     ${search.get('hidden')} 메서드 호출로 null-safe하게 읽고 hiddenParam으로 반복하므로, 여기서 지역·
+		     노선·정렬을 그대로 전달해 키워드 검색이 활성 필터를 덮어쓰지 않게 한다(§7 filter binding 불변). -->
 		<div th:replace="~{admin/fragments/list-toolbar :: toolbar(
 		         '/admin/stations/page', 'station-results',
-		         ${ {'name':'query','value':query,'placeholder':'역 이름 검색','label':'역 이름 검색','hidden':{}} },
+		         ${ {'name':'query','value':query,'placeholder':'역 이름 검색','label':'역 이름 검색',
+		            'hidden': {'region':selectedRegion,'lineId':selectedLine,'sort':selectedSort}} },
 		         ~{}, ~{::stationFilters}, ~{::stationView})}">
 			<form th:fragment="stationFilters" class="admin-toolbar-form" method="get"
 			      th:action="@{/admin/stations/page}" role="group" aria-label="지역·노선 필터"

--- a/backend/src/main/resources/templates/admin/stations/list.html
+++ b/backend/src/main/resources/templates/admin/stations/list.html
@@ -22,90 +22,140 @@
 	</header>
 
 	<!--
-	  역 목록 표준 테이블(#1741): 검색·지역·노선·정렬 툴바 + 표 + 페이지네이션을 stationResults fragment로 묶는다.
+	  역 목록 표준 테이블(#1741, V6-07 #2279 이관): 검색·필터·정렬을 V6-06 공통 툴바(list-toolbar)로,
+	  표는 공통 표 영역(table-region)으로 소비한다. 390px 첫 화면에서 sticky 첫 식별자 열(역)과 바로
+	  뒤 주의 항목(미확인 제보·확인 필요 시설)·데이터 품질이 즉시 보이고, 나머지 열은 가로 스크롤로 접근한다.
+	  식별자 링크가 상세 이동을 소유하므로 중복 상세 버튼은 두지 않는다.
 	  JS 있으면 htmx가 이 컨테이너만 교체하고 URL을 push, 없으면 form GET·링크가 전체 페이지로 동작한다.
 	-->
 	<div id="station-results" th:fragment="stationResults"
 	     hx-target="#station-results" hx-swap="outerHTML" hx-push-url="true">
-		<form class="table-toolbar" method="get" th:action="@{/admin/stations/page}"
-		      role="search" aria-label="역 검색"
-		      hx-target="#station-results" hx-swap="outerHTML" hx-push-url="true"
-		      th:attr="hx-get=@{/admin/stations/page}"
-		      hx-trigger="submit, change, keyup changed delay:300ms">
-			<input type="search" name="query" th:value="${query}"
-			       placeholder="역 이름 검색" aria-label="역 이름 검색" autocomplete="off">
-			<select name="region" aria-label="지역 필터">
-				<option th:each="opt : ${regionOptions}" th:value="${opt.value}"
-				        th:text="${opt.label}" th:selected="${opt.selected}">전체 지역</option>
-			</select>
-			<select name="lineId" aria-label="노선 필터">
-				<option th:each="opt : ${lineOptions}" th:value="${opt.value}"
-				        th:text="${opt.label}" th:selected="${opt.selected}">전체 노선</option>
-			</select>
-			<select name="sort" aria-label="정렬">
-				<option value="" th:selected="${selectedSort == null}">역명순</option>
-				<option value="name_desc" th:selected="${selectedSort == 'name_desc'}">역명 역순</option>
-				<option value="pending" th:selected="${selectedSort == 'pending'}">미확인 제보 많은 순</option>
-			</select>
-			<button type="submit">검색</button>
-		</form>
 
-		<div class="admin-table-scroll" tabindex="0" role="group"
-		     aria-label="가로로 스크롤 가능한 데이터 표">
-		<table>
-			<thead>
-			<tr>
-				<th scope="col">역</th>
-				<th scope="col">노선</th>
-				<th scope="col">지역</th>
-				<th scope="col">미확인 제보</th>
-				<th scope="col">확인 필요 시설</th>
-				<th scope="col">품질</th>
-				<th scope="col">출구 / 시설 / 자료</th>
-				<th scope="col">노드 / 간선</th>
-				<th scope="col">마지막 확인</th>
-				<th scope="col">작업</th>
-			</tr>
-			</thead>
-			<tbody>
-			<tr th:if="${stations.isEmpty()}">
-				<td colspan="10">
-					<div th:replace="~{admin/fragments/empty-state :: panel('검색된 역이 없습니다.', '검색어·지역·노선 필터를 조정해 보세요.')}"></div>
-				</td>
-			</tr>
-			<tr th:each="station : ${stations}">
-				<td>
-					<a th:href="@{/admin/stations/{stationId}/page(stationId=${station.stationId})}"
-					   th:text="${station.stationName}">상록수</a>
-				</td>
-				<td th:text="${station.lineNames}">4호선</td>
-				<td th:text="${station.region}">수도권</td>
-				<td>
-					<!-- 미확인 제보 뱃지: 대기(SUBMITTED+UNDER_REVIEW) 건수. 0이면 표시하지 않는다. -->
-					<a th:if="${station.pendingReportCount > 0}" class="count-badge"
-					   th:href="@{/admin/reports/page(station=${station.stationId})}"
-					   th:text="${station.pendingReportCount}"
-					   th:attr="aria-label=|${station.stationName} 미확인 제보 ${station.pendingReportCount}건|">0</a>
-					<span th:unless="${station.pendingReportCount > 0}" class="meta">0</span>
-				</td>
-				<td>
-					<!-- 확인 필요 시설 뱃지: 고장·공사·폐쇄·확인 필요·사용자 제보 시설 수. 클릭 시 역 필터 시설 상태판. -->
-					<a th:if="${station.attentionFacilityCount > 0}" class="count-badge is-warn"
-					   th:href="@{/admin/facilities/page(stationId=${station.stationId},sort='attention')}"
-					   th:text="${station.attentionFacilityCount}"
-					   th:attr="aria-label=|${station.stationName} 확인 필요 시설 ${station.attentionFacilityCount}개|">0</a>
-					<span th:unless="${station.attentionFacilityCount > 0}" class="meta">0</span>
-				</td>
-				<td><span class="admin-status" th:text="${station.qualityLabel}">정보 확인 중</span></td>
-				<td th:text="|${station.exitCount} / ${station.facilityCount} / ${station.layoutSourceCount}|">0 / 0 / 0</td>
-				<td th:text="|${station.routeNodeCount} / ${station.routeEdgeCount}|">0 / 0</td>
-				<td th:text="${station.lastVerifiedAt}">2026-06-20</td>
-				<td>
-					<a class="admin-btn" th:href="@{/admin/stations/{stationId}/page(stationId=${station.stationId})}">상세</a>
-				</td>
-			</tr>
-			</tbody>
-		</table>
+		<!-- V6-06 공통 툴바: 검색은 항상 direct, 지역·노선 필터와 정렬(보기 설정)은 compact에서 시트로 접힌다.
+		     각 영역은 자기 form을 소유하고 나머지 파라미터를 hidden으로 보존해 필터가 서로를 덮어쓰지 않는다. -->
+		<!-- NOTE(#2279): 검색 form의 필터 보존용 hidden(search.hidden)은 보류. list-toolbar.html의
+		     th:each="param" 이 Thymeleaf 예약어 param을 loop 변수로 써 non-empty hidden 전달 시 500이 난다.
+		     해당 fragment는 §5 수정 파일 밖이라 수정하지 않고 보고한다. 필터→필터·정렬·페이지네이션 보존은
+		     아래 자체 form(hidden th:value)이 담당하므로 정상 동작하고, 키워드 검색 시 필터 유지만 보류된다. -->
+		<div th:replace="~{admin/fragments/list-toolbar :: toolbar(
+		         '/admin/stations/page', 'station-results',
+		         ${ {'name':'query','value':query,'placeholder':'역 이름 검색','label':'역 이름 검색','hidden':{}} },
+		         ~{}, ~{::stationFilters}, ~{::stationView})}">
+			<form th:fragment="stationFilters" class="admin-toolbar-form" method="get"
+			      th:action="@{/admin/stations/page}" role="group" aria-label="지역·노선 필터"
+			      th:attr="hx-get=@{/admin/stations/page}" hx-target="#station-results"
+			      hx-swap="outerHTML" hx-push-url="true" hx-trigger="change, submit">
+				<input type="hidden" name="query" th:value="${query}">
+				<input type="hidden" name="sort" th:value="${selectedSort}">
+				<select name="region" aria-label="지역 필터">
+					<option th:each="opt : ${regionOptions}" th:value="${opt.value}"
+					        th:text="${opt.label}" th:selected="${opt.selected}">전체 지역</option>
+				</select>
+				<select name="lineId" aria-label="노선 필터">
+					<option th:each="opt : ${lineOptions}" th:value="${opt.value}"
+					        th:text="${opt.label}" th:selected="${opt.selected}">전체 노선</option>
+				</select>
+				<button type="submit">필터 적용</button>
+			</form>
+			<form th:fragment="stationView" class="admin-toolbar-form" method="get"
+			      th:action="@{/admin/stations/page}" role="group" aria-label="정렬"
+			      th:attr="hx-get=@{/admin/stations/page}" hx-target="#station-results"
+			      hx-swap="outerHTML" hx-push-url="true" hx-trigger="change, submit">
+				<input type="hidden" name="query" th:value="${query}">
+				<input type="hidden" name="region" th:value="${selectedRegion}">
+				<input type="hidden" name="lineId" th:value="${selectedLine}">
+				<select name="sort" aria-label="정렬">
+					<option value="" th:selected="${selectedSort == null}">역명순</option>
+					<option value="name_desc" th:selected="${selectedSort == 'name_desc'}">역명 역순</option>
+					<option value="pending" th:selected="${selectedSort == 'pending'}">미확인 제보 많은 순</option>
+				</select>
+				<button type="submit">정렬 적용</button>
+			</form>
+		</div>
+
+		<!-- V6-06 공통 표 영역: wrapper(.admin-table-scroll)만 가로 overflow를 소유하고, 첫 식별자 열은
+		     sticky다. head·rows 마크업만 주입한다(caption은 접근성 이름). -->
+		<div th:replace="~{admin/fragments/table-region :: region(
+		         '역 목록 표', ~{::stationTableHead}, ~{::stationTableRows})}">
+			<th:block th:fragment="stationTableHead">
+				<tr>
+					<th scope="col">역</th>
+					<th scope="col">미확인 제보</th>
+					<th scope="col">확인 필요 시설</th>
+					<th scope="col">데이터 품질</th>
+					<th scope="col">노선</th>
+					<th scope="col">지역</th>
+					<th scope="col">출구 / 시설 / 자료</th>
+					<th scope="col">노드 / 간선</th>
+					<th scope="col">마지막 확인</th>
+				</tr>
+			</th:block>
+			<th:block th:fragment="stationTableRows">
+				<tr th:if="${stations.isEmpty()}">
+					<td colspan="9">
+						<div th:replace="~{admin/fragments/empty-state :: panel('검색된 역이 없습니다.', '검색어·지역·노선 필터를 조정해 보세요.')}"></div>
+					</td>
+				</tr>
+				<tr th:each="station : ${stations}">
+					<td>
+						<!-- 식별자 링크가 상세 허브 이동을 소유한다(중복 상세 버튼 없음). -->
+						<a th:href="@{/admin/stations/{stationId}/page(stationId=${station.stationId})}"
+						   th:text="${station.stationName}">상록수</a>
+					</td>
+					<td>
+						<!-- 미확인 제보 뱃지: 대기(SUBMITTED+UNDER_REVIEW) 건수. 0이면 표시하지 않는다. -->
+						<a th:if="${station.pendingReportCount > 0}" class="count-badge"
+						   th:href="@{/admin/reports/page(station=${station.stationId})}"
+						   th:text="${station.pendingReportCount}"
+						   th:attr="aria-label=|${station.stationName} 미확인 제보 ${station.pendingReportCount}건|">0</a>
+						<span th:unless="${station.pendingReportCount > 0}" class="meta">0</span>
+					</td>
+					<td>
+						<!-- 확인 필요 시설 뱃지: 고장·공사·폐쇄·확인 필요·사용자 제보 시설 수. 클릭 시 역 필터 시설 상태판. -->
+						<a th:if="${station.attentionFacilityCount > 0}" class="count-badge is-warn"
+						   th:href="@{/admin/facilities/page(stationId=${station.stationId},sort='attention')}"
+						   th:text="${station.attentionFacilityCount}"
+						   th:attr="aria-label=|${station.stationName} 확인 필요 시설 ${station.attentionFacilityCount}개|">0</a>
+						<span th:unless="${station.attentionFacilityCount > 0}" class="meta">0</span>
+					</td>
+					<td>
+						<!-- 데이터 품질: 텍스트 + 아이콘 + 색으로 상태를 전한다(색 단독 표현 금지). -->
+						<th:block th:with="qtone=${station.qualityLabel == '고장·공사 반영' ? 'good'
+						                     : (station.qualityLabel == '정보 확인 중' ? 'warn' : 'info')},
+						                   qicon=${station.qualityLabel == '고장·공사 반영' ? 'check'
+						                     : (station.qualityLabel == '정보 확인 중' ? 'warning' : 'info')}">
+							<span class="data-status" th:classappend="|tone-${qtone}|">
+								<svg th:replace="~{admin/fragments/icon :: icon(${qicon})}"></svg>
+								<span th:text="${station.qualityLabel}">정보 확인 중</span>
+							</span>
+						</th:block>
+					</td>
+					<td th:text="${station.lineNames}">4호선</td>
+					<td th:text="${station.region}">수도권</td>
+					<td th:text="|${station.exitCount} / ${station.facilityCount} / ${station.layoutSourceCount}|">0 / 0 / 0</td>
+					<td th:text="|${station.routeNodeCount} / ${station.routeEdgeCount}|">0 / 0</td>
+					<td>
+						<!-- 마지막 확인: 상대 시간 + 정확한 날짜 병기(색 단독 금지 아님, 시간 정보). lastVerifiedAt은 뷰모델에서
+						     ISO 문자열(yyyy-MM-dd)로 직렬화돼 오므로 표시 계층에서 LocalDate로 되돌려 상대 시간을 계산한다.
+						     값이 없으면 '기록 없음'으로만 표기한다(placeholder 데이터 없음). -->
+						<th:block th:if="${station.lastVerifiedAt != null and station.lastVerifiedAt != 'null'}"
+						          th:with="verifiedDate=${T(java.time.LocalDate).parse(station.lastVerifiedAt)},
+						                   daysAgo=${T(java.time.temporal.ChronoUnit).DAYS.between(verifiedDate, T(java.time.LocalDate).now())}">
+							<span class="data-verified">
+								<span class="data-verified-relative"
+								      th:title="${#temporals.format(verifiedDate, 'yyyy-MM-dd')}"
+								      th:text="${daysAgo le 0 ? '오늘' : (daysAgo == 1 ? '어제'
+								        : (daysAgo lt 7 ? daysAgo + '일 전'
+								        : (daysAgo lt 31 ? daysAgo / 7 + '주 전'
+								        : (daysAgo lt 365 ? daysAgo / 30 + '개월 전' : daysAgo / 365 + '년 전'))))}">3일 전</span>
+								<span class="meta" th:text="${#temporals.format(verifiedDate, 'yyyy-MM-dd')}">2026-06-20</span>
+							</span>
+						</th:block>
+						<span th:unless="${station.lastVerifiedAt != null and station.lastVerifiedAt != 'null'}"
+						      class="meta">기록 없음</span>
+					</td>
+				</tr>
+			</th:block>
 		</div>
 		<div th:replace="~{admin/fragments/pagination :: pager('역 목록 페이지', ${page}, ${paginationLinks})}"></div>
 	</div>

--- a/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminV3PageSmokeTest.java
+++ b/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminV3PageSmokeTest.java
@@ -62,6 +62,15 @@ class AdminV3PageSmokeTest {
 			.contains("/admin/stations/station-sangnoksu/page?tab=facilities")
 			.contains("/admin/reports/page?station=station-sangnoksu");
 
+		// V6-07 #2279: 현재 상태는 text+icon+color(색 단독 금지), 상태 변경 열은 우측 sticky action,
+		// 갱신일은 상대 시간 + 정확한 날짜 병기, 공통 표 영역(table-region) 계약을 소비한다.
+		assertThat(html)
+			.contains("class=\"data-status")
+			.contains("/icons/admin-symbols.svg#")
+			.contains("class=\"cell-sticky-action\"")
+			.contains("class=\"data-verified-relative\"")
+			.contains("가로로 스크롤 가능한 데이터 표");
+
 		String fragment = mockMvc.perform(get("/admin/facilities/page")
 				.param("sort", "attention")
 				.header("HX-Request", "true")
@@ -90,6 +99,16 @@ class AdminV3PageSmokeTest {
 			.contains("확인 필요 시설")
 			// 상록수 역 링크가 상세 허브로 연결된다.
 			.contains("/admin/stations/station-sangnoksu/page");
+
+		// V6-07 #2279: 데이터 품질은 text+icon+color(색 단독 금지), 마지막 확인은 상대 시간 + 정확한 날짜
+		// 병기, 식별자 링크가 상세 이동을 소유해 중복 상세 버튼(admin-btn)을 제거, 공통 표 영역을 소비한다.
+		assertThat(html)
+			.contains("데이터 품질")
+			.contains("class=\"data-status")
+			.contains("/icons/admin-symbols.svg#")
+			.contains("class=\"data-verified-relative\"")
+			.contains("가로로 스크롤 가능한 데이터 표")
+			.doesNotContain(">상세</a>");
 
 		// 정렬·지역 파라미터가 페이지네이션/툴바에 유지된다(htmx 부분 갱신도 같은 필터 공유).
 		String sorted = mockMvc.perform(get("/admin/stations/page")

--- a/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitFacilityAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitFacilityAdminPageControllerTest.java
@@ -57,7 +57,11 @@ class TransitFacilityAdminPageControllerTest {
 			.contains("확인 필요")
 			.contains("최근 확인된 정보")
 			.contains("name=\"status\"")
-			.contains("name=\"_csrf\"");
+			.contains("name=\"_csrf\"")
+			// V6-07 #2279: 상태는 text+icon+color(색 단독 금지)로, 갱신일은 상대 시간 + 정확한 날짜 병기로 렌더한다.
+			.contains("class=\"data-status")
+			.contains("/icons/admin-symbols.svg#")
+			.contains("class=\"data-verified-relative\"");
 	}
 
 	@Test

--- a/tools/qa/admin-accessibility-qa.mjs
+++ b/tools/qa/admin-accessibility-qa.mjs
@@ -180,6 +180,21 @@ function finalizeReport(report) {
       nodes: 0,
     });
   }
+  // V6-07 #2279: 마스터 목록 상태 신호 계약을 위반으로 편입한다. 첫 식별자 열이 sticky가 아니거나,
+  // 상태 셀에 비색 아이콘(또는 텍스트) 신호가 없거나(색 단독), 헤더 scope 연결이 없으면 실패를 표면화한다.
+  const statusSignal = report.keyboard.find((entry) => entry.check === "master-list-status-signal");
+  if (statusSignal
+    && (statusSignal.stickyIdentifier === false
+      || statusSignal.statusHasIcon === false
+      || statusSignal.statusHasText === false
+      || statusSignal.scopedHeaders === 0)) {
+    blockingViolations.push({
+      page: "/admin/stations/page",
+      id: "master-list-status-signal",
+      impact: "serious",
+      nodes: 0,
+    });
+  }
   const criticalViolations = blockingViolations.filter((violation) => violation.impact === "critical");
   const seriousViolations = blockingViolations.filter((violation) => violation.impact === "serious");
   report.summary = {
@@ -214,6 +229,7 @@ async function runJsPass(browser, baseUrl, outputDir, adminUser, adminPassword, 
   await captureAxTree(page, outputDir, report);
   await noCurrentWorkspaceDisclosure(page, baseUrl, report);
   await keyboardTableCheck(page, baseUrl, report);
+  await masterListStatusSignalCheck(page, baseUrl, report);
   await listToolbarSheetCheck(page, baseUrl, report);
   await textScalePass(page, baseUrl, outputDir, report, ADMIN_TEXT_SCALE_PAGES);
   await context.close();
@@ -577,6 +593,30 @@ async function keyboardTableCheck(page, baseUrl, report) {
     outlineWidth: focusState ? focusState.outlineWidth : null,
     outlineVisible,
   });
+}
+
+// V6-07 #2279: 마스터 목록 상태 신호 계약. 이관된 master-list(역 목록)를 mobile-390에서 열어
+// (1) 첫 식별자 열이 sticky로 고정되는지, (2) 상태가 색 단독이 아니라 아이콘(비색 신호)+텍스트를
+// 함께 갖는지, (3) 표 헤더가 scope로 연결되는지 검사한다. 하나라도 어기면 finalizeReport가 위반으로
+// 편입해 exit code로 실패를 표면화한다(§9 식별자·주의·품질 즉시 접근, badge accessible name).
+async function masterListStatusSignalCheck(page, baseUrl, report) {
+  await page.setViewportSize(VIEWPORTS.find((viewport) => viewport.name === "mobile-390"));
+  const response = await page.goto(`${baseUrl}/admin/stations/page`, { waitUntil: "networkidle" });
+  await assertOk(page, "/admin/stations/page", response);
+
+  const signal = await page.evaluate(() => {
+    const firstCell = document.querySelector(".admin-table-scroll tbody td:first-child");
+    const stickyIdentifier = firstCell ? getComputedStyle(firstCell).position === "sticky" : false;
+    const statusCells = Array.from(document.querySelectorAll(".admin-table-scroll .data-status"));
+    const statusHasIcon = statusCells.length > 0
+      && statusCells.every((cell) => cell.querySelector("svg.admin-icon") !== null);
+    const statusHasText = statusCells.length > 0
+      && statusCells.every((cell) => (cell.textContent || "").trim().length > 0);
+    const scopedHeaders = document.querySelectorAll(".admin-table-scroll thead th[scope=\"col\"]").length;
+    return { stickyIdentifier, statusCells: statusCells.length, statusHasIcon, statusHasText, scopedHeaders };
+  });
+
+  report.keyboard.push({ check: "master-list-status-signal", ...signal });
 }
 
 // #2278 V6-06: 목록 툴바 시트 계약. compact viewport에서 (1) body가 가로 overflow를 소유하지 않는지(§9),

--- a/tools/qa/admin-accessibility-qa.test.mjs
+++ b/tools/qa/admin-accessibility-qa.test.mjs
@@ -141,6 +141,25 @@ test("admin accessibility QA script verifies list toolbar sheet body overflow an
   assert.match(source, /listToolbar\.sheetClosed === false/);
 });
 
+// V6-07 #2279: 마스터 목록 상태 신호(sticky 식별자·비색 상태 아이콘+텍스트·헤더 scope) 계약을 source로 고정한다.
+test("admin accessibility QA script verifies master-list sticky identifier and non-color status signal", () => {
+  assert.match(source, /async function masterListStatusSignalCheck\(page, baseUrl, report\)/);
+  assert.match(source, /await masterListStatusSignalCheck\(page, baseUrl, report\)/);
+  assert.match(source, /check: "master-list-status-signal"/);
+  // 첫 식별자 열 sticky 고정을 실제 computed style로 판정한다.
+  assert.match(source, /getComputedStyle\(firstCell\)\.position === "sticky"/);
+  // 상태가 색 단독이 아니라 아이콘(비색 신호)+텍스트를 함께 갖는지 검사한다.
+  assert.match(source, /cell\.querySelector\("svg\.admin-icon"\)/);
+  assert.match(source, /statusHasIcon/);
+  assert.match(source, /statusHasText/);
+  // 표 헤더 scope 연결을 센다.
+  assert.match(source, /thead th\[scope=/);
+  // 계약 실패가 blocking 위반으로 표면화되는지 고정한다.
+  assert.match(source, /id: "master-list-status-signal"/);
+  assert.match(source, /statusSignal\.stickyIdentifier === false/);
+  assert.match(source, /statusSignal\.statusHasIcon === false/);
+});
+
 test("admin accessibility QA script records manual-only screen reader and contrast work", () => {
   assert.match(source, /VoiceOver reading flow/);
   assert.match(source, /high-contrast visual inspection/);


### PR DESCRIPTION
## 관련 이슈

close #2279
Refs #2271

## 작업 배경

- Admin UX v6 Epic(#2271)의 V6-07. compact 첫 화면에서 역 식별자·주의 항목(미확인 제보·확인 필요 시설)·데이터 품질을 동시에 보기 어렵고, 역 목록에는 식별자 링크와 별도 상세 버튼이 중복돼 있었다.
- V6-06(#2278)에서 도입한 공통 툴바(`list-toolbar`)·표 영역(`table-region`) fragment의 첫 실사용 이관 대상이 역·시설 master-list다.

## 작업 내용

- 역 목록(`stations/list.html`)·시설 상태판(`facilities/list.html`)을 V6-06 공통 `list-toolbar`·`table-region` fragment 소비로 이관.
- 열 순서를 정보 우선순위로 재배치: sticky 첫 식별자 열(역/시설) 뒤에 주의 항목·데이터 품질을 배치해 390px 첫 화면에서 즉시 보이도록 하고, 나머지 열은 가로 스크롤로 접근.
- 상태를 **text + icon + color**로 표기(V6-04 sprite `check`/`warning`/`error`/`info`, `currentColor`). 색 단독 표현 제거. 역은 데이터 품질, 시설은 현재 상태에 적용.
- 마지막 확인/갱신일을 **상대 시간 + 정확한 날짜 병기**(병기 텍스트 + `title` 속성). 값이 없으면 `기록 없음`.
- 역 목록의 중복 상세 버튼 제거 — 식별자 링크가 상세 이동을 소유. 시설 상태판은 상태 변경 form 열만 우측 sticky action.
- `admin-data.css`에 목록 상태 셀(`.data-status`)·갱신 시간 셀(`.data-verified`)·시트 form(`.admin-toolbar-form`) 스타일 추가(무채색·radius≤8·shadow 0·기존 상태색 토큰 범위 유지, data 레이어 소유권 준수).
- QA 하네스에 master-list 상태 신호 계약 검사(`master-list-status-signal`: sticky 식별자·비색 아이콘+텍스트·헤더 scope) 추가 및 source 계약 테스트 고정.
- `admin/fragments/list-toolbar.html`(이슈 §5에 경로·이유·검증 반영된 추가 수정 파일): 검색 hidden 반복 변수를 Thymeleaf 예약 웹 변수 `param`에서 `hiddenParam`으로 교체하고, `search.hidden` 읽기를 점(.) 프로퍼티 접근에서 `search.get('hidden')` 메서드 호출로 바꿔 hidden 키 부재 시에도 예외 없이 null을 반환하도록 null-safe 처리했다(Spring `MapAccessor.read()`가 키 부재+null 값을 `MapAccessException`으로 던지는 경로 회피). 역·시설 검색 form에 지역·노선·정렬(역), 유형·상태·역·정렬(시설) hidden 재전달을 복원해 키워드 검색이 활성 필터를 덮어쓰지 않도록 §7 filter binding 불변 계약을 완결했다.
- station/facility ID·route·filter·sort·pagination binding·상세 permission·HTMX/no-JS/CSP 계약 불변. mobile duplicate DOM 없음.

## 검증

- 실행한 명령과 결과:

```
# repository root — 전부 exit 0
node tools/ci/api-catalog.mjs validate                              # API catalog valid: 245
LC_ALL=C.UTF-8 node --test tools/ci/repository-contract.test.mjs    # tests 218, pass 218, fail 0
npm test --prefix tools/qa                                          # tests 12, pass 12, fail 0

# backend
./gradlew test \
  --tests 'com.easysubway.transit.adapter.in.web.TransitFacilityAdminPageControllerTest' \
  --tests 'com.easysubway.admin.adapter.in.web.AdminE2EFlowTest' \
  --tests 'com.easysubway.admin.adapter.in.web.AdminAccessibilitySmokeTest' \
  --tests 'com.easysubway.admin.adapter.in.web.AdminV3PageSmokeTest'
# BUILD SUCCESSFUL — TransitFacilityAdminPageControllerTest 7, AdminE2EFlowTest 4,
#   AdminAccessibilitySmokeTest 5, AdminV3PageSmokeTest 18 (fail 0)

# list-toolbar hidden 재전달 수정 후 재검증(70555bc7)
./gradlew cleanTest test \
  --tests '*AdminDesignGuardTest*' --tests '*AdminV3PageSmokeTest*' --tests '*TransitFacilityAdminPageControllerTest*'
# BUILD SUCCESSFUL — AdminDesignGuardTest 13, AdminV3PageSmokeTest 18, TransitFacilityAdminPageControllerTest 7 (fail 0)
LC_ALL=C.UTF-8 node --test tools/ci/repository-contract.test.mjs    # tests 218, pass 218, fail 0
npm test --prefix tools/qa                                          # tests 12, pass 12, fail 0
```

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 390px 식별자·주의·품질 즉시 접근 | admin web (dev/H2, form login, 390×844) | Chromium 실측 — sticky 첫 식별자 열·상태 아이콘+텍스트·배지 접근명 | 로컬: `qa-2279/stations-390.png`, `qa-2279/facilities-390.png`; `verify-2279.json`(stickyIdentifier=true, statusIconOk=true, badgeAccessibleName="상록수 확인 필요 시설 1개") | Pass |
| badge accessible name·table header 연결 | admin web (390) | axe-core/playwright 실측 + scope 헤더 카운트 | `verify-2279.json` (axe blocking 0 / violations 0, scopedHeaders 역9·시설7) | Pass |
| 상대 시간 + 정확한 instant 병기 | admin web (390) | 렌더 텍스트·title 실측 | `verify-2279.json` (역 "4일 전"/title 2026-07-15, 시설 "1개월 전"/title 2026-06-12) | Pass |
| empty / pagination / filter 회귀 0 | admin web (390) | empty query·size=1·sort 파라미터 실측 | `qa-2279/stations-empty-390.png`, `qa-2279/facilities-empty-390.png`; `verify-2279.json` (emptyState 렌더, pager 현재=1, sort=pending 16행) | Pass |
| 키워드 검색 시 활성 필터·정렬 보존(hidden 재전달, §7 불변) | admin web (dev/H2, form login, 1280×900) | region+sort/status+sort 필터를 먼저 걸고 키워드 검색 제출 → 실제 GET 요청 파라미터 실측 | 로컬: `qa-2279-hidden/verify-2279-hidden.json` — 역: `region=수도권&sort=pending` 유지 채 `query=역` 검색(1행), 시설: `status=NORMAL&sort=updated` 유지 채 `query=엘리베이터` 검색(1행); 필터 미설정 상태(hidden 값 전부 없음)도 200으로 null-safe 확인 | Pass |
| 자동 검증 명령 | CI/local | 위 §검증 명령 | 명령·출력 요약 | Pass (전부 exit 0) |

- tested revision: `70555bc7` (base `origin/main@e4bdd1fb`, 1차 구현 `e742af08` + list-toolbar hidden 수정 `70555bc7`). evidence는 로컬 dev/H2 부팅 후 admin form login으로 수집, seed=InMemoryTransitMasterRepository(dev profile, 상록수), viewport 390×844(§9 캡처)·1280×900(hidden 재전달 실측). 산출물은 커밋하지 않음(로컬 전용).
- QA 하네스 계약 검사(`master-list-status-signal`)는 `npm test --prefix tools/qa`로 source 고정, 실브라우저 실측은 위 focused 하네스로 대체(전체 QA 하네스는 operator seed 미구성 환경 제약).
- 참고: admin Basic Auth 경로(`httpBasic`)로 직접 curl하면 topbar 로그아웃 form(`shell.html`)이 세션 커밋 이후 `AuthorizationDeniedException`으로 응답을 절단하는 기존(이 PR과 무관한) 환경 이슈가 재현된다 — 수정 대상이 아니므로 admin form login 경로로 우회해 실측했다.

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: admin 템플릿·정적 CSS·QA 도구만 변경(관리자 화면 배포 시 반영). API·DB·계약 불변.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - **list-toolbar hidden 재전달 완결**: `admin/fragments/list-toolbar.html`의 `th:each="param : ${search.hidden}"`이 Thymeleaf 예약어 `param`을 loop 변수로 써 non-empty `search.hidden` 전달 시 500이 나고, `search.hidden` 키 부재 시에도 Spring `MapAccessor`가 `MapAccessException`을 던지는 결함이 있었다. `hiddenParam` 변수명 + `search.get('hidden')` 메서드 호출(null-safe)로 교체했고, 역·시설 검색 form에 hidden 재전달을 복원해 키워드 검색이 활성 필터·정렬을 덮어쓰지 않는다. 이슈 #2279 §5에 이 fragment 경로·이유·검증이 반영됐다.
  - 상태 tone→아이콘 매핑: 역 품질은 라벨 기반(고장·공사 반영=good/check, 정보 확인 중=warn/warning, 그 외=info), 시설은 enum 기반(NORMAL·ADMIN_VERIFIED=good/check, BROKEN·CLOSED=bad/error, 그 외=warn/warning).
  - 상대 시간 계산: 뷰모델 `lastVerifiedAt`은 문자열(ISO)로 직렬화돼 표시 계층에서 `LocalDate.parse`로 되돌린다(자체 직렬값의 결정적 역변환, fallback 아님). 시설 `lastUpdatedAt`은 LocalDate라 직접 계산.

## 리스크

- 롤백 경계: 이 PR은 admin 템플릿(`stations/list.html`, `facilities/list.html`, `fragments/list-toolbar.html`)·정적 CSS·테스트·QA 도구만 변경하므로, 회귀 시 이 PR의 커밋만 revert하면 V6-06 상태로 무손실 복귀한다. DB·API·마이그레이션·런타임 계약 변경 없음.
- `list-toolbar.html`은 V6-06(#2278)이 도입한 공통 fragment라 다른 화면이 아직 소비하지 않지만(현재 소비자는 이 PR의 두 화면뿐), 향후 다른 이관(V6-08~10)에도 이 수정이 적용된다 — null-safe 처리라 하위 호환.
- 아이콘 sprite(`admin-symbols.svg`)는 same-origin 정적 자원으로 CSP default-src 'self' 준수, no-JS에서도 렌더.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **개선 사항**
  - 시설·역 관리 목록에 공통 필터·정렬 툴바를 적용해 변경 시 표가 더 일관되게 갱신됩니다.
  - 상태를 아이콘·텍스트·색상으로 함께 표시하고, 마지막 확인/갱신일을 상대 시간과 정확한 날짜로 제공합니다(기록 없음 표시 포함).
  - 모바일에서 가로 스크롤을 지원하고, 고정 열(우측 액션)을 유지합니다.
  - 역 목록에서 “상세” 버튼 열을 제거했습니다.
- **테스트/QA**
  - 상태 신호 관련 접근성 계약을 추가 검증하도록 스모크/QA를 확장했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
