### PR TITLE
[Fix] #2615 timetable auto-refresh 승격 경로를 정본 디렉터리에 맞춘다

### DIFF
--- a/.github/workflows/timetable-auto-refresh.yml
+++ b/.github/workflows/timetable-auto-refresh.yml
@@ -222,7 +222,7 @@ jobs:
           node tools/datapack/collect-korail-itx-cheongchun-timetable.mjs \
             --promote-candidate "${EASYSUBWAY_ITX_CANDIDATE}" \
             --completeness-evidence "${EASYSUBWAY_ITX_COMPLETENESS}" \
-            --source-output-dir "${GITHUB_WORKSPACE}" \
+            --source-output-dir "${GITHUB_WORKSPACE}/tools/datapack/sources" \
             --coverage-contract tools/datapack/itx-cheongchun-coverage-contract.json
           git add -N tools/datapack/sources tools/datapack/itx-cheongchun-coverage-contract.json
           git diff -- tools/datapack/sources tools/datapack/itx-cheongchun-coverage-contract.json > "${EASYSUBWAY_ITX_REFRESH_PATCH}"

--- a/tools/ci/timetable-auto-refresh-workflow.test.mjs
+++ b/tools/ci/timetable-auto-refresh-workflow.test.mjs
@@ -94,6 +94,10 @@ test("collect는 admission service dates를 전달하고 승격은 UNCHANGED_AUT
     /steps\.collect\.outputs\.collect_exit == '0' && steps\.collect\.outputs\.promotion_status == 'SUPPORTED'/,
   );
   assert.match(workflow, /--promote-candidate "\$\{EASYSUBWAY_ITX_CANDIDATE\}"/);
+  assert.match(
+    workflow,
+    /--source-output-dir "\$\{GITHUB_WORKSPACE\}\/tools\/datapack\/sources"/,
+  );
 });
 
 test("승인 게이트를 우회하지 않고 review-required·수집 실패 시 fail closed 한다", () => {


### PR DESCRIPTION
## 관련 이슈

Closes #2615

## 작업 배경

- scheduled run 30219996115에서 ITX 후보 수집은 `collect_exit=0`, `promotion_status=SUPPORTED`로 완료됐지만 `Promote unchanged source (UNCHANGED_AUTO)`가 `ADMITTED_SOURCE_REFERENCE_INVALID`로 실패했다.
- workflow가 repository root를 `--source-output-dir`로 넘겼고, collector는 canonical `<repositoryRoot>/tools/datapack/sources`만 허용해 `promotion.patch`가 생성되지 않았다.

## 작업 내용

- promotion command의 `--source-output-dir`을 `${GITHUB_WORKSPACE}/tools/datapack/sources`로 교정했다.
- workflow 계약 테스트가 canonical source directory wiring을 고정하도록 assertion을 추가했다.
- `contents: read`, 승인 게이트, artifact 업로드, 수동 PR·리뷰·병합 정책은 변경하지 않았다.

## 검증

- 실행한 명령과 결과:
  - RED: `node --test tools/ci/timetable-auto-refresh-workflow.test.mjs` → 새 assertion에서 12 pass / 1 fail
  - GREEN: `node --test tools/ci/timetable-auto-refresh-workflow.test.mjs` → 13 pass / 0 fail
  - `node --test tools/datapack/collect-korail-itx-cheongchun-timetable.test.mjs` → 111 pass / 0 fail
  - `git diff --check origin/main...HEAD` → PASS

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 기존 실패 재현 | GitHub Actions | scheduled run 로그 확인 | https://github.com/AquilaXk/easysubway/actions/runs/30219996115 | `ADMITTED_SOURCE_REFERENCE_INVALID` 확인 |
| workflow wiring TDD | Node.js 24 | 변경 전 RED, 변경 후 GREEN | `tools/ci/timetable-auto-refresh-workflow.test.mjs` | 13/13 PASS |
| 실제 collector promotion 회귀 | Node.js 24 | collector 전체 테스트 | `tools/datapack/collect-korail-itx-cheongchun-timetable.test.mjs` | 111/111 PASS |
| UI·접근성·수동 QA | 해당 없음 | workflow CLI 인자 1행 수정 | 사용자 화면·접근성 변경 없음 | N/A |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - workflow 인자가 collector의 `validateSourceOutputPath` 계약과 정확히 일치하는지
  - read-only 권한과 기존 승인/fail-closed 조건이 그대로인지
  - 새 assertion이 repository root로의 회귀를 잡는지

## 리스크

- 실제 provider 재수집과 artifact의 `promotion.patch` 생성은 다음 workflow 실행 전까지 live 검증되지 않는다. 이 PR은 실패 지점의 deterministic directory 계약만 수정하며 provider·승격 정책은 변경하지 않는다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다. (CI run 30238699155 성공)
- [x] CodeRabbit 리뷰를 확인했다. (draft PR로 review skipped)
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 자동 시간표 새로고침 시 변경되지 않은 데이터의 결과물이 올바른 소스 디렉터리에 생성되도록 수정했습니다.

* **테스트**
  * 자동 갱신 작업이 지정된 출력 경로를 사용하는지 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->