### PR TITLE
[Test] #2592 candidate line-scope 재기술 누락 fail-closed

### DIFF
--- a/tools/datapack/nationwide-candidate-coverage-gate.test.mjs
+++ b/tools/datapack/nationwide-candidate-coverage-gate.test.mjs
@@ -1557,8 +1557,9 @@ test("candidate 안전 경계는 spec 편집만으로 넓힐 수 없다", async 
     );
   });
 
-  // 등재 소스를 빼면 그 소스는 baseline에서도 line-scope를 유지해 판정 자체는 그대로 나온다 —
-  // 전이를 뒷받침한 소스와 등재 목록의 일치 축만 이 누락을 잡는다.
+  // 등재 소스를 빼면 그 소스는 baseline에서도 line-scope를 유지해 판정 자체는 그대로 나온다. #2592의
+  // actual required set 역결속이 buildEvidence 이전에 이 누락을 막으므로, 더 늦은 supporting-source 대조가
+  // 아니라 선언/실측 exact-match 진단을 기대한다.
   await context.test("전이를 뒷받침한 소스가 등재 목록과 다르면 거부된다", async () => {
     await rejectsWith(
       (value) => {
@@ -1566,9 +1567,30 @@ test("candidate 안전 경계는 spec 편집만으로 넓힐 수 없다", async 
           ({ sourceId }) => sourceId !== "molit-urban-rail-full-route-daegu-line1-membership",
         );
       },
-      /supporting sources must equal the spec redescriptions/,
+      /line-scope redescriptions must exactly match the actual required set/,
     );
   });
+
+  // 선언 목록을 순회하는 검증만으로는 실제 candidate pack에 line-scope가 있는 소스를 선언에서 통째로
+  // 빼도 baseline과 lineScoped가 함께 그 scope를 유지해 통과한다. actual required set 역결속이 이
+  // 삭제를 source/domain 단위로 막아야 한다.
+  for (const { sourceId, sourceDomain } of [
+    { sourceId: "busan-transportation-timetable", sourceDomain: "schedule_timetable" },
+    { sourceId: "busan-transportation-route-map-positions", sourceDomain: "route_map_positions" },
+    { sourceId: "busan-transportation-accessibility", sourceDomain: "accessibility_facilities" },
+    { sourceId: "daegu-transportation-accessibility", sourceDomain: "accessibility_facilities" },
+  ]) {
+    await context.test(`${sourceId}/${sourceDomain} 재기술을 지우면 거부된다`, async () => {
+      await rejectsWith(
+        (value) => {
+          value.lineScopeRedescriptions = value.lineScopeRedescriptions.filter(
+            (entry) => entry.sourceId !== sourceId || entry.sourceDomain !== sourceDomain,
+          );
+        },
+        /line-scope redescriptions must exactly match the actual required set/,
+      );
+    });
+  }
 
   await context.test("선언과 다른 행수를 싣는 편입은 거부된다", async () => {
     await rejectsWith(
@@ -2479,7 +2501,8 @@ test("candidate 안전 경계는 spec 편집만으로 넓힐 수 없다", async 
           `capital:incheon-transit:${INCHEON_LINE1_ID}:route_graph_topology`;
       },
       new RegExp(
-        "requirements declared as non-transitioning must not be SUPPORTED after the line-scope redescription: "
+        "line-scope redescriptions must exactly match the actual required set"
+          + "|requirements declared as non-transitioning must not be SUPPORTED after the line-scope redescription: "
           + `capital:incheon-transit:${INCHEON_LINE1_ID}:route_graph_topology`,
       ),
     );
@@ -2510,7 +2533,7 @@ test("candidate 안전 경계는 spec 편집만으로 넓힐 수 없다", async 
   await context.test("선언 없이 전환되지 않는 requirement가 남으면 거부된다", async () => {
     await rejectsWith(
       (value) => { delete nonTransitionEntryOf(value).redescription.nonTransitioningRequirements; },
-      /line-scoped SUPPORTED requirements must equal baseline plus the spec redescription requirementKeys/,
+      /line-scope redescriptions must exactly match the actual required set|line-scoped SUPPORTED requirements must equal baseline plus the spec redescription requirementKeys/,
     );
   });
 

--- a/tools/datapack/nationwide-candidate-coverage-gate.test.mjs
+++ b/tools/datapack/nationwide-candidate-coverage-gate.test.mjs
@@ -3042,30 +3042,27 @@ function lineScopeExactMatchFixture(sourceId, sourceDomain, releaseTier = "LAUNC
   };
 }
 
-function assertLineScopeExactMatch({ spec, pack, inventory, targets }) {
-  return assertLineScopeRedescriptionsMatchActualRequiredSet(spec, pack, inventory, targets);
-}
-
-test("actual line-scope set은 네 source/domain omission을 독립적으로 거부한다", () => {
-  for (const { sourceId, sourceDomain } of [
-    { sourceId: "busan-transportation-timetable", sourceDomain: "schedule_timetable" },
-    { sourceId: "busan-transportation-route-map-positions", sourceDomain: "route_map_positions" },
-    { sourceId: "busan-transportation-accessibility", sourceDomain: "accessibility_facilities" },
-    { sourceId: "daegu-transportation-accessibility", sourceDomain: "accessibility_facilities" },
-  ]) {
+for (const { sourceId, sourceDomain } of [
+  { sourceId: "busan-transportation-timetable", sourceDomain: "schedule_timetable" },
+  { sourceId: "busan-transportation-route-map-positions", sourceDomain: "route_map_positions" },
+  { sourceId: "busan-transportation-accessibility", sourceDomain: "accessibility_facilities" },
+  { sourceId: "daegu-transportation-accessibility", sourceDomain: "accessibility_facilities" },
+]) {
+  test(`${sourceId}/${sourceDomain} omission은 actual line-scope set에서 거부된다`, () => {
     const fixture = lineScopeExactMatchFixture(sourceId, sourceDomain);
     fixture.spec.lineScopeRedescriptions = [];
     assert.throws(
-      () => assertLineScopeExactMatch(fixture),
+      () => assertLineScopeRedescriptionsMatchActualRequiredSet(fixture.spec, fixture.pack, fixture.inventory, fixture.targets),
       /line-scope redescriptions must exactly match the actual required set/,
-      `${sourceId}/${sourceDomain}`,
     );
-  }
-});
+  });
+}
 
 test("actual line-scope 선언은 source/domain, lineIds, requirementKeys가 정확히 일치해야 한다", () => {
   const valid = lineScopeExactMatchFixture("source", "schedule_timetable");
-  assert.doesNotThrow(() => assertLineScopeExactMatch(valid));
+  assert.doesNotThrow(() => assertLineScopeRedescriptionsMatchActualRequiredSet(
+    valid.spec, valid.pack, valid.inventory, valid.targets,
+  ));
 
   for (const [label, mutate, expected] of [
     [
@@ -3093,7 +3090,13 @@ test("actual line-scope 선언은 source/domain, lineIds, requirementKeys가 정
   ]) {
     const fixture = structuredClone(valid);
     mutate(fixture);
-    assert.throws(() => assertLineScopeExactMatch(fixture), expected, label);
+    assert.throws(
+      () => assertLineScopeRedescriptionsMatchActualRequiredSet(
+        fixture.spec, fixture.pack, fixture.inventory, fixture.targets,
+      ),
+      expected,
+      label,
+    );
   }
 });
 
@@ -3101,11 +3104,15 @@ test("inactive scope와 LAUNCH_REQUIRED가 아닌 domain은 actual line-scope se
   const inactive = lineScopeExactMatchFixture("inactive", "schedule_timetable");
   inactive.spec.lineScopeRedescriptions = [];
   inactive.targets.activeLineScopes = [];
-  assert.doesNotThrow(() => assertLineScopeExactMatch(inactive));
+  assert.doesNotThrow(() => assertLineScopeRedescriptionsMatchActualRequiredSet(
+    inactive.spec, inactive.pack, inactive.inventory, inactive.targets,
+  ));
 
   const enhancement = lineScopeExactMatchFixture("enhancement", "schedule_timetable", "ENHANCEMENT");
   enhancement.spec.lineScopeRedescriptions = [];
-  assert.doesNotThrow(() => assertLineScopeExactMatch(enhancement));
+  assert.doesNotThrow(() => assertLineScopeRedescriptionsMatchActualRequiredSet(
+    enhancement.spec, enhancement.pack, enhancement.inventory, enhancement.targets,
+  ));
 });
 
 test("pack-only lineIds와 inventory 누락 lineIds는 fail closed다", () => {
@@ -3113,15 +3120,15 @@ test("pack-only lineIds와 inventory 누락 lineIds는 fail closed다", () => {
     lineIds: ["line"], sourceDomains: ["schedule_timetable"], regionIds: ["region"], operatorIds: ["operator"],
   };
   assert.throws(
-    () => assertLineScopeExactMatch({
-      spec: { lineScopeRedescriptions: [] },
-      pack: { sourceInventory: [{ id: "pack-only", coverageScope }] },
-      inventory: { sources: [{ id: "pack-only", coverageScope: { ...coverageScope, lineIds: [] } }] },
-      targets: {
+    () => assertLineScopeRedescriptionsMatchActualRequiredSet(
+      { lineScopeRedescriptions: [] },
+      { sourceInventory: [{ id: "pack-only", coverageScope }] },
+      { sources: [{ id: "pack-only", coverageScope: { ...coverageScope, lineIds: [] } }] },
+      {
         requiredSourceDomains: [{ id: "schedule_timetable", releaseTier: "LAUNCH_REQUIRED" }],
         activeLineScopes: [{ regionId: "region", operatorId: "operator", lineId: "line" }],
       },
-    }),
+    ),
     /candidate pack coverageScope\.lineIds must match source inventory: pack-only/,
   );
 });

--- a/tools/datapack/nationwide-candidate-coverage-gate.test.mjs
+++ b/tools/datapack/nationwide-candidate-coverage-gate.test.mjs
@@ -3022,3 +3022,36 @@ test("production 게시 트랙 fixture는 candidate 조립에 영향받지 않�
   // candidate 조립이 게시 정체성(id·version·url·channel·activePack)을 건드리지 않는다는 위 행위 단언과
   // datapack/release 계약 테스트로 유지한다.
 });
+
+test("누락된 재기술은 emit fixture를 남기지 않고 거부된다", async () => {
+  const spec = await readJson(SPEC_PATH);
+  const inventory = await readJson(INVENTORY_PATH);
+  spec.lineScopeRedescriptions = spec.lineScopeRedescriptions.filter(
+    ({ sourceId, sourceDomain }) =>
+      sourceId !== "busan-transportation-timetable" || sourceDomain !== "schedule_timetable",
+  );
+  const workspace = await mkdtemp(path.join(tmpdir(), "nationwide-candidate-gate-no-emit-"));
+  const emitFixturePath = path.join("tmp", `nationwide-candidate-gate-no-emit-${process.pid}.json`);
+  const emittedPath = path.join(root, emitFixturePath);
+  await rm(emittedPath, { force: true });
+  try {
+    await assert.rejects(
+      runNationwideCandidateCoverageGate({
+        spec,
+        specInput: { path: SPEC_PATH, sha256: "a".repeat(64) },
+        targetsInput: { path: TARGETS_PATH, sha256: "b".repeat(64) },
+        inventory,
+        inventoryInput: { path: INVENTORY_PATH, sha256: "c".repeat(64) },
+        resolutionPlanInput: { path: RESOLUTION_PLAN_PATH, sha256: "d".repeat(64) },
+        resolutionsInput: { path: RESOLUTIONS_PATH, sha256: "e".repeat(64) },
+        workDir: workspace,
+        emitFixturePath,
+      }),
+      /line-scope redescriptions must exactly match the actual required set/,
+    );
+    await assert.rejects(readFile(emittedPath), { code: "ENOENT" });
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+    await rm(emittedPath, { force: true });
+  }
+});

--- a/tools/datapack/nationwide-candidate-coverage-gate.test.mjs
+++ b/tools/datapack/nationwide-candidate-coverage-gate.test.mjs
@@ -3042,12 +3042,26 @@ function lineScopeExactMatchFixture(sourceId, sourceDomain, releaseTier = "LAUNC
   };
 }
 
-for (const { sourceId, sourceDomain } of [
+const OMITTED_LINE_SCOPE_CASES = Object.freeze([
   { sourceId: "busan-transportation-timetable", sourceDomain: "schedule_timetable" },
   { sourceId: "busan-transportation-route-map-positions", sourceDomain: "route_map_positions" },
   { sourceId: "busan-transportation-accessibility", sourceDomain: "accessibility_facilities" },
   { sourceId: "daegu-transportation-accessibility", sourceDomain: "accessibility_facilities" },
-]) {
+]);
+
+test("omission 회귀 대상은 tracked candidate spec에 선언돼 있다", async () => {
+  const { lineScopeRedescriptions } = await readJson(SPEC_PATH);
+  for (const { sourceId, sourceDomain } of OMITTED_LINE_SCOPE_CASES) {
+    assert.ok(
+      lineScopeRedescriptions.some(
+        (entry) => entry.sourceId === sourceId && entry.sourceDomain === sourceDomain,
+      ),
+      `${sourceId}/${sourceDomain}`,
+    );
+  }
+});
+
+for (const { sourceId, sourceDomain } of OMITTED_LINE_SCOPE_CASES) {
   test(`${sourceId}/${sourceDomain} omission은 actual line-scope set에서 거부된다`, () => {
     const fixture = lineScopeExactMatchFixture(sourceId, sourceDomain);
     fixture.spec.lineScopeRedescriptions = [];

--- a/tools/datapack/nationwide-candidate-coverage-gate.test.mjs
+++ b/tools/datapack/nationwide-candidate-coverage-gate.test.mjs
@@ -35,6 +35,7 @@ import { promisify } from "node:util";
 
 import {
   EVIDENCE_PATH,
+  assertLineScopeRedescriptionsMatchActualRequiredSet,
   assertInheritedRowsUnchanged,
   assertNonTransitionReasons,
   inheritedRowSnapshot,
@@ -1557,41 +1558,6 @@ test("candidate 안전 경계는 spec 편집만으로 넓힐 수 없다", async 
     );
   });
 
-  // 등재 소스를 빼면 그 소스는 baseline에서도 line-scope를 유지해 판정 자체는 그대로 나온다. #2592의
-  // actual required set 역결속이 buildEvidence 이전에 이 누락을 막으므로, 더 늦은 supporting-source 대조가
-  // 아니라 선언/실측 exact-match 진단을 기대한다.
-  await context.test("전이를 뒷받침한 소스가 등재 목록과 다르면 거부된다", async () => {
-    await rejectsWith(
-      (value) => {
-        value.lineScopeRedescriptions = value.lineScopeRedescriptions.filter(
-          ({ sourceId }) => sourceId !== "molit-urban-rail-full-route-daegu-line1-membership",
-        );
-      },
-      /line-scope redescriptions must exactly match the actual required set/,
-    );
-  });
-
-  // 선언 목록을 순회하는 검증만으로는 실제 candidate pack에 line-scope가 있는 소스를 선언에서 통째로
-  // 빼도 baseline과 lineScoped가 함께 그 scope를 유지해 통과한다. actual required set 역결속이 이
-  // 삭제를 source/domain 단위로 막아야 한다.
-  for (const { sourceId, sourceDomain } of [
-    { sourceId: "busan-transportation-timetable", sourceDomain: "schedule_timetable" },
-    { sourceId: "busan-transportation-route-map-positions", sourceDomain: "route_map_positions" },
-    { sourceId: "busan-transportation-accessibility", sourceDomain: "accessibility_facilities" },
-    { sourceId: "daegu-transportation-accessibility", sourceDomain: "accessibility_facilities" },
-  ]) {
-    await context.test(`${sourceId}/${sourceDomain} 재기술을 지우면 거부된다`, async () => {
-      await rejectsWith(
-        (value) => {
-          value.lineScopeRedescriptions = value.lineScopeRedescriptions.filter(
-            (entry) => entry.sourceId !== sourceId || entry.sourceDomain !== sourceDomain,
-          );
-        },
-        /line-scope redescriptions must exactly match the actual required set/,
-      );
-    });
-  }
-
   await context.test("선언과 다른 행수를 싣는 편입은 거부된다", async () => {
     await rejectsWith(
       (value) => { value.packDataInclusions[0].addedRows.transitStopTimes += 1; },
@@ -3054,4 +3020,108 @@ test("누락된 재기술은 emit fixture를 남기지 않고 거부된다", asy
     await rm(workspace, { recursive: true, force: true });
     await rm(emittedPath, { force: true });
   }
+});
+
+function lineScopeExactMatchFixture(sourceId, sourceDomain, releaseTier = "LAUNCH_REQUIRED") {
+  const requirementKey = `region:operator:line:${sourceDomain}`;
+  const coverageScope = {
+    lineIds: ["line"], sourceDomains: [sourceDomain], regionIds: ["region"], operatorIds: ["operator"],
+  };
+  return {
+    spec: {
+      lineScopeRedescriptions: [{ sourceId, sourceDomain, lineIds: ["line"], requirementKeys: [requirementKey] }],
+    },
+    pack: {
+      sourceInventory: [{ id: sourceId, coverageScope: { ...coverageScope, lineIds: undefined } }],
+    },
+    inventory: { sources: [{ id: sourceId, coverageScope }] },
+    targets: {
+      requiredSourceDomains: [{ id: sourceDomain, releaseTier }],
+      activeLineScopes: [{ regionId: "region", operatorId: "operator", lineId: "line" }],
+    },
+  };
+}
+
+function assertLineScopeExactMatch({ spec, pack, inventory, targets }) {
+  return assertLineScopeRedescriptionsMatchActualRequiredSet(spec, pack, inventory, targets);
+}
+
+test("actual line-scope set은 네 source/domain omission을 독립적으로 거부한다", () => {
+  for (const { sourceId, sourceDomain } of [
+    { sourceId: "busan-transportation-timetable", sourceDomain: "schedule_timetable" },
+    { sourceId: "busan-transportation-route-map-positions", sourceDomain: "route_map_positions" },
+    { sourceId: "busan-transportation-accessibility", sourceDomain: "accessibility_facilities" },
+    { sourceId: "daegu-transportation-accessibility", sourceDomain: "accessibility_facilities" },
+  ]) {
+    const fixture = lineScopeExactMatchFixture(sourceId, sourceDomain);
+    fixture.spec.lineScopeRedescriptions = [];
+    assert.throws(
+      () => assertLineScopeExactMatch(fixture),
+      /line-scope redescriptions must exactly match the actual required set/,
+      `${sourceId}/${sourceDomain}`,
+    );
+  }
+});
+
+test("actual line-scope 선언은 source/domain, lineIds, requirementKeys가 정확히 일치해야 한다", () => {
+  const valid = lineScopeExactMatchFixture("source", "schedule_timetable");
+  assert.doesNotThrow(() => assertLineScopeExactMatch(valid));
+
+  for (const [label, mutate, expected] of [
+    [
+      "추가",
+      (fixture) => fixture.spec.lineScopeRedescriptions.push({
+        sourceId: "extra", sourceDomain: "schedule_timetable", lineIds: ["line"], requirementKeys: [],
+      }),
+      /line-scope redescriptions must exactly match the actual required set/,
+    ],
+    [
+      "중복",
+      (fixture) => fixture.spec.lineScopeRedescriptions.push(structuredClone(fixture.spec.lineScopeRedescriptions[0])),
+      /duplicate declared line-scope source\/domain/,
+    ],
+    [
+      "lineIds 불일치",
+      (fixture) => { fixture.spec.lineScopeRedescriptions[0].lineIds = ["other-line"]; },
+      /line-scope redescriptions must exactly match the actual required set/,
+    ],
+    [
+      "requirementKeys 불일치",
+      (fixture) => { fixture.spec.lineScopeRedescriptions[0].requirementKeys = []; },
+      /line-scope redescriptions must exactly match the actual required set/,
+    ],
+  ]) {
+    const fixture = structuredClone(valid);
+    mutate(fixture);
+    assert.throws(() => assertLineScopeExactMatch(fixture), expected, label);
+  }
+});
+
+test("inactive scope와 LAUNCH_REQUIRED가 아닌 domain은 actual line-scope set에서 제외한다", () => {
+  const inactive = lineScopeExactMatchFixture("inactive", "schedule_timetable");
+  inactive.spec.lineScopeRedescriptions = [];
+  inactive.targets.activeLineScopes = [];
+  assert.doesNotThrow(() => assertLineScopeExactMatch(inactive));
+
+  const enhancement = lineScopeExactMatchFixture("enhancement", "schedule_timetable", "ENHANCEMENT");
+  enhancement.spec.lineScopeRedescriptions = [];
+  assert.doesNotThrow(() => assertLineScopeExactMatch(enhancement));
+});
+
+test("pack-only lineIds와 inventory 누락 lineIds는 fail closed다", () => {
+  const coverageScope = {
+    lineIds: ["line"], sourceDomains: ["schedule_timetable"], regionIds: ["region"], operatorIds: ["operator"],
+  };
+  assert.throws(
+    () => assertLineScopeExactMatch({
+      spec: { lineScopeRedescriptions: [] },
+      pack: { sourceInventory: [{ id: "pack-only", coverageScope }] },
+      inventory: { sources: [{ id: "pack-only", coverageScope: { ...coverageScope, lineIds: [] } }] },
+      targets: {
+        requiredSourceDomains: [{ id: "schedule_timetable", releaseTier: "LAUNCH_REQUIRED" }],
+        activeLineScopes: [{ regionId: "region", operatorId: "operator", lineId: "line" }],
+      },
+    }),
+    /candidate pack coverageScope\.lineIds must match source inventory: pack-only/,
+  );
 });

--- a/tools/datapack/run-nationwide-candidate-coverage-gate.mjs
+++ b/tools/datapack/run-nationwide-candidate-coverage-gate.mjs
@@ -317,6 +317,7 @@ export async function runNationwideCandidateCoverageGate({
   // variant마다 달라질 수 없고, 한 번만 조립해 두 실행이 같은 행 바이트를 쓰는 것을 구조로 보장한다.
   const inclusions = await applyPackDataInclusions(spec, inherited, inventory, materializers);
   const targets = (await readJsonInput(targetsInput.path)).document;
+  assertLineScopeRedescriptionsMatchActualRequiredSet(spec, inclusions.pack, inventory, targets);
 
   const signing = ephemeralSigningKeys();
   const variants = {};
@@ -367,13 +368,6 @@ export async function runNationwideCandidateCoverageGate({
     const provenance = JSON.parse(await readFile(path.join(buildDir, "current.provenance.json"), "utf8"));
     variants[variant] = summarizeVariant(spec, reports[variant], provenance);
   }
-
-  assertLineScopeRedescriptionsMatchActualRequiredSet(
-    spec,
-    inclusions.pack,
-    inventory,
-    targets,
-  );
 
   return buildEvidence({
     spec,

--- a/tools/datapack/run-nationwide-candidate-coverage-gate.mjs
+++ b/tools/datapack/run-nationwide-candidate-coverage-gate.mjs
@@ -1376,7 +1376,7 @@ function assertInventoryLineScopeSync(spec, inventory) {
 // lineScopeRedescriptions에 source/domain 단위로 빠짐없이 재기술돼야 한다. 선언 목록을 기준으로
 // fixture·baseline을 조립하면 선언을 지운 실제 소스가 두 variant에 함께 남아 fail open하므로, pack ×
 // tracked inventory × coverage targets에서 actual required set을 역으로 유도해 양방향 exact-match 한다.
-function assertLineScopeRedescriptionsMatchActualRequiredSet(spec, pack, inventory, targets) {
+export function assertLineScopeRedescriptionsMatchActualRequiredSet(spec, pack, inventory, targets) {
   const launchRequiredDomains = new Set(
     (targets.requiredSourceDomains ?? [])
       .filter(({ releaseTier }) => releaseTier === "LAUNCH_REQUIRED")
@@ -1398,7 +1398,12 @@ function assertLineScopeRedescriptionsMatchActualRequiredSet(spec, pack, invento
       continue;
     }
     const inventoryScope = inventorySource.coverageScope;
-    if (!inventoryScope?.lineIds?.length) continue;
+    if (!inventoryScope?.lineIds?.length) {
+      if (packScope?.lineIds?.length) {
+        throw new Error(`candidate pack coverageScope.lineIds must match source inventory: ${sourceId}`);
+      }
+      continue;
+    }
     // inclusions.pack은 재기술을 덮기 전 원형이다. 기존 source는 여기서 lineIds가 없고,
     // lineScoped fixture에서만 spec 값이 주입된다. tracked inventory가 그 후보 line scope의 정본이며,
     // 원형에 이미 lineIds가 있는 신규 source라면 둘의 집합이 같아야 한다.

--- a/tools/datapack/run-nationwide-candidate-coverage-gate.mjs
+++ b/tools/datapack/run-nationwide-candidate-coverage-gate.mjs
@@ -316,6 +316,7 @@ export async function runNationwideCandidateCoverageGate({
   // 지역 데이터 편입은 두 variant가 공유한다. line-scope 재기술은 소스 기술만 바꾸므로 편입 결과가
   // variant마다 달라질 수 없고, 한 번만 조립해 두 실행이 같은 행 바이트를 쓰는 것을 구조로 보장한다.
   const inclusions = await applyPackDataInclusions(spec, inherited, inventory, materializers);
+  const targets = (await readJsonInput(targetsInput.path)).document;
 
   const signing = ephemeralSigningKeys();
   const variants = {};
@@ -366,6 +367,13 @@ export async function runNationwideCandidateCoverageGate({
     const provenance = JSON.parse(await readFile(path.join(buildDir, "current.provenance.json"), "utf8"));
     variants[variant] = summarizeVariant(spec, reports[variant], provenance);
   }
+
+  assertLineScopeRedescriptionsMatchActualRequiredSet(
+    spec,
+    inclusions.pack,
+    inventory,
+    targets,
+  );
 
   return buildEvidence({
     spec,
@@ -1368,6 +1376,108 @@ function assertInventoryLineScopeSync(spec, inventory) {
       }
     }
   }
+}
+
+// candidate pack에 실제로 실린 line-scope 소스가 LAUNCH_REQUIRED scope를 뒷받침하면, 그 근거는
+// lineScopeRedescriptions에 source/domain 단위로 빠짐없이 재기술돼야 한다. 선언 목록을 기준으로
+// fixture·baseline을 조립하면 선언을 지운 실제 소스가 두 variant에 함께 남아 fail open하므로, pack ×
+// tracked inventory × coverage targets에서 actual required set을 역으로 유도해 양방향 exact-match 한다.
+function assertLineScopeRedescriptionsMatchActualRequiredSet(spec, pack, inventory, targets) {
+  const launchRequiredDomains = new Set(
+    (targets.requiredSourceDomains ?? [])
+      .filter(({ releaseTier }) => releaseTier === "LAUNCH_REQUIRED")
+      .map(({ id }) => requiredString(id, "coverage target requiredSourceDomains[].id")),
+  );
+  const activeLineScopes = targets.activeLineScopes ?? [];
+  const inventoryById = new Map((inventory.sources ?? []).map((source) => [source.id, source]));
+  const actual = new Map();
+  const sourcesById = new Map();
+
+  for (const packSource of pack.sourceInventory ?? []) {
+    const sourceId = requiredString(packSource?.id, "candidate pack sourceInventory[].id");
+    const inventorySource = inventoryById.get(sourceId);
+    const packScope = packSource.coverageScope;
+    if (!inventorySource) {
+      if (packScope?.lineIds?.length) {
+        throw new Error(`line-scoped candidate pack source is missing from source inventory: ${sourceId}`);
+      }
+      continue;
+    }
+    const inventoryScope = inventorySource.coverageScope;
+    if (!inventoryScope?.lineIds?.length) continue;
+    // inclusions.pack은 재기술을 덮기 전 원형이다. 기존 source는 여기서 lineIds가 없고,
+    // lineScoped fixture에서만 spec 값이 주입된다. tracked inventory가 그 후보 line scope의 정본이며,
+    // 원형에 이미 lineIds가 있는 신규 source라면 둘의 집합이 같아야 한다.
+    if (packScope?.lineIds && !sameStringSet(packScope.lineIds, inventoryScope.lineIds)) {
+      throw new Error(`candidate pack coverageScope.lineIds must match source inventory: ${sourceId}`);
+    }
+    sourcesById.set(sourceId, { packScope, inventoryScope });
+  }
+
+  const addActualRequirement = (sourceId, requirementKey) => {
+    const { regionId, operatorId, lineId, sourceDomain } = parseRequirementKey(
+      requirementKey,
+      "line-scoped coverage requirement",
+    );
+    if (!launchRequiredDomains.has(sourceDomain)) return;
+    const source = sourcesById.get(sourceId);
+    if (!source) return;
+    const { packScope, inventoryScope } = source;
+    if (!inventoryScope.lineIds.includes(lineId)
+      || !packScope?.sourceDomains?.includes(sourceDomain)
+      || !packScope.regionIds?.includes(regionId)
+      || !packScope.operatorIds?.includes(operatorId)
+      || !inventoryScope.sourceDomains?.includes(sourceDomain)
+      || !inventoryScope.regionIds?.includes(regionId)
+      || !inventoryScope.operatorIds?.includes(operatorId)
+      || !activeLineScopes.some((scope) =>
+        scope.regionId === regionId && scope.operatorId === operatorId && scope.lineId === lineId,
+      )) {
+      return;
+    }
+    const key = `${sourceId}:${sourceDomain}`;
+    const entry = actual.get(key) ?? { sourceId, sourceDomain, lineIds: inventoryScope.lineIds, requirementKeys: [] };
+    if (!entry.requirementKeys.includes(requirementKey)) entry.requirementKeys.push(requirementKey);
+    actual.set(key, entry);
+  };
+
+  // report/provenance는 materializer 편입 순서에 따라 supporting-source 표현이 달라질 수 있다. actual
+  // required set은 오직 candidate pack에 존재하는 source와 tracked inventory, coverage target의 active
+  // scope 교집합에서 유도한다. 따라서 순서 허용 조립은 이 선언 대조에 영향을 줄 수 없다.
+  for (const { regionId, operatorId, lineId } of activeLineScopes) {
+    for (const sourceDomain of launchRequiredDomains) {
+      const key = `${regionId}:${operatorId}:${lineId}:${sourceDomain}`;
+      for (const sourceId of sourcesById.keys()) addActualRequirement(sourceId, key);
+    }
+  }
+
+  const declared = new Map();
+  for (const redescription of spec.lineScopeRedescriptions) {
+    const key = `${redescription.sourceId}:${redescription.sourceDomain}`;
+    if (declared.has(key)) throw new Error(`duplicate declared line-scope source/domain: ${key}`);
+    declared.set(key, redescription);
+  }
+
+  if (actual.size !== declared.size) {
+    throw new Error(
+      "line-scope redescriptions must exactly match the actual required set: "
+        + `actual=${[...actual.keys()].sort(codepointCompare).join(",")}, `
+        + `declared=${[...declared.keys()].sort(codepointCompare).join(",")}`,
+    );
+  }
+  for (const [key, required] of actual) {
+    const redescription = declared.get(key);
+    if (!redescription
+      || !sameStringSet(redescription.lineIds, required.lineIds)
+      || !sameStringSet(redescription.requirementKeys, required.requirementKeys)) {
+      throw new Error(`line-scope redescriptions must exactly match the actual required set: ${key}`);
+    }
+  }
+}
+
+function sameStringSet(left, right) {
+  if (!Array.isArray(left) || !Array.isArray(right)) return false;
+  return JSON.stringify([...left].sort(codepointCompare)) === JSON.stringify([...right].sort(codepointCompare));
 }
 
 function summarizeVariant(spec, report, provenance) {


### PR DESCRIPTION
## 관련 이슈

Closes #2592

## 작업 배경

`lineScopeRedescriptions`에서 실제 LAUNCH_REQUIRED source/domain 선언을 통째로 삭제하면 baseline과 line-scoped variant가 함께 바뀌어 candidate gate가 완주하던 단방향 fail-open을 차단합니다.

## 작업 내용

- candidate pack source membership × tracked source inventory × active LAUNCH_REQUIRED target에서 actual required set을 선언과 독립적으로 산출합니다.
- actual set과 선언을 `sourceId/sourceDomain/lineIds/requirementKeys` 기준 양방향 exact-match하고 삭제·추가·중복을 fail closed합니다.
- 부산 timetable·route-map·accessibility, 대구 accessibility 삭제 4종을 정본 spec과 결속된 독립 회귀로 고정합니다.
- invalid 선언은 variant 조립과 `--emit-fixture` 기록 전에 거부하며, 실패 시 emit artifact가 남지 않는 회귀를 추가합니다.

## 검증

- `node --test --test-name-pattern='candidate 안전 경계는 spec 편집만으로 넓힐 수 없다' tools/datapack/nationwide-candidate-coverage-gate.test.mjs` — 165/165 PASS
- `node --test tools/datapack/nationwide-candidate-coverage-gate.test.mjs` — 187/187 PASS (최신 production assertion 변경 head)
- `node --test tools/datapack/*.test.mjs tools/datapack/lib/*.test.mjs` — 1,813/1,813 PASS
- 정본 결속 + 독립 omission focused tests — 5/5 PASS
- `git diff --check` — PASS
- 최신 head `29b10589030cf7a7fc8f7276d16579e15e479c49` GitHub required CI — PASS

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 4종 declaration 삭제 차단 | Node 24 / datapack gate | 정본 spec 결속 + pure assertion | focused 5/5, Repository CI | PASS |
| 현행 evidence byte parity | Node 24 / datapack gate | committed evidence 재생성 대조 | 로컬 1,813/1,813, Repository CI | PASS |
| invalid emit artifact 부재 | Node 24 / datapack gate | reject 후 output path `ENOENT` | 전용 회귀 1/1 | PASS |
| 최신 독립 리뷰 | GitHub Review | actionable finding/threads 재확인 | Review 4784904645, unresolved 0 | PASS |
| UI·수동 QA | Android | 사용자 화면 변경 없음 | gate/test only | 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음(candidate gate only)
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- `assertLineScopeRedescriptionsMatchActualRequiredSet`가 spec/report provenance가 아니라 pack membership·tracked inventory·targets만으로 집합을 유도하는지, emit 이전에 실행되는지 검토했습니다.
- CodeRabbit actionable 2건은 수정 1건/근거 기각 1건으로 원 thread에 답했고 모두 resolve했습니다.

## 리스크

- tracked inventory에 새 line-scoped LAUNCH_REQUIRED source를 추가하면서 선언을 동기화하지 않으면 의도적으로 gate가 실패합니다.
- 제품 데이터·게시 artifact·freshness 정책은 변경하지 않습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex 독립 리뷰를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)
