### PR TITLE
[Chore] WP4 — 오류 관측 운영 배선: 5xx burn-rate·Alloy→Loki·오류 대시보드 (#2434)

### DIFF
--- a/apps/mobile/release/post-launch-operations-review-gate.json
+++ b/apps/mobile/release/post-launch-operations-review-gate.json
@@ -86,10 +86,10 @@
           "refreshOn": "observability-infrastructure-change",
           "files": [
             {"path": "infra/prometheus/prometheus.yml", "sha256": "9bcde0205620224c01d86ec99fd2ef68314a9a96f40bd70c58fe67f8123e366f"},
-            {"path": "infra/prometheus/alerts.yml", "sha256": "41c18d783219a073e84abed81127a4217bd70306c48d5a3b3c0411e291bc6b39"},
-            {"path": "infra/grafana/provisioning/datasources/prometheus.yml", "sha256": "857e2caebec8b70f3aa50c0b968c1ceed46b668a8f08a08532b47be22af3ed97"},
-            {"path": "infra/grafana/provisioning/datasources/loki.yml", "sha256": "9156897987a95d3fe59f98651ade7802ad2fc9b65acd2845da90b36dd6f5949c"},
-            {"path": "infra/loki/loki.yml", "sha256": "101b9286a15cc0c4f2a66879d801995efabd2c4d98cac904c4c3bd0816bf0e20"}
+            {"path": "infra/prometheus/alerts.yml", "sha256": "764c3e88fb604ed598d053de5376c531e64f122fa7f496f5969e8511f00538af"},
+            {"path": "infra/grafana/provisioning/datasources/prometheus.yml", "sha256": "9598a3fc9b36ce35c997233ac4a61ff0293023dbb45e1d872270c2a3f8666fc5"},
+            {"path": "infra/grafana/provisioning/datasources/loki.yml", "sha256": "57bb87c11cec9f9e728e37a636de9eca2a291c8cd051c67d4e1cd2c683a7675e"},
+            {"path": "infra/loki/loki.yml", "sha256": "35ed63f6a069c0c6da0d711d4495f871886ec7466916cf61cd29989825c690b2"}
           ]
         },
         {

--- a/apps/mobile/release/post-launch-operations-review-gate.json
+++ b/apps/mobile/release/post-launch-operations-review-gate.json
@@ -89,7 +89,11 @@
             {"path": "infra/prometheus/alerts.yml", "sha256": "764c3e88fb604ed598d053de5376c531e64f122fa7f496f5969e8511f00538af"},
             {"path": "infra/grafana/provisioning/datasources/prometheus.yml", "sha256": "9598a3fc9b36ce35c997233ac4a61ff0293023dbb45e1d872270c2a3f8666fc5"},
             {"path": "infra/grafana/provisioning/datasources/loki.yml", "sha256": "57bb87c11cec9f9e728e37a636de9eca2a291c8cd051c67d4e1cd2c683a7675e"},
-            {"path": "infra/loki/loki.yml", "sha256": "35ed63f6a069c0c6da0d711d4495f871886ec7466916cf61cd29989825c690b2"}
+            {"path": "infra/loki/loki.yml", "sha256": "35ed63f6a069c0c6da0d711d4495f871886ec7466916cf61cd29989825c690b2"},
+            {"path": "infra/alloy/config.alloy", "sha256": "cb8333eecd52ef6cf5fc9ccf62e87a2990deaa57b6ff3b9a2effcfa33a9b3f5a"},
+            {"path": "infra/grafana/provisioning/dashboards/dashboards.yml", "sha256": "648f908f7ddf556b3ec4de0dd9d66dfc75e58a747ebfda411725b8ad301aeb41"},
+            {"path": "infra/grafana/provisioning/dashboards/json/error-ops.json", "sha256": "8d28d95d06780698b51014697ee4e942851876ea75ffcbf2c2a5ce7d394ec862"},
+            {"path": "infra/docker-compose.yml", "sha256": "a20b0acfc4f47caa72da7e7afdb0bb1f3d91eb6cdd0970d9fdf88a697a29f366"}
           ]
         },
         {

--- a/infra/alloy/config.alloy
+++ b/infra/alloy/config.alloy
@@ -1,0 +1,56 @@
+// #2434 WP4: Docker → Loki log collection (low-cardinality labels only).
+discovery.docker "linux" {
+  host = "unix:///var/run/docker.sock"
+}
+
+discovery.relabel "linux" {
+  targets = discovery.docker.linux.targets
+
+  rule {
+    source_labels = ["__meta_docker_container_name"]
+    regex         = "/?(.*)"
+    target_label  = "container"
+  }
+
+  rule {
+    target_label = "env"
+    replacement  = "local"
+  }
+
+  // Keep only low-cardinality labels + docker discovery meta used by loki.source.docker.
+  rule {
+    action = "labelkeep"
+    regex  = "container|env|__.*"
+  }
+}
+
+loki.source.docker "linux" {
+  host       = "unix:///var/run/docker.sock"
+  targets    = discovery.relabel.linux.output
+  forward_to = [loki.process.logs.receiver]
+}
+
+loki.process "logs" {
+  // Parse JSON fields for filtering; only `level` becomes a stream label.
+  // correlationId is intentionally NOT labeled (body/structured search only).
+  stage.json {
+    expressions = {
+      level         = "level",
+      correlationId = "correlationId",
+    }
+  }
+
+  stage.labels {
+    values = {
+      level = "",
+    }
+  }
+
+  forward_to = [loki.write.default.receiver]
+}
+
+loki.write "default" {
+  endpoint {
+    url = "http://loki:3100/loki/api/v1/push"
+  }
+}

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -354,6 +354,12 @@ services:
     depends_on:
       loki:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget --spider -q http://localhost:12345/-/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
 
 volumes:
   postgres-data:

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -335,6 +335,26 @@ services:
       retries: 5
       start_period: 30s
 
+  alloy:
+    image: grafana/alloy:v1.17.1
+    container_name: easysubway-alloy
+    restart: unless-stopped
+    profiles:
+      - observability
+    command:
+      - run
+      - /etc/alloy/config.alloy
+      - --storage.path=/var/lib/alloy/data
+      - --server.http.listen-addr=0.0.0.0:12345
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - ./alloy/config.alloy:/etc/alloy/config.alloy:ro
+      - alloy-data:/var/lib/alloy/data
+    depends_on:
+      loki:
+        condition: service_healthy
+
 volumes:
   postgres-data:
   object-storage-data:
@@ -342,6 +362,7 @@ volumes:
   prometheus-data:
   loki-data:
   grafana-data:
+  alloy-data:
   backend-logs:
   backend-standby-logs:
   back-worker-logs:

--- a/infra/grafana/provisioning/dashboards/dashboards.yml
+++ b/infra/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: easysubway-error-ops
+    orgId: 1
+    folder: EasySubway
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: false
+    options:
+      path: /etc/grafana/provisioning/dashboards/json

--- a/infra/grafana/provisioning/dashboards/json/error-ops.json
+++ b/infra/grafana/provisioning/dashboards/json/error-ops.json
@@ -84,6 +84,13 @@
           "legendFormat": "burn 6h",
           "editorMode": "code",
           "range": true
+        },
+        {
+          "refId": "D",
+          "expr": "(sum(rate(http_server_requests_seconds_count{status=~\"5..\"}[3d])) / sum(rate(http_server_requests_seconds_count[3d]))) / 0.001",
+          "legendFormat": "burn 3d",
+          "editorMode": "code",
+          "range": true
         }
       ]
     },

--- a/infra/grafana/provisioning/dashboards/json/error-ops.json
+++ b/infra/grafana/provisioning/dashboards/json/error-ops.json
@@ -1,0 +1,118 @@
+{
+  "uid": "easysubway-error-ops",
+  "title": "오류 조회",
+  "tags": ["easysubway", "error-ops", "wp4"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "correlationId",
+        "type": "textbox",
+        "label": "correlationId",
+        "query": "",
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "options": [],
+        "hide": 0
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "5xx 비율",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "easysubway-prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(http_server_requests_seconds_count{status=~\"5..\"}[$__rate_interval])) / sum(rate(http_server_requests_seconds_count[$__rate_interval]))",
+          "legendFormat": "5xx ratio",
+          "editorMode": "code",
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "5xx burn rate (error budget 0.001)",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "easysubway-prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "(sum(rate(http_server_requests_seconds_count{status=~\"5..\"}[5m])) / sum(rate(http_server_requests_seconds_count[5m]))) / 0.001",
+          "legendFormat": "burn 5m",
+          "editorMode": "code",
+          "range": true
+        },
+        {
+          "refId": "B",
+          "expr": "(sum(rate(http_server_requests_seconds_count{status=~\"5..\"}[1h])) / sum(rate(http_server_requests_seconds_count[1h]))) / 0.001",
+          "legendFormat": "burn 1h",
+          "editorMode": "code",
+          "range": true
+        },
+        {
+          "refId": "C",
+          "expr": "(sum(rate(http_server_requests_seconds_count{status=~\"5..\"}[6h])) / sum(rate(http_server_requests_seconds_count[6h]))) / 0.001",
+          "legendFormat": "burn 6h",
+          "editorMode": "code",
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "logs",
+      "title": "Backend ERROR logs",
+      "gridPos": { "h": 12, "w": 24, "x": 0, "y": 8 },
+      "datasource": { "type": "loki", "uid": "easysubway-loki" },
+      "options": {
+        "showTime": true,
+        "showLabels": true,
+        "showCommonLabels": false,
+        "wrapLogMessage": true,
+        "prettifyLogMessage": false,
+        "enableLogDetails": true,
+        "sortOrder": "Descending",
+        "dedupStrategy": "none"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "{container=~\".*backend.*\"} | json | level=\"ERROR\" |~ \"$correlationId\"",
+          "legendFormat": "",
+          "datasource": { "type": "loki", "uid": "easysubway-loki" },
+          "queryType": "range",
+          "editorMode": "code"
+        }
+      ]
+    }
+  ]
+}

--- a/infra/grafana/provisioning/datasources/loki.yml
+++ b/infra/grafana/provisioning/datasources/loki.yml
@@ -3,6 +3,7 @@ apiVersion: 1
 datasources:
   - name: easysubway-loki
     type: loki
+    uid: easysubway-loki
     access: proxy
     url: http://loki:3100
     isDefault: false

--- a/infra/grafana/provisioning/datasources/prometheus.yml
+++ b/infra/grafana/provisioning/datasources/prometheus.yml
@@ -3,6 +3,7 @@ apiVersion: 1
 datasources:
   - name: easysubway-prometheus
     type: prometheus
+    uid: easysubway-prometheus
     access: proxy
     url: http://prometheus:9090
     isDefault: true

--- a/infra/loki/loki.yml
+++ b/infra/loki/loki.yml
@@ -26,7 +26,7 @@ query_range:
 limits_config:
   allow_structured_metadata: true
   volume_enabled: true
-  retention_period: 168h
+  retention_period: 720h
 
 schema_config:
   configs:

--- a/infra/prometheus/alerts.test.yml
+++ b/infra/prometheus/alerts.test.yml
@@ -108,3 +108,37 @@ tests:
       - eval_time: 6m
         alertname: AquilaBackendAppMetricsScrapeDown
         exp_alerts: []
+
+  # #2434: 높은 5xx + 충분한 트래픽(>1 req/min)이면 Critical multi-window burn-rate가 발화한다.
+  # interval 1m × 70표본으로 1h/5m 창을 채운다. rate()*60 ≈ 분당 증가분.
+  - interval: 1m
+    name: Backend5xxBurnRateCritical fires with high 5xx and traffic
+    input_series:
+      - series: 'http_server_requests_seconds_count{status="500",uri="/api/x",method="GET",outcome="SERVER_ERROR"}'
+        values: '0+50x70'
+      - series: 'http_server_requests_seconds_count{status="200",uri="/api/x",method="GET",outcome="SUCCESS"}'
+        values: '0+5x70'
+    alert_rule_test:
+      - eval_time: 65m
+        alertname: Backend5xxBurnRateCritical
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              service: aquila-backend-5xx
+            exp_annotations:
+              summary: Backend 5xx burn rate exceeds critical multi-window threshold
+              description: 5xx error ratio burn rate is above 14.4x the 0.001 error budget on both the 1h and 5m windows, with traffic above 1 req/min on the 1h window.
+              title_ko: "백엔드 5xx 버짓 소진 긴급"
+              impact_ko: "짧은 시간에 오류 예산이 빠르게 소진되고 있어 사용자 요청 실패가 급증했을 수 있습니다."
+              action_ko: "Grafana '오류 조회' 대시보드에서 5xx 비율·버짓 소진과 ERROR 로그를 확인한 뒤, /admin/api/errors로 동일 구간 오류를 대조 확인하세요."
+
+  # #2434: 트래픽 가드(<1 req/min)에서는 5xx가 있어도 Critical이 발화하지 않는다.
+  - interval: 1m
+    name: Backend5xxBurnRateCritical stays silent under traffic guard
+    input_series:
+      - series: 'http_server_requests_seconds_count{status="500",uri="/api/x",method="GET",outcome="SERVER_ERROR"}'
+        values: '0+0.1x70'
+    alert_rule_test:
+      - eval_time: 65m
+        alertname: Backend5xxBurnRateCritical
+        exp_alerts: []

--- a/infra/prometheus/alerts.test.yml
+++ b/infra/prometheus/alerts.test.yml
@@ -142,3 +142,48 @@ tests:
       - eval_time: 65m
         alertname: Backend5xxBurnRateCritical
         exp_alerts: []
+
+  # #2434: Warning(6h+30m, 6x) — interval 5m × 85표본으로 6h/30m 창을 채운다.
+  - interval: 5m
+    name: Backend5xxBurnRateWarning fires with high 5xx and traffic
+    input_series:
+      - series: 'http_server_requests_seconds_count{status="500",uri="/api/x",method="GET",outcome="SERVER_ERROR"}'
+        values: '0+50x85'
+      - series: 'http_server_requests_seconds_count{status="200",uri="/api/x",method="GET",outcome="SUCCESS"}'
+        values: '0+5x85'
+    alert_rule_test:
+      - eval_time: 7h
+        alertname: Backend5xxBurnRateWarning
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              service: aquila-backend-5xx
+            exp_annotations:
+              summary: Backend 5xx burn rate exceeds warning multi-window threshold
+              description: 5xx error ratio burn rate is above 6x the 0.001 error budget on both the 6h and 30m windows, with traffic above 1 req/min on the 6h window.
+              title_ko: "백엔드 5xx 버짓 소진 주의"
+              impact_ko: "중기 창에서 오류 예산 소진이 계속되면 SLO(99.9%) 위반으로 이어질 수 있습니다."
+              action_ko: "Grafana '오류 조회' 대시보드에서 5xx 비율·버짓 소진과 ERROR 로그를 확인한 뒤, /admin/api/errors로 동일 구간 오류를 대조 확인하세요."
+
+  # #2434: Ticket(3d+6h, 1x) — interval 1h × 80표본으로 3d/6h 창을 채운다.
+  # traffic guard: rate*60 > 1 → 1h 표본당 증가분이 60 초과여야 함(0+70/0+10 ≈ 80/h).
+  - interval: 1h
+    name: Backend5xxBurnRateTicket fires with high 5xx and traffic
+    input_series:
+      - series: 'http_server_requests_seconds_count{status="500",uri="/api/x",method="GET",outcome="SERVER_ERROR"}'
+        values: '0+70x80'
+      - series: 'http_server_requests_seconds_count{status="200",uri="/api/x",method="GET",outcome="SUCCESS"}'
+        values: '0+10x80'
+    alert_rule_test:
+      - eval_time: 75h
+        alertname: Backend5xxBurnRateTicket
+        exp_alerts:
+          - exp_labels:
+              severity: info
+              service: aquila-backend-5xx
+            exp_annotations:
+              summary: Backend 5xx burn rate exceeds ticket multi-window threshold
+              description: 5xx error ratio burn rate is above 1x the 0.001 error budget on both the 3d and 6h windows, with traffic above 1 req/min on the 3d window.
+              title_ko: "백엔드 5xx 버짓 소진 티켓"
+              impact_ko: "장기 창에서 오류 예산이 소진되고 있어 추적·개선 작업이 필요합니다."
+              action_ko: "Grafana '오류 조회' 대시보드에서 5xx 비율·버짓 소진과 ERROR 로그를 확인한 뒤, /admin/api/errors로 동일 구간 오류를 대조 확인하세요."

--- a/infra/prometheus/alerts.yml
+++ b/infra/prometheus/alerts.yml
@@ -86,3 +86,83 @@ groups:
           title_ko: "운행표 snapshot 만료 6시간 전"
           impact_ko: "만료 시점 이후 재시작하면 부팅 hard fail로 서비스 중단 위험이 있습니다."
           action_ko: "즉시 재산출된 snapshot을 배포하거나 break-glass override 절차를 검토하세요."
+
+      # #2434 WP4: multi-window 5xx burn-rate (SLO 99.9% → error budget 0.001).
+      # SLI = 5xx rate / total request rate. Traffic guard: long-window rate * 60 > 1 (≈ >1 req/min).
+      - alert: Backend5xxBurnRateCritical
+        expr: |
+          (
+            sum(rate(http_server_requests_seconds_count{status=~"5.."}[1h]))
+            /
+            sum(rate(http_server_requests_seconds_count[1h]))
+          ) > (14.4 * 0.001)
+          and
+          (
+            sum(rate(http_server_requests_seconds_count{status=~"5.."}[5m]))
+            /
+            sum(rate(http_server_requests_seconds_count[5m]))
+          ) > (14.4 * 0.001)
+          and
+          sum(rate(http_server_requests_seconds_count[1h])) * 60 > 1
+        for: 2m
+        labels:
+          severity: critical
+          service: aquila-backend-5xx
+        annotations:
+          summary: Backend 5xx burn rate exceeds critical multi-window threshold
+          description: 5xx error ratio burn rate is above 14.4x the 0.001 error budget on both the 1h and 5m windows, with traffic above 1 req/min on the 1h window.
+          title_ko: "백엔드 5xx 버짓 소진 긴급"
+          impact_ko: "짧은 시간에 오류 예산이 빠르게 소진되고 있어 사용자 요청 실패가 급증했을 수 있습니다."
+          action_ko: "Grafana '오류 조회' 대시보드에서 5xx 비율·버짓 소진과 ERROR 로그를 확인한 뒤, /admin/api/errors로 동일 구간 오류를 대조 확인하세요."
+
+      - alert: Backend5xxBurnRateWarning
+        expr: |
+          (
+            sum(rate(http_server_requests_seconds_count{status=~"5.."}[6h]))
+            /
+            sum(rate(http_server_requests_seconds_count[6h]))
+          ) > (6 * 0.001)
+          and
+          (
+            sum(rate(http_server_requests_seconds_count{status=~"5.."}[30m]))
+            /
+            sum(rate(http_server_requests_seconds_count[30m]))
+          ) > (6 * 0.001)
+          and
+          sum(rate(http_server_requests_seconds_count[6h])) * 60 > 1
+        for: 2m
+        labels:
+          severity: warning
+          service: aquila-backend-5xx
+        annotations:
+          summary: Backend 5xx burn rate exceeds warning multi-window threshold
+          description: 5xx error ratio burn rate is above 6x the 0.001 error budget on both the 6h and 30m windows, with traffic above 1 req/min on the 6h window.
+          title_ko: "백엔드 5xx 버짓 소진 주의"
+          impact_ko: "중기 창에서 오류 예산 소진이 계속되면 SLO(99.9%) 위반으로 이어질 수 있습니다."
+          action_ko: "Grafana '오류 조회' 대시보드에서 5xx 비율·버짓 소진과 ERROR 로그를 확인한 뒤, /admin/api/errors로 동일 구간 오류를 대조 확인하세요."
+
+      - alert: Backend5xxBurnRateTicket
+        expr: |
+          (
+            sum(rate(http_server_requests_seconds_count{status=~"5.."}[3d]))
+            /
+            sum(rate(http_server_requests_seconds_count[3d]))
+          ) > (1 * 0.001)
+          and
+          (
+            sum(rate(http_server_requests_seconds_count{status=~"5.."}[6h]))
+            /
+            sum(rate(http_server_requests_seconds_count[6h]))
+          ) > (1 * 0.001)
+          and
+          sum(rate(http_server_requests_seconds_count[3d])) * 60 > 1
+        for: 2m
+        labels:
+          severity: info
+          service: aquila-backend-5xx
+        annotations:
+          summary: Backend 5xx burn rate exceeds ticket multi-window threshold
+          description: 5xx error ratio burn rate is above 1x the 0.001 error budget on both the 3d and 6h windows, with traffic above 1 req/min on the 3d window.
+          title_ko: "백엔드 5xx 버짓 소진 티켓"
+          impact_ko: "장기 창에서 오류 예산이 소진되고 있어 추적·개선 작업이 필요합니다."
+          action_ko: "Grafana '오류 조회' 대시보드에서 5xx 비율·버짓 소진과 ERROR 로그를 확인한 뒤, /admin/api/errors로 동일 구간 오류를 대조 확인하세요."

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -12055,14 +12055,18 @@ test("로컬 로그 관측성 스택은 Loki 기준선을 제공한다", () => {
   assert.match(alloyConfig, /loki\.source\.docker/);
   assert.match(alloyConfig, /loki\.write/);
   assert.match(alloyConfig, /stage\.labels[\s\S]*level/);
-  assert.doesNotMatch(alloyConfig, /stage\.labels[\s\S]*correlationId/);
+  assert.doesNotMatch(alloyConfig, /stage\.labels\s*\{[^}]*correlationId/);
   assert.doesNotMatch(alloyConfig, /target_label\s*=\s*"correlationId"/);
   assert.doesNotMatch(alloyConfig, /values\s*=\s*\{[^}]*correlationId/);
 
-  assert.match(dashboardProvider, /easysubway-error-ops|path: \/etc\/grafana\/provisioning\/dashboards\/json/);
+  assert.match(dashboardProvider, /easysubway-error-ops/);
+  assert.match(dashboardProvider, /path: \/etc\/grafana\/provisioning\/dashboards\/json/);
   assert.match(errorOpsDashboard, /"uid":\s*"easysubway-error-ops"/);
   assert.match(errorOpsDashboard, /"title":\s*"오류 조회"/);
   assert.match(errorOpsDashboard, /"name":\s*"correlationId"/);
+  assert.match(errorOpsDashboard, /"legendFormat":\s*"burn 3d"/);
+  assert.match(compose, /alloy:[\s\S]*healthcheck:[\s\S]*localhost:12345\/-\/ready/);
+  assert.match(compose, /\/var\/lib\/docker\/containers:\/var\/lib\/docker\/containers:ro/);
 });
 
 test("백엔드 스캐폴드는 eGovFrame 5.0 Spring Boot Java 21 헥사고날 프로젝트다", () => {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -11986,6 +11986,18 @@ test("로컬 관측성 스택은 Prometheus와 Grafana 기준선을 제공한다
   assert.match(grafanaDatasource, /type: prometheus/);
   assert.match(grafanaDatasource, /url: http:\/\/prometheus:9090/);
   assert.match(grafanaDatasource, /isDefault: true/);
+
+  // #2434 WP4: multi-window 5xx burn-rate alerts + traffic guard
+  assert.match(prometheusAlerts, /alert: Backend5xxBurnRateCritical/);
+  assert.match(prometheusAlerts, /alert: Backend5xxBurnRateWarning/);
+  assert.match(prometheusAlerts, /alert: Backend5xxBurnRateTicket/);
+  assert.match(prometheusAlerts, /alert: Backend5xxBurnRateCritical[\s\S]*severity: critical[\s\S]*service: aquila-backend-5xx/);
+  assert.match(prometheusAlerts, /alert: Backend5xxBurnRateWarning[\s\S]*severity: warning[\s\S]*service: aquila-backend-5xx/);
+  assert.match(prometheusAlerts, /alert: Backend5xxBurnRateTicket[\s\S]*severity: info[\s\S]*service: aquila-backend-5xx/);
+  assert.match(prometheusAlerts, /\* 60 > 1/);
+  assert.match(prometheusAlerts, /alert: Backend5xxBurnRateCritical[\s\S]*\* 60 > 1/);
+  assert.match(prometheusAlerts, /alert: Backend5xxBurnRateWarning[\s\S]*\* 60 > 1/);
+  assert.match(prometheusAlerts, /alert: Backend5xxBurnRateTicket[\s\S]*\* 60 > 1/);
 });
 
 test("로컬 로그 관측성 스택은 Loki 기준선을 제공한다", () => {
@@ -11993,6 +12005,9 @@ test("로컬 로그 관측성 스택은 Loki 기준선을 제공한다", () => {
   const lokiConfig = read("infra/loki/loki.yml");
   const lokiDatasource = read("infra/grafana/provisioning/datasources/loki.yml");
   const prometheusDatasource = read("infra/grafana/provisioning/datasources/prometheus.yml");
+  const alloyConfig = read("infra/alloy/config.alloy");
+  const dashboardProvider = read("infra/grafana/provisioning/dashboards/dashboards.yml");
+  const errorOpsDashboard = read("infra/grafana/provisioning/dashboards/json/error-ops.json");
 
   assert.match(compose, /loki:\n/);
   assert.match(compose, /loki-volume-init:\n/);
@@ -12016,12 +12031,38 @@ test("로컬 로그 관측성 스택은 Loki 기준선을 제공한다", () => {
   assert.match(lokiConfig, /rules_directory: \/loki\/rules/);
   assert.match(lokiConfig, /store: tsdb/);
   assert.match(lokiConfig, /object_store: filesystem/);
+  assert.match(lokiConfig, /retention_period: 720h/);
+  assert.match(lokiConfig, /retention_enabled: true/);
+  assert.match(lokiConfig, /delete_request_store: filesystem/);
 
   assert.match(lokiDatasource, /name: easysubway-loki/);
   assert.match(lokiDatasource, /type: loki/);
   assert.match(lokiDatasource, /url: http:\/\/loki:3100/);
   assert.match(lokiDatasource, /isDefault: false/);
   assert.match(prometheusDatasource, /isDefault: true/);
+
+  // #2434 WP4: Alloy log shipper + Grafana error-ops dashboard
+  assert.match(compose, /alloy:\n/);
+  assert.match(compose, /alloy:[\s\S]*profiles:\s*\n\s*-\s*observability/);
+  assert.match(compose, /image: grafana\/alloy:v[0-9]+\.[0-9]+\.[0-9]+/);
+  assert.match(compose, /\/var\/run\/docker\.sock:\/var\/run\/docker\.sock:ro/);
+  assert.match(compose, /\.\/alloy\/config\.alloy:\/etc\/alloy\/config\.alloy:ro/);
+  assert.match(compose, /alloy:[\s\S]*depends_on:\s*\n\s*loki:\s*\n\s*condition: service_healthy/);
+  assert.match(compose, /alloy:[\s\S]*restart: unless-stopped/);
+
+  assert.ok(existsSync(path.join(root, "infra/alloy/config.alloy")), "alloy config must exist");
+  assert.match(alloyConfig, /discovery\.docker/);
+  assert.match(alloyConfig, /loki\.source\.docker/);
+  assert.match(alloyConfig, /loki\.write/);
+  assert.match(alloyConfig, /stage\.labels[\s\S]*level/);
+  assert.doesNotMatch(alloyConfig, /stage\.labels[\s\S]*correlationId/);
+  assert.doesNotMatch(alloyConfig, /target_label\s*=\s*"correlationId"/);
+  assert.doesNotMatch(alloyConfig, /values\s*=\s*\{[^}]*correlationId/);
+
+  assert.match(dashboardProvider, /easysubway-error-ops|path: \/etc\/grafana\/provisioning\/dashboards\/json/);
+  assert.match(errorOpsDashboard, /"uid":\s*"easysubway-error-ops"/);
+  assert.match(errorOpsDashboard, /"title":\s*"오류 조회"/);
+  assert.match(errorOpsDashboard, /"name":\s*"correlationId"/);
 });
 
 test("백엔드 스캐폴드는 eGovFrame 5.0 Spring Boot Java 21 헥사고날 프로젝트다", () => {


### PR DESCRIPTION
## 관련 이슈

Closes #2434
Refs #2430

## 작업 배경

에픽 #2430 WP4. 기존 알람은 scrape down·timetable freshness뿐이라 5xx가 발생해도 알림이 없고, Loki/Grafana는 로컬 compose에만 있어 운영 ERROR 로그를 correlationId·code로 조회하기 어려웠다. WP2 JSON 구조화 로그를 수집·조회·알람으로 연결한다.

## 작업 내용

- Prometheus `alerts.yml`에 SRE Workbook multi-window 5xx burn-rate 3계층(`Backend5xxBurnRateCritical/Warning/Ticket`) + 분당 1req 미만 트래픽 가드 추가
- Grafana Alloy(`infra/alloy/config.alloy`)로 Docker stdout/stderr → Loki push (라벨: container/env, 스트림 라벨 level만; correlationId는 본문 검색)
- Loki `retention_period: 720h`(30일) + retention_enabled/compactor/delete_request_store 유지
- Grafana 프로비저닝 대시보드「오류 조회」(5xx 비율·burn rate, ERROR 로그, correlationId 변수)
- `promtool` 룰 테스트·`repository-contract` 관측성 계약 확장

운영 호스트 실제 반영은 QA 승인 후 CD/배포 절차로 별도 수행(이 PR 범위 밖).

## 검증

- 실행한 명령과 결과:
  - `promtool check rules infra/prometheus/alerts.yml` — PASS (9 rules, 로컬 promtool 3.9.1)
  - `promtool test rules infra/prometheus/alerts.test.yml` — PASS (Critical 발화 + 저트래픽 가드 비발화)
  - `docker compose --env-file .env.example -f infra/docker-compose.yml config --quiet` — PASS
  - `node --test tools/ci/repository-contract.test.mjs` — PASS (222)

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| burn-rate 룰 문법 | CI/로컬 | promtool check rules | 명령 PASS | 통과 |
| Critical 발화·가드 | CI/로컬 | promtool test rules | alerts.test.yml | 통과 |
| compose 배선 | CI/로컬 | docker compose config | alloy·loki·grafana 포함 | 통과 |
| 저장소 계약 | CI/로컬 | repository-contract.test.mjs | 222 green | 통과 |
| Grafana UI 캡처 | 로컬 compose | 수동 UI | 구성·promtool/계약 검증 중심. 강제 5xx 부하·Grafana 스크린샷은 QA 승인 후 로컬/운영 재현 시 별도 코멘트 | 보류 |
| 운영 반영 | 운영 | CD | QA 승인 전 미반영 | 제외 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [ ] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [ ] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: unchanged
- mobile versionCode: unchanged
- datapack version: unchanged
- route contract: unchanged
- realtime contract: unchanged
- backend identity: unchanged

## 리뷰어 메모

- burn-rate 식·트래픽 가드(`* 60 > 1`)와 Alloy 라벨 카디널리티(correlationId 라벨 금지)를 우선 확인
- Loki 30일 보존 3요소(retention_enabled·compactor·delete_request_store) 존재 여부
- 운영 반영은 이 PR에 포함되지 않음

## 리스크

- Alloy 이미지/권한(docker.sock) 이슈 시 로그 수집만 실패하고 알람 경로는 독립
- severity=info 티켓 알람은 기존 Alertmanager 이메일 템플릿 severity 매핑에 따라 표기가 일반화될 수 있음(로컬은 null receiver)
- 운영 미반영 상태에서 프로덕션 5xx는 계속 미알람 — QA 승인 후 배포 필요

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New production alerting on 5xx SLO burn rates can page on-call once deployed; Alloy needs docker.sock access so misconfiguration affects log collection only, not the metric alert path until rollout.
> 
> **Overview**
> **WP4** wires structured backend logs into on-call workflows: **Prometheus** gains three multi-window **5xx burn-rate** alerts (critical / warning / ticket) for a **99.9%** SLO (**0.001** error budget), each gated so traffic must exceed **~1 req/min** before firing. **promtool** rule tests cover firing and the low-traffic silence case.
> 
> **Grafana Alloy** is added on the **observability** compose profile to ship **Docker** container logs to **Loki** with low-cardinality labels (`container`, `env`, stream `level` only; **`correlationId`** stays in log body). **Loki** retention moves from **168h** to **720h** (30 days). Provisioned datasource **UIDs** support a new **「오류 조회」** dashboard (5xx ratio, burn rates, ERROR logs with a **correlationId** filter).
> 
> **`repository-contract`** and **`post-launch-operations-review-gate.json`** observability refresh bindings are updated for the new infra files and content hashes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 996c89e36207563ce36d9950e35b350d9b82fb5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * Docker 컨테이너 로그를 Loki로 수집하고 Grafana에서 조회할 수 있습니다.
  * 오류 조회 대시보드에서 5xx 비율, 에러 예산 소진율, ERROR 로그를 확인할 수 있습니다.
  * 백엔드 5xx 오류에 대한 다중 구간 모니터링 알림이 추가되었습니다.
  * Loki 로그 보관 기간이 30일로 연장되었습니다.

* **개선**
  * 관측성 구성 요소의 자동 프로비저닝과 데이터 저장이 안정화되었습니다.
  * 트래픽이 충분한 경우에만 5xx 알림이 발생하도록 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->