### PR TITLE
[Docs] D20 Actions artifact snapshot self-reference 계약 교정

### DIFF
--- a/contracts/documentation/public-sensitivity-audit-report.schema.json
+++ b/contracts/documentation/public-sensitivity-audit-report.schema.json
@@ -23,13 +23,15 @@
           "items": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["repository", "defaultBranch", "gitSha", "beginWatermark", "endWatermark", "receiptLocator"],
+            "required": ["repository", "defaultBranch", "gitSha", "beginWatermark", "endWatermark", "artifactBeginWatermark", "artifactEndWatermark", "receiptLocator"],
             "properties": {
               "repository": { "type": "string", "enum": ["AquilaXk/easysubway", "AquilaXk/easysubway-backend", "AquilaXk/easysubway-data", "AquilaXk/easysubway-mobile", "AquilaXk/easysubway-platform"] },
               "defaultBranch": { "type": "string", "pattern": "^[A-Za-z0-9._/-]+$" },
               "gitSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
               "beginWatermark": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
               "endWatermark": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+              "artifactBeginWatermark": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+              "artifactEndWatermark": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
               "receiptLocator": { "type": "string", "pattern": "^https://github\\.com/AquilaXk/easysubway(?:-(?:backend|data|mobile|platform))?/actions/runs/[0-9]+/artifacts/[0-9]+$" }
             }
           }

--- a/contracts/documentation/public-sensitivity-owner-receipt.schema.json
+++ b/contracts/documentation/public-sensitivity-owner-receipt.schema.json
@@ -24,13 +24,14 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["artifactId", "artifactName", "workflowPath", "runId", "archiveDigest", "expiresAt", "detectorPolicyVersion", "scanStatus", "scanReceiptLocator"],
+        "required": ["artifactId", "artifactName", "workflowPath", "runId", "archiveDigest", "createdAt", "expiresAt", "detectorPolicyVersion", "scanStatus", "scanReceiptLocator"],
         "properties": {
           "artifactId": { "type": "string", "pattern": "^[0-9]+$" },
           "artifactName": { "type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9._ -]{0,127}$" },
           "workflowPath": { "type": "string", "pattern": "^\\.github/workflows/[A-Za-z0-9._/-]+\\.ya?ml$" },
           "runId": { "type": "string", "pattern": "^[0-9]+$" },
           "archiveDigest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+          "createdAt": { "type": "string", "format": "date-time" },
           "expiresAt": { "type": "string", "format": "date-time" },
           "detectorPolicyVersion": { "type": "string", "pattern": "^[a-z0-9][a-z0-9.-]*$" },
           "scanStatus": { "type": "string", "enum": ["COMPLETE", "AUDIT_INCOMPLETE"] },

--- a/tools/ci/check-contracts.mjs
+++ b/tools/ci/check-contracts.mjs
@@ -776,10 +776,10 @@ export function validatePublicSensitivityOwnerReceiptSchema(schema, errors = [],
   const required = ["schemaVersion", "repository", "gitSha", "observedAt", "secretScanningEnabled", "pushProtectionEnabled", "reachableRefAuditComplete", "alertEnumerationComplete", "locationEnumerationComplete", "openAlertCount", "unresolvedAlertCount", "detectorPolicyVersion", "evidenceLocator", "publicArtifactEnumerationComplete", "publicArtifacts"];
   if (schema?.type !== "object" || schema?.additionalProperties !== false || JSON.stringify(schema?.required) !== JSON.stringify(required)) errors.push(`${path}: strict owner receipt top-level schema가 필요하다`);
   const artifact = schema?.properties?.publicArtifacts?.items;
-  const artifactRequired = ["artifactId", "artifactName", "workflowPath", "runId", "archiveDigest", "expiresAt", "detectorPolicyVersion", "scanStatus", "scanReceiptLocator"];
+  const artifactRequired = ["artifactId", "artifactName", "workflowPath", "runId", "archiveDigest", "createdAt", "expiresAt", "detectorPolicyVersion", "scanStatus", "scanReceiptLocator"];
   if (artifact?.additionalProperties !== false || JSON.stringify(artifact?.required) !== JSON.stringify(artifactRequired) || JSON.stringify(artifact?.properties?.scanStatus?.enum) !== JSON.stringify(["COMPLETE", "AUDIT_INCOMPLETE"])) errors.push(`${path}: corrected publicArtifacts exact schema가 필요하다`);
   if (schema?.properties?.openAlertCount?.type !== "integer" || schema?.properties?.unresolvedAlertCount?.type !== "integer" || schema?.properties?.publicArtifacts?.uniqueItems !== true) errors.push(`${path}: receipt count와 artifact uniqueness 계약이 필요하다`);
-  if (artifact?.properties?.artifactId?.pattern !== "^[0-9]+$" || artifact?.properties?.runId?.pattern !== "^[0-9]+$" || !artifact?.properties?.workflowPath?.pattern?.includes("github/workflows") || !artifact?.properties?.scanReceiptLocator?.pattern?.includes("actions/runs")) errors.push(`${path}: artifact identity/locator closed grammar가 필요하다`);
+  if (artifact?.properties?.artifactId?.pattern !== "^[0-9]+$" || artifact?.properties?.runId?.pattern !== "^[0-9]+$" || artifact?.properties?.createdAt?.format !== "date-time" || !artifact?.properties?.workflowPath?.pattern?.includes("github/workflows") || !artifact?.properties?.scanReceiptLocator?.pattern?.includes("actions/runs")) errors.push(`${path}: artifact identity/locator closed grammar가 필요하다`);
   return errors;
 }
 
@@ -801,6 +801,8 @@ export function validatePublicSensitivityAuditReportSchema(schema, errors = [], 
   if (!["scannedSurfaces", "scannedArtifacts", "detectors", "findings", "incomplete"].every((key) => report?.summary?.properties?.[key]?.type === "integer")) errors.push(`${path}: integer summary schema가 필요하다`);
   const parity = schema?.oneOf;
   if (!Array.isArray(parity) || parity.length !== 2 || parity[0]?.properties?.status?.const !== "COMPLETE" || parity[0]?.properties?.incomplete?.maxItems !== 0 || parity[1]?.properties?.status?.const !== "AUDIT_INCOMPLETE" || parity[1]?.properties?.incomplete?.minItems !== 1) errors.push(`${path}: status/incomplete oneOf parity가 필요하다`);
+  const inputRequired = repositoryList?.items?.required;
+  if (!Array.isArray(inputRequired) || !inputRequired.includes("artifactBeginWatermark") || !inputRequired.includes("artifactEndWatermark") || repositoryList?.items?.properties?.artifactBeginWatermark?.pattern !== "^[0-9a-f]{64}$" || repositoryList?.items?.properties?.artifactEndWatermark?.pattern !== "^[0-9a-f]{64}$") errors.push(`${path}: artifact snapshot watermark input이 필요하다`);
   return errors;
 }
 

--- a/tools/ci/check-contracts.test.mjs
+++ b/tools/ci/check-contracts.test.mjs
@@ -71,6 +71,7 @@ test("public sensitivity contracts bind the exact scope and corrected owner rece
     (value) => { value.properties.openAlertCount.type = "number"; },
     (value) => { value.properties.publicArtifacts.uniqueItems = false; },
     (value) => { value.properties.publicArtifacts.items.properties.artifactId.pattern = ".+"; },
+    (value) => { delete value.properties.publicArtifacts.items.properties.createdAt; },
   ]) {
     const weakened = structuredClone(receiptSchema);
     mutate(weakened);
@@ -82,6 +83,7 @@ test("public sensitivity contracts bind the exact scope and corrected owner rece
     (value) => { value.properties.findings.uniqueItems = false; },
     (value) => { value.properties.findings.items.properties.detectorId = { type: "string" }; },
     (value) => { value.properties.inputs.properties.repositories.minItems = 0; },
+    (value) => { value.properties.inputs.properties.repositories.items.required = value.properties.inputs.properties.repositories.items.required.filter((field) => field !== "artifactBeginWatermark"); },
   ]) {
     const weakened = structuredClone(reportSchema);
     mutate(weakened);

--- a/tools/repo/audit-public-sensitivity.mjs
+++ b/tools/repo/audit-public-sensitivity.mjs
@@ -200,15 +200,12 @@ export async function collectActionsArtifacts({ repository, execGh, catalog: sup
     if (collected.incomplete.length) return { findings, scannedArtifacts, incomplete: collected.incomplete };
     const catalog = collected.catalog;
     const eligible = catalog.filter((artifact) => artifact.expired === false && instant(artifact.createdAt) <= instant(observedAt));
-    if (receiptEvidenceLocator !== undefined) {
-      const transport = catalog.find((artifact) => artifactLocator(repository, artifact) === receiptEvidenceLocator);
-      if (transport == null || transport.expired !== false || instant(transport.createdAt) <= instant(observedAt)) incomplete.push(incompleteEntry("artifacts", "ARTIFACT_TRANSPORT_INVALID", repository));
-    }
+    if (!validReceiptTransport({ catalog, repository, receiptEvidenceLocator, observedAt })) incomplete.push(incompleteEntry("artifacts", "ARTIFACT_TRANSPORT_INVALID", repository));
     if (eligible.length !== receiptArtifacts.length || JSON.stringify(eligible.map((artifact) => String(artifact.id)).sort()) !== JSON.stringify(receiptArtifacts.map((artifact) => artifact.artifactId).sort())) incomplete.push(incompleteEntry("artifacts", "ARTIFACT_CATALOG_MISMATCH", repository));
     const runs = new Map();
     for (const artifact of eligible) {
       const receipt = receiptArtifacts.find((entry) => entry.artifactId === String(artifact.id));
-      if (receipt == null || receipt.detectorPolicyVersion !== detectorPolicyVersion || receipt.scanStatus !== "COMPLETE" || receipt.createdAt !== artifact.createdAt || receipt.expiresAt !== artifact.expiresAt || instant(receipt.createdAt) > instant(observedAt) || instant(observedAt) >= instant(receipt.expiresAt)) { incomplete.push(incompleteEntry("artifacts", "ARTIFACT_CATALOG_MISMATCH", repository)); continue; }
+      if (!validReceiptArtifact({ receipt, artifact, observedAt, detectorPolicyVersion })) { incomplete.push(incompleteEntry("artifacts", "ARTIFACT_CATALOG_MISMATCH", repository)); continue; }
       const runId = artifact.workflow_run?.id; let run = runs.get(runId);
       if (run == null) { run = await execGh({ method: "GET", endpoint: `repos/${repository}/actions/runs/${runId}` }); runs.set(runId, run); }
       if (receipt.workflowPath !== run?.path || receipt.runId !== String(artifact.workflow_run?.id) || receipt.artifactName !== artifact.name || receipt.archiveDigest !== artifact.digest) { incomplete.push(incompleteEntry("artifacts", "ARTIFACT_CATALOG_MISMATCH", repository)); continue; }
@@ -294,6 +291,14 @@ function normalizeCatalogArtifact(raw) {
 }
 function artifactCatalogWatermark(catalog) { return digestBytes(JSON.stringify([...catalog].sort((left, right) => left.id - right.id).map(({ id, createdAt, expiresAt, expired, digest, name, workflow_run }) => ({ id, createdAt, expiresAt, expired, digest, name, workflowRunId: workflow_run.id })))); }
 function artifactLocator(repository, artifact) { return `https://github.com/${repository}/actions/runs/${artifact.workflow_run.id}/artifacts/${artifact.id}`; }
+function validReceiptTransport({ catalog, repository, receiptEvidenceLocator, observedAt }) {
+  if (receiptEvidenceLocator === undefined) return true;
+  const transport = catalog.find((artifact) => artifactLocator(repository, artifact) === receiptEvidenceLocator);
+  return transport?.expired === false && instant(transport.createdAt) > instant(observedAt);
+}
+function validReceiptArtifact({ receipt, artifact, observedAt, detectorPolicyVersion }) {
+  return receipt != null && receipt.detectorPolicyVersion === detectorPolicyVersion && receipt.scanStatus === "COMPLETE" && receipt.createdAt === artifact.createdAt && receipt.expiresAt === artifact.expiresAt && instant(receipt.createdAt) <= instant(observedAt) && instant(observedAt) < instant(receipt.expiresAt);
+}
 function incompleteEntry(stage, code, affectedIdentity) { return { stage, code, affectedIdentity: safeIdentity(affectedIdentity) ? affectedIdentity : "redacted" }; }
 function safeLocator(value) { return /^https:\/\/github\.com\/AquilaXk\/easysubway(?:-(?:backend|data|mobile|platform))?\/actions\/runs\/\d+\/artifacts\/\d+$/.test(value ?? ""); }
 function safeLocatorForRepository(value, repository) { return safeLocator(value) && value.startsWith(`https://github.com/${repository}/actions/runs/`); }

--- a/tools/repo/audit-public-sensitivity.mjs
+++ b/tools/repo/audit-public-sensitivity.mjs
@@ -40,7 +40,7 @@ export function validateReceipt(receipt, expected, errors = []) {
   if (!canonicalUtc(receipt?.observedAt)) errors.push("RECEIPT_INVALID_TIME");
   for (const artifact of receipt?.publicArtifacts ?? []) {
     const identity = artifactIdentity(artifact);
-    if (identity <= previous || !safeArtifactFields(artifact) || artifact?.detectorPolicyVersion !== expected.detectorPolicyVersion || !canonicalUtc(artifact?.expiresAt) || artifact.expiresAt <= expected.observedAt || !safeArtifactLocator(receipt?.repository, artifact)) errors.push("RECEIPT_ARTIFACT_INVALID");
+    if (identity <= previous || !safeArtifactFields(artifact) || artifact?.detectorPolicyVersion !== expected.detectorPolicyVersion || !canonicalUtc(artifact?.createdAt) || !canonicalUtc(artifact?.expiresAt) || instant(artifact.createdAt) > instant(expected.observedAt) || instant(expected.observedAt) >= instant(artifact.expiresAt) || !safeArtifactLocator(receipt?.repository, artifact)) errors.push("RECEIPT_ARTIFACT_INVALID");
     previous = identity;
   }
   if (!Array.isArray(receipt?.publicArtifacts)) errors.push("RECEIPT_ARTIFACTS_MISSING");
@@ -117,9 +117,9 @@ export async function auditPublicSensitivity({ scope, receipts, observedAt, exec
   for (const receipt of Array.isArray(receipts) ? receipts : []) { if (receiptMap.has(receipt?.repository)) incomplete.push(incompleteEntry("receipt", "DUPLICATE_RECEIPT", receipt?.repository ?? "unknown")); receiptMap.set(receipt?.repository, receipt); }
   if (receiptMap.size !== REPOSITORIES.length) incomplete.push(incompleteEntry("receipt", "RECEIPT_SET_INCOMPLETE", "five-repositories"));
   for (const repository of REPOSITORIES) {
-    let first; let last; let metadata = { items: [], incomplete: [] };
+    let first; let last; let metadata = { items: [], incomplete: [] }; let artifactBegin = { catalog: [], watermark: digestBytes(""), incomplete: [] }; let artifactEnd = artifactBegin;
     let finalMetadata;
-    try { first = await repositoryIdentity(repository, execGh); metadata = await collectPublicMetadata({ repository, execGh }); last = await repositoryIdentity(repository, execGh); finalMetadata = await collectPublicMetadata({ repository, execGh }); } catch { incomplete.push(incompleteEntry("provider", "PROVIDER_UNAVAILABLE", repository)); continue; }
+    try { first = await repositoryIdentity(repository, execGh); artifactBegin = await collectArtifactCatalog({ repository, execGh }); metadata = await collectPublicMetadata({ repository, execGh }); last = await repositoryIdentity(repository, execGh); finalMetadata = await collectPublicMetadata({ repository, execGh }); } catch { incomplete.push(incompleteEntry("provider", "PROVIDER_UNAVAILABLE", repository)); continue; }
     const receipt = receiptMap.get(repository); const receiptErrors = validateReceipt(receipt, { repository, gitSha: first.gitSha, observedAt, detectorPolicyVersion: scope?.detectorPolicyVersion });
     if (receiptErrors.length) incomplete.push(incompleteEntry("receipt", "INVALID_RECEIPT", repository));
     if (receipt != null) {
@@ -128,15 +128,18 @@ export async function auditPublicSensitivity({ scope, receipts, observedAt, exec
     }
     const beginDigest = metadataDigest(metadata.items); const endDigest = metadataDigest(finalMetadata.items);
     if (first.gitSha !== last.gitSha || first.defaultBranch !== last.defaultBranch || beginDigest !== endDigest) incomplete.push(incompleteEntry("watermark", "WATERMARK_DRIFT", repository));
-    incomplete.push(...metadata.incomplete, ...finalMetadata.incomplete);
+    incomplete.push(...metadata.incomplete, ...finalMetadata.incomplete, ...artifactBegin.incomplete);
     for (const item of metadata.items) { scannedSurfaces += 1; candidates.push(...detect(item.text, item, scope)); }
     const evidence = await collectEvidenceBlobs({ repository, gitSha: first.gitSha, paths: scope?.repositories?.find((entry) => entry?.repository === repository)?.publicEvidencePaths ?? [], execGh });
     incomplete.push(...evidence.incomplete);
     for (const item of evidence.items) { scannedArtifacts += 1; candidates.push(...detect(item.text, item, scope)); }
-    const artifacts = await collectActionsArtifacts({ repository, execGh, receiptArtifacts: receipt?.publicArtifacts ?? [], observedAt, detectorPolicyVersion: scope?.detectorPolicyVersion });
+    const artifacts = await collectActionsArtifacts({ repository, execGh, catalog: artifactBegin.catalog, receiptArtifacts: receipt?.publicArtifacts ?? [], receiptEvidenceLocator: receipt?.evidenceLocator, observedAt, detectorPolicyVersion: scope?.detectorPolicyVersion });
     incomplete.push(...artifacts.incomplete);
     scannedArtifacts += artifacts.scannedArtifacts; candidates.push(...artifacts.findings);
-    inputs.push({ repository, defaultBranch: first.defaultBranch, gitSha: first.gitSha, beginWatermark: beginDigest, endWatermark: endDigest, receiptLocator: safeLocatorForRepository(receipt?.evidenceLocator, repository) ? receipt.evidenceLocator : safeReceiptLocator(repository) });
+    artifactEnd = await collectArtifactCatalog({ repository, execGh });
+    if (artifactBegin.watermark !== artifactEnd.watermark) incomplete.push(incompleteEntry("artifacts", "ARTIFACT_WATERMARK_DRIFT", repository));
+    incomplete.push(...artifactEnd.incomplete);
+    inputs.push({ repository, defaultBranch: first.defaultBranch, gitSha: first.gitSha, beginWatermark: beginDigest, endWatermark: endDigest, artifactBeginWatermark: artifactBegin.watermark, artifactEndWatermark: artifactEnd.watermark, receiptLocator: safeLocatorForRepository(receipt?.evidenceLocator, repository) ? receipt.evidenceLocator : safeReceiptLocator(repository) });
   }
   const dispositionKeys = new Set(candidates.map((item) => `${item.locationFingerprint}\u0000${item.detectorId}`));
   const observed = instant(observedAt);
@@ -169,27 +172,43 @@ async function collectEvidenceBlobs({ repository, gitSha, paths, execGh }) {
   return { items, incomplete };
 }
 
-export async function collectActionsArtifacts({ repository, execGh, receiptArtifacts, observedAt, detectorPolicyVersion }) {
-  const incomplete = []; const findings = []; let scannedArtifacts = 0;
+export async function collectArtifactCatalog({ repository, execGh }) {
   try {
     const catalog = []; const ids = new Set(); let expectedTotal = null; let page = 1;
     while (page <= PAGE_LIMIT) {
       const response = await execGh({ method: "GET", endpoint: `repos/${repository}/actions/artifacts?per_page=100&page=${page}` });
-      if (!Array.isArray(response?.artifacts) || !Number.isInteger(response?.total_count) || response.total_count < 0 || (expectedTotal != null && expectedTotal !== response.total_count)) return { findings, scannedArtifacts, incomplete: [incompleteEntry("artifacts", "ARTIFACT_CATALOG_INCOMPLETE", repository)] };
+      if (!Array.isArray(response?.artifacts) || !Number.isInteger(response?.total_count) || response.total_count < 0 || (expectedTotal != null && expectedTotal !== response.total_count)) return invalidArtifactCatalog(repository);
       expectedTotal ??= response.total_count;
-      for (const artifact of response.artifacts) { if (!Number.isInteger(artifact?.id) || ids.has(artifact.id)) return { findings, scannedArtifacts, incomplete: [incompleteEntry("artifacts", "ARTIFACT_CATALOG_INCOMPLETE", repository)] }; ids.add(artifact.id); catalog.push(artifact); }
+      for (const raw of response.artifacts) {
+        const artifact = normalizeCatalogArtifact(raw);
+        if (artifact == null || ids.has(artifact.id)) return invalidArtifactCatalog(repository);
+        ids.add(artifact.id); catalog.push(artifact);
+      }
       if (catalog.length === expectedTotal) break;
-      if (response.artifacts.length < 100 || catalog.length > expectedTotal) return { findings, scannedArtifacts, incomplete: [incompleteEntry("artifacts", "ARTIFACT_CATALOG_INCOMPLETE", repository)] };
+      if (response.artifacts.length < 100 || catalog.length > expectedTotal) return invalidArtifactCatalog(repository);
       page += 1;
     }
-    if (page > PAGE_LIMIT || catalog.length !== expectedTotal) return { findings, scannedArtifacts, incomplete: [incompleteEntry("artifacts", "ARTIFACT_CATALOG_INCOMPLETE", repository)] };
-    if (catalog.some((artifact) => typeof artifact?.expired !== "boolean")) incomplete.push(incompleteEntry("artifacts", "ARTIFACT_CATALOG_INCOMPLETE", repository));
-    const current = catalog.filter((artifact) => artifact?.expired === false);
-    if (current.length !== receiptArtifacts.length || JSON.stringify(current.map((artifact) => String(artifact.id)).sort()) !== JSON.stringify(receiptArtifacts.map((artifact) => artifact.artifactId).sort())) incomplete.push(incompleteEntry("artifacts", "ARTIFACT_CATALOG_MISMATCH", repository));
+    if (page > PAGE_LIMIT || catalog.length !== expectedTotal) return invalidArtifactCatalog(repository);
+    return { catalog, watermark: artifactCatalogWatermark(catalog), incomplete: [] };
+  } catch { return invalidArtifactCatalog(repository); }
+}
+
+export async function collectActionsArtifacts({ repository, execGh, catalog: suppliedCatalog, receiptArtifacts, receiptEvidenceLocator, observedAt, detectorPolicyVersion }) {
+  const incomplete = []; const findings = []; let scannedArtifacts = 0;
+  try {
+    const collected = suppliedCatalog == null ? await collectArtifactCatalog({ repository, execGh }) : { catalog: suppliedCatalog, incomplete: [] };
+    if (collected.incomplete.length) return { findings, scannedArtifacts, incomplete: collected.incomplete };
+    const catalog = collected.catalog;
+    const eligible = catalog.filter((artifact) => artifact.expired === false && instant(artifact.createdAt) <= instant(observedAt));
+    if (receiptEvidenceLocator !== undefined) {
+      const transport = catalog.find((artifact) => artifactLocator(repository, artifact) === receiptEvidenceLocator);
+      if (transport == null || transport.expired !== false || instant(transport.createdAt) <= instant(observedAt)) incomplete.push(incompleteEntry("artifacts", "ARTIFACT_TRANSPORT_INVALID", repository));
+    }
+    if (eligible.length !== receiptArtifacts.length || JSON.stringify(eligible.map((artifact) => String(artifact.id)).sort()) !== JSON.stringify(receiptArtifacts.map((artifact) => artifact.artifactId).sort())) incomplete.push(incompleteEntry("artifacts", "ARTIFACT_CATALOG_MISMATCH", repository));
     const runs = new Map();
-    for (const artifact of current) {
+    for (const artifact of eligible) {
       const receipt = receiptArtifacts.find((entry) => entry.artifactId === String(artifact.id));
-      if (receipt == null || receipt.detectorPolicyVersion !== detectorPolicyVersion || receipt.scanStatus !== "COMPLETE" || receipt.expiresAt <= observedAt || receipt.expiresAt !== artifact.expires_at) { incomplete.push(incompleteEntry("artifacts", "ARTIFACT_CATALOG_MISMATCH", repository)); continue; }
+      if (receipt == null || receipt.detectorPolicyVersion !== detectorPolicyVersion || receipt.scanStatus !== "COMPLETE" || receipt.createdAt !== artifact.createdAt || receipt.expiresAt !== artifact.expiresAt || instant(receipt.createdAt) > instant(observedAt) || instant(observedAt) >= instant(receipt.expiresAt)) { incomplete.push(incompleteEntry("artifacts", "ARTIFACT_CATALOG_MISMATCH", repository)); continue; }
       const runId = artifact.workflow_run?.id; let run = runs.get(runId);
       if (run == null) { run = await execGh({ method: "GET", endpoint: `repos/${repository}/actions/runs/${runId}` }); runs.set(runId, run); }
       if (receipt.workflowPath !== run?.path || receipt.runId !== String(artifact.workflow_run?.id) || receipt.artifactName !== artifact.name || receipt.archiveDigest !== artifact.digest) { incomplete.push(incompleteEntry("artifacts", "ARTIFACT_CATALOG_MISMATCH", repository)); continue; }
@@ -246,7 +265,7 @@ export function validateReport(report, errors = []) {
   if (!canonicalUtc(report?.observedAt) || !["COMPLETE", "AUDIT_INCOMPLETE"].includes(report?.status)) errors.push("INVALID_REPORT_STATUS");
   if (![report?.inputs?.policyDigest, report?.inputs?.schemaDigest, report?.inputs?.runnerDigest].every((value) => /^[0-9a-f]{64}$/.test(value ?? ""))
     || JSON.stringify(repositories.map(({ repository }) => repository)) !== JSON.stringify(REPOSITORIES)
-    || repositories.some((entry) => !safeBranch(entry?.defaultBranch) || !validSha(entry?.gitSha) || !/^[0-9a-f]{64}$/.test(entry?.beginWatermark) || !/^[0-9a-f]{64}$/.test(entry?.endWatermark) || !safeLocatorForRepository(entry?.receiptLocator, entry?.repository))) errors.push("INVALID_REPORT_INPUTS");
+    || repositories.some((entry) => !safeBranch(entry?.defaultBranch) || !validSha(entry?.gitSha) || !/^[0-9a-f]{64}$/.test(entry?.beginWatermark) || !/^[0-9a-f]{64}$/.test(entry?.endWatermark) || !/^[0-9a-f]{64}$/.test(entry?.artifactBeginWatermark) || !/^[0-9a-f]{64}$/.test(entry?.artifactEndWatermark) || !safeLocatorForRepository(entry?.receiptLocator, entry?.repository))) errors.push("INVALID_REPORT_INPUTS");
   if ((report?.status === "COMPLETE") !== (incomplete.length === 0)) errors.push("STATUS_INCOMPLETE_PARITY");
   const summaryValues = [report?.summary?.findings, report?.summary?.incomplete, report?.summary?.detectors, report?.summary?.scannedSurfaces, report?.summary?.scannedArtifacts];
   if (!summaryValues.every((value) => Number.isInteger(value) && value >= 0) || report?.summary?.detectors !== DETECTORS.length || report?.summary?.findings !== findings.length || report?.summary?.incomplete !== incomplete.length) errors.push("SUMMARY_MISMATCH");
@@ -266,7 +285,15 @@ function publicItem({ repository, surface, id, revision = null, text }) { return
 function metadataDigest(items) { return digestBytes(JSON.stringify([...items.map(({ repository, surface, immutableSourceIdentity, text }) => ({ repository, surface, immutableSourceIdentity, contentDigest: digestBytes(text) }))].sort((left, right) => codepointCompare(JSON.stringify(left), JSON.stringify(right))))); }
 function unpackPage(response) { if (Array.isArray(response)) return { body: response, next: false, expectedCount: null }; if (!response || !Array.isArray(response.body)) return null; return { body: response.body, next: response.next === true, expectedCount: response.totalCount ?? null }; }
 function disposed(finding, entries, observedAt) { const observed = instant(observedAt); return entries.some((entry) => { const verified = instant(entry.verifiedAt); const expires = instant(entry.expiresAt); return entry.locationFingerprint === finding.locationFingerprint && entry.detectorId === finding.detectorId && observed != null && verified != null && expires != null && verified <= observed && expires > observed; }); }
-function artifactIdentity(item) { return [item?.artifactId, item?.artifactName, item?.workflowPath, item?.runId, item?.archiveDigest, item?.expiresAt, item?.detectorPolicyVersion, item?.scanStatus, item?.scanReceiptLocator].join("\u0000"); }
+function artifactIdentity(item) { return [item?.artifactId, item?.artifactName, item?.workflowPath, item?.runId, item?.archiveDigest, item?.createdAt, item?.expiresAt, item?.detectorPolicyVersion, item?.scanStatus, item?.scanReceiptLocator].join("\u0000"); }
+function invalidArtifactCatalog(repository) { return { catalog: [], watermark: digestBytes(""), incomplete: [incompleteEntry("artifacts", "ARTIFACT_CATALOG_INCOMPLETE", repository)] }; }
+function normalizeCatalogArtifact(raw) {
+  const createdAt = normalizeTimestamp(raw?.created_at); const expiresAt = normalizeTimestamp(raw?.expires_at);
+  if (!Number.isSafeInteger(raw?.id) || raw.id < 0 || typeof raw?.expired !== "boolean" || createdAt == null || expiresAt == null || instant(expiresAt) <= instant(createdAt) || !/^[A-Za-z0-9][A-Za-z0-9._ -]{0,127}$/.test(raw?.name ?? "") || !Number.isSafeInteger(raw?.workflow_run?.id) || raw.workflow_run.id < 0 || !/^sha256:[0-9a-f]{64}$/.test(raw?.digest ?? "")) return null;
+  return { id: raw.id, expired: raw.expired, createdAt, expiresAt, name: raw.name, digest: raw.digest, workflow_run: { id: raw.workflow_run.id } };
+}
+function artifactCatalogWatermark(catalog) { return digestBytes(JSON.stringify([...catalog].sort((left, right) => left.id - right.id).map(({ id, createdAt, expiresAt, expired, digest, name, workflow_run }) => ({ id, createdAt, expiresAt, expired, digest, name, workflowRunId: workflow_run.id })))); }
+function artifactLocator(repository, artifact) { return `https://github.com/${repository}/actions/runs/${artifact.workflow_run.id}/artifacts/${artifact.id}`; }
 function incompleteEntry(stage, code, affectedIdentity) { return { stage, code, affectedIdentity: safeIdentity(affectedIdentity) ? affectedIdentity : "redacted" }; }
 function safeLocator(value) { return /^https:\/\/github\.com\/AquilaXk\/easysubway(?:-(?:backend|data|mobile|platform))?\/actions\/runs\/\d+\/artifacts\/\d+$/.test(value ?? ""); }
 function safeLocatorForRepository(value, repository) { return safeLocator(value) && value.startsWith(`https://github.com/${repository}/actions/runs/`); }
@@ -280,6 +307,15 @@ function safeBranch(value) { return typeof value === "string" && /^[A-Za-z0-9._/
 function safePathToken(value) { return typeof value === "string" && value.length > 0 && !isAbsolute(value) && !value.split(/[\\/]/).includes(".."); }
 function validSha(value) { return /^[0-9a-f]{40}$/.test(value ?? ""); }
 function canonicalUtc(value) { if (!/^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d\.\d{3}Z$/.test(value ?? "")) return false; try { return new Date(value).toISOString() === value; } catch { return false; } }
+function normalizeTimestamp(value) {
+  const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$/.exec(value ?? "");
+  if (match == null) return null;
+  const [year, month, day, hour, minute, second] = match.slice(1, 7).map(Number);
+  const offset = match[7]; const offsetHour = offset === "Z" ? 0 : Number(offset.slice(1, 3)); const offsetMinute = offset === "Z" ? 0 : Number(offset.slice(4, 6));
+  if (month < 1 || month > 12 || day < 1 || day > new Date(Date.UTC(year, month, 0)).getUTCDate() || hour > 23 || minute > 59 || second > 59 || offsetHour > 23 || offsetMinute > 59) return null;
+  const parsed = instant(value);
+  return parsed == null ? null : new Date(parsed).toISOString();
+}
 function instant(value) { if (typeof value !== "string") return null; const parsed = Date.parse(value); return Number.isFinite(parsed) ? parsed : null; }
 function digestBytes(value) { return createHash("sha256").update(value).digest("hex"); }
 function crc32(bytes) { let crc = 0xffffffff; for (const byte of bytes) { crc ^= byte; for (let bit = 0; bit < 8; bit += 1) crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1)); } return (crc ^ 0xffffffff) >>> 0; }
@@ -350,7 +386,7 @@ export async function runAuditCli(args = process.argv.slice(2)) {
     return 2;
   }
 }
-function failureInputs(scopeText, schemaText, runnerText) { return { policyDigest: digestBytes(scopeText), schemaDigest: digestBytes(schemaText), runnerDigest: digestBytes(runnerText), repositories: REPOSITORIES.map((repository) => ({ repository, defaultBranch: "main", gitSha: "0".repeat(40), beginWatermark: "0".repeat(64), endWatermark: "0".repeat(64), receiptLocator: safeReceiptLocator(repository) })) }; }
+function failureInputs(scopeText, schemaText, runnerText) { return { policyDigest: digestBytes(scopeText), schemaDigest: digestBytes(schemaText), runnerDigest: digestBytes(runnerText), repositories: REPOSITORIES.map((repository) => ({ repository, defaultBranch: "main", gitSha: "0".repeat(40), beginWatermark: "0".repeat(64), endWatermark: "0".repeat(64), artifactBeginWatermark: "0".repeat(64), artifactEndWatermark: "0".repeat(64), receiptLocator: safeReceiptLocator(repository) })) }; }
 function parseArgs(args) { if (args.length !== 10 || args[0] !== "--scope" || args[2] !== "--owner-receipts" || args[4] !== "--observed-at" || args[6] !== "--repository-root" || args[8] !== "--output" || !canonicalUtc(args[5])) throw new Error("invalid arguments"); return { scope: args[1], receipts: args[3], observedAt: args[5], root: args[7], output: args[9] }; }
 async function containedPath(root, candidate, output = false) { if (!safePathToken(candidate)) throw new Error("unsafe path"); const path = resolve(root, candidate); if (relative(root, path).startsWith("..")) throw new Error("unsafe path"); const boundary = output ? dirname(path) : path; const real = await realpath(boundary); if (real !== root && !real.startsWith(`${root}/`)) throw new Error("unsafe path"); const parts = relative(root, boundary).split("/").filter(Boolean); let cursor = root; for (const part of parts) { cursor = resolve(cursor, part); if ((await lstat(cursor)).isSymbolicLink()) throw new Error("unsafe path"); } if (!output && (await lstat(path)).isSymbolicLink()) throw new Error("unsafe path"); return path; }
 if (process.argv[1] === fileURLToPath(import.meta.url)) process.exitCode = await runAuditCli();

--- a/tools/repo/audit-public-sensitivity.test.mjs
+++ b/tools/repo/audit-public-sensitivity.test.mjs
@@ -7,7 +7,7 @@ import { join } from "node:path";
 import { test } from "node:test";
 
 import { validateSchema } from "../ci/lib/json-schema-lite.mjs";
-import { auditPublicSensitivity, collectActionsArtifacts, collectPublicMetadata, createReport, runAuditCli, scanArtifactArchive, validateReceipt, validateReport, validateScope } from "./audit-public-sensitivity.mjs";
+import { auditPublicSensitivity, collectActionsArtifacts, collectArtifactCatalog, collectPublicMetadata, createReport, runAuditCli, scanArtifactArchive, validateReceipt, validateReport, validateScope } from "./audit-public-sensitivity.mjs";
 
 const REPOSITORIES = ["AquilaXk/easysubway", "AquilaXk/easysubway-backend", "AquilaXk/easysubway-data", "AquilaXk/easysubway-mobile", "AquilaXk/easysubway-platform"];
 const SHA = "a".repeat(40); const OBSERVED_AT = "2026-08-09T03:00:00.000Z";
@@ -16,6 +16,7 @@ const fingerprint = (repository, surface, identity, detector, ordinal, offset) =
 
 function scope(dispositions = []) { return { schemaVersion: 1, detectorPolicyVersion: "public-sensitivity-v1", repositories: REPOSITORIES.map((repository) => ({ repository, publicEvidencePaths: ["evidence/public"] })), surfaces: ["REPOSITORY_SECURITY_RECEIPT", "ISSUE_TITLE", "ISSUE_BODY", "ISSUE_COMMENT", "PR_TITLE", "PR_BODY", "PR_COMMENT", "PR_REVIEW_BODY", "PR_REVIEW_COMMENT", "COMMIT_COMMENT", "RELEASE_METADATA", "PUBLIC_ARTIFACT"], detectors: ["PRIVATE_KEY_BLOCK", "KNOWN_TOKEN_FORMAT", "AUTHORIZATION_VALUE", "SIGNED_URL_QUERY", "PRIVATE_ABSOLUTE_PATH", "RAW_PROVIDER_PAYLOAD", "RAW_USER_PAYLOAD"], falsePositiveDispositions: dispositions }; }
 function receipt(repository) { return { schemaVersion: 1, repository, gitSha: SHA, observedAt: OBSERVED_AT, secretScanningEnabled: true, pushProtectionEnabled: true, reachableRefAuditComplete: true, alertEnumerationComplete: true, locationEnumerationComplete: true, openAlertCount: 0, unresolvedAlertCount: 0, detectorPolicyVersion: "public-sensitivity-v1", evidenceLocator: locator(repository), publicArtifactEnumerationComplete: true, publicArtifacts: [] }; }
+function catalogArtifact(id, { expired = true, createdAt = "2026-08-08T03:00:00.000Z", expiresAt = "2026-09-09T03:00:00.000Z", digest = `sha256:${"a".repeat(64)}`, name = "artifact", runId = 1 } = {}) { return { id, name, expired, created_at: createdAt, expires_at: expiresAt, digest, workflow_run: { id: runId } }; }
 
 function fakeGh({ body = "safe", next = false } = {}) { return async ({ method, endpoint }) => {
   assert.equal(method, "GET");
@@ -24,7 +25,7 @@ function fakeGh({ body = "safe", next = false } = {}) { return async ({ method, 
   if (endpoint === `repos/${repository}`) return { default_branch: "main" };
   if (endpoint === `repos/${repository}/git/ref/heads/main`) return { object: { sha: SHA } };
   if (endpoint.includes("/git/trees/")) return { truncated: false, tree: [] };
-  if (endpoint.includes("/actions/artifacts")) return { total_count: 0, artifacts: [] };
+  if (endpoint.includes("/actions/artifacts")) return { total_count: 1, artifacts: [catalogArtifact(1, { expired: false, createdAt: "2026-08-09T03:00:00.001Z" })] };
   if (endpoint.includes("/issues?")) return [{ id: 1, number: 1, title: "safe", body: repository === REPOSITORIES[0] ? body : "safe", pull_request: null, updated_at: OBSERVED_AT }];
   if (endpoint.includes("/pulls?")) return [];
   if (endpoint.includes("/issues/comments") || endpoint.includes("/issues/1/comments") || endpoint.includes("/pulls/comments") || endpoint.includes("/pulls/1/reviews") || endpoint.includes("/comments") || endpoint.includes("/releases")) return next ? { body: [], next: true } : [];
@@ -58,10 +59,10 @@ test("D20.1 metadata watermark binds content bytes even when provider revision i
 test("D20.1 F1 scans the declared repository security receipt surface", async () => {
   const raw = "ghp_abcdefghijklmnopqrstuvwxyz0123456789ABCD";
   const archive = zip([]); const archiveDigest = `sha256:${createHash("sha256").update(archive).digest("hex")}`;
-  const receipts = REPOSITORIES.map((repository) => ({ ...receipt(repository), publicArtifacts: [{ artifactId: "1", artifactName: raw, workflowPath: ".github/workflows/a.yml", runId: "1", archiveDigest, expiresAt: "2026-09-09T03:00:00.000Z", detectorPolicyVersion: "public-sensitivity-v1", scanStatus: "COMPLETE", scanReceiptLocator: locator(repository) }] }));
+  const receipts = REPOSITORIES.map((repository) => ({ ...receipt(repository), evidenceLocator: locator(repository, 2), publicArtifacts: [{ artifactId: "1", artifactName: raw, workflowPath: ".github/workflows/a.yml", runId: "1", archiveDigest, createdAt: "2026-08-08T03:00:00.000Z", expiresAt: "2026-09-09T03:00:00.000Z", detectorPolicyVersion: "public-sensitivity-v1", scanStatus: "COMPLETE", scanReceiptLocator: locator(repository) }] }));
   const gh = async (request) => {
     const repository = REPOSITORIES.find((candidate) => request.endpoint === `repos/${candidate}` || request.endpoint.startsWith(`repos/${candidate}/`));
-    if (request.endpoint.includes("/actions/artifacts?")) return { total_count: 1, artifacts: [{ id: 1, name: raw, expired: false, expires_at: "2026-09-09T03:00:00.000Z", digest: archiveDigest, workflow_run: { id: 1 } }] };
+    if (request.endpoint.includes("/actions/artifacts?")) return { total_count: 2, artifacts: [catalogArtifact(1, { name: raw, expired: false, digest: archiveDigest }), catalogArtifact(2, { expired: false, createdAt: "2026-08-09T03:00:00.001Z" })] };
     if (request.endpoint.endsWith("/actions/runs/1")) return { path: ".github/workflows/a.yml" };
     if (request.endpoint.endsWith("/actions/artifacts/1/zip")) return archive;
     assert.ok(repository);
@@ -217,10 +218,11 @@ test("D20.1 archive finding reaches the aggregate report without raw bytes", asy
   const archive = zip([{ name: "safe.txt", text: raw, method: 8 }]);
   const archiveDigest = `sha256:${createHash("sha256").update(archive).digest("hex")}`;
   const receipts = REPOSITORIES.map(receipt);
-  receipts[0].publicArtifacts = [{ artifactId: "7", artifactName: "sensitivity", workflowPath: ".github/workflows/audit.yml", runId: "1", archiveDigest, expiresAt: "2026-09-09T03:00:00.000Z", detectorPolicyVersion: "public-sensitivity-v1", scanStatus: "COMPLETE", scanReceiptLocator: locator(REPOSITORIES[0], 7) }];
+  receipts[0].evidenceLocator = locator(REPOSITORIES[0], 1);
+  receipts[0].publicArtifacts = [{ artifactId: "7", artifactName: "sensitivity", workflowPath: ".github/workflows/audit.yml", runId: "1", archiveDigest, createdAt: "2026-08-08T03:00:00.000Z", expiresAt: "2026-09-09T03:00:00.000Z", detectorPolicyVersion: "public-sensitivity-v1", scanStatus: "COMPLETE", scanReceiptLocator: locator(REPOSITORIES[0], 7) }];
   const base = fakeGh();
   const execGh = async (request) => {
-    if (request.endpoint === `repos/${REPOSITORIES[0]}/actions/artifacts?per_page=100&page=1`) return { total_count: 1, artifacts: [{ id: 7, name: "sensitivity", expired: false, expires_at: "2026-09-09T03:00:00.000Z", digest: archiveDigest, workflow_run: { id: 1 } }] };
+    if (request.endpoint === `repos/${REPOSITORIES[0]}/actions/artifacts?per_page=100&page=1`) return { total_count: 2, artifacts: [catalogArtifact(7, { name: "sensitivity", expired: false, digest: archiveDigest }), catalogArtifact(1, { expired: false, createdAt: "2026-08-09T03:00:00.001Z" })] };
     if (request.endpoint === `repos/${REPOSITORIES[0]}/actions/runs/1`) return { path: ".github/workflows/audit.yml" };
     if (request.endpoint === `repos/${REPOSITORIES[0]}/actions/artifacts/7/zip`) return archive;
     return base(request);
@@ -240,7 +242,7 @@ test("D20.1 receipt locators and artifact expiry are bound to the exact reposito
 });
 
 test("D20.1 F6 report validator is total and rejects parity, order, enum, and integer mutations", () => {
-  const report = createReport({ observedAt: OBSERVED_AT, inputs: { repositories: REPOSITORIES.map((repository) => ({ repository, defaultBranch: "main", gitSha: SHA, beginWatermark: "b".repeat(64), endWatermark: "b".repeat(64), receiptLocator: locator(repository) })) } });
+  const report = createReport({ observedAt: OBSERVED_AT, inputs: { repositories: REPOSITORIES.map((repository) => ({ repository, defaultBranch: "main", gitSha: SHA, beginWatermark: "b".repeat(64), endWatermark: "b".repeat(64), artifactBeginWatermark: "c".repeat(64), artifactEndWatermark: "c".repeat(64), receiptLocator: locator(repository) })) } });
   assert.deepEqual(validateReport(report), []);
   for (const mutate of [(value) => { value.summary.detectors = 1; }, (value) => { value.status = "COMPLETE"; value.incomplete.push({ stage: "a", code: "b", affectedIdentity: "c" }); }, (value) => { value.inputs.repositories.reverse(); }, (value) => { value.summary.findings = 1.5; }]) { const invalid = structuredClone(report); mutate(invalid); assert.ok(validateReport(invalid).length > 0); }
   assert.doesNotThrow(() => validateReport(null));
@@ -249,14 +251,14 @@ test("D20.1 F6 report validator is total and rejects parity, order, enum, and in
 test("D20.1 Actions artifact pagination consumes exact 101/200/201 catalog totals", async () => {
   for (const total of [101, 200, 201]) {
     const calls = [];
-    const result = await collectActionsArtifacts({ repository: REPOSITORIES[0], receiptArtifacts: [], observedAt: OBSERVED_AT, detectorPolicyVersion: "public-sensitivity-v1", execGh: async ({ endpoint }) => { calls.push(endpoint); const page = Number(endpoint.match(/[?&]page=(\d+)/)?.[1]); return { total_count: total, artifacts: Array.from({ length: Math.max(0, Math.min(100, total - (page - 1) * 100)) }, (_, offset) => ({ id: (page - 1) * 100 + offset, expired: true })) }; } });
+    const result = await collectActionsArtifacts({ repository: REPOSITORIES[0], receiptArtifacts: [], observedAt: OBSERVED_AT, detectorPolicyVersion: "public-sensitivity-v1", execGh: async ({ endpoint }) => { calls.push(endpoint); const page = Number(endpoint.match(/[?&]page=(\d+)/)?.[1]); return { total_count: total, artifacts: Array.from({ length: Math.max(0, Math.min(100, total - (page - 1) * 100)) }, (_, offset) => catalogArtifact((page - 1) * 100 + offset)) }; } });
     assert.deepEqual(result.incomplete, []); assert.equal(calls.length, Math.ceil(total / 100));
   }
 });
 
 test("D20.1 Actions artifact pagination rejects duplicate, drift, mismatch, and cap", async () => {
   for (const mode of ["duplicate", "drift", "short"]) {
-    const result = await collectActionsArtifacts({ repository: REPOSITORIES[0], receiptArtifacts: [], observedAt: OBSERVED_AT, detectorPolicyVersion: "public-sensitivity-v1", execGh: async ({ endpoint }) => { const page = Number(endpoint.match(/[?&]page=(\d+)/)?.[1]); if (mode === "short") return { total_count: 101, artifacts: [] }; return { total_count: mode === "drift" && page === 2 ? 102 : 101, artifacts: Array.from({ length: page === 1 ? 100 : 1 }, (_, offset) => ({ id: mode === "duplicate" && page === 2 ? 0 : (page - 1) * 100 + offset, expired: true })) }; } });
+    const result = await collectActionsArtifacts({ repository: REPOSITORIES[0], receiptArtifacts: [], observedAt: OBSERVED_AT, detectorPolicyVersion: "public-sensitivity-v1", execGh: async ({ endpoint }) => { const page = Number(endpoint.match(/[?&]page=(\d+)/)?.[1]); if (mode === "short") return { total_count: 101, artifacts: [] }; return { total_count: mode === "drift" && page === 2 ? 102 : 101, artifacts: Array.from({ length: page === 1 ? 100 : 1 }, (_, offset) => catalogArtifact(mode === "duplicate" && page === 2 ? 0 : (page - 1) * 100 + offset)) }; } });
     assert.ok(result.incomplete.length > 0);
   }
 });
@@ -264,6 +266,69 @@ test("D20.1 Actions artifact pagination rejects duplicate, drift, mismatch, and 
 test("D20.1 F7 rejects an unknown artifact expiry state", async () => {
   const result = await collectActionsArtifacts({ repository: REPOSITORIES[0], receiptArtifacts: [], observedAt: OBSERVED_AT, detectorPolicyVersion: "public-sensitivity-v1", execGh: async () => ({ total_count: 1, artifacts: [{ id: 1, expired: null }] }) });
   assert.ok(result.incomplete.some(({ code }) => code === "ARTIFACT_CATALOG_INCOMPLETE"));
+});
+
+test("D20.1a scans only a stable eligible artifact and transports the exact post-cutoff receipt evidence", async () => {
+  const archive = zip([{ name: "safe.txt", text: "safe", method: 0 }]); const archiveDigest = `sha256:${createHash("sha256").update(archive).digest("hex")}`;
+  const eligible = catalogArtifact(7, { expired: false, name: "eligible", digest: archiveDigest });
+  const transport = catalogArtifact(9, { expired: false, createdAt: "2026-08-09T03:00:00.001Z" });
+  const receiptArtifact = { artifactId: "7", artifactName: "eligible", workflowPath: ".github/workflows/audit.yml", runId: "1", archiveDigest, createdAt: "2026-08-08T03:00:00.000Z", expiresAt: "2026-09-09T03:00:00.000Z", detectorPolicyVersion: "public-sensitivity-v1", scanStatus: "COMPLETE", scanReceiptLocator: locator(REPOSITORIES[0], 7) };
+  const result = await collectActionsArtifacts({ repository: REPOSITORIES[0], receiptArtifacts: [receiptArtifact], receiptEvidenceLocator: locator(REPOSITORIES[0], 9), observedAt: OBSERVED_AT, detectorPolicyVersion: "public-sensitivity-v1", execGh: async ({ endpoint }) => {
+    if (endpoint.includes("/actions/artifacts?")) return { total_count: 2, artifacts: [eligible, transport] };
+    if (endpoint.endsWith("/actions/runs/1")) return { path: ".github/workflows/audit.yml" };
+    if (endpoint.endsWith("/actions/artifacts/7/zip")) return archive;
+    throw new Error("unexpected request");
+  } });
+  assert.deepEqual(result.incomplete, []); assert.equal(result.scannedArtifacts, 1);
+});
+
+test("D20.1a rejects malformed and boundary-violating createdAt evidence", async () => {
+  const candidate = receipt(REPOSITORIES[0]);
+  candidate.publicArtifacts = [{ artifactId: "1", artifactName: "artifact", workflowPath: ".github/workflows/a.yml", runId: "1", archiveDigest: `sha256:${"a".repeat(64)}`, createdAt: "2026-08-09T03:00:00.001Z", expiresAt: "2026-09-09T03:00:00.000Z", detectorPolicyVersion: "public-sensitivity-v1", scanStatus: "COMPLETE", scanReceiptLocator: locator(REPOSITORIES[0]) }];
+  assert.ok(validateReceipt(candidate, { repository: REPOSITORIES[0], gitSha: SHA, observedAt: OBSERVED_AT, detectorPolicyVersion: "public-sensitivity-v1" }).includes("RECEIPT_ARTIFACT_INVALID"));
+  for (const createdAt of ["not-a-time", "2026-08-09T05:00:00", "2026-08-09"]) {
+    const catalog = await collectArtifactCatalog({ repository: REPOSITORIES[0], execGh: async () => ({ total_count: 1, artifacts: [{ ...catalogArtifact(1), created_at: createdAt }] }) });
+    assert.ok(catalog.incomplete.some(({ code }) => code === "ARTIFACT_CATALOG_INCOMPLETE"));
+  }
+  for (const artifact of [
+    { ...catalogArtifact(1), id: Number.MAX_SAFE_INTEGER + 1 },
+    { ...catalogArtifact(1), name: "" },
+    { ...catalogArtifact(1), digest: "not-a-digest" },
+  ]) {
+    const malformed = await collectArtifactCatalog({ repository: REPOSITORIES[0], execGh: async () => ({ total_count: 1, artifacts: [artifact] }) });
+    assert.ok(malformed.incomplete.some(({ code }) => code === "ARTIFACT_CATALOG_INCOMPLETE"));
+  }
+});
+
+test("D20.1a terminal artifact watermark is collected after eligible archives are scanned", async () => {
+  const archive = zip([{ name: "safe.txt", text: "safe", method: 0 }]); const archiveDigest = `sha256:${createHash("sha256").update(archive).digest("hex")}`;
+  const receipts = REPOSITORIES.map(receipt);
+  receipts[0].evidenceLocator = locator(REPOSITORIES[0], 9);
+  receipts[0].publicArtifacts = [{ artifactId: "7", artifactName: "eligible", workflowPath: ".github/workflows/audit.yml", runId: "1", archiveDigest, createdAt: "2026-08-08T03:00:00.000Z", expiresAt: "2026-09-09T03:00:00.000Z", detectorPolicyVersion: "public-sensitivity-v1", scanStatus: "COMPLETE", scanReceiptLocator: locator(REPOSITORIES[0], 7) }];
+  let archiveScanned = false; const base = fakeGh();
+  const execGh = async (request) => {
+    if (request.endpoint === `repos/${REPOSITORIES[0]}/actions/artifacts?per_page=100&page=1`) return { total_count: 2, artifacts: [catalogArtifact(7, { expired: false, name: "eligible", digest: archiveScanned ? `sha256:${"b".repeat(64)}` : archiveDigest }), catalogArtifact(9, { expired: false, createdAt: "2026-08-09T03:00:00.001Z" })] };
+    if (request.endpoint === `repos/${REPOSITORIES[0]}/actions/runs/1`) return { path: ".github/workflows/audit.yml" };
+    if (request.endpoint === `repos/${REPOSITORIES[0]}/actions/artifacts/7/zip`) { archiveScanned = true; return archive; }
+    return base(request);
+  };
+  const audit = await auditPublicSensitivity({ scope: scope(), receipts, observedAt: OBSERVED_AT, execGh });
+  assert.ok(audit.incomplete.some(({ code }) => code === "ARTIFACT_WATERMARK_DRIFT"));
+});
+
+test("D20.1a preserves stable double catalog watermarks and rejects same-count drift", async () => {
+  for (const drift of [false, true]) {
+    const reads = new Map();
+    const gh = async (request) => {
+      const repository = REPOSITORIES.find((candidate) => request.endpoint === `repos/${candidate}` || request.endpoint.startsWith(`repos/${candidate}/`));
+      if (request.endpoint.includes("/actions/artifacts?")) { const count = (reads.get(repository) ?? 0) + 1; reads.set(repository, count); const page = Number(request.endpoint.match(/[?&]page=(\d+)/)?.[1]); return { total_count: 101, artifacts: Array.from({ length: page === 1 ? 100 : 1 }, (_, offset) => catalogArtifact((page - 1) * 100 + offset, { createdAt: "2026-08-09T03:00:00.001Z", digest: drift && count > 2 ? `sha256:${"b".repeat(64)}` : `sha256:${"a".repeat(64)}` })) }; }
+      return fakeGh()(request);
+    };
+    const audit = await auditPublicSensitivity({ scope: scope(), receipts: REPOSITORIES.map(receipt), observedAt: OBSERVED_AT, execGh: gh });
+    const report = createReport({ observedAt: OBSERVED_AT, ...audit });
+    assert.equal(report.inputs.repositories.every((entry) => /^[0-9a-f]{64}$/.test(entry.artifactBeginWatermark) && /^[0-9a-f]{64}$/.test(entry.artifactEndWatermark)), true);
+    assert.equal(audit.incomplete.some(({ code }) => code === "ARTIFACT_WATERMARK_DRIFT"), drift);
+  }
 });
 
 function zip(entries) {


### PR DESCRIPTION
## 관련 이슈

Closes #2790
Refs #2748

## 작업 배경

- D20 Phase 1 collector가 모든 non-expired Actions artifact를 owner receipt와 exact 대조해, receipt/evidence artifact가 자기 ID와 digest를 생성 전에 포함해야 하는 self-reference cycle이 있었습니다.
- 이전 artifact나 cache를 성공으로 선택하지 않고, 한 번의 immutable cutoff와 시작·종료 catalog watermark로 snapshot을 닫아야 합니다.

## 작업 내용

- owner receipt artifact에 canonical `createdAt`을 추가하고 `createdAt <= observedAt < expiresAt`을 검증합니다.
- scan 대상은 `expired=false && createdAt<=observedAt`으로 고정하고, exact `evidenceLocator` transport는 post-cutoff artifact로 검증해 scan set에서 제외합니다.
- Actions artifact catalog를 archive scan 전후로 끝까지 수집하고 ID/time/expiry/digest/name/run identity의 deterministic watermark drift를 fail-closed 처리합니다.
- report에 `artifactBeginWatermark`와 `artifactEndWatermark`를 보존하고 schema/semantic regression을 추가합니다.

## Documentation impact

- 영향 resource ID 또는 `NONE`: `NONE` (D20 evidence contract boundary; catalog promotion 없음)
- resourceClass: `EVIDENCE`
- documentationFamily: `evidence`
- lifecycle/evidence 영향: five-repository owner receipt와 Hub audit report의 artifact snapshot identity를 강화합니다.

## 검증

- `node --test --test-name-pattern 'D20.1a' tools/repo/audit-public-sensitivity.test.mjs` → 4/4 PASS
- `node --test tools/repo/audit-public-sensitivity.test.mjs tools/ci/check-contracts.test.mjs` → PASS
- `node --test tools/repo/audit-public-sensitivity.test.mjs` (CodeRabbit CR1 closure) → 26/26 PASS
- `node tools/ci/check-contracts.mjs --workspace contracts/workspaces/hub.json --current-only` → PASS
- `git diff --check` → PASS

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| cutoff/transport/watermark | Node.js | focused regression | D20.1a 4 tests | PASS |
| schema/semantic contract | Node.js | affected combined suite + current-only | local command | PASS |
| CodeRabbit CR1 closure | Node.js | finding-specific audit suite | commit `6c238b07`, 26/26 | PASS |
| required CI | GitHub Actions | current head `6c238b07…` | run `31299649742` | PASS |
| Review/thread gate | GitHub | CodeRabbit Review + GraphQL all-pages | `PRR_kwDOS4Iqac8AAAABI4IPqQ`, unresolved 0 | PASS |
| UI·접근성·수동 QA | 해당 없음 | product/UI surface 변경 없음 | 6-file contract allowlist | 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: archive scan이 시작·종료 artifact watermark 사이에 위치하는지, post-cutoff transport가 eligible set에서 제외되는지, timezone 없는 provider time이 incomplete인지 확인해 주세요.

## 리스크

- R2 shared evidence/schema contract입니다. 기존 receipt producer는 `createdAt`과 post-cutoff transport identity를 새 계약에 맞춰야 하며, 누락·drift는 성공 대신 `AUDIT_INCOMPLETE`로 종료합니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다. (run `31299649742`, required contexts all PASS)
- [x] CodeRabbit 리뷰를 확인했다. (`PRR_kwDOS4Iqac8AAAABI4IPqQ`; CR1 closure `6c238b07`)
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다. (CodeRabbit Review 객체가 있어 fallback 불필요; 앞선 wrapper 경로 오류는 단일 Codex budget을 소모해 Review 미게시)
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)
