### PR TITLE
[Fix] #2486 인천 accessibility topology snapshotId fail-closed 검증

### DIFF
--- a/tools/datapack/collect-incheon-accessibility.mjs
+++ b/tools/datapack/collect-incheon-accessibility.mjs
@@ -25,6 +25,7 @@ const SOURCE_ID = "incheon-transit-accessibility";
 const ARTIFACT_KIND = "incheon-accessibility-snapshot";
 const TOPOLOGY_SOURCE_ID = "incheon-transit-station-info";
 const TOPOLOGY_SNAPSHOT_ID = "incheon-transit-station-info-20260724";
+const TOPOLOGY_CONTENT_SHA256 = "5ee8cc4db3b9adf313907e2919baddfb9ffad93a2329a907589a9530e526c912";
 const LINE1 = "line-98718184f016";
 const LINE2 = "line-42b5805f3b5a";
 const LINE_IDS = Object.freeze([LINE2, LINE1]);
@@ -316,6 +317,8 @@ function countFacilityRows({
 function validateTopologySnapshot(topologySnapshot) {
   validateIncheonStationInfoSnapshot(topologySnapshot);
   if (topologySnapshot.sourceId !== TOPOLOGY_SOURCE_ID
+    || topologySnapshot.snapshotId !== TOPOLOGY_SNAPSHOT_ID
+    || topologySnapshot.contentSha256 !== TOPOLOGY_CONTENT_SHA256
     || topologySnapshot.stationCount !== EXPECTED_STATION_COUNT
     || topologySnapshot.scope?.length !== EXPECTED_STATION_COUNT
     || JSON.stringify(topologySnapshot.lineIds) !== JSON.stringify([...LINE_IDS])) {
@@ -389,17 +392,25 @@ function parseArgs(argv) {
 
 export async function runIncheonAccessibilityCollector(argv) {
   const args = parseArgs(argv);
+  const topologyPath = args["topology-snapshot"];
+  const topologySnapshotId = path.basename(topologyPath, ".json");
+  if (topologySnapshotId !== TOPOLOGY_SNAPSHOT_ID) {
+    throw new Error(`Incheon topology snapshot path must be ${TOPOLOGY_SNAPSHOT_ID}.json`);
+  }
   const [elevatorBytes, escalatorBytes, wheelchairBytes, topologySnapshot] = await Promise.all([
     readFile(args["elevator-input"]),
     readFile(args["escalator-input"]),
     readFile(args["wheelchair-input"]),
-    readFile(args["topology-snapshot"], "utf8").then(JSON.parse),
+    readFile(topologyPath, "utf8").then(JSON.parse),
   ]);
   const snapshot = collectIncheonAccessibility({
     elevatorBytes,
     escalatorBytes,
     wheelchairBytes,
-    topologySnapshot,
+    topologySnapshot: {
+      ...topologySnapshot,
+      snapshotId: topologySnapshot.snapshotId ?? topologySnapshotId,
+    },
     now: args["captured-at"] ? new Date(args["captured-at"]) : new Date(),
   });
   await writeFile(args.output, `${JSON.stringify(snapshot)}\n`);

--- a/tools/datapack/collect-incheon-accessibility.test.mjs
+++ b/tools/datapack/collect-incheon-accessibility.test.mjs
@@ -24,7 +24,11 @@ async function loadInputs() {
     readFile(ESCALATOR_CSV),
     readFile(WHEELCHAIR_CSV),
     readFile(path.join(root, "tools/datapack/sources/incheon-transit-station-info-20260724.json"), "utf8")
-      .then(JSON.parse),
+      .then(JSON.parse)
+      .then((snapshot) => ({
+        ...snapshot,
+        snapshotId: snapshot.snapshotId ?? "incheon-transit-station-info-20260724",
+      })),
   ]);
   return { elevatorBytes, escalatorBytes, wheelchairBytes, topologySnapshot };
 }
@@ -191,6 +195,16 @@ test("인천 accessibility collector는 schema·join·count 변조를 fail close
     topologySnapshot: badTopology,
     now: new Date("2026-07-24T07:00:00.000Z"),
   }), /topology snapshot|station info snapshot/);
+
+  const wrongSnapshotId = {
+    ...inputs.topologySnapshot,
+    snapshotId: "incheon-transit-station-info-20990101",
+  };
+  assert.throws(() => collectIncheonAccessibility({
+    ...inputs,
+    topologySnapshot: wrongSnapshotId,
+    now: new Date("2026-07-24T07:00:00.000Z"),
+  }), /invalid Incheon topology snapshot/);
 });
 
 test("인천 accessibility collector CLI는 absolute output 경로를 강제한다", async () => {


### PR DESCRIPTION
## 관련 이슈

Closes AquilaXk/easysubway#2486
Refs AquilaXk/easysubway-data#3
Refs AquilaXk/easysubway#2484
PR AquilaXk/easysubway#2485 Bugbot finding(medium) 후속.

## 작업 내용

- `validateTopologySnapshot`이 `snapshotId === TOPOLOGY_SNAPSHOT_ID`와 pinned `contentSha256`을 fail-closed로 검증
- CLI는 topology 경로 basename을 동일 snapshotId로 강제·주입
- 잘못된 snapshotId unit test 추가
- materializer는 기존 `topologySnapshotId` 검증 유지(변경 없음)

## 검증

- 실행한 명령과 결과:
  - `node --test tools/datapack/collect-incheon-accessibility.test.mjs tools/datapack/materialize-incheon-accessibility.test.mjs` → 6/6 pass

## 영향

- [x] 제품/운영 위험 없음 (route/accessibility/mobile UX/backend API/auth/security 아님)
- [x] DB migration 없음
- [x] 배포 영향 없음
- [x] route/realtime/datapack contract 영향 없음
- [x] CI workflow·계약 테스트·release gate JSON 변경 없음 (있으면 full.md로 전환)

## 체크리스트

- [x] 이 PR은 B/C등급 작업이며 full template이 필요 없다.
- [ ] CI 결과를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 폴백 리뷰를 단일 PR review로 게시했다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 인천 접근성 데이터 수집 시 토폴로지 스냅샷의 콘텐츠 해시와 식별자를 추가로 검증합니다.
  * 경로와 스냅샷 식별자가 일치하지 않거나 검증에 실패하면 데이터 수집을 중단합니다.
  * 잘못된 스냅샷이 사용되는 상황을 방지했습니다.

* **테스트**
  * 잘못된 토폴로지 스냅샷 식별자에 대한 오류 처리를 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->