### PR TITLE
[Feat] 역 검색 초성·상세 진입과 하단 패널 실시간→시간표 폴백

### DIFF
--- a/apps/mobile/lib/accessible_design.dart
+++ b/apps/mobile/lib/accessible_design.dart
@@ -176,9 +176,8 @@ class EasySubwayTouchTarget {
 /// 계약을 공유한다. 이 상수를 바꾸면 양쪽을 함께 갱신한다.
 const easySubwayTopBarContentHeight = 60.0;
 
-/// 네비/상단바 하단 구분선 색. 카카오 지하철 상단 카드 하단 엣지 실측
-/// 뉴트럴 그레이(#D5D5D5). 예전 청회색(#CBD6DD)은 선이 탁하고 두껍게 보였다.
-const easySubwayHeaderDividerColor = Color(0xFFD5D5D5);
+/// 네비/상단바 하단 구분선 색. 검색 박스 외곽선과 동일 톤(#C5CDD4).
+const easySubwayHeaderDividerColor = Color(0xFFC5CDD4);
 
 /// 상단바·시트와 본문을 나누는 1px 구분선.
 ///

--- a/apps/mobile/lib/app/demo_dependencies.dart
+++ b/apps/mobile/lib/app/demo_dependencies.dart
@@ -131,7 +131,11 @@ class DemoSearchHistoryRepository implements SearchHistoryRepository {
   DateTime _tick() =>
       DateTime.fromMillisecondsSinceEpoch(++_clock, isUtc: true);
 
-  void _addStation(String query, {required String region}) {
+  void _addStation(
+    String query, {
+    required String region,
+    List<StationSearchLine> lines = const [],
+  }) {
     _stations.removeWhere(
       (entry) => entry.query == query && (entry.region?.trim() ?? '') == region,
     );
@@ -141,18 +145,28 @@ class DemoSearchHistoryRepository implements SearchHistoryRepository {
         query: query,
         region: region,
         searchedAt: _tick(),
+        lines: lines,
       ),
     );
   }
 
   @override
-  Future<void> recordSearch(String query, {String? region}) async {
+  Future<void> recordSearch(
+    String query, {
+    String? region,
+    String? stationId,
+    StationSearchLine? line,
+  }) async {
     final trimmed = query.trim();
     final normalizedRegion = region?.trim() ?? '';
     if (trimmed.isEmpty || normalizedRegion.isEmpty) {
       return;
     }
-    _addStation(trimmed, region: normalizeStationRegion(normalizedRegion));
+    _addStation(
+      trimmed,
+      region: normalizeStationRegion(normalizedRegion),
+      lines: line == null || line.id.trim().isEmpty ? const [] : [line],
+    );
   }
 
   @override
@@ -169,10 +183,13 @@ class DemoSearchHistoryRepository implements SearchHistoryRepository {
       RecentRouteSearchEntry(
         originStationId: entry.originStationId,
         originStationName: entry.originStationName,
+        originLines: entry.originLines,
         waypointStationId: entry.waypointStationId,
         waypointStationName: entry.waypointStationName,
+        waypointLines: entry.waypointLines,
         destinationStationId: entry.destinationStationId,
         destinationStationName: entry.destinationStationName,
+        destinationLines: entry.destinationLines,
         region: entry.region,
         searchedAt: _tick(),
       ),

--- a/apps/mobile/lib/core/database/user/user_database.dart
+++ b/apps/mobile/lib/core/database/user/user_database.dart
@@ -37,7 +37,7 @@ class UserDatabase extends _$UserDatabase {
   }
 
   @override
-  int get schemaVersion => 4;
+  int get schemaVersion => 5;
 
   @override
   MigrationStrategy get migration {
@@ -111,6 +111,42 @@ class UserDatabase extends _$UserDatabase {
             await customStatement('DROP TABLE favorite_stations');
             await customStatement(
               'ALTER TABLE favorite_stations_v4 RENAME TO favorite_stations',
+            );
+          }
+        }
+        if (from < 5) {
+          // 최근 검색·경로에 "선택한 호선"만 저장해 환승역 전 호선 마크를 막는다.
+          await customStatement(
+            'ALTER TABLE search_history ADD COLUMN station_id TEXT',
+          );
+          await customStatement(
+            'ALTER TABLE search_history ADD COLUMN line_id TEXT',
+          );
+          await customStatement(
+            'ALTER TABLE search_history ADD COLUMN line_name TEXT',
+          );
+          await customStatement(
+            'ALTER TABLE search_history ADD COLUMN line_color TEXT',
+          );
+          await customStatement(
+            'ALTER TABLE search_history ADD COLUMN station_code TEXT',
+          );
+          for (final column in const [
+            'origin_line_id',
+            'origin_line_name',
+            'origin_line_color',
+            'origin_station_code',
+            'waypoint_line_id',
+            'waypoint_line_name',
+            'waypoint_line_color',
+            'waypoint_station_code',
+            'destination_line_id',
+            'destination_line_name',
+            'destination_line_color',
+            'destination_station_code',
+          ]) {
+            await customStatement(
+              'ALTER TABLE route_search_history ADD COLUMN $column TEXT',
             );
           }
         }

--- a/apps/mobile/lib/core/database/user/user_database.g.dart
+++ b/apps/mobile/lib/core/database/user/user_database.g.dart
@@ -972,6 +972,59 @@ class $SearchHistoryTable extends SearchHistory
     type: DriftSqlType.string,
     requiredDuringInsert: false,
   );
+  static const VerificationMeta _stationIdMeta = const VerificationMeta(
+    'stationId',
+  );
+  @override
+  late final GeneratedColumn<String> stationId = GeneratedColumn<String>(
+    'station_id',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _lineIdMeta = const VerificationMeta('lineId');
+  @override
+  late final GeneratedColumn<String> lineId = GeneratedColumn<String>(
+    'line_id',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _lineNameMeta = const VerificationMeta(
+    'lineName',
+  );
+  @override
+  late final GeneratedColumn<String> lineName = GeneratedColumn<String>(
+    'line_name',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _lineColorMeta = const VerificationMeta(
+    'lineColor',
+  );
+  @override
+  late final GeneratedColumn<String> lineColor = GeneratedColumn<String>(
+    'line_color',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _stationCodeMeta = const VerificationMeta(
+    'stationCode',
+  );
+  @override
+  late final GeneratedColumn<String> stationCode = GeneratedColumn<String>(
+    'station_code',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
   static const VerificationMeta _searchedAtMeta = const VerificationMeta(
     'searchedAt',
   );
@@ -984,7 +1037,17 @@ class $SearchHistoryTable extends SearchHistory
     requiredDuringInsert: true,
   );
   @override
-  List<GeneratedColumn> get $columns => [id, query, region, searchedAt];
+  List<GeneratedColumn> get $columns => [
+    id,
+    query,
+    region,
+    stationId,
+    lineId,
+    lineName,
+    lineColor,
+    stationCode,
+    searchedAt,
+  ];
   @override
   String get aliasedName => _alias ?? actualTableName;
   @override
@@ -1012,6 +1075,39 @@ class $SearchHistoryTable extends SearchHistory
       context.handle(
         _regionMeta,
         region.isAcceptableOrUnknown(data['region']!, _regionMeta),
+      );
+    }
+    if (data.containsKey('station_id')) {
+      context.handle(
+        _stationIdMeta,
+        stationId.isAcceptableOrUnknown(data['station_id']!, _stationIdMeta),
+      );
+    }
+    if (data.containsKey('line_id')) {
+      context.handle(
+        _lineIdMeta,
+        lineId.isAcceptableOrUnknown(data['line_id']!, _lineIdMeta),
+      );
+    }
+    if (data.containsKey('line_name')) {
+      context.handle(
+        _lineNameMeta,
+        lineName.isAcceptableOrUnknown(data['line_name']!, _lineNameMeta),
+      );
+    }
+    if (data.containsKey('line_color')) {
+      context.handle(
+        _lineColorMeta,
+        lineColor.isAcceptableOrUnknown(data['line_color']!, _lineColorMeta),
+      );
+    }
+    if (data.containsKey('station_code')) {
+      context.handle(
+        _stationCodeMeta,
+        stationCode.isAcceptableOrUnknown(
+          data['station_code']!,
+          _stationCodeMeta,
+        ),
       );
     }
     if (data.containsKey('searched_at')) {
@@ -1043,6 +1139,26 @@ class $SearchHistoryTable extends SearchHistory
         DriftSqlType.string,
         data['${effectivePrefix}region'],
       ),
+      stationId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}station_id'],
+      ),
+      lineId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}line_id'],
+      ),
+      lineName: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}line_name'],
+      ),
+      lineColor: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}line_color'],
+      ),
+      stationCode: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}station_code'],
+      ),
       searchedAt: attachedDatabase.typeMapping.read(
         DriftSqlType.dateTime,
         data['${effectivePrefix}searched_at'],
@@ -1064,11 +1180,23 @@ class SearchHistoryData extends DataClass
   /// 검색 당시 선택 지역(예: `수도권`, `부산`). 지역별 최근 목록 필터에 쓴다.
   /// 지역 정보 없이 저장된 레거시 행은 null이며, 지역 필터 목록에서 제외한다.
   final String? region;
+
+  /// 결과에서 고른 역·호선. 검색어만 있는 레거시/타이핑 기록은 null.
+  final String? stationId;
+  final String? lineId;
+  final String? lineName;
+  final String? lineColor;
+  final String? stationCode;
   final DateTime searchedAt;
   const SearchHistoryData({
     required this.id,
     required this.query,
     this.region,
+    this.stationId,
+    this.lineId,
+    this.lineName,
+    this.lineColor,
+    this.stationCode,
     required this.searchedAt,
   });
   @override
@@ -1078,6 +1206,21 @@ class SearchHistoryData extends DataClass
     map['query'] = Variable<String>(query);
     if (!nullToAbsent || region != null) {
       map['region'] = Variable<String>(region);
+    }
+    if (!nullToAbsent || stationId != null) {
+      map['station_id'] = Variable<String>(stationId);
+    }
+    if (!nullToAbsent || lineId != null) {
+      map['line_id'] = Variable<String>(lineId);
+    }
+    if (!nullToAbsent || lineName != null) {
+      map['line_name'] = Variable<String>(lineName);
+    }
+    if (!nullToAbsent || lineColor != null) {
+      map['line_color'] = Variable<String>(lineColor);
+    }
+    if (!nullToAbsent || stationCode != null) {
+      map['station_code'] = Variable<String>(stationCode);
     }
     map['searched_at'] = Variable<DateTime>(searchedAt);
     return map;
@@ -1090,6 +1233,21 @@ class SearchHistoryData extends DataClass
       region: region == null && nullToAbsent
           ? const Value.absent()
           : Value(region),
+      stationId: stationId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(stationId),
+      lineId: lineId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(lineId),
+      lineName: lineName == null && nullToAbsent
+          ? const Value.absent()
+          : Value(lineName),
+      lineColor: lineColor == null && nullToAbsent
+          ? const Value.absent()
+          : Value(lineColor),
+      stationCode: stationCode == null && nullToAbsent
+          ? const Value.absent()
+          : Value(stationCode),
       searchedAt: Value(searchedAt),
     );
   }
@@ -1103,6 +1261,11 @@ class SearchHistoryData extends DataClass
       id: serializer.fromJson<int>(json['id']),
       query: serializer.fromJson<String>(json['query']),
       region: serializer.fromJson<String?>(json['region']),
+      stationId: serializer.fromJson<String?>(json['stationId']),
+      lineId: serializer.fromJson<String?>(json['lineId']),
+      lineName: serializer.fromJson<String?>(json['lineName']),
+      lineColor: serializer.fromJson<String?>(json['lineColor']),
+      stationCode: serializer.fromJson<String?>(json['stationCode']),
       searchedAt: serializer.fromJson<DateTime>(json['searchedAt']),
     );
   }
@@ -1113,6 +1276,11 @@ class SearchHistoryData extends DataClass
       'id': serializer.toJson<int>(id),
       'query': serializer.toJson<String>(query),
       'region': serializer.toJson<String?>(region),
+      'stationId': serializer.toJson<String?>(stationId),
+      'lineId': serializer.toJson<String?>(lineId),
+      'lineName': serializer.toJson<String?>(lineName),
+      'lineColor': serializer.toJson<String?>(lineColor),
+      'stationCode': serializer.toJson<String?>(stationCode),
       'searchedAt': serializer.toJson<DateTime>(searchedAt),
     };
   }
@@ -1121,11 +1289,21 @@ class SearchHistoryData extends DataClass
     int? id,
     String? query,
     Value<String?> region = const Value.absent(),
+    Value<String?> stationId = const Value.absent(),
+    Value<String?> lineId = const Value.absent(),
+    Value<String?> lineName = const Value.absent(),
+    Value<String?> lineColor = const Value.absent(),
+    Value<String?> stationCode = const Value.absent(),
     DateTime? searchedAt,
   }) => SearchHistoryData(
     id: id ?? this.id,
     query: query ?? this.query,
     region: region.present ? region.value : this.region,
+    stationId: stationId.present ? stationId.value : this.stationId,
+    lineId: lineId.present ? lineId.value : this.lineId,
+    lineName: lineName.present ? lineName.value : this.lineName,
+    lineColor: lineColor.present ? lineColor.value : this.lineColor,
+    stationCode: stationCode.present ? stationCode.value : this.stationCode,
     searchedAt: searchedAt ?? this.searchedAt,
   );
   SearchHistoryData copyWithCompanion(SearchHistoryCompanion data) {
@@ -1133,6 +1311,13 @@ class SearchHistoryData extends DataClass
       id: data.id.present ? data.id.value : this.id,
       query: data.query.present ? data.query.value : this.query,
       region: data.region.present ? data.region.value : this.region,
+      stationId: data.stationId.present ? data.stationId.value : this.stationId,
+      lineId: data.lineId.present ? data.lineId.value : this.lineId,
+      lineName: data.lineName.present ? data.lineName.value : this.lineName,
+      lineColor: data.lineColor.present ? data.lineColor.value : this.lineColor,
+      stationCode: data.stationCode.present
+          ? data.stationCode.value
+          : this.stationCode,
       searchedAt: data.searchedAt.present
           ? data.searchedAt.value
           : this.searchedAt,
@@ -1145,13 +1330,28 @@ class SearchHistoryData extends DataClass
           ..write('id: $id, ')
           ..write('query: $query, ')
           ..write('region: $region, ')
+          ..write('stationId: $stationId, ')
+          ..write('lineId: $lineId, ')
+          ..write('lineName: $lineName, ')
+          ..write('lineColor: $lineColor, ')
+          ..write('stationCode: $stationCode, ')
           ..write('searchedAt: $searchedAt')
           ..write(')'))
         .toString();
   }
 
   @override
-  int get hashCode => Object.hash(id, query, region, searchedAt);
+  int get hashCode => Object.hash(
+    id,
+    query,
+    region,
+    stationId,
+    lineId,
+    lineName,
+    lineColor,
+    stationCode,
+    searchedAt,
+  );
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -1159,6 +1359,11 @@ class SearchHistoryData extends DataClass
           other.id == this.id &&
           other.query == this.query &&
           other.region == this.region &&
+          other.stationId == this.stationId &&
+          other.lineId == this.lineId &&
+          other.lineName == this.lineName &&
+          other.lineColor == this.lineColor &&
+          other.stationCode == this.stationCode &&
           other.searchedAt == this.searchedAt);
 }
 
@@ -1166,17 +1371,32 @@ class SearchHistoryCompanion extends UpdateCompanion<SearchHistoryData> {
   final Value<int> id;
   final Value<String> query;
   final Value<String?> region;
+  final Value<String?> stationId;
+  final Value<String?> lineId;
+  final Value<String?> lineName;
+  final Value<String?> lineColor;
+  final Value<String?> stationCode;
   final Value<DateTime> searchedAt;
   const SearchHistoryCompanion({
     this.id = const Value.absent(),
     this.query = const Value.absent(),
     this.region = const Value.absent(),
+    this.stationId = const Value.absent(),
+    this.lineId = const Value.absent(),
+    this.lineName = const Value.absent(),
+    this.lineColor = const Value.absent(),
+    this.stationCode = const Value.absent(),
     this.searchedAt = const Value.absent(),
   });
   SearchHistoryCompanion.insert({
     this.id = const Value.absent(),
     required String query,
     this.region = const Value.absent(),
+    this.stationId = const Value.absent(),
+    this.lineId = const Value.absent(),
+    this.lineName = const Value.absent(),
+    this.lineColor = const Value.absent(),
+    this.stationCode = const Value.absent(),
     required DateTime searchedAt,
   }) : query = Value(query),
        searchedAt = Value(searchedAt);
@@ -1184,12 +1404,22 @@ class SearchHistoryCompanion extends UpdateCompanion<SearchHistoryData> {
     Expression<int>? id,
     Expression<String>? query,
     Expression<String>? region,
+    Expression<String>? stationId,
+    Expression<String>? lineId,
+    Expression<String>? lineName,
+    Expression<String>? lineColor,
+    Expression<String>? stationCode,
     Expression<DateTime>? searchedAt,
   }) {
     return RawValuesInsertable({
       if (id != null) 'id': id,
       if (query != null) 'query': query,
       if (region != null) 'region': region,
+      if (stationId != null) 'station_id': stationId,
+      if (lineId != null) 'line_id': lineId,
+      if (lineName != null) 'line_name': lineName,
+      if (lineColor != null) 'line_color': lineColor,
+      if (stationCode != null) 'station_code': stationCode,
       if (searchedAt != null) 'searched_at': searchedAt,
     });
   }
@@ -1198,12 +1428,22 @@ class SearchHistoryCompanion extends UpdateCompanion<SearchHistoryData> {
     Value<int>? id,
     Value<String>? query,
     Value<String?>? region,
+    Value<String?>? stationId,
+    Value<String?>? lineId,
+    Value<String?>? lineName,
+    Value<String?>? lineColor,
+    Value<String?>? stationCode,
     Value<DateTime>? searchedAt,
   }) {
     return SearchHistoryCompanion(
       id: id ?? this.id,
       query: query ?? this.query,
       region: region ?? this.region,
+      stationId: stationId ?? this.stationId,
+      lineId: lineId ?? this.lineId,
+      lineName: lineName ?? this.lineName,
+      lineColor: lineColor ?? this.lineColor,
+      stationCode: stationCode ?? this.stationCode,
       searchedAt: searchedAt ?? this.searchedAt,
     );
   }
@@ -1220,6 +1460,21 @@ class SearchHistoryCompanion extends UpdateCompanion<SearchHistoryData> {
     if (region.present) {
       map['region'] = Variable<String>(region.value);
     }
+    if (stationId.present) {
+      map['station_id'] = Variable<String>(stationId.value);
+    }
+    if (lineId.present) {
+      map['line_id'] = Variable<String>(lineId.value);
+    }
+    if (lineName.present) {
+      map['line_name'] = Variable<String>(lineName.value);
+    }
+    if (lineColor.present) {
+      map['line_color'] = Variable<String>(lineColor.value);
+    }
+    if (stationCode.present) {
+      map['station_code'] = Variable<String>(stationCode.value);
+    }
     if (searchedAt.present) {
       map['searched_at'] = Variable<DateTime>(searchedAt.value);
     }
@@ -1232,6 +1487,11 @@ class SearchHistoryCompanion extends UpdateCompanion<SearchHistoryData> {
           ..write('id: $id, ')
           ..write('query: $query, ')
           ..write('region: $region, ')
+          ..write('stationId: $stationId, ')
+          ..write('lineId: $lineId, ')
+          ..write('lineName: $lineName, ')
+          ..write('lineColor: $lineColor, ')
+          ..write('stationCode: $stationCode, ')
           ..write('searchedAt: $searchedAt')
           ..write(')'))
         .toString();
@@ -1280,6 +1540,51 @@ class $RouteSearchHistoryTable extends RouteSearchHistory
         type: DriftSqlType.string,
         requiredDuringInsert: true,
       );
+  static const VerificationMeta _originLineIdMeta = const VerificationMeta(
+    'originLineId',
+  );
+  @override
+  late final GeneratedColumn<String> originLineId = GeneratedColumn<String>(
+    'origin_line_id',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _originLineNameMeta = const VerificationMeta(
+    'originLineName',
+  );
+  @override
+  late final GeneratedColumn<String> originLineName = GeneratedColumn<String>(
+    'origin_line_name',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _originLineColorMeta = const VerificationMeta(
+    'originLineColor',
+  );
+  @override
+  late final GeneratedColumn<String> originLineColor = GeneratedColumn<String>(
+    'origin_line_color',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _originStationCodeMeta = const VerificationMeta(
+    'originStationCode',
+  );
+  @override
+  late final GeneratedColumn<String> originStationCode =
+      GeneratedColumn<String>(
+        'origin_station_code',
+        aliasedName,
+        true,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+      );
   static const VerificationMeta _waypointStationIdMeta = const VerificationMeta(
     'waypointStationId',
   );
@@ -1298,6 +1603,51 @@ class $RouteSearchHistoryTable extends RouteSearchHistory
   late final GeneratedColumn<String> waypointStationName =
       GeneratedColumn<String>(
         'waypoint_station_name',
+        aliasedName,
+        true,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+      );
+  static const VerificationMeta _waypointLineIdMeta = const VerificationMeta(
+    'waypointLineId',
+  );
+  @override
+  late final GeneratedColumn<String> waypointLineId = GeneratedColumn<String>(
+    'waypoint_line_id',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _waypointLineNameMeta = const VerificationMeta(
+    'waypointLineName',
+  );
+  @override
+  late final GeneratedColumn<String> waypointLineName = GeneratedColumn<String>(
+    'waypoint_line_name',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _waypointLineColorMeta = const VerificationMeta(
+    'waypointLineColor',
+  );
+  @override
+  late final GeneratedColumn<String> waypointLineColor =
+      GeneratedColumn<String>(
+        'waypoint_line_color',
+        aliasedName,
+        true,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+      );
+  static const VerificationMeta _waypointStationCodeMeta =
+      const VerificationMeta('waypointStationCode');
+  @override
+  late final GeneratedColumn<String> waypointStationCode =
+      GeneratedColumn<String>(
+        'waypoint_station_code',
         aliasedName,
         true,
         type: DriftSqlType.string,
@@ -1325,6 +1675,51 @@ class $RouteSearchHistoryTable extends RouteSearchHistory
         type: DriftSqlType.string,
         requiredDuringInsert: true,
       );
+  static const VerificationMeta _destinationLineIdMeta = const VerificationMeta(
+    'destinationLineId',
+  );
+  @override
+  late final GeneratedColumn<String> destinationLineId =
+      GeneratedColumn<String>(
+        'destination_line_id',
+        aliasedName,
+        true,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+      );
+  static const VerificationMeta _destinationLineNameMeta =
+      const VerificationMeta('destinationLineName');
+  @override
+  late final GeneratedColumn<String> destinationLineName =
+      GeneratedColumn<String>(
+        'destination_line_name',
+        aliasedName,
+        true,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+      );
+  static const VerificationMeta _destinationLineColorMeta =
+      const VerificationMeta('destinationLineColor');
+  @override
+  late final GeneratedColumn<String> destinationLineColor =
+      GeneratedColumn<String>(
+        'destination_line_color',
+        aliasedName,
+        true,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+      );
+  static const VerificationMeta _destinationStationCodeMeta =
+      const VerificationMeta('destinationStationCode');
+  @override
+  late final GeneratedColumn<String> destinationStationCode =
+      GeneratedColumn<String>(
+        'destination_station_code',
+        aliasedName,
+        true,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+      );
   static const VerificationMeta _regionMeta = const VerificationMeta('region');
   @override
   late final GeneratedColumn<String> region = GeneratedColumn<String>(
@@ -1350,10 +1745,22 @@ class $RouteSearchHistoryTable extends RouteSearchHistory
     id,
     originStationId,
     originStationName,
+    originLineId,
+    originLineName,
+    originLineColor,
+    originStationCode,
     waypointStationId,
     waypointStationName,
+    waypointLineId,
+    waypointLineName,
+    waypointLineColor,
+    waypointStationCode,
     destinationStationId,
     destinationStationName,
+    destinationLineId,
+    destinationLineName,
+    destinationLineColor,
+    destinationStationCode,
     region,
     searchedAt,
   ];
@@ -1394,6 +1801,42 @@ class $RouteSearchHistoryTable extends RouteSearchHistory
     } else if (isInserting) {
       context.missing(_originStationNameMeta);
     }
+    if (data.containsKey('origin_line_id')) {
+      context.handle(
+        _originLineIdMeta,
+        originLineId.isAcceptableOrUnknown(
+          data['origin_line_id']!,
+          _originLineIdMeta,
+        ),
+      );
+    }
+    if (data.containsKey('origin_line_name')) {
+      context.handle(
+        _originLineNameMeta,
+        originLineName.isAcceptableOrUnknown(
+          data['origin_line_name']!,
+          _originLineNameMeta,
+        ),
+      );
+    }
+    if (data.containsKey('origin_line_color')) {
+      context.handle(
+        _originLineColorMeta,
+        originLineColor.isAcceptableOrUnknown(
+          data['origin_line_color']!,
+          _originLineColorMeta,
+        ),
+      );
+    }
+    if (data.containsKey('origin_station_code')) {
+      context.handle(
+        _originStationCodeMeta,
+        originStationCode.isAcceptableOrUnknown(
+          data['origin_station_code']!,
+          _originStationCodeMeta,
+        ),
+      );
+    }
     if (data.containsKey('waypoint_station_id')) {
       context.handle(
         _waypointStationIdMeta,
@@ -1409,6 +1852,42 @@ class $RouteSearchHistoryTable extends RouteSearchHistory
         waypointStationName.isAcceptableOrUnknown(
           data['waypoint_station_name']!,
           _waypointStationNameMeta,
+        ),
+      );
+    }
+    if (data.containsKey('waypoint_line_id')) {
+      context.handle(
+        _waypointLineIdMeta,
+        waypointLineId.isAcceptableOrUnknown(
+          data['waypoint_line_id']!,
+          _waypointLineIdMeta,
+        ),
+      );
+    }
+    if (data.containsKey('waypoint_line_name')) {
+      context.handle(
+        _waypointLineNameMeta,
+        waypointLineName.isAcceptableOrUnknown(
+          data['waypoint_line_name']!,
+          _waypointLineNameMeta,
+        ),
+      );
+    }
+    if (data.containsKey('waypoint_line_color')) {
+      context.handle(
+        _waypointLineColorMeta,
+        waypointLineColor.isAcceptableOrUnknown(
+          data['waypoint_line_color']!,
+          _waypointLineColorMeta,
+        ),
+      );
+    }
+    if (data.containsKey('waypoint_station_code')) {
+      context.handle(
+        _waypointStationCodeMeta,
+        waypointStationCode.isAcceptableOrUnknown(
+          data['waypoint_station_code']!,
+          _waypointStationCodeMeta,
         ),
       );
     }
@@ -1433,6 +1912,42 @@ class $RouteSearchHistoryTable extends RouteSearchHistory
       );
     } else if (isInserting) {
       context.missing(_destinationStationNameMeta);
+    }
+    if (data.containsKey('destination_line_id')) {
+      context.handle(
+        _destinationLineIdMeta,
+        destinationLineId.isAcceptableOrUnknown(
+          data['destination_line_id']!,
+          _destinationLineIdMeta,
+        ),
+      );
+    }
+    if (data.containsKey('destination_line_name')) {
+      context.handle(
+        _destinationLineNameMeta,
+        destinationLineName.isAcceptableOrUnknown(
+          data['destination_line_name']!,
+          _destinationLineNameMeta,
+        ),
+      );
+    }
+    if (data.containsKey('destination_line_color')) {
+      context.handle(
+        _destinationLineColorMeta,
+        destinationLineColor.isAcceptableOrUnknown(
+          data['destination_line_color']!,
+          _destinationLineColorMeta,
+        ),
+      );
+    }
+    if (data.containsKey('destination_station_code')) {
+      context.handle(
+        _destinationStationCodeMeta,
+        destinationStationCode.isAcceptableOrUnknown(
+          data['destination_station_code']!,
+          _destinationStationCodeMeta,
+        ),
+      );
     }
     if (data.containsKey('region')) {
       context.handle(
@@ -1471,6 +1986,22 @@ class $RouteSearchHistoryTable extends RouteSearchHistory
         DriftSqlType.string,
         data['${effectivePrefix}origin_station_name'],
       )!,
+      originLineId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}origin_line_id'],
+      ),
+      originLineName: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}origin_line_name'],
+      ),
+      originLineColor: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}origin_line_color'],
+      ),
+      originStationCode: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}origin_station_code'],
+      ),
       waypointStationId: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}waypoint_station_id'],
@@ -1478,6 +2009,22 @@ class $RouteSearchHistoryTable extends RouteSearchHistory
       waypointStationName: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}waypoint_station_name'],
+      ),
+      waypointLineId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}waypoint_line_id'],
+      ),
+      waypointLineName: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}waypoint_line_name'],
+      ),
+      waypointLineColor: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}waypoint_line_color'],
+      ),
+      waypointStationCode: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}waypoint_station_code'],
       ),
       destinationStationId: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
@@ -1487,6 +2034,22 @@ class $RouteSearchHistoryTable extends RouteSearchHistory
         DriftSqlType.string,
         data['${effectivePrefix}destination_station_name'],
       )!,
+      destinationLineId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}destination_line_id'],
+      ),
+      destinationLineName: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}destination_line_name'],
+      ),
+      destinationLineColor: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}destination_line_color'],
+      ),
+      destinationStationCode: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}destination_station_code'],
+      ),
       region: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}region'],
@@ -1509,20 +2072,44 @@ class RouteSearchHistoryData extends DataClass
   final int id;
   final String originStationId;
   final String originStationName;
+  final String? originLineId;
+  final String? originLineName;
+  final String? originLineColor;
+  final String? originStationCode;
   final String? waypointStationId;
   final String? waypointStationName;
+  final String? waypointLineId;
+  final String? waypointLineName;
+  final String? waypointLineColor;
+  final String? waypointStationCode;
   final String destinationStationId;
   final String destinationStationName;
+  final String? destinationLineId;
+  final String? destinationLineName;
+  final String? destinationLineColor;
+  final String? destinationStationCode;
   final String region;
   final DateTime searchedAt;
   const RouteSearchHistoryData({
     required this.id,
     required this.originStationId,
     required this.originStationName,
+    this.originLineId,
+    this.originLineName,
+    this.originLineColor,
+    this.originStationCode,
     this.waypointStationId,
     this.waypointStationName,
+    this.waypointLineId,
+    this.waypointLineName,
+    this.waypointLineColor,
+    this.waypointStationCode,
     required this.destinationStationId,
     required this.destinationStationName,
+    this.destinationLineId,
+    this.destinationLineName,
+    this.destinationLineColor,
+    this.destinationStationCode,
     required this.region,
     required this.searchedAt,
   });
@@ -1532,14 +2119,52 @@ class RouteSearchHistoryData extends DataClass
     map['id'] = Variable<int>(id);
     map['origin_station_id'] = Variable<String>(originStationId);
     map['origin_station_name'] = Variable<String>(originStationName);
+    if (!nullToAbsent || originLineId != null) {
+      map['origin_line_id'] = Variable<String>(originLineId);
+    }
+    if (!nullToAbsent || originLineName != null) {
+      map['origin_line_name'] = Variable<String>(originLineName);
+    }
+    if (!nullToAbsent || originLineColor != null) {
+      map['origin_line_color'] = Variable<String>(originLineColor);
+    }
+    if (!nullToAbsent || originStationCode != null) {
+      map['origin_station_code'] = Variable<String>(originStationCode);
+    }
     if (!nullToAbsent || waypointStationId != null) {
       map['waypoint_station_id'] = Variable<String>(waypointStationId);
     }
     if (!nullToAbsent || waypointStationName != null) {
       map['waypoint_station_name'] = Variable<String>(waypointStationName);
     }
+    if (!nullToAbsent || waypointLineId != null) {
+      map['waypoint_line_id'] = Variable<String>(waypointLineId);
+    }
+    if (!nullToAbsent || waypointLineName != null) {
+      map['waypoint_line_name'] = Variable<String>(waypointLineName);
+    }
+    if (!nullToAbsent || waypointLineColor != null) {
+      map['waypoint_line_color'] = Variable<String>(waypointLineColor);
+    }
+    if (!nullToAbsent || waypointStationCode != null) {
+      map['waypoint_station_code'] = Variable<String>(waypointStationCode);
+    }
     map['destination_station_id'] = Variable<String>(destinationStationId);
     map['destination_station_name'] = Variable<String>(destinationStationName);
+    if (!nullToAbsent || destinationLineId != null) {
+      map['destination_line_id'] = Variable<String>(destinationLineId);
+    }
+    if (!nullToAbsent || destinationLineName != null) {
+      map['destination_line_name'] = Variable<String>(destinationLineName);
+    }
+    if (!nullToAbsent || destinationLineColor != null) {
+      map['destination_line_color'] = Variable<String>(destinationLineColor);
+    }
+    if (!nullToAbsent || destinationStationCode != null) {
+      map['destination_station_code'] = Variable<String>(
+        destinationStationCode,
+      );
+    }
     map['region'] = Variable<String>(region);
     map['searched_at'] = Variable<DateTime>(searchedAt);
     return map;
@@ -1550,14 +2175,50 @@ class RouteSearchHistoryData extends DataClass
       id: Value(id),
       originStationId: Value(originStationId),
       originStationName: Value(originStationName),
+      originLineId: originLineId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(originLineId),
+      originLineName: originLineName == null && nullToAbsent
+          ? const Value.absent()
+          : Value(originLineName),
+      originLineColor: originLineColor == null && nullToAbsent
+          ? const Value.absent()
+          : Value(originLineColor),
+      originStationCode: originStationCode == null && nullToAbsent
+          ? const Value.absent()
+          : Value(originStationCode),
       waypointStationId: waypointStationId == null && nullToAbsent
           ? const Value.absent()
           : Value(waypointStationId),
       waypointStationName: waypointStationName == null && nullToAbsent
           ? const Value.absent()
           : Value(waypointStationName),
+      waypointLineId: waypointLineId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(waypointLineId),
+      waypointLineName: waypointLineName == null && nullToAbsent
+          ? const Value.absent()
+          : Value(waypointLineName),
+      waypointLineColor: waypointLineColor == null && nullToAbsent
+          ? const Value.absent()
+          : Value(waypointLineColor),
+      waypointStationCode: waypointStationCode == null && nullToAbsent
+          ? const Value.absent()
+          : Value(waypointStationCode),
       destinationStationId: Value(destinationStationId),
       destinationStationName: Value(destinationStationName),
+      destinationLineId: destinationLineId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(destinationLineId),
+      destinationLineName: destinationLineName == null && nullToAbsent
+          ? const Value.absent()
+          : Value(destinationLineName),
+      destinationLineColor: destinationLineColor == null && nullToAbsent
+          ? const Value.absent()
+          : Value(destinationLineColor),
+      destinationStationCode: destinationStationCode == null && nullToAbsent
+          ? const Value.absent()
+          : Value(destinationStationCode),
       region: Value(region),
       searchedAt: Value(searchedAt),
     );
@@ -1572,17 +2233,43 @@ class RouteSearchHistoryData extends DataClass
       id: serializer.fromJson<int>(json['id']),
       originStationId: serializer.fromJson<String>(json['originStationId']),
       originStationName: serializer.fromJson<String>(json['originStationName']),
+      originLineId: serializer.fromJson<String?>(json['originLineId']),
+      originLineName: serializer.fromJson<String?>(json['originLineName']),
+      originLineColor: serializer.fromJson<String?>(json['originLineColor']),
+      originStationCode: serializer.fromJson<String?>(
+        json['originStationCode'],
+      ),
       waypointStationId: serializer.fromJson<String?>(
         json['waypointStationId'],
       ),
       waypointStationName: serializer.fromJson<String?>(
         json['waypointStationName'],
       ),
+      waypointLineId: serializer.fromJson<String?>(json['waypointLineId']),
+      waypointLineName: serializer.fromJson<String?>(json['waypointLineName']),
+      waypointLineColor: serializer.fromJson<String?>(
+        json['waypointLineColor'],
+      ),
+      waypointStationCode: serializer.fromJson<String?>(
+        json['waypointStationCode'],
+      ),
       destinationStationId: serializer.fromJson<String>(
         json['destinationStationId'],
       ),
       destinationStationName: serializer.fromJson<String>(
         json['destinationStationName'],
+      ),
+      destinationLineId: serializer.fromJson<String?>(
+        json['destinationLineId'],
+      ),
+      destinationLineName: serializer.fromJson<String?>(
+        json['destinationLineName'],
+      ),
+      destinationLineColor: serializer.fromJson<String?>(
+        json['destinationLineColor'],
+      ),
+      destinationStationCode: serializer.fromJson<String?>(
+        json['destinationStationCode'],
       ),
       region: serializer.fromJson<String>(json['region']),
       searchedAt: serializer.fromJson<DateTime>(json['searchedAt']),
@@ -1595,11 +2282,25 @@ class RouteSearchHistoryData extends DataClass
       'id': serializer.toJson<int>(id),
       'originStationId': serializer.toJson<String>(originStationId),
       'originStationName': serializer.toJson<String>(originStationName),
+      'originLineId': serializer.toJson<String?>(originLineId),
+      'originLineName': serializer.toJson<String?>(originLineName),
+      'originLineColor': serializer.toJson<String?>(originLineColor),
+      'originStationCode': serializer.toJson<String?>(originStationCode),
       'waypointStationId': serializer.toJson<String?>(waypointStationId),
       'waypointStationName': serializer.toJson<String?>(waypointStationName),
+      'waypointLineId': serializer.toJson<String?>(waypointLineId),
+      'waypointLineName': serializer.toJson<String?>(waypointLineName),
+      'waypointLineColor': serializer.toJson<String?>(waypointLineColor),
+      'waypointStationCode': serializer.toJson<String?>(waypointStationCode),
       'destinationStationId': serializer.toJson<String>(destinationStationId),
       'destinationStationName': serializer.toJson<String>(
         destinationStationName,
+      ),
+      'destinationLineId': serializer.toJson<String?>(destinationLineId),
+      'destinationLineName': serializer.toJson<String?>(destinationLineName),
+      'destinationLineColor': serializer.toJson<String?>(destinationLineColor),
+      'destinationStationCode': serializer.toJson<String?>(
+        destinationStationCode,
       ),
       'region': serializer.toJson<String>(region),
       'searchedAt': serializer.toJson<DateTime>(searchedAt),
@@ -1610,25 +2311,71 @@ class RouteSearchHistoryData extends DataClass
     int? id,
     String? originStationId,
     String? originStationName,
+    Value<String?> originLineId = const Value.absent(),
+    Value<String?> originLineName = const Value.absent(),
+    Value<String?> originLineColor = const Value.absent(),
+    Value<String?> originStationCode = const Value.absent(),
     Value<String?> waypointStationId = const Value.absent(),
     Value<String?> waypointStationName = const Value.absent(),
+    Value<String?> waypointLineId = const Value.absent(),
+    Value<String?> waypointLineName = const Value.absent(),
+    Value<String?> waypointLineColor = const Value.absent(),
+    Value<String?> waypointStationCode = const Value.absent(),
     String? destinationStationId,
     String? destinationStationName,
+    Value<String?> destinationLineId = const Value.absent(),
+    Value<String?> destinationLineName = const Value.absent(),
+    Value<String?> destinationLineColor = const Value.absent(),
+    Value<String?> destinationStationCode = const Value.absent(),
     String? region,
     DateTime? searchedAt,
   }) => RouteSearchHistoryData(
     id: id ?? this.id,
     originStationId: originStationId ?? this.originStationId,
     originStationName: originStationName ?? this.originStationName,
+    originLineId: originLineId.present ? originLineId.value : this.originLineId,
+    originLineName: originLineName.present
+        ? originLineName.value
+        : this.originLineName,
+    originLineColor: originLineColor.present
+        ? originLineColor.value
+        : this.originLineColor,
+    originStationCode: originStationCode.present
+        ? originStationCode.value
+        : this.originStationCode,
     waypointStationId: waypointStationId.present
         ? waypointStationId.value
         : this.waypointStationId,
     waypointStationName: waypointStationName.present
         ? waypointStationName.value
         : this.waypointStationName,
+    waypointLineId: waypointLineId.present
+        ? waypointLineId.value
+        : this.waypointLineId,
+    waypointLineName: waypointLineName.present
+        ? waypointLineName.value
+        : this.waypointLineName,
+    waypointLineColor: waypointLineColor.present
+        ? waypointLineColor.value
+        : this.waypointLineColor,
+    waypointStationCode: waypointStationCode.present
+        ? waypointStationCode.value
+        : this.waypointStationCode,
     destinationStationId: destinationStationId ?? this.destinationStationId,
     destinationStationName:
         destinationStationName ?? this.destinationStationName,
+    destinationLineId: destinationLineId.present
+        ? destinationLineId.value
+        : this.destinationLineId,
+    destinationLineName: destinationLineName.present
+        ? destinationLineName.value
+        : this.destinationLineName,
+    destinationLineColor: destinationLineColor.present
+        ? destinationLineColor.value
+        : this.destinationLineColor,
+    destinationStationCode: destinationStationCode.present
+        ? destinationStationCode.value
+        : this.destinationStationCode,
     region: region ?? this.region,
     searchedAt: searchedAt ?? this.searchedAt,
   );
@@ -1641,18 +2388,54 @@ class RouteSearchHistoryData extends DataClass
       originStationName: data.originStationName.present
           ? data.originStationName.value
           : this.originStationName,
+      originLineId: data.originLineId.present
+          ? data.originLineId.value
+          : this.originLineId,
+      originLineName: data.originLineName.present
+          ? data.originLineName.value
+          : this.originLineName,
+      originLineColor: data.originLineColor.present
+          ? data.originLineColor.value
+          : this.originLineColor,
+      originStationCode: data.originStationCode.present
+          ? data.originStationCode.value
+          : this.originStationCode,
       waypointStationId: data.waypointStationId.present
           ? data.waypointStationId.value
           : this.waypointStationId,
       waypointStationName: data.waypointStationName.present
           ? data.waypointStationName.value
           : this.waypointStationName,
+      waypointLineId: data.waypointLineId.present
+          ? data.waypointLineId.value
+          : this.waypointLineId,
+      waypointLineName: data.waypointLineName.present
+          ? data.waypointLineName.value
+          : this.waypointLineName,
+      waypointLineColor: data.waypointLineColor.present
+          ? data.waypointLineColor.value
+          : this.waypointLineColor,
+      waypointStationCode: data.waypointStationCode.present
+          ? data.waypointStationCode.value
+          : this.waypointStationCode,
       destinationStationId: data.destinationStationId.present
           ? data.destinationStationId.value
           : this.destinationStationId,
       destinationStationName: data.destinationStationName.present
           ? data.destinationStationName.value
           : this.destinationStationName,
+      destinationLineId: data.destinationLineId.present
+          ? data.destinationLineId.value
+          : this.destinationLineId,
+      destinationLineName: data.destinationLineName.present
+          ? data.destinationLineName.value
+          : this.destinationLineName,
+      destinationLineColor: data.destinationLineColor.present
+          ? data.destinationLineColor.value
+          : this.destinationLineColor,
+      destinationStationCode: data.destinationStationCode.present
+          ? data.destinationStationCode.value
+          : this.destinationStationCode,
       region: data.region.present ? data.region.value : this.region,
       searchedAt: data.searchedAt.present
           ? data.searchedAt.value
@@ -1666,10 +2449,22 @@ class RouteSearchHistoryData extends DataClass
           ..write('id: $id, ')
           ..write('originStationId: $originStationId, ')
           ..write('originStationName: $originStationName, ')
+          ..write('originLineId: $originLineId, ')
+          ..write('originLineName: $originLineName, ')
+          ..write('originLineColor: $originLineColor, ')
+          ..write('originStationCode: $originStationCode, ')
           ..write('waypointStationId: $waypointStationId, ')
           ..write('waypointStationName: $waypointStationName, ')
+          ..write('waypointLineId: $waypointLineId, ')
+          ..write('waypointLineName: $waypointLineName, ')
+          ..write('waypointLineColor: $waypointLineColor, ')
+          ..write('waypointStationCode: $waypointStationCode, ')
           ..write('destinationStationId: $destinationStationId, ')
           ..write('destinationStationName: $destinationStationName, ')
+          ..write('destinationLineId: $destinationLineId, ')
+          ..write('destinationLineName: $destinationLineName, ')
+          ..write('destinationLineColor: $destinationLineColor, ')
+          ..write('destinationStationCode: $destinationStationCode, ')
           ..write('region: $region, ')
           ..write('searchedAt: $searchedAt')
           ..write(')'))
@@ -1677,17 +2472,29 @@ class RouteSearchHistoryData extends DataClass
   }
 
   @override
-  int get hashCode => Object.hash(
+  int get hashCode => Object.hashAll([
     id,
     originStationId,
     originStationName,
+    originLineId,
+    originLineName,
+    originLineColor,
+    originStationCode,
     waypointStationId,
     waypointStationName,
+    waypointLineId,
+    waypointLineName,
+    waypointLineColor,
+    waypointStationCode,
     destinationStationId,
     destinationStationName,
+    destinationLineId,
+    destinationLineName,
+    destinationLineColor,
+    destinationStationCode,
     region,
     searchedAt,
-  );
+  ]);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -1695,10 +2502,22 @@ class RouteSearchHistoryData extends DataClass
           other.id == this.id &&
           other.originStationId == this.originStationId &&
           other.originStationName == this.originStationName &&
+          other.originLineId == this.originLineId &&
+          other.originLineName == this.originLineName &&
+          other.originLineColor == this.originLineColor &&
+          other.originStationCode == this.originStationCode &&
           other.waypointStationId == this.waypointStationId &&
           other.waypointStationName == this.waypointStationName &&
+          other.waypointLineId == this.waypointLineId &&
+          other.waypointLineName == this.waypointLineName &&
+          other.waypointLineColor == this.waypointLineColor &&
+          other.waypointStationCode == this.waypointStationCode &&
           other.destinationStationId == this.destinationStationId &&
           other.destinationStationName == this.destinationStationName &&
+          other.destinationLineId == this.destinationLineId &&
+          other.destinationLineName == this.destinationLineName &&
+          other.destinationLineColor == this.destinationLineColor &&
+          other.destinationStationCode == this.destinationStationCode &&
           other.region == this.region &&
           other.searchedAt == this.searchedAt);
 }
@@ -1708,20 +2527,44 @@ class RouteSearchHistoryCompanion
   final Value<int> id;
   final Value<String> originStationId;
   final Value<String> originStationName;
+  final Value<String?> originLineId;
+  final Value<String?> originLineName;
+  final Value<String?> originLineColor;
+  final Value<String?> originStationCode;
   final Value<String?> waypointStationId;
   final Value<String?> waypointStationName;
+  final Value<String?> waypointLineId;
+  final Value<String?> waypointLineName;
+  final Value<String?> waypointLineColor;
+  final Value<String?> waypointStationCode;
   final Value<String> destinationStationId;
   final Value<String> destinationStationName;
+  final Value<String?> destinationLineId;
+  final Value<String?> destinationLineName;
+  final Value<String?> destinationLineColor;
+  final Value<String?> destinationStationCode;
   final Value<String> region;
   final Value<DateTime> searchedAt;
   const RouteSearchHistoryCompanion({
     this.id = const Value.absent(),
     this.originStationId = const Value.absent(),
     this.originStationName = const Value.absent(),
+    this.originLineId = const Value.absent(),
+    this.originLineName = const Value.absent(),
+    this.originLineColor = const Value.absent(),
+    this.originStationCode = const Value.absent(),
     this.waypointStationId = const Value.absent(),
     this.waypointStationName = const Value.absent(),
+    this.waypointLineId = const Value.absent(),
+    this.waypointLineName = const Value.absent(),
+    this.waypointLineColor = const Value.absent(),
+    this.waypointStationCode = const Value.absent(),
     this.destinationStationId = const Value.absent(),
     this.destinationStationName = const Value.absent(),
+    this.destinationLineId = const Value.absent(),
+    this.destinationLineName = const Value.absent(),
+    this.destinationLineColor = const Value.absent(),
+    this.destinationStationCode = const Value.absent(),
     this.region = const Value.absent(),
     this.searchedAt = const Value.absent(),
   });
@@ -1729,10 +2572,22 @@ class RouteSearchHistoryCompanion
     this.id = const Value.absent(),
     required String originStationId,
     required String originStationName,
+    this.originLineId = const Value.absent(),
+    this.originLineName = const Value.absent(),
+    this.originLineColor = const Value.absent(),
+    this.originStationCode = const Value.absent(),
     this.waypointStationId = const Value.absent(),
     this.waypointStationName = const Value.absent(),
+    this.waypointLineId = const Value.absent(),
+    this.waypointLineName = const Value.absent(),
+    this.waypointLineColor = const Value.absent(),
+    this.waypointStationCode = const Value.absent(),
     required String destinationStationId,
     required String destinationStationName,
+    this.destinationLineId = const Value.absent(),
+    this.destinationLineName = const Value.absent(),
+    this.destinationLineColor = const Value.absent(),
+    this.destinationStationCode = const Value.absent(),
     required String region,
     required DateTime searchedAt,
   }) : originStationId = Value(originStationId),
@@ -1745,10 +2600,22 @@ class RouteSearchHistoryCompanion
     Expression<int>? id,
     Expression<String>? originStationId,
     Expression<String>? originStationName,
+    Expression<String>? originLineId,
+    Expression<String>? originLineName,
+    Expression<String>? originLineColor,
+    Expression<String>? originStationCode,
     Expression<String>? waypointStationId,
     Expression<String>? waypointStationName,
+    Expression<String>? waypointLineId,
+    Expression<String>? waypointLineName,
+    Expression<String>? waypointLineColor,
+    Expression<String>? waypointStationCode,
     Expression<String>? destinationStationId,
     Expression<String>? destinationStationName,
+    Expression<String>? destinationLineId,
+    Expression<String>? destinationLineName,
+    Expression<String>? destinationLineColor,
+    Expression<String>? destinationStationCode,
     Expression<String>? region,
     Expression<DateTime>? searchedAt,
   }) {
@@ -1756,13 +2623,29 @@ class RouteSearchHistoryCompanion
       if (id != null) 'id': id,
       if (originStationId != null) 'origin_station_id': originStationId,
       if (originStationName != null) 'origin_station_name': originStationName,
+      if (originLineId != null) 'origin_line_id': originLineId,
+      if (originLineName != null) 'origin_line_name': originLineName,
+      if (originLineColor != null) 'origin_line_color': originLineColor,
+      if (originStationCode != null) 'origin_station_code': originStationCode,
       if (waypointStationId != null) 'waypoint_station_id': waypointStationId,
       if (waypointStationName != null)
         'waypoint_station_name': waypointStationName,
+      if (waypointLineId != null) 'waypoint_line_id': waypointLineId,
+      if (waypointLineName != null) 'waypoint_line_name': waypointLineName,
+      if (waypointLineColor != null) 'waypoint_line_color': waypointLineColor,
+      if (waypointStationCode != null)
+        'waypoint_station_code': waypointStationCode,
       if (destinationStationId != null)
         'destination_station_id': destinationStationId,
       if (destinationStationName != null)
         'destination_station_name': destinationStationName,
+      if (destinationLineId != null) 'destination_line_id': destinationLineId,
+      if (destinationLineName != null)
+        'destination_line_name': destinationLineName,
+      if (destinationLineColor != null)
+        'destination_line_color': destinationLineColor,
+      if (destinationStationCode != null)
+        'destination_station_code': destinationStationCode,
       if (region != null) 'region': region,
       if (searchedAt != null) 'searched_at': searchedAt,
     });
@@ -1772,10 +2655,22 @@ class RouteSearchHistoryCompanion
     Value<int>? id,
     Value<String>? originStationId,
     Value<String>? originStationName,
+    Value<String?>? originLineId,
+    Value<String?>? originLineName,
+    Value<String?>? originLineColor,
+    Value<String?>? originStationCode,
     Value<String?>? waypointStationId,
     Value<String?>? waypointStationName,
+    Value<String?>? waypointLineId,
+    Value<String?>? waypointLineName,
+    Value<String?>? waypointLineColor,
+    Value<String?>? waypointStationCode,
     Value<String>? destinationStationId,
     Value<String>? destinationStationName,
+    Value<String?>? destinationLineId,
+    Value<String?>? destinationLineName,
+    Value<String?>? destinationLineColor,
+    Value<String?>? destinationStationCode,
     Value<String>? region,
     Value<DateTime>? searchedAt,
   }) {
@@ -1783,11 +2678,24 @@ class RouteSearchHistoryCompanion
       id: id ?? this.id,
       originStationId: originStationId ?? this.originStationId,
       originStationName: originStationName ?? this.originStationName,
+      originLineId: originLineId ?? this.originLineId,
+      originLineName: originLineName ?? this.originLineName,
+      originLineColor: originLineColor ?? this.originLineColor,
+      originStationCode: originStationCode ?? this.originStationCode,
       waypointStationId: waypointStationId ?? this.waypointStationId,
       waypointStationName: waypointStationName ?? this.waypointStationName,
+      waypointLineId: waypointLineId ?? this.waypointLineId,
+      waypointLineName: waypointLineName ?? this.waypointLineName,
+      waypointLineColor: waypointLineColor ?? this.waypointLineColor,
+      waypointStationCode: waypointStationCode ?? this.waypointStationCode,
       destinationStationId: destinationStationId ?? this.destinationStationId,
       destinationStationName:
           destinationStationName ?? this.destinationStationName,
+      destinationLineId: destinationLineId ?? this.destinationLineId,
+      destinationLineName: destinationLineName ?? this.destinationLineName,
+      destinationLineColor: destinationLineColor ?? this.destinationLineColor,
+      destinationStationCode:
+          destinationStationCode ?? this.destinationStationCode,
       region: region ?? this.region,
       searchedAt: searchedAt ?? this.searchedAt,
     );
@@ -1805,12 +2713,38 @@ class RouteSearchHistoryCompanion
     if (originStationName.present) {
       map['origin_station_name'] = Variable<String>(originStationName.value);
     }
+    if (originLineId.present) {
+      map['origin_line_id'] = Variable<String>(originLineId.value);
+    }
+    if (originLineName.present) {
+      map['origin_line_name'] = Variable<String>(originLineName.value);
+    }
+    if (originLineColor.present) {
+      map['origin_line_color'] = Variable<String>(originLineColor.value);
+    }
+    if (originStationCode.present) {
+      map['origin_station_code'] = Variable<String>(originStationCode.value);
+    }
     if (waypointStationId.present) {
       map['waypoint_station_id'] = Variable<String>(waypointStationId.value);
     }
     if (waypointStationName.present) {
       map['waypoint_station_name'] = Variable<String>(
         waypointStationName.value,
+      );
+    }
+    if (waypointLineId.present) {
+      map['waypoint_line_id'] = Variable<String>(waypointLineId.value);
+    }
+    if (waypointLineName.present) {
+      map['waypoint_line_name'] = Variable<String>(waypointLineName.value);
+    }
+    if (waypointLineColor.present) {
+      map['waypoint_line_color'] = Variable<String>(waypointLineColor.value);
+    }
+    if (waypointStationCode.present) {
+      map['waypoint_station_code'] = Variable<String>(
+        waypointStationCode.value,
       );
     }
     if (destinationStationId.present) {
@@ -1821,6 +2755,24 @@ class RouteSearchHistoryCompanion
     if (destinationStationName.present) {
       map['destination_station_name'] = Variable<String>(
         destinationStationName.value,
+      );
+    }
+    if (destinationLineId.present) {
+      map['destination_line_id'] = Variable<String>(destinationLineId.value);
+    }
+    if (destinationLineName.present) {
+      map['destination_line_name'] = Variable<String>(
+        destinationLineName.value,
+      );
+    }
+    if (destinationLineColor.present) {
+      map['destination_line_color'] = Variable<String>(
+        destinationLineColor.value,
+      );
+    }
+    if (destinationStationCode.present) {
+      map['destination_station_code'] = Variable<String>(
+        destinationStationCode.value,
       );
     }
     if (region.present) {
@@ -1838,10 +2790,22 @@ class RouteSearchHistoryCompanion
           ..write('id: $id, ')
           ..write('originStationId: $originStationId, ')
           ..write('originStationName: $originStationName, ')
+          ..write('originLineId: $originLineId, ')
+          ..write('originLineName: $originLineName, ')
+          ..write('originLineColor: $originLineColor, ')
+          ..write('originStationCode: $originStationCode, ')
           ..write('waypointStationId: $waypointStationId, ')
           ..write('waypointStationName: $waypointStationName, ')
+          ..write('waypointLineId: $waypointLineId, ')
+          ..write('waypointLineName: $waypointLineName, ')
+          ..write('waypointLineColor: $waypointLineColor, ')
+          ..write('waypointStationCode: $waypointStationCode, ')
           ..write('destinationStationId: $destinationStationId, ')
           ..write('destinationStationName: $destinationStationName, ')
+          ..write('destinationLineId: $destinationLineId, ')
+          ..write('destinationLineName: $destinationLineName, ')
+          ..write('destinationLineColor: $destinationLineColor, ')
+          ..write('destinationStationCode: $destinationStationCode, ')
           ..write('region: $region, ')
           ..write('searchedAt: $searchedAt')
           ..write(')'))
@@ -4048,6 +5012,11 @@ typedef $$SearchHistoryTableCreateCompanionBuilder =
       Value<int> id,
       required String query,
       Value<String?> region,
+      Value<String?> stationId,
+      Value<String?> lineId,
+      Value<String?> lineName,
+      Value<String?> lineColor,
+      Value<String?> stationCode,
       required DateTime searchedAt,
     });
 typedef $$SearchHistoryTableUpdateCompanionBuilder =
@@ -4055,6 +5024,11 @@ typedef $$SearchHistoryTableUpdateCompanionBuilder =
       Value<int> id,
       Value<String> query,
       Value<String?> region,
+      Value<String?> stationId,
+      Value<String?> lineId,
+      Value<String?> lineName,
+      Value<String?> lineColor,
+      Value<String?> stationCode,
       Value<DateTime> searchedAt,
     });
 
@@ -4079,6 +5053,31 @@ class $$SearchHistoryTableFilterComposer
 
   ColumnFilters<String> get region => $composableBuilder(
     column: $table.region,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get stationId => $composableBuilder(
+    column: $table.stationId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get lineId => $composableBuilder(
+    column: $table.lineId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get lineName => $composableBuilder(
+    column: $table.lineName,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get lineColor => $composableBuilder(
+    column: $table.lineColor,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get stationCode => $composableBuilder(
+    column: $table.stationCode,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -4112,6 +5111,31 @@ class $$SearchHistoryTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get stationId => $composableBuilder(
+    column: $table.stationId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get lineId => $composableBuilder(
+    column: $table.lineId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get lineName => $composableBuilder(
+    column: $table.lineName,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get lineColor => $composableBuilder(
+    column: $table.lineColor,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get stationCode => $composableBuilder(
+    column: $table.stationCode,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<DateTime> get searchedAt => $composableBuilder(
     column: $table.searchedAt,
     builder: (column) => ColumnOrderings(column),
@@ -4135,6 +5159,23 @@ class $$SearchHistoryTableAnnotationComposer
 
   GeneratedColumn<String> get region =>
       $composableBuilder(column: $table.region, builder: (column) => column);
+
+  GeneratedColumn<String> get stationId =>
+      $composableBuilder(column: $table.stationId, builder: (column) => column);
+
+  GeneratedColumn<String> get lineId =>
+      $composableBuilder(column: $table.lineId, builder: (column) => column);
+
+  GeneratedColumn<String> get lineName =>
+      $composableBuilder(column: $table.lineName, builder: (column) => column);
+
+  GeneratedColumn<String> get lineColor =>
+      $composableBuilder(column: $table.lineColor, builder: (column) => column);
+
+  GeneratedColumn<String> get stationCode => $composableBuilder(
+    column: $table.stationCode,
+    builder: (column) => column,
+  );
 
   GeneratedColumn<DateTime> get searchedAt => $composableBuilder(
     column: $table.searchedAt,
@@ -4180,11 +5221,21 @@ class $$SearchHistoryTableTableManager
                 Value<int> id = const Value.absent(),
                 Value<String> query = const Value.absent(),
                 Value<String?> region = const Value.absent(),
+                Value<String?> stationId = const Value.absent(),
+                Value<String?> lineId = const Value.absent(),
+                Value<String?> lineName = const Value.absent(),
+                Value<String?> lineColor = const Value.absent(),
+                Value<String?> stationCode = const Value.absent(),
                 Value<DateTime> searchedAt = const Value.absent(),
               }) => SearchHistoryCompanion(
                 id: id,
                 query: query,
                 region: region,
+                stationId: stationId,
+                lineId: lineId,
+                lineName: lineName,
+                lineColor: lineColor,
+                stationCode: stationCode,
                 searchedAt: searchedAt,
               ),
           createCompanionCallback:
@@ -4192,11 +5243,21 @@ class $$SearchHistoryTableTableManager
                 Value<int> id = const Value.absent(),
                 required String query,
                 Value<String?> region = const Value.absent(),
+                Value<String?> stationId = const Value.absent(),
+                Value<String?> lineId = const Value.absent(),
+                Value<String?> lineName = const Value.absent(),
+                Value<String?> lineColor = const Value.absent(),
+                Value<String?> stationCode = const Value.absent(),
                 required DateTime searchedAt,
               }) => SearchHistoryCompanion.insert(
                 id: id,
                 query: query,
                 region: region,
+                stationId: stationId,
+                lineId: lineId,
+                lineName: lineName,
+                lineColor: lineColor,
+                stationCode: stationCode,
                 searchedAt: searchedAt,
               ),
           withReferenceMapper: (p0) => p0
@@ -4229,10 +5290,22 @@ typedef $$RouteSearchHistoryTableCreateCompanionBuilder =
       Value<int> id,
       required String originStationId,
       required String originStationName,
+      Value<String?> originLineId,
+      Value<String?> originLineName,
+      Value<String?> originLineColor,
+      Value<String?> originStationCode,
       Value<String?> waypointStationId,
       Value<String?> waypointStationName,
+      Value<String?> waypointLineId,
+      Value<String?> waypointLineName,
+      Value<String?> waypointLineColor,
+      Value<String?> waypointStationCode,
       required String destinationStationId,
       required String destinationStationName,
+      Value<String?> destinationLineId,
+      Value<String?> destinationLineName,
+      Value<String?> destinationLineColor,
+      Value<String?> destinationStationCode,
       required String region,
       required DateTime searchedAt,
     });
@@ -4241,10 +5314,22 @@ typedef $$RouteSearchHistoryTableUpdateCompanionBuilder =
       Value<int> id,
       Value<String> originStationId,
       Value<String> originStationName,
+      Value<String?> originLineId,
+      Value<String?> originLineName,
+      Value<String?> originLineColor,
+      Value<String?> originStationCode,
       Value<String?> waypointStationId,
       Value<String?> waypointStationName,
+      Value<String?> waypointLineId,
+      Value<String?> waypointLineName,
+      Value<String?> waypointLineColor,
+      Value<String?> waypointStationCode,
       Value<String> destinationStationId,
       Value<String> destinationStationName,
+      Value<String?> destinationLineId,
+      Value<String?> destinationLineName,
+      Value<String?> destinationLineColor,
+      Value<String?> destinationStationCode,
       Value<String> region,
       Value<DateTime> searchedAt,
     });
@@ -4273,6 +5358,26 @@ class $$RouteSearchHistoryTableFilterComposer
     builder: (column) => ColumnFilters(column),
   );
 
+  ColumnFilters<String> get originLineId => $composableBuilder(
+    column: $table.originLineId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get originLineName => $composableBuilder(
+    column: $table.originLineName,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get originLineColor => $composableBuilder(
+    column: $table.originLineColor,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get originStationCode => $composableBuilder(
+    column: $table.originStationCode,
+    builder: (column) => ColumnFilters(column),
+  );
+
   ColumnFilters<String> get waypointStationId => $composableBuilder(
     column: $table.waypointStationId,
     builder: (column) => ColumnFilters(column),
@@ -4283,6 +5388,26 @@ class $$RouteSearchHistoryTableFilterComposer
     builder: (column) => ColumnFilters(column),
   );
 
+  ColumnFilters<String> get waypointLineId => $composableBuilder(
+    column: $table.waypointLineId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get waypointLineName => $composableBuilder(
+    column: $table.waypointLineName,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get waypointLineColor => $composableBuilder(
+    column: $table.waypointLineColor,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get waypointStationCode => $composableBuilder(
+    column: $table.waypointStationCode,
+    builder: (column) => ColumnFilters(column),
+  );
+
   ColumnFilters<String> get destinationStationId => $composableBuilder(
     column: $table.destinationStationId,
     builder: (column) => ColumnFilters(column),
@@ -4290,6 +5415,26 @@ class $$RouteSearchHistoryTableFilterComposer
 
   ColumnFilters<String> get destinationStationName => $composableBuilder(
     column: $table.destinationStationName,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get destinationLineId => $composableBuilder(
+    column: $table.destinationLineId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get destinationLineName => $composableBuilder(
+    column: $table.destinationLineName,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get destinationLineColor => $composableBuilder(
+    column: $table.destinationLineColor,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get destinationStationCode => $composableBuilder(
+    column: $table.destinationStationCode,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -4328,6 +5473,26 @@ class $$RouteSearchHistoryTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get originLineId => $composableBuilder(
+    column: $table.originLineId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get originLineName => $composableBuilder(
+    column: $table.originLineName,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get originLineColor => $composableBuilder(
+    column: $table.originLineColor,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get originStationCode => $composableBuilder(
+    column: $table.originStationCode,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<String> get waypointStationId => $composableBuilder(
     column: $table.waypointStationId,
     builder: (column) => ColumnOrderings(column),
@@ -4338,6 +5503,26 @@ class $$RouteSearchHistoryTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get waypointLineId => $composableBuilder(
+    column: $table.waypointLineId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get waypointLineName => $composableBuilder(
+    column: $table.waypointLineName,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get waypointLineColor => $composableBuilder(
+    column: $table.waypointLineColor,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get waypointStationCode => $composableBuilder(
+    column: $table.waypointStationCode,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<String> get destinationStationId => $composableBuilder(
     column: $table.destinationStationId,
     builder: (column) => ColumnOrderings(column),
@@ -4345,6 +5530,26 @@ class $$RouteSearchHistoryTableOrderingComposer
 
   ColumnOrderings<String> get destinationStationName => $composableBuilder(
     column: $table.destinationStationName,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get destinationLineId => $composableBuilder(
+    column: $table.destinationLineId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get destinationLineName => $composableBuilder(
+    column: $table.destinationLineName,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get destinationLineColor => $composableBuilder(
+    column: $table.destinationLineColor,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get destinationStationCode => $composableBuilder(
+    column: $table.destinationStationCode,
     builder: (column) => ColumnOrderings(column),
   );
 
@@ -4381,6 +5586,26 @@ class $$RouteSearchHistoryTableAnnotationComposer
     builder: (column) => column,
   );
 
+  GeneratedColumn<String> get originLineId => $composableBuilder(
+    column: $table.originLineId,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get originLineName => $composableBuilder(
+    column: $table.originLineName,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get originLineColor => $composableBuilder(
+    column: $table.originLineColor,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get originStationCode => $composableBuilder(
+    column: $table.originStationCode,
+    builder: (column) => column,
+  );
+
   GeneratedColumn<String> get waypointStationId => $composableBuilder(
     column: $table.waypointStationId,
     builder: (column) => column,
@@ -4391,6 +5616,26 @@ class $$RouteSearchHistoryTableAnnotationComposer
     builder: (column) => column,
   );
 
+  GeneratedColumn<String> get waypointLineId => $composableBuilder(
+    column: $table.waypointLineId,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get waypointLineName => $composableBuilder(
+    column: $table.waypointLineName,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get waypointLineColor => $composableBuilder(
+    column: $table.waypointLineColor,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get waypointStationCode => $composableBuilder(
+    column: $table.waypointStationCode,
+    builder: (column) => column,
+  );
+
   GeneratedColumn<String> get destinationStationId => $composableBuilder(
     column: $table.destinationStationId,
     builder: (column) => column,
@@ -4398,6 +5643,26 @@ class $$RouteSearchHistoryTableAnnotationComposer
 
   GeneratedColumn<String> get destinationStationName => $composableBuilder(
     column: $table.destinationStationName,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get destinationLineId => $composableBuilder(
+    column: $table.destinationLineId,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get destinationLineName => $composableBuilder(
+    column: $table.destinationLineName,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get destinationLineColor => $composableBuilder(
+    column: $table.destinationLineColor,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get destinationStationCode => $composableBuilder(
+    column: $table.destinationStationCode,
     builder: (column) => column,
   );
 
@@ -4453,20 +5718,44 @@ class $$RouteSearchHistoryTableTableManager
                 Value<int> id = const Value.absent(),
                 Value<String> originStationId = const Value.absent(),
                 Value<String> originStationName = const Value.absent(),
+                Value<String?> originLineId = const Value.absent(),
+                Value<String?> originLineName = const Value.absent(),
+                Value<String?> originLineColor = const Value.absent(),
+                Value<String?> originStationCode = const Value.absent(),
                 Value<String?> waypointStationId = const Value.absent(),
                 Value<String?> waypointStationName = const Value.absent(),
+                Value<String?> waypointLineId = const Value.absent(),
+                Value<String?> waypointLineName = const Value.absent(),
+                Value<String?> waypointLineColor = const Value.absent(),
+                Value<String?> waypointStationCode = const Value.absent(),
                 Value<String> destinationStationId = const Value.absent(),
                 Value<String> destinationStationName = const Value.absent(),
+                Value<String?> destinationLineId = const Value.absent(),
+                Value<String?> destinationLineName = const Value.absent(),
+                Value<String?> destinationLineColor = const Value.absent(),
+                Value<String?> destinationStationCode = const Value.absent(),
                 Value<String> region = const Value.absent(),
                 Value<DateTime> searchedAt = const Value.absent(),
               }) => RouteSearchHistoryCompanion(
                 id: id,
                 originStationId: originStationId,
                 originStationName: originStationName,
+                originLineId: originLineId,
+                originLineName: originLineName,
+                originLineColor: originLineColor,
+                originStationCode: originStationCode,
                 waypointStationId: waypointStationId,
                 waypointStationName: waypointStationName,
+                waypointLineId: waypointLineId,
+                waypointLineName: waypointLineName,
+                waypointLineColor: waypointLineColor,
+                waypointStationCode: waypointStationCode,
                 destinationStationId: destinationStationId,
                 destinationStationName: destinationStationName,
+                destinationLineId: destinationLineId,
+                destinationLineName: destinationLineName,
+                destinationLineColor: destinationLineColor,
+                destinationStationCode: destinationStationCode,
                 region: region,
                 searchedAt: searchedAt,
               ),
@@ -4475,20 +5764,44 @@ class $$RouteSearchHistoryTableTableManager
                 Value<int> id = const Value.absent(),
                 required String originStationId,
                 required String originStationName,
+                Value<String?> originLineId = const Value.absent(),
+                Value<String?> originLineName = const Value.absent(),
+                Value<String?> originLineColor = const Value.absent(),
+                Value<String?> originStationCode = const Value.absent(),
                 Value<String?> waypointStationId = const Value.absent(),
                 Value<String?> waypointStationName = const Value.absent(),
+                Value<String?> waypointLineId = const Value.absent(),
+                Value<String?> waypointLineName = const Value.absent(),
+                Value<String?> waypointLineColor = const Value.absent(),
+                Value<String?> waypointStationCode = const Value.absent(),
                 required String destinationStationId,
                 required String destinationStationName,
+                Value<String?> destinationLineId = const Value.absent(),
+                Value<String?> destinationLineName = const Value.absent(),
+                Value<String?> destinationLineColor = const Value.absent(),
+                Value<String?> destinationStationCode = const Value.absent(),
                 required String region,
                 required DateTime searchedAt,
               }) => RouteSearchHistoryCompanion.insert(
                 id: id,
                 originStationId: originStationId,
                 originStationName: originStationName,
+                originLineId: originLineId,
+                originLineName: originLineName,
+                originLineColor: originLineColor,
+                originStationCode: originStationCode,
                 waypointStationId: waypointStationId,
                 waypointStationName: waypointStationName,
+                waypointLineId: waypointLineId,
+                waypointLineName: waypointLineName,
+                waypointLineColor: waypointLineColor,
+                waypointStationCode: waypointStationCode,
                 destinationStationId: destinationStationId,
                 destinationStationName: destinationStationName,
+                destinationLineId: destinationLineId,
+                destinationLineName: destinationLineName,
+                destinationLineColor: destinationLineColor,
+                destinationStationCode: destinationStationCode,
                 region: region,
                 searchedAt: searchedAt,
               ),

--- a/apps/mobile/lib/core/database/user/user_tables.dart
+++ b/apps/mobile/lib/core/database/user/user_tables.dart
@@ -52,6 +52,13 @@ class SearchHistory extends Table {
   /// 검색 당시 선택 지역(예: `수도권`, `부산`). 지역별 최근 목록 필터에 쓴다.
   /// 지역 정보 없이 저장된 레거시 행은 null이며, 지역 필터 목록에서 제외한다.
   TextColumn get region => text().nullable()();
+
+  /// 결과에서 고른 역·호선. 검색어만 있는 레거시/타이핑 기록은 null.
+  TextColumn get stationId => text().named('station_id').nullable()();
+  TextColumn get lineId => text().named('line_id').nullable()();
+  TextColumn get lineName => text().named('line_name').nullable()();
+  TextColumn get lineColor => text().named('line_color').nullable()();
+  TextColumn get stationCode => text().named('station_code').nullable()();
   DateTimeColumn get searchedAt => dateTime().named('searched_at')();
 }
 
@@ -62,14 +69,37 @@ class RouteSearchHistory extends Table {
   IntColumn get id => integer().autoIncrement()();
   TextColumn get originStationId => text().named('origin_station_id')();
   TextColumn get originStationName => text().named('origin_station_name')();
+  TextColumn get originLineId => text().named('origin_line_id').nullable()();
+  TextColumn get originLineName =>
+      text().named('origin_line_name').nullable()();
+  TextColumn get originLineColor =>
+      text().named('origin_line_color').nullable()();
+  TextColumn get originStationCode =>
+      text().named('origin_station_code').nullable()();
   TextColumn get waypointStationId =>
       text().named('waypoint_station_id').nullable()();
   TextColumn get waypointStationName =>
       text().named('waypoint_station_name').nullable()();
+  TextColumn get waypointLineId =>
+      text().named('waypoint_line_id').nullable()();
+  TextColumn get waypointLineName =>
+      text().named('waypoint_line_name').nullable()();
+  TextColumn get waypointLineColor =>
+      text().named('waypoint_line_color').nullable()();
+  TextColumn get waypointStationCode =>
+      text().named('waypoint_station_code').nullable()();
   TextColumn get destinationStationId =>
       text().named('destination_station_id')();
   TextColumn get destinationStationName =>
       text().named('destination_station_name')();
+  TextColumn get destinationLineId =>
+      text().named('destination_line_id').nullable()();
+  TextColumn get destinationLineName =>
+      text().named('destination_line_name').nullable()();
+  TextColumn get destinationLineColor =>
+      text().named('destination_line_color').nullable()();
+  TextColumn get destinationStationCode =>
+      text().named('destination_station_code').nullable()();
   TextColumn get region => text()();
   DateTimeColumn get searchedAt => dateTime().named('searched_at')();
 }

--- a/apps/mobile/lib/features/home/presentation/home_screen.dart
+++ b/apps/mobile/lib/features/home/presentation/home_screen.dart
@@ -444,11 +444,10 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
       String regionLabel,
       List<String> mapRegionLabels,
     ) async {
-      // #2109 Fix: 둘러보기 모드 결과 탭은 더 이상 즉시 상세를 밀지 않고
-      // 선택한 역 결과를 pop으로 반환한다(_returnStationToMap). 여기서 노선
-      // 정보까지 받아 노선도에 focus + 팬 메뉴 + 하단 패널을 요청한다.
-      final station = await Navigator.of(context).push<StationSearchResult>(
-        MaterialPageRoute<StationSearchResult>(
+      // 메뉴 역 검색: 결과 탭은 검색 화면이 상세를 push한다(목록 유지).
+      // 노선도 부채는 홈 in-place 검색 전용이다.
+      await Navigator.of(context).push<void>(
+        MaterialPageRoute<void>(
           builder: (_) => StationSearchScreen(
             repository: repository,
             reportRepository: reportRepository,
@@ -468,9 +467,6 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
       );
       if (!context.mounted) {
         return;
-      }
-      if (station != null) {
-        setState(() => _mapFocusStationRequest = station);
       }
       await refreshHomeState();
     }

--- a/apps/mobile/lib/features/network_map/presentation/nearby_station_line_bar.dart
+++ b/apps/mobile/lib/features/network_map/presentation/nearby_station_line_bar.dart
@@ -13,6 +13,7 @@ class NearbyStationLineBar extends StatelessWidget {
     required this.stationName,
     required this.badgeText,
     required this.lineColor,
+    this.onStationNameTap,
     super.key,
   });
 
@@ -22,11 +23,19 @@ class NearbyStationLineBar extends StatelessWidget {
   final String badgeText;
   final Color lineColor;
 
+  /// 현재 역 이름 탭 → 역 상세. null이면 이름만 표시한다.
+  final VoidCallback? onStationNameTap;
+
   @override
   Widget build(BuildContext context) {
+    final openDetail = onStationNameTap;
     return Semantics(
       container: true,
-      label: _semanticsLabel(),
+      label: openDetail == null
+          ? _semanticsLabel()
+          : '${_semanticsLabel()}, 상세 보기',
+      button: openDetail != null,
+      onTap: openDetail,
       child: ExcludeSemantics(child: _buildBar()),
     );
   }
@@ -113,16 +122,10 @@ class NearbyStationLineBar extends StatelessWidget {
                           const SizedBox(width: 7),
                         ],
                         Flexible(
-                          child: Text(
-                            stationName,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: TextStyle(
-                              color: const Color(0xFF102A2C),
-                              fontSize: stationNameSize,
-                              fontWeight: FontWeight.w800,
-                              height: 1.1,
-                            ),
+                          child: _StationNameLabel(
+                            stationName: stationName,
+                            fontSize: stationNameSize,
+                            onTap: onStationNameTap,
                           ),
                         ),
                       ],
@@ -134,6 +137,44 @@ class NearbyStationLineBar extends StatelessWidget {
           ),
         );
       },
+    );
+  }
+}
+
+class _StationNameLabel extends StatelessWidget {
+  const _StationNameLabel({
+    required this.stationName,
+    required this.fontSize,
+    this.onTap,
+  });
+
+  final String stationName;
+  final double fontSize;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final text = Text(
+      stationName,
+      maxLines: 1,
+      overflow: TextOverflow.ellipsis,
+      style: TextStyle(
+        color: const Color(0xFF102A2C),
+        fontSize: fontSize,
+        fontWeight: FontWeight.w800,
+        height: 1.1,
+      ),
+    );
+    final tap = onTap;
+    if (tap == null) {
+      return text;
+    }
+    // TalkBack 라벨·동작은 상위 NearbyStationLineBar Semantics가 담당한다.
+    return InkWell(
+      key: const Key('nearbyStationLineBarStationName'),
+      onTap: tap,
+      borderRadius: BorderRadius.circular(8),
+      child: text,
     );
   }
 }

--- a/apps/mobile/lib/features/search_history/data/drift_search_history_repository.dart
+++ b/apps/mobile/lib/features/search_history/data/drift_search_history_repository.dart
@@ -30,12 +30,25 @@ class DriftSearchHistoryRepository implements SearchHistoryRepository {
     }
 
     final resolvedStationId = stationId?.trim() ?? '';
+    // 지역 변수로 받아 null 승격 — storeLine bool만으로는 필드 접근이 안전하지 않다.
     final resolvedLine = line;
     final resolvedLineId = resolvedLine?.id.trim() ?? '';
     final storeLine =
         resolvedLine != null &&
         resolvedLineId.isNotEmpty &&
         resolvedStationId.isNotEmpty;
+    final String? lineName;
+    final String? lineColor;
+    final String? stationCode;
+    if (resolvedLine != null && storeLine) {
+      lineName = resolvedLine.name.trim();
+      lineColor = resolvedLine.color.trim();
+      stationCode = resolvedLine.stationCode.trim();
+    } else {
+      lineName = null;
+      lineColor = null;
+      stationCode = null;
+    }
 
     await userDatabase.transaction(() async {
       // 같은 검색어라도 지역이 다르면 별도 행으로 유지한다.
@@ -55,11 +68,9 @@ class DriftSearchHistoryRepository implements SearchHistoryRepository {
               region: Value(normalizedRegion),
               stationId: Value(storeLine ? resolvedStationId : null),
               lineId: Value(storeLine ? resolvedLineId : null),
-              lineName: Value(storeLine ? resolvedLine.name.trim() : null),
-              lineColor: Value(storeLine ? resolvedLine.color.trim() : null),
-              stationCode: Value(
-                storeLine ? resolvedLine.stationCode.trim() : null,
-              ),
+              lineName: Value(lineName),
+              lineColor: Value(lineColor),
+              stationCode: Value(stationCode),
               searchedAt: DateTime.now().toUtc(),
             ),
           );

--- a/apps/mobile/lib/features/search_history/data/drift_search_history_repository.dart
+++ b/apps/mobile/lib/features/search_history/data/drift_search_history_repository.dart
@@ -13,7 +13,12 @@ class DriftSearchHistoryRepository implements SearchHistoryRepository {
   final int maxEntries;
 
   @override
-  Future<void> recordSearch(String query, {String? region}) async {
+  Future<void> recordSearch(
+    String query, {
+    String? region,
+    String? stationId,
+    StationSearchLine? line,
+  }) async {
     final trimmed = query.trim();
     if (trimmed.isEmpty) {
       return;
@@ -23,6 +28,14 @@ class DriftSearchHistoryRepository implements SearchHistoryRepository {
     if (normalizedRegion == null || normalizedRegion.isEmpty) {
       return;
     }
+
+    final resolvedStationId = stationId?.trim() ?? '';
+    final resolvedLine = line;
+    final resolvedLineId = resolvedLine?.id.trim() ?? '';
+    final storeLine =
+        resolvedLine != null &&
+        resolvedLineId.isNotEmpty &&
+        resolvedStationId.isNotEmpty;
 
     await userDatabase.transaction(() async {
       // 같은 검색어라도 지역이 다르면 별도 행으로 유지한다.
@@ -40,6 +53,13 @@ class DriftSearchHistoryRepository implements SearchHistoryRepository {
             user_db.SearchHistoryCompanion.insert(
               query: trimmed,
               region: Value(normalizedRegion),
+              stationId: Value(storeLine ? resolvedStationId : null),
+              lineId: Value(storeLine ? resolvedLineId : null),
+              lineName: Value(storeLine ? resolvedLine.name.trim() : null),
+              lineColor: Value(storeLine ? resolvedLine.color.trim() : null),
+              stationCode: Value(
+                storeLine ? resolvedLine.stationCode.trim() : null,
+              ),
               searchedAt: DateTime.now().toUtc(),
             ),
           );
@@ -61,6 +81,9 @@ class DriftSearchHistoryRepository implements SearchHistoryRepository {
     }
     final waypointId = entry.waypointStationId?.trim();
     final waypointName = entry.waypointStationName?.trim();
+    final originLine = _singleStoredLine(entry.originLines);
+    final waypointLine = _singleStoredLine(entry.waypointLines);
+    final destinationLine = _singleStoredLine(entry.destinationLines);
 
     await userDatabase.transaction(() async {
       // 같은 경로(출발·경유·도착·지역)는 기존 항목을 지우고 다시 넣어 최신순으로 올린다.
@@ -80,6 +103,10 @@ class DriftSearchHistoryRepository implements SearchHistoryRepository {
             user_db.RouteSearchHistoryCompanion.insert(
               originStationId: originId,
               originStationName: entry.originStationName.trim(),
+              originLineId: Value(originLine?.id),
+              originLineName: Value(originLine?.name),
+              originLineColor: Value(originLine?.color),
+              originStationCode: Value(originLine?.stationCode),
               waypointStationId: Value(
                 waypointId == null || waypointId.isEmpty ? null : waypointId,
               ),
@@ -88,8 +115,16 @@ class DriftSearchHistoryRepository implements SearchHistoryRepository {
                     ? null
                     : waypointName,
               ),
+              waypointLineId: Value(waypointLine?.id),
+              waypointLineName: Value(waypointLine?.name),
+              waypointLineColor: Value(waypointLine?.color),
+              waypointStationCode: Value(waypointLine?.stationCode),
               destinationStationId: destinationId,
               destinationStationName: entry.destinationStationName.trim(),
+              destinationLineId: Value(destinationLine?.id),
+              destinationLineName: Value(destinationLine?.name),
+              destinationLineColor: Value(destinationLine?.color),
+              destinationStationCode: Value(destinationLine?.stationCode),
               region: region,
               searchedAt: DateTime.now().toUtc(),
             ),
@@ -126,7 +161,8 @@ class DriftSearchHistoryRepository implements SearchHistoryRepository {
     final stationRows = await userDatabase
         .customSelect(
           '''
-          SELECT query, region, searched_at
+          SELECT query, region, searched_at,
+                 station_id, line_id, line_name, line_color, station_code
           FROM search_history
           ORDER BY searched_at DESC, id DESC
           ''',
@@ -137,8 +173,14 @@ class DriftSearchHistoryRepository implements SearchHistoryRepository {
         .customSelect(
           '''
           SELECT origin_station_id, origin_station_name,
+                 origin_line_id, origin_line_name, origin_line_color,
+                 origin_station_code,
                  waypoint_station_id, waypoint_station_name,
+                 waypoint_line_id, waypoint_line_name, waypoint_line_color,
+                 waypoint_station_code,
                  destination_station_id, destination_station_name,
+                 destination_line_id, destination_line_name,
+                 destination_line_color, destination_station_code,
                  region, searched_at
           FROM route_search_history
           ORDER BY searched_at DESC, id DESC
@@ -158,6 +200,12 @@ class DriftSearchHistoryRepository implements SearchHistoryRepository {
           query: row.read<String>('query'),
           region: rowRegion,
           searchedAt: row.read<DateTime>('searched_at'),
+          lines: _linesFromStored(
+            lineId: row.read<String?>('line_id'),
+            lineName: row.read<String?>('line_name'),
+            lineColor: row.read<String?>('line_color'),
+            stationCode: row.read<String?>('station_code'),
+          ),
         ),
       );
     }
@@ -172,10 +220,28 @@ class DriftSearchHistoryRepository implements SearchHistoryRepository {
         RecentRouteSearchEntry(
           originStationId: row.read<String>('origin_station_id'),
           originStationName: row.read<String>('origin_station_name'),
+          originLines: _linesFromStored(
+            lineId: row.read<String?>('origin_line_id'),
+            lineName: row.read<String?>('origin_line_name'),
+            lineColor: row.read<String?>('origin_line_color'),
+            stationCode: row.read<String?>('origin_station_code'),
+          ),
           waypointStationId: row.read<String?>('waypoint_station_id'),
           waypointStationName: row.read<String?>('waypoint_station_name'),
+          waypointLines: _linesFromStored(
+            lineId: row.read<String?>('waypoint_line_id'),
+            lineName: row.read<String?>('waypoint_line_name'),
+            lineColor: row.read<String?>('waypoint_line_color'),
+            stationCode: row.read<String?>('waypoint_station_code'),
+          ),
           destinationStationId: row.read<String>('destination_station_id'),
           destinationStationName: row.read<String>('destination_station_name'),
+          destinationLines: _linesFromStored(
+            lineId: row.read<String?>('destination_line_id'),
+            lineName: row.read<String?>('destination_line_name'),
+            lineColor: row.read<String?>('destination_line_color'),
+            stationCode: row.read<String?>('destination_station_code'),
+          ),
           region: rowRegion,
           searchedAt: row.read<DateTime>('searched_at'),
         ),
@@ -300,4 +366,36 @@ class DriftSearchHistoryRepository implements SearchHistoryRepository {
   }
 
   String _placeholders(int count) => List.filled(count, '?').join(', ');
+}
+
+List<StationSearchLine> _linesFromStored({
+  String? lineId,
+  String? lineName,
+  String? lineColor,
+  String? stationCode,
+}) {
+  final id = lineId?.trim() ?? '';
+  if (id.isEmpty) {
+    return const [];
+  }
+  final name = lineName?.trim() ?? '';
+  return [
+    StationSearchLine(
+      id: id,
+      name: name.isEmpty ? id : name,
+      color: lineColor?.trim() ?? '',
+      stationCode: stationCode?.trim() ?? '',
+    ),
+  ];
+}
+
+StationSearchLine? _singleStoredLine(List<StationSearchLine> lines) {
+  if (lines.length != 1) {
+    return null;
+  }
+  final line = lines.first;
+  if (line.id.trim().isEmpty) {
+    return null;
+  }
+  return line;
 }

--- a/apps/mobile/lib/features/stations/application/station_search_controller.dart
+++ b/apps/mobile/lib/features/stations/application/station_search_controller.dart
@@ -45,6 +45,28 @@ class StationSearchController extends ChangeNotifier {
 
   StationSearchState get state => _state;
 
+  /// 한글 조합 중·검색 대기 UI. 성공 결과가 있으면 유지하고, empty/idle이면
+  /// loading으로 바꿔 "검색 결과가 없습니다" 깜빡임을 막는다.
+  void showPendingSearch() {
+    if (_isDisposed) {
+      return;
+    }
+    if (_state.source == StationSearchResultSource.search &&
+        _state.results.isNotEmpty &&
+        (_state.status == StationSearchStatus.success ||
+            _state.status == StationSearchStatus.loading)) {
+      return;
+    }
+    if (_state.status == StationSearchStatus.loading) {
+      return;
+    }
+    _state = const StationSearchState(
+      status: StationSearchStatus.loading,
+      results: [],
+    );
+    notifyListeners();
+  }
+
   Future<void> search(
     String query, {
     String? lineId,
@@ -60,11 +82,21 @@ class StationSearchController extends ChangeNotifier {
       return;
     }
 
-    _state = const StationSearchState(
-      status: StationSearchStatus.loading,
-      results: [],
-    );
-    _notifyIfActive(requestId);
+    // 타이핑 재검색: 이전 검색 결과를 비우지 않는다. 스피너로 갈아끼우면
+    // 글자마다 목록이 깜빡인다. 첫 검색(결과 없음)만 loading을 노출한다.
+    // empty 상태에서 다음 글자를 칠 때도 empty를 유지하지 않고 loading으로 간다.
+    final keepPreviousResults =
+        _state.source == StationSearchResultSource.search &&
+        _state.results.isNotEmpty &&
+        (_state.status == StationSearchStatus.success ||
+            _state.status == StationSearchStatus.loading);
+    if (!keepPreviousResults) {
+      _state = const StationSearchState(
+        status: StationSearchStatus.loading,
+        results: [],
+      );
+      _notifyIfActive(requestId);
+    }
 
     try {
       final selectedLineId = lineId?.trim();

--- a/apps/mobile/lib/features/stations/application/station_search_controller.dart
+++ b/apps/mobile/lib/features/stations/application/station_search_controller.dart
@@ -43,6 +43,9 @@ class StationSearchController extends ChangeNotifier {
   int _searchRequestId = 0;
   bool _isDisposed = false;
 
+  /// 직전 검색에 쓴 지역. 지역만 바뀌면 이전 결과 유지(keepPrevious)를 끈다.
+  String _lastSearchRegion = '';
+
   StationSearchState get state => _state;
 
   /// 한글 조합 중·검색 대기 UI. 성공 결과가 있으면 유지하고, empty/idle이면
@@ -85,11 +88,15 @@ class StationSearchController extends ChangeNotifier {
     // 타이핑 재검색: 이전 검색 결과를 비우지 않는다. 스피너로 갈아끼우면
     // 글자마다 목록이 깜빡인다. 첫 검색(결과 없음)만 loading을 노출한다.
     // empty 상태에서 다음 글자를 칠 때도 empty를 유지하지 않고 loading으로 간다.
+    // 지역이 바뀌면 이전 지역 역이 탭되지 않게 목록을 비운다.
+    final normalizedRegion = region?.trim() ?? '';
     final keepPreviousResults =
         _state.source == StationSearchResultSource.search &&
         _state.results.isNotEmpty &&
         (_state.status == StationSearchStatus.success ||
-            _state.status == StationSearchStatus.loading);
+            _state.status == StationSearchStatus.loading) &&
+        _lastSearchRegion == normalizedRegion;
+    _lastSearchRegion = normalizedRegion;
     if (!keepPreviousResults) {
       _state = const StationSearchState(
         status: StationSearchStatus.loading,
@@ -105,7 +112,11 @@ class StationSearchController extends ChangeNotifier {
               selectedLineId.isNotEmpty &&
               repository is StationLineFilterRepository
           ? await (repository as StationLineFilterRepository)
-                .searchStationsOnLine(trimmedQuery, selectedLineId)
+                .searchStationsOnLine(
+                  trimmedQuery,
+                  selectedLineId,
+                  region: region,
+                )
           : await repository.searchStations(trimmedQuery, region: region);
       if (!_isActiveRequest(requestId)) {
         return;

--- a/apps/mobile/lib/features/stations/application/station_search_controller.dart
+++ b/apps/mobile/lib/features/stations/application/station_search_controller.dart
@@ -106,11 +106,11 @@ class StationSearchController extends ChangeNotifier {
               repository is StationLineFilterRepository
           ? await (repository as StationLineFilterRepository)
                 .searchStationsOnLine(trimmedQuery, selectedLineId)
-          : await repository.searchStations(trimmedQuery);
+          : await repository.searchStations(trimmedQuery, region: region);
       if (!_isActiveRequest(requestId)) {
         return;
       }
-      // 지역이 주어지면 해당 지역 역만 남긴다(홈 노선도·풀페이지 검색 공통).
+      // 저장소가 region을 무시하는 구현(구 API 등)을 대비해 한 번 더 거른다.
       final filtered = _filterByRegion(results, region);
       // 디바운스 타이핑은 기록하지 않는다. 명시적 검색은 현재 지역에 실제
       // 결과가 있을 때만 기록해 타 지역 역이 잘못된 지역 이력으로 남지 않게 한다.

--- a/apps/mobile/lib/features/stations/data/drift_station_repository.dart
+++ b/apps/mobile/lib/features/stations/data/drift_station_repository.dart
@@ -797,6 +797,7 @@ class _LocalStationSummary {
   final List<StationSearchLine> lines;
 
   List<String>? _normalizedTermsCache;
+  List<String>? _chosungTermsCache;
 
   /// 검색은 역 이름만 본다(한글명·영문명·부역명).
   /// aliases에 섞인 역번호·호선 합성어("448", "4호선 상록수")는 쓰지 않는다.
@@ -809,8 +810,17 @@ class _LocalStationSummary {
     ].map(_normalize).where((term) => term.isNotEmpty).toList(growable: false);
   }
 
+  /// 정규화 term의 초성 키. 키입력마다 `_chosungKey`를 다시 돌리지 않는다.
+  List<String> get _chosungTerms {
+    return _chosungTermsCache ??= _normalizedTerms
+        .map(_chosungKey)
+        .where((key) => key.isNotEmpty)
+        .toList(growable: false);
+  }
+
   void primeSearchTerms() {
     _normalizedTerms;
+    _chosungTerms;
   }
 
   bool matches(String query) {
@@ -849,11 +859,7 @@ class _LocalStationSummary {
     if (queryChosung.isEmpty || !_isHangulJamoOnly(normalizedQuery)) {
       return null;
     }
-    for (final term in _normalizedTerms) {
-      final termChosung = _chosungKey(term);
-      if (termChosung.isEmpty) {
-        continue;
-      }
+    for (final termChosung in _chosungTerms) {
       if (termChosung == queryChosung) {
         return 0;
       }

--- a/apps/mobile/lib/features/stations/data/drift_station_repository.dart
+++ b/apps/mobile/lib/features/stations/data/drift_station_repository.dart
@@ -41,7 +41,10 @@ class DriftStationRepository
   }
 
   @override
-  Future<List<StationSearchResult>> searchStations(String query) async {
+  Future<List<StationSearchResult>> searchStations(
+    String query, {
+    String? region,
+  }) async {
     final trimmedQuery = query.trim();
     if (trimmedQuery.isEmpty) {
       return const [];
@@ -51,10 +54,15 @@ class DriftStationRepository
     if (normalizedQuery.isEmpty) {
       return const [];
     }
+    final regionFilter = region?.trim() ?? '';
 
     final stations = await _listStationSummaries();
     final ranked = <({_LocalStationSummary station, int rank})>[];
     for (final station in stations) {
+      if (regionFilter.isNotEmpty &&
+          !stationBelongsToRegion(station.region, regionFilter)) {
+        continue;
+      }
       final rank = station.matchRank(normalizedQuery);
       if (rank == null) {
         continue;

--- a/apps/mobile/lib/features/stations/data/drift_station_repository.dart
+++ b/apps/mobile/lib/features/stations/data/drift_station_repository.dart
@@ -13,6 +13,7 @@ import '../domain/station_repositories.dart';
 class DriftStationRepository
     implements
         StationSearchRepository,
+        StationSearchCache,
         StationLineFilterRepository,
         StationTimetableRepository,
         NetworkMapRepository {
@@ -20,6 +21,9 @@ class DriftStationRepository
 
   /// 지하철(`SUBWAY`) 출발에 허용되는 운행종별. 이 외 값은 경계에서 실패시킨다.
   static const _validSubwayServicePatterns = {'LOCAL', 'EXPRESS'};
+
+  /// 짧은 검색어가 전 역을 펼치면 목록·배지 빌드가 메인 스레드를 막는다.
+  static const _maxSearchResults = 40;
 
   final CatalogDatabase database;
   Future<List<_LocalStationSummary>>? _stationSummaryCache;
@@ -29,16 +33,44 @@ class DriftStationRepository
   }
 
   @override
+  Future<void> warmSearchCache() async {
+    final stations = await _listStationSummaries();
+    for (final station in stations) {
+      station.primeSearchTerms();
+    }
+  }
+
+  @override
   Future<List<StationSearchResult>> searchStations(String query) async {
     final trimmedQuery = query.trim();
     if (trimmedQuery.isEmpty) {
       return const [];
     }
 
+    final normalizedQuery = _normalize(trimmedQuery);
+    if (normalizedQuery.isEmpty) {
+      return const [];
+    }
+
     final stations = await _listStationSummaries();
-    return stations
-        .where((station) => station.matches(trimmedQuery))
-        .map((station) => station.toSearchResult())
+    final ranked = <({_LocalStationSummary station, int rank})>[];
+    for (final station in stations) {
+      final rank = station.matchRank(normalizedQuery);
+      if (rank == null) {
+        continue;
+      }
+      ranked.add((station: station, rank: rank));
+    }
+    ranked.sort((a, b) {
+      final byRank = a.rank.compareTo(b.rank);
+      if (byRank != 0) {
+        return byRank;
+      }
+      return a.station.nameKo.compareTo(b.station.nameKo);
+    });
+    return ranked
+        .take(_maxSearchResults)
+        .map((entry) => entry.station.toSearchResult())
         .toList(growable: false);
   }
 
@@ -756,27 +788,75 @@ class _LocalStationSummary {
   final List<String> aliases;
   final List<StationSearchLine> lines;
 
+  List<String>? _normalizedTermsCache;
+
+  /// 검색은 역 이름만 본다(한글명·영문명·부역명).
+  /// aliases에 섞인 역번호·호선 합성어("448", "4호선 상록수")는 쓰지 않는다.
+  List<String> get _normalizedTerms {
+    return _normalizedTermsCache ??= [
+      nameKo,
+      '$nameKo역',
+      nameEn,
+      if (nameSub.isNotEmpty) nameSub,
+    ].map(_normalize).where((term) => term.isNotEmpty).toList(growable: false);
+  }
+
+  void primeSearchTerms() {
+    _normalizedTerms;
+  }
+
   bool matches(String query) {
     final normalizedQuery = _normalize(query);
     if (normalizedQuery.isEmpty) {
       return false;
     }
+    return matchRank(normalizedQuery) != null;
+  }
 
-    final terms = <String>{
-      nameKo,
-      '$nameKo역',
-      nameEn,
-      if (nameSub.isNotEmpty) nameSub,
-      ...aliases,
-      ...lines.map((line) => line.stationCode),
-      ...lines.map((line) => '${_lineSearchName(line.name)}$nameKo'),
-    };
-
-    return terms
-        .map(_normalize)
-        .any(
-          (term) => term == normalizedQuery || term.contains(normalizedQuery),
-        );
+  /// 낮을수록 우선. 0=완전일치, 1=접두, 2=포함. 미매칭은 null.
+  /// 초성 질의(`ㅅ`, `ㅅㅂ`)는 역명 초성 접두/완전일치로 매칭한다.
+  int? matchRank(String normalizedQuery) {
+    var best = 3;
+    var matched = false;
+    for (final term in _normalizedTerms) {
+      if (term == normalizedQuery) {
+        return 0;
+      }
+      if (term.startsWith(normalizedQuery)) {
+        matched = true;
+        if (best > 1) {
+          best = 1;
+        }
+      } else if (term.contains(normalizedQuery)) {
+        matched = true;
+        if (best > 2) {
+          best = 2;
+        }
+      }
+    }
+    if (matched) {
+      return best;
+    }
+    final queryChosung = _chosungKey(normalizedQuery);
+    if (queryChosung.isEmpty || !_isHangulJamoOnly(normalizedQuery)) {
+      return null;
+    }
+    for (final term in _normalizedTerms) {
+      final termChosung = _chosungKey(term);
+      if (termChosung.isEmpty) {
+        continue;
+      }
+      if (termChosung == queryChosung) {
+        return 0;
+      }
+      if (termChosung.startsWith(queryChosung)) {
+        matched = true;
+        if (best > 1) {
+          best = 1;
+        }
+      }
+    }
+    return matched ? best : null;
   }
 
   StationSearchResult toSearchResult({int? distanceMeters}) {
@@ -795,8 +875,68 @@ class _LocalStationSummary {
   }
 }
 
+final _whitespacePattern = RegExp(r'\s+');
+
+/// 음절 초성 인덱스(0–18) → 호환 자모.
+const _hangulChoseongCompat = <String>[
+  'ㄱ',
+  'ㄲ',
+  'ㄴ',
+  'ㄷ',
+  'ㄸ',
+  'ㄹ',
+  'ㅁ',
+  'ㅂ',
+  'ㅃ',
+  'ㅅ',
+  'ㅆ',
+  'ㅇ',
+  'ㅈ',
+  'ㅉ',
+  'ㅊ',
+  'ㅋ',
+  'ㅌ',
+  'ㅍ',
+  'ㅎ',
+];
+
 String _normalize(String value) {
-  return value.toLowerCase().replaceAll(RegExp(r'\s+'), '').trim();
+  return value.toLowerCase().replaceAll(_whitespacePattern, '').trim();
+}
+
+bool _isHangulJamoRune(int rune) {
+  return (rune >= 0x3131 && rune <= 0x318E) ||
+      (rune >= 0x1100 && rune <= 0x11FF) ||
+      (rune >= 0xA960 && rune <= 0xA97F) ||
+      (rune >= 0xD7B0 && rune <= 0xD7FF);
+}
+
+bool _isHangulJamoOnly(String value) {
+  if (value.isEmpty) {
+    return false;
+  }
+  return value.runes.every(_isHangulJamoRune);
+}
+
+/// 음절·자모를 호환 초성 문자열로 펼친다. 영문 등은 건너뛴다.
+String _chosungKey(String value) {
+  final buffer = StringBuffer();
+  for (final rune in value.runes) {
+    if (rune >= 0xAC00 && rune <= 0xD7A3) {
+      buffer.write(_hangulChoseongCompat[(rune - 0xAC00) ~/ 588]);
+      continue;
+    }
+    // 호환 자모 초성만 유지(중·종성은 초성 질의에 쓰지 않음).
+    if (rune >= 0x3131 && rune <= 0x314E) {
+      buffer.write(String.fromCharCode(rune));
+      continue;
+    }
+    // 현대 초성 jamo (U+1100–U+1112)
+    if (rune >= 0x1100 && rune <= 0x1112) {
+      buffer.write(_hangulChoseongCompat[rune - 0x1100]);
+    }
+  }
+  return buffer.toString();
 }
 
 String _lineSearchName(String lineName) {

--- a/apps/mobile/lib/features/stations/data/drift_station_repository.dart
+++ b/apps/mobile/lib/features/stations/data/drift_station_repository.dart
@@ -44,6 +44,16 @@ class DriftStationRepository
   Future<List<StationSearchResult>> searchStations(
     String query, {
     String? region,
+  }) {
+    return _rankSearchStations(query, region: region);
+  }
+
+  /// [region]/[lineId]는 상한 적용 전에 거른다. 완전일치(rank 0)는 상한에
+  /// 잘리지 않게 해 동명·정확 질의 누락을 막는다.
+  Future<List<StationSearchResult>> _rankSearchStations(
+    String query, {
+    String? region,
+    String? lineId,
   }) async {
     final trimmedQuery = query.trim();
     if (trimmedQuery.isEmpty) {
@@ -55,12 +65,17 @@ class DriftStationRepository
       return const [];
     }
     final regionFilter = region?.trim() ?? '';
+    final lineFilter = lineId?.trim() ?? '';
 
     final stations = await _listStationSummaries();
     final ranked = <({_LocalStationSummary station, int rank})>[];
     for (final station in stations) {
       if (regionFilter.isNotEmpty &&
           !stationBelongsToRegion(station.region, regionFilter)) {
+        continue;
+      }
+      if (lineFilter.isNotEmpty &&
+          !station.lines.any((line) => line.id == lineFilter)) {
         continue;
       }
       final rank = station.matchRank(normalizedQuery);
@@ -76,8 +91,10 @@ class DriftStationRepository
       }
       return a.station.nameKo.compareTo(b.station.nameKo);
     });
+    final exactCount = ranked.where((entry) => entry.rank == 0).length;
+    final limit = math.max(_maxSearchResults, exactCount);
     return ranked
-        .take(_maxSearchResults)
+        .take(limit)
         .map((entry) => entry.station.toSearchResult())
         .toList(growable: false);
   }
@@ -182,14 +199,10 @@ class DriftStationRepository
   @override
   Future<List<StationSearchResult>> searchStationsOnLine(
     String query,
-    String lineId,
-  ) async {
-    final trimmedLineId = lineId.trim();
-    return (await searchStations(query))
-        .where(
-          (station) => station.lines.any((line) => line.id == trimmedLineId),
-        )
-        .toList(growable: false);
+    String lineId, {
+    String? region,
+  }) {
+    return _rankSearchStations(query, region: region, lineId: lineId);
   }
 
   @override

--- a/apps/mobile/lib/features/stations/data/station_api_repository.dart
+++ b/apps/mobile/lib/features/stations/data/station_api_repository.dart
@@ -37,9 +37,14 @@ class StationSearchApiRepository
   @override
   Future<List<StationSearchResult>> searchStationsOnLine(
     String query,
-    String lineId,
-  ) {
-    return _searchStations({'query': query, 'lineId': lineId});
+    String lineId, {
+    String? region,
+  }) {
+    return _searchStations({
+      'query': query,
+      'lineId': lineId,
+      if (region != null && region.trim().isNotEmpty) 'region': region.trim(),
+    });
   }
 
   Future<List<StationSearchResult>> _searchStations(

--- a/apps/mobile/lib/features/stations/data/station_api_repository.dart
+++ b/apps/mobile/lib/features/stations/data/station_api_repository.dart
@@ -24,8 +24,14 @@ class StationSearchApiRepository
   final ApiClient _apiClient;
 
   @override
-  Future<List<StationSearchResult>> searchStations(String query) async {
-    return _searchStations({'query': query});
+  Future<List<StationSearchResult>> searchStations(
+    String query, {
+    String? region,
+  }) async {
+    return _searchStations({
+      'query': query,
+      if (region != null && region.trim().isNotEmpty) 'region': region.trim(),
+    });
   }
 
   @override

--- a/apps/mobile/lib/features/stations/domain/station_repositories.dart
+++ b/apps/mobile/lib/features/stations/domain/station_repositories.dart
@@ -209,8 +209,9 @@ abstract class StationLineFilterRepository {
 
   Future<List<StationSearchResult>> searchStationsOnLine(
     String query,
-    String lineId,
-  );
+    String lineId, {
+    String? region,
+  });
 }
 
 abstract class StationTimetableRepository {

--- a/apps/mobile/lib/features/stations/domain/station_repositories.dart
+++ b/apps/mobile/lib/features/stations/domain/station_repositories.dart
@@ -2,7 +2,12 @@ import 'station_line.dart';
 import 'station_models.dart';
 
 abstract class StationSearchRepository {
-  Future<List<StationSearchResult>> searchStations(String query);
+  /// [region]이 있으면 해당 지역 역만 상한(_maxSearchResults 등) 적용 대상에 넣는다.
+  /// 짧은 초성 질의에서 타 지역이 상한을 채우며 현재 지역이 비는 것을 막는다.
+  Future<List<StationSearchResult>> searchStations(
+    String query, {
+    String? region,
+  });
 
   Future<List<StationSearchResult>> searchNearbyStations(
     CurrentLocation location, {

--- a/apps/mobile/lib/features/stations/domain/station_repositories.dart
+++ b/apps/mobile/lib/features/stations/domain/station_repositories.dart
@@ -1,3 +1,4 @@
+import 'station_line.dart';
 import 'station_models.dart';
 
 abstract class StationSearchRepository {
@@ -16,6 +17,24 @@ abstract class StationSearchRepository {
   Future<List<StationFacilityInfo>> listStationFacilities(String stationId);
 }
 
+/// 로컬 카탈로그 검색 인덱스를 미리 올리는 선택 계약.
+/// 첫 글자 입력 전에 SQLite·정규화 비용을 걷긴다.
+abstract interface class StationSearchCache {
+  Future<void> warmSearchCache();
+}
+
+Future<void> warmStationSearchCacheIfSupported(
+  StationSearchRepository repository,
+) {
+  final cache = repository is StationSearchCache
+      ? repository as StationSearchCache
+      : null;
+  if (cache == null) {
+    return Future<void>.value();
+  }
+  return cache.warmSearchCache();
+}
+
 /// 최근 검색 목록의 한 항목. 역 검색과 경로 검색을 같은 시간순 목록에 섞기
 /// 위한 공통 타입이다.
 sealed class RecentSearchEntry {
@@ -26,23 +45,38 @@ sealed class RecentSearchEntry {
 
 /// 역 검색 한 건. [region]은 검색 당시 선택 지역이며, 지역 정보 없이 저장된
 /// 레거시 항목은 null이다(지역 필터 목록에서 제외).
+///
+/// [lines]는 표시용 호선 마크. 저장소에는 없고 조회 직후 카탈로그로 채운다.
 class RecentStationSearchEntry extends RecentSearchEntry {
   const RecentStationSearchEntry({
     required this.query,
     required this.region,
     required this.searchedAt,
+    this.lines = const [],
   });
 
   final String query;
   final String? region;
+  final List<StationSearchLine> lines;
 
   @override
   final DateTime searchedAt;
+
+  RecentStationSearchEntry withLines(List<StationSearchLine> lines) {
+    return RecentStationSearchEntry(
+      query: query,
+      region: region,
+      searchedAt: searchedAt,
+      lines: lines,
+    );
+  }
 }
 
 /// 경로 검색 한 건. [displayLabel]은 `출발역 → 도착역` 또는
 /// `출발역 → 경유역 → 도착역` 형태이며, 역 접미사 보정은 검색 결과 화면과
 /// 같은 규칙(끝이 `역`이 아니면 붙임)을 쓴다.
+///
+/// `*Lines`는 표시용 호선 마크. 저장소에는 없고 조회 직후 카탈로그로 채운다.
 class RecentRouteSearchEntry extends RecentSearchEntry {
   const RecentRouteSearchEntry({
     required this.originStationId,
@@ -53,6 +87,9 @@ class RecentRouteSearchEntry extends RecentSearchEntry {
     required this.destinationStationName,
     required this.region,
     required this.searchedAt,
+    this.originLines = const [],
+    this.waypointLines = const [],
+    this.destinationLines = const [],
   });
 
   final String originStationId;
@@ -62,9 +99,32 @@ class RecentRouteSearchEntry extends RecentSearchEntry {
   final String destinationStationId;
   final String destinationStationName;
   final String region;
+  final List<StationSearchLine> originLines;
+  final List<StationSearchLine> waypointLines;
+  final List<StationSearchLine> destinationLines;
 
   @override
   final DateTime searchedAt;
+
+  RecentRouteSearchEntry withLines({
+    List<StationSearchLine> originLines = const [],
+    List<StationSearchLine> waypointLines = const [],
+    List<StationSearchLine> destinationLines = const [],
+  }) {
+    return RecentRouteSearchEntry(
+      originStationId: originStationId,
+      originStationName: originStationName,
+      waypointStationId: waypointStationId,
+      waypointStationName: waypointStationName,
+      destinationStationId: destinationStationId,
+      destinationStationName: destinationStationName,
+      region: region,
+      searchedAt: searchedAt,
+      originLines: originLines,
+      waypointLines: waypointLines,
+      destinationLines: destinationLines,
+    );
+  }
 
   String get displayLabel {
     final origin = _withStationSuffix(originStationName);
@@ -92,7 +152,15 @@ String _withStationSuffix(String name) {
 abstract class SearchHistoryRepository {
   /// 역 검색을 기록한다. [region]은 검색 당시 선택 지역(예: `수도권`, `부산`)이며,
   /// 지역별 최근 목록 필터에 쓴다.
-  Future<void> recordSearch(String query, {String? region});
+  ///
+  /// 결과에서 고른 호선이 있으면 [stationId]/[line]을 함께 넘겨 최근 목록에
+  /// 그 호선 마크만 보이게 한다. 검색어만 기록할 때는 호선 필드를 비운다.
+  Future<void> recordSearch(
+    String query, {
+    String? region,
+    String? stationId,
+    StationSearchLine? line,
+  });
 
   /// 경로 검색을 기록한다.
   Future<void> recordRouteSearch(RecentRouteSearchEntry entry) async {}

--- a/apps/mobile/lib/features/stations/presentation/station_line_badges.dart
+++ b/apps/mobile/lib/features/stations/presentation/station_line_badges.dart
@@ -51,12 +51,15 @@ class StationLineBadge extends StatelessWidget {
   Widget build(BuildContext context) {
     final assetPath = line.badgeAssetPath;
     if (assetPath != null) {
+      final cachePx = (size * MediaQuery.devicePixelRatioOf(context)).round();
       final image = Image.asset(
         assetPath,
         width: size,
         height: size,
         fit: BoxFit.contain,
-        filterQuality: FilterQuality.high,
+        filterQuality: FilterQuality.medium,
+        cacheWidth: cachePx,
+        cacheHeight: cachePx,
       );
       return SizedBox(
         key: Key('stationLineBadge-${line.id}'),

--- a/apps/mobile/lib/features/stations/presentation/station_recent_search_section.dart
+++ b/apps/mobile/lib/features/stations/presentation/station_recent_search_section.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 
 import '../../../accessible_design.dart';
 import '../../../design_tokens.dart';
+import '../domain/station_line.dart';
 import '../domain/station_repositories.dart';
+import 'station_line_badges.dart';
 
 /// 최근 검색 모두 지우기 확인 다이얼로그. `true`면 지우기.
 Future<bool?> confirmClearRecentSearches(BuildContext context) {
@@ -105,7 +107,7 @@ class _RecentSearchHeader extends StatelessWidget {
     // 없었다. InkWell + Semantics(button)로 복원하고, baseline 대신 center로
     // 정렬한다(48px 터치 영역이 텍스트보다 커서 baseline이 어긋난다).
     return Padding(
-      padding: const EdgeInsets.only(bottom: EasySubwaySpacing.sm),
+      padding: const EdgeInsets.only(bottom: EasySubwaySpacing.xs),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
@@ -213,29 +215,33 @@ class _RecentSearchItem extends StatelessWidget {
   final ValueChanged<RecentRouteSearchEntry> onRouteSelected;
   final ValueChanged<RecentSearchEntry> onRemove;
 
+  static const _badgeSize = 26.0;
+
   @override
   Widget build(BuildContext context) {
     final entry = this.entry;
-    // 역 검색은 지하철역, 경로 검색은 경로(갈래) 아이콘으로 구분한다.
+    final titleStyle = Theme.of(context).textTheme.titleMedium?.copyWith(
+      color: EasySubwayAccessibleColors.text,
+      fontWeight: FontWeight.w700,
+      height: 1.25,
+    );
     final (
-      label,
-      icon,
       itemKey,
       removeKey,
       removeTooltip,
       semanticsLabel,
+      leading,
+      title,
     ) = switch (entry) {
       RecentStationSearchEntry() => (
-        entry.query,
-        Icons.train_outlined,
         Key('stationRecentSearchQuery-${entry.query}'),
         Key('stationRecentSearchRemove-${entry.query}'),
         '${entry.query} 최근 검색 삭제',
         '최근 검색어 ${entry.query} 검색',
+        _stationLeading(entry.lines),
+        Text(entry.query, style: titleStyle),
       ),
       RecentRouteSearchEntry() => (
-        entry.displayLabel,
-        Icons.alt_route,
         Key(
           'recentRouteSearch-${entry.originStationId}-'
           '${entry.waypointStationId ?? ''}-${entry.destinationStationId}',
@@ -246,6 +252,8 @@ class _RecentSearchItem extends StatelessWidget {
         ),
         '${entry.displayLabel} 최근 경로 삭제',
         '최근 경로 ${entry.displayLabel} 다시 찾기',
+        null,
+        _RouteStationsLabel(entry: entry, textStyle: titleStyle),
       ),
     };
 
@@ -259,7 +267,7 @@ class _RecentSearchItem extends StatelessWidget {
     }
 
     return ConstrainedBox(
-      constraints: const BoxConstraints(minHeight: 56),
+      constraints: const BoxConstraints(minHeight: 48),
       child: Row(
         children: [
           Expanded(
@@ -274,23 +282,15 @@ class _RecentSearchItem extends StatelessWidget {
                   onTap: enabled ? onTap : null,
                   child: Padding(
                     padding: const EdgeInsets.symmetric(
-                      vertical: EasySubwaySpacing.md,
+                      vertical: EasySubwaySpacing.xs,
                     ),
                     child: Row(
                       children: [
-                        Icon(icon, color: EasySubwayAccessibleColors.iconMuted),
-                        const SizedBox(width: EasySubwaySpacing.md),
-                        Expanded(
-                          child: Text(
-                            label,
-                            style: Theme.of(context).textTheme.titleMedium
-                                ?.copyWith(
-                                  color: EasySubwayAccessibleColors.text,
-                                  fontWeight: FontWeight.w700,
-                                  height: 1.25,
-                                ),
-                          ),
-                        ),
+                        if (leading != null) ...[
+                          leading,
+                          const SizedBox(width: EasySubwaySpacing.sm),
+                        ],
+                        Expanded(child: title),
                       ],
                     ),
                   ),
@@ -308,4 +308,77 @@ class _RecentSearchItem extends StatelessWidget {
       ),
     );
   }
+
+  static Widget _stationLeading(List<StationSearchLine> lines) {
+    if (lines.isEmpty) {
+      return const Icon(
+        Icons.train_outlined,
+        color: EasySubwayAccessibleColors.iconMuted,
+      );
+    }
+    return StationLineBadges(lines: lines, size: _badgeSize, maxBadgeCount: 3);
+  }
+}
+
+class _RouteStationsLabel extends StatelessWidget {
+  const _RouteStationsLabel({required this.entry, required this.textStyle});
+
+  final RecentRouteSearchEntry entry;
+  final TextStyle? textStyle;
+
+  static const _badgeSize = 26.0;
+  static const _arrowStyle = TextStyle(
+    color: EasySubwayAccessibleColors.mutedText,
+    fontSize: 15,
+    fontWeight: FontWeight.w600,
+    height: 1.25,
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    final waypointName = entry.waypointStationName?.trim();
+    final hasWaypoint = waypointName != null && waypointName.isNotEmpty;
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: Row(
+        children: [
+          _station(entry.originStationName, entry.originLines),
+          const Padding(
+            padding: EdgeInsets.symmetric(horizontal: 4),
+            child: Text('→', style: _arrowStyle),
+          ),
+          if (hasWaypoint) ...[
+            _station(waypointName, entry.waypointLines),
+            const Padding(
+              padding: EdgeInsets.symmetric(horizontal: 4),
+              child: Text('→', style: _arrowStyle),
+            ),
+          ],
+          _station(entry.destinationStationName, entry.destinationLines),
+        ],
+      ),
+    );
+  }
+
+  Widget _station(String name, List<StationSearchLine> lines) {
+    final label = _withStationSuffix(name);
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (lines.isNotEmpty) ...[
+          StationLineBadges(lines: lines, size: _badgeSize, maxBadgeCount: 2),
+          const SizedBox(width: 6),
+        ],
+        Text(label, style: textStyle),
+      ],
+    );
+  }
+}
+
+String _withStationSuffix(String name) {
+  final trimmed = name.trim();
+  if (trimmed.isEmpty || trimmed.endsWith('역')) {
+    return trimmed;
+  }
+  return '$trimmed역';
 }

--- a/apps/mobile/lib/features/stations/presentation/station_search_body.dart
+++ b/apps/mobile/lib/features/stations/presentation/station_search_body.dart
@@ -41,6 +41,9 @@ class StationSearchBody extends StatelessWidget {
   Widget build(BuildContext context) {
     return switch (state.status) {
       StationSearchStatus.idle => const SizedBox.shrink(),
+      // 재검색 중에도 이전 결과가 있으면 목록을 유지한다(스피너 깜빡임 방지).
+      StationSearchStatus.loading when state.results.isNotEmpty =>
+        _buildResults(announceCount: false),
       StationSearchStatus.loading => Semantics(
         label: '역 검색 중',
         liveRegion: true,
@@ -60,43 +63,54 @@ class StationSearchBody extends StatelessWidget {
         message: state.message,
         liveRegion: true,
       ),
-      StationSearchStatus.success => Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
+      StationSearchStatus.success => _buildResults(announceCount: true),
+    };
+  }
+
+  Widget _buildResults({required bool announceCount}) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (announceCount)
           Semantics(
             container: true,
             label: '검색 결과 ${state.results.length}개',
             liveRegion: true,
             child: const SizedBox(width: 1, height: 1),
           ),
-          for (final row in _sortedResultRows(state.results, favoriteKeys))
-            _StationSearchResultLineRow(
-              key: Key(
-                'stationSearchResult-${row.result.id}-${row.line?.id ?? 'none'}',
-              ),
-              stationName: _stationResultDisplayName(row.result.nameKo),
-              query: query,
-              line: row.line,
-              showFavorite: onToggleFavorite != null,
-              isFavorite: isFavoriteStationLine(
-                favoriteKeys,
-                row.result.id,
-                row.line?.id,
-              ),
-              semanticLabel: row.line == null
-                  ? '${_stationResultDisplayName(row.result.nameKo)}, 선택'
-                  : '${_stationResultDisplayName(row.result.nameKo)}, ${row.line!.name}, 선택',
-              onTap: () => onResultTap(row.result, row.line),
-              onToggleFavorite: onToggleFavorite == null
-                  ? null
-                  : () => onToggleFavorite!(row.result, row.line),
-              favoriteButtonKey: Key(
-                'stationSearchFavorite-${row.result.id}-${row.line?.id ?? 'none'}',
-              ),
+        if (!announceCount)
+          Semantics(
+            label: '역 검색 중',
+            liveRegion: true,
+            child: const SizedBox(width: 1, height: 1),
+          ),
+        for (final row in _sortedResultRows(state.results, favoriteKeys))
+          _StationSearchResultLineRow(
+            key: Key(
+              'stationSearchResult-${row.result.id}-${row.line?.id ?? 'none'}',
             ),
-        ],
-      ),
-    };
+            stationName: _stationResultDisplayName(row.result.nameKo),
+            query: query,
+            line: row.line,
+            showFavorite: onToggleFavorite != null,
+            isFavorite: isFavoriteStationLine(
+              favoriteKeys,
+              row.result.id,
+              row.line?.id,
+            ),
+            semanticLabel: row.line == null
+                ? '${_stationResultDisplayName(row.result.nameKo)}, 선택'
+                : '${_stationResultDisplayName(row.result.nameKo)}, ${row.line!.name}, 선택',
+            onTap: () => onResultTap(row.result, row.line),
+            onToggleFavorite: onToggleFavorite == null
+                ? null
+                : () => onToggleFavorite!(row.result, row.line),
+            favoriteButtonKey: Key(
+              'stationSearchFavorite-${row.result.id}-${row.line?.id ?? 'none'}',
+            ),
+          ),
+      ],
+    );
   }
 }
 

--- a/apps/mobile/lib/features/stations/presentation/station_search_screen.dart
+++ b/apps/mobile/lib/features/stations/presentation/station_search_screen.dart
@@ -529,15 +529,17 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
     }
     controller.clear();
     controller.setOrigin(
-      RouteDraftStation(
+      _routeDraftStationFromRecent(
         id: entry.originStationId,
         nameKo: entry.originStationName,
+        lines: entry.originLines,
       ),
     );
     controller.setDestination(
-      RouteDraftStation(
+      _routeDraftStationFromRecent(
         id: entry.destinationStationId,
         nameKo: entry.destinationStationName,
+        lines: entry.destinationLines,
       ),
     );
     final waypointId = entry.waypointStationId;
@@ -547,7 +549,11 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
         waypointName != null &&
         waypointName.isNotEmpty) {
       controller.setWaypoint(
-        RouteDraftStation(id: waypointId, nameKo: waypointName),
+        _routeDraftStationFromRecent(
+          id: waypointId,
+          nameKo: waypointName,
+          lines: entry.waypointLines,
+        ),
       );
     }
     Navigator.of(context).maybePop();
@@ -649,9 +655,12 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
       return;
     }
     final selected = line ?? result.lines.firstOrNull;
+    // 명시 검색과 같은 query 키를 써야 최근 목록이 중복되지 않는다.
+    final typedQuery = _queryController.text.trim();
+    final historyQuery = typedQuery.isNotEmpty ? typedQuery : result.nameKo;
     try {
       await repository.recordSearch(
-        result.nameKo,
+        historyQuery,
         region: _regionLabel,
         stationId: result.id,
         line: selected,
@@ -715,6 +724,22 @@ RouteDraftStation _routeDraftStationFromSearch(
   return RouteDraftStation(
     id: result.id,
     nameKo: result.nameKo,
+    lineId: resolved?.id ?? '',
+    lineName: resolved?.name ?? '',
+    lineColor: resolved?.color ?? '',
+    stationCode: resolved?.stationCode ?? '',
+  );
+}
+
+RouteDraftStation _routeDraftStationFromRecent({
+  required String id,
+  required String nameKo,
+  required List<StationSearchLine> lines,
+}) {
+  final resolved = lines.firstOrNull;
+  return RouteDraftStation(
+    id: id,
+    nameKo: nameKo,
     lineId: resolved?.id ?? '',
     lineName: resolved?.name ?? '',
     lineColor: resolved?.color ?? '',

--- a/apps/mobile/lib/features/stations/presentation/station_search_screen.dart
+++ b/apps/mobile/lib/features/stations/presentation/station_search_screen.dart
@@ -18,12 +18,13 @@ import '../application/station_search_controller.dart';
 import '../domain/station_line.dart';
 import '../domain/station_models.dart';
 import '../domain/station_repositories.dart';
+import 'station_detail_screen.dart';
 import 'station_recent_search_section.dart';
 import 'station_search_body.dart';
 
 const _searchHistoryChangeErrorMessage = '최근 검색을 지우지 못했어요.';
-const _stationSearchPagePadding = EdgeInsets.fromLTRB(20, 20, 20, 32);
-const _stationSearchLargePagePadding = EdgeInsets.fromLTRB(24, 24, 24, 40);
+const _stationSearchPagePadding = EdgeInsets.fromLTRB(20, 8, 20, 20);
+const _stationSearchLargePagePadding = EdgeInsets.fromLTRB(24, 12, 24, 24);
 
 /// 홈 노선도 지역 메뉴와 같은 기본 목록. 호출부가 regions를 안 넘기면 쓴다.
 /// 호출부(홈)가 맵에만 있는 지역을 이 기본 목록에 병합할 때도 재사용한다
@@ -94,9 +95,16 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
   final TextEditingController _queryController = TextEditingController();
   final FocusNode _searchFocusNode = FocusNode();
   List<RecentSearchEntry> _recentEntries = const [];
+  bool _recentEntriesReady = false;
   Set<String> _favoriteKeys = const <String>{};
   Timer? _searchDebounce;
   late String _regionLabel;
+
+  /// 최근 검색 ↔ 결과 레이아웃(패딩) 전환 추적. 글자마다 Scaffold setState 방지.
+  bool _layoutHasSearchQuery = false;
+
+  /// 하이라이트용. 검색 완료 시점의 질의만 반영해 타이핑 재빌드를 막는다.
+  String _highlightQuery = '';
 
   @override
   void initState() {
@@ -110,6 +118,7 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
     _queryController.addListener(_handleQueryChanged);
     unawaited(_loadRecentEntries());
     unawaited(_loadFavoriteStationIds());
+    unawaited(warmStationSearchCacheIfSupported(widget.repository));
     // 검색 진입은 화면을 여는 즉시 입력 모드로 들어간다. autofocus가 담당한다.
   }
 
@@ -150,18 +159,30 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
     }
     _searchDebounce?.cancel();
     if (!_hasSearchQuery) {
+      _highlightQuery = '';
       if (_controller.state.status != StationSearchStatus.idle) {
         _controller.search('');
       }
     } else {
-      // 타이핑 즉시(디바운스) 검색으로 통일한다. 부분 입력은 최근 검색에 기록하지 않는다.
+      // 부분 입력·초성(ㅅ)도 검색한다. 첫 글자는 즉시, 이후는 짧게 디바운스.
       final query = _queryController.text;
-      _searchDebounce = Timer(
-        const Duration(milliseconds: 300),
-        () => unawaited(_runSearch(query, recordHistory: false)),
-      );
+      if (!_layoutHasSearchQuery) {
+        unawaited(_runSearch(query, recordHistory: false));
+      } else {
+        _searchDebounce = Timer(
+          const Duration(milliseconds: 180),
+          () => unawaited(_runSearch(query, recordHistory: false)),
+        );
+      }
     }
-    setState(() {});
+    // 최근 검색 ↔ 결과 패딩 전환일 때만 전체 Scaffold를 다시 그린다.
+    // 글자마다 setState하면 상단바까지 매 키입력마다 재빌드된다.
+    final hasQuery = _hasSearchQuery;
+    if (_layoutHasSearchQuery != hasQuery) {
+      setState(() {
+        _layoutHasSearchQuery = hasQuery;
+      });
+    }
   }
 
   bool get _hasSearchQuery => _queryController.text.trim().isNotEmpty;
@@ -182,7 +203,7 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
     // #2083 홈 편집 모드와 동일한 공용 검색 필드를 쓴다. pickSlot별 힌트는
     // hintText로 전달돼 placeholder이자 TalkBack 라벨 역할을 유지하고, 즉시
     // (디바운스) 검색은 _queryController를, 지우기는 onClear를 통해 보존된다.
-    // AppBar leading(자동 뒤로가기)은 title 왼쪽에 그대로 남아 "← + 46px 필드"
+    // AppBar leading(자동 뒤로가기)은 title 왼쪽에 그대로 남아 "← + 40px 필드"
     // 구성이 홈 편집 모드와 일치한다.
     final searchInputField = EasySubwaySearchField(
       controller: _queryController,
@@ -212,19 +233,16 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
       builder: (context, _) {
         final isSearching =
             _controller.state.status == StationSearchStatus.loading;
-        if (_hasSearchQuery) {
+        if (_hasSearchQuery || !_recentEntriesReady) {
           return const SizedBox.shrink();
         }
-        return Padding(
-          padding: const EdgeInsets.only(bottom: 12),
-          child: StationRecentSearchSection(
-            entries: _recentEntries,
-            enabled: !isSearching,
-            onStationSelected: _searchRecentEntry,
-            onRouteSelected: _selectRecentRoute,
-            onRemove: (entry) => unawaited(_removeRecentEntry(entry)),
-            onClearAll: () => unawaited(_clearAllRecentEntries()),
-          ),
+        return StationRecentSearchSection(
+          entries: _recentEntries,
+          enabled: !isSearching,
+          onStationSelected: _searchRecentEntry,
+          onRouteSelected: _selectRecentRoute,
+          onRemove: (entry) => unawaited(_removeRecentEntry(entry)),
+          onClearAll: () => unawaited(_clearAllRecentEntries()),
         );
       },
     );
@@ -234,12 +252,12 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
       builder: (context, _) {
         return StationSearchBody(
           state: _controller.state,
-          query: _queryController.text,
+          query: _highlightQuery,
           favoriteKeys: _favoriteKeys,
           // 칸 채우기 모드에서는 결과 한 번 탭 = 해당 칸 설정 후 닫기. 지도 탭과 동일
           // 하게 "출발역 선택 → 도착역 선택" UX로 수렴시킨다. 둘러보기 모드에서는
           // 선택한 역을 지도로 반환한다.
-          onResultTap: isPicking ? _pickStation : _returnStationToMap,
+          onResultTap: isPicking ? _pickStation : _openStationDetail,
           onToggleFavorite: widget.favoriteRepository == null
               ? null
               : _toggleFavoriteStation,
@@ -434,14 +452,13 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
 
   void _submit(String query) {
     // 키보드 검색 액션 등 명시적 검색: 디바운스를 취소하고 최근 검색에 기록한다.
+    // 진행 중 검색은 requestId로 무효화되므로 loading이어도 제출을 막지 않는다.
     _searchDebounce?.cancel();
-    if (_controller.state.status == StationSearchStatus.loading) {
-      return;
-    }
     unawaited(_runSearch(query));
   }
 
   Future<void> _runSearch(String query, {bool recordHistory = true}) async {
+    _highlightQuery = query.trim();
     await _controller.search(
       query,
       region: _regionLabel,
@@ -599,6 +616,11 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
   Future<void> _loadRecentEntries() async {
     final repository = widget.searchHistoryRepository;
     if (repository == null) {
+      if (mounted) {
+        setState(() => _recentEntriesReady = true);
+      } else {
+        _recentEntriesReady = true;
+      }
       return;
     }
     try {
@@ -606,9 +628,36 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
       if (!mounted) {
         return;
       }
-      setState(() => _recentEntries = entries);
+      setState(() {
+        _recentEntries = entries;
+        _recentEntriesReady = true;
+      });
     } catch (error, stackTrace) {
       reportMobileError(error, stackTrace, context: '최근 검색 조회 중 예외가 발생했습니다.');
+      if (mounted) {
+        setState(() => _recentEntriesReady = true);
+      }
+    }
+  }
+
+  Future<void> _recordSelectedStation(
+    StationSearchResult result,
+    StationSearchLine? line,
+  ) async {
+    final repository = widget.searchHistoryRepository;
+    if (repository == null) {
+      return;
+    }
+    final selected = line ?? result.lines.firstOrNull;
+    try {
+      await repository.recordSearch(
+        result.nameKo,
+        region: _regionLabel,
+        stationId: result.id,
+        line: selected,
+      );
+    } catch (error, stackTrace) {
+      reportMobileError(error, stackTrace, context: '최근 검색 저장 중 예외가 발생했습니다.');
     }
   }
 
@@ -621,6 +670,7 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
     if (slot == null) {
       return;
     }
+    unawaited(_recordSelectedStation(result, line));
     final station = _routeDraftStationFromSearch(result, line);
     switch (slot) {
       case RouteDraftSlot.origin:
@@ -633,12 +683,27 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
     Navigator.of(context).pop(station);
   }
 
-  /// #2109 둘러보기(비픽) 모드: 결과를 탭하면 상세를 밀지 않고 선택한 역 결과를
-  /// 반환하며 화면을 닫는다. 호출부(main.dart openStationSearch)가 이 결과를
-  /// 받아 노선도 focus + 팬 메뉴 + 해당 역 하단 패널을 트리거한다(임베디드
-  /// 검색과 동일한 흐름으로 수렴).
-  void _returnStationToMap(StationSearchResult result, StationSearchLine? _) {
-    Navigator.of(context).pop(result);
+  /// 메뉴·풀페이지 둘러보기: 결과 탭 → 상세를 검색 위에 push.
+  /// 뒤로가면 검색 목록(검색어)이 그대로 남는다. 홈 in-place 검색의 부채 흐름과
+  /// 분리한다.
+  void _openStationDetail(StationSearchResult result, StationSearchLine? line) {
+    unawaited(_recordSelectedStation(result, line));
+    Navigator.of(context).push<void>(
+      MaterialPageRoute<void>(
+        builder: (_) => StationDetailScreen(
+          repository: widget.repository,
+          reportRepository: widget.reportRepository,
+          favoriteRepository: widget.favoriteRepository,
+          adRepository: widget.adRepository,
+          realtimeRepository: widget.realtimeRepository,
+          stationId: result.id,
+          facilityReportDraftTargetStore: widget.facilityReportDraftTargetStore,
+          internalRouteRepository: widget.internalRouteRepository,
+          internalRouteMobilityType: widget.internalRouteMobilityType,
+          routeDraftController: widget.routeDraftController,
+        ),
+      ),
+    );
   }
 }
 

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -36,6 +36,7 @@ import 'features/realtime/realtime_repository.dart';
 import 'features/route_draft/application/route_draft_controller.dart';
 import 'features/route_draft/domain/route_draft.dart';
 import 'features/stations/presentation/service_pattern_badge.dart';
+import 'features/stations/presentation/station_detail_screen.dart';
 import 'features/stations/presentation/station_line_badges.dart';
 import 'internal_route.dart';
 import 'mobile_error_reporter.dart';
@@ -536,6 +537,12 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
   _NearbyPanelDataSource _nearbyDataSource = _NearbyPanelDataSource.realtime;
   StationTimetable? _nearbyTimetable;
   bool _nearbyTimetableLoading = false;
+
+  /// 패널을 열 때만 실시간→시간표 자동 전환. 사용자가 실시간 탭을 다시 고르면 끈다.
+  bool _nearbyAllowRealtimeAutoFallback = true;
+
+  /// 하단 패널 실시간은 API 기본 8초보다 짧게 끊고 시간표로 넘긴다.
+  static const _nearbyRealtimeTimeout = Duration(seconds: 2);
   late Future<_NetworkMapLoadResult> _future = _loadMap();
 
   /// 지도 탭 → draft 슬롯 지정 시 역의 [NetworkMapStation.lineId]로 노선
@@ -629,12 +636,15 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
   }
 
   void _enterSearchMode() {
-    if (widget.stationSearchRepository == null) {
+    final repository = widget.stationSearchRepository;
+    if (repository == null) {
       return;
     }
     if (!widget.routeDraftController.draft.isEmpty) {
       return;
     }
+    // 첫 글자 전에 카탈로그 인덱스를 올려 입력 체감 지연을 줄인다.
+    unawaited(warmStationSearchCacheIfSupported(repository));
     setState(() => _searchMode = true);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted && _searchMode) {
@@ -659,6 +669,8 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
     StationSearchResult result,
     StationSearchLine? line,
   ) {
+    // 결과에서 고른 호선만 최근 검색에 남긴다(환승역 전 호선 마크 방지).
+    unawaited(_recordSelectedStationSearch(result, line));
     // _exitSearchMode 가 이미 setState 로 검색을 닫으므로, 선택 역 상태는 그 뒤
     // 별도 setState 로 세팅해 검색 종료에 덮이지 않도록 한다.
     _exitSearchMode();
@@ -666,6 +678,27 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
       return;
     }
     _showStationPanelFromSearch(result, preferredLine: line);
+  }
+
+  Future<void> _recordSelectedStationSearch(
+    StationSearchResult result,
+    StationSearchLine? line,
+  ) async {
+    final repository = widget.searchHistoryRepository;
+    if (repository == null) {
+      return;
+    }
+    final selected = line ?? result.lines.firstOrNull;
+    try {
+      await repository.recordSearch(
+        result.nameKo,
+        region: _displayRegionName(_selectedRegion ?? result.region),
+        stationId: result.id,
+        line: selected,
+      );
+    } catch (error, stackTrace) {
+      reportMobileError(error, stackTrace, context: '최근 검색 저장 중 예외가 발생했습니다.');
+    }
   }
 
   void _showStationPanelFromSearch(
@@ -676,7 +709,6 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
     setState(() {
       _nearestStationRequestToken++;
       _selectionClearRevision++;
-      _nearbyDataRequestToken++;
       _nearbyPanelVisible = true;
       _nearbySelectedStationId = result.id;
       _nearbySelectedLineId = selectedLine?.id;
@@ -684,13 +716,15 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
       _nearbyRealtime = selectedLine == null
           ? const RealtimeSnapshot(status: RealtimeSnapshotStatus.unsupported)
           : const RealtimeSnapshot.loading();
-      _nearbyDataSource = _NearbyPanelDataSource.realtime;
+      // 로컬 시간표를 먼저 보여 탭 즉시 내용이 뜨게 한다. 실시간은 백그라운드 로드.
+      _nearbyDataSource = _NearbyPanelDataSource.timetable;
       _nearbyTimetable = null;
-      _nearbyTimetableLoading = false;
+      _nearbyTimetableLoading = selectedLine != null;
+      _nearbyAllowRealtimeAutoFallback = true;
       _searchFanMenuStationId = result.id;
     });
     if (selectedLine != null) {
-      unawaited(_loadNearbyRealtime(result, selectedLine));
+      _startNearbyPanelDataLoads(result, selectedLine);
     }
   }
 
@@ -877,6 +911,7 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
                 onCloseNearbyPanel: _hideNearbyPanel,
                 onNearbyLineSelected: _selectNearbyLine,
                 onNearbyDataSourceToggle: _toggleNearbyDataSource,
+                onOpenNearbyStationDetail: _openNearbyStationDetail,
                 routeDraftController: widget.routeDraftController,
                 onClearOrigin: _clearOriginStation,
                 onClearDestination: _clearDestinationStation,
@@ -923,6 +958,7 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
                 onCloseNearbyPanel: _hideNearbyPanel,
                 onNearbyLineSelected: _selectNearbyLine,
                 onNearbyDataSourceToggle: _toggleNearbyDataSource,
+                onOpenNearbyStationDetail: _openNearbyStationDetail,
                 routeDraftController: widget.routeDraftController,
                 onClearOrigin: _clearOriginStation,
                 onClearDestination: _clearDestinationStation,
@@ -975,6 +1011,7 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
               onCloseNearbyPanel: _hideNearbyPanel,
               onNearbyLineSelected: _selectNearbyLine,
               onNearbyDataSourceToggle: _toggleNearbyDataSource,
+              onOpenNearbyStationDetail: _openNearbyStationDetail,
               routeDraftController: widget.routeDraftController,
               onClearOrigin: _clearOriginStation,
               onClearDestination: _clearDestinationStation,
@@ -1116,6 +1153,7 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
         return;
       }
 
+      final firstLine = pendingResult.lines.firstOrNull;
       setState(() {
         if (regionChanged) {
           _selectedRegion = targetMap.data.selectedRegion;
@@ -1124,22 +1162,19 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
         }
         _nearbyPanelVisible = true;
         _nearbySelectedStationId = pendingResult.id;
-        _nearbySelectedLineId = pendingResult.lines.firstOrNull?.id;
+        _nearbySelectedLineId = firstLine?.id;
         _nearbyDataSource = _NearbyPanelDataSource.realtime;
+        _nearbyRealtime = firstLine == null
+            ? const RealtimeSnapshot(status: RealtimeSnapshotStatus.unsupported)
+            : const RealtimeSnapshot.loading();
         _nearbyTimetable = null;
-        _nearbyTimetableLoading = false;
+        _nearbyTimetableLoading = firstLine != null;
+        _nearbyAllowRealtimeAutoFallback = true;
         _nearbyPanelData = _NetworkMapNearbyPanelData.success([pendingResult]);
         _searchFanMenuStationId = pendingResult.id;
       });
-      final firstLine = pendingResult.lines.firstOrNull;
-      if (firstLine == null) {
-        setState(() {
-          _nearbyRealtime = const RealtimeSnapshot(
-            status: RealtimeSnapshotStatus.unsupported,
-          );
-        });
-      } else {
-        unawaited(_loadNearbyRealtime(pendingResult, firstLine));
+      if (firstLine != null) {
+        _startNearbyPanelDataLoads(pendingResult, firstLine);
       }
     } on CurrentLocationException catch (error) {
       if (!isCurrentRequest()) {
@@ -1253,40 +1288,72 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
     _nearbyDataSource = _NearbyPanelDataSource.realtime;
     _nearbyTimetable = null;
     _nearbyTimetableLoading = false;
+    _nearbyAllowRealtimeAutoFallback = true;
+  }
+
+  /// 실시간과 시간표를 같은 토큰으로 병렬 로드한다. 실시간 실패 시 즉시 시간표로 넘긴다.
+  void _startNearbyPanelDataLoads(
+    StationSearchResult station,
+    StationSearchLine line,
+  ) {
+    final requestToken = ++_nearbyDataRequestToken;
+    unawaited(_loadNearbyRealtime(station, line, requestToken: requestToken));
+    unawaited(
+      _loadNearbyTimetable(station, line, reuseRequestToken: requestToken),
+    );
   }
 
   Future<void> _loadNearbyRealtime(
     StationSearchResult station,
-    StationSearchLine line,
-  ) async {
-    final requestToken = ++_nearbyDataRequestToken;
+    StationSearchLine line, {
+    int? requestToken,
+  }) async {
+    final token = requestToken ?? ++_nearbyDataRequestToken;
     final repository = widget.realtimeRepository;
     if (repository == null) {
-      if (mounted && requestToken == _nearbyDataRequestToken) {
+      if (mounted && token == _nearbyDataRequestToken) {
         setState(() => _nearbyRealtime = const RealtimeSnapshot.unavailable());
+        unawaited(
+          _fallbackNearbyPanelToTimetable(station, line, requestToken: token),
+        );
       }
       return;
     }
     try {
-      final snapshot = await repository.arrivals(
-        RealtimeStationQuery(
-          stationId: station.id,
-          lineId: line.id,
-          providerLineId: line.stationCode.isEmpty ? line.id : line.stationCode,
-          stationQueryName: station.nameKo,
-        ),
-      );
-      if (mounted && requestToken == _nearbyDataRequestToken) {
+      final snapshot = await repository
+          .arrivals(
+            RealtimeStationQuery(
+              stationId: station.id,
+              lineId: line.id,
+              providerLineId: line.stationCode.isEmpty
+                  ? line.id
+                  : line.stationCode,
+              stationQueryName: station.nameKo,
+            ),
+          )
+          .timeout(
+            _nearbyRealtimeTimeout,
+            onTimeout: () => const RealtimeSnapshot.unavailable(),
+          );
+      if (mounted && token == _nearbyDataRequestToken) {
         setState(() => _nearbyRealtime = snapshot);
+        if (_nearbyRealtimeHasNoUsableData(snapshot)) {
+          unawaited(
+            _fallbackNearbyPanelToTimetable(station, line, requestToken: token),
+          );
+        }
       }
     } on RealtimeException catch (error) {
-      if (mounted && requestToken == _nearbyDataRequestToken) {
+      if (mounted && token == _nearbyDataRequestToken) {
         setState(() {
           _nearbyRealtime = RealtimeSnapshot(
             status: RealtimeSnapshotStatus.unavailable,
             message: error.message,
           );
         });
+        unawaited(
+          _fallbackNearbyPanelToTimetable(station, line, requestToken: token),
+        );
       }
     } catch (error, stackTrace) {
       reportMobileError(
@@ -1294,17 +1361,63 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
         stackTrace,
         context: '노선도 최근접 역 실시간 정보 조회 중 예외가 발생했습니다.',
       );
-      if (mounted && requestToken == _nearbyDataRequestToken) {
+      if (mounted && token == _nearbyDataRequestToken) {
         setState(() => _nearbyRealtime = const RealtimeSnapshot.unavailable());
+        unawaited(
+          _fallbackNearbyPanelToTimetable(station, line, requestToken: token),
+        );
       }
+    }
+  }
+
+  /// 실시간 채널이 없거나 쓸 도착이 없으면 하단 패널을 시간표로 자동 전환한다.
+  bool _nearbyRealtimeHasNoUsableData(RealtimeSnapshot snapshot) {
+    if (snapshot.status == RealtimeSnapshotStatus.unavailable ||
+        snapshot.status == RealtimeSnapshotStatus.unsupported) {
+      return true;
+    }
+    if (snapshot.status == RealtimeSnapshotStatus.fresh ||
+        snapshot.status == RealtimeSnapshotStatus.stale) {
+      return snapshot.arrivals.isEmpty;
+    }
+    return false;
+  }
+
+  Future<void> _fallbackNearbyPanelToTimetable(
+    StationSearchResult station,
+    StationSearchLine line, {
+    required int requestToken,
+  }) async {
+    if (!mounted || requestToken != _nearbyDataRequestToken) {
+      return;
+    }
+    if (!_nearbyAllowRealtimeAutoFallback) {
+      return;
+    }
+    // 사용자가 이미 시간표를 골랐거나 다른 요청이 끼어들면 덮지 않는다.
+    if (_nearbyDataSource != _NearbyPanelDataSource.realtime) {
+      return;
+    }
+    setState(() {
+      _nearbyDataSource = _NearbyPanelDataSource.timetable;
+      // 병렬 prefetch가 끝났으면 스피너 없이 바로 보여 준다.
+      _nearbyTimetableLoading = _nearbyTimetable == null;
+    });
+    if (_nearbyTimetable == null) {
+      await _loadNearbyTimetable(
+        station,
+        line,
+        reuseRequestToken: requestToken,
+      );
     }
   }
 
   Future<void> _loadNearbyTimetable(
     StationSearchResult station,
-    StationSearchLine line,
-  ) async {
-    final requestToken = ++_nearbyDataRequestToken;
+    StationSearchLine line, {
+    int? reuseRequestToken,
+  }) async {
+    final requestToken = reuseRequestToken ?? ++_nearbyDataRequestToken;
     final repository = widget.stationSearchRepository;
     if (repository is! StationTimetableRepository) {
       if (mounted && requestToken == _nearbyDataRequestToken) {
@@ -1348,18 +1461,16 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
       return;
     }
     final station = _nearbyPanelData.results.first;
+    // 호선이 바뀌면 실시간부터 다시 시도하고, 없으면 시간표로 폴백한다.
     setState(() {
       _nearbySelectedLineId = line.id;
+      _nearbyDataSource = _NearbyPanelDataSource.realtime;
       _nearbyRealtime = const RealtimeSnapshot.loading();
       _nearbyTimetable = null;
-      _nearbyTimetableLoading =
-          _nearbyDataSource == _NearbyPanelDataSource.timetable;
+      _nearbyTimetableLoading = true;
+      _nearbyAllowRealtimeAutoFallback = true;
     });
-    if (_nearbyDataSource == _NearbyPanelDataSource.realtime) {
-      unawaited(_loadNearbyRealtime(station, line));
-    } else {
-      unawaited(_loadNearbyTimetable(station, line));
-    }
+    _startNearbyPanelDataLoads(station, line);
   }
 
   void _toggleNearbyDataSource() {
@@ -1378,18 +1489,54 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
         : _NearbyPanelDataSource.realtime;
     setState(() {
       _nearbyDataSource = next;
-      _nearbyRealtime = const RealtimeSnapshot.loading();
-      _nearbyTimetable = null;
-      _nearbyTimetableLoading = next == _NearbyPanelDataSource.timetable;
+      // 수동으로 실시간을 고르면 빈 응답으로 다시 시간표에 튕기지 않는다.
+      _nearbyAllowRealtimeAutoFallback = false;
+      if (next == _NearbyPanelDataSource.realtime) {
+        _nearbyRealtime = const RealtimeSnapshot.loading();
+      } else if (_nearbyTimetable == null) {
+        _nearbyTimetableLoading = true;
+      }
     });
+    final requestToken = ++_nearbyDataRequestToken;
     if (next == _NearbyPanelDataSource.realtime) {
-      unawaited(_loadNearbyRealtime(station, line));
-    } else {
-      unawaited(_loadNearbyTimetable(station, line));
+      unawaited(_loadNearbyRealtime(station, line, requestToken: requestToken));
+    } else if (_nearbyTimetable == null) {
+      unawaited(
+        _loadNearbyTimetable(station, line, reuseRequestToken: requestToken),
+      );
     }
   }
 
   void _hideNearbyPanel() => setState(_resetNearbyPanelState);
+
+  void _openNearbyStationDetail() {
+    final results = _nearbyPanelData.results;
+    if (results.isEmpty) {
+      return;
+    }
+    final stationRepository = widget.stationSearchRepository;
+    final reportRepository = widget.reportRepository;
+    if (stationRepository == null || reportRepository == null) {
+      return;
+    }
+    Navigator.of(context).push<void>(
+      MaterialPageRoute<void>(
+        builder: (_) => StationDetailScreen(
+          repository: stationRepository,
+          reportRepository: reportRepository,
+          favoriteRepository: widget.favoriteRepository,
+          adRepository: widget.adRepository,
+          realtimeRepository: widget.realtimeRepository,
+          locationProvider: widget.locationProvider,
+          stationId: results.first.id,
+          facilityReportDraftTargetStore: widget.facilityReportDraftTargetStore,
+          internalRouteRepository: widget.internalRouteRepository,
+          internalRouteMobilityType: widget.internalRouteMobilityType,
+          routeDraftController: widget.routeDraftController,
+        ),
+      ),
+    );
+  }
 
   /// 현재 선택 지역의 표시명(예: '수도권', '부산'). 역 검색 화면을 열 때
   /// [StationSearchScreen.regionLabel]로 그대로 넘긴다(#2090 배선).
@@ -1610,6 +1757,7 @@ class _NetworkMapChrome extends StatelessWidget {
     required this.onCloseNearbyPanel,
     required this.onNearbyLineSelected,
     required this.onNearbyDataSourceToggle,
+    this.onOpenNearbyStationDetail,
     required this.routeDraftController,
     required this.onClearOrigin,
     required this.onClearDestination,
@@ -1648,6 +1796,7 @@ class _NetworkMapChrome extends StatelessWidget {
   final VoidCallback onCloseNearbyPanel;
   final ValueChanged<StationSearchLine> onNearbyLineSelected;
   final VoidCallback onNearbyDataSourceToggle;
+  final VoidCallback? onOpenNearbyStationDetail;
   final RouteDraftController routeDraftController;
   final VoidCallback onClearOrigin;
   final VoidCallback onClearDestination;
@@ -1745,6 +1894,7 @@ class _NetworkMapChrome extends StatelessWidget {
               onClose: onCloseNearbyPanel,
               onLineSelected: onNearbyLineSelected,
               onDataSourceToggle: onNearbyDataSourceToggle,
+              onOpenStationDetail: onOpenNearbyStationDetail,
             ),
           ),
         if (nearbyLookupMessage != null && !inSearchMode)
@@ -1886,13 +2036,19 @@ class _NetworkMapTopBar extends StatelessWidget {
               },
             ),
           ),
-          const Positioned(
+          Positioned(
             left: 0,
             right: 0,
             bottom: 0,
-            child: EasySubwayHeaderDivider.mapChrome(
-              key: Key('networkMapTopBarDivider'),
-            ),
+            // 노선도 idle/draft만 mapChrome 드롭. 검색 모드(흰 검색 본문)는
+            // 역 검색 화면과 같이 선만 둔다.
+            child: searchMode
+                ? const EasySubwayHeaderDivider(
+                    key: Key('networkMapTopBarDivider'),
+                  )
+                : const EasySubwayHeaderDivider.mapChrome(
+                    key: Key('networkMapTopBarDivider'),
+                  ),
           ),
         ],
       ),
@@ -2076,7 +2232,7 @@ class _NetworkMapSearchField extends StatelessWidget {
                     decoration: BoxDecoration(
                       color: EasySubwayAccessibleColors.searchFieldSurface,
                       border: Border.all(
-                        color: EasySubwayAccessibleColors.line,
+                        color: easySubwaySearchFieldBorderColor,
                         width: easySubwaySearchFieldBorderWidth,
                       ),
                       borderRadius: easySubwaySearchFieldRadius,
@@ -2159,7 +2315,14 @@ class _NetworkMapSearchSessionState extends State<_NetworkMapSearchSession> {
   late final StationSearchController _searchController;
   Timer? _searchDebounce;
   List<RecentSearchEntry> _searchRecentEntries = const [];
+  bool _searchRecentEntriesReady = false;
   Set<String> _favoriteKeys = const <String>{};
+
+  /// 최근↔결과 레이아웃만 전환. 글자마다 결과 목록을 다시 그리지 않는다.
+  bool _layoutHasSearchQuery = false;
+
+  /// 하이라이트용. 검색이 돌아왔을 때의 질의(타이핑 중 매 키입력 반영 안 함).
+  String _highlightQuery = '';
 
   TextEditingController get _queryController => widget.searchQueryController;
 
@@ -2175,6 +2338,9 @@ class _NetworkMapSearchSessionState extends State<_NetworkMapSearchSession> {
     _queryController.addListener(_handleSearchQueryChanged);
     unawaited(_loadSearchRecentEntries());
     unawaited(_loadFavoriteStationIds());
+    unawaited(
+      warmStationSearchCacheIfSupported(widget.stationSearchRepository),
+    );
   }
 
   @override
@@ -2204,23 +2370,34 @@ class _NetworkMapSearchSessionState extends State<_NetworkMapSearchSession> {
       return;
     }
     _searchDebounce?.cancel();
-    if (!_hasSearchQuery) {
+    final hasQuery = _hasSearchQuery;
+    if (!hasQuery) {
+      _highlightQuery = '';
       if (_searchController.state.status != StationSearchStatus.idle) {
         unawaited(_searchController.search(''));
       }
-      return;
+    } else {
+      // 부분 입력·초성(ㅅ)도 검색한다. 첫 글자는 즉시, 이후는 짧게 디바운스.
+      final query = _queryController.text;
+      if (!_layoutHasSearchQuery) {
+        unawaited(_runInPlaceSearch(query, recordHistory: false));
+      } else {
+        _searchDebounce = Timer(
+          const Duration(milliseconds: 180),
+          () => unawaited(_runInPlaceSearch(query, recordHistory: false)),
+        );
+      }
     }
-    final query = _queryController.text;
-    _searchDebounce = Timer(
-      const Duration(milliseconds: 300),
-      () => unawaited(_runInPlaceSearch(query, recordHistory: false)),
-    );
+    if (_layoutHasSearchQuery != hasQuery) {
+      setState(() => _layoutHasSearchQuery = hasQuery);
+    }
   }
 
   Future<void> _runInPlaceSearch(
     String query, {
     bool recordHistory = true,
   }) async {
+    _highlightQuery = query.trim();
     // 노선도 지역과 같은 범위로 결과·기록을 맞춘다. 전국 결과만 보고 현재
     // 지역 라벨로 저장하던 경로가 타 지역 역을 수도권 최근 검색에 남겼다.
     await _searchController.search(
@@ -2237,16 +2414,19 @@ class _NetworkMapSearchSessionState extends State<_NetworkMapSearchSession> {
   /// 상위 화면이 상단바 편집 필드의 제출(엔터/검색 액션)에서 [GlobalKey]로
   /// 호출한다. 세션이 검색 로직을 소유하므로 제출도 세션에서 처리한다.
   void submitSearch(String query) {
+    // 진행 중 검색은 requestId로 무효화되므로 loading이어도 제출을 막지 않는다.
     _searchDebounce?.cancel();
-    if (_searchController.state.status == StationSearchStatus.loading) {
-      return;
-    }
     unawaited(_runInPlaceSearch(query));
   }
 
   Future<void> _loadSearchRecentEntries() async {
     final repository = widget.searchHistoryRepository;
     if (repository == null) {
+      if (mounted) {
+        setState(() => _searchRecentEntriesReady = true);
+      } else {
+        _searchRecentEntriesReady = true;
+      }
       return;
     }
     try {
@@ -2256,9 +2436,15 @@ class _NetworkMapSearchSessionState extends State<_NetworkMapSearchSession> {
       if (!mounted) {
         return;
       }
-      setState(() => _searchRecentEntries = entries);
+      setState(() {
+        _searchRecentEntries = entries;
+        _searchRecentEntriesReady = true;
+      });
     } catch (error, stackTrace) {
       reportMobileError(error, stackTrace, context: '최근 검색 조회 중 예외가 발생했습니다.');
+      if (mounted) {
+        setState(() => _searchRecentEntriesReady = true);
+      }
     }
   }
 
@@ -2440,46 +2626,45 @@ class _NetworkMapSearchSessionState extends State<_NetworkMapSearchSession> {
     // searching·여백·배경은 builder 안에서 읽어야 한다. 바깥 build 클로저에
     // 묶으면 타이핑 때는 여백이 남고 즐겨찾기 setState 때만 풀블리드로
     // 바뀌어 화면이 갑자기 넓어진다.
+    // 결과 목록은 검색 컨트롤러만 구독한다. queryController를 묶으면
+    // 한글 조합 글자마다 배지·행 전체를 다시 그려 입력 자체가 버벅인다.
+    final searching = _layoutHasSearchQuery;
     return Semantics(
       container: true,
-      child: AnimatedBuilder(
-        animation: Listenable.merge([_searchController, _queryController]),
-        builder: (context, _) {
-          final searching = _hasSearchQuery;
-          final state = _searchController.state;
-          final showRecent = !searching;
-          final isSearching = state.status == StationSearchStatus.loading;
-          // 최근 검색만 SafeArea(좌우)·패딩. 검색 결과는 가장자리까지.
-          return ColoredBox(
-            color: searching
-                ? EasySubwayAccessibleColors.surface
-                : EasySubwayAccessibleColors.scaffoldSurface,
-            child: SafeArea(
-              top: false,
-              left: !searching,
-              right: !searching,
-              child: ListView(
+      child: ColoredBox(
+        color: searching
+            ? EasySubwayAccessibleColors.surface
+            : EasySubwayAccessibleColors.scaffoldSurface,
+        child: SafeArea(
+          top: false,
+          left: !searching,
+          right: !searching,
+          child: AnimatedBuilder(
+            animation: _searchController,
+            builder: (context, _) {
+              final state = _searchController.state;
+              final showRecent = !searching;
+              final isSearching = state.status == StationSearchStatus.loading;
+              // 최근 검색만 SafeArea(좌우)·패딩. 검색 결과는 가장자리까지.
+              return ListView(
                 padding: searching
                     ? EdgeInsets.zero
-                    : const EdgeInsets.fromLTRB(16, 12, 16, 24),
+                    : const EdgeInsets.fromLTRB(16, 4, 16, 16),
                 children: [
-                  if (showRecent)
-                    Padding(
-                      padding: const EdgeInsets.only(bottom: 12),
-                      child: StationRecentSearchSection(
-                        entries: _searchRecentEntries,
-                        enabled: !isSearching,
-                        onStationSelected: _searchRecentStationSelected,
-                        onRouteSelected: _searchRecentRouteSelected,
-                        onRemove: (entry) =>
-                            unawaited(_removeSearchRecentEntry(entry)),
-                        onClearAll: () =>
-                            unawaited(_clearAllSearchRecentEntries()),
-                      ),
+                  if (showRecent && _searchRecentEntriesReady)
+                    StationRecentSearchSection(
+                      entries: _searchRecentEntries,
+                      enabled: !isSearching,
+                      onStationSelected: _searchRecentStationSelected,
+                      onRouteSelected: _searchRecentRouteSelected,
+                      onRemove: (entry) =>
+                          unawaited(_removeSearchRecentEntry(entry)),
+                      onClearAll: () =>
+                          unawaited(_clearAllSearchRecentEntries()),
                     ),
                   StationSearchBody(
                     state: state,
-                    query: _queryController.text,
+                    query: _highlightQuery,
                     favoriteKeys: _favoriteKeys,
                     onResultTap: widget.onResultFocus,
                     onToggleFavorite: widget.favoriteRepository == null
@@ -2487,10 +2672,10 @@ class _NetworkMapSearchSessionState extends State<_NetworkMapSearchSession> {
                         : _toggleFavoriteStation,
                   ),
                 ],
-              ),
-            ),
-          );
-        },
+              );
+            },
+          ),
+        ),
       ),
     );
   }
@@ -2576,6 +2761,7 @@ class _NetworkMapNearbyStationPanel extends StatelessWidget {
     required this.onClose,
     required this.onLineSelected,
     required this.onDataSourceToggle,
+    this.onOpenStationDetail,
   });
 
   final _NetworkMapNearbyPanelData data;
@@ -2588,6 +2774,7 @@ class _NetworkMapNearbyStationPanel extends StatelessWidget {
   final VoidCallback onClose;
   final ValueChanged<StationSearchLine> onLineSelected;
   final VoidCallback onDataSourceToggle;
+  final VoidCallback? onOpenStationDetail;
 
   @override
   Widget build(BuildContext context) {
@@ -2672,6 +2859,7 @@ class _NetworkMapNearbyStationPanel extends StatelessWidget {
                 timetable: timetable,
                 timetableLoading: timetableLoading,
                 adjacentStations: adjacentStations,
+                onOpenStationDetail: onOpenStationDetail,
               ),
             ],
           ),
@@ -2690,6 +2878,7 @@ class _NetworkMapNearbyPanelBody extends StatelessWidget {
     required this.timetable,
     required this.timetableLoading,
     required this.adjacentStations,
+    this.onOpenStationDetail,
   });
 
   final _NetworkMapNearbyPanelData data;
@@ -2699,6 +2888,7 @@ class _NetworkMapNearbyPanelBody extends StatelessWidget {
   final StationTimetable? timetable;
   final bool timetableLoading;
   final _NetworkMapAdjacentStations adjacentStations;
+  final VoidCallback? onOpenStationDetail;
 
   @override
   Widget build(BuildContext context) {
@@ -2716,6 +2906,7 @@ class _NetworkMapNearbyPanelBody extends StatelessWidget {
         timetable: timetable,
         timetableLoading: timetableLoading,
         adjacentStations: adjacentStations,
+        onOpenStationDetail: onOpenStationDetail,
       ),
     };
   }
@@ -2760,6 +2951,7 @@ class _NetworkMapNearbySuccessList extends StatelessWidget {
     required this.timetable,
     required this.timetableLoading,
     required this.adjacentStations,
+    this.onOpenStationDetail,
   });
 
   final List<StationSearchResult> results;
@@ -2769,6 +2961,7 @@ class _NetworkMapNearbySuccessList extends StatelessWidget {
   final StationTimetable? timetable;
   final bool timetableLoading;
   final _NetworkMapAdjacentStations adjacentStations;
+  final VoidCallback? onOpenStationDetail;
 
   @override
   Widget build(BuildContext context) {
@@ -2784,6 +2977,7 @@ class _NetworkMapNearbySuccessList extends StatelessWidget {
           stationName: primary.nameKo,
           badgeText: selectedLine?.badgeText ?? '',
           lineColor: lineColor,
+          onStationNameTap: onOpenStationDetail,
         ),
         const SizedBox(height: 17),
         Padding(
@@ -5706,6 +5900,12 @@ class _NetworkMapTopBarRouteDraft extends StatelessWidget {
   /// 노선홈 지하철역 검색 시각 박스와 동일 높이(#2083).
   static const _fieldMinHeight = easySubwaySearchFieldVisualHeight;
 
+  /// 홈 idle 검색 행과 같은 필드↔구분선 간격.
+  /// 검색 행은 고정 높이 [easySubwayTopBarContentHeight] 안에서 필드가
+  /// 수직 중앙이라, 패딩 6 + 여유 4 = (60 − 40) / 2 = 10이 된다.
+  static const _chromeVerticalInset =
+      (easySubwayTopBarContentHeight - _fieldMinHeight) / 2;
+
   final RouteDraft draft;
 
   /// 빈 경유 칸 포함, 경유 행을 그릴지.
@@ -5804,9 +6004,14 @@ class _NetworkMapTopBarRouteDraft extends StatelessWidget {
       ),
     ];
 
-    // 노선홈 검색 행과 동일: 상·하 6(구분선↔박스 간격), 필드는 46 시각 높이.
+    // 노선홈 검색 행과 동일: 상·하 10(필드↔구분선), 필드는 검색 박스 시각 높이.
     return Padding(
-      padding: const EdgeInsets.fromLTRB(4, 6, 8, 6),
+      padding: const EdgeInsets.fromLTRB(
+        4,
+        _chromeVerticalInset,
+        8,
+        _chromeVerticalInset,
+      ),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -6072,7 +6277,7 @@ class _NetworkMapRouteDraftField extends StatelessWidget {
         color: EasySubwayAccessibleColors.searchFieldSurface,
         borderRadius: easySubwaySearchFieldRadius,
         border: Border.all(
-          color: EasySubwayAccessibleColors.line,
+          color: easySubwaySearchFieldBorderColor,
           width: easySubwaySearchFieldBorderWidth,
         ),
       ),
@@ -6086,7 +6291,7 @@ class _NetworkMapRouteDraftField extends StatelessWidget {
             // 출발역 | 선택역 사이 경계(외곽선과 동일 톤·굵기).
             Container(
               width: easySubwaySearchFieldBorderWidth,
-              color: EasySubwayAccessibleColors.line,
+              color: easySubwaySearchFieldBorderColor,
             ),
             Expanded(
               child: Padding(
@@ -6160,7 +6365,7 @@ class _NetworkMapRouteDraftField extends StatelessWidget {
                 color: EasySubwayAccessibleColors.searchFieldSurface,
                 borderRadius: easySubwaySearchFieldRadius,
                 border: Border.all(
-                  color: EasySubwayAccessibleColors.line,
+                  color: easySubwaySearchFieldBorderColor,
                   width: easySubwaySearchFieldBorderWidth,
                 ),
               ),

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -916,7 +916,7 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
                 onCloseNearbyPanel: _hideNearbyPanel,
                 onNearbyLineSelected: _selectNearbyLine,
                 onNearbyDataSourceToggle: _toggleNearbyDataSource,
-                onOpenNearbyStationDetail: _openNearbyStationDetail,
+                onOpenNearbyStationDetail: _nearbyStationDetailAction,
                 routeDraftController: widget.routeDraftController,
                 onClearOrigin: _clearOriginStation,
                 onClearDestination: _clearDestinationStation,
@@ -963,7 +963,7 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
                 onCloseNearbyPanel: _hideNearbyPanel,
                 onNearbyLineSelected: _selectNearbyLine,
                 onNearbyDataSourceToggle: _toggleNearbyDataSource,
-                onOpenNearbyStationDetail: _openNearbyStationDetail,
+                onOpenNearbyStationDetail: _nearbyStationDetailAction,
                 routeDraftController: widget.routeDraftController,
                 onClearOrigin: _clearOriginStation,
                 onClearDestination: _clearDestinationStation,
@@ -1016,7 +1016,7 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
               onCloseNearbyPanel: _hideNearbyPanel,
               onNearbyLineSelected: _selectNearbyLine,
               onNearbyDataSourceToggle: _toggleNearbyDataSource,
-              onOpenNearbyStationDetail: _openNearbyStationDetail,
+              onOpenNearbyStationDetail: _nearbyStationDetailAction,
               routeDraftController: widget.routeDraftController,
               onClearOrigin: _clearOriginStation,
               onClearDestination: _clearDestinationStation,
@@ -1513,6 +1513,12 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
   }
 
   void _hideNearbyPanel() => setState(_resetNearbyPanelState);
+
+  /// 저장소가 있을 때만 "상세 보기"를 탭 가능 컨트롤로 노출한다.
+  VoidCallback? get _nearbyStationDetailAction =>
+      widget.stationSearchRepository != null && widget.reportRepository != null
+      ? _openNearbyStationDetail
+      : null;
 
   void _openNearbyStationDetail() {
     final results = _nearbyPanelData.results;

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -709,6 +709,8 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
     setState(() {
       _nearestStationRequestToken++;
       _selectionClearRevision++;
+      // 호선이 없어도 이전 역의 비동기 로드가 이 패널을 덮지 않게 무효화한다.
+      _nearbyDataRequestToken++;
       _nearbyPanelVisible = true;
       _nearbySelectedStationId = result.id;
       _nearbySelectedLineId = selectedLine?.id;
@@ -761,7 +763,10 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
       // 데이터 없음 → 팬 메뉴만 유지(크래시·빈 패널 금지).
       return;
     }
-    _showStationPanelFromSearch(match);
+    final preferredLine = match.lines
+        .where((line) => line.id == station.lineId)
+        .firstOrNull;
+    _showStationPanelFromSearch(match, preferredLine: preferredLine);
   }
 
   /// #2109 검색 결과 탭으로 연 팬 메뉴가 닫히면(액션 선택·닫기·배경 탭·팬) 이

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -2874,6 +2874,9 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
   StationSearchResult? _originStation;
   StationSearchResult? _destinationStation;
   StationSearchResult? _waypointStation;
+
+  /// 경유역 칸은 선택(또는 추가) 전에는 숨긴다. draft에 경유가 있으면 연다.
+  bool _waypointSlotOpen = false;
   _RouteStationRole? _activeStationPicker;
   late MobilityPreset _selectedPreset;
   late String _selectedMobilityType;
@@ -2925,6 +2928,7 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
     _originStation = _stationFromDraft(widget.initialDraft?.origin);
     _destinationStation = _stationFromDraft(widget.initialDraft?.destination);
     _waypointStation = _stationFromDraft(widget.initialDraft?.waypoint);
+    _waypointSlotOpen = _waypointStation != null;
     _selectedPreset =
         mobilityPresetFromRepresentativeMobilityType(
           widget.initialMobilityType,
@@ -2949,6 +2953,7 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
       _originStation = _stationFromDraft(draft?.origin);
       _destinationStation = _stationFromDraft(draft?.destination);
       _waypointStation = _stationFromDraft(draft?.waypoint);
+      _waypointSlotOpen = _waypointStation != null;
       WidgetsBinding.instance.addPostFrameCallback((_) {
         _maybeAutoSearchFromDraft();
       });
@@ -3170,27 +3175,8 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
         }
         return Scaffold(
           key: const Key('routeSearchScreen'),
-          backgroundColor: EasySubwayAccessibleColors.scaffoldSurface,
-          appBar: AppBar(
-            toolbarHeight: 60,
-            backgroundColor: EasySubwayAccessibleColors.topBarSurface,
-            foregroundColor: EasySubwayAccessibleColors.text,
-            surfaceTintColor: Colors.transparent,
-            elevation: 0,
-            title: const Text(
-              '길찾기',
-              style: TextStyle(
-                color: EasySubwayAccessibleColors.text,
-                fontWeight: FontWeight.w700,
-                fontSize: 20,
-                height: 1.2,
-              ),
-            ),
-            flexibleSpace: const Align(
-              alignment: Alignment.bottomCenter,
-              child: EasySubwayHeaderDivider(),
-            ),
-          ),
+          backgroundColor: EasySubwayAccessibleColors.surface,
+          appBar: _routeSearchAppBar(onBack: () => unawaited(_endRoute())),
           bottomNavigationBar: widget.shellNavigationBar,
           body: Semantics(
             container: true,
@@ -3204,14 +3190,19 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
                   children: [
                     _RoutePointPickerCard(
                       key: const Key('routePointPickerCard'),
-                      // #1933 요구 3: 폼이 사라졌으므로 항상 얇은 헤더로 축소한다.
-                      // 역명 탭 → 인라인 역 검색으로 편집(→ 재검색)만 남긴다.
-                      compact: true,
+                      // #1933 요구 3 / #2436: 경유는 추가 시에만 칸을 열고, 역명 옆 호선 마크.
                       originStation: _originStation,
+                      waypointStation: _waypointStation,
                       destinationStation: _destinationStation,
+                      showWaypointRow: _waypointSlotOpen,
                       originPicker:
                           _activeStationPicker == _RouteStationRole.origin
                           ? _buildRouteStationPicker(_RouteStationRole.origin)
+                          : null,
+                      waypointPicker:
+                          _waypointSlotOpen &&
+                              _activeStationPicker == _RouteStationRole.waypoint
+                          ? _buildRouteStationPicker(_RouteStationRole.waypoint)
                           : null,
                       destinationPicker:
                           _activeStationPicker == _RouteStationRole.destination
@@ -3221,8 +3212,13 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
                           : null,
                       onOriginTap: () =>
                           _openStationPicker(_RouteStationRole.origin),
+                      onWaypointTap: _waypointSlotOpen
+                          ? () => _openStationPicker(_RouteStationRole.waypoint)
+                          : null,
                       onDestinationTap: () =>
                           _openStationPicker(_RouteStationRole.destination),
+                      onAddWaypoint: _openWaypointSlot,
+                      onRemoveWaypoint: _removeWaypointSlot,
                       onSwap: _swapStations,
                     ),
                     const SizedBox(height: 18),
@@ -3447,10 +3443,15 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
         RecentRouteSearchEntry(
           originStationId: origin.id,
           originStationName: origin.nameKo,
+          originLines: _recentLinesForStation(origin),
           waypointStationId: waypoint?.id,
           waypointStationName: waypoint?.nameKo,
+          waypointLines: waypoint == null
+              ? const []
+              : _recentLinesForStation(waypoint),
           destinationStationId: destination.id,
           destinationStationName: destination.nameKo,
+          destinationLines: _recentLinesForStation(destination),
           region: region,
           searchedAt: DateTime.now().toUtc(),
         ),
@@ -3508,43 +3509,101 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
   }
 
   Widget _buildRouteStationPicker(_RouteStationRole role) {
-    final isOrigin = role == _RouteStationRole.origin;
+    final (
+      label,
+      inputKey,
+      searchKey,
+      optionPrefix,
+      selected,
+      onSelected,
+    ) = switch (role) {
+      _RouteStationRole.origin => (
+        '출발역',
+        const Key('routeOriginStationInput'),
+        const Key('routeOriginStationSearchButton'),
+        'routeOriginStationOption',
+        _originStation,
+        _updateOriginStation,
+      ),
+      _RouteStationRole.waypoint => (
+        '경유역',
+        const Key('routeWaypointStationInput'),
+        const Key('routeWaypointStationSearchButton'),
+        'routeWaypointStationOption',
+        _waypointStation,
+        _updateWaypointStation,
+      ),
+      _RouteStationRole.destination => (
+        '도착역',
+        const Key('routeDestinationStationInput'),
+        const Key('routeDestinationStationSearchButton'),
+        'routeDestinationStationOption',
+        _destinationStation,
+        _updateDestinationStation,
+      ),
+    };
     return _RouteStationPicker(
-      isOrigin: isOrigin,
-      labelText: isOrigin ? '출발역' : '도착역',
-      inputKey: isOrigin
-          ? const Key('routeOriginStationInput')
-          : const Key('routeDestinationStationInput'),
-      searchButtonKey: isOrigin
-          ? const Key('routeOriginStationSearchButton')
-          : const Key('routeDestinationStationSearchButton'),
-      optionKeyPrefix: isOrigin
-          ? 'routeOriginStationOption'
-          : 'routeDestinationStationOption',
-      selectedStation: isOrigin ? _originStation : _destinationStation,
+      role: role,
+      labelText: label,
+      inputKey: inputKey,
+      searchButtonKey: searchKey,
+      optionKeyPrefix: optionPrefix,
+      selectedStation: selected,
       repository: widget.stationRepository,
-      onSelected: isOrigin ? _updateOriginStation : _updateDestinationStation,
+      onSelected: onSelected,
     );
   }
 
   Future<void> _updateOriginStation(StationSearchResult? station) async {
-    if (!await _disableActiveGetOffAlarm()) {
-      return;
-    }
-    if (!mounted) {
-      return;
-    }
+    await _updateRouteStation(
+      apply: () => _originStation = station,
+      selected: station,
+    );
+  }
+
+  Future<void> _updateWaypointStation(StationSearchResult? station) async {
+    await _updateRouteStation(
+      apply: () {
+        _waypointStation = station;
+        if (station != null) {
+          _waypointSlotOpen = true;
+        }
+      },
+      selected: station,
+    );
+  }
+
+  void _openWaypointSlot() {
     setState(() {
-      _originStation = station;
-      if (station != null) {
-        _activeStationPicker = null;
-      }
+      _waypointSlotOpen = true;
       _validationMessage = '';
     });
-    _controller.reset();
+  }
+
+  Future<void> _removeWaypointSlot() async {
+    await _updateRouteStation(
+      apply: () {
+        _waypointStation = null;
+        _waypointSlotOpen = false;
+        if (_activeStationPicker == _RouteStationRole.waypoint) {
+          _activeStationPicker = null;
+        }
+      },
+      selected: null,
+    );
   }
 
   Future<void> _updateDestinationStation(StationSearchResult? station) async {
+    await _updateRouteStation(
+      apply: () => _destinationStation = station,
+      selected: station,
+    );
+  }
+
+  Future<void> _updateRouteStation({
+    required VoidCallback apply,
+    required StationSearchResult? selected,
+  }) async {
     if (!await _disableActiveGetOffAlarm()) {
       return;
     }
@@ -3552,13 +3611,17 @@ class _RouteSearchScreenState extends State<RouteSearchScreen>
       return;
     }
     setState(() {
-      _destinationStation = station;
-      if (station != null) {
+      apply();
+      if (selected != null) {
         _activeStationPicker = null;
       }
       _validationMessage = '';
+      _autoSearchedSignature = null;
     });
     _controller.reset();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _maybeAutoSearchFromDraft();
+    });
   }
 
   void _openStationPicker(_RouteStationRole role) {
@@ -3643,6 +3706,18 @@ StationSearchResult? _stationFromDraft(RouteDraftStation? station) {
   if (station == null) {
     return null;
   }
+  final lines = station.hasLine
+      ? <StationSearchLine>[
+          StationSearchLine(
+            id: station.lineId,
+            name: station.lineName.trim().isEmpty
+                ? station.lineId
+                : station.lineName,
+            color: station.lineColor,
+            stationCode: station.stationCode,
+          ),
+        ]
+      : const <StationSearchLine>[];
   return StationSearchResult(
     id: station.id,
     nameKo: station.nameKo,
@@ -3651,11 +3726,19 @@ StationSearchResult? _stationFromDraft(RouteDraftStation? station) {
     region: '',
     dataQualityLevel: '',
     lastVerifiedAt: '',
-    lines: const [],
+    lines: lines,
   );
 }
 
-enum _RouteStationRole { origin, destination }
+/// 최근 경로 마크용. 선택 호선이 하나로 확정된 경우만 넘긴다(환승 전 호선 금지).
+List<StationSearchLine> _recentLinesForStation(StationSearchResult station) {
+  if (station.lines.length != 1) {
+    return const [];
+  }
+  return station.lines;
+}
+
+enum _RouteStationRole { origin, waypoint, destination }
 
 class _RoutePointPickerCard extends StatelessWidget {
   const _RoutePointPickerCard({
@@ -3666,71 +3749,78 @@ class _RoutePointPickerCard extends StatelessWidget {
     required this.onOriginTap,
     required this.onDestinationTap,
     required this.onSwap,
-    this.compact = false,
+    required this.showWaypointRow,
+    required this.onAddWaypoint,
+    required this.onRemoveWaypoint,
+    this.waypointStation,
+    this.waypointPicker,
+    this.onWaypointTap,
     super.key,
   });
 
   final StationSearchResult? originStation;
+  final StationSearchResult? waypointStation;
   final StationSearchResult? destinationStation;
+  final bool showWaypointRow;
   final Widget? originPicker;
+  final Widget? waypointPicker;
   final Widget? destinationPicker;
   final VoidCallback onOriginTap;
+  final VoidCallback? onWaypointTap;
   final VoidCallback onDestinationTap;
+  final VoidCallback onAddWaypoint;
+  final VoidCallback onRemoveWaypoint;
   final VoidCallback onSwap;
-
-  /// #1933 E: 결과-우선 화면에서는 이 카드를 얇은 헤더로 강등한다(역명 작게·세로
-  /// 패딩 축소). 입력 상태에서는 기존 큰 피커 크기를 그대로 둔다(false 기본).
-  final bool compact;
 
   @override
   Widget build(BuildContext context) {
-    // 지도 draft 필드와 같은 문법: [출발역|도착역 | 역명] 검색필드 크롬 + 우측 스왑.
+    // 지도 draft와 같은 문법: [역할 | 호선마크·역명] + 출발 옆 경유 추가/제거 + 우측 스왑.
     final originChild =
         originPicker ??
         _RoutePointRow(
           key: const Key('routeOriginPointButton'),
-          isOrigin: true,
+          role: _RouteStationRole.origin,
           station: originStation,
           fallback: '출발역 선택',
           onTap: onOriginTap,
-          compact: compact,
         );
+    final waypointTap = onWaypointTap;
+    final waypointChild = !showWaypointRow
+        ? null
+        : (waypointPicker ??
+              (waypointTap == null
+                  ? null
+                  : _RoutePointRow(
+                      key: const Key('routeWaypointPointButton'),
+                      role: _RouteStationRole.waypoint,
+                      station: waypointStation,
+                      fallback: '경유역 선택',
+                      onTap: waypointTap,
+                    )));
     final destinationChild =
         destinationPicker ??
         _RoutePointRow(
           key: const Key('routeDestinationPointButton'),
-          isOrigin: false,
+          role: _RouteStationRole.destination,
           station: destinationStation,
           fallback: '도착역 선택',
           onTap: onDestinationTap,
-          compact: compact,
         );
-    final swapButton = Semantics(
-      button: true,
-      label: '출발 도착 바꾸기',
-      onTap: onSwap,
-      child: ExcludeSemantics(
-        child: IconButton(
-          key: const Key('routeSwapStationsButton'),
-          onPressed: onSwap,
-          icon: const Icon(Icons.swap_vert, size: 22),
-          color: EasySubwayAccessibleColors.text,
-          style: IconButton.styleFrom(
-            minimumSize: const Size(
-              EasySubwayTouchTarget.general,
-              EasySubwayTouchTarget.general,
-            ),
-            backgroundColor: EasySubwayAccessibleColors.searchFieldSurface,
-            side: const BorderSide(
-              color: EasySubwayAccessibleColors.line,
-              width: easySubwaySearchFieldBorderWidth,
-            ),
-            shape: RoundedRectangleBorder(
-              borderRadius: easySubwaySearchFieldRadius,
-            ),
-          ),
-        ),
+    final waypointToggle = _routeChromeIconButton(
+      key: Key(
+        showWaypointRow
+            ? 'routeRemoveWaypointButton'
+            : 'routeAddWaypointButton',
       ),
+      semanticsLabel: showWaypointRow ? '경유역 제거' : '경유역 추가',
+      icon: showWaypointRow ? Icons.remove : Icons.add,
+      onPressed: showWaypointRow ? onRemoveWaypoint : onAddWaypoint,
+    );
+    final swapButton = _routeChromeIconButton(
+      key: const Key('routeSwapStationsButton'),
+      semanticsLabel: '출발 도착 바꾸기',
+      icon: Icons.swap_vert,
+      onPressed: onSwap,
     );
     return Row(
       crossAxisAlignment: CrossAxisAlignment.center,
@@ -3738,9 +3828,35 @@ class _RoutePointPickerCard extends StatelessWidget {
         Expanded(
           child: Column(
             children: [
-              originChild,
+              // 출발 행만 왼쪽에 경유 추가/제거 — 필드 폭은 경유·도착과 맞춘다.
+              Row(
+                children: [
+                  waypointToggle,
+                  const SizedBox(width: EasySubwaySpacing.sm),
+                  Expanded(child: originChild),
+                ],
+              ),
+              if (waypointChild != null) ...[
+                const SizedBox(height: EasySubwaySpacing.sm),
+                Row(
+                  children: [
+                    const SizedBox(
+                      width:
+                          EasySubwayTouchTarget.general + EasySubwaySpacing.sm,
+                    ),
+                    Expanded(child: waypointChild),
+                  ],
+                ),
+              ],
               const SizedBox(height: EasySubwaySpacing.sm),
-              destinationChild,
+              Row(
+                children: [
+                  const SizedBox(
+                    width: EasySubwayTouchTarget.general + EasySubwaySpacing.sm,
+                  ),
+                  Expanded(child: destinationChild),
+                ],
+              ),
             ],
           ),
         ),
@@ -3751,39 +3867,80 @@ class _RoutePointPickerCard extends StatelessWidget {
   }
 }
 
+Widget _routeChromeIconButton({
+  required Key key,
+  required String semanticsLabel,
+  required IconData icon,
+  required VoidCallback onPressed,
+}) {
+  return Semantics(
+    button: true,
+    label: semanticsLabel,
+    onTap: onPressed,
+    child: ExcludeSemantics(
+      child: IconButton(
+        key: key,
+        onPressed: onPressed,
+        icon: Icon(icon, size: 22),
+        color: EasySubwayAccessibleColors.text,
+        style: IconButton.styleFrom(
+          minimumSize: const Size(
+            EasySubwayTouchTarget.general,
+            EasySubwayTouchTarget.general,
+          ),
+          backgroundColor: EasySubwayAccessibleColors.searchFieldSurface,
+          side: const BorderSide(
+            color: easySubwaySearchFieldBorderColor,
+            width: easySubwaySearchFieldBorderWidth,
+          ),
+          shape: RoundedRectangleBorder(
+            borderRadius: easySubwaySearchFieldRadius,
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
 class _RoutePointRow extends StatelessWidget {
   const _RoutePointRow({
-    required this.isOrigin,
+    required this.role,
     required this.station,
     required this.fallback,
     required this.onTap,
-    this.compact = false,
     super.key,
   });
 
-  final bool isOrigin;
+  final _RouteStationRole role;
   final StationSearchResult? station;
   final String fallback;
   final VoidCallback onTap;
 
-  /// #1933 E: 결과-우선 헤더에서는 역명을 조금 작게·세로 패딩을 좁힌다.
-  /// 키·시맨틱·탭 편집은 그대로 둔다.
-  final bool compact;
-
   @override
   Widget build(BuildContext context) {
-    final roleLabel = isOrigin ? '출발역' : '도착역';
-    final roleColor = isOrigin
-        ? EasySubwayFanMenuColors.departure
-        : EasySubwayFanMenuColors.arrival;
-    final stationName = station == null
+    final roleLabel = switch (role) {
+      _RouteStationRole.origin => '출발역',
+      _RouteStationRole.waypoint => '경유역',
+      _RouteStationRole.destination => '도착역',
+    };
+    final roleColor = switch (role) {
+      _RouteStationRole.origin => EasySubwayFanMenuColors.departure,
+      _RouteStationRole.waypoint => EasySubwayFanMenuColors.waypoint,
+      _RouteStationRole.destination => EasySubwayFanMenuColors.arrival,
+    };
+    final filledStation = station;
+    final lineForBadge = filledStation == null || filledStation.lines.isEmpty
+        ? null
+        : filledStation.lines.first;
+    final stationName = filledStation == null
         ? fallback
-        : _routeStationDisplayName(station!);
-    final semanticsLabel = station == null
+        : _routeStationDisplayName(filledStation);
+    final lineNameLabel = lineForBadge?.name.trim();
+    final semanticsLabel = filledStation == null
         ? stationName
-        : '$roleLabel $stationName';
-    final minHeight = compact ? 48.0 : 52.0;
-    final nameFontSize = compact ? 16.0 : 17.0;
+        : (lineNameLabel == null || lineNameLabel.isEmpty
+              ? '$roleLabel $stationName'
+              : '$roleLabel $lineNameLabel $stationName');
     return Semantics(
       button: true,
       label: semanticsLabel,
@@ -3795,68 +3952,73 @@ class _RoutePointRow extends StatelessWidget {
             onTap: onTap,
             borderRadius: easySubwaySearchFieldRadius,
             child: Ink(
+              height: easySubwaySearchFieldVisualHeight,
               decoration: BoxDecoration(
                 color: EasySubwayAccessibleColors.searchFieldSurface,
                 borderRadius: easySubwaySearchFieldRadius,
                 border: Border.all(
-                  color: EasySubwayAccessibleColors.line,
+                  color: easySubwaySearchFieldBorderColor,
                   width: easySubwaySearchFieldBorderWidth,
                 ),
               ),
-              child: ConstrainedBox(
-                constraints: BoxConstraints(minHeight: minHeight),
-                child: IntrinsicHeight(
-                  child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: [
-                      SizedBox(
-                        width: 72,
-                        child: Center(
-                          child: Text(
-                            roleLabel,
-                            maxLines: 1,
-                            softWrap: false,
-                            textAlign: TextAlign.center,
-                            style: TextStyle(
-                              color: roleColor,
-                              fontSize: 15,
-                              fontWeight: FontWeight.w700,
-                              height: 1.2,
-                            ),
-                          ),
+              child: Row(
+                children: [
+                  SizedBox(
+                    width: 72,
+                    child: Center(
+                      child: Text(
+                        roleLabel,
+                        maxLines: 1,
+                        softWrap: false,
+                        textAlign: TextAlign.center,
+                        style: TextStyle(
+                          color: roleColor,
+                          fontSize: 15,
+                          fontWeight: FontWeight.w700,
+                          height: 1.2,
                         ),
                       ),
-                      Container(
-                        width: easySubwaySearchFieldBorderWidth,
-                        color: EasySubwayAccessibleColors.line,
-                      ),
-                      Expanded(
-                        child: Padding(
-                          padding: EdgeInsets.symmetric(
-                            horizontal: 10,
-                            vertical: compact ? 10 : 12,
-                          ),
-                          child: Align(
-                            alignment: Alignment.centerLeft,
-                            child: Text(
-                              stationName,
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                              style: TextStyle(
-                                color: station == null
-                                    ? EasySubwayAccessibleColors.mutedText
-                                    : EasySubwayAccessibleColors.text,
-                                fontSize: nameFontSize,
-                                fontWeight: FontWeight.w700,
-                                height: 1.2,
+                    ),
+                  ),
+                  Container(
+                    width: easySubwaySearchFieldBorderWidth,
+                    height: double.infinity,
+                    color: easySubwaySearchFieldBorderColor,
+                  ),
+                  Expanded(
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 10),
+                      child: Align(
+                        alignment: Alignment.centerLeft,
+                        child: Row(
+                          children: [
+                            if (lineForBadge != null) ...[
+                              StationLineBadge(line: lineForBadge, size: 26),
+                              const SizedBox(width: 8),
+                            ],
+                            Expanded(
+                              child: Text(
+                                stationName,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: TextStyle(
+                                  color: filledStation == null
+                                      ? EasySubwayAccessibleColors.mutedText
+                                      : EasySubwayAccessibleColors.text,
+                                  fontSize: filledStation == null ? 15 : 17,
+                                  fontWeight: filledStation == null
+                                      ? FontWeight.w600
+                                      : FontWeight.w700,
+                                  height: 1.2,
+                                ),
                               ),
                             ),
-                          ),
+                          ],
                         ),
                       ),
-                    ],
+                    ),
                   ),
-                ),
+                ],
               ),
             ),
           ),
@@ -3878,26 +4040,14 @@ class _RouteSearchEmptyRedirect extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       key: const Key('routeSearchScreen'),
-      backgroundColor: EasySubwayAccessibleColors.scaffoldSurface,
-      appBar: AppBar(
-        toolbarHeight: 60,
-        backgroundColor: EasySubwayAccessibleColors.topBarSurface,
-        foregroundColor: EasySubwayAccessibleColors.text,
-        surfaceTintColor: Colors.transparent,
-        elevation: 0,
-        title: const Text(
-          '길찾기',
-          style: TextStyle(
-            color: EasySubwayAccessibleColors.text,
-            fontWeight: FontWeight.w700,
-            fontSize: 20,
-            height: 1.2,
-          ),
-        ),
-        flexibleSpace: const Align(
-          alignment: Alignment.bottomCenter,
-          child: EasySubwayHeaderDivider(),
-        ),
+      backgroundColor: EasySubwayAccessibleColors.surface,
+      appBar: _routeSearchAppBar(
+        onBack: () {
+          final navigator = Navigator.of(context);
+          if (navigator.canPop()) {
+            navigator.pop();
+          }
+        },
       ),
       bottomNavigationBar: shellNavigationBar,
       body: SafeArea(
@@ -3919,6 +4069,43 @@ class _RouteSearchEmptyRedirect extends StatelessWidget {
       ),
     );
   }
+}
+
+/// 설정·도움말과 같은 AppBar 골격: 뒤로가기 + 제목 + 하단 구분선(#2436).
+PreferredSizeWidget _routeSearchAppBar({required VoidCallback onBack}) {
+  return AppBar(
+    key: const Key('routeSearchAppBar'),
+    toolbarHeight: easySubwayTopBarContentHeight,
+    backgroundColor: EasySubwayAccessibleColors.topBarSurface,
+    foregroundColor: EasySubwayAccessibleColors.text,
+    surfaceTintColor: Colors.transparent,
+    elevation: 0,
+    automaticallyImplyLeading: false,
+    leading: IconButton(
+      key: const Key('routeSearchBackButton'),
+      tooltip: '뒤로',
+      onPressed: onBack,
+      style: IconButton.styleFrom(
+        minimumSize: const Size.square(EasySubwayTouchTarget.general),
+        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        padding: EdgeInsets.zero,
+      ),
+      icon: const Icon(Icons.arrow_back, size: 26, color: Color(0xFF4B4B4B)),
+    ),
+    title: const Text(
+      '길찾기',
+      style: TextStyle(
+        color: EasySubwayAccessibleColors.text,
+        fontWeight: FontWeight.w700,
+        fontSize: 20,
+        height: 1.2,
+      ),
+    ),
+    flexibleSpace: const Align(
+      alignment: Alignment.bottomCenter,
+      child: EasySubwayHeaderDivider(key: Key('routeSearchHeaderDivider')),
+    ),
+  );
 }
 
 class _RouteSectionHeader extends StatelessWidget {
@@ -3957,7 +4144,7 @@ bool _showsRouteDataQualityLabel(String dataQualityLevel) {
 
 class _RouteStationPicker extends StatefulWidget {
   const _RouteStationPicker({
-    required this.isOrigin,
+    required this.role,
     required this.labelText,
     required this.inputKey,
     required this.searchButtonKey,
@@ -3967,7 +4154,7 @@ class _RouteStationPicker extends StatefulWidget {
     required this.onSelected,
   });
 
-  final bool isOrigin;
+  final _RouteStationRole role;
   final String labelText;
   final Key inputKey;
   final Key searchButtonKey;
@@ -4010,99 +4197,98 @@ class _RouteStationPickerState extends State<_RouteStationPicker> {
   @override
   Widget build(BuildContext context) {
     final selectedStation = widget.selectedStation;
-    final roleColor = widget.isOrigin
-        ? EasySubwayFanMenuColors.departure
-        : EasySubwayFanMenuColors.arrival;
+    final roleColor = switch (widget.role) {
+      _RouteStationRole.origin => EasySubwayFanMenuColors.departure,
+      _RouteStationRole.waypoint => EasySubwayFanMenuColors.waypoint,
+      _RouteStationRole.destination => EasySubwayFanMenuColors.arrival,
+    };
     // 요약 행(_RoutePointRow)과 같은 검색필드 크롬 위에서 인라인 검색한다.
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         Container(
-          constraints: const BoxConstraints(minHeight: 52),
+          height: easySubwaySearchFieldVisualHeight,
           decoration: BoxDecoration(
             color: EasySubwayAccessibleColors.searchFieldSurface,
             borderRadius: easySubwaySearchFieldRadius,
             border: Border.all(
-              color: EasySubwayAccessibleColors.line,
+              color: easySubwaySearchFieldBorderColor,
               width: easySubwaySearchFieldBorderWidth,
             ),
           ),
           clipBehavior: Clip.antiAlias,
-          child: IntrinsicHeight(
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                SizedBox(
-                  width: 72,
-                  child: Center(
-                    child: Text(
-                      widget.labelText,
-                      maxLines: 1,
-                      softWrap: false,
-                      textAlign: TextAlign.center,
-                      style: TextStyle(
-                        color: roleColor,
-                        fontSize: 15,
-                        fontWeight: FontWeight.w700,
-                        height: 1.2,
-                      ),
+          child: Row(
+            children: [
+              SizedBox(
+                width: 72,
+                child: Center(
+                  child: Text(
+                    widget.labelText,
+                    maxLines: 1,
+                    softWrap: false,
+                    textAlign: TextAlign.center,
+                    style: TextStyle(
+                      color: roleColor,
+                      fontSize: 15,
+                      fontWeight: FontWeight.w700,
+                      height: 1.2,
                     ),
                   ),
                 ),
-                Container(
-                  width: easySubwaySearchFieldBorderWidth,
-                  color: EasySubwayAccessibleColors.line,
-                ),
-                Expanded(
-                  child: Semantics(
-                    label: selectedStation == null
-                        ? '${widget.labelText} 입력'
-                        : '${widget.labelText} 선택됨, ${selectedStation.nameKo}',
-                    textField: true,
-                    liveRegion: selectedStation != null,
-                    child: TextField(
-                      key: widget.inputKey,
-                      controller: _textController,
-                      minLines: 1,
-                      textInputAction: TextInputAction.search,
-                      style: easySubwaySearchFieldInputStyle,
-                      decoration: InputDecoration(
-                        isDense: true,
-                        contentPadding: const EdgeInsets.symmetric(
-                          horizontal: 10,
-                          vertical: 12,
-                        ),
-                        hintText: '역 이름을 입력해 주세요',
-                        hintStyle: easySubwaySearchFieldHintStyle,
-                        filled: true,
-                        fillColor: Colors.transparent,
-                        border: InputBorder.none,
-                        enabledBorder: InputBorder.none,
-                        focusedBorder: InputBorder.none,
-                        suffixIcon: AnimatedBuilder(
-                          animation: _controller,
-                          builder: (context, _) {
-                            final isLoading =
-                                _controller.state.status ==
-                                StationSearchStatus.loading;
-                            return IconButton(
-                              key: widget.searchButtonKey,
-                              tooltip: '${widget.labelText} 검색',
-                              onPressed: isLoading ? null : _search,
-                              icon: const Icon(
-                                Icons.search,
-                                color: EasySubwayAccessibleColors.iconMuted,
-                              ),
-                            );
-                          },
-                        ),
+              ),
+              Container(
+                width: easySubwaySearchFieldBorderWidth,
+                height: double.infinity,
+                color: easySubwaySearchFieldBorderColor,
+              ),
+              Expanded(
+                child: Semantics(
+                  label: selectedStation == null
+                      ? '${widget.labelText} 입력'
+                      : '${widget.labelText} 선택됨, ${selectedStation.nameKo}',
+                  textField: true,
+                  liveRegion: selectedStation != null,
+                  child: TextField(
+                    key: widget.inputKey,
+                    controller: _textController,
+                    maxLines: 1,
+                    textInputAction: TextInputAction.search,
+                    style: easySubwaySearchFieldInputStyle,
+                    decoration: InputDecoration(
+                      isDense: true,
+                      contentPadding: const EdgeInsets.symmetric(
+                        horizontal: 10,
                       ),
-                      onSubmitted: (_) => _search(),
+                      hintText: '역 이름을 입력해 주세요',
+                      hintStyle: easySubwaySearchFieldHintStyle,
+                      filled: true,
+                      fillColor: Colors.transparent,
+                      border: InputBorder.none,
+                      enabledBorder: InputBorder.none,
+                      focusedBorder: InputBorder.none,
+                      suffixIcon: AnimatedBuilder(
+                        animation: _controller,
+                        builder: (context, _) {
+                          final isLoading =
+                              _controller.state.status ==
+                              StationSearchStatus.loading;
+                          return IconButton(
+                            key: widget.searchButtonKey,
+                            tooltip: '${widget.labelText} 검색',
+                            onPressed: isLoading ? null : _search,
+                            icon: const Icon(
+                              Icons.search,
+                              color: EasySubwayAccessibleColors.iconMuted,
+                            ),
+                          );
+                        },
+                      ),
                     ),
+                    onSubmitted: (_) => _search(),
                   ),
                 ),
-              ],
-            ),
+              ),
+            ],
           ),
         ),
         const SizedBox(height: EasySubwaySpacing.sm),
@@ -4122,9 +4308,7 @@ class _RouteStationPickerState extends State<_RouteStationPicker> {
   }
 
   void _search() {
-    if (_controller.state.status == StationSearchStatus.loading) {
-      return;
-    }
+    // 진행 중 검색은 requestId로 무효화되므로 loading이어도 막지 않는다.
     _controller.search(_textController.text);
   }
 
@@ -4182,6 +4366,8 @@ class _RouteStationSearchBody extends StatelessWidget {
   Widget build(BuildContext context) {
     return switch (state.status) {
       StationSearchStatus.idle => const SizedBox.shrink(),
+      StationSearchStatus.loading when state.results.isNotEmpty =>
+        _buildResults(announceSearching: true),
       StationSearchStatus.loading => Semantics(
         label: '$labelText 검색 중',
         liveRegion: true,
@@ -4194,27 +4380,33 @@ class _RouteStationSearchBody extends StatelessWidget {
       ),
       StationSearchStatus.empty || StationSearchStatus.failure =>
         _RouteSearchMessage(message: state.message, liveRegion: true),
-      StationSearchStatus.success => Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Semantics(
-            label: '$labelText 검색 결과 ${state.results.length}개',
-            liveRegion: true,
-            child: const SizedBox.shrink(),
-          ),
-          for (final entry in state.results.indexed) ...[
-            if (entry.$1 > 0)
-              const Divider(height: 1, color: EasySubwayAccessibleColors.line),
-            _RouteStationOptionTile(
-              key: Key('$optionKeyPrefix-${entry.$2.id}'),
-              labelText: labelText,
-              result: entry.$2,
-              onSelected: onSelected,
-            ),
-          ],
-        ],
-      ),
+      StationSearchStatus.success => _buildResults(announceSearching: false),
     };
+  }
+
+  Widget _buildResults({required bool announceSearching}) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Semantics(
+          label: announceSearching
+              ? '$labelText 검색 중'
+              : '$labelText 검색 결과 ${state.results.length}개',
+          liveRegion: true,
+          child: const SizedBox.shrink(),
+        ),
+        for (final entry in state.results.indexed) ...[
+          if (entry.$1 > 0)
+            const Divider(height: 1, color: EasySubwayAccessibleColors.line),
+          _RouteStationOptionTile(
+            key: Key('$optionKeyPrefix-${entry.$2.id}'),
+            labelText: labelText,
+            result: entry.$2,
+            onSelected: onSelected,
+          ),
+        ],
+      ],
+    );
   }
 }
 
@@ -5748,7 +5940,7 @@ class _RouteResultListButton extends StatelessWidget {
                 color: EasySubwayAccessibleColors.surface,
                 borderRadius: easySubwaySearchFieldRadius,
                 border: Border.all(
-                  color: EasySubwayAccessibleColors.line,
+                  color: easySubwaySearchFieldBorderColor,
                   width: easySubwaySearchFieldBorderWidth,
                 ),
               ),
@@ -6045,7 +6237,7 @@ class _RouteStatusChip extends StatelessWidget {
         color: EasySubwayAccessibleColors.searchFieldSurface,
         borderRadius: _routeSearchPillRadius,
         border: Border.all(
-          color: EasySubwayAccessibleColors.line,
+          color: easySubwaySearchFieldBorderColor,
           width: easySubwaySearchFieldBorderWidth,
         ),
       ),

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -3923,11 +3923,6 @@ class _RoutePointRow extends StatelessWidget {
       _RouteStationRole.waypoint => '경유역',
       _RouteStationRole.destination => '도착역',
     };
-    final roleColor = switch (role) {
-      _RouteStationRole.origin => EasySubwayFanMenuColors.departure,
-      _RouteStationRole.waypoint => EasySubwayFanMenuColors.waypoint,
-      _RouteStationRole.destination => EasySubwayFanMenuColors.arrival,
-    };
     final filledStation = station;
     final lineForBadge = filledStation == null || filledStation.lines.isEmpty
         ? null
@@ -3971,8 +3966,9 @@ class _RoutePointRow extends StatelessWidget {
                         maxLines: 1,
                         softWrap: false,
                         textAlign: TextAlign.center,
-                        style: TextStyle(
-                          color: roleColor,
+                        style: const TextStyle(
+                          // 역할 색은 배지 등 비텍스트에만. 라벨은 AA 통과 본문색.
+                          color: EasySubwayAccessibleColors.text,
                           fontSize: 15,
                           fontWeight: FontWeight.w700,
                           height: 1.2,
@@ -4197,11 +4193,6 @@ class _RouteStationPickerState extends State<_RouteStationPicker> {
   @override
   Widget build(BuildContext context) {
     final selectedStation = widget.selectedStation;
-    final roleColor = switch (widget.role) {
-      _RouteStationRole.origin => EasySubwayFanMenuColors.departure,
-      _RouteStationRole.waypoint => EasySubwayFanMenuColors.waypoint,
-      _RouteStationRole.destination => EasySubwayFanMenuColors.arrival,
-    };
     // 요약 행(_RoutePointRow)과 같은 검색필드 크롬 위에서 인라인 검색한다.
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -4227,8 +4218,9 @@ class _RouteStationPickerState extends State<_RouteStationPicker> {
                     maxLines: 1,
                     softWrap: false,
                     textAlign: TextAlign.center,
-                    style: TextStyle(
-                      color: roleColor,
+                    style: const TextStyle(
+                      // 역할 색은 배지 등 비텍스트에만. 라벨은 AA 통과 본문색.
+                      color: EasySubwayAccessibleColors.text,
                       fontSize: 15,
                       fontWeight: FontWeight.w700,
                       height: 1.2,
@@ -4269,13 +4261,11 @@ class _RouteStationPickerState extends State<_RouteStationPicker> {
                       suffixIcon: AnimatedBuilder(
                         animation: _controller,
                         builder: (context, _) {
-                          final isLoading =
-                              _controller.state.status ==
-                              StationSearchStatus.loading;
                           return IconButton(
                             key: widget.searchButtonKey,
                             tooltip: '${widget.labelText} 검색',
-                            onPressed: isLoading ? null : _search,
+                            // Enter(onSubmitted)와 같이 loading 중에도 재검색을 허용한다.
+                            onPressed: _search,
                             icon: const Icon(
                               Icons.search,
                               color: EasySubwayAccessibleColors.iconMuted,

--- a/apps/mobile/lib/search_field.dart
+++ b/apps/mobile/lib/search_field.dart
@@ -6,21 +6,26 @@ import 'accessible_design.dart';
 
 /// #2083 홈 노선도 편집 모드와 역 검색 화면의 입력 필드가 픽셀 단위로 동일한
 /// 시각 규격을 공유하도록 추출한 공용 검색 입력 위젯. 두 화면이 같은 시각
-/// 껍데기(46px 박스·아이콘 배치·단일 줄 TextField·지우기 버튼)를 소비해 규격이
+/// 껍데기(40px 박스·아이콘 배치·단일 줄 TextField·지우기 버튼)를 소비해 규격이
 /// 어긋나지 않게 한다. 홈 idle 검색 버튼도 아래 공유 상수를 참조해 탭 전환 시
 /// 박스가 점프하지 않는다(#1933).
 
 /// idle/active 시각 박스 radius(8).
 const easySubwaySearchFieldRadius = BorderRadius.all(Radius.circular(8));
 
-/// idle/active가 공유하는 시각 박스 높이(46). 바깥 터치타겟(56)과 분리된다.
-const easySubwaySearchFieldVisualHeight = 46.0;
+/// idle/active가 공유하는 시각 박스 높이(40). 바깥 터치타겟(56)과 분리된다.
+/// 17sp 입력 글자 대비 내부 상하 여백을 줄여 검색창이 덜 헐렁하게 보이게 한다(#2436).
+const easySubwaySearchFieldVisualHeight = 40.0;
 
 /// 시각 박스 좌우 내부 패딩(12).
 const easySubwaySearchFieldHorizontalPadding = 12.0;
 
-/// 시각 박스 테두리 두께(1.5).
-const easySubwaySearchFieldBorderWidth = 1.5;
+/// 시각 박스 테두리 두께(1.0). 선 색은 전역 [EasySubwayAccessibleColors.line]보다
+/// 진하게 두어 얇아도 윤곽이 읽히게 한다(#2436).
+const easySubwaySearchFieldBorderWidth = 1.0;
+
+/// 검색·출발/도착/경유 박스 외곽선. 상단 구분선([easySubwayHeaderDividerColor])과 동일.
+const easySubwaySearchFieldBorderColor = easySubwayHeaderDividerColor;
 
 /// 검색/지우기 아이콘 시각 크기(22).
 const easySubwaySearchFieldIconSize = 22.0;
@@ -47,12 +52,12 @@ const easySubwaySearchFieldInputStyle = TextStyle(
 );
 
 /// 홈 편집 모드와 역 검색 화면이 공유하는 편집 가능한 검색 입력 필드. 바깥
-/// 터치타겟(56)은 확보하되, 안쪽 시각 박스는 46px 고정 높이·패딩(12)·테두리·
+/// 터치타겟(56)은 확보하되, 안쪽 시각 박스는 40px 고정 높이·패딩(12)·테두리·
 /// 아이콘 배치를 공유 상수로 재사용한다. TextField 자체는 border/배경 없이 텍스트
 /// 편집만 담당하고, 시각적 테두리·배경·아이콘은 시각 껍데기 Container가 그린다.
 ///
-/// 시각(46px 박스)과 히트 영역(≥48px)은 Stack으로 분리한다: 배경 레이어가
-/// 46px 시각 껍데기를 그리고, 그 위 Positioned.fill 레이어에서 TextField가
+/// 시각(40px 박스)과 히트 영역(≥48px)은 Stack으로 분리한다: 배경 레이어가
+/// 40px 시각 껍데기를 그리고, 그 위 Positioned.fill 레이어에서 TextField가
 /// 바깥 터치타겟 높이(56)를 그대로 채우며 지우기 IconButton도 독립적인
 /// 48x48 탭 타깃을 갖는다. TextField와 지우기 버튼을 하나의 semantics로
 /// 병합하지 않아야 스크린리더 사용자가 '검색어 지우기' 액션에 별도로 접근할
@@ -90,10 +95,10 @@ class EasySubwaySearchField extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final editController = controller;
-    // #2090: 시스템 글자 배율을 키우면 고정 높이(시각 박스 46·입력 필드 48/56)가
+    // #2090: 시스템 글자 배율을 키우면 고정 높이(시각 박스 40·입력 필드 48/56)가
     // 확대된 입력 줄을 세로로 잘라 WCAG 1.4.4를 위반한다. 배율에 비례해 시각 박스와
     // 터치타겟이 함께 자라도록 배율을 곱해 높이를 재도출한다. clamp(min: 1.0)로
-    // 축소는 하지 않아 기본 배율(1.0)에서는 46/48/56 픽셀이 그대로 보존된다.
+    // 축소는 하지 않아 기본 배율(1.0)에서는 40/48/56 픽셀이 그대로 보존된다.
     final scaler = MediaQuery.textScalerOf(context);
     // 바깥 터치타겟: 기본 56, 배율에 비례해 확대(입력 줄이 자라도 필드가
     // 터치타겟보다 작아지지 않게). 배율 1.0에서 정확히 56.
@@ -102,19 +107,19 @@ class EasySubwaySearchField extends StatelessWidget {
       scaler.scale(EasySubwayTouchTarget.general),
     );
     // #2082 재작업: 편집 텍스트를 홈 idle 검색 필드와 동일한 폰트 메트릭 독립
-    // 방식으로 중앙 정렬한다. idle 필드는 Container(height 46) 안 Row가 고유 높이
+    // 방식으로 중앙 정렬한다. idle 필드는 Container(height 40) 안 Row가 고유 높이
     // Text를 crossAxis 중앙에 놓아 실기기 Noto Sans KR에서도 오프셋 0으로
     // 정합한다. 편집 필드도 TextField를 고유 높이(글자 줄)로 두고 Center로 시각
     // 박스 중앙에 놓아, 절대값 비대칭 패딩(구 21/9) 없이 동일 정합을 얻는다.
     // 비대칭 패딩은 FlutterTest 테스트 폰트 기준으로 맞춰 실기기 폰트에서는
-    // 편향됐다(#2082 실기기 QA). 시각 박스 높이: 기본 46, 배율에 비례해 확대.
+    // 편향됐다(#2082 실기기 QA). 시각 박스 높이: 기본 40, 배율에 비례해 확대.
     final visualBoxHeight = math.max(
       easySubwaySearchFieldVisualHeight,
       scaler.scale(easySubwaySearchFieldVisualHeight),
     );
     final field = ConstrainedBox(
       // 터치 타겟(≥48, 실제로는 56)을 만족시키기 위해 필드 자체가 전체 높이를
-      // 차지한다. 시각적 박스(46px)는 배경 레이어 Container가 idle 필드와
+      // 차지한다. 시각적 박스(40px)는 배경 레이어 Container가 idle 필드와
       // 동일하게 그리고, 입력/버튼 히트 영역은 그 위 레이어에서 시각 박스와
       // 독립적으로 ≥48px를 확보한다. 고정 높이 대신 minHeight를 써서 배율 확대
       // 시 안쪽 입력 줄이 세로로 자라도 잘리지 않게 한다(#2090).
@@ -122,11 +127,11 @@ class EasySubwaySearchField extends StatelessWidget {
       child: Stack(
         alignment: Alignment.center,
         children: [
-          // 시각 껍데기: idle 필드와 픽셀 단위로 동일(높이 46, radius 8,
-          // line 1.5, surface 배경). 히트 영역과 분리된 순수 배경이다.
+          // 시각 껍데기: idle 필드와 픽셀 단위로 동일(높이 40, radius 8,
+          // border 1.0·진한 외곽, surface 배경). 히트 영역과 분리된 순수 배경이다.
           // heroStationSearchInputBox 키는 홈/역 검색 두 화면 위젯 테스트가
           // 시각 박스 높이·중앙 정합을 검증하는 데 쓴다(두 화면은 동시에
-          // 렌더되지 않아 키 충돌 없음). 배율 1.0에서는 46 고정, 확대 시 배율에
+          // 렌더되지 않아 키 충돌 없음). 배율 1.0에서는 40 고정, 확대 시 배율에
           // 비례해 커져 확대된 입력 줄을 담는다.
           Container(
             key: const Key('heroStationSearchInputBox'),
@@ -134,7 +139,7 @@ class EasySubwaySearchField extends StatelessWidget {
             decoration: BoxDecoration(
               color: EasySubwayAccessibleColors.searchFieldSurface,
               border: Border.all(
-                color: EasySubwayAccessibleColors.line,
+                color: easySubwaySearchFieldBorderColor,
                 width: easySubwaySearchFieldBorderWidth,
               ),
               borderRadius: easySubwaySearchFieldRadius,
@@ -142,7 +147,7 @@ class EasySubwaySearchField extends StatelessWidget {
           ),
           Positioned.fill(
             child: Padding(
-              // idle의 콘텐츠 시작 위치와 동일: 테두리(1.5) + 패딩(12).
+              // idle의 콘텐츠 시작 위치와 동일: 테두리(1.0) + 패딩(12).
               padding: const EdgeInsets.symmetric(
                 horizontal:
                     easySubwaySearchFieldBorderWidth +
@@ -178,8 +183,8 @@ class EasySubwaySearchField extends StatelessWidget {
                       child: _maybeWrapSemantics(
                         // 터치타겟(56·배율확대) 안에서 단일 줄 필드를 세로 중앙에
                         // 놓는다. TextField는 고유 높이(글자 줄 높이 + isDense 최소
-                        // 여백)로 두고 Center가 그 줄을 46px 시각 박스 중앙(=터치타겟
-                        // 중앙)에 정렬한다. idle 필드가 Container(46) 안 Row로 고유
+                        // 여백)로 두고 Center가 그 줄을 40px 시각 박스 중앙(=터치타겟
+                        // 중앙)에 정렬한다. idle 필드가 Container(40) 안 Row로 고유
                         // 높이 Text를 중앙에 놓는 것과 같은 폰트 메트릭 독립 원리라,
                         // 실기기 Noto Sans KR에서 hint·캐럿·입력 글자가 시각 박스
                         // 중앙에 오프셋 0으로 정합함을 픽셀 판독으로 확인했다(정본 —
@@ -187,7 +192,7 @@ class EasySubwaySearchField extends StatelessWidget {
                         // textAlignVertical 조합은 실기기에서 입력 줄을 위/아래로
                         // 편향시켜 버렸다.
                         //
-                        // 입력 필드 자체(고유 높이)의 semantics 노드는 46 미만이지만,
+                        // 입력 필드 자체(고유 높이)의 semantics 노드는 40 미만이지만,
                         // 바깥 SizedBox(56)와 함께 MergeSemantics로 병합해 탭 타깃
                         // semantics 노드가 터치타겟 높이(≥48)를 갖게 한다(접근성 최소
                         // 탭 타깃). 지우기 버튼은 이 병합 밖 형제라 자체 탭 타깃·
@@ -241,7 +246,7 @@ class EasySubwaySearchField extends StatelessWidget {
                         }
                         // 시각 아이콘은 22px이지만 탭 타깃은 독립적으로 48x48을
                         // 확보한다(top bar IconButton 패턴과 동일). 히트 영역은
-                        // 46px 시각 박스 밖으로 넘치되 바깥 56px 터치타겟 안에
+                        // 40px 시각 박스 밖으로 넘치되 바깥 56px 터치타겟 안에
                         // 머물러 시각 박스 높이를 밀어 올리지 않는다.
                         return IconButton(
                           tooltip: '검색어 지우기',

--- a/apps/mobile/lib/search_field.dart
+++ b/apps/mobile/lib/search_field.dart
@@ -24,8 +24,9 @@ const easySubwaySearchFieldHorizontalPadding = 12.0;
 /// 진하게 두어 얇아도 윤곽이 읽히게 한다(#2436).
 const easySubwaySearchFieldBorderWidth = 1.0;
 
-/// 검색·출발/도착/경유 박스 외곽선. 상단 구분선([easySubwayHeaderDividerColor])과 동일.
-const easySubwaySearchFieldBorderColor = easySubwayHeaderDividerColor;
+/// 검색·출발/도착/경유 박스 외곽선.
+/// 표면 `#F6F8F9` 대비 약 3:1 이상인 전용 색(구분선 `#C5CDD4`와 분리).
+const easySubwaySearchFieldBorderColor = Color(0xFF8A9AA0);
 
 /// 검색/지우기 아이콘 시각 크기(22).
 const easySubwaySearchFieldIconSize = 22.0;

--- a/apps/mobile/release/post-launch-operations-review-gate.json
+++ b/apps/mobile/release/post-launch-operations-review-gate.json
@@ -73,7 +73,7 @@
             {"path": "apps/mobile/lib/features/account/presentation/user_data_deletion_screen.dart", "sha256": "58a527c44cfa1e19876f753d1433dac6952b32cf89bd29f42b15330033249484"},
             {"path": "apps/mobile/lib/features/attribution/presentation/data_source_attribution_screen.dart", "sha256": "7ef5b7236a008f54a22040931f294b00192987fe35cc56fc94ebc2d815ef4620"},
             {"path": "apps/mobile/lib/features/favorites/presentation/favorite_home_screen.dart", "sha256": "15ff6434e2e0584ed7f0404ebeb9dde62cfe1eaf04ab8e5f95c5e21d10a41edc"},
-            {"path": "apps/mobile/lib/features/home/presentation/home_screen.dart", "sha256": "7d7b8e91f87b3682525ee64396870133d24b71bd482df0841c9e31b76807c547"},
+            {"path": "apps/mobile/lib/features/home/presentation/home_screen.dart", "sha256": "fb2ef48145e91b9f4872a7f3331a46114b3f09c7eed76a2c7ad5c36d215e3e92"},
             {"path": "apps/mobile/lib/features/settings/presentation/app_settings_screen.dart", "sha256": "a25942153cb6d2bbfeaab6054c09f7e6813026596c635292d5b36b50714f81e8"},
             {"path": "apps/mobile/lib/features/settings/presentation/open_source_licenses_screen.dart", "sha256": "822762b61cd3824340c4e45cf5ffe3079e221d28712dd98d94fd9a03fe5fd591"},
             {"path": "apps/mobile/lib/features/settings/presentation/service_info_screen.dart", "sha256": "00fff84a415da6d5041c2e7bedbc453c251867058307c47478ead118d20d04c4"},

--- a/apps/mobile/test/accessibility_baseline_test.dart
+++ b/apps/mobile/test/accessibility_baseline_test.dart
@@ -155,7 +155,10 @@ OnboardingState _completedOnboardingState({
 
 class _AccessibilityStationSearchRepository implements StationSearchRepository {
   @override
-  Future<List<StationSearchResult>> searchStations(String query) {
+  Future<List<StationSearchResult>> searchStations(
+    String query, {
+    String? region,
+  }) {
     throw UnimplementedError('접근성 기준선 테스트는 역 검색 API를 호출하지 않는다.');
   }
 

--- a/apps/mobile/test/core/database/mobile_local_database_test.dart
+++ b/apps/mobile/test/core/database/mobile_local_database_test.dart
@@ -745,7 +745,7 @@ void main() {
     expect((additionalSteps[8] as Map)['distanceMeters'], 8000);
   });
 
-  test('내장 데이터팩은 로컬 역 검색 repository에서 역 번호 검색을 제공한다', () async {
+  test('로컬 역 검색은 역 번호가 아니라 역 이름으로만 찾는다', () async {
     final directory = await Directory.systemTemp.createTemp(
       'easysubway-catalog-search-',
     );
@@ -758,10 +758,12 @@ void main() {
     addTearDown(database.close);
     final repository = DriftStationRepository(database: database);
 
-    final results = await repository.searchStations('448');
+    // stationCode(예: 448)는 검색 대상이 아니다. 역 이름만 매칭한다.
+    expect(await repository.searchStations('448'), isEmpty);
 
-    expect(results, hasLength(1));
-    expect(results.single.id, 'station-sangnoksu');
+    final byName = await repository.searchStations('상록수');
+    expect(byName, isNotEmpty);
+    expect(byName.any((station) => station.id == 'station-sangnoksu'), isTrue);
   });
 
   test('내장 데이터팩은 설치된 파일이 손상되어 있으면 번들 asset으로 교체한다', () async {

--- a/apps/mobile/test/easy_subway_app_defaults_test.dart
+++ b/apps/mobile/test/easy_subway_app_defaults_test.dart
@@ -64,7 +64,10 @@ OnboardingState _completedOnboardingState() {
 
 class _UnusedStationSearchRepository implements StationSearchRepository {
   @override
-  Future<List<StationSearchResult>> searchStations(String query) {
+  Future<List<StationSearchResult>> searchStations(
+    String query, {
+    String? region,
+  }) {
     throw UnimplementedError();
   }
 

--- a/apps/mobile/test/features/stations/drift_station_repository_test.dart
+++ b/apps/mobile/test/features/stations/drift_station_repository_test.dart
@@ -34,7 +34,9 @@ void main() {
       "('station-surisan', '수리산', 'Surisan', '', '수리산', "
       "'수도권', 'LEVEL_1', 'OFFICIAL_FILE'), "
       "('station-sanbon', '산본', 'Sanbon', '', '산본', "
-      "'수도권', 'LEVEL_1', 'OFFICIAL_FILE')",
+      "'수도권', 'LEVEL_1', 'OFFICIAL_FILE'), "
+      "('station-seomyeon', '서면', 'Seomyeon', '', '서면', "
+      "'부산', 'LEVEL_1', 'OFFICIAL_FILE')",
     );
     final repository = DriftStationRepository(database: database);
 
@@ -44,6 +46,10 @@ void main() {
     final bySb = await repository.searchStations('ㅅㅂ');
     expect(bySb.map((s) => s.nameKo), contains('산본'));
     expect(bySb.map((s) => s.nameKo), isNot(contains('수리산')));
+
+    final busanOnly = await repository.searchStations('ㅅ', region: '부산');
+    expect(busanOnly.map((s) => s.nameKo), contains('서면'));
+    expect(busanOnly.map((s) => s.region), everyElement('부산'));
   });
 
   test('로컬 역 검색은 호선명·역번호만으로는 결과를 내지 않는다', () async {

--- a/apps/mobile/test/features/stations/drift_station_repository_test.dart
+++ b/apps/mobile/test/features/stations/drift_station_repository_test.dart
@@ -6,19 +6,56 @@ import 'package:easysubway_mobile/features/stations/domain/station_repositories.
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test('로컬 역 검색은 역명과 역 suffix, 영문명, 역 번호, 노선명 검색어를 같은 역으로 찾는다', () async {
+  test('로컬 역 검색은 역명·역 suffix·영문명만으로 찾는다', () async {
     final database = CatalogDatabase.memory();
     addTearDown(database.close);
     await database.seedBaselineIfEmpty();
     final repository = DriftStationRepository(database: database);
 
-    for (final query in ['상록수', '상록수역', 'Sangnoksu', '448', '4호선 상록수']) {
+    for (final query in ['상록수', '상록수역', 'Sangnoksu']) {
       final results = await repository.searchStations(query);
 
       expect(results, hasLength(1), reason: query);
       expect(results.single.id, 'station-sangnoksu', reason: query);
       expect(results.single.nameKo, '상록수', reason: query);
       expect(results.single.lines.single.stationCode, '448', reason: query);
+    }
+  });
+
+  test('로컬 역 검색은 초성 질의로 역명 접두를 찾는다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await database.seedBaselineIfEmpty();
+    await database.customStatement(
+      "INSERT INTO stations "
+      "(id, name_ko, name_en, name_sub, normalized_name, region, "
+      "data_quality_level, data_source_type) "
+      "VALUES "
+      "('station-surisan', '수리산', 'Surisan', '', '수리산', "
+      "'수도권', 'LEVEL_1', 'OFFICIAL_FILE'), "
+      "('station-sanbon', '산본', 'Sanbon', '', '산본', "
+      "'수도권', 'LEVEL_1', 'OFFICIAL_FILE')",
+    );
+    final repository = DriftStationRepository(database: database);
+
+    final byS = await repository.searchStations('ㅅ');
+    expect(byS.map((s) => s.nameKo), containsAll(['수리산', '산본', '상록수']));
+
+    final bySb = await repository.searchStations('ㅅㅂ');
+    expect(bySb.map((s) => s.nameKo), contains('산본'));
+    expect(bySb.map((s) => s.nameKo), isNot(contains('수리산')));
+  });
+
+  test('로컬 역 검색은 호선명·역번호만으로는 결과를 내지 않는다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await database.seedBaselineIfEmpty();
+    final repository = DriftStationRepository(database: database);
+
+    for (final query in ['448', '4호선', '4호선 상록수', '수인분당선']) {
+      final results = await repository.searchStations(query);
+
+      expect(results, isEmpty, reason: query);
     }
   });
 

--- a/apps/mobile/test/features/stations/station_search_screen_test.dart
+++ b/apps/mobile/test/features/stations/station_search_screen_test.dart
@@ -8,6 +8,7 @@ import 'package:easysubway_mobile/features/stations/domain/station_models.dart';
 import 'package:easysubway_mobile/features/stations/domain/station_repositories.dart';
 import 'package:easysubway_mobile/features/stations/presentation/station_search_screen.dart';
 import 'package:easysubway_mobile/onboarding.dart';
+import 'package:easysubway_mobile/search_field.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -22,7 +23,7 @@ const _completedOnboardingState = OnboardingState.completed(
 );
 
 void main() {
-  testWidgets('#2083 역 검색 화면은 홈 편집 모드와 같은 46px 시각 박스·중앙 정렬 입력 필드를 렌더한다', (
+  testWidgets('#2083 역 검색 화면은 홈 편집 모드와 같은 40px 시각 박스·중앙 정렬 입력 필드를 렌더한다', (
     tester,
   ) async {
     await tester.pumpWidget(
@@ -37,10 +38,10 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    // 홈 편집 모드와 동일한 공용 시각 박스(46px)를 렌더한다.
+    // 홈 편집 모드와 동일한 공용 시각 박스(40px)를 렌더한다.
     expect(
       tester.getSize(find.byKey(const Key('heroStationSearchInputBox'))).height,
-      46.0,
+      easySubwaySearchFieldVisualHeight,
     );
 
     // pickSlot별 힌트가 placeholder(이자 TalkBack 라벨)로 렌더된다. #2083 오너
@@ -59,7 +60,7 @@ void main() {
       greaterThanOrEqualTo(48.0),
     );
 
-    // 편집 텍스트가 46px 시각 박스 안에 렌더돼야 한다(#2082 수정을 공용 위젯이
+    // 편집 텍스트가 40px 시각 박스 안에 렌더돼야 한다(#2082 수정을 공용 위젯이
     // 소비함을 검증). #2082 실기기 재작업: 중앙 정렬은 고유 높이 필드 + Center
     // 위젯으로 얻으며 실기기(Noto Sans KR)에서 오프셋 0으로 정합함을 픽셀 판독으로
     // 확인했다(docs/2082-qa, 정본). FlutterTest 테스트 폰트·AppBar toolbar 배치
@@ -533,7 +534,8 @@ void main() {
         find.byKey(const Key('stationSearchInput')),
       );
       expect(searchInput.controller?.text, '상록수');
-      expect(repository.requestedQueries, ['상록수']);
+      // 최근 목록 호선 마크용 조회·재로드가 섞이므로 제출 기록만 본다.
+      expect(repository.requestedQueries, contains('상록수'));
       expect(searchHistoryRepository.recordedQueries, ['상록수']);
       expect(
         find.byKey(const Key('stationSearchResult-station-sangnoksu-seoul-4')),
@@ -638,7 +640,10 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('상록수역 → 사당역'), findsOneWidget);
+    // 경로 최근 항목은 역마다 호선 마크+이름을 나눠 그린다(한 줄 문자열 아님).
+    expect(find.text('상록수역'), findsOneWidget);
+    expect(find.text('사당역'), findsOneWidget);
+    expect(find.text('→'), findsOneWidget);
     expect(
       find.byKey(
         const Key('recentRouteSearch-station-sangnoksu--station-sadang'),
@@ -798,7 +803,11 @@ class _MemorySearchHistoryRepository implements SearchHistoryRepository {
   DateTime _tick() =>
       DateTime.fromMillisecondsSinceEpoch(++_clock, isUtc: true);
 
-  void _addStation(String query, {String? region}) {
+  void _addStation(
+    String query, {
+    String? region,
+    List<StationSearchLine> lines = const [],
+  }) {
     final normalized = region?.trim() ?? '';
     _stations.removeWhere(
       (entry) =>
@@ -810,6 +819,7 @@ class _MemorySearchHistoryRepository implements SearchHistoryRepository {
         query: query,
         region: normalized.isEmpty ? null : normalized,
         searchedAt: _tick(),
+        lines: lines,
       ),
     );
   }
@@ -860,14 +870,23 @@ class _MemorySearchHistoryRepository implements SearchHistoryRepository {
   }
 
   @override
-  Future<void> recordSearch(String query, {String? region}) async {
+  Future<void> recordSearch(
+    String query, {
+    String? region,
+    String? stationId,
+    StationSearchLine? line,
+  }) async {
     final trimmed = query.trim();
     final normalized = region?.trim() ?? '';
     if (trimmed.isEmpty || normalized.isEmpty) {
       return;
     }
     recordedQueries.add(trimmed);
-    _addStation(trimmed, region: normalized);
+    _addStation(
+      trimmed,
+      region: normalized,
+      lines: line == null || line.id.trim().isEmpty ? const [] : [line],
+    );
   }
 
   @override

--- a/apps/mobile/test/features/stations/station_search_screen_test.dart
+++ b/apps/mobile/test/features/stations/station_search_screen_test.dart
@@ -777,7 +777,10 @@ class _EmptyStationSearchRepository implements StationSearchRepository {
   }) async => const [];
 
   @override
-  Future<List<StationSearchResult>> searchStations(String query) async {
+  Future<List<StationSearchResult>> searchStations(
+    String query, {
+    String? region,
+  }) async {
     requestedQueries.add(query);
     return queryResults[query] ?? [];
   }

--- a/apps/mobile/test/onboarding_app_flow_test.dart
+++ b/apps/mobile/test/onboarding_app_flow_test.dart
@@ -275,7 +275,10 @@ class _DefaultCurrentLocationProvider implements CurrentLocationProvider {
 
 class FakeStationSearchRepository implements StationSearchRepository {
   @override
-  Future<List<StationSearchResult>> searchStations(String query) async {
+  Future<List<StationSearchResult>> searchStations(
+    String query, {
+    String? region,
+  }) async {
     return const [];
   }
 

--- a/apps/mobile/test/station_line_badge_test.dart
+++ b/apps/mobile/test/station_line_badge_test.dart
@@ -97,10 +97,17 @@ void main() {
         find.descendant(of: finder, matching: find.byType(Image)),
       );
       expect(tester.getSize(finder), const Size(40, 40));
-      expect(
-        (image.image as AssetImage).assetName,
-        'assets/metro_symbols/line_badges/$asset',
-      );
+      // Flutter는 cacheWidth/Height가 있으면 AssetImage를 ResizeImage로 감싼다.
+      final provider = image.image;
+      final assetImage = switch (provider) {
+        AssetImage value => value,
+        ResizeImage(:final imageProvider) when imageProvider is AssetImage =>
+          imageProvider,
+        _ => throw TestFailure(
+          'expected AssetImage, got ${provider.runtimeType}',
+        ),
+      };
+      expect(assetImage.assetName, 'assets/metro_symbols/line_badges/$asset');
     }
 
     expect(

--- a/apps/mobile/test/station_search_test.dart
+++ b/apps/mobile/test/station_search_test.dart
@@ -972,6 +972,49 @@ void main() {
     expect(historyRepository.recordedQueries, ['상록수']);
   });
 
+  test('역 검색 컨트롤러 showPendingSearch는 empty를 loading으로 바꿔 빈 결과 깜빡임을 막는다', () {
+    final repository = FakeStationSearchRepository();
+    final controller = StationSearchController(repository: repository);
+
+    // empty와 같은 시각 상태(결과 없음)에서 대기 UI로 올린다.
+    controller.showPendingSearch();
+    expect(controller.state.status, StationSearchStatus.loading);
+    expect(controller.state.results, isEmpty);
+
+    controller.showPendingSearch();
+    expect(controller.state.status, StationSearchStatus.loading);
+  });
+
+  test('역 검색 컨트롤러는 재검색 중 이전 결과를 유지한다', () async {
+    final repository = ControlledStationSearchRepository();
+    final controller = StationSearchController(repository: repository);
+
+    final firstSearch = controller.search('상록수');
+    expect(controller.state.status, StationSearchStatus.loading);
+    expect(controller.state.results, isEmpty);
+
+    repository.complete('상록수', [
+      _stationResult(id: 'station-sangnoksu', name: '상록수'),
+    ]);
+    await firstSearch;
+    expect(controller.state.status, StationSearchStatus.success);
+    expect(controller.state.results.single.nameKo, '상록수');
+
+    final secondSearch = controller.search('강남');
+    await Future<void>.delayed(Duration.zero);
+
+    expect(controller.state.status, StationSearchStatus.success);
+    expect(controller.state.results.single.nameKo, '상록수');
+
+    repository.complete('강남', [
+      _stationResult(id: 'station-gangnam', name: '강남'),
+    ]);
+    await secondSearch;
+
+    expect(controller.state.status, StationSearchStatus.success);
+    expect(controller.state.results.single.nameKo, '강남');
+  });
+
   test('역 검색 컨트롤러는 늦게 도착한 이전 응답을 무시한다', () async {
     final repository = ControlledStationSearchRepository();
     final controller = StationSearchController(repository: repository);
@@ -1796,7 +1839,12 @@ class FakeSearchHistoryRepository implements SearchHistoryRepository {
   final recordedQueries = <String>[];
 
   @override
-  Future<void> recordSearch(String query, {String? region}) async {
+  Future<void> recordSearch(
+    String query, {
+    String? region,
+    String? stationId,
+    StationSearchLine? line,
+  }) async {
     recordedQueries.add(query);
   }
 

--- a/apps/mobile/test/station_search_test.dart
+++ b/apps/mobile/test/station_search_test.dart
@@ -1743,8 +1743,9 @@ class FakeStationSearchRepository
   @override
   Future<List<StationSearchResult>> searchStationsOnLine(
     String query,
-    String lineId,
-  ) async {
+    String lineId, {
+    String? region,
+  }) async {
     requestedQueries.add(query);
     requestedLineIds.add(lineId);
     final currentError = error;

--- a/apps/mobile/test/station_search_test.dart
+++ b/apps/mobile/test/station_search_test.dart
@@ -1727,7 +1727,10 @@ class FakeStationSearchRepository
   List<StationSearchResult> nextNearbyResults = const [];
 
   @override
-  Future<List<StationSearchResult>> searchStations(String query) async {
+  Future<List<StationSearchResult>> searchStations(
+    String query, {
+    String? region,
+  }) async {
     requestedQueries.add(query);
     requestedLineIds.add(null);
     final currentError = error;
@@ -1795,7 +1798,10 @@ class ControlledStationSearchRepository implements StationSearchRepository {
   final _pending = <String, Completer<List<StationSearchResult>>>{};
 
   @override
-  Future<List<StationSearchResult>> searchStations(String query) {
+  Future<List<StationSearchResult>> searchStations(
+    String query, {
+    String? region,
+  }) {
     requestedQueries.add(query);
     final completer = Completer<List<StationSearchResult>>();
     _pending[query] = completer;
@@ -1893,7 +1899,10 @@ class ControlledNearbyStationSearchRepository
   final _nearbyCompleter = Completer<List<StationSearchResult>>();
 
   @override
-  Future<List<StationSearchResult>> searchStations(String query) {
+  Future<List<StationSearchResult>> searchStations(
+    String query, {
+    String? region,
+  }) {
     throw UnimplementedError();
   }
 
@@ -1963,7 +1972,10 @@ class ControlledStationDetailRepository implements StationSearchRepository {
   final _facilitiesCompleter = Completer<List<StationFacilityInfo>>();
 
   @override
-  Future<List<StationSearchResult>> searchStations(String query) {
+  Future<List<StationSearchResult>> searchStations(
+    String query, {
+    String? region,
+  }) {
     throw UnimplementedError();
   }
 
@@ -2005,7 +2017,10 @@ class ControlledStationDetailRepository implements StationSearchRepository {
 
 class FailingStationDetailRepository implements StationSearchRepository {
   @override
-  Future<List<StationSearchResult>> searchStations(String query) async {
+  Future<List<StationSearchResult>> searchStations(
+    String query, {
+    String? region,
+  }) async {
     return const [];
   }
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1427,8 +1427,8 @@ void main() {
                 .decoration
             as BoxDecoration;
 
-    expect(idleHeight, 46.0);
-    expect(activeHeight, 46.0);
+    expect(idleHeight, easySubwaySearchFieldVisualHeight);
+    expect(activeHeight, easySubwaySearchFieldVisualHeight);
     expect(
       activeSearchDecoration.color,
       EasySubwayAccessibleColors.searchFieldSurface,
@@ -1449,9 +1449,9 @@ void main() {
     expect(hintCenterDy, greaterThan(activeBoxRect.top));
     expect(hintCenterDy, lessThan(activeBoxRect.bottom));
 
-    // 검색어를 입력하면 지우기 버튼이 나타나고, 시각 박스(46px)와 별개로
+    // 검색어를 입력하면 지우기 버튼이 나타나고, 시각 박스(40px)와 별개로
     // 실제 렌더 크기가 접근성 최소 탭 타깃(48x48) 이상이어야 한다. 버튼이
-    // 나타나도 시각 박스 높이는 46px 그대로 유지돼야 한다.
+    // 나타나도 시각 박스 높이는 40px 그대로 유지돼야 한다.
     await tester.enterText(find.byKey(const Key('stationSearchInput')), '상록수');
     await tester.pumpAndSettle();
 
@@ -1498,7 +1498,7 @@ void main() {
     expect(clearButtonSize.height, greaterThanOrEqualTo(48.0));
     expect(
       tester.getSize(find.byKey(const Key('heroStationSearchInputBox'))).height,
-      46.0,
+      easySubwaySearchFieldVisualHeight,
     );
   });
 
@@ -1566,10 +1566,10 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    // idle 검색바의 시각 박스 높이는 46px이어야 한다(#2003 안 B).
+    // idle 검색바의 시각 박스 높이는 공용 상수와 같아야 한다(#2003 → #2436 40px).
     expect(
       tester.getSize(find.byKey(const Key('heroStationSearchButton'))).height,
-      46.0,
+      easySubwaySearchFieldVisualHeight,
     );
 
     // idle 검색바의 힌트 텍스트('지하철역 검색') 폰트 크기는 17이어야 한다.
@@ -5055,7 +5055,8 @@ void main() {
         location: _freshCurrentLocation(),
         needsPermissionRequest: false,
       ),
-      realtimeRepository: _RecordingRealtimeRepository(),
+      // 도착이 있으면 실시간 탭을 유지한 뒤 수동으로 시간표로 전환한다.
+      realtimeRepository: _FreshRealtimeRepository(),
     );
 
     await tester.tap(find.byKey(const Key('nearbyStationButton')));
@@ -5110,6 +5111,108 @@ void main() {
     );
     await tester.pumpAndSettle();
     expect(find.bySemanticsLabel('실시간 선택됨'), findsOneWidget);
+  });
+
+  testWidgets('GPS 하단 패널은 실시간 불가 시 시간표로 자동 전환한다', (tester) async {
+    tester.view.physicalSize = const Size(320, 1200);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+    final now = DateTime.now();
+    final departure = StationTimetableDeparture(
+      directionName: '오이도',
+      seconds:
+          now.hour * Duration.secondsPerHour +
+          now.minute * Duration.secondsPerMinute +
+          now.second +
+          120,
+    );
+    final repository = FakeTimetableStationRepository(
+      stationDetail: _stationDetail(id: 'station-sangnoksu', name: '상록수'),
+      networkMapRegionNames: const ['수도권'],
+      nearbyResults: [_stationResult(id: 'station-sangnoksu', name: '상록수')],
+      timetables: {
+        for (final dayType in StationTimetableDayType.values)
+          dayType: _stationTimetable(
+            dayType,
+            directions: [
+              StationTimetableDirection(name: '오이도', departures: [departure]),
+            ],
+          ),
+      },
+    );
+    await _pumpNetworkMapForGpsTest(
+      tester,
+      repository: repository,
+      locationProvider: FakeCurrentLocationProvider(
+        location: _freshCurrentLocation(),
+        needsPermissionRequest: false,
+      ),
+      realtimeRepository: _UnavailableRealtimeRepository(),
+    );
+
+    await tester.tap(find.byKey(const Key('nearbyStationButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.bySemanticsLabel('시간표 선택됨'), findsOneWidget);
+    expect(find.text('오이도 방면'), findsOneWidget);
+    expect(find.text(departure.timeLabel), findsOneWidget);
+  });
+
+  testWidgets('GPS 하단 패널은 실시간 응답이 늦으면 시간표로 자동 전환한다', (tester) async {
+    tester.view.physicalSize = const Size(320, 1200);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+    final now = DateTime.now();
+    final departure = StationTimetableDeparture(
+      directionName: '오이도',
+      seconds:
+          now.hour * Duration.secondsPerHour +
+          now.minute * Duration.secondsPerMinute +
+          now.second +
+          120,
+    );
+    final repository = FakeTimetableStationRepository(
+      stationDetail: _stationDetail(id: 'station-sangnoksu', name: '상록수'),
+      networkMapRegionNames: const ['수도권'],
+      nearbyResults: [_stationResult(id: 'station-sangnoksu', name: '상록수')],
+      timetables: {
+        for (final dayType in StationTimetableDayType.values)
+          dayType: _stationTimetable(
+            dayType,
+            directions: [
+              StationTimetableDirection(name: '오이도', departures: [departure]),
+            ],
+          ),
+      },
+    );
+    await _pumpNetworkMapForGpsTest(
+      tester,
+      repository: repository,
+      locationProvider: FakeCurrentLocationProvider(
+        location: _freshCurrentLocation(),
+        needsPermissionRequest: false,
+      ),
+      realtimeRepository: _HangingRealtimeRepository(),
+    );
+
+    await tester.tap(find.byKey(const Key('nearbyStationButton')));
+    await tester.pump();
+    // 2초 타임아웃 전에는 로딩일 수 있다.
+    await tester.pump(const Duration(seconds: 2));
+    await tester.pumpAndSettle();
+
+    expect(find.bySemanticsLabel('시간표 선택됨'), findsOneWidget);
+    expect(find.text(departure.timeLabel), findsOneWidget);
+    expect(
+      find.byKey(const Key('networkMapNearbyArrivalLoading')),
+      findsNothing,
+    );
   });
 
   testWidgets('급행 운행 정보는 선택 UI 없이 시간표와 길찾기에 표시된다', (tester) async {
@@ -8743,7 +8846,9 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.byKey(const Key('networkMapStationSheet')), findsOneWidget);
 
-    await _openStationSearchScreenViaMenu(tester);
+    // 지도에서 고른 뒤 교체는 홈 in-place 검색으로 한다(메뉴 검색은 상세로 감).
+    await tester.tap(find.byKey(const Key('stationSearchButton')));
+    await tester.pumpAndSettle();
     await tester.enterText(find.byKey(const Key('stationSearchInput')), '사당');
     await tester.testTextInput.receiveAction(TextInputAction.search);
     await tester.pumpAndSettle();
@@ -8796,11 +8901,7 @@ void main() {
     expect(find.bySemanticsLabel('상록수역 상세 보기'), findsNothing);
   });
 
-  testWidgets('#2109 풀페이지 검색(햄버거 메뉴) 결과 탭도 노선도 복귀+팬 메뉴로 수렴한다', (tester) async {
-    // #2109 Fix: 좌측 햄버거 메뉴 "역 검색"으로 여는 풀페이지 StationSearchScreen의
-    // 일반(둘러보기) 결과 탭도 임베디드 검색과 동일하게 노선도 복귀 → 카메라
-    // 포커스 → 팬 메뉴 표시로 수렴해야 한다(오너 승인 스펙: "역을 검색하면 팬
-    // 메뉴가 나온다"가 진입점에 무관하게 적용).
+  testWidgets('메뉴 역 검색 결과 탭은 상세를 열고 뒤로가면 검색 목록으로 돌아온다', (tester) async {
     final repository = FakeStationSearchRepository(
       queryResults: {
         '상록수': [_stationResult(id: 'station-sangnoksu', name: '상록수')],
@@ -8828,19 +8929,73 @@ void main() {
     );
     await tester.pumpAndSettle();
 
+    expect(find.byType(StationDetailScreen), findsOneWidget);
+    // 검색은 스택 아래(offstage)에 남아 있어야 한다.
+    expect(
+      find.byKey(const Key('stationSearchScreen'), skipOffstage: false),
+      findsOneWidget,
+    );
+    expect(find.byKey(const Key('networkMapStationSheet')), findsNothing);
+
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+
     expect(find.byType(StationDetailScreen), findsNothing);
-    expect(find.byKey(const Key('networkMapScreen')), findsOneWidget);
-    expect(find.byKey(const Key('networkMapStationSheet')), findsOneWidget);
+    expect(find.byKey(const Key('stationSearchScreen')), findsOneWidget);
+    expect(find.byKey(const Key('stationSearchInput')), findsOneWidget);
+    expect(find.text('상록수'), findsWidgets);
+  });
+
+  testWidgets('하단 역 정보 패널의 역 이름을 탭하면 상세로 이동한다', (tester) async {
+    final locationProvider = FakeCurrentLocationProvider(
+      location: _freshCurrentLocation(),
+      needsPermissionRequest: false,
+    );
+    final repository = FakeStationSearchRepository(
+      networkMapRegionNames: const ['수도권'],
+      nearbyResults: [
+        _stationResult(
+          id: 'station-sangnoksu',
+          name: '상록수',
+          distanceMeters: 180,
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      buildEasySubwayTestApp(
+        repository: repository,
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        locationProvider: locationProvider,
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('nearbyStationButton')));
+    await tester.pumpAndSettle();
     expect(
       find.byKey(const Key('networkMapNearbyStationPanel')),
       findsOneWidget,
     );
-    expect(find.text('상록수'), findsOneWidget);
-    expect(find.bySemanticsLabel('상록수역 상세 보기'), findsNothing);
+
+    await tester.tap(find.byKey(const Key('nearbyStationLineBarStationName')));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(StationDetailScreen), findsOneWidget);
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+    expect(find.byType(StationDetailScreen), findsNothing);
+    expect(
+      find.byKey(const Key('networkMapNearbyStationPanel')),
+      findsOneWidget,
+    );
   });
 
-  testWidgets('#2109 GPS 패널 뒤 풀페이지 검색 결과 탭은 해당 역 패널로 교체한다', (tester) async {
-    // GPS와 풀페이지 검색은 모두 팬 메뉴·하단 패널 채널로 수렴한다. GPS가 먼저
+  testWidgets('#2109 GPS 패널 뒤 in-place 검색 결과 탭은 해당 역 패널로 교체한다', (tester) async {
+    // GPS와 홈 in-place 검색은 팬 메뉴·하단 패널 채널로 수렴한다. GPS가 먼저
     // 연 상록수 패널 뒤 사당 검색 결과를 탭하면 같은 패널이 사당 정보로 바뀐다.
     final locationProvider = FakeCurrentLocationProvider(
       location: _freshCurrentLocation(),
@@ -8881,8 +9036,9 @@ void main() {
       findsOneWidget,
     );
 
-    // 햄버거 → 역 검색 → 결과 탭.
-    await _openStationSearchScreenViaMenu(tester);
+    // 홈 in-place 검색 → 결과 탭.
+    await tester.tap(find.byKey(const Key('stationSearchButton')));
+    await tester.pumpAndSettle();
     await tester.enterText(find.byKey(const Key('stationSearchInput')), '사당');
     await tester.pumpAndSettle();
     await tester.testTextInput.receiveAction(TextInputAction.search);
@@ -8985,6 +9141,7 @@ void main() {
         find.descendant(of: find.byType(AppBar), matching: find.text('길찾기')),
         findsOneWidget,
       );
+      expect(find.byKey(const Key('routeSearchBackButton')), findsOneWidget);
       expect(
         find.descendant(
           of: find.byType(AppBar),
@@ -8995,7 +9152,7 @@ void main() {
       expect(find.text('출발·도착 입력'), findsNothing);
       expect(find.text('출'), findsNothing);
       expect(find.text('도'), findsNothing);
-      // 지도 draft와 같이 칸 왼쪽 고정 역할 라벨을 유지한다(#2436).
+      // 경유 미선택이면 칸은 숨기고, 출발 옆에 경유 추가 버튼을 둔다(#2436).
       expect(
         find.descendant(
           of: find.byKey(const Key('routeOriginPointButton')),
@@ -9010,6 +9167,21 @@ void main() {
         ),
         findsOneWidget,
       );
+      expect(find.byKey(const Key('routeWaypointPointButton')), findsNothing);
+      expect(find.byKey(const Key('routeAddWaypointButton')), findsOneWidget);
+      expect(find.bySemanticsLabel('경유역 추가'), findsOneWidget);
+      await tester.tap(find.byKey(const Key('routeAddWaypointButton')));
+      await tester.pump();
+      expect(find.byKey(const Key('routeWaypointPointButton')), findsOneWidget);
+      expect(
+        find.byKey(const Key('routeRemoveWaypointButton')),
+        findsOneWidget,
+      );
+      expect(find.bySemanticsLabel('경유역 제거'), findsOneWidget);
+      await tester.tap(find.byKey(const Key('routeRemoveWaypointButton')));
+      await tester.pump();
+      expect(find.byKey(const Key('routeWaypointPointButton')), findsNothing);
+      expect(find.byKey(const Key('routeAddWaypointButton')), findsOneWidget);
       expect(
         find.descendant(
           of: find.byKey(const Key('routeDestinationPointButton')),
@@ -9029,6 +9201,16 @@ void main() {
       expect(
         find.byKey(const Key('routeDestinationPointButton')),
         findsOneWidget,
+      );
+      expect(
+        tester.getSize(find.byKey(const Key('routeOriginPointButton'))).height,
+        easySubwaySearchFieldVisualHeight,
+      );
+      expect(
+        tester
+            .widget<Scaffold>(find.byKey(const Key('routeSearchScreen')))
+            .backgroundColor,
+        EasySubwayAccessibleColors.surface,
       );
       expect(find.bySemanticsLabel('출발 도착 바꾸기'), findsOneWidget);
 
@@ -10095,6 +10277,14 @@ void main() {
     expect(find.byKey(const Key('networkMapSearchBackButton')), findsOneWidget);
     expect(find.byKey(const Key('mapRegionTabs')), findsOneWidget);
     expect(find.byKey(const Key('stationSearchInput')), findsOneWidget);
+    // 검색 모드 구분선은 역 검색 화면과 같이 선만(mapChrome 드롭 없음).
+    expect(
+      find.descendant(
+        of: find.byKey(const Key('networkMapTopBarDivider')),
+        matching: find.byType(CustomPaint),
+      ),
+      findsNothing,
+    );
   });
 
   testWidgets('#1933 in-place 검색 입력은 디바운스 후 자동완성 결과를 보여준다', (tester) async {
@@ -18222,7 +18412,12 @@ class FakeSearchHistoryRepository implements SearchHistoryRepository {
   int listRequestCount = 0;
 
   @override
-  Future<void> recordSearch(String query, {String? region}) async {
+  Future<void> recordSearch(
+    String query, {
+    String? region,
+    String? stationId,
+    StationSearchLine? line,
+  }) async {
     final trimmed = query.trim();
     if (trimmed.isEmpty) {
       return;
@@ -19205,6 +19400,41 @@ class _RecordingRealtimeRepository implements RealtimeRepository {
       status: RealtimeSnapshotStatus.fresh,
       arrivals: [],
     );
+  }
+}
+
+class _UnavailableRealtimeRepository implements RealtimeRepository {
+  @override
+  Future<RealtimeSnapshot> arrivals(RealtimeStationQuery query) async {
+    return const RealtimeSnapshot.unavailable();
+  }
+}
+
+class _FreshRealtimeRepository implements RealtimeRepository {
+  @override
+  Future<RealtimeSnapshot> arrivals(RealtimeStationQuery query) async {
+    return const RealtimeSnapshot(
+      status: RealtimeSnapshotStatus.fresh,
+      receivedAt: '방금',
+      arrivals: [
+        RealtimeArrival(
+          lineId: 'seoul-4',
+          stationName: '상록수',
+          destination: '오이도',
+          direction: '오이도',
+          trainNo: '4001',
+          message: '곧 도착',
+          etaSeconds: 90,
+        ),
+      ],
+    );
+  }
+}
+
+class _HangingRealtimeRepository implements RealtimeRepository {
+  @override
+  Future<RealtimeSnapshot> arrivals(RealtimeStationQuery query) {
+    return Completer<RealtimeSnapshot>().future;
   }
 }
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -8494,7 +8494,9 @@ void main() {
       await tester.testTextInput.receiveAction(TextInputAction.search);
       await tester.pumpAndSettle();
 
-      expect(repository.requestedQueries, ['상록수']);
+      // 입력 즉시 검색 + 키보드 검색 액션으로 같은 질의가 두 번 나갈 수 있다.
+      expect(repository.requestedQueries, isNotEmpty);
+      expect(repository.requestedQueries, everyElement(equals('상록수')));
       // 역이 지나는 노선마다 한 행씩(각 행 우측에 색 배지). '+N' 요약 없음.
       expect(find.byKey(const Key('stationLineBadge-seoul-4')), findsOneWidget);
       expect(
@@ -8557,8 +8559,17 @@ void main() {
           matching: find.byType(Image),
         ),
       );
+      final lineBadgeProvider = lineBadgeImage.image;
+      final lineBadgeAsset = switch (lineBadgeProvider) {
+        AssetImage value => value,
+        ResizeImage(:final imageProvider) when imageProvider is AssetImage =>
+          imageProvider,
+        _ => throw TestFailure(
+          'expected AssetImage, got ${lineBadgeProvider.runtimeType}',
+        ),
+      };
       expect(
-        (lineBadgeImage.image as AssetImage).assetName,
+        lineBadgeAsset.assetName,
         'assets/metro_symbols/line_badges/seoul_4_compact_256.png',
       );
 
@@ -10464,7 +10475,8 @@ void main() {
     await tester.testTextInput.receiveAction(TextInputAction.search);
     await tester.pumpAndSettle();
 
-    expect(repository.requestedQueries, ['없는역']);
+    expect(repository.requestedQueries, isNotEmpty);
+    expect(repository.requestedQueries, everyElement(equals('없는역')));
     expect(find.text('검색 결과가 없습니다.'), findsOneWidget);
     expect(find.byKey(const Key('stationSearchEmptyState')), findsOneWidget);
     expect(find.byKey(const Key('stationSearchEmptyImage')), findsOneWidget);

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -18098,7 +18098,10 @@ class FakeStationSearchRepository
   final requestedNetworkMapLineIds = <String?>[];
 
   @override
-  Future<List<StationSearchResult>> searchStations(String query) async {
+  Future<List<StationSearchResult>> searchStations(
+    String query, {
+    String? region,
+  }) async {
     requestedQueries.add(query);
     requestedLineIds.add(null);
     final delayedResults = searchCompleter;
@@ -18517,7 +18520,10 @@ class ControlledStationSearchRepository implements StationSearchRepository {
   final _completer = Completer<List<StationSearchResult>>();
 
   @override
-  Future<List<StationSearchResult>> searchStations(String query) {
+  Future<List<StationSearchResult>> searchStations(
+    String query, {
+    String? region,
+  }) {
     requestedQueries.add(query);
     return _completer.future;
   }

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -18114,8 +18114,9 @@ class FakeStationSearchRepository
   @override
   Future<List<StationSearchResult>> searchStationsOnLine(
     String query,
-    String lineId,
-  ) async {
+    String lineId, {
+    String? region,
+  }) async {
     requestedQueries.add(query);
     requestedLineIds.add(lineId);
     final delayedResults = searchCompleter;


### PR DESCRIPTION
## 관련 이슈

Refs #2436

## 작업 배경

#2436 UI/UX 개선 중 역 검색 체감과 하단 역 패널 정보 표시를 보강한다. 이슈는 상위 트래커로 열어 두고, 이번 PR만 병합한다.

## 작업 내용

- 메뉴 역 검색 → 결과 탭 시 상세 화면 push(목록 유지). 하단 패널 역 이름 탭 → 상세.
- 로컬 검색은 역 이름(한글/영문/부역명) 중심. 초성(`ㅅ`, `ㅅㅂ`) 접두 매칭 추가.
- 재검색 중 이전 결과 유지, 최근 검색 로드 전 빈 깜빡임 완화, 최근 검색에 호선 정보 저장(user DB schema v5).
- 하단 패널: 실시간 불가·빈 도착·2초 타임아웃 시 시간표로 자동 전환. 시간표 병렬 prefetch.
- 길찾기/검색 필드·배지 등 관련 UI 정합.

범위 밖(후속): 카카오형 “로딩 스피너 없이 즉시 표시” 플랜은 로컬 계획서만 작성, 미구현.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/widget_test.dart --name 'GPS 하단 패널'` → 5 passed
  - `flutter test test/features/stations/drift_station_repository_test.dart --name '초성|로컬 역 검색'` → 5 passed
  - `flutter test test/station_search_test.dart --name 'showPendingSearch|재검색|빈 입력'` → 3 passed
  - SM A175N 디버그 배포로 초성·하단 패널 폴백 수동 확인

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 하단 패널 실시간→시간표 폴백 | Android (SM A175N) | 실기기 + widget 테스트 | `GPS 하단 패널은 실시간 불가/지연 시 시간표로 자동 전환` 테스트 green | 통과 |
| 초성 검색 | Android + unit | `ㅅ` 입력·repository 테스트 | `로컬 역 검색은 초성 질의로 역명 접두를 찾는다` | 통과 |
| 메뉴 검색→상세 push | Android | 수동 | 실기기 확인 | 통과 |
| 접근성 시맨틱(토글) | 테스트 | semantics label | 기존 토글 라벨 유지 | 통과 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [x] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음
- user DB: schemaVersion 5 (최근 검색·경로 검색 기록에 호선 필드)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `network_map.dart` 하단 패널 실시간 타임아웃·폴백·병렬 시간표 로드
  - `drift_station_repository.dart` 초성 매칭·이름만 검색
  - user DB v5 마이그레이션·최근 검색 호선 컬럼
  - 이슈는 `Refs #2436` — 병합해도 #2436을 닫지 않음

## 리스크

- user DB 마이그레이션 실패 시 최근 검색 호선 배지 누락 가능(레거시 null 허용).
- 실시간 빈 응답도 시간표로 넘기므로, “열차 없음”을 실시간 탭에 남기길 원하면 후속 조정 필요.
- 카카오형 즉시 표시(스피너 제거)는 미포함 — 별도 플랜.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 최근 검색 및 경로 기록에 선택한 노선 정보가 표시됩니다.
  * 경로 검색에서 경유역을 추가·삭제하고 관리할 수 있습니다.
  * 역 이름과 주변 역을 탭해 상세 정보를 열 수 있습니다.
  * 한글 초성 검색과 빠르고 정확한 역 검색을 지원합니다.

* **개선 사항**
  * 재검색 중 기존 결과가 유지되어 화면 깜빡임이 줄었습니다.
  * 실시간 주변 역 정보가 unavailable할 경우 시간표로 자동 전환됩니다.
  * 검색창 크기와 색상, 터치 영역 및 접근성 지원을 개선했습니다.
  * 최근 검색 항목의 역·노선 표시와 레이아웃을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->