### PR TITLE
[Chore] #2427 내부 HTTP 사용처 NOSONAR 보강

### DIFF
--- a/tools/ops/verify-production-route-v2-capacity.sh
+++ b/tools/ops/verify-production-route-v2-capacity.sh
@@ -454,7 +454,7 @@ docker run -d --name "${clone_gateway}" --network "${network}" --network-alias g
 gateway_base="http://gateway:8081" # NOSONAR -- 격리된 내부 docker 네트워크(gateway) 전용 평문 HTTP, TLS는 프로덕션 엣지에서 종단한다.
 gateway_ready=false
 for _ in $(seq 1 60); do
-	if [[ "$(docker exec "${clone_curl}" curl -sS --noproxy '*' --connect-timeout 1 --max-time 2 -o /dev/null -w '%{http_code}' "${gateway_base}/" 2>/dev/null || true)" == 404 ]]; then
+	if [[ "$(docker exec "${clone_curl}" curl -sS --noproxy '*' --connect-timeout 1 --max-time 2 -o /dev/null -w '%{http_code}' "${gateway_base}/" 2>/dev/null || true)" == 404 ]]; then # NOSONAR
 		gateway_ready=true
 		break
 	fi
@@ -522,7 +522,7 @@ process.stdout.write(JSON.stringify({ integrityToken: `${nonce}.${signature}`, c
 		--request POST --header 'content-type: application/json' \
 		--header "CF-Connecting-IP: ${client_ip}" \
 		--data-binary "${session_request}" \
-		"${gateway_base}/api/v2/routes/session")"
+		"${gateway_base}/api/v2/routes/session")" # NOSONAR
 	last_status="${result%% *}"
 	time_seconds="${result#* }"
 	latency_ms="$(node -e 'const value = Number(process.argv[1]); if (!Number.isFinite(value)) process.exit(1); process.stdout.write(String(Math.round(value * 1000)));' "${time_seconds}")"
@@ -558,7 +558,7 @@ send_search() {
 		-D "$(to_curl_mount_path "${last_headers}")" -o "$(to_curl_mount_path "${last_body}")" -w '%{http_code} %{time_total}' \
 		--request POST --header 'content-type: application/json' \
 		--header "CF-Connecting-IP: ${client_ip}" --header "Authorization: Bearer ${token}" \
-		--data-binary "${request_body}" "${gateway_base}/api/v2/routes/search")"
+		--data-binary "${request_body}" "${gateway_base}/api/v2/routes/search")" # NOSONAR
 	last_status="${result%% *}"
 	time_seconds="${result#* }"
 	latency_ms="$(node -e 'const value = Number(process.argv[1]); if (!Number.isFinite(value)) process.exit(1); process.stdout.write(String(Math.round(value * 1000)));' "${time_seconds}")"
@@ -711,7 +711,7 @@ for ((index = 0; index <= search_burst; index += 1)); do
 			-D "$(to_curl_mount_path "${burst_headers}")" -o "$(to_curl_mount_path "${burst_body}")" -w '%{http_code} %{time_total}' \
 			--request POST --header 'content-type: application/json' \
 			--header 'CF-Connecting-IP: 198.51.100.200' --header "Authorization: Bearer ${burst_token}" \
-			--data-binary "${request_body}" "${gateway_base}/api/v2/routes/search" > "${burst_result}"
+			--data-binary "${request_body}" "${gateway_base}/api/v2/routes/search" > "${burst_result}" # NOSONAR
 	) &
 	burst_pids+=("$!")
 	burst_headers_files+=("${burst_headers}")

--- a/tools/ops/verify-production-timetable-snapshot.sh
+++ b/tools/ops/verify-production-timetable-snapshot.sh
@@ -195,7 +195,7 @@ for _ in $(seq 1 90); do
 		echo 'controlled cache application stopped before readiness' >&2
 		exit 1
 	fi
-	if [[ "$(curl -sS --noproxy '*' --connect-timeout 1 --max-time 2 -o /dev/null -w '%{http_code}' "${cache_base_url}/actuator/health/readiness" 2>/dev/null || true)" == 200 ]]; then
+	if [[ "$(curl -sS --noproxy '*' --connect-timeout 1 --max-time 2 -o /dev/null -w '%{http_code}' "${cache_base_url}/actuator/health/readiness" 2>/dev/null || true)" == 200 ]]; then # NOSONAR
 		cache_ready=true
 		break
 	fi
@@ -222,7 +222,7 @@ for attempt in 0 1; do
 	chmod 600 "${curl_config}"
 	status="$(curl --config "${curl_config}" -sS --noproxy '*' --connect-timeout 2 --max-time 10 --output "${response_file}" --write-out '%{http_code}' \
 		--request POST --header 'content-type: application/json' \
-		--data-binary "${request_body}" "${cache_base_url}/api/v2/routes/search")"
+		--data-binary "${request_body}" "${cache_base_url}/api/v2/routes/search")" # NOSONAR
 	rm -f "${curl_config}"
 	route_state_id="$(node -e '
 const response = JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8"));


### PR DESCRIPTION
## 관련 이슈

Closes #2427
Refs #2268

## 작업 내용

- #2424 이후 main New Code에 남은 `shell:S5332` MINOR 9건 해소
- 내부 docker/루프백 HTTP 할당부 NOSONAR만으로는 사용처 탐지가 남아, `${gateway_base}`/`${cache_base_url}` curl 사용 라인에 NOSONAR 보강
- 제품 동작·엔드포인트 변경 없음

## 검증

- 실행한 명령과 결과:
  - `bash -n` 대상 2스크립트 → OK

## 영향

- [x] 제품/운영 위험 없음 (route/accessibility/mobile UX/backend API/auth/security 아님)
- [x] DB migration 없음
- [x] 배포 영향 없음
- [x] route/realtime/datapack contract 영향 없음
- [x] CI workflow·계약 테스트·release gate JSON 변경 없음 (있으면 full.md로 전환)

## 체크리스트

- [x] 이 PR은 B/C등급 작업이며 full template이 필요 없다.
- [ ] CI 결과를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 폴백 리뷰를 단일 PR review로 게시했다.

Made with [Cursor](https://cursor.com)