### PR TITLE
[Test] 관리자 대시보드 날짜 의존 테스트 결정성 복구

### DIFF
--- a/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminDashboardPageTest.java
+++ b/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminDashboardPageTest.java
@@ -13,7 +13,10 @@ import com.easysubway.admin.authorization.AdminPermission;
 import com.easysubway.admin.metric.application.port.out.AdminMetricDailyRepository;
 import com.easysubway.admin.metric.domain.AdminMetricDaily;
 import com.easysubway.admin.metric.domain.AdminMetricKeys;
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.DisplayName;
@@ -21,6 +24,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -31,8 +37,11 @@ import org.springframework.test.web.servlet.MockMvc;
 	"easysubway.admin.password=admin-test-password"
 })
 @AutoConfigureMockMvc
+@Import(AdminDashboardPageTest.FixedClockConfiguration.class)
 @DisplayName("통합 대시보드 재설계")
 class AdminDashboardPageTest {
+
+	private static final LocalDate TODAY = LocalDate.of(2026, 8, 8);
 
 	@Autowired
 	private MockMvc mockMvc;
@@ -44,8 +53,8 @@ class AdminDashboardPageTest {
 	@DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
 	@DisplayName("현재 운영 상태와 최근 7일 제보 흐름을 실제 지표로 렌더한다")
 	void rendersCurrentOperationsAndSevenDayReportFlow() throws Exception {
-		repository.save(AdminMetricDaily.scalar(AdminMetricKeys.REPORTS_RECENT_24H, LocalDate.now().minusDays(1), 4));
-		repository.save(AdminMetricDaily.scalar(AdminMetricKeys.REPORTS_RECENT_24H, LocalDate.now(), 7));
+		repository.save(AdminMetricDaily.scalar(AdminMetricKeys.REPORTS_RECENT_24H, TODAY.minusDays(1), 4));
+		repository.save(AdminMetricDaily.scalar(AdminMetricKeys.REPORTS_RECENT_24H, TODAY, 7));
 
 		String html = mockMvc.perform(get("/admin/dashboard/page")
 				.with(httpBasic("admin-test", "admin-test-password")))
@@ -99,8 +108,8 @@ class AdminDashboardPageTest {
 	@Test
 	@DisplayName("핵심 카드가 클릭 가능하고 스냅샷 이력이 있으면 스파크라인을 그린다")
 	void rendersClickableCardsWithSparkline() throws Exception {
-		repository.save(AdminMetricDaily.scalar(AdminMetricKeys.REPORTS_PENDING, LocalDate.now().minusDays(1), 3));
-		repository.save(AdminMetricDaily.scalar(AdminMetricKeys.REPORTS_PENDING, LocalDate.now(), 8));
+		repository.save(AdminMetricDaily.scalar(AdminMetricKeys.REPORTS_PENDING, TODAY.minusDays(1), 3));
+		repository.save(AdminMetricDaily.scalar(AdminMetricKeys.REPORTS_PENDING, TODAY, 8));
 
 		String html = mockMvc.perform(get("/admin/dashboard/page")
 				.with(httpBasic("admin-test", "admin-test-password")))
@@ -124,8 +133,8 @@ class AdminDashboardPageTest {
 	@Test
 	@DisplayName("축과 범례가 없는 장식 운영 추이를 렌더하지 않는다")
 	void omitsDecorativeReferenceTrend() throws Exception {
-		repository.save(AdminMetricDaily.scalar(AdminMetricKeys.REPORTS_PENDING, LocalDate.now().minusDays(1), 3));
-		repository.save(AdminMetricDaily.scalar(AdminMetricKeys.REPORTS_PENDING, LocalDate.now(), 8));
+		repository.save(AdminMetricDaily.scalar(AdminMetricKeys.REPORTS_PENDING, TODAY.minusDays(1), 3));
+		repository.save(AdminMetricDaily.scalar(AdminMetricKeys.REPORTS_PENDING, TODAY, 8));
 
 		String html = mockMvc.perform(get("/admin/dashboard/page")
 				.with(httpBasic("admin-test", "admin-test-password")))
@@ -260,10 +269,19 @@ class AdminDashboardPageTest {
 	// 추이 섹션이 참조하는 4개 지표 키(REPORTS_RECENT_24H·REPORTS_PENDING·ROUTE_BLOCKED_RATE·
 	// API_ERROR_RATE) 모두에 오늘자 스냅샷을 채워 두 추이 패널이 모두 데이터를 갖게 한다(#2327).
 	private void seedAllTrendMetrics() {
-		repository.save(AdminMetricDaily.scalar(AdminMetricKeys.REPORTS_RECENT_24H, LocalDate.now(), 5));
-		repository.save(AdminMetricDaily.scalar(AdminMetricKeys.REPORTS_PENDING, LocalDate.now(), 3));
-		repository.save(AdminMetricDaily.scalar(AdminMetricKeys.ROUTE_BLOCKED_RATE, LocalDate.now(), 12));
-		repository.save(AdminMetricDaily.scalar(AdminMetricKeys.API_ERROR_RATE, LocalDate.now(), 1));
+		repository.save(AdminMetricDaily.scalar(AdminMetricKeys.REPORTS_RECENT_24H, TODAY, 5));
+		repository.save(AdminMetricDaily.scalar(AdminMetricKeys.REPORTS_PENDING, TODAY, 3));
+		repository.save(AdminMetricDaily.scalar(AdminMetricKeys.ROUTE_BLOCKED_RATE, TODAY, 12));
+		repository.save(AdminMetricDaily.scalar(AdminMetricKeys.API_ERROR_RATE, TODAY, 1));
+	}
+
+	@TestConfiguration
+	static class FixedClockConfiguration {
+
+		@Bean
+		Clock adminDashboardPageTestClock() {
+			return Clock.fixed(Instant.parse("2026-08-07T15:00:00Z"), ZoneId.of("Asia/Seoul"));
+		}
 	}
 
 	private String issueCommandToken(MockHttpSession session) throws Exception {


### PR DESCRIPTION
## 관련 이슈

Refs #2526

## 작업 내용

- current `main` CI에서 실패한 `AdminDashboardPageTest`의 시스템 날짜 의존성을 제거했습니다.
- 실패일인 2026-08-08(토요일)을 `Asia/Seoul` 고정 `Clock`과 단일 `TODAY`로 사용해 `is-today`와 `is-weekend`가 동시에 적용되는 회귀 조건을 보존했습니다.
- production code, template, runtime 동작은 변경하지 않았습니다.

## Documentation impact

- 영향 resource ID 또는 `NONE`: `NONE` — 테스트 컨텍스트의 날짜만 고정하며 외부 동작·계약·Owner·운영 절차·공개 Claim은 불변입니다.
- resourceClass: `NONE`
- documentationFamily: `NONE`
- lifecycle/evidence 영향: current `main` Backend CI 실패의 결정적 재현·closure evidence만 추가합니다.

## 검증

- 실행한 명령과 결과:
  - `git diff --check` — 통과
  - `rg -n 'LocalDate\.now\(' backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminDashboardPageTest.java` — 잔존 0
  - 로컬 Gradle은 owner machine exact-command 승인 경계에 따라 실행하지 않았습니다. Draft PR의 `Backend CI` 단일 class 포함 Gradle gate를 증거로 사용합니다.

## 영향

- [x] 제품/운영 위험 없음 (route/accessibility/mobile UX/backend API/auth/security 아님)
- [x] DB migration 없음
- [x] 배포 영향 없음
- [x] route/realtime/datapack contract 영향 없음
- [x] CI workflow·계약 테스트·release gate JSON 변경 없음 (있으면 full.md로 전환)

## 체크리스트

- [x] 이 PR은 B/C등급 작업이며 full template이 필요 없다.
- [ ] CI 결과를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 폴백 리뷰를 단일 PR review로 게시했다.
