### PR TITLE
[Chore] 이슈 이전 evidence 파일 권한 제한

### DIFF
--- a/tools/repo/migrate-issue.mjs
+++ b/tools/repo/migrate-issue.mjs
@@ -409,7 +409,7 @@ async function writeEvidenceAtomically(context, filename, value) {
   const temporary = join(context.canonicalPath, `.${filename}.tmp`);
   const expectedBytes = Buffer.from(`${JSON.stringify(value)}\n`);
   try {
-    const temporaryFd = openSync(temporary, "wx");
+    const temporaryFd = openSync(temporary, "wx", 0o600);
     try { writeFileSync(temporaryFd, expectedBytes); fsyncSync(temporaryFd); } finally { closeSync(temporaryFd); }
     linkSync(temporary, destination);
     unlinkSync(temporary);

--- a/tools/repo/migrate-issue.test.mjs
+++ b/tools/repo/migrate-issue.test.mjs
@@ -180,7 +180,7 @@ test("concurrent execute migrations claim one evidence directory before prefligh
   } finally { rmSync(directory, { recursive: true, force: true }); }
 });
 
-test("execute claim is a regular file", async () => {
+test("execute evidence files are regular and private", async () => {
   const directory = evidenceDirectory();
   const fake = fakeGh();
   const { ledger, schema } = migrationContract();
@@ -189,7 +189,11 @@ test("execute claim is a regular file", async () => {
     await runMigration({
       arguments_: { sourceIssue: SOURCE_ISSUE, mode: "execute", confirmations: { source: `${SOURCE_REPOSITORY}#${SOURCE_ISSUE}`, target: TARGET_REPOSITORY }, evidenceDir: directory }, ledger, schema, execGh: fake.execGh,
     });
-    assert.equal(lstatSync(join(directory, ".migration-claim")).isFile(), true);
+    for (const filename of [".migration-claim", `${SOURCE_ISSUE}-preflight.json`, `${SOURCE_ISSUE}-postflight-1.json`]) {
+      const stat = lstatSync(join(directory, filename));
+      assert.equal(stat.isFile(), true);
+      assert.equal(stat.mode & 0o777, 0o600);
+    }
   } finally { rmSync(directory, { recursive: true, force: true }); }
 });
 


### PR DESCRIPTION
## 관련 이슈

close #2724

Refs #2718

## 작업 배경

- Task9 선행 PR #2721은 merge됐지만, 병합 뒤 current-head Review `4828245883`에서 evidence JSON이 기본 mode로 생성돼 metadata가 0644로 노출될 수 있는 문제가 확인됐다.
- 원 PR branch는 coordinator가 삭제한 뒤 fix push로 재생성됐으므로, 최신 main 기반 follow-up PR에서 검증된 최소 변경만 전달한다.

## 작업 내용

- evidence temporary JSON 생성 시 mode `0600`을 명시했다.
- 기존 성공 경로 test가 `.migration-claim`, preflight JSON, postflight JSON 모두 regular file이며 `0600`인지 검증하도록 보강했다.
- issue transfer, evidence payload, retry, atomic hard-link publish 동작은 변경하지 않았다.

## 검증

- 실행한 명령과 결과:
  - RED `node --test tools/repo/migrate-issue.test.mjs`: 64/65 통과, JSON mode `0644`(420)와 기대 `0600`(384) 차이로 새 assertion 실패
  - GREEN `node --test tools/repo/migrate-issue.test.mjs`: 65/65 통과
  - `git diff --exit-code 9d082af8 HEAD -- tools/repo/migrate-issue.mjs tools/repo/migrate-issue.test.mjs`: 통과, 검증된 fix와 byte-for-byte 동일
  - `git diff --check origin/main...HEAD`: 통과

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| evidence 파일 권한 | Node.js/macOS | focused test에서 claim/preflight/postflight mode 확인 | 65/65 test 출력, Review `4828245883` | 통과 |
| UI·접근성·배포 | 해당 없음 | 제품 코드·workflow·배포 변경 없음 | 2파일 최소 diff | 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `openSync(temporary, "wx", 0o600)`이 기존 atomic publish를 유지하는지와 test가 claim/preflight/postflight 세 파일을 모두 검증하는지 확인한다.

## 리스크

- 파일 생성 mode 1개만 제한하는 최소 diff다. 기존 evidence directory/identity 검사, payload, transfer 동작은 그대로다.
- 원 PR merge 뒤 발견된 finding이므로 이 PR merge 및 최신 main 검증 전에는 Task9 issue transfer를 재개하지 않는다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. 배포 영향 없음.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **보안 개선**
  * 실행 증거 파일이 소유자만 읽고 쓸 수 있는 권한(0600)으로 생성되도록 개선했습니다.

* **검증 강화**
  * 사전·사후 실행 증거 파일에도 일반 파일 여부와 권한 검증을 적용했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->