### PR TITLE
[Feat] Generic Mobile bundle immutable 발행 고정

### DIFF
--- a/.github/workflows/generic-mobile-consumer-bundle-publish.yml
+++ b/.github/workflows/generic-mobile-consumer-bundle-publish.yml
@@ -19,15 +19,15 @@ jobs:
             exit 1
           fi
 
-      - name: Checkout closed producer
+      - name: Checkout dispatch revision
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          ref: 604a2ae525cc20b3bdcd3cbe2e22f93de19fefc3
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
-          node-version: 22.14.0
+          node-version: 24.19.0
 
       - name: Build and validate closed bundle
         shell: bash

--- a/.github/workflows/generic-mobile-consumer-bundle-publish.yml
+++ b/.github/workflows/generic-mobile-consumer-bundle-publish.yml
@@ -88,12 +88,15 @@ jobs:
           test -f "${metadata}" && test ! -L "${metadata}"
           node tools/repo/write-generic-mobile-consumer-bundle-receipt.mjs --artifact-metadata "${metadata}" --artifact-id "${artifact_id}" --artifact-digest "${artifact_digest}" --workflow-run-id "${GITHUB_RUN_ID}" --repository-id "${GITHUB_REPOSITORY_ID}" --head-sha "${GITHUB_SHA}"
 
-      - name: Clean artifact download directory
+      - name: Reject preexisting artifact download path
         shell: bash
         run: |
           set -euo pipefail
           download_directory="${RUNNER_TEMP}/easysubway-generic-mobile-consumer-bundle-download-${GITHUB_RUN_ID}"
-          rm -rf "${download_directory}"
+          if [[ -e "${download_directory}" || -L "${download_directory}" ]]; then
+            echo "artifact download path already exists" >&2
+            exit 1
+          fi
 
       - name: Download exact artifact ID
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093

--- a/.github/workflows/generic-mobile-consumer-bundle-publish.yml
+++ b/.github/workflows/generic-mobile-consumer-bundle-publish.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
 
 jobs:
@@ -57,6 +58,73 @@ jobs:
           if-no-files-found: error
           retention-days: 90
           overwrite: false
+
+      - name: Fetch and validate artifact metadata
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          artifact_id="${{ steps.upload.outputs.artifact-id }}"
+          artifact_digest="${{ steps.upload.outputs.artifact-digest }}"
+          if [[ ! "${artifact_id}" =~ ^[1-9][0-9]*$ ]]; then
+            echo "artifact-id is invalid" >&2
+            exit 1
+          fi
+          if [[ ! "${artifact_digest}" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "artifact-digest is invalid" >&2
+            exit 1
+          fi
+          if [[ ! "${GITHUB_RUN_ID}" =~ ^[1-9][0-9]*$ ]]; then
+            echo "workflow-run-id is invalid" >&2
+            exit 1
+          fi
+          if [[ ! "${GITHUB_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "workflow-head-sha is invalid" >&2
+            exit 1
+          fi
+          metadata="release-artifacts/mobile-contracts/generic-mobile-consumer-bundle-artifact-metadata.json"
+          gh api --method GET "repos/${GITHUB_REPOSITORY}/actions/artifacts/${artifact_id}" > "${metadata}"
+          test -f "${metadata}" && test ! -L "${metadata}"
+          node tools/repo/write-generic-mobile-consumer-bundle-receipt.mjs --artifact-metadata "${metadata}" --artifact-id "${artifact_id}" --artifact-digest "${artifact_digest}" --workflow-run-id "${GITHUB_RUN_ID}" --repository-id "${GITHUB_REPOSITORY_ID}" --head-sha "${GITHUB_SHA}"
+
+      - name: Clean artifact download directory
+        shell: bash
+        run: |
+          set -euo pipefail
+          download_directory="${RUNNER_TEMP}/easysubway-generic-mobile-consumer-bundle-download-${GITHUB_RUN_ID}"
+          rm -rf "${download_directory}"
+
+      - name: Download exact artifact ID
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          artifact-ids: ${{ steps.upload.outputs.artifact-id }}
+          path: ${{ runner.temp }}/easysubway-generic-mobile-consumer-bundle-download-${{ github.run_id }}
+
+      - name: Verify downloaded artifact bytes
+        shell: bash
+        run: |
+          set -euo pipefail
+          download_directory="${RUNNER_TEMP}/easysubway-generic-mobile-consumer-bundle-download-${GITHUB_RUN_ID}"
+          mapfile -t entries < <(find "${download_directory}" -mindepth 1 -printf '%P\n' | LC_ALL=C sort)
+          if [[ "${#entries[@]}" -ne 2 ]]; then
+            echo "downloaded artifact file count is invalid" >&2
+            exit 1
+          fi
+          if [[ "${entries[0]}" != "generic-mobile-consumer-bundle-v1.json" ]]; then
+            echo "downloaded bundle filename is invalid" >&2
+            exit 1
+          fi
+          if [[ "${entries[1]}" != "generic-mobile-consumer-publication-receipt-v1.json" ]]; then
+            echo "downloaded receipt filename is invalid" >&2
+            exit 1
+          fi
+          for entry in "${entries[@]}"; do
+            test -f "${download_directory}/${entry}"
+            test ! -L "${download_directory}/${entry}"
+          done
+          cmp -- "release-artifacts/mobile-contracts/generic-mobile-consumer-bundle-v1.json" "${download_directory}/generic-mobile-consumer-bundle-v1.json"
+          cmp -- "release-artifacts/mobile-contracts/generic-mobile-consumer-publication-receipt-v1.json" "${download_directory}/generic-mobile-consumer-publication-receipt-v1.json"
 
       - name: Validate and log artifact locator
         shell: bash

--- a/.github/workflows/generic-mobile-consumer-bundle-publish.yml
+++ b/.github/workflows/generic-mobile-consumer-bundle-publish.yml
@@ -1,0 +1,66 @@
+name: Generic Mobile Consumer Bundle Publish
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish Generic Mobile Consumer Bundle
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject non-main dispatch
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
+            echo "This workflow may only be dispatched from main."
+            exit 1
+          fi
+
+      - name: Checkout closed producer
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: 604a2ae525cc20b3bdcd3cbe2e22f93de19fefc3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: 22.14.0
+
+      - name: Build and validate closed bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+          output_directory="release-artifacts/mobile-contracts"
+          bundle="${output_directory}/generic-mobile-consumer-bundle-v1.json"
+          comparison_bundle="${output_directory}/generic-mobile-consumer-bundle-v1.comparison.json"
+          receipt="${output_directory}/generic-mobile-consumer-publication-receipt-v1.json"
+          mkdir -p "${output_directory}"
+          node tools/repo/build-generic-mobile-consumer-bundle.mjs --producer-sha 604a2ae525cc20b3bdcd3cbe2e22f93de19fefc3 --output "${bundle}"
+          node tools/repo/build-generic-mobile-consumer-bundle.mjs --producer-sha 604a2ae525cc20b3bdcd3cbe2e22f93de19fefc3 --output "${comparison_bundle}"
+          cmp -- "${bundle}" "${comparison_bundle}"
+          rm -- "${comparison_bundle}"
+          node tools/repo/write-generic-mobile-consumer-bundle-receipt.mjs --bundle "${bundle}" --output "${receipt}"
+          test -f "${bundle}" && test ! -L "${bundle}"
+          test -f "${receipt}" && test ! -L "${receipt}"
+
+      - name: Upload closed mobile consumer bundle
+        id: upload
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: easysubway-generic-mobile-consumer-bundle-1.0.0-604a2ae525cc20b3bdcd3cbe2e22f93de19fefc3
+          path: |
+            release-artifacts/mobile-contracts/generic-mobile-consumer-bundle-v1.json
+            release-artifacts/mobile-contracts/generic-mobile-consumer-publication-receipt-v1.json
+          if-no-files-found: error
+          retention-days: 90
+          overwrite: false
+
+      - name: Log artifact locator
+        shell: bash
+        run: |
+          echo "artifact-id=${{ steps.upload.outputs.artifact-id }}"
+          echo "artifact-digest=${{ steps.upload.outputs.artifact-digest }}"
+          echo "artifact-url=${{ steps.upload.outputs.artifact-url }}"

--- a/.github/workflows/generic-mobile-consumer-bundle-publish.yml
+++ b/.github/workflows/generic-mobile-consumer-bundle-publish.yml
@@ -58,9 +58,39 @@ jobs:
           retention-days: 90
           overwrite: false
 
-      - name: Log artifact locator
+      - name: Validate and log artifact locator
         shell: bash
         run: |
-          echo "artifact-id=${{ steps.upload.outputs.artifact-id }}"
-          echo "artifact-digest=${{ steps.upload.outputs.artifact-digest }}"
-          echo "artifact-url=${{ steps.upload.outputs.artifact-url }}"
+          set -euo pipefail
+          artifact_id="${{ steps.upload.outputs.artifact-id }}"
+          artifact_digest="${{ steps.upload.outputs.artifact-digest }}"
+          artifact_url="${{ steps.upload.outputs.artifact-url }}"
+          if [[ ! "${artifact_id}" =~ ^[1-9][0-9]*$ ]]; then
+            echo "artifact-id is invalid" >&2
+            exit 1
+          fi
+          if [[ ! "${artifact_digest}" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "artifact-digest is invalid" >&2
+            exit 1
+          fi
+          if [[ ! "${GITHUB_RUN_ID}" =~ ^[1-9][0-9]*$ ]]; then
+            echo "workflow-run-id is invalid" >&2
+            exit 1
+          fi
+          if [[ ! "${GITHUB_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "workflow-head-sha is invalid" >&2
+            exit 1
+          fi
+          expected_artifact_url="https://github.com/AquilaXk/easysubway/actions/runs/${GITHUB_RUN_ID}/artifacts/${artifact_id}"
+          if [[ "${artifact_url}" != "${expected_artifact_url}" ]]; then
+            echo "artifact-url is invalid" >&2
+            exit 1
+          fi
+          echo "workflow-path=.github/workflows/generic-mobile-consumer-bundle-publish.yml"
+          echo "workflow-run-id=${GITHUB_RUN_ID}"
+          echo "workflow-head-sha=${GITHUB_SHA}"
+          echo "artifact-id=${artifact_id}"
+          echo "artifact-name=easysubway-generic-mobile-consumer-bundle-1.0.0-604a2ae525cc20b3bdcd3cbe2e22f93de19fefc3"
+          echo "artifact-digest=${artifact_digest}"
+          echo "artifact-url=${artifact_url}"
+          echo "retention-days=90"

--- a/tools/repo/write-generic-mobile-consumer-bundle-receipt.mjs
+++ b/tools/repo/write-generic-mobile-consumer-bundle-receipt.mjs
@@ -3,6 +3,7 @@ import { constants } from "node:fs";
 import { link, lstat, mkdir, open, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { buildGenericMobileConsumerBundle } from "./build-generic-mobile-consumer-bundle.mjs";
 
 const producerRepository = "AquilaXk/easysubway";
 const producerSha = "604a2ae525cc20b3bdcd3cbe2e22f93de19fefc3";
@@ -72,6 +73,17 @@ function validateBundle(bytes) {
   return bundle;
 }
 
+const positiveDecimal = (value) => typeof value === "string" && /^[1-9][0-9]*$/.test(value);
+const isoTimestamp = (value) => typeof value === "string" && /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/.test(value) && Number.isFinite(Date.parse(value));
+
+export function validateGenericMobileConsumerBundleArtifactMetadata({ metadata, artifactId, artifactDigest, workflowRunId, repositoryId, headSha }) {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata) || !positiveDecimal(artifactId) || !/^[0-9a-f]{64}$/.test(artifactDigest) || !positiveDecimal(workflowRunId) || !positiveDecimal(repositoryId) || !/^[0-9a-f]{40}$/.test(headSha)) throw new Error("artifact metadata validation input is invalid");
+  const expectedArchiveUrl = `https://api.github.com/repos/${producerRepository}/actions/artifacts/${artifactId}/zip`;
+  const workflowRun = metadata.workflow_run;
+  if (String(metadata.id) !== artifactId || metadata.name !== artifactName || metadata.expired !== false || metadata.digest !== `sha256:${artifactDigest}` || metadata.archive_download_url !== expectedArchiveUrl || !workflowRun || typeof workflowRun !== "object" || Array.isArray(workflowRun) || String(workflowRun.id) !== workflowRunId || workflowRun.head_branch !== "main" || workflowRun.head_sha !== headSha || String(workflowRun.repository_id) !== repositoryId || String(workflowRun.head_repository_id) !== repositoryId) throw new Error("artifact metadata does not match the closed publication contract");
+  if (!isoTimestamp(metadata.created_at) || !isoTimestamp(metadata.expires_at) || Date.parse(metadata.expires_at) - Date.parse(metadata.created_at) !== 90 * 24 * 60 * 60 * 1000) throw new Error("artifact metadata retention is not exactly 90 days");
+}
+
 async function ensureOutputDirectory(root, output) {
   const expectedDirectory = path.join(root, outputDirectory);
   if (path.dirname(output) !== expectedDirectory || path.basename(output) !== receiptFileName) throw new Error("output must be confined to release-artifacts/mobile-contracts");
@@ -101,6 +113,8 @@ export async function writeGenericMobileConsumerBundleReceipt({ repositoryRoot, 
   const output = path.resolve(outputPath);
   if (path.basename(bundleTarget) !== bundleFileName) throw new Error("bundle filename does not match the closed contract");
   const bundleBytes = await readRegularFile(root, bundleTarget, "bundle");
+  const expectedBundleBytes = await buildGenericMobileConsumerBundle({ repositoryRoot: root, producerSha });
+  if (!bundleBytes.equals(expectedBundleBytes)) throw new Error("bundle bytes do not match the closed producer output");
   const bundle = validateBundle(bundleBytes);
   await ensureOutputDirectory(root, output);
   const receipt = {
@@ -126,6 +140,12 @@ export async function writeGenericMobileConsumerBundleReceipt({ repositoryRoot, 
 
 async function main() {
   const args = process.argv.slice(2);
+  if (args.length === 12 && args[0] === "--artifact-metadata" && args[2] === "--artifact-id" && args[4] === "--artifact-digest" && args[6] === "--workflow-run-id" && args[8] === "--repository-id" && args[10] === "--head-sha") {
+    const metadataPath = path.resolve(args[1]);
+    const metadataBytes = await readRegularFile(path.dirname(metadataPath), metadataPath, "artifact metadata");
+    validateGenericMobileConsumerBundleArtifactMetadata({ metadata: JSON.parse(metadataBytes), artifactId: args[3], artifactDigest: args[5], workflowRunId: args[7], repositoryId: args[9], headSha: args[11] });
+    return;
+  }
   if (args.length !== 4 || args[0] !== "--bundle" || args[2] !== "--output") throw new Error("usage: --bundle <generic-mobile-consumer-bundle-v1.json> --output <release-artifacts/mobile-contracts/generic-mobile-consumer-publication-receipt-v1.json>");
   await writeGenericMobileConsumerBundleReceipt({ repositoryRoot: process.cwd(), bundlePath: args[1], outputPath: args[3] });
 }

--- a/tools/repo/write-generic-mobile-consumer-bundle-receipt.mjs
+++ b/tools/repo/write-generic-mobile-consumer-bundle-receipt.mjs
@@ -1,0 +1,131 @@
+import { createHash } from "node:crypto";
+import { constants } from "node:fs";
+import { link, lstat, mkdir, open, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const producerRepository = "AquilaXk/easysubway";
+const producerSha = "604a2ae525cc20b3bdcd3cbe2e22f93de19fefc3";
+const bundleFileName = "generic-mobile-consumer-bundle-v1.json";
+const receiptFileName = "generic-mobile-consumer-publication-receipt-v1.json";
+const outputDirectory = "release-artifacts/mobile-contracts";
+const artifactName = `easysubway-generic-mobile-consumer-bundle-1.0.0-${producerSha}`;
+const expectedResources = [
+  ["errors/error-codes.json", "7527a60514a7000ae8df0c958516a856dfdc288b6e085e4efbde9e3ce61d4bf9", "AquilaXk/easysubway", 2747, "contracts/error-codes.json", null],
+  ["product/mobility-profile-policy.json", "5a63a03ff9ec9b61e0366d947251ee9294ebd48777b28b1ad6e2bdbe2d3fcc50", "AquilaXk/easysubway", 2747, "release/product-gates/mobility-profile-policy.json", 1],
+];
+
+const sha256 = (value) => createHash("sha256").update(value).digest("hex");
+const canonicalJson = (value) => {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (value && typeof value === "object") return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}`;
+  return JSON.stringify(value);
+};
+const exactKeys = (value, keys, label) => {
+  if (!value || typeof value !== "object" || Array.isArray(value) || Object.keys(value).join(",") !== keys.join(",")) throw new Error(`${label} has unknown, missing, or unordered keys`);
+};
+const safePath = (value) => typeof value === "string" && value.length > 0 && !value.includes("\\") && !path.posix.isAbsolute(value) && path.posix.normalize(value) === value && value.split("/").every((part) => part !== "" && part !== "." && part !== "..");
+
+async function regularDirectory(directory, label) {
+  const stat = await lstat(directory);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) throw new Error(`${label} must be a regular directory`);
+}
+
+async function readRegularFile(root, target, label) {
+  const relative = path.relative(root, target);
+  if (!safePath(relative)) throw new Error(`${label} path is unsafe`);
+  let current = root;
+  await regularDirectory(current, "repositoryRoot");
+  for (const [index, part] of relative.split("/").entries()) {
+    current = path.join(current, part);
+    const stat = await lstat(current);
+    if (stat.isSymbolicLink()) throw new Error(`${label} must not contain a symlink`);
+    if (index < relative.split("/").length - 1 && !stat.isDirectory()) throw new Error(`${label} parent must be a directory`);
+    if (index === relative.split("/").length - 1 && !stat.isFile()) throw new Error(`${label} must be a regular file`);
+  }
+  const handle = await open(target, constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile()) throw new Error(`${label} must be a regular file`);
+    return handle.readFile();
+  } finally {
+    await handle.close();
+  }
+}
+
+function validateBundle(bytes) {
+  const bundle = JSON.parse(bytes);
+  exactKeys(bundle, ["schemaVersion", "artifactKind", "component", "bundleVersion", "producer", "resources", "resourceInventorySha256", "payloadSha256"], "bundle");
+  if (bundle.schemaVersion !== 1 || bundle.artifactKind !== "generic-mobile-consumer-bundle" || bundle.component !== "mobile" || bundle.bundleVersion !== "1.0.0" || !/^[0-9a-f]{64}$/.test(bundle.resourceInventorySha256) || !/^[0-9a-f]{64}$/.test(bundle.payloadSha256)) throw new Error("bundle does not match the closed contract");
+  exactKeys(bundle.producer, ["repository", "gitSha"], "bundle producer");
+  if (bundle.producer.repository !== producerRepository || bundle.producer.gitSha !== producerSha || !Array.isArray(bundle.resources) || bundle.resources.length !== expectedResources.length) throw new Error("bundle producer or resources do not match the closed contract");
+  for (const [index, resource] of bundle.resources.entries()) {
+    exactKeys(resource, ["resourceId", "mediaType", "schemaVersion", "ownerRepository", "ownerIssue", "sourcePath", "contentBase64", "rawSha256", "sizeBytes"], `bundle resource ${index}`);
+    const [resourceId, rawSha256, ownerRepository, ownerIssue, sourcePath, schemaVersion] = expectedResources[index];
+    if (resource.resourceId !== resourceId || resource.mediaType !== "application/json" || resource.schemaVersion !== schemaVersion || resource.ownerRepository !== ownerRepository || resource.ownerIssue !== ownerIssue || resource.sourcePath !== sourcePath || resource.rawSha256 !== rawSha256 || !Number.isSafeInteger(resource.sizeBytes) || resource.sizeBytes < 0 || typeof resource.contentBase64 !== "string") throw new Error("bundle resource does not match the closed contract");
+    const raw = Buffer.from(resource.contentBase64, "base64");
+    if (raw.toString("base64") !== resource.contentBase64 || raw.length !== resource.sizeBytes || sha256(raw) !== resource.rawSha256) throw new Error("bundle resource digest or base64 is invalid");
+  }
+  const inventoryProjection = bundle.resources.map(({ resourceId, mediaType, schemaVersion, ownerRepository, ownerIssue, sourcePath }) => ({ resourceId, mediaType, schemaVersion, ownerRepository, ownerIssue, sourcePath }));
+  const payloadProjection = bundle.resources.map(({ resourceId, sizeBytes, rawSha256 }) => ({ resourceId, sizeBytes, rawSha256 }));
+  if (sha256(canonicalJson(inventoryProjection)) !== bundle.resourceInventorySha256 || sha256(canonicalJson(payloadProjection)) !== bundle.payloadSha256) throw new Error("bundle digest does not match resources");
+  return bundle;
+}
+
+async function ensureOutputDirectory(root, output) {
+  const expectedDirectory = path.join(root, outputDirectory);
+  if (path.dirname(output) !== expectedDirectory || path.basename(output) !== receiptFileName) throw new Error("output must be confined to release-artifacts/mobile-contracts");
+  await regularDirectory(root, "repositoryRoot");
+  for (const relativeDirectory of ["release-artifacts", outputDirectory]) {
+    const directory = path.join(root, relativeDirectory);
+    try {
+      await mkdir(directory);
+    } catch (error) {
+      if (error?.code !== "EEXIST") throw error;
+    }
+    await regularDirectory(directory, "output directory");
+  }
+  try {
+    await lstat(output);
+    throw new Error("output already exists");
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+  }
+}
+
+export async function writeGenericMobileConsumerBundleReceipt({ repositoryRoot, bundlePath, outputPath }) {
+  if (typeof repositoryRoot !== "string" || typeof bundlePath !== "string" || typeof outputPath !== "string") throw new Error("repositoryRoot, bundlePath, and outputPath must be strings");
+  const root = path.resolve(repositoryRoot);
+  const bundleTarget = path.resolve(bundlePath);
+  const output = path.resolve(outputPath);
+  if (path.basename(bundleTarget) !== bundleFileName) throw new Error("bundle filename does not match the closed contract");
+  const bundleBytes = await readRegularFile(root, bundleTarget, "bundle");
+  const bundle = validateBundle(bundleBytes);
+  await ensureOutputDirectory(root, output);
+  const receipt = {
+    schemaVersion: 1,
+    artifactKind: "generic-mobile-consumer-publication-receipt",
+    component: "mobile",
+    bundleVersion: "1.0.0",
+    producer: { repository: producerRepository, gitSha: producerSha },
+    bundle: { fileName: bundleFileName, rawSha256: sha256(bundleBytes), sizeBytes: bundleBytes.length, resourceInventorySha256: bundle.resourceInventorySha256, payloadSha256: bundle.payloadSha256 },
+    resources: bundle.resources.map(({ resourceId, rawSha256, sizeBytes }) => ({ resourceId, rawSha256, sizeBytes })),
+    publication: { repository: producerRepository, workflowPath: ".github/workflows/generic-mobile-consumer-bundle-publish.yml", artifactName, transport: "github-actions-artifact-v4", retentionDays: 90, overwrite: false },
+  };
+  const temporary = path.join(path.dirname(output), `.${receiptFileName}.${process.pid}.${Date.now()}.tmp`);
+  const bytes = Buffer.from(`${JSON.stringify(receipt, null, 2)}\n`, "utf8");
+  try {
+    await writeFile(temporary, bytes, { flag: "wx", mode: 0o600 });
+    await link(temporary, output);
+  } finally {
+    await rm(temporary, { force: true });
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length !== 4 || args[0] !== "--bundle" || args[2] !== "--output") throw new Error("usage: --bundle <generic-mobile-consumer-bundle-v1.json> --output <release-artifacts/mobile-contracts/generic-mobile-consumer-publication-receipt-v1.json>");
+  await writeGenericMobileConsumerBundleReceipt({ repositoryRoot: process.cwd(), bundlePath: args[1], outputPath: args[3] });
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main().catch((error) => { process.stderr.write(`${error.message}\n`); process.exitCode = 1; });

--- a/tools/repo/write-generic-mobile-consumer-bundle-receipt.mjs
+++ b/tools/repo/write-generic-mobile-consumer-bundle-receipt.mjs
@@ -75,13 +75,18 @@ function validateBundle(bytes) {
 
 const positiveDecimal = (value) => typeof value === "string" && /^[1-9][0-9]*$/.test(value);
 const isoTimestamp = (value) => typeof value === "string" && /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/.test(value) && Number.isFinite(Date.parse(value));
+const artifactRetentionMs = 90 * 24 * 60 * 60 * 1000;
+const artifactCreationSkewMs = 5 * 60 * 1000;
 
 export function validateGenericMobileConsumerBundleArtifactMetadata({ metadata, artifactId, artifactDigest, workflowRunId, repositoryId, headSha }) {
   if (!metadata || typeof metadata !== "object" || Array.isArray(metadata) || !positiveDecimal(artifactId) || !/^[0-9a-f]{64}$/.test(artifactDigest) || !positiveDecimal(workflowRunId) || !positiveDecimal(repositoryId) || !/^[0-9a-f]{40}$/.test(headSha)) throw new Error("artifact metadata validation input is invalid");
   const expectedArchiveUrl = `https://api.github.com/repos/${producerRepository}/actions/artifacts/${artifactId}/zip`;
   const workflowRun = metadata.workflow_run;
   if (String(metadata.id) !== artifactId || metadata.name !== artifactName || metadata.expired !== false || metadata.digest !== `sha256:${artifactDigest}` || metadata.archive_download_url !== expectedArchiveUrl || !workflowRun || typeof workflowRun !== "object" || Array.isArray(workflowRun) || String(workflowRun.id) !== workflowRunId || workflowRun.head_branch !== "main" || workflowRun.head_sha !== headSha || String(workflowRun.repository_id) !== repositoryId || String(workflowRun.head_repository_id) !== repositoryId) throw new Error("artifact metadata does not match the closed publication contract");
-  if (!isoTimestamp(metadata.created_at) || !isoTimestamp(metadata.expires_at) || Date.parse(metadata.expires_at) - Date.parse(metadata.created_at) !== 90 * 24 * 60 * 60 * 1000) throw new Error("artifact metadata retention is not exactly 90 days");
+  if (!isoTimestamp(metadata.created_at) || !isoTimestamp(metadata.expires_at)) throw new Error("artifact metadata retention timestamps are invalid");
+  const observedRetentionMs = Date.parse(metadata.expires_at) - Date.parse(metadata.created_at);
+  const requestToServerSkewMs = artifactRetentionMs - observedRetentionMs;
+  if (requestToServerSkewMs < 0 || requestToServerSkewMs > artifactCreationSkewMs) throw new Error("artifact metadata retention is outside the requested 90-day window");
 }
 
 async function ensureOutputDirectory(root, output) {

--- a/tools/repo/write-generic-mobile-consumer-bundle-receipt.mjs
+++ b/tools/repo/write-generic-mobile-consumer-bundle-receipt.mjs
@@ -93,8 +93,9 @@ async function ensureOutputDirectory(root, output) {
   }
 }
 
-export async function writeGenericMobileConsumerBundleReceipt({ repositoryRoot, bundlePath, outputPath }) {
+export async function writeGenericMobileConsumerBundleReceipt({ repositoryRoot, bundlePath, outputPath, testHook } = {}) {
   if (typeof repositoryRoot !== "string" || typeof bundlePath !== "string" || typeof outputPath !== "string") throw new Error("repositoryRoot, bundlePath, and outputPath must be strings");
+  if (testHook !== undefined && (process.env.NODE_ENV !== "test" || typeof testHook !== "function")) throw new Error("testHook is only available as a function when NODE_ENV=test");
   const root = path.resolve(repositoryRoot);
   const bundleTarget = path.resolve(bundlePath);
   const output = path.resolve(outputPath);
@@ -116,6 +117,7 @@ export async function writeGenericMobileConsumerBundleReceipt({ repositoryRoot, 
   const bytes = Buffer.from(`${JSON.stringify(receipt, null, 2)}\n`, "utf8");
   try {
     await writeFile(temporary, bytes, { flag: "wx", mode: 0o600 });
+    if (testHook) await testHook({ temporaryPath: temporary, bytes });
     await link(temporary, output);
   } finally {
     await rm(temporary, { force: true });

--- a/tools/repo/write-generic-mobile-consumer-bundle-receipt.mjs
+++ b/tools/repo/write-generic-mobile-consumer-bundle-receipt.mjs
@@ -19,7 +19,7 @@ const expectedResources = [
 const sha256 = (value) => createHash("sha256").update(value).digest("hex");
 const canonicalJson = (value) => {
   if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
-  if (value && typeof value === "object") return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}`;
+  if (value && typeof value === "object") return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}`; // NOSONAR: canonical JSON requires raw locale-independent JavaScript string ordering.
   return JSON.stringify(value);
 };
 const exactKeys = (value, keys, label) => {

--- a/tools/repo/write-generic-mobile-consumer-bundle-receipt.test.mjs
+++ b/tools/repo/write-generic-mobile-consumer-bundle-receipt.test.mjs
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { buildGenericMobileConsumerBundle } from "./build-generic-mobile-consumer-bundle.mjs";
-import { writeGenericMobileConsumerBundleReceipt } from "./write-generic-mobile-consumer-bundle-receipt.mjs";
+import { validateGenericMobileConsumerBundleArtifactMetadata, writeGenericMobileConsumerBundleReceipt } from "./write-generic-mobile-consumer-bundle-receipt.mjs";
 
 const producerSha = "604a2ae525cc20b3bdcd3cbe2e22f93de19fefc3";
 const sourceRoot = process.cwd();
@@ -124,6 +124,52 @@ test("receipt는 인증된 bundle의 닫힌 header, resource와 digest 변조를
   }
 });
 
+test("receipt는 semantic parse 전에 whitespace, numeric spelling, duplicate key raw drift를 거절한다", async (t) => {
+  const root = await fixtureRoot(t);
+  const bundlePath = await writeBundle(root);
+  const original = await readFile(bundlePath, "utf8");
+  const outputPath = path.join(root, "release-artifacts/mobile-contracts/generic-mobile-consumer-publication-receipt-v1.json");
+  const drifts = [
+    ["leading whitespace", ` ${original}`],
+    ["numeric 1.0", original.replace('"schemaVersion": 1', '"schemaVersion": 1.0')],
+    ["duplicate component", original.replace('"component": "mobile",', '"component": "mobile",\n  "component": "mobile",')],
+  ];
+  for (const [label, bytes] of drifts) {
+    const directory = path.join(root, "raw-drifts", label.replaceAll(" ", "-"));
+    const driftPath = path.join(directory, "generic-mobile-consumer-bundle-v1.json");
+    await mkdir(directory, { recursive: true });
+    await writeFile(driftPath, bytes, { flag: "wx" });
+    await assert.rejects(writeGenericMobileConsumerBundleReceipt({ repositoryRoot: root, bundlePath: driftPath, outputPath }), /bytes/i, label);
+    await assert.rejects(lstat(outputPath), { code: "ENOENT" }, label);
+  }
+});
+
+test("artifact metadata는 exact ID, digest, origin 및 90일 보존만 허용한다", () => {
+  const artifactId = "123";
+  const artifactDigest = "a".repeat(64);
+  const metadata = {
+    id: 123,
+    name: "easysubway-generic-mobile-consumer-bundle-1.0.0-604a2ae525cc20b3bdcd3cbe2e22f93de19fefc3",
+    expired: false,
+    digest: `sha256:${artifactDigest}`,
+    archive_download_url: "https://api.github.com/repos/AquilaXk/easysubway/actions/artifacts/123/zip",
+    created_at: "2026-01-01T00:00:00Z",
+    expires_at: "2026-04-01T00:00:00Z",
+    workflow_run: { id: 456, repository_id: 789, head_repository_id: 789, head_branch: "main", head_sha: producerSha },
+  };
+  const input = { metadata, artifactId, artifactDigest, workflowRunId: "456", repositoryId: "789", headSha: producerSha };
+  assert.doesNotThrow(() => validateGenericMobileConsumerBundleArtifactMetadata(input));
+  for (const mutate of [
+    (value) => { delete value.metadata.digest; },
+    (value) => { value.metadata.expires_at = "2026-01-31T00:00:00Z"; },
+    (value) => { value.metadata.workflow_run.head_branch = "feature"; },
+  ]) {
+    const invalid = structuredClone(input);
+    mutate(invalid);
+    assert.throws(() => validateGenericMobileConsumerBundleArtifactMetadata(invalid), /metadata|retention/i);
+  }
+});
+
 test("receipt 부분쓰기 hook은 test 환경에서만 허용되고 임시 파일까지 정리한다", async (t) => {
   const root = await fixtureRoot(t);
   const bundlePath = await writeBundle(root);
@@ -154,7 +200,7 @@ test("publication workflow는 main에서만 닫힌 producer와 정확히 두 파
   const workflow = await readFile(".github/workflows/generic-mobile-consumer-bundle-publish.yml", "utf8");
   assert.match(workflow, /^on:\n  workflow_dispatch:\n$/m);
   assert.doesNotMatch(workflow, /\n  (push|pull_request|schedule):/);
-  assert.match(workflow, /permissions:\n  contents: read/);
+  assert.match(workflow, /permissions:\n  actions: read\n  contents: read/);
   assert.match(workflow, /GITHUB_REF}" != "refs\/heads\/main"[\s\S]*exit 1/);
   assert.match(workflow, /actions\/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd[\s\S]*persist-credentials: false/);
   assert.doesNotMatch(workflow, /ref: 604a2ae525cc20b3bdcd3cbe2e22f93de19fefc3/);
@@ -173,5 +219,12 @@ test("publication workflow는 main에서만 닫힌 producer와 정확히 두 파
   assert.match(workflow, /expected_artifact_url="https:\/\/github\.com\/AquilaXk\/easysubway\/actions\/runs\/\$\{GITHUB_RUN_ID\}\/artifacts\/\$\{artifact_id\}"/);
   assert.match(workflow, /artifact_url}" != "\$\{expected_artifact_url\}"/);
   assert.match(workflow, /workflow-path=\.github\/workflows\/generic-mobile-consumer-bundle-publish\.yml[\s\S]*workflow-run-id=.*workflow-head-sha=.*artifact-id=.*artifact-name=.*artifact-digest=.*artifact-url=.*retention-days=90/s);
+  assert.match(workflow, /GH_TOKEN: \$\{\{ github\.token \}\}[\s\S]*gh api --method GET "repos\/\$\{GITHUB_REPOSITORY\}\/actions\/artifacts\/\$\{artifact_id\}" > "\$\{metadata\}"/);
+  assert.match(workflow, /--artifact-metadata "\$\{metadata\}" --artifact-id "\$\{artifact_id\}" --artifact-digest "\$\{artifact_digest\}" --workflow-run-id "\$\{GITHUB_RUN_ID\}" --repository-id "\$\{GITHUB_REPOSITORY_ID\}" --head-sha "\$\{GITHUB_SHA\}"/);
+  assert.match(workflow, /actions\/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093[\s\S]*artifact-ids: \$\{\{ steps\.upload\.outputs\.artifact-id \}\}/);
+  assert.match(workflow, /rm -rf "\$\{download_directory\}"/);
+  assert.match(workflow, /mapfile -t entries[\s\S]*"\$\{#entries\[@\]\}" -ne 2[\s\S]*generic-mobile-consumer-bundle-v1\.json[\s\S]*generic-mobile-consumer-publication-receipt-v1\.json/s);
+  assert.equal((workflow.match(/cmp -- /g) ?? []).length, 3);
+  assert.ok(workflow.indexOf("Verify downloaded artifact bytes") < workflow.indexOf("Validate and log artifact locator"));
   assert.doesNotMatch(workflow, /continue-on-error|fallback|\|\|/i);
 });

--- a/tools/repo/write-generic-mobile-consumer-bundle-receipt.test.mjs
+++ b/tools/repo/write-generic-mobile-consumer-bundle-receipt.test.mjs
@@ -165,5 +165,13 @@ test("publication workflow는 main에서만 닫힌 producer와 정확히 두 파
   assert.match(workflow, /name: easysubway-generic-mobile-consumer-bundle-1\.0\.0-604a2ae525cc20b3bdcd3cbe2e22f93de19fefc3/);
   assert.match(workflow, /path: \|\n            release-artifacts\/mobile-contracts\/generic-mobile-consumer-bundle-v1\.json\n            release-artifacts\/mobile-contracts\/generic-mobile-consumer-publication-receipt-v1\.json/);
   assert.match(workflow, /retention-days: 90\n          overwrite: false/);
-  assert.match(workflow, /artifact-id=.*artifact-digest=.*artifact-url/s);
+  assert.match(workflow, /set -euo pipefail/);
+  assert.match(workflow, /artifact_id="\$\{\{ steps\.upload\.outputs\.artifact-id \}\}"[\s\S]*\^\[1-9\]\[0-9\]\*\$/);
+  assert.match(workflow, /artifact_digest="\$\{\{ steps\.upload\.outputs\.artifact-digest \}\}"[\s\S]*\^\[0-9a-f\]\{64\}\$/);
+  assert.match(workflow, /GITHUB_RUN_ID.*\^\[1-9\]\[0-9\]\*\$/);
+  assert.match(workflow, /GITHUB_SHA.*\^\[0-9a-f\]\{40\}\$/);
+  assert.match(workflow, /expected_artifact_url="https:\/\/github\.com\/AquilaXk\/easysubway\/actions\/runs\/\$\{GITHUB_RUN_ID\}\/artifacts\/\$\{artifact_id\}"/);
+  assert.match(workflow, /artifact_url}" != "\$\{expected_artifact_url\}"/);
+  assert.match(workflow, /workflow-path=\.github\/workflows\/generic-mobile-consumer-bundle-publish\.yml[\s\S]*workflow-run-id=.*workflow-head-sha=.*artifact-id=.*artifact-name=.*artifact-digest=.*artifact-url=.*retention-days=90/s);
+  assert.doesNotMatch(workflow, /continue-on-error|fallback|\|\|/i);
 });

--- a/tools/repo/write-generic-mobile-consumer-bundle-receipt.test.mjs
+++ b/tools/repo/write-generic-mobile-consumer-bundle-receipt.test.mjs
@@ -159,9 +159,14 @@ test("artifact metadata는 exact ID, digest, origin 및 90일 보존만 허용�
   };
   const input = { metadata, artifactId, artifactDigest, workflowRunId: "456", repositoryId: "789", headSha: producerSha };
   assert.doesNotThrow(() => validateGenericMobileConsumerBundleArtifactMetadata(input));
+  const requestToServerSkew = structuredClone(input);
+  requestToServerSkew.metadata.expires_at = "2026-03-31T23:59:30Z";
+  assert.doesNotThrow(() => validateGenericMobileConsumerBundleArtifactMetadata(requestToServerSkew));
   for (const mutate of [
     (value) => { delete value.metadata.digest; },
     (value) => { value.metadata.expires_at = "2026-01-31T00:00:00Z"; },
+    (value) => { value.metadata.expires_at = "2026-03-31T23:54:59Z"; },
+    (value) => { value.metadata.expires_at = "2026-04-01T00:00:01Z"; },
     (value) => { value.metadata.workflow_run.head_branch = "feature"; },
   ]) {
     const invalid = structuredClone(input);

--- a/tools/repo/write-generic-mobile-consumer-bundle-receipt.test.mjs
+++ b/tools/repo/write-generic-mobile-consumer-bundle-receipt.test.mjs
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { lstat, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { buildGenericMobileConsumerBundle } from "./build-generic-mobile-consumer-bundle.mjs";
+import { writeGenericMobileConsumerBundleReceipt } from "./write-generic-mobile-consumer-bundle-receipt.mjs";
+
+const producerSha = "604a2ae525cc20b3bdcd3cbe2e22f93de19fefc3";
+const sourceRoot = process.cwd();
+const sha256 = (value) => createHash("sha256").update(value).digest("hex");
+
+async function fixtureRoot(t) {
+  const root = await mkdtemp(path.join(tmpdir(), "generic-mobile-receipt-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  for (const relativePath of [
+    "contracts/mobile/generic-mobile-resource-inventory.json",
+    "contracts/mobile/generic-mobile-consumer-bundle.schema.json",
+    "contracts/api/fixtures/report-status.ok.json",
+    "contracts/api/fixtures/report-upload-intent.created.json",
+    "backend/src/main/resources/messages.properties",
+    "contracts/datapack/canonical-number-contract.json",
+    "contracts/error-codes.json",
+    "release/product-gates/mobility-profile-policy.json",
+  ]) {
+    const target = path.join(root, relativePath);
+    await mkdir(path.dirname(target), { recursive: true });
+    await writeFile(target, await readFile(path.join(sourceRoot, relativePath)));
+  }
+  return root;
+}
+
+async function writeBundle(root) {
+  const bundle = await buildGenericMobileConsumerBundle({ repositoryRoot: root, producerSha });
+  const bundlePath = path.join(root, "generic-mobile-consumer-bundle-v1.json");
+  await writeFile(bundlePath, bundle, { flag: "wx" });
+  return bundlePath;
+}
+
+test("receipt는 검증된 bundle을 닫힌 publication 계약으로 원자적으로 기록한다", async (t) => {
+  const root = await fixtureRoot(t);
+  const bundlePath = await writeBundle(root);
+  const outputPath = path.join(root, "release-artifacts/mobile-contracts/generic-mobile-consumer-publication-receipt-v1.json");
+  await writeGenericMobileConsumerBundleReceipt({ repositoryRoot: root, bundlePath, outputPath });
+  const receiptBytes = await readFile(outputPath);
+  const receipt = JSON.parse(receiptBytes);
+  const bundleBytes = await readFile(bundlePath);
+  const bundle = JSON.parse(bundleBytes);
+
+  assert.deepEqual(Object.keys(receipt), ["schemaVersion", "artifactKind", "component", "bundleVersion", "producer", "bundle", "resources", "publication"]);
+  assert.deepEqual(receipt, {
+    schemaVersion: 1,
+    artifactKind: "generic-mobile-consumer-publication-receipt",
+    component: "mobile",
+    bundleVersion: "1.0.0",
+    producer: { repository: "AquilaXk/easysubway", gitSha: producerSha },
+    bundle: {
+      fileName: "generic-mobile-consumer-bundle-v1.json",
+      rawSha256: sha256(bundleBytes),
+      sizeBytes: bundleBytes.length,
+      resourceInventorySha256: bundle.resourceInventorySha256,
+      payloadSha256: bundle.payloadSha256,
+    },
+    resources: bundle.resources.map(({ resourceId, rawSha256, sizeBytes }) => ({ resourceId, rawSha256, sizeBytes })),
+    publication: {
+      repository: "AquilaXk/easysubway",
+      workflowPath: ".github/workflows/generic-mobile-consumer-bundle-publish.yml",
+      artifactName: `easysubway-generic-mobile-consumer-bundle-1.0.0-${producerSha}`,
+      transport: "github-actions-artifact-v4",
+      retentionDays: 90,
+      overwrite: false,
+    },
+  });
+  assert.equal((await lstat(outputPath)).isSymbolicLink(), false);
+});
+
+test("receipt는 변조·symlink·경로 이탈·기존 output을 fail closed한다", async (t) => {
+  const root = await fixtureRoot(t);
+  const bundlePath = await writeBundle(root);
+  const outputPath = path.join(root, "release-artifacts/mobile-contracts/generic-mobile-consumer-publication-receipt-v1.json");
+  await writeFile(bundlePath, "{}\n");
+  await assert.rejects(writeGenericMobileConsumerBundleReceipt({ repositoryRoot: root, bundlePath, outputPath }), /bundle|contract|digest/i);
+  await writeFile(bundlePath, await buildGenericMobileConsumerBundle({ repositoryRoot: root, producerSha }));
+  const linkDirectory = path.join(root, "linked");
+  await mkdir(linkDirectory);
+  const linkPath = path.join(linkDirectory, "generic-mobile-consumer-bundle-v1.json");
+  await symlink(bundlePath, linkPath);
+  await assert.rejects(writeGenericMobileConsumerBundleReceipt({ repositoryRoot: root, bundlePath: linkPath, outputPath }), /regular|symlink/i);
+  await assert.rejects(writeGenericMobileConsumerBundleReceipt({ repositoryRoot: root, bundlePath, outputPath: path.join(root, "outside.json") }), /confined|output/i);
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, "old", { flag: "wx" });
+  await assert.rejects(writeGenericMobileConsumerBundleReceipt({ repositoryRoot: root, bundlePath, outputPath }), /exists|output/i);
+  assert.equal(await readFile(outputPath, "utf8"), "old");
+});

--- a/tools/repo/write-generic-mobile-consumer-bundle-receipt.test.mjs
+++ b/tools/repo/write-generic-mobile-consumer-bundle-receipt.test.mjs
@@ -222,9 +222,10 @@ test("publication workflow는 main에서만 닫힌 producer와 정확히 두 파
   assert.match(workflow, /GH_TOKEN: \$\{\{ github\.token \}\}[\s\S]*gh api --method GET "repos\/\$\{GITHUB_REPOSITORY\}\/actions\/artifacts\/\$\{artifact_id\}" > "\$\{metadata\}"/);
   assert.match(workflow, /--artifact-metadata "\$\{metadata\}" --artifact-id "\$\{artifact_id\}" --artifact-digest "\$\{artifact_digest\}" --workflow-run-id "\$\{GITHUB_RUN_ID\}" --repository-id "\$\{GITHUB_REPOSITORY_ID\}" --head-sha "\$\{GITHUB_SHA\}"/);
   assert.match(workflow, /actions\/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093[\s\S]*artifact-ids: \$\{\{ steps\.upload\.outputs\.artifact-id \}\}/);
-  assert.match(workflow, /rm -rf "\$\{download_directory\}"/);
+  assert.match(workflow, /\[\[ -e "\$\{download_directory\}" \|\| -L "\$\{download_directory\}" \]\][\s\S]*artifact download path already exists[\s\S]*exit 1/);
+  assert.doesNotMatch(workflow, /rm -rf/);
   assert.match(workflow, /mapfile -t entries[\s\S]*"\$\{#entries\[@\]\}" -ne 2[\s\S]*generic-mobile-consumer-bundle-v1\.json[\s\S]*generic-mobile-consumer-publication-receipt-v1\.json/s);
   assert.equal((workflow.match(/cmp -- /g) ?? []).length, 3);
   assert.ok(workflow.indexOf("Verify downloaded artifact bytes") < workflow.indexOf("Validate and log artifact locator"));
-  assert.doesNotMatch(workflow, /continue-on-error|fallback|\|\|/i);
+  assert.doesNotMatch(workflow, /continue-on-error|fallback/i);
 });

--- a/tools/repo/write-generic-mobile-consumer-bundle-receipt.test.mjs
+++ b/tools/repo/write-generic-mobile-consumer-bundle-receipt.test.mjs
@@ -93,3 +93,20 @@ test("receipt는 변조·symlink·경로 이탈·기존 output을 fail closed한
   await assert.rejects(writeGenericMobileConsumerBundleReceipt({ repositoryRoot: root, bundlePath, outputPath }), /exists|output/i);
   assert.equal(await readFile(outputPath, "utf8"), "old");
 });
+
+test("publication workflow는 main에서만 닫힌 producer와 정확히 두 파일을 artifact v4로 게시한다", async () => {
+  const workflow = await readFile(".github/workflows/generic-mobile-consumer-bundle-publish.yml", "utf8");
+  assert.match(workflow, /^on:\n  workflow_dispatch:\n$/m);
+  assert.doesNotMatch(workflow, /\n  (push|pull_request|schedule):/);
+  assert.match(workflow, /permissions:\n  contents: read/);
+  assert.match(workflow, /GITHUB_REF}" != "refs\/heads\/main"[\s\S]*exit 1/);
+  assert.match(workflow, /actions\/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd[\s\S]*ref: 604a2ae525cc20b3bdcd3cbe2e22f93de19fefc3/);
+  assert.match(workflow, /actions\/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e/);
+  assert.equal((workflow.match(/build-generic-mobile-consumer-bundle\.mjs --producer-sha 604a2ae525cc20b3bdcd3cbe2e22f93de19fefc3/g) ?? []).length, 2);
+  assert.match(workflow, /cmp -- "\$\{bundle\}" "\$\{comparison_bundle\}"/);
+  assert.match(workflow, /actions\/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02/);
+  assert.match(workflow, /name: easysubway-generic-mobile-consumer-bundle-1\.0\.0-604a2ae525cc20b3bdcd3cbe2e22f93de19fefc3/);
+  assert.match(workflow, /path: \|\n            release-artifacts\/mobile-contracts\/generic-mobile-consumer-bundle-v1\.json\n            release-artifacts\/mobile-contracts\/generic-mobile-consumer-publication-receipt-v1\.json/);
+  assert.match(workflow, /retention-days: 90\n          overwrite: false/);
+  assert.match(workflow, /artifact-id=.*artifact-digest=.*artifact-url/s);
+});

--- a/tools/repo/write-generic-mobile-consumer-bundle-receipt.test.mjs
+++ b/tools/repo/write-generic-mobile-consumer-bundle-receipt.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { lstat, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { lstat, mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -94,14 +94,71 @@ test("receipt는 변조·symlink·경로 이탈·기존 output을 fail closed한
   assert.equal(await readFile(outputPath, "utf8"), "old");
 });
 
+test("receipt는 인증된 bundle의 닫힌 header, resource와 digest 변조를 output 없이 거절한다", async (t) => {
+  const root = await fixtureRoot(t);
+  const bundlePath = await writeBundle(root);
+  const original = JSON.parse(await readFile(bundlePath, "utf8"));
+  const outputPath = path.join(root, "release-artifacts/mobile-contracts/generic-mobile-consumer-publication-receipt-v1.json");
+  const mutations = [
+    ["extra top key", (bundle) => { bundle.extra = true; }],
+    ["component", (bundle) => { bundle.component = "other"; }],
+    ["version", (bundle) => { bundle.bundleVersion = "2.0.0"; }],
+    ["producer", (bundle) => { bundle.producer.gitSha = "0".repeat(40); }],
+    ["resource order", (bundle) => { bundle.resources.reverse(); }],
+    ["resource owner", (bundle) => { bundle.resources[0].ownerRepository = "AquilaXk/other"; }],
+    ["resource raw digest", (bundle) => { bundle.resources[0].rawSha256 = "0".repeat(64); }],
+    ["resource content", (bundle) => { bundle.resources[0].contentBase64 = Buffer.from("{}\n").toString("base64"); }],
+    ["resource size", (bundle) => { bundle.resources[0].sizeBytes += 1; }],
+    ["resource inventory digest", (bundle) => { bundle.resourceInventorySha256 = "0".repeat(64); }],
+    ["payload digest", (bundle) => { bundle.payloadSha256 = "0".repeat(64); }],
+  ];
+  for (const [label, mutate] of mutations) {
+    const bundle = structuredClone(original);
+    mutate(bundle);
+    const mutationDirectory = path.join(root, "mutations", label.replaceAll(" ", "-"));
+    const mutationPath = path.join(mutationDirectory, "generic-mobile-consumer-bundle-v1.json");
+    await mkdir(mutationDirectory, { recursive: true });
+    await writeFile(mutationPath, `${JSON.stringify(bundle)}\n`, { flag: "wx" });
+    await assert.rejects(writeGenericMobileConsumerBundleReceipt({ repositoryRoot: root, bundlePath: mutationPath, outputPath }), /bundle|contract|digest|keys|resource/i, label);
+    await assert.rejects(lstat(outputPath), { code: "ENOENT" }, label);
+  }
+});
+
+test("receipt 부분쓰기 hook은 test 환경에서만 허용되고 임시 파일까지 정리한다", async (t) => {
+  const root = await fixtureRoot(t);
+  const bundlePath = await writeBundle(root);
+  const outputDirectory = path.join(root, "release-artifacts/mobile-contracts");
+  const outputPath = path.join(outputDirectory, "generic-mobile-consumer-publication-receipt-v1.json");
+  await assert.rejects(writeGenericMobileConsumerBundleReceipt({ repositoryRoot: root, bundlePath, outputPath, testHook: () => {} }), /NODE_ENV=test/);
+  const previousNodeEnv = process.env.NODE_ENV;
+  process.env.NODE_ENV = "test";
+  try {
+    await assert.rejects(writeGenericMobileConsumerBundleReceipt({
+      repositoryRoot: root,
+      bundlePath,
+      outputPath,
+      testHook: async ({ temporaryPath }) => {
+        await writeFile(temporaryPath, "{", { flag: "w" });
+        throw new Error("simulated partial write");
+      },
+    }), /simulated partial write/);
+  } finally {
+    if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = previousNodeEnv;
+  }
+  await assert.rejects(lstat(outputPath), { code: "ENOENT" });
+  assert.deepEqual(await readdir(outputDirectory), []);
+});
+
 test("publication workflow는 main에서만 닫힌 producer와 정확히 두 파일을 artifact v4로 게시한다", async () => {
   const workflow = await readFile(".github/workflows/generic-mobile-consumer-bundle-publish.yml", "utf8");
   assert.match(workflow, /^on:\n  workflow_dispatch:\n$/m);
   assert.doesNotMatch(workflow, /\n  (push|pull_request|schedule):/);
   assert.match(workflow, /permissions:\n  contents: read/);
   assert.match(workflow, /GITHUB_REF}" != "refs\/heads\/main"[\s\S]*exit 1/);
-  assert.match(workflow, /actions\/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd[\s\S]*ref: 604a2ae525cc20b3bdcd3cbe2e22f93de19fefc3/);
-  assert.match(workflow, /actions\/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e/);
+  assert.match(workflow, /actions\/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd[\s\S]*persist-credentials: false/);
+  assert.doesNotMatch(workflow, /ref: 604a2ae525cc20b3bdcd3cbe2e22f93de19fefc3/);
+  assert.match(workflow, /actions\/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e[\s\S]*node-version: 24\.19\.0/);
   assert.equal((workflow.match(/build-generic-mobile-consumer-bundle\.mjs --producer-sha 604a2ae525cc20b3bdcd3cbe2e22f93de19fefc3/g) ?? []).length, 2);
   assert.match(workflow, /cmp -- "\$\{bundle\}" "\$\{comparison_bundle\}"/);
   assert.match(workflow, /actions\/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02/);


### PR DESCRIPTION
## 관련 이슈

Refs #2747

## 작업 배경

- Generic Mobile consumer bundle의 producer 계약은 병합됐지만, Mobile #73이 잠글 수 있는 immutable publication receipt·artifact locator·보존 계약이 없었습니다.
- 이름, branch, latest run, source checkout 또는 이전 artifact를 성공 입력으로 쓰지 않고 exact artifact ID와 digest로만 handoff해야 합니다.

## 작업 내용

- current `main`에서만 수동 실행되는 Actions artifact v4 publisher를 추가했습니다.
- 고정 producer SHA의 bundle을 두 번 재생성해 raw byte parity를 확인하고, 닫힌 publication receipt를 원자적으로 생성합니다.
- 업로드 뒤 REST metadata의 exact ID/name/digest/run/head/repository와 요청된 90일 보존을 검증합니다. Runner 요청 시각과 REST server 생성 시각의 차이는 최대 5분만 허용하며 90일 초과·5분 초과·retention clamp는 거부합니다.
- 같은 artifact ID를 task-owned 새 경로에 다시 내려받아 정확히 두 regular file만 존재하고 원본 bytes와 일치할 때만 immutable locator를 출력합니다.
- legacy/local/previous artifact, mutable name/run lookup, overwrite, best-effort 성공은 추가하지 않았습니다.

## Documentation impact

- 영향 resource ID 또는 `NONE`: `errors/error-codes.json`, `product/mobility-profile-policy.json`
- resourceClass: `HUB_GENERIC_MOBILE_RESOURCE`
- documentationFamily: `generic-mobile-consumer-bundle`
- lifecycle/evidence 영향: immutable Actions artifact publication receipt와 post-run locator 증거를 추가합니다. README/Markdown 문서 영향은 없습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/repo/write-generic-mobile-consumer-bundle-receipt.test.mjs` — 정상 30초 skew RED 재현 후 GREEN 7/7 PASS
  - `node --test tools/repo/build-generic-mobile-consumer-bundle.test.mjs` — 7/7 PASS
  - `git diff --check` — PASS
  - current-head CI run `31268980887` — Changes/Repository/Backend/Mobile/Android 및 affected gates PASS
  - 실제 Actions artifact API/download 검증은 merge 후 단일 workflow dispatch가 소유합니다.

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| receipt 정본 raw bytes 및 mutation-zero | Hub Node.js | focused unit test + current-head CI | run `31268980887` | PASS |
| artifact metadata·retention·exact-ID download 계약 | GitHub Actions | workflow contract test + merge 후 단일 dispatch | contract PASS, dispatch pending | PASS(contract) |
| UI·접근성·수동 QA | 해당 없음 | 사용자 UI 변경 없음 | 증거 불필요 | N/A |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - receipt가 기존 builder의 exact raw output과 먼저 일치해야 하는지
  - REST metadata의 exact origin·요청된 90일 expiry window와 upload digest가 결속되는지
  - exact artifact ID 재다운로드 뒤 두 파일 inventory·byte parity 전에 locator가 노출되지 않는지
  - 실패 시 previous/local/mutable locator로 성공하지 않는지

## 리스크

- R2: release-adjacent immutable artifact/provenance 계약입니다.
- 저장소/조직의 실제 artifact retention 상한이 90일보다 작으면 workflow가 의도적으로 실패합니다.
- 실제 publication은 merge 후 단일 dispatch에서 검증하며, 그 전에는 artifact를 게시하지 않습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다. (current head `427a3337`, run `31268980887` required gates PASS)
- [x] CodeRabbit 리뷰를 확인했다. (Review 객체 없이 rate limit 도달)
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다. (Review `4889284616`, finding fix `427a3337`, thread resolved)
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 모바일 소비자 번들을 수동으로 생성하고 발행 영수증과 함께 아티팩트로 업로드할 수 있습니다.
  * 생성된 번들의 파일 목록, 해시, 크기, 다운로드 정보 및 발행 메타데이터를 자동으로 검증합니다.
  * 동일한 입력으로 생성된 번들의 일관성을 확인합니다.

* **버그 수정**
  * 변조된 파일, 안전하지 않은 경로, 심볼릭 링크 및 잘못된 아티팩트 메타데이터를 감지해 발행을 차단합니다.
  * 기존 출력 파일이나 불완전한 파일 기록으로 인한 오류를 방지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
