### PR TITLE
[Feat] 역 검색 인덱스·노선도 첫 paint 체감 개선

### DIFF
--- a/apps/mobile/lib/core/perf/easy_subway_perf.dart
+++ b/apps/mobile/lib/core/perf/easy_subway_perf.dart
@@ -1,0 +1,54 @@
+import 'dart:developer' as developer;
+
+/// profile/release에서도 켤 수 있는 성능 계측 플래그.
+///
+/// ```bash
+/// flutter run --profile --dart-define=EASY_SUBWAY_PERF_LOGS=true
+/// ```
+const bool easySubwayPerfLogsEnabled = bool.fromEnvironment(
+  'EASY_SUBWAY_PERF_LOGS',
+);
+
+/// [easySubwayPerfLogsEnabled]일 때만 Timeline 이벤트와 로그를 남긴다.
+/// flag가 꺼져 있으면 release 경로에 부작용이 없다.
+void easySubwayPerfLog(String message) {
+  if (!easySubwayPerfLogsEnabled) {
+    return;
+  }
+  developer.log(message, name: 'EasySubwayPerf');
+}
+
+/// Timeline에 동기 구간을 기록한다. flag가 꺼져 있으면 [action]만 실행한다.
+T easySubwayPerfTimeSync<T>(String name, T Function() action) {
+  if (!easySubwayPerfLogsEnabled) {
+    return action();
+  }
+  final task = developer.TimelineTask()..start(name);
+  final sw = Stopwatch()..start();
+  try {
+    return action();
+  } finally {
+    sw.stop();
+    task.finish(arguments: {'elapsedMicros': sw.elapsedMicroseconds});
+    easySubwayPerfLog('$name ${sw.elapsedMicroseconds}µs');
+  }
+}
+
+/// Timeline에 비동기 구간을 기록한다. flag가 꺼져 있으면 [action]만 실행한다.
+Future<T> easySubwayPerfTimeAsync<T>(
+  String name,
+  Future<T> Function() action,
+) async {
+  if (!easySubwayPerfLogsEnabled) {
+    return action();
+  }
+  final task = developer.TimelineTask()..start(name);
+  final sw = Stopwatch()..start();
+  try {
+    return await action();
+  } finally {
+    sw.stop();
+    task.finish(arguments: {'elapsedMicros': sw.elapsedMicroseconds});
+    easySubwayPerfLog('$name ${sw.elapsedMicroseconds}µs');
+  }
+}

--- a/apps/mobile/lib/features/network_map/presentation/structured_route_map_painter.dart
+++ b/apps/mobile/lib/features/network_map/presentation/structured_route_map_painter.dart
@@ -565,6 +565,11 @@ class _StructuredRouteMapViewState extends State<StructuredRouteMapView> {
   bool? _drawLines;
   bool? _drawStationSymbols;
   Map<String, List<RouteMapOwnerLabelEntry>>? _ownerLabelsByStationName;
+  Map<String, Color>? _lineColors;
+  Map<String, String>? _labelTextByStationId;
+  Map<String, String>? _lineBadgeLabelByLineId;
+  Map<String, String>? _stationNameByStationId;
+  double? _ownerLabelMaxAnchorDistancePx;
   RouteMapDesignSpace? _design;
   ui.Picture? _picture;
   // attribution TextPainter는 region(텍스트) 변경 시에만 재생성한다. 매 pan 프레임의
@@ -572,6 +577,36 @@ class _StructuredRouteMapViewState extends State<StructuredRouteMapView> {
   TextPainter? _attributionPainter;
   String? _attributionPainterText;
   int _pictureBuildGeneration = 0;
+
+  bool _pictureInputsDiffer(
+    StructuredRouteMapView a,
+    StructuredRouteMapView b,
+  ) {
+    return !identical(a.map, b.map) ||
+        a.drawLines != b.drawLines ||
+        a.drawStationSymbols != b.drawStationSymbols ||
+        !identical(a.ownerLabelsByStationName, b.ownerLabelsByStationName) ||
+        !identical(a.lineColors, b.lineColors) ||
+        !identical(a.labelTextByStationId, b.labelTextByStationId) ||
+        !identical(a.lineBadgeLabelByLineId, b.lineBadgeLabelByLineId) ||
+        !identical(a.stationNameByStationId, b.stationNameByStationId) ||
+        a.ownerLabelMaxAnchorDistancePx != b.ownerLabelMaxAnchorDistancePx;
+  }
+
+  bool _cachedPictureInputsMatch(StructuredRouteMapView current) {
+    return identical(_sourceMap, current.map) &&
+        _drawLines == current.drawLines &&
+        _drawStationSymbols == current.drawStationSymbols &&
+        identical(
+          _ownerLabelsByStationName,
+          current.ownerLabelsByStationName,
+        ) &&
+        identical(_lineColors, current.lineColors) &&
+        identical(_labelTextByStationId, current.labelTextByStationId) &&
+        identical(_lineBadgeLabelByLineId, current.lineBadgeLabelByLineId) &&
+        identical(_stationNameByStationId, current.stationNameByStationId) &&
+        _ownerLabelMaxAnchorDistancePx == current.ownerLabelMaxAnchorDistancePx;
+  }
 
   @override
   void initState() {
@@ -584,15 +619,7 @@ class _StructuredRouteMapViewState extends State<StructuredRouteMapView> {
   @override
   void didUpdateWidget(StructuredRouteMapView oldWidget) {
     super.didUpdateWidget(oldWidget);
-    final mapChanged = !identical(oldWidget.map, widget.map);
-    final flagsChanged =
-        oldWidget.drawLines != widget.drawLines ||
-        oldWidget.drawStationSymbols != widget.drawStationSymbols ||
-        !identical(
-          oldWidget.ownerLabelsByStationName,
-          widget.ownerLabelsByStationName,
-        );
-    if (mapChanged || flagsChanged) {
+    if (_pictureInputsDiffer(oldWidget, widget)) {
       _picture?.dispose();
       _picture = null;
       _sourceMap = null;
@@ -658,11 +685,7 @@ class _StructuredRouteMapViewState extends State<StructuredRouteMapView> {
   }
 
   void _ensurePicture() {
-    if (identical(_sourceMap, widget.map) &&
-        _drawLines == widget.drawLines &&
-        _drawStationSymbols == widget.drawStationSymbols &&
-        identical(_ownerLabelsByStationName, widget.ownerLabelsByStationName) &&
-        _picture != null) {
+    if (_cachedPictureInputsMatch(widget) && _picture != null) {
       return;
     }
     _picture?.dispose();
@@ -670,6 +693,11 @@ class _StructuredRouteMapViewState extends State<StructuredRouteMapView> {
     _drawLines = widget.drawLines;
     _drawStationSymbols = widget.drawStationSymbols;
     _ownerLabelsByStationName = widget.ownerLabelsByStationName;
+    _lineColors = widget.lineColors;
+    _labelTextByStationId = widget.labelTextByStationId;
+    _lineBadgeLabelByLineId = widget.lineBadgeLabelByLineId;
+    _stationNameByStationId = widget.stationNameByStationId;
+    _ownerLabelMaxAnchorDistancePx = widget.ownerLabelMaxAnchorDistancePx;
     final design = routeMapDesignSpaceFor(widget.map);
     _design = design;
     // #2068 9차: fontSize를 인자로 받아 라벨별(오너 매치=오너 크기, 폴백=권역

--- a/apps/mobile/lib/features/network_map/presentation/structured_route_map_painter.dart
+++ b/apps/mobile/lib/features/network_map/presentation/structured_route_map_painter.dart
@@ -600,15 +600,56 @@ class _StructuredRouteMapViewState extends State<StructuredRouteMapView> {
     }
   }
 
-  void _schedulePictureBuild() {
+  void _schedulePictureBuild({int retry = 0}) {
     final generation = ++_pictureBuildGeneration;
     SchedulerBinding.instance.addPostFrameCallback((_) {
       if (!mounted || generation != _pictureBuildGeneration) {
         return;
       }
-      easySubwayPerfTimeSync('structured_route_map.picture_build', () {
-        _ensurePicture();
-      });
+      try {
+        easySubwayPerfTimeSync('structured_route_map.picture_build', () {
+          _ensurePicture();
+        });
+      } catch (error, stackTrace) {
+        FlutterError.reportError(
+          FlutterErrorDetails(
+            exception: error,
+            stack: stackTrace,
+            library: 'network_map',
+            context: ErrorDescription('구조화 노선도 picture 구축 실패'),
+          ),
+        );
+        // map/flags가 안 바뀌어도 한 번은 다음 프레임에 재시도한다.
+        // generation을 올리지 않고 같은 세대에서만 재시도해 최신 예약과 경합하지 않는다.
+        if (retry < 1 && mounted && generation == _pictureBuildGeneration) {
+          SchedulerBinding.instance.addPostFrameCallback((_) {
+            if (!mounted || generation != _pictureBuildGeneration) {
+              return;
+            }
+            try {
+              easySubwayPerfTimeSync(
+                'structured_route_map.picture_build_retry',
+                () {
+                  _ensurePicture();
+                },
+              );
+              if (mounted && generation == _pictureBuildGeneration) {
+                setState(() {});
+              }
+            } catch (error, stackTrace) {
+              FlutterError.reportError(
+                FlutterErrorDetails(
+                  exception: error,
+                  stack: stackTrace,
+                  library: 'network_map',
+                  context: ErrorDescription('구조화 노선도 picture 재시도 실패'),
+                ),
+              );
+            }
+          });
+        }
+        return;
+      }
       if (!mounted || generation != _pictureBuildGeneration) {
         return;
       }

--- a/apps/mobile/lib/features/network_map/presentation/structured_route_map_painter.dart
+++ b/apps/mobile/lib/features/network_map/presentation/structured_route_map_painter.dart
@@ -1,8 +1,10 @@
 import 'dart:math' as math;
 import 'dart:ui' as ui;
 
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 
+import '../../../core/perf/easy_subway_perf.dart';
 import '../../stations/domain/station_line.dart' show stationLineColor;
 import '../domain/map_camera.dart';
 import '../domain/route_map_design_space.dart';
@@ -11,6 +13,10 @@ import '../domain/route_map_parallel_offsets.dart';
 import '../domain/structured_route_map.dart';
 import 'route_map_label_layout.dart';
 import 'route_map_transfer_marker.dart';
+
+/// profile 계측용. [easySubwayPerfLogsEnabled]일 때만 증가한다.
+int debugStructuredRouteMapPictureBuildCount = 0;
+int debugStructuredRouteMapPaintCount = 0;
 
 // 구조화 노선도 정적 스케일 렌더러 (#1789 스펙 S6).
 //
@@ -447,6 +453,12 @@ class StructuredRouteMapPainter extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
+    if (easySubwayPerfLogsEnabled) {
+      debugStructuredRouteMapPaintCount++;
+      easySubwayPerfLog(
+        'structured_route_map.paint #$debugStructuredRouteMapPaintCount',
+      );
+    }
     canvas.save();
     final vc = camera.viewportSize.center(Offset.zero);
     // viewport = vc + (source − sourceOrigin − camera.center)·scale,
@@ -559,6 +571,50 @@ class _StructuredRouteMapViewState extends State<StructuredRouteMapView> {
   // TextPainter 생성·layout 할당을 제거하기 위한 캐시(#1973). State가 dispose를 소유한다.
   TextPainter? _attributionPainter;
   String? _attributionPainterText;
+  int _pictureBuildGeneration = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    // cold 진입 첫 프레임에서 label layout + picture record가 build를 막지 않게
+    // 다음 프레임으로 미룬다. 그 사이 바탕(.vec)만 보여 체감 jank를 줄인다.
+    _schedulePictureBuild();
+  }
+
+  @override
+  void didUpdateWidget(StructuredRouteMapView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final mapChanged = !identical(oldWidget.map, widget.map);
+    final flagsChanged =
+        oldWidget.drawLines != widget.drawLines ||
+        oldWidget.drawStationSymbols != widget.drawStationSymbols ||
+        !identical(
+          oldWidget.ownerLabelsByStationName,
+          widget.ownerLabelsByStationName,
+        );
+    if (mapChanged || flagsChanged) {
+      _picture?.dispose();
+      _picture = null;
+      _sourceMap = null;
+      _schedulePictureBuild();
+    }
+  }
+
+  void _schedulePictureBuild() {
+    final generation = ++_pictureBuildGeneration;
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || generation != _pictureBuildGeneration) {
+        return;
+      }
+      easySubwayPerfTimeSync('structured_route_map.picture_build', () {
+        _ensurePicture();
+      });
+      if (!mounted || generation != _pictureBuildGeneration) {
+        return;
+      }
+      setState(() {});
+    });
+  }
 
   void _ensurePicture() {
     if (identical(_sourceMap, widget.map) &&
@@ -627,6 +683,13 @@ class _StructuredRouteMapViewState extends State<StructuredRouteMapView> {
       drawLines: widget.drawLines,
       drawStationSymbols: widget.drawStationSymbols,
     );
+    if (easySubwayPerfLogsEnabled) {
+      debugStructuredRouteMapPictureBuildCount++;
+      easySubwayPerfLog(
+        'structured_route_map.picture_build '
+        '#$debugStructuredRouteMapPictureBuildCount',
+      );
+    }
   }
 
   void _ensureAttributionPainter() {
@@ -659,8 +722,14 @@ class _StructuredRouteMapViewState extends State<StructuredRouteMapView> {
 
   @override
   Widget build(BuildContext context) {
-    _ensurePicture();
     _ensureAttributionPainter();
+    final picture = _picture;
+    final design = _design;
+    // Picture 준비 전: 빈 레이어만 두어 첫 프레임 build를 가볍게 유지한다.
+    // 바탕(.vec)은 형제 RouteMapBasemapView가 담당한다.
+    if (picture == null || design == null) {
+      return SizedBox.fromSize(size: widget.camera.viewportSize);
+    }
     // RepaintBoundary로 지도 레이어를 부모 Stack의 형제 오버레이 rebuild와 분리한다.
     // isComplex/willChange 힌트로 정적 Picture 재생 레이어의 raster 캐싱을 돕는다(#1973).
     return RepaintBoundary(
@@ -669,8 +738,8 @@ class _StructuredRouteMapViewState extends State<StructuredRouteMapView> {
         isComplex: true,
         willChange: true,
         painter: StructuredRouteMapPainter(
-          picture: _picture!,
-          designScale: _design!.designScale,
+          picture: picture,
+          designScale: design.designScale,
           camera: widget.camera,
           sourceOrigin: widget.sourceOrigin,
           attributionText: widget.attributionText,

--- a/apps/mobile/lib/features/stations/data/drift_station_repository.dart
+++ b/apps/mobile/lib/features/stations/data/drift_station_repository.dart
@@ -5,10 +5,12 @@ import 'package:drift/drift.dart';
 import '../../../core/database/catalog/canonical_station_id.dart';
 import '../../../core/database/catalog/catalog_database.dart';
 import '../../../core/database/catalog/station_timetable_query.dart';
+import '../../../core/perf/easy_subway_perf.dart';
 import '../../../network_map.dart';
 import '../domain/station_line.dart';
 import '../domain/station_models.dart';
 import '../domain/station_repositories.dart';
+import 'station_search_index.dart';
 
 class DriftStationRepository
     implements
@@ -27,17 +29,16 @@ class DriftStationRepository
 
   final CatalogDatabase database;
   Future<List<_LocalStationSummary>>? _stationSummaryCache;
+  Future<StationSearchIndex>? _searchIndexFuture;
 
   void invalidateStationSummaryCache() {
     _stationSummaryCache = null;
+    _searchIndexFuture = null;
   }
 
   @override
   Future<void> warmSearchCache() async {
-    final stations = await _listStationSummaries();
-    for (final station in stations) {
-      station.primeSearchTerms();
-    }
+    await _ensureSearchIndex();
   }
 
   @override
@@ -50,53 +51,132 @@ class DriftStationRepository
 
   /// [region]/[lineId]는 상한 적용 전에 거른다. 완전일치(rank 0)는 상한에
   /// 잘리지 않게 해 동명·정확 질의 누락을 막는다.
+  ///
+  /// 초성·이름 prefix는 정렬 term 인덱스로 후보를 좁히고, 포함(substring)
+  /// 매칭은 기존과 동일한 선형 fallback으로 의미를 보존한다.
   Future<List<StationSearchResult>> _rankSearchStations(
     String query, {
     String? region,
     String? lineId,
-  }) async {
-    final trimmedQuery = query.trim();
-    if (trimmedQuery.isEmpty) {
-      return const [];
-    }
+  }) {
+    return easySubwayPerfTimeAsync('station_search.rank', () async {
+      final trimmedQuery = query.trim();
+      if (trimmedQuery.isEmpty) {
+        return const [];
+      }
 
-    final normalizedQuery = _normalize(trimmedQuery);
-    if (normalizedQuery.isEmpty) {
-      return const [];
-    }
-    final regionFilter = region?.trim() ?? '';
-    final lineFilter = lineId?.trim() ?? '';
+      final normalizedQuery = _normalize(trimmedQuery);
+      if (normalizedQuery.isEmpty) {
+        return const [];
+      }
+      final regionFilter = region?.trim() ?? '';
+      final lineFilter = lineId?.trim() ?? '';
 
-    final stations = await _listStationSummaries();
-    final ranked = <({_LocalStationSummary station, int rank})>[];
-    for (final station in stations) {
-      if (regionFilter.isNotEmpty &&
-          !stationBelongsToRegion(station.region, regionFilter)) {
-        continue;
+      final stations = await _listStationSummaries();
+      final index = await _ensureSearchIndex(stations);
+      final byId = {for (final station in stations) station.id: station};
+
+      final candidateIds = <String>{};
+      if (_isHangulJamoOnly(normalizedQuery)) {
+        candidateIds.addAll(
+          index.lookupChosungPrefix(_chosungKey(normalizedQuery)),
+        );
+      } else {
+        candidateIds.addAll(index.lookupNamePrefix(normalizedQuery));
+        // substring(rank 2) 보존: prefix에 없는 역만 포함 여부를 검사한다.
+        for (final station in stations) {
+          if (candidateIds.contains(station.id)) {
+            continue;
+          }
+          if (regionFilter.isNotEmpty &&
+              !stationBelongsToRegion(station.region, regionFilter)) {
+            continue;
+          }
+          if (lineFilter.isNotEmpty &&
+              !station.lines.any((line) => line.id == lineFilter)) {
+            continue;
+          }
+          if (station.hasNormalizedContains(normalizedQuery)) {
+            candidateIds.add(station.id);
+          }
+        }
       }
-      if (lineFilter.isNotEmpty &&
-          !station.lines.any((line) => line.id == lineFilter)) {
-        continue;
+
+      final ranked = <({_LocalStationSummary station, int rank})>[];
+      for (final stationId in candidateIds) {
+        final station = byId[stationId];
+        if (station == null) {
+          continue;
+        }
+        if (regionFilter.isNotEmpty &&
+            !stationBelongsToRegion(station.region, regionFilter)) {
+          continue;
+        }
+        if (lineFilter.isNotEmpty &&
+            !station.lines.any((line) => line.id == lineFilter)) {
+          continue;
+        }
+        final rank = station.matchRank(normalizedQuery);
+        if (rank == null) {
+          continue;
+        }
+        ranked.add((station: station, rank: rank));
       }
-      final rank = station.matchRank(normalizedQuery);
-      if (rank == null) {
-        continue;
-      }
-      ranked.add((station: station, rank: rank));
-    }
-    ranked.sort((a, b) {
-      final byRank = a.rank.compareTo(b.rank);
-      if (byRank != 0) {
-        return byRank;
-      }
-      return a.station.nameKo.compareTo(b.station.nameKo);
+      ranked.sort((a, b) {
+        final byRank = a.rank.compareTo(b.rank);
+        if (byRank != 0) {
+          return byRank;
+        }
+        return a.station.nameKo.compareTo(b.station.nameKo);
+      });
+      final exactCount = ranked.where((entry) => entry.rank == 0).length;
+      final limit = math.max(_maxSearchResults, exactCount);
+      return ranked
+          .take(limit)
+          .map((entry) => entry.station.toSearchResult())
+          .toList(growable: false);
     });
-    final exactCount = ranked.where((entry) => entry.rank == 0).length;
-    final limit = math.max(_maxSearchResults, exactCount);
-    return ranked
-        .take(limit)
-        .map((entry) => entry.station.toSearchResult())
-        .toList(growable: false);
+  }
+
+  Future<StationSearchIndex> _ensureSearchIndex([
+    List<_LocalStationSummary>? preloaded,
+  ]) async {
+    final existing = _searchIndexFuture;
+    if (existing != null) {
+      try {
+        return await existing;
+      } catch (_) {
+        // 실패한 Future는 영구 캐시하지 않고 재시도한다.
+        if (identical(_searchIndexFuture, existing)) {
+          _searchIndexFuture = null;
+        }
+      }
+    }
+
+    final future = _buildSearchIndex(preloaded);
+    _searchIndexFuture = future;
+    try {
+      return await future;
+    } catch (_) {
+      if (identical(_searchIndexFuture, future)) {
+        _searchIndexFuture = null;
+      }
+      rethrow;
+    }
+  }
+
+  Future<StationSearchIndex> _buildSearchIndex(
+    List<_LocalStationSummary>? preloaded,
+  ) async {
+    final stations = preloaded ?? await _listStationSummaries();
+    for (final station in stations) {
+      station.primeSearchTerms();
+    }
+    return easySubwayPerfTimeSync('station_search_index.build', () {
+      return StationSearchIndex.build([
+        for (final station in stations) station.toIndexRow(),
+      ]);
+    });
   }
 
   @override
@@ -834,6 +914,39 @@ class _LocalStationSummary {
   void primeSearchTerms() {
     _normalizedTerms;
     _chosungTerms;
+  }
+
+  StationSearchIndexStationRow toIndexRow() {
+    final korean = <String>[
+      _normalize(nameKo),
+      _normalize('$nameKo역'),
+    ].where((term) => term.isNotEmpty).toList(growable: false);
+    final english = <String>[
+      _normalize(nameEn),
+    ].where((term) => term.isNotEmpty).toList(growable: false);
+    final subname = <String>[
+      if (nameSub.isNotEmpty) _normalize(nameSub),
+    ].where((term) => term.isNotEmpty).toList(growable: false);
+    return StationSearchIndexStationRow(
+      stationId: id,
+      koreanTerms: korean,
+      englishTerms: english,
+      subnameTerms: subname,
+      chosungTerms: _chosungTerms,
+    );
+  }
+
+  /// substring fallback용. chosung·rank 계산 없이 정규화 term 포함만 본다.
+  bool hasNormalizedContains(String normalizedQuery) {
+    if (normalizedQuery.isEmpty) {
+      return false;
+    }
+    for (final term in _normalizedTerms) {
+      if (term.contains(normalizedQuery)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   bool matches(String query) {

--- a/apps/mobile/lib/features/stations/data/drift_station_repository.dart
+++ b/apps/mobile/lib/features/stations/data/drift_station_repository.dart
@@ -145,8 +145,11 @@ class DriftStationRepository
     if (existing != null) {
       try {
         return await existing;
-      } catch (_) {
+      } catch (error, stackTrace) {
         // 실패한 Future는 영구 캐시하지 않고 재시도한다.
+        easySubwayPerfLog(
+          'station_search_index warm retry after failure: $error\n$stackTrace',
+        );
         if (identical(_searchIndexFuture, existing)) {
           _searchIndexFuture = null;
         }
@@ -157,11 +160,11 @@ class DriftStationRepository
     _searchIndexFuture = future;
     try {
       return await future;
-    } catch (_) {
+    } catch (error, stackTrace) {
       if (identical(_searchIndexFuture, future)) {
         _searchIndexFuture = null;
       }
-      rethrow;
+      Error.throwWithStackTrace(error, stackTrace);
     }
   }
 

--- a/apps/mobile/lib/features/stations/data/drift_station_repository.dart
+++ b/apps/mobile/lib/features/stations/data/drift_station_repository.dart
@@ -30,10 +30,12 @@ class DriftStationRepository
   final CatalogDatabase database;
   Future<List<_LocalStationSummary>>? _stationSummaryCache;
   Future<StationSearchIndex>? _searchIndexFuture;
+  Map<String, _LocalStationSummary>? _stationByIdCache;
 
   void invalidateStationSummaryCache() {
     _stationSummaryCache = null;
     _searchIndexFuture = null;
+    _stationByIdCache = null;
   }
 
   @override
@@ -74,7 +76,9 @@ class DriftStationRepository
 
       final stations = await _listStationSummaries();
       final index = await _ensureSearchIndex(stations);
-      final byId = {for (final station in stations) station.id: station};
+      final byId = _stationByIdCache ??= {
+        for (final station in stations) station.id: station,
+      };
 
       final candidateIds = <String>{};
       if (_isHangulJamoOnly(normalizedQuery)) {

--- a/apps/mobile/lib/features/stations/data/station_search_index.dart
+++ b/apps/mobile/lib/features/stations/data/station_search_index.dart
@@ -1,0 +1,175 @@
+// 역 검색용 정렬 prefix term 인덱스.
+// 모든 prefix 조합을 Map으로 펼치지 않고, 정렬된 term 테이블에서
+// lower-bound + startsWith 순회로 후보 station id만 모은다.
+
+enum StationSearchTermKind { korean, english, subname, chosung }
+
+class StationSearchTermEntry implements Comparable<StationSearchTermEntry> {
+  const StationSearchTermEntry({
+    required this.normalizedKey,
+    required this.stationId,
+    required this.termKind,
+  });
+
+  final String normalizedKey;
+  final String stationId;
+  final StationSearchTermKind termKind;
+
+  @override
+  int compareTo(StationSearchTermEntry other) {
+    final byKey = normalizedKey.compareTo(other.normalizedKey);
+    if (byKey != 0) {
+      return byKey;
+    }
+    return stationId.compareTo(other.stationId);
+  }
+}
+
+/// 인덱스 구축에 필요한 최소 station 행.
+class StationSearchIndexStationRow {
+  const StationSearchIndexStationRow({
+    required this.stationId,
+    required this.koreanTerms,
+    required this.englishTerms,
+    required this.subnameTerms,
+    required this.chosungTerms,
+  });
+
+  final String stationId;
+  final List<String> koreanTerms;
+  final List<String> englishTerms;
+  final List<String> subnameTerms;
+  final List<String> chosungTerms;
+}
+
+class StationSearchIndex {
+  StationSearchIndex._({
+    required this.sortedKoreanTerms,
+    required this.sortedEnglishTerms,
+    required this.sortedSubnameTerms,
+    required this.sortedChosungTerms,
+  });
+
+  final List<StationSearchTermEntry> sortedKoreanTerms;
+  final List<StationSearchTermEntry> sortedEnglishTerms;
+  final List<StationSearchTermEntry> sortedSubnameTerms;
+  final List<StationSearchTermEntry> sortedChosungTerms;
+
+  factory StationSearchIndex.build(List<StationSearchIndexStationRow> rows) {
+    final korean = <StationSearchTermEntry>[];
+    final english = <StationSearchTermEntry>[];
+    final subname = <StationSearchTermEntry>[];
+    final chosung = <StationSearchTermEntry>[];
+
+    for (final row in rows) {
+      for (final term in row.koreanTerms) {
+        if (term.isEmpty) {
+          continue;
+        }
+        korean.add(
+          StationSearchTermEntry(
+            normalizedKey: term,
+            stationId: row.stationId,
+            termKind: StationSearchTermKind.korean,
+          ),
+        );
+      }
+      for (final term in row.englishTerms) {
+        if (term.isEmpty) {
+          continue;
+        }
+        english.add(
+          StationSearchTermEntry(
+            normalizedKey: term,
+            stationId: row.stationId,
+            termKind: StationSearchTermKind.english,
+          ),
+        );
+      }
+      for (final term in row.subnameTerms) {
+        if (term.isEmpty) {
+          continue;
+        }
+        subname.add(
+          StationSearchTermEntry(
+            normalizedKey: term,
+            stationId: row.stationId,
+            termKind: StationSearchTermKind.subname,
+          ),
+        );
+      }
+      for (final term in row.chosungTerms) {
+        if (term.isEmpty) {
+          continue;
+        }
+        chosung.add(
+          StationSearchTermEntry(
+            normalizedKey: term,
+            stationId: row.stationId,
+            termKind: StationSearchTermKind.chosung,
+          ),
+        );
+      }
+    }
+
+    korean.sort();
+    english.sort();
+    subname.sort();
+    chosung.sort();
+
+    return StationSearchIndex._(
+      sortedKoreanTerms: List.unmodifiable(korean),
+      sortedEnglishTerms: List.unmodifiable(english),
+      sortedSubnameTerms: List.unmodifiable(subname),
+      sortedChosungTerms: List.unmodifiable(chosung),
+    );
+  }
+
+  /// [query]로 시작하는 term의 station id를 중복 없이 모은다.
+  Set<String> lookupPrefix(
+    List<StationSearchTermEntry> sortedTerms,
+    String query,
+  ) {
+    if (query.isEmpty || sortedTerms.isEmpty) {
+      return const {};
+    }
+    final start = _lowerBound(sortedTerms, query);
+    if (start >= sortedTerms.length) {
+      return const {};
+    }
+    final ids = <String>{};
+    for (var i = start; i < sortedTerms.length; i++) {
+      final entry = sortedTerms[i];
+      if (!entry.normalizedKey.startsWith(query)) {
+        break;
+      }
+      ids.add(entry.stationId);
+    }
+    return ids;
+  }
+
+  Set<String> lookupChosungPrefix(String query) =>
+      lookupPrefix(sortedChosungTerms, query);
+
+  Set<String> lookupNamePrefix(String query) {
+    return {
+      ...lookupPrefix(sortedKoreanTerms, query),
+      ...lookupPrefix(sortedEnglishTerms, query),
+      ...lookupPrefix(sortedSubnameTerms, query),
+    };
+  }
+}
+
+int _lowerBound(List<StationSearchTermEntry> sorted, String query) {
+  var low = 0;
+  var high = sorted.length;
+  while (low < high) {
+    final mid = low + ((high - low) >> 1);
+    if (sorted[mid].normalizedKey.compareTo(query) < 0) {
+      low = mid + 1;
+    } else {
+      high = mid;
+    }
+  }
+  return low;
+}

--- a/apps/mobile/test/features/network_map/presentation/structured_route_map_painter_test.dart
+++ b/apps/mobile/test/features/network_map/presentation/structured_route_map_painter_test.dart
@@ -207,4 +207,57 @@ void main() {
     await tester.pump(); // post-frame picture build + setState
     expect(find.byType(CustomPaint), findsOneWidget);
   });
+
+  testWidgets('StructuredRouteMapView는 라벨 입력이 바뀌면 picture를 다시 만든다', (
+    tester,
+  ) async {
+    final map = _map();
+    const camera = MapCameraState(
+      sourceBounds: Rect.fromLTWH(0, 0, 48, 48),
+      viewportSize: Size(400, 800),
+      center: Offset(24, 24),
+      scale: 8,
+      minScale: 8,
+      maxScale: 20,
+      revision: 1,
+      initialScale: 8,
+    );
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: StructuredRouteMapView(
+          map: map,
+          camera: camera,
+          lineColors: const {'L1': Color(0xFF00A0E0)},
+          labelTextByStationId: const {'s0': '가', 's1': '나', 's2': '다'},
+          lineBadgeLabelByLineId: const {'L1': '1'},
+        ),
+      ),
+    );
+    await tester.pump();
+    final firstPaint = tester.widget<CustomPaint>(find.byType(CustomPaint));
+    final firstPicture =
+        (firstPaint.painter! as StructuredRouteMapPainter).picture;
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: StructuredRouteMapView(
+          map: map,
+          camera: camera,
+          lineColors: const {'L1': Color(0xFF00A0E0)},
+          labelTextByStationId: const {'s0': '가가', 's1': '나', 's2': '다'},
+          lineBadgeLabelByLineId: const {'L1': '1'},
+        ),
+      ),
+    );
+    // 입력 변경 직후는 picture를 비우고 다시 post-frame 구축한다.
+    expect(find.byType(CustomPaint), findsNothing);
+    await tester.pump();
+    final secondPaint = tester.widget<CustomPaint>(find.byType(CustomPaint));
+    final secondPicture =
+        (secondPaint.painter! as StructuredRouteMapPainter).picture;
+    expect(identical(firstPicture, secondPicture), isFalse);
+  });
 }

--- a/apps/mobile/test/features/network_map/presentation/structured_route_map_painter_test.dart
+++ b/apps/mobile/test/features/network_map/presentation/structured_route_map_painter_test.dart
@@ -5,6 +5,7 @@ import 'package:easysubway_mobile/features/network_map/domain/route_map_design_s
 import 'package:easysubway_mobile/features/network_map/domain/structured_route_map.dart';
 import 'package:easysubway_mobile/features/network_map/presentation/route_map_label_layout.dart';
 import 'package:easysubway_mobile/features/network_map/presentation/structured_route_map_painter.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -172,5 +173,39 @@ void main() {
     expect(routeMapStationLabel('신금호'), '신금호');
     // 맨 앞이 '('이면 축약할 역명이 없으므로 원문 유지.
     expect(routeMapStationLabel('(임시)역'), '(임시)역');
+  });
+
+  testWidgets('StructuredRouteMapView는 첫 프레임에서 picture를 미룬다', (tester) async {
+    final map = _map();
+    const camera = MapCameraState(
+      sourceBounds: Rect.fromLTWH(0, 0, 48, 48),
+      viewportSize: Size(400, 800),
+      center: Offset(24, 24),
+      scale: 8,
+      minScale: 8,
+      maxScale: 20,
+      revision: 1,
+      initialScale: 8,
+    );
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: StructuredRouteMapView(
+          map: map,
+          camera: camera,
+          lineColors: const {'L1': Color(0xFF00A0E0)},
+          labelTextByStationId: const {'s0': '가', 's1': '나', 's2': '다'},
+          lineBadgeLabelByLineId: const {'L1': '1'},
+        ),
+      ),
+    );
+
+    // 첫 build: CustomPaint(라벨 picture) 없이 SizedBox만.
+    expect(find.byType(CustomPaint), findsNothing);
+    expect(find.byType(SizedBox), findsWidgets);
+
+    await tester.pump(); // post-frame picture build + setState
+    expect(find.byType(CustomPaint), findsOneWidget);
   });
 }

--- a/apps/mobile/test/features/network_map/presentation/structured_route_map_painter_test.dart
+++ b/apps/mobile/test/features/network_map/presentation/structured_route_map_painter_test.dart
@@ -6,7 +6,6 @@ import 'package:easysubway_mobile/features/network_map/domain/structured_route_m
 import 'package:easysubway_mobile/features/network_map/presentation/route_map_label_layout.dart';
 import 'package:easysubway_mobile/features/network_map/presentation/structured_route_map_painter.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/painting.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 StructuredRouteMap _map() {

--- a/apps/mobile/test/features/stations/drift_station_repository_test.dart
+++ b/apps/mobile/test/features/stations/drift_station_repository_test.dart
@@ -98,6 +98,112 @@ void main() {
     }
   });
 
+  test('로컬 역 검색은 warm 전후·중복 warm에서 결과 집합과 순서가 같다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await database.seedBaselineIfEmpty();
+    await database.customStatement(
+      "INSERT INTO stations "
+      "(id, name_ko, name_en, name_sub, normalized_name, region, "
+      "data_quality_level, data_source_type) "
+      "VALUES "
+      "('station-surisan', '수리산', 'Surisan', '', '수리산', "
+      "'수도권', 'LEVEL_1', 'OFFICIAL_FILE'), "
+      "('station-sanbon', '산본', 'Sanbon', '', '산본', "
+      "'수도권', 'LEVEL_1', 'OFFICIAL_FILE')",
+    );
+    final repository = DriftStationRepository(database: database);
+
+    Future<List<String>> idsFor(String query) async {
+      final results = await repository.searchStations(query);
+      return results.map((station) => station.id).toList(growable: false);
+    }
+
+    final beforeWarm = await idsFor('ㅅ');
+    await Future.wait([
+      repository.warmSearchCache(),
+      repository.warmSearchCache(),
+    ]);
+    final afterWarm = await idsFor('ㅅ');
+    final afterSecondSearch = await idsFor('ㅅ');
+
+    expect(afterWarm, beforeWarm);
+    expect(afterSecondSearch, beforeWarm);
+    expect(await idsFor('상'), await idsFor('상'));
+  });
+
+  test('로컬 역 검색은 중간 문자열(substring) 매칭을 유지한다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await database.seedBaselineIfEmpty();
+    await database.customStatement(
+      "INSERT INTO stations "
+      "(id, name_ko, name_en, name_sub, normalized_name, region, "
+      "data_quality_level, data_source_type) "
+      "VALUES "
+      "('station-mid-sangnok', '테스트상록중앙', 'MidSangnok', '', "
+      "'테스트상록중앙', '수도권', 'LEVEL_1', 'OFFICIAL_FILE')",
+    );
+    final repository = DriftStationRepository(database: database);
+
+    final results = await repository.searchStations('상록');
+    expect(
+      results.map((station) => station.id),
+      contains('station-mid-sangnok'),
+    );
+    expect(results.map((station) => station.id), contains('station-sangnoksu'));
+  });
+
+  test('로컬 역 검색은 결과 상한 40과 완전일치 예외를 지킨다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await database.seedBaselineIfEmpty();
+    final buffer = StringBuffer();
+    for (var i = 0; i < 50; i++) {
+      if (i > 0) {
+        buffer.write(', ');
+      }
+      final id = 'station-bulk-$i';
+      final name = '상테스트$i';
+      buffer.write(
+        "('$id', '$name', 'Sang$i', '', '$name', "
+        "'수도권', 'LEVEL_1', 'OFFICIAL_FILE')",
+      );
+    }
+    await database.customStatement(
+      "INSERT INTO stations "
+      "(id, name_ko, name_en, name_sub, normalized_name, region, "
+      "data_quality_level, data_source_type) "
+      "VALUES ${buffer.toString()}",
+    );
+    final repository = DriftStationRepository(database: database);
+
+    final prefixResults = await repository.searchStations('상');
+    expect(prefixResults.length, lessThanOrEqualTo(40));
+
+    // 동명 완전일치가 40을 넘어도 잘리지 않는다.
+    final exactBuffer = StringBuffer();
+    for (var i = 0; i < 45; i++) {
+      if (i > 0) {
+        exactBuffer.write(', ');
+      }
+      exactBuffer.write(
+        "('station-exact-$i', '동일역명', 'Same$i', '', '동일역명', "
+        "'수도권', 'LEVEL_1', 'OFFICIAL_FILE')",
+      );
+    }
+    await database.customStatement(
+      "INSERT INTO stations "
+      "(id, name_ko, name_en, name_sub, normalized_name, region, "
+      "data_quality_level, data_source_type) "
+      "VALUES ${exactBuffer.toString()}",
+    );
+    repository.invalidateStationSummaryCache();
+    final exactResults = await repository.searchStations('동일역명');
+    expect(exactResults.length, greaterThanOrEqualTo(45));
+    expect(exactResults.every((station) => station.nameKo == '동일역명'), isTrue);
+  });
+
   test('노선 필터 검색과 노선 목록은 로컬 라인 매핑을 사용한다', () async {
     final database = CatalogDatabase.memory();
     addTearDown(database.close);

--- a/apps/mobile/test/features/stations/station_search_index_test.dart
+++ b/apps/mobile/test/features/stations/station_search_index_test.dart
@@ -1,0 +1,51 @@
+import 'package:easysubway_mobile/features/stations/data/station_search_index.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('prefix lookup은 lower-bound부터 startsWith 후보만 모은다', () {
+    final index = StationSearchIndex.build(const [
+      StationSearchIndexStationRow(
+        stationId: 'a',
+        koreanTerms: ['가산', '가산역'],
+        englishTerms: ['gasan'],
+        subnameTerms: [],
+        chosungTerms: ['ㄱㅅ'],
+      ),
+      StationSearchIndexStationRow(
+        stationId: 'b',
+        koreanTerms: ['상록수', '상록수역'],
+        englishTerms: ['sangnoksu'],
+        subnameTerms: [],
+        chosungTerms: ['ㅅㄹㅅ'],
+      ),
+      StationSearchIndexStationRow(
+        stationId: 'c',
+        koreanTerms: ['산본', '산본역'],
+        englishTerms: ['sanbon'],
+        subnameTerms: [],
+        chosungTerms: ['ㅅㅂ'],
+      ),
+    ]);
+
+    expect(index.lookupNamePrefix('상'), {'b'});
+    expect(index.lookupNamePrefix('sang'), {'b'});
+    expect(index.lookupChosungPrefix('ㅅ'), {'b', 'c'});
+    expect(index.lookupChosungPrefix('ㅅㅂ'), {'c'});
+    expect(index.lookupNamePrefix('없는'), isEmpty);
+  });
+
+  test('동일 역의 여러 term은 station id로 중복 제거된다', () {
+    final index = StationSearchIndex.build(const [
+      StationSearchIndexStationRow(
+        stationId: 'gongneung',
+        koreanTerms: ['공릉', '공릉역'],
+        englishTerms: [],
+        subnameTerms: ['서울과학기술대'],
+        chosungTerms: ['ㄱㄹ', 'ㅅㅇㄱㅎㄱㅅㄷ'],
+      ),
+    ]);
+
+    expect(index.lookupNamePrefix('공'), {'gongneung'});
+    expect(index.lookupNamePrefix('서울'), {'gongneung'});
+  });
+}

--- a/apps/mobile/test/features/stations/station_search_perf_benchmark_test.dart
+++ b/apps/mobile/test/features/stations/station_search_perf_benchmark_test.dart
@@ -1,0 +1,59 @@
+import 'package:easysubway_mobile/core/database/catalog/catalog_database.dart';
+import 'package:easysubway_mobile/features/stations/data/drift_station_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// wall-clock을 assert하지 않는다. 로그는 Stage 0/재측정 근거용이다.
+void main() {
+  test('검색 warm 경로 대표 질의 소요시간을 기록한다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await database.seedBaselineIfEmpty();
+
+    final buffer = StringBuffer();
+    for (var i = 0; i < 800; i++) {
+      if (i > 0) {
+        buffer.write(', ');
+      }
+      final syllable = String.fromCharCode(0xAC00 + (i % 11172));
+      final name = '$syllable역$i';
+      buffer.write(
+        "('station-perf-$i', '$name', 'En$i', '', '$name', "
+        "'수도권', 'LEVEL_1', 'OFFICIAL_FILE')",
+      );
+    }
+    await database.customStatement(
+      "INSERT INTO stations "
+      "(id, name_ko, name_en, name_sub, normalized_name, region, "
+      "data_quality_level, data_source_type) "
+      "VALUES ${buffer.toString()}",
+    );
+
+    final repository = DriftStationRepository(database: database);
+    final warmSw = Stopwatch()..start();
+    await repository.warmSearchCache();
+    warmSw.stop();
+
+    Future<int> micros(String query) async {
+      final samples = <int>[];
+      for (var i = 0; i < 8; i++) {
+        final sw = Stopwatch()..start();
+        await repository.searchStations(query);
+        sw.stop();
+        samples.add(sw.elapsedMicroseconds);
+      }
+      samples.sort();
+      return samples[samples.length ~/ 2];
+    }
+
+    final queries = ['ㅅ', 'ㅅㅂ', '상', '상록', 'sang', '없는역xyz'];
+    final lines = <String>['warm_index_build_us=${warmSw.elapsedMicroseconds}'];
+    for (final query in queries) {
+      final medianUs = await micros(query);
+      lines.add('query=$query median_us=$medianUs');
+    }
+
+    // ignore: avoid_print
+    print('EASY_SUBWAY_SEARCH_BENCH ${lines.join(' | ')}');
+    expect(lines, isNotEmpty);
+  });
+}


### PR DESCRIPTION
## 관련 이슈

Closes #2454

## 작업 배경

`#2452`로 초성·debounce·이전 결과 유지·warm term prime까지 반영된 뒤에도, warm 검색은 전 역 linear `matchRank`를 돌리고 노선도 cold 진입은 structured picture record가 첫 프레임 build를 막을 수 있다. 측정 우선으로 검색 인덱스와 cold paint 이관만 적용하고, isolate는 warm 검색이 frame budget을 침범하지 않아 미도입했다.

## 작업 내용

- `StationSearchIndex`: 정렬 term 테이블 + lower-bound prefix 후보 조회
- `DriftStationRepository`: 초성/이름 prefix fast path, substring 선형 fallback, warm memoized index, 실패 Future 비캐시, invalidateation 연동
- `EASY_SUBWAY_PERF_LOGS` compile-time 성능 계측 (`easy_subway_perf.dart`)
- `StructuredRouteMapView`: label layout·picture record를 post-frame으로 이관(cold 첫 프레임 분리). 기존 basemap Picture·RepaintBoundary 유지
- 계약/회귀 테스트·host warm 벤치 테스트 추가
- isolate worker: 미도입(측정 근거 — warm median ≪ 4ms)

## 검증

- 실행한 명령과 결과:
  - `flutter test test/features/stations/station_search_index_test.dart` → passed
  - `flutter test test/features/stations/drift_station_repository_test.dart` → passed
  - `flutter test test/features/stations/station_search_perf_benchmark_test.dart` → passed (warm median: ㅅ 89µs, 상록 839µs)
  - `flutter test test/station_search_test.dart --name 'showPendingSearch|재검색|빈 입력|초성'` → 4 passed
  - `flutter test test/features/network_map/presentation/structured_route_map_painter_test.dart` → passed (첫 프레임 picture defer 포함)
  - `flutter test test/widget_test.dart --name '지도 chrome'` → passed
  - `flutter analyze` (변경 경로) → No issues found
  - SM A175N profile APK 설치 (`EASY_SUBWAY_PERF_LOGS=true`)

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 검색 계약·인덱스 | Android/iOS 공통 | unit test | drift/index/station_search_test | green |
| chrome 비재빌드 | Android/iOS 공통 | widget test | widget_test chrome | green |
| cold picture defer | Android/iOS 공통 | widget test | structured_route_map_painter_test | green |
| warm 검색 소요 | host | bench test (wall-clock assert 없음) | median ≪ 4ms | isolate 미도입 |
| profile 빌드 | Android SM A175N | profile APK 설치 | 기기 설치 성공, 90Hz | 수동 체감은 QA 보완 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - prefix index + substring fallback이 `#2452` matchRank/상한(`max(40, exactCount)`)/region·lineId 필터를 보존하는지
  - warm index Future 실패 재시도·invalidate 경로
  - structured picture post-frame 이관 시 첫 프레임 빈 오버레이가 수용 가능한지
  - isolate 미도입 판단(측정 근거)이 타당한지

## 리스크

- substring fallback은 여전히 O(N) contains 검사(짧은 초성 인덱스가 주 이득)
- cold 진입 첫 프레임은 basemap만 보이고 라벨이 한 프레임 늦게 붙을 수 있음
- 실기기 DevTools frame before/after 수치는 host bench로 대체했고, QA 수동 profile 확인이 보완 필요

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 역 이름, 영문명, 부가 명칭 및 초성 기반 검색 인덱스를 추가했습니다.
  * 검색 결과의 접두사·부분 문자열 매칭과 중복 제거를 지원합니다.
  * 선택적으로 성능 측정 로그를 확인할 수 있습니다.

* **개선 사항**
  * 역 검색 속도와 캐시 활용을 개선했습니다.
  * 노선도 첫 화면 렌더링 부담을 줄이고 화면 표시를 더 원활하게 했습니다.

* **테스트**
  * 검색 정확도, 결과 제한, 캐시 동작 및 노선도 초기 렌더링 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->