### PR TITLE
[Feat] #2514 전국 candidate pack 게이트 하네스와 line-scope 파일럿 전환 실증

### DIFF
--- a/apps/mobile/assets/datapacks/source-inventory.json
+++ b/apps/mobile/assets/datapacks/source-inventory.json
@@ -7663,6 +7663,9 @@
         "operatorIds": [
           "seoul-metro"
         ],
+        "lineIds": [
+          "seoul-4"
+        ],
         "sourceDomains": [
           "route_map_positions"
         ]

--- a/tools/datapack/build-nationwide-coverage-tally.test.mjs
+++ b/tools/datapack/build-nationwide-coverage-tally.test.mjs
@@ -196,6 +196,19 @@ test("커밋된 전국 coverage tally ledger는 현행 입력에서 바이트 �
     assert.equal(ledger.enhancement.totalCount, 45);
     assert.equal(ledger.enhancement.earliestResolutionNextReviewAt, null);
     assert.equal(ledger.enhancement.requirements.length, 45);
+
+    // #2514 B0 파일럿: candidate 게이트가 SUPPORTED로 전이시킨 requirement는 이 ledger에서도 같은 소스로
+    // INVENTORY_ADMITTED여야 한다(두 판정 축이 반대 결론을 내지 않도록 고정).
+    const pilot = ledger.launchRequired.requirements.find((entry) =>
+      entry.regionId === "capital"
+      && entry.operatorId === "seoul-metro"
+      && entry.lineId === "seoul-4"
+      && entry.sourceDomain === "route_map_positions");
+    assert.equal(pilot.status, "INVENTORY_ADMITTED");
+    assert.deepEqual(pilot.admittedSourceIds, [
+      "seoul-metro-route-map-positions",
+      "seoulmetro-cyberstation-route-map",
+    ]);
   } finally {
     await rm(workspace, { recursive: true, force: true });
   }

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -12953,8 +12953,11 @@ test("수도권 pilot production source input은 검증된 접근성 상태로 �
       entry.lineId === "seoul-4" &&
       entry.sourceDomain === "route_map_positions",
   );
-  assert.equal(capitalRouteMapCoverage.status, "MISSING");
-  assert.deepEqual(capitalRouteMapCoverage.missingFields, ["route_map_position", "route_map_label_polygon"]);
+  // #2514 B0: seoulmetro-cyberstation-route-map coverageScope의 seoul-4 line-scope 재기술로 이 requirement가
+  // 전국 게이트에서 SUPPORTED로 전이한다. 재기술 이전에는 operator-scope provenance만 나와 MISSING이었다.
+  assert.equal(capitalRouteMapCoverage.status, "SUPPORTED");
+  assert.deepEqual(capitalRouteMapCoverage.missingFields, []);
+  assert.deepEqual(capitalRouteMapCoverage.sourceIds, ["seoulmetro-cyberstation-route-map"]);
 
   // #1999: release-scope 평가 모드는 게시 차단을 게시 범위(capital·seoul-metro × capitalPilotTargets domains) 내 gap만
   // 기준으로 판정한다. 현행 인벤토리는 전국 gap 다수 + scope 내 gap 0이므로, --allow-gaps 없이도 exit 0으로 통과하되

--- a/tools/datapack/nationwide-candidate-coverage-gate.test.mjs
+++ b/tools/datapack/nationwide-candidate-coverage-gate.test.mjs
@@ -37,7 +37,11 @@ const INPUT_PATHS = {
   inventory: INVENTORY_PATH,
   resolutionPlan: RESOLUTION_PLAN_PATH,
   resolutions: RESOLUTIONS_PATH,
+  // 승계 원본도 해시 축이다. 경로만 기록하면 원본의 값 drift가 evidence를 바이트 동일하게 통과한다.
+  inheritedPack: REVIEWED_PACK_PATH,
 };
+// 임시 RSA 키·런타임 SQLite에 좌우되는 축은 evidence 어느 노드에도 key로 존재하면 안 된다.
+const FORBIDDEN_EVIDENCE_KEYS = ["manifestSha256", "sqliteSha256", "signature"];
 
 async function readJson(relativePath) {
   return JSON.parse(await readFile(path.join(root, relativePath), "utf8"));
@@ -45,6 +49,18 @@ async function readJson(relativePath) {
 
 async function sha256Of(relativePath) {
   return createHash("sha256").update(await readFile(path.join(root, relativePath))).digest("hex");
+}
+
+// 문자열 substring 탐침은 서술 문자열의 인접 문자에 좌우된다 — 전 노드를 순회해 금지 key 부재를 본다.
+function forbiddenKeyPaths(node, nodePath = "$") {
+  if (Array.isArray(node)) {
+    return node.flatMap((entry, index) => forbiddenKeyPaths(entry, `${nodePath}[${index}]`));
+  }
+  if (!node || typeof node !== "object") return [];
+  return Object.entries(node).flatMap(([key, value]) => [
+    ...(FORBIDDEN_EVIDENCE_KEYS.includes(key) ? [`${nodePath}.${key}`] : []),
+    ...forbiddenKeyPaths(value, `${nodePath}.${key}`),
+  ]);
 }
 
 test("커밋된 candidate 게이트 evidence는 현행 입력에서 바이트 단위로 재생성된다", async () => {
@@ -86,7 +102,7 @@ test("커밋된 candidate 게이트 evidence는 현행 입력에서 바이트 �
     // 임시 RSA 키·SQLite 바이트·wall-clock 의존 집계는 기록 축이 아니다(결정성 계약).
     assert.equal(evidence.harness.signing.mode, "EPHEMERAL_RSA_2048");
     assert.equal(evidence.determinism.packPayloadIdenticalAcrossVariants, true);
-    assert.equal(JSON.stringify(evidence).includes("manifestSha256\":\""), false);
+    assert.deepEqual(forbiddenKeyPaths(evidence), []);
   } finally {
     await rm(workspace, { recursive: true, force: true });
   }
@@ -100,10 +116,18 @@ test("파일럿 scope는 line-scope 재기술로 MISSING에서 SUPPORTED로 전�
   assert.equal(evidence.candidatePack.artifactKind, "production");
   assert.equal(evidence.candidatePack.inheritsFrom.path, REVIEWED_PACK_PATH);
 
-  assert.deepEqual(evidence.variants.baseline.supportedRequirementKeys, []);
-  assert.equal(evidence.variants.baseline.launchRequired.supportedCount, 0);
-  assert.deepEqual(evidence.variants.lineScoped.supportedRequirementKeys, [PILOT_REQUIREMENT_KEY]);
-  assert.equal(evidence.variants.lineScoped.launchRequired.supportedCount, 1);
+  // 전이는 절대 수치가 아니라 상대 비교로 본다. 승계 팩의 다른 소스가 line-scope를 갖게 되면
+  // 두 variant의 supported 총량이 함께 늘 수 있고, 그때도 아래 두 축은 그대로 성립해야 한다.
+  const baselineKeys = evidence.variants.baseline.supportedRequirementKeys;
+  assert.equal(baselineKeys.includes(PILOT_REQUIREMENT_KEY), false);
+  assert.deepEqual(
+    evidence.variants.lineScoped.supportedRequirementKeys,
+    [...new Set([...baselineKeys, PILOT_REQUIREMENT_KEY])].sort(),
+  );
+  assert.equal(
+    evidence.variants.lineScoped.launchRequired.supportedCount,
+    evidence.variants.baseline.launchRequired.supportedCount + 1,
+  );
   assert.equal(evidence.variants.lineScoped.launchRequired.totalCount, 270);
 
   const [before] = evidence.variants.baseline.pilotRequirements;
@@ -117,6 +141,16 @@ test("파일럿 scope는 line-scope 재기술로 MISSING에서 SUPPORTED로 전�
   assert.equal(after.denominator, 2);
   assert.deepEqual(after.sourceIds, [PILOT_SOURCE_ID]);
   assert.deepEqual(after.missingFields, []);
+  // denominator 2는 필수 필드 2개를 뜻하고 데이터 행 2개가 아니다 — 뒷받침 행수를 따로 고정한다.
+  assert.deepEqual(after.supportingRecordCountByField, {
+    route_map_position: 2,
+    route_map_label_polygon: 2,
+  });
+  assert.deepEqual(before.supportingRecordCountByField, {
+    route_map_position: 0,
+    route_map_label_polygon: 0,
+  });
+  assert.match(evidence.readingGuide.denominatorSemanticsKo, /데이터 행 수가 아니다/);
 
   assert.deepEqual(evidence.transitions, [{
     requirementKey: PILOT_REQUIREMENT_KEY,
@@ -166,6 +200,57 @@ test("candidate spec의 line-scope 재기술은 tracked source inventory와 동�
   });
 });
 
+// candidate 안전 경계를 산문이 아니라 코드가 강제하는지 본다. 이 도구는 artifactKind production으로 실제
+// RSA 서명 manifest를 만들기 때문에, spec 편집만으로 production 채널·게시 가능 URL 서명본이 나오면 안 된다.
+test("candidate 안전 경계는 spec 편집만으로 넓힐 수 없다", async (context) => {
+  const spec = await readJson(SPEC_PATH);
+  const inventory = await readJson(INVENTORY_PATH);
+
+  async function rejectsWith(mutate, expected) {
+    const workspace = await mkdtemp(path.join(tmpdir(), "nationwide-candidate-gate-guard-"));
+    const mutated = structuredClone(spec);
+    mutate(mutated);
+    try {
+      await assert.rejects(
+        runNationwideCandidateCoverageGate({
+          spec: mutated,
+          specInput: { path: SPEC_PATH, sha256: "a".repeat(64) },
+          targetsInput: { path: TARGETS_PATH, sha256: "b".repeat(64) },
+          inventory,
+          inventoryInput: { path: INVENTORY_PATH, sha256: "c".repeat(64) },
+          resolutionPlanInput: { path: RESOLUTION_PLAN_PATH, sha256: "d".repeat(64) },
+          resolutionsInput: { path: RESOLUTIONS_PATH, sha256: "e".repeat(64) },
+          workDir: workspace,
+        }),
+        expected,
+      );
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  }
+
+  await context.test("production 채널 manifest는 거부된다", async () => {
+    await rejectsWith(
+      (value) => { value.manifest.channel = "production"; },
+      /manifest\.channel must be candidate/,
+    );
+  });
+
+  await context.test("게시 가능한 pack url은 거부된다", async () => {
+    await rejectsWith(
+      (value) => { value.pack.url = "https://objectstorage.example.com/catalog/nationwide-candidate-v1.sqlite.gz"; },
+      /pack\.url host must be the non-publishable host/,
+    );
+  });
+
+  await context.test("파일럿 범위를 넘는 다중 lineIds는 거부된다", async () => {
+    await rejectsWith(
+      (value) => { value.lineScopeRedescriptions[0].lineIds = ["seoul-4", "seoul-2"]; },
+      /lineIds must describe exactly one line/,
+    );
+  });
+});
+
 test("production 게시 트랙 fixture는 candidate 조립에 영향받지 않는다", async () => {
   const spec = await readJson(SPEC_PATH);
   const reviewed = await readJson(REVIEWED_PACK_PATH);
@@ -179,8 +264,8 @@ test("production 게시 트랙 fixture는 candidate 조립에 영향받지 않�
   assert.deepEqual(reviewed.manifest.activePack, { id: "capital", version: "1" });
   assert.notEqual(spec.pack.id, pack.id);
   assert.notEqual(spec.pack.url, pack.url);
-
-  // 게시 트랙 fixture는 operator-scope 기술을 유지한다. line-scope 재기술은 candidate 조립에서만 일어난다.
-  const source = pack.sourceInventory.find(({ id }) => id === PILOT_SOURCE_ID);
-  assert.equal(source.coverageScope.lineIds, undefined);
+  // 게시 fixture의 coverageScope 기술 자체는 여기서 못박지 않는다. #2510 로드맵의 최종 목표가 게시 팩의
+  // line-scope화이므로 operator-scope를 영구 계약으로 고정하면 정상 진행과 충돌한다. 게시 동작 불변은
+  // candidate 조립이 게시 정체성(id·version·url·channel·activePack)을 건드리지 않는다는 위 행위 단언과
+  // datapack/release 계약 테스트로 유지한다.
 });

--- a/tools/datapack/nationwide-candidate-coverage-gate.test.mjs
+++ b/tools/datapack/nationwide-candidate-coverage-gate.test.mjs
@@ -1,0 +1,186 @@
+// #2514 (#2510 B0) 전국 candidate pack 게이트 하네스 회귀.
+//
+// 검증 축:
+//   1. tracked evidence가 현행 입력에서 바이트 단위로 재생성된다(오프라인·서명 키 없이).
+//   2. 파일럿 scope가 line-scope 재기술 전 MISSING → 후 SUPPORTED로 전이한다.
+//   3. spec의 line-scope 재기술과 tracked source-inventory가 어긋나면 하네스가 fail closed 한다.
+//   4. production 게시 트랙 fixture는 candidate 조립에 영향받지 않는다.
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { promisify } from "node:util";
+
+import { EVIDENCE_PATH, runNationwideCandidateCoverageGate } from "./run-nationwide-candidate-coverage-gate.mjs";
+
+const execFileAsync = promisify(execFile);
+const root = path.resolve(import.meta.dirname, "../..");
+const TOOL_PATH = "tools/datapack/run-nationwide-candidate-coverage-gate.mjs";
+const SPEC_PATH = "tools/datapack/nationwide-candidate-pack-spec.json";
+const TARGETS_PATH = "tools/datapack/nationwide-coverage-targets.json";
+const INVENTORY_PATH = "tools/datapack/source-inventory.json";
+const APP_INVENTORY_PATH = "apps/mobile/assets/datapacks/source-inventory.json";
+const RESOLUTION_PLAN_PATH =
+  "tools/datapack/release/nationwide-public-api-coverage-search-plan-20260725.json";
+const RESOLUTIONS_PATH =
+  "tools/datapack/release/nationwide-public-api-coverage-resolutions-20260725.json";
+const REVIEWED_PACK_PATH = "tools/datapack/release/capital-production-reviewed-pack.json";
+const PILOT_REQUIREMENT_KEY = "capital:seoul-metro:seoul-4:route_map_positions";
+const PILOT_SOURCE_ID = "seoulmetro-cyberstation-route-map";
+
+const INPUT_PATHS = {
+  spec: SPEC_PATH,
+  targets: TARGETS_PATH,
+  inventory: INVENTORY_PATH,
+  resolutionPlan: RESOLUTION_PLAN_PATH,
+  resolutions: RESOLUTIONS_PATH,
+};
+
+async function readJson(relativePath) {
+  return JSON.parse(await readFile(path.join(root, relativePath), "utf8"));
+}
+
+async function sha256Of(relativePath) {
+  return createHash("sha256").update(await readFile(path.join(root, relativePath))).digest("hex");
+}
+
+test("커밋된 candidate 게이트 evidence는 현행 입력에서 바이트 단위로 재생성된다", async () => {
+  const workspace = await mkdtemp(path.join(tmpdir(), "nationwide-candidate-gate-"));
+  try {
+    const output = path.join(workspace, "evidence.json");
+    await execFileAsync(process.execPath, [
+      path.join(root, TOOL_PATH),
+      "--spec", SPEC_PATH,
+      "--targets", TARGETS_PATH,
+      "--inventory", INVENTORY_PATH,
+      "--resolution-plan", RESOLUTION_PLAN_PATH,
+      "--resolutions", RESOLUTIONS_PATH,
+      "--output", output,
+    ], { cwd: root });
+
+    const regenerated = await readFile(output, "utf8");
+    const tracked = await readFile(path.join(root, EVIDENCE_PATH), "utf8");
+    assert.equal(regenerated, tracked, "evidence는 재생성 결과와 바이트 단위로 같아야 한다");
+
+    const evidence = JSON.parse(tracked);
+    assert.equal(evidence.artifactKind, "nationwide-candidate-coverage-gate-evidence");
+    assert.equal(evidence.issue, 2514);
+    assert.deepEqual(evidence.parentIssues, [2510, 2138]);
+    assert.equal(evidence.regeneration.evidencePath, EVIDENCE_PATH);
+    assert.equal(
+      evidence.regeneration.command,
+      `node ${TOOL_PATH} --spec ${SPEC_PATH} --targets ${TARGETS_PATH} --inventory ${INVENTORY_PATH}`
+        + ` --resolution-plan ${RESOLUTION_PLAN_PATH} --resolutions ${RESOLUTIONS_PATH}`
+        + ` --output ${EVIDENCE_PATH}`,
+    );
+
+    // 기록된 입력 해시는 tracked 입력 파일의 실제 해시여야 한다(입력 drift 감지축).
+    for (const [name, relativePath] of Object.entries(INPUT_PATHS)) {
+      assert.equal(evidence.inputs[name].path, relativePath);
+      assert.equal(evidence.inputs[name].sha256, await sha256Of(relativePath));
+    }
+
+    // 임시 RSA 키·SQLite 바이트·wall-clock 의존 집계는 기록 축이 아니다(결정성 계약).
+    assert.equal(evidence.harness.signing.mode, "EPHEMERAL_RSA_2048");
+    assert.equal(evidence.determinism.packPayloadIdenticalAcrossVariants, true);
+    assert.equal(JSON.stringify(evidence).includes("manifestSha256\":\""), false);
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test("파일럿 scope는 line-scope 재기술로 MISSING에서 SUPPORTED로 전이한다", async () => {
+  const evidence = await readJson(EVIDENCE_PATH);
+
+  // candidate는 root가 되는 단일 pack이어야 게이트가 단독 계약으로 판정한다.
+  assert.equal(evidence.candidatePack.id, "nationwide-candidate");
+  assert.equal(evidence.candidatePack.artifactKind, "production");
+  assert.equal(evidence.candidatePack.inheritsFrom.path, REVIEWED_PACK_PATH);
+
+  assert.deepEqual(evidence.variants.baseline.supportedRequirementKeys, []);
+  assert.equal(evidence.variants.baseline.launchRequired.supportedCount, 0);
+  assert.deepEqual(evidence.variants.lineScoped.supportedRequirementKeys, [PILOT_REQUIREMENT_KEY]);
+  assert.equal(evidence.variants.lineScoped.launchRequired.supportedCount, 1);
+  assert.equal(evidence.variants.lineScoped.launchRequired.totalCount, 270);
+
+  const [before] = evidence.variants.baseline.pilotRequirements;
+  const [after] = evidence.variants.lineScoped.pilotRequirements;
+  assert.equal(before.requirementKey, PILOT_REQUIREMENT_KEY);
+  assert.equal(before.status, "MISSING");
+  assert.deepEqual(before.missingFields, ["route_map_position", "route_map_label_polygon"]);
+  assert.equal(after.status, "SUPPORTED");
+  assert.equal(after.releaseTier, "LAUNCH_REQUIRED");
+  assert.equal(after.coveredFields, 2);
+  assert.equal(after.denominator, 2);
+  assert.deepEqual(after.sourceIds, [PILOT_SOURCE_ID]);
+  assert.deepEqual(after.missingFields, []);
+
+  assert.deepEqual(evidence.transitions, [{
+    requirementKey: PILOT_REQUIREMENT_KEY,
+    before: "MISSING",
+    after: "SUPPORTED",
+    sourceIds: [PILOT_SOURCE_ID],
+    coveredFields: 2,
+    denominator: 2,
+  }]);
+});
+
+test("candidate spec의 line-scope 재기술은 tracked source inventory와 동기다", async (context) => {
+  const spec = await readJson(SPEC_PATH);
+  const inventory = await readJson(INVENTORY_PATH);
+  const appInventory = await readJson(APP_INVENTORY_PATH);
+  const [redescription] = spec.lineScopeRedescriptions;
+  assert.equal(redescription.sourceId, PILOT_SOURCE_ID);
+  assert.deepEqual(redescription.lineIds, ["seoul-4"]);
+  assert.deepEqual(redescription.requirementKeys, [PILOT_REQUIREMENT_KEY]);
+
+  const source = inventory.sources.find(({ id }) => id === PILOT_SOURCE_ID);
+  assert.deepEqual(source.coverageScope.lineIds, redescription.lineIds);
+  assert.ok(source.coverageScope.sourceDomains.includes(redescription.sourceDomain));
+  assert.deepEqual(appInventory, inventory, "앱 번들 사본은 datapack 정본과 같아야 한다");
+
+  await context.test("inventory lineIds가 spec과 어긋나면 하네스가 거부한다", async () => {
+    const workspace = await mkdtemp(path.join(tmpdir(), "nationwide-candidate-gate-drift-"));
+    const drifted = structuredClone(inventory);
+    delete drifted.sources.find(({ id }) => id === PILOT_SOURCE_ID).coverageScope.lineIds;
+    try {
+      await assert.rejects(
+        runNationwideCandidateCoverageGate({
+          spec,
+          specInput: { path: SPEC_PATH, sha256: "a".repeat(64) },
+          targetsInput: { path: TARGETS_PATH, sha256: "b".repeat(64) },
+          inventory: drifted,
+          inventoryInput: { path: INVENTORY_PATH, sha256: "c".repeat(64) },
+          resolutionPlanInput: { path: RESOLUTION_PLAN_PATH, sha256: "d".repeat(64) },
+          resolutionsInput: { path: RESOLUTIONS_PATH, sha256: "e".repeat(64) },
+          workDir: workspace,
+        }),
+        /source inventory coverageScope\.lineIds must match the spec redescription/,
+      );
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+});
+
+test("production 게시 트랙 fixture는 candidate 조립에 영향받지 않는다", async () => {
+  const spec = await readJson(SPEC_PATH);
+  const reviewed = await readJson(REVIEWED_PACK_PATH);
+  const [pack] = reviewed.packs;
+
+  assert.equal(reviewed.packs.length, 1);
+  assert.equal(pack.id, "capital");
+  assert.equal(pack.version, "1");
+  assert.equal(pack.artifactKind, "production");
+  assert.equal(reviewed.manifest.channel, "production");
+  assert.deepEqual(reviewed.manifest.activePack, { id: "capital", version: "1" });
+  assert.notEqual(spec.pack.id, pack.id);
+  assert.notEqual(spec.pack.url, pack.url);
+
+  // 게시 트랙 fixture는 operator-scope 기술을 유지한다. line-scope 재기술은 candidate 조립에서만 일어난다.
+  const source = pack.sourceInventory.find(({ id }) => id === PILOT_SOURCE_ID);
+  assert.equal(source.coverageScope.lineIds, undefined);
+});

--- a/tools/datapack/nationwide-candidate-pack-spec.json
+++ b/tools/datapack/nationwide-candidate-pack-spec.json
@@ -1,0 +1,46 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "nationwide-candidate-pack-spec",
+  "issue": 2514,
+  "parentIssues": [2510, 2138],
+  "candidateId": "nationwide-candidate-20260725",
+  "trackKo": "전국 candidate 트랙의 조립 정본이다. production 게시 트랙(capital pilot)과 분리되며 게시 대상이 아니다. 정본 게이트(report-coverage-gaps.mjs)는 manifest의 required root pack이 단독으로 coverage 계약을 만족해야 한다고 판정하므로 candidate는 root가 되는 단일 pack으로 조립한다.",
+  "harness": "tools/datapack/run-nationwide-candidate-coverage-gate.mjs",
+  "productionTrackInvarianceKo": "승계 원본(capital-production-reviewed-pack.json)의 pack.sourceInventory는 게시 시점 스냅샷이므로 operator-scope 기술을 그대로 둔다. line-scope 재기술은 candidate 조립분과 admission 정본(tools/datapack/source-inventory.json)에만 반영한다. 게시 차단 판정(report-coverage-gaps.mjs --release-scope)은 capital pilot targets(schemaVersion 1)로 평가돼 lineIds 기술 유무에 영향을 받지 않으므로 두 정본의 이 차이는 게시 동작을 바꾸지 않는다.",
+  "inheritsFrom": {
+    "path": "tools/datapack/release/capital-production-reviewed-pack.json",
+    "packId": "capital",
+    "packVersion": "1",
+    "reasonKo": "capital production pack 데이터를 그대로 승계한다. 1MB에 가까운 production 데이터를 복제하지 않고 참조로 승계해 원본과의 무성 drift를 구조적으로 막는다. 하네스가 이 spec을 적용해 candidate fixture를 결정적으로 조립하며, production 트랙 파일은 어떤 경로로도 수정하지 않는다."
+  },
+  "manifest": {
+    "manifestVersion": 2,
+    "channel": "candidate",
+    "releaseSequence": 1,
+    "publishedAt": "2026-07-25T00:00:00.000Z",
+    "expiresAt": "2026-08-24T00:00:00.000Z",
+    "keyId": "candidate-v1",
+    "ttlSeconds": 3600,
+    "pinnedTimeKo": "releaseSequence·publishedAt·expiresAt를 고정해 candidate 빌드가 wall-clock이나 CI 실행 번호에 의존하지 않게 한다."
+  },
+  "pack": {
+    "id": "nationwide-candidate",
+    "version": "1",
+    "artifactKind": "production",
+    "url": "https://easysubway-datapack-candidate.invalid/catalog/nationwide-candidate-v1.sqlite.gz",
+    "artifactKindReasonKo": "게이트는 required root pack의 field provenance artifactKind가 production일 때만 coverage를 인정한다(그 외는 fail closed). candidate도 production artifactKind로 조립하되 url은 게시가 불가능한 예약 도메인(.invalid)을 써서 실제 게시물과 혼동될 수 없게 한다.",
+    "metadataOverrides": {
+      "activePack": "nationwide-candidate"
+    }
+  },
+  "lineScopeRedescriptions": [
+    {
+      "sourceId": "seoulmetro-cyberstation-route-map",
+      "sourceDomain": "route_map_positions",
+      "lineIds": ["seoul-4"],
+      "requirementKeys": ["capital:seoul-metro:seoul-4:route_map_positions"],
+      "reasonKo": "B0 파일럿 1건. 이 소스는 admission이 완결(admissionEvidence.decision=APPROVED)돼 있고 승계 pack에 seoul-4 route_map_positions 행 2건(derivationKind=OFFICIAL, labelPolygon 포함)이 이미 있다. coverageScope에 lineIds가 있어야 build-datapack.mjs recordCoverageScopes가 (operator, line) 단일 pair line-scoped provenance를 낸다.",
+      "inventorySyncKo": "같은 lineIds를 tools/datapack/source-inventory.json의 같은 소스 coverageScope에도 적어야 한다. 하네스가 두 정본의 lineIds 일치를 fail closed로 확인한다."
+    }
+  ]
+}

--- a/tools/datapack/release/candidate-build-spec.json
+++ b/tools/datapack/release/candidate-build-spec.json
@@ -194,7 +194,7 @@
   "facilityEvidenceLedgerHash": "b3ffc88b4a9ce3515340366885beaace718c70058608567513f378e198935981",
   "routeEvidenceLedgerHash": "da884d0ff0138e009587753ec541997c29da57370e056dd8d3f6ad2687ad9fa9",
   "approvedOverrideSetHash": "ee5364319442d0bb4590d83e149631635c65ab59f1f3254fdbf196e04ec0f3cd",
-  "sourceInventorySha256": "f50b1189622462f21ed0ef28bd91ad032bc6c3b33699612f4db1d287ac1860de",
+  "sourceInventorySha256": "46ceb5a65ab19bb5316c2c5303717e7097d36e5c1347b3bdc59abaad4fba30a0",
   "builderGitSha": "4fc68131b397c0468d68728683bb6c79b7a42a39",
   "builderVersion": "build-datapack.mjs@1",
   "officialOdFareEvidence": {

--- a/tools/datapack/release/hash-evidence.json
+++ b/tools/datapack/release/hash-evidence.json
@@ -48,7 +48,7 @@
     "reproductionCommand": "node -e \"const c=require('crypto');console.log(c.createHash('sha256').update(JSON.stringify(require('./tools/datapack/release/source-snapshots.json'))).digest('hex'))\""
   },
   "sourceInventorySha256": {
-    "value": "f50b1189622462f21ed0ef28bd91ad032bc6c3b33699612f4db1d287ac1860de",
+    "value": "46ceb5a65ab19bb5316c2c5303717e7097d36e5c1347b3bdc59abaad4fba30a0",
     "contract": "run-source-admission-pipeline.mjs의 공식 sha256(JSON.stringify(admittedInventory)) 계약. 현행 브랜치의 tools/datapack/source-inventory.json이 최종 admitted inventory이며 워크플로 빌드가 실제로 소비하는 인벤토리와 동일 파일.",
     "reproductionCommand": "node -e \"const c=require('crypto'),fs=require('fs');console.log(c.createHash('sha256').update(JSON.stringify(JSON.parse(fs.readFileSync('tools/datapack/source-inventory.json','utf8')))).digest('hex'))\""
   },

--- a/tools/datapack/reports/nationwide-candidate-coverage-gate.json
+++ b/tools/datapack/reports/nationwide-candidate-coverage-gate.json
@@ -1,0 +1,190 @@
+{
+  "artifactKind": "nationwide-candidate-coverage-gate-evidence",
+  "candidatePack": {
+    "artifactKind": "production",
+    "candidateId": "nationwide-candidate-20260725",
+    "id": "nationwide-candidate",
+    "inheritsFrom": {
+      "packId": "capital",
+      "packVersion": "1",
+      "path": "tools/datapack/release/capital-production-reviewed-pack.json"
+    },
+    "manifestChannel": "candidate",
+    "rootPackRuleKo": "게이트는 manifest의 required root pack(emergencyOverride + activePack/default)만 판정하고 각 root pack이 단독으로 coverage 계약을 만족해야 한다. candidate manifest는 이 pack 하나만 root로 둔다.",
+    "version": "1"
+  },
+  "determinism": {
+    "excludedAxes": [
+      "candidate.manifestSha256",
+      "manifest.signature",
+      "packs[].signature",
+      "packs[].sqliteSha256",
+      "summary.*.explicitlyUnsupportedCount",
+      "summary.*.missingCount",
+      "summary.*.terminalResolutionRatio"
+    ],
+    "excludedAxesReasonKo": "manifest·pack 서명과 그 서명이 포함된 manifest sha256은 실행마다 새로 만드는 임시 RSA 키에 좌우되고, sqliteSha256은 런타임 SQLite 구현에 좌우된다. EXPLICITLY_UNSUPPORTED·MISSING 집계는 게이트가 resolutions nextReviewAt을 wall-clock으로 판정하므로 시간이 지나면 같은 입력에서도 값이 갈린다.",
+    "packPayloadIdenticalAcrossVariants": true,
+    "packPayloadIdenticalReasonKo": "line-scope 재기술은 소스 coverageScope 기술만 바꾸고 pack row 데이터를 바꾸지 않는다 — 두 variant의 sqliteSha256이 같은 실행에서 동일함을 하네스가 확인한다.",
+    "recordedAxesKo": "SUPPORTED 판정(requirement 키·필드 근거·소스)과 tier 분모만 기록한다. 이 축은 tracked 입력만으로 오프라인·서명 키 없이 바이트 단위 재현된다."
+  },
+  "harness": {
+    "builder": "tools/datapack/build-datapack.mjs",
+    "gate": "tools/datapack/report-coverage-gaps.mjs",
+    "offlineKo": "네트워크 호출이 없다. 입력은 전부 tracked 파일이고 산출물은 임시 작업 디렉터리에만 쓴다.",
+    "signing": {
+      "keyIdKo": "production artifactKind pack은 RSA 서명이 필수라 실행마다 임시 RSA-2048 키쌍을 만들어 자식 프로세스 env로만 주입한다. 저장소·CI 비밀에 서명 키가 필요 없고 키는 디스크에 남지 않는다.",
+      "mode": "EPHEMERAL_RSA_2048"
+    },
+    "tool": "tools/datapack/run-nationwide-candidate-coverage-gate.mjs"
+  },
+  "inputs": {
+    "inventory": {
+      "path": "tools/datapack/source-inventory.json",
+      "sha256": "8856a81a49f8f3814c9abd1a54fca7451dbcd1b5a3c2613e6427c3f1a3f49ff8"
+    },
+    "resolutionPlan": {
+      "path": "tools/datapack/release/nationwide-public-api-coverage-search-plan-20260725.json",
+      "sha256": "2af5546bdfc0b7873b5165a551153cf945abd4741686acbe30486abc4d29b6c2"
+    },
+    "resolutions": {
+      "path": "tools/datapack/release/nationwide-public-api-coverage-resolutions-20260725.json",
+      "sha256": "c71318595eac2c9f478f06ad4b1901d2602d8b5952d5e94c0718209d80dc555a"
+    },
+    "spec": {
+      "path": "tools/datapack/nationwide-candidate-pack-spec.json",
+      "sha256": "a2a867bfc59c8959b735435badadb689e74e9de16477634f37317966cda8607d"
+    },
+    "targets": {
+      "path": "tools/datapack/nationwide-coverage-targets.json",
+      "sha256": "2715e0bb28a25b2103add14747e74742fcb88f61e4cf357ed68453f20cf6cfc5"
+    }
+  },
+  "issue": 2514,
+  "lineScopeRedescriptions": [
+    {
+      "lineIds": [
+        "seoul-4"
+      ],
+      "requirementKeys": [
+        "capital:seoul-metro:seoul-4:route_map_positions"
+      ],
+      "sourceDomain": "route_map_positions",
+      "sourceId": "seoulmetro-cyberstation-route-map"
+    }
+  ],
+  "parentIssues": [
+    2510,
+    2138
+  ],
+  "regeneration": {
+    "command": "node tools/datapack/run-nationwide-candidate-coverage-gate.mjs --spec tools/datapack/nationwide-candidate-pack-spec.json --targets tools/datapack/nationwide-coverage-targets.json --inventory tools/datapack/source-inventory.json --resolution-plan tools/datapack/release/nationwide-public-api-coverage-search-plan-20260725.json --resolutions tools/datapack/release/nationwide-public-api-coverage-resolutions-20260725.json --output tools/datapack/reports/nationwide-candidate-coverage-gate.json",
+    "evidencePath": "tools/datapack/reports/nationwide-candidate-coverage-gate.json",
+    "pairedUpdateKo": "spec·targets·inventory·resolutions·search plan을 바꾸는 PR은 이 명령으로 evidence를 함께 재생성해야 한다. inventory를 바꾸면 tools/datapack/reports/nationwide-coverage-tally.json도 그 ledger의 regeneration.command로 같이 재생성한다. 재생성 누락은 datapack 도구 테스트에서 fail closed 된다."
+  },
+  "schemaVersion": 1,
+  "targetVersion": "2026-07-13",
+  "transitions": [
+    {
+      "after": "SUPPORTED",
+      "before": "MISSING",
+      "coveredFields": 2,
+      "denominator": 2,
+      "requirementKey": "capital:seoul-metro:seoul-4:route_map_positions",
+      "sourceIds": [
+        "seoulmetro-cyberstation-route-map"
+      ]
+    }
+  ],
+  "variants": {
+    "baseline": {
+      "descriptionKo": "line-scope 재기술 이전 상태. 재기술 대상 소스의 coverageScope.lineIds를 candidate fixture와 inventory 사본에서 함께 지워 operator-scope provenance만 나오게 한 실행이다.",
+      "enhancement": {
+        "supportedCount": 0,
+        "supportedRatio": 0,
+        "totalCount": 45
+      },
+      "launchRequired": {
+        "supportedCount": 0,
+        "supportedRatio": 0,
+        "totalCount": 270
+      },
+      "pilotRequirements": [
+        {
+          "blockingThreshold": 1,
+          "coverageRatio": 0,
+          "coveredFields": 0,
+          "denominator": 2,
+          "fieldCoverage": [
+            {
+              "field": "route_map_position",
+              "sourceIds": [],
+              "status": "missing"
+            },
+            {
+              "field": "route_map_label_polygon",
+              "sourceIds": [],
+              "status": "missing"
+            }
+          ],
+          "missingFields": [
+            "route_map_position",
+            "route_map_label_polygon"
+          ],
+          "releaseTier": "LAUNCH_REQUIRED",
+          "requirementKey": "capital:seoul-metro:seoul-4:route_map_positions",
+          "sourceIds": [],
+          "status": "MISSING"
+        }
+      ],
+      "supportedRequirementKeys": []
+    },
+    "lineScoped": {
+      "descriptionKo": "line-scope 재기술 이후 상태. candidate fixture와 tracked source-inventory.json이 같은 lineIds를 기술해 (operator, line) 단일 pair provenance가 나온 실행이다.",
+      "enhancement": {
+        "supportedCount": 0,
+        "supportedRatio": 0,
+        "totalCount": 45
+      },
+      "launchRequired": {
+        "supportedCount": 1,
+        "supportedRatio": 0.0037,
+        "totalCount": 270
+      },
+      "pilotRequirements": [
+        {
+          "blockingThreshold": 1,
+          "coverageRatio": 1,
+          "coveredFields": 2,
+          "denominator": 2,
+          "fieldCoverage": [
+            {
+              "field": "route_map_position",
+              "sourceIds": [
+                "seoulmetro-cyberstation-route-map"
+              ],
+              "status": "covered"
+            },
+            {
+              "field": "route_map_label_polygon",
+              "sourceIds": [
+                "seoulmetro-cyberstation-route-map"
+              ],
+              "status": "covered"
+            }
+          ],
+          "missingFields": [],
+          "releaseTier": "LAUNCH_REQUIRED",
+          "requirementKey": "capital:seoul-metro:seoul-4:route_map_positions",
+          "sourceIds": [
+            "seoulmetro-cyberstation-route-map"
+          ],
+          "status": "SUPPORTED"
+        }
+      ],
+      "supportedRequirementKeys": [
+        "capital:seoul-metro:seoul-4:route_map_positions"
+      ]
+    }
+  }
+}

--- a/tools/datapack/reports/nationwide-candidate-coverage-gate.json
+++ b/tools/datapack/reports/nationwide-candidate-coverage-gate.json
@@ -39,6 +39,10 @@
     "tool": "tools/datapack/run-nationwide-candidate-coverage-gate.mjs"
   },
   "inputs": {
+    "inheritedPack": {
+      "path": "tools/datapack/release/capital-production-reviewed-pack.json",
+      "sha256": "6b64e5e9f16306e7602a52fd47247c770b2b192c058f1f07a718aaf2dab2ff4a"
+    },
     "inventory": {
       "path": "tools/datapack/source-inventory.json",
       "sha256": "8856a81a49f8f3814c9abd1a54fca7451dbcd1b5a3c2613e6427c3f1a3f49ff8"
@@ -77,6 +81,11 @@
     2510,
     2138
   ],
+  "readingGuide": {
+    "denominatorSemanticsKo": "pilotRequirements의 denominator·coveredFields는 domain requiredFields 개수이지 데이터 행 수가 아니다. route_map_positions의 denominator 2는 필수 필드 2개(route_map_position·route_map_label_polygon)를 뜻하며 역 2개나 행 2개를 뜻하지 않는다. 실제로 그 판정을 뒷받침한 provenance 행 수는 필드별 supportingRecordCountByField에 따로 기록한다.",
+    "supportedScopeKo": "이 evidence는 SUPPORTED 축만 기록하므로 전국 gap 총량 판독에 쓰면 안 된다. 전국 진행 집계는 tools/datapack/reports/nationwide-coverage-tally.json이 정본이다.",
+    "variantComparisonKo": "전이 판정은 두 variant의 상대 비교다. baseline SUPPORTED 총량은 승계 팩의 다른 소스가 line-scope를 갖게 되면 함께 늘어날 수 있고, 하네스는 파일럿 키가 baseline에 없고 lineScoped가 baseline ∪ 파일럿 키와 정확히 같은지만 fail closed로 본다."
+  },
   "regeneration": {
     "command": "node tools/datapack/run-nationwide-candidate-coverage-gate.mjs --spec tools/datapack/nationwide-candidate-pack-spec.json --targets tools/datapack/nationwide-coverage-targets.json --inventory tools/datapack/source-inventory.json --resolution-plan tools/datapack/release/nationwide-public-api-coverage-search-plan-20260725.json --resolutions tools/datapack/release/nationwide-public-api-coverage-resolutions-20260725.json --output tools/datapack/reports/nationwide-candidate-coverage-gate.json",
     "evidencePath": "tools/datapack/reports/nationwide-candidate-coverage-gate.json",
@@ -134,7 +143,11 @@
           "releaseTier": "LAUNCH_REQUIRED",
           "requirementKey": "capital:seoul-metro:seoul-4:route_map_positions",
           "sourceIds": [],
-          "status": "MISSING"
+          "status": "MISSING",
+          "supportingRecordCountByField": {
+            "route_map_label_polygon": 0,
+            "route_map_position": 0
+          }
         }
       ],
       "supportedRequirementKeys": []
@@ -179,7 +192,11 @@
           "sourceIds": [
             "seoulmetro-cyberstation-route-map"
           ],
-          "status": "SUPPORTED"
+          "status": "SUPPORTED",
+          "supportingRecordCountByField": {
+            "route_map_label_polygon": 2,
+            "route_map_position": 2
+          }
         }
       ],
       "supportedRequirementKeys": [

--- a/tools/datapack/reports/nationwide-coverage-tally.json
+++ b/tools/datapack/reports/nationwide-coverage-tally.json
@@ -1075,7 +1075,7 @@
     "inventory": {
       "path": "tools/datapack/source-inventory.json",
       "retrievedAt": "2026-06-22",
-      "sha256": "1b5642c0530b59568d979208633c0e965b3cca8d49fb5ffce88f22231343426a"
+      "sha256": "8856a81a49f8f3814c9abd1a54fca7451dbcd1b5a3c2613e6427c3f1a3f49ff8"
     },
     "resolutions": {
       "entryCount": 4,
@@ -3394,7 +3394,8 @@
             "seoul-metro"
           ],
           "coveringSourceIds": [
-            "seoul-metro-route-map-positions"
+            "seoul-metro-route-map-positions",
+            "seoulmetro-cyberstation-route-map"
           ]
         },
         "lineId": "seoul-4",
@@ -5239,7 +5240,8 @@
             "seoul-metro"
           ],
           "coveringSourceIds": [
-            "seoul-metro-route-map-positions"
+            "seoul-metro-route-map-positions",
+            "seoulmetro-cyberstation-route-map"
           ]
         },
         "lineId": "seoul-4",
@@ -6302,7 +6304,8 @@
         "admissionRatio": 1,
         "admittedFieldCount": 2,
         "admittedSourceIds": [
-          "seoul-metro-route-map-positions"
+          "seoul-metro-route-map-positions",
+          "seoulmetro-cyberstation-route-map"
         ],
         "blockingThreshold": 1,
         "dualOperator": null,

--- a/tools/datapack/run-nationwide-candidate-coverage-gate.mjs
+++ b/tools/datapack/run-nationwide-candidate-coverage-gate.mjs
@@ -71,6 +71,9 @@ const ALLOWED_FLAGS = new Set([
 ]);
 const SPEC_ARTIFACT_KIND = "nationwide-candidate-pack-spec";
 const CANDIDATE_ARTIFACT_KIND = "production";
+const CANDIDATE_MANIFEST_CHANNEL = "candidate";
+// 예약 TLD(.invalid, RFC 2606)라 어떤 게시 경로에서도 해석되지 않는다.
+const NON_PUBLISHABLE_HOST = "easysubway-datapack-candidate.invalid";
 const SIGNING_MODE = "EPHEMERAL_RSA_2048";
 
 export async function runNationwideCandidateCoverageGate({
@@ -86,7 +89,10 @@ export async function runNationwideCandidateCoverageGate({
 }) {
   validateSpec(spec);
   assertInventoryLineScopeSync(spec, inventory);
-  const inherited = JSON.parse(await readFile(path.resolve(root, spec.inheritsFrom.path), "utf8"));
+  // 승계 원본도 입력 해시 축에 넣는다. 경로·pack 정체성만 기록하면 원본 좌표 같은 값 drift가
+  // evidence를 바이트 동일하게 통과시킨다(구조 drift만 잡히는 상태) — 파일 바이트로 결속한다.
+  const inheritedInput = await readJsonInput(spec.inheritsFrom.path);
+  const inherited = inheritedInput.document;
 
   const signing = ephemeralSigningKeys();
   const variants = {};
@@ -134,7 +140,8 @@ export async function runNationwideCandidateCoverageGate({
     ], { cwd: root });
 
     reports[variant] = JSON.parse(await readFile(reportPath, "utf8"));
-    variants[variant] = summarizeVariant(spec, reports[variant]);
+    const provenance = JSON.parse(await readFile(path.join(buildDir, "current.provenance.json"), "utf8"));
+    variants[variant] = summarizeVariant(spec, reports[variant], provenance);
   }
 
   return buildEvidence({
@@ -145,6 +152,7 @@ export async function runNationwideCandidateCoverageGate({
       inventory: inventoryInput,
       resolutionPlan: resolutionPlanInput,
       resolutions: resolutionsInput,
+      inheritedPack: inheritedInput.input,
     },
     reports,
     variants,
@@ -213,15 +221,10 @@ function coverageScopeWithLineIds(coverageScope, lineIds, label) {
   if (!coverageScope || typeof coverageScope !== "object" || Array.isArray(coverageScope)) {
     throw new Error(`${label} must be an object`);
   }
+  // coverageScope에 새 key가 생겨도 조립분에서 조용히 탈락하지 않도록 spread로 보존한다
+  // (고정 key 재조립은 미래 key를 무성 유실시킨다).
   const { lineIds: _dropped, ...rest } = coverageScope;
-  if (lineIds === null) return rest;
-  // source-inventory.json의 key 순서(regionIds → operatorIds → lineIds → sourceDomains)를 유지한다.
-  return {
-    regionIds: rest.regionIds,
-    operatorIds: rest.operatorIds,
-    lineIds: [...lineIds],
-    sourceDomains: rest.sourceDomains,
-  };
+  return lineIds === null ? rest : { ...rest, lineIds: [...lineIds] };
 }
 
 // fixture와 tracked inventory의 line-scope 재기술이 어긋나면 게이트 판정이 조용히 갈린다 — fail closed.
@@ -245,7 +248,7 @@ function assertInventoryLineScopeSync(spec, inventory) {
   }
 }
 
-function summarizeVariant(spec, report) {
+function summarizeVariant(spec, report, provenance) {
   const supportedRequirementKeys = report.requirements
     .filter((entry) => entry.status === "SUPPORTED")
     .map(requirementKey)
@@ -257,7 +260,7 @@ function summarizeVariant(spec, report) {
     pilotRequirements: spec.lineScopeRedescriptions
       .flatMap(({ requirementKeys }) => requirementKeys)
       .sort(codepointCompare)
-      .map((key) => pilotRequirement(report, key)),
+      .map((key) => pilotRequirement(report, key, provenance)),
   };
 }
 
@@ -270,13 +273,15 @@ function supportedCounts(tier) {
   };
 }
 
-function pilotRequirement(report, key) {
+function pilotRequirement(report, key, provenance) {
   const entry = report.requirements.find((requirement) => requirementKey(requirement) === key);
   if (!entry) throw new Error(`pilot requirement is not in the coverage report: ${key}`);
   return {
     requirementKey: key,
     releaseTier: entry.releaseTier,
     status: entry.status,
+    // denominator·coveredFields는 domain requiredFields 개수이지 데이터 행 수가 아니다.
+    // 실제 뒷받침 행 수는 supportingRecordCountByField로 따로 기록한다.
     denominator: entry.denominator,
     coveredFields: entry.coveredFields,
     coverageRatio: entry.coverageRatio,
@@ -284,7 +289,24 @@ function pilotRequirement(report, key) {
     missingFields: entry.missingFields,
     sourceIds: entry.sourceIds,
     fieldCoverage: entry.fieldCoverage.map(({ field, status, sourceIds }) => ({ field, status, sourceIds })),
+    supportingRecordCountByField: supportingRecordCountByField(provenance, entry),
   };
+}
+
+// requirement scope와 정확히 일치하는 official/field-verified provenance 레코드 수를 필드별로 센다.
+// "분모 2 = 데이터 2행"으로 읽히는 오독을 막는 뒷받침 행수 축이다(결정적 — 개수만 기록한다).
+function supportingRecordCountByField(provenance, entry) {
+  const records = (provenance.packs ?? []).flatMap((pack) => pack.records ?? []);
+  return Object.fromEntries(entry.fieldCoverage.map(({ field }) => [
+    field,
+    records.filter((record) =>
+      record.field === field
+      && ["OFFICIAL", "FIELD_VERIFIED"].includes(record.derivationKind)
+      && (record.coverageScope?.regionIds ?? []).includes(entry.regionId)
+      && (record.coverageScope?.operatorIds ?? []).includes(entry.operatorId)
+      && (record.coverageScope?.lineIds ?? []).includes(entry.lineId)
+      && (record.coverageScope?.sourceDomains ?? []).includes(entry.sourceDomain)).length,
+  ]));
 }
 
 function buildEvidence({ spec, inputs, reports, variants, signing }) {
@@ -292,16 +314,22 @@ function buildEvidence({ spec, inputs, reports, variants, signing }) {
     .flatMap(({ requirementKeys }) => requirementKeys)
     .sort(codepointCompare);
   assertCandidateRootPack(spec, reports);
-  // before가 0이 아니면 전이 실증이 성립하지 않는다 — fail closed.
-  if (variants.baseline.supportedRequirementKeys.length !== 0) {
+  // 전이 판정은 절대 수치가 아니라 두 variant의 상대 비교다. baseline SUPPORTED 총량을 0으로 못박으면
+  // 승계 팩의 다른 소스가 line-scope를 갖는 순간(#2510 로드맵의 정상 진행) 무관한 PR에서 하네스가 깨진다.
+  // 아래 두 축은 그대로 fail closed로 남는다: 파일럿 키가 baseline에 이미 있으면 전이 실증이 성립하지 않고,
+  // lineScoped가 baseline ∪ 파일럿 키와 다르면 선언보다 넓거나 좁은 전이가 일어난 것이다.
+  const baselineKeys = variants.baseline.supportedRequirementKeys;
+  const alreadySupported = expectedKeys.filter((key) => baselineKeys.includes(key));
+  if (alreadySupported.length > 0) {
     throw new Error(
-      `baseline variant must have zero SUPPORTED requirements: ${variants.baseline.supportedRequirementKeys.join(",")}`,
+      `pilot requirements must be MISSING before the line-scope redescription: ${alreadySupported.join(",")}`,
     );
   }
-  if (JSON.stringify(variants.lineScoped.supportedRequirementKeys) !== JSON.stringify(expectedKeys)) {
+  const expectedLineScopedKeys = [...new Set([...baselineKeys, ...expectedKeys])].sort(codepointCompare);
+  if (JSON.stringify(variants.lineScoped.supportedRequirementKeys) !== JSON.stringify(expectedLineScopedKeys)) {
     throw new Error(
-      "line-scoped SUPPORTED requirements must equal the spec redescription requirementKeys: "
-        + `expected ${expectedKeys.join(",")}, got ${variants.lineScoped.supportedRequirementKeys.join(",")}`,
+      "line-scoped SUPPORTED requirements must equal baseline plus the spec redescription requirementKeys: "
+        + `expected ${expectedLineScopedKeys.join(",")}, got ${variants.lineScoped.supportedRequirementKeys.join(",")}`,
     );
   }
   const baselineStatuses = new Map(
@@ -361,6 +389,20 @@ function buildEvidence({ spec, inputs, reports, variants, signing }) {
       packPayloadIdenticalReasonKo:
         "line-scope 재기술은 소스 coverageScope 기술만 바꾸고 pack row 데이터를 바꾸지 않는다 — 두 variant의 "
         + "sqliteSha256이 같은 실행에서 동일함을 하네스가 확인한다.",
+    },
+    readingGuide: {
+      denominatorSemanticsKo:
+        "pilotRequirements의 denominator·coveredFields는 domain requiredFields 개수이지 데이터 행 수가 아니다. "
+        + "route_map_positions의 denominator 2는 필수 필드 2개(route_map_position·route_map_label_polygon)를 "
+        + "뜻하며 역 2개나 행 2개를 뜻하지 않는다. 실제로 그 판정을 뒷받침한 provenance 행 수는 필드별 "
+        + "supportingRecordCountByField에 따로 기록한다.",
+      supportedScopeKo:
+        "이 evidence는 SUPPORTED 축만 기록하므로 전국 gap 총량 판독에 쓰면 안 된다. 전국 진행 집계는 "
+        + "tools/datapack/reports/nationwide-coverage-tally.json이 정본이다.",
+      variantComparisonKo:
+        "전이 판정은 두 variant의 상대 비교다. baseline SUPPORTED 총량은 승계 팩의 다른 소스가 line-scope를 "
+        + "갖게 되면 함께 늘어날 수 있고, 하네스는 파일럿 키가 baseline에 없고 lineScoped가 baseline ∪ 파일럿 "
+        + "키와 정확히 같은지만 fail closed로 본다.",
     },
     inputs: Object.fromEntries(
       Object.entries(inputs).map(([name, input]) => [name, { path: input.path, sha256: input.sha256 }]),
@@ -471,7 +513,12 @@ function validateSpec(spec) {
   requiredString(spec.inheritsFrom?.path, "candidate spec inheritsFrom.path");
   requiredString(spec.inheritsFrom?.packId, "candidate spec inheritsFrom.packId");
   requiredString(spec.inheritsFrom?.packVersion, "candidate spec inheritsFrom.packVersion");
-  requiredString(spec.manifest?.channel, "candidate spec manifest.channel");
+  // candidate 안전 경계는 주석이 아니라 단언으로 강제한다. 이 도구는 artifactKind production으로
+  // 실제 RSA 서명 manifest를 만들기 때문에, spec 편집만으로 production 채널·게시 가능 URL 서명본이
+  // 나오면 안 된다(심층방어 — 게시 경로에 오르지 못하게 채널과 호스트를 fail closed로 묶는다).
+  if (spec.manifest?.channel !== CANDIDATE_MANIFEST_CHANNEL) {
+    throw new Error(`candidate spec manifest.channel must be ${CANDIDATE_MANIFEST_CHANNEL}`);
+  }
   requiredString(spec.manifest?.publishedAt, "candidate spec manifest.publishedAt");
   requiredString(spec.manifest?.expiresAt, "candidate spec manifest.expiresAt");
   requiredString(spec.manifest?.keyId, "candidate spec manifest.keyId");
@@ -484,7 +531,7 @@ function validateSpec(spec) {
   }
   requiredString(spec.pack?.id, "candidate spec pack.id");
   requiredString(spec.pack?.version, "candidate spec pack.version");
-  requiredString(spec.pack?.url, "candidate spec pack.url");
+  assertNonPublishablePackUrl(requiredString(spec.pack?.url, "candidate spec pack.url"));
   if (spec.pack.artifactKind !== CANDIDATE_ARTIFACT_KIND) {
     throw new Error(`candidate spec pack.artifactKind must be ${CANDIDATE_ARTIFACT_KIND}`);
   }
@@ -500,8 +547,27 @@ function validateSpec(spec) {
     if (sourceIds.has(sourceId)) throw new Error(`duplicate line-scope redescription: ${sourceId}`);
     sourceIds.add(sourceId);
     requiredString(redescription.sourceDomain, `${sourceId}.sourceDomain`);
-    requiredStringArray(redescription.lineIds, `${sourceId}.lineIds`);
+    // B0 파일럿은 (operator, line) 단일 pair 전환만 다룬다. 여러 노선을 한 번에 열려면 그 배치에서
+    // 이 단언을 근거와 함께 넓혀야 한다 — spec 편집만으로 전환 범위가 넓어지지 않게 막는다.
+    if (requiredStringArray(redescription.lineIds, `${sourceId}.lineIds`).length !== 1) {
+      throw new Error(`${sourceId}.lineIds must describe exactly one line for the pilot redescription`);
+    }
     requiredStringArray(redescription.requirementKeys, `${sourceId}.requirementKeys`);
+  }
+}
+
+// candidate pack url은 예약 TLD(.invalid)만 허용한다. 게이트가 root pack artifactKind=production을
+// 요구해 production 형태로 서명하지만, 그 산출물이 게시 가능한 호스트를 가리키면 안 된다.
+function assertNonPublishablePackUrl(packUrl) {
+  let url;
+  try {
+    url = new URL(packUrl);
+  } catch {
+    throw new Error("candidate spec pack.url must be an absolute URL");
+  }
+  if (url.protocol !== "https:") throw new Error("candidate spec pack.url must use https");
+  if (url.hostname.toLowerCase().replace(/\.$/, "") !== NON_PUBLISHABLE_HOST) {
+    throw new Error(`candidate spec pack.url host must be the non-publishable host ${NON_PUBLISHABLE_HOST}`);
   }
 }
 

--- a/tools/datapack/run-nationwide-candidate-coverage-gate.mjs
+++ b/tools/datapack/run-nationwide-candidate-coverage-gate.mjs
@@ -1,0 +1,580 @@
+#!/usr/bin/env node
+// #2514 (#2510 B0) 전국 candidate pack 게이트 하네스.
+//
+// candidate spec → candidate fixture 조립 → build-datapack.mjs --fixture → report-coverage-gaps.mjs
+// 실행을 한 명령으로 묶고, line-scope 재기술 전(baseline)/후(lineScoped) 두 variant를 같은 실행에서
+// 돌려 MISSING → SUPPORTED 전이를 결정적 evidence로 남긴다.
+//
+// 왜 candidate가 root 단일 pack인가:
+//   report-coverage-gaps.mjs의 판정 대상은 manifest의 required root pack(emergencyOverride + activePack
+//   /default)뿐이고 각 root pack이 단독으로 coverage 계약을 만족해야 한다. 지역 pack을 병렬로 나열해도
+//   provenance가 합산되지 않으므로 candidate는 root가 되는 단일 pack으로 조립한다.
+//
+// 왜 두 variant를 한 실행에서 돌리나:
+//   before/after를 서로 다른 커밋에서 손으로 뽑으면 재현이 불가능하다. baseline variant는 재기술 대상
+//   소스의 coverageScope.lineIds를 fixture와 inventory 사본에서 함께 지워 재기술 이전 상태를 복원한다.
+//   같은 tracked 입력에서 before/after가 함께 나오므로 evidence가 언제든 재생성된다.
+//
+// 서명 키:
+//   게이트는 root pack의 field provenance artifactKind가 production일 때만 coverage를 인정하고,
+//   production pack 서명은 RSA 개인키를 요구한다. 하네스는 실행마다 임시 RSA-2048 키쌍을 만들어
+//   자식 프로세스 env로만 주입한다 — 저장소·CI에 서명 비밀이 필요 없고 키가 디스크에 남지 않는다.
+//
+// 결정성:
+//   임시 키로 만든 manifest·pack 서명과 그 서명이 들어간 manifest sha256, 그리고 런타임 SQLite 구현에
+//   좌우되는 sqliteSha256은 evidence에 기록하지 않는다. resolutions 만료(nextReviewAt)는 게이트가
+//   wall-clock으로 판정하므로 그 영향을 받는 EXPLICITLY_UNSUPPORTED·MISSING 집계도 기록하지 않는다.
+//   기록 축은 SUPPORTED 판정과 분모뿐이며 이 축은 오프라인·키 없이 바이트 단위로 재현된다.
+//
+// 사용:
+//   node tools/datapack/run-nationwide-candidate-coverage-gate.mjs \
+//     --spec tools/datapack/nationwide-candidate-pack-spec.json \
+//     --targets tools/datapack/nationwide-coverage-targets.json \
+//     --inventory tools/datapack/source-inventory.json \
+//     --resolution-plan tools/datapack/release/nationwide-public-api-coverage-search-plan-20260725.json \
+//     --resolutions tools/datapack/release/nationwide-public-api-coverage-resolutions-20260725.json \
+//     --output tools/datapack/reports/nationwide-candidate-coverage-gate.json
+//
+// 선택 인자:
+//   --work-dir       중간 산출물(조립 fixture·빌드 결과·원본 게이트 리포트) 보존 경로. 생략하면 임시
+//                    디렉터리를 쓰고 실행 후 지운다.
+//   --emit-fixture   조립된 lineScoped candidate fixture를 이 경로에 남긴다(수동 재현·검수용).
+import { execFile } from "node:child_process";
+import { createHash, generateKeyPairSync } from "node:crypto";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import { codepointCompare } from "../lib/codepoint-compare.mjs";
+import { isMainModule } from "../lib/is-main-module.mjs";
+import { parseArgs, requireArg, sortJson } from "./lib/ledger-admission-cli.mjs";
+
+const execFileAsync = promisify(execFile);
+const root = path.resolve(import.meta.dirname, "../..");
+
+// 재생성 명령에 기록하는 tracked evidence 경로. --output이 임시 경로여도 산출 바이트가 달라지지 않도록
+// 명령 문자열은 이 상수를 쓴다(재현성 검증이 임시 출력으로 가능해야 한다).
+export const EVIDENCE_PATH = "tools/datapack/reports/nationwide-candidate-coverage-gate.json";
+const TOOL_PATH = "tools/datapack/run-nationwide-candidate-coverage-gate.mjs";
+const BUILDER_PATH = "tools/datapack/build-datapack.mjs";
+const GATE_PATH = "tools/datapack/report-coverage-gaps.mjs";
+const ALLOWED_FLAGS = new Set([
+  "spec",
+  "targets",
+  "inventory",
+  "resolution-plan",
+  "resolutions",
+  "output",
+  "work-dir",
+  "emit-fixture",
+]);
+const SPEC_ARTIFACT_KIND = "nationwide-candidate-pack-spec";
+const CANDIDATE_ARTIFACT_KIND = "production";
+const SIGNING_MODE = "EPHEMERAL_RSA_2048";
+
+export async function runNationwideCandidateCoverageGate({
+  spec,
+  specInput,
+  targetsInput,
+  inventory,
+  inventoryInput,
+  resolutionPlanInput,
+  resolutionsInput,
+  workDir,
+  emitFixturePath = null,
+}) {
+  validateSpec(spec);
+  assertInventoryLineScopeSync(spec, inventory);
+  const inherited = JSON.parse(await readFile(path.resolve(root, spec.inheritsFrom.path), "utf8"));
+
+  const signing = ephemeralSigningKeys();
+  const variants = {};
+  const reports = {};
+  for (const lineScoped of [false, true]) {
+    const variant = lineScoped ? "lineScoped" : "baseline";
+    const variantDir = path.join(workDir, variant);
+    await mkdir(variantDir, { recursive: true });
+
+    const fixture = materializeCandidateFixture(spec, inherited, { lineScoped });
+    const fixturePath = path.join(variantDir, "nationwide-candidate-pack.json");
+    await writeJson(fixturePath, fixture);
+    if (lineScoped && emitFixturePath) {
+      await writeJson(path.resolve(root, emitFixturePath), fixture);
+    }
+
+    // baseline은 재기술 이전 상태를 복원해야 하므로 inventory 사본에서도 같은 lineIds를 지운다.
+    // lineScoped는 tracked inventory를 그대로 읽어 evidence가 커밋된 정본에 직접 묶이게 한다.
+    const inventoryPath = lineScoped
+      ? path.resolve(root, inventoryInput.path)
+      : path.join(variantDir, "source-inventory.json");
+    if (!lineScoped) {
+      await writeJson(inventoryPath, withoutLineScopeRedescriptions(spec, inventory));
+    }
+
+    const buildDir = path.join(variantDir, "build");
+    await execFileAsync(process.execPath, [
+      path.join(root, BUILDER_PATH),
+      "--fixture", fixturePath,
+      "--output", buildDir,
+    ], { cwd: root, env: { ...process.env, ...signing.env } });
+
+    const reportPath = path.join(variantDir, "coverage-gap-report.json");
+    await execFileAsync(process.execPath, [
+      path.join(root, GATE_PATH),
+      "--targets", path.resolve(root, targetsInput.path),
+      "--inventory", inventoryPath,
+      "--manifest", path.join(buildDir, "current.json"),
+      "--provenance", path.join(buildDir, "current.provenance.json"),
+      "--resolution-plan", path.resolve(root, resolutionPlanInput.path),
+      "--resolutions", path.resolve(root, resolutionsInput.path),
+      "--output", reportPath,
+      // 전국 gap은 아직 남아 있으므로 게이트를 리포트 모드로 돌린다(게시 차단 판정은 이 하네스의 축이 아니다).
+      "--allow-gaps",
+    ], { cwd: root });
+
+    reports[variant] = JSON.parse(await readFile(reportPath, "utf8"));
+    variants[variant] = summarizeVariant(spec, reports[variant]);
+  }
+
+  return buildEvidence({
+    spec,
+    inputs: {
+      spec: specInput,
+      targets: targetsInput,
+      inventory: inventoryInput,
+      resolutionPlan: resolutionPlanInput,
+      resolutions: resolutionsInput,
+    },
+    reports,
+    variants,
+    signing,
+  });
+}
+
+// candidate fixture 조립: 승계 pack을 그대로 복제하고 candidate 정체성과 line-scope 재기술만 덮어쓴다.
+// 승계 원본(production 트랙 파일)은 읽기만 한다.
+function materializeCandidateFixture(spec, inherited, { lineScoped }) {
+  const inheritedPack = (inherited.packs ?? []).find(
+    (pack) => pack.id === spec.inheritsFrom.packId && pack.version === spec.inheritsFrom.packVersion,
+  );
+  if (!inheritedPack) {
+    throw new Error(
+      `inherited pack is missing: ${spec.inheritsFrom.packId}@${spec.inheritsFrom.packVersion}`,
+    );
+  }
+  const pack = structuredClone(inheritedPack);
+  pack.id = spec.pack.id;
+  pack.version = spec.pack.version;
+  pack.artifactKind = spec.pack.artifactKind;
+  pack.url = spec.pack.url;
+  pack.metadata = { ...(pack.metadata ?? {}), ...(spec.pack.metadataOverrides ?? {}) };
+  for (const redescription of spec.lineScopeRedescriptions) {
+    const source = (pack.sourceInventory ?? []).find(({ id }) => id === redescription.sourceId);
+    if (!source) {
+      throw new Error(`redescribed source is missing from inherited pack: ${redescription.sourceId}`);
+    }
+    source.coverageScope = coverageScopeWithLineIds(
+      source.coverageScope,
+      lineScoped ? redescription.lineIds : null,
+      `${redescription.sourceId}.coverageScope`,
+    );
+  }
+  return {
+    manifest: {
+      manifestVersion: spec.manifest.manifestVersion,
+      channel: spec.manifest.channel,
+      releaseSequence: spec.manifest.releaseSequence,
+      publishedAt: spec.manifest.publishedAt,
+      expiresAt: spec.manifest.expiresAt,
+      keyId: spec.manifest.keyId,
+      ttlSeconds: spec.manifest.ttlSeconds,
+      activePack: { id: spec.pack.id, version: spec.pack.version },
+    },
+    packs: [pack],
+  };
+}
+
+// baseline inventory: 재기술 대상 소스의 lineIds만 지운 사본(다른 소스의 line-scope는 그대로 둔다).
+function withoutLineScopeRedescriptions(spec, inventory) {
+  const copy = structuredClone(inventory);
+  for (const redescription of spec.lineScopeRedescriptions) {
+    const source = copy.sources.find(({ id }) => id === redescription.sourceId);
+    source.coverageScope = coverageScopeWithLineIds(
+      source.coverageScope,
+      null,
+      `${redescription.sourceId}.coverageScope`,
+    );
+  }
+  return copy;
+}
+
+function coverageScopeWithLineIds(coverageScope, lineIds, label) {
+  if (!coverageScope || typeof coverageScope !== "object" || Array.isArray(coverageScope)) {
+    throw new Error(`${label} must be an object`);
+  }
+  const { lineIds: _dropped, ...rest } = coverageScope;
+  if (lineIds === null) return rest;
+  // source-inventory.json의 key 순서(regionIds → operatorIds → lineIds → sourceDomains)를 유지한다.
+  return {
+    regionIds: rest.regionIds,
+    operatorIds: rest.operatorIds,
+    lineIds: [...lineIds],
+    sourceDomains: rest.sourceDomains,
+  };
+}
+
+// fixture와 tracked inventory의 line-scope 재기술이 어긋나면 게이트 판정이 조용히 갈린다 — fail closed.
+function assertInventoryLineScopeSync(spec, inventory) {
+  for (const redescription of spec.lineScopeRedescriptions) {
+    const source = (inventory.sources ?? []).find(({ id }) => id === redescription.sourceId);
+    if (!source) {
+      throw new Error(`redescribed source is missing from source inventory: ${redescription.sourceId}`);
+    }
+    const actual = source.coverageScope?.lineIds ?? [];
+    if (JSON.stringify(actual) !== JSON.stringify(redescription.lineIds)) {
+      throw new Error(
+        `source inventory coverageScope.lineIds must match the spec redescription: ${redescription.sourceId}`,
+      );
+    }
+    if (!source.coverageScope?.sourceDomains?.includes(redescription.sourceDomain)) {
+      throw new Error(
+        `source inventory coverageScope.sourceDomains must include ${redescription.sourceDomain}: ${redescription.sourceId}`,
+      );
+    }
+  }
+}
+
+function summarizeVariant(spec, report) {
+  const supportedRequirementKeys = report.requirements
+    .filter((entry) => entry.status === "SUPPORTED")
+    .map(requirementKey)
+    .sort(codepointCompare);
+  return {
+    supportedRequirementKeys,
+    launchRequired: supportedCounts(report.summary.launchRequired),
+    enhancement: supportedCounts(report.summary.enhancement),
+    pilotRequirements: spec.lineScopeRedescriptions
+      .flatMap(({ requirementKeys }) => requirementKeys)
+      .sort(codepointCompare)
+      .map((key) => pilotRequirement(report, key)),
+  };
+}
+
+function supportedCounts(tier) {
+  // EXPLICITLY_UNSUPPORTED·MISSING 집계는 resolutions 만료(wall-clock)에 좌우되므로 기록하지 않는다.
+  return {
+    totalCount: tier.totalCount,
+    supportedCount: tier.supportedCount,
+    supportedRatio: tier.supportedRatio,
+  };
+}
+
+function pilotRequirement(report, key) {
+  const entry = report.requirements.find((requirement) => requirementKey(requirement) === key);
+  if (!entry) throw new Error(`pilot requirement is not in the coverage report: ${key}`);
+  return {
+    requirementKey: key,
+    releaseTier: entry.releaseTier,
+    status: entry.status,
+    denominator: entry.denominator,
+    coveredFields: entry.coveredFields,
+    coverageRatio: entry.coverageRatio,
+    blockingThreshold: entry.blockingThreshold,
+    missingFields: entry.missingFields,
+    sourceIds: entry.sourceIds,
+    fieldCoverage: entry.fieldCoverage.map(({ field, status, sourceIds }) => ({ field, status, sourceIds })),
+  };
+}
+
+function buildEvidence({ spec, inputs, reports, variants, signing }) {
+  const expectedKeys = spec.lineScopeRedescriptions
+    .flatMap(({ requirementKeys }) => requirementKeys)
+    .sort(codepointCompare);
+  assertCandidateRootPack(spec, reports);
+  // before가 0이 아니면 전이 실증이 성립하지 않는다 — fail closed.
+  if (variants.baseline.supportedRequirementKeys.length !== 0) {
+    throw new Error(
+      `baseline variant must have zero SUPPORTED requirements: ${variants.baseline.supportedRequirementKeys.join(",")}`,
+    );
+  }
+  if (JSON.stringify(variants.lineScoped.supportedRequirementKeys) !== JSON.stringify(expectedKeys)) {
+    throw new Error(
+      "line-scoped SUPPORTED requirements must equal the spec redescription requirementKeys: "
+        + `expected ${expectedKeys.join(",")}, got ${variants.lineScoped.supportedRequirementKeys.join(",")}`,
+    );
+  }
+  const baselineStatuses = new Map(
+    reports.baseline.requirements.map((entry) => [requirementKey(entry), entry.status]),
+  );
+  const transitions = variants.lineScoped.pilotRequirements.map((entry) => ({
+    requirementKey: entry.requirementKey,
+    before: baselineStatuses.get(entry.requirementKey),
+    after: entry.status,
+    sourceIds: entry.sourceIds,
+    coveredFields: entry.coveredFields,
+    denominator: entry.denominator,
+  }));
+
+  return {
+    schemaVersion: 1,
+    artifactKind: "nationwide-candidate-coverage-gate-evidence",
+    issue: spec.issue,
+    parentIssues: [...spec.parentIssues],
+    targetVersion: reports.lineScoped.targetVersion,
+    regeneration: {
+      command: regenerationCommand(inputs),
+      evidencePath: EVIDENCE_PATH,
+      pairedUpdateKo:
+        "spec·targets·inventory·resolutions·search plan을 바꾸는 PR은 이 명령으로 evidence를 함께 재생성해야 "
+        + "한다. inventory를 바꾸면 tools/datapack/reports/nationwide-coverage-tally.json도 그 ledger의 "
+        + "regeneration.command로 같이 재생성한다. 재생성 누락은 datapack 도구 테스트에서 fail closed 된다.",
+    },
+    harness: {
+      tool: TOOL_PATH,
+      builder: BUILDER_PATH,
+      gate: GATE_PATH,
+      offlineKo: "네트워크 호출이 없다. 입력은 전부 tracked 파일이고 산출물은 임시 작업 디렉터리에만 쓴다.",
+      signing: {
+        mode: SIGNING_MODE,
+        keyIdKo: signing.noteKo,
+      },
+    },
+    determinism: {
+      recordedAxesKo:
+        "SUPPORTED 판정(requirement 키·필드 근거·소스)과 tier 분모만 기록한다. 이 축은 tracked 입력만으로 "
+        + "오프라인·서명 키 없이 바이트 단위 재현된다.",
+      excludedAxes: [
+        "candidate.manifestSha256",
+        "manifest.signature",
+        "packs[].signature",
+        "packs[].sqliteSha256",
+        "summary.*.explicitlyUnsupportedCount",
+        "summary.*.missingCount",
+        "summary.*.terminalResolutionRatio",
+      ],
+      excludedAxesReasonKo:
+        "manifest·pack 서명과 그 서명이 포함된 manifest sha256은 실행마다 새로 만드는 임시 RSA 키에 좌우되고, "
+        + "sqliteSha256은 런타임 SQLite 구현에 좌우된다. EXPLICITLY_UNSUPPORTED·MISSING 집계는 게이트가 "
+        + "resolutions nextReviewAt을 wall-clock으로 판정하므로 시간이 지나면 같은 입력에서도 값이 갈린다.",
+      packPayloadIdenticalAcrossVariants: true,
+      packPayloadIdenticalReasonKo:
+        "line-scope 재기술은 소스 coverageScope 기술만 바꾸고 pack row 데이터를 바꾸지 않는다 — 두 variant의 "
+        + "sqliteSha256이 같은 실행에서 동일함을 하네스가 확인한다.",
+    },
+    inputs: Object.fromEntries(
+      Object.entries(inputs).map(([name, input]) => [name, { path: input.path, sha256: input.sha256 }]),
+    ),
+    candidatePack: {
+      id: spec.pack.id,
+      version: spec.pack.version,
+      artifactKind: spec.pack.artifactKind,
+      manifestChannel: spec.manifest.channel,
+      candidateId: spec.candidateId,
+      inheritsFrom: {
+        path: spec.inheritsFrom.path,
+        packId: spec.inheritsFrom.packId,
+        packVersion: spec.inheritsFrom.packVersion,
+      },
+      rootPackRuleKo:
+        "게이트는 manifest의 required root pack(emergencyOverride + activePack/default)만 판정하고 각 root "
+        + "pack이 단독으로 coverage 계약을 만족해야 한다. candidate manifest는 이 pack 하나만 root로 둔다.",
+    },
+    lineScopeRedescriptions: spec.lineScopeRedescriptions.map((redescription) => ({
+      sourceId: redescription.sourceId,
+      sourceDomain: redescription.sourceDomain,
+      lineIds: [...redescription.lineIds],
+      requirementKeys: [...redescription.requirementKeys],
+    })),
+    variants: {
+      baseline: {
+        descriptionKo:
+          "line-scope 재기술 이전 상태. 재기술 대상 소스의 coverageScope.lineIds를 candidate fixture와 "
+          + "inventory 사본에서 함께 지워 operator-scope provenance만 나오게 한 실행이다.",
+        ...variants.baseline,
+      },
+      lineScoped: {
+        descriptionKo:
+          "line-scope 재기술 이후 상태. candidate fixture와 tracked source-inventory.json이 같은 lineIds를 "
+          + "기술해 (operator, line) 단일 pair provenance가 나온 실행이다.",
+        ...variants.lineScoped,
+      },
+    },
+    transitions,
+  };
+}
+
+function assertCandidateRootPack(spec, reports) {
+  for (const [variant, report] of Object.entries(reports)) {
+    const packs = report.candidate?.packs ?? [];
+    if (packs.length !== 1) {
+      throw new Error(`${variant} candidate manifest must have exactly one required root pack`);
+    }
+    const [pack] = packs;
+    if (pack.id !== spec.pack.id || pack.version !== spec.pack.version) {
+      throw new Error(`${variant} candidate root pack identity mismatch: ${pack.id}@${pack.version}`);
+    }
+    if (pack.artifactKind !== CANDIDATE_ARTIFACT_KIND) {
+      throw new Error(`${variant} candidate root pack artifactKind must be ${CANDIDATE_ARTIFACT_KIND}`);
+    }
+  }
+  if (reports.baseline.candidate.packs[0].sqliteSha256 !== reports.lineScoped.candidate.packs[0].sqliteSha256) {
+    throw new Error("line-scope redescription must not change candidate pack payload bytes");
+  }
+}
+
+function requirementKey({ regionId, operatorId, lineId, sourceDomain }) {
+  return `${regionId}:${operatorId}:${lineId}:${sourceDomain}`;
+}
+
+function regenerationCommand(inputs) {
+  return [
+    "node",
+    TOOL_PATH,
+    "--spec", inputs.spec.path,
+    "--targets", inputs.targets.path,
+    "--inventory", inputs.inventory.path,
+    "--resolution-plan", inputs.resolutionPlan.path,
+    "--resolutions", inputs.resolutions.path,
+    "--output", EVIDENCE_PATH,
+  ].join(" ");
+}
+
+function ephemeralSigningKeys() {
+  const { privateKey, publicKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  return {
+    noteKo:
+      "production artifactKind pack은 RSA 서명이 필수라 실행마다 임시 RSA-2048 키쌍을 만들어 자식 프로세스 "
+      + "env로만 주입한다. 저장소·CI 비밀에 서명 키가 필요 없고 키는 디스크에 남지 않는다.",
+    env: {
+      EASYSUBWAY_DATAPACK_SIGNING_PRIVATE_KEY_PEM: privateKey.export({ type: "pkcs8", format: "pem" }).toString(),
+      EASYSUBWAY_DATAPACK_SIGNING_PUBLIC_KEY_PEM: publicKey.export({ type: "spki", format: "pem" }).toString(),
+    },
+  };
+}
+
+function validateSpec(spec) {
+  if (!spec || typeof spec !== "object" || Array.isArray(spec)) {
+    throw new Error("candidate spec must be an object");
+  }
+  if (spec.schemaVersion !== 1) throw new Error("candidate spec schemaVersion must be 1");
+  if (spec.artifactKind !== SPEC_ARTIFACT_KIND) {
+    throw new Error(`candidate spec artifactKind must be ${SPEC_ARTIFACT_KIND}`);
+  }
+  if (!Number.isInteger(spec.issue) || spec.issue <= 0) {
+    throw new Error("candidate spec issue must be a positive integer");
+  }
+  if (!Array.isArray(spec.parentIssues) || spec.parentIssues.some((issue) => !Number.isInteger(issue))) {
+    throw new Error("candidate spec parentIssues must be an integer array");
+  }
+  requiredString(spec.candidateId, "candidate spec candidateId");
+  requiredString(spec.inheritsFrom?.path, "candidate spec inheritsFrom.path");
+  requiredString(spec.inheritsFrom?.packId, "candidate spec inheritsFrom.packId");
+  requiredString(spec.inheritsFrom?.packVersion, "candidate spec inheritsFrom.packVersion");
+  requiredString(spec.manifest?.channel, "candidate spec manifest.channel");
+  requiredString(spec.manifest?.publishedAt, "candidate spec manifest.publishedAt");
+  requiredString(spec.manifest?.expiresAt, "candidate spec manifest.expiresAt");
+  requiredString(spec.manifest?.keyId, "candidate spec manifest.keyId");
+  if (spec.manifest.manifestVersion !== 2) throw new Error("candidate spec manifest.manifestVersion must be 2");
+  if (!Number.isInteger(spec.manifest.releaseSequence) || spec.manifest.releaseSequence <= 0) {
+    throw new Error("candidate spec manifest.releaseSequence must be a positive integer");
+  }
+  if (!Number.isInteger(spec.manifest.ttlSeconds) || spec.manifest.ttlSeconds <= 0) {
+    throw new Error("candidate spec manifest.ttlSeconds must be a positive integer");
+  }
+  requiredString(spec.pack?.id, "candidate spec pack.id");
+  requiredString(spec.pack?.version, "candidate spec pack.version");
+  requiredString(spec.pack?.url, "candidate spec pack.url");
+  if (spec.pack.artifactKind !== CANDIDATE_ARTIFACT_KIND) {
+    throw new Error(`candidate spec pack.artifactKind must be ${CANDIDATE_ARTIFACT_KIND}`);
+  }
+  if (spec.pack.id === spec.inheritsFrom.packId) {
+    throw new Error("candidate pack id must differ from the inherited production pack id");
+  }
+  if (!Array.isArray(spec.lineScopeRedescriptions) || spec.lineScopeRedescriptions.length === 0) {
+    throw new Error("candidate spec lineScopeRedescriptions must be a non-empty array");
+  }
+  const sourceIds = new Set();
+  for (const redescription of spec.lineScopeRedescriptions) {
+    const sourceId = requiredString(redescription?.sourceId, "lineScopeRedescriptions.sourceId");
+    if (sourceIds.has(sourceId)) throw new Error(`duplicate line-scope redescription: ${sourceId}`);
+    sourceIds.add(sourceId);
+    requiredString(redescription.sourceDomain, `${sourceId}.sourceDomain`);
+    requiredStringArray(redescription.lineIds, `${sourceId}.lineIds`);
+    requiredStringArray(redescription.requirementKeys, `${sourceId}.requirementKeys`);
+  }
+}
+
+function requiredString(value, label) {
+  if (typeof value !== "string" || value.trim() === "") throw new Error(`${label} is required`);
+  return value;
+}
+
+function requiredStringArray(value, label) {
+  if (
+    !Array.isArray(value)
+    || value.length === 0
+    || value.some((entry) => typeof entry !== "string" || entry.trim() === "")
+  ) {
+    throw new Error(`${label} must be a non-empty string array`);
+  }
+  return value;
+}
+
+async function writeJson(filePath, value) {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function readJsonInput(filePath) {
+  const bytes = await readFile(path.resolve(root, filePath));
+  return {
+    document: JSON.parse(bytes.toString("utf8")),
+    input: { path: filePath, sha256: createHash("sha256").update(bytes).digest("hex") },
+  };
+}
+
+async function main(argv) {
+  const args = parseArgs(argv);
+  for (const flag of Object.keys(args)) {
+    if (!ALLOWED_FLAGS.has(flag)) throw new Error(`unexpected argument: --${flag}`);
+  }
+  const outputPath = requireArg(args, "output");
+  const spec = await readJsonInput(requireArg(args, "spec"));
+  const targets = await readJsonInput(requireArg(args, "targets"));
+  const inventory = await readJsonInput(requireArg(args, "inventory"));
+  const resolutionPlan = await readJsonInput(requireArg(args, "resolution-plan"));
+  const resolutions = await readJsonInput(requireArg(args, "resolutions"));
+
+  const requestedWorkDir = args["work-dir"];
+  const workDir = requestedWorkDir
+    ? path.resolve(root, requestedWorkDir)
+    : await mkdtemp(path.join(tmpdir(), "easysubway-nationwide-candidate-gate-"));
+  try {
+    await mkdir(workDir, { recursive: true });
+    const evidence = await runNationwideCandidateCoverageGate({
+      spec: spec.document,
+      specInput: spec.input,
+      targetsInput: targets.input,
+      inventory: inventory.document,
+      inventoryInput: inventory.input,
+      resolutionPlanInput: resolutionPlan.input,
+      resolutionsInput: resolutions.input,
+      workDir,
+      emitFixturePath: args["emit-fixture"] ?? null,
+    });
+    await mkdir(path.dirname(path.resolve(root, outputPath)), { recursive: true });
+    await writeFile(path.resolve(root, outputPath), `${JSON.stringify(sortJson(evidence), null, 2)}\n`);
+  } finally {
+    if (!requestedWorkDir) {
+      await rm(workDir, { recursive: true, force: true });
+    }
+  }
+}
+
+if (isMainModule(import.meta.url)) {
+  main(process.argv.slice(2)).catch((error) => {
+    console.error(error.message);
+    process.exit(1);
+  });
+}

--- a/tools/datapack/source-inventory.json
+++ b/tools/datapack/source-inventory.json
@@ -7663,6 +7663,9 @@
         "operatorIds": [
           "seoul-metro"
         ],
+        "lineIds": [
+          "seoul-4"
+        ],
         "sourceDomains": [
           "route_map_positions"
         ]


### PR DESCRIPTION
## 관련 이슈

close AquilaXk/easysubway#2514

Refs AquilaXk/easysubway#2510 AquilaXk/easysubway-data#3

## 작업 배경

AquilaXk/easysubway#2510 배선 로드맵의 첫 배치(B0)다. 2026-07-25 설계 실측(#2510 코멘트)에서 확정된 사실은 두 가지다.

- 정본 게이트(`report-coverage-gaps.mjs`)의 판정 대상은 manifest의 **required root pack**뿐이고 각 root pack이 **단독으로** coverage 계약을 만족해야 한다. 지역 pack을 병렬로 나열해도 provenance가 합산되지 않으므로 전국 candidate는 root가 되는 단일 pack이어야 한다(D1).
- `build-datapack.mjs`의 `recordCoverageScopes`는 소스 `coverageScope.lineIds`가 있으면 이미 (operator, line) 단일 pair line-scoped provenance를 낸다. capital pack이 operator-scope인 원인은 fixture `packs[].sourceInventory[].coverageScope`에 lineIds가 없기 때문이다(D2).

즉 게이트·빌더·앱 코드 개조 없이 데이터/조립만으로 MISSING → SUPPORTED 전환이 가능하다. 이 PR은 그 경로를 하네스로 배선하고 파일럿 1 scope로 실증한다.

## 작업 내용

- **candidate 조립 정본 추가** — `tools/datapack/nationwide-candidate-pack-spec.json`. `tools/datapack/release/capital-production-reviewed-pack.json`의 capital@1 pack 데이터를 승계하고 candidate 정체성(`nationwide-candidate@1`, channel `candidate`, 게시 불가능한 `.invalid` URL)과 line-scope 재기술만 덮어쓴다. 1MB에 가까운 production 데이터를 복제하지 않고 참조로 승계해 원본과의 무성 drift를 구조적으로 막았다. 하네스가 이 spec으로 candidate fixture를 결정적으로 조립하며 production 트랙 파일은 어떤 경로로도 수정하지 않는다.
- **게이트 실행 하네스 추가** — `tools/datapack/run-nationwide-candidate-coverage-gate.mjs`. candidate fixture 조립 → `build-datapack.mjs --fixture` → `report-coverage-gaps.mjs --targets nationwide-coverage-targets.json --inventory --manifest --provenance --resolution-plan --resolutions` 를 한 명령으로 묶는다. baseline(재기술 이전)/lineScoped(재기술 이후) 두 실행을 같은 tracked 입력에서 함께 돌려 before/after가 언제든 재현된다. `--work-dir`로 중간 산출물을, `--emit-fixture`로 조립된 candidate fixture를 남길 수 있다.
- **서명 키 의존 제거** — 게이트는 required root pack의 field provenance `artifactKind`가 `production`일 때만 coverage를 인정하고(그 외 fail closed), production pack 서명은 RSA 개인키를 요구한다. 하네스는 실행마다 임시 RSA-2048 키쌍을 만들어 자식 프로세스 env로만 주입한다(`tools/release/build-datapack-prelaunch-gate-evidence.mjs` 선례). 저장소·CI 비밀에 서명 키가 필요 없고 키가 디스크에 남지 않는다.
- **파일럿 1 scope line-scope 재기술** — `capital:seoul-metro:seoul-4:route_map_positions`. 소스 `seoulmetro-cyberstation-route-map`의 `coverageScope`에 `lineIds: ["seoul-4"]`를 candidate 조립분과 `tools/datapack/source-inventory.json`(+앱 번들 사본)에 함께 기술했다. 하네스가 두 정본의 lineIds 일치를 fail closed로 확인한다.
- **결정적 evidence 커밋** — `tools/datapack/reports/nationwide-candidate-coverage-gate.json`. SUPPORTED 판정(requirement 키·필드 근거·소스)과 tier 분모만 기록하고, 임시 키에 좌우되는 manifest/pack 서명·manifest sha256, 런타임 SQLite에 좌우되는 sqliteSha256, resolutions 만료(wall-clock)에 좌우되는 EXPLICITLY_UNSUPPORTED·MISSING 집계는 기록 축에서 제외했다.
- **회귀 배선** — `tools/datapack/nationwide-candidate-coverage-gate.test.mjs`(4 test). CI는 `node --test tools/datapack/*.test.mjs`로 이미 glob 실행하므로 workflow 변경 없이 배선된다. 결정성·키 의존을 실측한 결과 evidence 바이트 재생성 + 전이 단언 + 정본 동기 fail closed + 게시 트랙 불변 단언이면 충분해 별도 workflow job은 만들지 않았다.
- **동반 갱신** — inventory 변경에 맞춰 `regeneration.pairedUpdateKo` 절차대로 tally ledger를 재생성했고, `validate-source-snapshot-freshness.mjs`가 강제하는 release hash binding 2건(`release/candidate-build-spec.json`, `release/hash-evidence.json`의 `sourceInventorySha256`)을 선례(#2508 PR AquilaXk/easysubway#2512)와 같이 갱신했다.

## 검증

- 실행한 명령과 결과:

```
$ node tools/datapack/run-nationwide-candidate-coverage-gate.mjs \
    --spec tools/datapack/nationwide-candidate-pack-spec.json \
    --targets tools/datapack/nationwide-coverage-targets.json \
    --inventory tools/datapack/source-inventory.json \
    --resolution-plan tools/datapack/release/nationwide-public-api-coverage-search-plan-20260725.json \
    --resolutions tools/datapack/release/nationwide-public-api-coverage-resolutions-20260725.json \
    --output tools/datapack/reports/nationwide-candidate-coverage-gate.json
(exit 0, 재실행 산출물과 tracked evidence 바이트 동일)

$ node --test tools/datapack/*.test.mjs
tests 1542 / pass 1542 / fail 0

$ node --test tools/ci/*.test.mjs tools/ci/lib/*.test.mjs tools/repo/*.test.mjs
tests 473 / pass 473 / fail 0

$ node --test tools/release/*.test.mjs
tests 90 / pass 90 / fail 0

$ node --test tools/route-map/*.test.mjs tools/realtime/*.test.mjs tools/security/*.test.mjs tools/ops/*.test.mjs
tests 491 / pass 491 / fail 0

$ node tools/ci/check-contracts.mjs
(exit 0)
```

게이트 before/after 실측(전이 requirement 키 `capital:seoul-metro:seoul-4:route_map_positions`):

| variant | LAUNCH_REQUIRED totalCount | supportedCount | 파일럿 requirement |
| --- | --- | --- | --- |
| baseline(재기술 이전) | 270 | **0** | MISSING, missingFields `route_map_position`·`route_map_label_polygon` |
| lineScoped(재기술 이후) | 270 | **1** | SUPPORTED, coveredFields 2/2, sourceIds `seoulmetro-cyberstation-route-map` |

수동 재현(하네스가 emit한 candidate fixture로 이슈의 재현 명령 그대로 실행):

```
$ node tools/datapack/build-datapack.mjs --fixture <emitted>/nationwide-candidate-pack.json --output <out>
$ node tools/datapack/report-coverage-gaps.mjs --targets tools/datapack/nationwide-coverage-targets.json \
    --inventory tools/datapack/source-inventory.json --manifest <out>/current.json \
    --provenance <out>/current.provenance.json \
    --resolution-plan tools/datapack/release/nationwide-public-api-coverage-search-plan-20260725.json \
    --resolutions tools/datapack/release/nationwide-public-api-coverage-resolutions-20260725.json \
    --output <out>/report.json --allow-gaps
→ supportedCount 1, [ 'capital:seoul-metro:seoul-4:route_map_positions' ]
```

tally ledger 집계 변화: LAUNCH_REQUIRED 270 / INVENTORY_ADMITTED 83 / EU 4 / MISSING 183(DUAL_OPERATOR_UNMATCHED 9, NO_ADMITTED_SOURCE 174) — **집계 상수 전부 불변**. 바뀐 것은 inventory 입력 해시와 진단 필드 3건뿐이다(파일럿 requirement의 `admittedSourceIds`에 `seoulmetro-cyberstation-route-map` 추가, 같은 노선 dual-operator 2건의 `coveringSourceIds` 추가). 파일럿 requirement가 재기술 이전부터 `seoul-metro-route-map-positions`로 이미 INVENTORY_ADMITTED였기 때문에 수치가 움직이지 않았다. 움직인 축을 고정하려고 tally 테스트에 파일럿 requirement의 `status`·`admittedSourceIds` 단언을 추가했다.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 게이트 before/after 전환 | 데이터 파이프라인 | 하네스 실행 후 evidence 확인 | `tools/datapack/reports/nationwide-candidate-coverage-gate.json`(`variants.baseline`/`variants.lineScoped`/`transitions`) | PASS (SUPPORTED 0 → 1) |
| candidate 빌드·게이트 재현 | 데이터 파이프라인 | `regeneration.command` 재실행 후 바이트 대조 | 위 evidence + `nationwide-candidate-coverage-gate.test.mjs` | PASS (바이트 동일) |
| production 게시 트랙 무변경 | 데이터 파이프라인 | 계약 테스트 실행 | `node --test tools/datapack/*.test.mjs`, `node --test tools/release/*.test.mjs` | PASS (1542/1542, 90/90) |
| inventory ↔ ledger 동반 갱신 | 데이터 파이프라인 | ledger 재생성 후 바이트 대조 | `tools/datapack/reports/nationwide-coverage-tally.json`, `build-nationwide-coverage-tally.test.mjs` | PASS |
| 사용자 화면 변경 | 모바일 | — | 증거 불필요 사유: 사용자 화면 변경 없음(candidate 트랙·evidence only). 앱 번들 inventory 사본은 `coverageScope.lineIds` 추가뿐이며 출처 화면은 이 필드를 읽지 않는다 | N/A |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] AquilaXk/easysubway#1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음(candidate `nationwide-candidate@1`은 게시 대상이 아니며 production `capital@1`은 무변경)
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `tools/datapack/run-nationwide-candidate-coverage-gate.mjs`의 fail-closed 4종 — baseline SUPPORTED 0, lineScoped SUPPORTED 집합 == spec `requirementKeys`, candidate root pack 단일·production, 두 variant의 pack payload 동일. 선언보다 넓은 전이가 나오면 하네스가 멈춘다.
  - candidate fixture를 파일로 복제하지 않고 spec + 결정적 조립으로 만든 선택. 이슈 문구는 "승계한 신규 파일"이지만 985KB production 데이터를 복제하면 원본과의 drift를 아무도 감지하지 못한다. spec이 승계 대상을 명시하고 하네스가 매 실행 원본에서 조립하므로 drift가 구조적으로 불가능하다. `--emit-fixture`로 조립 결과를 언제든 파일로 꺼내 이슈의 재현 명령을 그대로 돌릴 수 있다.
  - `tools/datapack/datapack-tools.test.mjs`의 기존 단언 변경(MISSING → SUPPORTED). 이 테스트는 tracked inventory의 coverageScope를 그대로 소비하는 `import-official-sources.mjs` 경로로 pack을 만들기 때문에 재기술 효과를 그대로 받는다. 같은 테스트의 release-scope 단언(in-scope gap 0, coverageComplete true)은 그대로 통과한다 — 게시 차단 판정은 capital pilot targets(schemaVersion 1)로 평가돼 lineIds 기술 유무에 영향을 받지 않는다.
  - `release/candidate-build-spec.json`·`release/hash-evidence.json`의 1줄 해시 갱신은 `validate-source-snapshot-freshness.mjs`가 강제하는 inventory 결합이다(선례 AquilaXk/easysubway#2512). 게시 fixture `capital-production-reviewed-pack.json`은 손대지 않았다.

## 리스크

- 승계 원본(`capital-production-reviewed-pack.json`)의 `pack.sourceInventory`는 게시 시점 스냅샷이라 operator-scope 기술을 유지하고, admission 정본(`source-inventory.json`)은 line-scope로 앞서간다. 게시 차단 판정은 pilot targets로 평가돼 동작이 갈리지 않지만 두 정본의 기술이 한동안 다르다. spec `productionTrackInvarianceKo`에 근거를 남겼고 production 트랙이 다음 재베이스라인 때 따라붙어야 한다.
- evidence는 SUPPORTED 축만 기록한다. resolutions `nextReviewAt`이 지나면 게이트의 EU·MISSING 집계가 같은 입력에서도 갈리는데 그 축은 tally ledger의 `earliestResolutionNextReviewAt`가 계속 담당한다. 이 evidence로 전국 gap 총량을 읽으면 안 된다.
- candidate pack URL은 게시가 불가능한 예약 도메인(`.invalid`)이다. 게이트가 root pack `artifactKind=production`을 요구해 production 형태로 조립하지만 게시 경로에는 올라갈 수 없다(리뷰 반영으로 `manifest.channel === "candidate"`·게시 불가 호스트를 `validateSpec` 기계 단언으로 승격했다). B1+에서 candidate를 실제로 배포하려면 별도 결정이 필요하다.
- **기존 결함(이 PR 이전부터 존재, 범위 밖)**: `tools/datapack/release/release-request.json`의 `buildSpecSha256`가 tracked `candidate-build-spec.json` 바이트와 불일치한다. 이 PR의 `sourceInventorySha256` 재결속으로 값이 또 한 번 갈리지만 원인은 이전부터 있던 stale binding이다. #2521로 분리해 추적한다.
- B1(대구 1·2·3호선 편입)은 spec의 승계 모델을 확장해야 한다. 현재 spec은 단일 승계 pack만 지원하며 다중 지역 병합 규칙은 B1에서 설계한다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 전국 후보 데이터 팩의 커버리지 게이트를 자동 실행하고, 기준 상태와 노선 범위 적용 상태를 비교하는 기능이 추가되었습니다.
  - 후보 팩의 커버리지 전환 및 재현 가능성을 확인하는 증거 리포트가 제공됩니다.

- **개선**
  - 서울 지하철 4호선 경로 지도 데이터의 적용 범위가 명확해졌습니다.
  - 해당 데이터가 관련 경로 위치 요구사항을 충족하는 것으로 반영되었습니다.

- **테스트**
  - 후보 팩의 범위 제한, 결정성, 안전한 배포 조건에 대한 검증이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->