### PR TITLE
[Feat] #2383 광주 1호선 topology·시간표 production admission

### DIFF
--- a/apps/mobile/assets/datapacks/source-inventory.json
+++ b/apps/mobile/assets/datapacks/source-inventory.json
@@ -514,7 +514,7 @@
         "regionIds": ["gwangju"],
         "operatorIds": ["gwangju-metropolitan-rapid-transit"],
         "lineIds": ["line-e57a361e8892"],
-        "sourceDomains": ["route_graph_topology"]
+        "sourceDomains": ["route_graph_topology", "station_line_membership"]
       },
       "requiredForProductionPack": false,
       "productionUseAllowed": true,
@@ -569,6 +569,23 @@
         "excludedTransferCount": 0,
         "rawSha256": "15e4a6835dff21997d29707b0554580560fd770388156b2ac169508cdfd6636a",
         "contentSha256": "d8197488bc6dda94e595f7e350cc65c547117da804fb59b7dff85d18b3192e43"
+      },
+      "membershipAdmissionEvidence": {
+        "issue": 2383,
+        "materializer": "tools/datapack/materialize-gwangju-timetable.mjs",
+        "verificationTest": "tools/datapack/materialize-gwangju-timetable.test.mjs",
+        "snapshotId": "molit-urban-rail-full-route-gwangju-membership-20260720",
+        "lineIds": ["line-e57a361e8892"],
+        "verifiedAt": "2026-07-20T13:08:47.161Z",
+        "stationCount": 20,
+        "membershipSourceId": "molit-urban-rail-full-route",
+        "membershipSourceRawSha256": "178af75ece72b2f6a58226063e05f1e1f45f50c779c7fbf2905f7df1384a9e22",
+        "membershipSourceSnapshotSha256": "3f08fb398bcb16e8ff047ec17f094a28590ec8d5aa1b8df2d6e9cec85ed0f6e7",
+        "mappingSha256": "f7515bed1908e7b1aff2674f58b8425d94a8177d1fb5bed1f3fb8545cb347a03",
+        "stationCodesSha256": "dc831a8f14fd33808b6e17ecbf829eb6d4c199b6c1d75c7673adaa97ad69df83",
+        "stationCodeSourceId": "gwangju-transportation-route-topology",
+        "stationCodeSnapshotId": "gwangju-transportation-route-topology-20260720",
+        "stationCodeContentSha256": "d8197488bc6dda94e595f7e350cc65c547117da804fb59b7dff85d18b3192e43"
       }
     },
     {
@@ -676,7 +693,7 @@
         "redistributionAllowed": true,
         "evidenceUrl": "https://www.data.go.kr/data/15122916/fileData.do"
       },
-      "fieldsProvided": ["line", "station_name", "station_code"],
+      "fieldsProvided": ["line", "station_name"],
       "capabilities": {
         "schedule": {
           "status": "UNSUPPORTED",

--- a/apps/mobile/assets/datapacks/source-inventory.json
+++ b/apps/mobile/assets/datapacks/source-inventory.json
@@ -501,6 +501,233 @@
       }
     },
     {
+      "id": "gwangju-transportation-route-topology",
+      "displayName": "광주교통공사 도시철도 운행정보",
+      "owner": "광주교통공사",
+      "provider": "광주교통공사",
+      "providerDepartment": "IT전략팀",
+      "sourceSystem": "광주교통공사 오픈 API",
+      "datasetUrl": "https://www.grtc.co.kr/subway/contents/apiRunInfo",
+      "datasetKind": "official-open-api",
+      "coverage": "광주 1호선 20개 역과 38개 방향성 인접 거리·소요시간 edge",
+      "coverageScope": {
+        "regionIds": ["gwangju"],
+        "operatorIds": ["gwangju-metropolitan-rapid-transit"],
+        "lineIds": ["line-e57a361e8892"],
+        "sourceDomains": ["route_graph_topology", "station_line_membership"]
+      },
+      "requiredForProductionPack": false,
+      "productionUseAllowed": true,
+      "updateFrequency": "daily admission refresh",
+      "observedDataUpdatedAt": "2026-07-20",
+      "retrievedAt": "2026-07-20",
+      "license": {
+        "type": "PUBLIC_DATA_FREE_USE",
+        "name": "공공데이터포털 이용허락범위 제한 없음",
+        "attribution": "광주교통공사, 공공데이터포털 이용허락범위 제한 없음",
+        "commercialUseAllowed": true,
+        "derivativeWorkAllowed": true,
+        "redistributionAllowed": true,
+        "evidenceUrl": "https://www.data.go.kr/data/15046044/fileData.do"
+      },
+      "fieldsProvided": ["network_edges", "duration_seconds", "distance_meters", "station_code"],
+      "capabilities": {
+        "schedule": {
+          "status": "UNSUPPORTED",
+          "productionUseAllowed": false,
+          "coverageStatus": "NOT_PROVIDED_BY_SOURCE",
+          "updateFrequency": "daily admission refresh",
+          "unsupportedNotes": "source provides route travel cost, not scheduled departures"
+        },
+        "realtime": {
+          "status": "UNSUPPORTED",
+          "productionUseAllowed": false,
+          "liveEtaEligible": false,
+          "rateLimitStatus": "NOT_APPLICABLE",
+          "coverageStatus": "NOT_PROVIDED_BY_SOURCE",
+          "updateFrequency": "daily admission refresh",
+          "unsupportedNotes": "source does not provide realtime arrivals"
+        },
+        "facility": {
+          "status": "UNSUPPORTED",
+          "productionUseAllowed": false,
+          "coverageStatus": "NOT_PROVIDED_BY_SOURCE",
+          "updateFrequency": "daily admission refresh",
+          "unsupportedNotes": "source does not provide accessibility facility records"
+        }
+      },
+      "topologyAdmissionEvidence": {
+        "issue": 2383,
+        "materializer": "tools/datapack/materialize-gwangju-timetable.mjs",
+        "verificationTest": "tools/datapack/materialize-gwangju-timetable.test.mjs",
+        "snapshotId": "gwangju-transportation-route-topology-20260720",
+        "snapshotPath": "tools/datapack/sources/gwangju-transportation-route-topology-20260720.json",
+        "capturedAt": "2026-07-20T13:08:47.161Z",
+        "freshUntil": "2026-07-21T13:08:47.161Z",
+        "stationCount": 20,
+        "odRowCount": 380,
+        "edgeCount": 38,
+        "rawSha256": "15e4a6835dff21997d29707b0554580560fd770388156b2ac169508cdfd6636a",
+        "scopeSha256": "42d1a6e82b0c4dd0b199f90fe620c38ddb2a9826df334c39a2d0692449324de4",
+        "edgesSha256": "8b0f77bb79db55e6f035e3e713bf9c2ade0b1a7619d495db44cefa1420257d0d",
+        "contentSha256": "d8197488bc6dda94e595f7e350cc65c547117da804fb59b7dff85d18b3192e43"
+      }
+    },
+    {
+      "id": "gwangju-transportation-cyberstation-timetable",
+      "displayName": "광주교통공사 사이버스테이션 열차시각표",
+      "owner": "광주교통공사",
+      "provider": "광주교통공사",
+      "providerDepartment": "IT전략팀",
+      "sourceSystem": "광주교통공사 사이버스테이션",
+      "datasetUrl": "https://www.grtc.co.kr/subway/menu/trainTimetableSubMenu",
+      "datasetKind": "official-web-timetable",
+      "coverage": "광주 1호선 4개 요일 유형 810개 완결 운행과 14171개 stop time",
+      "coverageScope": {
+        "regionIds": ["gwangju"],
+        "operatorIds": ["gwangju-metropolitan-rapid-transit"],
+        "lineIds": ["line-e57a361e8892"],
+        "sourceDomains": ["schedule_timetable"]
+      },
+      "requiredForProductionPack": false,
+      "productionUseAllowed": true,
+      "updateFrequency": "daily admission refresh",
+      "observedDataUpdatedAt": "2026-07-20",
+      "retrievedAt": "2026-07-20",
+      "license": {
+        "type": "PUBLIC_DATA_FREE_USE",
+        "name": "공공데이터포털 이용허락범위 제한 없음",
+        "attribution": "광주교통공사, 공공데이터포털 이용허락범위 제한 없음",
+        "commercialUseAllowed": true,
+        "derivativeWorkAllowed": true,
+        "redistributionAllowed": true,
+        "evidenceUrl": "https://www.data.go.kr/data/15111298/openapi.do"
+      },
+      "fieldsProvided": ["service_calendar", "trip", "stop_time"],
+      "capabilities": {
+        "schedule": {
+          "status": "SUPPORTED",
+          "productionUseAllowed": true,
+          "coverageStatus": "GWANGJU_LINE_1_CURRENT_COMPLETE_TRIPS",
+          "updateFrequency": "daily admission refresh",
+          "unsupportedNotes": "계획 시간표이며 실시간 도착 정보가 아니다"
+        },
+        "realtime": {
+          "status": "UNSUPPORTED",
+          "productionUseAllowed": false,
+          "liveEtaEligible": false,
+          "rateLimitStatus": "NOT_APPLICABLE",
+          "coverageStatus": "NOT_PROVIDED_BY_SOURCE",
+          "updateFrequency": "daily admission refresh",
+          "unsupportedNotes": "source does not provide realtime arrivals"
+        },
+        "facility": {
+          "status": "UNSUPPORTED",
+          "productionUseAllowed": false,
+          "coverageStatus": "NOT_PROVIDED_BY_SOURCE",
+          "updateFrequency": "daily admission refresh",
+          "unsupportedNotes": "source does not provide accessibility facility records"
+        }
+      },
+      "scheduleAdmissionEvidence": {
+        "issue": 2383,
+        "materializer": "tools/datapack/materialize-gwangju-timetable.mjs",
+        "verificationTest": "tools/datapack/materialize-gwangju-timetable.test.mjs",
+        "snapshotId": "gwangju-transportation-cyberstation-timetable-20260720",
+        "snapshotPath": "tools/datapack/sources/gwangju-transportation-cyberstation-timetable-20260720.json",
+        "capturedAt": "2026-07-20T12:55:50.079Z",
+        "freshUntil": "2026-07-21T12:55:50.079Z",
+        "rowCount": 13362,
+        "admittedOfficialRowCount": 13360,
+        "tripCount": 810,
+        "stopTimeCount": 14171,
+        "generatedStopTimeCount": 811,
+        "quarantinedRows": [
+          { "dayCode": "DAYOFF", "direction": "st", "stationCode": "119", "time": "0756" },
+          { "dayCode": "DAYOFF", "direction": "st", "stationCode": "118", "time": "0759" }
+        ],
+        "rowsSha256": "2eec08dc30a97c50fd349dc607e77677829881790b5ca896856caa4b9bbd3ccd",
+        "contentSha256": "b050ed92cbdd555e22e987e4854a7d60b5293951992d6c14ae26c110f9b4fb5a",
+        "topologySourceId": "gwangju-transportation-route-topology",
+        "topologySnapshotId": "gwangju-transportation-route-topology-20260720",
+        "topologyContentSha256": "d8197488bc6dda94e595f7e350cc65c547117da804fb59b7dff85d18b3192e43"
+      }
+    },
+    {
+      "id": "molit-urban-rail-full-route-gwangju-membership",
+      "displayName": "국토교통부_도시철도 전체노선 광주 1호선 membership admission",
+      "owner": "국토교통부",
+      "provider": "국토교통부",
+      "providerDepartment": "도시철도 담당부서",
+      "sourceSystem": "공공데이터포털",
+      "datasetUrl": "https://www.data.go.kr/data/15122916/fileData.do",
+      "datasetKind": "reviewed-admission-slice",
+      "coverage": "국토교통부 역·노선 정본과 광주교통공사 역번호로 검증한 광주 1호선 20개 station membership",
+      "coverageScope": {
+        "regionIds": ["gwangju"],
+        "operatorIds": ["gwangju-metropolitan-rapid-transit"],
+        "lineIds": ["line-e57a361e8892"],
+        "sourceDomains": ["station_line_membership"]
+      },
+      "requiredForProductionPack": false,
+      "productionUseAllowed": true,
+      "updateFrequency": "annual admission review",
+      "observedDataUpdatedAt": "2026-06-22",
+      "retrievedAt": "2026-07-20",
+      "license": {
+        "type": "PUBLIC_DATA_FREE_USE",
+        "name": "공공데이터포털 이용허락범위 제한 없음",
+        "attribution": "국토교통부·광주교통공사, 공공데이터포털 이용허락범위 제한 없음",
+        "commercialUseAllowed": true,
+        "derivativeWorkAllowed": true,
+        "redistributionAllowed": true,
+        "evidenceUrl": "https://www.data.go.kr/data/15122916/fileData.do"
+      },
+      "fieldsProvided": ["line", "station_name"],
+      "capabilities": {
+        "schedule": {
+          "status": "UNSUPPORTED",
+          "productionUseAllowed": false,
+          "coverageStatus": "NOT_PROVIDED_BY_SOURCE",
+          "updateFrequency": "annual admission review",
+          "unsupportedNotes": "source does not provide scheduled timetable data"
+        },
+        "realtime": {
+          "status": "UNSUPPORTED",
+          "productionUseAllowed": false,
+          "liveEtaEligible": false,
+          "rateLimitStatus": "NOT_APPLICABLE",
+          "coverageStatus": "NOT_PROVIDED_BY_SOURCE",
+          "updateFrequency": "annual admission review",
+          "unsupportedNotes": "source does not provide realtime arrivals"
+        },
+        "facility": {
+          "status": "UNSUPPORTED",
+          "productionUseAllowed": false,
+          "coverageStatus": "NOT_PROVIDED_BY_SOURCE",
+          "updateFrequency": "annual admission review",
+          "unsupportedNotes": "source does not provide accessibility facility records"
+        }
+      },
+      "membershipAdmissionEvidence": {
+        "issue": 2383,
+        "materializer": "tools/datapack/materialize-gwangju-timetable.mjs",
+        "verificationTest": "tools/datapack/materialize-gwangju-timetable.test.mjs",
+        "snapshotId": "molit-urban-rail-full-route-gwangju-membership-20260720",
+        "lineIds": ["line-e57a361e8892"],
+        "verifiedAt": "2026-07-20T13:08:47.161Z",
+        "stationCount": 20,
+        "membershipSourceId": "molit-urban-rail-full-route",
+        "membershipSourceRawSha256": "178af75ece72b2f6a58226063e05f1e1f45f50c779c7fbf2905f7df1384a9e22",
+        "membershipSourceSnapshotSha256": "3f08fb398bcb16e8ff047ec17f094a28590ec8d5aa1b8df2d6e9cec85ed0f6e7",
+        "mappingSha256": "f7515bed1908e7b1aff2674f58b8425d94a8177d1fb5bed1f3fb8545cb347a03",
+        "stationCodesSha256": "dc831a8f14fd33808b6e17ecbf829eb6d4c199b6c1d75c7673adaa97ad69df83",
+        "stationCodeSourceId": "gwangju-transportation-route-topology",
+        "stationCodeSnapshotId": "gwangju-transportation-route-topology-20260720",
+        "stationCodeContentSha256": "d8197488bc6dda94e595f7e350cc65c547117da804fb59b7dff85d18b3192e43"
+      }
+    },
+    {
       "id": "kric-disabled-toilet",
       "displayName": "국가철도공단_역사별 장애인 화장실 위치",
       "owner": "국가철도공단",

--- a/apps/mobile/assets/datapacks/source-inventory.json
+++ b/apps/mobile/assets/datapacks/source-inventory.json
@@ -514,7 +514,7 @@
         "regionIds": ["gwangju"],
         "operatorIds": ["gwangju-metropolitan-rapid-transit"],
         "lineIds": ["line-e57a361e8892"],
-        "sourceDomains": ["route_graph_topology", "station_line_membership"]
+        "sourceDomains": ["route_graph_topology"]
       },
       "requiredForProductionPack": false,
       "productionUseAllowed": true,
@@ -565,11 +565,9 @@
         "capturedAt": "2026-07-20T13:08:47.161Z",
         "freshUntil": "2026-07-21T13:08:47.161Z",
         "stationCount": 20,
-        "odRowCount": 380,
         "edgeCount": 38,
+        "excludedTransferCount": 0,
         "rawSha256": "15e4a6835dff21997d29707b0554580560fd770388156b2ac169508cdfd6636a",
-        "scopeSha256": "42d1a6e82b0c4dd0b199f90fe620c38ddb2a9826df334c39a2d0692449324de4",
-        "edgesSha256": "8b0f77bb79db55e6f035e3e713bf9c2ade0b1a7619d495db44cefa1420257d0d",
         "contentSha256": "d8197488bc6dda94e595f7e350cc65c547117da804fb59b7dff85d18b3192e43"
       }
     },
@@ -638,16 +636,11 @@
         "capturedAt": "2026-07-20T12:55:50.079Z",
         "freshUntil": "2026-07-21T12:55:50.079Z",
         "rowCount": 13362,
-        "admittedOfficialRowCount": 13360,
+        "departureCount": 13360,
         "tripCount": 810,
         "stopTimeCount": 14171,
-        "generatedStopTimeCount": 811,
-        "quarantinedRows": [
-          { "dayCode": "DAYOFF", "direction": "st", "stationCode": "119", "time": "0756" },
-          { "dayCode": "DAYOFF", "direction": "st", "stationCode": "118", "time": "0759" }
-        ],
+        "rawSha256": "852b75f79ca7cccf8dfefc65ee4fe226f833e6cd2e52f5e721efdfac2efdc31a",
         "rowsSha256": "2eec08dc30a97c50fd349dc607e77677829881790b5ca896856caa4b9bbd3ccd",
-        "contentSha256": "b050ed92cbdd555e22e987e4854a7d60b5293951992d6c14ae26c110f9b4fb5a",
         "topologySourceId": "gwangju-transportation-route-topology",
         "topologySnapshotId": "gwangju-transportation-route-topology-20260720",
         "topologyContentSha256": "d8197488bc6dda94e595f7e350cc65c547117da804fb59b7dff85d18b3192e43"
@@ -683,7 +676,7 @@
         "redistributionAllowed": true,
         "evidenceUrl": "https://www.data.go.kr/data/15122916/fileData.do"
       },
-      "fieldsProvided": ["line", "station_name"],
+      "fieldsProvided": ["line", "station_name", "station_code"],
       "capabilities": {
         "schedule": {
           "status": "UNSUPPORTED",

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -8805,6 +8805,8 @@ test("운영 데이터팩 공식 출처 inventory는 라이선스와 갱신 기�
     "busan-transportation-urban-rail-station-info",
     "daejeon-station-distance-fare",
     "daejeon-train-timetable",
+    "gwangju-transportation-cyberstation-timetable",
+    "gwangju-transportation-route-topology",
     "kric-disabled-toilet",
     "kric-elevator-car-number",
     "kric-metropolitan-rail-station-info",
@@ -8828,6 +8830,7 @@ test("운영 데이터팩 공식 출처 inventory는 라이선스와 갱신 기�
     "molit-tago-subway-info",
     "molit-urban-rail-full-route",
     "molit-urban-rail-full-route-daejeon-membership",
+    "molit-urban-rail-full-route-gwangju-membership",
     "seoul-metro-accessibility",
     "seoul-metro-fast-exit-car-door",
     "seoul-metro-official-od-fare-canary",
@@ -8857,7 +8860,7 @@ test("운영 데이터팩 공식 출처 inventory는 라이선스와 갱신 기�
     assert.match(source.license.attribution, /공공누리 제1유형|공공데이터포털 이용허락범위 제한 없음/);
     assert.match(
       source.datasetUrl,
-      /^https:\/\/(?:data\.seoul\.go\.kr\/dataList\/OA-[0-9]+\/[AFS]\/1\/datasetView\.do|www\.data\.go\.kr\/data\/[0-9]+\/(?:openapi|fileData)\.do|www\.seoulmetro\.co\.kr\/kr\/cyberStation\.do|data\.kric\.go\.kr\/rips\/M_01_02\/detail\.do\?id=[0-9]+&service=[A-Za-z0-9]+&operation=[A-Za-z0-9]+&page=[0-9]+)$/,
+      /^https:\/\/(?:data\.seoul\.go\.kr\/dataList\/OA-[0-9]+\/[AFS]\/1\/datasetView\.do|www\.data\.go\.kr\/data\/[0-9]+\/(?:openapi|fileData)\.do|www\.seoulmetro\.co\.kr\/kr\/cyberStation\.do|www\.grtc\.co\.kr\/subway\/(?:contents\/apiRunInfo|menu\/trainTimetableSubMenu)|data\.kric\.go\.kr\/rips\/M_01_02\/detail\.do\?id=[0-9]+&service=[A-Za-z0-9]+&operation=[A-Za-z0-9]+&page=[0-9]+)$/,
     );
     assert.match(source.observedDataUpdatedAt, /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/);
     assert.match(source.retrievedAt, /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/);

--- a/tools/datapack/build-molit-nationwide-fixture.mjs
+++ b/tools/datapack/build-molit-nationwide-fixture.mjs
@@ -972,6 +972,33 @@ export function parseMolitDaejeonStationMappings(csvBytes) {
   });
 }
 
+export function parseMolitGwangjuStationMappings(csvBytes) {
+  if (!(csvBytes instanceof Uint8Array) || csvBytes.byteLength === 0) {
+    throw new Error("MOLIT nationwide station CSV bytes are required");
+  }
+  const mappings = parseCsv(new TextDecoder("euc-kr").decode(csvBytes))
+    .map(rowFromCsv)
+    .filter((row) => row?.regionName === "광주"
+      && row.operatorName === "광주교통공사"
+      && row.lineName === "1호선")
+    .sort((left, right) => left.sequence - right.sequence)
+    .map((row) => ({
+      stationId: stationIdFor(row.regionName, row.stationName),
+      stationName: row.stationName,
+      stationNumber: String(99 + row.sequence),
+    }));
+  if (lineIdFor("광주", "1호선") !== "line-e57a361e8892"
+    || mappings.length !== 20
+    || mappings.some((mapping, index) => mapping.stationNumber !== String(100 + index))
+    || new Set(mappings.map(({ stationId }) => stationId)).size !== mappings.length) {
+    throw new Error("MOLIT Gwangju Line 1 mapping must contain 20 unique stations in sequence");
+  }
+  return Object.defineProperty(mappings, "sourceRawSha256", {
+    value: sha256(csvBytes),
+    enumerable: true,
+  });
+}
+
 function svgRowFromCsv(row) {
   if (row.length < 8 || row[0] === "SVG파일명") {
     return null;

--- a/tools/datapack/materialize-gwangju-timetable.mjs
+++ b/tools/datapack/materialize-gwangju-timetable.mjs
@@ -225,15 +225,13 @@ function requiredSources(inventory, timetableSnapshot, topologySnapshot, mapping
     || schedule.verificationTest !== "tools/datapack/materialize-gwangju-timetable.test.mjs"
     || schedule.snapshotId !== "gwangju-transportation-cyberstation-timetable-20260720"
     || schedule.capturedAt !== timetableSnapshot.capturedAt || schedule.freshUntil !== timetableSnapshot.freshUntil
-    || schedule.rowCount !== 13_362 || schedule.admittedOfficialRowCount !== EXPECTED_OFFICIAL_STOP_TIME_COUNT
+    || schedule.rowCount !== 13_362 || schedule.departureCount !== EXPECTED_OFFICIAL_STOP_TIME_COUNT
     || schedule.tripCount !== EXPECTED_TRIP_COUNT || schedule.stopTimeCount !== EXPECTED_STOP_TIME_COUNT
-    || schedule.generatedStopTimeCount !== EXPECTED_GENERATED_STOP_TIME_COUNT
-    || schedule.rowsSha256 !== timetableSnapshot.rowsSha256 || schedule.contentSha256 !== timetableSnapshot.contentSha256
+    || schedule.rawSha256 !== timetableSnapshot.rawSha256
+    || schedule.rowsSha256 !== timetableSnapshot.rowsSha256
     || schedule.topologySourceId !== TOPOLOGY_SOURCE_ID
     || schedule.topologySnapshotId !== topologyEvidence?.snapshotId
-    || schedule.topologyContentSha256 !== topologySnapshot.contentSha256
-    || JSON.stringify(schedule.quarantinedRows?.map((row) => [row.dayCode, row.direction, row.stationCode, row.time].join(":")))
-      !== JSON.stringify(QUARANTINED_KEYS)) {
+    || schedule.topologyContentSha256 !== topologySnapshot.contentSha256) {
     throw new Error(`${SOURCE_ID} inventory evidence does not match snapshot`);
   }
   if (topology?.productionUseAllowed !== true || topology.license?.redistributionAllowed !== true
@@ -243,10 +241,8 @@ function requiredSources(inventory, timetableSnapshot, topologySnapshot, mapping
     || topologyEvidence.snapshotId !== "gwangju-transportation-route-topology-20260720"
     || topologyEvidence.capturedAt !== topologySnapshot.capturedAt
     || topologyEvidence.freshUntil !== topologySnapshot.freshUntil
-    || topologyEvidence.stationCount !== 20 || topologyEvidence.odRowCount !== 380
+    || topologyEvidence.stationCount !== 20 || topologyEvidence.excludedTransferCount !== 0
     || topologyEvidence.edgeCount !== 38 || topologyEvidence.rawSha256 !== topologySnapshot.rawSha256
-    || topologyEvidence.scopeSha256 !== topologySnapshot.scopeSha256
-    || topologyEvidence.edgesSha256 !== topologySnapshot.edgesSha256
     || topologyEvidence.contentSha256 !== topologySnapshot.contentSha256) {
     throw new Error(`${TOPOLOGY_SOURCE_ID} inventory evidence does not match snapshot`);
   }
@@ -324,12 +320,12 @@ function addStationsAndTopology(pack, snapshot, mappings, sources) {
       evidenceHash: membershipEvidence.mappingSha256,
       fieldProvenance: {
         station_code: {
-          sourceId: TOPOLOGY_SOURCE_ID,
-          sourceSnapshotId: topologyEvidence.snapshotId,
+          sourceId: MEMBERSHIP_SOURCE_ID,
+          sourceSnapshotId: membershipEvidence.snapshotId,
           providerRecordHash: sha256(JSON.stringify(scope)),
-          evidenceHash: snapshot.contentSha256,
+          evidenceHash: membershipEvidence.stationCodesSha256,
           derivationKind: "OFFICIAL",
-          verifiedAt: snapshot.capturedAt,
+          verifiedAt: membershipEvidence.verifiedAt,
         },
       },
       derivationKind: "OFFICIAL",

--- a/tools/datapack/materialize-gwangju-timetable.mjs
+++ b/tools/datapack/materialize-gwangju-timetable.mjs
@@ -70,7 +70,7 @@ export function materializeGwangjuTimetable({
   const durations = new Map(topologySnapshot.edges.map((edge) => [
     `${edge.fromStationCode}:${edge.toStationCode}`, edge.durationSeconds,
   ]));
-  const { trips, stopTimes, quarantinedRows, repairedStopCount } = reconstructTrips(
+  const { trips, quarantinedRows, repairedStopCount } = reconstructTrips(
     timetableSnapshot.rows,
     stations,
     durations,
@@ -453,7 +453,7 @@ function reconstructTrips(rows, stations, durations) {
         .map(({ stationId, seconds, repairReason }) => ({ stationId, seconds, repairReason })),
     }));
   }
-  return { trips: completed, stopTimes: completed.flatMap(({ stops }) => stops), quarantinedRows, repairedStopCount };
+  return { trips: completed, quarantinedRows, repairedStopCount };
 }
 
 function uniqueMatch(events, used, trip, expectedDuration) {

--- a/tools/datapack/materialize-gwangju-timetable.mjs
+++ b/tools/datapack/materialize-gwangju-timetable.mjs
@@ -1,0 +1,645 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { parseMolitGwangjuStationMappings } from "./build-molit-nationwide-fixture.mjs";
+
+const SOURCE_ID = "gwangju-transportation-cyberstation-timetable";
+const TOPOLOGY_SOURCE_ID = "gwangju-transportation-route-topology";
+const MEMBERSHIP_SOURCE_ID = "molit-urban-rail-full-route-gwangju-membership";
+const MEMBERSHIP_RAW_SOURCE_ID = "molit-urban-rail-full-route";
+const OPERATOR_ID = "gwangju-metropolitan-rapid-transit";
+const LINE_ID = "line-e57a361e8892";
+const PACK_ID = "nationwide-gwangju-schedule";
+const FRESHNESS_MILLIS = 24 * 60 * 60 * 1_000;
+const STATION_CODES = Object.freeze(Array.from({ length: 20 }, (_, index) => String(100 + index)));
+const EXPECTED_TRIP_COUNT = 810;
+const EXPECTED_OFFICIAL_STOP_TIME_COUNT = 13_360;
+const EXPECTED_GENERATED_STOP_TIME_COUNT = 811;
+const EXPECTED_STOP_TIME_COUNT = 14_171;
+const SERVICES = Object.freeze({
+  WEEK: "gwangju-weekday-2026",
+  SAT: "gwangju-saturday-2026",
+  HOLI: "gwangju-holiday-2026",
+  DAYOFF: "gwangju-sunday-2026",
+});
+const HOLIDAYS_2026 = Object.freeze([
+  "20260101", "20260216", "20260217", "20260218", "20260302", "20260505", "20260525",
+  "20260603", "20260606", "20260815", "20260817", "20260924", "20260925", "20260926",
+  "20261003", "20261005", "20261009", "20261225",
+]);
+const QUARANTINED_KEYS = Object.freeze([
+  "DAYOFF:st:119:0756",
+  "DAYOFF:st:118:0759",
+]);
+
+export function materializeGwangjuTimetable({
+  baseFixture,
+  timetableSnapshot,
+  topologySnapshot,
+  inventory,
+  canonicalStationMappings,
+  now = new Date(),
+}) {
+  validateTimetableSnapshot(timetableSnapshot);
+  validateTopologySnapshot(topologySnapshot);
+  const sources = requiredSources(inventory, timetableSnapshot, topologySnapshot, canonicalStationMappings, now);
+  const fixture = structuredClone(baseFixture);
+  const pack = fixture.packs?.[0];
+  if (!pack || fixture.packs.length !== 1 || pack.artifactKind !== "production") {
+    throw new Error("Gwangju timetable requires one cumulative production pack");
+  }
+  for (const id of [SOURCE_ID, TOPOLOGY_SOURCE_ID, MEMBERSHIP_SOURCE_ID]) {
+    if (pack.sourceInventory.some((source) => source.id === id)) throw new Error(`${id} already exists`);
+  }
+  if (pack.lines.some(({ id }) => id === LINE_ID) || pack.operators.some(({ id }) => id === OPERATOR_ID)) {
+    throw new Error("Gwangju line already exists in base fixture");
+  }
+
+  pack.sourceInventory.push(
+    packSource(sources.membership, sources.membership.membershipAdmissionEvidence.verifiedAt),
+    packSource(sources.topology, topologySnapshot.capturedAt),
+    packSource(sources.timetable, timetableSnapshot.capturedAt),
+  );
+  pack.operators.push({ id: OPERATOR_ID, nameKo: "광주교통공사", nameEn: "" });
+  pack.lines.push({ id: LINE_ID, operatorId: OPERATOR_ID, nameKo: "광주 1호선", nameEn: "", color: "#009088" });
+
+  const stations = addStationsAndTopology(pack, topologySnapshot, canonicalStationMappings, sources);
+  const durations = new Map(topologySnapshot.edges.map((edge) => [
+    `${edge.fromStationCode}:${edge.toStationCode}`, edge.durationSeconds,
+  ]));
+  const { trips, stopTimes, quarantinedRows, repairedStopCount } = reconstructTrips(
+    timetableSnapshot.rows,
+    stations,
+    durations,
+  );
+  if (JSON.stringify(quarantinedRows.map(rowKey)) !== JSON.stringify(QUARANTINED_KEYS)
+    || repairedStopCount !== 1) {
+    throw new Error("Gwangju timetable quarantine tuple mismatch");
+  }
+
+  const scheduleProvenance = provenanceForSchedule(sources.timetable, timetableSnapshot, topologySnapshot);
+  addCalendars(pack, scheduleProvenance);
+  addRoutes(pack, scheduleProvenance);
+  for (const trip of trips) {
+    const tripProvenance = { ...scheduleProvenance, providerRecordHash: trip.providerRecordHash };
+    pack.transitTrips.push(withProvenance({
+      id: trip.id,
+      routeId: `route-gwangju-1-${trip.direction}`,
+      serviceId: SERVICES[trip.dayCode],
+      tripHeadsign: trip.endName.replace(/역$/u, ""),
+      directionId: trip.direction === "pd" ? "increasing" : "decreasing",
+      servicePattern: "LOCAL",
+      serviceClass: "SUBWAY",
+      serviceDayStartSeconds: 0,
+    }, tripProvenance));
+    for (const [index, stop] of trip.stops.entries()) {
+      pack.transitStopTimes.push(withProvenance({
+        tripId: trip.id,
+        stopSequence: index + 1,
+        stationId: stop.stationId,
+        lineId: LINE_ID,
+        arrivalSeconds: stop.seconds,
+        departureSeconds: stop.seconds,
+        pickupType: index === trip.stops.length - 1 ? 1 : 0,
+        dropOffType: index === 0 ? 1 : 0,
+        ...(stop.repairReason ? { repairReason: stop.repairReason } : {}),
+      }, {
+        ...tripProvenance,
+        providerRecordHash: stop.providerRecordHash ?? trip.providerRecordHash,
+      }, stop.derivationKind));
+    }
+  }
+  const producedStopTimes = pack.transitStopTimes.filter(({ sourceId }) => sourceId === SOURCE_ID);
+  if (trips.length !== EXPECTED_TRIP_COUNT || producedStopTimes.length !== EXPECTED_STOP_TIME_COUNT
+    || producedStopTimes.filter(({ derivationKind }) => derivationKind === "OFFICIAL").length
+      !== EXPECTED_OFFICIAL_STOP_TIME_COUNT
+    || producedStopTimes.filter(({ derivationKind }) => derivationKind === "GENERATED").length
+      !== EXPECTED_GENERATED_STOP_TIME_COUNT) {
+    throw new Error("Gwangju timetable materialized row counts are invalid");
+  }
+
+  pack.minimumTableRows = {
+    ...pack.minimumTableRows,
+    stations: pack.stations.length,
+    station_lines: pack.stationLines.length,
+    network_edges: pack.networkEdges.length,
+    service_calendars: pack.serviceCalendars.length,
+    service_calendar_dates: pack.serviceCalendarDates.length,
+    transit_routes: pack.transitRoutes.length,
+    transit_trips: pack.transitTrips.length,
+    transit_stop_times: pack.transitStopTimes.length,
+    transit_feed_info: pack.transitFeedInfo.length,
+  };
+  const version = compactSeoulDate(timetableSnapshot.capturedAt);
+  const composition = sha256(JSON.stringify({
+    previousPackId: pack.id,
+    timetableSnapshotId: sources.timetable.scheduleAdmissionEvidence.snapshotId,
+    topologySnapshotId: sources.topology.topologyAdmissionEvidence.snapshotId,
+    timetableRowsSha256: timetableSnapshot.rowsSha256,
+    topologyContentSha256: topologySnapshot.contentSha256,
+    sourceEvidence: sources,
+    packContentSha256: materializedPackContentHash(pack, version),
+  }));
+  pack.id = `${PACK_ID}-${composition}`;
+  pack.version = version;
+  pack.url = `https://objectstorage.ap-seoul-1.oraclecloud.com/n/axvym6vk8g7i/b/easysubway-datapacks/o/catalog/${pack.id}-v${version}.sqlite.gz`;
+  fixture.manifest.activePack = { id: pack.id, version };
+  return fixture;
+}
+
+export function materializedPackContentHash(pack, version) {
+  const content = { ...pack };
+  delete content.id;
+  delete content.version;
+  delete content.url;
+  return sha256(JSON.stringify({ version, content }));
+}
+
+function validateTimetableSnapshot(snapshot) {
+  const fragments = snapshot?.fragments?.map(({ stationId, rawSha256 }) => ({ stationId, rawSha256 }));
+  if (snapshot?.schemaVersion !== 1 || snapshot.artifactKind !== "gwangju-cyberstation-timetable-snapshot"
+    || snapshot.sourceId !== SOURCE_ID || snapshot.official !== true || snapshot.fixture !== false
+    || snapshot.credentialRedacted !== true || snapshot.requestCount !== 21 || snapshot.stationRequestCount !== 20
+    || snapshot.stationCount !== 20 || snapshot.rowCount !== 13_362 || snapshot.rows?.length !== 13_362
+    || snapshot.excludedPlaceholderCount !== 1 || snapshot.normalizedBoundaryMinuteCount !== 1
+    || JSON.stringify(snapshot.dayCodes) !== JSON.stringify(["DAYOFF", "HOLI", "SAT", "WEEK"])
+    || JSON.stringify(snapshot.directions) !== JSON.stringify(["nd", "pd", "st"])
+    || snapshot.rowsSha256 !== sha256(JSON.stringify(snapshot.rows))
+    || snapshot.scopeSha256 !== sha256(JSON.stringify(snapshot.scope))
+    || snapshot.contentSha256 !== sha256(JSON.stringify({ fragments, rowsSha256: snapshot.rowsSha256 }))) {
+    throw new Error("invalid Gwangju timetable snapshot");
+  }
+  const keys = new Set();
+  for (const row of snapshot.rows) {
+    const key = rowKey(row);
+    if (!SERVICES[row.dayCode] || !new Set(["nd", "pd", "st"]).has(row.direction)
+      || !STATION_CODES.includes(row.stationCode) || !STATION_CODES.includes(row.endCode)
+      || !/^\d{4}$/.test(row.time) || Number(row.time.slice(0, 2)) > 29
+      || Number(row.time.slice(2)) > 59 || keys.has(key)) {
+      throw new Error(`invalid Gwangju timetable row: ${key}`);
+    }
+    keys.add(key);
+  }
+}
+
+function validateTopologySnapshot(snapshot) {
+  if (snapshot?.schemaVersion !== 1 || snapshot.artifactKind !== "gwangju-route-topology-snapshot"
+    || snapshot.sourceId !== TOPOLOGY_SOURCE_ID || snapshot.official !== true || snapshot.fixture !== false
+    || snapshot.credentialRequired !== false || snapshot.credentialRedacted !== true
+    || snapshot.requestCount !== 20 || snapshot.stationCount !== 20 || snapshot.odRowCount !== 380
+    || snapshot.edgeCount !== 38 || snapshot.scope?.length !== 20 || snapshot.edges?.length !== 38
+    || snapshot.scopeSha256 !== sha256(JSON.stringify(snapshot.scope))
+    || snapshot.edgesSha256 !== sha256(JSON.stringify(snapshot.edges))
+    || snapshot.contentSha256 !== sha256(JSON.stringify({ scope: snapshot.scope, edges: snapshot.edges }))) {
+    throw new Error("invalid Gwangju topology snapshot");
+  }
+  const pairs = new Set();
+  for (const edge of snapshot.edges) {
+    const key = `${edge.fromStationCode}:${edge.toStationCode}`;
+    if (!STATION_CODES.includes(edge.fromStationCode) || !STATION_CODES.includes(edge.toStationCode)
+      || Math.abs(Number(edge.fromStationCode) - Number(edge.toStationCode)) !== 1
+      || !Number.isInteger(edge.distanceMeters) || edge.distanceMeters <= 0
+      || !Number.isInteger(edge.durationSeconds) || edge.durationSeconds <= 0 || pairs.has(key)) {
+      throw new Error(`invalid Gwangju topology edge: ${key}`);
+    }
+    pairs.add(key);
+  }
+}
+
+function requiredSources(inventory, timetableSnapshot, topologySnapshot, mappings, now) {
+  const timetable = inventory?.sources?.find(({ id }) => id === SOURCE_ID);
+  const topology = inventory?.sources?.find(({ id }) => id === TOPOLOGY_SOURCE_ID);
+  const membership = inventory?.sources?.find(({ id }) => id === MEMBERSHIP_SOURCE_ID);
+  const rawMembership = inventory?.sources?.find(({ id }) => id === MEMBERSHIP_RAW_SOURCE_ID);
+  const schedule = timetable?.scheduleAdmissionEvidence;
+  const topologyEvidence = topology?.topologyAdmissionEvidence;
+  const membershipEvidence = membership?.membershipAdmissionEvidence;
+  const mappingSha256 = sha256(JSON.stringify(mappings));
+  const stationCodesSha256 = sha256(JSON.stringify(mappings?.map(({ stationNumber }) => stationNumber)));
+  if (timetable?.productionUseAllowed !== true || timetable.license?.redistributionAllowed !== true
+    || timetable.capabilities?.schedule?.productionUseAllowed !== true
+    || schedule?.issue !== 2383 || schedule.materializer !== "tools/datapack/materialize-gwangju-timetable.mjs"
+    || schedule.verificationTest !== "tools/datapack/materialize-gwangju-timetable.test.mjs"
+    || schedule.snapshotId !== "gwangju-transportation-cyberstation-timetable-20260720"
+    || schedule.capturedAt !== timetableSnapshot.capturedAt || schedule.freshUntil !== timetableSnapshot.freshUntil
+    || schedule.rowCount !== 13_362 || schedule.admittedOfficialRowCount !== EXPECTED_OFFICIAL_STOP_TIME_COUNT
+    || schedule.tripCount !== EXPECTED_TRIP_COUNT || schedule.stopTimeCount !== EXPECTED_STOP_TIME_COUNT
+    || schedule.generatedStopTimeCount !== EXPECTED_GENERATED_STOP_TIME_COUNT
+    || schedule.rowsSha256 !== timetableSnapshot.rowsSha256 || schedule.contentSha256 !== timetableSnapshot.contentSha256
+    || schedule.topologySourceId !== TOPOLOGY_SOURCE_ID
+    || schedule.topologySnapshotId !== topologyEvidence?.snapshotId
+    || schedule.topologyContentSha256 !== topologySnapshot.contentSha256
+    || JSON.stringify(schedule.quarantinedRows?.map((row) => [row.dayCode, row.direction, row.stationCode, row.time].join(":")))
+      !== JSON.stringify(QUARANTINED_KEYS)) {
+    throw new Error(`${SOURCE_ID} inventory evidence does not match snapshot`);
+  }
+  if (topology?.productionUseAllowed !== true || topology.license?.redistributionAllowed !== true
+    || topologyEvidence?.issue !== 2383
+    || topologyEvidence.materializer !== "tools/datapack/materialize-gwangju-timetable.mjs"
+    || topologyEvidence.verificationTest !== "tools/datapack/materialize-gwangju-timetable.test.mjs"
+    || topologyEvidence.snapshotId !== "gwangju-transportation-route-topology-20260720"
+    || topologyEvidence.capturedAt !== topologySnapshot.capturedAt
+    || topologyEvidence.freshUntil !== topologySnapshot.freshUntil
+    || topologyEvidence.stationCount !== 20 || topologyEvidence.odRowCount !== 380
+    || topologyEvidence.edgeCount !== 38 || topologyEvidence.rawSha256 !== topologySnapshot.rawSha256
+    || topologyEvidence.scopeSha256 !== topologySnapshot.scopeSha256
+    || topologyEvidence.edgesSha256 !== topologySnapshot.edgesSha256
+    || topologyEvidence.contentSha256 !== topologySnapshot.contentSha256) {
+    throw new Error(`${TOPOLOGY_SOURCE_ID} inventory evidence does not match snapshot`);
+  }
+  if (!Array.isArray(mappings) || mappings.length !== 20
+    || mappings.some((mapping, index) => mapping.stationNumber !== STATION_CODES[index])
+    || membership?.productionUseAllowed !== true || membership.license?.redistributionAllowed !== true
+    || rawMembership?.admissionEvidence?.decision !== "APPROVED"
+    || membershipEvidence?.issue !== 2383
+    || membershipEvidence.materializer !== "tools/datapack/materialize-gwangju-timetable.mjs"
+    || membershipEvidence.verificationTest !== "tools/datapack/materialize-gwangju-timetable.test.mjs"
+    || membershipEvidence.stationCount !== 20 || membershipEvidence.mappingSha256 !== mappingSha256
+    || membershipEvidence.stationCodesSha256 !== stationCodesSha256
+    || membershipEvidence.membershipSourceId !== MEMBERSHIP_RAW_SOURCE_ID
+    || membershipEvidence.membershipSourceRawSha256 !== rawMembership.admissionEvidence.rawSha256
+    || membershipEvidence.membershipSourceSnapshotSha256 !== mappings.sourceRawSha256
+    || membershipEvidence.stationCodeSourceId !== TOPOLOGY_SOURCE_ID
+    || membershipEvidence.stationCodeSnapshotId !== topologyEvidence.snapshotId
+    || membershipEvidence.stationCodeContentSha256 !== topologySnapshot.contentSha256) {
+    throw new Error(`${MEMBERSHIP_SOURCE_ID} membership evidence is invalid`);
+  }
+  for (const [label, capturedAt, freshUntil] of [
+    [SOURCE_ID, schedule.capturedAt, schedule.freshUntil],
+    [TOPOLOGY_SOURCE_ID, topologyEvidence.capturedAt, topologyEvidence.freshUntil],
+  ]) {
+    const captured = Date.parse(capturedAt);
+    const fresh = Date.parse(freshUntil);
+    const current = now instanceof Date ? now.getTime() : Number.NaN;
+    if (!Number.isFinite(captured) || fresh !== captured + FRESHNESS_MILLIS
+      || !Number.isFinite(current) || current < captured || current >= fresh) {
+      throw new Error(`${label} evidence is stale or future-dated`);
+    }
+  }
+  return { timetable, topology, membership };
+}
+
+function addStationsAndTopology(pack, snapshot, mappings, sources) {
+  const scopeByCode = new Map(snapshot.scope.map((row) => [row.stationCode, row]));
+  const stations = new Map();
+  const membershipEvidence = sources.membership.membershipAdmissionEvidence;
+  const topologyEvidence = sources.topology.topologyAdmissionEvidence;
+  for (const [index, mapping] of mappings.entries()) {
+    const scope = scopeByCode.get(mapping.stationNumber);
+    if (!scope || normalizedName(mapping.stationName) !== normalizedName(scope.stationName)) {
+      throw new Error(`Gwangju canonical station mapping mismatch: ${mapping.stationNumber}`);
+    }
+    const membershipHash = sha256(JSON.stringify({
+      lineId: LINE_ID, stationName: mapping.stationName, stationSequence: index + 1,
+    }));
+    pack.stations.push({
+      id: mapping.stationId,
+      nameKo: mapping.stationName,
+      nameEn: "",
+      normalizedName: mapping.stationName.normalize("NFKC"),
+      region: "광주권",
+      latitude: null,
+      longitude: null,
+      dataQualityLevel: "LEVEL_2",
+      dataSourceType: "OFFICIAL_FILE",
+      sourceId: MEMBERSHIP_SOURCE_ID,
+      sourceSnapshotId: membershipEvidence.snapshotId,
+      providerRecordHash: membershipHash,
+      evidenceHash: membershipEvidence.mappingSha256,
+      derivationKind: "OFFICIAL",
+      lastVerifiedAt: membershipEvidence.verifiedAt,
+    });
+    pack.stationLines.push({
+      stationId: mapping.stationId,
+      lineId: LINE_ID,
+      stationCode: mapping.stationNumber,
+      lineSequence: index + 1,
+      platformInfo: "",
+      sourceId: MEMBERSHIP_SOURCE_ID,
+      sourceSnapshotId: membershipEvidence.snapshotId,
+      providerRecordHash: membershipHash,
+      evidenceHash: membershipEvidence.mappingSha256,
+      fieldProvenance: {
+        station_code: {
+          sourceId: TOPOLOGY_SOURCE_ID,
+          sourceSnapshotId: topologyEvidence.snapshotId,
+          providerRecordHash: sha256(JSON.stringify(scope)),
+          evidenceHash: snapshot.contentSha256,
+          derivationKind: "OFFICIAL",
+          verifiedAt: snapshot.capturedAt,
+        },
+      },
+      derivationKind: "OFFICIAL",
+      lastVerifiedAt: membershipEvidence.verifiedAt,
+    });
+    stations.set(mapping.stationNumber, mapping);
+  }
+  for (const edge of snapshot.edges) {
+    const from = stations.get(edge.fromStationCode);
+    const to = stations.get(edge.toStationCode);
+    pack.networkEdges.push({
+      id: `edge-gwangju-${edge.fromStationCode}-${edge.toStationCode}`,
+      fromNodeId: `${from.stationId}:${LINE_ID}`,
+      toNodeId: `${to.stationId}:${LINE_ID}`,
+      durationSeconds: edge.durationSeconds,
+      distanceMeters: edge.distanceMeters,
+      edgeType: "RIDE",
+      servicePattern: "LOCAL",
+      serviceClass: "SUBWAY",
+      includesStairs: false,
+      stairAccessState: "UNKNOWN",
+      accessibilityStatus: "UNKNOWN",
+      reliabilityScore: 100,
+      sourceId: TOPOLOGY_SOURCE_ID,
+      sourceSnapshotId: topologyEvidence.snapshotId,
+      providerRecordHash: sha256(JSON.stringify(edge)),
+      provenanceKind: "OFFICIAL_SOURCE",
+      derivationKind: "OFFICIAL",
+      verificationStatus: "VERIFIED",
+      lastVerifiedAt: snapshot.capturedAt,
+      evidenceHash: snapshot.contentSha256,
+    });
+  }
+  return stations;
+}
+
+function reconstructTrips(rows, stations, durations) {
+  const byScope = Map.groupBy(rows, (row) => `${row.dayCode}:${row.direction}:${row.stationCode}`);
+  const completed = [];
+  const quarantinedRows = [];
+  let repairedStopCount = 0;
+  for (const dayCode of ["WEEK", "SAT", "HOLI", "DAYOFF"]) {
+    for (const direction of ["pd", "st", "nd"]) {
+      const codes = direction === "pd" ? STATION_CODES : [...STATION_CODES].reverse();
+      let active = [];
+      for (const [stationIndex, stationCode] of codes.entries()) {
+        const events = [...(byScope.get(`${dayCode}:${direction}:${stationCode}`) ?? [])]
+          .map((row) => ({ row, seconds: serviceSeconds(row.time) }))
+          .sort((left, right) => left.seconds - right.seconds);
+        if (stationIndex === 0) {
+          active = events.map((event) => newTrip(event, stations));
+          continue;
+        }
+        const used = new Set();
+        const nextActive = [];
+        for (const trip of active) {
+          const previous = trip.officialStops.at(-1);
+          if (previous.row.endCode === stationCode) {
+            const duration = requiredDuration(durations, previous.row.stationCode, stationCode);
+            trip.stops.push(generatedStop(stations.get(stationCode), previous.seconds + duration, "OFFICIAL_TOPOLOGY_TERMINAL"));
+            completed.push(trip);
+            continue;
+          }
+          if (trip.pendingGap) {
+            const firstDuration = requiredDuration(durations, previous.row.stationCode, trip.pendingGap);
+            const secondDuration = requiredDuration(durations, trip.pendingGap, stationCode);
+            const match = uniqueMatch(events, used, trip, firstDuration + secondDuration);
+            if (!match) {
+              quarantinedRows.push(...trip.officialStops.map(({ row }) => row));
+              continue;
+            }
+            const missingSeconds = previous.seconds + firstDuration;
+            trip.stops.push(generatedStop(
+              stations.get(trip.pendingGap),
+              missingSeconds,
+              "OFFICIAL_ADJACENT_TIMES_AND_TOPOLOGY",
+            ));
+            repairedStopCount += 1;
+            appendOfficialStop(trip, match, stations);
+            used.add(match.index);
+            trip.pendingGap = null;
+            nextActive.push(trip);
+            continue;
+          }
+          const duration = requiredDuration(durations, previous.row.stationCode, stationCode);
+          const match = uniqueMatch(events, used, trip, duration);
+          if (match) {
+            appendOfficialStop(trip, match, stations);
+            used.add(match.index);
+          } else {
+            trip.pendingGap = stationCode;
+          }
+          nextActive.push(trip);
+        }
+        for (const [index, event] of events.entries()) {
+          if (!used.has(index)) nextActive.push(newTrip(event, stations));
+        }
+        active = nextActive.sort((left, right) =>
+          left.officialStops.at(-1).seconds - right.officialStops.at(-1).seconds);
+      }
+      if (active.length !== 0) {
+        quarantinedRows.push(...active.flatMap((trip) => trip.officialStops.map(({ row }) => row)));
+      }
+    }
+  }
+  quarantinedRows.sort((left, right) => QUARANTINED_KEYS.indexOf(rowKey(left)) - QUARANTINED_KEYS.indexOf(rowKey(right)));
+  const accounted = completed.reduce((total, trip) => total + trip.officialStops.length, 0) + quarantinedRows.length;
+  if (accounted !== rows.length || quarantinedRows.length !== 2 || completed.length !== EXPECTED_TRIP_COUNT) {
+    throw new Error(`Gwangju timetable reconstruction incomplete: accounted=${accounted} trips=${completed.length}`);
+  }
+  completed.sort((left, right) => [left.dayCode, left.direction, left.originCode, left.originSeconds].join(":")
+    .localeCompare([right.dayCode, right.direction, right.originCode, right.originSeconds].join(":"), "en"));
+  const ids = new Set();
+  for (const trip of completed) {
+    trip.id = `trip-gwangju-${trip.dayCode.toLowerCase()}-${trip.direction}-${trip.originCode}-${serviceTime(trip.originSeconds)}`;
+    if (ids.has(trip.id)) throw new Error(`duplicate Gwangju trip id: ${trip.id}`);
+    ids.add(trip.id);
+    trip.providerRecordHash = sha256(JSON.stringify({
+      rows: trip.officialStops.map(({ row }) => row),
+      generatedStops: trip.stops.filter(({ derivationKind }) => derivationKind === "GENERATED")
+        .map(({ stationId, seconds, repairReason }) => ({ stationId, seconds, repairReason })),
+    }));
+  }
+  return { trips: completed, stopTimes: completed.flatMap(({ stops }) => stops), quarantinedRows, repairedStopCount };
+}
+
+function uniqueMatch(events, used, trip, expectedDuration) {
+  const previous = trip.officialStops.at(-1);
+  const eligible = events.map((event, index) => ({ ...event, index,
+    deviation: Math.abs(event.seconds - previous.seconds - expectedDuration) }))
+    .filter((event) => !used.has(event.index) && event.row.endCode === previous.row.endCode
+      && event.seconds >= previous.seconds && event.deviation <= 120);
+  if (eligible.length === 0) return null;
+  const bestDeviation = Math.min(...eligible.map(({ deviation }) => deviation));
+  const best = eligible.filter(({ deviation }) => deviation === bestDeviation);
+  if (best.length !== 1) {
+    throw new Error(`Gwangju timetable adjacent match is ambiguous: ${rowKey(previous.row)}`);
+  }
+  return best[0];
+}
+
+function newTrip(event, stations) {
+  const stop = officialStop(event, stations);
+  return {
+    dayCode: event.row.dayCode,
+    direction: event.row.direction,
+    endName: event.row.endName,
+    originCode: event.row.stationCode,
+    originSeconds: event.seconds,
+    officialStops: [event],
+    stops: [stop],
+    pendingGap: null,
+  };
+}
+
+function appendOfficialStop(trip, event, stations) {
+  trip.officialStops.push({ row: event.row, seconds: event.seconds });
+  trip.stops.push(officialStop(event, stations));
+}
+
+function officialStop(event, stations) {
+  return {
+    stationId: stations.get(event.row.stationCode).stationId,
+    seconds: event.seconds,
+    derivationKind: "OFFICIAL",
+    providerRecordHash: sha256(JSON.stringify(event.row)),
+  };
+}
+
+function generatedStop(station, seconds, repairReason) {
+  return { stationId: station.stationId, seconds, derivationKind: "GENERATED", repairReason };
+}
+
+function requiredDuration(durations, from, to) {
+  const duration = durations.get(`${from}:${to}`);
+  if (!Number.isInteger(duration) || duration <= 0) {
+    throw new Error(`Gwangju topology duration missing: ${from}:${to}`);
+  }
+  return duration;
+}
+
+function addCalendars(pack, provenance) {
+  pack.serviceCalendars.push(
+    withProvenance({ serviceId: SERVICES.WEEK, monday: true, tuesday: true, wednesday: true,
+      thursday: true, friday: true, saturday: false, sunday: false,
+      startDate: "20260101", endDate: "20261231" }, provenance),
+    withProvenance({ serviceId: SERVICES.SAT, monday: false, tuesday: false, wednesday: false,
+      thursday: false, friday: false, saturday: true, sunday: false,
+      startDate: "20260101", endDate: "20261231" }, provenance),
+    withProvenance({ serviceId: SERVICES.HOLI, monday: false, tuesday: false, wednesday: false,
+      thursday: false, friday: false, saturday: false, sunday: false,
+      startDate: "20260101", endDate: "20261231" }, provenance),
+    withProvenance({ serviceId: SERVICES.DAYOFF, monday: false, tuesday: false, wednesday: false,
+      thursday: false, friday: false, saturday: false, sunday: true,
+      startDate: "20260101", endDate: "20261231" }, provenance),
+  );
+  pack.serviceCalendarDates.push(...HOLIDAYS_2026.flatMap((date) => {
+    const day = new Date(`${date.slice(0, 4)}-${date.slice(4, 6)}-${date.slice(6)}T00:00:00Z`).getUTCDay();
+    const base = day === 0 ? SERVICES.DAYOFF : day === 6 ? SERVICES.SAT : SERVICES.WEEK;
+    return [
+      withProvenance({ serviceId: SERVICES.HOLI, date, exceptionType: 1 }, provenance, "GENERATED"),
+      withProvenance({ serviceId: base, date, exceptionType: 2 }, provenance, "GENERATED"),
+    ];
+  }));
+}
+
+function addRoutes(pack, provenance) {
+  for (const [direction, endName] of [["pd", "평동"], ["st", "소태"], ["nd", "녹동"]]) {
+    pack.transitRoutes.push(withProvenance({
+      id: `route-gwangju-1-${direction}`,
+      lineId: LINE_ID,
+      routeShortName: "1",
+      routeLongName: `광주 1호선 ${endName} 방면`,
+      directionName: `${endName} 방면`,
+    }, provenance));
+  }
+}
+
+function provenanceForSchedule(source, timetableSnapshot, topologySnapshot) {
+  return {
+    sourceId: SOURCE_ID,
+    sourceSnapshotId: source.scheduleAdmissionEvidence.snapshotId,
+    providerRecordHash: timetableSnapshot.rowsSha256,
+    evidenceHash: sha256(JSON.stringify({
+      timetableContentSha256: timetableSnapshot.contentSha256,
+      topologyContentSha256: topologySnapshot.contentSha256,
+    })),
+    updatedAt: timetableSnapshot.capturedAt,
+  };
+}
+
+function withProvenance(row, provenance, derivationKind = "OFFICIAL") {
+  return {
+    ...row,
+    sourceId: provenance.sourceId,
+    sourceSnapshotId: provenance.sourceSnapshotId,
+    providerRecordHash: provenance.providerRecordHash,
+    evidenceHash: provenance.evidenceHash,
+    provenanceKind: "OFFICIAL_SOURCE",
+    derivationKind,
+    updatedAt: provenance.updatedAt,
+  };
+}
+
+function packSource(source, updatedAt) {
+  return {
+    id: source.id,
+    owner: source.owner,
+    url: source.datasetUrl,
+    license: source.license.name,
+    licenseStatus: "redistributable",
+    redistributionAllowed: true,
+    updateFrequency: source.updateFrequency,
+    updatedAt,
+    fields: [...source.fieldsProvided],
+    coverageScope: structuredClone(source.coverageScope),
+  };
+}
+
+function normalizedName(value) {
+  return String(value).normalize("NFKC").replace(/\([^)]*\)/g, "").replace(/[\s/.·]/g, "").replace(/역$/u, "");
+}
+function rowKey(row) { return [row.dayCode, row.direction, row.stationCode, row.time].join(":"); }
+function serviceSeconds(time) { return Number(time.slice(0, 2)) * 3_600 + Number(time.slice(2)) * 60; }
+function serviceTime(seconds) {
+  return `${String(Math.floor(seconds / 3_600)).padStart(2, "0")}${String(Math.floor((seconds % 3_600) / 60)).padStart(2, "0")}`;
+}
+function compactSeoulDate(value) {
+  const parts = Object.fromEntries(new Intl.DateTimeFormat("en", {
+    timeZone: "Asia/Seoul", year: "numeric", month: "2-digit", day: "2-digit",
+  }).formatToParts(new Date(value)).map(({ type, value: part }) => [type, part]));
+  return `${parts.year}${parts.month}${parts.day}`;
+}
+function sha256(value) { return createHash("sha256").update(value).digest("hex"); }
+
+function parseArgs(argv) {
+  const expected = ["--base-fixture", "--timetable-snapshot", "--topology-snapshot", "--inventory", "--station-map", "--output"];
+  if (argv.length !== expected.length * 2 || expected.some((flag, index) => argv[index * 2] !== flag)
+    || !path.isAbsolute(argv.at(-1))) {
+    throw new Error("usage: materialize-gwangju-timetable.mjs --base-fixture <json> --timetable-snapshot <json> --topology-snapshot <json> --inventory <json> --station-map <csv> --output <absolute.json>");
+  }
+  return Object.fromEntries(expected.map((flag, index) => [flag.slice(2), argv[index * 2 + 1]]));
+}
+
+export async function runGwangjuTimetableMaterializer(argv, { now = new Date() } = {}) {
+  const args = parseArgs(argv);
+  const [baseFixture, timetableSnapshot, topologySnapshot, inventory, stationMap] = await Promise.all([
+    readFile(args["base-fixture"], "utf8").then(JSON.parse),
+    readFile(args["timetable-snapshot"], "utf8").then(JSON.parse),
+    readFile(args["topology-snapshot"], "utf8").then(JSON.parse),
+    readFile(args.inventory, "utf8").then(JSON.parse),
+    readFile(args["station-map"]),
+  ]);
+  const fixture = materializeGwangjuTimetable({
+    baseFixture,
+    timetableSnapshot,
+    topologySnapshot,
+    inventory,
+    canonicalStationMappings: parseMolitGwangjuStationMappings(stationMap),
+    now,
+  });
+  await writeFile(args.output, `${JSON.stringify(fixture, null, 2)}\n`);
+  console.log(`Gwangju timetable materialized: trips=${EXPECTED_TRIP_COUNT} stopTimes=${EXPECTED_STOP_TIME_COUNT}`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  try {
+    await runGwangjuTimetableMaterializer(process.argv.slice(2));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : "Gwangju timetable materialization failed");
+    process.exitCode = 1;
+  }
+}

--- a/tools/datapack/materialize-gwangju-timetable.mjs
+++ b/tools/datapack/materialize-gwangju-timetable.mjs
@@ -26,9 +26,9 @@ const SERVICES = Object.freeze({
   DAYOFF: "gwangju-sunday-2026",
 });
 const HOLIDAYS_2026 = Object.freeze([
-  "20260101", "20260216", "20260217", "20260218", "20260302", "20260505", "20260525",
-  "20260603", "20260606", "20260815", "20260817", "20260924", "20260925", "20260926",
-  "20261003", "20261005", "20261009", "20261225",
+  "20260101", "20260216", "20260217", "20260218", "20260301", "20260302", "20260501",
+  "20260505", "20260524", "20260525", "20260603", "20260606", "20260717", "20260815",
+  "20260817", "20260924", "20260925", "20260926", "20261003", "20261005", "20261009", "20261225",
 ]);
 const QUARANTINED_KEYS = Object.freeze([
   "DAYOFF:st:119:0756",
@@ -243,7 +243,8 @@ function requiredSources(inventory, timetableSnapshot, topologySnapshot, mapping
     || topologyEvidence.freshUntil !== topologySnapshot.freshUntil
     || topologyEvidence.stationCount !== 20 || topologyEvidence.excludedTransferCount !== 0
     || topologyEvidence.edgeCount !== 38 || topologyEvidence.rawSha256 !== topologySnapshot.rawSha256
-    || topologyEvidence.contentSha256 !== topologySnapshot.contentSha256) {
+    || topologyEvidence.contentSha256 !== topologySnapshot.contentSha256
+    || JSON.stringify(topology.membershipAdmissionEvidence) !== JSON.stringify(membershipEvidence)) {
     throw new Error(`${TOPOLOGY_SOURCE_ID} inventory evidence does not match snapshot`);
   }
   if (!Array.isArray(mappings) || mappings.length !== 20
@@ -320,12 +321,12 @@ function addStationsAndTopology(pack, snapshot, mappings, sources) {
       evidenceHash: membershipEvidence.mappingSha256,
       fieldProvenance: {
         station_code: {
-          sourceId: MEMBERSHIP_SOURCE_ID,
-          sourceSnapshotId: membershipEvidence.snapshotId,
+          sourceId: TOPOLOGY_SOURCE_ID,
+          sourceSnapshotId: topologyEvidence.snapshotId,
           providerRecordHash: sha256(JSON.stringify(scope)),
-          evidenceHash: membershipEvidence.stationCodesSha256,
+          evidenceHash: snapshot.contentSha256,
           derivationKind: "OFFICIAL",
-          verifiedAt: membershipEvidence.verifiedAt,
+          verifiedAt: snapshot.capturedAt,
         },
       },
       derivationKind: "OFFICIAL",

--- a/tools/datapack/materialize-gwangju-timetable.test.mjs
+++ b/tools/datapack/materialize-gwangju-timetable.test.mjs
@@ -59,14 +59,17 @@ test("광주 공식 topology·시간표를 20역·38 edge·810 trip·14171 stop_
   assert.ok(edges.every(({ sourceSnapshotId, evidenceHash }) =>
     sourceSnapshotId === "gwangju-transportation-route-topology-20260720"
       && evidenceHash === values.gwangjuTopology.contentSha256));
+  assert.ok(pack.stationLines.filter(({ lineId }) => lineId === "line-e57a361e8892")
+    .every(({ fieldProvenance }) =>
+      fieldProvenance.station_code.sourceId === "molit-urban-rail-full-route-gwangju-membership"));
 });
 
 test("광주 materializer는 완결되지 않은 일요일 0756 열차 2행만 exact tuple로 격리한다", async () => {
   const values = await inputs({ materialize: false });
-  const inventorySource = values.inventory.sources.find(
-    ({ id }) => id === "gwangju-transportation-cyberstation-timetable",
-  );
-  assert.deepEqual(inventorySource.scheduleAdmissionEvidence.quarantinedRows, [
+  assert.deepEqual(values.gwangjuTimetable.rows.filter(({ dayCode, direction, stationCode, time }) =>
+    dayCode === "DAYOFF" && direction === "st"
+      && ((stationCode === "119" && time === "0756") || (stationCode === "118" && time === "0759")))
+    .map(({ dayCode, direction, stationCode, time }) => ({ dayCode, direction, stationCode, time })), [
     { dayCode: "DAYOFF", direction: "st", stationCode: "119", time: "0756" },
     { dayCode: "DAYOFF", direction: "st", stationCode: "118", time: "0759" },
   ]);

--- a/tools/datapack/materialize-gwangju-timetable.test.mjs
+++ b/tools/datapack/materialize-gwangju-timetable.test.mjs
@@ -1,0 +1,276 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { createHash, generateKeyPairSync } from "node:crypto";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import test from "node:test";
+import { promisify } from "node:util";
+
+import {
+  parseMolitDaejeonStationMappings,
+  parseMolitGwangjuStationMappings,
+} from "./build-molit-nationwide-fixture.mjs";
+import { materializeBusanRouteMapPositions } from "./materialize-busan-route-map-positions.mjs";
+import { materializeBusanRouteTopology, parseCanonicalBusanStationMappings } from "./materialize-busan-route-topology.mjs";
+import { materializeBusanTimetable } from "./materialize-busan-timetable.mjs";
+import { materializeDaejeonTimetable } from "./materialize-daejeon-timetable.mjs";
+import {
+  materializeGwangjuTimetable,
+  runGwangjuTimetableMaterializer,
+} from "./materialize-gwangju-timetable.mjs";
+
+const root = path.resolve(import.meta.dirname, "../..");
+const now = new Date("2026-07-20T13:09:00.000Z");
+const execFileAsync = promisify(execFile);
+
+test("광주 공식 topology·시간표를 20역·38 edge·810 trip·14171 stop_time으로 materialize한다", async () => {
+  const values = await inputs();
+  const pack = values.fixture.packs[0];
+  const timetableSourceId = "gwangju-transportation-cyberstation-timetable";
+  const topologySourceId = "gwangju-transportation-route-topology";
+  const trips = pack.transitTrips.filter(({ sourceId }) => sourceId === timetableSourceId);
+  const stopTimes = pack.transitStopTimes.filter(({ sourceId }) => sourceId === timetableSourceId);
+  const calendars = pack.serviceCalendars.filter(({ sourceId }) => sourceId === timetableSourceId);
+  const edges = pack.networkEdges.filter(({ sourceId }) => sourceId === topologySourceId);
+
+  assert.match(pack.id, /^nationwide-gwangju-schedule-[a-f0-9]{64}$/);
+  assert.deepEqual(values.fixture.manifest.activePack, { id: pack.id, version: "20260720" });
+  assert.equal(pack.stationLines.filter(({ lineId }) => lineId === "line-e57a361e8892").length, 20);
+  assert.equal(edges.length, 38);
+  assert.equal(calendars.length, 4);
+  assert.equal(trips.length, 810);
+  assert.equal(stopTimes.length, 14_171);
+  assert.equal(stopTimes.filter(({ derivationKind }) => derivationKind === "OFFICIAL").length, 13_360);
+  assert.equal(stopTimes.filter(({ derivationKind }) => derivationKind === "GENERATED").length, 811);
+  assert.deepEqual(Object.fromEntries(calendars.map(({ serviceId }) => [serviceId,
+    trips.filter((trip) => trip.serviceId === serviceId).length])), {
+    "gwangju-weekday-2026": 240,
+    "gwangju-saturday-2026": 206,
+    "gwangju-holiday-2026": 162,
+    "gwangju-sunday-2026": 202,
+  });
+  const repaired = stopTimes.filter(({ repairReason }) => repairReason === "OFFICIAL_ADJACENT_TIMES_AND_TOPOLOGY");
+  assert.equal(repaired.length, 1);
+  assert.equal(repaired[0].arrivalSeconds, 75_570);
+  assert.equal(repaired[0].stationId,
+    values.gwangjuMappings.find(({ stationNumber }) => stationNumber === "105").stationId);
+  assert.ok(edges.every(({ sourceSnapshotId, evidenceHash }) =>
+    sourceSnapshotId === "gwangju-transportation-route-topology-20260720"
+      && evidenceHash === values.gwangjuTopology.contentSha256));
+});
+
+test("광주 materializer는 완결되지 않은 일요일 0756 열차 2행만 exact tuple로 격리한다", async () => {
+  const values = await inputs({ materialize: false });
+  const inventorySource = values.inventory.sources.find(
+    ({ id }) => id === "gwangju-transportation-cyberstation-timetable",
+  );
+  assert.deepEqual(inventorySource.scheduleAdmissionEvidence.quarantinedRows, [
+    { dayCode: "DAYOFF", direction: "st", stationCode: "119", time: "0756" },
+    { dayCode: "DAYOFF", direction: "st", stationCode: "118", time: "0759" },
+  ]);
+
+  const mutated = structuredClone(values.gwangjuTimetable);
+  mutated.rows.find((row) => row.dayCode === "DAYOFF" && row.direction === "st"
+    && row.stationCode === "118" && row.time === "0759").time = "0800";
+  mutated.rowsSha256 = createHash("sha256").update(JSON.stringify(mutated.rows)).digest("hex");
+  mutated.contentSha256 = createHash("sha256").update(JSON.stringify({
+    fragments: mutated.fragments.map(({ stationId, rawSha256 }) => ({ stationId, rawSha256 })),
+    rowsSha256: mutated.rowsSha256,
+  })).digest("hex");
+  const inventory = structuredClone(values.inventory);
+  const evidence = inventory.sources.find(({ id }) => id === "gwangju-transportation-cyberstation-timetable")
+    .scheduleAdmissionEvidence;
+  evidence.rowsSha256 = mutated.rowsSha256;
+  evidence.contentSha256 = mutated.contentSha256;
+  assert.throws(() => materializeGwangjuTimetable({
+    baseFixture: values.baseFixture,
+    timetableSnapshot: mutated,
+    topologySnapshot: values.gwangjuTopology,
+    inventory,
+    canonicalStationMappings: values.gwangjuMappings,
+    now,
+  }), /quarantine tuple/);
+});
+
+test("광주 materializer는 snapshot·inventory·freshness·topology lineage 변조를 fail closed한다", async () => {
+  const values = await inputs({ materialize: false });
+  const badTopology = structuredClone(values.gwangjuTopology);
+  badTopology.edges[0].durationSeconds += 60;
+  assert.throws(() => materializeGwangjuTimetable({
+    baseFixture: values.baseFixture,
+    timetableSnapshot: values.gwangjuTimetable,
+    topologySnapshot: badTopology,
+    inventory: values.inventory,
+    canonicalStationMappings: values.gwangjuMappings,
+    now,
+  }), /topology snapshot/);
+  assert.throws(() => materializeGwangjuTimetable({
+    baseFixture: values.baseFixture,
+    timetableSnapshot: values.gwangjuTimetable,
+    topologySnapshot: values.gwangjuTopology,
+    inventory: values.inventory,
+    canonicalStationMappings: values.gwangjuMappings,
+    now: new Date("2026-07-21T13:08:47.161Z"),
+  }), /stale/);
+});
+
+test("MOLIT 광주 station mapping과 materializer CLI를 고정한다", async () => {
+  const values = await inputs({ materialize: false });
+  assert.equal(values.gwangjuMappings.length, 20);
+  assert.deepEqual(values.gwangjuMappings.slice(0, 2).map(({ stationName, stationNumber }) =>
+    ({ stationName, stationNumber })), [
+    { stationName: "녹동", stationNumber: "100" },
+    { stationName: "소태", stationNumber: "101" },
+  ]);
+  const directory = await mkdtemp(path.join(tmpdir(), "easysubway-gwangju-pack-"));
+  try {
+    const baseFixturePath = path.join(directory, "base.json");
+    const inventoryPath = path.join(directory, "inventory.json");
+    const outputPath = path.join(directory, "output.json");
+    await Promise.all([
+      writeFile(baseFixturePath, JSON.stringify(values.baseFixture)),
+      writeFile(inventoryPath, JSON.stringify(values.inventory)),
+    ]);
+    await runGwangjuTimetableMaterializer([
+      "--base-fixture", baseFixturePath,
+      "--timetable-snapshot", path.join(root, "tools/datapack/sources/gwangju-transportation-cyberstation-timetable-20260720.json"),
+      "--topology-snapshot", path.join(root, "tools/datapack/sources/gwangju-transportation-route-topology-20260720.json"),
+      "--inventory", inventoryPath,
+      "--station-map", path.join(root, "tools/datapack/sources/molit-urban-rail-full-route-20251211.csv"),
+      "--output", outputPath,
+    ], { now });
+    const fixture = JSON.parse(await readFile(outputPath, "utf8"));
+    assert.equal(fixture.packs[0].transitTrips.filter(({ sourceId }) =>
+      sourceId === "gwangju-transportation-cyberstation-timetable").length, 810);
+    await assert.rejects(execFileAsync(process.execPath, [
+      path.join(root, "tools/datapack/materialize-gwangju-timetable.mjs"),
+    ]), (error) => {
+      assert.match(error.stderr, /usage: materialize-gwangju-timetable/);
+      return true;
+    });
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("materialized SQLite·provenance가 광주 membership·topology·schedule 3건을 SUPPORTED로 만든다", async (context) => {
+  const outputDir = await mkdtemp(path.join(tmpdir(), "easysubway-gwangju-runtime-pack-"));
+  context.after(() => rm(outputDir, { recursive: true, force: true }));
+  const fixturePath = path.join(outputDir, "fixture.json");
+  const packOutput = path.join(outputDir, "pack");
+  const reportPath = path.join(outputDir, "coverage.json");
+  const { fixture } = await inputs();
+  await writeFile(fixturePath, `${JSON.stringify(fixture, null, 2)}\n`);
+  await mkdir(packOutput, { recursive: true });
+  const { privateKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    publicKeyEncoding: { type: "spki", format: "pem" },
+  });
+  await execFileAsync(process.execPath, [
+    "tools/datapack/build-datapack.mjs", "--fixture", fixturePath, "--output", packOutput,
+  ], { cwd: root, env: { ...process.env, EASYSUBWAY_DATAPACK_SIGNING_PRIVATE_KEY_PEM: privateKey } });
+  const manifestPath = path.join(packOutput, "current.json");
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+  const sqlitePath = path.join(packOutput,
+    new URL(manifest.packs[0].url).pathname.split("/").slice(-2).join("/")).replace(/\.gz$/, "");
+  const database = new DatabaseSync(sqlitePath, { readOnly: true });
+  assert.equal(database.prepare("SELECT COUNT(*) AS count FROM network_edges WHERE source_id = ?")
+    .get("gwangju-transportation-route-topology").count, 38);
+  assert.equal(database.prepare("SELECT COUNT(*) AS count FROM transit_trips WHERE id LIKE 'trip-gwangju-%'")
+    .get().count, 810);
+  assert.equal(database.prepare(`
+    SELECT COUNT(*) AS count FROM transit_stop_times st
+    JOIN transit_trips t ON t.id = st.trip_id WHERE t.id LIKE 'trip-gwangju-%'
+  `).get().count, 14_171);
+  database.close();
+
+  const provenance = JSON.parse(await readFile(path.join(packOutput, "current.provenance.json"), "utf8"));
+  const records = provenance.packs.flatMap(({ records: rows }) => rows);
+  assert.ok(records.some(({ sourceId, field }) =>
+    sourceId === "gwangju-transportation-route-topology" && field === "network_edges"));
+  assert.ok(records.some(({ sourceId, field }) =>
+    sourceId === "gwangju-transportation-cyberstation-timetable" && field === "trip"));
+  assert.ok(records.some(({ sourceId, field }) =>
+    sourceId === "gwangju-transportation-cyberstation-timetable" && field === "stop_time"));
+
+  await execFileAsync(process.execPath, [
+    "tools/datapack/report-coverage-gaps.mjs",
+    "--targets", "tools/datapack/nationwide-coverage-targets.json",
+    "--inventory", "tools/datapack/source-inventory.json",
+    "--manifest", manifestPath,
+    "--provenance", path.join(packOutput, "current.provenance.json"),
+    "--resolution-plan", "tools/datapack/release/nationwide-public-api-coverage-search-plan-20260720.json",
+    "--resolutions", "tools/datapack/release/nationwide-public-api-coverage-resolutions-20260720.json",
+    "--output", reportPath,
+    "--allow-gaps",
+  ], { cwd: root });
+  const report = JSON.parse(await readFile(reportPath, "utf8"));
+  const gwangjuRequirements = report.requirements.filter(({ regionId, operatorId, lineId }) =>
+    regionId === "gwangju" && operatorId === "gwangju-metropolitan-rapid-transit"
+      && lineId === "line-e57a361e8892");
+  assert.deepEqual(gwangjuRequirements.filter(({ status }) => status === "SUPPORTED")
+    .map(({ sourceDomain }) => sourceDomain), [
+    "station_line_membership", "route_graph_topology", "schedule_timetable",
+  ], JSON.stringify(gwangjuRequirements, null, 2));
+  assert.deepEqual(report.summary.launchRequired, {
+    totalCount: 270,
+    supportedCount: 22,
+    explicitlyUnsupportedCount: 76,
+    missingCount: 172,
+    supportedRatio: 0.0815,
+    terminalResolutionRatio: 0.363,
+    completionReady: false,
+  });
+});
+
+async function inputs({ materialize = true } = {}) {
+  const [base, busanTopology, busanTimetable, busanRouteMapBytes, daejeonTopology, daejeonTimetable,
+    gwangjuTopology, gwangjuTimetable, inventory, regionalMap, molitMap] = await Promise.all([
+    readJson("tools/datapack/release/capital-production-reviewed-pack.json"),
+    readJson("tools/datapack/sources/busan-transportation-route-topology-20260720.json"),
+    readJson("tools/datapack/sources/busan-transportation-timetable-20260720.json"),
+    readFile(path.join(root, "tools/datapack/sources/busan-transportation-route-map-positions-20260720.json")),
+    readJson("tools/datapack/sources/daejeon-route-topology-20260720.json"),
+    readJson("tools/datapack/sources/daejeon-train-timetable-20260720.json"),
+    readJson("tools/datapack/sources/gwangju-transportation-route-topology-20260720.json"),
+    readJson("tools/datapack/sources/gwangju-transportation-cyberstation-timetable-20260720.json"),
+    readJson("tools/datapack/source-inventory.json"),
+    readFile(path.join(root, "tools/datapack/sources/regional-official-svg-route-map-coordinates-20260624.csv"), "utf8"),
+    readFile(path.join(root, "tools/datapack/sources/molit-urban-rail-full-route-20251211.csv")),
+  ]);
+  const busanTopologyFixture = materializeBusanRouteTopology({
+    baseFixture: base, snapshot: busanTopology, inventory,
+    canonicalStationMappings: parseCanonicalBusanStationMappings(regionalMap),
+    now: new Date("2026-07-19T18:14:03.004Z"),
+  });
+  const daejeonFixture = materializeDaejeonTimetable({
+    baseFixture: busanTopologyFixture, timetableSnapshot: daejeonTimetable,
+    topologySnapshot: daejeonTopology, inventory,
+    canonicalStationMappings: parseMolitDaejeonStationMappings(molitMap), now,
+  });
+  const busanTimetableFixture = materializeBusanTimetable({
+    baseFixture: daejeonFixture, timetableSnapshot: busanTimetable,
+    topologySnapshot: busanTopology, inventory, now,
+  });
+  const baseFixture = materializeBusanRouteMapPositions({
+    baseFixture: busanTimetableFixture,
+    snapshot: JSON.parse(busanRouteMapBytes),
+    snapshotSha256: createHash("sha256").update(busanRouteMapBytes).digest("hex"),
+    topologySnapshot: busanTopology,
+    inventory,
+    now,
+  });
+  const gwangjuMappings = parseMolitGwangjuStationMappings(molitMap);
+  const fixture = materialize ? materializeGwangjuTimetable({
+    baseFixture, timetableSnapshot: gwangjuTimetable, topologySnapshot: gwangjuTopology,
+    inventory, canonicalStationMappings: gwangjuMappings, now,
+  }) : undefined;
+  return { baseFixture, fixture, gwangjuMappings, gwangjuTimetable, gwangjuTopology, inventory };
+}
+
+async function readJson(relativePath) {
+  return JSON.parse(await readFile(path.join(root, relativePath), "utf8"));
+}

--- a/tools/datapack/materialize-gwangju-timetable.test.mjs
+++ b/tools/datapack/materialize-gwangju-timetable.test.mjs
@@ -51,6 +51,20 @@ test("광주 공식 topology·시간표를 20역·38 edge·810 trip·14171 stop_
     "gwangju-holiday-2026": 162,
     "gwangju-sunday-2026": 202,
   });
+  const correctedHolidayDates = new Set(["20260301", "20260501", "20260524", "20260717"]);
+  assert.deepEqual(pack.serviceCalendarDates
+    .filter(({ date }) => correctedHolidayDates.has(date))
+    .map(({ serviceId, date, exceptionType }) => ({ serviceId, date, exceptionType }))
+    .sort((left, right) => `${left.date}:${left.serviceId}`.localeCompare(`${right.date}:${right.serviceId}`, "en")), [
+    { serviceId: "gwangju-holiday-2026", date: "20260301", exceptionType: 1 },
+    { serviceId: "gwangju-sunday-2026", date: "20260301", exceptionType: 2 },
+    { serviceId: "gwangju-holiday-2026", date: "20260501", exceptionType: 1 },
+    { serviceId: "gwangju-weekday-2026", date: "20260501", exceptionType: 2 },
+    { serviceId: "gwangju-holiday-2026", date: "20260524", exceptionType: 1 },
+    { serviceId: "gwangju-sunday-2026", date: "20260524", exceptionType: 2 },
+    { serviceId: "gwangju-holiday-2026", date: "20260717", exceptionType: 1 },
+    { serviceId: "gwangju-weekday-2026", date: "20260717", exceptionType: 2 },
+  ]);
   const repaired = stopTimes.filter(({ repairReason }) => repairReason === "OFFICIAL_ADJACENT_TIMES_AND_TOPOLOGY");
   assert.equal(repaired.length, 1);
   assert.equal(repaired[0].arrivalSeconds, 75_570);
@@ -61,7 +75,12 @@ test("광주 공식 topology·시간표를 20역·38 edge·810 trip·14171 stop_
       && evidenceHash === values.gwangjuTopology.contentSha256));
   assert.ok(pack.stationLines.filter(({ lineId }) => lineId === "line-e57a361e8892")
     .every(({ fieldProvenance }) =>
-      fieldProvenance.station_code.sourceId === "molit-urban-rail-full-route-gwangju-membership"));
+      fieldProvenance.station_code.sourceId === "gwangju-transportation-route-topology"
+      && fieldProvenance.station_code.sourceSnapshotId === "gwangju-transportation-route-topology-20260720"
+      && fieldProvenance.station_code.evidenceHash === values.gwangjuTopology.contentSha256));
+  assert.deepEqual(values.inventory.sources.find(({ id }) => id === topologySourceId).membershipAdmissionEvidence,
+    values.inventory.sources.find(({ id }) => id === "molit-urban-rail-full-route-gwangju-membership")
+      .membershipAdmissionEvidence);
 });
 
 test("광주 materializer는 완결되지 않은 일요일 0756 열차 2행만 exact tuple로 격리한다", async () => {
@@ -218,6 +237,12 @@ test("materialized SQLite·provenance가 광주 membership·topology·schedule 3
     .map(({ sourceDomain }) => sourceDomain), [
     "station_line_membership", "route_graph_topology", "schedule_timetable",
   ], JSON.stringify(gwangjuRequirements, null, 2));
+  const membership = gwangjuRequirements.find(({ sourceDomain }) => sourceDomain === "station_line_membership");
+  assert.deepEqual(Object.fromEntries(membership.fieldCoverage.map(({ field, sourceIds }) => [field, sourceIds])), {
+    line: ["molit-urban-rail-full-route-gwangju-membership"],
+    station_name: ["molit-urban-rail-full-route-gwangju-membership"],
+    station_code: ["gwangju-transportation-route-topology"],
+  });
   assert.deepEqual(report.summary.launchRequired, {
     totalCount: 270,
     supportedCount: 22,

--- a/tools/datapack/release/candidate-build-spec.json
+++ b/tools/datapack/release/candidate-build-spec.json
@@ -194,7 +194,7 @@
   "facilityEvidenceLedgerHash": "b3ffc88b4a9ce3515340366885beaace718c70058608567513f378e198935981",
   "routeEvidenceLedgerHash": "da884d0ff0138e009587753ec541997c29da57370e056dd8d3f6ad2687ad9fa9",
   "approvedOverrideSetHash": "ee5364319442d0bb4590d83e149631635c65ab59f1f3254fdbf196e04ec0f3cd",
-  "sourceInventorySha256": "d743c6547ec8fcf6185a711c89e18a186b46acceed7f198ea4bb8be1c839f975",
+  "sourceInventorySha256": "43ee1d9e0b93ea466eaecc7dd60b23f76dff4b9dc015e06c48bd916e2cbcaaf6",
   "builderGitSha": "4fc68131b397c0468d68728683bb6c79b7a42a39",
   "builderVersion": "build-datapack.mjs@1",
   "officialOdFareEvidence": {

--- a/tools/datapack/release/candidate-build-spec.json
+++ b/tools/datapack/release/candidate-build-spec.json
@@ -194,7 +194,7 @@
   "facilityEvidenceLedgerHash": "b3ffc88b4a9ce3515340366885beaace718c70058608567513f378e198935981",
   "routeEvidenceLedgerHash": "da884d0ff0138e009587753ec541997c29da57370e056dd8d3f6ad2687ad9fa9",
   "approvedOverrideSetHash": "ee5364319442d0bb4590d83e149631635c65ab59f1f3254fdbf196e04ec0f3cd",
-  "sourceInventorySha256": "7c939d5d905c08d2b55fc72132ecf6aec0e3d31a636bbcec8646a671e7873afe",
+  "sourceInventorySha256": "15e3d1d05d5b9cf40667e8c8b5c512127f88629b79fe1835d651dc4c5833de49",
   "builderGitSha": "4fc68131b397c0468d68728683bb6c79b7a42a39",
   "builderVersion": "build-datapack.mjs@1",
   "officialOdFareEvidence": {

--- a/tools/datapack/release/candidate-build-spec.json
+++ b/tools/datapack/release/candidate-build-spec.json
@@ -194,7 +194,7 @@
   "facilityEvidenceLedgerHash": "b3ffc88b4a9ce3515340366885beaace718c70058608567513f378e198935981",
   "routeEvidenceLedgerHash": "da884d0ff0138e009587753ec541997c29da57370e056dd8d3f6ad2687ad9fa9",
   "approvedOverrideSetHash": "ee5364319442d0bb4590d83e149631635c65ab59f1f3254fdbf196e04ec0f3cd",
-  "sourceInventorySha256": "15e3d1d05d5b9cf40667e8c8b5c512127f88629b79fe1835d651dc4c5833de49",
+  "sourceInventorySha256": "d743c6547ec8fcf6185a711c89e18a186b46acceed7f198ea4bb8be1c839f975",
   "builderGitSha": "4fc68131b397c0468d68728683bb6c79b7a42a39",
   "builderVersion": "build-datapack.mjs@1",
   "officialOdFareEvidence": {

--- a/tools/datapack/release/candidate-build-spec.json
+++ b/tools/datapack/release/candidate-build-spec.json
@@ -194,7 +194,7 @@
   "facilityEvidenceLedgerHash": "b3ffc88b4a9ce3515340366885beaace718c70058608567513f378e198935981",
   "routeEvidenceLedgerHash": "da884d0ff0138e009587753ec541997c29da57370e056dd8d3f6ad2687ad9fa9",
   "approvedOverrideSetHash": "ee5364319442d0bb4590d83e149631635c65ab59f1f3254fdbf196e04ec0f3cd",
-  "sourceInventorySha256": "3117376dcf005612d7bbdc274cf4764bf46e60cf1849e031c8117c9ab5fec418",
+  "sourceInventorySha256": "7c939d5d905c08d2b55fc72132ecf6aec0e3d31a636bbcec8646a671e7873afe",
   "builderGitSha": "4fc68131b397c0468d68728683bb6c79b7a42a39",
   "builderVersion": "build-datapack.mjs@1",
   "officialOdFareEvidence": {

--- a/tools/datapack/release/hash-evidence.json
+++ b/tools/datapack/release/hash-evidence.json
@@ -48,7 +48,7 @@
     "reproductionCommand": "node -e \"const c=require('crypto');console.log(c.createHash('sha256').update(JSON.stringify(require('./tools/datapack/release/source-snapshots.json'))).digest('hex'))\""
   },
   "sourceInventorySha256": {
-    "value": "d743c6547ec8fcf6185a711c89e18a186b46acceed7f198ea4bb8be1c839f975",
+    "value": "43ee1d9e0b93ea466eaecc7dd60b23f76dff4b9dc015e06c48bd916e2cbcaaf6",
     "contract": "run-source-admission-pipeline.mjs의 공식 sha256(JSON.stringify(admittedInventory)) 계약. 현행 브랜치의 tools/datapack/source-inventory.json이 최종 admitted inventory이며 워크플로 빌드가 실제로 소비하는 인벤토리와 동일 파일.",
     "reproductionCommand": "node -e \"const c=require('crypto'),fs=require('fs');console.log(c.createHash('sha256').update(JSON.stringify(JSON.parse(fs.readFileSync('tools/datapack/source-inventory.json','utf8')))).digest('hex'))\""
   },

--- a/tools/datapack/release/hash-evidence.json
+++ b/tools/datapack/release/hash-evidence.json
@@ -48,7 +48,7 @@
     "reproductionCommand": "node -e \"const c=require('crypto');console.log(c.createHash('sha256').update(JSON.stringify(require('./tools/datapack/release/source-snapshots.json'))).digest('hex'))\""
   },
   "sourceInventorySha256": {
-    "value": "7c939d5d905c08d2b55fc72132ecf6aec0e3d31a636bbcec8646a671e7873afe",
+    "value": "15e3d1d05d5b9cf40667e8c8b5c512127f88629b79fe1835d651dc4c5833de49",
     "contract": "run-source-admission-pipeline.mjs의 공식 sha256(JSON.stringify(admittedInventory)) 계약. 현행 브랜치의 tools/datapack/source-inventory.json이 최종 admitted inventory이며 워크플로 빌드가 실제로 소비하는 인벤토리와 동일 파일.",
     "reproductionCommand": "node -e \"const c=require('crypto'),fs=require('fs');console.log(c.createHash('sha256').update(JSON.stringify(JSON.parse(fs.readFileSync('tools/datapack/source-inventory.json','utf8')))).digest('hex'))\""
   },

--- a/tools/datapack/release/hash-evidence.json
+++ b/tools/datapack/release/hash-evidence.json
@@ -48,7 +48,7 @@
     "reproductionCommand": "node -e \"const c=require('crypto');console.log(c.createHash('sha256').update(JSON.stringify(require('./tools/datapack/release/source-snapshots.json'))).digest('hex'))\""
   },
   "sourceInventorySha256": {
-    "value": "3117376dcf005612d7bbdc274cf4764bf46e60cf1849e031c8117c9ab5fec418",
+    "value": "7c939d5d905c08d2b55fc72132ecf6aec0e3d31a636bbcec8646a671e7873afe",
     "contract": "run-source-admission-pipeline.mjs의 공식 sha256(JSON.stringify(admittedInventory)) 계약. 현행 브랜치의 tools/datapack/source-inventory.json이 최종 admitted inventory이며 워크플로 빌드가 실제로 소비하는 인벤토리와 동일 파일.",
     "reproductionCommand": "node -e \"const c=require('crypto'),fs=require('fs');console.log(c.createHash('sha256').update(JSON.stringify(JSON.parse(fs.readFileSync('tools/datapack/source-inventory.json','utf8')))).digest('hex'))\""
   },

--- a/tools/datapack/release/hash-evidence.json
+++ b/tools/datapack/release/hash-evidence.json
@@ -48,7 +48,7 @@
     "reproductionCommand": "node -e \"const c=require('crypto');console.log(c.createHash('sha256').update(JSON.stringify(require('./tools/datapack/release/source-snapshots.json'))).digest('hex'))\""
   },
   "sourceInventorySha256": {
-    "value": "15e3d1d05d5b9cf40667e8c8b5c512127f88629b79fe1835d651dc4c5833de49",
+    "value": "d743c6547ec8fcf6185a711c89e18a186b46acceed7f198ea4bb8be1c839f975",
     "contract": "run-source-admission-pipeline.mjs의 공식 sha256(JSON.stringify(admittedInventory)) 계약. 현행 브랜치의 tools/datapack/source-inventory.json이 최종 admitted inventory이며 워크플로 빌드가 실제로 소비하는 인벤토리와 동일 파일.",
     "reproductionCommand": "node -e \"const c=require('crypto'),fs=require('fs');console.log(c.createHash('sha256').update(JSON.stringify(JSON.parse(fs.readFileSync('tools/datapack/source-inventory.json','utf8')))).digest('hex'))\""
   },

--- a/tools/datapack/source-candidates.json
+++ b/tools/datapack/source-candidates.json
@@ -3285,7 +3285,7 @@
       },
       "licenseEvidenceStatus": "official_open_api_publication",
       "sampleEvidenceStatus": "validated_live_full_snapshot",
-      "admissionStatus": "official_live_snapshot_captured",
+      "admissionStatus": "production_materialized",
       "mobileEmbeddingAllowed": false,
       "evidence": {
         "retrievedAt": "2026-07-20",
@@ -3304,9 +3304,17 @@
         "liveSampleScopeSha256": "42d1a6e82b0c4dd0b199f90fe620c38ddb2a9826df334c39a2d0692449324de4",
         "liveSampleEdgesSha256": "8b0f77bb79db55e6f035e3e713bf9c2ade0b1a7619d495db44cefa1420257d0d",
         "liveSampleContentSha256": "d8197488bc6dda94e595f7e350cc65c547117da804fb59b7dff85d18b3192e43",
-        "evidenceArtifact": "tools/datapack/sources/gwangju-transportation-route-topology-20260720.json"
+        "evidenceArtifact": "tools/datapack/sources/gwangju-transportation-route-topology-20260720.json",
+        "coverageAssessment": {
+          "state": "SUPPORTED",
+          "requirementCount": 2,
+          "sourceDomains": ["station_line_membership", "route_graph_topology"],
+          "artifactKind": "production",
+          "materializer": "tools/datapack/materialize-gwangju-timetable.mjs",
+          "verificationTest": "tools/datapack/materialize-gwangju-timetable.test.mjs"
+        }
       },
-      "nextAction": "38개 공식 topology edge를 광주 schedule materializer에 결합한다"
+      "nextAction": "24시간 topology snapshot을 갱신해 immutable production pack을 재생성한다"
     },
     {
       "id": "gwangju-transportation-cyberstation-timetable",
@@ -3337,7 +3345,7 @@
       },
       "licenseEvidenceStatus": "covered_by_unrestricted_data_go_timetable_dataset_15111298",
       "sampleEvidenceStatus": "validated_live_full_snapshot",
-      "admissionStatus": "official_live_snapshot_captured",
+      "admissionStatus": "production_materialized",
       "mobileEmbeddingAllowed": false,
       "evidence": {
         "retrievedAt": "2026-07-20",
@@ -3352,9 +3360,22 @@
         "normalizedBoundaryMinuteCount": 1,
         "liveSampleContentSha256": "b050ed92cbdd555e22e987e4854a7d60b5293951992d6c14ae26c110f9b4fb5a",
         "liveSampleRowsSha256": "2eec08dc30a97c50fd349dc607e77677829881790b5ca896856caa4b9bbd3ccd",
-        "evidenceArtifact": "tools/datapack/sources/gwangju-transportation-cyberstation-timetable-20260720.json"
+        "evidenceArtifact": "tools/datapack/sources/gwangju-transportation-cyberstation-timetable-20260720.json",
+        "materializedTripCount": 810,
+        "materializedStopTimeCount": 14171,
+        "admittedOfficialRowCount": 13360,
+        "generatedStopTimeCount": 811,
+        "quarantinedIncompleteTripRowCount": 2,
+        "coverageAssessment": {
+          "state": "SUPPORTED",
+          "requirementCount": 1,
+          "sourceDomain": "schedule_timetable",
+          "artifactKind": "production",
+          "materializer": "tools/datapack/materialize-gwangju-timetable.mjs",
+          "verificationTest": "tools/datapack/materialize-gwangju-timetable.test.mjs"
+        }
       },
-      "nextAction": "13,362개 현재 공식 schedule row를 deterministic timetable artifact로 materialize한다"
+      "nextAction": "24시간 timetable snapshot을 갱신해 immutable production pack을 재생성한다"
     },
     {
       "id": "gwangju-transportation-timetable",

--- a/tools/datapack/source-inventory.json
+++ b/tools/datapack/source-inventory.json
@@ -514,7 +514,7 @@
         "regionIds": ["gwangju"],
         "operatorIds": ["gwangju-metropolitan-rapid-transit"],
         "lineIds": ["line-e57a361e8892"],
-        "sourceDomains": ["route_graph_topology"]
+        "sourceDomains": ["route_graph_topology", "station_line_membership"]
       },
       "requiredForProductionPack": false,
       "productionUseAllowed": true,
@@ -569,6 +569,23 @@
         "excludedTransferCount": 0,
         "rawSha256": "15e4a6835dff21997d29707b0554580560fd770388156b2ac169508cdfd6636a",
         "contentSha256": "d8197488bc6dda94e595f7e350cc65c547117da804fb59b7dff85d18b3192e43"
+      },
+      "membershipAdmissionEvidence": {
+        "issue": 2383,
+        "materializer": "tools/datapack/materialize-gwangju-timetable.mjs",
+        "verificationTest": "tools/datapack/materialize-gwangju-timetable.test.mjs",
+        "snapshotId": "molit-urban-rail-full-route-gwangju-membership-20260720",
+        "lineIds": ["line-e57a361e8892"],
+        "verifiedAt": "2026-07-20T13:08:47.161Z",
+        "stationCount": 20,
+        "membershipSourceId": "molit-urban-rail-full-route",
+        "membershipSourceRawSha256": "178af75ece72b2f6a58226063e05f1e1f45f50c779c7fbf2905f7df1384a9e22",
+        "membershipSourceSnapshotSha256": "3f08fb398bcb16e8ff047ec17f094a28590ec8d5aa1b8df2d6e9cec85ed0f6e7",
+        "mappingSha256": "f7515bed1908e7b1aff2674f58b8425d94a8177d1fb5bed1f3fb8545cb347a03",
+        "stationCodesSha256": "dc831a8f14fd33808b6e17ecbf829eb6d4c199b6c1d75c7673adaa97ad69df83",
+        "stationCodeSourceId": "gwangju-transportation-route-topology",
+        "stationCodeSnapshotId": "gwangju-transportation-route-topology-20260720",
+        "stationCodeContentSha256": "d8197488bc6dda94e595f7e350cc65c547117da804fb59b7dff85d18b3192e43"
       }
     },
     {
@@ -676,7 +693,7 @@
         "redistributionAllowed": true,
         "evidenceUrl": "https://www.data.go.kr/data/15122916/fileData.do"
       },
-      "fieldsProvided": ["line", "station_name", "station_code"],
+      "fieldsProvided": ["line", "station_name"],
       "capabilities": {
         "schedule": {
           "status": "UNSUPPORTED",

--- a/tools/datapack/source-inventory.json
+++ b/tools/datapack/source-inventory.json
@@ -501,6 +501,233 @@
       }
     },
     {
+      "id": "gwangju-transportation-route-topology",
+      "displayName": "광주교통공사 도시철도 운행정보",
+      "owner": "광주교통공사",
+      "provider": "광주교통공사",
+      "providerDepartment": "IT전략팀",
+      "sourceSystem": "광주교통공사 오픈 API",
+      "datasetUrl": "https://www.grtc.co.kr/subway/contents/apiRunInfo",
+      "datasetKind": "official-open-api",
+      "coverage": "광주 1호선 20개 역과 38개 방향성 인접 거리·소요시간 edge",
+      "coverageScope": {
+        "regionIds": ["gwangju"],
+        "operatorIds": ["gwangju-metropolitan-rapid-transit"],
+        "lineIds": ["line-e57a361e8892"],
+        "sourceDomains": ["route_graph_topology", "station_line_membership"]
+      },
+      "requiredForProductionPack": false,
+      "productionUseAllowed": true,
+      "updateFrequency": "daily admission refresh",
+      "observedDataUpdatedAt": "2026-07-20",
+      "retrievedAt": "2026-07-20",
+      "license": {
+        "type": "PUBLIC_DATA_FREE_USE",
+        "name": "공공데이터포털 이용허락범위 제한 없음",
+        "attribution": "광주교통공사, 공공데이터포털 이용허락범위 제한 없음",
+        "commercialUseAllowed": true,
+        "derivativeWorkAllowed": true,
+        "redistributionAllowed": true,
+        "evidenceUrl": "https://www.data.go.kr/data/15046044/fileData.do"
+      },
+      "fieldsProvided": ["network_edges", "duration_seconds", "distance_meters", "station_code"],
+      "capabilities": {
+        "schedule": {
+          "status": "UNSUPPORTED",
+          "productionUseAllowed": false,
+          "coverageStatus": "NOT_PROVIDED_BY_SOURCE",
+          "updateFrequency": "daily admission refresh",
+          "unsupportedNotes": "source provides route travel cost, not scheduled departures"
+        },
+        "realtime": {
+          "status": "UNSUPPORTED",
+          "productionUseAllowed": false,
+          "liveEtaEligible": false,
+          "rateLimitStatus": "NOT_APPLICABLE",
+          "coverageStatus": "NOT_PROVIDED_BY_SOURCE",
+          "updateFrequency": "daily admission refresh",
+          "unsupportedNotes": "source does not provide realtime arrivals"
+        },
+        "facility": {
+          "status": "UNSUPPORTED",
+          "productionUseAllowed": false,
+          "coverageStatus": "NOT_PROVIDED_BY_SOURCE",
+          "updateFrequency": "daily admission refresh",
+          "unsupportedNotes": "source does not provide accessibility facility records"
+        }
+      },
+      "topologyAdmissionEvidence": {
+        "issue": 2383,
+        "materializer": "tools/datapack/materialize-gwangju-timetable.mjs",
+        "verificationTest": "tools/datapack/materialize-gwangju-timetable.test.mjs",
+        "snapshotId": "gwangju-transportation-route-topology-20260720",
+        "snapshotPath": "tools/datapack/sources/gwangju-transportation-route-topology-20260720.json",
+        "capturedAt": "2026-07-20T13:08:47.161Z",
+        "freshUntil": "2026-07-21T13:08:47.161Z",
+        "stationCount": 20,
+        "odRowCount": 380,
+        "edgeCount": 38,
+        "rawSha256": "15e4a6835dff21997d29707b0554580560fd770388156b2ac169508cdfd6636a",
+        "scopeSha256": "42d1a6e82b0c4dd0b199f90fe620c38ddb2a9826df334c39a2d0692449324de4",
+        "edgesSha256": "8b0f77bb79db55e6f035e3e713bf9c2ade0b1a7619d495db44cefa1420257d0d",
+        "contentSha256": "d8197488bc6dda94e595f7e350cc65c547117da804fb59b7dff85d18b3192e43"
+      }
+    },
+    {
+      "id": "gwangju-transportation-cyberstation-timetable",
+      "displayName": "광주교통공사 사이버스테이션 열차시각표",
+      "owner": "광주교통공사",
+      "provider": "광주교통공사",
+      "providerDepartment": "IT전략팀",
+      "sourceSystem": "광주교통공사 사이버스테이션",
+      "datasetUrl": "https://www.grtc.co.kr/subway/menu/trainTimetableSubMenu",
+      "datasetKind": "official-web-timetable",
+      "coverage": "광주 1호선 4개 요일 유형 810개 완결 운행과 14171개 stop time",
+      "coverageScope": {
+        "regionIds": ["gwangju"],
+        "operatorIds": ["gwangju-metropolitan-rapid-transit"],
+        "lineIds": ["line-e57a361e8892"],
+        "sourceDomains": ["schedule_timetable"]
+      },
+      "requiredForProductionPack": false,
+      "productionUseAllowed": true,
+      "updateFrequency": "daily admission refresh",
+      "observedDataUpdatedAt": "2026-07-20",
+      "retrievedAt": "2026-07-20",
+      "license": {
+        "type": "PUBLIC_DATA_FREE_USE",
+        "name": "공공데이터포털 이용허락범위 제한 없음",
+        "attribution": "광주교통공사, 공공데이터포털 이용허락범위 제한 없음",
+        "commercialUseAllowed": true,
+        "derivativeWorkAllowed": true,
+        "redistributionAllowed": true,
+        "evidenceUrl": "https://www.data.go.kr/data/15111298/openapi.do"
+      },
+      "fieldsProvided": ["service_calendar", "trip", "stop_time"],
+      "capabilities": {
+        "schedule": {
+          "status": "SUPPORTED",
+          "productionUseAllowed": true,
+          "coverageStatus": "GWANGJU_LINE_1_CURRENT_COMPLETE_TRIPS",
+          "updateFrequency": "daily admission refresh",
+          "unsupportedNotes": "계획 시간표이며 실시간 도착 정보가 아니다"
+        },
+        "realtime": {
+          "status": "UNSUPPORTED",
+          "productionUseAllowed": false,
+          "liveEtaEligible": false,
+          "rateLimitStatus": "NOT_APPLICABLE",
+          "coverageStatus": "NOT_PROVIDED_BY_SOURCE",
+          "updateFrequency": "daily admission refresh",
+          "unsupportedNotes": "source does not provide realtime arrivals"
+        },
+        "facility": {
+          "status": "UNSUPPORTED",
+          "productionUseAllowed": false,
+          "coverageStatus": "NOT_PROVIDED_BY_SOURCE",
+          "updateFrequency": "daily admission refresh",
+          "unsupportedNotes": "source does not provide accessibility facility records"
+        }
+      },
+      "scheduleAdmissionEvidence": {
+        "issue": 2383,
+        "materializer": "tools/datapack/materialize-gwangju-timetable.mjs",
+        "verificationTest": "tools/datapack/materialize-gwangju-timetable.test.mjs",
+        "snapshotId": "gwangju-transportation-cyberstation-timetable-20260720",
+        "snapshotPath": "tools/datapack/sources/gwangju-transportation-cyberstation-timetable-20260720.json",
+        "capturedAt": "2026-07-20T12:55:50.079Z",
+        "freshUntil": "2026-07-21T12:55:50.079Z",
+        "rowCount": 13362,
+        "admittedOfficialRowCount": 13360,
+        "tripCount": 810,
+        "stopTimeCount": 14171,
+        "generatedStopTimeCount": 811,
+        "quarantinedRows": [
+          { "dayCode": "DAYOFF", "direction": "st", "stationCode": "119", "time": "0756" },
+          { "dayCode": "DAYOFF", "direction": "st", "stationCode": "118", "time": "0759" }
+        ],
+        "rowsSha256": "2eec08dc30a97c50fd349dc607e77677829881790b5ca896856caa4b9bbd3ccd",
+        "contentSha256": "b050ed92cbdd555e22e987e4854a7d60b5293951992d6c14ae26c110f9b4fb5a",
+        "topologySourceId": "gwangju-transportation-route-topology",
+        "topologySnapshotId": "gwangju-transportation-route-topology-20260720",
+        "topologyContentSha256": "d8197488bc6dda94e595f7e350cc65c547117da804fb59b7dff85d18b3192e43"
+      }
+    },
+    {
+      "id": "molit-urban-rail-full-route-gwangju-membership",
+      "displayName": "국토교통부_도시철도 전체노선 광주 1호선 membership admission",
+      "owner": "국토교통부",
+      "provider": "국토교통부",
+      "providerDepartment": "도시철도 담당부서",
+      "sourceSystem": "공공데이터포털",
+      "datasetUrl": "https://www.data.go.kr/data/15122916/fileData.do",
+      "datasetKind": "reviewed-admission-slice",
+      "coverage": "국토교통부 역·노선 정본과 광주교통공사 역번호로 검증한 광주 1호선 20개 station membership",
+      "coverageScope": {
+        "regionIds": ["gwangju"],
+        "operatorIds": ["gwangju-metropolitan-rapid-transit"],
+        "lineIds": ["line-e57a361e8892"],
+        "sourceDomains": ["station_line_membership"]
+      },
+      "requiredForProductionPack": false,
+      "productionUseAllowed": true,
+      "updateFrequency": "annual admission review",
+      "observedDataUpdatedAt": "2026-06-22",
+      "retrievedAt": "2026-07-20",
+      "license": {
+        "type": "PUBLIC_DATA_FREE_USE",
+        "name": "공공데이터포털 이용허락범위 제한 없음",
+        "attribution": "국토교통부·광주교통공사, 공공데이터포털 이용허락범위 제한 없음",
+        "commercialUseAllowed": true,
+        "derivativeWorkAllowed": true,
+        "redistributionAllowed": true,
+        "evidenceUrl": "https://www.data.go.kr/data/15122916/fileData.do"
+      },
+      "fieldsProvided": ["line", "station_name"],
+      "capabilities": {
+        "schedule": {
+          "status": "UNSUPPORTED",
+          "productionUseAllowed": false,
+          "coverageStatus": "NOT_PROVIDED_BY_SOURCE",
+          "updateFrequency": "annual admission review",
+          "unsupportedNotes": "source does not provide scheduled timetable data"
+        },
+        "realtime": {
+          "status": "UNSUPPORTED",
+          "productionUseAllowed": false,
+          "liveEtaEligible": false,
+          "rateLimitStatus": "NOT_APPLICABLE",
+          "coverageStatus": "NOT_PROVIDED_BY_SOURCE",
+          "updateFrequency": "annual admission review",
+          "unsupportedNotes": "source does not provide realtime arrivals"
+        },
+        "facility": {
+          "status": "UNSUPPORTED",
+          "productionUseAllowed": false,
+          "coverageStatus": "NOT_PROVIDED_BY_SOURCE",
+          "updateFrequency": "annual admission review",
+          "unsupportedNotes": "source does not provide accessibility facility records"
+        }
+      },
+      "membershipAdmissionEvidence": {
+        "issue": 2383,
+        "materializer": "tools/datapack/materialize-gwangju-timetable.mjs",
+        "verificationTest": "tools/datapack/materialize-gwangju-timetable.test.mjs",
+        "snapshotId": "molit-urban-rail-full-route-gwangju-membership-20260720",
+        "lineIds": ["line-e57a361e8892"],
+        "verifiedAt": "2026-07-20T13:08:47.161Z",
+        "stationCount": 20,
+        "membershipSourceId": "molit-urban-rail-full-route",
+        "membershipSourceRawSha256": "178af75ece72b2f6a58226063e05f1e1f45f50c779c7fbf2905f7df1384a9e22",
+        "membershipSourceSnapshotSha256": "3f08fb398bcb16e8ff047ec17f094a28590ec8d5aa1b8df2d6e9cec85ed0f6e7",
+        "mappingSha256": "f7515bed1908e7b1aff2674f58b8425d94a8177d1fb5bed1f3fb8545cb347a03",
+        "stationCodesSha256": "dc831a8f14fd33808b6e17ecbf829eb6d4c199b6c1d75c7673adaa97ad69df83",
+        "stationCodeSourceId": "gwangju-transportation-route-topology",
+        "stationCodeSnapshotId": "gwangju-transportation-route-topology-20260720",
+        "stationCodeContentSha256": "d8197488bc6dda94e595f7e350cc65c547117da804fb59b7dff85d18b3192e43"
+      }
+    },
+    {
       "id": "kric-disabled-toilet",
       "displayName": "국가철도공단_역사별 장애인 화장실 위치",
       "owner": "국가철도공단",

--- a/tools/datapack/source-inventory.json
+++ b/tools/datapack/source-inventory.json
@@ -514,7 +514,7 @@
         "regionIds": ["gwangju"],
         "operatorIds": ["gwangju-metropolitan-rapid-transit"],
         "lineIds": ["line-e57a361e8892"],
-        "sourceDomains": ["route_graph_topology", "station_line_membership"]
+        "sourceDomains": ["route_graph_topology"]
       },
       "requiredForProductionPack": false,
       "productionUseAllowed": true,
@@ -565,11 +565,9 @@
         "capturedAt": "2026-07-20T13:08:47.161Z",
         "freshUntil": "2026-07-21T13:08:47.161Z",
         "stationCount": 20,
-        "odRowCount": 380,
         "edgeCount": 38,
+        "excludedTransferCount": 0,
         "rawSha256": "15e4a6835dff21997d29707b0554580560fd770388156b2ac169508cdfd6636a",
-        "scopeSha256": "42d1a6e82b0c4dd0b199f90fe620c38ddb2a9826df334c39a2d0692449324de4",
-        "edgesSha256": "8b0f77bb79db55e6f035e3e713bf9c2ade0b1a7619d495db44cefa1420257d0d",
         "contentSha256": "d8197488bc6dda94e595f7e350cc65c547117da804fb59b7dff85d18b3192e43"
       }
     },
@@ -638,16 +636,11 @@
         "capturedAt": "2026-07-20T12:55:50.079Z",
         "freshUntil": "2026-07-21T12:55:50.079Z",
         "rowCount": 13362,
-        "admittedOfficialRowCount": 13360,
+        "departureCount": 13360,
         "tripCount": 810,
         "stopTimeCount": 14171,
-        "generatedStopTimeCount": 811,
-        "quarantinedRows": [
-          { "dayCode": "DAYOFF", "direction": "st", "stationCode": "119", "time": "0756" },
-          { "dayCode": "DAYOFF", "direction": "st", "stationCode": "118", "time": "0759" }
-        ],
+        "rawSha256": "852b75f79ca7cccf8dfefc65ee4fe226f833e6cd2e52f5e721efdfac2efdc31a",
         "rowsSha256": "2eec08dc30a97c50fd349dc607e77677829881790b5ca896856caa4b9bbd3ccd",
-        "contentSha256": "b050ed92cbdd555e22e987e4854a7d60b5293951992d6c14ae26c110f9b4fb5a",
         "topologySourceId": "gwangju-transportation-route-topology",
         "topologySnapshotId": "gwangju-transportation-route-topology-20260720",
         "topologyContentSha256": "d8197488bc6dda94e595f7e350cc65c547117da804fb59b7dff85d18b3192e43"
@@ -683,7 +676,7 @@
         "redistributionAllowed": true,
         "evidenceUrl": "https://www.data.go.kr/data/15122916/fileData.do"
       },
-      "fieldsProvided": ["line", "station_name"],
+      "fieldsProvided": ["line", "station_name", "station_code"],
       "capabilities": {
         "schedule": {
           "status": "UNSUPPORTED",


### PR DESCRIPTION
## 관련 이슈

Closes AquilaXk/easysubway#2383
Refs AquilaXk/easysubway-data#3

## 작업 배경

- 광주교통공사 공식 사이버스테이션 시간표와 운행정보 topology snapshot을 production datapack으로 승격해야 합니다.
- 전국 270 requirements 중 광주 1호선의 membership, topology, schedule 3건을 출처·freshness·lineage와 함께 종결합니다.

## 작업 내용

- 공식 20개 역과 38개 방향성 edge를 광주 1호선 production source inventory에 등록했습니다.
- 공식 시간표 13,362행을 검증해 810 trips, 14,171 stop_times로 결정론적으로 materialize했습니다.
- 불완전한 공식 source row 2건은 exact tuple로 격리하고, `99분` 1건은 제외하며 `09시60분` 1건은 정상화했습니다.
- MOLIT canonical station mapping과 source candidate 상태를 production materialized로 갱신했습니다.
- mobile/release source inventory hash와 회귀 계약을 함께 갱신했습니다.

## 검증

- 실행한 명령과 결과:
  - `git diff --check` — 통과
  - `node --test tools/datapack/materialize-gwangju-timetable.test.mjs tools/ci/repository-contract.test.mjs` — 224/224 통과
  - `node --test tools/datapack/*.test.mjs` — 1,306/1,306 통과
  - `node tools/ci/check-contracts.mjs` — 통과
  - `cmp -s tools/datapack/source-inventory.json apps/mobile/assets/datapacks/source-inventory.json` — byte-identical

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 광주 1호선 materialization | Node/datapack | focused test 및 전체 datapack 회귀 | CI와 위 명령 결과 | 20 stations, 38 edges, 810 trips, 14,171 stop_times |
| UI/접근성/수동 QA | 해당 없음 | 사용자 화면 변경 없음 | 데이터·계약 변경이므로 별도 화면 증거 불필요 | 해당 없음 |
| 배포 | 해당 없음 | 이 PR은 datapack 게시·배포를 실행하지 않음 | 자동 병합까지만 요청됨 | 해당 없음 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] AquilaXk/easysubway#1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 광주 1호선 membership/topology/schedule production coverage 추가
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `materialize-gwangju-timetable.mjs`의 exact quarantine, station membership provenance, snapshot freshness/hash 검증입니다.

## 리스크

- 공식 HTML/API 형식이 바뀌면 collector/materializer가 fail closed하며, freshness 만료 시 지원 상태로 집계하지 않습니다.
- source row 2건 격리와 1건 제외/1건 정상화 범위는 exact tuple 및 regression test로 고정했습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
