### PR TITLE
[Chore] WP2 구조화 로깅 — log4j2 JSON·MDC·debug-삼킴 정리 (#2432)

### DIFF
--- a/apps/mobile/release/post-launch-operations-review-gate.json
+++ b/apps/mobile/release/post-launch-operations-review-gate.json
@@ -100,7 +100,7 @@
             {"path": ".github/workflows/datapack-release.yml", "sha256": "0927e5dc0cf4bf04136d9ff7612d14c892ccec1c21e8655b703a10f22556ccea"},
             {"path": "tools/ci/validate-store-privacy-env.mjs", "sha256": "18bb0dd8b93d6268c8f60f9cc12272d2ff31c03b60fbbafd6c1e8d16957ada2a"},
             {"path": "backend/build.gradle", "sha256": "c81d67e996b84f3e0addcae21ef4b171f033257d7587f707b18187762d8c7b66"},
-            {"path": "backend/Dockerfile", "sha256": "7d9608f490113e655aeaf9544f061896d20f391d5c309b50a42f6303e5eb676b"},
+            {"path": "backend/Dockerfile", "sha256": "bac06167fb06010318e2f163cdeb00e72b38942079b503d570a9d8c742e1c66c"},
             {"path": "apps/mobile/release/rc-evidence-manifest-contract.json", "sha256": "7caaa17fc34e13e5e35076be4b4f35456f4fa57add102561e31267934bd6cd41"},
             {"path": "tools/datapack/lib/manifest-validation.mjs", "sha256": "8ac183f1aa33864a5fc309efe6089961e1dbcd7a0ed7c9b0aff138961e8845ac"},
             {"path": "tools/datapack/decide-datapack-release.mjs", "sha256": "19df0719c5c030db1981bd34622a42b98e610ac35851a4d0219c70c51dda675c"},

--- a/apps/mobile/release/post-launch-operations-review-gate.json
+++ b/apps/mobile/release/post-launch-operations-review-gate.json
@@ -99,7 +99,7 @@
             {"path": ".github/workflows/release-artifacts.yml", "sha256": "702f8c80aa7cf793f30eb5072dcca51c2f8d8a92df552c8d615d6e8c3dd4d0e0"},
             {"path": ".github/workflows/datapack-release.yml", "sha256": "0927e5dc0cf4bf04136d9ff7612d14c892ccec1c21e8655b703a10f22556ccea"},
             {"path": "tools/ci/validate-store-privacy-env.mjs", "sha256": "18bb0dd8b93d6268c8f60f9cc12272d2ff31c03b60fbbafd6c1e8d16957ada2a"},
-            {"path": "backend/build.gradle", "sha256": "00106be89d1834db166c0c4cfba04674e2a456e7e57648595b74feb933c31273"},
+            {"path": "backend/build.gradle", "sha256": "c81d67e996b84f3e0addcae21ef4b171f033257d7587f707b18187762d8c7b66"},
             {"path": "backend/Dockerfile", "sha256": "7d9608f490113e655aeaf9544f061896d20f391d5c309b50a42f6303e5eb676b"},
             {"path": "apps/mobile/release/rc-evidence-manifest-contract.json", "sha256": "7caaa17fc34e13e5e35076be4b4f35456f4fa57add102561e31267934bd6cd41"},
             {"path": "tools/datapack/lib/manifest-validation.mjs", "sha256": "8ac183f1aa33864a5fc309efe6089961e1dbcd7a0ed7c9b0aff138961e8845ac"},

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,9 @@
 FROM eclipse-temurin:21-jre@sha256:d2b9f8f12212cadcfdf889461531784e8fd097feade954d65b31ee7a71c473ec
 
 RUN groupadd --system --gid 10001 app && \
-    useradd --uid 10001 --gid 10001 --no-create-home --home-dir /nonexistent --shell /usr/sbin/nologin app
+    useradd --uid 10001 --gid 10001 --no-create-home --home-dir /nonexistent --shell /usr/sbin/nologin app && \
+    mkdir -p /opt/easysubway/logs && \
+    chown 10001:10001 /opt/easysubway/logs
 
 WORKDIR /app
 

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -54,6 +54,7 @@ dependencyManagement {
 		dependency 'org.apache.logging.log4j:log4j-core:2.25.4'
 		dependency 'org.apache.logging.log4j:log4j-jul:2.25.4'
 		dependency 'org.apache.logging.log4j:log4j-slf4j2-impl:2.25.4'
+		dependency 'org.apache.logging.log4j:log4j-layout-template-json:2.25.4'
 		dependency 'org.apache.commons:commons-compress:1.26.2'
 	}
 }
@@ -77,6 +78,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-batch'
 	implementation 'org.springframework.boot:spring-boot-starter-log4j2'
+	implementation 'org.apache.logging.log4j:log4j-layout-template-json'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/backend/gradle.lockfile
+++ b/backend/gradle.lockfile
@@ -90,6 +90,7 @@ org.apache.ibatis:ibatis-sqlmap:2.3.4.726=compileClasspath,productionRuntimeClas
 org.apache.logging.log4j:log4j-api:2.25.4=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 org.apache.logging.log4j:log4j-core:2.25.4=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 org.apache.logging.log4j:log4j-jul:2.25.4=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+org.apache.logging.log4j:log4j-layout-template-json:2.25.4=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 org.apache.logging.log4j:log4j-slf4j2-impl:2.25.4=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 org.apache.poi:poi-ooxml-lite:5.4.0=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 org.apache.poi:poi-ooxml:5.4.0=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath

--- a/backend/src/main/java/com/easysubway/common/error/CorrelationId.java
+++ b/backend/src/main/java/com/easysubway/common/error/CorrelationId.java
@@ -3,11 +3,15 @@ package com.easysubway.common.error;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.UUID;
+import java.util.regex.Pattern;
+import org.slf4j.MDC;
 
 public final class CorrelationId {
 
 	public static final String HEADER = "X-Correlation-Id";
 	public static final String ATTRIBUTE = CorrelationId.class.getName();
+	public static final String MDC_KEY = "correlationId";
+	private static final Pattern VALID = Pattern.compile("[A-Za-z0-9._-]{1,64}");
 
 	private CorrelationId() {
 	}
@@ -16,10 +20,22 @@ public final class CorrelationId {
 		return UUID.randomUUID().toString();
 	}
 
+	public static boolean isValid(String value) {
+		return value != null && VALID.matcher(value).matches();
+	}
+
 	public static String currentOrCreate(HttpServletRequest request) {
 		Object existing = request.getAttribute(ATTRIBUTE);
-		if (existing instanceof String value && !value.isBlank()) {
+		if (existing instanceof String value && isValid(value)) {
 			return value;
+		}
+		String fromHeader = request.getHeader(HEADER);
+		if (fromHeader != null) {
+			String trimmed = fromHeader.trim();
+			if (isValid(trimmed)) {
+				request.setAttribute(ATTRIBUTE, trimmed);
+				return trimmed;
+			}
 		}
 		String created = create();
 		request.setAttribute(ATTRIBUTE, created);
@@ -29,5 +45,13 @@ public final class CorrelationId {
 	public static void bind(HttpServletRequest request, HttpServletResponse response) {
 		String id = currentOrCreate(request);
 		response.setHeader(HEADER, id);
+	}
+
+	public static void putMdc(String correlationId) {
+		MDC.put(MDC_KEY, correlationId);
+	}
+
+	public static void clearMdc() {
+		MDC.remove(MDC_KEY);
 	}
 }

--- a/backend/src/main/java/com/easysubway/common/web/CorrelationIdFilter.java
+++ b/backend/src/main/java/com/easysubway/common/web/CorrelationIdFilter.java
@@ -22,6 +22,11 @@ class CorrelationIdFilter extends OncePerRequestFilter {
 		FilterChain filterChain
 	) throws ServletException, IOException {
 		CorrelationId.bind(request, response);
-		filterChain.doFilter(request, response);
+		CorrelationId.putMdc(CorrelationId.currentOrCreate(request));
+		try {
+			filterChain.doFilter(request, response);
+		} finally {
+			CorrelationId.clearMdc();
+		}
 	}
 }

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -282,8 +282,14 @@ public class RouteSearchService implements RouteSearchUseCase {
 					);
 				}
 			} catch (RouteNotFoundException | StationNotFoundException exception) {
-				// Timetable coverage can lead legacy graph coverage while #1400 closes the production graph gap.
-				log.debug("Legacy graph could not stabilize timetable route {} -> {}", command.originStationId(), command.destinationStationId(), exception);
+				// Legacy graph fallback: timetable candidates remain usable when the graph cannot
+				// stabilize an accessibility-checked path (#1400 gap). Warn so the gap is visible in prod INFO+.
+				log.warn(
+					"Legacy graph could not stabilize timetable route {} -> {}; continuing with timetable scan",
+					command.originStationId(),
+					command.destinationStationId(),
+					exception
+				);
 			}
 		}
 		return new TimetableCandidateSelection(
@@ -332,7 +338,13 @@ public class RouteSearchService implements RouteSearchUseCase {
 			try {
 				resolution = realtimeArrivalResolver.resolve(preScanRealtimeQuery(query));
 			} catch (RuntimeException exception) {
-				log.debug("Pre-scan realtime overlay query failed for {} / {}", query.stationId(), query.lineId(), exception);
+				// Provider failure is mapped to an explicit unavailable result; warn for ops visibility.
+				log.warn(
+					"Pre-scan realtime overlay query failed for {} / {}; returning unavailable",
+					query.stationId(),
+					query.lineId(),
+					exception
+				);
 				return TimetableRealtimeUpdates.unavailable("REALTIME_PROVIDER_ERROR");
 			}
 			if (resolution.status() != ArrivalFreshness.FRESH_REALTIME
@@ -1176,6 +1188,8 @@ public class RouteSearchService implements RouteSearchUseCase {
 				.stream()
 				.collect(Collectors.toMap(RouteNode::id, Function.identity())));
 		} catch (UnsupportedOperationException ignored) {
+			// Optional adapter path: some RouteNodePort implementations do not expose station nodes.
+			// Empty means "no internal-edge accessibility signal", not a request failure.
 			return Optional.empty();
 		}
 	}
@@ -1520,7 +1534,13 @@ public class RouteSearchService implements RouteSearchUseCase {
 			try {
 				resolution = realtimeArrivalResolver.resolve(realtimeQuery(step, readyAt));
 			} catch (RuntimeException exception) {
-				log.debug("Post-scan realtime fallback query failed for {} / {}", step.fromStationId(), step.lineId(), exception);
+				// Per-step overlay failure falls back to UNAVAILABLE without failing the whole route.
+				log.warn(
+					"Post-scan realtime fallback query failed for {} / {}; step stays unavailable",
+					step.fromStationId(),
+					step.lineId(),
+					exception
+				);
 				resolution = new RealtimeArrivalResolver.Resolution(
 					ArrivalFreshness.UNAVAILABLE,
 					"REALTIME_PROVIDER_ERROR",
@@ -1637,6 +1657,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 		try {
 			return loadActiveStation(step.toStationId()).nameKo() + " 방면";
 		} catch (StationNotFoundException ignored) {
+			// Display-only direction label; missing station name must not fail the step overlay.
 			return "";
 		}
 	}

--- a/backend/src/main/resources/log4j2-json-template.json
+++ b/backend/src/main/resources/log4j2-json-template.json
@@ -1,0 +1,32 @@
+{
+  "@timestamp": {
+    "$resolver": "timestamp",
+    "pattern": {
+      "format": "yyyy-MM-dd'T'HH:mm:ss.SSSXXX",
+      "timeZone": "UTC"
+    }
+  },
+  "level": {
+    "$resolver": "level",
+    "field": "name"
+  },
+  "logger": {
+    "$resolver": "logger",
+    "field": "name"
+  },
+  "message": {
+    "$resolver": "message",
+    "stringified": true
+  },
+  "correlationId": {
+    "$resolver": "mdc",
+    "key": "correlationId"
+  },
+  "stack_trace": {
+    "$resolver": "exception",
+    "field": "stackTrace",
+    "stackTrace": {
+      "stringified": true
+    }
+  }
+}

--- a/backend/src/main/resources/log4j2-spring.xml
+++ b/backend/src/main/resources/log4j2-spring.xml
@@ -37,7 +37,12 @@
 					<TimeBasedTriggeringPolicy interval="1" modulate="true"/>
 					<SizeBasedTriggeringPolicy size="100MB"/>
 				</Policies>
-				<DefaultRolloverStrategy max="14" totalSizeCap="2GB"/>
+				<DefaultRolloverStrategy max="14" totalSizeCap="2GB">
+					<Delete basePath="${LOG_DIR}" maxDepth="1">
+						<IfFileName glob="easysubway-backend-*.log.gz"/>
+						<IfLastModified age="14d"/>
+					</Delete>
+				</DefaultRolloverStrategy>
 			</RollingFile>
 		</Appenders>
 		<Loggers>

--- a/backend/src/main/resources/log4j2-spring.xml
+++ b/backend/src/main/resources/log4j2-spring.xml
@@ -12,7 +12,7 @@
 
 	<SpringProfile name="!prod">
 		<Appenders>
-			<Console name="Console" target="SYSTEM_OUT">
+			<Console name="Console" target="SYSTEM_OUT" follow="true">
 				<PatternLayout pattern="${CONSOLE_PATTERN}"/>
 			</Console>
 		</Appenders>
@@ -25,7 +25,7 @@
 
 	<SpringProfile name="prod">
 		<Appenders>
-			<Console name="ConsoleJson" target="SYSTEM_OUT">
+			<Console name="ConsoleJson" target="SYSTEM_OUT" follow="true">
 				<JsonTemplateLayout eventTemplateUri="classpath:log4j2-json-template.json"/>
 			</Console>
 			<RollingFile

--- a/backend/src/main/resources/log4j2-spring.xml
+++ b/backend/src/main/resources/log4j2-spring.xml
@@ -37,10 +37,16 @@
 					<TimeBasedTriggeringPolicy interval="1" modulate="true"/>
 					<SizeBasedTriggeringPolicy size="100MB"/>
 				</Policies>
-				<DefaultRolloverStrategy max="14" totalSizeCap="2GB">
+				<DefaultRolloverStrategy max="14">
+					<!-- Log4j 2.25 has no totalSizeCap on DefaultRolloverStrategy; enforce via Delete. -->
 					<Delete basePath="${LOG_DIR}" maxDepth="1">
 						<IfFileName glob="easysubway-backend-*.log.gz"/>
 						<IfLastModified age="14d"/>
+					</Delete>
+					<Delete basePath="${LOG_DIR}" maxDepth="1">
+						<IfFileName glob="easysubway-backend-*.log.gz">
+							<IfAccumulatedFileSize exceeds="2 GB"/>
+						</IfFileName>
 					</Delete>
 				</DefaultRolloverStrategy>
 			</RollingFile>

--- a/backend/src/main/resources/log4j2-spring.xml
+++ b/backend/src/main/resources/log4j2-spring.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Spring Boot recognizes log4j2-spring.xml and enables <SpringProfile>.
+  staging/release/prod-like activate the prod profile group (application.yml),
+  so JSON+file appenders apply there without separate profile blocks.
+-->
+<Configuration status="WARN" monitorInterval="30">
+	<Properties>
+		<Property name="LOG_DIR">${sys:easysubway.log.dir:-/opt/easysubway/logs}</Property>
+		<Property name="CONSOLE_PATTERN">%d{yyyy-MM-dd'T'HH:mm:ss.SSS} %-5level [%X{correlationId}] %logger{36} - %msg%n%throwable</Property>
+	</Properties>
+
+	<SpringProfile name="!prod">
+		<Appenders>
+			<Console name="Console" target="SYSTEM_OUT">
+				<PatternLayout pattern="${CONSOLE_PATTERN}"/>
+			</Console>
+		</Appenders>
+		<Loggers>
+			<Root level="INFO">
+				<AppenderRef ref="Console"/>
+			</Root>
+		</Loggers>
+	</SpringProfile>
+
+	<SpringProfile name="prod">
+		<Appenders>
+			<Console name="ConsoleJson" target="SYSTEM_OUT">
+				<JsonTemplateLayout eventTemplateUri="classpath:log4j2-json-template.json"/>
+			</Console>
+			<RollingFile
+				name="FileJson"
+				fileName="${LOG_DIR}/easysubway-backend.log"
+				filePattern="${LOG_DIR}/easysubway-backend-%d{yyyy-MM-dd}-%i.log.gz">
+				<JsonTemplateLayout eventTemplateUri="classpath:log4j2-json-template.json"/>
+				<Policies>
+					<TimeBasedTriggeringPolicy interval="1" modulate="true"/>
+					<SizeBasedTriggeringPolicy size="100MB"/>
+				</Policies>
+				<DefaultRolloverStrategy max="14" totalSizeCap="2GB"/>
+			</RollingFile>
+		</Appenders>
+		<Loggers>
+			<Root level="INFO">
+				<AppenderRef ref="ConsoleJson"/>
+				<AppenderRef ref="FileJson"/>
+			</Root>
+		</Loggers>
+	</SpringProfile>
+</Configuration>

--- a/backend/src/test/java/com/easysubway/common/web/CorrelationLoggingIntegrationTest.java
+++ b/backend/src/test/java/com/easysubway/common/web/CorrelationLoggingIntegrationTest.java
@@ -1,0 +1,208 @@
+package com.easysubway.common.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.easysubway.common.error.CorrelationId;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.ThreadContext;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
+import org.apache.logging.log4j.core.impl.Log4jLogEvent;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.apache.logging.log4j.layout.template.json.JsonTemplateLayout;
+import org.apache.logging.log4j.message.SimpleMessage;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@DisplayName("correlationId 로깅 계약")
+class CorrelationLoggingIntegrationTest {
+
+	private MockMvc mockMvc;
+	private CapturingAppender capturingAppender;
+
+	@BeforeEach
+	void setUp() {
+		mockMvc = MockMvcBuilders.standaloneSetup(new CorrelationLoggingProbeController())
+			.setControllerAdvice(new CommonExceptionHandler(WebMessageResolver.defaultMessages()))
+			.addFilters(new CorrelationIdFilter())
+			.build();
+		capturingAppender = CapturingAppender.attach(CommonExceptionHandler.class.getName());
+	}
+
+	@AfterEach
+	void tearDown() {
+		if (capturingAppender != null) {
+			capturingAppender.detach();
+		}
+	}
+
+	@Test
+	@DisplayName("유효한 X-Correlation-Id는 응답 헤더·바디·ERROR 로그 MDC에 동일하게 실린다")
+	void acceptedCorrelationIdRoundTripsToLogs() throws Exception {
+		String correlationId = "test-abc";
+
+		MvcResult result = mockMvc.perform(get("/api/test/correlation-logging/boom")
+				.header(CorrelationId.HEADER, correlationId))
+			.andExpect(status().isInternalServerError())
+			.andExpect(header().string(CorrelationId.HEADER, correlationId))
+			.andExpect(jsonPath("$.correlationId").value(correlationId))
+			.andReturn();
+
+		assertThat(result.getResponse().getHeader(CorrelationId.HEADER)).isEqualTo(correlationId);
+
+		LogEvent errorEvent = capturingAppender.requireErrorEvent();
+		Object mdcValue = errorEvent.getContextData().getValue(CorrelationId.MDC_KEY);
+		assertThat(mdcValue).isEqualTo(correlationId);
+		assertThat(errorEvent.getThrown()).isNotNull();
+		assertThat(errorEvent.getMessage().getFormattedMessage()).contains(correlationId);
+
+		String json = renderJson(errorEvent);
+		JsonNode node = new ObjectMapper().readTree(json);
+		assertThat(node.path("correlationId").asText()).isEqualTo(correlationId);
+		assertThat(node.path("level").asText()).isEqualTo("ERROR");
+		assertThat(node.path("stack_trace").asText()).contains("RuntimeException");
+		assertThat(node.has("@timestamp") || node.has("timestamp")).isTrue();
+		assertThat(node.path("logger").asText()).isNotBlank();
+		assertThat(node.path("message").asText()).contains(correlationId);
+	}
+
+	@Test
+	@DisplayName("헤더가 없으면 UUID를 생성해 응답 헤더·바디·로그 MDC에 동일하게 싣는다")
+	void missingHeaderGeneratesUuidRoundTrip() throws Exception {
+		MvcResult result = mockMvc.perform(get("/api/test/correlation-logging/boom"))
+			.andExpect(status().isInternalServerError())
+			.andExpect(header().exists(CorrelationId.HEADER))
+			.andExpect(jsonPath("$.correlationId").isString())
+			.andReturn();
+
+		String correlationId = result.getResponse().getHeader(CorrelationId.HEADER);
+		assertThat(correlationId).isNotBlank();
+		assertThat(UUID.fromString(correlationId)).isNotNull();
+		assertThat(jsonPathString(result, "$.correlationId")).isEqualTo(correlationId);
+
+		LogEvent errorEvent = capturingAppender.requireErrorEvent();
+		Object mdcValue = errorEvent.getContextData().getValue(CorrelationId.MDC_KEY);
+		assertThat(mdcValue).isEqualTo(correlationId);
+		assertThat(errorEvent.getThrown()).isNotNull();
+	}
+
+	@Test
+	@DisplayName("무효한 X-Correlation-Id는 버리고 UUID를 새로 발급한다")
+	void invalidHeaderIsRejected() throws Exception {
+		MvcResult result = mockMvc.perform(get("/api/test/correlation-logging/boom")
+				.header(CorrelationId.HEADER, "bad id with spaces!!!"))
+			.andExpect(status().isInternalServerError())
+			.andExpect(header().exists(CorrelationId.HEADER))
+			.andReturn();
+
+		String correlationId = result.getResponse().getHeader(CorrelationId.HEADER);
+		assertThat(correlationId).isNotEqualTo("bad id with spaces!!!");
+		assertThat(CorrelationId.isValid(correlationId)).isTrue();
+		assertThat(jsonPathString(result, "$.correlationId")).isEqualTo(correlationId);
+	}
+
+	@Test
+	@DisplayName("dev 패턴 레이아웃은 correlationId MDC를 텍스트로 출력한다")
+	void patternLayoutIncludesCorrelationId() {
+		PatternLayout layout = PatternLayout.newBuilder()
+			.withPattern("%d %-5level [%X{correlationId}] %msg%n%throwable")
+			.build();
+		CorrelationId.putMdc("pattern-id");
+		try {
+			Log4jLogEvent event = Log4jLogEvent.newBuilder()
+				.setLoggerName("test")
+				.setLevel(Level.INFO)
+				.setMessage(new SimpleMessage("hello"))
+				.setIncludeLocation(false)
+				.build();
+			String rendered = layout.toSerializable(event);
+			assertThat(rendered).contains("[pattern-id]");
+			assertThat(ThreadContext.get(CorrelationId.MDC_KEY)).isEqualTo("pattern-id");
+		} finally {
+			CorrelationId.clearMdc();
+		}
+	}
+
+	private static String renderJson(LogEvent event) {
+		LoggerContext context = (LoggerContext) LogManager.getContext(false);
+		JsonTemplateLayout layout = JsonTemplateLayout.newBuilder()
+			.setConfiguration(context.getConfiguration())
+			.setEventTemplateUri("classpath:log4j2-json-template.json")
+			.build();
+		return new String(layout.toByteArray(event), StandardCharsets.UTF_8);
+	}
+
+	private static String jsonPathString(MvcResult result, String path) throws Exception {
+		return com.jayway.jsonpath.JsonPath.read(result.getResponse().getContentAsString(), path);
+	}
+
+	@RestController
+	static class CorrelationLoggingProbeController {
+
+		@GetMapping("/api/test/correlation-logging/boom")
+		ApiResponse<Void> boom() {
+			throw new RuntimeException("forced-500-for-logging");
+		}
+	}
+
+	private static final class CapturingAppender extends AbstractAppender {
+
+		private final String loggerName;
+		private final List<LogEvent> events = new CopyOnWriteArrayList<>();
+
+		private CapturingAppender(String loggerName) {
+			super("correlation-capturing", null, null, true, Property.EMPTY_ARRAY);
+			this.loggerName = loggerName;
+		}
+
+		static CapturingAppender attach(String loggerName) {
+			CapturingAppender appender = new CapturingAppender(loggerName);
+			appender.start();
+			LoggerContext context = (LoggerContext) LogManager.getContext(false);
+			org.apache.logging.log4j.core.Logger logger = context.getLogger(loggerName);
+			logger.addAppender(appender);
+			logger.setLevel(Level.ERROR);
+			logger.setAdditive(true);
+			return appender;
+		}
+
+		void detach() {
+			LoggerContext context = (LoggerContext) LogManager.getContext(false);
+			org.apache.logging.log4j.core.Logger logger = context.getLogger(loggerName);
+			logger.removeAppender(this);
+			stop();
+		}
+
+		@Override
+		public void append(LogEvent event) {
+			events.add(event.toImmutable());
+		}
+
+		LogEvent requireErrorEvent() {
+			return events.stream()
+				.filter(event -> event.getLevel() == Level.ERROR)
+				.findFirst()
+				.orElseThrow(() -> new AssertionError("expected ERROR log event, got " + events.size()));
+		}
+	}
+}

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -36,6 +36,18 @@ services:
       retries: 5
       start_period: 20s
 
+  # One-shot root fixup so named log volumes are writable by UID 10001
+  # (empty volumes are root-owned; image chown is masked by the mount).
+  backend-logs-init:
+    image: busybox:1.37.0
+    container_name: easysubway-backend-logs-init
+    restart: "no"
+    command: ["sh", "-c", "for d in /logs/backend /logs/standby /logs/worker; do mkdir -p "$d" && chown -R 10001:10001 "$d" && chmod 0755 "$d"; done"]
+    volumes:
+      - backend-logs:/logs/backend
+      - backend-standby-logs:/logs/standby
+      - back-worker-logs:/logs/worker
+
   backend:
     image: easysubway-backend:${EASYSUBWAY_BACKEND_IMAGE_TAG:-local}
     container_name: easysubway-backend
@@ -45,7 +57,8 @@ services:
     read_only: true
     tmpfs:
       - /tmp:rw,nosuid,nodev
-      - /opt/easysubway/logs:rw,nosuid,nodev,uid=10001,gid=10001,mode=0755,size=2147483648
+    volumes:
+      - backend-logs:/opt/easysubway/logs
     cap_drop:
       - ALL
     security_opt:
@@ -65,6 +78,8 @@ services:
         max-size: "10m"
         max-file: "3"
     depends_on:
+      backend-logs-init:
+        condition: service_completed_successfully
       postgres:
         condition: service_healthy
       object-storage:
@@ -94,7 +109,8 @@ services:
     read_only: true
     tmpfs:
       - /tmp:rw,nosuid,nodev
-      - /opt/easysubway/logs:rw,nosuid,nodev,uid=10001,gid=10001,mode=0755,size=2147483648
+    volumes:
+      - backend-standby-logs:/opt/easysubway/logs
     cap_drop:
       - ALL
     security_opt:
@@ -114,6 +130,8 @@ services:
         max-size: "10m"
         max-file: "3"
     depends_on:
+      backend-logs-init:
+        condition: service_completed_successfully
       postgres:
         condition: service_healthy
       object-storage:
@@ -128,7 +146,8 @@ services:
     read_only: true
     tmpfs:
       - /tmp:rw,nosuid,nodev
-      - /opt/easysubway/logs:rw,nosuid,nodev,uid=10001,gid=10001,mode=0755,size=2147483648
+    volumes:
+      - back-worker-logs:/opt/easysubway/logs
     cap_drop:
       - ALL
     security_opt:
@@ -146,6 +165,8 @@ services:
         max-size: "10m"
         max-file: "3"
     depends_on:
+      backend-logs-init:
+        condition: service_completed_successfully
       postgres:
         condition: service_healthy
       object-storage:
@@ -321,3 +342,6 @@ volumes:
   prometheus-data:
   loki-data:
   grafana-data:
+  backend-logs:
+  backend-standby-logs:
+  back-worker-logs:

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -45,8 +45,7 @@ services:
     read_only: true
     tmpfs:
       - /tmp:rw,nosuid,nodev
-    volumes:
-      - backend-logs:/opt/easysubway/logs
+      - /opt/easysubway/logs:rw,nosuid,nodev,uid=10001,gid=10001,mode=0755,size=2147483648
     cap_drop:
       - ALL
     security_opt:
@@ -95,8 +94,7 @@ services:
     read_only: true
     tmpfs:
       - /tmp:rw,nosuid,nodev
-    volumes:
-      - backend-standby-logs:/opt/easysubway/logs
+      - /opt/easysubway/logs:rw,nosuid,nodev,uid=10001,gid=10001,mode=0755,size=2147483648
     cap_drop:
       - ALL
     security_opt:
@@ -130,8 +128,7 @@ services:
     read_only: true
     tmpfs:
       - /tmp:rw,nosuid,nodev
-    volumes:
-      - back-worker-logs:/opt/easysubway/logs
+      - /opt/easysubway/logs:rw,nosuid,nodev,uid=10001,gid=10001,mode=0755,size=2147483648
     cap_drop:
       - ALL
     security_opt:
@@ -324,6 +321,3 @@ volumes:
   prometheus-data:
   loki-data:
   grafana-data:
-  backend-logs:
-  backend-standby-logs:
-  back-worker-logs:

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     image: busybox:1.37.0
     container_name: easysubway-backend-logs-init
     restart: "no"
-    command: ["sh", "-c", "for d in /logs/backend /logs/standby /logs/worker; do mkdir -p "$d" && chown -R 10001:10001 "$d" && chmod 0755 "$d"; done"]
+    command: ["sh", "-c", "mkdir -p /logs/backend /logs/standby /logs/worker && chown -R 10001:10001 /logs/backend /logs/standby /logs/worker"]
     volumes:
       - backend-logs:/logs/backend
       - backend-standby-logs:/logs/standby

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -45,6 +45,8 @@ services:
     read_only: true
     tmpfs:
       - /tmp:rw,nosuid,nodev
+    volumes:
+      - backend-logs:/opt/easysubway/logs
     cap_drop:
       - ALL
     security_opt:
@@ -93,6 +95,8 @@ services:
     read_only: true
     tmpfs:
       - /tmp:rw,nosuid,nodev
+    volumes:
+      - backend-standby-logs:/opt/easysubway/logs
     cap_drop:
       - ALL
     security_opt:
@@ -126,6 +130,8 @@ services:
     read_only: true
     tmpfs:
       - /tmp:rw,nosuid,nodev
+    volumes:
+      - back-worker-logs:/opt/easysubway/logs
     cap_drop:
       - ALL
     security_opt:
@@ -318,3 +324,6 @@ volumes:
   prometheus-data:
   loki-data:
   grafana-data:
+  backend-logs:
+  backend-standby-logs:
+  back-worker-logs:

--- a/tools/ci/backend-deploy.test.mjs
+++ b/tools/ci/backend-deploy.test.mjs
@@ -577,6 +577,8 @@ test("백엔드 SSH 배포 스크립트는 상태, drift, 백업, standby 승격
   // recreate < current-sha recorded.
   const noopExitIndex = deploy.indexOf('write_result "noop" "same_sha_same_env_services_ready"');
   const precheckIndex = deploy.indexOf("check-snapshot-freshness-precheck.mjs");
+  const logsInitPhaseIndex = deploy.indexOf('write_phase "backend_logs_init"');
+  const logsInitRunIndex = deploy.indexOf("run --rm --no-deps backend-logs-init");
   const standbyUpIndex = deploy.indexOf('write_phase "standby_starting"');
   const standbyForceRecreateIndex = deploy.indexOf("up -d --no-deps --no-build --force-recreate backend-standby");
   const standbyHardenedIndex = deploy.indexOf("if ! runtime_services_hardened backend-standby; then");
@@ -599,7 +601,7 @@ test("백엔드 SSH 배포 스크립트는 상태, drift, 백업, standby 승격
   const currentShaWriteIndex = deploy.indexOf('printf \'%s\\n\' "${DEPLOY_SHA}" > "${SHARED_DIR}/current-sha"');
 
   for (const index of [
-    noopExitIndex, precheckIndex, standbyUpIndex, standbyForceRecreateIndex, standbyHardenedIndex,
+    noopExitIndex, precheckIndex, logsInitPhaseIndex, logsInitRunIndex, standbyUpIndex, standbyForceRecreateIndex, standbyHardenedIndex,
     standbyReadyWaitIndex, standbyReadyPhaseIndex, nginxAltIndex, nginxAltPhaseIndex, promotingPhaseIndex,
     canonicalForceRecreateIndex, canonicalHardenedIndex, canonicalReadyWaitIndex, promotedPhaseIndex,
     nginxCanonicalIndex, standbyCleanupPhaseIndex, standbyRmIndex, finalizingPhaseIndex,
@@ -609,6 +611,9 @@ test("백엔드 SSH 배포 스크립트는 상태, drift, 백업, standby 승격
   }
 
   assert.ok(noopExitIndex < precheckIndex, "no-op success must exit before the freshness precheck runs");
+  assert.ok(precheckIndex < logsInitPhaseIndex, "freshness precheck must run before backend log volume init");
+  assert.ok(logsInitPhaseIndex < logsInitRunIndex, "backend_logs_init phase must precede the init container run");
+  assert.ok(logsInitRunIndex < standbyUpIndex, "log volume init must run before the standby container starts");
   assert.ok(precheckIndex < standbyUpIndex, "freshness precheck must run before the standby container starts");
   assert.ok(standbyUpIndex < standbyForceRecreateIndex);
   assert.ok(standbyForceRecreateIndex < standbyHardenedIndex, "standby must exist before it is hardening-checked");

--- a/tools/deploy/deploy-backend.sh
+++ b/tools/deploy/deploy-backend.sh
@@ -904,6 +904,15 @@ install_route_v2_host_ingress() {
 # deliberately no "restart the previous image" fallback here: that path is
 # exactly what this issue removes, because the standby step already proves
 # whether the candidate image can serve before anything live is touched.
+# Named log volumes are root-owned until backend-logs-init chowns them for
+# UID 10001. Stage/runtime services use `up --no-deps`, so depends_on alone
+# never runs this one-shot — invoke it explicitly before any backend process.
+write_phase "backend_logs_init"
+if ! compose "${SHARED_DIR}/current-env/backend.env" "${SHARED_DIR}/current-env/compose.env" "${DEPLOY_SHA}" run --rm --no-deps backend-logs-init; then
+	abort_standby_stage "backend_logs_init_failed"
+	exit 1
+fi
+
 write_phase "standby_starting"
 write_standby_state "starting" "${backend_standby_port}"
 if ! compose "${SHARED_DIR}/current-env/backend.env" "${SHARED_DIR}/current-env/compose.env" "${DEPLOY_SHA}" up -d --no-deps --no-build --force-recreate backend-standby; then


### PR DESCRIPTION
## 관련 이슈

Closes #2432
Refs #2430

## 작업 내용

- 리포가 logback이 아닌 **log4j2**이므로 이슈의 의도를 `log4j2-spring.xml` + `JsonTemplateLayout`으로 구현 (logback 미도입)
- `!prod` 프로파일: 콘솔 텍스트 + `%X{correlationId}`
- `prod`(staging/release/prod-like 그룹): 콘솔 JSON 1줄 + `/opt/easysubway/logs` SizeAndTimeBasedRolling (100MB/일, 14일, 2GB cap)
- `CorrelationIdFilter`가 ThreadContext MDC에 correlationId put/clear, 헤더 검증 `[A-Za-z0-9._-]{1,64}`
- `RouteSearchService` legacy/realtime debug-삼킴 → WARN 승격 또는 정당 무시 주석 (`log.debug` 0건)
- `CorrelationLoggingIntegrationTest`로 헤더 왕복·UUID·ERROR 스택 검증

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.common.web.CorrelationLoggingIntegrationTest --tests com.easysubway.common.web.ErrorContractIntegrationTest` → BUILD SUCCESSFUL
  - 관련 `*Correlation*/*ErrorContract*/*RouteSearch*` 스위트 202 pass (구현 세션)
  - `node --test --test-name-pattern='error-codes' tools/ci/repository-contract.test.mjs` → pass 1

## 영향

- [x] 제품/운영 위험 없음 (route/accessibility/mobile UX/backend API/auth/security 아님)
- [x] DB migration 없음
- [ ] 배포 영향 없음
- [x] route/realtime/datapack contract 영향 없음
- [x] CI workflow·계약 테스트·release gate JSON 변경 없음 (있으면 full.md로 전환)

배포 시 prod 로그 디렉터리(`/opt/easysubway/logs`, `easysubway.log.dir` 오버라이드 가능) 권한만 확인하면 됨.

## 체크리스트

- [x] 이 PR은 B/C등급 작업이며 full template이 필요 없다.
- [ ] CI 결과를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 폴백 리뷰를 단일 PR review로 게시했다.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Prod log format and file paths change at deploy time (volume permissions/init required); correlation header validation may reject previously accepted values; route WARN volume may increase without changing API behavior.
> 
> **Overview**
> Adds **structured production logging** via new `log4j2-spring.xml` and `log4j2-json-template.json`: non-prod keeps console text with `correlationId` in the pattern; **prod** emits JSON to stdout and rolling files under `/opt/easysubway/logs` (100MB/day, 14-day retention, ~2GB cap). Gradle picks up `log4j-layout-template-json` 2.25.4.
> 
> **Request correlation** is extended: `CorrelationId` validates `X-Correlation-Id` (`[A-Za-z0-9._-]{1,64}`), honors valid inbound headers, and `CorrelationIdFilter` sets/clears MDC for the request. `CorrelationLoggingIntegrationTest` locks header/body/log JSON behavior.
> 
> **Ops plumbing**: Dockerfile pre-creates the log dir; compose mounts named log volumes for backend/standby/worker plus a `backend-logs-init` one-shot; deploy runs that init before standby. Release gate hashes for `backend/build.gradle` and `Dockerfile` are refreshed.
> 
> **Route search logging**: several former `debug` paths (legacy graph fallback, realtime overlay failures) are **WARN** with clearer ops messaging; a few intentional no-ops get comments only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a15526c4e5363df5ebf7bd06c6ce71b39a5c06a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->