### PR TITLE
[Docs] D20 owner receipt fan-in contract 추가

### DIFF
--- a/.github/workflows/public-sensitivity-audit.yml
+++ b/.github/workflows/public-sensitivity-audit.yml
@@ -1,0 +1,74 @@
+name: Public Sensitivity Audit
+
+on:
+  workflow_dispatch:
+    inputs:
+      observed_at:
+        description: Canonical UTC observation time
+        required: true
+        type: string
+      owner_receipts:
+        description: Repository-local JSON manifest of five exact receipt artifact locators and heads
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  actions: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  audit:
+    if: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Public Sensitivity Audit / Checkout default branch head
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Public Sensitivity Audit / Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24"
+
+      - name: Public Sensitivity Audit / Materialize immutable handoff manifest
+        shell: bash
+        env:
+          OWNER_RECEIPTS: ${{ inputs.owner_receipts }}
+        run: |
+          set -euo pipefail
+          mkdir --parents d20-audit
+          test ! -e d20-audit/owner-receipts.json
+          printf '%s\n' "${OWNER_RECEIPTS}" > d20-audit/owner-receipts.json
+
+      - name: Public Sensitivity Audit / Run write-once sanitized report
+        shell: bash
+        env:
+          D20_FIVE_REPO_PUBLIC_AUDIT_READ_TOKEN: ${{ secrets.D20_FIVE_REPO_PUBLIC_AUDIT_READ_TOKEN }}
+          GH_TOKEN: ${{ secrets.D20_FIVE_REPO_PUBLIC_AUDIT_READ_TOKEN }}
+          OBSERVED_AT: ${{ inputs.observed_at }}
+        run: |
+          set -euo pipefail
+          test ! -e d20-audit/public-sensitivity-audit-report.json
+          node tools/repo/run-public-sensitivity-audit.mjs \
+            --scope contracts/documentation/public-sensitivity-audit-scope.json \
+            --owner-receipts d20-audit/owner-receipts.json \
+            --observed-at "${OBSERVED_AT}" \
+            --runner-sha "${GITHUB_SHA}" \
+            --repository-root . \
+            --output d20-audit/public-sensitivity-audit-report.json
+
+      - name: Public Sensitivity Audit / Upload sanitized report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: d20-public-sensitivity-audit-${{ github.sha }}
+          path: d20-audit/public-sensitivity-audit-report.json
+          if-no-files-found: error
+          include-hidden-files: false
+          overwrite: false
+          retention-days: 14

--- a/.github/workflows/public-sensitivity-audit.yml
+++ b/.github/workflows/public-sensitivity-audit.yml
@@ -15,8 +15,6 @@ on:
 permissions:
   contents: read
   actions: read
-  issues: read
-  pull-requests: read
 
 jobs:
   audit:

--- a/.github/workflows/public-sensitivity-owner-receipt.yml
+++ b/.github/workflows/public-sensitivity-owner-receipt.yml
@@ -1,0 +1,107 @@
+name: Public Sensitivity Owner Receipt
+
+on:
+  workflow_call:
+    secrets:
+      D20_SECRET_SCANNING_ALERTS_READ_TOKEN:
+        required: true
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  receipt:
+    if: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      REPO_CODE: ${{ github.repository == 'AquilaXk/easysubway' && 'hub' || github.repository == 'AquilaXk/easysubway-backend' && 'backend' || github.repository == 'AquilaXk/easysubway-data' && 'data' || github.repository == 'AquilaXk/easysubway-mobile' && 'mobile' || github.repository == 'AquilaXk/easysubway-platform' && 'platform' || 'invalid' }}
+    steps:
+      - name: Public Sensitivity Owner Receipt / Reject missing secret-alert capability
+        shell: bash
+        env:
+          D20_SECRET_SCANNING_ALERTS_READ_TOKEN: ${{ secrets.D20_SECRET_SCANNING_ALERTS_READ_TOKEN }}
+        run: |
+          set -euo pipefail
+          test -n "${D20_SECRET_SCANNING_ALERTS_READ_TOKEN}"
+
+      - name: Public Sensitivity Owner Receipt / Checkout default branch head
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Public Sensitivity Owner Receipt / Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24"
+
+      - name: Public Sensitivity Owner Receipt / Create sanitized evidence bundle
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          D20_SECRET_SCANNING_ALERTS_READ_TOKEN: ${{ secrets.D20_SECRET_SCANNING_ALERTS_READ_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir --parents d20-evidence
+          test ! -e d20-evidence/evidence.json
+          OBSERVED_AT="$(date --utc +"%Y-%m-%dT%H:%M:%S.000Z")"
+          printf 'OBSERVED_AT=%s\n' "${OBSERVED_AT}" >> "${GITHUB_ENV}"
+          node tools/repo/produce-public-sensitivity-owner-receipt.mjs \
+            --repository "${GITHUB_REPOSITORY}" \
+            --git-sha "${GITHUB_SHA}" \
+            --observed-at "${OBSERVED_AT}" \
+            --evidence-output d20-evidence/evidence.json
+
+      - id: evidence-upload
+        name: Public Sensitivity Owner Receipt / Upload evidence first
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: d20-public-sensitivity-evidence-${{ env.REPO_CODE }}-${{ github.sha }}
+          path: d20-evidence/evidence.json
+          if-no-files-found: error
+          include-hidden-files: false
+          overwrite: false
+          retention-days: 14
+
+      - name: Public Sensitivity Owner Receipt / Finalize receipt after evidence identity
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVIDENCE_ARTIFACT_ID: ${{ steps.evidence-upload.outputs.artifact-id }}
+          EVIDENCE_ARTIFACT_DIGEST: ${{ steps.evidence-upload.outputs.artifact-digest }}
+        run: |
+          set -euo pipefail
+          test -n "${EVIDENCE_ARTIFACT_ID}"
+          [[ "${EVIDENCE_ARTIFACT_DIGEST}" =~ ^[0-9a-f]{64}$ ]]
+          mkdir --parents d20-receipt
+          gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${EVIDENCE_ARTIFACT_ID}" --jq '{id,expired,created_at,expires_at,name,digest,workflow_run}' > d20-receipt/evidence-artifact.json
+          node tools/repo/produce-public-sensitivity-owner-receipt.mjs \
+            --repository "${GITHUB_REPOSITORY}" \
+            --git-sha "${GITHUB_SHA}" \
+            --observed-at "${OBSERVED_AT}" \
+            --evidence-locator "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts/${EVIDENCE_ARTIFACT_ID}" \
+            --evidence-digest "${EVIDENCE_ARTIFACT_DIGEST}" \
+            --evidence-input d20-evidence/evidence.json \
+            --evidence-artifact d20-receipt/evidence-artifact.json \
+            --output d20-receipt/receipt.json
+
+      - name: Public Sensitivity Owner Receipt / Reject non-single receipt handoff
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(find d20-receipt -type f | wc -l | tr -d ' ')" = 2
+          test -s d20-receipt/receipt.json
+          rm d20-receipt/evidence-artifact.json
+          test "$(find d20-receipt -type f | wc -l | tr -d ' ')" = 1
+
+      - name: Public Sensitivity Owner Receipt / Upload finalized handoff
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: d20-public-sensitivity-owner-receipt-${{ env.REPO_CODE }}-${{ github.sha }}
+          path: d20-receipt/receipt.json
+          if-no-files-found: error
+          include-hidden-files: false
+          overwrite: false
+          retention-days: 14

--- a/.github/workflows/public-sensitivity-owner-receipt.yml
+++ b/.github/workflows/public-sensitivity-owner-receipt.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Public Sensitivity Owner Receipt / Checkout default branch head
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          repository: ${{ job.workflow_repository }}
-          ref: ${{ job.workflow_sha }}
+          repository: ${{ fromJSON(toJSON(job))[format('workflow_{0}', 'repository')] }}
+          ref: ${{ fromJSON(toJSON(job))[format('workflow_{0}', 'sha')] }}
           persist-credentials: false
 
       - name: Public Sensitivity Owner Receipt / Set up Node.js

--- a/.github/workflows/public-sensitivity-owner-receipt.yml
+++ b/.github/workflows/public-sensitivity-owner-receipt.yml
@@ -29,7 +29,8 @@ jobs:
       - name: Public Sensitivity Owner Receipt / Checkout default branch head
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          ref: ${{ github.sha }}
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
           persist-credentials: false
 
       - name: Public Sensitivity Owner Receipt / Set up Node.js

--- a/tools/ci/public-sensitivity-workflows.test.mjs
+++ b/tools/ci/public-sensitivity-workflows.test.mjs
@@ -23,6 +23,8 @@ test("owner receipt workflow pins the reusable two-artifact protocol and separat
   assert.match(text, /include-hidden-files: false/g);
   assert.match(text, /if-no-files-found: error/g);
   assert.match(text, /actions\/checkout@[0-9a-f]{40}/);
+  assert.match(text, /repository: \$\{\{ job\.workflow_repository \}\}/);
+  assert.match(text, /ref: \$\{\{ job\.workflow_sha \}\}/);
   assert.match(text, /actions\/setup-node@[0-9a-f]{40}/);
   assert.match(text, /actions\/upload-artifact@[0-9a-f]{40}/);
 });
@@ -31,6 +33,7 @@ test("fan-in workflow uses its dedicated five-repository public-audit token and 
   const text = await read("public-sensitivity-audit.yml");
   assert.match(text, /workflow_dispatch:/);
   assert.match(text, /D20_FIVE_REPO_PUBLIC_AUDIT_READ_TOKEN:/);
+  assert.doesNotMatch(text, /issues: read|pull-requests: read/);
   assert.match(text, /GH_TOKEN: \$\{\{ secrets\.D20_FIVE_REPO_PUBLIC_AUDIT_READ_TOKEN \}\}/);
   assert.match(text, /--owner-receipts/);
   assert.match(text, /--output/);

--- a/tools/ci/public-sensitivity-workflows.test.mjs
+++ b/tools/ci/public-sensitivity-workflows.test.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const read = (file) => readFile(new URL(`../../.github/workflows/${file}`, import.meta.url), "utf8");
+
+test("owner receipt workflow pins the reusable two-artifact protocol and separate alert secret", async () => {
+  const text = await read("public-sensitivity-owner-receipt.yml");
+  assert.match(text, /workflow_call:/);
+  assert.doesNotMatch(text, /secrets:\s*inherit/);
+  assert.match(text, /permissions:\s*\n\s*contents: read\s*\n\s*actions: read/);
+  assert.match(text, /D20_SECRET_SCANNING_ALERTS_READ_TOKEN:/);
+  assert.match(text, /REPO_CODE:.*'hub'.*'backend'.*'data'.*'mobile'.*'platform'/);
+  assert.match(text, /d20-public-sensitivity-evidence-\$\{\{ env\.REPO_CODE \}\}-\$\{\{ github\.sha \}\}/);
+  assert.match(text, /d20-public-sensitivity-owner-receipt-\$\{\{ env\.REPO_CODE \}\}-\$\{\{ github\.sha \}\}/);
+  assert.match(text, /GH_TOKEN: \$\{\{ github\.token \}\}/);
+  assert.match(text, /EVIDENCE_ARTIFACT_DIGEST: \$\{\{ steps\.evidence-upload\.outputs\.artifact-digest \}\}/);
+  assert.match(text, /--evidence-digest "\$\{EVIDENCE_ARTIFACT_DIGEST\}"/);
+  assert.match(text, /--evidence-input d20-evidence\/evidence\.json/);
+  assert.ok(text.indexOf("Upload evidence first") < text.indexOf("Finalize receipt after evidence identity"));
+  assert.ok(text.indexOf("Finalize receipt after evidence identity") < text.indexOf("Upload finalized handoff"));
+  assert.match(text, /retention-days: 14/g);
+  assert.match(text, /include-hidden-files: false/g);
+  assert.match(text, /if-no-files-found: error/g);
+  assert.match(text, /actions\/checkout@[0-9a-f]{40}/);
+  assert.match(text, /actions\/setup-node@[0-9a-f]{40}/);
+  assert.match(text, /actions\/upload-artifact@[0-9a-f]{40}/);
+});
+
+test("fan-in workflow uses its dedicated five-repository public-audit token and a write-once report", async () => {
+  const text = await read("public-sensitivity-audit.yml");
+  assert.match(text, /workflow_dispatch:/);
+  assert.match(text, /D20_FIVE_REPO_PUBLIC_AUDIT_READ_TOKEN:/);
+  assert.match(text, /GH_TOKEN: \$\{\{ secrets\.D20_FIVE_REPO_PUBLIC_AUDIT_READ_TOKEN \}\}/);
+  assert.match(text, /--owner-receipts/);
+  assert.match(text, /--output/);
+  assert.match(text, /--runner-sha "\$\{GITHUB_SHA\}"/);
+  assert.doesNotMatch(text, /GITHUB_TOKEN/);
+  assert.doesNotMatch(text, /test -n "\$\{D20_FIVE_REPO_PUBLIC_AUDIT_READ_TOKEN\}"/);
+  assert.match(text, /retention-days: 14/);
+  assert.match(text, /if: \$\{\{ always\(\) \}\}[\s\S]*if-no-files-found: error/);
+  assert.match(text, /actions\/checkout@[0-9a-f]{40}/);
+  assert.match(text, /actions\/setup-node@[0-9a-f]{40}/);
+  assert.match(text, /actions\/upload-artifact@[0-9a-f]{40}/);
+});

--- a/tools/ci/public-sensitivity-workflows.test.mjs
+++ b/tools/ci/public-sensitivity-workflows.test.mjs
@@ -23,8 +23,9 @@ test("owner receipt workflow pins the reusable two-artifact protocol and separat
   assert.match(text, /include-hidden-files: false/g);
   assert.match(text, /if-no-files-found: error/g);
   assert.match(text, /actions\/checkout@[0-9a-f]{40}/);
-  assert.match(text, /repository: \$\{\{ job\.workflow_repository \}\}/);
-  assert.match(text, /ref: \$\{\{ job\.workflow_sha \}\}/);
+  assert.match(text, /repository: \$\{\{ fromJSON\(toJSON\(job\)\)\[format\('workflow_\{0\}', 'repository'\)\] \}\}/);
+  assert.match(text, /ref: \$\{\{ fromJSON\(toJSON\(job\)\)\[format\('workflow_\{0\}', 'sha'\)\] \}\}/);
+  assert.match(text, /--git-sha "\$\{GITHUB_SHA\}"/);
   assert.match(text, /actions\/setup-node@[0-9a-f]{40}/);
   assert.match(text, /actions\/upload-artifact@[0-9a-f]{40}/);
 });

--- a/tools/repo/produce-public-sensitivity-owner-receipt.mjs
+++ b/tools/repo/produce-public-sensitivity-owner-receipt.mjs
@@ -1,0 +1,140 @@
+import { spawn } from "node:child_process";
+import { open, readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+import { DETECTORS, REPOSITORIES, collectArtifactCatalog, scanArtifactArchive, validateReceipt } from "./audit-public-sensitivity.mjs";
+
+const OUTPUT_LIMIT = 2 * 1024 * 1024;
+const BINARY_OUTPUT_LIMIT = 16 * 1024 * 1024;
+const POLICY = "public-sensitivity-v1";
+
+export async function produceOwnerReceipt({ repository, gitSha, observedAt, evidenceLocator, evidence, expectedEvidenceDigest, evidenceArtifact, execGh = githubGet }) {
+  if (!REPOSITORIES.includes(repository) || !/^[0-9a-f]{40}$/.test(gitSha) || !canonicalUtc(observedAt)) throw new Error("INVALID_INPUT");
+  const transport = normalizeArtifact(evidenceArtifact);
+  if (transport == null || !/^[0-9a-f]{64}$/.test(expectedEvidenceDigest ?? "") || transport.digest !== `sha256:${expectedEvidenceDigest}` || locator(repository, transport) !== evidenceLocator || transport.expired || instant(transport.createdAt) <= instant(observedAt)) throw new Error("EVIDENCE_TRANSPORT_INVALID");
+  const receipt = { ...evidence, evidenceLocator };
+  if (!validEvidenceShape(evidence) || validateReceipt(receipt, { repository, gitSha, observedAt, detectorPolicyVersion: POLICY }).length) throw new Error("EVIDENCE_SNAPSHOT_INVALID");
+  const catalog = await collectArtifactCatalog({ repository, execGh });
+  if (catalog.incomplete.length || !catalog.catalog.some((artifact) => sameArtifact(artifact, transport))) throw new Error("EVIDENCE_TRANSPORT_INVALID");
+  return { evidence, receipt };
+}
+
+export async function produceOwnerEvidence({ repository, gitSha, observedAt, execGh = githubGet, execAlerts = alertGet }) {
+  if (!REPOSITORIES.includes(repository) || !/^[0-9a-f]{40}$/.test(gitSha) || !canonicalUtc(observedAt)) throw new Error("INVALID_INPUT");
+  const [security, refs, alertResult] = await Promise.all([
+    securitySettings({ repository, execAlerts }),
+    reachableRefs({ repository, gitSha, execGh }),
+    enumerateAlerts({ repository, execAlerts }),
+  ]).catch(() => { throw new Error("ALERT_CAPABILITY_UNAVAILABLE"); });
+  const begin = await collectArtifactCatalog({ repository, execGh });
+  if (begin.incomplete.length) throw new Error("PUBLIC_ARTIFACT_INCOMPLETE");
+  const publicArtifacts = await scanEligibleArtifacts({ repository, observedAt, catalog: begin.catalog, execGh });
+  const end = await collectArtifactCatalog({ repository, execGh });
+  if (end.incomplete.length || begin.watermark !== end.watermark) throw new Error("PUBLIC_ARTIFACT_INCOMPLETE");
+  return {
+      schemaVersion: 1, repository, gitSha, observedAt, detectorPolicyVersion: POLICY,
+      secretScanningEnabled: security.secretScanningEnabled, pushProtectionEnabled: security.pushProtectionEnabled,
+      reachableRefAuditComplete: refs, alertEnumerationComplete: alertResult.complete,
+      locationEnumerationComplete: alertResult.complete, openAlertCount: alertResult.openAlertCount,
+      unresolvedAlertCount: alertResult.unresolvedAlertCount, publicArtifactEnumerationComplete: true,
+      publicArtifacts,
+  };
+}
+
+async function securitySettings({ repository, execAlerts }) {
+  const settings = await execAlerts({ method: "GET", endpoint: `repos/${repository}` });
+  if (settings?.security_and_analysis?.secret_scanning?.status !== "enabled" || settings?.security_and_analysis?.secret_scanning_push_protection?.status !== "enabled") throw new Error("ALERT_CAPABILITY_UNAVAILABLE");
+  return { secretScanningEnabled: true, pushProtectionEnabled: true };
+}
+
+async function reachableRefs({ repository, gitSha, execGh }) {
+  const ref = await execGh({ method: "GET", endpoint: `repos/${repository}/git/ref/heads/main` });
+  if (ref?.ref !== "refs/heads/main" || ref?.object?.sha !== gitSha) throw new Error("REACHABLE_REF_AUDIT_INCOMPLETE");
+  return true;
+}
+
+async function enumerateAlerts({ repository, execAlerts }) {
+  const alerts = await pages({ repository, endpoint: `repos/${repository}/secret-scanning/alerts?state=open&per_page=100&page=`, exec: execAlerts, identity: (entry) => entry?.number });
+  for (const alert of alerts) {
+    if (!Number.isSafeInteger(alert?.number) || alert.number < 1) throw new Error("ALERT_CAPABILITY_UNAVAILABLE");
+    await pages({ repository, endpoint: `repos/${repository}/secret-scanning/alerts/${alert.number}/locations?per_page=100&page=`, exec: execAlerts, identity: locationIdentity });
+  }
+  return { complete: true, openAlertCount: alerts.length, unresolvedAlertCount: alerts.length };
+}
+
+async function pages({ repository, endpoint, exec, identity }) {
+  const result = []; const ids = new Set();
+  for (let page = 1; page <= 1000; page += 1) {
+    const body = await exec({ method: "GET", endpoint: `${endpoint}${page}` });
+    if (!Array.isArray(body) || body.length > 100) throw new Error("PAGINATION_INCOMPLETE");
+    for (const entry of body) {
+      const itemIdentity = identity(entry);
+      if ((typeof itemIdentity !== "number" && typeof itemIdentity !== "string") || itemIdentity === "" || ids.has(itemIdentity)) throw new Error("PAGINATION_INCOMPLETE");
+      ids.add(itemIdentity); result.push(entry);
+    }
+    if (body.length < 100) return result;
+  }
+  throw new Error(`PAGINATION_INCOMPLETE:${repository}`);
+}
+function locationIdentity(entry) { return entry != null && typeof entry === "object" && !Array.isArray(entry) ? JSON.stringify(entry) : ""; }
+
+async function scanEligibleArtifacts({ repository, observedAt, catalog, execGh }) {
+  const eligible = catalog.filter((artifact) => !artifact.expired && instant(artifact.createdAt) <= instant(observedAt));
+  const output = [];
+  for (const artifact of eligible) {
+    const run = await execGh({ method: "GET", endpoint: `repos/${repository}/actions/runs/${artifact.workflow_run.id}` });
+    if (!safeWorkflow(run?.path)) throw new Error("PUBLIC_ARTIFACT_INCOMPLETE");
+    const bytes = await execGh({ method: "GET", endpoint: `repos/${repository}/actions/artifacts/${artifact.id}/zip`, binary: true });
+    const scanned = scanArtifactArchive({ repository, artifactId: String(artifact.id), bytes, scope: { detectors: DETECTORS } });
+    if (scanned.incomplete.length) throw new Error("PUBLIC_ARTIFACT_INCOMPLETE");
+    output.push({ artifactId: String(artifact.id), artifactName: artifact.name, workflowPath: run.path, runId: String(artifact.workflow_run.id), archiveDigest: artifact.digest, createdAt: artifact.createdAt, expiresAt: artifact.expiresAt, detectorPolicyVersion: POLICY, scanStatus: "COMPLETE", scanReceiptLocator: locator(repository, artifact) });
+  }
+  return output.sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right), "en"));
+}
+
+export async function runOwnerReceiptCli(args = process.argv.slice(2)) {
+  try {
+    const parsed = parseArgs(args);
+    const result = parsed.mode === "evidence"
+      ? await produceOwnerEvidence(parsed)
+      : (await produceOwnerReceipt({ ...parsed, evidence: JSON.parse(await readFile(parsed.evidenceInput, "utf8")), evidenceArtifact: JSON.parse(await readFile(parsed.evidenceArtifact, "utf8")) })).receipt;
+    const file = await open(parsed.output, "wx");
+    try { await file.writeFile(`${JSON.stringify(result, null, 2)}\n`); } finally { await file.close(); }
+    return 0;
+  } catch { process.stderr.write("OWNER_RECEIPT_INCOMPLETE\n"); return 2; }
+}
+
+function parseArgs(args) {
+  if (args.length === 8 && args[0] === "--repository" && args[2] === "--git-sha" && args[4] === "--observed-at" && args[6] === "--evidence-output") return { mode: "evidence", repository: args[1], gitSha: args[3], observedAt: args[5], output: args[7] };
+  if (args.length !== 16 || args[0] !== "--repository" || args[2] !== "--git-sha" || args[4] !== "--observed-at" || args[6] !== "--evidence-locator" || args[8] !== "--evidence-digest" || args[10] !== "--evidence-input" || args[12] !== "--evidence-artifact" || args[14] !== "--output") throw new Error("INVALID_INPUT");
+  return { repository: args[1], gitSha: args[3], observedAt: args[5], evidenceLocator: args[7], expectedEvidenceDigest: args[9], evidenceInput: args[11], evidenceArtifact: args[13], output: args[15] };
+}
+
+function validEvidenceShape(evidence) {
+  const keys = ["alertEnumerationComplete", "detectorPolicyVersion", "gitSha", "locationEnumerationComplete", "observedAt", "openAlertCount", "publicArtifactEnumerationComplete", "publicArtifacts", "pushProtectionEnabled", "reachableRefAuditComplete", "repository", "schemaVersion", "secretScanningEnabled", "unresolvedAlertCount"];
+  return evidence != null && !Array.isArray(evidence) && JSON.stringify(Object.keys(evidence).sort()) === JSON.stringify(keys);
+}
+
+function normalizeArtifact(raw) {
+  const createdAt = normalizeTimestamp(raw?.created_at); const expiresAt = normalizeTimestamp(raw?.expires_at);
+  if (!Number.isSafeInteger(raw?.id) || raw.id < 0 || raw?.expired !== false || createdAt == null || expiresAt == null || instant(expiresAt) <= instant(createdAt) || !/^[A-Za-z0-9][A-Za-z0-9._ -]{0,127}$/.test(raw?.name ?? "") || !Number.isSafeInteger(raw?.workflow_run?.id) || raw.workflow_run.id < 0 || !/^sha256:[0-9a-f]{64}$/.test(raw?.digest ?? "")) return null;
+  return { id: raw.id, expired: raw.expired, createdAt, expiresAt, name: raw.name, digest: raw.digest, workflow_run: { id: raw.workflow_run.id } };
+}
+function sameArtifact(left, right) { return left.id === right.id && left.createdAt === right.createdAt && left.expiresAt === right.expiresAt && left.name === right.name && left.digest === right.digest && left.workflow_run.id === right.workflow_run.id; }
+function locator(repository, artifact) { return `https://github.com/${repository}/actions/runs/${artifact.workflow_run.id}/artifacts/${artifact.id}`; }
+function safeWorkflow(value) { return /^\.github\/workflows\/[A-Za-z0-9._/-]+\.ya?ml$/.test(value ?? "") && !value.includes(".."); }
+function canonicalUtc(value) { return /^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d\.\d{3}Z$/.test(value ?? "") && new Date(value).toISOString() === value; }
+function normalizeTimestamp(value) { const parsed = Date.parse(value ?? ""); return Number.isFinite(parsed) && /(?:Z|[+-]\d\d:\d\d)$/.test(value ?? "") ? new Date(parsed).toISOString() : null; }
+function instant(value) { const parsed = Date.parse(value); return Number.isFinite(parsed) ? parsed : NaN; }
+function boundedGet({ token, method, endpoint, binary = false }) {
+  if (method !== "GET" || !/^repos\/AquilaXk\/easysubway(?:-(?:backend|data|mobile|platform))?(?:\/|$)/.test(endpoint) || !safeToken(token)) return Promise.reject(new Error("provider unavailable"));
+  return new Promise((resolve, reject) => {
+    const child = spawn("gh", ["api", "--method", "GET", endpoint], { env: { ...process.env, GH_TOKEN: token }, stdio: ["ignore", "pipe", "ignore"] }); const chunks = []; let size = 0; const limit = binary ? BINARY_OUTPUT_LIMIT : OUTPUT_LIMIT; const timer = setTimeout(() => child.kill("SIGTERM"), 30_000);
+    child.stdout.on("data", (chunk) => { chunks.push(chunk); size += chunk.length; if (size > limit) child.kill("SIGTERM"); });
+    child.on("error", reject); child.on("close", (code) => { clearTimeout(timer); if (code !== 0 || size > limit) reject(new Error("provider unavailable")); else try { const output = Buffer.concat(chunks); resolve(binary ? output : JSON.parse(output.toString("utf8"))); } catch { reject(new Error("provider unavailable")); } });
+  });
+}
+function safeToken(value) { return typeof value === "string" && value.length > 0 && value.length <= 4096 && !/[\0-\x1f\x7f]/.test(value); }
+function githubGet(request) { return boundedGet({ token: process.env.GH_TOKEN, ...request }); }
+function alertGet(request) { return boundedGet({ token: process.env.D20_SECRET_SCANNING_ALERTS_READ_TOKEN, ...request }); }
+if (process.argv[1] === fileURLToPath(import.meta.url)) process.exitCode = await runOwnerReceiptCli();

--- a/tools/repo/produce-public-sensitivity-owner-receipt.mjs
+++ b/tools/repo/produce-public-sensitivity-owner-receipt.mjs
@@ -3,6 +3,7 @@ import { open, readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 
 import { DETECTORS, REPOSITORIES, collectArtifactCatalog, scanArtifactArchive, validateReceipt } from "./audit-public-sensitivity.mjs";
+import { digest, readSingleZipJson, stableJson } from "./run-public-sensitivity-audit.mjs";
 
 const OUTPUT_LIMIT = 2 * 1024 * 1024;
 const BINARY_OUTPUT_LIMIT = 16 * 1024 * 1024;
@@ -16,6 +17,12 @@ export async function produceOwnerReceipt({ repository, gitSha, observedAt, evid
   if (!validEvidenceShape(evidence) || validateReceipt(receipt, { repository, gitSha, observedAt, detectorPolicyVersion: POLICY }).length) throw new Error("EVIDENCE_SNAPSHOT_INVALID");
   const catalog = await collectArtifactCatalog({ repository, execGh });
   if (catalog.incomplete.length || !catalog.catalog.some((artifact) => sameArtifact(artifact, transport))) throw new Error("EVIDENCE_TRANSPORT_INVALID");
+  let bytes;
+  try { bytes = await execGh({ method: "GET", endpoint: `repos/${repository}/actions/artifacts/${transport.id}/zip`, binary: true }); } catch { throw new Error("EVIDENCE_TRANSPORT_INVALID"); }
+  if (!Buffer.isBuffer(bytes) || `sha256:${digest(bytes)}` !== transport.digest) throw new Error("EVIDENCE_TRANSPORT_INVALID");
+  let archivedEvidence;
+  try { archivedEvidence = JSON.parse(readSingleZipJson(bytes, "evidence.json").text); } catch { throw new Error("EVIDENCE_TRANSPORT_INVALID"); }
+  if (stableJson(archivedEvidence) !== stableJson(evidence)) throw new Error("EVIDENCE_TRANSPORT_INVALID");
   return { evidence, receipt };
 }
 

--- a/tools/repo/produce-public-sensitivity-owner-receipt.test.mjs
+++ b/tools/repo/produce-public-sensitivity-owner-receipt.test.mjs
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import test from "node:test";
+
+import { produceOwnerEvidence, produceOwnerReceipt } from "./produce-public-sensitivity-owner-receipt.mjs";
+
+const REPOSITORY = "AquilaXk/easysubway";
+const SHA = "a".repeat(40);
+const OBSERVED_AT = "2026-08-09T00:00:00.000Z";
+const LOCATOR = `https://github.com/${REPOSITORY}/actions/runs/7/artifacts/9`;
+
+function artifact(id, overrides = {}) {
+  return { id, expired: false, created_at: "2026-08-08T00:00:00.000Z", expires_at: "2026-09-09T00:00:00.000Z", name: `evidence-${id}`, digest: `sha256:${"b".repeat(64)}`, workflow_run: { id: 7 }, ...overrides };
+}
+
+function gh({ evidence = artifact(9, { created_at: "2026-08-09T00:00:00.001Z" }) } = {}) {
+  return async ({ endpoint, binary }) => {
+    if (endpoint === `repos/${REPOSITORY}/actions/artifacts?per_page=100&page=1`) return { total_count: 1, artifacts: [evidence] };
+    if (endpoint === `repos/${REPOSITORY}/git/ref/heads/main`) return { ref: "refs/heads/main", object: { sha: SHA } };
+    if (endpoint === `repos/${REPOSITORY}/actions/runs/7`) return { path: ".github/workflows/public-sensitivity-owner-receipt.yml" };
+    if (endpoint === `repos/${REPOSITORY}/actions/artifacts/9/zip`) return Buffer.from("PK\x05\x06\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0", "binary");
+    throw new Error(`unexpected ${binary ? "binary " : ""}${endpoint}`);
+  };
+}
+
+function alerts({ open = [], locations = [] } = {}) {
+  return async ({ endpoint }) => {
+    if (endpoint === `repos/${REPOSITORY}`) return { security_and_analysis: { secret_scanning: { status: "enabled" }, secret_scanning_push_protection: { status: "enabled" } } };
+    if (endpoint === `repos/${REPOSITORY}/secret-scanning/alerts?state=open&per_page=100&page=1`) return open;
+    if (endpoint === `repos/${REPOSITORY}/secret-scanning/alerts/1/locations?per_page=100&page=1`) return locations;
+    throw new Error(`unexpected ${endpoint}`);
+  };
+}
+
+function zip(name, text) {
+  const filename = Buffer.from(name); const data = Buffer.from(text); const crc = crc32(data);
+  const local = Buffer.alloc(30 + filename.length + data.length);
+  local.writeUInt32LE(0x04034b50, 0); local.writeUInt32LE(crc, 14); local.writeUInt32LE(data.length, 18); local.writeUInt32LE(data.length, 22); local.writeUInt16LE(filename.length, 26); filename.copy(local, 30); data.copy(local, 30 + filename.length);
+  const central = Buffer.alloc(46 + filename.length);
+  central.writeUInt32LE(0x02014b50, 0); central.writeUInt32LE(crc, 16); central.writeUInt32LE(data.length, 20); central.writeUInt32LE(data.length, 24); central.writeUInt16LE(filename.length, 28); central.writeUInt32LE(0, 42); filename.copy(central, 46);
+  const end = Buffer.alloc(22); end.writeUInt32LE(0x06054b50, 0); end.writeUInt16LE(1, 8); end.writeUInt16LE(1, 10); end.writeUInt32LE(central.length, 12); end.writeUInt32LE(local.length, 16);
+  return Buffer.concat([local, central, end]);
+}
+
+function crc32(bytes) { let crc = 0xffffffff; for (const byte of bytes) { crc ^= byte; for (let bit = 0; bit < 8; bit += 1) crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1)); } return (crc ^ 0xffffffff) >>> 0; }
+
+test("receipt is created only after the post-cutoff evidence artifact identity is available", async () => {
+  const evidence = await produceOwnerEvidence({ repository: REPOSITORY, gitSha: SHA, observedAt: OBSERVED_AT, execGh: gh(), execAlerts: alerts() });
+  await assert.rejects(() => produceOwnerReceipt({ repository: REPOSITORY, gitSha: SHA, observedAt: OBSERVED_AT, evidenceLocator: LOCATOR, evidence, execGh: gh() }), /EVIDENCE_TRANSPORT_INVALID/);
+  const transport = artifact(9, { created_at: "2026-08-09T00:00:00.001Z" });
+  const result = await produceOwnerReceipt({ repository: REPOSITORY, gitSha: SHA, observedAt: OBSERVED_AT, evidenceLocator: LOCATOR, evidence, expectedEvidenceDigest: transport.digest.slice("sha256:".length), evidenceArtifact: transport, execGh: gh() });
+  assert.equal(result.receipt.evidenceLocator, LOCATOR);
+  assert.equal(result.receipt.alertEnumerationComplete, true);
+  assert.equal(result.receipt.publicArtifactEnumerationComplete, true);
+});
+
+test("producer fails closed when alert capability or post-cutoff evidence boundary is incomplete", async () => {
+  const evidence = await produceOwnerEvidence({ repository: REPOSITORY, gitSha: SHA, observedAt: OBSERVED_AT, execGh: gh(), execAlerts: alerts() });
+  const beforeCutoff = artifact(9);
+  await assert.rejects(() => produceOwnerReceipt({ repository: REPOSITORY, gitSha: SHA, observedAt: OBSERVED_AT, evidenceLocator: LOCATOR, evidence, expectedEvidenceDigest: beforeCutoff.digest.slice("sha256:".length), evidenceArtifact: beforeCutoff, execGh: gh({ evidence: beforeCutoff }) }), /EVIDENCE_TRANSPORT_INVALID/);
+  await assert.rejects(() => produceOwnerEvidence({ repository: REPOSITORY, gitSha: SHA, observedAt: OBSERVED_AT, execGh: gh(), execAlerts: async () => { throw new Error("403 secret value"); } }), /ALERT_CAPABILITY_UNAVAILABLE/);
+});
+
+test("complete scan with findings remains COMPLETE for receipt admission", async () => {
+  const archive = zip("finding.txt", "authorization: bearer not-a-real-secret");
+  const digest = `sha256:${createHash("sha256").update(archive).digest("hex")}`;
+  const eligible = artifact(5, { created_at: "2026-08-08T00:00:00.000Z", name: "eligible", digest, workflow_run: { id: 5 } });
+  const execGh = async ({ endpoint, binary }) => {
+    if (endpoint.endsWith("/actions/artifacts?per_page=100&page=1")) return { total_count: 1, artifacts: [eligible] };
+    if (endpoint.endsWith("/git/ref/heads/main")) return { ref: "refs/heads/main", object: { sha: SHA } };
+    if (endpoint.endsWith("/actions/runs/5")) return { path: ".github/workflows/ci.yml" };
+    if (endpoint.endsWith("/actions/artifacts/5/zip")) { assert.equal(binary, true); return archive; }
+    throw new Error(`unexpected ${endpoint}`);
+  };
+  const evidence = await produceOwnerEvidence({ repository: REPOSITORY, gitSha: SHA, observedAt: OBSERVED_AT, execGh, execAlerts: alerts() });
+  assert.equal(evidence.publicArtifacts[0].scanStatus, "COMPLETE");
+});
+
+test("receipt reuses the uploaded evidence snapshot without a second live scan", async () => {
+  const evidence = await produceOwnerEvidence({ repository: REPOSITORY, gitSha: SHA, observedAt: OBSERVED_AT, execGh: gh(), execAlerts: alerts() });
+  const transport = artifact(9, { created_at: "2026-08-09T00:00:00.001Z" });
+  const result = await produceOwnerReceipt({ repository: REPOSITORY, gitSha: SHA, observedAt: OBSERVED_AT, evidenceLocator: LOCATOR, evidence, expectedEvidenceDigest: transport.digest.slice("sha256:".length), evidenceArtifact: transport, execGh: gh(), execAlerts: async () => { throw new Error("must not rescan"); } });
+  assert.deepEqual(result.receipt, { ...evidence, evidenceLocator: LOCATOR });
+  await assert.rejects(() => produceOwnerReceipt({ repository: REPOSITORY, gitSha: SHA, observedAt: OBSERVED_AT, evidenceLocator: LOCATOR, evidence, expectedEvidenceDigest: `sha256:${"c".repeat(64)}`, evidenceArtifact: transport, execGh: gh() }), /EVIDENCE_TRANSPORT_INVALID/);
+});
+
+test("location enumeration accepts the native location shape without invented numeric IDs", async () => {
+  const evidence = await produceOwnerEvidence({ repository: REPOSITORY, gitSha: SHA, observedAt: OBSERVED_AT, execGh: gh(), execAlerts: alerts({ open: [{ number: 1 }], locations: [{ type: "commit", details: { path: "safe.txt", start_line: 1 } }] }) });
+  assert.equal(evidence.alertEnumerationComplete, true);
+  assert.equal(evidence.locationEnumerationComplete, true);
+  assert.equal(evidence.openAlertCount, 1);
+});

--- a/tools/repo/produce-public-sensitivity-owner-receipt.test.mjs
+++ b/tools/repo/produce-public-sensitivity-owner-receipt.test.mjs
@@ -13,12 +13,12 @@ function artifact(id, overrides = {}) {
   return { id, expired: false, created_at: "2026-08-08T00:00:00.000Z", expires_at: "2026-09-09T00:00:00.000Z", name: `evidence-${id}`, digest: `sha256:${"b".repeat(64)}`, workflow_run: { id: 7 }, ...overrides };
 }
 
-function gh({ evidence = artifact(9, { created_at: "2026-08-09T00:00:00.001Z" }) } = {}) {
+function gh({ evidence = artifact(9, { created_at: "2026-08-09T00:00:00.001Z" }), evidenceArchive = null } = {}) {
   return async ({ endpoint, binary }) => {
     if (endpoint === `repos/${REPOSITORY}/actions/artifacts?per_page=100&page=1`) return { total_count: 1, artifacts: [evidence] };
     if (endpoint === `repos/${REPOSITORY}/git/ref/heads/main`) return { ref: "refs/heads/main", object: { sha: SHA } };
     if (endpoint === `repos/${REPOSITORY}/actions/runs/7`) return { path: ".github/workflows/public-sensitivity-owner-receipt.yml" };
-    if (endpoint === `repos/${REPOSITORY}/actions/artifacts/9/zip`) return Buffer.from("PK\x05\x06\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0", "binary");
+    if (endpoint === `repos/${REPOSITORY}/actions/artifacts/9/zip`) return evidenceArchive ?? Buffer.from("PK\x05\x06\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0", "binary");
     throw new Error(`unexpected ${binary ? "binary " : ""}${endpoint}`);
   };
 }
@@ -48,7 +48,9 @@ test("receipt is created only after the post-cutoff evidence artifact identity i
   const evidence = await produceOwnerEvidence({ repository: REPOSITORY, gitSha: SHA, observedAt: OBSERVED_AT, execGh: gh(), execAlerts: alerts() });
   await assert.rejects(() => produceOwnerReceipt({ repository: REPOSITORY, gitSha: SHA, observedAt: OBSERVED_AT, evidenceLocator: LOCATOR, evidence, execGh: gh() }), /EVIDENCE_TRANSPORT_INVALID/);
   const transport = artifact(9, { created_at: "2026-08-09T00:00:00.001Z" });
-  const result = await produceOwnerReceipt({ repository: REPOSITORY, gitSha: SHA, observedAt: OBSERVED_AT, evidenceLocator: LOCATOR, evidence, expectedEvidenceDigest: transport.digest.slice("sha256:".length), evidenceArtifact: transport, execGh: gh() });
+  const archive = zip("evidence.json", JSON.stringify(evidence));
+  transport.digest = `sha256:${createHash("sha256").update(archive).digest("hex")}`;
+  const result = await produceOwnerReceipt({ repository: REPOSITORY, gitSha: SHA, observedAt: OBSERVED_AT, evidenceLocator: LOCATOR, evidence, expectedEvidenceDigest: transport.digest.slice("sha256:".length), evidenceArtifact: transport, execGh: gh({ evidence: transport, evidenceArchive: archive }) });
   assert.equal(result.receipt.evidenceLocator, LOCATOR);
   assert.equal(result.receipt.alertEnumerationComplete, true);
   assert.equal(result.receipt.publicArtifactEnumerationComplete, true);
@@ -59,6 +61,21 @@ test("producer fails closed when alert capability or post-cutoff evidence bounda
   const beforeCutoff = artifact(9);
   await assert.rejects(() => produceOwnerReceipt({ repository: REPOSITORY, gitSha: SHA, observedAt: OBSERVED_AT, evidenceLocator: LOCATOR, evidence, expectedEvidenceDigest: beforeCutoff.digest.slice("sha256:".length), evidenceArtifact: beforeCutoff, execGh: gh({ evidence: beforeCutoff }) }), /EVIDENCE_TRANSPORT_INVALID/);
   await assert.rejects(() => produceOwnerEvidence({ repository: REPOSITORY, gitSha: SHA, observedAt: OBSERVED_AT, execGh: gh(), execAlerts: async () => { throw new Error("403 secret value"); } }), /ALERT_CAPABILITY_UNAVAILABLE/);
+});
+
+test("receipt finalization rejects missing, digest-mismatched, malformed, and changed uploaded evidence", async () => {
+  const evidence = await produceOwnerEvidence({ repository: REPOSITORY, gitSha: SHA, observedAt: OBSERVED_AT, execGh: gh(), execAlerts: alerts() });
+  const transport = artifact(9, { created_at: "2026-08-09T00:00:00.001Z" });
+  const original = zip("evidence.json", JSON.stringify(evidence));
+  transport.digest = `sha256:${createHash("sha256").update(original).digest("hex")}`;
+  const input = { repository: REPOSITORY, gitSha: SHA, observedAt: OBSERVED_AT, evidenceLocator: LOCATOR, evidence, expectedEvidenceDigest: transport.digest.slice("sha256:".length), evidenceArtifact: transport };
+  await assert.rejects(() => produceOwnerReceipt({ ...input, execGh: async ({ endpoint }) => { if (endpoint.endsWith("/zip")) throw new Error("404"); return gh({ evidence: transport })({ endpoint }); } }), /EVIDENCE_TRANSPORT_INVALID/);
+  const malformed = Buffer.from("not-a-zip");
+  const malformedTransport = { ...transport, digest: `sha256:${createHash("sha256").update(malformed).digest("hex")}` };
+  await assert.rejects(() => produceOwnerReceipt({ ...input, expectedEvidenceDigest: malformedTransport.digest.slice("sha256:".length), evidenceArtifact: malformedTransport, execGh: gh({ evidence: malformedTransport, evidenceArchive: malformed }) }), /EVIDENCE_TRANSPORT_INVALID/);
+  const changed = zip("evidence.json", JSON.stringify({ ...evidence, openAlertCount: 1 }));
+  transport.digest = `sha256:${createHash("sha256").update(changed).digest("hex")}`;
+  await assert.rejects(() => produceOwnerReceipt({ ...input, expectedEvidenceDigest: transport.digest.slice("sha256:".length), evidenceArtifact: transport, execGh: gh({ evidence: transport, evidenceArchive: changed }) }), /EVIDENCE_TRANSPORT_INVALID/);
 });
 
 test("complete scan with findings remains COMPLETE for receipt admission", async () => {
@@ -79,7 +96,9 @@ test("complete scan with findings remains COMPLETE for receipt admission", async
 test("receipt reuses the uploaded evidence snapshot without a second live scan", async () => {
   const evidence = await produceOwnerEvidence({ repository: REPOSITORY, gitSha: SHA, observedAt: OBSERVED_AT, execGh: gh(), execAlerts: alerts() });
   const transport = artifact(9, { created_at: "2026-08-09T00:00:00.001Z" });
-  const result = await produceOwnerReceipt({ repository: REPOSITORY, gitSha: SHA, observedAt: OBSERVED_AT, evidenceLocator: LOCATOR, evidence, expectedEvidenceDigest: transport.digest.slice("sha256:".length), evidenceArtifact: transport, execGh: gh(), execAlerts: async () => { throw new Error("must not rescan"); } });
+  const archive = zip("evidence.json", JSON.stringify(evidence));
+  transport.digest = `sha256:${createHash("sha256").update(archive).digest("hex")}`;
+  const result = await produceOwnerReceipt({ repository: REPOSITORY, gitSha: SHA, observedAt: OBSERVED_AT, evidenceLocator: LOCATOR, evidence, expectedEvidenceDigest: transport.digest.slice("sha256:".length), evidenceArtifact: transport, execGh: gh({ evidence: transport, evidenceArchive: archive }), execAlerts: async () => { throw new Error("must not rescan"); } });
   assert.deepEqual(result.receipt, { ...evidence, evidenceLocator: LOCATOR });
   await assert.rejects(() => produceOwnerReceipt({ repository: REPOSITORY, gitSha: SHA, observedAt: OBSERVED_AT, evidenceLocator: LOCATOR, evidence, expectedEvidenceDigest: `sha256:${"c".repeat(64)}`, evidenceArtifact: transport, execGh: gh() }), /EVIDENCE_TRANSPORT_INVALID/);
 });

--- a/tools/repo/run-public-sensitivity-audit.mjs
+++ b/tools/repo/run-public-sensitivity-audit.mjs
@@ -67,7 +67,6 @@ export async function runFanInCli(args = process.argv.slice(2), { execGh = publi
     await containedInput(root, parsed.scope);
     const manifestPath = await containedInput(root, parsed.ownerReceipts);
     const outputPath = await containedOutput(root, parsed.output);
-    resolvedReceipts = relative(root, resolve(dirname(outputPath), "resolved-owner-receipts.json"));
     const scope = JSON.parse(await readFile(await containedInput(root, parsed.scope), "utf8"));
     if (!validateSchema(SCOPE_SCHEMA, scope).ok || validateScope(scope).length) throw new Error("INVALID_SCOPE");
     const inputs = JSON.parse(await readFile(manifestPath, "utf8"));
@@ -78,14 +77,13 @@ export async function runFanInCli(args = process.argv.slice(2), { execGh = publi
     const heads = Object.fromEntries(inputs.map(({ repository, gitSha }) => [repository, gitSha]));
     const receipts = assembleOwnerReceipts({ observedAt: parsed.observedAt, heads, handoffs });
     await verifyOwnerEvidence({ receipts, observedAt: parsed.observedAt, execGh });
-    await writeOnce(resolve(root, resolvedReceipts), receipts);
+    resolvedReceipts = await writeResolvedReceipts(root, outputPath, receipts);
   } catch {
     if (parsed == null) { process.stderr.write("AUDIT_INCOMPLETE\n"); return 2; }
     try {
       root ??= await realpath(parsed.root);
       const outputPath = await containedOutput(root, parsed.output);
-      resolvedReceipts ??= relative(root, resolve(dirname(outputPath), "resolved-owner-receipts.json"));
-      await writeOnce(resolve(root, resolvedReceipts), []);
+      resolvedReceipts ??= await writeResolvedReceipts(root, outputPath, []);
     } catch { process.stderr.write("AUDIT_INCOMPLETE\n"); return 2; }
   }
   const auditObservedAt = canonicalUtc(parsed.observedAt) ? parsed.observedAt : "1970-01-01T00:00:00.000Z";
@@ -105,7 +103,7 @@ function normalizeArtifact(raw) {
   return { id: raw.id, name: raw.name, digest: raw.digest, workflowRunId: raw.workflow_run.id, expired: raw.expired, createdAt, expiresAt };
 }
 
-function readSingleZipJson(bytes, expectedName) {
+export function readSingleZipJson(bytes, expectedName) {
   try {
     if (!Buffer.isBuffer(bytes) || bytes.length < 22 || bytes.length > BINARY_OUTPUT_LIMIT) throw new Error();
     let eocd = -1;
@@ -130,12 +128,12 @@ function readSingleZipJson(bytes, expectedName) {
 function repositoryCode(repository) { return repository === "AquilaXk/easysubway" ? "hub" : repository.slice("AquilaXk/easysubway-".length); }
 function handoffName(repository, gitSha) { return `d20-public-sensitivity-owner-receipt-${repositoryCode(repository)}-${gitSha}`; }
 function evidenceName(repository, gitSha) { return `d20-public-sensitivity-evidence-${repositoryCode(repository)}-${gitSha}`; }
-function stableJson(value) { if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`; if (value != null && typeof value === "object") return `{${Object.keys(value).sort(codepointCompare).map((key) => `${JSON.stringify(key)}:${stableJson(value[key])}`).join(",")}}`; return JSON.stringify(value); }
+export function stableJson(value) { if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`; if (value != null && typeof value === "object") return `{${Object.keys(value).sort(codepointCompare).map((key) => `${JSON.stringify(key)}:${stableJson(value[key])}`).join(",")}}`; return JSON.stringify(value); }
 function validInputs(inputs) { return Array.isArray(inputs) && inputs.length === REPOSITORIES.length && JSON.stringify([...inputs].map(({ repository }) => repository).sort(codepointCompare)) === JSON.stringify([...REPOSITORIES].sort(codepointCompare)) && inputs.every((input) => JSON.stringify(Object.keys(input ?? {}).sort(codepointCompare)) === JSON.stringify(["gitSha", "locator", "repository"]) && /^[0-9a-f]{40}$/.test(input.gitSha) && parseLocator(input.locator)?.repository === input.repository); }
 function canonicalUtc(value) { return /^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d\.\d{3}Z$/.test(value ?? "") && new Date(value).toISOString() === value; }
 function normalizeTimestamp(value) { const parsed = Date.parse(value ?? ""); return Number.isFinite(parsed) && /(?:Z|[+-]\d\d:\d\d)$/.test(value ?? "") ? new Date(parsed).toISOString() : null; }
 function instant(value) { const parsed = Date.parse(value); return Number.isFinite(parsed) ? parsed : NaN; }
-function digest(bytes) { return createHash("sha256").update(bytes).digest("hex"); }
+export function digest(bytes) { return createHash("sha256").update(bytes).digest("hex"); }
 function crc32(bytes) { let crc = 0xffffffff; for (const byte of bytes) { crc ^= byte; for (let bit = 0; bit < 8; bit += 1) crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1)); } return (crc ^ 0xffffffff) >>> 0; }
 function codepointCompare(left, right) { return left < right ? -1 : left > right ? 1 : 0; }
 function safeToken(value) { return typeof value === "string" && value.length > 0 && value.length <= 4096 && !/[\0-\x1f\x7f]/.test(value); }
@@ -153,5 +151,13 @@ function safePathToken(value) { return typeof value === "string" && value.length
 async function containedInput(root, candidate) { if (!safePathToken(candidate)) throw new Error("unsafe path"); const path = resolve(root, candidate); if (relative(root, path).startsWith("..") || (await realpath(path)) !== path || (await lstat(path)).isSymbolicLink()) throw new Error("unsafe path"); return path; }
 async function containedOutput(root, candidate) { if (!safePathToken(candidate)) throw new Error("unsafe path"); const path = resolve(root, candidate); if (relative(root, path).startsWith("..")) throw new Error("unsafe path"); const parent = await realpath(dirname(path)); if (parent !== dirname(path) || (parent !== root && !parent.startsWith(`${root}/`))) throw new Error("unsafe path"); let cursor = root; for (const part of relative(root, parent).split("/").filter(Boolean)) { cursor = resolve(cursor, part); if ((await lstat(cursor)).isSymbolicLink()) throw new Error("unsafe path"); } return path; }
 async function writeOnce(path, value) { const file = await open(path, "wx"); try { await file.writeFile(`${JSON.stringify(value, null, 2)}\n`); } finally { await file.close(); } }
+async function writeResolvedReceipts(root, outputPath, receipts) {
+  const parent = dirname(outputPath); const stem = `resolved-owner-receipts-${digest(Buffer.from(relative(root, outputPath))).slice(0, 16)}`;
+  for (let index = 0; index < 100; index += 1) {
+    const path = resolve(parent, `${stem}-${index}.json`);
+    try { await writeOnce(path, receipts); return relative(root, path); } catch (error) { if (error?.code !== "EEXIST") throw error; }
+  }
+  throw new Error("RESOLVED_RECEIPT_PATH_EXHAUSTED");
+}
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) process.exitCode = await runFanInCli();

--- a/tools/repo/run-public-sensitivity-audit.mjs
+++ b/tools/repo/run-public-sensitivity-audit.mjs
@@ -1,0 +1,157 @@
+import { createHash } from "node:crypto";
+import { spawn } from "node:child_process";
+import { lstat, open, readFile, realpath } from "node:fs/promises";
+import { dirname, isAbsolute, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { inflateRawSync } from "node:zlib";
+
+import { validateSchema } from "../ci/lib/json-schema-lite.mjs";
+import { REPOSITORIES, runAuditCli, validateReceipt, validateScope } from "./audit-public-sensitivity.mjs";
+
+const OUTPUT_LIMIT = 2 * 1024 * 1024;
+const BINARY_OUTPUT_LIMIT = 16 * 1024 * 1024;
+const POLICY = "public-sensitivity-v1";
+const RECEIPT_SCHEMA = JSON.parse(await readFile(new URL("../../contracts/documentation/public-sensitivity-owner-receipt.schema.json", import.meta.url), "utf8"));
+const SCOPE_SCHEMA = JSON.parse(await readFile(new URL("../../contracts/documentation/public-sensitivity-audit-scope.schema.json", import.meta.url), "utf8"));
+
+export function assembleOwnerReceipts({ observedAt, heads, handoffs }) {
+  if (!canonicalUtc(observedAt) || !heads || !Array.isArray(handoffs) || handoffs.length !== REPOSITORIES.length) throw new Error("RECEIPT_SET_INCOMPLETE");
+  const receipts = []; const repositories = new Set();
+  for (const handoff of handoffs) {
+    const repository = locatorRepository(handoff?.locator);
+    if (repository == null || repositories.has(repository) || !Array.isArray(handoff.files) || handoff.files.length !== 1 || handoff.files[0]?.name !== "receipt.json" || typeof handoff.files[0]?.text !== "string") throw new Error("HANDOFF_INVALID");
+    let receipt; try { receipt = JSON.parse(handoff.files[0].text); } catch { throw new Error("HANDOFF_INVALID"); }
+    const expected = { repository, gitSha: heads[repository], observedAt, detectorPolicyVersion: POLICY };
+    if (!/^[0-9a-f]{40}$/.test(expected.gitSha ?? "") || !validateSchema(RECEIPT_SCHEMA, receipt).ok || validateReceipt(receipt, expected).length) throw new Error("RECEIPT_IDENTITY_MISMATCH");
+    repositories.add(repository); receipts.push(receipt);
+  }
+  if (repositories.size !== REPOSITORIES.length || REPOSITORIES.some((repository) => !repositories.has(repository))) throw new Error("RECEIPT_SET_INCOMPLETE");
+  return receipts.sort((left, right) => codepointCompare(left.repository, right.repository));
+}
+
+export async function downloadOwnerHandoffs({ observedAt, inputs, execGh = publicAuditGet }) {
+  if (!canonicalUtc(observedAt) || !Array.isArray(inputs) || inputs.length !== REPOSITORIES.length) throw new Error("RECEIPT_SET_INCOMPLETE");
+  const handoffs = [];
+  for (const input of inputs) {
+    const parsed = parseLocator(input?.locator);
+    if (parsed == null || parsed.repository !== input?.repository || !/^[0-9a-f]{40}$/.test(input?.gitSha ?? "")) throw new Error("HANDOFF_INVALID");
+    const artifact = normalizeArtifact(await execGh({ method: "GET", endpoint: `repos/${parsed.repository}/actions/artifacts/${parsed.artifactId}` }));
+    if (artifact == null || artifact.id !== parsed.artifactId || artifact.workflowRunId !== parsed.runId || artifact.expired || instant(artifact.createdAt) <= instant(observedAt) || artifact.name !== handoffName(parsed.repository, input.gitSha)) throw new Error("HANDOFF_INVALID");
+    const bytes = await execGh({ method: "GET", endpoint: `repos/${parsed.repository}/actions/artifacts/${parsed.artifactId}/zip`, binary: true });
+    if (!Buffer.isBuffer(bytes) || `sha256:${digest(bytes)}` !== artifact.digest) throw new Error("HANDOFF_INVALID");
+    handoffs.push({ locator: input.locator, files: [readSingleZipJson(bytes, "receipt.json")] });
+  }
+  return handoffs;
+}
+
+export async function verifyOwnerEvidence({ receipts, observedAt, execGh = publicAuditGet }) {
+  for (const receipt of receipts) {
+    const parsed = parseLocator(receipt.evidenceLocator);
+    if (parsed == null || parsed.repository !== receipt.repository) throw new Error("EVIDENCE_INVALID");
+    const artifact = normalizeArtifact(await execGh({ method: "GET", endpoint: `repos/${parsed.repository}/actions/artifacts/${parsed.artifactId}` }));
+    if (artifact == null || artifact.id !== parsed.artifactId || artifact.workflowRunId !== parsed.runId || artifact.expired || instant(artifact.createdAt) <= instant(observedAt) || artifact.name !== evidenceName(receipt.repository, receipt.gitSha)) throw new Error("EVIDENCE_INVALID");
+    const bytes = await execGh({ method: "GET", endpoint: `repos/${parsed.repository}/actions/artifacts/${parsed.artifactId}/zip`, binary: true });
+    if (!Buffer.isBuffer(bytes) || `sha256:${digest(bytes)}` !== artifact.digest) throw new Error("EVIDENCE_INVALID");
+    const evidence = JSON.parse(readSingleZipJson(bytes, "evidence.json").text);
+    const receiptCore = Object.fromEntries(Object.entries(receipt).filter(([key]) => key !== "evidenceLocator"));
+    if (stableJson(evidence) !== stableJson(receiptCore)) throw new Error("EVIDENCE_INVALID");
+  }
+}
+
+export async function runFanInCli(args = process.argv.slice(2), { execGh = publicAuditGet, auditCli = runAuditCli } = {}) {
+  let parsed; let root; let resolvedReceipts;
+  try {
+    parsed = parseArgs(args);
+    if (!canonicalUtc(parsed.observedAt)) throw new Error("INVALID_OBSERVED_AT");
+    root = await realpath(parsed.root);
+    await containedInput(root, parsed.scope);
+    const manifestPath = await containedInput(root, parsed.ownerReceipts);
+    const outputPath = await containedOutput(root, parsed.output);
+    resolvedReceipts = relative(root, resolve(dirname(outputPath), "resolved-owner-receipts.json"));
+    const scope = JSON.parse(await readFile(await containedInput(root, parsed.scope), "utf8"));
+    if (!validateSchema(SCOPE_SCHEMA, scope).ok || validateScope(scope).length) throw new Error("INVALID_SCOPE");
+    const inputs = JSON.parse(await readFile(manifestPath, "utf8"));
+    if (!validInputs(inputs)) throw new Error("RECEIPT_SET_INCOMPLETE");
+    const hub = inputs.find(({ repository }) => repository === "AquilaXk/easysubway");
+    if (hub?.gitSha !== parsed.runnerSha) throw new Error("STALE_RUNNER_HEAD");
+    const handoffs = await downloadOwnerHandoffs({ observedAt: parsed.observedAt, inputs, execGh });
+    const heads = Object.fromEntries(inputs.map(({ repository, gitSha }) => [repository, gitSha]));
+    const receipts = assembleOwnerReceipts({ observedAt: parsed.observedAt, heads, handoffs });
+    await verifyOwnerEvidence({ receipts, observedAt: parsed.observedAt, execGh });
+    await writeOnce(resolve(root, resolvedReceipts), receipts);
+  } catch {
+    if (parsed == null) { process.stderr.write("AUDIT_INCOMPLETE\n"); return 2; }
+    try {
+      root ??= await realpath(parsed.root);
+      const outputPath = await containedOutput(root, parsed.output);
+      resolvedReceipts ??= relative(root, resolve(dirname(outputPath), "resolved-owner-receipts.json"));
+      await writeOnce(resolve(root, resolvedReceipts), []);
+    } catch { process.stderr.write("AUDIT_INCOMPLETE\n"); return 2; }
+  }
+  const auditObservedAt = canonicalUtc(parsed.observedAt) ? parsed.observedAt : "1970-01-01T00:00:00.000Z";
+  return auditCli(["--scope", parsed.scope, "--owner-receipts", resolvedReceipts, "--observed-at", auditObservedAt, "--repository-root", root, "--output", parsed.output]);
+}
+
+function parseArgs(args) {
+  if (args.length !== 12 || args[0] !== "--scope" || args[2] !== "--owner-receipts" || args[4] !== "--observed-at" || args[6] !== "--runner-sha" || args[8] !== "--repository-root" || args[10] !== "--output" || !/^[0-9a-f]{40}$/.test(args[7])) throw new Error("INVALID_INPUT");
+  return { scope: args[1], ownerReceipts: args[3], observedAt: args[5], runnerSha: args[7], root: args[9], output: args[11] };
+}
+
+function parseLocator(value) { const match = /^https:\/\/github\.com\/(AquilaXk\/easysubway(?:-(?:backend|data|mobile|platform))?)\/actions\/runs\/(\d+)\/artifacts\/(\d+)$/.exec(value ?? ""); return match == null ? null : { repository: match[1], runId: Number(match[2]), artifactId: Number(match[3]) }; }
+function locatorRepository(value) { return parseLocator(value)?.repository ?? null; }
+function normalizeArtifact(raw) {
+  const createdAt = normalizeTimestamp(raw?.created_at); const expiresAt = normalizeTimestamp(raw?.expires_at);
+  if (!Number.isSafeInteger(raw?.id) || raw.id < 0 || raw?.expired !== false || createdAt == null || expiresAt == null || instant(expiresAt) <= instant(createdAt) || !Number.isSafeInteger(raw?.workflow_run?.id) || raw.workflow_run.id < 0 || !/^[A-Za-z0-9][A-Za-z0-9._ -]{0,127}$/.test(raw?.name ?? "") || !/^sha256:[0-9a-f]{64}$/.test(raw?.digest ?? "")) return null;
+  return { id: raw.id, name: raw.name, digest: raw.digest, workflowRunId: raw.workflow_run.id, expired: raw.expired, createdAt, expiresAt };
+}
+
+function readSingleZipJson(bytes, expectedName) {
+  try {
+    if (!Buffer.isBuffer(bytes) || bytes.length < 22 || bytes.length > BINARY_OUTPUT_LIMIT) throw new Error();
+    let eocd = -1;
+    for (let offset = bytes.length - 22; offset >= Math.max(0, bytes.length - 65_557); offset -= 1) if (bytes.readUInt32LE(offset) === 0x06054b50) { eocd = offset; break; }
+    if (eocd < 0 || eocd + 22 + bytes.readUInt16LE(eocd + 20) !== bytes.length || bytes.readUInt16LE(eocd + 4) !== 0 || bytes.readUInt16LE(eocd + 6) !== 0 || bytes.readUInt16LE(eocd + 8) !== 1 || bytes.readUInt16LE(eocd + 10) !== 1) throw new Error();
+    const centralSize = bytes.readUInt32LE(eocd + 12); const centralOffset = bytes.readUInt32LE(eocd + 16);
+    if (centralOffset + centralSize !== eocd || centralSize < 46 || bytes.readUInt32LE(centralOffset) !== 0x02014b50) throw new Error();
+    const flags = bytes.readUInt16LE(centralOffset + 8); const method = bytes.readUInt16LE(centralOffset + 10); const crc = bytes.readUInt32LE(centralOffset + 16); const compressed = bytes.readUInt32LE(centralOffset + 20); const size = bytes.readUInt32LE(centralOffset + 24); const nameLength = bytes.readUInt16LE(centralOffset + 28); const extraLength = bytes.readUInt16LE(centralOffset + 30); const commentLength = bytes.readUInt16LE(centralOffset + 32); const external = bytes.readUInt32LE(centralOffset + 38); const localOffset = bytes.readUInt32LE(centralOffset + 42);
+    const centralEnd = centralOffset + 46 + nameLength + extraLength + commentLength;
+    if ((flags & ~0x0800) !== 0 || ![0, 8].includes(method) || compressed > BINARY_OUTPUT_LIMIT || size > OUTPUT_LIMIT || centralEnd !== eocd || Math.floor(external / 65_536) >> 12 === 0xa || localOffset + 30 > centralOffset || bytes.readUInt32LE(localOffset) !== 0x04034b50) throw new Error();
+    const centralName = bytes.subarray(centralOffset + 46, centralOffset + 46 + nameLength); const name = new TextDecoder("utf-8", { fatal: true }).decode(centralName);
+    const localNameLength = bytes.readUInt16LE(localOffset + 26); const localExtraLength = bytes.readUInt16LE(localOffset + 28); const localName = bytes.subarray(localOffset + 30, localOffset + 30 + localNameLength);
+    if (name !== expectedName || !localName.equals(centralName) || bytes.readUInt16LE(localOffset + 6) !== flags || bytes.readUInt16LE(localOffset + 8) !== method || bytes.readUInt32LE(localOffset + 14) !== crc || bytes.readUInt32LE(localOffset + 18) !== compressed || bytes.readUInt32LE(localOffset + 22) !== size) throw new Error();
+    const dataOffset = localOffset + 30 + localNameLength + localExtraLength; const data = bytes.subarray(dataOffset, dataOffset + compressed);
+    if (data.length !== compressed || dataOffset + compressed !== centralOffset) throw new Error();
+    const decoded = method === 0 ? data : inflateRawSync(data, { maxOutputLength: OUTPUT_LIMIT });
+    if (decoded.length !== size || crc32(decoded) !== crc) throw new Error();
+    return { name, text: new TextDecoder("utf-8", { fatal: true }).decode(decoded) };
+  } catch { throw new Error("HANDOFF_INVALID"); }
+}
+
+function repositoryCode(repository) { return repository === "AquilaXk/easysubway" ? "hub" : repository.slice("AquilaXk/easysubway-".length); }
+function handoffName(repository, gitSha) { return `d20-public-sensitivity-owner-receipt-${repositoryCode(repository)}-${gitSha}`; }
+function evidenceName(repository, gitSha) { return `d20-public-sensitivity-evidence-${repositoryCode(repository)}-${gitSha}`; }
+function stableJson(value) { if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`; if (value != null && typeof value === "object") return `{${Object.keys(value).sort(codepointCompare).map((key) => `${JSON.stringify(key)}:${stableJson(value[key])}`).join(",")}}`; return JSON.stringify(value); }
+function validInputs(inputs) { return Array.isArray(inputs) && inputs.length === REPOSITORIES.length && JSON.stringify([...inputs].map(({ repository }) => repository).sort(codepointCompare)) === JSON.stringify([...REPOSITORIES].sort(codepointCompare)) && inputs.every((input) => JSON.stringify(Object.keys(input ?? {}).sort(codepointCompare)) === JSON.stringify(["gitSha", "locator", "repository"]) && /^[0-9a-f]{40}$/.test(input.gitSha) && parseLocator(input.locator)?.repository === input.repository); }
+function canonicalUtc(value) { return /^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d\.\d{3}Z$/.test(value ?? "") && new Date(value).toISOString() === value; }
+function normalizeTimestamp(value) { const parsed = Date.parse(value ?? ""); return Number.isFinite(parsed) && /(?:Z|[+-]\d\d:\d\d)$/.test(value ?? "") ? new Date(parsed).toISOString() : null; }
+function instant(value) { const parsed = Date.parse(value); return Number.isFinite(parsed) ? parsed : NaN; }
+function digest(bytes) { return createHash("sha256").update(bytes).digest("hex"); }
+function crc32(bytes) { let crc = 0xffffffff; for (const byte of bytes) { crc ^= byte; for (let bit = 0; bit < 8; bit += 1) crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1)); } return (crc ^ 0xffffffff) >>> 0; }
+function codepointCompare(left, right) { return left < right ? -1 : left > right ? 1 : 0; }
+function safeToken(value) { return typeof value === "string" && value.length > 0 && value.length <= 4096 && !/[\0-\x1f\x7f]/.test(value); }
+function publicAuditGet(request) { return boundedGet({ token: process.env.D20_FIVE_REPO_PUBLIC_AUDIT_READ_TOKEN, ...request }); }
+function boundedGet({ token, method, endpoint, binary = false }) {
+  if (method !== "GET" || !safeToken(token) || !/^repos\/AquilaXk\/easysubway(?:-(?:backend|data|mobile|platform))?(?:\/|$)/.test(endpoint)) return Promise.reject(new Error("provider unavailable"));
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn("gh", ["api", "--method", "GET", endpoint], { env: { ...process.env, GH_TOKEN: token }, stdio: ["ignore", "pipe", "ignore"] }); const chunks = []; let size = 0; const limit = binary ? BINARY_OUTPUT_LIMIT : OUTPUT_LIMIT; const timer = setTimeout(() => child.kill("SIGTERM"), 30_000);
+    child.stdout.on("data", (chunk) => { chunks.push(chunk); size += chunk.length; if (size > limit) child.kill("SIGTERM"); });
+    child.on("error", reject); child.on("close", (code) => { clearTimeout(timer); if (code !== 0 || size > limit) reject(new Error("provider unavailable")); else try { const output = Buffer.concat(chunks); resolvePromise(binary ? output : JSON.parse(output.toString("utf8"))); } catch { reject(new Error("provider unavailable")); } });
+  });
+}
+
+function safePathToken(value) { return typeof value === "string" && value.length > 0 && !isAbsolute(value) && !value.split(/[\\/]/).includes(".."); }
+async function containedInput(root, candidate) { if (!safePathToken(candidate)) throw new Error("unsafe path"); const path = resolve(root, candidate); if (relative(root, path).startsWith("..") || (await realpath(path)) !== path || (await lstat(path)).isSymbolicLink()) throw new Error("unsafe path"); return path; }
+async function containedOutput(root, candidate) { if (!safePathToken(candidate)) throw new Error("unsafe path"); const path = resolve(root, candidate); if (relative(root, path).startsWith("..")) throw new Error("unsafe path"); const parent = await realpath(dirname(path)); if (parent !== dirname(path) || (parent !== root && !parent.startsWith(`${root}/`))) throw new Error("unsafe path"); let cursor = root; for (const part of relative(root, parent).split("/").filter(Boolean)) { cursor = resolve(cursor, part); if ((await lstat(cursor)).isSymbolicLink()) throw new Error("unsafe path"); } return path; }
+async function writeOnce(path, value) { const file = await open(path, "wx"); try { await file.writeFile(`${JSON.stringify(value, null, 2)}\n`); } finally { await file.close(); } }
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) process.exitCode = await runFanInCli();

--- a/tools/repo/run-public-sensitivity-audit.test.mjs
+++ b/tools/repo/run-public-sensitivity-audit.test.mjs
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { assembleOwnerReceipts, downloadOwnerHandoffs, runFanInCli, verifyOwnerEvidence } from "./run-public-sensitivity-audit.mjs";
+
+const REPOSITORIES = ["AquilaXk/easysubway", "AquilaXk/easysubway-backend", "AquilaXk/easysubway-data", "AquilaXk/easysubway-mobile", "AquilaXk/easysubway-platform"];
+const SHA = "a".repeat(40);
+const OBSERVED_AT = "2026-08-09T00:00:00.000Z";
+
+function receipt(repository, overrides = {}) {
+  return { schemaVersion: 1, repository, gitSha: SHA, observedAt: OBSERVED_AT, secretScanningEnabled: true, pushProtectionEnabled: true, reachableRefAuditComplete: true, alertEnumerationComplete: true, locationEnumerationComplete: true, openAlertCount: 0, unresolvedAlertCount: 0, detectorPolicyVersion: "public-sensitivity-v1", evidenceLocator: `https://github.com/${repository}/actions/runs/7/artifacts/9`, publicArtifactEnumerationComplete: true, publicArtifacts: [], ...overrides };
+}
+
+test("fan-in accepts exactly five immutable one-object handoffs with matching time, head, and policy", () => {
+  const result = assembleOwnerReceipts({ observedAt: OBSERVED_AT, heads: Object.fromEntries(REPOSITORIES.map((repository) => [repository, SHA])), handoffs: REPOSITORIES.map((repository) => ({ locator: `https://github.com/${repository}/actions/runs/8/artifacts/10`, files: [{ name: "receipt.json", text: JSON.stringify(receipt(repository)) }] })) });
+  assert.equal(result.length, 5);
+});
+
+test("fan-in rejects missing, mixed-time, and malformed handoff transport", () => {
+  const valid = REPOSITORIES.map((repository) => ({ locator: `https://github.com/${repository}/actions/runs/8/artifacts/10`, files: [{ name: "receipt.json", text: JSON.stringify(receipt(repository)) }] }));
+  assert.throws(() => assembleOwnerReceipts({ observedAt: OBSERVED_AT, heads: Object.fromEntries(REPOSITORIES.map((repository) => [repository, SHA])), handoffs: valid.slice(0, 4) }), /RECEIPT_SET_INCOMPLETE/);
+  valid[0].files[0].text = JSON.stringify(receipt(REPOSITORIES[0], { observedAt: "2026-08-09T00:00:01.000Z" }));
+  assert.throws(() => assembleOwnerReceipts({ observedAt: OBSERVED_AT, heads: Object.fromEntries(REPOSITORIES.map((repository) => [repository, SHA])), handoffs: valid }), /RECEIPT_IDENTITY_MISMATCH/);
+  valid[0].files = [{ name: "one.json", text: "{}" }, { name: "two.json", text: "{}" }];
+  assert.throws(() => assembleOwnerReceipts({ observedAt: OBSERVED_AT, heads: Object.fromEntries(REPOSITORIES.map((repository) => [repository, SHA])), handoffs: valid }), /HANDOFF_INVALID/);
+});
+
+test("fan-in rejects a schema-invalid receipt even when semantic fields look valid", () => {
+  const handoffs = REPOSITORIES.map((repository) => ({ locator: `https://github.com/${repository}/actions/runs/8/artifacts/10`, files: [{ name: "receipt.json", text: JSON.stringify(receipt(repository, { rawProviderBody: "must-not-pass" })) }] }));
+  assert.throws(() => assembleOwnerReceipts({ observedAt: OBSERVED_AT, heads: Object.fromEntries(REPOSITORIES.map((repository) => [repository, SHA])), handoffs }), /RECEIPT_IDENTITY_MISMATCH/);
+});
+
+test("fan-in rejects a handoff archive digest mismatch", async () => {
+  const archives = new Map(REPOSITORIES.map((repository) => [repository, zip("receipt.json", JSON.stringify(receipt(repository)))]));
+  const inputs = REPOSITORIES.map((repository) => ({ repository, gitSha: SHA, locator: `https://github.com/${repository}/actions/runs/8/artifacts/10` }));
+  const execGh = async ({ endpoint, binary }) => {
+    const repository = REPOSITORIES.find((candidate) => endpoint.startsWith(`repos/${candidate}/`));
+    if (endpoint.endsWith("/actions/artifacts/10")) return { id: 10, name: `d20-public-sensitivity-owner-receipt-${code(repository)}-${SHA}`, digest: `sha256:${"0".repeat(64)}`, expired: false, created_at: "2026-08-09T00:00:00.001Z", expires_at: "2026-09-09T00:00:00.000Z", workflow_run: { id: 8 } };
+    if (endpoint.endsWith("/actions/artifacts/10/zip")) { assert.equal(binary, true); return archives.get(repository); }
+    throw new Error(`unexpected ${endpoint}`);
+  };
+  await assert.rejects(() => downloadOwnerHandoffs({ observedAt: OBSERVED_AT, inputs, execGh }), /HANDOFF_INVALID/);
+});
+
+test("valid CLI arguments write a sanitized incomplete report on malformed handoff input", async () => {
+  const root = await mkdtemp(join(tmpdir(), "d20-fanin-")); await mkdir(join(root, "out"));
+  await writeFile(join(root, "scope.json"), "{}"); await writeFile(join(root, "handoffs.json"), "{raw-provider-secret");
+  const exitCode = await runFanInCli(["--scope", "scope.json", "--owner-receipts", "handoffs.json", "--observed-at", OBSERVED_AT, "--runner-sha", SHA, "--repository-root", root, "--output", "out/report.json"]);
+  assert.equal(exitCode, 2);
+  const text = await readFile(join(root, "out/report.json"), "utf8");
+  assert.equal(text.includes("raw-provider-secret"), false);
+  assert.equal(JSON.parse(text).status, "AUDIT_INCOMPLETE");
+});
+
+test("malformed observed_at still writes one schema-valid incomplete report", async () => {
+  const root = await mkdtemp(join(tmpdir(), "d20-invalid-time-")); await mkdir(join(root, "out"));
+  await writeFile(join(root, "scope.json"), await readFile("contracts/documentation/public-sensitivity-audit-scope.json", "utf8")); await writeFile(join(root, "handoffs.json"), "[]");
+  const exitCode = await runFanInCli(["--scope", "scope.json", "--owner-receipts", "handoffs.json", "--observed-at", "not-a-time", "--runner-sha", SHA, "--repository-root", root, "--output", "out/report.json"]);
+  assert.equal(exitCode, 2);
+  const report = JSON.parse(await readFile(join(root, "out/report.json"), "utf8"));
+  assert.equal(report.status, "AUDIT_INCOMPLETE"); assert.equal(report.observedAt, "1970-01-01T00:00:00.000Z");
+});
+
+test("fan-in binds every receipt to the exact post-cutoff evidence archive", async () => {
+  const receipts = REPOSITORIES.map((repository) => receipt(repository));
+  const archives = new Map(receipts.map((item) => [item.repository, zip("evidence.json", JSON.stringify(Object.fromEntries(Object.entries(item).filter(([key]) => key !== "evidenceLocator"))))]));
+  const execGh = async ({ endpoint, binary }) => {
+    const repository = REPOSITORIES.find((candidate) => endpoint.startsWith(`repos/${candidate}/`)); const bytes = archives.get(repository);
+    if (endpoint.endsWith("/actions/artifacts/9")) return { id: 9, name: `d20-public-sensitivity-evidence-${code(repository)}-${SHA}`, digest: `sha256:${createDigest(bytes)}`, expired: false, created_at: "2026-08-09T00:00:00.001Z", expires_at: "2026-09-09T00:00:00.000Z", workflow_run: { id: 7 } };
+    if (endpoint.endsWith("/actions/artifacts/9/zip")) { assert.equal(binary, true); return bytes; }
+    throw new Error(`unexpected ${endpoint}`);
+  };
+  await verifyOwnerEvidence({ receipts, observedAt: OBSERVED_AT, execGh });
+  archives.set(REPOSITORIES[0], zip("evidence.json", JSON.stringify({ changed: true })));
+  await assert.rejects(() => verifyOwnerEvidence({ receipts, observedAt: OBSERVED_AT, execGh }), /EVIDENCE_INVALID|HANDOFF_INVALID/);
+});
+
+test("fan-in rejects a stale coordinator head before provider reads and still writes incomplete evidence", async () => {
+  const root = await mkdtemp(join(tmpdir(), "d20-stale-runner-")); await mkdir(join(root, "out"));
+  const scope = await readFile("contracts/documentation/public-sensitivity-audit-scope.json", "utf8");
+  await writeFile(join(root, "scope.json"), scope);
+  await writeFile(join(root, "handoffs.json"), JSON.stringify(REPOSITORIES.map((repository) => ({ repository, gitSha: SHA, locator: `https://github.com/${repository}/actions/runs/8/artifacts/10` }))));
+  let calls = 0;
+  const exitCode = await runFanInCli(["--scope", "scope.json", "--owner-receipts", "handoffs.json", "--observed-at", OBSERVED_AT, "--runner-sha", "b".repeat(40), "--repository-root", root, "--output", "out/report.json"], { execGh: async () => { calls += 1; throw new Error("must not call"); } });
+  assert.equal(exitCode, 2); assert.equal(calls, 0);
+  assert.equal(JSON.parse(await readFile(join(root, "out/report.json"), "utf8")).status, "AUDIT_INCOMPLETE");
+});
+
+test("fan-in success passes only the five A-bound receipts to the existing auditor", async () => {
+  const root = await mkdtemp(join(tmpdir(), "d20-success-")); await mkdir(join(root, "out"));
+  await writeFile(join(root, "scope.json"), await readFile("contracts/documentation/public-sensitivity-audit-scope.json", "utf8"));
+  const inputs = REPOSITORIES.map((repository) => ({ repository, gitSha: SHA, locator: `https://github.com/${repository}/actions/runs/8/artifacts/10` }));
+  await writeFile(join(root, "handoffs.json"), JSON.stringify(inputs));
+  const bArchives = new Map(); const aArchives = new Map();
+  for (const repository of REPOSITORIES) {
+    const value = receipt(repository); bArchives.set(repository, zip("receipt.json", JSON.stringify(value)));
+    aArchives.set(repository, zip("evidence.json", JSON.stringify(Object.fromEntries(Object.entries(value).filter(([key]) => key !== "evidenceLocator")))));
+  }
+  const execGh = async ({ endpoint }) => {
+    const repository = REPOSITORIES.find((candidate) => endpoint.startsWith(`repos/${candidate}/`)); const isHandoff = endpoint.includes("/artifacts/10"); const bytes = isHandoff ? bArchives.get(repository) : aArchives.get(repository); const artifactId = isHandoff ? 10 : 9; const runId = isHandoff ? 8 : 7;
+    if (endpoint.endsWith(`/artifacts/${artifactId}`)) return { id: artifactId, name: `${isHandoff ? "d20-public-sensitivity-owner-receipt" : "d20-public-sensitivity-evidence"}-${code(repository)}-${SHA}`, digest: `sha256:${createDigest(bytes)}`, expired: false, created_at: "2026-08-09T00:00:00.001Z", expires_at: "2026-09-09T00:00:00.000Z", workflow_run: { id: runId } };
+    if (endpoint.endsWith(`/artifacts/${artifactId}/zip`)) return bytes;
+    throw new Error(`unexpected ${endpoint}`);
+  };
+  let resolved;
+  const exitCode = await runFanInCli(["--scope", "scope.json", "--owner-receipts", "handoffs.json", "--observed-at", OBSERVED_AT, "--runner-sha", SHA, "--repository-root", root, "--output", "out/report.json"], { execGh, auditCli: async (args) => { resolved = JSON.parse(await readFile(join(root, args[3]), "utf8")); return 0; } });
+  assert.equal(exitCode, 0); assert.deepEqual(resolved.map(({ repository }) => repository), REPOSITORIES);
+});
+
+function zip(name, text) {
+  const filename = Buffer.from(name); const data = Buffer.from(text); const crc = crc32(data);
+  const local = Buffer.alloc(30 + filename.length + data.length); local.writeUInt32LE(0x04034b50, 0); local.writeUInt32LE(crc, 14); local.writeUInt32LE(data.length, 18); local.writeUInt32LE(data.length, 22); local.writeUInt16LE(filename.length, 26); filename.copy(local, 30); data.copy(local, 30 + filename.length);
+  const central = Buffer.alloc(46 + filename.length); central.writeUInt32LE(0x02014b50, 0); central.writeUInt32LE(crc, 16); central.writeUInt32LE(data.length, 20); central.writeUInt32LE(data.length, 24); central.writeUInt16LE(filename.length, 28); central.writeUInt32LE(0, 42); filename.copy(central, 46);
+  const end = Buffer.alloc(22); end.writeUInt32LE(0x06054b50, 0); end.writeUInt16LE(1, 8); end.writeUInt16LE(1, 10); end.writeUInt32LE(central.length, 12); end.writeUInt32LE(local.length, 16);
+  return Buffer.concat([local, central, end]);
+}
+function crc32(bytes) { let crc = 0xffffffff; for (const byte of bytes) { crc ^= byte; for (let bit = 0; bit < 8; bit += 1) crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1)); } return (crc ^ 0xffffffff) >>> 0; }
+function code(repository) { return repository === "AquilaXk/easysubway" ? "hub" : repository.slice("AquilaXk/easysubway-".length); }
+function createDigest(bytes) { return createHash("sha256").update(bytes).digest("hex"); }

--- a/tools/repo/run-public-sensitivity-audit.test.mjs
+++ b/tools/repo/run-public-sensitivity-audit.test.mjs
@@ -49,11 +49,15 @@ test("fan-in rejects a handoff archive digest mismatch", async () => {
 test("valid CLI arguments write a sanitized incomplete report on malformed handoff input", async () => {
   const root = await mkdtemp(join(tmpdir(), "d20-fanin-")); await mkdir(join(root, "out"));
   await writeFile(join(root, "scope.json"), "{}"); await writeFile(join(root, "handoffs.json"), "{raw-provider-secret");
+  const resolvedName = `resolved-owner-receipts-${createHash("sha256").update("out/report.json").digest("hex").slice(0, 16)}-0.json`;
+  await writeFile(join(root, "out", resolvedName), "already-owned-by-another-attempt\n");
   const exitCode = await runFanInCli(["--scope", "scope.json", "--owner-receipts", "handoffs.json", "--observed-at", OBSERVED_AT, "--runner-sha", SHA, "--repository-root", root, "--output", "out/report.json"]);
   assert.equal(exitCode, 2);
   const text = await readFile(join(root, "out/report.json"), "utf8");
   assert.equal(text.includes("raw-provider-secret"), false);
   assert.equal(JSON.parse(text).status, "AUDIT_INCOMPLETE");
+  assert.equal(await readFile(join(root, "out", resolvedName), "utf8"), "already-owned-by-another-attempt\n");
+  assert.equal(JSON.parse(await readFile(join(root, "out", `${resolvedName.slice(0, -6)}1.json`), "utf8")).length, 0);
 });
 
 test("malformed observed_at still writes one schema-valid incomplete report", async () => {


### PR DESCRIPTION
## 관련 이슈

Closes #2792
Refs #2748
Refs #2790

## 작업 배경

- D20 common audit contract는 owner receipt 배열만 직접 소비할 수 있어 target 저장소가 중복 producer를 만들지 않고 exact Actions artifact handoff를 제공할 공통 엔진이 없었습니다.
- A evidence 업로드 전에는 artifact ID/digest를 알 수 없으므로, self-reference 없이 A를 receipt에 결속하고 B handoff를 five-repository fan-in이 검증하는 순차 계약이 필요합니다.

## 작업 내용

- caller repository context에서 실행되는 reusable owner-receipt workflow와 bounded GET-only producer를 추가했습니다. Called workflow source는 GitHub official `job.workflow_repository`/`job.workflow_sha` identity로 immutable checkout하고 caller `GITHUB_SHA`를 receipt target으로 별도 보존합니다.
- eligible artifact scan → evidence A upload → exact upload/API digest·downloaded ZIP bytes·single `evidence.json` semantic 대조 → 동일 evidence snapshot 기반 receipt → receipt-only B upload 순서를 고정했습니다.
- fan-in은 exact five B locators와 heads/time/policy를 검증하고 B/A ZIP digest·CRC·single-entry content를 receipt와 결속한 뒤 existing D20 auditor에 위임합니다.
- malformed time, missing credential/provider, schema/identity/archive mismatch와 intermediate receipt path collision도 기존 bytes를 보존하면서 write-once sanitized `AUDIT_INCOMPLETE` report를 남깁니다.

## Documentation impact

- 영향 resource ID 또는 `NONE`: `NONE` — documentation catalog/resource record는 변경하지 않고 D20 evidence transport/runner만 추가
- resourceClass: `Evidence`
- documentationFamily: `security-privacy`
- lifecycle/evidence 영향: five owner receipt 생성과 current public surface fan-in의 실행 경로를 추가하며 D20 상태는 live `COMPLETE/findings=0/incomplete=0` 전까지 변경하지 않음

## 검증

- 실행한 명령과 결과:
  - `node --test tools/repo/produce-public-sensitivity-owner-receipt.test.mjs` — PASS, 6/6
  - `node --test tools/repo/run-public-sensitivity-audit.test.mjs` — PASS, 9/9
  - `node --test tools/ci/public-sensitivity-workflows.test.mjs` — PASS, 2/2
  - `node tools/ci/check-contracts.mjs --workspace contracts/workspaces/hub.json --current-only` — PASS
  - pinned `actionlint 1.7.12 -color` — PASS, 새 workflow error 0
  - `git diff --check` — PASS

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| owner receipt/fan-in contract | GitHub Actions + Node.js | focused test 및 current-only contract gate | current head `ab8b4114338d0b2366a7d9e7b2d7c1815b9993dc`, CI run `31305165612` | PASS |
| frozen Review closure | GitHub PR | CodeRabbit Review `4890876564` finding 4건의 reply/resolve | threads 4/4 `isResolved=true`, pagination remainder 0 | PASS |
| UI/접근성/수동 QA | 해당 없음 | runtime/UI 변경 0 | 증거 불필요 | N/A |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: A upload digest/API metadata/actual ZIP 결속, receipt가 A snapshot을 재사용하는지, B/A strict ZIP 검증, failure report 보존, called workflow immutable identity와 caller head 분리

## 리스크

- R2: security/privacy evidence와 cross-repository Actions artifact contract입니다. 실제 target caller/credential/live run은 이 PR 범위가 아니며 #2792 merge SHA 확정 뒤 별도 owner issue에서 수행합니다.
- 기존 D20 scope/schema/evaluator는 수정하지 않았습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다. — current-head run `31305165612` required checks 전부 성공
- [x] CodeRabbit 리뷰를 확인했다. — Review `4890876564`, actionable 4건 모두 closure
- [x] GitHub PR Review 객체가 있는지 확인했다. — CodeRabbit Review commit `b0de499f8e0ce442699acb46fea7abac62012157`은 current PR commit set에 포함
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다. — 해당 없음; CodeRabbit Review 객체 존재
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. — 배포 영향 없음
