### PR TITLE
[Fix] KRIC facility 수집을 provider pacing으로 보호

### DIFF
--- a/.github/workflows/kric-nationwide-accessibility-snapshot.yml
+++ b/.github/workflows/kric-nationwide-accessibility-snapshot.yml
@@ -52,6 +52,7 @@ jobs:
             --targets tools/datapack/nationwide-coverage-targets.json \
             --fixture "${RUNNER_TEMP}/kric-nationwide-fixture.json" \
             --route-rosters "${RUNNER_TEMP}/kric-nationwide-route-rosters.json" \
+            --request-interval-ms 250 \
             --output-root "${RUNNER_TEMP}/kric-nationwide-accessibility-snapshot"
 
       - name: KRIC Nationwide Accessibility Snapshot / Upload sanitized snapshot

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -19655,6 +19655,7 @@ test("KRIC nationwide accessibility snapshot workflow는 default branch와 sanit
   assert.match(workflow, /collect-kric-nationwide-route-rosters\.mjs/);
   assert.match(workflow, /collect-kric-accessibility-snapshots\.mjs/);
   assert.match(workflow, /--targets tools\/datapack\/nationwide-coverage-targets\.json/);
+  assert.match(workflow, /--request-interval-ms 250/);
   assert.match(workflow, /uses: actions\/upload-artifact@[0-9a-f]{40}/);
   assert.match(workflow, /kric-station-convenience-standard-\*\.json/);
   assert.doesNotMatch(workflow, /\.env|github\.event\.inputs|\braw\b|response/i);

--- a/tools/datapack/collect-kric-accessibility-snapshots.mjs
+++ b/tools/datapack/collect-kric-accessibility-snapshots.mjs
@@ -4,6 +4,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
+import { setTimeout as delay } from "node:timers/promises";
 import { pathToFileURL } from "node:url";
 import { gunzipSync } from "node:zlib";
 import { codepointCompare } from "../lib/codepoint-compare.mjs";
@@ -32,8 +33,13 @@ export async function collectKricAccessibilitySnapshots({
   fetchImpl = fetch,
   now = new Date(),
   requestTimeoutMs = 30_000,
+  requestIntervalMs = 0,
+  delayImpl = delay,
 } = {}) {
   if (typeof serviceKey !== "string" || serviceKey === "") throw new Error("KRIC_SERVICE_KEY is required");
+  if (!Number.isInteger(requestIntervalMs) || requestIntervalMs < 0 || requestIntervalMs > 60_000) {
+    throw new Error("KRIC request interval is invalid");
+  }
   const tuples = validateRoster(roster);
   const capturedAt = now.toISOString();
   const freshUntil = new Date(now.getTime() + 86_400_000).toISOString();
@@ -45,6 +51,7 @@ export async function collectKricAccessibilitySnapshots({
     for (const tuple of tuples) {
       const providerKey = [tuple.railOprIsttCd, tuple.lnCd, tuple.stinCd].join("\0");
       if (!responsesByProviderTuple.has(providerKey)) {
+        if (responsesByProviderTuple.size > 0 && requestIntervalMs > 0) await delayImpl(requestIntervalMs);
         responsesByProviderTuple.set(providerKey, await requestRows({
           operation, tuple, serviceKey, fetchImpl, requestTimeoutMs,
         }));
@@ -292,7 +299,9 @@ async function requestRows({ operation, tuple, serviceKey, fetchImpl, requestTim
       response = await fetchImpl(url, { signal: AbortSignal.timeout(requestTimeoutMs) });
     } catch {
       if (attempt === 0) continue;
-      throw new Error(`KRIC accessibility request failed: ${operation.sourceId}`);
+      throw new Error(
+        `KRIC accessibility request failed: ${operation.sourceId}/${tuple.railOprIsttCd}/${tuple.lnCd}/${tuple.stinCd}`,
+      );
     }
     if (response.ok || response.status < 500 || attempt === 1) break;
   }
@@ -400,6 +409,7 @@ async function main(argv) {
   const snapshots = await collectKricAccessibilitySnapshots({
     roster,
     serviceKey: process.env.KRIC_SERVICE_KEY,
+    requestIntervalMs: Number(args["request-interval-ms"] ?? 0),
   });
   await mkdir(args["output-root"], { recursive: true });
   for (const snapshot of snapshots) {

--- a/tools/datapack/collect-kric-accessibility-snapshots.mjs
+++ b/tools/datapack/collect-kric-accessibility-snapshots.mjs
@@ -44,6 +44,11 @@ export async function collectKricAccessibilitySnapshots({
   const capturedAt = now.toISOString();
   const freshUntil = new Date(now.getTime() + 86_400_000).toISOString();
   const snapshots = [];
+  let requestCount = 0;
+  const paceRequest = async () => {
+    if (requestCount > 0 && requestIntervalMs > 0) await delayImpl(requestIntervalMs);
+    requestCount += 1;
+  };
   for (const operation of operations) {
     validateOperation(operation);
     const queries = [];
@@ -51,9 +56,8 @@ export async function collectKricAccessibilitySnapshots({
     for (const tuple of tuples) {
       const providerKey = [tuple.railOprIsttCd, tuple.lnCd, tuple.stinCd].join("\0");
       if (!responsesByProviderTuple.has(providerKey)) {
-        if (responsesByProviderTuple.size > 0 && requestIntervalMs > 0) await delayImpl(requestIntervalMs);
         responsesByProviderTuple.set(providerKey, await requestRows({
-          operation, tuple, serviceKey, fetchImpl, requestTimeoutMs,
+          operation, tuple, serviceKey, fetchImpl, requestTimeoutMs, paceRequest,
         }));
       }
       const { rows, rawResponseSha256 } = responsesByProviderTuple.get(providerKey);
@@ -288,13 +292,14 @@ function validateOperation(operation) {
   }
 }
 
-async function requestRows({ operation, tuple, serviceKey, fetchImpl, requestTimeoutMs }) {
+async function requestRows({ operation, tuple, serviceKey, fetchImpl, requestTimeoutMs, paceRequest }) {
   const url = new URL(operation.endpoint);
   url.searchParams.set("serviceKey", serviceKey);
   url.searchParams.set("format", "json");
   for (const field of ["railOprIsttCd", "lnCd", "stinCd"]) url.searchParams.set(field, tuple[field]);
   let response;
   for (let attempt = 0; attempt < 2; attempt += 1) {
+    await paceRequest();
     try {
       response = await fetchImpl(url, { signal: AbortSignal.timeout(requestTimeoutMs) });
     } catch {

--- a/tools/datapack/collect-kric-accessibility-snapshots.test.mjs
+++ b/tools/datapack/collect-kric-accessibility-snapshots.test.mjs
@@ -375,7 +375,10 @@ test("두 번째 transport 실패 뒤에는 fail closed다", async () => {
     operations: [operation],
     serviceKey: "key",
     fetchImpl: async () => { calls += 1; throw new Error("timeout"); },
-  }), /KRIC accessibility request failed: kric-station-elevator\/S1\/2\/202/);
+  }), {
+    name: "Error",
+    message: "KRIC accessibility request failed: kric-station-elevator/S1/2/202",
+  });
   assert.equal(calls, 2);
 });
 

--- a/tools/datapack/collect-kric-accessibility-snapshots.test.mjs
+++ b/tools/datapack/collect-kric-accessibility-snapshots.test.mjs
@@ -346,10 +346,13 @@ test("provider resultCode 00 body array envelope는 표준 rows로 검증한다"
 test("transport와 5xx는 정확히 한 번만 retry한다", async () => {
   for (const firstFailure of [new Error("timeout"), response(503, [])]) {
     let calls = 0;
+    const delays = [];
     const snapshots = await collectKricAccessibilitySnapshots({
       roster: roster.slice(0, 1),
       operations: [operation],
       serviceKey: "key",
+      requestIntervalMs: 250,
+      delayImpl: async (milliseconds) => { delays.push(milliseconds); },
       fetchImpl: async () => {
         calls += 1;
         if (calls === 1) {
@@ -360,6 +363,7 @@ test("transport와 5xx는 정확히 한 번만 retry한다", async () => {
       },
     });
     assert.equal(calls, 2);
+    assert.deepEqual(delays, [250]);
     assert.equal(snapshots[0].queries[0].status, "ABSENT_EXPLICIT_ZERO");
   }
 });

--- a/tools/datapack/collect-kric-accessibility-snapshots.test.mjs
+++ b/tools/datapack/collect-kric-accessibility-snapshots.test.mjs
@@ -193,11 +193,14 @@ test("전체 station-line을 다음 snapshot roster 입력으로 읽는다", asy
 
 test("KRIC accessibility snapshot은 tuple을 정렬하고 present/explicit-zero를 보존한다", async () => {
   const seen = [];
+  const delays = [];
   const snapshots = await collectKricAccessibilitySnapshots({
     roster: [...roster, { ...roster[0], stationId: "station-c" }],
     operations: [operation],
     serviceKey: "super-secret",
     now: new Date("2026-07-28T00:00:00.000Z"),
+    requestIntervalMs: 250,
+    delayImpl: async (milliseconds) => { delays.push(milliseconds); },
     fetchImpl: async (url) => {
       seen.push(url.searchParams.get("stinCd"));
       const tuple = Object.fromEntries(url.searchParams);
@@ -206,6 +209,7 @@ test("KRIC accessibility snapshot은 tuple을 정렬하고 present/explicit-zero
   });
 
   assert.deepEqual(seen, ["101", "202"]);
+  assert.deepEqual(delays, [250]);
   assert.deepEqual(snapshots[0].queries.map(({ status }) => status), [
     "PRESENT", "ABSENT_EXPLICIT_ZERO", "ABSENT_EXPLICIT_ZERO",
   ]);
@@ -367,7 +371,7 @@ test("두 번째 transport 실패 뒤에는 fail closed다", async () => {
     operations: [operation],
     serviceKey: "key",
     fetchImpl: async () => { calls += 1; throw new Error("timeout"); },
-  }), /KRIC accessibility request failed/);
+  }), /KRIC accessibility request failed: kric-station-elevator\/S1\/2\/202/);
   assert.equal(calls, 2);
 });
 


### PR DESCRIPTION
## 관련 이슈

Refs AquilaXk/easysubway-data#10
Parent: AquilaXk/easysubway-data#8

## 작업 배경

- 준비 PR AquilaXk/easysubway#2685 병합 후 main workflow run `30481830631`은 공식 route roster 45 scopes / 36 requests를 모두 통과했다.
- stationCnvFacl 수집은 각 요청의 1회 bounded retry 뒤 transport failure로 두 attempt 모두 종료했다. 세 번째 blind retry는 하지 않았다.
- 기존 오류에는 source ID만 있어 실패 provider tuple을 식별할 수 없었다.

## 작업 내용

- unique KRIC provider tuple 요청 사이에 적용할 `requestIntervalMs` calibration knob를 추가하고 0~60,000ms 정수만 허용한다.
- workflow는 250ms pacing을 명시한다. 같은 provider tuple을 공유하는 artifact별 canonical query는 기존 cache를 사용하므로 추가 대기나 요청이 없다.
- 두 번째 transport 실패에는 secret 없는 `sourceId/railOprIsttCd/lnCd/stinCd`만 기록한다.

## 검증

- `node --test --test-name-pattern='KRIC accessibility snapshot은|두 번째 transport 실패' tools/datapack/collect-kric-accessibility-snapshots.test.mjs` → 2/2 PASS
- `node --test --test-name-pattern='KRIC nationwide accessibility snapshot workflow' tools/ci/repository-contract.test.mjs` → 1/1 PASS
- `git diff --check` → PASS

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 결과 |
| --- | --- | --- | --- |
| failure reproduction | GitHub Actions | run 30481830631 attempts 1/2 | route roster PASS, stationCnvFacl transport fail-closed |
| provider pacing | Node 24 mock | 2 unique provider tuples + 1 canonical duplicate | 250ms delay 1회, provider request 2회 |
| sanitized diagnostic | Node 24 mock | 두 번째 transport failure | `source/operator/line/station` tuple만 출력 |
| workflow boundary | repository contract | default branch, single secret, 250ms pacing, sanitized artifact | PASS |

UI·수동 QA는 UI/mobile 동작을 변경하지 않아 불필요하다. 전체 회귀는 GitHub CI가 수행한다. 실제 snapshot은 이 PR 병합 후 workflow를 새 run으로 1회 실행한다.

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [x] AquilaXk/easysubway#1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- pacing이 unique provider tuple 사이에만 적용되고 canonical duplicate에는 추가 호출이 없는지 확인해 주세요.
- interval 입력이 fail closed하고 transport 진단에 credential/URL이 포함되지 않는지 확인해 주세요.
- 기존 HTTP/provider/schema 검증과 1회 bounded retry가 바뀌지 않았는지 확인해 주세요.

## 리스크

- 250ms는 실제 provider 경계용 초기 calibration이다. 재실패 시 secret-free exact tuple을 근거로 해당 boundary를 조사하며 blind retry하지 않는다.
- 이 PR은 snapshot이나 admission artifact를 변경하지 않는다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰와 conversation 경고를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 없어 CD 확인은 불필요하다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 접근성 스냅샷 수집 요청에 250ms 간격을 적용해 서비스 요청이 안정적으로 처리되도록 했습니다.
  * 네트워크 오류 재시도 시에도 요청 간격이 일관되게 유지됩니다.
  * 수집 실패 시 문제가 발생한 작업과 항목을 더 구체적으로 확인할 수 있습니다.

* **테스트**
  * 요청 간격 및 재시도 동작에 대한 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->