### PR TITLE
[Style] #2349 전역 셸 UI 정비 — 로그아웃 위계·브랜드 중복·환경 메타·로그인 화면 정합 (PR⑨)

### DIFF
--- a/backend/src/main/resources/static/css/admin-components.css
+++ b/backend/src/main/resources/static/css/admin-components.css
@@ -1062,12 +1062,16 @@
 	margin-top: 18px;
 }
 
+/* retry warning(#2349 PR⑨): 로그인 재시도 안내는 role="alert"인데도 설명문(.login-card p)과
+   같은 무채색 톤이라 오류 상태로 식별되지 않았다. 기존 하단 구분선 블록 패턴은 유지하고,
+   상태 컴포넌트(.admin-status/.status)와 같은 warn 톤(색+글자 강조)만 병기한다. */
 .login-note {
 	margin-top: 18px;
 	padding-top: 16px;
-	border-top: 1px solid var(--admin-border);
-	color: var(--admin-ink-2);
+	border-top: 1px solid var(--admin-warn);
+	color: var(--admin-warn);
 	font-size: 13px;
+	font-weight: var(--admin-w-strong);
 }
 
 .sr-only {
@@ -1752,17 +1756,19 @@
 	font-weight: var(--admin-w-strong);
 }
 
-/* topbar 로그아웃은 독립 neutral action이며 account dialog와 별개로 항상 접근 가능하다. */
+/* topbar 로그아웃은 독립 neutral action이며 account dialog와 별개로 항상 접근 가능하다.
+   자주 쓰지 않는 액션이라 계정 메뉴(상시 노출 박스 트리거)와 동급 박스로 보이지 않도록 위계를
+   낮춘다(#2349 PR⑨) — 기본 상태는 보더·채움 없는 텍스트 톤이고, 44px 터치 타깃은 아래 결합
+   셀렉터(min-width/min-height)가 여백만으로 공급한다. */
 .admin-v3 .admin-topbar-logout {
-	min-width: 44px;
-	min-height: 44px;
-	background: var(--admin-surface);
-	border: 1px solid var(--admin-border);
-	color: var(--admin-ink);
+	background: transparent;
+	border: 1px solid transparent;
+	color: var(--admin-ink-2);
 }
 
 .admin-v3 .admin-topbar-logout:hover {
-	background: var(--admin-bg);
+	border-color: var(--admin-border);
+	color: var(--admin-ink);
 }
 
 .admin-v3 .admin-sidebar-toggle,

--- a/backend/src/main/resources/static/css/admin-shell.css
+++ b/backend/src/main/resources/static/css/admin-shell.css
@@ -232,6 +232,17 @@
 	font-weight: var(--admin-w-medium);
 }
 
+/* 브랜드 중복 제거(#2349 PR⑨): 사이드바가 상시 노출되는 데스크톱(>1024px)에서는 사이드바
+   브랜드(.admin-brand)가 이미 "쉬운 지하철 / 통합 관리자"를 보여주므로 topbar 브랜드 표기를
+   숨긴다. 사이드바가 off-canvas로 바뀌는 ≤1024px에서는 topbar가 유일한 브랜드 표시가 되므로
+   아래 미디어 쿼리(반응형 앱 프레임)가 다시 노출한다. 접근성 스모크가 고정하는 클래스·aria-label은
+   그대로 두고 display만 바꾼다. */
+.admin-topbar-brand,
+.admin-topbar-sep,
+.admin-topbar-scope {
+	display: none;
+}
+
 .admin-topbar-actions {
 	display: flex;
 	align-items: center;
@@ -383,6 +394,13 @@
 	.admin-topbar-context {
 		flex: 1 1 190px;
 		align-items: center;
+	}
+
+	/* ≤1024px는 사이드바가 off-canvas라 topbar 브랜드가 유일한 브랜드 표시가 된다(#2349 PR⑨). */
+	.admin-topbar-brand,
+	.admin-topbar-sep,
+	.admin-topbar-scope {
+		display: inline;
 	}
 
 	.admin-topbar-actions {

--- a/backend/src/main/resources/static/css/operator-v3.css
+++ b/backend/src/main/resources/static/css/operator-v3.css
@@ -607,13 +607,14 @@ input:focus-visible {
 	font-weight: var(--admin-w-strong);
 }
 
+/* retry warning(#2349 PR⑨): admin 로그인과 동일한 warn 톤 정합(NONE/RETRY_WARNING parity 계약). */
 .login-note {
 	margin-top: 18px;
 	padding-top: 16px;
-	border-top: 1px solid var(--admin-border);
-	color: var(--admin-ink-2);
+	border-top: 1px solid var(--admin-warn);
+	color: var(--admin-warn);
 	font-size: 12px;
-	font-weight: var(--admin-w-body);
+	font-weight: var(--admin-w-strong);
 	line-height: 1.5;
 }
 

--- a/backend/src/main/resources/templates/admin/fragments/shell.html
+++ b/backend/src/main/resources/templates/admin/fragments/shell.html
@@ -173,10 +173,12 @@
 			<span class="admin-status-label">리비전</span>
 			<strong th:text="${adminShell != null ? adminShell.revision : 'local'}">local</strong>
 		</span>
+		<!-- 마스터데이터 raw 값 정리(#2349 PR⑨): 미상 값(env 미설정 시 서버 기본값 "unknown")을
+		     그대로 노출하지 않고 "—"로 표시한다. 실제 값 판정 로직(AdminNavigationAdvice)은 불변, 표시만 바꾼다. -->
 		<span class="admin-status-item"
 		      title="현재 적재된 마스터데이터(역·시설 참조 팩) 버전">
 			<span class="admin-status-label">마스터데이터</span>
-			<strong th:text="${adminShell != null ? adminShell.masterDataVersion : 'unknown'}">unknown</strong>
+			<strong th:text="${adminShell != null and adminShell.masterDataVersion != null and adminShell.masterDataVersion != 'unknown'} ? ${adminShell.masterDataVersion} : '—'">—</strong>
 		</span>
 	</div>
 </div>

--- a/backend/src/main/resources/templates/admin/login.html
+++ b/backend/src/main/resources/templates/admin/login.html
@@ -22,7 +22,7 @@
 			<label for="password">비밀번호</label>
 			<input id="password" name="password" type="password" autocomplete="current-password" required>
 		</div>
-		<button class="login-submit" type="submit">로그인</button>
+		<button class="login-submit primary" type="submit">로그인</button>
 		<div class="login-note"
 		     role="alert"
 		     th:if="${loginNotice == T(com.easysubway.common.security.LoginNotice).RETRY_WARNING}">아이디 또는 비밀번호를 확인하고 다시 시도해 주세요.</div>

--- a/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminV3PageSmokeTest.java
+++ b/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminV3PageSmokeTest.java
@@ -554,7 +554,8 @@ class AdminV3PageSmokeTest {
 			.contains("<span class=\"admin-status-label\">리비전</span>")
 			.contains("<strong>local</strong>")
 			.contains("<span class=\"admin-status-label\">마스터데이터</span>")
-			.contains("<strong>unknown</strong>")
+			// #2349 PR⑨: env 미설정 시 서버 기본값("unknown")을 raw로 노출하지 않고 "—"로 표시한다.
+			.contains("<strong>—</strong>")
 			.contains(expectedText);
 		assertThat(html.indexOf("href=\"#admin-content\""))
 			.isLessThan(html.indexOf("class=\"admin-shell\""));


### PR DESCRIPTION
## 관련 이슈

Refs #2349

## 작업 내용

- topbar `.admin-topbar-logout`을 계정 메뉴(`.admin-user-menu-trigger`)와 동급의 박스 버튼에서 보더·채움 없는 텍스트 톤(plain)으로 위계를 낮췄다. CSRF POST form·no-JS 동작·aria-label 계약은 그대로 두고, 44px 터치 타깃은 결합 셀렉터(`.admin-sidebar-toggle, .admin-alert-bell, .admin-user-menu-trigger, .admin-topbar-logout`)가 계속 공급한다.
- 사이드바가 상시 노출되는 데스크톱(>1024px)에서 topbar의 "쉬운 지하철 / 통합 관리자" 브랜드 표기(`.admin-topbar-brand`·`.admin-topbar-sep`·`.admin-topbar-scope`)를 CSS `display:none`으로 숨겨 사이드바 브랜드와의 중복을 제거했다. 사이드바가 off-canvas로 바뀌는 ≤1024px 미디어 쿼리에서는 다시 노출한다(모바일에서는 유일한 브랜드 표시). 접근성 스모크가 고정하는 클래스·aria-label은 변경하지 않았다.
- 상단바 상태 스트립의 마스터데이터 항목이 env 미설정 시 서버 기본값 `unknown`을 raw로 노출하던 것을 `—`로 표시하도록 템플릿만 바꿨다(`AdminNavigationAdvice`의 실제 값 판정 로직은 불변). "리비전 local"은 실값이므로 그대로 유지했다.
- admin/operator 로그인 화면의 retry warning(`role="alert"`, `LoginNotice.RETRY_WARNING`)이 설명문과 같은 무채색 톤이라 오류 상태로 식별되지 않던 것을, 기존 하단 구분선 블록 패턴은 유지한 채 상태 컴포넌트(`.admin-status`/`.status`)와 같은 warn 톤(색+글자 강조)으로 정합했다(admin·operator 동일 처리, NONE/RETRY_WARNING parity 유지). admin 로그인 버튼은 화면 유일 주 액션이라 filled를 유지하되, 기존 compat 기본값 대신 명시적 `primary` class로 정합했다(시각적으로는 동일, 이관 컨벤션 정합).

## 검증

- 실행한 명령과 결과:
  - `node --test tools/qa/admin-accessibility-qa.test.mjs` → 15 pass, 0 fail
  - `./gradlew test --tests "com.easysubway.admin.adapter.in.web.AdminV3PageSmokeTest" --tests "com.easysubway.admin.adapter.in.web.AdminAccessibilitySmokeTest" --tests "com.easysubway.admin.web.AdminDesignGuardTest" --tests "com.easysubway.admin.navigation.AdminNavigationAdviceTest" --tests "com.easysubway.admin.adapter.in.web.AdminPhase3QualityGateTest" --tests "com.easysubway.common.security.LoginNoticeTest" --tests "com.easysubway.common.security.LoginNoticeSecurityTest" --tests "com.easysubway.operator.adapter.in.web.OperatorLoginPageControllerTest"` → BUILD SUCCESSFUL (71 tests, 0 failures)
  - dev 프로파일 실기동(H2, `EASYSUBWAY_DEV_SEED=true`, `EASYSUBWAY_ADMIN_BASIC_AUTH_ENABLED=false`)으로 로그인 후 데스크톱(1440)·모바일(390) topbar, admin/operator 로그인 화면(NONE·RETRY_WARNING)을 실제로 확인. 스크린샷 6장을 `.superpowers/plans/2349-evidence/`에 저장(리포에는 커밋하지 않음, gitignore 대상 로컬 산출물).

## 영향

- [x] 제품/운영 위험 없음 (route/accessibility/mobile UX/backend API/auth/security 아님)
- [x] DB migration 없음
- [x] 배포 영향 없음
- [x] route/realtime/datapack contract 영향 없음
- [x] CI workflow·계약 테스트·release gate JSON 변경 없음 (있으면 full.md로 전환)

## 체크리스트

- [x] 이 PR은 B/C등급 작업이며 full template이 필요 없다.
- [ ] CI 결과를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 폴백 리뷰를 단일 PR review로 게시했다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 관리자 로그인 화면의 제출 버튼 스타일을 강조해 가시성을 높였습니다.
  - 모바일 화면에서 관리자 상단바의 브랜드·구분자·범위 정보가 표시됩니다.

- **개선 사항**
  - 로그인 재시도 안내를 경고 색상과 굵은 글씨로 표시합니다.
  - 로그아웃 버튼은 기본 상태를 간결하게 정리하고, 마우스를 올리면 활성화된 스타일을 제공합니다.
  - 마스터데이터 버전을 확인할 수 없을 때 `unknown` 대신 `—`로 표시합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->