### PR TITLE
[Style] #2313 관리자 버튼 위계 3단 + 필터 적용 버튼 JS 시 숨김 (PR①)

### DIFF
--- a/backend/src/main/resources/static/css/admin-components.css
+++ b/backend/src/main/resources/static/css/admin-components.css
@@ -70,7 +70,7 @@
    목록으로 돌아가기 등, 그 화면의 데이터를 바꾸지 않고 다른 화면으로 이동만 하는 액션에 부여한다. */
 .admin-btn.plain,
 .admin-v3 button.plain {
-	min-height: auto;
+	min-height: 24px;
 	padding: 0;
 	background: transparent;
 	color: var(--admin-accent);

--- a/backend/src/main/resources/static/css/admin-components.css
+++ b/backend/src/main/resources/static/css/admin-components.css
@@ -14,12 +14,15 @@
 }
 
 /*
- * 버튼 primitive(V6-04, #2276): shape·크기·타이포는 이 base가 소유하고, 강조(파랑 채움)는 명시적
- * class(.primary)가 소유하는 게 canonical이다. 아래 base의 `background: var(--admin-primary)`는
- * 화면 이관(V6-07~10) 전까지 유지하는 COMPAT 기본값이다 — class 없는 button/`.admin-btn`이 파랑으로
- * 계속 렌더돼 기존 화면 회귀를 막는다. 화면 owner가 명시적 `.primary`로 이관하면 이 기본값을 neutral로
- * 낮춘다. `.secondary`(warn)·`.danger`는 이미 명시적 class이며, `.primary`는 강조를 명시화하는 canonical
- * 마커다(현재 값은 compat 기본값과 동일). raw 색·shadow 없이 token만 사용한다. */
+ * 버튼 primitive(V6-04 #2276, 위계 3단 확장 V6-13 #2313): shape·크기·타이포는 이 base가 소유하고,
+ * 위계(filled/outline/plain)는 명시적 class(.primary/.outline/.plain)가 소유하는 게 canonical이다.
+ * 아래 base의 `background: var(--admin-primary)`는 화면 이관(V6-07~10) 전까지 유지하는 COMPAT
+ * 기본값이다 — class 없는 button/`.admin-btn`이 파랑으로 계속 렌더돼 기존 화면 회귀를 막는다. 화면
+ * owner가 명시적 class로 이관하면 이 기본값을 neutral로 낮춘다. `.danger`는 파괴적 액션 전용 filled로
+ * 유지한다. 화면당 filled(`.primary`/`.danger`)는 그 화면의 대표 액션 1개가 원칙이고, 나머지 액션은
+ * `.outline`(보조, 테두리만) 또는 `.plain`(내비게이션성, 텍스트/링크형)을 쓴다. 구 `.secondary`(주황
+ * 채움)는 위계가 아닌 또 다른 강조였던 문제로 폐지하고 `.outline`으로 이관했다(#2313, 원 계약 #2280).
+ * raw 색·shadow 없이 token만 사용한다. */
 .admin-btn,
 .admin-v3 button {
 	display: inline-flex;
@@ -46,6 +49,38 @@
 .admin-btn.primary:hover,
 .admin-v3 button.primary:hover {
 	background: var(--admin-primary-hover);
+}
+
+/* 보조 액션 canonical 명시 class(#2313) — 투명 배경 + 테두리, primary보다 무게를 낮추되 버튼 형태(크기)는
+   유지한다. 데이터를 바꾸지만 그 화면의 대표 액션은 아닌 액션, 또는 filled가 이미 다른 버튼에 쓰인
+   화면의 보조 액션에 부여한다. */
+.admin-btn.outline,
+.admin-v3 button.outline {
+	background: transparent;
+	border: 1px solid var(--admin-border-strong);
+	color: var(--admin-ink);
+}
+
+.admin-btn.outline:hover,
+.admin-v3 button.outline:hover {
+	background: var(--admin-accent-soft);
+}
+
+/* 내비게이션성 액션 canonical 명시 class(#2313) — 배경·테두리 없이 .detail-link와 같은 텍스트/링크 톤.
+   목록으로 돌아가기 등, 그 화면의 데이터를 바꾸지 않고 다른 화면으로 이동만 하는 액션에 부여한다. */
+.admin-btn.plain,
+.admin-v3 button.plain {
+	min-height: auto;
+	padding: 0;
+	background: transparent;
+	color: var(--admin-accent);
+	font-weight: var(--admin-w-strong);
+	text-decoration: none;
+}
+
+.admin-btn.plain:hover,
+.admin-v3 button.plain:hover {
+	text-decoration: underline;
 }
 
 .admin-v3 .tiny-btn {
@@ -1327,8 +1362,16 @@
 	font-weight: var(--admin-w-medium);
 }
 
+/* `.secondary`(주황 채움)는 #2313에서 `.outline`으로 이관되어 폐지했다. 남은 소비자가 있으면
+   outline과 동일한 무게로 렌더되도록 별칭만 유지한다. */
 .admin-v3 button.secondary {
-	background: var(--admin-warn);
+	background: transparent;
+	border: 1px solid var(--admin-border-strong);
+	color: var(--admin-ink);
+}
+
+.admin-v3 button.secondary:hover {
+	background: var(--admin-accent-soft);
 }
 
 .admin-v3 button.danger {

--- a/backend/src/main/resources/static/css/admin-data.css
+++ b/backend/src/main/resources/static/css/admin-data.css
@@ -571,6 +571,14 @@
 	font-variant-numeric: tabular-nums;
 }
 
+/* 필터/정렬 적용 버튼 JS 시 숨김(#2313): 이 버튼이 속한 필터 form은 htmx `hx-trigger="change, submit"`으로
+   이미 값이 바뀌는 즉시 자동 제출된다. JS 활성 환경에서 명시 제출 버튼은 잉여이므로 숨긴다. no-JS(has-js
+   미부착)에서는 자동 제출이 동작하지 않으므로 이 규칙이 걸리지 않아 버튼이 계속 노출되고, 그대로 수동
+   GET 제출로 필터가 적용된다(폴백 유지, hidden 필터 바인딩·GET 계약은 그대로). */
+.admin-v3.has-js .admin-filter-apply {
+	display: none;
+}
+
 /* compact: 필터·보기 설정을 시트로 접는다. JS가 있을 때만(has-js) 트리거를 노출하고 시트를 접어
    direct control을 5개 이하로 유지한다. no-JS(has-js 미부착)는 시트 내용이 인라인으로 남는다. */
 @media (max-width: 768px) {

--- a/backend/src/main/resources/templates/admin/ads/list.html
+++ b/backend/src/main/resources/templates/admin/ads/list.html
@@ -46,7 +46,7 @@
 			<input id="ends-at" name="endsAt" placeholder="2026-07-12T00:00:00Z">
 			<label for="save-reason">변경 사유</label>
 			<input id="save-reason" name="reason" required maxlength="500">
-			<button type="submit">저장</button>
+			<button type="submit" class="primary">저장</button>
 		</form>
 	</section>
 
@@ -90,7 +90,7 @@
 						<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 						<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 						<label>변경 사유 <input name="reason" required maxlength="500"></label>
-						<button type="submit" th:text="${creative.enabled ? '비활성화' : '활성화'}">활성화</button>
+						<button type="submit" class="outline" th:text="${creative.enabled ? '비활성화' : '활성화'}">활성화</button>
 					</form>
 				</td>
 			</tr>

--- a/backend/src/main/resources/templates/admin/audits/detail.html
+++ b/backend/src/main/resources/templates/admin/audits/detail.html
@@ -25,7 +25,7 @@
 				<p th:if="${privacyMode}">개인정보 조회 상세와 조회 사유, 같은 담당자의 전후 조회 흐름을 확인합니다.</p>
 			</div>
 			<div class="admin-actions">
-				<a class="admin-btn" th:href="@{${basePath}}">목록으로</a>
+				<a class="admin-btn plain" th:href="@{${basePath}}">목록으로</a>
 			</div>
 		</header>
 

--- a/backend/src/main/resources/templates/admin/audits/list.html
+++ b/backend/src/main/resources/templates/admin/audits/list.html
@@ -68,7 +68,7 @@
 						<input type="checkbox" name="reasonMissing" value="true" th:checked="${reasonMissing}">
 						<span>사유 없는 조회만</span>
 					</label>
-					<button type="submit">필터 적용</button>
+					<button type="submit" class="outline admin-filter-apply">필터 적용</button>
 				</form>
 			</div>
 

--- a/backend/src/main/resources/templates/admin/batches/list.html
+++ b/backend/src/main/resources/templates/admin/batches/list.html
@@ -50,7 +50,7 @@
 							<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 							<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 							<input type="hidden" name="runRequested" value="true">
-							<button type="submit" th:disabled="${job.running}">실행 확인</button>
+							<button type="submit" class="primary" th:disabled="${job.running}">실행 확인</button>
 						</form>
 					</details>
 				</td>
@@ -152,7 +152,7 @@
 							<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 							<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 							<input type="hidden" name="retryRequested" value="true">
-							<button type="submit">재처리 확인</button>
+							<button type="submit" class="primary">재처리 확인</button>
 						</form>
 					</details>
 					<span th:unless="${run.retryable}" th:text="${run.retryableLabel()}">불가</span>

--- a/backend/src/main/resources/templates/admin/codes/list.html
+++ b/backend/src/main/resources/templates/admin/codes/list.html
@@ -31,7 +31,7 @@
 				        th:selected="${group.groupCode == selectedGroup}"
 				        th:text="${group.displayName}">신고 반려 사유</option>
 			</select>
-			<button type="submit">조회</button>
+			<button type="submit" class="outline">조회</button>
 		</form>
 	</section>
 
@@ -66,7 +66,7 @@
 					<form th:if="${code.enabled and !code.requiredIncidentCode}" th:action="@{'/admin/codes/' + ${code.groupCode} + '/' + ${code.code} + '/disable'}" method="post">
 						<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 						<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
-						<button type="submit">비활성화</button>
+						<button type="submit" class="outline">비활성화</button>
 					</form>
 				</td>
 			</tr>
@@ -87,7 +87,7 @@
 			<label>설명 <input name="description"></label>
 			<label>정렬 <input name="sortOrder" type="number" min="0" value="0"></label>
 			<label><input name="enabled" type="checkbox" value="true" checked> 신규 선택 가능</label>
-			<button type="submit">저장</button>
+			<button type="submit" class="primary">저장</button>
 		</form>
 	</section>
 </main>

--- a/backend/src/main/resources/templates/admin/collections/list.html
+++ b/backend/src/main/resources/templates/admin/collections/list.html
@@ -31,7 +31,7 @@
 			       th:checked="${sourceOptionStat.first}">
 			<span th:text="${sourceOption.label + ' 데이터 수집'}">도시철도 마스터 데이터 수집</span>
 		</label>
-		<button type="submit">수집 실행</button>
+		<button type="submit" class="primary">수집 실행</button>
 	</form>
 
 	<section id="collection-live" th:fragment="live">
@@ -89,7 +89,7 @@
 							<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 							<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 							<input type="hidden" name="source" th:value="${run.source}">
-							<button type="submit">재시도 확인</button>
+							<button type="submit" class="primary">재시도 확인</button>
 						</form>
 					</details>
 					<span th:unless="${run.retryable}" th:text="${run.retryableLabel()}">불필요</span>

--- a/backend/src/main/resources/templates/admin/dashboard.html
+++ b/backend/src/main/resources/templates/admin/dashboard.html
@@ -27,7 +27,7 @@
 			      method="post" th:action="@{/admin/dashboard/metrics/snapshot}">
 				<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 				<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
-				<button type="submit" class="admin-btn">지표 지금 다시 집계</button>
+				<button type="submit" class="admin-btn outline">지표 지금 다시 집계</button>
 			</form>
 		</div>
 	</header>
@@ -159,7 +159,7 @@
 				<h2>먼저 확인할 제보</h2>
 			</div>
 			<p class="summary">확인할 제보는 제보 확인 대기열에서 상태·사진·위치를 함께 확인합니다.</p>
-			<a class="admin-btn" th:href="@{/admin/reports/page}">제보 확인 대기열 열기</a>
+			<a class="admin-btn outline" th:href="@{/admin/reports/page}">제보 확인 대기열 열기</a>
 		</section>
 		<section class="admin-section-flat" aria-labelledby="dashboard-health-title">
 			<div class="admin-panel-head">

--- a/backend/src/main/resources/templates/admin/datapack/alias-quarantine/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/alias-quarantine/list.html
@@ -37,8 +37,8 @@
 			</select>
 			<input type="hidden" name="candidateId" th:if="${filter.hasCandidate()}" th:value="${filter.candidateValue}">
 			<input type="hidden" name="sourceSnapshotId" th:if="${filter.hasSourceSnapshot()}" th:value="${filter.sourceSnapshotValue}">
-			<button type="submit">검색</button>
-			<a class="admin-btn" th:href="@{/admin/datapack/alias-quarantine/page}">초기화</a>
+			<button type="submit" class="outline">검색</button>
+			<a class="admin-btn plain" th:href="@{/admin/datapack/alias-quarantine/page}">초기화</a>
 		</form>
 		<div class="table-filters" th:if="${filter.active()}">
 			<div class="filter-chips" aria-label="적용된 필터">
@@ -101,7 +101,7 @@
 							<span class="sr-only">승인 사유</span>
 							<input name="reason" value="official alias reviewed" required>
 						</label>
-						<button type="submit">승인 저장</button>
+						<button type="submit" class="primary">승인 저장</button>
 					</form>
 					<form class="admin-form" method="post" th:action="@{'/admin/datapack/alias-approvals/' + ${alias.id} + '/reject'}">
 						<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
@@ -111,7 +111,7 @@
 							<span class="sr-only">반려 사유</span>
 							<input name="reason" value="official alias rejected" required>
 						</label>
-						<button type="submit">반려 저장</button>
+						<button type="submit" class="danger">반려 저장</button>
 					</form>
 				</td>
 			</tr>
@@ -181,7 +181,7 @@
 							<span class="sr-only">해결 사유</span>
 							<input name="resolutionReason" value="quarantine reviewed" required>
 						</label>
-						<button type="submit">해결 저장</button>
+						<button type="submit" class="primary">해결 저장</button>
 					</form>
 				</td>
 			</tr>

--- a/backend/src/main/resources/templates/admin/datapack/candidates/detail.html
+++ b/backend/src/main/resources/templates/admin/datapack/candidates/detail.html
@@ -21,7 +21,7 @@
 			<p th:text="${'scope ' + candidate.scopeId + ' · ' + candidate.artifactKind + ' · ' + candidate.version}">scope</p>
 		</div>
 		<div class="admin-actions">
-			<a class="admin-btn" th:href="@{/admin/datapack/pipeline/page}">파이프라인 개요</a>
+			<a class="admin-btn plain" th:href="@{/admin/datapack/pipeline/page}">파이프라인 개요</a>
 		</div>
 	</header>
 
@@ -76,28 +76,28 @@
 			<dd>
 				<span class="sha-inline" th:title="${evidenceBundle.evidenceBundleSha256}"
 				      th:text="${evidenceBundle.evidenceBundleSha256Short()}">sha</span>
-				<button type="button" class="tiny-btn" x-data="copyField" x-on:click="copy"
+				<button type="button" class="tiny-btn outline" x-data="copyField" x-on:click="copy"
 				        th:attr="data-copy-value=${evidenceBundle.evidenceBundleSha256}">복사</button>
 			</dd>
 			<dt>매니페스트 sha256</dt>
 			<dd>
 				<span class="sha-inline" th:title="${candidate.manifestSha256}"
 				      th:text="${candidate.manifestSha256Short()}">sha</span>
-				<button type="button" class="tiny-btn" x-data="copyField" x-on:click="copy"
+				<button type="button" class="tiny-btn outline" x-data="copyField" x-on:click="copy"
 				        th:attr="data-copy-value=${candidate.manifestSha256}">복사</button>
 			</dd>
 			<dt>원천 스냅샷 세트 hash</dt>
 			<dd>
 				<span class="sha-inline" th:title="${candidate.sourceSnapshotSetHash}"
 				      th:text="${candidate.sourceSnapshotSetHashShort()}">sha</span>
-				<button type="button" class="tiny-btn" x-data="copyField" x-on:click="copy"
+				<button type="button" class="tiny-btn outline" x-data="copyField" x-on:click="copy"
 				        th:attr="data-copy-value=${candidate.sourceSnapshotSetHash}">복사</button>
 			</dd>
 			<dt>오버라이드 세트 hash</dt>
 			<dd>
 				<span class="sha-inline" th:title="${candidate.overrideSetHash}"
 				      th:text="${candidate.overrideSetHashShort()}">sha</span>
-				<button type="button" class="tiny-btn" x-data="copyField" x-on:click="copy"
+				<button type="button" class="tiny-btn outline" x-data="copyField" x-on:click="copy"
 				        th:attr="data-copy-value=${candidate.overrideSetHash}">복사</button>
 			</dd>
 		</dl>
@@ -144,7 +144,7 @@
 			<label>사유
 				<input name="reason" value="candidate gates rerun requested" required>
 			</label>
-			<button type="submit">게이트 재실행</button>
+			<button type="submit" class="primary">게이트 재실행</button>
 		</form>
 	</section>
 </main>

--- a/backend/src/main/resources/templates/admin/datapack/candidates/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/candidates/list.html
@@ -41,8 +41,8 @@
 				<option value="candidate" th:selected="${filter.selectedSort('candidate')}">후보 ID순</option>
 			</select>
 			<input type="hidden" name="candidateId" th:if="${filter.hasCandidate()}" th:value="${filter.candidateValue}">
-			<button type="submit">검색</button>
-			<a class="admin-btn" th:href="@{/admin/datapack/candidates/page}">초기화</a>
+			<button type="submit" class="outline">검색</button>
+			<a class="admin-btn plain" th:href="@{/admin/datapack/candidates/page}">초기화</a>
 		</form>
 		<div class="table-filters" th:if="${filter.active()}">
 			<div class="filter-chips" aria-label="적용된 필터">

--- a/backend/src/main/resources/templates/admin/datapack/facility-evidence/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/facility-evidence/list.html
@@ -37,8 +37,8 @@
 			</select>
 			<input type="hidden" name="candidateId" th:if="${filter.hasCandidate()}" th:value="${filter.candidateValue}">
 			<input type="hidden" name="sourceSnapshotId" th:if="${filter.hasSourceSnapshot()}" th:value="${filter.sourceSnapshotValue}">
-			<button type="submit">검색</button>
-			<a class="admin-btn" th:href="@{/admin/datapack/facility-evidence/page}">초기화</a>
+			<button type="submit" class="outline">검색</button>
+			<a class="admin-btn plain" th:href="@{/admin/datapack/facility-evidence/page}">초기화</a>
 		</form>
 		<div class="table-filters" th:if="${filter.active()}">
 			<div class="filter-chips" aria-label="적용된 필터">
@@ -129,7 +129,7 @@
 							<span class="sr-only">검수 사유</span>
 							<input name="reason" value="facility evidence reviewed" required>
 						</label>
-						<button type="submit">검수 저장</button>
+						<button type="submit" class="primary">검수 저장</button>
 					</form>
 				</td>
 			</tr>

--- a/backend/src/main/resources/templates/admin/datapack/manual-overrides/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/manual-overrides/list.html
@@ -58,7 +58,7 @@
 					<label>expiresAt <input type="datetime-local" name="expiresAt" th:value="${overrideForm.expiresAt}" required></label>
 				</div>
 			</div>
-			<button type="submit">요청 저장</button>
+			<button type="submit" class="primary">요청 저장</button>
 		</form>
 	</section>
 
@@ -82,8 +82,8 @@
 				<option value="created" th:selected="${filter.selectedSort('created')}">시작 최신순</option>
 			</select>
 			<input type="hidden" name="candidateId" th:if="${filter.hasCandidate()}" th:value="${filter.candidateValue}">
-			<button type="submit">검색</button>
-			<a class="admin-btn" th:href="@{/admin/datapack/manual-overrides/page}">초기화</a>
+			<button type="submit" class="outline">검색</button>
+			<a class="admin-btn plain" th:href="@{/admin/datapack/manual-overrides/page}">초기화</a>
 		</form>
 		<div class="table-filters" th:if="${filter.active()}">
 			<div class="filter-chips" aria-label="적용된 필터">
@@ -164,7 +164,7 @@
 							<span class="sr-only">승인 사유</span>
 							<input name="reason" value="manual override reviewed" required>
 						</label>
-						<button type="submit">승인 저장</button>
+						<button type="submit" class="primary">승인 저장</button>
 					</form>
 					<form class="admin-form" method="post" th:action="@{'/admin/datapack/manual-overrides/' + ${row.id} + '/expire'}">
 						<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
@@ -174,7 +174,7 @@
 							<span class="sr-only">만료 사유</span>
 							<input name="reason" value="manual override expired" required>
 						</label>
-						<button type="submit">만료 저장</button>
+						<button type="submit" class="danger">만료 저장</button>
 					</form>
 				</td>
 			</tr>

--- a/backend/src/main/resources/templates/admin/datapack/pipeline/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/pipeline/list.html
@@ -130,21 +130,21 @@
 			<dd>
 				<span class="sha-inline" th:title="${pipeline.sourceSnapshotSetHash.fullValue}"
 				      th:text="${pipeline.sourceSnapshotSetHash.shortValue}">-</span>
-				<button type="button" class="tiny-btn" x-data="copyField" x-on:click="copy"
+				<button type="button" class="tiny-btn outline" x-data="copyField" x-on:click="copy"
 				        th:attr="data-copy-value=${pipeline.sourceSnapshotSetHash.fullValue}">복사</button>
 			</dd>
 			<dt>매니페스트 sha256</dt>
 			<dd>
 				<span class="sha-inline" th:title="${pipeline.manifestSha256.fullValue}"
 				      th:text="${pipeline.manifestSha256.shortValue}">-</span>
-				<button type="button" class="tiny-btn" x-data="copyField" x-on:click="copy"
+				<button type="button" class="tiny-btn outline" x-data="copyField" x-on:click="copy"
 				        th:attr="data-copy-value=${pipeline.manifestSha256.fullValue}">복사</button>
 			</dd>
 			<dt>증거 번들 sha256</dt>
 			<dd>
 				<span class="sha-inline" th:title="${pipeline.evidenceBundleSha256.fullValue}"
 				      th:text="${pipeline.evidenceBundleSha256.shortValue}">-</span>
-				<button type="button" class="tiny-btn" x-data="copyField" x-on:click="copy"
+				<button type="button" class="tiny-btn outline" x-data="copyField" x-on:click="copy"
 				        th:attr="data-copy-value=${pipeline.evidenceBundleSha256.fullValue}">복사</button>
 			</dd>
 			<dt>증거 워크플로</dt>

--- a/backend/src/main/resources/templates/admin/datapack/release-channels/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/release-channels/list.html
@@ -43,8 +43,8 @@
 				<option value="candidate" th:selected="${filter.selectedSort('candidate')}">후보 ID순</option>
 			</select>
 			<input type="hidden" name="candidateId" th:if="${filter.hasCandidate()}" th:value="${filter.candidateValue}">
-			<button type="submit">검색</button>
-			<a class="admin-btn" th:href="@{/admin/datapack/release-channels/page}">초기화</a>
+			<button type="submit" class="outline">검색</button>
+			<a class="admin-btn plain" th:href="@{/admin/datapack/release-channels/page}">초기화</a>
 		</form>
 		<div class="table-filters" th:if="${filter.active()}">
 			<div class="filter-chips" aria-label="적용된 필터">
@@ -131,7 +131,7 @@
 							workflow run URL
 							<input name="workflowRunUrl" type="url" required>
 						</label>
-						<button type="submit">production 승인</button>
+						<button type="submit" class="primary">production 승인</button>
 						</form>
 					</details>
 					<details class="admin-promote-confirm" th:if="${channel.previousStableCandidateId != '-'}">
@@ -161,7 +161,7 @@
 							workflow run URL
 							<input name="workflowRunUrl" type="url" required>
 						</label>
-						<button type="submit">rollback 실행</button>
+						<button type="submit" class="danger">rollback 실행</button>
 						</form>
 					</details>
 				</td>

--- a/backend/src/main/resources/templates/admin/datapack/release-requests/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/release-requests/list.html
@@ -53,7 +53,7 @@
 					<option value="dev">dev</option>
 				</select>
 			</label>
-			<button type="submit">release request 요청</button>
+			<button type="submit" class="primary">release request 요청</button>
 		</form>
 	</section>
 
@@ -102,14 +102,14 @@
 						  th:action="@{/admin/datapack/release-requests/{approvalId}/approve(approvalId=${request.approvalId})}">
 						<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 						<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
-						<button type="submit">승인</button>
+						<button type="submit" class="primary">승인</button>
 					</form>
 					<form th:if="${request.status == 'DISPATCH_FAILED'}"
 						  method="post"
 						  th:action="@{/admin/datapack/release-requests/{approvalId}/retry-dispatch(approvalId=${request.approvalId})}">
 						<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 						<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
-						<button type="submit">dispatch 재시도</button>
+						<button type="submit" class="outline">dispatch 재시도</button>
 					</form>
 					<span th:if="${request.status == 'APPROVED'}">수동 실행 필요</span>
 					<span th:if="${request.status == 'PUBLISHED' and request.promoteOutcome == 'REJECTED'}"
@@ -150,7 +150,7 @@
 						<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 						<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 						<label>repair reason <input name="reason" required maxlength="200"></label>
-						<button type="submit">수동 repair</button>
+						<button type="submit" class="outline">수동 repair</button>
 					</form>
 					<span th:unless="${delivery.repairable}">-</span>
 				</td>

--- a/backend/src/main/resources/templates/admin/datapack/route-gates/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/route-gates/list.html
@@ -37,8 +37,8 @@
 			</select>
 			<input type="hidden" name="candidateId" th:if="${filter.hasCandidate()}" th:value="${filter.candidateValue}">
 			<input type="hidden" name="sourceSnapshotId" th:if="${filter.hasSourceSnapshot()}" th:value="${filter.sourceSnapshotValue}">
-			<button type="submit">검색</button>
-			<a class="admin-btn" th:href="@{/admin/datapack/route-gates/page}">초기화</a>
+			<button type="submit" class="outline">검색</button>
+			<a class="admin-btn plain" th:href="@{/admin/datapack/route-gates/page}">초기화</a>
 		</form>
 		<div class="table-filters" th:if="${filter.active()}">
 			<div class="filter-chips" aria-label="적용된 필터">

--- a/backend/src/main/resources/templates/admin/datapack/source-snapshots/detail.html
+++ b/backend/src/main/resources/templates/admin/datapack/source-snapshots/detail.html
@@ -20,7 +20,7 @@
 			<p>raw 전문은 노출하지 않고 source snapshot metadata와 evidence 위치만 표시합니다.</p>
 		</div>
 		<div class="admin-actions">
-			<a class="admin-btn" th:href="@{/admin/datapack/source-snapshots/page}">목록</a>
+			<a class="admin-btn plain" th:href="@{/admin/datapack/source-snapshots/page}">목록</a>
 		</div>
 	</header>
 
@@ -218,7 +218,7 @@
 					<input name="idempotencyKey" required>
 				</label>
 			</div>
-			<button type="submit">LOCKED snapshot 저장</button>
+			<button type="submit" class="primary">LOCKED snapshot 저장</button>
 		</form>
 	</section>
 
@@ -247,7 +247,7 @@
 				idempotency key
 				<input name="idempotencyKey" required>
 			</label>
-			<button type="submit">Normalization run 요청</button>
+			<button type="submit" class="outline">Normalization run 요청</button>
 		</form>
 	</section>
 </main>

--- a/backend/src/main/resources/templates/admin/datapack/source-snapshots/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/source-snapshots/list.html
@@ -41,8 +41,8 @@
 			</select>
 			<input type="hidden" name="candidateId" th:if="${filter.hasCandidate()}" th:value="${filter.candidateValue}">
 			<input type="hidden" name="sourceSnapshotId" th:if="${filter.hasSourceSnapshot()}" th:value="${filter.sourceSnapshotValue}">
-			<button type="submit">검색</button>
-			<a class="admin-btn" th:href="@{/admin/datapack/source-snapshots/page}">초기화</a>
+			<button type="submit" class="outline">검색</button>
+			<a class="admin-btn plain" th:href="@{/admin/datapack/source-snapshots/page}">초기화</a>
 		</form>
 		<div class="table-filters" th:if="${filter.active()}">
 			<div class="filter-chips" aria-label="적용된 필터">

--- a/backend/src/main/resources/templates/admin/error.html
+++ b/backend/src/main/resources/templates/admin/error.html
@@ -20,7 +20,7 @@
 			<p th:text="${'상태 코드 ' + status}">상태 코드 500</p>
 		</div>
 		<div class="admin-actions">
-			<a class="admin-btn" th:href="@{/admin/dashboard/page}">대시보드</a>
+			<a class="admin-btn outline" th:href="@{/admin/dashboard/page}">대시보드</a>
 		</div>
 	</header>
 	<section class="admin-panel" role="alert" aria-labelledby="admin-error-title">

--- a/backend/src/main/resources/templates/admin/facilities/editor.html
+++ b/backend/src/main/resources/templates/admin/facilities/editor.html
@@ -20,8 +20,8 @@
 			<p>시설 종류, 출구, 층, 좌표, 설명, 상태, 확인 상태, 출처를 확인합니다.</p>
 		</div>
 		<div class="admin-actions">
-			<a class="admin-btn" th:href="@{/admin/facilities/editor/page(stationId=${selectedStationId},facilityId='__new')}">새 시설</a>
-			<a class="admin-btn" th:href="@{/admin/facilities/page}">상태판</a>
+			<a class="admin-btn outline" th:href="@{/admin/facilities/editor/page(stationId=${selectedStationId},facilityId='__new')}">새 시설</a>
+			<a class="admin-btn plain" th:href="@{/admin/facilities/page}">상태판</a>
 		</div>
 	</header>
 	<div class="alert warning" th:if="${!masterDataWritable}">
@@ -47,7 +47,7 @@
 						        th:text="${station.stationName}">상록수</option>
 					</select>
 				</label>
-				<button type="submit">역 시설 보기</button>
+				<button type="submit" class="outline">역 시설 보기</button>
 			</form>
 
 			<div class="admin-table-scroll" tabindex="0" role="group"
@@ -65,7 +65,7 @@
 					<td th:text="${facility.facilityName}">엘리베이터</td>
 					<td th:text="${facility.statusLabel}">정상</td>
 					<td>
-						<a class="admin-btn"
+						<a class="admin-btn outline"
 						   th:href="@{/admin/facilities/editor/page(stationId=${selectedStationId},facilityId=${facility.facilityId})}">열기</a>
 					</td>
 				</tr>
@@ -155,7 +155,7 @@
 					<span class="meta">사용자 위치 설명</span>
 					<textarea name="description" th:text="${facilityForm.description}"></textarea>
 				</label>
-				<button type="submit" th:disabled="${!masterDataWritable}" th:text="${selectedFacility == null ? '등록' : '저장'}">저장</button>
+				<button type="submit" class="primary" th:disabled="${!masterDataWritable}" th:text="${selectedFacility == null ? '등록' : '저장'}">저장</button>
 			</form>
 		</section>
 	</div>

--- a/backend/src/main/resources/templates/admin/facilities/list.html
+++ b/backend/src/main/resources/templates/admin/facilities/list.html
@@ -20,7 +20,7 @@
 			<p>모든 접근성 시설의 상태·확인 상태·갱신일을 필터링하고 즉시 변경합니다.</p>
 		</div>
 		<div class="admin-actions">
-			<a class="admin-btn" th:href="@{/admin/facilities/editor/page}">시설 등록·수정</a>
+			<a class="admin-btn outline" th:href="@{/admin/facilities/editor/page}">시설 등록·수정</a>
 		</div>
 	</header>
 	<p class="summary">역 상세와 경로 안내에 쓰는 시설 상태를 확인하고 수정합니다.</p>
@@ -73,7 +73,7 @@
 					<option th:each="opt : ${stationFilterOptions}" th:value="${opt.value}"
 					        th:text="${opt.label}" th:selected="${opt.selected}">전체 역</option>
 				</select>
-				<button type="submit">필터 적용</button>
+				<button type="submit" class="outline admin-filter-apply">필터 적용</button>
 			</form>
 			<form th:fragment="facilityView" class="admin-toolbar-form" method="get"
 			      th:action="@{/admin/facilities/page}" role="group" aria-label="정렬"
@@ -88,7 +88,7 @@
 					<option value="attention" th:selected="${selectedSort == 'attention'}">확인 필요 먼저</option>
 					<option value="updated" th:selected="${selectedSort == 'updated'}">갱신일 최신순</option>
 				</select>
-				<button type="submit">정렬 적용</button>
+				<button type="submit" class="outline admin-filter-apply">정렬 적용</button>
 			</form>
 		</div>
 
@@ -175,7 +175,7 @@
 									        th:text="${option.label}">정상</option>
 								</select>
 							</label>
-							<button type="submit" th:disabled="${!masterDataWritable}">저장</button>
+							<button type="submit" class="primary" th:disabled="${!masterDataWritable}">저장</button>
 						</form>
 					</td>
 				</tr>

--- a/backend/src/main/resources/templates/admin/field/detail.html
+++ b/backend/src/main/resources/templates/admin/field/detail.html
@@ -24,8 +24,8 @@
 			</p>
 		</div>
 		<div class="admin-actions">
-			<a class="admin-btn" th:href="@{/admin/field-verifications/stations/{stationId}/export.csv(stationId=${verification.stationId})}">CSV 내보내기</a>
-			<a class="admin-btn" th:href="@{/admin/field-verifications/page}">목록</a>
+			<a class="admin-btn outline" th:href="@{/admin/field-verifications/stations/{stationId}/export.csv(stationId=${verification.stationId})}">CSV 내보내기</a>
+			<a class="admin-btn plain" th:href="@{/admin/field-verifications/page}">목록</a>
 		</div>
 	</header>
 	<div th:replace="~{admin/fragments/form-errors :: summary}"></div>
@@ -84,7 +84,7 @@
 								<textarea name="note"
 								          th:text="${fieldVerificationFailedItemId == item.itemId ? fieldVerificationForm.note : item.note}">메모</textarea>
 							</label>
-							<button type="submit">상태 저장</button>
+							<button type="submit" class="primary">상태 저장</button>
 						</form>
 					</td>
 				</tr>

--- a/backend/src/main/resources/templates/admin/field/list.html
+++ b/backend/src/main/resources/templates/admin/field/list.html
@@ -50,7 +50,7 @@
 			<td th:text="|${verification.verifiedCount} / ${verification.itemCount}|">0 / 0</td>
 			<td th:text="${verification.recheckCount}">0</td>
 			<td>
-				<a class="admin-btn" th:href="@{/admin/field-verifications/{stationId}/page(stationId=${verification.stationId})}">상세</a>
+				<a class="admin-btn outline" th:href="@{/admin/field-verifications/{stationId}/page(stationId=${verification.stationId})}">상세</a>
 			</td>
 		</tr>
 		</tbody>

--- a/backend/src/main/resources/templates/admin/fragments/list-toolbar.html
+++ b/backend/src/main/resources/templates/admin/fragments/list-toolbar.html
@@ -35,7 +35,7 @@
 			<input type="hidden" th:each="hiddenParam : ${search.get('hidden')}"
 			       th:name="${hiddenParam.key}" th:value="${hiddenParam.value}">
 		</th:block>
-		<button type="submit">검색</button>
+		<button type="submit" class="outline">검색</button>
 	</form>
 
 	<!-- 3: 저장된 뷰(계정별 스냅샷). 적용은 htmx/no-JS 링크, 저장·기본·삭제는 command token + CSRF POST. -->

--- a/backend/src/main/resources/templates/admin/fragments/shell.html
+++ b/backend/src/main/resources/templates/admin/fragments/shell.html
@@ -36,7 +36,7 @@
 					<input type="search" name="q" x-ref="input" placeholder="메뉴·역 검색"
 					       aria-label="검색어" autocomplete="off"
 					       x-on:keydown.arrow-down.prevent="focusResults">
-					<button type="submit">검색</button>
+					<button type="submit" class="outline">검색</button>
 				</form>
 				<div id="palette-results" class="command-palette-results"
 				     x-on:keydown.arrow-down.prevent="moveDown"

--- a/backend/src/main/resources/templates/admin/incidents/list.html
+++ b/backend/src/main/resources/templates/admin/incidents/list.html
@@ -27,7 +27,7 @@
 		<form th:if="${healthStatus != 'UP'}" method="post" th:action="@{/admin/incidents/health}">
 			<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 			<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
-			<button type="submit">Health incident 생성</button>
+			<button type="submit" class="outline">Health incident 생성</button>
 		</form>
 	</section>
 
@@ -56,7 +56,7 @@
 			<label>담당자 <input name="owner"></label>
 			<label>연결 역 ID <input name="stationId" placeholder="선택"></label>
 			<label>연결 노선 ID <input name="lineId" placeholder="선택"></label>
-			<button type="submit">생성</button>
+			<button type="submit" class="primary">생성</button>
 		</form>
 	</section>
 
@@ -127,7 +127,7 @@
 								<label th:for="${'incident-note-' + incident.incidentId + '-' + option.code}">메모</label>
 								<input th:id="${'incident-note-' + incident.incidentId + '-' + option.code}" name="note"
 								       aria-label="전이 메모" placeholder="전이 메모(선택)">
-								<button type="submit" th:text="${option.label + '(으)로'}">전이</button>
+								<button type="submit" class="primary" th:text="${option.label + '(으)로'}">전이</button>
 							</form>
 						</div>
 						<p th:unless="${incident.open}" class="admin-incident-resolution" th:text="${incident.resolution}">해결됨</p>

--- a/backend/src/main/resources/templates/admin/notices/list.html
+++ b/backend/src/main/resources/templates/admin/notices/list.html
@@ -53,7 +53,7 @@
 				만료 시각
 				<input name="expiresAt" type="datetime-local">
 			</label>
-			<button type="submit">공지 발행</button>
+			<button type="submit" class="primary">공지 발행</button>
 		</form>
 	</section>
 
@@ -91,7 +91,7 @@
 					      th:action="@{/admin/notices/{id}/unpublish/page(id=${notice.id})}">
 						<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 						<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
-						<button type="submit">즉시 내리기</button>
+						<button type="submit" class="danger">즉시 내리기</button>
 					</form>
 				</td>
 			</tr>

--- a/backend/src/main/resources/templates/admin/notifications/push.html
+++ b/backend/src/main/resources/templates/admin/notifications/push.html
@@ -197,7 +197,7 @@
 					</select>
 					<input type="date" name="from" th:value="${historyFrom}" aria-label="발송 기간 시작">
 					<input type="date" name="to" th:value="${historyTo}" aria-label="발송 기간 종료">
-					<button type="submit">필터 적용</button>
+					<button type="submit" class="outline admin-filter-apply">필터 적용</button>
 				</form>
 			</div>
 
@@ -299,7 +299,7 @@
 					<p>선택한 실패 알림을 재발송합니다. 이미 발송 성공한 건은 자동으로 제외되며,
 						한 번에 최대 <strong th:text="${resendLimit}">50</strong>건까지 처리합니다.
 						상한을 넘으면 재발송되지 않으니 나눠서 처리하세요.</p>
-					<button type="submit" x-bind:disabled="submitDisabled">선택한 실패 건 재발송</button>
+					<button type="submit" class="primary" x-bind:disabled="submitDisabled">선택한 실패 건 재발송</button>
 				</details>
 			</form>
 

--- a/backend/src/main/resources/templates/admin/reports/detail.html
+++ b/backend/src/main/resources/templates/admin/reports/detail.html
@@ -24,7 +24,7 @@
 			<p>사진·위치·설명·중복 후보·감사 이력을 보고 승인·반려·중복 판정합니다.</p>
 		</div>
 		<div class="admin-actions">
-			<a class="admin-btn" th:href="@{/admin/reports/page}">목록으로</a>
+			<a class="admin-btn plain" th:href="@{/admin/reports/page}">목록으로</a>
 		</div>
 	</header>
 	<h1 class="sr-only">신고 상세</h1>
@@ -54,7 +54,7 @@
 			<dt>시설</dt>
 			<dd th:text="${facilityLabel}">엘리베이터(facility-id)</dd>
 			<dt th:if="${report.correctionOverrideHref != null}">임시 override</dt>
-			<dd th:if="${report.correctionOverrideHref != null}"><a class="admin-btn" th:href="@{__${report.correctionOverrideHref}__}">manual override 요청</a></dd>
+			<dd th:if="${report.correctionOverrideHref != null}"><a class="admin-btn outline" th:href="@{__${report.correctionOverrideHref}__}">manual override 요청</a></dd>
 			<dt>신고자</dt>
 			<dd th:text="${report.userId}">user-id</dd>
 			<dt>좌표</dt>
@@ -160,10 +160,11 @@
 			기준 신고 ID
 			<input name="duplicateOfReportId" type="text" autocomplete="off" placeholder="중복 처리할 때 입력" th:value="${reviewForm.duplicateOfReportId}">
 		</label>
-		<!-- V6-04 button 계약(V6-08 #2280): 승인 primary, 반려 danger, 중복 처리 secondary로 액션 위계를 명시한다. -->
+		<!-- 버튼 위계 계약(V6-08 #2280, outline 이관 #2313): 승인 primary(대표 액션), 반려 danger(파괴적),
+		     중복 처리 outline(보조)로 화면당 filled 1개 원칙을 지킨다. -->
 		<button class="primary" type="submit" name="decision" value="ACCEPT">승인</button>
 		<button class="danger" type="submit" name="decision" value="REJECT">반려</button>
-		<button class="secondary" type="submit" name="decision" value="MARK_DUPLICATE">중복 처리</button>
+		<button class="outline" type="submit" name="decision" value="MARK_DUPLICATE">중복 처리</button>
 	</form>
 	</div>
 </main>

--- a/backend/src/main/resources/templates/admin/reports/list.html
+++ b/backend/src/main/resources/templates/admin/reports/list.html
@@ -125,13 +125,13 @@
 						<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 						<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 						<input type="hidden" name="returnTo" th:value="${currentListHref}">
-						<button type="submit" title="기본으로 지정" aria-label="기본 뷰로 지정">★</button>
+						<button type="submit" class="plain" title="기본으로 지정" aria-label="기본 뷰로 지정">★</button>
 					</form>
 					<form method="post" th:action="@{/admin/saved-views/{id}/delete(id=${view.viewId})}">
 						<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 						<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 						<input type="hidden" name="returnTo" th:value="${currentListHref}">
-						<button type="submit" title="삭제" aria-label="저장된 뷰 삭제">✕</button>
+						<button type="submit" class="plain" title="삭제" aria-label="저장된 뷰 삭제">✕</button>
 					</form>
 				</span>
 			</div>

--- a/backend/src/main/resources/templates/admin/reports/list.html
+++ b/backend/src/main/resources/templates/admin/reports/list.html
@@ -85,7 +85,7 @@
 					<option th:each="opt : ${photoFilters}" th:value="${opt.value}"
 					        th:text="${opt.label}" th:selected="${opt.selected}">사진 전체</option>
 				</select>
-				<button type="submit">필터 적용</button>
+				<button type="submit" class="outline admin-filter-apply">필터 적용</button>
 			</form>
 			<!-- 보기 설정(보기 설정 시트): 밀도 3단·열 표시 토글·단축키 도움말. reportTable(#report-results
 			     조상 스코프)의 메서드에 바인딩된다. 순수 표시 설정이라 폼 밖에 두어 제출되지 않는다. no-JS는
@@ -145,7 +145,7 @@
 				<label class="save-view-default">
 					<input type="checkbox" name="makeDefault" value="true"> 기본
 				</label>
-				<button type="submit">저장</button>
+				<button type="submit" class="outline">저장</button>
 			</form>
 		</div>
 
@@ -287,7 +287,7 @@
 						<li><kbd>Esc</kbd> 패널 · 도움말 닫기</li>
 						<li><kbd>?</kbd> 이 도움말 열기 / 닫기</li>
 					</ul>
-					<button type="button" x-on:click="hideHelp">닫기</button>
+					<button type="button" class="plain" x-on:click="hideHelp">닫기</button>
 				</div>
 			</div>
 		</div>

--- a/backend/src/main/resources/templates/admin/search.html
+++ b/backend/src/main/resources/templates/admin/search.html
@@ -28,7 +28,7 @@
 	      th:attr="hx-get=@{/admin/search}" hx-trigger="submit, keyup changed delay:300ms">
 		<input type="search" name="q" th:value="${query}"
 		       placeholder="메뉴·역·제보 검색" aria-label="검색어" autocomplete="off">
-		<button type="submit">검색</button>
+		<button type="submit" class="outline">검색</button>
 	</form>
 
 	<div id="search-results">

--- a/backend/src/main/resources/templates/admin/stations/detail.html
+++ b/backend/src/main/resources/templates/admin/stations/detail.html
@@ -24,8 +24,8 @@
 			</p>
 		</div>
 		<div class="admin-actions">
-			<a class="admin-btn" th:href="@{/admin/stations/{stationId}/layouts/page(stationId=${station.stationId})}">구조·동선 편집</a>
-			<a class="admin-btn" th:href="@{/admin/stations/page}">역 목록</a>
+			<a class="admin-btn outline" th:href="@{/admin/stations/{stationId}/layouts/page(stationId=${station.stationId})}">구조·동선 편집</a>
+			<a class="admin-btn plain" th:href="@{/admin/stations/page}">역 목록</a>
 		</div>
 	</header>
 
@@ -159,7 +159,7 @@
 							<td th:text="${facility.statusLabel}">정상</td>
 							<td th:text="${facility.confidenceLabel}">높음</td>
 							<td>
-								<a class="admin-btn"
+								<a class="admin-btn outline"
 								   th:href="@{/admin/facilities/editor/page(stationId=${station.stationId},facilityId=${facility.facilityId})}">수정</a>
 							</td>
 						</tr>
@@ -176,7 +176,7 @@
 				<section>
 					<div class="hub-panel-head">
 						<h2>제보 이력</h2>
-						<a class="admin-btn" th:href="@{${stationReportsHref}}">전체 제보 보기</a>
+						<a class="admin-btn plain" th:href="@{${stationReportsHref}}">전체 제보 보기</a>
 					</div>
 					<div class="admin-table-scroll" tabindex="0" role="group"
 					     aria-label="가로로 스크롤 가능한 데이터 표" th:if="${!stationReports.isEmpty()}">
@@ -213,7 +213,7 @@
 				<section>
 					<div class="hub-panel-head">
 						<h2>현장 확인</h2>
-						<a class="admin-btn" th:href="@{${fieldVerificationHref}}">현장 확인 화면</a>
+						<a class="admin-btn outline" th:href="@{${fieldVerificationHref}}">현장 확인 화면</a>
 					</div>
 					<div th:if="${fieldSession == null}"
 					     th:replace="~{admin/fragments/empty-state :: panel('현장 확인 세션이 없습니다.', '현장 확인 화면에서 확인 일정을 등록하세요.')}"></div>
@@ -264,7 +264,7 @@
 				<section>
 					<div class="hub-panel-head">
 						<h2>구조·동선</h2>
-						<a class="admin-btn" th:href="@{${layoutEditorHref}}">구조·동선 편집</a>
+						<a class="admin-btn outline" th:href="@{${layoutEditorHref}}">구조·동선 편집</a>
 					</div>
 					<h3>구조 자료</h3>
 					<div class="admin-table-scroll" tabindex="0" role="group"

--- a/backend/src/main/resources/templates/admin/stations/layouts.html
+++ b/backend/src/main/resources/templates/admin/stations/layouts.html
@@ -23,7 +23,7 @@
 			</p>
 		</div>
 		<div class="admin-actions">
-			<a class="admin-btn" th:href="@{/admin/stations/{stationId}/page(stationId=${station.stationId})}">역 상세</a>
+			<a class="admin-btn plain" th:href="@{/admin/stations/{stationId}/page(stationId=${station.stationId})}">역 상세</a>
 		</div>
 	</header>
 
@@ -90,7 +90,7 @@
 						<label class="meta" th:for="|reviewed-at-${source.id}|">확인일</label>
 						<input type="date" name="reviewedAt" th:id="|reviewed-at-${source.id}|"
 						       aria-label="확인일" th:value="${source.rawReviewedAt}">
-						<button type="submit" th:disabled="${!masterDataWritable}">저장</button>
+						<button type="submit" class="primary" th:disabled="${!masterDataWritable}">저장</button>
 					</form>
 					<span class="meta" th:text="${source.sourceName}">상록수역 역사 안내도</span>
 					<span class="meta" th:text="${source.sourceUrl}">https://www.seoulmetro.co.kr</span>
@@ -145,7 +145,7 @@
 							        th:text="${option.label}"
 							        th:selected="${option.value == layout.statusValue}">DRAFT</option>
 						</select>
-						<button type="submit" th:disabled="${!masterDataWritable}">변경</button>
+						<button type="submit" class="primary" th:disabled="${!masterDataWritable}">변경</button>
 					</form>
 				</td>
 				<td th:text="${layout.confidenceLevel}">OFFICIAL_DIAGRAM_REFERENCED</td>
@@ -197,7 +197,7 @@
 						<label class="meta" th:for="|accessibility-note-${node.id}|">접근성 메모</label>
 						<input type="text" name="accessibilityNote" th:id="|accessibility-note-${node.id}|"
 						       aria-label="접근성 메모" th:value="${node.rawAccessibilityNote}">
-						<button type="submit" th:disabled="${!masterDataWritable}">저장</button>
+						<button type="submit" class="primary" th:disabled="${!masterDataWritable}">저장</button>
 						<span class="meta" th:text="${node.positionLabel}">x 120, y 240</span>
 						<span class="meta" th:text="${node.layoutId}">layout-sangnoksu-draft</span>
 					</form>
@@ -271,7 +271,7 @@
 							<option value="true" th:selected="${edge.active}">활성</option>
 							<option value="false" th:selected="${!edge.active}">비활성</option>
 						</select>
-						<button type="submit" th:disabled="${!masterDataWritable}">저장</button>
+						<button type="submit" class="primary" th:disabled="${!masterDataWritable}">저장</button>
 					</form>
 					<span class="meta" th:text="${edge.distanceLabel}">28m</span>
 					<span class="meta" th:text="${edge.estimatedSecondsLabel}">75초</span>

--- a/backend/src/main/resources/templates/admin/stations/list.html
+++ b/backend/src/main/resources/templates/admin/stations/list.html
@@ -55,7 +55,7 @@
 					<option th:each="opt : ${lineOptions}" th:value="${opt.value}"
 					        th:text="${opt.label}" th:selected="${opt.selected}">전체 노선</option>
 				</select>
-				<button type="submit">필터 적용</button>
+				<button type="submit" class="outline admin-filter-apply">필터 적용</button>
 			</form>
 			<form th:fragment="stationView" class="admin-toolbar-form" method="get"
 			      th:action="@{/admin/stations/page}" role="group" aria-label="정렬"
@@ -69,7 +69,7 @@
 					<option value="name_desc" th:selected="${selectedSort == 'name_desc'}">역명 역순</option>
 					<option value="pending" th:selected="${selectedSort == 'pending'}">미확인 제보 많은 순</option>
 				</select>
-				<button type="submit">정렬 적용</button>
+				<button type="submit" class="outline admin-filter-apply">정렬 적용</button>
 			</form>
 		</div>
 

--- a/backend/src/test/java/com/easysubway/admin/web/AdminDesignGuardTest.java
+++ b/backend/src/test/java/com/easysubway/admin/web/AdminDesignGuardTest.java
@@ -364,7 +364,7 @@ class AdminDesignGuardTest {
 
 		// direct control ≤5: 검색 입력 1 + 검색 버튼 1 + 저장된 뷰 zone 1 + 필터 트리거 1 + 보기 설정 트리거 1.
 		assertThat(count(Pattern.compile("type=\"search\""), fragment)).as("검색 입력 1개").isEqualTo(1);
-		assertThat(count(Pattern.compile("<button type=\"submit\">검색</button>"), fragment))
+		assertThat(count(Pattern.compile("<button type=\"submit\" class=\"outline\">검색</button>"), fragment))
 			.as("검색 버튼 1개").isEqualTo(1);
 		assertThat(count(Pattern.compile("class=\"admin-toolbar-sheet-trigger"), fragment))
 			.as("시트 트리거 2개(필터·보기 설정)").isEqualTo(2);

--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageControllerTest.java
@@ -255,10 +255,10 @@ class FacilityReportAdminPageControllerTest {
 			.doesNotContain("facility-reports/")
 			.contains("37.302421")
 			.contains("126.866221")
-			// V6-08 #2280 action 체계: 승인 primary, 반려 danger, 중복 처리 secondary로 위계를 명시한다.
+			// 버튼 위계 계약(V6-08 #2280, outline 이관 #2313): 승인 primary, 반려 danger, 중복 처리 outline으로 위계를 명시한다.
 			.contains("class=\"primary\" type=\"submit\" name=\"decision\" value=\"ACCEPT\"")
 			.contains("class=\"danger\" type=\"submit\" name=\"decision\" value=\"REJECT\"")
-			.contains("class=\"secondary\" type=\"submit\" name=\"decision\" value=\"MARK_DUPLICATE\"");
+			.contains("class=\"outline\" type=\"submit\" name=\"decision\" value=\"MARK_DUPLICATE\"");
 		assertThat(auditEventRepository.findRecent(AdminAuditEventType.PRIVACY_READ, 1))
 			.singleElement()
 				.satisfies(event -> {


### PR DESCRIPTION
## 관련 이슈

Refs #2313

## 작업 내용

- `admin-components.css`에 버튼 3계층 canonical class(`.primary`/`.outline`/`.plain`) 추가. 구 `.secondary`(주황 fill)는 위계가 아닌 또 다른 강조였던 문제로 폐지하고 `.outline`으로 이관(원 계약 #2280).
- `templates/admin/**`의 naked `<button>`·`.admin-btn`을 전수 점검해 화면당 filled(primary/danger) 버튼 1개 원칙으로 명시 class를 부여(조회·이동·보조 액션은 outline/plain).
- 필터/정렬 폼은 이미 htmx `hx-trigger="change, submit"` 자동 제출이 동작하므로, JS 활성 환경(`body.has-js`)에서는 "필터 적용"/"정렬 적용" 제출 버튼을 CSS로 숨김(`admin-filter-apply` + `admin-data.css`). no-JS는 이 규칙이 걸리지 않아 버튼이 그대로 노출되고 수동 GET 제출이 폴백으로 동작(hidden 필터 바인딩·GET 계약 불변).
- operator 화면(`templates/operator/**`)은 조사 결과 htmx 자동 제출 패턴이 없어(순수 GET form) 필터 적용 버튼 숨김 대상에서 제외 — 화면당 filled 버튼도 이미 1개뿐이라 위계 조정 대상 없음.
- 기존 마크업을 고정 assert하던 테스트 2건(신고 상세 중복 처리 버튼 class, 목록 툴바 검색 버튼 markup)을 새 계약에 맞춰 갱신.

## 검증

- 실행한 명령과 결과:
  - `./gradlew compileJava` — 성공
  - `./gradlew test --tests "com.easysubway.admin.web.AdminDesignGuardTest" --tests "com.easysubway.admin.adapter.in.web.AdminV3PageSmokeTest" --tests "com.easysubway.admin.web.AdminIconContractTest"` — 통과
  - `./gradlew test --tests "*AdminPageControllerTest" --tests "*FacilityReportAdminPageControllerTest" --tests "*TransitFacilityAdminPageControllerTest" --tests "*TransitStationLayoutAdminPageControllerTest" --tests "*PushNotificationAdminPageControllerTest" --tests "*AdminAuditPageControllerTest"` 등 변경 화면을 렌더링하는 컨트롤러 테스트 다수(100여 건) — 전부 통과
  - `./gradlew test --tests "*Operator*PageControllerTest"` — 통과
  - dev profile(H2, break-glass env 계정) 로 실기동 부팅 후 브라우저 자동화로 역 목록 화면 확인: JS 활성 시 "필터 적용"/"정렬 적용" `display: none` 확인, `has-js` 클래스 제거(no-JS 시뮬레이션) 시 두 버튼 모두 `display: flex`로 노출 확인. 검색 버튼이 outline 스타일로 렌더됨을 스크린샷으로 확인.

## 영향

- [x] 제품/운영 위험 없음 (route/accessibility/mobile UX/backend API/auth/security 아님)
- [x] DB migration 없음
- [x] 배포 영향 없음
- [x] route/realtime/datapack contract 영향 없음
- [x] CI workflow·계약 테스트·release gate JSON 변경 없음 (있으면 full.md로 전환)

## 체크리스트

- [x] 이 PR은 B/C등급 작업이며 full template이 필요 없다.
- [ ] CI 결과를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 폴백 리뷰를 단일 PR review로 게시했다.