### PR TITLE
[CI] D20 Hub observedAt 전달 계약 갱신

### DIFF
--- a/.github/workflows/public-sensitivity-owner-receipt-caller.yml
+++ b/.github/workflows/public-sensitivity-owner-receipt-caller.yml
@@ -2,6 +2,10 @@ name: Public Sensitivity Owner Receipt Caller
 
 on:
   workflow_dispatch:
+    inputs:
+      observed_at:
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -9,6 +13,8 @@ permissions:
 
 jobs:
   receipt:
-    uses: AquilaXk/easysubway/.github/workflows/public-sensitivity-owner-receipt.yml@3d1590baa98c929ceabd0d2d44414cebcc643c6f
+    uses: AquilaXk/easysubway/.github/workflows/public-sensitivity-owner-receipt.yml@fa2f2602573651af6694e7f56077414b685987b9
+    with:
+      observed_at: ${{ inputs.observed_at }}
     secrets:
       D20_SECRET_SCANNING_ALERTS_READ_TOKEN: ${{ secrets.D20_SECRET_SCANNING_ALERTS_READ_TOKEN }}

--- a/tools/ci/public-sensitivity-owner-receipt-caller.test.mjs
+++ b/tools/ci/public-sensitivity-owner-receipt-caller.test.mjs
@@ -2,13 +2,14 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 
-test("hub caller pins the common owner receipt engine and maps only its alert secret", async () => {
+test("hub caller forwards the coordinator observed_at to the pinned common owner receipt engine", async () => {
   const text = await readFile(new URL("../../.github/workflows/public-sensitivity-owner-receipt-caller.yml", import.meta.url), "utf8");
-  assert.match(text, /workflow_dispatch:/);
+  assert.match(text, /workflow_dispatch:\s*\n\s*inputs:\s*\n\s*observed_at:\s*\n\s*required: true\s*\n\s*type: string/);
   assert.match(text, /permissions:\s*\n\s*contents: read\s*\n\s*actions: read/);
-  assert.match(text, /uses: AquilaXk\/easysubway\/\.github\/workflows\/public-sensitivity-owner-receipt\.yml@3d1590baa98c929ceabd0d2d44414cebcc643c6f/);
+  assert.match(text, /uses: AquilaXk\/easysubway\/\.github\/workflows\/public-sensitivity-owner-receipt\.yml@fa2f2602573651af6694e7f56077414b685987b9/);
+  assert.match(text, /with:\s*\n\s*observed_at: \$\{\{ inputs\.observed_at \}\}/);
   assert.match(text, /D20_SECRET_SCANNING_ALERTS_READ_TOKEN: \$\{\{ secrets\.D20_SECRET_SCANNING_ALERTS_READ_TOKEN \}\}/);
-  assert.doesNotMatch(text, /secrets:\s*inherit|@main|@master|issues: write|pull-requests: write|contents: write/);
+  assert.doesNotMatch(text, /observed_at:\s*\n\s*default:|secrets:\s*inherit|@main|@master|issues: write|pull-requests: write|contents: write/);
   assert.equal(validateCallerWorkflow(text), true);
 });
 
@@ -17,6 +18,10 @@ test("caller contract rejects permission, invocation, and secret expansions", ()
 
 on:
   workflow_dispatch:
+    inputs:
+      observed_at:
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -24,13 +29,21 @@ permissions:
 
 jobs:
   receipt:
-    uses: AquilaXk/easysubway/.github/workflows/public-sensitivity-owner-receipt.yml@3d1590baa98c929ceabd0d2d44414cebcc643c6f
+    uses: AquilaXk/easysubway/.github/workflows/public-sensitivity-owner-receipt.yml@fa2f2602573651af6694e7f56077414b685987b9
+    with:
+      observed_at: \${{ inputs.observed_at }}
     secrets:
       D20_SECRET_SCANNING_ALERTS_READ_TOKEN: \${{ secrets.D20_SECRET_SCANNING_ALERTS_READ_TOKEN }}`;
   for (const mutation of [
     canonical.replace("  actions: read", "  actions: read\n  id-token: write"),
     canonical.replace("workflow_dispatch:", "push:"),
-    canonical.replace("@3d1590baa98c929ceabd0d2d44414cebcc643c6f", "@main"),
+    canonical.replace("        required: true", "        required: false"),
+    canonical.replace("        type: string", "        default: 2026-08-10T00:00:00.000Z\n        type: string"),
+    canonical.replace("      observed_at:", "      observedAt:"),
+    canonical.replace("@fa2f2602573651af6694e7f56077414b685987b9", "@3d1590baa98c929ceabd0d2d44414cebcc643c6f"),
+    canonical.replace("@fa2f2602573651af6694e7f56077414b685987b9", "@main"),
+    canonical.replace("    with:\n      observed_at: \${{ inputs.observed_at }}\n", ""),
+    canonical.replace("      observed_at: \${{ inputs.observed_at }}", "      observed_at: \${{ inputs.observedAt }}"),
     canonical.replace("    secrets:", "    with:\n      unsafe: true\n    secrets:"),
     canonical.replace("D20_SECRET_SCANNING_ALERTS_READ_TOKEN }}", "D20_SECRET_SCANNING_ALERTS_READ_TOKEN }}\n      EXTRA: \${{ secrets.EXTRA }}"),
     `${canonical}\n  extra:\n    runs-on: ubuntu-latest`,
@@ -42,6 +55,10 @@ function validateCallerWorkflow(value) {
 
 on:
   workflow_dispatch:
+    inputs:
+      observed_at:
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -49,7 +66,9 @@ permissions:
 
 jobs:
   receipt:
-    uses: AquilaXk/easysubway/.github/workflows/public-sensitivity-owner-receipt.yml@3d1590baa98c929ceabd0d2d44414cebcc643c6f
+    uses: AquilaXk/easysubway/.github/workflows/public-sensitivity-owner-receipt.yml@fa2f2602573651af6694e7f56077414b685987b9
+    with:
+      observed_at: \${{ inputs.observed_at }}
     secrets:
       D20_SECRET_SCANNING_ALERTS_READ_TOKEN: \${{ secrets.D20_SECRET_SCANNING_ALERTS_READ_TOKEN }}`;
   return value.trimEnd() === expected;


### PR DESCRIPTION
## 관련 이슈

Closes #2807
Refs #2748

## 작업 배경

- Hub caller는 old common `3d1590…`를 input 없이 호출해 coordinator-selected same `observedAt`을 전달할 수 없었습니다.
- Common contract correction은 exact merge `fa2f2602573651af6694e7f56077414b685987b9`로 terminal입니다.

## 작업 내용

- `workflow_dispatch.inputs.observed_at` required string/no-default 계약을 추가했습니다.
- common pin을 exact `fa2f2602573651af6694e7f56077414b685987b9`로 갱신했습니다.
- `with.observed_at: ${{ inputs.observed_at }}`만 전달합니다.
- Whole-workflow canonical 및 input/with/pin/permission/secret/job mutation 거부 테스트를 보강했습니다.

## Documentation impact

- 영향 resource ID 또는 `NONE`: `D20_PUBLIC_SENSITIVITY_HUB_CALLER`
- resourceClass: `GOVERNANCE_EVIDENCE`
- documentationFamily: `Security / Public Evidence`
- lifecycle/evidence 영향: caller interface correction. Live receipt/evidence status는 변경하지 않습니다.

## 검증

- RED: `node --test tools/ci/public-sensitivity-owner-receipt-caller.test.mjs` → input contract 부재로 1 fail.
- GREEN: 같은 명령 → 2/2 pass.
- `git diff --check` → pass.

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Hub caller contract | GitHub Actions | focused Node test + required CI | [CI run 31378983724](https://github.com/AquilaXk/easysubway/actions/runs/31378983724) + 위 명령 | PASS |
| Supported discovery Review | GitHub Review | CodeRabbit bounded 관찰 뒤 isolated Codex fallback | [Review 4895820383](https://github.com/AquilaXk/easysubway/pull/2808#pullrequestreview-4895820383), actionable 0 | PASS |
| UI/수동 QA | 해당 없음 | workflow caller-only | runtime/UI 변경 없음 | 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- Exact required input/no-default, exact `with` forwarding, common merge pin을 우선 확인해 주세요.
- Credential/secret/permission과 live dispatch는 이 PR 범위가 아닙니다.

## 리스크

- R2: security evidence correlation caller 계약입니다. 잘못된 forwarding은 fan-in incomplete를 유발합니다.
- Old receipt/cache/local clock fallback은 허용하지 않습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다. (bounded 관찰에서 Review 객체 없음)
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)
