### PR TITLE
[Style] #2280 V6-08 신고 queue·bulk action·photo 경계 이관

### DIFF
--- a/backend/src/main/resources/templates/admin/reports/detail.html
+++ b/backend/src/main/resources/templates/admin/reports/detail.html
@@ -160,7 +160,8 @@
 			기준 신고 ID
 			<input name="duplicateOfReportId" type="text" autocomplete="off" placeholder="중복 처리할 때 입력" th:value="${reviewForm.duplicateOfReportId}">
 		</label>
-		<button type="submit" name="decision" value="ACCEPT">승인</button>
+		<!-- V6-04 button 계약(V6-08 #2280): 승인 primary, 반려 danger, 중복 처리 secondary로 액션 위계를 명시한다. -->
+		<button class="primary" type="submit" name="decision" value="ACCEPT">승인</button>
 		<button class="danger" type="submit" name="decision" value="REJECT">반려</button>
 		<button class="secondary" type="submit" name="decision" value="MARK_DUPLICATE">중복 처리</button>
 	</form>

--- a/backend/src/main/resources/templates/admin/reports/list.html
+++ b/backend/src/main/resources/templates/admin/reports/list.html
@@ -49,53 +49,70 @@
 	  hx-target·hx-swap·hx-push-url은 이 컨테이너에서 하위 링크로 상속된다.
 	-->
 	<div id="report-results" th:fragment="reportResults"
-	     hx-target="#report-results" hx-swap="outerHTML" hx-push-url="true">
-		<!-- 검색 툴바(#1737·#1740): 키워드 live search + 유형·사진 유무 select. JS 있으면 keyword는
-		     300ms debounce, select 변경(change)은 즉시 htmx 부분 갱신, 없으면 form GET 제출로 동일 동작.
-		     상태·정렬·기간·역은 hidden으로 유지된다(select·검색이 다른 필터를 덮어쓰지 않게). -->
-		<form class="table-toolbar" method="get" th:action="@{/admin/reports/page}"
-		      role="search" aria-label="신고 검색"
-		      hx-target="#report-results" hx-swap="outerHTML" hx-push-url="true"
-		      th:attr="hx-get=@{/admin/reports/page}"
-		      hx-trigger="submit, change, keyup changed delay:300ms">
-			<input type="search" name="keyword" th:value="${searchKeyword}"
-			       placeholder="신고 내용 검색" aria-label="신고 내용 검색" autocomplete="off">
-			<select name="type" aria-label="신고 유형 필터">
-				<option th:each="opt : ${typeFilters}" th:value="${opt.value}"
-				        th:text="${opt.label}" th:selected="${opt.selected}">전체 유형</option>
-			</select>
-			<select name="hasPhoto" aria-label="사진 유무 필터">
-				<option th:each="opt : ${photoFilters}" th:value="${opt.value}"
-				        th:text="${opt.label}" th:selected="${opt.selected}">사진 전체</option>
-			</select>
-			<input type="hidden" name="status" th:if="${selectedStatus != null}" th:value="${selectedStatus}">
-			<input type="hidden" name="station" th:if="${selectedStation != null}" th:value="${selectedStation}">
-			<input type="hidden" name="sort" th:if="${sortParam != null}" th:value="${sortParam}">
-			<input type="hidden" name="from" th:if="${createdFrom != null}" th:value="${createdFrom}">
-			<input type="hidden" name="to" th:if="${createdTo != null}" th:value="${createdTo}">
-			<button type="submit">검색</button>
-		</form>
-
-		<div class="table-filters">
-			<nav class="date-presets" aria-label="접수 기간">
-				<a th:each="preset : ${datePresets}"
-				   th:href="${preset.href}"
-				   th:attr="hx-get=${preset.href},aria-current=${preset.active ? 'true' : null}"
-				   th:text="${preset.label}">오늘</a>
-			</nav>
-			<div class="filter-chips" th:if="${!filterChips.isEmpty()}" aria-label="적용된 필터">
-				<a th:each="chip : ${filterChips}" class="filter-chip"
-				   th:href="${chip.removeHref}" th:attr="hx-get=${chip.removeHref}"
-				   th:title="|${chip.label} 제거|">
-					<span th:text="${chip.label}">검색: 키워드</span>
-					<span aria-hidden="true">✕</span>
-				</a>
+	     hx-target="#report-results" hx-swap="outerHTML" hx-push-url="true"
+	     x-data="reportTable" x-on:keydown.window="handleKey">
+		<!-- V6-06 공통 툴바(V6-08 #2280 이관): 검색은 항상 direct, 유형·사진 필터는 필터 시트, 밀도·열 표시는
+		     보기 설정 시트로 접힌다(compact ≤768px). 각 영역 form은 나머지 파라미터를 hidden으로 보존해
+		     검색·필터가 서로를 덮어쓰지 않는다(§7 filter binding 불변). 저장된 뷰는 툴바 바로 아래 형제로 유지한다
+		     (모델 attribute savedViews가 툴바 fragment 파라미터명 savedViews와 충돌해 슬롯 주입 시 셰도잉되므로).
+		     보기 설정(밀도·열 표시)은 reportTable 조상 스코프(#report-results)의 메서드에 바인딩된다. -->
+		<!-- 검색 form의 필터·정렬 보존용 hidden(search.hidden): list-toolbar.html이 ${search.get('hidden')}
+		     메서드 호출로 null-safe하게 읽고 hiddenParam으로 반복하므로, 유형·사진·상태·역·정렬·기간을 그대로
+		     전달해 키워드 검색이 활성 필터를 덮어쓰지 않게 한다. -->
+		<div th:replace="~{admin/fragments/list-toolbar :: toolbar(
+		         '/admin/reports/page', 'report-results',
+		         ${ {'name':'keyword','value':searchKeyword,'placeholder':'신고 내용 검색','label':'신고 내용 검색',
+		            'hidden': {'type':selectedType,'hasPhoto':selectedHasPhoto,'status':selectedStatus,
+		                       'station':selectedStation,'sort':sortParam,'from':createdFrom,'to':createdTo}} },
+		         ~{}, ~{::reportFilters}, ~{::reportView})}">
+			<!-- 유형·사진 필터(필터 시트): 키워드·상태·역·정렬·기간을 hidden으로 보존한다. change/submit에
+			     htmx 부분 갱신, no-JS는 form GET 제출로 동일 동작. -->
+			<form th:fragment="reportFilters" class="admin-toolbar-form" method="get"
+			      th:action="@{/admin/reports/page}" role="group" aria-label="유형·사진 필터"
+			      th:attr="hx-get=@{/admin/reports/page}" hx-target="#report-results"
+			      hx-swap="outerHTML" hx-push-url="true" hx-trigger="change, submit">
+				<input type="hidden" name="keyword" th:value="${searchKeyword}">
+				<input type="hidden" name="status" th:value="${selectedStatus}">
+				<input type="hidden" name="station" th:value="${selectedStation}">
+				<input type="hidden" name="sort" th:value="${sortParam}">
+				<input type="hidden" name="from" th:value="${createdFrom}">
+				<input type="hidden" name="to" th:value="${createdTo}">
+				<select name="type" aria-label="신고 유형 필터">
+					<option th:each="opt : ${typeFilters}" th:value="${opt.value}"
+					        th:text="${opt.label}" th:selected="${opt.selected}">전체 유형</option>
+				</select>
+				<select name="hasPhoto" aria-label="사진 유무 필터">
+					<option th:each="opt : ${photoFilters}" th:value="${opt.value}"
+					        th:text="${opt.label}" th:selected="${opt.selected}">사진 전체</option>
+				</select>
+				<button type="submit">필터 적용</button>
+			</form>
+			<!-- 보기 설정(보기 설정 시트): 밀도 3단·열 표시 토글·단축키 도움말. reportTable(#report-results
+			     조상 스코프)의 메서드에 바인딩된다. 순수 표시 설정이라 폼 밖에 두어 제출되지 않는다. no-JS는
+			     x-cloak 트리거가 숨고 시트 내용이 인라인으로 남는다(JS 전용 토글은 no-JS에서 무동작). -->
+			<div th:fragment="reportView" class="table-viewbar" role="group" aria-label="표 보기 설정">
+				<fieldset class="density-control">
+					<legend>밀도</legend>
+					<label><input type="radio" name="_density" value="compact" x-on:change="setDensity"> 좁게</label>
+					<label><input type="radio" name="_density" value="default" checked x-on:change="setDensity"> 기본</label>
+					<label><input type="radio" name="_density" value="comfortable" x-on:change="setDensity"> 넓게</label>
+				</fieldset>
+				<fieldset class="column-control">
+					<legend>열 표시</legend>
+					<label><input type="checkbox" x-on:change="toggleCoordinate"> 좌표 숨김</label>
+					<label><input type="checkbox" x-on:change="togglePhoto"> 사진 숨김</label>
+				</fieldset>
+				<!-- 단축키 도움말(#1740): 버튼으로도 여닫아 스크린리더·마우스 사용자도 접근한다. no-JS는 x-cloak로 숨김. -->
+				<button type="button" class="shortcut-help-trigger" x-cloak
+				        x-on:click="toggleHelp" x-bind:aria-expanded="helpExpanded"
+				        aria-label="키보드 단축키 도움말 열기">단축키 <kbd>?</kbd></button>
 			</div>
 		</div>
 
 		<!--
 		  저장된 뷰(#1737): 계정별 검색 스냅샷. 적용은 htmx/no-JS 링크, 저장·기본·삭제는 command token +
-		  CSRF POST(no-JS 기준선, 처리 후 목록으로 리다이렉트). 화면군 이슈가 이 패턴을 복제한다.
+		  CSRF POST(no-JS 기준선, 처리 후 목록으로 리다이렉트). command token·CSRF·payload 계약은 불변.
+		  툴바 파라미터명 savedViews와의 셰도잉을 피해 툴바 슬롯이 아닌 형제로 둔다.
 		-->
 		<div class="saved-views" aria-label="저장된 뷰">
 			<div class="saved-view-list" th:if="${!savedViews.isEmpty()}">
@@ -132,6 +149,23 @@
 			</form>
 		</div>
 
+		<div class="table-filters">
+			<nav class="date-presets" aria-label="접수 기간">
+				<a th:each="preset : ${datePresets}"
+				   th:href="${preset.href}"
+				   th:attr="hx-get=${preset.href},aria-current=${preset.active ? 'true' : null}"
+				   th:text="${preset.label}">오늘</a>
+			</nav>
+			<div class="filter-chips" th:if="${!filterChips.isEmpty()}" aria-label="적용된 필터">
+				<a th:each="chip : ${filterChips}" class="filter-chip"
+				   th:href="${chip.removeHref}" th:attr="hx-get=${chip.removeHref}"
+				   th:title="|${chip.label} 제거|">
+					<span th:text="${chip.label}">검색: 키워드</span>
+					<span aria-hidden="true">✕</span>
+				</a>
+			</div>
+		</div>
+
 		<nav class="status-filter" aria-label="신고 상태 필터">
 			<a th:href="${allFilter.href}"
 			   th:attr="hx-get=${allFilter.href},aria-current=${allFilter.current ? 'page' : null}">전체</a>
@@ -145,28 +179,9 @@
 		  일괄 검수(#1737): 체크박스로 선택한 신고를 한 번에 승인/반려한다. command token + CSRF POST.
 		  진화형 향상 — JS 없으면 체크박스 + 액션 버튼이 그대로 동작하고, 있으면 전체 선택·선택 수 표시가 붙는다.
 		-->
-		<div class="report-table" x-data="reportTable" x-on:keydown.window="handleKey">
-			<!--
-			  표 보기 설정(#1737): 밀도 3단·컬럼 표시 토글. 순수 표시 설정이라 폼 밖에 두어 제출되지 않는다.
-			  진화형 향상 — JS 없으면 기본 밀도·전체 컬럼으로 보이고, 있으면 즉시 반영된다(CSP: 메서드 참조만).
-			-->
-			<div class="table-viewbar" role="group" aria-label="표 보기 설정">
-				<fieldset class="density-control">
-					<legend>밀도</legend>
-					<label><input type="radio" name="_density" value="compact" x-on:change="setDensity"> 좁게</label>
-					<label><input type="radio" name="_density" value="default" checked x-on:change="setDensity"> 기본</label>
-					<label><input type="radio" name="_density" value="comfortable" x-on:change="setDensity"> 넓게</label>
-				</fieldset>
-				<fieldset class="column-control">
-					<legend>열 표시</legend>
-					<label><input type="checkbox" x-on:change="toggleCoordinate"> 좌표 숨김</label>
-					<label><input type="checkbox" x-on:change="togglePhoto"> 사진 숨김</label>
-				</fieldset>
-				<!-- 단축키 도움말(#1740): 버튼으로도 여닫아 스크린리더·마우스 사용자도 접근한다. no-JS는 x-cloak로 숨김. -->
-				<button type="button" class="shortcut-help-trigger" x-cloak
-				        x-on:click="toggleHelp" x-bind:aria-expanded="helpExpanded"
-				        aria-label="키보드 단축키 도움말 열기">단축키 <kbd>?</kbd></button>
-			</div>
+		<!-- reportTable 스코프는 #report-results(조상)로 올려, 보기 설정 시트(밀도·열 표시)와 표·일괄 폼·단축키가
+		     같은 컴포넌트를 공유한다. 이 컨테이너는 폼·표·단축키 오버레이만 묶는다(x-data는 조상이 소유). -->
+		<div class="report-table">
 			<form class="bulk-form" method="post" th:action="@{/admin/reports/bulk-review}">
 				<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 				<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
@@ -251,7 +266,8 @@
 				</div>
 			<div class="bulk-actionbar" x-show="hasSelection">
 				<span class="bulk-count" x-text="selectionLabel">선택한 신고 일괄 처리</span>
-				<button type="submit" name="decision" value="ACCEPT">선택 승인</button>
+				<!-- V6-04 button 계약(V6-08 #2280): 승인 primary, 반려 danger로 액션 위계를 명시한다. -->
+				<button class="primary" type="submit" name="decision" value="ACCEPT">선택 승인</button>
 				<button class="danger" type="submit" name="decision" value="REJECT">선택 반려</button>
 			</div>
 			</form>

--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminHtmxPilotTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminHtmxPilotTest.java
@@ -196,6 +196,34 @@ class FacilityReportAdminHtmxPilotTest {
 	}
 
 	@Test
+	@DisplayName("신고 대기열은 V6-06 공통 툴바(list-toolbar)를 소비하고 reportTable 스코프를 컨테이너로 올린다")
+	void reportQueueConsumesUnifiedListToolbar() throws Exception {
+		createReport("툴바 이관 확인 신고");
+
+		String html = mockMvc.perform(get("/admin/reports/page")
+				.with(httpBasic("admin-test", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn().getResponse().getContentAsString();
+
+		assertThat(html)
+			// 공통 툴바 루트 + 시트 트리거(필터·보기 설정)를 소비한다.
+			.contains("class=\"admin-list-toolbar\"")
+			.contains("admin-toolbar-filter-sheet")
+			.contains("admin-toolbar-view-sheet")
+			// 유형·사진 필터는 필터 시트 form으로, 밀도·열 표시는 보기 설정 시트로 이관된다.
+			.contains("aria-label=\"유형·사진 필터\"")
+			.contains("class=\"table-viewbar\"")
+			// 보기 설정(밀도·열 표시)이 동작하도록 reportTable 스코프가 컨테이너(#report-results)로 올라간다.
+			.contains("id=\"report-results\"")
+			.contains("x-data=\"reportTable\"")
+			.contains("x-bind:class=\"tableClass\"");
+		// 필터 form은 키워드·상태를 hidden으로 보존해 필터 변경이 검색·상태를 덮어쓰지 않는다(§7 filter binding).
+		assertThat(html.replaceAll("\\s+", " "))
+			.contains("<input type=\"hidden\" name=\"keyword\"")
+			.contains("<input type=\"hidden\" name=\"status\"");
+	}
+
+	@Test
 	@DisplayName("검색·상태 필터 링크는 현재 키워드를 유지한다")
 	void filterLinksPreserveKeyword() throws Exception {
 		String html = mockMvc.perform(get("/admin/reports/page")

--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageControllerTest.java
@@ -222,6 +222,8 @@ class FacilityReportAdminPageControllerTest {
 			.contains("신고 급증")
 			.contains("시설 신고 확인")
 			.doesNotContain("상태·사진·위치·접수일 기준으로 제보를 확인 대기열에 배치합니다.")
+			// V6-08 #2280 action 체계: 승인 primary, 반려 danger로 위계를 명시한다.
+			.contains("class=\"primary\" type=\"submit\" name=\"decision\" value=\"ACCEPT\">선택 승인")
 			.contains("class=\"danger\" type=\"submit\" name=\"decision\" value=\"REJECT\">선택 반려")
 			.contains("점검 필요")
 			.contains("신고가 평소보다 많습니다")
@@ -253,9 +255,10 @@ class FacilityReportAdminPageControllerTest {
 			.doesNotContain("facility-reports/")
 			.contains("37.302421")
 			.contains("126.866221")
-			.contains("name=\"decision\" value=\"ACCEPT\"")
-			.contains("name=\"decision\" value=\"REJECT\"")
-			.contains("name=\"decision\" value=\"MARK_DUPLICATE\"");
+			// V6-08 #2280 action 체계: 승인 primary, 반려 danger, 중복 처리 secondary로 위계를 명시한다.
+			.contains("class=\"primary\" type=\"submit\" name=\"decision\" value=\"ACCEPT\"")
+			.contains("class=\"danger\" type=\"submit\" name=\"decision\" value=\"REJECT\"")
+			.contains("class=\"secondary\" type=\"submit\" name=\"decision\" value=\"MARK_DUPLICATE\"");
 		assertThat(auditEventRepository.findRecent(AdminAuditEventType.PRIVACY_READ, 1))
 			.singleElement()
 				.satisfies(event -> {

--- a/tools/qa/admin-accessibility-qa.mjs
+++ b/tools/qa/admin-accessibility-qa.mjs
@@ -195,6 +195,23 @@ function finalizeReport(report) {
       nodes: 0,
     });
   }
+  // V6-08 #2280: 신고 대기열 action·photo 경계 계약을 위반으로 편입한다. 일괄 승인이 primary가 아니거나,
+  // 반려가 danger가 아니거나, 사진 셀이 raw object key를 노출하거나 썸네일이 permission-gated endpoint를
+  // 벗어나면 실패를 표면화한다(§7 action 체계, §9 photo matrix).
+  const actionSignal = report.keyboard.find((entry) => entry.check === "report-queue-action-signal");
+  if (actionSignal
+    && (actionSignal.bulkbarPresent === false
+      || actionSignal.approvePrimary === false
+      || actionSignal.rejectDanger === false
+      || actionSignal.noRawPhotoKey === false
+      || actionSignal.photoScoped === false)) {
+    blockingViolations.push({
+      page: "/admin/reports/page",
+      id: "report-queue-action-signal",
+      impact: "serious",
+      nodes: 0,
+    });
+  }
   const criticalViolations = blockingViolations.filter((violation) => violation.impact === "critical");
   const seriousViolations = blockingViolations.filter((violation) => violation.impact === "serious");
   report.summary = {
@@ -230,6 +247,7 @@ async function runJsPass(browser, baseUrl, outputDir, adminUser, adminPassword, 
   await noCurrentWorkspaceDisclosure(page, baseUrl, report);
   await keyboardTableCheck(page, baseUrl, report);
   await masterListStatusSignalCheck(page, baseUrl, report);
+  await reportQueueActionSignalCheck(page, baseUrl, report);
   await listToolbarSheetCheck(page, baseUrl, report);
   await textScalePass(page, baseUrl, outputDir, report, ADMIN_TEXT_SCALE_PAGES);
   await context.close();
@@ -617,6 +635,38 @@ async function masterListStatusSignalCheck(page, baseUrl, report) {
   });
 
   report.keyboard.push({ check: "master-list-status-signal", ...signal });
+}
+
+// V6-08 #2280: 신고 대기열 action·photo 경계 계약. 이관된 queue-review(신고 목록)를 mobile-390에서 열어
+// (1) 일괄 승인 버튼이 primary, 반려 버튼이 danger로 액션 위계를 명시하는지, (2) 사진 셀이 fail closed인지
+// — raw object key(facility-reports/)를 노출하지 않고 썸네일은 permission-gated endpoint만 참조하는지
+// 검사한다. 하나라도 어기면 finalizeReport가 위반으로 편입해 exit code로 실패를 표면화한다(§7 action 체계·§9 photo matrix).
+async function reportQueueActionSignalCheck(page, baseUrl, report) {
+  await page.setViewportSize(VIEWPORTS.find((viewport) => viewport.name === "mobile-390"));
+  const response = await page.goto(`${baseUrl}/admin/reports/page`, { waitUntil: "networkidle" });
+  await assertOk(page, "/admin/reports/page", response);
+
+  const signal = await page.evaluate(() => {
+    const bulkbar = document.querySelector(".bulk-actionbar");
+    const approve = document.querySelector(".bulk-actionbar button[name=\"decision\"][value=\"ACCEPT\"]");
+    const reject = document.querySelector(".bulk-actionbar button[name=\"decision\"][value=\"REJECT\"]");
+    const approvePrimary = approve ? approve.classList.contains("primary") : false;
+    const rejectDanger = reject ? reject.classList.contains("danger") : false;
+    // 사진 fail closed: 어떤 셀도 raw object key를 노출하지 않고, 썸네일은 permission-gated 원본 endpoint만 가리킨다.
+    const noRawPhotoKey = !(document.body.textContent || "").includes("facility-reports/");
+    const thumbs = Array.from(document.querySelectorAll(".report-thumb"));
+    const photoScoped = thumbs.every((anchor) => (anchor.getAttribute("href") || "").includes("/photo/original"));
+    return {
+      bulkbarPresent: Boolean(bulkbar),
+      approvePrimary,
+      rejectDanger,
+      noRawPhotoKey,
+      photoScoped,
+      thumbs: thumbs.length,
+    };
+  });
+
+  report.keyboard.push({ check: "report-queue-action-signal", ...signal });
 }
 
 // #2278 V6-06: 목록 툴바 시트 계약. compact viewport에서 (1) body가 가로 overflow를 소유하지 않는지(§9),

--- a/tools/qa/admin-accessibility-qa.mjs
+++ b/tools/qa/admin-accessibility-qa.mjs
@@ -197,14 +197,16 @@ function finalizeReport(report) {
   }
   // V6-08 #2280: 신고 대기열 action·photo 경계 계약을 위반으로 편입한다. 일괄 승인이 primary가 아니거나,
   // 반려가 danger가 아니거나, 사진 셀이 raw object key를 노출하거나 썸네일이 permission-gated endpoint를
-  // 벗어나면 실패를 표면화한다(§7 action 체계, §9 photo matrix).
+  // 벗어나거나, 사진 셀 검증 자체가 수행되지 않았으면(썸네일 0개, 무검증 PASS 위장 방지) 실패를 표면화한다
+  // (§7 action 체계, §9 photo matrix).
   const actionSignal = report.keyboard.find((entry) => entry.check === "report-queue-action-signal");
   if (actionSignal
     && (actionSignal.bulkbarPresent === false
       || actionSignal.approvePrimary === false
       || actionSignal.rejectDanger === false
       || actionSignal.noRawPhotoKey === false
-      || actionSignal.photoScoped === false)) {
+      || actionSignal.photoScoped === false
+      || actionSignal.photoScopedVerified === false)) {
     blockingViolations.push({
       page: "/admin/reports/page",
       id: "report-queue-action-signal",
@@ -652,16 +654,22 @@ async function reportQueueActionSignalCheck(page, baseUrl, report) {
     const reject = document.querySelector(".bulk-actionbar button[name=\"decision\"][value=\"REJECT\"]");
     const approvePrimary = approve ? approve.classList.contains("primary") : false;
     const rejectDanger = reject ? reject.classList.contains("danger") : false;
-    // 사진 fail closed: 어떤 셀도 raw object key를 노출하지 않고, 썸네일은 permission-gated 원본 endpoint만 가리킨다.
-    const noRawPhotoKey = !(document.body.textContent || "").includes("facility-reports/");
+    // 사진 fail closed: 어떤 셀도 raw object key를 노출하지 않고(속성값 leak 포함 innerHTML 스캔),
+    // 썸네일은 permission-gated 원본 endpoint만 가리킨다.
+    const noRawPhotoKey = !(document.body.innerHTML || "").includes("facility-reports/");
     const thumbs = Array.from(document.querySelectorAll(".report-thumb"));
-    const photoScoped = thumbs.every((anchor) => (anchor.getAttribute("href") || "").includes("/photo/original"));
+    // 썸네일이 0개면 every()가 무검증인데도 true를 반환해 PASS로 위장한다 — photoScopedVerified로 실제
+    // 검증 여부를 분리하고, photoScoped 자체도 미검증 시 fail closed로 false를 반환한다.
+    const photoScopedVerified = thumbs.length > 0;
+    const photoScoped = photoScopedVerified
+      && thumbs.every((anchor) => (anchor.getAttribute("href") || "").includes("/photo/original"));
     return {
       bulkbarPresent: Boolean(bulkbar),
       approvePrimary,
       rejectDanger,
       noRawPhotoKey,
       photoScoped,
+      photoScopedVerified,
       thumbs: thumbs.length,
     };
   });

--- a/tools/qa/admin-accessibility-qa.test.mjs
+++ b/tools/qa/admin-accessibility-qa.test.mjs
@@ -160,6 +160,25 @@ test("admin accessibility QA script verifies master-list sticky identifier and n
   assert.match(source, /statusSignal\.statusHasIcon === false/);
 });
 
+// V6-08 #2280: 신고 대기열 action·photo 경계(승인 primary·반려 danger·사진 fail closed) 계약을 source로 고정한다.
+test("admin accessibility QA script verifies report queue action hierarchy and photo fail-closed", () => {
+  assert.match(source, /async function reportQueueActionSignalCheck\(page, baseUrl, report\)/);
+  assert.match(source, /await reportQueueActionSignalCheck\(page, baseUrl, report\)/);
+  assert.match(source, /check: "report-queue-action-signal"/);
+  // 일괄 승인 primary·반려 danger 위계를 실제 DOM class로 판정한다.
+  assert.match(source, /button\[name=\\"decision\\"\]\[value=\\"ACCEPT\\"\]/);
+  assert.match(source, /button\[name=\\"decision\\"\]\[value=\\"REJECT\\"\]/);
+  assert.match(source, /classList\.contains\("primary"\)/);
+  assert.match(source, /classList\.contains\("danger"\)/);
+  // 사진 fail closed: raw object key 미노출 + 썸네일은 permission-gated 원본 endpoint만 참조한다.
+  assert.match(source, /noRawPhotoKey/);
+  assert.match(source, /photoScoped/);
+  // 계약 실패가 blocking 위반으로 표면화되는지 고정한다.
+  assert.match(source, /id: "report-queue-action-signal"/);
+  assert.match(source, /actionSignal\.approvePrimary === false/);
+  assert.match(source, /actionSignal\.rejectDanger === false/);
+});
+
 test("admin accessibility QA script records manual-only screen reader and contrast work", () => {
   assert.match(source, /VoiceOver reading flow/);
   assert.match(source, /high-contrast visual inspection/);

--- a/tools/qa/admin-accessibility-qa.test.mjs
+++ b/tools/qa/admin-accessibility-qa.test.mjs
@@ -170,13 +170,20 @@ test("admin accessibility QA script verifies report queue action hierarchy and p
   assert.match(source, /button\[name=\\"decision\\"\]\[value=\\"REJECT\\"\]/);
   assert.match(source, /classList\.contains\("primary"\)/);
   assert.match(source, /classList\.contains\("danger"\)/);
-  // 사진 fail closed: raw object key 미노출 + 썸네일은 permission-gated 원본 endpoint만 참조한다.
+  // 사진 fail closed: raw object key 미노출(속성값 leak 포함 innerHTML 스캔) + 썸네일은 permission-gated
+  // 원본 endpoint만 참조한다.
+  assert.match(source, /document\.body\.innerHTML \|\| ""\)\.includes\("facility-reports\/"\)/);
   assert.match(source, /noRawPhotoKey/);
   assert.match(source, /photoScoped/);
+  // 썸네일 0개 무검증 PASS 위장을 방지하는 photoScopedVerified 신호를 고정한다.
+  assert.match(source, /const photoScopedVerified = thumbs\.length > 0;/);
+  assert.match(source, /photoScopedVerified\s*\n\s*&&\s*thumbs\.every/);
   // 계약 실패가 blocking 위반으로 표면화되는지 고정한다.
   assert.match(source, /id: "report-queue-action-signal"/);
   assert.match(source, /actionSignal\.approvePrimary === false/);
   assert.match(source, /actionSignal\.rejectDanger === false/);
+  assert.match(source, /actionSignal\.photoScoped === false/);
+  assert.match(source, /actionSignal\.photoScopedVerified === false/);
 });
 
 test("admin accessibility QA script records manual-only screen reader and contrast work", () => {


### PR DESCRIPTION
## 관련 이슈

close #2280
Refs #2271

## 작업 배경

- 신고 처리자가 compact(390px) 화면에서도 필터·사진 확인·단건/일괄 승인·반려를 안전하게 완료해야 한다(#2280 §1).
- 기존 신고 대기열은 검색·필터·저장된 뷰·보기 설정이 개별 마크업으로 흩어져 있어 compact에서 우선순위와 시트 접힘 계약이 없었다.

## 작업 내용

- 신고 대기열(`admin/reports/list.html`)을 V6-06 공통 툴바(`list-toolbar`)로 이관: 검색은 direct, 유형·사진 필터는 필터 시트, 밀도·열 표시는 보기 설정 시트로 접는다(compact ≤768px). 각 영역 form은 나머지 파라미터를 hidden으로 보존해 검색·필터가 서로를 덮어쓰지 않는다(§7 filter binding 불변).
- 보기 설정(밀도·열 표시)이 동작하도록 `reportTable` Alpine 스코프를 컨테이너(`#report-results`)로 올려 툴바 보기 시트의 컨트롤이 조상 스코프 메서드에 바인딩되게 했다. `x-bind:class="tableClass"`(밀도·열 숨김)는 표 요소에 그대로 유지.
- 저장된 뷰는 모델 attribute `savedViews`가 툴바 fragment 파라미터명 `savedViews`와 셰도잉되어(슬롯 주입 시 500) 슬롯 대신 툴바 바로 아래 형제로 유지했다.
- action 체계(V6-04 button 계약): 승인 **primary**, 반려 **danger**를 명시(일괄 검수 바 + 상세 검수 폼, 중복 처리는 secondary).
- 사진/좌표 경계: original/thumbnail 권한과 raw object key 미노출(fail closed)을 drawer와 no-JS detail 모두에서 유지, 권한 surface 미확대. shortcut은 input·textarea·select·contenteditable focus 중 실행되지 않는 기존 가드 유지.
- 보존 계약: report status·bulk payload·CSRF·command token·audit 불변(관련 테스트 무변경 통과로 확인).
- QA 하네스에 신고 대기열 action·photo 경계 검사(`report-queue-action-signal`: 승인 primary·반려 danger·사진 fail closed) + source 고정 추가.

### 보류(§5 범위 밖 fragment 수정 필요)

- 표 자체의 `table-region` 이관은 보류했다. 밀도(`table.density-*`)·열 숨김(`table.hide-col-*` nth-child)이 `<table>` 요소의 `x-bind:class`를 요구하는데, `region(caption, head, rows)` 시그니처와 해당 CSS(`admin-components.css`)가 모두 §5 수정 파일 목록 밖이라 fragment 수정 없이는 불가하다. 표는 기존 접근성 scroll wrapper 계약(`admin-table-scroll`)을 그대로 유지하며 `AdminDesignGuardTest` 통과.

## 검증

- 실행한 명령과 결과:
  - `node tools/ci/api-catalog.mjs validate` → exit 0 (`API catalog valid: 245`)
  - `LC_ALL=C.UTF-8 node --test tools/ci/repository-contract.test.mjs` → 218 pass / 0 fail
  - `npm test --prefix tools/qa` → 13 pass / 0 fail
  - `cd backend && ./gradlew test --tests FacilityReportAdminPageControllerTest --tests FacilityReportAdminHtmxPilotTest --tests FacilityReportAdminPageReadOnlyControllerTest --tests JdbcFacilityReportReviewAuditRepositoryTest --tests AdminCommandTokenServiceTest` → BUILD SUCCESSFUL (Docker up, Testcontainers 포함)
  - `AdminDesignGuardTest` → 통과(표 wrapper·버튼 canonical class 계약 유지)

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

Tested SHA: `0d010b14` · seed/profile: dev/H2 in-memory(`SPRING_PROFILES_ACTIVE=dev`) · admin form-login · viewport 언급 시 mobile-390

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 390px 핵심 triage(필터→사진→승인/반려·bulk) | backend admin | dev/H2 부팅 후 `/admin/reports/page` 인증 렌더 + 마이그레이션 마커 grep | `admin-list-toolbar`(1)·filter/view 시트(2/2)·`table-viewbar`(1)·`x-data="reportTable"`(1)·`x-bind:class="tableClass"`(1)·bulk `primary`ACCEPT/`danger`REJECT(각1); 로컬 `/private/tmp/.../reports-page-live.html` | PASS |
| bulk selection/result/audit 일치 | backend admin | `FacilityReportAdminPageControllerTest`(bulkReviewAcceptsSelectedReports·감사 이력·command token 409) | gradle BUILD SUCCESSFUL, bulk payload·audit·token 불변 | PASS |
| photo unauthorized/authorized matrix | backend admin | 자동: `adminReportListShowsPhotoThumbnailOnlyWithReadPermission`(권한 없으면 '있음'만) + 라이브: admin-dev 권한 O → `report-thumb`·`/photo/original`(각1), `facility-reports/` raw key **0**(fail closed) | 자동 PASS + 라이브 grep | PASS |
| filter URL·HTMX fragment parity | backend admin | `?type=INFORMATION_WRONG` → 링크 18곳 전파; `HX-Request: true` → `admin-list-toolbar`(1)·doctype/sidebar 0; 필터 hidden(keyword/status/station/sort/from/to 각 2회) | 로컬 `frag.html`·`filtered.html` | PASS |
| drawer ↔ no-JS detail parity | backend admin | 동일 report id로 full page + `HX-Request` fragment 비교 | 두 응답 모두 승인 primary·반려 danger·중복 secondary 동일; drawer는 breadcrumb/doctype 없음; 사진 authorized·raw key 0·좌표 label 유지 | PASS |
| QA 하네스 action·photo 경계 검사 | tools/qa | `npm test --prefix tools/qa`(신규 `report-queue-action-signal` source 고정) | 13 pass / 0 fail | PASS |
| JS 렌더 390px 스크린샷 | backend admin | Playwright a11y 하네스 | 로컬 sandbox에서 controllable 브라우저 미확보(공유 Chrome 프로필 lock, tools/qa Playwright 미설치)로 라이브 JS 캡처 보류; no-JS 인증 렌더·자동 테스트로 계약 커버, Alpine 조상 스코프 해석은 v3 closestDataStack 문서 동작 | 부분(사유 기재) |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [ ] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [ ] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: admin 신고 화면 템플릿·QA 하네스만 변경(계약 불변), 배포 시 반영

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `list.html`: `reportTable` `x-data`가 `#report-results`로 올라가고 밀도·열 표시 컨트롤이 툴바 보기 시트로 이동한 점(Alpine 조상 스코프 바인딩). `x-bind:class="tableClass"`는 표에 유지.
  - 저장된 뷰를 툴바 슬롯이 아닌 형제로 둔 이유(모델 `savedViews` ↔ 툴바 파라미터 `savedViews` 셰도잉 회피). `~{}`를 슬롯으로 전달.
  - 표 `table-region` 이관 보류 근거(§5 밖 fragment/CSS 필요).

## 리스크

- 신고 대기열은 route/realtime/datapack/DB에 영향이 없고 admin 템플릿·QA 하네스에 국한된다. Rollback 경계: 이 커밋(`0d010b14`) revert 시 `list.html`/`detail.html`이 이전 툴바·버튼 마크업으로 복귀하고 QA 하네스 검사 1건이 제거될 뿐, API·payload·CSRF·command token·audit·photo 권한 계약은 이 PR에서 불변이라 데이터/스키마 롤백이 없다. 배포 롤백은 이전 backend 아티팩트 재배포로 충분.
- 라이브 JS 390px 스크린샷은 sandbox 브라우저 제약으로 보류(no-JS 인증 렌더·자동 테스트로 계약 커버). merge 전 a11y 하네스(Playwright)로 재확인 권장.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
