### PR TITLE
[Docs] D13 Hub clean-checkout owner receipt

### DIFF
--- a/.github/workflows/clean-checkout-reproducibility-owner-receipt-caller.yml
+++ b/.github/workflows/clean-checkout-reproducibility-owner-receipt-caller.yml
@@ -1,0 +1,14 @@
+name: D13 Hub Clean Checkout Owner Receipt
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  owner-receipt:
+    permissions:
+      contents: read
+    uses: AquilaXk/easysubway/.github/workflows/clean-checkout-reproducibility-owner-receipt.yml@c84a23f981516640a530ab3119152c239597b6c6
+    with:
+      contract_path: contracts/documentation/clean-checkout-reproducibility-owner-contract.json

--- a/contracts/documentation/clean-checkout-reproducibility-owner-contract.json
+++ b/contracts/documentation/clean-checkout-reproducibility-owner-contract.json
@@ -1,0 +1,63 @@
+{
+  "schemaVersion": 1,
+  "repository": "AquilaXk/easysubway",
+  "variants": [
+    {
+      "variantId": "hub-documentation-contracts",
+      "runnerImage": "ubuntu-24.04",
+      "toolchainDigest": "2bafa62df07a90cbc8501e2cc9c7f7abdcbb99069462893ab7f0c2ce02b31ac1",
+      "phases": [
+        {
+          "phase": "SETUP",
+          "entrypoint": "tools/ci/run-clean-checkout-reproducibility-phase.mjs",
+          "arguments": [
+            "setup",
+            "24",
+            "2bafa62df07a90cbc8501e2cc9c7f7abdcbb99069462893ab7f0c2ce02b31ac1"
+          ],
+          "workingDirectory": ".",
+          "requiredEnvironment": [],
+          "networkPolicy": "NONE",
+          "timeoutSeconds": 60,
+          "expectedExitCode": 0
+        },
+        {
+          "phase": "BUILD",
+          "entrypoint": "tools/ci/run-clean-checkout-reproducibility-phase.mjs",
+          "arguments": [
+            "build"
+          ],
+          "workingDirectory": ".",
+          "requiredEnvironment": [],
+          "networkPolicy": "NONE",
+          "timeoutSeconds": 120,
+          "expectedExitCode": 0
+        },
+        {
+          "phase": "TEST",
+          "entrypoint": "tools/ci/run-clean-checkout-reproducibility-phase.mjs",
+          "arguments": [
+            "test"
+          ],
+          "workingDirectory": ".",
+          "requiredEnvironment": [],
+          "networkPolicy": "NONE",
+          "timeoutSeconds": 300,
+          "expectedExitCode": 0
+        },
+        {
+          "phase": "DEBUG",
+          "entrypoint": "tools/ci/run-clean-checkout-reproducibility-phase.mjs",
+          "arguments": [
+            "debug"
+          ],
+          "workingDirectory": ".",
+          "requiredEnvironment": [],
+          "networkPolicy": "LOCAL_ONLY",
+          "timeoutSeconds": 60,
+          "expectedExitCode": 0
+        }
+      ]
+    }
+  ]
+}

--- a/tools/ci/clean-checkout-reproducibility-owner-contract.test.mjs
+++ b/tools/ci/clean-checkout-reproducibility-owner-contract.test.mjs
@@ -114,6 +114,11 @@ test("phase entrypoint maps only the four approved commands and fails closed", a
   }
   assert.throws(() => runHubReproducibilityPhase(["setup", "24", "0".repeat(64)], base), /D13_HUB_TOOLCHAIN_MISMATCH/);
   assert.throws(() => runHubReproducibilityPhase(["setup", "24", TOOLCHAIN_DIGEST], { ...base, nodeVersion: "23.0.0" }), /D13_HUB_NODE_MISMATCH/);
+  for (const command of ["build", "test", "debug"]) {
+    assert.throws(() => runHubReproducibilityPhase([command], { ...base, nodeVersion: "23.0.0" }), /D13_HUB_NODE_MISMATCH/);
+    assert.throws(() => runHubReproducibilityPhase([command], { ...base, lockBytes: Buffer.from("mismatch") }), /D13_HUB_TOOLCHAIN_MISMATCH/);
+  }
+  assert.equal(calls.length, 3);
   assert.throws(() => runHubReproducibilityPhase(["build"], { ...base, spawnProcess: () => ({ status: 1 }) }), /D13_HUB_PHASE_NONZERO/);
   assert.throws(() => runHubReproducibilityPhase(["build"], { ...base, spawnProcess: () => ({ error: new Error("raw") }) }), /D13_HUB_PHASE_START_FAILED/);
 });

--- a/tools/ci/clean-checkout-reproducibility-owner-contract.test.mjs
+++ b/tools/ci/clean-checkout-reproducibility-owner-contract.test.mjs
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFile, stat } from "node:fs/promises";
+import test from "node:test";
+
+import { validateSchema } from "./lib/json-schema-lite.mjs";
+import { validateOwnerContract } from "../repo/audit-clean-checkout-reproducibility.mjs";
+
+const ENGINE_SHA = "c84a23f981516640a530ab3119152c239597b6c6";
+const TOOLCHAIN_DIGEST = "2bafa62df07a90cbc8501e2cc9c7f7abdcbb99069462893ab7f0c2ce02b31ac1";
+const ENTRYPOINT = "tools/ci/run-clean-checkout-reproducibility-phase.mjs";
+const CONTRACT_PATH = "contracts/documentation/clean-checkout-reproducibility-owner-contract.json";
+
+const expectedContract = {
+  schemaVersion: 1,
+  repository: "AquilaXk/easysubway",
+  variants: [{
+    variantId: "hub-documentation-contracts",
+    runnerImage: "ubuntu-24.04",
+    toolchainDigest: TOOLCHAIN_DIGEST,
+    phases: [
+      phase("SETUP", ["setup", "24", TOOLCHAIN_DIGEST], "NONE", 60),
+      phase("BUILD", ["build"], "NONE", 120),
+      phase("TEST", ["test"], "NONE", 300),
+      phase("DEBUG", ["debug"], "LOCAL_ONLY", 60),
+    ],
+  }],
+};
+
+const expectedWorkflow = `name: D13 Hub Clean Checkout Owner Receipt
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  owner-receipt:
+    permissions:
+      contents: read
+    uses: AquilaXk/easysubway/.github/workflows/clean-checkout-reproducibility-owner-receipt.yml@${ENGINE_SHA}
+    with:
+      contract_path: ${CONTRACT_PATH}
+`;
+
+test("Hub owner contract pins the exact four reproducibility phases and current toolchain lock", async () => {
+  const [contractText, schemaText, lockBytes, entrypointStat] = await Promise.all([
+    readFile(new URL(`../../${CONTRACT_PATH}`, import.meta.url), "utf8"),
+    readFile(new URL("../../contracts/documentation/clean-checkout-reproducibility-owner-contract.schema.json", import.meta.url), "utf8"),
+    readFile(new URL("../../tools/qa/package-lock.json", import.meta.url)),
+    stat(new URL(`../../${ENTRYPOINT}`, import.meta.url)),
+  ]);
+  const contract = JSON.parse(contractText);
+  const schema = JSON.parse(schemaText);
+  const liteSchema = structuredClone(schema);
+  delete liteSchema.properties.variants.items.properties.phases.items.properties.timeoutSeconds.maximum;
+
+  assert.deepEqual(contract, expectedContract);
+  assert.equal(validateSchema(liteSchema, contract).ok, true);
+  assert.deepEqual(validateOwnerContract(contract), []);
+  assert.equal(createHash("sha256").update(lockBytes).digest("hex"), TOOLCHAIN_DIGEST);
+  assert.notEqual(entrypointStat.mode & 0o111, 0);
+});
+
+test("Hub caller is dispatch-only and invokes the immutable reusable producer without secrets", async () => {
+  const text = await readFile(
+    new URL("../../.github/workflows/clean-checkout-reproducibility-owner-receipt-caller.yml", import.meta.url),
+    "utf8",
+  );
+  assert.equal(text, expectedWorkflow);
+  for (const mutation of [
+    expectedWorkflow.replace("workflow_dispatch:", "push:"),
+    expectedWorkflow.replace("permissions: {}", "permissions:\n  actions: write"),
+    expectedWorkflow.replace("      contents: read", "      contents: write"),
+    expectedWorkflow.replace(`@${ENGINE_SHA}`, "@main"),
+    expectedWorkflow.replace(`@${ENGINE_SHA}`, "@b89f4ddd50e98b2cff5a2a4cee0e0245a59a383a"),
+    expectedWorkflow.replace(`contract_path: ${CONTRACT_PATH}`, "contract_path: contracts/other.json"),
+    expectedWorkflow.replace("    with:\n", "    secrets: inherit\n    with:\n"),
+    `${expectedWorkflow}  extra:\n    runs-on: ubuntu-latest\n`,
+  ]) assert.equal(validateCaller(mutation), false);
+});
+
+test("phase entrypoint maps only the four approved commands and fails closed", async () => {
+  const { runHubReproducibilityPhase } = await import("./run-clean-checkout-reproducibility-phase.mjs");
+  const lockBytes = await readFile(new URL("../../tools/qa/package-lock.json", import.meta.url));
+  const calls = [];
+  const spawnProcess = (executable, arguments_, options) => {
+    calls.push({ executable, arguments_, options });
+    return { status: 0, error: undefined };
+  };
+  const base = {
+    nodeVersion: "24.19.0",
+    repositoryRoot: "/workspace",
+    lockBytes,
+    spawnProcess,
+  };
+
+  assert.equal(runHubReproducibilityPhase(["setup", "24", TOOLCHAIN_DIGEST], base), 0);
+  assert.equal(runHubReproducibilityPhase(["build"], base), 0);
+  assert.equal(runHubReproducibilityPhase(["test"], base), 0);
+  assert.equal(runHubReproducibilityPhase(["debug"], base), 0);
+  assert.deepEqual(calls.map(({ arguments_ }) => arguments_), [
+    ["tools/ci/check-contracts.mjs", "--workspace", "contracts/workspaces/hub.json", "--current-only"],
+    ["--test", "tools/repo/audit-clean-checkout-reproducibility.test.mjs", "tools/repo/produce-clean-checkout-reproducibility-owner-receipt.test.mjs"],
+    ["tools/ci/api-catalog.mjs", "list"],
+  ]);
+  assert.equal(calls.every(({ executable, options }) => executable === process.execPath
+    && options.cwd === "/workspace"
+    && options.shell === false
+    && options.stdio === "ignore"), true);
+
+  for (const arguments_ of [[], ["unknown"], ["build", "extra"], ["setup", "23", TOOLCHAIN_DIGEST]]) {
+    assert.throws(() => runHubReproducibilityPhase(arguments_, base), /D13_HUB_PHASE_INVALID/);
+  }
+  assert.throws(() => runHubReproducibilityPhase(["setup", "24", "0".repeat(64)], base), /D13_HUB_TOOLCHAIN_MISMATCH/);
+  assert.throws(() => runHubReproducibilityPhase(["setup", "24", TOOLCHAIN_DIGEST], { ...base, nodeVersion: "23.0.0" }), /D13_HUB_NODE_MISMATCH/);
+  assert.throws(() => runHubReproducibilityPhase(["build"], { ...base, spawnProcess: () => ({ status: 1 }) }), /D13_HUB_PHASE_NONZERO/);
+  assert.throws(() => runHubReproducibilityPhase(["build"], { ...base, spawnProcess: () => ({ error: new Error("raw") }) }), /D13_HUB_PHASE_START_FAILED/);
+});
+
+function phase(name, arguments_, networkPolicy, timeoutSeconds) {
+  return {
+    phase: name,
+    entrypoint: ENTRYPOINT,
+    arguments: arguments_,
+    workingDirectory: ".",
+    requiredEnvironment: [],
+    networkPolicy,
+    timeoutSeconds,
+    expectedExitCode: 0,
+  };
+}
+
+function validateCaller(value) {
+  return value === expectedWorkflow;
+}

--- a/tools/ci/run-clean-checkout-reproducibility-phase.mjs
+++ b/tools/ci/run-clean-checkout-reproducibility-phase.mjs
@@ -26,13 +26,12 @@ export function runHubReproducibilityPhase(arguments_, {
   if (arguments_[0] === "setup") {
     if (arguments_.length !== 3 || arguments_[1] !== NODE_MAJOR) fail("D13_HUB_PHASE_INVALID");
     if (arguments_[2] !== TOOLCHAIN_DIGEST) fail("D13_HUB_TOOLCHAIN_MISMATCH");
-    if (nodeVersion.split(".", 1)[0] !== NODE_MAJOR) fail("D13_HUB_NODE_MISMATCH");
-    const bytes = lockBytes ?? readToolchainLock(repositoryRoot);
-    if (createHash("sha256").update(bytes).digest("hex") !== TOOLCHAIN_DIGEST) fail("D13_HUB_TOOLCHAIN_MISMATCH");
+    verifyToolchain({ nodeVersion, repositoryRoot, lockBytes });
     return 0;
   }
 
   if (arguments_.length !== 1 || !COMMANDS.has(arguments_[0])) fail("D13_HUB_PHASE_INVALID");
+  verifyToolchain({ nodeVersion, repositoryRoot, lockBytes });
   const result = spawnProcess(process.execPath, COMMANDS.get(arguments_[0]), {
     cwd: repositoryRoot,
     env: process.env,
@@ -42,6 +41,14 @@ export function runHubReproducibilityPhase(arguments_, {
   if (result?.error) fail("D13_HUB_PHASE_START_FAILED");
   if (result?.status !== 0) fail("D13_HUB_PHASE_NONZERO");
   return 0;
+}
+
+function verifyToolchain({ nodeVersion, repositoryRoot, lockBytes }) {
+  if (nodeVersion.split(".", 1)[0] !== NODE_MAJOR) fail("D13_HUB_NODE_MISMATCH");
+  const bytes = lockBytes ?? readToolchainLock(repositoryRoot);
+  if (createHash("sha256").update(bytes).digest("hex") !== TOOLCHAIN_DIGEST) {
+    fail("D13_HUB_TOOLCHAIN_MISMATCH");
+  }
 }
 
 function readToolchainLock(repositoryRoot) {

--- a/tools/ci/run-clean-checkout-reproducibility-phase.mjs
+++ b/tools/ci/run-clean-checkout-reproducibility-phase.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const NODE_MAJOR = "24";
+const TOOLCHAIN_LOCK_PATH = "tools/qa/package-lock.json";
+const TOOLCHAIN_DIGEST = "2bafa62df07a90cbc8501e2cc9c7f7abdcbb99069462893ab7f0c2ce02b31ac1";
+
+const COMMANDS = new Map([
+  ["build", ["tools/ci/check-contracts.mjs", "--workspace", "contracts/workspaces/hub.json", "--current-only"]],
+  ["test", ["--test", "tools/repo/audit-clean-checkout-reproducibility.test.mjs", "tools/repo/produce-clean-checkout-reproducibility-owner-receipt.test.mjs"]],
+  ["debug", ["tools/ci/api-catalog.mjs", "list"]],
+]);
+
+export function runHubReproducibilityPhase(arguments_, {
+  nodeVersion = process.versions.node,
+  repositoryRoot = process.cwd(),
+  lockBytes,
+  spawnProcess = spawnSync,
+} = {}) {
+  if (!Array.isArray(arguments_)) fail("D13_HUB_PHASE_INVALID");
+  if (arguments_[0] === "setup") {
+    if (arguments_.length !== 3 || arguments_[1] !== NODE_MAJOR) fail("D13_HUB_PHASE_INVALID");
+    if (arguments_[2] !== TOOLCHAIN_DIGEST) fail("D13_HUB_TOOLCHAIN_MISMATCH");
+    if (nodeVersion.split(".", 1)[0] !== NODE_MAJOR) fail("D13_HUB_NODE_MISMATCH");
+    const bytes = lockBytes ?? readToolchainLock(repositoryRoot);
+    if (createHash("sha256").update(bytes).digest("hex") !== TOOLCHAIN_DIGEST) fail("D13_HUB_TOOLCHAIN_MISMATCH");
+    return 0;
+  }
+
+  if (arguments_.length !== 1 || !COMMANDS.has(arguments_[0])) fail("D13_HUB_PHASE_INVALID");
+  const result = spawnProcess(process.execPath, COMMANDS.get(arguments_[0]), {
+    cwd: repositoryRoot,
+    env: process.env,
+    shell: false,
+    stdio: "ignore",
+  });
+  if (result?.error) fail("D13_HUB_PHASE_START_FAILED");
+  if (result?.status !== 0) fail("D13_HUB_PHASE_NONZERO");
+  return 0;
+}
+
+function readToolchainLock(repositoryRoot) {
+  try {
+    return readFileSync(path.join(repositoryRoot, TOOLCHAIN_LOCK_PATH));
+  } catch {
+    fail("D13_HUB_TOOLCHAIN_UNAVAILABLE");
+  }
+}
+
+function fail(code) {
+  throw new Error(code);
+}
+
+function isMain() {
+  return process.argv[1] != null && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+}
+
+if (isMain()) {
+  try {
+    runHubReproducibilityPhase(process.argv.slice(2));
+  } catch (error) {
+    const code = typeof error?.message === "string" && /^D13_HUB_[A-Z_]+$/.test(error.message)
+      ? error.message
+      : "D13_HUB_PHASE_FAILED";
+    process.stderr.write(`${code}\n`);
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## 관련 이슈

Closes #2825

## 작업 배경

- D13 clean-checkout reproducibility audit는 현재 5개 owner slot이 모두 `PENDING`이며, Hub default head에는 owner-approved SETUP/BUILD/TEST/DEBUG 계약과 호출 surface가 없습니다.
- 이 PR은 Hub direct-owner slot만 좁게 구현합니다. 5-repo READY fan-in과 D13 최종 판정은 별도 PLAN-DOC consumer slice로 유지합니다.

## 작업 내용

- Hub documentation contracts용 단일 owner contract에 SETUP/BUILD/TEST/DEBUG 네 phase와 현재 Node/toolchain identity를 고정했습니다.
- shell expansion 없이 승인된 네 phase만 실행하는 tracked entrypoint를 추가했습니다.
- immutable reusable producer `c84a23f981516640a530ab3119152c239597b6c6`를 호출하는 `workflow_dispatch` 전용 caller를 추가했습니다.
- contract 전체 구조, toolchain digest, executable mode, caller 최소 권한·immutable ref, command allowlist와 fail-closed 오류를 focused test로 고정했습니다.

## Documentation impact

- 영향 resource ID 또는 `NONE`: `NONE` (documentation catalog/resource lifecycle 변경 없음)
- resourceClass: `NONE`
- documentationFamily: D13 clean-checkout reproducibility owner evidence
- lifecycle/evidence 영향: Hub direct-owner receipt 생성 기반만 추가하며, D13 `PROVEN` 또는 5-repo READY를 주장하지 않습니다.

## 검증

- 실행한 명령과 결과:
  - RED: `node --test tools/ci/clean-checkout-reproducibility-owner-contract.test.mjs` → 필수 surface 부재로 0 pass / 3 fail
  - GREEN: 같은 명령 → 3 pass / 0 fail
  - `git diff --check` 및 `git diff --cached --check` → PASS
  - staged allowlist → 정확히 4파일, entrypoint Git mode `100755`
  - finding fix RED → non-SETUP Node mismatch가 실패하지 않아 2 pass / 1 fail
  - finding fix GREEN → build/test/debug의 Node·lock mismatch를 spawn 전에 거부, 3 pass / 0 fail
  - current-head CI run `31445873674` → SUCCESS

## 검증 증거

UI·접근성·수동 QA·배포 surface는 변경하지 않습니다. 실제 네 phase와 receipt JSON은 병합된 default head에서 caller를 1회 실행한 뒤 검증합니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| owner contract/caller/entrypoint | Hub CI contract | focused Node test | head `33f4a55864275a46c7abe18bbc78cf005c18a47b` | PASS |
| discovery Review | GitHub | CodeRabbit Review와 original threads 확인 | Review `4901957882`, actionable 2 | PASS |
| finding closure | GitHub/CI | F1 fix, P3 no-change 근거, original thread resolve | current-head CI `31445873674`, unresolved 0 | PASS |
| clean-checkout receipt | GitHub Actions `ubuntu-24.04` | 병합 후 caller 1회 dispatch 및 artifact strict read-back | 병합 후 추가 | PENDING |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: N/A
- mobile versionCode: N/A
- datapack version: N/A
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: contract의 exact four-phase command mapping, immutable reusable workflow SHA, no-secret/minimum-permission caller, toolchain lock digest fail-closed 동작입니다.

## 리스크

- R2. 재현성 evidence producer의 owner 입력 계약을 추가하므로 잘못된 command/digest/권한은 허위 receipt로 이어질 수 있습니다. 전체 구조 equality, command allowlist, current lock digest, schema·semantic validation, immutable producer pin으로 차단합니다.
- target repo, application/runtime, deploy/release, secret/permission 설정은 변경하지 않습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다. (CodeRabbit Review 객체가 있어 fallback 불필요)
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)
