### PR TITLE
[Test] #2358 전국 누적 coverage 83/270 기준선

### DIFF
--- a/tools/datapack/materialize-daejeon-timetable.test.mjs
+++ b/tools/datapack/materialize-daejeon-timetable.test.mjs
@@ -11,6 +11,10 @@ import test from "node:test";
 import { parseMolitDaejeonStationMappings } from "./build-molit-nationwide-fixture.mjs";
 import { checkTimetableRideConsistency } from "./validate-timetable-ride-consistency.mjs";
 import {
+  materializeBusanRouteTopology,
+  parseCanonicalBusanStationMappings,
+} from "./materialize-busan-route-topology.mjs";
+import {
   materializeDaejeonTimetable,
   materializedPackContentHash,
 } from "./materialize-daejeon-timetable.mjs";
@@ -232,6 +236,97 @@ test("production SQLite·field provenance가 대전 schedule requirement와 런�
     operatorId === "daejeon-transportation" && sourceDomain === "schedule_timetable");
   assert.deepEqual(schedule.missingFields, []);
   assert.deepEqual(schedule.sourceIds, ["daejeon-train-timetable"]);
+});
+
+test("병합된 부산·대전 admission과 공식 미지원 evidence를 83/270 terminal 기준선으로 누적한다", async (context) => {
+  const outputDir = await mkdtemp(path.join(tmpdir(), "easysubway-nationwide-cumulative-baseline-"));
+  context.after(() => rm(outputDir, { recursive: true, force: true }));
+  const values = await inputs();
+  const [busanSnapshot, busanStationMapCsv] = await Promise.all([
+    readJson("tools/datapack/sources/busan-transportation-route-topology-20260720.json"),
+    readFile(path.join(root, "tools/datapack/sources/regional-official-svg-route-map-coordinates-20260624.csv"), "utf8"),
+  ]);
+  const busanFixture = materializeBusanRouteTopology({
+    baseFixture: values.baseFixture,
+    snapshot: busanSnapshot,
+    inventory: values.inventory,
+    canonicalStationMappings: parseCanonicalBusanStationMappings(busanStationMapCsv),
+    now: evidenceNow,
+  });
+  const fixture = materializeDaejeonTimetable({
+    ...values,
+    baseFixture: busanFixture,
+    now: evidenceNow,
+  });
+  const fixturePath = path.join(outputDir, "fixture.json");
+  const packOutput = path.join(outputDir, "pack");
+  const reportPath = path.join(outputDir, "coverage.json");
+  await writeFile(fixturePath, `${JSON.stringify(fixture, null, 2)}\n`);
+  await mkdir(packOutput, { recursive: true });
+
+  const { privateKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    publicKeyEncoding: { type: "spki", format: "pem" },
+  });
+  await execFileAsync(process.execPath, [
+    "tools/datapack/build-datapack.mjs", "--fixture", fixturePath, "--output", packOutput,
+  ], {
+    cwd: root,
+    env: { ...process.env, EASYSUBWAY_DATAPACK_SIGNING_PRIVATE_KEY_PEM: privateKey },
+  });
+  const manifest = await readJsonAbsolute(path.join(packOutput, "current.json"));
+  const sqlitePath = path.join(packOutput,
+    new URL(manifest.packs[0].url).pathname.split("/").slice(-2).join("/")).replace(/\.gz$/, "");
+  const database = new DatabaseSync(sqlitePath, { readOnly: true });
+  assert.equal(database.prepare("SELECT COUNT(*) AS count FROM network_edges WHERE source_id = ?")
+    .get("busan-transportation-route-topology").count, 220);
+  assert.equal(database.prepare("SELECT COUNT(*) AS count FROM network_edges WHERE source_id = ?")
+    .get("daejeon-station-distance-fare").count, 42);
+  assert.equal(database.prepare("SELECT COUNT(*) AS count FROM transit_trips WHERE id LIKE 'trip-daejeon-%'")
+    .get().count, 460);
+  assert.equal(database.prepare(`
+    SELECT COUNT(*) AS count
+    FROM transit_stop_times st
+    JOIN transit_trips t ON t.id = st.trip_id
+    WHERE t.id LIKE 'trip-daejeon-%'
+  `).get().count, 10_034);
+  database.close();
+  await execFileAsync(process.execPath, [
+    "tools/datapack/report-coverage-gaps.mjs",
+    "--targets", "tools/datapack/nationwide-coverage-targets.json",
+    "--inventory", "tools/datapack/source-inventory.json",
+    "--manifest", path.join(packOutput, "current.json"),
+    "--provenance", path.join(packOutput, "current.provenance.json"),
+    "--resolution-plan", "tools/datapack/release/nationwide-public-api-coverage-search-plan-20260720.json",
+    "--resolutions", "tools/datapack/release/nationwide-public-api-coverage-resolutions-20260720.json",
+    "--output", reportPath,
+    "--allow-gaps",
+  ], { cwd: root });
+
+  const report = await readJsonAbsolute(reportPath);
+  assert.deepEqual(report.summary.launchRequired, {
+    totalCount: 270,
+    supportedCount: 7,
+    explicitlyUnsupportedCount: 76,
+    missingCount: 187,
+    supportedRatio: 0.0259,
+    terminalResolutionRatio: 0.3074,
+    completionReady: false,
+  });
+  assert.deepEqual(report.requirements
+    .filter(({ status }) => status === "SUPPORTED")
+    .map(({ regionId, operatorId, lineId, sourceDomain }) =>
+      `${regionId}:${operatorId}:${lineId}:${sourceDomain}`)
+    .sort(), [
+    "busan:busan-transportation:line-ab1a041f6266:route_graph_topology",
+    "busan:busan-transportation:line-d74614a04530:route_graph_topology",
+    "busan:busan-transportation:line-d812a5bc1e5f:route_graph_topology",
+    "busan:busan-transportation:line-eb7b47920390:route_graph_topology",
+    "daejeon:daejeon-transportation:line-7051a9c2525c:route_graph_topology",
+    "daejeon:daejeon-transportation:line-7051a9c2525c:schedule_timetable",
+    "daejeon:daejeon-transportation:line-7051a9c2525c:station_line_membership",
+  ]);
 });
 
 async function readJson(relativePath) {


### PR DESCRIPTION
## 관련 이슈

Closes AquilaXk/easysubway#2358
Refs AquilaXk/easysubway-data#3

## 작업 배경

부산교통공사 topology 4건과 대전 1호선 membership/topology/schedule 3건은 개별 production admission 검증만 존재해, #2138의 공식 미지원 76건과 합친 누적 전국 기준선이 없었다.

## 작업 내용

- 기존 부산 materializer 결과를 대전 timetable materializer의 base fixture로 연결한다.
- 동일 production SQLite에서 부산 edge 220개, 대전 edge 42개, trip 460개, stop time 10,034개를 검증한다.
- 동일 manifest/provenance와 공식 미지원 resolution으로 `SUPPORTED=7`, `EXPLICITLY_UNSUPPORTED=76`, `MISSING=187`을 고정한다.
- production 구현은 추가하지 않고 기존 CLI 연결 가능성을 regression test로 보존한다.

## 검증

- `node --test tools/datapack/materialize-busan-route-topology.test.mjs tools/datapack/materialize-daejeon-route-topology.test.mjs tools/datapack/materialize-daejeon-timetable.test.mjs tools/datapack/nationwide-public-api-coverage-evidence.test.mjs` — 19/19 pass
- `node tools/ci/check-contracts.mjs` — exit 0
- `git diff --check` — exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 누적 SQLite row | Node.js SQLite | regression test SQL count | 부산 edge 220, 대전 edge 42, trip 460, stop time 10,034 | PASS |
| 전국 coverage | Node.js reporter | manifest/provenance + resolution report | supported 7, unsupported 76, missing 187 | PASS |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] AquilaXk/easysubway#1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: unchanged
- mobile versionCode: unchanged
- datapack version: unchanged
- route contract: unchanged
- realtime contract: unchanged
- backend identity: unchanged

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 개별 admission을 한 SQLite에 누적한 뒤 coverage reporter가 exact 7개 requirement만 `SUPPORTED`로 인정하는지 확인해 주세요.

## 리스크

- 테스트 전용 변경이다. source snapshot freshness가 바뀌면 누적 기준선 입력을 새 공식 snapshot으로 갱신해야 한다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다. (rate limit으로 fallback 전환)
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)
