### PR TITLE
[Style] 어드민 시그니처 컬러를 semantic token으로 전환

### DIFF
--- a/backend/src/main/resources/static/css/admin-components.css
+++ b/backend/src/main/resources/static/css/admin-components.css
@@ -172,7 +172,7 @@
 }
 
 .admin-v3 .admin-table-scroll:focus-visible {
-	outline: 3px solid #ffbf47;
+	outline: 3px solid var(--admin-focus);
 	outline-offset: 3px;
 }
 

--- a/backend/src/main/resources/static/css/admin-data.css
+++ b/backend/src/main/resources/static/css/admin-data.css
@@ -480,6 +480,10 @@
 	font-weight: var(--admin-w-medium);
 }
 
+.admin-v3 .timeline .timeline-current .timeline-time {
+	color: var(--admin-ink-2);
+}
+
 /* 핵심 지표 그리드 반응형(#1983): 900px 이하 2열, 768px 이하 1열. 각 행의 첫 열은
    좌측 구분선을 빼고, 1열에서는 상단 구분선으로 전환한다. */
 @media (max-width: 900px) {

--- a/backend/src/main/resources/static/css/admin-foundation.css
+++ b/backend/src/main/resources/static/css/admin-foundation.css
@@ -26,7 +26,7 @@ body.admin-v3 {
 .admin-v3 select:focus-visible,
 .admin-v3 textarea:focus-visible,
 .admin-v3 .admin-panel:focus-visible {
-	outline: 3px solid #ffbf47;
+	outline: 3px solid var(--admin-focus);
 	outline-offset: 3px;
 }
 

--- a/backend/src/main/resources/static/css/admin-shell.css
+++ b/backend/src/main/resources/static/css/admin-shell.css
@@ -174,8 +174,12 @@
 	border-radius: 0;
 	border-left-color: var(--admin-accent);
 	background: var(--admin-sidebar-accent);
-	color: var(--admin-ink);
+	color: var(--admin-accent-ink);
 	font-weight: var(--admin-w-strong);
+}
+
+.admin-nav-item:hover:focus-visible {
+	outline-color: var(--admin-focus-on-signature);
 }
 
 .admin-nav-item.is-active:focus-visible {

--- a/backend/src/main/resources/static/css/admin-shell.css
+++ b/backend/src/main/resources/static/css/admin-shell.css
@@ -178,6 +178,10 @@
 	font-weight: var(--admin-w-strong);
 }
 
+.admin-nav-item.is-active:focus-visible {
+	outline-color: var(--admin-focus-on-signature);
+}
+
 .admin-main {
 	min-width: 0;
 	width: 100%;

--- a/backend/src/main/resources/static/css/admin-shell.css
+++ b/backend/src/main/resources/static/css/admin-shell.css
@@ -165,14 +165,14 @@
 
 .admin-nav-item:hover {
 	border-radius: 0;
-	border-left-color: var(--admin-border-strong);
+	border-left-color: var(--admin-sidebar-accent-border);
 	background: var(--admin-sidebar-accent);
 	color: var(--admin-ink);
 }
 
 .admin-nav-item.is-active {
 	border-radius: 0;
-	border-left-color: var(--admin-accent);
+	border-left-color: var(--admin-sidebar-accent-border);
 	background: var(--admin-sidebar-accent);
 	color: var(--admin-accent-ink);
 	font-weight: var(--admin-w-strong);

--- a/backend/src/main/resources/static/css/admin-tokens.css
+++ b/backend/src/main/resources/static/css/admin-tokens.css
@@ -6,36 +6,100 @@
  * 유발할 수 있으므로, 새 semantic token은 추가하되 기존 이름은 alias로 보존한다.
  */
 :root {
+	/* JSON v1 primitive token */
+	--es-brand-50: #F8F9FF;
+	--es-brand-100: #F0F2FE;
+	--es-brand-200: #E2E5FD;
+	--es-brand-300: #CCD2FC;
+	--es-brand-400: #B4BCFB;
+	--es-brand-500: #949FE8;
+	--es-brand-600: #7480D2;
+	--es-brand-700: #5C6BC0;
+	--es-brand-800: #4A58A9;
+	--es-brand-900: #3B4890;
+	--es-brand-950: #1F2340;
+	--es-neutral-white: #FFFFFF;
+	--es-neutral-scaffold: #F7F8FC;
+	--es-neutral-subtle: #F0F2F7;
+	--es-neutral-border: #E1E4EE;
+	--es-ink-secondary: #4D536B;
+	--es-ink-muted: #697089;
+	--es-status-success: #0A705A;
+	--es-status-warning: #9A5600;
+	--es-status-danger: #B42318;
+	--es-status-info: #215EA8;
+	--es-status-success-soft: #F0FBF7;
+	--es-status-warning-soft: #FFF0D1;
+	--es-status-danger-soft: #FFE8E6;
+	--es-status-info-soft: #EEF5FF;
+
+	/* JSON v1 semantic token */
+	--es-surface-default: var(--es-neutral-white);
+	--es-surface-scaffold: var(--es-neutral-scaffold);
+	--es-surface-subtle: var(--es-neutral-subtle);
+	--es-surface-brand-chrome: var(--es-brand-50);
+	--es-surface-brand: var(--es-brand-100);
+	--es-surface-brand-strong: var(--es-brand-200);
+	--es-surface-signature: var(--es-brand-400);
+	--es-border-subtle: var(--es-neutral-border);
+	--es-content-primary: var(--es-brand-950);
+	--es-content-secondary: var(--es-ink-secondary);
+	--es-content-muted: var(--es-ink-muted);
+	--es-interaction-primary: var(--es-brand-700);
+	--es-interaction-primary-pressed: var(--es-brand-800);
+	--es-interaction-on-primary: var(--es-neutral-white);
+	--es-interaction-secondary-surface: var(--es-brand-100);
+	--es-interaction-secondary-border: var(--es-brand-600);
+	--es-interaction-secondary-pressed-surface: var(--es-brand-200);
+	--es-interaction-secondary-pressed-border: var(--es-brand-700);
+	--es-interaction-on-signature-border: var(--es-brand-900);
+	--es-interaction-on-brand: var(--es-brand-900);
+	--es-focus-default: var(--es-brand-700);
+	--es-focus-on-signature: var(--es-brand-900);
+	--es-decorative-divider: var(--es-brand-300);
+	--es-status-success-content: var(--es-status-success);
+	--es-status-success-surface: var(--es-status-success-soft);
+	--es-status-warning-content: var(--es-status-warning);
+	--es-status-warning-surface: var(--es-status-warning-soft);
+	--es-status-danger-content: var(--es-status-danger);
+	--es-status-danger-surface: var(--es-status-danger-soft);
+	--es-status-info-content: var(--es-status-info);
+	--es-status-info-surface: var(--es-status-info-soft);
+
 	/* 표면 — 플랫한 중립 배경, 카드는 얇은 테두리만(그림자 0) */
-	--admin-bg: #F6F8F9;
-	--admin-surface: #FFFFFF;
-	--admin-border: #DBE3E9;
-	--admin-border-strong: #006FD6;
-	--admin-header-bg: #F6F8F9;
+	--admin-bg: var(--es-surface-scaffold);
+	--admin-surface: var(--es-surface-default);
+	--admin-border: var(--es-border-subtle);
+	--admin-border-strong: var(--es-interaction-secondary-border);
+	--admin-header-bg: var(--es-surface-brand-chrome);
 
 	/* 텍스트 — 중립 그레이 위계 */
-	--admin-ink: #102A2C;
-	--admin-ink-2: #29484B;
-	--admin-ink-3: #466467;
+	--admin-ink: var(--es-content-primary);
+	--admin-ink-2: var(--es-content-secondary);
+	--admin-ink-3: var(--es-content-muted);
 
 	/* 브랜드 액센트 1계열 + 의미 상태색 */
-	--admin-accent: #006FD6;
-	--admin-accent-soft: rgba(0, 111, 214, 0.08);
-	/* accent-soft 배경 위 텍스트용 어둠 파생(#2288): hue 유지, accent-soft 렌더 배경(#e2edf6) 위 4.5:1 이상 AA 충족 */
-	--admin-accent-ink: color-mix(in srgb, var(--admin-accent) 90%, #000);
-	--admin-sidebar-bg: #FFFFFF;
-	--admin-sidebar-accent: #F6F8F9;
-	--admin-primary: #006FD6;
-	--admin-primary-hover: color-mix(in srgb, #006FD6 85%, #000);
-	--admin-on-primary: #FFFFFF;
+	--admin-accent: var(--es-interaction-primary);
+	--admin-accent-soft: var(--es-interaction-secondary-surface);
+	/* accent-soft 배경 위 텍스트는 대비가 검증된 interaction.onBrand semantic pair를 쓴다. */
+	--admin-accent-ink: var(--es-interaction-on-brand);
+	--admin-sidebar-bg: var(--es-surface-default);
+	--admin-sidebar-accent: var(--es-surface-signature);
+	--admin-primary: var(--es-interaction-primary);
+	--admin-primary-hover: var(--es-interaction-primary-pressed);
+	--admin-on-primary: var(--es-interaction-on-primary);
+	--admin-focus: var(--es-focus-default);
+	--admin-focus-on-signature: var(--es-focus-on-signature);
 	--admin-danger-hover: color-mix(in srgb, var(--admin-danger) 85%, #000);
-	--admin-good: #0A705A;
-	--admin-warn: #9A5600;
-	--admin-danger: #B42318;
-	--admin-good-soft: #F0FBF7;
-	--admin-warn-soft: #FFF0D1;
-	--admin-danger-soft: #FFE8E6;
-	--admin-chart-series: #2f6f9f; /* 차트 보조 시리즈색(상태 의미 없음) */
+	--admin-good: var(--es-status-success-content);
+	--admin-warn: var(--es-status-warning-content);
+	--admin-danger: var(--es-status-danger-content);
+	--admin-info: var(--es-status-info-content);
+	--admin-good-soft: var(--es-status-success-surface);
+	--admin-warn-soft: var(--es-status-warning-surface);
+	--admin-danger-soft: var(--es-status-danger-surface);
+	--admin-info-soft: var(--es-status-info-surface);
+	--admin-chart-series: #2F6F9F; /* 차트 보조 시리즈색(상태 의미 없음) */
 
 	/* radius — 2단계 토큰(컨트롤/카드) + 뱃지·칩 전용 */
 	--admin-radius-control: 8px;

--- a/backend/src/main/resources/static/css/admin-tokens.css
+++ b/backend/src/main/resources/static/css/admin-tokens.css
@@ -85,6 +85,7 @@
 	--admin-accent-ink: var(--es-interaction-on-brand);
 	--admin-sidebar-bg: var(--es-surface-default);
 	--admin-sidebar-accent: var(--es-surface-signature);
+	--admin-sidebar-accent-border: var(--es-interaction-on-signature-border);
 	--admin-primary: var(--es-interaction-primary);
 	--admin-primary-hover: var(--es-interaction-primary-pressed);
 	--admin-on-primary: var(--es-interaction-on-primary);

--- a/backend/src/main/resources/static/css/operator-v3.css
+++ b/backend/src/main/resources/static/css/operator-v3.css
@@ -32,7 +32,7 @@ a {
 a:focus-visible,
 button:focus-visible,
 input:focus-visible {
-	outline: 3px solid #ffbf47;
+	outline: 3px solid var(--admin-focus);
 	outline-offset: 3px;
 }
 
@@ -116,6 +116,10 @@ input:focus-visible {
 	background: var(--admin-sidebar-accent);
 	color: var(--admin-ink);
 	font-weight: var(--admin-w-strong);
+}
+
+.nav-link.active:focus-visible {
+	outline-color: var(--admin-focus-on-signature);
 }
 
 .desktop-user {
@@ -221,7 +225,7 @@ input:focus-visible {
 .desk-btn.primary {
 	border-color: var(--admin-accent);
 	background: var(--admin-accent);
-	color: #fff;
+	color: var(--admin-on-primary);
 }
 
 /* auto-fit(#2349 PR⑩e 리뷰 반영): 4개 카드 화면은 4열을 채우고, 5개 카드 화면(접근성 현황)은
@@ -459,7 +463,7 @@ input:focus-visible {
 }
 
 .operator-table-scroll:focus-visible {
-	outline: 3px solid #ffbf47;
+	outline: 3px solid var(--admin-focus);
 	outline-offset: 3px;
 }
 
@@ -562,7 +566,7 @@ input:focus-visible {
 	border: 1px solid var(--admin-accent);
 	border-radius: var(--admin-radius-control);
 	background: var(--admin-accent);
-	color: #fff;
+	color: var(--admin-on-primary);
 	padding: 0 12px;
 	font-weight: var(--admin-w-strong);
 }
@@ -677,7 +681,7 @@ input:focus-visible {
 	border: 0;
 	border-radius: var(--admin-radius-control);
 	background: var(--admin-primary);
-	color: #fff;
+	color: var(--admin-on-primary);
 	font-weight: var(--admin-w-strong);
 }
 

--- a/backend/src/main/resources/static/css/operator-v3.css
+++ b/backend/src/main/resources/static/css/operator-v3.css
@@ -105,14 +105,14 @@ input:focus-visible {
 
 .nav-link:hover {
 	border-radius: 0;
-	border-left-color: var(--admin-border-strong);
+	border-left-color: var(--admin-sidebar-accent-border);
 	background: var(--admin-sidebar-accent);
 	color: var(--admin-ink);
 }
 
 .nav-link.active {
 	border-radius: 0;
-	border-left-color: var(--admin-accent);
+	border-left-color: var(--admin-sidebar-accent-border);
 	background: var(--admin-sidebar-accent);
 	color: var(--admin-accent-ink);
 	font-weight: var(--admin-w-strong);

--- a/backend/src/main/resources/static/css/operator-v3.css
+++ b/backend/src/main/resources/static/css/operator-v3.css
@@ -114,8 +114,12 @@ input:focus-visible {
 	border-radius: 0;
 	border-left-color: var(--admin-accent);
 	background: var(--admin-sidebar-accent);
-	color: var(--admin-ink);
+	color: var(--admin-accent-ink);
 	font-weight: var(--admin-w-strong);
+}
+
+.nav-link:hover:focus-visible {
+	outline-color: var(--admin-focus-on-signature);
 }
 
 .nav-link.active:focus-visible {

--- a/backend/src/main/resources/static/js/admin/batch-history-charts.js
+++ b/backend/src/main/resources/static/js/admin/batch-history-charts.js
@@ -4,23 +4,22 @@
 // htmx 부분 갱신(자동 갱신 폴링)으로 새 canvas가 들어오면 afterSwap에서 다시 그린다.
 // Chart.js가 없거나 JSON이 없으면 조용히 넘어가고 details 안 데이터 표가 대체한다.
 (function () {
-	function tokenColor(name, fallback) {
+	function tokenColor(name) {
 		if (typeof getComputedStyle !== 'function') {
-			return fallback;
+			return '';
 		}
-		var value = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
-		return value || fallback;
+		return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
 	}
 
 	var COLORS = {
-		COMPLETED: tokenColor('--admin-good', '#0a705a'),
-		FAILED: tokenColor('--admin-danger', '#b42318'),
-		RUNNING: tokenColor('--admin-warn', '#9a5600')
+		COMPLETED: tokenColor('--admin-good'),
+		FAILED: tokenColor('--admin-danger'),
+		RUNNING: tokenColor('--admin-warn')
 	};
 
 	function barColor(status) {
 		// 상태 매핑 밖(알 수 없는 상태)은 장식적 색 대신 무채색 잉크 톤으로 폴백한다(#1983).
-		return COLORS[status] || tokenColor('--admin-ink-3', '#466467');
+		return COLORS[status] || tokenColor('--admin-ink-3');
 	}
 
 	function renderChart(canvas) {

--- a/backend/src/main/resources/static/js/admin/dashboard-charts.js
+++ b/backend/src/main/resources/static/js/admin/dashboard-charts.js
@@ -3,21 +3,20 @@
 // 기간 버튼이 htmx로 #dashboard-trends를 부분 갱신하면 새 canvas가 들어오므로 afterSwap에서
 // 다시 그린다. Chart.js가 없거나 JSON이 없으면 조용히 넘어가고 details 안 데이터 표가 대체한다.
 (function () {
-	function tokenColor(name, fallback) {
+	function tokenColor(name) {
 		if (typeof getComputedStyle !== 'function') {
-			return fallback;
+			return '';
 		}
-		var value = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
-		return value || fallback;
+		return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
 	}
 
 	// 팔레트(#1983): 무채색(잉크 계열) + 파랑 액센트 + 상태 3색만 사용한다. 장식적 초록·빨강
 	// 조합 대신 1번 시리즈는 파랑(주 지표), 2번은 잉크 톤(보조 지표)으로 구분한다.
 	var PALETTE = [
-		tokenColor('--admin-accent', '#006fd6'),
-		tokenColor('--admin-ink-2', '#29484b'),
-		tokenColor('--admin-ink-3', '#466467'),
-		tokenColor('--admin-danger', '#b42318')
+		tokenColor('--admin-accent'),
+		tokenColor('--admin-ink-2'),
+		tokenColor('--admin-ink-3'),
+		tokenColor('--admin-chart-series')
 	];
 
 	// #2281 V6-09: 차트를 그리지 못하면(Chart.js 부재·JSON 파싱 실패) 같은 값의 대체 표

--- a/backend/src/main/resources/static/js/operator/report-charts.js
+++ b/backend/src/main/resources/static/js/operator/report-charts.js
@@ -1,11 +1,10 @@
 // Operator report charts read the adjacent fallback table, so no inline JSON is needed.
 (function () {
-	function tokenColor(name, fallback) {
+	function tokenColor(name) {
 		if (typeof getComputedStyle !== 'function') {
-			return fallback;
+			return '';
 		}
-		var value = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
-		return value || fallback;
+		return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
 	}
 
 	// 색 매핑(#2349 PR⑩e 리뷰 반영): dashboard-charts.js PALETTE처럼 인덱스 순서로 색을 배정하면
@@ -17,15 +16,15 @@
 	var GOOD_LABELS = ['완료', '발송 완료'];
 	var DANGER_LABELS = ['실패', '발송 실패'];
 	var NEUTRAL_SEQUENCE = [
-		tokenColor('--admin-accent', '#006fd6'),
-		tokenColor('--admin-ink-2', '#29484b'),
-		tokenColor('--admin-ink-3', '#466467'),
-		tokenColor('--admin-chart-series', '#2f6f9f')
+		tokenColor('--admin-accent'),
+		tokenColor('--admin-ink-2'),
+		tokenColor('--admin-ink-3'),
+		tokenColor('--admin-chart-series')
 	];
 
 	function colorsForLabels(labels) {
-		var goodColor = tokenColor('--admin-good', '#0a705a');
-		var dangerColor = tokenColor('--admin-danger', '#b42318');
+		var goodColor = tokenColor('--admin-good');
+		var dangerColor = tokenColor('--admin-danger');
 		var neutralIndex = 0;
 		return labels.map(function (label) {
 			if (GOOD_LABELS.indexOf(label) !== -1) {

--- a/backend/src/test/java/com/easysubway/admin/web/AdminDesignGuardTest.java
+++ b/backend/src/test/java/com/easysubway/admin/web/AdminDesignGuardTest.java
@@ -14,6 +14,8 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -30,6 +32,9 @@ class AdminDesignGuardTest {
 	private static final String CSS_DATA = "backend/src/main/resources/static/css/admin-data.css";
 	private static final String CSS_ADMIN_V3 = "backend/src/main/resources/static/css/admin-v3.css";
 	private static final String CSS_OPERATOR = "backend/src/main/resources/static/css/operator-v3.css";
+	private static final String COLOR_SYSTEM_JSON = "tools/design/easysubway-color-system.json";
+	private static final Pattern CSS_CUSTOM_PROPERTY = Pattern.compile(
+		"(?m)^\\s*(--[a-z0-9-]+)\\s*:\\s*([^;]+);");
 
 	// import 순서(tokens → foundation → shell → components → data)를 그대로 소유하는 4책임 파일.
 	private static final List<String> RESPONSIBILITY_FILES = List.of(
@@ -89,6 +94,70 @@ class AdminDesignGuardTest {
 		"provenance", "generated", "hash", "gates", "rollback", "approval", "updated", "diff");
 	private static final Pattern STATIC_TH = Pattern.compile("<th\\b([^>]*)>([^<]*)</th>", Pattern.DOTALL);
 	private static final Pattern H2_TAG = Pattern.compile("<h2\\b[^>]*>([^<]*)</h2>", Pattern.DOTALL);
+
+	@Test
+	@DisplayName("색상 JSON version 1의 primitive·semantic property와 관리자 alias가 정확히 일치한다")
+	void colorSystemJsonMatchesAdminTokensAndCompatibilityAliases() throws IOException {
+		JsonNode colorSystem = new ObjectMapper().readTree(read(COLOR_SYSTEM_JSON));
+		assertThat(colorSystem.path("version").asInt()).isEqualTo(1);
+
+		Map<String, String> expectedProperties = new LinkedHashMap<>();
+		JsonNode primitives = colorSystem.path("primitives");
+		assertThat(primitives.size()).as("JSON primitive 수").isEqualTo(25);
+		primitives.properties().forEach(entry ->
+			expectedProperties.put(primitiveProperty(entry.getKey()), entry.getValue().asText()));
+
+		JsonNode semantic = colorSystem.path("semantic");
+		assertThat(semantic.size()).as("JSON semantic 수").isEqualTo(31);
+		semantic.properties().forEach(entry -> expectedProperties.put(
+			primitiveProperty(entry.getKey()), "var(" + primitiveProperty(entry.getValue().asText()) + ")"));
+
+		String tokensCss = read(CSS_TOKENS).replaceAll("(?s)/\\*.*?\\*/", "");
+		Matcher root = Pattern.compile("(?m)^\\s*:root\\s*\\{([^}]*)}", Pattern.DOTALL).matcher(tokensCss);
+		assertThat(root.find()).as(":root token block이 존재한다").isTrue();
+		Map<String, String> cssProperties = cssCustomProperties(root.group(1));
+		assertThat(root.find()).as(":root token block은 하나다").isFalse();
+		Map<String, String> esProperties = new LinkedHashMap<>();
+		cssProperties.forEach((name, value) -> {
+			if (name.startsWith("--es-")) {
+				esProperties.put(name, value);
+			}
+		});
+		assertThat(esProperties).containsExactlyInAnyOrderEntriesOf(expectedProperties);
+
+		Map<String, String> expectedAliases = Map.ofEntries(
+			Map.entry("--admin-bg", "var(--es-surface-scaffold)"),
+			Map.entry("--admin-surface", "var(--es-surface-default)"),
+			Map.entry("--admin-border", "var(--es-border-subtle)"),
+			Map.entry("--admin-border-strong", "var(--es-interaction-secondary-border)"),
+			Map.entry("--admin-header-bg", "var(--es-surface-brand-chrome)"),
+			Map.entry("--admin-ink", "var(--es-content-primary)"),
+			Map.entry("--admin-ink-2", "var(--es-content-secondary)"),
+			Map.entry("--admin-ink-3", "var(--es-content-muted)"),
+			Map.entry("--admin-accent", "var(--es-interaction-primary)"),
+			Map.entry("--admin-accent-soft", "var(--es-interaction-secondary-surface)"),
+			Map.entry("--admin-accent-ink", "var(--es-interaction-on-brand)"),
+			Map.entry("--admin-sidebar-bg", "var(--es-surface-default)"),
+			Map.entry("--admin-sidebar-accent", "var(--es-surface-signature)"),
+			Map.entry("--admin-primary", "var(--es-interaction-primary)"),
+			Map.entry("--admin-primary-hover", "var(--es-interaction-primary-pressed)"),
+			Map.entry("--admin-on-primary", "var(--es-interaction-on-primary)"),
+			Map.entry("--admin-focus", "var(--es-focus-default)"),
+			Map.entry("--admin-focus-on-signature", "var(--es-focus-on-signature)"),
+			Map.entry("--admin-good", "var(--es-status-success-content)"),
+			Map.entry("--admin-warn", "var(--es-status-warning-content)"),
+			Map.entry("--admin-danger", "var(--es-status-danger-content)"),
+			Map.entry("--admin-info", "var(--es-status-info-content)"),
+			Map.entry("--admin-good-soft", "var(--es-status-success-surface)"),
+			Map.entry("--admin-warn-soft", "var(--es-status-warning-surface)"),
+			Map.entry("--admin-danger-soft", "var(--es-status-danger-surface)"),
+			Map.entry("--admin-info-soft", "var(--es-status-info-surface)")
+		);
+		assertThat(expectedAliases).hasSize(26);
+		Map<String, String> actualAliases = new LinkedHashMap<>();
+		expectedAliases.keySet().forEach(name -> actualAliases.put(name, cssProperties.get(name)));
+		assertThat(actualAliases).containsExactlyInAnyOrderEntriesOf(expectedAliases);
+	}
 
 	@Test
 	@DisplayName("admin-v3.css는 tokens → foundation → shell → components → data import manifest다")
@@ -528,6 +597,20 @@ class AdminDesignGuardTest {
 			count++;
 		}
 		return count;
+	}
+
+	private static String primitiveProperty(String token) {
+		return "--es-" + token.replace(".", "-")
+			.replaceAll("([a-z])([A-Z])", "$1-$2").toLowerCase(Locale.ROOT);
+	}
+
+	private static Map<String, String> cssCustomProperties(String css) {
+		Map<String, String> properties = new LinkedHashMap<>();
+		Matcher matcher = CSS_CUSTOM_PROPERTY.matcher(css);
+		while (matcher.find()) {
+			properties.put(matcher.group(1), matcher.group(2).trim());
+		}
+		return properties;
 	}
 
 	private static String rule(String css, String selectorPattern) {

--- a/backend/src/test/java/com/easysubway/admin/web/AdminDesignGuardTest.java
+++ b/backend/src/test/java/com/easysubway/admin/web/AdminDesignGuardTest.java
@@ -186,6 +186,14 @@ class AdminDesignGuardTest {
 			.contains("outline-color: var(--admin-focus-on-signature);");
 		assertThat(rule(read(CSS_OPERATOR), "\\.nav-link\\.active:focus-visible"))
 			.contains("outline-color: var(--admin-focus-on-signature);");
+		assertThat(rule(read(CSS_SHELL), "\\.admin-nav-item\\.is-active"))
+			.contains("color: var(--admin-accent-ink);");
+		assertThat(rule(read(CSS_OPERATOR), "\\.nav-link\\.active"))
+			.contains("color: var(--admin-accent-ink);");
+		assertThat(rule(read(CSS_SHELL), "\\.admin-nav-item:hover:focus-visible"))
+			.contains("outline-color: var(--admin-focus-on-signature);");
+		assertThat(rule(read(CSS_OPERATOR), "\\.nav-link:hover:focus-visible"))
+			.contains("outline-color: var(--admin-focus-on-signature);");
 		assertThat(read(CSS_COMPONENTS)).contains("color: var(--admin-on-primary);");
 		assertThat(read(CSS_OPERATOR)).contains("color: var(--admin-on-primary);");
 

--- a/backend/src/test/java/com/easysubway/admin/web/AdminDesignGuardTest.java
+++ b/backend/src/test/java/com/easysubway/admin/web/AdminDesignGuardTest.java
@@ -170,25 +170,7 @@ class AdminDesignGuardTest {
 	void adminAndOperatorColorConsumersUseSemanticTokensOnly() throws IOException {
 		List<String> rawColors = new ArrayList<>();
 		for (String path : CSS_FILES) {
-			String css = read(path).replaceAll("(?s)/\\*.*?\\*/", "");
-			Matcher colors = HEX_COLOR.matcher(css);
-			while (colors.find()) {
-				String color = colors.group();
-				boolean allowedTokenPrimitive = path.equals(CSS_TOKENS)
-					&& css.substring(0, colors.start()).lastIndexOf("--es-")
-						> css.substring(0, colors.start()).lastIndexOf(";");
-				boolean allowedChartSeries = path.equals(CSS_TOKENS)
-					&& color.equalsIgnoreCase("#2F6F9F")
-					&& css.substring(0, colors.start()).lastIndexOf("--admin-chart-series")
-						> css.substring(0, colors.start()).lastIndexOf(";");
-				boolean allowedDangerHover = path.equals(CSS_TOKENS)
-					&& color.equalsIgnoreCase("#000")
-					&& css.substring(0, colors.start()).lastIndexOf("--admin-danger-hover")
-						> css.substring(0, colors.start()).lastIndexOf(";");
-				if (!allowedTokenPrimitive && !allowedChartSeries && !allowedDangerHover) {
-					rawColors.add(path + ": " + color);
-				}
-			}
+			rawColors.addAll(rawColors(path, read(path)));
 		}
 		assertThat(rawColors).as("token 선언 밖 CSS raw color: %s", rawColors).isEmpty();
 
@@ -229,6 +211,53 @@ class AdminDesignGuardTest {
 			.contains("tokenColor('--admin-warn')")
 			.contains("tokenColor('--admin-ink-3')")
 			.doesNotContain("--admin-chart-series");
+		String operatorReportCharts = read(JS_OPERATOR_REPORT_CHARTS);
+		assertThat(operatorReportCharts)
+			.contains("var GOOD_LABELS = ['완료', '발송 완료'];")
+			.contains("var DANGER_LABELS = ['실패', '발송 실패'];")
+			.contains("var goodColor = tokenColor('--admin-good');")
+			.contains("var dangerColor = tokenColor('--admin-danger');")
+			.contains("var NEUTRAL_SEQUENCE = [\n"
+				+ "\t\ttokenColor('--admin-accent'),\n"
+				+ "\t\ttokenColor('--admin-ink-2'),\n"
+				+ "\t\ttokenColor('--admin-ink-3'),\n"
+				+ "\t\ttokenColor('--admin-chart-series')\n"
+				+ "\t];")
+			.contains("if (GOOD_LABELS.indexOf(label) !== -1) {\n\t\t\t\treturn goodColor;")
+			.contains("if (DANGER_LABELS.indexOf(label) !== -1) {\n\t\t\t\treturn dangerColor;");
+	}
+
+	@Test
+	void rawColorGuardRejectsRawHexInsideAlias() {
+		assertThat(rawColors(CSS_TOKENS,
+			":root { --new-alias: color-mix(in srgb, var(--es-surface-default), #123456); }"))
+			.containsExactly(CSS_TOKENS + ": #123456");
+	}
+
+	private static List<String> rawColors(String path, String source) {
+		String css = source.replaceAll("(?s)/\\*.*?\\*/", "");
+		List<String> rawColors = new ArrayList<>();
+		Matcher colors = HEX_COLOR.matcher(css);
+		while (colors.find()) {
+			String color = colors.group();
+			String preceding = css.substring(0, colors.start());
+			int declarationStart = Math.max(preceding.lastIndexOf(';'), preceding.lastIndexOf('{')) + 1;
+			String declaration = preceding.substring(declarationStart);
+			Matcher declarationName = Pattern.compile("\\s*(--[a-z0-9-]+)\\s*:").matcher(declaration);
+			String propertyName = declarationName.find() ? declarationName.group(1) : "";
+			boolean allowedTokenPrimitive = path.equals(CSS_TOKENS)
+				&& propertyName.startsWith("--es-");
+			boolean allowedChartSeries = path.equals(CSS_TOKENS)
+				&& color.equalsIgnoreCase("#2F6F9F")
+				&& propertyName.equals("--admin-chart-series");
+			boolean allowedDangerHover = path.equals(CSS_TOKENS)
+				&& color.equalsIgnoreCase("#000")
+				&& propertyName.equals("--admin-danger-hover");
+			if (!allowedTokenPrimitive && !allowedChartSeries && !allowedDangerHover) {
+				rawColors.add(path + ": " + color);
+			}
+		}
+		return rawColors;
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/admin/web/AdminDesignGuardTest.java
+++ b/backend/src/test/java/com/easysubway/admin/web/AdminDesignGuardTest.java
@@ -203,6 +203,9 @@ class AdminDesignGuardTest {
 			.contains("border-left-color: var(--admin-sidebar-accent-border);");
 		assertThat(rule(read(CSS_OPERATOR), "\\.nav-link\\.active"))
 			.contains("border-left-color: var(--admin-sidebar-accent-border);");
+		assertThat(rule(read(CSS_DATA),
+			"\\.admin-v3 \\.timeline \\.timeline-current \\.timeline-time"))
+			.contains("color: var(--admin-ink-2);");
 		assertThat(read(CSS_COMPONENTS)).contains("color: var(--admin-on-primary);");
 		assertThat(read(CSS_OPERATOR)).contains("color: var(--admin-on-primary);");
 

--- a/backend/src/test/java/com/easysubway/admin/web/AdminDesignGuardTest.java
+++ b/backend/src/test/java/com/easysubway/admin/web/AdminDesignGuardTest.java
@@ -145,6 +145,7 @@ class AdminDesignGuardTest {
 			Map.entry("--admin-accent-ink", "var(--es-interaction-on-brand)"),
 			Map.entry("--admin-sidebar-bg", "var(--es-surface-default)"),
 			Map.entry("--admin-sidebar-accent", "var(--es-surface-signature)"),
+			Map.entry("--admin-sidebar-accent-border", "var(--es-interaction-on-signature-border)"),
 			Map.entry("--admin-primary", "var(--es-interaction-primary)"),
 			Map.entry("--admin-primary-hover", "var(--es-interaction-primary-pressed)"),
 			Map.entry("--admin-on-primary", "var(--es-interaction-on-primary)"),
@@ -159,7 +160,7 @@ class AdminDesignGuardTest {
 			Map.entry("--admin-danger-soft", "var(--es-status-danger-surface)"),
 			Map.entry("--admin-info-soft", "var(--es-status-info-surface)")
 		);
-		assertThat(expectedAliases).hasSize(26);
+		assertThat(expectedAliases).hasSize(27);
 		Map<String, String> actualAliases = new LinkedHashMap<>();
 		expectedAliases.keySet().forEach(name -> actualAliases.put(name, cssProperties.get(name)));
 		assertThat(actualAliases).containsExactlyInAnyOrderEntriesOf(expectedAliases);
@@ -194,6 +195,14 @@ class AdminDesignGuardTest {
 			.contains("outline-color: var(--admin-focus-on-signature);");
 		assertThat(rule(read(CSS_OPERATOR), "\\.nav-link:hover:focus-visible"))
 			.contains("outline-color: var(--admin-focus-on-signature);");
+		assertThat(rule(read(CSS_SHELL), "\\.admin-nav-item:hover"))
+			.contains("border-left-color: var(--admin-sidebar-accent-border);");
+		assertThat(rule(read(CSS_SHELL), "\\.admin-nav-item\\.is-active"))
+			.contains("border-left-color: var(--admin-sidebar-accent-border);");
+		assertThat(rule(read(CSS_OPERATOR), "\\.nav-link:hover"))
+			.contains("border-left-color: var(--admin-sidebar-accent-border);");
+		assertThat(rule(read(CSS_OPERATOR), "\\.nav-link\\.active"))
+			.contains("border-left-color: var(--admin-sidebar-accent-border);");
 		assertThat(read(CSS_COMPONENTS)).contains("color: var(--admin-on-primary);");
 		assertThat(read(CSS_OPERATOR)).contains("color: var(--admin-on-primary);");
 

--- a/backend/src/test/java/com/easysubway/admin/web/AdminDesignGuardTest.java
+++ b/backend/src/test/java/com/easysubway/admin/web/AdminDesignGuardTest.java
@@ -32,9 +32,15 @@ class AdminDesignGuardTest {
 	private static final String CSS_DATA = "backend/src/main/resources/static/css/admin-data.css";
 	private static final String CSS_ADMIN_V3 = "backend/src/main/resources/static/css/admin-v3.css";
 	private static final String CSS_OPERATOR = "backend/src/main/resources/static/css/operator-v3.css";
+	private static final String JS_DASHBOARD_CHARTS = "backend/src/main/resources/static/js/admin/dashboard-charts.js";
+	private static final String JS_BATCH_HISTORY_CHARTS = "backend/src/main/resources/static/js/admin/batch-history-charts.js";
+	private static final String JS_OPERATOR_REPORT_CHARTS = "backend/src/main/resources/static/js/operator/report-charts.js";
 	private static final String COLOR_SYSTEM_JSON = "tools/design/easysubway-color-system.json";
 	private static final Pattern CSS_CUSTOM_PROPERTY = Pattern.compile(
 		"(?m)^\\s*(--[a-z0-9-]+)\\s*:\\s*([^;]+);");
+	private static final Pattern HEX_COLOR = Pattern.compile("#[0-9a-fA-F]{3,8}\\b");
+	private static final List<String> CHART_JS_FILES = List.of(
+		JS_DASHBOARD_CHARTS, JS_BATCH_HISTORY_CHARTS, JS_OPERATOR_REPORT_CHARTS);
 
 	// import 순서(tokens → foundation → shell → components → data)를 그대로 소유하는 4책임 파일.
 	private static final List<String> RESPONSIBILITY_FILES = List.of(
@@ -157,6 +163,72 @@ class AdminDesignGuardTest {
 		Map<String, String> actualAliases = new LinkedHashMap<>();
 		expectedAliases.keySet().forEach(name -> actualAliases.put(name, cssProperties.get(name)));
 		assertThat(actualAliases).containsExactlyInAnyOrderEntriesOf(expectedAliases);
+	}
+
+	@Test
+	@DisplayName("관리자·운영자 색 소비자는 semantic token과 chart 역할을 분리한다")
+	void adminAndOperatorColorConsumersUseSemanticTokensOnly() throws IOException {
+		List<String> rawColors = new ArrayList<>();
+		for (String path : CSS_FILES) {
+			String css = read(path).replaceAll("(?s)/\\*.*?\\*/", "");
+			Matcher colors = HEX_COLOR.matcher(css);
+			while (colors.find()) {
+				String color = colors.group();
+				boolean allowedTokenPrimitive = path.equals(CSS_TOKENS)
+					&& css.substring(0, colors.start()).lastIndexOf("--es-")
+						> css.substring(0, colors.start()).lastIndexOf(";");
+				boolean allowedChartSeries = path.equals(CSS_TOKENS)
+					&& color.equalsIgnoreCase("#2F6F9F")
+					&& css.substring(0, colors.start()).lastIndexOf("--admin-chart-series")
+						> css.substring(0, colors.start()).lastIndexOf(";");
+				boolean allowedDangerHover = path.equals(CSS_TOKENS)
+					&& color.equalsIgnoreCase("#000")
+					&& css.substring(0, colors.start()).lastIndexOf("--admin-danger-hover")
+						> css.substring(0, colors.start()).lastIndexOf(";");
+				if (!allowedTokenPrimitive && !allowedChartSeries && !allowedDangerHover) {
+					rawColors.add(path + ": " + color);
+				}
+			}
+		}
+		assertThat(rawColors).as("token 선언 밖 CSS raw color: %s", rawColors).isEmpty();
+
+		assertThat(rule(read(CSS_FOUNDATION),
+			"\\.admin-v3 a:focus-visible,\\s*\\.admin-v3 button:focus-visible,\\s*"
+				+ "\\.admin-v3 input:focus-visible,\\s*\\.admin-v3 select:focus-visible,\\s*"
+				+ "\\.admin-v3 textarea:focus-visible,\\s*\\.admin-v3 \\.admin-panel:focus-visible"))
+			.contains("outline: 3px solid var(--admin-focus);");
+		assertThat(rule(read(CSS_OPERATOR),
+			"a:focus-visible,\\s*button:focus-visible,\\s*input:focus-visible"))
+			.contains("outline: 3px solid var(--admin-focus);");
+		assertThat(rule(read(CSS_SHELL), "\\.admin-nav-item\\.is-active:focus-visible"))
+			.contains("outline-color: var(--admin-focus-on-signature);");
+		assertThat(rule(read(CSS_OPERATOR), "\\.nav-link\\.active:focus-visible"))
+			.contains("outline-color: var(--admin-focus-on-signature);");
+		assertThat(read(CSS_COMPONENTS)).contains("color: var(--admin-on-primary);");
+		assertThat(read(CSS_OPERATOR)).contains("color: var(--admin-on-primary);");
+
+		for (String path : CHART_JS_FILES) {
+			String js = read(path);
+			assertThat(js).as("%s tokenColor fallback 금지", path)
+				.contains("function tokenColor(name) {")
+				.doesNotContain("function tokenColor(name,");
+			assertThat(js.replaceAll("(?m)//.*$", ""))
+				.as("%s raw HEX fallback 금지", path)
+				.doesNotContainPattern(HEX_COLOR);
+		}
+
+		String dashboardCharts = read(JS_DASHBOARD_CHARTS);
+		assertThat(dashboardCharts)
+			.contains("tokenColor('--admin-chart-series')")
+			.doesNotContain("tokenColor('--admin-good')")
+			.doesNotContain("tokenColor('--admin-warn')")
+			.doesNotContain("tokenColor('--admin-danger')");
+		assertThat(read(JS_BATCH_HISTORY_CHARTS))
+			.contains("tokenColor('--admin-good')")
+			.contains("tokenColor('--admin-danger')")
+			.contains("tokenColor('--admin-warn')")
+			.contains("tokenColor('--admin-ink-3')")
+			.doesNotContain("--admin-chart-series");
 	}
 
 	@Test

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -13446,7 +13446,7 @@ test("관리자 v3 공통 shell은 접근성 chrome과 inline style 제한을 �
   assert.match(formErrorsFragment, /id="form-error-summary-title"/);
   assert.match(paginationFragment, /aria-current=\$\{pageLink\.current \? 'page' : null\}/);
   assert.match(adminCss, /\.admin-v3 a:focus-visible/);
-  assert.match(adminCss, /outline: 3px solid #ffbf47/);
+  assert.match(adminCss, /outline: 3px solid var\(--admin-focus\)/);
   assert.match(adminCss, /\.admin-topbar-row/);
   // #2071 scroll 소유권 계약: 관리자 table의 horizontal scroll은 .admin-table-scroll wrapper가 단독 소유한다.
   // .admin-main / .admin-panel / .admin-card 는 scroll을 소유하지 않는다(overflow-x: visible).


### PR DESCRIPTION
## 관련 이슈

Closes #2644
Refs #2632

## 작업 배경

관리자·운영자 CSS와 chart JavaScript가 구 파랑·중립색 및 raw fallback을 직접 사용해
`easysubway-color-system.json` version 1과 드리프트했습니다. HTML과 화면 구조는
유지하고 모던한 시그니처 컬러를 역할 기반으로 소비하도록 정리합니다.

## 작업 내용

- JSON 25개 Primitive·31개 Semantic을 `--es-*` CSS custom property로 고정했습니다.
- 기존 `--admin-*` compatibility alias를 Semantic에 연결하고 focus/status/primary 소비를 역할별로 분리했습니다.
- chart JS는 raw HEX fallback 없이 CSS token만 읽고, 상태색과 중립 chart series를 분리했습니다.
- raw HEX 허용을 실제 token primitive 선언으로 한정하고 alias 우회와 chart 역할 드리프트를 회귀 테스트로 차단했습니다.
- HTML, layout, 크기, 타이포, radius, shadow, chart data와 지도는 변경하지 않았고 색 상태 override selector만 추가했습니다.

## 검증

- `backend/gradlew -p backend test --no-daemon --tests com.easysubway.admin.web.AdminDesignGuardTest.rawColorGuardRejectsRawHexInsideAlias` — TDD RED→GREEN PASS
- `backend/gradlew -p backend test --no-daemon --tests com.easysubway.admin.web.AdminDesignGuardTest --tests com.easysubway.operator.adapter.in.web.OperatorUiV4ContractTest` — PASS, 21 tests
- 마지막 대비 보정 후 `backend/gradlew -p backend test --no-daemon --tests com.easysubway.admin.web.AdminDesignGuardTest` — PASS, 19 tests
- `node --test tools/ci/repository-contract.test.mjs` — PASS
- `git diff --check` — PASS
- current-head Codex fallback Review — actionable 0 ([Review 4789122532](https://github.com/AquilaXk/easysubway/pull/2651#pullrequestreview-4789122532))
- 전체 Backend/Admin QA/Repository regression은 GitHub CI를 정식 gate로 사용합니다.

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| JSON↔CSS 정합 | 관리자·운영자 | `AdminDesignGuardTest` exact map | current-head 로컬 19 tests | PASS |
| raw color·chart 역할 | 관리자·운영자 | alias 우회 RED→GREEN + exact mapping | `AdminDesignGuardTest` | PASS |
| DOM·layout 비변경 | 관리자·운영자 | base/head diff + current-head Review | CSS/JS/test 11파일, HTML 변경 없음 | PASS |
| 대표 화면·접근성 | Chrome CI | 실제 backend + 6 viewport + 200% text + 400% reflow | [Admin QA Gates](https://github.com/AquilaXk/easysubway/actions/runs/30283131220/job/90034362021), `admin-accessibility-qa` screenshots | PASS |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 영향 없음
- realtime contract: 영향 없음
- backend identity: 변경 없음

## 리뷰어 메모

- `admin-tokens.css`의 JSON 정적 사본과 `--admin-*` alias가 첫 검토 지점입니다.
- `AdminDesignGuardTest`는 token declaration/raw HEX와 chart status/neutral 역할을 함께 고정합니다.
- JS `tokenColor`는 CSS 값이 없으면 빈 문자열을 반환하며 raw 색 fallback을 만들지 않습니다.

## 리스크

- 관리자·운영자 전역 색 인상이 바뀌는 A등급 변경입니다. fresh GitHub Review와 required CI, 실제 browser Admin QA artifact를 확인한 뒤 auto-merge합니다.
- 배포·DB·API·route·지도 영향은 없습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다. (quota 제한)
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 없어 CD 확인이 필요하지 않다.
