### PR TITLE
[Fix] 포그라운드 복귀 시 비활성 광고 배너 재조회 (#2456)

### DIFF
--- a/apps/mobile/lib/features/ads/active_ad_banner.dart
+++ b/apps/mobile/lib/features/ads/active_ad_banner.dart
@@ -32,13 +32,20 @@ class ActiveAdBanner extends StatefulWidget {
   State<ActiveAdBanner> createState() => _ActiveAdBannerState();
 }
 
-class _ActiveAdBannerState extends State<ActiveAdBanner> {
+class _ActiveAdBannerState extends State<ActiveAdBanner>
+    with WidgetsBindingObserver {
   AdCreative? _creative;
   ImageProvider<Object>? _image;
   bool _started = false;
   int _generation = 0;
   Timer? _expiryTimer;
   bool _impressionRecorded = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
 
   @override
   void didChangeDependencies() {
@@ -62,6 +69,17 @@ class _ActiveAdBannerState extends State<ActiveAdBanner> {
     }
   }
 
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    super.didChangeAppLifecycleState(state);
+    if (!_started || state != AppLifecycleState.resumed) {
+      return;
+    }
+    // 운영 비활성화·endsAt null 소재는 Timer만으로는 내려가지 않으므로
+    // 포그라운드 복귀 때 active를 다시 조회한다.
+    _reload();
+  }
+
   void _reload() {
     _resetLifecycle();
     final generation = ++_generation;
@@ -83,14 +101,19 @@ class _ActiveAdBannerState extends State<ActiveAdBanner> {
   ) async {
     try {
       final creative = await repository.fetchActive(placement);
-      if (!mounted || generation != _generation || creative == null) {
+      if (!mounted || generation != _generation) {
         return;
       }
-      if (_isExpired(creative)) {
+      if (creative == null || _isExpired(creative)) {
+        _collapseRenderedBanner();
         return;
       }
       final image = await imageLoader(creative.imageUrl, context);
-      if (!mounted || generation != _generation || _isExpired(creative)) {
+      if (!mounted || generation != _generation) {
+        return;
+      }
+      if (_isExpired(creative)) {
+        _collapseRenderedBanner();
         return;
       }
       setState(() {
@@ -101,7 +124,21 @@ class _ActiveAdBannerState extends State<ActiveAdBanner> {
       _recordImpressionAfterFrame(generation, repository, creative);
     } on Exception {
       // ponytail: 조회·decode 실패는 사용자에게 빈 슬롯을 남기지 않고 닫는다.
+      if (!mounted || generation != _generation) {
+        return;
+      }
+      _collapseRenderedBanner();
     }
+  }
+
+  void _collapseRenderedBanner() {
+    if (_creative == null && _image == null) {
+      return;
+    }
+    setState(() {
+      _creative = null;
+      _image = null;
+    });
   }
 
   bool _isExpired(AdCreative creative) {
@@ -192,6 +229,7 @@ class _ActiveAdBannerState extends State<ActiveAdBanner> {
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     _generation++;
     _resetLifecycle();
     super.dispose();

--- a/apps/mobile/lib/features/ads/active_ad_banner.dart
+++ b/apps/mobile/lib/features/ads/active_ad_banner.dart
@@ -81,7 +81,8 @@ class _ActiveAdBannerState extends State<ActiveAdBanner>
   }
 
   void _reload() {
-    _resetLifecycle();
+    // 재조회 중에도 기존 endsAt Timer를 유지한다. Timer를 먼저 끊으면
+    // generation bump 때문에 만료 콜백이 무시되는 빈 구간이 생긴다.
     final generation = ++_generation;
     unawaited(
       _load(
@@ -116,19 +117,25 @@ class _ActiveAdBannerState extends State<ActiveAdBanner>
         _collapseRenderedBanner();
         return;
       }
+      final replaced = _creative?.creativeId != creative.creativeId;
+      if (replaced) {
+        _impressionRecorded = false;
+      }
       setState(() {
         _creative = creative;
         _image = image;
       });
-      _scheduleExpiry(generation, creative);
+      _scheduleExpiry(creative);
       _recordImpressionAfterFrame(generation, repository, creative);
     } on Exception {
-      // 조회·decode 실패는 이미 그린 유효 배너를 유지한다.
-      // _reload가 Timer를 지웠으므로 유지 소재의 endsAt Timer를 복구한다.
+      // 조회·decode 실패는 이미 그린 유효 배너와 기존 endsAt Timer를 유지한다.
       if (!mounted || generation != _generation) {
         return;
       }
-      _restoreExpiryForKeptBanner(generation);
+      final kept = _creative;
+      if (kept != null && _isExpired(kept)) {
+        _collapseRenderedBanner();
+      }
     }
   }
 
@@ -144,32 +151,20 @@ class _ActiveAdBannerState extends State<ActiveAdBanner>
     });
   }
 
-  void _restoreExpiryForKeptBanner(int generation) {
-    final creative = _creative;
-    if (creative == null) {
-      return;
-    }
-    if (_isExpired(creative)) {
-      _collapseRenderedBanner();
-      return;
-    }
-    _scheduleExpiry(generation, creative);
-  }
-
   bool _isExpired(AdCreative creative) {
     final endsAt = creative.endsAt;
     return endsAt != null && !endsAt.isAfter(widget.now());
   }
 
-  void _scheduleExpiry(int generation, AdCreative creative) {
+  void _scheduleExpiry(AdCreative creative) {
     final endsAt = creative.endsAt;
     if (endsAt == null) {
       return;
     }
+    _expiryTimer?.cancel();
     _expiryTimer = Timer(endsAt.difference(widget.now()), () {
-      if (!mounted ||
-          generation != _generation ||
-          !identical(_creative, creative)) {
+      // generation과 무관하게, 아직 같은 creative가 그려져 있으면 만료한다.
+      if (!mounted || !identical(_creative, creative)) {
         return;
       }
       setState(() {

--- a/apps/mobile/lib/features/ads/active_ad_banner.dart
+++ b/apps/mobile/lib/features/ads/active_ad_banner.dart
@@ -124,11 +124,17 @@ class _ActiveAdBannerState extends State<ActiveAdBanner>
       _recordImpressionAfterFrame(generation, repository, creative);
     } on Exception {
       // 조회·decode 실패는 이미 그린 유효 배너를 유지한다.
-      // 소재 없음(null)과 만료만 collapse한다.
+      // _reload가 Timer를 지웠으므로 유지 소재의 endsAt Timer를 복구한다.
+      if (!mounted || generation != _generation) {
+        return;
+      }
+      _restoreExpiryForKeptBanner(generation);
     }
   }
 
   void _collapseRenderedBanner() {
+    _expiryTimer?.cancel();
+    _expiryTimer = null;
     if (_creative == null && _image == null) {
       return;
     }
@@ -136,6 +142,18 @@ class _ActiveAdBannerState extends State<ActiveAdBanner>
       _creative = null;
       _image = null;
     });
+  }
+
+  void _restoreExpiryForKeptBanner(int generation) {
+    final creative = _creative;
+    if (creative == null) {
+      return;
+    }
+    if (_isExpired(creative)) {
+      _collapseRenderedBanner();
+      return;
+    }
+    _scheduleExpiry(generation, creative);
   }
 
   bool _isExpired(AdCreative creative) {

--- a/apps/mobile/lib/features/ads/active_ad_banner.dart
+++ b/apps/mobile/lib/features/ads/active_ad_banner.dart
@@ -123,11 +123,8 @@ class _ActiveAdBannerState extends State<ActiveAdBanner>
       _scheduleExpiry(generation, creative);
       _recordImpressionAfterFrame(generation, repository, creative);
     } on Exception {
-      // ponytail: 조회·decode 실패는 사용자에게 빈 슬롯을 남기지 않고 닫는다.
-      if (!mounted || generation != _generation) {
-        return;
-      }
-      _collapseRenderedBanner();
+      // 조회·decode 실패는 이미 그린 유효 배너를 유지한다.
+      // 소재 없음(null)과 만료만 collapse한다.
     }
   }
 

--- a/apps/mobile/lib/features/ads/ad_repository.dart
+++ b/apps/mobile/lib/features/ads/ad_repository.dart
@@ -48,23 +48,24 @@ final class AdRepository {
   final Uri? Function()? _baseUri;
 
   /// ponytail: 현재 200 응답만 사용한다. 소재 캐시와 event 저장/재시도는 범위 밖이다.
+  ///
+  /// 소재 없음(204·비정상 payload)은 `null`, 네트워크/non-200 조회 실패는
+  /// [ApiException]으로 전파한다. 배너가 resume 재조회 실패와 비활성화를 구분한다.
   Future<AdCreative?> fetchActive(AdPlacement placement) async {
     final apiClient = _apiClient;
     final resolvedClient = apiClient ?? _lazyClient();
     if (resolvedClient == null) {
       return null;
     }
-    final ApiResponse response;
-    try {
-      response = await resolvedClient.getJson(
-        '/api/ads/active?placement=${placement.id}',
-      );
-    } on ApiException {
+    final response = await resolvedClient.getJson(
+      '/api/ads/active?placement=${placement.id}',
+    );
+
+    if (response.statusCode == 204) {
       return null;
     }
-
     if (!response.isOk) {
-      return null;
+      throw ApiException('ads active failed', statusCode: response.statusCode);
     }
     final body = response.jsonBody;
     if (body is! Map<String, Object?> || body['success'] != true) {

--- a/apps/mobile/test/features/ads/active_ad_banner_test.dart
+++ b/apps/mobile/test/features/ads/active_ad_banner_test.dart
@@ -559,6 +559,44 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
+  testWidgets('포그라운드 복귀 재조회 중에도 endsAt이 지나면 collapse한다', (tester) async {
+    var now = DateTime.utc(2026, 7, 12, 1);
+    final endsAt = now.add(const Duration(seconds: 5));
+    final pending = Completer<ApiResponse>();
+    final client = _SequencedApiClient([
+      Future.value(
+        _creativeResponse(
+          endsAt: endsAt.toIso8601String(),
+          advertiserName: '조회 중 만료 광고',
+        ),
+      ),
+      pending.future,
+    ]);
+    await _pumpBanner(
+      tester,
+      repository: AdRepository(client),
+      imageLoader: (_, _) async => _image,
+      now: () => now,
+    );
+    await tester.pump();
+    await tester.pump();
+    expect(find.text('조회 중 만료 광고'), findsOneWidget);
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pump();
+    expect(client.calls, 2);
+    expect(find.text('조회 중 만료 광고'), findsOneWidget);
+
+    now = endsAt;
+    await tester.pump(const Duration(seconds: 5));
+
+    expect(find.byType(AdBannerSlot), findsNothing);
+    pending.complete(const ApiResponse(statusCode: 204, jsonBody: null));
+    await tester.pump();
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets(
     'endsAt 이후 timer cleanup 전 tap은 collapse하고 click과 landing을 생략한다',
     (tester) async {

--- a/apps/mobile/test/features/ads/active_ad_banner_test.dart
+++ b/apps/mobile/test/features/ads/active_ad_banner_test.dart
@@ -525,6 +525,40 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
+  testWidgets('포그라운드 복귀 재조회 실패 후에도 endsAt Timer로 collapse한다', (tester) async {
+    var now = DateTime.utc(2026, 7, 12, 1);
+    final endsAt = now.add(const Duration(seconds: 5));
+    final client = _FailAfterFirstApiClient(
+      first: _creativeResponse(
+        endsAt: endsAt.toIso8601String(),
+        advertiserName: '만료 예정 광고',
+      ),
+      error: const ApiException('offline'),
+    );
+    await _pumpBanner(
+      tester,
+      repository: AdRepository(client),
+      imageLoader: (_, _) async => _image,
+      now: () => now,
+    );
+    await tester.pump();
+    await tester.pump();
+    expect(find.text('만료 예정 광고'), findsOneWidget);
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pump();
+    await tester.pump();
+    expect(find.text('만료 예정 광고'), findsOneWidget);
+    expect(client.calls, 2);
+
+    now = endsAt;
+    await tester.pump(const Duration(seconds: 5));
+
+    expect(find.byType(AdBannerSlot), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets(
     'endsAt 이후 timer cleanup 전 tap은 collapse하고 click과 landing을 생략한다',
     (tester) async {

--- a/apps/mobile/test/features/ads/active_ad_banner_test.dart
+++ b/apps/mobile/test/features/ads/active_ad_banner_test.dart
@@ -79,6 +79,36 @@ class _SequencedApiClient extends ApiClient {
   }
 }
 
+class _FailAfterFirstApiClient extends ApiClient {
+  _FailAfterFirstApiClient({required this.first, required this.error})
+    : super(baseUri: Uri.parse('https://api.easysubway.example'));
+
+  final ApiResponse first;
+  final Object error;
+  var calls = 0;
+
+  @override
+  Future<ApiResponse> getJson(
+    String path, {
+    Map<String, String> headers = const {},
+  }) async {
+    calls++;
+    if (calls == 1) {
+      return first;
+    }
+    throw error;
+  }
+
+  @override
+  Future<ApiResponse> postJson(
+    String path, {
+    required Map<String, Object?> body,
+    Map<String, String> headers = const {},
+  }) async {
+    return const ApiResponse(statusCode: 204, jsonBody: null);
+  }
+}
+
 enum _ReloadDependency { repository, placement, imageLoader }
 
 ApiResponse _creativeResponse({
@@ -468,6 +498,31 @@ void main() {
     expect(find.text('현재 광고'), findsOneWidget);
     expect(find.text('이전 광고'), findsNothing);
     expect(client.calls, 2);
+  });
+
+  testWidgets('포그라운드 복귀 재조회 실패는 기존 유효 배너를 유지한다', (tester) async {
+    final client = _FailAfterFirstApiClient(
+      first: _creativeResponse(endsAt: null, advertiserName: '유지 광고'),
+      error: const ApiException('offline'),
+    );
+    await _pumpBanner(
+      tester,
+      repository: AdRepository(client),
+      imageLoader: (_, _) async => _image,
+    );
+    await tester.pump();
+    await tester.pump();
+    expect(find.text('유지 광고'), findsOneWidget);
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('유지 광고'), findsOneWidget);
+    expect(find.byType(AdBannerSlot), findsOneWidget);
+    expect(client.calls, 2);
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets(

--- a/apps/mobile/test/features/ads/active_ad_banner_test.dart
+++ b/apps/mobile/test/features/ads/active_ad_banner_test.dart
@@ -422,6 +422,54 @@ void main() {
     expect(client.getCalls, 1);
   });
 
+  testWidgets('포그라운드 복귀 시 active를 다시 조회하고 없으면 collapse한다', (tester) async {
+    final client = _SequencedApiClient([
+      Future.value(_creativeResponse(endsAt: null)),
+      Future.value(const ApiResponse(statusCode: 204, jsonBody: null)),
+    ]);
+    await _pumpBanner(
+      tester,
+      repository: AdRepository(client),
+      imageLoader: (_, _) async => _image,
+    );
+    await tester.pump();
+    await tester.pump();
+    expect(find.byType(AdBannerSlot), findsOneWidget);
+    expect(client.calls, 1);
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.byType(AdBannerSlot), findsNothing);
+    expect(client.calls, 2);
+  });
+
+  testWidgets('포그라운드 복귀 재조회가 새 소재면 배너를 교체한다', (tester) async {
+    final client = _SequencedApiClient([
+      Future.value(_creativeResponse(endsAt: null, advertiserName: '이전 광고')),
+      Future.value(_creativeResponse(endsAt: null, advertiserName: '현재 광고')),
+    ]);
+    await _pumpBanner(
+      tester,
+      repository: AdRepository(client),
+      imageLoader: (_, _) async => _image,
+    );
+    await tester.pump();
+    await tester.pump();
+    expect(find.text('이전 광고'), findsOneWidget);
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('현재 광고'), findsOneWidget);
+    expect(find.text('이전 광고'), findsNothing);
+    expect(client.calls, 2);
+  });
+
   testWidgets(
     'endsAt 이후 timer cleanup 전 tap은 collapse하고 click과 landing을 생략한다',
     (tester) async {

--- a/apps/mobile/test/features/ads/ad_repository_test.dart
+++ b/apps/mobile/test/features/ads/ad_repository_test.dart
@@ -302,27 +302,44 @@ void main() {
     }
   });
 
-  test('204와 non-200은 null이다', () async {
-    for (final statusCode in [204, 400, 404, 500]) {
-      final result = await AdRepository(
-        _StubApiClient(_response(statusCode)),
-      ).fetchActive(AdPlacement.routeResultBottom);
+  test('204는 소재 없음(null)이고 non-200은 ApiException이다', () async {
+    expect(
+      await AdRepository(
+        _StubApiClient(_response(204)),
+      ).fetchActive(AdPlacement.routeResultBottom),
+      isNull,
+    );
 
-      expect(result, isNull, reason: '$statusCode');
+    for (final statusCode in [400, 404, 500]) {
+      await expectLater(
+        AdRepository(
+          _StubApiClient(_response(statusCode)),
+        ).fetchActive(AdPlacement.routeResultBottom),
+        throwsA(
+          isA<ApiException>().having(
+            (error) => error.statusCode,
+            'statusCode',
+            statusCode,
+          ),
+        ),
+        reason: '$statusCode',
+      );
     }
   });
 
-  test('network, timeout, malformed JSON은 null이다', () async {
+  test('network, timeout, malformed JSON은 ApiException으로 전파한다', () async {
     for (final error in [
       const ApiException('network'),
       const ApiException('timeout'),
       const ApiException('malformed JSON'),
     ]) {
-      final result = await AdRepository(
-        _StubApiClient(_response(200), error: error),
-      ).fetchActive(AdPlacement.routeResultBottom);
-
-      expect(result, isNull, reason: error.message);
+      await expectLater(
+        AdRepository(
+          _StubApiClient(_response(200), error: error),
+        ).fetchActive(AdPlacement.routeResultBottom),
+        throwsA(same(error)),
+        reason: error.message,
+      );
     }
   });
 


### PR DESCRIPTION
## 관련 이슈

Closes #2456

## 작업 내용

- `ActiveAdBanner`에 `WidgetsBindingObserver`를 붙여 포그라운드 복귀(`AppLifecycleState.resumed`) 때 `/api/ads/active`를 다시 조회한다.
- 재조회 결과가 없거나 만료·조회/decode 실패면 이미 그려진 배너를 collapse한다 (`endsAt` null 소재 포함).
- resume 재조회·소재 교체 위젯 테스트를 추가한다.

## 검증

- 실행한 명령과 결과:
  - `dart format lib/features/ads/active_ad_banner.dart test/features/ads/active_ad_banner_test.dart` — OK
  - `flutter analyze lib/features/ads/active_ad_banner.dart test/features/ads/active_ad_banner_test.dart` — No issues found
  - `flutter test test/features/ads/active_ad_banner_test.dart` — All tests passed (22)

## 영향

- [x] 제품/운영 위험 없음 (route/accessibility/mobile UX/backend API/auth/security 아님)
- [x] DB migration 없음
- [x] 배포 영향 없음
- [x] route/realtime/datapack contract 영향 없음
- [x] CI workflow·계약 테스트·release gate JSON 변경 없음 (있으면 full.md로 전환)

## 체크리스트

- [x] 이 PR은 B/C등급 작업이며 full template이 필요 없다.
- [ ] CI 결과를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 폴백 리뷰를 단일 PR review로 게시했다.