### PR TITLE
[Style] #2349 통합 대시보드 과업 우선 재구성 (PR⑦)

### DIFF
--- a/backend/src/main/java/com/easysubway/admin/adapter/in/web/AdminOverviewPageController.java
+++ b/backend/src/main/java/com/easysubway/admin/adapter/in/web/AdminOverviewPageController.java
@@ -262,10 +262,12 @@ class AdminOverviewPageController {
 		return "%.1f%%".formatted((double) summary.blockedCount() * 100 / summary.totalCount());
 	}
 
-	// 데이터팩 출시 준비 상세 표(#2349): 후보 게이트·별칭·격리·수동 오버라이드·시설 근거·경로 게이트·
-	// 매니페스트 서명 7개 차단 요인 카테고리 중 0건은 숨기고 비-0만 노출한다(뷰 모델 한정 가공,
-	// DatapackReleaseBlockerSummaryUseCase 집계 로직은 변경하지 않는다).
-	private static final int DATAPACK_BLOCKER_ROW_TOTAL = 7;
+	// 데이터팩 출시 준비 상세 표(#2349, #2352 리뷰로 10개로 확장): 후보 게이트·별칭·격리·소스 최신성·
+	// 수동 오버라이드·시설 근거·경로 게이트·콜백 정합성 확인·증거 번들 검증·매니페스트 서명 10개 차단 요인
+	// 카테고리 중 0건은 숨기고 비-0만 노출한다(뷰 모델 한정 가공, DatapackReleaseBlockerSummaryUseCase
+	// 집계 로직은 변경하지 않는다). 10개 행의 합은 항상 datapackReleaseSummary.totalBlockers()와
+	// 일치해야 한다(트리아지 카드·blocker-total 표기와의 정합, #2352 리뷰 지적).
+	private static final int DATAPACK_BLOCKER_ROW_TOTAL = 10;
 
 	private static List<DatapackBlockerRow> datapackBlockerRows(
 		DatapackReleaseBlockerSummaryUseCase.DatapackReleaseBlockerSummary summary
@@ -277,9 +279,14 @@ class AdminOverviewPageController {
 		addBlockerRow(rows, "후보 게이트", summary.candidateGateBlockers());
 		addBlockerRow(rows, "별칭", summary.aliasBlockers());
 		addBlockerRow(rows, "격리", summary.quarantineBlockers());
+		addBlockerRow(rows, "소스 최신성", summary.sourceFreshnessBlockers());
 		addBlockerRow(rows, "수동 오버라이드", summary.manualOverrideBlockers());
 		addBlockerRow(rows, "시설 근거", summary.facilityBlockers());
 		addBlockerRow(rows, "경로 게이트", summary.routeGateBlockers());
+		addBlockerRow(rows, "콜백 정합성 확인", summary.callbackReconciliationBlockers());
+		// "증거 번들" 단독 라벨은 위 sha·워크플로 상세 표의 evidenceBundleSha256 행(같은 details 안,
+		// 같은 <th scope="row">증거 번들</th> 마크업)과 충돌해 "증거 번들 검증"으로 구분한다(#2352 리뷰).
+		addBlockerRow(rows, "증거 번들 검증", summary.evidenceBundleBlockers());
 		addBlockerRow(rows, "매니페스트 서명", summary.manifestBlockers());
 		return rows;
 	}

--- a/backend/src/main/java/com/easysubway/admin/adapter/in/web/AdminOverviewPageController.java
+++ b/backend/src/main/java/com/easysubway/admin/adapter/in/web/AdminOverviewPageController.java
@@ -120,13 +120,20 @@ class AdminOverviewPageController {
 			health.status(),
 			health.service()
 		));
+		// 데이터팩 출시 준비: 권한 있을 때만 조회. 상세 표의 차단 요인 행은 0건을 숨기고 비-0만 노출한다(#2349).
+		DatapackReleaseBlockerSummaryUseCase.DatapackReleaseBlockerSummary datapackSummary = null;
 		if (AdminAuthorization.hasPermission(authentication, AdminPermission.DATAPACK_READ)) {
-			model.addAttribute("datapackReleaseSummary", datapackReleaseBlockerSummaryUseCase.summarize());
+			datapackSummary = datapackReleaseBlockerSummaryUseCase.summarize();
+			model.addAttribute("datapackReleaseSummary", datapackSummary);
 		}
+		List<DatapackBlockerRow> datapackBlockerRows = datapackBlockerRows(datapackSummary);
+		model.addAttribute("datapackBlockerRows", datapackBlockerRows);
+		model.addAttribute("datapackHiddenBlockerRowCount", DATAPACK_BLOCKER_ROW_TOTAL - datapackBlockerRows.size());
 
 		// 핵심 카드: 현재 값 + 7일 스파크라인 + 전일 대비. 화면 권한이 있는 카드만 노출(역할 인지).
 		long pending = count(reportCounts, FacilityReportStatus.SUBMITTED)
 			+ count(reportCounts, FacilityReportStatus.UNDER_REVIEW);
+		long needsVerification = quality.needsVerificationFacilityCount();
 		double blockedRate = routes.totalCount() == 0
 			? 0.0 : (double) routes.blockedCount() * 100 / routes.totalCount();
 		List<AdminProgram> visible = AdminProgram.visibleTo(authentication);
@@ -136,7 +143,6 @@ class AdminOverviewPageController {
 				AdminMetricKeys.REPORTS_PENDING, pending, String.valueOf(pending)));
 		}
 		if (visible.contains(AdminProgram.FACILITIES)) {
-			long needsVerification = quality.needsVerificationFacilityCount();
 			cards.add(dashboardCardService.card("확인 필요 시설", AdminProgram.FACILITIES.path(),
 				AdminMetricKeys.FACILITIES_NEEDS_VERIFICATION, needsVerification, String.valueOf(needsVerification)));
 		}
@@ -149,6 +155,20 @@ class AdminOverviewPageController {
 				AdminMetricKeys.PUSH_FAILED, push.failedCount(), String.valueOf(push.failedCount())));
 		}
 		model.addAttribute("cards", cards);
+
+		// 확인 필요(#2349): 트리아지 최우선 통합 카드. 제보·시설·데이터팩 차단 요인 중 0건인 항목은 뺀다.
+		List<TriageItem> triageItems = new ArrayList<>();
+		if (visible.contains(AdminProgram.REPORTS) && pending > 0) {
+			triageItems.add(new TriageItem("확인할 제보", AdminProgram.REPORTS.path(), pending));
+		}
+		if (visible.contains(AdminProgram.FACILITIES) && needsVerification > 0) {
+			triageItems.add(new TriageItem("확인 필요 시설", AdminProgram.FACILITIES.path(), needsVerification));
+		}
+		if (datapackSummary != null && datapackSummary.totalBlockers() > 0) {
+			triageItems.add(new TriageItem(
+				"데이터팩 차단 요인", "#dashboard-datapack-readiness", datapackSummary.totalBlockers()));
+		}
+		model.addAttribute("triageItems", triageItems);
 
 		// 긴급 줄: 알림 센터 신호 요약(있을 때만). 지표 스냅샷 마지막 실행 상태.
 		model.addAttribute("alertSummary", alertService.summarize(authentication));
@@ -240,6 +260,41 @@ class AdminOverviewPageController {
 			return "0.0%";
 		}
 		return "%.1f%%".formatted((double) summary.blockedCount() * 100 / summary.totalCount());
+	}
+
+	// 데이터팩 출시 준비 상세 표(#2349): 후보 게이트·별칭·격리·수동 오버라이드·시설 근거·경로 게이트·
+	// 매니페스트 서명 7개 차단 요인 카테고리 중 0건은 숨기고 비-0만 노출한다(뷰 모델 한정 가공,
+	// DatapackReleaseBlockerSummaryUseCase 집계 로직은 변경하지 않는다).
+	private static final int DATAPACK_BLOCKER_ROW_TOTAL = 7;
+
+	private static List<DatapackBlockerRow> datapackBlockerRows(
+		DatapackReleaseBlockerSummaryUseCase.DatapackReleaseBlockerSummary summary
+	) {
+		if (summary == null) {
+			return List.of();
+		}
+		List<DatapackBlockerRow> rows = new ArrayList<>();
+		addBlockerRow(rows, "후보 게이트", summary.candidateGateBlockers());
+		addBlockerRow(rows, "별칭", summary.aliasBlockers());
+		addBlockerRow(rows, "격리", summary.quarantineBlockers());
+		addBlockerRow(rows, "수동 오버라이드", summary.manualOverrideBlockers());
+		addBlockerRow(rows, "시설 근거", summary.facilityBlockers());
+		addBlockerRow(rows, "경로 게이트", summary.routeGateBlockers());
+		addBlockerRow(rows, "매니페스트 서명", summary.manifestBlockers());
+		return rows;
+	}
+
+	private static void addBlockerRow(List<DatapackBlockerRow> rows, String label, long count) {
+		if (count > 0) {
+			rows.add(new DatapackBlockerRow(label, count));
+		}
+	}
+
+	// 확인 필요 통합 카드(#2349)의 행 하나. count는 항상 0보다 크다(0건 항목은 컨트롤러에서 걸러진다).
+	record TriageItem(String label, String href, long count) {
+	}
+
+	record DatapackBlockerRow(String label, long count) {
 	}
 
 	record DashboardView(

--- a/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcDatapackReleaseBlockerSummaryRepository.java
+++ b/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcDatapackReleaseBlockerSummaryRepository.java
@@ -96,6 +96,8 @@ public class JdbcDatapackReleaseBlockerSummaryRepository implements DatapackRele
 			manualOverrideBlockers,
 			facilityBlockers,
 			routeGateBlockers,
+			callbackReconciliationBlockers,
+			evidenceBundle.otherBlockerCount(),
 			manifestSignature.blockerCount(),
 			readinessRows(
 				candidate,
@@ -454,6 +456,12 @@ public class JdbcDatapackReleaseBlockerSummaryRepository implements DatapackRele
 
 		long androidBlocker() {
 			return statusBlocker(androidEvidenceStatus);
+		}
+
+		// blockerCount() 중 매니페스트 서명(manifestSignature)을 제외한 나머지 증거 번들 차단 요인.
+		// 대시보드 상세 표의 "매니페스트 서명" 행과 중복 집계하지 않기 위해 분리한다(#2352 리뷰).
+		long otherBlockerCount() {
+			return validatorBlocker() + routeRegressionBlocker() + androidBlocker();
 		}
 
 		ManifestSignatureSummary manifestSignature() {

--- a/backend/src/main/java/com/easysubway/datapack/application/port/in/DatapackReleaseBlockerSummaryUseCase.java
+++ b/backend/src/main/java/com/easysubway/datapack/application/port/in/DatapackReleaseBlockerSummaryUseCase.java
@@ -27,6 +27,8 @@ public interface DatapackReleaseBlockerSummaryUseCase {
 		long manualOverrideBlockers,
 		long facilityBlockers,
 		long routeGateBlockers,
+		long callbackReconciliationBlockers,
+		long evidenceBundleBlockers,
 		long manifestBlockers,
 		List<ReleaseReadinessRow> readinessRows,
 		LocalDateTime candidateCreatedAt
@@ -43,6 +45,8 @@ public interface DatapackReleaseBlockerSummaryUseCase {
 				"-",
 				"-",
 				"확인 필요",
+				0,
+				0,
 				0,
 				0,
 				0,

--- a/backend/src/main/resources/static/css/admin-data.css
+++ b/backend/src/main/resources/static/css/admin-data.css
@@ -76,6 +76,47 @@
 	font-size: 12px;
 }
 
+/* 확인 필요 통합 카드(#2349): 트리아지 최우선 영역. 상태 톤 구분 없이 플랫 행+1px 구분선만 쓴다
+   (긴급 신호와 달리 심각도가 아니라 "해야 할 일" 목록이라 tone 마커를 붙이지 않는다). */
+.dashboard-triage-list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.dashboard-triage-list li + li {
+	border-top: 1px solid var(--admin-border);
+}
+
+.dashboard-triage-list a {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	padding: 10px 2px;
+	text-decoration: none;
+	color: var(--admin-ink);
+}
+
+.dashboard-triage-list a:hover .dashboard-triage-label {
+	color: var(--admin-accent);
+}
+
+.dashboard-triage-count {
+	font-variant-numeric: tabular-nums;
+}
+
+/* 전부 0건일 때 카드 대신 보여주는 한 줄 상태 텍스트(#2349). 인접 섹션과 리듬을 맞춘다. */
+.dashboard-triage-empty {
+	margin: 0 0 24px;
+}
+
+/* 데이터팩 출시 준비 | 운영 이상 신호 2열(#2349): 데이터팩 권한이 없는 계정은 운영 이상 신호만
+   단독 폭으로 렌더한다. */
+.dashboard-readiness-grid.is-single {
+	grid-template-columns: 1fr;
+}
+
 /* 핵심 지표 그리드(#1983): .admin-panel 하나 안에서 3열 반응형(최대 3열)으로 배치하고,
    카드 자체는 보더·그림자 없이 .metric-cell 좌측 1px 구분선으로만 나뉜다(패널 보더 중복 방지).
    좁은 화면에서는 하단 미디어쿼리로 2열 → 1열로 줄어든다(각 행 첫 열은 구분선 제외). */

--- a/backend/src/main/resources/templates/admin/dashboard.html
+++ b/backend/src/main/resources/templates/admin/dashboard.html
@@ -149,8 +149,10 @@
 					</tbody>
 				</table>
 				</div>
-				<!-- 차단 요인 상세(#2349 노이즈 제거): 7개 차단 요인 카테고리(datapackBlockerRows) 중
-				     0건은 숨기고 비-0만 노출한다. 숨긴 건수는 아래 요약 줄, 전부 숨었으면 빈 상태로 대체한다. -->
+				<!-- 차단 요인 상세(#2349 노이즈 제거, #2352 리뷰로 10개로 확장): 10개 차단 요인 카테고리
+				     (datapackBlockerRows) 중 0건은 숨기고 비-0만 노출한다. 숨긴 건수는 아래 요약 줄, 전부
+				     숨었으면 빈 상태로 대체한다. 10개 행의 합은 항상 datapackReleaseSummary.totalBlockers()
+				     (위 트리아지 카드·blocker-total)와 일치한다. -->
 				<th:block th:if="${!datapackBlockerRows.isEmpty()}">
 				<div class="admin-table-scroll" tabindex="0" role="group"
 				     aria-label="가로로 스크롤 가능한 데이터 표">

--- a/backend/src/main/resources/templates/admin/dashboard.html
+++ b/backend/src/main/resources/templates/admin/dashboard.html
@@ -34,14 +34,35 @@
 
 	<div th:replace="~{admin/fragments/shell :: flash}"></div>
 
-	<!-- 긴급 줄: 알림 센터 신호 요약(있을 때만). 각 신호는 처리 화면으로 딥링크. -->
-	<section class="dashboard-urgent" th:if="${alertSummary.hasAlerts()}" aria-label="긴급 신호">
-		<a th:each="item : ${alertSummary.items}" class="dashboard-urgent-item"
+	<!-- 확인 필요(#2349): 트리아지 최우선 통합 카드. 확인할 제보·확인 필요 시설·데이터팩 차단 요인 중
+	     0건인 항목은 행 자체를 뺀다. 전부 0(또는 권한 밖)이면 카드 대신 한 줄 상태 텍스트만 보여준다. -->
+	<section class="admin-panel dashboard-triage-panel" aria-labelledby="dashboard-triage-title"
+	          th:if="${!triageItems.isEmpty()}">
+		<div class="admin-panel-head">
+			<h2 id="dashboard-triage-title">확인 필요</h2>
+		</div>
+		<ul class="dashboard-triage-list">
+			<li th:each="item : ${triageItems}">
+				<a th:href="@{${item.href}}">
+					<span class="dashboard-triage-label" th:text="${item.label}">라벨</span>
+					<strong class="dashboard-triage-count cell-num" th:text="|${item.count}건|">0건</strong>
+				</a>
+			</li>
+		</ul>
+	</section>
+	<p th:if="${triageItems.isEmpty()}" class="admin-status good dashboard-triage-empty">지금 확인할 항목이 없습니다</p>
+
+	<!-- 긴급 줄: 알림 센터 신호 요약(있을 때만). 데이터팩 blocker 신호는 위 확인 필요 카드와
+	     같은 값을 중복 서술하므로 이 화면에서는 뺀다(#2349 blocker 이중 노출 해소). -->
+	<th:block th:with="dashboardUrgentItems=${alertSummary.items.?[id != 'datapack-blocker']}">
+	<section class="dashboard-urgent" th:if="${!dashboardUrgentItems.isEmpty()}" aria-label="긴급 신호">
+		<a th:each="item : ${dashboardUrgentItems}" class="dashboard-urgent-item"
 		   th:classappend="${' tone-' + item.tone}" th:href="@{${item.href}}">
 			<strong th:text="${item.label}">신호</strong>
 			<small th:text="${item.detail}">설명</small>
 		</a>
 	</section>
+	</th:block>
 
 	<!-- 핵심 지표 패널(#2281 V6-09): 시점·비율 대표 KPI만 headline으로 노출하고 누계 총량 지표는
 	     disclosure로 격하해 urgent state를 먼저 식별하게 한다. 각 셀 = 흐린 라벨 + 큰 숫자(tabular-nums)
@@ -85,60 +106,70 @@
 		<div th:replace="~{admin/fragments/dashboard-trends :: section}"></div>
 	</div>
 
-	<section class="admin-panel" th:if="${datapackReleaseSummary != null}">
-		<div class="admin-panel-head">
-			<h2>데이터팩 출시 준비</h2>
-			<a th:if="${adminProgramIds.contains('a-datapack-candidates')}"
-			   class="admin-link" th:href="@{/admin/datapack/candidates/page}">파이프라인 보기</a>
-		</div>
-		<p class="summary">
-			<strong th:text="${datapackReleaseSummary.candidateId}">candidate-id</strong>
-			<span th:replace="~{admin/fragments/shell :: status(${datapackReleaseSummary.status}, ${datapackReleaseSummary.status == 'READY' || datapackReleaseSummary.status == 'PASS' ? 'good' : (datapackReleaseSummary.status == 'FAIL' ? 'bad' : 'warn')})}">FAIL</span>
-		</p>
-		<p class="summary" th:text="${datapackReleaseSummary.productionPromoteReason()}">프로덕션 반영 차단: 차단 요인 0건</p>
-		<!-- 차단 요인 내역(#2047 오너 지적): 원자 항목 사이 구분선 제거 → 촘촘한 key-value 목록(라벨 좌·값 우,
-		     값 tabular-nums). "전체 차단 요인 N건"은 소계라 굵기·상단 여백으로만 위계를 준다(선 없음). -->
-		<p class="blocker-total" th:text="|전체 차단 요인 ${datapackReleaseSummary.totalBlockers}건|">전체 차단 요인 0건</p>
-		<dl class="blocker-breakdown">
-			<div><dt>별칭</dt><dd th:text="${datapackReleaseSummary.aliasBlockers}">0</dd></div>
-			<div><dt>격리</dt><dd th:text="${datapackReleaseSummary.quarantineBlockers}">0</dd></div>
-			<div><dt>수동 오버라이드</dt><dd th:text="${datapackReleaseSummary.manualOverrideBlockers}">0</dd></div>
-			<div><dt>경로 게이트</dt><dd th:text="${datapackReleaseSummary.routeGateBlockers}">0</dd></div>
-		</dl>
-		<!-- sha·workflow 상세 13행은 기본 접힘으로 격하(추세·요약을 앞세운다). -->
-		<details class="dashboard-details">
-			<summary>상세 해시·워크플로 보기</summary>
-			<div class="admin-table-scroll" tabindex="0" role="group"
-			     aria-label="가로로 스크롤 가능한 데이터 표">
-			<table>
-				<tbody>
-				<tr><th scope="row">범위</th><td th:text="${datapackReleaseSummary.scopeId}">범위</td></tr>
-				<tr><th scope="row">원천 스냅샷 세트</th><td th:text="${datapackReleaseSummary.sourceSnapshotSetHash}">sha</td></tr>
-				<tr><th scope="row">매니페스트</th><td th:text="${datapackReleaseSummary.manifestSha256}">sha</td></tr>
-				<tr><th scope="row">증거 번들</th><td th:text="${datapackReleaseSummary.evidenceBundleSha256}">sha</td></tr>
-				<tr><th scope="row">증거 워크플로</th><td th:text="${datapackReleaseSummary.evidenceWorkflowRunUrl}">workflow</td></tr>
-				<tr><th scope="row">현재 프로덕션</th><td th:text="${datapackReleaseSummary.productionCandidateId}">candidate</td></tr>
-				<tr><th scope="row">롤백 대상</th><td th:text="${datapackReleaseSummary.rollbackCandidateId}">candidate</td></tr>
-				<tr><th scope="row">후보 게이트</th><td th:text="${datapackReleaseSummary.candidateGateBlockers}">0</td></tr>
-				<tr><th scope="row">별칭</th><td th:text="${datapackReleaseSummary.aliasBlockers}">0</td></tr>
-				<tr><th scope="row">격리</th><td th:text="${datapackReleaseSummary.quarantineBlockers}">0</td></tr>
-				<tr><th scope="row">수동 오버라이드</th><td th:text="${datapackReleaseSummary.manualOverrideBlockers}">0</td></tr>
-				<tr><th scope="row">시설 근거</th><td th:text="${datapackReleaseSummary.facilityBlockers}">0</td></tr>
-				<tr><th scope="row">경로 게이트</th><td th:text="${datapackReleaseSummary.routeGateBlockers}">0</td></tr>
-				<tr><th scope="row">매니페스트 서명</th><td th:text="${datapackReleaseSummary.manifestBlockers}">0</td></tr>
-				</tbody>
-			</table>
-			</div>
-		</details>
-	</section>
-
-	<div class="admin-grid-2">
-		<section class="admin-panel" th:if="${adminProgramIds.contains('a-reports')}">
+	<!-- 상세 섹션(#2349): 데이터팩 릴리스 준비 패널 | 운영 이상 신호 2열. 데이터팩 권한이 없으면 운영 이상
+	     신호만 단독 폭으로 렌더한다(is-single). -->
+	<div class="admin-grid-2 dashboard-readiness-grid"
+	     th:classappend="${datapackReleaseSummary == null} ? ' is-single' : ''">
+		<section class="admin-panel" id="dashboard-datapack-readiness" th:if="${datapackReleaseSummary != null}">
 			<div class="admin-panel-head">
-				<h2>먼저 확인할 제보</h2>
+				<h2>데이터팩 출시 준비</h2>
+				<a th:if="${adminProgramIds.contains('a-datapack-candidates')}"
+				   class="admin-link" th:href="@{/admin/datapack/candidates/page}">파이프라인 보기</a>
 			</div>
-			<p class="summary">확인할 제보는 제보 확인 대기열에서 상태·사진·위치를 함께 확인합니다.</p>
-			<a class="admin-btn outline" th:href="@{/admin/reports/page}">제보 확인 대기열 열기</a>
+			<p class="summary">
+				<!-- 후보가 없으면 candidateId는 "-" placeholder다. 상태 뱃지 앞 "- ●"로 겹쳐 보이던
+				     잔존 표기를 결측 규칙(—)으로 정리한다(#2349). -->
+				<strong th:text="${datapackReleaseSummary.candidateId == '-'} ? '—' : ${datapackReleaseSummary.candidateId}">candidate-id</strong>
+				<span th:replace="~{admin/fragments/shell :: status(${datapackReleaseSummary.status}, ${datapackReleaseSummary.status == 'READY' || datapackReleaseSummary.status == 'PASS' ? 'good' : (datapackReleaseSummary.status == 'FAIL' ? 'bad' : 'warn')})}">FAIL</span>
+			</p>
+			<p class="summary" th:text="${datapackReleaseSummary.productionPromoteReason()}">프로덕션 반영 차단: 차단 요인 0건</p>
+			<!-- 차단 요인 내역(#2047 오너 지적): 원자 항목 사이 구분선 제거 → 촘촘한 key-value 목록(라벨 좌·값 우,
+			     값 tabular-nums). "전체 차단 요인 N건"은 소계라 굵기·상단 여백으로만 위계를 준다(선 없음). -->
+			<p class="blocker-total" th:text="|전체 차단 요인 ${datapackReleaseSummary.totalBlockers}건|">전체 차단 요인 0건</p>
+			<dl class="blocker-breakdown">
+				<div><dt>별칭</dt><dd th:text="${datapackReleaseSummary.aliasBlockers}">0</dd></div>
+				<div><dt>격리</dt><dd th:text="${datapackReleaseSummary.quarantineBlockers}">0</dd></div>
+				<div><dt>수동 오버라이드</dt><dd th:text="${datapackReleaseSummary.manualOverrideBlockers}">0</dd></div>
+				<div><dt>경로 게이트</dt><dd th:text="${datapackReleaseSummary.routeGateBlockers}">0</dd></div>
+			</dl>
+			<!-- sha·workflow 상세는 기본 접힘으로 격하(추세·요약을 앞세운다). -->
+			<details class="dashboard-details">
+				<summary>상세 해시·워크플로 보기</summary>
+				<div class="admin-table-scroll" tabindex="0" role="group"
+				     aria-label="가로로 스크롤 가능한 데이터 표">
+				<table>
+					<tbody>
+					<tr><th scope="row">범위</th><td th:text="${datapackReleaseSummary.scopeId}">범위</td></tr>
+					<tr><th scope="row">원천 스냅샷 세트</th><td th:text="${datapackReleaseSummary.sourceSnapshotSetHash}">sha</td></tr>
+					<tr><th scope="row">매니페스트</th><td th:text="${datapackReleaseSummary.manifestSha256}">sha</td></tr>
+					<tr><th scope="row">증거 번들</th><td th:text="${datapackReleaseSummary.evidenceBundleSha256}">sha</td></tr>
+					<tr><th scope="row">증거 워크플로</th><td th:text="${datapackReleaseSummary.evidenceWorkflowRunUrl}">workflow</td></tr>
+					<tr><th scope="row">현재 프로덕션</th><td th:text="${datapackReleaseSummary.productionCandidateId}">candidate</td></tr>
+					<tr><th scope="row">롤백 대상</th><td th:text="${datapackReleaseSummary.rollbackCandidateId}">candidate</td></tr>
+					</tbody>
+				</table>
+				</div>
+				<!-- 차단 요인 상세(#2349 노이즈 제거): 7개 차단 요인 카테고리(datapackBlockerRows) 중
+				     0건은 숨기고 비-0만 노출한다. 숨긴 건수는 아래 요약 줄, 전부 숨었으면 빈 상태로 대체한다. -->
+				<th:block th:if="${!datapackBlockerRows.isEmpty()}">
+				<div class="admin-table-scroll" tabindex="0" role="group"
+				     aria-label="가로로 스크롤 가능한 데이터 표">
+				<table>
+					<tbody>
+					<tr th:each="row : ${datapackBlockerRows}">
+						<th scope="row" th:text="${row.label}">라벨</th>
+						<td th:text="${row.count}">0</td>
+					</tr>
+					</tbody>
+				</table>
+				</div>
+				</th:block>
+				<p class="summary" th:if="${datapackHiddenBlockerRowCount > 0 and !datapackBlockerRows.isEmpty()}"
+				   th:text="|그 외 항목 ${datapackHiddenBlockerRowCount}건은 0건입니다|">그 외 항목 0건</p>
+				<th:block th:if="${datapackBlockerRows.isEmpty()}">
+				<div th:replace="~{admin/fragments/empty-state :: panel('차단 요인이 없습니다.', null)}"></div>
+				</th:block>
+			</details>
 		</section>
 		<section class="admin-panel" aria-labelledby="dashboard-health-title">
 			<div class="admin-panel-head">

--- a/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminDashboardTriagePanelTest.java
+++ b/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminDashboardTriagePanelTest.java
@@ -1,0 +1,217 @@
+package com.easysubway.admin.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.easysubway.datapack.application.port.in.DatapackReleaseBlockerSummaryUseCase;
+import com.easysubway.datapack.application.port.in.DatapackReleaseBlockerSummaryUseCase.DatapackReleaseBlockerSummary;
+import com.easysubway.quality.application.port.in.DataQualityUseCase;
+import com.easysubway.quality.domain.DataQualitySummary;
+import com.easysubway.report.application.port.in.FacilityReportUseCase;
+import com.easysubway.report.domain.FacilityReportStatus;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * "확인 필요" 통합 트리아지 카드(#2349 PR⑦) 렌더링 검증. 실제 DB 상태로는 제보·시설·데이터팩
+ * 차단 요인 건수를 결정적으로 만들기 어려워, {@link AdminAlertRenderingTest}와 같은 패턴으로
+ * 값을 주입하는 use case를 대체(MockBean)해 0건 생략·전부 0 폴백·데이터팩 상세 표의 0건 행 숨김을 고정한다.
+ */
+@SpringBootTest(properties = {
+	"easysubway.admin.username=admin-test",
+	"easysubway.admin.password=admin-test-password"
+})
+@AutoConfigureMockMvc
+@DisplayName("통합 대시보드 확인 필요 카드")
+class AdminDashboardTriagePanelTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockBean
+	private FacilityReportUseCase facilityReportUseCase;
+
+	@MockBean
+	private DataQualityUseCase dataQualityUseCase;
+
+	@MockBean
+	private DatapackReleaseBlockerSummaryUseCase datapackReleaseBlockerSummaryUseCase;
+
+	@Test
+	@DisplayName("0건이 아닌 항목만 라벨·건수·딥링크로 보여준다")
+	void showsOnlyNonZeroItemsWithDeepLinks() throws Exception {
+		when(facilityReportUseCase.countReportsByStatus())
+			.thenReturn(Map.of(FacilityReportStatus.SUBMITTED, 5L));
+		when(facilityReportUseCase.countReportsCreatedSince(any())).thenReturn(0L);
+		when(dataQualityUseCase.summarizeDataQuality()).thenReturn(dataQualitySummary(0));
+		when(datapackReleaseBlockerSummaryUseCase.summarize()).thenReturn(blockerSummary(0, 0, 0, 0, 0, 0, 0));
+
+		String triage = triageSection(fetchDashboard());
+
+		assertThat(triage)
+			.contains("확인할 제보")
+			.contains(">5건<")
+			.contains("href=\"/admin/reports/page\"")
+			// 확인 필요 시설·데이터팩 차단 요인은 0건이라 딥링크 자체가 빠진다(라벨 텍스트는 섹션
+			// 안내 주석에도 나오므로 href로 스코핑한다).
+			.doesNotContain("href=\"/admin/facilities/page\"")
+			.doesNotContain("href=\"#dashboard-datapack-readiness\"");
+	}
+
+	@Test
+	@DisplayName("전부 0건이면 카드 대신 한 줄 상태 텍스트만 보여준다")
+	void fallsBackToOneLineStatusWhenAllZero() throws Exception {
+		when(facilityReportUseCase.countReportsByStatus()).thenReturn(Map.of());
+		when(facilityReportUseCase.countReportsCreatedSince(any())).thenReturn(0L);
+		when(dataQualityUseCase.summarizeDataQuality()).thenReturn(dataQualitySummary(0));
+		when(datapackReleaseBlockerSummaryUseCase.summarize()).thenReturn(blockerSummary(0, 0, 0, 0, 0, 0, 0));
+
+		String html = fetchDashboard();
+
+		assertThat(html)
+			.contains("class=\"admin-status good dashboard-triage-empty\"")
+			.contains("지금 확인할 항목이 없습니다")
+			.doesNotContain("id=\"dashboard-triage-title\"");
+	}
+
+	@Test
+	@DisplayName("데이터팩 차단 요인 상세 표는 0건 카테고리를 숨기고 비-0만 노출한 뒤 숨긴 건수를 요약한다")
+	void datapackBlockerDetailHidesZeroRowsAndSummarizesHidden() throws Exception {
+		when(facilityReportUseCase.countReportsByStatus()).thenReturn(Map.of());
+		when(facilityReportUseCase.countReportsCreatedSince(any())).thenReturn(0L);
+		when(dataQualityUseCase.summarizeDataQuality()).thenReturn(dataQualitySummary(0));
+		// 별칭 2건·매니페스트 서명 1건만 non-zero, 나머지 5개 카테고리(후보 게이트·격리·수동 오버라이드·
+		// 시설 근거·경로 게이트)는 0건.
+		when(datapackReleaseBlockerSummaryUseCase.summarize()).thenReturn(blockerSummary(2, 0, 0, 0, 0, 0, 1));
+
+		String details = blockerDetailsSection(fetchDashboard());
+
+		assertThat(details)
+			.contains("<th scope=\"row\">별칭</th>")
+			.contains("<th scope=\"row\">매니페스트 서명</th>")
+			.contains("그 외 항목 5건은 0건입니다")
+			.doesNotContain("<th scope=\"row\">후보 게이트</th>")
+			.doesNotContain("<th scope=\"row\">격리</th>")
+			.doesNotContain("<th scope=\"row\">수동 오버라이드</th>")
+			.doesNotContain("<th scope=\"row\">시설 근거</th>")
+			.doesNotContain("<th scope=\"row\">경로 게이트</th>")
+			.doesNotContain("차단 요인이 없습니다.");
+	}
+
+	@Test
+	@DisplayName("데이터팩 차단 요인이 전부 0건이면 상세 표 대신 빈 상태 문법을 적용한다")
+	void datapackBlockerDetailShowsEmptyStateWhenAllZero() throws Exception {
+		when(facilityReportUseCase.countReportsByStatus()).thenReturn(Map.of());
+		when(facilityReportUseCase.countReportsCreatedSince(any())).thenReturn(0L);
+		when(dataQualityUseCase.summarizeDataQuality()).thenReturn(dataQualitySummary(0));
+		when(datapackReleaseBlockerSummaryUseCase.summarize()).thenReturn(blockerSummary(0, 0, 0, 0, 0, 0, 0));
+
+		String details = blockerDetailsSection(fetchDashboard());
+
+		assertThat(details)
+			.contains("차단 요인이 없습니다.")
+			.doesNotContain("그 외 항목")
+			.doesNotContain("<th scope=\"row\">별칭</th>");
+	}
+
+	@Test
+	@DisplayName("후보가 없어 candidateId가 결측이면 - 원문 대신 — 로 표기한다")
+	void showsEmDashInsteadOfRawDashForMissingCandidateId() throws Exception {
+		when(facilityReportUseCase.countReportsByStatus()).thenReturn(Map.of());
+		when(facilityReportUseCase.countReportsCreatedSince(any())).thenReturn(0L);
+		when(dataQualityUseCase.summarizeDataQuality()).thenReturn(dataQualitySummary(0));
+		when(datapackReleaseBlockerSummaryUseCase.summarize()).thenReturn(DatapackReleaseBlockerSummary.empty());
+
+		String html = fetchDashboard();
+
+		assertThat(html)
+			.contains("<strong>—</strong>")
+			.doesNotContain("<strong>-</strong>");
+	}
+
+	private String fetchDashboard() throws Exception {
+		return mockMvc.perform(get("/admin/dashboard/page")
+				.with(httpBasic("admin-test", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+	}
+
+	private String triageSection(String html) {
+		int start = html.indexOf("<!-- 확인 필요");
+		int end = html.indexOf("<!-- 긴급 줄", start);
+		assertThat(start).as("확인 필요 영역 시작 마커").isGreaterThan(-1);
+		assertThat(end).as("긴급 줄 영역 시작 마커").isGreaterThan(start);
+		return html.substring(start, end);
+	}
+
+	private String blockerDetailsSection(String html) {
+		int start = html.indexOf("상세 해시·워크플로 보기");
+		int end = html.indexOf("</details>", start);
+		assertThat(start).as("데이터팩 상세 표 시작 지점").isGreaterThan(-1);
+		assertThat(end).as("데이터팩 상세 표 종료 지점").isGreaterThan(start);
+		return html.substring(start, end);
+	}
+
+	private static DataQualitySummary dataQualitySummary(long needsVerificationFacilityCount) {
+		return new DataQualitySummary(
+			0, 0, 0,
+			Map.of(),
+			List.of(),
+			Map.of(),
+			Map.of(),
+			needsVerificationFacilityCount,
+			0,
+			Map.of(),
+			0,
+			List.of(),
+			List.of()
+		);
+	}
+
+	private static DatapackReleaseBlockerSummary blockerSummary(
+		long alias,
+		long quarantine,
+		long manualOverride,
+		long routeGate,
+		long candidateGate,
+		long facility,
+		long manifest
+	) {
+		long total = alias + quarantine + manualOverride + routeGate + candidateGate + facility + manifest;
+		return new DatapackReleaseBlockerSummary(
+			"candidate-triage-test",
+			"scope-triage-test",
+			"a".repeat(64),
+			"b".repeat(64),
+			"c".repeat(64),
+			"https://github.com/AquilaXk/easysubway/actions/runs/1",
+			"candidate-prod-triage-test",
+			"candidate-rollback-triage-test",
+			total > 0 ? "FAIL" : "READY",
+			total,
+			candidateGate,
+			alias,
+			quarantine,
+			0,
+			manualOverride,
+			facility,
+			routeGate,
+			manifest,
+			List.of(),
+			null
+		);
+	}
+}

--- a/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminDashboardTriagePanelTest.java
+++ b/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminDashboardTriagePanelTest.java
@@ -55,12 +55,15 @@ class AdminDashboardTriagePanelTest {
 			.thenReturn(Map.of(FacilityReportStatus.SUBMITTED, 5L));
 		when(facilityReportUseCase.countReportsCreatedSince(any())).thenReturn(0L);
 		when(dataQualityUseCase.summarizeDataQuality()).thenReturn(dataQualitySummary(0));
-		when(datapackReleaseBlockerSummaryUseCase.summarize()).thenReturn(blockerSummary(0, 0, 0, 0, 0, 0, 0));
+		when(datapackReleaseBlockerSummaryUseCase.summarize())
+			.thenReturn(blockerSummary(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0));
 
 		String triage = triageSection(fetchDashboard());
 
 		assertThat(triage)
-			.contains("확인할 제보")
+			// 라벨은 렌더 마크업(dashboard-triage-label 태그)으로 스코핑해 안내 주석 등 다른 위치의
+			// 우연한 텍스트 일치와 구분한다(#2352 리뷰).
+			.contains("<span class=\"dashboard-triage-label\">확인할 제보</span>")
 			.contains(">5건<")
 			.contains("href=\"/admin/reports/page\"")
 			// 확인 필요 시설·데이터팩 차단 요인은 0건이라 딥링크 자체가 빠진다(라벨 텍스트는 섹션
@@ -70,12 +73,42 @@ class AdminDashboardTriagePanelTest {
 	}
 
 	@Test
+	@DisplayName("소스 최신성·콜백 정합성 확인·증거 번들 검증처럼 상세 표에 없던 구성요소도 totalBlockers에 반영되면 "
+		+ "새 행으로 노출되고 트리아지 카드 앵커도 정상 연결된다(#2352 리뷰: 표시 행 전부 0인데 totalBlockers>0인 모순 해소)")
+	void datapackBlockerDetailExposesPreviouslyUncountedComponents() throws Exception {
+		when(facilityReportUseCase.countReportsByStatus()).thenReturn(Map.of());
+		when(facilityReportUseCase.countReportsCreatedSince(any())).thenReturn(0L);
+		when(dataQualityUseCase.summarizeDataQuality()).thenReturn(dataQualitySummary(0));
+		// 기존 7개 표시 행(후보 게이트·별칭·격리·수동 오버라이드·시설 근거·경로 게이트·매니페스트 서명)은
+		// 전부 0이지만, 소스 최신성·콜백 정합성 확인·증거 번들 검증이 각 1건씩 있어 totalBlockers는 3건이다.
+		// #2352 리뷰 이전에는 이 상황에서 상세 표가 "표시 행 전부 0"이라 빈 상태로 폴백해 트리아지
+		// 카드·blocker-total의 "3건 있음"과 모순됐다.
+		when(datapackReleaseBlockerSummaryUseCase.summarize())
+			.thenReturn(blockerSummary(3, 0, 0, 0, 1, 0, 0, 0, 1, 1, 0));
+
+		String html = fetchDashboard();
+		String details = blockerDetailsSection(html);
+
+		assertThat(details)
+			.contains("<th scope=\"row\">소스 최신성</th>")
+			.contains("<th scope=\"row\">콜백 정합성 확인</th>")
+			.contains("<th scope=\"row\">증거 번들 검증</th>")
+			.contains("그 외 항목 7건은 0건입니다")
+			.doesNotContain("차단 요인이 없습니다.");
+		assertThat(triageSection(html))
+			.contains("<span class=\"dashboard-triage-label\">데이터팩 차단 요인</span>")
+			.contains(">3건<")
+			.contains("href=\"#dashboard-datapack-readiness\"");
+	}
+
+	@Test
 	@DisplayName("전부 0건이면 카드 대신 한 줄 상태 텍스트만 보여준다")
 	void fallsBackToOneLineStatusWhenAllZero() throws Exception {
 		when(facilityReportUseCase.countReportsByStatus()).thenReturn(Map.of());
 		when(facilityReportUseCase.countReportsCreatedSince(any())).thenReturn(0L);
 		when(dataQualityUseCase.summarizeDataQuality()).thenReturn(dataQualitySummary(0));
-		when(datapackReleaseBlockerSummaryUseCase.summarize()).thenReturn(blockerSummary(0, 0, 0, 0, 0, 0, 0));
+		when(datapackReleaseBlockerSummaryUseCase.summarize())
+			.thenReturn(blockerSummary(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0));
 
 		String html = fetchDashboard();
 
@@ -91,21 +124,25 @@ class AdminDashboardTriagePanelTest {
 		when(facilityReportUseCase.countReportsByStatus()).thenReturn(Map.of());
 		when(facilityReportUseCase.countReportsCreatedSince(any())).thenReturn(0L);
 		when(dataQualityUseCase.summarizeDataQuality()).thenReturn(dataQualitySummary(0));
-		// 별칭 2건·매니페스트 서명 1건만 non-zero, 나머지 5개 카테고리(후보 게이트·격리·수동 오버라이드·
-		// 시설 근거·경로 게이트)는 0건.
-		when(datapackReleaseBlockerSummaryUseCase.summarize()).thenReturn(blockerSummary(2, 0, 0, 0, 0, 0, 1));
+		// 별칭 2건·매니페스트 서명 1건만 non-zero, 나머지 8개 카테고리(후보 게이트·격리·소스 최신성·
+		// 수동 오버라이드·시설 근거·경로 게이트·콜백 정합성 확인·증거 번들 검증)는 0건.
+		when(datapackReleaseBlockerSummaryUseCase.summarize())
+			.thenReturn(blockerSummary(3, 0, 2, 0, 0, 0, 0, 0, 0, 0, 1));
 
 		String details = blockerDetailsSection(fetchDashboard());
 
 		assertThat(details)
 			.contains("<th scope=\"row\">별칭</th>")
 			.contains("<th scope=\"row\">매니페스트 서명</th>")
-			.contains("그 외 항목 5건은 0건입니다")
+			.contains("그 외 항목 8건은 0건입니다")
 			.doesNotContain("<th scope=\"row\">후보 게이트</th>")
 			.doesNotContain("<th scope=\"row\">격리</th>")
+			.doesNotContain("<th scope=\"row\">소스 최신성</th>")
 			.doesNotContain("<th scope=\"row\">수동 오버라이드</th>")
 			.doesNotContain("<th scope=\"row\">시설 근거</th>")
 			.doesNotContain("<th scope=\"row\">경로 게이트</th>")
+			.doesNotContain("<th scope=\"row\">콜백 정합성 확인</th>")
+			.doesNotContain("<th scope=\"row\">증거 번들 검증</th>")
 			.doesNotContain("차단 요인이 없습니다.");
 	}
 
@@ -115,7 +152,8 @@ class AdminDashboardTriagePanelTest {
 		when(facilityReportUseCase.countReportsByStatus()).thenReturn(Map.of());
 		when(facilityReportUseCase.countReportsCreatedSince(any())).thenReturn(0L);
 		when(dataQualityUseCase.summarizeDataQuality()).thenReturn(dataQualitySummary(0));
-		when(datapackReleaseBlockerSummaryUseCase.summarize()).thenReturn(blockerSummary(0, 0, 0, 0, 0, 0, 0));
+		when(datapackReleaseBlockerSummaryUseCase.summarize())
+			.thenReturn(blockerSummary(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0));
 
 		String details = blockerDetailsSection(fetchDashboard());
 
@@ -181,16 +219,22 @@ class AdminDashboardTriagePanelTest {
 		);
 	}
 
+	// total을 구성 요소 합과 분리해 명시적으로 주입한다(#2352 리뷰): 상세 표 10개 행(candidateGate ~
+	// manifest)의 합이 totalBlockers와 다른 픽스처도 구성할 수 있어야 "totalBlockers>0인데 표시 행
+	// 전부 0" 모순 회귀 테스트를 만들 수 있다. 일반적인 호출부는 total을 구성 요소 합과 일치시켜 쓴다.
 	private static DatapackReleaseBlockerSummary blockerSummary(
+		long total,
+		long candidateGate,
 		long alias,
 		long quarantine,
+		long sourceFreshness,
 		long manualOverride,
-		long routeGate,
-		long candidateGate,
 		long facility,
+		long routeGate,
+		long callbackReconciliation,
+		long evidenceBundle,
 		long manifest
 	) {
-		long total = alias + quarantine + manualOverride + routeGate + candidateGate + facility + manifest;
 		return new DatapackReleaseBlockerSummary(
 			"candidate-triage-test",
 			"scope-triage-test",
@@ -205,10 +249,12 @@ class AdminDashboardTriagePanelTest {
 			candidateGate,
 			alias,
 			quarantine,
-			0,
+			sourceFreshness,
 			manualOverride,
 			facility,
 			routeGate,
+			callbackReconciliation,
+			evidenceBundle,
 			manifest,
 			List.of(),
 			null

--- a/backend/src/test/java/com/easysubway/admin/alert/AdminAlertServiceTest.java
+++ b/backend/src/test/java/com/easysubway/admin/alert/AdminAlertServiceTest.java
@@ -176,7 +176,7 @@ class AdminAlertServiceTest {
 		return new DatapackReleaseBlockerSummary(
 			"candidate", "scope", "sourceHash", "manifestHash", "evidenceHash", "workflowUrl",
 			"prodCandidate", "rollbackCandidate", "검토 필요",
-			totalBlockers, 0, 0, 0, 0, 0, 0, 0, 0,
+			totalBlockers, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 			List.of(), LocalDateTime.now());
 	}
 }


### PR DESCRIPTION
## 관련 이슈

Refs #2349

## 작업 내용

- "확인 필요" 통합 카드 신설: 확인할 제보·확인 필요 시설·데이터팩 차단 요인을 페이지 제목 바로 아래 하나의 카드로 모으고, 각 항목은 기존 뷰 모델 값을 그대로 재사용해 해당 화면(제보 확인 대기열/시설 상태판)이나 데이터팩 출시 준비 섹션 앵커로 딥링크한다. 0건 항목은 행 자체를 생략하고, 전부 0(또는 권한 밖)이면 카드 대신 `.admin-status.good` 한 줄 상태 텍스트("지금 확인할 항목이 없습니다")로 대체한다.
- 위 카드가 흡수한 중복·약한 섹션 제거: 상단 알림 바의 데이터팩 blocker 중복 서술, "먼저 확인할 제보"(안내문+버튼뿐이던 섹션)를 제거했다.
- 데스크톱 2열 그리드: 하단 "데이터팩 출시 준비"와 "운영 이상 신호"를 `admin-grid-2`로 나란히 배치해 우측 부유를 해소했다(데이터팩 권한이 없으면 운영 이상 신호가 단독 폭으로 렌더).
- 차단 요인 상세 표 노이즈 제거: 후보 게이트·별칭·격리·수동 오버라이드·시설 근거·경로 게이트·매니페스트 서명 7개 카테고리 중 0건은 숨기고 비-0만 노출, 하단에 숨긴 건수 요약 줄을 추가했다. 전부 0건이면 표 대신 기존 빈 상태 fragment(#2327 문법)를 적용한다.
- 후보명 결측 시 노출되던 `-` 원문("- ● 확인 필요")을 결측 규칙에 맞춰 `—`로 정리했다.
- 뷰포트 적응: 태블릿(1024/768)은 `admin-grid-2`의 기존 반응형 규칙으로 1열 전환, 모바일은 HTML 순서(확인 필요 카드 → 핵심 지표 → 추이 → 상세 섹션)로 자연스럽게 단열 순서를 충족한다.
- flash message는 기존 `admin/fragments/shell :: flash` 컴포넌트(`.alert`)를 이미 사용 중임을 실기동으로 확인했다(변경 없음).
- 지표 집계·조회 로직, backend API, 기존 링크 URL은 변경하지 않았다(`AdminOverviewPageController` 뷰 모델 가공과 템플릿·CSS만).

## 검증

- 실행한 명령과 결과:
  - `cd backend && ./gradlew compileJava` — 성공
  - `cd backend && ./gradlew test --tests "com.easysubway.admin.*" --tests "com.easysubway.datapack.*" --tests "com.easysubway.report.*"` — 전부 통과(AdminDashboardPageTest, AdminV3PageSmokeTest, AdminDesignGuardTest, DatapackReleaseBlockerSummaryAdminPageTest 포함)
  - `cd backend && ./gradlew test --tests "com.easysubway.admin.adapter.in.web.AdminDashboardTriagePanelTest"` — 신설 테스트 5건 통과(0건 생략, 전부 0 폴백, 차단 요인 상세 0건 숨김·요약, 전부 0 빈 상태, 후보명 em dash 표기)
  - `node --test tools/qa/admin-accessibility-qa.test.mjs` — 15/15 통과
  - dev 실기동(H2, `EASYSUBWAY_DEV_SEED=true`/미설정 각각 별도 인메모리 인스턴스, 임의 포트, 종료 후 정리): 1440/1024/390 스크린샷을 로컬 전용 `.superpowers/plans/2349-evidence/`에 저장(리포에는 커밋하지 않음)

## 영향

- [x] 제품/운영 위험 없음 (route/accessibility/mobile UX/backend API/auth/security 아님)
- [x] DB migration 없음
- [x] 배포 영향 없음
- [x] route/realtime/datapack contract 영향 없음
- [x] CI workflow·계약 테스트·release gate JSON 변경 없음 (있으면 full.md로 전환)

## 체크리스트

- [x] 이 PR은 B/C등급 작업이며 full template이 필요 없다.
- [ ] CI 결과를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 폴백 리뷰를 단일 PR review로 게시했다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 관리자 대시보드에 통합 “확인 필요” 카드가 추가되었습니다.
  * 데이터팩 출시 준비 현황을 권한에 따라 표시하고, 차단 요인 상세 내역을 확인할 수 있습니다.
  * 차단 요인이 없는 항목은 자동으로 숨겨져 핵심 정보만 간결하게 표시됩니다.
  * 데이터가 없을 때 안내 문구와 빈 상태 화면을 제공합니다.
  * 긴급 신호에서 데이터팩 차단 항목을 분리해 더 명확하게 확인할 수 있습니다.
  * 후보 정보가 없을 경우 대시(—)로 일관되게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->