### PR TITLE
[Fix] #2417 #2415 병합 후 접근성 보완

### DIFF
--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -3235,6 +3235,7 @@ class _NetworkMapMenuHeader extends StatelessWidget {
                 image: AssetImage('assets/branding/app_icon/app_icon.png'),
                 width: 44,
                 height: 44,
+                excludeFromSemantics: true,
               ),
               SizedBox(width: 12),
               Expanded(

--- a/apps/mobile/lib/onboarding.dart
+++ b/apps/mobile/lib/onboarding.dart
@@ -749,8 +749,16 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                 top: 0,
                 left: EasySubwaySpacing.sm,
                 child: IconButton(
+                  key: const Key('onboardingBackButton'),
                   tooltip: '이전 단계',
                   onPressed: _goBack,
+                  style: IconButton.styleFrom(
+                    backgroundColor: EasySubwayAccessibleColors.surface,
+                    foregroundColor: EasySubwayAccessibleColors.text,
+                    minimumSize: const Size.square(
+                      EasySubwayTouchTarget.general,
+                    ),
+                  ),
                   icon: const Icon(Icons.arrow_back),
                 ),
               ),

--- a/apps/mobile/test/onboarding_test.dart
+++ b/apps/mobile/test/onboarding_test.dart
@@ -466,6 +466,35 @@ void main() {
     );
   });
 
+  testWidgets('권한 화면 이전 버튼은 큰 글자 스크롤 위에서 불투명 표면을 유지한다', (tester) async {
+    tester.view.physicalSize = const Size(360, 640);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(textScaler: TextScaler.linear(2)),
+        child: MaterialApp(home: OnboardingScreen(onCompleted: (_) {})),
+      ),
+    );
+    await tester.tap(find.byKey(const Key('onboardingDoneButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(SingleChildScrollView), findsOneWidget);
+    final backButton = tester.widget<IconButton>(
+      find.byKey(const Key('onboardingBackButton')),
+    );
+    expect(
+      backButton.style?.backgroundColor?.resolve(<WidgetState>{}),
+      EasySubwayAccessibleColors.surface,
+    );
+    expect(
+      backButton.style?.minimumSize?.resolve(<WidgetState>{}),
+      const Size.square(EasySubwayTouchTarget.general),
+    );
+  });
+
   testWidgets('온보딩 프로필 묶음은 아래로 내리고 선택 상태를 은은한 보라색 원으로 표시한다', (tester) async {
     tester.view.physicalSize = const Size(360, 800);
     tester.view.devicePixelRatio = 1;

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1120,6 +1120,12 @@ void main() {
       tester.getSize(find.byKey(const Key('networkMapMenuAppIcon'))),
       const Size.square(44),
     );
+    expect(
+      tester
+          .widget<Image>(find.byKey(const Key('networkMapMenuAppIcon')))
+          .excludeFromSemantics,
+      isTrue,
+    );
     expect(find.byKey(const Key('networkMapMenuNearbyButton')), findsNothing);
     expect(find.text('탐색'), findsNothing);
     expect(find.text('내 정보'), findsNothing);


### PR DESCRIPTION
## 관련 이슈

Closes #2417

## 작업 배경

PR #2415(main `11b2fd598`) 병합 시 CodeRabbit/Codex 한도로 대체 reviewer가 지적한 접근성 2건이 main에 포함되지 않았다. 병합 후 로컬 커밋(`3cc70afb3`)을 main 기준 후속 PR로 분리 반영한다.

## 작업 내용

- 노선도 메뉴 헤더 앱 아이콘 `Image`에 `excludeFromSemantics: true` 추가(장식용, 중복 낭독 방지)
- 온보딩 권한 단계 뒤로가기 `IconButton`에 `onboardingBackButton` Key, 불투명 surface 배경, `EasySubwayTouchTarget.general` 최소 터치 영역 적용
- `widget_test.dart`: 메뉴 아이콘 semantics 제외 검증
- `onboarding_test.dart`: 큰 글자(2x) 권한 화면 뒤로가기 surface·터치 영역 회귀 테스트

## 검증

- 실행한 명령과 결과:
  - `dart format lib/network_map.dart lib/onboarding.dart test/onboarding_test.dart test/widget_test.dart` — OK
  - `flutter analyze lib test` — No issues found
  - `flutter test` — 1,563 passed
  - `node --test tools/ci/repository-contract.test.mjs` — 220 passed

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 메뉴 아이콘 semantics 제외 | 공통 | widget test | `widget_test.dart` `excludeFromSemantics` assertion | pass |
| 온보딩 권한 뒤로가기 surface | 공통 | widget test | `onboarding_test.dart` 2x textScaler 회귀 | pass |
| Android/iOS 수동 a11y | Android/iOS | TalkBack/VoiceOver | 후속 QA 예정 | 미실행(테스트로 1차 검증) |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `network_map.dart` `_NetworkMapMenuHeader` Image semantics, `onboarding.dart` Positioned back IconButton style/key, 신규 회귀 테스트 2건

## 리스크

- UI 미세 변경(뒤로가기 배경 surface)만 있으며 기능·데이터·API 영향 없음

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.

Made with [Cursor](https://cursor.com)