### PR TITLE
[Fix] D33 closing relation 정본 교정

### DIFF
--- a/tools/repo/audit-plan-doc-execution.mjs
+++ b/tools/repo/audit-plan-doc-execution.mjs
@@ -13,6 +13,7 @@ const MAX_ITEMS = 3000;
 const GH_TIMEOUT_MS = 30_000;
 const GH_MAX_BUFFER = 64 * 1024 * 1024;
 const execFileAsync = promisify(execFile);
+const CLOSING_ISSUES_QUERY = `query($owner: String!, $name: String!, $number: Int!) { repository(owner: $owner, name: $name) { pullRequest(number: $number) { number merged mergeCommit { oid } closingIssuesReferences(first: 100) { totalCount pageInfo { hasNextPage } nodes { number state repository { nameWithOwner } } } } } }`;
 const EXPECTED_RECORDS = new Map([
   [2749, [2748, "5ad660a7f07563999c1c076790614e7e717e0ea7", "COORDINATOR_FOLLOWUP"]], [2755, [2754, "0568c2195ccac35f0d46f6bb3594093471310977", "CLOSES"]], [2757, [2756, "2b102c1b50f495d628617e61ae95f81944b69c20", "CLOSES"]], [2759, [2758, "00c6109bf91e052fc0d9944a84fde1601c1c50c1", "CLOSES"]], [2761, [2760, "decc1072aa8c8facbfa0143fa1f8fe7646bc016d", "CLOSES"]], [2763, [2762, "560e07239e9ef99b3bfea2ab4bf758b5115acb43", "CLOSES"]], [2730, [2729, "4ccf78d8bf60db2d25233d6fe744daf805c7b0ac", "COORDINATOR_FOLLOWUP"]], [2775, [2733, "96119c4d723d9c60fcd8999da8e58af0731b0847", "CLOSES"]], [2782, [2781, "6194860b5cb13334b91410374fd2504ee056684c", "CLOSES"]], [2784, [2783, "3ea7ef2929ce680268783a1a14476138beb2b521", "CLOSES"]], [2787, [2785, "79bcd0b8e05eb90907c411bdde9b30e24592ce53", "CLOSES"]], [2788, [2729, "a44259fcbdd5538586f4aabaa9a6cb844a41dc03", "COORDINATOR_FOLLOWUP"]], [2789, [2748, "90a169d9b35e4845bfd03d518522544b66dd189f", "COORDINATOR_FOLLOWUP"]], [2791, [2790, "40d1bb13906a6a96a3c7342b0923ad180d290234", "CLOSES"]], [2793, [2792, "3d1590baa98c929ceabd0d2d44414cebcc643c6f", "CLOSES"]], [2796, [2795, "b853fe6101c7848a8d556bf21b882b3f0e3060a9", "CLOSES"]],
 ]);
@@ -63,31 +64,46 @@ export function auditPlanDocExecution({ scope, sourceSha, live }) {
 
 function relationMatches(record, observed) {
   const number = record.issueNumber;
-  const exactCloses = new RegExp(`(?:^|\\n)\\s*(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\\s+#${number}\\s*(?:$|\\n)`, "im").test(observed.relationText ?? "");
+  const exactCloses = new RegExp(`(?:^|\\n)\\s*Closes\\s+#${number}\\s*(?:$|\\n)`, "m").test(observed.relationText ?? "");
   const exactRefs = new RegExp(`(?:^|\\n)\\s*Refs\\s+#${number}\\s*(?:$|\\n)`, "m").test(observed.relationText ?? "");
-  return record.relation === "CLOSES" ? exactCloses && observed.closedByMerge === true : exactRefs && observed.closedByMerge === false;
+  const closingIssues = observed.closingIssues ?? [];
+  return record.relation === "CLOSES"
+    ? exactCloses && closingIssues.length === 1 && closingIssues[0]?.number === number && closingIssues[0]?.state === "CLOSED"
+    : exactRefs && closingIssues.length === 0;
 }
 
 function duplicateValues(values) { return [...new Set(values.filter((value, index) => values.indexOf(value) !== index))].sort((a, b) => codepointCompare(String(a), String(b))); }
 function compare(left, right) { return codepointCompare(`${left.code}\0${left.identity}`, `${right.code}\0${right.identity}`); }
 
-export async function collectPlanDocExecutionLive({ scope, sourceSha, execGh = runGh }) {
+export async function collectPlanDocExecutionLive({ scope, sourceSha, execGh = runGh, execGraphql = runClosingIssuesGraphql }) {
   const records = [];
-  for (const record of scope.historical) records.push(await collectRecord({ issueNumber: record.issueNumber, prNumber: record.prNumber, execGh }));
+  for (const record of scope.historical) records.push(await collectRecord({ issueNumber: record.issueNumber, prNumber: record.prNumber, execGh, execGraphql }));
   const associated = parseJson(await execGh(["api", `repos/${REPOSITORY}/commits/${sourceSha}/pulls`]), `sha:${sourceSha}`);
   if (!Array.isArray(associated) || associated.length !== 1 || !Number.isInteger(associated[0]?.number)) throw new AuditIncomplete("ASSOCIATION_AMBIGUOUS", `sha:${sourceSha}`);
-  const self = await collectRecord({ issueNumber: scope.self.issueNumber, prNumber: associated[0].number, execGh });
+  const self = await collectRecord({ issueNumber: scope.self.issueNumber, prNumber: associated[0].number, execGh, execGraphql });
   return { records, self };
 }
 
-async function collectRecord({ issueNumber, prNumber, execGh }) {
+async function collectRecord({ issueNumber, prNumber, execGh, execGraphql }) {
   const pr = parseJson(await execGh(["api", `repos/${REPOSITORY}/pulls/${prNumber}`]), `pr:${prNumber}`);
   if (pr?.number !== prNumber || pr?.merged !== true || !/^[0-9a-f]{40}$/.test(pr?.merge_commit_sha) || pr?.base?.repo?.full_name !== REPOSITORY || !Number.isInteger(pr?.changed_files) || pr.changed_files < 0 || pr.changed_files > MAX_ITEMS) throw new AuditIncomplete("PROVIDER_MALFORMED", `pr:${prNumber}`);
   const changedFileEntries = await collectPages(`repos/${REPOSITORY}/pulls/${prNumber}/files`, `pr:${prNumber}:files`, execGh, (entry) => typeof entry?.filename === "string" && entry.filename !== "" && (entry.previous_filename == null || (typeof entry.previous_filename === "string" && entry.previous_filename !== "")), (entry) => entry.filename);
   if (changedFileEntries.length !== pr.changed_files) throw new AuditIncomplete("PROVIDER_PARTIAL", `pr:${prNumber}:files`);
   const changedFiles = [...new Set(changedFileEntries.flatMap(({ filename, previous_filename: previousFilename }) => previousFilename == null ? [filename] : [previousFilename, filename]))].sort(codepointCompare);
-  const events = await collectPages(`repos/${REPOSITORY}/issues/${issueNumber}/events`, `issue:${issueNumber}:events`, execGh, (entry) => typeof entry?.event === "string", (entry) => JSON.stringify(entry));
-  return { issueNumber, prNumber, repository: pr.base.repo.full_name, mergeSha: pr.merge_commit_sha, mergedAt: pr.merged_at, changedFiles, relationText: String(pr.body ?? ""), closedByMerge: events.some((event) => event.event === "closed" && event.commit_id === pr.merge_commit_sha) };
+  const closingIssues = parseClosingIssues(await execGraphql(prNumber), prNumber, pr.merge_commit_sha);
+  return { issueNumber, prNumber, repository: pr.base.repo.full_name, mergeSha: pr.merge_commit_sha, mergedAt: pr.merged_at, changedFiles, relationText: String(pr.body ?? ""), closingIssues };
+}
+
+export function parseClosingIssues(text, prNumber, mergeSha) {
+  const response = parseJson(text, `pr:${prNumber}:closing-issues`);
+  const pullRequest = response?.data?.repository?.pullRequest;
+  const references = pullRequest?.closingIssuesReferences;
+  if (!Array.isArray(response?.errors) && response?.errors != null) throw new AuditIncomplete("PROVIDER_MALFORMED", `pr:${prNumber}:closing-issues`);
+  if (Array.isArray(response?.errors) && response.errors.length !== 0) throw new AuditIncomplete("PROVIDER_MALFORMED", `pr:${prNumber}:closing-issues`);
+  if (pullRequest?.number !== prNumber || pullRequest?.merged !== true || pullRequest?.mergeCommit?.oid !== mergeSha || !Number.isInteger(references?.totalCount) || references.totalCount < 0 || references.totalCount > PAGE_SIZE || references?.pageInfo?.hasNextPage !== false || !Array.isArray(references?.nodes) || references.nodes.length !== references.totalCount) throw new AuditIncomplete("PROVIDER_PARTIAL", `pr:${prNumber}:closing-issues`);
+  if (!references.nodes.every((node) => Number.isInteger(node?.number) && node.number > 0 && (node.state === "OPEN" || node.state === "CLOSED") && node.repository?.nameWithOwner === REPOSITORY)) throw new AuditIncomplete("PROVIDER_MALFORMED", `pr:${prNumber}:closing-issues`);
+  if (new Set(references.nodes.map((node) => node.number)).size !== references.nodes.length) throw new AuditIncomplete("PROVIDER_PARTIAL", `pr:${prNumber}:closing-issues`);
+  return references.nodes.map(({ number, state }) => ({ number, state })).sort((left, right) => left.number - right.number);
 }
 
 async function collectPages(base, identity, execGh, valid, key) {
@@ -116,8 +132,14 @@ function compareIncomplete(a, b) { return codepointCompare(`${a.stage}\0${a.code
 function sha256(value) { return createHash("sha256").update(value).digest("hex"); }
 
 export async function runGh(args, execute = execFileAsync) {
-  if (!Array.isArray(args) || args.length !== 2 || args[0] !== "api" || typeof args[1] !== "string" || !new RegExp(`^repos/${REPOSITORY}/(?:pulls/[1-9]\\d*(?:/files)?|issues/[1-9]\\d*/events|commits/[0-9a-f]{40}/pulls)(?:\\?|$)`).test(args[1])) throw new Error("gh read-only allowlist violation");
+  if (!Array.isArray(args) || args.length !== 2 || args[0] !== "api" || typeof args[1] !== "string" || !new RegExp(`^repos/${REPOSITORY}/(?:pulls/[1-9]\\d*(?:/files)?|commits/[0-9a-f]{40}/pulls)(?:\\?|$)`).test(args[1])) throw new Error("gh read-only allowlist violation");
   const { stdout } = await execute("gh", args, { encoding: "utf8", timeout: GH_TIMEOUT_MS, killSignal: "SIGTERM", maxBuffer: GH_MAX_BUFFER });
+  return stdout;
+}
+
+export async function runClosingIssuesGraphql(prNumber, execute = execFileAsync) {
+  if (!Number.isInteger(prNumber) || prNumber < 1) throw new Error("gh GraphQL allowlist violation");
+  const { stdout } = await execute("gh", ["api", "graphql", "-f", `query=${CLOSING_ISSUES_QUERY}`, "-F", "owner=AquilaXk", "-F", "name=easysubway", "-F", `number=${prNumber}`], { encoding: "utf8", timeout: GH_TIMEOUT_MS, killSignal: "SIGTERM", maxBuffer: GH_MAX_BUFFER });
   return stdout;
 }
 

--- a/tools/repo/audit-plan-doc-execution.test.mjs
+++ b/tools/repo/audit-plan-doc-execution.test.mjs
@@ -9,6 +9,7 @@ import {
   auditPlanDocExecution,
   collectPlanDocExecutionLive,
   createPlanDocExecutionReport,
+  parseClosingIssues,
   runAuditCli,
   validatePlanDocExecutionScope,
 } from "./audit-plan-doc-execution.mjs";
@@ -25,7 +26,7 @@ function matchingLive(scope = SCOPE) {
       mergedAt: OBSERVED_AT,
       changedFiles: ["contracts/documentation/example.json"],
       relationText: record.relation === "CLOSES" ? `Closes #${record.issueNumber}` : `Refs #${record.issueNumber}`,
-      closedByMerge: record.relation === "CLOSES",
+      closingIssues: record.relation === "CLOSES" ? [{ number: record.issueNumber, state: "CLOSED" }] : [],
     })),
     self: {
       issueNumber: scope.self.issueNumber,
@@ -35,7 +36,7 @@ function matchingLive(scope = SCOPE) {
       mergedAt: OBSERVED_AT,
       changedFiles: ["contracts/documentation/plan-doc-execution-audit-scope.json"],
       relationText: `Closes #${scope.self.issueNumber}`,
-      closedByMerge: true,
+      closingIssues: [{ number: scope.self.issueNumber, state: "CLOSED" }],
     },
   };
 }
@@ -61,13 +62,19 @@ test("plan-doc execution audit emits concrete findings for merge, relation, repo
   live.records[1].repository = "AquilaXk/easysubway-mobile";
   live.records[2].relationText = `Refs #${SCOPE.historical[2].issueNumber}`;
   live.records[3].changedFiles = ["apps/mobile/lib/main.dart"];
+  live.records[4].closingIssues = [{ number: 9999, state: "CLOSED" }];
+  live.records[0].closingIssues = [{ number: 2748, state: "CLOSED" }];
+  live.records[5].relationText = `Fixes #${SCOPE.historical[5].issueNumber}`;
 
   assert.deepEqual(
     auditPlanDocExecution({ scope: SCOPE, sourceSha: SHA, live }).map(({ code, identity }) => [code, identity]),
     [
       ["EXECUTION_REPOSITORY_MISMATCH", "pr:2755"],
       ["MERGE_SHA_MISMATCH", "pr:2749"],
+      ["RELATION_MISMATCH", "pr:2749"],
       ["RELATION_MISMATCH", "pr:2757"],
+      ["RELATION_MISMATCH", "pr:2761"],
+      ["RELATION_MISMATCH", "pr:2763"],
       ["TARGET_PATH_MODIFICATION", "pr:2759:apps/mobile/lib/main.dart"],
     ],
   );
@@ -128,18 +135,63 @@ test("plan-doc execution audit preserves both sides of a rename without treating
         ? [{ filename: "contracts/documentation/renamed.json", previous_filename: "apps/mobile/lib/old.dart" }]
         : [{ filename: "contracts/documentation/example.json" }]);
     }
-    const eventMatch = endpoint.match(/^repos\/AquilaXk\/easysubway\/issues\/(\d+)\/events\?per_page=100&page=(\d+)$/);
-    if (eventMatch != null) {
-      const issueNumber = Number(eventMatch[1]);
-      const record = [...recordByPr.values()].find((candidate) => candidate.issueNumber === issueNumber && candidate.relation === "CLOSES") ?? (issueNumber === 2797 ? { mergeSha: SHA } : null);
-      return JSON.stringify(Number(eventMatch[2]) === 1 && record != null ? [{ event: "closed", commit_id: record.mergeSha }] : []);
-    }
     throw new Error(`unexpected provider request: ${endpoint}`);
   };
 
-  const live = await collectPlanDocExecutionLive({ scope: SCOPE, sourceSha: SHA, execGh: provider });
+  const graphql = async (prNumber) => {
+    const record = recordByPr.get(prNumber) ?? { issueNumber: 2797, relation: "CLOSES", mergeSha: SHA };
+    return JSON.stringify({ data: { repository: { pullRequest: {
+      number: prNumber, merged: true, mergeCommit: { oid: record.mergeSha },
+      closingIssuesReferences: { totalCount: record.relation === "CLOSES" ? 1 : 0, pageInfo: { hasNextPage: false }, nodes: record.relation === "CLOSES" ? [{ number: record.issueNumber, state: "CLOSED", repository: { nameWithOwner: SCOPE.executionRepository } }] : [] },
+    } } } });
+  };
+
+  const live = await collectPlanDocExecutionLive({ scope: SCOPE, sourceSha: SHA, execGh: provider, execGraphql: graphql });
   assert.deepEqual(live.records[0].changedFiles, ["apps/mobile/lib/old.dart", "contracts/documentation/renamed.json"]);
   assert.deepEqual(auditPlanDocExecution({ scope: SCOPE, sourceSha: SHA, live }).filter(({ code }) => code === "TARGET_PATH_MODIFICATION"), [{ code: "TARGET_PATH_MODIFICATION", identity: "pr:2749:apps/mobile/lib/old.dart" }]);
+});
+
+test("plan-doc execution audit accepts a GitHub-shaped null close event only through an exact GraphQL closing reference", async () => {
+  const recordByPr = new Map(SCOPE.historical.map((record) => [record.prNumber, record]));
+  const provider = async ([, endpoint]) => {
+    if (endpoint === `repos/AquilaXk/easysubway/commits/${SHA}/pulls`) return JSON.stringify([{ number: 2798 }]);
+    const pr = endpoint.match(/^repos\/AquilaXk\/easysubway\/pulls\/(\d+)$/);
+    if (pr != null) {
+      const record = recordByPr.get(Number(pr[1])) ?? { issueNumber: 2797, relation: "CLOSES", mergeSha: SHA };
+      return JSON.stringify({ number: Number(pr[1]), merged: true, merge_commit_sha: record.mergeSha, base: { repo: { full_name: SCOPE.executionRepository } }, changed_files: 0, body: record.relation === "CLOSES" ? `Closes #${record.issueNumber}` : `Refs #${record.issueNumber}`, merged_at: OBSERVED_AT });
+    }
+    if (/\/files\?per_page=100&page=1$/.test(endpoint)) return "[]";
+    throw new Error(`unexpected REST request: ${endpoint}`);
+  };
+  const graphql = async (prNumber) => {
+    const record = recordByPr.get(prNumber) ?? { issueNumber: 2797, relation: "CLOSES", mergeSha: SHA };
+    return JSON.stringify({ data: { repository: { pullRequest: {
+      number: prNumber, merged: true, mergeCommit: { oid: record.mergeSha },
+      closingIssuesReferences: { totalCount: record.relation === "CLOSES" ? 1 : 0, pageInfo: { hasNextPage: false }, nodes: record.relation === "CLOSES" ? [{ number: record.issueNumber, state: "CLOSED", repository: { nameWithOwner: SCOPE.executionRepository } }] : [] },
+    } } } });
+  };
+
+  const live = await collectPlanDocExecutionLive({ scope: SCOPE, sourceSha: SHA, execGh: provider, execGraphql: graphql });
+  assert.deepEqual(auditPlanDocExecution({ scope: SCOPE, sourceSha: SHA, live }), []);
+});
+
+test("plan-doc execution audit fails closed for GraphQL relation provider drift", async () => {
+  const valid = JSON.stringify({ data: { repository: { pullRequest: {
+    number: 2749, merged: true, mergeCommit: { oid: SCOPE.historical[0].mergeSha },
+    closingIssuesReferences: { totalCount: 1, pageInfo: { hasNextPage: false }, nodes: [{ number: 2748, state: "CLOSED", repository: { nameWithOwner: SCOPE.executionRepository } }] },
+  } } } });
+  for (const response of [
+    JSON.stringify({ errors: [{ message: "unavailable" }] }),
+    JSON.stringify({ data: { repository: { pullRequest: { number: 2749, merged: true, mergeCommit: { oid: SCOPE.historical[0].mergeSha }, closingIssuesReferences: { totalCount: 1, pageInfo: { hasNextPage: false }, nodes: [] } } } } }),
+    JSON.stringify({ data: { repository: { pullRequest: { number: 2749, merged: true, mergeCommit: { oid: SCOPE.historical[0].mergeSha }, closingIssuesReferences: { totalCount: 101, pageInfo: { hasNextPage: true }, nodes: [] } } } } }),
+    JSON.stringify({ data: { repository: { pullRequest: { number: 2749, merged: true, mergeCommit: { oid: "b".repeat(40) }, closingIssuesReferences: { totalCount: 0, pageInfo: { hasNextPage: false }, nodes: [] } } } } }),
+    JSON.stringify({ data: { repository: { pullRequest: { number: 2749, merged: true, mergeCommit: { oid: SCOPE.historical[0].mergeSha }, closingIssuesReferences: { totalCount: 1, pageInfo: { hasNextPage: false }, nodes: [{ number: 2748, state: "CLOSED", repository: { nameWithOwner: "AquilaXk/other" } }] } } } } }),
+    JSON.stringify({ data: { repository: { pullRequest: { number: 2749, merged: true, mergeCommit: { oid: SCOPE.historical[0].mergeSha }, closingIssuesReferences: { totalCount: 2, pageInfo: { hasNextPage: false }, nodes: [{ number: 2748, state: "CLOSED", repository: { nameWithOwner: SCOPE.executionRepository } }, { number: 2748, state: "CLOSED", repository: { nameWithOwner: SCOPE.executionRepository } }] } } } } }),
+    "{malformed",
+  ]) {
+    assert.throws(() => parseClosingIssues(response, 2749, SCOPE.historical[0].mergeSha), AuditIncomplete);
+  }
+  assert.deepEqual(parseClosingIssues(valid, 2749, SCOPE.historical[0].mergeSha), [{ number: 2748, state: "CLOSED" }]);
 });
 
 test("plan-doc execution audit report uses the repository codepoint comparator", () => {


### PR DESCRIPTION
## 관련 이슈

Closes #2797

## 작업 배경

- PR #2798 merged-head run `31315406425`은 schema-valid `COMPLETE/findings=13/incomplete=0` artifact를 생성했습니다.
- 정상 squash closure에서도 REST issue event의 `closed.commit_id`가 `null`이어서 12 historical `CLOSES` relation과 self relation을 오판했습니다.
- GitHub GraphQL `pullRequest.closingIssuesReferences`가 PR↔closing issue의 authoritative identity입니다.

## 작업 내용

- REST issue events 수집과 `closed.commit_id` 판정을 제거했습니다.
- 고정·bounded GraphQL query로 PR merge identity와 closing issue number/state/repository를 검증합니다.
- `CLOSES`는 exact `Closes #N` + same-repository closed issue 하나, `COORDINATOR_FOLLOWUP`은 exact `Refs #N` + closing issue 0개를 요구합니다.
- GraphQL error/null/malformed/duplicate/partial/page overflow/REST merge drift는 sanitized `AUDIT_INCOMPLETE`로 fail closed합니다.

## Documentation impact

- 영향 resource ID 또는 `NONE`: `audit:plan-doc-execution`
- resourceClass: `EVIDENCE`
- documentationFamily: `governance`
- lifecycle/evidence 영향: D33 merged-head current evidence의 relation identity를 REST event heuristic에서 authoritative GraphQL closing reference로 교정합니다.

## 검증

- 실행한 명령과 결과:
  - RED: `node --test tools/repo/audit-plan-doc-execution.test.mjs` — 기존 REST event 의존으로 신규 live-shaped 회귀 포함 5건 실패
  - GREEN: `node --test tools/repo/audit-plan-doc-execution.test.mjs` — 10/10 통과
  - `git diff --check` — 통과
  - ready-event required CI: run `31317532438` — terminal SUCCESS
  - Codex CLI Review `4891555195` — exact base/head, actionable 0
  - CodeRabbit run `93bbdecc-9ea5-402c-a7f1-ea0f44538d01` — Review 객체 미생성, conversation summary `No actionable comments`
  - GraphQL review threads — 0개, unresolved 0

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| closing relation 회귀 | Hub Node audit | focused test | 10/10 | PASS |
| provider failure semantics | Hub Node audit | malformed/duplicate/page/merge drift fixtures | focused test 포함 | PASS |
| delivery gate | GitHub PR | required CI + Review + threads | run `31317532438`, Review `4891555195` | PASS |
| 렌더·수동 QA | 해당 없음 | UI/runtime 변경 0 | exact 2-file audit allowlist | 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - fixed GraphQL query의 least/bounded surface
  - REST PR merge SHA와 GraphQL `mergeCommit.oid` exact equality
  - same-repository single closing issue와 coordinator zero-closing semantics
  - raw provider result를 성공 fallback이나 report detail로 사용하지 않는 fail-closed path

## 리스크

- GitHub GraphQL provider shape 또는 권한이 불완전하면 audit가 `AUDIT_INCOMPLETE`/exit 2로 중단됩니다.
- closing issues가 100개를 넘거나 다음 page가 있으면 추정·부분 성공 없이 fail closed합니다.
- workflow/schema/scope/report와 target repository/runtime는 변경하지 않습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)
