### PR TITLE
[Fix] issue transfer metadata 전파 재검증

### DIFF
--- a/tools/repo/migrate-issue.mjs
+++ b/tools/repo/migrate-issue.mjs
@@ -1,5 +1,6 @@
 import { execFile } from "node:child_process";
 import { readFile } from "node:fs/promises";
+import { setTimeout as delay } from "node:timers/promises";
 import { promisify } from "node:util";
 import { validateLedger } from "./issue-migration-ledger.mjs";
 import { validateSchema } from "../ci/lib/json-schema-lite.mjs";
@@ -68,7 +69,7 @@ export function validateMigrationLedger({ ledger, schema }) {
   return [...schemaErrors, ...validateLedger(ledger)];
 }
 
-export async function runMigration({ arguments_, ledger, schema, execGh }) {
+export async function runMigration({ arguments_, ledger, schema, execGh, retryDelayMs = 0 }) {
   if (validateMigrationLedger({ ledger, schema }).length !== 0) throw new Error("ledger validation failed");
   const entry = ledger.issues.find(({ sourceIssue }) => sourceIssue === arguments_.sourceIssue);
   if (!entry) throw new Error("source issue is not in the ledger");
@@ -79,7 +80,7 @@ export async function runMigration({ arguments_, ledger, schema, execGh }) {
     execGh,
   });
   try {
-    return await verifyTransferredIssue({ entry, transferResult, execGh });
+    return await verifyTransferredIssue({ entry, transferResult, execGh, retryDelayMs });
   } catch (error) {
     const partialFailure = new Error(`issue transfer completed but post-transfer verification failed: ${error instanceof Error ? error.message : String(error)}`);
     partialFailure.transferCompleted = true;
@@ -111,25 +112,34 @@ export async function executeIssueTransfer({ entry, confirmations, execGh }) {
   }
 }
 
-export async function verifyTransferredIssue({ entry, transferResult, execGh }) {
+export async function verifyTransferredIssue({ entry, transferResult, execGh, retryDelayMs = 0 }) {
   const targetUrl = transferResult?.redirectedIssue;
   if (!targetUrl) throw new Error("transferred issue identity is missing");
-  const target = await readIssueMetadata(targetUrl.repository, targetUrl.number, execGh);
   const expected = transferResult?.expectedMetadata;
-  if (target.number !== targetUrl.number || target.url !== `https://github.com/${targetUrl.repository}/issues/${targetUrl.number}`) {
-    throw new Error("redirect target metadata is stale");
+  let verificationError;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      const target = await readIssueMetadata(targetUrl.repository, targetUrl.number, execGh);
+      if (target.number !== targetUrl.number || target.url !== `https://github.com/${targetUrl.repository}/issues/${targetUrl.number}`) {
+        throw new Error("redirect target metadata is stale");
+      }
+      if (!expected || !sameMetadata(expected, target)) throw new Error("transferred issue metadata does not match source");
+      return {
+        sourceUrl: entry.sourceUrl,
+        targetUrl: target.url,
+        number: target.number,
+        title: target.title,
+        state: target.state,
+        labelCount: target.labels.length,
+        milestone: target.milestone?.title ?? null,
+        commentCount: target.commentCount,
+      };
+    } catch (error) {
+      verificationError = error;
+      if (attempt < 2) await delay(retryDelayMs);
+    }
   }
-  if (!expected || !sameMetadata(expected, target)) throw new Error("transferred issue metadata does not match source");
-  return {
-    sourceUrl: entry.sourceUrl,
-    targetUrl: target.url,
-    number: target.number,
-    title: target.title,
-    state: target.state,
-    labelCount: target.labels.length,
-    milestone: target.milestone?.title ?? null,
-    commentCount: target.commentCount,
-  };
+  throw verificationError;
 }
 
 async function preflightDetails({ entry, execGh }) {
@@ -322,6 +332,7 @@ async function main() {
       ledger: JSON.parse(ledgerText),
       schema: JSON.parse(schemaText),
       execGh,
+      retryDelayMs: 1_000,
     })));
   } catch (error) {
     if (error?.transferCompleted === true || error?.transferIndeterminate === true) console.error(error.message);

--- a/tools/repo/migrate-issue.test.mjs
+++ b/tools/repo/migrate-issue.test.mjs
@@ -36,8 +36,9 @@ function metadata({ url = SOURCE_URL, number = SOURCE_ISSUE, title, state = "OPE
   return { id: `I_${number}`, url, number, title: title ?? transferEntry().title, state, repository: { nameWithOwner: repo }, labels: connection(labels.map((name) => ({ name }))), milestone: milestone === null ? null : { title: milestone, dueOn: null }, comments: { totalCount: commentCount }, assignees: connection([]), projectItems: connection([]), parent: null, subIssues: connection([]), blocking: connection([]), blockedBy: connection([]), closedByPullRequestsReferences: connection(closingPullRequests) };
 }
 
-function fakeGh({ source = metadata(), target = metadata({ url: TARGET_URL, number: 7 }), targetExists = true, unassignableLogin, malformedAssigneeResponse, transferFailure = false, transferOutput = `${TARGET_URL}\n` } = {}) {
+function fakeGh({ source = metadata(), target = metadata({ url: TARGET_URL, number: 7 }), targetResponses, targetExists = true, unassignableLogin, malformedAssigneeResponse, transferFailure = false, transferOutput = `${TARGET_URL}\n` } = {}) {
   const calls = [];
+  let targetReadCount = 0;
   const execGh = async (args) => {
     calls.push(args);
     if (args[0] === "repo" && args[1] === "view") {
@@ -57,7 +58,9 @@ function fakeGh({ source = metadata(), target = metadata({ url: TARGET_URL, numb
       return JSON.stringify([args.at(-1).includes("labels") ? target.labels.nodes : (target.milestone === null ? [] : [{ title: target.milestone.title, due_on: target.milestone.dueOn }])]);
     }
     if (args[0] === "api" && args[1] === "graphql") {
-      const issue = args.includes(`name=${TARGET_REPOSITORY.split("/")[1]}`) ? target : source;
+      const issue = args.includes(`name=${TARGET_REPOSITORY.split("/")[1]}`)
+        ? (targetResponses?.[Math.min(targetReadCount++, targetResponses.length - 1)] ?? target)
+        : source;
       return JSON.stringify({ data: { repository: { issue } } });
     }
     throw new Error(`unexpected gh invocation: ${args.join(" ")}`);
@@ -224,6 +227,25 @@ test("completed transfer with failed verification reports a partial-success erro
       && error.transferCompleted === true,
   );
   assert.equal(transferCalls(fake.calls).length, 1);
+});
+
+test("post-transfer verification retries temporary target metadata propagation lag", async () => {
+  const { ledger, schema } = migrationContract();
+  const entry = ledger.issues.find(({ sourceIssue }) => sourceIssue === SOURCE_ISSUE);
+  entry.executionApproval = "https://github.com/AquilaXk/easysubway/issues/2691#issuecomment-1";
+  const target = metadata({ url: TARGET_URL, number: 7 });
+  const fake = fakeGh({ target, targetResponses: [{ ...target, comments: { totalCount: 0 } }, target] });
+
+  const verified = await runMigration({
+    arguments_: { sourceIssue: SOURCE_ISSUE, mode: "execute", confirmations: { source: `${SOURCE_REPOSITORY}#${SOURCE_ISSUE}`, target: TARGET_REPOSITORY } },
+    ledger,
+    schema,
+    execGh: fake.execGh,
+    retryDelayMs: 0,
+  });
+
+  assert.equal(verified.targetUrl, TARGET_URL);
+  assert.equal(fake.calls.filter((args) => args[0] === "api" && args[1] === "graphql" && args.includes("name=easysubway-data")).length, 2);
 });
 
 test("unconfirmed transfer response reports an indeterminate result", async () => {


### PR DESCRIPTION
## 관련 이슈

Refs #2705

## 작업 배경

`gh issue transfer` 직후 target issue URL은 확정되지만 sub-issue 등 relation metadata 전파가 늦을 수 있다. #2523 transfer에서 첫 equality check는 실패했으나 잠시 뒤 target #4의 7개 sub-issue 관계와 old URL redirect가 정상 확인됐다.

## 작업 내용

- post-transfer target metadata를 최대 3회 조회한다.
- 실제 CLI는 조회 사이에 1초만 기다리고, 3회 뒤에도 불일치하면 기존처럼 partial failure로 중단한다.
- 테스트는 delay 0으로 stale 첫 응답 뒤 완성된 두 번째 응답을 검증한다.

## 검증

- `node --test tools/repo/migrate-issue.test.mjs` — 43 pass
- `git diff --check` — pass

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| relation propagation retry | Node.js | focused test | stale→complete fixture | 통과 |
| 실제 propagation | GitHub | #2523 old URL 및 target #4 relation 조회 | 302 redirect, 7 sub-issues | 확인 |
| UI·접근성·수동 QA | 해당 없음 | migration CLI 변경 | UI surface 없음 | 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: retry가 post-transfer target read에만 제한되고 횟수·간격이 고정됐는지 확인한다.

## 리스크

- 2초 안에 metadata가 완성되지 않으면 안전하게 partial failure로 남는다. execute 재시도는 금지한다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향 없음.
