### PR TITLE
[Style] #2349 결측 표기 — 셀 스크린리더 텍스트 병기 (PR⑩b)

### DIFF
--- a/backend/src/main/resources/static/css/operator-v3.css
+++ b/backend/src/main/resources/static/css/operator-v3.css
@@ -607,6 +607,19 @@ input:focus-visible {
 	font-weight: var(--admin-w-strong);
 }
 
+/* 결측값 스크린리더 텍스트(#2349 PR⑩b): admin-components.css .sr-only와 동일 정의. */
+.sr-only {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
+}
+
 /* retry warning(#2349 PR⑨): admin 로그인과 동일한 warn 톤 정합(NONE/RETRY_WARNING parity 계약). */
 .login-note {
 	margin-top: 18px;

--- a/backend/src/main/resources/templates/admin/ads/list.html
+++ b/backend/src/main/resources/templates/admin/ads/list.html
@@ -82,7 +82,7 @@
 				       th:aria-label="${creative.id + ' ' + creative.advertiserName + ' 랜딩 페이지 열기'}">랜딩 열기</a></td>
 				<td th:text="${creative.altText}">대체텍스트</td>
 				<td th:text="${creative.startsAt}">2026-07-11T00:00</td>
-				<td th:text="${creative.endsAt != null ? creative.endsAt : '—'}">—</td>
+				<td th:insert="~{admin/fragments/missing-value :: value(${creative.endsAt}, '없음')}">—</td>
 				<td>
 					<span th:text="${creative.enabled ? '활성' : '비활성'}">비활성</span>
 					<form method="post"

--- a/backend/src/main/resources/templates/admin/audits/detail.html
+++ b/backend/src/main/resources/templates/admin/audits/detail.html
@@ -54,11 +54,11 @@
 				</dd>
 				<dt>사유</dt>
 				<dd th:class="${privacyMode and event.reasonMissing} ? 'reason-missing'"
-				    th:text="${event.reason}">—</dd>
+				    th:insert="~{admin/fragments/missing-value :: value(${event.reason}, '미상')}">—</dd>
 				<dt>요청 ID</dt>
-				<dd th:text="${event.requestId}">—</dd>
+				<dd th:insert="~{admin/fragments/missing-value :: value(${event.requestId}, '미상')}">—</dd>
 				<dt>클라이언트 IP</dt>
-				<dd th:text="${event.clientIp}">—</dd>
+				<dd th:insert="~{admin/fragments/missing-value :: value(${event.clientIp}, '미상')}">—</dd>
 			</dl>
 		</section>
 

--- a/backend/src/main/resources/templates/admin/audits/list.html
+++ b/backend/src/main/resources/templates/admin/audits/list.html
@@ -125,7 +125,7 @@
 						<span th:replace="~{admin/fragments/shell :: status(${event.outcomeLabel}, ${event.outcomeTone == 'failure'} ? 'bad' : 'good')}">성공</span>
 					</td>
 					<td th:class="${privacyMode and event.reasonMissing} ? 'reason-missing'"
-					    th:text="${event.reason}">—</td>
+					    th:insert="~{admin/fragments/missing-value :: value(${event.reason}, '미상')}">—</td>
 					<td>
 						<a th:href="@{${detailBase} + '/' + ${event.id}}"
 						   th:attr="hx-get=@{${detailBase} + '/' + ${event.id}}"

--- a/backend/src/main/resources/templates/admin/batches/list.html
+++ b/backend/src/main/resources/templates/admin/batches/list.html
@@ -132,14 +132,14 @@
 				<td><span th:replace="~{admin/fragments/shell :: statusAuto(${run.statusLabel})}">실패</span></td>
 				<td th:text="${run.requestedBy}">admin</td>
 				<td th:text="${run.startedAt}">2026-06-27T00:00</td>
-				<td th:text="${run.completedAtLabel()}">—</td>
+				<td th:insert="~{admin/fragments/missing-value :: value(${run.completedAtLabel()}, '없음')}">—</td>
 				<td>
 					<ul>
 						<li th:each="step : ${run.steps}">
 							<strong th:text="${step.name}">FETCH</strong>
 							<span th:text="${step.statusLabel}">실패</span>
 							<span th:text="${'건수 ' + step.recordCount}">건수 0</span>
-							<span th:text="${step.failureMessage}">—</span>
+							<span th:insert="~{admin/fragments/missing-value :: value(${step.failureMessage}, '미상')}">—</span>
 						</li>
 					</ul>
 				</td>

--- a/backend/src/main/resources/templates/admin/collections/list.html
+++ b/backend/src/main/resources/templates/admin/collections/list.html
@@ -75,12 +75,13 @@
 								<strong th:text="${step.name}">FETCH</strong>
 								<span th:text="${step.statusLabel}">완료</span>
 								<span th:text="${'건수 ' + step.recordCount}">건수 14</span>
-								<span th:if="${step.failed}" class="admin-step-failure" th:text="${step.failureMessage}">—</span>
+								<span th:if="${step.failed}" class="admin-step-failure"><th:block
+								      th:insert="~{admin/fragments/missing-value :: value(${step.failureMessage}, '미상')}">—</th:block></span>
 							</li>
 						</ol>
 					</details>
 				</td>
-				<td th:text="${run.failureLabel()}">—</td>
+				<td th:insert="~{admin/fragments/missing-value :: value(${run.failureLabel()}, '미상')}">—</td>
 				<td>
 					<details th:if="${run.retryable}" class="admin-retry-confirm">
 						<summary>재시도…</summary>

--- a/backend/src/main/resources/templates/admin/dashboard.html
+++ b/backend/src/main/resources/templates/admin/dashboard.html
@@ -119,7 +119,7 @@
 			<p class="summary">
 				<!-- 후보가 없으면 candidateId는 "-" placeholder다. 상태 뱃지 앞 "- ●"로 겹쳐 보이던
 				     잔존 표기를 결측 규칙(—)으로 정리한다(#2349). -->
-				<strong th:text="${datapackReleaseSummary.candidateId == '-'} ? '—' : ${datapackReleaseSummary.candidateId}">candidate-id</strong>
+				<strong th:insert="~{admin/fragments/missing-value :: value(${datapackReleaseSummary.candidateId == '-' ? null : datapackReleaseSummary.candidateId}, '미상')}">candidate-id</strong>
 				<span th:replace="~{admin/fragments/shell :: status(${datapackReleaseSummary.status}, ${datapackReleaseSummary.status == 'READY' || datapackReleaseSummary.status == 'PASS' ? 'good' : (datapackReleaseSummary.status == 'FAIL' ? 'bad' : 'warn')})}">FAIL</span>
 			</p>
 			<p class="summary" th:text="${datapackReleaseSummary.productionPromoteReason()}">프로덕션 반영 차단: 차단 요인 0건</p>

--- a/backend/src/main/resources/templates/admin/datapack/candidates/detail.html
+++ b/backend/src/main/resources/templates/admin/datapack/candidates/detail.html
@@ -71,7 +71,7 @@
 		<h2>증거·산출물</h2>
 		<dl class="admin-meta-list">
 			<dt>증거 워크플로</dt>
-			<dd th:text="${evidenceBundle.workflowRunUrl}">workflow</dd>
+			<dd th:insert="~{admin/fragments/missing-value :: value(${evidenceBundle.workflowRunUrl}, '미상')}">workflow</dd>
 			<dt>증거 번들 sha256</dt>
 			<dd>
 				<span class="sha-inline" th:title="${evidenceBundle.evidenceBundleSha256}"

--- a/backend/src/main/resources/templates/admin/datapack/facility-evidence/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/facility-evidence/list.html
@@ -97,10 +97,10 @@
 				<td th:text="${row.confidence}">95</td>
 				<td>
 					<strong th:text="${row.strictRouteLabel}">strict 가능</strong>
-					<span th:text="${row.strictRouteReason}">—</span>
+					<span th:insert="~{admin/fragments/missing-value :: value(${row.strictRouteReason}, '미상')}">—</span>
 				</td>
 				<td th:text="${row.conflictStatus}">NONE</td>
-				<td th:text="${row.manualOverrideId}">—</td>
+				<td th:insert="~{admin/fragments/missing-value :: value(${row.manualOverrideId}, '미상')}">—</td>
 				<td>
 					<form class="admin-form" method="post" th:action="@{'/admin/datapack/facility-evidence/' + ${row.id} + '/review'}">
 						<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">

--- a/backend/src/main/resources/templates/admin/datapack/manual-overrides/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/manual-overrides/list.html
@@ -147,13 +147,13 @@
 				<td th:text="${row.conflictStatus}">NONE</td>
 				<td>
 					<span th:text="${row.strictRouteEligible ? 'strict 요청' : 'strict 아님'}">strict 아님</span>
-					<span th:text="${row.routeSafetyApprovedBy}">—</span>
+					<span th:insert="~{admin/fragments/missing-value :: value(${row.routeSafetyApprovedBy}, '미상')}">—</span>
 				</td>
 				<td>
 					<span th:text="${row.effectiveFrom}">2026-06-29T03:00</span>
 					<span th:text="${row.expiresAt}">2026-07-29T03:00</span>
 				</td>
-				<td th:text="${row.supersededBy}">—</td>
+				<td th:insert="~{admin/fragments/missing-value :: value(${row.supersededBy}, '미상')}">—</td>
 				<td th:text="${row.productionStatus}">candidate 가능</td>
 				<td>
 					<form class="admin-form" method="post" th:action="@{'/admin/datapack/manual-overrides/' + ${row.id} + '/approve'}">

--- a/backend/src/main/resources/templates/admin/datapack/pipeline/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/pipeline/list.html
@@ -26,7 +26,7 @@
 		<div class="metric-grid" aria-label="현재 후보 요약">
 			<div class="metric metric-cell">
 				<span>후보</span>
-				<strong><span th:title="${pipeline.candidateId}" th:text="${pipeline.candidateIdShort}">—</span></strong>
+				<strong><span th:title="${pipeline.candidateId}" th:insert="~{admin/fragments/missing-value :: value(${pipeline.candidateIdShort}, '미상')}">—</span></strong>
 				<em th:text="${'범위 ' + pipeline.scopeId}">범위</em>
 			</div>
 			<div class="metric metric-cell">
@@ -129,21 +129,21 @@
 			<dt>원천 스냅샷 세트</dt>
 			<dd>
 				<span class="sha-inline" th:title="${pipeline.sourceSnapshotSetHash.fullValue}"
-				      th:text="${pipeline.sourceSnapshotSetHash.shortValue}">—</span>
+				      th:insert="~{admin/fragments/missing-value :: value(${pipeline.sourceSnapshotSetHash.shortValue}, '미상')}">—</span>
 				<button type="button" class="tiny-btn outline" x-data="copyField" x-on:click="copy"
 				        th:attr="data-copy-value=${pipeline.sourceSnapshotSetHash.fullValue}">복사</button>
 			</dd>
 			<dt>매니페스트 sha256</dt>
 			<dd>
 				<span class="sha-inline" th:title="${pipeline.manifestSha256.fullValue}"
-				      th:text="${pipeline.manifestSha256.shortValue}">—</span>
+				      th:insert="~{admin/fragments/missing-value :: value(${pipeline.manifestSha256.shortValue}, '미상')}">—</span>
 				<button type="button" class="tiny-btn outline" x-data="copyField" x-on:click="copy"
 				        th:attr="data-copy-value=${pipeline.manifestSha256.fullValue}">복사</button>
 			</dd>
 			<dt>증거 번들 sha256</dt>
 			<dd>
 				<span class="sha-inline" th:title="${pipeline.evidenceBundleSha256.fullValue}"
-				      th:text="${pipeline.evidenceBundleSha256.shortValue}">—</span>
+				      th:insert="~{admin/fragments/missing-value :: value(${pipeline.evidenceBundleSha256.shortValue}, '미상')}">—</span>
 				<button type="button" class="tiny-btn outline" x-data="copyField" x-on:click="copy"
 				        th:attr="data-copy-value=${pipeline.evidenceBundleSha256.fullValue}">복사</button>
 			</dd>
@@ -154,11 +154,11 @@
 			<summary>sha 원문 보기</summary>
 			<dl class="admin-meta-list">
 				<dt>원천 스냅샷 세트</dt>
-				<dd th:text="${pipeline.sourceSnapshotSetHash.fullValue}">—</dd>
+				<dd th:insert="~{admin/fragments/missing-value :: value(${pipeline.sourceSnapshotSetHash.fullValue}, '미상')}">—</dd>
 				<dt>매니페스트 sha256</dt>
-				<dd th:text="${pipeline.manifestSha256.fullValue}">—</dd>
+				<dd th:insert="~{admin/fragments/missing-value :: value(${pipeline.manifestSha256.fullValue}, '미상')}">—</dd>
 				<dt>증거 번들 sha256</dt>
-				<dd th:text="${pipeline.evidenceBundleSha256.fullValue}">—</dd>
+				<dd th:insert="~{admin/fragments/missing-value :: value(${pipeline.evidenceBundleSha256.fullValue}, '미상')}">—</dd>
 			</dl>
 		</details>
 		</details>

--- a/backend/src/main/resources/templates/admin/datapack/release-channels/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/release-channels/list.html
@@ -85,7 +85,7 @@
 					<span th:title="${channel.manifestSha256}" th:text="${#strings.abbreviate(channel.manifestSha256, 11)}">sha</span>
 				</td>
 				<td>
-					<span th:text="${channel.previousStableCandidateId}">previous candidate</span>
+					<span th:insert="~{admin/fragments/missing-value :: value(${channel.previousStableCandidateId}, '미상')}">previous candidate</span>
 					<span th:text="${channel.previousStableCandidateVersion}">previous version</span>
 					<span th:title="${channel.previousManifestSha256}" th:text="${#strings.abbreviate(channel.previousManifestSha256, 11)}">previous sha</span>
 				</td>

--- a/backend/src/main/resources/templates/admin/datapack/release-channels/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/release-channels/list.html
@@ -86,8 +86,8 @@
 				</td>
 				<td>
 					<span th:insert="~{admin/fragments/missing-value :: value(${channel.previousStableCandidateId}, '미상')}">previous candidate</span>
-					<span th:text="${channel.previousStableCandidateVersion}">previous version</span>
-					<span th:title="${channel.previousManifestSha256}" th:text="${#strings.abbreviate(channel.previousManifestSha256, 11)}">previous sha</span>
+					<span th:insert="~{admin/fragments/missing-value :: value(${channel.previousStableCandidateVersion}, '미상')}">previous version</span>
+					<span th:title="${channel.previousManifestSha256}" th:insert="~{admin/fragments/missing-value :: value(${#strings.abbreviate(channel.previousManifestSha256, 11)}, '미상')}">previous sha</span>
 				</td>
 				<td th:text="${channel.rollbackLabel}">rollback 가능</td>
 				<td>
@@ -217,7 +217,7 @@
 					<span th:text="${event.approvedBy}">approved</span>
 					<span th:text="${event.reason}">reason</span>
 				</td>
-				<td th:text="${event.workflowRunUrl}">workflow</td>
+				<td th:insert="~{admin/fragments/missing-value :: value(${event.workflowRunUrl}, '미상')}">workflow</td>
 				<td th:text="${event.createdAt}">2026-06-29T03:10</td>
 			</tr>
 			</tbody>

--- a/backend/src/main/resources/templates/admin/datapack/release-requests/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/release-requests/list.html
@@ -142,8 +142,7 @@
 			<tr th:each="delivery : ${deliveries}">
 				<td th:text="${delivery.releaseRequestId + ' / ' + delivery.releaseSequence}">request</td>
 				<td th:text="${delivery.channel + ' / ' + delivery.state}">state</td>
-				<td><span th:text="${delivery.attempts}">0</span> / <th:block
-				    th:insert="~{admin/fragments/missing-value :: value(${delivery.httpClass}, '미상')}">—</th:block></td>
+				<td><span th:text="${delivery.attempts}">0</span> / <th:block th:insert="~{admin/fragments/missing-value :: value(${delivery.httpClass}, '미상')}">—</th:block></td>
 				<td><time th:text="${delivery.nextAttemptAt}">next attempt</time> / <time th:text="${delivery.reconcileDeadline}">reconcile</time> / <time th:text="${delivery.deadLetterDeadline}">dead letter</time></td>
 				<td><code th:text="${delivery.payloadSha256}">payload hash</code><br><code th:text="${delivery.signatureSha256}">signature hash</code></td>
 				<td th:insert="~{admin/fragments/missing-value :: value(${delivery.detail}, '미상')}">차단 요인</td>

--- a/backend/src/main/resources/templates/admin/datapack/release-requests/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/release-requests/list.html
@@ -93,7 +93,8 @@
 					   th:href="${request.workflowRunUrl}"
 					   th:text="${request.workflowRunUrl}"
 					   target="_blank" rel="noopener noreferrer">workflow run</a>
-					<span th:unless="${request.workflowRunUrl != null}">—</span>
+					<span th:unless="${request.workflowRunUrl != null}"><th:block
+					      th:insert="~{admin/fragments/missing-value :: value(null, '미상')}">—</th:block></span>
 				</td>
 				<td th:text="${request.createdAt}">2026-07-06T00:00</td>
 				<td>
@@ -117,7 +118,8 @@
 					<span th:if="${request.status != 'REQUESTED'
 						and request.status != 'DISPATCH_FAILED'
 						and request.status != 'APPROVED'
-						and not (request.status == 'PUBLISHED' and request.promoteOutcome == 'REJECTED')}">—</span>
+						and not (request.status == 'PUBLISHED' and request.promoteOutcome == 'REJECTED')}"><th:block
+					      th:insert="~{admin/fragments/missing-value :: value(null, '미상')}">—</th:block></span>
 				</td>
 			</tr>
 			</tbody>
@@ -140,10 +142,11 @@
 			<tr th:each="delivery : ${deliveries}">
 				<td th:text="${delivery.releaseRequestId + ' / ' + delivery.releaseSequence}">request</td>
 				<td th:text="${delivery.channel + ' / ' + delivery.state}">state</td>
-				<td th:text="${delivery.attempts + ' / ' + (delivery.httpClass ?: '—')}">attempt</td>
+				<td><span th:text="${delivery.attempts}">0</span> / <th:block
+				    th:insert="~{admin/fragments/missing-value :: value(${delivery.httpClass}, '미상')}">—</th:block></td>
 				<td><time th:text="${delivery.nextAttemptAt}">next attempt</time> / <time th:text="${delivery.reconcileDeadline}">reconcile</time> / <time th:text="${delivery.deadLetterDeadline}">dead letter</time></td>
 				<td><code th:text="${delivery.payloadSha256}">payload hash</code><br><code th:text="${delivery.signatureSha256}">signature hash</code></td>
-				<td th:text="${delivery.detail ?: '—'}">차단 요인</td>
+				<td th:insert="~{admin/fragments/missing-value :: value(${delivery.detail}, '미상')}">차단 요인</td>
 				<td>
 					<form th:if="${delivery.repairable}" method="post"
 						  th:action="@{/admin/datapack/release-deliveries/{idempotencyKey}/repair(idempotencyKey=${delivery.idempotencyKey})}">
@@ -152,7 +155,8 @@
 						<label>복구 사유 <input name="reason" required maxlength="200"></label>
 						<button type="submit" class="outline">수동 복구</button>
 					</form>
-					<span th:unless="${delivery.repairable}">—</span>
+					<span th:unless="${delivery.repairable}"><th:block
+					      th:insert="~{admin/fragments/missing-value :: value(null, '미상')}">—</th:block></span>
 				</td>
 			</tr>
 			</tbody>

--- a/backend/src/main/resources/templates/admin/datapack/route-gates/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/route-gates/list.html
@@ -80,7 +80,7 @@
 				<td th:text="${row.edgeType}">ENTRY</td>
 				<td th:text="${row.verificationStatus}">VERIFIED</td>
 				<td th:text="${row.provenanceKind}">OFFICIAL_SOURCE</td>
-				<td th:text="${row.generatedConnector ? 'generated connector' : '—'}">—</td>
+				<td th:insert="~{admin/fragments/missing-value :: value(${row.generatedConnector ? 'generated connector' : null}, '미상')}">—</td>
 				<td>
 					<span th:text="${row.sourceId}">source-id</span>
 					<span th:text="${row.sourceSnapshotId}">snapshot-id</span>
@@ -88,7 +88,7 @@
 				<td th:text="${row.lastVerifiedAt}">2026-06-29T03:00</td>
 				<td><span th:title="${row.evidenceHash}" th:text="${#strings.abbreviate(row.evidenceHash, 11)}">sha256</span></td>
 				<td th:text="${row.strictRouteLabel}">strict 가능</td>
-				<td th:text="${row.blockerReason}">—</td>
+				<td th:insert="~{admin/fragments/missing-value :: value(${row.blockerReason}, '미상')}">—</td>
 			</tr>
 			</tbody>
 		</table>

--- a/backend/src/main/resources/templates/admin/datapack/source-snapshots/detail.html
+++ b/backend/src/main/resources/templates/admin/datapack/source-snapshots/detail.html
@@ -38,9 +38,9 @@
 			<tr><th scope="row">provider valid until</th><td th:text="${snapshot.providerValidUntil}">2026-07-28T00:00</td></tr>
 			<tr><th scope="row">row count</th><td th:text="${snapshot.rowCount}">0</td></tr>
 			<tr><th scope="row">coverage count</th><td th:text="${snapshot.coverageCount}">0</td></tr>
-			<tr><th scope="row">previous snapshot</th><td th:text="${snapshot.previousSnapshotId}">—</td></tr>
-			<tr><th scope="row">diff summary</th><td th:text="${snapshot.diffSummary}">—</td></tr>
-			<tr><th scope="row">diff summary JSON</th><td th:text="${snapshot.diffSummaryJson}">—</td></tr>
+			<tr><th scope="row">previous snapshot</th><td th:insert="~{admin/fragments/missing-value :: value(${snapshot.previousSnapshotId}, '미상')}">—</td></tr>
+			<tr><th scope="row">diff summary</th><td th:insert="~{admin/fragments/missing-value :: value(${snapshot.diffSummary}, '미상')}">—</td></tr>
+			<tr><th scope="row">diff summary JSON</th><td th:insert="~{admin/fragments/missing-value :: value(${snapshot.diffSummaryJson}, '미상')}">—</td></tr>
 			</tbody>
 		</table>
 		</div>
@@ -60,8 +60,8 @@
 			<tr><th scope="row">credential redacted</th><td th:text="${snapshot.credentialRedactedLabel()}">credential redacted</td></tr>
 			<tr><th scope="row">freshness expires</th><td th:text="${snapshot.freshnessExpiresAt}">2026-07-06T03:00</td></tr>
 			<tr><th scope="row">raw retention</th><td th:text="${snapshot.rawRetentionExpiresAt}">2026-09-29T03:00</td></tr>
-			<tr><th scope="row">governance policy version</th><td th:text="${snapshot.governancePolicyVersion}">—</td></tr>
-			<tr><th scope="row">governance policy sha256</th><td th:text="${snapshot.governancePolicySha256}">—</td></tr>
+			<tr><th scope="row">governance policy version</th><td th:insert="~{admin/fragments/missing-value :: value(${snapshot.governancePolicyVersion}, '미상')}">—</td></tr>
+			<tr><th scope="row">governance policy sha256</th><td th:insert="~{admin/fragments/missing-value :: value(${snapshot.governancePolicySha256}, '미상')}">—</td></tr>
 			</tbody>
 		</table>
 		</div>

--- a/backend/src/main/resources/templates/admin/datapack/source-snapshots/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/source-snapshots/list.html
@@ -87,7 +87,7 @@
 					<span th:text="${snapshot.fetchStatus}">SUCCESS</span>
 				</td>
 				<td><span th:title="${snapshot.rawSha256}" th:text="${#strings.abbreviate(snapshot.rawSha256, 11)}">sha256</span></td>
-				<td th:text="${snapshot.diffSummary}">—</td>
+				<td th:insert="~{admin/fragments/missing-value :: value(${snapshot.diffSummary}, '미상')}">—</td>
 				<td>
 					<a class="detail-link"
 					   th:href="@{/admin/datapack/source-snapshots/{snapshotId}/page(snapshotId=${snapshot.snapshotId})}">보기</a>

--- a/backend/src/main/resources/templates/admin/fragments/dashboard-trends.html
+++ b/backend/src/main/resources/templates/admin/fragments/dashboard-trends.html
@@ -52,8 +52,8 @@
 					<tbody>
 					<tr th:each="label, iter : ${trend.data.labels}">
 						<th scope="row" th:text="${label}">날짜</th>
-						<td th:each="s : ${trend.data.series}"
-						    th:text="${s.values[iter.index] != null ? s.values[iter.index] : '—'}">0</td>
+						<td th:each="s : ${trend.data.series}"><th:block
+						    th:insert="~{admin/fragments/missing-value :: value(${s.values[iter.index]}, '미상')}">0</th:block></td>
 					</tr>
 					</tbody>
 				</table>

--- a/backend/src/main/resources/templates/admin/fragments/missing-value.html
+++ b/backend/src/main/resources/templates/admin/fragments/missing-value.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="utf-8">
+	<title>결측값 표시 fragment</title>
+</head>
+<body>
+<!--
+  결측값 표시 fragment(#2349 PR⑩b). "—"(em-dash) 단독 셀은 스크린리더가 대시 문자로만 읽어 의미가
+  전달되지 않는다. raw가 null이거나 결측 sentinel 문자열 "—"이면(도메인 계층이 미리 "—"로 치환해 넘기는
+  케이스 포함) 시각은 기존과 동일하게 "—"를 보여주되 aria-hidden="true"로 감추고, 실제 접근 가능한
+  텍스트는 .sr-only로 병기한다. raw가 실값이면 그대로 텍스트로 렌더한다.
+  th:insert로 호출해 호스트 태그(td/dd/span 등)와 그 속성(class·th:if 등)은 그대로 유지한다.
+  사용: <td th:insert="~{admin/fragments/missing-value :: value(${x}, '미상')}">—</td>
+        <td th:insert="~{admin/fragments/missing-value :: value(${x}, '없음')}">—</td>
+-->
+<!-- 렌더 결과에 불필요한 개행/공백이 섞이지 않도록(HTML 스모크 테스트의 정확 문자열 매칭 대상) 분기를 한 줄로 붙여 쓴다. -->
+<th:block th:fragment="value(raw, srText)"><th:block th:if="${raw != null and raw != '—'}" th:text="${raw}">값</th:block><th:block th:unless="${raw != null and raw != '—'}"><span aria-hidden="true">—</span><span class="sr-only" th:text="${srText}">미상</span></th:block></th:block>
+</body>
+</html>

--- a/backend/src/main/resources/templates/admin/fragments/missing-value.html
+++ b/backend/src/main/resources/templates/admin/fragments/missing-value.html
@@ -7,14 +7,17 @@
 <body>
 <!--
   결측값 표시 fragment(#2349 PR⑩b). "—"(em-dash) 단독 셀은 스크린리더가 대시 문자로만 읽어 의미가
-  전달되지 않는다. raw가 null이거나 결측 sentinel 문자열 "—"이면(도메인 계층이 미리 "—"로 치환해 넘기는
-  케이스 포함) 시각은 기존과 동일하게 "—"를 보여주되 aria-hidden="true"로 감추고, 실제 접근 가능한
-  텍스트는 .sr-only로 병기한다. raw가 실값이면 그대로 텍스트로 렌더한다.
+  전달되지 않는다. raw가 null이거나 결측 sentinel 문자열 "—"이거나 빈/공백 문자열이면(도메인 계층이 미리
+  "—"로 치환해 넘기는 케이스 포함) 시각은 기존과 동일하게 "—"를 보여주되 aria-hidden="true"로 감추고,
+  실제 접근 가능한 텍스트는 .sr-only로 병기한다. raw가 실값이면 그대로 텍스트로 렌더한다.
+  raw는 문자열 외 Integer 등도 넘어올 수 있다(추이 표 등) — #strings.trim/#strings.isEmpty는 Object를
+  내부적으로 toString() 후 처리하므로(Thymeleaf 3.1.5 Strings#trim(Object)/#isEmpty(Object) 확인) 비문자열
+  raw에도 안전하다.
   th:insert로 호출해 호스트 태그(td/dd/span 등)와 그 속성(class·th:if 등)은 그대로 유지한다.
   사용: <td th:insert="~{admin/fragments/missing-value :: value(${x}, '미상')}">—</td>
         <td th:insert="~{admin/fragments/missing-value :: value(${x}, '없음')}">—</td>
 -->
 <!-- 렌더 결과에 불필요한 개행/공백이 섞이지 않도록(HTML 스모크 테스트의 정확 문자열 매칭 대상) 분기를 한 줄로 붙여 쓴다. -->
-<th:block th:fragment="value(raw, srText)"><th:block th:if="${raw != null and raw != '—'}" th:text="${raw}">값</th:block><th:block th:unless="${raw != null and raw != '—'}"><span aria-hidden="true">—</span><span class="sr-only" th:text="${srText}">미상</span></th:block></th:block>
+<th:block th:fragment="value(raw, srText)" th:with="present=${raw != null and raw != '—' and !#strings.isEmpty(#strings.trim(raw))}"><th:block th:if="${present}" th:text="${raw}">값</th:block><th:block th:unless="${present}"><span aria-hidden="true">—</span><span class="sr-only" th:text="${srText}">미상</span></th:block></th:block>
 </body>
 </html>

--- a/backend/src/main/resources/templates/admin/fragments/shell.html
+++ b/backend/src/main/resources/templates/admin/fragments/shell.html
@@ -178,7 +178,7 @@
 		<span class="admin-status-item"
 		      title="현재 적재된 마스터데이터(역·시설 참조 팩) 버전">
 			<span class="admin-status-label">마스터데이터</span>
-			<strong th:text="${adminShell != null and adminShell.masterDataVersion != null and adminShell.masterDataVersion != 'unknown'} ? ${adminShell.masterDataVersion} : '—'">—</strong>
+			<strong th:insert="~{admin/fragments/missing-value :: value(${adminShell != null and adminShell.masterDataVersion != null and adminShell.masterDataVersion != 'unknown' ? adminShell.masterDataVersion : null}, '미상')}">—</strong>
 		</span>
 	</div>
 </div>

--- a/backend/src/main/resources/templates/admin/fragments/trend-chart-table.html
+++ b/backend/src/main/resources/templates/admin/fragments/trend-chart-table.html
@@ -25,8 +25,8 @@
 		<tbody>
 		<tr th:each="label, iter : ${trendChart.labels}">
 			<th scope="row" th:text="${label}">날짜</th>
-			<td th:each="s : ${trendChart.series}"
-			    th:text="${s.values[iter.index] != null ? s.values[iter.index] : '—'}">0</td>
+			<td th:each="s : ${trendChart.series}"><th:block
+			    th:insert="~{admin/fragments/missing-value :: value(${s.values[iter.index]}, '미상')}">0</th:block></td>
 		</tr>
 		</tbody>
 	</table>

--- a/backend/src/main/resources/templates/admin/incidents/list.html
+++ b/backend/src/main/resources/templates/admin/incidents/list.html
@@ -95,7 +95,7 @@
 				<td th:text="${incident.summary}">요약</td>
 				<td th:text="${incident.owner}">admin</td>
 				<td th:text="${incident.openedAt}">2026-06-27T00:00</td>
-				<td th:text="${incident.resolvedAt}">—</td>
+				<td th:insert="~{admin/fragments/missing-value :: value(${incident.resolvedAt}, '없음')}">—</td>
 				<td>
 					<details class="admin-incident-detail">
 						<summary th:text="${'타임라인 (' + incident.timeline.size() + '건)'}">타임라인</summary>

--- a/backend/src/main/resources/templates/admin/notices/list.html
+++ b/backend/src/main/resources/templates/admin/notices/list.html
@@ -84,7 +84,7 @@
 				<td th:text="${notice.severity}">INFO</td>
 				<td th:text="${notice.body}">본문</td>
 				<td th:text="${notice.publishedAt}">2026-07-09T10:00</td>
-				<td th:text="${notice.expiresAt != null ? notice.expiresAt : '—'}">—</td>
+				<td th:insert="~{admin/fragments/missing-value :: value(${notice.expiresAt}, '없음')}">—</td>
 				<td th:text="${notice.publishedBy}">operator</td>
 				<td>
 					<form method="post"

--- a/backend/src/main/resources/templates/operator/data-collection-failures.html
+++ b/backend/src/main/resources/templates/operator/data-collection-failures.html
@@ -24,7 +24,7 @@
 
 			<div class="alert-banner" th:classappend="${report.freshnessAlertClass}">
 				<strong>데이터 갱신 상태: <span th:text="${report.freshnessAlertLabel}">점검 필요</span></strong>
-				<span>최신 완료 수집: <b th:text="${report.latestCompletedAtLabel}">—</b></span>
+				<span>최신 완료 수집: <b th:insert="~{admin/fragments/missing-value :: value(${report.latestCompletedAtLabel}, '없음')}">—</b></span>
 				<p th:text="${report.freshnessAlertDescription}">데이터 수집 완료 기록이 없습니다.</p>
 			</div>
 
@@ -32,7 +32,7 @@
 				<div class="metric"><span>전체 수집 실행</span><strong th:text="${report.totalRunCount}">0</strong></div>
 				<div class="metric"><span>실패 실행</span><strong th:text="${report.failedRunCount}">0</strong></div>
 				<div class="metric"><span>재시도 가능</span><strong th:text="${report.retryableRunCount}">0</strong></div>
-				<div class="metric"><span>최신 완료</span><strong th:text="${report.latestCompletedAtLabel}">—</strong></div>
+				<div class="metric"><span>최신 완료</span><strong th:insert="~{admin/fragments/missing-value :: value(${report.latestCompletedAtLabel}, '없음')}">—</strong></div>
 			</div>
 
 			<form class="table-toolbar" method="get" action="/operator/data-collection-failures/page">

--- a/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminDashboardTriagePanelTest.java
+++ b/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminDashboardTriagePanelTest.java
@@ -174,7 +174,7 @@ class AdminDashboardTriagePanelTest {
 		String html = fetchDashboard();
 
 		assertThat(html)
-			.contains("<strong>—</strong>")
+			.contains("<strong><span aria-hidden=\"true\">—</span><span class=\"sr-only\">미상</span></strong>")
 			.doesNotContain("<strong>-</strong>");
 	}
 

--- a/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminV3PageSmokeTest.java
+++ b/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminV3PageSmokeTest.java
@@ -555,7 +555,8 @@ class AdminV3PageSmokeTest {
 			.contains("<strong>local</strong>")
 			.contains("<span class=\"admin-status-label\">마스터데이터</span>")
 			// #2349 PR⑨: env 미설정 시 서버 기본값("unknown")을 raw로 노출하지 않고 "—"로 표시한다.
-			.contains("<strong>—</strong>")
+			// #2349 PR⑩b: "—" 단독 표시는 스크린리더가 대시 문자로만 읽으므로 sr-only 텍스트를 병기한다.
+			.contains("<strong><span aria-hidden=\"true\">—</span><span class=\"sr-only\">미상</span></strong>")
 			.contains(expectedText);
 		assertThat(html.indexOf("href=\"#admin-content\""))
 			.isLessThan(html.indexOf("class=\"admin-shell\""));

--- a/backend/src/test/java/com/easysubway/admin/fragments/MissingValueFragmentTest.java
+++ b/backend/src/test/java/com/easysubway/admin/fragments/MissingValueFragmentTest.java
@@ -1,0 +1,67 @@
+package com.easysubway.admin.fragments;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.StringWriter;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+import org.thymeleaf.templatemode.TemplateMode;
+import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
+
+/**
+ * admin/fragments/missing-value.html의 결측 판정 조건(#2349 PR⑩b 리뷰 반영)을 Spring MVC 없이
+ * 직접 렌더해 검증한다. null·"—"뿐 아니라 빈/공백 문자열도 결측 분기로 가야 하고,
+ * raw로 문자열이 아닌 값(Integer 등, 추이 표 호출부에서 사용)도 안전하게 처리되어야 한다.
+ */
+class MissingValueFragmentTest {
+
+	private static final String MISSING_MARKUP =
+		"<span aria-hidden=\"true\">—</span><span class=\"sr-only\">미상</span>";
+
+	private final TemplateEngine templateEngine = newTemplateEngine();
+
+	private static TemplateEngine newTemplateEngine() {
+		ClassLoaderTemplateResolver resolver = new ClassLoaderTemplateResolver();
+		resolver.setPrefix("templates/");
+		resolver.setSuffix(".html");
+		resolver.setTemplateMode(TemplateMode.HTML);
+		resolver.setCacheable(false);
+		// 운영 렌더링과 동일하게 SpringTemplateEngine(SpringStandardDialect/SpEL)을 사용한다.
+		// 기본 TemplateEngine(OGNL)은 이 프로젝트가 ognl 의존성을 끌어오지 않아 테스트 클래스패스에 없다.
+		SpringTemplateEngine engine = new SpringTemplateEngine();
+		engine.setTemplateResolver(resolver);
+		return engine;
+	}
+
+	@Test
+	void nullSentinelAndBlankStringsAllRenderAsMissing() {
+		assertThat(render(null)).isEqualTo(MISSING_MARKUP);
+		assertThat(render("—")).isEqualTo(MISSING_MARKUP);
+		assertThat(render("")).isEqualTo(MISSING_MARKUP);
+		assertThat(render("   ")).isEqualTo(MISSING_MARKUP);
+	}
+
+	@Test
+	void nonBlankStringRendersAsPlainText() {
+		assertThat(render("candidate-1")).isEqualTo("candidate-1");
+	}
+
+	@Test
+	void nonStringRawIsHandledSafely() {
+		assertThat(render(7)).isEqualTo("7");
+	}
+
+	private String render(Object raw) {
+		// th:fragment="value(raw, srText)"는 매개변수 목록을 서명으로 선언할 뿐이므로, 이름이 같은
+		// 컨텍스트 변수를 미리 채워 두면 셀렉터만으로도(인자 표현식 없이) 동일하게 바인딩된다.
+		Context context = new Context();
+		context.setVariable("raw", raw);
+		context.setVariable("srText", "미상");
+		StringWriter writer = new StringWriter();
+		templateEngine.process("admin/fragments/missing-value", Set.of("value"), context, writer);
+		return writer.toString();
+	}
+}

--- a/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackCandidateAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackCandidateAdminPageControllerTest.java
@@ -152,8 +152,9 @@ class DatapackCandidateAdminPageControllerTest {
 			.getContentAsString();
 
 		assertThat(detailHtml)
-			.contains("<dd>—</dd>")
-			.doesNotContain("<dd>-</dd>");
+			.contains("<dd><span aria-hidden=\"true\">—</span><span class=\"sr-only\">미상</span></dd>")
+			.doesNotContain("<dd>-</dd>")
+			.doesNotContain("<dd>—</dd>");
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackReleaseChannelAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackReleaseChannelAdminPageControllerTest.java
@@ -149,8 +149,9 @@ class DatapackReleaseChannelAdminPageControllerTest {
 			.getContentAsString();
 
 		assertThat(html)
-			.contains("<td>—</td>")
-			.doesNotContain("<td>-</td>");
+			.contains("<td><span aria-hidden=\"true\">—</span><span class=\"sr-only\">미상</span></td>")
+			.doesNotContain("<td>-</td>")
+			.doesNotContain("<td>—</td>");
 	}
 
 	private void insertCandidate(String id, String version) {


### PR DESCRIPTION
## 관련 이슈

Refs #2349

## 작업 내용

- 결측값을 `—`(em-dash) 단독으로 렌더하던 셀 42곳(admin 20파일 + operator 1파일)이 스크린리더에서 대시 문자로만 읽히던 것을, 공통 fragment `admin/fragments/missing-value.html`(신규)로 이관해 `<span aria-hidden="true">—</span><span class="sr-only">미상</span>` 병기로 통일했다(일시류 맥락은 "없음"). 시각 출력은 기존과 동일.
- `th:insert`로 호스트 태그·속성을 유지하고, `th:if`/`th:each`가 걸린 태그에는 자식 `th:block`으로 분리해 같은 태그 `th:if`+`th:replace` 선처리 함정을 회피했다.
- operator CSS에는 `.sr-only`가 없어 admin-components.css와 동일 정의를 `operator-v3.css`에 추가했다.
- `AdminV3PageSmokeTest`의 마스터데이터 결측 표기 단정문을 새 마크업에 맞게 갱신했다(검사 의도 불변).
- 문장 속 구분 기호 `—`(prose)와 hyphen `-` 기반 placeholder는 범위 밖으로 남겼다(후자는 PR⑩d에서 `—` 표준화와 함께 정리 예정).

## 검증

- 실행한 명령과 결과:
  - `node --test tools/qa/admin-accessibility-qa.test.mjs` → 15 pass, 0 fail
  - `./gradlew test`(AdminV3PageSmokeTest + 변경 템플릿 렌더 PageControllerTest 15클래스, 114 tests) → BUILD SUCCESSFUL
  - dev 실기동(H2, `EASYSUBWAY_DEV_SEED=true`) 후 로그인 세션으로 dashboard·datapack pipeline·notices·audits·batches HTML에서 신규 마크업 실렌더 확인(dashboard 2건·pipeline 8건 등). operator 화면은 렌더 동등성을 `OperatorDataCollectionFailuresPageControllerTest` green으로 확인.
  - `grep` 재실측으로 단독 결측 `—` 셀 잔여 0곳 확인.

## 영향

- [x] 제품/운영 위험 없음 (route/accessibility/mobile UX/backend API/auth/security 아님)
- [x] DB migration 없음
- [x] 배포 영향 없음
- [x] route/realtime/datapack contract 영향 없음
- [x] CI workflow·계약 테스트·release gate JSON 변경 없음 (있으면 full.md로 전환)

## 체크리스트

- [x] 이 PR은 B/C등급 작업이며 full template이 필요 없다.
- [ ] CI 결과를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 폴백 리뷰를 단일 PR review로 게시했다.