### PR TITLE
[Chore] Alloy healthcheck wget 제거 — bash /dev/tcp ready 판정 (#2449)

### DIFF
--- a/apps/mobile/release/post-launch-operations-review-gate.json
+++ b/apps/mobile/release/post-launch-operations-review-gate.json
@@ -93,7 +93,7 @@
             {"path": "infra/alloy/config.alloy", "sha256": "cb8333eecd52ef6cf5fc9ccf62e87a2990deaa57b6ff3b9a2effcfa33a9b3f5a"},
             {"path": "infra/grafana/provisioning/dashboards/dashboards.yml", "sha256": "648f908f7ddf556b3ec4de0dd9d66dfc75e58a747ebfda411725b8ad301aeb41"},
             {"path": "infra/grafana/provisioning/dashboards/json/error-ops.json", "sha256": "8d28d95d06780698b51014697ee4e942851876ea75ffcbf2c2a5ce7d394ec862"},
-            {"path": "infra/docker-compose.yml", "sha256": "a20b0acfc4f47caa72da7e7afdb0bb1f3d91eb6cdd0970d9fdf88a697a29f366"}
+            {"path": "infra/docker-compose.yml", "sha256": "0f14db02823e85a748b2918b0ea72360f90573bfd31c6042a4fcbf78db6ee145"}
           ]
         },
         {

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -354,8 +354,13 @@ services:
     depends_on:
       loki:
         condition: service_healthy
+    # grafana/alloy 이미지에 wget/curl이 없어 bash /dev/tcp로 ready를 판정한다 (#2449).
     healthcheck:
-      test: ["CMD-SHELL", "wget --spider -q http://localhost:12345/-/ready"]
+      test:
+        [
+          "CMD-SHELL",
+          "bash -c 'exec 3<>/dev/tcp/localhost/12345; printf \"GET /-/ready HTTP/1.0\\r\\n\\r\\n\" >&3; grep -q \"Alloy is ready\" <&3'",
+        ]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -12068,7 +12068,19 @@ test("로컬 로그 관측성 스택은 Loki 기준선을 제공한다", () => {
   assert.match(errorOpsDashboard, /"title":\s*"오류 조회"/);
   assert.match(errorOpsDashboard, /"name":\s*"correlationId"/);
   assert.match(errorOpsDashboard, /"legendFormat":\s*"burn 3d"/);
-  assert.match(compose, /alloy:[\s\S]*healthcheck:[\s\S]*localhost:12345\/-\/ready/);
+  assert.match(
+    compose,
+    /container_name: easysubway-alloy[\s\S]*?healthcheck:[\s\S]*?\/dev\/tcp\/localhost\/12345[\s\S]*?\/-\/ready/,
+  );
+  assert.match(
+    compose,
+    /container_name: easysubway-alloy[\s\S]*?healthcheck:[\s\S]*?Alloy is ready/,
+  );
+  assert.doesNotMatch(
+    compose,
+    /container_name: easysubway-alloy[\s\S]*?healthcheck:[\s\S]*?wget --spider/,
+    "Alloy healthcheck must not rely on wget (missing in grafana/alloy image)",
+  );
   const deployBackend = read("tools/deploy/deploy-backend.sh");
   assert.match(
     deployBackend,


### PR DESCRIPTION
## 관련 이슈

Refs #2449

## 작업 배경

운영 호스트의 `easysubway-alloy`가 실동작(`/-/ready`)은 정상인데 compose healthcheck가 이미지에 없는 `wget`을 호출해 Docker 상태가 `unhealthy`로 고정됩니다. 호스트 main CD catch-up(#2449) 전에 관측성 스택 신호를 바로잡습니다.

## 작업 내용

- `infra/docker-compose.yml` Alloy healthcheck를 `bash /dev/tcp/localhost/12345` + `/-/ready` 본문 확인으로 교체
- `repository-contract.test.mjs`에 wget 금지·tcp ready 계약 추가

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern='로컬 로그 관측성' tools/ci/repository-contract.test.mjs` → pass
  - 호스트에서 동일 bash /dev/tcp 판정 `exit=0` 확인

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Alloy healthcheck 계약 | CI/local | repository-contract 테스트 | 위 명령 pass | 통과 |
| /dev/tcp ready 판정 | ops host | docker exec bash one-liner | exit=0 | 통과 |
| 호스트 CD catch-up(V68/V69) | ops | 이 PR 병합 후 #2449에서 CD로 진행 | 후속 | 미완료(이슈 잔여) |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [ ] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [ ] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- Alloy 서비스 healthcheck만 변경. Prometheus/Grafana의 wget healthcheck는 해당 이미지에 wget이 있어 유지.

## 리스크

- 낮음. bash /dev/tcp는 grafana/alloy 이미지에 존재하는 bash로 검증함. IPv6-only localhost 해석 이슈 가능성은 호스트에서 `localhost` 판정으로 사전 확인.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.