### PR TITLE
[Feat] #2409 전국 공공 API 커버리지 검색 교정 — dataType·발행처·별칭 확장과 KRIC/MOLIT 후보 배선 (Phase 1)

### DIFF
--- a/tools/datapack/collect-nationwide-public-api-coverage.mjs
+++ b/tools/datapack/collect-nationwide-public-api-coverage.mjs
@@ -22,6 +22,25 @@ const CREDENTIAL_ENVS = new Set(["DATA_GO_KR_SERVICE_KEY", "KRIC_SERVICE_KEY", "
 const DATA_GO_ORGANIZATION_NAMES = new Map([
   ["korail", "한국철도공사"],
 ]);
+// 노선명 별칭 사전: 공공데이터 카탈로그가 실제로 사용하는 발행 노선명(개별 지선·주관기관 명칭)으로 확장한다.
+// data.go.kr 검색은 다단어를 AND로 처리해 0건을 양산하므로, 각 별칭을 단일 키워드 질의로 나눠 던지고
+// 후처리(matchTermGroups)로 노선·도메인 term을 교차 검증한다.
+const LINE_NAME_ALIASES = new Map([
+  ["3호선", ["일산선"]],
+  ["4호선", ["과천선", "안산선"]],
+  ["김포골드라인", ["김포도시철도"]],
+  ["동해선", ["부산동해선"]],
+]);
+// topology/positions 도메인의 실발행처(국가철도공단·국토교통부)를 built-in known-provider 후보로 배선한다.
+// source-candidates.json의 해당 도메인 후보는 대부분 allowlist 밖 endpoint라 indexKnownProviderCandidates가
+// 걸러내 knownProviderCandidateIds:[]가 되므로, 전국 단위 실발행처를 코드에 고정해 오탐(공식 미지원) 확정을 막는다.
+const BUILTIN_KNOWN_PROVIDER_CANDIDATES = Object.freeze({
+  route_graph_topology: [{ id: "kric-nationwide-station-interval-distance" }],
+  route_map_positions: [
+    { id: "kric-nationwide-station-coordinates" },
+    { id: "molit-nationwide-station-standard-data" },
+  ],
+});
 const SOURCE_DOMAIN_SEARCH = Object.freeze({
   station_line_membership: {
     terms: ["역정보", "역명", "역코드", "노선정보", "역사정보"],
@@ -29,7 +48,8 @@ const SOURCE_DOMAIN_SEARCH = Object.freeze({
     userMessageKo: "공공기관 API에서 역·노선 정보를 제공하지 않습니다.",
   },
   route_graph_topology: {
-    terms: ["역간거리", "이동거리", "소요시간", "운행시간"],
+    terms: ["역간거리", "이동거리", "소요시간", "운행시간", "구간정보", "거리표", "역위치", "좌표", "주소데이터"],
+    organizations: ["국가철도공단"],
     fallback: "STATIC_LOCAL",
     userMessageKo: "공공기관 API에서 경로 거리·소요시간 정보를 제공하지 않습니다.",
   },
@@ -49,7 +69,8 @@ const SOURCE_DOMAIN_SEARCH = Object.freeze({
     userMessageKo: "공공기관 API에서 시간표 정보를 제공하지 않습니다.",
   },
   route_map_positions: {
-    terms: ["노선도", "노선좌표", "역위치", "위도", "경도"],
+    terms: ["노선도", "노선좌표", "역위치", "위도", "경도", "좌표", "주소데이터"],
+    organizations: ["국가철도공단", "국토교통부"],
     fallback: "STATIC_LOCAL",
     userMessageKo: "공공기관 API에서 공식 노선도 좌표를 제공하지 않습니다.",
   },
@@ -68,12 +89,13 @@ export function buildNationwidePublicApiSearchPlan({ targets, fixture, sourceCan
   if (!Array.isArray(targets?.activeLineScopes) || domains.length === 0) {
     throw new Error("nationwide targets active scopes and launch domains are required");
   }
-  const knownProviderCandidatesByDomain = indexKnownProviderCandidates(sourceCandidates);
+  const knownProviderCandidatesByDomain = mergeBuiltinProviderCandidates(indexKnownProviderCandidates(sourceCandidates));
   const entries = targets.activeLineScopes.flatMap((scope) => domains.map((sourceDomain) => {
     const domain = SOURCE_DOMAIN_SEARCH[sourceDomain];
     if (!domain) throw new Error(`unsupported launch source domain: ${sourceDomain}`);
     const fixtureOperatorName = requiredString(operators.get(scope.operatorId), `operator ${scope.operatorId}`);
     const operatorName = DATA_GO_ORGANIZATION_NAMES.get(scope.operatorId) ?? fixtureOperatorName;
+    const organizations = [...new Set([operatorName, ...(domain.organizations ?? [])])];
     const lineName = requiredString(lines.get(scope.lineId), `line ${scope.lineId}`);
     const lineTerms = lineSearchTerms(lineName);
     return {
@@ -86,13 +108,13 @@ export function buildNationwidePublicApiSearchPlan({ targets, fixture, sourceCan
         .map(({ id }) => id),
       queries: [
         ...lineTerms.map((keyword) => publicApiSearchQuery({
-          operatorName,
+          organizations,
           keyword,
           coverageScope: "LINE_EVIDENCE",
           matchTermGroups: [domain.terms, lineTerms],
         })),
         ...domain.terms.map((keyword) => publicApiSearchQuery({
-          operatorName,
+          organizations,
           keyword,
           coverageScope: "OPERATOR_DISCOVERY",
           matchTermGroups: [domain.terms],
@@ -108,7 +130,7 @@ export function buildNationwidePublicApiSearchPlan({ targets, fixture, sourceCan
   };
 }
 
-function publicApiSearchQuery({ operatorName, keyword, coverageScope, matchTermGroups }) {
+function publicApiSearchQuery({ organizations, keyword, coverageScope, matchTermGroups }) {
   return {
     providerId: "data-go-search",
     endpoint: "https://api.odcloud.kr/api/GetSearchDataList/v1/searchData",
@@ -120,8 +142,17 @@ function publicApiSearchQuery({ operatorName, keyword, coverageScope, matchTermG
     format: "json",
     coverageScope,
     matchTermGroups,
-    query: { page: 0, size: 10_000, dataType: ["API"], organizations: [operatorName], keyword },
+    query: { page: 0, size: 10_000, dataType: ["API", "FILE", "STANDARD"], organizations, keyword },
   };
+}
+
+function mergeBuiltinProviderCandidates(indexed) {
+  for (const [domain, builtins] of Object.entries(BUILTIN_KNOWN_PROVIDER_CANDIDATES)) {
+    const merged = [...(indexed.get(domain) ?? []), ...builtins];
+    indexed.set(domain, [...new Map(merged.map((candidate) => [candidate.id, candidate])).values()]
+      .sort((a, b) => alphabeticalCompare(a.id, b.id)));
+  }
+  return indexed;
 }
 
 function lineSearchTerms(lineName) {
@@ -131,6 +162,7 @@ function lineSearchTerms(lineName) {
   if (!base.endsWith("선") && !base.endsWith("호선")) aliases.push(`${base}선`);
   if (base === "공항") aliases.push("공항철도");
   if (base === "의정부") aliases.push("의정부경전철");
+  aliases.push(...(LINE_NAME_ALIASES.get(base) ?? []));
   return [...new Set(aliases)];
 }
 

--- a/tools/datapack/collect-nationwide-public-api-coverage.mjs
+++ b/tools/datapack/collect-nationwide-public-api-coverage.mjs
@@ -148,7 +148,7 @@ function publicApiSearchQuery({ organizations, keyword, coverageScope, matchTerm
 
 function mergeBuiltinProviderCandidates(indexed) {
   for (const [domain, builtins] of Object.entries(BUILTIN_KNOWN_PROVIDER_CANDIDATES)) {
-    const merged = [...(indexed.get(domain) ?? []), ...builtins];
+    const merged = [...builtins, ...(indexed.get(domain) ?? [])];
     indexed.set(domain, [...new Map(merged.map((candidate) => [candidate.id, candidate])).values()]
       .sort((a, b) => alphabeticalCompare(a.id, b.id)));
   }

--- a/tools/datapack/collect-nationwide-public-api-coverage.test.mjs
+++ b/tools/datapack/collect-nationwide-public-api-coverage.test.mjs
@@ -917,4 +917,3 @@ test("같은 id의 builtin과 catalog 후보 충돌 시 catalog 후보의 필드
   assert.equal(candidateIds.length, 1);
   assert.equal(candidateIds[0], "kric-nationwide-station-interval-distance");
 });
-

--- a/tools/datapack/collect-nationwide-public-api-coverage.test.mjs
+++ b/tools/datapack/collect-nationwide-public-api-coverage.test.mjs
@@ -244,12 +244,17 @@ test("지역 전용 provider 후보는 다른 지역의 공식 미지원 판정�
     },
   });
 
+  // route_graph_topology는 국가철도공단 전국 built-in 후보를 항상 배선한다. 지역 전용 후보(daejeon)는
+  // 자기 scope에만 더해지므로 busan은 전국 후보만, daejeon은 전국 후보 + 지역 후보를 갖는다.
   assert.deepEqual(searchPlan.entries.map(({ lineId, knownProviderCandidateIds }) => ({
     lineId,
     knownProviderCandidateIds,
   })), [
-    { lineId: "busan-1", knownProviderCandidateIds: [] },
-    { lineId: "daejeon-1", knownProviderCandidateIds: ["daejeon-station-distance-fare"] },
+    { lineId: "busan-1", knownProviderCandidateIds: ["kric-nationwide-station-interval-distance"] },
+    {
+      lineId: "daejeon-1",
+      knownProviderCandidateIds: ["daejeon-station-distance-fare", "kric-nationwide-station-interval-distance"],
+    },
   ]);
 });
 
@@ -318,6 +323,208 @@ test("공공데이터 검색이 거부하는 GTX-A 문장부호는 안전한 ali
     "실제일시",
   ]);
   assert.deepEqual(searchPlan.entries[0].queries[0].matchTermGroups[1], ["GTXA"]);
+});
+
+test("공공데이터 검색은 API·FILE·STANDARD dataType과 도메인 실발행처를 함께 조회한다", () => {
+  const searchPlan = buildNationwidePublicApiSearchPlan({
+    targets: {
+      targetVersion: "2026-07-13",
+      activeLineScopes: [{ regionId: "capital", operatorId: "korail", lineId: "korail-1" }],
+      requiredSourceDomains: [
+        { id: "route_graph_topology", releaseTier: "LAUNCH_REQUIRED" },
+        { id: "route_map_positions", releaseTier: "LAUNCH_REQUIRED" },
+        { id: "realtime_arrivals", releaseTier: "LAUNCH_REQUIRED" },
+      ],
+    },
+    fixture: {
+      packs: [{
+        operators: [{ id: "korail", nameKo: "코레일" }],
+        lines: [{ id: "korail-1", nameKo: "수도권 1호선" }],
+      }],
+    },
+  });
+
+  const byDomain = new Map(searchPlan.entries.map((entry) => [entry.sourceDomain, entry]));
+  for (const entry of searchPlan.entries) {
+    for (const { query } of entry.queries) {
+      assert.deepEqual(query.dataType, ["API", "FILE", "STANDARD"]);
+    }
+  }
+  // topology는 국가철도공단, positions는 국가철도공단·국토교통부를 실발행처로 함께 조회한다.
+  assert.deepEqual(byDomain.get("route_graph_topology").queries[0].query.organizations, ["한국철도공사", "국가철도공단"]);
+  assert.deepEqual(
+    byDomain.get("route_map_positions").queries[0].query.organizations,
+    ["한국철도공사", "국가철도공단", "국토교통부"],
+  );
+  // realtime_arrivals 도메인은 실발행처를 추가하지 않아 운영기관만 조회한다(기존 계약 유지).
+  assert.deepEqual(byDomain.get("realtime_arrivals").queries[0].query.organizations, ["한국철도공사"]);
+});
+
+test("route_graph_topology 검색은 역간거리 대체 명칭까지 후처리 term으로 검증한다", () => {
+  const searchPlan = buildNationwidePublicApiSearchPlan({
+    targets: {
+      targetVersion: "2026-07-13",
+      activeLineScopes: [{ regionId: "capital", operatorId: "korail", lineId: "korail-1" }],
+      requiredSourceDomains: [{ id: "route_graph_topology", releaseTier: "LAUNCH_REQUIRED" }],
+    },
+    fixture: {
+      packs: [{
+        operators: [{ id: "korail", nameKo: "코레일" }],
+        lines: [{ id: "korail-1", nameKo: "수도권 1호선" }],
+      }],
+    },
+  });
+
+  const domainTerms = searchPlan.entries[0].queries[0].matchTermGroups[0];
+  for (const alt of ["역간거리", "구간정보", "거리표", "역위치", "좌표", "주소데이터"]) {
+    assert.ok(domainTerms.includes(alt), `${alt} must be a topology match term`);
+  }
+});
+
+test("노선명 별칭 사전은 지선·주관기관 발행 명칭을 검색 키워드로 확장한다", () => {
+  const searchPlan = buildNationwidePublicApiSearchPlan({
+    targets: {
+      targetVersion: "2026-07-13",
+      activeLineScopes: [
+        { regionId: "capital", operatorId: "korail", lineId: "line-3" },
+        { regionId: "capital", operatorId: "korail", lineId: "line-4" },
+        { regionId: "busan", operatorId: "korail", lineId: "donghae" },
+        { regionId: "capital", operatorId: "gimpo-goldline", lineId: "gimpo" },
+      ],
+      requiredSourceDomains: [{ id: "route_graph_topology", releaseTier: "LAUNCH_REQUIRED" }],
+    },
+    fixture: {
+      packs: [{
+        operators: [
+          { id: "korail", nameKo: "코레일" },
+          { id: "gimpo-goldline", nameKo: "김포골드라인운영" },
+        ],
+        lines: [
+          { id: "line-3", nameKo: "수도권 3호선" },
+          { id: "line-4", nameKo: "수도권 4호선" },
+          { id: "donghae", nameKo: "동해선" },
+          { id: "gimpo", nameKo: "김포골드라인" },
+        ],
+      }],
+    },
+  });
+
+  const keywordsByLine = new Map(searchPlan.entries.map((entry) => [
+    entry.lineId,
+    entry.queries.map(({ query }) => query.keyword),
+  ]));
+  assert.ok(keywordsByLine.get("line-3").includes("일산선"));
+  assert.ok(keywordsByLine.get("line-4").includes("과천선"));
+  assert.ok(keywordsByLine.get("line-4").includes("안산선"));
+  assert.ok(keywordsByLine.get("donghae").includes("부산동해선"));
+  assert.ok(keywordsByLine.get("gimpo").includes("김포도시철도"));
+});
+
+test("topology·positions는 KRIC·MOLIT 전국 후보를 배선해 catalog 0건을 미지원으로 확정하지 않는다", async () => {
+  const searchPlan = buildNationwidePublicApiSearchPlan({
+    targets: {
+      targetVersion: "2026-07-13",
+      activeLineScopes: [{ regionId: "incheon", operatorId: "incheon-transit", lineId: "incheon-1" }],
+      requiredSourceDomains: [
+        { id: "route_graph_topology", releaseTier: "LAUNCH_REQUIRED" },
+        { id: "route_map_positions", releaseTier: "LAUNCH_REQUIRED" },
+      ],
+    },
+    fixture: {
+      packs: [{
+        operators: [{ id: "incheon-transit", nameKo: "인천교통공사" }],
+        lines: [{ id: "incheon-1", nameKo: "인천 1호선" }],
+      }],
+    },
+  });
+
+  const byDomain = new Map(searchPlan.entries.map((entry) => [entry.sourceDomain, entry]));
+  assert.deepEqual(
+    byDomain.get("route_graph_topology").knownProviderCandidateIds,
+    ["kric-nationwide-station-interval-distance"],
+  );
+  assert.deepEqual(
+    byDomain.get("route_map_positions").knownProviderCandidateIds,
+    ["kric-nationwide-station-coordinates", "molit-nationwide-station-standard-data"],
+  );
+
+  const resolutions = await collectNationwidePublicApiCoverage({
+    searchPlan,
+    credentials: { DATA_GO_KR_SERVICE_KEY: "key" },
+    fetchImpl: async () => new Response(JSON.stringify({
+      statusCode: 200,
+      result: { sum: 0, dataCount: 0, data: [] },
+    }), { status: 200, headers: { "content-type": "application/json" } }),
+    now: new Date("2026-07-13T00:00:00.000Z"),
+  });
+
+  assert.equal(resolutions.entries.length, 0);
+  assert.deepEqual(resolutions.unresolved.map(({ sourceDomain, reasonCode, providerCandidateIds }) => ({
+    sourceDomain,
+    reasonCode,
+    providerCandidateIds,
+  })), [
+    {
+      sourceDomain: "route_graph_topology",
+      reasonCode: "KNOWN_PROVIDER_REQUIRES_LINE_VALIDATION",
+      providerCandidateIds: ["kric-nationwide-station-interval-distance"],
+    },
+    {
+      sourceDomain: "route_map_positions",
+      reasonCode: "KNOWN_PROVIDER_REQUIRES_LINE_VALIDATION",
+      providerCandidateIds: ["kric-nationwide-station-coordinates", "molit-nationwide-station-standard-data"],
+    },
+  ]);
+});
+
+test("감사 반증 FILE dataset(국가철도공단 발행)은 교정된 질의로 검출돼 공식 미지원을 뒤집는다", async () => {
+  const searchPlan = buildNationwidePublicApiSearchPlan({
+    targets: {
+      targetVersion: "2026-07-13",
+      activeLineScopes: [{ regionId: "capital", operatorId: "korail", lineId: "korail-1" }],
+      requiredSourceDomains: [{ id: "route_graph_topology", releaseTier: "LAUNCH_REQUIRED" }],
+    },
+    fixture: {
+      packs: [{
+        operators: [{ id: "korail", nameKo: "코레일" }],
+        lines: [{ id: "korail-1", nameKo: "수도권 1호선" }],
+      }],
+    },
+  });
+
+  let firstQuery;
+  const resolutions = await collectNationwidePublicApiCoverage({
+    searchPlan,
+    credentials: { DATA_GO_KR_SERVICE_KEY: "key" },
+    fetchImpl: async (_url, init) => {
+      firstQuery ??= JSON.parse(init.body);
+      return new Response(JSON.stringify({
+        statusCode: 200,
+        result: {
+          sum: 1,
+          dataCount: 1,
+          data: [{
+            dataName: "국가철도공단_수도권1호선_역간거리",
+            organization: "국가철도공단",
+            dataType: "FILE",
+          }],
+        },
+      }), { status: 200, headers: { "content-type": "application/json" } });
+    },
+    now: new Date("2026-07-13T00:00:00.000Z"),
+  });
+
+  // 반증 dataset이 검출되면 EXPLICITLY_UNSUPPORTED로 확정하지 않는다.
+  assert.equal(resolutions.entries.length, 0);
+  assert.equal(resolutions.unresolved[0].reasonCode, "PUBLIC_API_DATA_AVAILABLE");
+  assert.deepEqual(resolutions.unresolved[0].matches, [{
+    dataName: "국가철도공단_수도권1호선_역간거리",
+    organization: "국가철도공단",
+    dataType: "FILE",
+  }]);
+  // 검출이 성립하려면 교정된 질의가 FILE dataType과 국가철도공단 발행처를 실제로 조회해야 한다.
+  assert.deepEqual(firstQuery.dataType, ["API", "FILE", "STANDARD"]);
+  assert.ok(firstQuery.organizations.includes("국가철도공단"));
 });
 
 test("공공기관 API 정상 0건만 공식 미지원 resolution을 생성한다", async () => {

--- a/tools/datapack/collect-nationwide-public-api-coverage.test.mjs
+++ b/tools/datapack/collect-nationwide-public-api-coverage.test.mjs
@@ -885,3 +885,36 @@ test("sanitized 진단은 reason과 transport code별 건수만 고정한다", (
     transportReason: "ENOTFOUND\nnever-print-this-key",
   }]).join(","), /never-print-this-key|\n/);
 });
+
+test("같은 id의 builtin과 catalog 후보 충돌 시 catalog 후보의 필드를 보존한다", () => {
+  const searchPlan = buildNationwidePublicApiSearchPlan({
+    targets: {
+      targetVersion: "2026-07-13",
+      activeLineScopes: [{ regionId: "capital", operatorId: "korail", lineId: "korail-1" }],
+      requiredSourceDomains: [{ id: "route_graph_topology", releaseTier: "LAUNCH_REQUIRED" }],
+    },
+    fixture: {
+      packs: [{
+        operators: [{ id: "korail", nameKo: "코레일" }],
+        lines: [{ id: "korail-1", nameKo: "수도권 1호선" }],
+      }],
+    },
+    sourceCandidates: {
+      // builtin과 같은 id를 가지는 catalog 후보를 추가한다.
+      // builtin은 { id: "kric-nationwide-station-interval-distance" } 형태이고,
+      // catalog에서는 온전한 객체를 전달한다.
+      candidates: [{
+        id: "kric-nationwide-station-interval-distance",
+        domain: "route_graph_topology",
+        requestUrl: "https://openapi.kric.go.kr/api/override",
+        // coverageScope를 명시하지 않음: 필터링을 통과하고, 병합 후 builtin 필드와 함께 보존됨
+      }],
+    },
+  });
+
+  // catalog 후보가 builtin을 덮어써서, 온전한 필드들이 보존되어야 한다.
+  const candidateIds = searchPlan.entries[0].knownProviderCandidateIds;
+  assert.equal(candidateIds.length, 1);
+  assert.equal(candidateIds[0], "kric-nationwide-station-interval-distance");
+});
+


### PR DESCRIPTION
<!-- B/C등급(일반 코드 변경·낮은 위험 maintenance) 전용. A등급(제품/운영 위험, CI/계약 테스트/release gate 변경)은 full.md를 사용합니다. -->

## 관련 이슈

Refs #2409

## 작업 내용

- `collect-nationwide-public-api-coverage.mjs` 검색 질의 교정: `dataType`을 `API`+`FILE`+`STANDARD`로 확장하고, topology/positions 도메인 `organizations`에 실발행처(국가철도공단, positions는 국토교통부 포함)를 운영기관과 dedup 병합해 추가했습니다.
- 노선명 별칭 사전(`LINE_NAME_ALIASES`: 3호선↔일산선, 4호선↔과천선·안산선, 김포골드라인↔김포도시철도, 동해선↔부산동해선)과 topology/positions 대체 명칭(`구간정보`·`거리표`·`역위치`·`좌표`·`주소데이터`)을 단일 키워드 질의로 분리 발사하고 `matchTermGroups` 후처리로 교차 검증해 다단어 AND 0건 아티팩트를 회피합니다.
- topology/positions의 `knownProviderCandidateIds:[]` 배선 공백을 built-in 전국 후보(KRIC 역간거리·역좌표, MOLIT 표준데이터)로 해소해, catalog 0건만으로 두 도메인이 미지원 확정되지 않도록 가드했습니다.
- 감사 반증 oracle 회귀 테스트: 반증 dataset(예: 국가철도공단_수도권1호선_역간거리, FILE) 검출 시 미지원 확정이 뒤집히는 검출 축과, 검색 0건이어도 built-in 후보가 fail-closed로 확정을 저지하는 가드 축을 각각 단언합니다.
- resolutions ledger·coverage 집계·source-candidates·source-inventory는 변경하지 않았습니다(재크롤·재생성은 #2409 Phase 2).

## 검증

- 실행한 명령과 결과:
  - `git diff --check` — 통과
  - `node --test tools/datapack/collect-nationwide-public-api-coverage.test.mjs` — 25/25 통과 (신규 6건 포함)
  - `node --test tools/datapack/*.test.mjs` — 1,345/1,345 통과
  - `node tools/ci/check-contracts.mjs` — 통과 (exit 0)
  - `node --test tools/ci/repository-contract.test.mjs` — 220/220 통과 (계약 테스트 무수정)

## 영향

- [x] 제품/운영 위험 없음 (route/accessibility/mobile UX/backend API/auth/security 아님)
- [x] DB migration 없음
- [x] 배포 영향 없음
- [x] route/realtime/datapack contract 영향 없음
- [x] CI workflow·계약 테스트·release gate JSON 변경 없음 (있으면 full.md로 전환)

## 체크리스트

- [x] 이 PR은 B/C등급 작업이며 full template이 필요 없다.
- [ ] CI 결과를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 폴백 리뷰를 단일 PR review로 게시했다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 전국 공공데이터 검색 범위가 확대되어 API, 파일, 표준데이터를 함께 조회합니다.
  * 여러 발행기관을 기준으로 데이터를 검색해 기관별 공개 데이터를 더 정확히 찾습니다.
  * 철도 노선의 별칭과 대체 명칭을 지원해 검색 누락을 줄였습니다.
  * 전국 및 지역별 데이터 제공 후보를 함께 확인하여 지원 여부 판정의 정확도를 높였습니다.

* **테스트**
  * 다양한 기관, 노선 별칭, 파일 데이터에 대한 검색 및 지원 여부 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->