### PR TITLE
[Fix] #2636 candidate line-scope 역결속 경계 보정

### DIFF
--- a/tools/datapack/nationwide-candidate-coverage-gate.test.mjs
+++ b/tools/datapack/nationwide-candidate-coverage-gate.test.mjs
@@ -3034,6 +3034,7 @@ function lineScopeExactMatchFixture(sourceId, sourceDomain, releaseTier = "LAUNC
     pack: {
       sourceInventory: [{ id: sourceId, coverageScope: { ...coverageScope, lineIds: undefined } }],
     },
+    inheritedPack: { sourceInventory: [] },
     inventory: { sources: [{ id: sourceId, coverageScope }] },
     targets: {
       requiredSourceDomains: [{ id: sourceDomain, releaseTier }],
@@ -3123,10 +3124,30 @@ test("inactive scope와 LAUNCH_REQUIRED가 아닌 domain은 actual line-scope se
   ));
 
   const enhancement = lineScopeExactMatchFixture("enhancement", "schedule_timetable", "ENHANCEMENT");
-  enhancement.spec.lineScopeRedescriptions = [];
   assert.doesNotThrow(() => assertLineScopeRedescriptionsMatchActualRequiredSet(
     enhancement.spec, enhancement.pack, enhancement.inventory, enhancement.targets,
   ));
+});
+
+test("승계 pack에 이미 있던 line scope는 신규 재기술 대상으로 세지 않는다", () => {
+  const fixture = lineScopeExactMatchFixture("inherited", "schedule_timetable");
+  fixture.spec.lineScopeRedescriptions = [];
+  fixture.pack.sourceInventory[0].coverageScope = structuredClone(
+    fixture.inventory.sources[0].coverageScope,
+  );
+  fixture.inheritedPack.sourceInventory = structuredClone(fixture.pack.sourceInventory);
+
+  assert.doesNotThrow(() => assertLineScopeRedescriptionsMatchActualRequiredSet(
+    fixture.spec, fixture.pack, fixture.inventory, fixture.targets, fixture.inheritedPack,
+  ));
+
+  fixture.inheritedPack.sourceInventory[0].coverageScope.lineIds = ["other-line"];
+  assert.throws(
+    () => assertLineScopeRedescriptionsMatchActualRequiredSet(
+      fixture.spec, fixture.pack, fixture.inventory, fixture.targets, fixture.inheritedPack,
+    ),
+    /inherited candidate pack coverageScope\.lineIds must match candidate pack and source inventory/,
+  );
 });
 
 test("pack-only lineIds와 inventory 누락 lineIds는 fail closed다", () => {

--- a/tools/datapack/run-nationwide-candidate-coverage-gate.mjs
+++ b/tools/datapack/run-nationwide-candidate-coverage-gate.mjs
@@ -317,7 +317,13 @@ export async function runNationwideCandidateCoverageGate({
   // variant마다 달라질 수 없고, 한 번만 조립해 두 실행이 같은 행 바이트를 쓰는 것을 구조로 보장한다.
   const inclusions = await applyPackDataInclusions(spec, inherited, inventory, materializers);
   const targets = (await readJsonInput(targetsInput.path)).document;
-  assertLineScopeRedescriptionsMatchActualRequiredSet(spec, inclusions.pack, inventory, targets);
+  assertLineScopeRedescriptionsMatchActualRequiredSet(
+    spec,
+    inclusions.pack,
+    inventory,
+    targets,
+    inclusions.inheritedPack,
+  );
 
   const signing = ephemeralSigningKeys();
   const variants = {};
@@ -430,7 +436,7 @@ async function applyPackDataInclusions(spec, inherited, inventory, materializers
       inputs: [...inputs.values()].sort((left, right) => codepointCompare(left.path, right.path)),
     });
   }
-  return { pack: fixture.packs[0], records };
+  return { pack: fixture.packs[0], inheritedPack, records };
 }
 
 // 대구 1·2·3호선 노선 선언 대조와 topology snapshot 로딩. 세 대구 어댑터가 공유한다.
@@ -1376,7 +1382,13 @@ function assertInventoryLineScopeSync(spec, inventory) {
 // lineScopeRedescriptions에 source/domain 단위로 빠짐없이 재기술돼야 한다. 선언 목록을 기준으로
 // fixture·baseline을 조립하면 선언을 지운 실제 소스가 두 variant에 함께 남아 fail open하므로, pack ×
 // tracked inventory × coverage targets에서 actual required set을 역으로 유도해 양방향 exact-match 한다.
-export function assertLineScopeRedescriptionsMatchActualRequiredSet(spec, pack, inventory, targets) {
+export function assertLineScopeRedescriptionsMatchActualRequiredSet(
+  spec,
+  pack,
+  inventory,
+  targets,
+  inheritedPack = { sourceInventory: [] },
+) {
   const launchRequiredDomains = new Set(
     (targets.requiredSourceDomains ?? [])
       .filter(({ releaseTier }) => releaseTier === "LAUNCH_REQUIRED")
@@ -1384,6 +1396,9 @@ export function assertLineScopeRedescriptionsMatchActualRequiredSet(spec, pack, 
   );
   const activeLineScopes = targets.activeLineScopes ?? [];
   const inventoryById = new Map((inventory.sources ?? []).map((source) => [source.id, source]));
+  const inheritedById = new Map(
+    (inheritedPack.sourceInventory ?? []).map((source) => [source.id, source]),
+  );
   const actual = new Map();
   const sourcesById = new Map();
 
@@ -1409,6 +1424,16 @@ export function assertLineScopeRedescriptionsMatchActualRequiredSet(spec, pack, 
     // 원형에 이미 lineIds가 있는 신규 source라면 둘의 집합이 같아야 한다.
     if (packScope?.lineIds && !sameStringSet(packScope.lineIds, inventoryScope.lineIds)) {
       throw new Error(`candidate pack coverageScope.lineIds must match source inventory: ${sourceId}`);
+    }
+    const inheritedLineIds = inheritedById.get(sourceId)?.coverageScope?.lineIds;
+    if (inheritedLineIds?.length) {
+      if (!sameStringSet(inheritedLineIds, inventoryScope.lineIds)
+        || !sameStringSet(inheritedLineIds, packScope?.lineIds)) {
+        throw new Error(
+          `inherited candidate pack coverageScope.lineIds must match candidate pack and source inventory: ${sourceId}`,
+        );
+      }
+      continue;
     }
     sourcesById.set(sourceId, { packScope, inventoryScope });
   }
@@ -1451,9 +1476,12 @@ export function assertLineScopeRedescriptionsMatchActualRequiredSet(spec, pack, 
   }
 
   const declared = new Map();
+  const declaredKeys = new Set();
   for (const redescription of spec.lineScopeRedescriptions) {
     const key = `${redescription.sourceId}:${redescription.sourceDomain}`;
-    if (declared.has(key)) throw new Error(`duplicate declared line-scope source/domain: ${key}`);
+    if (declaredKeys.has(key)) throw new Error(`duplicate declared line-scope source/domain: ${key}`);
+    declaredKeys.add(key);
+    if (!launchRequiredDomains.has(redescription.sourceDomain)) continue;
     declared.set(key, redescription);
   }
 


### PR DESCRIPTION
## 관련 이슈

Closes #2636

## 작업 배경

- PR #2631 병합 전 독립 리뷰에서 candidate line-scope 역결속 검증이 inherited scope와 `ENHANCEMENT` redescription을 잘못 거부하는 경계를 확인했다.
- #2631이 먼저 병합되어 검증된 보정 커밋을 별도 후속 PR로 전달한다.

## 작업 내용

- 승계 pack을 exact-match validator에 전달해 이미 존재하던 line scope를 신규 재기술 집합에서 제외한다.
- inherited pack·candidate pack·tracked inventory의 `lineIds` drift는 fail closed한다.
- `ENHANCEMENT` declaration은 `LAUNCH_REQUIRED` exact-match 집합에서 제외하되 기존 spec/evidence 검증은 유지한다.
- synthetic fixture로 inherited 정상·drift와 `ENHANCEMENT` 회귀를 고정한다.

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern='omission 회귀 대상|omission은 actual|actual line-scope 선언|inactive scope|승계 pack|pack-only' tools/datapack/nationwide-candidate-coverage-gate.test.mjs` — 9/9 통과, 3.8초
  - 동일 두 파일 diff의 datapack 전체 lane — 1,818/1,818 통과, 1,032.7초
  - `git diff --check origin/main...HEAD` — 통과
  - 이전 독립 plugin-disabled review — actionable finding 0건

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| pure validator 회귀 | 데이터팩 도구 | Node focused test | PR Checks 및 위 명령 결과 | 통과 |
| 전체 datapack 회귀 | 데이터팩 도구 | 동일 diff 전체 lane | 1,818/1,818, 1,032.7초 | 통과 |
| UI·수동 QA | 해당 없음 | UI 변경 없음 | 두 datapack 도구 파일만 변경 | 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `assertLineScopeRedescriptionsMatchActualRequiredSet()`가 inherited source를 제외하기 전에 세 입력의 `lineIds` 일치를 검증하는지, non-launch declaration을 exact-match 집합에서만 제외하는지 확인해 주세요.

## 리스크

- inherited source 판정을 넓게 적용하면 실제 신규 재기술을 누락할 수 있다. 승계 원본에 이미 non-empty `lineIds`가 있고 세 입력이 정확히 일치할 때만 제외한다.
- 로컬 리소스 보호를 위해 동일 byte diff의 전수 테스트를 재실행하지 않았으며, 병합본 기준 전수 검증은 required CI에서 확인한다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
