### PR TITLE
[Docs] D13 owner source full-history checkout

### DIFF
--- a/.github/workflows/clean-checkout-reproducibility-owner-receipt.yml
+++ b/.github/workflows/clean-checkout-reproducibility-owner-receipt.yml
@@ -23,6 +23,7 @@ jobs:
           ref: ${{ github.sha }}
           path: owner-source
           persist-credentials: false
+          fetch-depth: 0
 
       - name: Validate immutable D13 engine identity
         id: d13-engine-identity

--- a/tools/repo/produce-clean-checkout-reproducibility-owner-receipt.test.mjs
+++ b/tools/repo/produce-clean-checkout-reproducibility-owner-receipt.test.mjs
@@ -328,6 +328,21 @@ function validateImmutableEngineCheckoutBoundary(workflow) {
   assert.doesNotMatch(checkoutBlock, /fromJSON\(toJSON\(job\)\)|github\.(?:repository|sha)/);
 }
 
+function validateOwnerSourceCheckoutBoundary(workflow) {
+  const checkoutBlocks = workflow.match(/      - name: Checkout caller source\n[\s\S]*?(?=\n      - name:)/g) ?? [];
+  assert.equal(checkoutBlocks.length, 1);
+  assert.equal(checkoutBlocks[0], `      - name: Checkout caller source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          repository: \${{ github.repository }}
+          ref: \${{ github.sha }}
+          path: owner-source
+          persist-credentials: false
+          fetch-depth: 0
+`);
+  assert.equal((workflow.match(/^\s+fetch-depth:/gm) ?? []).length, 1);
+}
+
 test("reusable workflow and composite action freeze the dual-checkout single-artifact boundary", async () => {
   const action = await readFile(path.join(root, ".github/actions/clean-checkout-reproducibility-owner-receipt/action.yml"), "utf8");
   const workflow = await readFile(path.join(root, ".github/workflows/clean-checkout-reproducibility-owner-receipt.yml"), "utf8");
@@ -345,7 +360,7 @@ test("reusable workflow and composite action freeze the dual-checkout single-art
   assert.match(workflow, /runs-on: ubuntu-24\.04/);
   assert.match(workflow, /actions\/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1/);
   assert.match(workflow, /python-version: "3\.13\.15"/);
-  assert.match(workflow, /repository: \$\{\{ github\.repository \}\}\n          ref: \$\{\{ github\.sha \}\}\n          path: owner-source\n          persist-credentials: false/);
+  validateOwnerSourceCheckoutBoundary(workflow);
   validateImmutableEngineCheckoutBoundary(workflow);
   assert.match(workflow, /uses: \.\/d13-engine\/\.github\/actions\/clean-checkout-reproducibility-owner-receipt/);
   assert.match(workflow, /contract-path: \$\{\{ inputs\.contract_path \}\}/);
@@ -382,5 +397,21 @@ test("reusable workflow rejects unvalidated or weak D13 engine identities", asyn
   ];
   for (const mutation of mutations) {
     assert.throws(() => validateImmutableEngineCheckoutBoundary(mutation));
+  }
+});
+
+test("reusable workflow rejects shallow or misplaced owner-source history", async () => {
+  const workflow = await readFile(path.join(root, ".github/workflows/clean-checkout-reproducibility-owner-receipt.yml"), "utf8");
+  validateOwnerSourceCheckoutBoundary(workflow);
+  const mutations = [
+    workflow.replace("          fetch-depth: 0\n", ""),
+    workflow.replace("fetch-depth: 0", "fetch-depth: 1"),
+    workflow.replace("fetch-depth: 0", 'fetch-depth: "0"'),
+    workflow
+      .replace("          fetch-depth: 0\n", "")
+      .replace("          path: d13-engine\n", "          path: d13-engine\n          fetch-depth: 0\n"),
+  ];
+  for (const mutation of mutations) {
+    assert.throws(() => validateOwnerSourceCheckoutBoundary(mutation));
   }
 });


### PR DESCRIPTION
## 관련 이슈

Closes #2827

Refs #2825

## 작업 배경

- Hub owner caller merge `2f26c9028f74ce46ef934bc4938dd42fcd966441`의 live run `31447389143` 두 attempt가 모두 `D13_OWNER_RECEIPT_PHASE_NONZERO`로 실패했습니다.
- Exact merge SHA의 depth-1 clean Linux clone에서 동일 실패를 재현했고, BUILD의 current-only contract gate가 historical `inventoryBaseHead` object/ancestry를 요구함을 확인했습니다.
- 이 ancestry 검사를 약화하지 않고 reusable caller-source checkout이 full Git history를 제공해야 합니다.

## 작업 내용

- reusable workflow의 `Checkout caller source`에만 exact `fetch-depth: 0`을 추가했습니다.
- focused test가 owner-source checkout whole shape와 missing/nonzero/string/moved `fetch-depth` 변이를 거부하도록 고정했습니다.
- immutable engine checkout, producer runtime, permissions, artifact와 owner command는 변경하지 않았습니다.

## Documentation impact

- 영향 resource ID 또는 `NONE`: D13 clean-checkout reproducibility owner receipt producer
- resourceClass: CI_EVIDENCE_PRODUCER
- documentationFamily: CLEAN_CHECKOUT_REPRODUCIBILITY
- lifecycle/evidence 영향: source engine correction만 전달하며 Hub slot은 후속 immutable caller repin/live receipt 전 `PENDING` 유지

## 검증

- RED: `node --test --test-name-pattern='reusable workflow' tools/repo/produce-clean-checkout-reproducibility-owner-receipt.test.mjs` → 1 pass / 2 fail (`fetch-depth: 0` 부재)
- GREEN: 동일 명령 → 3 pass / 0 fail
- `actionlint .github/workflows/clean-checkout-reproducibility-owner-receipt.yml` → PASS
- `git diff --check` → PASS
- latest same-head required CI run `31448992972` → Changes, Repository CI, Backend CI, Mobile App CI, Android CI 모두 SUCCESS
- Release Artifacts required `Changes` job `93647150330` → SUCCESS

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| merged-head failure | GitHub Actions / ubuntu-24.04 | exact caller dispatch + bounded failed-job rerun | run `31447389143` | 두 attempt 동일 failure, artifact 없음 |
| depth-1 reproduction | Node 24.18 Linux | exact merge SHA shallow clone production producer | task-owned `/tmp/easysubway-d13-shallow-Qx81pu/repo` | 동일 `PHASE_NONZERO`; BUILD ancestry error 확정 |
| focused contract | macOS / Node 24 | RED→GREEN 및 mutation contract | 위 검증 명령 | PASS |
| current-head required CI | GitHub Actions | latest same-head run | [run `31448992972`](https://github.com/AquilaXk/easysubway/actions/runs/31448992972) | required jobs 전부 SUCCESS |
| supported discovery Review | GitHub Review | CodeRabbit Review 객체 부재 후 isolated Codex fallback | [Review `4902314209`](https://github.com/AquilaXk/easysubway/pull/2828#pullrequestreview-4902314209) | actionable 0, thread 0 |
| UI·접근성·수동 QA | N/A | workflow checkout metadata-only 변경 | UI/runtime 변경 없음 | 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `fetch-depth: 0`이 owner-source checkout에만 있고 immutable engine checkout으로 이동·복제되지 않는지 확인해 주세요.
- BUILD command나 `inventoryBaseHead` ancestry 검증을 약화하는 대안은 scope 밖입니다.

## 리스크

- R2: shared reusable workflow의 checkout history 범위를 바꾸므로 clone 비용과 five-owner 영향이 있습니다. 변경은 exact one-line behavior와 focused whole-shape/mutation test로 제한했습니다.
- 별도 non-required `Android Release Artifact` failure는 datapack artifact producer 상태이며 이 두 파일 변경의 required merge gate가 아닙니다. Release Artifacts의 required `Changes`는 성공했습니다.
- 이 PR merge만으로 Hub READY를 주장하지 않습니다. Merge SHA를 후속 별도 caller repin PR에 immutable ref로 사용한 뒤 live receipt를 검증합니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰 표면을 확인했다. (코멘트/status만 있고 Review 객체 없음)
- [x] GitHub PR Review 객체가 있는지 확인했다. Codex fallback Review `4902314209`가 exact head에 존재한다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 소스 체크아웃 시 전체 Git 이력을 가져오도록 개선했습니다.
  * 체크아웃 경계와 설정을 자동으로 검증해 재현성을 높였습니다.
  * 잘못된 얕은 체크아웃 및 부적절한 설정을 감지하는 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
