### PR TITLE
[Fix] D22 product-gate issue owner identity 정합

### DIFF
--- a/release/product-gates/abuse-penetration-rehearsal-gate.json
+++ b/release/product-gates/abuse-penetration-rehearsal-gate.json
@@ -178,7 +178,7 @@
     "policyKo": "#1022는 Play-generated/Play-installed artifact와 deployed production-like backend/object-storage rehearsal 증거가 없으면 preflight, local selected test, static contract만으로 완료 처리하지 않는다."
   },
   "buildIdentityPolicy": {
-    "requiredIssueLinks": ["#1015", "#1016", "#1020", "#1914"],
+    "requiredIssueLinks": ["#1015", "Mobile #8", "#1020", "#1914"],
     "acceptedArtifactSources": ["rc-aab", "play-generated-apk", "play-installed-build", "backend-release-image"],
     "requiredIdentityFields": [
       "gitSha",

--- a/release/product-gates/server-minimized-qa-gate.json
+++ b/release/product-gates/server-minimized-qa-gate.json
@@ -8,7 +8,7 @@
     "androidGooglePlayV1Required": true,
     "iosDeferredOutOfScope": true,
     "iosEvidenceRetainedForHistory": true,
-    "completionRuleKo": "Android Google Play v1 release evidence만 #571 release blocker로 본다. 기존 iOS 증거는 참고로 유지하지만 Android 완료를 차단하지 않는다."
+    "completionRuleKo": "Android Google Play v1 release evidence만 Mobile #7 release blocker로 본다. 기존 iOS 증거는 참고로 유지하지만 Android 완료를 차단하지 않는다."
   },
   "platformCompletionRule": {
     "androidRequired": true,

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -4657,7 +4657,7 @@ test("모바일 signed release artifact gate와 광고 counter는 CI 산출물�
   assert.match(routeV2GatewayTest, /IP·token limiter와 exact 429 계약/);
   assert.match(routeV2GatewayProbe, /Retry-After: 60/);
   assert.match(ciWorkflow, /tools\/test\/run-route-v2-gateway-integration\.sh/);
-  assert.deepEqual(abusePenetrationRehearsalGate.buildIdentityPolicy.requiredIssueLinks, ["#1015", "#1016", "#1020", "#1914"]);
+  assert.deepEqual(abusePenetrationRehearsalGate.buildIdentityPolicy.requiredIssueLinks, ["#1015", "Mobile #8", "#1020", "#1914"]);
   assert.ok(
     abusePenetrationRehearsalGate.productionLikeEvidencePolicy.requiredForClosing.includes(
       "container-hardening-negative-controls",
@@ -8823,7 +8823,7 @@ test("서버 최소화 PR10 QA gate는 최종 인수 증거를 로컬 전용 정
   assert.equal(gate.releaseBlockerScope.androidGooglePlayV1Required, true);
   assert.equal(gate.releaseBlockerScope.iosDeferredOutOfScope, true);
   assert.equal(gate.releaseBlockerScope.iosEvidenceRetainedForHistory, true);
-  assert.match(gate.releaseBlockerScope.completionRuleKo, /Android Google Play v1 release evidence만/);
+  assert.equal(gate.releaseBlockerScope.completionRuleKo, "Android Google Play v1 release evidence만 Mobile #7 release blocker로 본다. 기존 iOS 증거는 참고로 유지하지만 Android 완료를 차단하지 않는다.");
   assert.doesNotMatch(
     JSON.stringify(gate),
     /com\.easysubway\.mobile/,


### PR DESCRIPTION
## 관련 이슈

Closes #2786

## 작업 배경

- Documentation Reference Audit [run 31349946027](https://github.com/AquilaXk/easysubway/actions/runs/31349946027)은 Hub product-gate의 transferred issue identity 2건을 `WRONG_REPOSITORY_OR_OWNER`로 판정했습니다.
- Migration ledger의 latest-effective owner는 각각 [Mobile issue #8](https://github.com/AquilaXk/easysubway-mobile/issues/8)과 [Mobile issue #7](https://github.com/AquilaXk/easysubway-mobile/issues/7)입니다.

## 작업 내용

- Abuse rehearsal gate의 transferred release issue reference를 exact `Mobile #8`로 재결속했습니다.
- Server-minimized QA gate의 transferred release blocker reference를 exact `Mobile #7`로 재결속했습니다.
- Repository contract test가 두 reference와 나머지 문구/배열을 exact하게 고정하도록 보강했습니다.

## Documentation impact

- 영향 resource ID 또는 `NONE`: `release/product-gates/abuse-penetration-rehearsal-gate.json`, `release/product-gates/server-minimized-qa-gate.json`
- resourceClass: `PRODUCT_GATE_REFERENCE`
- documentationFamily: Release / Security / QA
- lifecycle/evidence 영향: gate 상태·결정·증거는 유지하고 latest-effective owner identity만 정정

## 검증

- RED — `node --test --test-name-pattern='모바일 signed release artifact gate|서버 최소화 PR10 QA gate' tools/ci/repository-contract.test.mjs`: exit 1, old identity 불일치 2건
- GREEN — 같은 command: 2 passed, 0 failed, exit 0
- `node tools/ci/check-contracts.mjs --workspace contracts/workspaces/hub.json --current-only`: exit 0
- `git diff --check`: exit 0
- Ready-event required CI [run 31351405885](https://github.com/AquilaXk/easysubway/actions/runs/31351405885): Changes, Repository CI, Backend CI, Mobile App CI, Android CI 모두 SUCCESS
- Isolated Codex fallback [Review 4893467887](https://github.com/AquilaXk/easysubway/pull/2804#pullrequestreview-4893467887): exact base/head, actionable 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Product-gate reference contract | Hub | focused Node contract test | 위 RED/GREEN 명령 | PASS |
| Current D22 baseline | Five repositories | merged-main workflow artifact | [artifact 9048637725](https://github.com/AquilaXk/easysubway/actions/runs/31349946027/artifacts/9048637725) | 변경 전 Hub finding 2건 확인 |
| Required CI | GitHub Actions | exact current head | [run 31351405885](https://github.com/AquilaXk/easysubway/actions/runs/31351405885) | PASS |
| Supported discovery Review | GitHub Review | canonical isolated Codex fallback | [Review 4893467887](https://github.com/AquilaXk/easysubway/pull/2804#pullrequestreview-4893467887) | actionable 0 |
| UI/수동 QA | N/A | 사용자 동작·UI·runtime semantics 변경 없음 | 증거 불필요 | N/A |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: unchanged
- mobile versionCode: unchanged
- datapack version: unchanged
- route contract: unchanged
- realtime contract: unchanged
- backend identity: unchanged

## 리뷰어 메모

- `requiredIssueLinks`의 배열 순서·다른 값과 `completionRuleKo`의 나머지 문구가 그대로이며 exact `Mobile #8` / `Mobile #7` grammar만 바뀌었습니다.

## 리스크

- Release gate 파일을 건드리므로 R2로 검증했지만 status·threshold·evidence·GO/NO_GO·runtime behavior는 변경하지 않았습니다.
- Aggregate D22는 이 PR만으로 완료되지 않으며 다른 direct-owner findings가 모두 닫힌 후 별도 current audit로 판정합니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit bounded 결과를 확인했다. (actionable 0 summary, GitHub Review 객체 0)
- [x] GitHub PR Review 객체가 있는지 확인했다. (canonical Codex fallback Review 4893467887)
- [x] CodeRabbit PR Review 객체가 없어 Codex CLI code review를 단일 PR Review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)
