### PR TITLE
[Fix] #2598 route-map admission P1Y freshness fail-closed

### DIFF
--- a/apps/mobile/assets/datapacks/source-inventory.json
+++ b/apps/mobile/assets/datapacks/source-inventory.json
@@ -257,7 +257,8 @@
         "connectorAssetCount": 32,
         "topologySourceId": "busan-transportation-route-topology",
         "topologySnapshotId": "busan-transportation-route-topology-20260720",
-        "topologyContentSha256": "9ec95ebb6d789457060e243f079ad371465d0e5e1a309504b18b9a78e00a24cc"
+        "topologyContentSha256": "9ec95ebb6d789457060e243f079ad371465d0e5e1a309504b18b9a78e00a24cc",
+        "freshUntil": "2027-07-20T11:13:18.000Z"
       }
     },
     {
@@ -1358,7 +1359,8 @@
             "lineId": "line-0ffaa95b1b5d"
           }
         ],
-        "topologyContentSha256": "4e76459d4588f97bd55e767374b81031402c768d8f4805c69484d7c3f8771d1f"
+        "topologyContentSha256": "4e76459d4588f97bd55e767374b81031402c768d8f4805c69484d7c3f8771d1f",
+        "freshUntil": "2027-07-24T03:00:00.000Z"
       }
     },
     {
@@ -1754,7 +1756,8 @@
             "contentSha256": "111ef488fc9d1f960445844b907e7f7b6f804e4adff0867f2f8c1e43433c747f",
             "lineId": "line-7051a9c2525c"
           }
-        ]
+        ],
+        "freshUntil": "2027-07-25T03:00:00.000Z"
       }
     },
     {
@@ -2046,7 +2049,8 @@
             "contentSha256": "d8197488bc6dda94e595f7e350cc65c547117da804fb59b7dff85d18b3192e43",
             "lineId": "line-e57a361e8892"
           }
-        ]
+        ],
+        "freshUntil": "2027-07-25T02:00:00.000Z"
       }
     },
     {
@@ -2594,7 +2598,8 @@
         "observedDataUpdatedAt": "2025-06-30",
         "topologySourceId": "incheon-transit-station-info",
         "topologySnapshotId": "incheon-transit-station-info-20260724",
-        "topologyContentSha256": "710878689282ba967697cd9411940b657a51eee5499106ed884d5bd9111501a8"
+        "topologyContentSha256": "710878689282ba967697cd9411940b657a51eee5499106ed884d5bd9111501a8",
+        "freshUntil": "2027-07-24T06:00:00.000Z"
       }
     },
     {
@@ -2699,7 +2704,8 @@
             "contentSha256": "0492df28ff51dc4262508363e960ed1a5fed847d3aa5f593ea62ad0fd3d773f3",
             "lineId": "line-e9e9a5b520a4"
           }
-        ]
+        ],
+        "freshUntil": "2027-07-25T06:00:00.000Z"
       }
     },
     {
@@ -2957,7 +2963,8 @@
             "contentSha256": "0492df28ff51dc4262508363e960ed1a5fed847d3aa5f593ea62ad0fd3d773f3",
             "lineId": "line-828f04afc588"
           }
-        ]
+        ],
+        "freshUntil": "2027-07-25T06:00:00.000Z"
       }
     },
     {
@@ -3062,7 +3069,8 @@
             "contentSha256": "0492df28ff51dc4262508363e960ed1a5fed847d3aa5f593ea62ad0fd3d773f3",
             "lineId": "line-5500c1600f71"
           }
-        ]
+        ],
+        "freshUntil": "2027-07-25T06:00:00.000Z"
       }
     },
     {
@@ -3169,7 +3177,8 @@
             "contentSha256": "0492df28ff51dc4262508363e960ed1a5fed847d3aa5f593ea62ad0fd3d773f3",
             "lineId": "line-8604048b6430"
           }
-        ]
+        ],
+        "freshUntil": "2027-07-25T06:00:00.000Z"
       }
     },
     {
@@ -3283,7 +3292,8 @@
           "광운대",
           "망우",
           "상봉"
-        ]
+        ],
+        "freshUntil": "2027-07-25T06:00:00.000Z"
       }
     },
     {
@@ -3395,7 +3405,8 @@
         "overlayRawSha256": "9bb0720467d344a16eeb384e46042fbe19698f0d3375b12cbe5b68dc2b0b134e",
         "overlayStationNames": [
           "성남"
-        ]
+        ],
+        "freshUntil": "2027-07-25T06:00:00.000Z"
       }
     },
     {
@@ -3500,7 +3511,8 @@
             "contentSha256": "0492df28ff51dc4262508363e960ed1a5fed847d3aa5f593ea62ad0fd3d773f3",
             "lineId": "line-6e39be0cb6e2"
           }
-        ]
+        ],
+        "freshUntil": "2027-07-25T06:00:00.000Z"
       }
     },
     {
@@ -3846,7 +3858,8 @@
             "contentSha256": "0492df28ff51dc4262508363e960ed1a5fed847d3aa5f593ea62ad0fd3d773f3",
             "lineId": "line-051552e50435"
           }
-        ]
+        ],
+        "freshUntil": "2027-07-25T06:00:00.000Z"
       }
     },
     {
@@ -3951,7 +3964,8 @@
             "contentSha256": "0492df28ff51dc4262508363e960ed1a5fed847d3aa5f593ea62ad0fd3d773f3",
             "lineId": "line-f0e747248a31"
           }
-        ]
+        ],
+        "freshUntil": "2027-07-25T05:00:00.000Z"
       }
     },
     {
@@ -4058,7 +4072,8 @@
             "contentSha256": "0492df28ff51dc4262508363e960ed1a5fed847d3aa5f593ea62ad0fd3d773f3",
             "lineId": "shinbundang"
           }
-        ]
+        ],
+        "freshUntil": "2027-07-25T06:00:00.000Z"
       }
     },
     {
@@ -4163,7 +4178,8 @@
             "contentSha256": "0492df28ff51dc4262508363e960ed1a5fed847d3aa5f593ea62ad0fd3d773f3",
             "lineId": "line-aefa08ccc0a9"
           }
-        ]
+        ],
+        "freshUntil": "2027-07-25T06:00:00.000Z"
       }
     },
     {
@@ -5415,7 +5431,8 @@
             "contentSha256": "0492df28ff51dc4262508363e960ed1a5fed847d3aa5f593ea62ad0fd3d773f3",
             "lineId": "line-558d0bd8312d"
           }
-        ]
+        ],
+        "freshUntil": "2027-07-25T06:00:00.000Z"
       }
     },
     {
@@ -5716,7 +5733,8 @@
             "contentSha256": "0492df28ff51dc4262508363e960ed1a5fed847d3aa5f593ea62ad0fd3d773f3",
             "lineId": "line-30886152e4f8"
           }
-        ]
+        ],
+        "freshUntil": "2027-07-25T06:00:00.000Z"
       }
     },
     {
@@ -5821,7 +5839,8 @@
             "contentSha256": "0492df28ff51dc4262508363e960ed1a5fed847d3aa5f593ea62ad0fd3d773f3",
             "lineId": "line-62096860ab09"
           }
-        ]
+        ],
+        "freshUntil": "2027-07-25T06:00:00.000Z"
       }
     },
     {
@@ -7011,7 +7030,8 @@
             "contentSha256": "0492df28ff51dc4262508363e960ed1a5fed847d3aa5f593ea62ad0fd3d773f3",
             "lineId": "line-f0e747248a31"
           }
-        ]
+        ],
+        "freshUntil": "2027-07-25T04:00:00.000Z"
       }
     },
     {
@@ -7262,7 +7282,8 @@
           "7": 42,
           "8": 18
         },
-        "observedDataUpdatedAt": "2025-08-14"
+        "observedDataUpdatedAt": "2025-08-14",
+        "freshUntil": "2027-07-24T02:00:00.000Z"
       }
     },
     {

--- a/contracts/datapack/source-inventory.schema.json
+++ b/contracts/datapack/source-inventory.schema.json
@@ -229,6 +229,7 @@
               "snapshotPath",
               "snapshotSha256",
               "capturedAt",
+              "freshUntil",
               "stationCount",
               "rawSha256",
               "positionsSha256"
@@ -246,6 +247,7 @@
               "snapshotPath": { "type": "string", "minLength": 1 },
               "snapshotSha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
               "capturedAt": { "type": "string", "format": "date-time" },
+              "freshUntil": { "type": "string", "format": "date-time" },
               "stationCount": { "type": "integer", "minimum": 1 },
               "rawStationCount": { "type": "integer", "minimum": 0 },
               "quarantinedCount": { "type": "integer", "minimum": 0 },

--- a/tools/datapack/freshness-policy.mjs
+++ b/tools/datapack/freshness-policy.mjs
@@ -63,7 +63,7 @@ export function decideScheduledRun({
   return decision("NO_CHANGE_VALID", false);
 }
 
-function addCadence(basisMillis, cadence) {
+export function addCadence(basisMillis, cadence) {
   if (typeof cadence !== "string") {
     throw new Error("SOURCE_FRESHNESS_POLICY_MISSING: cadence");
   }

--- a/tools/datapack/lib/route-map-admission-freshness.mjs
+++ b/tools/datapack/lib/route-map-admission-freshness.mjs
@@ -1,0 +1,16 @@
+import { addCadence } from "../freshness-policy.mjs";
+import { requiredUtcInstant } from "./utc-instant.mjs";
+
+export const ROUTE_MAP_REVERIFICATION_CADENCE = "P1Y";
+
+export function assertRouteMapAdmissionFreshness(evidence, now, sourceId) {
+  const capturedAt = requiredUtcInstant(evidence?.capturedAt, `${sourceId} route-map capturedAt`);
+  const freshUntil = requiredUtcInstant(evidence?.freshUntil, `${sourceId} route-map freshUntil`);
+  if (freshUntil !== addCadence(capturedAt, ROUTE_MAP_REVERIFICATION_CADENCE)) {
+    throw new Error(`${sourceId} route-map freshness contract is invalid`);
+  }
+  const observedNow = now instanceof Date ? now.getTime() : Number.NaN;
+  if (!Number.isFinite(observedNow) || observedNow < capturedAt || observedNow >= freshUntil) {
+    throw new Error(`${sourceId} route-map admission snapshot is stale or future-dated`);
+  }
+}

--- a/tools/datapack/lib/route-map-admission-freshness.mjs
+++ b/tools/datapack/lib/route-map-admission-freshness.mjs
@@ -13,4 +13,5 @@ export function assertRouteMapAdmissionFreshness(evidence, now, sourceId) {
   if (!Number.isFinite(observedNow) || observedNow < capturedAt || observedNow >= freshUntil) {
     throw new Error(`${sourceId} route-map admission snapshot is stale or future-dated`);
   }
+  return observedNow;
 }

--- a/tools/datapack/lib/route-map-admission-freshness.test.mjs
+++ b/tools/datapack/lib/route-map-admission-freshness.test.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  assertRouteMapAdmissionFreshness,
+  ROUTE_MAP_REVERIFICATION_CADENCE,
+} from "./route-map-admission-freshness.mjs";
+
+const root = path.resolve(import.meta.dirname, "../../..");
+const sourceId = "route-map-source";
+const evidence = {
+  capturedAt: "2024-02-29T12:00:00.000Z",
+  freshUntil: "2025-03-01T12:00:00.000Z",
+};
+
+test("route-map admission은 SLA의 P1Y UTC calendar-year 반개구간만 허용한다", async () => {
+  const policy = JSON.parse(await readFile(
+    path.join(root, "apps/mobile/release/datapack-freshness-sla.json"),
+    "utf8",
+  ));
+  assert.equal(
+    policy.sourceClasses.find(({ id }) => id === "route_map_asset")?.reverificationCadence,
+    ROUTE_MAP_REVERIFICATION_CADENCE,
+  );
+  assert.doesNotThrow(() => assertRouteMapAdmissionFreshness(
+    evidence, new Date(evidence.capturedAt), sourceId,
+  ));
+  for (const invalidEvidence of [
+    { ...evidence, freshUntil: "2025-02-28T12:00:00.000Z" },
+    { ...evidence, freshUntil: "invalid" },
+    { capturedAt: evidence.capturedAt },
+  ]) {
+    assert.throws(() => assertRouteMapAdmissionFreshness(
+      invalidEvidence, new Date(evidence.capturedAt), sourceId,
+    ));
+  }
+  assert.throws(() => assertRouteMapAdmissionFreshness(
+    evidence, new Date("2024-02-29T11:59:59.999Z"), sourceId,
+  ));
+  assert.throws(() => assertRouteMapAdmissionFreshness(
+    evidence, new Date(evidence.freshUntil), sourceId,
+  ));
+});

--- a/tools/datapack/materialize-busan-route-map-positions.mjs
+++ b/tools/datapack/materialize-busan-route-map-positions.mjs
@@ -145,7 +145,6 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshot, n
   if (!/^[a-f0-9]{64}$/.test(snapshotSha256 ?? "") || evidence?.snapshotSha256 !== snapshotSha256) {
     throw new Error("Busan route map snapshot byte identity mismatch");
   }
-  const observedNow = now instanceof Date ? now.getTime() : Number.NaN;
   if (source?.productionUseAllowed !== true || source.license?.redistributionAllowed !== true
     || source.license.commercialUseAllowed !== true || source.license.derivativeWorkAllowed !== true
     || evidence?.issue !== 2379
@@ -164,8 +163,7 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshot, n
     || evidence.connectorAssetCount !== snapshot.connectorAssetCount
     || evidence.topologySourceId !== snapshot.topologySourceId
     || evidence.topologySnapshotId !== snapshot.topologySnapshotId
-    || evidence.topologyContentSha256 !== snapshot.topologyContentSha256
-    || !Number.isFinite(observedNow) || observedNow < Date.parse(snapshot.capturedAt)) {
+    || evidence.topologyContentSha256 !== snapshot.topologyContentSha256) {
     throw new Error(`${SOURCE_ID} inventory evidence does not match snapshot`);
   }
   if (topologySnapshot?.sourceId !== TOPOLOGY_SOURCE_ID

--- a/tools/datapack/materialize-busan-route-map-positions.mjs
+++ b/tools/datapack/materialize-busan-route-map-positions.mjs
@@ -6,6 +6,7 @@ import { pathToFileURL } from "node:url";
 
 import { validateBusanRouteMapPositionsSnapshot } from "./collect-busan-route-map-positions.mjs";
 import { busanRouteTopologyContentHash } from "./collect-busan-route-topology.mjs";
+import { assertRouteMapAdmissionFreshness } from "./lib/route-map-admission-freshness.mjs";
 
 const SOURCE_ID = "busan-transportation-route-map-positions";
 const TOPOLOGY_SOURCE_ID = "busan-transportation-route-topology";
@@ -178,6 +179,7 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshot, n
     }) || JSON.stringify(source.fieldsProvided) !== JSON.stringify(snapshot.fieldsProvided)) {
     throw new Error(`${SOURCE_ID} topology or coverage scope mismatch`);
   }
+  assertRouteMapAdmissionFreshness(evidence, now, SOURCE_ID);
   return source;
 }
 

--- a/tools/datapack/materialize-busan-route-map-positions.mjs
+++ b/tools/datapack/materialize-busan-route-map-positions.mjs
@@ -145,6 +145,7 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshot, n
   if (!/^[a-f0-9]{64}$/.test(snapshotSha256 ?? "") || evidence?.snapshotSha256 !== snapshotSha256) {
     throw new Error("Busan route map snapshot byte identity mismatch");
   }
+  const observedNow = assertRouteMapAdmissionFreshness(evidence, now, SOURCE_ID);
   if (source?.productionUseAllowed !== true || source.license?.redistributionAllowed !== true
     || source.license.commercialUseAllowed !== true || source.license.derivativeWorkAllowed !== true
     || evidence?.issue !== 2379
@@ -163,7 +164,8 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshot, n
     || evidence.connectorAssetCount !== snapshot.connectorAssetCount
     || evidence.topologySourceId !== snapshot.topologySourceId
     || evidence.topologySnapshotId !== snapshot.topologySnapshotId
-    || evidence.topologyContentSha256 !== snapshot.topologyContentSha256) {
+    || evidence.topologyContentSha256 !== snapshot.topologyContentSha256
+    || !Number.isFinite(observedNow) || observedNow < Date.parse(snapshot.capturedAt)) {
     throw new Error(`${SOURCE_ID} inventory evidence does not match snapshot`);
   }
   if (topologySnapshot?.sourceId !== TOPOLOGY_SOURCE_ID
@@ -177,7 +179,6 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshot, n
     }) || JSON.stringify(source.fieldsProvided) !== JSON.stringify(snapshot.fieldsProvided)) {
     throw new Error(`${SOURCE_ID} topology or coverage scope mismatch`);
   }
-  assertRouteMapAdmissionFreshness(evidence, now, SOURCE_ID);
   return source;
 }
 

--- a/tools/datapack/materialize-daegu-route-map-positions.mjs
+++ b/tools/datapack/materialize-daegu-route-map-positions.mjs
@@ -127,7 +127,6 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshots, 
   if (!/^[a-f0-9]{64}$/.test(snapshotSha256 ?? "") || evidence?.snapshotSha256 !== snapshotSha256) {
     throw new Error("Daegu route map snapshot byte identity mismatch");
   }
-  const observedNow = now instanceof Date ? now.getTime() : Number.NaN;
   if (source?.productionUseAllowed !== true || source.license?.redistributionAllowed !== true
     || source.license?.type !== "PUBLIC_DATA_FREE_USE"
     || source.license.commercialUseAllowed !== true || source.license.derivativeWorkAllowed !== true
@@ -158,8 +157,7 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshots, 
       lineIds: [...LINE_IDS],
       sourceDomains: ["route_map_positions"],
     })
-    || JSON.stringify(source.fieldsProvided) !== JSON.stringify(snapshot.fieldsProvided)
-    || !Number.isFinite(observedNow) || observedNow < Date.parse(snapshot.capturedAt)) {
+    || JSON.stringify(source.fieldsProvided) !== JSON.stringify(snapshot.fieldsProvided)) {
     throw new Error(`${SOURCE_ID} inventory evidence does not match snapshot`);
   }
   validateTopologyLineages(inventory, evidence, topologySnapshots);

--- a/tools/datapack/materialize-daegu-route-map-positions.mjs
+++ b/tools/datapack/materialize-daegu-route-map-positions.mjs
@@ -6,6 +6,7 @@ import { pathToFileURL } from "node:url";
 
 import { DAEGU_LINES } from "./collect-daegu-datapack-sources.mjs";
 import { validateDaeguRouteMapPositionsSnapshot } from "./collect-daegu-route-map-positions.mjs";
+import { assertRouteMapAdmissionFreshness } from "./lib/route-map-admission-freshness.mjs";
 
 const SOURCE_ID = "daegu-transportation-route-map-positions";
 const PACK_ID = "nationwide-daegu-route-map";
@@ -162,6 +163,7 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshots, 
     throw new Error(`${SOURCE_ID} inventory evidence does not match snapshot`);
   }
   validateTopologyLineages(inventory, evidence, topologySnapshots);
+  assertRouteMapAdmissionFreshness(evidence, now, SOURCE_ID);
   return source;
 }
 

--- a/tools/datapack/materialize-daegu-route-map-positions.mjs
+++ b/tools/datapack/materialize-daegu-route-map-positions.mjs
@@ -127,6 +127,7 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshots, 
   if (!/^[a-f0-9]{64}$/.test(snapshotSha256 ?? "") || evidence?.snapshotSha256 !== snapshotSha256) {
     throw new Error("Daegu route map snapshot byte identity mismatch");
   }
+  const observedNow = assertRouteMapAdmissionFreshness(evidence, now, SOURCE_ID);
   if (source?.productionUseAllowed !== true || source.license?.redistributionAllowed !== true
     || source.license?.type !== "PUBLIC_DATA_FREE_USE"
     || source.license.commercialUseAllowed !== true || source.license.derivativeWorkAllowed !== true
@@ -157,11 +158,11 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshots, 
       lineIds: [...LINE_IDS],
       sourceDomains: ["route_map_positions"],
     })
-    || JSON.stringify(source.fieldsProvided) !== JSON.stringify(snapshot.fieldsProvided)) {
+    || JSON.stringify(source.fieldsProvided) !== JSON.stringify(snapshot.fieldsProvided)
+    || !Number.isFinite(observedNow) || observedNow < Date.parse(snapshot.capturedAt)) {
     throw new Error(`${SOURCE_ID} inventory evidence does not match snapshot`);
   }
   validateTopologyLineages(inventory, evidence, topologySnapshots);
-  assertRouteMapAdmissionFreshness(evidence, now, SOURCE_ID);
   return source;
 }
 

--- a/tools/datapack/materialize-daegu-route-map-positions.test.mjs
+++ b/tools/datapack/materialize-daegu-route-map-positions.test.mjs
@@ -139,6 +139,16 @@ test("공식 대구 출구 위경도 snapshot을 누적 production candidate pac
   assert.equal(pack.version, "20260724");
   assert.deepEqual(fixture.manifest.activePack, { id: pack.id, version: "20260724" });
 
+  const routeMapFreshUntil = inventory.sources.find(({ id }) => id === SOURCE_ID)
+    .routeMapAdmissionEvidence.freshUntil;
+  assert.throws(
+    () => materializeDaeguRouteMapPositions({
+      baseFixture, snapshot: daeguSnapshot, snapshotSha256: daeguSnapshotSha256,
+      topologySnapshots, inventory, now: new Date(routeMapFreshUntil),
+    }),
+    /route-map admission snapshot is stale or future-dated/,
+  );
+
   const mismatchedInventory = structuredClone(inventory);
   mismatchedInventory.sources.find(({ id }) => id === SOURCE_ID)
     .routeMapAdmissionEvidence.positionsSha256 = "0".repeat(64);

--- a/tools/datapack/materialize-daejeon-route-map-positions.mjs
+++ b/tools/datapack/materialize-daejeon-route-map-positions.mjs
@@ -129,7 +129,6 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshot, n
   if (!/^[a-f0-9]{64}$/.test(snapshotSha256 ?? "") || evidence?.snapshotSha256 !== snapshotSha256) {
     throw new Error("Daejeon route map snapshot byte identity mismatch");
   }
-  const observedNow = now instanceof Date ? now.getTime() : Number.NaN;
   if (source?.productionUseAllowed !== true || source.license?.redistributionAllowed !== true
     || source.license?.type !== "PUBLIC_DATA_FREE_USE"
     || source.license.commercialUseAllowed !== true || source.license.derivativeWorkAllowed !== true
@@ -160,8 +159,7 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshot, n
       lineIds: [...LINE_IDS],
       sourceDomains: ["route_map_positions"],
     })
-    || JSON.stringify(source.fieldsProvided) !== JSON.stringify(snapshot.fieldsProvided)
-    || !Number.isFinite(observedNow) || observedNow < Date.parse(snapshot.capturedAt)) {
+    || JSON.stringify(source.fieldsProvided) !== JSON.stringify(snapshot.fieldsProvided)) {
     throw new Error(`${SOURCE_ID} inventory evidence does not match snapshot`);
   }
   validateTopologyLineage(inventory, evidence, topologySnapshot);

--- a/tools/datapack/materialize-daejeon-route-map-positions.mjs
+++ b/tools/datapack/materialize-daejeon-route-map-positions.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 
 import { validateDaejeonRouteMapPositionsSnapshot } from "./collect-daejeon-route-map-positions.mjs";
+import { assertRouteMapAdmissionFreshness } from "./lib/route-map-admission-freshness.mjs";
 
 const SOURCE_ID = "daejeon-transportation-route-map-positions";
 const TOPOLOGY_SOURCE_ID = "daejeon-station-distance-fare";
@@ -164,6 +165,7 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshot, n
     throw new Error(`${SOURCE_ID} inventory evidence does not match snapshot`);
   }
   validateTopologyLineage(inventory, evidence, topologySnapshot);
+  assertRouteMapAdmissionFreshness(evidence, now, SOURCE_ID);
   return source;
 }
 

--- a/tools/datapack/materialize-daejeon-route-map-positions.mjs
+++ b/tools/datapack/materialize-daejeon-route-map-positions.mjs
@@ -129,6 +129,7 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshot, n
   if (!/^[a-f0-9]{64}$/.test(snapshotSha256 ?? "") || evidence?.snapshotSha256 !== snapshotSha256) {
     throw new Error("Daejeon route map snapshot byte identity mismatch");
   }
+  const observedNow = assertRouteMapAdmissionFreshness(evidence, now, SOURCE_ID);
   if (source?.productionUseAllowed !== true || source.license?.redistributionAllowed !== true
     || source.license?.type !== "PUBLIC_DATA_FREE_USE"
     || source.license.commercialUseAllowed !== true || source.license.derivativeWorkAllowed !== true
@@ -159,11 +160,11 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshot, n
       lineIds: [...LINE_IDS],
       sourceDomains: ["route_map_positions"],
     })
-    || JSON.stringify(source.fieldsProvided) !== JSON.stringify(snapshot.fieldsProvided)) {
+    || JSON.stringify(source.fieldsProvided) !== JSON.stringify(snapshot.fieldsProvided)
+    || !Number.isFinite(observedNow) || observedNow < Date.parse(snapshot.capturedAt)) {
     throw new Error(`${SOURCE_ID} inventory evidence does not match snapshot`);
   }
   validateTopologyLineage(inventory, evidence, topologySnapshot);
-  assertRouteMapAdmissionFreshness(evidence, now, SOURCE_ID);
   return source;
 }
 

--- a/tools/datapack/materialize-gwangju-route-map-positions.mjs
+++ b/tools/datapack/materialize-gwangju-route-map-positions.mjs
@@ -129,6 +129,7 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshot, n
   if (!/^[a-f0-9]{64}$/.test(snapshotSha256 ?? "") || evidence?.snapshotSha256 !== snapshotSha256) {
     throw new Error("Gwangju route map snapshot byte identity mismatch");
   }
+  const observedNow = assertRouteMapAdmissionFreshness(evidence, now, SOURCE_ID);
   if (source?.productionUseAllowed !== true || source.license?.redistributionAllowed !== true
     || source.license?.type !== "PUBLIC_DATA_FREE_USE"
     || source.license.commercialUseAllowed !== true || source.license.derivativeWorkAllowed !== true
@@ -159,11 +160,11 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshot, n
       lineIds: [...LINE_IDS],
       sourceDomains: ["route_map_positions"],
     })
-    || JSON.stringify(source.fieldsProvided) !== JSON.stringify(snapshot.fieldsProvided)) {
+    || JSON.stringify(source.fieldsProvided) !== JSON.stringify(snapshot.fieldsProvided)
+    || !Number.isFinite(observedNow) || observedNow < Date.parse(snapshot.capturedAt)) {
     throw new Error(`${SOURCE_ID} inventory evidence does not match snapshot`);
   }
   validateTopologyLineage(inventory, evidence, topologySnapshot);
-  assertRouteMapAdmissionFreshness(evidence, now, SOURCE_ID);
   return source;
 }
 

--- a/tools/datapack/materialize-gwangju-route-map-positions.mjs
+++ b/tools/datapack/materialize-gwangju-route-map-positions.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 
 import { validateGwangjuRouteMapPositionsSnapshot } from "./collect-gwangju-route-map-positions.mjs";
+import { assertRouteMapAdmissionFreshness } from "./lib/route-map-admission-freshness.mjs";
 
 const SOURCE_ID = "gwangju-transportation-route-map-positions";
 const TOPOLOGY_SOURCE_ID = "gwangju-transportation-route-topology";
@@ -164,6 +165,7 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshot, n
     throw new Error(`${SOURCE_ID} inventory evidence does not match snapshot`);
   }
   validateTopologyLineage(inventory, evidence, topologySnapshot);
+  assertRouteMapAdmissionFreshness(evidence, now, SOURCE_ID);
   return source;
 }
 

--- a/tools/datapack/materialize-gwangju-route-map-positions.mjs
+++ b/tools/datapack/materialize-gwangju-route-map-positions.mjs
@@ -129,7 +129,6 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshot, n
   if (!/^[a-f0-9]{64}$/.test(snapshotSha256 ?? "") || evidence?.snapshotSha256 !== snapshotSha256) {
     throw new Error("Gwangju route map snapshot byte identity mismatch");
   }
-  const observedNow = now instanceof Date ? now.getTime() : Number.NaN;
   if (source?.productionUseAllowed !== true || source.license?.redistributionAllowed !== true
     || source.license?.type !== "PUBLIC_DATA_FREE_USE"
     || source.license.commercialUseAllowed !== true || source.license.derivativeWorkAllowed !== true
@@ -160,8 +159,7 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshot, n
       lineIds: [...LINE_IDS],
       sourceDomains: ["route_map_positions"],
     })
-    || JSON.stringify(source.fieldsProvided) !== JSON.stringify(snapshot.fieldsProvided)
-    || !Number.isFinite(observedNow) || observedNow < Date.parse(snapshot.capturedAt)) {
+    || JSON.stringify(source.fieldsProvided) !== JSON.stringify(snapshot.fieldsProvided)) {
     throw new Error(`${SOURCE_ID} inventory evidence does not match snapshot`);
   }
   validateTopologyLineage(inventory, evidence, topologySnapshot);

--- a/tools/datapack/materialize-incheon-station-info.mjs
+++ b/tools/datapack/materialize-incheon-station-info.mjs
@@ -7,6 +7,7 @@ import { pathToFileURL } from "node:url";
 import {
   validateIncheonStationInfoSnapshot,
 } from "./collect-incheon-station-info.mjs";
+import { assertRouteMapAdmissionFreshness } from "./lib/route-map-admission-freshness.mjs";
 
 const SOURCE_ID = "incheon-transit-station-info";
 const OPERATOR_ID = "incheon-transit";
@@ -394,6 +395,7 @@ function requiredSource(inventory, snapshot, snapshotSha256, now) {
     || Date.parse(snapshot.freshUntil) !== Date.parse(snapshot.capturedAt) + FRESHNESS_MILLIS) {
     throw new Error(`${SOURCE_ID} inventory evidence does not match snapshot`);
   }
+  assertRouteMapAdmissionFreshness(routeMap, now, SOURCE_ID);
   return source;
 }
 

--- a/tools/datapack/materialize-incheon-station-info.test.mjs
+++ b/tools/datapack/materialize-incheon-station-info.test.mjs
@@ -214,6 +214,17 @@ test("인천 station-info materialize는 freshness·hash·중복을 fail closed�
     now: new Date("2026-07-25T06:00:00.000Z"),
   }), /inventory evidence|fresh/);
 
+  const mismatchedRouteMapFreshness = structuredClone(inventory);
+  mismatchedRouteMapFreshness.sources.find(({ id }) => id === SOURCE_ID)
+    .routeMapAdmissionEvidence.freshUntil = "2026-07-25T06:00:00.000Z";
+  assert.throws(() => materializeIncheonStationInfo({
+    baseFixture: accessibilityFixture,
+    snapshot: incheonSnapshot,
+    snapshotSha256,
+    inventory: mismatchedRouteMapFreshness,
+    now: incheonNow,
+  }), /route-map freshness contract is invalid/);
+
   const badHash = structuredClone(incheonSnapshot);
   badHash.contentSha256 = "0".repeat(64);
   assert.throws(() => materializeIncheonStationInfo({

--- a/tools/datapack/materialize-kric-capital-light-rail-route-map-positions.mjs
+++ b/tools/datapack/materialize-kric-capital-light-rail-route-map-positions.mjs
@@ -9,6 +9,7 @@ import {
   getCapitalLightRailRouteMapPositionLine,
   validateCapitalLightRailRouteMapPositionsSnapshot,
 } from "./collect-kric-capital-light-rail-route-map-positions.mjs";
+import { assertRouteMapAdmissionFreshness } from "./lib/route-map-admission-freshness.mjs";
 
 const TOPOLOGY_SOURCE_ID = "capital-route-topology";
 const TOPOLOGY_SNAPSHOT_ID = "capital-route-topology-20260724";
@@ -192,6 +193,7 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshot, l
     throw new Error(`${line.sourceId} inventory evidence does not match snapshot`);
   }
   validateTopologyLineage(evidence, topologySnapshot, line);
+  assertRouteMapAdmissionFreshness(evidence, now, line.sourceId);
   return source;
 }
 

--- a/tools/datapack/materialize-kric-capital-light-rail-route-map-positions.mjs
+++ b/tools/datapack/materialize-kric-capital-light-rail-route-map-positions.mjs
@@ -157,7 +157,6 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshot, l
   if (!/^[a-f0-9]{64}$/.test(snapshotSha256 ?? "") || evidence?.snapshotSha256 !== snapshotSha256) {
     throw new Error(`${line.sourceId} snapshot byte identity mismatch`);
   }
-  const observedNow = now instanceof Date ? now.getTime() : Number.NaN;
   if (source?.productionUseAllowed !== true || source.license?.redistributionAllowed !== true
     || source.license?.type !== "PUBLIC_DATA_FREE_USE"
     || source.license.commercialUseAllowed !== true || source.license.derivativeWorkAllowed !== true
@@ -188,8 +187,7 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshot, l
       lineIds: [line.lineId],
       sourceDomains: ["route_map_positions"],
     })
-    || JSON.stringify(source.fieldsProvided) !== JSON.stringify(snapshot.fieldsProvided)
-    || !Number.isFinite(observedNow) || observedNow < Date.parse(snapshot.capturedAt)) {
+    || JSON.stringify(source.fieldsProvided) !== JSON.stringify(snapshot.fieldsProvided)) {
     throw new Error(`${line.sourceId} inventory evidence does not match snapshot`);
   }
   validateTopologyLineage(evidence, topologySnapshot, line);

--- a/tools/datapack/materialize-kric-capital-light-rail-route-map-positions.mjs
+++ b/tools/datapack/materialize-kric-capital-light-rail-route-map-positions.mjs
@@ -157,6 +157,7 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshot, l
   if (!/^[a-f0-9]{64}$/.test(snapshotSha256 ?? "") || evidence?.snapshotSha256 !== snapshotSha256) {
     throw new Error(`${line.sourceId} snapshot byte identity mismatch`);
   }
+  const observedNow = assertRouteMapAdmissionFreshness(evidence, now, line.sourceId);
   if (source?.productionUseAllowed !== true || source.license?.redistributionAllowed !== true
     || source.license?.type !== "PUBLIC_DATA_FREE_USE"
     || source.license.commercialUseAllowed !== true || source.license.derivativeWorkAllowed !== true
@@ -187,11 +188,11 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshot, l
       lineIds: [line.lineId],
       sourceDomains: ["route_map_positions"],
     })
-    || JSON.stringify(source.fieldsProvided) !== JSON.stringify(snapshot.fieldsProvided)) {
+    || JSON.stringify(source.fieldsProvided) !== JSON.stringify(snapshot.fieldsProvided)
+    || !Number.isFinite(observedNow) || observedNow < Date.parse(snapshot.capturedAt)) {
     throw new Error(`${line.sourceId} inventory evidence does not match snapshot`);
   }
   validateTopologyLineage(evidence, topologySnapshot, line);
-  assertRouteMapAdmissionFreshness(evidence, now, line.sourceId);
   return source;
 }
 

--- a/tools/datapack/materialize-kric-capital-wide-rail-route-map-positions.mjs
+++ b/tools/datapack/materialize-kric-capital-wide-rail-route-map-positions.mjs
@@ -138,7 +138,6 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshot, l
   if (!/^[a-f0-9]{64}$/.test(snapshotSha256 ?? "") || evidence?.snapshotSha256 !== snapshotSha256) {
     throw new Error(`${line.sourceId} snapshot byte identity mismatch`);
   }
-  const observedNow = now instanceof Date ? now.getTime() : Number.NaN;
   if (source?.productionUseAllowed !== true || source.license?.redistributionAllowed !== true
     || source.license?.type !== "PUBLIC_DATA_FREE_USE"
     || source.license.commercialUseAllowed !== true || source.license.derivativeWorkAllowed !== true
@@ -169,8 +168,7 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshot, l
       lineIds: [line.lineId],
       sourceDomains: ["route_map_positions"],
     })
-    || JSON.stringify(source.fieldsProvided) !== JSON.stringify(snapshot.fieldsProvided)
-    || !Number.isFinite(observedNow) || observedNow < Date.parse(snapshot.capturedAt)) {
+    || JSON.stringify(source.fieldsProvided) !== JSON.stringify(snapshot.fieldsProvided)) {
     throw new Error(`${line.sourceId} inventory evidence does not match snapshot`);
   }
   validateTopologyLineage(evidence, topologySnapshot, line);

--- a/tools/datapack/materialize-kric-capital-wide-rail-route-map-positions.mjs
+++ b/tools/datapack/materialize-kric-capital-wide-rail-route-map-positions.mjs
@@ -138,6 +138,7 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshot, l
   if (!/^[a-f0-9]{64}$/.test(snapshotSha256 ?? "") || evidence?.snapshotSha256 !== snapshotSha256) {
     throw new Error(`${line.sourceId} snapshot byte identity mismatch`);
   }
+  const observedNow = assertRouteMapAdmissionFreshness(evidence, now, line.sourceId);
   if (source?.productionUseAllowed !== true || source.license?.redistributionAllowed !== true
     || source.license?.type !== "PUBLIC_DATA_FREE_USE"
     || source.license.commercialUseAllowed !== true || source.license.derivativeWorkAllowed !== true
@@ -168,11 +169,11 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshot, l
       lineIds: [line.lineId],
       sourceDomains: ["route_map_positions"],
     })
-    || JSON.stringify(source.fieldsProvided) !== JSON.stringify(snapshot.fieldsProvided)) {
+    || JSON.stringify(source.fieldsProvided) !== JSON.stringify(snapshot.fieldsProvided)
+    || !Number.isFinite(observedNow) || observedNow < Date.parse(snapshot.capturedAt)) {
     throw new Error(`${line.sourceId} inventory evidence does not match snapshot`);
   }
   validateTopologyLineage(evidence, topologySnapshot, line);
-  assertRouteMapAdmissionFreshness(evidence, now, line.sourceId);
   return source;
 }
 

--- a/tools/datapack/materialize-kric-capital-wide-rail-route-map-positions.mjs
+++ b/tools/datapack/materialize-kric-capital-wide-rail-route-map-positions.mjs
@@ -9,6 +9,7 @@ import {
   getCapitalWideRailRouteMapPositionLine,
   validateCapitalWideRailRouteMapPositionsSnapshot,
 } from "./collect-kric-capital-wide-rail-route-map-positions.mjs";
+import { assertRouteMapAdmissionFreshness } from "./lib/route-map-admission-freshness.mjs";
 
 const TOPOLOGY_SOURCE_ID = "capital-route-topology";
 const TOPOLOGY_SNAPSHOT_ID = "capital-route-topology-20260724";
@@ -173,6 +174,7 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshot, l
     throw new Error(`${line.sourceId} inventory evidence does not match snapshot`);
   }
   validateTopologyLineage(evidence, topologySnapshot, line);
+  assertRouteMapAdmissionFreshness(evidence, now, line.sourceId);
   return source;
 }
 

--- a/tools/datapack/materialize-seoul-route-map-positions.mjs
+++ b/tools/datapack/materialize-seoul-route-map-positions.mjs
@@ -146,6 +146,7 @@ function requiredSource(inventory, snapshot, snapshotSha256, now) {
   if (!/^[a-f0-9]{64}$/.test(snapshotSha256 ?? "") || evidence?.snapshotSha256 !== snapshotSha256) {
     throw new Error("Seoul route map snapshot byte identity mismatch");
   }
+  const observedNow = assertRouteMapAdmissionFreshness(evidence, now, SOURCE_ID);
   if (source?.productionUseAllowed !== true || source.license?.redistributionAllowed !== true
     || source.license?.type !== "PUBLIC_DATA_FREE_USE"
     || source.license.commercialUseAllowed !== true || source.license.derivativeWorkAllowed !== true
@@ -169,10 +170,10 @@ function requiredSource(inventory, snapshot, snapshotSha256, now) {
       lineIds: [...LINE_IDS],
       sourceDomains: ["route_map_positions"],
     })
-    || JSON.stringify(source.fieldsProvided) !== JSON.stringify(snapshot.fieldsProvided)) {
+    || JSON.stringify(source.fieldsProvided) !== JSON.stringify(snapshot.fieldsProvided)
+    || !Number.isFinite(observedNow) || observedNow < Date.parse(snapshot.capturedAt)) {
     throw new Error(`${SOURCE_ID} inventory evidence does not match snapshot`);
   }
-  assertRouteMapAdmissionFreshness(evidence, now, SOURCE_ID);
   return source;
 }
 

--- a/tools/datapack/materialize-seoul-route-map-positions.mjs
+++ b/tools/datapack/materialize-seoul-route-map-positions.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 
 import { validateSeoulRouteMapPositionsSnapshot } from "./collect-seoul-route-map-positions.mjs";
+import { assertRouteMapAdmissionFreshness } from "./lib/route-map-admission-freshness.mjs";
 
 const SOURCE_ID = "seoul-metro-route-map-positions";
 const CYBERSTATION_SOURCE_ID = "seoulmetro-cyberstation-route-map";
@@ -173,6 +174,7 @@ function requiredSource(inventory, snapshot, snapshotSha256, now) {
     || !Number.isFinite(observedNow) || observedNow < Date.parse(snapshot.capturedAt)) {
     throw new Error(`${SOURCE_ID} inventory evidence does not match snapshot`);
   }
+  assertRouteMapAdmissionFreshness(evidence, now, SOURCE_ID);
   return source;
 }
 

--- a/tools/datapack/materialize-seoul-route-map-positions.mjs
+++ b/tools/datapack/materialize-seoul-route-map-positions.mjs
@@ -146,7 +146,6 @@ function requiredSource(inventory, snapshot, snapshotSha256, now) {
   if (!/^[a-f0-9]{64}$/.test(snapshotSha256 ?? "") || evidence?.snapshotSha256 !== snapshotSha256) {
     throw new Error("Seoul route map snapshot byte identity mismatch");
   }
-  const observedNow = now instanceof Date ? now.getTime() : Number.NaN;
   if (source?.productionUseAllowed !== true || source.license?.redistributionAllowed !== true
     || source.license?.type !== "PUBLIC_DATA_FREE_USE"
     || source.license.commercialUseAllowed !== true || source.license.derivativeWorkAllowed !== true
@@ -170,8 +169,7 @@ function requiredSource(inventory, snapshot, snapshotSha256, now) {
       lineIds: [...LINE_IDS],
       sourceDomains: ["route_map_positions"],
     })
-    || JSON.stringify(source.fieldsProvided) !== JSON.stringify(snapshot.fieldsProvided)
-    || !Number.isFinite(observedNow) || observedNow < Date.parse(snapshot.capturedAt)) {
+    || JSON.stringify(source.fieldsProvided) !== JSON.stringify(snapshot.fieldsProvided)) {
     throw new Error(`${SOURCE_ID} inventory evidence does not match snapshot`);
   }
   assertRouteMapAdmissionFreshness(evidence, now, SOURCE_ID);

--- a/tools/datapack/materialize-seoul9-phase1-route-map-positions.mjs
+++ b/tools/datapack/materialize-seoul9-phase1-route-map-positions.mjs
@@ -160,7 +160,6 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshot, n
   if (!/^[a-f0-9]{64}$/.test(snapshotSha256 ?? "") || evidence?.snapshotSha256 !== snapshotSha256) {
     throw new Error("Seoul9 phase1 route map snapshot byte identity mismatch");
   }
-  const observedNow = now instanceof Date ? now.getTime() : Number.NaN;
   if (source?.productionUseAllowed !== true || source.license?.redistributionAllowed !== true
     || source.license?.type !== "PUBLIC_DATA_FREE_USE"
     || source.license.commercialUseAllowed !== true || source.license.derivativeWorkAllowed !== true
@@ -191,8 +190,7 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshot, n
       lineIds: [...LINE_IDS],
       sourceDomains: ["route_map_positions"],
     })
-    || JSON.stringify(source.fieldsProvided) !== JSON.stringify(snapshot.fieldsProvided)
-    || !Number.isFinite(observedNow) || observedNow < Date.parse(snapshot.capturedAt)) {
+    || JSON.stringify(source.fieldsProvided) !== JSON.stringify(snapshot.fieldsProvided)) {
     throw new Error(`${SOURCE_ID} inventory evidence does not match snapshot`);
   }
   validateTopologyLineage(evidence, topologySnapshot);

--- a/tools/datapack/materialize-seoul9-phase1-route-map-positions.mjs
+++ b/tools/datapack/materialize-seoul9-phase1-route-map-positions.mjs
@@ -160,6 +160,7 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshot, n
   if (!/^[a-f0-9]{64}$/.test(snapshotSha256 ?? "") || evidence?.snapshotSha256 !== snapshotSha256) {
     throw new Error("Seoul9 phase1 route map snapshot byte identity mismatch");
   }
+  const observedNow = assertRouteMapAdmissionFreshness(evidence, now, SOURCE_ID);
   if (source?.productionUseAllowed !== true || source.license?.redistributionAllowed !== true
     || source.license?.type !== "PUBLIC_DATA_FREE_USE"
     || source.license.commercialUseAllowed !== true || source.license.derivativeWorkAllowed !== true
@@ -190,11 +191,11 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshot, n
       lineIds: [...LINE_IDS],
       sourceDomains: ["route_map_positions"],
     })
-    || JSON.stringify(source.fieldsProvided) !== JSON.stringify(snapshot.fieldsProvided)) {
+    || JSON.stringify(source.fieldsProvided) !== JSON.stringify(snapshot.fieldsProvided)
+    || !Number.isFinite(observedNow) || observedNow < Date.parse(snapshot.capturedAt)) {
     throw new Error(`${SOURCE_ID} inventory evidence does not match snapshot`);
   }
   validateTopologyLineage(evidence, topologySnapshot);
-  assertRouteMapAdmissionFreshness(evidence, now, SOURCE_ID);
   return source;
 }
 

--- a/tools/datapack/materialize-seoul9-phase1-route-map-positions.mjs
+++ b/tools/datapack/materialize-seoul9-phase1-route-map-positions.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 
 import { validateSeoul9Phase1RouteMapPositionsSnapshot } from "./collect-seoul9-phase1-route-map-positions.mjs";
+import { assertRouteMapAdmissionFreshness } from "./lib/route-map-admission-freshness.mjs";
 
 const SOURCE_ID = "kric-seoul-metro-line9-1-route-map-positions";
 const TOPOLOGY_SOURCE_ID = "capital-route-topology";
@@ -195,6 +196,7 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshot, n
     throw new Error(`${SOURCE_ID} inventory evidence does not match snapshot`);
   }
   validateTopologyLineage(evidence, topologySnapshot);
+  assertRouteMapAdmissionFreshness(evidence, now, SOURCE_ID);
   return source;
 }
 

--- a/tools/datapack/materialize-seoul9-route-map-positions.mjs
+++ b/tools/datapack/materialize-seoul9-route-map-positions.mjs
@@ -161,7 +161,6 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshot, n
   if (!/^[a-f0-9]{64}$/.test(snapshotSha256 ?? "") || evidence?.snapshotSha256 !== snapshotSha256) {
     throw new Error("Seoul9 route map snapshot byte identity mismatch");
   }
-  const observedNow = now instanceof Date ? now.getTime() : Number.NaN;
   if (source?.productionUseAllowed !== true || source.license?.redistributionAllowed !== true
     || source.license?.type !== "PUBLIC_DATA_FREE_USE"
     || source.license.commercialUseAllowed !== true || source.license.derivativeWorkAllowed !== true
@@ -192,8 +191,7 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshot, n
       lineIds: [...LINE_IDS],
       sourceDomains: ["route_map_positions"],
     })
-    || JSON.stringify(source.fieldsProvided) !== JSON.stringify(snapshot.fieldsProvided)
-    || !Number.isFinite(observedNow) || observedNow < Date.parse(snapshot.capturedAt)) {
+    || JSON.stringify(source.fieldsProvided) !== JSON.stringify(snapshot.fieldsProvided)) {
     throw new Error(`${SOURCE_ID} inventory evidence does not match snapshot`);
   }
   validateTopologyLineage(evidence, topologySnapshot);

--- a/tools/datapack/materialize-seoul9-route-map-positions.mjs
+++ b/tools/datapack/materialize-seoul9-route-map-positions.mjs
@@ -161,6 +161,7 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshot, n
   if (!/^[a-f0-9]{64}$/.test(snapshotSha256 ?? "") || evidence?.snapshotSha256 !== snapshotSha256) {
     throw new Error("Seoul9 route map snapshot byte identity mismatch");
   }
+  const observedNow = assertRouteMapAdmissionFreshness(evidence, now, SOURCE_ID);
   if (source?.productionUseAllowed !== true || source.license?.redistributionAllowed !== true
     || source.license?.type !== "PUBLIC_DATA_FREE_USE"
     || source.license.commercialUseAllowed !== true || source.license.derivativeWorkAllowed !== true
@@ -191,11 +192,11 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshot, n
       lineIds: [...LINE_IDS],
       sourceDomains: ["route_map_positions"],
     })
-    || JSON.stringify(source.fieldsProvided) !== JSON.stringify(snapshot.fieldsProvided)) {
+    || JSON.stringify(source.fieldsProvided) !== JSON.stringify(snapshot.fieldsProvided)
+    || !Number.isFinite(observedNow) || observedNow < Date.parse(snapshot.capturedAt)) {
     throw new Error(`${SOURCE_ID} inventory evidence does not match snapshot`);
   }
   validateTopologyLineage(evidence, topologySnapshot);
-  assertRouteMapAdmissionFreshness(evidence, now, SOURCE_ID);
   return source;
 }
 

--- a/tools/datapack/materialize-seoul9-route-map-positions.mjs
+++ b/tools/datapack/materialize-seoul9-route-map-positions.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 
 import { validateSeoul9RouteMapPositionsSnapshot } from "./collect-seoul9-route-map-positions.mjs";
+import { assertRouteMapAdmissionFreshness } from "./lib/route-map-admission-freshness.mjs";
 
 const SOURCE_ID = "seoul-metro-line9-23-route-map-positions";
 const TOPOLOGY_SOURCE_ID = "capital-route-topology";
@@ -196,6 +197,7 @@ function requiredSource(inventory, snapshot, snapshotSha256, topologySnapshot, n
     throw new Error(`${SOURCE_ID} inventory evidence does not match snapshot`);
   }
   validateTopologyLineage(evidence, topologySnapshot);
+  assertRouteMapAdmissionFreshness(evidence, now, SOURCE_ID);
   return source;
 }
 

--- a/tools/datapack/nationwide-candidate-coverage-gate.test.mjs
+++ b/tools/datapack/nationwide-candidate-coverage-gate.test.mjs
@@ -219,11 +219,7 @@ const BUSAN_INCLUSION_BINDINGS = [
     offset: 2,
     sourceId: "busan-transportation-route-map-positions",
     evidenceKey: "routeMapAdmissionEvidence",
-    // 이 문구만 신선도 전용이 아니다 — 노선도 정본에는 freshUntil이 없어 materializer에 신선도 블록이
-    // 따로 없고, 하한(capturedAt 이후) 검사가 admission 정본 대조(positionsSha256·topologyContentSha256
-    // 등)와 한 조건에 묶여 같은 문구를 낸다. 문구를 가르는 것은 materializer 쪽 판단이라 이 하네스가
-    // 동작으로 바꾸지 않고, 대신 아래 대조 회귀가 그 문구의 원인을 하한 교차로 좁힌다.
-    stalePinPattern: /busan-transportation-route-map-positions inventory evidence does not match snapshot/,
+    stalePinPattern: /busan-transportation-route-map-positions route-map admission snapshot is stale or future-dated/,
   },
   {
     labelKo: "편의시설",
@@ -280,10 +276,9 @@ const DAEJEON_INCLUSION_BINDINGS = [
       evidenceKey: "routeMapAdmissionEvidence",
       field: "capturedAt",
     },
-    // 부산 노선도와 같은 비대칭이다 — 정본에 freshUntil이 없고 materializer도 하한만 검사하며, 그 하한
-    // 검사가 정본 대조와 한 조건에 묶여 있어 문구가 신선도 전용이 아니다.
-    belowLowerBoundPattern:
-      /daejeon-transportation-route-map-positions inventory evidence does not match snapshot/,
+    upperBound: { sourceId: "daejeon-transportation-route-map-positions", evidenceKey: "routeMapAdmissionEvidence", field: "freshUntil" },
+    belowLowerBoundPattern: /daejeon-transportation-route-map-positions route-map admission snapshot is stale or future-dated/,
+    atUpperBoundPattern: /daejeon-transportation-route-map-positions route-map admission snapshot is stale or future-dated/,
     topologyBinding: { sourceId: DAEJEON_TOPOLOGY_SOURCE_ID, evidenceKey: "topologyAdmissionEvidence" },
   },
   {
@@ -341,8 +336,9 @@ const GWANGJU_INCLUSION_BINDINGS = [
       evidenceKey: "routeMapAdmissionEvidence",
       field: "capturedAt",
     },
-    belowLowerBoundPattern:
-      /gwangju-transportation-route-map-positions inventory evidence does not match snapshot/,
+    upperBound: { sourceId: "gwangju-transportation-route-map-positions", evidenceKey: "routeMapAdmissionEvidence", field: "freshUntil" },
+    belowLowerBoundPattern: /gwangju-transportation-route-map-positions route-map admission snapshot is stale or future-dated/,
+    atUpperBoundPattern: /gwangju-transportation-route-map-positions route-map admission snapshot is stale or future-dated/,
     topologyBinding: { sourceId: GWANGJU_TOPOLOGY_SOURCE_ID, evidenceKey: "topologyAdmissionEvidence" },
   },
   {
@@ -395,7 +391,7 @@ const CAPITAL_INCLUSION_BINDINGS = [
     lineSourceIds: CAPITAL_WIDE_RAIL_LINE_SOURCE_IDS,
     reorderedTables: ["lines", "operators"],
     belowLowerBoundPattern:
-      /kric-gyeongui-jungang-route-map-positions inventory evidence does not match snapshot/,
+      /kric-gyeongui-jungang-route-map-positions route-map admission snapshot is stale or future-dated/,
   },
   {
     labelKo: "경전철",
@@ -404,7 +400,7 @@ const CAPITAL_INCLUSION_BINDINGS = [
     lineSourceIds: CAPITAL_LIGHT_RAIL_LINE_SOURCE_IDS,
     reorderedTables: ["coverageLineOperatorScopes", "lines", "operators"],
     // 하한 위반은 편입이 체인하는 첫 노선 소스에서 걸린다 — 카탈로그 순서상 신분당선이 첫 노선이다.
-    belowLowerBoundPattern: /kric-shinbundang-route-map-positions inventory evidence does not match snapshot/,
+    belowLowerBoundPattern: /kric-shinbundang-route-map-positions route-map admission snapshot is stale or future-dated/,
   },
   {
     labelKo: "서울 1~8호선",
@@ -413,7 +409,7 @@ const CAPITAL_INCLUSION_BINDINGS = [
     sourceId: CAPITAL_SEOUL_ROUTE_MAP_SOURCE_ID,
     evidenceKey: "routeMapAdmissionEvidence",
     reorderedTables: ["lines"],
-    belowLowerBoundPattern: /seoul-metro-route-map-positions inventory evidence does not match snapshot/,
+    belowLowerBoundPattern: /seoul-metro-route-map-positions route-map admission snapshot is stale or future-dated/,
   },
   // 9호선 두 소스는 노선 층 경로 키를 쓰지 않는다 — 한 편입이 소스 하나만 싣기 때문이다. 대신 편입 층에
   // snapshotPath와 topologySnapshotPath를 함께 두고 둘 다 그 소스의 정본에 결속한다.
@@ -425,7 +421,7 @@ const CAPITAL_INCLUSION_BINDINGS = [
     evidenceKey: "routeMapAdmissionEvidence",
     reorderedTables: ["coverageLineOperatorScopes", "lines", "operators"],
     belowLowerBoundPattern:
-      /kric-seoul-metro-line9-1-route-map-positions inventory evidence does not match snapshot/,
+      /kric-seoul-metro-line9-1-route-map-positions route-map admission snapshot is stale or future-dated/,
   },
   {
     labelKo: "9호선 2·3단계",
@@ -437,7 +433,7 @@ const CAPITAL_INCLUSION_BINDINGS = [
     // scope로 내지 않는다) 어느 표도 재정렬하지 않는다 — 선언 키 자체가 없어야 한다.
     reorderedTables: undefined,
     belowLowerBoundPattern:
-      /seoul-metro-line9-23-route-map-positions inventory evidence does not match snapshot/,
+      /seoul-metro-line9-23-route-map-positions route-map admission snapshot is stale or future-dated/,
   },
 ];
 // 인천 편입 3종의 결속 지점·신선도 창 축. 세 편입 모두 [capturedAt, freshUntil) 양끝을 검사하는 창을
@@ -774,8 +770,8 @@ test("대구 route_map/accessibility 6 requirement는 체인 편입으로 MISSIN
     "daegu-transportation-route-map-positions",
     "routeMapAdmissionEvidence",
   );
-  assert.equal(routeMapEvidence.freshUntil, undefined, "노선도 admission 정본에는 상한이 없다");
-  assert.ok(pins.get(DAEGU_MATERIALIZERS[1]) >= Date.parse(routeMapEvidence.capturedAt), "노선도 창 하한");
+  const routeMapPin = pins.get(DAEGU_MATERIALIZERS[1]);
+  assert.ok(routeMapPin >= Date.parse(routeMapEvidence.capturedAt) && routeMapPin < Date.parse(routeMapEvidence.freshUntil), "노선도 창");
   // 편의시설 편입: [capturedAt, freshUntil) 양끝을 검사한다.
   const accessibilityEvidence = admissionEvidence(
     "daegu-transportation-accessibility",
@@ -888,8 +884,8 @@ test("부산 20 requirement는 체인 편입으로 MISSING에서 SUPPORTED로 �
     assert.ok(pin >= Date.parse(capturedAt) && pin < Date.parse(freshUntil), `${binding.sourceId} 창`);
   }
   const routeMapEvidence = bindingEvidence(BUSAN_ROUTE_MAP_BINDING);
-  assert.equal(routeMapEvidence.freshUntil, undefined, "부산 노선도 admission 정본에도 상한이 없다");
-  assert.ok(Date.parse(routeMap.materializedAt) >= Date.parse(routeMapEvidence.capturedAt), "노선도 창 하한");
+  assert.ok(Date.parse(routeMap.materializedAt) >= Date.parse(routeMapEvidence.capturedAt)
+    && Date.parse(routeMap.materializedAt) < Date.parse(routeMapEvidence.freshUntil), "노선도 창");
   // 편의시설 창은 상한이 있는 두 창(topology·시각표)과 서로소다 — 그 셋은 pin 하나로 묶는 것이 애초에
   // 불가능하다. 다만 "부산 네 창이 전부 서로소"는 아니다: 노선도 창은 상한이 없어 [capturedAt, ∞)이고
   // 편의시설 창을 통째로 품는다(실측: 노선도 pin을 편의시설 capturedAt으로 옮기면 조립이 통과하고
@@ -1001,7 +997,7 @@ test("대전 5 requirement는 체인 편입으로 MISSING에서 SUPPORTED로 전
     "daejeon-transportation-accessibility",
     "accessibilityAdmissionEvidence",
   );
-  assert.equal(daejeonRouteMap.freshUntil, undefined, "대전 노선도 정본에는 상한이 없다");
+  assert.ok(Date.parse(daejeonRouteMap.freshUntil) > Date.parse(daejeonRouteMap.capturedAt));
   assert.ok(
     Date.parse(daejeonRouteMap.capturedAt) >= Date.parse(daejeonAccessibility.freshUntil),
     "대전은 상한 없는 노선도 창이 편의시설 창보다 뒤에서 시작해 두 창이 서로소다",
@@ -1090,7 +1086,7 @@ test("광주 5 requirement는 체인 편입으로 MISSING에서 SUPPORTED로 전
     "gwangju-transportation-accessibility",
     "accessibilityAdmissionEvidence",
   );
-  assert.equal(gwangjuRouteMap.freshUntil, undefined, "광주 노선도 정본에도 상한이 없다");
+  assert.ok(Date.parse(gwangjuRouteMap.freshUntil) > Date.parse(gwangjuRouteMap.capturedAt));
   assert.ok(
     Date.parse(gwangjuRouteMap.capturedAt) < Date.parse(gwangjuAccessibility.freshUntil)
       && Date.parse(gwangjuRouteMap.capturedAt) >= Date.parse(gwangjuAccessibility.capturedAt),
@@ -1929,8 +1925,6 @@ test("candidate 안전 경계는 spec 편집만으로 넓힐 수 없다", async 
         { solo: BUSAN_TOPOLOGY_INDEX + offset },
       );
     });
-    // 노선도 편입의 창에는 상한이 없다 — 그 비대칭은 아래 별도 축이 "먼 미래 pin도 통과한다"로 고정한다.
-    if (freshUntil === undefined) continue;
     await context.test(`부산 ${labelKo} 편입 기준 시각을 창 상한 이상으로 옮기면 거부된다`, async () => {
       await rejectsWith(
         (value) => { value.packDataInclusions[0].materializedAt = freshUntil; },
@@ -2070,16 +2064,16 @@ test("candidate 안전 경계는 spec 편집만으로 넓힐 수 없다", async 
     });
   }
 
-  // 수도권 다섯 편입의 창에는 상한이 없다(정본에 freshUntil이 없고 materializer도 하한만 검사한다).
+  // 수도권 노선도 편입도 P1Y 반개구간을 공유한다.
   // 하한은 광역·경전철에서 노선마다 따로 있지만 값이 모두 같아 편입 하나의 pin이 여덟/다섯 하한을 함께
   // 만족한다 — 그 "값이 같다"는 사실부터 정본에서 확인하고, 하한 위반은 첫 노선 소스에서 걸린다.
   for (const { labelKo, offset, lineSourceIds, sourceId, belowLowerBoundPattern } of CAPITAL_INCLUSION_BINDINGS) {
     const sourceIds = lineSourceIds ?? [sourceId];
     const windows = sourceIds.map((id) => admissionEvidenceOf(inventory, id, "routeMapAdmissionEvidence"));
-    await context.test(`수도권 ${labelKo} 편입 소스의 창은 상한이 없고 하한이 하나로 모인다`, () => {
+    await context.test(`수도권 ${labelKo} 편입 소스의 P1Y 창이 하나로 모인다`, () => {
       for (const window of windows) {
-        assert.equal(window.freshUntil, undefined, "수도권 노선도 정본에는 상한이 없다");
         assert.equal(window.capturedAt, windows[0].capturedAt, "한 편입이 싣는 소스의 하한은 모두 같다");
+        assert.equal(window.freshUntil, windows[0].freshUntil, "한 편입이 싣는 소스의 상한은 모두 같다");
       }
     });
     await context.test(`수도권 ${labelKo} 편입 기준 시각을 창 하한 미만으로 옮기면 거부된다`, async () => {
@@ -2089,6 +2083,13 @@ test("candidate 안전 경계는 spec 편집만으로 넓힐 수 없다", async 
             new Date(Date.parse(windows[0].capturedAt) - 1).toISOString();
         },
         belowLowerBoundPattern,
+        { solo: CAPITAL_INDEX + offset },
+      );
+    });
+    await context.test(`수도권 ${labelKo} 편입 기준 시각을 창 상한 이상으로 옮기면 거부된다`, async () => {
+      await rejectsWith(
+        (value) => { value.packDataInclusions[0].materializedAt = windows[0].freshUntil; },
+        /route-map admission snapshot is stale or future-dated/,
         { solo: CAPITAL_INDEX + offset },
       );
     });
@@ -2510,15 +2511,10 @@ test("candidate 안전 경계는 spec 편집만으로 넓힐 수 없다", async 
   });
 });
 
-// 부산 편입 넷 중 노선도만 신선도 창에 상한이 없다 — admission 정본에 freshUntil이 없고 materializer도
-// 하한(capturedAt 이후)만 검사한다. 하한 미만은 위 회귀가 fail closed로 고정하지만 상한 쪽에는 가드가
-// 아예 없어 100년 뒤 pin도 조립을 완주하고 판정까지 그대로 낸다. 상한 도입은 materializer 쪽 판단이라
-// 이 하네스가 동작으로 바꾸지 않고, 그 비대칭이 의도된 기록이라는 것을 성질 자체로 고정한다 — 나중에
-// 상한이 생기면 이 단언이 깨져 spec·evidence 서술까지 함께 고치도록 강제한다.
-test("부산 노선도 편입은 상한이 없어 먼 미래 기준 시각도 조립을 통과한다", async () => {
-  const fullSpec = await readJson(SPEC_PATH);
-  const trackedSpec = structuredClone(fullSpec);
-  const spec = structuredClone(fullSpec);
+// 부산 노선도 P1Y 반개구간의 상한은 downstream builder 전에 fail closed 한다. #2641의 경량
+// inclusion seam을 사용해 이 단언 하나 때문에 full candidate gate를 반복하지 않는다.
+test("부산 노선도 편입은 P1Y 상한에서 거부된다", async () => {
+  const spec = await readJson(SPEC_PATH);
   const inventory = await readJson(INVENTORY_PATH);
   const inherited = await readJson(REVIEWED_PACK_PATH);
   const { capturedAt, freshUntil } = admissionEvidenceOf(
@@ -2526,26 +2522,18 @@ test("부산 노선도 편입은 상한이 없어 먼 미래 기준 시각도 �
     BUSAN_ROUTE_MAP_BINDING.sourceId,
     BUSAN_ROUTE_MAP_BINDING.evidenceKey,
   );
-  assert.equal(freshUntil, undefined, "이 축은 노선도 정본에 상한이 없다는 전제 위에 있다");
-  const farFuture = capturedAt.replace(/^\d{4}/, (year) => String(Number(year) + 100));
+  assert.ok(Date.parse(freshUntil) > Date.parse(capturedAt));
   const index = BUSAN_TOPOLOGY_INDEX + BUSAN_ROUTE_MAP_BINDING.offset;
-  spec.packDataInclusions[index].materializedAt = farFuture;
+  const routeMapInclusion = structuredClone(spec.packDataInclusions[index]);
+  routeMapInclusion.materializedAt = freshUntil;
   spec.packDataInclusions = [
     spec.packDataInclusions[BUSAN_TOPOLOGY_INDEX],
-    spec.packDataInclusions[index],
+    routeMapInclusion,
   ];
-  trackedSpec.packDataInclusions = [
-    trackedSpec.packDataInclusions[BUSAN_TOPOLOGY_INDEX],
-    trackedSpec.packDataInclusions[index],
-  ];
-
-  const tracked = await applyPackDataInclusions(trackedSpec, inherited, inventory);
-  const inclusions = await applyPackDataInclusions(spec, inherited, inventory);
-  assert.equal(inclusions.records[1].materializedAt, farFuture);
-  assert.deepEqual(inclusions.pack, tracked.pack, "미래 pin은 downstream builder 입력을 바꾸지 않아야 한다");
-
-  const evidence = await readJson(EVIDENCE_PATH);
-  assertDeclaredTransitionsMatchVariants(fullSpec, evidence.variants);
+  await assert.rejects(
+    () => applyPackDataInclusions(spec, inherited, inventory),
+    /busan-transportation-route-map-positions route-map admission snapshot is stale or future-dated/,
+  );
 });
 
 // 노선도 편입의 하한 회귀는 나머지 셋과 진단 특정성이 비대칭이다: 시각표·편의시설은 신선도 전용 문구

--- a/tools/datapack/nationwide-candidate-coverage-gate.test.mjs
+++ b/tools/datapack/nationwide-candidate-coverage-gate.test.mjs
@@ -239,7 +239,7 @@ const [
 // 대전·광주·수도권 편입의 결속 지점·신선도 창 축(#2595). 부산 표와 같은 목적이지만 창 서술이 한 단계
 // 넓다: 이 배치의 시각표 편입은 소스 하나가 아니라 두셋의 시각 판정을 동시에 받으므로 pin 창의 하한·상한이
 // 서로 다른 정본에서 온다. 그래서 snapshot 결속(경로)과 창 경계(어느 정본의 어느 필드)를 따로 기술하고,
-// 값은 전부 admission 정본에서 끌어온다. upperBound가 없으면 그 편입의 창에는 상한이 없다는 뜻이다.
+// 값은 전부 admission 정본에서 끌어온다.
 const DAEJEON_TOPOLOGY_SOURCE_ID = "daejeon-station-distance-fare";
 const GWANGJU_TOPOLOGY_SOURCE_ID = "gwangju-transportation-route-topology";
 const DAEJEON_INCLUSION_BINDINGS = [
@@ -363,8 +363,7 @@ const GWANGJU_INCLUSION_BINDINGS = [
   },
 ];
 // 수도권 노선도 편입은 결속 단위가 편입이 아니라 노선(=소스)이다. 광역·경전철 편입은 노선별 snapshotPath를
-// 각 노선 소스의 정본 경로에 결속하고, 서울 편입만 편입 층 snapshotPath 하나를 쓴다. 세 편입 모두 창에
-// 상한이 없다(정본에 freshUntil이 없고 materializer도 하한만 검사한다).
+// 각 노선 소스의 정본 경로에 결속하고, 서울 편입만 편입 층 snapshotPath 하나를 쓴다.
 const CAPITAL_WIDE_RAIL_LINE_SOURCE_IDS = [
   "kric-gyeongui-jungang-route-map-positions",
   "kric-gyeongchun-route-map-positions",
@@ -763,9 +762,7 @@ test("대구 route_map/accessibility 6 requirement는 체인 편입으로 MISSIN
       assert.ok(pin >= Date.parse(capturedAt) && pin < Date.parse(freshUntil), `${sourceId} 창`);
     }
   }
-  // 노선도 편입: 신선도 보장이 다른 두 편입과 비대칭이다 — admission 정본에 freshUntil이 없고
-  // materializer도 하한(capturedAt 이후)만 검사해 상한이 없다(먼 미래 pin도 통과함이 실측된다).
-  // 상한 도입 여부는 materializer 쪽 판단이라 이 하네스의 축이 아니며, 여기서는 그 비대칭을 기록한다.
+  // 노선도 편입도 SLA P1Y 반개구간 안의 pin만 허용한다.
   const routeMapEvidence = admissionEvidence(
     "daegu-transportation-route-map-positions",
     "routeMapAdmissionEvidence",
@@ -867,8 +864,7 @@ test("부산 20 requirement는 체인 편입으로 MISSING에서 SUPPORTED로 �
   assert.equal(accessibility.addedRows.stationFacilityEvidence, 342);
   assert.equal(accessibility.addedRows.routeMapPositions, 0);
 
-  // pin은 편입마다 따로 두고 각각 그 소스의 admission 창 안이어야 한다. 부산 4소스의 창은 모양이 갈린다 —
-  // topology·시각표·편의시설은 [capturedAt, freshUntil) 양끝을 검사하고 노선도는 상한이 없다.
+  // pin은 편입마다 따로 두고 각각 그 소스의 admission 창 안이어야 한다.
   // 소스 id·evidence 키는 BUSAN_INCLUSION_BINDINGS가 정본이다 — 여기서 다시 인라인으로 쓰면 정본이
   // 갱신돼도 이 블록만 낡은 짝을 보게 된다.
   const inventory = await readJson(INVENTORY_PATH);
@@ -887,9 +883,7 @@ test("부산 20 requirement는 체인 편입으로 MISSING에서 SUPPORTED로 �
   assert.ok(Date.parse(routeMap.materializedAt) >= Date.parse(routeMapEvidence.capturedAt)
     && Date.parse(routeMap.materializedAt) < Date.parse(routeMapEvidence.freshUntil), "노선도 창");
   // 편의시설 창은 상한이 있는 두 창(topology·시각표)과 서로소다 — 그 셋은 pin 하나로 묶는 것이 애초에
-  // 불가능하다. 다만 "부산 네 창이 전부 서로소"는 아니다: 노선도 창은 상한이 없어 [capturedAt, ∞)이고
-  // 편의시설 창을 통째로 품는다(실측: 노선도 pin을 편의시설 capturedAt으로 옮기면 조립이 통과하고
-  // 시각표 capturedAt으로 옮기면 거부된다). 그 포함 관계까지 함께 고정한다.
+  // 불가능하다. 다만 "부산 네 창이 전부 서로소"는 아니다: P1Y 노선도 창이 편의시설 창을 통째로 품는다.
   const accessibilityWindow = bindingEvidence(BUSAN_ACCESSIBILITY_BINDING);
   for (const binding of [BUSAN_TOPOLOGY_BINDING, BUSAN_TIMETABLE_BINDING]) {
     assert.ok(
@@ -899,7 +893,11 @@ test("부산 20 requirement는 체인 편입으로 MISSING에서 SUPPORTED로 �
   }
   assert.ok(
     Date.parse(routeMapEvidence.capturedAt) <= Date.parse(accessibilityWindow.capturedAt),
-    "상한 없는 노선도 창은 편의시설 창을 통째로 품는다",
+    "노선도 창은 편의시설 창보다 먼저 시작한다",
+  );
+  assert.ok(
+    Date.parse(accessibilityWindow.freshUntil) <= Date.parse(routeMapEvidence.freshUntil),
+    "P1Y 노선도 창은 편의시설 창보다 나중에 닫힌다",
   );
 });
 
@@ -983,7 +981,7 @@ test("대전 5 requirement는 체인 편입으로 MISSING에서 SUPPORTED로 전
   assert.equal(accessibility.addedRows.routeMapPositions, 0);
 
   // pin은 편입마다 따로 두고 각각 그 소스의 창 안이어야 한다. 대전 세 창은 서로소인데, 그 서로소가
-  // 성립하는 이유가 광주와 다르므로(상한 없는 노선도 창의 하한이 편의시설 창 상한보다 늦다) 그 부등식을
+  // 성립하는 이유가 광주와 다르므로(P1Y 노선도 창의 하한이 편의시설 창 상한보다 늦다) 그 부등식을
   // 직접 고정한다 — spec 서술이 실측과 갈리면 여기서 깨진다.
   const inventory = await readJson(INVENTORY_PATH);
   assertPinsInsideWindows(inventory, evidence, DAEJEON_INDEX, DAEJEON_INCLUSION_BINDINGS);
@@ -1000,12 +998,12 @@ test("대전 5 requirement는 체인 편입으로 MISSING에서 SUPPORTED로 전
   assert.ok(Date.parse(daejeonRouteMap.freshUntil) > Date.parse(daejeonRouteMap.capturedAt));
   assert.ok(
     Date.parse(daejeonRouteMap.capturedAt) >= Date.parse(daejeonAccessibility.freshUntil),
-    "대전은 상한 없는 노선도 창이 편의시설 창보다 뒤에서 시작해 두 창이 서로소다",
+    "대전은 P1Y 노선도 창이 편의시설 창보다 뒤에서 시작해 두 창이 서로소다",
   );
 });
 
 // pin이 그 편입의 창 [하한, 상한) 안인지 본다. 이 배치의 시각표 편입은 창 경계가 서로 다른 정본에서
-// 오므로 경계 값을 binding 기술대로 끌어온다. 상한이 없는 편입은 하한만 본다.
+// 오므로 경계 값을 binding 기술대로 끌어온다.
 function assertPinsInsideWindows(inventory, evidence, regionIndex, bindings) {
   for (const binding of bindings) {
     const pin = Date.parse(evidence.packDataInclusions.entries[regionIndex + binding.offset].materializedAt);
@@ -1015,14 +1013,6 @@ function assertPinsInsideWindows(inventory, evidence, regionIndex, bindings) {
       binding.lowerBound.evidenceKey,
     )[binding.lowerBound.field];
     assert.ok(pin >= Date.parse(lower), `${binding.sourceId} 창 하한`);
-    if (binding.upperBound === undefined) {
-      assert.equal(
-        admissionEvidenceOf(inventory, binding.sourceId, binding.evidenceKey).freshUntil,
-        undefined,
-        `${binding.sourceId} 정본에는 상한이 없다`,
-      );
-      continue;
-    }
     const upper = admissionEvidenceOf(
       inventory,
       binding.upperBound.sourceId,
@@ -1071,8 +1061,8 @@ test("광주 5 requirement는 체인 편입으로 MISSING에서 SUPPORTED로 전
   assert.equal(schedule.supportingRecordCountByField.stop_time, 13_360);
   assert.equal(timetable.addedRows.transitStopTimes - schedule.supportingRecordCountByField.stop_time, 811);
 
-  // 광주 세 창의 관계는 대전과 다르다 — 상한 없는 노선도 창의 하한이 편의시설 창 상한보다 이르러 두 창이
-  // 한 시간을 공유한다. "상한이 없으면 늘 다른 창을 품는다"도 "지역 안 창은 늘 서로소다"도 아니라는 뜻이라
+  // 광주 세 창의 관계는 대전과 다르다 — P1Y 노선도 창의 하한이 편의시설 창 상한보다 이르러 두 창이
+  // 한 시간을 공유한다. "노선도 창은 늘 다른 창을 품는다"도 "지역 안 창은 늘 서로소다"도 아니라는 뜻이라
   // 실측 부등식을 그대로 고정한다.
   const inventory = await readJson(INVENTORY_PATH);
   assertPinsInsideWindows(inventory, evidence, GWANGJU_INDEX, GWANGJU_INCLUSION_BINDINGS);
@@ -1090,7 +1080,7 @@ test("광주 5 requirement는 체인 편입으로 MISSING에서 SUPPORTED로 전
   assert.ok(
     Date.parse(gwangjuRouteMap.capturedAt) < Date.parse(gwangjuAccessibility.freshUntil)
       && Date.parse(gwangjuRouteMap.capturedAt) >= Date.parse(gwangjuAccessibility.capturedAt),
-    "광주는 상한 없는 노선도 창이 편의시설 창 안에서 시작해 두 창이 겹친다",
+    "광주는 P1Y 노선도 창이 편의시설 창 안에서 시작해 두 창이 겹친다",
   );
   // 시각표 편입 창은 두 창 모두와 서로소다(상한이 편의시설 창 하한보다 앞에서 닫힌다).
   const gwangjuScheduleUpper = admissionEvidenceOf(
@@ -1794,14 +1784,25 @@ test("candidate 안전 경계는 spec 편집만으로 넓힐 수 없다", async 
     );
   });
 
-  // 편입마다 신선도 창이 다르므로 기준 시각 pin도 편입 단위다. 다만 노선도 편입의 창은 하한뿐이라
-  // 다른 두 편입(시각표·편의시설의 [capturedAt, freshUntil))과 신선도 보장이 비대칭이다 — 포착 이전
-  // pin만 fail closed 되고 먼 미래 pin은 통과한다. 상한 도입은 materializer 쪽 판단이라 여기서
-  // 동작으로 고정하지 않고 비대칭을 기록만 한다.
-  await context.test("노선도 편입 기준 시각을 snapshot 포착 이전으로 옮기면 거부된다(하한만 검사·상한 없음)", async () => {
+  // 노선도 편입도 P1Y 반개구간의 양끝을 fail closed 한다.
+  await context.test("노선도 편입 기준 시각을 snapshot 포착 이전으로 옮기면 거부된다", async () => {
     await rejectsWith(
       (value) => { value.packDataInclusions[1].materializedAt = "2026-07-20T16:00:00.000Z"; },
-      /daegu-transportation-route-map-positions inventory evidence does not match snapshot/,
+      /daegu-transportation-route-map-positions route-map admission snapshot is stale or future-dated/,
+    );
+  });
+
+  await context.test("노선도 편입 기준 시각을 P1Y 상한으로 옮기면 거부된다", async () => {
+    const inventory = await readJson(INVENTORY_PATH);
+    const freshUntil = admissionEvidenceOf(
+      inventory,
+      "daegu-transportation-route-map-positions",
+      "routeMapAdmissionEvidence",
+    ).freshUntil;
+    await rejectsWith(
+      (value) => { value.packDataInclusions[0].materializedAt = freshUntil; },
+      /daegu-transportation-route-map-positions route-map admission snapshot is stale or future-dated/,
+      { solo: 1 },
     );
   });
 
@@ -1911,7 +1912,7 @@ test("candidate 안전 경계는 spec 편집만으로 넓힐 수 없다", async 
   });
 
   // pin 창 회귀도 편입 단위다. 편입 하나의 창만 덮으면 나머지 세 창이 풀려도 침묵하는데, 창 모양이
-  // 편입마다 갈리므로(양끝 검사 3편입 / 하한만 1편입) 한 편입의 통과가 다른 편입의 근거가 되지도
+  // 편입마다 갈리므로 한 편입의 통과가 다른 편입의 근거가 되지도
   // 않는다. 창 값은 admission 정본에서 끌어와 하한 직전(capturedAt - 1ms)과 상한 정각(freshUntil,
   // 반개구간이라 이미 창 밖)을 각각 때린다.
   for (const { labelKo, offset, sourceId, evidenceKey, stalePinPattern } of BUSAN_INCLUSION_BINDINGS) {

--- a/tools/datapack/nationwide-candidate-pack-spec.json
+++ b/tools/datapack/nationwide-candidate-pack-spec.json
@@ -138,7 +138,7 @@
         "sourceInventory": 1
       },
       "reasonKo": "#2580 B2-a. 대구 3노선 route_map_positions requirement를 판정에 올리려면 candidate root pack이 공식 노선도 좌표 행을 담아야 한다. materializer가 pack.sourceInventory에 대구 시각표 소스가 이미 있을 것을 선행 조건으로 검사하므로 시각표 편입 뒤에 체인한다. 신규 admission·재수집은 없고 이미 admission이 끝난 snapshot(#2473)을 재생한다.",
-      "materializedAtReasonKo": "이 snapshot의 capturedAt은 2026-07-24T03:00:00Z이고 materializer는 기준 시각이 capturedAt 이전이면 fail closed 한다. 소스마다 포착 시각대가 다르므로 pin도 편입마다 따로 둔다."
+      "materializedAtReasonKo": "이 snapshot의 P1Y 신선도 창은 [2026-07-24T03:00:00Z, 2027-07-24T03:00:00Z)이고 materializer가 양끝 밖의 기준 시각을 fail closed 한다. 소스마다 포착·상한 시각이 다르므로 pin은 이 창의 하한에 편입별로 둔다."
     },
     {
       "regionId": "daegu",
@@ -189,7 +189,7 @@
         "sourceInventory": 1
       },
       "reasonKo": "#2580 B2-a. 대구 3노선 accessibility_facilities requirement를 판정에 올리려면 candidate root pack이 공식 편의시설 행을 담아야 한다. 이 materializer도 대구 시각표 소스를 선행 조건으로 검사하므로 같은 체인 뒤에 붙인다. 이미 admission이 끝난 snapshot(#2467)을 재생한다.",
-      "materializedAtReasonKo": "이 snapshot의 신선도 창은 capturedAt 2026-07-24T01:00:00Z ~ freshUntil 2026-07-25T01:00:00Z이며 materializer가 그 밖의 기준 시각을 fail closed 한다. 창은 소스마다 다르고 상한 유무도 갈린다 — 시각표는 [capturedAt, freshUntil) 양끝을 검사하지만 노선도 materializer는 하한(capturedAt 이후)만 검사해 상한이 없다. 시각표 창은 이 창과 서로소이고 노선도 창은 이 창과 겹치므로, 편입 하나의 창만 보고 pin을 묶으면 그 소스의 snapshot이 갱신될 때 다른 편입의 기준 시각까지 함께 흔들린다. pin을 편입마다 따로 두면 각 pin이 자기 소스의 창에만 묶인다."
+      "materializedAtReasonKo": "이 snapshot의 신선도 창은 [2026-07-24T01:00:00Z, 2026-07-25T01:00:00Z)이고 materializer가 양끝 밖을 fail closed 한다. 시각표 창은 이 창과 서로소이며, 노선도 P1Y 창 [2026-07-24T03:00:00Z, 2027-07-24T03:00:00Z)은 이 창과 [2026-07-24T03:00:00Z, 2026-07-25T01:00:00Z)를 공유한다. 창이 겹쳐도 한 소스의 snapshot 갱신이 다른 편입의 기준 시각을 흔들지 않도록 pin은 편입마다 따로 둔다."
     },
     {
       "regionId": "busan",
@@ -315,7 +315,7 @@
       },
       "addedRowsKo": "이 편입은 승계 원본에 없던 표(routeMapLineTracks)를 새로 만든다. 집계 목록을 pack 자신에서 끌어오므로 새 표도 자동으로 대조 축에 들어오며, 선언하지 않으면 조립이 fail closed 된다. 이후 편입은 그 표를 0으로 선언해야 한다.",
       "reasonKo": "#2587 B2-b. 부산 4노선 route_map_positions requirement를 판정에 올리려면 candidate root pack이 공식 노선도 좌표 행을 담아야 한다. materializer가 부산 topology 소스 등재와 station_lines·network_edges 계보를 선행 조건으로 검사하므로 topology 편입 뒤에 체인한다. 이미 admission이 끝난 snapshot(#2379)을 재생한다.",
-      "materializedAtReasonKo": "이 snapshot의 admission 정본에는 freshUntil이 없고 materializer도 하한(capturedAt 2026-07-20T11:13:18Z 이후)만 검사해 상한이 없다 — 대구 노선도 편입과 같은 비대칭이며 상한 도입은 materializer 쪽 판단이라 이 spec의 축이 아니다. pin은 그 하한에 맞춘다."
+      "materializedAtReasonKo": "이 snapshot의 P1Y 신선도 창은 [2026-07-20T11:13:18Z, 2027-07-20T11:13:18Z)이고 materializer가 양끝 밖의 기준 시각을 fail closed 한다. pin은 이 창의 하한에 맞춘다."
     },
     {
       "regionId": "busan",
@@ -357,7 +357,7 @@
         "sourceInventory": 1
       },
       "reasonKo": "#2587 B2-b. 부산 4노선 accessibility_facilities requirement를 판정에 올리려면 candidate root pack이 공식 편의시설 행을 담아야 한다. 114 역·노선 쌍 × 3종(엘리베이터·에스컬레이터·휠체어리프트) = 342행이며 미설치도 NOT_EXISTS 근거로 함께 싣는다 — 정본 station id 기준 고유 역은 108이라 두 노선에 걸친 환승역 6곳은 6행씩 낸다. 이 materializer도 부산 topology 계보를 선행 조건으로 검사하므로 같은 체인 뒤에 붙인다. 이미 admission이 끝난 snapshot(#2374)을 재생한다.",
-      "materializedAtReasonKo": "이 snapshot의 신선도 창은 capturedAt 2026-07-24T00:19:05.836Z ~ freshUntil 2026-07-25T00:19:05.836Z이며 materializer가 [capturedAt, freshUntil) 양끝을 검사한다. 창은 소스마다 다르고 상한 유무도 갈린다 — topology·시각표는 [capturedAt, freshUntil) 양끝을 검사하지만 노선도 materializer는 하한(capturedAt 이후)만 검사해 상한이 없다. topology·시각표 창은 이 창과 서로소이고 노선도 창은 상한이 없어 이 창을 통째로 품으므로, 편입 하나의 창만 보고 pin을 묶으면 그 소스의 snapshot이 갱신될 때 다른 편입의 기준 시각까지 함께 흔들린다. pin을 편입마다 따로 두면 각 pin이 자기 소스의 창에만 묶인다."
+      "materializedAtReasonKo": "이 snapshot의 신선도 창은 [2026-07-24T00:19:05.836Z, 2026-07-25T00:19:05.836Z)이고 materializer가 양끝 밖을 fail closed 한다. topology·시각표 창은 이 창과 서로소이며, 노선도 P1Y 창 [2026-07-20T11:13:18Z, 2027-07-20T11:13:18Z)은 이 창을 포함한다. 창의 관계가 달라도 한 소스의 snapshot 갱신이 다른 편입의 기준 시각을 흔들지 않도록 pin은 편입마다 따로 둔다."
     },
     {
       "regionId": "daejeon",
@@ -437,7 +437,7 @@
         "sourceInventory": 1
       },
       "reasonKo": "#2595 B3. 대전 1호선 route_map_positions requirement를 판정에 올리려면 candidate root pack이 공식 노선도 좌표 행을 담아야 한다. materializer가 pack에 대전 운영기관이 있을 것·시각표 소스가 등재돼 있을 것·역노선 station_code 계보가 topology 소스에서 온 것을 선행 조건으로 검사하므로 시각표 편입 뒤에 체인한다(시각표보다 앞서면 운영기관 조건에서 먼저 걸린다). 이미 admission이 끝난 snapshot(#2496)을 재생한다.",
-      "materializedAtReasonKo": "이 snapshot의 admission 정본에는 freshUntil이 없고 materializer도 하한(capturedAt 2026-07-25T03:00:00Z 이후)만 검사해 상한이 없다 — 대구·부산 노선도 편입과 같은 비대칭이며 상한 도입은 materializer 쪽 판단이라 이 spec의 축이 아니다. pin은 그 하한에 맞춘다."
+      "materializedAtReasonKo": "이 snapshot의 P1Y 신선도 창은 [2026-07-25T03:00:00Z, 2027-07-25T03:00:00Z)이고 materializer가 양끝 밖의 기준 시각을 fail closed 한다. pin은 이 창의 하한에 맞춘다."
     },
     {
       "regionId": "daejeon",
@@ -477,7 +477,7 @@
       },
       "addedRowsKo": "22 역·노선 쌍 × 3종(엘리베이터·에스컬레이터·휠체어리프트) = 66행이며 미설치도 NOT_EXISTS 근거로 함께 싣는다. 대전 1호선은 단일 노선이라 역 수 22와 역·노선 쌍 수 22가 같다.",
       "reasonKo": "#2595 B3. 대전 1호선 accessibility_facilities requirement를 판정에 올리려면 candidate root pack이 공식 편의시설 행을 담아야 한다. 이 materializer도 대전 운영기관·시각표 소스 등재와 topology 계보를 선행 조건으로 검사하므로 같은 체인 뒤에 붙인다. 노선도 편입과는 서로 선행 조건이 없어 둘의 순서를 바꿔도 조립은 통과한다(실측) — 기록된 순서를 고정하는 것은 evidence 순서 대조다. 이미 admission이 끝난 snapshot(#2467)을 재생한다.",
-      "materializedAtReasonKo": "이 snapshot의 신선도 창은 capturedAt 2026-07-24T02:00:00Z ~ freshUntil 2026-07-25T02:00:00Z이며 materializer가 [capturedAt, freshUntil) 양끝을 검사한다. 대전 세 편입의 창은 서로소다(실측) — 시각표 편입 창은 [2026-07-20T03:30:00Z, 2026-07-20T22:12:49.895Z), 이 창은 [2026-07-24T02:00:00Z, 2026-07-25T02:00:00Z), 노선도 창은 상한이 없어 [2026-07-25T03:00:00Z, ∞)인데 노선도 하한이 이 창의 상한보다 한 시간 늦어 겹치지 않는다. 상한 없는 창이 늘 다른 창을 품는 것은 아니라는 뜻이며(광주는 같은 자리에서 겹친다) 그래서 pin은 편입마다 따로 둔다."
+      "materializedAtReasonKo": "이 snapshot의 신선도 창은 [2026-07-24T02:00:00Z, 2026-07-25T02:00:00Z)이고 materializer가 양끝 밖을 fail closed 한다. 시각표 편입 창 [2026-07-20T03:30:00Z, 2026-07-20T22:12:49.895Z), 이 창, 노선도 P1Y 창 [2026-07-25T03:00:00Z, 2027-07-25T03:00:00Z)은 서로소다. 노선도 하한이 이 창의 상한보다 한 시간 늦으므로 겹치지 않으며, pin은 각 소스의 창에 편입별로 둔다."
     },
     {
       "regionId": "gwangju",
@@ -557,7 +557,7 @@
         "sourceInventory": 1
       },
       "reasonKo": "#2595 B3. 광주 1호선 route_map_positions requirement를 판정에 올리려면 candidate root pack이 공식 노선도 좌표 행을 담아야 한다. materializer가 pack에 광주 운영기관이 있을 것·시각표 소스가 등재돼 있을 것·역노선 station_code 계보가 topology 소스에서 온 것을 선행 조건으로 검사하므로 시각표 편입 뒤에 체인한다(시각표보다 앞서면 운영기관 조건에서 먼저 걸린다). 이미 admission이 끝난 snapshot(#2496)을 재생한다.",
-      "materializedAtReasonKo": "이 snapshot의 admission 정본에는 freshUntil이 없고 materializer도 하한(capturedAt 2026-07-25T02:00:00Z 이후)만 검사해 상한이 없다. pin은 그 하한에 맞춘다."
+      "materializedAtReasonKo": "이 snapshot의 P1Y 신선도 창은 [2026-07-25T02:00:00Z, 2027-07-25T02:00:00Z)이고 materializer가 양끝 밖의 기준 시각을 fail closed 한다. pin은 이 창의 하한에 맞춘다."
     },
     {
       "regionId": "gwangju",
@@ -597,7 +597,7 @@
       },
       "addedRowsKo": "20 역·노선 쌍 × 3종(엘리베이터·에스컬레이터·휠체어리프트) = 60행이며 미설치도 NOT_EXISTS 근거로 함께 싣는다. 광주 1호선은 단일 노선이라 역 수 20과 역·노선 쌍 수 20이 같다.",
       "reasonKo": "#2595 B3. 광주 1호선 accessibility_facilities requirement를 판정에 올리려면 candidate root pack이 공식 편의시설 행을 담아야 한다. 이 materializer도 광주 운영기관·시각표 소스 등재와 topology 계보를 선행 조건으로 검사하므로 같은 체인 뒤에 붙인다. 노선도 편입과는 서로 선행 조건이 없어 둘의 순서를 바꿔도 조립은 통과한다(실측). 이미 admission이 끝난 snapshot(#2467)을 재생한다.",
-      "materializedAtReasonKo": "이 snapshot의 신선도 창은 capturedAt 2026-07-24T03:00:00Z ~ freshUntil 2026-07-25T03:00:00Z이며 materializer가 [capturedAt, freshUntil) 양끝을 검사한다. 광주 세 창의 관계는 대전과 다르다(실측). 시각표 편입 창 [2026-07-20T13:08:47.161Z, 2026-07-21T12:55:50.079Z)은 이 창과 서로소이지만, 노선도 창은 상한이 없어 [2026-07-25T02:00:00Z, ∞)이고 그 하한이 이 창의 상한(2026-07-25T03:00:00Z)보다 한 시간 이르러 두 창이 [2026-07-25T02:00:00Z, 2026-07-25T03:00:00Z)를 공유한다 — 대전은 같은 자리에서 서로소다. 겹치는 창끼리라도 pin을 묶으면 한 소스의 snapshot 갱신이 다른 편입의 기준 시각까지 흔들므로 편입마다 따로 둔다."
+      "materializedAtReasonKo": "이 snapshot의 신선도 창은 [2026-07-24T03:00:00Z, 2026-07-25T03:00:00Z)이고 materializer가 양끝 밖을 fail closed 한다. 시각표 편입 창 [2026-07-20T13:08:47.161Z, 2026-07-21T12:55:50.079Z)은 이 창과 서로소이지만, 노선도 P1Y 창 [2026-07-25T02:00:00Z, 2027-07-25T02:00:00Z)은 이 창과 [2026-07-25T02:00:00Z, 2026-07-25T03:00:00Z)를 공유한다. 겹치는 창끼리도 한 소스의 snapshot 갱신이 다른 편입의 기준 시각을 흔들지 않도록 pin은 편입마다 따로 둔다."
     },
     {
       "regionId": "capital",
@@ -646,7 +646,7 @@
       "reorderedTables": ["lines", "operators"],
       "reorderedTablesKo": "이 materializer는 append 뒤 pack.operators와 pack.lines를 id 오름차순으로 다시 정렬한다(실측). 승계 행 자체는 바이트 동일하게 남지만 위치가 바뀌므로 접두사 대조가 걸린다 — 재정렬을 표 단위로 명시 선언한 편입에서만 그 표를 다중집합 대조로 본다. coverageLineOperatorScopes는 이 편입이 처음 만드는 표라 승계 행이 없어 선언 대상이 아니다.",
       "reasonKo": "#2595 B3. 수도권 광역철도 8노선(경의중앙·경춘·수인분당·경강·공항철도·의정부경전철·서해선·GTX-A) route_map_positions requirement를 판정에 올리려면 candidate root pack이 공식 노선도 좌표 행을 담아야 한다. materializer가 노선 하나만 처리하므로 편입 하나가 노선별 snapshot을 카탈로그 순서대로 체인한다. 이 편입은 승계 pack에 의존하지 않는다 — 경로 그래프 계보를 inventory 소스가 아니라 tracked snapshot 파일(capital-route-topology-20260724.json)로 대조하고 역·역노선을 스스로 만든다. 서해선·GTX-A는 이 배치의 첫 묶음에서 빠져 있었다: 두 소스의 admission coverageScope.operatorIds가 2개인데 materializer의 정본 대조가 단일 운영기관만 허용했기 때문이다. 카탈로그가 그 두 번째 운영기관을 additionalCoverageOperators로 등재하고 materializer가 [노선 운영기관, ...등재분]을 정본과 전량 대조하도록 바꾸면서 두 노선이 열렸다. 이미 admission이 끝난 snapshot(#2503)을 재생한다.",
-      "materializedAtReasonKo": "이 편입이 싣는 8개 소스의 admission 정본에는 모두 freshUntil이 없고 materializer도 하한(capturedAt 이후)만 검사한다. 8개 소스의 capturedAt이 2026-07-25T06:00:00Z로 모두 같아(실측) 편입 하나의 pin이 여덟 하한을 동시에 만족한다 — pin은 그 공통 하한 정각이다."
+      "materializedAtReasonKo": "이 편입이 싣는 8개 소스는 모두 P1Y 신선도 창 [2026-07-25T06:00:00Z, 2027-07-25T06:00:00Z)을 공유하고 materializer가 양끝 밖을 fail closed 한다. 편입 하나의 pin은 여덟 창의 공통 하한 정각에 둔다."
     },
     {
       "regionId": "capital",
@@ -692,7 +692,7 @@
       "reorderedTables": ["coverageLineOperatorScopes", "lines", "operators"],
       "reorderedTablesKo": "이 materializer도 append 뒤 pack.operators·pack.lines를 id 오름차순으로 다시 정렬하며, 광역철도 편입이 이미 만들어 둔 coverageLineOperatorScopes까지 같은 축으로 다시 정렬한다(실측). 그래서 선언 표가 광역철도 편입보다 하나 많다 — 그 표가 이 편입에는 승계 행이 있는 표이기 때문이다.",
       "reasonKo": "#2595 B3. 수도권 경전철 5노선(신분당·에버라인·우이신설·신림·김포골드라인) route_map_positions requirement를 판정에 올리려면 candidate root pack이 공식 노선도 좌표 행을 담아야 한다. 광역철도 편입과 형상이 같고(노선별 snapshot 체인) 서로 선행 조건이 없다. 신분당선은 이 배치의 첫 묶음에서 빠져 있었다: admission coverageScope.operatorIds가 2개라 서해선·GTX-A와 같은 이유로 거부됐고, 같은 카탈로그 등재 축으로 열렸다. 신분당선 정본은 두 운영기관을 등재하지만 pack scope와 requirement는 하나씩이다 — 정본의 서울교통공사 표기는 FILE admission 계보 항목이라 #2138 activeLineScopes에 대응 scope가 없고, 카탈로그가 그 표기를 lineageOnlyOperatorIds로 갈라 정본 대조·운영기관 등재에만 쓰고 scope 행으로는 내지 않는다. 이미 admission이 끝난 snapshot(#2505)을 재생한다.",
-      "materializedAtReasonKo": "이 편입이 싣는 5개 소스도 admission 정본에 freshUntil이 없고 materializer가 하한만 검사하며, 다섯 소스의 capturedAt이 2026-07-25T06:00:00Z로 모두 같다(실측). 광역철도 편입과 pin 값이 같지만 묶지 않는다 — 값이 같은 것은 두 카탈로그의 snapshot을 같은 날 뜬 결과일 뿐이고, 한쪽 snapshot이 갱신되면 다른 편입의 기준 시각까지 함께 흔들려서는 안 된다."
+      "materializedAtReasonKo": "이 편입이 싣는 5개 소스는 모두 P1Y 신선도 창 [2026-07-25T06:00:00Z, 2027-07-25T06:00:00Z)을 공유하고 materializer가 양끝 밖을 fail closed 한다. 광역철도 편입과 현재 pin 값이 같아도 한쪽 snapshot 갱신이 다른 편입의 기준 시각을 흔들지 않도록 pin은 따로 둔다."
     },
     {
       "regionId": "capital",
@@ -741,7 +741,7 @@
       "reorderedTables": ["lines"],
       "reorderedTablesKo": "이 materializer는 노선 append 뒤 pack.lines를 id 오름차순으로 다시 정렬한다(실측). 운영기관은 이미 있어 건드리지 않고 coverageLineOperatorScopes에도 손대지 않으므로 선언 표는 lines 하나뿐이다.",
       "reasonKo": "#2595 B3. 수도권 1~8호선 route_map_positions requirement를 판정에 올리려면 candidate root pack이 공식 좌표 행을 담아야 한다. materializer는 승계 원본의 서울교통공사 운영기관과 capital pilot cyberstation 소스가 pack에 남아 있을 것을 선행 조건으로 검사하지만, 그 둘은 승계 원본이 이미 갖고 있어 다른 편입에 대한 순서 의존은 없다. 4호선은 B0 파일럿에서 cyberstation 소스로 이미 SUPPORTED이므로 이 편입이 여는 것은 나머지 7 requirement이고, 4호선 requirement는 이후 두 소스가 함께 뒷받침한다. 이미 admission이 끝난 snapshot(#2470)을 재생한다.",
-      "materializedAtReasonKo": "이 snapshot의 admission 정본에도 freshUntil이 없고 materializer는 하한(capturedAt 2026-07-24T02:00:00Z 이후)만 검사한다. 같은 수도권 편입이지만 KRIC 두 편입의 창과 하한이 다르다 — 셋 다 상한이 없어 이 창 [2026-07-24T02:00:00Z, ∞)이 KRIC 창 [2026-07-25T06:00:00Z, ∞)을 통째로 품는다(포함 관계이지 서로소가 아니다). 포함 관계여도 pin은 묶지 않는다."
+      "materializedAtReasonKo": "이 snapshot의 P1Y 신선도 창은 [2026-07-24T02:00:00Z, 2027-07-24T02:00:00Z)이고 materializer가 양끝 밖을 fail closed 한다. KRIC 두 편입의 창 [2026-07-25T06:00:00Z, 2027-07-25T06:00:00Z)과는 겹치지만 시작·종료 시각이 모두 달라 어느 한쪽도 다른 창을 포함하지 않는다. pin은 각 편입의 창 하한에 따로 둔다."
     },
     {
       "regionId": "capital",
@@ -784,7 +784,7 @@
       "reorderedTables": ["coverageLineOperatorScopes", "lines", "operators"],
       "reorderedTablesKo": "이 materializer도 append 뒤 pack.operators·pack.lines를 id 오름차순으로, coverageLineOperatorScopes를 (권역:운영기관:노선) 오름차순으로 다시 정렬한다(실측). 세 표 모두 이 시점에는 승계 행이 있어 선언 대상이다.",
       "reasonKo": "#2595 B3. 수도권 9호선 route_map_positions requirement를 판정에 올리려면 candidate root pack이 공식 좌표 행을 담아야 한다. 9호선은 한 노선을 두 소스가 나눠 덮어(1단계 25역 / 2·3단계 13역) 편입도 소스마다 하나씩이고, 이 편입이 그중 1단계다. 승계 pack 의존이 없다 — 경로 그래프 계보를 tracked snapshot 파일로 대조하고 운영기관·노선·역·역노선을 스스로 만든다. 이미 admission이 끝난 snapshot(#2500)을 재생한다.",
-      "materializedAtReasonKo": "이 소스의 admission 정본에도 freshUntil이 없고 materializer는 하한(capturedAt 2026-07-25T05:00:00Z 이후)만 검사한다 — pin은 그 하한 정각이다. 2·3단계 소스의 하한(2026-07-25T04:00:00Z)과 값이 달라 두 편입의 pin을 묶을 수 없다."
+      "materializedAtReasonKo": "이 소스의 P1Y 신선도 창은 [2026-07-25T05:00:00Z, 2027-07-25T05:00:00Z)이고 materializer가 양끝 밖을 fail closed 한다. 2·3단계 소스의 창 [2026-07-25T04:00:00Z, 2027-07-25T04:00:00Z)과 겹치지만 양끝이 한 시간씩 달라 어느 한쪽도 다른 창을 포함하지 않으므로 pin은 각 창의 하한에 따로 둔다."
     },
     {
       "regionId": "capital",
@@ -825,7 +825,7 @@
       },
       "addedRowsKo": "2·3단계 좌표 13행 중 앞선 편입이 이미 실은 역 3곳(선정릉·종합운동장·석촌)이 있어 역은 10행만 늘고 소속은 13행 전부 는다. 1단계 소스와 겹치는 역은 없다(두 소스가 9호선을 구간으로 나눠 덮는다). 운영기관·노선은 0행 — 1단계 편입이 이미 만들었다. coverageLineOperatorScopes도 0행이다: 이 소스는 dual coverage(FILE 계보 표기 서울교통공사 + 노선 운영기관 서울시메트로9호선)로 등재돼 있지만 계보 표기에는 #2138 activeLineScopes에 대응 scope가 없어 scope 행으로 내지 않고, 노선 운영기관 scope는 1단계 편입이 이미 실었다. 그래서 이 편입은 어느 표에도 재정렬을 일으키지 않는다(reorderedTables 선언 없음).",
       "reasonKo": "#2595 B3. 9호선 2·3단계 소스를 같은 노선 위에 이어 싣는다. 1단계 편입과 서로 선행 조건은 없지만 두 편입이 같은 노선의 역을 나눠 실어 중복 제거 결과가 순서에 따라 갈리므로 선언 행수 대조가 순서를 고정한다. 이미 admission이 끝난 snapshot(#2498)을 재생한다.",
-      "materializedAtReasonKo": "이 소스의 admission 정본에도 freshUntil이 없고 materializer는 하한(capturedAt 2026-07-25T04:00:00Z 이후)만 검사한다 — pin은 그 하한 정각이다."
+      "materializedAtReasonKo": "이 소스의 P1Y 신선도 창은 [2026-07-25T04:00:00Z, 2027-07-25T04:00:00Z)이고 materializer가 양끝 밖을 fail closed 한다. pin은 이 창의 하한 정각에 둔다."
     },
     {
       "regionId": "incheon",

--- a/tools/datapack/refresh-route-map-admission-freshness.mjs
+++ b/tools/datapack/refresh-route-map-admission-freshness.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { addCadence } from "./freshness-policy.mjs";
+import { requiredUtcInstant } from "./lib/utc-instant.mjs";
+import { ROUTE_MAP_REVERIFICATION_CADENCE } from "./lib/route-map-admission-freshness.mjs";
+
+const root = path.resolve(import.meta.dirname, "../..");
+const inventoryPaths = [
+  "tools/datapack/source-inventory.json",
+  "apps/mobile/assets/datapacks/source-inventory.json",
+];
+
+export function withRouteMapAdmissionFreshness(inventory) {
+  const next = structuredClone(inventory);
+  for (const source of next.sources ?? []) {
+    const evidence = source.routeMapAdmissionEvidence;
+    if (!evidence) continue;
+    const capturedAt = requiredUtcInstant(evidence.capturedAt, `${source.id} route-map capturedAt`);
+    evidence.freshUntil = new Date(addCadence(capturedAt, ROUTE_MAP_REVERIFICATION_CADENCE)).toISOString();
+  }
+  return next;
+}
+
+async function main() {
+  const inventories = await Promise.all(inventoryPaths.map(async (relativePath) => ({
+    relativePath,
+    inventory: JSON.parse(await readFile(path.join(root, relativePath), "utf8")),
+  })));
+  const canonical = withRouteMapAdmissionFreshness(inventories[0].inventory);
+  const bytes = `${JSON.stringify(canonical, null, 2)}\n`;
+  await Promise.all(inventories.map(({ relativePath }) => writeFile(path.join(root, relativePath), bytes)));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/tools/datapack/refresh-route-map-admission-freshness.mjs
+++ b/tools/datapack/refresh-route-map-admission-freshness.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-import { readFile, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { mkdir, open, readFile, rename, rm, stat } from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
@@ -30,6 +31,26 @@ export function assertInventoryMirrorByteParity(inventories) {
   }
 }
 
+export async function replaceFileAtomically(targetPath, bytes) {
+  const directory = path.dirname(targetPath);
+  await mkdir(directory, { recursive: true });
+  const mode = (await stat(targetPath)).mode & 0o777;
+  const temporaryPath = path.join(directory, `.${path.basename(targetPath)}.${process.pid}.${randomUUID()}.tmp`);
+  let temporaryFile;
+  try {
+    temporaryFile = await open(temporaryPath, "wx", mode);
+    await temporaryFile.writeFile(bytes);
+    await temporaryFile.sync();
+    await temporaryFile.close();
+    temporaryFile = undefined;
+    await rename(temporaryPath, targetPath);
+  } catch (error) {
+    await temporaryFile?.close().catch(() => {});
+    await rm(temporaryPath, { force: true }).catch(() => {});
+    throw error;
+  }
+}
+
 async function main() {
   const inventories = await Promise.all(inventoryPaths.map(async (relativePath) => ({
     relativePath,
@@ -38,7 +59,7 @@ async function main() {
   assertInventoryMirrorByteParity(inventories);
   const canonical = withRouteMapAdmissionFreshness(JSON.parse(inventories[0].bytes.toString("utf8")));
   const bytes = `${JSON.stringify(canonical, null, 2)}\n`;
-  await Promise.all(inventories.map(({ relativePath }) => writeFile(path.join(root, relativePath), bytes)));
+  await Promise.all(inventories.map(({ relativePath }) => replaceFileAtomically(path.join(root, relativePath), bytes)));
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {

--- a/tools/datapack/refresh-route-map-admission-freshness.mjs
+++ b/tools/datapack/refresh-route-map-admission-freshness.mjs
@@ -32,22 +32,71 @@ export function assertInventoryMirrorByteParity(inventories) {
 }
 
 export async function replaceFileAtomically(targetPath, bytes) {
+  const replacement = await stageFileReplacement(targetPath, bytes);
+  try {
+    await replacement.commit();
+  } finally {
+    await replacement.cleanup();
+  }
+}
+
+async function stageFileReplacement(targetPath, bytes) {
   const directory = path.dirname(targetPath);
   await mkdir(directory, { recursive: true });
   const mode = (await stat(targetPath)).mode & 0o777;
   const temporaryPath = path.join(directory, `.${path.basename(targetPath)}.${process.pid}.${randomUUID()}.tmp`);
-  let temporaryFile;
+  const temporaryFile = await open(temporaryPath, "wx", mode);
   try {
-    temporaryFile = await open(temporaryPath, "wx", mode);
     await temporaryFile.writeFile(bytes);
     await temporaryFile.sync();
     await temporaryFile.close();
-    temporaryFile = undefined;
-    await rename(temporaryPath, targetPath);
   } catch (error) {
-    await temporaryFile?.close().catch(() => {});
+    await temporaryFile.close().catch(() => {});
     await rm(temporaryPath, { force: true }).catch(() => {});
     throw error;
+  }
+  return {
+    targetPath,
+    commit: () => rename(temporaryPath, targetPath),
+    cleanup: () => rm(temporaryPath, { force: true }),
+  };
+}
+
+export async function replaceInventoryMirrors(
+  targets,
+  bytes,
+  { stageReplacement = stageFileReplacement, restore = replaceFileAtomically } = {},
+) {
+  const stageResults = await Promise.allSettled(
+    targets.map(({ targetPath }) => stageReplacement(targetPath, bytes)),
+  );
+  const staged = stageResults.filter(({ status }) => status === "fulfilled").map(({ value }) => value);
+  const stageFailure = stageResults.find(({ status }) => status === "rejected");
+  if (stageFailure) {
+    await Promise.allSettled(staged.map(({ cleanup }) => cleanup()));
+    throw stageFailure.reason;
+  }
+
+  const committed = [];
+  try {
+    for (const replacement of staged) {
+      await replacement.commit();
+      committed.push(replacement.targetPath);
+    }
+  } catch (error) {
+    const originals = new Map(targets.map(({ targetPath, originalBytes }) => [targetPath, originalBytes]));
+    const rollbackResults = await Promise.allSettled(
+      committed.reverse().map((targetPath) => restore(targetPath, originals.get(targetPath))),
+    );
+    const rollbackFailures = rollbackResults
+      .filter(({ status }) => status === "rejected")
+      .map(({ reason }) => reason);
+    if (rollbackFailures.length > 0) {
+      throw new AggregateError([error, ...rollbackFailures], "source inventory mirror rollback failed");
+    }
+    throw error;
+  } finally {
+    await Promise.allSettled(staged.map(({ cleanup }) => cleanup()));
   }
 }
 
@@ -59,7 +108,10 @@ async function main() {
   assertInventoryMirrorByteParity(inventories);
   const canonical = withRouteMapAdmissionFreshness(JSON.parse(inventories[0].bytes.toString("utf8")));
   const bytes = `${JSON.stringify(canonical, null, 2)}\n`;
-  await Promise.all(inventories.map(({ relativePath }) => replaceFileAtomically(path.join(root, relativePath), bytes)));
+  await replaceInventoryMirrors(inventories.map(({ relativePath, bytes: originalBytes }) => ({
+    targetPath: path.join(root, relativePath),
+    originalBytes,
+  })), bytes);
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {

--- a/tools/datapack/refresh-route-map-admission-freshness.mjs
+++ b/tools/datapack/refresh-route-map-admission-freshness.mjs
@@ -24,12 +24,19 @@ export function withRouteMapAdmissionFreshness(inventory) {
   return next;
 }
 
+export function assertInventoryMirrorByteParity(inventories) {
+  if (inventories.some(({ bytes }) => !bytes.equals(inventories[0].bytes))) {
+    throw new Error("source inventory mirrors must be byte-identical before refresh");
+  }
+}
+
 async function main() {
   const inventories = await Promise.all(inventoryPaths.map(async (relativePath) => ({
     relativePath,
-    inventory: JSON.parse(await readFile(path.join(root, relativePath), "utf8")),
+    bytes: await readFile(path.join(root, relativePath)),
   })));
-  const canonical = withRouteMapAdmissionFreshness(inventories[0].inventory);
+  assertInventoryMirrorByteParity(inventories);
+  const canonical = withRouteMapAdmissionFreshness(JSON.parse(inventories[0].bytes.toString("utf8")));
   const bytes = `${JSON.stringify(canonical, null, 2)}\n`;
   await Promise.all(inventories.map(({ relativePath }) => writeFile(path.join(root, relativePath), bytes)));
 }

--- a/tools/datapack/refresh-route-map-admission-freshness.test.mjs
+++ b/tools/datapack/refresh-route-map-admission-freshness.test.mjs
@@ -7,6 +7,7 @@ import test from "node:test";
 import {
   assertInventoryMirrorByteParity,
   replaceFileAtomically,
+  replaceInventoryMirrors,
   withRouteMapAdmissionFreshness,
 } from "./refresh-route-map-admission-freshness.mjs";
 
@@ -39,6 +40,41 @@ test("inventory 교체는 임시 파일을 남기지 않고 기존 파일 권한
     assert.equal(await readFile(targetPath, "utf8"), "after\n");
     assert.equal((await stat(targetPath)).mode & 0o777, 0o640);
     assert.deepEqual(await readdir(directory), ["inventory.json"]);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("두 번째 mirror commit 실패 시 첫 번째 mirror를 원본으로 롤백한다", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "route-map-mirror-rollback-"));
+  const targets = ["canonical.json", "mobile.json"].map((name) => ({
+    targetPath: path.join(directory, name),
+    originalBytes: Buffer.from(`${name}:before\n`),
+  }));
+  let stagedCount = 0;
+  try {
+    await Promise.all(targets.map(({ targetPath, originalBytes }) => writeFile(targetPath, originalBytes)));
+    await assert.rejects(
+      () => replaceInventoryMirrors(targets, "after\n", {
+        stageReplacement: async (targetPath, bytes) => {
+          stagedCount += 1;
+          return {
+            targetPath,
+            commit: async () => {
+              assert.equal(stagedCount, targets.length, "모든 mirror가 commit 전에 staging돼야 한다");
+              if (targetPath === targets[1].targetPath) throw new Error("injected second commit failure");
+              await writeFile(targetPath, bytes);
+            },
+            cleanup: async () => {},
+          };
+        },
+      }),
+      /injected second commit failure/,
+    );
+    assert.deepEqual(
+      await Promise.all(targets.map(({ targetPath }) => readFile(targetPath))),
+      targets.map(({ originalBytes }) => originalBytes),
+    );
   } finally {
     await rm(directory, { recursive: true, force: true });
   }

--- a/tools/datapack/refresh-route-map-admission-freshness.test.mjs
+++ b/tools/datapack/refresh-route-map-admission-freshness.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  assertInventoryMirrorByteParity,
+  withRouteMapAdmissionFreshness,
+} from "./refresh-route-map-admission-freshness.mjs";
+
+const paths = ["canonical.json", "mobile.json"];
+const inventory = JSON.stringify({
+  sources: [{
+    id: "route-map-source",
+    routeMapAdmissionEvidence: { capturedAt: "2024-02-29T12:00:00.000Z" },
+  }],
+});
+
+test("route-map freshness refresh는 mirror 불일치를 parse/write 전에 거부하고 정규화는 멱등이다", () => {
+  assert.throws(() => assertInventoryMirrorByteParity([
+    { bytes: Buffer.from(inventory) },
+    { bytes: Buffer.from(`${inventory}\n`) },
+  ]), /source inventory mirrors must be byte-identical before refresh/);
+  assert.doesNotThrow(() => assertInventoryMirrorByteParity(paths.map(() => ({ bytes: Buffer.from(inventory) }))));
+
+  const normalized = withRouteMapAdmissionFreshness(JSON.parse(inventory));
+  assert.deepEqual(withRouteMapAdmissionFreshness(normalized), normalized);
+  assert.equal(normalized.sources[0].routeMapAdmissionEvidence.freshUntil, "2025-03-01T12:00:00.000Z");
+});

--- a/tools/datapack/refresh-route-map-admission-freshness.test.mjs
+++ b/tools/datapack/refresh-route-map-admission-freshness.test.mjs
@@ -1,8 +1,12 @@
 import assert from "node:assert/strict";
+import { mkdtemp, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 
 import {
   assertInventoryMirrorByteParity,
+  replaceFileAtomically,
   withRouteMapAdmissionFreshness,
 } from "./refresh-route-map-admission-freshness.mjs";
 
@@ -24,4 +28,18 @@ test("route-map freshness refresh는 mirror 불일치를 parse/write 전에 거�
   const normalized = withRouteMapAdmissionFreshness(JSON.parse(inventory));
   assert.deepEqual(withRouteMapAdmissionFreshness(normalized), normalized);
   assert.equal(normalized.sources[0].routeMapAdmissionEvidence.freshUntil, "2025-03-01T12:00:00.000Z");
+});
+
+test("inventory 교체는 임시 파일을 남기지 않고 기존 파일 권한을 보존한다", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "route-map-freshness-"));
+  const targetPath = path.join(directory, "inventory.json");
+  try {
+    await writeFile(targetPath, "before\n", { mode: 0o640 });
+    await replaceFileAtomically(targetPath, "after\n");
+    assert.equal(await readFile(targetPath, "utf8"), "after\n");
+    assert.equal((await stat(targetPath)).mode & 0o777, 0o640);
+    assert.deepEqual(await readdir(directory), ["inventory.json"]);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
 });

--- a/tools/datapack/release/candidate-build-spec.json
+++ b/tools/datapack/release/candidate-build-spec.json
@@ -194,7 +194,7 @@
   "facilityEvidenceLedgerHash": "b3ffc88b4a9ce3515340366885beaace718c70058608567513f378e198935981",
   "routeEvidenceLedgerHash": "da884d0ff0138e009587753ec541997c29da57370e056dd8d3f6ad2687ad9fa9",
   "approvedOverrideSetHash": "ee5364319442d0bb4590d83e149631635c65ab59f1f3254fdbf196e04ec0f3cd",
-  "sourceInventorySha256": "46ceb5a65ab19bb5316c2c5303717e7097d36e5c1347b3bdc59abaad4fba30a0",
+  "sourceInventorySha256": "3f47b5b54e44500f589ae037bed24477eb461a00041623250bd7cc45fca3874c",
   "builderGitSha": "4fc68131b397c0468d68728683bb6c79b7a42a39",
   "builderVersion": "build-datapack.mjs@1",
   "officialOdFareEvidence": {

--- a/tools/datapack/release/hash-evidence.json
+++ b/tools/datapack/release/hash-evidence.json
@@ -48,7 +48,7 @@
     "reproductionCommand": "node -e \"const c=require('crypto');console.log(c.createHash('sha256').update(JSON.stringify(require('./tools/datapack/release/source-snapshots.json'))).digest('hex'))\""
   },
   "sourceInventorySha256": {
-    "value": "46ceb5a65ab19bb5316c2c5303717e7097d36e5c1347b3bdc59abaad4fba30a0",
+    "value": "3f47b5b54e44500f589ae037bed24477eb461a00041623250bd7cc45fca3874c",
     "contract": "run-source-admission-pipeline.mjs의 공식 sha256(JSON.stringify(admittedInventory)) 계약. 현행 브랜치의 tools/datapack/source-inventory.json이 최종 admitted inventory이며 워크플로 빌드가 실제로 소비하는 인벤토리와 동일 파일.",
     "reproductionCommand": "node -e \"const c=require('crypto'),fs=require('fs');console.log(c.createHash('sha256').update(JSON.stringify(JSON.parse(fs.readFileSync('tools/datapack/source-inventory.json','utf8')))).digest('hex'))\""
   },

--- a/tools/datapack/reports/nationwide-candidate-coverage-gate.json
+++ b/tools/datapack/reports/nationwide-candidate-coverage-gate.json
@@ -67,7 +67,7 @@
     },
     "inventory": {
       "path": "tools/datapack/source-inventory.json",
-      "sha256": "8856a81a49f8f3814c9abd1a54fca7451dbcd1b5a3c2613e6427c3f1a3f49ff8"
+      "sha256": "d6425d21333dcbb08341a40bc57571e31a0ea7cfc087732c5596af351dd3b1b7"
     },
     "resolutionPlan": {
       "path": "tools/datapack/release/nationwide-public-api-coverage-search-plan-20260725.json",

--- a/tools/datapack/reports/nationwide-candidate-coverage-gate.json
+++ b/tools/datapack/reports/nationwide-candidate-coverage-gate.json
@@ -79,7 +79,7 @@
     },
     "spec": {
       "path": "tools/datapack/nationwide-candidate-pack-spec.json",
-      "sha256": "29658061a7723e547231b7620c4d86f2a6afd99375e213815f4e7efc6c6f6ef4"
+      "sha256": "57512260f212b10090b1d162453af509ae88753d20eb5a5ac8b1a931fc75f309"
     },
     "targets": {
       "path": "tools/datapack/nationwide-coverage-targets.json",

--- a/tools/datapack/reports/nationwide-coverage-tally.json
+++ b/tools/datapack/reports/nationwide-coverage-tally.json
@@ -1075,7 +1075,7 @@
     "inventory": {
       "path": "tools/datapack/source-inventory.json",
       "retrievedAt": "2026-06-22",
-      "sha256": "8856a81a49f8f3814c9abd1a54fca7451dbcd1b5a3c2613e6427c3f1a3f49ff8"
+      "sha256": "d6425d21333dcbb08341a40bc57571e31a0ea7cfc087732c5596af351dd3b1b7"
     },
     "resolutions": {
       "entryCount": 4,

--- a/tools/datapack/source-inventory.json
+++ b/tools/datapack/source-inventory.json
@@ -257,7 +257,8 @@
         "connectorAssetCount": 32,
         "topologySourceId": "busan-transportation-route-topology",
         "topologySnapshotId": "busan-transportation-route-topology-20260720",
-        "topologyContentSha256": "9ec95ebb6d789457060e243f079ad371465d0e5e1a309504b18b9a78e00a24cc"
+        "topologyContentSha256": "9ec95ebb6d789457060e243f079ad371465d0e5e1a309504b18b9a78e00a24cc",
+        "freshUntil": "2027-07-20T11:13:18.000Z"
       }
     },
     {
@@ -1358,7 +1359,8 @@
             "lineId": "line-0ffaa95b1b5d"
           }
         ],
-        "topologyContentSha256": "4e76459d4588f97bd55e767374b81031402c768d8f4805c69484d7c3f8771d1f"
+        "topologyContentSha256": "4e76459d4588f97bd55e767374b81031402c768d8f4805c69484d7c3f8771d1f",
+        "freshUntil": "2027-07-24T03:00:00.000Z"
       }
     },
     {
@@ -1754,7 +1756,8 @@
             "contentSha256": "111ef488fc9d1f960445844b907e7f7b6f804e4adff0867f2f8c1e43433c747f",
             "lineId": "line-7051a9c2525c"
           }
-        ]
+        ],
+        "freshUntil": "2027-07-25T03:00:00.000Z"
       }
     },
     {
@@ -2046,7 +2049,8 @@
             "contentSha256": "d8197488bc6dda94e595f7e350cc65c547117da804fb59b7dff85d18b3192e43",
             "lineId": "line-e57a361e8892"
           }
-        ]
+        ],
+        "freshUntil": "2027-07-25T02:00:00.000Z"
       }
     },
     {
@@ -2594,7 +2598,8 @@
         "observedDataUpdatedAt": "2025-06-30",
         "topologySourceId": "incheon-transit-station-info",
         "topologySnapshotId": "incheon-transit-station-info-20260724",
-        "topologyContentSha256": "710878689282ba967697cd9411940b657a51eee5499106ed884d5bd9111501a8"
+        "topologyContentSha256": "710878689282ba967697cd9411940b657a51eee5499106ed884d5bd9111501a8",
+        "freshUntil": "2027-07-24T06:00:00.000Z"
       }
     },
     {
@@ -2699,7 +2704,8 @@
             "contentSha256": "0492df28ff51dc4262508363e960ed1a5fed847d3aa5f593ea62ad0fd3d773f3",
             "lineId": "line-e9e9a5b520a4"
           }
-        ]
+        ],
+        "freshUntil": "2027-07-25T06:00:00.000Z"
       }
     },
     {
@@ -2957,7 +2963,8 @@
             "contentSha256": "0492df28ff51dc4262508363e960ed1a5fed847d3aa5f593ea62ad0fd3d773f3",
             "lineId": "line-828f04afc588"
           }
-        ]
+        ],
+        "freshUntil": "2027-07-25T06:00:00.000Z"
       }
     },
     {
@@ -3062,7 +3069,8 @@
             "contentSha256": "0492df28ff51dc4262508363e960ed1a5fed847d3aa5f593ea62ad0fd3d773f3",
             "lineId": "line-5500c1600f71"
           }
-        ]
+        ],
+        "freshUntil": "2027-07-25T06:00:00.000Z"
       }
     },
     {
@@ -3169,7 +3177,8 @@
             "contentSha256": "0492df28ff51dc4262508363e960ed1a5fed847d3aa5f593ea62ad0fd3d773f3",
             "lineId": "line-8604048b6430"
           }
-        ]
+        ],
+        "freshUntil": "2027-07-25T06:00:00.000Z"
       }
     },
     {
@@ -3283,7 +3292,8 @@
           "광운대",
           "망우",
           "상봉"
-        ]
+        ],
+        "freshUntil": "2027-07-25T06:00:00.000Z"
       }
     },
     {
@@ -3395,7 +3405,8 @@
         "overlayRawSha256": "9bb0720467d344a16eeb384e46042fbe19698f0d3375b12cbe5b68dc2b0b134e",
         "overlayStationNames": [
           "성남"
-        ]
+        ],
+        "freshUntil": "2027-07-25T06:00:00.000Z"
       }
     },
     {
@@ -3500,7 +3511,8 @@
             "contentSha256": "0492df28ff51dc4262508363e960ed1a5fed847d3aa5f593ea62ad0fd3d773f3",
             "lineId": "line-6e39be0cb6e2"
           }
-        ]
+        ],
+        "freshUntil": "2027-07-25T06:00:00.000Z"
       }
     },
     {
@@ -3846,7 +3858,8 @@
             "contentSha256": "0492df28ff51dc4262508363e960ed1a5fed847d3aa5f593ea62ad0fd3d773f3",
             "lineId": "line-051552e50435"
           }
-        ]
+        ],
+        "freshUntil": "2027-07-25T06:00:00.000Z"
       }
     },
     {
@@ -3951,7 +3964,8 @@
             "contentSha256": "0492df28ff51dc4262508363e960ed1a5fed847d3aa5f593ea62ad0fd3d773f3",
             "lineId": "line-f0e747248a31"
           }
-        ]
+        ],
+        "freshUntil": "2027-07-25T05:00:00.000Z"
       }
     },
     {
@@ -4058,7 +4072,8 @@
             "contentSha256": "0492df28ff51dc4262508363e960ed1a5fed847d3aa5f593ea62ad0fd3d773f3",
             "lineId": "shinbundang"
           }
-        ]
+        ],
+        "freshUntil": "2027-07-25T06:00:00.000Z"
       }
     },
     {
@@ -4163,7 +4178,8 @@
             "contentSha256": "0492df28ff51dc4262508363e960ed1a5fed847d3aa5f593ea62ad0fd3d773f3",
             "lineId": "line-aefa08ccc0a9"
           }
-        ]
+        ],
+        "freshUntil": "2027-07-25T06:00:00.000Z"
       }
     },
     {
@@ -5415,7 +5431,8 @@
             "contentSha256": "0492df28ff51dc4262508363e960ed1a5fed847d3aa5f593ea62ad0fd3d773f3",
             "lineId": "line-558d0bd8312d"
           }
-        ]
+        ],
+        "freshUntil": "2027-07-25T06:00:00.000Z"
       }
     },
     {
@@ -5716,7 +5733,8 @@
             "contentSha256": "0492df28ff51dc4262508363e960ed1a5fed847d3aa5f593ea62ad0fd3d773f3",
             "lineId": "line-30886152e4f8"
           }
-        ]
+        ],
+        "freshUntil": "2027-07-25T06:00:00.000Z"
       }
     },
     {
@@ -5821,7 +5839,8 @@
             "contentSha256": "0492df28ff51dc4262508363e960ed1a5fed847d3aa5f593ea62ad0fd3d773f3",
             "lineId": "line-62096860ab09"
           }
-        ]
+        ],
+        "freshUntil": "2027-07-25T06:00:00.000Z"
       }
     },
     {
@@ -7011,7 +7030,8 @@
             "contentSha256": "0492df28ff51dc4262508363e960ed1a5fed847d3aa5f593ea62ad0fd3d773f3",
             "lineId": "line-f0e747248a31"
           }
-        ]
+        ],
+        "freshUntil": "2027-07-25T04:00:00.000Z"
       }
     },
     {
@@ -7262,7 +7282,8 @@
           "7": 42,
           "8": 18
         },
-        "observedDataUpdatedAt": "2025-08-14"
+        "observedDataUpdatedAt": "2025-08-14",
+        "freshUntil": "2027-07-24T02:00:00.000Z"
       }
     },
     {


### PR DESCRIPTION
<!-- exact-head-gate-2026-07-27:start -->
## Latest exact-head gate

- Base: `509c51166ad7a84e3634d6b404665bc89c13c2f9`
- Head: `463492d7d62374dffb501d1296c653c0327f9b4c`
- 실제 Codex CLI Review: [4787035833](https://github.com/AquilaXk/easysubway/pull/2635#pullrequestreview-4787035833), actionable 0
- Review threads / requested changes: 0 / 0
- Required CI: [30266905686](https://github.com/AquilaXk/easysubway/actions/runs/30266905686) — SUCCESS
- Release Artifacts: [30266905374](https://github.com/AquilaXk/easysubway/actions/runs/30266905374) — SUCCESS
- Mergeability: `CLEAN`
- 로컬 resource incident 이후 final 증거는 exact-head GitHub Actions로만 판정했다. 이전 head의 로컬 실행은 historical implementation evidence이며 final gate로 재사용하지 않는다.

<!-- exact-head-gate-2026-07-27:end -->

## 관련 이슈

Closes #2598

## 작업 배경

route-map admission evidence는 `capturedAt` 하한만 검사해 먼 미래의 materialization pin도 통과했습니다. Android v1 candidate 편입이 stale route-map snapshot을 조용히 수락하지 않도록 저장소 SLA의 `route_map_asset = P1Y`를 실제 consumer와 evidence에 결속합니다.

## 작업 내용

- `capturedAt + P1Y` UTC calendar-year와 `[capturedAt, freshUntil)`을 검증하는 공통 fail-closed helper를 추가했습니다.
- 9개 route-map position materializer와 Incheon station-info까지 10 consumer가 같은 helper를 호출합니다.
- source inventory 두 mirror의 route-map evidence 21건에 machine-derived `freshUntil`을 추가하고 candidate evidence를 재생성했습니다.
- source-inventory schema와 release build/hash evidence, 전국 tally를 같은 inventory identity로 재결속했습니다.
- freshness generator는 mirror byte parity를 확인한 뒤 각 mirror를 같은 디렉터리의 임시 파일에 완전히 기록·fsync하고 atomic rename합니다. 실패 시 임시 파일을 제거하고 전체 작업을 실패시킵니다.
- missing/invalid/P1Y mismatch/before-captured/at-or-after-expiry 회귀와 9 route-map materializer·Incheon 소비 결속을 고정했습니다.
- Incheon의 기존 topology 1일 freshness window는 유지하고 route-map P1Y만 별도 evidence로 검증합니다.

## 검증

- exact-head GitHub Actions CI `30266905686` — SUCCESS
- exact-head Release Artifacts `30266905374` — SUCCESS
- Repository CI에서 datapack tool tests, schema parity, contract/release gates 포함 required jobs green
- Android Release Artifact와 RC Evidence Manifest green
- Codex CLI Review `4787035833` — actionable 0
- unresolved review thread 0, requested changes 0
- route-map evidence 21/21 `freshUntil === capturedAt + P1Y`
- inventory mirror byte identity, raw SHA `d6425d…d3b1b7`, canonical JSON SHA `3f47b5…3874c`
- `git diff --check` — PASS
- 로컬 resource incident 이후 테스트를 재실행하지 않았으며 final 판정은 위 exact-head 원격 증거만 사용

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| P1Y/반개구간 | Node 24 | helper unit | missing/invalid/mismatch/before/stale 포함 | PASS |
| consumer 결속 | Node 24 / datapack | candidate + Daegu/Incheon focused | 9 route-map materializer + Incheon | PASS |
| evidence 재생성 | JSON / Node 24 | generator idempotence·mirror cmp·count | 21/21, SHA `d6425d…d3b1b7` | PASS |
| release identity | GitHub Actions / Node 24 | schema·build spec·hash evidence·tally | inventory JSON SHA `3f47b5…3874c` | PASS |
| 독립 리뷰 | Codex CLI | `509c5116…463492d7` | Review `4787035833`, actionable 0 | PASS |
| required CI | GitHub Actions | run `30266905686` | exact-head required jobs green | PASS |
| release artifact | GitHub Actions | run `30266905374` | Android artifact·RC evidence manifest green | PASS |
| review state | GitHub | thread/requested changes | 0 / 0 | PASS |
| UI·수동 QA | Android | 사용자 화면 변경 없음 | data gate only | 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음(admission freshness/evidence only)
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- `route-map-admission-freshness.mjs`가 저장소 P1Y 의미(`addCadence`)와 exact match하는지 확인해 주세요.
- Incheon은 route-map P1Y를 추가하되 기존 topology 24시간 창을 연장하지 않습니다.
- inventory 의미 diff는 21개 `freshUntil`과 그에 따른 candidate inventory SHA뿐입니다.

## 리스크

- P1Y 만료 시 source snapshot을 재검증하지 않으면 candidate gate가 의도적으로 실패합니다.
- indefinite-static exception이나 provider별 임의 cadence는 추가하지 않았습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex 독립 리뷰를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 노선도 및 역 정보의 데이터 신선도 만료 시각을 정비했습니다.
  * 신선도 기간을 벗어나거나 미래 시점인 데이터는 처리되지 않도록 검증을 강화했습니다.
  * 데이터 미러 간 불일치와 잘못된 신선도 정보를 더욱 엄격하게 감지합니다.

* **테스트**
  * 다양한 지역 및 노선 데이터에 대한 만료·경계 조건 검증을 추가했습니다.
  * 데이터 무결성 및 신선도 갱신 동작을 확인하는 회귀 테스트를 보강했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
