### PR TITLE
[CI] Component identity 기반 system release manifest v2 도입

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -575,6 +575,18 @@ jobs:
           name: easysubway-android-production-rc-${{ github.sha }}
           path: release-artifacts/downloaded/android-production-rc
 
+      - name: Play internal upload / Download RC evidence artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: easysubway-rc-evidence-manifest-${{ github.sha }}
+          path: release-artifacts/downloaded/rc
+
+      - name: Play internal upload / Require authoritative GO decision
+        run: >-
+          node tools/release/validate-system-release-manifest.mjs
+          --manifest release-artifacts/downloaded/rc/system-release-manifest.json
+          --require-decision GO
+
       - name: Play internal upload / Restore release environment
         shell: bash
         env:
@@ -639,7 +651,7 @@ jobs:
     needs: changes
     permissions:
       contents: read
-    if: ${{ needs.changes.outputs.backend == 'true' || needs.changes.outputs.deploy == 'true' }}
+    if: ${{ needs.changes.outputs.backend == 'true' || needs.changes.outputs.deploy == 'true' || needs.changes.outputs.android == 'true' || needs.changes.outputs.mobile == 'true' || github.event_name == 'workflow_dispatch' }}
 
     steps:
       - name: Backend Release Image / Checkout repository
@@ -678,7 +690,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          mkdir -p release-artifacts/backend
           docker compose --env-file .env.example -f infra/docker-compose.yml config --quiet
+          docker compose --env-file .env.example -f infra/docker-compose.yml config > release-artifacts/backend/rendered-compose.yml
+          test -f release-artifacts/backend/rendered-compose.yml
+          test ! -L release-artifacts/backend/rendered-compose.yml
 
       - name: Backend Release Image / Collect release metadata
         shell: bash
@@ -721,7 +737,7 @@ jobs:
     permissions:
       actions: read
       contents: read
-    if: ${{ always() && (needs.android-release.result == 'success' || needs.android-production-rc-release.result == 'success' || needs.backend-release.result == 'success') }}
+    if: ${{ always() && needs.backend-release.result == 'success' && ((needs.android-release.result == 'success' && needs.android-release.outputs.artifact_available == 'true') || needs.android-production-rc-release.result == 'success') }}
 
     steps:
       - name: RC Evidence Manifest / Checkout repository
@@ -821,10 +837,13 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p release-artifacts/rc
-          data_pack_manifest=apps/mobile/assets/datapacks/metro_map_pack/manifest.json
+          data_pack_manifest=apps/mobile/assets/datapacks/index.json
           data_pack_artifact=apps/mobile/assets/datapacks/capital.sqlite.gz
           data_pack_fallback_artifact="${data_pack_artifact}"
           data_pack_release_decision=""
+          source_snapshot_evidence="${data_pack_manifest}"
+          release_sequence=0
+          data_version=unpromoted
           if [[ "${ANDROID_RC_SIGNING_MODE}" == production-upload-key && -z "${DATAPACK_RUN_ID}" ]]; then
             echo "datapack_run_id is required for production RC identity" >&2
             exit 1
@@ -834,6 +853,9 @@ jobs:
             data_pack_artifact=release-artifacts/downloaded/datapack-selected/active.sqlite.gz
             data_pack_fallback_artifact=release-artifacts/downloaded/datapack-selected/fallback.sqlite.gz
             data_pack_release_decision=release-artifacts/downloaded/datapack-selected/release-decision.json
+            source_snapshot_evidence="${data_pack_release_decision}"
+            release_sequence="$(node -p 'JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8")).releaseSequence' "${data_pack_manifest}")"
+            data_version="$(node -p 'const manifest = JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8")); manifest.dataVersion ?? manifest.version ?? manifest.date ?? manifest.activePack?.version ?? "unpromoted"' "${data_pack_manifest}")"
           fi
           generator_args=(
             --repo-root .
@@ -843,6 +865,7 @@ jobs:
             --data-pack-manifest "${data_pack_manifest}"
             --data-pack-artifact "${data_pack_artifact}"
             --data-pack-fallback-artifact "${data_pack_fallback_artifact}"
+            --release-sequence "${release_sequence}"
             --evidence-root ".codex/evidence/release/rc-evidence-manifest/${GITHUB_SHA}/"
             --device local_android_emulator
             --android-version android-15-or-16
@@ -883,24 +906,64 @@ jobs:
             )
           fi
           android_artifact_source="none"
+          aab_path=""
           if [[ -f release-artifacts/downloaded/android-production-rc/app-release.aab ]]; then
-            generator_args+=(--aab release-artifacts/downloaded/android-production-rc/app-release.aab)
+            aab_path=release-artifacts/downloaded/android-production-rc/app-release.aab
             generator_args+=(--android-release-metadata release-artifacts/downloaded/android-production-rc/release-metadata.txt)
             android_artifact_source="easysubway-android-production-rc-${GITHUB_SHA}"
           elif [[ -f release-artifacts/downloaded/android/app-release.aab ]]; then
-            generator_args+=(--aab release-artifacts/downloaded/android/app-release.aab)
+            aab_path=release-artifacts/downloaded/android/app-release.aab
             generator_args+=(--android-release-metadata release-artifacts/downloaded/android/release-metadata.txt)
             android_artifact_source="easysubway-android-release-${GITHUB_SHA}"
           fi
-          if [[ -f release-artifacts/downloaded/backend/backend-boot.jar ]]; then
-            generator_args+=(--backend-artifact release-artifacts/downloaded/backend/backend-boot.jar)
-          elif [[ -f release-artifacts/downloaded/backend/image-inspect.json ]]; then
-            generator_args+=(--backend-image-inspect release-artifacts/downloaded/backend/image-inspect.json)
+          if [[ -z "${aab_path}" ]]; then
+            echo "exactly one Android AAB is required for RC evidence" >&2
+            exit 1
           fi
+          generator_args+=(--aab "${aab_path}")
+          if [[ ! -f release-artifacts/downloaded/backend/image-inspect.json ]]; then
+            echo "backend image inspect is required for RC evidence" >&2
+            exit 1
+          fi
+          generator_args+=(--backend-image-inspect release-artifacts/downloaded/backend/image-inspect.json)
           node tools/release/generate-rc-evidence-manifest.mjs \
             "${generator_args[@]}" \
             --phase CANDIDATE \
             --output release-artifacts/rc/candidate-context.json
+          version_line="$(awk '/^version:/{print $2; exit}' apps/mobile/pubspec.yaml)"
+          version_name="${version_line%%+*}"
+          version_code="${version_line##*+}"
+          contracts_bundle="${RUNNER_TEMP}/contracts.tar"
+          component_output="${RUNNER_TEMP}/component-manifests-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          git archive --format=tar HEAD contracts > "${RUNNER_TEMP}/contracts.tar"
+          node tools/release/build-monorepo-component-manifests.mjs \
+            --repository AquilaXk/easysubway \
+            --git-sha "${GITHUB_SHA}" \
+            --mobile-version-name "${version_name}" \
+            --mobile-version-code "${version_code}" \
+            --aab "${aab_path}" \
+            --bundled-data-manifest "${data_pack_manifest}" \
+            --backend-image-inspect release-artifacts/downloaded/backend/image-inspect.json \
+            --backend-evidence release-artifacts/downloaded/backend/release-metadata.txt \
+            --data-version "${data_version}" \
+            --data-release-sequence "${release_sequence}" \
+            --data-manifest "${data_pack_manifest}" \
+            --source-snapshot-evidence "${source_snapshot_evidence}" \
+            --platform-environment ci \
+            --platform-evidence release-artifacts/downloaded/backend/rendered-compose.yml \
+            --contracts-version 1.0.0 \
+            --contracts-bundle "${contracts_bundle}" \
+            --issue-ref AquilaXk/easysubway#2693 \
+            --output-dir "${component_output}"
+          cp "${component_output}/mobile-component-manifest.json" release-artifacts/rc/mobile-component-manifest.json
+          cp "${component_output}/backend-component-manifest.json" release-artifacts/rc/backend-component-manifest.json
+          cp "${component_output}/data-component-manifest.json" release-artifacts/rc/data-component-manifest.json
+          cp "${component_output}/platform-component-manifest.json" release-artifacts/rc/platform-component-manifest.json
+          cp "${component_output}/contracts-identity.json" release-artifacts/rc/contracts-identity.json
+          for manifest in release-artifacts/rc/{mobile,backend,data,platform}-component-manifest.json release-artifacts/rc/contracts-identity.json; do
+            test -f "${manifest}"
+            test ! -L "${manifest}"
+          done
           if [[ -f release-artifacts/downloaded/backend/planner-canary-result.json ]]; then
             node tools/release/build-planner-success-evidence.mjs \
               --candidate-context release-artifacts/rc/candidate-context.json \
@@ -968,7 +1031,16 @@ jobs:
             "${final_readiness_args[@]}" \
             --phase FINAL \
             --candidate-context release-artifacts/rc/candidate-context.json \
-            --output release-artifacts/rc/final-readiness.json
+            --output release-artifacts/rc/final-readiness.json \
+            --mobile-component-manifest release-artifacts/rc/mobile-component-manifest.json \
+            --backend-component-manifest release-artifacts/rc/backend-component-manifest.json \
+            --data-component-manifest release-artifacts/rc/data-component-manifest.json \
+            --platform-component-manifest release-artifacts/rc/platform-component-manifest.json \
+            --contracts-identity release-artifacts/rc/contracts-identity.json \
+            --system-release-output release-artifacts/rc/system-release-manifest.json \
+            --product-release-id "android-v${version_name}+${version_code}"
+          node tools/release/validate-system-release-manifest.mjs \
+            --manifest release-artifacts/rc/system-release-manifest.json
           # #1414 route/datapack 통합 판정. same-RC identity로 E1~E9 matrix를 결합한다.
           # planner(#2098)/mobile(#2099) evidence는 이 job에서 candidate-context 기준으로 생성해
           # 바로 연결한다. route-map(#2068) evidence는 아직 identity+provenance+integrationScenarios

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -691,10 +691,11 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p release-artifacts/backend
-          docker compose --env-file .env.example -f infra/docker-compose.yml config --quiet
-          docker compose --env-file .env.example -f infra/docker-compose.yml config > release-artifacts/backend/rendered-compose.yml
+          EASYSUBWAY_BACKEND_IMAGE_TAG="${GITHUB_SHA}" docker compose --env-file .env.example -f infra/docker-compose.yml config --quiet
+          EASYSUBWAY_BACKEND_IMAGE_TAG="${GITHUB_SHA}" docker compose --env-file .env.example -f infra/docker-compose.yml config > release-artifacts/backend/rendered-compose.yml
           test -f release-artifacts/backend/rendered-compose.yml
           test ! -L release-artifacts/backend/rendered-compose.yml
+          grep -Fq "image: easysubway-backend:${GITHUB_SHA}" release-artifacts/backend/rendered-compose.yml
 
       - name: Backend Release Image / Collect release metadata
         shell: bash
@@ -837,6 +838,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p release-artifacts/rc
+          bundled_data_manifest=apps/mobile/assets/datapacks/index.json
           data_pack_manifest=apps/mobile/assets/datapacks/index.json
           data_pack_artifact=apps/mobile/assets/datapacks/capital.sqlite.gz
           data_pack_fallback_artifact="${data_pack_artifact}"
@@ -942,7 +944,7 @@ jobs:
             --mobile-version-name "${version_name}" \
             --mobile-version-code "${version_code}" \
             --aab "${aab_path}" \
-            --bundled-data-manifest "${data_pack_manifest}" \
+            --bundled-data-manifest "${bundled_data_manifest}" \
             --backend-image-inspect release-artifacts/downloaded/backend/image-inspect.json \
             --backend-evidence release-artifacts/downloaded/backend/release-metadata.txt \
             --data-version "${data_version}" \

--- a/apps/mobile/release/rc-evidence-manifest-contract.json
+++ b/apps/mobile/release/rc-evidence-manifest-contract.json
@@ -1,14 +1,14 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "applicationId": "easysubway",
   "androidApplicationId": "com.easysubway.app",
   "releaseGate": "rc-evidence-manifest",
-  "issue": 1020,
-  "parentIssues": [1014, 1020],
-  "linkedEvidenceIssues": [547, 571, 1015, 1016, 1017, 1018, 1019, 1021, 1022, 1393, 1914, 2051, 2054, 2055, 2056, 2057, 2058, 2133],
-  "phaseConsumers": { "CANDIDATE": [2058, 1393], "FINAL": [1020] },
-  "requiredFinalFragmentIssues": [2058, 1393],
-  "activeBlockerIssues": [],
+  "issueRef": "AquilaXk/easysubway#1020",
+  "parentIssueRefs": ["AquilaXk/easysubway#1014", "AquilaXk/easysubway#1020"],
+  "linkedEvidenceIssueRefs": ["AquilaXk/easysubway#547", "AquilaXk/easysubway#571", "AquilaXk/easysubway#1015", "AquilaXk/easysubway#1016", "AquilaXk/easysubway#1017", "AquilaXk/easysubway#1018", "AquilaXk/easysubway#1019", "AquilaXk/easysubway#1021", "AquilaXk/easysubway#1022", "AquilaXk/easysubway#1393", "AquilaXk/easysubway#1914", "AquilaXk/easysubway#2051", "AquilaXk/easysubway#2054", "AquilaXk/easysubway#2055", "AquilaXk/easysubway#2056", "AquilaXk/easysubway#2057", "AquilaXk/easysubway#2058", "AquilaXk/easysubway#2133"],
+  "phaseConsumers": { "CANDIDATE": ["AquilaXk/easysubway#2058", "AquilaXk/easysubway#1393"], "FINAL": ["AquilaXk/easysubway#1020"] },
+  "requiredFinalFragmentIssueRefs": ["AquilaXk/easysubway#2058", "AquilaXk/easysubway#1393"],
+  "activeBlockerIssueRefs": [],
   "androidRcEvidenceManifest": "apps/mobile/release/android-rc-store-evidence.json",
   "signedReleaseArtifactGate": "apps/mobile/release/signed-release-artifact-gate.json",
   "releaseGovernanceGate": "apps/mobile/release/release-governance-gate.json",
@@ -37,7 +37,7 @@
   "backendIdentityFieldsAnyOf": ["backendImageDigest", "backendArtifactSha256"],
   "requiredEvidenceEntryFields": [
     "id",
-    "sourceIssue",
+    "issueRef",
     "device",
     "androidVersion",
     "testedAt",
@@ -47,66 +47,66 @@
   "requiredEvidenceEntries": [
     {
       "id": "rc_device_qa",
-      "sourceIssue": 571,
+      "issueRef": "AquilaXk/easysubway#571",
       "expiresAfterDays": 14, "requiredChecks": ["exactRcInstalled", "launchSmokePassed", "accessibilityPassed", "crashFree", "evidenceRedacted"]
     },
     {
       "id": "production_datapack",
-      "sourceIssue": 547,
+      "issueRef": "AquilaXk/easysubway#547",
       "expiresAfterDays": 14, "requiredChecks": ["signedManifestVerified", "artifactHashVerified", "schemaValidated", "sqliteIntegrityVerified", "productionScopeValidated"]
     },
     {
       "id": "signed_rc_store_submission",
-      "sourceIssue": 1015,
+      "issueRef": "AquilaXk/easysubway#1015",
       "expiresAfterDays": 14, "requiredChecks": ["signedAabVerified", "payloadIdentityVerified", "signingCertificateVerified", "storeReady"]
     },
     {
       "id": "play_generated_install",
-      "sourceIssue": 1016,
+      "issueRef": "AquilaXk/easysubway#1016",
       "expiresAfterDays": 14, "requiredChecks": ["playGeneratedApkInstalled", "artifactProvenanceVerified", "launchSmokePassed", "crashFree"]
     },
     {
       "id": "store_privacy_submission",
-      "sourceIssue": 1018,
+      "issueRef": "AquilaXk/easysubway#1018",
       "expiresAfterDays": 14, "requiredChecks": ["dataSafetyMatched", "privacyPolicyVerified", "permissionsAudited", "storeListingReady"]
     },
     {
       "id": "backend_operations",
-      "sourceIssue": 1017,
+      "issueRef": "AquilaXk/easysubway#1017",
       "expiresAfterDays": 14, "requiredChecks": ["backendArtifactVerified", "migrationsValidated", "healthChecksPassed", "rollbackReady"]
     },
     {
       "id": "post_launch_operations",
-      "sourceIssue": 1019,
+      "issueRef": "AquilaXk/easysubway#1019",
       "expiresAfterDays": 14
     },
     {
       "id": "android_release_quality",
-      "sourceIssue": 1021,
+      "issueRef": "AquilaXk/easysubway#1021",
       "expiresAfterDays": 14, "requiredChecks": ["qualitySuitePassed", "performancePassed", "accessibilityPassed", "recoveryPassed"]
     },
     {
       "id": "abuse_penetration_rehearsal",
-      "sourceIssue": 1022,
+      "issueRef": "AquilaXk/easysubway#1022",
       "expiresAfterDays": 14
     },
     {
       "id": "container_hardening",
-      "sourceIssue": 1914,
+      "issueRef": "AquilaXk/easysubway#1914",
       "expiresAfterDays": 14, "requiredChecks": ["nonRootVerified", "imageScanPassed", "immutableDigestVerified", "runtimePolicyPassed"]
     },
-    { "id": "production_equivalent_rehearsal", "sourceIssue": 2058, "expiresAfterDays": 14,
+    { "id": "production_equivalent_rehearsal", "issueRef": "AquilaXk/easysubway#2058", "expiresAfterDays": 14,
       "requiredChecks": ["currentBaselineCaptured", "appFirstCompatibilityPassed", "governanceNegativeNoProductionMutation", "restrictedCohortPassed", "monotonicRescueRollbackPassed", "finalTestCohortPassed"] },
-    { "id": "production_artifact_android_integration", "sourceIssue": 1393, "expiresAfterDays": 14,
+    { "id": "production_artifact_android_integration", "issueRef": "AquilaXk/easysubway#1393", "expiresAfterDays": 14,
       "requiredChecks": ["productionBaselineValidated", "candidateArtifactStrictValidated", "negativeArtifactsRejected", "playTestInstalledRcVerified", "installerRecoveryPassed", "routeAndItxSmokesPassed"] }
   ],
   "requiredDatapackGates": [
-    { "id": "source_admission", "sourceIssue": 2133, "expiresAfterDays": 14 },
-    { "id": "source_governance", "sourceIssue": 2133, "expiresAfterDays": 14 },
-    { "id": "freshness_conditional_publish", "sourceIssue": 2054, "expiresAfterDays": 14 },
-    { "id": "rollback_rescue", "sourceIssue": 2051, "expiresAfterDays": 14 },
-    { "id": "device_performance", "sourceIssue": 2055, "expiresAfterDays": 14 },
-    { "id": "callback_reconciliation", "sourceIssue": 2057, "expiresAfterDays": 14 }
+    { "id": "source_admission", "issueRef": "AquilaXk/easysubway#2133", "expiresAfterDays": 14 },
+    { "id": "source_governance", "issueRef": "AquilaXk/easysubway#2133", "expiresAfterDays": 14 },
+    { "id": "freshness_conditional_publish", "issueRef": "AquilaXk/easysubway#2054", "expiresAfterDays": 14 },
+    { "id": "rollback_rescue", "issueRef": "AquilaXk/easysubway#2051", "expiresAfterDays": 14 },
+    { "id": "device_performance", "issueRef": "AquilaXk/easysubway#2055", "expiresAfterDays": 14 },
+    { "id": "callback_reconciliation", "issueRef": "AquilaXk/easysubway#2057", "expiresAfterDays": 14 }
   ],
   "requiredGateStatuses": ["androidRcEvidence", "productionDatapack", "playGeneratedApkDeviceMatrix", "backendOperations",
     "androidReleaseQuality", "abusePenetrationRehearsal", "postLaunchOperations", "scopeCoverage",

--- a/contracts/release/component-manifest.schema.json
+++ b/contracts/release/component-manifest.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Release component manifest",
+  "oneOf": [
+    {
+      "type": "object", "additionalProperties": false,
+      "required": ["schemaVersion", "component", "repository", "gitSha", "artifactIdentity", "contractVersion", "evidenceSha256", "issueRefs"],
+      "properties": {
+        "schemaVersion": { "const": 1 }, "component": { "const": "mobile" }, "repository": { "type": "string", "minLength": 1 }, "gitSha": { "type": "string", "pattern": "^[a-f0-9]{40}$" },
+        "artifactIdentity": { "type": "object", "additionalProperties": false, "required": ["versionName", "versionCode", "aabSha256", "bundledDataManifestSha256"], "properties": { "versionName": { "type": "string", "minLength": 1 }, "versionCode": { "type": "integer", "minimum": 1 }, "aabSha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" }, "bundledDataManifestSha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" } } },
+        "contractVersion": { "type": "string", "minLength": 1 }, "evidenceSha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" }, "issueRefs": { "type": "array", "minItems": 1, "uniqueItems": true, "items": { "type": "string", "pattern": "^AquilaXk/(easysubway|easysubway-data|easysubway-platform|easysubway-backend|easysubway-mobile)#[1-9][0-9]*$" } }
+      }
+    },
+    {
+      "type": "object", "additionalProperties": false,
+      "required": ["schemaVersion", "component", "repository", "gitSha", "artifactIdentity", "contractVersion", "evidenceSha256", "issueRefs"],
+      "properties": {
+        "schemaVersion": { "const": 1 }, "component": { "const": "backend" }, "repository": { "type": "string", "minLength": 1 }, "gitSha": { "type": "string", "pattern": "^[a-f0-9]{40}$" },
+        "artifactIdentity": { "type": "object", "additionalProperties": false, "required": ["imageDigest", "apiContractVersion"], "properties": { "imageDigest": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" }, "apiContractVersion": { "type": "string", "minLength": 1 } } },
+        "contractVersion": { "type": "string", "minLength": 1 }, "evidenceSha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" }, "issueRefs": { "type": "array", "minItems": 1, "uniqueItems": true, "items": { "type": "string", "pattern": "^AquilaXk/(easysubway|easysubway-data|easysubway-platform|easysubway-backend|easysubway-mobile)#[1-9][0-9]*$" } }
+      }
+    },
+    {
+      "type": "object", "additionalProperties": false,
+      "required": ["schemaVersion", "component", "repository", "gitSha", "artifactIdentity", "contractVersion", "evidenceSha256", "issueRefs"],
+      "properties": {
+        "schemaVersion": { "const": 1 }, "component": { "const": "data" }, "repository": { "type": "string", "minLength": 1 }, "gitSha": { "type": "string", "pattern": "^[a-f0-9]{40}$" },
+        "artifactIdentity": { "type": "object", "additionalProperties": false, "required": ["dataVersion", "releaseSequence", "manifestSha256", "sourceSnapshotSetHash"], "properties": { "dataVersion": { "type": "string", "minLength": 1 }, "releaseSequence": { "type": "integer", "minimum": 0 }, "manifestSha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" }, "sourceSnapshotSetHash": { "type": "string", "pattern": "^[a-f0-9]{64}$" } } },
+        "contractVersion": { "type": "string", "minLength": 1 }, "evidenceSha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" }, "issueRefs": { "type": "array", "minItems": 1, "uniqueItems": true, "items": { "type": "string", "pattern": "^AquilaXk/(easysubway|easysubway-data|easysubway-platform|easysubway-backend|easysubway-mobile)#[1-9][0-9]*$" } }
+      }
+    },
+    {
+      "type": "object", "additionalProperties": false,
+      "required": ["schemaVersion", "component", "repository", "gitSha", "artifactIdentity", "contractVersion", "evidenceSha256", "issueRefs"],
+      "properties": {
+        "schemaVersion": { "const": 1 }, "component": { "const": "platform" }, "repository": { "type": "string", "minLength": 1 }, "gitSha": { "type": "string", "pattern": "^[a-f0-9]{40}$" },
+        "artifactIdentity": { "type": "object", "additionalProperties": false, "required": ["environment", "deployedImageDigest", "deploymentEvidenceSha256"], "properties": { "environment": { "type": "string", "minLength": 1 }, "deployedImageDigest": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" }, "deploymentEvidenceSha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" } } },
+        "contractVersion": { "type": "string", "minLength": 1 }, "evidenceSha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" }, "issueRefs": { "type": "array", "minItems": 1, "uniqueItems": true, "items": { "type": "string", "pattern": "^AquilaXk/(easysubway|easysubway-data|easysubway-platform|easysubway-backend|easysubway-mobile)#[1-9][0-9]*$" } }
+      }
+    }
+  ]
+}

--- a/contracts/release/issue-ref.schema.json
+++ b/contracts/release/issue-ref.schema.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Repository-qualified release issue reference",
+  "type": "string",
+  "pattern": "^AquilaXk/(easysubway|easysubway-data|easysubway-platform|easysubway-backend|easysubway-mobile)#[1-9][0-9]*$"
+}

--- a/contracts/release/system-release-manifest.schema.json
+++ b/contracts/release/system-release-manifest.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "System release manifest v2",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "productReleaseId", "phase", "decision", "generatedAt", "issueRefs", "contracts", "mobile", "backend", "data", "platform"],
+  "properties": {
+    "schemaVersion": { "const": 2 },
+    "productReleaseId": { "type": "string", "minLength": 1 },
+    "phase": { "type": "string", "enum": ["CANDIDATE", "FINAL"] },
+    "decision": { "type": "string", "enum": ["GO", "NO_GO"] },
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "issueRefs": { "type": "array", "minItems": 1, "uniqueItems": true, "items": { "type": "string", "pattern": "^AquilaXk/(easysubway|easysubway-data|easysubway-platform|easysubway-backend|easysubway-mobile)#[1-9][0-9]*$" } },
+    "contracts": { "type": "object", "additionalProperties": false, "required": ["version", "sha256"], "properties": { "version": { "type": "string", "minLength": 1 }, "sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" } } },
+    "mobile": { "type": "object" }, "backend": { "type": "object" }, "data": { "type": "object" }, "platform": { "type": "object" }
+  }
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -5659,6 +5659,118 @@ test("RC evidence manifest generator는 RC identity와 No-Go blocker를 생성�
   assert.ok(corruptManifest.readiness.blockers.some((blocker) => blocker.id === "missing_aabPayloadSha256"));
 });
 
+test("[system-release-generator] FINAL은 component manifest에서 검증된 system release v2를 별도로 생성한다", async () => {
+  const tempDir = await mkdtemp(path.join(tmpdir(), "easysubway-system-release-"));
+  const candidatePath = path.join(tempDir, "candidate.json");
+  const outputPath = path.join(tempDir, "legacy-final.json");
+  const systemOutputPath = path.join(tempDir, "system-release.json");
+  const aabPayloadPath = path.join(tempDir, "payload.bin");
+  const aabPath = path.join(tempDir, "app.aab");
+  const dataManifestPath = path.join(tempDir, "data-manifest.json");
+  const dataArtifactPath = path.join(tempDir, "data.sqlite.gz");
+  const rehearsalBindingPath = path.join(tempDir, "rehearsal-binding.json");
+  const backendInspectPath = path.join(tempDir, "backend-inspect.json");
+  const componentPaths = Object.fromEntries(["mobile", "backend", "data", "platform"].map(
+    (component) => [component, path.join(tempDir, `${component}.json`)],
+  ));
+  const contractsPath = path.join(tempDir, "contracts.json");
+  const dataManifest = { releaseSequence: 1 };
+  const dataArtifact = "data-artifact";
+  const digest = (value) => createHash("sha256").update(value).digest("hex");
+  const systemArgs = (overrides = {}) => [
+    "tools/release/generate-rc-evidence-manifest.mjs",
+    "--repo-root", ".", "--app-root", "apps/mobile", "--git-sha", currentGitSha,
+    "--now", "2026-07-30T00:00:00.000Z", "--aab", aabPath,
+    "--backend-image-inspect", backendInspectPath,
+    "--data-pack-manifest", dataManifestPath, "--data-pack-artifact", dataArtifactPath,
+    "--data-pack-rehearsal-binding", rehearsalBindingPath,
+    "--output", overrides.outputPath ?? outputPath,
+    "--mobile-component-manifest", overrides.mobilePath ?? componentPaths.mobile,
+    "--backend-component-manifest", overrides.backendPath ?? componentPaths.backend,
+    "--data-component-manifest", overrides.dataPath ?? componentPaths.data,
+    "--platform-component-manifest", overrides.platformPath ?? componentPaths.platform,
+    "--contracts-identity", overrides.contractsPath ?? contractsPath,
+    "--system-release-output", overrides.systemOutputPath ?? systemOutputPath,
+    "--product-release-id", "easysubway-2026.07.30.2693",
+  ];
+  try {
+    await writeFile(aabPayloadPath, "system-release-aab");
+    await execFileAsync("zip", ["-q", aabPath, path.basename(aabPayloadPath)], { cwd: tempDir });
+    await writeFile(dataManifestPath, JSON.stringify(dataManifest));
+    await writeFile(dataArtifactPath, dataArtifact);
+    await writeFile(rehearsalBindingPath, JSON.stringify({
+      schemaVersion: 1, artifactKind: "datapack-prelaunch-rehearsal-binding",
+      executionEnvironment: "ISOLATED_PRELAUNCH", productionExecuted: false,
+      sourceSnapshotSetHash: "c".repeat(64),
+      selectedManifestSha256: digest(JSON.stringify(dataManifest)),
+      selectedArtifactSha256: digest(dataArtifact), selectedReleaseSequence: 1,
+    }));
+    await writeFile(backendInspectPath, JSON.stringify([
+      { RepoDigests: [`ghcr.io/aquilaxk/easysubway-backend@sha256:${"b".repeat(64)}`] },
+    ]));
+
+    const candidateArgs = systemArgs().filter((value, index, values) => {
+      const componentOptions = new Set([
+        "--mobile-component-manifest", "--backend-component-manifest", "--data-component-manifest",
+        "--platform-component-manifest", "--contracts-identity", "--system-release-output", "--product-release-id",
+      ]);
+      return !componentOptions.has(value) && !componentOptions.has(values[index - 1]);
+    });
+    candidateArgs[candidateArgs.indexOf("--output") + 1] = candidatePath;
+    await execFileAsync(process.execPath, [...candidateArgs, "--phase", "CANDIDATE"], { cwd: root });
+    const candidate = JSON.parse(await readFile(candidatePath, "utf8"));
+    const identity = candidate.releaseCandidateIdentity;
+    const issueRefs = ["AquilaXk/easysubway-mobile#2693", "AquilaXk/easysubway-backend#2694", "AquilaXk/easysubway-data#2695", "AquilaXk/easysubway-platform#2696"];
+    const common = { schemaVersion: 1, repository: "AquilaXk/easysubway", gitSha: currentGitSha, contractVersion: "1.2.3", evidenceSha256: "d".repeat(64) };
+    const components = {
+      mobile: { ...common, component: "mobile", issueRefs: [issueRefs[0]], artifactIdentity: { versionName: identity.appVersionName, versionCode: Number(identity.versionCode), aabSha256: identity.aabSha256, bundledDataManifestSha256: identity.dataPackManifestSha256 } },
+      backend: { ...common, component: "backend", issueRefs: [issueRefs[1]], artifactIdentity: { imageDigest: identity.backendImageDigest, apiContractVersion: "1.2.3" } },
+      data: { ...common, component: "data", issueRefs: [issueRefs[2]], artifactIdentity: { dataVersion: "2026.07.30", releaseSequence: identity.releaseSequence, manifestSha256: identity.dataPackManifestSha256, sourceSnapshotSetHash: identity.sourceSnapshotSetHash } },
+      platform: { ...common, component: "platform", issueRefs: [issueRefs[3]], artifactIdentity: { environment: "ci", deployedImageDigest: identity.backendImageDigest, deploymentEvidenceSha256: "e".repeat(64) } },
+    };
+    for (const [component, document] of Object.entries(components)) await writeFile(componentPaths[component], JSON.stringify(document));
+    await writeFile(contractsPath, JSON.stringify({ version: "1.2.3", sha256: "f".repeat(64) }));
+
+    await execFileAsync(process.execPath, [
+      ...systemArgs(), "--phase", "FINAL", "--candidate-context", candidatePath,
+    ], { cwd: root });
+    const legacy = JSON.parse(await readFile(outputPath, "utf8"));
+    const system = JSON.parse(await readFile(systemOutputPath, "utf8"));
+    assert.equal(Object.hasOwn(system, "gitSha"), false);
+    assert.equal(system.schemaVersion, 2);
+    assert.equal(system.phase, "FINAL");
+    assert.equal(system.decision, "NO_GO");
+    assert.deepEqual(system.issueRefs, issueRefs);
+    assert.deepEqual(system.mobile.artifactIdentity, components.mobile.artifactIdentity);
+    assert.deepEqual(system.backend.artifactIdentity, components.backend.artifactIdentity);
+    assert.deepEqual(system.data.artifactIdentity, components.data.artifactIdentity);
+    assert.deepEqual(system.platform.artifactIdentity, components.platform.artifactIdentity);
+    assert.equal(Object.hasOwn(legacy, "mobile"), false);
+    await execFileAsync(process.execPath, ["tools/release/validate-system-release-manifest.mjs", "--manifest", systemOutputPath], { cwd: root });
+
+    await assert.rejects(
+      execFileAsync(process.execPath, [...systemArgs({ mobilePath: path.join(tempDir, "missing-mobile.json") }), "--phase", "FINAL", "--candidate-context", candidatePath], { cwd: root }),
+      /mobile component manifest is unreadable or invalid JSON/,
+    );
+    await assert.rejects(
+      execFileAsync(process.execPath, [...systemArgs({ systemOutputPath: outputPath }), "--phase", "FINAL", "--candidate-context", candidatePath], { cwd: root }),
+      /--system-release-output must differ from --output/,
+    );
+    await writeFile(componentPaths.mobile, "not-json");
+    await assert.rejects(
+      execFileAsync(process.execPath, [...systemArgs(), "--phase", "FINAL", "--candidate-context", candidatePath], { cwd: root }),
+      /mobile component manifest is unreadable or invalid JSON/,
+    );
+    await writeFile(componentPaths.mobile, JSON.stringify({ ...components.mobile, artifactIdentity: { ...components.mobile.artifactIdentity, versionName: "9.9.9" } }));
+    await assert.rejects(
+      execFileAsync(process.execPath, [...systemArgs(), "--phase", "FINAL", "--candidate-context", candidatePath], { cwd: root }),
+      /mobile component manifest drifts from candidate context/,
+    );
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("datapack readiness producer는 required gate를 동일 final identity로 결정론적으로 결합한다", async () => {
   const contract = readJson("apps/mobile/release/rc-evidence-manifest-contract.json");
   const requiredDatapackGates = [

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -45,12 +45,69 @@ async function initializeFixtureGitRepo(repoPath) {
   return execFileSync("git", ["rev-parse", "HEAD"], { cwd: repoPath, encoding: "utf8" }).trim();
 }
 
+function optionValue(args, option) {
+  const index = args.indexOf(option);
+  return index === -1 ? null : args[index + 1];
+}
+
+function withOption(args, option, value) {
+  const next = [...args];
+  const index = next.indexOf(option);
+  if (index === -1) next.push(option, value);
+  else next[index + 1] = value;
+  return next;
+}
+
+async function completeCandidateGeneratorArgs(generatorArgs, finalOutputPath) {
+  let args = [...generatorArgs];
+  if (!optionValue(args, "--aab")) {
+    const aabPath = `${finalOutputPath}.candidate.aab`;
+    await writeFile(aabPath, "candidate-aab");
+    args = withOption(args, "--aab", aabPath);
+  }
+  if (!optionValue(args, "--backend-image-digest") && !optionValue(args, "--backend-artifact") && !optionValue(args, "--backend-image-inspect")) {
+    args = withOption(args, "--backend-image-digest", `sha256:${"a".repeat(64)}`);
+  }
+  if (!optionValue(args, "--data-pack-release-decision") && !optionValue(args, "--data-pack-rehearsal-binding")) {
+    const appRoot = path.resolve(root, optionValue(args, "--app-root") ?? "apps/mobile");
+    const selectedManifestPath = path.resolve(root, optionValue(args, "--data-pack-manifest")
+      ?? path.join(appRoot, "assets/datapacks/metro_map_pack/manifest.json"));
+    const selectedManifest = JSON.parse(await readFile(selectedManifestPath, "utf8"));
+    const manifestPath = `${finalOutputPath}.candidate-data-manifest.json`;
+    const manifest = { ...selectedManifest, releaseSequence: selectedManifest.releaseSequence ?? 1 };
+    await writeFile(manifestPath, JSON.stringify(manifest));
+    args = withOption(args, "--data-pack-manifest", manifestPath);
+    let artifactPath = optionValue(args, "--data-pack-artifact");
+    if (!artifactPath) {
+      artifactPath = `${finalOutputPath}.candidate-data-artifact`;
+      await writeFile(artifactPath, "candidate-data-artifact");
+      args = withOption(args, "--data-pack-artifact", artifactPath);
+    }
+    const manifestBytes = await readFile(manifestPath);
+    const artifactBytes = await readFile(path.resolve(root, artifactPath));
+    const bindingPath = `${finalOutputPath}.candidate-rehearsal-binding.json`;
+    await writeFile(bindingPath, JSON.stringify({
+      schemaVersion: 1, artifactKind: "datapack-prelaunch-rehearsal-binding",
+      executionEnvironment: "ISOLATED_PRELAUNCH", productionExecuted: false,
+      sourceSnapshotSetHash: "c".repeat(64),
+      selectedManifestSha256: createHash("sha256").update(manifestBytes).digest("hex"),
+      selectedArtifactSha256: createHash("sha256").update(artifactBytes).digest("hex"),
+      selectedReleaseSequence: manifest.releaseSequence,
+    }));
+    args = withOption(args, "--data-pack-rehearsal-binding", bindingPath);
+  }
+  return args;
+}
+
 async function writeFinalSystemReleaseArgs(candidatePath, finalOutputPath) {
   const candidate = JSON.parse(await readFile(candidatePath, "utf8"));
   const identity = candidate.releaseCandidateIdentity;
-  const fallbackDigest = `sha256:${"a".repeat(64)}`;
   const fallbackHash = "b".repeat(64);
-  const value = (field, fallback) => identity[field] ?? fallback;
+  const required = (field) => {
+    assert.notEqual(identity[field], null, `candidate identity requires ${field}`);
+    assert.notEqual(identity[field], undefined, `candidate identity requires ${field}`);
+    return identity[field];
+  };
   const componentPaths = Object.fromEntries(["mobile", "backend", "data", "platform"].map(
     (component) => [component, `${finalOutputPath}.${component}-component.json`],
   ));
@@ -62,24 +119,24 @@ async function writeFinalSystemReleaseArgs(candidatePath, finalOutputPath) {
     mobile: {
       ...common, component: "mobile", issueRefs: ["AquilaXk/easysubway#2693"],
       artifactIdentity: {
-        versionName: value("appVersionName", "1.0.0"), versionCode: Number(value("versionCode", 1)),
-        aabSha256: value("aabSha256", fallbackHash), bundledDataManifestSha256: value("dataPackManifestSha256", fallbackHash),
+        versionName: required("appVersionName"), versionCode: Number(required("versionCode")),
+        aabSha256: required("aabSha256"), bundledDataManifestSha256: required("dataPackManifestSha256"),
       },
     },
     backend: {
       ...common, component: "backend", issueRefs: ["AquilaXk/easysubway#2693"],
-      artifactIdentity: { imageDigest: value("backendImageDigest", fallbackDigest), apiContractVersion: "1.0.0" },
+      artifactIdentity: { imageDigest: required("backendImageDigest"), apiContractVersion: "1.0.0" },
     },
     data: {
       ...common, component: "data", issueRefs: ["AquilaXk/easysubway#2693"],
       artifactIdentity: {
-        dataVersion: "1.0.0", releaseSequence: Number(value("releaseSequence", 0)),
-        manifestSha256: value("dataPackManifestSha256", fallbackHash), sourceSnapshotSetHash: value("sourceSnapshotSetHash", fallbackHash),
+        dataVersion: "1.0.0", releaseSequence: Number(required("releaseSequence")),
+        manifestSha256: required("dataPackManifestSha256"), sourceSnapshotSetHash: required("sourceSnapshotSetHash"),
       },
     },
     platform: {
       ...common, component: "platform", issueRefs: ["AquilaXk/easysubway#2693"],
-      artifactIdentity: { environment: "ci", deployedImageDigest: value("backendImageDigest", fallbackDigest), deploymentEvidenceSha256: fallbackHash },
+      artifactIdentity: { environment: "ci", deployedImageDigest: required("backendImageDigest"), deploymentEvidenceSha256: fallbackHash },
     },
   };
   for (const [component, document] of Object.entries(components)) await writeFile(componentPaths[component], JSON.stringify(document));
@@ -5259,12 +5316,13 @@ test("RC evidence manifest generator는 RC identity와 No-Go blocker를 생성�
     const finalOutput = generatorArgs[outputIndex + 1];
     const withoutOutput = generatorArgs.filter((_, index) => index !== outputIndex && index !== outputIndex + 1);
     const candidateOutput = `${finalOutput}.candidate-context.json`;
+    const completeArgs = await completeCandidateGeneratorArgs(withoutOutput, finalOutput);
     await execFileAsync(process.execPath, [
-      ...withoutOutput, "--phase", "CANDIDATE", "--output", candidateOutput,
+      ...completeArgs, "--phase", "CANDIDATE", "--output", candidateOutput,
     ], options);
     const systemReleaseArgs = await writeFinalSystemReleaseArgs(candidateOutput, finalOutput);
     return execFileAsync(process.execPath, [
-      ...withoutOutput, ...systemReleaseArgs, "--phase", "FINAL", "--candidate-context", candidateOutput, "--output", finalOutput,
+      ...completeArgs, ...systemReleaseArgs, "--phase", "FINAL", "--candidate-context", candidateOutput, "--output", finalOutput,
     ], options);
   };
   const appVersion = read("apps/mobile/pubspec.yaml").match(/^version:\s*([^+\s]+)\+([0-9]+)\s*$/m);
@@ -5651,7 +5709,7 @@ test("RC evidence manifest generator는 RC identity와 No-Go blocker를 생성�
   const metadataOnlyInspect = JSON.stringify([{ RepoDigests: [], Size: 367184804 }]);
   const metadataOnlyInspectSha256 = createHash("sha256").update(metadataOnlyInspect).digest("hex");
   await writeFile(metadataOnlyInspectPath, metadataOnlyInspect);
-  await runFinalGenerator([
+  await execFileAsync(process.execPath, [
     "tools/release/generate-rc-evidence-manifest.mjs",
     "--repo-root",
     ".",
@@ -5667,6 +5725,8 @@ test("RC evidence manifest generator는 RC identity와 No-Go blocker를 생성�
     "apps/mobile/assets/datapacks/metro_map_pack/manifest.json",
     "--output",
     metadataOnlyManifestPath,
+    "--phase",
+    "CANDIDATE",
     "--tested-at",
     "2026-06-26T00:00:00.000Z",
   ], { cwd: root });
@@ -5910,12 +5970,11 @@ if (!existsSync(value("--summary")) || !process.argv.includes("--require-pass"))
     evaluatedAt: now, expiresAt: "2026-07-30T00:00:00.000Z",
   }));
   const aabPayloadPath = path.join(tempDir, "payload.bin"), aabPath = path.join(tempDir, "app-release.aab");
-  const backendArtifactPath = path.join(tempDir, "backend.jar"), dataPackManifestPath = path.join(tempDir, "current.json");
+  const dataPackManifestPath = path.join(tempDir, "current.json");
   const dataPackArtifactPath = path.join(tempDir, "capital.sqlite.gz");
   const dataPackReleaseDecisionPath = path.join(tempDir, "final-release-decision.json");
   await writeFile(aabPayloadPath, "datapack-readiness-aab");
   await execFileAsync("zip", ["-q", aabPath, path.basename(aabPayloadPath)], { cwd: tempDir });
-  await writeFile(backendArtifactPath, "datapack-readiness-backend");
   const dataPackArtifactContents = Buffer.from("datapack-readiness-pack");
   const compressedDataPackArtifact = gzipSync(dataPackArtifactContents);
   const dataPackArtifactBytes = compressedDataPackArtifact.length;
@@ -5977,7 +6036,7 @@ if (!existsSync(value("--summary")) || !process.argv.includes("--require-pass"))
   const args = [
     "tools/release/generate-rc-evidence-manifest.mjs",
     "--repo-root", validationRepo, "--app-root", "apps/mobile", "--git-sha", gitSha, "--now", now,
-    "--aab", aabPath, "--backend-artifact", backendArtifactPath,
+    "--aab", aabPath, "--backend-image-digest", `sha256:${"a".repeat(64)}`,
     "--data-pack-manifest", dataPackManifestPath, "--data-pack-artifact", dataPackArtifactPath,
     "--data-pack-release-decision", dataPackReleaseDecisionPath,
     "--require-production-data-pack-binding", "true",
@@ -6274,7 +6333,7 @@ if (!existsSync(value("--summary")) || !process.argv.includes("--require-pass"))
           androidApplicationId: "com.easysubway.app",
           dataPackManifestSha256: evidenceRcIdentity.dataPackManifestSha256,
           aabSha256: evidenceRcIdentity.aabSha256,
-          backendArtifactSha256: evidenceRcIdentity.backendArtifactSha256,
+          backendImageDigest: evidenceRcIdentity.backendImageDigest,
         },
       })}\n`);
       evidence.canonicalSummaryPath = abuseSummaryPath;
@@ -6550,12 +6609,13 @@ test("datapack readiness producer는 unknown·mixed identity·expired evidence�
     const finalOutput = generatorArgs[outputIndex + 1];
     const withoutOutput = generatorArgs.filter((_, index) => index !== outputIndex && index !== outputIndex + 1);
     const candidateOutput = `${finalOutput}.candidate-context.json`;
+    const completeArgs = await completeCandidateGeneratorArgs(withoutOutput, finalOutput);
     await execFileAsync(process.execPath, [
-      ...withoutOutput, "--phase", "CANDIDATE", "--output", candidateOutput,
+      ...completeArgs, "--phase", "CANDIDATE", "--output", candidateOutput,
     ], options);
     const systemReleaseArgs = await writeFinalSystemReleaseArgs(candidateOutput, finalOutput);
     return execFileAsync(process.execPath, [
-      ...withoutOutput, ...systemReleaseArgs, "--phase", "FINAL", "--candidate-context", candidateOutput, "--output", finalOutput,
+      ...completeArgs, ...systemReleaseArgs, "--phase", "FINAL", "--candidate-context", candidateOutput, "--output", finalOutput,
     ], options);
   };
   const rejects = (extraArgs, expected) => assert.rejects(

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -3397,7 +3397,7 @@ test("릴리즈 산출물 워크플로우는 모바일 스토어 산출물과 ba
   assert.match(workflow, /name: easysubway-backend-release-\$\{\{ github\.sha \}\}/);
 });
 
-test("[release-v2] RC evidence contract uses repository-qualified issue references", () => {
+test("[release-v2] RC evidence contract uses repository-qualified issue references", async () => {
   const contract = readJson("apps/mobile/release/rc-evidence-manifest-contract.json");
   const issueRefSchema = readJson("contracts/release/issue-ref.schema.json");
   const issueRefPattern = new RegExp(issueRefSchema.pattern);
@@ -3421,6 +3421,31 @@ test("[release-v2] RC evidence contract uses repository-qualified issue referenc
   assert.ok(contract.requiredEvidenceEntryFields.includes("issueRef"));
   assert.ok(!contract.requiredEvidenceEntryFields.includes("sourceIssue"));
   assert.ok(issueRefs.every((issueRef) => issueRefPattern.test(issueRef)));
+
+  const tempApp = await mkdtemp(path.join(tmpdir(), "release-v2-contract-"));
+  try {
+    await mkdir(path.join(tempApp, "release"), { recursive: true });
+    await writeFile(path.join(tempApp, "pubspec.yaml"), read("apps/mobile/pubspec.yaml"));
+    for (const issueRef of ["AquilaXk/easysubway-data#2133", "AquilaXk/easysubway#0"]) {
+      await writeFile(path.join(tempApp, "release/rc-evidence-manifest-contract.json"), JSON.stringify({
+        ...contract, issueRef,
+      }));
+      await assert.rejects(
+        execFileAsync(process.execPath, [
+          "tools/release/generate-rc-evidence-manifest.mjs",
+          "--repo-root", root,
+          "--app-root", tempApp,
+          "--git-sha", currentGitSha,
+          "--phase", "CANDIDATE",
+          "--output", path.join(tempApp, "candidate-context.json"),
+          "--data-pack-manifest", path.join(root, "apps/mobile/assets/datapacks/metro_map_pack/manifest.json"),
+        ], { cwd: root }),
+        new RegExp(`Invalid EasySubway issue reference: ${issueRef}`),
+      );
+    }
+  } finally {
+    await rm(tempApp, { recursive: true, force: true });
+  }
 });
 
 test("모바일 signed release artifact gate와 광고 counter는 CI 산출물과 스토어 제출 준비 상태를 분리한다", () => {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -5901,6 +5901,13 @@ test("[system-release-generator] FINAL은 component manifest에서 검증된 sys
     await execFileAsync(process.execPath, [...candidateArgs, "--phase", "CANDIDATE"], { cwd: root });
     const candidate = JSON.parse(await readFile(candidatePath, "utf8"));
     const identity = candidate.releaseCandidateIdentity;
+    const legacyOnlyOutput = path.join(tempDir, "legacy-only-final.json");
+    const legacyOnlyArgs = [...candidateArgs];
+    legacyOnlyArgs[legacyOnlyArgs.indexOf("--output") + 1] = legacyOnlyOutput;
+    await execFileAsync(process.execPath, [
+      ...legacyOnlyArgs, "--phase", "FINAL", "--candidate-context", candidatePath,
+    ], { cwd: root });
+    assert.equal(JSON.parse(await readFile(legacyOnlyOutput, "utf8")).schemaVersion, 1);
     const issueRefs = ["AquilaXk/easysubway-mobile#2693", "AquilaXk/easysubway-backend#2694", "AquilaXk/easysubway-data#2695", "AquilaXk/easysubway-platform#2696"];
     const common = { schemaVersion: 1, repository: "AquilaXk/easysubway", gitSha: currentGitSha, contractVersion: "1.2.3", evidenceSha256: "d".repeat(64) };
     const components = {
@@ -6033,10 +6040,25 @@ test("[system-release-generator] FINAL은 component manifest에서 검증된 sys
     assert.equal(await readFile(hardlinkLegacyOutput, "utf8"), "hardlink sentinel");
     assert.equal(await readFile(hardlinkSystemOutput, "utf8"), "hardlink sentinel");
 
+    const prevalidationLegacyOutput = path.join(tempDir, "prevalidation-legacy.json");
+    const prevalidationSystemOutput = path.join(tempDir, "prevalidation-system.json");
+    const prevalidationMobilePath = path.join(tempDir, "prevalidation-mobile.json");
+    await writeFile(prevalidationLegacyOutput, "legacy sentinel");
+    await writeFile(prevalidationSystemOutput, "system sentinel");
+    await writeFile(prevalidationMobilePath, JSON.stringify({
+      ...components.mobile,
+      artifactIdentity: { ...components.mobile.artifactIdentity, versionName: "9.9.9" },
+    }));
     await assert.rejects(
-      execFileAsync(process.execPath, [...systemArgs({ mobilePath: path.join(tempDir, "missing-mobile.json") }), "--phase", "FINAL", "--candidate-context", candidatePath], { cwd: root }),
-      /mobile component manifest is unreadable or invalid JSON/,
+      execFileAsync(process.execPath, [...systemArgs({
+        mobilePath: prevalidationMobilePath,
+        outputPath: prevalidationLegacyOutput,
+        systemOutputPath: prevalidationSystemOutput,
+      }), "--phase", "FINAL", "--candidate-context", candidatePath], { cwd: root }),
+      /mobile component manifest drifts from candidate context/,
     );
+    assert.equal(await readFile(prevalidationLegacyOutput, "utf8"), "legacy sentinel");
+    assert.equal(await readFile(prevalidationSystemOutput, "utf8"), "system sentinel");
     await assert.rejects(
       execFileAsync(process.execPath, [...systemArgs({ systemOutputPath: outputPath }), "--phase", "FINAL", "--candidate-context", candidatePath], { cwd: root }),
       /--system-release-output must differ from --output/,

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -3568,16 +3568,23 @@ test("[release-v2-workflow] release workflow assembles v2 and gates Play on GO",
   assert.match(backendJob, /needs\.changes\.outputs\.android == 'true'/);
   assert.match(backendJob, /needs\.changes\.outputs\.mobile == 'true'/);
   assert.match(backendJob, /github\.event_name == 'workflow_dispatch'/);
+  assert.equal(
+    (backendJob.match(/EASYSUBWAY_BACKEND_IMAGE_TAG="\$\{GITHUB_SHA\}" docker compose/g) ?? []).length,
+    2,
+  );
   assert.match(backendJob, /docker compose --env-file \.env\.example -f infra\/docker-compose\.yml config --quiet/);
   assert.match(backendJob, /docker compose --env-file \.env\.example -f infra\/docker-compose\.yml config > release-artifacts\/backend\/rendered-compose\.yml/);
   assert.match(backendJob, /test -f release-artifacts\/backend\/rendered-compose\.yml/);
   assert.match(backendJob, /test ! -L release-artifacts\/backend\/rendered-compose\.yml/);
+  assert.match(backendJob, /grep -Fq "image: easysubway-backend:\$\{GITHUB_SHA\}" release-artifacts\/backend\/rendered-compose\.yml/);
   assert.match(backendJob, /path: release-artifacts\/backend/);
 
   assert.match(rcJob, /needs\.backend-release\.result == 'success'/);
   assert.match(rcJob, /needs\.android-release\.outputs\.artifact_available == 'true'/);
   assert.match(rcJob, /needs\.android-production-rc-release\.result == 'success'/);
+  assert.match(rcJob, /bundled_data_manifest=apps\/mobile\/assets\/datapacks\/index\.json/);
   assert.match(rcJob, /data_pack_manifest=apps\/mobile\/assets\/datapacks\/index\.json/);
+  assert.doesNotMatch(rcJob, /bundled_data_manifest=release-artifacts\/downloaded\/datapack-selected\/current\.json/);
   assert.match(rcJob, /data_pack_artifact=apps\/mobile\/assets\/datapacks\/capital\.sqlite\.gz/);
   assert.match(rcJob, /source_snapshot_evidence="\$\{data_pack_manifest\}"/);
   assert.match(rcJob, /release_sequence=0/);
@@ -3586,7 +3593,7 @@ test("[release-v2-workflow] release workflow assembles v2 and gates Play on GO",
   assert.match(rcJob, /node tools\/release\/build-monorepo-component-manifests\.mjs/);
   assert.match(rcJob, /--output-dir "\$\{component_output\}"/);
   assert.match(rcJob, /--backend-image-inspect release-artifacts\/downloaded\/backend\/image-inspect\.json/);
-  assert.match(rcJob, /--bundled-data-manifest "\$\{data_pack_manifest\}"/);
+  assert.match(rcJob, /--bundled-data-manifest "\$\{bundled_data_manifest\}"/);
   assert.match(rcJob, /--data-manifest "\$\{data_pack_manifest\}"/);
   assert.match(rcJob, /--source-snapshot-evidence "\$\{source_snapshot_evidence\}"/);
   assert.doesNotMatch(rcJob, /--backend-artifact/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -5938,6 +5938,26 @@ test("[system-release-generator] FINAL은 component manifest에서 검증된 sys
     );
     assert.deepEqual(await readFile(outputPath), legacyBeforeInvalidSemVer);
     assert.deepEqual(await readFile(systemOutputPath), systemBeforeInvalidSemVer);
+    const missingIdentityMobile = structuredClone(components.mobile);
+    delete missingIdentityMobile.artifactIdentity.aabSha256;
+    await writeFile(componentPaths.mobile, JSON.stringify(missingIdentityMobile));
+    await assert.rejects(
+      execFileAsync(process.execPath, [...systemArgs(), "--phase", "FINAL", "--candidate-context", candidatePath], { cwd: root }),
+      /mobile component manifest drifts from candidate context/,
+    );
+    assert.deepEqual(await readFile(outputPath), legacyBeforeInvalidSemVer);
+    assert.deepEqual(await readFile(systemOutputPath), systemBeforeInvalidSemVer);
+
+    const stringVersionCodeMobile = structuredClone(components.mobile);
+    stringVersionCodeMobile.artifactIdentity.versionCode = String(stringVersionCodeMobile.artifactIdentity.versionCode);
+    await writeFile(componentPaths.mobile, JSON.stringify(stringVersionCodeMobile));
+    await assert.rejects(
+      execFileAsync(process.execPath, [...systemArgs(), "--phase", "FINAL", "--candidate-context", candidatePath], { cwd: root }),
+      /mobile component manifest drifts from candidate context/,
+    );
+    assert.deepEqual(await readFile(outputPath), legacyBeforeInvalidSemVer);
+    assert.deepEqual(await readFile(systemOutputPath), systemBeforeInvalidSemVer);
+    await writeFile(componentPaths.mobile, JSON.stringify(components.mobile));
     const semanticSchemas = {
       componentSchema: JSON.parse(read("contracts/release/component-manifest.schema.json")),
       systemSchema: JSON.parse(read("contracts/release/system-release-manifest.schema.json")),

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -6063,6 +6063,13 @@ test("[system-release-generator] FINAL은 component manifest에서 검증된 sys
       execFileAsync(process.execPath, [...systemArgs({ systemOutputPath: outputPath }), "--phase", "FINAL", "--candidate-context", candidatePath], { cwd: root }),
       /--system-release-output must differ from --output/,
     );
+    const caseFoldedOutput = path.join(tempDir, "CASE-SYSTEM-RELEASE.JSON");
+    await assert.rejects(
+      execFileAsync(process.execPath, [...systemArgs({
+        outputPath: path.join(tempDir, "case-system-release.json"), systemOutputPath: caseFoldedOutput,
+      }), "--phase", "FINAL", "--candidate-context", candidatePath], { cwd: root }),
+      /--system-release-output must differ from --output/,
+    );
     await writeFile(componentPaths.mobile, "not-json");
     await assert.rejects(
       execFileAsync(process.execPath, [...systemArgs(), "--phase", "FINAL", "--candidate-context", candidatePath], { cwd: root }),

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -3557,6 +3557,61 @@ test("[release-v2] RC evidence contract uses repository-qualified issue referenc
   }
 });
 
+test("[release-v2-workflow] release workflow assembles v2 and gates Play on GO", () => {
+  const workflow = read(".github/workflows/release-artifacts.yml");
+  const generator = read("tools/release/generate-rc-evidence-manifest.mjs");
+  const validator = read("tools/release/validate-system-release-manifest.mjs");
+  const backendJob = jobBlock(workflow, "backend-release", "rc-evidence-manifest");
+  const rcJob = jobBlock(workflow, "rc-evidence-manifest", "notify-slack-release-result");
+  const playJob = jobBlock(workflow, "play-internal-upload", "backend-release");
+
+  assert.match(backendJob, /needs\.changes\.outputs\.android == 'true'/);
+  assert.match(backendJob, /needs\.changes\.outputs\.mobile == 'true'/);
+  assert.match(backendJob, /github\.event_name == 'workflow_dispatch'/);
+  assert.match(backendJob, /docker compose --env-file \.env\.example -f infra\/docker-compose\.yml config --quiet/);
+  assert.match(backendJob, /docker compose --env-file \.env\.example -f infra\/docker-compose\.yml config > release-artifacts\/backend\/rendered-compose\.yml/);
+  assert.match(backendJob, /test -f release-artifacts\/backend\/rendered-compose\.yml/);
+  assert.match(backendJob, /test ! -L release-artifacts\/backend\/rendered-compose\.yml/);
+  assert.match(backendJob, /path: release-artifacts\/backend/);
+
+  assert.match(rcJob, /needs\.backend-release\.result == 'success'/);
+  assert.match(rcJob, /needs\.android-release\.outputs\.artifact_available == 'true'/);
+  assert.match(rcJob, /needs\.android-production-rc-release\.result == 'success'/);
+  assert.match(rcJob, /data_pack_manifest=apps\/mobile\/assets\/datapacks\/index\.json/);
+  assert.match(rcJob, /data_pack_artifact=apps\/mobile\/assets\/datapacks\/capital\.sqlite\.gz/);
+  assert.match(rcJob, /source_snapshot_evidence="\$\{data_pack_manifest\}"/);
+  assert.match(rcJob, /release_sequence=0/);
+  assert.match(rcJob, /--release-sequence "\$\{release_sequence\}"/);
+  assert.match(rcJob, /git archive --format=tar HEAD contracts > "\$\{RUNNER_TEMP\}\/contracts\.tar"/);
+  assert.match(rcJob, /node tools\/release\/build-monorepo-component-manifests\.mjs/);
+  assert.match(rcJob, /--output-dir "\$\{component_output\}"/);
+  assert.match(rcJob, /--backend-image-inspect release-artifacts\/downloaded\/backend\/image-inspect\.json/);
+  assert.match(rcJob, /--bundled-data-manifest "\$\{data_pack_manifest\}"/);
+  assert.match(rcJob, /--data-manifest "\$\{data_pack_manifest\}"/);
+  assert.match(rcJob, /--source-snapshot-evidence "\$\{source_snapshot_evidence\}"/);
+  assert.doesNotMatch(rcJob, /--backend-artifact/);
+  for (const component of ["mobile", "backend", "data", "platform"]) {
+    assert.match(rcJob, new RegExp(`--${component}-component-manifest release-artifacts/rc/${component}-component-manifest\\.json`));
+    assert.match(rcJob, new RegExp(`cp "\\$\\{component_output\\}/${component}-component-manifest\\.json" release-artifacts/rc/${component}-component-manifest\\.json`));
+  }
+  assert.match(rcJob, /--contracts-identity release-artifacts\/rc\/contracts-identity\.json/);
+  assert.match(rcJob, /--output release-artifacts\/rc\/final-readiness\.json/);
+  assert.match(rcJob, /--system-release-output release-artifacts\/rc\/system-release-manifest\.json/);
+  assert.match(rcJob, /--product-release-id "android-v\$\{version_name\}\+\$\{version_code\}"/);
+  assert.match(rcJob, /node tools\/release\/validate-system-release-manifest\.mjs[\s\S]*--manifest release-artifacts\/rc\/system-release-manifest\.json/);
+  assert.ok(rcJob.indexOf("--system-release-output") < rcJob.indexOf("validate-system-release-manifest.mjs"));
+  assert.match(rcJob, /name: easysubway-rc-evidence-manifest-\$\{\{ github\.sha \}\}[\s\S]*path: release-artifacts\/rc/);
+
+  assert.match(playJob, /name: easysubway-rc-evidence-manifest-\$\{\{ github\.sha \}\}/);
+  assert.match(playJob, /--manifest release-artifacts\/downloaded\/rc\/system-release-manifest\.json[\s\S]*--require-decision GO/);
+  assert.ok(playJob.indexOf("--require-decision GO") < playJob.indexOf("Play internal upload / Restore release environment"));
+  assert.match(generator, /assets\/datapacks\/index\.json/);
+  assert.match(generator, /dataPackManifest\?\.sourceSnapshotSetHash/);
+  assert.match(generator, /!Number\.isSafeInteger\(parsed\) \|\| parsed < 0/);
+  assert.match(validator, /requireDecision/);
+  assert.match(validator, /manifest\.decision !== options\.requireDecision/);
+});
+
 test("모바일 signed release artifact gate와 광고 counter는 CI 산출물과 스토어 제출 준비 상태를 분리한다", () => {
   const gatePath = "apps/mobile/release/signed-release-artifact-gate.json";
 
@@ -4863,7 +4918,7 @@ test("모바일 signed release artifact gate와 광고 counter는 CI 산출물�
   assert.match(workflow, /--gate-status productionDatapack=BLOCKED_EXTERNAL/);
   assert.match(workflow, /--backend-image-inspect release-artifacts\/downloaded\/backend\/image-inspect\.json/);
   assert.match(workflow, /cp "\$\{boot_jar\[0\]\}" release-artifacts\/backend\/backend-boot\.jar/);
-  assert.match(workflow, /--backend-artifact release-artifacts\/downloaded\/backend\/backend-boot\.jar/);
+  assert.doesNotMatch(workflow, /--backend-artifact release-artifacts\/downloaded\/backend\/backend-boot\.jar/);
   assert.match(backendBuild, /preserveFileTimestamps\s*=\s*false/);
   assert.match(backendBuild, /reproducibleFileOrder\s*=\s*true/);
   assert.match(workflow, /--gate-status backendOperations=BLOCKED_EXTERNAL/);
@@ -6171,7 +6226,7 @@ if (!existsSync(value("--summary")) || !process.argv.includes("--require-pass"))
   );
   await assert.rejects(execFileAsync(process.execPath, [...args, "--release-sequence", "2026.07.12",
     "--phase", "CANDIDATE", "--output", path.join(tempDir, "invalid-release-sequence.json")], generatorOptions),
-  /--release-sequence must be a positive safe integer/);
+  /--release-sequence must be a non-negative safe integer/);
   const evidenceRcIdentity = candidateManifest.releaseCandidateIdentity;
   const invalidCandidatePath = path.join(tempDir, "invalid-candidate-context.json");
   await writeFile(invalidCandidatePath, JSON.stringify({ ...candidateManifest, decision: "GO" }));
@@ -7262,7 +7317,7 @@ test("릴리즈 산출물 워크플로우는 관련 변경에서만 비용 큰 �
   assert.match(androidReleaseJob, /if: \$\{\{ needs\.changes\.outputs\.android == 'true' \|\| needs\.changes\.outputs\.mobile == 'true' \}\}/);
   assert.doesNotMatch(workflow, /ios-release:/);
   assert.match(backendReleaseJob, /needs: changes/);
-  assert.match(backendReleaseJob, /if: \$\{\{ needs\.changes\.outputs\.backend == 'true' \|\| needs\.changes\.outputs\.deploy == 'true' \}\}/);
+  assert.match(backendReleaseJob, /needs\.changes\.outputs\.backend == 'true'[\s\S]*needs\.changes\.outputs\.android == 'true'[\s\S]*github\.event_name == 'workflow_dispatch'/);
   assert.match(detector, /apps\/mobile\/release\/\*\*/);
   assert.match(detector, /apps\/mobile\/android\/app\/build\.gradle\.kts/);
   assert.match(detector, /apps\/mobile\/ios\/Runner\.xcodeproj\/\*\*/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -5928,6 +5928,16 @@ test("[system-release-generator] FINAL은 component manifest에서 검증된 sys
     assert.deepEqual(system.platform.artifactIdentity, components.platform.artifactIdentity);
     assert.equal(Object.hasOwn(legacy, "mobile"), false);
     await execFileAsync(process.execPath, ["tools/release/validate-system-release-manifest.mjs", "--manifest", systemOutputPath], { cwd: root });
+    const legacyBeforeInvalidSemVer = await readFile(outputPath);
+    const systemBeforeInvalidSemVer = await readFile(systemOutputPath);
+    const invalidSemVerContractsPath = path.join(tempDir, "invalid-semver-contracts.json");
+    await writeFile(invalidSemVerContractsPath, JSON.stringify({ version: `1.2.3-${"a.".repeat(150)}a`, sha256: "f".repeat(64) }));
+    await assert.rejects(
+      execFileAsync(process.execPath, [...systemArgs({ contractsPath: invalidSemVerContractsPath }), "--phase", "FINAL", "--candidate-context", candidatePath], { cwd: root }),
+      /contracts identity must be exactly \{version,sha256\}/,
+    );
+    assert.deepEqual(await readFile(outputPath), legacyBeforeInvalidSemVer);
+    assert.deepEqual(await readFile(systemOutputPath), systemBeforeInvalidSemVer);
     const semanticSchemas = {
       componentSchema: JSON.parse(read("contracts/release/component-manifest.schema.json")),
       systemSchema: JSON.parse(read("contracts/release/system-release-manifest.schema.json")),

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -5731,11 +5731,9 @@ test("RC evidence manifest generator는 RC identity와 No-Go blocker를 생성�
     "2026-06-26T00:00:00.000Z",
   ], { cwd: root });
   const metadataOnlyManifest = JSON.parse(readFileSync(metadataOnlyManifestPath, "utf8"));
-  assert.equal(metadataOnlyManifest.backendImageDigest, null);
-  assert.equal(metadataOnlyManifest.backendArtifactSha256, metadataOnlyInspectSha256);
-  assert.ok(
-    !metadataOnlyManifest.readiness.blockers.map((blocker) => blocker.id).includes("missing_backend_identity"),
-  );
+  assert.equal(metadataOnlyManifest.releaseCandidateIdentity.backendImageDigest, null);
+  assert.equal(metadataOnlyManifest.releaseCandidateIdentity.backendArtifactSha256, metadataOnlyInspectSha256);
+  assert.equal(Object.hasOwn(metadataOnlyManifest, "readiness"), false);
 
   await assert.rejects(
     runFinalGenerator([

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -20,6 +20,7 @@ import {
 } from "../release/generate-route-integration-verdict.mjs";
 import { codepointCompare } from "../lib/codepoint-compare.mjs";
 import { validateLineage } from "../datapack/source-snapshot-policy.mjs";
+import { selectSystemReleaseDecision } from "../release/validate-system-release-manifest.mjs";
 
 const root = process.cwd();
 const execFileAsync = promisify(execFile);
@@ -42,6 +43,57 @@ async function initializeFixtureGitRepo(repoPath) {
     "commit", "-q", "-m", "fixture",
   ], { cwd: repoPath });
   return execFileSync("git", ["rev-parse", "HEAD"], { cwd: repoPath, encoding: "utf8" }).trim();
+}
+
+async function writeFinalSystemReleaseArgs(candidatePath, finalOutputPath) {
+  const candidate = JSON.parse(await readFile(candidatePath, "utf8"));
+  const identity = candidate.releaseCandidateIdentity;
+  const fallbackDigest = `sha256:${"a".repeat(64)}`;
+  const fallbackHash = "b".repeat(64);
+  const value = (field, fallback) => identity[field] ?? fallback;
+  const componentPaths = Object.fromEntries(["mobile", "backend", "data", "platform"].map(
+    (component) => [component, `${finalOutputPath}.${component}-component.json`],
+  ));
+  const common = {
+    schemaVersion: 1, repository: "AquilaXk/easysubway", gitSha: currentGitSha,
+    contractVersion: "1.0.0", evidenceSha256: fallbackHash,
+  };
+  const components = {
+    mobile: {
+      ...common, component: "mobile", issueRefs: ["AquilaXk/easysubway#2693"],
+      artifactIdentity: {
+        versionName: value("appVersionName", "1.0.0"), versionCode: Number(value("versionCode", 1)),
+        aabSha256: value("aabSha256", fallbackHash), bundledDataManifestSha256: value("dataPackManifestSha256", fallbackHash),
+      },
+    },
+    backend: {
+      ...common, component: "backend", issueRefs: ["AquilaXk/easysubway#2693"],
+      artifactIdentity: { imageDigest: value("backendImageDigest", fallbackDigest), apiContractVersion: "1.0.0" },
+    },
+    data: {
+      ...common, component: "data", issueRefs: ["AquilaXk/easysubway#2693"],
+      artifactIdentity: {
+        dataVersion: "1.0.0", releaseSequence: Number(value("releaseSequence", 0)),
+        manifestSha256: value("dataPackManifestSha256", fallbackHash), sourceSnapshotSetHash: value("sourceSnapshotSetHash", fallbackHash),
+      },
+    },
+    platform: {
+      ...common, component: "platform", issueRefs: ["AquilaXk/easysubway#2693"],
+      artifactIdentity: { environment: "ci", deployedImageDigest: value("backendImageDigest", fallbackDigest), deploymentEvidenceSha256: fallbackHash },
+    },
+  };
+  for (const [component, document] of Object.entries(components)) await writeFile(componentPaths[component], JSON.stringify(document));
+  const contractsPath = `${finalOutputPath}.contracts-identity.json`;
+  await writeFile(contractsPath, JSON.stringify({ version: "1.0.0", sha256: fallbackHash }));
+  return [
+    "--mobile-component-manifest", componentPaths.mobile,
+    "--backend-component-manifest", componentPaths.backend,
+    "--data-component-manifest", componentPaths.data,
+    "--platform-component-manifest", componentPaths.platform,
+    "--contracts-identity", contractsPath,
+    "--system-release-output", `${finalOutputPath}.system-release.json`,
+    "--product-release-id", "easysubway-test-2693",
+  ];
 }
 
 function mobileProductionDartFiles() {
@@ -3801,6 +3853,14 @@ test("모바일 signed release artifact gate와 광고 counter는 CI 산출물�
       "tools/ci/validate-store-privacy-env.mjs",
       "18bb0dd8b93d6268c8f60f9cc12272d2ff31c03b60fbbafd6c1e8d16957ada2a",
     ],
+    [
+      "apps/mobile/release/rc-evidence-manifest-contract.json",
+      "7caaa17fc34e13e5e35076be4b4f35456f4fa57add102561e31267934bd6cd41",
+    ],
+    [
+      "tools/release/generate-rc-evidence-manifest.mjs",
+      "18becb8c1ae390c89cbf303c2e4f2ee83ba3c00d6290f7ea42869fef90c212cf",
+    ],
   ]);
   for (const binding of refreshBindings) {
     assert.ok(binding.files.length > 0, `${binding.refreshOn} must bind at least one file`);
@@ -3808,7 +3868,7 @@ test("모바일 signed release artifact gate와 광고 counter는 CI 산출물�
       const liveSha256 = createHash("sha256").update(read(file.path)).digest("hex");
       const supersededSha256 = supersededFinalRcBindings.get(file.path);
       if (supersededSha256 != null) {
-        // #2068과 #2655가 고정 RC 입력을 변경해 기존 evidence를 중단(superseded)했다.
+        // #2068, #2655, #2693이 고정 RC 입력을 변경해 기존 evidence를 중단(superseded)했다.
         // 마지막 RC 기록값은 보존하고 live hash 불일치로 재사용 불가를 증명한다.
         // #1016(final RC) 재개 시 전체 identity와 함께 재바인딩한다.
         assert.equal(
@@ -5202,8 +5262,9 @@ test("RC evidence manifest generator는 RC identity와 No-Go blocker를 생성�
     await execFileAsync(process.execPath, [
       ...withoutOutput, "--phase", "CANDIDATE", "--output", candidateOutput,
     ], options);
+    const systemReleaseArgs = await writeFinalSystemReleaseArgs(candidateOutput, finalOutput);
     return execFileAsync(process.execPath, [
-      ...withoutOutput, "--phase", "FINAL", "--candidate-context", candidateOutput, "--output", finalOutput,
+      ...withoutOutput, ...systemReleaseArgs, "--phase", "FINAL", "--candidate-context", candidateOutput, "--output", finalOutput,
     ], options);
   };
   const appVersion = read("apps/mobile/pubspec.yaml").match(/^version:\s*([^+\s]+)\+([0-9]+)\s*$/m);
@@ -5226,7 +5287,7 @@ test("RC evidence manifest generator는 RC identity와 No-Go blocker를 생성�
   }));
   await writeFile(
     backendInspectPath,
-    JSON.stringify([{ RepoDigests: ["ghcr.io/aquilaxk/easysubway-backend@sha256:abcdef"] }]),
+    JSON.stringify([{ RepoDigests: [`ghcr.io/aquilaxk/easysubway-backend@sha256:${"a".repeat(64)}`] }]),
   );
 
   await runFinalGenerator([
@@ -5273,7 +5334,7 @@ test("RC evidence manifest generator는 RC identity와 No-Go blocker를 생성�
   assert.ok(
     manifest.readiness.blockers.some((blocker) => blocker.id === "mismatch_android_release_metadata_aabPayloadSha256"),
   );
-  assert.equal(manifest.backendImageDigest, "sha256:abcdef");
+  assert.equal(manifest.backendImageDigest, `sha256:${"a".repeat(64)}`);
   assert.equal(manifest.backendArtifactSha256, null);
   assert.match(manifest.dataPackManifestSha256, /^[a-f0-9]{64}$/);
   assert.equal(manifest.routeContractVersion, "route-map-contract-v1");
@@ -5747,6 +5808,31 @@ test("[system-release-generator] FINAL은 component manifest에서 검증된 sys
     assert.deepEqual(system.platform.artifactIdentity, components.platform.artifactIdentity);
     assert.equal(Object.hasOwn(legacy, "mobile"), false);
     await execFileAsync(process.execPath, ["tools/release/validate-system-release-manifest.mjs", "--manifest", systemOutputPath], { cwd: root });
+    const semanticSchemas = {
+      componentSchema: JSON.parse(read("contracts/release/component-manifest.schema.json")),
+      systemSchema: JSON.parse(read("contracts/release/system-release-manifest.schema.json")),
+      issueRefSchema: JSON.parse(read("contracts/release/issue-ref.schema.json")),
+    };
+    const canonicalGoCandidate = structuredClone(system);
+    for (const component of ["mobile", "backend", "data", "platform"]) {
+      canonicalGoCandidate[component].repository = `AquilaXk/easysubway-${component}`;
+    }
+    canonicalGoCandidate.platform.artifactIdentity.environment = "production";
+    canonicalGoCandidate.data.artifactIdentity.releaseSequence = Math.max(1, canonicalGoCandidate.data.artifactIdentity.releaseSequence);
+    assert.equal(
+      selectSystemReleaseDecision({ legacyDecision: "GO", manifest: canonicalGoCandidate, ...semanticSchemas }),
+      "GO",
+    );
+    const ciSemanticFailure = structuredClone(canonicalGoCandidate);
+    ciSemanticFailure.platform.artifactIdentity.environment = "ci";
+    assert.equal(
+      selectSystemReleaseDecision({ legacyDecision: "GO", manifest: ciSemanticFailure, ...semanticSchemas }),
+      "NO_GO",
+    );
+    assert.equal(
+      selectSystemReleaseDecision({ legacyDecision: "NO_GO", manifest: canonicalGoCandidate, ...semanticSchemas }),
+      "NO_GO",
+    );
 
     await assert.rejects(
       execFileAsync(process.execPath, [...systemArgs({ mobilePath: path.join(tempDir, "missing-mobile.json") }), "--phase", "FINAL", "--candidate-context", candidatePath], { cwd: root }),
@@ -6035,7 +6121,7 @@ if (!existsSync(value("--summary")) || !process.argv.includes("--require-pass"))
   await assert.rejects(execFileAsync(process.execPath, [...args, "--phase", "FINAL",
     "--candidate-context", invalidCandidatePath, "--output", path.join(tempDir, "invalid-final.json")], generatorOptions),
   /without readiness or decision fields/);
-  args.push("--phase", "FINAL", "--candidate-context", baselineOutput);
+  args.push(...await writeFinalSystemReleaseArgs(baselineOutput, path.join(tempDir, "final-readiness.json")), "--phase", "FINAL", "--candidate-context", baselineOutput);
   for (const invalidCount of ["1abc", "1.5", "-0.5"]) {
     await assert.rejects(execFileAsync(process.execPath, [
       ...args, "--open-android-p0-count", invalidCount,
@@ -6467,8 +6553,9 @@ test("datapack readiness producer는 unknown·mixed identity·expired evidence�
     await execFileAsync(process.execPath, [
       ...withoutOutput, "--phase", "CANDIDATE", "--output", candidateOutput,
     ], options);
+    const systemReleaseArgs = await writeFinalSystemReleaseArgs(candidateOutput, finalOutput);
     return execFileAsync(process.execPath, [
-      ...withoutOutput, "--phase", "FINAL", "--candidate-context", candidateOutput, "--output", finalOutput,
+      ...withoutOutput, ...systemReleaseArgs, "--phase", "FINAL", "--candidate-context", candidateOutput, "--output", finalOutput,
     ], options);
   };
   const rejects = (extraArgs, expected) => assert.rejects(

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -3397,6 +3397,32 @@ test("릴리즈 산출물 워크플로우는 모바일 스토어 산출물과 ba
   assert.match(workflow, /name: easysubway-backend-release-\$\{\{ github\.sha \}\}/);
 });
 
+test("[release-v2] RC evidence contract uses repository-qualified issue references", () => {
+  const contract = readJson("apps/mobile/release/rc-evidence-manifest-contract.json");
+  const issueRefSchema = readJson("contracts/release/issue-ref.schema.json");
+  const issueRefPattern = new RegExp(issueRefSchema.pattern);
+  const issueRefs = [
+    contract.issueRef,
+    ...contract.parentIssueRefs,
+    ...contract.linkedEvidenceIssueRefs,
+    ...Object.values(contract.phaseConsumers).flat(),
+    ...contract.requiredFinalFragmentIssueRefs,
+    ...contract.activeBlockerIssueRefs,
+    ...contract.requiredEvidenceEntries.map(({ issueRef }) => issueRef),
+    ...contract.requiredDatapackGates.map(({ issueRef }) => issueRef),
+  ];
+
+  assert.equal(contract.schemaVersion, 2);
+  assert.equal(Object.hasOwn(contract, "issue"), false);
+  assert.equal(Object.hasOwn(contract, "parentIssues"), false);
+  assert.equal(Object.hasOwn(contract, "linkedEvidenceIssues"), false);
+  assert.equal(Object.hasOwn(contract, "requiredFinalFragmentIssues"), false);
+  assert.equal(Object.hasOwn(contract, "activeBlockerIssues"), false);
+  assert.ok(contract.requiredEvidenceEntryFields.includes("issueRef"));
+  assert.ok(!contract.requiredEvidenceEntryFields.includes("sourceIssue"));
+  assert.ok(issueRefs.every((issueRef) => issueRefPattern.test(issueRef)));
+});
+
 test("모바일 signed release artifact gate와 광고 counter는 CI 산출물과 스토어 제출 준비 상태를 분리한다", () => {
   const gatePath = "apps/mobile/release/signed-release-artifact-gate.json";
 
@@ -4514,18 +4540,18 @@ test("모바일 signed release artifact gate와 광고 counter는 CI 산출물�
   assert.ok(androidRcEvidence.requiredEvidence.postReleaseReadiness.includes("retention-duplicate-override-recovery-policy"));
   assert.ok(androidRcEvidence.evidencePolicy.localOnlyEvidenceRoot.startsWith(".codex/evidence/"));
   assert.equal(rcEvidenceManifestContract.releaseGate, "rc-evidence-manifest");
-  assert.equal(rcEvidenceManifestContract.issue, 1020);
-  assert.deepEqual(rcEvidenceManifestContract.parentIssues, [1014, 1020]);
+  assert.equal(rcEvidenceManifestContract.issueRef, "AquilaXk/easysubway#1020");
+  assert.deepEqual(rcEvidenceManifestContract.parentIssueRefs, ["AquilaXk/easysubway#1014", "AquilaXk/easysubway#1020"]);
   assert.deepEqual(
-    rcEvidenceManifestContract.linkedEvidenceIssues,
-    [547, 571, 1015, 1016, 1017, 1018, 1019, 1021, 1022, 1393, 1914, 2051, 2054, 2055, 2056, 2057, 2058, 2133],
+    rcEvidenceManifestContract.linkedEvidenceIssueRefs,
+    [547, 571, 1015, 1016, 1017, 1018, 1019, 1021, 1022, 1393, 1914, 2051, 2054, 2055, 2056, 2057, 2058, 2133].map((issue) => `AquilaXk/easysubway#${issue}`),
   );
   assert.deepEqual(rcEvidenceManifestContract.phaseConsumers, {
-    CANDIDATE: [2058, 1393],
-    FINAL: [1020],
+    CANDIDATE: ["AquilaXk/easysubway#2058", "AquilaXk/easysubway#1393"],
+    FINAL: ["AquilaXk/easysubway#1020"],
   });
-  assert.deepEqual(rcEvidenceManifestContract.requiredFinalFragmentIssues, [2058, 1393]);
-  assert.deepEqual(rcEvidenceManifestContract.activeBlockerIssues, []);
+  assert.deepEqual(rcEvidenceManifestContract.requiredFinalFragmentIssueRefs, ["AquilaXk/easysubway#2058", "AquilaXk/easysubway#1393"]);
+  assert.deepEqual(rcEvidenceManifestContract.activeBlockerIssueRefs, []);
   assert.equal(rcEvidenceManifestContract.androidRcEvidenceManifest, androidRcEvidencePath);
   assert.equal(rcEvidenceManifestContract.signedReleaseArtifactGate, gatePath);
   assert.equal(rcEvidenceManifestContract.releaseGovernanceGate, "apps/mobile/release/release-governance-gate.json");
@@ -4550,24 +4576,24 @@ test("모바일 signed release artifact gate와 광고 counter는 CI 산출물�
     assert.ok(rcEvidenceManifestContract.requiredRcIdentityFields.includes(field), `${field} must be required`);
   }
   assert.deepEqual(rcEvidenceManifestContract.backendIdentityFieldsAnyOf, ["backendImageDigest", "backendArtifactSha256"]);
-  for (const field of ["device", "androidVersion", "testedAt", "evidencePaths", "expiresWhen"]) {
+  for (const field of ["issueRef", "device", "androidVersion", "testedAt", "evidencePaths", "expiresWhen"]) {
     assert.ok(rcEvidenceManifestContract.requiredEvidenceEntryFields.includes(field), `${field} must be required`);
   }
   assert.deepEqual(
-    rcEvidenceManifestContract.requiredEvidenceEntries.map(({ id, sourceIssue }) => ({ id, sourceIssue })),
+    rcEvidenceManifestContract.requiredEvidenceEntries.map(({ id, issueRef }) => ({ id, issueRef })),
     [
-      { id: "rc_device_qa", sourceIssue: 571 },
-      { id: "production_datapack", sourceIssue: 547 },
-      { id: "signed_rc_store_submission", sourceIssue: 1015 },
-      { id: "play_generated_install", sourceIssue: 1016 },
-      { id: "store_privacy_submission", sourceIssue: 1018 },
-      { id: "backend_operations", sourceIssue: 1017 },
-      { id: "post_launch_operations", sourceIssue: 1019 },
-      { id: "android_release_quality", sourceIssue: 1021 },
-      { id: "abuse_penetration_rehearsal", sourceIssue: 1022 },
-      { id: "container_hardening", sourceIssue: 1914 },
-      { id: "production_equivalent_rehearsal", sourceIssue: 2058 },
-      { id: "production_artifact_android_integration", sourceIssue: 1393 },
+      { id: "rc_device_qa", issueRef: "AquilaXk/easysubway#571" },
+      { id: "production_datapack", issueRef: "AquilaXk/easysubway#547" },
+      { id: "signed_rc_store_submission", issueRef: "AquilaXk/easysubway#1015" },
+      { id: "play_generated_install", issueRef: "AquilaXk/easysubway#1016" },
+      { id: "store_privacy_submission", issueRef: "AquilaXk/easysubway#1018" },
+      { id: "backend_operations", issueRef: "AquilaXk/easysubway#1017" },
+      { id: "post_launch_operations", issueRef: "AquilaXk/easysubway#1019" },
+      { id: "android_release_quality", issueRef: "AquilaXk/easysubway#1021" },
+      { id: "abuse_penetration_rehearsal", issueRef: "AquilaXk/easysubway#1022" },
+      { id: "container_hardening", issueRef: "AquilaXk/easysubway#1914" },
+      { id: "production_equivalent_rehearsal", issueRef: "AquilaXk/easysubway#2058" },
+      { id: "production_artifact_android_integration", issueRef: "AquilaXk/easysubway#1393" },
     ],
   );
   assert.equal(rcEvidenceManifestContract.readinessPolicy.openAndroidP0BlocksGo, true);
@@ -5615,7 +5641,12 @@ test("datapack readiness producer는 required gate를 동일 final identity로 �
     { id: "freshness_conditional_publish", sourceIssue: 2054, expiresAfterDays: 14 }, { id: "rollback_rescue", sourceIssue: 2051, expiresAfterDays: 14 },
     { id: "device_performance", sourceIssue: 2055, expiresAfterDays: 14 }, { id: "callback_reconciliation", sourceIssue: 2057, expiresAfterDays: 14 },
   ];
-  assert.deepEqual(contract.requiredDatapackGates, requiredDatapackGates);
+  assert.deepEqual(
+    contract.requiredDatapackGates,
+    requiredDatapackGates.map(({ id, sourceIssue, expiresAfterDays }) => ({
+      id, issueRef: `AquilaXk/easysubway#${sourceIssue}`, expiresAfterDays,
+    })),
+  );
   const producerFiles = execFileSync("git", ["grep", "-l", "summaryArtifactDigest", "--", "tools", "apps", ".github"],
     { cwd: root, encoding: "utf8" }).trim().split("\n").filter((file) => !file.includes(".test."));
   assert.deepEqual(producerFiles, ["tools/release/generate-rc-evidence-manifest.mjs"]);
@@ -6000,7 +6031,7 @@ if (!existsSync(value("--summary")) || !process.argv.includes("--require-pass"))
     const evidencePath = path.join(tempDir, `required-evidence-${entry.id}.json`);
     if (entry.id === "post_launch_operations") postLaunchEvidencePath = evidencePath;
     const evidence = {
-      schemaVersion: 1, evidenceId: entry.id, sourceIssue: entry.sourceIssue,
+      schemaVersion: 1, evidenceId: entry.id, sourceIssue: Number(entry.issueRef.slice(entry.issueRef.indexOf("#") + 1)),
       status: "SATISFIED", reasonCodes: [], rcIdentity: evidenceRcIdentity,
       evidenceValidity: { testedAt: now, expiresWhen: "2026-07-30T00:00:00.000Z" },
     };
@@ -6460,7 +6491,7 @@ test("datapack readiness producer는 unknown·mixed identity·expired evidence�
 
   const missingFinalFragmentArgs = await contractArgs("missing-final-fragment-app", (contract) => {
     contract.requiredEvidenceEntries = contract.requiredEvidenceEntries.filter(
-    ({ sourceIssue }) => sourceIssue !== 2058,
+    ({ issueRef }) => issueRef !== "AquilaXk/easysubway#2058",
     );
   });
   await assert.rejects(
@@ -6486,7 +6517,7 @@ test("datapack readiness producer는 unknown·mixed identity·expired evidence�
   );
 
   const closedBlockerArgs = await contractArgs("closed-blocker-app", (contract) => {
-    contract.activeBlockerIssues = [2133];
+    contract.activeBlockerIssueRefs = ["AquilaXk/easysubway#2133"];
   });
   await runFinalGenerator([
     ...closedBlockerArgs,

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -6053,10 +6053,13 @@ test("datapack readiness producer는 required gate를 동일 final identity로 �
 
   const tempDir = await mkdtemp(path.join(tmpdir(), "easysubway-datapack-readiness-"));
   const validationRepo = path.join(tempDir, "validation-repo");
-  for (const directory of ["apps/mobile/release", "tools/release", "tools/ops", "tools/security"]) {
+  for (const directory of ["apps/mobile/release", "contracts/release", "tools/release", "tools/ops", "tools/security"]) {
     await mkdir(path.join(validationRepo, directory), { recursive: true });
   }
   await symlink(path.join(root, "apps/mobile/release/production-datapack-scope.json"), path.join(validationRepo, "apps/mobile/release/production-datapack-scope.json"));
+  for (const schema of ["component-manifest.schema.json", "system-release-manifest.schema.json", "issue-ref.schema.json"]) {
+    await symlink(path.join(root, "contracts/release", schema), path.join(validationRepo, "contracts/release", schema));
+  }
   await symlink(path.join(root, "tools/release/hash-android-bundle-payload.mjs"), path.join(validationRepo, "tools/release/hash-android-bundle-payload.mjs"));
   await symlink(path.join(root, "tools/release/count-gzip-uncompressed-bytes.mjs"), path.join(validationRepo, "tools/release/count-gzip-uncompressed-bytes.mjs"));
   await writeFile(path.join(validationRepo, "tools/ops/validate-operations-release-summary.mjs"), `import { readFileSync } from "node:fs";

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { execFile, execFileSync } from "node:child_process";
 import { createHash, generateKeyPairSync, sign as signBytes } from "node:crypto";
-import { lstat as fsLstat, mkdir, mkdtemp, readFile, readdir, rm, symlink, utimes, writeFile } from "node:fs/promises";
+import { link, lstat as fsLstat, mkdir, mkdtemp, readFile, readdir, rm, symlink, utimes, writeFile } from "node:fs/promises";
 import { existsSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -5953,6 +5953,55 @@ test("[system-release-generator] FINAL은 component manifest에서 검증된 sys
       selectSystemReleaseDecision({ legacyDecision: "NO_GO", manifest: canonicalGoCandidate, ...semanticSchemas }),
       "NO_GO",
     );
+
+    const candidateSymlinkTarget = path.join(tempDir, "candidate-symlink-target.json");
+    const candidateSymlinkOutput = path.join(tempDir, "candidate-symlink-output.json");
+    await writeFile(candidateSymlinkTarget, "candidate sentinel");
+    await symlink(candidateSymlinkTarget, candidateSymlinkOutput);
+    const symlinkCandidateArgs = [...candidateArgs];
+    symlinkCandidateArgs[symlinkCandidateArgs.indexOf("--output") + 1] = candidateSymlinkOutput;
+    await assert.rejects(
+      execFileAsync(process.execPath, [...symlinkCandidateArgs, "--phase", "CANDIDATE"], { cwd: root }),
+      /--output must not be a symlink/,
+    );
+    assert.equal(await readFile(candidateSymlinkTarget, "utf8"), "candidate sentinel");
+
+    const symlinkLegacyTarget = path.join(tempDir, "symlink-legacy-target.json");
+    const symlinkLegacyOutput = path.join(tempDir, "symlink-legacy-output.json");
+    const symlinkSystemOutput = path.join(tempDir, "symlink-system-output.json");
+    await writeFile(symlinkLegacyTarget, "legacy sentinel");
+    await symlink(symlinkLegacyTarget, symlinkLegacyOutput);
+    await writeFile(symlinkSystemOutput, "system sentinel");
+    await assert.rejects(
+      execFileAsync(process.execPath, [...systemArgs({ outputPath: symlinkLegacyOutput, systemOutputPath: symlinkSystemOutput }), "--phase", "FINAL", "--candidate-context", candidatePath], { cwd: root }),
+      /--output must not be a symlink/,
+    );
+    assert.equal(await readFile(symlinkLegacyTarget, "utf8"), "legacy sentinel");
+    assert.equal(await readFile(symlinkSystemOutput, "utf8"), "system sentinel");
+
+    const regularLegacyOutput = path.join(tempDir, "regular-legacy-output.json");
+    const symlinkSystemTarget = path.join(tempDir, "symlink-system-target.json");
+    const symlinkSystemAlias = path.join(tempDir, "symlink-system-alias.json");
+    await writeFile(regularLegacyOutput, "legacy sentinel");
+    await writeFile(symlinkSystemTarget, "system sentinel");
+    await symlink(symlinkSystemTarget, symlinkSystemAlias);
+    await assert.rejects(
+      execFileAsync(process.execPath, [...systemArgs({ outputPath: regularLegacyOutput, systemOutputPath: symlinkSystemAlias }), "--phase", "FINAL", "--candidate-context", candidatePath], { cwd: root }),
+      /--system-release-output must not be a symlink/,
+    );
+    assert.equal(await readFile(regularLegacyOutput, "utf8"), "legacy sentinel");
+    assert.equal(await readFile(symlinkSystemTarget, "utf8"), "system sentinel");
+
+    const hardlinkLegacyOutput = path.join(tempDir, "hardlink-legacy-output.json");
+    const hardlinkSystemOutput = path.join(tempDir, "hardlink-system-output.json");
+    await writeFile(hardlinkLegacyOutput, "hardlink sentinel");
+    await link(hardlinkLegacyOutput, hardlinkSystemOutput);
+    await assert.rejects(
+      execFileAsync(process.execPath, [...systemArgs({ outputPath: hardlinkLegacyOutput, systemOutputPath: hardlinkSystemOutput }), "--phase", "FINAL", "--candidate-context", candidatePath], { cwd: root }),
+      /--system-release-output must not alias --output/,
+    );
+    assert.equal(await readFile(hardlinkLegacyOutput, "utf8"), "hardlink sentinel");
+    assert.equal(await readFile(hardlinkSystemOutput, "utf8"), "hardlink sentinel");
 
     await assert.rejects(
       execFileAsync(process.execPath, [...systemArgs({ mobilePath: path.join(tempDir, "missing-mobile.json") }), "--phase", "FINAL", "--candidate-context", candidatePath], { cwd: root }),

--- a/tools/release/build-monorepo-component-manifests.mjs
+++ b/tools/release/build-monorepo-component-manifests.mjs
@@ -3,6 +3,7 @@
 import { createHash } from "node:crypto";
 import { existsSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { validateSchema } from "../ci/lib/json-schema-lite.mjs";
 
 const outputFiles = [
@@ -183,7 +184,8 @@ function main() {
   };
   let componentSchema;
   try {
-    componentSchema = JSON.parse(readFileSync(path.resolve("contracts/release/component-manifest.schema.json"), "utf8"));
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    componentSchema = JSON.parse(readFileSync(path.join(here, "../../contracts/release/component-manifest.schema.json"), "utf8"));
   } catch {
     fail("component manifest schema is unavailable");
   }

--- a/tools/release/build-monorepo-component-manifests.mjs
+++ b/tools/release/build-monorepo-component-manifests.mjs
@@ -72,17 +72,22 @@ function imageDigest(inspectPath) {
   fail("backend image inspect lacks an immutable digest");
 }
 
-function sourceSnapshotSetHash(evidencePath) {
+function sourceSnapshotEvidence(evidencePath) {
+  let evidenceBytes;
   let evidence;
   try {
-    evidence = JSON.parse(readFileSync(evidencePath, "utf8"));
+    evidenceBytes = readFileSync(evidencePath);
+    evidence = JSON.parse(evidenceBytes.toString("utf8"));
   } catch {
     fail("source snapshot evidence is unreadable or invalid JSON");
   }
   if (!evidence || typeof evidence !== "object" || Array.isArray(evidence) || !/^[a-f0-9]{64}$/.test(evidence.sourceSnapshotSetHash)) {
     fail("source snapshot evidence has an invalid sourceSnapshotSetHash");
   }
-  return evidence.sourceSnapshotSetHash;
+  return {
+    evidenceSha256: createHash("sha256").update(evidenceBytes).digest("hex"),
+    sourceSnapshotSetHash: evidence.sourceSnapshotSetHash,
+  };
 }
 
 function validateComponent(component, schema) {
@@ -121,8 +126,7 @@ function main() {
   const dataManifestSha256 = sha256File(args["--data-manifest"], "data manifest");
   if (bundledDataManifestSha256 !== dataManifestSha256) fail("bundled data manifest hash mismatch");
   const backendEvidenceSha256 = sha256File(args["--backend-evidence"], "backend evidence");
-  const sourceEvidenceSha256 = sha256File(args["--source-snapshot-evidence"], "source snapshot evidence");
-  const declaredSourceSnapshotSetHash = sourceSnapshotSetHash(args["--source-snapshot-evidence"]);
+  const sourceEvidence = sourceSnapshotEvidence(args["--source-snapshot-evidence"]);
   const platformEvidenceSha256 = sha256File(args["--platform-evidence"], "platform evidence");
   const contractsSha256 = sha256File(args["--contracts-bundle"], "contracts bundle");
   const digest = imageDigest(args["--backend-image-inspect"]);
@@ -139,8 +143,8 @@ function main() {
   };
   const data = {
     ...common, component: "data",
-    artifactIdentity: { dataVersion: args["--data-version"], releaseSequence, manifestSha256: dataManifestSha256, sourceSnapshotSetHash: declaredSourceSnapshotSetHash },
-    evidenceSha256: sourceEvidenceSha256,
+    artifactIdentity: { dataVersion: args["--data-version"], releaseSequence, manifestSha256: dataManifestSha256, sourceSnapshotSetHash: sourceEvidence.sourceSnapshotSetHash },
+    evidenceSha256: sourceEvidence.evidenceSha256,
   };
   const platform = {
     ...common, component: "platform",

--- a/tools/release/build-monorepo-component-manifests.mjs
+++ b/tools/release/build-monorepo-component-manifests.mjs
@@ -72,6 +72,19 @@ function imageDigest(inspectPath) {
   fail("backend image inspect lacks an immutable digest");
 }
 
+function sourceSnapshotSetHash(evidencePath) {
+  let evidence;
+  try {
+    evidence = JSON.parse(readFileSync(evidencePath, "utf8"));
+  } catch {
+    fail("source snapshot evidence is unreadable or invalid JSON");
+  }
+  if (!evidence || typeof evidence !== "object" || Array.isArray(evidence) || !/^[a-f0-9]{64}$/.test(evidence.sourceSnapshotSetHash)) {
+    fail("source snapshot evidence has an invalid sourceSnapshotSetHash");
+  }
+  return evidence.sourceSnapshotSetHash;
+}
+
 function validateComponent(component, schema) {
   const errors = validateSchema(schema, component).errors;
   if (errors.length > 0) fail(`component manifest validation failed: ${errors.join(", ")}`);
@@ -109,6 +122,7 @@ function main() {
   if (bundledDataManifestSha256 !== dataManifestSha256) fail("bundled data manifest hash mismatch");
   const backendEvidenceSha256 = sha256File(args["--backend-evidence"], "backend evidence");
   const sourceEvidenceSha256 = sha256File(args["--source-snapshot-evidence"], "source snapshot evidence");
+  const declaredSourceSnapshotSetHash = sourceSnapshotSetHash(args["--source-snapshot-evidence"]);
   const platformEvidenceSha256 = sha256File(args["--platform-evidence"], "platform evidence");
   const contractsSha256 = sha256File(args["--contracts-bundle"], "contracts bundle");
   const digest = imageDigest(args["--backend-image-inspect"]);
@@ -125,7 +139,7 @@ function main() {
   };
   const data = {
     ...common, component: "data",
-    artifactIdentity: { dataVersion: args["--data-version"], releaseSequence, manifestSha256: dataManifestSha256, sourceSnapshotSetHash: sourceEvidenceSha256 },
+    artifactIdentity: { dataVersion: args["--data-version"], releaseSequence, manifestSha256: dataManifestSha256, sourceSnapshotSetHash: declaredSourceSnapshotSetHash },
     evidenceSha256: sourceEvidenceSha256,
   };
   const platform = {

--- a/tools/release/build-monorepo-component-manifests.mjs
+++ b/tools/release/build-monorepo-component-manifests.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { validateSchema } from "../ci/lib/json-schema-lite.mjs";
 
@@ -81,17 +81,12 @@ function writeOutput(outputDir, documents) {
   const parent = path.dirname(outputDir);
   if (!existsSync(parent)) fail("output parent directory does not exist");
   const temporary = mkdtempSync(path.join(parent, `.${path.basename(outputDir)}.tmp-`));
-  let claimedOutput = false;
   try {
     for (const [name, document] of documents) writeFileSync(path.join(temporary, name), `${JSON.stringify(document, null, 2)}\n`);
     if (outputFiles.some((name) => !existsSync(path.join(temporary, name)))) fail("output write failed");
-    mkdirSync(outputDir);
-    claimedOutput = true;
-    for (const name of outputFiles) renameSync(path.join(temporary, name), path.join(outputDir, name));
-    rmSync(temporary, { recursive: true, force: true });
+    symlinkSync(path.basename(temporary), outputDir, "dir");
   } catch (error) {
     rmSync(temporary, { recursive: true, force: true });
-    if (claimedOutput) rmSync(outputDir, { recursive: true, force: true });
     throw error;
   }
 }

--- a/tools/release/build-monorepo-component-manifests.mjs
+++ b/tools/release/build-monorepo-component-manifests.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { validateSchema } from "../ci/lib/json-schema-lite.mjs";
+
+const outputFiles = [
+  "mobile-component-manifest.json",
+  "backend-component-manifest.json",
+  "data-component-manifest.json",
+  "platform-component-manifest.json",
+  "contracts-identity.json",
+];
+const issueRefPattern = /^AquilaXk\/(easysubway|easysubway-data|easysubway-platform|easysubway-backend|easysubway-mobile)#[1-9][0-9]*$/;
+const semverPattern = /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function parseArgs(args) {
+  if (args.length % 2 !== 0) fail("arguments must be option/value pairs");
+  const values = {};
+  for (let index = 0; index < args.length; index += 2) {
+    const [option, value] = [args[index], args[index + 1]];
+    if (!option.startsWith("--") || !value || Object.hasOwn(values, option)) fail("invalid arguments");
+    values[option] = value;
+  }
+  const required = [
+    "--repository", "--git-sha", "--mobile-version-name", "--mobile-version-code", "--aab", "--bundled-data-manifest",
+    "--backend-image-inspect", "--backend-evidence", "--data-version", "--data-release-sequence", "--data-manifest",
+    "--source-snapshot-evidence", "--platform-environment", "--platform-evidence", "--contracts-version", "--contracts-bundle",
+    "--issue-ref", "--output-dir",
+  ];
+  if (Object.keys(values).length !== required.length || required.some((option) => !Object.hasOwn(values, option))) fail("invalid arguments");
+  return values;
+}
+
+function sha256File(file, label) {
+  try {
+    return createHash("sha256").update(readFileSync(file)).digest("hex");
+  } catch {
+    fail(`${label} is unreadable`);
+  }
+}
+
+function parseInteger(value, name, minimum) {
+  if (!/^(0|[1-9][0-9]*)$/.test(value)) fail(`${name} must be an integer`);
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < minimum) fail(`${name} is out of range`);
+  return parsed;
+}
+
+function imageDigest(inspectPath) {
+  let inspect;
+  try {
+    inspect = JSON.parse(readFileSync(inspectPath, "utf8"));
+  } catch {
+    fail("backend image inspect is unreadable or invalid JSON");
+  }
+  if (Array.isArray(inspect)) {
+    if (inspect.length !== 1) fail("backend image inspect must contain one image");
+    inspect = inspect[0];
+  }
+  if (!inspect || typeof inspect !== "object" || Array.isArray(inspect)) fail("backend image inspect must be an object");
+  const repoDigest = typeof inspect.RepoDigests?.[0] === "string"
+    ? inspect.RepoDigests[0].match(/^.+@(sha256:[a-f0-9]{64})$/)?.[1]
+    : null;
+  if (repoDigest) return repoDigest;
+  if (typeof inspect.Id === "string" && /^sha256:[a-f0-9]{64}$/.test(inspect.Id)) return inspect.Id;
+  fail("backend image inspect lacks an immutable digest");
+}
+
+function validateComponent(component, schema) {
+  const errors = validateSchema(schema, component).errors;
+  if (errors.length > 0) fail(`component manifest validation failed: ${errors.join(", ")}`);
+}
+
+function writeOutput(outputDir, documents) {
+  const parent = path.dirname(outputDir);
+  if (existsSync(outputDir)) fail("output directory already exists");
+  if (!existsSync(parent)) fail("output parent directory does not exist");
+  const temporary = mkdtempSync(path.join(parent, `.${path.basename(outputDir)}.tmp-`));
+  try {
+    for (const [name, document] of documents) writeFileSync(path.join(temporary, name), `${JSON.stringify(document, null, 2)}\n`);
+    if (outputFiles.some((name) => !existsSync(path.join(temporary, name)))) fail("output write failed");
+    renameSync(temporary, outputDir);
+  } catch (error) {
+    rmSync(temporary, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args["--repository"] !== "AquilaXk/easysubway") fail("repository must be AquilaXk/easysubway");
+  if (!/^[a-f0-9]{40}$/.test(args["--git-sha"])) fail("git sha must be 40 lowercase hex characters");
+  if (!args["--mobile-version-name"]) fail("mobile version name is required");
+  if (!args["--data-version"]) fail("data version is required");
+  if (!semverPattern.test(args["--contracts-version"])) fail("contracts version must be SemVer");
+  if (!issueRefPattern.test(args["--issue-ref"])) fail("issue ref is invalid");
+  if (!["ci", "staging", "production"].includes(args["--platform-environment"])) fail("platform environment is invalid");
+
+  const versionCode = parseInteger(args["--mobile-version-code"], "mobile version code", 1);
+  const releaseSequence = parseInteger(args["--data-release-sequence"], "data release sequence", 0);
+  const aabSha256 = sha256File(args["--aab"], "AAB");
+  const bundledDataManifestSha256 = sha256File(args["--bundled-data-manifest"], "bundled data manifest");
+  const dataManifestSha256 = sha256File(args["--data-manifest"], "data manifest");
+  if (bundledDataManifestSha256 !== dataManifestSha256) fail("bundled data manifest hash mismatch");
+  const backendEvidenceSha256 = sha256File(args["--backend-evidence"], "backend evidence");
+  const sourceEvidenceSha256 = sha256File(args["--source-snapshot-evidence"], "source snapshot evidence");
+  const platformEvidenceSha256 = sha256File(args["--platform-evidence"], "platform evidence");
+  const contractsSha256 = sha256File(args["--contracts-bundle"], "contracts bundle");
+  const digest = imageDigest(args["--backend-image-inspect"]);
+  const common = { schemaVersion: 1, repository: args["--repository"], gitSha: args["--git-sha"], contractVersion: args["--contracts-version"], issueRefs: [args["--issue-ref"]] };
+  const mobile = {
+    ...common, component: "mobile",
+    artifactIdentity: { versionName: args["--mobile-version-name"], versionCode, aabSha256, bundledDataManifestSha256 },
+    evidenceSha256: aabSha256,
+  };
+  const backend = {
+    ...common, component: "backend",
+    artifactIdentity: { imageDigest: digest, apiContractVersion: args["--contracts-version"] },
+    evidenceSha256: backendEvidenceSha256,
+  };
+  const data = {
+    ...common, component: "data",
+    artifactIdentity: { dataVersion: args["--data-version"], releaseSequence, manifestSha256: dataManifestSha256, sourceSnapshotSetHash: sourceEvidenceSha256 },
+    evidenceSha256: sourceEvidenceSha256,
+  };
+  const platform = {
+    ...common, component: "platform",
+    artifactIdentity: { environment: args["--platform-environment"], deployedImageDigest: digest, deploymentEvidenceSha256: platformEvidenceSha256 },
+    evidenceSha256: platformEvidenceSha256,
+  };
+  let componentSchema;
+  try {
+    componentSchema = JSON.parse(readFileSync(path.resolve("contracts/release/component-manifest.schema.json"), "utf8"));
+  } catch {
+    fail("component manifest schema is unavailable");
+  }
+  for (const component of [mobile, backend, data, platform]) validateComponent(component, componentSchema);
+  writeOutput(args["--output-dir"], [
+    ["mobile-component-manifest.json", mobile],
+    ["backend-component-manifest.json", backend],
+    ["data-component-manifest.json", data],
+    ["platform-component-manifest.json", platform],
+    ["contracts-identity.json", { version: args["--contracts-version"], sha256: contractsSha256 }],
+  ]);
+}
+
+try {
+  main();
+} catch (error) {
+  process.stderr.write(`build-monorepo-component-manifests: ${error.message}\n`);
+  process.exitCode = 1;
+}

--- a/tools/release/build-monorepo-component-manifests.mjs
+++ b/tools/release/build-monorepo-component-manifests.mjs
@@ -5,6 +5,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSy
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { validateSchema } from "../ci/lib/json-schema-lite.mjs";
+import { isSemVer } from "./lib/semver.mjs";
 
 const outputFiles = [
   "mobile-component-manifest.json",
@@ -17,37 +18,6 @@ const issueRefPattern = /^AquilaXk\/(easysubway|easysubway-data|easysubway-platf
 
 function fail(message) {
   throw new Error(message);
-}
-
-function isDigits(value) {
-  return value.length > 0 && [...value].every((character) => character >= "0" && character <= "9");
-}
-
-function isSemVerIdentifier(value, rejectNumericLeadingZero) {
-  return value.length > 0
-    && [...value].every((character) => (
-      (character >= "0" && character <= "9")
-      || (character >= "A" && character <= "Z")
-      || (character >= "a" && character <= "z")
-      || character === "-"
-    ))
-    && (!rejectNumericLeadingZero || !isDigits(value) || value === "0" || value[0] !== "0");
-}
-
-function isSemVer(value) {
-  if (typeof value !== "string" || value.length === 0 || value.length > 255) return false;
-  const buildParts = value.split("+");
-  if (buildParts.length > 2) return false;
-  const [version, build] = buildParts;
-  if (build !== undefined && !build.split(".").every((identifier) => isSemVerIdentifier(identifier, false))) return false;
-
-  const prereleaseSeparator = version.indexOf("-");
-  const core = prereleaseSeparator === -1 ? version : version.slice(0, prereleaseSeparator);
-  const prerelease = prereleaseSeparator === -1 ? undefined : version.slice(prereleaseSeparator + 1);
-  if (prerelease !== undefined && !prerelease.split(".").every((identifier) => isSemVerIdentifier(identifier, true))) return false;
-  const coreIdentifiers = core.split(".");
-  return coreIdentifiers.length === 3
-    && coreIdentifiers.every((identifier) => isDigits(identifier) && (identifier === "0" || identifier[0] !== "0"));
 }
 
 function parseArgs(args) {

--- a/tools/release/build-monorepo-component-manifests.mjs
+++ b/tools/release/build-monorepo-component-manifests.mjs
@@ -79,15 +79,19 @@ function validateComponent(component, schema) {
 
 function writeOutput(outputDir, documents) {
   const parent = path.dirname(outputDir);
-  if (existsSync(outputDir)) fail("output directory already exists");
   if (!existsSync(parent)) fail("output parent directory does not exist");
   const temporary = mkdtempSync(path.join(parent, `.${path.basename(outputDir)}.tmp-`));
+  let claimedOutput = false;
   try {
     for (const [name, document] of documents) writeFileSync(path.join(temporary, name), `${JSON.stringify(document, null, 2)}\n`);
     if (outputFiles.some((name) => !existsSync(path.join(temporary, name)))) fail("output write failed");
-    renameSync(temporary, outputDir);
+    mkdirSync(outputDir);
+    claimedOutput = true;
+    for (const name of outputFiles) renameSync(path.join(temporary, name), path.join(outputDir, name));
+    rmSync(temporary, { recursive: true, force: true });
   } catch (error) {
     rmSync(temporary, { recursive: true, force: true });
+    if (claimedOutput) rmSync(outputDir, { recursive: true, force: true });
     throw error;
   }
 }

--- a/tools/release/build-monorepo-component-manifests.mjs
+++ b/tools/release/build-monorepo-component-manifests.mjs
@@ -13,10 +13,40 @@ const outputFiles = [
   "contracts-identity.json",
 ];
 const issueRefPattern = /^AquilaXk\/(easysubway|easysubway-data|easysubway-platform|easysubway-backend|easysubway-mobile)#[1-9][0-9]*$/;
-const semverPattern = /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 
 function fail(message) {
   throw new Error(message);
+}
+
+function isDigits(value) {
+  return value.length > 0 && [...value].every((character) => character >= "0" && character <= "9");
+}
+
+function isSemVerIdentifier(value, rejectNumericLeadingZero) {
+  return value.length > 0
+    && [...value].every((character) => (
+      (character >= "0" && character <= "9")
+      || (character >= "A" && character <= "Z")
+      || (character >= "a" && character <= "z")
+      || character === "-"
+    ))
+    && (!rejectNumericLeadingZero || !isDigits(value) || value === "0" || value[0] !== "0");
+}
+
+function isSemVer(value) {
+  if (typeof value !== "string" || value.length === 0 || value.length > 255) return false;
+  const buildParts = value.split("+");
+  if (buildParts.length > 2) return false;
+  const [version, build] = buildParts;
+  if (build !== undefined && !build.split(".").every((identifier) => isSemVerIdentifier(identifier, false))) return false;
+
+  const prereleaseSeparator = version.indexOf("-");
+  const core = prereleaseSeparator === -1 ? version : version.slice(0, prereleaseSeparator);
+  const prerelease = prereleaseSeparator === -1 ? undefined : version.slice(prereleaseSeparator + 1);
+  if (prerelease !== undefined && !prerelease.split(".").every((identifier) => isSemVerIdentifier(identifier, true))) return false;
+  const coreIdentifiers = core.split(".");
+  return coreIdentifiers.length === 3
+    && coreIdentifiers.every((identifier) => isDigits(identifier) && (identifier === "0" || identifier[0] !== "0"));
 }
 
 function parseArgs(args) {
@@ -115,7 +145,7 @@ function main() {
   if (!/^[a-f0-9]{40}$/.test(args["--git-sha"])) fail("git sha must be 40 lowercase hex characters");
   if (!args["--mobile-version-name"]) fail("mobile version name is required");
   if (!args["--data-version"]) fail("data version is required");
-  if (!semverPattern.test(args["--contracts-version"])) fail("contracts version must be SemVer");
+  if (!isSemVer(args["--contracts-version"])) fail("contracts version must be SemVer");
   if (!issueRefPattern.test(args["--issue-ref"])) fail("issue ref is invalid");
   if (!["ci", "staging", "production"].includes(args["--platform-environment"])) fail("platform environment is invalid");
 

--- a/tools/release/build-monorepo-component-manifests.test.mjs
+++ b/tools/release/build-monorepo-component-manifests.test.mjs
@@ -170,6 +170,9 @@ test("preserves an existing output directory and rejects required CLI boundaries
     assert.notEqual(run(files).status, 0);
     assert.equal(readFileSync(sentinel, "utf8"), "preserve me");
     assert.equal(readdirSync(files.directory).some((name) => name.startsWith(".output.tmp-")), false);
+    const validSemVerOutput = path.join(files.directory, "valid-semver");
+    assert.equal(run(files, { "--contracts-version": "1.2.3-alpha.1+build.007", "--output-dir": validSemVerOutput }).status, 0);
+    assert.equal(json(validSemVerOutput, "contracts-identity.json").version, "1.2.3-alpha.1+build.007");
     const base = args(files, { "--output-dir": path.join(files.directory, "boundary-output") });
     const without = (option) => {
       const index = base.indexOf(option);
@@ -182,6 +185,7 @@ test("preserves an existing output directory and rejects required CLI boundaries
       ["git SHA", args(files, { "--git-sha": "A".repeat(40), "--output-dir": path.join(files.directory, "git") })],
       ["platform environment", args(files, { "--platform-environment": "dev", "--output-dir": path.join(files.directory, "environment") })],
       ["SemVer", args(files, { "--contracts-version": "1.2", "--output-dir": path.join(files.directory, "semver") })],
+      ["long SemVer", args(files, { "--contracts-version": `1.2.3-${"a.".repeat(150)}a`, "--output-dir": path.join(files.directory, "long-semver") })],
       ["issueRef", args(files, { "--issue-ref": "2693", "--output-dir": path.join(files.directory, "issue") })],
     ]) assert.notEqual(runArguments(arguments_).status, 0, name);
   } finally {

--- a/tools/release/build-monorepo-component-manifests.test.mjs
+++ b/tools/release/build-monorepo-component-manifests.test.mjs
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const script = path.resolve("tools/release/build-monorepo-component-manifests.mjs");
+const gitSha = "a".repeat(40);
+const imageDigest = `sha256:${"b".repeat(64)}`;
+const sha256 = (value) => createHash("sha256").update(value).digest("hex");
+
+function fixture() {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "component-manifests-"));
+  const file = (name, content) => {
+    const target = path.join(directory, name);
+    writeFileSync(target, content);
+    return target;
+  };
+  return {
+    directory,
+    aab: file("app.aab", "android bundle bytes"),
+    dataManifest: file("data-manifest.json", "{\"data\":true}\n"),
+    backendInspect: file("backend-inspect.json", JSON.stringify([{ RepoDigests: [`registry.example/easysubway@${imageDigest}`] }])),
+    backendEvidence: file("backend-evidence.json", "backend evidence"),
+    sourceEvidence: file("source-evidence.json", "source evidence"),
+    platformEvidence: file("platform-evidence.json", "platform evidence"),
+    contractsBundle: file("contracts.tgz", "contracts bundle"),
+    output: path.join(directory, "output"),
+  };
+}
+
+function args(files, overrides = {}) {
+  const values = {
+    "--repository": "AquilaXk/easysubway",
+    "--git-sha": gitSha,
+    "--mobile-version-name": "2.3.4",
+    "--mobile-version-code": "17",
+    "--aab": files.aab,
+    "--bundled-data-manifest": files.dataManifest,
+    "--backend-image-inspect": files.backendInspect,
+    "--backend-evidence": files.backendEvidence,
+    "--data-version": "2026.07.30",
+    "--data-release-sequence": "0",
+    "--data-manifest": files.dataManifest,
+    "--source-snapshot-evidence": files.sourceEvidence,
+    "--platform-environment": "ci",
+    "--platform-evidence": files.platformEvidence,
+    "--contracts-version": "1.2.3",
+    "--contracts-bundle": files.contractsBundle,
+    "--issue-ref": "AquilaXk/easysubway#2693",
+    "--output-dir": files.output,
+    ...overrides,
+  };
+  return Object.entries(values).flat();
+}
+
+function run(files, overrides) {
+  return spawnSync(process.execPath, [script, ...args(files, overrides)], { encoding: "utf8" });
+}
+
+test("builds deterministic truthful monorepo component manifests", () => {
+  const files = fixture();
+  try {
+    const result = run(files);
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(requireFiles(files.output), [
+      "backend-component-manifest.json", "contracts-identity.json", "data-component-manifest.json",
+      "mobile-component-manifest.json", "platform-component-manifest.json",
+    ]);
+    const mobile = json(files.output, "mobile-component-manifest.json");
+    const backend = json(files.output, "backend-component-manifest.json");
+    const data = json(files.output, "data-component-manifest.json");
+    const platform = json(files.output, "platform-component-manifest.json");
+    assert.deepEqual(mobile, {
+      schemaVersion: 1, component: "mobile", repository: "AquilaXk/easysubway", gitSha,
+      artifactIdentity: { versionName: "2.3.4", versionCode: 17, aabSha256: sha256("android bundle bytes"), bundledDataManifestSha256: sha256("{\"data\":true}\n") },
+      contractVersion: "1.2.3", evidenceSha256: sha256("android bundle bytes"), issueRefs: ["AquilaXk/easysubway#2693"],
+    });
+    assert.equal(backend.artifactIdentity.imageDigest, imageDigest);
+    assert.equal(backend.artifactIdentity.apiContractVersion, "1.2.3");
+    assert.equal(backend.evidenceSha256, sha256("backend evidence"));
+    assert.equal(data.artifactIdentity.manifestSha256, mobile.artifactIdentity.bundledDataManifestSha256);
+    assert.equal(data.artifactIdentity.sourceSnapshotSetHash, sha256("source evidence"));
+    assert.equal(data.evidenceSha256, sha256("source evidence"));
+    assert.equal(platform.artifactIdentity.environment, "ci");
+    assert.equal(platform.artifactIdentity.deployedImageDigest, imageDigest);
+    assert.equal(platform.artifactIdentity.deploymentEvidenceSha256, sha256("platform evidence"));
+    assert.equal(platform.evidenceSha256, sha256("platform evidence"));
+    assert.deepEqual(json(files.output, "contracts-identity.json"), { version: "1.2.3", sha256: sha256("contracts bundle") });
+    for (const name of requireFiles(files.output)) assert.match(readFileSync(path.join(files.output, name), "utf8"), /\n$/);
+  } finally {
+    rmSync(files.directory, { recursive: true, force: true });
+  }
+});
+
+test("rejects missing inputs and mutable Docker identities without publishing output", () => {
+  const files = fixture();
+  try {
+    assert.notEqual(run(files, { "--aab": path.join(files.directory, "missing.aab") }).status, 0);
+    writeFileSync(files.backendInspect, JSON.stringify([{ RepoDigests: [], Id: "sha256:latest" }]));
+    const result = run(files);
+    assert.notEqual(result.status, 0);
+    assert.equal(requireFiles(files.output), null);
+  } finally {
+    rmSync(files.directory, { recursive: true, force: true });
+  }
+});
+
+test("rejects version bounds and mismatched bundled data manifests", () => {
+  const files = fixture();
+  try {
+    assert.notEqual(run(files, { "--mobile-version-code": "0" }).status, 0);
+    assert.notEqual(run(files, { "--data-release-sequence": "-1" }).status, 0);
+    const otherManifest = path.join(files.directory, "different-data-manifest.json");
+    writeFileSync(otherManifest, "different manifest");
+    assert.notEqual(run(files, { "--bundled-data-manifest": otherManifest }).status, 0);
+    assert.equal(requireFiles(files.output), null);
+  } finally {
+    rmSync(files.directory, { recursive: true, force: true });
+  }
+});
+
+function json(directory, name) {
+  return JSON.parse(readFileSync(path.join(directory, name), "utf8"));
+}
+
+function requireFiles(directory) {
+  try {
+    return readdirSync(directory).sort();
+  } catch {
+    return null;
+  }
+}

--- a/tools/release/build-monorepo-component-manifests.test.mjs
+++ b/tools/release/build-monorepo-component-manifests.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
@@ -69,6 +69,7 @@ test("builds deterministic truthful monorepo component manifests", () => {
   try {
     const result = run(files);
     assert.equal(result.status, 0, result.stderr);
+    assert.equal(lstatSync(files.output).isSymbolicLink(), true);
     assert.deepEqual(requireFiles(files.output), [
       "backend-component-manifest.json", "contracts-identity.json", "data-component-manifest.json",
       "mobile-component-manifest.json", "platform-component-manifest.json",
@@ -152,6 +153,7 @@ test("preserves an existing output directory and rejects required CLI boundaries
     writeFileSync(sentinel, "preserve me");
     assert.notEqual(run(files).status, 0);
     assert.equal(readFileSync(sentinel, "utf8"), "preserve me");
+    assert.equal(readdirSync(files.directory).some((name) => name.startsWith(".output.tmp-")), false);
     const base = args(files, { "--output-dir": path.join(files.directory, "boundary-output") });
     const without = (option) => {
       const index = base.indexOf(option);

--- a/tools/release/build-monorepo-component-manifests.test.mjs
+++ b/tools/release/build-monorepo-component-manifests.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
@@ -56,8 +56,12 @@ function args(files, overrides = {}) {
   return Object.entries(values).flat();
 }
 
-function run(files, overrides) {
-  return spawnSync(process.execPath, [script, ...args(files, overrides)], { encoding: "utf8" });
+function runArguments(arguments_) {
+  return spawnSync(process.execPath, [script, ...arguments_], { encoding: "utf8" });
+}
+
+function run(files, overrides, extra = []) {
+  return runArguments([...args(files, overrides), ...extra]);
 }
 
 test("builds deterministic truthful monorepo component manifests", () => {
@@ -90,19 +94,37 @@ test("builds deterministic truthful monorepo component manifests", () => {
     assert.equal(platform.evidenceSha256, sha256("platform evidence"));
     assert.deepEqual(json(files.output, "contracts-identity.json"), { version: "1.2.3", sha256: sha256("contracts bundle") });
     for (const name of requireFiles(files.output)) assert.match(readFileSync(path.join(files.output, name), "utf8"), /\n$/);
+    const secondOutput = path.join(files.directory, "output-second");
+    assert.equal(run(files, { "--output-dir": secondOutput }).status, 0);
+    for (const name of requireFiles(files.output)) {
+      assert.deepEqual(readFileSync(path.join(files.output, name)), readFileSync(path.join(secondOutput, name)), name);
+    }
   } finally {
     rmSync(files.directory, { recursive: true, force: true });
   }
 });
 
-test("rejects missing inputs and mutable Docker identities without publishing output", () => {
+test("accepts object-form immutable Id fallback and rejects mutable Docker identity", () => {
   const files = fixture();
   try {
-    assert.notEqual(run(files, { "--aab": path.join(files.directory, "missing.aab") }).status, 0);
-    writeFileSync(files.backendInspect, JSON.stringify([{ RepoDigests: [], Id: "sha256:latest" }]));
-    const result = run(files);
-    assert.notEqual(result.status, 0);
-    assert.equal(requireFiles(files.output), null);
+    writeFileSync(files.backendInspect, JSON.stringify({ RepoDigests: ["registry.example/easysubway:latest"], Id: imageDigest }));
+    assert.equal(run(files).status, 0);
+    assert.equal(json(files.output, "backend-component-manifest.json").artifactIdentity.imageDigest, imageDigest);
+    const absent = fixture();
+    try {
+      writeFileSync(absent.backendInspect, JSON.stringify({ Id: imageDigest }));
+      assert.equal(run(absent).status, 0);
+    } finally {
+      rmSync(absent.directory, { recursive: true, force: true });
+    }
+    const mutable = fixture();
+    try {
+      writeFileSync(mutable.backendInspect, JSON.stringify({ RepoDigests: ["registry.example/easysubway:latest"], Id: "sha256:latest" }));
+      assert.notEqual(run(mutable).status, 0);
+      assert.equal(requireFiles(mutable.output), null);
+    } finally {
+      rmSync(mutable.directory, { recursive: true, force: true });
+    }
   } finally {
     rmSync(files.directory, { recursive: true, force: true });
   }
@@ -117,6 +139,33 @@ test("rejects version bounds and mismatched bundled data manifests", () => {
     writeFileSync(otherManifest, "different manifest");
     assert.notEqual(run(files, { "--bundled-data-manifest": otherManifest }).status, 0);
     assert.equal(requireFiles(files.output), null);
+  } finally {
+    rmSync(files.directory, { recursive: true, force: true });
+  }
+});
+
+test("preserves an existing output directory and rejects required CLI boundaries", () => {
+  const files = fixture();
+  try {
+    mkdirSync(files.output);
+    const sentinel = path.join(files.output, "sentinel");
+    writeFileSync(sentinel, "preserve me");
+    assert.notEqual(run(files).status, 0);
+    assert.equal(readFileSync(sentinel, "utf8"), "preserve me");
+    const base = args(files, { "--output-dir": path.join(files.directory, "boundary-output") });
+    const without = (option) => {
+      const index = base.indexOf(option);
+      return [...base.slice(0, index), ...base.slice(index + 2)];
+    };
+    for (const [name, arguments_] of [
+      ["missing option", without("--aab")],
+      ["extraneous option", [...base, "--extra", "x"]],
+      ["repository", args(files, { "--repository": "AquilaXk/other", "--output-dir": path.join(files.directory, "repository") })],
+      ["git SHA", args(files, { "--git-sha": "A".repeat(40), "--output-dir": path.join(files.directory, "git") })],
+      ["platform environment", args(files, { "--platform-environment": "dev", "--output-dir": path.join(files.directory, "environment") })],
+      ["SemVer", args(files, { "--contracts-version": "1.2", "--output-dir": path.join(files.directory, "semver") })],
+      ["issueRef", args(files, { "--issue-ref": "2693", "--output-dir": path.join(files.directory, "issue") })],
+    ]) assert.notEqual(runArguments(arguments_).status, 0, name);
   } finally {
     rmSync(files.directory, { recursive: true, force: true });
   }

--- a/tools/release/build-monorepo-component-manifests.test.mjs
+++ b/tools/release/build-monorepo-component-manifests.test.mjs
@@ -9,6 +9,8 @@ import test from "node:test";
 const script = path.resolve("tools/release/build-monorepo-component-manifests.mjs");
 const gitSha = "a".repeat(40);
 const imageDigest = `sha256:${"b".repeat(64)}`;
+const sourceSnapshotSetHash = "c".repeat(64);
+const sourceEvidence = JSON.stringify({ sourceSnapshotSetHash });
 const sha256 = (value) => createHash("sha256").update(value).digest("hex");
 
 function fixture() {
@@ -24,7 +26,7 @@ function fixture() {
     dataManifest: file("data-manifest.json", "{\"data\":true}\n"),
     backendInspect: file("backend-inspect.json", JSON.stringify([{ RepoDigests: [`registry.example/easysubway@${imageDigest}`] }])),
     backendEvidence: file("backend-evidence.json", "backend evidence"),
-    sourceEvidence: file("source-evidence.json", "source evidence"),
+    sourceEvidence: file("source-evidence.json", sourceEvidence),
     platformEvidence: file("platform-evidence.json", "platform evidence"),
     contractsBundle: file("contracts.tgz", "contracts bundle"),
     output: path.join(directory, "output"),
@@ -87,8 +89,9 @@ test("builds deterministic truthful monorepo component manifests", () => {
     assert.equal(backend.artifactIdentity.apiContractVersion, "1.2.3");
     assert.equal(backend.evidenceSha256, sha256("backend evidence"));
     assert.equal(data.artifactIdentity.manifestSha256, mobile.artifactIdentity.bundledDataManifestSha256);
-    assert.equal(data.artifactIdentity.sourceSnapshotSetHash, sha256("source evidence"));
-    assert.equal(data.evidenceSha256, sha256("source evidence"));
+    assert.equal(data.artifactIdentity.sourceSnapshotSetHash, sourceSnapshotSetHash);
+    assert.equal(data.evidenceSha256, sha256(sourceEvidence));
+    assert.notEqual(data.artifactIdentity.sourceSnapshotSetHash, data.evidenceSha256);
     assert.equal(platform.artifactIdentity.environment, "ci");
     assert.equal(platform.artifactIdentity.deployedImageDigest, imageDigest);
     assert.equal(platform.artifactIdentity.deploymentEvidenceSha256, sha256("platform evidence"));
@@ -140,6 +143,19 @@ test("rejects version bounds and mismatched bundled data manifests", () => {
     writeFileSync(otherManifest, "different manifest");
     assert.notEqual(run(files, { "--bundled-data-manifest": otherManifest }).status, 0);
     assert.equal(requireFiles(files.output), null);
+  } finally {
+    rmSync(files.directory, { recursive: true, force: true });
+  }
+});
+
+test("rejects invalid source snapshot evidence before publication", () => {
+  const files = fixture();
+  try {
+    for (const evidence of ["not JSON", "{}", JSON.stringify({ sourceSnapshotSetHash: "C".repeat(64) }), JSON.stringify({ sourceSnapshotSetHash: "c".repeat(63) })]) {
+      writeFileSync(files.sourceEvidence, evidence);
+      assert.notEqual(run(files).status, 0);
+      assert.equal(requireFiles(files.output), null);
+    }
   } finally {
     rmSync(files.directory, { recursive: true, force: true });
   }

--- a/tools/release/build-monorepo-component-manifests.test.mjs
+++ b/tools/release/build-monorepo-component-manifests.test.mjs
@@ -103,6 +103,13 @@ test("builds deterministic truthful monorepo component manifests", () => {
     for (const name of requireFiles(files.output)) {
       assert.deepEqual(readFileSync(path.join(files.output, name)), readFileSync(path.join(secondOutput, name)), name);
     }
+    const cwdOutput = path.join(files.directory, "cwd-output");
+    const cwdResult = spawnSync(process.execPath, [script, ...args(files, { "--output-dir": cwdOutput })], {
+      cwd: files.directory,
+      encoding: "utf8",
+    });
+    assert.equal(cwdResult.status, 0, cwdResult.stderr);
+    assert.equal(json(cwdOutput, "contracts-identity.json").version, "1.2.3");
   } finally {
     rmSync(files.directory, { recursive: true, force: true });
   }

--- a/tools/release/generate-rc-evidence-manifest.mjs
+++ b/tools/release/generate-rc-evidence-manifest.mjs
@@ -421,7 +421,6 @@ function assertComponentCandidateIdentity(components, candidate) {
     ["platform", "backendImageDigest", components.platform?.artifactIdentity?.deployedImageDigest],
   ];
   for (const [component, field, value] of comparisons) {
-    if (candidate?.[field] == null) continue;
     if (String(candidate?.[field]) !== String(value)) fail(`${component} component manifest drifts from candidate context`);
   }
 }

--- a/tools/release/generate-rc-evidence-manifest.mjs
+++ b/tools/release/generate-rc-evidence-manifest.mjs
@@ -11,6 +11,7 @@ import path from "node:path";
 import { canonicalScopeHash } from "../datapack/build-launch-denominator-report.mjs";
 import { selectEffectiveDataPack, selectFallbackDataPack, validateManifest } from "../datapack/lib/manifest-validation.mjs";
 import { codepointCompare } from "../lib/codepoint-compare.mjs";
+import { isSemVer } from "./lib/semver.mjs";
 import { selectSystemReleaseDecision, validateSystemReleaseManifest } from "./validate-system-release-manifest.mjs";
 
 const SUCCESSFUL_FRESHNESS_REASON_CODES = new Set([
@@ -502,35 +503,8 @@ function readRequiredJson(filePath, label) {
   }
 }
 
-function isSemVer(value) {
-  if (typeof value !== "string" || value.length === 0 || value.length > 255) return false;
-  const buildParts = value.split("+");
-  if (buildParts.length > 2) return false;
-  const [version, build] = buildParts;
-  if (build !== undefined && !build.split(".").every((identifier) => isSemVerIdentifier(identifier, false))) return false;
-
-  const prereleaseSeparator = version.indexOf("-");
-  const core = prereleaseSeparator === -1 ? version : version.slice(0, prereleaseSeparator);
-  const prerelease = prereleaseSeparator === -1 ? undefined : version.slice(prereleaseSeparator + 1);
-  if (prerelease !== undefined && !prerelease.split(".").every((identifier) => isSemVerIdentifier(identifier, true))) return false;
-  const coreIdentifiers = core.split(".");
-  return coreIdentifiers.length === 3
-    && coreIdentifiers.every((identifier) => isDigits(identifier) && (identifier === "0" || identifier[0] !== "0"));
-}
-
 function isDigits(value) {
   return value.length > 0 && [...value].every((character) => character >= "0" && character <= "9");
-}
-
-function isSemVerIdentifier(value, rejectNumericLeadingZero) {
-  return value.length > 0
-    && [...value].every((character) => (
-      (character >= "0" && character <= "9")
-      || (character >= "A" && character <= "Z")
-      || (character >= "a" && character <= "z")
-      || character === "-"
-    ))
-    && (!rejectNumericLeadingZero || !isDigits(value) || value === "0" || value[0] !== "0");
 }
 
 function projectRcEvidenceContract(contract) {

--- a/tools/release/generate-rc-evidence-manifest.mjs
+++ b/tools/release/generate-rc-evidence-manifest.mjs
@@ -471,9 +471,27 @@ function assertComponentCandidateIdentity(components, candidate) {
     ["data", "releaseSequence", components.data?.artifactIdentity?.releaseSequence],
     ["platform", "backendImageDigest", components.platform?.artifactIdentity?.deployedImageDigest],
   ];
+  const integerFields = new Set(["versionCode", "releaseSequence"]);
   for (const [component, field, value] of comparisons) {
-    if (String(candidate?.[field]) !== String(value)) fail(`${component} component manifest drifts from candidate context`);
+    const candidateValue = candidate?.[field];
+    const matches = integerFields.has(field)
+      ? Number.isSafeInteger(value) && value >= 0 && normalizeCandidateIdentityInteger(candidateValue) === value
+      : candidateValue === value;
+    if (
+      !candidate || typeof candidate !== "object" || Array.isArray(candidate)
+      || !Object.hasOwn(candidate, field) || candidateValue === null || value === undefined || value === null || !matches
+    ) {
+      fail(`${component} component manifest drifts from candidate context`);
+    }
   }
+}
+
+function normalizeCandidateIdentityInteger(value) {
+  if (typeof value === "string") {
+    if (!isDigits(value) || (value !== "0" && value[0] === "0")) return null;
+    value = Number(value);
+  }
+  return Number.isSafeInteger(value) && value >= 0 ? value : null;
 }
 
 function readRequiredJson(filePath, label) {

--- a/tools/release/generate-rc-evidence-manifest.mjs
+++ b/tools/release/generate-rc-evidence-manifest.mjs
@@ -120,9 +120,9 @@ const gitSha = suppliedGitSha ?? process.env.GITHUB_SHA ?? checkoutGitSha;
 if (!/^[a-f0-9]{40}$/.test(gitSha) || gitSha !== checkoutGitSha) {
   fail("--git-sha must match the current checkout HEAD");
 }
-const rcEvidenceContract = readJsonIfExists(
+const rcEvidenceContract = projectRcEvidenceContract(readJsonIfExists(
   path.join(appRoot, "release/rc-evidence-manifest-contract.json"),
-);
+));
 if (!Array.isArray(rcEvidenceContract?.requiredEvidenceEntries)) {
   fail("RC evidence manifest contract with requiredEvidenceEntries is required");
 }
@@ -340,6 +340,34 @@ if (failOnBlocked && blockers.length > 0) {
 function writeManifest(filePath, value) {
   mkdirSync(path.dirname(filePath), { recursive: true });
   writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function projectRcEvidenceContract(contract) {
+  const sourceIssue = (issueRef) => {
+    const match = typeof issueRef === "string" && issueRef.match(/^AquilaXk\/easysubway#([1-9][0-9]*)$/);
+    if (!match) fail(`Invalid EasySubway issue reference: ${issueRef}`);
+    return Number(match[1]);
+  };
+  return {
+    ...contract,
+    issue: sourceIssue(contract?.issueRef),
+    parentIssues: contract.parentIssueRefs.map(sourceIssue),
+    linkedEvidenceIssues: contract.linkedEvidenceIssueRefs.map(sourceIssue),
+    phaseConsumers: Object.fromEntries(
+      Object.entries(contract.phaseConsumers ?? {}).map(([phase, issueRefs]) => [phase, issueRefs.map(sourceIssue)]),
+    ),
+    requiredFinalFragmentIssues: contract.requiredFinalFragmentIssueRefs.map(sourceIssue),
+    activeBlockerIssues: contract.activeBlockerIssueRefs.map(sourceIssue),
+    requiredEvidenceEntryFields: contract.requiredEvidenceEntryFields.map(
+      (field) => field === "issueRef" ? "sourceIssue" : field,
+    ),
+    requiredEvidenceEntries: contract.requiredEvidenceEntries.map(({ issueRef, ...entry }) => ({
+      ...entry, sourceIssue: sourceIssue(issueRef),
+    })),
+    requiredDatapackGates: contract.requiredDatapackGates.map(({ issueRef, ...gate }) => ({
+      ...gate, sourceIssue: sourceIssue(issueRef),
+    })),
+  };
 }
 
 function validateCandidateContext(candidate, expected) {

--- a/tools/release/generate-rc-evidence-manifest.mjs
+++ b/tools/release/generate-rc-evidence-manifest.mjs
@@ -249,7 +249,9 @@ if (requestedPhase === "FINAL" && !candidateContextPath) {
 if (candidateContextPath) {
   validateCandidateContext(readJsonIfExists(resolvePath(candidateContextPath)), candidateContext);
 }
-const systemReleaseInputs = readSystemReleaseInputs();
+const systemReleaseInputs = arg("systemReleaseOutput", "system-release-output")
+  ? readSystemReleaseInputs()
+  : null;
 
 const gateEntries = requiredGateEntries(
   rcEvidenceContract.requiredGateStatuses, rcEvidenceContract.requiredGateChecks,
@@ -342,9 +344,13 @@ const manifest = {
   },
 };
 
-const systemReleaseManifest = buildSystemReleaseManifest(manifest, systemReleaseInputs);
+const systemReleaseManifest = systemReleaseInputs
+  ? buildSystemReleaseManifest(manifest, systemReleaseInputs)
+  : null;
 writeManifest(outputPath, manifest, "--output");
-writeManifest(systemReleaseInputs.outputPath, systemReleaseManifest, "--system-release-output");
+if (systemReleaseInputs) {
+  writeManifest(systemReleaseInputs.outputPath, systemReleaseManifest, "--system-release-output");
+}
 
 if (failOnBlocked && blockers.length > 0) {
   fail(`RC evidence manifest is blocked: ${blockers.map((blocker) => blocker.id).join(", ")}`);

--- a/tools/release/generate-rc-evidence-manifest.mjs
+++ b/tools/release/generate-rc-evidence-manifest.mjs
@@ -10,7 +10,7 @@ import path from "node:path";
 import { canonicalScopeHash } from "../datapack/build-launch-denominator-report.mjs";
 import { selectEffectiveDataPack, selectFallbackDataPack, validateManifest } from "../datapack/lib/manifest-validation.mjs";
 import { codepointCompare } from "../lib/codepoint-compare.mjs";
-import { validateSystemReleaseManifest } from "./validate-system-release-manifest.mjs";
+import { selectSystemReleaseDecision, validateSystemReleaseManifest } from "./validate-system-release-manifest.mjs";
 
 const SUCCESSFUL_FRESHNESS_REASON_CODES = new Set([
   "PACK_PUBLISH_FRESHNESS_EXPIRED",
@@ -399,8 +399,10 @@ function buildSystemReleaseManifest(legacyManifest, inputs) {
     contracts: inputs.contracts,
     ...inputs.components,
   };
-  const goErrors = validateSystemReleaseManifest({ manifest: { ...base, decision: "GO" }, ...inputs.schemas });
-  const manifest = { ...base, decision: legacyManifest.decision === "GO" && goErrors.length === 0 ? "GO" : "NO_GO" };
+  const manifest = {
+    ...base,
+    decision: selectSystemReleaseDecision({ legacyDecision: legacyManifest.decision, manifest: base, ...inputs.schemas }),
+  };
   const errors = validateSystemReleaseManifest({ manifest, ...inputs.schemas });
   if (errors.length > 0) fail(`system release manifest validation failed: ${errors.join(", ")}`);
   return manifest;
@@ -419,6 +421,7 @@ function assertComponentCandidateIdentity(components, candidate) {
     ["platform", "backendImageDigest", components.platform?.artifactIdentity?.deployedImageDigest],
   ];
   for (const [component, field, value] of comparisons) {
+    if (candidate?.[field] == null) continue;
     if (String(candidate?.[field]) !== String(value)) fail(`${component} component manifest drifts from candidate context`);
   }
 }

--- a/tools/release/generate-rc-evidence-manifest.mjs
+++ b/tools/release/generate-rc-evidence-manifest.mjs
@@ -10,6 +10,7 @@ import path from "node:path";
 import { canonicalScopeHash } from "../datapack/build-launch-denominator-report.mjs";
 import { selectEffectiveDataPack, selectFallbackDataPack, validateManifest } from "../datapack/lib/manifest-validation.mjs";
 import { codepointCompare } from "../lib/codepoint-compare.mjs";
+import { validateSystemReleaseManifest } from "./validate-system-release-manifest.mjs";
 
 const SUCCESSFUL_FRESHNESS_REASON_CODES = new Set([
   "PACK_PUBLISH_FRESHNESS_EXPIRED",
@@ -239,6 +240,7 @@ if (requestedPhase === "FINAL" && !candidateContextPath) {
 if (candidateContextPath) {
   validateCandidateContext(readJsonIfExists(resolvePath(candidateContextPath)), candidateContext);
 }
+const systemReleaseInputs = readSystemReleaseInputs();
 
 const gateEntries = requiredGateEntries(
   rcEvidenceContract.requiredGateStatuses, rcEvidenceContract.requiredGateChecks,
@@ -331,7 +333,9 @@ const manifest = {
   },
 };
 
+const systemReleaseManifest = buildSystemReleaseManifest(manifest, systemReleaseInputs);
 writeManifest(outputPath, manifest);
+writeManifest(systemReleaseInputs.outputPath, systemReleaseManifest);
 
 if (failOnBlocked && blockers.length > 0) {
   fail(`RC evidence manifest is blocked: ${blockers.map((blocker) => blocker.id).join(", ")}`);
@@ -340,6 +344,95 @@ if (failOnBlocked && blockers.length > 0) {
 function writeManifest(filePath, value) {
   mkdirSync(path.dirname(filePath), { recursive: true });
   writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function readSystemReleaseInputs() {
+  const required = [
+    ["mobile", "mobileComponentManifest", "mobile-component-manifest"],
+    ["backend", "backendComponentManifest", "backend-component-manifest"],
+    ["data", "dataComponentManifest", "data-component-manifest"],
+    ["platform", "platformComponentManifest", "platform-component-manifest"],
+  ];
+  const components = Object.fromEntries(required.map(([slot, camelName, kebabName]) => {
+    const rawPath = arg(camelName, kebabName);
+    if (!rawPath) fail(`FINAL phase requires --${kebabName}`);
+    return [slot, readRequiredJson(resolvePath(rawPath), `${slot} component manifest`)];
+  }));
+  const contractsPath = arg("contractsIdentity", "contracts-identity");
+  if (!contractsPath) fail("FINAL phase requires --contracts-identity");
+  const contracts = readRequiredJson(resolvePath(contractsPath), "contracts identity");
+  if (
+    !contracts || typeof contracts !== "object" || Array.isArray(contracts)
+    || Object.keys(contracts).length !== 2
+    || !Object.hasOwn(contracts, "version") || !Object.hasOwn(contracts, "sha256")
+    || !isSemVer(contracts.version) || !/^[a-f0-9]{64}$/.test(contracts.sha256)
+  ) {
+    fail("contracts identity must be exactly {version,sha256}");
+  }
+  const output = arg("systemReleaseOutput", "system-release-output");
+  if (!output) fail("FINAL phase requires --system-release-output");
+  const systemReleaseOutputPath = resolvePath(output);
+  if (systemReleaseOutputPath === outputPath) fail("--system-release-output must differ from --output");
+  const productReleaseId = arg("productReleaseId", "product-release-id");
+  if (!productReleaseId) fail("FINAL phase requires --product-release-id");
+  const schemas = Object.fromEntries([
+    ["componentSchema", "component-manifest.schema.json"],
+    ["systemSchema", "system-release-manifest.schema.json"],
+    ["issueRefSchema", "issue-ref.schema.json"],
+  ].map(([key, file]) => [key, readRequiredJson(path.join(repoRoot, "contracts/release", file), `release contract ${file}`)]));
+  return { components, contracts, outputPath: systemReleaseOutputPath, productReleaseId, schemas };
+}
+
+function buildSystemReleaseManifest(legacyManifest, inputs) {
+  assertComponentCandidateIdentity(inputs.components, legacyManifest.releaseCandidateIdentity);
+  const issueRefs = [];
+  for (const component of [inputs.components.mobile, inputs.components.backend, inputs.components.data, inputs.components.platform]) {
+    for (const issueRef of component.issueRefs ?? []) if (!issueRefs.includes(issueRef)) issueRefs.push(issueRef);
+  }
+  const base = {
+    schemaVersion: 2,
+    productReleaseId: inputs.productReleaseId,
+    phase: "FINAL",
+    decision: "NO_GO",
+    generatedAt,
+    issueRefs,
+    contracts: inputs.contracts,
+    ...inputs.components,
+  };
+  const goErrors = validateSystemReleaseManifest({ manifest: { ...base, decision: "GO" }, ...inputs.schemas });
+  const manifest = { ...base, decision: legacyManifest.decision === "GO" && goErrors.length === 0 ? "GO" : "NO_GO" };
+  const errors = validateSystemReleaseManifest({ manifest, ...inputs.schemas });
+  if (errors.length > 0) fail(`system release manifest validation failed: ${errors.join(", ")}`);
+  return manifest;
+}
+
+function assertComponentCandidateIdentity(components, candidate) {
+  const comparisons = [
+    ["mobile", "appVersionName", components.mobile?.artifactIdentity?.versionName],
+    ["mobile", "versionCode", components.mobile?.artifactIdentity?.versionCode],
+    ["mobile", "aabSha256", components.mobile?.artifactIdentity?.aabSha256],
+    ["mobile", "dataPackManifestSha256", components.mobile?.artifactIdentity?.bundledDataManifestSha256],
+    ["backend", "backendImageDigest", components.backend?.artifactIdentity?.imageDigest],
+    ["data", "dataPackManifestSha256", components.data?.artifactIdentity?.manifestSha256],
+    ["data", "sourceSnapshotSetHash", components.data?.artifactIdentity?.sourceSnapshotSetHash],
+    ["data", "releaseSequence", components.data?.artifactIdentity?.releaseSequence],
+    ["platform", "backendImageDigest", components.platform?.artifactIdentity?.deployedImageDigest],
+  ];
+  for (const [component, field, value] of comparisons) {
+    if (String(candidate?.[field]) !== String(value)) fail(`${component} component manifest drifts from candidate context`);
+  }
+}
+
+function readRequiredJson(filePath, label) {
+  try {
+    return JSON.parse(readFileSync(filePath, "utf8"));
+  } catch {
+    fail(`${label} is unreadable or invalid JSON`);
+  }
+}
+
+function isSemVer(value) {
+  return typeof value === "string" && /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.test(value);
 }
 
 function projectRcEvidenceContract(contract) {

--- a/tools/release/generate-rc-evidence-manifest.mjs
+++ b/tools/release/generate-rc-evidence-manifest.mjs
@@ -485,7 +485,34 @@ function readRequiredJson(filePath, label) {
 }
 
 function isSemVer(value) {
-  return typeof value === "string" && /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.test(value);
+  if (typeof value !== "string" || value.length === 0 || value.length > 255) return false;
+  const buildParts = value.split("+");
+  if (buildParts.length > 2) return false;
+  const [version, build] = buildParts;
+  if (build !== undefined && !build.split(".").every((identifier) => isSemVerIdentifier(identifier, false))) return false;
+
+  const prereleaseSeparator = version.indexOf("-");
+  const core = prereleaseSeparator === -1 ? version : version.slice(0, prereleaseSeparator);
+  const prerelease = prereleaseSeparator === -1 ? undefined : version.slice(prereleaseSeparator + 1);
+  if (prerelease !== undefined && !prerelease.split(".").every((identifier) => isSemVerIdentifier(identifier, true))) return false;
+  const coreIdentifiers = core.split(".");
+  return coreIdentifiers.length === 3
+    && coreIdentifiers.every((identifier) => isDigits(identifier) && (identifier === "0" || identifier[0] !== "0"));
+}
+
+function isDigits(value) {
+  return value.length > 0 && [...value].every((character) => character >= "0" && character <= "9");
+}
+
+function isSemVerIdentifier(value, rejectNumericLeadingZero) {
+  return value.length > 0
+    && [...value].every((character) => (
+      (character >= "0" && character <= "9")
+      || (character >= "A" && character <= "Z")
+      || (character >= "a" && character <= "z")
+      || character === "-"
+    ))
+    && (!rejectNumericLeadingZero || !isDigits(value) || value === "0" || value[0] !== "0");
 }
 
 function projectRcEvidenceContract(contract) {

--- a/tools/release/generate-rc-evidence-manifest.mjs
+++ b/tools/release/generate-rc-evidence-manifest.mjs
@@ -3,7 +3,8 @@
 import { createHash } from "node:crypto";
 import { execFileSync } from "node:child_process";
 import {
-  closeSync, existsSync, mkdirSync, mkdtempSync, openSync, readFileSync, rmSync, statSync, writeFileSync,
+  closeSync, existsSync, lstatSync, mkdirSync, mkdtempSync, openSync, readFileSync, realpathSync, renameSync,
+  rmSync, statSync, writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -236,7 +237,7 @@ const candidateContext = {
 };
 
 if (requestedPhase === "CANDIDATE") {
-  writeManifest(outputPath, candidateContext);
+  writeManifest(outputPath, candidateContext, "--output");
   process.exit(0);
 }
 
@@ -341,16 +342,50 @@ const manifest = {
 };
 
 const systemReleaseManifest = buildSystemReleaseManifest(manifest, systemReleaseInputs);
-writeManifest(outputPath, manifest);
-writeManifest(systemReleaseInputs.outputPath, systemReleaseManifest);
+writeManifest(outputPath, manifest, "--output");
+writeManifest(systemReleaseInputs.outputPath, systemReleaseManifest, "--system-release-output");
 
 if (failOnBlocked && blockers.length > 0) {
   fail(`RC evidence manifest is blocked: ${blockers.map((blocker) => blocker.id).join(", ")}`);
 }
 
-function writeManifest(filePath, value) {
-  mkdirSync(path.dirname(filePath), { recursive: true });
-  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+function outputDestination(filePath, label) {
+  const parent = path.dirname(filePath);
+  mkdirSync(parent, { recursive: true });
+  const existing = lstatSync(filePath, { throwIfNoEntry: false });
+  if (existing?.isSymbolicLink()) fail(`${label} must not be a symlink`);
+  return { canonicalPath: path.join(realpathSync(parent), path.basename(filePath)), existing };
+}
+
+function writeManifest(filePath, value, label) {
+  outputDestination(filePath, label);
+  const parent = path.dirname(filePath);
+  let descriptor;
+  let temporaryPath;
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    temporaryPath = path.join(parent, `.${path.basename(filePath)}.tmp-${process.pid}-${attempt}`);
+    try {
+      descriptor = openSync(temporaryPath, "wx", 0o600);
+      break;
+    } catch (error) {
+      if (error.code !== "EEXIST") throw error;
+    }
+  }
+  if (descriptor === undefined) fail(`${label} temporary file is unavailable`);
+  try {
+    writeFileSync(descriptor, `${JSON.stringify(value, null, 2)}\n`);
+    closeSync(descriptor);
+    descriptor = undefined;
+    renameSync(temporaryPath, filePath);
+  } catch (error) {
+    if (descriptor !== undefined) {
+      try {
+        closeSync(descriptor);
+      } catch {}
+    }
+    rmSync(temporaryPath, { force: true });
+    throw error;
+  }
 }
 
 function readSystemReleaseInputs() {
@@ -379,7 +414,16 @@ function readSystemReleaseInputs() {
   const output = arg("systemReleaseOutput", "system-release-output");
   if (!output) fail("FINAL phase requires --system-release-output");
   const systemReleaseOutputPath = resolvePath(output);
-  if (systemReleaseOutputPath === outputPath) fail("--system-release-output must differ from --output");
+  const legacyOutput = outputDestination(outputPath, "--output");
+  const systemOutput = outputDestination(systemReleaseOutputPath, "--system-release-output");
+  if (legacyOutput.canonicalPath === systemOutput.canonicalPath) fail("--system-release-output must differ from --output");
+  if (
+    legacyOutput.existing?.isFile() && systemOutput.existing?.isFile()
+    && legacyOutput.existing.dev === systemOutput.existing.dev
+    && legacyOutput.existing.ino === systemOutput.existing.ino
+  ) {
+    fail("--system-release-output must not alias --output");
+  }
   const productReleaseId = arg("productReleaseId", "product-release-id");
   if (!productReleaseId) fail("FINAL phase requires --product-release-id");
   const schemas = Object.fromEntries([

--- a/tools/release/generate-rc-evidence-manifest.mjs
+++ b/tools/release/generate-rc-evidence-manifest.mjs
@@ -43,7 +43,7 @@ const evidenceRoot = normalizeEvidenceRoot(
 );
 const appVersion = readFlutterVersion(path.join(appRoot, "pubspec.yaml"));
 const dataPackManifestPath = resolvePath(
-  arg("dataPackManifest", "data-pack-manifest") ?? path.join(appRoot, "assets/datapacks/metro_map_pack/manifest.json"),
+  arg("dataPackManifest", "data-pack-manifest") ?? path.join(appRoot, "assets/datapacks/index.json"),
 );
 const dataPackManifest = readJsonIfExists(dataPackManifestPath);
 const dataPackArtifactArg = arg("dataPackArtifact", "data-pack-artifact");
@@ -84,8 +84,15 @@ const dataPackRehearsalBinding = readDataPackRehearsalBinding(
   dataPackManifest,
   dataPackArtifactPath,
 );
+if (
+  dataPackManifest?.sourceSnapshotSetHash !== undefined
+  && !/^[a-f0-9]{64}$/.test(dataPackManifest.sourceSnapshotSetHash)
+) {
+  fail("data pack manifest sourceSnapshotSetHash must be a SHA-256 digest");
+}
 const sourceSnapshotSetHash = dataPackReleaseDecision?.sourceSnapshotSetHash
   ?? dataPackRehearsalBinding?.sourceSnapshotSetHash
+  ?? dataPackManifest?.sourceSnapshotSetHash
   ?? null;
 if (requireProductionDataPackBinding) {
   validateProductionDataPackBinding(
@@ -1349,13 +1356,13 @@ function requirePositiveSafeInteger(value, name) {
 function normalizeReleaseSequence(explicitValue, manifestValue) {
   const value = explicitValue ?? manifestValue ?? null;
   if (value === null) return null;
-  const parsed = typeof value === "string" && /^[1-9]\d*$/.test(value)
+  const parsed = typeof value === "string" && /^(?:0|[1-9]\d*)$/.test(value)
     ? Number(value)
     : value;
-  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
     fail(explicitValue === undefined
-      ? "data pack manifest releaseSequence must be a positive safe integer"
-      : "--release-sequence must be a positive safe integer");
+      ? "data pack manifest releaseSequence must be a non-negative safe integer"
+      : "--release-sequence must be a non-negative safe integer");
   }
   return parsed;
 }

--- a/tools/release/generate-rc-evidence-manifest.mjs
+++ b/tools/release/generate-rc-evidence-manifest.mjs
@@ -423,7 +423,9 @@ function readSystemReleaseInputs() {
   const systemReleaseOutputPath = resolvePath(output);
   const legacyOutput = outputDestination(outputPath, "--output");
   const systemOutput = outputDestination(systemReleaseOutputPath, "--system-release-output");
-  if (legacyOutput.canonicalPath === systemOutput.canonicalPath) fail("--system-release-output must differ from --output");
+  if (legacyOutput.canonicalPath.toLowerCase() === systemOutput.canonicalPath.toLowerCase()) {
+    fail("--system-release-output must differ from --output");
+  }
   if (
     legacyOutput.existing?.isFile() && systemOutput.existing?.isFile()
     && legacyOutput.existing.dev === systemOutput.existing.dev

--- a/tools/release/lib/semver.mjs
+++ b/tools/release/lib/semver.mjs
@@ -1,0 +1,30 @@
+function isDigits(value) {
+  return value.length > 0 && [...value].every((character) => character >= "0" && character <= "9");
+}
+
+function isIdentifier(value, rejectNumericLeadingZero) {
+  return value.length > 0
+    && [...value].every((character) => (
+      (character >= "0" && character <= "9")
+      || (character >= "A" && character <= "Z")
+      || (character >= "a" && character <= "z")
+      || character === "-"
+    ))
+    && (!rejectNumericLeadingZero || !isDigits(value) || value === "0" || value[0] !== "0");
+}
+
+export function isSemVer(value) {
+  if (typeof value !== "string" || value.length === 0 || value.length > 255) return false;
+  const buildParts = value.split("+");
+  if (buildParts.length > 2) return false;
+  const [version, build] = buildParts;
+  if (build !== undefined && !build.split(".").every((identifier) => isIdentifier(identifier, false))) return false;
+
+  const prereleaseSeparator = version.indexOf("-");
+  const core = prereleaseSeparator === -1 ? version : version.slice(0, prereleaseSeparator);
+  const prerelease = prereleaseSeparator === -1 ? undefined : version.slice(prereleaseSeparator + 1);
+  if (prerelease !== undefined && !prerelease.split(".").every((identifier) => isIdentifier(identifier, true))) return false;
+  const coreIdentifiers = core.split(".");
+  return coreIdentifiers.length === 3
+    && coreIdentifiers.every((identifier) => isDigits(identifier) && (identifier === "0" || identifier[0] !== "0"));
+}

--- a/tools/release/validate-system-release-manifest.mjs
+++ b/tools/release/validate-system-release-manifest.mjs
@@ -32,6 +32,8 @@ export function validateSystemReleaseManifest({ manifest, componentSchema, syste
   }
 
   const components = slots.map((slot) => manifest[slot]).filter(Boolean);
+  if (!Number.isSafeInteger(manifest.mobile?.artifactIdentity?.versionCode)) errors.push("mobile: versionCode must be a safe integer");
+  if (!Number.isSafeInteger(manifest.data?.artifactIdentity?.releaseSequence)) errors.push("data: releaseSequence must be a safe integer");
   if (new Set(components.map((component) => component.component)).size !== components.length) errors.push("system: duplicate component name");
   if (manifest.mobile?.artifactIdentity?.bundledDataManifestSha256 !== manifest.data?.artifactIdentity?.manifestSha256) errors.push("system: mobile/data manifest hash mismatch");
   if (manifest.backend?.artifactIdentity?.imageDigest !== manifest.platform?.artifactIdentity?.deployedImageDigest) errors.push("system: backend/platform image digest mismatch");

--- a/tools/release/validate-system-release-manifest.mjs
+++ b/tools/release/validate-system-release-manifest.mjs
@@ -19,12 +19,16 @@ export function validateSystemReleaseManifest({ manifest, componentSchema, syste
     errors.push(...validateSchema(componentSchema, component).errors.map((error) => `${slot}${error.slice(1)}`));
     if (component.component !== slot) errors.push(`${slot}: component must match slot`);
     if (!allowedRepositories[slot].has(component.repository)) errors.push(`${slot}: repository is not allowed for slot`);
-    for (const issueRef of component.issueRefs ?? []) {
-      errors.push(...validateSchema(issueRefSchema, issueRef).errors.map(() => `${slot}: invalid issue ref`));
+    if (Array.isArray(component.issueRefs)) {
+      for (const issueRef of component.issueRefs) {
+        errors.push(...validateSchema(issueRefSchema, issueRef).errors.map(() => `${slot}: invalid issue ref`));
+      }
     }
   }
-  for (const issueRef of manifest.issueRefs ?? []) {
-    errors.push(...validateSchema(issueRefSchema, issueRef).errors.map(() => "system: invalid issue ref"));
+  if (Array.isArray(manifest.issueRefs)) {
+    for (const issueRef of manifest.issueRefs) {
+      errors.push(...validateSchema(issueRefSchema, issueRef).errors.map(() => "system: invalid issue ref"));
+    }
   }
 
   const components = slots.map((slot) => manifest[slot]).filter(Boolean);
@@ -46,9 +50,15 @@ function redact(errors) {
 
 function main() {
   const manifestPath = parseManifestPath(process.argv.slice(2));
+  if (!manifestPath) return fail("invalid arguments");
   const here = path.dirname(fileURLToPath(import.meta.url));
+  let manifest;
   try {
-    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  } catch {
+    return fail("manifest file is unreadable or invalid JSON");
+  }
+  try {
     const schema = (name) => JSON.parse(readFileSync(path.join(here, "../../contracts/release", name), "utf8"));
     const errors = validateSystemReleaseManifest({
       manifest,
@@ -56,17 +66,21 @@ function main() {
       systemSchema: schema("system-release-manifest.schema.json"),
       issueRefSchema: schema("issue-ref.schema.json"),
     });
-    if (errors.length > 0) throw new Error(errors.join("\n"));
+    if (errors.length > 0) return fail(errors.join("\n"));
     process.stdout.write(`system-release-manifest: OK ${manifest.productReleaseId}\n`);
-  } catch (error) {
-    process.stderr.write(`system-release-manifest: invalid\n${error.message}\n`);
-    process.exitCode = 1;
+  } catch {
+    fail("validator unavailable");
   }
 }
 
 function parseManifestPath(args) {
   if (args.length === 2 && args[0] === "--manifest" && args[1]) return args[1];
-  throw new Error("usage: --manifest <path>");
+  return null;
+}
+
+function fail(message) {
+  process.stderr.write(`system-release-manifest: invalid\n${message}\n`);
+  process.exitCode = 1;
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) main();

--- a/tools/release/validate-system-release-manifest.mjs
+++ b/tools/release/validate-system-release-manifest.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { validateSchema } from "../ci/lib/json-schema-lite.mjs";
+
+const slots = ["mobile", "backend", "data", "platform"];
+const canonicalRepositories = Object.fromEntries(slots.map((slot) => [slot, `AquilaXk/easysubway-${slot}`]));
+const allowedRepositories = Object.fromEntries(slots.map((slot) => [slot, new Set(["AquilaXk/easysubway", canonicalRepositories[slot]])]));
+
+export function validateSystemReleaseManifest({ manifest, componentSchema, systemSchema, issueRefSchema }) {
+  const errors = [...validateSchema(systemSchema, manifest).errors];
+  if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) return redact(errors);
+
+  for (const slot of slots) {
+    const component = manifest[slot];
+    if (!component || typeof component !== "object" || Array.isArray(component)) continue;
+    errors.push(...validateSchema(componentSchema, component).errors.map((error) => `${slot}${error.slice(1)}`));
+    if (component.component !== slot) errors.push(`${slot}: component must match slot`);
+    if (!allowedRepositories[slot].has(component.repository)) errors.push(`${slot}: repository is not allowed for slot`);
+    for (const issueRef of component.issueRefs ?? []) {
+      errors.push(...validateSchema(issueRefSchema, issueRef).errors.map(() => `${slot}: invalid issue ref`));
+    }
+  }
+  for (const issueRef of manifest.issueRefs ?? []) {
+    errors.push(...validateSchema(issueRefSchema, issueRef).errors.map(() => "system: invalid issue ref"));
+  }
+
+  const components = slots.map((slot) => manifest[slot]).filter(Boolean);
+  if (new Set(components.map((component) => component.component)).size !== components.length) errors.push("system: duplicate component name");
+  if (manifest.mobile?.artifactIdentity?.bundledDataManifestSha256 !== manifest.data?.artifactIdentity?.manifestSha256) errors.push("system: mobile/data manifest hash mismatch");
+  if (manifest.backend?.artifactIdentity?.imageDigest !== manifest.platform?.artifactIdentity?.deployedImageDigest) errors.push("system: backend/platform image digest mismatch");
+  if (manifest.decision === "GO") {
+    if (manifest.phase !== "FINAL") errors.push("system: GO requires FINAL phase");
+    if (slots.some((slot) => manifest[slot]?.repository !== canonicalRepositories[slot])) errors.push("system: GO requires canonical target repositories");
+    if (manifest.platform?.artifactIdentity?.environment !== "production") errors.push("system: GO requires production platform");
+    if (manifest.data?.artifactIdentity?.releaseSequence < 1) errors.push("system: GO requires data release sequence");
+  }
+  return redact(errors);
+}
+
+function redact(errors) {
+  return [...new Set(errors.map((error) => String(error).replace(/\$\.[^:]+/g, "$")))];
+}
+
+function main() {
+  const manifestPath = parseManifestPath(process.argv.slice(2));
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  try {
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    const schema = (name) => JSON.parse(readFileSync(path.join(here, "../../contracts/release", name), "utf8"));
+    const errors = validateSystemReleaseManifest({
+      manifest,
+      componentSchema: schema("component-manifest.schema.json"),
+      systemSchema: schema("system-release-manifest.schema.json"),
+      issueRefSchema: schema("issue-ref.schema.json"),
+    });
+    if (errors.length > 0) throw new Error(errors.join("\n"));
+    process.stdout.write(`system-release-manifest: OK ${manifest.productReleaseId}\n`);
+  } catch (error) {
+    process.stderr.write(`system-release-manifest: invalid\n${error.message}\n`);
+    process.exitCode = 1;
+  }
+}
+
+function parseManifestPath(args) {
+  if (args.length === 2 && args[0] === "--manifest" && args[1]) return args[1];
+  throw new Error("usage: --manifest <path>");
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main();

--- a/tools/release/validate-system-release-manifest.mjs
+++ b/tools/release/validate-system-release-manifest.mjs
@@ -9,6 +9,37 @@ const slots = ["mobile", "backend", "data", "platform"];
 const canonicalRepositories = Object.fromEntries(slots.map((slot) => [slot, `AquilaXk/easysubway-${slot}`]));
 const allowedRepositories = Object.fromEntries(slots.map((slot) => [slot, new Set(["AquilaXk/easysubway", canonicalRepositories[slot]])]));
 
+function isDigits(value) {
+  return value.length > 0 && [...value].every((character) => character >= "0" && character <= "9");
+}
+
+function isSemVerIdentifier(value, rejectNumericLeadingZero) {
+  return value.length > 0
+    && [...value].every((character) => (
+      (character >= "0" && character <= "9")
+      || (character >= "A" && character <= "Z")
+      || (character >= "a" && character <= "z")
+      || character === "-"
+    ))
+    && (!rejectNumericLeadingZero || !isDigits(value) || value === "0" || value[0] !== "0");
+}
+
+function isSemVer(value) {
+  if (typeof value !== "string" || value.length === 0 || value.length > 255) return false;
+  const buildParts = value.split("+");
+  if (buildParts.length > 2) return false;
+  const [version, build] = buildParts;
+  if (build !== undefined && !build.split(".").every((identifier) => isSemVerIdentifier(identifier, false))) return false;
+
+  const prereleaseSeparator = version.indexOf("-");
+  const core = prereleaseSeparator === -1 ? version : version.slice(0, prereleaseSeparator);
+  const prerelease = prereleaseSeparator === -1 ? undefined : version.slice(prereleaseSeparator + 1);
+  if (prerelease !== undefined && !prerelease.split(".").every((identifier) => isSemVerIdentifier(identifier, true))) return false;
+  const coreIdentifiers = core.split(".");
+  return coreIdentifiers.length === 3
+    && coreIdentifiers.every((identifier) => isDigits(identifier) && (identifier === "0" || identifier[0] !== "0"));
+}
+
 export function validateSystemReleaseManifest({ manifest, componentSchema, systemSchema, issueRefSchema }) {
   const errors = [...validateSchema(systemSchema, manifest).errors];
   if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) return redact(errors);
@@ -30,6 +61,7 @@ export function validateSystemReleaseManifest({ manifest, componentSchema, syste
       errors.push(...validateSchema(issueRefSchema, issueRef).errors.map(() => "system: invalid issue ref"));
     }
   }
+  if (!isSemVer(manifest.contracts?.version)) errors.push("system: contracts version must be SemVer");
 
   const components = slots.map((slot) => manifest[slot]).filter(Boolean);
   if (!Number.isSafeInteger(manifest.mobile?.artifactIdentity?.versionCode)) errors.push("mobile: versionCode must be a safe integer");

--- a/tools/release/validate-system-release-manifest.mjs
+++ b/tools/release/validate-system-release-manifest.mjs
@@ -4,41 +4,11 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { validateSchema } from "../ci/lib/json-schema-lite.mjs";
+import { isSemVer } from "./lib/semver.mjs";
 
 const slots = ["mobile", "backend", "data", "platform"];
 const canonicalRepositories = Object.fromEntries(slots.map((slot) => [slot, `AquilaXk/easysubway-${slot}`]));
 const allowedRepositories = Object.fromEntries(slots.map((slot) => [slot, new Set(["AquilaXk/easysubway", canonicalRepositories[slot]])]));
-
-function isDigits(value) {
-  return value.length > 0 && [...value].every((character) => character >= "0" && character <= "9");
-}
-
-function isSemVerIdentifier(value, rejectNumericLeadingZero) {
-  return value.length > 0
-    && [...value].every((character) => (
-      (character >= "0" && character <= "9")
-      || (character >= "A" && character <= "Z")
-      || (character >= "a" && character <= "z")
-      || character === "-"
-    ))
-    && (!rejectNumericLeadingZero || !isDigits(value) || value === "0" || value[0] !== "0");
-}
-
-function isSemVer(value) {
-  if (typeof value !== "string" || value.length === 0 || value.length > 255) return false;
-  const buildParts = value.split("+");
-  if (buildParts.length > 2) return false;
-  const [version, build] = buildParts;
-  if (build !== undefined && !build.split(".").every((identifier) => isSemVerIdentifier(identifier, false))) return false;
-
-  const prereleaseSeparator = version.indexOf("-");
-  const core = prereleaseSeparator === -1 ? version : version.slice(0, prereleaseSeparator);
-  const prerelease = prereleaseSeparator === -1 ? undefined : version.slice(prereleaseSeparator + 1);
-  if (prerelease !== undefined && !prerelease.split(".").every((identifier) => isSemVerIdentifier(identifier, true))) return false;
-  const coreIdentifiers = core.split(".");
-  return coreIdentifiers.length === 3
-    && coreIdentifiers.every((identifier) => isDigits(identifier) && (identifier === "0" || identifier[0] !== "0"));
-}
 
 export function validateSystemReleaseManifest({ manifest, componentSchema, systemSchema, issueRefSchema }) {
   const errors = [...validateSchema(systemSchema, manifest).errors];

--- a/tools/release/validate-system-release-manifest.mjs
+++ b/tools/release/validate-system-release-manifest.mjs
@@ -44,6 +44,13 @@ export function validateSystemReleaseManifest({ manifest, componentSchema, syste
   return redact(errors);
 }
 
+export function selectSystemReleaseDecision({ legacyDecision, manifest, componentSchema, systemSchema, issueRefSchema }) {
+  const semanticErrors = validateSystemReleaseManifest({
+    manifest: { ...manifest, decision: "GO" }, componentSchema, systemSchema, issueRefSchema,
+  });
+  return legacyDecision === "GO" && semanticErrors.length === 0 ? "GO" : "NO_GO";
+}
+
 function redact(errors) {
   return [...new Set(errors.map((error) => String(error).replace(/\$\.[^:]+/g, "$")))];
 }

--- a/tools/release/validate-system-release-manifest.mjs
+++ b/tools/release/validate-system-release-manifest.mjs
@@ -56,12 +56,12 @@ function redact(errors) {
 }
 
 function main() {
-  const manifestPath = parseManifestPath(process.argv.slice(2));
-  if (!manifestPath) return fail("invalid arguments");
+  const options = parseOptions(process.argv.slice(2));
+  if (!options) return fail("invalid arguments");
   const here = path.dirname(fileURLToPath(import.meta.url));
   let manifest;
   try {
-    manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    manifest = JSON.parse(readFileSync(options.manifestPath, "utf8"));
   } catch {
     return fail("manifest file is unreadable or invalid JSON");
   }
@@ -74,14 +74,26 @@ function main() {
       issueRefSchema: schema("issue-ref.schema.json"),
     });
     if (errors.length > 0) return fail(errors.join("\n"));
+    if (options.requireDecision && manifest.decision !== options.requireDecision) {
+      return fail(`decision must be ${options.requireDecision}`);
+    }
     process.stdout.write(`system-release-manifest: OK ${manifest.productReleaseId}\n`);
   } catch {
     fail("validator unavailable");
   }
 }
 
-function parseManifestPath(args) {
-  if (args.length === 2 && args[0] === "--manifest" && args[1]) return args[1];
+function parseOptions(args) {
+  if (args.length === 2 && args[0] === "--manifest" && args[1]) {
+    return { manifestPath: args[1], requireDecision: null };
+  }
+  if (
+    args.length === 4
+    && args[0] === "--manifest" && args[1]
+    && args[2] === "--require-decision" && args[3] === "GO"
+  ) {
+    return { manifestPath: args[1], requireDecision: args[3] };
+  }
   return null;
 }
 

--- a/tools/release/validate-system-release-manifest.test.mjs
+++ b/tools/release/validate-system-release-manifest.test.mjs
@@ -4,7 +4,7 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { validateSystemReleaseManifest } from "./validate-system-release-manifest.mjs";
+import { selectSystemReleaseDecision, validateSystemReleaseManifest } from "./validate-system-release-manifest.mjs";
 
 const sha = "a".repeat(64);
 const gitSha = "b".repeat(40);
@@ -18,7 +18,7 @@ function validManifest() {
     decision: "GO",
     generatedAt: "2026-07-30T00:00:00Z",
     issueRefs: [issue("easysubway", 2693)],
-    contracts: { version: "release-manifest-v2", sha256: sha },
+    contracts: { version: "1.2.3", sha256: sha },
     mobile: {
       schemaVersion: 1, component: "mobile", repository: "AquilaXk/easysubway-mobile", gitSha,
       artifactIdentity: { versionName: "1.0.0", versionCode: 1, aabSha256: sha, bundledDataManifestSha256: sha },
@@ -50,6 +50,27 @@ const schemas = {
 
 test("system release manifest v2 validates the locked release identity", () => {
   assert.deepEqual(validateSystemReleaseManifest({ manifest: validManifest(), ...schemas }), []);
+});
+
+test("system release manifest v2 rejects invalid contracts SemVer", () => {
+  const manifest = validManifest();
+  manifest.contracts.version = `1.2.3-${"a.".repeat(150)}a`;
+  assert.ok(validateSystemReleaseManifest({ manifest, ...schemas }).includes("system: contracts version must be SemVer"));
+});
+
+test("system release decision requires legacy GO and every GO transition condition", () => {
+  assert.equal(selectSystemReleaseDecision({ legacyDecision: "GO", manifest: validManifest(), ...schemas }), "GO");
+  assert.equal(selectSystemReleaseDecision({ legacyDecision: "NO_GO", manifest: validManifest(), ...schemas }), "NO_GO");
+
+  for (const mutate of [
+    (manifest) => { manifest.platform.artifactIdentity.environment = "ci"; },
+    (manifest) => { manifest.data.artifactIdentity.releaseSequence = 0; },
+    (manifest) => { for (const slot of ["mobile", "backend", "data", "platform"]) manifest[slot].repository = "AquilaXk/easysubway"; },
+  ]) {
+    const manifest = validManifest();
+    mutate(manifest);
+    assert.equal(selectSystemReleaseDecision({ legacyDecision: "GO", manifest, ...schemas }), "NO_GO");
+  }
 });
 
 test("system release manifest v2 rejects every locked identity violation", () => {

--- a/tools/release/validate-system-release-manifest.test.mjs
+++ b/tools/release/validate-system-release-manifest.test.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { validateSystemReleaseManifest } from "./validate-system-release-manifest.mjs";
+
+const sha = "a".repeat(64);
+const gitSha = "b".repeat(40);
+const issue = (repository, number) => `AquilaXk/${repository}#${number}`;
+
+function validManifest() {
+  return {
+    schemaVersion: 2,
+    productReleaseId: "easysubway-2026.07.30.1",
+    phase: "FINAL",
+    decision: "GO",
+    generatedAt: "2026-07-30T00:00:00Z",
+    issueRefs: [issue("easysubway", 2693)],
+    contracts: { version: "release-manifest-v2", sha256: sha },
+    mobile: {
+      schemaVersion: 1, component: "mobile", repository: "AquilaXk/easysubway-mobile", gitSha,
+      artifactIdentity: { versionName: "1.0.0", versionCode: 1, aabSha256: sha, bundledDataManifestSha256: sha },
+      contractVersion: "mobile-v1", evidenceSha256: sha, issueRefs: [issue("easysubway-mobile", 2693)],
+    },
+    backend: {
+      schemaVersion: 1, component: "backend", repository: "AquilaXk/easysubway-backend", gitSha,
+      artifactIdentity: { imageDigest: `sha256:${sha}`, apiContractVersion: "api-v1" },
+      contractVersion: "backend-v1", evidenceSha256: sha, issueRefs: [issue("easysubway-backend", 2693)],
+    },
+    data: {
+      schemaVersion: 1, component: "data", repository: "AquilaXk/easysubway-data", gitSha,
+      artifactIdentity: { dataVersion: "2026.07", releaseSequence: 1, manifestSha256: sha, sourceSnapshotSetHash: sha },
+      contractVersion: "data-v1", evidenceSha256: sha, issueRefs: [issue("easysubway-data", 2693)],
+    },
+    platform: {
+      schemaVersion: 1, component: "platform", repository: "AquilaXk/easysubway-platform", gitSha,
+      artifactIdentity: { environment: "production", deployedImageDigest: `sha256:${sha}`, deploymentEvidenceSha256: sha },
+      contractVersion: "platform-v1", evidenceSha256: sha, issueRefs: [issue("easysubway-platform", 2693)],
+    },
+  };
+}
+
+const schemas = {
+  componentSchema: JSON.parse(readFileSync("contracts/release/component-manifest.schema.json", "utf8")),
+  systemSchema: JSON.parse(readFileSync("contracts/release/system-release-manifest.schema.json", "utf8")),
+  issueRefSchema: JSON.parse(readFileSync("contracts/release/issue-ref.schema.json", "utf8")),
+};
+
+test("system release manifest v2 validates the locked release identity", () => {
+  assert.deepEqual(validateSystemReleaseManifest({ manifest: validManifest(), ...schemas }), []);
+});
+
+test("system release manifest v2 rejects every locked identity violation", () => {
+  const cases = [
+    ["top-level gitSha", (manifest) => { manifest.gitSha = gitSha; }],
+    ["bare issue number", (manifest) => { manifest.issueRefs = [2693]; }],
+    ["uppercase hash", (manifest) => { manifest.contracts.sha256 = sha.toUpperCase(); }],
+    ["malformed hash", (manifest) => { manifest.contracts.sha256 = "invalid"; }],
+    ["mutable backend tag", (manifest) => { manifest.backend.artifactIdentity.imageDigest = "latest"; }],
+    ["wrong slot component", (manifest) => { manifest.mobile.component = "backend"; }],
+    ["wrong target repository", (manifest) => { manifest.mobile.repository = "AquilaXk/easysubway-data"; }],
+    ["duplicate component name", (manifest) => { manifest.backend.component = "mobile"; }],
+    ["mobile/data hash mismatch", (manifest) => { manifest.mobile.artifactIdentity.bundledDataManifestSha256 = "c".repeat(64); }],
+    ["backend/platform digest mismatch", (manifest) => { manifest.platform.artifactIdentity.deployedImageDigest = `sha256:${"c".repeat(64)}`; }],
+    ["invalid GO transition", (manifest) => { manifest.phase = "CANDIDATE"; }],
+  ];
+
+  for (const [name, mutate] of cases) {
+    const manifest = validManifest();
+    mutate(manifest);
+    assert.ok(validateSystemReleaseManifest({ manifest, ...schemas }).length > 0, name);
+  }
+});

--- a/tools/release/validate-system-release-manifest.test.mjs
+++ b/tools/release/validate-system-release-manifest.test.mjs
@@ -108,3 +108,33 @@ test("CLI emits fixed redacted errors for argument, file, and JSON failures", ()
     rmSync(directory, { recursive: true, force: true });
   }
 });
+
+test("CLI require-decision GO rejects NO_GO and accepts GO", () => {
+  const directory = mkdtempSync(path.join(tmpdir(), "release-manifest-decision-"));
+  const manifestPath = path.join(directory, "system-release-manifest.json");
+  try {
+    const manifest = validManifest();
+    manifest.decision = "NO_GO";
+    writeFileSync(manifestPath, JSON.stringify(manifest));
+    const rejected = spawnSync(process.execPath, [
+      "tools/release/validate-system-release-manifest.mjs",
+      "--manifest", manifestPath,
+      "--require-decision", "GO",
+    ], { encoding: "utf8" });
+    assert.equal(rejected.status, 1);
+    assert.equal(rejected.stdout, "");
+    assert.equal(rejected.stderr, "system-release-manifest: invalid\ndecision must be GO\n");
+
+    manifest.decision = "GO";
+    writeFileSync(manifestPath, JSON.stringify(manifest));
+    const accepted = spawnSync(process.execPath, [
+      "tools/release/validate-system-release-manifest.mjs",
+      "--manifest", manifestPath,
+      "--require-decision", "GO",
+    ], { encoding: "utf8" });
+    assert.equal(accepted.status, 0, accepted.stderr);
+    assert.equal(accepted.stdout, `system-release-manifest: OK ${manifest.productReleaseId}\n`);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/tools/release/validate-system-release-manifest.test.mjs
+++ b/tools/release/validate-system-release-manifest.test.mjs
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { validateSystemReleaseManifest } from "./validate-system-release-manifest.mjs";
 
 const sha = "a".repeat(64);
@@ -68,5 +71,40 @@ test("system release manifest v2 rejects every locked identity violation", () =>
     const manifest = validManifest();
     mutate(manifest);
     assert.ok(validateSystemReleaseManifest({ manifest, ...schemas }).length > 0, name);
+  }
+});
+
+test("system and component non-array issue refs return validation errors without throwing", () => {
+  for (const mutate of [
+    (manifest) => { manifest.issueRefs = 2693; },
+    (manifest) => { manifest.mobile.issueRefs = {}; },
+  ]) {
+    const manifest = validManifest();
+    mutate(manifest);
+    assert.doesNotThrow(() => validateSystemReleaseManifest({ manifest, ...schemas }));
+    assert.ok(validateSystemReleaseManifest({ manifest, ...schemas }).length > 0);
+  }
+});
+
+test("CLI emits fixed redacted errors for argument, file, and JSON failures", () => {
+  const directory = mkdtempSync(path.join(tmpdir(), "release-manifest-test-"));
+  const missingPath = path.join(directory, "TOP_SECRET_MANIFEST_BODY.json");
+  const malformedPath = path.join(directory, "malformed.json");
+  writeFileSync(malformedPath, '{"secret":"TOP_SECRET_MANIFEST_BODY"');
+  try {
+    const cases = [
+      [[], "invalid arguments"],
+      [["--manifest", missingPath], "manifest file is unreadable or invalid JSON"],
+      [["--manifest", malformedPath], "manifest file is unreadable or invalid JSON"],
+    ];
+    for (const [args, message] of cases) {
+      const result = spawnSync(process.execPath, ["tools/release/validate-system-release-manifest.mjs", ...args], { encoding: "utf8" });
+      assert.equal(result.status, 1);
+      assert.equal(result.stdout, "");
+      assert.equal(result.stderr, `system-release-manifest: invalid\n${message}\n`);
+      assert.doesNotMatch(result.stderr, /TOP_SECRET_MANIFEST_BODY|release-manifest-test/);
+    }
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
   }
 });

--- a/tools/release/validate-system-release-manifest.test.mjs
+++ b/tools/release/validate-system-release-manifest.test.mjs
@@ -74,6 +74,17 @@ test("system release manifest v2 rejects every locked identity violation", () =>
   }
 });
 
+test("system release manifest v2 rejects unsafe identity integers", () => {
+  for (const [mutate, expected] of [
+    [(manifest) => { manifest.mobile.artifactIdentity.versionCode = Number.MAX_SAFE_INTEGER + 1; }, "mobile: versionCode must be a safe integer"],
+    [(manifest) => { manifest.data.artifactIdentity.releaseSequence = Number.MAX_SAFE_INTEGER + 1; }, "data: releaseSequence must be a safe integer"],
+  ]) {
+    const manifest = validManifest();
+    mutate(manifest);
+    assert.deepEqual(validateSystemReleaseManifest({ manifest, ...schemas }), [expected]);
+  }
+});
+
 test("system and component non-array issue refs return validation errors without throwing", () => {
   for (const mutate of [
     (manifest) => { manifest.issueRefs = 2693; },


### PR DESCRIPTION
## 관련 이슈

Closes #2693

## 작업 배경

현재 RC evidence는 mobile·backend·data·platform을 하나의 checkout SHA로 표현해, 독립 repository와 immutable artifact를 안전하게 조립할 수 없습니다. Repository 분리 전에 component identity tuple과 contracts hash를 authoritative product release identity로 고정합니다.

## 작업 내용

- repository-qualified `issueRef`, component manifest v1, system release manifest v2 schema와 fail-closed validator를 추가했습니다.
- 기존 `final-readiness.json` v1은 별도 compatibility evidence로 유지하고, FINAL 생성기가 명시적인 네 component manifest와 contracts identity로 `system-release-manifest.json`을 조립하도록 변경했습니다.
- monorepo 전환 producer가 실제 AAB, image inspect, data/source evidence, Compose evidence, contracts bundle을 hash해 다섯 manifest를 원자적으로 공개하도록 추가했습니다.
- release workflow가 component manifests와 v2를 생성·업로드하고, Play internal upload 전에 authoritative v2 `GO`를 요구하도록 연결했습니다.
- 실제 AAB bundled index와 별도 production data manifest가 다르면 fail closed하며, Compose evidence는 빌드한 `${GITHUB_SHA}` image에 결속됩니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/release/validate-system-release-manifest.test.mjs` — 5 pass, 0 fail
  - `node --test tools/release/build-monorepo-component-manifests.test.mjs` — 5 pass, 0 fail
  - `node --test --test-name-pattern='\[release-v2\]' tools/ci/repository-contract.test.mjs` — 1 pass, 0 fail
  - `node --test --test-name-pattern='\[system-release-generator\]' tools/ci/repository-contract.test.mjs` — 1 pass, 0 fail
  - `node --test --test-name-pattern='\[release-v2-workflow\]' tools/ci/repository-contract.test.mjs` — 1 pass, 0 fail
  - `git diff --check d1eeb4b416749b3f2ffeadd6d9c94a8ab89d3594..HEAD` — pass
  - 전체 regression — GitHub CI `30524049191` 및 Release Artifacts `30524048769` 통과

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Schema/validator | Node.js 24 | malformed identity 및 GO 조건 단위 테스트 | PR CI와 위 로컬 명령 | 통과 |
| Component producer | Node.js 24 | 실제 파일 hash·원자 publication 회귀 테스트 | PR CI와 위 로컬 명령 | 통과 |
| Workflow contract | GitHub Actions | v1/v2 분리, artifact dataflow, Play GO gate 정적 계약 | PR CI와 위 로컬 명령 | 통과 |
| Current-head Review | Codex CLI fallback | `d1eeb4b4…e6c86186` 전체 diff 재검토 | Review `4816586558` | actionable 0건 |
| UI/접근성/수동 QA | 해당 없음 | 사용자 UI를 변경하지 않음 | 해당 없음 | 불필요 |
| 배포/스토어 업로드 | 실행 안 함 | 이 PR은 CI 계약만 변경하고 production external effect를 수행하지 않음 | 해당 없음 | 미실행 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음; workflow evidence만 immutable image digest로 기록

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `tools/release/validate-system-release-manifest.mjs`의 GO semantics, `generate-rc-evidence-manifest.mjs`의 candidate/component drift, `.github/workflows/release-artifacts.yml`의 Play fail-closed 순서

## 리스크

- 전환기 repository와 platform environment는 의도적으로 `NO_GO`입니다.
- production data manifest가 실제 AAB bundled index와 다르면 거짓 identity를 만들지 않고 workflow가 중단됩니다. 동일 immutable data artifact를 Android build 전에 staging하는 후속 작업이 필요합니다.
- 전체 Actions 실행 결과는 PR required CI에서 확인합니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰와 rate-limit 경고를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit current-head 실행이 rate limit으로 불가능해 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. 이 PR은 deploy를 실행하지 않는다.
