### PR TITLE
[Fix] Generic Mobile artifact exact-ID 다운로드 검증 복구

### DIFF
--- a/.github/workflows/generic-mobile-consumer-bundle-publish.yml
+++ b/.github/workflows/generic-mobile-consumer-bundle-publish.yml
@@ -102,6 +102,7 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           artifact-ids: ${{ steps.upload.outputs.artifact-id }}
+          merge-multiple: true
           path: ${{ runner.temp }}/easysubway-generic-mobile-consumer-bundle-download-${{ github.run_id }}
 
       - name: Verify downloaded artifact bytes

--- a/tools/repo/write-generic-mobile-consumer-bundle-receipt.test.mjs
+++ b/tools/repo/write-generic-mobile-consumer-bundle-receipt.test.mjs
@@ -226,7 +226,7 @@ test("publication workflow는 main에서만 닫힌 producer와 정확히 두 파
   assert.match(workflow, /workflow-path=\.github\/workflows\/generic-mobile-consumer-bundle-publish\.yml[\s\S]*workflow-run-id=.*workflow-head-sha=.*artifact-id=.*artifact-name=.*artifact-digest=.*artifact-url=.*retention-days=90/s);
   assert.match(workflow, /GH_TOKEN: \$\{\{ github\.token \}\}[\s\S]*gh api --method GET "repos\/\$\{GITHUB_REPOSITORY\}\/actions\/artifacts\/\$\{artifact_id\}" > "\$\{metadata\}"/);
   assert.match(workflow, /--artifact-metadata "\$\{metadata\}" --artifact-id "\$\{artifact_id\}" --artifact-digest "\$\{artifact_digest\}" --workflow-run-id "\$\{GITHUB_RUN_ID\}" --repository-id "\$\{GITHUB_REPOSITORY_ID\}" --head-sha "\$\{GITHUB_SHA\}"/);
-  assert.match(workflow, /actions\/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093[\s\S]*artifact-ids: \$\{\{ steps\.upload\.outputs\.artifact-id \}\}/);
+  assert.match(workflow, /actions\/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093[\s\S]*artifact-ids: \$\{\{ steps\.upload\.outputs\.artifact-id \}\}\n          merge-multiple: true/);
   assert.match(workflow, /\[\[ -e "\$\{download_directory\}" \|\| -L "\$\{download_directory\}" \]\][\s\S]*artifact download path already exists[\s\S]*exit 1/);
   assert.doesNotMatch(workflow, /rm -rf/);
   assert.match(workflow, /mapfile -t entries[\s\S]*"\$\{#entries\[@\]\}" -ne 2[\s\S]*generic-mobile-consumer-bundle-v1\.json[\s\S]*generic-mobile-consumer-publication-receipt-v1\.json/s);


### PR DESCRIPTION
## 관련 이슈

Refs #2747

## 작업 배경

PR #2779 병합 뒤 current `main@7f4c3607f417acc9a98d4684ef83f3ffe4254884`에서 실행한 publication run `31276901582`가 upload, 90일 REST metadata, exact artifact-ID download까지 통과한 뒤 downloaded file-count 검증에서 fail-closed했습니다. Pinned `actions/download-artifact`는 `artifact-ids` 입력과 기본 `merge-multiple=false` 조합에서 artifact-name 하위 디렉터리를 만들지만, workflow는 download root에 JSON 두 파일만 존재한다고 검증하고 있었습니다.

## 작업 내용

- exact `artifact-ids` 입력 바로 다음에 `merge-multiple: true`를 명시해 단일 exact-ID artifact의 두 파일을 검증 root에 추출합니다.
- workflow 계약 테스트가 이 입력 조합을 고정하도록 보강했습니다.
- 기존 main-only, exact ID/digest/run/head/repository, 90일 retention, two-file/name/regular-file/byte parity와 locator-before-success 검증은 유지합니다.
- 실패 artifact, mutable name/latest, previous/local artifact를 성공 근거로 사용하지 않습니다.

## Documentation impact

- 영향 resource ID 또는 `NONE`: `NONE`
- resourceClass: `NONE`
- documentationFamily: `NONE`
- lifecycle/evidence 영향: Hub #2747 immutable publication runtime extraction 계약만 복구하며 bundle/receipt/resource bytes는 변경하지 않습니다.

## 검증

- RED: `node --test tools/repo/write-generic-mobile-consumer-bundle-receipt.test.mjs` — 6 PASS / 1 FAIL (`merge-multiple: true` 계약 부재)
- GREEN: 같은 명령 — 7 PASS / 0 FAIL
- `git diff --check` — PASS
- Full regression: current-head CI run `31277261335` — queue-required 8개 모두 PASS

## 검증 증거

UI, 접근성, 수동 QA 변경이 없는 GitHub Actions workflow 계약 수정이므로 화면 증거는 불필요합니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 실제 실패 재현 | GitHub Actions | run step/log 확인 | run `31276901582`, artifact `9027263646` | locator 전 fail-closed |
| exact download layout 계약 | Node | focused contract test | 7/7 PASS | PASS |
| 변경 형식 | Git | `git diff --check` | local current commit | PASS |
| required CI | GitHub Actions | current-head CI | run `31277261335` | PASS |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `.github/workflows/generic-mobile-consumer-bundle-publish.yml`의 exact `artifact-ids`와 `merge-multiple: true` 인접 결속, 그리고 downstream two-file byte parity guard가 그대로 유지되는지 확인해 주세요.

## 리스크

- 실제 Actions runner 추출 동작은 merge 뒤 새 current-main publication operation으로만 최종 증명할 수 있습니다. PR에서는 publication을 실행하지 않습니다.
- 두 실패 artifact는 성공 locator로 승격하거나 삭제하지 않습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. 실제 publication은 merge 후 별도 current-main operation으로 검증합니다.
