### PR TITLE
[CI] CD deploy job environment를 production-cd로 분리

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -231,7 +231,7 @@ jobs:
       contents: read
       packages: read
     environment:
-      name: production
+      name: production-cd
       url: ${{ vars.DEPLOY_PUBLIC_API_BASE_URL }}
     concurrency:
       group: cd-production-deploy

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1314,13 +1314,14 @@ test("백엔드 배포는 GHCR digest를 pull하고 서버 위 build 경로를 �
   assert.match(deploy, /current-image-digest/);
 });
 
-test("CD 배포는 production environment를 선언하고 배포 태그는 record-deploy 잡만 기록한다", () => {
+test("CD 배포는 production-cd environment를 선언하고 배포 태그는 record-deploy 잡만 기록한다", () => {
   const cd = read(".github/workflows/cd.yml");
   const cleanup = read(".github/workflows/actions-storage-cleanup.yml");
 
-  // production environment gives the deploy GitHub deployment history and lets a
-  // branch protection rule (deployment branches = main) apply (issue #1687).
-  assert.match(cd, /environment:\n\s*name: production\n\s*url: \$\{\{ vars\.DEPLOY_PUBLIC_API_BASE_URL \}\}/);
+  // production-cd environment gives the deploy GitHub deployment history without
+  // requiring manual review; the production environment stays reserved as the
+  // required-reviewer gate for sensitive workflows (issue #1687, #2350).
+  assert.match(cd, /environment:\n\s*name: production-cd\n\s*url: \$\{\{ vars\.DEPLOY_PUBLIC_API_BASE_URL \}\}/);
   assert.match(cd, /outputs:\n\s*sha: \$\{\{ steps\.target\.outputs\.sha \}\}/);
 
   // A lightweight deploy/backend/* tag records the deployed sha on GitHub.


### PR DESCRIPTION
## 관련 이슈

close #2350

## 작업 배경

- 2026-07-20 장애 복구 과정에서 CD `deploy` job의 `production` GitHub Environment(required reviewers) 승인 대기가 복구 시간을 지연시켰다.
- 배포 전 timetable snapshot freshness 사전 검사(#2330)와 자동 갱신 워크플로(#2333), required CI·PR Review 게이트가 이미 배포 안전을 담보해 수동 승인의 한계 효용이 낮아졌다.
- 오너 결정(2026-07-20): CD `deploy` job만 승인 불요 environment로 분리하고, 기존 `production` environment는 민감 워크플로(Sensitive backup retention, Production route API closure evidence)의 게이트로 유지한다.
- 사전 작업(별도 세션): environment `production-cd` 생성(protection rule 없음), variable `DEPLOY_COMPOSE_PROJECT`/`DEPLOY_ROOT` 복사, secret `EASYSUBWAY_ENV` 주입 완료.

## 작업 내용

- `.github/workflows/cd.yml`의 `deploy` job `environment.name`을 `production` → `production-cd`로 전환했다. `url` 등 나머지 설정은 유지했다.
- `cd.yml`의 다른 job(`plan`, `build-image`, `post-deploy-smoke`, `record-deploy`, `notify-slack-cd-result`)과 다른 워크플로 파일(`sensitive-backup-retention.yml`, `production-route-api-closure-evidence.yml`, `production-route-v2-capacity-evidence.yml`, `production-timetable-snapshot-evidence.yml`)의 `environment: production` 참조는 전수 확인 후 변경하지 않았다.
- `tools/ci/repository-contract.test.mjs`의 CD environment 계약 테스트 기대값을 `production-cd`로 갱신했다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/repository-contract.test.mjs` → 219개 중 218 pass, 1 fail(`Android v1 production 데이터팩 scope는 수도권 pilot 승인 기준을 고정한다`, 이 브랜치와 무관한 datapack scope 해시 불일치 — 수정 전 `origin/main` 체크아웃에서도 동일하게 재현되는 기존 실패로 확인).
  - `ruby -ryaml -e "YAML.load_file('.github/workflows/cd.yml')"` → YAML 구문 정상, `jobs.deploy.environment` 값이 `{"name"=>"production-cd", "url"=>"${{ vars.DEPLOY_PUBLIC_API_BASE_URL }}"}`임을 확인.
  - `gh api repos/:owner/:repo/environments/production-cd/variables` → `DEPLOY_COMPOSE_PROJECT`, `DEPLOY_ROOT` 2개 variable 존재 확인(이름만, 값 미접근).
  - `gh api repos/:owner/:repo/environments/production-cd/secrets` → `EASYSUBWAY_ENV` secret 1개 존재 확인(이름만, 값 미접근).
  - `grep -n "environment:" .github/workflows/cd.yml` → 233행 `deploy` job 1건만 존재함을 확인.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| CD deploy job environment 전환 | GitHub Actions | `tools/ci/repository-contract.test.mjs` 계약 테스트 | 위 검증 명령 출력 | PASS |
| production-cd environment secret/variable 존재 | GitHub Environments | `gh api .../environments/production-cd/{variables,secrets}` | 위 검증 명령 출력(이름만) | PASS |
| 이 PR의 CD workflow 실제 실행이 승인 대기 없이 진행 | GitHub Actions | PR push 이후 Actions 탭에서 `CD` workflow run 상태 확인 | PR 코멘트로 링크 추가 예정 | 확인 예정 |

## Version impact

- [x] no version change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `cd.yml` 233행 `deploy` job의 `environment.name`만 바뀌었는지, 다른 job·다른 워크플로 파일의 `environment: production` 참조가 그대로 남아 있는지 diff로 확인해 달라.

## 리스크

- deploy job이 더 이상 수동 승인을 거치지 않으므로, main에 머지된 커밋은 CI·사전검사·자동갱신 게이트를 통과하는 즉시 production 서버에 자동 배포된다. 배포 전 freshness 사전 검사(#2330)와 자동 갱신(#2333)이 서비스 중단을 방지하는 1차 안전장치로 작동한다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
