### PR TITLE
[Fix] KRIC provider 실패 tuple 진단을 완결

### DIFF
--- a/tools/datapack/collect-kric-accessibility-snapshots.mjs
+++ b/tools/datapack/collect-kric-accessibility-snapshots.mjs
@@ -293,6 +293,7 @@ function validateOperation(operation) {
 }
 
 async function requestRows({ operation, tuple, serviceKey, fetchImpl, requestTimeoutMs, paceRequest }) {
+  const requestIdentity = `${operation.sourceId}/${tuple.railOprIsttCd}/${tuple.lnCd}/${tuple.stinCd}`;
   const url = new URL(operation.endpoint);
   url.searchParams.set("serviceKey", serviceKey);
   url.searchParams.set("format", "json");
@@ -304,18 +305,16 @@ async function requestRows({ operation, tuple, serviceKey, fetchImpl, requestTim
       response = await fetchImpl(url, { signal: AbortSignal.timeout(requestTimeoutMs) });
     } catch {
       if (attempt === 0) continue;
-      throw new Error(
-        `KRIC accessibility request failed: ${operation.sourceId}/${tuple.railOprIsttCd}/${tuple.lnCd}/${tuple.stinCd}`,
-      );
+      throw new Error(`KRIC accessibility request failed: ${requestIdentity}`);
     }
     if (response.ok || response.status < 500 || attempt === 1) break;
   }
-  if (!response?.ok) throw new Error(`KRIC accessibility HTTP ${response?.status ?? "unknown"}: ${operation.sourceId}`);
+  if (!response?.ok) throw new Error(`KRIC accessibility HTTP ${response?.status ?? "unknown"}: ${requestIdentity}`);
   let payload;
   try {
     payload = await response.json();
   } catch {
-    throw new Error(`KRIC accessibility schema invalid: ${operation.sourceId}`);
+    throw new Error(`KRIC accessibility schema invalid: ${requestIdentity}`);
   }
   const rawResponseSha256 = hash(payload);
   const resultCode = payload?.header?.resultCode;
@@ -327,13 +326,13 @@ async function requestRows({ operation, tuple, serviceKey, fetchImpl, requestTim
       .sort(codepointCompare).slice(0, 12);
     const safeBodyKeys = Object.keys(payload?.body ?? {}).filter((key) => /^[A-Za-z0-9._-]{1,32}$/.test(key))
       .sort(codepointCompare).slice(0, 12);
-    throw new Error(`KRIC accessibility provider result invalid: ${operation.sourceId}/${safeCode}; keys=${safeKeys.join(",")}; bodyKeys=${safeBodyKeys.join(",")}`);
+    throw new Error(`KRIC accessibility provider result invalid: ${requestIdentity}/${safeCode}; keys=${safeKeys.join(",")}; bodyKeys=${safeBodyKeys.join(",")}`);
   }
   const tupleIdentityFields = operation.tupleIdentityFields ?? ["railOprIsttCd", "lnCd", "stinCd"];
   for (const row of payload) {
     if (!row || typeof row !== "object" || operation.responseFields.some((field) => !(field in row))
       || tupleIdentityFields.some((field) => row[field] !== tuple[field])) {
-      throw new Error(`KRIC accessibility schema invalid: ${operation.sourceId}`);
+      throw new Error(`KRIC accessibility schema invalid: ${requestIdentity}`);
     }
   }
   return {

--- a/tools/datapack/collect-kric-accessibility-snapshots.test.mjs
+++ b/tools/datapack/collect-kric-accessibility-snapshots.test.mjs
@@ -302,6 +302,22 @@ test("provider result 실패와 schema drift는 retry하지 않는다", async ()
   }
 });
 
+test("provider result 실패는 exact tuple만 진단한다", async () => {
+  await assert.rejects(() => collectKricAccessibilitySnapshots({
+    roster: roster.slice(0, 1),
+    operations: [operation],
+    serviceKey: "key",
+    fetchImpl: async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ header: { resultCode: "03" } }),
+    }),
+  }), {
+    name: "Error",
+    message: "KRIC accessibility provider result invalid: kric-station-elevator/S1/2/202/03; keys=header; bodyKeys=",
+  });
+});
+
 test("header 없는 provider resultCode 00도 absence evidence로 인정하지 않는다", async () => {
   await assert.rejects(() => collectKricAccessibilitySnapshots({
     roster: roster.slice(0, 1),


### PR DESCRIPTION
## 관련 이슈

Refs AquilaXk/easysubway-data#10
Parent: AquilaXk/easysubway-data#8

## 작업 배경

- pacing PR AquilaXk/easysubway#2686 병합 후 main workflow run `30484140616`은 36개 공식 route-roster 요청을 통과했다.
- stationCnvFacl 수집은 2분 34초 후 provider `resultCode=03`으로 fail-closed했고 artifact를 업로드하지 않았다.
- provider-result 오류에는 source와 code만 있어 실패한 exact provider tuple을 식별할 수 없다. 진단 보강 전 blind retry는 하지 않는다.

## 작업 내용

- 기존 `requestRows` 안에 secret/URL을 포함하지 않는 `sourceId/railOprIsttCd/lnCd/stinCd` identity를 한 번 만든다.
- transport뿐 아니라 HTTP, JSON/row schema, provider-result terminal 오류도 같은 identity를 사용한다.
- run `30484140616`의 `{header:{resultCode:"03"}}` envelope를 재현하고 전체 redacted message를 exact assertion으로 고정한다.

## 검증

- `node --test --test-name-pattern='provider result 실패는 exact tuple만 진단한다' tools/datapack/collect-kric-accessibility-snapshots.test.mjs` → RED 후 1/1 PASS
- `node --test --test-name-pattern='provider result 실패와 schema drift|두 번째 transport 실패|provider result 실패는 exact tuple만 진단한다' tools/datapack/collect-kric-accessibility-snapshots.test.mjs` → 3/3 PASS
- `git diff --check` → PASS

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 결과 |
| --- | --- | --- | --- |
| provider failure reproduction | GitHub Actions | run 30484140616 | roster PASS, stationCnvFacl `03`, no artifact |
| exact tuple diagnostic | Node 24 mock | provider `03` header envelope | source/operator/line/station/code exact match |
| redaction | exact `Error.message` assertion | secret/endpoint 없는 전체 문자열 | PASS |
| retry/schema regression | focused Node tests | provider/schema no retry + transport bounded retry | 3/3 PASS |

UI·수동 QA는 UI/mobile 동작을 변경하지 않아 불필요하다. 전체 회귀는 GitHub CI가 수행한다. 실제 snapshot은 이 PR 병합 후 새 main workflow run으로 1회만 다시 시도한다.

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [x] AquilaXk/easysubway#1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- exact tuple identity가 credential/URL을 포함하지 않는지 확인해 주세요.
- provider/HTTP/schema/transport가 같은 진단 identity를 사용하면서 기존 fail-closed와 bounded retry를 보존하는지 확인해 주세요.
- 테스트가 실제 run의 provider `03` envelope를 그대로 재현하는지 확인해 주세요.

## 리스크

- 이 PR은 `resultCode=03`을 success/absence/retry로 재분류하지 않는다. 정확한 tuple 확인 전 상태를 그대로 fail-closed한다.
- snapshot이나 admission artifact를 변경하지 않는다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰와 conversation 경고를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 없어 CD 확인은 불필요하다.
