### PR TITLE
[Chore] #2095 production capacity run URL 결속·timetable snapshot 정합

### DIFF
--- a/apps/mobile/release/operations-release-evidence.json
+++ b/apps/mobile/release/operations-release-evidence.json
@@ -292,9 +292,9 @@
           "currentImplementation": {
             "status": "SATISFIED",
             "fields": ["snapshotSha256", "freshUntil"],
-            "snapshotId": "server-timetable-snapshot-c8ae07b67e133c8e",
-            "snapshotSha256": "c8ae07b67e133c8ee019069b1c11590aac1449398caf87eb68bca540615b9623",
-            "freshUntil": "2026-07-20T00:00:00+09:00",
+            "snapshotId": "server-timetable-snapshot-9f9be14b6cdd6e4d",
+            "snapshotSha256": "9f9be14b6cdd6e4d9a2eda1391b0bd7a48e6330485c9e1ec81d399958eae45d8",
+            "freshUntil": "2026-07-27T00:00:00+09:00",
             "evidencePath": "tools/datapack/server-timetable-snapshot-evidence.json"
           },
           "sharedRouteResponseCacheAllowed": false
@@ -306,7 +306,13 @@
           "runner": "tools/ops/verify-production-route-v2-capacity.sh",
           "workflow": ".github/workflows/production-route-v2-capacity-evidence.yml",
           "runnerExitCode": 0,
-          "productionWorkflowRunUrl": "production workflow run URL 대기(인프라 안정화 후 첨부)",
+          "productionWorkflowRunUrl": "https://github.com/AquilaXk/easysubway/actions/runs/29712689840",
+          "productionWorkflowRun": {
+            "runUrl": "https://github.com/AquilaXk/easysubway/actions/runs/29712689840",
+            "deployedSha": "3cad74667dc4c519aac0d1a9f9bcab2bcf5e5142",
+            "conclusion": "success",
+            "note": "production capacity workflow 최초 완주. run은 candidate SHA(e317f3af90292b9e2dff5e7ec90c22792b845435)가 아닌 이후 배포·검증된 SHA(3cad7466)에서 수행됨 — candidate 블록은 candidate identity로 불변 유지."
+          },
           "candidate": {
             "versionName": "1.0.5",
             "versionCode": 10006,

--- a/apps/mobile/release/post-launch-operations-review-gate.json
+++ b/apps/mobile/release/post-launch-operations-review-gate.json
@@ -53,7 +53,7 @@
         {
           "refreshOn": "operations-contract-change",
           "files": [
-            {"path": "apps/mobile/release/operations-release-evidence.json", "sha256": "31dd6595feebfb25aa1993d4115300b8e84fb2ccd6b64a8258c4bb219dd08a06"},
+            {"path": "apps/mobile/release/operations-release-evidence.json", "sha256": "2a6fb09122f51a68cc962b08f0705b91191722aaab76b62edc5a4a6508434d28"},
             {"path": "apps/mobile/release/operations-observability-gate.json", "sha256": "6955ac139fbc57be0721bb955e834164015050f397f2562e4402298578027afe"},
             {"path": "tools/ops/generate-operations-phase-a-summary.mjs", "sha256": "e89a520d6b229c5fd042ef8bcaf74873476c7253cd03b48fac1de21cf55e0c4d"},
             {"path": "tools/ops/validate-operations-release-summary.mjs", "sha256": "71a2a51da2b9c3a20d14512b608bccfbfee9022ca5718b77d44ff9254cc67979"},

--- a/tools/ci/production-route-v2-canary-rollback-workflow.test.mjs
+++ b/tools/ci/production-route-v2-canary-rollback-workflow.test.mjs
@@ -531,28 +531,27 @@ test("canary runner dotenv parser는 키가 없으면 fail-closed로 거부한�
   }
 });
 
-test("canary runner --test-expected-candidate는 operations-release-evidence.json과 timetable evidence의 현재 drift를 거부한다", async () => {
+test("canary runner --test-expected-candidate는 정합된 operations-release-evidence.json과 timetable evidence에서 checked-in RC candidate를 resolve한다", async () => {
   // apps/mobile/release/operations-release-evidence.json's
-  // routeV2Readiness.timetableSnapshotCache.currentImplementation is a KNOWN,
-  // pre-existing drift from the checked-in timetable evidence file this runner
-  // actually reads (backend/src/main/resources/timetable/server-timetable-snapshot-evidence.json)
-  // — a separate follow-up binding PR owns reconciling which value is
-  // authoritative. Until that lands, resolveExpectedCandidate() must correctly
-  // REFUSE to resolve a candidate instead of silently trusting one of the two
-  // mismatched evidences (this is the fail-closed behavior the cross-check
-  // exists to produce, not a bug in the cross-check itself).
+  // routeV2Readiness.timetableSnapshotCache.currentImplementation is now
+  // reconciled with the checked-in timetable evidence file this runner actually
+  // reads (backend/src/main/resources/timetable/server-timetable-snapshot-evidence.json)
+  // — the earlier known drift was reconciled in #2095. resolveExpectedCandidate()
+  // therefore resolves the SAME checked-in RC candidate from the two matching
+  // evidences instead of fail-closing on a snapshot mismatch.
   const [operations, timetable] = await Promise.all([
     readFile(operationsEvidencePath, "utf8").then(JSON.parse),
     readFile(timetableEvidencePath, "utf8").then(JSON.parse),
   ]);
-  assert.throws(
-    () => resolveExpectedCandidate(operations, timetable),
-    /timetableSnapshotCache does not match the timetable evidence file/,
+  const resolved = resolveExpectedCandidate(operations, timetable);
+  assert.equal(resolved.timetableSnapshotId, timetable.snapshotId);
+  assert.equal(resolved.timetableSnapshotSha256, timetable.snapshotSha256);
+  assert.equal(
+    resolved.backendDeploySha,
+    operations.backendControlPlane.publicApiSurface.routeV2Readiness.realisticLoadEvidence.candidate
+      .candidateGitSha,
   );
-  await assert.rejects(
-    execFileAsync("bash", [runnerPath, "--test-expected-candidate"]),
-    (error) => error.code === 2,
-  );
+  await execFileAsync("bash", [runnerPath, "--test-expected-candidate"]);
 });
 
 test("resolveExpectedCandidate는 operations-release-evidence.json과 timetable evidence의 snapshot 일치 여부를 검증한다", () => {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -7268,9 +7268,9 @@ test("운영 관측성과 알림 기준선은 필수 release 신호와 심볼 �
     currentImplementation: {
       status: "SATISFIED",
       fields: ["snapshotSha256", "freshUntil"],
-      snapshotId: "server-timetable-snapshot-c8ae07b67e133c8e",
-      snapshotSha256: "c8ae07b67e133c8ee019069b1c11590aac1449398caf87eb68bca540615b9623",
-      freshUntil: "2026-07-20T00:00:00+09:00",
+      snapshotId: "server-timetable-snapshot-9f9be14b6cdd6e4d",
+      snapshotSha256: "9f9be14b6cdd6e4d9a2eda1391b0bd7a48e6330485c9e1ec81d399958eae45d8",
+      freshUntil: "2026-07-27T00:00:00+09:00",
       evidencePath: "tools/datapack/server-timetable-snapshot-evidence.json",
     },
     sharedRouteResponseCacheAllowed: false,
@@ -7282,7 +7282,13 @@ test("운영 관측성과 알림 기준선은 필수 release 신호와 심볼 �
     runner: "tools/ops/verify-production-route-v2-capacity.sh",
     workflow: ".github/workflows/production-route-v2-capacity-evidence.yml",
     runnerExitCode: 0,
-    productionWorkflowRunUrl: "production workflow run URL 대기(인프라 안정화 후 첨부)",
+    productionWorkflowRunUrl: "https://github.com/AquilaXk/easysubway/actions/runs/29712689840",
+    productionWorkflowRun: {
+      runUrl: "https://github.com/AquilaXk/easysubway/actions/runs/29712689840",
+      deployedSha: "3cad74667dc4c519aac0d1a9f9bcab2bcf5e5142",
+      conclusion: "success",
+      note: "production capacity workflow 최초 완주. run은 candidate SHA(e317f3af90292b9e2dff5e7ec90c22792b845435)가 아닌 이후 배포·검증된 SHA(3cad7466)에서 수행됨 — candidate 블록은 candidate identity로 불변 유지.",
+    },
     candidate: {
       versionName: "1.0.5",
       versionCode: 10006,


### PR DESCRIPTION
## 관련 이슈

Refs AquilaXk/easysubway-backend#3

## 작업 배경

production Route V2 capacity workflow(`.github/workflows/production-route-v2-capacity-evidence.yml`)가 오늘 최초로 완주 성공했다. 그동안 `routeV2Readiness.realisticLoadEvidence.productionWorkflowRunUrl`은 로컬 러너 완주 근거로 SATISFIED 결속되어 있었고, production workflow run URL은 "production workflow run URL 대기(인프라 안정화 후 첨부)" placeholder로 남아 있었다. 이제 실제 production run이 확보되어 run identity를 결속한다.

또한 PR #2337에서 canary rollback helper(`tools/ops/route-v2-canary-rollback-evidence.mjs`)가 operations evidence의 `timetableSnapshotCache.currentImplementation`과 checked-in timetable evidence 파일의 snapshot 일치를 강제하도록 강화됐는데, operations evidence의 currentImplementation이 옛 snapshot(`c8ae07b6…`, freshUntil 2026-07-20)으로 stale 상태였다. 이 PR이 그 drift를 reconcile한다.

## 작업 내용

- `apps/mobile/release/operations-release-evidence.json`
  - `realisticLoadEvidence.productionWorkflowRunUrl`을 실제 run URL(`.../runs/29712689840`)로 교체.
  - `realisticLoadEvidence.productionWorkflowRun` 객체 신설로 production run identity를 별도 결속: `runUrl`, `deployedSha`(`3cad7466…`), `conclusion`(success), `note`. run은 candidate SHA(`e317f3af…`)가 아닌 이후 배포·검증된 SHA에서 수행됐으므로 candidate 블록(versionName 1.0.5 / versionCode 10006 / candidateGitSha e317f3af)은 불변 유지.
  - `timetableSnapshotCache.currentImplementation`을 현재 `tools/datapack/server-timetable-snapshot-evidence.json` 실측값(snapshotId `server-timetable-snapshot-9f9be14b6cdd6e4d`, snapshotSha256 `9f9be14b…`, freshUntil `2026-07-27T00:00:00+09:00`)으로 갱신. 이 값은 canary runner가 읽는 `backend/src/main/resources/timetable/server-timetable-snapshot-evidence.json`과도 동일하다.
- `apps/mobile/release/post-launch-operations-review-gate.json`: `operations-contract-change` refresh binding의 operations-release-evidence.json sha256을 `2a6fb091…`로 갱신.
- `tools/ci/repository-contract.test.mjs`: 위 evidence 변경에 맞춰 `realisticLoadEvidence`·`timetableSnapshotCache` deepEqual assertion 갱신.
- `tools/ci/production-route-v2-canary-rollback-workflow.test.mjs`: 기존 "현재 drift를 거부한다" 테스트는 drift reconcile 완료(#2095)에 따라, 정합된 두 evidence에서 checked-in RC candidate를 정상 resolve하는지 검증하도록 전환.

## 검증

- 실행한 명령과 결과:
  - `node tools/ci/repository-contract.test.mjs` → tests 219 / pass 218 / fail 1. 유일한 fail("Android v1 production 데이터팩 scope는 수도권 pilot 승인 기준을 고정한다")은 이 PR 이전 origin/main에도 존재하는 base 실패로, `production-datapack-scope.json`·`play-store-submission-content.json`(이 PR 미변경 파일)만 참조한다. 이 PR이 유발한 실패는 0.
  - `node --test tools/ci/production-route-v2-canary-rollback-workflow.test.mjs` → tests 18 / pass 18 / fail 0.
  - `node -e "JSON.parse(...)"`로 변경한 두 JSON parse 검증 → OK.
  - `node tools/ops/route-v2-canary-rollback-evidence.mjs expected-candidate <operations> <backend timetable>` → exit 0, checked-in RC candidate 정상 resolve(정합 확인).

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| repository contract test | CI | `node tools/ci/repository-contract.test.mjs` | pass 218 / fail 1(사전 존재 base 실패) | PASS(이 PR 유발 실패 0) |
| canary rollback workflow test | CI | `node --test tools/ci/production-route-v2-canary-rollback-workflow.test.mjs` | pass 18 / fail 0 | PASS |
| evidence 정합(canary cross-check) | 러너 | `route-v2-canary-rollback-evidence.mjs expected-candidate` | exit 0, candidate resolve | PASS |
| production capacity run | GitHub Actions | run URL | https://github.com/AquilaXk/easysubway/actions/runs/29712689840 (conclusion success) | PASS |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] AquilaXk/easysubway#1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음(1.0.5 유지)
- mobile versionCode: 변경 없음(10006 유지)
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음(candidate git sha e317f3af 불변)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `operations-release-evidence.json`의 `productionWorkflowRun.deployedSha`(3cad7466)가 candidate 블록의 candidateGitSha(e317f3af)와 다른 점은 의도된 정직한 결속이다. production run이 candidate SHA가 아닌 이후 배포·검증된 SHA에서 최초 완주했기 때문이며, candidate identity는 별개로 불변 유지한다.
  - `timetableSnapshotCache.currentImplementation` 값은 `tools/datapack/…`와 canary runner가 읽는 `backend/src/main/resources/timetable/…` 두 evidence 파일에서 동일하므로 canary cross-check가 정합(exit 0)한다.
  - canary workflow 테스트에서 기존 drift 재현 테스트를 resolve 검증으로 전환한 것은, 해당 테스트 주석이 명시했던 "reconciling를 담당할 follow-up binding PR"이 바로 이 PR이기 때문이다.

## 리스크

- production run은 candidate SHA(e317f3af)가 아닌 이후 배포 SHA(3cad7466)에서 수행됐다 — candidate 블록은 불변 유지하고 run identity를 별도 필드로 결속하여 정직하게 기록했다. candidate identity와 run deploy SHA를 혼동하지 않도록 `note`로 명시했다.
- operations evidence의 `currentImplementation.evidencePath`는 `tools/datapack/…`를 가리키지만 canary runner는 `backend/src/main/resources/timetable/…`를 읽는다. 현재 두 파일의 snapshot identity가 동일해 정합 문제는 없으나, 향후 두 파일이 갈라지면 재점검이 필요하다(이 PR 범위 밖의 사전 존재 구조).

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음 — no version change, evidence·test 정합만 변경)
