### PR TITLE
[Feat] #2507 전국 270 coverage tally 도구와 커밋 ledger

### DIFF
--- a/tools/datapack/build-nationwide-coverage-tally.mjs
+++ b/tools/datapack/build-nationwide-coverage-tally.mjs
@@ -1,0 +1,522 @@
+#!/usr/bin/env node
+// #2507 전국 270 coverage 집계 정본화 — tally 도구(tracked ledger 생성기).
+//
+// #2138 전국 requirement 진행 집계를 이슈 코멘트 수기 집계에서 재현 가능한 커밋 산출물로 옮긴다.
+// requirement 분모는 targets의 activeLineScopes × requiredSourceDomains이며, LAUNCH_REQUIRED tier가
+// 270건(45 scope × 6 domain), ENHANCEMENT tier가 45건(45 scope × 1 domain)이다.
+//
+// 입력:
+//   --targets     tools/datapack/nationwide-coverage-targets.json (분모·domain 계약 정본)
+//   --inventory   tools/datapack/source-inventory.json (coverageScope admission 정본)
+//   --resolutions EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE 정본. 생략하면 DEFAULT_RESOLUTIONS_PATH.
+//                 (경로를 인자로 받는 이유: resolutions 문서는 재생성 시 파일이 교체된다.)
+//   --output      ledger 출력 경로
+//   --expected-launch-required-total  분모 drift fail-closed용 기대값(선택). 계산된 LAUNCH_REQUIRED
+//                 분모와 다르면 실패한다.
+//
+// 상태 축(이 ledger가 산출하는 축):
+//   INVENTORY_ADMITTED                  source-inventory coverageScope의 (operatorIds, lineIds,
+//                                       sourceDomains) 엄격 매칭으로 domain requiredFields를
+//                                       blockingThreshold 이상 충족.
+//   EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE resolutions 문서의 정본 판정.
+//   MISSING                              그 외. dual-operator 미매칭 여부를 하위 구분으로 남긴다.
+//
+// 범위 밖(별도 축):
+//   provenance 기반 게이트 SUPPORTED 판정(report-coverage-gaps.mjs --manifest/--provenance)은 이
+//   도구의 축이 아니다. INVENTORY_ADMITTED는 admission 근사치이며 게이트 통과를 뜻하지 않는다.
+//   resolutions entry의 만료(nextReviewAt) 재검토 판정도 wall-clock에 의존하므로 게이트 몫이다.
+//
+// 판정 의미론은 report-coverage-gaps.mjs의 evaluateRequirements/coveredField와 어긋나면 안 된다.
+// 특히 빈 lineIds는 와일드카드가 아니다(strictLineScope=true와 동일). 이 도구는 게이트의
+// requireProvenance=false 경로(= inventory fieldsProvided 매칭)에 대응한다.
+//
+// 결정성: 같은 입력 → 같은 출력 바이트. wall-clock(Date.now/new Date)을 쓰지 않고 시각 값은
+// 입력 파일에서만 유도한다. 정렬은 로케일 무관 코드포인트 비교로 고정한다.
+//
+// 사용: node tools/datapack/build-nationwide-coverage-tally.mjs \
+//   --targets tools/datapack/nationwide-coverage-targets.json \
+//   --inventory tools/datapack/source-inventory.json \
+//   --resolutions tools/datapack/release/nationwide-public-api-coverage-resolutions-20260721.json \
+//   --expected-launch-required-total 270 \
+//   --output tools/datapack/reports/nationwide-coverage-tally.json
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { codepointCompare } from "../lib/codepoint-compare.mjs";
+import { isMainModule } from "../lib/is-main-module.mjs";
+import { parseArgs, requireArg, sortJson } from "./lib/ledger-admission-cli.mjs";
+
+export const DEFAULT_RESOLUTIONS_PATH =
+  "tools/datapack/release/nationwide-public-api-coverage-resolutions-20260721.json";
+// 재생성 명령에 기록하는 tracked ledger 경로. --output이 임시 경로여도 산출 바이트가 달라지지
+// 않도록 명령 문자열은 이 상수를 쓴다(재현성 검증이 임시 출력으로 가능해야 한다).
+export const LEDGER_PATH = "tools/datapack/reports/nationwide-coverage-tally.json";
+const TOOL_PATH = "tools/datapack/build-nationwide-coverage-tally.mjs";
+const ALLOWED_FLAGS = new Set([
+  "targets",
+  "inventory",
+  "resolutions",
+  "output",
+  "expected-launch-required-total",
+]);
+const TALLY_STATUSES = ["INVENTORY_ADMITTED", "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE", "MISSING"];
+const MISSING_KINDS = ["DUAL_OPERATOR_UNMATCHED", "NO_ADMITTED_SOURCE"];
+const RELEASE_TIERS = ["LAUNCH_REQUIRED", "ENHANCEMENT"];
+
+export function buildNationwideCoverageTally({
+  targets,
+  inventory,
+  resolutions,
+  inputs,
+  expectedLaunchRequiredTotal = null,
+}) {
+  validateTargets(targets);
+  validateInventory(inventory);
+  const sources = inventory.sources.map(normalizeSource);
+  const scopes = [...targets.activeLineScopes]
+    .map(({ regionId, operatorId, lineId }) => ({ regionId, operatorId, lineId }))
+    .sort(compareScopes);
+  const domains = [...targets.requiredSourceDomains].sort((left, right) =>
+    codepointCompare(left.id, right.id));
+  const resolutionIndex = indexResolutions(targets, resolutions, scopes, domains);
+
+  const requirements = scopes.flatMap((scope) =>
+    domains.map((domain) => evaluateRequirement(scope, domain, sources, resolutionIndex)));
+  const tiers = Object.fromEntries(RELEASE_TIERS.map((releaseTier) => [
+    releaseTier,
+    summarizeTier(requirements, releaseTier, domains, scopes),
+  ]));
+
+  const launchRequiredDomainCount = domains.filter(
+    ({ releaseTier }) => releaseTier === "LAUNCH_REQUIRED").length;
+  const enhancementDomainCount = domains.filter(
+    ({ releaseTier }) => releaseTier === "ENHANCEMENT").length;
+  const launchRequiredTotal = tiers.LAUNCH_REQUIRED.totalCount;
+  // 분모 drift fail closed: scope × domain 곱과 어긋나면 집계를 신뢰할 수 없다.
+  if (launchRequiredTotal !== scopes.length * launchRequiredDomainCount) {
+    throw new Error(
+      `launch-required denominator is inconsistent: ${launchRequiredTotal} != ` +
+        `${scopes.length} scopes × ${launchRequiredDomainCount} domains`,
+    );
+  }
+  if (expectedLaunchRequiredTotal !== null && launchRequiredTotal !== expectedLaunchRequiredTotal) {
+    throw new Error(
+      `launch-required denominator drift: expected ${expectedLaunchRequiredTotal}, ` +
+        `computed ${launchRequiredTotal}`,
+    );
+  }
+
+  return {
+    schemaVersion: 1,
+    artifactKind: "nationwide-coverage-tally-ledger",
+    issue: 2507,
+    parentIssue: 2138,
+    targetVersion: targets.targetVersion,
+    regeneration: {
+      command: regenerationCommand(inputs, expectedLaunchRequiredTotal),
+      ledgerPath: LEDGER_PATH,
+    },
+    statusAxis: {
+      values: [...TALLY_STATUSES],
+      missingKinds: [...MISSING_KINDS],
+      inventoryAdmittedRuleKo:
+        "source-inventory coverageScope의 (operatorIds, lineIds, sourceDomains) 엄격 매칭으로 domain의 "
+        + "requiredFields를 blockingThreshold 이상 충족한 requirement. 빈 lineIds는 와일드카드가 아니다.",
+      explicitlyUnsupportedRuleKo:
+        "resolutions 문서의 EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE entry가 정본이다. entry의 evidence "
+        + "심층 검증과 nextReviewAt 만료 재검토는 wall-clock에 의존하므로 report-coverage-gaps.mjs 게이트 몫이다.",
+      dualOperatorRuleKo:
+        "MISSING 중 operator 조건만 풀면 admitted가 되는 requirement는 DUAL_OPERATOR_UNMATCHED로 구분한다. "
+        + "같은 노선을 커버하는 소스가 있으나 해당 운영기관이 coverageScope에 없는 경우다.",
+      outOfScopeAxisKo:
+        "provenance 기반 게이트 SUPPORTED 판정(report-coverage-gaps.mjs --manifest/--provenance)은 별도 축이며 "
+        + "이 ledger가 대체하지 않는다. INVENTORY_ADMITTED는 admission 근사치이고 게이트 통과를 의미하지 않는다.",
+    },
+    inputs: {
+      targets: { ...inputRecord(inputs, "targets"), targetVersion: targets.targetVersion },
+      inventory: { ...inputRecord(inputs, "inventory"), retrievedAt: inventory.retrievedAt },
+      resolutions: {
+        ...inputRecord(inputs, "resolutions"),
+        generatedAt: resolutions.generatedAt ?? null,
+        entryCount: resolutions.entries.length,
+      },
+    },
+    denominator: {
+      activeLineScopeCount: scopes.length,
+      activeLineCount: new Set(scopes.map(({ lineId }) => lineId)).size,
+      launchRequiredDomainCount,
+      launchRequiredTotal,
+      enhancementDomainCount,
+      enhancementTotal: tiers.ENHANCEMENT.totalCount,
+      expectedLaunchRequiredTotal,
+    },
+    launchRequired: tiers.LAUNCH_REQUIRED,
+    enhancement: tiers.ENHANCEMENT,
+  };
+}
+
+// requirement 하나의 상태를 판정한다. 우선순위는 INVENTORY_ADMITTED > EXPLICITLY_UNSUPPORTED > MISSING이며,
+// admitted requirement에 unsupported resolution이 붙으면 판정 충돌이므로 fail closed한다.
+function evaluateRequirement(scope, domain, sources, resolutionIndex) {
+  const threshold = domain.blockingThreshold?.minimumOfficialFieldCoverageRatio ?? 1;
+  const fieldRows = domain.requiredFields.map((field) => ({
+    field,
+    sourceIds: admittedSourceIds(sources, scope, domain.id, field, { ignoreOperator: false }),
+  }));
+  const admittedFieldCount = fieldRows.filter(({ sourceIds }) => sourceIds.length > 0).length;
+  const unadmittedFields = fieldRows
+    .filter(({ sourceIds }) => sourceIds.length === 0)
+    .map(({ field }) => field);
+  const key = requirementKey(scope, domain.id);
+  const base = {
+    regionId: scope.regionId,
+    operatorId: scope.operatorId,
+    lineId: scope.lineId,
+    sourceDomain: domain.id,
+    releaseTier: domain.releaseTier,
+    requiredFieldCount: fieldRows.length,
+    admittedFieldCount,
+    admissionRatio: ratio(admittedFieldCount, fieldRows.length),
+    blockingThreshold: threshold,
+    admittedSourceIds: uniqueSorted(fieldRows.flatMap(({ sourceIds }) => sourceIds)),
+    unadmittedFields,
+  };
+  const resolution = resolutionIndex.get(key) ?? null;
+  if (base.admissionRatio >= threshold) {
+    if (resolution) {
+      throw new Error(`inventory-admitted requirement must not have an unsupported resolution: ${key}`);
+    }
+    return { ...base, status: "INVENTORY_ADMITTED", missingKind: null, dualOperator: null, resolution: null };
+  }
+  if (resolution) {
+    return {
+      ...base,
+      status: "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+      missingKind: null,
+      dualOperator: null,
+      resolution,
+    };
+  }
+
+  // dual-operator 미매칭: operator 조건만 풀면 admitted가 되는지 확인한다.
+  const relaxedRows = domain.requiredFields.map((field) => ({
+    field,
+    sourceIds: admittedSourceIds(sources, scope, domain.id, field, { ignoreOperator: true }),
+  }));
+  const relaxedRatio = ratio(
+    relaxedRows.filter(({ sourceIds }) => sourceIds.length > 0).length,
+    relaxedRows.length,
+  );
+  if (relaxedRatio < threshold) {
+    return { ...base, status: "MISSING", missingKind: "NO_ADMITTED_SOURCE", dualOperator: null, resolution: null };
+  }
+  const unadmitted = new Set(unadmittedFields);
+  const coveringSourceIds = uniqueSorted(
+    relaxedRows.filter(({ field }) => unadmitted.has(field)).flatMap(({ sourceIds }) => sourceIds),
+  );
+  const coveringSources = new Set(coveringSourceIds);
+  const coveringOperatorIds = uniqueSorted(
+    sources
+      .filter(({ id }) => coveringSources.has(id))
+      .flatMap(({ operatorIds }) => operatorIds)
+      .filter((operatorId) => operatorId !== scope.operatorId),
+  );
+  return {
+    ...base,
+    status: "MISSING",
+    missingKind: "DUAL_OPERATOR_UNMATCHED",
+    dualOperator: { coveringOperatorIds, coveringSourceIds },
+    resolution: null,
+  };
+}
+
+// report-coverage-gaps.mjs coveredField(strictLineScope=true, requireProvenance=false)와 같은 매칭 규칙.
+// 빈 lineIds를 와일드카드로 취급하지 않는다.
+function admittedSourceIds(sources, scope, sourceDomain, field, { ignoreOperator }) {
+  return sources
+    .filter((source) =>
+      source.regionIds.includes(scope.regionId)
+      && (ignoreOperator || source.operatorIds.includes(scope.operatorId))
+      && source.lineIds.includes(scope.lineId)
+      && source.sourceDomains.includes(sourceDomain)
+      && source.fields.includes(field))
+    .map(({ id }) => id);
+}
+
+function summarizeTier(requirements, releaseTier, domains, scopes) {
+  const tierRequirements = requirements.filter((entry) => entry.releaseTier === releaseTier);
+  const tierDomains = domains.filter((domain) => domain.releaseTier === releaseTier);
+  const regionIds = uniqueSorted(scopes.map(({ regionId }) => regionId));
+  return {
+    ...tierCounts(tierRequirements),
+    byDomain: tierDomains.map((domain) => ({
+      sourceDomain: domain.id,
+      ...tierCounts(tierRequirements.filter((entry) => entry.sourceDomain === domain.id)),
+    })),
+    byRegion: regionIds.map((regionId) => ({
+      regionId,
+      ...tierCounts(tierRequirements.filter((entry) => entry.regionId === regionId)),
+    })),
+    requirements: tierRequirements,
+  };
+}
+
+function tierCounts(entries) {
+  const countStatus = (status) => entries.filter((entry) => entry.status === status).length;
+  const inventoryAdmittedCount = countStatus("INVENTORY_ADMITTED");
+  const explicitlyUnsupportedWithEvidenceCount = countStatus("EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE");
+  const terminalCount = inventoryAdmittedCount + explicitlyUnsupportedWithEvidenceCount;
+  return {
+    totalCount: entries.length,
+    inventoryAdmittedCount,
+    explicitlyUnsupportedWithEvidenceCount,
+    missingCount: countStatus("MISSING"),
+    missingByKind: Object.fromEntries(MISSING_KINDS.map((kind) => [
+      kind,
+      entries.filter((entry) => entry.missingKind === kind).length,
+    ])),
+    terminalCount,
+    terminalRatio: ratio(terminalCount, entries.length),
+    inventoryAdmittedRatio: ratio(inventoryAdmittedCount, entries.length),
+  };
+}
+
+// resolutions는 EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE의 정본이다. 이 도구는 requirement 매핑 무결성만
+// fail closed로 확인하고, evidence 심층 검증(query·hash·만료)은 report-coverage-gaps.mjs 게이트에 맡긴다.
+function indexResolutions(targets, resolutions, scopes, domains) {
+  if (!resolutions || typeof resolutions !== "object" || Array.isArray(resolutions)) {
+    throw new Error("coverage resolutions must be an object");
+  }
+  if (resolutions.schemaVersion !== 1) throw new Error("coverage resolutions schemaVersion must be 1");
+  if (resolutions.artifactKind !== "nationwide-coverage-resolutions") {
+    throw new Error("coverage resolutions artifactKind must be nationwide-coverage-resolutions");
+  }
+  if (resolutions.targetVersion !== targets.targetVersion) {
+    throw new Error("coverage resolutions targetVersion must match coverage targets");
+  }
+  if (!Array.isArray(resolutions.entries)) {
+    throw new Error("coverage resolutions entries must be an array");
+  }
+  const requirementKeys = new Set(
+    scopes.flatMap((scope) => domains.map((domain) => requirementKey(scope, domain.id))),
+  );
+  const byKey = new Map();
+  for (const [index, entry] of resolutions.entries.entries()) {
+    const label = `coverage resolutions entries[${index}]`;
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new Error(`${label} must be an object`);
+    }
+    if (entry.state !== "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE") {
+      throw new Error(`${label}.state is invalid: ${entry.state ?? "missing"}`);
+    }
+    const key = requirementKey(
+      {
+        regionId: requiredString(entry.regionId, `${label}.regionId`),
+        operatorId: requiredString(entry.operatorId, `${label}.operatorId`),
+        lineId: requiredString(entry.lineId, `${label}.lineId`),
+      },
+      requiredString(entry.sourceDomain, `${label}.sourceDomain`),
+    );
+    if (byKey.has(key)) throw new Error(`duplicate coverage resolution: ${key}`);
+    if (!requirementKeys.has(key)) throw new Error(`unknown coverage resolution requirement: ${key}`);
+    byKey.set(key, {
+      reasonCode: requiredString(entry.reasonCode, `${label}.reasonCode`),
+      fallback: requiredString(entry.fallback, `${label}.fallback`),
+      evidenceHash: requiredString(entry.evidenceHash, `${label}.evidenceHash`),
+      reviewedAt: requiredString(entry.reviewedAt, `${label}.reviewedAt`),
+      nextReviewAt: requiredString(entry.nextReviewAt, `${label}.nextReviewAt`),
+    });
+  }
+  return byKey;
+}
+
+function validateTargets(targets) {
+  if (!targets || typeof targets !== "object" || Array.isArray(targets)) {
+    throw new Error("coverage targets must be an object");
+  }
+  if (targets.schemaVersion !== 2) throw new Error("coverage targets schemaVersion must be 2");
+  if (targets.artifactKind !== "nationwide-datapack-coverage-targets") {
+    throw new Error("coverage targets artifactKind must be nationwide-datapack-coverage-targets");
+  }
+  requiredString(targets.targetVersion, "coverage targets targetVersion");
+  if (!Array.isArray(targets.requiredSourceDomains) || targets.requiredSourceDomains.length === 0) {
+    throw new Error("coverage targets requiredSourceDomains must be a non-empty array");
+  }
+  const domainIds = new Set();
+  for (const domain of targets.requiredSourceDomains) {
+    const id = requiredString(domain?.id, "requiredSourceDomains.id");
+    if (domainIds.has(id)) throw new Error(`duplicate source domain id: ${id}`);
+    domainIds.add(id);
+    if (!RELEASE_TIERS.includes(domain.releaseTier)) {
+      throw new Error(`${id}.releaseTier must be LAUNCH_REQUIRED or ENHANCEMENT`);
+    }
+    requiredStringArray(domain.requiredFields, `${id}.requiredFields`);
+    const threshold = domain.blockingThreshold?.minimumOfficialFieldCoverageRatio ?? 1;
+    if (typeof threshold !== "number" || threshold <= 0 || threshold > 1) {
+      throw new Error(`${id}.blockingThreshold.minimumOfficialFieldCoverageRatio must be between 0 and 1`);
+    }
+  }
+  if (!targets.requiredSourceDomains.some(({ releaseTier }) => releaseTier === "LAUNCH_REQUIRED")) {
+    throw new Error("coverage targets must include at least one LAUNCH_REQUIRED domain");
+  }
+  if (!Array.isArray(targets.activeLineScopes) || targets.activeLineScopes.length === 0) {
+    throw new Error("coverage targets activeLineScopes must be a non-empty array");
+  }
+  // scope 중복은 분모를 부풀리므로 fail closed.
+  const scopeKeys = new Set();
+  for (const scope of targets.activeLineScopes) {
+    const lineId = requiredString(scope?.lineId, "activeLineScopes.lineId");
+    const key = [
+      requiredString(scope.regionId, `${lineId}.regionId`),
+      requiredString(scope.operatorId, `${lineId}.operatorId`),
+      lineId,
+    ].join(":");
+    if (scopeKeys.has(key)) throw new Error(`duplicate active line scope: ${key}`);
+    scopeKeys.add(key);
+  }
+}
+
+function validateInventory(inventory) {
+  if (!inventory || typeof inventory !== "object" || Array.isArray(inventory)) {
+    throw new Error("source inventory must be an object");
+  }
+  if (inventory.schemaVersion !== 1) throw new Error("source inventory schemaVersion must be 1");
+  if (!Array.isArray(inventory.sources) || inventory.sources.length === 0) {
+    throw new Error("source inventory sources must be a non-empty array");
+  }
+  requiredString(inventory.retrievedAt, "source inventory retrievedAt");
+}
+
+function normalizeSource(source) {
+  const id = requiredString(source?.id, "source.id");
+  const coverage = source.coverageScope;
+  if (!coverage || typeof coverage !== "object" || Array.isArray(coverage)) {
+    throw new Error(`${id}.coverageScope must be an object`);
+  }
+  return {
+    id,
+    regionIds: requiredStringArray(coverage.regionIds, `${id}.coverageScope.regionIds`),
+    operatorIds: requiredStringArray(coverage.operatorIds, `${id}.coverageScope.operatorIds`),
+    sourceDomains: requiredStringArray(coverage.sourceDomains, `${id}.coverageScope.sourceDomains`),
+    lineIds: optionalStringArray(coverage.lineIds, `${id}.coverageScope.lineIds`),
+    fields: requiredStringArray(source.fieldsProvided ?? source.fields, `${id}.fieldsProvided`),
+  };
+}
+
+function regenerationCommand(inputs, expectedLaunchRequiredTotal) {
+  const expected = expectedLaunchRequiredTotal === null
+    ? []
+    : ["--expected-launch-required-total", String(expectedLaunchRequiredTotal)];
+  return [
+    "node",
+    TOOL_PATH,
+    "--targets",
+    inputRecord(inputs, "targets").path,
+    "--inventory",
+    inputRecord(inputs, "inventory").path,
+    "--resolutions",
+    inputRecord(inputs, "resolutions").path,
+    ...expected,
+    "--output",
+    LEDGER_PATH,
+  ].join(" ");
+}
+
+function inputRecord(inputs, name) {
+  const record = inputs?.[name];
+  if (!record || typeof record !== "object" || Array.isArray(record)) {
+    throw new Error(`inputs.${name} must be an object`);
+  }
+  return {
+    path: requiredString(record.path, `inputs.${name}.path`),
+    sha256: requiredString(record.sha256, `inputs.${name}.sha256`),
+  };
+}
+
+function requirementKey({ regionId, operatorId, lineId }, sourceDomain) {
+  return `${regionId}:${operatorId}:${lineId}:${sourceDomain}`;
+}
+
+function compareScopes(left, right) {
+  return codepointCompare(left.regionId, right.regionId)
+    || codepointCompare(left.operatorId, right.operatorId)
+    || codepointCompare(left.lineId, right.lineId);
+}
+
+function uniqueSorted(values) {
+  return [...new Set(values)].sort(codepointCompare);
+}
+
+function ratio(numerator, denominator) {
+  return denominator === 0 ? 0 : Number((numerator / denominator).toFixed(4));
+}
+
+function requiredString(value, label) {
+  if (typeof value !== "string" || value.trim() === "") throw new Error(`${label} is required`);
+  return value;
+}
+
+function requiredStringArray(value, label) {
+  if (
+    !Array.isArray(value)
+    || value.length === 0
+    || value.some((entry) => typeof entry !== "string" || entry.trim() === "")
+  ) {
+    throw new Error(`${label} must be a non-empty string array`);
+  }
+  return value;
+}
+
+function optionalStringArray(value, label) {
+  if (value === undefined) return [];
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string" || entry.trim() === "")) {
+    throw new Error(`${label} must be a string array`);
+  }
+  return value;
+}
+
+async function readJsonInput(filePath) {
+  const bytes = await readFile(filePath);
+  return {
+    document: JSON.parse(bytes.toString("utf8")),
+    input: { path: filePath, sha256: createHash("sha256").update(bytes).digest("hex") },
+  };
+}
+
+async function main(argv) {
+  const args = parseArgs(argv);
+  for (const flag of Object.keys(args)) {
+    if (!ALLOWED_FLAGS.has(flag)) throw new Error(`unexpected argument: --${flag}`);
+  }
+  const outputPath = requireArg(args, "output");
+  const targets = await readJsonInput(requireArg(args, "targets"));
+  const inventory = await readJsonInput(requireArg(args, "inventory"));
+  const resolutions = await readJsonInput(args.resolutions ?? DEFAULT_RESOLUTIONS_PATH);
+  const expectedRaw = args["expected-launch-required-total"];
+  if (expectedRaw !== undefined && !/^\d+$/.test(expectedRaw)) {
+    throw new Error("--expected-launch-required-total must be a non-negative integer");
+  }
+
+  const ledger = buildNationwideCoverageTally({
+    targets: targets.document,
+    inventory: inventory.document,
+    resolutions: resolutions.document,
+    inputs: {
+      targets: targets.input,
+      inventory: inventory.input,
+      resolutions: resolutions.input,
+    },
+    expectedLaunchRequiredTotal: expectedRaw === undefined ? null : Number(expectedRaw),
+  });
+
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, `${JSON.stringify(sortJson(ledger), null, 2)}\n`);
+}
+
+if (isMainModule(import.meta.url)) {
+  main(process.argv.slice(2)).catch((error) => {
+    console.error(error.message);
+    process.exit(1);
+  });
+}

--- a/tools/datapack/build-nationwide-coverage-tally.mjs
+++ b/tools/datapack/build-nationwide-coverage-tally.mjs
@@ -100,6 +100,12 @@ export function buildNationwideCoverageTally({
         `${scopes.length} scopes × ${launchRequiredDomainCount} domains`,
     );
   }
+  if (tiers.ENHANCEMENT.totalCount !== scopes.length * enhancementDomainCount) {
+    throw new Error(
+      `enhancement denominator is inconsistent: ${tiers.ENHANCEMENT.totalCount} != ` +
+        `${scopes.length} scopes × ${enhancementDomainCount} domains`,
+    );
+  }
   if (expectedLaunchRequiredTotal !== null && launchRequiredTotal !== expectedLaunchRequiredTotal) {
     throw new Error(
       `launch-required denominator drift: expected ${expectedLaunchRequiredTotal}, ` +

--- a/tools/datapack/build-nationwide-coverage-tally.mjs
+++ b/tools/datapack/build-nationwide-coverage-tally.mjs
@@ -63,6 +63,12 @@ const ALLOWED_FLAGS = new Set([
 const TALLY_STATUSES = ["INVENTORY_ADMITTED", "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE", "MISSING"];
 const MISSING_KINDS = ["DUAL_OPERATOR_UNMATCHED", "NO_ADMITTED_SOURCE"];
 const RELEASE_TIERS = ["LAUNCH_REQUIRED", "ENHANCEMENT"];
+// 게이트 validateUnsupportedResolution과 같은 allowlist.
+const RESOLUTION_REASON_CODE = "PUBLIC_API_NO_DATA";
+const COVERAGE_FALLBACKS = ["PLANNED", "STATIC_LOCAL", "UNSUPPORTED_REGION"];
+// 게이트의 `new Date(text).toISOString() === text`와 같은 canonical UTC instant. wall-clock을 읽지 않고
+// 형식만 강제해 nextReviewAt의 코드포인트 정렬이 시간순 정렬과 일치하도록 보장한다.
+const ISO_INSTANT = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
 
 export function buildNationwideCoverageTally({
   targets,
@@ -73,7 +79,8 @@ export function buildNationwideCoverageTally({
 }) {
   validateTargets(targets);
   validateInventory(inventory);
-  const sources = inventory.sources.map(normalizeSource);
+  const targetIndex = coverageTargetIndex(targets);
+  const sources = inventory.sources.map((source) => normalizeSource(source, targetIndex));
   const scopes = [...targets.activeLineScopes]
     .map(({ regionId, operatorId, lineId }) => ({ regionId, operatorId, lineId }))
     .sort(compareScopes);
@@ -122,6 +129,10 @@ export function buildNationwideCoverageTally({
     regeneration: {
       command: regenerationCommand(inputs, expectedLaunchRequiredTotal),
       ledgerPath: LEDGER_PATH,
+      pairedUpdateKo:
+        "targets·inventory·resolutions를 바꾸는 PR은 이 명령으로 ledger를 함께 재생성하고, "
+        + "tools/datapack/build-nationwide-coverage-tally.test.mjs의 집계 기대 상수(admitted/EU/missing)도 "
+        + "같은 커밋에서 갱신해야 한다. 재생성 누락은 datapack 도구 테스트에서 fail closed 된다.",
     },
     statusAxis: {
       values: [...TALLY_STATUSES],
@@ -130,8 +141,13 @@ export function buildNationwideCoverageTally({
         "source-inventory coverageScope의 (operatorIds, lineIds, sourceDomains) 엄격 매칭으로 domain의 "
         + "requiredFields를 blockingThreshold 이상 충족한 requirement. 빈 lineIds는 와일드카드가 아니다.",
       explicitlyUnsupportedRuleKo:
-        "resolutions 문서의 EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE entry가 정본이다. entry의 evidence "
-        + "심층 검증과 nextReviewAt 만료 재검토는 wall-clock에 의존하므로 report-coverage-gaps.mjs 게이트 몫이다.",
+        "resolutions 문서의 EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE entry가 정본이다. supportStartedAt이 있는 "
+        + "entry는 게이트와 같이 terminal에서 제외하고 MISSING + resolutionReviewStatus=SUPPORT_STARTED로 남긴다. "
+        + "publicApiQueries 재계산·search plan 대조와 nextReviewAt 만료 재검토는 report-coverage-gaps.mjs 게이트 몫이다.",
+      resolutionExpiryDivergenceKo:
+        "이 ledger는 wall-clock을 읽지 않으므로 nextReviewAt이 지난 entry도 terminal로 계상한다. "
+        + "각 tier의 earliestResolutionNextReviewAt이 그 유효 지평이며, 이 시각을 넘기면 입력이 그대로여도 "
+        + "게이트는 해당 entry를 MISSING(EXPIRED)로 판정해 수치가 갈린다 — resolutions 재검토로 해소한다.",
       dualOperatorRuleKo:
         "MISSING 중 operator 조건만 풀면 admitted가 되는 requirement는 DUAL_OPERATOR_UNMATCHED로 구분한다. "
         + "같은 노선을 커버하는 소스가 있으나 해당 운영기관이 coverageScope에 없는 경우다.",
@@ -164,6 +180,8 @@ export function buildNationwideCoverageTally({
 
 // requirement 하나의 상태를 판정한다. 우선순위는 INVENTORY_ADMITTED > EXPLICITLY_UNSUPPORTED > MISSING이며,
 // admitted requirement에 unsupported resolution이 붙으면 판정 충돌이므로 fail closed한다.
+// resolution에 supportStartedAt이 있으면 게이트(report-coverage-gaps.mjs applyCoverageResolutions)와 같이
+// EU 전이를 취소하고 MISSING으로 남기되 resolutionReviewStatus=SUPPORT_STARTED로 표시한다.
 function evaluateRequirement(scope, domain, sources, resolutionIndex) {
   const threshold = domain.blockingThreshold?.minimumOfficialFieldCoverageRatio ?? 1;
   const fieldRows = domain.requiredFields.map((field) => ({
@@ -190,20 +208,34 @@ function evaluateRequirement(scope, domain, sources, resolutionIndex) {
   };
   const resolution = resolutionIndex.get(key) ?? null;
   if (base.admissionRatio >= threshold) {
+    // 게이트는 provenance 기반 SUPPORTED와의 충돌만 throw하지만, 이 도구는 더 넓은 INVENTORY_ADMITTED
+    // 기준으로 throw한다(의도적으로 게이트보다 엄격). admission-only 소스가 unsupported resolution이 붙은
+    // requirement를 덮으면 ledger 재생성이 hard fail하며, resolutions 문서를 정리해야 풀린다 — 두 정본이
+    // 서로 반대 판정을 주장하는 상태로 집계가 계속되는 것을 막기 위한 fail closed다.
     if (resolution) {
       throw new Error(`inventory-admitted requirement must not have an unsupported resolution: ${key}`);
     }
-    return { ...base, status: "INVENTORY_ADMITTED", missingKind: null, dualOperator: null, resolution: null };
+    return {
+      ...base,
+      status: "INVENTORY_ADMITTED",
+      missingKind: null,
+      dualOperator: null,
+      resolution: null,
+      resolutionReviewStatus: null,
+    };
   }
-  if (resolution) {
+  if (resolution && !resolution.supportStartedAt) {
+    // EU는 terminal 상태라 dual-operator 진단을 계산하지 않는다(가시화 대상은 미해결 MISSING이다).
     return {
       ...base,
       status: "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
       missingKind: null,
       dualOperator: null,
       resolution,
+      resolutionReviewStatus: "CURRENT",
     };
   }
+  const resolutionReviewStatus = resolution ? "SUPPORT_STARTED" : null;
 
   // dual-operator 미매칭: operator 조건만 풀면 admitted가 되는지 확인한다.
   const relaxedRows = domain.requiredFields.map((field) => ({
@@ -215,7 +247,14 @@ function evaluateRequirement(scope, domain, sources, resolutionIndex) {
     relaxedRows.length,
   );
   if (relaxedRatio < threshold) {
-    return { ...base, status: "MISSING", missingKind: "NO_ADMITTED_SOURCE", dualOperator: null, resolution: null };
+    return {
+      ...base,
+      status: "MISSING",
+      missingKind: "NO_ADMITTED_SOURCE",
+      dualOperator: null,
+      resolution,
+      resolutionReviewStatus,
+    };
   }
   const unadmitted = new Set(unadmittedFields);
   const coveringSourceIds = uniqueSorted(
@@ -233,7 +272,8 @@ function evaluateRequirement(scope, domain, sources, resolutionIndex) {
     status: "MISSING",
     missingKind: "DUAL_OPERATOR_UNMATCHED",
     dualOperator: { coveringOperatorIds, coveringSourceIds },
-    resolution: null,
+    resolution,
+    resolutionReviewStatus,
   };
 }
 
@@ -285,11 +325,28 @@ function tierCounts(entries) {
     terminalCount,
     terminalRatio: ratio(terminalCount, entries.length),
     inventoryAdmittedRatio: ratio(inventoryAdmittedCount, entries.length),
+    // 게이트가 EU 전이를 취소한 supportStartedAt entry 수 — MISSING에 포함되며 terminal이 아니다.
+    supportStartedResolutionCount: entries.filter(
+      (entry) => entry.resolutionReviewStatus === "SUPPORT_STARTED").length,
+    // EU terminal 계상의 유효 지평. wall-clock을 읽지 않으므로 만료를 판정하지 않고 입력 값만 노출한다.
+    // 이 시각이 지나면 게이트는 같은 입력에서도 해당 entry를 MISSING(EXPIRED)로 판정해 수치가 갈린다.
+    earliestResolutionNextReviewAt: earliestNextReviewAt(entries),
   };
 }
 
-// resolutions는 EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE의 정본이다. 이 도구는 requirement 매핑 무결성만
-// fail closed로 확인하고, evidence 심층 검증(query·hash·만료)은 report-coverage-gaps.mjs 게이트에 맡긴다.
+function earliestNextReviewAt(entries) {
+  const horizons = entries
+    .filter((entry) => entry.status === "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE")
+    .map((entry) => entry.resolution.nextReviewAt)
+    .sort(codepointCompare);
+  return horizons.length === 0 ? null : horizons[0];
+}
+
+// resolutions는 EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE의 정본이다. 이 도구는 requirement 매핑 무결성과
+// 게이트 validateUnsupportedResolution의 계약 축(state·reasonCode·fallback allowlist, evidenceHash 형식,
+// ISO instant 형식)을 fail closed로 확인한다. publicApiQueries 재계산·search plan 대조·wall-clock 만료
+// 판정은 report-coverage-gaps.mjs 게이트에 남긴다. 게이트가 PR CI가 아니라 datapack-release workflow에서만
+// 돌기 때문에, 무효 entry가 이 ledger의 terminal 수치를 부풀리는 경로는 여기서 막는다.
 function indexResolutions(targets, resolutions, scopes, domains) {
   if (!resolutions || typeof resolutions !== "object" || Array.isArray(resolutions)) {
     throw new Error("coverage resolutions must be an object");
@@ -326,12 +383,25 @@ function indexResolutions(targets, resolutions, scopes, domains) {
     );
     if (byKey.has(key)) throw new Error(`duplicate coverage resolution: ${key}`);
     if (!requirementKeys.has(key)) throw new Error(`unknown coverage resolution requirement: ${key}`);
+    if (entry.reasonCode !== RESOLUTION_REASON_CODE) {
+      throw new Error(`${label}.reasonCode must be ${RESOLUTION_REASON_CODE}: ${entry.reasonCode ?? "missing"}`);
+    }
+    if (!COVERAGE_FALLBACKS.includes(entry.fallback)) {
+      throw new Error(`${label}.fallback is invalid: ${entry.fallback ?? "missing"}`);
+    }
+    if (!/^[a-f0-9]{64}$/.test(entry.evidenceHash ?? "")) {
+      throw new Error(`${label}.evidenceHash must be sha256 hex`);
+    }
     byKey.set(key, {
-      reasonCode: requiredString(entry.reasonCode, `${label}.reasonCode`),
-      fallback: requiredString(entry.fallback, `${label}.fallback`),
-      evidenceHash: requiredString(entry.evidenceHash, `${label}.evidenceHash`),
-      reviewedAt: requiredString(entry.reviewedAt, `${label}.reviewedAt`),
-      nextReviewAt: requiredString(entry.nextReviewAt, `${label}.nextReviewAt`),
+      reasonCode: entry.reasonCode,
+      fallback: entry.fallback,
+      evidenceHash: entry.evidenceHash,
+      reviewedAt: isoInstant(entry.reviewedAt, `${label}.reviewedAt`),
+      nextReviewAt: isoInstant(entry.nextReviewAt, `${label}.nextReviewAt`),
+      // 게이트는 supportStartedAt이 있으면 EU 전이를 취소한다. 순수 입력 필드라 결정성에 영향이 없다.
+      supportStartedAt: entry.supportStartedAt === undefined
+        ? null
+        : isoInstant(entry.supportStartedAt, `${label}.supportStartedAt`),
     });
   }
   return byKey;
@@ -366,6 +436,16 @@ function validateTargets(targets) {
   if (!targets.requiredSourceDomains.some(({ releaseTier }) => releaseTier === "LAUNCH_REQUIRED")) {
     throw new Error("coverage targets must include at least one LAUNCH_REQUIRED domain");
   }
+  if (!Array.isArray(targets.regions) || targets.regions.length === 0) {
+    throw new Error("coverage targets regions must be a non-empty array");
+  }
+  const regionIds = new Set();
+  for (const region of targets.regions) {
+    const id = requiredString(region?.id, "regions.id");
+    if (regionIds.has(id)) throw new Error(`duplicate region id: ${id}`);
+    regionIds.add(id);
+    requiredStringArray(region.operatorIds, `${id}.operatorIds`);
+  }
   if (!Array.isArray(targets.activeLineScopes) || targets.activeLineScopes.length === 0) {
     throw new Error("coverage targets activeLineScopes must be a non-empty array");
   }
@@ -373,11 +453,11 @@ function validateTargets(targets) {
   const scopeKeys = new Set();
   for (const scope of targets.activeLineScopes) {
     const lineId = requiredString(scope?.lineId, "activeLineScopes.lineId");
-    const key = [
-      requiredString(scope.regionId, `${lineId}.regionId`),
-      requiredString(scope.operatorId, `${lineId}.operatorId`),
-      lineId,
-    ].join(":");
+    const regionId = requiredString(scope.regionId, `${lineId}.regionId`);
+    if (!regionIds.has(regionId)) {
+      throw new Error(`${lineId}.regionId contains undefined region: ${regionId}`);
+    }
+    const key = [regionId, requiredString(scope.operatorId, `${lineId}.operatorId`), lineId].join(":");
     if (scopeKeys.has(key)) throw new Error(`duplicate active line scope: ${key}`);
     scopeKeys.add(key);
   }
@@ -394,13 +474,13 @@ function validateInventory(inventory) {
   requiredString(inventory.retrievedAt, "source inventory retrievedAt");
 }
 
-function normalizeSource(source) {
+function normalizeSource(source, targetIndex) {
   const id = requiredString(source?.id, "source.id");
   const coverage = source.coverageScope;
   if (!coverage || typeof coverage !== "object" || Array.isArray(coverage)) {
     throw new Error(`${id}.coverageScope must be an object`);
   }
-  return {
+  const normalized = {
     id,
     regionIds: requiredStringArray(coverage.regionIds, `${id}.coverageScope.regionIds`),
     operatorIds: requiredStringArray(coverage.operatorIds, `${id}.coverageScope.operatorIds`),
@@ -408,6 +488,50 @@ function normalizeSource(source) {
     lineIds: optionalStringArray(coverage.lineIds, `${id}.coverageScope.lineIds`),
     fields: requiredStringArray(source.fieldsProvided ?? source.fields, `${id}.fieldsProvided`),
   };
+  // 게이트 validateKnownValues 대응. 오타 id를 조용한 매칭 실패(=과소 집계)로 흘리지 않고 fail closed한다.
+  validateKnownValues(normalized.regionIds, targetIndex.regionIds, `${id}.coverageScope.regionIds`, "region");
+  validateKnownValues(normalized.operatorIds, targetIndex.operatorIds, `${id}.coverageScope.operatorIds`, "operator");
+  validateKnownValues(
+    normalized.sourceDomains,
+    targetIndex.sourceDomains,
+    `${id}.coverageScope.sourceDomains`,
+    "source domain",
+  );
+  if (targetIndex.lineIds.size > 0) {
+    validateKnownValues(normalized.lineIds, targetIndex.lineIds, `${id}.coverageScope.lineIds`, "line");
+  }
+  return normalized;
+}
+
+// 게이트 coverageTargetIndex와 같은 known id 집합.
+function coverageTargetIndex(targets) {
+  return {
+    regionIds: new Set([
+      ...targets.regions.map((region) => region.id),
+      ...optionalStringArray(targets.knownRegionIds, "knownRegionIds"),
+    ]),
+    operatorIds: new Set([
+      ...targets.regions.flatMap((region) => region.operatorIds),
+      ...targets.activeLineScopes.map((scope) => scope.operatorId),
+      ...optionalStringArray(targets.knownOperatorIds, "knownOperatorIds"),
+    ]),
+    lineIds: new Set([
+      ...targets.activeLineScopes.map((scope) => scope.lineId),
+      ...(targets.inactiveLineExclusions ?? []).map((exclusion) => exclusion.lineId),
+    ]),
+    sourceDomains: new Set([
+      ...targets.requiredSourceDomains.map((domain) => domain.id),
+      ...optionalStringArray(targets.knownSourceDomains, "knownSourceDomains"),
+    ]),
+  };
+}
+
+function validateKnownValues(values, knownValues, label, valueLabel) {
+  for (const value of values) {
+    if (!knownValues.has(value)) {
+      throw new Error(`${label} contains undefined ${valueLabel}: ${value}`);
+    }
+  }
 }
 
 function regenerationCommand(inputs, expectedLaunchRequiredTotal) {
@@ -460,6 +584,13 @@ function ratio(numerator, denominator) {
 
 function requiredString(value, label) {
   if (typeof value !== "string" || value.trim() === "") throw new Error(`${label} is required`);
+  return value;
+}
+
+function isoInstant(value, label) {
+  if (!ISO_INSTANT.test(requiredString(value, label))) {
+    throw new Error(`${label} must be a canonical UTC instant (YYYY-MM-DDTHH:MM:SS.sssZ)`);
+  }
   return value;
 }
 

--- a/tools/datapack/build-nationwide-coverage-tally.test.mjs
+++ b/tools/datapack/build-nationwide-coverage-tally.test.mjs
@@ -47,6 +47,7 @@ function fixtureTargets(overrides = {}) {
       { lineId: "line-a", regionId: "capital", operatorId: "operator-a" },
       { lineId: "line-a", regionId: "capital", operatorId: "operator-b" },
     ],
+    regions: [{ id: "capital", displayName: "수도권", operatorIds: ["operator-a", "operator-b"] }],
     ...overrides,
   };
 }
@@ -177,6 +178,9 @@ test("커밋된 전국 coverage tally ledger는 현행 입력에서 바이트 �
       enhancementTotal: 45,
       expectedLaunchRequiredTotal: 270,
     });
+    // 아래 집계 상수는 tracked ledger와 짝을 이루는 이중 장부다. targets·inventory·resolutions를 바꾸는
+    // 후속 #2138 admission PR은 (1) ledger.regeneration.command로 ledger를 재생성하고 (2) 이 상수를
+    // 같은 커밋에서 함께 갱신해야 한다. 둘 중 하나만 하면 이 테스트가 fail closed 된다.
     assert.equal(ledger.launchRequired.totalCount, 270);
     assert.equal(ledger.launchRequired.inventoryAdmittedCount, 80);
     assert.equal(ledger.launchRequired.explicitlyUnsupportedWithEvidenceCount, 4);
@@ -186,8 +190,11 @@ test("커밋된 전국 coverage tally ledger는 현행 입력에서 바이트 �
       NO_ADMITTED_SOURCE: 174,
     });
     assert.equal(ledger.launchRequired.terminalCount, 84);
+    assert.equal(ledger.launchRequired.supportStartedResolutionCount, 0);
+    assert.equal(ledger.launchRequired.earliestResolutionNextReviewAt, "2026-10-19T02:43:09.257Z");
     assert.equal(ledger.launchRequired.requirements.length, 270);
     assert.equal(ledger.enhancement.totalCount, 45);
+    assert.equal(ledger.enhancement.earliestResolutionNextReviewAt, null);
     assert.equal(ledger.enhancement.requirements.length, 45);
   } finally {
     await rm(workspace, { recursive: true, force: true });
@@ -295,6 +302,44 @@ test("빈 lineIds coverageScope는 와일드카드가 아니다", () => {
   });
 });
 
+test("coverageScope의 unknown id는 조용한 미매칭이 아니라 fail closed다", async (context) => {
+  const unknownScopes = [
+    ["region", { regionIds: ["capitol"] }, /coverageScope.regionIds contains undefined region: capitol/],
+    ["operator", { operatorIds: ["operator-zz"] }, /coverageScope.operatorIds contains undefined operator: operator-zz/],
+    ["line", { lineIds: ["line-zz"] }, /coverageScope.lineIds contains undefined line: line-zz/],
+    [
+      "source domain",
+      { sourceDomains: ["station_line_membershop"] },
+      /coverageScope.sourceDomains contains undefined source domain: station_line_membershop/,
+    ],
+  ];
+  for (const [name, override, expected] of unknownScopes) {
+    await context.test(name, () => {
+      const source = operatorAMembershipSource();
+      Object.assign(source.coverageScope, override);
+      assert.throws(
+        () => buildFixtureLedger({
+          targets: fixtureTargets(),
+          inventory: fixtureInventory([source]),
+          resolutions: fixtureResolutions(),
+        }),
+        expected,
+      );
+    });
+  }
+
+  await context.test("targets가 아는 id는 통과한다", () => {
+    const source = operatorAMembershipSource();
+    source.coverageScope.regionIds = ["capital"];
+    const ledger = buildFixtureLedger({
+      targets: fixtureTargets(),
+      inventory: fixtureInventory([source]),
+      resolutions: fixtureResolutions(),
+    });
+    assert.equal(ledger.launchRequired.inventoryAdmittedCount, 1);
+  });
+});
+
 test("resolutions는 EXPLICITLY_UNSUPPORTED 정본이며 계약 위반은 fail closed다", async (context) => {
   const inventory = fixtureInventory([operatorAMembershipSource()]);
 
@@ -307,9 +352,31 @@ test("resolutions는 EXPLICITLY_UNSUPPORTED 정본이며 계약 위반은 fail c
     const resolved = requirementFor(ledger, "operator-b");
     assert.equal(resolved.status, "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE");
     assert.equal(resolved.resolution.reasonCode, "PUBLIC_API_NO_DATA");
+    assert.equal(resolved.resolutionReviewStatus, "CURRENT");
     assert.equal(resolved.missingKind, null);
     assert.equal(ledger.launchRequired.terminalCount, 2);
     assert.equal(ledger.launchRequired.missingCount, 0);
+    assert.equal(ledger.launchRequired.earliestResolutionNextReviewAt, "2026-10-19T02:43:09.257Z");
+  });
+
+  // 게이트(report-coverage-gaps.mjs)는 supportStartedAt이 있으면 EU 전이를 취소한다. 같은 판정을 유지한다.
+  await context.test("supportStartedAt entry는 terminal에서 제외된다", () => {
+    const ledger = buildFixtureLedger({
+      targets: fixtureTargets(),
+      inventory,
+      resolutions: fixtureResolutions([
+        fixtureResolutionEntry({ supportStartedAt: "2026-07-24T00:00:00.000Z" }),
+      ]),
+    });
+    const entry = requirementFor(ledger, "operator-b");
+    assert.equal(entry.status, "MISSING");
+    assert.equal(entry.resolutionReviewStatus, "SUPPORT_STARTED");
+    assert.equal(entry.missingKind, "DUAL_OPERATOR_UNMATCHED");
+    assert.equal(entry.resolution.supportStartedAt, "2026-07-24T00:00:00.000Z");
+    assert.equal(ledger.launchRequired.explicitlyUnsupportedWithEvidenceCount, 0);
+    assert.equal(ledger.launchRequired.supportStartedResolutionCount, 1);
+    assert.equal(ledger.launchRequired.terminalCount, 1);
+    assert.equal(ledger.launchRequired.earliestResolutionNextReviewAt, null);
   });
 
   const rejections = [
@@ -337,6 +404,26 @@ test("resolutions는 EXPLICITLY_UNSUPPORTED 정본이며 계약 위반은 fail c
       "state 위반",
       fixtureResolutions([fixtureResolutionEntry({ state: "SUPPORTED" })]),
       /state is invalid: SUPPORTED/,
+    ],
+    [
+      "reasonCode allowlist 위반",
+      fixtureResolutions([fixtureResolutionEntry({ reasonCode: "WHATEVER" })]),
+      /reasonCode must be PUBLIC_API_NO_DATA: WHATEVER/,
+    ],
+    [
+      "fallback allowlist 위반",
+      fixtureResolutions([fixtureResolutionEntry({ fallback: "SOMETHING_ELSE" })]),
+      /fallback is invalid: SOMETHING_ELSE/,
+    ],
+    [
+      "evidenceHash 형식 위반",
+      fixtureResolutions([fixtureResolutionEntry({ evidenceHash: "zz" })]),
+      /evidenceHash must be sha256 hex/,
+    ],
+    [
+      "nextReviewAt ISO instant 위반",
+      fixtureResolutions([fixtureResolutionEntry({ nextReviewAt: "2026-10-19" })]),
+      /nextReviewAt must be a canonical UTC instant/,
     ],
   ];
   for (const [name, resolutions, expected] of rejections) {

--- a/tools/datapack/build-nationwide-coverage-tally.test.mjs
+++ b/tools/datapack/build-nationwide-coverage-tally.test.mjs
@@ -1,0 +1,410 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { appendFile, copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { promisify } from "node:util";
+
+import { buildNationwideCoverageTally, LEDGER_PATH } from "./build-nationwide-coverage-tally.mjs";
+
+const execFileAsync = promisify(execFile);
+const root = path.resolve(import.meta.dirname, "../..");
+const TOOL_PATH = "tools/datapack/build-nationwide-coverage-tally.mjs";
+const TARGETS_PATH = "tools/datapack/nationwide-coverage-targets.json";
+const INVENTORY_PATH = "tools/datapack/source-inventory.json";
+const RESOLUTIONS_PATH = "tools/datapack/release/nationwide-public-api-coverage-resolutions-20260721.json";
+const INPUT_PATHS = [TARGETS_PATH, INVENTORY_PATH, RESOLUTIONS_PATH];
+const EXPECTED_LAUNCH_REQUIRED_TOTAL = "270";
+
+const FIXTURE_INPUTS = {
+  targets: { path: TARGETS_PATH, sha256: "a".repeat(64) },
+  inventory: { path: INVENTORY_PATH, sha256: "b".repeat(64) },
+  resolutions: { path: RESOLUTIONS_PATH, sha256: "c".repeat(64) },
+};
+
+function fixtureTargets(overrides = {}) {
+  return {
+    schemaVersion: 2,
+    artifactKind: "nationwide-datapack-coverage-targets",
+    targetVersion: "2026-07-13",
+    requiredSourceDomains: [
+      {
+        id: "station_line_membership",
+        releaseTier: "LAUNCH_REQUIRED",
+        requiredFields: ["line", "station_name"],
+        blockingThreshold: { minimumOfficialFieldCoverageRatio: 1 },
+      },
+      {
+        id: "demand_reference",
+        releaseTier: "ENHANCEMENT",
+        requiredFields: ["hourly_boarding_count"],
+        blockingThreshold: { minimumOfficialFieldCoverageRatio: 1 },
+      },
+    ],
+    activeLineScopes: [
+      { lineId: "line-a", regionId: "capital", operatorId: "operator-a" },
+      { lineId: "line-a", regionId: "capital", operatorId: "operator-b" },
+    ],
+    ...overrides,
+  };
+}
+
+function fixtureInventory(sources) {
+  return { schemaVersion: 1, retrievedAt: "2026-06-22", sources };
+}
+
+function fixtureResolutions(entries = []) {
+  return {
+    schemaVersion: 1,
+    artifactKind: "nationwide-coverage-resolutions",
+    targetVersion: "2026-07-13",
+    generatedAt: "2026-07-21T02:43:09.257Z",
+    entries,
+  };
+}
+
+function fixtureResolutionEntry(overrides = {}) {
+  return {
+    regionId: "capital",
+    operatorId: "operator-b",
+    lineId: "line-a",
+    sourceDomain: "station_line_membership",
+    state: "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+    reasonCode: "PUBLIC_API_NO_DATA",
+    fallback: "UNSUPPORTED_REGION",
+    reviewedAt: "2026-07-21T02:43:09.257Z",
+    nextReviewAt: "2026-10-19T02:43:09.257Z",
+    evidenceHash: "d".repeat(64),
+    ...overrides,
+  };
+}
+
+// operator-a만 커버하는 노선 소스 — operator-b는 dual-operator 미매칭이 된다.
+function operatorAMembershipSource() {
+  return {
+    id: "operator-a-membership",
+    coverageScope: {
+      regionIds: ["capital"],
+      operatorIds: ["operator-a"],
+      lineIds: ["line-a"],
+      sourceDomains: ["station_line_membership"],
+    },
+    fieldsProvided: ["line", "station_name"],
+  };
+}
+
+function buildFixtureLedger({ targets, inventory, resolutions, expectedLaunchRequiredTotal = null }) {
+  return buildNationwideCoverageTally({
+    targets,
+    inventory,
+    resolutions,
+    inputs: FIXTURE_INPUTS,
+    expectedLaunchRequiredTotal,
+  });
+}
+
+function requirementFor(ledger, operatorId, sourceDomain = "station_line_membership") {
+  const tier = sourceDomain === "demand_reference" ? ledger.enhancement : ledger.launchRequired;
+  return tier.requirements.find(
+    (entry) => entry.operatorId === operatorId && entry.sourceDomain === sourceDomain,
+  );
+}
+
+// tracked 입력 3종을 임시 workspace에 repo 상대 경로 그대로 복제한다. 도구를 그 workspace를 cwd로
+// 실행하면 ledger가 기록하는 입력 경로는 tracked 산출물과 같으므로, 바이트 차이는 입력 내용 차이만 남는다.
+async function stageWorkspace(mutate) {
+  const workspace = await mkdtemp(path.join(tmpdir(), "coverage-tally-"));
+  for (const relativePath of INPUT_PATHS) {
+    await mkdir(path.join(workspace, path.dirname(relativePath)), { recursive: true });
+    await copyFile(path.join(root, relativePath), path.join(workspace, relativePath));
+  }
+  if (mutate) await mutate(workspace);
+  return workspace;
+}
+
+async function regenerateLedger(workspace, extraArgs = []) {
+  const output = path.join(workspace, "ledger.json");
+  await execFileAsync(process.execPath, [
+    path.join(root, TOOL_PATH),
+    "--targets", TARGETS_PATH,
+    "--inventory", INVENTORY_PATH,
+    "--resolutions", RESOLUTIONS_PATH,
+    "--expected-launch-required-total", EXPECTED_LAUNCH_REQUIRED_TOTAL,
+    "--output", output,
+    ...extraArgs,
+  ], { cwd: workspace });
+  return readFile(output, "utf8");
+}
+
+test("커밋된 전국 coverage tally ledger는 현행 입력에서 바이트 단위로 재생성된다", async () => {
+  const workspace = await stageWorkspace();
+  try {
+    const regenerated = await regenerateLedger(workspace);
+    const tracked = await readFile(path.join(root, LEDGER_PATH), "utf8");
+    assert.equal(regenerated, tracked, "ledger는 재생성 결과와 바이트 단위로 같아야 한다");
+
+    const ledger = JSON.parse(tracked);
+    assert.equal(ledger.artifactKind, "nationwide-coverage-tally-ledger");
+    assert.equal(ledger.issue, 2507);
+    assert.equal(ledger.regeneration.ledgerPath, LEDGER_PATH);
+    assert.equal(
+      ledger.regeneration.command,
+      `node ${TOOL_PATH} --targets ${TARGETS_PATH} --inventory ${INVENTORY_PATH}`
+        + ` --resolutions ${RESOLUTIONS_PATH}`
+        + ` --expected-launch-required-total ${EXPECTED_LAUNCH_REQUIRED_TOTAL} --output ${LEDGER_PATH}`,
+    );
+
+    // 기록된 입력 해시는 tracked 입력 파일의 실제 해시여야 한다(입력 drift 감지축).
+    for (const [name, relativePath] of [
+      ["targets", TARGETS_PATH],
+      ["inventory", INVENTORY_PATH],
+      ["resolutions", RESOLUTIONS_PATH],
+    ]) {
+      assert.equal(ledger.inputs[name].path, relativePath);
+      assert.equal(
+        ledger.inputs[name].sha256,
+        createHash("sha256").update(await readFile(path.join(root, relativePath))).digest("hex"),
+      );
+    }
+
+    assert.deepEqual(ledger.denominator, {
+      activeLineScopeCount: 45,
+      activeLineCount: 36,
+      launchRequiredDomainCount: 6,
+      launchRequiredTotal: 270,
+      enhancementDomainCount: 1,
+      enhancementTotal: 45,
+      expectedLaunchRequiredTotal: 270,
+    });
+    assert.equal(ledger.launchRequired.totalCount, 270);
+    assert.equal(ledger.launchRequired.inventoryAdmittedCount, 80);
+    assert.equal(ledger.launchRequired.explicitlyUnsupportedWithEvidenceCount, 4);
+    assert.equal(ledger.launchRequired.missingCount, 186);
+    assert.deepEqual(ledger.launchRequired.missingByKind, {
+      DUAL_OPERATOR_UNMATCHED: 12,
+      NO_ADMITTED_SOURCE: 174,
+    });
+    assert.equal(ledger.launchRequired.terminalCount, 84);
+    assert.equal(ledger.launchRequired.requirements.length, 270);
+    assert.equal(ledger.enhancement.totalCount, 45);
+    assert.equal(ledger.enhancement.requirements.length, 45);
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test("입력 3종이 바뀌면 ledger 재생성 없이는 tracked 바이트와 어긋난다", async (context) => {
+  const tracked = await readFile(path.join(root, LEDGER_PATH), "utf8");
+  for (const relativePath of INPUT_PATHS) {
+    await context.test(relativePath, async () => {
+      // 의미가 같은 공백 한 바이트만 바꿔도 입력 해시가 달라져 ledger 재생성이 강제돼야 한다.
+      const workspace = await stageWorkspace(async (dir) => {
+        await appendFile(path.join(dir, relativePath), "\n");
+      });
+      try {
+        assert.notEqual(await regenerateLedger(workspace), tracked);
+      } finally {
+        await rm(workspace, { recursive: true, force: true });
+      }
+    });
+  }
+});
+
+test("분모 drift는 fail closed다", async (context) => {
+  await context.test("활성 노선 scope 중복", () => {
+    const targets = fixtureTargets({
+      activeLineScopes: [
+        { lineId: "line-a", regionId: "capital", operatorId: "operator-a" },
+        { lineId: "line-a", regionId: "capital", operatorId: "operator-a" },
+      ],
+    });
+    assert.throws(
+      () => buildFixtureLedger({
+        targets,
+        inventory: fixtureInventory([operatorAMembershipSource()]),
+        resolutions: fixtureResolutions(),
+      }),
+      /duplicate active line scope: capital:operator-a:line-a/,
+    );
+  });
+
+  await context.test("기대 분모 불일치", () => {
+    assert.throws(
+      () => buildFixtureLedger({
+        targets: fixtureTargets(),
+        inventory: fixtureInventory([operatorAMembershipSource()]),
+        resolutions: fixtureResolutions(),
+        expectedLaunchRequiredTotal: 3,
+      }),
+      /launch-required denominator drift: expected 3, computed 2/,
+    );
+  });
+
+  await context.test("실제 입력에서 270이 아닌 기대값은 CLI가 거부한다", async () => {
+    const workspace = await stageWorkspace();
+    try {
+      await assert.rejects(
+        regenerateLedger(workspace, ["--expected-launch-required-total", "269"]),
+        (error) => /launch-required denominator drift: expected 269, computed 270/.test(error.stderr),
+      );
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+});
+
+test("dual-operator 미매칭은 MISSING 하위 구분으로 가시화된다", () => {
+  const ledger = buildFixtureLedger({
+    targets: fixtureTargets(),
+    inventory: fixtureInventory([operatorAMembershipSource()]),
+    resolutions: fixtureResolutions(),
+  });
+
+  const admitted = requirementFor(ledger, "operator-a");
+  assert.equal(admitted.status, "INVENTORY_ADMITTED");
+  assert.deepEqual(admitted.admittedSourceIds, ["operator-a-membership"]);
+  assert.equal(admitted.dualOperator, null);
+
+  const unmatched = requirementFor(ledger, "operator-b");
+  assert.equal(unmatched.status, "MISSING");
+  assert.equal(unmatched.missingKind, "DUAL_OPERATOR_UNMATCHED");
+  assert.deepEqual(unmatched.dualOperator, {
+    coveringOperatorIds: ["operator-a"],
+    coveringSourceIds: ["operator-a-membership"],
+  });
+  assert.deepEqual(ledger.launchRequired.missingByKind, {
+    DUAL_OPERATOR_UNMATCHED: 1,
+    NO_ADMITTED_SOURCE: 0,
+  });
+});
+
+test("빈 lineIds coverageScope는 와일드카드가 아니다", () => {
+  const source = operatorAMembershipSource();
+  delete source.coverageScope.lineIds;
+  const ledger = buildFixtureLedger({
+    targets: fixtureTargets(),
+    inventory: fixtureInventory([source]),
+    resolutions: fixtureResolutions(),
+  });
+
+  assert.equal(ledger.launchRequired.inventoryAdmittedCount, 0);
+  assert.deepEqual(ledger.launchRequired.missingByKind, {
+    DUAL_OPERATOR_UNMATCHED: 0,
+    NO_ADMITTED_SOURCE: 2,
+  });
+});
+
+test("resolutions는 EXPLICITLY_UNSUPPORTED 정본이며 계약 위반은 fail closed다", async (context) => {
+  const inventory = fixtureInventory([operatorAMembershipSource()]);
+
+  await context.test("정본 entry는 MISSING을 terminal 상태로 바꾼다", () => {
+    const ledger = buildFixtureLedger({
+      targets: fixtureTargets(),
+      inventory,
+      resolutions: fixtureResolutions([fixtureResolutionEntry()]),
+    });
+    const resolved = requirementFor(ledger, "operator-b");
+    assert.equal(resolved.status, "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE");
+    assert.equal(resolved.resolution.reasonCode, "PUBLIC_API_NO_DATA");
+    assert.equal(resolved.missingKind, null);
+    assert.equal(ledger.launchRequired.terminalCount, 2);
+    assert.equal(ledger.launchRequired.missingCount, 0);
+  });
+
+  const rejections = [
+    [
+      "admitted requirement 충돌",
+      fixtureResolutions([fixtureResolutionEntry({ operatorId: "operator-a" })]),
+      /inventory-admitted requirement must not have an unsupported resolution/,
+    ],
+    [
+      "requirement 공간 밖 entry",
+      fixtureResolutions([fixtureResolutionEntry({ operatorId: "operator-z" })]),
+      /unknown coverage resolution requirement/,
+    ],
+    [
+      "중복 entry",
+      fixtureResolutions([fixtureResolutionEntry(), fixtureResolutionEntry()]),
+      /duplicate coverage resolution/,
+    ],
+    [
+      "targetVersion 불일치",
+      { ...fixtureResolutions(), targetVersion: "2026-01-01" },
+      /coverage resolutions targetVersion must match coverage targets/,
+    ],
+    [
+      "state 위반",
+      fixtureResolutions([fixtureResolutionEntry({ state: "SUPPORTED" })]),
+      /state is invalid: SUPPORTED/,
+    ],
+  ];
+  for (const [name, resolutions, expected] of rejections) {
+    await context.test(name, () => {
+      assert.throws(
+        () => buildFixtureLedger({ targets: fixtureTargets(), inventory, resolutions }),
+        expected,
+      );
+    });
+  }
+});
+
+test("ENHANCEMENT tier는 LAUNCH_REQUIRED 집계와 분리 보고된다", () => {
+  const demandSource = {
+    id: "operator-a-demand",
+    coverageScope: {
+      regionIds: ["capital"],
+      operatorIds: ["operator-a"],
+      lineIds: ["line-a"],
+      sourceDomains: ["demand_reference"],
+    },
+    fieldsProvided: ["hourly_boarding_count"],
+  };
+  const ledger = buildFixtureLedger({
+    targets: fixtureTargets(),
+    inventory: fixtureInventory([operatorAMembershipSource(), demandSource]),
+    resolutions: fixtureResolutions(),
+  });
+
+  assert.equal(ledger.denominator.launchRequiredTotal, 2);
+  assert.equal(ledger.denominator.enhancementTotal, 2);
+  assert.equal(ledger.launchRequired.totalCount, 2);
+  assert.equal(ledger.launchRequired.inventoryAdmittedCount, 1);
+  assert.ok(ledger.launchRequired.requirements.every((entry) => entry.releaseTier === "LAUNCH_REQUIRED"));
+  assert.equal(ledger.enhancement.totalCount, 2);
+  assert.equal(ledger.enhancement.inventoryAdmittedCount, 1);
+  assert.ok(ledger.enhancement.requirements.every((entry) => entry.releaseTier === "ENHANCEMENT"));
+  assert.equal(requirementFor(ledger, "operator-a", "demand_reference").status, "INVENTORY_ADMITTED");
+});
+
+test("tally 산출물은 wall-clock을 쓰지 않고 결정적이다", async () => {
+  const source = await readFile(path.join(root, TOOL_PATH), "utf8");
+  const code = source.split("\n").filter((line) => !line.trimStart().startsWith("//")).join("\n");
+  assert.doesNotMatch(code, /Date\.now\(|new Date\(/, "산출물 값은 입력에서만 유도해야 한다");
+
+  const build = () => buildFixtureLedger({
+    targets: fixtureTargets(),
+    inventory: fixtureInventory([operatorAMembershipSource()]),
+    resolutions: fixtureResolutions([fixtureResolutionEntry()]),
+  });
+  assert.equal(JSON.stringify(build()), JSON.stringify(build()));
+
+  // 알 수 없는 인자는 조용히 기본값으로 흐르지 않고 거부돼야 한다(오타로 다른 resolutions를 읽는 사고 방지).
+  const workspace = await mkdtemp(path.join(tmpdir(), "coverage-tally-args-"));
+  try {
+    await writeFile(path.join(workspace, "targets.json"), JSON.stringify(fixtureTargets()));
+    await assert.rejects(
+      execFileAsync(process.execPath, [
+        path.join(root, TOOL_PATH),
+        "--targets", path.join(workspace, "targets.json"),
+        "--inventory", path.join(root, INVENTORY_PATH),
+        "--resolution", path.join(root, RESOLUTIONS_PATH),
+        "--output", path.join(workspace, "ledger.json"),
+      ], { cwd: root }),
+      (error) => /unexpected argument: --resolution/.test(error.stderr),
+    );
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});

--- a/tools/datapack/build-nationwide-coverage-tally.test.mjs
+++ b/tools/datapack/build-nationwide-coverage-tally.test.mjs
@@ -124,16 +124,15 @@ async function stageWorkspace(mutate) {
   return workspace;
 }
 
-async function regenerateLedger(workspace, extraArgs = []) {
+async function regenerateLedger(workspace, expectedLaunchRequiredTotal = EXPECTED_LAUNCH_REQUIRED_TOTAL) {
   const output = path.join(workspace, "ledger.json");
   await execFileAsync(process.execPath, [
     path.join(root, TOOL_PATH),
     "--targets", TARGETS_PATH,
     "--inventory", INVENTORY_PATH,
     "--resolutions", RESOLUTIONS_PATH,
-    "--expected-launch-required-total", EXPECTED_LAUNCH_REQUIRED_TOTAL,
+    "--expected-launch-required-total", expectedLaunchRequiredTotal,
     "--output", output,
-    ...extraArgs,
   ], { cwd: workspace });
   return readFile(output, "utf8");
 }
@@ -246,7 +245,7 @@ test("분모 drift는 fail closed다", async (context) => {
     const workspace = await stageWorkspace();
     try {
       await assert.rejects(
-        regenerateLedger(workspace, ["--expected-launch-required-total", "269"]),
+        regenerateLedger(workspace, "269"),
         (error) => /launch-required denominator drift: expected 269, computed 270/.test(error.stderr),
       );
     } finally {
@@ -381,7 +380,11 @@ test("ENHANCEMENT tier는 LAUNCH_REQUIRED 집계와 분리 보고된다", () => 
 test("tally 산출물은 wall-clock을 쓰지 않고 결정적이다", async () => {
   const source = await readFile(path.join(root, TOOL_PATH), "utf8");
   const code = source.split("\n").filter((line) => !line.trimStart().startsWith("//")).join("\n");
-  assert.doesNotMatch(code, /Date\.now\(|new Date\(/, "산출물 값은 입력에서만 유도해야 한다");
+  assert.doesNotMatch(
+    code,
+    /Date\.now\(|Date\.UTC\(|new Date\(|performance\.now\(|process\.hrtime|Math\.random\(/,
+    "산출물 값은 입력에서만 유도해야 한다",
+  );
 
   const build = () => buildFixtureLedger({
     targets: fixtureTargets(),

--- a/tools/datapack/build-nationwide-coverage-tally.test.mjs
+++ b/tools/datapack/build-nationwide-coverage-tally.test.mjs
@@ -182,14 +182,14 @@ test("커밋된 전국 coverage tally ledger는 현행 입력에서 바이트 �
     // 후속 #2138 admission PR은 (1) ledger.regeneration.command로 ledger를 재생성하고 (2) 이 상수를
     // 같은 커밋에서 함께 갱신해야 한다. 둘 중 하나만 하면 이 테스트가 fail closed 된다.
     assert.equal(ledger.launchRequired.totalCount, 270);
-    assert.equal(ledger.launchRequired.inventoryAdmittedCount, 80);
+    assert.equal(ledger.launchRequired.inventoryAdmittedCount, 83);
     assert.equal(ledger.launchRequired.explicitlyUnsupportedWithEvidenceCount, 4);
-    assert.equal(ledger.launchRequired.missingCount, 186);
+    assert.equal(ledger.launchRequired.missingCount, 183);
     assert.deepEqual(ledger.launchRequired.missingByKind, {
-      DUAL_OPERATOR_UNMATCHED: 12,
+      DUAL_OPERATOR_UNMATCHED: 9,
       NO_ADMITTED_SOURCE: 174,
     });
-    assert.equal(ledger.launchRequired.terminalCount, 84);
+    assert.equal(ledger.launchRequired.terminalCount, 87);
     assert.equal(ledger.launchRequired.supportStartedResolutionCount, 0);
     assert.equal(ledger.launchRequired.earliestResolutionNextReviewAt, "2026-10-19T02:43:09.257Z");
     assert.equal(ledger.launchRequired.requirements.length, 270);

--- a/tools/datapack/reports/nationwide-coverage-tally.json
+++ b/tools/datapack/reports/nationwide-coverage-tally.json
@@ -12,6 +12,7 @@
   "enhancement": {
     "byDomain": [
       {
+        "earliestResolutionNextReviewAt": null,
         "explicitlyUnsupportedWithEvidenceCount": 0,
         "inventoryAdmittedCount": 0,
         "inventoryAdmittedRatio": 0,
@@ -21,6 +22,7 @@
         },
         "missingCount": 45,
         "sourceDomain": "demand_reference",
+        "supportStartedResolutionCount": 0,
         "terminalCount": 0,
         "terminalRatio": 0,
         "totalCount": 45
@@ -28,6 +30,7 @@
     ],
     "byRegion": [
       {
+        "earliestResolutionNextReviewAt": null,
         "explicitlyUnsupportedWithEvidenceCount": 0,
         "inventoryAdmittedCount": 0,
         "inventoryAdmittedRatio": 0,
@@ -37,11 +40,13 @@
         },
         "missingCount": 6,
         "regionId": "busan",
+        "supportStartedResolutionCount": 0,
         "terminalCount": 0,
         "terminalRatio": 0,
         "totalCount": 6
       },
       {
+        "earliestResolutionNextReviewAt": null,
         "explicitlyUnsupportedWithEvidenceCount": 0,
         "inventoryAdmittedCount": 0,
         "inventoryAdmittedRatio": 0,
@@ -51,11 +56,13 @@
         },
         "missingCount": 33,
         "regionId": "capital",
+        "supportStartedResolutionCount": 0,
         "terminalCount": 0,
         "terminalRatio": 0,
         "totalCount": 33
       },
       {
+        "earliestResolutionNextReviewAt": null,
         "explicitlyUnsupportedWithEvidenceCount": 0,
         "inventoryAdmittedCount": 0,
         "inventoryAdmittedRatio": 0,
@@ -65,11 +72,13 @@
         },
         "missingCount": 4,
         "regionId": "daegu",
+        "supportStartedResolutionCount": 0,
         "terminalCount": 0,
         "terminalRatio": 0,
         "totalCount": 4
       },
       {
+        "earliestResolutionNextReviewAt": null,
         "explicitlyUnsupportedWithEvidenceCount": 0,
         "inventoryAdmittedCount": 0,
         "inventoryAdmittedRatio": 0,
@@ -79,11 +88,13 @@
         },
         "missingCount": 1,
         "regionId": "daejeon",
+        "supportStartedResolutionCount": 0,
         "terminalCount": 0,
         "terminalRatio": 0,
         "totalCount": 1
       },
       {
+        "earliestResolutionNextReviewAt": null,
         "explicitlyUnsupportedWithEvidenceCount": 0,
         "inventoryAdmittedCount": 0,
         "inventoryAdmittedRatio": 0,
@@ -93,11 +104,13 @@
         },
         "missingCount": 1,
         "regionId": "gwangju",
+        "supportStartedResolutionCount": 0,
         "terminalCount": 0,
         "terminalRatio": 0,
         "totalCount": 1
       }
     ],
+    "earliestResolutionNextReviewAt": null,
     "explicitlyUnsupportedWithEvidenceCount": 0,
     "inventoryAdmittedCount": 0,
     "inventoryAdmittedRatio": 0,
@@ -120,6 +133,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -140,6 +154,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -160,6 +175,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -180,6 +196,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -200,6 +217,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -220,6 +238,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -240,6 +259,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -260,6 +280,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -280,6 +301,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -300,6 +322,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -320,6 +343,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -340,6 +364,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -360,6 +385,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -380,6 +406,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -400,6 +427,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -420,6 +448,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -440,6 +469,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -460,6 +490,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -480,6 +511,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -500,6 +532,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -520,6 +553,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -540,6 +574,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -560,6 +595,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -580,6 +616,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -600,6 +637,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -620,6 +658,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -640,6 +679,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -660,6 +700,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -680,6 +721,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -700,6 +742,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -720,6 +763,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -740,6 +784,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -760,6 +805,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -780,6 +826,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -800,6 +847,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -820,6 +868,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -840,6 +889,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -860,6 +910,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -880,6 +931,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -900,6 +952,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -920,6 +973,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -940,6 +994,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -960,6 +1015,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -980,6 +1036,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -1000,6 +1057,7 @@
         "releaseTier": "ENHANCEMENT",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "demand_reference",
         "status": "MISSING",
         "unadmittedFields": [
@@ -1008,6 +1066,7 @@
         ]
       }
     ],
+    "supportStartedResolutionCount": 0,
     "terminalCount": 0,
     "terminalRatio": 0,
     "totalCount": 45
@@ -1034,6 +1093,7 @@
   "launchRequired": {
     "byDomain": [
       {
+        "earliestResolutionNextReviewAt": null,
         "explicitlyUnsupportedWithEvidenceCount": 0,
         "inventoryAdmittedCount": 12,
         "inventoryAdmittedRatio": 0.2667,
@@ -1043,11 +1103,13 @@
         },
         "missingCount": 33,
         "sourceDomain": "accessibility_facilities",
+        "supportStartedResolutionCount": 0,
         "terminalCount": 12,
         "terminalRatio": 0.2667,
         "totalCount": 45
       },
       {
+        "earliestResolutionNextReviewAt": "2026-10-19T02:43:09.257Z",
         "explicitlyUnsupportedWithEvidenceCount": 4,
         "inventoryAdmittedCount": 0,
         "inventoryAdmittedRatio": 0,
@@ -1057,11 +1119,13 @@
         },
         "missingCount": 41,
         "sourceDomain": "realtime_arrivals",
+        "supportStartedResolutionCount": 0,
         "terminalCount": 4,
         "terminalRatio": 0.0889,
         "totalCount": 45
       },
       {
+        "earliestResolutionNextReviewAt": null,
         "explicitlyUnsupportedWithEvidenceCount": 0,
         "inventoryAdmittedCount": 12,
         "inventoryAdmittedRatio": 0.2667,
@@ -1071,11 +1135,13 @@
         },
         "missingCount": 33,
         "sourceDomain": "route_graph_topology",
+        "supportStartedResolutionCount": 0,
         "terminalCount": 12,
         "terminalRatio": 0.2667,
         "totalCount": 45
       },
       {
+        "earliestResolutionNextReviewAt": null,
         "explicitlyUnsupportedWithEvidenceCount": 0,
         "inventoryAdmittedCount": 33,
         "inventoryAdmittedRatio": 0.7333,
@@ -1085,11 +1151,13 @@
         },
         "missingCount": 12,
         "sourceDomain": "route_map_positions",
+        "supportStartedResolutionCount": 0,
         "terminalCount": 33,
         "terminalRatio": 0.7333,
         "totalCount": 45
       },
       {
+        "earliestResolutionNextReviewAt": null,
         "explicitlyUnsupportedWithEvidenceCount": 0,
         "inventoryAdmittedCount": 11,
         "inventoryAdmittedRatio": 0.2444,
@@ -1099,11 +1167,13 @@
         },
         "missingCount": 34,
         "sourceDomain": "schedule_timetable",
+        "supportStartedResolutionCount": 0,
         "terminalCount": 11,
         "terminalRatio": 0.2444,
         "totalCount": 45
       },
       {
+        "earliestResolutionNextReviewAt": null,
         "explicitlyUnsupportedWithEvidenceCount": 0,
         "inventoryAdmittedCount": 12,
         "inventoryAdmittedRatio": 0.2667,
@@ -1113,6 +1183,7 @@
         },
         "missingCount": 33,
         "sourceDomain": "station_line_membership",
+        "supportStartedResolutionCount": 0,
         "terminalCount": 12,
         "terminalRatio": 0.2667,
         "totalCount": 45
@@ -1120,6 +1191,7 @@
     ],
     "byRegion": [
       {
+        "earliestResolutionNextReviewAt": "2026-10-19T02:43:09.257Z",
         "explicitlyUnsupportedWithEvidenceCount": 1,
         "inventoryAdmittedCount": 20,
         "inventoryAdmittedRatio": 0.5556,
@@ -1129,11 +1201,13 @@
         },
         "missingCount": 15,
         "regionId": "busan",
+        "supportStartedResolutionCount": 0,
         "terminalCount": 21,
         "terminalRatio": 0.5833,
         "totalCount": 36
       },
       {
+        "earliestResolutionNextReviewAt": null,
         "explicitlyUnsupportedWithEvidenceCount": 0,
         "inventoryAdmittedCount": 35,
         "inventoryAdmittedRatio": 0.1768,
@@ -1143,11 +1217,13 @@
         },
         "missingCount": 163,
         "regionId": "capital",
+        "supportStartedResolutionCount": 0,
         "terminalCount": 35,
         "terminalRatio": 0.1768,
         "totalCount": 198
       },
       {
+        "earliestResolutionNextReviewAt": "2026-10-19T02:43:09.257Z",
         "explicitlyUnsupportedWithEvidenceCount": 3,
         "inventoryAdmittedCount": 15,
         "inventoryAdmittedRatio": 0.625,
@@ -1157,11 +1233,13 @@
         },
         "missingCount": 6,
         "regionId": "daegu",
+        "supportStartedResolutionCount": 0,
         "terminalCount": 18,
         "terminalRatio": 0.75,
         "totalCount": 24
       },
       {
+        "earliestResolutionNextReviewAt": null,
         "explicitlyUnsupportedWithEvidenceCount": 0,
         "inventoryAdmittedCount": 5,
         "inventoryAdmittedRatio": 0.8333,
@@ -1171,11 +1249,13 @@
         },
         "missingCount": 1,
         "regionId": "daejeon",
+        "supportStartedResolutionCount": 0,
         "terminalCount": 5,
         "terminalRatio": 0.8333,
         "totalCount": 6
       },
       {
+        "earliestResolutionNextReviewAt": null,
         "explicitlyUnsupportedWithEvidenceCount": 0,
         "inventoryAdmittedCount": 5,
         "inventoryAdmittedRatio": 0.8333,
@@ -1185,11 +1265,13 @@
         },
         "missingCount": 1,
         "regionId": "gwangju",
+        "supportStartedResolutionCount": 0,
         "terminalCount": 5,
         "terminalRatio": 0.8333,
         "totalCount": 6
       }
     ],
+    "earliestResolutionNextReviewAt": "2026-10-19T02:43:09.257Z",
     "explicitlyUnsupportedWithEvidenceCount": 4,
     "inventoryAdmittedCount": 80,
     "inventoryAdmittedRatio": 0.2963,
@@ -1214,6 +1296,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -1231,6 +1314,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -1252,6 +1336,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -1271,6 +1356,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -1290,6 +1376,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -1309,6 +1396,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -1328,6 +1416,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -1345,6 +1434,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -1366,6 +1456,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -1385,6 +1476,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -1404,6 +1496,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -1423,6 +1516,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -1442,6 +1536,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -1459,6 +1554,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -1480,6 +1576,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -1499,6 +1596,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -1518,6 +1616,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -1537,6 +1636,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -1556,6 +1656,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -1573,6 +1674,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -1594,6 +1696,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -1613,6 +1716,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -1632,6 +1736,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -1651,6 +1756,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -1668,6 +1774,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "MISSING",
         "unadmittedFields": [
@@ -1691,6 +1798,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -1710,6 +1818,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "MISSING",
         "unadmittedFields": [
@@ -1731,6 +1840,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "MISSING",
         "unadmittedFields": [
@@ -1751,6 +1861,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "MISSING",
         "unadmittedFields": [
@@ -1772,6 +1883,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "MISSING",
         "unadmittedFields": [
@@ -1793,6 +1905,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "MISSING",
         "unadmittedFields": [
@@ -1820,8 +1933,10 @@
           "fallback": "UNSUPPORTED_REGION",
           "nextReviewAt": "2026-10-19T02:43:09.257Z",
           "reasonCode": "PUBLIC_API_NO_DATA",
-          "reviewedAt": "2026-07-21T02:43:09.257Z"
+          "reviewedAt": "2026-07-21T02:43:09.257Z",
+          "supportStartedAt": null
         },
+        "resolutionReviewStatus": "CURRENT",
         "sourceDomain": "realtime_arrivals",
         "status": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
         "unadmittedFields": [
@@ -1841,6 +1956,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "MISSING",
         "unadmittedFields": [
@@ -1862,6 +1978,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "MISSING",
         "unadmittedFields": [
@@ -1882,6 +1999,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "MISSING",
         "unadmittedFields": [
@@ -1903,6 +2021,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "MISSING",
         "unadmittedFields": [
@@ -1926,6 +2045,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -1943,6 +2063,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -1964,6 +2085,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -1983,6 +2105,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -2000,6 +2123,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "MISSING",
         "unadmittedFields": [
@@ -2023,6 +2147,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -2042,6 +2167,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -2059,6 +2185,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -2080,6 +2207,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -2099,6 +2227,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -2118,6 +2247,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -2137,6 +2267,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -2156,6 +2287,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -2173,6 +2305,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -2194,6 +2327,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -2213,6 +2347,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -2232,6 +2367,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -2251,6 +2387,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -2268,6 +2405,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "MISSING",
         "unadmittedFields": [
@@ -2291,6 +2429,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -2310,6 +2449,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "MISSING",
         "unadmittedFields": [
@@ -2333,6 +2473,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -2350,6 +2491,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "MISSING",
         "unadmittedFields": [
@@ -2371,6 +2513,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "MISSING",
         "unadmittedFields": [
@@ -2392,6 +2535,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "MISSING",
         "unadmittedFields": [
@@ -2415,6 +2559,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -2434,6 +2579,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "MISSING",
         "unadmittedFields": [
@@ -2462,6 +2608,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "MISSING",
         "unadmittedFields": [
@@ -2482,6 +2629,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "MISSING",
         "unadmittedFields": [
@@ -2503,6 +2651,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "MISSING",
         "unadmittedFields": [
@@ -2524,6 +2673,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "MISSING",
         "unadmittedFields": [
@@ -2547,6 +2697,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -2566,6 +2717,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "MISSING",
         "unadmittedFields": [
@@ -2594,6 +2746,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "MISSING",
         "unadmittedFields": [
@@ -2614,6 +2767,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "MISSING",
         "unadmittedFields": [
@@ -2635,6 +2789,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "MISSING",
         "unadmittedFields": [
@@ -2656,6 +2811,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "MISSING",
         "unadmittedFields": [
@@ -2679,6 +2835,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -2698,6 +2855,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "MISSING",
         "unadmittedFields": [
@@ -2721,6 +2879,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -2738,6 +2897,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "MISSING",
         "unadmittedFields": [
@@ -2759,6 +2919,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "MISSING",
         "unadmittedFields": [
@@ -2780,6 +2941,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "MISSING",
         "unadmittedFields": [
@@ -2803,6 +2965,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -2822,6 +2985,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "MISSING",
         "unadmittedFields": [
@@ -2845,6 +3009,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -2862,6 +3027,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "MISSING",
         "unadmittedFields": [
@@ -2883,6 +3049,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "MISSING",
         "unadmittedFields": [
@@ -2904,6 +3071,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "MISSING",
         "unadmittedFields": [
@@ -2927,6 +3095,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -2946,6 +3115,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "MISSING",
         "unadmittedFields": [
@@ -2969,6 +3139,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -2986,6 +3157,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3007,6 +3179,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3028,6 +3201,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3051,6 +3225,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3070,6 +3245,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3093,6 +3269,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -3110,6 +3287,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3131,6 +3309,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3152,6 +3331,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3175,6 +3355,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3194,6 +3375,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3222,6 +3404,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3242,6 +3425,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3263,6 +3447,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3284,6 +3469,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3307,6 +3493,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3326,6 +3513,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3354,6 +3542,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3374,6 +3563,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3395,6 +3585,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3416,6 +3607,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3439,6 +3631,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3458,6 +3651,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3481,6 +3675,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -3498,6 +3693,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3519,6 +3715,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3540,6 +3737,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3563,6 +3761,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3582,6 +3781,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3610,6 +3810,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3630,6 +3831,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3651,6 +3853,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3672,6 +3875,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3695,6 +3899,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3714,6 +3919,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3737,6 +3943,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -3754,6 +3961,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3775,6 +3983,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3796,6 +4005,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3819,6 +4029,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3838,6 +4049,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3861,6 +4073,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -3878,6 +4091,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3899,6 +4113,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3920,6 +4135,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3943,6 +4159,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3962,6 +4179,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "MISSING",
         "unadmittedFields": [
@@ -3990,6 +4208,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4010,6 +4229,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4031,6 +4251,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4052,6 +4273,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4075,6 +4297,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4094,6 +4317,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4117,6 +4341,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -4134,6 +4359,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4155,6 +4381,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4176,6 +4403,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4199,6 +4427,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4218,6 +4447,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4241,6 +4471,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -4258,6 +4489,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4279,6 +4511,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4300,6 +4533,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4323,6 +4557,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4342,6 +4577,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4365,6 +4601,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -4382,6 +4619,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4403,6 +4641,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4424,6 +4663,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4447,6 +4687,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4466,6 +4707,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4490,6 +4732,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -4507,6 +4750,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4528,6 +4772,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4549,6 +4794,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4572,6 +4818,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4591,6 +4838,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4619,6 +4867,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4639,6 +4888,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4660,6 +4910,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4681,6 +4932,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4704,6 +4956,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4723,6 +4976,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4746,6 +5000,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -4763,6 +5018,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4784,6 +5040,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4805,6 +5062,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4828,6 +5086,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4847,6 +5106,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4875,6 +5135,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4895,6 +5156,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4916,6 +5178,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4937,6 +5200,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4960,6 +5224,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -4979,6 +5244,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5007,6 +5273,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5027,6 +5294,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5048,6 +5316,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5076,6 +5345,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5099,6 +5369,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5125,6 +5396,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5148,6 +5420,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -5165,6 +5438,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5193,6 +5467,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5214,6 +5489,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5237,6 +5513,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5256,6 +5533,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5279,6 +5557,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -5296,6 +5575,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5317,6 +5597,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5338,6 +5619,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5361,6 +5643,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5380,6 +5663,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5403,6 +5687,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -5420,6 +5705,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5441,6 +5727,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5462,6 +5749,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5485,6 +5773,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5504,6 +5793,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5527,6 +5817,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -5544,6 +5835,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5565,6 +5857,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5586,6 +5879,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5609,6 +5903,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5628,6 +5923,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5651,6 +5947,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -5668,6 +5965,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5689,6 +5987,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5710,6 +6009,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5733,6 +6033,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5752,6 +6053,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5775,6 +6077,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -5792,6 +6095,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5813,6 +6117,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5834,6 +6139,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5857,6 +6163,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5876,6 +6183,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5899,6 +6207,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -5916,6 +6225,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5937,6 +6247,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5958,6 +6269,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "MISSING",
         "unadmittedFields": [
@@ -5981,6 +6293,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -6000,6 +6313,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "MISSING",
         "unadmittedFields": [
@@ -6023,6 +6337,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -6040,6 +6355,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "MISSING",
         "unadmittedFields": [
@@ -6061,6 +6377,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "MISSING",
         "unadmittedFields": [
@@ -6084,6 +6401,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -6105,8 +6423,10 @@
           "fallback": "UNSUPPORTED_REGION",
           "nextReviewAt": "2026-10-19T02:43:09.257Z",
           "reasonCode": "PUBLIC_API_NO_DATA",
-          "reviewedAt": "2026-07-21T02:43:09.257Z"
+          "reviewedAt": "2026-07-21T02:43:09.257Z",
+          "supportStartedAt": null
         },
+        "resolutionReviewStatus": "CURRENT",
         "sourceDomain": "realtime_arrivals",
         "status": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
         "unadmittedFields": [
@@ -6128,6 +6448,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -6147,6 +6468,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -6166,6 +6488,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -6186,6 +6509,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -6205,6 +6529,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -6226,8 +6551,10 @@
           "fallback": "UNSUPPORTED_REGION",
           "nextReviewAt": "2026-10-19T02:43:09.257Z",
           "reasonCode": "PUBLIC_API_NO_DATA",
-          "reviewedAt": "2026-07-21T02:43:09.257Z"
+          "reviewedAt": "2026-07-21T02:43:09.257Z",
+          "supportStartedAt": null
         },
+        "resolutionReviewStatus": "CURRENT",
         "sourceDomain": "realtime_arrivals",
         "status": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
         "unadmittedFields": [
@@ -6249,6 +6576,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -6268,6 +6596,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -6287,6 +6616,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -6307,6 +6637,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -6326,6 +6657,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -6347,8 +6679,10 @@
           "fallback": "UNSUPPORTED_REGION",
           "nextReviewAt": "2026-10-19T02:43:09.257Z",
           "reasonCode": "PUBLIC_API_NO_DATA",
-          "reviewedAt": "2026-07-21T02:43:09.257Z"
+          "reviewedAt": "2026-07-21T02:43:09.257Z",
+          "supportStartedAt": null
         },
+        "resolutionReviewStatus": "CURRENT",
         "sourceDomain": "realtime_arrivals",
         "status": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
         "unadmittedFields": [
@@ -6370,6 +6704,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -6389,6 +6724,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -6408,6 +6744,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -6428,6 +6765,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -6445,6 +6783,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "MISSING",
         "unadmittedFields": [
@@ -6468,6 +6807,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -6487,6 +6827,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "MISSING",
         "unadmittedFields": [
@@ -6508,6 +6849,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "MISSING",
         "unadmittedFields": [
@@ -6528,6 +6870,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "MISSING",
         "unadmittedFields": [
@@ -6549,6 +6892,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "MISSING",
         "unadmittedFields": [
@@ -6572,6 +6916,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -6589,6 +6934,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -6610,6 +6956,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -6629,6 +6976,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -6648,6 +6996,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -6668,6 +7017,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -6687,6 +7037,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 5,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "accessibility_facilities",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -6704,6 +7055,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 1,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "realtime_arrivals",
         "status": "MISSING",
         "unadmittedFields": [
@@ -6725,6 +7077,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_graph_topology",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -6744,6 +7097,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 2,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -6763,6 +7117,7 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "schedule_timetable",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
@@ -6783,11 +7138,13 @@
         "releaseTier": "LAUNCH_REQUIRED",
         "requiredFieldCount": 3,
         "resolution": null,
+        "resolutionReviewStatus": null,
         "sourceDomain": "station_line_membership",
         "status": "INVENTORY_ADMITTED",
         "unadmittedFields": []
       }
     ],
+    "supportStartedResolutionCount": 0,
     "terminalCount": 84,
     "terminalRatio": 0.3111,
     "totalCount": 270
@@ -6795,18 +7152,20 @@
   "parentIssue": 2138,
   "regeneration": {
     "command": "node tools/datapack/build-nationwide-coverage-tally.mjs --targets tools/datapack/nationwide-coverage-targets.json --inventory tools/datapack/source-inventory.json --resolutions tools/datapack/release/nationwide-public-api-coverage-resolutions-20260721.json --expected-launch-required-total 270 --output tools/datapack/reports/nationwide-coverage-tally.json",
-    "ledgerPath": "tools/datapack/reports/nationwide-coverage-tally.json"
+    "ledgerPath": "tools/datapack/reports/nationwide-coverage-tally.json",
+    "pairedUpdateKo": "targets·inventory·resolutions를 바꾸는 PR은 이 명령으로 ledger를 함께 재생성하고, tools/datapack/build-nationwide-coverage-tally.test.mjs의 집계 기대 상수(admitted/EU/missing)도 같은 커밋에서 갱신해야 한다. 재생성 누락은 datapack 도구 테스트에서 fail closed 된다."
   },
   "schemaVersion": 1,
   "statusAxis": {
     "dualOperatorRuleKo": "MISSING 중 operator 조건만 풀면 admitted가 되는 requirement는 DUAL_OPERATOR_UNMATCHED로 구분한다. 같은 노선을 커버하는 소스가 있으나 해당 운영기관이 coverageScope에 없는 경우다.",
-    "explicitlyUnsupportedRuleKo": "resolutions 문서의 EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE entry가 정본이다. entry의 evidence 심층 검증과 nextReviewAt 만료 재검토는 wall-clock에 의존하므로 report-coverage-gaps.mjs 게이트 몫이다.",
+    "explicitlyUnsupportedRuleKo": "resolutions 문서의 EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE entry가 정본이다. supportStartedAt이 있는 entry는 게이트와 같이 terminal에서 제외하고 MISSING + resolutionReviewStatus=SUPPORT_STARTED로 남긴다. publicApiQueries 재계산·search plan 대조와 nextReviewAt 만료 재검토는 report-coverage-gaps.mjs 게이트 몫이다.",
     "inventoryAdmittedRuleKo": "source-inventory coverageScope의 (operatorIds, lineIds, sourceDomains) 엄격 매칭으로 domain의 requiredFields를 blockingThreshold 이상 충족한 requirement. 빈 lineIds는 와일드카드가 아니다.",
     "missingKinds": [
       "DUAL_OPERATOR_UNMATCHED",
       "NO_ADMITTED_SOURCE"
     ],
     "outOfScopeAxisKo": "provenance 기반 게이트 SUPPORTED 판정(report-coverage-gaps.mjs --manifest/--provenance)은 별도 축이며 이 ledger가 대체하지 않는다. INVENTORY_ADMITTED는 admission 근사치이고 게이트 통과를 의미하지 않는다.",
+    "resolutionExpiryDivergenceKo": "이 ledger는 wall-clock을 읽지 않으므로 nextReviewAt이 지난 entry도 terminal로 계상한다. 각 tier의 earliestResolutionNextReviewAt이 그 유효 지평이며, 이 시각을 넘기면 입력이 그대로여도 게이트는 해당 entry를 MISSING(EXPIRED)로 판정해 수치가 갈린다 — resolutions 재검토로 해소한다.",
     "values": [
       "INVENTORY_ADMITTED",
       "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",

--- a/tools/datapack/reports/nationwide-coverage-tally.json
+++ b/tools/datapack/reports/nationwide-coverage-tally.json
@@ -1,0 +1,6817 @@
+{
+  "artifactKind": "nationwide-coverage-tally-ledger",
+  "denominator": {
+    "activeLineCount": 36,
+    "activeLineScopeCount": 45,
+    "enhancementDomainCount": 1,
+    "enhancementTotal": 45,
+    "expectedLaunchRequiredTotal": 270,
+    "launchRequiredDomainCount": 6,
+    "launchRequiredTotal": 270
+  },
+  "enhancement": {
+    "byDomain": [
+      {
+        "explicitlyUnsupportedWithEvidenceCount": 0,
+        "inventoryAdmittedCount": 0,
+        "inventoryAdmittedRatio": 0,
+        "missingByKind": {
+          "DUAL_OPERATOR_UNMATCHED": 0,
+          "NO_ADMITTED_SOURCE": 45
+        },
+        "missingCount": 45,
+        "sourceDomain": "demand_reference",
+        "terminalCount": 0,
+        "terminalRatio": 0,
+        "totalCount": 45
+      }
+    ],
+    "byRegion": [
+      {
+        "explicitlyUnsupportedWithEvidenceCount": 0,
+        "inventoryAdmittedCount": 0,
+        "inventoryAdmittedRatio": 0,
+        "missingByKind": {
+          "DUAL_OPERATOR_UNMATCHED": 0,
+          "NO_ADMITTED_SOURCE": 6
+        },
+        "missingCount": 6,
+        "regionId": "busan",
+        "terminalCount": 0,
+        "terminalRatio": 0,
+        "totalCount": 6
+      },
+      {
+        "explicitlyUnsupportedWithEvidenceCount": 0,
+        "inventoryAdmittedCount": 0,
+        "inventoryAdmittedRatio": 0,
+        "missingByKind": {
+          "DUAL_OPERATOR_UNMATCHED": 0,
+          "NO_ADMITTED_SOURCE": 33
+        },
+        "missingCount": 33,
+        "regionId": "capital",
+        "terminalCount": 0,
+        "terminalRatio": 0,
+        "totalCount": 33
+      },
+      {
+        "explicitlyUnsupportedWithEvidenceCount": 0,
+        "inventoryAdmittedCount": 0,
+        "inventoryAdmittedRatio": 0,
+        "missingByKind": {
+          "DUAL_OPERATOR_UNMATCHED": 0,
+          "NO_ADMITTED_SOURCE": 4
+        },
+        "missingCount": 4,
+        "regionId": "daegu",
+        "terminalCount": 0,
+        "terminalRatio": 0,
+        "totalCount": 4
+      },
+      {
+        "explicitlyUnsupportedWithEvidenceCount": 0,
+        "inventoryAdmittedCount": 0,
+        "inventoryAdmittedRatio": 0,
+        "missingByKind": {
+          "DUAL_OPERATOR_UNMATCHED": 0,
+          "NO_ADMITTED_SOURCE": 1
+        },
+        "missingCount": 1,
+        "regionId": "daejeon",
+        "terminalCount": 0,
+        "terminalRatio": 0,
+        "totalCount": 1
+      },
+      {
+        "explicitlyUnsupportedWithEvidenceCount": 0,
+        "inventoryAdmittedCount": 0,
+        "inventoryAdmittedRatio": 0,
+        "missingByKind": {
+          "DUAL_OPERATOR_UNMATCHED": 0,
+          "NO_ADMITTED_SOURCE": 1
+        },
+        "missingCount": 1,
+        "regionId": "gwangju",
+        "terminalCount": 0,
+        "terminalRatio": 0,
+        "totalCount": 1
+      }
+    ],
+    "explicitlyUnsupportedWithEvidenceCount": 0,
+    "inventoryAdmittedCount": 0,
+    "inventoryAdmittedRatio": 0,
+    "missingByKind": {
+      "DUAL_OPERATOR_UNMATCHED": 0,
+      "NO_ADMITTED_SOURCE": 45
+    },
+    "missingCount": 45,
+    "requirements": [
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-ab1a041f6266",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "busan-transportation",
+        "regionId": "busan",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-d74614a04530",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "busan-transportation",
+        "regionId": "busan",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-d812a5bc1e5f",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "busan-transportation",
+        "regionId": "busan",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-eb7b47920390",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "busan-transportation",
+        "regionId": "busan",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-f52eb59d8497",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "busan",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-e4cce88f0d7f",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-72566d06475a",
+        "regionId": "busan",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-15b3b8a93259",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "incheon-transit",
+        "regionId": "capital",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-42b5805f3b5a",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "incheon-transit",
+        "regionId": "capital",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-98718184f016",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "incheon-transit",
+        "regionId": "capital",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-051552e50435",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-41a8c75ec9d8",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-472a81add377",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-54a7b980b7c3",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-558d0bd8312d",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-6e39be0cb6e2",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-e4939a4b4713",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "seoul-4",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-2b2d9eaa53d0",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-07a9e77a02b6",
+        "regionId": "capital",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-aefa08ccc0a9",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-10d7cf275a80",
+        "regionId": "capital",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "shinbundang",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-28e01fb8509d",
+        "regionId": "capital",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-62096860ab09",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-29e323a78a93",
+        "regionId": "capital",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-5500c1600f71",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-2e23276dfa94",
+        "regionId": "capital",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-051552e50435",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-38450e138464",
+        "regionId": "capital",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-30886152e4f8",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-3c623bf1a427",
+        "regionId": "capital",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-8604048b6430",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-5ca780d7dee1",
+        "regionId": "capital",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-e9e9a5b520a4",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-8134e61f8dbd",
+        "regionId": "capital",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-f0e747248a31",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-936e454d0bfb",
+        "regionId": "capital",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-8604048b6430",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-9e999d4aa596",
+        "regionId": "capital",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-828f04afc588",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-b2d80436b438",
+        "regionId": "capital",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-2b2d9eaa53d0",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-c361f9fc17e9",
+        "regionId": "capital",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "seoul-4",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-c361f9fc17e9",
+        "regionId": "capital",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-15b3b8a93259",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-2b2d9eaa53d0",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-3f41718e0833",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-41a8c75ec9d8",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-472a81add377",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-80fc4d5350d4",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "seoul-2",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "seoul-4",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-0ffaa95b1b5d",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "daegu-transportation",
+        "regionId": "daegu",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-5b8d9b05e7e6",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "daegu-transportation",
+        "regionId": "daegu",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-e2938a4cc492",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "daegu-transportation",
+        "regionId": "daegu",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-8f7ed01f290a",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "daegu",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-7051a9c2525c",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "daejeon-transportation",
+        "regionId": "daejeon",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-e57a361e8892",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "gwangju-metropolitan-rapid-transit",
+        "regionId": "gwangju",
+        "releaseTier": "ENHANCEMENT",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "demand_reference",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "hourly_boarding_count",
+          "hourly_alighting_count"
+        ]
+      }
+    ],
+    "terminalCount": 0,
+    "terminalRatio": 0,
+    "totalCount": 45
+  },
+  "inputs": {
+    "inventory": {
+      "path": "tools/datapack/source-inventory.json",
+      "retrievedAt": "2026-06-22",
+      "sha256": "284a5b0ed4d47428531f07594f153bbdf8e18153bdc268049b79ae3df2c9931d"
+    },
+    "resolutions": {
+      "entryCount": 4,
+      "generatedAt": "2026-07-21T02:43:09.257Z",
+      "path": "tools/datapack/release/nationwide-public-api-coverage-resolutions-20260721.json",
+      "sha256": "6b20a8c2a2670b03cb626bad91e80b39ec4bc5e81e69760186487a847ed30a1a"
+    },
+    "targets": {
+      "path": "tools/datapack/nationwide-coverage-targets.json",
+      "sha256": "2715e0bb28a25b2103add14747e74742fcb88f61e4cf357ed68453f20cf6cfc5",
+      "targetVersion": "2026-07-13"
+    }
+  },
+  "issue": 2507,
+  "launchRequired": {
+    "byDomain": [
+      {
+        "explicitlyUnsupportedWithEvidenceCount": 0,
+        "inventoryAdmittedCount": 12,
+        "inventoryAdmittedRatio": 0.2667,
+        "missingByKind": {
+          "DUAL_OPERATOR_UNMATCHED": 1,
+          "NO_ADMITTED_SOURCE": 32
+        },
+        "missingCount": 33,
+        "sourceDomain": "accessibility_facilities",
+        "terminalCount": 12,
+        "terminalRatio": 0.2667,
+        "totalCount": 45
+      },
+      {
+        "explicitlyUnsupportedWithEvidenceCount": 4,
+        "inventoryAdmittedCount": 0,
+        "inventoryAdmittedRatio": 0,
+        "missingByKind": {
+          "DUAL_OPERATOR_UNMATCHED": 0,
+          "NO_ADMITTED_SOURCE": 41
+        },
+        "missingCount": 41,
+        "sourceDomain": "realtime_arrivals",
+        "terminalCount": 4,
+        "terminalRatio": 0.0889,
+        "totalCount": 45
+      },
+      {
+        "explicitlyUnsupportedWithEvidenceCount": 0,
+        "inventoryAdmittedCount": 12,
+        "inventoryAdmittedRatio": 0.2667,
+        "missingByKind": {
+          "DUAL_OPERATOR_UNMATCHED": 1,
+          "NO_ADMITTED_SOURCE": 32
+        },
+        "missingCount": 33,
+        "sourceDomain": "route_graph_topology",
+        "terminalCount": 12,
+        "terminalRatio": 0.2667,
+        "totalCount": 45
+      },
+      {
+        "explicitlyUnsupportedWithEvidenceCount": 0,
+        "inventoryAdmittedCount": 33,
+        "inventoryAdmittedRatio": 0.7333,
+        "missingByKind": {
+          "DUAL_OPERATOR_UNMATCHED": 9,
+          "NO_ADMITTED_SOURCE": 3
+        },
+        "missingCount": 12,
+        "sourceDomain": "route_map_positions",
+        "terminalCount": 33,
+        "terminalRatio": 0.7333,
+        "totalCount": 45
+      },
+      {
+        "explicitlyUnsupportedWithEvidenceCount": 0,
+        "inventoryAdmittedCount": 11,
+        "inventoryAdmittedRatio": 0.2444,
+        "missingByKind": {
+          "DUAL_OPERATOR_UNMATCHED": 0,
+          "NO_ADMITTED_SOURCE": 34
+        },
+        "missingCount": 34,
+        "sourceDomain": "schedule_timetable",
+        "terminalCount": 11,
+        "terminalRatio": 0.2444,
+        "totalCount": 45
+      },
+      {
+        "explicitlyUnsupportedWithEvidenceCount": 0,
+        "inventoryAdmittedCount": 12,
+        "inventoryAdmittedRatio": 0.2667,
+        "missingByKind": {
+          "DUAL_OPERATOR_UNMATCHED": 1,
+          "NO_ADMITTED_SOURCE": 32
+        },
+        "missingCount": 33,
+        "sourceDomain": "station_line_membership",
+        "terminalCount": 12,
+        "terminalRatio": 0.2667,
+        "totalCount": 45
+      }
+    ],
+    "byRegion": [
+      {
+        "explicitlyUnsupportedWithEvidenceCount": 1,
+        "inventoryAdmittedCount": 20,
+        "inventoryAdmittedRatio": 0.5556,
+        "missingByKind": {
+          "DUAL_OPERATOR_UNMATCHED": 0,
+          "NO_ADMITTED_SOURCE": 15
+        },
+        "missingCount": 15,
+        "regionId": "busan",
+        "terminalCount": 21,
+        "terminalRatio": 0.5833,
+        "totalCount": 36
+      },
+      {
+        "explicitlyUnsupportedWithEvidenceCount": 0,
+        "inventoryAdmittedCount": 35,
+        "inventoryAdmittedRatio": 0.1768,
+        "missingByKind": {
+          "DUAL_OPERATOR_UNMATCHED": 12,
+          "NO_ADMITTED_SOURCE": 151
+        },
+        "missingCount": 163,
+        "regionId": "capital",
+        "terminalCount": 35,
+        "terminalRatio": 0.1768,
+        "totalCount": 198
+      },
+      {
+        "explicitlyUnsupportedWithEvidenceCount": 3,
+        "inventoryAdmittedCount": 15,
+        "inventoryAdmittedRatio": 0.625,
+        "missingByKind": {
+          "DUAL_OPERATOR_UNMATCHED": 0,
+          "NO_ADMITTED_SOURCE": 6
+        },
+        "missingCount": 6,
+        "regionId": "daegu",
+        "terminalCount": 18,
+        "terminalRatio": 0.75,
+        "totalCount": 24
+      },
+      {
+        "explicitlyUnsupportedWithEvidenceCount": 0,
+        "inventoryAdmittedCount": 5,
+        "inventoryAdmittedRatio": 0.8333,
+        "missingByKind": {
+          "DUAL_OPERATOR_UNMATCHED": 0,
+          "NO_ADMITTED_SOURCE": 1
+        },
+        "missingCount": 1,
+        "regionId": "daejeon",
+        "terminalCount": 5,
+        "terminalRatio": 0.8333,
+        "totalCount": 6
+      },
+      {
+        "explicitlyUnsupportedWithEvidenceCount": 0,
+        "inventoryAdmittedCount": 5,
+        "inventoryAdmittedRatio": 0.8333,
+        "missingByKind": {
+          "DUAL_OPERATOR_UNMATCHED": 0,
+          "NO_ADMITTED_SOURCE": 1
+        },
+        "missingCount": 1,
+        "regionId": "gwangju",
+        "terminalCount": 5,
+        "terminalRatio": 0.8333,
+        "totalCount": 6
+      }
+    ],
+    "explicitlyUnsupportedWithEvidenceCount": 4,
+    "inventoryAdmittedCount": 80,
+    "inventoryAdmittedRatio": 0.2963,
+    "missingByKind": {
+      "DUAL_OPERATOR_UNMATCHED": 12,
+      "NO_ADMITTED_SOURCE": 174
+    },
+    "missingCount": 186,
+    "requirements": [
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 5,
+        "admittedSourceIds": [
+          "busan-transportation-accessibility"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-ab1a041f6266",
+        "missingKind": null,
+        "operatorId": "busan-transportation",
+        "regionId": "busan",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-ab1a041f6266",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "busan-transportation",
+        "regionId": "busan",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 3,
+        "admittedSourceIds": [
+          "busan-transportation-route-topology"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-ab1a041f6266",
+        "missingKind": null,
+        "operatorId": "busan-transportation",
+        "regionId": "busan",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 2,
+        "admittedSourceIds": [
+          "busan-transportation-route-map-positions"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-ab1a041f6266",
+        "missingKind": null,
+        "operatorId": "busan-transportation",
+        "regionId": "busan",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 3,
+        "admittedSourceIds": [
+          "busan-transportation-timetable"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-ab1a041f6266",
+        "missingKind": null,
+        "operatorId": "busan-transportation",
+        "regionId": "busan",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 3,
+        "admittedSourceIds": [
+          "busan-transportation-route-topology"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-ab1a041f6266",
+        "missingKind": null,
+        "operatorId": "busan-transportation",
+        "regionId": "busan",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 5,
+        "admittedSourceIds": [
+          "busan-transportation-accessibility"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-d74614a04530",
+        "missingKind": null,
+        "operatorId": "busan-transportation",
+        "regionId": "busan",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-d74614a04530",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "busan-transportation",
+        "regionId": "busan",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 3,
+        "admittedSourceIds": [
+          "busan-transportation-route-topology"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-d74614a04530",
+        "missingKind": null,
+        "operatorId": "busan-transportation",
+        "regionId": "busan",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 2,
+        "admittedSourceIds": [
+          "busan-transportation-route-map-positions"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-d74614a04530",
+        "missingKind": null,
+        "operatorId": "busan-transportation",
+        "regionId": "busan",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 3,
+        "admittedSourceIds": [
+          "busan-transportation-timetable"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-d74614a04530",
+        "missingKind": null,
+        "operatorId": "busan-transportation",
+        "regionId": "busan",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 3,
+        "admittedSourceIds": [
+          "busan-transportation-route-topology"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-d74614a04530",
+        "missingKind": null,
+        "operatorId": "busan-transportation",
+        "regionId": "busan",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 5,
+        "admittedSourceIds": [
+          "busan-transportation-accessibility"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-d812a5bc1e5f",
+        "missingKind": null,
+        "operatorId": "busan-transportation",
+        "regionId": "busan",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-d812a5bc1e5f",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "busan-transportation",
+        "regionId": "busan",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 3,
+        "admittedSourceIds": [
+          "busan-transportation-route-topology"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-d812a5bc1e5f",
+        "missingKind": null,
+        "operatorId": "busan-transportation",
+        "regionId": "busan",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 2,
+        "admittedSourceIds": [
+          "busan-transportation-route-map-positions"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-d812a5bc1e5f",
+        "missingKind": null,
+        "operatorId": "busan-transportation",
+        "regionId": "busan",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 3,
+        "admittedSourceIds": [
+          "busan-transportation-timetable"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-d812a5bc1e5f",
+        "missingKind": null,
+        "operatorId": "busan-transportation",
+        "regionId": "busan",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 3,
+        "admittedSourceIds": [
+          "busan-transportation-route-topology"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-d812a5bc1e5f",
+        "missingKind": null,
+        "operatorId": "busan-transportation",
+        "regionId": "busan",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 5,
+        "admittedSourceIds": [
+          "busan-transportation-accessibility"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-eb7b47920390",
+        "missingKind": null,
+        "operatorId": "busan-transportation",
+        "regionId": "busan",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-eb7b47920390",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "busan-transportation",
+        "regionId": "busan",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 3,
+        "admittedSourceIds": [
+          "busan-transportation-route-topology"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-eb7b47920390",
+        "missingKind": null,
+        "operatorId": "busan-transportation",
+        "regionId": "busan",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 2,
+        "admittedSourceIds": [
+          "busan-transportation-route-map-positions"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-eb7b47920390",
+        "missingKind": null,
+        "operatorId": "busan-transportation",
+        "regionId": "busan",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 3,
+        "admittedSourceIds": [
+          "busan-transportation-timetable"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-eb7b47920390",
+        "missingKind": null,
+        "operatorId": "busan-transportation",
+        "regionId": "busan",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 3,
+        "admittedSourceIds": [
+          "busan-transportation-route-topology"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-eb7b47920390",
+        "missingKind": null,
+        "operatorId": "busan-transportation",
+        "regionId": "busan",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-f52eb59d8497",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "busan",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "elevator",
+          "escalator",
+          "wheelchair_lift",
+          "status",
+          "verified_at"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-f52eb59d8497",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "busan",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-f52eb59d8497",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "busan",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "network_edges",
+          "duration_seconds",
+          "distance_meters"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-f52eb59d8497",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "busan",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "route_map_position",
+          "route_map_label_polygon"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-f52eb59d8497",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "busan",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "service_calendar",
+          "trip",
+          "stop_time"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-f52eb59d8497",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "busan",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "line",
+          "station_name",
+          "station_code"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-e4cce88f0d7f",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-72566d06475a",
+        "regionId": "busan",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "elevator",
+          "escalator",
+          "wheelchair_lift",
+          "status",
+          "verified_at"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-e4cce88f0d7f",
+        "missingKind": null,
+        "operatorId": "operator-72566d06475a",
+        "regionId": "busan",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": {
+          "evidenceHash": "378d349c5936090927cf1b8ac894c3377b9beaef3e7377c7cdcbeb3b09bfd022",
+          "fallback": "UNSUPPORTED_REGION",
+          "nextReviewAt": "2026-10-19T02:43:09.257Z",
+          "reasonCode": "PUBLIC_API_NO_DATA",
+          "reviewedAt": "2026-07-21T02:43:09.257Z"
+        },
+        "sourceDomain": "realtime_arrivals",
+        "status": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-e4cce88f0d7f",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-72566d06475a",
+        "regionId": "busan",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "network_edges",
+          "duration_seconds",
+          "distance_meters"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-e4cce88f0d7f",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-72566d06475a",
+        "regionId": "busan",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "route_map_position",
+          "route_map_label_polygon"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-e4cce88f0d7f",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-72566d06475a",
+        "regionId": "busan",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "service_calendar",
+          "trip",
+          "stop_time"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-e4cce88f0d7f",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-72566d06475a",
+        "regionId": "busan",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "line",
+          "station_name",
+          "station_code"
+        ]
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 5,
+        "admittedSourceIds": [
+          "incheon-transit-accessibility"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-15b3b8a93259",
+        "missingKind": null,
+        "operatorId": "incheon-transit",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-15b3b8a93259",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "incheon-transit",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 3,
+        "admittedSourceIds": [
+          "incheon-transit-station-info"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-15b3b8a93259",
+        "missingKind": null,
+        "operatorId": "incheon-transit",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 2,
+        "admittedSourceIds": [
+          "incheon-transit-station-info"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-15b3b8a93259",
+        "missingKind": null,
+        "operatorId": "incheon-transit",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-15b3b8a93259",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "incheon-transit",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "service_calendar",
+          "trip",
+          "stop_time"
+        ]
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 3,
+        "admittedSourceIds": [
+          "incheon-transit-station-info"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-15b3b8a93259",
+        "missingKind": null,
+        "operatorId": "incheon-transit",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 5,
+        "admittedSourceIds": [
+          "incheon-transit-accessibility"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-42b5805f3b5a",
+        "missingKind": null,
+        "operatorId": "incheon-transit",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-42b5805f3b5a",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "incheon-transit",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 3,
+        "admittedSourceIds": [
+          "incheon-transit-station-info"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-42b5805f3b5a",
+        "missingKind": null,
+        "operatorId": "incheon-transit",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 2,
+        "admittedSourceIds": [
+          "incheon-transit-station-info"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-42b5805f3b5a",
+        "missingKind": null,
+        "operatorId": "incheon-transit",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 3,
+        "admittedSourceIds": [
+          "incheon-line2-train-timetable"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-42b5805f3b5a",
+        "missingKind": null,
+        "operatorId": "incheon-transit",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 3,
+        "admittedSourceIds": [
+          "incheon-transit-station-info"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-42b5805f3b5a",
+        "missingKind": null,
+        "operatorId": "incheon-transit",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 5,
+        "admittedSourceIds": [
+          "incheon-transit-accessibility"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-98718184f016",
+        "missingKind": null,
+        "operatorId": "incheon-transit",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-98718184f016",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "incheon-transit",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 3,
+        "admittedSourceIds": [
+          "incheon-transit-station-info"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-98718184f016",
+        "missingKind": null,
+        "operatorId": "incheon-transit",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 2,
+        "admittedSourceIds": [
+          "incheon-transit-station-info"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-98718184f016",
+        "missingKind": null,
+        "operatorId": "incheon-transit",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 3,
+        "admittedSourceIds": [
+          "incheon-line1-train-timetable"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-98718184f016",
+        "missingKind": null,
+        "operatorId": "incheon-transit",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 3,
+        "admittedSourceIds": [
+          "incheon-transit-station-info"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-98718184f016",
+        "missingKind": null,
+        "operatorId": "incheon-transit",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-051552e50435",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "elevator",
+          "escalator",
+          "wheelchair_lift",
+          "status",
+          "verified_at"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-051552e50435",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-051552e50435",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "network_edges",
+          "duration_seconds",
+          "distance_meters"
+        ]
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 2,
+        "admittedSourceIds": [
+          "kric-seohae-route-map-positions"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-051552e50435",
+        "missingKind": null,
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-051552e50435",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "service_calendar",
+          "trip",
+          "stop_time"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-051552e50435",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "line",
+          "station_name",
+          "station_code"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-41a8c75ec9d8",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "elevator",
+          "escalator",
+          "wheelchair_lift",
+          "status",
+          "verified_at"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-41a8c75ec9d8",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-41a8c75ec9d8",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "network_edges",
+          "duration_seconds",
+          "distance_meters"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": {
+          "coveringOperatorIds": [
+            "seoul-metro"
+          ],
+          "coveringSourceIds": [
+            "seoul-metro-route-map-positions"
+          ]
+        },
+        "lineId": "line-41a8c75ec9d8",
+        "missingKind": "DUAL_OPERATOR_UNMATCHED",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "route_map_position",
+          "route_map_label_polygon"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-41a8c75ec9d8",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "service_calendar",
+          "trip",
+          "stop_time"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-41a8c75ec9d8",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "line",
+          "station_name",
+          "station_code"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-472a81add377",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "elevator",
+          "escalator",
+          "wheelchair_lift",
+          "status",
+          "verified_at"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-472a81add377",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-472a81add377",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "network_edges",
+          "duration_seconds",
+          "distance_meters"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": {
+          "coveringOperatorIds": [
+            "seoul-metro"
+          ],
+          "coveringSourceIds": [
+            "seoul-metro-route-map-positions"
+          ]
+        },
+        "lineId": "line-472a81add377",
+        "missingKind": "DUAL_OPERATOR_UNMATCHED",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "route_map_position",
+          "route_map_label_polygon"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-472a81add377",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "service_calendar",
+          "trip",
+          "stop_time"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-472a81add377",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "line",
+          "station_name",
+          "station_code"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-54a7b980b7c3",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "elevator",
+          "escalator",
+          "wheelchair_lift",
+          "status",
+          "verified_at"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-54a7b980b7c3",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-54a7b980b7c3",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "network_edges",
+          "duration_seconds",
+          "distance_meters"
+        ]
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 2,
+        "admittedSourceIds": [
+          "kric-gyeongchun-route-map-positions"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-54a7b980b7c3",
+        "missingKind": null,
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-54a7b980b7c3",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "service_calendar",
+          "trip",
+          "stop_time"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-54a7b980b7c3",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "line",
+          "station_name",
+          "station_code"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-558d0bd8312d",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "elevator",
+          "escalator",
+          "wheelchair_lift",
+          "status",
+          "verified_at"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-558d0bd8312d",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-558d0bd8312d",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "network_edges",
+          "duration_seconds",
+          "distance_meters"
+        ]
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 2,
+        "admittedSourceIds": [
+          "kric-suin-bundang-route-map-positions"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-558d0bd8312d",
+        "missingKind": null,
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-558d0bd8312d",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "service_calendar",
+          "trip",
+          "stop_time"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-558d0bd8312d",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "line",
+          "station_name",
+          "station_code"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-6e39be0cb6e2",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "elevator",
+          "escalator",
+          "wheelchair_lift",
+          "status",
+          "verified_at"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-6e39be0cb6e2",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-6e39be0cb6e2",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "network_edges",
+          "duration_seconds",
+          "distance_meters"
+        ]
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 2,
+        "admittedSourceIds": [
+          "kric-gyeongui-jungang-route-map-positions"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-6e39be0cb6e2",
+        "missingKind": null,
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-6e39be0cb6e2",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "service_calendar",
+          "trip",
+          "stop_time"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-6e39be0cb6e2",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "line",
+          "station_name",
+          "station_code"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-e4939a4b4713",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "elevator",
+          "escalator",
+          "wheelchair_lift",
+          "status",
+          "verified_at"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-e4939a4b4713",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-e4939a4b4713",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "network_edges",
+          "duration_seconds",
+          "distance_meters"
+        ]
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 2,
+        "admittedSourceIds": [
+          "kric-gyeonggang-route-map-positions"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-e4939a4b4713",
+        "missingKind": null,
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-e4939a4b4713",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "service_calendar",
+          "trip",
+          "stop_time"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-e4939a4b4713",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "line",
+          "station_name",
+          "station_code"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "seoul-4",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "elevator",
+          "escalator",
+          "wheelchair_lift",
+          "status",
+          "verified_at"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "seoul-4",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "seoul-4",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "network_edges",
+          "duration_seconds",
+          "distance_meters"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": {
+          "coveringOperatorIds": [
+            "seoul-metro"
+          ],
+          "coveringSourceIds": [
+            "seoul-metro-route-map-positions"
+          ]
+        },
+        "lineId": "seoul-4",
+        "missingKind": "DUAL_OPERATOR_UNMATCHED",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "route_map_position",
+          "route_map_label_polygon"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "seoul-4",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "service_calendar",
+          "trip",
+          "stop_time"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "seoul-4",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "line",
+          "station_name",
+          "station_code"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-2b2d9eaa53d0",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-07a9e77a02b6",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "elevator",
+          "escalator",
+          "wheelchair_lift",
+          "status",
+          "verified_at"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-2b2d9eaa53d0",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-07a9e77a02b6",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-2b2d9eaa53d0",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-07a9e77a02b6",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "network_edges",
+          "duration_seconds",
+          "distance_meters"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": {
+          "coveringOperatorIds": [
+            "seoul-metro"
+          ],
+          "coveringSourceIds": [
+            "seoul-metro-route-map-positions"
+          ]
+        },
+        "lineId": "line-2b2d9eaa53d0",
+        "missingKind": "DUAL_OPERATOR_UNMATCHED",
+        "operatorId": "operator-07a9e77a02b6",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "route_map_position",
+          "route_map_label_polygon"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-2b2d9eaa53d0",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-07a9e77a02b6",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "service_calendar",
+          "trip",
+          "stop_time"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-2b2d9eaa53d0",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-07a9e77a02b6",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "line",
+          "station_name",
+          "station_code"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-aefa08ccc0a9",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-10d7cf275a80",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "elevator",
+          "escalator",
+          "wheelchair_lift",
+          "status",
+          "verified_at"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-aefa08ccc0a9",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-10d7cf275a80",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-aefa08ccc0a9",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-10d7cf275a80",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "network_edges",
+          "duration_seconds",
+          "distance_meters"
+        ]
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 2,
+        "admittedSourceIds": [
+          "kric-sillim-route-map-positions"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-aefa08ccc0a9",
+        "missingKind": null,
+        "operatorId": "operator-10d7cf275a80",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-aefa08ccc0a9",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-10d7cf275a80",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "service_calendar",
+          "trip",
+          "stop_time"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-aefa08ccc0a9",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-10d7cf275a80",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "line",
+          "station_name",
+          "station_code"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "shinbundang",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-28e01fb8509d",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "elevator",
+          "escalator",
+          "wheelchair_lift",
+          "status",
+          "verified_at"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "shinbundang",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-28e01fb8509d",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "shinbundang",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-28e01fb8509d",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "network_edges",
+          "duration_seconds",
+          "distance_meters"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": {
+          "coveringOperatorIds": [
+            "seoul-metro"
+          ],
+          "coveringSourceIds": [
+            "kric-shinbundang-route-map-positions"
+          ]
+        },
+        "lineId": "shinbundang",
+        "missingKind": "DUAL_OPERATOR_UNMATCHED",
+        "operatorId": "operator-28e01fb8509d",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "route_map_position",
+          "route_map_label_polygon"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "shinbundang",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-28e01fb8509d",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "service_calendar",
+          "trip",
+          "stop_time"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "shinbundang",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-28e01fb8509d",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "line",
+          "station_name",
+          "station_code"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-62096860ab09",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-29e323a78a93",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "elevator",
+          "escalator",
+          "wheelchair_lift",
+          "status",
+          "verified_at"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-62096860ab09",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-29e323a78a93",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-62096860ab09",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-29e323a78a93",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "network_edges",
+          "duration_seconds",
+          "distance_meters"
+        ]
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 2,
+        "admittedSourceIds": [
+          "kric-uijeongbu-route-map-positions"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-62096860ab09",
+        "missingKind": null,
+        "operatorId": "operator-29e323a78a93",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-62096860ab09",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-29e323a78a93",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "service_calendar",
+          "trip",
+          "stop_time"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-62096860ab09",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-29e323a78a93",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "line",
+          "station_name",
+          "station_code"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-5500c1600f71",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-2e23276dfa94",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "elevator",
+          "escalator",
+          "wheelchair_lift",
+          "status",
+          "verified_at"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-5500c1600f71",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-2e23276dfa94",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-5500c1600f71",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-2e23276dfa94",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "network_edges",
+          "duration_seconds",
+          "distance_meters"
+        ]
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 2,
+        "admittedSourceIds": [
+          "kric-gimpo-goldline-route-map-positions"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-5500c1600f71",
+        "missingKind": null,
+        "operatorId": "operator-2e23276dfa94",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-5500c1600f71",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-2e23276dfa94",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "service_calendar",
+          "trip",
+          "stop_time"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-5500c1600f71",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-2e23276dfa94",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "line",
+          "station_name",
+          "station_code"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-051552e50435",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-38450e138464",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "elevator",
+          "escalator",
+          "wheelchair_lift",
+          "status",
+          "verified_at"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-051552e50435",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-38450e138464",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-051552e50435",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-38450e138464",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "network_edges",
+          "duration_seconds",
+          "distance_meters"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": {
+          "coveringOperatorIds": [
+            "korail"
+          ],
+          "coveringSourceIds": [
+            "kric-seohae-route-map-positions"
+          ]
+        },
+        "lineId": "line-051552e50435",
+        "missingKind": "DUAL_OPERATOR_UNMATCHED",
+        "operatorId": "operator-38450e138464",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "route_map_position",
+          "route_map_label_polygon"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-051552e50435",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-38450e138464",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "service_calendar",
+          "trip",
+          "stop_time"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-051552e50435",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-38450e138464",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "line",
+          "station_name",
+          "station_code"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-30886152e4f8",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-3c623bf1a427",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "elevator",
+          "escalator",
+          "wheelchair_lift",
+          "status",
+          "verified_at"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-30886152e4f8",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-3c623bf1a427",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-30886152e4f8",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-3c623bf1a427",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "network_edges",
+          "duration_seconds",
+          "distance_meters"
+        ]
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 2,
+        "admittedSourceIds": [
+          "kric-ui-sinseol-route-map-positions"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-30886152e4f8",
+        "missingKind": null,
+        "operatorId": "operator-3c623bf1a427",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-30886152e4f8",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-3c623bf1a427",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "service_calendar",
+          "trip",
+          "stop_time"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-30886152e4f8",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-3c623bf1a427",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "line",
+          "station_name",
+          "station_code"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-8604048b6430",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-5ca780d7dee1",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "elevator",
+          "escalator",
+          "wheelchair_lift",
+          "status",
+          "verified_at"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-8604048b6430",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-5ca780d7dee1",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-8604048b6430",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-5ca780d7dee1",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "network_edges",
+          "duration_seconds",
+          "distance_meters"
+        ]
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 2,
+        "admittedSourceIds": [
+          "kric-gtx-a-route-map-positions"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-8604048b6430",
+        "missingKind": null,
+        "operatorId": "operator-5ca780d7dee1",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-8604048b6430",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-5ca780d7dee1",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "service_calendar",
+          "trip",
+          "stop_time"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-8604048b6430",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-5ca780d7dee1",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "line",
+          "station_name",
+          "station_code"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-e9e9a5b520a4",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-8134e61f8dbd",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "elevator",
+          "escalator",
+          "wheelchair_lift",
+          "status",
+          "verified_at"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-e9e9a5b520a4",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-8134e61f8dbd",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-e9e9a5b520a4",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-8134e61f8dbd",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "network_edges",
+          "duration_seconds",
+          "distance_meters"
+        ]
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 2,
+        "admittedSourceIds": [
+          "kric-airport-railroad-route-map-positions"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-e9e9a5b520a4",
+        "missingKind": null,
+        "operatorId": "operator-8134e61f8dbd",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-e9e9a5b520a4",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-8134e61f8dbd",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "service_calendar",
+          "trip",
+          "stop_time"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-e9e9a5b520a4",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-8134e61f8dbd",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "line",
+          "station_name",
+          "station_code"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-f0e747248a31",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-936e454d0bfb",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "elevator",
+          "escalator",
+          "wheelchair_lift",
+          "status",
+          "verified_at"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-f0e747248a31",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-936e454d0bfb",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-f0e747248a31",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-936e454d0bfb",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "network_edges",
+          "duration_seconds",
+          "distance_meters"
+        ]
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 2,
+        "admittedSourceIds": [
+          "kric-seoul-metro-line9-1-route-map-positions",
+          "seoul-metro-line9-23-route-map-positions"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-f0e747248a31",
+        "missingKind": null,
+        "operatorId": "operator-936e454d0bfb",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-f0e747248a31",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-936e454d0bfb",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "service_calendar",
+          "trip",
+          "stop_time"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-f0e747248a31",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-936e454d0bfb",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "line",
+          "station_name",
+          "station_code"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-8604048b6430",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-9e999d4aa596",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "elevator",
+          "escalator",
+          "wheelchair_lift",
+          "status",
+          "verified_at"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-8604048b6430",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-9e999d4aa596",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-8604048b6430",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-9e999d4aa596",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "network_edges",
+          "duration_seconds",
+          "distance_meters"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": {
+          "coveringOperatorIds": [
+            "operator-5ca780d7dee1"
+          ],
+          "coveringSourceIds": [
+            "kric-gtx-a-route-map-positions"
+          ]
+        },
+        "lineId": "line-8604048b6430",
+        "missingKind": "DUAL_OPERATOR_UNMATCHED",
+        "operatorId": "operator-9e999d4aa596",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "route_map_position",
+          "route_map_label_polygon"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-8604048b6430",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-9e999d4aa596",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "service_calendar",
+          "trip",
+          "stop_time"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-8604048b6430",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-9e999d4aa596",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "line",
+          "station_name",
+          "station_code"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-828f04afc588",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-b2d80436b438",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "elevator",
+          "escalator",
+          "wheelchair_lift",
+          "status",
+          "verified_at"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-828f04afc588",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-b2d80436b438",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-828f04afc588",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-b2d80436b438",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "network_edges",
+          "duration_seconds",
+          "distance_meters"
+        ]
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 2,
+        "admittedSourceIds": [
+          "kric-everline-route-map-positions"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-828f04afc588",
+        "missingKind": null,
+        "operatorId": "operator-b2d80436b438",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-828f04afc588",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-b2d80436b438",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "service_calendar",
+          "trip",
+          "stop_time"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-828f04afc588",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-b2d80436b438",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "line",
+          "station_name",
+          "station_code"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-2b2d9eaa53d0",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-c361f9fc17e9",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "elevator",
+          "escalator",
+          "wheelchair_lift",
+          "status",
+          "verified_at"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-2b2d9eaa53d0",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-c361f9fc17e9",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-2b2d9eaa53d0",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-c361f9fc17e9",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "network_edges",
+          "duration_seconds",
+          "distance_meters"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": {
+          "coveringOperatorIds": [
+            "seoul-metro"
+          ],
+          "coveringSourceIds": [
+            "seoul-metro-route-map-positions"
+          ]
+        },
+        "lineId": "line-2b2d9eaa53d0",
+        "missingKind": "DUAL_OPERATOR_UNMATCHED",
+        "operatorId": "operator-c361f9fc17e9",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "route_map_position",
+          "route_map_label_polygon"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-2b2d9eaa53d0",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-c361f9fc17e9",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "service_calendar",
+          "trip",
+          "stop_time"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-2b2d9eaa53d0",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-c361f9fc17e9",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "line",
+          "station_name",
+          "station_code"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "seoul-4",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-c361f9fc17e9",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "elevator",
+          "escalator",
+          "wheelchair_lift",
+          "status",
+          "verified_at"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "seoul-4",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-c361f9fc17e9",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "seoul-4",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-c361f9fc17e9",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "network_edges",
+          "duration_seconds",
+          "distance_meters"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": {
+          "coveringOperatorIds": [
+            "seoul-metro"
+          ],
+          "coveringSourceIds": [
+            "seoul-metro-route-map-positions"
+          ]
+        },
+        "lineId": "seoul-4",
+        "missingKind": "DUAL_OPERATOR_UNMATCHED",
+        "operatorId": "operator-c361f9fc17e9",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "route_map_position",
+          "route_map_label_polygon"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "seoul-4",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-c361f9fc17e9",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "service_calendar",
+          "trip",
+          "stop_time"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "seoul-4",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "operator-c361f9fc17e9",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "line",
+          "station_name",
+          "station_code"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": {
+          "coveringOperatorIds": [
+            "incheon-transit"
+          ],
+          "coveringSourceIds": [
+            "incheon-transit-accessibility"
+          ]
+        },
+        "lineId": "line-15b3b8a93259",
+        "missingKind": "DUAL_OPERATOR_UNMATCHED",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "elevator",
+          "escalator",
+          "wheelchair_lift",
+          "status",
+          "verified_at"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-15b3b8a93259",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": {
+          "coveringOperatorIds": [
+            "incheon-transit"
+          ],
+          "coveringSourceIds": [
+            "incheon-transit-station-info"
+          ]
+        },
+        "lineId": "line-15b3b8a93259",
+        "missingKind": "DUAL_OPERATOR_UNMATCHED",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "network_edges",
+          "duration_seconds",
+          "distance_meters"
+        ]
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 2,
+        "admittedSourceIds": [
+          "seoul-metro-route-map-positions"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-15b3b8a93259",
+        "missingKind": null,
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-15b3b8a93259",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "service_calendar",
+          "trip",
+          "stop_time"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": {
+          "coveringOperatorIds": [
+            "incheon-transit"
+          ],
+          "coveringSourceIds": [
+            "incheon-transit-station-info"
+          ]
+        },
+        "lineId": "line-15b3b8a93259",
+        "missingKind": "DUAL_OPERATOR_UNMATCHED",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "line",
+          "station_name",
+          "station_code"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-2b2d9eaa53d0",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "elevator",
+          "escalator",
+          "wheelchair_lift",
+          "status",
+          "verified_at"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-2b2d9eaa53d0",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-2b2d9eaa53d0",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "network_edges",
+          "duration_seconds",
+          "distance_meters"
+        ]
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 2,
+        "admittedSourceIds": [
+          "seoul-metro-route-map-positions"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-2b2d9eaa53d0",
+        "missingKind": null,
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-2b2d9eaa53d0",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "service_calendar",
+          "trip",
+          "stop_time"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-2b2d9eaa53d0",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "line",
+          "station_name",
+          "station_code"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-3f41718e0833",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "elevator",
+          "escalator",
+          "wheelchair_lift",
+          "status",
+          "verified_at"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-3f41718e0833",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-3f41718e0833",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "network_edges",
+          "duration_seconds",
+          "distance_meters"
+        ]
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 2,
+        "admittedSourceIds": [
+          "seoul-metro-route-map-positions"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-3f41718e0833",
+        "missingKind": null,
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-3f41718e0833",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "service_calendar",
+          "trip",
+          "stop_time"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-3f41718e0833",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "line",
+          "station_name",
+          "station_code"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-41a8c75ec9d8",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "elevator",
+          "escalator",
+          "wheelchair_lift",
+          "status",
+          "verified_at"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-41a8c75ec9d8",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-41a8c75ec9d8",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "network_edges",
+          "duration_seconds",
+          "distance_meters"
+        ]
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 2,
+        "admittedSourceIds": [
+          "seoul-metro-route-map-positions"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-41a8c75ec9d8",
+        "missingKind": null,
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-41a8c75ec9d8",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "service_calendar",
+          "trip",
+          "stop_time"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-41a8c75ec9d8",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "line",
+          "station_name",
+          "station_code"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-472a81add377",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "elevator",
+          "escalator",
+          "wheelchair_lift",
+          "status",
+          "verified_at"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-472a81add377",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-472a81add377",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "network_edges",
+          "duration_seconds",
+          "distance_meters"
+        ]
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 2,
+        "admittedSourceIds": [
+          "seoul-metro-route-map-positions"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-472a81add377",
+        "missingKind": null,
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-472a81add377",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "service_calendar",
+          "trip",
+          "stop_time"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-472a81add377",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "line",
+          "station_name",
+          "station_code"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-80fc4d5350d4",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "elevator",
+          "escalator",
+          "wheelchair_lift",
+          "status",
+          "verified_at"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-80fc4d5350d4",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-80fc4d5350d4",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "network_edges",
+          "duration_seconds",
+          "distance_meters"
+        ]
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 2,
+        "admittedSourceIds": [
+          "seoul-metro-route-map-positions"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-80fc4d5350d4",
+        "missingKind": null,
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-80fc4d5350d4",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "service_calendar",
+          "trip",
+          "stop_time"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-80fc4d5350d4",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "line",
+          "station_name",
+          "station_code"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "seoul-2",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "elevator",
+          "escalator",
+          "wheelchair_lift",
+          "status",
+          "verified_at"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "seoul-2",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "seoul-2",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "network_edges",
+          "duration_seconds",
+          "distance_meters"
+        ]
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 2,
+        "admittedSourceIds": [
+          "seoul-metro-route-map-positions"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "seoul-2",
+        "missingKind": null,
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "seoul-2",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "service_calendar",
+          "trip",
+          "stop_time"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "seoul-2",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "line",
+          "station_name",
+          "station_code"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "seoul-4",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "elevator",
+          "escalator",
+          "wheelchair_lift",
+          "status",
+          "verified_at"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "seoul-4",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "seoul-4",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "network_edges",
+          "duration_seconds",
+          "distance_meters"
+        ]
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 2,
+        "admittedSourceIds": [
+          "seoul-metro-route-map-positions"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "seoul-4",
+        "missingKind": null,
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "seoul-4",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "service_calendar",
+          "trip",
+          "stop_time"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "seoul-4",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "seoul-metro",
+        "regionId": "capital",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "line",
+          "station_name",
+          "station_code"
+        ]
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 5,
+        "admittedSourceIds": [
+          "daegu-transportation-accessibility"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-0ffaa95b1b5d",
+        "missingKind": null,
+        "operatorId": "daegu-transportation",
+        "regionId": "daegu",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-0ffaa95b1b5d",
+        "missingKind": null,
+        "operatorId": "daegu-transportation",
+        "regionId": "daegu",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": {
+          "evidenceHash": "26707fe21d281ec5b41d7b5809ef026d99b4a256ee551abba85f28f814c684e0",
+          "fallback": "UNSUPPORTED_REGION",
+          "nextReviewAt": "2026-10-19T02:43:09.257Z",
+          "reasonCode": "PUBLIC_API_NO_DATA",
+          "reviewedAt": "2026-07-21T02:43:09.257Z"
+        },
+        "sourceDomain": "realtime_arrivals",
+        "status": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 3,
+        "admittedSourceIds": [
+          "daegu-line3-route-topology"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-0ffaa95b1b5d",
+        "missingKind": null,
+        "operatorId": "daegu-transportation",
+        "regionId": "daegu",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 2,
+        "admittedSourceIds": [
+          "daegu-transportation-route-map-positions"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-0ffaa95b1b5d",
+        "missingKind": null,
+        "operatorId": "daegu-transportation",
+        "regionId": "daegu",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 3,
+        "admittedSourceIds": [
+          "daegu-line3-train-timetable"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-0ffaa95b1b5d",
+        "missingKind": null,
+        "operatorId": "daegu-transportation",
+        "regionId": "daegu",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 3,
+        "admittedSourceIds": [
+          "daegu-line3-route-topology",
+          "molit-urban-rail-full-route-daegu-line3-membership"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-0ffaa95b1b5d",
+        "missingKind": null,
+        "operatorId": "daegu-transportation",
+        "regionId": "daegu",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 5,
+        "admittedSourceIds": [
+          "daegu-transportation-accessibility"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-5b8d9b05e7e6",
+        "missingKind": null,
+        "operatorId": "daegu-transportation",
+        "regionId": "daegu",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-5b8d9b05e7e6",
+        "missingKind": null,
+        "operatorId": "daegu-transportation",
+        "regionId": "daegu",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": {
+          "evidenceHash": "6dd3b2105095af993d0b3baf5d880cfcc21b78e9e73e4617bd025a62459a19d8",
+          "fallback": "UNSUPPORTED_REGION",
+          "nextReviewAt": "2026-10-19T02:43:09.257Z",
+          "reasonCode": "PUBLIC_API_NO_DATA",
+          "reviewedAt": "2026-07-21T02:43:09.257Z"
+        },
+        "sourceDomain": "realtime_arrivals",
+        "status": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 3,
+        "admittedSourceIds": [
+          "daegu-line1-route-topology"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-5b8d9b05e7e6",
+        "missingKind": null,
+        "operatorId": "daegu-transportation",
+        "regionId": "daegu",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 2,
+        "admittedSourceIds": [
+          "daegu-transportation-route-map-positions"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-5b8d9b05e7e6",
+        "missingKind": null,
+        "operatorId": "daegu-transportation",
+        "regionId": "daegu",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 3,
+        "admittedSourceIds": [
+          "daegu-line1-train-timetable"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-5b8d9b05e7e6",
+        "missingKind": null,
+        "operatorId": "daegu-transportation",
+        "regionId": "daegu",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 3,
+        "admittedSourceIds": [
+          "daegu-line1-route-topology",
+          "molit-urban-rail-full-route-daegu-line1-membership"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-5b8d9b05e7e6",
+        "missingKind": null,
+        "operatorId": "daegu-transportation",
+        "regionId": "daegu",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 5,
+        "admittedSourceIds": [
+          "daegu-transportation-accessibility"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-e2938a4cc492",
+        "missingKind": null,
+        "operatorId": "daegu-transportation",
+        "regionId": "daegu",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-e2938a4cc492",
+        "missingKind": null,
+        "operatorId": "daegu-transportation",
+        "regionId": "daegu",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": {
+          "evidenceHash": "294add5285742f58dd92ea97c599dd8203a9c8b96784ffa2a822d33a10cfaa35",
+          "fallback": "UNSUPPORTED_REGION",
+          "nextReviewAt": "2026-10-19T02:43:09.257Z",
+          "reasonCode": "PUBLIC_API_NO_DATA",
+          "reviewedAt": "2026-07-21T02:43:09.257Z"
+        },
+        "sourceDomain": "realtime_arrivals",
+        "status": "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 3,
+        "admittedSourceIds": [
+          "daegu-line2-route-topology"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-e2938a4cc492",
+        "missingKind": null,
+        "operatorId": "daegu-transportation",
+        "regionId": "daegu",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 2,
+        "admittedSourceIds": [
+          "daegu-transportation-route-map-positions"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-e2938a4cc492",
+        "missingKind": null,
+        "operatorId": "daegu-transportation",
+        "regionId": "daegu",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 3,
+        "admittedSourceIds": [
+          "daegu-line2-train-timetable"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-e2938a4cc492",
+        "missingKind": null,
+        "operatorId": "daegu-transportation",
+        "regionId": "daegu",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 3,
+        "admittedSourceIds": [
+          "daegu-line2-route-topology",
+          "molit-urban-rail-full-route-daegu-line2-membership"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-e2938a4cc492",
+        "missingKind": null,
+        "operatorId": "daegu-transportation",
+        "regionId": "daegu",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-8f7ed01f290a",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "daegu",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "elevator",
+          "escalator",
+          "wheelchair_lift",
+          "status",
+          "verified_at"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-8f7ed01f290a",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "daegu",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-8f7ed01f290a",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "daegu",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "network_edges",
+          "duration_seconds",
+          "distance_meters"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-8f7ed01f290a",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "daegu",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "route_map_position",
+          "route_map_label_polygon"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-8f7ed01f290a",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "daegu",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "service_calendar",
+          "trip",
+          "stop_time"
+        ]
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-8f7ed01f290a",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "korail",
+        "regionId": "daegu",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "line",
+          "station_name",
+          "station_code"
+        ]
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 5,
+        "admittedSourceIds": [
+          "daejeon-transportation-accessibility"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-7051a9c2525c",
+        "missingKind": null,
+        "operatorId": "daejeon-transportation",
+        "regionId": "daejeon",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-7051a9c2525c",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "daejeon-transportation",
+        "regionId": "daejeon",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 3,
+        "admittedSourceIds": [
+          "daejeon-station-distance-fare"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-7051a9c2525c",
+        "missingKind": null,
+        "operatorId": "daejeon-transportation",
+        "regionId": "daejeon",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 2,
+        "admittedSourceIds": [
+          "daejeon-transportation-route-map-positions"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-7051a9c2525c",
+        "missingKind": null,
+        "operatorId": "daejeon-transportation",
+        "regionId": "daejeon",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 3,
+        "admittedSourceIds": [
+          "daejeon-train-timetable"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-7051a9c2525c",
+        "missingKind": null,
+        "operatorId": "daejeon-transportation",
+        "regionId": "daejeon",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 3,
+        "admittedSourceIds": [
+          "daejeon-station-distance-fare",
+          "molit-urban-rail-full-route-daejeon-membership"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-7051a9c2525c",
+        "missingKind": null,
+        "operatorId": "daejeon-transportation",
+        "regionId": "daejeon",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 5,
+        "admittedSourceIds": [
+          "gwangju-transportation-accessibility"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-e57a361e8892",
+        "missingKind": null,
+        "operatorId": "gwangju-metropolitan-rapid-transit",
+        "regionId": "gwangju",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 5,
+        "resolution": null,
+        "sourceDomain": "accessibility_facilities",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 0,
+        "admittedFieldCount": 0,
+        "admittedSourceIds": [],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-e57a361e8892",
+        "missingKind": "NO_ADMITTED_SOURCE",
+        "operatorId": "gwangju-metropolitan-rapid-transit",
+        "regionId": "gwangju",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 1,
+        "resolution": null,
+        "sourceDomain": "realtime_arrivals",
+        "status": "MISSING",
+        "unadmittedFields": [
+          "realtime_arrival_reference"
+        ]
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 3,
+        "admittedSourceIds": [
+          "gwangju-transportation-route-topology"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-e57a361e8892",
+        "missingKind": null,
+        "operatorId": "gwangju-metropolitan-rapid-transit",
+        "regionId": "gwangju",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "route_graph_topology",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 2,
+        "admittedSourceIds": [
+          "gwangju-transportation-route-map-positions"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-e57a361e8892",
+        "missingKind": null,
+        "operatorId": "gwangju-metropolitan-rapid-transit",
+        "regionId": "gwangju",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 2,
+        "resolution": null,
+        "sourceDomain": "route_map_positions",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 3,
+        "admittedSourceIds": [
+          "gwangju-transportation-cyberstation-timetable"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-e57a361e8892",
+        "missingKind": null,
+        "operatorId": "gwangju-metropolitan-rapid-transit",
+        "regionId": "gwangju",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "schedule_timetable",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      },
+      {
+        "admissionRatio": 1,
+        "admittedFieldCount": 3,
+        "admittedSourceIds": [
+          "gwangju-transportation-route-topology",
+          "molit-urban-rail-full-route-gwangju-membership"
+        ],
+        "blockingThreshold": 1,
+        "dualOperator": null,
+        "lineId": "line-e57a361e8892",
+        "missingKind": null,
+        "operatorId": "gwangju-metropolitan-rapid-transit",
+        "regionId": "gwangju",
+        "releaseTier": "LAUNCH_REQUIRED",
+        "requiredFieldCount": 3,
+        "resolution": null,
+        "sourceDomain": "station_line_membership",
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
+      }
+    ],
+    "terminalCount": 84,
+    "terminalRatio": 0.3111,
+    "totalCount": 270
+  },
+  "parentIssue": 2138,
+  "regeneration": {
+    "command": "node tools/datapack/build-nationwide-coverage-tally.mjs --targets tools/datapack/nationwide-coverage-targets.json --inventory tools/datapack/source-inventory.json --resolutions tools/datapack/release/nationwide-public-api-coverage-resolutions-20260721.json --expected-launch-required-total 270 --output tools/datapack/reports/nationwide-coverage-tally.json",
+    "ledgerPath": "tools/datapack/reports/nationwide-coverage-tally.json"
+  },
+  "schemaVersion": 1,
+  "statusAxis": {
+    "dualOperatorRuleKo": "MISSING 중 operator 조건만 풀면 admitted가 되는 requirement는 DUAL_OPERATOR_UNMATCHED로 구분한다. 같은 노선을 커버하는 소스가 있으나 해당 운영기관이 coverageScope에 없는 경우다.",
+    "explicitlyUnsupportedRuleKo": "resolutions 문서의 EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE entry가 정본이다. entry의 evidence 심층 검증과 nextReviewAt 만료 재검토는 wall-clock에 의존하므로 report-coverage-gaps.mjs 게이트 몫이다.",
+    "inventoryAdmittedRuleKo": "source-inventory coverageScope의 (operatorIds, lineIds, sourceDomains) 엄격 매칭으로 domain의 requiredFields를 blockingThreshold 이상 충족한 requirement. 빈 lineIds는 와일드카드가 아니다.",
+    "missingKinds": [
+      "DUAL_OPERATOR_UNMATCHED",
+      "NO_ADMITTED_SOURCE"
+    ],
+    "outOfScopeAxisKo": "provenance 기반 게이트 SUPPORTED 판정(report-coverage-gaps.mjs --manifest/--provenance)은 별도 축이며 이 ledger가 대체하지 않는다. INVENTORY_ADMITTED는 admission 근사치이고 게이트 통과를 의미하지 않는다.",
+    "values": [
+      "INVENTORY_ADMITTED",
+      "EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE",
+      "MISSING"
+    ]
+  },
+  "targetVersion": "2026-07-13"
+}

--- a/tools/datapack/reports/nationwide-coverage-tally.json
+++ b/tools/datapack/reports/nationwide-coverage-tally.json
@@ -1075,7 +1075,7 @@
     "inventory": {
       "path": "tools/datapack/source-inventory.json",
       "retrievedAt": "2026-06-22",
-      "sha256": "284a5b0ed4d47428531f07594f153bbdf8e18153bdc268049b79ae3df2c9931d"
+      "sha256": "1b5642c0530b59568d979208633c0e965b3cca8d49fb5ffce88f22231343426a"
     },
     "resolutions": {
       "entryCount": 4,
@@ -1143,17 +1143,17 @@
       {
         "earliestResolutionNextReviewAt": null,
         "explicitlyUnsupportedWithEvidenceCount": 0,
-        "inventoryAdmittedCount": 33,
-        "inventoryAdmittedRatio": 0.7333,
+        "inventoryAdmittedCount": 36,
+        "inventoryAdmittedRatio": 0.8,
         "missingByKind": {
-          "DUAL_OPERATOR_UNMATCHED": 9,
+          "DUAL_OPERATOR_UNMATCHED": 6,
           "NO_ADMITTED_SOURCE": 3
         },
-        "missingCount": 12,
+        "missingCount": 9,
         "sourceDomain": "route_map_positions",
         "supportStartedResolutionCount": 0,
-        "terminalCount": 33,
-        "terminalRatio": 0.7333,
+        "terminalCount": 36,
+        "terminalRatio": 0.8,
         "totalCount": 45
       },
       {
@@ -1209,17 +1209,17 @@
       {
         "earliestResolutionNextReviewAt": null,
         "explicitlyUnsupportedWithEvidenceCount": 0,
-        "inventoryAdmittedCount": 35,
-        "inventoryAdmittedRatio": 0.1768,
+        "inventoryAdmittedCount": 38,
+        "inventoryAdmittedRatio": 0.1919,
         "missingByKind": {
-          "DUAL_OPERATOR_UNMATCHED": 12,
+          "DUAL_OPERATOR_UNMATCHED": 9,
           "NO_ADMITTED_SOURCE": 151
         },
-        "missingCount": 163,
+        "missingCount": 160,
         "regionId": "capital",
         "supportStartedResolutionCount": 0,
-        "terminalCount": 35,
-        "terminalRatio": 0.1768,
+        "terminalCount": 38,
+        "terminalRatio": 0.1919,
         "totalCount": 198
       },
       {
@@ -1273,13 +1273,13 @@
     ],
     "earliestResolutionNextReviewAt": "2026-10-19T02:43:09.257Z",
     "explicitlyUnsupportedWithEvidenceCount": 4,
-    "inventoryAdmittedCount": 80,
-    "inventoryAdmittedRatio": 0.2963,
+    "inventoryAdmittedCount": 83,
+    "inventoryAdmittedRatio": 0.3074,
     "missingByKind": {
-      "DUAL_OPERATOR_UNMATCHED": 12,
+      "DUAL_OPERATOR_UNMATCHED": 9,
       "NO_ADMITTED_SOURCE": 174
     },
-    "missingCount": 186,
+    "missingCount": 183,
     "requirements": [
       {
         "admissionRatio": 1,
@@ -3791,20 +3791,15 @@
         ]
       },
       {
-        "admissionRatio": 0,
-        "admittedFieldCount": 0,
-        "admittedSourceIds": [],
+        "admissionRatio": 1,
+        "admittedFieldCount": 2,
+        "admittedSourceIds": [
+          "kric-shinbundang-route-map-positions"
+        ],
         "blockingThreshold": 1,
-        "dualOperator": {
-          "coveringOperatorIds": [
-            "seoul-metro"
-          ],
-          "coveringSourceIds": [
-            "kric-shinbundang-route-map-positions"
-          ]
-        },
+        "dualOperator": null,
         "lineId": "shinbundang",
-        "missingKind": "DUAL_OPERATOR_UNMATCHED",
+        "missingKind": null,
         "operatorId": "operator-28e01fb8509d",
         "regionId": "capital",
         "releaseTier": "LAUNCH_REQUIRED",
@@ -3812,11 +3807,8 @@
         "resolution": null,
         "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
-        "status": "MISSING",
-        "unadmittedFields": [
-          "route_map_position",
-          "route_map_label_polygon"
-        ]
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
       },
       {
         "admissionRatio": 0,
@@ -4189,20 +4181,15 @@
         ]
       },
       {
-        "admissionRatio": 0,
-        "admittedFieldCount": 0,
-        "admittedSourceIds": [],
+        "admissionRatio": 1,
+        "admittedFieldCount": 2,
+        "admittedSourceIds": [
+          "kric-seohae-route-map-positions"
+        ],
         "blockingThreshold": 1,
-        "dualOperator": {
-          "coveringOperatorIds": [
-            "korail"
-          ],
-          "coveringSourceIds": [
-            "kric-seohae-route-map-positions"
-          ]
-        },
+        "dualOperator": null,
         "lineId": "line-051552e50435",
-        "missingKind": "DUAL_OPERATOR_UNMATCHED",
+        "missingKind": null,
         "operatorId": "operator-38450e138464",
         "regionId": "capital",
         "releaseTier": "LAUNCH_REQUIRED",
@@ -4210,11 +4197,8 @@
         "resolution": null,
         "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
-        "status": "MISSING",
-        "unadmittedFields": [
-          "route_map_position",
-          "route_map_label_polygon"
-        ]
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
       },
       {
         "admissionRatio": 0,
@@ -4848,20 +4832,15 @@
         ]
       },
       {
-        "admissionRatio": 0,
-        "admittedFieldCount": 0,
-        "admittedSourceIds": [],
+        "admissionRatio": 1,
+        "admittedFieldCount": 2,
+        "admittedSourceIds": [
+          "kric-gtx-a-route-map-positions"
+        ],
         "blockingThreshold": 1,
-        "dualOperator": {
-          "coveringOperatorIds": [
-            "operator-5ca780d7dee1"
-          ],
-          "coveringSourceIds": [
-            "kric-gtx-a-route-map-positions"
-          ]
-        },
+        "dualOperator": null,
         "lineId": "line-8604048b6430",
-        "missingKind": "DUAL_OPERATOR_UNMATCHED",
+        "missingKind": null,
         "operatorId": "operator-9e999d4aa596",
         "regionId": "capital",
         "releaseTier": "LAUNCH_REQUIRED",
@@ -4869,11 +4848,8 @@
         "resolution": null,
         "resolutionReviewStatus": null,
         "sourceDomain": "route_map_positions",
-        "status": "MISSING",
-        "unadmittedFields": [
-          "route_map_position",
-          "route_map_label_polygon"
-        ]
+        "status": "INVENTORY_ADMITTED",
+        "unadmittedFields": []
       },
       {
         "admissionRatio": 0,
@@ -7145,8 +7121,8 @@
       }
     ],
     "supportStartedResolutionCount": 0,
-    "terminalCount": 84,
-    "terminalRatio": 0.3111,
+    "terminalCount": 87,
+    "terminalRatio": 0.3222,
     "totalCount": 270
   },
   "parentIssue": 2138,


### PR DESCRIPTION
## 관련 이슈

Closes AquilaXk/easysubway#2507
Refs AquilaXk/easysubway-data#3

## 작업 배경

AquilaXk/easysubway-data#3 전국 270 requirement 진행 집계가 세 갈래로 갈라져 있었다. 정본 게이트(`report-coverage-gaps.mjs`)는 production manifest와 line-strict provenance를 요구해 terminal 4/270을 내고, inventory `coverageScope` 기준 admitted 근사치는 별도 수치이며, 마지막 전체 집계는 이슈 코멘트 수기 장부(2026-07-21)에 머물러 있었다. EXPLICITLY_UNSUPPORTED 76건 오판 사건(#2409)과 같은 계열의 수기 집계 드리프트를 막기 위해 "270 완결" 판정의 단일 근거가 될 재현 가능한 커밋 산출물이 필요하다.

## 작업 내용

- `tools/datapack/build-nationwide-coverage-tally.mjs` 추가 — targets(`activeLineScopes` 45) × `requiredSourceDomains`로 requirement를 만들고 상태를 결정적으로 산출한다.
  - 상태 축: `INVENTORY_ADMITTED`(coverageScope `(operatorIds, lineIds, sourceDomains)` 엄격 매칭 — 빈 `lineIds`를 와일드카드로 취급하지 않음) / `EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE`(resolutions 정본) / `MISSING`.
  - `MISSING` 하위 구분: operator 조건만 풀면 admitted가 되는 항목을 `DUAL_OPERATOR_UNMATCHED`로, 나머지를 `NO_ADMITTED_SOURCE`로 가시화하고 커버 중인 운영기관·소스 id를 함께 남긴다.
  - 판정 의미론은 `report-coverage-gaps.mjs`의 `evaluateRequirements`/`coveredField`(strictLineScope=true, requireProvenance=false 경로)와 일치시켰다. provenance 기반 게이트 `SUPPORTED` 판정은 이 도구의 축이 아니며 ledger `statusAxis.outOfScopeAxisKo`에 별도 축임을 명시만 한다.
  - `--resolutions`는 CLI 인자(기본값=현행 경로)로 받아 후속 resolutions 교체에 대비했다.
- `tools/datapack/reports/nationwide-coverage-tally.json` ledger 커밋 — 재생성 명령(`regeneration.command`)과 입력 3종의 경로·sha256을 산출물 안에 기록한다.
  - LAUNCH_REQUIRED 270: `INVENTORY_ADMITTED` 80 / `EXPLICITLY_UNSUPPORTED_WITH_EVIDENCE` 4 / `MISSING` 186(`DUAL_OPERATOR_UNMATCHED` 12 + `NO_ADMITTED_SOURCE` 174), terminal 84.
  - ENHANCEMENT(`demand_reference`) 45건은 270 집계와 분리해 별도 섹션으로 보고한다(현재 admitted 0).
- `tools/datapack/build-nationwide-coverage-tally.test.mjs` 회귀 추가 — 기존 `node --test tools/datapack/*.test.mjs` CI 배선에 그대로 올라간다.
  - drift fail closed: tracked 입력 3종을 임시 workspace에 같은 상대 경로로 복제해 재생성한 결과가 커밋본과 바이트 일치해야 하고, 입력 어느 하나가 1바이트라도 바뀌면(공백 포함) 커밋본과 어긋난다.
  - 분모 drift fail closed: `activeLineScopes` 중복, `--expected-launch-required-total` 불일치(270 아닌 값)를 거부한다.
  - resolutions 계약: admitted requirement 충돌·requirement 공간 밖 entry·중복 entry·targetVersion 불일치·state 위반을 거부한다.
  - 결정성: wall-clock(`Date.now`/`new Date`) 미사용을 도구 소스에서 확인하고, 시각 값은 입력 파일에서만 유도한다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/datapack/build-nationwide-coverage-tally.test.mjs` → tests 20 / pass 20 / fail 0
  - `node --test tools/datapack/*.test.mjs` → tests 1511 / pass 1511 / fail 0
  - `node --test tools/ci/repository-contract.test.mjs` → tests 222 / pass 222 / fail 0
  - `node tools/ci/check-boundaries.mjs`, `node tools/ci/check-contracts.mjs` → 통과
  - ledger 재생성 바이트 일치: 임시 workspace 재생성 결과 == 커밋본(위 도구 테스트 첫 케이스에서 단언)
  - `git diff --check HEAD^ HEAD` → clean
  - 리뷰 반영(99e1e3c6) 후 재실행: `node --test tools/datapack/build-nationwide-coverage-tally.test.mjs` → 20/20 pass, `node --test tools/datapack/*.test.mjs` → 1511/1511 pass, ledger 재생성 결과 커밋본과 바이트 동일
  - 폴백 리뷰 반영(88471ba0) 후 재실행: `node --test tools/datapack/build-nationwide-coverage-tally.test.mjs` → 31/31 pass, `node --test tools/datapack/*.test.mjs` → 1522/1522 pass, `node --test tools/ci/repository-contract.test.mjs` → 222/222 pass, ledger 재생성 결과 커밋본과 바이트 동일(집계 수치 무변동: admitted 80 / EU 4 / MISSING 186(dual 12))

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| tally 도구 테스트 | datapack | `node --test tools/datapack/build-nationwide-coverage-tally.test.mjs` | 위 검증 로그 20/20 pass | pass |
| ledger 재생성 바이트 일치 | datapack | 임시 workspace 재생성 후 커밋본과 바이트 비교 | 도구 테스트 "바이트 단위로 재생성된다" 케이스 | pass |
| 입력 drift fail closed | datapack | 입력 3종 각각 1바이트 변형 후 재생성 | 도구 테스트 "입력 3종이 바뀌면 ..." 3개 하위 케이스 | pass |
| 계약 테스트 회귀 | datapack | `node --test tools/datapack/*.test.mjs`, `node --test tools/ci/repository-contract.test.mjs` | 1511/1511, 222/222 pass | pass |
| 사용자 화면 | - | - | 증거 불필요 사유: 도구·ledger only, 사용자 화면 변경 없음 | n/a |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] AquilaXk/easysubway#1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음(집계 ledger only)
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `admittedSourceIds` 매칭 규칙이 `report-coverage-gaps.mjs` `coveredField`와 어긋나지 않는지(빈 `lineIds` 와일드카드 금지, `fieldsProvided` 매칭, `blockingThreshold` 비교)
  - `INVENTORY_ADMITTED`와 resolutions entry가 겹치면 fail closed 하는 판정 우선순위
  - `DUAL_OPERATOR_UNMATCHED` 분류가 unadmitted field 기준으로만 covering 소스를 모으는지
  - `regeneration.command`가 `LEDGER_PATH` 상수를 쓰는 이유(임시 출력으로도 바이트 재현이 가능해야 함)
  - 산출물 정렬·비율 계산이 로케일 무관·결정적인지(`codepointCompare`, `toFixed(4)`)

## 리스크

- 낮음: 도구·ledger 추가만으로 게이트 판정 로직(`report-coverage-gaps.mjs`)·inventory·resolutions를 건드리지 않는다. 입력이 바뀌면 ledger 재생성 없이는 datapack 도구 테스트가 실패하므로 재생성 누락은 CI에서 잡힌다(운영 부담은 입력 변경 PR마다 재생성 1회).

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 전국 coverage 현황을 재현 가능한 ledger 리포트로 생성하는 CLI 도구를 추가했습니다.
  * 도메인·지역·라인별 커버리지, 누락 사유, 지원 불가 판정 및 분모 집계를 제공합니다.
  * 입력 데이터의 해시와 재생성 정보를 리포트에 포함해 결과를 검증할 수 있습니다.
  * 잘못된 입력, 중복, 분모 불일치 및 지원 상태 충돌을 엄격히 감지합니다.

* **문서화**
  * 최신 전국 coverage 집계 리포트를 추가했습니다.

* **테스트**
  * 결정성, 입력 변경 감지, 분모 검증, 커버리지 판정 및 CLI 인자 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

