### PR TITLE
[Style] #2281 V6-09 Dashboard KPI·datapack 상태 계층 정리

### DIFF
--- a/backend/src/main/java/com/easysubway/admin/metric/application/service/AdminDashboardCardService.java
+++ b/backend/src/main/java/com/easysubway/admin/metric/application/service/AdminDashboardCardService.java
@@ -30,7 +30,7 @@ public class AdminDashboardCardService {
 		String sparkPoints = AdminMetricSparkline.points(values, SPARK_WIDTH, SPARK_HEIGHT);
 		Delta delta = delta(values, currentValue);
 		return new DashboardCard(
-			title, valueLabel, href, sparkPoints, delta.label(), delta.tone(), SPARK_WIDTH, SPARK_HEIGHT);
+			title, metricKey, valueLabel, href, sparkPoints, delta.label(), delta.tone(), SPARK_WIDTH, SPARK_HEIGHT);
 	}
 
 	// 전일(마지막 인덱스 직전의 가장 최근 비결측 스냅샷) 대비 증감. 이력이 없으면 증감을 비운다.
@@ -64,6 +64,9 @@ public class AdminDashboardCardService {
 
 	/**
 	 * @param title      카드 제목
+	 * @param metricKey  지표 키({@link com.easysubway.admin.metric.domain.AdminMetricKeys}). 카드의
+	 *                   의미 정체성이라 headline/disclosure 격하를 index가 아닌 지표 의미로 판정하는
+	 *                   근거로 쓴다(#2306 리뷰). 표시용 {@code data-metric-key}로도 노출된다.
 	 * @param value      현재 값 표시 문자열
 	 * @param href       카드 전체 클릭 시 이동할 화면
 	 * @param sparkPoints SVG polyline points(비면 스파크라인 생략)
@@ -74,6 +77,7 @@ public class AdminDashboardCardService {
 	 */
 	public record DashboardCard(
 		String title,
+		String metricKey,
 		String value,
 		String href,
 		String sparkPoints,

--- a/backend/src/main/resources/static/css/admin-data.css
+++ b/backend/src/main/resources/static/css/admin-data.css
@@ -152,6 +152,12 @@
 	font-size: 13px;
 }
 
+/* 나머지 KPI disclosure(#2281 V6-09): 대표 3개 아래로 격하된 지표를 접어 둔다. 펼치면 headline과
+   같은 카드 그리드(.dashboard-cards)를 재사용하되 요약과 카드 사이 상단 여백만 준다(구분선·시각 언어 불변). */
+.dashboard-more[open] .dashboard-cards {
+	margin-top: 12px;
+}
+
 /* 핵심 지표 패널 ↔ 기간 토글 사이 여백(#2047): #dashboard-trends는 section이 아니라 div라
    section+section 자동 간격을 못 받으므로, 추이 섹션 상단에 명시 여백을 준다(붙어 보이는 문제).
    대시보드 전용 스코프(#dashboard-trends)로 좁혀 usage·routes·notifications 화면에는 파급하지 않는다. */

--- a/backend/src/main/resources/static/js/admin/dashboard-charts.js
+++ b/backend/src/main/resources/static/js/admin/dashboard-charts.js
@@ -20,18 +20,32 @@
 		tokenColor('--admin-danger', '#b42318')
 	];
 
+	// #2281 V6-09: 차트를 그리지 못하면(Chart.js 부재·JSON 파싱 실패) 같은 값의 대체 표
+	// (details.dashboard-details "데이터 표로 보기")를 펼쳐 동일 데이터를 즉시 보이게 한다.
+	// 표 값은 서버가 canvas data-chart와 같은 소스로 렌더해 chart와 항상 일치한다.
+	function revealFallbackTable(canvas) {
+		var section = canvas.closest('section');
+		var fallback = section && section.querySelector('details.dashboard-details');
+		if (fallback) {
+			fallback.open = true;
+		}
+	}
+
 	function renderChart(canvas) {
 		if (!window.Chart) {
+			revealFallbackTable(canvas);
 			return;
 		}
 		var raw = canvas.getAttribute('data-chart');
 		if (!raw) {
+			revealFallbackTable(canvas);
 			return;
 		}
 		var data;
 		try {
 			data = JSON.parse(raw);
 		} catch (error) {
+			revealFallbackTable(canvas);
 			return;
 		}
 		if (canvas.chartInstance) {
@@ -67,8 +81,30 @@
 		scope.querySelectorAll('canvas.trend-canvas').forEach(renderChart);
 	}
 
+	// #2281 V6-09: 지표 수동 재집계 중복 실행 방지. snapshotToday()는 멱등이지만 더블클릭이 중복 POST를
+	// 낸다. 첫 제출에서 버튼을 비활성화(자리·크기 그대로 두어 layout stability 유지, aria-busy로 진행 표시)해
+	// 중복 실행을 막는다. no-JS에서는 이 가드 없이 폼이 그대로 한 번 제출된다.
+	function guardSnapshotRerun() {
+		var form = document.querySelector('.admin-dashboard-snapshot-actions form');
+		if (!form) {
+			return;
+		}
+		form.addEventListener('submit', function () {
+			if (form.getAttribute('data-submitting') === 'true') {
+				return;
+			}
+			form.setAttribute('data-submitting', 'true');
+			var button = form.querySelector('button[type="submit"]');
+			if (button) {
+				button.setAttribute('aria-busy', 'true');
+				button.disabled = true;
+			}
+		});
+	}
+
 	document.addEventListener('DOMContentLoaded', function () {
 		renderAll(document);
+		guardSnapshotRerun();
 	});
 	document.body.addEventListener('htmx:afterSwap', function (event) {
 		renderAll(event.target);

--- a/backend/src/main/resources/templates/admin/dashboard.html
+++ b/backend/src/main/resources/templates/admin/dashboard.html
@@ -43,21 +43,29 @@
 		</a>
 	</section>
 
-	<!-- 핵심 지표 패널(#2281 V6-09): 대표 KPI 3개만 headline으로 항상 노출하고 나머지는 disclosure로
-	     격하해 urgent state를 먼저 식별하게 한다. 각 셀 = 흐린 라벨 + 큰 숫자(tabular-nums) + 파랑
-	     스파크라인 + 상태 3색 델타. 셀 전체가 해당 화면으로 이동(a 태그 유지).
+	<!-- 핵심 지표 패널(#2281 V6-09): 시점·비율 대표 KPI만 headline으로 노출하고 누계 총량 지표는
+	     disclosure로 격하해 urgent state를 먼저 식별하게 한다. 각 셀 = 흐린 라벨 + 큰 숫자(tabular-nums)
+	     + 파랑 스파크라인 + 상태 3색 델타. 셀 전체가 해당 화면으로 이동(a 태그 유지).
+	     격하 판정은 index가 아니라 지표 의미(metric key)로 한다(#2306 리뷰): index 기준은 REPORT_REVIEW가
+	     없어 대표 제보 카드가 빠진 권한 부분집합에서 남은 세 카드가 전부 headline이 되어 누계 총량 카드가
+	     headline으로 잘못 승격됐다. 누계 총량 지표(AdminMetricKeys의 누계 총량 키)는 권한·카드 수와 무관하게
+	     항상 disclosure로 내린다. 남는 headline이 세 개 미만인 role에서도 3열 그리드가 좌측 정렬로 자연스럽게
+	     채워진다.
 	     기간 표기 명확화(#2293 리뷰 이관): 큰 숫자는 "현재 값", 스파크라인은 "최근 7일 추이", 델타는
 	     "전일 대비"임을 caption으로 못 박아 누계·시점 값이 아래 추이 기간 셀렉터(7/30/90)에 딸린
 	     수치로 읽히는 headline 의미 희석을 없앤다. -->
-	<section class="admin-panel dashboard-metric-panel" aria-labelledby="dashboard-metric-panel-title">
+	<section class="admin-panel dashboard-metric-panel" aria-labelledby="dashboard-metric-panel-title"
+	         th:with="headlineCards=${cards.?[metricKey != T(com.easysubway.admin.metric.domain.AdminMetricKeys).PUSH_FAILED]},
+	                  moreCards=${cards.?[metricKey == T(com.easysubway.admin.metric.domain.AdminMetricKeys).PUSH_FAILED]}">
 		<div class="admin-panel-head">
 			<h2 id="dashboard-metric-panel-title">핵심 지표</h2>
 		</div>
 		<p class="section-hint">현재 값 · 최근 7일 스파크라인 · 전일 대비. 기간 추이는 아래 추이 섹션에서 봅니다.</p>
-		<!-- 대표 KPI 3개: 시점·비율 지표를 앞세워 urgent state를 3초 내 식별한다. -->
+		<!-- headline: 시점·비율 대표 KPI. data-metric-key로 카드의 지표 정체성을 노출한다(격하 근거·QA 계약). -->
 		<div class="dashboard-cards">
-			<a th:each="card, iter : ${cards}" th:if="${iter.index < 3}"
-			   class="dashboard-card metric-cell" th:href="@{${card.href}}">
+			<a th:each="card : ${headlineCards}"
+			   class="dashboard-card metric-cell" th:href="@{${card.href}}"
+			   th:attr="data-metric-key=${card.metricKey}">
 				<span class="dashboard-card-title" th:text="${card.title}">제목</span>
 				<strong class="dashboard-card-value cell-num" th:text="${card.value}">0</strong>
 				<svg th:if="${!card.sparkPoints.isEmpty()}" class="dashboard-spark"
@@ -70,13 +78,14 @@
 				      th:text="${card.deltaLabel}">전일 대비</span>
 			</a>
 		</div>
-		<!-- 나머지 KPI(누계 총량 등)는 disclosure로 격하. native details라 keyboard·no-JS에서 그대로
-		     펼칠 수 있고, 셀 마크업은 headline과 동일 계약을 유지한다. -->
-		<details class="dashboard-details dashboard-more" th:if="${cards.size() > 3}">
-			<summary th:text="|나머지 지표 ${cards.size() - 3}개 보기|">나머지 지표 보기</summary>
+		<!-- 누계 총량 KPI는 disclosure로 격하. native details라 keyboard·no-JS에서 그대로 펼칠 수 있고,
+		     셀 마크업은 headline과 동일 계약을 유지한다. -->
+		<details class="dashboard-details dashboard-more" th:if="${!moreCards.isEmpty()}">
+			<summary th:text="|나머지 지표 ${moreCards.size()}개 보기|">나머지 지표 보기</summary>
 			<div class="dashboard-cards">
-				<a th:each="card, iter : ${cards}" th:if="${iter.index >= 3}"
-				   class="dashboard-card metric-cell" th:href="@{${card.href}}">
+				<a th:each="card : ${moreCards}"
+				   class="dashboard-card metric-cell" th:href="@{${card.href}}"
+				   th:attr="data-metric-key=${card.metricKey}">
 					<span class="dashboard-card-title" th:text="${card.title}">제목</span>
 					<strong class="dashboard-card-value cell-num" th:text="${card.value}">0</strong>
 					<svg th:if="${!card.sparkPoints.isEmpty()}" class="dashboard-spark"

--- a/backend/src/main/resources/templates/admin/dashboard.html
+++ b/backend/src/main/resources/templates/admin/dashboard.html
@@ -43,15 +43,21 @@
 		</a>
 	</section>
 
-	<!-- 핵심 지표 패널: 1px 보더 플랫 패널(#1983) 하나 안에 지표 셀을 1px 내부 구분선으로 분할.
-	     각 셀 = 흐린 라벨 + 큰 숫자(tabular-nums) + 파랑 스파크라인 + 상태 3색 델타.
-	     셀 전체가 해당 화면으로 이동(a 태그 유지). -->
+	<!-- 핵심 지표 패널(#2281 V6-09): 대표 KPI 3개만 headline으로 항상 노출하고 나머지는 disclosure로
+	     격하해 urgent state를 먼저 식별하게 한다. 각 셀 = 흐린 라벨 + 큰 숫자(tabular-nums) + 파랑
+	     스파크라인 + 상태 3색 델타. 셀 전체가 해당 화면으로 이동(a 태그 유지).
+	     기간 표기 명확화(#2293 리뷰 이관): 큰 숫자는 "현재 값", 스파크라인은 "최근 7일 추이", 델타는
+	     "전일 대비"임을 caption으로 못 박아 누계·시점 값이 아래 추이 기간 셀렉터(7/30/90)에 딸린
+	     수치로 읽히는 headline 의미 희석을 없앤다. -->
 	<section class="admin-panel dashboard-metric-panel" aria-labelledby="dashboard-metric-panel-title">
 		<div class="admin-panel-head">
 			<h2 id="dashboard-metric-panel-title">핵심 지표</h2>
 		</div>
+		<p class="section-hint">현재 값 · 최근 7일 스파크라인 · 전일 대비. 기간 추이는 아래 추이 섹션에서 봅니다.</p>
+		<!-- 대표 KPI 3개: 시점·비율 지표를 앞세워 urgent state를 3초 내 식별한다. -->
 		<div class="dashboard-cards">
-			<a th:each="card : ${cards}" class="dashboard-card metric-cell" th:href="@{${card.href}}">
+			<a th:each="card, iter : ${cards}" th:if="${iter.index < 3}"
+			   class="dashboard-card metric-cell" th:href="@{${card.href}}">
 				<span class="dashboard-card-title" th:text="${card.title}">제목</span>
 				<strong class="dashboard-card-value cell-num" th:text="${card.value}">0</strong>
 				<svg th:if="${!card.sparkPoints.isEmpty()}" class="dashboard-spark"
@@ -64,6 +70,26 @@
 				      th:text="${card.deltaLabel}">전일 대비</span>
 			</a>
 		</div>
+		<!-- 나머지 KPI(누계 총량 등)는 disclosure로 격하. native details라 keyboard·no-JS에서 그대로
+		     펼칠 수 있고, 셀 마크업은 headline과 동일 계약을 유지한다. -->
+		<details class="dashboard-details dashboard-more" th:if="${cards.size() > 3}">
+			<summary th:text="|나머지 지표 ${cards.size() - 3}개 보기|">나머지 지표 보기</summary>
+			<div class="dashboard-cards">
+				<a th:each="card, iter : ${cards}" th:if="${iter.index >= 3}"
+				   class="dashboard-card metric-cell" th:href="@{${card.href}}">
+					<span class="dashboard-card-title" th:text="${card.title}">제목</span>
+					<strong class="dashboard-card-value cell-num" th:text="${card.value}">0</strong>
+					<svg th:if="${!card.sparkPoints.isEmpty()}" class="dashboard-spark"
+					     viewBox="0 0 100 24" preserveAspectRatio="none" role="img"
+					     aria-label="최근 7일 추이" focusable="false">
+						<polyline th:attr="points=${card.sparkPoints}" fill="none"
+						          stroke="currentColor" stroke-width="1.5"></polyline>
+					</svg>
+					<span class="dashboard-card-delta" th:classappend="${' is-' + card.deltaTone}"
+					      th:text="${card.deltaLabel}">전일 대비</span>
+				</a>
+			</div>
+		</details>
 	</section>
 
 	<!-- 추이 섹션: 기간(7/30/90) 라인 차트 2개. 기간 버튼이 이 컨테이너를 htmx로 부분 갱신한다. -->

--- a/backend/src/main/resources/templates/admin/datapack/pipeline/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/pipeline/list.html
@@ -92,8 +92,12 @@
 		</div>
 	</section>
 
+	<!-- 게이트 매트릭스·서명 상세(#2281 V6-09): 단계 그래프·blocker 표를 앞세우고, 게이트 6종
+	     매트릭스와 서명·증거 해시는 details로 격하한다. native details라 keyboard·no-JS에서 그대로
+	     펼칠 수 있고 route/permission/CSRF 계약은 그대로다. -->
 	<section class="admin-panel">
-		<h2>게이트 6종 + 서명</h2>
+		<details class="dashboard-details">
+		<summary>게이트 6종 + 서명</summary>
 		<div class="admin-table-scroll" tabindex="0" role="group"
 		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table class="static-table">
@@ -115,10 +119,12 @@
 			</tbody>
 		</table>
 		</div>
+		</details>
 	</section>
 
 	<section class="admin-panel">
-		<h2>서명·증거</h2>
+		<details class="dashboard-details">
+		<summary>서명·증거</summary>
 		<dl class="admin-meta-list">
 			<dt>원천 스냅샷 세트</dt>
 			<dd>
@@ -154,6 +160,7 @@
 				<dt>증거 번들 sha256</dt>
 				<dd th:text="${pipeline.evidenceBundleSha256.fullValue}">-</dd>
 			</dl>
+		</details>
 		</details>
 	</section>
 </main>

--- a/backend/src/main/resources/templates/admin/datapack/pipeline/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/pipeline/list.html
@@ -97,7 +97,7 @@
 	     펼칠 수 있고 route/permission/CSRF 계약은 그대로다. -->
 	<section class="admin-panel">
 		<details class="dashboard-details">
-		<summary>게이트 6종 + 서명</summary>
+		<summary><h2>게이트 6종 + 서명</h2></summary>
 		<div class="admin-table-scroll" tabindex="0" role="group"
 		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table class="static-table">
@@ -124,7 +124,7 @@
 
 	<section class="admin-panel">
 		<details class="dashboard-details">
-		<summary>서명·증거</summary>
+		<summary><h2>서명·증거</h2></summary>
 		<dl class="admin-meta-list">
 			<dt>원천 스냅샷 세트</dt>
 			<dd>

--- a/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminDashboardPageTest.java
+++ b/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminDashboardPageTest.java
@@ -3,11 +3,13 @@ package com.easysubway.admin.adapter.in.web;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.easysubway.admin.authorization.AdminPermission;
 import com.easysubway.admin.metric.application.port.out.AdminMetricDailyRepository;
 import com.easysubway.admin.metric.domain.AdminMetricDaily;
 import com.easysubway.admin.metric.domain.AdminMetricKeys;
@@ -20,6 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest(properties = {
@@ -79,6 +82,34 @@ class AdminDashboardPageTest {
 			.contains("확인 필요 시설")
 			.contains("경로 차단률")
 			.contains("푸시 실패");
+	}
+
+	@Test
+	@DisplayName("권한 부분집합(ADMIN_VIEW+DATA_OPERATE, REPORT_REVIEW 없음)에서도 누계 카드(푸시 실패)는 headline이 아니라 disclosure로 격하된다")
+	void demotesCumulativeCardEvenWhenHeadlineWouldFillWithoutIt() throws Exception {
+		// REPORT_REVIEW가 없으면 대표 제보 카드가 빠져 남는 카드가 3개(시설·차단률·푸시 실패)가 된다.
+		// index 기반이면 3개가 전부 headline이라 누계 총량인 푸시 실패가 headline으로 승격되는 결함(#2306
+		// 리뷰). 지표 의미(metric key) 기반 격하는 index와 무관하게 누계 카드를 항상 disclosure로 내린다.
+		String html = mockMvc.perform(get("/admin/dashboard/page")
+				.with(user("dataop").authorities(
+					new SimpleGrantedAuthority(AdminPermission.ADMIN_VIEW.authority()),
+					new SimpleGrantedAuthority(AdminPermission.DATA_OPERATE.authority()))))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		int disclosureAt = html.indexOf("class=\"dashboard-details dashboard-more\"");
+		assertThat(disclosureAt).as("누계 카드를 담는 disclosure 블록이 존재해야 한다").isGreaterThan(-1);
+		// 카드 정체성은 data-metric-key로 판정한다(서술 코멘트 텍스트에 의존하지 않게).
+		String headline = html.substring(0, disclosureAt);
+		String disclosure = html.substring(disclosureAt);
+		assertThat(headline)
+			.contains("data-metric-key=\"" + AdminMetricKeys.FACILITIES_NEEDS_VERIFICATION + "\"")
+			.contains("data-metric-key=\"" + AdminMetricKeys.ROUTE_BLOCKED_RATE + "\"")
+			.doesNotContain("data-metric-key=\"" + AdminMetricKeys.REPORTS_PENDING + "\"")
+			.doesNotContain("data-metric-key=\"" + AdminMetricKeys.PUSH_FAILED + "\"");
+		assertThat(disclosure).contains("data-metric-key=\"" + AdminMetricKeys.PUSH_FAILED + "\"");
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminDashboardPageTest.java
+++ b/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminDashboardPageTest.java
@@ -61,6 +61,27 @@ class AdminDashboardPageTest {
 	}
 
 	@Test
+	@DisplayName("핵심 지표는 대표 KPI 3개를 headline으로 노출하고 나머지는 disclosure로 격하한다")
+	void foregroundsThreeRepresentativeKpisWithRestInDisclosure() throws Exception {
+		String html = mockMvc.perform(get("/admin/dashboard/page")
+				.with(httpBasic("admin-test", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		// 기간 표기 명확화(headline 의미 희석 해소): 값=현재, 스파크라인=최근 7일, 델타=전일 대비.
+		assertThat(html)
+			.contains("현재 값 · 최근 7일 스파크라인 · 전일 대비")
+			// 대표 KPI 3개(시점·비율)는 headline, 4번째(누계 총량인 푸시 실패)는 disclosure로 격하.
+			.contains("class=\"dashboard-details dashboard-more\"")
+			.contains("나머지 지표")
+			.contains("확인 필요 시설")
+			.contains("경로 차단률")
+			.contains("푸시 실패");
+	}
+
+	@Test
 	@DisplayName("지표 스냅샷 수동 재실행은 command token으로 집계 후 대시보드로 리다이렉트한다")
 	void manualSnapshotRerunRedirects() throws Exception {
 		MockHttpSession session = new MockHttpSession();

--- a/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackPipelineAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackPipelineAdminPageControllerTest.java
@@ -64,7 +64,10 @@ class DatapackPipelineAdminPageControllerTest {
 			.contains("별칭·격리")
 			.contains("매니페스트 서명")
 			.contains("채널 승격")
-			.contains("게이트 6종 + 서명")
+			// 게이트 매트릭스·서명 상세는 details로 격하하되 keyboard·no-JS에서 접근 가능하다(#2281 V6-09).
+			.contains("<summary>게이트 6종 + 서명</summary>")
+			.contains("<summary>서명·증거</summary>")
+			.contains("class=\"dashboard-details\"")
 			.contains("복사")
 			.contains("snapshot-kric-20260629")
 			.contains("/admin/datapack/source-snapshots/page?candidateId=candidate-capital-1&amp;sourceSnapshotId=snapshot-kric-20260629,snapshot-route-20260629")

--- a/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackPipelineAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackPipelineAdminPageControllerTest.java
@@ -65,8 +65,8 @@ class DatapackPipelineAdminPageControllerTest {
 			.contains("매니페스트 서명")
 			.contains("채널 승격")
 			// 게이트 매트릭스·서명 상세는 details로 격하하되 keyboard·no-JS에서 접근 가능하다(#2281 V6-09).
-			.contains("<summary>게이트 6종 + 서명</summary>")
-			.contains("<summary>서명·증거</summary>")
+			.contains("<summary><h2>게이트 6종 + 서명</h2></summary>")
+			.contains("<summary><h2>서명·증거</h2></summary>")
 			.contains("class=\"dashboard-details\"")
 			.contains("복사")
 			.contains("snapshot-kric-20260629")

--- a/tools/qa/admin-accessibility-qa.mjs
+++ b/tools/qa/admin-accessibility-qa.mjs
@@ -214,6 +214,23 @@ function finalizeReport(report) {
       nodes: 0,
     });
   }
+  // #2281 V6-09: 대시보드 KPI 상태 계층 계약을 위반으로 편입한다. headline 카드가 3개를 넘거나,
+  // 기간 표기 caption이 없거나, 총 카드가 3개 초과인데 나머지를 담는 native details가 없거나 DETAILS가
+  // 아니면(keyboard·no-JS 접근 불가) 실패를 표면화한다.
+  const kpiHierarchy = report.keyboard.find((entry) => entry.check === "dashboard-kpi-hierarchy");
+  if (kpiHierarchy
+    && (kpiHierarchy.panelPresent === false
+      || kpiHierarchy.headlineCards > 3
+      || kpiHierarchy.captionPresent === false
+      || (kpiHierarchy.totalCards > 3
+        && (kpiHierarchy.disclosureCards === 0 || kpiHierarchy.disclosureIsDetails !== true)))) {
+    blockingViolations.push({
+      page: "/admin/dashboard/page",
+      id: "dashboard-kpi-hierarchy",
+      impact: "serious",
+      nodes: 0,
+    });
+  }
   const criticalViolations = blockingViolations.filter((violation) => violation.impact === "critical");
   const seriousViolations = blockingViolations.filter((violation) => violation.impact === "serious");
   report.summary = {
@@ -245,6 +262,7 @@ async function runJsPass(browser, baseUrl, outputDir, adminUser, adminPassword, 
     }
   }
   await keyboardSmoke(page, baseUrl, report);
+  await dashboardKpiHierarchyCheck(page, baseUrl, report);
   await captureAxTree(page, outputDir, report);
   await noCurrentWorkspaceDisclosure(page, baseUrl, report);
   await keyboardTableCheck(page, baseUrl, report);
@@ -757,6 +775,41 @@ async function listToolbarSheetCheck(page, baseUrl, report) {
     sheetClosed,
     focusRestored,
   });
+}
+
+// #2281 V6-09: 통합 대시보드 KPI 상태 계층 계약. 대표 KPI 3개만 headline으로 노출하고 나머지는
+// disclosure로 격하해 urgent state를 먼저 식별하게 한다. headline 카드가 3개를 넘거나(우선순위 붕괴),
+// 기간 표기 caption(값=현재·스파크라인=최근 7일·델타=전일)이 없거나, 총 카드가 3개 초과인데 나머지를
+// 담는 native details(.dashboard-more)가 없거나 DETAILS 요소가 아니면(keyboard·no-JS 접근 불가)
+// finalizeReport가 위반으로 편입해 exit code로 실패를 표면화한다(§7 대표 KPI·§9 urgent state 식별).
+async function dashboardKpiHierarchyCheck(page, baseUrl, report) {
+  await page.setViewportSize(VIEWPORTS.find((viewport) => viewport.name === "mobile-390"));
+  const response = await page.goto(`${baseUrl}/admin/dashboard/page`, { waitUntil: "networkidle" });
+  await assertOk(page, "/admin/dashboard/page", response);
+
+  const signal = await page.evaluate(() => {
+    const panel = document.querySelector(".dashboard-metric-panel");
+    const headlineGrid = panel ? panel.querySelector(":scope > .dashboard-cards") : null;
+    const headlineCards = headlineGrid ? headlineGrid.querySelectorAll(".dashboard-card").length : 0;
+    const more = panel ? panel.querySelector(".dashboard-more") : null;
+    const disclosureCards = more ? more.querySelectorAll(".dashboard-card").length : 0;
+    const totalCards = panel ? panel.querySelectorAll(".dashboard-card").length : 0;
+    const captionPresent = Boolean(
+      panel
+        && panel.querySelector(".section-hint")
+        && /현재 값/.test(panel.querySelector(".section-hint").textContent || ""),
+    );
+    return {
+      panelPresent: Boolean(panel),
+      headlineCards,
+      disclosureCards,
+      totalCards,
+      captionPresent,
+      disclosureIsDetails: more ? more.tagName === "DETAILS" : null,
+    };
+  });
+
+  report.keyboard.push({ check: "dashboard-kpi-hierarchy", ...signal });
 }
 
 async function captureAxTree(page, outputDir, report) {

--- a/tools/qa/admin-accessibility-qa.mjs
+++ b/tools/qa/admin-accessibility-qa.mjs
@@ -217,13 +217,24 @@ function finalizeReport(report) {
   // #2281 V6-09: 대시보드 KPI 상태 계층 계약을 위반으로 편입한다. headline 카드가 3개를 넘거나,
   // 기간 표기 caption이 없거나, 총 카드가 3개 초과인데 나머지를 담는 native details가 없거나 DETAILS가
   // 아니면(keyboard·no-JS 접근 불가) 실패를 표면화한다.
+  // #2306 리뷰: (1) check entry 자체가 없으면(pass가 돌지 않았거나 신호 미기록) false-green이므로
+  // 위반으로 편입한다. (2) 누계 총량 카드가 headline에 있거나(index 기반 격하 회귀), headline 카드가
+  // 지표 정체성(data-metric-key)을 노출하지 않으면(정체성 검증 불가) 위반으로 편입한다.
   const kpiHierarchy = report.keyboard.find((entry) => entry.check === "dashboard-kpi-hierarchy");
-  if (kpiHierarchy
-    && (kpiHierarchy.panelPresent === false
+  if (!kpiHierarchy) {
+    blockingViolations.push({
+      page: "/admin/dashboard/page",
+      id: "dashboard-kpi-hierarchy-missing",
+      impact: "serious",
+      nodes: 0,
+    });
+  } else if (kpiHierarchy.panelPresent === false
       || kpiHierarchy.headlineCards > 3
       || kpiHierarchy.captionPresent === false
+      || kpiHierarchy.headlineMetricKeysPresent === false
+      || kpiHierarchy.cumulativeInHeadline === true
       || (kpiHierarchy.totalCards > 3
-        && (kpiHierarchy.disclosureCards === 0 || kpiHierarchy.disclosureIsDetails !== true)))) {
+        && (kpiHierarchy.disclosureCards === 0 || kpiHierarchy.disclosureIsDetails !== true))) {
     blockingViolations.push({
       page: "/admin/dashboard/page",
       id: "dashboard-kpi-hierarchy",
@@ -788,12 +799,25 @@ async function dashboardKpiHierarchyCheck(page, baseUrl, report) {
   await assertOk(page, "/admin/dashboard/page", response);
 
   const signal = await page.evaluate(() => {
+    // #2306 리뷰: 누계 총량 지표(AdminMetricKeys.PUSH_FAILED)는 index가 아니라 지표 의미로 격하한다.
+    // Java 상수값을 그대로 미러링한다(계약 값).
+    const CUMULATIVE_METRIC_KEY = "push.failed";
+    const metricKeysOf = (root) =>
+      root ? Array.from(root.querySelectorAll(".dashboard-card")).map((card) => card.getAttribute("data-metric-key")) : [];
     const panel = document.querySelector(".dashboard-metric-panel");
     const headlineGrid = panel ? panel.querySelector(":scope > .dashboard-cards") : null;
     const headlineCards = headlineGrid ? headlineGrid.querySelectorAll(".dashboard-card").length : 0;
     const more = panel ? panel.querySelector(".dashboard-more") : null;
     const disclosureCards = more ? more.querySelectorAll(".dashboard-card").length : 0;
     const totalCards = panel ? panel.querySelectorAll(".dashboard-card").length : 0;
+    const headlineMetricKeys = metricKeysOf(headlineGrid);
+    const disclosureMetricKeys = metricKeysOf(more);
+    // headline 카드 정체성: 모든 headline 카드가 실제 metric key를 노출해야 한다(속성 부재 시 false-green 방지).
+    const headlineMetricKeysPresent = headlineCards > 0
+      && headlineMetricKeys.every((key) => typeof key === "string" && key.length > 0);
+    // 누계 카드는 headline에 없어야 하고, 존재한다면 disclosure에 있어야 한다.
+    const cumulativeInHeadline = headlineMetricKeys.includes(CUMULATIVE_METRIC_KEY);
+    const cumulativeDemoted = disclosureMetricKeys.includes(CUMULATIVE_METRIC_KEY);
     const captionPresent = Boolean(
       panel
         && panel.querySelector(".section-hint")
@@ -804,6 +828,11 @@ async function dashboardKpiHierarchyCheck(page, baseUrl, report) {
       headlineCards,
       disclosureCards,
       totalCards,
+      headlineMetricKeys,
+      disclosureMetricKeys,
+      headlineMetricKeysPresent,
+      cumulativeInHeadline,
+      cumulativeDemoted,
       captionPresent,
       disclosureIsDetails: more ? more.tagName === "DETAILS" : null,
     };

--- a/tools/qa/admin-accessibility-qa.test.mjs
+++ b/tools/qa/admin-accessibility-qa.test.mjs
@@ -186,6 +186,26 @@ test("admin accessibility QA script verifies report queue action hierarchy and p
   assert.match(source, /actionSignal\.photoScopedVerified === false/);
 });
 
+// #2281 V6-09: 통합 대시보드 KPI 상태 계층(대표 3개 headline·나머지 disclosure·기간 표기 caption) 계약을 source로 고정한다.
+test("admin accessibility QA script verifies dashboard KPI hierarchy and disclosure", () => {
+  assert.match(source, /async function dashboardKpiHierarchyCheck\(page, baseUrl, report\)/);
+  assert.match(source, /await dashboardKpiHierarchyCheck\(page, baseUrl, report\)/);
+  assert.match(source, /check: "dashboard-kpi-hierarchy"/);
+  // 대표 KPI 3개만 headline으로 노출하는지 headline 그리드 카드 수로 판정한다.
+  assert.match(source, /:scope > \.dashboard-cards/);
+  assert.match(source, /headlineCards/);
+  // 나머지는 native details(.dashboard-more)로 격하돼 keyboard·no-JS에서 접근 가능한지 검사한다.
+  assert.match(source, /\.dashboard-more/);
+  assert.match(source, /disclosureIsDetails/);
+  // 기간 표기 caption(값=현재·스파크라인=최근 7일·델타=전일)이 headline 의미 희석을 없애는지 검사한다.
+  assert.match(source, /captionPresent/);
+  // 계약 실패가 blocking 위반으로 표면화되는지 고정한다.
+  assert.match(source, /id: "dashboard-kpi-hierarchy"/);
+  assert.match(source, /kpiHierarchy\.headlineCards > 3/);
+  assert.match(source, /kpiHierarchy\.captionPresent === false/);
+  assert.match(source, /kpiHierarchy\.disclosureIsDetails !== true/);
+});
+
 test("admin accessibility QA script records manual-only screen reader and contrast work", () => {
   assert.match(source, /VoiceOver reading flow/);
   assert.match(source, /high-contrast visual inspection/);

--- a/tools/qa/admin-accessibility-qa.test.mjs
+++ b/tools/qa/admin-accessibility-qa.test.mjs
@@ -199,11 +199,22 @@ test("admin accessibility QA script verifies dashboard KPI hierarchy and disclos
   assert.match(source, /disclosureIsDetails/);
   // 기간 표기 caption(값=현재·스파크라인=최근 7일·델타=전일)이 headline 의미 희석을 없애는지 검사한다.
   assert.match(source, /captionPresent/);
+  // #2306 리뷰: headline 카드 정체성(metric key)을 data-metric-key로 읽어 누계 카드가 headline에
+  // 없는지(cumulativeInHeadline) 판정하고, 카드가 정체성을 노출하는지(headlineMetricKeysPresent) 검사한다.
+  assert.match(source, /data-metric-key/);
+  assert.match(source, /const CUMULATIVE_METRIC_KEY = "push\.failed";/);
+  assert.match(source, /cumulativeInHeadline/);
+  assert.match(source, /headlineMetricKeysPresent/);
   // 계약 실패가 blocking 위반으로 표면화되는지 고정한다.
   assert.match(source, /id: "dashboard-kpi-hierarchy"/);
   assert.match(source, /kpiHierarchy\.headlineCards > 3/);
   assert.match(source, /kpiHierarchy\.captionPresent === false/);
   assert.match(source, /kpiHierarchy\.disclosureIsDetails !== true/);
+  assert.match(source, /kpiHierarchy\.cumulativeInHeadline === true/);
+  assert.match(source, /kpiHierarchy\.headlineMetricKeysPresent === false/);
+  // #2306 리뷰: check entry 부재(pass 미실행/신호 미기록)를 false-green으로 통과시키지 않는다.
+  assert.match(source, /if \(!kpiHierarchy\)/);
+  assert.match(source, /id: "dashboard-kpi-hierarchy-missing"/);
 });
 
 test("admin accessibility QA script records manual-only screen reader and contrast work", () => {


### PR DESCRIPTION
## 관련 이슈

close #2281
Refs #2271

## 작업 배경

- 통합 대시보드는 KPI 카드와 datapack blocker가 한 화면에서 같은 시각 우선순위를 가져, urgent state와 근거 drill-down이 느렸다.
- V6-01(#2273) 리뷰에서 이관된 참고 finding: 누계 GAUGE 지표(누적 총량)가 headline 큰 숫자로 노출되면서 바로 아래 추이 기간 셀렉터(7/30/90일)에 딸린 수치처럼 읽혀 headline 의미가 희석됐다(PR #2293 Additional comments). label·단위·기간 표기 정리는 V6-09 소관으로 넘어왔다.
- datapack 파이프라인 개요는 게이트 6종 매트릭스와 서명·증거 해시가 항상 펼쳐져 있어 단계 그래프·blocker보다 밀도가 높았다.

## 작업 내용

- `dashboard.html`: 핵심 지표 패널을 대표 KPI 3개(시점·비율 지표) headline + 나머지 disclosure로 재편했다. 나머지 카드(누계 총량인 푸시 실패 등)는 `<details class="dashboard-details dashboard-more">`로 격하해 native details라 keyboard·no-JS에서 그대로 펼칠 수 있다. 카드 마크업 계약(라벨·값·스파크라인·델타 tone)은 headline과 disclosure가 동일하다.
- headline 의미 희석 해소: 패널에 "현재 값 · 최근 7일 스파크라인 · 전일 대비" caption(`.section-hint`)을 추가해 큰 숫자=현재 값, 스파크라인=최근 7일, 델타=전일 대비임을 못 박고, 기간 추이는 아래 추이 섹션에서 본다고 명시했다. 누계 총량 지표를 headline에서 disclosure로 내려 셀렉터에 딸린 수치로 오독될 여지를 줄였다. 카드 값·단위 문자열(비율 %·개수)은 컨트롤러 label 그대로라 V6-01 metric kind와 단위 parity를 유지한다.
- `datapack/pipeline/list.html`: 게이트 6종 매트릭스와 서명·증거(해시·워크플로) 섹션 본문을 각각 `<details class="dashboard-details">`로 격하했다. 단계 그래프·단계별 blocker 표는 그대로 앞에 노출한다. summary 텍스트("게이트 6종 + 서명", "서명·증거")·복사 버튼·드릴다운 링크·sha 원문 nested details는 유지해 keyboard·no-JS 접근성과 route/permission/CSRF 계약이 불변이다.
- `dashboard-charts.js`: (1) 차트를 그리지 못하면(Chart.js 부재·JSON 파싱 실패) 같은 섹션의 대체 표 details(`데이터 표로 보기`)를 자동으로 펼쳐 동일 값 fallback을 즉시 보이게 한다. 표 값은 서버가 canvas `data-chart`와 같은 소스로 렌더해 chart와 항상 일치한다. (2) 지표 수동 재집계 폼은 첫 제출에서 버튼을 비활성화(자리·크기 유지, `aria-busy`로 진행 표시)해 멱등 `snapshotToday()`의 중복 POST를 막는다. no-JS에서는 가드 없이 폼이 한 번 그대로 제출된다. 자체 호스팅 파일이라 CSP(script-src 'self')를 지킨다.
- `admin-data.css`: 나머지 KPI disclosure(`.dashboard-more[open] .dashboard-cards`)에 요약↔카드 상단 여백만 추가했다. 카드 그리드·1px 구분선·반응형(≤900px 2열, ≤768px 1열) 규칙은 기존 `.dashboard-cards`를 재사용해 시각 언어·구분선 계약이 불변이다. data/page 뷰 소유(admin-data.css) 경계를 지킨다.
- 테스트: `AdminDashboardPageTest`에 대표 KPI 3개 headline + disclosure + caption 계약을 고정하는 케이스를 추가했다. `DatapackPipelineAdminPageControllerTest`에 게이트·서명 details summary 구조 단언을 추가했다. `admin-accessibility-qa.mjs`에 대시보드 KPI 상태 계층 QA 체크(headline ≤3·caption·나머지 native details)를 추가하고 finalizeReport 위반으로 편입, `admin-accessibility-qa.test.mjs`에 source 계약 테스트를 추가했다.

## 검증

- 실행한 명령과 결과 (tested SHA `a9c49ef8`, base `origin/main@531d1be9`):
  - `node tools/ci/api-catalog.mjs validate` → exit 0 (`API catalog valid: 245`)
  - `LC_ALL=C.UTF-8 node --test tools/ci/repository-contract.test.mjs` → exit 0 (tests 218, pass 218, fail 0) — `LC_ALL=C.UTF-8`는 ko_KR 정렬 오탐 회피용
  - `npm test --prefix tools/qa` → exit 0 (tests 14, pass 14, fail 0; 신규 `dashboard KPI hierarchy and disclosure` 포함)
  - `cd backend && ./gradlew test --tests '...AdminDashboardPageTest' --tests '...AdminMetricChartControllerTest' --tests '...DatapackPipelineAdminPageControllerTest' --tests '...DatapackReleaseBlockerSummaryAdminPageTest'` → BUILD SUCCESSFUL (fail 0)

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 대표 KPI 3개 headline + 나머지 disclosure | backend | `AdminDashboardPageTest.foregroundsThreeRepresentativeKpisWithRestInDisclosure` — 실제 Thymeleaf 렌더 HTML에서 caption·`dashboard-more` details·headline 3개·disclosure 카드 단언 | `./gradlew test` 로그 (SHA `a9c49ef8`) | green |
| metric label/단위/기간 parity | backend | 카드 값·단위는 컨트롤러 label 그대로(변경 없음), caption으로 값=현재·스파크=7일·델타=전일 기간 표기 고정. `AdminMetricChartControllerTest`(series label·단위 회귀) BUILD SUCCESSFUL | 아래 대조표, gradle 로그 | green |
| blocker drill-down · chart fallback 동일 값 | backend | datapack 파이프라인 단계 그래프·drill URL 유지 + 게이트·서명 details 접근(`DatapackPipelineAdminPageControllerTest`); chart 실패 시 fallback 표 auto-open(`dashboard-charts.js`, 표는 canvas와 동일 소스) | gradle 로그, 코드 diff | green |
| compact/200% clipping 0 | backend/QA | 나머지 KPI는 기존 `.dashboard-cards` 반응형(≤768px 1열) 재사용, wrapper만 가로 overflow 소유(신규 overflow 컨테이너 없음). QA 하네스 `dashboard-kpi-hierarchy` + textScale(390/1440) 체크 추가 | `admin-accessibility-qa.mjs`/`.test.mjs` | 하네스 계약 green · 실브라우저 캡처는 아래 유의 참조 |
| 실브라우저 스크린샷(390/1440·urgent 3s) | backend/QA | 로컬 dev/H2 부팅(포트 8092) 확인 — 앱은 정상 기동하나 fresh H2에 RBAC 권한 미시드로 bootstrap admin이 method-secured 렌더에서 Access Denied(대상 화면 무관·미변경 stations 화면도 동일). 실브라우저/클리핑 캡처는 권한이 시드된 CI QA job 소관 | bootrun.log(로컬, 커밋 제외), MockMvc 구조 단언으로 대체 | 부분 — CI QA에서 실캡처 |

### V6-01 metric kind 단위·기간 parity 대조표 (카드 소비 지표)

| 카드 | metricKey | metric kind | 값 표기 | 단위 | 기간 표기 위치 |
| --- | --- | --- | --- | --- | --- |
| 확인할 제보 | reports.pending | GAUGE(시점) | 현재 값 | 개수 | headline |
| 확인 필요 시설 | facilities.needs_verification | GAUGE(시점) | 현재 값 | 개수 | headline |
| 경로 차단률 | route.blocked_rate | RATE(비율) | 현재 값 | % | headline |
| 푸시 실패 | push.failed | GAUGE(누계 총량) | 현재 누계 | 개수 | disclosure로 격하 |
| (전 카드 공통) | — | — | 스파크라인=최근 7일 · 델타=전일 대비 | — | caption 명시 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

admin 대시보드·datapack 파이프라인 template·CSS·정적 JS·테스트만 바뀌며 반영에는 backend 배포가 필요하다. 스키마·API route·계약 JSON 변경 없음.

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [ ] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [ ] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 동작 변경 없음(뷰 계층 정리, 배포 필요), 버전 문자열 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `dashboard.html`의 KPI headline/disclosure 분리에서 카드 앵커 마크업이 headline 그리드와 disclosure 그리드에 의도적으로 중복돼 있다(두 DOM 위치가 필요하고 계약이 동일). 두 사본은 항상 같이 유지해야 한다. `dashboard-charts.js`의 재집계 가드는 submit 이벤트 내에서 버튼을 disabled 처리하지만, 폼 데이터가 hidden input(commandToken·CSRF)에 있어 제출은 그대로 진행된다(버튼 name/value 미사용).
- headline 의미 희석 해소 방식: Java(카드 값·kind) 미변경 범위에서, (1) 누계 총량 지표를 headline→disclosure로 내리고 (2) 값=현재·스파크=7일·델타=전일 기간 표기를 caption으로 고정했다. metric kind/단위 원본은 V6-01 `AdminMetricKeys`이며 이 PR은 표기·배치만 정리한다.

## 리스크

- 순수 뷰 계층(template·CSS·정적 JS·테스트) 변경. route·HTTP method/status·request param·fragment·permission·CSRF·no-JS·CSP·datapack workflow/state transition 계약 불변.
- rollback 경계: 단일 revert 가능. 8개 파일 한 커밋(`a9c49ef8`)으로 `git revert`하면 전량 원복되며 스키마·datapack·계약 JSON·gate/tracker를 건드리지 않아 backend 배포만 되돌리면 된다.
- gate/tracker(JSON) 영향 없음, CI workflow·계약 테스트 변경 없음.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. — backend deploy only, DB migration·계약 변경 없음.
