### PR TITLE
[CI] D20 Hub owner receipt caller 추가

### DIFF
--- a/.github/workflows/public-sensitivity-owner-receipt-caller.yml
+++ b/.github/workflows/public-sensitivity-owner-receipt-caller.yml
@@ -1,0 +1,14 @@
+name: Public Sensitivity Owner Receipt Caller
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  receipt:
+    uses: AquilaXk/easysubway/.github/workflows/public-sensitivity-owner-receipt.yml@3d1590baa98c929ceabd0d2d44414cebcc643c6f
+    secrets:
+      D20_SECRET_SCANNING_ALERTS_READ_TOKEN: ${{ secrets.D20_SECRET_SCANNING_ALERTS_READ_TOKEN }}

--- a/tools/ci/public-sensitivity-owner-receipt-caller.test.mjs
+++ b/tools/ci/public-sensitivity-owner-receipt-caller.test.mjs
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("hub caller pins the common owner receipt engine and maps only its alert secret", async () => {
+  const text = await readFile(new URL("../../.github/workflows/public-sensitivity-owner-receipt-caller.yml", import.meta.url), "utf8");
+  assert.match(text, /workflow_dispatch:/);
+  assert.match(text, /permissions:\s*\n\s*contents: read\s*\n\s*actions: read/);
+  assert.match(text, /uses: AquilaXk\/easysubway\/\.github\/workflows\/public-sensitivity-owner-receipt\.yml@3d1590baa98c929ceabd0d2d44414cebcc643c6f/);
+  assert.match(text, /D20_SECRET_SCANNING_ALERTS_READ_TOKEN: \$\{\{ secrets\.D20_SECRET_SCANNING_ALERTS_READ_TOKEN \}\}/);
+  assert.doesNotMatch(text, /secrets:\s*inherit|@main|@master|issues: write|pull-requests: write|contents: write/);
+});

--- a/tools/ci/public-sensitivity-owner-receipt-caller.test.mjs
+++ b/tools/ci/public-sensitivity-owner-receipt-caller.test.mjs
@@ -9,4 +9,48 @@ test("hub caller pins the common owner receipt engine and maps only its alert se
   assert.match(text, /uses: AquilaXk\/easysubway\/\.github\/workflows\/public-sensitivity-owner-receipt\.yml@3d1590baa98c929ceabd0d2d44414cebcc643c6f/);
   assert.match(text, /D20_SECRET_SCANNING_ALERTS_READ_TOKEN: \$\{\{ secrets\.D20_SECRET_SCANNING_ALERTS_READ_TOKEN \}\}/);
   assert.doesNotMatch(text, /secrets:\s*inherit|@main|@master|issues: write|pull-requests: write|contents: write/);
+  assert.equal(validateCallerWorkflow(text), true);
 });
+
+test("caller contract rejects permission, invocation, and secret expansions", () => {
+  const canonical = `name: Public Sensitivity Owner Receipt Caller
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  receipt:
+    uses: AquilaXk/easysubway/.github/workflows/public-sensitivity-owner-receipt.yml@3d1590baa98c929ceabd0d2d44414cebcc643c6f
+    secrets:
+      D20_SECRET_SCANNING_ALERTS_READ_TOKEN: \${{ secrets.D20_SECRET_SCANNING_ALERTS_READ_TOKEN }}`;
+  for (const mutation of [
+    canonical.replace("  actions: read", "  actions: read\n  id-token: write"),
+    canonical.replace("workflow_dispatch:", "push:"),
+    canonical.replace("@3d1590baa98c929ceabd0d2d44414cebcc643c6f", "@main"),
+    canonical.replace("    secrets:", "    with:\n      unsafe: true\n    secrets:"),
+    canonical.replace("D20_SECRET_SCANNING_ALERTS_READ_TOKEN }}", "D20_SECRET_SCANNING_ALERTS_READ_TOKEN }}\n      EXTRA: \${{ secrets.EXTRA }}"),
+    `${canonical}\n  extra:\n    runs-on: ubuntu-latest`,
+  ]) assert.equal(validateCallerWorkflow(mutation), false);
+});
+
+function validateCallerWorkflow(value) {
+  const expected = `name: Public Sensitivity Owner Receipt Caller
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  receipt:
+    uses: AquilaXk/easysubway/.github/workflows/public-sensitivity-owner-receipt.yml@3d1590baa98c929ceabd0d2d44414cebcc643c6f
+    secrets:
+      D20_SECRET_SCANNING_ALERTS_READ_TOKEN: \${{ secrets.D20_SECRET_SCANNING_ALERTS_READ_TOKEN }}`;
+  return value.trimEnd() === expected;
+}


### PR DESCRIPTION
## 관련 이슈

Closes #2795
Refs #2792
Refs #2748

## 작업 배경

- D20 common owner-receipt engine은 squash merge `3d1590baa98c929ceabd0d2d44414cebcc643c6f`에서 terminal이지만 Hub current default-branch head를 그 engine에 전달하는 target-owned caller가 없었습니다.
- Mutable common ref, copied engine, inherited secret 또는 previous receipt를 사용하지 않는 exact caller boundary가 필요합니다.

## 작업 내용

- `workflow_dispatch` 전용 Hub caller workflow를 추가했습니다.
- Common reusable workflow를 exact merge SHA로 고정하고 `D20_SECRET_SCANNING_ALERTS_READ_TOKEN`만 explicit mapping했습니다.
- Caller의 least read permissions, exact SHA, no `secrets: inherit`, no mutable ref/write permission을 focused contract test로 고정했습니다.

## Documentation impact

- 영향 resource ID 또는 `NONE`: `D20`
- resourceClass: `Evidence`
- documentationFamily: `security-governance`
- lifecycle/evidence 영향: owner receipt caller transport만 추가하며 live receipt와 D20 상태는 변경하지 않습니다.

## 검증

- `node --test tools/ci/public-sensitivity-owner-receipt-caller.test.mjs` — initial RED(파일 부재)→GREEN, CodeRabbit F1 mutation RED→exact-structure GREEN `2/2 PASS`
- `actionlint -color .github/workflows/public-sensitivity-owner-receipt-caller.yml` — PASS
- `git diff --check` — PASS
- current-head required CI run `31308072343` — 전부 SUCCESS

## 검증 증거

UI·접근성·수동 QA·배포 변경이 없는 workflow caller/contract-test 변경이므로 화면 증거는 불필요합니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| caller contract | GitHub Actions | focused Node test | local RED→GREEN | PASS |
| workflow syntax | GitHub Actions | actionlint 1.7.12 | local command | PASS |
| regression | GitHub Actions | required CI run `31308072343` | current head `9d42e5973e5242daf25a074178a6eab9902499f5` | PASS |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: exact common merge SHA pin, explicit single-secret mapping, least permissions, producer logic 미복제 여부입니다.

## 리스크

- Owner-provided alert-read credential capability가 없으면 live caller run은 fail closed합니다. 이 PR은 secret·permission 설정을 만들거나 변경하지 않습니다.
- Caller delivery만으로 D20을 `PROVEN`으로 승격하지 않으며 five-owner same-window receipt와 fan-in report가 별도로 필요합니다.
- CodeRabbit Review의 exact-structure finding은 commit `9d42e5973e5242daf25a074178a6eab9902499f5`에서 test-only로 닫았고 original thread `1/1 isResolved=true`입니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다. (`4891104602`)
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)
