### PR TITLE
[Fix] KRIC provider gap을 전수 진단

### DIFF
--- a/tools/datapack/collect-kric-accessibility-snapshots.mjs
+++ b/tools/datapack/collect-kric-accessibility-snapshots.mjs
@@ -52,15 +52,24 @@ export async function collectKricAccessibilitySnapshots({
   for (const operation of operations) {
     validateOperation(operation);
     const queries = [];
+    const providerGaps = [];
     const responsesByProviderTuple = new Map();
     for (const tuple of tuples) {
       const providerKey = [tuple.railOprIsttCd, tuple.lnCd, tuple.stinCd].join("\0");
       if (!responsesByProviderTuple.has(providerKey)) {
-        responsesByProviderTuple.set(providerKey, await requestRows({
-          operation, tuple, serviceKey, fetchImpl, requestTimeoutMs, paceRequest,
-        }));
+        try {
+          responsesByProviderTuple.set(providerKey, await requestRows({
+            operation, tuple, serviceKey, fetchImpl, requestTimeoutMs, paceRequest,
+          }));
+        } catch (error) {
+          if (error?.kricResultCode !== "03") throw error;
+          providerGaps.push(`${error.kricRequestIdentity}/${error.kricResultCode}`);
+          responsesByProviderTuple.set(providerKey, null);
+        }
       }
-      const { rows, rawResponseSha256 } = responsesByProviderTuple.get(providerKey);
+      const response = responsesByProviderTuple.get(providerKey);
+      if (response === null) continue;
+      const { rows, rawResponseSha256 } = response;
       const providerRecordHash = hash(rows);
       queries.push({
         ...tuple,
@@ -69,6 +78,9 @@ export async function collectKricAccessibilitySnapshots({
         providerRecordHash,
         rows,
       });
+    }
+    if (providerGaps.length > 0) {
+      throw new Error(`KRIC accessibility provider gaps: count=${providerGaps.length}; tuples=${providerGaps.sort(compare).join(",")}`);
     }
     const contentSha256 = hash(queries.map(({ rawResponseSha256: _, ...query }) => query));
     const rawSha256 = hash(queries.map(({
@@ -326,7 +338,10 @@ async function requestRows({ operation, tuple, serviceKey, fetchImpl, requestTim
       .sort(codepointCompare).slice(0, 12);
     const safeBodyKeys = Object.keys(payload?.body ?? {}).filter((key) => /^[A-Za-z0-9._-]{1,32}$/.test(key))
       .sort(codepointCompare).slice(0, 12);
-    throw new Error(`KRIC accessibility provider result invalid: ${requestIdentity}/${safeCode}; keys=${safeKeys.join(",")}; bodyKeys=${safeBodyKeys.join(",")}`);
+    const error = new Error(`KRIC accessibility provider result invalid: ${requestIdentity}/${safeCode}; keys=${safeKeys.join(",")}; bodyKeys=${safeBodyKeys.join(",")}`);
+    error.kricRequestIdentity = requestIdentity;
+    error.kricResultCode = safeCode;
+    throw error;
   }
   const tupleIdentityFields = operation.tupleIdentityFields ?? ["railOprIsttCd", "lnCd", "stinCd"];
   for (const row of payload) {

--- a/tools/datapack/collect-kric-accessibility-snapshots.test.mjs
+++ b/tools/datapack/collect-kric-accessibility-snapshots.test.mjs
@@ -314,8 +314,29 @@ test("provider result 실패는 exact tuple만 진단한다", async () => {
     }),
   }), {
     name: "Error",
-    message: "KRIC accessibility provider result invalid: kric-station-elevator/S1/2/202/03; keys=header; bodyKeys=",
+    message: "KRIC accessibility provider gaps: count=1; tuples=kric-station-elevator/S1/2/202/03",
   });
+});
+
+test("provider 03은 전체 safe tuple을 모은 뒤 fail closed한다", async () => {
+  let calls = 0;
+  await assert.rejects(() => collectKricAccessibilitySnapshots({
+    roster,
+    operations: [operation],
+    serviceKey: "key",
+    fetchImpl: async () => {
+      calls += 1;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ header: { resultCode: "03" } }),
+      };
+    },
+  }), {
+    name: "Error",
+    message: "KRIC accessibility provider gaps: count=2; tuples=kric-station-elevator/S1/1/101/03,kric-station-elevator/S1/2/202/03",
+  });
+  assert.equal(calls, 2);
 });
 
 test("header 없는 provider resultCode 00도 absence evidence로 인정하지 않는다", async () => {


### PR DESCRIPTION
## 관련 이슈

Refs AquilaXk/easysubway-data#10
Parent: AquilaXk/easysubway-data#8

## 작업 배경

- diagnostic PR AquilaXk/easysubway#2687 병합 후 main workflow run `30485436915`은 36개 공식 route-roster 요청을 통과했다.
- stationCnvFacl 수집은 exact official-roster tuple `GU/8/2805`에서 provider `resultCode=03`으로 fail-closed했고 artifact를 업로드하지 않았다.
- KRIC 공개 operation 문서는 세 tuple 요청변수는 확인하지만 `03`을 absence로 정의하지 않는다. 첫 실패만으로는 전체 provider gap을 알 수 없고, `03`을 success/absence로 완화할 수도 없다.

## 작업 내용

- exact `03`만 safe `sourceId/railOprIsttCd/lnCd/stinCd/resultCode` gap으로 누적하고 bounded roster를 끝까지 순회한다.
- 같은 provider tuple의 canonical duplicate는 cached gap을 재사용해 재호출하지 않는다.
- 한 건이라도 gap이 있으면 snapshot 생성 전에 정렬된 전체 tuple 목록으로 한 번 throw한다.
- 다른 provider code와 transport/HTTP/schema 실패는 기존처럼 즉시 중단한다.

## 검증

- `node --test --test-name-pattern='provider 03은 전체 safe tuple을 모은 뒤 fail closed한다' tools/datapack/collect-kric-accessibility-snapshots.test.mjs` → RED 후 1/1 PASS
- `node --test --test-name-pattern='provider result 실패와 schema drift|provider result 실패는 exact tuple만 진단한다|provider 03은 전체 safe tuple을 모은 뒤 fail closed한다|두 번째 transport 실패' tools/datapack/collect-kric-accessibility-snapshots.test.mjs` → 4/4 PASS
- `git diff --check` → PASS
- 독립 정적 review → actionable 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 결과 |
| --- | --- | --- | --- |
| provider gap reproduction | GitHub Actions | run 30485436915 | roster PASS, `GU/8/2805/03`, no artifact |
| bounded gap exhaustion | Node 24 mock | 두 distinct `03` tuple | 2 calls 후 정렬된 count=2 error |
| exact redaction | exact `Error.message` assertion | source/operator/line/station/code만 포함 | PASS |
| fail-closed regression | focused Node tests | provider/schema/transport 경계 | 4/4 PASS |

UI·수동 QA는 UI/mobile 동작을 변경하지 않아 불필요하다. 전체 회귀는 GitHub CI가 수행한다. 실제 nationwide diagnostic pass는 이 PR 병합 후 새 main workflow run으로 1회만 실행한다.

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [x] AquilaXk/easysubway#1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- exact `03` 외의 실패가 즉시 중단되는지 확인해 주세요.
- duplicate provider tuple이 gap 뒤 재호출되지 않고, gap 존재 시 snapshot을 생성하지 않는지 확인해 주세요.
- aggregate message가 credential, URL, raw provider message를 포함하지 않는지 확인해 주세요.

## 리스크

- 이 PR은 `resultCode=03`을 success/absence/retry로 재분류하지 않는다.
- snapshot이나 production admission artifact를 변경하지 않는다.
- mixed `03 + other code`와 duplicate-03 cache는 단순 분기·Map 경로를 정적으로 검토했으며 별도 fixture는 추가하지 않았다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰와 conversation 경고를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 없어 CD 확인은 불필요하다.
