### PR TITLE
[Fix] 기차검색 cache 테스트 시간 의존 제거 — 하드코딩 instant를 상대 시각으로

### DIFF
--- a/backend/src/test/java/com/easysubway/common/persistence/DatabaseMigrationContainerTest.java
+++ b/backend/src/test/java/com/easysubway/common/persistence/DatabaseMigrationContainerTest.java
@@ -18,6 +18,7 @@ import java.time.Instant;
 import java.time.Duration;
 import java.time.ZoneId;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
@@ -287,7 +288,10 @@ class DatabaseMigrationContainerTest {
 				.containsEntry("minute_calls", 1)
 				.containsEntry("daily_calls", 1);
 
-			Instant observedAt = Instant.parse("2026-07-19T00:00:00Z");
+			// freshLeg/tryAcquireLease는 저장소의 CURRENT_TIMESTAMP(실시간 DB 시계)와 expires_at을
+			// 비교하므로 관측 시각을 실행 시점 기준 상대 시각으로 고정해 시간 의존성을 제거한다.
+			// 초 단위 절삭으로 DB 타임스탬프 정밀도에 따른 round-trip 불일치(contains(leg))도 방지한다.
+			Instant observedAt = Instant.now().truncatedTo(ChronoUnit.SECONDS);
 			var leg = new CachedLeg(
 				"owned", "{}", "[]", "a".repeat(64), observedAt, observedAt.plusSeconds(300));
 			assertThat(repository.tryAcquireLease("owned", "owner-a", observedAt, Duration.ofSeconds(15))).isTrue();


### PR DESCRIPTION
## 관련 이슈

Refs #2094

## 작업 내용

- `DatabaseMigrationContainerTest`의 "PostgreSQL 기차검색 cache는 lease 경쟁과 KST quota window를 원자적으로 조정한다" 테스트가 하드코딩한 `Instant.parse("2026-07-19T00:00:00Z")`(관측 시각)를 실행 시점 기준 상대 시각 `Instant.now().truncatedTo(ChronoUnit.SECONDS)`로 교체.
- 원인: 저장소 `JdbcTrainSearchCache`의 `freshLeg`는 `expires_at > CURRENT_TIMESTAMP`(실시간 DB 시계)로 필터하고 `tryAcquireLease`는 `databaseNow()`(실시간 DB 시계)로 lease 만료를 판정한다. 전달 `Instant now`는 null 검사만 하고 SQL 비교에 쓰지 않는다. 테스트가 저장한 leg의 `expires_at = observedAt + 300s = 2026-07-19T00:05:00Z`가 실 벽시계로 과거가 되면, `freshLeg`가 빈 결과를 돌려주어 296행 `.contains(leg)`가 먼저 깨지고(보고된 AssertionError), 이어 297행 `tryAcquireLease("owned","owner-c",...)`도 `expires_at <= databaseNow`가 참이 되어 lease를 재획득해 `isFalse()`가 깨진다. 즉 2026-07-19T00:05:00Z 경계 이후 결정적 실패이며, CI에서 2연속 재현되었다.
- 프로덕션 코드는 설계대로 DB 시계와 비교하므로 정상. 테스트만 시간 독립적으로 수정. 초 단위 절삭으로 DB 타임스탬프 정밀도에 따른 round-trip 불일치(`contains(leg)` 동등성)도 방지한다.

## 검증

- 실행한 명령과 결과:
  - `cd backend && ./gradlew test --tests '*DatabaseMigrationContainerTest*'` → `BUILD SUCCESSFUL`, testsuite tests="17" failures="0" errors="0" skipped="0" (전체 green).
- 결정적 실패 재현 CI run (2026-07-19T00:00Z 경계 이후):
  - https://github.com/AquilaXk/easysubway/actions/runs/29666607146
  - https://github.com/AquilaXk/easysubway/actions/runs/29666607146

## 영향

- [x] 제품/운영 위험 없음 (route/accessibility/mobile UX/backend API/auth/security 아님)
- [x] DB migration 없음
- [x] 배포 영향 없음
- [x] route/realtime/datapack contract 영향 없음
- [x] CI workflow·계약 테스트·release gate JSON 변경 없음 (있으면 full.md로 전환)

## 체크리스트

- [x] 이 PR은 B/C등급 작업이며 full template이 필요 없다.
- [ ] CI 결과를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 폴백 리뷰를 단일 PR review로 게시했다.
