### PR TITLE
[Chore] KRIC accessibility roster를 전체 역으로 확장

### DIFF
--- a/.github/workflows/kric-nationwide-accessibility-snapshot.yml
+++ b/.github/workflows/kric-nationwide-accessibility-snapshot.yml
@@ -1,0 +1,64 @@
+name: KRIC Nationwide Accessibility Snapshot
+
+on:
+  workflow_dispatch:
+
+jobs:
+  collect:
+    name: KRIC Nationwide Accessibility Snapshot
+    if: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      NODE_OPTIONS: --disable-warning=ExperimentalWarning
+
+    steps:
+      - name: KRIC Nationwide Accessibility Snapshot / Checkout default branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: KRIC Nationwide Accessibility Snapshot / Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24"
+
+      - name: KRIC Nationwide Accessibility Snapshot / Collect sanitized snapshot
+        env:
+          KRIC_SERVICE_KEY: ${{ secrets.KRIC_SERVICE_KEY }}
+        run: |
+          set -euo pipefail
+          test -n "${KRIC_SERVICE_KEY}"
+          node tools/datapack/build-molit-nationwide-fixture.mjs \
+            --csv tools/datapack/sources/molit-urban-rail-full-route-20251211.csv \
+            --svg-csv tools/datapack/sources/molit-rail-station-svg-route-20250811.csv \
+            --kric-code-catalog tools/datapack/sources/kric-provider-code-catalog-20260228.json \
+            --seoulmetro-js tools/datapack/sources/seoulmetro-cyberstation-line-data-20260623.js \
+            --humetro-html tools/datapack/sources/humetro-cyberstation-map-20260623.html \
+            --humetro-css tools/datapack/sources/humetro-cyber-station-20250310c.css \
+            --grtc-html tools/datapack/sources/grtc-cyber-simple-20260623.html \
+            --dtro-html tools/datapack/sources/dtro-cyberstation-20260623.html \
+            --djtc-html tools/datapack/sources/djtc-cyberstation-20260623.html \
+            --djtc-css tools/datapack/sources/djtc-content-20260623.css \
+            --output "${RUNNER_TEMP}/kric-nationwide-fixture.json"
+          node tools/datapack/collect-kric-nationwide-route-rosters.mjs \
+            --targets tools/datapack/nationwide-coverage-targets.json \
+            --fixture "${RUNNER_TEMP}/kric-nationwide-fixture.json" \
+            --output "${RUNNER_TEMP}/kric-nationwide-route-rosters.json"
+          node tools/datapack/collect-kric-accessibility-snapshots.mjs \
+            --bundled-index apps/mobile/assets/datapacks/index.json \
+            --targets tools/datapack/nationwide-coverage-targets.json \
+            --fixture "${RUNNER_TEMP}/kric-nationwide-fixture.json" \
+            --route-rosters "${RUNNER_TEMP}/kric-nationwide-route-rosters.json" \
+            --output-root "${RUNNER_TEMP}/kric-nationwide-accessibility-snapshot"
+
+      - name: KRIC Nationwide Accessibility Snapshot / Upload sanitized snapshot
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: kric-nationwide-accessibility-snapshot
+          path: ${{ runner.temp }}/kric-nationwide-accessibility-snapshot/kric-station-convenience-standard-*.json
+          if-no-files-found: error
+          include-hidden-files: false
+          retention-days: 14

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -19637,6 +19637,29 @@ test("데이터팩 만료 감시 workflow는 SLA 임계보다 촘촘한 cron으�
   }
 });
 
+test("KRIC nationwide accessibility snapshot workflow는 default branch와 sanitized artifact 경계를 유지한다", () => {
+  const workflowPath = ".github/workflows/kric-nationwide-accessibility-snapshot.yml";
+  assert.ok(existsSync(path.join(root, workflowPath)), "KRIC nationwide accessibility workflow must exist");
+  const workflow = read(workflowPath);
+
+  assert.match(workflow, /^on:\s*\n  workflow_dispatch: *$/m);
+  assert.match(
+    workflow,
+    /if: \$\{\{ github\.ref == format\('refs\/heads\/\{0\}', github\.event\.repository\.default_branch\) \}\}/,
+  );
+  assert.deepEqual(
+    [...new Set([...workflow.matchAll(/secrets\.([A-Z0-9_]+)/g)].map((match) => match[1]))],
+    ["KRIC_SERVICE_KEY"],
+  );
+  assert.match(workflow, /build-molit-nationwide-fixture\.mjs/);
+  assert.match(workflow, /collect-kric-nationwide-route-rosters\.mjs/);
+  assert.match(workflow, /collect-kric-accessibility-snapshots\.mjs/);
+  assert.match(workflow, /--targets tools\/datapack\/nationwide-coverage-targets\.json/);
+  assert.match(workflow, /uses: actions\/upload-artifact@[0-9a-f]{40}/);
+  assert.match(workflow, /kric-station-convenience-standard-\*\.json/);
+  assert.doesNotMatch(workflow, /\.env|github\.event\.inputs|\braw\b|response/i);
+});
+
 test("KRIC source 후보 evidence workflow는 고정 allowlist와 sanitized artifact 경계를 유지한다", () => {
   const workflowPath = ".github/workflows/kric-source-candidate-evidence.yml";
   assert.ok(existsSync(path.join(root, workflowPath)), "KRIC evidence workflow must exist");

--- a/tools/datapack/collect-kric-accessibility-snapshots.mjs
+++ b/tools/datapack/collect-kric-accessibility-snapshots.mjs
@@ -17,11 +17,12 @@ export const KRIC_ACCESSIBILITY_OPERATIONS = Object.freeze([
   },
 ]);
 
-const CONSUMED_KRIC_FACILITY_SOURCE_IDS = Object.freeze([
-  "kric-station-convenience-standard",
-  "kric-station-elevator",
-  "kric-station-escalator",
-  "kric-wheelchair-lift-location",
+// Provider roster의 개명·오기만 exact tuple로 결속한다. 이름 유사도 fallback은 두지 않는다.
+export const KRIC_STATION_TUPLE_MAPPINGS = Object.freeze([
+  { stationId: "station-47b514f305d8", lineId: "seoul-4", railOprIsttCd: "KR", lnCd: "4", stinCd: "454" },
+  { stationId: "station-47b514f305d8", lineId: "line-558d0bd8312d", railOprIsttCd: "KR", lnCd: "K1", stinCd: "K256" },
+  { stationId: "station-9d261727e400", lineId: "line-828f04afc588", railOprIsttCd: "EV", lnCd: "E1", stinCd: "Y120" },
+  { stationId: "station-b1a5f63faf69", lineId: "line-42b5805f3b5a", railOprIsttCd: "IC", lnCd: "I2", stinCd: "210" },
 ]);
 
 export async function collectKricAccessibilitySnapshots({
@@ -40,10 +41,15 @@ export async function collectKricAccessibilitySnapshots({
   for (const operation of operations) {
     validateOperation(operation);
     const queries = [];
+    const responsesByProviderTuple = new Map();
     for (const tuple of tuples) {
-      const { rows, rawResponseSha256 } = await requestRows({
-        operation, tuple, serviceKey, fetchImpl, requestTimeoutMs,
-      });
+      const providerKey = [tuple.railOprIsttCd, tuple.lnCd, tuple.stinCd].join("\0");
+      if (!responsesByProviderTuple.has(providerKey)) {
+        responsesByProviderTuple.set(providerKey, await requestRows({
+          operation, tuple, serviceKey, fetchImpl, requestTimeoutMs,
+        }));
+      }
+      const { rows, rawResponseSha256 } = responsesByProviderTuple.get(providerKey);
       const providerRecordHash = hash(rows);
       queries.push({
         ...tuple,
@@ -79,10 +85,10 @@ export async function collectKricAccessibilitySnapshots({
   return snapshots;
 }
 
-export function buildKricAccessibilityRoster({ fixture, canonicalStationLines, routeRosters }) {
+export function buildKricAccessibilityRoster({ activeLineScopes, fixture, canonicalStationLines, routeRosters }) {
   if (!Array.isArray(fixture?.providerLineScopes) || !Array.isArray(canonicalStationLines)
-    || !Array.isArray(routeRosters?.rosters)) {
-    throw new Error("KRIC fixture, canonical station lines, and route rosters are required");
+    || !Array.isArray(routeRosters?.providerScopes) || !Array.isArray(routeRosters?.rosters)) {
+    throw new Error("KRIC fixture, canonical station lines, provider scopes, and route rosters are required");
   }
   const stationLines = new Map();
   for (const membership of canonicalStationLines) {
@@ -90,6 +96,7 @@ export function buildKricAccessibilityRoster({ fixture, canonicalStationLines, r
   }
   const canonicalByLineAndName = new Map();
   const canonicalByLineAndCode = new Map();
+  const canonicalByProviderTuple = new Map();
   for (const membership of stationLines.values()) {
     if (!Array.isArray(membership.names) || membership.names.length === 0) {
       throw new Error(`canonical station names missing: ${membership.stationId}`);
@@ -109,6 +116,12 @@ export function buildKricAccessibilityRoster({ fixture, canonicalStationLines, r
       canonicalByLineAndCode.set(key, matches);
     }
   }
+  for (const mapping of KRIC_STATION_TUPLE_MAPPINGS) {
+    const matches = [...stationLines.values()].filter(({ stationId, lineId }) => (
+      stationId === mapping.stationId && lineId === mapping.lineId
+    ));
+    if (matches.length > 0) canonicalByProviderTuple.set(providerTupleKey(mapping), matches);
+  }
   const rosterByRequest = new Map(routeRosters.rosters.map((roster) => [
     `${roster.mreaWideCd}\0${roster.lnCd}`,
     roster,
@@ -116,9 +129,13 @@ export function buildKricAccessibilityRoster({ fixture, canonicalStationLines, r
   const tuples = [];
   const coveredMemberships = new Set();
   const scopedLineIds = new Set();
-  const activeScopes = Array.isArray(routeRosters.providerScopes)
-    ? routeRosters.providerScopes
-    : fixture.providerLineScopes;
+  const activeScopes = routeRosters.providerScopes;
+  const expectedScopeKeys = uniqueActiveScopeKeys(activeLineScopes);
+  const actualScopeKeys = uniqueActiveScopeKeys(activeScopes);
+  if (expectedScopeKeys.length !== actualScopeKeys.length
+    || expectedScopeKeys.some((key, index) => key !== actualScopeKeys[index])) {
+    throw new Error("KRIC active provider scope set mismatch");
+  }
   const fixtureScopeKeys = new Set(fixture.providerLineScopes.map((scope) => (
     `${scope.lineId}\0${scope.railOprIsttCd}\0${scope.lnCd}`
   )));
@@ -135,6 +152,7 @@ export function buildKricAccessibilityRoster({ fixture, canonicalStationLines, r
       const matches = [...new Map([
         ...(canonicalByLineAndName.get(`${scope.lineId}\0${normalizeStationName(station.stinNm)}`) ?? []),
         ...(canonicalByLineAndCode.get(`${scope.lineId}\0${station.stinCd}`) ?? []),
+        ...(canonicalByProviderTuple.get(providerTupleKey({ ...station, lineId: scope.lineId })) ?? []),
       ].map((match) => [`${match.artifactId}\0${match.stationId}`, match])).values()];
       const matchesByArtifact = new Map();
       for (const match of matches) {
@@ -148,9 +166,6 @@ export function buildKricAccessibilityRoster({ fixture, canonicalStationLines, r
         );
       }
       if (matches.length === 0) continue;
-      for (const membership of matches) {
-        coveredMemberships.add(`${membership.artifactId}\0${membership.stationId}\0${membership.lineId}`);
-      }
       const canonicalMappings = matches.map(({ artifactId, stationId, lineId }) => ({
         artifactId,
         stationId,
@@ -159,14 +174,26 @@ export function buildKricAccessibilityRoster({ fixture, canonicalStationLines, r
         `${left.artifactId}\0${left.stationId}\0${left.lineId}`,
         `${right.artifactId}\0${right.stationId}\0${right.lineId}`,
       ));
-      tuples.push({
-        stationId: canonicalMappings[0].stationId,
-        lineId: canonicalMappings[0].lineId,
-        railOprIsttCd: station.railOprIsttCd,
-        lnCd: station.lnCd,
-        stinCd: station.stinCd,
-        canonicalMappings,
-      });
+      for (const membership of matches) {
+        coveredMemberships.add(`${membership.artifactId}\0${membership.stationId}\0${membership.lineId}`);
+      }
+      const mappingsByIdentity = new Map();
+      for (const mapping of canonicalMappings) {
+        const identity = `${mapping.stationId}\0${mapping.lineId}`;
+        const identityMappings = mappingsByIdentity.get(identity) ?? [];
+        identityMappings.push(mapping);
+        mappingsByIdentity.set(identity, identityMappings);
+      }
+      for (const identityMappings of mappingsByIdentity.values()) {
+        tuples.push({
+          stationId: identityMappings[0].stationId,
+          lineId: identityMappings[0].lineId,
+          railOprIsttCd: station.railOprIsttCd,
+          lnCd: station.lnCd,
+          stinCd: station.stinCd,
+          canonicalMappings: identityMappings,
+        });
+      }
     }
   }
   const uncovered = [...stationLines.values()]
@@ -191,29 +218,12 @@ export async function loadCanonicalStationLinesFromBundledIndex({ bundledIndex, 
       await writeFile(sqlitePath, sqliteBytes);
       const database = new DatabaseSync(sqlitePath, { readOnly: true });
       try {
-        if (!tableExists(database, "station_facility_evidence")) continue;
-        const requiredMemberships = new Set(database.prepare(`
-          SELECT DISTINCT station_id, line_id
-          FROM station_facility_evidence
-          WHERE source_id IN (${CONSUMED_KRIC_FACILITY_SOURCE_IDS.map(() => "?").join(",")})
-        `).all(...CONSUMED_KRIC_FACILITY_SOURCE_IDS).map(({ station_id, line_id }) => (
-          `${station_id}\0${line_id}`
-        )));
-        const aliases = new Map();
-        if (tableExists(database, "station_aliases")) {
-          for (const { station_id: stationId, alias } of database.prepare("SELECT station_id, alias FROM station_aliases").all()) {
-            const values = aliases.get(stationId) ?? [];
-            values.push(alias);
-            aliases.set(stationId, values);
-          }
-        }
         for (const row of database.prepare(`
           SELECT stations.id AS station_id, stations.name_ko, station_lines.line_id,
                  station_lines.station_code
           FROM stations
           JOIN station_lines ON station_lines.station_id = stations.id
         `).all()) {
-          if (!requiredMemberships.has(`${row.station_id}\0${row.line_id}`)) continue;
           const key = `${pack.id}\0${row.station_id}\0${row.line_id}`;
           const membership = memberships.get(key) ?? {
             artifactId: `bundled-${pack.id}`,
@@ -223,7 +233,6 @@ export async function loadCanonicalStationLinesFromBundledIndex({ bundledIndex, 
             names: new Set(),
           };
           membership.names.add(row.name_ko);
-          for (const alias of aliases.get(row.station_id) ?? []) membership.names.add(alias);
           memberships.set(key, membership);
         }
       } finally {
@@ -252,7 +261,7 @@ function validateRoster(roster) {
     for (const field of ["stationId", "lineId", "railOprIsttCd", "lnCd", "stinCd"]) {
       if (typeof tuple?.[field] !== "string" || tuple[field] === "") throw new Error(`KRIC roster ${field} is required`);
     }
-    const key = `${tuple.railOprIsttCd}\0${tuple.lnCd}\0${tuple.stinCd}`;
+    const key = tupleKey(tuple);
     if (seen.has(key)) throw new Error(`duplicate KRIC station tuple: ${key}`);
     seen.add(key);
     return { ...tuple };
@@ -325,6 +334,10 @@ function tupleKey(tuple) {
   return `${tuple.railOprIsttCd}\0${tuple.lnCd}\0${tuple.stinCd}\0${tuple.stationId}\0${tuple.lineId}`;
 }
 
+function providerTupleKey(tuple) {
+  return `${tuple.lineId}\0${tuple.railOprIsttCd}\0${tuple.lnCd}\0${tuple.stinCd}`;
+}
+
 function hash(value) {
   return createHash("sha256").update(JSON.stringify(value)).digest("hex");
 }
@@ -350,10 +363,23 @@ function normalizeStationName(value) {
     .toLocaleLowerCase("ko-KR");
 }
 
+function uniqueActiveScopeKeys(scopes) {
+  if (!Array.isArray(scopes) || scopes.length === 0) return [];
+  const keys = scopes.map((scope) => ["regionId", "operatorId", "lineId"].map((field) => {
+    if (typeof scope?.[field] !== "string" || scope[field] === "") {
+      throw new Error("KRIC active provider scope set mismatch");
+    }
+    return scope[field];
+  }).join("\0"));
+  if (new Set(keys).size !== keys.length) throw new Error("KRIC active provider scope set mismatch");
+  return keys.sort(compare);
+}
+
 async function main(argv) {
   const args = parseArgs(argv);
-  const [bundledIndex, fixture, routeRosters] = await Promise.all([
+  const [bundledIndex, targets, fixture, routeRosters] = await Promise.all([
     readJson(args["bundled-index"]),
+    readJson(args.targets),
     readJson(args.fixture),
     readJson(args["route-rosters"]),
   ]);
@@ -361,7 +387,12 @@ async function main(argv) {
     bundledIndex,
     bundledRoot: path.resolve(path.dirname(args["bundled-index"]), "../.."),
   });
-  const roster = buildKricAccessibilityRoster({ fixture, canonicalStationLines, routeRosters });
+  const roster = buildKricAccessibilityRoster({
+    activeLineScopes: targets.activeLineScopes,
+    fixture,
+    canonicalStationLines,
+    routeRosters,
+  });
   if (args["validate-roster-only"] === true) {
     process.stdout.write(`validated KRIC accessibility roster: tuples=${roster.length}\n`);
     return;
@@ -393,7 +424,7 @@ function parseArgs(argv) {
     args[argv[index].slice(2)] = argv[index + 1];
     index += 2;
   }
-  for (const name of ["bundled-index", "fixture", "route-rosters", "output-root"]) {
+  for (const name of ["bundled-index", "targets", "fixture", "route-rosters", "output-root"]) {
     if (!args[name]) throw new Error(`missing --${name}`);
   }
   if (!path.isAbsolute(args["output-root"])) throw new Error("--output-root must be absolute");

--- a/tools/datapack/collect-kric-accessibility-snapshots.test.mjs
+++ b/tools/datapack/collect-kric-accessibility-snapshots.test.mjs
@@ -24,6 +24,7 @@ const roster = [
 ];
 
 test("canonical fixture와 official route roster를 station-line tuple로 결속한다", () => {
+  const activeLineScopes = [{ lineId: "line-1", regionId: "capital", operatorId: "operator-1" }];
   const fixture = {
     providerLineScopes: [
       { lineId: "line-1", mreaWideCd: "01", lnCd: "1", railOprIsttCd: "S1" },
@@ -35,6 +36,7 @@ test("canonical fixture와 official route roster를 station-line tuple로 결속
     { artifactId: "bundled-core", stationId: "station-a", lineId: "line-1", stationCode: "101", names: ["구가나"] },
   ];
   const routeRosters = {
+    providerScopes: [{ ...activeLineScopes[0], mreaWideCd: "01", lnCd: "1", railOprIsttCd: "S1" }],
     rosters: [{
       mreaWideCd: "01",
       lnCd: "1",
@@ -46,7 +48,7 @@ test("canonical fixture와 official route roster를 station-line tuple로 결속
     }],
   };
 
-  assert.deepEqual(buildKricAccessibilityRoster({ fixture, canonicalStationLines, routeRosters }), [
+  assert.deepEqual(buildKricAccessibilityRoster({ activeLineScopes, fixture, canonicalStationLines, routeRosters }), [
     { stationId: "station-a", lineId: "line-1", railOprIsttCd: "S1", lnCd: "1", stinCd: "101", canonicalMappings: [
       { artifactId: "bundled-capital", stationId: "station-a", lineId: "line-1" },
       { artifactId: "bundled-core", stationId: "station-a", lineId: "line-1" },
@@ -55,12 +57,13 @@ test("canonical fixture와 official route roster를 station-line tuple로 결속
   ]);
   canonicalStationLines.push({ artifactId: "bundled-capital", stationId: "station-duplicate", lineId: "line-1", stationCode: "101", names: ["새가나"] });
   assert.throws(
-    () => buildKricAccessibilityRoster({ fixture, canonicalStationLines, routeRosters }),
+    () => buildKricAccessibilityRoster({ activeLineScopes, fixture, canonicalStationLines, routeRosters }),
     /ambiguous canonical KRIC station join/,
   );
   assert.throws(
     () => buildKricAccessibilityRoster({
       fixture,
+      activeLineScopes,
       canonicalStationLines: canonicalStationLines.filter(({ stationId }) => stationId !== "station-duplicate")
         .concat({ artifactId: "bundled-capital", stationId: "station-missing", lineId: "line-1", stationCode: "999", names: ["없는역"] }),
       routeRosters,
@@ -70,17 +73,91 @@ test("canonical fixture와 official route roster를 station-line tuple로 결속
   assert.throws(
     () => buildKricAccessibilityRoster({
       fixture,
+      activeLineScopes: [{ lineId: "line-x", regionId: "capital", operatorId: "operator-x" }],
       canonicalStationLines: [],
       routeRosters: {
         ...routeRosters,
-        providerScopes: [{ lineId: "line-x", mreaWideCd: "01", lnCd: "9", railOprIsttCd: "SX" }],
+        providerScopes: [{
+          lineId: "line-x",
+          regionId: "capital",
+          operatorId: "operator-x",
+          mreaWideCd: "01",
+          lnCd: "9",
+          railOprIsttCd: "SX",
+        }],
       },
     }),
     /KRIC active provider scope missing from fixture: line-x\/SX/,
   );
+  assert.throws(
+    () => buildKricAccessibilityRoster({
+      activeLineScopes: [],
+      fixture,
+      canonicalStationLines: canonicalStationLines.filter(({ stationId }) => stationId !== "station-duplicate"),
+      routeRosters,
+    }),
+    /KRIC active provider scope set mismatch/,
+  );
+  const divergentIdentities = buildKricAccessibilityRoster({
+    activeLineScopes,
+    fixture,
+    canonicalStationLines: canonicalStationLines.filter(({ stationId }) => stationId !== "station-duplicate").concat({
+      artifactId: "bundled-core",
+      stationId: "station-different",
+      lineId: "line-1",
+      stationCode: "102",
+      names: ["다라"],
+    }),
+    routeRosters,
+  }).filter(({ stinCd }) => stinCd === "102");
+  assert.deepEqual(divergentIdentities.map(({ stationId, canonicalMappings }) => ({
+    stationId,
+    artifactIds: canonicalMappings.map(({ artifactId }) => artifactId),
+  })), [
+    { stationId: "station-b", artifactIds: ["bundled-capital"] },
+    { stationId: "station-different", artifactIds: ["bundled-core"] },
+  ]);
 });
 
-test("현재 standard source claim도 다음 snapshot roster 입력으로 다시 읽는다", async (t) => {
+test("공식 KRIC 개명 tuple correction을 station id와 provider code로 결속한다", () => {
+  const lineId = "line-828f04afc588";
+  assert.deepEqual(buildKricAccessibilityRoster({
+    activeLineScopes: [{ lineId, regionId: "capital", operatorId: "operator-b2d80436b438" }],
+    fixture: { providerLineScopes: [{ lineId, mreaWideCd: "01", lnCd: "E1", railOprIsttCd: "EV" }] },
+    canonicalStationLines: [{
+      artifactId: "bundled-capital",
+      stationId: "station-9d261727e400",
+      lineId,
+      stationCode: "11",
+      names: ["운동장.송담대"],
+    }],
+    routeRosters: {
+      providerScopes: [{
+        lineId,
+        regionId: "capital",
+        operatorId: "operator-b2d80436b438",
+        mreaWideCd: "01",
+        lnCd: "E1",
+        railOprIsttCd: "EV",
+      }],
+      rosters: [{
+      mreaWideCd: "01",
+      lnCd: "E1",
+      resultCode: "00",
+      stations: [{ railOprIsttCd: "EV", lnCd: "E1", stinCd: "Y120", stinNm: "용인중앙시장(용인예술과학대)" }],
+      }],
+    },
+  }), [{
+    stationId: "station-9d261727e400",
+    lineId,
+    railOprIsttCd: "EV",
+    lnCd: "E1",
+    stinCd: "Y120",
+    canonicalMappings: [{ artifactId: "bundled-capital", stationId: "station-9d261727e400", lineId }],
+  }]);
+});
+
+test("전체 station-line을 다음 snapshot roster 입력으로 읽는다", async (t) => {
   const directory = await mkdtemp(path.join(tmpdir(), "easysubway-kric-current-claim-"));
   t.after(() => rm(directory, { recursive: true, force: true }));
   const sqlitePath = path.join(directory, "capital.sqlite");
@@ -93,7 +170,9 @@ test("현재 standard source claim도 다음 snapshot roster 입력으로 다시
     CREATE TABLE station_facility_evidence (station_id TEXT, line_id TEXT, source_id TEXT);
   `);
   database.prepare("INSERT INTO stations VALUES (?,?)").run("station-a", "현재역");
+  database.prepare("INSERT INTO stations VALUES (?,?)").run("station-b", "미평가역");
   database.prepare("INSERT INTO station_lines VALUES (?,?,?)").run("station-a", "line-a", "101");
+  database.prepare("INSERT INTO station_lines VALUES (?,?,?)").run("station-b", "line-a", "102");
   database.prepare("INSERT INTO station_aliases VALUES (?,?)").run("station-a", "옛이름역");
   database.prepare("INSERT INTO station_facility_evidence VALUES (?,?,?)").run("station-a", "line-a", "kric-station-convenience-standard");
   database.close();
@@ -106,14 +185,16 @@ test("현재 standard source claim도 다음 snapshot roster 입력으로 다시
   });
 
   assert.deepEqual(memberships, [{
-    artifactId: "bundled-capital", stationId: "station-a", lineId: "line-a", stationCode: "101", names: ["옛이름역", "현재역"],
+    artifactId: "bundled-capital", stationId: "station-a", lineId: "line-a", stationCode: "101", names: ["현재역"],
+  }, {
+    artifactId: "bundled-capital", stationId: "station-b", lineId: "line-a", stationCode: "102", names: ["미평가역"],
   }]);
 });
 
 test("KRIC accessibility snapshot은 tuple을 정렬하고 present/explicit-zero를 보존한다", async () => {
   const seen = [];
   const snapshots = await collectKricAccessibilitySnapshots({
-    roster,
+    roster: [...roster, { ...roster[0], stationId: "station-c" }],
     operations: [operation],
     serviceKey: "super-secret",
     now: new Date("2026-07-28T00:00:00.000Z"),
@@ -125,7 +206,9 @@ test("KRIC accessibility snapshot은 tuple을 정렬하고 present/explicit-zero
   });
 
   assert.deepEqual(seen, ["101", "202"]);
-  assert.deepEqual(snapshots[0].queries.map(({ status }) => status), ["PRESENT", "ABSENT_EXPLICIT_ZERO"]);
+  assert.deepEqual(snapshots[0].queries.map(({ status }) => status), [
+    "PRESENT", "ABSENT_EXPLICIT_ZERO", "ABSENT_EXPLICIT_ZERO",
+  ]);
   assert.equal(snapshots[0].capturedAt, "2026-07-28T00:00:00.000Z");
   assert.equal(snapshots[0].observedAt, "2026-07-28T00:00:00.000Z");
   assert.equal(snapshots[0].snapshotId, "kric-station-elevator-20260728T000000000Z");
@@ -191,7 +274,7 @@ test("소비하지 않는 provider 필드 drift는 raw hash만 바꾼다", async
 test("duplicate station tuple은 호출 전에 거부한다", async () => {
   let calls = 0;
   await assert.rejects(() => collectKricAccessibilitySnapshots({
-    roster: [roster[0], { ...roster[0], stationId: "duplicate" }],
+    roster: [roster[0], { ...roster[0] }],
     operations: [operation],
     serviceKey: "key",
     fetchImpl: async () => { calls += 1; },


### PR DESCRIPTION
## 관련 이슈

Refs AquilaXk/easysubway-data#10
Parent: AquilaXk/easysubway-data#8

## 작업 배경

- 기존 KRIC accessibility collector는 이미 facility evidence가 있는 2개 station-line만 다음 snapshot roster로 읽어, AquilaXk/easysubway-data#8 전체 분모를 영구히 확장할 수 없는 순환 구조였다.
- 공식 nationwide route roster는 45 scopes / 36 requests를 정상 반환하지만 main의 `--validate-roster-only` 결과는 `tuples=2`였다.
- 전체 stationCnvFacl 1,102 provider tuple 수집은 owner 로컬 60초 실행 경계를 넘으므로 default branch에서만 실행되는 credential-safe workflow가 필요하다.

## 작업 내용

- 기존 `collect-kric-accessibility-snapshots.mjs`가 bundled `capital`·`core`의 전체 `station_lines`를 읽도록 pilot evidence 필터를 제거했다.
- 승인용 `station_aliases`는 provider join에 사용하지 않는다. current canonical name·exact station code와 4개의 공식 exact provider tuple mapping만 허용한다.
- `targets.activeLineScopes`와 roster scope가 정확히 일치해야 수집을 허용한다. 실제 artifact의 2,211 membership은 1,119 canonical query / 1,102 unique KRIC provider tuple로 exact·unambiguous join된다.
- artifact별 station ID가 다른 정당한 물리역 분리도 canonical query로 각각 보존하되, 동일 provider tuple은 한 번만 호출한다.
- default branch 전용 `KRIC Nationwide Accessibility Snapshot` workflow를 추가했다. KRIC secret은 env로만 주입하고 tracked fixture→roster→accessibility collector를 실행하며 sanitized snapshot JSON만 14일 artifact로 보존한다.

## 검증

- `node --test --test-name-pattern='전체 station-line|canonical fixture와 official route roster|공식 KRIC 개명 tuple correction|KRIC accessibility snapshot' tools/datapack/collect-kric-accessibility-snapshots.test.mjs` → 4/4 PASS
- `node --test --test-name-pattern='duplicate station tuple' tools/datapack/collect-kric-accessibility-snapshots.test.mjs` → 1/1 PASS
- `node --test --test-name-pattern='KRIC nationwide accessibility snapshot workflow' tools/ci/repository-contract.test.mjs` → 1/1 PASS
- 실제 committed artifact + credential-redacted official route roster `--validate-roster-only` → `tuples=1119` PASS
- `git diff --check` → PASS

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 결과 |
| --- | --- | --- | --- |
| artifact denominator | Node 24 / SQLite | bundled capital·core hash 검증 후 전체 station_lines 조회 | 2,211 memberships |
| official provider roster | KRIC tracked runner | 45 active scopes / 36 requests, HTTP·provider `00`·schema 검증 | PASS |
| exact tuple join | Node 24 | active scope exact-set + canonical name/code + 4-row exact correction ledger | 1,119 canonical queries / 1,102 provider tuples, missing/ambiguous 0 |
| remote collection boundary | GitHub Actions contract | default branch, `KRIC_SERVICE_KEY` only, sanitized JSON artifact only | PASS |

UI·수동 QA는 UI/mobile 동작을 변경하지 않아 불필요하다. 전체 회귀는 GitHub CI가 수행한다. 실제 1,102-provider-tuple snapshot 수집과 catalog/gate admission은 이 준비 PR 병합 후 #2684의 다음 PR에서 수행한다.

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [x] AquilaXk/easysubway#1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 전체 station-line loader가 active target scope와 roster scope를 양방향 결속하고, artifact별 canonical identity를 누락하지 않는지 확인해 주세요.
- 4개 correction이 exact station/provider tuple에만 적용되며 fuzzy/sequence fallback이 없는지 확인해 주세요.
- workflow가 default branch와 sanitized artifact 경계를 벗어나지 않는지 확인해 주세요.

## 리스크

- 이 PR은 snapshot 자체를 commit/admit하지 않는다. 병합 후 workflow artifact를 검증해 다음 PR에서 source inventory·snapshot·FACILITY matrix에 결속해야 한다.
- KRIC provider가 1,102 provider tuple 중 하나라도 HTTP/provider/schema 실패를 반환하면 workflow는 fail closed한다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰와 conversation 경고를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 없어 CD 확인은 불필요하다.
