### PR TITLE
[Fix] production datapack 테스트 clock 결정성 복구

### DIFF
--- a/tools/ci/datapack-release-workflow.test.mjs
+++ b/tools/ci/datapack-release-workflow.test.mjs
@@ -7,6 +7,10 @@ import path from "node:path";
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const yml = readFileSync(path.join(root, ".github/workflows/datapack-release.yml"), "utf8");
 
+test("production release workflow는 test fixture clock을 사용하지 않는다", () => {
+  assert.doesNotMatch(yml, /EASYSUBWAY_DATAPACK_BUILD_NOW/);
+});
+
 test("product datapack 정책 변경은 release workflow를 실행한다", () => {
   assert.match(yml, /paths:[\s\S]*release\/product-gates\/datapack-freshness-sla\.json/);
   assert.match(yml, /paths:[\s\S]*release\/product-gates\/production-datapack-scope\.json/);

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -187,6 +187,11 @@ const productionEnv = {
   EASYSUBWAY_DATAPACK_SIGNING_PUBLIC_KEY_PEM: testPublicKeyPem,
   EASYSUBWAY_DATAPACK_PRODUCTION_FIXTURE_VALIDATION_ONLY: "true",
 };
+const candidateReplayEnv = {
+  ...productionEnv,
+  // ponytail: committed fixture replay clock; release workflow keeps actual time.
+  EASYSUBWAY_DATAPACK_BUILD_NOW: "2026-07-30T00:00:00.000Z",
+};
 
 test("데이터팩 생성기는 TEST_ONLY admission fixture를 build input으로 거부한다", async (context) => {
   const outputDir = await mkdtemp(path.join(tmpdir(), "easysubway-itx-test-only-"));
@@ -17966,7 +17971,7 @@ test("official OD fare release candidate는 승인된 두 방향 quote와 proven
     await execFileAsync(
       process.execPath,
       ["tools/datapack/build-datapack.mjs", "--build-spec", "tools/datapack/release/candidate-build-spec.json", "--output", outputDir],
-      { cwd: root, env: productionEnv },
+      { cwd: root, env: candidateReplayEnv },
     );
     const database = new DatabaseSync(path.join(outputDir, "catalog/capital-v1.sqlite"));
     let rows;
@@ -18019,7 +18024,7 @@ test("official OD fare release candidate는 승인 quote 순서에 의존하지 
       "tools/datapack/build-datapack.mjs",
       "--build-spec", buildSpecPath,
       "--output", path.join(workspace, "output"),
-    ], { cwd: root, env: productionEnv });
+    ], { cwd: root, env: candidateReplayEnv });
   } finally {
     await rm(workspace, { recursive: true, force: true });
   }
@@ -18088,7 +18093,7 @@ test("official OD fare release candidate는 admission과 다른 quote set eviden
       execFileAsync(
         process.execPath,
         ["tools/datapack/build-datapack.mjs", "--build-spec", buildSpecPath, "--output", path.join(workspace, "output")],
-        { cwd: root, env: productionEnv },
+        { cwd: root, env: candidateReplayEnv },
       ),
       /officialOdFareEvidence.quoteSetHash must match admission/,
     );

--- a/tools/datapack/nationwide-candidate-coverage-gate.test.mjs
+++ b/tools/datapack/nationwide-candidate-coverage-gate.test.mjs
@@ -597,7 +597,11 @@ test("커밋된 candidate 게이트 evidence는 현행 입력에서 바이트 �
       "--resolution-plan", RESOLUTION_PLAN_PATH,
       "--resolutions", RESOLUTIONS_PATH,
       "--output", output,
-    ], { cwd: root });
+    ], {
+      cwd: root,
+      // ponytail: committed fixture replay clock; release workflow keeps actual time.
+      env: { ...process.env, EASYSUBWAY_DATAPACK_BUILD_NOW: "2026-07-30T00:00:00.000Z" },
+    });
 
     const regenerated = await readFile(output, "utf8");
     const tracked = await readFile(path.join(root, EVIDENCE_PATH), "utf8");

--- a/tools/datapack/verify-production-pack-artifact-identity.test.mjs
+++ b/tools/datapack/verify-production-pack-artifact-identity.test.mjs
@@ -13,6 +13,8 @@ import { verifyProductionPackArtifactIdentity } from "./verify-production-pack-a
 
 const execFileAsync = promisify(execFile);
 const root = path.resolve(import.meta.dirname, "../..");
+// ponytail: committed fixture replay clock; release workflow keeps actual time.
+process.env.EASYSUBWAY_DATAPACK_BUILD_NOW = "2026-07-30T00:00:00.000Z";
 const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
 const env = {
   ...process.env,


### PR DESCRIPTION
## 관련 이슈

Closes #2752

## 작업 배경

- committed production candidate 재생 테스트가 실제 wall clock을 사용해 fixture 만료 뒤 목적 assertion보다 먼저 freshness 오류로 실패했습니다.
- 실제 release workflow는 actual time에서 계속 fail-closed해야 하므로 test harness만 결정적으로 고정합니다.

## 작업 내용

- affected official OD fare fixture 3개 build에만 `2026-07-30T00:00:00.000Z` replay clock을 주입했습니다.
- production artifact identity와 nationwide evidence 재생 test process에 같은 test-owned clock을 주입했습니다.
- Data Pack Release workflow에 clock override가 들어오면 실패하는 contract test를 추가했습니다.
- production builder, candidate/evidence bytes, `freshUntil`, release workflow는 변경하지 않았습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern='production build와 bundled asset/index|network edge evidence는' tools/datapack/verify-production-pack-artifact-identity.test.mjs` → 2/2 PASS
  - `node --test --test-name-pattern='official OD fare release candidate' tools/datapack/datapack-tools.test.mjs` → 3/3 PASS
  - `node --test --test-name-pattern='커밋된 candidate 게이트 evidence' tools/datapack/nationwide-candidate-coverage-gate.test.mjs` → PASS
  - `node --test --test-name-pattern='test fixture clock' tools/ci/datapack-release-workflow.test.mjs` → 1/1 PASS
  - `git diff --check` → PASS

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| actual-clock RED | Hub CI | 기존 production identity focused test | https://github.com/AquilaXk/easysubway/actions/runs/30908144348/job/91988097260 | FAIL 재현 |
| affected matrix | Node test harness | test-owned clock에서 2+3+1 및 workflow contract 실행 | 위 검증 명령 | PASS |
| runtime·release 무변경 | Hub | changed file 및 production path diff 확인 | test 파일 4개만 변경 | PASS |
| UI·접근성 | 해당 없음 | runtime/UI diff 없음 | test harness 전용 변경 | 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: clock이 test process와 affected fixture replay 3곳에만 한정되고 `.github/workflows/datapack-release.yml`에는 주입되지 않는지 확인해 주세요.

## 리스크

- 고정 clock의 범위가 넓으면 actual-clock regression을 숨길 수 있어 affected call과 committed fixture 재생 test 파일에만 제한했습니다.
- release workflow override 0 contract로 production freshness 완화를 막습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * 후보 릴리스와 프로덕션 데이터팩의 재현성 검증을 강화했습니다.
  * 고정된 기준 시각과 저장소 환경에서 증거 및 아티팩트를 재생성하도록 테스트를 개선했습니다.
  * 프로덕션 릴리스 검증이 테스트 전용 시간 설정에 의존하지 않는지 확인하는 검사를 추가했습니다.
  * 이를 통해 릴리스 결과와 검증 절차의 일관성 및 신뢰성이 향상됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->