### PR TITLE
[Fix] #2515 tools/lib 변경 감지 매핑 추가 — 공유 라이브러리 변경 시 테스트 스킵 갭 해소

### DIFF
--- a/tools/ci/detect-changed-paths.sh
+++ b/tools/ci/detect-changed-paths.sh
@@ -64,6 +64,12 @@ while IFS= read -r file; do
       ci=true
       repository=true
       ;;
+    tools/lib/**)
+      # tools/lib는 계약·datapack·route-map 등 도구 전반이 공유하는 단일 원본이다(#2515).
+      # ci=true로 올려야 정렬 의미 변경이 tracked ledger 회귀까지 도달한다.
+      ci=true
+      repository=true
+      ;;
     .env.example)
       repository=true
       contracts=true

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -18132,6 +18132,7 @@ test("경로 분류기는 저장소, 백엔드, 모바일, Android, iOS 변경�
   assert.equal(sharedLib.datapack, "true");
   assert.equal(sharedLib.route_map, "true");
   assert.equal(sharedLib.release, "true");
+  assert.equal(sharedLib.deploy, "false");
   assert.equal(sharedLib.docs_only, "false");
 
   const envExample = await classifyChangedFiles([".env.example"]);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -18123,6 +18123,17 @@ test("경로 분류기는 저장소, 백엔드, 모바일, Android, iOS 변경�
   assert.equal(repoTool.repository, "true");
   assert.equal(repoTool.ci, "true");
 
+  // #2515: tools/lib는 도구 전반이 공유하는 단일 원본이라, 이 파일만 바뀌어도
+  // 계약·datapack 테스트가 스킵되면 안 된다.
+  const sharedLib = await classifyChangedFiles(["tools/lib/codepoint-compare.mjs"]);
+  assert.equal(sharedLib.repository, "true");
+  assert.equal(sharedLib.ci, "true");
+  assert.equal(sharedLib.contracts, "true");
+  assert.equal(sharedLib.datapack, "true");
+  assert.equal(sharedLib.route_map, "true");
+  assert.equal(sharedLib.release, "true");
+  assert.equal(sharedLib.docs_only, "false");
+
   const envExample = await classifyChangedFiles([".env.example"]);
   assert.equal(envExample.repository, "true");
   assert.equal(envExample.contracts, "true");


### PR DESCRIPTION
## 관련 이슈

close #2515

## 작업 배경

- `tools/lib/`는 도구 전반이 공유하는 단일 원본이다. 실측 결과 `codepoint-compare.mjs`를 참조하는 파일이 57개, `is-main-module.mjs`를 import하는 도구가 50개다(계약 검사·datapack 빌드·tally·route-map·ops·release 도구 전반).
- 그런데 `tools/ci/detect-changed-paths.sh`의 case 매핑에 `tools/lib/**`가 없어, 이 경로만 바꾸는 PR은 `repository=false`, `ci=false`로 분류됐다. 그 결과 `.github/workflows/ci.yml`의 계약 테스트(`Repository CI / Run contract tests`)와 datapack 도구 테스트(`Repository CI / Run data pack tool tests`)가 모두 스킵되어, 결정성 정렬 의미가 바뀌어도 tracked ledger 바이트 회귀가 실행되지 않는 갭이 있었다.
- 이슈 본문의 `is-main-module.mjs` 소비자 0건 서술은 이번 실측과 다르다(소비자 50건). 어느 쪽이든 삭제는 범위 밖이며 파일은 그대로 둔다.

## 작업 내용

- `tools/ci/detect-changed-paths.sh`에 `tools/lib/**` -> `ci=true, repository=true` 매핑을 추가했다. 기존 `tools/ci/**`·`tools/repo/**`·`tools/qa/**` 항목 바로 아래에 동일한 case 스타일로 배치했다.
- `tools/ci/repository-contract.test.mjs`의 기존 회귀 패턴(`classifyChangedFiles` 헬퍼로 스크립트를 실제 실행해 플래그를 검증)을 그대로 따라, `tools/lib/codepoint-compare.mjs` 단독 변경 시나리오 회귀를 추가했다.
- `ci.yml`은 변경하지 않았다. 486행 datapack 도구 테스트를 포함해 관련 스텝이 모두 `repository == 'true' || ci == 'true'` 조건이라 매핑 추가만으로 커버됨을 실측 확인했다.

## 검증

- 실행한 명령과 결과:
  - `env -u GITHUB_OUTPUT -u GITHUB_STEP_SUMMARY bash tools/ci/detect-changed-paths.sh <tools/lib/codepoint-compare.mjs 단독 파일목록>` — before/after 비교(아래 증거 표).
  - `node --test tools/ci/*.test.mjs tools/ci/lib/*.test.mjs tools/repo/*.test.mjs` (ci.yml 계약 테스트 스텝과 동일 커맨드) — `pass 473 / fail 0`.
  - `node --test tools/lib/*.test.mjs` — `pass 1 / fail 0`.
  - `shellcheck tools/ci/detect-changed-paths.sh` — 경고 0건.
  - 회귀 실효성 확인: 스크립트 변경만 stash한 상태로 회귀 테스트를 돌려 `AssertionError (actual: 'false', expected: 'true')`로 실패함을 확인했다(테스트가 실제로 매핑을 고정한다).
  - PR CI: required check 5종(Changes, Repository CI, Backend CI, Mobile App CI, Android CI) 전부 pass.

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 감지 스크립트 before/after (`tools/lib/codepoint-compare.mjs` 단독) | CI | 스크립트 직접 실행 | before: `repository=false ci=false datapack=false contracts=false route_map=false release=false` / after: `repository=true ci=true datapack=true contracts=true route_map=true release=true realtime=true` | PASS |
| 매핑 회귀 고정 | CI | `node --test tools/ci/*.test.mjs tools/ci/lib/*.test.mjs tools/repo/*.test.mjs` | `pass 473 / fail 0` | PASS |
| 회귀 실효성 | CI | 스크립트 변경 stash 후 동일 테스트 재실행 | `fail 1` (`actual: 'false', expected: 'true'`) | PASS |
| 스크립트 정적 검사 | CI | `shellcheck tools/ci/detect-changed-paths.sh` | 경고 0건 | PASS |
| release gate 해시 pin 영향 | CI | `post-launch-operations-review-gate.json`의 `refreshBindings` 파일 목록 전량 열람 | `tools/ci/detect-changed-paths.sh`, `tools/ci/repository-contract.test.mjs`, `.github/workflows/ci.yml` 모두 pin 목록에 없음 | 영향 없음 |
| 사용자 화면 변경 | 모바일 | 증거 불필요 사유 | CI 변경 감지 스크립트와 그 회귀 테스트만 수정 — 앱 코드·자산 무변경 | 해당 없음 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `tools/ci/detect-changed-paths.sh`의 새 case 위치다. 이 case는 `.github/workflows/*.yml|...|tools/ci/**|tools/repo/**|tools/qa/**` 다음에 오는데, 첫 번째 `case` 블록은 첫 매치에서 빠져나오므로 `tools/lib/**`가 상위 패턴 중 어디에도 걸리지 않아야 의미가 있다. `tools/lib/**`는 상위 어느 패턴과도 겹치지 않음을 확인했다.
- `ci=true`가 붙으면 스크립트 하단의 승격 블록이 android/backend/mobile/ios/datapack/route_map/realtime/release/contracts를 모두 true로 올린다. 공유 라이브러리 변경은 소비자 범위가 도구 전반이므로 이 광범위 승격이 의도된 동작이다.

## 리스크

- `tools/lib/**` 변경 PR의 CI 실행 시간이 늘어난다(전 게이트 실행). 갭 해소가 목적이므로 의도된 트레이드오프이며, 대상 경로가 파일 2개뿐이라 빈도는 낮다.
- ci 승격의 파급은 `ci.yml`에 그치지 않고 `release-artifacts.yml`까지 미친다. `mobile`·`android`·`backend`가 함께 켜지므로 `tools/lib/**` 변경 PR마다 서명 AAB(Android Release Artifact)와 backend release image 빌드가 돈다. 다만 `deploy`는 false로 유지되어 실제 원격 배포(`cd.yml`의 배포 경로)는 트리거되지 않으며, 이 불변은 새 회귀 어서션 `assert.equal(sharedLib.deploy, "false")`로 고정했다.
- 별도 관측 사항(이번 범위 밖): `ci.yml`의 계약 테스트 스텝 글롭은 `tools/ci/*.test.mjs tools/ci/lib/*.test.mjs tools/repo/*.test.mjs`라서 `tools/lib/is-main-module.test.mjs`는 CI에서 실행되지 않는다. 이번 매핑 추가로 다른 스위트는 돌게 되지만, 해당 테스트 자체를 CI에 편입하려면 `ci.yml` 변경이 필요해 이 PR 범위(ci.yml 무변경)에서 제외했다. 이 잔여 갭(orphan 테스트 편입·`tools/mobile` 매핑·매핑 열거 가드)은 후속 이슈 #2518에서 다룬다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다. (required check 5종 전부 pass)
- [x] CodeRabbit 리뷰를 확인했다. (walkthrough 코멘트만 게시됨)
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다. (현재 Review 객체 0건, unresolved thread 0건)
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음 — `deploy=false` 유지)
