### PR TITLE
[Feat] EasySubway 공개 사이트와 OCI 제품 호스트 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
@@ -423,9 +423,8 @@ public class SecurityConfig {
 					"/api/v1/trains/stations",
 					"/api/v1/trains/search"
 				).permitAll()
+				.requestMatchers(HttpMethod.GET, "/", "/index.html").permitAll()
 				.requestMatchers(
-					"/",
-					"/index.html",
 					"/api/health",
 					"/actuator/health",
 					"/actuator/health/liveness",

--- a/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
@@ -424,6 +424,8 @@ public class SecurityConfig {
 					"/api/v1/trains/search"
 				).permitAll()
 				.requestMatchers(
+					"/",
+					"/index.html",
 					"/api/health",
 					"/actuator/health",
 					"/actuator/health/liveness",

--- a/backend/src/main/resources/static/index.html
+++ b/backend/src/main/resources/static/index.html
@@ -17,7 +17,7 @@
       --green: #08785d;
       --green-dark: #075d49;
       --lime: #d9ee7e;
-      --orange: #e96b3f;
+      --orange: #c84e28;
       --shadow: 0 20px 60px rgb(23 49 43 / 10%);
     }
 
@@ -277,7 +277,7 @@
   <main id="main">
     <section class="hero wrap" aria-labelledby="hero-title">
       <div>
-        <p class="eyebrow">Accessible subway navigation</p>
+        <p class="eyebrow" lang="en">Accessible subway navigation</p>
         <h1 id="hero-title">빠른 길보다,<br>갈 수 있는 길.</h1>
         <p class="hero-copy">쉬운 지하철은 휠체어, 유모차, 불편한 걸음을 먼저 생각하는 지하철 길찾기입니다.</p>
         <div class="actions">
@@ -289,7 +289,7 @@
     </section>
 
     <section id="why" class="wrap" aria-labelledby="why-title">
-      <p class="eyebrow">Designed around real barriers</p>
+      <p class="eyebrow" lang="en">Designed around real barriers</p>
       <h2 id="why-title">당신의 상황이<br>곧 길의 기준입니다.</h2>
       <div class="grid">
         <article class="card">
@@ -322,7 +322,7 @@
 
     <section id="now" class="wrap" aria-labelledby="now-title">
       <div class="current">
-        <p class="eyebrow">What we are validating now</p>
+        <p class="eyebrow" lang="en">What we are validating now</p>
         <h2 id="now-title">작게 시작하고,<br>확인한 만큼만 말합니다.</h2>
         <p>현재 상록수·사당의 접근성 정보를 먼저 검증하고 있습니다. Android 출시를 준비 중이며, 공개 다운로드가 시작되면 이곳에서 안내합니다.</p>
         <a href="mailto:aquila@aquilaxk.site">aquila@aquilaxk.site로 연락하기</a>

--- a/backend/src/main/resources/static/index.html
+++ b/backend/src/main/resources/static/index.html
@@ -1,0 +1,344 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="휠체어, 유모차, 불편한 걸음을 먼저 생각하는 지하철 길찾기, 쉬운 지하철">
+  <meta name="theme-color" content="#f4f1ea">
+  <title>쉬운 지하철 | 접근 가능한 지하철 길찾기</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --ink: #17312b;
+      --muted: #52655f;
+      --paper: #f4f1ea;
+      --card: #fffdf8;
+      --line: #d5dbd4;
+      --green: #08785d;
+      --green-dark: #075d49;
+      --lime: #d9ee7e;
+      --orange: #e96b3f;
+      --shadow: 0 20px 60px rgb(23 49 43 / 10%);
+    }
+
+    * { box-sizing: border-box; }
+
+    html { scroll-behavior: smooth; }
+
+    body {
+      margin: 0;
+      background: var(--paper);
+      color: var(--ink);
+      font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo", "Noto Sans KR", sans-serif;
+      line-height: 1.6;
+    }
+
+    a { color: inherit; }
+
+    a:focus-visible {
+      outline: 3px solid var(--orange);
+      outline-offset: 4px;
+      border-radius: 4px;
+    }
+
+    .skip {
+      position: fixed;
+      top: 1rem;
+      left: 1rem;
+      z-index: 10;
+      padding: .65rem 1rem;
+      background: var(--ink);
+      color: white;
+      transform: translateY(-200%);
+    }
+
+    .skip:focus { transform: none; }
+
+    .wrap {
+      width: min(1120px, calc(100% - 2rem));
+      margin-inline: auto;
+    }
+
+    header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+      padding-block: 1.25rem;
+    }
+
+    .brand {
+      display: inline-flex;
+      align-items: center;
+      gap: .65rem;
+      font-weight: 800;
+      text-decoration: none;
+    }
+
+    .brand-mark {
+      display: grid;
+      width: 2rem;
+      height: 2rem;
+      place-items: center;
+      border-radius: 50%;
+      background: var(--green);
+      color: white;
+      font-size: .78rem;
+    }
+
+    nav { display: flex; gap: 1rem; }
+    nav a { color: var(--muted); font-size: .9rem; font-weight: 700; }
+
+    .hero {
+      display: grid;
+      min-height: 70vh;
+      align-items: center;
+      gap: 3rem;
+      padding-block: 5rem 7rem;
+    }
+
+    .eyebrow {
+      margin: 0 0 1rem;
+      color: var(--green-dark);
+      font-size: .82rem;
+      font-weight: 800;
+      letter-spacing: .12em;
+      text-transform: uppercase;
+    }
+
+    h1 {
+      max-width: 760px;
+      margin: 0;
+      font-size: clamp(3rem, 9vw, 6.6rem);
+      line-height: .98;
+      letter-spacing: -.065em;
+      text-wrap: balance;
+    }
+
+    .hero-copy {
+      max-width: 620px;
+      margin: 2rem 0 0;
+      color: var(--muted);
+      font-size: clamp(1.08rem, 2.5vw, 1.35rem);
+      word-break: keep-all;
+    }
+
+    .actions {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: .85rem;
+      margin-top: 2rem;
+    }
+
+    .button {
+      display: inline-flex;
+      min-height: 3rem;
+      align-items: center;
+      justify-content: center;
+      padding: .7rem 1.2rem;
+      border: 1px solid var(--ink);
+      border-radius: 999px;
+      font-weight: 800;
+      text-decoration: none;
+    }
+
+    .button.primary { background: var(--ink); color: white; }
+
+    .status {
+      display: inline-flex;
+      align-items: center;
+      gap: .5rem;
+      color: var(--green-dark);
+      font-size: .92rem;
+      font-weight: 800;
+    }
+
+    .status::before {
+      width: .65rem;
+      height: .65rem;
+      border-radius: 50%;
+      background: var(--orange);
+      content: "";
+    }
+
+    .route-line {
+      position: relative;
+      height: 8px;
+      margin-top: 4rem;
+      border-radius: 999px;
+      background: linear-gradient(90deg, var(--green) 0 68%, var(--lime) 68%);
+    }
+
+    .route-line::before,
+    .route-line::after {
+      position: absolute;
+      top: 50%;
+      width: 1.25rem;
+      height: 1.25rem;
+      border: 5px solid var(--green);
+      border-radius: 50%;
+      background: var(--paper);
+      content: "";
+      transform: translateY(-50%);
+    }
+
+    .route-line::before { left: 18%; }
+    .route-line::after { left: 67%; }
+
+    section { padding-block: 5rem; }
+
+    h2 {
+      max-width: 700px;
+      margin: 0 0 2rem;
+      font-size: clamp(2rem, 5vw, 3.6rem);
+      line-height: 1.12;
+      letter-spacing: -.045em;
+      text-wrap: balance;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 1rem;
+    }
+
+    .card {
+      min-height: 220px;
+      padding: 1.75rem;
+      border: 1px solid var(--line);
+      border-radius: 1.5rem;
+      background: var(--card);
+      box-shadow: var(--shadow);
+    }
+
+    .card:first-child { grid-row: span 2; }
+    .card-number { color: var(--orange); font-size: .8rem; font-weight: 900; letter-spacing: .1em; }
+    .card h3 { margin: 2rem 0 .5rem; font-size: 1.45rem; line-height: 1.25; }
+    .card p { margin: 0; color: var(--muted); word-break: keep-all; }
+
+    .current {
+      display: grid;
+      gap: 1.5rem;
+      padding: clamp(2rem, 6vw, 4.5rem);
+      border-radius: 2rem;
+      background: var(--ink);
+      color: white;
+    }
+
+    .current p { max-width: 680px; margin: 0; color: #cdd9d5; font-size: 1.1rem; }
+    .current a { width: fit-content; color: var(--lime); font-weight: 800; }
+
+    footer {
+      display: grid;
+      gap: 1.5rem;
+      padding-block: 3rem;
+      border-top: 1px solid var(--line);
+      color: var(--muted);
+      font-size: .9rem;
+    }
+
+    .footer-links { display: flex; flex-wrap: wrap; gap: .8rem 1.25rem; }
+    .footer-links a { text-underline-offset: 3px; }
+
+    @media (min-width: 760px) {
+      .hero { grid-template-columns: minmax(0, 4fr) minmax(260px, 1fr); }
+      .hero .route-line { height: 70%; margin: 0; background: linear-gradient(var(--green) 0 68%, var(--lime) 68%); justify-self: center; width: 8px; }
+      .hero .route-line::before { top: 18%; left: 50%; transform: translate(-50%, -50%); }
+      .hero .route-line::after { top: 67%; left: 50%; transform: translate(-50%, -50%); }
+      .grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    }
+
+    @media (max-width: 600px) {
+      nav a:first-child { display: none; }
+      .hero { min-height: auto; padding-block: 4rem 5rem; }
+      .grid { grid-template-columns: 1fr; }
+      .card:first-child { grid-row: auto; }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      html { scroll-behavior: auto; }
+    }
+  </style>
+</head>
+<body>
+  <a class="skip" href="#main">본문으로 바로가기</a>
+  <header class="wrap">
+    <a class="brand" href="/" aria-label="쉬운 지하철 홈">
+      <span class="brand-mark" aria-hidden="true">ES</span>
+      <span>쉬운 지하철</span>
+    </a>
+    <nav aria-label="주요 메뉴">
+      <a href="#why">왜 쉬운 지하철인가</a>
+      <a href="#now">현재 범위</a>
+    </nav>
+  </header>
+
+  <main id="main">
+    <section class="hero wrap" aria-labelledby="hero-title">
+      <div>
+        <p class="eyebrow">Accessible subway navigation</p>
+        <h1 id="hero-title">빠른 길보다,<br>갈 수 있는 길.</h1>
+        <p class="hero-copy">쉬운 지하철은 휠체어, 유모차, 불편한 걸음을 먼저 생각하는 지하철 길찾기입니다.</p>
+        <div class="actions">
+          <a class="button primary" href="https://github.com/AquilaXk/easysubway">GitHub에서 보기</a>
+          <span class="status">Android 출시 준비 중</span>
+        </div>
+      </div>
+      <div class="route-line" aria-hidden="true"></div>
+    </section>
+
+    <section id="why" class="wrap" aria-labelledby="why-title">
+      <p class="eyebrow">Designed around real barriers</p>
+      <h2 id="why-title">당신의 상황이<br>곧 길의 기준입니다.</h2>
+      <div class="grid">
+        <article class="card">
+          <span class="card-number">01</span>
+          <h3>지하에서도, 인터넷 없이도</h3>
+          <p>역 검색과 길찾기를 기기 안에서 처리해 연결이 불안정한 지하에서도 필요한 정보를 찾습니다.</p>
+        </article>
+        <article class="card">
+          <span class="card-number">02</span>
+          <h3>갈 수 있는 경로를 먼저</h3>
+          <p>휠체어, 유모차, 불편한 걸음처럼 이동 상황에 맞춰 계단 없는 길을 우선합니다.</p>
+        </article>
+        <article class="card">
+          <span class="card-number">03</span>
+          <h3>모르는 것은 모른다고</h3>
+          <p>접근성 정보에 출처와 확인 날짜를 붙이고, 확인되지 않은 정보는 분명히 구분합니다.</p>
+        </article>
+        <article class="card">
+          <span class="card-number">04</span>
+          <h3>가입 없는 시설 제보</h3>
+          <p>엘리베이터 고장처럼 이동을 막는 상황을 계정 없이 알리고 접수 번호로 확인합니다.</p>
+        </article>
+        <article class="card">
+          <span class="card-number">05</span>
+          <h3>당신을 따라다니지 않게</h3>
+          <p>계정을 요구하지 않고, 즐겨찾기는 기기에 보관하는 방식으로 개인정보를 줄입니다.</p>
+        </article>
+      </div>
+    </section>
+
+    <section id="now" class="wrap" aria-labelledby="now-title">
+      <div class="current">
+        <p class="eyebrow">What we are validating now</p>
+        <h2 id="now-title">작게 시작하고,<br>확인한 만큼만 말합니다.</h2>
+        <p>현재 상록수·사당의 접근성 정보를 먼저 검증하고 있습니다. Android 출시를 준비 중이며, 공개 다운로드가 시작되면 이곳에서 안내합니다.</p>
+        <a href="mailto:aquila@aquilaxk.site">aquila@aquilaxk.site로 연락하기</a>
+      </div>
+    </section>
+  </main>
+
+  <footer class="wrap">
+    <strong>Aquila Software · 쉬운 지하철</strong>
+    <div class="footer-links">
+      <a href="mailto:support@aquilaxk.site">고객 문의</a>
+      <a href="/privacy">개인정보 처리방침</a>
+      <a href="/terms">서비스 이용약관</a>
+      <a href="/location-terms">위치정보 이용약관</a>
+    </div>
+    <span>계단 앞에서 막막했던 모든 순간을 위해.</span>
+  </footer>
+</body>
+</html>

--- a/backend/src/main/resources/static/index.html
+++ b/backend/src/main/resources/static/index.html
@@ -197,6 +197,8 @@
       text-wrap: balance;
     }
 
+    .section-copy { margin: -1rem 0 2rem; color: var(--muted); }
+
     .grid {
       display: grid;
       grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -291,6 +293,7 @@
     <section id="why" class="wrap" aria-labelledby="why-title">
       <p class="eyebrow" lang="en">Designed around real barriers</p>
       <h2 id="why-title">당신의 상황이<br>곧 길의 기준입니다.</h2>
+      <p class="section-copy">아래 기능을 Android 앱에 담아 출시를 준비하고 있습니다.</p>
       <div class="grid">
         <article class="card">
           <span class="card-number">01</span>

--- a/backend/src/test/java/com/easysubway/health/adapter/in/web/HealthCheckControllerTest.java
+++ b/backend/src/test/java/com/easysubway/health/adapter/in/web/HealthCheckControllerTest.java
@@ -2,6 +2,7 @@ package com.easysubway.health.adapter.in.web;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -133,26 +134,38 @@ class HealthCheckControllerTest {
 	@Test
 	@DisplayName("제품 소개 페이지를 인증 없이 노출한다")
 	void productLandingPageIsPublic() {
-		ResponseEntity<String> response = restTemplate.getForEntity(
-			"http://127.0.0.1:" + port + "/",
-			String.class
-		);
+		for (String path : List.of("/", "/index.html")) {
+			ResponseEntity<String> response = restTemplate.getForEntity(
+				"http://127.0.0.1:" + port + path,
+				String.class
+			);
 
-		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-		assertThat(response.getHeaders().getContentType()).isNotNull();
-		assertThat(response.getHeaders().getContentType().isCompatibleWith(MediaType.TEXT_HTML)).isTrue();
-		assertThat(response.getBody()).contains(
-			"쉬운 지하철",
-			"빠른 길보다,",
-			"갈 수 있는 길.",
-			"Android 출시 준비 중",
-			"https://github.com/AquilaXk/easysubway",
-			"/privacy",
-			"/terms",
-			"/location-terms",
-			"mailto:aquila@aquilaxk.site",
-			"mailto:support@aquilaxk.site"
-		);
+			assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+			assertThat(response.getHeaders().getContentType()).isNotNull();
+			assertThat(response.getHeaders().getContentType().isCompatibleWith(MediaType.TEXT_HTML)).isTrue();
+			assertThat(response.getBody()).contains(
+				"쉬운 지하철",
+				"빠른 길보다,",
+				"갈 수 있는 길.",
+				"Android 출시 준비 중",
+				"아래 기능을 Android 앱에 담아 출시를 준비하고 있습니다.",
+				"https://github.com/AquilaXk/easysubway",
+				"/privacy",
+				"/terms",
+				"/location-terms",
+				"mailto:aquila@aquilaxk.site",
+				"mailto:support@aquilaxk.site"
+			);
+		}
+	}
+
+	@Test
+	@DisplayName("제품 소개 페이지는 GET 이외 요청을 차단한다")
+	void productLandingPageRejectsNonGetRequests() throws Exception {
+		for (String path : List.of("/", "/index.html")) {
+			mockMvc.perform(post(path))
+				.andExpect(status().isForbidden());
+		}
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/health/adapter/in/web/HealthCheckControllerTest.java
+++ b/backend/src/test/java/com/easysubway/health/adapter/in/web/HealthCheckControllerTest.java
@@ -26,6 +26,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -127,6 +128,31 @@ class HealthCheckControllerTest {
 			// alerts.yml의 freshness 경보가 참조하는 라이브 게이지가 실제로 scrape 본문에 렌더링된다.
 			.andExpect(content().string(
 				org.hamcrest.Matchers.containsString("easysubway_timetable_snapshot_remaining_seconds")));
+	}
+
+	@Test
+	@DisplayName("제품 소개 페이지를 인증 없이 노출한다")
+	void productLandingPageIsPublic() {
+		ResponseEntity<String> response = restTemplate.getForEntity(
+			"http://127.0.0.1:" + port + "/",
+			String.class
+		);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(response.getHeaders().getContentType()).isNotNull();
+		assertThat(response.getHeaders().getContentType().isCompatibleWith(MediaType.TEXT_HTML)).isTrue();
+		assertThat(response.getBody()).contains(
+			"쉬운 지하철",
+			"빠른 길보다,",
+			"갈 수 있는 길.",
+			"Android 출시 준비 중",
+			"https://github.com/AquilaXk/easysubway",
+			"/privacy",
+			"/terms",
+			"/location-terms",
+			"mailto:aquila@aquilaxk.site",
+			"mailto:support@aquilaxk.site"
+		);
 	}
 
 	@Test

--- a/infra/nginx/host-easysubway.conf.template
+++ b/infra/nginx/host-easysubway.conf.template
@@ -1,7 +1,7 @@
 server {
     listen 80 default_server;
     listen [::]:80 default_server;
-    server_name easysubway-api.aquilaxk.site;
+    server_name easysubway-api.aquilaxk.site easysubway.aquilaxk.site;
     access_log off;
 
     location ^~ /.well-known/acme-challenge/ {
@@ -29,7 +29,7 @@ server {
 server {
     listen 443 ssl;
     listen [::]:443 ssl;
-    server_name easysubway-api.aquilaxk.site;
+    server_name easysubway-api.aquilaxk.site easysubway.aquilaxk.site;
     access_log off;
 
     ssl_certificate /etc/letsencrypt/live/easysubway-api.aquilaxk.site/fullchain.pem;

--- a/tools/ci/backend-deploy.test.mjs
+++ b/tools/ci/backend-deploy.test.mjs
@@ -777,8 +777,12 @@ test("Route V2 host ingress는 두 exact 경로만 gateway로 보내고 실패 �
       .matchAll(/"([0-9.]+\/[0-9]+)"/g),
   ].map((match) => match[1]);
 
-  const httpServer = host.slice(0, host.indexOf("server {", 1));
-  const httpsServer = host.slice(host.indexOf("server {", 1));
+  const defaultHttpsStart = host.indexOf("server {", 1);
+  const namedHttpsStart = host.indexOf("server {", defaultHttpsStart + 1);
+  const httpServer = host.slice(0, defaultHttpsStart);
+  const defaultHttpsServer = host.slice(defaultHttpsStart, namedHttpsStart);
+  const httpsServer = host.slice(namedHttpsStart);
+  assert.match(httpServer, /server_name easysubway-api\.aquilaxk\.site easysubway\.aquilaxk\.site;/);
   assert.match(httpServer, /location \^~ \/\.well-known\/acme-challenge\//);
   assert.match(httpServer, /location \/ \{\s*return 308 https:\/\/\$host\$request_uri;\s*\}/);
   assert.doesNotMatch(httpServer, /proxy_pass|__ROUTE_V2_ACTION__/);
@@ -795,11 +799,12 @@ test("Route V2 host ingress는 두 exact 경로만 gateway로 보내고 실패 �
   assert.match(routeHeaders, /proxy_set_header CF-Connecting-IP \$remote_addr;/);
   assert.doesNotMatch(routeHeaders, /proxy_set_header CF-Connecting-IP \$http_cf_connecting_ip;/);
   assert.match(routeHeaders, /proxy_set_header X-Forwarded-For "";/);
-  assert.match(host, /listen 443 ssl default_server;[\s\S]*server_name _;[\s\S]*return 444;/);
-  assert.equal(
-    (host.match(/server_name easysubway-api\.aquilaxk\.site easysubway\.aquilaxk\.site;/g) ?? []).length,
-    2,
-  );
+  assert.match(defaultHttpsServer, /listen 443 ssl default_server;/);
+  assert.match(defaultHttpsServer, /server_name _;/);
+  assert.match(defaultHttpsServer, /return 444;/);
+  assert.doesNotMatch(defaultHttpsServer, /easysubway\.aquilaxk\.site/);
+  assert.match(httpsServer, /listen 443 ssl;/);
+  assert.match(httpsServer, /server_name easysubway-api\.aquilaxk\.site easysubway\.aquilaxk\.site;/);
   assert.equal((host.match(/listen 443 ssl default_server;/g) ?? []).length, 1);
   assert.match(deploy, /sudo nginx -t/);
   assert.match(deploy, /sudo systemctl reload nginx/);

--- a/tools/ci/backend-deploy.test.mjs
+++ b/tools/ci/backend-deploy.test.mjs
@@ -796,7 +796,10 @@ test("Route V2 host ingress는 두 exact 경로만 gateway로 보내고 실패 �
   assert.doesNotMatch(routeHeaders, /proxy_set_header CF-Connecting-IP \$http_cf_connecting_ip;/);
   assert.match(routeHeaders, /proxy_set_header X-Forwarded-For "";/);
   assert.match(host, /listen 443 ssl default_server;[\s\S]*server_name _;[\s\S]*return 444;/);
-  assert.match(host, /listen 443 ssl;[\s\S]*server_name easysubway-api\.aquilaxk\.site;/);
+  assert.equal(
+    (host.match(/server_name easysubway-api\.aquilaxk\.site easysubway\.aquilaxk\.site;/g) ?? []).length,
+    2,
+  );
   assert.equal((host.match(/listen 443 ssl default_server;/g) ?? []).length, 1);
   assert.match(deploy, /sudo nginx -t/);
   assert.match(deploy, /sudo systemctl reload nginx/);


### PR DESCRIPTION
## 관련 이슈

Closes #2662

## 작업 배경

- `aquilaxk.site`의 개인 블로그와 분리된 EasySubway 공식 제품 페이지가 필요합니다.
- 새 호스팅을 추가하지 않고 현재 OCI/Spring Boot 배포와 Cloudflare 프록시를 재사용합니다.

## 작업 내용

- Spring Boot 정적 welcome page로 의존성·JavaScript 없는 한국어 제품 소개 페이지를 추가했습니다.
- `/`와 내부 welcome-page 포워드 대상 `/index.html`만 인증 없이 열고 기존 기본 차단 정책은 유지했습니다.
- OCI Nginx의 HTTP ACME/리다이렉트 및 HTTPS 프록시 server block이 `easysubway-api.aquilaxk.site`와 `easysubway.aquilaxk.site`를 함께 받도록 했습니다.
- HTTPS 기본 server의 unknown SNI `444` 차단과 기존 API·Route V2 동작은 유지했습니다.

## 검증

- 실행한 명령과 결과:
  - `cd backend && ./gradlew test --tests com.easysubway.health.adapter.in.web.HealthCheckControllerTest` — PASS (15 tests)
  - `node --test tools/ci/backend-deploy.test.mjs` — PASS (28/28)
  - `git diff --check origin/main...HEAD` — PASS

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 랜딩 HTTP 계약 | Spring Boot test server | 실제 HTTP `GET /`, status/MIME/필수 문구·링크 검증 | `HealthCheckControllerTest.productLandingPageIsPublic` | PASS |
| OCI ingress 계약 | Node test runner | 두 named server block의 exact dual-host와 default `444` 검증 | `tools/ci/backend-deploy.test.mjs` | PASS |
| 데스크톱·모바일 UI | Production web | 병합·OCI 배포·TLS 전환 후 브라우저 수동 확인 | 배포 후 PR에 첨부 예정 | PENDING |
| 기존 API readiness | Production API | 배포 후 기존 hostname readiness 확인 | 배포 후 PR에 기록 예정 | PENDING |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음(기존 backend 배포에 정적 페이지와 hostname만 추가)

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: Spring Security가 `/`의 `/index.html` 내부 포워드까지 명시적으로 허용하는지, Nginx의 unknown SNI `444` 기본 서버가 유지되는지 확인해 주세요.

## 리스크

- 새 hostname은 병합 후 DNS-only 레코드 생성 → 기존 Let's Encrypt 인증서 SAN 확장 → origin SNI 확인 → Cloudflare proxy 활성화 순서로 전환해야 합니다.
- 페이지는 현재 검증 중인 범위와 Android 출시 준비 상태만 표현하며 공개 출시나 전국 지원을 주장하지 않습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
