### PR TITLE
[Docs] D13 Hub caller full-history engine repin

### DIFF
--- a/.github/workflows/clean-checkout-reproducibility-owner-receipt-caller.yml
+++ b/.github/workflows/clean-checkout-reproducibility-owner-receipt-caller.yml
@@ -9,6 +9,6 @@ jobs:
   owner-receipt:
     permissions:
       contents: read
-    uses: AquilaXk/easysubway/.github/workflows/clean-checkout-reproducibility-owner-receipt.yml@c84a23f981516640a530ab3119152c239597b6c6
+    uses: AquilaXk/easysubway/.github/workflows/clean-checkout-reproducibility-owner-receipt.yml@4475e6d9da634e28cda4179b738d4f9f440f06a7
     with:
       contract_path: contracts/documentation/clean-checkout-reproducibility-owner-contract.json

--- a/tools/ci/clean-checkout-reproducibility-owner-contract.test.mjs
+++ b/tools/ci/clean-checkout-reproducibility-owner-contract.test.mjs
@@ -6,7 +6,7 @@ import test from "node:test";
 import { validateSchema } from "./lib/json-schema-lite.mjs";
 import { validateOwnerContract } from "../repo/audit-clean-checkout-reproducibility.mjs";
 
-const ENGINE_SHA = "c84a23f981516640a530ab3119152c239597b6c6";
+const ENGINE_SHA = "4475e6d9da634e28cda4179b738d4f9f440f06a7";
 const TOOLCHAIN_DIGEST = "2bafa62df07a90cbc8501e2cc9c7f7abdcbb99069462893ab7f0c2ce02b31ac1";
 const ENTRYPOINT = "tools/ci/run-clean-checkout-reproducibility-phase.mjs";
 const CONTRACT_PATH = "contracts/documentation/clean-checkout-reproducibility-owner-contract.json";


### PR DESCRIPTION
## 관련 이슈

Closes #2829

Refs #2827

Refs #2825

## 작업 배경

- D13 common engine은 merge `4475e6d9da634e28cda4179b738d4f9f440f06a7`에서 caller source full Git history를 제공하도록 수정됐습니다.
- Hub caller는 아직 old shallow engine `c84a23f981516640a530ab3119152c239597b6c6`를 pin해 새 engine correction을 소비하지 못합니다.
- Old merged-head caller run `31447389143`과 bounded rerun은 모두 BUILD에서 실패했고 artifact가 없으므로 재사용할 수 없습니다.

## 작업 내용

- Hub caller reusable ref를 exact Slice A merge SHA `4475e6d9da634e28cda4179b738d4f9f440f06a7`로 교체했습니다.
- focused caller contract의 `ENGINE_SHA`도 같은 immutable SHA로 고정했습니다.
- owner contract, 네 phase command, common engine, permissions, secret/cache/artifact semantics는 변경하지 않았습니다.

## Documentation impact

- 영향 resource ID 또는 `NONE`: D13 Hub clean-checkout reproducibility owner receipt caller
- resourceClass: CI_EVIDENCE_PRODUCER_CALLER
- documentationFamily: CLEAN_CHECKOUT_REPRODUCIBILITY
- lifecycle/evidence 영향: merged caller가 새 live receipt를 만들기 전 Hub slot은 `PENDING`; 성공 artifact 검증 뒤에만 `READY`

## 검증

- RED: `node --test tools/ci/clean-checkout-reproducibility-owner-contract.test.mjs` → 2 pass / 1 fail (caller old SHA와 required new SHA 불일치)
- GREEN: 동일 명령 → 3 pass / 0 fail
- `actionlint .github/workflows/clean-checkout-reproducibility-owner-receipt-caller.yml` → PASS
- `git diff --check` → PASS

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| prior live failure | GitHub Actions / ubuntu-24.04 | old merged caller dispatch + bounded rerun | run `31447389143` | 두 attempt failure, artifact 없음 |
| common engine delivery | GitHub | Slice A exact-head squash merge | PR #2828, merge `4475e6d9da634e28cda4179b738d4f9f440f06a7` | delivered |
| immutable caller contract | macOS / Node 24 | focused RED→GREEN | 위 명령 | 3/3 PASS |
| workflow syntax | actionlint | target caller workflow only | 위 명령 | PASS |
| current-head CI | GitHub Actions | Ready exact-head required checks | run `31452597268` | 전부 PASS |
| discovery Review | GitHub Review | CodeRabbit status/comment는 Review 객체가 아니므로 canonical Codex fallback | Review `4902552390`, actionable 0 | PASS |
| UI·접근성·수동 QA | N/A | immutable workflow ref-only 변경 | UI/runtime product 변경 없음 | 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 두 파일이 같은 exact full-history engine SHA를 고정하는지 확인해 주세요.
- Contract/phase command 변경, mutable ref, same-commit self-pin, old run/artifact 재사용은 scope 밖입니다.

## 리스크

- R2: caller가 실행할 shared engine identity를 바꾸는 evidence-producer 변경입니다.
- 변경은 exact immutable SHA 두 occurrence로 제한됐고 whole-workflow focused contract가 permission/input/job/secret/ref drift를 거부합니다.
- 이 PR merge만으로 성공을 주장하지 않습니다. Merged default-head에서 새 caller를 한 번 dispatch하고 exact artifact를 검증해야 Hub slot이 `READY`입니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다. (No actionable comments; Review 객체 미생성)
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음; post-merge live evidence 별도)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 재사용 워크플로가 최신 커밋 참조를 사용하도록 업데이트되었습니다.
  * 관련 자동 검증 기준이 새 커밋 참조에 맞게 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->