### PR TITLE
[Fix] 팬 메뉴 앵커를 노드 바닥 기준 2/3로 교정

### DIFF
--- a/apps/mobile/lib/features/network_map/presentation/station_fan_menu_geometry.dart
+++ b/apps/mobile/lib/features/network_map/presentation/station_fan_menu_geometry.dart
@@ -5,7 +5,7 @@ import 'dart:ui';
 const Size kFanMenuDesignSize = Size(700, 380);
 
 /// v3 말풍선 꼬리 팁(design 좌표). 닫기 섹터·실루엣 하단 베지어의 t=0.5 접점이며
-/// 이 점이 앵커 역 노드의 앵커점(가로 중앙 · 노드 상단에서 높이의 2/3 지점,
+/// 이 점이 앵커 역 노드의 앵커점(가로 중앙 · 노드 바닥에서 높이의 2/3 위 지점,
 /// #2068 QA)에 닿도록 배치한다(팬 메뉴 placement가 소비하는 단일 출처 —
 /// 배치식이 좌표를 재하드코딩하지 않게 한다).
 const Offset kFanMenuTailTip = Offset(350, 375);

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -5143,8 +5143,9 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
     };
   }
 
-  /// 팬 메뉴 꼬리 팁이 닿을 앵커의 source 좌표(#2068 QA). 노드 정중앙
-  /// ([_fanMenuAnchorSource])에서 노드 높이의 1/6만큼 내려온 "높이 2/3" 지점이다.
+  /// 팬 메뉴 꼬리 팁이 닿을 앵커의 source 좌표(#2068 QA). 노드 바닥에서
+  /// 노드 높이의 2/3만큼 위, 즉 ([_fanMenuAnchorSource])에서 높이의 1/6만큼
+  /// 위로 올라간 지점이다.
   /// build(렌더)와 [_panCameraToRevealFanMenu](카메라)가 같은 앵커를 소비하도록
   /// 단일 헬퍼로 둔다. **팬 메뉴 전용** — 드래프트 핀은 이동 없이
   /// [_fanMenuAnchorSource](정중앙)를 그대로 쓴다.
@@ -7487,7 +7488,7 @@ Offset fanMenuTransferAnchor({
 }
 
 /// 팬 메뉴 꼬리 팁이 닿을 앵커점(#2068 QA). 가로는 노드 정중앙 그대로, 세로는
-/// **노드 상단에서 높이의 2/3** 지점이다(= 노드 중심에서 아래로 높이의 1/6).
+/// **노드 바닥에서 높이의 2/3 위** 지점이다(= 노드 중심에서 위로 높이의 1/6).
 /// 정중앙 접촉(#2192 v3)은 메뉴가 노드보다 살짝 위에 떠 보인다는 실기기 QA
 /// 반려에 따라 이 지점으로 옮겼다.
 ///
@@ -7501,8 +7502,8 @@ Offset fanMenuTailAnchorPoint({
   required double nodeHeight,
 }) => Offset(
   nodeCenter.dx,
-  // 노드 상단(중심 − 높이/2)에서 높이의 2/3만큼 내려온 지점.
-  nodeCenter.dy - nodeHeight / 2 + nodeHeight * 2 / 3,
+  // 노드 바닥(중심 + 높이/2)에서 높이의 2/3만큼 위로 올라간 지점.
+  nodeCenter.dy + nodeHeight / 2 - nodeHeight * 2 / 3,
 );
 
 /// [fanMenuTailAnchorPoint]가 쓰는 "노드"의 세로 크기(source 단위, #2068 QA).

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -5168,7 +5168,7 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
   /// 일반역은 노드 좌표 그대로 유도한 뒤 [_MapGeometry] 원점을 빼
   /// [MapCameraState.sourceToViewportPoint] 입력 좌표계로 맞춘다.
   /// 드래프트 핀(출발·경유·도착)이 이 좌표를 그대로 앵커로 쓴다. 팬 메뉴는
-  /// 여기서 한 번 더 내린 [_fanMenuTailAnchorSource]를 쓴다(#2068 QA).
+  /// 여기서 한 번 더 올린 [_fanMenuTailAnchorSource]를 쓴다(#2068 QA).
   Offset _fanMenuAnchorSource(
     NetworkMapStation station,
     _MapGeometry geometry,

--- a/apps/mobile/test/features/network_map/presentation/network_map_fan_menu_wiring_test.dart
+++ b/apps/mobile/test/features/network_map/presentation/network_map_fan_menu_wiring_test.dart
@@ -160,17 +160,17 @@ void main() {
     });
   });
 
-  group('팬 메뉴 꼬리 앵커점(#2068 QA — 노드 높이 2/3 지점)', () {
-    test('가로는 노드 중앙 그대로, 세로는 노드 상단에서 높이의 2/3', () {
-      // 노드 중심 (100,200)·높이 12 → 상단 194, 2/3 지점 = 194 + 8 = 202.
+  group('팬 메뉴 꼬리 앵커점(#2068 QA — 노드 바닥에서 높이 2/3 위)', () {
+    test('가로는 노드 중앙 그대로, 세로는 노드 바닥에서 높이의 2/3 위', () {
+      // 노드 중심 (100,200)·높이 12 → 바닥 206, 2/3 위 지점 = 206 - 8 = 198.
       final anchor = fanMenuTailAnchorPoint(
         nodeCenter: const Offset(100, 200),
         nodeHeight: 12,
       );
       expect(anchor.dx, closeTo(100, 0.001));
-      expect(anchor.dy, closeTo(202, 0.001));
-      // 중심 기준으로는 항상 아래로 높이의 1/6.
-      expect(anchor.dy - 200, closeTo(12 / 6, 0.001));
+      expect(anchor.dy, closeTo(198, 0.001));
+      // 중심 기준으로는 항상 위로 높이의 1/6.
+      expect(200 - anchor.dy, closeTo(12 / 6, 0.001));
     });
 
     test('높이 0(노드 크기 미상)이면 중심 그대로 — 회귀 안전', () {
@@ -346,7 +346,7 @@ void main() {
       }
     });
 
-    test('앵커점은 노드 중심보다 아래(꼬리 팁이 노드 하단쪽 2/3에 닿는다)', () {
+    test('앵커점은 노드 중심보다 위(꼬리 팁이 노드 바닥에서 2/3 위에 닿는다)', () {
       const center = Offset(120, 340);
       final height = fanMenuAnchorNodeHeight(
         memberPositions: const [],
@@ -357,8 +357,8 @@ void main() {
         nodeHeight: height,
       );
       expect(anchor.dx, closeTo(center.dx, 0.001));
-      expect(anchor.dy, greaterThan(center.dy));
-      expect(anchor.dy, closeTo(center.dy + 1.5, 0.001));
+      expect(anchor.dy, lessThan(center.dy));
+      expect(anchor.dy, closeTo(center.dy - 1.5, 0.001));
     });
   });
 

--- a/apps/mobile/test/features/network_map/presentation/network_map_fan_menu_wiring_test.dart
+++ b/apps/mobile/test/features/network_map/presentation/network_map_fan_menu_wiring_test.dart
@@ -310,7 +310,7 @@ void main() {
       };
       for (final entry in regions.entries) {
         final (designScale, nodeRadiusDesign, capsuleHalfDesign) = entry.value;
-        // 일반역: 중심에서 아래로 height/6. design px로 환산해 실측 반경과 비교.
+        // 일반역: 중심에서 위로 height/6. design px로 환산해 실측 반경과 비교.
         final regularOffsetDesign =
             fanMenuAnchorNodeHeight(
               memberPositions: const [],

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2632,11 +2632,11 @@ void main() {
     expect(routeDraftController.draft.origin, isNull);
   });
 
-  testWidgets('#2068 팬 메뉴 꼬리 팁은 노드 정중앙이 아니라 그 아래(높이 2/3 지점)에 닿는다', (
+  testWidgets('#2068 팬 메뉴 꼬리 팁은 노드 바닥에서 높이 2/3 위에 닿는다', (
     tester,
   ) async {
     // 배선 가드: network_map.dart의 팬 메뉴 호출부를 _fanMenuTailAnchorSource에서
-    // _fanMenuAnchorSource(정중앙)로 되돌리면 아래 delta가 0이 되어 red가 된다.
+    // _fanMenuAnchorSource(정중앙)로 되돌리면 이 delta가 0이 되어 red가 된다.
     // 기준점은 같은 역의 draft pin이다 — pin은 정중앙 앵커를 그대로 쓰고
     // (_NetworkMapDraftPin: pinTop = anchor.dy - 52, hitPadTop 10 · hitPadBottom 0)
     // 히트박스 하단이 곧 노드 정중앙의 뷰포트 y다.
@@ -2682,18 +2682,18 @@ void main() {
         menuRect.top +
         menuRect.height * (kFanMenuTailTip.dy / kFanMenuDesignSize.height);
 
-    // 팁은 노드 정중앙보다 아래다(정중앙 앵커로 회귀하면 delta = 0 → red).
-    // 팁은 노드 정중앙보다 아래다. 이 fixture 실측 이동량은 0.70px
+    // 팁은 노드 정중앙보다 위다(정중앙 앵커로 회귀하면 delta = 0 → red).
+    // 팁은 노드 정중앙보다 위다. 이 fixture 실측 이동량은 0.70px
     // (= nodeHeight/6 × camera.scale)이고, 정중앙 앵커로 회귀하면 5.7e-14(=0)로
     // 떨어진다 — 0.25는 그 사이를 양쪽 3배 여유로 가르는 문턱이다.
     expect(
-      tipY - nodeCenterY,
+      nodeCenterY - tipY,
       greaterThan(0.25),
       reason: '꼬리 팁이 노드 정중앙($nodeCenterY)에 붙어 있으면 #2068 QA 이동이 배선되지 않은 것이다',
     );
     // 이동량은 노드 크기(height/6) 수준이라 메뉴 높이에 비하면 매우 작다 —
     // 과도한 이동(메뉴가 노드에서 떨어짐)도 함께 막는다.
-    expect(tipY - nodeCenterY, lessThan(menuRect.height * 0.1));
+    expect(nodeCenterY - tipY, lessThan(menuRect.height * 0.1));
   });
 
   testWidgets('상단 오버레이 출발칸 검색 선택은 지도 탭과 같은 draft로 수렴한다(G4)', (tester) async {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2632,9 +2632,7 @@ void main() {
     expect(routeDraftController.draft.origin, isNull);
   });
 
-  testWidgets('#2068 팬 메뉴 꼬리 팁은 노드 바닥에서 높이 2/3 위에 닿는다', (
-    tester,
-  ) async {
+  testWidgets('#2068 팬 메뉴 꼬리 팁은 노드 바닥에서 높이 2/3 위에 닿는다', (tester) async {
     // 배선 가드: network_map.dart의 팬 메뉴 호출부를 _fanMenuTailAnchorSource에서
     // _fanMenuAnchorSource(정중앙)로 되돌리면 이 delta가 0이 되어 red가 된다.
     // 기준점은 같은 역의 draft pin이다 — pin은 정중앙 앵커를 그대로 쓰고


### PR DESCRIPTION
## 관련 이슈

Closes #2659

## 작업 배경

- PR #2575에서 오너의 “세로기준 높이 2/3” 요구를 노드 상단 기준으로 해석해 팬 메뉴 꼬리 팁이 중심 아래에 붙었다.
- 확정 요구사항은 X축 노드 중앙, Y축 노드 바닥에서 위로 높이의 2/3이다. 이는 중심에서 위로 높이의 1/6과 같다.

## 작업 내용

- `fanMenuTailAnchorPoint`의 Y 식을 `center + height / 6`에서 `center - height / 6`으로 교정했다.
- `(100, 200), height=12 → (100, 198)`과 중심보다 위라는 방향을 회귀 테스트로 고정했다.
- 팬 메뉴 Path·크기·clamp·카메라 패닝·드래프트 핀·노드 높이 모델은 변경하지 않았다.

## 검증

- RED: `flutter test test/features/network_map/presentation/network_map_fan_menu_wiring_test.dart --plain-name "가로는 노드 중앙 그대로, 세로는 노드 바닥에서 높이의 2/3 위"` — 예상 실패, actual `202.0`, expected `198.0`.
- GREEN: `flutter test test/features/network_map/presentation/network_map_fan_menu_wiring_test.dart` — 30 tests PASS, 0 failures.
- `dart format --output=none --set-exit-if-changed lib test` — PASS, 335 files, 0 changed.
- `flutter analyze` — PASS, No issues found.
- 최종 리뷰 주석 교정 후 같은 영향 테스트 — 30 tests PASS, 0 failures.
- 기존 위젯 회귀 RED: `flutter test test/widget_test.dart --plain-name "#2068 팬 메뉴 꼬리 팁은 노드 정중앙이 아니라 그 아래(높이 2/3 지점)에 닿는다"` — 예상 실패, `nodeCenterY - tipY = -0.697674…`.
- 위젯 회귀 GREEN: `flutter test test/widget_test.dart --plain-name "#2068 팬 메뉴 꼬리 팁은 노드 바닥에서 높이 2/3 위에 닿는다"` — PASS, 0 failures.
- 후속 수정 `flutter analyze` — PASS. CI 포맷 실패 후 `dart format test/widget_test.dart`로 선언부 1곳을 정규화하고 `dart format --output=none --set-exit-if-changed test/widget_test.dart` — PASS, 0 changed.
- 포맷 수정 후 위젯 회귀 GREEN 재실행 — PASS, 0 failures.
- GitHub CI `30350110695` — Mobile 전체 analyzer/test, Android CI 포함 PASS.

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 팬 메뉴 꼬리 앵커 | Android / iOS 공통 | 공유 Dart 순수 함수와 위젯 배선 RED/GREEN | `(100, 200), h=12`: 수정 전 `202`, 수정 후 `198`; 영향 테스트 30건; 위젯 테스트 1건 | PASS |
| 화면 캡처 | Android / iOS 공통 | 불필요 사유 | 좌표 접점 수치는 캡처보다 순수 함수가 직접 증명하고 두 플랫폼이 같은 Dart 경로를 사용함 | N/A |
| 독립 리뷰 | 공통 | task review + 전체 branch review + Codex fallback fix/re-review | 현재 HEAD `7308dfaf` actionable finding 0건 | PASS |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: unchanged
- mobile versionCode: unchanged
- datapack version: unchanged
- route contract: unchanged
- realtime contract: unchanged
- backend identity: unchanged

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `fanMenuTailAnchorPoint` Y 부호와 대표 좌표 테스트가 “바닥에서 2/3 위” 계약과 일치하는지 확인해 주세요.

## 리스크

- 노드 높이는 기존 basemap 실측 모델을 그대로 사용한다. 이번 변경은 이동 방향만 반대로 교정한다.
- `flutter`가 호환되지 않는 최신 패키지 33개를 안내하지만 기존 의존성 상태이며 테스트·analyze는 통과했다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다. — https://github.com/AquilaXk/easysubway/actions/runs/30350110695
- [x] CodeRabbit 리뷰를 확인했다. — rate limit 경고로 Review 객체를 만들지 못했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. — 배포·버전·데이터 변경 없음.
