### PR TITLE
[Chore] WP4 운영 반영 — deploy에 Alloy 포함·관측성 스택 CD 적용 (#2447)

### DIFF
--- a/tools/ci/backend-deploy.test.mjs
+++ b/tools/ci/backend-deploy.test.mjs
@@ -504,8 +504,8 @@ test("백엔드 SSH 배포 스크립트는 상태, drift, 백업, standby 승격
   assert.match(deploy, /tools\/ops\/postgres-backup\.sh/);
   assert.match(deploy, /EASYSUBWAY_BACKEND_ENV_FILE="\$\{BACKEND_ENV\}"/);
   assert.match(deploy, /RUNTIME_SERVICES=\(backend back-worker route-v2-gateway\)/);
-  assert.match(deploy, /OBSERVABILITY_SERVICES=\(public-edge-probe docker-runtime-probe alertmanager prometheus loki grafana\)/);
-  assert.match(deploy, /OBSERVABILITY_CONFIG_SERVICES=\(alertmanager prometheus loki grafana\)/);
+  assert.match(deploy, /OBSERVABILITY_SERVICES=\(public-edge-probe docker-runtime-probe alertmanager prometheus loki grafana alloy\)/);
+  assert.match(deploy, /OBSERVABILITY_CONFIG_SERVICES=\(alertmanager prometheus loki grafana alloy\)/);
   assert.match(deploy, /EASYSUBWAY_ALERTMANAGER_CONFIG_FILE=/);
   assert.match(deploy, /write_alertmanager_config "\$\{tmp_env_set\}\/alertmanager\.yml"/);
   assert.match(deploy, /chmod 600 "\$\{tmp_env_set\}\/compose\.env" "\$\{tmp_env_set\}\/backend\.env" "\$\{tmp_env_set\}\/metadata\.env"/);

--- a/tools/ci/backend-deploy.test.mjs
+++ b/tools/ci/backend-deploy.test.mjs
@@ -522,7 +522,7 @@ test("백엔드 SSH 배포 스크립트는 상태, drift, 백업, standby 승격
   assert.match(deploy, /--profile observability up -d --no-build --force-recreate "\$\{OBSERVABILITY_CONFIG_SERVICES\[@\]\}" \|\| return 1/);
   assert.match(deploy, /--profile observability up -d --no-build --force-recreate alertmanager \|\| return 1/);
   assert.match(deploy, /if \[\[ "\$\{current_env_hash\}" != "\$\{target_env_hash\}" \]\]; then/);
-  assert.match(deploy, /git diff --quiet "\$\{current_sha\}" "\$\{DEPLOY_SHA\}" -- infra\/prometheus infra\/alertmanager\/templates infra\/loki infra\/grafana\/provisioning/);
+  assert.match(deploy, /git diff --quiet "\$\{current_sha\}" "\$\{DEPLOY_SHA\}" -- infra\/prometheus infra\/alertmanager\/templates infra\/loki infra\/grafana\/provisioning infra\/alloy/);
   assert.doesNotMatch(deploy, /--force-recreate "\$\{OBSERVABILITY_SERVICES\[@\]\}"/);
   assert.match(deploy, /verify_runtime_hardening\(\)/);
   assert.match(deploy, /runtime_services_hardened\(\)/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -12069,6 +12069,22 @@ test("로컬 로그 관측성 스택은 Loki 기준선을 제공한다", () => {
   assert.match(errorOpsDashboard, /"name":\s*"correlationId"/);
   assert.match(errorOpsDashboard, /"legendFormat":\s*"burn 3d"/);
   assert.match(compose, /alloy:[\s\S]*healthcheck:[\s\S]*localhost:12345\/-\/ready/);
+  const deployBackend = read("tools/deploy/deploy-backend.sh");
+  assert.match(
+    deployBackend,
+    /OBSERVABILITY_SERVICES=\([^)]*\balloy\b[^)]*\)/,
+    "deploy-backend must start Alloy in the observability profile",
+  );
+  assert.match(
+    deployBackend,
+    /OBSERVABILITY_CONFIG_SERVICES=\([^)]*\balloy\b[^)]*\)/,
+    "deploy-backend must recreate Alloy when observability config changes",
+  );
+  assert.match(
+    deployBackend,
+    /git diff --quiet "\$\{current_sha\}" "\$\{DEPLOY_SHA\}" --[\s\S]*infra\/alloy/,
+    "deploy-backend must treat infra/alloy changes as observability config recreate",
+  );
   assert.match(compose, /\/var\/lib\/docker\/containers:\/var\/lib\/docker\/containers:ro/);
 });
 

--- a/tools/deploy/deploy-backend.sh
+++ b/tools/deploy/deploy-backend.sh
@@ -72,8 +72,8 @@ LOCK_FILE="${DEPLOY_ROOT}/deploy.lock"
 COMPOSE_ENV="${INCOMING_DIR}/compose.env"
 BACKEND_ENV="${INCOMING_DIR}/backend.env"
 RUNTIME_SERVICES=(backend back-worker route-v2-gateway)
-OBSERVABILITY_SERVICES=(public-edge-probe docker-runtime-probe alertmanager prometheus loki grafana)
-OBSERVABILITY_CONFIG_SERVICES=(alertmanager prometheus loki grafana)
+OBSERVABILITY_SERVICES=(public-edge-probe docker-runtime-probe alertmanager prometheus loki grafana alloy)
+OBSERVABILITY_CONFIG_SERVICES=(alertmanager prometheus loki grafana alloy)
 
 # The image content sha (digest hex) replaces the former jar sha256 as the
 # deployed-artifact identity; it flows into the compose metadata label.
@@ -563,7 +563,7 @@ fi
 recreate_observability_config=0
 if [[ -z "${current_sha}" ]]; then
 	recreate_observability_config=1
-elif ! git diff --quiet "${current_sha}" "${DEPLOY_SHA}" -- infra/prometheus infra/alertmanager/templates infra/loki infra/grafana/provisioning; then
+elif ! git diff --quiet "${current_sha}" "${DEPLOY_SHA}" -- infra/prometheus infra/alertmanager/templates infra/loki infra/grafana/provisioning infra/alloy; then
 	recreate_observability_config=1
 fi
 


### PR DESCRIPTION
## 관련 이슈

Closes #2447
Refs #2434
Refs #2430

## 작업 배경

WP4(#2434)는 main에 병합됐지만 운영 호스트에 Alloy가 없고, `deploy-backend.sh`의 observability 서비스 목록에도 `alloy`가 빠져 CD만으로는 Docker 로그 수집기가 기동되지 않는다. QA 승인하에 deploy 배선을 고치고 CD로 관측성 스택을 갱신한다.

## 작업 내용

- `OBSERVABILITY_SERVICES` / `OBSERVABILITY_CONFIG_SERVICES`에 `alloy` 추가
- observability config recreate git diff 경로에 `infra/alloy` 추가
- repository-contract로 Alloy deploy 배선 고정

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern='로컬 로그 관측성 스택은 Loki 기준선을 제공한다' tools/ci/repository-contract.test.mjs` — PASS
  - 관련 관측성 계약 테스트 4건 PASS

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Alloy deploy 배선 | CI/로컬 | repository-contract | OBSERVABILITY_*에 alloy, infra/alloy diff | 통과 |
| 운영 Alloy 기동 | 운영 | CD 후 docker ps | 병합 후 CD workflow_dispatch로 확인 | 대기 |
| Prometheus burn-rate·Grafana | 운영 | CD 후 rules/대시보드 | 동일 CD 검증 | 대기 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [ ] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [ ] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: unchanged
- mobile versionCode: unchanged
- datapack version: unchanged
- route contract: unchanged
- realtime contract: unchanged
- backend identity: CD로 최신 main SHA 배포 예정

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `tools/deploy/deploy-backend.sh` 서비스 배열과 recreate diff 경로. compose의 alloy 정의는 WP4에서 이미 존재.

## 리스크

- CD 시 observability 컨테이너 force-recreate로 짧은 관측 공백 가능
- Alloy가 docker.sock을 읽으므로 호스트 권한/소켓 마운트 실패 시 수집만 실패하고 백엔드는 유지되어야 함

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.