### PR TITLE
[Test] 데이터 수집 RUNNING fixture 시간 의존 제거

### DIFF
--- a/backend/src/test/java/com/easysubway/collection/application/service/DataCollectionServiceTest.java
+++ b/backend/src/test/java/com/easysubway/collection/application/service/DataCollectionServiceTest.java
@@ -382,7 +382,7 @@ class DataCollectionServiceTest {
 			DataCollectionSource.TRANSIT_MASTER,
 			DataCollectionStatus.RUNNING,
 			"admin-user",
-			LocalDateTime.of(2026, 7, 18, 12, 0),
+			LocalDateTime.now().minusMinutes(1),
 			null,
 			0,
 			null,


### PR DESCRIPTION
## 관련 이슈

이슈 없음(C등급)

## 작업 내용

- 현재 실행을 나타내는 RUNNING fixture를 고정 과거 시각 대신 현재 시각 기준 1분 전으로 생성합니다.
- 달력 시간이 2026-07-19를 지나면서 정상 실행 fixture가 24시간 고아 실행으로 오인되던 테스트 실패를 제거합니다.

## 검증

- `./gradlew test --tests 'com.easysubway.collection.application.service.DataCollectionServiceTest' --rerun-tasks --no-daemon`: 성공 (8/8)
- `./gradlew check --no-daemon`: 성공 (1,892 tests, 4 skipped)
- `git diff --check`: 성공

## 영향

- [x] 제품/운영 위험 없음 (route/accessibility/mobile UX/backend API/auth/security 아님)
- [x] DB migration 없음
- [x] 배포 영향 없음
- [x] route/realtime/datapack contract 영향 없음
- [x] CI workflow·계약 테스트·release gate JSON 변경 없음 (있으면 full.md로 전환)

## 체크리스트

- [x] 이 PR은 B/C등급 작업이며 full template이 필요 없다.
- [ ] CI 결과를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 폴백 리뷰를 단일 PR review로 게시했다.
