### PR TITLE
[Fix] #2422 Sonar New Code Security VULN 15건 해소

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
           node-version: "24"
 
       - name: Admin QA Gates / Install pinned QA tools
-        run: npm ci --prefix tools/qa
+        run: npm ci --prefix tools/qa --ignore-scripts
 
       - name: Admin QA Gates / Run static QA gates
         env:

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -389,7 +389,7 @@ jobs:
           DEPLOY_PUBLIC_API_BASE_URL: ${{ vars.DEPLOY_PUBLIC_API_BASE_URL }}
         run: |
           set -euo pipefail
-          flutter pub get
+          flutter pub get --enforce-lockfile
           ../../tools/mobile/validate-release-dart-defines.sh \
             --dart-define=EASYSUBWAY_API_BASE_URL="${DEPLOY_PUBLIC_API_BASE_URL}" \
             --dart-define=EASYSUBWAY_TERMS_OF_SERVICE_URL="${EASYSUBWAY_TERMS_OF_SERVICE_URL}" \

--- a/apps/mobile/release/post-launch-operations-review-gate.json
+++ b/apps/mobile/release/post-launch-operations-review-gate.json
@@ -58,7 +58,7 @@
             {"path": "tools/ops/generate-operations-phase-a-summary.mjs", "sha256": "e89a520d6b229c5fd042ef8bcaf74873476c7253cd03b48fac1de21cf55e0c4d"},
             {"path": "tools/ops/validate-operations-release-summary.mjs", "sha256": "71a2a51da2b9c3a20d14512b608bccfbfee9022ca5718b77d44ff9254cc67979"},
             {"path": "tools/release/summary-validation-utils.mjs", "sha256": "d6c8980536e6aba14d9d2f41879339c434759bfa986aca2045d6bf5909fe0d8e"},
-            {"path": "tools/release/hash-android-bundle-payload.mjs", "sha256": "86b5e211f2f8be3308092f71613fdca1b88dfa9fc9b3101d4ba384236d945c9f"},
+            {"path": "tools/release/hash-android-bundle-payload.mjs", "sha256": "0bea0f2d7775960a4672e27622aa32a239cabadad07399cb3ee51ae524b234eb"},
             {"path": "tools/datapack/run-emergency-datapack-drill.mjs", "sha256": "d371ece038c80d6ba9e50798528339344d3a314e983085aa4b8d3009813d83e7"},
             {"path": "apps/mobile/release/route-commercialization-gate.json", "sha256": "0ac7b2c2ee1e75fc556fa5418ddeac1473d329d2ccd5a1e539e8aced869cab30"}
           ]

--- a/apps/mobile/release/post-launch-operations-review-gate.json
+++ b/apps/mobile/release/post-launch-operations-review-gate.json
@@ -96,7 +96,7 @@
           "files": [
             {"path": "apps/mobile/release/signed-release-artifact-gate.json", "sha256": "42c9f83dca5a1c2c24d921cf6ab748c9be5a901dd1b62212a81055098349fc67"},
             {"path": "apps/mobile/pubspec.yaml", "sha256": "1c4918747c4acf22bbe885b7cb01cc34cc311e7e44598ac6b817848712614d42"},
-            {"path": ".github/workflows/release-artifacts.yml", "sha256": "b430a8f8cbe0278b126d6347c1d3e4d21c541e9893ac387ce32720d567f4a276"},
+            {"path": ".github/workflows/release-artifacts.yml", "sha256": "702f8c80aa7cf793f30eb5072dcca51c2f8d8a92df552c8d615d6e8c3dd4d0e0"},
             {"path": ".github/workflows/datapack-release.yml", "sha256": "0927e5dc0cf4bf04136d9ff7612d14c892ccec1c21e8655b703a10f22556ccea"},
             {"path": "tools/ci/validate-store-privacy-env.mjs", "sha256": "18bb0dd8b93d6268c8f60f9cc12272d2ff31c03b60fbbafd6c1e8d16957ada2a"},
             {"path": "backend/build.gradle", "sha256": "00106be89d1834db166c0c4cfba04674e2a456e7e57648595b74feb933c31273"},

--- a/tools/ops/verify-production-route-v2-capacity.sh
+++ b/tools/ops/verify-production-route-v2-capacity.sh
@@ -428,7 +428,8 @@ fi
 
 backend_ready=false
 for _ in $(seq 1 120); do
-	if [[ "$(docker exec "${clone_curl}" curl -sS --noproxy '*' --connect-timeout 1 --max-time 2 -o /dev/null -w '%{http_code}' "http://backend:8080/actuator/health/readiness" 2>/dev/null || true)" == 200 ]]; then
+	# 격리된 내부 docker 네트워크(backend) 전용 평문 HTTP, TLS는 프로덕션 엣지에서 종단한다.
+	if [[ "$(docker exec "${clone_curl}" curl -sS --noproxy '*' --connect-timeout 1 --max-time 2 -o /dev/null -w '%{http_code}' "http://backend:8080/actuator/health/readiness" 2>/dev/null || true)" == 200 ]]; then # NOSONAR
 		backend_ready=true
 		break
 	fi
@@ -450,7 +451,7 @@ docker run -d --name "${clone_gateway}" --network "${network}" --network-alias g
 	-v "${PWD}/infra/nginx/route-v2-gateway.conf.template:/etc/nginx/templates/default.conf.template:ro" \
 	-v "${PWD}/infra/nginx/route-v2-proxy-headers.conf.template:/etc/nginx/templates/route-v2-proxy-headers.inc.template:ro" \
 	"${gateway_image}" nginx -g 'daemon off;' >/dev/null
-gateway_base="http://gateway:8081"
+gateway_base="http://gateway:8081" # NOSONAR -- 격리된 내부 docker 네트워크(gateway) 전용 평문 HTTP, TLS는 프로덕션 엣지에서 종단한다.
 gateway_ready=false
 for _ in $(seq 1 60); do
 	if [[ "$(docker exec "${clone_curl}" curl -sS --noproxy '*' --connect-timeout 1 --max-time 2 -o /dev/null -w '%{http_code}' "${gateway_base}/" 2>/dev/null || true)" == 404 ]]; then

--- a/tools/ops/verify-production-timetable-snapshot.sh
+++ b/tools/ops/verify-production-timetable-snapshot.sh
@@ -180,7 +180,7 @@ run_backend_clone 30 -d --name "${cache_app}" --network "${production_network}" 
 	"${backend_image}" >/dev/null
 cache_binding="$(docker port "${cache_app}" 8080/tcp)"
 [[ "${cache_binding}" =~ ^127\.0\.0\.1:[0-9]+$ ]] || { echo 'controlled cache application port binding is invalid' >&2; exit 1; }
-cache_base_url="http://${cache_binding}"
+cache_base_url="http://${cache_binding}" # NOSONAR -- 로컬 루프백(127.0.0.1) 컨테이너 전용 평문 HTTP 프로브로 외부 노출이 없다.
 origin_secret="$(node -e '
 const entries = JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8"));
 const entry = entries.find((value) => value.startsWith("EASYSUBWAY_ROUTE_V2_ORIGIN_SECRET="));

--- a/tools/release/hash-android-bundle-payload.mjs
+++ b/tools/release/hash-android-bundle-payload.mjs
@@ -10,8 +10,17 @@ if (!aabPath || !existsSync(aabPath)) {
   throw new Error("--aab must reference an existing Android App Bundle");
 }
 
+// unzip을 이름으로 호출하면 쓰기 가능한 PATH를 상속하므로, 신뢰된 시스템 경로에서
+// 절대 경로를 한 번만 해석해 PATH 조작을 차단한다(macOS·Linux CI 모두 /usr/bin/unzip).
+const unzipBinary = ["/usr/bin/unzip", "/bin/unzip", "/usr/local/bin/unzip", "/opt/homebrew/bin/unzip"].find(
+  (candidate) => existsSync(candidate),
+);
+if (!unzipBinary) {
+  throw new Error("unzip executable was not found in a trusted system path");
+}
+
 const signatureEntry = /^META-INF\/(?:MANIFEST\.MF|[^/]+\.(?:SF|RSA|DSA|EC))$/i;
-const entries = execFileSync("unzip", ["-Z1", aabPath], {
+const entries = execFileSync(unzipBinary, ["-Z1", aabPath], {
   encoding: "utf8",
   maxBuffer: 16 * 1024 * 1024,
 })
@@ -26,7 +35,7 @@ if (entries.length === 0) {
 const digest = createHash("sha256");
 for (const entry of entries) {
   const entryName = Buffer.from(entry, "utf8");
-  const contents = execFileSync("unzip", ["-p", aabPath, entry], {
+  const contents = execFileSync(unzipBinary, ["-p", aabPath, entry], {
     encoding: "buffer",
     maxBuffer: 512 * 1024 * 1024,
   });

--- a/tools/release/hash-android-bundle-payload.mjs
+++ b/tools/release/hash-android-bundle-payload.mjs
@@ -10,11 +10,9 @@ if (!aabPath || !existsSync(aabPath)) {
   throw new Error("--aab must reference an existing Android App Bundle");
 }
 
-// unzip을 이름으로 호출하면 쓰기 가능한 PATH를 상속하므로, 신뢰된 시스템 경로에서
-// 절대 경로를 한 번만 해석해 PATH 조작을 차단한다(macOS·Linux CI 모두 /usr/bin/unzip).
-const unzipBinary = ["/usr/bin/unzip", "/bin/unzip", "/usr/local/bin/unzip", "/opt/homebrew/bin/unzip"].find(
-  (candidate) => existsSync(candidate),
-);
+// unzip을 이름으로 호출하면 쓰기 가능한 PATH를 상속하므로, root 소유 고정 경로에서만
+// 절대 경로를 해석해 PATH 조작을 차단한다(macOS·Linux CI: /usr/bin/unzip).
+const unzipBinary = ["/usr/bin/unzip", "/bin/unzip"].find((candidate) => existsSync(candidate));
 if (!unzipBinary) {
   throw new Error("unzip executable was not found in a trusted system path");
 }

--- a/tools/route-map/pack-io.mjs
+++ b/tools/route-map/pack-io.mjs
@@ -46,9 +46,13 @@ export function openPack(packRelPath, tmpPrefix) {
  * 갱신된 `byteSize`와 gz `sha256`을 돌려준다.
  */
 export function writePack({ sqlitePath, packPath, packRelPath, indexRelPath }) {
+  const resolvedPackPath = resolveWithinRepo(packRelPath);
+  if (path.resolve(packPath) !== resolvedPackPath) {
+    throw new Error(`packPath가 packRelPath와 일치하지 않는다: ${packPath}`);
+  }
   const sqliteBytes = readFileSync(sqlitePath);
   const gz = gzipSync(sqliteBytes, { level: 9 });
-  writeFileSync(packPath, gz);
+  writeFileSync(resolvedPackPath, gz);
   const indexPath = resolveWithinRepo(indexRelPath);
   const index = JSON.parse(readFileSync(indexPath, "utf8"));
   const pack = index.packs.find((p) => packRelPath.endsWith(p.asset));

--- a/tools/route-map/pack-io.mjs
+++ b/tools/route-map/pack-io.mjs
@@ -13,6 +13,15 @@ import { DatabaseSync } from "node:sqlite";
 /** 리포지토리 루트(도구는 tools/route-map/ 아래에 있다). */
 export const repoRoot = path.resolve(import.meta.dirname, "../..");
 
+/** 리포 루트 하위로만 해석되는 절대 경로를 돌려준다(`..` 탈출·루트 밖 절대경로 차단). */
+function resolveWithinRepo(relPath) {
+  const resolved = path.resolve(repoRoot, relPath);
+  if (resolved !== repoRoot && !resolved.startsWith(repoRoot + path.sep)) {
+    throw new Error(`경로가 리포지토리 루트를 벗어난다: ${relPath}`);
+  }
+  return resolved;
+}
+
 /** 버퍼의 sha256 hex 문자열. */
 export const sha256 = (buffer) =>
   createHash("sha256").update(buffer).digest("hex");
@@ -23,7 +32,7 @@ export const sha256 = (buffer) =>
  * `packRelPath`는 리포 루트 기준 상대 경로, `tmpPrefix`는 임시 디렉터리 접두.
  */
 export function openPack(packRelPath, tmpPrefix) {
-  const packPath = path.join(repoRoot, packRelPath);
+  const packPath = resolveWithinRepo(packRelPath);
   const sqliteBytes = gunzipSync(readFileSync(packPath));
   const dir = mkdtempSync(path.join(tmpdir(), tmpPrefix));
   const sqlitePath = path.join(dir, "pack.sqlite");
@@ -40,7 +49,7 @@ export function writePack({ sqlitePath, packPath, packRelPath, indexRelPath }) {
   const sqliteBytes = readFileSync(sqlitePath);
   const gz = gzipSync(sqliteBytes, { level: 9 });
   writeFileSync(packPath, gz);
-  const indexPath = path.join(repoRoot, indexRelPath);
+  const indexPath = resolveWithinRepo(indexRelPath);
   const index = JSON.parse(readFileSync(indexPath, "utf8"));
   const pack = index.packs.find((p) => packRelPath.endsWith(p.asset));
   if (pack) {


### PR DESCRIPTION
## 관련 이슈

Closes #2422

## 작업 배경

main SonarCloud Quality Gate가 New Code Security Rating C로 실패한다. #2421로 Reliability BUG는 제거했고, 남은 New Code VULNERABILITY 15건을 처리해 Security ≥ A로 복구한다.

## 작업 내용

- `ci.yml`: Admin QA `npm ci`에 `--ignore-scripts` 추가 (`githubactions:S6505`)
- `release-artifacts.yml`: Production RC `flutter pub get --enforce-lockfile` (`githubactions:S8550`)
- `tools/route-map/pack-io.mjs`: `resolveWithinRepo`로 경로 탈출 차단 (`jssecurity:S8707`)
- `tools/release/hash-android-bundle-payload.mjs`: unzip 절대경로 사용 (`javascript:S4036`)
- ops verify 스크립트: 내부 docker/루프백 평문 HTTP에 사유 + `# NOSONAR` (`shell:S5332`)

## 검증

- 실행한 명령과 결과:
  - `node --check tools/route-map/pack-io.mjs` → OK
  - `node --check tools/release/hash-android-bundle-payload.mjs` → OK
  - `bash -n` 대상 ops 스크립트 2개 → OK
  - 관련 unit/contract 스모크 → pass

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Sonar Security New Code | n/a | SonarCloud QG / PR check | PR SonarCloud Code Analysis + main 재분석 | 대기 |
| CI workflow 변경 | n/a | GitHub Actions | 이 PR CI 런 | 대기 |

증거 불필요 사유(제품 UI): 사용자 화면·경로 안내 변경 없음. 도구/워크플로/보안 정적 분석 해소.

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `npm ci --ignore-scripts`가 `tools/qa`에 안전한지(lifecycle 스크립트 부재)
  - Production RC만 `--enforce-lockfile`로 좁힌 범위
  - pack-io 경로 검증이 정상 상대경로를 깨지 않는지
  - 내부 HTTP NOSONAR 사유가 타당한지

## 리스크

- `flutter pub get --enforce-lockfile`는 lock 불일치 시 Production RC를 fail-fast 한다(의도된 보안 동작).
- 내부 docker/루프백 평문 HTTP는 TLS 종단 구조상 HTTPS 전환 불가 → NOSONAR로 문서화.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.

Made with [Cursor](https://cursor.com)