### PR TITLE
[Fix] #2360 전국 API transport 진단 보강

### DIFF
--- a/tools/datapack/collect-nationwide-public-api-coverage.mjs
+++ b/tools/datapack/collect-nationwide-public-api-coverage.mjs
@@ -217,6 +217,18 @@ export async function collectNationwidePublicApiCoverage({
   };
 }
 
+export function summarizeUnresolvedDiagnostics(unresolved) {
+  const counts = new Map();
+  for (const entry of unresolved) {
+    const detail = entry.transportReason
+      ?? (Number.isInteger(entry.httpStatus) ? `HTTP_${entry.httpStatus}` : null)
+      ?? (typeof entry.providerResultCode === "string" ? `PROVIDER_${entry.providerResultCode}` : "UNSPECIFIED");
+    const key = `${entry.reasonCode}/${detail}`;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return [...counts.entries()].sort(([left], [right]) => left.localeCompare(right)).map(([key, count]) => `${key}=${count}`);
+}
+
 function indexKnownProviderCandidates(sourceCandidates) {
   const indexed = new Map();
   for (const [index, candidate] of (sourceCandidates?.candidates ?? []).entries()) {
@@ -402,8 +414,10 @@ async function fetchPublicApiPage({ url, request, expectedContentTypes, fetchImp
     try {
       response = await fetchImpl(url, { ...request, signal: AbortSignal.timeout(15_000) });
       break;
-    } catch {
-      if (attempt === 1) return { reasonCode: "PUBLIC_API_FETCH_FAILED", attempts: 2 };
+    } catch (error) {
+      if (attempt === 1) {
+        return { reasonCode: "PUBLIC_API_FETCH_FAILED", attempts: 2, transportReason: transportReason(error) };
+      }
     }
   }
   if (!response.ok) return { reasonCode: "PUBLIC_API_HTTP_FAILURE", httpStatus: response.status };
@@ -412,6 +426,13 @@ async function fetchPublicApiPage({ url, request, expectedContentTypes, fetchImp
     return { reasonCode: "PUBLIC_API_SCHEMA_MISMATCH", httpStatus: response.status, contentType: contentType ?? null };
   }
   return { raw: await response.text(), httpStatus: response.status, contentType };
+}
+
+function transportReason(error) {
+  const reason = error?.cause?.code ?? error?.code ?? error?.name;
+  return typeof reason === "string" && /^[A-Z][A-Z0-9_]{1,63}$/.test(reason.toUpperCase())
+    ? reason.toUpperCase()
+    : "UNKNOWN";
 }
 
 function captureXmlRows(raw, fields) {
@@ -667,6 +688,7 @@ async function main(argv) {
   const resolutions = await collectNationwidePublicApiCoverage({ searchPlan });
   await writeFile(args.output, `${JSON.stringify(resolutions, null, 2)}\n`);
   console.log(`public API coverage search complete: unsupported=${resolutions.entries.length} unresolved=${resolutions.unresolved.length}`);
+  console.log(`sanitized diagnostics: ${summarizeUnresolvedDiagnostics(resolutions.unresolved).join(", ")}`);
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {

--- a/tools/datapack/collect-nationwide-public-api-coverage.mjs
+++ b/tools/datapack/collect-nationwide-public-api-coverage.mjs
@@ -220,13 +220,24 @@ export async function collectNationwidePublicApiCoverage({
 export function summarizeUnresolvedDiagnostics(unresolved) {
   const counts = new Map();
   for (const entry of unresolved) {
-    const detail = entry.transportReason
-      ?? (Number.isInteger(entry.httpStatus) ? `HTTP_${entry.httpStatus}` : null)
-      ?? (typeof entry.providerResultCode === "string" ? `PROVIDER_${entry.providerResultCode}` : "UNSPECIFIED");
-    const key = `${entry.reasonCode}/${detail}`;
+    const reason = diagnosticToken(entry?.reasonCode, /^PUBLIC_API_[A-Z0-9_]{1,63}$/, "PUBLIC_API_UNKNOWN");
+    let detail = "UNSPECIFIED";
+    if (entry?.transportReason !== undefined) {
+      detail = diagnosticToken(entry.transportReason, /^[A-Z][A-Z0-9_]{1,63}$/, "TRANSPORT_UNKNOWN");
+    } else if (entry?.httpStatus !== undefined) {
+      detail = Number.isInteger(entry.httpStatus) && entry.httpStatus >= 100 && entry.httpStatus <= 599
+        ? `HTTP_${entry.httpStatus}` : "HTTP_UNKNOWN";
+    } else if (entry?.providerResultCode !== undefined) {
+      detail = `PROVIDER_${diagnosticToken(entry.providerResultCode, /^[A-Za-z0-9._-]{1,32}$/, "UNKNOWN")}`;
+    }
+    const key = `${reason}/${detail}`;
     counts.set(key, (counts.get(key) ?? 0) + 1);
   }
   return [...counts.entries()].sort(([left], [right]) => left.localeCompare(right)).map(([key, count]) => `${key}=${count}`);
+}
+
+function diagnosticToken(value, pattern, fallback) {
+  return typeof value === "string" && pattern.test(value) ? value : fallback;
 }
 
 function indexKnownProviderCandidates(sourceCandidates) {

--- a/tools/datapack/collect-nationwide-public-api-coverage.test.mjs
+++ b/tools/datapack/collect-nationwide-public-api-coverage.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   buildNationwidePublicApiSearchPlan,
   collectNationwidePublicApiCoverage,
+  summarizeUnresolvedDiagnostics,
 } from "./collect-nationwide-public-api-coverage.mjs";
 
 const target = {
@@ -623,7 +624,7 @@ test("데이터 존재·provider 실패·bounded retry 실패는 MISSING으로 �
       }
       if (url.searchParams.get("lnCd") === "2") return xmlResponse({ code: "99" });
       retryCalls += 1;
-      throw new TypeError("network unavailable");
+      throw new TypeError("network unavailable never-print-this-key", { cause: { code: "ENOTFOUND" } });
     },
     now: new Date("2026-07-13T00:00:00.000Z"),
   });
@@ -637,6 +638,8 @@ test("데이터 존재·provider 실패·bounded retry 실패는 MISSING으로 �
   assert.equal(retryCalls, 2);
   assert.deepEqual(resolutions.unresolved[0].matches, [{ stinCd: "101" }]);
   assert.equal(resolutions.unresolved[2].attempts, 2);
+  assert.equal(resolutions.unresolved[2].transportReason, "ENOTFOUND");
+  assert.doesNotMatch(JSON.stringify(resolutions), /never-print-this-key/);
 });
 
 test("bounded retry는 attempt마다 새 timeout signal을 사용한다", async () => {
@@ -655,4 +658,15 @@ test("bounded retry는 attempt마다 새 timeout signal을 사용한다", async 
   assert.equal(resolutions.entries.length, 1);
   assert.equal(signals.length, 2);
   assert.notEqual(signals[0], signals[1]);
+});
+
+test("sanitized 진단은 reason과 transport code별 건수만 고정한다", () => {
+  assert.deepEqual(summarizeUnresolvedDiagnostics([
+    { reasonCode: "PUBLIC_API_FETCH_FAILED", transportReason: "ENOTFOUND" },
+    { reasonCode: "PUBLIC_API_FETCH_FAILED", transportReason: "ENOTFOUND", secret: "never-print-this-key" },
+    { reasonCode: "PUBLIC_API_HTTP_FAILURE", httpStatus: 403 },
+  ]), [
+    "PUBLIC_API_FETCH_FAILED/ENOTFOUND=2",
+    "PUBLIC_API_HTTP_FAILURE/HTTP_403=1",
+  ]);
 });

--- a/tools/datapack/collect-nationwide-public-api-coverage.test.mjs
+++ b/tools/datapack/collect-nationwide-public-api-coverage.test.mjs
@@ -663,10 +663,18 @@ test("bounded retry는 attempt마다 새 timeout signal을 사용한다", async 
 test("sanitized 진단은 reason과 transport code별 건수만 고정한다", () => {
   assert.deepEqual(summarizeUnresolvedDiagnostics([
     { reasonCode: "PUBLIC_API_FETCH_FAILED", transportReason: "ENOTFOUND" },
-    { reasonCode: "PUBLIC_API_FETCH_FAILED", transportReason: "ENOTFOUND", secret: "never-print-this-key" },
+    { reasonCode: "PUBLIC_API_FETCH_FAILED", transportReason: "ENOTFOUND" },
     { reasonCode: "PUBLIC_API_HTTP_FAILURE", httpStatus: 403 },
+    { reasonCode: "PUBLIC_API_FETCH_FAILED\nnever-print-this-key", transportReason: "ENOTFOUND\nnever-print-this-key" },
+    { reasonCode: "PUBLIC_API_PROVIDER_FAILURE", providerResultCode: "03\nnever-print-this-key" },
   ]), [
     "PUBLIC_API_FETCH_FAILED/ENOTFOUND=2",
     "PUBLIC_API_HTTP_FAILURE/HTTP_403=1",
+    "PUBLIC_API_PROVIDER_FAILURE/PROVIDER_UNKNOWN=1",
+    "PUBLIC_API_UNKNOWN/TRANSPORT_UNKNOWN=1",
   ]);
+  assert.doesNotMatch(summarizeUnresolvedDiagnostics([{
+    reasonCode: "PUBLIC_API_FETCH_FAILED\nnever-print-this-key",
+    transportReason: "ENOTFOUND\nnever-print-this-key",
+  }]).join(","), /never-print-this-key|\n/);
 });


### PR DESCRIPTION
## 목적

AquilaXk/easysubway-data#3 전국 270 requirements 공공 API 검색에서 transport 실패를 공식 미지원으로 오판하지 않도록 sanitized 진단을 보강합니다.

Closes AquilaXk/easysubway#2360
Refs AquilaXk/easysubway-data#3

## 변경

- bounded retry 최종 실패에 안전한 transport code(`ENOTFOUND`, TLS/timeout code 등)만 기록
- unresolved 결과를 reason/HTTP/provider/transport 단위 건수로 출력하는 deterministic 요약 추가
- 원본 오류 메시지와 credential이 결과에 포함되지 않는 회귀 테스트 추가

## 공식 계약 확인

- 공공데이터포털 검색 서비스: https://www.data.go.kr/data/15112888/openapi.do
  - `POST /GetSearchDataList/v1/searchData`
  - 개발계정 자동승인, 운영계정 자동승인
- 서울교통공사 노선·역 API: https://www.data.go.kr/dataset/3045253/openapi.do
- 서울교통공사 시간표 API: https://www.data.go.kr/dataset/15003143/openapi.do
- 서울교통공사 교통약자 API: https://www.data.go.kr/data/15143843/openapi.do

## Live evidence

owner `.env`는 `node --env-file=/Users/aquila/easysubway/.env`로만 주입했습니다. 비밀값은 출력·저장하지 않았습니다.

```text
public API coverage search complete: unsupported=0 unresolved=270
sanitized diagnostics: PUBLIC_API_FETCH_FAILED/ENOTFOUND=270
```

따라서 이번 결과로 공식 미지원 항목을 추가하지 않습니다. 기존 source catalog에는 서울교통공사 접근성·실시간 및 KRIC 후보가 이미 등록되어 있어 중복 후보도 추가하지 않습니다.

## 검증

- [x] `node --test tools/datapack/collect-nationwide-public-api-coverage.test.mjs tools/datapack/nationwide-public-api-coverage-evidence.test.mjs` (21/21)
- [x] `node tools/ci/check-contracts.mjs`
- [x] `git diff --check`
- [x] 독립 review (CodeRabbit finding 1건 수정 후 fresh re-review 0 finding)
- [ ] required CI

## 위험 / rollback

- production data와 270 coverage 판정 수치는 변경하지 않습니다.
- CLI에 진단 필드와 집계 한 줄만 추가합니다.
- 문제가 있으면 이 커밋을 revert하면 기존 `PUBLIC_API_FETCH_FAILED` 동작으로 복원됩니다.
