### PR TITLE
[Docs] ADR successor decision schema 분리

### DIFF
--- a/contracts/documentation/ADR-HUB-0001-decision.schema.json
+++ b/contracts/documentation/ADR-HUB-0001-decision.schema.json
@@ -1,0 +1,262 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "easysubway/contracts/documentation/ADR-HUB-0001-decision",
+  "title": "ADR-HUB-0001 decision policy",
+  "type": "object",
+  "required": [
+    "trackedHumanDocumentFormat",
+    "durableMachineFormat",
+    "humanReviewSurfaces",
+    "artifactKinds",
+    "repositoryOwners",
+    "lifecycle",
+    "contentBoundary",
+    "hubCatalog",
+    "sensitiveEvidence",
+    "childIssuePolicy",
+    "changeGrades",
+    "implementationFallbackAllowed"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "trackedHumanDocumentFormat": {
+      "const": "NONE"
+    },
+    "durableMachineFormat": {
+      "const": "JSON"
+    },
+    "humanReviewSurfaces": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "github-issue",
+          "github-pr-review"
+        ]
+      }
+    },
+    "artifactKinds": {
+      "type": "array",
+      "minItems": 8,
+      "maxItems": 8,
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "ADR",
+          "DESIGN",
+          "RUNBOOK",
+          "PLAYBOOK",
+          "POLICY",
+          "GATE",
+          "EVIDENCE",
+          "PIR"
+        ]
+      }
+    },
+    "repositoryOwners": {
+      "type": "object",
+      "required": [
+        "hub",
+        "data",
+        "backend",
+        "mobile",
+        "platform"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "hub": {
+          "const": "AquilaXk/easysubway"
+        },
+        "data": {
+          "const": "AquilaXk/easysubway-data"
+        },
+        "backend": {
+          "const": "AquilaXk/easysubway-backend"
+        },
+        "mobile": {
+          "const": "AquilaXk/easysubway-mobile"
+        },
+        "platform": {
+          "const": "AquilaXk/easysubway-platform"
+        }
+      }
+    },
+    "lifecycle": {
+      "type": "object",
+      "required": [
+        "adrStatuses",
+        "operationalStatuses",
+        "acceptedMutationPolicy",
+        "identifierReuseAllowed"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "adrStatuses": {
+          "type": "array",
+          "minItems": 5,
+          "maxItems": 5,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "proposed",
+              "accepted",
+              "rejected",
+              "withdrawn",
+              "superseded"
+            ]
+          }
+        },
+        "operationalStatuses": {
+          "type": "array",
+          "minItems": 4,
+          "maxItems": 4,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "draft",
+              "active",
+              "deprecated",
+              "retired"
+            ]
+          }
+        },
+        "acceptedMutationPolicy": {
+          "const": "SUPERSEDE_ONLY"
+        },
+        "identifierReuseAllowed": {
+          "const": false
+        }
+      }
+    },
+    "contentBoundary": {
+      "type": "object",
+      "required": [
+        "humanJudgment",
+        "machineContract",
+        "executableProcedure",
+        "gate",
+        "evidence"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "humanJudgment": {
+          "const": "GITHUB_ISSUE_AND_PR_REVIEW"
+        },
+        "machineContract": {
+          "const": "VERSIONED_JSON"
+        },
+        "executableProcedure": {
+          "const": "TRACKED_SCRIPT_OR_WORKFLOW"
+        },
+        "gate": {
+          "const": "MACHINE_DECISION_JSON"
+        },
+        "evidence": {
+          "const": "IMMUTABLE_RESULT_OR_DIGEST_REFERENCE"
+        }
+      }
+    },
+    "hubCatalog": {
+      "type": "object",
+      "required": [
+        "targetContentReplicationAllowed",
+        "navigationReference",
+        "releaseBinding"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "targetContentReplicationAllowed": {
+          "const": false
+        },
+        "navigationReference": {
+          "const": "REPOSITORY_AND_PATH"
+        },
+        "releaseBinding": {
+          "const": "FULL_SHA_AND_MANIFEST_DIGEST"
+        }
+      }
+    },
+    "sensitiveEvidence": {
+      "type": "object",
+      "required": [
+        "trackedContentAllowed",
+        "forbiddenClasses"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "trackedContentAllowed": {
+          "const": false
+        },
+        "forbiddenClasses": {
+          "type": "array",
+          "minItems": 5,
+          "maxItems": 5,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "SECRET",
+              "RAW_TOKEN",
+              "PERSONAL_DATA",
+              "PRIVATE_CONTACT",
+              "PRIVATE_ENDPOINT_CREDENTIAL"
+            ]
+          }
+        }
+      }
+    },
+    "childIssuePolicy": {
+      "type": "object",
+      "required": [
+        "firstChildAfter",
+        "inventoryRequiredBefore"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "firstChildAfter": {
+          "const": "ADR_HUB_0001_MERGED"
+        },
+        "inventoryRequiredBefore": {
+          "type": "array",
+          "minItems": 6,
+          "maxItems": 6,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "SCHEMA_CATALOG_BOOTSTRAP",
+              "ADR_MIGRATION",
+              "OPERATIONAL_MIGRATION",
+              "ALERT_GATE_EVIDENCE_BINDING",
+              "DRILL_AND_PIR",
+              "DUPLICATE_HANDOFF"
+            ]
+          }
+        }
+      }
+    },
+    "changeGrades": {
+      "type": "object",
+      "required": [
+        "A",
+        "B",
+        "C"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "A": {
+          "const": "FULL_ADR_AND_OPERATIONAL_IMPACT"
+        },
+        "B": {
+          "const": "ADR_WHEN_ARCHITECTURALLY_SIGNIFICANT"
+        },
+        "C": {
+          "const": "NO_ADR"
+        }
+      }
+    },
+    "implementationFallbackAllowed": {
+      "const": false
+    }
+  }
+}

--- a/contracts/documentation/ADR-HUB-0001.json
+++ b/contracts/documentation/ADR-HUB-0001.json
@@ -85,6 +85,7 @@
       "risks": ["issue 편집으로 accepted decision의 의미가 조용히 바뀔 수 있다."]
     }
   ],
+  "decisionSchema": "./ADR-HUB-0001-decision.schema.json",
   "decision": {
     "trackedHumanDocumentFormat": "NONE",
     "durableMachineFormat": "JSON",

--- a/contracts/documentation/architecture-decision.schema.json
+++ b/contracts/documentation/architecture-decision.schema.json
@@ -19,6 +19,7 @@
     "context",
     "decisionDrivers",
     "consideredOptions",
+    "decisionSchema",
     "decision",
     "consequences",
     "operationalImpact",
@@ -123,159 +124,11 @@
         }
       }
     },
-    "decision": {
-      "type": "object",
-      "required": [
-        "trackedHumanDocumentFormat",
-        "durableMachineFormat",
-        "humanReviewSurfaces",
-        "artifactKinds",
-        "repositoryOwners",
-        "lifecycle",
-        "contentBoundary",
-        "hubCatalog",
-        "sensitiveEvidence",
-        "childIssuePolicy",
-        "changeGrades",
-        "implementationFallbackAllowed"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "trackedHumanDocumentFormat": { "type": "string", "const": "NONE" },
-        "durableMachineFormat": { "type": "string", "const": "JSON" },
-        "humanReviewSurfaces": {
-          "type": "array",
-          "minItems": 2,
-          "maxItems": 2,
-          "uniqueItems": true,
-          "items": { "type": "string", "enum": ["github-issue", "github-pr-review"] }
-        },
-        "artifactKinds": {
-          "type": "array",
-          "minItems": 8,
-          "maxItems": 8,
-          "uniqueItems": true,
-          "items": {
-            "type": "string",
-            "enum": ["ADR", "DESIGN", "RUNBOOK", "PLAYBOOK", "POLICY", "GATE", "EVIDENCE", "PIR"]
-          }
-        },
-        "repositoryOwners": {
-          "type": "object",
-          "required": ["hub", "data", "backend", "mobile", "platform"],
-          "additionalProperties": false,
-          "properties": {
-            "hub": { "type": "string", "const": "AquilaXk/easysubway" },
-            "data": { "type": "string", "const": "AquilaXk/easysubway-data" },
-            "backend": { "type": "string", "const": "AquilaXk/easysubway-backend" },
-            "mobile": { "type": "string", "const": "AquilaXk/easysubway-mobile" },
-            "platform": { "type": "string", "const": "AquilaXk/easysubway-platform" }
-          }
-        },
-        "lifecycle": {
-          "type": "object",
-          "required": ["adrStatuses", "operationalStatuses", "acceptedMutationPolicy", "identifierReuseAllowed"],
-          "additionalProperties": false,
-          "properties": {
-            "adrStatuses": {
-              "type": "array",
-              "minItems": 5,
-              "maxItems": 5,
-              "uniqueItems": true,
-              "items": {
-                "type": "string",
-                "enum": ["proposed", "accepted", "rejected", "withdrawn", "superseded"]
-              }
-            },
-            "operationalStatuses": {
-              "type": "array",
-              "minItems": 4,
-              "maxItems": 4,
-              "uniqueItems": true,
-              "items": { "type": "string", "enum": ["draft", "active", "deprecated", "retired"] }
-            },
-            "acceptedMutationPolicy": { "type": "string", "const": "SUPERSEDE_ONLY" },
-            "identifierReuseAllowed": { "type": "boolean", "const": false }
-          }
-        },
-        "contentBoundary": {
-          "type": "object",
-          "required": ["humanJudgment", "machineContract", "executableProcedure", "gate", "evidence"],
-          "additionalProperties": false,
-          "properties": {
-            "humanJudgment": { "type": "string", "const": "GITHUB_ISSUE_AND_PR_REVIEW" },
-            "machineContract": { "type": "string", "const": "VERSIONED_JSON" },
-            "executableProcedure": { "type": "string", "const": "TRACKED_SCRIPT_OR_WORKFLOW" },
-            "gate": { "type": "string", "const": "MACHINE_DECISION_JSON" },
-            "evidence": { "type": "string", "const": "IMMUTABLE_RESULT_OR_DIGEST_REFERENCE" }
-          }
-        },
-        "hubCatalog": {
-          "type": "object",
-          "required": ["targetContentReplicationAllowed", "navigationReference", "releaseBinding"],
-          "additionalProperties": false,
-          "properties": {
-            "targetContentReplicationAllowed": { "type": "boolean", "const": false },
-            "navigationReference": { "type": "string", "const": "REPOSITORY_AND_PATH" },
-            "releaseBinding": { "type": "string", "const": "FULL_SHA_AND_MANIFEST_DIGEST" }
-          }
-        },
-        "sensitiveEvidence": {
-          "type": "object",
-          "required": ["trackedContentAllowed", "forbiddenClasses"],
-          "additionalProperties": false,
-          "properties": {
-            "trackedContentAllowed": { "type": "boolean", "const": false },
-            "forbiddenClasses": {
-              "type": "array",
-              "minItems": 5,
-              "maxItems": 5,
-              "uniqueItems": true,
-              "items": {
-                "type": "string",
-                "enum": ["SECRET", "RAW_TOKEN", "PERSONAL_DATA", "PRIVATE_CONTACT", "PRIVATE_ENDPOINT_CREDENTIAL"]
-              }
-            }
-          }
-        },
-        "childIssuePolicy": {
-          "type": "object",
-          "required": ["firstChildAfter", "inventoryRequiredBefore"],
-          "additionalProperties": false,
-          "properties": {
-            "firstChildAfter": { "type": "string", "const": "ADR_HUB_0001_MERGED" },
-            "inventoryRequiredBefore": {
-              "type": "array",
-              "minItems": 6,
-              "maxItems": 6,
-              "uniqueItems": true,
-              "items": {
-                "type": "string",
-                "enum": [
-                  "SCHEMA_CATALOG_BOOTSTRAP",
-                  "ADR_MIGRATION",
-                  "OPERATIONAL_MIGRATION",
-                  "ALERT_GATE_EVIDENCE_BINDING",
-                  "DRILL_AND_PIR",
-                  "DUPLICATE_HANDOFF"
-                ]
-              }
-            }
-          }
-        },
-        "changeGrades": {
-          "type": "object",
-          "required": ["A", "B", "C"],
-          "additionalProperties": false,
-          "properties": {
-            "A": { "type": "string", "const": "FULL_ADR_AND_OPERATIONAL_IMPACT" },
-            "B": { "type": "string", "const": "ADR_WHEN_ARCHITECTURALLY_SIGNIFICANT" },
-            "C": { "type": "string", "const": "NO_ADR" }
-          }
-        },
-        "implementationFallbackAllowed": { "type": "boolean", "const": false }
-      }
+    "decisionSchema": {
+      "type": "string",
+      "pattern": "^\\./ADR-HUB-[0-9]{4}-decision\\.schema\\.json$"
     },
+    "decision": { "type": "object" },
     "consequences": {
       "type": "object",
       "required": ["positive", "negative", "neutral", "acceptedDebt"],

--- a/tools/ci/check-contracts.mjs
+++ b/tools/ci/check-contracts.mjs
@@ -303,6 +303,12 @@ function validateArchitectureDecisionSchema(adr, valuePath, errors) {
     errors.push(`${valuePath}: decisionSchema ${reference}: 유효한 JSON이 필요하다`);
     return false;
   }
+  if (schema == null || typeof schema !== "object" || Array.isArray(schema)
+      || schema.type !== "object" || !Array.isArray(schema.required) || schema.required.length === 0
+      || schema.additionalProperties !== false) {
+    errors.push(`${valuePath}: decisionSchema ${reference}: 최상위 object, 비어 있지 않은 required, additionalProperties false가 필요하다`);
+    return false;
+  }
   try {
     const result = validateSchema(schema, adr.decision);
     errors.push(...result.errors.map((error) =>

--- a/tools/ci/check-contracts.mjs
+++ b/tools/ci/check-contracts.mjs
@@ -10,6 +10,7 @@ import { codepointCompare } from "../lib/codepoint-compare.mjs";
 import { isDeepStrictEqual } from "node:util";
 
 const DEFAULT_WORKSPACE_PATH = "contracts/workspaces/hub.json";
+const architectureDecisionSchemaSnapshots = new WeakMap();
 const EXTRACTION_REPOSITORIES = {
   data: "AquilaXk/easysubway-data",
   platform: "AquilaXk/easysubway-platform",
@@ -164,6 +165,20 @@ export function collectContractErrors(
       const transitionErrors = validateArchitectureDecisionTransition(previous, current.adr);
       errors.push(...transitionErrors
         .map((error) => `${current.path}: ${error}`));
+      const previousDecisionSchema = architectureDecisionSchemaSnapshots.get(previous);
+      if (transitionErrors.length === 0 && previous.status !== "proposed"
+        && previousDecisionSchema !== undefined) {
+        let currentDecisionSchema;
+        try {
+          currentDecisionSchema = loadJson(resolve(dirname(current.path), current.adr.decisionSchema));
+        } catch {
+          currentDecisionSchema = undefined;
+        }
+        if (currentDecisionSchema !== undefined
+          && !isDeepStrictEqual(previousDecisionSchema, currentDecisionSchema)) {
+          errors.push(`${current.path}: accepted/terminal ADR decision schema는 in-place 변경할 수 없고 새 ADR로 supersede해야 한다`);
+        }
+      }
       if (transitionErrors.length === 0
         && previous.status === "accepted" && current.adr.status === "superseded") {
         const successors = currentArchitectureDecisionCandidates.get(current.adr.supersededBy) ?? [];
@@ -573,19 +588,35 @@ export function loadArchitectureDecisionAtRef(workspacePath, baseRef) {
     .map((path) => join(directory, path));
   for (const candidatePath of candidatePaths) {
     const namedAdr = /^ADR-[A-Z0-9-]+\.json$/.test(basename(candidatePath));
+    let candidate;
     try {
-      const candidate = loadAtRef(candidatePath, true);
-      const declaredAdr = candidate?.kind === "architecture-decision"
-        || (typeof candidate?.$schema === "string"
-          && basename(candidate.$schema) === "architecture-decision.schema.json");
-      if (candidatePath !== repositoryPath && !namedAdr && !declaredAdr && !/^ADR-/.test(candidate?.id)) continue;
-      if (typeof candidate?.id !== "string") continue;
-      const candidates = candidatesById.get(candidate.id) ?? [];
-      candidates.push(candidate);
-      candidatesById.set(candidate.id, candidates);
+      candidate = loadAtRef(candidatePath, true);
     } catch {
       if (namedAdr) hasMalformedCandidate = true;
+      continue;
     }
+    const declaredAdr = candidate?.kind === "architecture-decision"
+      || (typeof candidate?.$schema === "string"
+        && basename(candidate.$schema) === "architecture-decision.schema.json");
+    if (candidatePath !== repositoryPath && !namedAdr && !declaredAdr && !/^ADR-/.test(candidate?.id)) continue;
+    if (typeof candidate?.id !== "string") continue;
+    if (typeof candidate.decisionSchema === "string") {
+      const expectedReference = `./${candidate.id}-decision.schema.json`;
+      if (candidate.decisionSchema !== expectedReference) {
+        throw new Error(`${baseRef}:${candidatePath}: decisionSchema는 ${expectedReference}여야 한다`);
+      }
+      const decisionSchemaPath = relative(
+        "/",
+        resolve("/", dirname(candidatePath), candidate.decisionSchema),
+      );
+      if (decisionSchemaPath.startsWith("..") || decisionSchemaPath === "") {
+        throw new Error(`${baseRef}:${candidatePath}: decisionSchema 경로는 repository 내부여야 한다`);
+      }
+      architectureDecisionSchemaSnapshots.set(candidate, loadAtRef(decisionSchemaPath, true));
+    }
+    const candidates = candidatesById.get(candidate.id) ?? [];
+    candidates.push(candidate);
+    candidatesById.set(candidate.id, candidates);
   }
   const visited = new Set();
   let current = root;

--- a/tools/ci/check-contracts.mjs
+++ b/tools/ci/check-contracts.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { isMainModule } from "../lib/is-main-module.mjs";
-import { existsSync, readFileSync, readdirSync, realpathSync } from "node:fs";
+import { existsSync, lstatSync, readFileSync, readdirSync, realpathSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { basename, dirname, join, relative, resolve } from "node:path";
 import { validateSourceGovernancePolicy } from "../datapack/source-governance-policy.mjs";
@@ -309,6 +309,10 @@ function validateArchitectureDecisionSchema(adr, valuePath, errors) {
   const schemaPath = resolve(dirname(valuePath), reference);
   if (!existsSync(schemaPath)) {
     errors.push(`${valuePath}: decisionSchema ${reference} 누락`);
+    return false;
+  }
+  if (lstatSync(schemaPath).isSymbolicLink()) {
+    errors.push(`${valuePath}: decisionSchema symlink는 허용하지 않는다`);
     return false;
   }
   if (dirname(realpathSync(schemaPath)) !== realpathSync(dirname(resolve(valuePath)))) {

--- a/tools/ci/check-contracts.mjs
+++ b/tools/ci/check-contracts.mjs
@@ -166,8 +166,10 @@ export function collectContractErrors(
       errors.push(...transitionErrors
         .map((error) => `${current.path}: ${error}`));
       const previousDecisionSchema = architectureDecisionSchemaSnapshots.get(previous);
-      if (transitionErrors.length === 0 && previous.status !== "proposed"
-        && previousDecisionSchema !== undefined) {
+      const finalizingProposal = previous.status === "proposed"
+        && ["accepted", "rejected", "withdrawn"].includes(current.adr.status);
+      if (transitionErrors.length === 0 && previousDecisionSchema !== undefined
+        && (previous.status !== "proposed" || finalizingProposal)) {
         let currentDecisionSchema;
         try {
           currentDecisionSchema = loadJson(resolve(dirname(current.path), current.adr.decisionSchema));
@@ -176,7 +178,9 @@ export function collectContractErrors(
         }
         if (currentDecisionSchema !== undefined
           && !isDeepStrictEqual(previousDecisionSchema, currentDecisionSchema)) {
-          errors.push(`${current.path}: accepted/terminal ADR decision schema는 in-place 변경할 수 없고 새 ADR로 supersede해야 한다`);
+          errors.push(finalizingProposal
+            ? `${current.path}: proposed ADR의 종결 전환은 decision schema도 status-only여야 한다`
+            : `${current.path}: accepted/terminal ADR decision schema는 in-place 변경할 수 없고 새 ADR로 supersede해야 한다`);
         }
       }
       if (transitionErrors.length === 0

--- a/tools/ci/check-contracts.mjs
+++ b/tools/ci/check-contracts.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { isMainModule } from "../lib/is-main-module.mjs";
-import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, realpathSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { basename, dirname, join, relative, resolve } from "node:path";
 import { validateSourceGovernancePolicy } from "../datapack/source-governance-policy.mjs";
@@ -252,9 +252,11 @@ export function validateJson(schemaPath, valuePath, errors) {
   const result = validateSchema(schema, value);
   errors.push(...result.errors.map((error) => `${valuePath}: ${error}`));
   let semanticErrors = [];
+  let referencedSchemaValid = true;
   switch (basename(schemaPath)) {
     case "architecture-decision.schema.json":
-      if (result.errors.length === 0) {
+      referencedSchemaValid = validateArchitectureDecisionSchema(value, valuePath, errors);
+      if (result.errors.length === 0 && referencedSchemaValid) {
         semanticErrors = validateArchitectureDecision(value);
         errors.push(...semanticErrors.map((error) => `${valuePath}: ${error}`));
       }
@@ -271,7 +273,45 @@ export function validateJson(schemaPath, valuePath, errors) {
     default:
       break;
   }
-  return result.errors.length === 0 && semanticErrors.length === 0;
+  return result.errors.length === 0 && referencedSchemaValid && semanticErrors.length === 0;
+}
+
+function validateArchitectureDecisionSchema(adr, valuePath, errors) {
+  const reference = adr?.decisionSchema;
+  if (typeof reference !== "string" || typeof adr?.id !== "string") {
+    errors.push(`${valuePath}: decisionSchema는 repository 내부 상대 JSON path여야 한다`);
+    return false;
+  }
+  const expectedReference = `./${adr.id}-decision.schema.json`;
+  if (reference !== expectedReference) {
+    errors.push(`${valuePath}: decisionSchema는 repository 내부 상대 JSON path ${expectedReference}여야 한다`);
+    return false;
+  }
+  const schemaPath = resolve(dirname(valuePath), reference);
+  if (!existsSync(schemaPath)) {
+    errors.push(`${valuePath}: decisionSchema ${reference} 누락`);
+    return false;
+  }
+  if (dirname(realpathSync(schemaPath)) !== realpathSync(dirname(resolve(valuePath)))) {
+    errors.push(`${valuePath}: decisionSchema는 repository 내부 상대 JSON path여야 한다`);
+    return false;
+  }
+  let schema;
+  try {
+    schema = loadJson(schemaPath);
+  } catch {
+    errors.push(`${valuePath}: decisionSchema ${reference}: 유효한 JSON이 필요하다`);
+    return false;
+  }
+  try {
+    const result = validateSchema(schema, adr.decision);
+    errors.push(...result.errors.map((error) =>
+      `${valuePath}: ${error.replace(/^\$/, "$.decision")}`));
+    return result.errors.length === 0;
+  } catch (error) {
+    errors.push(`${valuePath}: decisionSchema ${reference}: ${error instanceof Error ? error.message : String(error)}`);
+    return false;
+  }
 }
 
 export function validateArchitectureDecision(adr) {
@@ -284,9 +324,20 @@ export function validateArchitectureDecision(adr) {
     mobile: "AquilaXk/easysubway-mobile",
     platform: "AquilaXk/easysubway-platform",
   };
-  for (const [component, repository] of Object.entries(repositoryOwners)) {
-    if (adr.decision?.repositoryOwners?.[component] !== repository) {
-      errors.push(`${component} repository owner는 ${repository}여야 한다`);
+  if (adr.id === "ADR-HUB-0001") {
+    for (const [component, repository] of Object.entries(repositoryOwners)) {
+      if (adr.decision?.repositoryOwners?.[component] !== repository) {
+        errors.push(`${component} repository owner는 ${repository}여야 한다`);
+      }
+    }
+    if (adr.decision?.childIssuePolicy?.firstChildAfter !== "ADR_HUB_0001_MERGED") {
+      errors.push("첫 파생 이슈는 ADR-HUB-0001 병합 뒤에만 만들 수 있다");
+    }
+    if (adr.decision?.sensitiveEvidence?.trackedContentAllowed !== false) {
+      errors.push("sensitiveEvidence.trackedContentAllowed는 false여야 한다");
+    }
+    if (adr.contextIssue !== "https://github.com/AquilaXk/easysubway/issues/2748") {
+      errors.push("ADR-HUB-0001 contextIssue는 Hub #2748이어야 한다");
     }
   }
   if ((Array.isArray(adr.supersedes) && adr.supersedes.includes(adr.id)) || adr.supersededBy === adr.id) {
@@ -297,16 +348,6 @@ export function validateArchitectureDecision(adr) {
   }
   if (adr.status !== "superseded" && adr.supersededBy != null) {
     errors.push("non-superseded 상태의 supersededBy는 null이어야 한다");
-  }
-  if (adr.decision?.childIssuePolicy?.firstChildAfter !== "ADR_HUB_0001_MERGED") {
-    errors.push("첫 파생 이슈는 ADR-HUB-0001 병합 뒤에만 만들 수 있다");
-  }
-  if (adr.decision?.sensitiveEvidence?.trackedContentAllowed !== false) {
-    errors.push("sensitiveEvidence.trackedContentAllowed는 false여야 한다");
-  }
-  if (adr.id === "ADR-HUB-0001"
-    && adr.contextIssue !== "https://github.com/AquilaXk/easysubway/issues/2748") {
-    errors.push("ADR-HUB-0001 contextIssue는 Hub #2748이어야 한다");
   }
   if (Array.isArray(adr.consideredOptions)) {
     const chosenCount = adr.consideredOptions.filter((option) => option?.chosen === true).length;

--- a/tools/ci/check-contracts.test.mjs
+++ b/tools/ci/check-contracts.test.mjs
@@ -45,7 +45,14 @@ function createExternalWorkspace() {
     architectureDecision: "inputs/architecture-decision.json",
   }));
   copy("contracts/documentation/ADR-HUB-0001.json", "inputs/architecture-decision.json");
+  copy("contracts/documentation/ADR-HUB-0001-decision.schema.json", "inputs/ADR-HUB-0001-decision.schema.json");
   return { directory, workspacePath };
+}
+
+function bindRootDecisionSchema(directory, adr) {
+  const schemaName = `${adr.id}-decision.schema.json`;
+  adr.decisionSchema = `./${schemaName}`;
+  cpSync("contracts/documentation/ADR-HUB-0001-decision.schema.json", join(directory, schemaName));
 }
 
 test("[gate-ownership] workspace는 legacy 경로 밖 복사 입력을 검증한다", () => {
@@ -127,27 +134,80 @@ test("문서 거버넌스 계약은 ADR-HUB-0001 실물을 허용한다", () => 
   assert.ok(adr.confirmation.some(({ method }) => method.endsWith("--current-only")));
 });
 
+test("문서 거버넌스 계약은 successor의 자체 decision schema와 안전한 schema path만 허용한다", () => {
+  const { directory, workspacePath } = createExternalWorkspace();
+  try {
+    const rootPath = join(directory, "inputs/architecture-decision.json");
+    const root = loadJson(rootPath);
+    root.status = "superseded";
+    root.supersededBy = "ADR-HUB-0002";
+    writeFileSync(rootPath, JSON.stringify(root));
+
+    const successor = structuredClone(root);
+    successor.id = "ADR-HUB-0002";
+    successor.status = "accepted";
+    successor.supersededBy = null;
+    successor.supersedes = [root.id];
+    successor.decisionSchema = "./ADR-HUB-0002-decision.schema.json";
+    successor.decision = { policy: "successor-specific" };
+    const successorPath = join(directory, "inputs/ADR-HUB-0002.json");
+    const decisionSchemaPath = join(directory, "inputs/ADR-HUB-0002-decision.schema.json");
+    const successorDecisionSchema = {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "required": ["policy"],
+      "additionalProperties": false,
+      "properties": {
+        "policy": { "type": "string", "const": "successor-specific" }
+      }
+    };
+    writeFileSync(decisionSchemaPath, JSON.stringify(successorDecisionSchema));
+    writeFileSync(successorPath, JSON.stringify(successor));
+
+    assert.deepEqual(collectContractErrors(workspacePath), []);
+
+    for (const [name, mutate, expected] of [
+      ["missing-reference", (adr) => { delete adr.decisionSchema; }, "decisionSchema"],
+      ["missing-file", () => { rmSync(decisionSchemaPath); }, "decisionSchema ./ADR-HUB-0002-decision.schema.json 누락"],
+      ["absolute", (adr) => { adr.decisionSchema = "/tmp/decision.schema.json"; }, "repository 내부 상대 JSON path"],
+      ["escape", (adr) => { adr.decisionSchema = "../ADR-HUB-0002-decision.schema.json"; }, "repository 내부 상대 JSON path"],
+      ["malformed", () => { writeFileSync(decisionSchemaPath, "{"); }, "유효한 JSON이 필요하다"],
+      ["invalid", (adr) => { adr.decision.policy = "wrong"; }, "$.decision.policy"],
+    ]) {
+      const candidate = structuredClone(successor);
+      mutate(candidate);
+      writeFileSync(successorPath, JSON.stringify(candidate));
+      const errors = collectContractErrors(workspacePath);
+      assert.ok(errors.some((error) => error.includes("ADR-HUB-0002.json") && error.includes(expected)), name);
+      writeFileSync(decisionSchemaPath, JSON.stringify(successorDecisionSchema));
+    }
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
 test("문서 거버넌스 계약은 대표적인 ADR 계약 위반을 거부한다", () => {
   const directory = mkdtempSync(join(tmpdir(), "architecture-decision-contract-"));
   try {
     const schemaPath = "contracts/documentation/architecture-decision.schema.json";
     const valid = loadJson("contracts/documentation/ADR-HUB-0001.json");
-    for (const [name, mutate] of [
-      ["invalid-id", (adr) => { adr.id = "ADR-DATA-0001"; }],
-      ["invalid-kind", (adr) => { adr.kind = "runbook"; }],
-      ["missing-owner", (adr) => { delete adr.owner; }],
-      ["owner-prefix-mismatch", (adr) => { adr.owner.repository = "AquilaXk/easysubway-data"; }],
-      ["invalid-status", (adr) => { adr.status = "implemented"; }],
-      ["missing-decision", (adr) => { delete adr.decision; }],
-      ["missing-context-issue", (adr) => { delete adr.contextIssue; }],
-      ["wrong-context-issue", (adr) => { adr.contextIssue = "https://github.com/AquilaXk/easysubway/issues/1"; }],
-      ["unknown-field", (adr) => { adr.futureField = true; }],
-      ["target-owner-mismatch", (adr) => { adr.decision.repositoryOwners.data = "AquilaXk/easysubway"; }],
-      ["tracked-sensitive-evidence", (adr) => { adr.decision.sensitiveEvidence.trackedContentAllowed = true; }],
-      ["malformed-supersedes", (adr) => { adr.supersedes = 1; }],
-      ["no-chosen-option", (adr) => { adr.consideredOptions.forEach((option) => { option.chosen = false; }); }],
-      ["multiple-chosen-options", (adr) => { adr.consideredOptions.forEach((option) => { option.chosen = true; }); }],
-      ["duplicate-option-id", (adr) => { adr.consideredOptions[1].id = adr.consideredOptions[0].id; }],
+    cpSync("contracts/documentation/ADR-HUB-0001-decision.schema.json", join(directory, "ADR-HUB-0001-decision.schema.json"));
+    for (const [name, mutate, expected] of [
+      ["invalid-id", (adr) => { adr.id = "ADR-DATA-0001"; }, "$.id: pattern"],
+      ["invalid-kind", (adr) => { adr.kind = "runbook"; }, "$.kind: const"],
+      ["missing-owner", (adr) => { delete adr.owner; }, "$.owner: 필수 필드 누락"],
+      ["owner-prefix-mismatch", (adr) => { adr.owner.repository = "AquilaXk/easysubway-data"; }, "$.owner.repository: const"],
+      ["invalid-status", (adr) => { adr.status = "implemented"; }, "$.status: enum"],
+      ["missing-decision", (adr) => { delete adr.decision; }, "$.decision: 필수 필드 누락"],
+      ["missing-context-issue", (adr) => { delete adr.contextIssue; }, "$.contextIssue: 필수 필드 누락"],
+      ["wrong-context-issue", (adr) => { adr.contextIssue = "https://github.com/AquilaXk/easysubway/issues/1"; }, "ADR-HUB-0001 contextIssue"],
+      ["unknown-field", (adr) => { adr.futureField = true; }, "$.futureField: 허용되지 않은 필드"],
+      ["target-owner-mismatch", (adr) => { adr.decision.repositoryOwners.data = "AquilaXk/easysubway"; }, "$.decision.repositoryOwners.data: const"],
+      ["tracked-sensitive-evidence", (adr) => { adr.decision.sensitiveEvidence.trackedContentAllowed = true; }, "$.decision.sensitiveEvidence.trackedContentAllowed: const"],
+      ["malformed-supersedes", (adr) => { adr.supersedes = 1; }, "$.supersedes: type array"],
+      ["no-chosen-option", (adr) => { adr.consideredOptions.forEach((option) => { option.chosen = false; }); }, "chosen 옵션이 정확히 하나"],
+      ["multiple-chosen-options", (adr) => { adr.consideredOptions.forEach((option) => { option.chosen = true; }); }, "chosen 옵션이 정확히 하나"],
+      ["duplicate-option-id", (adr) => { adr.consideredOptions[1].id = adr.consideredOptions[0].id; }, "id는 유일"],
     ]) {
       const candidate = structuredClone(valid);
       mutate(candidate);
@@ -156,7 +216,7 @@ test("문서 거버넌스 계약은 대표적인 ADR 계약 위반을 거부한�
       const errors = [];
 
       assert.equal(validateJson(schemaPath, candidatePath, errors), false, name);
-      assert.ok(errors.length > 0, `${name} 오류가 필요하다`);
+      assert.ok(errors.some((error) => error.includes(expected)), `${name}: ${expected}`);
     }
   } finally {
     rmSync(directory, { recursive: true, force: true });
@@ -289,6 +349,7 @@ test("문서 거버넌스 계약은 accepted ADR의 supersession successor를 fa
       const successor = structuredClone(previous);
       successor.id = "ADR-HUB-0002";
       successor.supersedes = [previous.id];
+      bindRootDecisionSchema(join(directory, "inputs"), successor);
       prepare(directory, successor);
 
       assert.ok(
@@ -315,6 +376,7 @@ test("문서 거버넌스 계약은 reciprocal successor가 있는 accepted ADR 
     const successor = structuredClone(previous);
     successor.id = "ADR-HUB-0002";
     successor.supersedes = [previous.id];
+    bindRootDecisionSchema(join(directory, "inputs"), successor);
     writeFileSync(join(directory, "inputs/ADR-HUB-0002.json"), JSON.stringify(successor));
     writeFileSync(join(directory, "inputs/unrelated-malformed.json"), "{");
 
@@ -329,6 +391,7 @@ test("문서 거버넌스 계약은 active chain 밖 ADR 후보도 검증한다"
   try {
     const candidate = loadJson(join(directory, "inputs/architecture-decision.json"));
     candidate.id = "ADR-HUB-0002";
+    bindRootDecisionSchema(join(directory, "inputs"), candidate);
     delete candidate.decision;
     writeFileSync(join(directory, "inputs/ADR-HUB-0002.json"), JSON.stringify(candidate));
     const unidentified = loadJson(join(directory, "inputs/architecture-decision.json"));
@@ -336,6 +399,7 @@ test("문서 거버넌스 계약은 active chain 밖 ADR 후보도 검증한다"
     writeFileSync(join(directory, "inputs/candidate.json"), JSON.stringify(unidentified));
     const duplicate = loadJson(join(directory, "inputs/architecture-decision.json"));
     duplicate.id = "ADR-HUB-0003";
+    bindRootDecisionSchema(join(directory, "inputs"), duplicate);
     writeFileSync(join(directory, "inputs/off-chain-a.json"), JSON.stringify(duplicate));
     writeFileSync(join(directory, "inputs/off-chain-b.json"), JSON.stringify(duplicate));
 
@@ -372,6 +436,7 @@ test("문서 거버넌스 계약은 active chain 밖 ADR lifecycle도 fail close
       writeFileSync(rootPath, JSON.stringify(root));
       const previousStandalone = structuredClone(root);
       previousStandalone.id = "ADR-HUB-0004";
+      bindRootDecisionSchema(join(directory, "inputs"), previousStandalone);
       const currentStandalone = structuredClone(previousStandalone);
       currentStandalone.status = "superseded";
       currentStandalone.supersededBy = "ADR-HUB-0005";
@@ -379,6 +444,7 @@ test("문서 거버넌스 계약은 active chain 밖 ADR lifecycle도 fail close
       const successor = structuredClone(root);
       successor.id = "ADR-HUB-0005";
       successor.supersedes = [currentStandalone.id];
+      bindRootDecisionSchema(join(directory, "inputs"), successor);
       prepare(directory, successor);
 
       const errors = collectContractErrors(workspacePath, {
@@ -398,6 +464,7 @@ test("문서 거버넌스 계약은 active chain 밖 ADR lifecycle도 fail close
     writeFileSync(rootPath, JSON.stringify(root));
     const falseClaim = structuredClone(root);
     falseClaim.id = "ADR-HUB-0010";
+    bindRootDecisionSchema(join(currentOnly.directory, "inputs"), falseClaim);
     falseClaim.status = "proposed";
     falseClaim.supersedes = [root.id];
     writeFileSync(join(currentOnly.directory, "inputs/false-claim.json"), JSON.stringify(falseClaim));
@@ -409,6 +476,7 @@ test("문서 거버넌스 계약은 active chain 밖 ADR lifecycle도 fail close
     const successorPath = join(currentOnly.directory, "inputs/off-root-b.json");
     const standalone = structuredClone(root);
     standalone.id = "ADR-HUB-0006";
+    bindRootDecisionSchema(join(currentOnly.directory, "inputs"), standalone);
     standalone.status = "superseded";
     standalone.supersededBy = "ADR-HUB-0007";
     writeFileSync(standalonePath, JSON.stringify(standalone));
@@ -417,6 +485,7 @@ test("문서 거버넌스 계약은 active chain 밖 ADR lifecycle도 fail close
 
     const successor = structuredClone(standalone);
     successor.id = "ADR-HUB-0007";
+    bindRootDecisionSchema(join(currentOnly.directory, "inputs"), successor);
     standalone.supersedes = [successor.id];
     successor.supersededBy = standalone.id;
     successor.supersedes = [standalone.id];
@@ -456,6 +525,7 @@ test("문서 거버넌스 계약은 current-only와 base 비교에서 supersessi
     writeFileSync(decisionPath, JSON.stringify(root));
     const successor = structuredClone(root);
     successor.id = "ADR-HUB-0002";
+    bindRootDecisionSchema(join(directory, "inputs"), successor);
     successor.status = "proposed";
     successor.supersededBy = null;
     successor.supersedes = [root.id];
@@ -471,6 +541,7 @@ test("문서 거버넌스 계약은 current-only와 base 비교에서 supersessi
     writeFileSync(successorPath, JSON.stringify(successor));
     const terminal = structuredClone(successor);
     terminal.id = "ADR-HUB-0003";
+    bindRootDecisionSchema(join(directory, "inputs"), terminal);
     terminal.status = "accepted";
     terminal.supersededBy = null;
     terminal.supersedes = [successor.id];
@@ -535,15 +606,18 @@ test("문서 거버넌스 계약은 base-ref에서 전체 supersession chain을 
   try {
     mkdirSync(join(repository, "docs"), { recursive: true });
     const root = loadJson("contracts/documentation/ADR-HUB-0001.json");
+    bindRootDecisionSchema(join(repository, "docs"), root);
     root.status = "superseded";
     root.supersededBy = "ADR-HUB-0002";
     const intermediate = structuredClone(root);
     intermediate.id = "ADR-HUB-0002";
+    bindRootDecisionSchema(join(repository, "docs"), intermediate);
     intermediate.status = "superseded";
     intermediate.supersededBy = "ADR-HUB-0003";
     intermediate.supersedes = [root.id];
     const terminal = structuredClone(intermediate);
     terminal.id = "ADR-HUB-0003";
+    bindRootDecisionSchema(join(repository, "docs"), terminal);
     terminal.status = "accepted";
     terminal.supersededBy = null;
     terminal.supersedes = [intermediate.id];
@@ -563,6 +637,7 @@ test("문서 거버넌스 계약은 base-ref에서 전체 supersession chain을 
       architectureDecision: "docs/ADR-HUB-0001.json",
     }));
     const rootLevel = structuredClone(root);
+    bindRootDecisionSchema(repository, rootLevel);
     rootLevel.status = "accepted";
     rootLevel.supersededBy = null;
     writeFileSync(join(repository, "ADR-HUB-0001.json"), JSON.stringify(rootLevel));
@@ -571,8 +646,10 @@ test("문서 거버넌스 계약은 base-ref에서 전체 supersession chain을 
     writeFileSync(join(repository, "root-workspace.json"), JSON.stringify(rootWorkspace));
     mkdirSync(join(repository, "staged"));
     const stagedRoot = structuredClone(rootLevel);
+    bindRootDecisionSchema(join(repository, "staged"), stagedRoot);
     const stagedSuccessor = structuredClone(stagedRoot);
     stagedSuccessor.id = "ADR-HUB-0002";
+    bindRootDecisionSchema(join(repository, "staged"), stagedSuccessor);
     stagedSuccessor.status = "proposed";
     stagedSuccessor.title = "base staged successor";
     stagedSuccessor.supersedes = [stagedRoot.id];
@@ -583,6 +660,7 @@ test("문서 거버넌스 계약은 base-ref에서 전체 supersession chain을 
     writeFileSync(join(repository, "staged-workspace.json"), JSON.stringify(stagedWorkspace));
     mkdirSync(join(repository, "malformed"));
     const malformedRoot = structuredClone(root);
+    bindRootDecisionSchema(join(repository, "malformed"), malformedRoot);
     malformedRoot.supersededBy = "ADR-HUB-0099";
     writeFileSync(join(repository, "malformed/ADR-HUB-0001.json"), JSON.stringify(malformedRoot));
     writeFileSync(join(repository, "malformed/ADR-HUB-0099.json"), "{");

--- a/tools/ci/check-contracts.test.mjs
+++ b/tools/ci/check-contracts.test.mjs
@@ -684,6 +684,18 @@ test("문서 거버넌스 계약은 base-ref에서 전체 supersession chain을 
       /successor ADR 판정에 유효한 JSON이 필요하다/,
     );
     const stagedBase = loadArchitectureDecisionAtRef("staged-workspace.json", baseRef);
+    const stagedDecisionSchemaPath = join(repository, "staged/ADR-HUB-0002-decision.schema.json");
+    const stagedDecisionSchema = loadJson(stagedDecisionSchemaPath);
+    stagedDecisionSchema.properties.futureField = { type: "string" };
+    writeFileSync(stagedDecisionSchemaPath, JSON.stringify(stagedDecisionSchema));
+    stagedSuccessor.status = "accepted";
+    writeFileSync(join(repository, "staged/ADR-HUB-0002.json"), JSON.stringify(stagedSuccessor));
+    assert.ok(collectContractErrors("staged-workspace.json", {
+      previousArchitectureDecision: stagedBase,
+    }).some((error) => error.includes("decision schema") && error.includes("status-only")));
+    stagedSuccessor.status = "proposed";
+    delete stagedDecisionSchema.properties.futureField;
+    writeFileSync(stagedDecisionSchemaPath, JSON.stringify(stagedDecisionSchema));
     stagedSuccessor.status = "accepted";
     stagedSuccessor.title = "mutated current successor";
     writeFileSync(join(repository, "staged/ADR-HUB-0002.json"), JSON.stringify(stagedSuccessor));

--- a/tools/ci/check-contracts.test.mjs
+++ b/tools/ci/check-contracts.test.mjs
@@ -172,6 +172,8 @@ test("문서 거버넌스 계약은 successor의 자체 decision schema와 안�
       ["absolute", (adr) => { adr.decisionSchema = "/tmp/decision.schema.json"; }, "repository 내부 상대 JSON path"],
       ["escape", (adr) => { adr.decisionSchema = "../ADR-HUB-0002-decision.schema.json"; }, "repository 내부 상대 JSON path"],
       ["malformed", () => { writeFileSync(decisionSchemaPath, "{"); }, "유효한 JSON이 필요하다"],
+      ["empty-schema", () => { writeFileSync(decisionSchemaPath, "{}"); }, "비어 있지 않은 required"],
+      ["array-schema", () => { writeFileSync(decisionSchemaPath, "[]"); }, "비어 있지 않은 required"],
       ["invalid", (adr) => { adr.decision.policy = "wrong"; }, "$.decision.policy"],
     ]) {
       const candidate = structuredClone(successor);

--- a/tools/ci/check-contracts.test.mjs
+++ b/tools/ci/check-contracts.test.mjs
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, relative, resolve } from "node:path";
 import {
@@ -171,6 +171,10 @@ test("문서 거버넌스 계약은 successor의 자체 decision schema와 안�
       ["missing-file", () => { rmSync(decisionSchemaPath); }, "decisionSchema ./ADR-HUB-0002-decision.schema.json 누락"],
       ["absolute", (adr) => { adr.decisionSchema = "/tmp/decision.schema.json"; }, "repository 내부 상대 JSON path"],
       ["escape", (adr) => { adr.decisionSchema = "../ADR-HUB-0002-decision.schema.json"; }, "repository 내부 상대 JSON path"],
+      ["symlink", () => {
+        rmSync(decisionSchemaPath);
+        symlinkSync("ADR-HUB-0001-decision.schema.json", decisionSchemaPath);
+      }, "symlink"],
       ["malformed", () => { writeFileSync(decisionSchemaPath, "{"); }, "유효한 JSON이 필요하다"],
       ["empty-schema", () => { writeFileSync(decisionSchemaPath, "{}"); }, "비어 있지 않은 required"],
       ["array-schema", () => { writeFileSync(decisionSchemaPath, "[]"); }, "비어 있지 않은 required"],
@@ -181,6 +185,7 @@ test("문서 거버넌스 계약은 successor의 자체 decision schema와 안�
       writeFileSync(successorPath, JSON.stringify(candidate));
       const errors = collectContractErrors(workspacePath);
       assert.ok(errors.some((error) => error.includes("ADR-HUB-0002.json") && error.includes(expected)), name);
+      rmSync(decisionSchemaPath, { force: true });
       writeFileSync(decisionSchemaPath, JSON.stringify(successorDecisionSchema));
     }
   } finally {

--- a/tools/ci/check-contracts.test.mjs
+++ b/tools/ci/check-contracts.test.mjs
@@ -701,6 +701,14 @@ test("문서 거버넌스 계약은 base-ref에서 전체 supersession chain을 
       baseChain.map(({ id }) => id),
       ["ADR-HUB-0001", "ADR-HUB-0002", "ADR-HUB-0003"],
     );
+    const terminalDecisionSchemaPath = join(repository, "docs/ADR-HUB-0003-decision.schema.json");
+    const terminalDecisionSchema = loadJson(terminalDecisionSchemaPath);
+    terminalDecisionSchema.properties.futureField = { type: "string" };
+    writeFileSync(terminalDecisionSchemaPath, JSON.stringify(terminalDecisionSchema));
+    assert.ok(collectContractErrors("workspace.json", { previousArchitectureDecision: baseChain })
+      .some((error) => error.includes("decision schema") && error.includes("in-place")));
+    delete terminalDecisionSchema.properties.futureField;
+    writeFileSync(terminalDecisionSchemaPath, JSON.stringify(terminalDecisionSchema));
     rmSync(join(repository, "docs/ADR-HUB-0002.json"));
     assert.ok(collectContractErrors("workspace.json", { previousArchitectureDecision: baseChain })
       .some((error) => error.includes("base ADR ADR-HUB-0002가 current chain에서 삭제되었다")));


### PR DESCRIPTION
## 관련 이슈

Closes #2754

## 작업 배경

PR #2749의 post-merge 독립 audit에서 공통 ADR schema가 ADR-HUB-0001의 최초 decision 값을 모든 successor에 고정해, 승인된 supersession lifecycle로 정책을 바꿀 수 없는 모순이 확인됐다.

## 작업 내용

- 공통 `architecture-decision.schema.json`에는 ADR envelope와 `decisionSchema` identity만 남겼다.
- ADR-HUB-0001의 기존 decision 상수·필수 필드·no-fallback 제약을 `ADR-HUB-0001-decision.schema.json`으로 분리했다.
- validator가 ADR별 같은 디렉터리의 자체 JSON schema만 매번 로드하고, 누락·경로 이탈·malformed·payload 불일치를 원 ADR path에 결속해 실패하도록 했다.
- 기존 supersession·reciprocity·duplicate·cycle·accepted in-place mutation 검증은 유지했다.

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern '문서 거버넌스' tools/ci/check-contracts.test.mjs` — 17/17 PASS
  - `node tools/ci/check-contracts.mjs --workspace contracts/workspaces/hub.json --base-ref 5ad660a7f07563999c1c076790614e7e717e0ea7` — PASS
  - `git diff --check` — PASS
  - `git ls-files '*.md'` — 기존 4개만 확인, 새 tracked Markdown 0

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| ADR decision schema | Hub CI | focused Node contract test | 위 검증 명령 | PASS |
| accepted ADR transition | Hub CI | base-ref transition gate | base `5ad660a7f07563999c1c076790614e7e717e0ea7` | PASS |
| UI·접근성 | 해당 없음 | machine contract/CI만 변경 | 사용자 UI·runtime 변경 0 | 불필요 |
| 배포 | 해당 없음 | diff 범위 확인 | runtime·artifact·deploy 파일 변경 0 | 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `validateArchitectureDecisionSchema`의 ADR별 filename 결속·symlink 이탈 차단과 ADR-HUB-0001 전용 semantic guard 유지 여부.
- successor는 자체 schema를 써서 root와 다른 decision을 표현할 수 있지만, 공통 lifecycle과 Hub owner/scope envelope는 계속 적용된다.

## 리스크

- decision schema 파일을 누락하거나 이름을 ADR ID와 다르게 두면 contract gate가 명시적으로 실패한다.
- schema validation 결과를 cache하지 않으므로 stale schema 성공 경로가 없다.
- 새 package·Markdown·runtime·route·artifact·deploy 변경은 없다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. 배포 영향 없음.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * ADR 결정 문서에 전용 결정 스키마를 연결해 필수 항목과 허용 값을 검증합니다.
  * 문서 형식, 생명주기, 저장소 소유자, 민감 정보 및 하위 이슈 정책 등을 엄격히 확인합니다.

* **버그 수정**
  * 참조 스키마의 경로, 파일 존재 여부, JSON 형식 및 문서 일치 여부를 검증합니다.
  * 허브 전용 결정 정책 위반 시 구체적인 오류를 제공합니다.

* **테스트**
  * 누락되거나 잘못된 스키마 참조, 형식 오류 및 다양한 ADR 생명주기 시나리오에 대한 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->