### PR TITLE
[Chore] #2332 timetable snapshot 만료 시 degraded 운용 전환

### DIFF
--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/JdbcRouteTimetableRepository.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/JdbcRouteTimetableRepository.java
@@ -45,7 +45,16 @@ public class JdbcRouteTimetableRepository implements LoadRouteTimetablePort {
 
 	@Override
 	public boolean hasRouteTimetable() {
-		return activeItxArtifact().isPresent() && Boolean.TRUE.equals(jdbcTemplate.queryForObject(
+		return activeItxArtifact().isPresent() && hasReadableTransitTrips();
+	}
+
+	@Override
+	public boolean hasActivatableRouteTimetable() {
+		return admissibleItxArtifact().isPresent() && hasReadableTransitTrips();
+	}
+
+	private boolean hasReadableTransitTrips() {
+		return Boolean.TRUE.equals(jdbcTemplate.queryForObject(
 			"""
 				SELECT CASE
 					WHEN EXISTS (
@@ -84,6 +93,12 @@ public class JdbcRouteTimetableRepository implements LoadRouteTimetablePort {
 	}
 
 	private Optional<ItxArtifact> activeItxArtifact() {
+		return admissibleItxArtifact()
+			.filter(artifact -> freshOffsetDateTime(artifact.freshUntil()).isPresent());
+	}
+
+	// 시간 기반 freshness를 제외한 lineage·schema 적격성만 판정한다(활성화 시점 readability 검사용).
+	private Optional<ItxArtifact> admissibleItxArtifact() {
 		return jdbcTemplate.query(
 			"""
 				SELECT h.snapshot_sha256, h.snapshot_id, h.fresh_until,
@@ -125,7 +140,7 @@ public class JdbcRouteTimetableRepository implements LoadRouteTimetablePort {
 					resultSet.getString("evidence_hash")
 				)
 			)
-		).stream().filter(artifact -> freshOffsetDateTime(artifact.freshUntil()).isPresent()).findFirst();
+		).stream().findFirst();
 	}
 
 	@Override

--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/TimetableFreshnessMonitor.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/TimetableFreshnessMonitor.java
@@ -14,7 +14,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.boot.actuate.health.Status;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.annotation.Profile;
+import org.springframework.context.event.EventListener;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -23,9 +25,13 @@ import org.springframework.stereotype.Component;
  * timetable snapshot의 시간 기반 freshness를 런타임에 재평가해 degraded 운용을 관측 가능하게 노출한다.
  *
  * <p>만료 판정은 부팅 한 번이 아니라 주기적으로(그리고 요청 시점의 {@link JdbcRouteTimetableRepository})
- * 이뤄진다. 만료되면 {@code STALE} health 컴포넌트와 gauge(0)로 드러난다. {@code STALE}은 status order상 UP보다
- * 위지만 HTTP 503으로 매핑되지 않고, 이 컴포넌트는 readiness/liveness group에도 포함되지 않으므로
- * admin·상태·복구 엔드포인트와 배포 probe는 영향받지 않는다.
+ * 이뤄진다. 만료되면 이 health indicator가 집계 status 문자열을 {@code "STALE"}로 바꾼다(status order상
+ * {@code up}보다 상위) — 단 HTTP status는 계속 200이고, 이 컴포넌트는 readiness/liveness group에 포함되지
+ * 않으므로 admin·상태·복구 엔드포인트와 배포 probe(HTTP 상태만 보는 readiness probe)는 영향받지 않는다.
+ * 저장소 내에는 root `/actuator/health` status 문자열을 {@code "UP"}과 동등 비교하는 소비처가 없음을
+ * 확인했다(2026-07-20 실측: infra prometheus/probe는 `/actuator/health/readiness`만 HTTP status로 확인하고,
+ * admin의 {@code HealthCheckService}는 이 actuator 레지스트리와 무관한 별도 hand-rolled 상태다). 저장소 밖
+ * alerting·대시보드에서 root status 문자열 동등 비교를 하는지는 별도 확인이 필요하다.
  */
 @Component
 @Profile("prod | staging | release | prod-like")
@@ -47,16 +53,33 @@ class TimetableFreshnessMonitor implements HealthIndicator {
 		this.jdbcTemplate = jdbcTemplate;
 		this.clock = clock;
 		Gauge.builder("easysubway.timetable.snapshot.fresh", state, current -> current.get().fresh() ? 1.0 : 0.0)
-			.description("Active timetable snapshot freshness: 1 when fresh, 0 when stale or absent")
+			.description("Active timetable snapshot freshness: 1 when fresh, 0 when stale, absent, or unknown")
 			.register(meterRegistry);
+	}
+
+	// 스케줄 첫 실행(fixedDelay) 전 창에서 fresh 스냅샷도 UNKNOWN/0으로 오표시되지 않도록 기동 직후 1회 즉시 평가한다.
+	// ApplicationReadyEvent는 ApplicationRunner(TimetableSeedLoader 포함)까지 끝난 뒤 발생해 활성화 순서가 보장된다.
+	@EventListener(ApplicationReadyEvent.class)
+	void evaluateOnStartup() {
+		evaluate();
 	}
 
 	@Scheduled(fixedDelayString = "${easysubway.timetable.freshness-check-interval-ms:60000}")
 	void evaluate() {
 		Freshness previous = state.get();
-		Freshness current = current();
-		state.set(current);
-		logTransition(previous, current);
+		Freshness observed = query();
+		if (observed == null) {
+			// transient 쿼리 오류: 실제 FRESH/STALE 관측이 있었다면 그 신호를 유지해 오탐(false alerting)과
+			// 복구 로그 누락을 막는다. 유효 관측이 아직 없을 때만 ERROR로 표시해 "쿼리 실패"와
+			// "활성 스냅샷 없음"을 구분한다.
+			if (previous.state() == State.FRESH || previous.state() == State.STALE) {
+				return;
+			}
+			state.set(Freshness.error());
+			return;
+		}
+		state.set(observed);
+		logTransition(previous, observed);
 	}
 
 	@Override
@@ -77,10 +100,15 @@ class TimetableFreshnessMonitor implements HealthIndicator {
 			case NO_ACTIVE_SNAPSHOT -> Health.unknown()
 				.withDetail("state", "NO_ACTIVE_SNAPSHOT")
 				.build();
+			case ERROR -> Health.unknown()
+				.withDetail("state", "EVALUATION_ERROR")
+				.withDetail("reason", "freshness query failed; see application logs")
+				.build();
 		};
 	}
 
-	private Freshness current() {
+	/** 쿼리 성공 시 관측 결과를, 실패 시 {@code null}을 반환한다(호출부가 이전 상태 유지 여부를 결정한다). */
+	private Freshness query() {
 		try {
 			return jdbcTemplate.query(
 				"""
@@ -96,8 +124,8 @@ class TimetableFreshnessMonitor implements HealthIndicator {
 				)
 			).stream().findFirst().orElseGet(Freshness::noActiveSnapshot);
 		} catch (RuntimeException exception) {
-			log.debug("timetable freshness evaluation skipped: {}", exception.getMessage());
-			return Freshness.unknown();
+			log.warn("timetable freshness evaluation failed: {}", exception.getMessage(), exception);
+			return null;
 		}
 	}
 
@@ -118,7 +146,8 @@ class TimetableFreshnessMonitor implements HealthIndicator {
 	private enum State {
 		FRESH,
 		STALE,
-		NO_ACTIVE_SNAPSHOT
+		NO_ACTIVE_SNAPSHOT,
+		ERROR
 	}
 
 	private record Freshness(State state, String snapshotId, OffsetDateTime freshUntil) {
@@ -139,6 +168,10 @@ class TimetableFreshnessMonitor implements HealthIndicator {
 
 		private static Freshness unknown() {
 			return new Freshness(State.NO_ACTIVE_SNAPSHOT, null, null);
+		}
+
+		private static Freshness error() {
+			return new Freshness(State.ERROR, null, null);
 		}
 
 		private static Optional<OffsetDateTime> parse(String value) {

--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/TimetableFreshnessMonitor.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/TimetableFreshnessMonitor.java
@@ -1,0 +1,159 @@
+package com.easysubway.route.adapter.out.persistence;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * timetable snapshot의 시간 기반 freshness를 런타임에 재평가해 degraded 운용을 관측 가능하게 노출한다.
+ *
+ * <p>만료 판정은 부팅 한 번이 아니라 주기적으로(그리고 요청 시점의 {@link JdbcRouteTimetableRepository})
+ * 이뤄진다. 만료되면 {@code STALE} health 컴포넌트와 gauge(0)로 드러난다. {@code STALE}은 status order상 UP보다
+ * 위지만 HTTP 503으로 매핑되지 않고, 이 컴포넌트는 readiness/liveness group에도 포함되지 않으므로
+ * admin·상태·복구 엔드포인트와 배포 probe는 영향받지 않는다.
+ */
+@Component
+@Profile("prod | staging | release | prod-like")
+class TimetableFreshnessMonitor implements HealthIndicator {
+
+	static final Status STALE = new Status("STALE");
+	private static final Logger log = LoggerFactory.getLogger(TimetableFreshnessMonitor.class);
+
+	private final JdbcTemplate jdbcTemplate;
+	private final Clock clock;
+	private final AtomicReference<Freshness> state = new AtomicReference<>(Freshness.unknown());
+
+	@Autowired
+	TimetableFreshnessMonitor(DataSource dataSource, MeterRegistry meterRegistry) {
+		this(new JdbcTemplate(dataSource), Clock.systemUTC(), meterRegistry);
+	}
+
+	TimetableFreshnessMonitor(JdbcTemplate jdbcTemplate, Clock clock, MeterRegistry meterRegistry) {
+		this.jdbcTemplate = jdbcTemplate;
+		this.clock = clock;
+		Gauge.builder("easysubway.timetable.snapshot.fresh", state, current -> current.get().fresh() ? 1.0 : 0.0)
+			.description("Active timetable snapshot freshness: 1 when fresh, 0 when stale or absent")
+			.register(meterRegistry);
+	}
+
+	@Scheduled(fixedDelayString = "${easysubway.timetable.freshness-check-interval-ms:60000}")
+	void evaluate() {
+		Freshness previous = state.get();
+		Freshness current = current();
+		state.set(current);
+		logTransition(previous, current);
+	}
+
+	@Override
+	public Health health() {
+		Freshness current = state.get();
+		return switch (current.state()) {
+			case FRESH -> Health.up()
+				.withDetail("state", "FRESH")
+				.withDetail("snapshotId", current.snapshotId())
+				.withDetail("freshUntil", String.valueOf(current.freshUntil()))
+				.build();
+			case STALE -> Health.status(STALE)
+				.withDetail("state", "STALE")
+				.withDetail("snapshotId", current.snapshotId())
+				.withDetail("freshUntil", String.valueOf(current.freshUntil()))
+				.withDetail("reason", "route search serves 503 until a fresh snapshot is admitted")
+				.build();
+			case NO_ACTIVE_SNAPSHOT -> Health.unknown()
+				.withDetail("state", "NO_ACTIVE_SNAPSHOT")
+				.build();
+		};
+	}
+
+	private Freshness current() {
+		try {
+			return jdbcTemplate.query(
+				"""
+					SELECT h.snapshot_id, h.fresh_until
+					FROM timetable_snapshot_active a
+					JOIN timetable_snapshot_history h ON h.snapshot_sha256 = a.snapshot_sha256
+					WHERE a.singleton_id = 1
+					""",
+				(resultSet, rowNumber) -> Freshness.of(
+					resultSet.getString("snapshot_id"),
+					resultSet.getString("fresh_until"),
+					clock
+				)
+			).stream().findFirst().orElseGet(Freshness::noActiveSnapshot);
+		} catch (RuntimeException exception) {
+			log.debug("timetable freshness evaluation skipped: {}", exception.getMessage());
+			return Freshness.unknown();
+		}
+	}
+
+	private void logTransition(Freshness previous, Freshness current) {
+		if (previous.state() == State.FRESH && current.state() == State.STALE) {
+			log.warn(
+				"transit timetable snapshot became stale at {}; route search now serves 503 (degraded) until refresh",
+				current.freshUntil()
+			);
+		} else if (previous.state() == State.STALE && current.state() == State.FRESH) {
+			log.info(
+				"transit timetable snapshot refreshed (fresh until {}); route search restored",
+				current.freshUntil()
+			);
+		}
+	}
+
+	private enum State {
+		FRESH,
+		STALE,
+		NO_ACTIVE_SNAPSHOT
+	}
+
+	private record Freshness(State state, String snapshotId, OffsetDateTime freshUntil) {
+
+		private static Freshness of(String snapshotId, String freshUntil, Clock clock) {
+			Optional<OffsetDateTime> parsed = parse(freshUntil);
+			if (parsed.isEmpty()) {
+				return new Freshness(State.STALE, snapshotId, null);
+			}
+			OffsetDateTime value = parsed.get();
+			State state = value.toInstant().isAfter(clock.instant()) ? State.FRESH : State.STALE;
+			return new Freshness(state, snapshotId, value);
+		}
+
+		private static Freshness noActiveSnapshot() {
+			return new Freshness(State.NO_ACTIVE_SNAPSHOT, null, null);
+		}
+
+		private static Freshness unknown() {
+			return new Freshness(State.NO_ACTIVE_SNAPSHOT, null, null);
+		}
+
+		private static Optional<OffsetDateTime> parse(String value) {
+			if (value == null || value.isBlank()) {
+				return Optional.empty();
+			}
+			try {
+				return Optional.of(OffsetDateTime.parse(value));
+			} catch (DateTimeParseException exception) {
+				return Optional.empty();
+			}
+		}
+
+		private boolean fresh() {
+			return state == State.FRESH;
+		}
+	}
+}

--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoader.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoader.java
@@ -109,9 +109,27 @@ public class TimetableSeedLoader implements ApplicationRunner {
 			if (result == null) {
 				throw new IllegalStateException("snapshot transaction returned no result");
 			}
+			logActivationFreshness(candidate.evidence());
 			return result;
 		} catch (RuntimeException exception) {
 			throw new IllegalStateException("transit timetable snapshot activation failed", exception);
+		}
+	}
+
+	/**
+	 * 시간 기반 만료(freshUntil)는 last-known-good snapshot 활성화를 막지 않는다. 만료 상태로 기동하면
+	 * degraded 운용(경로검색 503, 나머지 정상)임을 경고 로그로 남기고, 실제 만료 판정은 런타임에서 재평가한다.
+	 */
+	private void logActivationFreshness(SnapshotEvidence evidence) {
+		OffsetDateTime freshUntil = OffsetDateTime.parse(evidence.freshUntil());
+		if (freshUntil.toInstant().isAfter(clock.instant())) {
+			log.info("transit timetable snapshot is fresh until {}", freshUntil);
+		} else {
+			log.warn(
+				"transit timetable snapshot expired at {}; activated last-known-good snapshot and route search "
+					+ "will serve 503 until a fresh snapshot is admitted (integrity verified, freshness degraded)",
+				freshUntil
+			);
 		}
 	}
 
@@ -146,7 +164,7 @@ public class TimetableSeedLoader implements ApplicationRunner {
 				candidate.evidence().snapshotSha256()
 			);
 		}
-		if (!routeTimetablePort.hasRouteTimetable()) {
+		if (!routeTimetablePort.hasActivatableRouteTimetable()) {
 			throw new IllegalStateException("activated snapshot is not readable by the runtime repository");
 		}
 		return ActivationResult.ACTIVATED;
@@ -369,7 +387,7 @@ public class TimetableSeedLoader implements ApplicationRunner {
 			if (!(parsed instanceof ObjectNode evidenceNode)) {
 				throw new IllegalStateException("timetable snapshot evidence must be an object");
 			}
-			SnapshotEvidence evidence = SnapshotEvidence.from(evidenceNode, objectMapper, clock);
+			SnapshotEvidence evidence = SnapshotEvidence.from(evidenceNode, objectMapper);
 			if (!evidence.snapshotSha256().equals(sha256(sqlBytes))
 				|| evidence.snapshotSqlByteSize() != sqlBytes.length
 				|| !evidence.snapshotGzipSha256().equals(sha256(rawSeedBytes))
@@ -465,7 +483,7 @@ public class TimetableSeedLoader implements ApplicationRunner {
 		int routeEdgeEvidenceCount
 	) {
 
-		static SnapshotEvidence from(ObjectNode node, ObjectMapper mapper, Clock clock) {
+		static SnapshotEvidence from(ObjectNode node, ObjectMapper mapper) {
 			String evidenceHash = text(node, "evidenceHash");
 			ObjectNode withoutHash = node.deepCopy();
 			withoutHash.remove("evidenceHash");
@@ -488,10 +506,9 @@ public class TimetableSeedLoader implements ApplicationRunner {
 			JsonNode stations = object(node, "canonicalStationSet");
 			JsonNode counts = object(node, "rowCounts");
 			String freshUntil = text(node, "freshUntil");
+			// 형식 무결성만 부팅 시 강제한다. 시간 기반 만료는 부팅을 막지 않고 런타임에서 재평가한다.
 			try {
-				if (!OffsetDateTime.parse(freshUntil).toInstant().isAfter(clock.instant())) {
-					throw new IllegalStateException("timetable snapshot evidence is stale");
-				}
+				OffsetDateTime.parse(freshUntil);
 			} catch (DateTimeParseException exception) {
 				throw new IllegalStateException("timetable snapshot evidence freshness is invalid", exception);
 			}

--- a/backend/src/main/java/com/easysubway/route/application/port/out/LoadRouteTimetablePort.java
+++ b/backend/src/main/java/com/easysubway/route/application/port/out/LoadRouteTimetablePort.java
@@ -28,6 +28,14 @@ public interface LoadRouteTimetablePort {
 		return !timetable.transitTrips().isEmpty() && !timetable.transitStopTimes().isEmpty();
 	}
 
+	/**
+	 * 활성화 시점 readability 검사: 활성 snapshot 행이 구조적으로 읽을 수 있으면 true다. 시간 기반 만료(freshUntil)는
+	 * 여기서 판정하지 않는다 — 만료된 last-known-good snapshot도 활성화(기동)는 가능해야 하고, 만료 강등은 serving 경로가 담당한다.
+	 */
+	default boolean hasActivatableRouteTimetable() {
+		return hasRouteTimetable();
+	}
+
 	default Optional<String> activeItxTimetableArtifactId() {
 		return Optional.empty();
 	}

--- a/backend/src/test/java/com/easysubway/route/adapter/out/persistence/TimetableFreshnessMonitorTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/out/persistence/TimetableFreshnessMonitorTest.java
@@ -6,7 +6,16 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Clock;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.actuate.health.Status;
@@ -21,6 +30,8 @@ class TimetableFreshnessMonitorTest {
 	private static final String GAUGE = "easysubway.timetable.snapshot.fresh";
 
 	private JdbcTemplate jdbc;
+	private CapturingAppender logAppender;
+	private org.apache.logging.log4j.core.Logger monitorLogger;
 
 	@BeforeEach
 	void setUp() {
@@ -33,6 +44,20 @@ class TimetableFreshnessMonitorTest {
 				+ "snapshot_id VARCHAR(120), fresh_until VARCHAR(40))");
 		jdbc.execute(
 			"CREATE TABLE timetable_snapshot_active (singleton_id INTEGER PRIMARY KEY, snapshot_sha256 VARCHAR(64))");
+		logAppender = new CapturingAppender();
+		logAppender.start();
+		monitorLogger = (org.apache.logging.log4j.core.Logger) LogManager.getLogger(TimetableFreshnessMonitor.class);
+		// 순수 단위 테스트에는 Spring Boot의 logging.level 바인딩이 적용되지 않으므로, ambient 기본 설정과
+		// 무관하게 WARN/INFO 전환 로그를 확실히 포착하도록 로거 레벨을 명시적으로 낮춘다.
+		monitorLogger.setLevel(Level.ALL);
+		monitorLogger.addAppender(logAppender);
+	}
+
+	@AfterEach
+	void tearDown() {
+		monitorLogger.removeAppender(logAppender);
+		monitorLogger.setLevel(null);
+		logAppender.stop();
 	}
 
 	@Test
@@ -75,6 +100,122 @@ class TimetableFreshnessMonitorTest {
 		assertThat(meterRegistry.get(GAUGE).gauge().value()).isEqualTo(0.0);
 	}
 
+	@Test
+	void blankFreshUntilIsTreatedAsStale() {
+		insertActiveSnapshot("");
+		MeterRegistry meterRegistry = new SimpleMeterRegistry();
+		TimetableFreshnessMonitor monitor = monitor(BEFORE, meterRegistry);
+
+		monitor.evaluate();
+
+		assertThat(monitor.health().getStatus()).isEqualTo(TimetableFreshnessMonitor.STALE);
+		assertThat(monitor.health().getDetails()).containsEntry("state", "STALE");
+	}
+
+	@Test
+	void unparsableFreshUntilIsTreatedAsStale() {
+		insertActiveSnapshot("not-a-timestamp");
+		MeterRegistry meterRegistry = new SimpleMeterRegistry();
+		TimetableFreshnessMonitor monitor = monitor(BEFORE, meterRegistry);
+
+		monitor.evaluate();
+
+		assertThat(monitor.health().getStatus()).isEqualTo(TimetableFreshnessMonitor.STALE);
+		assertThat(monitor.health().getDetails()).containsEntry("state", "STALE");
+	}
+
+	@Test
+	void queryFailurePreservesPreviousFreshStateInsteadOfReportingUnknown() {
+		insertActiveSnapshot(FRESH_UNTIL);
+		MeterRegistry meterRegistry = new SimpleMeterRegistry();
+		TimetableFreshnessMonitor monitor = monitor(BEFORE, meterRegistry);
+		monitor.evaluate();
+		assertThat(monitor.health().getStatus()).isEqualTo(Status.UP);
+
+		jdbc.execute("DROP ALL OBJECTS");
+		monitor.evaluate();
+
+		// transient 쿼리 오류가 이전 FRESH 관측을 UNKNOWN으로 덮어쓰지 않는다(false alerting 방지).
+		assertThat(monitor.health().getStatus()).isEqualTo(Status.UP);
+		assertThat(monitor.health().getDetails()).containsEntry("state", "FRESH");
+		assertThat(meterRegistry.get(GAUGE).gauge().value()).isEqualTo(1.0);
+	}
+
+	@Test
+	void queryFailurePreservesPreviousStaleStateInsteadOfReportingUnknown() {
+		insertActiveSnapshot(FRESH_UNTIL);
+		MeterRegistry meterRegistry = new SimpleMeterRegistry();
+		TimetableFreshnessMonitor monitor = monitor(AFTER, meterRegistry);
+		monitor.evaluate();
+		assertThat(monitor.health().getStatus()).isEqualTo(TimetableFreshnessMonitor.STALE);
+
+		jdbc.execute("DROP ALL OBJECTS");
+		monitor.evaluate();
+
+		// transient 쿼리 오류가 이전 STALE 신호(경로검색 degraded 관측)를 삭제하지 않는다.
+		assertThat(monitor.health().getStatus()).isEqualTo(TimetableFreshnessMonitor.STALE);
+		assertThat(monitor.health().getDetails()).containsEntry("state", "STALE");
+	}
+
+	@Test
+	void queryFailureWithoutPriorObservationReportsDistinctErrorStateAndWarnLogs() {
+		jdbc.execute("DROP ALL OBJECTS");
+		MeterRegistry meterRegistry = new SimpleMeterRegistry();
+		TimetableFreshnessMonitor monitor = monitor(BEFORE, meterRegistry);
+
+		monitor.evaluate();
+
+		// "쿼리 실패"는 "활성 스냅샷 없음"과 detail로 구분되고(둘 다 Status.UNKNOWN), gauge는 0이다.
+		assertThat(monitor.health().getStatus()).isEqualTo(Status.UNKNOWN);
+		assertThat(monitor.health().getDetails()).containsEntry("state", "EVALUATION_ERROR");
+		assertThat(meterRegistry.get(GAUGE).gauge().value()).isEqualTo(0.0);
+		assertThat(logAppender.events()).anySatisfy(event -> {
+			assertThat(event.getLevel()).isEqualTo(Level.WARN);
+			assertThat(event.getMessage().getFormattedMessage()).contains("freshness evaluation failed");
+		});
+	}
+
+	@Test
+	void evaluateOnStartupPopulatesStateBeforeFirstScheduledRun() {
+		insertActiveSnapshot(FRESH_UNTIL);
+		MeterRegistry meterRegistry = new SimpleMeterRegistry();
+		TimetableFreshnessMonitor monitor = monitor(BEFORE, meterRegistry);
+
+		// 부팅 직후 첫 스케줄 실행 전에도 ApplicationReadyEvent 리스너가 즉시 1회 평가해 UNKNOWN/0으로
+		// 오표시되지 않는다.
+		monitor.evaluateOnStartup();
+
+		assertThat(monitor.health().getStatus()).isEqualTo(Status.UP);
+		assertThat(meterRegistry.get(GAUGE).gauge().value()).isEqualTo(1.0);
+	}
+
+	@Test
+	void transitionFromFreshToStaleLogsWarnRecoveryFromStaleToFreshLogsInfo() {
+		insertActiveSnapshot(FRESH_UNTIL);
+		MutableClock clock = new MutableClock(BEFORE);
+		MeterRegistry meterRegistry = new SimpleMeterRegistry();
+		TimetableFreshnessMonitor monitor = new TimetableFreshnessMonitor(jdbc, clock, meterRegistry);
+
+		monitor.evaluate();
+		assertThat(monitor.health().getStatus()).isEqualTo(Status.UP);
+
+		clock.set(AFTER);
+		monitor.evaluate();
+		assertThat(monitor.health().getStatus()).isEqualTo(TimetableFreshnessMonitor.STALE);
+		assertThat(logAppender.events()).anySatisfy(event -> {
+			assertThat(event.getLevel()).isEqualTo(Level.WARN);
+			assertThat(event.getMessage().getFormattedMessage()).contains("became stale");
+		});
+
+		clock.set(BEFORE);
+		monitor.evaluate();
+		assertThat(monitor.health().getStatus()).isEqualTo(Status.UP);
+		assertThat(logAppender.events()).anySatisfy(event -> {
+			assertThat(event.getLevel()).isEqualTo(Level.INFO);
+			assertThat(event.getMessage().getFormattedMessage()).contains("refreshed");
+		});
+	}
+
 	private TimetableFreshnessMonitor monitor(Instant now, MeterRegistry meterRegistry) {
 		return new TimetableFreshnessMonitor(jdbc, Clock.fixed(now, ZoneOffset.UTC), meterRegistry);
 	}
@@ -85,5 +226,50 @@ class TimetableFreshnessMonitorTest {
 			"a".repeat(64), "snapshot-a", freshUntil);
 		jdbc.update(
 			"INSERT INTO timetable_snapshot_active (singleton_id, snapshot_sha256) VALUES (1, ?)", "a".repeat(64));
+	}
+
+	/** 테스트 안에서 스냅샷을 재활성화하지 않고 "현재 시각"만 이동시켜 전환(transition) 로그를 검증하기 위한 clock. */
+	private static final class MutableClock extends Clock {
+		private Instant instant;
+
+		private MutableClock(Instant instant) {
+			this.instant = instant;
+		}
+
+		void set(Instant instant) {
+			this.instant = instant;
+		}
+
+		@Override
+		public ZoneId getZone() {
+			return ZoneOffset.UTC;
+		}
+
+		@Override
+		public Clock withZone(ZoneId zone) {
+			return this;
+		}
+
+		@Override
+		public Instant instant() {
+			return instant;
+		}
+	}
+
+	private static final class CapturingAppender extends AbstractAppender {
+		private final List<LogEvent> events = new CopyOnWriteArrayList<>();
+
+		private CapturingAppender() {
+			super("timetable-freshness-monitor-test-appender", null, null, false, Property.EMPTY_ARRAY);
+		}
+
+		@Override
+		public void append(LogEvent event) {
+			events.add(event.toImmutable());
+		}
+
+		List<LogEvent> events() {
+			return events;
+		}
 	}
 }

--- a/backend/src/test/java/com/easysubway/route/adapter/out/persistence/TimetableFreshnessMonitorTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/out/persistence/TimetableFreshnessMonitorTest.java
@@ -1,0 +1,89 @@
+package com.easysubway.route.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+class TimetableFreshnessMonitorTest {
+
+	private static final Instant BEFORE = Instant.parse("2026-07-16T00:00:00Z");
+	private static final Instant AFTER = Instant.parse("2026-07-21T00:00:00Z");
+	private static final String FRESH_UNTIL = "2026-07-20T00:00:00+09:00";
+	private static final String GAUGE = "easysubway.timetable.snapshot.fresh";
+
+	private JdbcTemplate jdbc;
+
+	@BeforeEach
+	void setUp() {
+		DriverManagerDataSource dataSource = new DriverManagerDataSource(
+			"jdbc:h2:mem:freshness-monitor;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE", "sa", "");
+		jdbc = new JdbcTemplate(dataSource);
+		jdbc.execute("DROP ALL OBJECTS");
+		jdbc.execute(
+			"CREATE TABLE timetable_snapshot_history (snapshot_sha256 VARCHAR(64) PRIMARY KEY, "
+				+ "snapshot_id VARCHAR(120), fresh_until VARCHAR(40))");
+		jdbc.execute(
+			"CREATE TABLE timetable_snapshot_active (singleton_id INTEGER PRIMARY KEY, snapshot_sha256 VARCHAR(64))");
+	}
+
+	@Test
+	void reportsFreshWhenActiveSnapshotHasNotExpired() {
+		insertActiveSnapshot(FRESH_UNTIL);
+		MeterRegistry meterRegistry = new SimpleMeterRegistry();
+		TimetableFreshnessMonitor monitor = monitor(BEFORE, meterRegistry);
+
+		monitor.evaluate();
+
+		assertThat(monitor.health().getStatus()).isEqualTo(Status.UP);
+		assertThat(monitor.health().getDetails()).containsEntry("state", "FRESH");
+		assertThat(meterRegistry.get(GAUGE).gauge().value()).isEqualTo(1.0);
+	}
+
+	@Test
+	void reportsStaleWhenActiveSnapshotExpiredWithoutRestart() {
+		insertActiveSnapshot(FRESH_UNTIL);
+		MeterRegistry meterRegistry = new SimpleMeterRegistry();
+		TimetableFreshnessMonitor monitor = monitor(AFTER, meterRegistry);
+
+		monitor.evaluate();
+
+		assertThat(monitor.health().getStatus()).isEqualTo(TimetableFreshnessMonitor.STALE);
+		assertThat(monitor.health().getDetails())
+			.containsEntry("state", "STALE")
+			.containsEntry("reason", "route search serves 503 until a fresh snapshot is admitted");
+		assertThat(meterRegistry.get(GAUGE).gauge().value()).isEqualTo(0.0);
+	}
+
+	@Test
+	void reportsUnknownWhenNoActiveSnapshot() {
+		MeterRegistry meterRegistry = new SimpleMeterRegistry();
+		TimetableFreshnessMonitor monitor = monitor(BEFORE, meterRegistry);
+
+		monitor.evaluate();
+
+		assertThat(monitor.health().getStatus()).isEqualTo(Status.UNKNOWN);
+		assertThat(monitor.health().getDetails()).containsEntry("state", "NO_ACTIVE_SNAPSHOT");
+		assertThat(meterRegistry.get(GAUGE).gauge().value()).isEqualTo(0.0);
+	}
+
+	private TimetableFreshnessMonitor monitor(Instant now, MeterRegistry meterRegistry) {
+		return new TimetableFreshnessMonitor(jdbc, Clock.fixed(now, ZoneOffset.UTC), meterRegistry);
+	}
+
+	private void insertActiveSnapshot(String freshUntil) {
+		jdbc.update(
+			"INSERT INTO timetable_snapshot_history (snapshot_sha256, snapshot_id, fresh_until) VALUES (?, ?, ?)",
+			"a".repeat(64), "snapshot-a", freshUntil);
+		jdbc.update(
+			"INSERT INTO timetable_snapshot_active (singleton_id, snapshot_sha256) VALUES (1, ?)", "a".repeat(64));
+	}
+}

--- a/backend/src/test/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoaderTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/out/persistence/TimetableSeedLoaderTest.java
@@ -32,6 +32,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 class TimetableSeedLoaderTest {
 
 	private static final Instant NOW = Instant.parse("2026-07-16T00:00:00Z");
+	private static final Instant STALE_NOW = Instant.parse("2026-07-21T00:00:00Z");
 	private static final String FRESH_UNTIL = "2026-07-20T00:00:00+09:00";
 	private final ObjectMapper objectMapper = new ObjectMapper();
 	private DriverManagerDataSource dataSource;
@@ -259,7 +260,7 @@ class TimetableSeedLoaderTest {
 	}
 
 	@Test
-	void rejectsDisabledItxOrStaleAndTamperedEvidenceBeforeWrites() throws Exception {
+	void rejectsDisabledItxAndTamperedEvidenceBeforeWrites() throws Exception {
 		SnapshotResource snapshot = snapshot("a", false);
 		TimetableSeedLoader disabled = new TimetableSeedLoader(
 			repository(),
@@ -274,15 +275,17 @@ class TimetableSeedLoaderTest {
 		assertThatThrownBy(() -> disabled.run(null)).isInstanceOf(IllegalStateException.class)
 			.hasMessageContaining("includes-itx");
 
-		ObjectNode stale;
+		// freshUntil은 evidenceHash로 보호되는 무결성 필드다. 재해시 없이 변조하면 부팅 hard fail을 유지한다.
+		ObjectNode tamperedFreshness;
 		try (var input = snapshot.evidence().getInputStream()) {
-			stale = (ObjectNode) objectMapper.readTree(input);
+			tamperedFreshness = (ObjectNode) objectMapper.readTree(input);
 		}
-		stale.put("freshUntil", "2000-01-01T00:00:00Z");
-		SnapshotResource staleSnapshot = new SnapshotResource(snapshot.seed(), jsonResource(stale, "stale.json"));
-		assertThatThrownBy(() -> loader(staleSnapshot).run(null))
+		tamperedFreshness.put("freshUntil", "2000-01-01T00:00:00Z");
+		SnapshotResource tamperedSnapshot = new SnapshotResource(
+			snapshot.seed(), jsonResource(tamperedFreshness, "tampered-freshness.json"));
+		assertThatThrownBy(() -> loader(tamperedSnapshot).run(null))
 			.isInstanceOf(IllegalStateException.class)
-			.hasMessageContaining("evidence");
+			.hasMessageContaining("hash");
 		assertThat(jdbc.queryForObject("SELECT COUNT(*) FROM timetable_snapshot_history", Integer.class)).isZero();
 
 		ObjectNode mismatchedAccessibility;
@@ -303,10 +306,44 @@ class TimetableSeedLoaderTest {
 		assertThat(jdbc.queryForObject("SELECT COUNT(*) FROM timetable_snapshot_history", Integer.class)).isZero();
 	}
 
+	@Test
+	void staleSnapshotBootsAsLastKnownGoodAndDegradesRouteSearchAtRuntime() throws Exception {
+		SnapshotResource snapshot = snapshot("a", false);
+
+		// freshUntil이 이미 지난 시각에 기동해도 컨텍스트를 죽이지 않고 last-known-good snapshot을 활성화한다.
+		assertThat(staleLoader(snapshot).activateSeed(snapshot.seed(), snapshot.evidence()))
+			.isEqualTo(TimetableSeedLoader.ActivationResult.ACTIVATED);
+		assertSnapshotRows("a");
+		assertThat(jdbc.queryForObject("SELECT COUNT(*) FROM timetable_snapshot_history", Integer.class)).isOne();
+
+		// 런타임 재평가: 재활성화 없이 clock만으로 serving 여부가 갈린다. 만료 clock은 경로검색 게이트를 fail closed한다.
+		JdbcRouteTimetableRepository stale = new JdbcRouteTimetableRepository(jdbc, Clock.fixed(STALE_NOW, ZoneOffset.UTC));
+		assertThat(stale.activeItxTimetableArtifactId()).isEmpty();
+		assertThat(stale.hasRouteTimetable()).isFalse();
+		// 만료 상태여도 활성화 시점 readability는 여전히 통과한다(무결성·구조는 정상, freshness만 강등).
+		assertThat(stale.hasActivatableRouteTimetable()).isTrue();
+		// 동일 데이터를 신선 clock으로 보면 정상 serving된다(회귀).
+		assertThat(repository().activeItxTimetableArtifactId()).contains("snapshot-a");
+	}
+
 	private TimetableSeedLoader loader(SnapshotResource snapshot) {
 		Clock clock = Clock.fixed(NOW, ZoneOffset.UTC);
 		return new TimetableSeedLoader(
 			repository(),
+			dataSource,
+			new DataSourceTransactionManager(dataSource),
+			snapshot.seed(),
+			snapshot.evidence(),
+			true,
+			objectMapper,
+			clock
+		);
+	}
+
+	private TimetableSeedLoader staleLoader(SnapshotResource snapshot) {
+		Clock clock = Clock.fixed(STALE_NOW, ZoneOffset.UTC);
+		return new TimetableSeedLoader(
+			new JdbcRouteTimetableRepository(jdbc, clock),
 			dataSource,
 			new DataSourceTransactionManager(dataSource),
 			snapshot.seed(),


### PR DESCRIPTION
## 관련 이슈

close #2332
Refs #2329

## 작업 배경

2026-07-20 운영 장애(#2328)에서 실측된 구조 결함이다. `TimetableSeedLoader`의 ApplicationRunner는 부팅 시 evidence `freshUntil`이 지났으면 `IllegalStateException`을 전파해 Spring 컨텍스트 전체를 종료시켰다. 이 때문에 timetable snapshot 만료 하나로 공개 경로검색 API뿐 아니라 admin·상태·복구 화면까지 전부 죽었다. 게다가 검사가 부팅 시점에만 실행되어, 이미 떠 있는 프로세스는 만료 이후에도 재시작 전까지 만료 데이터를 계속 서빙하는 반면 재시작·재배포만 전면 장애로 전환되는 모순이 있었다.

이 PR은 시간 기반 만료(freshness)를 데이터 무결성(해시·스키마·출처)과 분리해, 만료가 가용성을 해치지 않고 degraded 운용으로 전환되도록 하는 backend 행동 변경만 다룬다.

## 작업 내용

- **부팅 hard fail 제거 / 무결성·만료 분리** — `TimetableSeedLoader`의 `SnapshotEvidence.from`에서 만료 예외를 제거하고 `freshUntil` 형식 무결성만 부팅 시 강제한다. last-known-good snapshot을 그대로 활성화한 뒤 만료 여부를 경고/정보 로그로 남긴다. 무결성 검증 실패(evidence 해시·스키마·출처·seed 바이트 불일치 등)는 기존과 동일하게 부팅 hard fail을 유지한다.
- **활성화 readability와 freshness 분리** — `JdbcRouteTimetableRepository`의 활성화 시점 readability 검사(`hasActivatableRouteTimetable`/`admissibleItxArtifact`)를 시간 기반 만료와 분리했다. 만료된 last-known-good snapshot도 활성화(기동)는 가능하고, 만료 강등은 serving 경로가 담당한다. 요청 시점 Clock 만료 판정(`activeItxArtifact`의 freshness 필터)은 그대로 유지된다.
- **경로검색 503** — 만료 상태에서 Route V2 경로검색은 기존 `activeItxTimetableArtifactId()`의 요청 시점 만료 판정 → `ItxTimetableUnavailableException` → 503(`ITX_TIMETABLE_UNAVAILABLE`) 경로로 fail closed한다. 떠 있는 프로세스도 자정 경과 시 재시작 없이 degraded로 전환된다. admin·상태·복구·V1은 정상.
- **관측성** — `TimetableFreshnessMonitor`(주기 재평가 + 전환 경고 로그 + actuator health `STALE` + gauge `easysubway.timetable.snapshot.fresh`)를 추가했다. `STALE`은 status order상 UP보다 위지만 HTTP 503으로 매핑되지 않고, 이 컴포넌트는 readiness/liveness group에 포함되지 않아 admin·배포 probe(`/actuator/health/readiness`)는 영향받지 않는다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests 'com.easysubway.route.*' --tests 'com.easysubway.health.*' --tests 'com.easysubway.architecture.*' --tests 'com.easysubway.common.persistence.*'` → **BUILD SUCCESSFUL**
  - 신규/변경 케이스:
    - `TimetableSeedLoaderTest.staleSnapshotBootsAsLastKnownGoodAndDegradesRouteSearchAtRuntime` — 만료 시각 기동해도 컨텍스트가 뜨고 snapshot을 활성화(GREEN). 같은 데이터를 만료 clock으로 보면 경로검색 게이트가 fail closed, 신선 clock으로 보면 정상 serving(런타임 재평가).
    - `TimetableSeedLoaderTest.rejectsDisabledItxAndTamperedEvidenceBeforeWrites` — 무결성 실패(includes-itx 미설정, evidence 해시 변조, accessibility SQL 불일치)는 여전히 부팅 hard fail(negative).
    - `TimetableFreshnessMonitorTest` — 신선=UP/gauge 1, 만료=STALE/gauge 0(재시작 없이 clock만으로 전환), 활성 snapshot 없음=UNKNOWN.
    - `JdbcRouteTimetableRepositoryTest.rejectsExpiredActiveSnapshotAtRequestTime`(기존) — 요청 시점 만료 판정 회귀 유지.
    - `ProductionRouteApiClosureTest`·`HealthCheckControllerTest`·`EasySubwayBackendApplicationTests`(prod/staging full context) — 컨텍스트 기동 및 readiness UP 회귀 통과.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 만료 evidence 부팅 degraded | backend | Gradle 단위 테스트 | `TimetableSeedLoaderTest.staleSnapshotBootsAsLastKnownGoodAndDegradesRouteSearchAtRuntime` | PASS |
| 무결성 실패 hard fail 유지 | backend | Gradle 단위 테스트 | `TimetableSeedLoaderTest.rejectsDisabledItxAndTamperedEvidenceBeforeWrites` | PASS |
| 런타임 재평가(만료 전환) | backend | Gradle 단위 테스트 | `TimetableFreshnessMonitorTest`, `JdbcRouteTimetableRepositoryTest.rejectsExpiredActiveSnapshotAtRequestTime` | PASS |
| readiness 회귀(admin 미영향) | backend | prod/staging full-context 테스트 | `EasySubwayBackendApplicationTests`, `HealthCheckControllerTest` | PASS |
| 수동 QA/UI | - | 해당 없음 | 서버 사이드 운용 로직 변경으로 UI 영향 없음 | N/A |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음 (503 응답 코드/바디는 기존 `ITX_TIMETABLE_UNAVAILABLE` 유지)
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `TimetableSeedLoader`에서 무결성(hard fail)과 만료(비치명적 degraded)의 경계.
  - `JdbcRouteTimetableRepository`에서 활성화 readability(`hasActivatableRouteTimetable`, freshness 무관)와 serving 만료 판정(`activeItxArtifact`, Clock 필터)의 분리 — `hasRouteTimetable`은 serving 게이트(`RouteV2Planner`)에서 계속 freshness-aware로 쓰인다.
  - `TimetableFreshnessMonitor`의 `STALE` 상태가 status order(`down,out-of-service,degraded,stale,up,unknown`)상 UP보다 위이지만 HTTP 503으로 매핑되지 않고 readiness group 밖이라 admin·배포 probe에 영향이 없다는 점.

## 리스크

- 만료 상태 기동을 허용하므로 "만료된 데이터로 오래 서빙"을 막는 책임은 serving 경로(요청 시점 503)와 상위 이슈(#2333 자동 갱신, #2330 배포 전 사전검사)로 이동한다. 이 PR은 가용성 회복과 degraded 관측만 담당한다.
- `TimetableFreshnessMonitor`의 주기 재평가는 기본 60초 간격(`easysubway.timetable.freshness-check-interval-ms`)이며 요청 시점 만료 판정과 독립적이라, 관측 지표에는 최대 1분 지연이 있을 수 있다(serving 판정은 지연 없음).

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
