### PR TITLE
[Feat] 하단 역 패널 즉시 표시 — 스피너 제거·표시/요청 상태 분리

### DIFF
--- a/apps/mobile/lib/features/network_map/presentation/nearby_direction_columns.dart
+++ b/apps/mobile/lib/features/network_map/presentation/nearby_direction_columns.dart
@@ -145,7 +145,7 @@ class NearbyPanelColumns extends StatelessWidget {
   }
 
   Widget _buildColumn(NearbyPanelColumn column) {
-    return Column(
+    final body = Column(
       crossAxisAlignment: CrossAxisAlignment.center,
       mainAxisSize: MainAxisSize.min,
       children: [
@@ -160,11 +160,20 @@ class NearbyPanelColumns extends StatelessWidget {
         if (column.hasData)
           ...column.rows
         else
-          const SizedBox(
-            height: 46,
-            child: Center(child: Text('-', style: dashStyle)),
+          // 시각 대시('-')는 TalkBack에 반복 발화되지 않게 제외하고,
+          // 열 단위 Semantics 라벨로만 의미를 전달한다(#2453 Task 5).
+          const ExcludeSemantics(
+            child: SizedBox(
+              height: 46,
+              child: Center(child: Text('-', style: dashStyle)),
+            ),
           ),
       ],
     );
+    if (column.hasData) {
+      return body;
+    }
+    final label = column.title.isEmpty ? '정보 없음' : '${column.title} 정보 없음';
+    return Semantics(label: label, excludeSemantics: true, child: body);
   }
 }

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -529,17 +529,25 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
   bool _initialNearbyFocusStarted = false;
   int _selectionClearRevision = 0;
   int _nearestStationRequestToken = 0;
+
+  /// 하단 패널 데이터 요청 generation. 역·호선과 함께 [_NearbyPanelRequestKey]로
+  /// 늦은 응답을 걸러 낸다(#2453 Task 3).
   int _nearbyDataRequestToken = 0;
   // #2200: 캔버스 역 탭 → StationSearchResult 해석은 비동기라 연속 탭 시 마지막
   // 탭만 패널에 반영되도록 토큰으로 앞선 요청을 무효화한다.
   int _canvasTapPanelToken = 0;
-  RealtimeSnapshot _nearbyRealtime = const RealtimeSnapshot.loading();
-  _NearbyPanelDataSource _nearbyDataSource = _NearbyPanelDataSource.realtime;
-  StationTimetable? _nearbyTimetable;
-  bool _nearbyTimetableLoading = false;
 
-  /// 패널을 열 때만 실시간→시간표 자동 전환. 사용자가 실시간 탭을 다시 고르면 끈다.
-  bool _nearbyAllowRealtimeAutoFallback = true;
+  /// 성공한 실시간만 stationId+lineId 키로 보관. unavailable/loading/empty로 덮지 않는다.
+  _NearbyRealtimeDisplay? _nearbyRealtimeDisplay;
+
+  /// 성공한 시간표만 stationId+lineId 키로 보관. 실패로 성공 캐시를 지우지 않는다.
+  _NearbyTimetableDisplay? _nearbyTimetableDisplay;
+  _NearbyPanelDataSource _nearbyDataSource = _NearbyPanelDataSource.realtime;
+
+  /// 요청 중복 방지용 in-flight. UI 렌더 분기에는 쓰지 않는다(#2453).
+  /// 이전 요청 완료가 현재 요청 플래그를 내리지 않도록 현재 키일 때만 false로 돌린다.
+  bool _nearbyRealtimeRequestInFlight = false;
+  bool _nearbyTimetableRequestInFlight = false;
 
   /// 하단 패널 실시간은 API 기본 8초보다 짧게 끊고 시간표로 넘긴다.
   static const _nearbyRealtimeTimeout = Duration(seconds: 2);
@@ -604,7 +612,7 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
     }
     final request = widget.focusStationRequest;
     if (request != null && request != oldWidget.focusStationRequest) {
-      _showStationPanelFromSearch(request);
+      _openNearbyStationPanel(request);
       WidgetsBinding.instance.addPostFrameCallback((_) {
         widget.onFocusStationRequestHandled?.call();
       });
@@ -677,7 +685,7 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
     if (!mounted) {
       return;
     }
-    _showStationPanelFromSearch(result, preferredLine: line);
+    _openNearbyStationPanel(result, preferredLine: line);
   }
 
   Future<void> _recordSelectedStationSearch(
@@ -701,40 +709,92 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
     }
   }
 
-  void _showStationPanelFromSearch(
-    StationSearchResult result, {
+  /// 검색·GPS·캔버스(신원 해석 후) 공통 오픈. 패널을 즉시 표시하고
+  /// 실시간/시간표 조회는 백그라운드에서만 시작한다(표시 전 await 금지).
+  void _openNearbyStationPanel(
+    StationSearchResult station, {
     StationSearchLine? preferredLine,
   }) {
-    final selectedLine = preferredLine ?? result.lines.firstOrNull;
+    final selectedLine = preferredLine ?? station.lines.firstOrNull;
+    // generation을 먼저 올려 이전 요청을 무효화한 뒤 패널을 연다.
+    final generation = ++_nearbyDataRequestToken;
+    final request = selectedLine == null
+        ? null
+        : _NearbyPanelRequestKey(
+            stationId: station.id,
+            lineId: selectedLine.id,
+            generation: generation,
+          );
     setState(() {
       _nearestStationRequestToken++;
       _selectionClearRevision++;
-      // 호선이 없어도 이전 역의 비동기 로드가 이 패널을 덮지 않게 무효화한다.
-      _nearbyDataRequestToken++;
       _nearbyPanelVisible = true;
-      _nearbySelectedStationId = result.id;
+      _nearbySelectedStationId = station.id;
       _nearbySelectedLineId = selectedLine?.id;
-      _nearbyPanelData = _NetworkMapNearbyPanelData.success([result]);
-      _nearbyRealtime = selectedLine == null
-          ? const RealtimeSnapshot(status: RealtimeSnapshotStatus.unsupported)
-          : const RealtimeSnapshot.loading();
-      // 로컬 시간표를 먼저 보여 탭 즉시 내용이 뜨게 한다. 실시간은 백그라운드 로드.
+      _nearbyPanelData = _NetworkMapNearbyPanelData.success([station]);
+      // 모든 오픈 경로 기본 탭은 시간표. 실시간은 백그라운드 prefetch.
+      // keyed display는 지우지 않는다 — 키 불일치면 미표시, 일치하면 즉시 재사용.
       _nearbyDataSource = _NearbyPanelDataSource.timetable;
-      _nearbyTimetable = null;
-      _nearbyTimetableLoading = selectedLine != null;
-      _nearbyAllowRealtimeAutoFallback = true;
-      _searchFanMenuStationId = result.id;
+      _nearbyRealtimeRequestInFlight = selectedLine != null;
+      _nearbyTimetableRequestInFlight = selectedLine != null;
+      _searchFanMenuStationId = station.id;
     });
-    if (selectedLine != null) {
-      _startNearbyPanelDataLoads(result, selectedLine);
+    if (request != null && selectedLine != null) {
+      _startNearbyPanelDataLoads(station, selectedLine, request);
     }
+  }
+
+  /// 현재 패널에 반영해도 되는 최신 요청인지 검사한다.
+  /// `mounted`만으로 setState 하지 않도록 완료 경로에서 반드시 호출한다.
+  bool _isCurrentNearbyRequest(_NearbyPanelRequestKey request) {
+    return mounted &&
+        _nearbyPanelVisible &&
+        request.generation == _nearbyDataRequestToken &&
+        request.stationId == _nearbySelectedStationId &&
+        request.lineId == _nearbySelectedLineId;
+  }
+
+  bool _nearbyRealtimeDisplayMatchesCurrent() {
+    final display = _nearbyRealtimeDisplay;
+    return display != null &&
+        display.stationId == _nearbySelectedStationId &&
+        display.lineId == _nearbySelectedLineId;
+  }
+
+  bool _nearbyTimetableDisplayMatchesCurrent() {
+    final display = _nearbyTimetableDisplay;
+    return display != null &&
+        display.stationId == _nearbySelectedStationId &&
+        display.lineId == _nearbySelectedLineId;
+  }
+
+  /// 현재 역·호선 키와 맞는 성공 캐시만 넘긴다. 없으면 loading → 방면 골격.
+  RealtimeSnapshot get _nearbyRealtimeForDisplay {
+    final display = _nearbyRealtimeDisplay;
+    if (display != null &&
+        display.stationId == _nearbySelectedStationId &&
+        display.lineId == _nearbySelectedLineId) {
+      return display.snapshot;
+    }
+    return const RealtimeSnapshot.loading();
+  }
+
+  StationTimetable? get _nearbyTimetableForDisplay {
+    final display = _nearbyTimetableDisplay;
+    if (display != null &&
+        display.stationId == _nearbySelectedStationId &&
+        display.lineId == _nearbySelectedLineId) {
+      return display.timetable;
+    }
+    return null;
   }
 
   /// #2200 캔버스에서 역을 탭하면(팬 메뉴는 canvas가 이미 띄운다) 그 역을
   /// 검색과 동일한 방식([StationSearchRepository.searchStations])으로
-  /// [StationSearchResult]로 해석해 [_showStationPanelFromSearch]와 같은 상태
-  /// 갱신으로 하단 역 정보 패널을 연다. 해석에 실패하면(저장소 없음·데이터 없음)
-  /// 패널을 열지 않고 canvas가 띄운 팬 메뉴만 유지한다.
+  /// [StationSearchResult]로 해석해 [_openNearbyStationPanel]로 하단 역 정보
+  /// 패널을 연다. 해석에 실패하면(저장소 없음·데이터 없음) 패널을 열지 않고
+  /// canvas가 띄운 팬 메뉴만 유지한다. 신원 해석 await는 허용되며, 해석 후
+  /// 데이터 로드는 fire-and-forget이다.
   Future<void> _handleCanvasStationTapped(NetworkMapStation station) async {
     final repository = widget.stationSearchRepository;
     if (repository == null) {
@@ -766,7 +826,7 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
     final preferredLine = match.lines
         .where((line) => line.id == station.lineId)
         .firstOrNull;
-    _showStationPanelFromSearch(match, preferredLine: preferredLine);
+    _openNearbyStationPanel(match, preferredLine: preferredLine);
   }
 
   /// #2109 검색 결과 탭으로 연 팬 메뉴가 닫히면(액션 선택·닫기·배경 탭·팬) 이
@@ -905,11 +965,10 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
                 onRegionSelected: (region) => _reload(region: region),
                 nearbyPanelVisible: _nearbyPanelVisible,
                 nearbyPanelData: _nearbyPanelData,
-                realtime: _nearbyRealtime,
+                realtime: _nearbyRealtimeForDisplay,
                 nearbySelectedLineId: _nearbySelectedLineId,
                 nearbyDataSource: _nearbyDataSource,
-                nearbyTimetable: _nearbyTimetable,
-                nearbyTimetableLoading: _nearbyTimetableLoading,
+                nearbyTimetable: _nearbyTimetableForDisplay,
                 nearbyLookupMessage: _nearbyLookupMessage,
                 adjacentStations: const _NetworkMapAdjacentStations(),
                 onCurrentLocationTap: _showNearestStationFanMenu,
@@ -952,11 +1011,10 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
                 onRegionSelected: (region) => _reload(region: region),
                 nearbyPanelVisible: _nearbyPanelVisible,
                 nearbyPanelData: _nearbyPanelData,
-                realtime: _nearbyRealtime,
+                realtime: _nearbyRealtimeForDisplay,
                 nearbySelectedLineId: _nearbySelectedLineId,
                 nearbyDataSource: _nearbyDataSource,
-                nearbyTimetable: _nearbyTimetable,
-                nearbyTimetableLoading: _nearbyTimetableLoading,
+                nearbyTimetable: _nearbyTimetableForDisplay,
                 nearbyLookupMessage: _nearbyLookupMessage,
                 adjacentStations: const _NetworkMapAdjacentStations(),
                 onCurrentLocationTap: _showNearestStationFanMenu,
@@ -1005,11 +1063,10 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
               onRegionSelected: (region) => _reload(region: region),
               nearbyPanelVisible: _nearbyPanelVisible,
               nearbyPanelData: _nearbyPanelData,
-              realtime: _nearbyRealtime,
+              realtime: _nearbyRealtimeForDisplay,
               nearbySelectedLineId: _nearbySelectedLineId,
               nearbyDataSource: _nearbyDataSource,
-              nearbyTimetable: _nearbyTimetable,
-              nearbyTimetableLoading: _nearbyTimetableLoading,
+              nearbyTimetable: _nearbyTimetableForDisplay,
               nearbyLookupMessage: _nearbyLookupMessage,
               adjacentStations: _adjacentStationsFor(data),
               onCurrentLocationTap: _showNearestStationFanMenu,
@@ -1158,29 +1215,18 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
         return;
       }
 
-      final firstLine = pendingResult.lines.firstOrNull;
-      setState(() {
-        if (regionChanged) {
+      if (regionChanged) {
+        setState(() {
           _selectedRegion = targetMap.data.selectedRegion;
           _future = Future.value(targetMap);
           _initialNearbyFocusStarted = true;
-        }
-        _nearbyPanelVisible = true;
-        _nearbySelectedStationId = pendingResult.id;
-        _nearbySelectedLineId = firstLine?.id;
-        _nearbyDataSource = _NearbyPanelDataSource.realtime;
-        _nearbyRealtime = firstLine == null
-            ? const RealtimeSnapshot(status: RealtimeSnapshotStatus.unsupported)
-            : const RealtimeSnapshot.loading();
-        _nearbyTimetable = null;
-        _nearbyTimetableLoading = firstLine != null;
-        _nearbyAllowRealtimeAutoFallback = true;
-        _nearbyPanelData = _NetworkMapNearbyPanelData.success([pendingResult]);
-        _searchFanMenuStationId = pendingResult.id;
-      });
-      if (firstLine != null) {
-        _startNearbyPanelDataLoads(pendingResult, firstLine);
+        });
       }
+      // 역 확정 후 공통 오픈으로 즉시 표시(기본 탭 시간표). 실시간/시간표 await 금지.
+      _openNearbyStationPanel(
+        pendingResult,
+        preferredLine: pendingResult.lines.firstOrNull,
+      );
     } on CurrentLocationException catch (error) {
       if (!isCurrentRequest()) {
         return;
@@ -1284,44 +1330,45 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
   }
 
   void _resetNearbyPanelState() {
+    // 닫힌 뒤 완료되는 요청이 UI를 건드리지 않도록 generation을 무효화한다.
     _nearbyDataRequestToken++;
     _nearbyPanelVisible = false;
     _nearbySelectedStationId = null;
     _nearbySelectedLineId = null;
     _nearbyPanelData = const _NetworkMapNearbyPanelData.idle();
-    _nearbyRealtime = const RealtimeSnapshot.loading();
+    _nearbyRealtimeDisplay = null;
     _nearbyDataSource = _NearbyPanelDataSource.realtime;
-    _nearbyTimetable = null;
-    _nearbyTimetableLoading = false;
-    _nearbyAllowRealtimeAutoFallback = true;
+    _nearbyTimetableDisplay = null;
+    _nearbyRealtimeRequestInFlight = false;
+    _nearbyTimetableRequestInFlight = false;
   }
 
-  /// 실시간과 시간표를 같은 토큰으로 병렬 로드한다. 실시간 실패 시 즉시 시간표로 넘긴다.
+  /// 실시간과 시간표를 같은 요청 키로 병렬 로드한다. 실시간 실패 시 즉시 시간표로 넘긴다.
   void _startNearbyPanelDataLoads(
     StationSearchResult station,
     StationSearchLine line,
+    _NearbyPanelRequestKey request,
   ) {
-    final requestToken = ++_nearbyDataRequestToken;
-    unawaited(_loadNearbyRealtime(station, line, requestToken: requestToken));
-    unawaited(
-      _loadNearbyTimetable(station, line, reuseRequestToken: requestToken),
-    );
+    unawaited(_loadNearbyRealtime(station, line, request: request));
+    unawaited(_loadNearbyTimetable(station, line, request: request));
   }
 
   Future<void> _loadNearbyRealtime(
     StationSearchResult station,
     StationSearchLine line, {
-    int? requestToken,
+    required _NearbyPanelRequestKey request,
   }) async {
-    final token = requestToken ?? ++_nearbyDataRequestToken;
     final repository = widget.realtimeRepository;
     if (repository == null) {
-      if (mounted && token == _nearbyDataRequestToken) {
-        setState(() => _nearbyRealtime = const RealtimeSnapshot.unavailable());
-        unawaited(
-          _fallbackNearbyPanelToTimetable(station, line, requestToken: token),
-        );
+      if (!_isCurrentNearbyRequest(request)) {
+        return;
       }
+      setState(() {
+        _nearbyRealtimeRequestInFlight = false;
+      });
+      unawaited(
+        _handleNearbyRealtimeUnavailable(station, line, request: request),
+      );
       return;
     }
     try {
@@ -1340,97 +1387,99 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
             _nearbyRealtimeTimeout,
             onTimeout: () => const RealtimeSnapshot.unavailable(),
           );
-      if (mounted && token == _nearbyDataRequestToken) {
-        setState(() => _nearbyRealtime = snapshot);
-        if (_nearbyRealtimeHasNoUsableData(snapshot)) {
-          unawaited(
-            _fallbackNearbyPanelToTimetable(station, line, requestToken: token),
-          );
-        }
+      if (!_isCurrentNearbyRequest(request)) {
+        return;
       }
-    } on RealtimeException catch (error) {
-      if (mounted && token == _nearbyDataRequestToken) {
+      if (_isCacheableNearbyRealtime(snapshot)) {
         setState(() {
-          _nearbyRealtime = RealtimeSnapshot(
-            status: RealtimeSnapshotStatus.unavailable,
-            message: error.message,
+          _nearbyRealtimeDisplay = _NearbyRealtimeDisplay(
+            stationId: request.stationId,
+            lineId: request.lineId,
+            snapshot: snapshot,
           );
+          _nearbyRealtimeRequestInFlight = false;
         });
-        unawaited(
-          _fallbackNearbyPanelToTimetable(station, line, requestToken: token),
-        );
+        return;
       }
+      // unavailable/empty/loading 등은 성공 캐시를 덮지 않는다.
+      setState(() {
+        _nearbyRealtimeRequestInFlight = false;
+      });
+      unawaited(
+        _handleNearbyRealtimeUnavailable(station, line, request: request),
+      );
+    } on RealtimeException {
+      if (!_isCurrentNearbyRequest(request)) {
+        return;
+      }
+      setState(() {
+        _nearbyRealtimeRequestInFlight = false;
+      });
+      unawaited(
+        _handleNearbyRealtimeUnavailable(station, line, request: request),
+      );
     } catch (error, stackTrace) {
       reportMobileError(
         error,
         stackTrace,
         context: '노선도 최근접 역 실시간 정보 조회 중 예외가 발생했습니다.',
       );
-      if (mounted && token == _nearbyDataRequestToken) {
-        setState(() => _nearbyRealtime = const RealtimeSnapshot.unavailable());
-        unawaited(
-          _fallbackNearbyPanelToTimetable(station, line, requestToken: token),
-        );
+      if (!_isCurrentNearbyRequest(request)) {
+        return;
       }
+      setState(() {
+        _nearbyRealtimeRequestInFlight = false;
+      });
+      unawaited(
+        _handleNearbyRealtimeUnavailable(station, line, request: request),
+      );
     }
   }
 
-  /// 실시간 채널이 없거나 쓸 도착이 없으면 하단 패널을 시간표로 자동 전환한다.
-  bool _nearbyRealtimeHasNoUsableData(RealtimeSnapshot snapshot) {
-    if (snapshot.status == RealtimeSnapshotStatus.unavailable ||
-        snapshot.status == RealtimeSnapshotStatus.unsupported) {
-      return true;
-    }
-    if (snapshot.status == RealtimeSnapshotStatus.fresh ||
-        snapshot.status == RealtimeSnapshotStatus.stale) {
-      return snapshot.arrivals.isEmpty;
-    }
-    return false;
+  /// fresh/stale + 도착 ≥1만 display cache에 저장한다.
+  bool _isCacheableNearbyRealtime(RealtimeSnapshot snapshot) {
+    return (snapshot.status == RealtimeSnapshotStatus.fresh ||
+            snapshot.status == RealtimeSnapshotStatus.stale) &&
+        snapshot.arrivals.isNotEmpty;
   }
 
-  Future<void> _fallbackNearbyPanelToTimetable(
+  /// 현재 실시간 탭 + 최신 요청의 unavailable/empty/timeout일 때만 시간표로 전환한다.
+  /// 시간표 탭 prefetch 실패·이전 역/호선·닫힌 패널은 no-op.
+  Future<void> _handleNearbyRealtimeUnavailable(
     StationSearchResult station,
     StationSearchLine line, {
-    required int requestToken,
+    required _NearbyPanelRequestKey request,
   }) async {
-    if (!mounted || requestToken != _nearbyDataRequestToken) {
+    final shouldFallbackToTimetable =
+        mounted &&
+        _isCurrentNearbyRequest(request) &&
+        _nearbyDataSource == _NearbyPanelDataSource.realtime;
+    if (!shouldFallbackToTimetable) {
       return;
     }
-    if (!_nearbyAllowRealtimeAutoFallback) {
-      return;
-    }
-    // 사용자가 이미 시간표를 골랐거나 다른 요청이 끼어들면 덮지 않는다.
-    if (_nearbyDataSource != _NearbyPanelDataSource.realtime) {
-      return;
-    }
+    final hasTimetable = _nearbyTimetableDisplayMatchesCurrent();
     setState(() {
       _nearbyDataSource = _NearbyPanelDataSource.timetable;
-      // 병렬 prefetch가 끝났으면 스피너 없이 바로 보여 준다.
-      _nearbyTimetableLoading = _nearbyTimetable == null;
+      _nearbyTimetableRequestInFlight = !hasTimetable;
     });
-    if (_nearbyTimetable == null) {
-      await _loadNearbyTimetable(
-        station,
-        line,
-        reuseRequestToken: requestToken,
-      );
+    if (!hasTimetable) {
+      await _loadNearbyTimetable(station, line, request: request);
     }
   }
 
   Future<void> _loadNearbyTimetable(
     StationSearchResult station,
     StationSearchLine line, {
-    int? reuseRequestToken,
+    required _NearbyPanelRequestKey request,
   }) async {
-    final requestToken = reuseRequestToken ?? ++_nearbyDataRequestToken;
     final repository = widget.stationSearchRepository;
     if (repository is! StationTimetableRepository) {
-      if (mounted && requestToken == _nearbyDataRequestToken) {
-        setState(() {
-          _nearbyTimetable = null;
-          _nearbyTimetableLoading = false;
-        });
+      if (!_isCurrentNearbyRequest(request)) {
+        return;
       }
+      setState(() {
+        _nearbyTimetableRequestInFlight = false;
+      });
       return;
     }
     final timetableRepository = repository as StationTimetableRepository;
@@ -1440,24 +1489,30 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
         lineId: line.id,
         date: DateTime.now(),
       );
-      if (mounted && requestToken == _nearbyDataRequestToken) {
-        setState(() {
-          _nearbyTimetable = timetable;
-          _nearbyTimetableLoading = false;
-        });
+      if (!_isCurrentNearbyRequest(request)) {
+        return;
       }
+      setState(() {
+        _nearbyTimetableDisplay = _NearbyTimetableDisplay(
+          stationId: request.stationId,
+          lineId: request.lineId,
+          timetable: timetable,
+        );
+        _nearbyTimetableRequestInFlight = false;
+      });
     } catch (error, stackTrace) {
       reportMobileError(
         error,
         stackTrace,
         context: '노선도 최근접 역 시간표 조회 중 예외가 발생했습니다.',
       );
-      if (mounted && requestToken == _nearbyDataRequestToken) {
-        setState(() {
-          _nearbyTimetable = null;
-          _nearbyTimetableLoading = false;
-        });
+      if (!_isCurrentNearbyRequest(request)) {
+        return;
       }
+      // 실패로 성공 캐시를 지우지 않는다.
+      setState(() {
+        _nearbyTimetableRequestInFlight = false;
+      });
     }
   }
 
@@ -1466,16 +1521,18 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
       return;
     }
     final station = _nearbyPanelData.results.first;
-    // 호선이 바뀌면 실시간부터 다시 시도하고, 없으면 시간표로 폴백한다.
+    final request = _NearbyPanelRequestKey(
+      stationId: station.id,
+      lineId: line.id,
+      generation: ++_nearbyDataRequestToken,
+    );
+    // 호선 변경 시 모드 유지. 이전 호선 display는 키 불일치로 미표시.
     setState(() {
       _nearbySelectedLineId = line.id;
-      _nearbyDataSource = _NearbyPanelDataSource.realtime;
-      _nearbyRealtime = const RealtimeSnapshot.loading();
-      _nearbyTimetable = null;
-      _nearbyTimetableLoading = true;
-      _nearbyAllowRealtimeAutoFallback = true;
+      _nearbyRealtimeRequestInFlight = true;
+      _nearbyTimetableRequestInFlight = true;
     });
-    _startNearbyPanelDataLoads(station, line);
+    _startNearbyPanelDataLoads(station, line, request);
   }
 
   void _toggleNearbyDataSource() {
@@ -1494,22 +1551,42 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
         : _NearbyPanelDataSource.realtime;
     setState(() {
       _nearbyDataSource = next;
-      // 수동으로 실시간을 고르면 빈 응답으로 다시 시간표에 튕기지 않는다.
-      _nearbyAllowRealtimeAutoFallback = false;
-      if (next == _NearbyPanelDataSource.realtime) {
-        _nearbyRealtime = const RealtimeSnapshot.loading();
-      } else if (_nearbyTimetable == null) {
-        _nearbyTimetableLoading = true;
-      }
     });
-    final requestToken = ++_nearbyDataRequestToken;
     if (next == _NearbyPanelDataSource.realtime) {
-      unawaited(_loadNearbyRealtime(station, line, requestToken: requestToken));
-    } else if (_nearbyTimetable == null) {
-      unawaited(
-        _loadNearbyTimetable(station, line, reuseRequestToken: requestToken),
+      // 현재 키 캐시가 있으면 즉시 표시만 하고 재요청하지 않는다.
+      if (_nearbyRealtimeDisplayMatchesCurrent()) {
+        return;
+      }
+      // 오픈 시 prefetch가 진행 중이면 재사용해 세대만 올리지 않는다.
+      if (_nearbyRealtimeRequestInFlight) {
+        return;
+      }
+      final request = _NearbyPanelRequestKey(
+        stationId: station.id,
+        lineId: line.id,
+        generation: ++_nearbyDataRequestToken,
       );
+      setState(() {
+        _nearbyRealtimeRequestInFlight = true;
+      });
+      unawaited(_loadNearbyRealtime(station, line, request: request));
+      return;
     }
+    if (_nearbyTimetableDisplayMatchesCurrent()) {
+      return;
+    }
+    if (_nearbyTimetableRequestInFlight) {
+      return;
+    }
+    final request = _NearbyPanelRequestKey(
+      stationId: station.id,
+      lineId: line.id,
+      generation: ++_nearbyDataRequestToken,
+    );
+    setState(() {
+      _nearbyTimetableRequestInFlight = true;
+    });
+    unawaited(_loadNearbyTimetable(station, line, request: request));
   }
 
   void _hideNearbyPanel() => setState(_resetNearbyPanelState);
@@ -1761,7 +1838,6 @@ class _NetworkMapChrome extends StatelessWidget {
     required this.nearbySelectedLineId,
     required this.nearbyDataSource,
     required this.nearbyTimetable,
-    required this.nearbyTimetableLoading,
     required this.nearbyLookupMessage,
     required this.adjacentStations,
     required this.onCurrentLocationTap,
@@ -1800,7 +1876,6 @@ class _NetworkMapChrome extends StatelessWidget {
   final String? nearbySelectedLineId;
   final _NearbyPanelDataSource nearbyDataSource;
   final StationTimetable? nearbyTimetable;
-  final bool nearbyTimetableLoading;
   final String? nearbyLookupMessage;
   final _NetworkMapAdjacentStations adjacentStations;
   final VoidCallback onCurrentLocationTap;
@@ -1900,7 +1975,6 @@ class _NetworkMapChrome extends StatelessWidget {
               selectedLineId: nearbySelectedLineId,
               dataSource: nearbyDataSource,
               timetable: nearbyTimetable,
-              timetableLoading: nearbyTimetableLoading,
               adjacentStations: adjacentStations,
               onClose: onCloseNearbyPanel,
               onLineSelected: onNearbyLineSelected,
@@ -2734,6 +2808,46 @@ enum _NetworkMapNearbyPanelStatus { idle, loading, success }
 
 enum _NearbyPanelDataSource { realtime, timetable }
 
+/// 하단 패널 비동기 요청 신원. stationId·lineId·generation이 모두 현재와
+/// 일치할 때만 응답을 UI에 반영한다(#2453 Task 3).
+class _NearbyPanelRequestKey {
+  const _NearbyPanelRequestKey({
+    required this.stationId,
+    required this.lineId,
+    required this.generation,
+  });
+
+  final String stationId;
+  final String lineId;
+  final int generation;
+}
+
+/// 성공한 실시간 스냅샷의 keyed display cache(#2453 Task 4).
+class _NearbyRealtimeDisplay {
+  const _NearbyRealtimeDisplay({
+    required this.stationId,
+    required this.lineId,
+    required this.snapshot,
+  });
+
+  final String stationId;
+  final String lineId;
+  final RealtimeSnapshot snapshot;
+}
+
+/// 성공한 시간표의 keyed display cache(#2453 Task 4).
+class _NearbyTimetableDisplay {
+  const _NearbyTimetableDisplay({
+    required this.stationId,
+    required this.lineId,
+    required this.timetable,
+  });
+
+  final String stationId;
+  final String lineId;
+  final StationTimetable timetable;
+}
+
 class _NetworkMapNearbyPanelData {
   const _NetworkMapNearbyPanelData._({
     required this.status,
@@ -2767,7 +2881,6 @@ class _NetworkMapNearbyStationPanel extends StatelessWidget {
     required this.selectedLineId,
     required this.dataSource,
     required this.timetable,
-    required this.timetableLoading,
     required this.adjacentStations,
     required this.onClose,
     required this.onLineSelected,
@@ -2780,7 +2893,6 @@ class _NetworkMapNearbyStationPanel extends StatelessWidget {
   final String? selectedLineId;
   final _NearbyPanelDataSource dataSource;
   final StationTimetable? timetable;
-  final bool timetableLoading;
   final _NetworkMapAdjacentStations adjacentStations;
   final VoidCallback onClose;
   final ValueChanged<StationSearchLine> onLineSelected;
@@ -2868,7 +2980,6 @@ class _NetworkMapNearbyStationPanel extends StatelessWidget {
                 selectedLineId: selectedLineId,
                 dataSource: dataSource,
                 timetable: timetable,
-                timetableLoading: timetableLoading,
                 adjacentStations: adjacentStations,
                 onOpenStationDetail: onOpenStationDetail,
               ),
@@ -2887,7 +2998,6 @@ class _NetworkMapNearbyPanelBody extends StatelessWidget {
     required this.selectedLineId,
     required this.dataSource,
     required this.timetable,
-    required this.timetableLoading,
     required this.adjacentStations,
     this.onOpenStationDetail,
   });
@@ -2897,7 +3007,6 @@ class _NetworkMapNearbyPanelBody extends StatelessWidget {
   final String? selectedLineId;
   final _NearbyPanelDataSource dataSource;
   final StationTimetable? timetable;
-  final bool timetableLoading;
   final _NetworkMapAdjacentStations adjacentStations;
   final VoidCallback? onOpenStationDetail;
 
@@ -2915,7 +3024,6 @@ class _NetworkMapNearbyPanelBody extends StatelessWidget {
         selectedLineId: selectedLineId,
         dataSource: dataSource,
         timetable: timetable,
-        timetableLoading: timetableLoading,
         adjacentStations: adjacentStations,
         onOpenStationDetail: onOpenStationDetail,
       ),
@@ -2960,7 +3068,6 @@ class _NetworkMapNearbySuccessList extends StatelessWidget {
     required this.selectedLineId,
     required this.dataSource,
     required this.timetable,
-    required this.timetableLoading,
     required this.adjacentStations,
     this.onOpenStationDetail,
   });
@@ -2970,7 +3077,6 @@ class _NetworkMapNearbySuccessList extends StatelessWidget {
   final String? selectedLineId;
   final _NearbyPanelDataSource dataSource;
   final StationTimetable? timetable;
-  final bool timetableLoading;
   final _NetworkMapAdjacentStations adjacentStations;
   final VoidCallback? onOpenStationDetail;
 
@@ -3002,7 +3108,6 @@ class _NetworkMapNearbySuccessList extends StatelessWidget {
                 )
               : _SubwayTimetablePanel(
                   timetable: timetable,
-                  loading: timetableLoading,
                   lineColor: lineColor,
                   leftName: adjacentStations.leftName,
                   rightName: adjacentStations.rightName,
@@ -3116,20 +3221,7 @@ class _SubwayArrivalPanel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (snapshot.status == RealtimeSnapshotStatus.loading) {
-      return const SizedBox(
-        key: Key('networkMapNearbyArrivalLoading'),
-        height: 46,
-        child: Center(
-          child: SizedBox(
-            width: 22,
-            height: 22,
-            child: CircularProgressIndicator(strokeWidth: 2),
-          ),
-        ),
-      );
-    }
-
+    // loading이어도 스피너 대신 인접역 방면·대시 골격을 즉시 그린다(#2453).
     final hasData =
         (snapshot.status == RealtimeSnapshotStatus.fresh ||
             snapshot.status == RealtimeSnapshotStatus.stale) &&
@@ -3161,8 +3253,8 @@ class _SubwayArrivalPanel extends StatelessWidget {
     for (final slot in slots) {
       final dataIndex = slot.dataIndex;
       if (dataIndex == null) {
+        // 대시 열 의미는 NearbyPanelColumns 열 단위 Semantics가 담당한다.
         columns.add(NearbyPanelColumn(title: slot.title));
-        semanticParts.add('${slot.title} 정보 없음');
         continue;
       }
       final visible = dataGroups[dataIndex].take(2).toList(growable: false);
@@ -3193,28 +3285,44 @@ class _SubwayArrivalPanel extends StatelessWidget {
     }
 
     final isStale = snapshot.status == RealtimeSnapshotStatus.stale && hasData;
-    return Semantics(
-      liveRegion: true,
-      label: semanticParts.isEmpty ? '도착 정보 없음' : semanticParts.join(', '),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          if (isStale) ...[
-            Text(
-              snapshot.receivedAt.trim().isEmpty
-                  ? '최근 도착 정보'
-                  : '최근 도착 정보 · ${snapshot.receivedAt.trim()}',
-              style: const TextStyle(
-                color: EasySubwayAccessibleColors.mutedText,
-                fontSize: 12,
-                fontWeight: FontWeight.w600,
-              ),
+    final columnsView = NearbyPanelColumns(
+      columns: columns,
+      lineColor: lineColor,
+    );
+    final body = Column(
+      key: hasData ? null : const Key('networkMapNearbyArrivalSkeleton'),
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (isStale) ...[
+          Text(
+            snapshot.receivedAt.trim().isEmpty
+                ? '최근 도착 정보'
+                : '최근 도착 정보 · ${snapshot.receivedAt.trim()}',
+            style: const TextStyle(
+              color: EasySubwayAccessibleColors.mutedText,
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
             ),
-            const SizedBox(height: 6),
-          ],
-          NearbyPanelColumns(columns: columns, lineColor: lineColor),
+          ),
+          const SizedBox(height: 6),
         ],
-      ),
+        columnsView,
+      ],
+    );
+    // 골격↔데이터 갱신 시 liveRegion 재발화를 피한다.
+    // 순수 골격은 열 단위 Semantics, 데이터 혼재 시 부모 라벨에 대시 열도 합친다.
+    if (semanticParts.isEmpty) {
+      return body;
+    }
+    final dashLabels = [
+      for (final slot in slots)
+        if (slot.dataIndex == null)
+          slot.title.isEmpty ? '정보 없음' : '${slot.title} 정보 없음',
+    ];
+    return Semantics(
+      excludeSemantics: true,
+      label: [...semanticParts, ...dashLabels].join(', '),
+      child: body,
     );
   }
 }
@@ -3225,7 +3333,6 @@ class _SubwayDataUnavailable extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Semantics(
-      liveRegion: true,
       label: '정보 없음',
       excludeSemantics: true,
       child: const SizedBox(
@@ -3249,33 +3356,19 @@ class _SubwayDataUnavailable extends StatelessWidget {
 class _SubwayTimetablePanel extends StatelessWidget {
   const _SubwayTimetablePanel({
     required this.timetable,
-    required this.loading,
     required this.lineColor,
     required this.leftName,
     required this.rightName,
   });
 
   final StationTimetable? timetable;
-  final bool loading;
   final Color lineColor;
   final String? leftName;
   final String? rightName;
 
   @override
   Widget build(BuildContext context) {
-    if (loading) {
-      return const SizedBox(
-        key: Key('networkMapNearbyTimetableLoading'),
-        height: 46,
-        child: Center(
-          child: SizedBox(
-            width: 22,
-            height: 22,
-            child: CircularProgressIndicator(strokeWidth: 2),
-          ),
-        ),
-      );
-    }
+    // 로컬 조회 중이어도 스피너 대신 인접역 방면·대시 골격을 즉시 그린다(#2453).
     final departures = _nextTimetableDepartures(timetable, DateTime.now());
     // 방면별로 그룹핑(실시간과 동일한 열 구성 원칙 적용).
     final dataGroups = <List<_NextTimetableDeparture>>[];
@@ -3304,8 +3397,8 @@ class _SubwayTimetablePanel extends StatelessWidget {
     for (final slot in slots) {
       final dataIndex = slot.dataIndex;
       if (dataIndex == null) {
+        // 대시 열 의미는 NearbyPanelColumns 열 단위 Semantics가 담당한다.
         columns.add(NearbyPanelColumn(title: slot.title));
-        semanticParts.add('${slot.title} 정보 없음');
         continue;
       }
       final group = dataGroups[dataIndex];
@@ -3320,11 +3413,25 @@ class _SubwayTimetablePanel extends StatelessWidget {
       columns.add(NearbyPanelColumn(title: slot.title, rows: rows));
     }
 
-    return Semantics(
-      liveRegion: true,
-      excludeSemantics: true,
-      label: semanticParts.isEmpty ? '정보 없음' : semanticParts.join(', '),
+    final hasData = departures.isNotEmpty;
+    final columnsView = KeyedSubtree(
+      key: hasData ? null : const Key('networkMapNearbyTimetableSkeleton'),
       child: NearbyPanelColumns(columns: columns, lineColor: lineColor),
+    );
+    // 골격↔데이터 갱신 시 liveRegion 재발화를 피한다.
+    // 순수 골격은 열 단위 Semantics, 데이터 혼재 시 부모 라벨에 대시 열도 합친다.
+    if (semanticParts.isEmpty) {
+      return columnsView;
+    }
+    final dashLabels = [
+      for (final slot in slots)
+        if (slot.dataIndex == null)
+          slot.title.isEmpty ? '정보 없음' : '${slot.title} 정보 없음',
+    ];
+    return Semantics(
+      excludeSemantics: true,
+      label: [...semanticParts, ...dashLabels].join(', '),
+      child: columnsView,
     );
   }
 }

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -545,9 +545,38 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
   _NearbyPanelDataSource _nearbyDataSource = _NearbyPanelDataSource.realtime;
 
   /// 요청 중복 방지용 in-flight. UI 렌더 분기에는 쓰지 않는다(#2453).
-  /// 이전 요청 완료가 현재 요청 플래그를 내리지 않도록 현재 키일 때만 false로 돌린다.
+  /// 채널별 generation을 함께 두어, stale 완료도 자기 generation의 플래그만 내린다
+  /// (토글이 한쪽만 재조회해도 반대 채널이 고아 in-flight로 남지 않게).
   bool _nearbyRealtimeRequestInFlight = false;
   bool _nearbyTimetableRequestInFlight = false;
+  int? _nearbyRealtimeInFlightGeneration;
+  int? _nearbyTimetableInFlightGeneration;
+
+  void _markNearbyRealtimeInFlight(_NearbyPanelRequestKey request) {
+    _nearbyRealtimeRequestInFlight = true;
+    _nearbyRealtimeInFlightGeneration = request.generation;
+  }
+
+  void _markNearbyTimetableInFlight(_NearbyPanelRequestKey request) {
+    _nearbyTimetableRequestInFlight = true;
+    _nearbyTimetableInFlightGeneration = request.generation;
+  }
+
+  void _clearNearbyRealtimeInFlightIf(_NearbyPanelRequestKey request) {
+    if (_nearbyRealtimeInFlightGeneration != request.generation) {
+      return;
+    }
+    _nearbyRealtimeRequestInFlight = false;
+    _nearbyRealtimeInFlightGeneration = null;
+  }
+
+  void _clearNearbyTimetableInFlightIf(_NearbyPanelRequestKey request) {
+    if (_nearbyTimetableInFlightGeneration != request.generation) {
+      return;
+    }
+    _nearbyTimetableRequestInFlight = false;
+    _nearbyTimetableInFlightGeneration = null;
+  }
 
   /// 하단 패널 실시간은 API 기본 8초보다 짧게 끊고 시간표로 넘긴다.
   static const _nearbyRealtimeTimeout = Duration(seconds: 2);
@@ -735,8 +764,15 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
       // 모든 오픈 경로 기본 탭은 시간표. 실시간은 백그라운드 prefetch.
       // keyed display는 지우지 않는다 — 키 불일치면 미표시, 일치하면 즉시 재사용.
       _nearbyDataSource = _NearbyPanelDataSource.timetable;
-      _nearbyRealtimeRequestInFlight = selectedLine != null;
-      _nearbyTimetableRequestInFlight = selectedLine != null;
+      if (request != null) {
+        _markNearbyRealtimeInFlight(request);
+        _markNearbyTimetableInFlight(request);
+      } else {
+        _nearbyRealtimeRequestInFlight = false;
+        _nearbyTimetableRequestInFlight = false;
+        _nearbyRealtimeInFlightGeneration = null;
+        _nearbyTimetableInFlightGeneration = null;
+      }
       _searchFanMenuStationId = station.id;
     });
     if (request != null && selectedLine != null) {
@@ -1341,6 +1377,8 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
     _nearbyTimetableDisplay = null;
     _nearbyRealtimeRequestInFlight = false;
     _nearbyTimetableRequestInFlight = false;
+    _nearbyRealtimeInFlightGeneration = null;
+    _nearbyTimetableInFlightGeneration = null;
   }
 
   /// 실시간과 시간표를 같은 요청 키로 병렬 로드한다. 실시간 실패 시 즉시 시간표로 넘긴다.
@@ -1360,12 +1398,14 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
   }) async {
     final repository = widget.realtimeRepository;
     if (repository == null) {
+      if (mounted) {
+        setState(() => _clearNearbyRealtimeInFlightIf(request));
+      } else {
+        _clearNearbyRealtimeInFlightIf(request);
+      }
       if (!_isCurrentNearbyRequest(request)) {
         return;
       }
-      setState(() {
-        _nearbyRealtimeRequestInFlight = false;
-      });
       unawaited(
         _handleNearbyRealtimeUnavailable(station, line, request: request),
       );
@@ -1388,6 +1428,11 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
             onTimeout: () => const RealtimeSnapshot.unavailable(),
           );
       if (!_isCurrentNearbyRequest(request)) {
+        if (mounted) {
+          setState(() => _clearNearbyRealtimeInFlightIf(request));
+        } else {
+          _clearNearbyRealtimeInFlightIf(request);
+        }
         return;
       }
       if (_isCacheableNearbyRealtime(snapshot)) {
@@ -1397,24 +1442,25 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
             lineId: request.lineId,
             snapshot: snapshot,
           );
-          _nearbyRealtimeRequestInFlight = false;
+          _clearNearbyRealtimeInFlightIf(request);
         });
         return;
       }
       // unavailable/empty/loading 등은 성공 캐시를 덮지 않는다.
-      setState(() {
-        _nearbyRealtimeRequestInFlight = false;
-      });
+      setState(() => _clearNearbyRealtimeInFlightIf(request));
       unawaited(
         _handleNearbyRealtimeUnavailable(station, line, request: request),
       );
     } on RealtimeException {
       if (!_isCurrentNearbyRequest(request)) {
+        if (mounted) {
+          setState(() => _clearNearbyRealtimeInFlightIf(request));
+        } else {
+          _clearNearbyRealtimeInFlightIf(request);
+        }
         return;
       }
-      setState(() {
-        _nearbyRealtimeRequestInFlight = false;
-      });
+      setState(() => _clearNearbyRealtimeInFlightIf(request));
       unawaited(
         _handleNearbyRealtimeUnavailable(station, line, request: request),
       );
@@ -1425,11 +1471,14 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
         context: '노선도 최근접 역 실시간 정보 조회 중 예외가 발생했습니다.',
       );
       if (!_isCurrentNearbyRequest(request)) {
+        if (mounted) {
+          setState(() => _clearNearbyRealtimeInFlightIf(request));
+        } else {
+          _clearNearbyRealtimeInFlightIf(request);
+        }
         return;
       }
-      setState(() {
-        _nearbyRealtimeRequestInFlight = false;
-      });
+      setState(() => _clearNearbyRealtimeInFlightIf(request));
       unawaited(
         _handleNearbyRealtimeUnavailable(station, line, request: request),
       );
@@ -1460,7 +1509,9 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
     final hasTimetable = _nearbyTimetableDisplayMatchesCurrent();
     setState(() {
       _nearbyDataSource = _NearbyPanelDataSource.timetable;
-      _nearbyTimetableRequestInFlight = !hasTimetable;
+      if (!hasTimetable) {
+        _markNearbyTimetableInFlight(request);
+      }
     });
     if (!hasTimetable) {
       await _loadNearbyTimetable(station, line, request: request);
@@ -1474,12 +1525,11 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
   }) async {
     final repository = widget.stationSearchRepository;
     if (repository is! StationTimetableRepository) {
-      if (!_isCurrentNearbyRequest(request)) {
-        return;
+      if (mounted) {
+        setState(() => _clearNearbyTimetableInFlightIf(request));
+      } else {
+        _clearNearbyTimetableInFlightIf(request);
       }
-      setState(() {
-        _nearbyTimetableRequestInFlight = false;
-      });
       return;
     }
     final timetableRepository = repository as StationTimetableRepository;
@@ -1490,6 +1540,11 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
         date: DateTime.now(),
       );
       if (!_isCurrentNearbyRequest(request)) {
+        if (mounted) {
+          setState(() => _clearNearbyTimetableInFlightIf(request));
+        } else {
+          _clearNearbyTimetableInFlightIf(request);
+        }
         return;
       }
       setState(() {
@@ -1498,7 +1553,7 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
           lineId: request.lineId,
           timetable: timetable,
         );
-        _nearbyTimetableRequestInFlight = false;
+        _clearNearbyTimetableInFlightIf(request);
       });
     } catch (error, stackTrace) {
       reportMobileError(
@@ -1507,12 +1562,15 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
         context: '노선도 최근접 역 시간표 조회 중 예외가 발생했습니다.',
       );
       if (!_isCurrentNearbyRequest(request)) {
+        if (mounted) {
+          setState(() => _clearNearbyTimetableInFlightIf(request));
+        } else {
+          _clearNearbyTimetableInFlightIf(request);
+        }
         return;
       }
       // 실패로 성공 캐시를 지우지 않는다.
-      setState(() {
-        _nearbyTimetableRequestInFlight = false;
-      });
+      setState(() => _clearNearbyTimetableInFlightIf(request));
     }
   }
 
@@ -1529,8 +1587,8 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
     // 호선 변경 시 모드 유지. 이전 호선 display는 키 불일치로 미표시.
     setState(() {
       _nearbySelectedLineId = line.id;
-      _nearbyRealtimeRequestInFlight = true;
-      _nearbyTimetableRequestInFlight = true;
+      _markNearbyRealtimeInFlight(request);
+      _markNearbyTimetableInFlight(request);
     });
     _startNearbyPanelDataLoads(station, line, request);
   }
@@ -1567,7 +1625,11 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
         generation: ++_nearbyDataRequestToken,
       );
       setState(() {
-        _nearbyRealtimeRequestInFlight = true;
+        _markNearbyRealtimeInFlight(request);
+        // generation을 올린 뒤 반대 채널 이전 요청은 무효 — 고아 in-flight로
+        // 재요청이 영구 스킵되지 않게 플래그를 함께 정리한다.
+        _nearbyTimetableRequestInFlight = false;
+        _nearbyTimetableInFlightGeneration = null;
       });
       unawaited(_loadNearbyRealtime(station, line, request: request));
       return;
@@ -1584,7 +1646,9 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
       generation: ++_nearbyDataRequestToken,
     );
     setState(() {
-      _nearbyTimetableRequestInFlight = true;
+      _markNearbyTimetableInFlight(request);
+      _nearbyRealtimeRequestInFlight = false;
+      _nearbyRealtimeInFlightGeneration = null;
     });
     unawaited(_loadNearbyTimetable(station, line, request: request));
   }

--- a/apps/mobile/test/network_map_nearby_panel_test.dart
+++ b/apps/mobile/test/network_map_nearby_panel_test.dart
@@ -234,6 +234,21 @@ void main() {
       handle.dispose();
     });
 
+    testWidgets('시간표 선택 세그먼트도 Semantics selected를 노출한다', (tester) async {
+      final handle = tester.ensureSemantics();
+      await tester.pumpWidget(hostToggle(isRealtime: false));
+
+      final selected = tester
+          .getSemantics(find.bySemanticsLabel('시간표 선택됨'))
+          .getSemanticsData();
+      expect(selected.flagsCollection.isSelected, Tristate.isTrue);
+      final unselected = tester
+          .getSemantics(find.bySemanticsLabel('실시간로 전환'))
+          .getSemanticsData();
+      expect(unselected.flagsCollection.isSelected, isNot(Tristate.isTrue));
+      handle.dispose();
+    });
+
     testWidgets('비선택 세그먼트 탭은 onToggle, 선택 세그먼트 탭은 no-op이다', (tester) async {
       var calls = 0;
       await tester.pumpWidget(
@@ -445,6 +460,17 @@ void main() {
       expect(slots.single.dataIndex, isNull);
     });
 
+    test('(c\'\') 종착(다음역만)도 한 열만이다', () {
+      final slots = resolveNearbyColumnSlots(
+        dataTitles: const [],
+        leftName: null,
+        rightName: '한양대',
+      );
+      expect(slots.length, 1);
+      expect(slots.single.title, '한양대 방면');
+      expect(slots.single.dataIndex, isNull);
+    });
+
     test('(c\') 데이터 1방면 + 인접 0개 → 데이터 한 열만', () {
       final slots = resolveNearbyColumnSlots(
         dataTitles: const ['성수 방면'],
@@ -521,6 +547,22 @@ void main() {
       expect(find.text('-'), findsOneWidget);
     });
 
+    testWidgets('종착역(인접 1개) 슬롯은 한 열·대시만 그리고 구분선이 없다', (tester) async {
+      final slots = resolveNearbyColumnSlots(
+        dataTitles: const [],
+        leftName: '건대입구',
+        rightName: null,
+      );
+      await tester.pumpWidget(
+        host([for (final slot in slots) NearbyPanelColumn(title: slot.title)]),
+      );
+
+      expect(find.byType(NearbyDirectionTitle), findsOneWidget);
+      expect(find.text('건대입구 방면'), findsOneWidget);
+      expect(find.text('-'), findsOneWidget);
+      expect(find.byType(VerticalDivider), findsNothing);
+    });
+
     testWidgets('대시 스타일은 16sp w700 #2F2F2F이다', (tester) async {
       await tester.pumpWidget(
         host(const [NearbyPanelColumn(title: '건대입구 방면')]),
@@ -529,6 +571,22 @@ void main() {
       expect(dash.style!.fontSize, 16);
       expect(dash.style!.fontWeight, FontWeight.w700);
       expect(dash.style!.color, const Color(0xFF2F2F2F));
+    });
+
+    testWidgets('대시 열은 열 단위 Semantics 라벨을 쓰고 대시 문자는 제외한다', (tester) async {
+      final handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        host(const [
+          NearbyPanelColumn(title: '건대입구 방면'),
+          NearbyPanelColumn(title: '한양대 방면'),
+        ]),
+      );
+
+      expect(find.bySemanticsLabel('건대입구 방면 정보 없음'), findsOneWidget);
+      expect(find.bySemanticsLabel('한양대 방면 정보 없음'), findsOneWidget);
+      // 시각 대시('-')는 ExcludeSemantics라 단독 Semantics 라벨로 노출되지 않는다.
+      expect(find.bySemanticsLabel('-'), findsNothing);
+      handle.dispose();
     });
   });
 }

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -5055,30 +5055,21 @@ void main() {
         location: _freshCurrentLocation(),
         needsPermissionRequest: false,
       ),
-      // 도착이 있으면 실시간 탭을 유지한 뒤 수동으로 시간표로 전환한다.
+      // 기본 탭은 시간표. 실시간 토글 회귀를 위해 fresh 응답을 둔다.
       realtimeRepository: _FreshRealtimeRepository(),
     );
 
     await tester.tap(find.byKey(const Key('nearbyStationButton')));
     await tester.pumpAndSettle();
-    // 2버튼 세그먼트 토글(#2200). 초기 선택은 실시간.
-    expect(find.bySemanticsLabel('실시간 선택됨'), findsOneWidget);
+    // 2버튼 세그먼트 토글(#2200). 초기 선택은 시간표.
+    expect(find.bySemanticsLabel('시간표 선택됨'), findsOneWidget);
     expect(
-      find.descendant(
-        of: find.byKey(const Key('networkMapNearbyDataSourceToggle')),
-        matching: find.text('실시간'),
-      ),
-      findsOneWidget,
-    );
-
-    // 비선택 '시간표' 세그먼트를 눌러 시간표로 전환.
-    await tester.tap(
       find.descendant(
         of: find.byKey(const Key('networkMapNearbyDataSourceToggle')),
         matching: find.text('시간표'),
       ),
+      findsOneWidget,
     );
-    await tester.pumpAndSettle();
 
     // 방면 제목은 열당 1개 헤더로 올라가고, 그 아래 두 시각이 각각 한 줄.
     expect(find.text('오이도 방면'), findsOneWidget);
@@ -5094,7 +5085,6 @@ void main() {
         findsOneWidget,
       );
     }
-    expect(find.bySemanticsLabel('시간표 선택됨'), findsOneWidget);
     expect(
       tester
           .getSize(find.byKey(const Key('networkMapNearbyDataSourceToggle')))
@@ -5102,7 +5092,7 @@ void main() {
       greaterThanOrEqualTo(48),
     );
 
-    // 다시 '실시간' 세그먼트를 눌러 복귀.
+    // '실시간' 세그먼트를 눌러 전환 후 복귀.
     await tester.tap(
       find.descendant(
         of: find.byKey(const Key('networkMapNearbyDataSourceToggle')),
@@ -5111,9 +5101,17 @@ void main() {
     );
     await tester.pumpAndSettle();
     expect(find.bySemanticsLabel('실시간 선택됨'), findsOneWidget);
+    await tester.tap(
+      find.descendant(
+        of: find.byKey(const Key('networkMapNearbyDataSourceToggle')),
+        matching: find.text('시간표'),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.bySemanticsLabel('시간표 선택됨'), findsOneWidget);
   });
 
-  testWidgets('GPS 하단 패널은 실시간 불가 시 시간표로 자동 전환한다', (tester) async {
+  testWidgets('시간표 선택 중 실시간 prefetch 실패는 선택 상태를 변경하지 않는다', (tester) async {
     tester.view.physicalSize = const Size(320, 1200);
     tester.view.devicePixelRatio = 1;
     addTearDown(() {
@@ -5156,12 +5154,13 @@ void main() {
     await tester.tap(find.byKey(const Key('nearbyStationButton')));
     await tester.pumpAndSettle();
 
+    // #2453: 기본 시간표 탭에서 prefetch unavailable은 탭을 바꾸지 않는다.
     expect(find.bySemanticsLabel('시간표 선택됨'), findsOneWidget);
     expect(find.text('오이도 방면'), findsOneWidget);
     expect(find.text(departure.timeLabel), findsOneWidget);
   });
 
-  testWidgets('GPS 하단 패널은 실시간 응답이 늦으면 시간표로 자동 전환한다', (tester) async {
+  testWidgets('GPS 하단 패널은 늦은 실시간 prefetch에도 시간표 선택을 유지한다', (tester) async {
     tester.view.physicalSize = const Size(320, 1200);
     tester.view.devicePixelRatio = 1;
     addTearDown(() {
@@ -5203,7 +5202,7 @@ void main() {
 
     await tester.tap(find.byKey(const Key('nearbyStationButton')));
     await tester.pump();
-    // 2초 타임아웃 전에는 로딩일 수 있다.
+    // #2453: 기본 시간표 탭은 hanging 실시간과 무관하게 즉시 유지된다.
     await tester.pump(const Duration(seconds: 2));
     await tester.pumpAndSettle();
 
@@ -5213,6 +5212,1254 @@ void main() {
       find.byKey(const Key('networkMapNearbyArrivalLoading')),
       findsNothing,
     );
+  });
+
+  testWidgets('GPS 하단 패널은 조회 완료 전에도 첫 프레임에 시간표 골격과 패널을 표시한다', (tester) async {
+    tester.view.physicalSize = const Size(320, 1200);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+    final timetableCompleter = Completer<StationTimetable>();
+    addTearDown(() {
+      if (!timetableCompleter.isCompleted) {
+        timetableCompleter.complete(
+          _stationTimetable(
+            StationTimetableDayType.weekday,
+            directions: const [],
+          ),
+        );
+      }
+    });
+    final repository = _HangingTimetableStationRepository(
+      completer: timetableCompleter,
+      stationDetail: _stationDetail(
+        id: 'station-sangnoksu',
+        name: '상록수',
+        lines: const [
+          StationSearchLine(
+            id: 'seoul-4',
+            name: '수도권 4호선',
+            color: '#00A5DE',
+            stationCode: '448',
+          ),
+        ],
+      ),
+      networkMapRegionNames: const ['수도권'],
+      nearbyResults: [
+        _stationResult(
+          id: 'station-sangnoksu',
+          name: '상록수',
+          lines: const [
+            StationSearchLine(
+              id: 'seoul-4',
+              name: '수도권 4호선',
+              color: '#00A5DE',
+              stationCode: '448',
+            ),
+          ],
+        ),
+      ],
+    );
+    await _pumpNetworkMapForGpsTest(
+      tester,
+      repository: repository,
+      locationProvider: FakeCurrentLocationProvider(
+        location: _freshCurrentLocation(),
+        needsPermissionRequest: false,
+      ),
+      realtimeRepository: _HangingRealtimeRepository(),
+    );
+
+    await tester.tap(find.byKey(const Key('nearbyStationButton')));
+    // GPS 역 확정 후 공통 오픈이 첫 프레임에 패널을 그린다. settle 금지.
+    await tester.pump();
+    await tester.pump();
+
+    final panel = find.byKey(const Key('networkMapNearbyStationPanel'));
+    expect(panel, findsOneWidget);
+    expect(find.bySemanticsLabel('시간표 선택됨'), findsOneWidget);
+    expect(
+      find.descendant(
+        of: panel,
+        matching: find.byType(CircularProgressIndicator),
+      ),
+      findsNothing,
+    );
+    expect(
+      find.descendant(
+        of: panel,
+        matching: find.byKey(const Key('networkMapNearbyTimetableSkeleton')),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: panel, matching: find.text('반월 방면')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: panel, matching: find.text('한대앞 방면')),
+      findsOneWidget,
+    );
+
+    // hanging realtime .timeout(2s) FakeTimer를 dispose 전에 비운다.
+    await tester.pump(const Duration(seconds: 2));
+    await tester.pump();
+  });
+
+  testWidgets('검색 선택은 조회 완료 전에 하단 패널을 표시한다', (tester) async {
+    tester.view.physicalSize = const Size(320, 1200);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+    final timetableCompleter = Completer<StationTimetable>();
+    addTearDown(() {
+      if (!timetableCompleter.isCompleted) {
+        timetableCompleter.complete(
+          _stationTimetable(
+            StationTimetableDayType.weekday,
+            directions: const [],
+          ),
+        );
+      }
+    });
+    const sangnoksuLines = [
+      StationSearchLine(
+        id: 'seoul-4',
+        name: '수도권 4호선',
+        color: '#00A5DE',
+        stationCode: '448',
+      ),
+    ];
+    final repository = _HangingTimetableStationRepository(
+      completer: timetableCompleter,
+      stationDetail: _stationDetail(
+        id: 'station-sangnoksu',
+        name: '상록수',
+        lines: sangnoksuLines,
+      ),
+      networkMapRegionNames: const ['수도권'],
+      queryResults: {
+        '상록수': [
+          _stationResult(
+            id: 'station-sangnoksu',
+            name: '상록수',
+            lines: sangnoksuLines,
+          ),
+        ],
+      },
+    );
+
+    await tester.pumpWidget(
+      buildEasySubwayTestApp(
+        repository: repository,
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        locationProvider: FakeCurrentLocationProvider(
+          location: _freshCurrentLocation(),
+          needsPermissionRequest: false,
+        ),
+        realtimeRepository: _HangingRealtimeRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('stationSearchButton')));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byKey(const Key('stationSearchInput')), '상록수');
+    await tester.pumpAndSettle();
+    await tester.testTextInput.receiveAction(TextInputAction.search);
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const Key('stationSearchResult-station-sangnoksu-seoul-4')),
+    );
+    // 조회 완료 전 첫 프레임: settle 없이 패널·시간표 골격이 보여야 한다.
+    await tester.pump();
+
+    final panel = find.byKey(const Key('networkMapNearbyStationPanel'));
+    expect(panel, findsOneWidget);
+    expect(find.bySemanticsLabel('시간표 선택됨'), findsOneWidget);
+    expect(
+      find.descendant(
+        of: panel,
+        matching: find.byType(CircularProgressIndicator),
+      ),
+      findsNothing,
+    );
+    expect(
+      find.descendant(
+        of: panel,
+        matching: find.byKey(const Key('networkMapNearbyTimetableSkeleton')),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: panel, matching: find.text('상록수')),
+      findsOneWidget,
+    );
+
+    await tester.pump(const Duration(seconds: 2));
+    await tester.pump();
+  });
+
+  testWidgets('GPS 하단 패널 시간표는 로컬 조회 전에도 스피너 없이 방면 골격을 표시한다', (tester) async {
+    tester.view.physicalSize = const Size(320, 1200);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+    final timetableCompleter = Completer<StationTimetable>();
+    addTearDown(() {
+      if (!timetableCompleter.isCompleted) {
+        timetableCompleter.complete(
+          _stationTimetable(
+            StationTimetableDayType.weekday,
+            directions: const [],
+          ),
+        );
+      }
+    });
+    final repository = _HangingTimetableStationRepository(
+      completer: timetableCompleter,
+      stationDetail: _stationDetail(
+        id: 'station-sangnoksu',
+        name: '상록수',
+        lines: const [
+          StationSearchLine(
+            id: 'seoul-4',
+            name: '수도권 4호선',
+            color: '#00A5DE',
+            stationCode: '448',
+          ),
+        ],
+      ),
+      networkMapRegionNames: const ['수도권'],
+      nearbyResults: [
+        _stationResult(
+          id: 'station-sangnoksu',
+          name: '상록수',
+          lines: const [
+            StationSearchLine(
+              id: 'seoul-4',
+              name: '수도권 4호선',
+              color: '#00A5DE',
+              stationCode: '448',
+            ),
+          ],
+        ),
+      ],
+    );
+    await _pumpNetworkMapForGpsTest(
+      tester,
+      repository: repository,
+      locationProvider: FakeCurrentLocationProvider(
+        location: _freshCurrentLocation(),
+        needsPermissionRequest: false,
+      ),
+      // 기본 탭은 시간표. 시간표만 hanging으로 첫 프레임 골격을 검증한다.
+      realtimeRepository: _FreshRealtimeRepository(),
+    );
+
+    await tester.tap(find.byKey(const Key('nearbyStationButton')));
+    // 첫 프레임 계약: settle 없이 pump로 시간표 골격이 보여야 한다.
+    await tester.pump();
+    await tester.pump();
+
+    final panel = find.byKey(const Key('networkMapNearbyStationPanel'));
+    expect(panel, findsOneWidget);
+    expect(find.bySemanticsLabel('시간표 선택됨'), findsOneWidget);
+    expect(
+      find.descendant(
+        of: panel,
+        matching: find.byType(CircularProgressIndicator),
+      ),
+      findsNothing,
+    );
+    expect(
+      find.descendant(
+        of: panel,
+        matching: find.byKey(const Key('networkMapNearbyTimetableLoading')),
+      ),
+      findsNothing,
+    );
+    expect(
+      find.descendant(
+        of: panel,
+        matching: find.byKey(const Key('networkMapNearbyTimetableSkeleton')),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: panel, matching: find.text('반월 방면')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: panel, matching: find.text('한대앞 방면')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: panel, matching: find.text('-')),
+      findsNWidgets(2),
+    );
+  });
+
+  testWidgets('실시간 탭은 응답 전에도 스피너 없이 방면 골격을 표시한다', (tester) async {
+    tester.view.physicalSize = const Size(320, 1200);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+    final realtimeCompleter = Completer<RealtimeSnapshot>();
+    addTearDown(() {
+      if (!realtimeCompleter.isCompleted) {
+        realtimeCompleter.complete(const RealtimeSnapshot.unavailable());
+      }
+    });
+    final repository = FakeStationSearchRepository(
+      networkMapRegionNames: const ['수도권'],
+      nearbyResults: [
+        _stationResult(
+          id: 'station-sangnoksu',
+          name: '상록수',
+          lines: const [
+            StationSearchLine(
+              id: 'seoul-4',
+              name: '수도권 4호선',
+              color: '#00A5DE',
+              stationCode: '448',
+            ),
+          ],
+        ),
+      ],
+    );
+    await _pumpNetworkMapForGpsTest(
+      tester,
+      repository: repository,
+      locationProvider: FakeCurrentLocationProvider(
+        location: _freshCurrentLocation(),
+        needsPermissionRequest: false,
+      ),
+      realtimeRepository: _CompleterRealtimeRepository(realtimeCompleter),
+    );
+
+    await tester.tap(find.byKey(const Key('nearbyStationButton')));
+    // GPS 조회는 완료하되 hanging 실시간 Future는 settle하지 않는다.
+    await tester.pump();
+    await tester.pump();
+    // 기본은 시간표이므로 실시간 탭을 명시한 뒤 골격 계약을 검증한다.
+    await tester.tap(
+      find.descendant(
+        of: find.byKey(const Key('networkMapNearbyDataSourceToggle')),
+        matching: find.text('실시간'),
+      ),
+    );
+    await tester.pump();
+
+    final panel = find.byKey(const Key('networkMapNearbyStationPanel'));
+    expect(panel, findsOneWidget);
+    expect(find.bySemanticsLabel('실시간 선택됨'), findsOneWidget);
+    expect(
+      find.descendant(
+        of: panel,
+        matching: find.byType(CircularProgressIndicator),
+      ),
+      findsNothing,
+    );
+    expect(
+      find.descendant(
+        of: panel,
+        matching: find.byKey(const Key('networkMapNearbyArrivalLoading')),
+      ),
+      findsNothing,
+    );
+    expect(
+      find.descendant(
+        of: panel,
+        matching: find.byKey(const Key('networkMapNearbyArrivalSkeleton')),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: panel, matching: find.text('반월 방면')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: panel, matching: find.text('한대앞 방면')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: panel, matching: find.text('-')),
+      findsNWidgets(2),
+    );
+
+    // 실시간 .timeout(2s) FakeTimer가 dispose 전에 남아 있지 않게 비운다.
+    await tester.pump(const Duration(seconds: 2));
+    await tester.pump();
+  });
+
+  testWidgets('실시간 성공 후 다시 실시간을 선택하면 직전 도착을 즉시 표시한다', (tester) async {
+    tester.view.physicalSize = const Size(320, 1200);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+    final now = DateTime.now();
+    final departure = StationTimetableDeparture(
+      directionName: '오이도',
+      seconds:
+          now.hour * Duration.secondsPerHour +
+          now.minute * Duration.secondsPerMinute +
+          now.second +
+          120,
+    );
+    final repository = FakeTimetableStationRepository(
+      stationDetail: _stationDetail(id: 'station-sangnoksu', name: '상록수'),
+      networkMapRegionNames: const ['수도권'],
+      nearbyResults: [_stationResult(id: 'station-sangnoksu', name: '상록수')],
+      timetables: {
+        for (final dayType in StationTimetableDayType.values)
+          dayType: _stationTimetable(
+            dayType,
+            directions: [
+              StationTimetableDirection(name: '오이도', departures: [departure]),
+            ],
+          ),
+      },
+    );
+    await _pumpNetworkMapForGpsTest(
+      tester,
+      repository: repository,
+      locationProvider: FakeCurrentLocationProvider(
+        location: _freshCurrentLocation(),
+        needsPermissionRequest: false,
+      ),
+      realtimeRepository: _FreshRealtimeRepository(),
+    );
+
+    await tester.tap(find.byKey(const Key('nearbyStationButton')));
+    await tester.pumpAndSettle();
+    expect(find.bySemanticsLabel('시간표 선택됨'), findsOneWidget);
+
+    await tester.tap(
+      find.descendant(
+        of: find.byKey(const Key('networkMapNearbyDataSourceToggle')),
+        matching: find.text('실시간'),
+      ),
+    );
+    await tester.pumpAndSettle();
+    final panel = find.byKey(const Key('networkMapNearbyStationPanel'));
+    expect(find.bySemanticsLabel('실시간 선택됨'), findsOneWidget);
+    expect(
+      find.descendant(of: panel, matching: find.text('오이도행')),
+      findsOneWidget,
+    );
+
+    await tester.tap(
+      find.descendant(
+        of: find.byKey(const Key('networkMapNearbyDataSourceToggle')),
+        matching: find.text('시간표'),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.bySemanticsLabel('시간표 선택됨'), findsOneWidget);
+
+    await tester.tap(
+      find.descendant(
+        of: find.byKey(const Key('networkMapNearbyDataSourceToggle')),
+        matching: find.text('실시간'),
+      ),
+    );
+    // 첫 프레임: 직전 성공 캐시를 settle 없이 즉시 표시.
+    await tester.pump();
+
+    expect(find.bySemanticsLabel('실시간 선택됨'), findsOneWidget);
+    expect(
+      find.descendant(of: panel, matching: find.text('오이도행')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: panel,
+        matching: find.byType(CircularProgressIndicator),
+      ),
+      findsNothing,
+    );
+  });
+
+  testWidgets('첫 실시간 선택에서 API가 지연돼도 방면 골격을 즉시 표시한다', (tester) async {
+    tester.view.physicalSize = const Size(320, 1200);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+    final realtimeCompleter = Completer<RealtimeSnapshot>();
+    addTearDown(() {
+      if (!realtimeCompleter.isCompleted) {
+        realtimeCompleter.complete(const RealtimeSnapshot.unavailable());
+      }
+    });
+    final repository = FakeStationSearchRepository(
+      networkMapRegionNames: const ['수도권'],
+      nearbyResults: [
+        _stationResult(
+          id: 'station-sangnoksu',
+          name: '상록수',
+          lines: const [
+            StationSearchLine(
+              id: 'seoul-4',
+              name: '수도권 4호선',
+              color: '#00A5DE',
+              stationCode: '448',
+            ),
+          ],
+        ),
+      ],
+    );
+    await _pumpNetworkMapForGpsTest(
+      tester,
+      repository: repository,
+      locationProvider: FakeCurrentLocationProvider(
+        location: _freshCurrentLocation(),
+        needsPermissionRequest: false,
+      ),
+      realtimeRepository: _CompleterRealtimeRepository(realtimeCompleter),
+    );
+
+    await tester.tap(find.byKey(const Key('nearbyStationButton')));
+    await tester.pump();
+    await tester.pump();
+
+    await tester.tap(
+      find.descendant(
+        of: find.byKey(const Key('networkMapNearbyDataSourceToggle')),
+        matching: find.text('실시간'),
+      ),
+    );
+    await tester.pump();
+
+    final panel = find.byKey(const Key('networkMapNearbyStationPanel'));
+    expect(find.bySemanticsLabel('실시간 선택됨'), findsOneWidget);
+    expect(
+      find.descendant(
+        of: panel,
+        matching: find.byKey(const Key('networkMapNearbyArrivalSkeleton')),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: panel,
+        matching: find.byType(CircularProgressIndicator),
+      ),
+      findsNothing,
+    );
+    expect(
+      find.descendant(of: panel, matching: find.text('반월 방면')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: panel, matching: find.text('한대앞 방면')),
+      findsOneWidget,
+    );
+
+    await tester.pump(const Duration(seconds: 2));
+    await tester.pump();
+  });
+
+  testWidgets('실시간 unavailable 시 시간표로 자동 전환한다', (tester) async {
+    tester.view.physicalSize = const Size(320, 1200);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+    final now = DateTime.now();
+    final departure = StationTimetableDeparture(
+      directionName: '오이도',
+      seconds:
+          now.hour * Duration.secondsPerHour +
+          now.minute * Duration.secondsPerMinute +
+          now.second +
+          120,
+    );
+    final repository = FakeTimetableStationRepository(
+      stationDetail: _stationDetail(id: 'station-sangnoksu', name: '상록수'),
+      networkMapRegionNames: const ['수도권'],
+      nearbyResults: [_stationResult(id: 'station-sangnoksu', name: '상록수')],
+      timetables: {
+        for (final dayType in StationTimetableDayType.values)
+          dayType: _stationTimetable(
+            dayType,
+            directions: [
+              StationTimetableDirection(name: '오이도', departures: [departure]),
+            ],
+          ),
+      },
+    );
+    await _pumpNetworkMapForGpsTest(
+      tester,
+      repository: repository,
+      locationProvider: FakeCurrentLocationProvider(
+        location: _freshCurrentLocation(),
+        needsPermissionRequest: false,
+      ),
+      realtimeRepository: _UnavailableRealtimeRepository(),
+    );
+
+    await tester.tap(find.byKey(const Key('nearbyStationButton')));
+    await tester.pumpAndSettle();
+    expect(find.bySemanticsLabel('시간표 선택됨'), findsOneWidget);
+
+    await tester.tap(
+      find.descendant(
+        of: find.byKey(const Key('networkMapNearbyDataSourceToggle')),
+        matching: find.text('실시간'),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // 수동 실시간 선택이어도 최신 요청 unavailable이면 시간표로 돌아온다.
+    expect(find.bySemanticsLabel('시간표 선택됨'), findsOneWidget);
+    expect(find.text(departure.timeLabel), findsOneWidget);
+  });
+
+  testWidgets('실시간 empty 시 시간표로 자동 전환한다', (tester) async {
+    tester.view.physicalSize = const Size(320, 1200);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+    final now = DateTime.now();
+    final departure = StationTimetableDeparture(
+      directionName: '오이도',
+      seconds:
+          now.hour * Duration.secondsPerHour +
+          now.minute * Duration.secondsPerMinute +
+          now.second +
+          120,
+    );
+    final repository = FakeTimetableStationRepository(
+      stationDetail: _stationDetail(id: 'station-sangnoksu', name: '상록수'),
+      networkMapRegionNames: const ['수도권'],
+      nearbyResults: [_stationResult(id: 'station-sangnoksu', name: '상록수')],
+      timetables: {
+        for (final dayType in StationTimetableDayType.values)
+          dayType: _stationTimetable(
+            dayType,
+            directions: [
+              StationTimetableDirection(name: '오이도', departures: [departure]),
+            ],
+          ),
+      },
+    );
+    await _pumpNetworkMapForGpsTest(
+      tester,
+      repository: repository,
+      locationProvider: FakeCurrentLocationProvider(
+        location: _freshCurrentLocation(),
+        needsPermissionRequest: false,
+      ),
+      realtimeRepository: _EmptyRealtimeRepository(),
+    );
+
+    await tester.tap(find.byKey(const Key('nearbyStationButton')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(
+      find.descendant(
+        of: find.byKey(const Key('networkMapNearbyDataSourceToggle')),
+        matching: find.text('실시간'),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.bySemanticsLabel('시간표 선택됨'), findsOneWidget);
+    expect(find.text(departure.timeLabel), findsOneWidget);
+  });
+
+  testWidgets('실시간 timeout 시 시간표로 자동 전환한다', (tester) async {
+    tester.view.physicalSize = const Size(320, 1200);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+    final now = DateTime.now();
+    final departure = StationTimetableDeparture(
+      directionName: '오이도',
+      seconds:
+          now.hour * Duration.secondsPerHour +
+          now.minute * Duration.secondsPerMinute +
+          now.second +
+          120,
+    );
+    final repository = FakeTimetableStationRepository(
+      stationDetail: _stationDetail(id: 'station-sangnoksu', name: '상록수'),
+      networkMapRegionNames: const ['수도권'],
+      nearbyResults: [_stationResult(id: 'station-sangnoksu', name: '상록수')],
+      timetables: {
+        for (final dayType in StationTimetableDayType.values)
+          dayType: _stationTimetable(
+            dayType,
+            directions: [
+              StationTimetableDirection(name: '오이도', departures: [departure]),
+            ],
+          ),
+      },
+    );
+    await _pumpNetworkMapForGpsTest(
+      tester,
+      repository: repository,
+      locationProvider: FakeCurrentLocationProvider(
+        location: _freshCurrentLocation(),
+        needsPermissionRequest: false,
+      ),
+      realtimeRepository: _HangingRealtimeRepository(),
+    );
+
+    await tester.tap(find.byKey(const Key('nearbyStationButton')));
+    await tester.pump();
+    await tester.pump();
+
+    await tester.tap(
+      find.descendant(
+        of: find.byKey(const Key('networkMapNearbyDataSourceToggle')),
+        matching: find.text('실시간'),
+      ),
+    );
+    await tester.pump();
+    expect(find.bySemanticsLabel('실시간 선택됨'), findsOneWidget);
+
+    // 패널 실시간 timeout 상수(2초)를 실제로 흘려 폴백을 검증한다.
+    await tester.pump(const Duration(seconds: 2));
+    await tester.pumpAndSettle();
+
+    expect(find.bySemanticsLabel('시간표 선택됨'), findsOneWidget);
+    expect(find.text(departure.timeLabel), findsOneWidget);
+  });
+
+  testWidgets('호선을 변경해도 현재 데이터 소스 선택을 유지한다', (tester) async {
+    tester.view.physicalSize = const Size(320, 1200);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+    // 기본 선택 호선을 4호선으로 두어 인접 방면(반월·한대앞) 골격을 바로 쓸 수 있게 한다.
+    const lines = [
+      StationSearchLine(
+        id: 'seoul-4',
+        name: '수도권 4호선',
+        color: '#00A5DE',
+        stationCode: '454',
+      ),
+      StationSearchLine(
+        id: 'seoul-2',
+        name: '수도권 2호선',
+        color: '#00A84D',
+        stationCode: '222',
+      ),
+    ];
+    final line2Completer = Completer<RealtimeSnapshot>();
+    final line4Completer = Completer<RealtimeSnapshot>();
+    addTearDown(() {
+      if (!line2Completer.isCompleted) {
+        line2Completer.complete(const RealtimeSnapshot.unavailable());
+      }
+      if (!line4Completer.isCompleted) {
+        line4Completer.complete(const RealtimeSnapshot.unavailable());
+      }
+    });
+    final realtimeRepository = _PerLineCompleterRealtimeRepository({
+      'seoul-2': line2Completer,
+      'seoul-4': line4Completer,
+    });
+    final now = DateTime.now();
+    final line2Departure = StationTimetableDeparture(
+      directionName: '성수',
+      seconds:
+          now.hour * Duration.secondsPerHour +
+          now.minute * Duration.secondsPerMinute +
+          now.second +
+          180,
+    );
+    final repository = FakeTimetableStationRepository(
+      stationDetail: _stationDetail(
+        id: 'station-sangnoksu',
+        name: '상록수',
+        lines: lines,
+      ),
+      networkMapRegionNames: const ['수도권'],
+      nearbyResults: [
+        _stationResult(id: 'station-sangnoksu', name: '상록수', lines: lines),
+      ],
+      timetableLineId: 'seoul-2',
+      timetables: {
+        for (final dayType in StationTimetableDayType.values)
+          dayType: _stationTimetable(
+            dayType,
+            directions: [
+              StationTimetableDirection(
+                name: '성수',
+                departures: [line2Departure],
+              ),
+            ],
+          ),
+      },
+    );
+    await _pumpNetworkMapForGpsTest(
+      tester,
+      repository: repository,
+      locationProvider: FakeCurrentLocationProvider(
+        location: _freshCurrentLocation(),
+        needsPermissionRequest: false,
+      ),
+      realtimeRepository: realtimeRepository,
+    );
+
+    await tester.tap(find.byKey(const Key('nearbyStationButton')));
+    await tester.pump();
+    await tester.pump();
+
+    final panel = find.byKey(const Key('networkMapNearbyStationPanel'));
+    // 기본 탭 시간표 + 4호선: 시간표 데이터 없음 → 인접 방면 골격.
+    expect(find.bySemanticsLabel('시간표 선택됨'), findsOneWidget);
+    expect(
+      find.descendant(of: panel, matching: find.text('반월 방면')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: panel, matching: find.text('한대앞 방면')),
+      findsOneWidget,
+    );
+
+    // 2호선으로 바꿔도 시간표 선택 유지. 2호선 시간표가 오면 이전 4호선 전용 도착 텍스트는 없다.
+    await tester.tap(find.byKey(const Key('networkMapNearbyLineTab-seoul-2')));
+    await tester.pump();
+    await tester.pumpAndSettle();
+    expect(find.bySemanticsLabel('시간표 선택됨'), findsOneWidget);
+    expect(
+      find.descendant(of: panel, matching: find.text(line2Departure.timeLabel)),
+      findsOneWidget,
+    );
+
+    // 다시 4호선: 시간표 유지 + 이전 호선(2호선) 시간표 시각 미노출 + 새 호선 방면.
+    await tester.tap(find.byKey(const Key('networkMapNearbyLineTab-seoul-4')));
+    await tester.pump();
+    expect(find.bySemanticsLabel('시간표 선택됨'), findsOneWidget);
+    expect(
+      find.descendant(of: panel, matching: find.text(line2Departure.timeLabel)),
+      findsNothing,
+    );
+    expect(
+      find.descendant(of: panel, matching: find.text('반월 방면')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: panel, matching: find.text('한대앞 방면')),
+      findsOneWidget,
+    );
+
+    // 실시간 전환 후 호선 변경해도 실시간 선택 유지, 이전 호선 도착 텍스트 미노출.
+    await tester.tap(
+      find.descendant(
+        of: find.byKey(const Key('networkMapNearbyDataSourceToggle')),
+        matching: find.text('실시간'),
+      ),
+    );
+    await tester.pump();
+    line4Completer.complete(
+      const RealtimeSnapshot(
+        status: RealtimeSnapshotStatus.fresh,
+        receivedAt: '방금',
+        arrivals: [
+          RealtimeArrival(
+            lineId: 'seoul-4',
+            stationName: '상록수',
+            destination: '오이도',
+            direction: '오이도',
+            trainNo: '4001',
+            message: '곧 도착',
+            etaSeconds: 90,
+          ),
+        ],
+      ),
+    );
+    await tester.pump();
+    expect(find.bySemanticsLabel('실시간 선택됨'), findsOneWidget);
+    expect(
+      find.descendant(of: panel, matching: find.text('오이도행')),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byKey(const Key('networkMapNearbyLineTab-seoul-2')));
+    await tester.pump();
+    expect(find.bySemanticsLabel('실시간 선택됨'), findsOneWidget);
+    expect(find.bySemanticsLabel('시간표 선택됨'), findsNothing);
+    expect(
+      find.descendant(of: panel, matching: find.text('오이도행')),
+      findsNothing,
+    );
+
+    line2Completer.complete(
+      const RealtimeSnapshot(
+        status: RealtimeSnapshotStatus.fresh,
+        receivedAt: '방금',
+        arrivals: [
+          RealtimeArrival(
+            lineId: 'seoul-2',
+            stationName: '상록수',
+            destination: '성수',
+            direction: '성수',
+            trainNo: '2002',
+            message: '곧 도착',
+            etaSeconds: 60,
+          ),
+        ],
+      ),
+    );
+    await tester.pump();
+    expect(
+      find.descendant(of: panel, matching: find.text('성수행')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: panel, matching: find.text('오이도행')),
+      findsNothing,
+    );
+  });
+
+  testWidgets('호선 변경 후 이전 호선의 늦은 실시간 응답을 무시한다', (tester) async {
+    tester.view.physicalSize = const Size(320, 1200);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+    const lines = [
+      StationSearchLine(
+        id: 'seoul-2',
+        name: '수도권 2호선',
+        color: '#00A84D',
+        stationCode: '222',
+      ),
+      StationSearchLine(
+        id: 'seoul-4',
+        name: '수도권 4호선',
+        color: '#00A5DE',
+        stationCode: '454',
+      ),
+    ];
+    final line2Completer = Completer<RealtimeSnapshot>();
+    final line4Completer = Completer<RealtimeSnapshot>();
+    addTearDown(() {
+      if (!line2Completer.isCompleted) {
+        line2Completer.complete(const RealtimeSnapshot.unavailable());
+      }
+      if (!line4Completer.isCompleted) {
+        line4Completer.complete(const RealtimeSnapshot.unavailable());
+      }
+    });
+    final realtimeRepository = _PerLineCompleterRealtimeRepository({
+      'seoul-2': line2Completer,
+      'seoul-4': line4Completer,
+    });
+    final repository = FakeStationSearchRepository(
+      networkMapRegionNames: const ['수도권'],
+      nearbyResults: [
+        _stationResult(id: 'station-sangnoksu', name: '상록수', lines: lines),
+      ],
+    );
+    await _pumpNetworkMapForGpsTest(
+      tester,
+      repository: repository,
+      locationProvider: FakeCurrentLocationProvider(
+        location: _freshCurrentLocation(),
+        needsPermissionRequest: false,
+      ),
+      realtimeRepository: realtimeRepository,
+    );
+
+    await tester.tap(find.byKey(const Key('nearbyStationButton')));
+    await tester.pump();
+    await tester.pump();
+    await tester.tap(
+      find.descendant(
+        of: find.byKey(const Key('networkMapNearbyDataSourceToggle')),
+        matching: find.text('실시간'),
+      ),
+    );
+    await tester.pump();
+
+    await tester.tap(find.byKey(const Key('networkMapNearbyLineTab-seoul-4')));
+    await tester.pump();
+
+    // 이전 호선(2호선)의 늦은 성공 응답은 현재 4호선 패널에 반영되면 안 된다.
+    line2Completer.complete(
+      const RealtimeSnapshot(
+        status: RealtimeSnapshotStatus.fresh,
+        receivedAt: '방금',
+        arrivals: [
+          RealtimeArrival(
+            lineId: 'seoul-2',
+            stationName: '상록수',
+            destination: '성수',
+            direction: '성수',
+            trainNo: '2002',
+            message: '곧 도착',
+            etaSeconds: 60,
+          ),
+        ],
+      ),
+    );
+    await tester.pump();
+
+    final panel = find.byKey(const Key('networkMapNearbyStationPanel'));
+    expect(panel, findsOneWidget);
+    expect(
+      find.descendant(of: panel, matching: find.text('성수행')),
+      findsNothing,
+    );
+    expect(find.bySemanticsLabel('실시간 선택됨'), findsOneWidget);
+
+    line4Completer.complete(
+      const RealtimeSnapshot(
+        status: RealtimeSnapshotStatus.fresh,
+        receivedAt: '방금',
+        arrivals: [
+          RealtimeArrival(
+            lineId: 'seoul-4',
+            stationName: '상록수',
+            destination: '오이도',
+            direction: '오이도',
+            trainNo: '4001',
+            message: '곧 도착',
+            etaSeconds: 90,
+          ),
+        ],
+      ),
+    );
+    await tester.pump();
+
+    expect(
+      find.descendant(of: panel, matching: find.text('오이도행')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: panel, matching: find.text('성수행')),
+      findsNothing,
+    );
+  });
+
+  testWidgets('이전 호선의 실시간 실패는 현재 호선을 시간표로 전환하지 않는다', (tester) async {
+    tester.view.physicalSize = const Size(320, 1200);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+    const lines = [
+      StationSearchLine(
+        id: 'seoul-2',
+        name: '수도권 2호선',
+        color: '#00A84D',
+        stationCode: '222',
+      ),
+      StationSearchLine(
+        id: 'seoul-4',
+        name: '수도권 4호선',
+        color: '#00A5DE',
+        stationCode: '454',
+      ),
+    ];
+    final line2Completer = Completer<RealtimeSnapshot>();
+    final line4Completer = Completer<RealtimeSnapshot>();
+    addTearDown(() {
+      if (!line2Completer.isCompleted) {
+        line2Completer.complete(const RealtimeSnapshot.unavailable());
+      }
+      if (!line4Completer.isCompleted) {
+        line4Completer.complete(const RealtimeSnapshot.unavailable());
+      }
+    });
+    final realtimeRepository = _PerLineCompleterRealtimeRepository({
+      'seoul-2': line2Completer,
+      'seoul-4': line4Completer,
+    });
+    final now = DateTime.now();
+    final departure = StationTimetableDeparture(
+      directionName: '오이도',
+      seconds:
+          now.hour * Duration.secondsPerHour +
+          now.minute * Duration.secondsPerMinute +
+          now.second +
+          120,
+    );
+    final repository = FakeTimetableStationRepository(
+      stationDetail: _stationDetail(
+        id: 'station-sangnoksu',
+        name: '상록수',
+        lines: lines,
+      ),
+      networkMapRegionNames: const ['수도권'],
+      nearbyResults: [
+        _stationResult(id: 'station-sangnoksu', name: '상록수', lines: lines),
+      ],
+      timetables: {
+        for (final dayType in StationTimetableDayType.values)
+          dayType: _stationTimetable(
+            dayType,
+            directions: [
+              StationTimetableDirection(name: '오이도', departures: [departure]),
+            ],
+          ),
+      },
+    );
+    await _pumpNetworkMapForGpsTest(
+      tester,
+      repository: repository,
+      locationProvider: FakeCurrentLocationProvider(
+        location: _freshCurrentLocation(),
+        needsPermissionRequest: false,
+      ),
+      realtimeRepository: realtimeRepository,
+    );
+
+    await tester.tap(find.byKey(const Key('nearbyStationButton')));
+    await tester.pump();
+    await tester.pump();
+    await tester.tap(
+      find.descendant(
+        of: find.byKey(const Key('networkMapNearbyDataSourceToggle')),
+        matching: find.text('실시간'),
+      ),
+    );
+    await tester.pump();
+
+    await tester.tap(find.byKey(const Key('networkMapNearbyLineTab-seoul-4')));
+    await tester.pump();
+    expect(find.bySemanticsLabel('실시간 선택됨'), findsOneWidget);
+
+    // 이전 호선 실패만 완료한다. 현재 호선(4호선)은 hanging 유지해 timeout 폴백과 구분한다.
+    line2Completer.complete(const RealtimeSnapshot.unavailable());
+    await tester.pump();
+
+    expect(find.bySemanticsLabel('실시간 선택됨'), findsOneWidget);
+    expect(find.bySemanticsLabel('시간표 선택됨'), findsNothing);
+
+    // 현재 호선 hanging .timeout(2s) FakeTimer를 dispose 전에 성공으로 비운다.
+    line4Completer.complete(
+      const RealtimeSnapshot(
+        status: RealtimeSnapshotStatus.fresh,
+        receivedAt: '방금',
+        arrivals: [
+          RealtimeArrival(
+            lineId: 'seoul-4',
+            stationName: '상록수',
+            destination: '오이도',
+            direction: '오이도',
+            trainNo: '4001',
+            message: '곧 도착',
+            etaSeconds: 90,
+          ),
+        ],
+      ),
+    );
+    await tester.pump();
+  });
+
+  testWidgets('패널을 닫은 뒤 완료된 요청은 패널 상태를 변경하지 않는다', (tester) async {
+    tester.view.physicalSize = const Size(320, 1200);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+    final realtimeCompleter = Completer<RealtimeSnapshot>();
+    addTearDown(() {
+      if (!realtimeCompleter.isCompleted) {
+        realtimeCompleter.complete(const RealtimeSnapshot.unavailable());
+      }
+    });
+    final repository = FakeStationSearchRepository(
+      networkMapRegionNames: const ['수도권'],
+      nearbyResults: [
+        _stationResult(
+          id: 'station-sangnoksu',
+          name: '상록수',
+          lines: const [
+            StationSearchLine(
+              id: 'seoul-4',
+              name: '수도권 4호선',
+              color: '#00A5DE',
+              stationCode: '448',
+            ),
+          ],
+        ),
+      ],
+    );
+    await _pumpNetworkMapForGpsTest(
+      tester,
+      repository: repository,
+      locationProvider: FakeCurrentLocationProvider(
+        location: _freshCurrentLocation(),
+        needsPermissionRequest: false,
+      ),
+      realtimeRepository: _CompleterRealtimeRepository(realtimeCompleter),
+    );
+
+    await tester.tap(find.byKey(const Key('nearbyStationButton')));
+    await tester.pump();
+    await tester.pump();
+    await tester.tap(
+      find.descendant(
+        of: find.byKey(const Key('networkMapNearbyDataSourceToggle')),
+        matching: find.text('실시간'),
+      ),
+    );
+    await tester.pump();
+    expect(
+      find.byKey(const Key('networkMapNearbyStationPanel')),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byKey(const Key('networkMapNearbyPanelCloseButton')));
+    await tester.pump();
+    expect(find.byKey(const Key('networkMapNearbyStationPanel')), findsNothing);
+
+    realtimeCompleter.complete(
+      const RealtimeSnapshot(
+        status: RealtimeSnapshotStatus.fresh,
+        receivedAt: '방금',
+        arrivals: [
+          RealtimeArrival(
+            lineId: 'seoul-4',
+            stationName: '상록수',
+            destination: '오이도',
+            direction: '오이도',
+            trainNo: '4001',
+            message: '곧 도착',
+            etaSeconds: 90,
+          ),
+        ],
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 2));
+    await tester.pump();
+
+    expect(find.byKey(const Key('networkMapNearbyStationPanel')), findsNothing);
+    expect(find.text('오이도행'), findsNothing);
   });
 
   testWidgets('급행 운행 정보는 선택 UI 없이 시간표와 길찾기에 표시된다', (tester) async {
@@ -5269,13 +6516,7 @@ void main() {
 
       await tester.tap(find.byKey(const Key('nearbyStationButton')));
       await tester.pumpAndSettle();
-      await tester.tap(
-        find.descendant(
-          of: find.byKey(const Key('networkMapNearbyDataSourceToggle')),
-          matching: find.text('시간표'),
-        ),
-      );
-      await tester.pumpAndSettle();
+      // 기본 탭이 시간표이므로 추가 토글 없이 급행 배지를 검증한다.
 
       // --- 시간표 부분(#2099 WP1) ---
       // 인접역 시간표 패널로 범위를 좁힌다. 노선도 자체의 일반/급행 노선 뷰
@@ -5283,6 +6524,7 @@ void main() {
       // 별개 기능이므로 이 검증에 섞이지 않게 한다.
       final panel = find.byKey(const Key('networkMapNearbyStationPanel'));
       expect(panel, findsOneWidget);
+      expect(find.bySemanticsLabel('시간표 선택됨'), findsOneWidget);
       // 급행 출발 행에만 배지 1회, 일반 행에는 배지 없음.
       expect(
         find.descendant(
@@ -18418,6 +19660,51 @@ class FakeTimetableStationRepository extends FakeStationSearchRepository
   }
 }
 
+/// #2453: 로컬 시간표 Future를 완료하지 않아 패널 첫 프레임 골격을 검증한다.
+class _HangingTimetableStationRepository extends FakeStationSearchRepository
+    implements StationTimetableRepository {
+  _HangingTimetableStationRepository({
+    required this.completer,
+    required super.stationDetail,
+    super.nearbyResults,
+    super.networkMapRegionNames,
+    super.queryResults,
+  });
+
+  final Completer<StationTimetable> completer;
+  final requestedDayTypes = <StationTimetableDayType>[];
+
+  @override
+  Future<StationTimetable> loadStationTimetable({
+    required String stationId,
+    required String lineId,
+    required StationTimetableDayType dayType,
+    required DateTime referenceDate,
+  }) {
+    requestedDayTypes.add(dayType);
+    return completer.future;
+  }
+
+  @override
+  Future<StationTimetable> loadStationTimetableForDate({
+    required String stationId,
+    required String lineId,
+    required DateTime date,
+  }) {
+    final dayType = switch (date.weekday) {
+      DateTime.saturday => StationTimetableDayType.saturday,
+      DateTime.sunday => StationTimetableDayType.sundayHoliday,
+      _ => StationTimetableDayType.weekday,
+    };
+    return loadStationTimetable(
+      stationId: stationId,
+      lineId: lineId,
+      dayType: dayType,
+      referenceDate: date,
+    );
+  }
+}
+
 class FakeSearchHistoryRepository implements SearchHistoryRepository {
   FakeSearchHistoryRepository(List<String> queries) : queries = [...queries];
 
@@ -19429,6 +20716,16 @@ class _UnavailableRealtimeRepository implements RealtimeRepository {
   }
 }
 
+class _EmptyRealtimeRepository implements RealtimeRepository {
+  @override
+  Future<RealtimeSnapshot> arrivals(RealtimeStationQuery query) async {
+    return const RealtimeSnapshot(
+      status: RealtimeSnapshotStatus.fresh,
+      arrivals: [],
+    );
+  }
+}
+
 class _FreshRealtimeRepository implements RealtimeRepository {
   @override
   Future<RealtimeSnapshot> arrivals(RealtimeStationQuery query) async {
@@ -19454,6 +20751,37 @@ class _HangingRealtimeRepository implements RealtimeRepository {
   @override
   Future<RealtimeSnapshot> arrivals(RealtimeStationQuery query) {
     return Completer<RealtimeSnapshot>().future;
+  }
+}
+
+class _CompleterRealtimeRepository implements RealtimeRepository {
+  _CompleterRealtimeRepository(this.completer);
+
+  final Completer<RealtimeSnapshot> completer;
+
+  @override
+  Future<RealtimeSnapshot> arrivals(RealtimeStationQuery query) {
+    return completer.future;
+  }
+}
+
+/// 호선별 Completer로 늦은 응답·경합을 재현한다(#2453 Task 3).
+class _PerLineCompleterRealtimeRepository implements RealtimeRepository {
+  _PerLineCompleterRealtimeRepository(this.completersByLineId);
+
+  final Map<String, Completer<RealtimeSnapshot>> completersByLineId;
+  final queries = <RealtimeStationQuery>[];
+
+  @override
+  Future<RealtimeSnapshot> arrivals(RealtimeStationQuery query) {
+    queries.add(query);
+    final completer = completersByLineId[query.lineId];
+    if (completer == null) {
+      return Future<RealtimeSnapshot>.value(
+        const RealtimeSnapshot.unavailable(),
+      );
+    }
+    return completer.future;
   }
 }
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -5775,6 +5775,137 @@ void main() {
     await tester.pump();
   });
 
+  testWidgets(
+    '토글 후 이전 채널 요청이 끝나도 시간표 재조회가 고아 in-flight에 막히지 않는다',
+    (tester) async {
+      tester.view.physicalSize = const Size(320, 1200);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+      final secondRealtimeCompleter = Completer<RealtimeSnapshot>();
+      final timetableCompleter = Completer<StationTimetable>();
+      addTearDown(() {
+        if (!secondRealtimeCompleter.isCompleted) {
+          secondRealtimeCompleter.complete(
+            const RealtimeSnapshot.unavailable(),
+          );
+        }
+        if (!timetableCompleter.isCompleted) {
+          timetableCompleter.complete(
+            StationTimetable(
+              stationId: 'station-sangnoksu',
+              lineId: 'seoul-4',
+              dayType: StationTimetableDayType.weekday,
+              directions: const [],
+            ),
+          );
+        }
+      });
+      final now = DateTime.now();
+      final departure = StationTimetableDeparture(
+        directionName: '오이도',
+        seconds:
+            now.hour * Duration.secondsPerHour +
+            now.minute * Duration.secondsPerMinute +
+            now.second +
+            180,
+      );
+      final repository = _HangingTimetableStationRepository(
+        completer: timetableCompleter,
+        stationDetail: _stationDetail(id: 'station-sangnoksu', name: '상록수'),
+        networkMapRegionNames: const ['수도권'],
+        nearbyResults: [
+          _stationResult(
+            id: 'station-sangnoksu',
+            name: '상록수',
+            lines: const [
+              StationSearchLine(
+                id: 'seoul-4',
+                name: '수도권 4호선',
+                color: '#00A5DE',
+                stationCode: '448',
+              ),
+            ],
+          ),
+        ],
+      );
+      await _pumpNetworkMapForGpsTest(
+        tester,
+        repository: repository,
+        locationProvider: FakeCurrentLocationProvider(
+          location: _freshCurrentLocation(),
+          needsPermissionRequest: false,
+        ),
+        realtimeRepository: _SequenceRealtimeRepository(
+          first: const RealtimeSnapshot.unavailable(),
+          second: secondRealtimeCompleter,
+        ),
+      );
+
+      await tester.tap(find.byKey(const Key('nearbyStationButton')));
+      await tester.pump();
+      await tester.pump();
+
+      // 오픈 prefetch 실시간 실패는 시간표 탭에서 no-op. 시간표는 hanging.
+      expect(find.bySemanticsLabel('시간표 선택됨'), findsOneWidget);
+
+      // 실시간 토글 → generation 상승 + 실시간만 재조회(두 번째 호출은 hanging).
+      await tester.tap(
+        find.descendant(
+          of: find.byKey(const Key('networkMapNearbyDataSourceToggle')),
+          matching: find.text('실시간'),
+        ),
+      );
+      await tester.pump();
+      expect(find.bySemanticsLabel('실시간 선택됨'), findsOneWidget);
+
+      // stale 시간표 완료. 고아 in-flight가 남으면 다음 시간표 토글이 재조회를 막는다.
+      timetableCompleter.complete(
+        StationTimetable(
+          stationId: 'station-sangnoksu',
+          lineId: 'seoul-4',
+          dayType: StationTimetableDayType.weekday,
+          directions: [
+            StationTimetableDirection(name: '오이도', departures: [departure]),
+          ],
+        ),
+      );
+      await tester.pump();
+
+      await tester.tap(
+        find.descendant(
+          of: find.byKey(const Key('networkMapNearbyDataSourceToggle')),
+          matching: find.text('시간표'),
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      final panel = find.byKey(const Key('networkMapNearbyStationPanel'));
+      expect(find.bySemanticsLabel('시간표 선택됨'), findsOneWidget);
+      expect(
+        find.descendant(of: panel, matching: find.text(departure.timeLabel)),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(
+          of: panel,
+          matching: find.byType(CircularProgressIndicator),
+        ),
+        findsNothing,
+      );
+
+      // 두 번째 실시간 Future·timeout Timer를 정리한다.
+      if (!secondRealtimeCompleter.isCompleted) {
+        secondRealtimeCompleter.complete(const RealtimeSnapshot.unavailable());
+      }
+      await tester.pump(const Duration(seconds: 2));
+      await tester.pump();
+    },
+  );
+
   testWidgets('실시간 unavailable 시 시간표로 자동 전환한다', (tester) async {
     tester.view.physicalSize = const Size(320, 1200);
     tester.view.devicePixelRatio = 1;
@@ -20762,6 +20893,24 @@ class _CompleterRealtimeRepository implements RealtimeRepository {
   @override
   Future<RealtimeSnapshot> arrivals(RealtimeStationQuery query) {
     return completer.future;
+  }
+}
+
+/// 첫 호출은 즉시 응답, 두 번째부터는 Completer로 지연(#2453 in-flight 고아 회귀).
+class _SequenceRealtimeRepository implements RealtimeRepository {
+  _SequenceRealtimeRepository({required this.first, required this.second});
+
+  final RealtimeSnapshot first;
+  final Completer<RealtimeSnapshot> second;
+  var _calls = 0;
+
+  @override
+  Future<RealtimeSnapshot> arrivals(RealtimeStationQuery query) async {
+    _calls += 1;
+    if (_calls == 1) {
+      return first;
+    }
+    return second.future;
   }
 }
 


### PR DESCRIPTION
## 관련 이슈

Closes #2453

## 작업 배경

노선도 하단 역 패널이 실시간/시간표 조회를 기다리는 동안 `CircularProgressIndicator`와 빈 대기 화면을 보여 체감이 끊겼다. GPS 경로는 기본 실시간+loading이었고, 수동 실시간 선택은 실패 시 시간표 폴백을 막았으며, 호선 변경은 모드를 realtime으로 강제했다. 늦은 응답이 현재 패널을 덮을 여지도 남아 있었다.

## 작업 내용

- `_openNearbyStationPanel`로 GPS·검색·캔버스(신원 해석 후) 오픈을 통일하고 기본 탭을 시간표로 맞춤
- `_SubwayArrivalPanel` / `_SubwayTimetablePanel` 스피너·loading key 제거, 방면·대시 골격(`networkMapNearbyArrivalSkeleton` / `TimetableSkeleton`) 즉시 표시
- `_NearbyPanelRequestKey` + `_isCurrentNearbyRequest`로 역·호선·generation 일치 응답만 반영
- keyed 성공 캐시(실시간/시간표). unavailable/empty/timeout으로 성공 캐시를 덮지 않음
- `_nearbyAllowRealtimeAutoFallback` 제거. 현재 실시간 탭 + 최신 요청일 때만 시간표 자동 전환. prefetch 실패는 no-op
- 호선 변경 시 현재 모드 유지. 대시 열 ExcludeSemantics + 열 단위 라벨. 패널 `liveRegion` 제거(골격↔데이터 재발화 방지)

## 검증

- 실행한 명령과 결과:
  - `flutter test test/network_map_nearby_panel_test.dart` → 36 passed
  - `flutter test test/widget_test.dart --name 'GPS 하단 패널|스피너 없이|늦은|prefetch|자동 전환|호선을 변경|조회 완료|직전 도착|API가 지연|패널을 닫은|이전 호선'` → 18 passed
  - `flutter analyze lib/network_map.dart lib/features/network_map/presentation/nearby_direction_columns.dart` → No issues
  - `dart format` 대상 파일 → 변경 없음
  - `rg networkMapNearbyArrivalLoading|networkMapNearbyTimetableLoading|_nearbyAllowRealtimeAutoFallback lib` → production 0건(테스트는 findsNothing 부정 검증만)

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 첫 프레임 즉시 표시·스피너 없음 | Android/iOS 공통 | widget `pump()` 계약 테스트 | CI/로컬 `widget_test` 18건 + nearby panel 36건 | 통과 |
| 토글 selected·대시 a11y | Android/iOS 공통 | Semantics 테스트 | `network_map_nearby_panel_test.dart` | 통과 |
| 실기기 profile 체감 | Android SM A175N | `flutter run --profile` 수동 | PR 시점 미실행 — QA 확인 권장(기기 연결됨) | 보류 |
| TalkBack 실기기 | Android | 수동 | widget Semantics 회귀로 대체, 실기기 TalkBack은 QA | 보류 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음(저장소 공개 API 유지, UI 오케스트레이션만)
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `_openNearbyStationPanel` / `_isCurrentNearbyRequest` / keyed display cache
  - 자동 폴백이 현재 실시간 탭+최신 요청에서만 도는지
  - GPS 기본 시간표·호선 변경 모드 유지
  - 패널 content 경로에 스피너가 없는지(노선도 FutureBuilder·패널 idle/loading 레거시 분기는 별개)

## 리스크

- 실시간 API가 오래 지연되면 골격이 유지된다(스피너로 되돌리지 않음). 기존 timeout 후 시간표 전환으로 완화.
- 캔버스 탭은 역 신원 해석(`searchStations`) await 후 패널을 연다(정본상 허용). 실시간/시간표 await는 패널 표시 후.
- 실기기 profile/TalkBack 체감은 QA 보류.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)