### PR TITLE
[Fix] #2518 tools 변경 감지·테스트 글롭 잔여 갭 해소 — tools/mobile 매핑·orphan 테스트 편입·열거 가드

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -700,6 +700,17 @@ jobs:
           EASYSUBWAY_EXPECT_ANDROID_RELEASE_MANIFEST: "true"
         run: node --test --test-name-pattern "모바일 generic catch|모바일 접근성 출시 QA|릴리즈 보안 기준선|모바일 스토어 심사 정보 기준선|모바일 스토어 개인정보 인벤토리|Android 릴리즈 권한|iOS 앱은 개인정보 매니페스트|Android 런처 아이콘" tools/ci/repository-contract.test.mjs
 
+      # tools/mobile의 status voice 인벤토리는 apps/mobile/lib 트리를 실제로 스캔하는
+      # drift 가드다(#2518). repository 게이트의 계약 테스트 스텝에만 배선하면 Dart 전용
+      # PR(mobile=true, repository=false)에서 스킵되어, drift가 green으로 병합되고 실패는
+      # 나중에 무관한 PR에서 터진다. 위 mobile contracts 스텝은 --test-name-pattern으로
+      # 걸러지므로 별도 스텝으로 mobile 게이트에 연결한다.
+      - name: Mobile App CI / Run mobile tool tests
+        if: ${{ needs.changes.outputs.mobile == 'true' && steps.scaffold.outputs.present == 'true' }}
+        env:
+          NODE_OPTIONS: --disable-warning=ExperimentalWarning
+        run: node --test tools/mobile/*.test.mjs
+
       - name: Mobile App CI / Run Flutter analyzer and tests
         if: ${{ needs.changes.outputs.mobile == 'true' && steps.scaffold.outputs.present == 'true' }}
         working-directory: apps/mobile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -473,7 +473,7 @@ jobs:
         if: ${{ needs.changes.outputs.repository == 'true' || needs.changes.outputs.docs_only == 'true' || needs.changes.outputs.ci == 'true' }}
         env:
           NODE_OPTIONS: --disable-warning=ExperimentalWarning
-        run: node --test tools/ci/*.test.mjs tools/ci/lib/*.test.mjs tools/repo/*.test.mjs
+        run: node --test tools/ci/*.test.mjs tools/ci/lib/*.test.mjs tools/repo/*.test.mjs tools/lib/*.test.mjs tools/mobile/*.test.mjs
 
       - name: Repository CI / Validate contracts
         if: ${{ needs.changes.outputs.contracts == 'true' }}

--- a/tools/ci/detect-changed-paths.sh
+++ b/tools/ci/detect-changed-paths.sh
@@ -93,6 +93,16 @@ while IFS= read -r file; do
       ios=true
       deploy=true
       ;;
+    tools/mobile/**)
+      # tools/mobile은 Android 릴리즈 산출물 가드(dart-define 검증, 16KB page size,
+      # ELF load 정렬)와 status voice 인벤토리를 담는다(#2518).
+      # repository=true: 이 스크립트를 읽고 실행하는 계약 테스트가 스킵되면 안 된다.
+      # android=true: 가드를 실제로 실행하는 소비자는 release-artifacts.yml의
+      #   android-release job(if: android || mobile)이다. mobile=true는 tools/mobile을
+      #   소비하지 않는 Flutter mobile-app job까지 깨우므로 올리지 않는다.
+      repository=true
+      android=true
+      ;;
     tools/route-map/**|tools/routes/**)
       repository=true
       route_map=true

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -18264,6 +18264,24 @@ test("CI 계약 테스트 스텝은 tools/lib, tools/mobile 테스트 글롭을 
   }
 });
 
+// #2518: status voice 인벤토리는 apps/mobile/lib 트리를 스캔하는 drift 가드라,
+// repository 게이트의 계약 테스트 스텝만으로는 Dart 전용 PR(mobile=true, repository=false)에서
+// 스킵된다. mobile 게이트에도 배선되어 있어야 두 변경 클래스가 모두 닫힌다.
+test("Mobile App CI는 tools/mobile 도구 테스트를 mobile 게이트 전용 스텝으로 실행한다", () => {
+  const workflow = read(".github/workflows/ci.yml");
+  const mobileToolStep = workflow.match(
+    /- name: Mobile App CI \/ Run mobile tool tests\n        if: (\$\{\{[^\n]*\}\})\n[\s\S]*?\n        run: (node --test [^\n]*)\n/,
+  );
+  assert.ok(mobileToolStep, "Mobile App CI must declare a mobile-gated tools/mobile test step");
+
+  const [, gate, command] = mobileToolStep;
+  assert.match(gate, /needs\.changes\.outputs\.mobile == 'true'/);
+  assert.match(gate, /steps\.scaffold\.outputs\.present == 'true'/);
+  assert.ok(command.includes("tools/mobile/*.test.mjs"), "mobile tool test step must run tools/mobile/*.test.mjs");
+  // --test-name-pattern이 붙으면 이름이 걸러져 drift 가드가 실행되지 않는다.
+  assert.doesNotMatch(command, /--test-name-pattern/);
+});
+
 test("경로 분류기는 백엔드 품질 gate 변경을 repository contract 대상으로 처리한다", async () => {
   const outputs = await classifyChangedFiles(["backend/quality/static-analysis-gate.json"]);
 

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { execFile, execFileSync } from "node:child_process";
 import { createHash, generateKeyPairSync, sign as signBytes } from "node:crypto";
-import { lstat as fsLstat, mkdir, mkdtemp, readFile, rm, symlink, utimes, writeFile } from "node:fs/promises";
+import { lstat as fsLstat, mkdir, mkdtemp, readFile, readdir, rm, symlink, utimes, writeFile } from "node:fs/promises";
 import { existsSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -18200,12 +18200,59 @@ test("경로 분류기는 저장소, 백엔드, 모바일, Android, iOS 변경�
   assert.equal(releaseTool.deploy, "false");
   assert.equal(releaseTool.release, "true");
 
+  // #2518: tools/mobile은 Android 릴리즈 산출물 가드를 담고 있어, 단독 변경에서도
+  // 계약 테스트(repository)와 release-artifacts android-release(android)가 돌아야 한다.
+  const mobileTool = await classifyChangedFiles(["tools/mobile/validate-release-dart-defines.sh"]);
+  assert.equal(mobileTool.repository, "true");
+  assert.equal(mobileTool.android, "true");
+  assert.equal(mobileTool.docs_only, "false");
+  assert.equal(mobileTool.ios, "false");
+  assert.equal(mobileTool.deploy, "false");
+
   const releaseGate = await classifyChangedFiles(["apps/mobile/release/release-governance-gate.json"]);
   assert.equal(releaseGate.release, "true");
   assert.equal(releaseGate.contracts, "true");
   assert.equal(releaseGate.mobile, "true");
   // #2390: release 자산 변경은 repository=true여야 claim 스캔(contract test)이 스킵되지 않는다.
   assert.equal(releaseGate.repository, "true");
+});
+
+// #2518: tools/ 하위에 새 디렉토리가 생겨도 detect-changed-paths.sh 매핑 누락이
+// 조용히 재발하지 않도록, 실제 디렉토리 목록을 열거해 최소 게이트를 강제한다.
+test("경로 분류기는 tools/ 하위 모든 디렉토리를 최소 repository 게이트로 분류한다", async () => {
+  const entries = await readdir(path.join(root, "tools"), { withFileTypes: true });
+  const toolDirs = entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name).sort();
+  assert.ok(toolDirs.length > 0, "tools/ must contain at least one subdirectory");
+
+  for (const dir of toolDirs) {
+    const outputs = await classifyChangedFiles([`tools/${dir}/detect-changed-paths-coverage-probe.txt`]);
+    assert.equal(
+      outputs.repository,
+      "true",
+      `tools/${dir}/** must map to repository=true in tools/ci/detect-changed-paths.sh`,
+    );
+    assert.equal(outputs.docs_only, "false", `tools/${dir}/** must not be classified as docs-only`);
+  }
+});
+
+// #2518: orphan 테스트 재발 방지 — tools/lib, tools/mobile 테스트는 계약 테스트 스텝 글롭에 있어야 한다.
+test("CI 계약 테스트 스텝은 tools/lib, tools/mobile 테스트 글롭을 포함한다", () => {
+  const workflow = read(".github/workflows/ci.yml");
+  const contractStep = workflow.match(
+    /- name: Repository CI \/ Run contract tests\n[\s\S]*?\n        run: (node --test [^\n]*)\n/,
+  );
+  assert.ok(contractStep, "Repository CI / Run contract tests step must declare a node --test run");
+
+  const command = contractStep[1];
+  for (const glob of [
+    "tools/ci/*.test.mjs",
+    "tools/ci/lib/*.test.mjs",
+    "tools/repo/*.test.mjs",
+    "tools/lib/*.test.mjs",
+    "tools/mobile/*.test.mjs",
+  ]) {
+    assert.ok(command.includes(glob), `contract test step must run ${glob}`);
+  }
 });
 
 test("경로 분류기는 백엔드 품질 gate 변경을 repository contract 대상으로 처리한다", async () => {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -18202,12 +18202,21 @@ test("경로 분류기는 저장소, 백엔드, 모바일, Android, iOS 변경�
 
   // #2518: tools/mobile은 Android 릴리즈 산출물 가드를 담고 있어, 단독 변경에서도
   // 계약 테스트(repository)와 release-artifacts android-release(android)가 돌아야 한다.
-  const mobileTool = await classifyChangedFiles(["tools/mobile/validate-release-dart-defines.sh"]);
-  assert.equal(mobileTool.repository, "true");
-  assert.equal(mobileTool.android, "true");
-  assert.equal(mobileTool.docs_only, "false");
-  assert.equal(mobileTool.ios, "false");
-  assert.equal(mobileTool.deploy, "false");
+  // mobile=false도 계약이다 — tools/mobile을 소비하지 않는 Flutter mobile-app job까지
+  // 깨우지 않는다. 알려진 파일과 임의의 중첩 경로를 각각 따로 분류해, 매핑이 특정 파일로
+  // 좁아지는 회귀와 mobile 게이트가 잘못 올라가는 회귀를 모두 잡는다.
+  for (const mobileToolFile of [
+    "tools/mobile/validate-release-dart-defines.sh",
+    "tools/mobile/nested/arbitrary-coverage-probe.txt",
+  ]) {
+    const mobileTool = await classifyChangedFiles([mobileToolFile]);
+    assert.equal(mobileTool.repository, "true", `${mobileToolFile} must map to repository=true`);
+    assert.equal(mobileTool.android, "true", `${mobileToolFile} must map to android=true`);
+    assert.equal(mobileTool.mobile, "false", `${mobileToolFile} must not raise the mobile gate`);
+    assert.equal(mobileTool.docs_only, "false", `${mobileToolFile} must not be docs-only`);
+    assert.equal(mobileTool.ios, "false", `${mobileToolFile} must not raise the ios gate`);
+    assert.equal(mobileTool.deploy, "false", `${mobileToolFile} must not raise the deploy gate`);
+  }
 
   const releaseGate = await classifyChangedFiles(["apps/mobile/release/release-governance-gate.json"]);
   assert.equal(releaseGate.release, "true");


### PR DESCRIPTION
## 관련 이슈

close #2518

## 작업 배경

- PR #2517 독립 리뷰 실측(2026-07-25)에서 남은 CI 변경 감지·테스트 글롭 갭 3건이 확인됐다.
- `tools/mobile/**`는 `tools/ci/detect-changed-paths.sh`에서 유일하게 미매핑으로 남은 tools 하위 디렉토리였다. 단독 변경 시 전 플래그 false가 되어 계약 테스트·경계 검사·Android 릴리즈 산출물 가드가 전부 스킵됐다(#2515와 동일 클래스).
- `tools/lib/is-main-module.test.mjs`, `tools/mobile/status-voice-inventory.test.mjs`는 `ci.yml`의 어떤 테스트 글롭에도 편입되어 있지 않아 CI에서 한 번도 실행되지 않았다.
- 감지 스크립트에 열거 가드가 없어 새 tools 하위 디렉토리가 생기면 미매핑이 조용히 재발한다.

## 작업 내용

- `tools/ci/detect-changed-paths.sh`에 `tools/mobile/**` → `repository=true`, `android=true` 매핑을 추가했다. 플래그는 소비자 실측으로 판정했다.
  - `repository`: `tools/ci/repository-contract.test.mjs`가 `validate-release-dart-defines.sh`, `check-android-aab-16kb-page-size.sh`, `check-elf-load-alignment.mjs`, `run-route-map-android-evidence.sh` 등을 읽고 실행한다. 이 테스트가 도는 `Repository CI / Run contract tests` 스텝 게이트는 `repository || docs_only || ci`다. 같은 이유로 `Repository CI / Check directory boundaries`도 `repository`로 열린다.
  - `android`: 이 가드를 실제로 실행하는 유일한 job은 `.github/workflows/release-artifacts.yml`의 `android-release`(`if: android == 'true' || mobile == 'true'`)로, `validate-release-dart-defines.sh`와 16KB page size/ELF 정렬 스크립트를 소비한다.
  - `mobile`은 올리지 않았다. `android`만으로 `android-release` 게이트가 열리고, `mobile=true`는 `tools/mobile`을 전혀 소비하지 않는 `ci.yml`의 `mobile-app` job(flutter analyze/test)까지 깨우기 때문이다.
- `.github/workflows/ci.yml`의 계약 테스트 스텝 글롭에 `tools/lib/*.test.mjs tools/mobile/*.test.mjs`를 편입했다.
  - 두 orphan 테스트가 현행 코드에서 실제 통과함을 편입 전 로컬 실행으로 확인했다(아래 검증).
  - `apps/mobile/release/post-launch-operations-review-gate.json`의 `refreshBindings` 해시 pin 목록을 재실측한 결과 `.github/workflows/ci.yml`은 pin 대상이 아니다(pin된 워크플로는 `release-artifacts.yml`, `datapack-release.yml` 2건). `tools/ci/detect-changed-paths.sh`, `tools/ci/repository-contract.test.mjs`도 pin 대상이 아니다.
- `tools/ci/repository-contract.test.mjs`에 회귀 3종을 추가했다.
  - `tools/mobile/validate-release-dart-defines.sh` 단독 변경의 분류 고정(`repository=true`, `android=true`, `ios=false`, `deploy=false`, `docs_only=false`).
  - 재발 방지 열거 가드: `tools/` 하위 디렉토리를 `readdir`로 열거해 각 경로가 최소 `repository=true`, `docs_only=false`로 분류되는지 강제.
  - `ci.yml` 계약 테스트 스텝 글롭이 `tools/ci`, `tools/ci/lib`, `tools/repo`, `tools/lib`, `tools/mobile` 5개 글롭을 모두 포함하는지 고정.

## 검증

- 실행한 명령과 결과:

`tools/mobile` 단독 변경 분류 (변경 전 → 후, `changed-files.txt = tools/mobile/status-voice-inventory.mjs`):

```
# BEFORE
android=false  backend=false  mobile=false  ios=false  repository=false
docs_only=false  ci=false  deploy=false  datapack=false  route_map=false
realtime=false  release=false  contracts=false

# AFTER
android=true   backend=false  mobile=false  ios=false  repository=true
docs_only=false  ci=false  deploy=false  datapack=false  route_map=false
realtime=false  release=false  contracts=false
```

`tools/` 하위 14개 디렉토리 전수 실측 (`repository` 플래그):

```
# BEFORE                          # AFTER
tools/ci        -> true           tools/ci        -> true
tools/datapack  -> true           tools/datapack  -> true
tools/deploy    -> true           tools/deploy    -> true
tools/lib       -> true           tools/lib       -> true
tools/mobile    -> false  <<<     tools/mobile    -> true   <<<
tools/ops       -> true           tools/ops       -> true
tools/qa        -> true           tools/qa        -> true
tools/realtime  -> true           tools/realtime  -> true
tools/release   -> true           tools/release   -> true
tools/repo      -> true           tools/repo      -> true
tools/route-map -> true           tools/route-map -> true
tools/routes    -> true           tools/routes    -> true
tools/security  -> true           tools/security  -> true
tools/test      -> true           tools/test      -> true
```

orphan 테스트 편입 전 로컬 실행 (현행 코드 통과 확인):

```
$ node --test tools/lib/*.test.mjs
ℹ tests 1   ℹ pass 1   ℹ fail 0

$ node --test tools/mobile/*.test.mjs
ℹ tests 12  ℹ pass 12  ℹ fail 0
```

기존 글롭(회귀 확인):

```
$ node --test tools/ci/*.test.mjs tools/ci/lib/*.test.mjs tools/repo/*.test.mjs
ℹ tests 475  ℹ pass 475  ℹ fail 0  ℹ duration_ms 44990.2
```

편입 후 신규 글롭(= CI가 실제로 실행할 명령):

```
$ node --test tools/ci/*.test.mjs tools/ci/lib/*.test.mjs tools/repo/*.test.mjs \
       tools/lib/*.test.mjs tools/mobile/*.test.mjs
ℹ tests 488  ℹ pass 488  ℹ fail 0  ℹ duration_ms 49337.1
```

계약·경계·워크플로 린트:

```
$ node tools/ci/check-contracts.mjs   # exit 0
$ node tools/ci/check-boundaries.mjs  # exit 0
$ bash -n tools/ci/detect-changed-paths.sh   # exit 0
$ actionlint .github/workflows/ci.yml        # clean
```

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| `tools/mobile` 단독 변경 게이트 분류 | CI | `bash tools/ci/detect-changed-paths.sh changed-files.txt` 변경 전/후 실행 | 본문 "검증" 섹션 전/후 출력 | pass (`repository=false` → `repository=true`, `android=true`) |
| tools 하위 디렉토리 전수 매핑 | CI | 14개 디렉토리 단독 변경 분류 실측 + 열거 가드 회귀 테스트 | 본문 "검증" 섹션 전/후 표 | pass (14/14 `repository=true`) |
| orphan 테스트 CI 편입 | CI | `node --test tools/lib/*.test.mjs tools/mobile/*.test.mjs` | 1 pass / 12 pass, fail 0 | pass |
| 계약 테스트 글롭 회귀 | CI | 기존 글롭 및 편입 후 글롭 전체 실행 | 475 pass → 488 pass, fail 0 | pass |
| `refreshBindings` 해시 pin 영향 | CI | `post-launch-operations-review-gate.json` pin 경로 목록 재실측 | `.github/workflows/ci.yml` pin 미포함(pin 워크플로는 `release-artifacts.yml`, `datapack-release.yml`) | 영향 없음 |
| 사용자 화면 변경 | mobile | - | `증거 불필요 사유`: 사용자 화면 변경 없음(CI 게이트 only) | 해당 없음 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `tools/mobile/**`에 `mobile=true`를 올리지 않은 판단. `release-artifacts.yml`의 `android-release` 게이트가 `android || mobile`이라 `android`만으로 소비자에 도달하며, `mobile=true`는 `tools/mobile`을 소비하지 않는 `ci.yml`의 `mobile-app` job까지 불필요하게 깨운다. 다만 이 매핑은 현행 감지 스크립트에서 처음으로 `android=true`이면서 `mobile=false`가 되는 경로다(기존 규칙은 모두 android와 mobile을 함께 올렸다). `ci.yml`의 `android` job은 `needs.changes.outputs.android`만 참조해 자족적이므로 이 조합이 깨지는 소비자는 없음을 실측했다.
- 열거 가드는 `tools/` 하위 디렉토리를 `readdir`로 열거하므로, 새 디렉토리를 매핑 없이 추가하면 이 테스트가 즉시 실패한다.

## 리스크

- `tools/mobile` 변경 시 `ci.yml`의 Android CI job(디버그 APK 빌드)이 추가로 도는 비용이 생긴다. `android` 플래그가 `release-artifacts.yml`의 `android-release` 소비자에 도달하기 위한 최소 선택이라 감수했다.
- 이번 PR 범위 밖 잔여 orphan 테스트가 실측됐다: `tools/routes/*.test.mjs`(7건), `tools/qa/*.test.mjs`(1건), `tools/datapack/lib/*.test.mjs`(1건)도 `ci.yml`의 어떤 `node --test` 글롭에도 편입되어 있지 않다(이슈 #2518은 orphan 2건만 범위로 명시). 후속 이슈 #2558로 등록했다 — 9건 전부 현행 코드에서 통과함(82 tests / 82 pass / 0 fail)을 실측해 배경에 기재했고, 편입과 함께 `tools/**/*.test.mjs` 열거 가드를 매핑 가드와 동형으로 추가하는 것을 완료 조건에 넣었다.
- `ci.yml` 계약 테스트 스텝이 13건 늘어 실행 시간이 약 4.3초 증가한다(로컬 실측 44.99s → 49.34s).

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음 — CI 게이트 변경 only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 모바일 도구 관련 변경 사항이 저장소 및 Android 검사 대상에 올바르게 반영됩니다.
  - CI에서 라이브러리와 모바일 도구 영역의 계약 테스트까지 자동으로 실행합니다.
  - 도구 디렉터리의 테스트가 CI 실행 범위에서 누락되지 않는지 자동으로 확인합니다.

- **버그 수정**
  - 모바일 관련 파일 변경 시 CI 검사 플래그가 잘못 분류될 수 있는 문제를 수정했습니다.
  - 변경 경로 분류와 문서 전용 변경 판정에 대한 회귀 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
