### PR TITLE
[Style] 관리자 콘솔 HIG 후속 — 운영자 카피·표 헤더·셸 햄버거 계약 고정

### DIFF
--- a/backend/src/main/resources/templates/admin/codes/list.html
+++ b/backend/src/main/resources/templates/admin/codes/list.html
@@ -22,10 +22,10 @@
 	</header>
 
 	<section class="admin-panel">
-		<h2>Group</h2>
+		<h2>그룹</h2>
 		<form class="table-toolbar" method="get" th:action="@{/admin/codes/page}"
-		      role="search" aria-label="공통코드 Group 조회">
-			<select id="code-group-filter" name="groupCode" aria-label="Group 필터">
+		      role="search" aria-label="공통코드 그룹 조회">
+			<select id="code-group-filter" name="groupCode" aria-label="그룹 필터">
 				<option th:each="group : ${groups}"
 				        th:value="${group.groupCode}"
 				        th:selected="${group.groupCode == selectedGroup}"
@@ -37,13 +37,13 @@
 	</section>
 
 	<section class="admin-panel">
-		<h2>Code</h2>
+		<h2>코드 목록</h2>
 		<div class="admin-table-scroll" tabindex="0" role="group"
 		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table>
 			<thead>
 			<tr>
-				<th scope="col">Code</th>
+				<th scope="col">코드</th>
 				<th scope="col">이름</th>
 				<th scope="col">설명</th>
 				<th scope="col">정렬</th>
@@ -54,7 +54,7 @@
 			<tbody>
 			<tr th:if="${codes.isEmpty()}">
 				<td class="empty" colspan="6">
-					<div th:replace="~{admin/fragments/empty-state :: panel('등록된 코드가 없습니다.', '선택한 Group에 코드가 없습니다. 아래에서 코드를 추가하세요.')}"></div>
+					<div th:replace="~{admin/fragments/empty-state :: panel('등록된 코드가 없습니다.', '선택한 그룹에 코드가 없습니다. 아래에서 코드를 추가하세요.')}"></div>
 				</td>
 			</tr>
 			<tr th:each="code : ${codes}">
@@ -82,12 +82,12 @@
 	</section>
 
 	<section class="admin-panel">
-		<h2>Code 추가·수정</h2>
+		<h2>코드 추가·수정</h2>
 		<form class="admin-form" method="post" th:action="@{/admin/codes}">
 			<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 			<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 			<input type="hidden" name="groupCode" th:value="${selectedGroup}">
-			<label>Code <input name="code" required></label>
+			<label>코드 <input name="code" required></label>
 			<label>이름 <input name="displayName" required></label>
 			<label>설명 <input name="description"></label>
 			<label>정렬 <input name="sortOrder" type="number" min="0" value="0"></label>

--- a/backend/src/main/resources/templates/admin/datapack/alias-quarantine/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/alias-quarantine/list.html
@@ -25,7 +25,7 @@
 		<form class="table-toolbar" method="get" th:action="@{/admin/datapack/alias-quarantine/page}"
 		      role="search" aria-label="별칭·격리 검색">
 			<input type="search" name="query" th:value="${filter.queryValue}"
-			       placeholder="alias·quarantine·station 검색" aria-label="별칭·격리 검색" autocomplete="off">
+			       placeholder="별칭·격리·역 검색" aria-label="별칭·격리 검색" autocomplete="off">
 			<select name="status" aria-label="상태 필터">
 				<option value="ALL" th:selected="${filter.selectedStatus('ALL')}">전체 상태</option>
 				<option value="BLOCKER" th:selected="${filter.selectedStatus('BLOCKER')}">차단</option>
@@ -51,24 +51,24 @@
 	</section>
 
 	<section class="admin-panel">
-		<h2>Alias 검수 큐</h2>
+		<h2>별칭 검수 큐</h2>
 		<div class="admin-table-scroll" tabindex="0" role="group"
 		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table class="static-table">
 			<thead>
 			<tr>
-				<th scope="col">id</th>
-				<th scope="col">source</th>
-				<th scope="col">snapshot</th>
-				<th scope="col">provider entity</th>
-				<th scope="col">canonical entity</th>
-				<th scope="col">confidence</th>
-				<th scope="col">method</th>
-				<th scope="col">status</th>
-				<th scope="col">requested</th>
-				<th scope="col">approved</th>
-				<th scope="col">evidence</th>
-				<th scope="col">command</th>
+				<th scope="col">ID</th>
+				<th scope="col">출처</th>
+				<th scope="col">스냅샷</th>
+				<th scope="col">제공 엔티티</th>
+				<th scope="col">정규 엔티티</th>
+				<th scope="col">신뢰도</th>
+				<th scope="col">방법</th>
+				<th scope="col">상태</th>
+				<th scope="col">요청</th>
+				<th scope="col">승인</th>
+				<th scope="col">증거</th>
+				<th scope="col">작업</th>
 			</tr>
 			</thead>
 			<tbody>
@@ -131,18 +131,18 @@
 		<table class="static-table">
 			<thead>
 			<tr>
-				<th scope="col">id</th>
-				<th scope="col">source</th>
-				<th scope="col">snapshot</th>
-				<th scope="col">provider hash</th>
-				<th scope="col">reason</th>
-				<th scope="col">severity</th>
-				<th scope="col">status</th>
-				<th scope="col">latest resolution</th>
-				<th scope="col">canonical</th>
-				<th scope="col">resolved</th>
-				<th scope="col">excerpt</th>
-				<th scope="col">command</th>
+				<th scope="col">ID</th>
+				<th scope="col">출처</th>
+				<th scope="col">스냅샷</th>
+				<th scope="col">제공자 해시</th>
+				<th scope="col">사유</th>
+				<th scope="col">심각도</th>
+				<th scope="col">상태</th>
+				<th scope="col">최근 해결</th>
+				<th scope="col">정규 엔티티</th>
+				<th scope="col">해결</th>
+				<th scope="col">발췌</th>
+				<th scope="col">작업</th>
 			</tr>
 			</thead>
 			<tbody>

--- a/backend/src/main/resources/templates/admin/datapack/candidates/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/candidates/list.html
@@ -25,7 +25,7 @@
 		<form class="table-toolbar" method="get" th:action="@{/admin/datapack/candidates/page}"
 		      role="search" aria-label="후보 팩 검색">
 			<input type="search" name="query" th:value="${filter.queryValue}"
-			       placeholder="후보·scope·version 검색" aria-label="후보 팩 검색" autocomplete="off">
+			       placeholder="후보·범위·버전 검색" aria-label="후보 팩 검색" autocomplete="off">
 			<select name="status" aria-label="후보 상태 필터">
 				<option value="ALL" th:selected="${filter.selectedStatus('ALL')}">전체 상태</option>
 				<option value="BLOCKER" th:selected="${filter.selectedStatus('BLOCKER')}">게이트 차단</option>
@@ -57,11 +57,11 @@
 			<thead>
 			<tr>
 				<th scope="col">후보</th>
-				<th scope="col">scope</th>
-				<th scope="col">version</th>
-				<th scope="col">approval</th>
-				<th scope="col">gates</th>
-				<th scope="col">hash</th>
+				<th scope="col">범위</th>
+				<th scope="col">버전</th>
+				<th scope="col">승인</th>
+				<th scope="col">게이트</th>
+				<th scope="col">해시</th>
 				<th scope="col">생성</th>
 				<th scope="col">상세</th>
 			</tr>

--- a/backend/src/main/resources/templates/admin/datapack/facility-evidence/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/facility-evidence/list.html
@@ -17,7 +17,7 @@
 	<header class="admin-page-head">
 		<div>
 			<h1>시설 근거 검토</h1>
-			<p>station x facility type별 source evidence, 상태 의미, strict route 사용 가능 여부를 검수합니다.</p>
+			<p>역×시설 유형별 출처 근거, 상태 의미, strict 경로 사용 가능 여부를 검수합니다.</p>
 		</div>
 	</header>
 
@@ -25,7 +25,7 @@
 		<form class="table-toolbar" method="get" th:action="@{/admin/datapack/facility-evidence/page}"
 		      role="search" aria-label="시설 근거 검색">
 			<input type="search" name="query" th:value="${filter.queryValue}"
-			       placeholder="역·시설·source 검색" aria-label="시설 근거 검색" autocomplete="off">
+			       placeholder="역·시설·출처 검색" aria-label="시설 근거 검색" autocomplete="off">
 			<select name="status" aria-label="상태 필터">
 				<option value="ALL" th:selected="${filter.selectedStatus('ALL')}">전체 상태</option>
 				<option value="BLOCKER" th:selected="${filter.selectedStatus('BLOCKER')}">차단</option>
@@ -53,21 +53,21 @@
 		<table class="static-table">
 			<thead>
 			<tr>
-				<th scope="col">station</th>
-				<th scope="col">line</th>
-				<th scope="col">facility</th>
-				<th scope="col">evidence</th>
-				<th scope="col">installation</th>
-				<th scope="col">operation</th>
-				<th scope="col">meaning</th>
-				<th scope="col">source</th>
-				<th scope="col">verified</th>
-				<th scope="col">freshness</th>
-				<th scope="col">confidence</th>
+				<th scope="col">역</th>
+				<th scope="col">노선</th>
+				<th scope="col">시설</th>
+				<th scope="col">증거</th>
+				<th scope="col">설치</th>
+				<th scope="col">운영</th>
+				<th scope="col">의미</th>
+				<th scope="col">출처</th>
+				<th scope="col">검증</th>
+				<th scope="col">신선도</th>
+				<th scope="col">신뢰도</th>
 				<th scope="col">strict</th>
-				<th scope="col">conflict</th>
-				<th scope="col">override</th>
-				<th scope="col">command</th>
+				<th scope="col">충돌</th>
+				<th scope="col">오버라이드</th>
+				<th scope="col">작업</th>
 			</tr>
 			</thead>
 			<tbody>

--- a/backend/src/main/resources/templates/admin/datapack/manual-overrides/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/manual-overrides/list.html
@@ -17,38 +17,38 @@
 	<header class="admin-page-head">
 		<div>
 			<h1>수동 오버라이드</h1>
-			<p>production candidate 입력 전에 override 요청, 승인, 만료, strict route 안전 승인 상태를 검수합니다.</p>
+			<p>프로덕션 후보 입력 전에 오버라이드 요청·승인·만료·strict 경로 안전 승인 상태를 검수합니다.</p>
 		</div>
 	</header>
 
 	<section class="admin-panel">
-		<h2>Override 요청</h2>
+		<h2>오버라이드 요청</h2>
 		<form class="admin-form" method="post" th:action="@{/admin/datapack/manual-overrides}">
 			<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 			<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 			<input type="hidden" name="idempotencyKey" th:value="${overrideForm.idempotencyKey != null ? overrideForm.idempotencyKey : 'manual-override-request'}">
 			<fieldset>
 				<legend>대상 식별</legend>
-				<label>오버라이드 ID <input name="id" th:value="${overrideForm.id}" placeholder="id" required></label>
+				<label>오버라이드 ID <input name="id" th:value="${overrideForm.id}" placeholder="예: ov-20260722-01" required></label>
 				<div class="admin-form-row-2">
-					<label>대상 유형 <input name="entityType" th:value="${overrideForm.entityType != null ? overrideForm.entityType : 'FACILITY'}" placeholder="entityType" required></label>
-					<label>대상 ID <input name="entityId" th:value="${overrideForm.entityId}" placeholder="entityId" required></label>
+					<label>대상 유형 <input name="entityType" th:value="${overrideForm.entityType != null ? overrideForm.entityType : 'FACILITY'}" placeholder="예: FACILITY" required></label>
+					<label>대상 ID <input name="entityId" th:value="${overrideForm.entityId}" placeholder="예: facility-id" required></label>
 				</div>
-				<label>필드명 <input name="fieldName" th:value="${overrideForm.fieldName}" placeholder="fieldName" required></label>
+				<label>필드명 <input name="fieldName" th:value="${overrideForm.fieldName}" placeholder="예: operatingStatus" required></label>
 			</fieldset>
 			<fieldset>
 				<legend>변경 값</legend>
 				<div class="admin-form-row-2">
-					<label>변경 전 값 <input name="beforeValue" th:value="${overrideForm.beforeValue}" placeholder="beforeValue"></label>
-					<label>변경 후 값 <input name="afterValue" th:value="${overrideForm.afterValue}" placeholder="afterValue" required></label>
+					<label>변경 전 값 <input name="beforeValue" th:value="${overrideForm.beforeValue}" placeholder="예: AVAILABLE"></label>
+					<label>변경 후 값 <input name="afterValue" th:value="${overrideForm.afterValue}" placeholder="예: UNAVAILABLE" required></label>
 				</div>
 			</fieldset>
 			<fieldset>
 				<legend>근거·안전</legend>
-				<label>사유 코드 <input name="reasonCode" th:value="${overrideForm.reasonCode != null ? overrideForm.reasonCode : 'FIELD_CHECK'}" placeholder="reasonCode" required></label>
-				<label>사유 <input name="reason" th:value="${overrideForm.reason}" placeholder="reason" required></label>
-				<label>증거 URI <input name="evidenceUri" th:value="${overrideForm.evidenceUri}" placeholder="evidenceUri" required></label>
-				<label>증거 해시 <input name="evidenceHash" th:value="${overrideForm.evidenceHash}" placeholder="evidenceHash" required></label>
+				<label>사유 코드 <input name="reasonCode" th:value="${overrideForm.reasonCode != null ? overrideForm.reasonCode : 'FIELD_CHECK'}" placeholder="예: FIELD_CHECK" required></label>
+				<label>사유 <input name="reason" th:value="${overrideForm.reason}" placeholder="예: 현장 확인 결과 반영" required></label>
+				<label>증거 URI <input name="evidenceUri" th:value="${overrideForm.evidenceUri}" placeholder="예: https://example.com/evidence.pdf" required></label>
+				<label>증거 해시 <input name="evidenceHash" th:value="${overrideForm.evidenceHash}" placeholder="예: 64자리 SHA-256 해시" required></label>
 				<label>strict 경로 사용 가능 <input type="checkbox" name="strictRouteEligible" value="true" th:checked="${overrideForm.strictRouteEligible}"></label>
 			</fieldset>
 			<fieldset>
@@ -66,7 +66,7 @@
 		<form class="table-toolbar" method="get" th:action="@{/admin/datapack/manual-overrides/page}"
 		      role="search" aria-label="수동 오버라이드 검색">
 			<input type="search" name="query" th:value="${filter.queryValue}"
-			       placeholder="entity·field·reason 검색" aria-label="수동 오버라이드 검색" autocomplete="off">
+			       placeholder="대상·필드·사유 검색" aria-label="수동 오버라이드 검색" autocomplete="off">
 			<select name="status" aria-label="상태 필터">
 				<option value="ALL" th:selected="${filter.selectedStatus('ALL')}">전체 상태</option>
 				<option value="BLOCKER" th:selected="${filter.selectedStatus('BLOCKER')}">차단</option>
@@ -78,7 +78,7 @@
 			</select>
 			<select name="sort" aria-label="정렬">
 				<option value="" th:selected="${filter.selectedSort('')}">운영 차단 우선</option>
-				<option value="entity" th:selected="${filter.selectedSort('entity')}">entity순</option>
+				<option value="entity" th:selected="${filter.selectedSort('entity')}">대상순</option>
 				<option value="created" th:selected="${filter.selectedSort('created')}">시작 최신순</option>
 			</select>
 			<input type="hidden" name="candidateId" th:if="${filter.hasCandidate()}" th:value="${filter.candidateValue}">
@@ -97,22 +97,22 @@
 		<table class="static-table">
 			<thead>
 			<tr>
-				<th scope="col">id</th>
-				<th scope="col">entity</th>
-				<th scope="col">field</th>
-				<th scope="col">before</th>
-				<th scope="col">after</th>
-				<th scope="col">reason</th>
-				<th scope="col">evidence</th>
-				<th scope="col">requested</th>
-				<th scope="col">approved</th>
-				<th scope="col">status</th>
-				<th scope="col">conflict</th>
+				<th scope="col">ID</th>
+				<th scope="col">대상</th>
+				<th scope="col">필드</th>
+				<th scope="col">변경 전</th>
+				<th scope="col">변경 후</th>
+				<th scope="col">사유</th>
+				<th scope="col">증거</th>
+				<th scope="col">요청</th>
+				<th scope="col">승인</th>
+				<th scope="col">상태</th>
+				<th scope="col">충돌</th>
 				<th scope="col">strict</th>
-				<th scope="col">window</th>
-				<th scope="col">superseded</th>
-				<th scope="col">production</th>
-				<th scope="col">command</th>
+				<th scope="col">유효 기간</th>
+				<th scope="col">대체됨</th>
+				<th scope="col">프로덕션</th>
+				<th scope="col">작업</th>
 			</tr>
 			</thead>
 			<tbody>

--- a/backend/src/main/resources/templates/admin/datapack/release-channels/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/release-channels/list.html
@@ -28,9 +28,9 @@
 			       placeholder="채널·후보·사유 검색" aria-label="배포 채널 검색" autocomplete="off">
 			<select name="status" aria-label="상태 필터">
 				<option value="ALL" th:selected="${filter.selectedStatus('ALL')}">전체 상태</option>
-				<option value="production" th:selected="${filter.selectedStatus('production')}">production</option>
-				<option value="staging" th:selected="${filter.selectedStatus('staging')}">staging</option>
-				<option value="dev" th:selected="${filter.selectedStatus('dev')}">dev</option>
+				<option value="production" th:selected="${filter.selectedStatus('production')}">프로덕션</option>
+				<option value="staging" th:selected="${filter.selectedStatus('staging')}">스테이징</option>
+				<option value="dev" th:selected="${filter.selectedStatus('dev')}">개발</option>
 				<option value="ROLLBACK_AVAILABLE" th:selected="${filter.selectedStatus('ROLLBACK_AVAILABLE')}">rollback 가능</option>
 				<option value="PROMOTE" th:selected="${filter.selectedStatus('PROMOTE')}">승격</option>
 				<option value="ROLLBACK" th:selected="${filter.selectedStatus('ROLLBACK')}">롤백</option>
@@ -58,14 +58,14 @@
 		<table class="static-table">
 			<thead>
 			<tr>
-				<th scope="col">channel</th>
-				<th scope="col">current</th>
-				<th scope="col">manifest</th>
-				<th scope="col">rollback target</th>
-				<th scope="col">rollback</th>
-				<th scope="col">last operation</th>
-				<th scope="col">approval</th>
-				<th scope="col">updated</th>
+				<th scope="col">채널</th>
+				<th scope="col">현재</th>
+				<th scope="col">매니페스트</th>
+				<th scope="col">롤백 대상</th>
+				<th scope="col">롤백</th>
+				<th scope="col">최근 작업</th>
+				<th scope="col">승인</th>
+				<th scope="col">갱신</th>
 			</tr>
 			</thead>
 			<tbody>
@@ -75,7 +75,7 @@
 				</td>
 			</tr>
 			<tr th:each="channel : ${channels}">
-				<td th:text="${channel.channel}">production</td>
+				<td th:text="${channel.channel == 'production' ? '프로덕션' : (channel.channel == 'staging' ? '스테이징' : (channel.channel == 'dev' ? '개발' : channel.channel))}">프로덕션</td>
 				<td>
 					<span th:text="${channel.candidateId}">candidate</span>
 					<span th:text="${channel.candidateVersion}">version</span>
@@ -92,7 +92,7 @@
 				<td th:text="${channel.rollbackLabel}">rollback 가능</td>
 				<td>
 					<span th:text="${channel.lastOperationType}">PROMOTE</span>
-					<span th:text="${channel.lastOperationStatus}">PASS</span>
+					<span th:text="${channel.lastOperationStatus == 'PASS' ? '통과' : (channel.lastOperationStatus == 'FAIL' ? '실패' : channel.lastOperationStatus)}">통과</span>
 					<span th:text="${channel.idempotencyKey}">idempotency</span>
 					<details class="admin-promote-confirm">
 						<summary th:text="${'승격 승인 (' + channel.channel + ')'}">승격 승인</summary>
@@ -104,34 +104,34 @@
 						<input type="hidden" name="previousCandidateId" th:value="${channel.candidateId}">
 						<input type="hidden" name="previousManifestSha256" th:value="${channel.manifestSha256}">
 						<label>
-							next candidate
+							다음 후보
 							<input name="nextCandidateId" required>
 						</label>
 						<label>
-							next manifest sha256
+							다음 매니페스트 sha256
 							<input name="nextManifestSha256" minlength="64" maxlength="64" required>
 						</label>
 						<label th:if="${channel.channel == 'production'}">
-							evidence bundle sha256
+							증거 번들 sha256
 							<input name="evidenceBundleSha256" minlength="64" maxlength="64" required>
 						</label>
 						<label>
-							requested by
+							요청자
 							<input name="requestedBy" required>
 						</label>
 						<label>
-							reason
+							사유
 							<input name="reason" required>
 						</label>
 						<label>
-							idempotency key
+							멱등 키
 							<input name="idempotencyKey" required>
 						</label>
 						<label>
-							workflow run URL
+							워크플로 실행 URL
 							<input name="workflowRunUrl" type="url" required>
 						</label>
-						<button type="submit" class="primary">production 승인</button>
+						<button type="submit" class="primary">프로덕션 승인</button>
 						</form>
 					</details>
 					<details class="admin-promote-confirm" th:if="${channel.previousStableCandidateId != '—'}">
@@ -184,13 +184,13 @@
 		<table class="static-table">
 			<thead>
 			<tr>
-				<th scope="col">event</th>
-				<th scope="col">channel</th>
-				<th scope="col">candidate</th>
-				<th scope="col">operation</th>
-				<th scope="col">approval</th>
-				<th scope="col">workflow</th>
-				<th scope="col">created</th>
+				<th scope="col">이벤트</th>
+				<th scope="col">채널</th>
+				<th scope="col">후보</th>
+				<th scope="col">작업</th>
+				<th scope="col">승인</th>
+				<th scope="col">워크플로</th>
+				<th scope="col">생성</th>
 			</tr>
 			</thead>
 			<tbody>
@@ -201,7 +201,7 @@
 			</tr>
 			<tr th:each="event : ${events}">
 				<td th:text="${event.id}">event</td>
-				<td th:text="${event.channel}">production</td>
+				<td th:text="${event.channel == 'production' ? '프로덕션' : (event.channel == 'staging' ? '스테이징' : (event.channel == 'dev' ? '개발' : event.channel))}">프로덕션</td>
 				<td>
 					<span th:text="${event.previousCandidateId}">previous</span>
 					<span th:text="${event.nextCandidateId}">next</span>
@@ -209,7 +209,7 @@
 				</td>
 				<td>
 					<span th:text="${event.operationType}">PROMOTE</span>
-					<span th:text="${event.operationStatus}">PASS</span>
+					<span th:text="${event.operationStatus == 'PASS' ? '통과' : (event.operationStatus == 'FAIL' ? '실패' : event.operationStatus)}">통과</span>
 					<span th:text="${event.idempotencyKey}">idempotency</span>
 				</td>
 				<td>

--- a/backend/src/main/resources/templates/admin/datapack/release-channels/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/release-channels/list.html
@@ -131,7 +131,8 @@
 							워크플로 실행 URL
 							<input name="workflowRunUrl" type="url" required>
 						</label>
-						<button type="submit" class="primary">프로덕션 승인</button>
+						<button type="submit" class="primary"
+						        th:text="${channel.channel == 'production' ? '프로덕션 승인' : '승격 승인'}">승격 승인</button>
 						</form>
 					</details>
 					<details class="admin-promote-confirm" th:if="${channel.previousStableCandidateId != '—'}">

--- a/backend/src/main/resources/templates/admin/datapack/release-requests/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/release-requests/list.html
@@ -17,7 +17,7 @@
 	<header class="admin-page-head">
 		<div>
 			<h1>릴리스 요청</h1>
-			<p>게시 대상 후보를 골라 릴리스 요청을 생성하고, 다른 관리자가 승인합니다. 승인 후 production 게이트는 수동 dispatch로 실행합니다.</p>
+			<p>게시 대상 후보를 골라 릴리스 요청을 생성하고, 다른 관리자가 승인합니다. 승인 후 프로덕션 게이트는 수동 dispatch로 실행합니다.</p>
 		</div>
 	</header>
 
@@ -48,9 +48,9 @@
 			<label>
 				대상 채널
 				<select name="targetChannel">
-					<option value="staging">staging</option>
-					<option value="production">production</option>
-					<option value="dev">dev</option>
+					<option value="staging">스테이징</option>
+					<option value="production">프로덕션</option>
+					<option value="dev">개발</option>
 				</select>
 			</label>
 			<button type="submit" class="primary">릴리스 요청 생성</button>
@@ -84,7 +84,7 @@
 				<td th:text="${request.approvalId}">approval</td>
 				<td th:text="${request.candidateId}">candidate</td>
 				<td th:text="${request.scopeId}">scope</td>
-				<td th:text="${request.targetChannel}">staging</td>
+				<td th:text="${request.targetChannel == 'production' ? '프로덕션' : (request.targetChannel == 'staging' ? '스테이징' : (request.targetChannel == 'dev' ? '개발' : request.targetChannel))}">스테이징</td>
 				<td th:text="${request.status}">REQUESTED</td>
 				<td th:text="${request.requestedBy}">requested</td>
 				<td th:text="${request.approvedBy}">approved</td>

--- a/backend/src/main/resources/templates/admin/datapack/route-gates/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/route-gates/list.html
@@ -17,7 +17,7 @@
 	<header class="admin-page-head">
 		<div>
 			<h1>경로 게이트</h1>
-			<p>ENTRY, EXIT, TRANSFER edge evidence와 strict route blocker를 읽기 전용으로 확인합니다.</p>
+			<p>진입·진출·환승 엣지 근거와 strict 경로 차단 요인을 읽기 전용으로 확인합니다.</p>
 		</div>
 	</header>
 
@@ -25,7 +25,7 @@
 		<form class="table-toolbar" method="get" th:action="@{/admin/datapack/route-gates/page}"
 		      role="search" aria-label="경로 게이트 검색">
 			<input type="search" name="query" th:value="${filter.queryValue}"
-			       placeholder="역·edge·source 검색" aria-label="경로 게이트 검색" autocomplete="off">
+			       placeholder="역·엣지·출처 검색" aria-label="경로 게이트 검색" autocomplete="off">
 			<select name="status" aria-label="상태 필터">
 				<option value="ALL" th:selected="${filter.selectedStatus('ALL')}">전체 상태</option>
 				<option value="BLOCKER" th:selected="${filter.selectedStatus('BLOCKER')}">차단</option>
@@ -53,16 +53,16 @@
 		<table class="static-table">
 			<thead>
 			<tr>
-				<th scope="col">station</th>
-				<th scope="col">line</th>
-				<th scope="col">edge</th>
-				<th scope="col">type</th>
-				<th scope="col">verification</th>
-				<th scope="col">provenance</th>
-				<th scope="col">generated</th>
-				<th scope="col">source</th>
-				<th scope="col">verified</th>
-				<th scope="col">evidence</th>
+				<th scope="col">역</th>
+				<th scope="col">노선</th>
+				<th scope="col">엣지</th>
+				<th scope="col">유형</th>
+				<th scope="col">검증</th>
+				<th scope="col">출처 추적</th>
+				<th scope="col">생성</th>
+				<th scope="col">출처</th>
+				<th scope="col">검증</th>
+				<th scope="col">증거</th>
 				<th scope="col">strict</th>
 				<th scope="col">차단 요인</th>
 			</tr>

--- a/backend/src/main/resources/templates/admin/datapack/route-gates/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/route-gates/list.html
@@ -61,7 +61,7 @@
 				<th scope="col">출처 추적</th>
 				<th scope="col">생성</th>
 				<th scope="col">출처</th>
-				<th scope="col">검증</th>
+				<th scope="col">검증 시각</th>
 				<th scope="col">증거</th>
 				<th scope="col">strict</th>
 				<th scope="col">차단 요인</th>

--- a/backend/src/main/resources/templates/admin/datapack/source-snapshots/detail.html
+++ b/backend/src/main/resources/templates/admin/datapack/source-snapshots/detail.html
@@ -57,7 +57,7 @@
 			<tr><th scope="row">라이선스 상태</th><td th:text="${snapshot.licenseStatus == 'PASS' ? '통과' : (snapshot.licenseStatus == 'FAIL' ? '실패' : snapshot.licenseStatus)}">통과</td></tr>
 			<tr><th scope="row">수집 상태</th><td th:text="${snapshot.fetchStatus}">SUCCESS</td></tr>
 			<tr><th scope="row">재배포</th><td th:text="${snapshot.redistributionLabel()}">허용</td></tr>
-			<tr><th scope="row">자격증명 마스킹</th><td th:text="${snapshot.credentialRedactedLabel()}">마스킹됨</td></tr>
+			<tr><th scope="row">자격증명 마스킹</th><td th:text="${snapshot.credentialRedacted ? '마스킹됨' : '마스킹 필요'}">마스킹됨</td></tr>
 			<tr><th scope="row">신선도 만료</th><td th:text="${snapshot.freshnessExpiresAt}">2026-07-06T03:00</td></tr>
 			<tr><th scope="row">원본 보존 기한</th><td th:text="${snapshot.rawRetentionExpiresAt}">2026-09-29T03:00</td></tr>
 			<tr><th scope="row">거버넌스 정책 버전</th><td th:insert="~{admin/fragments/missing-value :: value(${snapshot.governancePolicyVersion}, '미상')}">—</td></tr>

--- a/backend/src/main/resources/templates/admin/datapack/source-snapshots/detail.html
+++ b/backend/src/main/resources/templates/admin/datapack/source-snapshots/detail.html
@@ -30,17 +30,17 @@
 		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table class="static-table">
 			<tbody>
-			<tr><th scope="row">source id</th><td th:text="${snapshot.sourceId}">source-id</td></tr>
-			<tr><th scope="row">provider</th><td th:text="${snapshot.provider}">provider</td></tr>
-			<tr><th scope="row">retrieved at</th><td th:text="${snapshot.retrievedAt}">2026-06-29T03:00</td></tr>
-			<tr><th scope="row">source updated at</th><td th:text="${snapshot.sourceUpdatedAt}">2026-06-28T00:00</td></tr>
-			<tr><th scope="row">freshness basis at</th><td th:text="${snapshot.freshnessBasisAt}">2026-06-28T00:00</td></tr>
-			<tr><th scope="row">provider valid until</th><td th:text="${snapshot.providerValidUntil}">2026-07-28T00:00</td></tr>
-			<tr><th scope="row">row count</th><td th:text="${snapshot.rowCount}">0</td></tr>
-			<tr><th scope="row">coverage count</th><td th:text="${snapshot.coverageCount}">0</td></tr>
-			<tr><th scope="row">previous snapshot</th><td th:insert="~{admin/fragments/missing-value :: value(${snapshot.previousSnapshotId}, '미상')}">—</td></tr>
-			<tr><th scope="row">diff summary</th><td th:insert="~{admin/fragments/missing-value :: value(${snapshot.diffSummary}, '미상')}">—</td></tr>
-			<tr><th scope="row">diff summary JSON</th><td th:insert="~{admin/fragments/missing-value :: value(${snapshot.diffSummaryJson}, '미상')}">—</td></tr>
+			<tr><th scope="row">출처 ID</th><td th:text="${snapshot.sourceId}">source-id</td></tr>
+			<tr><th scope="row">제공자</th><td th:text="${snapshot.provider}">provider</td></tr>
+			<tr><th scope="row">수집 시각</th><td th:text="${snapshot.retrievedAt}">2026-06-29T03:00</td></tr>
+			<tr><th scope="row">출처 갱신 시각</th><td th:text="${snapshot.sourceUpdatedAt}">2026-06-28T00:00</td></tr>
+			<tr><th scope="row">신선도 기준 시각</th><td th:text="${snapshot.freshnessBasisAt}">2026-06-28T00:00</td></tr>
+			<tr><th scope="row">제공자 유효 기한</th><td th:text="${snapshot.providerValidUntil}">2026-07-28T00:00</td></tr>
+			<tr><th scope="row">행 수</th><td th:text="${snapshot.rowCount}">0</td></tr>
+			<tr><th scope="row">커버리지 수</th><td th:text="${snapshot.coverageCount}">0</td></tr>
+			<tr><th scope="row">이전 스냅샷</th><td th:insert="~{admin/fragments/missing-value :: value(${snapshot.previousSnapshotId}, '미상')}">—</td></tr>
+			<tr><th scope="row">차이 요약</th><td th:insert="~{admin/fragments/missing-value :: value(${snapshot.diffSummary}, '미상')}">—</td></tr>
+			<tr><th scope="row">차이 요약 JSON</th><td th:insert="~{admin/fragments/missing-value :: value(${snapshot.diffSummaryJson}, '미상')}">—</td></tr>
 			</tbody>
 		</table>
 		</div>
@@ -52,31 +52,31 @@
 		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table class="static-table">
 			<tbody>
-			<tr><th scope="row">snapshot status</th><td th:text="${snapshot.snapshotStatus}">LOCKED</td></tr>
-			<tr><th scope="row">schema status</th><td th:text="${snapshot.schemaStatus}">PASS</td></tr>
-			<tr><th scope="row">license status</th><td th:text="${snapshot.licenseStatus}">PASS</td></tr>
-			<tr><th scope="row">fetch status</th><td th:text="${snapshot.fetchStatus}">SUCCESS</td></tr>
-			<tr><th scope="row">redistribution</th><td th:text="${snapshot.redistributionLabel()}">허용</td></tr>
-			<tr><th scope="row">credential redacted</th><td th:text="${snapshot.credentialRedactedLabel()}">credential redacted</td></tr>
-			<tr><th scope="row">freshness expires</th><td th:text="${snapshot.freshnessExpiresAt}">2026-07-06T03:00</td></tr>
-			<tr><th scope="row">raw retention</th><td th:text="${snapshot.rawRetentionExpiresAt}">2026-09-29T03:00</td></tr>
-			<tr><th scope="row">governance policy version</th><td th:insert="~{admin/fragments/missing-value :: value(${snapshot.governancePolicyVersion}, '미상')}">—</td></tr>
-			<tr><th scope="row">governance policy sha256</th><td th:insert="~{admin/fragments/missing-value :: value(${snapshot.governancePolicySha256}, '미상')}">—</td></tr>
+			<tr><th scope="row">스냅샷 상태</th><td th:text="${snapshot.snapshotStatus}">LOCKED</td></tr>
+			<tr><th scope="row">스키마 상태</th><td th:text="${snapshot.schemaStatus == 'PASS' ? '통과' : (snapshot.schemaStatus == 'FAIL' ? '실패' : snapshot.schemaStatus)}">통과</td></tr>
+			<tr><th scope="row">라이선스 상태</th><td th:text="${snapshot.licenseStatus == 'PASS' ? '통과' : (snapshot.licenseStatus == 'FAIL' ? '실패' : snapshot.licenseStatus)}">통과</td></tr>
+			<tr><th scope="row">수집 상태</th><td th:text="${snapshot.fetchStatus}">SUCCESS</td></tr>
+			<tr><th scope="row">재배포</th><td th:text="${snapshot.redistributionLabel()}">허용</td></tr>
+			<tr><th scope="row">자격증명 마스킹</th><td th:text="${snapshot.credentialRedactedLabel()}">마스킹됨</td></tr>
+			<tr><th scope="row">신선도 만료</th><td th:text="${snapshot.freshnessExpiresAt}">2026-07-06T03:00</td></tr>
+			<tr><th scope="row">원본 보존 기한</th><td th:text="${snapshot.rawRetentionExpiresAt}">2026-09-29T03:00</td></tr>
+			<tr><th scope="row">거버넌스 정책 버전</th><td th:insert="~{admin/fragments/missing-value :: value(${snapshot.governancePolicyVersion}, '미상')}">—</td></tr>
+			<tr><th scope="row">거버넌스 정책 sha256</th><td th:insert="~{admin/fragments/missing-value :: value(${snapshot.governancePolicySha256}, '미상')}">—</td></tr>
 			</tbody>
 		</table>
 		</div>
 	</section>
 
 	<section class="admin-panel">
-		<h2>Evidence</h2>
+		<h2>근거</h2>
 		<div class="admin-table-scroll" tabindex="0" role="group"
 		     aria-label="가로로 스크롤 가능한 데이터 표">
 		<table class="static-table">
 			<tbody>
 			<tr><th scope="row">raw sha256</th><td th:text="${snapshot.rawSha256}">sha256</td></tr>
-			<tr><th scope="row">raw object uri</th><td th:text="${snapshot.rawObjectUri}">s3://bucket/object.json</td></tr>
-			<tr><th scope="row">request fingerprint</th><td th:text="${snapshot.redactedRequestFingerprint}">sha256</td></tr>
-			<tr><th scope="row">schema fingerprint</th><td th:text="${snapshot.schemaFingerprint}">sha256</td></tr>
+			<tr><th scope="row">원본 객체 URI</th><td th:text="${snapshot.rawObjectUri}">s3://bucket/object.json</td></tr>
+			<tr><th scope="row">요청 지문</th><td th:text="${snapshot.redactedRequestFingerprint}">sha256</td></tr>
+			<tr><th scope="row">스키마 지문</th><td th:text="${snapshot.schemaFingerprint}">sha256</td></tr>
 			</tbody>
 		</table>
 		</div>
@@ -90,42 +90,42 @@
 			<div class="admin-form-section">
 				<h3 class="admin-form-section-title">스냅샷 식별</h3>
 				<label>
-					snapshot id
+					스냅샷 ID
 					<input name="snapshotId" required>
 				</label>
 				<label>
-					source id
+					출처 ID
 					<input name="sourceId" th:value="${snapshot.sourceId}" required>
 				</label>
 				<label>
-					provider
+					제공자
 					<input name="provider" th:value="${snapshot.provider}" required>
 				</label>
 			</div>
 			<div class="admin-form-section">
 				<h3 class="admin-form-section-title">수집 시각</h3>
 				<label>
-					retrieved at
+					수집 시각
 					<input name="retrievedAt" type="datetime-local" required>
 				</label>
 				<label>
-					source updated at
+					출처 갱신 시각
 					<input name="sourceUpdatedAt" type="datetime-local">
 				</label>
 				<label>
-					freshness basis at (retrievedAt 이외 기준만 입력)
+					신선도 기준 시각 (수집 시각 이외 기준만 입력)
 					<input name="freshnessBasisAt" type="datetime-local">
 				</label>
 				<label>
-					provider valid until (policy 필수 source만 입력)
+					제공자 유효 기한 (정책 필수 출처만 입력)
 					<input name="providerValidUntil" type="datetime-local">
 				</label>
 				<label>
-					row count
+					행 수
 					<input name="rowCount" type="number" min="0" required>
 				</label>
 				<label>
-					coverage count
+					커버리지 수
 					<input name="coverageCount" type="number" min="0" required>
 				</label>
 			</div>
@@ -136,45 +136,45 @@
 					<input name="rawSha256" minlength="64" maxlength="64" required>
 				</label>
 				<label>
-					raw object uri
+					원본 객체 URI
 					<input name="rawObjectUri" required>
 				</label>
 				<label>
-					request fingerprint
+					요청 지문
 					<input name="redactedRequestFingerprint" minlength="64" maxlength="64" required>
 				</label>
 				<label>
-					schema fingerprint
+					스키마 지문
 					<input name="schemaFingerprint" minlength="64" maxlength="64" required>
 				</label>
 			</div>
 			<div class="admin-form-section">
 				<h3 class="admin-form-section-title">상태</h3>
 				<label>
-					schema status
+					스키마 상태
 					<input name="schemaStatus" value="PASS" required>
 				</label>
 				<label>
-					license status
+					라이선스 상태
 					<input name="licenseStatus" value="PASS" required>
 				</label>
 				<label>
-					fetch status
+					수집 상태
 					<input name="fetchStatus" value="SUCCESS" required>
 				</label>
 				<div class="admin-form-row-2">
 					<label>
-						redistribution allowed
+						재배포 허용
 						<select name="redistributionAllowed" required>
-							<option value="true">true</option>
-							<option value="false">false</option>
+							<option value="true">허용</option>
+							<option value="false">비허용</option>
 						</select>
 					</label>
 					<label>
-						credential redacted
+						자격증명 마스킹
 						<select name="credentialRedacted" required>
-							<option value="true">true</option>
-							<option value="false">false</option>
+							<option value="true">마스킹됨</option>
+							<option value="false">마스킹 안 됨</option>
 						</select>
 					</label>
 				</div>
@@ -182,39 +182,39 @@
 			<div class="admin-form-section">
 				<h3 class="admin-form-section-title">보존·후속</h3>
 				<label>
-					previous snapshot id
+					이전 스냅샷 ID
 					<input name="previousSnapshotId" th:value="${snapshot.snapshotId}">
 				</label>
 				<label>
-					diff summary
+					차이 요약
 					<input name="diffSummary">
 				</label>
 				<label>
-					diff summary JSON
+					차이 요약 JSON
 					<textarea name="diffSummaryJson"></textarea>
 				</label>
 				<label>
-					freshness expires at
+					신선도 만료 시각
 					<input name="freshnessExpiresAt" type="datetime-local" required>
 				</label>
 				<label>
-					raw retention expires at
+					원본 보존 만료 시각
 					<input name="rawRetentionExpiresAt" type="datetime-local" required>
 				</label>
 				<label>
-					governance policy version
+					거버넌스 정책 버전
 					<input name="governancePolicyVersion" required>
 				</label>
 				<label>
-					governance policy sha256
+					거버넌스 정책 sha256
 					<input name="governancePolicySha256" minlength="64" maxlength="64" required>
 				</label>
 				<label>
-					reason
+					사유
 					<input name="reason" required>
 				</label>
 				<label>
-					idempotency key
+					멱등 키
 					<input name="idempotencyKey" required>
 				</label>
 			</div>
@@ -223,31 +223,31 @@
 	</section>
 
 	<section class="admin-panel">
-		<h2>Normalization run 요청</h2>
+		<h2>정규화 실행 요청</h2>
 		<form class="admin-form" method="post" th:action="@{'/admin/datapack/source-snapshots/' + ${snapshot.snapshotId} + '/normalization-runs'}">
 			<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 			<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 			<label>
-				run id
+				실행 ID
 				<input name="runId" required>
 			</label>
 			<label>
-				schema diff sha256
+				스키마 차이 sha256
 				<input name="schemaDiffSha256" minlength="64" maxlength="64" required>
 			</label>
 			<label>
-				schema diff summary
+				스키마 차이 요약
 				<input name="schemaDiffSummary" required>
 			</label>
 			<label>
-				reason
+				사유
 				<input name="reason" required>
 			</label>
 			<label>
-				idempotency key
+				멱등 키
 				<input name="idempotencyKey" required>
 			</label>
-			<button type="submit" class="outline">Normalization run 요청</button>
+			<button type="submit" class="outline">정규화 실행 요청</button>
 		</form>
 	</section>
 </main>

--- a/backend/src/main/resources/templates/admin/datapack/source-snapshots/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/source-snapshots/list.html
@@ -25,7 +25,7 @@
 		<form class="table-toolbar" method="get" th:action="@{/admin/datapack/source-snapshots/page}"
 		      role="search" aria-label="원천 스냅샷 검색">
 			<input type="search" name="query" th:value="${filter.queryValue}"
-			       placeholder="스냅샷·source·provider 검색" aria-label="원천 스냅샷 검색" autocomplete="off">
+			       placeholder="스냅샷·출처·제공자 검색" aria-label="원천 스냅샷 검색" autocomplete="off">
 			<select name="status" aria-label="상태 필터">
 				<option value="ALL" th:selected="${filter.selectedStatus('ALL')}">전체 상태</option>
 				<option value="BLOCKER" th:selected="${filter.selectedStatus('BLOCKER')}">차단</option>
@@ -37,7 +37,7 @@
 			<select name="sort" aria-label="정렬">
 				<option value="" th:selected="${filter.selectedSort('')}">수집 최신순</option>
 				<option value="retrieved_asc" th:selected="${filter.selectedSort('retrieved_asc')}">수집 오래된순</option>
-				<option value="source" th:selected="${filter.selectedSort('source')}">source순</option>
+				<option value="source" th:selected="${filter.selectedSort('source')}">출처순</option>
 			</select>
 			<input type="hidden" name="candidateId" th:if="${filter.hasCandidate()}" th:value="${filter.candidateValue}">
 			<input type="hidden" name="sourceSnapshotId" th:if="${filter.hasSourceSnapshot()}" th:value="${filter.sourceSnapshotValue}">
@@ -58,13 +58,13 @@
 			<thead>
 			<tr>
 				<th scope="col">스냅샷</th>
-				<th scope="col">source</th>
-				<th scope="col">provider</th>
+				<th scope="col">출처</th>
+				<th scope="col">제공자</th>
 				<th scope="col">수집</th>
-				<th scope="col">rows</th>
-				<th scope="col">status</th>
+				<th scope="col">행 수</th>
+				<th scope="col">상태</th>
 				<th scope="col">raw sha256</th>
-				<th scope="col">diff</th>
+				<th scope="col">차이</th>
 				<th scope="col">상세</th>
 			</tr>
 			</thead>

--- a/backend/src/main/resources/templates/admin/quality/dashboard.html
+++ b/backend/src/main/resources/templates/admin/quality/dashboard.html
@@ -85,7 +85,7 @@
 			<tbody>
 			<tr th:each="row : ${datapackReleaseSummary.readinessRows}">
 				<td th:text="${row.label}">소스 커버리지</td>
-				<td th:text="${row.status}">FAIL</td>
+				<td th:text="${row.status == 'PASS' ? '통과' : (row.status == 'FAIL' ? '실패' : row.status)}">실패</td>
 				<td th:text="${row.blockerCount}">0</td>
 				<td th:text="${row.note}">확인 필요</td>
 			</tr>

--- a/backend/src/test/java/com/easysubway/admin/web/AdminDesignGuardTest.java
+++ b/backend/src/test/java/com/easysubway/admin/web/AdminDesignGuardTest.java
@@ -8,6 +8,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
@@ -75,6 +76,19 @@ class AdminDesignGuardTest {
 			+ "aria-label=\"가로로 스크롤 가능한 [^\"]*표\"[^>]*>\\s*<table\\b",
 		Pattern.DOTALL);
 	private static final Pattern TABLE_WRAPPER_CLOSE = Pattern.compile("</table>\\s*</div>");
+
+	// #2425(R1·R11): 데이터팩·공통코드 표 헤더에 남는 영문 필드명 원문 금지 목록. 정확히 일치(trim, 소문자)할 때만
+	// 위반이다 — "provider entity"처럼 여러 단어로 합쳐지거나 한국어가 섞이면(예: "raw sha256", "증거 해시") 잡지 않는다.
+	// strict는 계획상 열 헤더에 그대로 남기는 예외 토큰이라 이 목록에서 제외한다. "ID"(대문자)는 별도로 허용한다.
+	private static final Set<String> FORBIDDEN_TABLE_HEADER_TOKENS = Set.of(
+		"id", "entity", "field", "before", "after", "station", "line", "facility", "evidence",
+		"command", "source", "status", "channel", "current", "scope", "version", "group", "code",
+		"reason", "requested", "approved", "conflict", "window", "superseded", "production",
+		"installation", "operation", "meaning", "verified", "freshness", "confidence", "override",
+		"snapshot", "method", "manifest", "provider", "rows", "edge", "type", "verification",
+		"provenance", "generated", "hash", "gates", "rollback", "approval", "updated", "diff");
+	private static final Pattern STATIC_TH = Pattern.compile("<th\\b([^>]*)>([^<]*)</th>", Pattern.DOTALL);
+	private static final Pattern H2_TAG = Pattern.compile("<h2\\b[^>]*>([^<]*)</h2>", Pattern.DOTALL);
 
 	@Test
 	@DisplayName("admin-v3.css는 tokens → foundation → shell → components → data import manifest다")
@@ -413,6 +427,98 @@ class AdminDesignGuardTest {
 			.as("listToolbar 컴포넌트는 수동 addEventListener·setInterval를 등록하지 않는다")
 			.doesNotContain("addEventListener")
 			.doesNotContain("setInterval");
+	}
+
+	@Test
+	@DisplayName("데이터팩·공통코드 목록 표 헤더는 영문 필드명 원문을 쓰지 않는다")
+	void datapackAndCodesTableHeadersAreKorean() throws IOException {
+		List<Path> targets = new ArrayList<>();
+		Path datapackTemplates = ROOT.resolve("backend/src/main/resources/templates/admin/datapack");
+		try (var paths = Files.walk(datapackTemplates)) {
+			paths.filter(path -> path.toString().endsWith("list.html")).forEach(targets::add);
+		}
+		targets.add(ROOT.resolve("backend/src/main/resources/templates/admin/codes/list.html"));
+
+		List<String> violations = new ArrayList<>();
+		for (Path path : targets) {
+			String html = Files.readString(path);
+			Matcher matcher = STATIC_TH.matcher(html);
+			while (matcher.find()) {
+				String attrs = matcher.group(1);
+				if (attrs.contains("th:text")) {
+					continue;
+				}
+				String text = matcher.group(2).trim();
+				if (text.isEmpty() || text.equals("ID")) {
+					continue;
+				}
+				if (FORBIDDEN_TABLE_HEADER_TOKENS.contains(text.toLowerCase(Locale.ROOT))) {
+					violations.add(ROOT.relativize(path) + ": <th>" + text + "</th>");
+				}
+			}
+		}
+
+		assertThat(violations)
+			.as("영문 필드명 원문 표 헤더(파일: <th>텍스트</th>): %s", violations)
+			.isEmpty();
+	}
+
+	@Test
+	@DisplayName("운영자 섹션 제목에 단독 영문 Group/Code/Override/Evidence 를 쓰지 않는다")
+	void operatorSectionTitlesAreKorean() throws IOException {
+		Set<String> forbiddenExact = Set.of("Group", "Code", "Override 요청", "Evidence");
+		Path templates = ROOT.resolve("backend/src/main/resources/templates/admin");
+		List<String> violations = new ArrayList<>();
+		try (var paths = Files.walk(templates)) {
+			for (Path path : paths.filter(path -> path.toString().endsWith(".html")).toList()) {
+				String html = Files.readString(path);
+				Matcher matcher = H2_TAG.matcher(html);
+				while (matcher.find()) {
+					String text = matcher.group(1).trim();
+					boolean violates = forbiddenExact.contains(text)
+						|| text.startsWith("Code ")
+						|| text.equals("Alias")
+						|| text.startsWith("Alias ");
+					if (violates) {
+						violations.add(ROOT.relativize(path) + ": <h2>" + text + "</h2>");
+					}
+				}
+			}
+		}
+
+		assertThat(violations)
+			.as("영문 단독·혼재 섹션 제목(파일: <h2>텍스트</h2>): %s", violations)
+			.isEmpty();
+	}
+
+	@Test
+	@DisplayName("주 메뉴 토글은 데스크톱 숨김·좁은 화면 topbar leading 계약을 CSS에 유지한다")
+	void sidebarToggleDesktopHiddenNarrowTopbarLeading() throws IOException {
+		String components = read(CSS_COMPONENTS);
+
+		assertThat(components)
+			.as(">1024px 기본: 사이드바 토글 숨김")
+			.containsPattern(Pattern.compile(
+				"\\.admin-v3 \\.admin-sidebar-toggle \\{[^}]*display:\\s*none;", Pattern.DOTALL));
+
+		Matcher narrowMedia = Pattern.compile("@media \\(max-width: 1024px\\)\\s*\\{(.*)", Pattern.DOTALL)
+			.matcher(components);
+		assertThat(narrowMedia.find()).as("≤1024px media query가 존재한다").isTrue();
+		assertThat(narrowMedia.group(1))
+			.as("≤1024px: nav-control 안 토글을 inline-flex(또는 flex)로 노출")
+			.containsPattern(Pattern.compile(
+				"\\.admin-v3 \\.admin-sidebar-nav-control \\.admin-sidebar-toggle \\{[^}]*display:\\s*(inline-flex|flex);",
+				Pattern.DOTALL));
+
+		String shell = read("backend/src/main/resources/templates/admin/fragments/shell.html");
+		assertThat(shell)
+			.as("toggle는 admin-topbar-context 안 첫 컨트롤이다")
+			.containsPattern(Pattern.compile(
+				"<div class=\"admin-topbar-context\">\\s*(?:<!--.*?-->\\s*)?<div class=\"admin-sidebar-nav-control\"",
+				Pattern.DOTALL))
+			.doesNotContain("☰")
+			.contains("icon('menu')")
+			.contains("aria-label=\"주 메뉴 열기·닫기\"");
 	}
 
 	private static int count(Pattern pattern, String source) {

--- a/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DataSourceSnapshotAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DataSourceSnapshotAdminPageControllerTest.java
@@ -149,8 +149,8 @@ class DataSourceSnapshotAdminPageControllerTest {
 			.contains("snapshot-kric-20260629")
 			.contains("raw sha256")
 			.contains("s3://easysubway-datapack-sources/kric-station-elevator/snapshot-kric-20260629.json")
-			.contains("credential redacted")
-			.contains("raw retention")
+			.contains("자격증명 마스킹")
+			.contains("원본 보존")
 			.contains("name=\"commandToken\"")
 			.contains("잠금 스냅샷 저장")
 			.doesNotContain("serviceKey");

--- a/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackCandidateAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackCandidateAdminPageControllerTest.java
@@ -93,7 +93,7 @@ class DatapackCandidateAdminPageControllerTest {
 			.contains("프로덕션 반영 가능")
 			.contains("name=\"commandToken\"")
 			.contains("게이트 재실행")
-			.doesNotContain("production 승인")
+			.doesNotContain("프로덕션 승인")
 			.doesNotContain("serviceKey");
 	}
 

--- a/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackReleaseBlockerSummaryAdminPageTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackReleaseBlockerSummaryAdminPageTest.java
@@ -309,7 +309,7 @@ class DatapackReleaseBlockerSummaryAdminPageTest {
 			.contains("Android 증거")
 			.contains("매니페스트 서명")
 			.contains("수동 오버라이드")
-			.contains("FAIL")
+			.contains("실패")
 			.contains("확인 필요");
 	}
 
@@ -334,7 +334,7 @@ class DatapackReleaseBlockerSummaryAdminPageTest {
 		assertThat(qualityHtml)
 			.contains("소스 최신성")
 			.contains("SOURCE_SNAPSHOT_EXPIRED")
-			.contains("FAIL");
+			.contains("실패");
 		assertThat(pipelineHtml)
 			.contains("원천 스냅샷")
 			.contains("차단 요인 1건");

--- a/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackReleaseChannelAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackReleaseChannelAdminPageControllerTest.java
@@ -79,7 +79,7 @@ class DatapackReleaseChannelAdminPageControllerTest {
 			.contains("https://github.com/AquilaXk/easysubway/actions/runs/1128")
 			.contains("name=\"commandToken\"")
 			.contains("rollback 실행")
-			.contains("production 승인")
+			.contains("프로덕션 승인")
 			.doesNotContain("serviceKey")
 			.doesNotContain("OBJECT_STORAGE_SECRET");
 	}


### PR DESCRIPTION
## 관련 이슈

Closes #2425

## 작업 내용

- 데이터팩·공통코드 목록 표 헤더·섹션 제목·placeholder·채널/상태 **표시**를 한국어로 정리 (폼 `name`·enum value·URL 불변)
- `AdminDesignGuardTest`에 영문 `<th>`/섹션 금지와 주 메뉴 토글(데스크톱 숨김 · ≤1024px topbar leading · SVG·44px) CSS/마크업 계약 가드 추가
- source-snapshots 상세·품질 대시보드 PASS/FAIL·영문 섹션 라벨 정리
- 리뷰 finding 반영: 승격 버튼 채널별 표시, 경로 게이트 「검증 시각」 헤더 분리, 자격증명 마스킹 셀 한국어 표시
- 검색 submit `primary` 금지 회귀 확인(변경 없음)
- 로컬 증거: `.codex/evidence/2425-admin-hig-followup/` (커밋 제외)

## 검증

- `./gradlew test --tests 'com.easysubway.admin.web.AdminDesignGuardTest' --tests 'com.easysubway.admin.adapter.in.web.AdminAccessibilitySmokeTest'` → green
- 관련 page controller 문자열 앵커 갱신 후 green
- `node --test tools/ci/repository-contract.test.mjs` → 220 pass (gate 미변경)
- Playwright 재캡처: 햄버거 `(x=16,y=22,44×44)`, `aria-label="주 메뉴 열기·닫기"` 확인
- Bugbot finding 4 thread resolve 완료 (`isResolved=true`)

## 영향

- [x] 제품/운영 위험 없음 (route/accessibility/mobile UX/backend API/auth/security 아님)
- [x] DB migration 없음
- [x] 배포 영향 없음
- [x] route/realtime/datapack contract 영향 없음
- [x] CI workflow·계약 테스트·release gate JSON 변경 없음 (있으면 full.md로 전환)

## 체크리스트

- [x] 이 PR은 B/C등급 작업이며 full template이 필요 없다.
- [x] CI 결과를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 폴백 리뷰를 단일 PR review로 게시했다.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only Thymeleaf and test changes; no API, auth, or data contract changes. Residual risk is minor copy/display mismatches caught by updated guard and smoke tests.
> 
> **Overview**
> **관리자 HIG 후속**으로 데이터팩·공통코드·품질 대시보드 등 Thymeleaf 화면의 **운영자용 문구**를 한국어로 맞춥니다. 표 `<th>`, `<h2>` 섹션 제목, 검색 placeholder, 폼 라벨·예시 placeholder, 페이지 설명을 영문 필드명 대신 한국어로 바꾸며, 폼 `name`·enum value·URL은 그대로 둡니다.
> 
> **표시 로직**은 채널(`production`/`staging`/`dev`)·`PASS`/`FAIL` 같은 값을 화면에서 **프로덕션·통과·실패** 등으로 매핑하고, 배포 채널 승격 버튼은 채널에 따라 **프로덕션 승인** vs **승격 승인**으로 나뉩니다. source-snapshot 상세는 행 라벨·자격증명 마스킹 문구를 정리했습니다.
> 
> **회귀 방지**로 `AdminDesignGuardTest`에 데이터팩·공통코드 목록의 금지 영문 `<th>` 토큰, 운영자 `<h2>` 금지 패턴, 주 메뉴 토글(데스크톱 숨김·≤1024px 노출·SVG·`aria-label`) CSS/셸 마크업 계약 검사를 추가했고, 관련 page controller 테스트의 HTML 앵커 문자열을 갱신했습니다.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d67df67e28a1610de4329ee142893dec18e5a987. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->