### PR TITLE
[Chore] Seoul facility-location snapshot mode 추가

### DIFF
--- a/tools/datapack/collect-seoul-accessibility-evidence.mjs
+++ b/tools/datapack/collect-seoul-accessibility-evidence.mjs
@@ -37,8 +37,7 @@ const OPERATION_SITUATION_STATES = new Map([
 const REMOVED_OPERATION_SITUATION = "D";
 
 export function normalizeAccessibilityRows(rows, { source = "accessibility" } = {}) {
-  const sourceConfig = SOURCES[source];
-  if (!sourceConfig) throw new Error(`${INVALID_RESPONSE}: source`);
+  if (!Object.hasOwn(SOURCES, source)) throw new Error(`${INVALID_RESPONSE}: source`);
   if (!Array.isArray(rows)) {
     throw new Error(INVALID_RESPONSE);
   }
@@ -87,8 +86,8 @@ export function buildAccessibilitySnapshot(
   retrievedAt,
   { source = "accessibility", rawRowCount, rawSha256, previousSnapshot = null },
 ) {
+  if (!Object.hasOwn(SOURCES, source)) throw new Error(`${INVALID_RESPONSE}: source`);
   const sourceConfig = SOURCES[source];
-  if (!sourceConfig) throw new Error(`${INVALID_RESPONSE}: source`);
   if (
     !Array.isArray(rows) ||
     rows.some(
@@ -199,7 +198,7 @@ export async function collectSeoulAccessibility({
   fetchImpl = fetch,
   requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
 }) {
-  if (!SOURCES[source]) throw new Error(`${INVALID_RESPONSE}: source`);
+  if (!Object.hasOwn(SOURCES, source)) throw new Error(`${INVALID_RESPONSE}: source`);
   const endpointUrl = new URL(endpoint);
   if (endpointUrl.protocol !== "https:") {
     throw new Error("HTTPS endpoint is required");
@@ -281,8 +280,8 @@ export async function writeSeoulAccessibilityEvidence({
   previousSnapshot = null,
 }) {
   const { outputPath: requestedOutputPath } = await validatedOutputPath(output, outputRoot);
+  if (!Object.hasOwn(SOURCES, source)) throw new Error(`${INVALID_RESPONSE}: source`);
   const sourceConfig = SOURCES[source];
-  if (!sourceConfig) throw new Error(`${INVALID_RESPONSE}: source`);
   if (source === "facility-location" && endpoint !== undefined && endpoint !== sourceConfig.endpoint) {
     throw new Error(`${INVALID_RESPONSE}: endpoint`);
   }
@@ -417,7 +416,7 @@ async function main() {
     );
   }
   const source = sourceArgument ? process.argv[7] : "accessibility";
-  if (!SOURCES[source]) throw new Error(`${INVALID_RESPONSE}: source`);
+  if (!Object.hasOwn(SOURCES, source)) throw new Error(`${INVALID_RESPONSE}: source`);
   const serviceKey = process.env.DATA_GO_KR_SERVICE_KEY;
   if (!serviceKey) {
     throw new Error("DATA_GO_KR_SERVICE_KEY env is required");

--- a/tools/datapack/collect-seoul-accessibility-evidence.mjs
+++ b/tools/datapack/collect-seoul-accessibility-evidence.mjs
@@ -199,6 +199,10 @@ export async function collectSeoulAccessibility({
   requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
 }) {
   if (!Object.hasOwn(SOURCES, source)) throw new Error(`${INVALID_RESPONSE}: source`);
+  const sourceConfig = SOURCES[source];
+  if (source === "facility-location" && endpoint !== sourceConfig.endpoint) {
+    throw new Error(`${INVALID_RESPONSE}: endpoint`);
+  }
   const endpointUrl = new URL(endpoint);
   if (endpointUrl.protocol !== "https:") {
     throw new Error("HTTPS endpoint is required");
@@ -282,9 +286,6 @@ export async function writeSeoulAccessibilityEvidence({
   const { outputPath: requestedOutputPath } = await validatedOutputPath(output, outputRoot);
   if (!Object.hasOwn(SOURCES, source)) throw new Error(`${INVALID_RESPONSE}: source`);
   const sourceConfig = SOURCES[source];
-  if (source === "facility-location" && endpoint !== undefined && endpoint !== sourceConfig.endpoint) {
-    throw new Error(`${INVALID_RESPONSE}: endpoint`);
-  }
   const collected = await collectSeoulAccessibility({
     endpoint: endpoint ?? sourceConfig.endpoint,
     serviceKey,

--- a/tools/datapack/collect-seoul-accessibility-evidence.mjs
+++ b/tools/datapack/collect-seoul-accessibility-evidence.mjs
@@ -283,6 +283,9 @@ export async function writeSeoulAccessibilityEvidence({
   const { outputPath: requestedOutputPath } = await validatedOutputPath(output, outputRoot);
   const sourceConfig = SOURCES[source];
   if (!sourceConfig) throw new Error(`${INVALID_RESPONSE}: source`);
+  if (source === "facility-location" && endpoint !== undefined && endpoint !== sourceConfig.endpoint) {
+    throw new Error(`${INVALID_RESPONSE}: endpoint`);
+  }
   const collected = await collectSeoulAccessibility({
     endpoint: endpoint ?? sourceConfig.endpoint,
     serviceKey,

--- a/tools/datapack/collect-seoul-accessibility-evidence.mjs
+++ b/tools/datapack/collect-seoul-accessibility-evidence.mjs
@@ -5,7 +5,20 @@ import { lstat, mkdir, open, readFile, realpath } from "node:fs/promises";
 import { basename, dirname, extname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const DEFAULT_ENDPOINT = "https://apis.data.go.kr/B553766/wksn/getWksnElvtr";
+const SOURCES = {
+  accessibility: {
+    endpoint: "https://apis.data.go.kr/B553766/wksn/getWksnElvtr",
+    sourceId: "seoul-metro-accessibility",
+    artifactKind: "seoul-accessibility-snapshot",
+    schemaFields: ["dtlPstn", "lineNm", "oprtngSitu", "stnNm"],
+  },
+  "facility-location": {
+    endpoint: "https://apis.data.go.kr/B553766/facility/getFcElvtr",
+    sourceId: "seoul-metro-facility-location",
+    artifactKind: "seoul-facility-location-snapshot",
+    schemaFields: ["dtlPstn", "lineNm", "oprtngSitu", "stnCd", "stnNm"],
+  },
+};
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 const INVALID_RESPONSE = "Seoul accessibility API response invalid";
 const INVALID_OUTPUT_PATH = "output path must stay within allowed root";
@@ -23,7 +36,9 @@ const OPERATION_SITUATION_STATES = new Map([
 ]);
 const REMOVED_OPERATION_SITUATION = "D";
 
-export function normalizeAccessibilityRows(rows) {
+export function normalizeAccessibilityRows(rows, { source = "accessibility" } = {}) {
+  const sourceConfig = SOURCES[source];
+  if (!sourceConfig) throw new Error(`${INVALID_RESPONSE}: source`);
   if (!Array.isArray(rows)) {
     throw new Error(INVALID_RESPONSE);
   }
@@ -32,8 +47,11 @@ export function normalizeAccessibilityRows(rows) {
     if (!row || typeof row !== "object" || Array.isArray(row)) {
       throw new Error(`${INVALID_RESPONSE}: row`);
     }
-    const { lineNm, stnNm, oprtngSitu, dtlPstn } = row;
-    for (const [field, value] of Object.entries({ lineNm, stnNm, dtlPstn })) {
+    const { lineNm, stnNm, stnCd, oprtngSitu, dtlPstn } = row;
+    const requiredFields = source === "facility-location"
+      ? { lineNm, stnNm, stnCd, dtlPstn }
+      : { lineNm, stnNm, dtlPstn };
+    for (const [field, value] of Object.entries(requiredFields)) {
       if (typeof value !== "string" || value.trim() === "") {
         throw new Error(`${INVALID_RESPONSE}: requiredField:${field}`);
       }
@@ -54,6 +72,7 @@ export function normalizeAccessibilityRows(rows) {
     normalized.push({
       stationName: stnNm.trim(),
       lineName: lineNm.trim(),
+      ...(source === "facility-location" ? { providerStationCode: stnCd.trim() } : {}),
       operational: state.operational,
       situationCode: state.situationCode,
       situation: state.situation,
@@ -63,7 +82,13 @@ export function normalizeAccessibilityRows(rows) {
   return normalized;
 }
 
-export function buildAccessibilitySnapshot(rows, retrievedAt, { rawRowCount, rawSha256, previousSnapshot = null }) {
+export function buildAccessibilitySnapshot(
+  rows,
+  retrievedAt,
+  { source = "accessibility", rawRowCount, rawSha256, previousSnapshot = null },
+) {
+  const sourceConfig = SOURCES[source];
+  if (!sourceConfig) throw new Error(`${INVALID_RESPONSE}: source`);
   if (
     !Array.isArray(rows) ||
     rows.some(
@@ -73,6 +98,8 @@ export function buildAccessibilitySnapshot(rows, retrievedAt, { rawRowCount, raw
         row.stationName.trim() === "" ||
         typeof row.lineName !== "string" ||
         row.lineName.trim() === "" ||
+        (source === "facility-location" &&
+          (typeof row.providerStationCode !== "string" || row.providerStationCode.trim() === "")) ||
         !(
           (typeof row.operational === "boolean" &&
             typeof row.situationCode === "string" &&
@@ -93,7 +120,7 @@ export function buildAccessibilitySnapshot(rows, retrievedAt, { rawRowCount, raw
     throw new Error(`${INVALID_RESPONSE}: rawIdentity`);
   }
   const retrievedMillis = Date.parse(retrievedAt);
-  const snapshotId = `seoul-metro-accessibility-${typeof retrievedAt === "string" ? retrievedAt.replaceAll(/[-:.]/g, "") : ""}`;
+  const snapshotId = `${sourceConfig.sourceId}-${typeof retrievedAt === "string" ? retrievedAt.replaceAll(/[-:.]/g, "") : ""}`;
   if (typeof retrievedAt !== "string"
     || !Number.isFinite(retrievedMillis)
     || new Date(retrievedMillis).toISOString() !== retrievedAt) {
@@ -102,13 +129,13 @@ export function buildAccessibilitySnapshot(rows, retrievedAt, { rawRowCount, raw
   let previousSnapshotId = null;
   if (previousSnapshot !== null) {
     const previousMillis = Date.parse(previousSnapshot?.retrievedAt);
-    const previousFullId = `seoul-metro-accessibility-${typeof previousSnapshot?.retrievedAt === "string"
+    const previousFullId = `${sourceConfig.sourceId}-${typeof previousSnapshot?.retrievedAt === "string"
       ? previousSnapshot.retrievedAt.replaceAll(/[-:.]/g, "") : ""}`;
-    const previousLegacyId = `seoul-metro-accessibility-${typeof previousSnapshot?.retrievedAt === "string"
+    const previousLegacyId = `${sourceConfig.sourceId}-${typeof previousSnapshot?.retrievedAt === "string"
       ? previousSnapshot.retrievedAt.slice(0, 10).replaceAll("-", "") : ""}`;
     if (previousSnapshot?.schemaVersion !== 1
-      || previousSnapshot?.artifactKind !== "seoul-accessibility-snapshot"
-      || previousSnapshot?.sourceId !== "seoul-metro-accessibility"
+      || previousSnapshot?.artifactKind !== sourceConfig.artifactKind
+      || previousSnapshot?.sourceId !== sourceConfig.sourceId
       || !Number.isFinite(previousMillis)
       || new Date(previousMillis).toISOString() !== previousSnapshot.retrievedAt
       || ![previousFullId, previousLegacyId].includes(previousSnapshot.snapshotId)
@@ -119,10 +146,11 @@ export function buildAccessibilitySnapshot(rows, retrievedAt, { rawRowCount, raw
   }
   const stationsByIdentity = new Map();
   for (const row of rows) {
-    const key = `${row.lineName}\0${row.stationName}`;
+    const key = `${row.lineName}\0${row.stationName}\0${row.providerStationCode ?? ""}`;
     const station = stationsByIdentity.get(key) ?? {
       stationName: row.stationName,
       lineName: row.lineName,
+      ...(source === "facility-location" ? { providerStationCode: row.providerStationCode } : {}),
       facilities: [],
     };
     station.facilities.push({
@@ -142,8 +170,8 @@ export function buildAccessibilitySnapshot(rows, retrievedAt, { rawRowCount, raw
   const contentSha256 = hash(stations);
   return {
     schemaVersion: 1,
-    artifactKind: "seoul-accessibility-snapshot",
-    sourceId: "seoul-metro-accessibility",
+    artifactKind: sourceConfig.artifactKind,
+    sourceId: sourceConfig.sourceId,
     snapshotId,
     previousSnapshotId,
     retrievedAt,
@@ -156,7 +184,7 @@ export function buildAccessibilitySnapshot(rows, retrievedAt, { rawRowCount, raw
     normalizedRowCount: rows.length,
     rawSha256,
     contentSha256,
-    schemaFingerprint: hash(["dtlPstn", "lineNm", "oprtngSitu", "stnNm"]),
+    schemaFingerprint: hash(sourceConfig.schemaFields),
     stations,
   };
 }
@@ -164,6 +192,7 @@ export function buildAccessibilitySnapshot(rows, retrievedAt, { rawRowCount, raw
 export async function collectSeoulAccessibility({
   endpoint,
   serviceKey,
+  source = "accessibility",
   fetchImpl = fetch,
   requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
 }) {
@@ -223,7 +252,7 @@ export async function collectSeoulAccessibility({
       rowIdentities.add(rowIdentity);
     }
     rawPages.push({ pageNo, totalCount: pageTotal, rawSha256: hashText(raw) });
-    const normalizedRows = normalizeAccessibilityRows(rows);
+    const normalizedRows = normalizeAccessibilityRows(rows, { source });
     collected.push(...normalizedRows);
     receivedCount += rows.length;
     if (receivedCount > totalCount || (receivedCount < totalCount && rows.length === 0)) {
@@ -240,6 +269,7 @@ export async function collectSeoulAccessibility({
 export async function writeSeoulAccessibilityEvidence({
   endpoint,
   serviceKey,
+  source = "accessibility",
   output,
   outputRoot = REPOSITORY_ROOT,
   fetchImpl = fetch,
@@ -247,8 +277,19 @@ export async function writeSeoulAccessibilityEvidence({
   previousSnapshot = null,
 }) {
   const { outputPath: requestedOutputPath } = await validatedOutputPath(output, outputRoot);
-  const collected = await collectSeoulAccessibility({ endpoint, serviceKey, fetchImpl });
-  const snapshot = buildAccessibilitySnapshot(collected.rows, retrievedAt, { ...collected, previousSnapshot });
+  const sourceConfig = SOURCES[source];
+  if (!sourceConfig) throw new Error(`${INVALID_RESPONSE}: source`);
+  const collected = await collectSeoulAccessibility({
+    endpoint: endpoint ?? sourceConfig.endpoint,
+    serviceKey,
+    source,
+    fetchImpl,
+  });
+  const snapshot = buildAccessibilitySnapshot(collected.rows, retrievedAt, {
+    source,
+    ...collected,
+    previousSnapshot,
+  });
   const outputPath = extname(requestedOutputPath) === ".json"
     ? requestedOutputPath
     : join(requestedOutputPath, `${snapshot.snapshotId}.json`);
@@ -356,17 +397,20 @@ function compare(left, right) {
 }
 
 async function main() {
-  const previousSnapshotArgument = process.argv.length === 8
-    && process.argv[6] === "--previous-snapshot";
+  const sourceArgument = process.argv[6] === "--source";
+  const previousSnapshotIndex = sourceArgument ? 8 : 6;
+  const previousSnapshotArgument = process.argv[previousSnapshotIndex] === "--previous-snapshot";
   if (
-    (process.argv.length !== 6 && !previousSnapshotArgument) ||
+    ![6, sourceArgument ? 8 : -1, previousSnapshotArgument ? previousSnapshotIndex + 2 : -1].includes(process.argv.length) ||
     process.argv[2] !== "--output" ||
     process.argv[4] !== "--output-root"
   ) {
     throw new Error(
-      "usage: collect-seoul-accessibility-evidence.mjs --output <path-or-directory> --output-root <path> [--previous-snapshot <repository-relative-path>]",
+      "usage: collect-seoul-accessibility-evidence.mjs --output <path-or-directory> --output-root <path> [--source <accessibility|facility-location>] [--previous-snapshot <repository-relative-path>]",
     );
   }
+  const source = sourceArgument ? process.argv[7] : "accessibility";
+  if (!SOURCES[source]) throw new Error(`${INVALID_RESPONSE}: source`);
   const serviceKey = process.env.DATA_GO_KR_SERVICE_KEY;
   if (!serviceKey) {
     throw new Error("DATA_GO_KR_SERVICE_KEY env is required");
@@ -374,14 +418,14 @@ async function main() {
   let previousSnapshot = null;
   if (previousSnapshotArgument) {
     const canonicalSourceRoot = await realpath(SOURCE_SNAPSHOT_ROOT);
-    const canonicalPreviousPath = await realpath(resolve(REPOSITORY_ROOT, process.argv[7]));
+    const canonicalPreviousPath = await realpath(resolve(REPOSITORY_ROOT, process.argv[previousSnapshotIndex + 1]));
     if (!isPathWithin(canonicalSourceRoot, canonicalPreviousPath)) {
       throw new Error(`${INVALID_RESPONSE}: snapshotIdentity`);
     }
     previousSnapshot = JSON.parse(await readFile(canonicalPreviousPath, "utf8"));
   }
   await writeSeoulAccessibilityEvidence({
-    endpoint: DEFAULT_ENDPOINT,
+    source,
     serviceKey,
     output: process.argv[3],
     outputRoot: process.argv[5],

--- a/tools/datapack/collect-seoul-accessibility-evidence.mjs
+++ b/tools/datapack/collect-seoul-accessibility-evidence.mjs
@@ -162,7 +162,10 @@ export function buildAccessibilitySnapshot(
     stationsByIdentity.set(key, station);
   }
   const stations = [...stationsByIdentity.values()].sort((left, right) => (
-    compare(`${left.lineName}\0${left.stationName}`, `${right.lineName}\0${right.stationName}`)
+    compare(
+      `${left.lineName}\0${left.stationName}\0${left.providerStationCode ?? ""}`,
+      `${right.lineName}\0${right.stationName}\0${right.providerStationCode ?? ""}`,
+    )
   ));
   for (const station of stations) {
     station.facilities.sort((left, right) => compare(JSON.stringify(left), JSON.stringify(right)));

--- a/tools/datapack/collect-seoul-accessibility-evidence.mjs
+++ b/tools/datapack/collect-seoul-accessibility-evidence.mjs
@@ -145,8 +145,11 @@ export function buildAccessibilitySnapshot(
     previousSnapshotId = previousSnapshot.snapshotId;
   }
   const stationsByIdentity = new Map();
+  const stationIdentity = (station) => `${station.lineName}\0${station.stationName}${
+    source === "facility-location" ? `\0${station.providerStationCode}` : ""
+  }`;
   for (const row of rows) {
-    const key = `${row.lineName}\0${row.stationName}\0${row.providerStationCode ?? ""}`;
+    const key = stationIdentity(row);
     const station = stationsByIdentity.get(key) ?? {
       stationName: row.stationName,
       lineName: row.lineName,
@@ -162,10 +165,7 @@ export function buildAccessibilitySnapshot(
     stationsByIdentity.set(key, station);
   }
   const stations = [...stationsByIdentity.values()].sort((left, right) => (
-    compare(
-      `${left.lineName}\0${left.stationName}\0${left.providerStationCode ?? ""}`,
-      `${right.lineName}\0${right.stationName}\0${right.providerStationCode ?? ""}`,
-    )
+    compare(stationIdentity(left), stationIdentity(right))
   ));
   for (const station of stations) {
     station.facilities.sort((left, right) => compare(JSON.stringify(left), JSON.stringify(right)));
@@ -199,6 +199,7 @@ export async function collectSeoulAccessibility({
   fetchImpl = fetch,
   requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
 }) {
+  if (!SOURCES[source]) throw new Error(`${INVALID_RESPONSE}: source`);
   const endpointUrl = new URL(endpoint);
   if (endpointUrl.protocol !== "https:") {
     throw new Error("HTTPS endpoint is required");

--- a/tools/datapack/collect-seoul-accessibility-evidence.test.mjs
+++ b/tools/datapack/collect-seoul-accessibility-evidence.test.mjs
@@ -23,6 +23,22 @@ test("collector rejects non-HTTPS endpoints", async () => {
   );
 });
 
+test("collector rejects unknown sources before fetching", async () => {
+  let fetched = false;
+  await assert.rejects(
+    collectSeoulAccessibility({
+      endpoint: "https://apis.data.go.kr/example",
+      serviceKey: "secret",
+      source: "other",
+      fetchImpl: async () => {
+        fetched = true;
+      },
+    }),
+    /Seoul accessibility API response invalid: source/,
+  );
+  assert.equal(fetched, false);
+});
+
 test("collector redacts request details from network failures", async () => {
   await assert.rejects(
     collectSeoulAccessibility({
@@ -497,6 +513,16 @@ test("snapshot content identity is stable when provider facility order changes",
 
   assert.deepEqual(first.stations, reversed.stations);
   assert.equal(first.contentSha256, reversed.contentSha256);
+});
+
+test("accessibility snapshot ignores facility-only provider codes in station identity", () => {
+  const snapshot = buildAccessibilitySnapshot([
+    { stationName: "사당", lineName: "4호선", providerStationCode: "A", operational: true, situationCode: "M", situation: "사용가능", pathDescription: "1번" },
+    { stationName: "사당", lineName: "4호선", providerStationCode: "B", operational: true, situationCode: "M", situation: "사용가능", pathDescription: "2번" },
+  ], "2026-07-29T00:00:00.000Z", { rawRowCount: 2, rawSha256: "a".repeat(64) });
+
+  assert.equal(snapshot.stations.length, 1);
+  assert.equal(snapshot.stations[0].facilities.length, 2);
 });
 
 test("snapshot rejects facilities without a verified or provider-missing status tuple", () => {

--- a/tools/datapack/collect-seoul-accessibility-evidence.test.mjs
+++ b/tools/datapack/collect-seoul-accessibility-evidence.test.mjs
@@ -25,17 +25,19 @@ test("collector rejects non-HTTPS endpoints", async () => {
 
 test("collector rejects unknown sources before fetching", async () => {
   let fetched = false;
-  await assert.rejects(
-    collectSeoulAccessibility({
-      endpoint: "https://apis.data.go.kr/example",
-      serviceKey: "secret",
-      source: "other",
-      fetchImpl: async () => {
-        fetched = true;
-      },
-    }),
-    /Seoul accessibility API response invalid: source/,
-  );
+  for (const source of ["other", "toString", "constructor"]) {
+    await assert.rejects(
+      collectSeoulAccessibility({
+        endpoint: "https://apis.data.go.kr/example",
+        serviceKey: "secret",
+        source,
+        fetchImpl: async () => {
+          fetched = true;
+        },
+      }),
+      /Seoul accessibility API response invalid: source/,
+    );
+  }
   assert.equal(fetched, false);
 });
 

--- a/tools/datapack/collect-seoul-accessibility-evidence.test.mjs
+++ b/tools/datapack/collect-seoul-accessibility-evidence.test.mjs
@@ -435,10 +435,22 @@ test("facility-location snapshot identity is stable for duplicate station names 
   assert.equal(build(rows).contentSha256, build([...rows].reverse()).contentSha256);
 });
 
-test("facility-location writer rejects endpoint overrides before fetching", async () => {
+test("facility-location collection rejects endpoint overrides before fetching", async () => {
   const outputRoot = await mkdtemp(join(tmpdir(), "easysubway-facility-location-endpoint-"));
   let fetched = false;
   try {
+    await assert.rejects(
+      collectSeoulAccessibility({
+        endpoint: "https://apis.data.go.kr/example",
+        serviceKey: "secret",
+        source: "facility-location",
+        fetchImpl: async () => {
+          fetched = true;
+          throw new Error("must not fetch");
+        },
+      }),
+      /endpoint/,
+    );
     await assert.rejects(
       writeSeoulAccessibilityEvidence({
         endpoint: "https://apis.data.go.kr/example",

--- a/tools/datapack/collect-seoul-accessibility-evidence.test.mjs
+++ b/tools/datapack/collect-seoul-accessibility-evidence.test.mjs
@@ -385,6 +385,23 @@ test("snapshot contains sorted full-scope evidence and hashes", () => {
   assert.doesNotMatch(JSON.stringify(snapshot), /serviceKey|https?:\/\//);
 });
 
+test("facility-location snapshot preserves the provider station code under a distinct source identity", () => {
+  const rows = normalizeAccessibilityRows(
+    [{ lineNm: "2호선", stnNm: "신정네거리", stnCd: "0249", oprtngSitu: "M", dtlPstn: "대합실-승강장" }],
+    { source: "facility-location" },
+  );
+  const snapshot = buildAccessibilitySnapshot(
+    rows,
+    "2026-07-29T00:00:00.000Z",
+    { source: "facility-location", rawRowCount: 1, rawSha256: "a".repeat(64) },
+  );
+
+  assert.equal(snapshot.sourceId, "seoul-metro-facility-location");
+  assert.equal(snapshot.artifactKind, "seoul-facility-location-snapshot");
+  assert.equal(snapshot.snapshotId, "seoul-metro-facility-location-20260729T000000000Z");
+  assert.equal(snapshot.stations[0].providerStationCode, "0249");
+});
+
 test("same-day captures keep distinct timestamped files and explicit lineage", async (t) => {
   const outputRoot = await mkdtemp(join(tmpdir(), "easysubway-seoul-snapshots-"));
   t.after(() => rm(outputRoot, { recursive: true, force: true }));
@@ -642,6 +659,22 @@ test("CLI requires the service key before collection", async () => {
       { env: {} },
     ),
     /DATA_GO_KR_SERVICE_KEY env is required/,
+  );
+});
+
+test("CLI rejects unknown facility-location source modes before collection", async () => {
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        collectorPath,
+        "--output", "unused.json",
+        "--output-root", tmpdir(),
+        "--source", "other",
+      ],
+      { env: { DATA_GO_KR_SERVICE_KEY: "secret" } },
+    ),
+    /Seoul accessibility API response invalid: source/,
   );
 });
 

--- a/tools/datapack/collect-seoul-accessibility-evidence.test.mjs
+++ b/tools/datapack/collect-seoul-accessibility-evidence.test.mjs
@@ -402,6 +402,21 @@ test("facility-location snapshot preserves the provider station code under a dis
   assert.equal(snapshot.stations[0].providerStationCode, "0249");
 });
 
+test("facility-location snapshot identity is stable for duplicate station names with distinct codes", () => {
+  const rows = normalizeAccessibilityRows([
+    { lineNm: "2호선", stnNm: "환승역", stnCd: "0202", oprtngSitu: "M", dtlPstn: "2번" },
+    { lineNm: "2호선", stnNm: "환승역", stnCd: "0201", oprtngSitu: "M", dtlPstn: "1번" },
+  ], { source: "facility-location" });
+  const build = (input) => buildAccessibilitySnapshot(input, "2026-07-29T00:00:00.000Z", {
+    source: "facility-location",
+    rawRowCount: 2,
+    rawSha256: "a".repeat(64),
+  });
+
+  assert.deepEqual(build(rows).stations, build([...rows].reverse()).stations);
+  assert.equal(build(rows).contentSha256, build([...rows].reverse()).contentSha256);
+});
+
 test("same-day captures keep distinct timestamped files and explicit lineage", async (t) => {
   const outputRoot = await mkdtemp(join(tmpdir(), "easysubway-seoul-snapshots-"));
   t.after(() => rm(outputRoot, { recursive: true, force: true }));

--- a/tools/datapack/collect-seoul-accessibility-evidence.test.mjs
+++ b/tools/datapack/collect-seoul-accessibility-evidence.test.mjs
@@ -433,6 +433,30 @@ test("facility-location snapshot identity is stable for duplicate station names 
   assert.equal(build(rows).contentSha256, build([...rows].reverse()).contentSha256);
 });
 
+test("facility-location writer rejects endpoint overrides before fetching", async () => {
+  const outputRoot = await mkdtemp(join(tmpdir(), "easysubway-facility-location-endpoint-"));
+  let fetched = false;
+  try {
+    await assert.rejects(
+      writeSeoulAccessibilityEvidence({
+        endpoint: "https://apis.data.go.kr/example",
+        serviceKey: "secret",
+        source: "facility-location",
+        output: "unused.json",
+        outputRoot,
+        fetchImpl: async () => {
+          fetched = true;
+          throw new Error("must not fetch");
+        },
+      }),
+      /endpoint/,
+    );
+    assert.equal(fetched, false);
+  } finally {
+    await rm(outputRoot, { recursive: true, force: true });
+  }
+});
+
 test("same-day captures keep distinct timestamped files and explicit lineage", async (t) => {
   const outputRoot = await mkdtemp(join(tmpdir(), "easysubway-seoul-snapshots-"));
   t.after(() => rm(outputRoot, { recursive: true, force: true }));


### PR DESCRIPTION
## 관련 이슈

Refs AquilaXk/easysubway-data#10

## 작업 배경

- KRIC 전국 FACILITY 전수 수집에서 미검증 `03` gap 24개 중 `S1/2/234-4` 1건이 확인됐다.
- 이미 cataloged된 공식 서울교통공사 편의시설 위치 API를 임의 endpoint 없이 동일 collector의 fixed source mode로 수집할 경로가 필요하다.

## 작업 내용

- `collect-seoul-accessibility-evidence.mjs`에 `accessibility|facility-location` fixed source mode를 추가했다.
- 새 mode도 기존 HTTPS, pagination, provider envelope `00`, schema, raw/content hash, redaction, output path gate를 그대로 사용한다.
- facility-location snapshot은 source/artifact/snapshot identity를 분리하고 공식 `stnCd`를 `providerStationCode`로 보존한다.
- 동일 line/name에 provider code가 여러 개여도 station/content hash가 provider row 순서와 무관하도록 code까지 정렬 identity에 포함한다.
- source별 identity token을 grouping/sort에 함께 사용하고, direct collector도 잘못된 source를 fetch 전에 거부한다.
- live snapshot에서 exact KRIC `S1/2/234-4` identity가 증명되지 않아 source inventory admission과 FACILITY materialization은 변경하지 않았다.

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern='facility-location' tools/datapack/collect-seoul-accessibility-evidence.test.mjs` → 4/4 PASS
  - `node --test --test-name-pattern='unknown sources|facility-location|accessibility snapshot ignores|snapshot content identity' tools/datapack/collect-seoul-accessibility-evidence.test.mjs` → 7/7 PASS
  - `node --test --test-name-pattern='snapshot contains sorted|same-day captures|snapshot content identity|snapshot rejects|CLI ' tools/datapack/collect-seoul-accessibility-evidence.test.mjs` → 6/6 PASS
  - `git diff --check` → PASS
  - `node --env-file=/Users/aquila/easysubway/.env tools/datapack/collect-seoul-accessibility-evidence.mjs --output snapshots --output-root /tmp/easysubway-2684-seoul-facility-location --source facility-location` → HTTP/provider/schema PASS, 865/865 rows

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| official full snapshot | Data.go.kr / Seoul Metro | tracked credential-safe collector | snapshot `seoul-metro-facility-location-20260729T203032687Z`, raw `3f0b58f…`, content `60d3decb…`, schema `0a8ee6d5…` | PASS |
| S1 exact identity | KRIC + Seoul official sources | exact operator/line/station identity 비교 | Seoul source는 까치산을 5호선 `2519`로만 제공 | BLOCKED 유지 |
| UI·수동 QA | 해당 없음 | collector-only diff | UI/앱 artifact 변경 없음 | 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [x] AquilaXk/easysubway#1414 하위 release blocker issue 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: default `accessibility` mode의 snapshot/lineage가 byte-contract상 유지되는지, `facility-location`의 source identity와 `stnCd` 보존이 cross-source 혼합을 막는지 확인해 주세요.

## 리스크

- 두 provider station-code 체계가 다르므로 name/position 추정 join을 하지 않았다. `S1/2/234-4`는 계속 fail-closed다.
- source inventory, production snapshot, materialization, `03` 의미는 변경하지 않았다.
- CodeRabbit의 reordered CLI finding은 제시한 명령이 silent fallback 없이 usage error(exit 1)로 거부됨을 재현해 fixed-order 기존 contract를 유지했다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향 없음.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 서울 지하철 접근성 데이터 수집 기능이 시설 위치 데이터까지 지원합니다.
  * 데이터 소스를 선택해 수집하고, 소스별 스냅샷을 생성할 수 있습니다.
  * 시설 위치 데이터에 제공기관의 역 코드가 포함됩니다.
  * 동일한 역명과 서로 다른 역 코드가 있는 경우에도 데이터를 안정적으로 보존합니다.

* **버그 수정**
  * 지원하지 않는 데이터 소스나 잘못된 엔드포인트를 사전에 거부합니다.
  * 스냅샷 식별 및 이전 스냅샷 검증을 데이터 소스별로 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->