### PR TITLE
[Fix] issue transfer target URL 검증

### DIFF
--- a/tools/repo/migrate-issue.mjs
+++ b/tools/repo/migrate-issue.mjs
@@ -46,6 +46,14 @@ export function parseArguments(argv) {
       if (values[key] !== undefined || value === undefined || value.startsWith("--")) throw new Error(argument === "--source-issue" ? "exactly one --source-issue is required" : `${argument} must appear exactly once with a value`);
       values[key] = value;
     }
+    else if (argument === "--verify-transfer") {
+      const value = argv[++index];
+      if (values.mode || value === undefined || value.startsWith("--")) {
+        throw new Error("choose exactly one execution mode");
+      }
+      values.mode = "verify-transfer";
+      values.targetUrl = value;
+    }
     else if (argument === "--dry-run" || argument === "--execute") {
       if (values.mode) throw new Error("choose exactly one execution mode");
       values.mode = argument.slice(2);
@@ -60,7 +68,13 @@ export function parseArguments(argv) {
   if (values.mode === "execute" && (!values.confirmSource || !values.confirmTarget)) {
     throw new Error("--execute requires both confirmations");
   }
-  return { ledgerPath: values.ledgerPath, sourceIssue: Number(values.sourceIssue), mode: values.mode, confirmations: { source: values.confirmSource, target: values.confirmTarget } };
+  return {
+    ledgerPath: values.ledgerPath,
+    sourceIssue: Number(values.sourceIssue),
+    mode: values.mode,
+    ...(values.targetUrl === undefined ? {} : { targetUrl: values.targetUrl }),
+    confirmations: { source: values.confirmSource, target: values.confirmTarget },
+  };
 }
 
 export function validateMigrationLedger({ ledger, schema }) {
@@ -73,6 +87,18 @@ export async function runMigration({ arguments_, ledger, schema, execGh }) {
   const entry = ledger.issues.find(({ sourceIssue }) => sourceIssue === arguments_.sourceIssue);
   if (!entry) throw new Error("source issue is not in the ledger");
   if (arguments_.mode === "dry-run") return preflightIssueTransfer({ entry, execGh });
+  if (arguments_.mode === "verify-transfer") {
+    const details = await preflightDetails({ entry, execGh });
+    return verifyTransferredIssue({
+      entry,
+      transferResult: {
+        sourceUrl: entry.sourceUrl,
+        expectedMetadata: details.source,
+        redirectedIssue: transferredIssueFromUrl(arguments_.targetUrl, entry.targetRepository),
+      },
+      execGh,
+    });
+  }
   const transferResult = await executeIssueTransfer({
     entry,
     confirmations: arguments_.confirmations,
@@ -96,22 +122,24 @@ export async function executeIssueTransfer({ entry, confirmations, execGh }) {
   confirmExecution(entry, confirmations);
   const details = await preflightDetails({ entry, execGh });
   try {
-    await execGh(["issue", "transfer", String(entry.sourceIssue), entry.targetRepository, "--repo", SOURCE_REPOSITORY]);
-    return { sourceUrl: entry.sourceUrl, expectedMetadata: details.source };
+    const output = await execGh([
+      "issue", "transfer", String(entry.sourceIssue), entry.targetRepository, "--repo", SOURCE_REPOSITORY,
+    ]);
+    return {
+      sourceUrl: entry.sourceUrl,
+      expectedMetadata: details.source,
+      redirectedIssue: transferredIssueFromUrl(output.trim(), entry.targetRepository),
+    };
   } catch {
-    try {
-      const redirectedIssue = await readRedirectedIssue(entry, execGh);
-      return { sourceUrl: entry.sourceUrl, expectedMetadata: details.source, redirectedIssue };
-    } catch {
-      const indeterminate = new Error("issue transfer response is indeterminate; source redirect could not be confirmed");
-      indeterminate.transferIndeterminate = true;
-      throw indeterminate;
-    }
+    const indeterminate = new Error("issue transfer response is indeterminate; use --verify-transfer with the exact target URL before retrying");
+    indeterminate.transferIndeterminate = true;
+    throw indeterminate;
   }
 }
 
 export async function verifyTransferredIssue({ entry, transferResult, execGh }) {
-  const targetUrl = transferResult?.redirectedIssue ?? await readRedirectedIssue(entry, execGh);
+  const targetUrl = transferResult?.redirectedIssue;
+  if (!targetUrl) throw new Error("transferred issue identity is missing");
   const target = await readIssueMetadata(targetUrl.repository, targetUrl.number, execGh);
   const expected = transferResult?.expectedMetadata;
   if (target.number !== targetUrl.number || target.url !== `https://github.com/${targetUrl.repository}/issues/${targetUrl.number}`) {
@@ -128,13 +156,6 @@ export async function verifyTransferredIssue({ entry, transferResult, execGh }) 
     milestone: target.milestone?.title ?? null,
     commentCount: target.commentCount,
   };
-}
-
-async function readRedirectedIssue(entry, execGh) {
-  const representation = JSON.parse(await execGh([
-    "api", "-H", "X-GitHub-Api-Version: 2022-11-28", `/repos/${SOURCE_REPOSITORY}/issues/${entry.sourceIssue}`,
-  ]));
-  return redirectRepresentation(representation, entry.targetRepository);
 }
 
 async function preflightDetails({ entry, execGh }) {
@@ -268,11 +289,9 @@ function canonicalDueOn(value) {
   return date.toISOString();
 }
 
-function redirectRepresentation(representation, targetRepository) {
-  const match = typeof representation?.html_url === "string" && representation.html_url.match(new RegExp(`^https://github\\.com/${escapeRegExp(targetRepository)}/issues/(\\d+)$`));
-  if (!match || representation.number !== Number(match[1]) || representation.repository_url !== `https://api.github.com/repos/${targetRepository}`) {
-    throw new Error("source issue redirect is missing or invalid");
-  }
+function transferredIssueFromUrl(url, targetRepository) {
+  const match = typeof url === "string" && url.match(new RegExp(`^https://github\\.com/${escapeRegExp(targetRepository)}/issues/([1-9]\\d*)$`));
+  if (!match) throw new Error("transferred issue URL is missing or invalid");
   return { repository: targetRepository, number: Number(match[1]) };
 }
 

--- a/tools/repo/migrate-issue.mjs
+++ b/tools/repo/migrate-issue.mjs
@@ -46,14 +46,6 @@ export function parseArguments(argv) {
       if (values[key] !== undefined || value === undefined || value.startsWith("--")) throw new Error(argument === "--source-issue" ? "exactly one --source-issue is required" : `${argument} must appear exactly once with a value`);
       values[key] = value;
     }
-    else if (argument === "--verify-transfer") {
-      const value = argv[++index];
-      if (values.mode || value === undefined || value.startsWith("--")) {
-        throw new Error("choose exactly one execution mode");
-      }
-      values.mode = "verify-transfer";
-      values.targetUrl = value;
-    }
     else if (argument === "--dry-run" || argument === "--execute") {
       if (values.mode) throw new Error("choose exactly one execution mode");
       values.mode = argument.slice(2);
@@ -68,13 +60,7 @@ export function parseArguments(argv) {
   if (values.mode === "execute" && (!values.confirmSource || !values.confirmTarget)) {
     throw new Error("--execute requires both confirmations");
   }
-  return {
-    ledgerPath: values.ledgerPath,
-    sourceIssue: Number(values.sourceIssue),
-    mode: values.mode,
-    ...(values.targetUrl === undefined ? {} : { targetUrl: values.targetUrl }),
-    confirmations: { source: values.confirmSource, target: values.confirmTarget },
-  };
+  return { ledgerPath: values.ledgerPath, sourceIssue: Number(values.sourceIssue), mode: values.mode, confirmations: { source: values.confirmSource, target: values.confirmTarget } };
 }
 
 export function validateMigrationLedger({ ledger, schema }) {
@@ -87,18 +73,6 @@ export async function runMigration({ arguments_, ledger, schema, execGh }) {
   const entry = ledger.issues.find(({ sourceIssue }) => sourceIssue === arguments_.sourceIssue);
   if (!entry) throw new Error("source issue is not in the ledger");
   if (arguments_.mode === "dry-run") return preflightIssueTransfer({ entry, execGh });
-  if (arguments_.mode === "verify-transfer") {
-    const details = await preflightDetails({ entry, execGh });
-    return verifyTransferredIssue({
-      entry,
-      transferResult: {
-        sourceUrl: entry.sourceUrl,
-        expectedMetadata: details.source,
-        redirectedIssue: transferredIssueFromUrl(arguments_.targetUrl, entry.targetRepository),
-      },
-      execGh,
-    });
-  }
   const transferResult = await executeIssueTransfer({
     entry,
     confirmations: arguments_.confirmations,
@@ -131,7 +105,7 @@ export async function executeIssueTransfer({ entry, confirmations, execGh }) {
       redirectedIssue: transferredIssueFromUrl(output.trim(), entry.targetRepository),
     };
   } catch {
-    const indeterminate = new Error("issue transfer response is indeterminate; use --verify-transfer with the exact target URL before retrying");
+    const indeterminate = new Error("issue transfer response is indeterminate; do not retry without confirming the exact target issue");
     indeterminate.transferIndeterminate = true;
     throw indeterminate;
   }

--- a/tools/repo/migrate-issue.test.mjs
+++ b/tools/repo/migrate-issue.test.mjs
@@ -85,10 +85,6 @@ test("argument parser accepts exactly one source issue and one mode", () => {
     () => parseArguments(["--ledger", "ledger.json", "--source-issue", "2684", "--source-issue", "2685", "--dry-run"]),
     /exactly one --source-issue/,
   );
-  assert.deepEqual(
-    parseArguments(["--ledger", "ledger.json", "--source-issue", "2684", "--verify-transfer", TARGET_URL]),
-    { ledgerPath: "ledger.json", sourceIssue: 2684, mode: "verify-transfer", targetUrl: TARGET_URL, confirmations: { source: undefined, target: undefined } },
-  );
 });
 
 test("preflight fails closed before transfer for unsafe ledger and GitHub metadata", async (t) => {
@@ -228,23 +224,6 @@ test("completed transfer with failed verification reports a partial-success erro
       && error.transferCompleted === true,
   );
   assert.equal(transferCalls(fake.calls).length, 1);
-});
-
-test("an already transferred issue can be recovery-verified without another transfer", async () => {
-  const { ledger, schema } = migrationContract();
-  const entry = ledger.issues.find(({ sourceIssue }) => sourceIssue === SOURCE_ISSUE);
-  entry.executionApproval = "https://github.com/AquilaXk/easysubway/issues/2691#issuecomment-1";
-  const fake = fakeGh();
-
-  const verified = await runMigration({
-    arguments_: { sourceIssue: SOURCE_ISSUE, mode: "verify-transfer", targetUrl: TARGET_URL, confirmations: { source: undefined, target: undefined } },
-    ledger,
-    schema,
-    execGh: fake.execGh,
-  });
-
-  assert.equal(verified.targetUrl, TARGET_URL);
-  assert.equal(transferCalls(fake.calls).length, 0);
 });
 
 test("unconfirmed transfer response reports an indeterminate result", async () => {

--- a/tools/repo/migrate-issue.test.mjs
+++ b/tools/repo/migrate-issue.test.mjs
@@ -36,9 +36,8 @@ function metadata({ url = SOURCE_URL, number = SOURCE_ISSUE, title, state = "OPE
   return { id: `I_${number}`, url, number, title: title ?? transferEntry().title, state, repository: { nameWithOwner: repo }, labels: connection(labels.map((name) => ({ name }))), milestone: milestone === null ? null : { title: milestone, dueOn: null }, comments: { totalCount: commentCount }, assignees: connection([]), projectItems: connection([]), parent: null, subIssues: connection([]), blocking: connection([]), blockedBy: connection([]), closedByPullRequestsReferences: connection(closingPullRequests) };
 }
 
-function fakeGh({ source = metadata(), target = metadata({ url: TARGET_URL, number: 7 }), targetExists = true, unassignableLogin, malformedAssigneeResponse, transferFailure = false, redirectedAfterTransferFailure = false } = {}) {
+function fakeGh({ source = metadata(), target = metadata({ url: TARGET_URL, number: 7 }), targetExists = true, unassignableLogin, malformedAssigneeResponse, transferFailure = false, transferOutput = `${TARGET_URL}\n` } = {}) {
   const calls = [];
-  let transferred = false;
   const execGh = async (args) => {
     calls.push(args);
     if (args[0] === "repo" && args[1] === "view") {
@@ -46,9 +45,8 @@ function fakeGh({ source = metadata(), target = metadata({ url: TARGET_URL, numb
       return JSON.stringify({ nameWithOwner: TARGET_REPOSITORY });
     }
     if (args[0] === "issue" && args[1] === "transfer") {
-      transferred = !transferFailure || redirectedAfterTransferFailure;
       if (transferFailure) throw new Error("transfer response lost");
-      return "";
+      return transferOutput;
     }
     if (args[0] === "api" && args.at(-1).includes("/assignees/")) {
       if (args.at(-1).endsWith(`/${encodeURIComponent(unassignableLogin)}`)) throw new Error("not assignable");
@@ -57,10 +55,6 @@ function fakeGh({ source = metadata(), target = metadata({ url: TARGET_URL, numb
     }
     if (args[0] === "api" && args.includes("--paginate")) {
       return JSON.stringify([args.at(-1).includes("labels") ? target.labels.nodes : (target.milestone === null ? [] : [{ title: target.milestone.title, due_on: target.milestone.dueOn }])]);
-    }
-    if (args[0] === "api" && args.at(-1) === `/repos/${SOURCE_REPOSITORY}/issues/${SOURCE_ISSUE}`) {
-      if (!transferred) throw new Error("redirect requested before transfer");
-      return JSON.stringify({ html_url: TARGET_URL, number: 7, repository_url: `https://api.github.com/repos/${TARGET_REPOSITORY}` });
     }
     if (args[0] === "api" && args[1] === "graphql") {
       const issue = args.includes(`name=${TARGET_REPOSITORY.split("/")[1]}`) ? target : source;
@@ -90,6 +84,10 @@ test("argument parser accepts exactly one source issue and one mode", () => {
   assert.throws(
     () => parseArguments(["--ledger", "ledger.json", "--source-issue", "2684", "--source-issue", "2685", "--dry-run"]),
     /exactly one --source-issue/,
+  );
+  assert.deepEqual(
+    parseArguments(["--ledger", "ledger.json", "--source-issue", "2684", "--verify-transfer", TARGET_URL]),
+    { ledgerPath: "ledger.json", sourceIssue: 2684, mode: "verify-transfer", targetUrl: TARGET_URL, confirmations: { source: undefined, target: undefined } },
   );
 });
 
@@ -232,22 +230,21 @@ test("completed transfer with failed verification reports a partial-success erro
   assert.equal(transferCalls(fake.calls).length, 1);
 });
 
-test("lost transfer response follows a confirmed redirect through verification", async () => {
+test("an already transferred issue can be recovery-verified without another transfer", async () => {
   const { ledger, schema } = migrationContract();
   const entry = ledger.issues.find(({ sourceIssue }) => sourceIssue === SOURCE_ISSUE);
   entry.executionApproval = "https://github.com/AquilaXk/easysubway/issues/2691#issuecomment-1";
-  const fake = fakeGh({ transferFailure: true, redirectedAfterTransferFailure: true });
+  const fake = fakeGh();
 
   const verified = await runMigration({
-    arguments_: { sourceIssue: SOURCE_ISSUE, mode: "execute", confirmations: { source: `${SOURCE_REPOSITORY}#${SOURCE_ISSUE}`, target: TARGET_REPOSITORY } },
+    arguments_: { sourceIssue: SOURCE_ISSUE, mode: "verify-transfer", targetUrl: TARGET_URL, confirmations: { source: undefined, target: undefined } },
     ledger,
     schema,
     execGh: fake.execGh,
   });
 
   assert.equal(verified.targetUrl, TARGET_URL);
-  assert.equal(transferCalls(fake.calls).length, 1);
-  assert.equal(fake.calls.filter((args) => args.at(-1) === `/repos/${SOURCE_REPOSITORY}/issues/${SOURCE_ISSUE}`).length, 1);
+  assert.equal(transferCalls(fake.calls).length, 0);
 });
 
 test("unconfirmed transfer response reports an indeterminate result", async () => {
@@ -255,6 +252,25 @@ test("unconfirmed transfer response reports an indeterminate result", async () =
   const entry = ledger.issues.find(({ sourceIssue }) => sourceIssue === SOURCE_ISSUE);
   entry.executionApproval = "https://github.com/AquilaXk/easysubway/issues/2691#issuecomment-1";
   const fake = fakeGh({ transferFailure: true });
+
+  await assert.rejects(
+    () => runMigration({
+      arguments_: { sourceIssue: SOURCE_ISSUE, mode: "execute", confirmations: { source: `${SOURCE_REPOSITORY}#${SOURCE_ISSUE}`, target: TARGET_REPOSITORY } },
+      ledger,
+      schema,
+      execGh: fake.execGh,
+    }),
+    (error) => error.message.includes("indeterminate") && error.transferIndeterminate === true,
+  );
+  assert.equal(transferCalls(fake.calls).length, 1);
+  assert.equal(fake.calls.some((args) => args.at(-1) === `/repos/${SOURCE_REPOSITORY}/issues/${SOURCE_ISSUE}`), false);
+});
+
+test("malformed successful transfer output reports an indeterminate result", async () => {
+  const { ledger, schema } = migrationContract();
+  const entry = ledger.issues.find(({ sourceIssue }) => sourceIssue === SOURCE_ISSUE);
+  entry.executionApproval = "https://github.com/AquilaXk/easysubway/issues/2691#issuecomment-1";
+  const fake = fakeGh({ transferOutput: "Transferred\n" });
 
   await assert.rejects(
     () => runMigration({


### PR DESCRIPTION
## 관련 이슈

Refs #2705

## 작업 배경

`gh issue transfer`는 성공 시 target issue URL을 stdout으로 반환하지만 migration tool은 이를 버리고 old source REST URL의 redirect representation을 가정했다. 실제 #2138 transfer는 완료됐으나 post-transfer verification만 실패했다.

## 작업 내용

- `gh issue transfer` stdout의 정확한 target repository/issue URL을 검증 입력으로 사용한다.
- 응답이 유실되거나 malformed이면 재실행하지 않고 indeterminate로 fail closed한다.

## 검증

- `node --test tools/repo/migrate-issue.test.mjs` — 42 pass
- `git diff --check` — pass

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| transfer URL 및 recovery contract | Node.js | focused test | PR CI와 위 로컬 명령 | 통과 |
| UI·접근성·수동 QA | 해당 없음 | migration CLI 변경 | UI surface 없음 | 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 성공 stdout URL을 trust boundary에서 exact target으로 제한하고, 불명확한 결과는 retry하지 않는지 확인한다.

## 리스크

- GitHub CLI 출력 계약이 바뀌면 transfer 이후 indeterminate로 중단된다. 정확한 target issue를 별도로 확인하기 전에는 execute를 재시도하지 않는다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향 없음.
