### PR TITLE
[Feat] 노선도 역탭 확장으로 역 상세

### DIFF
--- a/apps/mobile/lib/features/stations/presentation/station_detail_screen.dart
+++ b/apps/mobile/lib/features/stations/presentation/station_detail_screen.dart
@@ -9,6 +9,7 @@ import '../../ads/ad_repository.dart';
 import '../../realtime/realtime_repository.dart';
 import '../../route_draft/application/route_draft_controller.dart';
 import '../application/station_detail_controller.dart';
+import '../domain/station_line.dart';
 import '../domain/station_repositories.dart';
 import 'station_detail_body.dart';
 import 'station_line_badges.dart';
@@ -234,6 +235,165 @@ class _StationDetailAppBarTitle extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+/// 노선도 하단 패널 확장용 Host. Family AppBar 없이 [StationDetailBody]만 소유한다.
+class StationDetailExpandHost extends StatefulWidget {
+  const StationDetailExpandHost({
+    required this.repository,
+    required this.reportRepository,
+    required this.stationId,
+    this.favoriteRepository,
+    this.adRepository,
+    this.realtimeRepository,
+    this.locationProvider,
+    this.initiallyFavorite,
+    this.facilityReportDraftTargetStore,
+    this.internalRouteRepository,
+    this.internalRouteRequest,
+    this.internalRouteMobilityType = 'SENIOR',
+    this.routeDraftController,
+    this.mapLauncher = const UrlLauncherKakaoMapLauncher(),
+    this.onClose,
+    this.previousStation,
+    this.nextStation,
+    this.onSelectNeighbor,
+    this.lineForChrome,
+    super.key,
+  });
+
+  final StationSearchRepository repository;
+  final FacilityReportRepository reportRepository;
+  final FavoriteStationRepository? favoriteRepository;
+  final AdRepository? adRepository;
+  final RealtimeRepository? realtimeRepository;
+  final CurrentLocationProvider? locationProvider;
+  final String stationId;
+  final bool? initiallyFavorite;
+  final FacilityReportDraftTargetStore? facilityReportDraftTargetStore;
+  final InternalRouteRepository? internalRouteRepository;
+  final InternalRouteRequest? internalRouteRequest;
+  final String internalRouteMobilityType;
+  final RouteDraftController? routeDraftController;
+  final KakaoMapLauncher mapLauncher;
+  final VoidCallback? onClose;
+  final StationDetailNeighbor? previousStation;
+  final StationDetailNeighbor? nextStation;
+  final ValueChanged<StationDetailNeighbor>? onSelectNeighbor;
+  final StationSearchLine? lineForChrome;
+
+  @override
+  State<StationDetailExpandHost> createState() =>
+      _StationDetailExpandHostState();
+}
+
+class _StationDetailExpandHostState extends State<StationDetailExpandHost> {
+  late final StationDetailController _controller;
+  StationFavoriteToggleController? _favoriteController;
+  InternalRouteController? _internalRouteController;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = StationDetailController(
+      repository: widget.repository,
+      realtimeRepository: widget.realtimeRepository,
+    );
+    _bindInternalRoute(widget.stationId);
+    _bindFavorite(widget.stationId, widget.initiallyFavorite);
+    _controller.load(widget.stationId);
+  }
+
+  @override
+  void didUpdateWidget(covariant StationDetailExpandHost oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.stationId != widget.stationId) {
+      _bindInternalRoute(widget.stationId);
+      _bindFavorite(widget.stationId, widget.initiallyFavorite);
+      _controller.load(widget.stationId);
+    }
+  }
+
+  void _bindInternalRoute(String stationId) {
+    final repository = widget.internalRouteRepository;
+    if (repository == null) {
+      _internalRouteController?.dispose();
+      _internalRouteController = null;
+      return;
+    }
+    _internalRouteController ??= InternalRouteController(
+      repository: repository,
+    );
+    final request = widget.internalRouteRequest;
+    if (request != null) {
+      _internalRouteController!.load(request);
+    } else {
+      _internalRouteController!.loadDefault(
+        stationId: stationId,
+        mobilityType: widget.internalRouteMobilityType,
+      );
+    }
+  }
+
+  void _bindFavorite(String stationId, bool? initiallyFavorite) {
+    final repository = widget.favoriteRepository;
+    _favoriteController?.dispose();
+    _favoriteController = null;
+    if (repository == null) {
+      return;
+    }
+    _favoriteController = StationFavoriteToggleController(
+      repository: repository,
+      stationId: stationId,
+      initiallyFavorite: initiallyFavorite ?? false,
+      initiallyChecking: initiallyFavorite == null,
+    );
+    if (initiallyFavorite == null) {
+      _favoriteController!.load();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _favoriteController?.dispose();
+    _internalRouteController?.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: Listenable.merge([_controller, ?_internalRouteController]),
+      builder: (context, _) {
+        return ColoredBox(
+          color: EasySubwayAccessibleColors.surface,
+          child: StationDetailBody(
+            state: _controller.state,
+            onRetryRealtime: _controller.retryRealtime,
+            internalRouteState: _internalRouteController?.state,
+            reportRepository: widget.reportRepository,
+            favoriteController: _favoriteController,
+            adRepository: widget.adRepository,
+            routeDraftController: widget.routeDraftController,
+            locationProvider: widget.locationProvider,
+            mapLauncher: widget.mapLauncher,
+            facilityReportDraftTargetStore:
+                widget.facilityReportDraftTargetStore,
+            timetableRepository: widget.repository is StationTimetableRepository
+                ? widget.repository as StationTimetableRepository
+                : null,
+            showContextChrome: true,
+            onClose: widget.onClose,
+            previousStation: widget.previousStation,
+            nextStation: widget.nextStation,
+            onSelectNeighbor: widget.onSelectNeighbor,
+            lineForChrome: widget.lineForChrome,
+          ),
+        );
+      },
     );
   }
 }

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -36,6 +36,7 @@ import 'features/realtime/realtime_repository.dart';
 import 'features/route_draft/application/route_draft_controller.dart';
 import 'features/route_draft/domain/route_draft.dart';
 import 'features/stations/presentation/service_pattern_badge.dart';
+import 'features/stations/presentation/station_detail_body.dart';
 import 'features/stations/presentation/station_detail_screen.dart';
 import 'features/stations/presentation/station_line_badges.dart';
 import 'internal_route.dart';
@@ -517,6 +518,7 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
   // 캐싱해 검색을 열 때 함께 넘긴다.
   List<String> _availableRegionLabels = const ['수도권'];
   bool _nearbyPanelVisible = false;
+  bool _nearbyPanelExpanded = false;
   _NetworkMapNearbyPanelData _nearbyPanelData =
       const _NetworkMapNearbyPanelData.idle();
   String? _nearbySelectedStationId;
@@ -1000,6 +1002,7 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
                 onSearchClear: _searchQueryController.clear,
                 onRegionSelected: (region) => _reload(region: region),
                 nearbyPanelVisible: _nearbyPanelVisible,
+                nearbyPanelExpanded: _nearbyPanelExpanded,
                 nearbyPanelData: _nearbyPanelData,
                 realtime: _nearbyRealtimeForDisplay,
                 nearbySelectedLineId: _nearbySelectedLineId,
@@ -1012,6 +1015,17 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
                 onNearbyLineSelected: _selectNearbyLine,
                 onNearbyDataSourceToggle: _toggleNearbyDataSource,
                 onOpenNearbyStationDetail: _nearbyStationDetailAction,
+                onSelectNearbyNeighbor: _selectNearbyNeighborStation,
+                stationSearchRepository: widget.stationSearchRepository,
+                reportRepository: widget.reportRepository,
+                favoriteRepository: widget.favoriteRepository,
+                adRepository: widget.adRepository,
+                realtimeRepository: widget.realtimeRepository,
+                locationProvider: widget.locationProvider,
+                facilityReportDraftTargetStore:
+                    widget.facilityReportDraftTargetStore,
+                internalRouteRepository: widget.internalRouteRepository,
+                internalRouteMobilityType: widget.internalRouteMobilityType,
                 routeDraftController: widget.routeDraftController,
                 onClearOrigin: _clearOriginStation,
                 onClearDestination: _clearDestinationStation,
@@ -1046,6 +1060,7 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
                 onSearchClear: _searchQueryController.clear,
                 onRegionSelected: (region) => _reload(region: region),
                 nearbyPanelVisible: _nearbyPanelVisible,
+                nearbyPanelExpanded: _nearbyPanelExpanded,
                 nearbyPanelData: _nearbyPanelData,
                 realtime: _nearbyRealtimeForDisplay,
                 nearbySelectedLineId: _nearbySelectedLineId,
@@ -1058,6 +1073,17 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
                 onNearbyLineSelected: _selectNearbyLine,
                 onNearbyDataSourceToggle: _toggleNearbyDataSource,
                 onOpenNearbyStationDetail: _nearbyStationDetailAction,
+                onSelectNearbyNeighbor: _selectNearbyNeighborStation,
+                stationSearchRepository: widget.stationSearchRepository,
+                reportRepository: widget.reportRepository,
+                favoriteRepository: widget.favoriteRepository,
+                adRepository: widget.adRepository,
+                realtimeRepository: widget.realtimeRepository,
+                locationProvider: widget.locationProvider,
+                facilityReportDraftTargetStore:
+                    widget.facilityReportDraftTargetStore,
+                internalRouteRepository: widget.internalRouteRepository,
+                internalRouteMobilityType: widget.internalRouteMobilityType,
                 routeDraftController: widget.routeDraftController,
                 onClearOrigin: _clearOriginStation,
                 onClearDestination: _clearDestinationStation,
@@ -1098,6 +1124,7 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
               onSearchClear: _searchQueryController.clear,
               onRegionSelected: (region) => _reload(region: region),
               nearbyPanelVisible: _nearbyPanelVisible,
+              nearbyPanelExpanded: _nearbyPanelExpanded,
               nearbyPanelData: _nearbyPanelData,
               realtime: _nearbyRealtimeForDisplay,
               nearbySelectedLineId: _nearbySelectedLineId,
@@ -1110,6 +1137,17 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
               onNearbyLineSelected: _selectNearbyLine,
               onNearbyDataSourceToggle: _toggleNearbyDataSource,
               onOpenNearbyStationDetail: _nearbyStationDetailAction,
+              onSelectNearbyNeighbor: _selectNearbyNeighborStation,
+              stationSearchRepository: widget.stationSearchRepository,
+              reportRepository: widget.reportRepository,
+              favoriteRepository: widget.favoriteRepository,
+              adRepository: widget.adRepository,
+              realtimeRepository: widget.realtimeRepository,
+              locationProvider: widget.locationProvider,
+              facilityReportDraftTargetStore:
+                  widget.facilityReportDraftTargetStore,
+              internalRouteRepository: widget.internalRouteRepository,
+              internalRouteMobilityType: widget.internalRouteMobilityType,
               routeDraftController: widget.routeDraftController,
               onClearOrigin: _clearOriginStation,
               onClearDestination: _clearDestinationStation,
@@ -1369,6 +1407,7 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
     // 닫힌 뒤 완료되는 요청이 UI를 건드리지 않도록 generation을 무효화한다.
     _nearbyDataRequestToken++;
     _nearbyPanelVisible = false;
+    _nearbyPanelExpanded = false;
     _nearbySelectedStationId = null;
     _nearbySelectedLineId = null;
     _nearbyPanelData = const _NetworkMapNearbyPanelData.idle();
@@ -1671,23 +1710,44 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
     if (stationRepository == null || reportRepository == null) {
       return;
     }
-    Navigator.of(context).push<void>(
-      MaterialPageRoute<void>(
-        builder: (_) => StationDetailScreen(
-          repository: stationRepository,
-          reportRepository: reportRepository,
-          favoriteRepository: widget.favoriteRepository,
-          adRepository: widget.adRepository,
-          realtimeRepository: widget.realtimeRepository,
-          locationProvider: widget.locationProvider,
-          stationId: results.first.id,
-          facilityReportDraftTargetStore: widget.facilityReportDraftTargetStore,
-          internalRouteRepository: widget.internalRouteRepository,
-          internalRouteMobilityType: widget.internalRouteMobilityType,
-          routeDraftController: widget.routeDraftController,
-        ),
-      ),
-    );
+    setState(() => _nearbyPanelExpanded = true);
+  }
+
+  /// 확장 패널 이전/다음 역 탭. 패널 역을 바꾸고 확장을 유지한다.
+  Future<void> _selectNearbyNeighborStation(
+    StationDetailNeighbor neighbor,
+  ) async {
+    final repository = widget.stationSearchRepository;
+    if (repository == null) {
+      return;
+    }
+    List<StationSearchResult> results;
+    try {
+      results = await repository.searchStations(neighbor.nameKo);
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '노선도 인접 역 패널 해석 중 예외가 발생했습니다.',
+      );
+      return;
+    }
+    if (!mounted) {
+      return;
+    }
+    final match = results
+        .where((result) => result.id == neighbor.stationId)
+        .firstOrNull;
+    if (match == null) {
+      return;
+    }
+    final preferredLine = match.lines
+        .where((line) => line.id == _nearbySelectedLineId)
+        .firstOrNull;
+    if (!_nearbyPanelExpanded) {
+      setState(() => _nearbyPanelExpanded = true);
+    }
+    _openNearbyStationPanel(match, preferredLine: preferredLine);
   }
 
   /// 현재 선택 지역의 표시명(예: '수도권', '부산'). 역 검색 화면을 열 때
@@ -1873,6 +1933,8 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
     return _NetworkMapAdjacentStations(
       leftName: left?.nameKo,
       rightName: right?.nameKo,
+      leftStationId: left?.id,
+      rightStationId: right?.id,
     );
   }
 }
@@ -1897,6 +1959,7 @@ class _NetworkMapChrome extends StatelessWidget {
     required this.onSearchTap,
     required this.onRegionSelected,
     required this.nearbyPanelVisible,
+    required this.nearbyPanelExpanded,
     required this.nearbyPanelData,
     required this.realtime,
     required this.nearbySelectedLineId,
@@ -1909,6 +1972,16 @@ class _NetworkMapChrome extends StatelessWidget {
     required this.onNearbyLineSelected,
     required this.onNearbyDataSourceToggle,
     this.onOpenNearbyStationDetail,
+    this.onSelectNearbyNeighbor,
+    this.stationSearchRepository,
+    this.reportRepository,
+    this.favoriteRepository,
+    this.adRepository,
+    this.realtimeRepository,
+    this.locationProvider,
+    this.facilityReportDraftTargetStore,
+    this.internalRouteRepository,
+    this.internalRouteMobilityType = 'SENIOR',
     required this.routeDraftController,
     required this.onClearOrigin,
     required this.onClearDestination,
@@ -1935,6 +2008,7 @@ class _NetworkMapChrome extends StatelessWidget {
   final VoidCallback onSearchTap;
   final ValueChanged<String> onRegionSelected;
   final bool nearbyPanelVisible;
+  final bool nearbyPanelExpanded;
   final _NetworkMapNearbyPanelData nearbyPanelData;
   final RealtimeSnapshot realtime;
   final String? nearbySelectedLineId;
@@ -1947,6 +2021,16 @@ class _NetworkMapChrome extends StatelessWidget {
   final ValueChanged<StationSearchLine> onNearbyLineSelected;
   final VoidCallback onNearbyDataSourceToggle;
   final VoidCallback? onOpenNearbyStationDetail;
+  final ValueChanged<StationDetailNeighbor>? onSelectNearbyNeighbor;
+  final StationSearchRepository? stationSearchRepository;
+  final FacilityReportRepository? reportRepository;
+  final FavoriteStationRepository? favoriteRepository;
+  final AdRepository? adRepository;
+  final RealtimeRepository? realtimeRepository;
+  final CurrentLocationProvider? locationProvider;
+  final FacilityReportDraftTargetStore? facilityReportDraftTargetStore;
+  final InternalRouteRepository? internalRouteRepository;
+  final String internalRouteMobilityType;
   final RouteDraftController routeDraftController;
   final VoidCallback onClearOrigin;
   final VoidCallback onClearDestination;
@@ -2035,6 +2119,7 @@ class _NetworkMapChrome extends StatelessWidget {
             bottom: 0,
             child: _NetworkMapNearbyStationPanel(
               data: nearbyPanelData,
+              expanded: nearbyPanelExpanded,
               realtime: realtime,
               selectedLineId: nearbySelectedLineId,
               dataSource: nearbyDataSource,
@@ -2044,16 +2129,29 @@ class _NetworkMapChrome extends StatelessWidget {
               onLineSelected: onNearbyLineSelected,
               onDataSourceToggle: onNearbyDataSourceToggle,
               onOpenStationDetail: onOpenNearbyStationDetail,
+              onSelectNeighbor: onSelectNearbyNeighbor,
+              stationSearchRepository: stationSearchRepository,
+              reportRepository: reportRepository,
+              favoriteRepository: favoriteRepository,
+              adRepository: adRepository,
+              realtimeRepository: realtimeRepository,
+              locationProvider: locationProvider,
+              facilityReportDraftTargetStore: facilityReportDraftTargetStore,
+              internalRouteRepository: internalRouteRepository,
+              internalRouteMobilityType: internalRouteMobilityType,
+              routeDraftController: routeDraftController,
             ),
           ),
-        if (nearbyLookupMessage != null && !inSearchMode)
+        if (nearbyLookupMessage != null &&
+            !inSearchMode &&
+            !nearbyPanelExpanded)
           Positioned(
             left: 24,
             right: 24,
             bottom: nearbyPanelVisible ? 318 : 132,
             child: _NetworkMapLookupToast(message: nearbyLookupMessage!),
           ),
-        if (!inSearchMode)
+        if (!inSearchMode && !nearbyPanelExpanded)
           Positioned(
             right: 16,
             bottom: nearbyPanelVisible ? 280 : 26,
@@ -2932,15 +3030,41 @@ class _NetworkMapNearbyPanelData {
 }
 
 class _NetworkMapAdjacentStations {
-  const _NetworkMapAdjacentStations({this.leftName, this.rightName});
+  const _NetworkMapAdjacentStations({
+    this.leftName,
+    this.rightName,
+    this.leftStationId,
+    this.rightStationId,
+  });
 
   final String? leftName;
   final String? rightName;
+  final String? leftStationId;
+  final String? rightStationId;
+
+  StationDetailNeighbor? get previousNeighbor {
+    final id = leftStationId;
+    final name = leftName;
+    if (id == null || name == null || name.isEmpty) {
+      return null;
+    }
+    return StationDetailNeighbor(stationId: id, nameKo: name);
+  }
+
+  StationDetailNeighbor? get nextNeighbor {
+    final id = rightStationId;
+    final name = rightName;
+    if (id == null || name == null || name.isEmpty) {
+      return null;
+    }
+    return StationDetailNeighbor(stationId: id, nameKo: name);
+  }
 }
 
 class _NetworkMapNearbyStationPanel extends StatelessWidget {
   const _NetworkMapNearbyStationPanel({
     required this.data,
+    required this.expanded,
     required this.realtime,
     required this.selectedLineId,
     required this.dataSource,
@@ -2950,9 +3074,21 @@ class _NetworkMapNearbyStationPanel extends StatelessWidget {
     required this.onLineSelected,
     required this.onDataSourceToggle,
     this.onOpenStationDetail,
+    this.onSelectNeighbor,
+    this.stationSearchRepository,
+    this.reportRepository,
+    this.favoriteRepository,
+    this.adRepository,
+    this.realtimeRepository,
+    this.locationProvider,
+    this.facilityReportDraftTargetStore,
+    this.internalRouteRepository,
+    this.internalRouteMobilityType = 'SENIOR',
+    this.routeDraftController,
   });
 
   final _NetworkMapNearbyPanelData data;
+  final bool expanded;
   final RealtimeSnapshot realtime;
   final String? selectedLineId;
   final _NearbyPanelDataSource dataSource;
@@ -2962,92 +3098,147 @@ class _NetworkMapNearbyStationPanel extends StatelessWidget {
   final ValueChanged<StationSearchLine> onLineSelected;
   final VoidCallback onDataSourceToggle;
   final VoidCallback? onOpenStationDetail;
+  final ValueChanged<StationDetailNeighbor>? onSelectNeighbor;
+  final StationSearchRepository? stationSearchRepository;
+  final FacilityReportRepository? reportRepository;
+  final FavoriteStationRepository? favoriteRepository;
+  final AdRepository? adRepository;
+  final RealtimeRepository? realtimeRepository;
+  final CurrentLocationProvider? locationProvider;
+  final FacilityReportDraftTargetStore? facilityReportDraftTargetStore;
+  final InternalRouteRepository? internalRouteRepository;
+  final String internalRouteMobilityType;
+  final RouteDraftController? routeDraftController;
 
   @override
   Widget build(BuildContext context) {
     final primary = data.results.isEmpty ? null : data.results.first;
     final dataSourceToggleEnabled = !(primary?.lines.isEmpty ?? true);
+    final selectedLine = primary == null
+        ? null
+        : _nearbySelectedLine(primary, selectedLineId);
+    final panelHeight = expanded
+        ? MediaQuery.sizeOf(context).height * 0.92
+        : null;
+    final canExpandDetail =
+        expanded &&
+        primary != null &&
+        stationSearchRepository != null &&
+        reportRepository != null;
+
     return Material(
       key: const Key('networkMapNearbyStationPanel'),
       color: Colors.white,
       elevation: 0,
-      child: SafeArea(
-        top: false,
-        child: DecoratedBox(
-          decoration: const BoxDecoration(
-            border: Border(top: BorderSide(color: Color(0xFFD8D8D8))),
-          ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              SizedBox(
-                height: 52,
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.end,
-                  children: [
-                    const SizedBox(width: 14),
-                    Expanded(
-                      child: SingleChildScrollView(
-                        scrollDirection: Axis.horizontal,
-                        child: Row(
-                          children: [
-                            for (final line
-                                in primary?.lines ??
-                                    const <StationSearchLine>[])
-                              Padding(
-                                padding: const EdgeInsets.only(bottom: 2),
-                                child: _SubwayLinePanelTab(
-                                  line: line,
-                                  selected: line.id == selectedLineId,
-                                  onTap: () => onLineSelected(line),
+      child: SizedBox(
+        key: expanded
+            ? const Key('networkMapNearbyStationPanelExpanded')
+            : null,
+        height: panelHeight,
+        child: SafeArea(
+          top: false,
+          child: DecoratedBox(
+            decoration: const BoxDecoration(
+              border: Border(top: BorderSide(color: Color(0xFFD8D8D8))),
+            ),
+            child: Column(
+              mainAxisSize: expanded ? MainAxisSize.max : MainAxisSize.min,
+              children: [
+                SizedBox(
+                  height: 52,
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      const SizedBox(width: 14),
+                      Expanded(
+                        child: SingleChildScrollView(
+                          scrollDirection: Axis.horizontal,
+                          child: Row(
+                            children: [
+                              for (final line
+                                  in primary?.lines ??
+                                      const <StationSearchLine>[])
+                                Padding(
+                                  padding: const EdgeInsets.only(bottom: 2),
+                                  child: _SubwayLinePanelTab(
+                                    line: line,
+                                    selected: line.id == selectedLineId,
+                                    onTap: () => onLineSelected(line),
+                                  ),
                                 ),
-                              ),
-                          ],
+                            ],
+                          ),
                         ),
                       ),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.only(bottom: 2),
-                      child: NearbyDataSourceToggle(
-                        isRealtime:
-                            dataSource == _NearbyPanelDataSource.realtime,
-                        enabled: dataSourceToggleEnabled,
-                        onToggle: onDataSourceToggle,
-                      ),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.only(bottom: 2),
-                      child: IconButton(
-                        key: const Key('networkMapNearbyPanelCloseButton'),
-                        tooltip: '닫기',
-                        onPressed: onClose,
-                        constraints: const BoxConstraints.tightFor(
-                          width: 48,
-                          height: 48,
+                      if (!expanded)
+                        Padding(
+                          padding: const EdgeInsets.only(bottom: 2),
+                          child: NearbyDataSourceToggle(
+                            isRealtime:
+                                dataSource == _NearbyPanelDataSource.realtime,
+                            enabled: dataSourceToggleEnabled,
+                            onToggle: onDataSourceToggle,
+                          ),
                         ),
-                        padding: EdgeInsets.zero,
-                        icon: const Icon(
-                          Icons.close,
-                          color: Color(0xFF454545),
-                          size: 27,
+                      Padding(
+                        padding: const EdgeInsets.only(bottom: 2),
+                        child: IconButton(
+                          key: const Key('networkMapNearbyPanelCloseButton'),
+                          tooltip: '닫기',
+                          onPressed: onClose,
+                          constraints: const BoxConstraints.tightFor(
+                            width: 48,
+                            height: 48,
+                          ),
+                          padding: EdgeInsets.zero,
+                          icon: const Icon(
+                            Icons.close,
+                            color: Color(0xFF454545),
+                            size: 27,
+                          ),
                         ),
                       ),
-                    ),
-                    const SizedBox(width: 10),
-                  ],
+                      const SizedBox(width: 10),
+                    ],
+                  ),
                 ),
-              ),
-              const Divider(height: 1, color: Color(0xFFD8D8D8)),
-              _NetworkMapNearbyPanelBody(
-                data: data,
-                realtime: realtime,
-                selectedLineId: selectedLineId,
-                dataSource: dataSource,
-                timetable: timetable,
-                adjacentStations: adjacentStations,
-                onOpenStationDetail: onOpenStationDetail,
-              ),
-            ],
+                const Divider(height: 1, color: Color(0xFFD8D8D8)),
+                if (canExpandDetail)
+                  Expanded(
+                    child: StationDetailExpandHost(
+                      key: ValueKey('nearbyStationDetailHost-${primary.id}'),
+                      repository: stationSearchRepository!,
+                      reportRepository: reportRepository!,
+                      favoriteRepository: favoriteRepository,
+                      adRepository: adRepository,
+                      realtimeRepository: realtimeRepository,
+                      locationProvider: locationProvider,
+                      stationId: primary.id,
+                      facilityReportDraftTargetStore:
+                          facilityReportDraftTargetStore,
+                      internalRouteRepository: internalRouteRepository,
+                      internalRouteMobilityType: internalRouteMobilityType,
+                      routeDraftController: routeDraftController,
+                      // 패널 상단 X가 닫기를 담당. Body chrome은 이웃 역·역명만.
+                      onClose: null,
+                      previousStation: adjacentStations.previousNeighbor,
+                      nextStation: adjacentStations.nextNeighbor,
+                      onSelectNeighbor: onSelectNeighbor,
+                      lineForChrome: selectedLine,
+                    ),
+                  )
+                else
+                  _NetworkMapNearbyPanelBody(
+                    data: data,
+                    realtime: realtime,
+                    selectedLineId: selectedLineId,
+                    dataSource: dataSource,
+                    timetable: timetable,
+                    adjacentStations: adjacentStations,
+                    onOpenStationDetail: onOpenStationDetail,
+                  ),
+              ],
+            ),
           ),
         ),
       ),

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -539,6 +539,9 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
   // 탭만 패널에 반영되도록 토큰으로 앞선 요청을 무효화한다.
   int _canvasTapPanelToken = 0;
 
+  /// #2436: 인접 역 탭 해석도 비동기라 연타·닫기 후 늦은 응답을 토큰으로 버린다.
+  int _neighborSelectPanelToken = 0;
+
   /// 성공한 실시간만 stationId+lineId 키로 보관. unavailable/loading/empty로 덮지 않는다.
   _NearbyRealtimeDisplay? _nearbyRealtimeDisplay;
 
@@ -746,6 +749,8 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
     StationSearchResult station, {
     StationSearchLine? preferredLine,
   }) {
+    // 인접 역 해석 중 다른 경로로 패널이 열리면 늦은 neighbor 응답을 버린다.
+    _neighborSelectPanelToken++;
     final selectedLine = preferredLine ?? station.lines.firstOrNull;
     // generation을 먼저 올려 이전 요청을 무효화한 뒤 패널을 연다.
     final generation = ++_nearbyDataRequestToken;
@@ -1406,6 +1411,7 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
   void _resetNearbyPanelState() {
     // 닫힌 뒤 완료되는 요청이 UI를 건드리지 않도록 generation을 무효화한다.
     _nearbyDataRequestToken++;
+    _neighborSelectPanelToken++;
     _nearbyPanelVisible = false;
     _nearbyPanelExpanded = false;
     _nearbySelectedStationId = null;
@@ -1721,6 +1727,7 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
     if (repository == null) {
       return;
     }
+    final token = ++_neighborSelectPanelToken;
     List<StationSearchResult> results;
     try {
       results = await repository.searchStations(neighbor.nameKo);
@@ -1732,7 +1739,10 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
       );
       return;
     }
-    if (!mounted) {
+    // 연타·닫기 후 늦은 응답은 패널을 다시 열거나 잘못된 역으로 덮지 않는다.
+    if (!mounted ||
+        token != _neighborSelectPanelToken ||
+        !_nearbyPanelVisible) {
       return;
     }
     final match = results

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -34,6 +34,7 @@ import 'package:easysubway_mobile/features/get_off_alarm/get_off_alarm_subscript
 import 'package:easysubway_mobile/features/network_map/domain/map_camera.dart';
 import 'package:easysubway_mobile/features/realtime/realtime_repository.dart';
 import 'package:easysubway_mobile/features/route_draft/application/route_draft_controller.dart';
+import 'package:easysubway_mobile/features/stations/presentation/station_detail_body.dart';
 import 'package:easysubway_mobile/features/stations/presentation/station_detail_screen.dart';
 import 'package:easysubway_mobile/features/stations/presentation/station_search_screen.dart';
 import 'package:easysubway_mobile/features/service_notice/data/notice_repository.dart';
@@ -10367,13 +10368,23 @@ void main() {
     await tester.tap(find.byKey(const Key('nearbyStationLineBarStationName')));
     await tester.pumpAndSettle();
 
-    expect(find.byType(StationDetailScreen), findsOneWidget);
-    await tester.tap(find.byKey(const Key('stationDetailBackButton')));
-    await tester.pumpAndSettle();
+    // #2436 PR-B: 역 이름 탭은 라우트 push 대신 패널 확장 + StationDetailBody.
     expect(find.byType(StationDetailScreen), findsNothing);
     expect(
-      find.byKey(const Key('networkMapNearbyStationPanel')),
+      find.byKey(const Key('networkMapNearbyStationPanelExpanded')),
       findsOneWidget,
+    );
+    expect(find.byType(StationDetailBody), findsOneWidget);
+    expect(find.byKey(const Key('stationDetailList')), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('networkMapNearbyPanelCloseButton')));
+    await tester.pumpAndSettle();
+    expect(find.byType(StationDetailScreen), findsNothing);
+    expect(find.byType(StationDetailBody), findsNothing);
+    expect(find.byKey(const Key('networkMapNearbyStationPanel')), findsNothing);
+    expect(
+      find.byKey(const Key('networkMapNearbyStationPanelExpanded')),
+      findsNothing,
     );
   });
 


### PR DESCRIPTION
## 관련 이슈

Refs #2436

## 작업 배경

#2436 PR-A에서 공통 `StationDetailBody`·카카오식 IA·검색/즐겨찾기 시트를 도입했다. PR-B는 노선도 하단 역 패널에서 역 이름 탭 시 `Navigator.push(StationDetailScreen)` 대신 패널을 확장해 동일한 Body를 in-panel로 보여 주는 경로를 맞춘다.

## 작업 내용

- 노선도 하단 패널에 `_nearbyPanelExpanded` 상태를 추가하고, 역 이름 탭(`onOpenStationDetail`) 시 확장한다.
- 확장 시 화면 높이의 약 92% 패널 + `StationDetailExpandHost`(`StationDetailBody`, `showContextChrome: true`)를 표시한다. `StationDetailScreen` 라우트 push는 제거했다.
- 선택/GPS/캔버스는 기존처럼 접힌 요약 패널을 연다. 확장 중 다른 역 선택·인접 역 탭은 확장을 유지한 채 역 데이터를 교체한다.
- 닫기(X)는 `_resetNearbyPanelState`로 패널을 숨긴다. 확장 중 위치 버튼·토스트는 가린다.
- 위젯 테스트를 패널 확장/비-push 기대로 갱신했다.

## 검증

- 실행한 명령과 결과:
  - `dart format lib test` — OK
  - `flutter analyze lib test` — No issues found
  - `flutter test test/network_map_nearby_panel_test.dart` — All tests passed (36)
  - `flutter test test/widget_test.dart --name '하단 역|nearby|StationDetail|networkMapNearby|메뉴 역 검색'` — All tests passed (3)

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 역 이름 탭 → 패널 확장 | mobile widget | `하단 역 정보 패널의 역 이름을 탭하면 상세로 이동한다` | `networkMapNearbyStationPanelExpanded` + `StationDetailBody`, `StationDetailScreen` 없음 | pass |
| 닫기 → 패널 숨김 | mobile widget | 동일 테스트에서 close 후 panel key Nothing | `networkMapNearbyStationPanel` findsNothing | pass |
| 주변 패널 단위 UI | mobile widget | `network_map_nearby_panel_test.dart` | 36 passed | pass |
| 정적 분석 | mobile | `flutter analyze lib test` | No issues found | pass |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: unchanged
- mobile versionCode: unchanged
- datapack version: unchanged
- route contract: unchanged
- realtime contract: unchanged
- backend identity: unchanged

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `_openNearbyStationDetail`이 push 대신 `_nearbyPanelExpanded = true`만 설정하는지
  - `StationDetailExpandHost`의 `didUpdateWidget`으로 역 교체 시 reload되는지
  - 닫기·확장 중 다른 역 선택·인접 역 전환 상태 머신
  - 카카오버스 배너 미추가·시설 제보/보내기 유지

## 리스크

- 확장 패널이 거의 전체 높이라 지도 조작이 가려짐(의도된 UX). 닫기 전 위치 버튼도 숨김.
- 인접 역 전환은 `searchStations(name)` 재해석에 의존하므로 검색 결과가 비면 전환이 실패할 수 있다.
- 확장 Host는 `StationDetailScreen`과 컨트롤러 설정이 유사해 추후 중복 정리가 필요할 수 있다(이번 PR 범위 밖).

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.