### PR TITLE
[Backend] TAGO KTX-산천 실응답 정규화

### DIFF
--- a/backend/src/main/java/com/easysubway/train/adapter/out/http/TagoTrainSearchProvider.java
+++ b/backend/src/main/java/com/easysubway/train/adapter/out/http/TagoTrainSearchProvider.java
@@ -392,6 +392,7 @@ public final class TagoTrainSearchProvider implements TrainSearchProvider {
 
 	private String trainType(String value) {
 		String normalized = value.replaceAll("[^0-9A-Za-z가-힣]", "").toUpperCase(Locale.ROOT);
+		if (normalized.startsWith("KTX산천")) return "KTX_SANCHEON";
 		return TRAIN_TYPES.getOrDefault(normalized, normalized);
 	}
 

--- a/backend/src/test/java/com/easysubway/train/adapter/out/http/TagoTrainSearchProviderTest.java
+++ b/backend/src/test/java/com/easysubway/train/adapter/out/http/TagoTrainSearchProviderTest.java
@@ -81,8 +81,8 @@ class TagoTrainSearchProviderTest {
 				case "GetVhcleKndList" -> respond(exchange, catalogResponse("""
 					[
 					  {"vehiclekndid":"00","vehiclekndnm":"KTX"},
-					  {"vehiclekndid":"01","vehiclekndnm":"KTX-산천"},
-					  {"vehiclekndid":"10","vehiclekndnm":"KTX-산천"},
+					  {"vehiclekndid":"01","vehiclekndnm":"KTX-산천(A-type)"},
+					  {"vehiclekndid":"10","vehiclekndnm":"KTX-산천(B-type)"},
 					  {"vehiclekndid":"02","vehiclekndnm":"SRT"},
 					  {"vehiclekndid":"03","vehiclekndnm":"ITX-마음"},
 					  {"vehiclekndid":"04","vehiclekndnm":"ITX-새마을"},


### PR DESCRIPTION
## 관련 이슈

#2094 (후속 capacity·live·Android 증거 PR에서 종료)

## 작업 배경

- `9fd69f5d` 배포 후 post-deploy smoke에서 `/api/v1/trains/stations?query=서울&trainType=KTX`가 HTTP 502로 종료됐다.
- 공식 TAGO `GetVhcleKndList` 실응답은 `KTX-산천(A-type)`, `KTX-산천(B-type)`인데 backend가 기본 `KTX-산천`만 정규화해 catalog 전체를 fail-closed로 거부했다.

## 작업 내용

- 구두점 제거 뒤 `KTX산천`으로 시작하는 공식 A/B type 명칭을 canonical `KTX_SANCHEON`으로 정규화한다.
- provider fixture를 실제 공식 명칭과 일치시켜 두 provider code가 모두 유지되는 회귀 테스트를 고정한다.
- 다른 KTX 계열(`KTX-이음`, `KTX-청룡`)은 승인된 8종 범위에 자동 편입하지 않는다.

## 검증

- 실행한 명령과 결과:
  - `./backend/gradlew -p backend test --tests com.easysubway.train.adapter.out.http.TagoTrainSearchProviderTest --tests com.easysubway.train.domain.TrainSearchScopePolicyTest` — 성공
  - `node --test tools/ci/train-search-itx-exclusion-contract.test.mjs tools/ci/api-catalog.test.mjs` — 16/16 성공
  - `node --env-file=/Users/aquila/easysubway/.env tools/test/train-search-live-smoke.mjs ...` — 공식 4개 operation, 8개 지원종, 서울→대전 KTX 운임 54행, ITX-청춘 0행 성공(후속 증거 runner 작업트리에서 실행)
  - `git diff --check` — 성공

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 실패 재현 | Production | CD post-deploy smoke | [run 29674505194](https://github.com/AquilaXk/easysubway/actions/runs/29674505194) | 서울 station catalog HTTP 502 |
| 공식 provider | TAGO | credential-safe tracked live call | HTTP 성공, `resultCode=00`, schema EXPECTED, 응답 hash 저장 | 성공 |
| 열차종 정규화 | Backend | provider + scope tests | A/B type → `KTX_SANCHEON`, provider code 2개 | 성공 |
| UI·접근성 | Mobile | 이 PR은 UI를 변경하지 않음 | 불필요 | 해당 없음 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: PR merge SHA

## 리뷰어 메모

- 실제 공식 명칭의 A/B suffix만 승인된 `KTX_SANCHEON`으로 묶고 `KTX-이음`, `KTX-청룡`은 기존 범위 밖으로 유지하는지 확인해 주세요.

## 리스크

- prefix 정규화가 과도하면 다른 KTX 계열을 섞을 수 있으므로 `KTX산천` prefix에만 한정했다.
- 이 PR은 production 502 복구만 포함하며 capacity·Android·최종 release evidence는 후속 PR에서 고정한다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
