### PR TITLE
[CI] #2396 워크플로 정적 검증 게이트(actionlint) 도입

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+self-hosted-runner:
+  # self-hosted 운영 러너의 커스텀 라벨. 등록하지 않으면 runs-on의 이 라벨을
+  # actionlint가 미지의 라벨로 오탐 처리한다(#2396).
+  labels:
+    - easysubway-production

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -551,7 +551,7 @@ jobs:
           tarball="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
           url="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${tarball}"
           workdir="$(mktemp -d)"
-          curl -fsSL "${url}" -o "${workdir}/${tarball}"
+          curl --proto '=https' --tlsv1.2 -fsSL "${url}" -o "${workdir}/${tarball}"
           echo "${ACTIONLINT_SHA256}  ${workdir}/${tarball}" | sha256sum --check --status
           tar -xzf "${workdir}/${tarball}" -C "${workdir}" actionlint
           "${workdir}/actionlint" -color

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -535,6 +535,27 @@ jobs:
         if: ${{ needs.changes.outputs.repository == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.contracts == 'true' || needs.changes.outputs.backend == 'true' }}
         run: tools/test/run-route-v2-gateway-integration.sh
 
+      - name: Repository CI / Lint GitHub Actions workflows
+        if: ${{ needs.changes.outputs.ci == 'true' }}
+        shell: bash
+        env:
+          # #2396: job 수준 env에서 runner context를 쓰는 등 context availability·표현식·스키마
+          # 오류를 PR 단계에서 사전 차단한다. 커스텀 self-hosted 러너 라벨은 .github/actionlint.yaml에 등록.
+          ACTIONLINT_VERSION: "1.7.12"
+          ACTIONLINT_SHA256: "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+          # 사전 존재하는 info/style 수준 shellcheck 잡음은 게이트 대상에서 제외하고
+          # warning 이상(실제 셸 결함)만 실패시킨다.
+          SHELLCHECK_OPTS: --severity=warning
+        run: |
+          set -euo pipefail
+          tarball="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          url="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${tarball}"
+          workdir="$(mktemp -d)"
+          curl -fsSL "${url}" -o "${workdir}/${tarball}"
+          echo "${ACTIONLINT_SHA256}  ${workdir}/${tarball}" | sha256sum --check --status
+          tar -xzf "${workdir}/${tarball}" -C "${workdir}" actionlint
+          "${workdir}/actionlint" -color
+
       - name: Repository CI / Validate issue forms
         if: ${{ needs.changes.outputs.repository == 'true' || needs.changes.outputs.docs_only == 'true' || needs.changes.outputs.ci == 'true' }}
         run: ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts f }' .github/ISSUE_TEMPLATE/*.yml

--- a/tools/ci/detect-changed-paths.sh
+++ b/tools/ci/detect-changed-paths.sh
@@ -60,7 +60,7 @@ while IFS= read -r file; do
       repository=true
       deploy=true
       ;;
-    .github/workflows/*.yml|tools/ci/**|tools/repo/**|tools/qa/**)
+    .github/workflows/*.yml|.github/actionlint.yaml|tools/ci/**|tools/repo/**|tools/qa/**)
       ci=true
       repository=true
       ;;

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -959,6 +959,13 @@ test("지속적 통합 작업과 스텝 이름은 실패 영역을 구분할 수
   assert.match(workflow, /node --test tools\/security\/\*\.test\.mjs/);
   assert.match(workflow, /Repository CI \/ Run ops tool tests/);
   assert.match(workflow, /node --test tools\/ops\/\*\.test\.mjs/);
+  // #2396: 워크플로 변경 시 actionlint 정적 검증 게이트가 pinned·checksum 검증으로 실행된다.
+  const repositoryJob = jobBlock(workflow, "repository-contracts", "backend");
+  assert.match(repositoryJob, /Repository CI \/ Lint GitHub Actions workflows/);
+  assert.match(repositoryJob, /needs\.changes\.outputs\.ci == 'true'/);
+  assert.match(repositoryJob, /ACTIONLINT_VERSION: "1\.7\.12"/);
+  assert.match(repositoryJob, /ACTIONLINT_SHA256: "[0-9a-f]{64}"/);
+  assert.match(repositoryJob, /sha256sum --check --status/);
   assert.match(releaseGateJob, /Release Gate Consistency \/ Run release gate contract tests/);
   assert.match(releaseGateJob, /node --test tools\/ci\/repository-contract\.test\.mjs/);
   assert.match(releaseGateJob, /node tools\/ci\/check-map-attribution\.mjs/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -966,6 +966,8 @@ test("지속적 통합 작업과 스텝 이름은 실패 영역을 구분할 수
   assert.match(repositoryJob, /ACTIONLINT_VERSION: "1\.7\.12"/);
   assert.match(repositoryJob, /ACTIONLINT_SHA256: "[0-9a-f]{64}"/);
   assert.match(repositoryJob, /sha256sum --check --status/);
+  // #2396(S6506): actionlint 다운로드 curl은 HTTPS·TLS 1.2 이상을 강제한다.
+  assert.match(repositoryJob, /curl --proto '=https' --tlsv1\.2 -fsSL/);
   assert.match(releaseGateJob, /Release Gate Consistency \/ Run release gate contract tests/);
   assert.match(releaseGateJob, /node --test tools\/ci\/repository-contract\.test\.mjs/);
   assert.match(releaseGateJob, /node tools\/ci\/check-map-attribution\.mjs/);
@@ -17825,6 +17827,11 @@ test("경로 분류기는 저장소, 백엔드, 모바일, Android, iOS 변경�
   const ci = await classifyChangedFiles([".github/workflows/ci.yml"]);
   assert.equal(ci.repository, "true");
   assert.equal(ci.ci, "true");
+
+  // #2396: actionlint 설정(self-hosted 러너 라벨 등록)만 바뀌어도 actionlint 게이트가 돌아야 한다.
+  const actionlintConfig = await classifyChangedFiles([".github/actionlint.yaml"]);
+  assert.equal(actionlintConfig.repository, "true");
+  assert.equal(actionlintConfig.ci, "true");
 
   const cd = await classifyChangedFiles([".github/workflows/cd.yml"]);
   assert.equal(cd.repository, "true");


### PR DESCRIPTION
## 관련 이슈

close #2396

## 작업 배경

- #2387에서 canary rollback dry-run 워크플로가 job-level env의 `runner` context 사용(GitHub 파서 무효)으로 모든 push에서 job 없는 실패 run 149회를 만들었지만, 저장소에 워크플로 정적 검증 게이트가 없어 PR CI가 잡지 못했다. actionlint는 이 클래스(context availability·표현식·스키마) 오류를 사전 차단한다.

## 작업 내용

- `.github/actionlint.yaml` 신규: self-hosted 커스텀 runner label `easysubway-production` 등록(전 22개 워크플로 runs-on 실측 — 커스텀 라벨은 이것 하나) → runner-label 오탐 7건 제거.
- `.github/workflows/ci.yml`: Repository CI job에 "Lint GitHub Actions workflows" step 추가 — `.github/workflows/*.yml` 변경 시(`changes.ci` 게이트) 실행. actionlint v1.7.12 릴리스 tarball을 sha256 checksum 검증 다운로드로 설치(버전·해시 고정, CLI 도구라 pinned action 대신 checksum 방식 — 기존 관례와 동렬). `SHELLCHECK_OPTS=--severity=warning`으로 사전 존재 info/style 잡음 6건(SC2016·SC2129·SC2295)은 게이트에서 제외하되 warning 이상 실셸 결함과 actionlint 네이티브 검사(context/expression/schema — #2387 클래스)는 그대로 실패시킨다.
- `tools/ci/repository-contract.test.mjs`: 새 step·게이트 조건·pinned 버전·checksum 검증 assertion 추가.
- 현행 전 워크플로 실측: 실오류(context/expression/schema) 0건 — 어떤 워크플로도 의미 변경 없이 게이트 통과.

## 검증

- 실행한 명령과 결과:
  - 전 워크플로 actionlint(수정 후 설정 기준) → 출력 없음, exit 0 (수정 전 baseline: runner-label 오탐 7건 + shellcheck info/style 6건, 실오류 0건)
  - RED 재현: #2387 원 결함(job-level env `${{ runner.temp }}`)을 임시 주입 → `context "runner" is not allowed here [expression]`, exit 1 (원복 완료, 미커밋)
  - `node --test tools/ci/repository-contract.test.mjs` → 219/219 pass (신규 assertion 포함)
  - actionlint v1.7.12 tarball 실다운로드로 sha256 일치 검증, ruby psych 파싱 OK(ci.yml·actionlint.yaml), `git diff --check` 클린

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 게이트 RED/GREEN | CI (actionlint) | 결함 임시 주입/원복 실행 | 본문 검증 섹션 | RED exit 1 / GREEN exit 0 |
| 전 워크플로 무회귀 | CI (actionlint) | 22개 전체 실행 | 본문 검증 섹션 | 실오류 0건 |
| 구조 테스트 | CI (Node) | repository-contract assertion | 본문 검증 섹션 | 219/219 pass |
| UI/접근성/수동 QA | — | — | 해당 없음(CI 게이트 추가만) | N/A |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: checksum 검증 다운로드 스크립트의 fail-closed 여부(해시 불일치 시 실패), shellcheck 임계값 트레이드오프(info/style 제외의 정당성 — 사전 존재 6건은 별건).

## 리스크

- `.github/actionlint.yaml` 단독 변경 PR에서는 게이트 step이 안 돈다(`detect-changed-paths.sh`가 `.github/**`를 ci로 분류하지 않는 경로 있음) — 워크플로 파일과 함께 변경될 때 유효. 매핑 확장은 범위 밖 후속.
- shellcheck info/style 6건은 게이트 제외로 남는다(사전 존재, 별건 판단).

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.