### PR TITLE
[Build] candidate gate에 배포 artifact evidence 결속

### DIFF
--- a/tools/datapack/nationwide-candidate-coverage-gate.test.mjs
+++ b/tools/datapack/nationwide-candidate-coverage-gate.test.mjs
@@ -514,10 +514,76 @@ function forbiddenKeyPaths(node, nodePath = "$") {
   }
   if (!node || typeof node !== "object") return [];
   return Object.entries(node).flatMap(([key, value]) => [
-    ...(FORBIDDEN_EVIDENCE_KEYS.includes(key) ? [`${nodePath}.${key}`] : []),
+    ...(FORBIDDEN_EVIDENCE_KEYS.includes(key) && `${nodePath}.${key}` !== "$.deployedArtifact.sqliteSha256"
+      ? [`${nodePath}.${key}`]
+      : []),
     ...forbiddenKeyPaths(value, `${nodePath}.${key}`),
   ]);
 }
+
+test("candidate evidence는 배포 artifact row count와 transition을 함께 기록한다", async () => {
+  const evidence = await readJson(EVIDENCE_PATH);
+
+  assert.deepEqual(evidence.deployedArtifact, {
+    verifierPath: "tools/datapack/verify-production-pack-artifact-identity.mjs",
+    packId: "capital",
+    gzipSha256: "dddfba965fb735efccc01d5f4501a0c4a4e9cf7d2a6bd2324bbeaef47c03141e",
+    sqliteSha256: "afefead8a5cb8c3c1121e825e37d22a340d277cb98279ba5c218ff5c2adcd18b",
+    byteSize: 1463806,
+    rowCounts: {
+      catalog_metadata: 2,
+      data_quality_records: 5,
+      facilities: 7,
+      facility_status_snapshots: 0,
+      fare_discounts: 0,
+      fare_rules: 0,
+      fare_zones: 0,
+      internal_route_edges: 1,
+      internal_route_nodes: 2,
+      lines: 37,
+      network_edges: 2178,
+      official_od_fare_quotes: 6,
+      operators: 22,
+      out_of_station_transfer_links: 0,
+      realtime_provider_line_mappings: 0,
+      realtime_provider_station_mappings: 0,
+      route_map_line_tracks: 48,
+      route_map_positions: 1102,
+      route_service_artifact_evidence: 1,
+      service_calendar_dates: 28,
+      service_calendars: 2,
+      station_accessibility_summaries: 0,
+      station_aliases: 18,
+      station_car_door_hints: 35,
+      station_exits: 1,
+      station_facility_evidence: 8,
+      station_fare_zones: 0,
+      station_lines: 1108,
+      station_pathway_edges: 0,
+      station_pathway_nodes: 0,
+      stations: 946,
+      transfer_rules: 0,
+      transit_feed_info: 1,
+      transit_frequencies: 0,
+      transit_routes: 2,
+      transit_stop_times: 932,
+      transit_trips: 466,
+    },
+    networkEdgeCounts: {
+      total: 2178,
+      provenanceComplete: 652,
+      strictEligible: 652,
+    },
+  });
+  assert.deepEqual(evidence.transitions.find((entry) => entry.requirementKey === PILOT_REQUIREMENT_KEY), {
+    requirementKey: PILOT_REQUIREMENT_KEY,
+    before: "MISSING",
+    after: "SUPPORTED",
+    sourceIds: [CAPITAL_SEOUL_ROUTE_MAP_SOURCE_ID, PILOT_SOURCE_ID],
+    coveredFields: 2,
+    denominator: 2,
+  });
+});
 
 test("커밋된 candidate 게이트 evidence는 현행 입력에서 바이트 단위로 재생성된다", async () => {
   const workspace = await mkdtemp(path.join(tmpdir(), "nationwide-candidate-gate-"));

--- a/tools/datapack/nationwide-candidate-coverage-gate.test.mjs
+++ b/tools/datapack/nationwide-candidate-coverage-gate.test.mjs
@@ -2962,6 +2962,7 @@ test("누락된 재기술은 emit fixture를 남기지 않고 거부된다", asy
         resolutionsInput: { path: RESOLUTIONS_PATH, sha256: "e".repeat(64) },
         workDir: workspace,
         emitFixturePath,
+        verifyDeployedArtifact: async () => ({}),
       }),
       /line-scope redescriptions must exactly match the actual required set/,
     );

--- a/tools/datapack/nationwide-candidate-coverage-gate.test.mjs
+++ b/tools/datapack/nationwide-candidate-coverage-gate.test.mjs
@@ -1399,6 +1399,34 @@ test("candidate spec validation seam은 production 채널을 거부한다", asyn
   );
 });
 
+test("배포 artifact identity는 SUPPORTED 판정 전에 검증한다", async () => {
+  const spec = await readJson(SPEC_PATH);
+  const inventory = await readJson(INVENTORY_PATH);
+  spec.packDataInclusions = [{
+    ...spec.packDataInclusions[0],
+    materializer: "test://supported-judgment",
+  }];
+
+  await assert.rejects(
+    runNationwideCandidateCoverageGate({
+      spec,
+      specInput: { path: SPEC_PATH, sha256: "a".repeat(64) },
+      targetsInput: { path: TARGETS_PATH, sha256: "b".repeat(64) },
+      inventory,
+      inventoryInput: { path: INVENTORY_PATH, sha256: "c".repeat(64) },
+      resolutionPlanInput: { path: RESOLUTION_PLAN_PATH, sha256: "d".repeat(64) },
+      resolutionsInput: { path: RESOLUTIONS_PATH, sha256: "e".repeat(64) },
+      workDir: path.join(tmpdir(), "nationwide-candidate-gate-artifact-ordering"),
+      verifyDeployedArtifact: async () => { throw new Error("deployed artifact identity mismatch"); },
+      materializers: new Map([["test://supported-judgment", {
+        inputs: { paths: ["stationMapPath"], linePaths: ["topologySnapshotPath", "timetableSnapshotPath"] },
+        materialize: () => { throw new Error("SUPPORTED judgment reached"); },
+      }]]),
+    }),
+    /deployed artifact identity mismatch/,
+  );
+});
+
 test("declared transition seam은 실제 SUPPORTED non-transition을 거부한다", async () => {
   const spec = await readJson(SPEC_PATH);
   const evidence = await readJson(EVIDENCE_PATH);

--- a/tools/datapack/reports/nationwide-candidate-coverage-gate.json
+++ b/tools/datapack/reports/nationwide-candidate-coverage-gate.json
@@ -35,6 +35,57 @@
     "reasonCodesKo": "NO_SUPPORTING_ROWS_FOR_LINE — 그 scope를 뒷받침하는 official/field-verified provenance 행이 조립 결과에 필드마다 0건임을 하네스가 확인한다(아래 supportingRecordCountByField). 사유가 자유 서술로만 남지 않도록 코드마다 실측 술어를 하나씩 둔다. 새 사유 코드는 그 코드가 요구하는 실측 술어를 함께 넣어야만 allowlist에 오른다.",
     "scopeKo": "선언 단위는 (sourceId, sourceDomain, lineId)다. 선언은 그 재기술이 declare한 requirement 키 안에서만 고를 수 있어 도메인 전체·소스 전체·와일드카드 선언이 들어올 통로가 없고, 한 재기술의 노선을 전부 선언하면 그 재기술이 아무것도 열지 않게 되므로 거부된다."
   },
+  "deployedArtifact": {
+    "byteSize": 1463806,
+    "gzipSha256": "dddfba965fb735efccc01d5f4501a0c4a4e9cf7d2a6bd2324bbeaef47c03141e",
+    "networkEdgeCounts": {
+      "provenanceComplete": 652,
+      "strictEligible": 652,
+      "total": 2178
+    },
+    "packId": "capital",
+    "rowCounts": {
+      "catalog_metadata": 2,
+      "data_quality_records": 5,
+      "facilities": 7,
+      "facility_status_snapshots": 0,
+      "fare_discounts": 0,
+      "fare_rules": 0,
+      "fare_zones": 0,
+      "internal_route_edges": 1,
+      "internal_route_nodes": 2,
+      "lines": 37,
+      "network_edges": 2178,
+      "official_od_fare_quotes": 6,
+      "operators": 22,
+      "out_of_station_transfer_links": 0,
+      "realtime_provider_line_mappings": 0,
+      "realtime_provider_station_mappings": 0,
+      "route_map_line_tracks": 48,
+      "route_map_positions": 1102,
+      "route_service_artifact_evidence": 1,
+      "service_calendar_dates": 28,
+      "service_calendars": 2,
+      "station_accessibility_summaries": 0,
+      "station_aliases": 18,
+      "station_car_door_hints": 35,
+      "station_exits": 1,
+      "station_facility_evidence": 8,
+      "station_fare_zones": 0,
+      "station_lines": 1108,
+      "station_pathway_edges": 0,
+      "station_pathway_nodes": 0,
+      "stations": 946,
+      "transfer_rules": 0,
+      "transit_feed_info": 1,
+      "transit_frequencies": 0,
+      "transit_routes": 2,
+      "transit_stop_times": 932,
+      "transit_trips": 466
+    },
+    "sqliteSha256": "afefead8a5cb8c3c1121e825e37d22a340d277cb98279ba5c218ff5c2adcd18b",
+    "verifierPath": "tools/datapack/verify-production-pack-artifact-identity.mjs"
+  },
   "determinism": {
     "excludedAxes": [
       "candidate.manifestSha256",
@@ -1710,6 +1761,7 @@
   "readingGuide": {
     "baselineSemanticsKo": "baseline은 저장소의 특정 과거 커밋 상태가 아니라 '등재된 재기술을 걷어낸' counterfactual이다. 아래 lineScopeRedescriptions에 등재된 소스의 coverageScope.lineIds만 fixture와 inventory 사본에서 지운 실행이며, 편입 행은 두 variant에 동일하게 들어간다. 따라서 이 evidence의 전이는 '어떤 소스의 line-scope 기술이 그 requirement를 여는가'를 뜻하고, 그 소스의 line-scope가 admission 정본에 언제 들어왔는지(대구 소스는 #2549 이전부터 line-scope였다)와는 다른 축이다. 전이를 뒷받침한 소스가 등재 목록과 정확히 같은지는 하네스가 fail closed로 확인한다.",
     "denominatorSemanticsKo": "pilotRequirements의 denominator·coveredFields는 domain requiredFields 개수이지 데이터 행 수가 아니다. route_map_positions의 denominator 2는 필수 필드 2개(route_map_position·route_map_label_polygon)를 뜻하며 역 2개나 행 2개를 뜻하지 않는다. 실제로 그 판정을 뒷받침한 provenance 행 수는 필드별 supportingRecordCountByField에 따로 기록한다.",
+    "deployedArtifactSemanticsKo": "reviewed-seed counterfactual 전이는 line-scope 재기술의 판정 축이고, shipped artifact row counts는 실제 배포 팩의 별도 축이다.",
     "supportedScopeKo": "이 evidence는 SUPPORTED 축만 기록하므로 전국 gap 총량 판독에 쓰면 안 된다. 전국 진행 집계는 tools/datapack/reports/nationwide-coverage-tally.json이 정본이다.",
     "variantComparisonKo": "전이 판정은 두 variant의 상대 비교다. baseline SUPPORTED 총량은 승계 팩의 다른 소스가 line-scope를 갖게 되면 함께 늘어날 수 있고, 하네스는 파일럿 키가 baseline에 없고 lineScoped가 baseline ∪ 파일럿 키와 정확히 같은지만 fail closed로 본다."
   },

--- a/tools/datapack/run-nationwide-candidate-coverage-gate.mjs
+++ b/tools/datapack/run-nationwide-candidate-coverage-gate.mjs
@@ -61,6 +61,7 @@ import { promisify } from "node:util";
 
 import { codepointCompare } from "../lib/codepoint-compare.mjs";
 import { isMainModule } from "../lib/is-main-module.mjs";
+import { verifyProductionPackArtifactIdentity } from "./verify-production-pack-artifact-identity.mjs";
 import {
   parseMolitDaeguStationMappings,
   parseMolitDaejeonStationMappings,
@@ -130,6 +131,10 @@ const ALLOWED_FLAGS = new Set([
 const SPEC_ARTIFACT_KIND = "nationwide-candidate-pack-spec";
 const CANDIDATE_ARTIFACT_KIND = "production";
 const CANDIDATE_MANIFEST_CHANNEL = "candidate";
+const DEPLOYED_ARTIFACT_BUILD_SPEC_PATH = "tools/datapack/release/candidate-build-spec.json";
+const DEPLOYED_ARTIFACT_ASSET_PATH = "apps/mobile/assets/datapacks/capital.sqlite.gz";
+const DEPLOYED_ARTIFACT_INDEX_PATH = "apps/mobile/assets/datapacks/index.json";
+const DEPLOYED_ARTIFACT_PACK_ID = "capital";
 // 예약 TLD(.invalid, RFC 2606)라 어떤 게시 경로에서도 해석되지 않는다.
 const NON_PUBLISHABLE_HOST = "easysubway-datapack-candidate.invalid";
 const SIGNING_MODE = "EPHEMERAL_RSA_2048";
@@ -315,7 +320,14 @@ export async function runNationwideCandidateCoverageGate({
   // 않으므로 기본 allowlist가 그대로 적용되고, spec은 이 맵에 항목을 추가할 수 없다 — "spec 편집만으로
   // 임의 모듈을 실행시킬 수 없다"는 성질은 그대로다.
   materializers = PACK_DATA_MATERIALIZERS,
+  verifyDeployedArtifact = () => verifyProductionPackArtifactIdentity({
+    buildSpecPath: path.join(root, DEPLOYED_ARTIFACT_BUILD_SPEC_PATH),
+    assetPath: path.join(root, DEPLOYED_ARTIFACT_ASSET_PATH),
+    indexPath: path.join(root, DEPLOYED_ARTIFACT_INDEX_PATH),
+    packId: DEPLOYED_ARTIFACT_PACK_ID,
+  }),
 }) {
+  await verifyDeployedArtifact();
   validateNationwideCandidateCoverageSpec(spec, inventory, materializers);
   // 승계 원본도 입력 해시 축에 넣는다. 경로·pack 정체성만 기록하면 원본 좌표 같은 값 drift가
   // evidence를 바이트 동일하게 통과시킨다(구조 drift만 잡히는 상태) — 파일 바이트로 결속한다.

--- a/tools/datapack/run-nationwide-candidate-coverage-gate.mjs
+++ b/tools/datapack/run-nationwide-candidate-coverage-gate.mjs
@@ -35,7 +35,8 @@
 //
 // 결정성:
 //   임시 키로 만든 manifest·pack 서명과 그 서명이 들어간 manifest sha256, 그리고 런타임 SQLite 구현에
-//   좌우되는 sqliteSha256은 evidence에 기록하지 않는다. resolutions 만료(nextReviewAt)는 게이트가
+//   좌우되는 candidate sqliteSha256은 evidence에 기록하지 않는다. 배포 artifact verifier가 확인한
+//   SQLite identity는 후보 산출물과 별도 축으로 기록한다. resolutions 만료(nextReviewAt)는 게이트가
 //   wall-clock으로 판정하므로 그 영향을 받는 EXPLICITLY_UNSUPPORTED·MISSING 집계도 기록하지 않는다.
 //   기록 축은 SUPPORTED 판정과 분모뿐이며 이 축은 오프라인·키 없이 바이트 단위로 재현된다.
 //
@@ -327,7 +328,7 @@ export async function runNationwideCandidateCoverageGate({
     packId: DEPLOYED_ARTIFACT_PACK_ID,
   }),
 }) {
-  await verifyDeployedArtifact();
+  const deployedArtifact = await verifyDeployedArtifact();
   validateNationwideCandidateCoverageSpec(spec, inventory, materializers);
   // 승계 원본도 입력 해시 축에 넣는다. 경로·pack 정체성만 기록하면 원본 좌표 같은 값 drift가
   // evidence를 바이트 동일하게 통과시킨다(구조 drift만 잡히는 상태) — 파일 바이트로 결속한다.
@@ -416,6 +417,7 @@ export async function runNationwideCandidateCoverageGate({
     reports,
     variants,
     signing,
+    deployedArtifact,
   });
 }
 
@@ -1702,7 +1704,7 @@ export function assertDeclaredTransitionsMatchVariants(spec, variants) {
   return nonTransitions;
 }
 
-function buildEvidence({ spec, inputs, packDataInclusions, reports, variants, signing }) {
+function buildEvidence({ spec, inputs, packDataInclusions, reports, variants, signing, deployedArtifact }) {
   const nonTransitions = assertDeclaredNonTransitionsMatchVariants(spec, variants);
   assertEvidenceModelTotals(variants);
   assertCandidateRootPack(spec, reports);
@@ -1740,6 +1742,10 @@ function buildEvidence({ spec, inputs, packDataInclusions, reports, variants, si
     issue: spec.issue,
     parentIssues: [...spec.parentIssues],
     targetVersion: reports.lineScoped.targetVersion,
+    deployedArtifact: {
+      verifierPath: "tools/datapack/verify-production-pack-artifact-identity.mjs",
+      ...deployedArtifact,
+    },
     regeneration: {
       command: regenerationCommand(inputs),
       evidencePath: EVIDENCE_PATH,
@@ -1800,6 +1806,8 @@ function buildEvidence({ spec, inputs, packDataInclusions, reports, variants, si
         + "line-scope 기술이 그 requirement를 여는가'를 뜻하고, 그 소스의 line-scope가 admission 정본에 언제 "
         + "들어왔는지(대구 소스는 #2549 이전부터 line-scope였다)와는 다른 축이다. 전이를 뒷받침한 소스가 등재 "
         + "목록과 정확히 같은지는 하네스가 fail closed로 확인한다.",
+      deployedArtifactSemanticsKo:
+        "reviewed-seed counterfactual 전이는 line-scope 재기술의 판정 축이고, shipped artifact row counts는 실제 배포 팩의 별도 축이다.",
     },
     inputs: Object.fromEntries(
       Object.entries(inputs).map(([name, input]) => [name, { path: input.path, sha256: input.sha256 }]),

--- a/tools/datapack/verify-production-pack-artifact-identity.mjs
+++ b/tools/datapack/verify-production-pack-artifact-identity.mjs
@@ -141,16 +141,19 @@ export async function verifyProductionPackArtifactIdentity({ buildSpecPath, asse
   }
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  const args = parseArgs(process.argv.slice(2));
-  verifyProductionPackArtifactIdentity({
+async function main(argv) {
+  const args = parseArgs(argv);
+  const report = await verifyProductionPackArtifactIdentity({
     buildSpecPath: requiredArg(args, "build-spec"),
     assetPath: requiredArg(args, "asset"),
     indexPath: requiredArg(args, "index"),
     packId: requiredArg(args, "pack-id"),
-  }).then((report) => {
-    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
-  }).catch((error) => {
+  });
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main(process.argv.slice(2)).catch((error) => {
     console.error(error.message);
     process.exitCode = 1;
   });

--- a/tools/datapack/verify-production-pack-artifact-identity.mjs
+++ b/tools/datapack/verify-production-pack-artifact-identity.mjs
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { promisify } from "node:util";
+import { pathToFileURL } from "node:url";
 import { gunzipSync } from "node:zlib";
 
 import { stagedPackPath } from "./lib/manifest-validation.mjs";
@@ -52,12 +53,39 @@ function tableRowCounts(sqlitePath) {
   }
 }
 
-async function main(argv) {
-  const args = parseArgs(argv);
-  const buildSpecPath = path.resolve(requiredArg(args, "build-spec"));
-  const assetPath = path.resolve(requiredArg(args, "asset"));
-  const indexPath = path.resolve(requiredArg(args, "index"));
-  const packId = requiredArg(args, "pack-id");
+function networkEdgeCounts(sqlitePath) {
+  const database = new DatabaseSync(sqlitePath, { readOnly: true });
+  try {
+    const rows = database.prepare(`
+      SELECT source_id, source_snapshot_id, provider_record_hash, provenance_kind,
+             verification_status, last_verified_at, evidence_hash
+      FROM network_edges
+    `).all();
+    const hasValidHash = (value) => /^[0-9a-f]{64}$/.test(value);
+    const hasCompleteProvenance = (row) => row.source_id !== ""
+      && row.source_snapshot_id !== ""
+      && hasValidHash(row.provider_record_hash)
+      && hasValidHash(row.evidence_hash)
+      && row.provenance_kind !== "UNKNOWN"
+      && row.verification_status !== "UNKNOWN"
+      && row.last_verified_at != null;
+    const provenanceComplete = rows.filter(hasCompleteProvenance);
+    return {
+      total: rows.length,
+      provenanceComplete: provenanceComplete.length,
+      strictEligible: provenanceComplete.filter((row) => row.verification_status === "VERIFIED"
+        && ["OFFICIAL_SOURCE", "OPERATOR_CONFIRMED", "FIELD_SURVEY"].includes(row.provenance_kind)
+        && !/^([0-9a-f])\1{63}$/.test(row.evidence_hash)).length,
+    };
+  } finally {
+    database.close();
+  }
+}
+
+export async function verifyProductionPackArtifactIdentity({ buildSpecPath, assetPath, indexPath, packId }) {
+  buildSpecPath = path.resolve(buildSpecPath);
+  assetPath = path.resolve(assetPath);
+  indexPath = path.resolve(indexPath);
   const outputDir = await mkdtemp(path.join(tmpdir(), "easysubway-production-pack-identity-"));
   try {
     // ponytail: manifest signatures are outside this SQLite identity gate, so CI needs no publish private key.
@@ -100,19 +128,30 @@ async function main(argv) {
     assertEqual(indexPacks[0].sqliteSha256, sqliteSha256, "index SQLite sha256");
     assertEqual(indexPacks[0].byteSize, byteSize, "index byteSize");
 
-    process.stdout.write(`${JSON.stringify({
+    return {
       packId,
       gzipSha256,
       sqliteSha256,
       byteSize,
       rowCounts: tableRowCounts(builtPath.replace(/\.gz$/, "")),
-    }, null, 2)}\n`);
+      networkEdgeCounts: networkEdgeCounts(builtPath.replace(/\.gz$/, "")),
+    };
   } finally {
     await rm(outputDir, { recursive: true, force: true });
   }
 }
 
-main(process.argv.slice(2)).catch((error) => {
-  console.error(error.message);
-  process.exitCode = 1;
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const args = parseArgs(process.argv.slice(2));
+  verifyProductionPackArtifactIdentity({
+    buildSpecPath: requiredArg(args, "build-spec"),
+    assetPath: requiredArg(args, "asset"),
+    indexPath: requiredArg(args, "index"),
+    packId: requiredArg(args, "pack-id"),
+  }).then((report) => {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  }).catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/tools/datapack/verify-production-pack-artifact-identity.mjs
+++ b/tools/datapack/verify-production-pack-artifact-identity.mjs
@@ -124,6 +124,7 @@ export async function verifyProductionPackArtifactIdentity({ buildSpecPath, asse
     const index = JSON.parse(await readFile(indexPath, "utf8"));
     const indexPacks = index.packs?.filter(({ id }) => id === packId) ?? [];
     if (indexPacks.length !== 1) throw new Error(`index must contain exactly one pack: ${packId}`);
+    assertEqual(indexPacks[0].asset, path.relative(path.join(root, "apps/mobile"), assetPath).split(path.sep).join("/"), "index asset");
     assertEqual(indexPacks[0].sha256, gzipSha256, "index sha256");
     assertEqual(indexPacks[0].sqliteSha256, sqliteSha256, "index SQLite sha256");
     assertEqual(indexPacks[0].byteSize, byteSize, "index byteSize");

--- a/tools/datapack/verify-production-pack-artifact-identity.test.mjs
+++ b/tools/datapack/verify-production-pack-artifact-identity.test.mjs
@@ -9,6 +9,7 @@ import { promisify } from "node:util";
 import test from "node:test";
 import { gunzipSync } from "node:zlib";
 import { normalizeUnverifiedNetworkEdgeStates } from "./build-datapack.mjs";
+import { verifyProductionPackArtifactIdentity } from "./verify-production-pack-artifact-identity.mjs";
 
 const execFileAsync = promisify(execFile);
 const root = path.resolve(import.meta.dirname, "../..");
@@ -169,6 +170,12 @@ test("production build와 bundled asset/index의 artifact identity를 exact-matc
       provenanceComplete: 652,
       strictEligible: 652,
     });
+    assert.deepEqual(await verifyProductionPackArtifactIdentity({
+      buildSpecPath: "tools/datapack/release/candidate-build-spec.json",
+      assetPath,
+      indexPath,
+      packId: "capital",
+    }), report);
 
     const index = JSON.parse(await readFile(indexPath, "utf8"));
     index.packs[0].sha256 = "f".repeat(64);

--- a/tools/datapack/verify-production-pack-artifact-identity.test.mjs
+++ b/tools/datapack/verify-production-pack-artifact-identity.test.mjs
@@ -164,6 +164,11 @@ test("production build와 bundled asset/index의 artifact identity를 exact-matc
     assert.equal(report.sqliteSha256, pack.sqliteSha256);
     assert.equal(report.byteSize, pack.sizeBytes);
     assert.ok(report.rowCounts.stations > 0);
+    assert.deepEqual(report.networkEdgeCounts, {
+      total: 2178,
+      provenanceComplete: 652,
+      strictEligible: 652,
+    });
 
     const index = JSON.parse(await readFile(indexPath, "utf8"));
     index.packs[0].sha256 = "f".repeat(64);

--- a/tools/datapack/verify-production-pack-artifact-identity.test.mjs
+++ b/tools/datapack/verify-production-pack-artifact-identity.test.mjs
@@ -46,7 +46,7 @@ test("production producer는 미승격 network edge와 역외 환승 link 상태
 test("production build와 bundled asset/index의 artifact identity를 exact-match한다", async () => {
   const workspace = await mkdtemp(path.join(tmpdir(), "easysubway-production-pack-identity-"));
   const baselineDir = path.join(workspace, "baseline");
-  const assetPath = path.join(workspace, "capital.sqlite.gz");
+  const assetPath = path.join(root, "apps/mobile/assets/datapacks/capital.sqlite.gz");
   const indexPath = path.join(workspace, "index.json");
   try {
     await execFileAsync(process.execPath, [
@@ -94,7 +94,7 @@ test("production build와 bundled asset/index의 artifact identity를 exact-matc
         && ["duration_seconds", "distance_meters"].includes(field));
     assert.equal(new Set(itxPlaceholderRecords.map(({ entityId, field }) => `${entityId}\0${field}`)).size, 96);
     assert.ok(itxPlaceholderRecords.every(({ derivationKind }) => derivationKind === "GENERATED"));
-    await copyFile(path.join(baselineDir, "catalog/capital-v1.sqlite.gz"), assetPath);
+    await copyFile(path.join(root, "apps/mobile/assets/datapacks/index.json"), indexPath);
     const gzipBytes = await readFile(assetPath);
     assert.equal(gzipBytes[9], 255);
     const sqliteBytes = gunzipSync(gzipBytes);
@@ -146,13 +146,6 @@ test("production build와 bundled asset/index의 artifact identity를 exact-matc
     } finally {
       database.close();
     }
-    await writeFile(indexPath, `${JSON.stringify({ packs: [{
-      id: "capital",
-      sha256: pack.sha256,
-      sqliteSha256: pack.sqliteSha256,
-      byteSize: pack.sizeBytes,
-    }] })}\n`);
-
     const { stdout } = await execFileAsync(process.execPath, [
       "tools/datapack/verify-production-pack-artifact-identity.mjs",
       "--build-spec", "tools/datapack/release/candidate-build-spec.json",
@@ -178,7 +171,21 @@ test("production build와 bundled asset/index의 artifact identity를 exact-matc
     }), report);
 
     const index = JSON.parse(await readFile(indexPath, "utf8"));
-    index.packs[0].sha256 = "f".repeat(64);
+    const capitalIndex = index.packs.find(({ id }) => id === "capital");
+    capitalIndex.asset = "assets/datapacks/core.sqlite.gz";
+    await writeFile(indexPath, `${JSON.stringify(index)}\n`);
+    await assert.rejects(
+      execFileAsync(process.execPath, [
+        "tools/datapack/verify-production-pack-artifact-identity.mjs",
+        "--build-spec", "tools/datapack/release/candidate-build-spec.json",
+        "--asset", assetPath,
+        "--index", indexPath,
+        "--pack-id", "capital",
+      ], { cwd: root, env: verifierEnv }),
+      /index asset mismatch/,
+    );
+    capitalIndex.asset = "assets/datapacks/capital.sqlite.gz";
+    capitalIndex.sha256 = "f".repeat(64);
     await writeFile(indexPath, `${JSON.stringify(index)}\n`);
     await assert.rejects(
       execFileAsync(process.execPath, [


### PR DESCRIPTION
## 관련 이슈

Closes #2650
Refs #2510

## 작업 배경

candidate gate는 reviewed seed의 MISSING→SUPPORTED 전환은 보여도, 같은 실행이 실제 모바일 build-spec·bundle·index identity와 배포 SQLite 행 수를 증명하지 않았습니다. 따라서 판정된 필드와 사용자에게 배포된 행을 함께 판독할 수 없었습니다.

## 작업 내용

- 기존 production artifact verifier를 import-safe 함수로 공개하고 CLI와 같은 검증 경로를 사용하게 했습니다.
- build-spec으로 재생성한 production pack, 실제 mobile gzip asset, index의 `asset`·gzip SHA·SQLite SHA·byteSize를 exact-match합니다.
- candidate runner의 첫 단계에서 verifier를 await해 spec validation·fixture 조립·variant build·SUPPORTED 판정보다 먼저 drift를 거부합니다.
- evidence 최상위 `deployedArtifact`에 verifier path, pack identity, 전체 table row counts와 `networkEdgeCounts`를 한 번 기록했습니다.
- `network_edges`는 전체 2,178행, provenance complete 652행, mobile static strict eligible 652행으로 분리했습니다.
- reviewed-seed counterfactual transition과 실제 shipped row counts가 서로 다른 판독 축임을 reading guide에 명시했습니다.
- ephemeral candidate SQLite hash 제외, 기존 transitions·variants·#2634 inherited-scope classifier는 유지했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern "production build와 bundled asset/index의 artifact identity를 exact-match한다" tools/datapack/verify-production-pack-artifact-identity.test.mjs` — report RED 확인 후 1/1 PASS; CLI/import 회귀 보정 후 1/1 PASS; index asset-only drift RED 확인 후 1/1 PASS
  - `node --test --test-name-pattern "배포 artifact identity는 SUPPORTED 판정 전에 검증한다" tools/datapack/nationwide-candidate-coverage-gate.test.mjs` — RED 확인 후 1/1 PASS
  - `node --test --test-name-pattern "누락된 재기술은 emit fixture를 남기지 않고 거부된다" tools/datapack/nationwide-candidate-coverage-gate.test.mjs` — verifier seam 격리 후 1/1 PASS
  - `node --test --test-name-pattern "candidate evidence는 배포 artifact row count와 transition을 함께 기록한다" tools/datapack/nationwide-candidate-coverage-gate.test.mjs` — RED 확인 후 1/1 PASS
  - `node --check tools/datapack/run-nationwide-candidate-coverage-gate.mjs` — PASS
  - `node --check tools/datapack/verify-production-pack-artifact-identity.mjs` — PASS
  - `git diff --check origin/main...HEAD` — PASS
  - 전체 nationwide candidate evidence 바이트 재생성 — 로컬 resource boundary에 따라 미실행, required GitHub CI에서 검증
  - Task별 독립 리뷰와 current full-diff 재리뷰 — actionable finding 수정 후 PASS

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| deployed artifact identity | datapack | production verifier | gzip `dddfba96…`, SQLite `afefead8…`, 1,463,806 bytes, index asset exact-match | 통과 |
| deployed rows | SQLite | verifier row 집계 | stations 946, station_lines 1,108, network_edges 2,178 | 통과 |
| network edge evidence | SQLite/mobile contract | static strict 조건 집계 | total 2,178 / provenanceComplete 652 / strictEligible 652 | 통과 |
| candidate transition | datapack evidence | tracked evidence shape | capital pilot MISSING→SUPPORTED 유지 | 통과 |
| UI·접근성·수동 QA | 해당 없음 | gate/evidence만 변경 | 화면·runtime·data row 변경 없음 | 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음; 현 bundled artifact identity를 evidence에 결속
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 먼저 볼 지점은 verifier의 build-spec↔asset↔index exact identity와 candidate runner 첫 await 순서입니다.
- `deployedArtifact`는 실제 배포 행 증거이고, 기존 reviewed-seed transition과 동일 row set이라고 주장하지 않습니다.
- `sqliteSha256` evidence 예외는 `$.deployedArtifact.sqliteSha256` 한 곳뿐입니다.

## 리스크

- tracked evidence는 focused verifier의 확정값으로 갱신했습니다. full nationwide byte regeneration은 required CI가 최종 증명합니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)
