### PR TITLE
[Chore] #2334 timetable freshness break-glass override 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/JdbcRouteTimetableRepository.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/JdbcRouteTimetableRepository.java
@@ -13,6 +13,7 @@ import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
@@ -28,19 +29,34 @@ public class JdbcRouteTimetableRepository implements LoadRouteTimetablePort {
 
 	private final JdbcTemplate jdbcTemplate;
 	private final Clock clock;
+	// break-glass override: 활성 시 시간 기반 freshness 필터만 우회해 만료 snapshot도 서빙한다.
+	// 무결성(lineage·schema·출처)은 admissibleItxArtifact()가 계속 강제하므로 우회 대상이 아니다.
+	private final boolean breakGlass;
 
 	@Autowired
+	public JdbcRouteTimetableRepository(
+		DataSource dataSource,
+		@Value("${easysubway.timetable.freshness.break-glass:false}") boolean breakGlass
+	) {
+		this(new JdbcTemplate(dataSource), Clock.systemUTC(), breakGlass);
+	}
+
 	public JdbcRouteTimetableRepository(DataSource dataSource) {
-		this(new JdbcTemplate(dataSource), Clock.systemUTC());
+		this(new JdbcTemplate(dataSource), Clock.systemUTC(), false);
 	}
 
 	JdbcRouteTimetableRepository(JdbcTemplate jdbcTemplate) {
-		this(jdbcTemplate, Clock.systemUTC());
+		this(jdbcTemplate, Clock.systemUTC(), false);
 	}
 
 	JdbcRouteTimetableRepository(JdbcTemplate jdbcTemplate, Clock clock) {
+		this(jdbcTemplate, clock, false);
+	}
+
+	JdbcRouteTimetableRepository(JdbcTemplate jdbcTemplate, Clock clock, boolean breakGlass) {
 		this.jdbcTemplate = jdbcTemplate;
 		this.clock = clock;
+		this.breakGlass = breakGlass;
 	}
 
 	@Override
@@ -93,8 +109,13 @@ public class JdbcRouteTimetableRepository implements LoadRouteTimetablePort {
 	}
 
 	private Optional<ItxArtifact> activeItxArtifact() {
-		return admissibleItxArtifact()
-			.filter(artifact -> freshOffsetDateTime(artifact.freshUntil()).isPresent());
+		Optional<ItxArtifact> admissible = admissibleItxArtifact();
+		if (breakGlass) {
+			// break-glass override 활성: 시간 기반 freshness 필터만 우회해 만료 snapshot도 서빙한다.
+			// admissibleItxArtifact()가 lineage·schema·출처 검증을 이미 통과시킨 행만 반환하므로 무결성은 우회되지 않는다.
+			return admissible;
+		}
+		return admissible.filter(artifact -> freshOffsetDateTime(artifact.freshUntil()).isPresent());
 	}
 
 	// 시간 기반 freshness를 제외한 lineage·schema 적격성만 판정한다(활성화 시점 readability 검사용).

--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/TimetableFreshnessMonitor.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/TimetableFreshnessMonitor.java
@@ -33,6 +33,17 @@ import org.springframework.stereotype.Component;
  * 확인했다(2026-07-20 실측: infra prometheus/probe는 `/actuator/health/readiness`만 HTTP status로 확인하고,
  * admin의 {@code HealthCheckService}는 이 actuator 레지스트리와 무관한 별도 hand-rolled 상태다). 저장소 밖
  * alerting·대시보드에서 root status 문자열 동등 비교를 하는지는 별도 확인이 필요하다.
+ *
+ * <p><b>break-glass override({@code easysubway.timetable.freshness.break-glass})</b>는 {@code fresh_until}
+ * 축(시간 기반 만료)만 우회한다. {@code RouteV2Planner.search}의 {@code isFeedStale} 게이트({@code feed_end_date}가
+ * 검색일보다 과거면 {@code STALE_TIMETABLE} → 503)는 override와 무관하게 그대로 적용된다 — feed_end_date 이후
+ * 날짜에는 애초에 실제 trip이 없어 우회할 대상이 없으므로 의도된 동작이다. 즉 override를 켜도 만료된 snapshot의
+ * {@code feed_end_date}가 지난 날짜의 검색은 여전히 503이다.
+ *
+ * <p>이 override의 실효 감사 표면은 <b>WARN 로그와 {@code easysubway.timetable.snapshot.break-glass} gauge</b>다.
+ * {@code health()}가 반환하는 {@code breakGlass}/{@code breakGlassReason} detail은 참고용이며,
+ * {@code management.endpoint.health.show-details} 기본값({@code never})에서는 {@code /actuator/health} 응답에
+ * 노출되지 않는다. 노출을 원하면 별도로 {@code show-details: when-authorized}를 검토해야 한다(이 변경 범위 밖).
  */
 @Component
 @Profile("prod | staging | release | prod-like")
@@ -75,7 +86,9 @@ class TimetableFreshnessMonitor implements HealthIndicator {
 		this.breakGlass = breakGlass;
 		this.breakGlassReason = breakGlassReason == null || breakGlassReason.isBlank()
 			? UNSPECIFIED_REASON
-			: breakGlassReason.strip();
+			// 감사 문자열이 WARN 로그·health detail에 그대로 들어가므로, 앞뒤 공백 제거뿐 아니라 내부 제어문자
+			// (CR/LF 포함)도 공백으로 치환해 가짜 로그 라인 삽입을 차단한다.
+			: breakGlassReason.strip().replaceAll("\\p{Cntrl}+", " ");
 		Gauge.builder("easysubway.timetable.snapshot.fresh", state, current -> current.get().fresh() ? 1.0 : 0.0)
 			.description("Active timetable snapshot freshness: 1 when fresh, 0 when stale, absent, or unknown")
 			.register(meterRegistry);

--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/TimetableFreshnessMonitor.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/TimetableFreshnessMonitor.java
@@ -11,6 +11,7 @@ import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.boot.actuate.health.Status;
@@ -39,21 +40,50 @@ class TimetableFreshnessMonitor implements HealthIndicator {
 
 	static final Status STALE = new Status("STALE");
 	private static final Logger log = LoggerFactory.getLogger(TimetableFreshnessMonitor.class);
+	private static final String UNSPECIFIED_REASON = "(unspecified)";
 
 	private final JdbcTemplate jdbcTemplate;
 	private final Clock clock;
+	// break-glass override 활성 여부와 감사 문맥(활성 사유·주체). freshness 판정 자체는 바꾸지 않고 관측만 얹는다.
+	private final boolean breakGlass;
+	private final String breakGlassReason;
 	private final AtomicReference<Freshness> state = new AtomicReference<>(Freshness.unknown());
 
 	@Autowired
-	TimetableFreshnessMonitor(DataSource dataSource, MeterRegistry meterRegistry) {
-		this(new JdbcTemplate(dataSource), Clock.systemUTC(), meterRegistry);
+	TimetableFreshnessMonitor(
+		DataSource dataSource,
+		MeterRegistry meterRegistry,
+		@Value("${easysubway.timetable.freshness.break-glass:false}") boolean breakGlass,
+		@Value("${easysubway.timetable.freshness.break-glass-reason:}") String breakGlassReason
+	) {
+		this(new JdbcTemplate(dataSource), Clock.systemUTC(), meterRegistry, breakGlass, breakGlassReason);
 	}
 
 	TimetableFreshnessMonitor(JdbcTemplate jdbcTemplate, Clock clock, MeterRegistry meterRegistry) {
+		this(jdbcTemplate, clock, meterRegistry, false, "");
+	}
+
+	TimetableFreshnessMonitor(
+		JdbcTemplate jdbcTemplate,
+		Clock clock,
+		MeterRegistry meterRegistry,
+		boolean breakGlass,
+		String breakGlassReason
+	) {
 		this.jdbcTemplate = jdbcTemplate;
 		this.clock = clock;
+		this.breakGlass = breakGlass;
+		this.breakGlassReason = breakGlassReason == null || breakGlassReason.isBlank()
+			? UNSPECIFIED_REASON
+			: breakGlassReason.strip();
 		Gauge.builder("easysubway.timetable.snapshot.fresh", state, current -> current.get().fresh() ? 1.0 : 0.0)
 			.description("Active timetable snapshot freshness: 1 when fresh, 0 when stale, absent, or unknown")
+			.register(meterRegistry);
+		boolean overrideEnabled = breakGlass;
+		Gauge.builder("easysubway.timetable.snapshot.break-glass", state, current -> overrideEnabled ? 1.0 : 0.0)
+			.description(
+				"Timetable freshness break-glass override: 1 when enabled (expired snapshots served without "
+					+ "freshness gating; integrity still enforced), 0 otherwise")
 			.register(meterRegistry);
 	}
 
@@ -61,6 +91,14 @@ class TimetableFreshnessMonitor implements HealthIndicator {
 	// ApplicationReadyEvent는 ApplicationRunner(TimetableSeedLoader 포함)까지 끝난 뒤 발생해 활성화 순서가 보장된다.
 	@EventListener(ApplicationReadyEvent.class)
 	void evaluateOnStartup() {
+		if (breakGlass) {
+			log.warn(
+				"TIMETABLE FRESHNESS BREAK-GLASS OVERRIDE ENABLED (reason={}): expired timetable snapshots will be "
+					+ "served without freshness gating. Integrity verification (hash/schema/lineage) is NOT bypassed. "
+					+ "Disable easysubway.timetable.freshness.break-glass once a fresh snapshot is admitted.",
+				breakGlassReason
+			);
+		}
 		evaluate();
 	}
 
@@ -80,12 +118,20 @@ class TimetableFreshnessMonitor implements HealthIndicator {
 		}
 		state.set(observed);
 		logTransition(previous, observed);
+		if (breakGlass && observed.state() == State.STALE) {
+			// 우회가 은폐되지 않도록 만료 snapshot을 실제로 서빙하는 동안 주기마다 강한 WARN을 남긴다.
+			log.warn(
+				"break-glass override active: serving EXPIRED timetable snapshot {} (fresh_until={}, reason={}); "
+					+ "route search bypasses freshness gating while integrity checks remain enforced",
+				observed.snapshotId(), observed.freshUntil(), breakGlassReason
+			);
+		}
 	}
 
 	@Override
 	public Health health() {
 		Freshness current = state.get();
-		return switch (current.state()) {
+		Health base = switch (current.state()) {
 			case FRESH -> Health.up()
 				.withDetail("state", "FRESH")
 				.withDetail("snapshotId", current.snapshotId())
@@ -105,6 +151,19 @@ class TimetableFreshnessMonitor implements HealthIndicator {
 				.withDetail("reason", "freshness query failed; see application logs")
 				.build();
 		};
+		if (!breakGlass) {
+			return base;
+		}
+		// override 활성 시 "우회 중"이 health detail에도 드러나도록 감사 정보를 얹는다. STALE일 때는 만료 데이터를
+		// 실제로 서빙 중이므로 reason을 override 문맥으로 덮어쓴다.
+		Health.Builder builder = Health.status(base.getStatus());
+		base.getDetails().forEach(builder::withDetail);
+		builder.withDetail("breakGlass", true).withDetail("breakGlassReason", breakGlassReason);
+		if (current.state() == State.STALE) {
+			builder.withDetail("reason",
+				"break-glass override active: expired snapshot is being served (integrity still verified)");
+		}
+		return builder.build();
 	}
 
 	/** 쿼리 성공 시 관측 결과를, 실패 시 {@code null}을 반환한다(호출부가 이전 상태 유지 여부를 결정한다). */

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -90,8 +90,20 @@ easysubway:
       includes-itx: ${EASYSUBWAY_TIMETABLE_SEED_INCLUDES_ITX:false}
     freshness:
       # break-glass override: 만료된 timetable snapshot을 명시적 운영 결정으로 한시 서빙한다(기본 false).
-      # 활성화 시 기동·주기 WARN 로그, actuator health detail, break-glass 메트릭으로 우회가 관측되며,
-      # 무결성(해시·스키마·출처) 검증은 우회되지 않는다 — 시간 기반 만료만 우회한다.
+      # 활성화 시 기동·주기 WARN 로그와 break-glass 메트릭으로 우회가 관측된다. actuator health detail에도
+      # breakGlass/breakGlassReason이 실리지만, management.endpoint.health.show-details 기본값(never)에서는
+      # /actuator/health 응답에 노출되지 않는다 — 실효 감사 표면은 WARN 로그 + gauge다(health detail 노출을
+      # 원하면 show-details: when-authorized 검토가 필요하며 이 변경 범위 밖이다).
+      # 무결성(해시·스키마·출처) 검증은 우회되지 않는다 — 시간 기반 만료(fresh_until)만 우회한다.
+      # RouteV2Planner의 feed_end_date staleness 게이트(isFeedStale → STALE_TIMETABLE → 503)는 fresh_until과
+      # 무관한 별도 축이라 override와 상관없이 그대로 적용된다(feed_end_date 이후 날짜는 실제 trip이 없어 우회
+      # 대상이 아님) — override를 켜도 feed_end_date가 지난 날짜의 인증 경로검색은 여전히 503이다.
+      # 오타(예: "ture")나 형식이 안 맞는 값은 boolean 바인딩 실패로 "OFF 폴백"이 아니라 애플리케이션 기동
+      # 자체가 실패한다(fail-safe이지만 무중단이 아니므로 운영 중 혼선에 유의).
+      # 적용 프로파일 범위: 이 파일(application-prod.yml)은 spring.profiles.group(application.yml)에 의해
+      # staging/release/prod-like에도 상속되므로 이 플래그는 prod 전용이 아니라 운영 계열 프로파일 전체
+      # (prod·staging·release·prod-like)에 공통으로 적용된다 — 의도된 범위다(모니터 bean과 동일한
+      # @Profile("prod | staging | release | prod-like") 대상에 대한 공통 안전장치).
       # 사용 후에는 fresh snapshot이 admit되는 즉시 반드시 비활성으로 되돌린다.
       break-glass: ${EASYSUBWAY_TIMETABLE_FRESHNESS_BREAK_GLASS:false}
       # 활성 사유·활성화 주체 감사 문맥(로그·health detail에 그대로 노출된다). 활성 시 채우기를 권장한다.

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -88,6 +88,14 @@ easysubway:
     seed:
       enabled: ${EASYSUBWAY_TIMETABLE_SEED_ENABLED:false}
       includes-itx: ${EASYSUBWAY_TIMETABLE_SEED_INCLUDES_ITX:false}
+    freshness:
+      # break-glass override: 만료된 timetable snapshot을 명시적 운영 결정으로 한시 서빙한다(기본 false).
+      # 활성화 시 기동·주기 WARN 로그, actuator health detail, break-glass 메트릭으로 우회가 관측되며,
+      # 무결성(해시·스키마·출처) 검증은 우회되지 않는다 — 시간 기반 만료만 우회한다.
+      # 사용 후에는 fresh snapshot이 admit되는 즉시 반드시 비활성으로 되돌린다.
+      break-glass: ${EASYSUBWAY_TIMETABLE_FRESHNESS_BREAK_GLASS:false}
+      # 활성 사유·활성화 주체 감사 문맥(로그·health detail에 그대로 노출된다). 활성 시 채우기를 권장한다.
+      break-glass-reason: ${EASYSUBWAY_TIMETABLE_FRESHNESS_BREAK_GLASS_REASON:}
   route-v2:
     origin-secret: ${EASYSUBWAY_ROUTE_V2_ORIGIN_SECRET:}
     session-max-requests: ${EASYSUBWAY_ROUTE_V2_SESSION_MAX_REQUESTS:50}

--- a/backend/src/test/java/com/easysubway/route/adapter/out/persistence/JdbcRouteTimetableRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/out/persistence/JdbcRouteTimetableRepositoryTest.java
@@ -83,6 +83,54 @@ class JdbcRouteTimetableRepositoryTest {
 	}
 
 	@Test
+	@DisplayName("break-glass override가 켜지면 만료된 active snapshot도 서빙한다")
+	void breakGlassOverrideServesExpiredSnapshot() {
+		insertTimetableRows();
+		insertItxRows("2000-01-01T00:00:00Z");
+
+		var override = new JdbcRouteTimetableRepository(
+			jdbcTemplate,
+			Clock.fixed(Instant.parse("2026-07-16T00:00:00Z"), ZoneOffset.UTC),
+			true
+		);
+
+		assertThat(override.hasRouteTimetable()).isTrue();
+		assertThat(override.activeItxTimetableArtifactId()).contains("snapshot-test");
+		assertThat(override.timetableCacheKey()).isNotEqualTo("UNAVAILABLE");
+	}
+
+	@Test
+	@DisplayName("break-glass override여도 무결성(schema·lineage) 실패는 계속 fail closed한다")
+	void breakGlassOverrideDoesNotBypassIntegrity() {
+		insertTimetableRows();
+		insertItxRows("2000-01-01T00:00:00Z");
+
+		var override = new JdbcRouteTimetableRepository(
+			jdbcTemplate,
+			Clock.fixed(Instant.parse("2026-07-16T00:00:00Z"), ZoneOffset.UTC),
+			true
+		);
+		assertThat(override.activeItxTimetableArtifactId()).contains("snapshot-test");
+
+		jdbcTemplate.update(
+			"UPDATE timetable_snapshot_history SET schema_identity = 'invalid' WHERE snapshot_sha256 = ?",
+			"a".repeat(64)
+		);
+		assertThat(override.activeItxTimetableArtifactId()).isEmpty();
+
+		jdbcTemplate.update(
+			"UPDATE timetable_snapshot_history SET schema_identity = 'backend-timetable-snapshot-v1' "
+				+ "WHERE snapshot_sha256 = ?",
+			"a".repeat(64)
+		);
+		jdbcTemplate.update(
+			"UPDATE route_service_artifact_evidence SET canonical_pack_sha256 = ? WHERE service_class = 'ITX_CHEONGCHUN'",
+			"9".repeat(64)
+		);
+		assertThat(override.activeItxTimetableArtifactId()).isEmpty();
+	}
+
+	@Test
 	@DisplayName("ITX admission freshness 상태가 바뀌면 timetable cache key도 바뀐다")
 	void changesCacheKeyWhenItxAdmissionExpires() {
 		insertItxRows("2999-01-01T00:00:00Z");

--- a/backend/src/test/java/com/easysubway/route/adapter/out/persistence/TimetableFreshnessMonitorTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/out/persistence/TimetableFreshnessMonitorTest.java
@@ -280,6 +280,28 @@ class TimetableFreshnessMonitorTest {
 	}
 
 	@Test
+	void breakGlassReasonControlCharactersAreNormalizedToPreventLogForging() {
+		insertActiveSnapshot(FRESH_UNTIL);
+		MeterRegistry meterRegistry = new SimpleMeterRegistry();
+		// 내부 개행·제어문자가 있는 사유값(가짜 로그 라인 삽입 시도)이 공백으로 치환되는지 확인한다.
+		TimetableFreshnessMonitor monitor = breakGlassMonitor(
+			AFTER, meterRegistry, "ops-jdoe\r\nWARN forged line\tinjected");
+
+		monitor.evaluate();
+
+		assertThat(monitor.health().getDetails())
+			.extracting("breakGlassReason")
+			.isEqualTo("ops-jdoe WARN forged line injected");
+		assertThat(logAppender.events()).anySatisfy(event -> {
+			assertThat(event.getLevel()).isEqualTo(Level.WARN);
+			assertThat(event.getMessage().getFormattedMessage())
+				.doesNotContain("\r")
+				.doesNotContain("\n")
+				.contains("ops-jdoe WARN forged line injected");
+		});
+	}
+
+	@Test
 	void breakGlassBlankReasonIsNormalizedInAudit() {
 		insertActiveSnapshot(FRESH_UNTIL);
 		MeterRegistry meterRegistry = new SimpleMeterRegistry();

--- a/backend/src/test/java/com/easysubway/route/adapter/out/persistence/TimetableFreshnessMonitorTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/out/persistence/TimetableFreshnessMonitorTest.java
@@ -28,6 +28,7 @@ class TimetableFreshnessMonitorTest {
 	private static final Instant AFTER = Instant.parse("2026-07-21T00:00:00Z");
 	private static final String FRESH_UNTIL = "2026-07-20T00:00:00+09:00";
 	private static final String GAUGE = "easysubway.timetable.snapshot.fresh";
+	private static final String BREAK_GLASS_GAUGE = "easysubway.timetable.snapshot.break-glass";
 
 	private JdbcTemplate jdbc;
 	private CapturingAppender logAppender;
@@ -216,8 +217,85 @@ class TimetableFreshnessMonitorTest {
 		});
 	}
 
+	@Test
+	void breakGlassOverrideExposesGaugeHealthDetailAndWarnWhileRemainingStale() {
+		insertActiveSnapshot(FRESH_UNTIL);
+		MeterRegistry meterRegistry = new SimpleMeterRegistry();
+		TimetableFreshnessMonitor monitor = breakGlassMonitor(AFTER, meterRegistry, "incident-2328 operator jdoe");
+
+		monitor.evaluate();
+
+		// override는 freshness 판정을 바꾸지 않는다 — 여전히 STALE로 노출해 "우회 중"이 관측되게 한다.
+		assertThat(monitor.health().getStatus()).isEqualTo(TimetableFreshnessMonitor.STALE);
+		assertThat(monitor.health().getDetails())
+			.containsEntry("state", "STALE")
+			.containsEntry("breakGlass", true)
+			.containsEntry("breakGlassReason", "incident-2328 operator jdoe")
+			.containsEntry("reason",
+				"break-glass override active: expired snapshot is being served (integrity still verified)");
+		assertThat(meterRegistry.get(BREAK_GLASS_GAUGE).gauge().value()).isEqualTo(1.0);
+		assertThat(meterRegistry.get(GAUGE).gauge().value()).isEqualTo(0.0);
+		assertThat(logAppender.events()).anySatisfy(event -> {
+			assertThat(event.getLevel()).isEqualTo(Level.WARN);
+			assertThat(event.getMessage().getFormattedMessage())
+				.contains("break-glass override active")
+				.contains("serving EXPIRED");
+		});
+	}
+
+	@Test
+	void breakGlassStartupLogsWarnAndArmsGaugeEvenWhenSnapshotStillFresh() {
+		insertActiveSnapshot(FRESH_UNTIL);
+		MeterRegistry meterRegistry = new SimpleMeterRegistry();
+		TimetableFreshnessMonitor monitor = breakGlassMonitor(BEFORE, meterRegistry, "incident-2328 operator jdoe");
+
+		monitor.evaluateOnStartup();
+
+		// snapshot이 아직 fresh여도 override가 armed임을 기동 WARN·health detail·gauge로 노출한다.
+		assertThat(monitor.health().getStatus()).isEqualTo(Status.UP);
+		assertThat(monitor.health().getDetails())
+			.containsEntry("state", "FRESH")
+			.containsEntry("breakGlass", true);
+		assertThat(meterRegistry.get(BREAK_GLASS_GAUGE).gauge().value()).isEqualTo(1.0);
+		assertThat(meterRegistry.get(GAUGE).gauge().value()).isEqualTo(1.0);
+		assertThat(logAppender.events()).anySatisfy(event -> {
+			assertThat(event.getLevel()).isEqualTo(Level.WARN);
+			assertThat(event.getMessage().getFormattedMessage()).contains("BREAK-GLASS OVERRIDE ENABLED");
+		});
+	}
+
+	@Test
+	void breakGlassDisabledLeavesGaugeZeroAndStandardStaleReason() {
+		insertActiveSnapshot(FRESH_UNTIL);
+		MeterRegistry meterRegistry = new SimpleMeterRegistry();
+		TimetableFreshnessMonitor monitor = monitor(AFTER, meterRegistry);
+
+		monitor.evaluate();
+
+		assertThat(monitor.health().getStatus()).isEqualTo(TimetableFreshnessMonitor.STALE);
+		assertThat(monitor.health().getDetails())
+			.containsEntry("reason", "route search serves 503 until a fresh snapshot is admitted")
+			.doesNotContainKey("breakGlass");
+		assertThat(meterRegistry.get(BREAK_GLASS_GAUGE).gauge().value()).isEqualTo(0.0);
+	}
+
+	@Test
+	void breakGlassBlankReasonIsNormalizedInAudit() {
+		insertActiveSnapshot(FRESH_UNTIL);
+		MeterRegistry meterRegistry = new SimpleMeterRegistry();
+		TimetableFreshnessMonitor monitor = breakGlassMonitor(AFTER, meterRegistry, "   ");
+
+		monitor.evaluate();
+
+		assertThat(monitor.health().getDetails()).containsEntry("breakGlassReason", "(unspecified)");
+	}
+
 	private TimetableFreshnessMonitor monitor(Instant now, MeterRegistry meterRegistry) {
 		return new TimetableFreshnessMonitor(jdbc, Clock.fixed(now, ZoneOffset.UTC), meterRegistry);
+	}
+
+	private TimetableFreshnessMonitor breakGlassMonitor(Instant now, MeterRegistry meterRegistry, String reason) {
+		return new TimetableFreshnessMonitor(jdbc, Clock.fixed(now, ZoneOffset.UTC), meterRegistry, true, reason);
 	}
 
 	private void insertActiveSnapshot(String freshUntil) {


### PR DESCRIPTION
## 관련 이슈

close #2334
Refs #2329

## 작업 배경

- 상위 이슈 #2329의 마지막 backend 항목이다. #2332(PR #2347)로 만료 시 degraded 운용(경로검색만 503, 나머지 정상)이 도입됐지만, 자동 갱신·degraded 경로 자체에 결함이 생겨 운영자가 만료 데이터를 의도적으로 한시 서빙해 정상 모드로 즉시 복귀시켜야 하는 예외 상황에 대한 명시적 우회 수단이 없었다.
- 이 override는 은폐되지 않는 감사 흔적을 남기고, 무결성 검증은 절대 우회하지 않아야 한다(시간 기반 만료만 우회).

## 작업 내용

- `easysubway.timetable.freshness.break-glass`(기본 `false`)와 감사 문맥용 `easysubway.timetable.freshness.break-glass-reason` 플래그를 추가했다. `application-prod.yml`에 환경변수 바인딩과 사용 주의를 문서화했다.
- `JdbcRouteTimetableRepository.activeItxArtifact()`가 override 활성 시 요청 시점 freshness 필터만 우회하도록 했다. lineage·schema·출처 검증을 이미 통과시킨 `admissibleItxArtifact()` 결과만 서빙하므로 무결성은 우회 불가다.
- `TimetableFreshnessMonitor`에 감사 노출을 얹었다: 기동 시 강한 WARN, 만료 snapshot 서빙 중 주기 WARN, actuator health detail(`breakGlass`·`breakGlassReason`·override reason), `easysubway.timetable.snapshot.break-glass` 메트릭. override 활성 시에도 만료 상태는 `STALE`로 계속 노출해 "우회 중"이 관측되게 유지했다.
- override OFF 회귀(만료=fail closed), override ON 만료 서빙, override여도 무결성 실패는 fail closed, 사유 정규화 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests JdbcRouteTimetableRepositoryTest --tests TimetableFreshnessMonitorTest --tests TimetableSeedLoaderTest` → BUILD SUCCESSFUL (신규 4건 포함 전체 통과, `compileTestJava`가 기존 모든 호출부 호환 확인).

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| override OFF 시 만료=degraded 회귀 유지 | backend | `rejectsExpiredActiveSnapshotAtRequestTime`, `breakGlassDisabledLeavesGaugeZeroAndStandardStaleReason` | 위 Gradle 실행 로그 | PASS |
| override ON 시 만료 snapshot 서빙 + WARN + health/metric 노출 | backend | `breakGlassOverrideServesExpiredSnapshot`, `breakGlassOverrideExposesGaugeHealthDetailAndWarnWhileRemainingStale`, `breakGlassStartupLogsWarnAndArmsGaugeEvenWhenSnapshotStillFresh` | 위 Gradle 실행 로그 | PASS |
| override여도 무결성(schema·lineage) 실패는 fail closed | backend | `breakGlassOverrideDoesNotBypassIntegrity` | 위 Gradle 실행 로그 | PASS |
| 플래그 사유 정규화 경계 | backend | `breakGlassBlankReasonIsNormalizedInAudit` | 위 Gradle 실행 로그 | PASS |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음(기본 비활성 운영 플래그, 코드 계약 무변경)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `JdbcRouteTimetableRepository.activeItxArtifact()` — override가 `admissibleItxArtifact()`의 무결성 검증 뒤 freshness 필터만 우회하는지(무결성 불우회 경계).
  - `TimetableFreshnessMonitor` — override 활성 시에도 freshness 판정을 바꾸지 않고 STALE 관측을 유지하며 감사(WARN/health/metric)만 얹는지.

## 리스크

- 시간 제한/자동 해제 장치는 이슈 DoD에 없어 무기한 플래그로 두었다. override는 명시적 env 설정과 재기동으로만 켜지고, 활성 상태가 기동·주기 WARN 로그·health detail·메트릭으로 지속 노출되므로 은폐 위험은 낮다. 다만 운영 절차상 fresh snapshot admit 즉시 반드시 비활성으로 되돌려야 한다(로그·yml 주석에 명시).
- 사유(reason)는 fail-safe를 위해 필수화하지 않았다(장애 중 사유 누락이 긴급 서빙을 막지 않도록). 미설정 시 로그·health에 `(unspecified)`로 노출된다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (기본 비활성 운영 플래그로 CD 동작 무변경 — 활성화는 운영자 명시 결정)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 시간표가 만료된 경우에도 설정된 비상 우회 모드에서 서비스를 계속 제공할 수 있습니다.
  * 비상 우회 모드의 활성 상태와 운영자 사유가 상태 정보 및 모니터링 지표에 표시됩니다.
  * 만료된 시간표 제공 시 운영 경고가 기록됩니다.

* **개선 사항**
  * 비상 우회 모드에서도 시간표 무결성 검증은 계속 수행됩니다.
  * 비상 우회 사유의 개행·제어문자와 빈 입력을 안전하게 정규화합니다.
  * 운영 환경에서 비상 우회 설정과 사유를 환경 변수로 지정할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->