### PR TITLE
[Style] #2349 표 명칭 컬럼 낱글자 랩 잔여 수정 — operator 접근성·admin 역 목록 (PR⑩j)

### DIFF
--- a/backend/src/main/resources/static/css/admin-components.css
+++ b/backend/src/main/resources/static/css/admin-components.css
@@ -238,7 +238,7 @@
    끊는다("남춘/천", "상록/수"). sticky 계약(.admin-table-scroll td:first-child)은 그대로 유지한 채 폭만
    역명에 맞춰 늘어나도 되므로 nowrap을 더한다. 다른 admin 목록 표는 이번 스코프 밖이라 역 목록
    결과 영역(#station-results)으로 좁힌다. */
-#station-results .admin-table-scroll td:first-child {
+#station-results .admin-table-scroll td:first-child:not([colspan]) {
 	white-space: nowrap;
 }
 

--- a/backend/src/main/resources/static/css/admin-components.css
+++ b/backend/src/main/resources/static/css/admin-components.css
@@ -233,6 +233,15 @@
 	background: var(--admin-header-bg);
 }
 
+/* 역 목록 표 역명 열 어절 유지(#2349 PR⑩j): keep-all + overflow-wrap: anywhere만으로는 390 첫 화면에서
+   sticky 첫 열(역명) 폭이 좁아지면 "남춘천"·"상록수" 같은 공백 없는 역명이 anywhere가 글자 단위로
+   끊는다("남춘/천", "상록/수"). sticky 계약(.admin-table-scroll td:first-child)은 그대로 유지한 채 폭만
+   역명에 맞춰 늘어나도 되므로 nowrap을 더한다. 다른 admin 목록 표는 이번 스코프 밖이라 역 목록
+   결과 영역(#station-results)으로 좁힌다. */
+#station-results .admin-table-scroll td:first-child {
+	white-space: nowrap;
+}
+
 .admin-v3 tbody tr {
 	height: 44px;
 }

--- a/backend/src/main/resources/static/css/operator-v3.css
+++ b/backend/src/main/resources/static/css/operator-v3.css
@@ -401,6 +401,25 @@ input:focus-visible {
 	white-space: nowrap;
 }
 
+/* 역별 접근성 점수 표 역·지역 열 어절 유지(#2349 PR⑩j, region-quality-table과 동일 원칙): keep-all +
+   overflow-wrap: anywhere만으로는 1024 폭에서 역·지역 열이 좁아지면 "상록수"·"강원권" 같은 공백 없는 짧은
+   고유명사도 anywhere가 글자 단위로 끊는다("상록/수", "강원/권"). 보강 사유 열은 자유 텍스트라 줄바꿈을
+   유지해야 하므로 역(첫 열)·지역(둘째 열)에만 nowrap을 좁혀 적용한다. 다른 표에는 영향 없게 이 표에만
+   붙는 .station-score-table로 스코프를 좁힌다. */
+.station-score-table td:first-child,
+.station-score-table td:nth-child(2) {
+	white-space: nowrap;
+}
+
+/* 접근성 개선 우선순위 표 역·시설 열 어절 유지(#2349 PR⑩j, region-quality-table과 동일 원칙): 좁아진 열에서
+   "상록수"·"장애인 화장실" 같은 역명·시설명이 글자 단위로 끊긴다("상록/수", "장/애/인/화/장/실"). 개선 사유
+   열은 자유 텍스트라 줄바꿈을 유지해야 하므로 역(첫 열)·시설(둘째 열)에만 nowrap을 좁혀 적용한다. 다른
+   표에는 영향 없게 이 표에만 붙는 .priority-table로 스코프를 좁힌다. */
+.priority-table td:first-child,
+.priority-table td:nth-child(2) {
+	white-space: nowrap;
+}
+
 /* 빈 상태 표준화(#2349 PR⑩e, admin td.empty와 동일 원칙): colspan 메시지 셀이 last-child 우측 정렬을
    상속해 붕괴하는 것을 막고 admin/fragments 빈 상태 문법(.empty-state)과 정렬을 맞춘다. */
 .data-table td.empty {

--- a/backend/src/main/resources/templates/operator/accessibility-report.html
+++ b/backend/src/main/resources/templates/operator/accessibility-report.html
@@ -140,7 +140,7 @@
 						</div>
 						<div class="operator-table-scroll" tabindex="0" role="group"
 						     aria-label="가로로 스크롤 가능한 역별 접근성 점수 표">
-						<table class="data-table">
+						<table class="data-table station-score-table">
 							<thead>
 							<tr>
 								<th scope="col">역</th>
@@ -203,7 +203,7 @@
 						</div>
 						<div class="operator-table-scroll" tabindex="0" role="group"
 						     aria-label="가로로 스크롤 가능한 접근성 개선 우선순위 표">
-						<table class="data-table">
+						<table class="data-table priority-table">
 							<thead>
 							<tr>
 								<th scope="col">역</th>


### PR DESCRIPTION
## 관련 이슈

Refs #2349

## 작업 내용

- 최종 전 화면 재캡처 판독에서 확인된 마지막 잔여 3건을 수정했다. `word-break: keep-all` + `overflow-wrap: anywhere` 조합에서 좁은 컬럼이 anywhere를 발동시켜 명칭이 낱글자로 갈라지던 케이스다.
- operator 접근성 현황의 역별 접근성 점수 표("강원/권")·접근성 개선 우선순위 표("상/록/수", "장/애/인/화/장/실")에 ⑩g의 `region-quality-table` 선례와 동일한 스코프 클래스(`station-score-table`·`priority-table`)를 부여하고 명칭 컬럼(1·2열)만 nowrap 처리했다(자유 텍스트 사유 컬럼은 불변). 두 표 모두 기존 `.operator-table-scroll` wrapper가 가로 overflow를 흡수함을 실측했다.
- admin 역 목록 390의 역명 셀("남춘/천") nowrap: 페이지 고유 `#station-results` 컨테이너로 스코프를 한정해 다른 admin 목록 표의 sticky 첫 컬럼 계약에 영향이 없게 했다. QA 하네스 `master-list-status-signal`의 sticky 단정은 position을 건드리지 않아 그대로 통과.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/qa/admin-accessibility-qa.test.mjs` → 15 pass, 0 fail
  - `./gradlew test`(OperatorAccessibilityReportPage/Api·AdminV3PageSmoke·AdminPhase3QualityGate) → BUILD SUCCESSFUL
  - dev 실기동(H2, seed) + mouse-reset 캡처로 operator 접근성 1024·1440에서 두 표 명칭 셀 한 줄, admin 역 목록 390에서 "남춘천"·"상록수" 한 줄·sticky 유지 확인(`.superpowers/plans/2349-evidence/pr10j/` 로컬)

## 영향

- [x] 제품/운영 위험 없음 (route/accessibility/mobile UX/backend API/auth/security 아님)
- [x] DB migration 없음
- [x] 배포 영향 없음
- [x] route/realtime/datapack contract 영향 없음
- [x] CI workflow·계약 테스트·release gate JSON 변경 없음 (있으면 full.md로 전환)

## 체크리스트

- [x] 이 PR은 B/C등급 작업이며 full template이 필요 없다.
- [ ] CI 결과를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 폴백 리뷰를 단일 PR review로 게시했다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 접근성 보고서 표에서 역명, 지역명, 시설명이 좁은 열에서 임의로 끊기지 않도록 표시 방식을 개선했습니다.
  * 역별 접근성 점수 및 개선 우선순위 표의 가독성을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->