### PR TITLE
[Fix] ITX admission 서비스 날짜를 YYYYMMDD로 통일

### DIFF
--- a/tools/datapack/check-timetable-snapshot-freshness.mjs
+++ b/tools/datapack/check-timetable-snapshot-freshness.mjs
@@ -104,7 +104,8 @@ export function computeItxAdmissionServiceDates(now) {
         const yyyy = candidate.getUTCFullYear();
         const mm = String(candidate.getUTCMonth() + 1).padStart(2, "0");
         const dd = String(candidate.getUTCDate()).padStart(2, "0");
-        dates[dayCd] = `${yyyy}-${mm}-${dd}`;
+        // ITX admission / collect CLI(--day*-date) / selectedServiceDates 정본은 YYYYMMDD.
+        dates[dayCd] = `${yyyy}${mm}${dd}`;
         break;
       }
     }

--- a/tools/datapack/check-timetable-snapshot-freshness.test.mjs
+++ b/tools/datapack/check-timetable-snapshot-freshness.test.mjs
@@ -71,9 +71,9 @@ test("Prometheus exposition 형식은 gauge 3종을 노출한다", () => {
 test("admission service dates는 창 안의 평일·토·일을 고른다", () => {
   // 2026-07-20은 월요일(KST). 창: 07-20(월)~07-26(일).
   const dates = computeItxAdmissionServiceDates(new Date("2026-07-20T00:00:00+09:00"));
-  assert.equal(dates["8"], "2026-07-20"); // 월요일(평일)
-  assert.equal(dates["7"], "2026-07-25"); // 토요일
-  assert.equal(dates["9"], "2026-07-26"); // 일요일
+  assert.equal(dates["8"], "20260720"); // 월요일(평일)
+  assert.equal(dates["7"], "20260725"); // 토요일
+  assert.equal(dates["9"], "20260726"); // 일요일
 });
 
 test("parseArgs는 --로 시작하지만 플래그 이름 형태가 아닌 값을 값으로 인식한다", () => {
@@ -113,10 +113,11 @@ test("CLI는 evidence를 읽어 evidence/metrics/github-output를 남기고 fail
   assert.equal(exitCode, 1);
   const evidenceOut = JSON.parse(await readFile(outputPath, "utf8"));
   assert.equal(evidenceOut.artifactKind, "timetable-snapshot-freshness-alert");
-  assert.equal(evidenceOut.serviceDates["8"].length, 10);
+  assert.equal(evidenceOut.serviceDates["8"].length, 8);
+  assert.match(evidenceOut.serviceDates["8"], /^\d{8}$/);
   const ghOutput = await readFile(githubOutputPath, "utf8");
   assert.match(ghOutput, /severity=critical/);
   assert.match(ghOutput, /should_refresh=true/);
-  assert.match(ghOutput, /day8_date=\d{4}-\d{2}-\d{2}/);
+  assert.match(ghOutput, /day8_date=\d{8}/);
   assert.match(await readFile(metricsPath, "utf8"), /easysubway_timetable_snapshot_expired 0/);
 });


### PR DESCRIPTION
## 관련 이슈

Closes #2464

## 작업 내용

- `computeItxAdmissionServiceDates` 출력을 collect/`validateItxServiceDates`/source artifact 정본인 `YYYYMMDD`로 맞춘다.
- freshness 단위 테스트 기대값을 동일 계약으로 수정한다.
- 실패 근거: Actions run 30044501289 (`service date must be YYYYMMDD`, `COLLECT_EXIT=1`).

## 검증

- 실행한 명령과 결과:
  - `node --test tools/datapack/check-timetable-snapshot-freshness.test.mjs` → 12/12 pass

## 영향

- [x] 제품/운영 위험 없음 (route/accessibility/mobile UX/backend API/auth/security 아님)
- [x] DB migration 없음
- [x] 배포 영향 없음
- [x] route/realtime/datapack contract 영향 없음 (admission 날짜 포맷을 기존 collect 정본에 정렬)
- [x] CI workflow·계약 테스트·release gate JSON 변경 없음 (있으면 full.md로 전환)

## 체크리스트

- [x] 이 PR은 B/C등급 작업이며 full template이 필요 없다.
- [ ] CI 결과를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 폴백 리뷰를 단일 PR review로 게시했다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * ITX 운행일 날짜 형식이 하이픈 없는 8자리 숫자(`YYYYMMDD`)로 변경되었습니다.
  * 타임테이블 스냅샷 결과와 CLI 출력의 서비스 날짜 형식이 일관되게 업데이트되었습니다.
* **테스트**
  * 변경된 날짜 형식에 맞춰 관련 검증 및 출력 테스트를 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->