### PR TITLE
[Docs] 5-repository reference audit evidence runner 추가

### DIFF
--- a/.github/workflows/documentation-reference-audit.yml
+++ b/.github/workflows/documentation-reference-audit.yml
@@ -1,0 +1,67 @@
+name: Documentation Reference Audit Evidence
+
+on:
+  workflow_dispatch:
+
+jobs:
+  audit:
+    name: Audit current documentation references
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+    env:
+      DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+
+    steps:
+      - name: Documentation Reference Audit / Reject non-default branch execution
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_REF}" != "refs/heads/${DEFAULT_BRANCH}" ]]; then
+            echo "documentation reference audit must run from the default branch" >&2
+            exit 1
+          fi
+
+      - name: Documentation Reference Audit / Checkout current source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Documentation Reference Audit / Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24"
+
+      - name: Documentation Reference Audit / Create current report
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          EVIDENCE_DIR="audit-evidence"
+          REPORT_PATH="${EVIDENCE_DIR}/reference-audit-report.json"
+          OBSERVED_AT="$(date --utc +"%Y-%m-%dT%H:%M:%S.000Z")"
+          mkdir --parents "${EVIDENCE_DIR}"
+          test ! -e "${REPORT_PATH}"
+          node tools/repo/audit-active-reference-drift.mjs \
+            --scope contracts/documentation/reference-audit-scope.json \
+            --repository-root . \
+            --source-sha "${GITHUB_SHA}" \
+            --ledger release/migrations/repository-split-issues.json \
+            --amendments release/migrations/repository-split-issues-amendments.json \
+            --observed-at "${OBSERVED_AT}" \
+            --output "${REPORT_PATH}"
+
+      - name: Documentation Reference Audit / Upload sanitized report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: documentation-reference-audit-${{ github.sha }}
+          path: audit-evidence/reference-audit-report.json
+          if-no-files-found: error
+          include-hidden-files: false
+          retention-days: 14

--- a/.github/workflows/documentation-reference-audit.yml
+++ b/.github/workflows/documentation-reference-audit.yml
@@ -45,7 +45,8 @@ jobs:
           EVIDENCE_DIR="audit-evidence"
           REPORT_PATH="${EVIDENCE_DIR}/reference-audit-report.json"
           OBSERVED_AT="$(date --utc +"%Y-%m-%dT%H:%M:%S.000Z")"
-          mkdir --parents "${EVIDENCE_DIR}"
+          rm --recursive --force -- "${EVIDENCE_DIR}"
+          mkdir --parents -- "${EVIDENCE_DIR}"
           test ! -e "${REPORT_PATH}"
           node tools/repo/audit-active-reference-drift.mjs \
             --scope contracts/documentation/reference-audit-scope.json \

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -20997,6 +20997,14 @@ test("documentation reference audit evidence workflow는 current main의 sanitiz
   assert.match(workflow, /EVIDENCE_DIR="audit-evidence"/);
   assert.match(workflow, /REPORT_PATH="\$\{EVIDENCE_DIR\}\/reference-audit-report\.json"/);
   assert.doesNotMatch(workflow, /REPORT_PATH="\$\{RUNNER_TEMP\}/);
+  assert.match(
+    workflow,
+    /rm --recursive --force -- "\$\{EVIDENCE_DIR\}"\n\s+mkdir --parents -- "\$\{EVIDENCE_DIR\}"/,
+  );
+  assert.match(
+    workflow,
+    /OBSERVED_AT="\$\(date --utc \+"%Y-%m-%dT%H:%M:%S\.000Z"\)"/,
+  );
   assert.match(workflow, /node tools\/repo\/audit-active-reference-drift\.mjs/);
   for (const input of [
     "--scope contracts/documentation/reference-audit-scope.json",

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -20977,3 +20977,42 @@ test("#2609 accessibility release canonical pins는 tracked source와 exact-matc
     "seoul-metro-accessibility-20260728",
   ]);
 });
+
+test("documentation reference audit evidence workflow는 current main의 sanitized report만 보존한다", () => {
+  const workflow = read(".github/workflows/documentation-reference-audit.yml");
+
+  assert.match(workflow, /^on:\n  workflow_dispatch:\s*$/m);
+  assert.doesNotMatch(workflow, /^\s{2}(push|pull_request|schedule):/m);
+  assert.doesNotMatch(workflow, /^\s{4}inputs:/m);
+  assert.match(workflow, /timeout-minutes: 15/);
+  assert.match(workflow, /DEFAULT_BRANCH: \$\{\{ github\.event\.repository\.default_branch \}\}/);
+  assert.match(workflow, /if \[\[ "\$\{GITHUB_REF\}" != "refs\/heads\/\$\{DEFAULT_BRANCH\}" \]\]; then[\s\S]*?exit 1/);
+  assert.match(workflow, /permissions:\n      contents: read\n      issues: read\n      pull-requests: read/);
+  assert.match(workflow, /actions\/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd/);
+  assert.match(workflow, /ref: \$\{\{ github\.sha \}\}/);
+  assert.match(workflow, /persist-credentials: false/);
+  assert.match(workflow, /actions\/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e/);
+  assert.match(workflow, /node-version: "24"/);
+  assert.match(workflow, /GH_TOKEN: \$\{\{ github\.token \}\}/);
+  assert.match(workflow, /EVIDENCE_DIR="audit-evidence"/);
+  assert.match(workflow, /REPORT_PATH="\$\{EVIDENCE_DIR\}\/reference-audit-report\.json"/);
+  assert.doesNotMatch(workflow, /REPORT_PATH="\$\{RUNNER_TEMP\}/);
+  assert.match(workflow, /node tools\/repo\/audit-active-reference-drift\.mjs/);
+  for (const input of [
+    "--scope contracts/documentation/reference-audit-scope.json",
+    "--repository-root .",
+    "--source-sha \"${GITHUB_SHA}\"",
+    "--ledger release/migrations/repository-split-issues.json",
+    "--amendments release/migrations/repository-split-issues-amendments.json",
+    "--observed-at \"${OBSERVED_AT}\"",
+    "--output \"${REPORT_PATH}\"",
+  ]) assert.match(workflow, new RegExp(input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  assert.match(workflow, /test ! -e "\$\{REPORT_PATH\}"/);
+  assert.match(workflow, /if: \$\{\{ always\(\) \}\}/);
+  assert.match(workflow, /actions\/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02/);
+  assert.match(workflow, /path: audit-evidence\/reference-audit-report\.json/);
+  assert.match(workflow, /if-no-files-found: error/);
+  assert.match(workflow, /include-hidden-files: false/);
+  assert.match(workflow, /retention-days: 14/);
+  assert.doesNotMatch(workflow, /continue-on-error|cache|previous report|git (?:add|commit|push)/i);
+});


### PR DESCRIPTION
## 관련 이슈

Closes #2781
Refs #2748
Refs #2733

## 작업 배경

병합된 #2733 auditor에는 current default branch에서 5개 저장소 live reference report를 실행·보존하는 remote 경로가 없었습니다. Owner-machine 실행은 60초 경계 안에 끝나지 않아 partial result 없이 중단됐으므로, previous report 없이 current evidence를 생성할 manual CI runner가 필요합니다.

## 작업 내용

- input 없는 default-branch `workflow_dispatch` runner를 추가했습니다.
- exact `github.sha`, current tracked scope/ledger/amendments와 canonical UTC만 existing auditor에 전달합니다.
- 매 실행 전 constant `audit-evidence` directory를 제거·재생성하고, report를 non-hidden repository-relative `audit-evidence/reference-audit-report.json`에 write-once로 생성합니다.
- auditor exit `0|1|2`를 job conclusion에 그대로 반영하고, report는 `if: always()` artifact로 보존합니다.
- workflow trigger·permissions·action pins·timeout·path·UTC·stale-output 차단·no-fallback 계약을 focused repository contract test로 고정했습니다.

## Documentation impact

- 영향 resource ID 또는 `NONE`: `NONE` — canonical resource/schema/catalog는 변경하지 않고 current evidence runner만 추가
- resourceClass: `EVIDENCE`
- documentationFamily: `GOVERNANCE_EVIDENCE`
- lifecycle/evidence 영향: workflow run마다 exact source SHA에 결속된 sanitized immutable artifact를 생성하며 tracked report는 만들지 않음

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern 'documentation reference audit evidence workflow' tools/ci/repository-contract.test.mjs` — initial workflow ENOENT, timeout, absolute output, hidden output, stale directory를 각각 RED로 고정한 뒤 current head GREEN 1/1
  - `node --test tools/repo/audit-active-reference-drift.test.mjs` — auditor 변경 전 fresh 27/27 PASS; finding fix는 auditor를 변경하지 않음
  - `git diff --check` / `git diff --cached --check` — PASS
  - current head `7d8b94211c159798c676e9613e542034698368f9` required CI run `31280342142` — 9/9 SUCCESS

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Workflow contract | Node 24 | focused contract test | local RED→GREEN 1/1 및 Repository CI | PASS |
| Existing auditor boundary | Node 24 | auditor unit suite | 27/27 | PASS |
| Required CI | GitHub Actions | current-head run | https://github.com/AquilaXk/easysubway/actions/runs/31280342142 | PASS |
| CodeRabbit findings | GitHub Review | original threads reply/resolve | stale artifact·UTC 2건, `isResolved=true` 2/2 | PASS |
| UI/accessibility | 해당 없음 | runtime/UI를 변경하지 않는 manual evidence workflow | 증거 불필요 | N/A |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: `NONE`
- mobile versionCode: `NONE`
- datapack version: `NONE`
- route contract: `NONE`
- realtime contract: `NONE`
- backend identity: `NONE`

## 리뷰어 메모

- frozen CodeRabbit Review는 pre-fix discovery head `9c68d99a44c649cda4916ec753dede6450bd0291`의 exact base/head diff를 검토하고 blocking finding 2건을 게시했습니다.
- finding은 follow-up에서 test-first로 수정하고 원 thread에 검증 증거를 남긴 뒤 2/2 resolve했습니다. 최신 `main@135922eaafad9367d001e1d100518cd7395fa962` rebase 후 current head는 `7d8b94211c159798c676e9613e542034698368f9`입니다.
- success discovery 뒤 fix/rebase는 review budget을 reset하지 않으므로 CodeRabbit rate-limit 재호출은 기다리거나 Codex CLI second discovery로 대체하지 않습니다.

## 리스크

- 실제 5-repository live run은 merge 뒤 default branch workflow에서 처음 수행합니다. Finding 또는 `AUDIT_INCOMPLETE`이면 job은 의도대로 실패하고 artifact의 exact owner handoff를 별도로 처리합니다.
- Runner merge만으로 Full Documentation DoD D22 완료를 주장하지 않습니다.
- non-required Android Release Artifact의 datapack failure는 이 2-file PLAN-DOC 변경과 무관하며 required merge gate가 아닙니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] current-head required CI 결과를 확인했다.
- [x] CodeRabbit Review 객체와 conversation warning을 확인했다.
- [x] frozen finding 2건을 current-head affected verification으로 닫고 original thread 2/2 resolve를 확인했다.
- [x] CodeRabbit Review 객체가 있으므로 Codex CLI fallback은 실행하지 않았다.
- [x] 배포 영향이 없는 CI evidence runner임을 확인했다.
