### PR TITLE
[Fix] exploratory provenance staging 복원

### DIFF
--- a/.github/workflows/datapack-release.yml
+++ b/.github/workflows/datapack-release.yml
@@ -691,7 +691,7 @@ jobs:
             --freshness-policy release/product-gates/datapack-freshness-sla.json
 
       - name: Data Pack Release / Stage candidate provenance
-        if: ${{ steps.release-mode.outputs.mode == 'release-candidate' }}
+        if: ${{ steps.release-mode.outputs.is-pointer-only != 'true' && steps.release-mode.outputs.mode != 'production-publish' }}
         run: |
           set -euo pipefail
           cp "${EASYSUBWAY_DATAPACK_OUTPUT}/current.provenance.json" "${EASYSUBWAY_DATAPACK_STAGE}/current.provenance.json"

--- a/tools/ci/datapack-release-workflow.test.mjs
+++ b/tools/ci/datapack-release-workflow.test.mjs
@@ -732,6 +732,8 @@ test("production-publish는 attested candidate를 no-rebuild로 소비한다", (
 
   const provenance = step("Data Pack Release / Stage candidate provenance");
   assert.match(provenance, /current\.provenance\.json/);
+  assert.match(provenance, /is-pointer-only != 'true'/);
+  assert.match(provenance, /mode != 'production-publish'/);
   assert.match(step("Data Pack Release / Validate source snapshot freshness"), /mode == 'release-candidate'/);
   const accessibility = step("Data Pack Release / Validate accessibility source coverage");
   assert.match(accessibility, /mode == 'release-candidate'/);

--- a/tools/ci/datapack-release-workflow.test.mjs
+++ b/tools/ci/datapack-release-workflow.test.mjs
@@ -732,8 +732,10 @@ test("production-publish는 attested candidate를 no-rebuild로 소비한다", (
 
   const provenance = step("Data Pack Release / Stage candidate provenance");
   assert.match(provenance, /current\.provenance\.json/);
-  assert.match(provenance, /is-pointer-only != 'true'/);
-  assert.match(provenance, /mode != 'production-publish'/);
+  assert.match(
+    provenance,
+    /if:\s*\$\{\{ steps\.release-mode\.outputs\.is-pointer-only != 'true' && steps\.release-mode\.outputs\.mode != 'production-publish' \}\}/,
+  );
   assert.match(step("Data Pack Release / Validate source snapshot freshness"), /mode == 'release-candidate'/);
   const accessibility = step("Data Pack Release / Validate accessibility source coverage");
   assert.match(accessibility, /mode == 'release-candidate'/);


### PR DESCRIPTION
## 관련 이슈

Closes #2699

## 작업 배경

#2703 병합 직후 main push의 Data Pack Release run `30564158962`에서 exploratory evidence bundle 검증이 staged `current.provenance.json`을 찾지 못해 실패했습니다.

## 작업 내용

- `Stage candidate provenance`를 pointer-only와 `production-publish`에서만 제외해 exploratory와 release-candidate build 결과에는 provenance를 stage합니다.
- focused workflow contract가 이 조건을 고정해 production no-rebuild 경로의 provenance 생성 회귀도 막습니다.

## 검증

- RED: focused workflow contract가 기존 `release-candidate` 전용 조건에서 실패
- `node --test --test-name-pattern='production-publish는 attested candidate를 no-rebuild로 소비한다' tools/ci/datapack-release-workflow.test.mjs` — 1 passed
- `git diff --check` — passed

## 검증 증거

| 항목 | 확인 방법 | 결과 |
| --- | --- | --- |
| post-merge 재현 | main run `30564158962` 실패 로그 | exploratory staged provenance ENOENT 확인 |
| 조건 회귀 | focused named-step contract | PASS |
| production no-rebuild | 동일 contract에서 `mode != 'production-publish'` 고정 | PASS |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route evidence를 갱신했다.
- [x] 상용 경로/ETA claim을 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] release blocker evidence를 갱신했다.
- [x] 출시 준비 완료 claim을 변경하지 않는다.

### Version decision

- mobile/backend/datapack identity: unchanged
- workflow condition only

## 리뷰어 메모

- 변경은 workflow condition 한 줄과 이를 고정하는 assertion 두 개뿐입니다.
- `production-publish`와 rollback/rollout pointer-only 경로에는 provenance build/staging이 추가되지 않습니다.

## 리스크

- exploratory push workflow가 다시 provenance를 stage합니다. production write나 Store upload는 이 PR에서 수행하지 않습니다.

## 체크리스트

- [x] PR 본문은 전체 A등급 섹션을 유지했다.
- [ ] current-head Review를 확인했다.
- [ ] required CI를 확인했다.
- [ ] merge 후 Data Pack Release post-check를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 데이터 팩 릴리스 과정에서 포인터 전용 및 프로덕션 게시 모드를 제외한 다양한 모드에서 후보 출처 정보가 올바르게 처리되도록 개선했습니다.

* **테스트**
  * 후보 출처 단계의 실행 조건 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->