### PR TITLE
[Docs] D33 current execution inventory refresh

### DIFF
--- a/contracts/documentation/plan-doc-execution-audit-scope.json
+++ b/contracts/documentation/plan-doc-execution-audit-scope.json
@@ -19,7 +19,13 @@
     { "issueNumber": 2748, "prNumber": 2789, "mergeSha": "90a169d9b35e4845bfd03d518522544b66dd189f", "relation": "COORDINATOR_FOLLOWUP", "planOwner": "PLAN-DOC", "changedPathClass": "HUB_GOVERNANCE_ONLY" },
     { "issueNumber": 2790, "prNumber": 2791, "mergeSha": "40d1bb13906a6a96a3c7342b0923ad180d290234", "relation": "CLOSES", "planOwner": "PLAN-DOC", "changedPathClass": "HUB_GOVERNANCE_ONLY" },
     { "issueNumber": 2792, "prNumber": 2793, "mergeSha": "3d1590baa98c929ceabd0d2d44414cebcc643c6f", "relation": "CLOSES", "planOwner": "PLAN-DOC", "changedPathClass": "HUB_GOVERNANCE_ONLY" },
-    { "issueNumber": 2795, "prNumber": 2796, "mergeSha": "b853fe6101c7848a8d556bf21b882b3f0e3060a9", "relation": "CLOSES", "planOwner": "PLAN-DOC", "changedPathClass": "HUB_GOVERNANCE_ONLY" }
+    { "issueNumber": 2795, "prNumber": 2796, "mergeSha": "b853fe6101c7848a8d556bf21b882b3f0e3060a9", "relation": "CLOSES", "planOwner": "PLAN-DOC", "changedPathClass": "HUB_GOVERNANCE_ONLY" },
+    { "issueNumber": 2797, "prNumber": 2798, "mergeSha": "7e1cc3d33d579ead965322fe2fa023409aba8c6b", "relation": "CLOSES", "planOwner": "PLAN-DOC", "changedPathClass": "HUB_GOVERNANCE_ONLY" },
+    { "issueNumber": 2797, "prNumber": 2799, "mergeSha": "01ce0b2e4572f65b86ea4f2c91a32c9ff6a2fae1", "relation": "CLOSES", "planOwner": "PLAN-DOC", "changedPathClass": "HUB_GOVERNANCE_ONLY" },
+    { "issueNumber": 2800, "prNumber": 2801, "mergeSha": "f89c284f76654fef5e32387304edaac64618fce2", "relation": "CLOSES", "planOwner": "PLAN-DOC", "changedPathClass": "HUB_GOVERNANCE_ONLY" },
+    { "issueNumber": 2802, "prNumber": 2803, "mergeSha": "b96e8753cb406de6067bbf22a0da158b96b4d898", "relation": "CLOSES", "planOwner": "PLAN-DOC", "changedPathClass": "HUB_GOVERNANCE_ONLY" },
+    { "issueNumber": 2805, "prNumber": 2806, "mergeSha": "fa2f2602573651af6694e7f56077414b685987b9", "relation": "CLOSES", "planOwner": "PLAN-DOC", "changedPathClass": "HUB_GOVERNANCE_ONLY" },
+    { "issueNumber": 2807, "prNumber": 2808, "mergeSha": "3b0076e04df4f6947f33c37c09949ad6b7487238", "relation": "CLOSES", "planOwner": "PLAN-DOC", "changedPathClass": "HUB_GOVERNANCE_ONLY" }
   ],
-  "self": { "issueNumber": 2797, "planOwner": "PLAN-DOC" }
+  "self": { "issueNumber": 2809, "planOwner": "PLAN-DOC" }
 }

--- a/contracts/documentation/plan-doc-execution-audit-scope.schema.json
+++ b/contracts/documentation/plan-doc-execution-audit-scope.schema.json
@@ -10,7 +10,7 @@
     "planOwner": { "const": "PLAN-DOC" },
     "forbiddenTargetPathPrefixes": { "type": "array", "minItems": 6, "maxItems": 6, "uniqueItems": true, "items": { "enum": ["apps/mobile/", "backend/", "infra/", "tools/datapack/", "tools/ops/", "tools/release/"] } },
     "historical": {
-      "type": "array", "minItems": 16, "maxItems": 16,
+      "type": "array", "minItems": 22, "maxItems": 22,
       "items": {
         "type": "object", "additionalProperties": false,
         "required": ["issueNumber", "prNumber", "mergeSha", "relation", "planOwner", "changedPathClass"],
@@ -27,7 +27,7 @@
     "self": {
       "type": "object", "additionalProperties": false,
       "required": ["issueNumber", "planOwner"],
-      "properties": { "issueNumber": { "const": 2797 }, "planOwner": { "const": "PLAN-DOC" } }
+      "properties": { "issueNumber": { "const": 2809 }, "planOwner": { "const": "PLAN-DOC" } }
     }
   }
 }

--- a/tools/ci/check-contracts.mjs
+++ b/tools/ci/check-contracts.mjs
@@ -845,10 +845,10 @@ export function validatePublicSensitivityAuditReportSchema(schema, errors = [], 
 }
 
 export function validatePlanDocExecutionAuditScope(scope, errors = [], path = "plan-doc-execution-audit-scope") {
-  if (scope?.schemaVersion !== 1 || scope?.executionRepository !== "AquilaXk/easysubway" || scope?.planOwner !== "PLAN-DOC" || scope?.self?.issueNumber !== 2797 || scope?.self?.planOwner !== "PLAN-DOC") errors.push(`${path}: exact PLAN-DOC self binding이 필요하다`);
+  if (scope?.schemaVersion !== 1 || scope?.executionRepository !== "AquilaXk/easysubway" || scope?.planOwner !== "PLAN-DOC" || scope?.self?.issueNumber !== 2809 || scope?.self?.planOwner !== "PLAN-DOC") errors.push(`${path}: exact PLAN-DOC self binding이 필요하다`);
   if (JSON.stringify(scope?.forbiddenTargetPathPrefixes) !== JSON.stringify(["apps/mobile/", "backend/", "infra/", "tools/datapack/", "tools/ops/", "tools/release/"])) errors.push(`${path}: target path deny inventory는 exact여야 한다`);
   const records = scope?.historical;
-  if (!Array.isArray(records) || records.length !== 16 || new Set(records.map(({ prNumber }) => prNumber)).size !== 16 || new Set(records.map(({ mergeSha }) => mergeSha)).size !== 16 || records.some((record) => record?.planOwner !== "PLAN-DOC" || record?.changedPathClass !== "HUB_GOVERNANCE_ONLY")) errors.push(`${path}: exact historical PLAN-DOC inventory가 필요하다`);
+  if (!Array.isArray(records) || records.length !== 22 || new Set(records.map(({ prNumber }) => prNumber)).size !== 22 || new Set(records.map(({ mergeSha }) => mergeSha)).size !== 22 || records.some((record) => record?.planOwner !== "PLAN-DOC" || record?.changedPathClass !== "HUB_GOVERNANCE_ONLY")) errors.push(`${path}: exact historical PLAN-DOC inventory가 필요하다`);
   errors.push(...validatePlanDocExecutionAuditInventory(scope).map((error) => `${path}: ${error}`));
   return errors;
 }

--- a/tools/ci/check-contracts.test.mjs
+++ b/tools/ci/check-contracts.test.mjs
@@ -107,11 +107,22 @@ test("plan-doc execution audit contracts fix the historical inventory and fail-c
   const scope = loadJson("contracts/documentation/plan-doc-execution-audit-scope.json");
   const scopeSchema = loadJson("contracts/documentation/plan-doc-execution-audit-scope.schema.json");
   const reportSchema = loadJson("contracts/documentation/plan-doc-execution-audit-report.schema.json");
+  assert.equal(scope.historical.length, 22);
+  assert.equal(scope.self.issueNumber, 2809);
+  assert.equal(scopeSchema.properties.historical.minItems, 22);
+  assert.equal(scopeSchema.properties.historical.maxItems, 22);
+  assert.equal(scopeSchema.properties.self.properties.issueNumber.const, 2809);
+  const recordsByPr = new Map(scope.historical.map((record) => [record.prNumber, record]));
+  for (const [prNumber, issueNumber] of [[2798, 2797], [2799, 2797], [2801, 2800], [2803, 2802], [2806, 2805], [2808, 2807]]) {
+    assert.equal(recordsByPr.get(prNumber)?.issueNumber, issueNumber);
+  }
   assert.equal(validateSchema(scopeSchema, scope).ok, true);
   assert.deepEqual(validatePlanDocExecutionAuditScope(scope), []);
   assert.deepEqual(validatePlanDocExecutionAuditReportSchema(reportSchema), []);
   const invalid = structuredClone(scope); invalid.historical[0].mergeSha = "a".repeat(40);
   assert.ok(validatePlanDocExecutionAuditScope(invalid).length > 0);
+  const invalidSelf = structuredClone(scope); invalidSelf.self.issueNumber = 2797;
+  assert.ok(validatePlanDocExecutionAuditScope(invalidSelf).length > 0);
   const weakened = structuredClone(reportSchema); delete weakened.oneOf;
   assert.ok(validatePlanDocExecutionAuditReportSchema(weakened).length > 0);
   for (const [name, mutate] of [

--- a/tools/repo/audit-plan-doc-execution.mjs
+++ b/tools/repo/audit-plan-doc-execution.mjs
@@ -16,6 +16,9 @@ const execFileAsync = promisify(execFile);
 const CLOSING_ISSUES_QUERY = `query($owner: String!, $name: String!, $number: Int!) { repository(owner: $owner, name: $name) { pullRequest(number: $number) { number merged mergeCommit { oid } closingIssuesReferences(first: 100) { totalCount pageInfo { hasNextPage } nodes { number state repository { nameWithOwner } } } } } }`;
 const EXPECTED_RECORDS = new Map([
   [2749, [2748, "5ad660a7f07563999c1c076790614e7e717e0ea7", "COORDINATOR_FOLLOWUP"]], [2755, [2754, "0568c2195ccac35f0d46f6bb3594093471310977", "CLOSES"]], [2757, [2756, "2b102c1b50f495d628617e61ae95f81944b69c20", "CLOSES"]], [2759, [2758, "00c6109bf91e052fc0d9944a84fde1601c1c50c1", "CLOSES"]], [2761, [2760, "decc1072aa8c8facbfa0143fa1f8fe7646bc016d", "CLOSES"]], [2763, [2762, "560e07239e9ef99b3bfea2ab4bf758b5115acb43", "CLOSES"]], [2730, [2729, "4ccf78d8bf60db2d25233d6fe744daf805c7b0ac", "COORDINATOR_FOLLOWUP"]], [2775, [2733, "96119c4d723d9c60fcd8999da8e58af0731b0847", "CLOSES"]], [2782, [2781, "6194860b5cb13334b91410374fd2504ee056684c", "CLOSES"]], [2784, [2783, "3ea7ef2929ce680268783a1a14476138beb2b521", "CLOSES"]], [2787, [2785, "79bcd0b8e05eb90907c411bdde9b30e24592ce53", "CLOSES"]], [2788, [2729, "a44259fcbdd5538586f4aabaa9a6cb844a41dc03", "COORDINATOR_FOLLOWUP"]], [2789, [2748, "90a169d9b35e4845bfd03d518522544b66dd189f", "COORDINATOR_FOLLOWUP"]], [2791, [2790, "40d1bb13906a6a96a3c7342b0923ad180d290234", "CLOSES"]], [2793, [2792, "3d1590baa98c929ceabd0d2d44414cebcc643c6f", "CLOSES"]], [2796, [2795, "b853fe6101c7848a8d556bf21b882b3f0e3060a9", "CLOSES"]],
+  [2798, [2797, "7e1cc3d33d579ead965322fe2fa023409aba8c6b", "CLOSES"]], [2799, [2797, "01ce0b2e4572f65b86ea4f2c91a32c9ff6a2fae1", "CLOSES"]],
+  [2801, [2800, "f89c284f76654fef5e32387304edaac64618fce2", "CLOSES"]], [2803, [2802, "b96e8753cb406de6067bbf22a0da158b96b4d898", "CLOSES"]],
+  [2806, [2805, "fa2f2602573651af6694e7f56077414b685987b9", "CLOSES"]], [2808, [2807, "3b0076e04df4f6947f33c37c09949ad6b7487238", "CLOSES"]],
 ]);
 
 export class AuditIncomplete extends Error {
@@ -25,7 +28,7 @@ export class AuditIncomplete extends Error {
 export function validatePlanDocExecutionScope(scope, errors = []) {
   if (scope?.schemaVersion !== 1 || scope?.executionRepository !== REPOSITORY || scope?.planOwner !== "PLAN-DOC") errors.push("scope header mismatch");
   if (JSON.stringify(scope?.forbiddenTargetPathPrefixes) !== JSON.stringify(["apps/mobile/", "backend/", "infra/", "tools/datapack/", "tools/ops/", "tools/release/"])) errors.push("forbidden target prefix mismatch");
-  if (scope?.self?.issueNumber !== 2797 || scope?.self?.planOwner !== "PLAN-DOC") errors.push("self binding mismatch");
+  if (scope?.self?.issueNumber !== 2809 || scope?.self?.planOwner !== "PLAN-DOC") errors.push("self binding mismatch");
   const records = scope?.historical;
   if (!Array.isArray(records) || records.length !== EXPECTED_RECORDS.size) return [...errors, "historical inventory count mismatch"];
   const actual = new Map(records.map((record) => [record?.prNumber, record]));

--- a/tools/repo/audit-plan-doc-execution.test.mjs
+++ b/tools/repo/audit-plan-doc-execution.test.mjs
@@ -17,6 +17,15 @@ import {
 const SCOPE = JSON.parse(readFileSync("contracts/documentation/plan-doc-execution-audit-scope.json", "utf8"));
 const SHA = "a".repeat(40);
 const OBSERVED_AT = "2026-08-09T00:00:00.000Z";
+const SELF_PR = 9999;
+const REFRESH_RECORDS = new Map([
+  [2798, [2797, "7e1cc3d33d579ead965322fe2fa023409aba8c6b"]],
+  [2799, [2797, "01ce0b2e4572f65b86ea4f2c91a32c9ff6a2fae1"]],
+  [2801, [2800, "f89c284f76654fef5e32387304edaac64618fce2"]],
+  [2803, [2802, "b96e8753cb406de6067bbf22a0da158b96b4d898"]],
+  [2806, [2805, "fa2f2602573651af6694e7f56077414b685987b9"]],
+  [2808, [2807, "3b0076e04df4f6947f33c37c09949ad6b7487238"]],
+]);
 
 function matchingLive(scope = SCOPE) {
   return {
@@ -30,7 +39,7 @@ function matchingLive(scope = SCOPE) {
     })),
     self: {
       issueNumber: scope.self.issueNumber,
-      prNumber: 2798,
+      prNumber: SELF_PR,
       repository: scope.executionRepository,
       mergeSha: SHA,
       mergedAt: OBSERVED_AT,
@@ -42,6 +51,14 @@ function matchingLive(scope = SCOPE) {
 }
 
 test("plan-doc execution audit scope fixes the exact historical inventory and self binding", () => {
+  assert.equal(SCOPE.historical.length, 22);
+  assert.equal(SCOPE.self.issueNumber, 2809);
+  const byPr = new Map(SCOPE.historical.map((record) => [record.prNumber, record]));
+  for (const [prNumber, [issueNumber, mergeSha]] of REFRESH_RECORDS) {
+    assert.deepEqual(byPr.get(prNumber), {
+      issueNumber, prNumber, mergeSha, relation: "CLOSES", planOwner: "PLAN-DOC", changedPathClass: "HUB_GOVERNANCE_ONLY",
+    });
+  }
   assert.deepEqual(validatePlanDocExecutionScope(SCOPE), []);
   for (const mutate of [
     (scope) => { scope.historical[0].mergeSha = "b".repeat(40); },
@@ -49,6 +66,7 @@ test("plan-doc execution audit scope fixes the exact historical inventory and se
     (scope) => { scope.historical[0].planOwner = "PLAN-REPO"; },
     (scope) => { scope.executionRepository = "AquilaXk/easysubway-mobile"; },
     (scope) => { scope.historical[1].relation = "COORDINATOR_FOLLOWUP"; },
+    (scope) => { scope.self.issueNumber = 2797; },
   ]) {
     const invalid = structuredClone(SCOPE);
     mutate(invalid);
@@ -86,7 +104,7 @@ test("plan-doc execution audit rejects duplicate PR/SHA and self source to PR to
   scope.historical[2].mergeSha = scope.historical[0].mergeSha;
   const live = matchingLive(scope);
   live.self.mergeSha = "c".repeat(40);
-  live.self.relationText = "Refs #2797";
+  live.self.relationText = `Refs #${SCOPE.self.issueNumber}`;
 
   const codes = auditPlanDocExecution({ scope, sourceSha: SHA, live }).map(({ code }) => code);
   for (const code of ["DUPLICATE_PR", "DUPLICATE_MERGE_SHA", "SELF_SOURCE_SHA_MISMATCH", "SELF_CLOSING_ISSUE_MISMATCH"]) assert.ok(codes.includes(code));
@@ -121,11 +139,11 @@ test("plan-doc execution audit fail closes malformed or partial provider respons
 test("plan-doc execution audit preserves both sides of a rename without treating one PR file as two", async () => {
   const recordByPr = new Map(SCOPE.historical.map((record) => [record.prNumber, record]));
   const provider = async ([, endpoint]) => {
-    if (endpoint === `repos/AquilaXk/easysubway/commits/${SHA}/pulls`) return JSON.stringify([{ number: 2798 }]);
+    if (endpoint === `repos/AquilaXk/easysubway/commits/${SHA}/pulls`) return JSON.stringify([{ number: SELF_PR }]);
     const prMatch = endpoint.match(/^repos\/AquilaXk\/easysubway\/pulls\/(\d+)$/);
     if (prMatch != null) {
       const prNumber = Number(prMatch[1]);
-      const record = recordByPr.get(prNumber) ?? { issueNumber: 2797, relation: "CLOSES", mergeSha: SHA };
+      const record = recordByPr.get(prNumber) ?? { issueNumber: SCOPE.self.issueNumber, relation: "CLOSES", mergeSha: SHA };
       return JSON.stringify({ number: prNumber, merged: true, merge_commit_sha: record.mergeSha, base: { repo: { full_name: SCOPE.executionRepository } }, changed_files: 1, body: record.relation === "CLOSES" ? `Closes #${record.issueNumber}` : `Refs #${record.issueNumber}`, merged_at: OBSERVED_AT });
     }
     const filesMatch = endpoint.match(/^repos\/AquilaXk\/easysubway\/pulls\/(\d+)\/files\?per_page=100&page=(\d+)$/);
@@ -139,7 +157,7 @@ test("plan-doc execution audit preserves both sides of a rename without treating
   };
 
   const graphql = async (prNumber) => {
-    const record = recordByPr.get(prNumber) ?? { issueNumber: 2797, relation: "CLOSES", mergeSha: SHA };
+    const record = recordByPr.get(prNumber) ?? { issueNumber: SCOPE.self.issueNumber, relation: "CLOSES", mergeSha: SHA };
     return JSON.stringify({ data: { repository: { pullRequest: {
       number: prNumber, merged: true, mergeCommit: { oid: record.mergeSha },
       closingIssuesReferences: { totalCount: record.relation === "CLOSES" ? 1 : 0, pageInfo: { hasNextPage: false }, nodes: record.relation === "CLOSES" ? [{ number: record.issueNumber, state: "CLOSED", repository: { nameWithOwner: SCOPE.executionRepository } }] : [] },
@@ -154,17 +172,17 @@ test("plan-doc execution audit preserves both sides of a rename without treating
 test("plan-doc execution audit accepts a GitHub-shaped null close event only through an exact GraphQL closing reference", async () => {
   const recordByPr = new Map(SCOPE.historical.map((record) => [record.prNumber, record]));
   const provider = async ([, endpoint]) => {
-    if (endpoint === `repos/AquilaXk/easysubway/commits/${SHA}/pulls`) return JSON.stringify([{ number: 2798 }]);
+    if (endpoint === `repos/AquilaXk/easysubway/commits/${SHA}/pulls`) return JSON.stringify([{ number: SELF_PR }]);
     const pr = endpoint.match(/^repos\/AquilaXk\/easysubway\/pulls\/(\d+)$/);
     if (pr != null) {
-      const record = recordByPr.get(Number(pr[1])) ?? { issueNumber: 2797, relation: "CLOSES", mergeSha: SHA };
+      const record = recordByPr.get(Number(pr[1])) ?? { issueNumber: SCOPE.self.issueNumber, relation: "CLOSES", mergeSha: SHA };
       return JSON.stringify({ number: Number(pr[1]), merged: true, merge_commit_sha: record.mergeSha, base: { repo: { full_name: SCOPE.executionRepository } }, changed_files: 0, body: record.relation === "CLOSES" ? `Closes #${record.issueNumber}` : `Refs #${record.issueNumber}`, merged_at: OBSERVED_AT });
     }
     if (/\/files\?per_page=100&page=1$/.test(endpoint)) return "[]";
     throw new Error(`unexpected REST request: ${endpoint}`);
   };
   const graphql = async (prNumber) => {
-    const record = recordByPr.get(prNumber) ?? { issueNumber: 2797, relation: "CLOSES", mergeSha: SHA };
+    const record = recordByPr.get(prNumber) ?? { issueNumber: SCOPE.self.issueNumber, relation: "CLOSES", mergeSha: SHA };
     return JSON.stringify({ data: { repository: { pullRequest: {
       number: prNumber, merged: true, mergeCommit: { oid: record.mergeSha },
       closingIssuesReferences: { totalCount: record.relation === "CLOSES" ? 1 : 0, pageInfo: { hasNextPage: false }, nodes: record.relation === "CLOSES" ? [{ number: record.issueNumber, state: "CLOSED", repository: { nameWithOwner: SCOPE.executionRepository } }] : [] },


### PR DESCRIPTION
## 관련 이슈

Closes #2809
Refs #2748

## 작업 배경

- Existing D33 artifact는 source `01ce0b2e4572f65b86ea4f2c91a32c9ff6a2fae1`의 17 records에는 유효하지만 current Hub main의 PLAN-DOC execution 전체를 결속하지 않습니다.
- Self-binding이 PR #2799로 이동하면서 최초 D33 delivery PR #2798이 current report에서 빠졌고, 후속 PLAN-DOC PR #2801/#2803/#2806/#2808도 frozen 16-record inventory 밖입니다.

## 작업 내용

- Historical inventory를 기존 16건에서 exact 22건으로 확장했습니다.
- #2797의 PR #2798과 correction PR #2799를 distinct execution records로 함께 보존했습니다.
- D34 #2800/PR #2801, D35 #2802/PR #2803, D20 common #2805/PR #2806, Hub caller #2807/PR #2808의 exact merge SHA와 `CLOSES` relation을 추가했습니다.
- Current self binding을 issue #2809로 이동하고 scope schema, runtime semantic validator와 contract guard를 동일하게 고정했습니다.
- Existing provider pagination/GraphQL relation/fail-closed/report/workflow semantics는 변경하지 않았습니다.

## Documentation impact

- 영향 resource ID 또는 `NONE`: `plan-doc-execution-audit-scope`
- resourceClass: `EVIDENCE`
- documentationFamily: `GOVERNANCE_EVIDENCE`
- lifecycle/evidence 영향: historical D33 evidence를 current 22 + merged self 1 inventory로 refresh합니다. Merged-head artifact 전까지 D33은 `MISSING_EVIDENCE`입니다.

## 검증

- RED: `node --test tools/repo/audit-plan-doc-execution.test.mjs` — current historical count `16 !== 22`, 9 pass/1 fail.
- RED: `node --test --test-name-pattern='plan-doc execution audit' tools/ci/check-contracts.test.mjs` — current historical count `16 !== 22`, 0 pass/1 fail.
- GREEN: `node --test tools/repo/audit-plan-doc-execution.test.mjs` — 10/10 pass.
- GREEN: `node --test --test-name-pattern='plan-doc execution audit' tools/ci/check-contracts.test.mjs` — 1/1 pass.
- `node tools/ci/check-contracts.mjs --workspace contracts/workspaces/hub.json --current-only` — pass.
- `git diff --check` — pass.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| exact historical inventory | Hub Node contract | PR/SHA/issue exact assertions | focused RED→GREEN | PASS |
| scope/schema/self parity | Hub contract checker | exact 22/2809 guards | named test + current-only | PASS |
| current-head required CI | GitHub Actions | [run 31390678239](https://github.com/AquilaXk/easysubway/actions/runs/31390678239) at `8551adf03f696dccc133f45bbd565575fb505f51` | Repository/Backend/Mobile/Android/Changes 모두 성공 | PASS |
| supported discovery Review | GitHub Review | [Review 4897165093](https://github.com/AquilaXk/easysubway/pull/2810#pullrequestreview-4897165093), exact head | Codex CLI fallback, actionable 0 | PASS |
| live merged self | GitHub Actions | main push audit artifact | merge 뒤 생성 | PENDING |
| UI/접근성/수동 QA | 해당 없음 | governance JSON/Node only | 사용자 동작·runtime diff 0 | 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: historical 22 exact set, 같은 issue #2797의 두 PR 동시 보존, self #2809 binding, report/workflow/target scope 변경 0입니다.
- PR #2794는 Data production contract direct-owner, PR #2804는 PLAN-REPO product-gate correction이므로 의도적으로 제외했습니다.
- Merged source associated PR과 GraphQL closing reference를 live resolve하므로 branch CI는 self report를 생성하지 않고, main merge 뒤 exact 23-record artifact를 확인합니다.

## 리스크

- A / R2: governance evidence completeness contract입니다. Record 누락은 D33의 전칭 claim을 거짓으로 만들 수 있습니다.
- Future PLAN-DOC delivery는 이 report가 자동 포괄하지 않습니다. 이후 새 delivery가 생기면 current refresh 전 historical artifact를 미래 evidence로 재사용하지 않습니다.
- Target repository/runtime/build/deploy/release와 provider permissions는 변경하지 않습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 없으므로 CD 증거가 필요하지 않다.
