### PR TITLE
[Fix] Frozen discovery Review와 delivery gate 분리

### DIFF
--- a/.github/workflows/automerge-queue.yml
+++ b/.github/workflows/automerge-queue.yml
@@ -4,8 +4,8 @@ name: Automerge Queue
 # automerge 라벨이 붙은 PR을 생성순으로 한 번에 하나만 처리한다:
 # head PR에 auto-merge를 예약하고 BEHIND면 update-branch 한다.
 # 병합이 일어나면 push 이벤트가 이 워크플로우를 다시 실행해 다음 PR을 처리한다.
-# 라벨은 merge-workflow 규약 4단계(코드리뷰 게이트) 완료 후에만 붙인다.
-# 코디네이터는 review 객체가 없는 PR을 큐에서 제외해 규약을 재검증한다.
+# 라벨은 merge-workflow 규약 4단계(단일 discovery Review 게이트) 완료 후에만 붙인다.
+# fix/rebase는 discovery Review를 무효화하지 않으며 current-head CI·thread·exact-head gate가 delivery를 보호한다.
 # labeled 이벤트의 라벨 검색 인덱싱 지연(빈 큐 오검출)은 이벤트 PR 직접 합류 + REST 재확인으로 보정한다 (#2010).
 
 on:
@@ -111,7 +111,7 @@ jobs:
             merge_state=$(jq -r '.mergeStateStatus' <<<"${state}")
             head=$(jq -r '.headRefOid' <<<"${state}")
             reviews=$(gh api --paginate --slurp "repos/${REPO}/pulls/${pr_number}/reviews")
-            review_gate=$(jq -r --arg head "${head}" '
+            review_gate=$(jq -r '
               def is_coderabbit:
                 .author_association == "NONE" and
                 .user.login == "coderabbitai[bot]" and
@@ -128,29 +128,58 @@ jobs:
               | ($latest | length > 0) and
                 all($latest[]; .state != "CHANGES_REQUESTED") and
                 any($latest[];
-                  .commit_id == $head and
                   ((.state == "APPROVED" and is_trusted_human) or
                     (.state == "COMMENTED" and
                       (is_coderabbit or
                         ((.body // "" | startswith("**Actionable comments posted: ")) and
                           (.body // "" | contains("<!-- Review source: Codex CLI fallback; canonical visible structure:")))))))
             ' <<<"${reviews}")
+            threads=$(gh api graphql --paginate --slurp \
+              -f query='query($owner: String!, $name: String!, $number: Int!, $endCursor: String) {
+                repository(owner: $owner, name: $name) {
+                  pullRequest(number: $number) {
+                    reviewThreads(first: 100, after: $endCursor) {
+                      nodes { isResolved }
+                      pageInfo { hasNextPage endCursor }
+                    }
+                  }
+                }
+              }' \
+              -F owner="${REPO%%/*}" \
+              -F name="${REPO##*/}" \
+              -F number="${pr_number}")
+            unresolved_threads=$(jq -r \
+              '[flatten[] | .data.repository.pullRequest.reviewThreads.nodes[]?
+                | select(.isResolved == false)] | length' <<<"${threads}")
             failed_required=$(jq -r --argjson required "${required_checks}" \
               '[.statusCheckRollup[]?
                 | select(($required | index(.name? // .context?)) != null)
                 | select(((.conclusion? // .state?) // "") as $c
                   | $c == "FAILURE" or $c == "ERROR")] | length' <<<"${state}")
 
-            echo "PR #${pr_number}: mergeStateStatus=${merge_state}, reviewGate=${review_gate}, failedRequiredChecks=${failed_required}"
+            echo "PR #${pr_number}: mergeStateStatus=${merge_state}, reviewGate=${review_gate}, unresolvedThreads=${unresolved_threads}, failedRequiredChecks=${failed_required}"
 
             if [ "${review_gate}" != "true" ]; then
-              derail "${pr_number}" "현재 head의 신뢰 가능한 GitHub PR Review가 없거나 active change request가 있습니다."
+              derail "${pr_number}" "지원되는 단일 discovery Review가 없거나 active change request가 있습니다."
+              continue
+            fi
+
+            if [ "${unresolved_threads}" -gt 0 ]; then
+              derail "${pr_number}" "미해결 Review thread가 ${unresolved_threads}개 있습니다."
               continue
             fi
 
             if [ "${merge_state}" = "DIRTY" ]; then
               derail "${pr_number}" "main과 충돌(DIRTY) 상태입니다. 충돌 해결이 필요합니다."
               continue
+            fi
+
+            if [ "${merge_state}" = "BEHIND" ]; then
+              gh api --method PUT "repos/${REPO}/pulls/${pr_number}/update-branch" \
+                -H "Accept: application/vnd.github+json" \
+                -f expected_head_sha="${head}"
+              echo "큐 head PR #${pr_number}: exact head ${head}에서 base 갱신 완료 — current-head CI 뒤 재처리한다."
+              exit 0
             fi
 
             if [ "${failed_required}" -gt 0 ]; then
@@ -160,13 +189,8 @@ jobs:
 
             # 여기부터 큐 head 확정 — 한 번에 하나만 처리한다.
             gh pr merge "${pr_number}" --repo "${REPO}" --squash --auto \
+              --match-head-commit "${head}" \
               || echo "::warning::PR #${pr_number} auto-merge 예약 실패 — 다음 트리거에서 재시도한다."
-
-            if [ "${merge_state}" = "BEHIND" ]; then
-              gh api --method PUT "repos/${REPO}/pulls/${pr_number}/update-branch" \
-                -H "Accept: application/vnd.github+json" \
-                || echo "::warning::PR #${pr_number} update-branch 실패(transient 가능) — 다음 트리거에서 재시도한다."
-            fi
 
             echo "큐 head PR #${pr_number} 처리 완료 — 필수 체크 통과 시 auto-merge가 병합한다."
             exit 0

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1434,12 +1434,12 @@ test("main ruleset 필수 체크는 ci.yml 잡 이름·automerge 코디네이터
   assert.deepEqual(JSON.parse(fallbackMatch[1]), REQUIRED_STATUS_CHECK_CONTEXTS);
 });
 
-test("automerge 큐는 current head의 신뢰 가능한 최신 리뷰 상태만 허용한다", () => {
+test("automerge 큐는 frozen discovery 리뷰와 current-head delivery gate를 분리한다", () => {
   const coordinator = read(".github/workflows/automerge-queue.yml");
 
   assert.match(coordinator, /--json mergeStateStatus,headRefOid,statusCheckRollup/);
   assert.match(coordinator, /gh api --paginate --slurp "repos\/\$\{REPO\}\/pulls\/\$\{pr_number\}\/reviews"/);
-  assert.match(coordinator, /\.commit_id == \$head/);
+  assert.doesNotMatch(coordinator, /\.commit_id == \$head/);
   assert.match(coordinator, /\["OWNER", "MEMBER", "COLLABORATOR"\]/);
   assert.match(coordinator, /\*\*Actionable comments posted: /);
   assert.match(coordinator, /<!-- Review source: Codex CLI fallback; canonical visible structure:/);
@@ -1451,6 +1451,16 @@ test("automerge 큐는 current head의 신뢰 가능한 최신 리뷰 상태만 
   assert.match(coordinator, /\.state != "CHANGES_REQUESTED"/);
   assert.match(coordinator, /\.state == "APPROVED"/);
   assert.match(coordinator, /\.state == "COMMENTED"/);
+  assert.match(coordinator, /reviewThreads\(first: 100, after: \$endCursor\)/);
+  assert.match(coordinator, /unresolved_threads/);
+  assert.match(coordinator, /\[ "\$\{unresolved_threads\}" -gt 0 \]/);
+  assert.match(coordinator, /--match-head-commit "\$\{head\}"/);
+  assert.match(coordinator, /-f expected_head_sha="\$\{head\}"/);
+  assert.ok(
+    coordinator.indexOf('if [ "${merge_state}" = "BEHIND" ]')
+      < coordinator.indexOf('if [ "${failed_required}" -gt 0 ]'),
+    "BEHIND PR must refresh its exact head before stale required failures are judged",
+  );
   assert.doesNotMatch(coordinator, /reviews\.length/);
   assert.doesNotMatch(coordinator, /review_count/);
 });


### PR DESCRIPTION
## 관련 이슈

Closes #2772

## 작업 배경

- #2771이 reviewer identity 검증은 추가했지만 `Review.commit_id == current head`를 강제해 single discovery Review를 fix/rebase마다 무효화했습니다.

## 작업 내용

- 동일 PR/change set의 trusted Human/Codex 또는 exact CodeRabbit discovery Review 1회를 인정합니다.
- active `CHANGES_REQUESTED`와 spoof reviewer를 계속 차단합니다.
- unresolved Review thread 0, current-head required CI, exact update/merge head를 fail closed로 확인합니다.
- BEHIND PR은 stale check failure 판정 전에 exact head로 base를 갱신합니다.

## Documentation impact

- 영향 resource ID 또는 `NONE`: NONE
- resourceClass: NONE
- documentationFamily: NONE
- lifecycle/evidence 영향: automerge Review와 delivery gate만 변경

## 검증

- 계약 테스트 RED→GREEN: 1/1 PASS
- exact CodeRabbit positive filter: `true`
- latest active `CHANGES_REQUESTED` filter: `false`
- `git diff --check`: PASS

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 결과 |
| --- | --- | --- | --- |
| frozen discovery contract | local Node | targeted repository contract test | PASS |
| reviewer state filter | local jq | positive/changes-requested matrix | PASS |
| diff hygiene | git | `git diff --check` | PASS |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName/versionCode: 변경 없음
- datapack version: 변경 없음
- route/realtime/backend identity: 변경 없음

## 리뷰어 메모

- owner가 exact trust-gate 변경과 #2772의 main 직접 squash merge를 초긴급 승인했습니다.

## 리스크

- discovery Review는 fix/rebase 뒤 유지되므로, delivery 안전성은 unresolved thread 0·current-head required CI·exact head gate가 독립적으로 보장합니다.

## 체크리스트

- [x] PR 본문 필수 section을 유지했다.
- [x] targeted contract test와 diff check를 확인했다.
- [x] owner가 code review/CI 대기 없이 직접 squash merge를 승인했다.
- [x] 배포 영향 없음
