### PR TITLE
[Test] #2634 inherited line-scope 전이 계약 고정

### DIFF
--- a/tools/datapack/nationwide-candidate-coverage-gate.test.mjs
+++ b/tools/datapack/nationwide-candidate-coverage-gate.test.mjs
@@ -3052,6 +3052,18 @@ test("actual line-scope 선언은 source/domain, lineIds, requirementKeys가 정
   }
 });
 
+test("actual line-scope 새 candidate의 동수 key 불일치도 transition reason을 남긴다", () => {
+  const fixture = lineScopeExactMatchFixture("new-candidate", "schedule_timetable");
+  fixture.spec.lineScopeRedescriptions[0].sourceId = "declared-other-source";
+
+  assert.throws(
+    () => assertLineScopeRedescriptionsMatchActualRequiredSet(
+      fixture.spec, fixture.pack, fixture.inventory, fixture.targets,
+    ),
+    /line-scope redescriptions must exactly match the actual required set: .*NEW_CANDIDATE_SCOPE:new-candidate/,
+  );
+});
+
 test("inactive scope와 LAUNCH_REQUIRED가 아닌 domain은 actual line-scope set에서 제외한다", () => {
   const inactive = lineScopeExactMatchFixture("inactive", "schedule_timetable");
   inactive.spec.lineScopeRedescriptions = [];
@@ -3101,6 +3113,24 @@ test("승계 pack line scope의 부분 확장은 명시 재기술 없이 거부�
       fixture.spec, fixture.pack, fixture.inventory, fixture.targets, fixture.inheritedPack,
     ),
     /UNDECLARED_INHERITED_SCOPE_EXTENSION: inherited-extension/,
+  );
+});
+
+test("승계 pack line scope의 축소는 빈 candidate와 inventory여도 거부된다", () => {
+  const fixture = lineScopeExactMatchFixture("inherited-shrink", "schedule_timetable");
+  fixture.spec.lineScopeRedescriptions = [];
+  fixture.pack.sourceInventory[0].coverageScope = structuredClone(
+    fixture.inventory.sources[0].coverageScope,
+  );
+  fixture.inheritedPack.sourceInventory = structuredClone(fixture.pack.sourceInventory);
+  fixture.pack.sourceInventory[0].coverageScope.lineIds = [];
+  fixture.inventory.sources[0].coverageScope.lineIds = [];
+
+  assert.throws(
+    () => assertLineScopeRedescriptionsMatchActualRequiredSet(
+      fixture.spec, fixture.pack, fixture.inventory, fixture.targets, fixture.inheritedPack,
+    ),
+    /inherited candidate pack coverageScope\.lineIds must match candidate pack and source inventory: inherited-shrink/,
   );
 });
 

--- a/tools/datapack/nationwide-candidate-coverage-gate.test.mjs
+++ b/tools/datapack/nationwide-candidate-coverage-gate.test.mjs
@@ -41,6 +41,7 @@ import {
   assertLineScopeRedescriptionsMatchActualRequiredSet,
   assertInheritedRowsUnchanged,
   assertNonTransitionReasons,
+  classifyLineScopeTransition,
   inheritedRowSnapshot,
   runNationwideCandidateCoverageGate,
   validateNationwideCandidateCoverageSpec,
@@ -2989,10 +2990,25 @@ for (const { sourceId, sourceDomain } of OMITTED_LINE_SCOPE_CASES) {
     fixture.spec.lineScopeRedescriptions = [];
     assert.throws(
       () => assertLineScopeRedescriptionsMatchActualRequiredSet(fixture.spec, fixture.pack, fixture.inventory, fixture.targets),
-      /line-scope redescriptions must exactly match the actual required set/,
+      /line-scope redescriptions must exactly match the actual required set.*NEW_CANDIDATE_SCOPE/,
     );
   });
 }
+
+test("actual line-scope transition은 승계 경계를 분류한다", () => {
+  assert.equal(
+    classifyLineScopeTransition(["line-a"], ["line-a"], ["line-a"]),
+    "UNCHANGED_INHERITED_SCOPE",
+  );
+  assert.equal(
+    classifyLineScopeTransition([], undefined, ["line-a"]),
+    "NEW_CANDIDATE_SCOPE",
+  );
+  assert.equal(
+    classifyLineScopeTransition(["line-a"], ["line-a"], ["line-a", "line-b"]),
+    "UNDECLARED_INHERITED_SCOPE_EXTENSION",
+  );
+});
 
 test("actual line-scope 선언은 source/domain, lineIds, requirementKeys가 정확히 일치해야 한다", () => {
   const valid = lineScopeExactMatchFixture("source", "schedule_timetable");
@@ -3068,6 +3084,23 @@ test("승계 pack에 이미 있던 line scope는 신규 재기술 대상으로 �
       fixture.spec, fixture.pack, fixture.inventory, fixture.targets, fixture.inheritedPack,
     ),
     /inherited candidate pack coverageScope\.lineIds must match candidate pack and source inventory/,
+  );
+});
+
+test("승계 pack line scope의 부분 확장은 명시 재기술 없이 거부된다", () => {
+  const fixture = lineScopeExactMatchFixture("inherited-extension", "schedule_timetable");
+  fixture.spec.lineScopeRedescriptions = [];
+  fixture.pack.sourceInventory[0].coverageScope = structuredClone(
+    fixture.inventory.sources[0].coverageScope,
+  );
+  fixture.inheritedPack.sourceInventory = structuredClone(fixture.pack.sourceInventory);
+  fixture.inventory.sources[0].coverageScope.lineIds.push("line-b");
+
+  assert.throws(
+    () => assertLineScopeRedescriptionsMatchActualRequiredSet(
+      fixture.spec, fixture.pack, fixture.inventory, fixture.targets, fixture.inheritedPack,
+    ),
+    /UNDECLARED_INHERITED_SCOPE_EXTENSION: inherited-extension/,
   );
 });
 

--- a/tools/datapack/nationwide-candidate-coverage-gate.test.mjs
+++ b/tools/datapack/nationwide-candidate-coverage-gate.test.mjs
@@ -3008,6 +3008,10 @@ test("actual line-scope transition은 승계 경계를 분류한다", () => {
     classifyLineScopeTransition(["line-a"], ["line-a"], ["line-a", "line-b"]),
     "UNDECLARED_INHERITED_SCOPE_EXTENSION",
   );
+  assert.equal(
+    classifyLineScopeTransition(["line-a"], ["line-a", "line-b"], ["line-a", "line-b"]),
+    "UNDECLARED_INHERITED_SCOPE_EXTENSION",
+  );
 });
 
 test("actual line-scope 선언은 source/domain, lineIds, requirementKeys가 정확히 일치해야 한다", () => {
@@ -3064,6 +3068,33 @@ test("actual line-scope 새 candidate의 동수 key 불일치도 transition reas
   );
 });
 
+test("actual line-scope 새 candidate transition diagnostic은 source 입력 순서와 무관하다", () => {
+  const diagnosticFor = (sourceIds) => {
+    const coverageScope = {
+      lineIds: ["line"], sourceDomains: ["schedule_timetable"], regionIds: ["region"], operatorIds: ["operator"],
+    };
+    let error;
+    assert.throws(
+      () => assertLineScopeRedescriptionsMatchActualRequiredSet(
+        { lineScopeRedescriptions: [] },
+        { sourceInventory: sourceIds.map((id) => ({ id, coverageScope: { ...coverageScope, lineIds: undefined } })) },
+        { sources: sourceIds.map((id) => ({ id, coverageScope })) },
+        {
+          requiredSourceDomains: [{ id: "schedule_timetable", releaseTier: "LAUNCH_REQUIRED" }],
+          activeLineScopes: [{ regionId: "region", operatorId: "operator", lineId: "line" }],
+        },
+      ),
+      (value) => { error = value; return true; },
+    );
+    return error.message;
+  };
+
+  assert.equal(
+    diagnosticFor(["source-b", "source-a"]),
+    diagnosticFor(["source-a", "source-b"]),
+  );
+});
+
 test("inactive scope와 LAUNCH_REQUIRED가 아닌 domain은 actual line-scope set에서 제외한다", () => {
   const inactive = lineScopeExactMatchFixture("inactive", "schedule_timetable");
   inactive.spec.lineScopeRedescriptions = [];
@@ -3113,6 +3144,24 @@ test("승계 pack line scope의 부분 확장은 명시 재기술 없이 거부�
       fixture.spec, fixture.pack, fixture.inventory, fixture.targets, fixture.inheritedPack,
     ),
     /UNDECLARED_INHERITED_SCOPE_EXTENSION: inherited-extension/,
+  );
+});
+
+test("승계 pack line scope의 pack과 inventory 동시 확장도 거부된다", () => {
+  const fixture = lineScopeExactMatchFixture("inherited-extension-both", "schedule_timetable");
+  fixture.spec.lineScopeRedescriptions = [];
+  fixture.pack.sourceInventory[0].coverageScope = structuredClone(
+    fixture.inventory.sources[0].coverageScope,
+  );
+  fixture.inheritedPack.sourceInventory = structuredClone(fixture.pack.sourceInventory);
+  fixture.pack.sourceInventory[0].coverageScope.lineIds.push("line-b");
+  fixture.inventory.sources[0].coverageScope.lineIds.push("line-b");
+
+  assert.throws(
+    () => assertLineScopeRedescriptionsMatchActualRequiredSet(
+      fixture.spec, fixture.pack, fixture.inventory, fixture.targets, fixture.inheritedPack,
+    ),
+    /UNDECLARED_INHERITED_SCOPE_EXTENSION: inherited-extension-both/,
   );
 });
 

--- a/tools/datapack/run-nationwide-candidate-coverage-gate.mjs
+++ b/tools/datapack/run-nationwide-candidate-coverage-gate.mjs
@@ -1427,13 +1427,18 @@ export function assertLineScopeRedescriptionsMatchActualRequiredSet(
       continue;
     }
     const inventoryScope = inventorySource.coverageScope;
+    const inheritedLineIds = inheritedById.get(sourceId)?.coverageScope?.lineIds;
     if (!inventoryScope?.lineIds?.length) {
+      if (inheritedLineIds?.length) {
+        throw new Error(
+          `inherited candidate pack coverageScope.lineIds must match candidate pack and source inventory: ${sourceId}`,
+        );
+      }
       if (packScope?.lineIds?.length) {
         throw new Error(`candidate pack coverageScope.lineIds must match source inventory: ${sourceId}`);
       }
       continue;
     }
-    const inheritedLineIds = inheritedById.get(sourceId)?.coverageScope?.lineIds;
     const transition = classifyLineScopeTransition(
       inheritedLineIds,
       packScope?.lineIds,
@@ -1504,13 +1509,16 @@ export function assertLineScopeRedescriptionsMatchActualRequiredSet(
     if (!launchRequiredDomains.has(redescription.sourceDomain)) continue;
     declared.set(key, redescription);
   }
+  const transitionDiagnostics = newCandidateSourceIds
+    .map((sourceId) => `NEW_CANDIDATE_SCOPE:${sourceId}`)
+    .join(",");
 
   if (actual.size !== declared.size) {
     throw new Error(
       "line-scope redescriptions must exactly match the actual required set: "
         + `actual=${[...actual.keys()].sort(codepointCompare).join(",")}, `
         + `declared=${[...declared.keys()].sort(codepointCompare).join(",")}, `
-        + `transitions=${newCandidateSourceIds.map((sourceId) => `NEW_CANDIDATE_SCOPE:${sourceId}`).join(",")}`,
+        + `transitions=${transitionDiagnostics}`,
     );
   }
   for (const [key, required] of actual) {
@@ -1518,7 +1526,10 @@ export function assertLineScopeRedescriptionsMatchActualRequiredSet(
     if (!redescription
       || !sameStringSet(redescription.lineIds, required.lineIds)
       || !sameStringSet(redescription.requirementKeys, required.requirementKeys)) {
-      throw new Error(`line-scope redescriptions must exactly match the actual required set: ${key}`);
+      throw new Error(
+        `line-scope redescriptions must exactly match the actual required set: ${key}, `
+          + `transitions=${transitionDiagnostics}`,
+      );
     }
   }
 }

--- a/tools/datapack/run-nationwide-candidate-coverage-gate.mjs
+++ b/tools/datapack/run-nationwide-candidate-coverage-gate.mjs
@@ -1414,6 +1414,7 @@ export function assertLineScopeRedescriptionsMatchActualRequiredSet(
   );
   const actual = new Map();
   const sourcesById = new Map();
+  const newCandidateSourceIds = [];
 
   for (const packSource of pack.sourceInventory ?? []) {
     const sourceId = requiredString(packSource?.id, "candidate pack sourceInventory[].id");
@@ -1432,22 +1433,28 @@ export function assertLineScopeRedescriptionsMatchActualRequiredSet(
       }
       continue;
     }
+    const inheritedLineIds = inheritedById.get(sourceId)?.coverageScope?.lineIds;
+    const transition = classifyLineScopeTransition(
+      inheritedLineIds,
+      packScope?.lineIds,
+      inventoryScope.lineIds,
+    );
+    if (transition === "UNDECLARED_INHERITED_SCOPE_EXTENSION") {
+      throw new Error(`${transition}: ${sourceId}`);
+    }
+    if (inheritedLineIds?.length && transition === null) {
+      throw new Error(
+        `inherited candidate pack coverageScope.lineIds must match candidate pack and source inventory: ${sourceId}`,
+      );
+    }
     // inclusions.pack은 재기술을 덮기 전 원형이다. 기존 source는 여기서 lineIds가 없고,
     // lineScoped fixture에서만 spec 값이 주입된다. tracked inventory가 그 후보 line scope의 정본이며,
     // 원형에 이미 lineIds가 있는 신규 source라면 둘의 집합이 같아야 한다.
     if (packScope?.lineIds && !sameStringSet(packScope.lineIds, inventoryScope.lineIds)) {
       throw new Error(`candidate pack coverageScope.lineIds must match source inventory: ${sourceId}`);
     }
-    const inheritedLineIds = inheritedById.get(sourceId)?.coverageScope?.lineIds;
-    if (inheritedLineIds?.length) {
-      if (!sameStringSet(inheritedLineIds, inventoryScope.lineIds)
-        || !sameStringSet(inheritedLineIds, packScope?.lineIds)) {
-        throw new Error(
-          `inherited candidate pack coverageScope.lineIds must match candidate pack and source inventory: ${sourceId}`,
-        );
-      }
-      continue;
-    }
+    if (transition === "UNCHANGED_INHERITED_SCOPE") continue;
+    if (transition === "NEW_CANDIDATE_SCOPE") newCandidateSourceIds.push(sourceId);
     sourcesById.set(sourceId, { packScope, inventoryScope });
   }
 
@@ -1502,7 +1509,8 @@ export function assertLineScopeRedescriptionsMatchActualRequiredSet(
     throw new Error(
       "line-scope redescriptions must exactly match the actual required set: "
         + `actual=${[...actual.keys()].sort(codepointCompare).join(",")}, `
-        + `declared=${[...declared.keys()].sort(codepointCompare).join(",")}`,
+        + `declared=${[...declared.keys()].sort(codepointCompare).join(",")}, `
+        + `transitions=${newCandidateSourceIds.map((sourceId) => `NEW_CANDIDATE_SCOPE:${sourceId}`).join(",")}`,
     );
   }
   for (const [key, required] of actual) {
@@ -1513,6 +1521,24 @@ export function assertLineScopeRedescriptionsMatchActualRequiredSet(
       throw new Error(`line-scope redescriptions must exactly match the actual required set: ${key}`);
     }
   }
+}
+
+export function classifyLineScopeTransition(inheritedLineIds, packLineIds, inventoryLineIds) {
+  if (!Array.isArray(inventoryLineIds) || inventoryLineIds.length === 0) return null;
+  if (!Array.isArray(inheritedLineIds) || inheritedLineIds.length === 0) {
+    return "NEW_CANDIDATE_SCOPE";
+  }
+  if (sameStringSet(inheritedLineIds, packLineIds)
+    && sameStringSet(inheritedLineIds, inventoryLineIds)) {
+    return "UNCHANGED_INHERITED_SCOPE";
+  }
+  if (inheritedLineIds.every((lineId) => inventoryLineIds.includes(lineId))
+    && inventoryLineIds.length > new Set(inheritedLineIds).size
+    && (sameStringSet(packLineIds, inheritedLineIds)
+      || sameStringSet(packLineIds, inventoryLineIds))) {
+    return "UNDECLARED_INHERITED_SCOPE_EXTENSION";
+  }
+  return null;
 }
 
 function sameStringSet(left, right) {

--- a/tools/datapack/run-nationwide-candidate-coverage-gate.mjs
+++ b/tools/datapack/run-nationwide-candidate-coverage-gate.mjs
@@ -1509,7 +1509,8 @@ export function assertLineScopeRedescriptionsMatchActualRequiredSet(
     if (!launchRequiredDomains.has(redescription.sourceDomain)) continue;
     declared.set(key, redescription);
   }
-  const transitionDiagnostics = newCandidateSourceIds
+  const transitionDiagnostics = [...newCandidateSourceIds]
+    .sort(codepointCompare)
     .map((sourceId) => `NEW_CANDIDATE_SCOPE:${sourceId}`)
     .join(",");
 


### PR DESCRIPTION
## 관련 이슈

Closes #2634

## 작업 배경

- #2637이 production inherited line scope의 동일 승계를 신규 candidate 재기술에서 제외하고 drift를 거부했지만, 동일 승계·신규 scope·부분 확장의 machine-readable 판정과 `[A] -> [A, B]` 직접 회귀는 없었다.
- #2510에서 production inherited line-scoped source를 만들거나 확장하기 전에 이 경계를 닫는다.

## 작업 내용

- `classifyLineScopeTransition()`으로 `UNCHANGED_INHERITED_SCOPE`, `NEW_CANDIDATE_SCOPE`, `UNDECLARED_INHERITED_SCOPE_EXTENSION`을 구분했다.
- 동일 승계만 actual required set에서 제외하고, 신규 source/domain은 기존 exact-set declaration을 계속 요구한다.
- 미선언 부분 확장, inherited scope 축소·교체, candidate/inventory 불일치를 fail closed한다.
- exact-set 오류의 신규-source 진단을 source 입력 순서와 무관하게 결정적으로 정렬했다.
- Candidate spec, production reviewed pack, inventory, targets, evidence 및 workflow는 변경하지 않았다.

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern='actual line-scope|inactive scope|승계 pack|부분 확장|pack-only' tools/datapack/nationwide-candidate-coverage-gate.test.mjs` → 최종 14/14 통과
  - `node --check tools/datapack/run-nationwide-candidate-coverage-gate.mjs` → 통과
  - `node --check tools/datapack/nationwide-candidate-coverage-gate.test.mjs` → 통과
  - `git diff --check` → 통과
  - task review → inherited empty shrink fail-open 1건과 진단 누락 1건 수정 후 승인
  - 최종 독립 review → diagnostic 결정성·부분 확장 두 번째 분기 보강 후 승인
  - 로컬 전체 candidate/datapack suite는 owner-machine 리소스 정책에 따라 실행하지 않고 GitHub-hosted required CI에 위임한다.

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 판정 계약 | Node.js synthetic fixture | TDD RED/GREEN focused test | PR 본문의 명령 | 14/14 통과 |
| 범위 불변 | Git diff | 변경 파일 및 protected artifact 대조 | runner/test 2파일만 변경 | 통과 |
| 전체 회귀 | GitHub Actions | required Repository CI | PR checks | 통과 |
| UI·수동 QA | 해당 없음 | datapack validator 도구만 변경 | UI/asset 변경 없음 | 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: candidate line-scope validation diagnostic만 변경, runtime route contract 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- `classifyLineScopeTransition()`이 동일 승계만 제외하고 부분 확장·축소·교체를 fail closed하는지 확인해 주세요.
- exact-set cardinality/key/lineIds/requirementKeys 오류가 모두 정렬된 `NEW_CANDIDATE_SCOPE` 진단을 남기는지 확인해 주세요.
- #2641의 pure seam과 full-gate 실제 실행 횟수가 바뀌지 않았는지 확인해 주세요.

## 리스크

- 실제 production partial-extension delta는 이번 PR에서 허용하지 않는다. 새 producer가 생길 때 `addedLineIds`와 provenance ownership을 별도 계약으로 설계해야 한다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 없어 CD 확인이 불필요하다.
