### PR TITLE
[Chore] #2397 배포 성공 후 로컬 backend 이미지 자동 정리 — 디스크 포화 재발 방지

### DIFF
--- a/tools/ci/backend-deploy.test.mjs
+++ b/tools/ci/backend-deploy.test.mjs
@@ -1124,3 +1124,58 @@ test("CD 배포는 컨테이너 교체 전에 timetable snapshot freshness를 �
   assert.doesNotMatch(staleBlock, /abort_deploy|abort_standby_stage/);
   assert.match(staleBlock, /write_result "blocked" "stale_snapshot_precheck_failed"\n\texit 1/);
 });
+
+test("배포 성공 종단은 로컬 backend 이미지를 최신 10개+실행 중으로 정리하되 실패를 전파하지 않는다", async () => {
+  await execFileAsync("bash", ["-n", "tools/deploy/deploy-backend.sh"], { cwd: root });
+  const deploy = read("tools/deploy/deploy-backend.sh");
+
+  // 정리 함수가 존재한다.
+  assert.match(deploy, /prune_stale_backend_images\(\) \{/);
+  const fnStart = deploy.indexOf("prune_stale_backend_images() {");
+  const fnEnd = deploy.indexOf("\n}\n", fnStart);
+  assert.notEqual(fnStart, -1);
+  assert.notEqual(fnEnd, -1);
+  const fnBody = deploy.slice(fnStart, fnEnd);
+
+  // 실패 무전파 구조: errexit-off 서브셸에서 실행되고 항상 0을 반환한다.
+  assert.match(fnBody, /\(\n\t\tset \+e/);
+  assert.match(fnBody, /\n\treturn 0$/);
+
+  // 보존: 실행 중 컨테이너의 이미지 ID 전부.
+  assert.match(
+    fnBody,
+    /running_ids="\$\(docker ps -q \| xargs -r docker inspect --format '\{\{\.Image\}\}'/,
+  );
+  // 보존: easysubway-backend 이미지 중 생성일 최신 10개.
+  assert.match(fnBody, /docker images easysubway-backend --no-trunc --format '\{\{\.ID\}\}'/);
+  assert.match(fnBody, /head -n 10/);
+  // 보존 대상(실행 중·최신 10개)은 삭제 루프에서 continue로 건너뛴다.
+  assert.match(fnBody, /grep -qxF "\$\{id\}" <<<"\$\{running_ids\}" && continue/);
+  assert.match(fnBody, /grep -qxF "\$\{id\}" <<<"\$\{keep_ids\}" && continue/);
+
+  // 삭제: 그 외 이미지 → dangling prune → build cache prune (이 순서로).
+  assert.match(fnBody, /docker rmi "\$\{id\}"/);
+  assert.match(fnBody, /docker image prune -f/);
+  assert.match(fnBody, /docker builder prune -af/);
+  const rmiIdx = fnBody.indexOf("docker rmi");
+  const imagePruneIdx = fnBody.indexOf("docker image prune -f");
+  const builderPruneIdx = fnBody.indexOf("docker builder prune -af");
+  assert.ok(rmiIdx < imagePruneIdx, "삭제는 dangling prune보다 먼저 수행된다");
+  assert.ok(imagePruneIdx < builderPruneIdx, "dangling prune은 build cache prune보다 먼저 수행된다");
+
+  // 로그: 삭제 개수·회수 공간을 남긴다.
+  assert.match(fnBody, /image-cleanup\(#2397\): removed %s stale easysubway-backend image\(s\)/);
+  assert.match(fnBody, /dangling reclaimed %s, build-cache reclaimed %s/);
+
+  // 성공 종단 이후에만 호출된다: 모든 trap 해제 → 성공 결과 기록 → 정리 호출.
+  const trapDisarmIdx = deploy.lastIndexOf("trap - ERR INT TERM HUP");
+  const successIdx = deploy.indexOf('write_result "success" "backend_ready"');
+  const callMatches = deploy.match(/\nprune_stale_backend_images\n/g);
+  const callIdx = deploy.indexOf("\nprune_stale_backend_images\n");
+  assert.notEqual(successIdx, -1);
+  assert.notEqual(callIdx, -1);
+  assert.equal(callMatches?.length, 1, "정리는 최종 성공 경로에서 한 번만 호출된다");
+  assert.ok(trapDisarmIdx !== -1 && trapDisarmIdx < successIdx, "정리 호출 전에 모든 trap이 해제되어 있어야 한다");
+  assert.ok(successIdx < callIdx, "정리는 성공 결과(last-result.env)가 기록된 이후에만 호출된다");
+  assert.ok(fnEnd < callIdx, "정리 호출은 함수 정의 이후에 온다");
+});

--- a/tools/ci/backend-deploy.test.mjs
+++ b/tools/ci/backend-deploy.test.mjs
@@ -1137,8 +1137,11 @@ test("배포 성공 종단은 로컬 backend 이미지를 최신 10개+실행 �
   assert.notEqual(fnEnd, -1);
   const fnBody = deploy.slice(fnStart, fnEnd);
 
-  // 실패 무전파 구조: errexit-off 서브셸에서 실행되고 항상 0을 반환한다.
+  // 실패 무전파 구조: errexit-off 서브셸에서 실행되고, 서브셸 종료코드는
+  // `|| true`로 흡수한 뒤 항상 0을 반환한다(마지막 명령 실패가 errexit를
+  // 발화시켜 성공 기록 후 exit code를 뒤집지 못하게 한다).
   assert.match(fnBody, /\(\n\t\tset \+e/);
+  assert.match(fnBody, /\n\t\) \|\| true\n/);
   assert.match(fnBody, /\n\treturn 0$/);
 
   // 보존: 실행 중 컨테이너의 이미지 ID 전부.
@@ -1154,7 +1157,8 @@ test("배포 성공 종단은 로컬 backend 이미지를 최신 10개+실행 �
   assert.match(fnBody, /grep -qxF "\$\{id\}" <<<"\$\{keep_ids\}" && continue/);
 
   // 삭제: 그 외 이미지 → dangling prune → build cache prune (이 순서로).
-  assert.match(fnBody, /docker rmi "\$\{id\}"/);
+  // -f: 다중 repository/tag·GHCR RepoDigest 참조를 가진 이미지도 강제 삭제한다.
+  assert.match(fnBody, /docker rmi -f "\$\{id\}"/);
   assert.match(fnBody, /docker image prune -f/);
   assert.match(fnBody, /docker builder prune -af/);
   const rmiIdx = fnBody.indexOf("docker rmi");

--- a/tools/deploy/deploy-backend.sh
+++ b/tools/deploy/deploy-backend.sh
@@ -736,7 +736,10 @@ prune_stale_backend_images() {
 			[[ -z "${id}" ]] && continue
 			grep -qxF "${id}" <<<"${running_ids}" && continue
 			grep -qxF "${id}" <<<"${keep_ids}" && continue
-			if docker rmi "${id}" >/dev/null 2>&1; then
+			# -f: a stale image ID can carry multiple repository/tag and GHCR
+			# RepoDigest references; plain rmi refuses to delete those, so force
+			# removal (safe — running + newest 10 are already excluded above).
+			if docker rmi -f "${id}" >/dev/null 2>&1; then
 				removed=$((removed + 1))
 			fi
 		done <<<"${all_ids}"
@@ -747,7 +750,7 @@ prune_stale_backend_images() {
 
 		printf 'image-cleanup(#2397): removed %s stale easysubway-backend image(s), kept %s newest + running; dangling reclaimed %s, build-cache reclaimed %s\n' \
 			"${removed}" "${kept:-0}" "${images_reclaimed:-0B}" "${builder_reclaimed:-0B}"
-	)
+	) || true
 	return 0
 }
 

--- a/tools/deploy/deploy-backend.sh
+++ b/tools/deploy/deploy-backend.sh
@@ -706,6 +706,51 @@ cleanup_standby() {
 	compose "${SHARED_DIR}/current-env/backend.env" "${SHARED_DIR}/current-env/compose.env" "${DEPLOY_SHA}" rm -f -s backend-standby || true
 }
 
+# --- Post-success local image hygiene (issue #2397) -------------------------
+# Reclaims host disk AFTER a deploy is already recorded as a success. On
+# 2026-07-20 the operational host's 48G root filled to 100% from 268
+# accumulated easysubway-backend images (44.7GB) + build cache (15.7GB),
+# cutting off the CD runner. GHCR remote images are already trimmed to the
+# newest 10 by actions-storage-cleanup.yml (#1686); this applies the same
+# "keep newest 10" retention to host-local easysubway-backend images (plus
+# every image ID still backing a running container — never removed regardless
+# of age) and then prunes dangling images + build cache. Best-effort by
+# contract: it is only ever called from the success epilogue below, after all
+# traps are disarmed and last-result.env already reads success, and its whole
+# body runs in an errexit-off subshell that always returns 0 — a cleanup error
+# can never fire a trap or flip a successful deploy to failed (issue #2397).
+prune_stale_backend_images() {
+	(
+		set +e
+		# Image IDs of every currently-running container are always preserved,
+		# regardless of repo or age, so nothing is removed out from under a
+		# live container (canonical backend, back-worker, observability, …).
+		running_ids="$(docker ps -q | xargs -r docker inspect --format '{{.Image}}' 2>/dev/null | sort -u)"
+		# docker images lists newest-first; dedupe by full ID and keep the 10
+		# most-recently-created as rollback candidates (mirrors #1686).
+		all_ids="$(docker images easysubway-backend --no-trunc --format '{{.ID}}' 2>/dev/null | awk '!seen[$0]++')"
+		keep_ids="$(printf '%s\n' "${all_ids}" | head -n 10)"
+
+		removed=0
+		while IFS= read -r id; do
+			[[ -z "${id}" ]] && continue
+			grep -qxF "${id}" <<<"${running_ids}" && continue
+			grep -qxF "${id}" <<<"${keep_ids}" && continue
+			if docker rmi "${id}" >/dev/null 2>&1; then
+				removed=$((removed + 1))
+			fi
+		done <<<"${all_ids}"
+
+		kept="$(grep -c . <<<"${keep_ids}")"
+		images_reclaimed="$(docker image prune -f 2>/dev/null | awk -F': ' '/Total reclaimed space/ {print $2}')"
+		builder_reclaimed="$(docker builder prune -af 2>/dev/null | awk -F': ' '/Total reclaimed space/ {print $2}')"
+
+		printf 'image-cleanup(#2397): removed %s stale easysubway-backend image(s), kept %s newest + running; dangling reclaimed %s, build-cache reclaimed %s\n' \
+			"${removed}" "${kept:-0}" "${images_reclaimed:-0B}" "${builder_reclaimed:-0B}"
+	)
+	return 0
+}
+
 abort_deploy() {
 	local detail="$1"
 	write_result "failed" "${detail}"
@@ -1038,3 +1083,9 @@ printf '%s\n' "${DEPLOY_IMAGE_DIGEST}" > "${SHARED_DIR}/current-image-digest"
 chmod 600 "${SHARED_DIR}/current-sha" "${SHARED_DIR}/current-image-digest"
 write_phase "completed"
 write_result "success" "backend_ready"
+
+# Deploy is now recorded as a success; reclaim host disk from accumulated
+# local backend images + build cache. Best-effort and non-fatal by contract
+# (see prune_stale_backend_images above) — must never change the result
+# written just above (issue #2397).
+prune_stale_backend_images


### PR DESCRIPTION
## 관련 이슈

close #2397

## 작업 배경

- 2026-07-20 운영 인시던트(#2376 코멘트 기록): 호스트 root 48G가 backend docker 이미지 268개(44.7GB)+빌드 캐시(15.7GB) 누적으로 100% 포화 → CD runner 통신 두절·배포 불능·checkout git 쓰기 실패. GHCR 원격은 `actions-storage-cleanup.yml`(최신 10개 유지, #1686)이 정리하지만 호스트 로컬 이미지는 무관리였다.

## 작업 내용

- `tools/deploy/deploy-backend.sh`: 성공 종단(`write_result "success" "backend_ready"` 직후)에 `prune_stale_backend_images` 호출 추가 — 실행 중 컨테이너 이미지 전부 + `easysubway-backend` 최신 10개(합집합) 보존, 나머지 삭제 → dangling prune → builder cache prune. 삭제 수·회수 공간을 `image-cleanup(#2397)` 로그로 기록.
- **실패 무전파 구조**: 함수 본문을 `( set +e … )` errexit-off 서브셸로 격리하고 항상 return 0 — 배포 성공 기록을 정리 오류가 뒤집을 수 없다. ERR trap 상호작용 실측: legacy-restore trap은 성공 경로에서 이미 `trap - ERR`로 해제된 뒤(1033-1034행) 정리가 호출되므로 부작용 원천 차단.
- `tools/ci/backend-deploy.test.mjs`: 정리 함수 존재·성공 종단 이후 호출·보존 로직(최신 10+실행 중)·비전파 구조 assertion 추가.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/backend-deploy.test.mjs` → 28/28 pass (신규 1건 포함)
  - `bash -n tools/deploy/deploy-backend.sh` → syntax OK
  - `shellcheck` → 신규 코드 지적 0건 (기존 SC2016 info 1건은 사전 존재·무관)
  - `git diff --check` → 클린
- 병합·배포 후 확인 예정: 운영 호스트 이미지 수(≤10+실행 중)·디스크 사용률 실측.

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 보존·비전파 계약 | CI (Node) | backend-deploy.test.mjs assertion | 본문 검증 섹션 | 28/28 pass |
| 셸 문법·정적 검사 | tools | bash -n·shellcheck | 본문 검증 섹션 | OK·신규 지적 0 |
| 실배포 정리 동작 | production | 병합 후 배포 시 호스트 실측(이미지 수·디스크) | 배포 후 확인 — 로컬 재현 불가(운영 docker 데몬 필요) | 배포 후 |
| UI/접근성/수동 QA | — | — | 해당 없음(배포 스크립트·테스트만) | N/A |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음 (배포 후처리 단계 추가 — 배포 산출물·계약 무변경)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 성공 결과 기록 이후 호출 순서와 errexit-off 서브셸 격리가 기존 `set -Eeuo pipefail`·trap 체계와 충돌하지 않는지, 보존 집합 산정(newest-first 정렬 의존)이 실행 중 이미지 별도 보존으로 안전한지.

## 리스크

- "최신 10개" 산정이 `docker images` 기본 newest-first 정렬에 의존(#1686 원격 정책과 동일 가정). 정렬 변경 시 보존 선정이 달라질 수 있으나 실행 중 이미지는 정렬 무관 별도 보존이라 라이브 컨테이너 삭제 위험 없음.
- 실동작 검증은 병합 후 첫 배포에서 호스트 실측으로 확인한다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.