### PR TITLE
[Chore] #1018 Play 폼·공개 정책·runtime inventory 일치 #2056 fragment 결속

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -874,6 +874,16 @@ jobs:
               --repo-root . \
               --output release-artifacts/rc/mobile-consumption-evidence.json
           fi
+          # #1018 마지막 DoD의 #2056 fragment. Play Data Safety 폼(answerMatrix), 공개 개인정보
+          # 처리방침, runtime 수집 inventory 세 tracked 원본의 machine-auditable 일치 판정을 같은
+          # candidate-context RC identity에 결속해 emit한다. planner/mobile step과 동일하게 입력
+          # artifact 존재를 먼저 확인하고, 불일치는 producer가 fail-closed로 BLOCKED 처리한다.
+          if [[ -f release-artifacts/rc/candidate-context.json ]]; then
+            node tools/release/build-privacy-consistency-evidence.mjs \
+              --candidate-context release-artifacts/rc/candidate-context.json \
+              --repo-root . \
+              --output release-artifacts/rc/store-privacy-consistency-evidence.json
+          fi
           if [[ "${android_artifact_source}" == easysubway-android-production-rc-* ]]; then
             node tools/ops/generate-operations-phase-a-summary.mjs \
               --rc-manifest release-artifacts/rc/candidate-context.json \

--- a/apps/mobile/release/post-launch-operations-review-gate.json
+++ b/apps/mobile/release/post-launch-operations-review-gate.json
@@ -96,7 +96,7 @@
           "files": [
             {"path": "apps/mobile/release/signed-release-artifact-gate.json", "sha256": "42c9f83dca5a1c2c24d921cf6ab748c9be5a901dd1b62212a81055098349fc67"},
             {"path": "apps/mobile/pubspec.yaml", "sha256": "1c4918747c4acf22bbe885b7cb01cc34cc311e7e44598ac6b817848712614d42"},
-            {"path": ".github/workflows/release-artifacts.yml", "sha256": "2f9b62ddbd00bac86a69d832b9e3cf35dd3c14a1731d6b201f47f04b991c20cb"},
+            {"path": ".github/workflows/release-artifacts.yml", "sha256": "b430a8f8cbe0278b126d6347c1d3e4d21c541e9893ac387ce32720d567f4a276"},
             {"path": ".github/workflows/datapack-release.yml", "sha256": "dc93cb03764e035d8cd4c05a96a3f979f0ffa2c7a332395b4c8ae1a528e875d7"},
             {"path": "tools/ci/validate-store-privacy-env.mjs", "sha256": "18bb0dd8b93d6268c8f60f9cc12272d2ff31c03b60fbbafd6c1e8d16957ada2a"},
             {"path": "backend/build.gradle", "sha256": "00106be89d1834db166c0c4cfba04674e2a456e7e57648595b74feb933c31273"},

--- a/tools/release/build-mobile-consumption-evidence.mjs
+++ b/tools/release/build-mobile-consumption-evidence.mjs
@@ -5,9 +5,9 @@
 // 근거를 tracked source·test 참조로 결합한다. UI 렌더링/길찾기 로직을 재구현하지 않고, 이미
 // tracked된 위젯 test 이름과 request 직렬화 소스의 존재·내용만 정적으로 검증한다.
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { runCandidateContextEvidenceCli } from "./lib/candidate-context-evidence-cli.mjs";
 
 const API_CATALOG_ID = "internal:POST:/api/v2/routes/search:com.easysubway.route.adapter.in.web.RouteSearchController#searchRouteV2";
 
@@ -263,25 +263,4 @@ export function buildMobileConsumptionEvidence({
   };
 }
 
-function argument(name) {
-  const index = process.argv.indexOf(`--${name}`);
-  return index < 0 ? null : process.argv[index + 1];
-}
-
-const entry = process.argv[1] ? path.resolve(process.argv[1]) : null;
-if (entry === fileURLToPath(import.meta.url)) {
-  const candidatePath = argument("candidate-context");
-  const outputPath = argument("output");
-  if (!candidatePath || !outputPath) {
-    throw new Error("--candidate-context and --output are required");
-  }
-  const repoRoot = argument("repo-root") ? path.resolve(argument("repo-root")) : process.cwd();
-  const provenance = argument("provenance") ?? "final-candidate";
-  const evidence = buildMobileConsumptionEvidence({
-    candidate: JSON.parse(readFileSync(candidatePath, "utf8")),
-    repoRoot,
-    provenance,
-  });
-  mkdirSync(path.dirname(outputPath), { recursive: true });
-  writeFileSync(outputPath, `${JSON.stringify(evidence, null, 2)}\n`);
-}
+runCandidateContextEvidenceCli(import.meta.url, buildMobileConsumptionEvidence);

--- a/tools/release/build-privacy-consistency-evidence.mjs
+++ b/tools/release/build-privacy-consistency-evidence.mjs
@@ -47,21 +47,21 @@ const BOUND_EVIDENCE_REFERENCES = {
 
 // 정책 원본에 존재해야 하는 핵심 경계 서술의 최소 anchor. 각 boundary는 (1) inventory가
 // 실제로 그 경계를 선언하는지와 (2) 정책 원본에 그 경계를 알리는 문구 anchor가 있는지를
-// 함께 요구한다. anchor는 산문 전체를 동결하지 않는 최소 리터럴만 쓴다.
+// 함께 요구한다. anchor는 산문 전체를 동결하지 않는 최소 리터럴만 쓴다. inventoryFact는
+// evaluatePolicyBoundaryConsistency가 한 번만 조회해 넘기는 공유 context를 받아, 같은
+// inventory 항목을 여러 boundary가 각자 다시 조회하는 중복을 없앤다.
 const POLICY_BOUNDARIES = [
   {
     id: "gateway_shared_memory_non_persistence",
     descriptionKo:
       "Nginx IP·Authorization shared-memory rate-limit 처리와 DB·access log 비저장 경계",
-    inventoryFact(inventory, items) {
-      const gateway = items.get("route_v2_gateway_abuse_rate_limit_state");
-      const keys = inventory.routeV2GatewayRateLimit?.keys ?? [];
+    inventoryFact({ gateway, gatewayKeys }) {
       return Boolean(
         gateway
           && gateway.googlePlayDataSafety?.deletionSupported === false
           && gateway.googlePlayDataSafety?.processedEphemerally === false
-          && keys.length > 0
-          && keys.every((key) => key.persistedToDatabase === false && key.includedInAccessLog === false),
+          && gatewayKeys.length > 0
+          && gatewayKeys.every((key) => key.persistedToDatabase === false && key.includedInAccessLog === false),
       );
     },
     anchors: [
@@ -75,12 +75,11 @@ const POLICY_BOUNDARIES = [
     id: "route_v2_raw_hash_boundary",
     descriptionKo:
       "선택형 ITX-청춘 Route V2 raw token·nonce 미저장과 SHA-256·논리 만료·5분 purge 물리 파기 경계",
-    inventoryFact(_inventory, items) {
-      const integrity = items.get("route_v2_itx_integrity");
-      const stored = integrity?.backendStoredFields ?? [];
-      const neverPersisted = integrity?.backendNeverPersistedOrLogged ?? [];
+    inventoryFact({ routeV2Integrity }) {
+      const stored = routeV2Integrity?.backendStoredFields ?? [];
+      const neverPersisted = routeV2Integrity?.backendNeverPersistedOrLogged ?? [];
       return Boolean(
-        integrity
+        routeV2Integrity
           && stored.includes("tokenSha256")
           && stored.includes("nonceSha256")
           && neverPersisted.includes("rawIntegrityToken")
@@ -97,9 +96,8 @@ const POLICY_BOUNDARIES = [
     id: "external_map_user_initiated",
     descriptionKo:
       "외부 지도 도보 길안내는 사용자가 직접 누를 때만 좌표를 전달하고 서버에 저장하지 않는 user-initiated 예외 경계",
-    inventoryFact(_inventory, items) {
-      const location = items.get("precise_location");
-      const exception = location?.userInitiatedSharingException;
+    inventoryFact({ preciseLocation }) {
+      const exception = preciseLocation?.userInitiatedSharingException;
       return Boolean(
         exception?.applies === true
           && exception?.consoleThirdPartySharingDeclared === false,
@@ -114,11 +112,10 @@ const POLICY_BOUNDARIES = [
     id: "play_integrity_boundary",
     descriptionKo:
       "Google Play Integrity 처리 정보는 Google 고정 정책을 따르고 backend가 raw token·verdict를 저장·로그하지 않는 경계",
-    inventoryFact(_inventory, items) {
-      const integrity = items.get("route_v2_itx_integrity");
+    inventoryFact({ routeV2Integrity }) {
       return Boolean(
-        integrity?.googlePlayProcessing?.sharedOnward === false
-          && integrity?.googleProcessingMayBeLinkedToSignedInAccountOrDevice === true,
+        routeV2Integrity?.googlePlayProcessing?.sharedOnward === false
+          && routeV2Integrity?.googleProcessingMayBeLinkedToSignedInAccountOrDevice === true,
       );
     },
     anchors: [
@@ -139,6 +136,86 @@ function readInput(repoRoot, relativePath) {
   return { present: true, path: relativePath, text: bytes.toString("utf8"), sha256: sha256(bytes) };
 }
 
+// entry.inventoryDataIds가 가리키는 inventory 항목을 조회해 (1) 참조된 항목 목록과
+// (2) 조회 자체에서 나온 모순(존재하지 않는 id, dataType 불일치)을 반환한다.
+function resolveMatrixEntryReferences(entry, items) {
+  const referenced = [];
+  const contradictions = [];
+  for (const id of entry.inventoryDataIds ?? []) {
+    const item = items.get(id);
+    if (!item) {
+      contradictions.push({ dataType: entry.dataType, code: "missing_inventory_data_id", detail: id });
+      continue;
+    }
+    referenced.push(item);
+    if (item.googlePlayDataSafety?.dataType !== entry.dataType) {
+      contradictions.push({
+        dataType: entry.dataType,
+        code: "inventory_data_type_mismatch",
+        detail: `${id}=${item.googlePlayDataSafety?.dataType}`,
+      });
+    }
+  }
+  return { referenced, contradictions };
+}
+
+// entry의 boolean 집계 플래그(collected/required/optional/deletion-unsupported)가 참조된
+// inventory 항목들의 실제 googlePlayDataSafety 값과 일치하는지 각각 검증한다.
+function checkMatrixEntryAggregateFlags(entry, referenced) {
+  const some = (predicate) => referenced.some((item) => predicate(item.googlePlayDataSafety ?? {}));
+  const flagChecks = [
+    ["containsCollectedData", "collected_flag_mismatch", some((safety) => safety.collected === true)],
+    ["containsRequiredData", "required_flag_mismatch", some((safety) => safety.required === true)],
+    ["containsOptionalData", "optional_flag_mismatch", some((safety) => safety.optional === true)],
+    [
+      "containsDeletionUnsupportedData",
+      "deletion_unsupported_flag_mismatch",
+      some((safety) => safety.deletionSupported === false),
+    ],
+  ];
+  const contradictions = [];
+  for (const [field, code, expected] of flagChecks) {
+    if (Boolean(entry[field]) !== expected) contradictions.push({ dataType: entry.dataType, code });
+  }
+  return contradictions;
+}
+
+// containsLocalOnlyDiagnostics와 requiredConsoleFields는 boolean 집계와 형태가 달라
+// (선언적일 때만 검사, 배열 비교) 별도 helper로 분리한다.
+function checkMatrixEntrySupplementalFields(entry, referenced, requiredConsoleFields) {
+  const contradictions = [];
+  if (entry.containsLocalOnlyDiagnostics !== undefined) {
+    const expectLocalOnly = referenced.some(
+      (item) => (item.googlePlayDataSafety?.collectionType ?? "").includes("local-only"),
+    );
+    if (Boolean(entry.containsLocalOnlyDiagnostics) !== expectLocalOnly) {
+      contradictions.push({ dataType: entry.dataType, code: "local_only_diagnostics_flag_mismatch" });
+    }
+  }
+  if (JSON.stringify(entry.requiredConsoleFields ?? []) !== JSON.stringify(requiredConsoleFields)) {
+    contradictions.push({ dataType: entry.dataType, code: "required_console_fields_mismatch" });
+  }
+  return contradictions;
+}
+
+// inventory에서 실제 수집(collected=true)하는 항목이 모두 폼 matrix에서 참조됐는지
+// (coverage) 확인한다. 누락된 id는 uncovered로, 그 자체도 모순으로 기록한다.
+function findUncoveredCollectedData(inventory, referencedIds) {
+  const uncovered = [];
+  const contradictions = [];
+  for (const item of inventory.dataTypes ?? []) {
+    if (item.googlePlayDataSafety?.collected === true && !referencedIds.has(item.id)) {
+      uncovered.push(item.id);
+      contradictions.push({
+        dataType: item.googlePlayDataSafety?.dataType,
+        code: "uncovered_collected_data",
+        detail: item.id,
+      });
+    }
+  }
+  return { uncovered, contradictions };
+}
+
 // answerMatrix(폼 target)의 각 dataType 집계 선언이 그것이 참조하는 inventory 수집 항목의
 // 실제 값과 모순되지 않는지 검증한다. inventory의 어떤 collected 항목도 폼 matrix에서
 // 누락되지 않았는지(coverage)도 확인한다. 반환하는 contradictions가 비어야 일치다.
@@ -146,67 +223,20 @@ function evaluateAnswerMatrixConsistency(inventory, playForm) {
   const items = new Map((inventory.dataTypes ?? []).map((item) => [item.id, item]));
   const matrix = playForm.dataSafetyDeclarations?.answerMatrix ?? [];
   const requiredConsoleFields = inventory.googlePlayDataSafetyRequiredFields ?? [];
-  const contradictions = [];
   const referencedIds = new Set();
+  const contradictions = [];
 
   for (const entry of matrix) {
-    const referenced = [];
-    for (const id of entry.inventoryDataIds ?? []) {
-      referencedIds.add(id);
-      const item = items.get(id);
-      if (!item) {
-        contradictions.push({ dataType: entry.dataType, code: "missing_inventory_data_id", detail: id });
-        continue;
-      }
-      referenced.push(item);
-      if (item.googlePlayDataSafety?.dataType !== entry.dataType) {
-        contradictions.push({
-          dataType: entry.dataType,
-          code: "inventory_data_type_mismatch",
-          detail: `${id}=${item.googlePlayDataSafety?.dataType}`,
-        });
-      }
-    }
-
-    const some = (predicate) => referenced.some((item) => predicate(item.googlePlayDataSafety ?? {}));
-    const expectCollected = some((safety) => safety.collected === true);
-    const expectRequired = some((safety) => safety.required === true);
-    const expectOptional = some((safety) => safety.optional === true);
-    const expectDeletionUnsupported = some((safety) => safety.deletionSupported === false);
-
-    if (Boolean(entry.containsCollectedData) !== expectCollected) {
-      contradictions.push({ dataType: entry.dataType, code: "collected_flag_mismatch" });
-    }
-    if (Boolean(entry.containsRequiredData) !== expectRequired) {
-      contradictions.push({ dataType: entry.dataType, code: "required_flag_mismatch" });
-    }
-    if (Boolean(entry.containsOptionalData) !== expectOptional) {
-      contradictions.push({ dataType: entry.dataType, code: "optional_flag_mismatch" });
-    }
-    if (Boolean(entry.containsDeletionUnsupportedData) !== expectDeletionUnsupported) {
-      contradictions.push({ dataType: entry.dataType, code: "deletion_unsupported_flag_mismatch" });
-    }
-    if (entry.containsLocalOnlyDiagnostics !== undefined) {
-      const expectLocalOnly = referenced.some(
-        (item) => (item.googlePlayDataSafety?.collectionType ?? "").includes("local-only"),
-      );
-      if (Boolean(entry.containsLocalOnlyDiagnostics) !== expectLocalOnly) {
-        contradictions.push({ dataType: entry.dataType, code: "local_only_diagnostics_flag_mismatch" });
-      }
-    }
-    if (JSON.stringify(entry.requiredConsoleFields ?? []) !== JSON.stringify(requiredConsoleFields)) {
-      contradictions.push({ dataType: entry.dataType, code: "required_console_fields_mismatch" });
-    }
+    for (const id of entry.inventoryDataIds ?? []) referencedIds.add(id);
+    const { referenced, contradictions: referenceContradictions } = resolveMatrixEntryReferences(entry, items);
+    contradictions.push(...referenceContradictions);
+    contradictions.push(...checkMatrixEntryAggregateFlags(entry, referenced));
+    contradictions.push(...checkMatrixEntrySupplementalFields(entry, referenced, requiredConsoleFields));
   }
 
-  // Coverage: inventory에서 실제 수집(collected=true)하는 항목은 모두 폼 matrix가 참조해야 한다.
-  const uncoveredCollected = [];
-  for (const item of inventory.dataTypes ?? []) {
-    if (item.googlePlayDataSafety?.collected === true && !referencedIds.has(item.id)) {
-      uncoveredCollected.push(item.id);
-      contradictions.push({ dataType: item.googlePlayDataSafety?.dataType, code: "uncovered_collected_data", detail: item.id });
-    }
-  }
+  const { uncovered: uncoveredCollected, contradictions: coverageContradictions } =
+    findUncoveredCollectedData(inventory, referencedIds);
+  contradictions.push(...coverageContradictions);
 
   return {
     checkedDataTypes: matrix.length,
@@ -216,12 +246,24 @@ function evaluateAnswerMatrixConsistency(inventory, playForm) {
   };
 }
 
+// 여러 boundary가 공통으로 참조하는 inventory 항목을 한 번만 조회해 각 boundary의
+// inventoryFact에 공유 context로 넘긴다(같은 항목을 boundary마다 다시 조회하는 중복 제거).
+function buildPolicyBoundaryContext(inventory, items) {
+  return {
+    gateway: items.get("route_v2_gateway_abuse_rate_limit_state"),
+    gatewayKeys: inventory.routeV2GatewayRateLimit?.keys ?? [],
+    routeV2Integrity: items.get("route_v2_itx_integrity"),
+    preciseLocation: items.get("precise_location"),
+  };
+}
+
 // runtime inventory가 선언하는 핵심 경계가 실제로 성립하고, 그 경계를 알리는 정책 문구
 // anchor가 공개 정책 원본에 모두 존재하는지 검증한다.
 function evaluatePolicyBoundaryConsistency(inventory, privacyPolicyHtml) {
   const items = new Map((inventory.dataTypes ?? []).map((item) => [item.id, item]));
+  const context = buildPolicyBoundaryContext(inventory, items);
   const boundaries = POLICY_BOUNDARIES.map((boundary) => {
-    const inventoryFactHolds = boundary.inventoryFact(inventory, items);
+    const inventoryFactHolds = boundary.inventoryFact(context);
     const missingAnchors = boundary.anchors.filter((anchor) => !privacyPolicyHtml.includes(anchor));
     return {
       id: boundary.id,

--- a/tools/release/build-privacy-consistency-evidence.mjs
+++ b/tools/release/build-privacy-consistency-evidence.mjs
@@ -7,9 +7,9 @@
 // 존재만 정적으로 검증한다. 불일치가 하나라도 있으면 fail-closed로 BLOCKED를 산출한다.
 
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { runCandidateContextEvidenceCli } from "./lib/candidate-context-evidence-cli.mjs";
 
 const INVENTORY_FILE = "apps/mobile/release/store-privacy-inventory.json";
 const PLAY_FORM_FILE = "apps/mobile/release/play-store-submission-content.json";
@@ -224,19 +224,22 @@ function evaluateAnswerMatrixConsistency(inventory, playForm) {
   const matrix = playForm.dataSafetyDeclarations?.answerMatrix ?? [];
   const requiredConsoleFields = inventory.googlePlayDataSafetyRequiredFields ?? [];
   const referencedIds = new Set();
-  const contradictions = [];
 
-  for (const entry of matrix) {
+  // entry별 세 판정(참조 조회·집계 플래그·보조 필드)의 모순을 한 번에 모은다. push()를
+  // 연쇄 호출하는 대신 flatMap으로 배열을 구성해 같은 entry 순서·같은 판정 순서를 유지한다.
+  const entryContradictions = matrix.flatMap((entry) => {
     for (const id of entry.inventoryDataIds ?? []) referencedIds.add(id);
-    const { referenced, contradictions: referenceContradictions } = resolveMatrixEntryReferences(entry, items);
-    contradictions.push(...referenceContradictions);
-    contradictions.push(...checkMatrixEntryAggregateFlags(entry, referenced));
-    contradictions.push(...checkMatrixEntrySupplementalFields(entry, referenced, requiredConsoleFields));
-  }
+    const { referenced, contradictions } = resolveMatrixEntryReferences(entry, items);
+    return [
+      ...contradictions,
+      ...checkMatrixEntryAggregateFlags(entry, referenced),
+      ...checkMatrixEntrySupplementalFields(entry, referenced, requiredConsoleFields),
+    ];
+  });
 
   const { uncovered: uncoveredCollected, contradictions: coverageContradictions } =
     findUncoveredCollectedData(inventory, referencedIds);
-  contradictions.push(...coverageContradictions);
+  const contradictions = [...entryContradictions, ...coverageContradictions];
 
   return {
     checkedDataTypes: matrix.length,
@@ -349,25 +352,4 @@ export function buildPrivacyConsistencyEvidence({
   };
 }
 
-function argument(name) {
-  const index = process.argv.indexOf(`--${name}`);
-  return index < 0 ? null : process.argv[index + 1];
-}
-
-const entry = process.argv[1] ? path.resolve(process.argv[1]) : null;
-if (entry === fileURLToPath(import.meta.url)) {
-  const candidatePath = argument("candidate-context");
-  const outputPath = argument("output");
-  if (!candidatePath || !outputPath) {
-    throw new Error("--candidate-context and --output are required");
-  }
-  const repoRoot = argument("repo-root") ? path.resolve(argument("repo-root")) : process.cwd();
-  const provenance = argument("provenance") ?? "final-candidate";
-  const evidence = buildPrivacyConsistencyEvidence({
-    candidate: JSON.parse(readFileSync(candidatePath, "utf8")),
-    repoRoot,
-    provenance,
-  });
-  mkdirSync(path.dirname(outputPath), { recursive: true });
-  writeFileSync(outputPath, `${JSON.stringify(evidence, null, 2)}\n`);
-}
+runCandidateContextEvidenceCli(import.meta.url, buildPrivacyConsistencyEvidence);

--- a/tools/release/build-privacy-consistency-evidence.mjs
+++ b/tools/release/build-privacy-consistency-evidence.mjs
@@ -1,0 +1,331 @@
+#!/usr/bin/env node
+
+// #1018 마지막 DoD의 #2056 fragment. Play Data Safety 폼 target(answerMatrix), 공개된
+// 개인정보 처리방침, runtime 수집 inventory 세 원본 사이의 machine-auditable 일치 판정을
+// 같은 candidate-context(#2056) RC identity에 결속해 emit한다. 개인정보 처리방침 산문이나
+// 폼 답변을 재작성하지 않고, 이미 tracked된 세 원본의 내부 모순 0과 정책 경계 문구 anchor
+// 존재만 정적으로 검증한다. 불일치가 하나라도 있으면 fail-closed로 BLOCKED를 산출한다.
+
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const INVENTORY_FILE = "apps/mobile/release/store-privacy-inventory.json";
+const PLAY_FORM_FILE = "apps/mobile/release/play-store-submission-content.json";
+const PRIVACY_POLICY_FILE = "backend/src/main/resources/templates/legal/privacy.html";
+
+// 이미 확보된 외부 검증 사실의 provenance 참조다. 이 값들은 기계적으로 재현할 수 없는
+// 외부 검증(공개 URL 200 응답, runtime denylist audit, Play Console 폼 재제출)이 어디에
+// 기록됐는지 가리키는 인용이며, 아래 status 판정에는 사용하지 않는다. status는 오직 세
+// tracked 원본의 정적 일치 검증 결과로만 결정한다(외부 사실을 status로 위조하지 않는다).
+const BOUND_EVIDENCE_REFERENCES = {
+  publishedPolicy: {
+    url: "https://easysubway-api.aquilaxk.site/easysubway/privacy",
+    effectiveDate: "2026-07-16",
+    trackedSource: PRIVACY_POLICY_FILE,
+    trackedSourceIssue: 2225,
+    trackedSourceCommit: "4b35c23c",
+    recordedResult: "PASS_PUBLIC_HTTPS_UNAUTHENTICATED",
+    verificationCommentUrl:
+      "https://github.com/AquilaXk/easysubway/issues/1018#issuecomment-5018187764",
+  },
+  runtimeDenylistAudit: {
+    scopes: ["database", "application-log", "proxy-log", "metric", "analytics"],
+    recordedViolationCount: 0,
+    capacityRunUrl: "https://github.com/AquilaXk/easysubway/actions/runs/29712689840",
+    verificationCommentUrl:
+      "https://github.com/AquilaXk/easysubway/issues/1018#issuecomment-5018496643",
+  },
+  playConsoleDataSafetyForm: {
+    inventorySource: INVENTORY_FILE,
+    formSource: PLAY_FORM_FILE,
+    resubmittedAt: "2026-07-18",
+    recordedResult: "RESUBMITTED_AND_REVIEWED_FROM_TRACKED_INVENTORY",
+  },
+};
+
+// 정책 원본에 존재해야 하는 핵심 경계 서술의 최소 anchor. 각 boundary는 (1) inventory가
+// 실제로 그 경계를 선언하는지와 (2) 정책 원본에 그 경계를 알리는 문구 anchor가 있는지를
+// 함께 요구한다. anchor는 산문 전체를 동결하지 않는 최소 리터럴만 쓴다.
+const POLICY_BOUNDARIES = [
+  {
+    id: "gateway_shared_memory_non_persistence",
+    descriptionKo:
+      "Nginx IP·Authorization shared-memory rate-limit 처리와 DB·access log 비저장 경계",
+    inventoryFact(inventory, items) {
+      const gateway = items.get("route_v2_gateway_abuse_rate_limit_state");
+      const keys = inventory.routeV2GatewayRateLimit?.keys ?? [];
+      return Boolean(
+        gateway
+          && gateway.googlePlayDataSafety?.deletionSupported === false
+          && gateway.googlePlayDataSafety?.processedEphemerally === false
+          && keys.length > 0
+          && keys.every((key) => key.persistedToDatabase === false && key.includedInAccessLog === false),
+      );
+    },
+    anchors: [
+      "$binary_remote_addr",
+      "$http_authorization",
+      "shared memory",
+      "DB나 access log에는 저장하지 않습니다",
+    ],
+  },
+  {
+    id: "route_v2_raw_hash_boundary",
+    descriptionKo:
+      "선택형 ITX-청춘 Route V2 raw token·nonce 미저장과 SHA-256·논리 만료·5분 purge 물리 파기 경계",
+    inventoryFact(_inventory, items) {
+      const integrity = items.get("route_v2_itx_integrity");
+      const stored = integrity?.backendStoredFields ?? [];
+      const neverPersisted = integrity?.backendNeverPersistedOrLogged ?? [];
+      return Boolean(
+        integrity
+          && stored.includes("tokenSha256")
+          && stored.includes("nonceSha256")
+          && neverPersisted.includes("rawIntegrityToken")
+          && neverPersisted.includes("rawClientNonce"),
+      );
+    },
+    anchors: [
+      "raw integrityToken을 저장하지 않고",
+      "nonce SHA-256",
+      "purge로 물리 삭제",
+    ],
+  },
+  {
+    id: "external_map_user_initiated",
+    descriptionKo:
+      "외부 지도 도보 길안내는 사용자가 직접 누를 때만 좌표를 전달하고 서버에 저장하지 않는 user-initiated 예외 경계",
+    inventoryFact(_inventory, items) {
+      const location = items.get("precise_location");
+      const exception = location?.userInitiatedSharingException;
+      return Boolean(
+        exception?.applies === true
+          && exception?.consoleThirdPartySharingDeclared === false,
+      );
+    },
+    anchors: [
+      "출구 도보 길안내를 명시적으로 누른 경우에만",
+      "쉬운 지하철 서버에는 저장하지 않습니다",
+    ],
+  },
+  {
+    id: "play_integrity_boundary",
+    descriptionKo:
+      "Google Play Integrity 처리 정보는 Google 고정 정책을 따르고 backend가 raw token·verdict를 저장·로그하지 않는 경계",
+    inventoryFact(_inventory, items) {
+      const integrity = items.get("route_v2_itx_integrity");
+      return Boolean(
+        integrity?.googlePlayProcessing?.sharedOnward === false
+          && integrity?.googleProcessingMayBeLinkedToSignedInAccountOrDevice === true,
+      );
+    },
+    anchors: [
+      "Integrity payload·verdict를 DB에 저장하거나 로그에 남기지 않으며",
+      "Google Play Integrity decode API",
+    ],
+  },
+];
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function readInput(repoRoot, relativePath) {
+  const absolute = path.join(repoRoot, relativePath);
+  if (!existsSync(absolute)) return { present: false, path: relativePath, text: null, sha256: null };
+  const bytes = readFileSync(absolute);
+  return { present: true, path: relativePath, text: bytes.toString("utf8"), sha256: sha256(bytes) };
+}
+
+// answerMatrix(폼 target)의 각 dataType 집계 선언이 그것이 참조하는 inventory 수집 항목의
+// 실제 값과 모순되지 않는지 검증한다. inventory의 어떤 collected 항목도 폼 matrix에서
+// 누락되지 않았는지(coverage)도 확인한다. 반환하는 contradictions가 비어야 일치다.
+function evaluateAnswerMatrixConsistency(inventory, playForm) {
+  const items = new Map((inventory.dataTypes ?? []).map((item) => [item.id, item]));
+  const matrix = playForm.dataSafetyDeclarations?.answerMatrix ?? [];
+  const requiredConsoleFields = inventory.googlePlayDataSafetyRequiredFields ?? [];
+  const contradictions = [];
+  const referencedIds = new Set();
+
+  for (const entry of matrix) {
+    const referenced = [];
+    for (const id of entry.inventoryDataIds ?? []) {
+      referencedIds.add(id);
+      const item = items.get(id);
+      if (!item) {
+        contradictions.push({ dataType: entry.dataType, code: "missing_inventory_data_id", detail: id });
+        continue;
+      }
+      referenced.push(item);
+      if (item.googlePlayDataSafety?.dataType !== entry.dataType) {
+        contradictions.push({
+          dataType: entry.dataType,
+          code: "inventory_data_type_mismatch",
+          detail: `${id}=${item.googlePlayDataSafety?.dataType}`,
+        });
+      }
+    }
+
+    const some = (predicate) => referenced.some((item) => predicate(item.googlePlayDataSafety ?? {}));
+    const expectCollected = some((safety) => safety.collected === true);
+    const expectRequired = some((safety) => safety.required === true);
+    const expectOptional = some((safety) => safety.optional === true);
+    const expectDeletionUnsupported = some((safety) => safety.deletionSupported === false);
+
+    if (Boolean(entry.containsCollectedData) !== expectCollected) {
+      contradictions.push({ dataType: entry.dataType, code: "collected_flag_mismatch" });
+    }
+    if (Boolean(entry.containsRequiredData) !== expectRequired) {
+      contradictions.push({ dataType: entry.dataType, code: "required_flag_mismatch" });
+    }
+    if (Boolean(entry.containsOptionalData) !== expectOptional) {
+      contradictions.push({ dataType: entry.dataType, code: "optional_flag_mismatch" });
+    }
+    if (Boolean(entry.containsDeletionUnsupportedData) !== expectDeletionUnsupported) {
+      contradictions.push({ dataType: entry.dataType, code: "deletion_unsupported_flag_mismatch" });
+    }
+    if (entry.containsLocalOnlyDiagnostics !== undefined) {
+      const expectLocalOnly = referenced.some(
+        (item) => (item.googlePlayDataSafety?.collectionType ?? "").includes("local-only"),
+      );
+      if (Boolean(entry.containsLocalOnlyDiagnostics) !== expectLocalOnly) {
+        contradictions.push({ dataType: entry.dataType, code: "local_only_diagnostics_flag_mismatch" });
+      }
+    }
+    if (JSON.stringify(entry.requiredConsoleFields ?? []) !== JSON.stringify(requiredConsoleFields)) {
+      contradictions.push({ dataType: entry.dataType, code: "required_console_fields_mismatch" });
+    }
+  }
+
+  // Coverage: inventory에서 실제 수집(collected=true)하는 항목은 모두 폼 matrix가 참조해야 한다.
+  const uncoveredCollected = [];
+  for (const item of inventory.dataTypes ?? []) {
+    if (item.googlePlayDataSafety?.collected === true && !referencedIds.has(item.id)) {
+      uncoveredCollected.push(item.id);
+      contradictions.push({ dataType: item.googlePlayDataSafety?.dataType, code: "uncovered_collected_data", detail: item.id });
+    }
+  }
+
+  return {
+    checkedDataTypes: matrix.length,
+    uncoveredCollected,
+    contradictions,
+    consistent: contradictions.length === 0,
+  };
+}
+
+// runtime inventory가 선언하는 핵심 경계가 실제로 성립하고, 그 경계를 알리는 정책 문구
+// anchor가 공개 정책 원본에 모두 존재하는지 검증한다.
+function evaluatePolicyBoundaryConsistency(inventory, privacyPolicyHtml) {
+  const items = new Map((inventory.dataTypes ?? []).map((item) => [item.id, item]));
+  const boundaries = POLICY_BOUNDARIES.map((boundary) => {
+    const inventoryFactHolds = boundary.inventoryFact(inventory, items);
+    const missingAnchors = boundary.anchors.filter((anchor) => !privacyPolicyHtml.includes(anchor));
+    return {
+      id: boundary.id,
+      descriptionKo: boundary.descriptionKo,
+      inventoryFactHolds,
+      anchors: boundary.anchors,
+      missingAnchors,
+      consistent: inventoryFactHolds && missingAnchors.length === 0,
+    };
+  });
+  return {
+    boundaries,
+    consistent: boundaries.every((boundary) => boundary.consistent),
+  };
+}
+
+export function buildPrivacyConsistencyEvidence({
+  candidate,
+  repoRoot = process.cwd(),
+  generatedAt = new Date().toISOString(),
+  provenance = "final-candidate",
+}) {
+  const identity = candidate?.releaseCandidateIdentity;
+  if (candidate?.phase !== "CANDIDATE" || candidate?.issue !== 2056 || !identity) {
+    throw new Error("privacy consistency evidence requires the #2056 CANDIDATE context");
+  }
+
+  const inventoryInput = readInput(repoRoot, INVENTORY_FILE);
+  const playFormInput = readInput(repoRoot, PLAY_FORM_FILE);
+  const policyInput = readInput(repoRoot, PRIVACY_POLICY_FILE);
+  const inputs = {
+    inventory: { path: inventoryInput.path, sha256: inventoryInput.sha256 },
+    playForm: { path: playFormInput.path, sha256: playFormInput.sha256 },
+    privacyPolicy: { path: policyInput.path, sha256: policyInput.sha256 },
+  };
+  const missingInputs = [inventoryInput, playFormInput, policyInput]
+    .filter((input) => !input.present)
+    .map((input) => input.path);
+
+  if (missingInputs.length > 0) {
+    return {
+      schemaVersion: 1,
+      artifactKind: "store-privacy-consistency-evidence",
+      sourceIssue: 1018,
+      consumerIssue: 2056,
+      generatedAt,
+      provenance,
+      status: "BLOCKED_PRIVACY_CONSISTENCY_INPUTS",
+      releaseCandidateIdentity: identity,
+      inputs,
+      missingInputs,
+      boundEvidenceReferences: BOUND_EVIDENCE_REFERENCES,
+      checks: {
+        inventoryFormConsistent: "BLOCKED",
+        inventoryPolicyConsistent: "BLOCKED",
+      },
+    };
+  }
+
+  const inventory = JSON.parse(inventoryInput.text);
+  const playForm = JSON.parse(playFormInput.text);
+  const answerMatrixConsistency = evaluateAnswerMatrixConsistency(inventory, playForm);
+  const policyBoundaryConsistency = evaluatePolicyBoundaryConsistency(inventory, policyInput.text);
+  const consistent = answerMatrixConsistency.consistent && policyBoundaryConsistency.consistent;
+
+  return {
+    schemaVersion: 1,
+    artifactKind: "store-privacy-consistency-evidence",
+    sourceIssue: 1018,
+    consumerIssue: 2056,
+    generatedAt,
+    provenance,
+    status: consistent ? "SATISFIED" : "BLOCKED_PRIVACY_CONSISTENCY",
+    releaseCandidateIdentity: identity,
+    inputs,
+    boundEvidenceReferences: BOUND_EVIDENCE_REFERENCES,
+    answerMatrixConsistency,
+    policyBoundaryConsistency,
+    checks: {
+      inventoryFormConsistent: answerMatrixConsistency.consistent ? "SATISFIED" : "FAILED",
+      inventoryPolicyConsistent: policyBoundaryConsistency.consistent ? "SATISFIED" : "FAILED",
+    },
+  };
+}
+
+function argument(name) {
+  const index = process.argv.indexOf(`--${name}`);
+  return index < 0 ? null : process.argv[index + 1];
+}
+
+const entry = process.argv[1] ? path.resolve(process.argv[1]) : null;
+if (entry === fileURLToPath(import.meta.url)) {
+  const candidatePath = argument("candidate-context");
+  const outputPath = argument("output");
+  if (!candidatePath || !outputPath) {
+    throw new Error("--candidate-context and --output are required");
+  }
+  const repoRoot = argument("repo-root") ? path.resolve(argument("repo-root")) : process.cwd();
+  const provenance = argument("provenance") ?? "final-candidate";
+  const evidence = buildPrivacyConsistencyEvidence({
+    candidate: JSON.parse(readFileSync(candidatePath, "utf8")),
+    repoRoot,
+    provenance,
+  });
+  mkdirSync(path.dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, `${JSON.stringify(evidence, null, 2)}\n`);
+}

--- a/tools/release/build-privacy-consistency-evidence.mjs
+++ b/tools/release/build-privacy-consistency-evidence.mjs
@@ -37,9 +37,18 @@ const BOUND_EVIDENCE_REFERENCES = {
     verificationCommentUrl:
       "https://github.com/AquilaXk/easysubway/issues/1018#issuecomment-5018496643",
   },
+  // reviewedFormSha256/reviewedFormCommit은 2026-07-18 Play Console 재제출·검토 당시
+  // play-store-submission-content.json 원문에 결속된 고정값이다(git show
+  // 7ca868068717132c984d673718f350c3400e4ac5:apps/mobile/release/play-store-submission-content.json
+  // | shasum -a 256). 이후(2026-07-19, train_search_queries 추가 등) 파일이 바뀌면 현재
+  // tracked 파일의 sha256이 이 값과 달라지고, evaluatePlayConsoleProvenanceConsistency가
+  // 그 차이를 STALE로 fail-closed 판정한다 — Console이 실제로 검토한 적 없는 최신 내용을
+  // 검토된 것처럼 위조하지 않는다.
   playConsoleDataSafetyForm: {
     inventorySource: INVENTORY_FILE,
     formSource: PLAY_FORM_FILE,
+    reviewedFormCommit: "7ca86806",
+    reviewedFormSha256: "67cc31f63c90e1a28fd5d1a0e372ffaa1d1dfe6f41f3a55d439ce3b376af1803",
     resubmittedAt: "2026-07-18",
     recordedResult: "RESUBMITTED_AND_REVIEWED_FROM_TRACKED_INVENTORY",
   },
@@ -82,6 +91,11 @@ const POLICY_BOUNDARIES = [
         routeV2Integrity
           && stored.includes("tokenSha256")
           && stored.includes("nonceSha256")
+          // raw 필드가 backendStoredFields에 있으면 backendNeverPersistedOrLogged가 같은
+          // 필드를 "저장 안 함"으로 선언해도 실제 저장 목록과 모순이다 — hash 필드 존재만
+          // 보고 통과시키지 않는다.
+          && !stored.includes("rawIntegrityToken")
+          && !stored.includes("rawClientNonce")
           && neverPersisted.includes("rawIntegrityToken")
           && neverPersisted.includes("rawClientNonce"),
       );
@@ -113,9 +127,13 @@ const POLICY_BOUNDARIES = [
     descriptionKo:
       "Google Play Integrity 처리 정보는 Google 고정 정책을 따르고 backend가 raw token·verdict를 저장·로그하지 않는 경계",
     inventoryFact({ routeV2Integrity }) {
+      const neverPersisted = routeV2Integrity?.backendNeverPersistedOrLogged ?? [];
       return Boolean(
         routeV2Integrity?.googlePlayProcessing?.sharedOnward === false
-          && routeV2Integrity?.googleProcessingMayBeLinkedToSignedInAccountOrDevice === true,
+          && routeV2Integrity?.googleProcessingMayBeLinkedToSignedInAccountOrDevice === true
+          // Google Integrity payload·verdict 자체를 backend가 저장·로그하지 않는다는
+          // 선언이 없으면, sharedOnward=false만으로는 이 boundary가 실제로 성립하지 않는다.
+          && neverPersisted.includes("integrityPayloadOrVerdict"),
       );
     },
     anchors: [
@@ -160,7 +178,9 @@ function resolveMatrixEntryReferences(entry, items) {
 }
 
 // entry의 boolean 집계 플래그(collected/required/optional/deletion-unsupported)가 참조된
-// inventory 항목들의 실제 googlePlayDataSafety 값과 일치하는지 각각 검증한다.
+// inventory 항목들의 실제 googlePlayDataSafety 값과 일치하는지 각각 검증한다. 필드가
+// 아예 없거나 boolean이 아니면(예: 문자열 "true") malformed/불완전한 Console 선언으로
+// fail-closed 처리한다 — Boolean(...) truthy 변환이나 undefined 기본값에 기대지 않는다.
 function checkMatrixEntryAggregateFlags(entry, referenced) {
   const some = (predicate) => referenced.some((item) => predicate(item.googlePlayDataSafety ?? {}));
   const flagChecks = [
@@ -175,7 +195,16 @@ function checkMatrixEntryAggregateFlags(entry, referenced) {
   ];
   const contradictions = [];
   for (const [field, code, expected] of flagChecks) {
-    if (Boolean(entry[field]) !== expected) contradictions.push({ dataType: entry.dataType, code });
+    const value = entry[field];
+    if (typeof value !== "boolean") {
+      contradictions.push({
+        dataType: entry.dataType,
+        code: "aggregate_flag_missing_or_not_boolean",
+        detail: `${field}=${JSON.stringify(value ?? null)}`,
+      });
+      continue;
+    }
+    if (value !== expected) contradictions.push({ dataType: entry.dataType, code });
   }
   return contradictions;
 }
@@ -260,14 +289,22 @@ function buildPolicyBoundaryContext(inventory, items) {
   };
 }
 
+// HTML 주석(<!-- ... -->) 안에만 남은 문구는 실제 사용자에게 렌더링되지 않으므로 anchor
+// 검사 대상에서 제외한다. 완전한 HTML 파서는 만들지 않고 주석 블록만 제거하는 최소
+// 정규식을 쓴다(각 anchor는 순수 텍스트 리터럴이라 이 정도로 충분하다).
+function stripHtmlComments(html) {
+  return html.replace(/<!--[\s\S]*?-->/g, "");
+}
+
 // runtime inventory가 선언하는 핵심 경계가 실제로 성립하고, 그 경계를 알리는 정책 문구
-// anchor가 공개 정책 원본에 모두 존재하는지 검증한다.
+// anchor가 공개 정책 원본(주석 제외 렌더링 텍스트)에 모두 존재하는지 검증한다.
 function evaluatePolicyBoundaryConsistency(inventory, privacyPolicyHtml) {
   const items = new Map((inventory.dataTypes ?? []).map((item) => [item.id, item]));
   const context = buildPolicyBoundaryContext(inventory, items);
+  const renderedPolicyText = stripHtmlComments(privacyPolicyHtml);
   const boundaries = POLICY_BOUNDARIES.map((boundary) => {
     const inventoryFactHolds = boundary.inventoryFact(context);
-    const missingAnchors = boundary.anchors.filter((anchor) => !privacyPolicyHtml.includes(anchor));
+    const missingAnchors = boundary.anchors.filter((anchor) => !renderedPolicyText.includes(anchor));
     return {
       id: boundary.id,
       descriptionKo: boundary.descriptionKo,
@@ -283,11 +320,31 @@ function evaluatePolicyBoundaryConsistency(inventory, privacyPolicyHtml) {
   };
 }
 
+// Console이 실제로 검토·재제출한 폼 원문 sha256(reviewedFormSha256)과 현재 tracked
+// play-store-submission-content.json의 sha256이 같은지 검증한다. 다르면(예: 검토 이후
+// commit이 폼을 바꿨는데 재제출·재검토가 없었으면) 그 provenance는 최신 상태를 대변하지
+// 않으므로 STALE로 fail-closed 처리한다 — 검토된 적 없는 내용을 검토된 것처럼 위조하지
+// 않는다.
+function evaluatePlayConsoleProvenanceConsistency(currentFormSha256, reviewedFormSha256) {
+  const matchesReviewedRevision = /^[0-9a-f]{64}$/.test(reviewedFormSha256 ?? "")
+    && currentFormSha256 === reviewedFormSha256;
+  return {
+    reviewedFormSha256: reviewedFormSha256 ?? null,
+    currentFormSha256,
+    matchesReviewedRevision,
+    consistent: matchesReviewedRevision,
+  };
+}
+
 export function buildPrivacyConsistencyEvidence({
   candidate,
   repoRoot = process.cwd(),
   generatedAt = new Date().toISOString(),
   provenance = "final-candidate",
+  // 프로덕션/CLI 경로는 항상 기본값(2026-07-18 실제 검토 시점의 고정 historical hash)을
+  // 쓴다. 이 파라미터는 evaluatePlayConsoleProvenanceConsistency 로직을 git 이력에
+  // 결합하지 않고 독립적으로 단위 테스트하기 위한 테스트 전용 override다.
+  reviewedPlayFormSha256 = BOUND_EVIDENCE_REFERENCES.playConsoleDataSafetyForm.reviewedFormSha256,
 }) {
   const identity = candidate?.releaseCandidateIdentity;
   if (candidate?.phase !== "CANDIDATE" || candidate?.issue !== 2056 || !identity) {
@@ -322,6 +379,7 @@ export function buildPrivacyConsistencyEvidence({
       checks: {
         inventoryFormConsistent: "BLOCKED",
         inventoryPolicyConsistent: "BLOCKED",
+        playConsoleProvenanceCurrent: "BLOCKED",
       },
     };
   }
@@ -330,7 +388,13 @@ export function buildPrivacyConsistencyEvidence({
   const playForm = JSON.parse(playFormInput.text);
   const answerMatrixConsistency = evaluateAnswerMatrixConsistency(inventory, playForm);
   const policyBoundaryConsistency = evaluatePolicyBoundaryConsistency(inventory, policyInput.text);
-  const consistent = answerMatrixConsistency.consistent && policyBoundaryConsistency.consistent;
+  const playConsoleProvenanceConsistency = evaluatePlayConsoleProvenanceConsistency(
+    playFormInput.sha256,
+    reviewedPlayFormSha256,
+  );
+  const consistent = answerMatrixConsistency.consistent
+    && policyBoundaryConsistency.consistent
+    && playConsoleProvenanceConsistency.consistent;
 
   return {
     schemaVersion: 1,
@@ -345,9 +409,11 @@ export function buildPrivacyConsistencyEvidence({
     boundEvidenceReferences: BOUND_EVIDENCE_REFERENCES,
     answerMatrixConsistency,
     policyBoundaryConsistency,
+    playConsoleProvenanceConsistency,
     checks: {
       inventoryFormConsistent: answerMatrixConsistency.consistent ? "SATISFIED" : "FAILED",
       inventoryPolicyConsistent: policyBoundaryConsistency.consistent ? "SATISFIED" : "FAILED",
+      playConsoleProvenanceCurrent: playConsoleProvenanceConsistency.consistent ? "SATISFIED" : "STALE",
     },
   };
 }

--- a/tools/release/build-privacy-consistency-evidence.test.mjs
+++ b/tools/release/build-privacy-consistency-evidence.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -40,10 +41,31 @@ async function fixtureRepoRoot({ mutateInventory, mutatePlayForm, mutatePolicy }
   return root;
 }
 
-test("현재 tracked 원본에 대해 실행하면 SATISFIED와 모순 0을 산출한다", () => {
+// PR #2357 폴백 리뷰(review id 4732563185)의 aggregate flag 지적(모든 dataType이 4개
+// boolean을 명시)을 만족하는 fixture. 실제 tracked play-store-submission-content.json은
+// 5개 dataType이 containsDeletionUnsupportedData를 생략해 이 요구를 충족하지 못한다(아래
+// "현재 tracked 원본" 테스트가 그 사실 자체를 검증한다) — 이 fixture는 "데이터가 완전할
+// 때 SATISFIED가 나온다"는 happy path를 별도로 증명하기 위한 것이다.
+function fillExplicitAggregateFlags(playForm) {
+  for (const entry of playForm.dataSafetyDeclarations.answerMatrix) {
+    if (typeof entry.containsDeletionUnsupportedData !== "boolean") {
+      entry.containsDeletionUnsupportedData = false;
+    }
+  }
+}
+
+async function sha256File(filePath) {
+  return createHash("sha256").update(await readFile(filePath)).digest("hex");
+}
+
+test("aggregate flag가 모두 명시적 boolean이고 provenance가 검토 revision과 일치하면 SATISFIED와 모순 0을 산출한다", async () => {
+  const repoRoot = await fixtureRepoRoot({ mutatePlayForm: fillExplicitAggregateFlags });
+  const reviewedPlayFormSha256 = await sha256File(path.join(repoRoot, PLAY_FORM_FILE));
+
   const evidence = buildPrivacyConsistencyEvidence({
     candidate: candidate(),
-    repoRoot: REPO_ROOT,
+    repoRoot,
+    reviewedPlayFormSha256,
     generatedAt: "2026-07-20T00:00:00.000Z",
   });
 
@@ -56,8 +78,11 @@ test("현재 tracked 원본에 대해 실행하면 SATISFIED와 모순 0을 산�
   assert.equal(evidence.answerMatrixConsistency.contradictions.length, 0);
   assert.equal(evidence.answerMatrixConsistency.uncoveredCollected.length, 0);
   assert.equal(evidence.policyBoundaryConsistency.consistent, true);
+  assert.equal(evidence.playConsoleProvenanceConsistency.consistent, true);
+  assert.equal(evidence.playConsoleProvenanceConsistency.matchesReviewedRevision, true);
   assert.equal(evidence.checks.inventoryFormConsistent, "SATISFIED");
   assert.equal(evidence.checks.inventoryPolicyConsistent, "SATISFIED");
+  assert.equal(evidence.checks.playConsoleProvenanceCurrent, "SATISFIED");
   for (const boundary of evidence.policyBoundaryConsistency.boundaries) {
     assert.equal(boundary.inventoryFactHolds, true, `${boundary.id} inventory fact`);
     assert.deepEqual(boundary.missingAnchors, [], `${boundary.id} anchors`);
@@ -66,7 +91,71 @@ test("현재 tracked 원본에 대해 실행하면 SATISFIED와 모순 0을 산�
   assert.match(evidence.inputs.privacyPolicy.sha256, /^[0-9a-f]{64}$/);
 });
 
-// 네 BLOCKED 회귀는 "fixtureRepoRoot로 특정 원본만 오염 → 실행 → status가
+// [Major, PR #2357 review 4732563185] 2026-07-18 커밋(7ca86806)이 Play Console 재제출·검토
+// 당시의 play-store-submission-content.json이고, 그 sha256을 BOUND_EVIDENCE_REFERENCES에
+// 고정했다. 2026-07-19 커밋(9fd69f5, train_search_queries 추가)이 그 뒤로 파일을 바꿨으므로
+// 현재 tracked 파일은 검토된 revision과 다르다 — provenance는 STALE이어야 하고(위조 금지),
+// 같은 변경으로 5개 dataType이 containsDeletionUnsupportedData를 명시하지 않아
+// answerMatrix도 FAILED다. 정책 anchor·inventory boundary fact는 이 변경과 무관하게
+// 여전히 일치한다.
+test("현재 tracked 원본에 대해 실행하면 실제 결함(폼 provenance stale·집계 flag 누락)을 fail-closed로 드러낸다", () => {
+  const evidence = buildPrivacyConsistencyEvidence({
+    candidate: candidate(),
+    repoRoot: REPO_ROOT,
+    generatedAt: "2026-07-20T00:00:00.000Z",
+  });
+
+  assert.equal(evidence.playConsoleProvenanceConsistency.consistent, false);
+  assert.equal(evidence.playConsoleProvenanceConsistency.matchesReviewedRevision, false);
+  assert.equal(
+    evidence.playConsoleProvenanceConsistency.reviewedFormSha256,
+    "67cc31f63c90e1a28fd5d1a0e372ffaa1d1dfe6f41f3a55d439ce3b376af1803",
+  );
+  assert.notEqual(
+    evidence.playConsoleProvenanceConsistency.currentFormSha256,
+    evidence.playConsoleProvenanceConsistency.reviewedFormSha256,
+  );
+  assert.equal(evidence.checks.playConsoleProvenanceCurrent, "STALE");
+
+  assert.equal(evidence.checks.inventoryFormConsistent, "FAILED");
+  const missingFlagTypes = evidence.answerMatrixConsistency.contradictions
+    .filter((item) => item.code === "aggregate_flag_missing_or_not_boolean")
+    .map((item) => item.dataType)
+    .sort();
+  assert.deepEqual(missingFlagTypes, [
+    "Diagnostics",
+    "Location",
+    "Personal info",
+    "Photos and videos",
+    "User-generated content",
+  ]);
+
+  assert.equal(evidence.checks.inventoryPolicyConsistent, "SATISFIED");
+  assert.equal(evidence.policyBoundaryConsistency.consistent, true);
+
+  assert.equal(evidence.status, "BLOCKED_PRIVACY_CONSISTENCY");
+});
+
+// reviewedPlayFormSha256 override로 provenance 판정 로직 자체를 git 이력과 분리해
+// 단위 검증한다: answerMatrix·policy는 fixture에서 완전히 일치하지만 검토 revision이
+// 현재 폼과 다르면 그 사실 하나만으로 BLOCKED되는지 확인한다.
+test("reviewedPlayFormSha256이 현재 폼 sha256과 다르면 다른 판정이 전부 통과해도 STALE로 BLOCKED한다", async () => {
+  const repoRoot = await fixtureRepoRoot({ mutatePlayForm: fillExplicitAggregateFlags });
+
+  const evidence = buildPrivacyConsistencyEvidence({
+    candidate: candidate(),
+    repoRoot,
+    reviewedPlayFormSha256: "f".repeat(64),
+  });
+
+  assert.equal(evidence.answerMatrixConsistency.consistent, true);
+  assert.equal(evidence.policyBoundaryConsistency.consistent, true);
+  assert.equal(evidence.playConsoleProvenanceConsistency.consistent, false);
+  assert.equal(evidence.checks.playConsoleProvenanceCurrent, "STALE");
+  assert.equal(evidence.status, "BLOCKED_PRIVACY_CONSISTENCY");
+});
+
+// 아래 BLOCKED 회귀는 "fixtureRepoRoot로 특정 원본만 오염 → 실행 → status가
 // BLOCKED_PRIVACY_CONSISTENCY" 구조가 모두 같다. 그 반복되는 실행·공통 assert 골격을
 // 한 곳(아래 for 루프)에만 두고, 케이스마다 다른 mutate 콜백과 세부 assert만 테이블로 둔다.
 const BLOCKED_CONSISTENCY_CASES = [
@@ -96,6 +185,25 @@ const BLOCKED_CONSISTENCY_CASES = [
     },
   },
   {
+    // [Minor, review 4732563185] aggregate flag 문자열("true")이 truthy 변환으로 우연히
+    // 통과하지 않는지 확인한다. Boolean("true")===true이므로 예전 구현이면 이 mutation은
+    // 오히려 "일치"로 오판했을 것이다.
+    name: "aggregate flag가 boolean이 아닌 문자열이면 truthy 변환 없이 fail-closed BLOCKED한다",
+    mutatePlayForm(playForm) {
+      const location = playForm.dataSafetyDeclarations.answerMatrix.find((item) => item.dataType === "Location");
+      location.containsCollectedData = "true";
+    },
+    assertEvidence(evidence) {
+      assert.ok(
+        evidence.answerMatrixConsistency.contradictions.some(
+          (item) => item.dataType === "Location"
+            && item.code === "aggregate_flag_missing_or_not_boolean"
+            && item.detail.includes("containsCollectedData"),
+        ),
+      );
+    },
+  },
+  {
     name: "정책 원본에서 경계 문구 anchor가 사라지면 fail-closed BLOCKED한다",
     mutatePolicy(policy) {
       return policy.replace("DB나 access log에는 저장하지 않습니다", "생략");
@@ -110,7 +218,26 @@ const BLOCKED_CONSISTENCY_CASES = [
     },
   },
   {
-    name: "inventory가 경계를 더 이상 선언하지 않으면 정책 anchor가 있어도 BLOCKED한다",
+    // [Minor, review 4732563185] 같은 anchor 문구가 HTML 주석 안으로만 옮겨져도 원문
+    // includes()는 여전히 true를 반환한다 — 렌더링되지 않는 주석은 anchor 검사에서
+    // 제외돼야 한다.
+    name: "정책 anchor 문구가 HTML 주석 안에만 남으면 렌더링되지 않은 것으로 보아 fail-closed BLOCKED한다",
+    mutatePolicy(policy) {
+      return policy.replace(
+        "DB나 access log에는 저장하지 않습니다",
+        "<!-- DB나 access log에는 저장하지 않습니다 -->",
+      );
+    },
+    assertEvidence(evidence) {
+      const gateway = evidence.policyBoundaryConsistency.boundaries.find(
+        (item) => item.id === "gateway_shared_memory_non_persistence",
+      );
+      assert.equal(gateway.consistent, false);
+      assert.ok(gateway.missingAnchors.includes("DB나 access log에는 저장하지 않습니다"));
+    },
+  },
+  {
+    name: "inventory가 raw/hash 경계를 더 이상 선언하지 않으면 정책 anchor가 있어도 BLOCKED한다",
     mutateInventory(inventory) {
       const integrity = inventory.dataTypes.find((item) => item.id === "route_v2_itx_integrity");
       integrity.backendNeverPersistedOrLogged = integrity.backendNeverPersistedOrLogged.filter(
@@ -120,6 +247,41 @@ const BLOCKED_CONSISTENCY_CASES = [
     assertEvidence(evidence) {
       const boundary = evidence.policyBoundaryConsistency.boundaries.find(
         (item) => item.id === "route_v2_raw_hash_boundary",
+      );
+      assert.equal(boundary.inventoryFactHolds, false);
+      assert.equal(boundary.consistent, false);
+    },
+  },
+  {
+    // [Minor, review 4732563185] raw 필드가 backendStoredFields에 실제로 추가되면(내부
+    // 모순) backendNeverPersistedOrLogged에 두 raw 필드가 남아 있어도 boundary는 거짓이어야
+    // 한다 — hash 필드 존재만으로 통과시키지 않는다.
+    name: "backendStoredFields에 raw 필드가 추가되면 raw/hash 경계가 fail-closed BLOCKED한다",
+    mutateInventory(inventory) {
+      const integrity = inventory.dataTypes.find((item) => item.id === "route_v2_itx_integrity");
+      integrity.backendStoredFields = [...integrity.backendStoredFields, "rawIntegrityToken"];
+    },
+    assertEvidence(evidence) {
+      const boundary = evidence.policyBoundaryConsistency.boundaries.find(
+        (item) => item.id === "route_v2_raw_hash_boundary",
+      );
+      assert.equal(boundary.inventoryFactHolds, false);
+      assert.equal(boundary.consistent, false);
+    },
+  },
+  {
+    // [Minor, review 4732563185] integrityPayloadOrVerdict 비저장 선언이 사라지면
+    // sharedOnward=false만으로는 Play Integrity boundary가 성립하지 않아야 한다.
+    name: "route_v2_itx_integrity가 integrityPayloadOrVerdict 비저장을 더 이상 선언하지 않으면 Play Integrity 경계가 BLOCKED한다",
+    mutateInventory(inventory) {
+      const integrity = inventory.dataTypes.find((item) => item.id === "route_v2_itx_integrity");
+      integrity.backendNeverPersistedOrLogged = integrity.backendNeverPersistedOrLogged.filter(
+        (field) => field !== "integrityPayloadOrVerdict",
+      );
+    },
+    assertEvidence(evidence) {
+      const boundary = evidence.policyBoundaryConsistency.boundaries.find(
+        (item) => item.id === "play_integrity_boundary",
       );
       assert.equal(boundary.inventoryFactHolds, false);
       assert.equal(boundary.consistent, false);
@@ -144,6 +306,7 @@ test("입력 원본이 없으면 fail-closed BLOCKED_PRIVACY_CONSISTENCY_INPUTS�
   assert.equal(evidence.status, "BLOCKED_PRIVACY_CONSISTENCY_INPUTS");
   assert.deepEqual(evidence.missingInputs, [INVENTORY_FILE, PLAY_FORM_FILE, PRIVACY_POLICY_FILE]);
   assert.equal(evidence.checks.inventoryFormConsistent, "BLOCKED");
+  assert.equal(evidence.checks.playConsoleProvenanceCurrent, "BLOCKED");
 });
 
 test("CANDIDATE context가 아니면 거부한다", () => {

--- a/tools/release/build-privacy-consistency-evidence.test.mjs
+++ b/tools/release/build-privacy-consistency-evidence.test.mjs
@@ -66,72 +66,76 @@ test("현재 tracked 원본에 대해 실행하면 SATISFIED와 모순 0을 산�
   assert.match(evidence.inputs.privacyPolicy.sha256, /^[0-9a-f]{64}$/);
 });
 
-test("폼 answerMatrix 집계가 inventory 값과 모순되면 fail-closed BLOCKED한다", async () => {
-  const repoRoot = await fixtureRepoRoot({
+// 네 BLOCKED 회귀는 "fixtureRepoRoot로 특정 원본만 오염 → 실행 → status가
+// BLOCKED_PRIVACY_CONSISTENCY" 구조가 모두 같다. 그 반복되는 실행·공통 assert 골격을
+// 한 곳(아래 for 루프)에만 두고, 케이스마다 다른 mutate 콜백과 세부 assert만 테이블로 둔다.
+const BLOCKED_CONSISTENCY_CASES = [
+  {
+    name: "폼 answerMatrix 집계가 inventory 값과 모순되면 fail-closed BLOCKED한다",
     mutatePlayForm(playForm) {
       const location = playForm.dataSafetyDeclarations.answerMatrix.find((item) => item.dataType === "Location");
       location.containsRequiredData = true; // inventory Location은 required 항목이 없다.
     },
-  });
-  const evidence = buildPrivacyConsistencyEvidence({ candidate: candidate(), repoRoot });
-
-  assert.equal(evidence.status, "BLOCKED_PRIVACY_CONSISTENCY");
-  assert.equal(evidence.checks.inventoryFormConsistent, "FAILED");
-  assert.ok(
-    evidence.answerMatrixConsistency.contradictions.some(
-      (item) => item.dataType === "Location" && item.code === "required_flag_mismatch",
-    ),
-  );
-});
-
-test("inventory의 collected 항목이 폼 matrix에서 누락되면 coverage 모순으로 BLOCKED한다", async () => {
-  const repoRoot = await fixtureRepoRoot({
+    assertEvidence(evidence) {
+      assert.equal(evidence.checks.inventoryFormConsistent, "FAILED");
+      assert.ok(
+        evidence.answerMatrixConsistency.contradictions.some(
+          (item) => item.dataType === "Location" && item.code === "required_flag_mismatch",
+        ),
+      );
+    },
+  },
+  {
+    name: "inventory의 collected 항목이 폼 matrix에서 누락되면 coverage 모순으로 BLOCKED한다",
     mutatePlayForm(playForm) {
       const appActivity = playForm.dataSafetyDeclarations.answerMatrix.find((item) => item.dataType === "App activity");
       appActivity.inventoryDataIds = appActivity.inventoryDataIds.filter((id) => id !== "search_queries");
     },
-  });
-  const evidence = buildPrivacyConsistencyEvidence({ candidate: candidate(), repoRoot });
-
-  assert.equal(evidence.status, "BLOCKED_PRIVACY_CONSISTENCY");
-  assert.ok(evidence.answerMatrixConsistency.uncoveredCollected.includes("search_queries"));
-});
-
-test("정책 원본에서 경계 문구 anchor가 사라지면 fail-closed BLOCKED한다", async () => {
-  const repoRoot = await fixtureRepoRoot({
+    assertEvidence(evidence) {
+      assert.ok(evidence.answerMatrixConsistency.uncoveredCollected.includes("search_queries"));
+    },
+  },
+  {
+    name: "정책 원본에서 경계 문구 anchor가 사라지면 fail-closed BLOCKED한다",
     mutatePolicy(policy) {
       return policy.replace("DB나 access log에는 저장하지 않습니다", "생략");
     },
-  });
-  const evidence = buildPrivacyConsistencyEvidence({ candidate: candidate(), repoRoot });
-
-  assert.equal(evidence.status, "BLOCKED_PRIVACY_CONSISTENCY");
-  assert.equal(evidence.checks.inventoryPolicyConsistent, "FAILED");
-  const gateway = evidence.policyBoundaryConsistency.boundaries.find(
-    (item) => item.id === "gateway_shared_memory_non_persistence",
-  );
-  assert.equal(gateway.consistent, false);
-  assert.ok(gateway.missingAnchors.includes("DB나 access log에는 저장하지 않습니다"));
-});
-
-test("inventory가 경계를 더 이상 선언하지 않으면 정책 anchor가 있어도 BLOCKED한다", async () => {
-  const repoRoot = await fixtureRepoRoot({
+    assertEvidence(evidence) {
+      assert.equal(evidence.checks.inventoryPolicyConsistent, "FAILED");
+      const gateway = evidence.policyBoundaryConsistency.boundaries.find(
+        (item) => item.id === "gateway_shared_memory_non_persistence",
+      );
+      assert.equal(gateway.consistent, false);
+      assert.ok(gateway.missingAnchors.includes("DB나 access log에는 저장하지 않습니다"));
+    },
+  },
+  {
+    name: "inventory가 경계를 더 이상 선언하지 않으면 정책 anchor가 있어도 BLOCKED한다",
     mutateInventory(inventory) {
       const integrity = inventory.dataTypes.find((item) => item.id === "route_v2_itx_integrity");
       integrity.backendNeverPersistedOrLogged = integrity.backendNeverPersistedOrLogged.filter(
         (field) => field !== "rawIntegrityToken",
       );
     },
-  });
-  const evidence = buildPrivacyConsistencyEvidence({ candidate: candidate(), repoRoot });
+    assertEvidence(evidence) {
+      const boundary = evidence.policyBoundaryConsistency.boundaries.find(
+        (item) => item.id === "route_v2_raw_hash_boundary",
+      );
+      assert.equal(boundary.inventoryFactHolds, false);
+      assert.equal(boundary.consistent, false);
+    },
+  },
+];
 
-  assert.equal(evidence.status, "BLOCKED_PRIVACY_CONSISTENCY");
-  const boundary = evidence.policyBoundaryConsistency.boundaries.find(
-    (item) => item.id === "route_v2_raw_hash_boundary",
-  );
-  assert.equal(boundary.inventoryFactHolds, false);
-  assert.equal(boundary.consistent, false);
-});
+for (const testCase of BLOCKED_CONSISTENCY_CASES) {
+  test(testCase.name, async () => {
+    const repoRoot = await fixtureRepoRoot(testCase);
+    const evidence = buildPrivacyConsistencyEvidence({ candidate: candidate(), repoRoot });
+
+    assert.equal(evidence.status, "BLOCKED_PRIVACY_CONSISTENCY");
+    testCase.assertEvidence(evidence);
+  });
+}
 
 test("입력 원본이 없으면 fail-closed BLOCKED_PRIVACY_CONSISTENCY_INPUTS를 산출한다", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "easysubway-privacy-evidence-empty-"));

--- a/tools/release/build-privacy-consistency-evidence.test.mjs
+++ b/tools/release/build-privacy-consistency-evidence.test.mjs
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { buildPrivacyConsistencyEvidence } from "./build-privacy-consistency-evidence.mjs";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "../..");
+const INVENTORY_FILE = "apps/mobile/release/store-privacy-inventory.json";
+const PLAY_FORM_FILE = "apps/mobile/release/play-store-submission-content.json";
+const PRIVACY_POLICY_FILE = "backend/src/main/resources/templates/legal/privacy.html";
+
+const identity = {
+  gitSha: "1".repeat(40),
+  appVersionName: "1.0.4",
+  versionCode: "10005",
+};
+
+function candidate(overrides = {}) {
+  return { phase: "CANDIDATE", issue: 2056, releaseCandidateIdentity: identity, ...overrides };
+}
+
+// tracked 원본을 그대로 복사한 임시 repoRoot를 만들고, mutate 콜백으로 특정 파일만
+// 오염시켜 fail-closed 회귀를 강제한다.
+async function fixtureRepoRoot({ mutateInventory, mutatePlayForm, mutatePolicy } = {}) {
+  const root = await mkdtemp(path.join(tmpdir(), "easysubway-privacy-evidence-"));
+  const inventory = JSON.parse(readFileSync(path.join(REPO_ROOT, INVENTORY_FILE), "utf8"));
+  const playForm = JSON.parse(readFileSync(path.join(REPO_ROOT, PLAY_FORM_FILE), "utf8"));
+  let policy = readFileSync(path.join(REPO_ROOT, PRIVACY_POLICY_FILE), "utf8");
+  if (mutateInventory) mutateInventory(inventory);
+  if (mutatePlayForm) mutatePlayForm(playForm);
+  if (mutatePolicy) policy = mutatePolicy(policy);
+  await mkdir(path.join(root, "apps/mobile/release"), { recursive: true });
+  await mkdir(path.join(root, "backend/src/main/resources/templates/legal"), { recursive: true });
+  await writeFile(path.join(root, INVENTORY_FILE), `${JSON.stringify(inventory, null, 2)}\n`);
+  await writeFile(path.join(root, PLAY_FORM_FILE), `${JSON.stringify(playForm, null, 2)}\n`);
+  await writeFile(path.join(root, PRIVACY_POLICY_FILE), policy);
+  return root;
+}
+
+test("현재 tracked 원본에 대해 실행하면 SATISFIED와 모순 0을 산출한다", () => {
+  const evidence = buildPrivacyConsistencyEvidence({
+    candidate: candidate(),
+    repoRoot: REPO_ROOT,
+    generatedAt: "2026-07-20T00:00:00.000Z",
+  });
+
+  assert.equal(evidence.schemaVersion, 1);
+  assert.equal(evidence.artifactKind, "store-privacy-consistency-evidence");
+  assert.equal(evidence.sourceIssue, 1018);
+  assert.equal(evidence.consumerIssue, 2056);
+  assert.equal(evidence.status, "SATISFIED");
+  assert.deepEqual(evidence.releaseCandidateIdentity, identity);
+  assert.equal(evidence.answerMatrixConsistency.contradictions.length, 0);
+  assert.equal(evidence.answerMatrixConsistency.uncoveredCollected.length, 0);
+  assert.equal(evidence.policyBoundaryConsistency.consistent, true);
+  assert.equal(evidence.checks.inventoryFormConsistent, "SATISFIED");
+  assert.equal(evidence.checks.inventoryPolicyConsistent, "SATISFIED");
+  for (const boundary of evidence.policyBoundaryConsistency.boundaries) {
+    assert.equal(boundary.inventoryFactHolds, true, `${boundary.id} inventory fact`);
+    assert.deepEqual(boundary.missingAnchors, [], `${boundary.id} anchors`);
+  }
+  assert.match(evidence.inputs.inventory.sha256, /^[0-9a-f]{64}$/);
+  assert.match(evidence.inputs.privacyPolicy.sha256, /^[0-9a-f]{64}$/);
+});
+
+test("폼 answerMatrix 집계가 inventory 값과 모순되면 fail-closed BLOCKED한다", async () => {
+  const repoRoot = await fixtureRepoRoot({
+    mutatePlayForm(playForm) {
+      const location = playForm.dataSafetyDeclarations.answerMatrix.find((item) => item.dataType === "Location");
+      location.containsRequiredData = true; // inventory Location은 required 항목이 없다.
+    },
+  });
+  const evidence = buildPrivacyConsistencyEvidence({ candidate: candidate(), repoRoot });
+
+  assert.equal(evidence.status, "BLOCKED_PRIVACY_CONSISTENCY");
+  assert.equal(evidence.checks.inventoryFormConsistent, "FAILED");
+  assert.ok(
+    evidence.answerMatrixConsistency.contradictions.some(
+      (item) => item.dataType === "Location" && item.code === "required_flag_mismatch",
+    ),
+  );
+});
+
+test("inventory의 collected 항목이 폼 matrix에서 누락되면 coverage 모순으로 BLOCKED한다", async () => {
+  const repoRoot = await fixtureRepoRoot({
+    mutatePlayForm(playForm) {
+      const appActivity = playForm.dataSafetyDeclarations.answerMatrix.find((item) => item.dataType === "App activity");
+      appActivity.inventoryDataIds = appActivity.inventoryDataIds.filter((id) => id !== "search_queries");
+    },
+  });
+  const evidence = buildPrivacyConsistencyEvidence({ candidate: candidate(), repoRoot });
+
+  assert.equal(evidence.status, "BLOCKED_PRIVACY_CONSISTENCY");
+  assert.ok(evidence.answerMatrixConsistency.uncoveredCollected.includes("search_queries"));
+});
+
+test("정책 원본에서 경계 문구 anchor가 사라지면 fail-closed BLOCKED한다", async () => {
+  const repoRoot = await fixtureRepoRoot({
+    mutatePolicy(policy) {
+      return policy.replace("DB나 access log에는 저장하지 않습니다", "생략");
+    },
+  });
+  const evidence = buildPrivacyConsistencyEvidence({ candidate: candidate(), repoRoot });
+
+  assert.equal(evidence.status, "BLOCKED_PRIVACY_CONSISTENCY");
+  assert.equal(evidence.checks.inventoryPolicyConsistent, "FAILED");
+  const gateway = evidence.policyBoundaryConsistency.boundaries.find(
+    (item) => item.id === "gateway_shared_memory_non_persistence",
+  );
+  assert.equal(gateway.consistent, false);
+  assert.ok(gateway.missingAnchors.includes("DB나 access log에는 저장하지 않습니다"));
+});
+
+test("inventory가 경계를 더 이상 선언하지 않으면 정책 anchor가 있어도 BLOCKED한다", async () => {
+  const repoRoot = await fixtureRepoRoot({
+    mutateInventory(inventory) {
+      const integrity = inventory.dataTypes.find((item) => item.id === "route_v2_itx_integrity");
+      integrity.backendNeverPersistedOrLogged = integrity.backendNeverPersistedOrLogged.filter(
+        (field) => field !== "rawIntegrityToken",
+      );
+    },
+  });
+  const evidence = buildPrivacyConsistencyEvidence({ candidate: candidate(), repoRoot });
+
+  assert.equal(evidence.status, "BLOCKED_PRIVACY_CONSISTENCY");
+  const boundary = evidence.policyBoundaryConsistency.boundaries.find(
+    (item) => item.id === "route_v2_raw_hash_boundary",
+  );
+  assert.equal(boundary.inventoryFactHolds, false);
+  assert.equal(boundary.consistent, false);
+});
+
+test("입력 원본이 없으면 fail-closed BLOCKED_PRIVACY_CONSISTENCY_INPUTS를 산출한다", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "easysubway-privacy-evidence-empty-"));
+  const evidence = buildPrivacyConsistencyEvidence({ candidate: candidate(), repoRoot: root });
+
+  assert.equal(evidence.status, "BLOCKED_PRIVACY_CONSISTENCY_INPUTS");
+  assert.deepEqual(evidence.missingInputs, [INVENTORY_FILE, PLAY_FORM_FILE, PRIVACY_POLICY_FILE]);
+  assert.equal(evidence.checks.inventoryFormConsistent, "BLOCKED");
+});
+
+test("CANDIDATE context가 아니면 거부한다", () => {
+  assert.throws(
+    () => buildPrivacyConsistencyEvidence({
+      candidate: { phase: "FINAL", issue: 2056, releaseCandidateIdentity: identity },
+      repoRoot: REPO_ROOT,
+    }),
+    /CANDIDATE context/,
+  );
+  assert.throws(
+    () => buildPrivacyConsistencyEvidence({
+      candidate: { phase: "CANDIDATE", issue: 1020, releaseCandidateIdentity: identity },
+      repoRoot: REPO_ROOT,
+    }),
+    /CANDIDATE context/,
+  );
+});

--- a/tools/release/lib/candidate-context-evidence-cli.mjs
+++ b/tools/release/lib/candidate-context-evidence-cli.mjs
@@ -1,0 +1,40 @@
+// candidate-context(#2056 CANDIDATE) 기반 #2056 fragment producer들이 공유하는 최소
+// CLI 진입점. --candidate-context/--output(필수)과 --repo-root/--provenance(선택)만
+// 파싱해 build(...)를 호출하고 결과를 JSON으로 쓴다. 이 셋보다 인자가 더 필요한
+// producer(예: build-planner-success-evidence.mjs의 --canary-result)는 대상이 아니다
+// — 정확히 같은 4-인자 shape인 producer만 이 helper로 대체한다(SonarCloud PR #2357
+// build-privacy-consistency-evidence.mjs ↔ build-mobile-consumption-evidence.mjs
+// 17-line 중복 실측 결과에 대한 최소 공통화).
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+function argument(name) {
+  const index = process.argv.indexOf(`--${name}`);
+  return index < 0 ? null : process.argv[index + 1];
+}
+
+// importMetaUrl은 호출한 producer 모듈의 import.meta.url이어야 한다(직접 실행 여부
+// 판별). build는 { candidate, repoRoot, provenance }를 받아 evidence 객체를 반환하는
+// producer의 buildXxxEvidence 함수를 그대로 넘긴다.
+export function runCandidateContextEvidenceCli(importMetaUrl, build) {
+  const entry = process.argv[1] ? path.resolve(process.argv[1]) : null;
+  if (entry !== fileURLToPath(importMetaUrl)) return;
+
+  const candidatePath = argument("candidate-context");
+  const outputPath = argument("output");
+  if (!candidatePath || !outputPath) {
+    throw new Error("--candidate-context and --output are required");
+  }
+  const repoRootArg = argument("repo-root");
+  const repoRoot = repoRootArg ? path.resolve(repoRootArg) : process.cwd();
+  const provenance = argument("provenance") ?? "final-candidate";
+  const evidence = build({
+    candidate: JSON.parse(readFileSync(candidatePath, "utf8")),
+    repoRoot,
+    provenance,
+  });
+  mkdirSync(path.dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, `${JSON.stringify(evidence, null, 2)}\n`);
+}


### PR DESCRIPTION
## 관련 이슈

Refs AquilaXk/easysubway-backend#3

## 작업 배경

production Route V2 capacity workflow(`.github/workflows/production-route-v2-capacity-evidence.yml`)가 오늘 최초로 완주 성공했다. 그동안 `routeV2Readiness.realisticLoadEvidence.productionWorkflowRunUrl`은 로컬 러너 완주 근거로 SATISFIED 결속되어 있었고, production workflow run URL은 "production workflow run URL 대기(인프라 안정화 후 첨부)" placeholder로 남아 있었다. 이제 실제 production run이 확보되어 run identity를 결속한다.

또한 PR #2337에서 canary rollback helper(`tools/ops/route-v2-canary-rollback-evidence.mjs`)가 operations evidence의 `timetableSnapshotCache.currentImplementation`과 checked-in timetable evidence 파일의 snapshot 일치를 강제하도록 강화됐는데, operations evidence의 currentImplementation이 옛 snapshot(`c8ae07b6…`, freshUntil 2026-07-20)으로 stale 상태였다. 이 PR이 그 drift를 reconcile한다.

## 작업 내용

- `apps/mobile/release/operations-release-evidence.json`
  - `realisticLoadEvidence.productionWorkflowRunUrl`을 실제 run URL(`.../runs/29712689840`)로 교체.
  - `realisticLoadEvidence.productionWorkflowRun` 객체 신설로 production run identity를 별도 결속: `runUrl`, `deployedSha`(`3cad7466…`), `conclusion`(success), `note`. run은 candidate SHA(`e317f3af…`)가 아닌 이후 배포·검증된 SHA에서 수행됐으므로 candidate 블록(versionName 1.0.5 / versionCode 10006 / candidateGitSha e317f3af)은 불변 유지.
  - `timetableSnapshotCache.currentImplementation`을 현재 `tools/datapack/server-timetable-snapshot-evidence.json` 실측값(snapshotId `server-timetable-snapshot-9f9be14b6cdd6e4d`, snapshotSha256 `9f9be14b…`, freshUntil `2026-07-27T00:00:00+09:00`)으로 갱신. 이 값은 canary runner가 읽는 `backend/src/main/resources/timetable/server-timetable-snapshot-evidence.json`과도 동일하다.
- `apps/mobile/release/post-launch-operations-review-gate.json`: `operations-contract-change` refresh binding의 operations-release-evidence.json sha256을 `2a6fb091…`로 갱신.
- `tools/ci/repository-contract.test.mjs`: 위 evidence 변경에 맞춰 `realisticLoadEvidence`·`timetableSnapshotCache` deepEqual assertion 갱신.
- `tools/ci/production-route-v2-canary-rollback-workflow.test.mjs`: 기존 "현재 drift를 거부한다" 테스트는 drift reconcile 완료(#2095)에 따라, 정합된 두 evidence에서 checked-in RC candidate를 정상 resolve하는지 검증하도록 전환.

## 검증

- 실행한 명령과 결과:
  - `node tools/ci/repository-contract.test.mjs` → tests 219 / pass 218 / fail 1. 유일한 fail("Android v1 production 데이터팩 scope는 수도권 pilot 승인 기준을 고정한다")은 이 PR 이전 origin/main에도 존재하는 base 실패로, `production-datapack-scope.json`·`play-store-submission-content.json`(이 PR 미변경 파일)만 참조한다. 이 PR이 유발한 실패는 0.
  - `node --test tools/ci/production-route-v2-canary-rollback-workflow.test.mjs` → tests 18 / pass 18 / fail 0.
  - `node -e "JSON.parse(...)"`로 변경한 두 JSON parse 검증 → OK.
  - `node tools/ops/route-v2-canary-rollback-evidence.mjs expected-candidate <operations> <backend timetable>` → exit 0, checked-in RC candidate 정상 resolve(정합 확인).

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| repository contract test | CI | `node tools/ci/repository-contract.test.mjs` | pass 218 / fail 1(사전 존재 base 실패) | PASS(이 PR 유발 실패 0) |
| canary rollback workflow test | CI | `node --test tools/ci/production-route-v2-canary-rollback-workflow.test.mjs` | pass 18 / fail 0 | PASS |
| evidence 정합(canary cross-check) | 러너 | `route-v2-canary-rollback-evidence.mjs expected-candidate` | exit 0, candidate resolve | PASS |
| production capacity run | GitHub Actions | run URL | https://github.com/AquilaXk/easysubway/actions/runs/29712689840 (conclusion success) | PASS |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] AquilaXk/easysubway#1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음(1.0.5 유지)
- mobile versionCode: 변경 없음(10006 유지)
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음(candidate git sha e317f3af 불변)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `operations-release-evidence.json`의 `productionWorkflowRun.deployedSha`(3cad7466)가 candidate 블록의 candidateGitSha(e317f3af)와 다른 점은 의도된 정직한 결속이다. production run이 candidate SHA가 아닌 이후 배포·검증된 SHA에서 최초 완주했기 때문이며, candidate identity는 별개로 불변 유지한다.
  - `timetableSnapshotCache.currentImplementation` 값은 `tools/datapack/…`와 canary runner가 읽는 `backend/src/main/resources/timetable/…` 두 evidence 파일에서 동일하므로 canary cross-check가 정합(exit 0)한다.
  - canary workflow 테스트에서 기존 drift 재현 테스트를 resolve 검증으로 전환한 것은, 해당 테스트 주석이 명시했던 "reconciling를 담당할 follow-up binding PR"이 바로 이 PR이기 때문이다.

## 리스크

- production run은 candidate SHA(e317f3af)가 아닌 이후 배포 SHA(3cad7466)에서 수행됐다 — candidate 블록은 불변 유지하고 run identity를 별도 필드로 결속하여 정직하게 기록했다. candidate identity와 run deploy SHA를 혼동하지 않도록 `note`로 명시했다.
- operations evidence의 `currentImplementation.evidencePath`는 `tools/datapack/…`를 가리키지만 canary runner는 `backend/src/main/resources/timetable/…`를 읽는다. 현재 두 파일의 snapshot identity가 동일해 정합 문제는 없으나, 향후 두 파일이 갈라지면 재점검이 필요하다(이 PR 범위 밖의 사전 존재 구조).

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음 — no version change, evidence·test 정합만 변경)
