### PR TITLE
[Feat] station-domain source matrix와 transfer partition gate

### DIFF
--- a/tools/datapack/build-accessibility-source-coverage-report.mjs
+++ b/tools/datapack/build-accessibility-source-coverage-report.mjs
@@ -127,6 +127,7 @@ export function buildAccessibilitySourceCoverageReport({
     ? buildStationDomainSourceGate({
         artifacts,
         validClaims,
+        sources,
         molitTransferSnapshot,
         providerCodeCatalog,
       })
@@ -146,7 +147,7 @@ export function buildAccessibilitySourceCoverageReport({
 }
 
 export function buildStationDomainSourceGate({
-  artifacts, validClaims, molitTransferSnapshot, providerCodeCatalog,
+  artifacts, validClaims, sources, molitTransferSnapshot, providerCodeCatalog,
 }) {
   if (artifacts.some((artifact) => !Array.isArray(artifact.stationLines) || artifact.stationLines.length === 0)) {
     throw new Error("station domain gate requires station-lines for every artifact");
@@ -161,7 +162,7 @@ export function buildStationDomainSourceGate({
     throw new Error("MOLIT transfer snapshot row count mismatch");
   }
 
-  const evaluated = collectEvaluatedStationDomains(artifacts, validClaims);
+  const evaluated = collectEvaluatedStationDomains(artifacts, validClaims, sources);
   const matrix = buildStationDomainMatrix(artifacts, stationLines, evaluated);
   const transferTuplePartition = partitionMolitTransferTuples({
     artifacts,
@@ -190,7 +191,7 @@ export function buildStationDomainSourceGate({
   return { matrix, transferTuplePartition, decision };
 }
 
-function collectEvaluatedStationDomains(artifacts, validClaims) {
+function collectEvaluatedStationDomains(artifacts, validClaims, sources) {
   const evaluated = new Map();
   for (const artifact of artifacts) {
     const stationLineByKey = new Map((artifact.stationLines ?? []).map((row) => [
@@ -202,7 +203,9 @@ function collectEvaluatedStationDomains(artifacts, validClaims) {
       const stationLine = domain && claim.lineId
         ? stationLineByKey.get(`${claim.stationId}\0${claim.lineId}`)
         : undefined;
-      if (!stationLine || !validClaims.has(claim)) continue;
+      const source = sources.get(claim.sourceId);
+      if (!stationLine || !validClaims.has(claim)
+        || !sourceCoversStationDomain(source, stationLine.operatorId, domain)) continue;
       const key = `${artifact.artifactId}\0${stationLine.operatorId}\0${domain}`;
       const entry = evaluated.get(key) ?? { stationLines: new Set(), sourceIds: new Set() };
       entry.stationLines.add(`${claim.stationId}\0${claim.lineId}`);
@@ -211,6 +214,17 @@ function collectEvaluatedStationDomains(artifacts, validClaims) {
     }
   }
   return evaluated;
+}
+
+function sourceCoversStationDomain(source, operatorId, domain) {
+  const sourceDomain = {
+    FACILITY: "accessibility_facilities",
+    EXIT: "indoor_movement_paths",
+    TRANSFER: "indoor_movement_paths",
+  }[domain];
+  return ABSENCE_EVIDENCE_MODES.has(source?.accessibilityAdmissionEvidence?.absenceEvidenceMode)
+    && source?.coverageScope?.operatorIds?.includes(operatorId)
+    && source?.coverageScope?.sourceDomains?.includes(sourceDomain);
 }
 
 function buildStationDomainMatrix(artifacts, stationLines, evaluated) {
@@ -544,9 +558,14 @@ export async function loadMolitTransferSnapshot({
     throw new Error("MOLIT transfer snapshot binding mismatch");
   }
   const evaluatedMillis = Date.parse(evaluatedAt);
+  const capturedMillis = Date.parse(metadata.capturedAt);
+  const observedMillis = Date.parse(metadata.observedAt);
   const freshUntilMillis = Date.parse(metadata.freshUntil);
-  if (!Number.isFinite(evaluatedMillis) || !Number.isFinite(freshUntilMillis)) {
+  if (![evaluatedMillis, capturedMillis, observedMillis, freshUntilMillis].every(Number.isFinite)) {
     throw new TypeError("MOLIT transfer snapshot freshness is invalid");
+  }
+  if (capturedMillis > evaluatedMillis || observedMillis > evaluatedMillis) {
+    throw new Error("MOLIT transfer snapshot is future-dated");
   }
   if (freshUntilMillis <= evaluatedMillis) throw new Error("MOLIT transfer snapshot is stale");
   const rebuilt = buildMolitRailwayTransferMovementSnapshot({

--- a/tools/datapack/build-accessibility-source-coverage-report.mjs
+++ b/tools/datapack/build-accessibility-source-coverage-report.mjs
@@ -24,6 +24,13 @@ const VIOLATION_KEYS = Object.freeze([
   "artifactIdentity",
 ]);
 const ABSENCE_EVIDENCE_MODES = new Set(["EXPLICIT_ZERO", "EXHAUSTIVE_LIST"]);
+const COVERAGE_REGION_IDS = Object.freeze({
+  "수도권": "capital",
+  "부산권": "busan",
+  "대구권": "daegu",
+  "광주권": "gwangju",
+  "대전권": "daejeon",
+});
 
 export function buildAccessibilitySourceCoverageReport({
   artifacts,
@@ -205,7 +212,7 @@ function collectEvaluatedStationDomains(artifacts, validClaims, sources) {
         : undefined;
       const source = sources.get(claim.sourceId);
       if (!stationLine || !validClaims.has(claim)
-        || !sourceCoversStationDomain(source, stationLine.operatorId, domain)) continue;
+        || !sourceCoversStationDomain(source, stationLine, domain)) continue;
       const key = `${artifact.artifactId}\0${stationLine.operatorId}\0${domain}`;
       const entry = evaluated.get(key) ?? { stationLines: new Set(), sourceIds: new Set() };
       entry.stationLines.add(`${claim.stationId}\0${claim.lineId}`);
@@ -216,15 +223,18 @@ function collectEvaluatedStationDomains(artifacts, validClaims, sources) {
   return evaluated;
 }
 
-function sourceCoversStationDomain(source, operatorId, domain) {
+function sourceCoversStationDomain(source, stationLine, domain) {
   const sourceDomain = {
     FACILITY: "accessibility_facilities",
     EXIT: "indoor_movement_paths",
     TRANSFER: "indoor_movement_paths",
   }[domain];
+  const scope = source?.coverageScope;
   return ABSENCE_EVIDENCE_MODES.has(source?.accessibilityAdmissionEvidence?.absenceEvidenceMode)
-    && source?.coverageScope?.operatorIds?.includes(operatorId)
-    && source?.coverageScope?.sourceDomains?.includes(sourceDomain);
+    && scope?.regionIds?.includes(stationLine.regionId)
+    && scope?.operatorIds?.includes(stationLine.operatorId)
+    && (!scope.lineIds || scope.lineIds.includes(stationLine.lineId))
+    && scope?.sourceDomains?.includes(sourceDomain);
 }
 
 function buildStationDomainMatrix(artifacts, stationLines, evaluated) {
@@ -615,9 +625,10 @@ function readAccessibilityArtifact(sqlitePath, artifactId, sqliteSha256) {
       && tableHasColumns(database, "operators", ["id", "name_ko"])
       && tableHasColumns(database, "lines", ["id", "operator_id", "name_ko"])
       && tableHasColumns(database, "station_lines", ["station_id", "line_id"])
-      && tableHasColumns(database, "stations", ["id", "name_ko"])
+      && tableHasColumns(database, "stations", ["id", "name_ko", "region"])
       ? database.prepare(`
           SELECT station_lines.station_id AS station_id, stations.name_ko AS station_name,
+                 stations.region AS region_id,
                  station_lines.line_id AS line_id, lines.name_ko AS line_name,
                  operators.id AS operator_id, operators.name_ko AS operator_name
           FROM station_lines
@@ -629,6 +640,7 @@ function readAccessibilityArtifact(sqlitePath, artifactId, sqliteSha256) {
           stationId: row.station_id,
           stationName: row.station_name,
           stationAliases: stationAliases.get(row.station_id) ?? [],
+          regionId: COVERAGE_REGION_IDS[row.region_id],
           lineId: row.line_id,
           lineName: row.line_name,
           operatorId: row.operator_id,

--- a/tools/datapack/build-accessibility-source-coverage-report.mjs
+++ b/tools/datapack/build-accessibility-source-coverage-report.mjs
@@ -7,6 +7,13 @@ import { DatabaseSync } from "node:sqlite";
 import { pathToFileURL } from "node:url";
 import { gunzipSync } from "node:zlib";
 
+import {
+  buildMolitRailwayTransferMovementSnapshot,
+  MOLIT_RAILWAY_TRANSFER_MOVEMENT_SOURCE_ID,
+} from "./collect-molit-railway-transfer-movement.mjs";
+import { validateKricProviderCodeCatalogIdentity } from "./build-molit-nationwide-fixture.mjs";
+import { normalizeMolitProviderLineName } from "./lib/molit-svg-provider-identity.mjs";
+
 const VIOLATION_KEYS = Object.freeze([
   "freshness",
   "license",
@@ -24,6 +31,8 @@ export function buildAccessibilitySourceCoverageReport({
   snapshots,
   sourceSnapshotPolicies,
   evaluatedAt,
+  molitTransferSnapshot,
+  providerCodeCatalog,
 }) {
   const evaluatedMillis = Date.parse(evaluatedAt);
   if (!Number.isFinite(evaluatedMillis)) throw new TypeError("evaluatedAt must be an ISO instant");
@@ -44,6 +53,7 @@ export function buildAccessibilitySourceCoverageReport({
   ]));
   const artifactIds = new Set();
   const providerDomains = new Map();
+  const validClaims = new Set();
   const referencedSourceIds = new Set(
     artifacts.flatMap((artifact) => artifact.claims ?? []).map((claim) => claim.sourceId).filter(Boolean),
   );
@@ -63,7 +73,7 @@ export function buildAccessibilitySourceCoverageReport({
       violations.artifactIdentity.push(`${artifact.artifactId}:SQLITE_SHA256_INVALID`);
     }
     for (const claim of artifact.claims ?? []) {
-      validateClaim(artifact, claim, sources, snapshotsByIdentity, violations);
+      if (validateClaim(artifact, claim, sources, snapshotsByIdentity, violations)) validClaims.add(claim);
       if (!claim.sourceId) continue;
       const key = `${claim.sourceId}\0${claim.domain}`;
       const entry = providerDomains.get(key) ?? {
@@ -85,6 +95,9 @@ export function buildAccessibilitySourceCoverageReport({
       .filter((value) => value.split(":").length === 2)
       .map((value) => value.split(":", 1)[0]),
   );
+  for (const claim of validClaims) {
+    if (blockedSources.has(claim.sourceId)) validClaims.delete(claim);
+  }
   const providerDomainMatrix = [...providerDomains.values()]
     .map((entry) => ({
       sourceId: entry.sourceId,
@@ -100,8 +113,21 @@ export function buildAccessibilitySourceCoverageReport({
       sqliteSha256: artifact.sqliteSha256,
       searchableStationCount: new Set(artifact.searchableStationIds ?? []).size,
       claimCount: artifact.claims?.length ?? 0,
+      ...(Array.isArray(artifact.stationLines) ? {
+        stationLineCount: artifact.stationLines.length,
+        operatorCount: new Set(artifact.stationLines.map(({ operatorId }) => operatorId)).size,
+      } : {}),
     }))
     .sort((left, right) => compareStrings(left.artifactId, right.artifactId));
+
+  const stationDomainSourceGate = molitTransferSnapshot && providerCodeCatalog
+    ? buildStationDomainSourceGate({
+        artifacts,
+        validClaims,
+        molitTransferSnapshot,
+        providerCodeCatalog,
+      })
+    : undefined;
 
   return {
     schemaVersion: 1,
@@ -109,9 +135,244 @@ export function buildAccessibilitySourceCoverageReport({
     evaluatedAt,
     artifacts: artifactSummaries,
     providerDomainMatrix,
+    ...(stationDomainSourceGate ? { stationDomainSourceGate } : {}),
     violations,
-    decision: Object.values(violations).every((values) => values.length === 0) ? "GO" : "NO_GO",
+    decision: Object.values(violations).every((values) => values.length === 0)
+      && (!stationDomainSourceGate || stationDomainSourceGate.decision === "GO") ? "GO" : "NO_GO",
   };
+}
+
+export function buildStationDomainSourceGate({
+  artifacts, validClaims, molitTransferSnapshot, providerCodeCatalog,
+}) {
+  const stationLines = artifacts.flatMap((artifact) => (artifact.stationLines ?? []).map((row) => ({
+    ...row,
+    artifactId: artifact.artifactId,
+  })));
+  if (stationLines.length === 0) throw new Error("station domain gate requires artifact station-lines");
+  if (!Array.isArray(molitTransferSnapshot?.rows)
+    || molitTransferSnapshot.rows.length !== molitTransferSnapshot.rowCount) {
+    throw new Error("MOLIT transfer snapshot row count mismatch");
+  }
+
+  const evaluated = new Map();
+  for (const artifact of artifacts) {
+    const stationLineByKey = new Map((artifact.stationLines ?? []).map((row) => [
+      `${row.stationId}\0${row.lineId}`,
+      row,
+    ]));
+    for (const claim of artifact.claims ?? []) {
+      const domain = stationDomainForClaim(claim);
+      const stationLine = domain && claim.lineId
+        ? stationLineByKey.get(`${claim.stationId}\0${claim.lineId}`)
+        : undefined;
+      if (!stationLine || !validClaims.has(claim)) continue;
+      const key = `${artifact.artifactId}\0${stationLine.operatorId}\0${domain}`;
+      const entry = evaluated.get(key) ?? { stationLines: new Set(), sourceIds: new Set() };
+      entry.stationLines.add(`${claim.stationId}\0${claim.lineId}`);
+      entry.sourceIds.add(claim.sourceId);
+      evaluated.set(key, entry);
+    }
+  }
+
+  const operators = new Map();
+  for (const { operatorId, operatorName } of stationLines) {
+    if (operators.has(operatorId) && operators.get(operatorId) !== operatorName) {
+      throw new Error(`operator identity mismatch: ${operatorId}`);
+    }
+    operators.set(operatorId, operatorName);
+  }
+  const matrix = [...operators].flatMap(([operatorId, operatorName]) =>
+    ["FACILITY", "EXIT", "TRANSFER"].map((domain) => {
+      const scopedLines = stationLines.filter((row) => row.operatorId === operatorId);
+      const evaluatedKeys = new Set();
+      const sourceIds = new Set();
+      const artifactScopes = [];
+      for (const artifact of artifacts) {
+        const entry = evaluated.get(`${artifact.artifactId}\0${operatorId}\0${domain}`);
+        const artifactStationLineCount = (artifact.stationLines ?? [])
+          .filter((row) => row.operatorId === operatorId).length;
+        if (artifactStationLineCount === 0) continue;
+        for (const stationLine of entry?.stationLines ?? []) {
+          evaluatedKeys.add(`${artifact.artifactId}\0${stationLine}`);
+        }
+        for (const sourceId of entry?.sourceIds ?? []) sourceIds.add(sourceId);
+        artifactScopes.push({
+          artifactId: artifact.artifactId,
+          stationLineCount: artifactStationLineCount,
+          evaluatedStationLineCount: entry?.stationLines.size ?? 0,
+          missingStationLineCount: artifactStationLineCount - (entry?.stationLines.size ?? 0),
+        });
+      }
+      artifactScopes.sort((left, right) => compareStrings(left.artifactId, right.artifactId));
+      const missingStationLineCount = scopedLines.length - evaluatedKeys.size;
+      const blockingReasons = [];
+      if (sourceIds.size === 0) blockingReasons.push("NO_ADMITTED_SOURCE");
+      if (missingStationLineCount > 0) blockingReasons.push("STATION_LINE_COVERAGE_INCOMPLETE");
+      return {
+        operatorId,
+        operatorName,
+        domain,
+        stationLineCount: scopedLines.length,
+        evaluatedStationLineCount: evaluatedKeys.size,
+        missingStationLineCount,
+        artifacts: artifactScopes,
+        sourceIds: [...sourceIds].sort(compareStrings),
+        blockingReasons,
+        requiredEvidence: requiredEvidenceFor(domain),
+        status: blockingReasons.length === 0 ? "ADMITTED" : "BLOCKED",
+      };
+    }))
+    .sort((left, right) => compareStrings(`${left.operatorId}\0${left.domain}`, `${right.operatorId}\0${right.domain}`));
+  const transferTuplePartition = partitionMolitTransferTuples({
+    artifacts,
+    rows: molitTransferSnapshot.rows,
+    providerCodeCatalog,
+  });
+  const partitionIsComplete = transferTuplePartition.summary.joinedRowCount
+    + transferTuplePartition.summary.unmatchedRowCount
+    + transferTuplePartition.summary.ambiguousRowCount === molitTransferSnapshot.rowCount;
+  if (!partitionIsComplete) throw new Error("MOLIT transfer tuple row partition mismatch");
+  transferTuplePartition.identity = Object.fromEntries([
+    "sourceId", "snapshotId", "rawSha256", "gzipSha256", "metadataFileSha256",
+    "sourceInventoryFileSha256", "sourceInventorySha256", "candidateBuildSpecSourceInventorySha256", "rowCount",
+  ].map((key) => [key, molitTransferSnapshot[key]]));
+  const decision = matrix.every(({ status }) => status === "ADMITTED")
+    && transferTuplePartition.unmatched.length === 0
+    && transferTuplePartition.ambiguous.length === 0 ? "GO" : "NO_GO";
+  return { matrix, transferTuplePartition, decision };
+}
+
+export function partitionMolitTransferTuples({ artifacts, rows, providerCodeCatalog }) {
+  if (!Array.isArray(rows) || !Array.isArray(providerCodeCatalog?.providerLines)) {
+    throw new TypeError("MOLIT rows and provider code catalog are required");
+  }
+  const canonical = new Map();
+  const artifactsByProviderLine = new Map();
+  for (const artifact of artifacts) {
+    for (const stationLine of artifact.stationLines ?? []) {
+      const providerLineKey = `${stationLine.operatorName}\0${normalizeMolitProviderLineName(stationLine.lineName)}`;
+      const artifactIds = artifactsByProviderLine.get(providerLineKey) ?? new Set();
+      artifactIds.add(artifact.artifactId);
+      artifactsByProviderLine.set(providerLineKey, artifactIds);
+      const entry = { ...stationLine, artifactId: artifact.artifactId };
+      for (const name of [stationLine.stationName, ...(stationLine.stationAliases ?? [])]) {
+        const nameKey = `${artifact.artifactId}\0${providerLineKey}\0${normalizeStationName(name)}`;
+        const byIdentity = canonical.get(nameKey) ?? new Map();
+        const identity = `${stationLine.operatorId}\0${stationLine.lineId}\0${stationLine.stationId}`;
+        byIdentity.set(identity, entry);
+        canonical.set(nameKey, byIdentity);
+      }
+    }
+  }
+
+  const tuples = new Map();
+  for (const row of rows) {
+    const values = [row.RAIL_OPR_ISTT_CD, row.LN_NM, row.STIN_NM];
+    if (values.some((value) => typeof value !== "string" || value.trim() === "")) {
+      throw new Error("MOLIT transfer tuple identity is blank");
+    }
+    const key = values.join("\0");
+    const tuple = tuples.get(key) ?? { row, rowCount: 0 };
+    tuple.rowCount += 1;
+    tuples.set(key, tuple);
+  }
+
+  const partition = { joined: [], unmatched: [], ambiguous: [] };
+  for (const [, { row, rowCount }] of [...tuples].sort(([left], [right]) => compareStrings(left, right))) {
+    const provider = parseMolitOperator(row.RAIL_OPR_ISTT_CD);
+    const lineName = normalizeMolitProviderLineName(row.LN_NM);
+    const providerLines = providerCodeCatalog.providerLines.filter((line) =>
+      line.railOprIsttCd === provider.code && normalizeMolitProviderLineName(line.lineName) === lineName);
+    const base = {
+      providerOperatorCode: provider.code,
+      providerOperatorName: provider.name,
+      providerLineName: row.LN_NM,
+      providerStationName: row.STIN_NM,
+      rowCount,
+    };
+    if (providerLines.length === 0) {
+      partition.unmatched.push({ ...base, reason: "PROVIDER_LINE_SCOPE_UNMAPPED" });
+      continue;
+    }
+    if (providerLines.length > 1) {
+      partition.ambiguous.push({ ...base, reason: "PROVIDER_LINE_SCOPE_AMBIGUOUS" });
+      continue;
+    }
+    const providerLineKey = `${provider.name}\0${lineName}`;
+    const artifactIds = [...(artifactsByProviderLine.get(providerLineKey) ?? [])].sort(compareStrings);
+    if (artifactIds.length === 0) {
+      partition.unmatched.push({ ...base, reason: "CANONICAL_LINE_SCOPE_UNMATCHED" });
+      continue;
+    }
+    const matchesByArtifact = artifactIds.map((artifactId) => ({
+      artifactId,
+      matches: [...(canonical.get(
+        `${artifactId}\0${providerLineKey}\0${normalizeStationName(row.STIN_NM)}`,
+      )?.values() ?? [])].sort((left, right) => compareStrings(
+        `${left.operatorId}\0${left.lineId}\0${left.stationId}`,
+        `${right.operatorId}\0${right.lineId}\0${right.stationId}`,
+      )),
+    }));
+    const ambiguous = matchesByArtifact.filter(({ matches }) => matches.length > 1);
+    const unmatched = matchesByArtifact.filter(({ matches }) => matches.length === 0);
+    if (ambiguous.length > 0) {
+      partition.ambiguous.push({
+        ...base,
+        reason: "CANONICAL_STATION_AMBIGUOUS",
+        candidates: ambiguous.flatMap(({ matches }) => matches),
+      });
+    } else if (unmatched.length > 0) {
+      partition.unmatched.push({
+        ...base,
+        reason: "CANONICAL_STATION_UNMATCHED",
+        unmatchedArtifactIds: unmatched.map(({ artifactId }) => artifactId),
+      });
+    } else {
+      partition.joined.push({
+        ...base,
+        mappings: matchesByArtifact.map(({ matches: [match] }) => {
+          const { stationAliases: ignoredAliases, ...mapping } = match;
+          return mapping;
+        }),
+      });
+    }
+  }
+  const sumRows = (entries) => entries.reduce((total, entry) => total + entry.rowCount, 0);
+  return {
+    summary: {
+      rowCount: rows.length,
+      tupleCount: tuples.size,
+      joinedTupleCount: partition.joined.length,
+      joinedRowCount: sumRows(partition.joined),
+      unmatchedTupleCount: partition.unmatched.length,
+      unmatchedRowCount: sumRows(partition.unmatched),
+      ambiguousTupleCount: partition.ambiguous.length,
+      ambiguousRowCount: sumRows(partition.ambiguous),
+    },
+    ...partition,
+  };
+}
+
+function stationDomainForClaim(claim) {
+  if (["STATION_FACILITY_EVIDENCE", "FACILITY"].includes(claim.domain)) return "FACILITY";
+  if (claim.domain === "STATION_EXIT") return "EXIT";
+  if (claim.domain === "NETWORK_EDGE" && claim.facilityType === "OUT_OF_STATION_TRANSFER") return "TRANSFER";
+  return undefined;
+}
+
+function requiredEvidenceFor(domain) {
+  return {
+    FACILITY: "OFFICIAL_EXHAUSTIVE_FACILITY_SNAPSHOT_OR_EXPLICIT_ZERO",
+    EXIT: "OFFICIAL_EXHAUSTIVE_EXIT_PATH_SNAPSHOT_OR_EXPLICIT_ZERO",
+    TRANSFER: "OFFICIAL_TRANSFER_TOPOLOGY_AND_ACCESSIBILITY_SNAPSHOT",
+  }[domain];
+}
+
+function parseMolitOperator(value) {
+  const match = /^([A-Z0-9]+)\(([^()]+)\)$/.exec(value);
+  if (!match) throw new Error(`MOLIT provider operator identity is invalid: ${value}`);
+  return { code: match[1], name: match[2].trim() };
 }
 
 export async function loadSelectableAccessibilityArtifacts({
@@ -163,6 +424,54 @@ export async function loadAccessibilityAdmissionSnapshots({ sources, referencedS
   }));
 }
 
+export async function loadMolitTransferSnapshot({
+  metadataPath, inventory, inventoryBytes, candidateBuildSpec, repositoryRoot,
+}) {
+  const source = inventory?.sources?.find(({ id }) => id === MOLIT_RAILWAY_TRANSFER_MOVEMENT_SOURCE_ID);
+  const admission = source?.rawSnapshotAdmission;
+  const expectedMetadataPath = path.resolve(repositoryRoot, admission?.metadataPath ?? "");
+  if (!admission || admission.status !== "LOCKED"
+    || !expectedMetadataPath.endsWith(".csv.gz.json")
+    || path.resolve(metadataPath) !== expectedMetadataPath) {
+    throw new Error("MOLIT transfer metadata path is not inventory-bound");
+  }
+  const [metadataBytes, gzipBytes] = await Promise.all([
+    readFile(expectedMetadataPath),
+    readFile(expectedMetadataPath.replace(/\.json$/, "")),
+  ]);
+  const metadataFileSha256 = digest(metadataBytes);
+  const sourceInventoryFileSha256 = digest(inventoryBytes);
+  const sourceInventorySha256 = digest(JSON.stringify(inventory));
+  const metadata = JSON.parse(metadataBytes);
+  if (metadataFileSha256 !== admission.metadataFileSha256
+    || digest(gzipBytes) !== admission.gzipSha256
+    || metadata.sourceId !== source.id
+    || metadata.snapshotId !== admission.snapshotId
+    || metadata.gzipSha256 !== admission.gzipSha256
+    || metadata.rawSha256 !== admission.rawSha256
+    || metadata.rowCount !== admission.rowCount
+    || candidateBuildSpec?.sourceInventorySha256 !== sourceInventorySha256) {
+    throw new Error("MOLIT transfer snapshot binding mismatch");
+  }
+  const rebuilt = buildMolitRailwayTransferMovementSnapshot({
+    bytes: gunzipSync(gzipBytes),
+    capturedAt: metadata.capturedAt,
+  });
+  const { gzipBytes: ignored, rows, gzipSha256: ignoredPlatformGzipSha256, ...rebuiltMetadata } = rebuilt;
+  const { gzipSha256: ignoredStoredGzipSha256, ...logicalMetadata } = metadata;
+  if (JSON.stringify({ ...rebuiltMetadata, gzipPath: metadata.gzipPath }) !== JSON.stringify(logicalMetadata)) {
+    throw new Error("MOLIT transfer logical metadata mismatch");
+  }
+  return {
+    ...metadata,
+    metadataFileSha256,
+    sourceInventoryFileSha256,
+    sourceInventorySha256,
+    candidateBuildSpecSourceInventorySha256: candidateBuildSpec.sourceInventorySha256,
+    rows,
+  };
+}
+
 function readAccessibilityArtifact(sqlitePath, artifactId, sqliteSha256) {
   const database = new DatabaseSync(sqlitePath, { readOnly: true });
   try {
@@ -175,6 +484,33 @@ function readAccessibilityArtifact(sqlitePath, artifactId, sqliteSha256) {
       JOIN station_lines ON station_lines.station_id = stations.id
       ORDER BY stations.id
     `).all().map(({ id }) => id);
+    const stationAliases = tableExists(database, "station_aliases")
+      ? database.prepare("SELECT station_id, alias FROM station_aliases ORDER BY station_id, alias").all()
+        .reduce((aliases, row) => {
+          aliases.set(row.station_id, [...(aliases.get(row.station_id) ?? []), row.alias]);
+          return aliases;
+        }, new Map())
+      : new Map();
+    const stationLines = ["operators", "lines", "station_lines", "stations"].every((table) => tableExists(database, table))
+      ? database.prepare(`
+          SELECT station_lines.station_id AS station_id, stations.name_ko AS station_name,
+                 station_lines.line_id AS line_id, lines.name_ko AS line_name,
+                 operators.id AS operator_id, operators.name_ko AS operator_name
+          FROM station_lines
+          JOIN stations ON stations.id = station_lines.station_id
+          JOIN lines ON lines.id = station_lines.line_id
+          JOIN operators ON operators.id = lines.operator_id
+          ORDER BY operators.id, lines.id, stations.id
+        `).all().map((row) => ({
+          stationId: row.station_id,
+          stationName: row.station_name,
+          stationAliases: stationAliases.get(row.station_id) ?? [],
+          lineId: row.line_id,
+          lineName: row.line_name,
+          operatorId: row.operator_id,
+          operatorName: row.operator_name,
+        }))
+      : undefined;
     const evidenceClaims = tableExists(database, "station_facility_evidence")
       ? database.prepare(`
           SELECT station_id, line_id, facility_type, evidence_kind, source_id, source_snapshot_id,
@@ -326,7 +662,13 @@ function readAccessibilityArtifact(sqlitePath, artifactId, sqliteSha256) {
       const stationName = stationNames.get(claim.stationId);
       return stationName ? { ...claim, stationName } : claim;
     });
-    return { artifactId, sqliteSha256, searchableStationIds, claims };
+    return {
+      artifactId,
+      sqliteSha256,
+      searchableStationIds,
+      ...(stationLines ? { stationLines } : {}),
+      claims,
+    };
   } finally {
     database.close();
   }
@@ -455,21 +797,27 @@ function validateClaim(artifact, claim, sources, snapshotsByIdentity, violations
     || claim.sourceSnapshotId !== evidence?.snapshotId
     || !sha256(claim.providerRecordHash)
     || !sha256(claim.evidenceHash);
+  let valid = true;
   if (provenanceMissing) {
     violations.provenance.push(`${claimId}:PROVENANCE_MISSING`);
+    valid = false;
   } else {
     const snapshot = snapshotsByIdentity.get(`${claim.sourceId}\0${claim.sourceSnapshotId}`);
     if (!claimMatchesSnapshot(snapshot, claim)) {
       violations.provenance.push(`${claimId}:CLAIM_SNAPSHOT_BINDING_MISMATCH`);
+      valid = false;
     }
   }
   if (placeholderHash(claim.providerRecordHash) || placeholderHash(claim.evidenceHash)) {
     violations.placeholder.push(`${claimId}:EVIDENCE_HASH_PLACEHOLDER`);
+    valid = false;
   }
   if (claim.evidenceKind === "NOT_EXISTS"
     && !ABSENCE_EVIDENCE_MODES.has(evidence?.absenceEvidenceMode)) {
     violations.absenceEvidence.push(`${claimId}:ABSENCE_EVIDENCE_MISSING`);
+    valid = false;
   }
+  return valid;
 }
 
 function claimMatchesSnapshot(snapshot, claim) {
@@ -554,12 +902,25 @@ async function main(argv) {
   for (const name of ["manifest", "bundled-index", "inventory", "source-snapshots", "evaluation-at", "output"]) {
     if (!args[name]) throw new Error(`missing --${name}`);
   }
-  const [manifest, bundledIndex, inventory, sourceSnapshotPolicies] = await Promise.all([
+  if (args["station-domain-gate"] !== undefined && args["station-domain-gate"] !== "true") {
+    throw new Error("--station-domain-gate must be true");
+  }
+  const gateEnabled = args["station-domain-gate"] === "true";
+  if (gateEnabled && ["molit-transfer-metadata", "kric-provider-code-catalog", "candidate-build-spec"]
+    .some((name) => !args[name])) {
+    throw new Error("station domain gate inputs are required");
+  }
+  if (args["expected-station-domain-decision"]
+    && (!gateEnabled || !new Set(["GO", "NO_GO"]).has(args["expected-station-domain-decision"]))) {
+    throw new Error("--expected-station-domain-decision requires the gate and must be GO or NO_GO");
+  }
+  const inventoryBytes = await readFile(args.inventory);
+  const [manifest, bundledIndex, sourceSnapshotPolicies] = await Promise.all([
     readJson(args.manifest),
     readJson(args["bundled-index"]),
-    readJson(args.inventory),
     readJson(args["source-snapshots"]),
   ]);
+  const inventory = JSON.parse(inventoryBytes);
   const artifacts = await loadSelectableAccessibilityArtifacts({
     manifest,
     manifestRoot: args["manifest-root"] ?? manifestAssetRoot(args.manifest),
@@ -574,16 +935,36 @@ async function main(argv) {
     referencedSourceIds,
     repositoryRoot: path.resolve(path.dirname(args.inventory), "../.."),
   });
+  let molitTransferSnapshot;
+  let providerCodeCatalog;
+  if (gateEnabled) {
+    [providerCodeCatalog, molitTransferSnapshot] = await Promise.all([
+      readJson(args["kric-provider-code-catalog"]),
+      loadMolitTransferSnapshot({
+        metadataPath: args["molit-transfer-metadata"],
+        inventory,
+        inventoryBytes,
+        candidateBuildSpec: await readJson(args["candidate-build-spec"]),
+        repositoryRoot: path.resolve(path.dirname(args.inventory), "../.."),
+      }),
+    ]);
+    validateKricProviderCodeCatalogIdentity(providerCodeCatalog);
+  }
   const report = buildAccessibilitySourceCoverageReport({
     artifacts,
     inventory,
     snapshots,
     sourceSnapshotPolicies,
     evaluatedAt: args["evaluation-at"],
+    molitTransferSnapshot,
+    providerCodeCatalog,
   });
   await mkdir(path.dirname(args.output), { recursive: true });
   await writeFile(args.output, `${JSON.stringify(report, null, 2)}\n`);
-  if (report.decision !== "GO") process.exitCode = 1;
+  if (args["expected-station-domain-decision"]
+    ? Object.values(report.violations).some((values) => values.length > 0)
+      || report.stationDomainSourceGate.decision !== args["expected-station-domain-decision"]
+    : report.decision !== "GO") process.exitCode = 1;
 }
 
 function parseArgs(argv) {

--- a/tools/datapack/build-accessibility-source-coverage-report.mjs
+++ b/tools/datapack/build-accessibility-source-coverage-report.mjs
@@ -120,6 +120,9 @@ export function buildAccessibilitySourceCoverageReport({
     }))
     .sort((left, right) => compareStrings(left.artifactId, right.artifactId));
 
+  if (Boolean(molitTransferSnapshot) !== Boolean(providerCodeCatalog)) {
+    throw new TypeError("station domain gate inputs must be provided together");
+  }
   const stationDomainSourceGate = molitTransferSnapshot && providerCodeCatalog
     ? buildStationDomainSourceGate({
         artifacts,
@@ -166,10 +169,18 @@ export function buildStationDomainSourceGate({
     + transferTuplePartition.summary.unmatchedRowCount
     + transferTuplePartition.summary.ambiguousRowCount === molitTransferSnapshot.rowCount;
   if (!partitionIsComplete) throw new Error("MOLIT transfer tuple row partition mismatch");
-  transferTuplePartition.identity = Object.fromEntries([
+  const identity = Object.fromEntries([
     "sourceId", "snapshotId", "rawSha256", "gzipSha256", "metadataFileSha256",
     "sourceInventoryFileSha256", "sourceInventorySha256", "candidateBuildSpecSourceInventorySha256", "rowCount",
   ].map((key) => [key, molitTransferSnapshot[key]]));
+  if (typeof identity.sourceId !== "string" || identity.sourceId === ""
+    || typeof identity.snapshotId !== "string" || identity.snapshotId === ""
+    || !Number.isInteger(identity.rowCount) || identity.rowCount < 0
+    || ["rawSha256", "gzipSha256", "metadataFileSha256", "sourceInventoryFileSha256",
+      "sourceInventorySha256", "candidateBuildSpecSourceInventorySha256"].some((key) => !sha256(identity[key]))) {
+    throw new Error("MOLIT transfer snapshot identity is invalid");
+  }
+  transferTuplePartition.identity = identity;
   const decision = matrix.every(({ status }) => status === "ADMITTED")
     && transferTuplePartition.unmatched.length === 0
     && transferTuplePartition.ambiguous.length === 0 ? "GO" : "NO_GO";
@@ -201,17 +212,27 @@ function collectEvaluatedStationDomains(artifacts, validClaims) {
 
 function buildStationDomainMatrix(artifacts, stationLines, evaluated) {
   const operators = new Map();
+  const stationLineCountsByOperator = new Map();
+  const artifactStationLineCounts = new Map();
   for (const { operatorId, operatorName } of stationLines) {
     if (operators.has(operatorId) && operators.get(operatorId) !== operatorName) {
       throw new Error(`operator identity mismatch: ${operatorId}`);
     }
     operators.set(operatorId, operatorName);
+    stationLineCountsByOperator.set(operatorId, (stationLineCountsByOperator.get(operatorId) ?? 0) + 1);
+  }
+  for (const artifact of artifacts) {
+    for (const { operatorId } of artifact.stationLines ?? []) {
+      const key = `${artifact.artifactId}\0${operatorId}`;
+      artifactStationLineCounts.set(key, (artifactStationLineCounts.get(key) ?? 0) + 1);
+    }
   }
   return [...operators].flatMap(([operatorId, operatorName]) =>
     ["FACILITY", "EXIT", "TRANSFER"].map((domain) => buildStationDomainCell({
       artifacts,
-      stationLines,
       evaluated,
+      stationLineCountsByOperator,
+      artifactStationLineCounts,
       operatorId,
       operatorName,
       domain,
@@ -219,15 +240,17 @@ function buildStationDomainMatrix(artifacts, stationLines, evaluated) {
     .sort((left, right) => compareStrings(`${left.operatorId}\0${left.domain}`, `${right.operatorId}\0${right.domain}`));
 }
 
-function buildStationDomainCell({ artifacts, stationLines, evaluated, operatorId, operatorName, domain }) {
-  const scopedLines = stationLines.filter((row) => row.operatorId === operatorId);
+function buildStationDomainCell({
+  artifacts, evaluated, stationLineCountsByOperator, artifactStationLineCounts,
+  operatorId, operatorName, domain,
+}) {
+  const stationLineCount = stationLineCountsByOperator.get(operatorId) ?? 0;
   const evaluatedKeys = new Set();
   const sourceIds = new Set();
   const artifactScopes = [];
   for (const artifact of artifacts) {
     const entry = evaluated.get(`${artifact.artifactId}\0${operatorId}\0${domain}`);
-    const artifactStationLineCount = (artifact.stationLines ?? [])
-      .filter((row) => row.operatorId === operatorId).length;
+    const artifactStationLineCount = artifactStationLineCounts.get(`${artifact.artifactId}\0${operatorId}`) ?? 0;
     if (artifactStationLineCount === 0) continue;
     for (const stationLine of entry?.stationLines ?? []) {
       evaluatedKeys.add(`${artifact.artifactId}\0${stationLine}`);
@@ -241,7 +264,7 @@ function buildStationDomainCell({ artifacts, stationLines, evaluated, operatorId
     });
   }
   artifactScopes.sort((left, right) => compareStrings(left.artifactId, right.artifactId));
-  const missingStationLineCount = scopedLines.length - evaluatedKeys.size;
+  const missingStationLineCount = stationLineCount - evaluatedKeys.size;
   const blockingReasons = [];
   if (sourceIds.size === 0) blockingReasons.push("NO_ADMITTED_SOURCE");
   if (missingStationLineCount > 0) blockingReasons.push("STATION_LINE_COVERAGE_INCOMPLETE");
@@ -249,7 +272,7 @@ function buildStationDomainCell({ artifacts, stationLines, evaluated, operatorId
     operatorId,
     operatorName,
     domain,
-    stationLineCount: scopedLines.length,
+    stationLineCount,
     evaluatedStationLineCount: evaluatedKeys.size,
     missingStationLineCount,
     artifacts: artifactScopes,
@@ -478,7 +501,7 @@ export async function loadAccessibilityAdmissionSnapshots({ sources, referencedS
 }
 
 export async function loadMolitTransferSnapshot({
-  metadataPath, inventory, inventoryBytes, candidateBuildSpec, repositoryRoot,
+  metadataPath, inventory, inventoryBytes, candidateBuildSpec, repositoryRoot, evaluatedAt,
 }) {
   const source = inventory?.sources?.find(({ id }) => id === MOLIT_RAILWAY_TRANSFER_MOVEMENT_SOURCE_ID);
   const admission = source?.rawSnapshotAdmission;
@@ -506,6 +529,12 @@ export async function loadMolitTransferSnapshot({
     || candidateBuildSpec?.sourceInventorySha256 !== sourceInventorySha256) {
     throw new Error("MOLIT transfer snapshot binding mismatch");
   }
+  const evaluatedMillis = Date.parse(evaluatedAt);
+  const freshUntilMillis = Date.parse(metadata.freshUntil);
+  if (!Number.isFinite(evaluatedMillis) || !Number.isFinite(freshUntilMillis)) {
+    throw new TypeError("MOLIT transfer snapshot freshness is invalid");
+  }
+  if (freshUntilMillis <= evaluatedMillis) throw new Error("MOLIT transfer snapshot is stale");
   const rebuilt = buildMolitRailwayTransferMovementSnapshot({
     bytes: gunzipSync(gzipBytes),
     capturedAt: metadata.capturedAt,
@@ -517,7 +546,7 @@ export async function loadMolitTransferSnapshot({
   delete rebuiltMetadata.gzipSha256;
   const logicalMetadata = { ...metadata };
   delete logicalMetadata.gzipSha256;
-  if (JSON.stringify({ ...rebuiltMetadata, gzipPath: metadata.gzipPath }) !== JSON.stringify(logicalMetadata)) {
+  if (canonicalJson({ ...rebuiltMetadata, gzipPath: metadata.gzipPath }) !== canonicalJson(logicalMetadata)) {
     throw new Error("MOLIT transfer logical metadata mismatch");
   }
   return {
@@ -550,6 +579,10 @@ function readAccessibilityArtifact(sqlitePath, artifactId, sqliteSha256) {
         }, new Map())
       : new Map();
     const stationLines = ["operators", "lines", "station_lines", "stations"].every((table) => tableExists(database, table))
+      && tableHasColumns(database, "operators", ["id", "name_ko"])
+      && tableHasColumns(database, "lines", ["id", "operator_id", "name_ko"])
+      && tableHasColumns(database, "station_lines", ["station_id", "line_id"])
+      && tableHasColumns(database, "stations", ["id", "name_ko"])
       ? database.prepare(`
           SELECT station_lines.station_id AS station_id, stations.name_ko AS station_name,
                  station_lines.line_id AS line_id, lines.name_ko AS line_name,
@@ -955,6 +988,12 @@ function compareStrings(left, right) {
   return left < right ? -1 : left > right ? 1 : 0;
 }
 
+function canonicalJson(value) {
+  return JSON.stringify(value, (_key, inner) => inner && typeof inner === "object" && !Array.isArray(inner)
+    ? Object.fromEntries(Object.entries(inner).sort(([left], [right]) => compareStrings(left, right)))
+    : inner);
+}
+
 async function main(argv) {
   const args = parseArgs(argv);
   for (const name of ["manifest", "bundled-index", "inventory", "source-snapshots", "evaluation-at", "output"]) {
@@ -1004,6 +1043,7 @@ async function main(argv) {
         inventoryBytes,
         candidateBuildSpec: await readJson(args["candidate-build-spec"]),
         repositoryRoot: path.resolve(path.dirname(args.inventory), "../.."),
+        evaluatedAt: args["evaluation-at"],
       }),
     ]);
     validateKricProviderCodeCatalogIdentity(providerCodeCatalog);

--- a/tools/datapack/build-accessibility-source-coverage-report.mjs
+++ b/tools/datapack/build-accessibility-source-coverage-report.mjs
@@ -155,75 +155,8 @@ export function buildStationDomainSourceGate({
     throw new Error("MOLIT transfer snapshot row count mismatch");
   }
 
-  const evaluated = new Map();
-  for (const artifact of artifacts) {
-    const stationLineByKey = new Map((artifact.stationLines ?? []).map((row) => [
-      `${row.stationId}\0${row.lineId}`,
-      row,
-    ]));
-    for (const claim of artifact.claims ?? []) {
-      const domain = stationDomainForClaim(claim);
-      const stationLine = domain && claim.lineId
-        ? stationLineByKey.get(`${claim.stationId}\0${claim.lineId}`)
-        : undefined;
-      if (!stationLine || !validClaims.has(claim)) continue;
-      const key = `${artifact.artifactId}\0${stationLine.operatorId}\0${domain}`;
-      const entry = evaluated.get(key) ?? { stationLines: new Set(), sourceIds: new Set() };
-      entry.stationLines.add(`${claim.stationId}\0${claim.lineId}`);
-      entry.sourceIds.add(claim.sourceId);
-      evaluated.set(key, entry);
-    }
-  }
-
-  const operators = new Map();
-  for (const { operatorId, operatorName } of stationLines) {
-    if (operators.has(operatorId) && operators.get(operatorId) !== operatorName) {
-      throw new Error(`operator identity mismatch: ${operatorId}`);
-    }
-    operators.set(operatorId, operatorName);
-  }
-  const matrix = [...operators].flatMap(([operatorId, operatorName]) =>
-    ["FACILITY", "EXIT", "TRANSFER"].map((domain) => {
-      const scopedLines = stationLines.filter((row) => row.operatorId === operatorId);
-      const evaluatedKeys = new Set();
-      const sourceIds = new Set();
-      const artifactScopes = [];
-      for (const artifact of artifacts) {
-        const entry = evaluated.get(`${artifact.artifactId}\0${operatorId}\0${domain}`);
-        const artifactStationLineCount = (artifact.stationLines ?? [])
-          .filter((row) => row.operatorId === operatorId).length;
-        if (artifactStationLineCount === 0) continue;
-        for (const stationLine of entry?.stationLines ?? []) {
-          evaluatedKeys.add(`${artifact.artifactId}\0${stationLine}`);
-        }
-        for (const sourceId of entry?.sourceIds ?? []) sourceIds.add(sourceId);
-        artifactScopes.push({
-          artifactId: artifact.artifactId,
-          stationLineCount: artifactStationLineCount,
-          evaluatedStationLineCount: entry?.stationLines.size ?? 0,
-          missingStationLineCount: artifactStationLineCount - (entry?.stationLines.size ?? 0),
-        });
-      }
-      artifactScopes.sort((left, right) => compareStrings(left.artifactId, right.artifactId));
-      const missingStationLineCount = scopedLines.length - evaluatedKeys.size;
-      const blockingReasons = [];
-      if (sourceIds.size === 0) blockingReasons.push("NO_ADMITTED_SOURCE");
-      if (missingStationLineCount > 0) blockingReasons.push("STATION_LINE_COVERAGE_INCOMPLETE");
-      return {
-        operatorId,
-        operatorName,
-        domain,
-        stationLineCount: scopedLines.length,
-        evaluatedStationLineCount: evaluatedKeys.size,
-        missingStationLineCount,
-        artifacts: artifactScopes,
-        sourceIds: [...sourceIds].sort(compareStrings),
-        blockingReasons,
-        requiredEvidence: requiredEvidenceFor(domain),
-        status: blockingReasons.length === 0 ? "ADMITTED" : "BLOCKED",
-      };
-    }))
-    .sort((left, right) => compareStrings(`${left.operatorId}\0${left.domain}`, `${right.operatorId}\0${right.domain}`));
+  const evaluated = collectEvaluatedStationDomains(artifacts, validClaims);
+  const matrix = buildStationDomainMatrix(artifacts, stationLines, evaluated);
   const transferTuplePartition = partitionMolitTransferTuples({
     artifacts,
     rows: molitTransferSnapshot.rows,
@@ -243,10 +176,123 @@ export function buildStationDomainSourceGate({
   return { matrix, transferTuplePartition, decision };
 }
 
+function collectEvaluatedStationDomains(artifacts, validClaims) {
+  const evaluated = new Map();
+  for (const artifact of artifacts) {
+    const stationLineByKey = new Map((artifact.stationLines ?? []).map((row) => [
+      `${row.stationId}\0${row.lineId}`,
+      row,
+    ]));
+    for (const claim of artifact.claims ?? []) {
+      const domain = stationDomainForClaim(claim);
+      const stationLine = domain && claim.lineId
+        ? stationLineByKey.get(`${claim.stationId}\0${claim.lineId}`)
+        : undefined;
+      if (!stationLine || !validClaims.has(claim)) continue;
+      const key = `${artifact.artifactId}\0${stationLine.operatorId}\0${domain}`;
+      const entry = evaluated.get(key) ?? { stationLines: new Set(), sourceIds: new Set() };
+      entry.stationLines.add(`${claim.stationId}\0${claim.lineId}`);
+      entry.sourceIds.add(claim.sourceId);
+      evaluated.set(key, entry);
+    }
+  }
+  return evaluated;
+}
+
+function buildStationDomainMatrix(artifacts, stationLines, evaluated) {
+  const operators = new Map();
+  for (const { operatorId, operatorName } of stationLines) {
+    if (operators.has(operatorId) && operators.get(operatorId) !== operatorName) {
+      throw new Error(`operator identity mismatch: ${operatorId}`);
+    }
+    operators.set(operatorId, operatorName);
+  }
+  return [...operators].flatMap(([operatorId, operatorName]) =>
+    ["FACILITY", "EXIT", "TRANSFER"].map((domain) => buildStationDomainCell({
+      artifacts,
+      stationLines,
+      evaluated,
+      operatorId,
+      operatorName,
+      domain,
+    })))
+    .sort((left, right) => compareStrings(`${left.operatorId}\0${left.domain}`, `${right.operatorId}\0${right.domain}`));
+}
+
+function buildStationDomainCell({ artifacts, stationLines, evaluated, operatorId, operatorName, domain }) {
+  const scopedLines = stationLines.filter((row) => row.operatorId === operatorId);
+  const evaluatedKeys = new Set();
+  const sourceIds = new Set();
+  const artifactScopes = [];
+  for (const artifact of artifacts) {
+    const entry = evaluated.get(`${artifact.artifactId}\0${operatorId}\0${domain}`);
+    const artifactStationLineCount = (artifact.stationLines ?? [])
+      .filter((row) => row.operatorId === operatorId).length;
+    if (artifactStationLineCount === 0) continue;
+    for (const stationLine of entry?.stationLines ?? []) {
+      evaluatedKeys.add(`${artifact.artifactId}\0${stationLine}`);
+    }
+    for (const sourceId of entry?.sourceIds ?? []) sourceIds.add(sourceId);
+    artifactScopes.push({
+      artifactId: artifact.artifactId,
+      stationLineCount: artifactStationLineCount,
+      evaluatedStationLineCount: entry?.stationLines.size ?? 0,
+      missingStationLineCount: artifactStationLineCount - (entry?.stationLines.size ?? 0),
+    });
+  }
+  artifactScopes.sort((left, right) => compareStrings(left.artifactId, right.artifactId));
+  const missingStationLineCount = scopedLines.length - evaluatedKeys.size;
+  const blockingReasons = [];
+  if (sourceIds.size === 0) blockingReasons.push("NO_ADMITTED_SOURCE");
+  if (missingStationLineCount > 0) blockingReasons.push("STATION_LINE_COVERAGE_INCOMPLETE");
+  return {
+    operatorId,
+    operatorName,
+    domain,
+    stationLineCount: scopedLines.length,
+    evaluatedStationLineCount: evaluatedKeys.size,
+    missingStationLineCount,
+    artifacts: artifactScopes,
+    sourceIds: [...sourceIds].sort(compareStrings),
+    blockingReasons,
+    requiredEvidence: requiredEvidenceFor(domain),
+    status: blockingReasons.length === 0 ? "ADMITTED" : "BLOCKED",
+  };
+}
+
 export function partitionMolitTransferTuples({ artifacts, rows, providerCodeCatalog }) {
   if (!Array.isArray(rows) || !Array.isArray(providerCodeCatalog?.providerLines)) {
     throw new TypeError("MOLIT rows and provider code catalog are required");
   }
+  const { canonical, artifactsByProviderLine } = indexCanonicalStationLines(artifacts);
+  const tuples = groupMolitTransferTuples(rows);
+  const partition = { joined: [], unmatched: [], ambiguous: [] };
+  for (const [, tuple] of [...tuples].sort(([left], [right]) => compareStrings(left, right))) {
+    const classified = classifyMolitTransferTuple({
+      ...tuple,
+      providerCodeCatalog,
+      canonical,
+      artifactsByProviderLine,
+    });
+    partition[classified.kind].push(classified.entry);
+  }
+  const sumRows = (entries) => entries.reduce((total, entry) => total + entry.rowCount, 0);
+  return {
+    summary: {
+      rowCount: rows.length,
+      tupleCount: tuples.size,
+      joinedTupleCount: partition.joined.length,
+      joinedRowCount: sumRows(partition.joined),
+      unmatchedTupleCount: partition.unmatched.length,
+      unmatchedRowCount: sumRows(partition.unmatched),
+      ambiguousTupleCount: partition.ambiguous.length,
+      ambiguousRowCount: sumRows(partition.ambiguous),
+    },
+    ...partition,
+  };
+}
+
+function indexCanonicalStationLines(artifacts) {
   const canonical = new Map();
   const artifactsByProviderLine = new Map();
   for (const artifact of artifacts) {
@@ -265,7 +311,10 @@ export function partitionMolitTransferTuples({ artifacts, rows, providerCodeCata
       }
     }
   }
+  return { canonical, artifactsByProviderLine };
+}
 
+function groupMolitTransferTuples(rows) {
   const tuples = new Map();
   for (const row of rows) {
     const values = [row.RAIL_OPR_ISTT_CD, row.LN_NM, row.STIN_NM];
@@ -277,81 +326,85 @@ export function partitionMolitTransferTuples({ artifacts, rows, providerCodeCata
     tuple.rowCount += 1;
     tuples.set(key, tuple);
   }
+  return tuples;
+}
 
-  const partition = { joined: [], unmatched: [], ambiguous: [] };
-  for (const [, { row, rowCount }] of [...tuples].sort(([left], [right]) => compareStrings(left, right))) {
-    const provider = parseMolitOperator(row.RAIL_OPR_ISTT_CD);
-    const lineName = normalizeMolitProviderLineName(row.LN_NM);
-    const providerLines = providerCodeCatalog.providerLines.filter((line) =>
-      line.railOprIsttCd === provider.code && normalizeMolitProviderLineName(line.lineName) === lineName);
-    const base = {
-      providerOperatorCode: provider.code,
-      providerOperatorName: provider.name,
-      providerLineName: row.LN_NM,
-      providerStationName: row.STIN_NM,
-      rowCount,
-    };
-    if (providerLines.length === 0) {
-      partition.unmatched.push({ ...base, reason: "PROVIDER_LINE_SCOPE_UNMAPPED" });
-      continue;
-    }
-    if (providerLines.length > 1) {
-      partition.ambiguous.push({ ...base, reason: "PROVIDER_LINE_SCOPE_AMBIGUOUS" });
-      continue;
-    }
-    const providerLineKey = `${provider.name}\0${lineName}`;
-    const artifactIds = [...(artifactsByProviderLine.get(providerLineKey) ?? [])].sort(compareStrings);
-    if (artifactIds.length === 0) {
-      partition.unmatched.push({ ...base, reason: "CANONICAL_LINE_SCOPE_UNMATCHED" });
-      continue;
-    }
-    const matchesByArtifact = artifactIds.map((artifactId) => ({
-      artifactId,
-      matches: [...(canonical.get(
-        `${artifactId}\0${providerLineKey}\0${normalizeStationName(row.STIN_NM)}`,
-      )?.values() ?? [])].sort((left, right) => compareStrings(
-        `${left.operatorId}\0${left.lineId}\0${left.stationId}`,
-        `${right.operatorId}\0${right.lineId}\0${right.stationId}`,
-      )),
-    }));
-    const ambiguous = matchesByArtifact.filter(({ matches }) => matches.length > 1);
-    const unmatched = matchesByArtifact.filter(({ matches }) => matches.length === 0);
-    if (ambiguous.length > 0) {
-      partition.ambiguous.push({
+function classifyMolitTransferTuple({
+  row, rowCount, providerCodeCatalog, canonical, artifactsByProviderLine,
+}) {
+  const provider = parseMolitOperator(row.RAIL_OPR_ISTT_CD);
+  const lineName = normalizeMolitProviderLineName(row.LN_NM);
+  const providerLines = providerCodeCatalog.providerLines.filter((line) =>
+    line.railOprIsttCd === provider.code && normalizeMolitProviderLineName(line.lineName) === lineName);
+  const base = {
+    providerOperatorCode: provider.code,
+    providerOperatorName: provider.name,
+    providerLineName: row.LN_NM,
+    providerStationName: row.STIN_NM,
+    rowCount,
+  };
+  if (providerLines.length === 0) {
+    return { kind: "unmatched", entry: { ...base, reason: "PROVIDER_LINE_SCOPE_UNMAPPED" } };
+  }
+  if (providerLines.length > 1) {
+    return { kind: "ambiguous", entry: { ...base, reason: "PROVIDER_LINE_SCOPE_AMBIGUOUS" } };
+  }
+  const providerLineKey = `${provider.name}\0${lineName}`;
+  const artifactIds = [...(artifactsByProviderLine.get(providerLineKey) ?? [])].sort(compareStrings);
+  if (artifactIds.length === 0) {
+    return { kind: "unmatched", entry: { ...base, reason: "CANONICAL_LINE_SCOPE_UNMATCHED" } };
+  }
+  const matchesByArtifact = canonicalMatchesByArtifact({
+    artifactIds,
+    canonical,
+    providerLineKey,
+    stationName: row.STIN_NM,
+  });
+  const ambiguous = matchesByArtifact.filter(({ matches }) => matches.length > 1);
+  const unmatched = matchesByArtifact.filter(({ matches }) => matches.length === 0);
+  if (ambiguous.length > 0) {
+    return {
+      kind: "ambiguous",
+      entry: {
         ...base,
         reason: "CANONICAL_STATION_AMBIGUOUS",
         candidates: ambiguous.flatMap(({ matches }) => matches),
-      });
-    } else if (unmatched.length > 0) {
-      partition.unmatched.push({
+      },
+    };
+  }
+  if (unmatched.length > 0) {
+    return {
+      kind: "unmatched",
+      entry: {
         ...base,
         reason: "CANONICAL_STATION_UNMATCHED",
         unmatchedArtifactIds: unmatched.map(({ artifactId }) => artifactId),
-      });
-    } else {
-      partition.joined.push({
-        ...base,
-        mappings: matchesByArtifact.map(({ matches: [match] }) => {
-          const { stationAliases: ignoredAliases, ...mapping } = match;
-          return mapping;
-        }),
-      });
-    }
+      },
+    };
   }
-  const sumRows = (entries) => entries.reduce((total, entry) => total + entry.rowCount, 0);
   return {
-    summary: {
-      rowCount: rows.length,
-      tupleCount: tuples.size,
-      joinedTupleCount: partition.joined.length,
-      joinedRowCount: sumRows(partition.joined),
-      unmatchedTupleCount: partition.unmatched.length,
-      unmatchedRowCount: sumRows(partition.unmatched),
-      ambiguousTupleCount: partition.ambiguous.length,
-      ambiguousRowCount: sumRows(partition.ambiguous),
+    kind: "joined",
+    entry: {
+      ...base,
+      mappings: matchesByArtifact.map(({ matches: [match] }) => {
+        const mapping = { ...match };
+        delete mapping.stationAliases;
+        return mapping;
+      }),
     },
-    ...partition,
   };
+}
+
+function canonicalMatchesByArtifact({ artifactIds, canonical, providerLineKey, stationName }) {
+  return artifactIds.map((artifactId) => ({
+    artifactId,
+    matches: [...(canonical.get(
+      `${artifactId}\0${providerLineKey}\0${normalizeStationName(stationName)}`,
+    )?.values() ?? [])].sort((left, right) => compareStrings(
+      `${left.operatorId}\0${left.lineId}\0${left.stationId}`,
+      `${right.operatorId}\0${right.lineId}\0${right.stationId}`,
+    )),
+  }));
 }
 
 function stationDomainForClaim(claim) {
@@ -430,7 +483,7 @@ export async function loadMolitTransferSnapshot({
   const source = inventory?.sources?.find(({ id }) => id === MOLIT_RAILWAY_TRANSFER_MOVEMENT_SOURCE_ID);
   const admission = source?.rawSnapshotAdmission;
   const expectedMetadataPath = path.resolve(repositoryRoot, admission?.metadataPath ?? "");
-  if (!admission || admission.status !== "LOCKED"
+  if (admission?.status !== "LOCKED"
     || !expectedMetadataPath.endsWith(".csv.gz.json")
     || path.resolve(metadataPath) !== expectedMetadataPath) {
     throw new Error("MOLIT transfer metadata path is not inventory-bound");
@@ -457,8 +510,13 @@ export async function loadMolitTransferSnapshot({
     bytes: gunzipSync(gzipBytes),
     capturedAt: metadata.capturedAt,
   });
-  const { gzipBytes: ignored, rows, gzipSha256: ignoredPlatformGzipSha256, ...rebuiltMetadata } = rebuilt;
-  const { gzipSha256: ignoredStoredGzipSha256, ...logicalMetadata } = metadata;
+  const rows = rebuilt.rows;
+  const rebuiltMetadata = { ...rebuilt };
+  delete rebuiltMetadata.gzipBytes;
+  delete rebuiltMetadata.rows;
+  delete rebuiltMetadata.gzipSha256;
+  const logicalMetadata = { ...metadata };
+  delete logicalMetadata.gzipSha256;
   if (JSON.stringify({ ...rebuiltMetadata, gzipPath: metadata.gzipPath }) !== JSON.stringify(logicalMetadata)) {
     throw new Error("MOLIT transfer logical metadata mismatch");
   }

--- a/tools/datapack/build-accessibility-source-coverage-report.mjs
+++ b/tools/datapack/build-accessibility-source-coverage-report.mjs
@@ -148,6 +148,9 @@ export function buildAccessibilitySourceCoverageReport({
 export function buildStationDomainSourceGate({
   artifacts, validClaims, molitTransferSnapshot, providerCodeCatalog,
 }) {
+  if (artifacts.some((artifact) => !Array.isArray(artifact.stationLines) || artifact.stationLines.length === 0)) {
+    throw new Error("station domain gate requires station-lines for every artifact");
+  }
   const stationLines = artifacts.flatMap((artifact) => (artifact.stationLines ?? []).map((row) => ({
     ...row,
     artifactId: artifact.artifactId,
@@ -372,7 +375,18 @@ function classifyMolitTransferTuple({
   if (providerLines.length > 1) {
     return { kind: "ambiguous", entry: { ...base, reason: "PROVIDER_LINE_SCOPE_AMBIGUOUS" } };
   }
-  const providerLineKey = `${provider.name}\0${lineName}`;
+  const [providerLine] = providerLines;
+  if (provider.name !== providerLine.operatorName) {
+    return {
+      kind: "unmatched",
+      entry: {
+        ...base,
+        reason: "PROVIDER_OPERATOR_IDENTITY_MISMATCH",
+        catalogOperatorName: providerLine.operatorName,
+      },
+    };
+  }
+  const providerLineKey = `${providerLine.operatorName}\0${lineName}`;
   const artifactIds = [...(artifactsByProviderLine.get(providerLineKey) ?? [])].sort(compareStrings);
   if (artifactIds.length === 0) {
     return { kind: "unmatched", entry: { ...base, reason: "CANONICAL_LINE_SCOPE_UNMATCHED" } };

--- a/tools/datapack/build-accessibility-source-coverage-report.test.mjs
+++ b/tools/datapack/build-accessibility-source-coverage-report.test.mjs
@@ -9,7 +9,9 @@ import { gzipSync } from "node:zlib";
 
 import {
   buildAccessibilitySourceCoverageReport,
+  partitionMolitTransferTuples,
   loadAccessibilityAdmissionSnapshots,
+  loadMolitTransferSnapshot,
   loadSelectableAccessibilityArtifacts,
   manifestAssetRoot,
 } from "./build-accessibility-source-coverage-report.mjs";
@@ -44,6 +46,174 @@ test("미승인 source는 provider-domain matrix에서도 BLOCKED다", () => {
 
   assert.equal(report.decision, "NO_GO");
   assert.equal(report.providerDomainMatrix[0].status, "BLOCKED");
+});
+
+test("station domain source matrix는 실제 station-line 분모의 미평가 cell을 NO_GO로 남긴다", () => {
+  const input = validInput();
+  input.artifacts = [input.artifacts[0]];
+  input.artifacts[0].stationLines = [{
+    stationId: "station-a",
+    stationName: "사당",
+    stationAliases: [],
+    lineId: "line-a",
+    lineName: "수도권 4호선",
+    operatorId: "seoul-metro",
+    operatorName: "서울교통공사",
+  }];
+  input.molitTransferSnapshot = {
+    sourceId: "molit-railway-transfer-movement",
+    snapshotId: "molit-railway-transfer-movement-20250811",
+    rawSha256: hash("transfer-raw"),
+    gzipSha256: hash("transfer-gzip"),
+    metadataFileSha256: hash("transfer-metadata"),
+    rowCount: 1,
+    rows: [{
+      RAIL_OPR_ISTT_CD: "S1(서울교통공사)",
+      LN_NM: "4호선",
+      STIN_NM: "사당",
+    }],
+  };
+  input.providerCodeCatalog = {
+    providerLines: [{ railOprIsttCd: "S1", operatorName: "서울교통공사", lnCd: "4", lineName: "4호선" }],
+  };
+
+  const report = buildAccessibilitySourceCoverageReport(input);
+
+  assert.equal(report.decision, "NO_GO");
+  assert.deepEqual(report.stationDomainSourceGate.matrix, [{
+    operatorId: "seoul-metro",
+    operatorName: "서울교통공사",
+    domain: "EXIT",
+    stationLineCount: 1,
+    evaluatedStationLineCount: 0,
+    missingStationLineCount: 1,
+    artifacts: [{
+      artifactId: "bundled-capital",
+      stationLineCount: 1,
+      evaluatedStationLineCount: 0,
+      missingStationLineCount: 1,
+    }],
+    sourceIds: [],
+    blockingReasons: ["NO_ADMITTED_SOURCE", "STATION_LINE_COVERAGE_INCOMPLETE"],
+    requiredEvidence: "OFFICIAL_EXHAUSTIVE_EXIT_PATH_SNAPSHOT_OR_EXPLICIT_ZERO",
+    status: "BLOCKED",
+  }, {
+    operatorId: "seoul-metro",
+    operatorName: "서울교통공사",
+    domain: "FACILITY",
+    stationLineCount: 1,
+    evaluatedStationLineCount: 1,
+    missingStationLineCount: 0,
+    artifacts: [{
+      artifactId: "bundled-capital",
+      stationLineCount: 1,
+      evaluatedStationLineCount: 1,
+      missingStationLineCount: 0,
+    }],
+    sourceIds: ["official-accessibility"],
+    blockingReasons: [],
+    requiredEvidence: "OFFICIAL_EXHAUSTIVE_FACILITY_SNAPSHOT_OR_EXPLICIT_ZERO",
+    status: "ADMITTED",
+  }, {
+    operatorId: "seoul-metro",
+    operatorName: "서울교통공사",
+    domain: "TRANSFER",
+    stationLineCount: 1,
+    evaluatedStationLineCount: 0,
+    missingStationLineCount: 1,
+    artifacts: [{
+      artifactId: "bundled-capital",
+      stationLineCount: 1,
+      evaluatedStationLineCount: 0,
+      missingStationLineCount: 1,
+    }],
+    sourceIds: [],
+    blockingReasons: ["NO_ADMITTED_SOURCE", "STATION_LINE_COVERAGE_INCOMPLETE"],
+    requiredEvidence: "OFFICIAL_TRANSFER_TOPOLOGY_AND_ACCESSIBILITY_SNAPSHOT",
+    status: "BLOCKED",
+  }]);
+  assert.equal(report.stationDomainSourceGate.transferTuplePartition.joined.length, 1);
+  assert.equal(report.stationDomainSourceGate.transferTuplePartition.unmatched.length, 0);
+  assert.equal(report.stationDomainSourceGate.transferTuplePartition.ambiguous.length, 0);
+});
+
+test("MOLIT transfer tuple partition은 unmatched와 ambiguous를 추정 없이 보존한다", () => {
+  const row = (stationName) => ({
+    RAIL_OPR_ISTT_CD: "S1(서울교통공사)",
+    LN_NM: "4호선",
+    STIN_NM: stationName,
+  });
+  const artifacts = [{
+    artifactId: "capital",
+    stationLines: ["station-a", "station-b"].map((stationId) => ({
+      stationId,
+      stationName: "중앙",
+      stationAliases: [],
+      lineId: "line-a",
+      lineName: "수도권 4호선",
+      operatorId: "seoul-metro",
+      operatorName: "서울교통공사",
+    })),
+  }];
+
+  const partition = partitionMolitTransferTuples({
+    artifacts,
+    rows: [row("중앙"), row("중앙"), row("없는역")],
+    providerCodeCatalog: {
+      providerLines: [{ railOprIsttCd: "S1", operatorName: "서울교통공사", lnCd: "4", lineName: "4호선" }],
+    },
+  });
+
+  assert.deepEqual(partition.summary, {
+    rowCount: 3,
+    tupleCount: 2,
+    joinedTupleCount: 0,
+    joinedRowCount: 0,
+    unmatchedTupleCount: 1,
+    unmatchedRowCount: 1,
+    ambiguousTupleCount: 1,
+    ambiguousRowCount: 2,
+  });
+  assert.equal(partition.unmatched[0].reason, "CANONICAL_STATION_UNMATCHED");
+  assert.equal(partition.ambiguous[0].reason, "CANONICAL_STATION_AMBIGUOUS");
+});
+
+test("MOLIT transfer tuple partition snapshot binding은 inventory와 build spec hash를 강제한다", async () => {
+  const repositoryRoot = path.resolve(import.meta.dirname, "../..");
+  const inventoryPath = path.join(import.meta.dirname, "source-inventory.json");
+  const inventoryBytes = await readFile(inventoryPath);
+  const inventory = JSON.parse(inventoryBytes);
+  const candidateBuildSpec = JSON.parse(await readFile(
+    path.join(import.meta.dirname, "release/candidate-build-spec.json"),
+  ));
+  const metadataPath = path.join(
+    repositoryRoot,
+    inventory.sources.find(({ id }) => id === "molit-railway-transfer-movement").rawSnapshotAdmission.metadataPath,
+  );
+
+  const snapshot = await loadMolitTransferSnapshot({
+    metadataPath,
+    inventory,
+    inventoryBytes,
+    candidateBuildSpec,
+    repositoryRoot,
+  });
+
+  assert.equal(snapshot.rowCount, 8054);
+  assert.equal(snapshot.rows.length, 8054);
+  assert.equal(snapshot.sourceInventorySha256, candidateBuildSpec.sourceInventorySha256);
+  await assert.rejects(loadMolitTransferSnapshot({
+    metadataPath,
+    inventory: {
+      ...inventory,
+      sources: inventory.sources.map((source) => source.id === "molit-railway-transfer-movement"
+        ? { ...source, rawSnapshotAdmission: { ...source.rawSnapshotAdmission, rawSha256: hash("tampered") } }
+        : source),
+    },
+    inventoryBytes,
+    candidateBuildSpec,
+    repositoryRoot,
+  }), /snapshot binding mismatch/);
 });
 
 test("inventory에 없는 source는 provider-domain matrix에서도 BLOCKED다", () => {

--- a/tools/datapack/build-accessibility-source-coverage-report.test.mjs
+++ b/tools/datapack/build-accessibility-source-coverage-report.test.mjs
@@ -66,6 +66,9 @@ test("station domain source matrix는 실제 station-line 분모의 미평가 ce
     rawSha256: hash("transfer-raw"),
     gzipSha256: hash("transfer-gzip"),
     metadataFileSha256: hash("transfer-metadata"),
+    sourceInventoryFileSha256: hash("inventory-file"),
+    sourceInventorySha256: hash("inventory-canonical"),
+    candidateBuildSpecSourceInventorySha256: hash("inventory-canonical"),
     rowCount: 1,
     rows: [{
       RAIL_OPR_ISTT_CD: "S1(서울교통공사)",
@@ -135,6 +138,27 @@ test("station domain source matrix는 실제 station-line 분모의 미평가 ce
   assert.equal(report.stationDomainSourceGate.transferTuplePartition.joined.length, 1);
   assert.equal(report.stationDomainSourceGate.transferTuplePartition.unmatched.length, 0);
   assert.equal(report.stationDomainSourceGate.transferTuplePartition.ambiguous.length, 0);
+  assert.deepEqual(report.stationDomainSourceGate.transferTuplePartition.identity, {
+    sourceId: "molit-railway-transfer-movement",
+    snapshotId: "molit-railway-transfer-movement-20250811",
+    rawSha256: hash("transfer-raw"),
+    gzipSha256: hash("transfer-gzip"),
+    metadataFileSha256: hash("transfer-metadata"),
+    sourceInventoryFileSha256: hash("inventory-file"),
+    sourceInventorySha256: hash("inventory-canonical"),
+    candidateBuildSpecSourceInventorySha256: hash("inventory-canonical"),
+    rowCount: 1,
+  });
+
+  input.molitTransferSnapshot.rawSha256 = "invalid";
+  assert.throws(() => buildAccessibilitySourceCoverageReport(input), /identity is invalid/);
+});
+
+test("station domain gate 입력은 둘 중 하나만 있으면 fail-closed다", () => {
+  const input = validInput();
+  input.molitTransferSnapshot = {};
+
+  assert.throws(() => buildAccessibilitySourceCoverageReport(input), /inputs must be provided together/);
 });
 
 test("MOLIT transfer tuple partition은 unmatched와 ambiguous를 추정 없이 보존한다", () => {
@@ -178,6 +202,45 @@ test("MOLIT transfer tuple partition은 unmatched와 ambiguous를 추정 없이 
   assert.equal(partition.ambiguous[0].reason, "CANONICAL_STATION_AMBIGUOUS");
 });
 
+for (const { name, artifacts, providerLines, expectedKind, expectedReason } of [
+  {
+    name: "provider line 미등록",
+    artifacts: [],
+    providerLines: [],
+    expectedKind: "unmatched",
+    expectedReason: "PROVIDER_LINE_SCOPE_UNMAPPED",
+  },
+  {
+    name: "provider line 중복",
+    artifacts: [],
+    providerLines: [
+      { railOprIsttCd: "S1", lineName: "4호선" },
+      { railOprIsttCd: "S1", lineName: "4호선" },
+    ],
+    expectedKind: "ambiguous",
+    expectedReason: "PROVIDER_LINE_SCOPE_AMBIGUOUS",
+  },
+  {
+    name: "canonical line 미등록",
+    artifacts: [],
+    providerLines: [{ railOprIsttCd: "S1", lineName: "4호선" }],
+    expectedKind: "unmatched",
+    expectedReason: "CANONICAL_LINE_SCOPE_UNMATCHED",
+  },
+]) {
+  test(`MOLIT transfer tuple partition은 ${name} 사유를 보존한다`, () => {
+    const partition = partitionMolitTransferTuples({
+      artifacts,
+      rows: [{ RAIL_OPR_ISTT_CD: "S1(서울교통공사)", LN_NM: "4호선", STIN_NM: "사당" }],
+      providerCodeCatalog: { providerLines },
+    });
+
+    assert.equal(partition[expectedKind][0].reason, expectedReason);
+    assert.equal(partition.summary[`${expectedKind}TupleCount`], 1);
+    assert.equal(partition.summary[`${expectedKind}RowCount`], 1);
+  });
+}
+
 test("MOLIT transfer tuple partition snapshot binding은 inventory와 build spec hash를 강제한다", async () => {
   const repositoryRoot = path.resolve(import.meta.dirname, "../..");
   const inventoryPath = path.join(import.meta.dirname, "source-inventory.json");
@@ -197,6 +260,7 @@ test("MOLIT transfer tuple partition snapshot binding은 inventory와 build spec
     inventoryBytes,
     candidateBuildSpec,
     repositoryRoot,
+    evaluatedAt: EVALUATED_AT,
   });
 
   assert.equal(snapshot.rowCount, 8054);
@@ -213,7 +277,16 @@ test("MOLIT transfer tuple partition snapshot binding은 inventory와 build spec
     inventoryBytes,
     candidateBuildSpec,
     repositoryRoot,
+    evaluatedAt: EVALUATED_AT,
   }), /snapshot binding mismatch/);
+  await assert.rejects(loadMolitTransferSnapshot({
+    metadataPath,
+    inventory,
+    inventoryBytes,
+    candidateBuildSpec,
+    repositoryRoot,
+    evaluatedAt: "2026-08-11T00:00:00.000Z",
+  }), /snapshot is stale/);
 });
 
 test("inventory에 없는 source는 provider-domain matrix에서도 BLOCKED다", () => {
@@ -279,6 +352,8 @@ test("remote manifest URL과 bundled index가 같은 gzip SQLite를 가리키면
   const database = new DatabaseSync(sqlitePath);
   database.exec(`
     CREATE TABLE stations (id TEXT PRIMARY KEY);
+    CREATE TABLE operators (id TEXT PRIMARY KEY);
+    CREATE TABLE lines (id TEXT PRIMARY KEY);
     CREATE TABLE station_lines (station_id TEXT, line_id TEXT);
     CREATE TABLE station_facility_evidence (
       station_id TEXT, line_id TEXT, facility_type TEXT, evidence_kind TEXT,

--- a/tools/datapack/build-accessibility-source-coverage-report.test.mjs
+++ b/tools/datapack/build-accessibility-source-coverage-report.test.mjs
@@ -79,6 +79,10 @@ test("station domain source matrix는 실제 station-line 분모의 미평가 ce
   input.providerCodeCatalog = {
     providerLines: [{ railOprIsttCd: "S1", operatorName: "서울교통공사", lnCd: "4", lineName: "4호선" }],
   };
+  input.inventory.sources[0].coverageScope = {
+    operatorIds: ["seoul-metro"],
+    sourceDomains: ["accessibility_facilities"],
+  };
 
   const report = buildAccessibilitySourceCoverageReport(input);
 
@@ -150,6 +154,21 @@ test("station domain source matrix는 실제 station-line 분모의 미평가 ce
     rowCount: 1,
   });
 
+  delete input.inventory.sources[0].accessibilityAdmissionEvidence.absenceEvidenceMode;
+  assert.equal(buildAccessibilitySourceCoverageReport(input)
+    .stationDomainSourceGate.matrix.find(({ domain }) => domain === "FACILITY").status, "BLOCKED");
+
+  input.inventory.sources[0].accessibilityAdmissionEvidence.absenceEvidenceMode = "EXPLICIT_ZERO";
+  input.inventory.sources[0].coverageScope.operatorIds = ["korail"];
+  assert.equal(buildAccessibilitySourceCoverageReport(input)
+    .stationDomainSourceGate.matrix.find(({ domain }) => domain === "FACILITY").status, "BLOCKED");
+
+  input.inventory.sources[0].coverageScope.operatorIds = ["seoul-metro"];
+  input.inventory.sources[0].coverageScope.sourceDomains = ["indoor_movement_paths"];
+  assert.equal(buildAccessibilitySourceCoverageReport(input)
+    .stationDomainSourceGate.matrix.find(({ domain }) => domain === "FACILITY").status, "BLOCKED");
+
+  input.inventory.sources[0].coverageScope.sourceDomains = ["accessibility_facilities"];
   input.molitTransferSnapshot.rawSha256 = "invalid";
   assert.throws(() => buildAccessibilitySourceCoverageReport(input), /identity is invalid/);
 
@@ -293,12 +312,20 @@ test("MOLIT transfer tuple partition snapshot binding은 inventory와 build spec
     inventoryBytes,
     candidateBuildSpec,
     repositoryRoot,
-    evaluatedAt: EVALUATED_AT,
+    evaluatedAt: "2026-07-30T00:00:00.000Z",
   });
 
   assert.equal(snapshot.rowCount, 8054);
   assert.equal(snapshot.rows.length, 8054);
   assert.equal(snapshot.sourceInventorySha256, candidateBuildSpec.sourceInventorySha256);
+  await assert.rejects(loadMolitTransferSnapshot({
+    metadataPath,
+    inventory,
+    inventoryBytes,
+    candidateBuildSpec,
+    repositoryRoot,
+    evaluatedAt: EVALUATED_AT,
+  }), /snapshot is future-dated/);
   await assert.rejects(loadMolitTransferSnapshot({
     metadataPath,
     inventory: {
@@ -310,7 +337,7 @@ test("MOLIT transfer tuple partition snapshot binding은 inventory와 build spec
     inventoryBytes,
     candidateBuildSpec,
     repositoryRoot,
-    evaluatedAt: EVALUATED_AT,
+    evaluatedAt: "2026-07-30T00:00:00.000Z",
   }), /snapshot binding mismatch/);
   await assert.rejects(loadMolitTransferSnapshot({
     metadataPath,

--- a/tools/datapack/build-accessibility-source-coverage-report.test.mjs
+++ b/tools/datapack/build-accessibility-source-coverage-report.test.mjs
@@ -55,6 +55,7 @@ test("station domain source matrix는 실제 station-line 분모의 미평가 ce
     stationId: "station-a",
     stationName: "사당",
     stationAliases: [],
+    regionId: "capital",
     lineId: "line-a",
     lineName: "수도권 4호선",
     operatorId: "seoul-metro",
@@ -80,7 +81,9 @@ test("station domain source matrix는 실제 station-line 분모의 미평가 ce
     providerLines: [{ railOprIsttCd: "S1", operatorName: "서울교통공사", lnCd: "4", lineName: "4호선" }],
   };
   input.inventory.sources[0].coverageScope = {
+    regionIds: ["capital"],
     operatorIds: ["seoul-metro"],
+    lineIds: ["line-a"],
     sourceDomains: ["accessibility_facilities"],
   };
 
@@ -169,6 +172,16 @@ test("station domain source matrix는 실제 station-line 분모의 미평가 ce
     .stationDomainSourceGate.matrix.find(({ domain }) => domain === "FACILITY").status, "BLOCKED");
 
   input.inventory.sources[0].coverageScope.sourceDomains = ["accessibility_facilities"];
+  input.inventory.sources[0].coverageScope.regionIds = ["busan"];
+  assert.equal(buildAccessibilitySourceCoverageReport(input)
+    .stationDomainSourceGate.matrix.find(({ domain }) => domain === "FACILITY").status, "BLOCKED");
+
+  input.inventory.sources[0].coverageScope.regionIds = ["capital"];
+  input.inventory.sources[0].coverageScope.lineIds = ["line-b"];
+  assert.equal(buildAccessibilitySourceCoverageReport(input)
+    .stationDomainSourceGate.matrix.find(({ domain }) => domain === "FACILITY").status, "BLOCKED");
+
+  input.inventory.sources[0].coverageScope.lineIds = ["line-a"];
   input.molitTransferSnapshot.rawSha256 = "invalid";
   assert.throws(() => buildAccessibilitySourceCoverageReport(input), /identity is invalid/);
 

--- a/tools/datapack/build-accessibility-source-coverage-report.test.mjs
+++ b/tools/datapack/build-accessibility-source-coverage-report.test.mjs
@@ -152,6 +152,15 @@ test("station domain source matrix는 실제 station-line 분모의 미평가 ce
 
   input.molitTransferSnapshot.rawSha256 = "invalid";
   assert.throws(() => buildAccessibilitySourceCoverageReport(input), /identity is invalid/);
+
+  input.molitTransferSnapshot.rawSha256 = hash("transfer-raw");
+  input.artifacts.push({
+    artifactId: "remote-core",
+    sqliteSha256: hash("sqlite-core"),
+    searchableStationIds: ["station-a"],
+    claims: [],
+  });
+  assert.throws(() => buildAccessibilitySourceCoverageReport(input), /station-lines for every artifact/);
 });
 
 test("station domain gate 입력은 둘 중 하나만 있으면 fail-closed다", () => {
@@ -214,8 +223,8 @@ for (const { name, artifacts, providerLines, expectedKind, expectedReason } of [
     name: "provider line 중복",
     artifacts: [],
     providerLines: [
-      { railOprIsttCd: "S1", lineName: "4호선" },
-      { railOprIsttCd: "S1", lineName: "4호선" },
+      { railOprIsttCd: "S1", operatorName: "서울교통공사", lineName: "4호선" },
+      { railOprIsttCd: "S1", operatorName: "서울교통공사", lineName: "4호선" },
     ],
     expectedKind: "ambiguous",
     expectedReason: "PROVIDER_LINE_SCOPE_AMBIGUOUS",
@@ -223,7 +232,7 @@ for (const { name, artifacts, providerLines, expectedKind, expectedReason } of [
   {
     name: "canonical line 미등록",
     artifacts: [],
-    providerLines: [{ railOprIsttCd: "S1", lineName: "4호선" }],
+    providerLines: [{ railOprIsttCd: "S1", operatorName: "서울교통공사", lineName: "4호선" }],
     expectedKind: "unmatched",
     expectedReason: "CANONICAL_LINE_SCOPE_UNMATCHED",
   },
@@ -240,6 +249,30 @@ for (const { name, artifacts, providerLines, expectedKind, expectedReason } of [
     assert.equal(partition.summary[`${expectedKind}RowCount`], 1);
   });
 }
+
+test("MOLIT transfer tuple partition은 raw 운영사명 대신 검증된 catalog scope를 사용한다", () => {
+  const partition = partitionMolitTransferTuples({
+    artifacts: [{
+      artifactId: "capital",
+      stationLines: [{
+        stationId: "station-a",
+        stationName: "사당",
+        lineId: "line-a",
+        lineName: "4호선",
+        operatorId: "operator-a",
+        operatorName: "위조운영사",
+      }],
+    }],
+    rows: [{ RAIL_OPR_ISTT_CD: "S1(위조운영사)", LN_NM: "4호선", STIN_NM: "사당" }],
+    providerCodeCatalog: {
+      providerLines: [{ railOprIsttCd: "S1", operatorName: "서울교통공사", lineName: "4호선" }],
+    },
+  });
+
+  assert.equal(partition.unmatched[0].reason, "PROVIDER_OPERATOR_IDENTITY_MISMATCH");
+  assert.equal(partition.unmatched[0].catalogOperatorName, "서울교통공사");
+  assert.equal(partition.joined.length, 0);
+});
 
 test("MOLIT transfer tuple partition snapshot binding은 inventory와 build spec hash를 강제한다", async () => {
   const repositoryRoot = path.resolve(import.meta.dirname, "../..");


### PR DESCRIPTION
## 관련 이슈

Closes AquilaXk/easysubway#2682
Parent: AquilaXk/easysubway-data#8

## 작업 배경

- 기존 accessibility source report는 이미 존재하는 claim만 집계해 selectable `capital`·`core`의 전체 station-line과 18개 운영사 × 3개 domain 미평가 cell을 열거하지 못했다.
- AquilaXk/easysubway#2672 raw snapshot은 올바르게 `UNMAPPED_RAW_SNAPSHOT`으로 격리돼 있어 provider tuple의 joined/unmatched/ambiguous partition을 먼저 증명해야 AquilaXk/easysubway-data#8 schema 진행 여부를 판단할 수 있다.

## 작업 내용

- 기존 `build-accessibility-source-coverage-report.mjs`에 opt-in station-domain gate를 추가했다. 운영사 분모는 artifact의 `operators → lines → station_lines` join에서 직접 도출하며 FACILITY·EXIT·TRANSFER 54개 cell을 artifact별로 집계한다.
- 검증된 line-specific claim만 평가로 인정하고 source/snapshot/license/freshness/provenance 또는 absence evidence가 막힌 claim은 admission에서 제외한다.
- claim source의 canonical region/operator/선택적 line/domain `coverageScope`와 `EXHAUSTIVE_LIST|EXPLICIT_ZERO` 완전성 계약을 함께 강제하고, MOLIT `capturedAt|observedAt`이 평가 시점보다 미래면 거부한다.
- AquilaXk/easysubway#2672 gzip/raw/metadata, canonical source inventory, candidate build-spec hash를 함께 검증하고 8,054개 raw row를 provider code+line 및 artifact별 exact canonical name/alias 기준으로 `joined|unmatched|ambiguous`에 손실 없이 partition한다. 좌표·순서·부분일치 추정은 사용하지 않는다.
- gate는 opt-in이라 기존 release claim coverage 동작을 바꾸지 않는다. station-domain `NO_GO` evidence check는 global violation이 0이고 예상 gate decision이 정확히 일치할 때만 성공한다.

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern='station domain|MOLIT transfer tuple partition' tools/datapack/build-accessibility-source-coverage-report.test.mjs` → 8/8 PASS
  - 실제 committed `capital`·`core` + AquilaXk/easysubway#2672 + KRIC catalog + candidate build-spec gate → expected `NO_GO` PASS, global violation 0
  - `git diff --check` → PASS

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| artifact denominator | Node 24 / SQLite | 실제 bundled gzip를 hash 검증 후 조회 | capital `1,108/18`, core `1,103/18`; sqlite SHA `a581c5d2...ddfc5`, `da8f967a...13221` | PASS |
| 18×3 source matrix | Node 24 | opt-in station-domain gate | 54 cells, ADMITTED 0, BLOCKED 54; FACILITY 2/2,211, EXIT 0/2,211, TRANSFER 0/2,211 | expected NO_GO |
| MOLIT tuple partition | Node 24 | committed 8,054-row snapshot 재검증 | 258 tuples; joined 108/3,473 rows, unmatched 150/4,581 rows, ambiguous 0/0; 합계 8,054 | PASS |
| hash binding | Node 24 | inventory/admission/metadata/gzip/build-spec 비교 | raw `3a45dc...18ce3`, gzip `94e712...66d28`, metadata `f75e3e...a284`, inventory file `69cdbd...70d2`, canonical/build-spec `892d05...dd24` | PASS |
| evidence artifact | local-only | `evaluation-at=2026-07-30T00:00:00Z` regenerated JSON SHA-256 | `/tmp/easysubway-2682-source-gate.json`, `2400d0c667cdad67eb7ee65d9622000a872dfd815c2094bf95fc663b019efb4a` | PASS |

UI·수동 QA는 UI/mobile 동작을 변경하지 않아 불필요하다. 전체 회귀는 GitHub CI가 수행한다.

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [x] AquilaXk/easysubway#1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: opt-in gate가 기존 release path의 decision을 바꾸지 않는지, invalid claim이 54-cell matrix에 admission되지 않는지, artifact별 exact join 외의 station 추정이 없는지 확인해 주세요.

## 리스크

- raw transfer tuple 150개는 현재 artifact/provider scope와 exact join되지 않는다. 이 PR은 이를 숨기거나 보정하지 않고 #2610을 `NO_GO`로 유지한다.
- source matrix 54개 cell이 모두 BLOCKED이므로 schema v19·fixture materialization은 이 PR 범위에서 시작하지 않았다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰와 latest-head rate-limit 경고를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 없어 CD 확인은 불필요하다.
