### PR TITLE
[Style] #2313 관리자 상태 표현 단일화 + 영문/enum 표시 한국어화 (PR②)

### DIFF
--- a/backend/src/main/java/com/easysubway/datapack/adapter/in/web/DatapackCandidateAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/datapack/adapter/in/web/DatapackCandidateAdminPageController.java
@@ -267,9 +267,9 @@ class DatapackCandidateAdminPageController {
 
 		public String productionPromoteReason() {
 			if (productionPromoteAllowed()) {
-				return "production promote 가능";
+				return "프로덕션 반영 가능";
 			}
-			return "production promote 차단: evidence bundle PASS 필요";
+			return "프로덕션 반영 차단: 증거 번들 PASS 필요";
 		}
 	}
 

--- a/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcDatapackReleaseBlockerSummaryRepository.java
+++ b/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcDatapackReleaseBlockerSummaryRepository.java
@@ -126,8 +126,8 @@ public class JdbcDatapackReleaseBlockerSummaryRepository implements DatapackRele
 			hasAnyEvidence && totalBlockers == 0 ? "PASS" : "확인 필요",
 			totalBlockers,
 			List.of(
-				new StationReleaseBlockerRow("Facility evidence", facilityBlockers, stationRowStatus(facilityBlockers, facilityEvidenceRows)),
-				new StationReleaseBlockerRow("Route gate", routeGateBlockers, stationRowStatus(routeGateBlockers, routeEvidenceRows))
+				new StationReleaseBlockerRow("시설 근거", facilityBlockers, stationRowStatus(facilityBlockers, facilityEvidenceRows)),
+				new StationReleaseBlockerRow("경로 게이트", routeGateBlockers, stationRowStatus(routeGateBlockers, routeEvidenceRows))
 			)
 		);
 	}
@@ -180,28 +180,28 @@ public class JdbcDatapackReleaseBlockerSummaryRepository implements DatapackRele
 		long androidBlockers = candidate.map(row -> "PASS".equals(row.androidEvidenceStatus()) ? 0L : 1L).orElse(1L)
 			+ evidenceBundle.androidBlocker();
 		return List.of(
-			new ReleaseReadinessRow("Source coverage", statusFor(sourceBlockers), sourceBlockers, sourceNote(aliasBlockers, quarantineBlockers)),
+			new ReleaseReadinessRow("소스 커버리지", statusFor(sourceBlockers), sourceBlockers, sourceNote(aliasBlockers, quarantineBlockers)),
 			new ReleaseReadinessRow(
-				"Source freshness",
+				"소스 최신성",
 				candidate.isEmpty() ? "확인 필요" : statusFor(sourceFreshnessBlockers),
 				sourceFreshnessBlockers,
 				candidate.isEmpty()
 					? "source snapshot 없음"
-					: sourceFreshnessBlockers > 0 ? "SOURCE_SNAPSHOT_EXPIRED" : "latest source snapshots"
+					: sourceFreshnessBlockers > 0 ? "SOURCE_SNAPSHOT_EXPIRED" : "최신 원천 스냅샷"
 			),
-			new ReleaseReadinessRow("Validator", statusFor(validatorBlockers), validatorBlockers, "SQLite integrity / validator gates"),
-			new ReleaseReadinessRow("Facility evidence", statusFor(facilityBlockers), facilityBlockers, "strict route eligible facility evidence"),
-			new ReleaseReadinessRow("Route gate", statusFor(routeBlockers), routeBlockers, "ENTRY/EXIT/TRANSFER and generated connector gates"),
-			new ReleaseReadinessRow("Android evidence", statusFor(androidBlockers), androidBlockers, "Android datapack adoption evidence"),
-			new ReleaseReadinessRow("Manifest signature", manifestSignature.status(), manifestSignature.blockerCount(), "release evidence bundle / signature"),
+			new ReleaseReadinessRow("검증기", statusFor(validatorBlockers), validatorBlockers, "SQLite 무결성 / 검증기 게이트"),
+			new ReleaseReadinessRow("시설 근거", statusFor(facilityBlockers), facilityBlockers, "엄격 경로 대상 시설 근거"),
+			new ReleaseReadinessRow("경로 게이트", statusFor(routeBlockers), routeBlockers, "ENTRY/EXIT/TRANSFER 및 생성된 커넥터 게이트"),
+			new ReleaseReadinessRow("Android 증거", statusFor(androidBlockers), androidBlockers, "Android 데이터팩 도입 증거"),
+			new ReleaseReadinessRow("매니페스트 서명", manifestSignature.status(), manifestSignature.blockerCount(), "릴리스 증거 번들 / 서명"),
 			new ReleaseReadinessRow(
-				"Callback reconciliation",
+				"콜백 정합성 확인",
 				candidate.isEmpty() && callbackReconciliationBlockers == 0
 					? "확인 필요" : statusFor(callbackReconciliationBlockers),
 				callbackReconciliationBlockers,
 				callbackReconciliationBlockers > 0
-					? "CALLBACK_RECONCILIATION_REQUIRED" : "delivery confirmed"),
-			new ReleaseReadinessRow("Manual override", statusFor(manualOverrideBlockers), manualOverrideBlockers, "approval / expiry / conflict gates")
+					? "CALLBACK_RECONCILIATION_REQUIRED" : "발송 확인됨"),
+			new ReleaseReadinessRow("수동 오버라이드", statusFor(manualOverrideBlockers), manualOverrideBlockers, "승인 / 만료 / 충돌 게이트")
 		);
 	}
 

--- a/backend/src/main/java/com/easysubway/datapack/application/port/in/DatapackReleaseBlockerSummaryUseCase.java
+++ b/backend/src/main/java/com/easysubway/datapack/application/port/in/DatapackReleaseBlockerSummaryUseCase.java
@@ -53,15 +53,15 @@ public interface DatapackReleaseBlockerSummaryUseCase {
 				0,
 				0,
 				List.of(
-					new ReleaseReadinessRow("Source coverage", "확인 필요", 0, "candidate 없음"),
-					new ReleaseReadinessRow("Source freshness", "확인 필요", 0, "source snapshot 없음"),
-					new ReleaseReadinessRow("Validator", "확인 필요", 0, "candidate 없음"),
-					new ReleaseReadinessRow("Facility evidence", "확인 필요", 0, "candidate 없음"),
-					new ReleaseReadinessRow("Route gate", "확인 필요", 0, "candidate 없음"),
-					new ReleaseReadinessRow("Android evidence", "확인 필요", 0, "candidate 없음"),
-					new ReleaseReadinessRow("Manifest signature", "확인 필요", 0, "candidate 없음"),
-					new ReleaseReadinessRow("Callback reconciliation", "확인 필요", 0, "delivery 없음"),
-					new ReleaseReadinessRow("Manual override", "확인 필요", 0, "candidate 없음")
+					new ReleaseReadinessRow("소스 커버리지", "확인 필요", 0, "candidate 없음"),
+					new ReleaseReadinessRow("소스 최신성", "확인 필요", 0, "source snapshot 없음"),
+					new ReleaseReadinessRow("검증기", "확인 필요", 0, "candidate 없음"),
+					new ReleaseReadinessRow("시설 근거", "확인 필요", 0, "candidate 없음"),
+					new ReleaseReadinessRow("경로 게이트", "확인 필요", 0, "candidate 없음"),
+					new ReleaseReadinessRow("Android 증거", "확인 필요", 0, "candidate 없음"),
+					new ReleaseReadinessRow("매니페스트 서명", "확인 필요", 0, "candidate 없음"),
+					new ReleaseReadinessRow("콜백 정합성 확인", "확인 필요", 0, "delivery 없음"),
+					new ReleaseReadinessRow("수동 오버라이드", "확인 필요", 0, "candidate 없음")
 				),
 				null
 			);
@@ -73,9 +73,9 @@ public interface DatapackReleaseBlockerSummaryUseCase {
 
 		public String productionPromoteReason() {
 			if (productionPromoteAllowed()) {
-				return "production promote 가능";
+				return "프로덕션 반영 가능";
 			}
-			return "production promote 차단: blocker " + totalBlockers + "건";
+			return "프로덕션 반영 차단: 차단 요인 " + totalBlockers + "건";
 		}
 	}
 
@@ -95,8 +95,8 @@ public interface DatapackReleaseBlockerSummaryUseCase {
 				"확인 필요",
 				0,
 				List.of(
-					new StationReleaseBlockerRow("Facility evidence", 0, "집계 전"),
-					new StationReleaseBlockerRow("Route gate", 0, "집계 전")
+					new StationReleaseBlockerRow("시설 근거", 0, "집계 전"),
+					new StationReleaseBlockerRow("경로 게이트", 0, "집계 전")
 				)
 			);
 		}

--- a/backend/src/main/java/com/easysubway/transit/adapter/in/web/FacilityStatusRow.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/in/web/FacilityStatusRow.java
@@ -48,16 +48,7 @@ record FacilityStatusRow(
 	}
 
 	private static String typeLabel(AccessibilityFacilityType type) {
-		return switch (type) {
-			case ELEVATOR -> "엘리베이터";
-			case ESCALATOR -> "에스컬레이터";
-			case WHEELCHAIR_LIFT -> "휠체어 리프트";
-			case RAMP -> "경사로";
-			case ACCESSIBLE_TOILET -> "장애인 화장실";
-			case TOILET -> "화장실";
-			case NURSING_ROOM -> "수유실";
-			case CUSTOMER_CENTER -> "고객센터";
-		};
+		return type.label();
 	}
 
 	private static String confidenceLabel(DataConfidenceLevel confidence) {
@@ -69,12 +60,10 @@ record FacilityStatusRow(
 		};
 	}
 
+	// #2313 F1: 출처 유형 표시 라벨의 단일 원본은 DataSourceType.label()이다. 이전에는 공식 계열
+	// (OFFICIAL_API/OFFICIAL_FILE/OPERATOR_PAGE)을 "공식 안내"로 묶어, 역 상세의 label() 표시와
+	// 시설 요약 표시가 같은 출처인데 다른 문구로 보이는 불일치가 있었다 — label()에 위임해 해소한다.
 	private static String sourceLabel(com.easysubway.transit.domain.DataSourceType sourceType) {
-		return switch (sourceType) {
-			case ADMIN_VERIFIED -> "관리자 확인";
-			case OFFICIAL_API, OFFICIAL_FILE, OPERATOR_PAGE -> "공식 안내";
-			case USER_REPORT -> "사용자 제보";
-			case PARTNER_FEED -> "제휴기관 안내";
-		};
+		return sourceType.label();
 	}
 }

--- a/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitStationAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitStationAdminPageController.java
@@ -540,7 +540,7 @@ class TransitStationAdminPageController {
 				String.valueOf(stationWithLines.station().latitude()),
 				String.valueOf(stationWithLines.station().longitude()),
 				TransitStationAdminPageController.qualityLabel(stationWithLines.station().dataQualityLevel()),
-				stationWithLines.station().dataSourceType().name(),
+				stationWithLines.station().dataSourceType().label(),
 				String.valueOf(stationWithLines.station().lastVerifiedAt())
 			);
 		}
@@ -649,7 +649,7 @@ class TransitStationAdminPageController {
 				facility.id(),
 				facility.name(),
 				facility.type(),
-				facility.type().name(),
+				facility.type().label(),
 				facility.exitId(),
 				facility.floorFrom(),
 				facility.floorTo(),

--- a/backend/src/main/java/com/easysubway/transit/domain/AccessibilityFacilityType.java
+++ b/backend/src/main/java/com/easysubway/transit/domain/AccessibilityFacilityType.java
@@ -1,12 +1,22 @@
 package com.easysubway.transit.domain;
 
 public enum AccessibilityFacilityType {
-	ELEVATOR,
-	ESCALATOR,
-	WHEELCHAIR_LIFT,
-	RAMP,
-	ACCESSIBLE_TOILET,
-	TOILET,
-	NURSING_ROOM,
-	CUSTOMER_CENTER
+	ELEVATOR("엘리베이터"),
+	ESCALATOR("에스컬레이터"),
+	WHEELCHAIR_LIFT("휠체어 리프트"),
+	RAMP("경사로"),
+	ACCESSIBLE_TOILET("장애인 화장실"),
+	TOILET("화장실"),
+	NURSING_ROOM("수유실"),
+	CUSTOMER_CENTER("고객센터");
+
+	private final String label;
+
+	AccessibilityFacilityType(String label) {
+		this.label = label;
+	}
+
+	public String label() {
+		return label;
+	}
 }

--- a/backend/src/main/java/com/easysubway/transit/domain/DataSourceType.java
+++ b/backend/src/main/java/com/easysubway/transit/domain/DataSourceType.java
@@ -1,10 +1,20 @@
 package com.easysubway.transit.domain;
 
 public enum DataSourceType {
-	OFFICIAL_API,
-	OFFICIAL_FILE,
-	OPERATOR_PAGE,
-	USER_REPORT,
-	ADMIN_VERIFIED,
-	PARTNER_FEED
+	OFFICIAL_API("공식 API"),
+	OFFICIAL_FILE("공식 자료"),
+	OPERATOR_PAGE("운영자 안내"),
+	USER_REPORT("사용자 제보"),
+	ADMIN_VERIFIED("관리자 확인"),
+	PARTNER_FEED("제휴기관 안내");
+
+	private final String label;
+
+	DataSourceType(String label) {
+		this.label = label;
+	}
+
+	public String label() {
+		return label;
+	}
 }

--- a/backend/src/main/resources/static/css/admin-components.css
+++ b/backend/src/main/resources/static/css/admin-components.css
@@ -892,6 +892,10 @@
 	color: var(--admin-danger);
 }
 
+.admin-status.info {
+	color: var(--admin-ink-2);
+}
+
 .admin-grid-2 {
 	display: grid;
 	grid-template-columns: minmax(0, 1fr) minmax(320px, 0.62fr);

--- a/backend/src/main/resources/static/css/admin-data.css
+++ b/backend/src/main/resources/static/css/admin-data.css
@@ -524,40 +524,6 @@
 	margin: 0;
 }
 
-/* 목록 상태 셀(V6-07 #2279): 상태를 텍스트 + 아이콘 + 색으로 함께 전한다(색 단독 표현 금지).
-   아이콘은 프로젝트 sprite(check·warning·error·info)를 currentColor로 그리므로 tone class의 색을
-   그대로 물려받는다. 시각 언어는 기존 상태색 토큰 범위 안에서만 쓴다. */
-.admin-v3 .data-status {
-	display: inline-flex;
-	align-items: center;
-	gap: 6px;
-	font-size: 13px;
-	color: var(--admin-ink);
-	white-space: nowrap;
-}
-
-.admin-v3 .data-status .admin-icon {
-	width: 16px;
-	height: 16px;
-	flex: none;
-}
-
-.admin-v3 .data-status.tone-good {
-	color: var(--admin-good);
-}
-
-.admin-v3 .data-status.tone-warn {
-	color: var(--admin-warn);
-}
-
-.admin-v3 .data-status.tone-bad {
-	color: var(--admin-danger);
-}
-
-.admin-v3 .data-status.tone-info {
-	color: var(--admin-ink-2);
-}
-
 /* 마지막 확인/갱신일 셀(V6-07 #2279): 상대 시간을 위, 정확한 날짜를 아래(meta)로 병기한다.
    상대 시간에는 정확한 날짜를 title로도 달아 hover·스크린리더에서 절대 시각을 확인할 수 있다. */
 .admin-v3 .data-verified {

--- a/backend/src/main/resources/templates/admin/dashboard.html
+++ b/backend/src/main/resources/templates/admin/dashboard.html
@@ -116,15 +116,15 @@
 			<strong th:text="${datapackReleaseSummary.candidateId}">candidate-id</strong>
 			<span th:replace="~{admin/fragments/shell :: status(${datapackReleaseSummary.status}, ${datapackReleaseSummary.status == 'READY' || datapackReleaseSummary.status == 'PASS' ? 'good' : (datapackReleaseSummary.status == 'FAIL' ? 'bad' : 'warn')})}">FAIL</span>
 		</p>
-		<p class="summary" th:text="${datapackReleaseSummary.productionPromoteReason()}">production promote 차단: blocker 0건</p>
-		<!-- blocker 내역(#2047 오너 지적): 원자 항목 사이 구분선 제거 → 촘촘한 key-value 목록(라벨 좌·값 우,
-		     값 tabular-nums). "전체 blocker N건"은 소계라 굵기·상단 여백으로만 위계를 준다(선 없음). -->
-		<p class="blocker-total" th:text="|전체 blocker ${datapackReleaseSummary.totalBlockers}건|">전체 blocker 0건</p>
+		<p class="summary" th:text="${datapackReleaseSummary.productionPromoteReason()}">프로덕션 반영 차단: 차단 요인 0건</p>
+		<!-- 차단 요인 내역(#2047 오너 지적): 원자 항목 사이 구분선 제거 → 촘촘한 key-value 목록(라벨 좌·값 우,
+		     값 tabular-nums). "전체 차단 요인 N건"은 소계라 굵기·상단 여백으로만 위계를 준다(선 없음). -->
+		<p class="blocker-total" th:text="|전체 차단 요인 ${datapackReleaseSummary.totalBlockers}건|">전체 차단 요인 0건</p>
 		<dl class="blocker-breakdown">
-			<div><dt>alias</dt><dd th:text="${datapackReleaseSummary.aliasBlockers}">0</dd></div>
-			<div><dt>quarantine</dt><dd th:text="${datapackReleaseSummary.quarantineBlockers}">0</dd></div>
-			<div><dt>manual override</dt><dd th:text="${datapackReleaseSummary.manualOverrideBlockers}">0</dd></div>
-			<div><dt>route gate</dt><dd th:text="${datapackReleaseSummary.routeGateBlockers}">0</dd></div>
+			<div><dt>별칭</dt><dd th:text="${datapackReleaseSummary.aliasBlockers}">0</dd></div>
+			<div><dt>격리</dt><dd th:text="${datapackReleaseSummary.quarantineBlockers}">0</dd></div>
+			<div><dt>수동 오버라이드</dt><dd th:text="${datapackReleaseSummary.manualOverrideBlockers}">0</dd></div>
+			<div><dt>경로 게이트</dt><dd th:text="${datapackReleaseSummary.routeGateBlockers}">0</dd></div>
 		</dl>
 		<!-- sha·workflow 상세 13행은 기본 접힘으로 격하(추세·요약을 앞세운다). -->
 		<details class="dashboard-details">
@@ -133,20 +133,20 @@
 			     aria-label="가로로 스크롤 가능한 데이터 표">
 			<table>
 				<tbody>
-				<tr><th scope="row">scope</th><td th:text="${datapackReleaseSummary.scopeId}">scope</td></tr>
-				<tr><th scope="row">source snapshot set</th><td th:text="${datapackReleaseSummary.sourceSnapshotSetHash}">sha</td></tr>
-				<tr><th scope="row">manifest</th><td th:text="${datapackReleaseSummary.manifestSha256}">sha</td></tr>
-				<tr><th scope="row">evidence bundle</th><td th:text="${datapackReleaseSummary.evidenceBundleSha256}">sha</td></tr>
-				<tr><th scope="row">evidence workflow</th><td th:text="${datapackReleaseSummary.evidenceWorkflowRunUrl}">workflow</td></tr>
-				<tr><th scope="row">production current</th><td th:text="${datapackReleaseSummary.productionCandidateId}">candidate</td></tr>
-				<tr><th scope="row">rollback target</th><td th:text="${datapackReleaseSummary.rollbackCandidateId}">candidate</td></tr>
-				<tr><th scope="row">candidate gate</th><td th:text="${datapackReleaseSummary.candidateGateBlockers}">0</td></tr>
-				<tr><th scope="row">alias</th><td th:text="${datapackReleaseSummary.aliasBlockers}">0</td></tr>
-				<tr><th scope="row">quarantine</th><td th:text="${datapackReleaseSummary.quarantineBlockers}">0</td></tr>
-				<tr><th scope="row">manual override</th><td th:text="${datapackReleaseSummary.manualOverrideBlockers}">0</td></tr>
-				<tr><th scope="row">facility evidence</th><td th:text="${datapackReleaseSummary.facilityBlockers}">0</td></tr>
-				<tr><th scope="row">route gate</th><td th:text="${datapackReleaseSummary.routeGateBlockers}">0</td></tr>
-				<tr><th scope="row">manifest signature</th><td th:text="${datapackReleaseSummary.manifestBlockers}">0</td></tr>
+				<tr><th scope="row">범위</th><td th:text="${datapackReleaseSummary.scopeId}">범위</td></tr>
+				<tr><th scope="row">원천 스냅샷 세트</th><td th:text="${datapackReleaseSummary.sourceSnapshotSetHash}">sha</td></tr>
+				<tr><th scope="row">매니페스트</th><td th:text="${datapackReleaseSummary.manifestSha256}">sha</td></tr>
+				<tr><th scope="row">증거 번들</th><td th:text="${datapackReleaseSummary.evidenceBundleSha256}">sha</td></tr>
+				<tr><th scope="row">증거 워크플로</th><td th:text="${datapackReleaseSummary.evidenceWorkflowRunUrl}">workflow</td></tr>
+				<tr><th scope="row">현재 프로덕션</th><td th:text="${datapackReleaseSummary.productionCandidateId}">candidate</td></tr>
+				<tr><th scope="row">롤백 대상</th><td th:text="${datapackReleaseSummary.rollbackCandidateId}">candidate</td></tr>
+				<tr><th scope="row">후보 게이트</th><td th:text="${datapackReleaseSummary.candidateGateBlockers}">0</td></tr>
+				<tr><th scope="row">별칭</th><td th:text="${datapackReleaseSummary.aliasBlockers}">0</td></tr>
+				<tr><th scope="row">격리</th><td th:text="${datapackReleaseSummary.quarantineBlockers}">0</td></tr>
+				<tr><th scope="row">수동 오버라이드</th><td th:text="${datapackReleaseSummary.manualOverrideBlockers}">0</td></tr>
+				<tr><th scope="row">시설 근거</th><td th:text="${datapackReleaseSummary.facilityBlockers}">0</td></tr>
+				<tr><th scope="row">경로 게이트</th><td th:text="${datapackReleaseSummary.routeGateBlockers}">0</td></tr>
+				<tr><th scope="row">매니페스트 서명</th><td th:text="${datapackReleaseSummary.manifestBlockers}">0</td></tr>
 				</tbody>
 			</table>
 			</div>

--- a/backend/src/main/resources/templates/admin/datapack/pipeline/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/pipeline/list.html
@@ -27,15 +27,15 @@
 			<div class="metric metric-cell">
 				<span>후보</span>
 				<strong><span th:title="${pipeline.candidateId}" th:text="${pipeline.candidateIdShort}">-</span></strong>
-				<em th:text="${'scope ' + pipeline.scopeId}">scope</em>
+				<em th:text="${'범위 ' + pipeline.scopeId}">범위</em>
 			</div>
 			<div class="metric metric-cell">
 				<span>상태</span>
 				<strong><span th:replace="~{admin/fragments/shell :: status(${pipeline.status}, ${pipeline.statusTone})}">확인 필요</span></strong>
-				<em th:text="${pipeline.productionPromoteReason}">production promote</em>
+				<em th:text="${pipeline.productionPromoteReason}">프로덕션 반영 상태</em>
 			</div>
 			<div class="metric metric-cell" th:classappend="${pipeline.totalBlockers > 0} ? ' tone-bad'">
-				<span>총 blocker</span>
+				<span>총 차단 요인</span>
 				<strong class="cell-num" th:text="${pipeline.totalBlockers}">0</strong>
 				<em th:text="${'생성 ' + pipeline.candidateCreatedAt}">생성 시각</em>
 			</div>
@@ -45,16 +45,16 @@
 				<em th:text="${pipeline.sourceSnapshotIds}">snapshot ids</em>
 			</div>
 			<div class="metric metric-cell">
-				<span>production / rollback</span>
+				<span>프로덕션 / 롤백</span>
 				<strong th:text="${pipeline.productionCandidateId}">-</strong>
-				<em th:text="${'rollback ' + pipeline.rollbackCandidateId}">rollback</em>
+				<em th:text="${'롤백 ' + pipeline.rollbackCandidateId}">롤백</em>
 			</div>
 		</div>
 	</section>
 
 	<section class="admin-panel">
 		<h2>파이프라인 단계</h2>
-		<p>단계 노드를 눌러 해당 화면으로 이동합니다. blocker가 있는 단계는 강조됩니다.</p>
+		<p>단계 노드를 눌러 해당 화면으로 이동합니다. 차단 요인이 있는 단계는 강조됩니다.</p>
 		<ol class="datapack-pipeline" aria-label="데이터팩 파이프라인 단계">
 			<li th:each="node : ${pipeline.stages}" class="datapack-pipeline-node"
 			    th:classappend="${node.blocked} ? ' is-blocked'">
@@ -62,7 +62,7 @@
 					<span class="datapack-pipeline-label" th:text="${node.label}">단계</span>
 					<span class="datapack-pipeline-badge"
 					      th:classappend="${node.blocked} ? ' bad' : ' good'"
-					      th:text="${node.blocked ? 'blocker ' + node.blockerCount + '건' : '통과'}">통과</span>
+					      th:text="${node.blocked ? '차단 요인 ' + node.blockerCount + '건' : '통과'}">통과</span>
 					<span class="meta" th:text="${node.drillLabel}">이동</span>
 				</a>
 			</li>
@@ -70,14 +70,14 @@
 	</section>
 
 	<section class="admin-panel">
-		<h2>단계별 blocker (표)</h2>
+		<h2>단계별 차단 요인 (표)</h2>
 		<div class="admin-table-scroll" tabindex="0" role="group"
 		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table class="static-table">
 			<thead>
 			<tr>
 				<th scope="col">단계</th>
-				<th scope="col">blocker</th>
+				<th scope="col">차단 요인</th>
 				<th scope="col">상세</th>
 			</tr>
 			</thead>
@@ -92,7 +92,7 @@
 		</div>
 	</section>
 
-	<!-- 게이트 매트릭스·서명 상세(#2281 V6-09): 단계 그래프·blocker 표를 앞세우고, 게이트 6종
+	<!-- 게이트 매트릭스·서명 상세(#2281 V6-09): 단계 그래프·차단 요인 표를 앞세우고, 게이트 6종
 	     매트릭스와 서명·증거 해시는 details로 격하한다. native details라 keyboard·no-JS에서 그대로
 	     펼칠 수 있고 route/permission/CSRF 계약은 그대로다. -->
 	<section class="admin-panel">
@@ -105,13 +105,13 @@
 			<tr>
 				<th scope="col">게이트</th>
 				<th scope="col">상태</th>
-				<th scope="col">blocker</th>
+				<th scope="col">차단 요인</th>
 				<th scope="col">근거</th>
 			</tr>
 			</thead>
 			<tbody>
 			<tr th:each="gate : ${pipeline.gateNodes}">
-				<td th:text="${gate.label}">게이트</td>
+				<td th:text="${gate.label}">경로 게이트</td>
 				<td><span th:replace="~{admin/fragments/shell :: status(${gate.status}, ${gate.tone})}">PASS</span></td>
 				<td th:text="${gate.blockerCount}">0</td>
 				<td th:text="${gate.note}">근거</td>

--- a/backend/src/main/resources/templates/admin/datapack/release-requests/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/release-requests/list.html
@@ -64,15 +64,15 @@
 		<table class="static-table">
 			<thead>
 			<tr>
-				<th scope="col">approval</th>
-				<th scope="col">candidate</th>
-				<th scope="col">scope</th>
-				<th scope="col">channel</th>
-				<th scope="col">status</th>
-				<th scope="col">requested</th>
-				<th scope="col">approved</th>
-				<th scope="col">workflow</th>
-				<th scope="col">created</th>
+				<th scope="col">승인 ID</th>
+				<th scope="col">후보</th>
+				<th scope="col">범위</th>
+				<th scope="col">채널</th>
+				<th scope="col">상태</th>
+				<th scope="col">요청자</th>
+				<th scope="col">승인자</th>
+				<th scope="col">워크플로</th>
+				<th scope="col">생성 시각</th>
 				<th scope="col">액션</th>
 			</tr>
 			</thead>
@@ -126,17 +126,17 @@
 	</section>
 
 	<section class="admin-panel">
-		<h2>callback delivery / reconciliation</h2>
+		<h2>콜백 전송 / 재조정</h2>
 		<div class="admin-table-scroll" tabindex="0" role="group"
 		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table class="static-table">
 			<thead><tr>
-				<th scope="col">request / sequence</th><th scope="col">channel / state</th>
-				<th scope="col">attempt / HTTP</th><th scope="col">deadlines</th>
+				<th scope="col">요청 / 시퀀스</th><th scope="col">채널 / 상태</th>
+				<th scope="col">시도 / HTTP</th><th scope="col">기한</th>
 				<th scope="col">증거 해시</th><th scope="col">차단 요인</th><th scope="col">복구</th>
 			</tr></thead>
 			<tbody>
-			<tr th:if="${deliveries.isEmpty()}"><td colspan="7">callback delivery가 없습니다.</td></tr>
+			<tr th:if="${deliveries.isEmpty()}"><td colspan="7">콜백 전송 내역이 없습니다.</td></tr>
 			<tr th:each="delivery : ${deliveries}">
 				<td th:text="${delivery.releaseRequestId + ' / ' + delivery.releaseSequence}">request</td>
 				<td th:text="${delivery.channel + ' / ' + delivery.state}">state</td>

--- a/backend/src/main/resources/templates/admin/datapack/release-requests/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/release-requests/list.html
@@ -133,7 +133,7 @@
 			<thead><tr>
 				<th scope="col">request / sequence</th><th scope="col">channel / state</th>
 				<th scope="col">attempt / HTTP</th><th scope="col">deadlines</th>
-				<th scope="col">evidence hash</th><th scope="col">blocker</th><th scope="col">repair</th>
+				<th scope="col">증거 해시</th><th scope="col">차단 요인</th><th scope="col">복구</th>
 			</tr></thead>
 			<tbody>
 			<tr th:if="${deliveries.isEmpty()}"><td colspan="7">callback delivery가 없습니다.</td></tr>
@@ -143,14 +143,14 @@
 				<td th:text="${delivery.attempts + ' / ' + (delivery.httpClass ?: '-')}">attempt</td>
 				<td><time th:text="${delivery.nextAttemptAt}">next attempt</time> / <time th:text="${delivery.reconcileDeadline}">reconcile</time> / <time th:text="${delivery.deadLetterDeadline}">dead letter</time></td>
 				<td><code th:text="${delivery.payloadSha256}">payload hash</code><br><code th:text="${delivery.signatureSha256}">signature hash</code></td>
-				<td th:text="${delivery.detail ?: '-'}">blocker</td>
+				<td th:text="${delivery.detail ?: '-'}">차단 요인</td>
 				<td>
 					<form th:if="${delivery.repairable}" method="post"
 						  th:action="@{/admin/datapack/release-deliveries/{idempotencyKey}/repair(idempotencyKey=${delivery.idempotencyKey})}">
 						<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 						<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
-						<label>repair reason <input name="reason" required maxlength="200"></label>
-						<button type="submit" class="outline">수동 repair</button>
+						<label>복구 사유 <input name="reason" required maxlength="200"></label>
+						<button type="submit" class="outline">수동 복구</button>
 					</form>
 					<span th:unless="${delivery.repairable}">-</span>
 				</td>

--- a/backend/src/main/resources/templates/admin/facilities/list.html
+++ b/backend/src/main/resources/templates/admin/facilities/list.html
@@ -119,16 +119,11 @@
 						<span class="meta" th:text="${facility.typeLabel}">엘리베이터</span>
 					</td>
 					<td>
-						<!-- 현재 상태: 텍스트 + 아이콘 + 색으로 상태를 전한다(색 단독 표현 금지). -->
-						<th:block th:with="ftone=${facility.status.name() == 'NORMAL' or facility.status.name() == 'ADMIN_VERIFIED' ? 'good'
-						                     : (facility.status.name() == 'BROKEN' or facility.status.name() == 'CLOSED' ? 'bad' : 'warn')},
-						                   ficon=${facility.status.name() == 'NORMAL' or facility.status.name() == 'ADMIN_VERIFIED' ? 'check'
-						                     : (facility.status.name() == 'BROKEN' or facility.status.name() == 'CLOSED' ? 'error' : 'warning')}">
-							<span class="data-status" th:classappend="|tone-${ftone}|">
-								<svg th:replace="~{admin/fragments/icon :: icon(${ficon})}"></svg>
-								<span th:text="${facility.statusLabel}">정상</span>
-							</span>
-						</th:block>
+						<!-- 현재 상태: 상태 텍스트(● 점 + 텍스트)로 상태를 전한다. 정상·관리자 확인은 완료(good),
+						     고장·폐쇄는 실패(bad), 공사 중·확인 필요·사용자 제보는 경고(warn) 톤이다. -->
+						<span th:replace="~{admin/fragments/shell :: status(${facility.statusLabel},
+						         ${facility.status.name() == 'NORMAL' or facility.status.name() == 'ADMIN_VERIFIED' ? 'good'
+						           : (facility.status.name() == 'BROKEN' or facility.status.name() == 'CLOSED' ? 'bad' : 'warn')})}">정상</span>
 					</td>
 					<td>
 						<a th:href="@{/admin/stations/{stationId}/page(stationId=${facility.stationId},tab='facilities')}"

--- a/backend/src/main/resources/templates/admin/facilities/list.html
+++ b/backend/src/main/resources/templates/admin/facilities/list.html
@@ -132,7 +132,7 @@
 					<td>
 						<!-- 확인 상태: 데이터 품질(신뢰도)과 출처를 함께 보여준다. -->
 						<span th:text="${facility.confidenceLabel}">최근 확인된 정보</span>
-						<span class="meta" th:text="${facility.sourceLabel}">공식 안내</span>
+						<span class="meta" th:text="${facility.sourceLabel}">공식 자료</span>
 					</td>
 					<td>
 						<!-- 갱신일: 상대 시간 + 정확한 날짜 병기. lastUpdatedAt은 LocalDate라 표시 계층에서

--- a/backend/src/main/resources/templates/admin/fragments/shell.html
+++ b/backend/src/main/resources/templates/admin/fragments/shell.html
@@ -247,7 +247,7 @@
 	        crossorigin="anonymous" defer></script>
 </th:block>
 <span th:fragment="status(text, tone)" class="admin-status"
-      th:classappend="${tone == 'good'} ? ' good' : (${tone == 'bad'} ? ' bad' : (${tone == 'warn'} ? ' warn' : ''))"
+      th:classappend="${tone == 'good'} ? ' good' : (${tone == 'bad'} ? ' bad' : (${tone == 'warn'} ? ' warn' : (${tone == 'info'} ? ' info' : '')))"
       th:text="${text}">상태</span>
 <span th:fragment="statusAuto(label)" class="admin-status"
       th:classappend="${label == null ? '' :

--- a/backend/src/main/resources/templates/admin/quality/dashboard.html
+++ b/backend/src/main/resources/templates/admin/quality/dashboard.html
@@ -70,7 +70,7 @@
 	</section>
 
 	<section th:if="${datapackReleaseSummary != null}">
-		<h2>데이터팩 Release readiness</h2>
+		<h2>데이터팩 출시 준비도</h2>
 		<div class="admin-table-scroll" tabindex="0" role="group"
 		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table>
@@ -78,13 +78,13 @@
 			<tr>
 				<th scope="col">항목</th>
 				<th scope="col">상태</th>
-				<th scope="col">blocker</th>
+				<th scope="col">차단 요인</th>
 				<th scope="col">근거</th>
 			</tr>
 			</thead>
 			<tbody>
 			<tr th:each="row : ${datapackReleaseSummary.readinessRows}">
-				<td th:text="${row.label}">Source coverage</td>
+				<td th:text="${row.label}">소스 커버리지</td>
 				<td th:text="${row.status}">FAIL</td>
 				<td th:text="${row.blockerCount}">0</td>
 				<td th:text="${row.note}">확인 필요</td>

--- a/backend/src/main/resources/templates/admin/stations/detail.html
+++ b/backend/src/main/resources/templates/admin/stations/detail.html
@@ -70,7 +70,7 @@
 						<tr><th scope="row">지역</th><td th:text="${station.region}">수도권</td></tr>
 						<tr><th scope="row">위도</th><td th:text="${station.latitude}">0</td></tr>
 						<tr><th scope="row">경도</th><td th:text="${station.longitude}">0</td></tr>
-						<tr><th scope="row">출처 유형</th><td th:text="${station.sourceType}">OPERATOR</td></tr>
+						<tr><th scope="row">출처 유형</th><td th:text="${station.sourceType}">운영자 안내</td></tr>
 						<tr><th scope="row">마지막 확인</th><td th:text="${station.lastVerifiedAt}">2026-06-20</td></tr>
 						</tbody>
 					</table>
@@ -78,8 +78,8 @@
 				</section>
 
 				<section th:if="${stationReleaseSummary != null}">
-					<h2>Release readiness</h2>
-					<p class="summary" th:text="|${station.stationName}역 release blocker|">상록수역 release blocker</p>
+					<h2>출시 준비도</h2>
+					<p class="summary" th:text="|${station.stationName}역 릴리스 차단 요인|">상록수역 릴리스 차단 요인</p>
 					<p class="summary">
 						<strong th:text="|${stationReleaseSummary.status} ${stationReleaseSummary.totalBlockers}건|">확인 필요 0건</strong>
 					</p>
@@ -90,12 +90,12 @@
 						<tr>
 							<th scope="col">항목</th>
 							<th scope="col">상태</th>
-							<th scope="col">blocker</th>
+							<th scope="col">차단 요인</th>
 						</tr>
 						</thead>
 						<tbody>
 						<tr th:each="row : ${stationReleaseSummary.rows}">
-							<td th:text="${row.label}">Facility evidence</td>
+							<td th:text="${row.label}">시설 근거</td>
 							<td><span th:replace="~{admin/fragments/shell :: statusAuto(${row.status})}">확인 필요</span></td>
 							<td th:text="${row.blockerCount}">0</td>
 						</tr>
@@ -153,7 +153,7 @@
 						<tr th:each="facility : ${facilities}">
 							<td>
 								<strong th:text="${facility.facilityName}">엘리베이터</strong>
-								<span class="meta" th:text="${facility.typeLabel}">ELEVATOR</span>
+								<span class="meta" th:text="${facility.typeLabel}">엘리베이터</span>
 							</td>
 							<td th:text="${facility.floorLabel}">B1 → 지상</td>
 							<td th:text="${facility.statusLabel}">정상</td>

--- a/backend/src/main/resources/templates/admin/stations/list.html
+++ b/backend/src/main/resources/templates/admin/stations/list.html
@@ -119,16 +119,10 @@
 						<span th:unless="${station.attentionFacilityCount > 0}" class="meta">0</span>
 					</td>
 					<td>
-						<!-- 데이터 품질: 텍스트 + 아이콘 + 색으로 상태를 전한다(색 단독 표현 금지). -->
-						<th:block th:with="qtone=${station.qualityLabel == '고장·공사 반영' ? 'good'
-						                     : (station.qualityLabel == '정보 확인 중' ? 'warn' : 'info')},
-						                   qicon=${station.qualityLabel == '고장·공사 반영' ? 'check'
-						                     : (station.qualityLabel == '정보 확인 중' ? 'warning' : 'info')}">
-							<span class="data-status" th:classappend="|tone-${qtone}|">
-								<svg th:replace="~{admin/fragments/icon :: icon(${qicon})}"></svg>
-								<span th:text="${station.qualityLabel}">정보 확인 중</span>
-							</span>
-						</th:block>
+						<!-- 데이터 품질: 상태 텍스트(● 점 + 텍스트)로 상태를 전한다. "정보 확인 중" 등 진행 중
+						     단계는 경고가 아니라 중립(info) 톤으로, "고장·공사 반영"만 완료(good) 톤으로 표시한다. -->
+						<span th:replace="~{admin/fragments/shell :: status(${station.qualityLabel},
+						         ${station.qualityLabel == '고장·공사 반영' ? 'good' : 'info'})}">정보 확인 중</span>
 					</td>
 					<td th:text="${station.lineNames}">4호선</td>
 					<td th:text="${station.region}">수도권</td>

--- a/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminV3PageSmokeTest.java
+++ b/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminV3PageSmokeTest.java
@@ -62,11 +62,10 @@ class AdminV3PageSmokeTest {
 			.contains("/admin/stations/station-sangnoksu/page?tab=facilities")
 			.contains("/admin/reports/page?station=station-sangnoksu");
 
-		// V6-07 #2279: 현재 상태는 text+icon+color(색 단독 금지), 상태 변경 열은 우측 sticky action,
-		// 갱신일은 상대 시간 + 정확한 날짜 병기, 공통 표 영역(table-region) 계약을 소비한다.
+		// #2313 PR②: 현재 상태는 상태 텍스트(.admin-status, ● 점 + 텍스트)로 표시한다. 상태 변경 열은
+		// 우측 sticky action, 갱신일은 상대 시간 + 정확한 날짜 병기, 공통 표 영역(table-region) 계약을 소비한다.
 		assertThat(html)
-			.contains("class=\"data-status")
-			.contains("/icons/admin-symbols.svg#")
+			.contains("class=\"admin-status")
 			.contains("class=\"cell-sticky-action\"")
 			.contains("class=\"data-verified-relative\"")
 			.contains("가로로 스크롤 가능한 데이터 표");
@@ -100,12 +99,12 @@ class AdminV3PageSmokeTest {
 			// 상록수 역 링크가 상세 허브로 연결된다.
 			.contains("/admin/stations/station-sangnoksu/page");
 
-		// V6-07 #2279: 데이터 품질은 text+icon+color(색 단독 금지), 마지막 확인은 상대 시간 + 정확한 날짜
-		// 병기, 식별자 링크가 상세 이동을 소유해 중복 상세 버튼(admin-btn)을 제거, 공통 표 영역을 소비한다.
+		// #2313 PR②: 데이터 품질은 상태 텍스트(.admin-status, ● 점 + 텍스트)로 표시한다. 마지막 확인은
+		// 상대 시간 + 정확한 날짜 병기, 식별자 링크가 상세 이동을 소유해 중복 상세 버튼(admin-btn)을 제거,
+		// 공통 표 영역을 소비한다.
 		assertThat(html)
 			.contains("데이터 품질")
-			.contains("class=\"data-status")
-			.contains("/icons/admin-symbols.svg#")
+			.contains("class=\"admin-status")
 			.contains("class=\"data-verified-relative\"")
 			.contains("가로로 스크롤 가능한 데이터 표")
 			.doesNotContain(">상세</a>");

--- a/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackCandidateAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackCandidateAdminPageControllerTest.java
@@ -90,7 +90,7 @@ class DatapackCandidateAdminPageControllerTest {
 			.contains("증거 번들 sha256")
 			.contains("sha 원문 보기")
 			.contains("복사")
-			.contains("production promote 가능")
+			.contains("프로덕션 반영 가능")
 			.contains("name=\"commandToken\"")
 			.contains("게이트 재실행")
 			.doesNotContain("production 승인")

--- a/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackReleaseBlockerSummaryAdminPageTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackReleaseBlockerSummaryAdminPageTest.java
@@ -73,13 +73,13 @@ class DatapackReleaseBlockerSummaryAdminPageTest {
 			.contains(SHA_A)
 			.contains("https://github.com/AquilaXk/easysubway/actions/runs/1164?redacted")
 			.contains("candidate-previous-stable")
-			.contains("production promote 차단: blocker 9건")
-			.contains("전체 blocker 9건")
-			.contains("<dt>alias</dt><dd>1</dd>")
-			.contains("<dt>quarantine</dt><dd>1</dd>")
-			.contains("<dt>manual override</dt><dd>1</dd>")
-			.contains("<dt>route gate</dt><dd>1</dd>")
-			.contains("manifest signature")
+			.contains("프로덕션 반영 차단: 차단 요인 9건")
+			.contains("전체 차단 요인 9건")
+			.contains("<dt>별칭</dt><dd>1</dd>")
+			.contains("<dt>격리</dt><dd>1</dd>")
+			.contains("<dt>수동 오버라이드</dt><dd>1</dd>")
+			.contains("<dt>경로 게이트</dt><dd>1</dd>")
+			.contains("매니페스트 서명")
 			.doesNotContain("name=\"commandToken\"")
 			.doesNotContain("serviceKey");
 	}
@@ -110,13 +110,13 @@ class DatapackReleaseBlockerSummaryAdminPageTest {
 		String qualityHtml = getAdminHtml("/admin/data-quality/page");
 
 		assertThat(dashboardHtml)
-			.contains("production promote 차단: blocker 1건")
-			.contains("전체 blocker 1건")
-			.doesNotContain("production promote 가능")
+			.contains("프로덕션 반영 차단: 차단 요인 1건")
+			.contains("전체 차단 요인 1건")
+			.doesNotContain("프로덕션 반영 가능")
 			.doesNotContain("READY");
 		assertThat(qualityHtml)
-			.contains("Route gate")
-			.contains("ENTRY/EXIT/TRANSFER and generated connector gates");
+			.contains("경로 게이트")
+			.contains("ENTRY/EXIT/TRANSFER 및 생성된 커넥터 게이트");
 	}
 
 	@Test
@@ -143,7 +143,7 @@ class DatapackReleaseBlockerSummaryAdminPageTest {
 		String html = getAdminHtml("/admin/dashboard/page");
 
 		assertThat(html)
-			.contains("production promote 가능")
+			.contains("프로덕션 반영 가능")
 			.contains("class=\"admin-status  good\"")
 			.contains(">READY</span>");
 	}
@@ -163,7 +163,7 @@ class DatapackReleaseBlockerSummaryAdminPageTest {
 			""", "request-blocked:42:" + SHA_A, SHA_A, SHA_B, SHA_C);
 
 		var callback = blockerSummaryUseCase.summarize().readinessRows().stream()
-			.filter(row -> "Callback reconciliation".equals(row.label()))
+			.filter(row -> "콜백 정합성 확인".equals(row.label()))
 			.findFirst().orElseThrow();
 		assertThat(callback.blockerCount()).isEqualTo(1);
 		assertThat(callback.note()).isEqualTo("CALLBACK_RECONCILIATION_REQUIRED");
@@ -185,7 +185,7 @@ class DatapackReleaseBlockerSummaryAdminPageTest {
 			""", "request-superseded:41:" + SHA_A, SHA_A, SHA_B, SHA_C);
 
 		var callback = blockerSummaryUseCase.summarize().readinessRows().stream()
-			.filter(row -> "Callback reconciliation".equals(row.label()))
+			.filter(row -> "콜백 정합성 확인".equals(row.label()))
 			.findFirst().orElseThrow();
 
 		assertThat(callback.blockerCount()).isZero();
@@ -207,7 +207,7 @@ class DatapackReleaseBlockerSummaryAdminPageTest {
 			""", SHA_A, SHA_B, SHA_C);
 
 		var callback = blockerSummaryUseCase.summarize().readinessRows().stream()
-			.filter(row -> "Callback reconciliation".equals(row.label()))
+			.filter(row -> "콜백 정합성 확인".equals(row.label()))
 			.findFirst().orElseThrow();
 
 		assertThat(callback.blockerCount()).isEqualTo(1);
@@ -222,7 +222,7 @@ class DatapackReleaseBlockerSummaryAdminPageTest {
 		assertThat(html)
 			.doesNotContain("데이터팩 출시 준비")
 			.doesNotContain("candidate-release-blocked")
-			.doesNotContain("전체 blocker 9건");
+			.doesNotContain("전체 차단 요인 9건");
 	}
 
 	@Test
@@ -231,9 +231,9 @@ class DatapackReleaseBlockerSummaryAdminPageTest {
 		String html = getAdminHtmlWithoutDatapackRead("/admin/data-quality/page");
 
 		assertThat(html)
-			.doesNotContain("데이터팩 Release readiness")
+			.doesNotContain("데이터팩 출시 준비도")
 			.doesNotContain("candidate-release-blocked")
-			.doesNotContain("Manifest signature");
+			.doesNotContain("매니페스트 서명");
 	}
 
 	@Test
@@ -242,8 +242,8 @@ class DatapackReleaseBlockerSummaryAdminPageTest {
 		String html = getAdminHtmlWithoutDatapackRead("/admin/stations/station-sangnoksu/page");
 
 		assertThat(html)
-			.doesNotContain("Release readiness")
-			.doesNotContain("상록수역 release blocker")
+			.doesNotContain("출시 준비도")
+			.doesNotContain("상록수역 릴리스 차단 요인")
 			.doesNotContain("확인 필요 2건");
 	}
 
@@ -253,7 +253,7 @@ class DatapackReleaseBlockerSummaryAdminPageTest {
 		clearDatapackTables();
 		var summary = blockerSummaryUseCase.summarize();
 		var sourceFreshness = summary.readinessRows().stream()
-			.filter(row -> "Source freshness".equals(row.label()))
+			.filter(row -> "소스 최신성".equals(row.label()))
 			.findFirst()
 			.orElseThrow();
 
@@ -264,16 +264,16 @@ class DatapackReleaseBlockerSummaryAdminPageTest {
 		assertThat(dashboardHtml)
 			.contains("데이터팩 출시 준비")
 			.contains("확인 필요")
-			.contains("전체 blocker 1건")
+			.contains("전체 차단 요인 1건")
 			.doesNotContain("FAIL")
 			.doesNotContain("PASS");
 		assertThat(qualityHtml)
-			.contains("데이터팩 Release readiness")
-			.contains("Source coverage")
+			.contains("데이터팩 출시 준비도")
+			.contains("소스 커버리지")
 			.contains("확인 필요");
 		assertThat(stationHtml)
-			.contains("Release readiness")
-			.contains("상록수역 release blocker")
+			.contains("출시 준비도")
+			.contains("상록수역 릴리스 차단 요인")
 			.contains("확인 필요 0건")
 			.contains("집계 전")
 			.doesNotContain("PASS 0건");
@@ -289,10 +289,10 @@ class DatapackReleaseBlockerSummaryAdminPageTest {
 		String html = getAdminHtml("/admin/dashboard/page");
 
 		assertThat(html)
-			.contains("전체 blocker 9건")
-			.contains("<dt>manual override</dt><dd>1</dd>")
-			.doesNotContain("전체 blocker 10건")
-			.doesNotContain("<dt>manual override</dt><dd>2</dd>");
+			.contains("전체 차단 요인 9건")
+			.contains("<dt>수동 오버라이드</dt><dd>1</dd>")
+			.doesNotContain("전체 차단 요인 10건")
+			.doesNotContain("<dt>수동 오버라이드</dt><dd>2</dd>");
 	}
 
 	@Test
@@ -301,14 +301,14 @@ class DatapackReleaseBlockerSummaryAdminPageTest {
 		String html = getAdminHtml("/admin/data-quality/page");
 
 		assertThat(html)
-			.contains("데이터팩 Release readiness")
-			.contains("Source coverage")
-			.contains("Validator")
-			.contains("Facility evidence")
-			.contains("Route gate")
-			.contains("Android evidence")
-			.contains("Manifest signature")
-			.contains("Manual override")
+			.contains("데이터팩 출시 준비도")
+			.contains("소스 커버리지")
+			.contains("검증기")
+			.contains("시설 근거")
+			.contains("경로 게이트")
+			.contains("Android 증거")
+			.contains("매니페스트 서명")
+			.contains("수동 오버라이드")
 			.contains("FAIL")
 			.contains("확인 필요");
 	}
@@ -327,17 +327,17 @@ class DatapackReleaseBlockerSummaryAdminPageTest {
 		String pipelineHtml = getAdminHtml("/admin/datapack/pipeline/page");
 
 		assertThat(dashboardHtml)
-			.contains("production promote 차단: blocker 10건")
-			.contains("전체 blocker 10건")
-			.doesNotContain("production promote 가능")
+			.contains("프로덕션 반영 차단: 차단 요인 10건")
+			.contains("전체 차단 요인 10건")
+			.doesNotContain("프로덕션 반영 가능")
 			.doesNotContain(">READY</span>");
 		assertThat(qualityHtml)
-			.contains("Source freshness")
+			.contains("소스 최신성")
 			.contains("SOURCE_SNAPSHOT_EXPIRED")
 			.contains("FAIL");
 		assertThat(pipelineHtml)
 			.contains("원천 스냅샷")
-			.contains("blocker 1건");
+			.contains("차단 요인 1건");
 		assertThat(blockerSummaryUseCase.summarize().sourceFreshnessBlockers()).isEqualTo(1);
 	}
 
@@ -401,10 +401,10 @@ class DatapackReleaseBlockerSummaryAdminPageTest {
 		String html = getAdminHtml("/admin/stations/station-sangnoksu/page");
 
 		assertThat(html)
-			.contains("Release readiness")
-			.contains("상록수역 release blocker")
-			.contains("Facility evidence")
-			.contains("Route gate")
+			.contains("출시 준비도")
+			.contains("상록수역 릴리스 차단 요인")
+			.contains("시설 근거")
+			.contains("경로 게이트")
 			.contains("확인 필요 2건");
 	}
 

--- a/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitFacilityAdminApiControllerTest.java
+++ b/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitFacilityAdminApiControllerTest.java
@@ -41,7 +41,7 @@ class TransitFacilityAdminApiControllerTest {
 			.andExpect(jsonPath("$.data[0].status").value("NORMAL"))
 			.andExpect(jsonPath("$.data[0].statusLabel").value("정상"))
 			.andExpect(jsonPath("$.data[0].confidenceLabel").value("최근 확인된 정보"))
-			.andExpect(jsonPath("$.data[0].sourceLabel").value("공식 안내"))
+			.andExpect(jsonPath("$.data[0].sourceLabel").value("공식 자료"))
 			.andExpect(jsonPath("$.data[0].lastUpdatedAt").value("2026-06-12"))
 			.andExpect(jsonPath("$.data[2].facilityName").value("장애인 화장실"))
 			.andExpect(jsonPath("$.data[2].statusLabel").value("확인 필요"))

--- a/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitFacilityAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitFacilityAdminPageControllerTest.java
@@ -58,9 +58,9 @@ class TransitFacilityAdminPageControllerTest {
 			.contains("최근 확인된 정보")
 			.contains("name=\"status\"")
 			.contains("name=\"_csrf\"")
-			// V6-07 #2279: 상태는 text+icon+color(색 단독 금지)로, 갱신일은 상대 시간 + 정확한 날짜 병기로 렌더한다.
-			.contains("class=\"data-status")
-			.contains("/icons/admin-symbols.svg#")
+			// #2313 PR②: 상태는 상태 텍스트(.admin-status, ● 점 + 텍스트)로, 갱신일은 상대 시간 + 정확한 날짜
+			// 병기로 렌더한다.
+			.contains("class=\"admin-status")
 			.contains("class=\"data-verified-relative\"");
 	}
 

--- a/tools/qa/admin-accessibility-qa.mjs
+++ b/tools/qa/admin-accessibility-qa.mjs
@@ -198,12 +198,12 @@ function finalizeReport(report) {
       nodes: 0,
     });
   }
-  // V6-07 #2279: 마스터 목록 상태 신호 계약을 위반으로 편입한다. 첫 식별자 열이 sticky가 아니거나,
-  // 상태 셀에 비색 아이콘(또는 텍스트) 신호가 없거나(색 단독), 헤더 scope 연결이 없으면 실패를 표면화한다.
+  // V6-07 #2279 / #2313: 마스터 목록 상태 신호 계약을 위반으로 편입한다. 첫 식별자 열이 sticky가 아니거나,
+  // 상태 셀(.admin-status)에 비색 신호인 상태 텍스트가 병기되지 않거나(색 단독 ● 점만 존재), 헤더 scope
+  // 연결이 없으면 실패를 표면화한다.
   const statusSignal = report.keyboard.find((entry) => entry.check === "master-list-status-signal");
   if (statusSignal
     && (statusSignal.stickyIdentifier === false
-      || statusSignal.statusHasIcon === false
       || statusSignal.statusHasText === false
       || statusSignal.scopedHeaders === 0)) {
     blockingViolations.push({
@@ -710,10 +710,12 @@ async function keyboardTableCheck(page, baseUrl, report) {
   });
 }
 
-// V6-07 #2279: 마스터 목록 상태 신호 계약. 이관된 master-list(역 목록)를 mobile-390에서 열어
-// (1) 첫 식별자 열이 sticky로 고정되는지, (2) 상태가 색 단독이 아니라 아이콘(비색 신호)+텍스트를
-// 함께 갖는지, (3) 표 헤더가 scope로 연결되는지 검사한다. 하나라도 어기면 finalizeReport가 위반으로
-// 편입해 exit code로 실패를 표면화한다(§9 식별자·주의·품질 즉시 접근, badge accessible name).
+// V6-07 #2279 / #2313: 마스터 목록 상태 신호 계약. 이관된 master-list(역 목록)를 mobile-390에서 열어
+// (1) 첫 식별자 열이 sticky로 고정되는지, (2) 상태가 색 단독이 아닌지 — #2313에서 상태 표현을
+// .admin-status(● 점 + 상태 텍스트)로 단일화했으므로, 색으로만 구분되는 ● 점 옆에 상태 텍스트가
+// 항상 병기되는지로 판정한다(WCAG 1.4.1 색 단독 금지: 비색 신호 = 상태 텍스트), (3) 표 헤더가
+// scope로 연결되는지 검사한다. 하나라도 어기면 finalizeReport가 위반으로 편입해 exit code로 실패를
+// 표면화한다(§9 식별자·주의·품질 즉시 접근, badge accessible name).
 async function masterListStatusSignalCheck(page, baseUrl, report) {
   await page.setViewportSize(VIEWPORTS.find((viewport) => viewport.name === "mobile-390"));
   const response = await page.goto(`${baseUrl}/admin/stations/page`, { waitUntil: "networkidle" });
@@ -722,13 +724,13 @@ async function masterListStatusSignalCheck(page, baseUrl, report) {
   const signal = await page.evaluate(() => {
     const firstCell = document.querySelector(".admin-table-scroll tbody td:first-child");
     const stickyIdentifier = firstCell ? getComputedStyle(firstCell).position === "sticky" : false;
-    const statusCells = Array.from(document.querySelectorAll(".admin-table-scroll .data-status"));
-    const statusHasIcon = statusCells.length > 0
-      && statusCells.every((cell) => cell.querySelector("svg.admin-icon") !== null);
+    const statusCells = Array.from(document.querySelectorAll(".admin-table-scroll .admin-status"));
+    // 색 단독 금지의 유일한 비색 신호는 상태 텍스트다. ● 점은 ::before 색상 신호이므로 textContent에
+    // 잡히지 않는다 — 모든 상태 셀이 비어있지 않은 텍스트 라벨을 병기해야 통과한다.
     const statusHasText = statusCells.length > 0
       && statusCells.every((cell) => (cell.textContent || "").trim().length > 0);
     const scopedHeaders = document.querySelectorAll(".admin-table-scroll thead th[scope=\"col\"]").length;
-    return { stickyIdentifier, statusCells: statusCells.length, statusHasIcon, statusHasText, scopedHeaders };
+    return { stickyIdentifier, statusCells: statusCells.length, statusHasText, scopedHeaders };
   });
 
   report.keyboard.push({ check: "master-list-status-signal", ...signal });

--- a/tools/qa/admin-accessibility-qa.test.mjs
+++ b/tools/qa/admin-accessibility-qa.test.mjs
@@ -161,23 +161,25 @@ test("admin accessibility QA script verifies list toolbar sheet body overflow an
   assert.match(source, /listToolbar\.sheetClosed === false/);
 });
 
-// V6-07 #2279: 마스터 목록 상태 신호(sticky 식별자·비색 상태 아이콘+텍스트·헤더 scope) 계약을 source로 고정한다.
+// V6-07 #2279 / #2313: 마스터 목록 상태 신호(sticky 식별자·비색 상태 텍스트·헤더 scope) 계약을 source로 고정한다.
+// #2313에서 상태 표현이 .admin-status(● 점 + 상태 텍스트)로 단일화되어 비색 신호 판정 기준이
+// 아이콘 존재에서 상태 텍스트 병기로 바뀌었다.
 test("admin accessibility QA script verifies master-list sticky identifier and non-color status signal", () => {
   assert.match(source, /async function masterListStatusSignalCheck\(page, baseUrl, report\)/);
   assert.match(source, /await masterListStatusSignalCheck\(page, baseUrl, report\)/);
   assert.match(source, /check: "master-list-status-signal"/);
   // 첫 식별자 열 sticky 고정을 실제 computed style로 판정한다.
   assert.match(source, /getComputedStyle\(firstCell\)\.position === "sticky"/);
-  // 상태가 색 단독이 아니라 아이콘(비색 신호)+텍스트를 함께 갖는지 검사한다.
-  assert.match(source, /cell\.querySelector\("svg\.admin-icon"\)/);
-  assert.match(source, /statusHasIcon/);
+  // 상태 셀은 .admin-status(● 점 + 텍스트) 계약을 대상으로 한다.
+  assert.match(source, /querySelectorAll\("\.admin-table-scroll \.admin-status"\)/);
+  // 색 단독이 아니라 비색 신호인 상태 텍스트가 항상 병기되는지 검사한다.
   assert.match(source, /statusHasText/);
   // 표 헤더 scope 연결을 센다.
   assert.match(source, /thead th\[scope=/);
   // 계약 실패가 blocking 위반으로 표면화되는지 고정한다.
   assert.match(source, /id: "master-list-status-signal"/);
   assert.match(source, /statusSignal\.stickyIdentifier === false/);
-  assert.match(source, /statusSignal\.statusHasIcon === false/);
+  assert.match(source, /statusSignal\.statusHasText === false/);
 });
 
 // V6-08 #2280: 신고 대기열 action·photo 경계(승인 primary·반려 danger·사진 fail closed) 계약을 source로 고정한다.


### PR DESCRIPTION
## 관련 이슈

Refs #2313

## 작업 배경

관리자 화면의 상태 표현이 아이콘+텍스트(`.data-status`)·수량 뱃지 등으로 분화되어 있고, 역 상세·데이터팩 화면 곳곳에 영문/enum 원문 라벨이 노출되어 있었다. 이를 상태 2종(`.admin-status` ● 점+텍스트, `.count-badge`)으로 축소하고 표시 라벨을 한국어로 통일한다.

추가로, 상태 컴포넌트 계약 변경이 `Admin QA Gates`의 actual browser QA 계약 검사(`master-list-status-signal`)를 깨뜨렸다. 이 검사가 구 컴포넌트 계약(`.data-status` 셀렉터 + `svg.admin-icon` 아이콘)을 하드코딩하고 있어 `.admin-status`(● 점 + 상태 텍스트) 전환 후 매칭 0개로 blocking axe violation을 표면화했다. 계약 테스트(QA 하네스)를 새 상태 컴포넌트 계약에 맞춰 갱신해야 하므로 이 PR은 A등급으로 승격한다.

## 작업 내용

- 상태 표현을 2종(`.admin-status` 텍스트+● 점, `.count-badge` 수량 뱃지)으로 축소했다. 아이콘+텍스트 방식이던 `.data-status`(`stations/list.html`, `facilities/list.html`)를 `admin/fragments/shell :: status(text, tone)` 프래그먼트 기반 `.admin-status`로 흡수·치환하고, 사용처가 0이 된 `.data-status` CSS 규칙(`admin-data.css`)을 제거했다.
- `.admin-status`에 중립 톤 `.info`를 신설(`admin-components.css`, admin-tokens 변수만 사용)하고 `shell.html`의 `status(text, tone)` 프래그먼트에 `info` 분기를 추가했다. 전 행에 붙는 데이터 품질 "정보 확인 중"은 실제 경고가 아니므로 warn이 아닌 info 톤으로 강등하고, "고장·공사 반영"만 good 톤으로 남겼다(시설 상태의 warn/bad는 진짜 확인 필요·고장 상태이므로 그대로 유지).
- `stations/detail.html`, `dashboard.html`, `quality/dashboard.html`, `datapack/pipeline/list.html`, `datapack/release-requests/list.html`의 영문 라벨(출시 준비도·scope/alias/quarantine/route gate/facility evidence/rollback target·evidence hash/repair 등)을 한국어로 옮겼다. "blocker"는 위 화면 전반에서 "차단 요인"으로 통일했다(오너 승인 사항).
- `ReleaseReadinessRow`/`StationReleaseBlockerRow`·`productionPromoteReason()`의 문구를 서버 한 곳에서 한국어로 번역해, 이를 재사용하는 대시보드·데이터 품질·역 상세·파이프라인 화면이 함께 갱신되도록 했다. `SOURCE_SNAPSHOT_EXPIRED` 등 진단 코드성 값은 유지했다.
- `DataSourceType`·`AccessibilityFacilityType` enum에 `label()`을 신설해, 역 상세의 출처 유형·시설 유형 원문 노출(`OFFICIAL_FILE`, `ELEVATOR` 등)을 한국어 표시 라벨로 매핑했다.
- **(QA 하네스 계약 변경 — A등급 사유)** `tools/qa/admin-accessibility-qa.mjs`의 `master-list-status-signal` 계약 검사를 새 상태 컴포넌트 계약에 맞췄다. 셀렉터를 `.admin-table-scroll .data-status` → `.admin-table-scroll .admin-status`로 바꾸고, 색 단독 금지(WCAG 1.4.1) 판정 기준을 아이콘 존재(`statusHasIcon` + `svg.admin-icon`)에서 **상태 텍스트 병기(`statusHasText`)** 로 대체했다. ● 점은 `::before` 색상 신호이므로 유일한 비색 신호인 상태 텍스트가 항상 병기되는지를 계속 보증한다. 위반 편입 로직과 `tools/qa/admin-accessibility-qa.test.mjs`의 source 계약 assert도 함께 갱신했다. sticky 식별자·`th[scope]` 헤더 검사는 그대로 유지했다.
- **(리뷰 지적 반영)** F1: `FacilityStatusRow.sourceLabel()`이 공식 계열(`OFFICIAL_API`/`OFFICIAL_FILE`/`OPERATOR_PAGE`)을 "공식 안내"로 묶어 `DataSourceType.label()`("공식 자료"/"공식 API"/"운영자 안내")과 화면 간 불일치가 나던 것을, `label()`을 단일 원본으로 삼아 위임으로 정리했다(`OFFICIAL_FILE` → "공식 자료"). F2: `typeLabel()` switch를 `type.label()` 위임으로 축약했다. F3: 릴리스 요청 화면의 콜백 전송/재조정 zone과 인접 목록 표의 잔여 영문 표시 라벨을 한국어로 통일했다(코드 토큰 `HTTP`·`sha256` 등은 유지).
- 코드 식별자·API 계약(Java 필드명·record 시그니처·URL·필터 파라미터 값 등)은 변경하지 않았다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/qa/admin-accessibility-qa.test.mjs` — `tests 15 pass 15 fail 0`
  - `./gradlew test --tests TransitFacilityAdminApiControllerTest --tests TransitFacilityAdminPageControllerTest --tests DatapackReleaseRequestAdminPageControllerTest` — `BUILD SUCCESSFUL`
  - dev 프로파일(H2, break-glass env admin/operator 계정, 포트 8080)로 백엔드를 실기동하고 신고 사진 1건을 시드한 뒤 `node tools/qa/admin-accessibility-qa.mjs`(actual browser QA)를 로컬 1회 실행 — `admin accessibility QA ok`, blocking violations `[]`. `/admin/stations/page`의 `master-list-status-signal`이 `{ stickyIdentifier: true, statusCells: 16(.admin-status로 매칭), statusHasText: true, scopedHeaders: 9 }`로 통과함을 리포트 JSON에서 직접 확인. 종료 시 백엔드 프로세스·시크릿 파일 정리 완료.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| master-list-status-signal 계약 통과 | admin web | dev/H2 실기동 후 actual browser QA 하네스 로컬 1회 실행 | report JSON: `stickyIdentifier=true, statusCells=16, statusHasText=true, scopedHeaders=9`, blocking `[]` | 통과 |
| QA 하네스 source 계약 테스트 | tooling | `node --test tools/qa/admin-accessibility-qa.test.mjs` | `tests 15 pass 15 fail 0` | 통과 |
| 출처 라벨 단일 원본(F1) | backend | `TransitFacilityAdminApiControllerTest` (sourceLabel "공식 자료" 기대) | `BUILD SUCCESSFUL` | 통과 |
| 콜백 zone 한국어화(F3) | admin web | `DatapackReleaseRequestAdminPageControllerTest` 렌더 검증 | `BUILD SUCCESSFUL` | 통과 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `tools/qa/admin-accessibility-qa.mjs`의 `master-list-status-signal` 검사가 아이콘 대신 상태 텍스트 병기로 비색 신호를 판정하도록 바뀐 부분(WCAG 1.4.1 취지 유지 여부)과, `FacilityStatusRow.sourceLabel()`이 `DataSourceType.label()`로 위임되며 "공식 안내" 묶음 표기가 출처별 개별 라벨로 바뀐 부분(화면 간 일관성).

## 리스크

- QA 하네스 계약 검사를 변경하므로, 상태 컴포넌트 마크업이 다시 `.admin-status`에서 벗어나면 검사가 놓칠 수 있다. 상태 텍스트 병기 자체는 계속 강제된다. 백엔드 라벨은 표시 문구만 바뀌고 enum 값·API 계약은 불변이다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)
