### PR TITLE
[Docs] Wave 4 trusted fragment Git-object transport

### DIFF
--- a/tools/ci/check-contracts.mjs
+++ b/tools/ci/check-contracts.mjs
@@ -350,7 +350,7 @@ const DOCUMENTATION_GIT_ENV = Object.freeze({
   GIT_CONFIG_NOSYSTEM: "1",
   GIT_ATTR_NOSYSTEM: "1",
 });
-const DOCUMENTATION_GIT_UNSET = Object.freeze(["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE", "GIT_OBJECT_DIRECTORY", "GIT_ALTERNATE_OBJECT_DIRECTORIES", "GIT_CONFIG_COUNT", "GIT_CONFIG_PARAMETERS", "GIT_NAMESPACE", "GIT_SHALLOW_FILE", "GIT_QUARANTINE_PATH", "GIT_CEILING_DIRECTORIES"]);
+const DOCUMENTATION_GIT_UNSET = Object.freeze(["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE", "GIT_OBJECT_DIRECTORY", "GIT_ALTERNATE_OBJECT_DIRECTORIES", "GIT_CONFIG_COUNT", "GIT_CONFIG_PARAMETERS", "GIT_NAMESPACE", "GIT_SHALLOW_FILE", "GIT_QUARANTINE_PATH", "GIT_CEILING_DIRECTORIES", "GIT_GLOB_PATHSPECS", "GIT_NOGLOB_PATHSPECS", "GIT_ICASE_PATHSPECS"]);
 const DOCUMENTATION_GIT_MAX_BUFFER = 64 * 1024 * 1024;
 
 function documentationGit(root, args, encoding = "buffer") {
@@ -418,6 +418,9 @@ function resolveDocumentationBlob(root, commit, path) {
     if (entries.length !== 1) return null;
     const match = /^(\d+) (\w+) ([0-9a-f]{40})\t(.+)$/.exec(entries[0]);
     if (match == null || match[1] === "120000" || match[2] !== "blob" || match[4] !== path) return null;
+    const size = documentationGit(root, ["cat-file", "-s", match[3]], "utf8").trim();
+    if (!/^\d+$/.test(size)) return null;
+    if (BigInt(size) > BigInt(DOCUMENTATION_GIT_MAX_BUFFER)) return { oid: match[3], tooLarge: true };
     return { oid: match[3], bytes: documentationGit(root, ["cat-file", "blob", match[3]]) };
   } catch { return null; }
 }
@@ -448,6 +451,11 @@ function resolveActiveDocumentationFragments(catalog, workspacePath, errors, sch
       continue;
     }
     const fragmentBlob = resolveDocumentationBlob(root, entry.fragment.gitSha, entry.fragment.path);
+    if (fragmentBlob?.tooLarge) {
+      documentationTransportError(errors, `${entry.repository} fragment blob은 64 MiB 이하여야 한다`);
+      failed = true;
+      continue;
+    }
     if (fragmentBlob == null) {
       documentationTransportError(errors, `${entry.repository} fragment blob을 확인할 수 없다`);
       failed = true;
@@ -494,6 +502,10 @@ function resolveActiveDocumentationFragments(catalog, workspacePath, errors, sch
       const identity = /^git:([0-9a-f]{40}):([^:]+):([0-9a-f]{40}|[0-9a-f]{64})$/.exec(record.canonicalIdentity);
       const blob = identity != null && identity[1] === fragment.gitSha
         ? resolveDocumentationBlob(root, fragment.gitSha, identity[2]) : null;
+      if (blob?.tooLarge) {
+        fragmentErrors.push("TRACKED resource blob은 64 MiB 이하여야 한다");
+        continue;
+      }
       const actual = blob == null ? null : identity[3].length === 40
         ? blob.oid : createHash("sha256").update(blob.bytes).digest("hex");
       if (actual !== identity?.[3]) fragmentErrors.push("TRACKED resource blob identity가 일치하지 않는다");

--- a/tools/ci/check-contracts.mjs
+++ b/tools/ci/check-contracts.mjs
@@ -419,6 +419,7 @@ function resolveActiveDocumentationFragments(catalog, workspacePath, errors) {
   if (roots == null) return;
   const records = [];
   for (const entry of active) {
+    if (entry.fragment == null) continue;
     const root = roots.get(entry.repository);
     if (!validateDocumentationGitRoot(root)) {
       documentationTransportError(errors, `${entry.repository} Git root가 유효하지 않다`);

--- a/tools/ci/check-contracts.mjs
+++ b/tools/ci/check-contracts.mjs
@@ -2,6 +2,7 @@
 import { isMainModule } from "../lib/is-main-module.mjs";
 import { existsSync, lstatSync, readFileSync, readdirSync, realpathSync } from "node:fs";
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { basename, dirname, isAbsolute, join, relative, resolve, win32 } from "node:path";
 import { validateSourceGovernancePolicy } from "../datapack/source-governance-policy.mjs";
 import { validateLedger } from "../repo/issue-migration-ledger.mjs";
@@ -10,6 +11,7 @@ import { codepointCompare } from "../lib/codepoint-compare.mjs";
 import { isDeepStrictEqual } from "node:util";
 import {
   DOCUMENTATION_REPOSITORIES,
+  validateDocumentationRelations,
   validateDocumentationRecord,
 } from "./documentation-inventory.mjs";
 
@@ -73,7 +75,7 @@ export function loadWorkspace(workspacePath = DEFAULT_WORKSPACE_PATH) {
 
 export function collectContractErrors(
   workspacePath = DEFAULT_WORKSPACE_PATH,
-  { previousArchitectureDecision = null } = {},
+  { previousArchitectureDecision = null, documentationFragmentWorkspacePath = null } = {},
 ) {
   const errors = [];
   let workspace;
@@ -113,11 +115,9 @@ export function collectContractErrors(
   );
   const documentationSystemCatalogSchema = contract("documentation/documentation-system-catalog.schema.json");
   if (validateJson(documentationSystemCatalogSchema, workspace.documentationSystemCatalog, errors)) {
-    validateDocumentationSystemCatalogSemantics(
-      loadJson(workspace.documentationSystemCatalog),
-      errors,
-      workspace.documentationSystemCatalog,
-    );
+    const catalog = loadJson(workspace.documentationSystemCatalog);
+    validateDocumentationSystemCatalogSemantics(catalog, errors, workspace.documentationSystemCatalog, false);
+    resolveActiveDocumentationFragments(catalog, documentationFragmentWorkspacePath, errors);
   }
   let currentArchitectureDecisions = [];
   const currentArchitectureDecisionCandidates = new Map();
@@ -308,13 +308,13 @@ export function validateJson(schemaPath, valuePath, errors) {
   return result.errors.length === 0 && referencedSchemaValid && semanticErrors.length === 0;
 }
 
-export function validateDocumentationSystemCatalog(catalog, schema, errors) {
+export function validateDocumentationSystemCatalog(catalog, schema, errors, { requireActiveResolution = true } = {}) {
   const result = validateSchema(schema, catalog);
   errors.push(...result.errors.map((error) => `documentation-system-catalog: ${error}`));
-  if (result.ok) validateDocumentationSystemCatalogSemantics(catalog, errors, "documentation-system-catalog");
+  if (result.ok) validateDocumentationSystemCatalogSemantics(catalog, errors, "documentation-system-catalog", requireActiveResolution);
 }
 
-function validateDocumentationSystemCatalogSemantics(catalog, errors, label) {
+function validateDocumentationSystemCatalogSemantics(catalog, errors, label, requireActiveResolution = true) {
   const expected = [...DOCUMENTATION_REPOSITORIES].sort(codepointCompare);
   const actual = catalog.repositories.map(({ repository }) => repository);
   if (!isDeepStrictEqual(actual, expected)) errors.push(`${label}: repositories는 정렬된 5개 정본 저장소와 정확히 일치해야 한다`);
@@ -326,7 +326,7 @@ function validateDocumentationSystemCatalogSemantics(catalog, errors, label) {
       errors.push(`${label}: ${entry.repository} ACTIVE fragment가 필요하다`);
       continue;
     }
-    if (entry.status === "ACTIVE") {
+    if (entry.status === "ACTIVE" && requireActiveResolution) {
       errors.push(`${label}: ${entry.repository} ACTIVE fragment resolution contract가 필요하다`);
     }
     if (entry.fragment !== null) {
@@ -334,6 +334,145 @@ function validateDocumentationSystemCatalogSemantics(catalog, errors, label) {
       if (!isCanonicalUtc(entry.fragment.lastVerifiedAt)) errors.push(`${label}: ${entry.repository} fragment lastVerifiedAt은 canonical UTC여야 한다`);
       validateDocumentationEvidence(entry.fragment.verificationEvidence, `${label}: ${entry.repository} fragment verificationEvidence`, errors);
     }
+  }
+}
+
+const DOCUMENTATION_GIT_ENV = Object.freeze({
+  GIT_NO_REPLACE_OBJECTS: "1",
+  GIT_NO_LAZY_FETCH: "1",
+  GIT_TERMINAL_PROMPT: "0",
+  GIT_LITERAL_PATHSPECS: "1",
+});
+
+function documentationGit(root, args, encoding = "buffer") {
+  return execFileSync("/usr/bin/git", ["-C", root, ...args], {
+    encoding,
+    env: { ...process.env, ...DOCUMENTATION_GIT_ENV },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function documentationTransportError(errors, message) {
+  errors.push(`documentation fragment transport: ${message}`);
+}
+
+function loadDocumentationFragmentWorkspace(path, activeRepositories, errors) {
+  if (path == null) {
+    documentationTransportError(errors, "ACTIVE fragment workspace가 필요하다");
+    return null;
+  }
+  let workspace;
+  try { workspace = loadJson(path); } catch {
+    documentationTransportError(errors, "유효한 local workspace JSON이 필요하다");
+    return null;
+  }
+  if (workspace == null || typeof workspace !== "object" || Array.isArray(workspace)
+      || workspace.schemaVersion !== 1 || !Array.isArray(workspace.repositories)
+      || Object.keys(workspace).length !== 2) {
+    documentationTransportError(errors, "local workspace shape가 유효하지 않다");
+    return null;
+  }
+  const mappings = new Map();
+  for (const item of workspace.repositories) {
+    if (item == null || typeof item !== "object" || Array.isArray(item)
+        || Object.keys(item).length !== 2 || typeof item.repository !== "string"
+        || typeof item.root !== "string" || !isAbsolute(item.root) || mappings.has(item.repository)) {
+      documentationTransportError(errors, "local workspace mapping이 유효하지 않다");
+      return null;
+    }
+    mappings.set(item.repository, item.root);
+  }
+  const actual = [...mappings.keys()].sort(codepointCompare);
+  if (!isDeepStrictEqual(actual, activeRepositories)) {
+    documentationTransportError(errors, "local workspace mapping이 ACTIVE repository 집합과 일치하지 않는다");
+    return null;
+  }
+  return mappings;
+}
+
+function validateDocumentationGitRoot(root) {
+  try {
+    if (lstatSync(root).isSymbolicLink() || realpathSync(root) !== root) return false;
+    if (documentationGit(root, ["rev-parse", "--show-toplevel"], "utf8").trim() !== root) return false;
+    return documentationGit(root, ["rev-parse", "--show-object-format=storage"], "utf8").trim() === "sha1";
+  } catch { return false; }
+}
+
+function resolveDocumentationBlob(root, commit, path) {
+  if (!/^[0-9a-f]{40}$/.test(commit) || !safeDocumentationPath(path)) return null;
+  try {
+    if (documentationGit(root, ["cat-file", "-t", commit], "utf8").trim() !== "commit") return null;
+    const raw = documentationGit(root, ["ls-tree", "-z", commit, "--", path]);
+    const entries = raw.toString("utf8").split("\0").filter(Boolean);
+    if (entries.length !== 1) return null;
+    const match = /^(\d+) (\w+) ([0-9a-f]{40})\t(.+)$/.exec(entries[0]);
+    if (match == null || match[1] === "120000" || match[2] !== "blob" || match[4] !== path) return null;
+    return { oid: match[3], bytes: documentationGit(root, ["cat-file", "blob", match[3]]) };
+  } catch { return null; }
+}
+
+function resolveActiveDocumentationFragments(catalog, workspacePath, errors) {
+  const active = catalog.repositories.filter(({ status }) => status === "ACTIVE");
+  if (active.length === 0) return;
+  const repositories = active.map(({ repository }) => repository).sort(codepointCompare);
+  const roots = loadDocumentationFragmentWorkspace(workspacePath, repositories, errors);
+  if (roots == null) return;
+  const records = [];
+  for (const entry of active) {
+    const root = roots.get(entry.repository);
+    if (!validateDocumentationGitRoot(root)) {
+      documentationTransportError(errors, `${entry.repository} Git root가 유효하지 않다`);
+      continue;
+    }
+    const fragmentBlob = resolveDocumentationBlob(root, entry.fragment.gitSha, entry.fragment.path);
+    if (fragmentBlob == null) {
+      documentationTransportError(errors, `${entry.repository} fragment blob을 확인할 수 없다`);
+      continue;
+    }
+    const expectedBlob = entry.fragment.blobSha.length === 40
+      ? fragmentBlob.oid : createHash("sha256").update(fragmentBlob.bytes).digest("hex");
+    if (expectedBlob !== entry.fragment.blobSha) {
+      documentationTransportError(errors, `${entry.repository} fragment blob identity가 일치하지 않는다`);
+      continue;
+    }
+    let fragment;
+    try { fragment = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(fragmentBlob.bytes)); } catch {
+      documentationTransportError(errors, `${entry.repository} fragment JSON이 유효하지 않다`);
+      continue;
+    }
+    const fragmentErrors = [];
+    validateDocumentationFragment(
+      fragment,
+      loadJson("contracts/documentation/documentation-fragment.schema.json"),
+      loadJson("contracts/documentation/documentation-resource.schema.json"),
+      fragmentErrors,
+    );
+    if (fragment.repository !== entry.repository || fragment.status !== "ACTIVE"
+        || fragment.lastVerifiedAt !== entry.fragment.lastVerifiedAt
+        || !isDeepStrictEqual(fragment.verificationEvidence, entry.fragment.verificationEvidence)) {
+      fragmentErrors.push("catalog fragment header 불일치");
+    }
+    try {
+      if (documentationGit(root, ["cat-file", "-t", fragment.gitSha], "utf8").trim() !== "commit"
+          || documentationGit(root, ["merge-base", "--is-ancestor", fragment.gitSha, entry.fragment.gitSha], "utf8") == null) {
+        fragmentErrors.push("inner commit relation 불일치");
+      }
+    } catch { fragmentErrors.push("inner commit relation 불일치"); }
+    for (const record of fragment.resources ?? []) {
+      if (record.sourceSurface !== "TRACKED") continue;
+      const identity = /^git:([0-9a-f]{40}):([^:]+):([0-9a-f]{40}|[0-9a-f]{64})$/.exec(record.canonicalIdentity);
+      const blob = identity != null && identity[1] === fragment.gitSha
+        ? resolveDocumentationBlob(root, fragment.gitSha, identity[2]) : null;
+      const actual = blob == null ? null : identity[3].length === 40
+        ? blob.oid : createHash("sha256").update(blob.bytes).digest("hex");
+      if (actual !== identity?.[3]) fragmentErrors.push("TRACKED resource blob identity가 일치하지 않는다");
+    }
+    if (fragmentErrors.length > 0) {
+      errors.push(...fragmentErrors.map((error) => `documentation fragment transport: ${entry.repository}: ${error}`));
+    } else records.push(...fragment.resources);
+  }
+  try { validateDocumentationRelations(records); } catch {
+    documentationTransportError(errors, "ACTIVE fragment relation이 유효하지 않다");
   }
 }
 
@@ -1111,11 +1250,15 @@ function compareText(left, right) {
 if (isMainModule(import.meta.url)) {
   const args = process.argv.slice(2);
   const hasWorkspace = args[0] === "--workspace" && args[1]?.trim() !== "";
-  const hasBaseRef = args.length === 4 && args[2] === "--base-ref" && args[3].trim() !== "";
-  const isCurrentOnly = args.length === 3 && args[2] === "--current-only";
-  const validArgs = hasWorkspace && (hasBaseRef || isCurrentOnly);
+  const fragmentWorkspaceIndex = args.indexOf("--documentation-fragment-workspace");
+  const hasFragmentWorkspace = fragmentWorkspaceIndex === -1
+    || (fragmentWorkspaceIndex === args.length - 2 && args[fragmentWorkspaceIndex + 1].trim() !== "");
+  const contractArgs = fragmentWorkspaceIndex === -1 ? args : args.slice(0, fragmentWorkspaceIndex);
+  const hasBaseRef = contractArgs.length === 4 && contractArgs[2] === "--base-ref" && contractArgs[3].trim() !== "";
+  const isCurrentOnly = contractArgs.length === 3 && contractArgs[2] === "--current-only";
+  const validArgs = hasWorkspace && hasFragmentWorkspace && (hasBaseRef || isCurrentOnly);
   if (!validArgs) {
-    console.error("사용법: node tools/ci/check-contracts.mjs --workspace <workspace.json> (--base-ref <40-hex-sha>|--current-only)");
+    console.error("사용법: node tools/ci/check-contracts.mjs --workspace <workspace.json> (--base-ref <40-hex-sha>|--current-only) [--documentation-fragment-workspace <local-json>]");
     process.exit(1);
   }
   let previousArchitectureDecision = null;
@@ -1125,7 +1268,10 @@ if (isMainModule(import.meta.url)) {
     console.error(`- ${error instanceof Error ? error.message : String(error)}`);
     process.exit(1);
   }
-  const errors = collectContractErrors(args[1], { previousArchitectureDecision });
+  const errors = collectContractErrors(args[1], {
+    previousArchitectureDecision,
+    documentationFragmentWorkspacePath: fragmentWorkspaceIndex === -1 ? null : args[fragmentWorkspaceIndex + 1],
+  });
   if (errors.length) {
     console.error(errors.map((error) => `- ${error}`).join("\n"));
     process.exit(1);

--- a/tools/ci/check-contracts.mjs
+++ b/tools/ci/check-contracts.mjs
@@ -382,7 +382,7 @@ function loadDocumentationFragmentWorkspace(path, activeRepositories, errors) {
     }
     mappings.set(item.repository, item.root);
   }
-  const actual = [...mappings.keys()].sort(codepointCompare);
+  const actual = [...mappings.keys()];
   if (!isDeepStrictEqual(actual, activeRepositories)) {
     documentationTransportError(errors, "local workspace mapping이 ACTIVE repository 집합과 일치하지 않는다");
     return null;
@@ -447,6 +447,10 @@ function resolveActiveDocumentationFragments(catalog, workspacePath, errors) {
       loadJson("contracts/documentation/documentation-resource.schema.json"),
       fragmentErrors,
     );
+    if (fragmentErrors.length > 0) {
+      errors.push(...fragmentErrors.map((error) => `documentation fragment transport: ${entry.repository}: ${error}`));
+      continue;
+    }
     if (fragment.repository !== entry.repository || fragment.status !== "ACTIVE"
         || fragment.lastVerifiedAt !== entry.fragment.lastVerifiedAt
         || !isDeepStrictEqual(fragment.verificationEvidence, entry.fragment.verificationEvidence)) {

--- a/tools/ci/check-contracts.mjs
+++ b/tools/ci/check-contracts.mjs
@@ -352,6 +352,7 @@ const DOCUMENTATION_GIT_ENV = Object.freeze({
 });
 const DOCUMENTATION_GIT_UNSET = Object.freeze(["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE", "GIT_OBJECT_DIRECTORY", "GIT_ALTERNATE_OBJECT_DIRECTORIES", "GIT_CONFIG_COUNT", "GIT_CONFIG_PARAMETERS", "GIT_NAMESPACE", "GIT_SHALLOW_FILE", "GIT_QUARANTINE_PATH", "GIT_CEILING_DIRECTORIES", "GIT_GLOB_PATHSPECS", "GIT_NOGLOB_PATHSPECS", "GIT_ICASE_PATHSPECS"]);
 const DOCUMENTATION_GIT_MAX_BUFFER = 64 * 1024 * 1024;
+const DOCUMENTATION_FRAGMENT_MAX_RESOURCES = 4096;
 
 function documentationGit(root, args, encoding = "buffer") {
   const env = { ...process.env, ...DOCUMENTATION_GIT_ENV };
@@ -471,6 +472,11 @@ function resolveActiveDocumentationFragments(catalog, workspacePath, errors, sch
     let fragment;
     try { fragment = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(fragmentBlob.bytes)); } catch {
       documentationTransportError(errors, `${entry.repository} fragment JSON이 유효하지 않다`);
+      failed = true;
+      continue;
+    }
+    if (Array.isArray(fragment?.resources) && fragment.resources.length > DOCUMENTATION_FRAGMENT_MAX_RESOURCES) {
+      documentationTransportError(errors, `${entry.repository} fragment resources는 4096개 이하여야 한다`);
       failed = true;
       continue;
     }

--- a/tools/ci/check-contracts.mjs
+++ b/tools/ci/check-contracts.mjs
@@ -117,7 +117,10 @@ export function collectContractErrors(
   if (validateJson(documentationSystemCatalogSchema, workspace.documentationSystemCatalog, errors)) {
     const catalog = loadJson(workspace.documentationSystemCatalog);
     validateDocumentationSystemCatalogSemantics(catalog, errors, workspace.documentationSystemCatalog, false);
-    resolveActiveDocumentationFragments(catalog, documentationFragmentWorkspacePath, errors);
+    resolveActiveDocumentationFragments(catalog, documentationFragmentWorkspacePath, errors, {
+      fragmentSchema: contract("documentation/documentation-fragment.schema.json"),
+      resourceSchema: contract("documentation/documentation-resource.schema.json"),
+    });
   }
   let currentArchitectureDecisions = [];
   const currentArchitectureDecisionCandidates = new Map();
@@ -342,12 +345,20 @@ const DOCUMENTATION_GIT_ENV = Object.freeze({
   GIT_NO_LAZY_FETCH: "1",
   GIT_TERMINAL_PROMPT: "0",
   GIT_LITERAL_PATHSPECS: "1",
+  GIT_CONFIG_GLOBAL: "/dev/null",
+  GIT_CONFIG_SYSTEM: "/dev/null",
+  GIT_CONFIG_NOSYSTEM: "1",
+  GIT_ATTR_NOSYSTEM: "1",
 });
+const DOCUMENTATION_GIT_UNSET = Object.freeze(["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE", "GIT_OBJECT_DIRECTORY", "GIT_ALTERNATE_OBJECT_DIRECTORIES", "GIT_CONFIG_COUNT", "GIT_CONFIG_PARAMETERS", "GIT_NAMESPACE", "GIT_SHALLOW_FILE", "GIT_QUARANTINE_PATH", "GIT_CEILING_DIRECTORIES"]);
+const DOCUMENTATION_GIT_MAX_BUFFER = 64 * 1024 * 1024;
 
 function documentationGit(root, args, encoding = "buffer") {
+  const env = { ...process.env, ...DOCUMENTATION_GIT_ENV };
+  for (const key of DOCUMENTATION_GIT_UNSET) delete env[key];
   return execFileSync("/usr/bin/git", ["-C", root, ...args], {
     encoding,
-    env: { ...process.env, ...DOCUMENTATION_GIT_ENV },
+    env, maxBuffer: DOCUMENTATION_GIT_MAX_BUFFER,
     stdio: ["ignore", "pipe", "pipe"],
   });
 }
@@ -411,44 +422,58 @@ function resolveDocumentationBlob(root, commit, path) {
   } catch { return null; }
 }
 
-function resolveActiveDocumentationFragments(catalog, workspacePath, errors) {
+function resolveActiveDocumentationFragments(catalog, workspacePath, errors, schemaPaths) {
   const active = catalog.repositories.filter(({ status }) => status === "ACTIVE");
   if (active.length === 0) return;
   const repositories = active.map(({ repository }) => repository).sort(codepointCompare);
   const roots = loadDocumentationFragmentWorkspace(workspacePath, repositories, errors);
   if (roots == null) return;
+  let fragmentSchema;
+  let resourceSchema;
+  try {
+    fragmentSchema = loadJson(schemaPaths.fragmentSchema);
+    resourceSchema = loadJson(schemaPaths.resourceSchema);
+  } catch {
+    documentationTransportError(errors, "fragment schema를 읽을 수 없다");
+    return;
+  }
   const records = [];
+  let failed = false;
   for (const entry of active) {
-    if (entry.fragment == null) continue;
+    if (entry.fragment == null) { failed = true; continue; }
     const root = roots.get(entry.repository);
     if (!validateDocumentationGitRoot(root)) {
       documentationTransportError(errors, `${entry.repository} Git root가 유효하지 않다`);
+      failed = true;
       continue;
     }
     const fragmentBlob = resolveDocumentationBlob(root, entry.fragment.gitSha, entry.fragment.path);
     if (fragmentBlob == null) {
       documentationTransportError(errors, `${entry.repository} fragment blob을 확인할 수 없다`);
+      failed = true;
       continue;
     }
     const expectedBlob = entry.fragment.blobSha.length === 40
       ? fragmentBlob.oid : createHash("sha256").update(fragmentBlob.bytes).digest("hex");
     if (expectedBlob !== entry.fragment.blobSha) {
       documentationTransportError(errors, `${entry.repository} fragment blob identity가 일치하지 않는다`);
+      failed = true;
       continue;
     }
     let fragment;
     try { fragment = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(fragmentBlob.bytes)); } catch {
       documentationTransportError(errors, `${entry.repository} fragment JSON이 유효하지 않다`);
+      failed = true;
       continue;
     }
     const fragmentErrors = [];
     validateDocumentationFragment(
       fragment,
-      loadJson("contracts/documentation/documentation-fragment.schema.json"),
-      loadJson("contracts/documentation/documentation-resource.schema.json"),
+      fragmentSchema, resourceSchema,
       fragmentErrors,
     );
     if (fragmentErrors.length > 0) {
+      failed = true;
       errors.push(...fragmentErrors.map((error) => `documentation fragment transport: ${entry.repository}: ${error}`));
       continue;
     }
@@ -476,6 +501,7 @@ function resolveActiveDocumentationFragments(catalog, workspacePath, errors) {
       errors.push(...fragmentErrors.map((error) => `documentation fragment transport: ${entry.repository}: ${error}`));
     } else records.push(...fragment.resources);
   }
+  if (failed) return;
   try { validateDocumentationRelations(records); } catch {
     documentationTransportError(errors, "ACTIVE fragment relation이 유효하지 않다");
   }

--- a/tools/ci/check-contracts.mjs
+++ b/tools/ci/check-contracts.mjs
@@ -475,11 +475,16 @@ function resolveActiveDocumentationFragments(catalog, workspacePath, errors, sch
       continue;
     }
     const fragmentErrors = [];
-    validateDocumentationFragment(
-      fragment,
-      fragmentSchema, resourceSchema,
-      fragmentErrors,
-    );
+    try {
+      validateDocumentationFragment(
+        fragment,
+        fragmentSchema, resourceSchema,
+        fragmentErrors,
+      );
+    } catch {
+      documentationTransportError(errors, "fragment schema가 유효하지 않다");
+      return;
+    }
     if (fragmentErrors.length > 0) {
       failed = true;
       for (const error of fragmentErrors) errors.push(`documentation fragment transport: ${entry.repository}: ${error}`);

--- a/tools/ci/check-contracts.mjs
+++ b/tools/ci/check-contracts.mjs
@@ -353,8 +353,9 @@ const DOCUMENTATION_GIT_ENV = Object.freeze({
 });
 const DOCUMENTATION_GIT_UNSET = Object.freeze(["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE", "GIT_OBJECT_DIRECTORY", "GIT_ALTERNATE_OBJECT_DIRECTORIES", "GIT_CONFIG_COUNT", "GIT_CONFIG_PARAMETERS", "GIT_NAMESPACE", "GIT_SHALLOW_FILE", "GIT_QUARANTINE_PATH", "GIT_CEILING_DIRECTORIES", "GIT_GLOB_PATHSPECS", "GIT_NOGLOB_PATHSPECS", "GIT_ICASE_PATHSPECS"]);
 const DOCUMENTATION_GIT_MAX_BUFFER = 64 * 1024 * 1024;
-const DOCUMENTATION_FRAGMENT_MAX_RESOURCES = 4096;
-const DOCUMENTATION_MAX_TRACKED_RESOURCES = 256;
+const DOCUMENTATION_FRAGMENT_MAX_BYTES = 1024 * 1024;
+const DOCUMENTATION_MAX_ARRAY_ITEMS = 256;
+const DOCUMENTATION_MAX_RESOURCES = 256;
 
 function documentationGit(root, args, encoding = "buffer") {
   const env = { ...process.env, ...DOCUMENTATION_GIT_ENV };
@@ -412,7 +413,10 @@ function validateDocumentationGitRoot(root) {
   } catch { return false; }
 }
 
-function resolveDocumentationBlob(root, commit, path, readBytes = true) {
+function resolveDocumentationBlob(
+  root, commit, path,
+  { readBytes = true, maxBytes = DOCUMENTATION_GIT_MAX_BUFFER } = {},
+) {
   if (!/^[0-9a-f]{40}$/.test(commit) || !safeDocumentationPath(path)) return null;
   try {
     if (documentationGit(root, ["cat-file", "-t", commit], "utf8").trim() !== "commit") return null;
@@ -424,12 +428,26 @@ function resolveDocumentationBlob(root, commit, path, readBytes = true) {
     const size = documentationGit(root, ["cat-file", "-s", match[3]], "utf8").trim();
     if (!/^\d+$/.test(size)) return null;
     const byteLength = BigInt(size);
-    if (byteLength > BigInt(DOCUMENTATION_GIT_MAX_BUFFER)) return { oid: match[3], byteLength, tooLarge: true };
+    if (byteLength > BigInt(maxBytes)) return { oid: match[3], byteLength, tooLarge: true };
     return {
       oid: match[3], byteLength,
       bytes: readBytes ? documentationGit(root, ["cat-file", "blob", match[3]]) : null,
     };
   } catch { return null; }
+}
+
+function hasOversizedDocumentationArray(value) {
+  const pending = [value];
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (Array.isArray(current)) {
+      if (current.length > DOCUMENTATION_MAX_ARRAY_ITEMS) return true;
+      for (const item of current) pending.push(item);
+    } else if (current != null && typeof current === "object") {
+      for (const item of Object.values(current)) pending.push(item);
+    }
+  }
+  return false;
 }
 
 function resolveActiveDocumentationFragments(catalog, workspacePath, errors, schemaPaths) {
@@ -447,10 +465,9 @@ function resolveActiveDocumentationFragments(catalog, workspacePath, errors, sch
     documentationTransportError(errors, "fragment schema를 읽을 수 없다");
     return;
   }
-  const records = [];
+  const resolvedFragments = [];
   let failed = false;
-  let trackedResourceCount = 0;
-  let trackedDigestBytes = 0n;
+  let resourceCount = 0;
   for (const entry of active) {
     if (entry.fragment == null) { failed = true; continue; }
     const root = roots.get(entry.repository);
@@ -459,9 +476,11 @@ function resolveActiveDocumentationFragments(catalog, workspacePath, errors, sch
       failed = true;
       continue;
     }
-    const fragmentBlob = resolveDocumentationBlob(root, entry.fragment.gitSha, entry.fragment.path);
+    const fragmentBlob = resolveDocumentationBlob(root, entry.fragment.gitSha, entry.fragment.path, {
+      maxBytes: DOCUMENTATION_FRAGMENT_MAX_BYTES,
+    });
     if (fragmentBlob?.tooLarge) {
-      documentationTransportError(errors, `${entry.repository} fragment blob은 64 MiB 이하여야 한다`);
+      documentationTransportError(errors, `${entry.repository} fragment blob은 1 MiB 이하여야 한다`);
       failed = true;
       continue;
     }
@@ -483,8 +502,13 @@ function resolveActiveDocumentationFragments(catalog, workspacePath, errors, sch
       failed = true;
       continue;
     }
-    if (Array.isArray(fragment?.resources) && fragment.resources.length > DOCUMENTATION_FRAGMENT_MAX_RESOURCES) {
-      documentationTransportError(errors, `${entry.repository} fragment resources는 4096개 이하여야 한다`);
+    if (Array.isArray(fragment?.resources) && fragment.resources.length > DOCUMENTATION_MAX_ARRAY_ITEMS) {
+      documentationTransportError(errors, `${entry.repository} fragment resources는 256개 이하여야 한다`);
+      failed = true;
+      continue;
+    }
+    if (hasOversizedDocumentationArray(fragment)) {
+      documentationTransportError(errors, `${entry.repository} fragment 배열은 256개 항목 이하여야 한다`);
       failed = true;
       continue;
     }
@@ -504,6 +528,19 @@ function resolveActiveDocumentationFragments(catalog, workspacePath, errors, sch
       for (const error of fragmentErrors) errors.push(`documentation fragment transport: ${entry.repository}: ${error}`);
       continue;
     }
+    resourceCount += fragment.resources.length;
+    if (resourceCount > DOCUMENTATION_MAX_RESOURCES) {
+      documentationTransportError(errors, `${entry.repository} resources는 전체 256개 이하여야 한다`);
+      failed = true;
+      continue;
+    }
+    resolvedFragments.push({ entry, root, fragment });
+  }
+  if (failed) return;
+  const records = [];
+  let trackedDigestBytes = 0n;
+  for (const { entry, root, fragment } of resolvedFragments) {
+    const fragmentErrors = [];
     if (fragment.repository !== entry.repository || fragment.status !== "ACTIVE"
         || fragment.lastVerifiedAt !== entry.fragment.lastVerifiedAt
         || !isDeepStrictEqual(fragment.verificationEvidence, entry.fragment.verificationEvidence)) {
@@ -517,13 +554,10 @@ function resolveActiveDocumentationFragments(catalog, workspacePath, errors, sch
       }
     } catch { fragmentErrors.push("inner commit relation 불일치"); }
     const trackedRecords = fragment.resources.filter(({ sourceSurface }) => sourceSurface === "TRACKED");
-    trackedResourceCount += trackedRecords.length;
-    if (trackedResourceCount > DOCUMENTATION_MAX_TRACKED_RESOURCES) {
-      fragmentErrors.push("TRACKED resources는 전체 256개 이하여야 한다");
-    } else for (const record of trackedRecords) {
+    for (const record of trackedRecords) {
       const identity = /^git:([0-9a-f]{40}):([^:]+):([0-9a-f]{40}|[0-9a-f]{64})$/.exec(record.canonicalIdentity);
       const blob = identity != null && identity[1] === fragment.gitSha
-        ? resolveDocumentationBlob(root, fragment.gitSha, identity[2], false) : null;
+        ? resolveDocumentationBlob(root, fragment.gitSha, identity[2], { readBytes: false }) : null;
       if (blob?.tooLarge) {
         fragmentErrors.push("TRACKED resource blob은 64 MiB 이하여야 한다");
         continue;

--- a/tools/ci/check-contracts.mjs
+++ b/tools/ci/check-contracts.mjs
@@ -483,9 +483,10 @@ function resolveActiveDocumentationFragments(catalog, workspacePath, errors, sch
       fragmentErrors.push("catalog fragment header 불일치");
     }
     try {
-      if (documentationGit(root, ["cat-file", "-t", fragment.gitSha], "utf8").trim() !== "commit"
-          || documentationGit(root, ["merge-base", "--is-ancestor", fragment.gitSha, entry.fragment.gitSha], "utf8") == null) {
+      if (documentationGit(root, ["cat-file", "-t", fragment.gitSha], "utf8").trim() !== "commit") {
         fragmentErrors.push("inner commit relation 불일치");
+      } else {
+        documentationGit(root, ["merge-base", "--is-ancestor", fragment.gitSha, entry.fragment.gitSha]);
       }
     } catch { fragmentErrors.push("inner commit relation 불일치"); }
     for (const record of fragment.resources ?? []) {
@@ -498,6 +499,7 @@ function resolveActiveDocumentationFragments(catalog, workspacePath, errors, sch
       if (actual !== identity?.[3]) fragmentErrors.push("TRACKED resource blob identity가 일치하지 않는다");
     }
     if (fragmentErrors.length > 0) {
+      failed = true;
       errors.push(...fragmentErrors.map((error) => `documentation fragment transport: ${entry.repository}: ${error}`));
     } else records.push(...fragment.resources);
   }

--- a/tools/ci/check-contracts.mjs
+++ b/tools/ci/check-contracts.mjs
@@ -342,6 +342,7 @@ function validateDocumentationSystemCatalogSemantics(catalog, errors, label, req
 
 const DOCUMENTATION_GIT_ENV = Object.freeze({
   GIT_NO_REPLACE_OBJECTS: "1",
+  GIT_GRAFT_FILE: "/dev/null",
   GIT_NO_LAZY_FETCH: "1",
   GIT_TERMINAL_PROMPT: "0",
   GIT_LITERAL_PATHSPECS: "1",
@@ -353,6 +354,7 @@ const DOCUMENTATION_GIT_ENV = Object.freeze({
 const DOCUMENTATION_GIT_UNSET = Object.freeze(["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE", "GIT_OBJECT_DIRECTORY", "GIT_ALTERNATE_OBJECT_DIRECTORIES", "GIT_CONFIG_COUNT", "GIT_CONFIG_PARAMETERS", "GIT_NAMESPACE", "GIT_SHALLOW_FILE", "GIT_QUARANTINE_PATH", "GIT_CEILING_DIRECTORIES", "GIT_GLOB_PATHSPECS", "GIT_NOGLOB_PATHSPECS", "GIT_ICASE_PATHSPECS"]);
 const DOCUMENTATION_GIT_MAX_BUFFER = 64 * 1024 * 1024;
 const DOCUMENTATION_FRAGMENT_MAX_RESOURCES = 4096;
+const DOCUMENTATION_MAX_TRACKED_RESOURCES = 256;
 
 function documentationGit(root, args, encoding = "buffer") {
   const env = { ...process.env, ...DOCUMENTATION_GIT_ENV };
@@ -410,7 +412,7 @@ function validateDocumentationGitRoot(root) {
   } catch { return false; }
 }
 
-function resolveDocumentationBlob(root, commit, path) {
+function resolveDocumentationBlob(root, commit, path, readBytes = true) {
   if (!/^[0-9a-f]{40}$/.test(commit) || !safeDocumentationPath(path)) return null;
   try {
     if (documentationGit(root, ["cat-file", "-t", commit], "utf8").trim() !== "commit") return null;
@@ -421,8 +423,12 @@ function resolveDocumentationBlob(root, commit, path) {
     if (match == null || match[1] === "120000" || match[2] !== "blob" || match[4] !== path) return null;
     const size = documentationGit(root, ["cat-file", "-s", match[3]], "utf8").trim();
     if (!/^\d+$/.test(size)) return null;
-    if (BigInt(size) > BigInt(DOCUMENTATION_GIT_MAX_BUFFER)) return { oid: match[3], tooLarge: true };
-    return { oid: match[3], bytes: documentationGit(root, ["cat-file", "blob", match[3]]) };
+    const byteLength = BigInt(size);
+    if (byteLength > BigInt(DOCUMENTATION_GIT_MAX_BUFFER)) return { oid: match[3], byteLength, tooLarge: true };
+    return {
+      oid: match[3], byteLength,
+      bytes: readBytes ? documentationGit(root, ["cat-file", "blob", match[3]]) : null,
+    };
   } catch { return null; }
 }
 
@@ -443,6 +449,8 @@ function resolveActiveDocumentationFragments(catalog, workspacePath, errors, sch
   }
   const records = [];
   let failed = false;
+  let trackedResourceCount = 0;
+  let trackedDigestBytes = 0n;
   for (const entry of active) {
     if (entry.fragment == null) { failed = true; continue; }
     const root = roots.get(entry.repository);
@@ -508,17 +516,28 @@ function resolveActiveDocumentationFragments(catalog, workspacePath, errors, sch
         documentationGit(root, ["merge-base", "--is-ancestor", fragment.gitSha, entry.fragment.gitSha]);
       }
     } catch { fragmentErrors.push("inner commit relation 불일치"); }
-    for (const record of fragment.resources ?? []) {
-      if (record.sourceSurface !== "TRACKED") continue;
+    const trackedRecords = fragment.resources.filter(({ sourceSurface }) => sourceSurface === "TRACKED");
+    trackedResourceCount += trackedRecords.length;
+    if (trackedResourceCount > DOCUMENTATION_MAX_TRACKED_RESOURCES) {
+      fragmentErrors.push("TRACKED resources는 전체 256개 이하여야 한다");
+    } else for (const record of trackedRecords) {
       const identity = /^git:([0-9a-f]{40}):([^:]+):([0-9a-f]{40}|[0-9a-f]{64})$/.exec(record.canonicalIdentity);
       const blob = identity != null && identity[1] === fragment.gitSha
-        ? resolveDocumentationBlob(root, fragment.gitSha, identity[2]) : null;
+        ? resolveDocumentationBlob(root, fragment.gitSha, identity[2], false) : null;
       if (blob?.tooLarge) {
         fragmentErrors.push("TRACKED resource blob은 64 MiB 이하여야 한다");
         continue;
       }
-      const actual = blob == null ? null : identity[3].length === 40
-        ? blob.oid : createHash("sha256").update(blob.bytes).digest("hex");
+      let actual = blob?.oid ?? null;
+      if (blob != null && identity[3].length === 64) {
+        if (trackedDigestBytes + blob.byteLength > BigInt(DOCUMENTATION_GIT_MAX_BUFFER)) {
+          fragmentErrors.push("TRACKED resource SHA-256 payload 합계는 64 MiB 이하여야 한다");
+          break;
+        }
+        trackedDigestBytes += blob.byteLength;
+        try { actual = createHash("sha256").update(documentationGit(root, ["cat-file", "blob", blob.oid])).digest("hex"); }
+        catch { actual = null; }
+      }
       if (actual !== identity?.[3]) fragmentErrors.push("TRACKED resource blob identity가 일치하지 않는다");
     }
     if (fragmentErrors.length > 0) {

--- a/tools/ci/check-contracts.mjs
+++ b/tools/ci/check-contracts.mjs
@@ -482,7 +482,7 @@ function resolveActiveDocumentationFragments(catalog, workspacePath, errors, sch
     );
     if (fragmentErrors.length > 0) {
       failed = true;
-      errors.push(...fragmentErrors.map((error) => `documentation fragment transport: ${entry.repository}: ${error}`));
+      for (const error of fragmentErrors) errors.push(`documentation fragment transport: ${entry.repository}: ${error}`);
       continue;
     }
     if (fragment.repository !== entry.repository || fragment.status !== "ACTIVE"
@@ -512,7 +512,7 @@ function resolveActiveDocumentationFragments(catalog, workspacePath, errors, sch
     }
     if (fragmentErrors.length > 0) {
       failed = true;
-      errors.push(...fragmentErrors.map((error) => `documentation fragment transport: ${entry.repository}: ${error}`));
+      for (const error of fragmentErrors) errors.push(`documentation fragment transport: ${entry.repository}: ${error}`);
     } else records.push(...fragment.resources);
   }
   if (failed) return;

--- a/tools/ci/check-contracts.test.mjs
+++ b/tools/ci/check-contracts.test.mjs
@@ -27,6 +27,23 @@ import {
 } from "./check-contracts.mjs";
 import { validateSchema } from "./lib/json-schema-lite.mjs";
 
+const FIXTURE_GIT_UNSET = ["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE", "GIT_OBJECT_DIRECTORY", "GIT_ALTERNATE_OBJECT_DIRECTORIES", "GIT_CONFIG_COUNT", "GIT_CONFIG_PARAMETERS", "GIT_NAMESPACE", "GIT_SHALLOW_FILE", "GIT_QUARANTINE_PATH", "GIT_CEILING_DIRECTORIES"];
+
+function fixtureGit(args, options = {}) {
+  const env = {
+    ...process.env,
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_CONFIG_SYSTEM: "/dev/null",
+    GIT_CONFIG_NOSYSTEM: "1",
+  };
+  for (const key of FIXTURE_GIT_UNSET) delete env[key];
+  const command = args[0] === "init" ? ["init", "--template=", ...args.slice(1)] : args;
+  return execFileSync("/usr/bin/git", ["-c", "commit.gpgSign=false", "-c", "core.hooksPath=/dev/null", ...command], {
+    ...options,
+    env,
+  });
+}
+
 function createExternalWorkspace() {
   const directory = mkdtempSync(join(tmpdir(), "gate-ownership-workspace-"));
   mkdirSync(join(directory, "inputs"), { recursive: true });
@@ -98,13 +115,13 @@ function createDocumentationCatalogWorkspace({ activeIndexes = null } = {}) {
       const root = join(directory, `repository-${index}`);
       mkdirSync(join(root, "docs"), { recursive: true });
       for (const args of [["init"], ["config", "user.email", "test@example.com"], ["config", "user.name", "Test"]]) {
-        execFileSync("/usr/bin/git", args, { cwd: root, stdio: "ignore" });
+        fixtureGit(args, { cwd: root, stdio: "ignore" });
       }
       writeFileSync(join(root, "docs/resource.txt"), `resource-${index}\n`);
-      execFileSync("/usr/bin/git", ["add", "."], { cwd: root, stdio: "ignore" });
-      execFileSync("/usr/bin/git", ["commit", "-m", "inner"], { cwd: root, stdio: "ignore" });
-      const innerSha = execFileSync("/usr/bin/git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
-      const resourceBlob = execFileSync("/usr/bin/git", ["rev-parse", "HEAD:docs/resource.txt"], { cwd: root, encoding: "utf8" }).trim();
+      fixtureGit(["add", "."], { cwd: root, stdio: "ignore" });
+      fixtureGit(["commit", "-m", "inner"], { cwd: root, stdio: "ignore" });
+      const innerSha = fixtureGit(["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+      const resourceBlob = fixtureGit(["rev-parse", "HEAD:docs/resource.txt"], { cwd: root, encoding: "utf8" }).trim();
       const resourceDigest = createHash("sha256").update(readFileSync(join(root, "docs/resource.txt"))).digest("hex");
       const resourceIdentity = index === 0 ? resourceBlob : resourceDigest;
       const fragment = {
@@ -114,10 +131,10 @@ function createDocumentationCatalogWorkspace({ activeIndexes = null } = {}) {
         resources: [documentationCatalogRecord(entry.repository, innerSha, resourceIdentity)],
       };
       writeFileSync(join(root, "docs/fragment.json"), JSON.stringify(fragment));
-      execFileSync("/usr/bin/git", ["add", "."], { cwd: root, stdio: "ignore" });
-      execFileSync("/usr/bin/git", ["commit", "-m", "outer"], { cwd: root, stdio: "ignore" });
-      const outerSha = execFileSync("/usr/bin/git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
-      const fragmentBlob = execFileSync("/usr/bin/git", ["rev-parse", "HEAD:docs/fragment.json"], { cwd: root, encoding: "utf8" }).trim();
+      fixtureGit(["add", "."], { cwd: root, stdio: "ignore" });
+      fixtureGit(["commit", "-m", "outer"], { cwd: root, stdio: "ignore" });
+      const outerSha = fixtureGit(["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+      const fragmentBlob = fixtureGit(["rev-parse", "HEAD:docs/fragment.json"], { cwd: root, encoding: "utf8" }).trim();
       entry.status = "ACTIVE";
       entry.fragment = {
         gitSha: outerSha, path: "docs/fragment.json", blobSha: index === 0
@@ -138,18 +155,6 @@ function createDocumentationCatalogWorkspace({ activeIndexes = null } = {}) {
 
 function createSingleDocumentationCatalogWorkspace() {
   return createDocumentationCatalogWorkspace({ activeIndexes: [0] });
-}
-
-function replaceDocumentationCatalogFragment(fixture, index, value) {
-  const root = fixture.repositories[index].root;
-  writeFileSync(join(root, "docs/fragment.json"), value);
-  execFileSync("/usr/bin/git", ["add", "."], { cwd: root, stdio: "ignore" });
-  execFileSync("/usr/bin/git", ["commit", "-m", "invalid fragment"], { cwd: root, stdio: "ignore" });
-  const catalog = loadJson(fixture.catalogPath);
-  const fragment = catalog.repositories[index].fragment;
-  fragment.gitSha = execFileSync("/usr/bin/git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
-  fragment.blobSha = execFileSync("/usr/bin/git", ["rev-parse", "HEAD:docs/fragment.json"], { cwd: root, encoding: "utf8" }).trim();
-  writeFileSync(fixture.catalogPath, JSON.stringify(catalog));
 }
 
 function documentationCatalogErrors(fixture) {
@@ -173,12 +178,12 @@ function updateDocumentationCatalogWorkspace(fixture, mutate) {
 function commitDocumentationCatalogFragment(fixture, index, value, mutateCatalog = () => {}) {
   const root = fixture.repositories[index].root;
   writeFileSync(join(root, "docs/fragment.json"), value);
-  execFileSync("/usr/bin/git", ["add", "."], { cwd: root, stdio: "ignore" });
-  execFileSync("/usr/bin/git", ["commit", "-m", "mutate fragment"], { cwd: root, stdio: "ignore" });
+  fixtureGit(["add", "."], { cwd: root, stdio: "ignore" });
+  fixtureGit(["commit", "-m", "mutate fragment"], { cwd: root, stdio: "ignore" });
   const catalog = loadJson(fixture.catalogPath);
   const fragment = catalog.repositories[index].fragment;
-  fragment.gitSha = execFileSync("/usr/bin/git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
-  fragment.blobSha = execFileSync("/usr/bin/git", ["rev-parse", "HEAD:docs/fragment.json"], { cwd: root, encoding: "utf8" }).trim();
+  fragment.gitSha = fixtureGit(["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+  fragment.blobSha = fixtureGit(["rev-parse", "HEAD:docs/fragment.json"], { cwd: root, encoding: "utf8" }).trim();
   mutateCatalog(catalog.repositories[index]);
   writeFileSync(fixture.catalogPath, JSON.stringify(catalog));
 }
@@ -188,7 +193,7 @@ function rebindDocumentationCatalogFragment(fixture, index, path, blobSha) {
   const catalog = loadJson(fixture.catalogPath);
   catalog.repositories[index].fragment = {
     ...catalog.repositories[index].fragment,
-    gitSha: execFileSync("/usr/bin/git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim(),
+    gitSha: fixtureGit(["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim(),
     path,
     blobSha,
   };
@@ -242,7 +247,7 @@ test("documentation catalog resolves exact outer and inner Git blobs", () => {
 test("documentation catalog rejects schema-invalid fragment blobs without throwing", () => {
   const fixture = createDocumentationCatalogWorkspace();
   try {
-    replaceDocumentationCatalogFragment(fixture, 0, "null");
+    commitDocumentationCatalogFragment(fixture, 0, "null");
     const errors = collectContractErrors(fixture.workspacePath, {
       documentationFragmentWorkspacePath: fixture.fragmentWorkspacePath,
     });
@@ -285,16 +290,65 @@ test("documentation catalog rejects ACTIVE null fragment without throwing", () =
 
 test("documentation catalog ignores inherited hostile Git environment", () => {
   const fixture = createDocumentationCatalogWorkspace();
-  const previous = process.env.GIT_DIR;
+  const hostile = {
+    GIT_DIR: join(fixture.directory, "not-a-git-dir"),
+    GIT_OBJECT_DIRECTORY: join(fixture.directory, "not-an-object-directory"),
+    GIT_CONFIG_COUNT: "1",
+    GIT_CONFIG_KEY_0: "core.hooksPath",
+    GIT_CONFIG_VALUE_0: join(fixture.directory, "not-a-hook-directory"),
+  };
+  const previous = Object.fromEntries(Object.keys(hostile).map((key) => [key, process.env[key]]));
   try {
-    process.env.GIT_DIR = join(fixture.directory, "not-a-git-dir");
+    Object.assign(process.env, hostile);
     assert.deepEqual(collectContractErrors(fixture.workspacePath, {
       documentationFragmentWorkspacePath: fixture.fragmentWorkspacePath,
     }), []);
   } finally {
-    if (previous === undefined) delete process.env.GIT_DIR;
-    else process.env.GIT_DIR = previous;
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
     rmSync(fixture.directory, { recursive: true, force: true });
+  }
+});
+
+test("documentation catalog uses workspace-selected fragment schemas and sanitizes schema failures", () => {
+  const fixture = createSingleDocumentationCatalogWorkspace();
+  try {
+    const contracts = join(fixture.directory, "selected-contracts");
+    cpSync("contracts", contracts, { recursive: true });
+    mkdirSync(join(fixture.directory, "release/migrations"), { recursive: true });
+    cpSync("release/migrations/repository-split-issues.json", join(fixture.directory, "release/migrations/repository-split-issues.json"));
+    const workspace = loadJson(fixture.workspacePath);
+    workspace.contracts = "selected-contracts";
+    writeFileSync(fixture.workspacePath, JSON.stringify(workspace));
+    assert.deepEqual(documentationCatalogErrors(fixture), []);
+
+    const schemaPath = join(contracts, "documentation/documentation-fragment.schema.json");
+    for (const value of [null, "{"]) {
+      if (value === null) rmSync(schemaPath);
+      else writeFileSync(schemaPath, value);
+      const errors = documentationCatalogErrors(fixture);
+      assert.ok(errors.some((error) => error.includes("fragment schema를 읽을 수 없다")), errors.join("\n"));
+      assert.ok(errors.every((error) => !error.includes(schemaPath)), errors.join("\n"));
+    }
+  } finally { rmSync(fixture.directory, { recursive: true, force: true }); }
+});
+
+test("documentation catalog fixtures ignore hostile global Git config", () => {
+  const directory = mkdtempSync(join(tmpdir(), "documentation-git-config-"));
+  const configPath = join(directory, "global-config");
+  const previous = process.env.GIT_CONFIG_GLOBAL;
+  writeFileSync(configPath, "[");
+  try {
+    process.env.GIT_CONFIG_GLOBAL = configPath;
+    const fixture = createSingleDocumentationCatalogWorkspace();
+    try { assert.deepEqual(documentationCatalogErrors(fixture), []); }
+    finally { rmSync(fixture.directory, { recursive: true, force: true }); }
+  } finally {
+    if (previous === undefined) delete process.env.GIT_CONFIG_GLOBAL;
+    else process.env.GIT_CONFIG_GLOBAL = previous;
+    rmSync(directory, { recursive: true, force: true });
   }
 });
 
@@ -360,12 +414,12 @@ test("documentation catalog treats metacharacter paths literally and rejects mal
     const fragment = loadJson(join(root, "docs/fragment.json"));
     const metacharacterPath = "docs/[fragment]*?.json";
     writeFileSync(join(root, metacharacterPath), JSON.stringify(fragment));
-    execFileSync("/usr/bin/git", ["add", "."], { cwd: root, stdio: "ignore" });
-    execFileSync("/usr/bin/git", ["commit", "-m", "literal path"], { cwd: root, stdio: "ignore" });
+    fixtureGit(["add", "."], { cwd: root, stdio: "ignore" });
+    fixtureGit(["commit", "-m", "literal path"], { cwd: root, stdio: "ignore" });
     const catalog = loadJson(fixture.catalogPath);
-    catalog.repositories[0].fragment.gitSha = execFileSync("/usr/bin/git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+    catalog.repositories[0].fragment.gitSha = fixtureGit(["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
     catalog.repositories[0].fragment.path = metacharacterPath;
-    catalog.repositories[0].fragment.blobSha = execFileSync("/usr/bin/git", ["rev-parse", `HEAD:${metacharacterPath}`], { cwd: root, encoding: "utf8" }).trim();
+    catalog.repositories[0].fragment.blobSha = fixtureGit(["rev-parse", `HEAD:${metacharacterPath}`], { cwd: root, encoding: "utf8" }).trim();
     writeFileSync(fixture.catalogPath, JSON.stringify(catalog));
     assert.deepEqual(documentationCatalogErrors(fixture), []);
   } finally { rmSync(fixture.directory, { recursive: true, force: true }); }
@@ -443,6 +497,37 @@ test("documentation catalog rejects fragment header and TRACKED identity drift",
   }
 });
 
+test("documentation catalog accepts TRACKED resources larger than the default child-process buffer", () => {
+  const fixture = createSingleDocumentationCatalogWorkspace();
+  try {
+    const root = fixture.repositories[0].root;
+    const resourcePath = join(root, "docs/resource.txt");
+    writeFileSync(resourcePath, "x".repeat(1024 * 1024 + 1));
+    fixtureGit(["add", "docs/resource.txt"], { cwd: root, stdio: "ignore" });
+    fixtureGit(["commit", "-m", "large resource"], { cwd: root, stdio: "ignore" });
+    const innerSha = fixtureGit(["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+    const blobSha = fixtureGit(["rev-parse", "HEAD:docs/resource.txt"], { cwd: root, encoding: "utf8" }).trim();
+    const fragment = loadJson(join(root, "docs/fragment.json"));
+    rewriteDocumentationFragmentInnerCommit(fragment, innerSha, "docs/resource.txt", blobSha);
+    commitDocumentationCatalogFragment(fixture, 0, JSON.stringify(fragment));
+    assert.deepEqual(documentationCatalogErrors(fixture), []);
+  } finally { rmSync(fixture.directory, { recursive: true, force: true }); }
+});
+
+test("documentation catalog does not validate global relations after a fragment transport failure", () => {
+  const fixture = createDocumentationCatalogWorkspace();
+  try {
+    const fragment = loadJson(join(fixture.repositories[0].root, "docs/fragment.json"));
+    fragment.status = "PROPOSED";
+    commitDocumentationCatalogFragment(fixture, 0, JSON.stringify(fragment));
+    commitDocumentationCatalogResources(fixture, 1, (records) => { records[0] = documentationExternalRecord(records[0], "external:duplicate"); });
+    commitDocumentationCatalogResources(fixture, 2, (records) => { records[0] = documentationExternalRecord(records[0], "external:duplicate"); });
+    const errors = documentationCatalogErrors(fixture);
+    assert.ok(errors.some((error) => error.includes("catalog fragment header 불일치")), errors.join("\n"));
+    assert.ok(errors.every((error) => !error.includes("ACTIVE fragment relation")), errors.join("\n"));
+  } finally { rmSync(fixture.directory, { recursive: true, force: true }); }
+});
+
 test("documentation catalog validates global relations across two ACTIVE fragments", () => {
   const cases = [
     ["duplicate resource", (fixture) => {
@@ -490,8 +575,8 @@ test("documentation catalog rejects non-blob outer fragment paths", () => {
       const root = fixture.repositories[0].root;
       rmSync(join(root, "docs/fragment.json"));
       symlinkSync("resource.txt", join(root, "docs/fragment.json"));
-      execFileSync("/usr/bin/git", ["add", "-A"], { cwd: root, stdio: "ignore" });
-      execFileSync("/usr/bin/git", ["commit", "-m", "symlink fragment"], { cwd: root, stdio: "ignore" });
+      fixtureGit(["add", "-A"], { cwd: root, stdio: "ignore" });
+      fixtureGit(["commit", "-m", "symlink fragment"], { cwd: root, stdio: "ignore" });
       rebindDocumentationCatalogFragment(fixture, 0, "docs/fragment.json", "0".repeat(40));
     }],
     ["tree", (fixture) => {
@@ -501,9 +586,9 @@ test("documentation catalog rejects non-blob outer fragment paths", () => {
     ["gitlink", (fixture) => {
       const root = fixture.repositories[0].root;
       rmSync(join(root, "docs/fragment.json"));
-      execFileSync("/usr/bin/git", ["rm", "--cached", "docs/fragment.json"], { cwd: root, stdio: "ignore" });
-      execFileSync("/usr/bin/git", ["update-index", "--add", "--cacheinfo", `160000,${"1".repeat(40)},docs/fragment.json`], { cwd: root, stdio: "ignore" });
-      execFileSync("/usr/bin/git", ["commit", "-m", "gitlink fragment"], { cwd: root, stdio: "ignore" });
+      fixtureGit(["rm", "--cached", "docs/fragment.json"], { cwd: root, stdio: "ignore" });
+      fixtureGit(["update-index", "--add", "--cacheinfo", `160000,${"1".repeat(40)},docs/fragment.json`], { cwd: root, stdio: "ignore" });
+      fixtureGit(["commit", "-m", "gitlink fragment"], { cwd: root, stdio: "ignore" });
       rebindDocumentationCatalogFragment(fixture, 0, "docs/fragment.json", "0".repeat(40));
     }],
   ];
@@ -526,7 +611,7 @@ test("documentation catalog rejects missing and non-ancestor inner commits", () 
     }],
     ["non-ancestor", (fixture) => {
       const root = fixture.repositories[0].root;
-      const innerSha = execFileSync("/usr/bin/git", ["commit-tree", "HEAD^{tree}", "-m", "orphan inner"], { cwd: root, encoding: "utf8" }).trim();
+      const innerSha = fixtureGit(["commit-tree", "HEAD^{tree}", "-m", "orphan inner"], { cwd: root, encoding: "utf8" }).trim();
       const fragment = loadJson(join(root, "docs/fragment.json"));
       rewriteDocumentationFragmentInnerCommit(fragment, innerSha);
       commitDocumentationCatalogFragment(fixture, 0, JSON.stringify(fragment));
@@ -556,9 +641,9 @@ test("documentation catalog rejects missing and symlink TRACKED resources", () =
     const root = symlink.repositories[0].root;
     rmSync(join(root, "docs/resource.txt"));
     symlinkSync("fragment.json", join(root, "docs/resource.txt"));
-    execFileSync("/usr/bin/git", ["add", "-A"], { cwd: root, stdio: "ignore" });
-    execFileSync("/usr/bin/git", ["commit", "-m", "symlink resource inner"], { cwd: root, stdio: "ignore" });
-    const innerSha = execFileSync("/usr/bin/git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+    fixtureGit(["add", "-A"], { cwd: root, stdio: "ignore" });
+    fixtureGit(["commit", "-m", "symlink resource inner"], { cwd: root, stdio: "ignore" });
+    const innerSha = fixtureGit(["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
     const fragment = loadJson(join(root, "docs/fragment.json"));
     rewriteDocumentationFragmentInnerCommit(fragment, innerSha);
     commitDocumentationCatalogFragment(symlink, 0, JSON.stringify(fragment));
@@ -570,13 +655,13 @@ test("documentation catalog ignores local Git replacement objects", () => {
   const fixture = createSingleDocumentationCatalogWorkspace();
   try {
     const root = fixture.repositories[0].root;
-    const goodOuter = execFileSync("/usr/bin/git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
-    const goodBlob = execFileSync("/usr/bin/git", ["rev-parse", "HEAD:docs/fragment.json"], { cwd: root, encoding: "utf8" }).trim();
+    const goodOuter = fixtureGit(["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+    const goodBlob = fixtureGit(["rev-parse", "HEAD:docs/fragment.json"], { cwd: root, encoding: "utf8" }).trim();
     writeFileSync(join(root, "docs/fragment.json"), "null");
-    execFileSync("/usr/bin/git", ["add", "."], { cwd: root, stdio: "ignore" });
-    execFileSync("/usr/bin/git", ["commit", "-m", "bad outer"], { cwd: root, stdio: "ignore" });
-    const badOuter = execFileSync("/usr/bin/git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
-    execFileSync("/usr/bin/git", ["replace", badOuter, goodOuter], { cwd: root, stdio: "ignore" });
+    fixtureGit(["add", "."], { cwd: root, stdio: "ignore" });
+    fixtureGit(["commit", "-m", "bad outer"], { cwd: root, stdio: "ignore" });
+    const badOuter = fixtureGit(["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+    fixtureGit(["replace", badOuter, goodOuter], { cwd: root, stdio: "ignore" });
     const catalog = loadJson(fixture.catalogPath);
     catalog.repositories[0].fragment.gitSha = badOuter;
     catalog.repositories[0].fragment.blobSha = goodBlob;
@@ -590,18 +675,18 @@ test("documentation catalog rejects SHA-256 Git roots when local Git supports th
   try {
     const root = join(fixture.directory, "sha256-root");
     try {
-      execFileSync("/usr/bin/git", ["init", "--object-format=sha256", root], { encoding: "utf8", stdio: "pipe" });
+      fixtureGit(["init", "--object-format=sha256", root], { encoding: "utf8", stdio: "pipe" });
     } catch (error) {
       t.skip(`fixed /usr/bin/git init --object-format=sha256 unavailable: ${error instanceof Error ? error.message : String(error)}`);
       return;
     }
-    updateDocumentationCatalogWorkspace(fixture, (workspace) => { workspace.repositories[0].root = root; });
+    updateDocumentationCatalogWorkspace(fixture, (workspace) => { workspace.repositories[0].root = realpathSync(root); });
     assertDocumentationCatalogFailure(fixture, "Git root");
   } finally { rmSync(fixture.directory, { recursive: true, force: true }); }
 });
 
 test("documentation catalog CLI accepts compatibility modes and rejects malformed optional pairs", () => {
-  const run = (args, cwd = process.cwd()) => execFileSync("node", [resolve("tools/ci/check-contracts.mjs"), ...args], {
+  const run = (args, cwd = process.cwd()) => execFileSync(process.execPath, [resolve("tools/ci/check-contracts.mjs"), ...args], {
     cwd, encoding: "utf8", stdio: "pipe",
   });
   const proposed = createExternalWorkspace();
@@ -615,7 +700,7 @@ test("documentation catalog CLI accepts compatibility modes and rejects malforme
     assert.doesNotThrow(() => run(valid));
     const clone = mkdtempSync(join(tmpdir(), "documentation-catalog-cli-"));
     try {
-      execFileSync("/usr/bin/git", ["init", clone], { stdio: "ignore" });
+      fixtureGit(["init", clone], { stdio: "ignore" });
       const copied = join(clone, "fixture");
       mkdirSync(copied);
       cpSync("contracts", join(clone, "contracts"), { recursive: true });
@@ -626,11 +711,11 @@ test("documentation catalog CLI accepts compatibility modes and rejects malforme
       const clonedWorkspace = loadJson(clonedWorkspacePath);
       clonedWorkspace.contracts = "../contracts";
       writeFileSync(clonedWorkspacePath, JSON.stringify(clonedWorkspace));
-      execFileSync("/usr/bin/git", ["config", "user.email", "test@example.com"], { cwd: clone, stdio: "ignore" });
-      execFileSync("/usr/bin/git", ["config", "user.name", "Test"], { cwd: clone, stdio: "ignore" });
-      execFileSync("/usr/bin/git", ["add", "fixture"], { cwd: clone, stdio: "ignore" });
-      execFileSync("/usr/bin/git", ["commit", "-m", "CLI fixture"], { cwd: clone, stdio: "ignore" });
-      const baseRef = execFileSync("/usr/bin/git", ["rev-parse", "HEAD"], { cwd: clone, encoding: "utf8" }).trim();
+      fixtureGit(["config", "user.email", "test@example.com"], { cwd: clone, stdio: "ignore" });
+      fixtureGit(["config", "user.name", "Test"], { cwd: clone, stdio: "ignore" });
+      fixtureGit(["add", "fixture"], { cwd: clone, stdio: "ignore" });
+      fixtureGit(["commit", "-m", "CLI fixture"], { cwd: clone, stdio: "ignore" });
+      const baseRef = fixtureGit(["rev-parse", "HEAD"], { cwd: clone, encoding: "utf8" }).trim();
       assert.doesNotThrow(() => run([
         "--workspace", "fixture/hub.json", "--base-ref", baseRef,
         "--documentation-fragment-workspace", fixture.fragmentWorkspacePath,
@@ -651,9 +736,9 @@ test("documentation catalog redacts real Git object diagnostics", () => {
     const root = fixture.repositories[0].root;
     const marker = "RAW-FRAGMENT-BYTES-MUST-NOT-LEAK";
     writeFileSync(join(root, "docs/fragment.json"), marker);
-    execFileSync("/usr/bin/git", ["add", "."], { cwd: root, stdio: "ignore" });
-    execFileSync("/usr/bin/git", ["commit", "-m", "bad bytes"], { cwd: root, stdio: "ignore" });
-    const badSha = execFileSync("/usr/bin/git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+    fixtureGit(["add", "."], { cwd: root, stdio: "ignore" });
+    fixtureGit(["commit", "-m", "bad bytes"], { cwd: root, stdio: "ignore" });
+    const badSha = fixtureGit(["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
     const catalog = loadJson(fixture.catalogPath);
     catalog.repositories[0].fragment.gitSha = badSha;
     catalog.repositories[0].fragment.blobSha = "0".repeat(40);
@@ -701,7 +786,7 @@ test("[gate-ownership] workspace는 필수 키 누락을 fail closed한다", () 
 });
 
 test("[gate-ownership] check-contracts CLI는 정확한 workspace 인자만 허용한다", () => {
-  const run = (args) => execFileSync("node", ["tools/ci/check-contracts.mjs", ...args], {
+  const run = (args) => execFileSync(process.execPath, ["tools/ci/check-contracts.mjs", ...args], {
     encoding: "utf8",
     stdio: "pipe",
   });
@@ -1524,9 +1609,9 @@ test("문서 거버넌스 계약은 base-ref에서 전체 supersession chain을 
     malformedWorkspace.architectureDecision = "malformed/ADR-HUB-0001.json";
     writeFileSync(join(repository, "malformed-workspace.json"), JSON.stringify(malformedWorkspace));
     for (const args of [["init"], ["config", "user.email", "test@example.com"], ["config", "user.name", "Test"], ["add", "."], ["commit", "-m", "base"]]) {
-      execFileSync("/usr/bin/git", args, { cwd: repository, stdio: "ignore" });
+      fixtureGit(args, { cwd: repository, stdio: "ignore" });
     }
-    const baseRef = execFileSync("/usr/bin/git", ["rev-parse", "HEAD"], { cwd: repository, encoding: "utf8" }).trim();
+    const baseRef = fixtureGit(["rev-parse", "HEAD"], { cwd: repository, encoding: "utf8" }).trim();
 
     process.chdir(repository);
     assert.deepEqual(

--- a/tools/ci/check-contracts.test.mjs
+++ b/tools/ci/check-contracts.test.mjs
@@ -27,7 +27,7 @@ import {
 } from "./check-contracts.mjs";
 import { validateSchema } from "./lib/json-schema-lite.mjs";
 
-const FIXTURE_GIT_UNSET = ["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE", "GIT_OBJECT_DIRECTORY", "GIT_ALTERNATE_OBJECT_DIRECTORIES", "GIT_CONFIG_COUNT", "GIT_CONFIG_PARAMETERS", "GIT_NAMESPACE", "GIT_SHALLOW_FILE", "GIT_QUARANTINE_PATH", "GIT_CEILING_DIRECTORIES"];
+const FIXTURE_GIT_UNSET = ["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE", "GIT_OBJECT_DIRECTORY", "GIT_ALTERNATE_OBJECT_DIRECTORIES", "GIT_CONFIG_COUNT", "GIT_CONFIG_PARAMETERS", "GIT_NAMESPACE", "GIT_SHALLOW_FILE", "GIT_QUARANTINE_PATH", "GIT_CEILING_DIRECTORIES", "GIT_GLOB_PATHSPECS", "GIT_NOGLOB_PATHSPECS", "GIT_ICASE_PATHSPECS"];
 
 function fixtureGit(args, options = {}) {
   const env = {
@@ -296,6 +296,7 @@ test("documentation catalog ignores inherited hostile Git environment", () => {
     GIT_CONFIG_COUNT: "1",
     GIT_CONFIG_KEY_0: "core.hooksPath",
     GIT_CONFIG_VALUE_0: join(fixture.directory, "not-a-hook-directory"),
+    GIT_GLOB_PATHSPECS: "1",
   };
   const previous = Object.fromEntries(Object.keys(hostile).map((key) => [key, process.env[key]]));
   try {
@@ -511,6 +512,29 @@ test("documentation catalog accepts TRACKED resources larger than the default ch
     rewriteDocumentationFragmentInnerCommit(fragment, innerSha, "docs/resource.txt", blobSha);
     commitDocumentationCatalogFragment(fixture, 0, JSON.stringify(fragment));
     assert.deepEqual(documentationCatalogErrors(fixture), []);
+  } finally { rmSync(fixture.directory, { recursive: true, force: true }); }
+});
+
+test("documentation catalog enforces the explicit 64 MiB blob limit", () => {
+  const fixture = createSingleDocumentationCatalogWorkspace();
+  try {
+    const root = fixture.repositories[0].root;
+    const resourcePath = join(root, "docs/resource.txt");
+    const bindResource = (size) => {
+      writeFileSync(resourcePath, Buffer.alloc(size, "x"));
+      fixtureGit(["add", "docs/resource.txt"], { cwd: root, stdio: "ignore" });
+      fixtureGit(["commit", "-m", `resource ${size}`], { cwd: root, stdio: "ignore" });
+      const innerSha = fixtureGit(["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+      const blobSha = fixtureGit(["rev-parse", "HEAD:docs/resource.txt"], { cwd: root, encoding: "utf8" }).trim();
+      const fragment = loadJson(join(root, "docs/fragment.json"));
+      rewriteDocumentationFragmentInnerCommit(fragment, innerSha, "docs/resource.txt", blobSha);
+      commitDocumentationCatalogFragment(fixture, 0, JSON.stringify(fragment));
+    };
+
+    bindResource(64 * 1024 * 1024);
+    assert.deepEqual(documentationCatalogErrors(fixture), []);
+    bindResource(64 * 1024 * 1024 + 1);
+    assertDocumentationCatalogFailure(fixture, "TRACKED resource blob은 64 MiB 이하여야 한다");
   } finally { rmSync(fixture.directory, { recursive: true, force: true }); }
 });
 

--- a/tools/ci/check-contracts.test.mjs
+++ b/tools/ci/check-contracts.test.mjs
@@ -142,6 +142,37 @@ function replaceDocumentationCatalogFragment(fixture, index, value) {
   writeFileSync(fixture.catalogPath, JSON.stringify(catalog));
 }
 
+function documentationCatalogErrors(fixture) {
+  return collectContractErrors(fixture.workspacePath, {
+    documentationFragmentWorkspacePath: fixture.fragmentWorkspacePath,
+  });
+}
+
+function assertDocumentationCatalogFailure(fixture, expected) {
+  const errors = documentationCatalogErrors(fixture);
+  assert.ok(errors.some((error) => error.includes(expected)), errors.join("\n"));
+  for (const { root } of fixture.repositories) assert.ok(errors.every((error) => !error.includes(root)), errors.join("\n"));
+}
+
+function updateDocumentationCatalogWorkspace(fixture, mutate) {
+  const workspace = loadJson(fixture.fragmentWorkspacePath);
+  mutate(workspace);
+  writeFileSync(fixture.fragmentWorkspacePath, JSON.stringify(workspace));
+}
+
+function commitDocumentationCatalogFragment(fixture, index, value, mutateCatalog = () => {}) {
+  const root = fixture.repositories[index].root;
+  writeFileSync(join(root, "docs/fragment.json"), value);
+  execFileSync("/usr/bin/git", ["add", "."], { cwd: root, stdio: "ignore" });
+  execFileSync("/usr/bin/git", ["commit", "-m", "mutate fragment"], { cwd: root, stdio: "ignore" });
+  const catalog = loadJson(fixture.catalogPath);
+  const fragment = catalog.repositories[index].fragment;
+  fragment.gitSha = execFileSync("/usr/bin/git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+  fragment.blobSha = execFileSync("/usr/bin/git", ["rev-parse", "HEAD:docs/fragment.json"], { cwd: root, encoding: "utf8" }).trim();
+  mutateCatalog(catalog.repositories[index]);
+  writeFileSync(fixture.catalogPath, JSON.stringify(catalog));
+}
+
 test("documentation catalog resolves exact outer and inner Git blobs", () => {
   const fixture = createDocumentationCatalogWorkspace();
   try {
@@ -186,6 +217,151 @@ test("documentation catalog rejects reversed local workspace mappings", () => {
     }).some((error) => error.includes("mapping")));
   } finally {
     rmSync(fixture.directory, { recursive: true, force: true });
+  }
+});
+
+test("documentation catalog rejects malformed and drifting local workspace mappings", () => {
+  const cases = [
+    ["malformed JSON", (fixture) => writeFileSync(fixture.fragmentWorkspacePath, "{"), "유효한 local workspace JSON"],
+    ["invalid shape", (fixture) => writeFileSync(fixture.fragmentWorkspacePath, JSON.stringify({ schemaVersion: 2, repositories: [] })), "shape"],
+    ["relative root", (fixture) => updateDocumentationCatalogWorkspace(fixture, (workspace) => { workspace.repositories[0].root = "relative"; }), "mapping"],
+    ["duplicate mapping", (fixture) => updateDocumentationCatalogWorkspace(fixture, (workspace) => { workspace.repositories.push(structuredClone(workspace.repositories[0])); }), "mapping"],
+    ["unknown mapping", (fixture) => updateDocumentationCatalogWorkspace(fixture, (workspace) => { workspace.repositories[0].repository = "unknown/repository"; }), "mapping"],
+    ["missing mapping", (fixture) => updateDocumentationCatalogWorkspace(fixture, (workspace) => { workspace.repositories.pop(); }), "mapping"],
+  ];
+  for (const [, mutate, expected] of cases) {
+    const fixture = createDocumentationCatalogWorkspace();
+    try {
+      mutate(fixture);
+      assertDocumentationCatalogFailure(fixture, expected);
+    } finally { rmSync(fixture.directory, { recursive: true, force: true }); }
+  }
+});
+
+test("documentation catalog rejects unsafe Git roots and missing outer objects without local path leaks", () => {
+  const cases = [
+    ["non-Git root", (fixture) => {
+      const root = join(fixture.directory, "not-a-git-root");
+      mkdirSync(root);
+      updateDocumentationCatalogWorkspace(fixture, (workspace) => { workspace.repositories[0].root = root; });
+    }, "Git root"],
+    ["nested root", (fixture) => {
+      const root = join(fixture.repositories[0].root, "nested");
+      mkdirSync(root);
+      updateDocumentationCatalogWorkspace(fixture, (workspace) => { workspace.repositories[0].root = root; });
+    }, "Git root"],
+    ["symlink root", (fixture) => {
+      const link = join(fixture.directory, "root-link");
+      symlinkSync(fixture.repositories[0].root, link);
+      updateDocumentationCatalogWorkspace(fixture, (workspace) => { workspace.repositories[0].root = link; });
+    }, "Git root"],
+    ["missing outer SHA", (fixture) => {
+      const catalog = loadJson(fixture.catalogPath);
+      catalog.repositories[0].fragment.gitSha = "f".repeat(40);
+      writeFileSync(fixture.catalogPath, JSON.stringify(catalog));
+    }, "fragment blob"],
+    ["missing outer path", (fixture) => {
+      const catalog = loadJson(fixture.catalogPath);
+      catalog.repositories[0].fragment.path = "docs/missing.json";
+      writeFileSync(fixture.catalogPath, JSON.stringify(catalog));
+    }, "fragment blob"],
+  ];
+  for (const [, mutate, expected] of cases) {
+    const fixture = createDocumentationCatalogWorkspace();
+    try {
+      mutate(fixture);
+      assertDocumentationCatalogFailure(fixture, expected);
+    } finally { rmSync(fixture.directory, { recursive: true, force: true }); }
+  }
+});
+
+test("documentation catalog treats metacharacter paths literally and rejects malformed fragment bytes", () => {
+  const fixture = createDocumentationCatalogWorkspace();
+  try {
+    const root = fixture.repositories[0].root;
+    const fragment = loadJson(join(root, "docs/fragment.json"));
+    const metacharacterPath = "docs/[fragment]*?.json";
+    writeFileSync(join(root, metacharacterPath), JSON.stringify(fragment));
+    execFileSync("/usr/bin/git", ["add", "."], { cwd: root, stdio: "ignore" });
+    execFileSync("/usr/bin/git", ["commit", "-m", "literal path"], { cwd: root, stdio: "ignore" });
+    const catalog = loadJson(fixture.catalogPath);
+    catalog.repositories[0].fragment.gitSha = execFileSync("/usr/bin/git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+    catalog.repositories[0].fragment.path = metacharacterPath;
+    catalog.repositories[0].fragment.blobSha = execFileSync("/usr/bin/git", ["rev-parse", `HEAD:${metacharacterPath}`], { cwd: root, encoding: "utf8" }).trim();
+    writeFileSync(fixture.catalogPath, JSON.stringify(catalog));
+    assert.deepEqual(documentationCatalogErrors(fixture), []);
+  } finally { rmSync(fixture.directory, { recursive: true, force: true }); }
+
+  for (const [label, value, expected] of [
+    ["invalid UTF-8", Buffer.from([0xc3, 0x28]), "fragment JSON"],
+    ["invalid JSON", "{", "fragment JSON"],
+    ["schema invalid", "null", "documentation-fragment"],
+  ]) {
+    const invalid = createDocumentationCatalogWorkspace();
+    try {
+      commitDocumentationCatalogFragment(invalid, 0, value);
+      assertDocumentationCatalogFailure(invalid, expected);
+    } finally { rmSync(invalid.directory, { recursive: true, force: true }); }
+  }
+});
+
+test("documentation catalog rejects fragment header and TRACKED identity drift", () => {
+  const cases = [
+    ["SHA-1 fragment identity", (fixture) => {
+      const catalog = loadJson(fixture.catalogPath);
+      catalog.repositories[0].fragment.blobSha = "0".repeat(40);
+      writeFileSync(fixture.catalogPath, JSON.stringify(catalog));
+    }, "fragment blob identity"],
+    ["SHA-256 fragment identity", (fixture) => {
+      const catalog = loadJson(fixture.catalogPath);
+      catalog.repositories[1].fragment.blobSha = "0".repeat(64);
+      writeFileSync(fixture.catalogPath, JSON.stringify(catalog));
+    }, "fragment blob identity"],
+    ["repository header", (fixture) => {
+      const root = fixture.repositories[0].root;
+      const fragment = loadJson(join(root, "docs/fragment.json"));
+      fragment.repository = fixture.repositories[1].repository;
+      commitDocumentationCatalogFragment(fixture, 0, JSON.stringify(fragment));
+    }, "invalid ownerRepository"],
+    ["status header", (fixture) => {
+      const root = fixture.repositories[0].root;
+      const fragment = loadJson(join(root, "docs/fragment.json"));
+      fragment.status = "PROPOSED";
+      commitDocumentationCatalogFragment(fixture, 0, JSON.stringify(fragment));
+    }, "catalog fragment header"],
+    ["lastVerifiedAt header", (fixture) => {
+      const root = fixture.repositories[0].root;
+      const fragment = loadJson(join(root, "docs/fragment.json"));
+      fragment.lastVerifiedAt = "2026-08-06T00:00:00.000Z";
+      commitDocumentationCatalogFragment(fixture, 0, JSON.stringify(fragment));
+    }, "catalog fragment header"],
+    ["verificationEvidence header", (fixture) => {
+      const root = fixture.repositories[0].root;
+      const fragment = loadJson(join(root, "docs/fragment.json"));
+      fragment.verificationEvidence = ["evidence:other"];
+      commitDocumentationCatalogFragment(fixture, 0, JSON.stringify(fragment));
+    }, "catalog fragment header"],
+    ["TRACKED resource SHA-1", (fixture) => {
+      const root = fixture.repositories[0].root;
+      const fragment = loadJson(join(root, "docs/fragment.json"));
+      fragment.resources[0].canonicalIdentity = fragment.resources[0].canonicalIdentity.replace(/:[0-9a-f]{40}$/, `:${"0".repeat(40)}`);
+      fragment.resources[0].lastVerifiedIdentity = fragment.resources[0].canonicalIdentity;
+      commitDocumentationCatalogFragment(fixture, 0, JSON.stringify(fragment));
+    }, "TRACKED resource blob identity"],
+    ["TRACKED resource SHA-256", (fixture) => {
+      const root = fixture.repositories[1].root;
+      const fragment = loadJson(join(root, "docs/fragment.json"));
+      fragment.resources[0].canonicalIdentity = fragment.resources[0].canonicalIdentity.replace(/:[0-9a-f]{64}$/, `:${"0".repeat(64)}`);
+      fragment.resources[0].lastVerifiedIdentity = fragment.resources[0].canonicalIdentity;
+      commitDocumentationCatalogFragment(fixture, 1, JSON.stringify(fragment));
+    }, "TRACKED resource blob identity"],
+  ];
+  for (const [, mutate, expected] of cases) {
+    const fixture = createDocumentationCatalogWorkspace();
+    try {
+      mutate(fixture);
+      assertDocumentationCatalogFailure(fixture, expected);
+    } finally { rmSync(fixture.directory, { recursive: true, force: true }); }
   }
 });
 

--- a/tools/ci/check-contracts.test.mjs
+++ b/tools/ci/check-contracts.test.mjs
@@ -258,12 +258,12 @@ test("documentation catalog rejects schema-invalid fragment blobs without throwi
   }
 });
 
-test("documentation catalog returns many malformed resource errors without throwing", () => {
+test("documentation catalog returns bounded malformed resource errors without throwing", () => {
   const fixture = createSingleDocumentationCatalogWorkspace();
   try {
     const root = fixture.repositories[0].root;
     const fragment = loadJson(join(root, "docs/fragment.json"));
-    fragment.resources = Array.from({ length: 4000 }, () => ({}));
+    fragment.resources = Array.from({ length: 256 }, () => ({}));
     commitDocumentationCatalogFragment(fixture, 0, JSON.stringify(fragment));
     let errors;
     assert.doesNotThrow(() => { errors = documentationCatalogErrors(fixture); });
@@ -271,35 +271,54 @@ test("documentation catalog returns many malformed resource errors without throw
   } finally { rmSync(fixture.directory, { recursive: true, force: true }); }
 });
 
-test("documentation catalog rejects fragment resource arrays above 4096 before item validation", () => {
+test("documentation catalog rejects fragment resource arrays above 256 before item validation", () => {
   const fixture = createSingleDocumentationCatalogWorkspace();
   try {
     const root = fixture.repositories[0].root;
     const fragment = loadJson(join(root, "docs/fragment.json"));
-    fragment.resources = Array.from({ length: 4097 }, () => ({}));
+    fragment.resources = Array.from({ length: 257 }, () => ({}));
     commitDocumentationCatalogFragment(fixture, 0, JSON.stringify(fragment));
     const errors = documentationCatalogErrors(fixture);
-    assert.ok(errors.some((error) => error.includes("fragment resources는 4096개 이하여야 한다")), errors.join("\n"));
+    assert.ok(errors.some((error) => error.includes("fragment resources는 256개 이하여야 한다")), errors.join("\n"));
     assert.ok(errors.every((error) => !error.includes("documentation-fragment resource")), errors.join("\n"));
   } finally { rmSync(fixture.directory, { recursive: true, force: true }); }
 });
 
-test("documentation catalog limits TRACKED resource work across ACTIVE fragments", () => {
+test("documentation catalog limits the resource union across ACTIVE fragments", () => {
+  const fixture = createDocumentationCatalogWorkspace({ activeIndexes: [0, 1] });
+  try {
+    for (const [repositoryIndex, count] of [128, 129].entries()) {
+      const root = fixture.repositories[repositoryIndex].root;
+      const fragment = loadJson(join(root, "docs/fragment.json"));
+      const base = fragment.resources[0];
+      fragment.resources = Array.from({ length: count }, (_, index) => {
+        const record = documentationExternalRecord(base, `https://example.invalid/${repositoryIndex}/${String(index).padStart(3, "0")}`);
+        record.canonicalIdentity = `sha256:${repositoryIndex}${index.toString(16).padStart(63, "0")}`;
+        record.lastVerifiedIdentity = record.canonicalIdentity;
+        return record;
+      });
+      if (repositoryIndex === 0) {
+        fragment.resources[0] = documentationCatalogRecord(
+          fragment.repository, fragment.gitSha, "0".repeat(40), "docs/missing.txt",
+        );
+      }
+      commitDocumentationCatalogFragment(fixture, repositoryIndex, JSON.stringify(fragment));
+    }
+    const errors = documentationCatalogErrors(fixture);
+    assert.ok(errors.some((error) => error.includes("resources는 전체 256개 이하여야 한다")), errors.join("\n"));
+    assert.ok(errors.every((error) => !error.includes("TRACKED resource blob identity")), errors.join("\n"));
+    assert.ok(errors.every((error) => !error.includes("ACTIVE fragment relation")), errors.join("\n"));
+  } finally { rmSync(fixture.directory, { recursive: true, force: true }); }
+});
+
+test("documentation catalog rejects oversized nested arrays before schema validation", () => {
   const fixture = createSingleDocumentationCatalogWorkspace();
   try {
     const root = fixture.repositories[0].root;
     const fragment = loadJson(join(root, "docs/fragment.json"));
-    const blobSha = fragment.resources[0].canonicalIdentity.split(":").at(-1);
-    fragment.resources = Array.from({ length: 257 }, (_, index) => documentationCatalogRecord(
-      fragment.repository,
-      fragment.gitSha,
-      blobSha,
-      `docs/resource-${String(index).padStart(3, "0")}.txt`,
-    ));
+    fragment.resources[0].currentConsumers = Array.from({ length: 257 }, (_, index) => `consumer:${index}`);
     commitDocumentationCatalogFragment(fixture, 0, JSON.stringify(fragment));
-    const errors = documentationCatalogErrors(fixture);
-    assert.ok(errors.some((error) => error.includes("TRACKED resources는 전체 256개 이하여야 한다")), errors.join("\n"));
-    assert.ok(errors.every((error) => !error.includes("TRACKED resource blob identity")), errors.join("\n"));
+    assertDocumentationCatalogFailure(fixture, "fragment 배열은 256개 항목 이하여야 한다");
   } finally { rmSync(fixture.directory, { recursive: true, force: true }); }
 });
 
@@ -617,6 +636,18 @@ test("documentation catalog enforces the explicit 64 MiB blob limit", () => {
 
     bindResource(64 * 1024 * 1024 + 1);
     assertDocumentationCatalogFailure(fixture, "TRACKED resource blob은 64 MiB 이하여야 한다");
+  } finally { rmSync(fixture.directory, { recursive: true, force: true }); }
+});
+
+test("documentation catalog enforces the 1 MiB fragment JSON limit before parsing", () => {
+  const fixture = createSingleDocumentationCatalogWorkspace();
+  try {
+    const root = fixture.repositories[0].root;
+    const fragment = JSON.stringify(loadJson(join(root, "docs/fragment.json")));
+    commitDocumentationCatalogFragment(fixture, 0, fragment.padEnd(1024 * 1024, " "));
+    assert.deepEqual(documentationCatalogErrors(fixture), []);
+    commitDocumentationCatalogFragment(fixture, 0, fragment.padEnd(1024 * 1024 + 1, " "));
+    assertDocumentationCatalogFailure(fixture, "fragment blob은 1 MiB 이하여야 한다");
   } finally { rmSync(fixture.directory, { recursive: true, force: true }); }
 });
 

--- a/tools/ci/check-contracts.test.mjs
+++ b/tools/ci/check-contracts.test.mjs
@@ -1,7 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, relative, resolve } from "node:path";
 import {
@@ -58,6 +59,95 @@ function bindRootDecisionSchema(directory, adr) {
   adr.decisionSchema = `./${schemaName}`;
   cpSync("contracts/documentation/ADR-HUB-0001-decision.schema.json", join(directory, schemaName));
 }
+
+function documentationCatalogRecord(repository, innerSha, blobSha) {
+  const resource = `${repository}:docs/resource.txt`;
+  const canonicalIdentity = `git:${innerSha}:docs/resource.txt:${blobSha}`;
+  return {
+    resource, resourceClass: "CANONICAL_RESOURCE", documentationFamily: "ARCHITECTURE",
+    kindCandidate: "DOCUMENTATION_RESOURCE", sourceSurface: "TRACKED", canonicalIdentity,
+    status: "ACTIVE", ownerRepository: repository, ownerIssue: null,
+    currentConsumers: ["consumer:documentation"], releaseReachability: "NONE",
+    publicSurfaceReachability: [], assertionState: "REQUIRED_FINAL_PRODUCTION_BEHAVIOR",
+    sensitivity: "INTERNAL", duplicateGroup: null, disposition: "RETAIN_CANONICAL",
+    deletePrerequisite: [], supersedes: [], supersededBy: null, invalidatedBy: null,
+    invalidationReason: null, invalidationEvidence: [], mutationPolicy: "CURRENT_STATE_WITH_CHANGE",
+    reviewPolicyId: "EVENT_ONLY", reviewTrigger: ["event:change"],
+    lastVerifiedAt: "2026-08-05T00:00:00.000Z", lastVerifiedIdentity: canonicalIdentity,
+    verificationMethod: "contract-test", verificationEvidence: ["evidence:fixture"],
+    nextReviewAtOrSemanticExpiry: null, implementationPlan: "PLAN-DOC", workloadClass: null,
+    orchestrationProfile: null, stateClass: null, configurationDelivery: null,
+    healthContract: null, availabilityContract: null, securityContract: null, releaseContract: null,
+    portabilityOwner: null, portabilityEvidence: [], portabilityGap: [],
+  };
+}
+
+function createDocumentationCatalogWorkspace() {
+  const { directory, workspacePath } = createExternalWorkspace();
+  const catalogPath = join(directory, "inputs/documentation-system-catalog.json");
+  const catalog = loadJson(catalogPath);
+  const repositories = [];
+  try {
+    for (const [index, entry] of catalog.repositories.entries()) {
+      const root = join(directory, `repository-${index}`);
+      mkdirSync(join(root, "docs"), { recursive: true });
+      for (const args of [["init"], ["config", "user.email", "test@example.com"], ["config", "user.name", "Test"]]) {
+        execFileSync("/usr/bin/git", args, { cwd: root, stdio: "ignore" });
+      }
+      writeFileSync(join(root, "docs/resource.txt"), `resource-${index}\n`);
+      execFileSync("/usr/bin/git", ["add", "."], { cwd: root, stdio: "ignore" });
+      execFileSync("/usr/bin/git", ["commit", "-m", "inner"], { cwd: root, stdio: "ignore" });
+      const innerSha = execFileSync("/usr/bin/git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+      const resourceBlob = execFileSync("/usr/bin/git", ["rev-parse", "HEAD:docs/resource.txt"], { cwd: root, encoding: "utf8" }).trim();
+      const resourceDigest = createHash("sha256").update(readFileSync(join(root, "docs/resource.txt"))).digest("hex");
+      const resourceIdentity = index === 0 ? resourceBlob : resourceDigest;
+      const fragment = {
+        $schema: "./documentation-fragment.schema.json", schemaVersion: 1,
+        repository: entry.repository, gitSha: innerSha, status: "ACTIVE",
+        lastVerifiedAt: "2026-08-05T00:00:00.000Z", verificationEvidence: ["evidence:fixture"],
+        resources: [documentationCatalogRecord(entry.repository, innerSha, resourceIdentity)],
+      };
+      writeFileSync(join(root, "docs/fragment.json"), JSON.stringify(fragment));
+      execFileSync("/usr/bin/git", ["add", "."], { cwd: root, stdio: "ignore" });
+      execFileSync("/usr/bin/git", ["commit", "-m", "outer"], { cwd: root, stdio: "ignore" });
+      const outerSha = execFileSync("/usr/bin/git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+      const fragmentBlob = execFileSync("/usr/bin/git", ["rev-parse", "HEAD:docs/fragment.json"], { cwd: root, encoding: "utf8" }).trim();
+      entry.status = "ACTIVE";
+      entry.fragment = {
+        gitSha: outerSha, path: "docs/fragment.json", blobSha: index === 0
+          ? fragmentBlob : createHash("sha256").update(readFileSync(join(root, "docs/fragment.json"))).digest("hex"),
+        lastVerifiedAt: fragment.lastVerifiedAt, verificationEvidence: fragment.verificationEvidence,
+      };
+      repositories.push({ repository: entry.repository, root: realpathSync(root) });
+    }
+    writeFileSync(catalogPath, JSON.stringify(catalog));
+    const fragmentWorkspacePath = join(directory, "documentation-fragment-workspace.json");
+    writeFileSync(fragmentWorkspacePath, JSON.stringify({ schemaVersion: 1, repositories }));
+    return { directory, workspacePath, fragmentWorkspacePath, catalogPath, repositories };
+  } catch (error) {
+    rmSync(directory, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+test("documentation catalog resolves exact outer and inner Git blobs", () => {
+  const fixture = createDocumentationCatalogWorkspace();
+  try {
+    assert.ok(collectContractErrors(fixture.workspacePath).some((error) => error.includes("workspace가 필요하다")));
+    assert.deepEqual(collectContractErrors(fixture.workspacePath, {
+      documentationFragmentWorkspacePath: fixture.fragmentWorkspacePath,
+    }), []);
+
+    const localWorkspace = loadJson(fixture.fragmentWorkspacePath);
+    localWorkspace.repositories.pop();
+    writeFileSync(fixture.fragmentWorkspacePath, JSON.stringify(localWorkspace));
+    assert.ok(collectContractErrors(fixture.workspacePath, {
+      documentationFragmentWorkspacePath: fixture.fragmentWorkspacePath,
+    }).some((error) => error.includes("mapping")));
+  } finally {
+    rmSync(fixture.directory, { recursive: true, force: true });
+  }
+});
 
 test("[gate-ownership] workspace는 legacy 경로 밖 복사 입력을 검증한다", () => {
   const { directory, workspacePath } = createExternalWorkspace();

--- a/tools/ci/check-contracts.test.mjs
+++ b/tools/ci/check-contracts.test.mjs
@@ -267,6 +267,22 @@ test("documentation catalog rejects reversed local workspace mappings", () => {
   }
 });
 
+test("documentation catalog rejects ACTIVE null fragment without throwing", () => {
+  const fixture = createDocumentationCatalogWorkspace();
+  try {
+    const catalog = loadJson(fixture.catalogPath);
+    catalog.repositories[0].fragment = null;
+    writeFileSync(fixture.catalogPath, JSON.stringify(catalog));
+    const errors = collectContractErrors(fixture.workspacePath, {
+      documentationFragmentWorkspacePath: fixture.fragmentWorkspacePath,
+    });
+    assert.ok(errors.some((error) => error.includes("ACTIVE fragment가 필요하다")), errors.join("\n"));
+    assert.ok(errors.every((error) => !error.includes(fixture.repositories[0].root)));
+  } finally {
+    rmSync(fixture.directory, { recursive: true, force: true });
+  }
+});
+
 test("documentation catalog rejects malformed and drifting local workspace mappings", () => {
   const cases = [
     ["malformed JSON", (fixture) => writeFileSync(fixture.fragmentWorkspacePath, "{"), "유효한 local workspace JSON"],

--- a/tools/ci/check-contracts.test.mjs
+++ b/tools/ci/check-contracts.test.mjs
@@ -283,6 +283,21 @@ test("documentation catalog rejects ACTIVE null fragment without throwing", () =
   }
 });
 
+test("documentation catalog ignores inherited hostile Git environment", () => {
+  const fixture = createDocumentationCatalogWorkspace();
+  const previous = process.env.GIT_DIR;
+  try {
+    process.env.GIT_DIR = join(fixture.directory, "not-a-git-dir");
+    assert.deepEqual(collectContractErrors(fixture.workspacePath, {
+      documentationFragmentWorkspacePath: fixture.fragmentWorkspacePath,
+    }), []);
+  } finally {
+    if (previous === undefined) delete process.env.GIT_DIR;
+    else process.env.GIT_DIR = previous;
+    rmSync(fixture.directory, { recursive: true, force: true });
+  }
+});
+
 test("documentation catalog rejects malformed and drifting local workspace mappings", () => {
   const cases = [
     ["malformed JSON", (fixture) => writeFileSync(fixture.fragmentWorkspacePath, "{"), "유효한 local workspace JSON"],

--- a/tools/ci/check-contracts.test.mjs
+++ b/tools/ci/check-contracts.test.mjs
@@ -77,9 +77,9 @@ function bindRootDecisionSchema(directory, adr) {
   cpSync("contracts/documentation/ADR-HUB-0001-decision.schema.json", join(directory, schemaName));
 }
 
-function documentationCatalogRecord(repository, innerSha, blobSha) {
-  const resource = `${repository}:docs/resource.txt`;
-  const canonicalIdentity = `git:${innerSha}:docs/resource.txt:${blobSha}`;
+function documentationCatalogRecord(repository, innerSha, blobSha, path = "docs/resource.txt") {
+  const resource = `${repository}:${path}`;
+  const canonicalIdentity = `git:${innerSha}:${path}:${blobSha}`;
   return {
     resource, resourceClass: "CANONICAL_RESOURCE", documentationFamily: "ARCHITECTURE",
     kindCandidate: "DOCUMENTATION_RESOURCE", sourceSurface: "TRACKED", canonicalIdentity,
@@ -281,6 +281,25 @@ test("documentation catalog rejects fragment resource arrays above 4096 before i
     const errors = documentationCatalogErrors(fixture);
     assert.ok(errors.some((error) => error.includes("fragment resources는 4096개 이하여야 한다")), errors.join("\n"));
     assert.ok(errors.every((error) => !error.includes("documentation-fragment resource")), errors.join("\n"));
+  } finally { rmSync(fixture.directory, { recursive: true, force: true }); }
+});
+
+test("documentation catalog limits TRACKED resource work across ACTIVE fragments", () => {
+  const fixture = createSingleDocumentationCatalogWorkspace();
+  try {
+    const root = fixture.repositories[0].root;
+    const fragment = loadJson(join(root, "docs/fragment.json"));
+    const blobSha = fragment.resources[0].canonicalIdentity.split(":").at(-1);
+    fragment.resources = Array.from({ length: 257 }, (_, index) => documentationCatalogRecord(
+      fragment.repository,
+      fragment.gitSha,
+      blobSha,
+      `docs/resource-${String(index).padStart(3, "0")}.txt`,
+    ));
+    commitDocumentationCatalogFragment(fixture, 0, JSON.stringify(fragment));
+    const errors = documentationCatalogErrors(fixture);
+    assert.ok(errors.some((error) => error.includes("TRACKED resources는 전체 256개 이하여야 한다")), errors.join("\n"));
+    assert.ok(errors.every((error) => !error.includes("TRACKED resource blob identity")), errors.join("\n"));
   } finally { rmSync(fixture.directory, { recursive: true, force: true }); }
 });
 
@@ -561,18 +580,41 @@ test("documentation catalog enforces the explicit 64 MiB blob limit", () => {
     const root = fixture.repositories[0].root;
     const resourcePath = join(root, "docs/resource.txt");
     const bindResource = (size) => {
-      writeFileSync(resourcePath, Buffer.alloc(size, "x"));
+      const bytes = Buffer.alloc(size, "x");
+      writeFileSync(resourcePath, bytes);
       fixtureGit(["add", "docs/resource.txt"], { cwd: root, stdio: "ignore" });
       fixtureGit(["commit", "-m", `resource ${size}`], { cwd: root, stdio: "ignore" });
       const innerSha = fixtureGit(["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
       const blobSha = fixtureGit(["rev-parse", "HEAD:docs/resource.txt"], { cwd: root, encoding: "utf8" }).trim();
       const fragment = loadJson(join(root, "docs/fragment.json"));
+      fragment.resources = [fragment.resources[0]];
       rewriteDocumentationFragmentInnerCommit(fragment, innerSha, "docs/resource.txt", blobSha);
       commitDocumentationCatalogFragment(fixture, 0, JSON.stringify(fragment));
+      return createHash("sha256").update(bytes).digest("hex");
     };
 
-    bindResource(64 * 1024 * 1024);
+    const largeDigest = bindResource(64 * 1024 * 1024);
     assert.deepEqual(documentationCatalogErrors(fixture), []);
+
+    const smallBytes = Buffer.from("y");
+    writeFileSync(join(root, "docs/small.txt"), smallBytes);
+    fixtureGit(["add", "docs/small.txt"], { cwd: root, stdio: "ignore" });
+    fixtureGit(["commit", "-m", "aggregate digest payload"], { cwd: root, stdio: "ignore" });
+    const innerSha = fixtureGit(["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+    const fragment = loadJson(join(root, "docs/fragment.json"));
+    fragment.gitSha = innerSha;
+    fragment.resources = [
+      documentationCatalogRecord(fragment.repository, innerSha, largeDigest),
+      documentationCatalogRecord(
+        fragment.repository,
+        innerSha,
+        createHash("sha256").update(smallBytes).digest("hex"),
+        "docs/small.txt",
+      ),
+    ];
+    commitDocumentationCatalogFragment(fixture, 0, JSON.stringify(fragment));
+    assertDocumentationCatalogFailure(fixture, "TRACKED resource SHA-256 payload 합계는 64 MiB 이하여야 한다");
+
     bindResource(64 * 1024 * 1024 + 1);
     assertDocumentationCatalogFailure(fixture, "TRACKED resource blob은 64 MiB 이하여야 한다");
   } finally { rmSync(fixture.directory, { recursive: true, force: true }); }
@@ -679,6 +721,16 @@ test("documentation catalog rejects missing and non-ancestor inner commits", () 
       const fragment = loadJson(join(root, "docs/fragment.json"));
       rewriteDocumentationFragmentInnerCommit(fragment, innerSha);
       commitDocumentationCatalogFragment(fixture, 0, JSON.stringify(fragment));
+    }],
+    ["grafted non-ancestor", (fixture) => {
+      const root = fixture.repositories[0].root;
+      const innerSha = fixtureGit(["commit-tree", "HEAD^{tree}", "-m", "grafted inner"], { cwd: root, encoding: "utf8" }).trim();
+      const fragment = loadJson(join(root, "docs/fragment.json"));
+      rewriteDocumentationFragmentInnerCommit(fragment, innerSha);
+      commitDocumentationCatalogFragment(fixture, 0, JSON.stringify(fragment));
+      const outerSha = fixtureGit(["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+      mkdirSync(join(root, ".git/info"), { recursive: true });
+      writeFileSync(join(root, ".git/info/grafts"), `${outerSha} ${innerSha}\n`);
     }],
   ];
   for (const [, mutate] of cases) {

--- a/tools/ci/check-contracts.test.mjs
+++ b/tools/ci/check-contracts.test.mjs
@@ -338,12 +338,26 @@ test("documentation catalog uses workspace-selected fragment schemas and sanitiz
     writeFileSync(fixture.workspacePath, JSON.stringify(workspace));
     assert.deepEqual(documentationCatalogErrors(fixture), []);
 
-    const schemaPath = join(contracts, "documentation/documentation-fragment.schema.json");
-    for (const value of [null, "{"]) {
+    const fragmentSchemaPath = join(contracts, "documentation/documentation-fragment.schema.json");
+    const resourceSchemaPath = join(contracts, "documentation/documentation-resource.schema.json");
+    const originalFragmentSchema = readFileSync(fragmentSchemaPath);
+    const originalResourceSchema = readFileSync(resourceSchemaPath);
+    const unsupportedFragmentSchema = { ...loadJson(fragmentSchemaPath), unsupportedKeyword: true };
+    const unsupportedResourceSchema = { ...loadJson(resourceSchemaPath), unsupportedKeyword: true };
+    for (const [schemaPath, value, expected] of [
+      [fragmentSchemaPath, null, "fragment schema를 읽을 수 없다"],
+      [fragmentSchemaPath, "{", "fragment schema를 읽을 수 없다"],
+      [fragmentSchemaPath, "null", "fragment schema가 유효하지 않다"],
+      [fragmentSchemaPath, JSON.stringify(unsupportedFragmentSchema), "fragment schema가 유효하지 않다"],
+      [resourceSchemaPath, JSON.stringify(unsupportedResourceSchema), "fragment schema가 유효하지 않다"],
+    ]) {
+      writeFileSync(fragmentSchemaPath, originalFragmentSchema);
+      writeFileSync(resourceSchemaPath, originalResourceSchema);
       if (value === null) rmSync(schemaPath);
       else writeFileSync(schemaPath, value);
-      const errors = documentationCatalogErrors(fixture);
-      assert.ok(errors.some((error) => error.includes("fragment schema를 읽을 수 없다")), errors.join("\n"));
+      let errors;
+      assert.doesNotThrow(() => { errors = documentationCatalogErrors(fixture); });
+      assert.ok(errors.some((error) => error.includes(expected)), errors.join("\n"));
       assert.ok(errors.every((error) => !error.includes(schemaPath)), errors.join("\n"));
     }
   } finally { rmSync(fixture.directory, { recursive: true, force: true }); }

--- a/tools/ci/check-contracts.test.mjs
+++ b/tools/ci/check-contracts.test.mjs
@@ -82,13 +82,19 @@ function documentationCatalogRecord(repository, innerSha, blobSha) {
   };
 }
 
-function createDocumentationCatalogWorkspace() {
+function createDocumentationCatalogWorkspace({ activeIndexes = null } = {}) {
   const { directory, workspacePath } = createExternalWorkspace();
   const catalogPath = join(directory, "inputs/documentation-system-catalog.json");
   const catalog = loadJson(catalogPath);
+  const active = activeIndexes ?? catalog.repositories.map((_, index) => index);
   const repositories = [];
   try {
     for (const [index, entry] of catalog.repositories.entries()) {
+      if (!active.includes(index)) {
+        entry.status = "PROPOSED";
+        entry.fragment = null;
+        continue;
+      }
       const root = join(directory, `repository-${index}`);
       mkdirSync(join(root, "docs"), { recursive: true });
       for (const args of [["init"], ["config", "user.email", "test@example.com"], ["config", "user.name", "Test"]]) {
@@ -128,6 +134,10 @@ function createDocumentationCatalogWorkspace() {
     rmSync(directory, { recursive: true, force: true });
     throw error;
   }
+}
+
+function createSingleDocumentationCatalogWorkspace() {
+  return createDocumentationCatalogWorkspace({ activeIndexes: [0] });
 }
 
 function replaceDocumentationCatalogFragment(fixture, index, value) {
@@ -171,6 +181,27 @@ function commitDocumentationCatalogFragment(fixture, index, value, mutateCatalog
   fragment.blobSha = execFileSync("/usr/bin/git", ["rev-parse", "HEAD:docs/fragment.json"], { cwd: root, encoding: "utf8" }).trim();
   mutateCatalog(catalog.repositories[index]);
   writeFileSync(fixture.catalogPath, JSON.stringify(catalog));
+}
+
+function rebindDocumentationCatalogFragment(fixture, index, path, blobSha) {
+  const root = fixture.repositories[index].root;
+  const catalog = loadJson(fixture.catalogPath);
+  catalog.repositories[index].fragment = {
+    ...catalog.repositories[index].fragment,
+    gitSha: execFileSync("/usr/bin/git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim(),
+    path,
+    blobSha,
+  };
+  writeFileSync(fixture.catalogPath, JSON.stringify(catalog));
+}
+
+function rewriteDocumentationFragmentInnerCommit(fragment, innerSha, resourcePath = "docs/resource.txt", blobSha = null) {
+  const record = fragment.resources[0];
+  const identity = blobSha ?? record.canonicalIdentity.split(":").at(-1);
+  record.resource = `${fragment.repository}:${resourcePath}`;
+  record.canonicalIdentity = `git:${innerSha}:${resourcePath}:${identity}`;
+  record.lastVerifiedIdentity = record.canonicalIdentity;
+  fragment.gitSha = innerSha;
 }
 
 test("documentation catalog resolves exact outer and inner Git blobs", () => {
@@ -363,6 +394,122 @@ test("documentation catalog rejects fragment header and TRACKED identity drift",
       assertDocumentationCatalogFailure(fixture, expected);
     } finally { rmSync(fixture.directory, { recursive: true, force: true }); }
   }
+});
+
+test("documentation catalog rejects non-blob outer fragment paths", () => {
+  const cases = [
+    ["symlink", (fixture) => {
+      const root = fixture.repositories[0].root;
+      rmSync(join(root, "docs/fragment.json"));
+      symlinkSync("resource.txt", join(root, "docs/fragment.json"));
+      execFileSync("/usr/bin/git", ["add", "-A"], { cwd: root, stdio: "ignore" });
+      execFileSync("/usr/bin/git", ["commit", "-m", "symlink fragment"], { cwd: root, stdio: "ignore" });
+      rebindDocumentationCatalogFragment(fixture, 0, "docs/fragment.json", "0".repeat(40));
+    }],
+    ["tree", (fixture) => {
+      const root = fixture.repositories[0].root;
+      rebindDocumentationCatalogFragment(fixture, 0, "docs", "0".repeat(40));
+    }],
+    ["gitlink", (fixture) => {
+      const root = fixture.repositories[0].root;
+      rmSync(join(root, "docs/fragment.json"));
+      execFileSync("/usr/bin/git", ["rm", "--cached", "docs/fragment.json"], { cwd: root, stdio: "ignore" });
+      execFileSync("/usr/bin/git", ["update-index", "--add", "--cacheinfo", `160000,${"1".repeat(40)},docs/fragment.json`], { cwd: root, stdio: "ignore" });
+      execFileSync("/usr/bin/git", ["commit", "-m", "gitlink fragment"], { cwd: root, stdio: "ignore" });
+      rebindDocumentationCatalogFragment(fixture, 0, "docs/fragment.json", "0".repeat(40));
+    }],
+  ];
+  for (const [, mutate] of cases) {
+    const fixture = createSingleDocumentationCatalogWorkspace();
+    try {
+      mutate(fixture);
+      assertDocumentationCatalogFailure(fixture, "fragment blob");
+    } finally { rmSync(fixture.directory, { recursive: true, force: true }); }
+  }
+});
+
+test("documentation catalog rejects missing and non-ancestor inner commits", () => {
+  const cases = [
+    ["missing", (fixture) => {
+      const root = fixture.repositories[0].root;
+      const fragment = loadJson(join(root, "docs/fragment.json"));
+      rewriteDocumentationFragmentInnerCommit(fragment, "f".repeat(40));
+      commitDocumentationCatalogFragment(fixture, 0, JSON.stringify(fragment));
+    }],
+    ["non-ancestor", (fixture) => {
+      const root = fixture.repositories[0].root;
+      const innerSha = execFileSync("/usr/bin/git", ["commit-tree", "HEAD^{tree}", "-m", "orphan inner"], { cwd: root, encoding: "utf8" }).trim();
+      const fragment = loadJson(join(root, "docs/fragment.json"));
+      rewriteDocumentationFragmentInnerCommit(fragment, innerSha);
+      commitDocumentationCatalogFragment(fixture, 0, JSON.stringify(fragment));
+    }],
+  ];
+  for (const [, mutate] of cases) {
+    const fixture = createSingleDocumentationCatalogWorkspace();
+    try {
+      mutate(fixture);
+      assertDocumentationCatalogFailure(fixture, "inner commit relation");
+    } finally { rmSync(fixture.directory, { recursive: true, force: true }); }
+  }
+});
+
+test("documentation catalog rejects missing and symlink TRACKED resources", () => {
+  const missing = createSingleDocumentationCatalogWorkspace();
+  try {
+    const root = missing.repositories[0].root;
+    const fragment = loadJson(join(root, "docs/fragment.json"));
+    rewriteDocumentationFragmentInnerCommit(fragment, fragment.gitSha, "docs/missing.txt", "0".repeat(40));
+    commitDocumentationCatalogFragment(missing, 0, JSON.stringify(fragment));
+    assertDocumentationCatalogFailure(missing, "TRACKED resource blob identity");
+  } finally { rmSync(missing.directory, { recursive: true, force: true }); }
+
+  const symlink = createSingleDocumentationCatalogWorkspace();
+  try {
+    const root = symlink.repositories[0].root;
+    rmSync(join(root, "docs/resource.txt"));
+    symlinkSync("fragment.json", join(root, "docs/resource.txt"));
+    execFileSync("/usr/bin/git", ["add", "-A"], { cwd: root, stdio: "ignore" });
+    execFileSync("/usr/bin/git", ["commit", "-m", "symlink resource inner"], { cwd: root, stdio: "ignore" });
+    const innerSha = execFileSync("/usr/bin/git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+    const fragment = loadJson(join(root, "docs/fragment.json"));
+    rewriteDocumentationFragmentInnerCommit(fragment, innerSha);
+    commitDocumentationCatalogFragment(symlink, 0, JSON.stringify(fragment));
+    assertDocumentationCatalogFailure(symlink, "TRACKED resource blob identity");
+  } finally { rmSync(symlink.directory, { recursive: true, force: true }); }
+});
+
+test("documentation catalog ignores local Git replacement objects", () => {
+  const fixture = createSingleDocumentationCatalogWorkspace();
+  try {
+    const root = fixture.repositories[0].root;
+    const goodOuter = execFileSync("/usr/bin/git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+    const goodBlob = execFileSync("/usr/bin/git", ["rev-parse", "HEAD:docs/fragment.json"], { cwd: root, encoding: "utf8" }).trim();
+    writeFileSync(join(root, "docs/fragment.json"), "null");
+    execFileSync("/usr/bin/git", ["add", "."], { cwd: root, stdio: "ignore" });
+    execFileSync("/usr/bin/git", ["commit", "-m", "bad outer"], { cwd: root, stdio: "ignore" });
+    const badOuter = execFileSync("/usr/bin/git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+    execFileSync("/usr/bin/git", ["replace", badOuter, goodOuter], { cwd: root, stdio: "ignore" });
+    const catalog = loadJson(fixture.catalogPath);
+    catalog.repositories[0].fragment.gitSha = badOuter;
+    catalog.repositories[0].fragment.blobSha = goodBlob;
+    writeFileSync(fixture.catalogPath, JSON.stringify(catalog));
+    assertDocumentationCatalogFailure(fixture, "fragment blob identity");
+  } finally { rmSync(fixture.directory, { recursive: true, force: true }); }
+});
+
+test("documentation catalog rejects SHA-256 Git roots when local Git supports them", (t) => {
+  const fixture = createSingleDocumentationCatalogWorkspace();
+  try {
+    const root = join(fixture.directory, "sha256-root");
+    try {
+      execFileSync("/usr/bin/git", ["init", "--object-format=sha256", root], { encoding: "utf8", stdio: "pipe" });
+    } catch (error) {
+      t.skip(`fixed /usr/bin/git init --object-format=sha256 unavailable: ${error instanceof Error ? error.message : String(error)}`);
+      return;
+    }
+    updateDocumentationCatalogWorkspace(fixture, (workspace) => { workspace.repositories[0].root = root; });
+    assertDocumentationCatalogFailure(fixture, "Git root");
+  } finally { rmSync(fixture.directory, { recursive: true, force: true }); }
 });
 
 test("[gate-ownership] workspace는 legacy 경로 밖 복사 입력을 검증한다", () => {

--- a/tools/ci/check-contracts.test.mjs
+++ b/tools/ci/check-contracts.test.mjs
@@ -271,6 +271,19 @@ test("documentation catalog returns many malformed resource errors without throw
   } finally { rmSync(fixture.directory, { recursive: true, force: true }); }
 });
 
+test("documentation catalog rejects fragment resource arrays above 4096 before item validation", () => {
+  const fixture = createSingleDocumentationCatalogWorkspace();
+  try {
+    const root = fixture.repositories[0].root;
+    const fragment = loadJson(join(root, "docs/fragment.json"));
+    fragment.resources = Array.from({ length: 4097 }, () => ({}));
+    commitDocumentationCatalogFragment(fixture, 0, JSON.stringify(fragment));
+    const errors = documentationCatalogErrors(fixture);
+    assert.ok(errors.some((error) => error.includes("fragment resources는 4096개 이하여야 한다")), errors.join("\n"));
+    assert.ok(errors.every((error) => !error.includes("documentation-fragment resource")), errors.join("\n"));
+  } finally { rmSync(fixture.directory, { recursive: true, force: true }); }
+});
+
 test("documentation catalog rejects reversed local workspace mappings", () => {
   const fixture = createDocumentationCatalogWorkspace();
   try {

--- a/tools/ci/check-contracts.test.mjs
+++ b/tools/ci/check-contracts.test.mjs
@@ -204,6 +204,22 @@ function rewriteDocumentationFragmentInnerCommit(fragment, innerSha, resourcePat
   fragment.gitSha = innerSha;
 }
 
+function documentationExternalRecord(record, resource) {
+  const output = structuredClone(record);
+  output.resource = resource;
+  output.sourceSurface = "EXTERNAL";
+  output.canonicalIdentity = `sha256:${"a".repeat(64)}`;
+  output.lastVerifiedIdentity = output.canonicalIdentity;
+  return output;
+}
+
+function commitDocumentationCatalogResources(fixture, index, mutate) {
+  const root = fixture.repositories[index].root;
+  const fragment = loadJson(join(root, "docs/fragment.json"));
+  mutate(fragment.resources);
+  commitDocumentationCatalogFragment(fixture, index, JSON.stringify(fragment));
+}
+
 test("documentation catalog resolves exact outer and inner Git blobs", () => {
   const fixture = createDocumentationCatalogWorkspace();
   try {
@@ -396,6 +412,47 @@ test("documentation catalog rejects fragment header and TRACKED identity drift",
   }
 });
 
+test("documentation catalog validates global relations across two ACTIVE fragments", () => {
+  const cases = [
+    ["duplicate resource", (fixture) => {
+      commitDocumentationCatalogResources(fixture, 0, (records) => { records[0] = documentationExternalRecord(records[0], "external:duplicate"); });
+      commitDocumentationCatalogResources(fixture, 1, (records) => { records[0] = documentationExternalRecord(records[0], "external:duplicate"); });
+    }],
+    ["invalid duplicate group", (fixture) => {
+      commitDocumentationCatalogResources(fixture, 0, (records) => { records[0] = documentationExternalRecord(records[0], "external:solo"); records[0].duplicateGroup = "group:solo"; });
+    }],
+    ["missing supersession reciprocal", (fixture) => {
+      commitDocumentationCatalogResources(fixture, 0, (records) => { records[0] = documentationExternalRecord(records[0], "external:old"); records[0].status = "SUPERSEDED"; records[0].supersededBy = "external:new"; });
+      commitDocumentationCatalogResources(fixture, 1, (records) => { records[0] = documentationExternalRecord(records[0], "external:new"); });
+    }],
+    ["missing invalidation reciprocal", (fixture) => {
+      commitDocumentationCatalogResources(fixture, 0, (records) => {
+        records[0] = documentationExternalRecord(records[0], "external:invalidated");
+        Object.assign(records[0], { resourceClass: "EVIDENCE", status: "INVALIDATED", invalidatedBy: "external:replacement", invalidationReason: "reason:test", invalidationEvidence: ["evidence:test"], mutationPolicy: "EVIDENCE_IMMUTABLE", releaseReachability: "EVIDENCE", currentConsumers: ["evidence:test"] });
+      });
+      commitDocumentationCatalogResources(fixture, 1, (records) => { records[0] = documentationExternalRecord(records[0], "external:replacement"); });
+    }],
+    ["supersession cycle", (fixture) => {
+      commitDocumentationCatalogResources(fixture, 0, (records) => { records[0] = documentationExternalRecord(records[0], "external:a"); records[0].status = "SUPERSEDED"; records[0].supersededBy = "external:b"; records[0].supersedes = ["external:b"]; });
+      commitDocumentationCatalogResources(fixture, 1, (records) => { records[0] = documentationExternalRecord(records[0], "external:b"); records[0].status = "SUPERSEDED"; records[0].supersededBy = "external:a"; records[0].supersedes = ["external:a"]; });
+    }],
+  ];
+  for (const [, mutate] of cases) {
+    const fixture = createDocumentationCatalogWorkspace({ activeIndexes: [0, 1] });
+    try {
+      mutate(fixture);
+      assertDocumentationCatalogFailure(fixture, "ACTIVE fragment relation");
+    } finally { rmSync(fixture.directory, { recursive: true, force: true }); }
+  }
+
+  const valid = createDocumentationCatalogWorkspace({ activeIndexes: [0, 1] });
+  try {
+    commitDocumentationCatalogResources(valid, 0, (records) => { records[0] = documentationExternalRecord(records[0], "external:old"); records[0].status = "SUPERSEDED"; records[0].supersededBy = "external:new"; });
+    commitDocumentationCatalogResources(valid, 1, (records) => { records[0] = documentationExternalRecord(records[0], "external:new"); records[0].supersedes = ["external:old"]; });
+    assert.deepEqual(documentationCatalogErrors(valid), []);
+  } finally { rmSync(valid.directory, { recursive: true, force: true }); }
+});
+
 test("documentation catalog rejects non-blob outer fragment paths", () => {
   const cases = [
     ["symlink", (fixture) => {
@@ -509,6 +566,70 @@ test("documentation catalog rejects SHA-256 Git roots when local Git supports th
     }
     updateDocumentationCatalogWorkspace(fixture, (workspace) => { workspace.repositories[0].root = root; });
     assertDocumentationCatalogFailure(fixture, "Git root");
+  } finally { rmSync(fixture.directory, { recursive: true, force: true }); }
+});
+
+test("documentation catalog CLI accepts compatibility modes and rejects malformed optional pairs", () => {
+  const run = (args, cwd = process.cwd()) => execFileSync("node", [resolve("tools/ci/check-contracts.mjs"), ...args], {
+    cwd, encoding: "utf8", stdio: "pipe",
+  });
+  const proposed = createExternalWorkspace();
+  try {
+    assert.doesNotThrow(() => run(["--workspace", proposed.workspacePath, "--current-only"]));
+  } finally { rmSync(proposed.directory, { recursive: true, force: true }); }
+
+  const fixture = createSingleDocumentationCatalogWorkspace();
+  try {
+    const valid = ["--workspace", fixture.workspacePath, "--current-only", "--documentation-fragment-workspace", fixture.fragmentWorkspacePath];
+    assert.doesNotThrow(() => run(valid));
+    const clone = mkdtempSync(join(tmpdir(), "documentation-catalog-cli-"));
+    try {
+      execFileSync("/usr/bin/git", ["init", clone], { stdio: "ignore" });
+      const copied = join(clone, "fixture");
+      mkdirSync(copied);
+      cpSync("contracts", join(clone, "contracts"), { recursive: true });
+      for (const name of ["hub.json", "inputs", "gates"]) cpSync(join(fixture.directory, name), join(copied, name), { recursive: true });
+      mkdirSync(join(clone, "release/migrations"), { recursive: true });
+      cpSync("release/migrations/repository-split-issues.json", join(clone, "release/migrations/repository-split-issues.json"));
+      const clonedWorkspacePath = join(copied, "hub.json");
+      const clonedWorkspace = loadJson(clonedWorkspacePath);
+      clonedWorkspace.contracts = "../contracts";
+      writeFileSync(clonedWorkspacePath, JSON.stringify(clonedWorkspace));
+      execFileSync("/usr/bin/git", ["config", "user.email", "test@example.com"], { cwd: clone, stdio: "ignore" });
+      execFileSync("/usr/bin/git", ["config", "user.name", "Test"], { cwd: clone, stdio: "ignore" });
+      execFileSync("/usr/bin/git", ["add", "fixture"], { cwd: clone, stdio: "ignore" });
+      execFileSync("/usr/bin/git", ["commit", "-m", "CLI fixture"], { cwd: clone, stdio: "ignore" });
+      const baseRef = execFileSync("/usr/bin/git", ["rev-parse", "HEAD"], { cwd: clone, encoding: "utf8" }).trim();
+      assert.doesNotThrow(() => run([
+        "--workspace", "fixture/hub.json", "--base-ref", baseRef,
+        "--documentation-fragment-workspace", fixture.fragmentWorkspacePath,
+      ], clone));
+    } finally { rmSync(clone, { recursive: true, force: true }); }
+    for (const args of [
+      valid.slice(0, -1),
+      ["--workspace", fixture.workspacePath, "--documentation-fragment-workspace", fixture.fragmentWorkspacePath, "--current-only"],
+      [...valid, "--documentation-fragment-workspace", fixture.fragmentWorkspacePath],
+      [...valid, "extra"],
+    ]) assert.throws(() => run(args), /사용법/);
+  } finally { rmSync(fixture.directory, { recursive: true, force: true }); }
+});
+
+test("documentation catalog redacts real Git object diagnostics", () => {
+  const fixture = createSingleDocumentationCatalogWorkspace();
+  try {
+    const root = fixture.repositories[0].root;
+    const marker = "RAW-FRAGMENT-BYTES-MUST-NOT-LEAK";
+    writeFileSync(join(root, "docs/fragment.json"), marker);
+    execFileSync("/usr/bin/git", ["add", "."], { cwd: root, stdio: "ignore" });
+    execFileSync("/usr/bin/git", ["commit", "-m", "bad bytes"], { cwd: root, stdio: "ignore" });
+    const badSha = execFileSync("/usr/bin/git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+    const catalog = loadJson(fixture.catalogPath);
+    catalog.repositories[0].fragment.gitSha = badSha;
+    catalog.repositories[0].fragment.blobSha = "0".repeat(40);
+    writeFileSync(fixture.catalogPath, JSON.stringify(catalog));
+    const errors = documentationCatalogErrors(fixture).join("\n");
+    assert.match(errors, /fragment blob identity/);
+    for (const secret of [root, badSha, marker]) assert.ok(!errors.includes(secret), errors);
   } finally { rmSync(fixture.directory, { recursive: true, force: true }); }
 });
 

--- a/tools/ci/check-contracts.test.mjs
+++ b/tools/ci/check-contracts.test.mjs
@@ -258,6 +258,19 @@ test("documentation catalog rejects schema-invalid fragment blobs without throwi
   }
 });
 
+test("documentation catalog returns many malformed resource errors without throwing", () => {
+  const fixture = createSingleDocumentationCatalogWorkspace();
+  try {
+    const root = fixture.repositories[0].root;
+    const fragment = loadJson(join(root, "docs/fragment.json"));
+    fragment.resources = Array.from({ length: 4000 }, () => ({}));
+    commitDocumentationCatalogFragment(fixture, 0, JSON.stringify(fragment));
+    let errors;
+    assert.doesNotThrow(() => { errors = documentationCatalogErrors(fixture); });
+    assert.ok(errors.some((error) => error.includes("documentation-fragment resource")), errors.join("\n"));
+  } finally { rmSync(fixture.directory, { recursive: true, force: true }); }
+});
+
 test("documentation catalog rejects reversed local workspace mappings", () => {
   const fixture = createDocumentationCatalogWorkspace();
   try {

--- a/tools/ci/check-contracts.test.mjs
+++ b/tools/ci/check-contracts.test.mjs
@@ -130,6 +130,18 @@ function createDocumentationCatalogWorkspace() {
   }
 }
 
+function replaceDocumentationCatalogFragment(fixture, index, value) {
+  const root = fixture.repositories[index].root;
+  writeFileSync(join(root, "docs/fragment.json"), value);
+  execFileSync("/usr/bin/git", ["add", "."], { cwd: root, stdio: "ignore" });
+  execFileSync("/usr/bin/git", ["commit", "-m", "invalid fragment"], { cwd: root, stdio: "ignore" });
+  const catalog = loadJson(fixture.catalogPath);
+  const fragment = catalog.repositories[index].fragment;
+  fragment.gitSha = execFileSync("/usr/bin/git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+  fragment.blobSha = execFileSync("/usr/bin/git", ["rev-parse", "HEAD:docs/fragment.json"], { cwd: root, encoding: "utf8" }).trim();
+  writeFileSync(fixture.catalogPath, JSON.stringify(catalog));
+}
+
 test("documentation catalog resolves exact outer and inner Git blobs", () => {
   const fixture = createDocumentationCatalogWorkspace();
   try {
@@ -140,6 +152,34 @@ test("documentation catalog resolves exact outer and inner Git blobs", () => {
 
     const localWorkspace = loadJson(fixture.fragmentWorkspacePath);
     localWorkspace.repositories.pop();
+    writeFileSync(fixture.fragmentWorkspacePath, JSON.stringify(localWorkspace));
+    assert.ok(collectContractErrors(fixture.workspacePath, {
+      documentationFragmentWorkspacePath: fixture.fragmentWorkspacePath,
+    }).some((error) => error.includes("mapping")));
+  } finally {
+    rmSync(fixture.directory, { recursive: true, force: true });
+  }
+});
+
+test("documentation catalog rejects schema-invalid fragment blobs without throwing", () => {
+  const fixture = createDocumentationCatalogWorkspace();
+  try {
+    replaceDocumentationCatalogFragment(fixture, 0, "null");
+    const errors = collectContractErrors(fixture.workspacePath, {
+      documentationFragmentWorkspacePath: fixture.fragmentWorkspacePath,
+    });
+    assert.ok(errors.some((error) => error.includes("documentation-fragment")), errors.join("\n"));
+    assert.ok(errors.every((error) => !error.includes(fixture.repositories[0].root)));
+  } finally {
+    rmSync(fixture.directory, { recursive: true, force: true });
+  }
+});
+
+test("documentation catalog rejects reversed local workspace mappings", () => {
+  const fixture = createDocumentationCatalogWorkspace();
+  try {
+    const localWorkspace = loadJson(fixture.fragmentWorkspacePath);
+    localWorkspace.repositories.reverse();
     writeFileSync(fixture.fragmentWorkspacePath, JSON.stringify(localWorkspace));
     assert.ok(collectContractErrors(fixture.workspacePath, {
       documentationFragmentWorkspacePath: fixture.fragmentWorkspacePath,


### PR DESCRIPTION
## 관련 이슈

Closes #2760
Refs #2748

## 작업 배경

- 문서 시스템 catalog의 `ACTIVE` fragment를 신뢰할 수 있는 고정 Git object로 해석하는 경로가 없어 Wave 4 문서 fragment를 활성화할 수 없었습니다.

## 작업 내용

- local-only workspace가 지정한 5개 정본 저장소의 exact SHA-1 commit/blob을 fixed `/usr/bin/git`으로 검증합니다.
- catalog outer commit과 fragment inner resource snapshot을 분리하고 ancestor 관계, blob OID/SHA-256, schema·semantic·global relation을 fail closed로 검증합니다.
- workspace, Git root/object, bytes/header, TRACKED resource, cross-fragment relation, CLI 및 오류 redaction 실패 행렬을 추가했습니다.

## Documentation impact

- 영향 resource ID 또는 `NONE`: `NONE` (fragment payload 및 catalog status 변경 없음)
- resourceClass: `NONE`
- documentationFamily: `NONE`
- lifecycle/evidence 영향: 후속 Wave 4 fragment가 `ACTIVE`로 전환되기 전에 exact Git object와 global relation을 검증할 transport gate를 추가합니다.

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern 'documentation catalog' tools/ci/check-contracts.test.mjs` — 17/17 통과, 33.6초, skip 0
  - `node tools/ci/check-contracts.mjs --workspace contracts/workspaces/hub.json --current-only` — 통과
  - `node tools/ci/check-contracts.mjs --workspace contracts/workspaces/hub.json --base-ref 00c6109bf91e052fc0d9944a84fde1601c1c50c1` — 통과
  - `git diff --check 00c6109bf91e052fc0d9944a84fde1601c1c50c1..HEAD` — 통과

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Git-object transport 계약 | Hub CI | focused Node test 및 current/base contract 명령 | 위 검증 명령 출력 | 통과 |
| UI·배포 | 해당 없음 | 코드/계약 validator와 테스트만 변경 | UI·배포 변경 없음 | 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: fixed Git environment, outer/inner commit 분리, literal non-symlink blob resolution, schema-invalid 입력의 예외 탈출 차단, global relation union 검증을 확인해 주세요.

## 리스크

- local-only workspace의 absolute root는 PR 산출물에 포함하지 않습니다. SHA-256 Git repository와 missing/local replacement object는 fail closed하며 remote/network fallback을 사용하지 않습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 없어 CD 상태 확인이 필요하지 않다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 문서 시스템 카탈로그 검증 시 ACTIVE fragment workspace 경로를 지정할 수 있습니다.
  * 로컬 저장소의 fragment와 카탈로그 간 커밋·blob 식별자, JSON 스키마, 구조 및 관계를 종합적으로 검증합니다.
  * SHA-1·SHA-256 저장소와 다양한 문서 생명주기 관계를 지원합니다.

* **버그 수정**
  * 잘못된 경로, 손상된 데이터, 식별자 불일치 및 부적절한 커밋 관계를 더욱 정확하게 감지합니다.
  * 진단 메시지에 민감한 저장소 정보가 노출되지 않도록 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->