### PR TITLE
[Docs] D01–D05 current five-fragment 감사기

### DIFF
--- a/.github/workflows/documentation-inventory-audit.yml
+++ b/.github/workflows/documentation-inventory-audit.yml
@@ -1,0 +1,54 @@
+name: Documentation Inventory Audit
+
+on:
+  push:
+    branches: [main]
+
+permissions: {}
+
+concurrency:
+  group: documentation-inventory-audit-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24"
+      - name: Audit current five-fragment documentation inventory
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          EVIDENCE_DIR="audit-evidence"
+          REPORT_PATH="${EVIDENCE_DIR}/documentation-inventory-audit-report.json"
+          OBSERVED_AT="$(date --utc +"%Y-%m-%dT%H:%M:%S.000Z")"
+          rm --recursive --force -- "${EVIDENCE_DIR}"
+          mkdir --parents -- "${EVIDENCE_DIR}"
+          test ! -e "${REPORT_PATH}"
+          node tools/repo/audit-documentation-inventory.mjs \
+            --scope contracts/documentation/documentation-inventory-audit-scope.json \
+            --scope-schema contracts/documentation/documentation-inventory-audit-scope.schema.json \
+            --report-schema contracts/documentation/documentation-inventory-audit-report.schema.json \
+            --source-sha "${GITHUB_SHA}" \
+            --observed-at "${OBSERVED_AT}" \
+            --output "${REPORT_PATH}"
+      - name: Upload sanitized documentation inventory audit
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: documentation-inventory-audit-${{ github.sha }}
+          path: audit-evidence/documentation-inventory-audit-report.json
+          if-no-files-found: error
+          include-hidden-files: false
+          retention-days: 14

--- a/contracts/documentation/documentation-inventory-audit-report.schema.json
+++ b/contracts/documentation/documentation-inventory-audit-report.schema.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://easysubway.local/schema/documentation-inventory-audit-report.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "status", "observedAt", "inputs", "summary", "repositories", "dods", "findings", "incomplete"],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "status": { "enum": ["COMPLETE", "AUDIT_INCOMPLETE"] },
+    "observedAt": { "type": "string", "format": "date-time" },
+    "inputs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sourceSha", "scopeSha256", "stateBeginSha256", "stateEndSha256"],
+      "properties": {
+        "sourceSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+        "scopeSha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "stateBeginSha256": { "type": ["string", "null"], "pattern": "^[0-9a-f]{64}$" },
+        "stateEndSha256": { "type": ["string", "null"], "pattern": "^[0-9a-f]{64}$" }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pending", "ready", "activeResources", "findings", "incomplete"],
+      "properties": {
+        "pending": { "type": "integer", "minimum": 0 },
+        "ready": { "type": "integer", "minimum": 0 },
+        "activeResources": { "type": "integer", "minimum": 0 },
+        "findings": { "type": "integer", "minimum": 0 },
+        "incomplete": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "repositories": {
+      "type": "array",
+      "minItems": 5,
+      "maxItems": 5,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["repository", "headSha", "state", "fragmentStatus", "fragmentBlobSha", "resourceCount", "activeResourceCount"],
+        "properties": {
+          "repository": { "enum": ["AquilaXk/easysubway", "AquilaXk/easysubway-backend", "AquilaXk/easysubway-data", "AquilaXk/easysubway-mobile", "AquilaXk/easysubway-platform"] },
+          "headSha": { "type": ["string", "null"], "pattern": "^[0-9a-f]{40}$" },
+          "state": { "enum": ["PENDING", "READY", "UNAVAILABLE"] },
+          "fragmentStatus": { "enum": ["MISSING", "PROPOSED", "ACTIVE", "UNAVAILABLE"] },
+          "fragmentBlobSha": { "type": ["string", "null"], "pattern": "^[0-9a-f]{40}$" },
+          "resourceCount": { "type": "integer", "minimum": 0 },
+          "activeResourceCount": { "type": "integer", "minimum": 0 }
+        }
+      }
+    },
+    "dods": {
+      "type": "array",
+      "minItems": 5,
+      "maxItems": 5,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "status", "findings"],
+        "properties": {
+          "id": { "enum": ["D01", "D02", "D03", "D04", "D05"] },
+          "status": { "enum": ["PENDING", "PROVEN", "CONTRADICTED", "INCOMPLETE"] },
+          "findings": { "type": "integer", "minimum": 0 }
+        }
+      }
+    },
+    "findings": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["dod", "code", "identity"],
+        "properties": {
+          "dod": { "enum": ["D01", "D02", "D03", "D04", "D05"] },
+          "code": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]*$" },
+          "identity": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "incomplete": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["stage", "code", "affectedIdentity"],
+        "properties": {
+          "stage": { "type": "string", "pattern": "^[a-z][a-z0-9-]*$" },
+          "code": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]*$" },
+          "affectedIdentity": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  },
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "status": { "const": "COMPLETE" },
+        "inputs": {
+          "type": "object",
+          "properties": {
+            "stateBeginSha256": { "type": "string" },
+            "stateEndSha256": { "type": "string" }
+          }
+        },
+        "incomplete": { "type": "array", "maxItems": 0 }
+      }
+    },
+    {
+      "type": "object",
+      "properties": {
+        "status": { "const": "AUDIT_INCOMPLETE" },
+        "incomplete": { "type": "array", "minItems": 1 }
+      }
+    }
+  ]
+}

--- a/contracts/documentation/documentation-inventory-audit-scope.json
+++ b/contracts/documentation/documentation-inventory-audit-scope.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": 1,
+  "repositories": [
+    { "repository": "AquilaXk/easysubway", "defaultBranch": "main", "fragmentPath": "contracts/documentation/documentation-fragment.json", "requiredStatus": "ACTIVE" },
+    { "repository": "AquilaXk/easysubway-backend", "defaultBranch": "main", "fragmentPath": "contracts/documentation/documentation-fragment.json", "requiredStatus": "ACTIVE" },
+    { "repository": "AquilaXk/easysubway-data", "defaultBranch": "main", "fragmentPath": "contracts/documentation/documentation-fragment.json", "requiredStatus": "ACTIVE" },
+    { "repository": "AquilaXk/easysubway-mobile", "defaultBranch": "main", "fragmentPath": "contracts/documentation/documentation-fragment.json", "requiredStatus": "ACTIVE" },
+    { "repository": "AquilaXk/easysubway-platform", "defaultBranch": "main", "fragmentPath": "contracts/documentation/documentation-fragment.json", "requiredStatus": "ACTIVE" }
+  ],
+  "dods": ["D01", "D02", "D03", "D04", "D05"]
+}

--- a/contracts/documentation/documentation-inventory-audit-scope.schema.json
+++ b/contracts/documentation/documentation-inventory-audit-scope.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://easysubway.local/schema/documentation-inventory-audit-scope.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "repositories", "dods"],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "repositories": {
+      "type": "array",
+      "minItems": 5,
+      "maxItems": 5,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["repository", "defaultBranch", "fragmentPath", "requiredStatus"],
+        "properties": {
+          "repository": { "enum": ["AquilaXk/easysubway", "AquilaXk/easysubway-backend", "AquilaXk/easysubway-data", "AquilaXk/easysubway-mobile", "AquilaXk/easysubway-platform"] },
+          "defaultBranch": { "const": "main" },
+          "fragmentPath": { "const": "contracts/documentation/documentation-fragment.json" },
+          "requiredStatus": { "const": "ACTIVE" }
+        }
+      }
+    },
+    "dods": {
+      "type": "array",
+      "minItems": 5,
+      "maxItems": 5,
+      "uniqueItems": true,
+      "items": { "enum": ["D01", "D02", "D03", "D04", "D05"] }
+    }
+  }
+}

--- a/contracts/workspaces/hub.json
+++ b/contracts/workspaces/hub.json
@@ -25,5 +25,7 @@
   "cleanCheckoutReproducibilityAuditScope": "../documentation/clean-checkout-reproducibility-audit-scope.json",
   "cleanCheckoutReproducibilityOwnerContractSchema": "../documentation/clean-checkout-reproducibility-owner-contract.schema.json",
   "cleanCheckoutReproducibilityOwnerReceiptSchema": "../documentation/clean-checkout-reproducibility-owner-receipt.schema.json",
-  "cleanCheckoutReproducibilityAuditReportSchema": "../documentation/clean-checkout-reproducibility-audit-report.schema.json"
+  "cleanCheckoutReproducibilityAuditReportSchema": "../documentation/clean-checkout-reproducibility-audit-report.schema.json",
+  "documentationInventoryAuditScope": "../documentation/documentation-inventory-audit-scope.json",
+  "documentationInventoryAuditReportSchema": "../documentation/documentation-inventory-audit-report.schema.json"
 }

--- a/tools/ci/check-contracts.mjs
+++ b/tools/ci/check-contracts.mjs
@@ -9,6 +9,7 @@ import { validateAmendments, validateLedger } from "../repo/issue-migration-ledg
 import { validatePlanDocExecutionScope as validatePlanDocExecutionAuditInventory } from "../repo/audit-plan-doc-execution.mjs";
 import { validateExternalTerminalLocatorScope as validateExternalTerminalLocatorAuditInventory } from "../repo/audit-external-terminal-locators.mjs";
 import { validateCleanCheckoutReproducibilityScope as validateCleanCheckoutReproducibilityAuditInventory } from "../repo/audit-clean-checkout-reproducibility.mjs";
+import { validateDocumentationInventoryAuditScope as validateDocumentationInventoryAuditInventory } from "../repo/audit-documentation-inventory.mjs";
 import { validateSchema } from "./lib/json-schema-lite.mjs";
 import { codepointCompare } from "../lib/codepoint-compare.mjs";
 import { isDeepStrictEqual } from "node:util";
@@ -101,6 +102,8 @@ export function loadWorkspace(workspacePath = DEFAULT_WORKSPACE_PATH) {
     cleanCheckoutReproducibilityOwnerContractSchema: workspace.cleanCheckoutReproducibilityOwnerContractSchema == null ? null : resolveWorkspacePath(workspace.cleanCheckoutReproducibilityOwnerContractSchema),
     cleanCheckoutReproducibilityOwnerReceiptSchema: workspace.cleanCheckoutReproducibilityOwnerReceiptSchema == null ? null : resolveWorkspacePath(workspace.cleanCheckoutReproducibilityOwnerReceiptSchema),
     cleanCheckoutReproducibilityAuditReportSchema: workspace.cleanCheckoutReproducibilityAuditReportSchema == null ? null : resolveWorkspacePath(workspace.cleanCheckoutReproducibilityAuditReportSchema),
+    documentationInventoryAuditScope: workspace.documentationInventoryAuditScope == null ? null : resolveWorkspacePath(workspace.documentationInventoryAuditScope),
+    documentationInventoryAuditReportSchema: workspace.documentationInventoryAuditReportSchema == null ? null : resolveWorkspacePath(workspace.documentationInventoryAuditReportSchema),
   };
 }
 
@@ -250,6 +253,16 @@ export function collectContractErrors(
           } catch { errors.push(`${path}: 유효한 JSON이 필요하다`); }
         }
       }
+    }
+  }
+  const documentationInventoryAuditEntries = [workspace.documentationInventoryAuditScope, workspace.documentationInventoryAuditReportSchema];
+  if (documentationInventoryAuditEntries.some((entry) => entry != null)) {
+    if (documentationInventoryAuditEntries.some((entry) => entry == null)) errors.push("documentation inventory audit workspace entries는 함께 필요하다");
+    else {
+      const scopeValid = validateJson(contract("documentation/documentation-inventory-audit-scope.schema.json"), workspace.documentationInventoryAuditScope, errors);
+      if (scopeValid) errors.push(...validateDocumentationInventoryAuditInventory(loadJson(workspace.documentationInventoryAuditScope)).map((error) => `${workspace.documentationInventoryAuditScope}: ${error}`));
+      if (!existsSync(workspace.documentationInventoryAuditReportSchema)) errors.push(`${workspace.documentationInventoryAuditReportSchema} 누락`);
+      else { try { validateDocumentationInventoryAuditReportSchema(loadJson(workspace.documentationInventoryAuditReportSchema), errors, workspace.documentationInventoryAuditReportSchema); } catch { errors.push(`${workspace.documentationInventoryAuditReportSchema}: 유효한 JSON이 필요하다`); } }
     }
   }
   let currentArchitectureDecisions = [];
@@ -895,6 +908,27 @@ export function validatePlanDocExecutionAuditReportSchema(schema, errors = [], p
   if (JSON.stringify(record?.required) !== JSON.stringify(["kind", "issueNumber", "prNumber", "repository", "mergeSha", "changedFiles"]) || JSON.stringify(finding?.required) !== JSON.stringify(["code", "identity"]) || JSON.stringify(incomplete?.required) !== JSON.stringify(["stage", "code", "affectedIdentity"])) errors.push(`${path}: records/findings/incomplete exact required lists가 필요하다`);
   const parity = schema?.oneOf;
   if (!Array.isArray(parity) || parity.length !== 2 || parity[0]?.properties?.status?.const !== "COMPLETE" || parity[0]?.properties?.incomplete?.maxItems !== 0 || parity[1]?.properties?.status?.const !== "AUDIT_INCOMPLETE" || parity[1]?.properties?.incomplete?.minItems !== 1) errors.push(`${path}: incomplete fail-closed parity가 필요하다`);
+  return errors;
+}
+
+export function validateDocumentationInventoryAuditReportSchema(schema, errors = [], path = "documentation-inventory-audit-report.schema") {
+  const repositories = ["AquilaXk/easysubway", "AquilaXk/easysubway-backend", "AquilaXk/easysubway-data", "AquilaXk/easysubway-mobile", "AquilaXk/easysubway-platform"];
+  const dods = ["D01", "D02", "D03", "D04", "D05"];
+  const p = schema?.properties;
+  const strictObject = (value, required) => value?.type === "object" && value?.additionalProperties === false && JSON.stringify(value?.required) === JSON.stringify(required);
+  const inputRequired = ["sourceSha", "scopeSha256", "stateBeginSha256", "stateEndSha256"];
+  const summaryRequired = ["pending", "ready", "activeResources", "findings", "incomplete"];
+  const repositoryRequired = ["repository", "headSha", "state", "fragmentStatus", "fragmentBlobSha", "resourceCount", "activeResourceCount"];
+  if (!strictObject(schema, ["schemaVersion", "status", "observedAt", "inputs", "summary", "repositories", "dods", "findings", "incomplete"]) || p?.schemaVersion?.const !== 1 || JSON.stringify(p?.status?.enum) !== JSON.stringify(["COMPLETE", "AUDIT_INCOMPLETE"])) errors.push(`${path}: strict report root가 필요하다`);
+  if (!strictObject(p?.inputs, inputRequired) || p?.inputs?.properties?.sourceSha?.pattern !== "^[0-9a-f]{40}$" || p?.inputs?.properties?.scopeSha256?.pattern !== "^[0-9a-f]{64}$" || !["stateBeginSha256", "stateEndSha256"].every((key) => JSON.stringify(p?.inputs?.properties?.[key]?.type) === JSON.stringify(["string", "null"]) && p.inputs.properties[key]?.pattern === "^[0-9a-f]{64}$")) errors.push(`${path}: immutable input watermark schema가 필요하다`);
+  if (!strictObject(p?.summary, summaryRequired) || !summaryRequired.every((key) => p?.summary?.properties?.[key]?.type === "integer" && p.summary.properties[key]?.minimum === 0)) errors.push(`${path}: strict summary schema가 필요하다`);
+  const repository = p?.repositories?.items;
+  if (p?.repositories?.type !== "array" || p?.repositories?.minItems !== 5 || p?.repositories?.maxItems !== 5 || p?.repositories?.uniqueItems !== true || !strictObject(repository, repositoryRequired) || JSON.stringify(repository?.properties?.repository?.enum) !== JSON.stringify(repositories) || JSON.stringify(repository?.properties?.state?.enum) !== JSON.stringify(["PENDING", "READY", "UNAVAILABLE"]) || !["resourceCount", "activeResourceCount"].every((key) => repository?.properties?.[key]?.type === "integer" && repository.properties[key]?.minimum === 0)) errors.push(`${path}: strict five-repository result schema가 필요하다`);
+  const dod = p?.dods?.items;
+  if (p?.dods?.minItems !== 5 || p?.dods?.maxItems !== 5 || p?.dods?.uniqueItems !== true || !strictObject(dod, ["id", "status", "findings"]) || JSON.stringify(dod?.properties?.id?.enum) !== JSON.stringify(dods) || JSON.stringify(dod?.properties?.status?.enum) !== JSON.stringify(["PENDING", "PROVEN", "CONTRADICTED", "INCOMPLETE"])) errors.push(`${path}: strict D01-D05 result schema가 필요하다`);
+  if (p?.findings?.uniqueItems !== true || !strictObject(p?.findings?.items, ["dod", "code", "identity"]) || p?.incomplete?.uniqueItems !== true || !strictObject(p?.incomplete?.items, ["stage", "code", "affectedIdentity"])) errors.push(`${path}: strict finding/incomplete schema가 필요하다`);
+  const parity = schema?.oneOf;
+  if (!Array.isArray(parity) || parity.length !== 2 || parity[0]?.properties?.status?.const !== "COMPLETE" || parity[0]?.properties?.inputs?.properties?.stateBeginSha256?.type !== "string" || parity[0]?.properties?.inputs?.properties?.stateEndSha256?.type !== "string" || parity[0]?.properties?.incomplete?.maxItems !== 0 || parity[1]?.properties?.status?.const !== "AUDIT_INCOMPLETE" || parity[1]?.properties?.incomplete?.minItems !== 1) errors.push(`${path}: fail-closed status parity가 필요하다`);
   return errors;
 }
 

--- a/tools/ci/check-contracts.test.mjs
+++ b/tools/ci/check-contracts.test.mjs
@@ -34,6 +34,7 @@ import {
   validatePublicSensitivityAuditReportSchema,
   validatePlanDocExecutionAuditScope,
   validatePlanDocExecutionAuditReportSchema,
+  validateDocumentationInventoryAuditReportSchema,
   validateExternalTerminalLocatorAuditScope,
   validateExternalTerminalLocatorAuditReportSchema,
   validateCleanCheckoutReproducibilityAuditScope,
@@ -45,6 +46,32 @@ import {
   validatePostGoBoundaryAuditReportSchema,
 } from "./check-contracts.mjs";
 import { validateSchema } from "./lib/json-schema-lite.mjs";
+import { validateDocumentationInventoryAuditScope } from "../repo/audit-documentation-inventory.mjs";
+
+test("documentation inventory audit contracts bind the exact five repositories and D01-D05", () => {
+  const scope = loadJson("contracts/documentation/documentation-inventory-audit-scope.json");
+  const scopeSchema = loadJson("contracts/documentation/documentation-inventory-audit-scope.schema.json");
+  const reportSchema = loadJson("contracts/documentation/documentation-inventory-audit-report.schema.json");
+  const workspace = loadWorkspace();
+  assert.equal(workspace.documentationInventoryAuditScope, "contracts/documentation/documentation-inventory-audit-scope.json");
+  assert.equal(workspace.documentationInventoryAuditReportSchema, "contracts/documentation/documentation-inventory-audit-report.schema.json");
+  assert.equal(validateSchema(scopeSchema, scope).ok, true);
+  assert.deepEqual(validateDocumentationInventoryAuditScope(scope), []);
+  assert.deepEqual(validateDocumentationInventoryAuditReportSchema(reportSchema), []);
+  for (const mutate of [
+    (value) => value.repositories.reverse(),
+    (value) => { value.repositories[0].fragmentPath = "../fragment.json"; },
+    (value) => value.dods.pop(),
+  ]) { const invalid = structuredClone(scope); mutate(invalid); assert.ok(validateDocumentationInventoryAuditScope(invalid).length > 0); }
+  for (const mutate of [
+    (value) => { value.properties.status.enum = ["COMPLETE"]; },
+    (value) => { value.properties.summary.required.pop(); },
+    (value) => { value.properties.repositories.maxItems = 6; },
+    (value) => { value.properties.repositories.items.required.pop(); },
+    (value) => { value.properties.dods.items.properties.id.enum.pop(); },
+    (value) => { value.oneOf[0].properties.incomplete.maxItems = 1; },
+  ]) { const invalid = structuredClone(reportSchema); mutate(invalid); assert.ok(validateDocumentationInventoryAuditReportSchema(invalid).length > 0); }
+});
 
 test("reference audit scope requires the exact five-repository inventory", () => {
   const errors = [];

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -21053,6 +21053,40 @@ test("plan-doc execution audit workflow binds merged source SHA to a write-once 
   assert.doesNotMatch(workflow, /continue-on-error|uses:\s*actions\/cache@|git (?:add|commit|push)/i);
 });
 
+test("Documentation Inventory Audit workflow binds main SHA to the exact five-fragment report", () => {
+  const workflow = read(".github/workflows/documentation-inventory-audit.yml");
+  assert.match(workflow, /^name: Documentation Inventory Audit$/m);
+  assert.match(workflow, /^on:\n  push:\n    branches: \[main\]$/m);
+  assert.doesNotMatch(workflow, /^\s+paths:/m);
+  assert.match(workflow, /^permissions: \{\}$/m);
+  assert.match(workflow, /^concurrency:\n  group: documentation-inventory-audit-\$\{\{ github\.ref \}\}\n  cancel-in-progress: false$/m);
+  assert.match(workflow, /permissions:\n      contents: read/);
+  assert.match(workflow, /actions\/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd/);
+  assert.match(workflow, /ref: \$\{\{ github\.sha \}\}/);
+  assert.match(workflow, /persist-credentials: false/);
+  assert.match(workflow, /actions\/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e/);
+  assert.match(workflow, /node-version: "24"/);
+  assert.match(workflow, /set -euo pipefail/);
+  assert.match(workflow, /rm --recursive --force -- "\$\{EVIDENCE_DIR\}"\n          mkdir --parents -- "\$\{EVIDENCE_DIR\}"\n          test ! -e "\$\{REPORT_PATH\}"/);
+  for (const input of [
+    "tools/repo/audit-documentation-inventory.mjs",
+    "--scope contracts/documentation/documentation-inventory-audit-scope.json",
+    "--scope-schema contracts/documentation/documentation-inventory-audit-scope.schema.json",
+    "--report-schema contracts/documentation/documentation-inventory-audit-report.schema.json",
+    "--source-sha \"${GITHUB_SHA}\"",
+    "--observed-at \"${OBSERVED_AT}\"",
+    "--output \"${REPORT_PATH}\"",
+  ]) assert.match(workflow, new RegExp(input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  assert.match(workflow, /if: \$\{\{ always\(\) \}\}/);
+  assert.match(workflow, /actions\/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02/);
+  assert.match(workflow, /name: documentation-inventory-audit-\$\{\{ github\.sha \}\}/);
+  assert.match(workflow, /path: audit-evidence\/documentation-inventory-audit-report\.json/);
+  assert.match(workflow, /if-no-files-found: error/);
+  assert.match(workflow, /include-hidden-files: false/);
+  assert.match(workflow, /retention-days: 14/);
+  assert.doesNotMatch(workflow, /secrets:|secrets\.|inherit|continue-on-error|actions\/cache|previous report|git (?:add|commit|push)/i);
+});
+
 test("post-GO boundary audit workflow pins merged SHA, write-once report, and always upload", () => {
   const workflow = read(".github/workflows/post-go-boundary-audit.yml");
   assert.match(workflow, /^on:\n  push:\n    branches: \[main\]/m);

--- a/tools/repo/audit-documentation-inventory.mjs
+++ b/tools/repo/audit-documentation-inventory.mjs
@@ -40,11 +40,11 @@ const fallbackScope = () => ({ schemaVersion: 1, repositories: EXPECTED_REPOSITO
 
 export function validateDocumentationInventoryAuditScope(scope, errors = []) {
   if (scope?.schemaVersion !== 1 || !Array.isArray(scope.repositories) || !Array.isArray(scope.dods)) return [...errors, "scope shape mismatch"];
-  const repositories = scope.repositories.map(({ repository }) => repository);
+  const repositories = scope.repositories.map((entry) => entry != null && typeof entry === "object" && !Array.isArray(entry) ? entry.repository : null);
   if (JSON.stringify(repositories) !== JSON.stringify(EXPECTED_REPOSITORIES)) errors.push("repository inventory mismatch");
   if (JSON.stringify(scope.dods) !== JSON.stringify(EXPECTED_DODS)) errors.push("DoD inventory mismatch");
   for (const entry of scope.repositories) {
-    if (!exactKeys(entry, ["repository", "defaultBranch", "fragmentPath", "requiredStatus"]) || entry.defaultBranch !== "main" || entry.fragmentPath !== FRAGMENT_PATH || !safePath(entry.fragmentPath) || entry.requiredStatus !== "ACTIVE") errors.push(`repository contract mismatch:${entry?.repository ?? "unknown"}`);
+    if (entry == null || typeof entry !== "object" || Array.isArray(entry) || !exactKeys(entry, ["repository", "defaultBranch", "fragmentPath", "requiredStatus"]) || entry.defaultBranch !== "main" || entry.fragmentPath !== FRAGMENT_PATH || !safePath(entry.fragmentPath) || entry.requiredStatus !== "ACTIVE") errors.push(`repository contract mismatch:${entry?.repository ?? "unknown"}`);
   }
   return errors;
 }
@@ -214,7 +214,19 @@ export async function collectContent(repository, path, sha, runGh = gh) {
   return providerJson(await runGh(["api", `repos/${repository}/contents/${path}?ref=${sha}`]), `${repository}:${path}`);
 }
 
-export async function gh(args, execute = execFileAsync) {
+function includedGitHubResponse(stdout) {
+  const text = String(stdout ?? "");
+  const status = Number(/^HTTP\/\S+ ([0-9]{3})(?: [^\r\n]*)?$/m.exec(text)?.[1]);
+  const crlfBoundary = text.indexOf("\r\n\r\n");
+  const lfBoundary = text.indexOf("\n\n");
+  const boundary = crlfBoundary >= 0 && (lfBoundary < 0 || crlfBoundary <= lfBoundary) ? crlfBoundary : lfBoundary;
+  const separatorLength = boundary === crlfBoundary ? 4 : 2;
+  return { status: Number.isInteger(status) ? status : null, body: boundary >= 0 ? text.slice(boundary + separatorLength) : "" };
+}
+
+const wait = (delay) => new Promise((resolve) => setTimeout(resolve, delay));
+
+export async function gh(args, execute = execFileAsync, pause = wait) {
   const endpoint = args?.[1];
   const repositories = "AquilaXk/easysubway(?:-(?:backend|data|mobile|platform))?";
   const allowed = new RegExp(`^repos/${repositories}(?:/git/ref/heads/main|/contents/[A-Za-z0-9][A-Za-z0-9._/-]*\\?ref=[0-9a-f]{40})$`);
@@ -224,11 +236,22 @@ export async function gh(args, execute = execFileAsync) {
     const refIndex = endpoint.indexOf("?ref=", contentIndex);
     if (refIndex < 0 || !safePath(endpoint.slice(contentIndex + "/contents/".length, refIndex))) throw new Error("gh read-only allowlist violation");
   }
-  try { return (await execute("gh", args, { encoding: "utf8", timeout: 30_000, killSignal: "SIGTERM", maxBuffer: 8 * 1024 * 1024 })).stdout; }
-  catch (error) {
-    if (/(?:^|\D)HTTP 404(?:\D|$)/.test(String(error?.stderr ?? ""))) throw Object.assign(new Error("not found"), { status: 404 });
-    throw error;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      const result = await execute("gh", ["api", "--include", endpoint], { encoding: "utf8", timeout: 30_000, killSignal: "SIGTERM", maxBuffer: 8 * 1024 * 1024 });
+      const response = includedGitHubResponse(result.stdout);
+      if (response.status != null && response.status >= 200 && response.status < 300) return response.body;
+      throw Object.assign(new Error("GitHub API response invalid"), { status: response.status, stdout: result.stdout, stderr: result.stderr });
+    } catch (error) {
+      const response = includedGitHubResponse(error?.stdout);
+      const status = Number.isInteger(error?.status) ? error.status : response.status;
+      if (status === 404) throw Object.assign(new Error("not found"), { status });
+      const transient = status == null || status === 429 || status >= 500;
+      if (!transient || attempt === 2) throw error;
+      await pause(250 * (2 ** attempt));
+    }
   }
+  throw new Error("GitHub API retry exhausted");
 }
 
 function parseArguments(argv) {

--- a/tools/repo/audit-documentation-inventory.mjs
+++ b/tools/repo/audit-documentation-inventory.mjs
@@ -1,0 +1,300 @@
+#!/usr/bin/env node
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { open, readFile } from "node:fs/promises";
+import { promisify } from "node:util";
+import { codepointCompare } from "../lib/codepoint-compare.mjs";
+import { isMainModule } from "../lib/is-main-module.mjs";
+import { validateSchema } from "../ci/lib/json-schema-lite.mjs";
+import { validateDocumentationRecord, validateDocumentationRelations } from "../ci/documentation-inventory.mjs";
+
+const EXPECTED_REPOSITORIES = [
+  "AquilaXk/easysubway",
+  "AquilaXk/easysubway-backend",
+  "AquilaXk/easysubway-data",
+  "AquilaXk/easysubway-mobile",
+  "AquilaXk/easysubway-platform",
+];
+const EXPECTED_DODS = ["D01", "D02", "D03", "D04", "D05"];
+const FRAGMENT_PATH = "contracts/documentation/documentation-fragment.json";
+const SHA = /^[0-9a-f]{40}$/;
+const DIGEST = /^[0-9a-f]{64}$/;
+const execFileAsync = promisify(execFile);
+const FRAGMENT_SCHEMA = JSON.parse(await readFile(new URL("../../contracts/documentation/documentation-fragment.schema.json", import.meta.url), "utf8"));
+const RESOURCE_SCHEMA = JSON.parse(await readFile(new URL("../../contracts/documentation/documentation-resource.schema.json", import.meta.url), "utf8"));
+
+export class AuditIncomplete extends Error {
+  constructor(code, identity, stage = "provider") {
+    super(code);
+    this.code = code;
+    this.identity = identity;
+    this.stage = stage;
+  }
+}
+
+const sha256 = (value) => createHash("sha256").update(value).digest("hex");
+const canonicalUtc = (value) => typeof value === "string" && /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(value) && Number.isFinite(Date.parse(value)) && new Date(value).toISOString() === value;
+const exactKeys = (value, keys) => value != null && typeof value === "object" && !Array.isArray(value) && Object.keys(value).length === keys.length && keys.every((key) => Object.hasOwn(value, key));
+const safePath = (value) => typeof value === "string" && /^(?!\/)(?!.*(?:^|\/)\.{1,2}(?:\/|$))(?!.*[?#])[A-Za-z0-9][A-Za-z0-9._/-]*$/.test(value);
+const fallbackScope = () => ({ schemaVersion: 1, repositories: EXPECTED_REPOSITORIES.map((repository) => ({ repository, defaultBranch: "main", fragmentPath: FRAGMENT_PATH, requiredStatus: "ACTIVE" })), dods: [...EXPECTED_DODS] });
+
+export function validateDocumentationInventoryAuditScope(scope, errors = []) {
+  if (scope?.schemaVersion !== 1 || !Array.isArray(scope.repositories) || !Array.isArray(scope.dods)) return [...errors, "scope shape mismatch"];
+  const repositories = scope.repositories.map(({ repository }) => repository);
+  if (JSON.stringify(repositories) !== JSON.stringify(EXPECTED_REPOSITORIES)) errors.push("repository inventory mismatch");
+  if (JSON.stringify(scope.dods) !== JSON.stringify(EXPECTED_DODS)) errors.push("DoD inventory mismatch");
+  for (const entry of scope.repositories) {
+    if (!exactKeys(entry, ["repository", "defaultBranch", "fragmentPath", "requiredStatus"]) || entry.defaultBranch !== "main" || entry.fragmentPath !== FRAGMENT_PATH || !safePath(entry.fragmentPath) || entry.requiredStatus !== "ACTIVE") errors.push(`repository contract mismatch:${entry?.repository ?? "unknown"}`);
+  }
+  return errors;
+}
+
+function decodeBase64(value, identity) {
+  if (typeof value !== "string") throw new AuditIncomplete("FRAGMENT_DECODE_INVALID", identity, "fragment");
+  const normalized = value.replace(/\s/g, "");
+  if (normalized.length === 0 || normalized.length % 4 !== 0 || !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(normalized)) throw new AuditIncomplete("FRAGMENT_DECODE_INVALID", identity, "fragment");
+  const bytes = Buffer.from(normalized, "base64");
+  if (bytes.toString("base64") !== normalized) throw new AuditIncomplete("FRAGMENT_DECODE_INVALID", identity, "fragment");
+  return bytes;
+}
+
+function parseJson(bytes, identity) {
+  try { return JSON.parse(bytes.toString("utf8")); } catch { throw new AuditIncomplete("FRAGMENT_JSON_INVALID", identity, "fragment"); }
+}
+
+function validateFragment(fragment, entry, headSha) {
+  const errors = validateSchema(FRAGMENT_SCHEMA, fragment).errors;
+  if (errors.length !== 0) throw new AuditIncomplete("FRAGMENT_SCHEMA_INVALID", entry.repository, "fragment");
+  if (fragment.repository !== entry.repository || fragment.gitSha !== headSha) throw new AuditIncomplete("FRAGMENT_HEAD_MISMATCH", entry.repository, "fragment");
+  if (fragment.status === "ACTIVE" && (fragment.verificationEvidence.length === 0 || !canonicalUtc(fragment.lastVerifiedAt))) throw new AuditIncomplete("FRAGMENT_SEMANTIC_INVALID", entry.repository, "fragment");
+  const resourceIds = fragment.resources.map(({ resource }) => resource);
+  if (resourceIds.some((resource) => typeof resource !== "string") || JSON.stringify(resourceIds) !== JSON.stringify([...new Set(resourceIds)].sort(codepointCompare))) throw new AuditIncomplete("FRAGMENT_SEMANTIC_INVALID", entry.repository, "fragment");
+  for (const record of fragment.resources) {
+    if (!validateSchema(RESOURCE_SCHEMA, record).ok) throw new AuditIncomplete("RESOURCE_SCHEMA_INVALID", entry.repository, "fragment");
+    try { validateDocumentationRecord(record, { ownerRepository: entry.repository, gitSha: headSha, tracked: record.sourceSurface === "TRACKED" }); }
+    catch { throw new AuditIncomplete("RESOURCE_SEMANTIC_INVALID", entry.repository, "fragment"); }
+  }
+}
+
+function trackedIdentity(record) {
+  return /^git:([0-9a-f]{40}):([^:]+):([0-9a-f]{40}|[0-9a-f]{64})$/.exec(record.canonicalIdentity);
+}
+
+export async function verifyFragment(entry, headSha, { readContent = collectContent } = {}) {
+  let content;
+  try { content = await readContent(entry.repository, entry.fragmentPath, headSha); }
+  catch (error) {
+    if (error?.status === 404) return { repository: entry.repository, headSha, state: "PENDING", fragmentStatus: "MISSING", fragmentBlobSha: null, fragment: null, resourceCount: 0, activeResourceCount: 0, verificationFindings: [] };
+    throw error instanceof AuditIncomplete ? error : new AuditIncomplete("PROVIDER_UNAVAILABLE", entry.repository);
+  }
+  if (content?.type !== "file" || !SHA.test(content?.sha) || content?.encoding !== "base64") throw new AuditIncomplete("FRAGMENT_PROVIDER_MALFORMED", entry.repository, "fragment");
+  const fragment = parseJson(decodeBase64(content.content, entry.repository), entry.repository);
+  validateFragment(fragment, entry, headSha);
+  if (fragment.status !== entry.requiredStatus) return { repository: entry.repository, headSha, state: "PENDING", fragmentStatus: fragment.status, fragmentBlobSha: content.sha, fragment: null, resourceCount: 0, activeResourceCount: 0, verificationFindings: [] };
+  const verificationFindings = [];
+  for (const record of fragment.resources.filter(({ sourceSurface }) => sourceSurface === "TRACKED")) {
+    const identity = trackedIdentity(record);
+    if (identity == null || identity[1] !== headSha) throw new AuditIncomplete("RESOURCE_IDENTITY_INVALID", record.resource, "fragment");
+    let tracked;
+    try { tracked = await readContent(entry.repository, identity[2], headSha); }
+    catch (error) {
+      if (error?.status === 404) { verificationFindings.push({ dod: "D01", code: "TRACKED_RESOURCE_MISSING", identity: record.resource }); continue; }
+      throw error instanceof AuditIncomplete ? error : new AuditIncomplete("PROVIDER_UNAVAILABLE", record.resource);
+    }
+    if (tracked?.type !== "file" || !SHA.test(tracked?.sha) || tracked?.encoding !== "base64") throw new AuditIncomplete("RESOURCE_PROVIDER_MALFORMED", record.resource, "fragment");
+    const bytes = decodeBase64(tracked.content, record.resource);
+    const actual = identity[3].length === 40 ? tracked.sha : sha256(bytes);
+    if (actual !== identity[3]) verificationFindings.push({ dod: "D01", code: "TRACKED_RESOURCE_BLOB_MISMATCH", identity: record.resource });
+  }
+  return { repository: entry.repository, headSha, state: "READY", fragmentStatus: "ACTIVE", fragmentBlobSha: content.sha, fragment, resourceCount: fragment.resources.length, activeResourceCount: fragment.resources.filter(({ status }) => status === "ACTIVE").length, verificationFindings };
+}
+
+function findingCompare(left, right) { return codepointCompare(`${left.dod}\0${left.code}\0${left.identity}`, `${right.dod}\0${right.code}\0${right.identity}`); }
+
+function repositoryParity(scope, repositories) {
+  const actual = repositories.map(({ repository }) => repository);
+  if (JSON.stringify(actual) !== JSON.stringify(scope.repositories.map(({ repository }) => repository))) throw new AuditIncomplete("REPOSITORY_RESULT_IDENTITY", "repositories", "audit");
+}
+
+export function auditDocumentationInventory({ scope, sourceSha, observedAt, repositories, stateBeginSha256 = null, stateEndSha256 = null, scopeText = JSON.stringify(scope) }) {
+  repositoryParity(scope, repositories);
+  const findings = repositories.flatMap(({ verificationFindings = [] }) => verificationFindings);
+  const readyEntries = repositories.filter(({ state }) => state === "READY");
+  const pending = repositories.length - readyEntries.length;
+  const records = readyEntries.flatMap(({ fragment }) => fragment?.resources ?? []);
+  if (pending === 0) {
+    for (const entry of readyEntries) if ((entry.fragment?.resources.length ?? 0) === 0) findings.push({ dod: "D01", code: "ACTIVE_CLASSIFICATION_EMPTY", identity: entry.repository });
+    for (const record of records.filter(({ status, ownerIssue }) => status === "ACTIVE" && ownerIssue === null)) findings.push({ dod: "D02", code: "ACTIVE_OWNER_ISSUE_MISSING", identity: record.resource });
+    const resourceIds = records.map(({ resource }) => resource);
+    for (const resource of [...new Set(resourceIds.filter((value, index) => resourceIds.indexOf(value) !== index))].sort(codepointCompare)) findings.push({ dod: "D03", code: "RESOURCE_ID_DUPLICATE", identity: resource });
+    const groups = new Map();
+    for (const record of records.filter(({ status, duplicateGroup }) => status === "ACTIVE" && duplicateGroup !== null)) groups.set(record.duplicateGroup, [...(groups.get(record.duplicateGroup) ?? []), record]);
+    for (const [identity, group] of groups) {
+      if (group.length < 2 || group.filter(({ disposition }) => disposition === "RETAIN_CANONICAL").length !== 1) findings.push({ dod: "D03", code: "DUPLICATE_CANONICAL_COUNT", identity });
+      else if (group.some((record) => record.currentConsumers.length === 0 || record.disposition !== "RETAIN_CANONICAL" && record.deletePrerequisite.length === 0)) findings.push({ dod: "D03", code: "DUPLICATE_HANDOFF_INCOMPLETE", identity });
+    }
+    if (!findings.some(({ dod }) => dod === "D03")) {
+      try { validateDocumentationRelations(records); } catch { findings.push({ dod: "D03", code: "AGGREGATE_RELATION_INVALID", identity: "five-fragment-aggregate" }); }
+    }
+    for (const record of records.filter(({ ownerRepository, status, implementationPlan }) => ownerRepository === "AquilaXk/easysubway" && status === "ACTIVE" && implementationPlan !== "PLAN-DOC")) findings.push({ dod: "D05", code: "HUB_TARGET_PLAN_ACTIVE_COPY", identity: record.resource });
+  }
+  findings.sort(findingCompare);
+  const dods = scope.dods.map((id) => {
+    const count = findings.filter(({ dod }) => dod === id).length;
+    return { id, status: pending > 0 ? "PENDING" : count === 0 ? "PROVEN" : "CONTRADICTED", findings: count };
+  });
+  return {
+    schemaVersion: 1,
+    status: "COMPLETE",
+    observedAt,
+    inputs: { sourceSha, scopeSha256: sha256(scopeText), stateBeginSha256, stateEndSha256 },
+    summary: { pending, ready: readyEntries.length, activeResources: records.filter(({ status }) => status === "ACTIVE").length, findings: findings.length, incomplete: 0 },
+    repositories: repositories.map(({ repository, headSha, state, fragmentStatus, fragmentBlobSha, resourceCount, activeResourceCount }) => ({ repository, headSha, state, fragmentStatus, fragmentBlobSha, resourceCount, activeResourceCount })),
+    dods,
+    findings,
+    incomplete: [],
+  };
+}
+
+export function validateDocumentationInventoryAuditReport(report, errors = []) {
+  if (report?.schemaVersion !== 1 || !canonicalUtc(report?.observedAt) || !["COMPLETE", "AUDIT_INCOMPLETE"].includes(report?.status)) return [...errors, "report shape mismatch"];
+  if (!Array.isArray(report.repositories) || !Array.isArray(report.dods) || !Array.isArray(report.findings) || !Array.isArray(report.incomplete)) return [...errors, "report collection mismatch"];
+  if (JSON.stringify(report.repositories.map(({ repository }) => repository)) !== JSON.stringify(EXPECTED_REPOSITORIES)) errors.push("repository parity mismatch");
+  if (JSON.stringify(report.dods.map(({ id }) => id)) !== JSON.stringify(EXPECTED_DODS)) errors.push("DoD parity mismatch");
+  const pending = report.repositories.filter(({ state }) => state !== "READY").length;
+  const ready = report.repositories.length - pending;
+  const activeResources = report.repositories.filter(({ state }) => state === "READY").reduce((sum, { activeResourceCount }) => sum + activeResourceCount, 0);
+  if (report.summary?.pending !== pending || report.summary?.ready !== ready || report.summary?.activeResources !== activeResources || report.summary?.findings !== report.findings.length || report.summary?.incomplete !== report.incomplete.length) errors.push("summary parity mismatch");
+  for (const dod of report.dods) {
+    const count = report.findings.filter(({ dod: id }) => id === dod.id).length;
+    const expected = report.status === "AUDIT_INCOMPLETE" ? "INCOMPLETE" : pending > 0 ? "PENDING" : count === 0 ? "PROVEN" : "CONTRADICTED";
+    if (dod.findings !== count || dod.status !== expected) errors.push(`DoD status mismatch:${dod.id}`);
+  }
+  if (report.status === "COMPLETE" && (report.incomplete.length !== 0 || !DIGEST.test(report.inputs?.stateBeginSha256) || report.inputs.stateBeginSha256 !== report.inputs.stateEndSha256)) errors.push("complete watermark mismatch");
+  if (report.status === "AUDIT_INCOMPLETE" && report.incomplete.length === 0) errors.push("incomplete detail missing");
+  const hub = report.repositories.find(({ repository }) => repository === "AquilaXk/easysubway");
+  if (report.status === "COMPLETE" && hub?.headSha !== report.inputs?.sourceSha) errors.push("source identity mismatch");
+  return errors;
+}
+
+function snapshotWatermark(repositories) {
+  return sha256(JSON.stringify(repositories.map(({ repository, headSha, state, fragmentStatus, fragmentBlobSha, resourceCount, activeResourceCount, verificationFindings = [] }) => ({ repository, headSha, state, fragmentStatus, fragmentBlobSha, resourceCount, activeResourceCount, verificationFindings }))));
+}
+
+export async function collectSnapshot(scope, { readHead = collectHead, readContent = collectContent } = {}) {
+  const repositories = [];
+  for (const entry of scope.repositories) {
+    const headSha = await readHead(entry.repository, entry.defaultBranch);
+    if (!SHA.test(headSha)) throw new AuditIncomplete("HEAD_PROVIDER_MALFORMED", entry.repository);
+    repositories.push(await verifyFragment(entry, headSha, { readContent }));
+  }
+  return { repositories, watermark: snapshotWatermark(repositories) };
+}
+
+export async function collectLive(scope, { sourceSha, collectSnapshot: snapshot = () => collectSnapshot(scope) } = {}) {
+  const begin = await snapshot();
+  const end = await snapshot();
+  const beginHub = begin.repositories.find(({ repository }) => repository === "AquilaXk/easysubway")?.headSha;
+  const endHub = end.repositories.find(({ repository }) => repository === "AquilaXk/easysubway")?.headSha;
+  if (beginHub !== sourceSha || endHub !== sourceSha || begin.watermark !== end.watermark) throw new AuditIncomplete("STATE_WATERMARK_DRIFT", "five-fragment-state", "watermark");
+  return { repositories: begin.repositories, stateBeginSha256: begin.watermark, stateEndSha256: end.watermark };
+}
+
+function providerJson(text, identity) {
+  try { return JSON.parse(text); } catch { throw new AuditIncomplete("PROVIDER_MALFORMED", identity); }
+}
+
+export async function collectHead(repository, branch = "main", runGh = gh) {
+  const ref = providerJson(await runGh(["api", `repos/${repository}/git/ref/heads/${branch}`]), repository);
+  if (!SHA.test(ref?.object?.sha)) throw new AuditIncomplete("HEAD_PROVIDER_MALFORMED", repository);
+  return ref.object.sha;
+}
+
+export async function collectContent(repository, path, sha, runGh = gh) {
+  return providerJson(await runGh(["api", `repos/${repository}/contents/${path}?ref=${sha}`]), `${repository}:${path}`);
+}
+
+export async function gh(args, execute = execFileAsync) {
+  const endpoint = args?.[1];
+  const repositories = "AquilaXk/easysubway(?:-(?:backend|data|mobile|platform))?";
+  const allowed = new RegExp(`^repos/${repositories}(?:/git/ref/heads/main|/contents/[A-Za-z0-9][A-Za-z0-9._/-]*\\?ref=[0-9a-f]{40})$`);
+  if (args?.length !== 2 || args[0] !== "api" || typeof endpoint !== "string" || !allowed.test(endpoint)) throw new Error("gh read-only allowlist violation");
+  const contentIndex = endpoint.indexOf("/contents/");
+  if (contentIndex >= 0) {
+    const refIndex = endpoint.indexOf("?ref=", contentIndex);
+    if (refIndex < 0 || !safePath(endpoint.slice(contentIndex + "/contents/".length, refIndex))) throw new Error("gh read-only allowlist violation");
+  }
+  try { return (await execute("gh", args, { encoding: "utf8", timeout: 30_000, killSignal: "SIGTERM", maxBuffer: 8 * 1024 * 1024 })).stdout; }
+  catch (error) {
+    if (/(?:^|\D)HTTP 404(?:\D|$)/.test(String(error?.stderr ?? ""))) throw Object.assign(new Error("not found"), { status: 404 });
+    throw error;
+  }
+}
+
+function parseArguments(argv) {
+  const names = { "--scope": "scope", "--scope-schema": "scopeSchema", "--report-schema": "reportSchema", "--source-sha": "sourceSha", "--observed-at": "observedAt", "--output": "output" };
+  const result = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = names[argv[index]];
+    if (key == null || argv[index + 1] == null || result[key] != null) throw new Error("unsupported or duplicate argument");
+    result[key] = argv[index + 1];
+  }
+  if (Object.keys(result).length !== Object.keys(names).length || !SHA.test(result.sourceSha) || !canonicalUtc(result.observedAt)) throw new Error("invalid arguments");
+  return result;
+}
+
+function fallbackReport({ sourceSha, observedAt, scope, incomplete }) {
+  return {
+    schemaVersion: 1,
+    status: "AUDIT_INCOMPLETE",
+    observedAt,
+    inputs: { sourceSha, scopeSha256: sha256(JSON.stringify(scope)), stateBeginSha256: null, stateEndSha256: null },
+    summary: { pending: 5, ready: 0, activeResources: 0, findings: 0, incomplete: 1 },
+    repositories: EXPECTED_REPOSITORIES.map((repository) => ({ repository, headSha: null, state: "UNAVAILABLE", fragmentStatus: "UNAVAILABLE", fragmentBlobSha: null, resourceCount: 0, activeResourceCount: 0 })),
+    dods: EXPECTED_DODS.map((id) => ({ id, status: "INCOMPLETE", findings: 0 })),
+    findings: [],
+    incomplete: [incomplete],
+  };
+}
+
+async function writeExclusive(path, report) {
+  const file = await open(path, "wx");
+  try { await file.writeFile(`${JSON.stringify(report, null, 2)}\n`); } finally { await file.close(); }
+}
+
+export async function runAuditCli({ argv = process.argv.slice(2), read = (path) => readFile(path, "utf8"), collect = null } = {}) {
+  let args;
+  let scope = fallbackScope();
+  let reportSchema = null;
+  let report;
+  let exitCode = 2;
+  try {
+    args = parseArguments(argv);
+    const [scopeText, scopeSchemaText, reportSchemaText] = await Promise.all([read(args.scope), read(args.scopeSchema), read(args.reportSchema)]);
+    scope = JSON.parse(scopeText);
+    const scopeSchema = JSON.parse(scopeSchemaText);
+    reportSchema = JSON.parse(reportSchemaText);
+    const scopeErrors = [...validateSchema(scopeSchema, scope).errors, ...validateDocumentationInventoryAuditScope(scope)];
+    if (scopeErrors.length !== 0) throw new AuditIncomplete("SCOPE_INVALID", "scope", "scope");
+    const live = await (collect ?? (() => collectLive(scope, { sourceSha: args.sourceSha })))();
+    report = auditDocumentationInventory({ scope, sourceSha: args.sourceSha, observedAt: args.observedAt, ...live, scopeText });
+    const reportErrors = [...validateSchema(reportSchema, report).errors, ...validateDocumentationInventoryAuditReport(report)];
+    if (reportErrors.length !== 0) throw new AuditIncomplete("REPORT_INVALID", "report", "report");
+    exitCode = report.summary.pending === 0 && report.summary.findings === 0 ? 0 : 1;
+  } catch (error) {
+    const sourceSha = args?.sourceSha ?? argv[argv.indexOf("--source-sha") + 1] ?? "0".repeat(40);
+    const observedAt = args?.observedAt ?? argv[argv.indexOf("--observed-at") + 1] ?? "1970-01-01T00:00:00.000Z";
+    const code = error instanceof AuditIncomplete ? error.code : "AUDIT_INVALID_OR_UNAVAILABLE";
+    const stage = error instanceof AuditIncomplete ? error.stage : "audit";
+    const identity = error instanceof AuditIncomplete ? error.identity : "audit-input";
+    report = fallbackReport({ sourceSha: SHA.test(sourceSha) ? sourceSha : "0".repeat(40), observedAt: canonicalUtc(observedAt) ? observedAt : "1970-01-01T00:00:00.000Z", scope: validateDocumentationInventoryAuditScope(scope).length === 0 ? scope : fallbackScope(), incomplete: { stage, code, affectedIdentity: identity } });
+    if (reportSchema != null && (!validateSchema(reportSchema, report).ok || validateDocumentationInventoryAuditReport(report).length !== 0)) report = fallbackReport({ sourceSha: SHA.test(sourceSha) ? sourceSha : "0".repeat(40), observedAt: canonicalUtc(observedAt) ? observedAt : "1970-01-01T00:00:00.000Z", scope: fallbackScope(), incomplete: { stage: "report", code: "REPORT_SCHEMA_INVALID", affectedIdentity: "report-schema" } });
+  }
+  try { if (args?.output != null) await writeExclusive(args.output, report); } catch { exitCode = 2; return { exitCode, report }; }
+  return { exitCode, report };
+}
+
+if (isMainModule(import.meta.url)) {
+  const result = await runAuditCli();
+  process.exitCode = result.exitCode;
+}

--- a/tools/repo/audit-documentation-inventory.test.mjs
+++ b/tools/repo/audit-documentation-inventory.test.mjs
@@ -1,0 +1,182 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { validateSchema } from "../ci/lib/json-schema-lite.mjs";
+import {
+  AuditIncomplete,
+  auditDocumentationInventory,
+  collectLive,
+  runAuditCli,
+  validateDocumentationInventoryAuditReport,
+  validateDocumentationInventoryAuditScope,
+  verifyFragment,
+} from "./audit-documentation-inventory.mjs";
+
+const REPOSITORIES = [
+  "AquilaXk/easysubway",
+  "AquilaXk/easysubway-backend",
+  "AquilaXk/easysubway-data",
+  "AquilaXk/easysubway-mobile",
+  "AquilaXk/easysubway-platform",
+];
+const PATH = "contracts/documentation/documentation-fragment.json";
+const SCOPE = {
+  schemaVersion: 1,
+  repositories: REPOSITORIES.map((repository) => ({ repository, defaultBranch: "main", fragmentPath: PATH, requiredStatus: "ACTIVE" })),
+  dods: ["D01", "D02", "D03", "D04", "D05"],
+};
+const SHA = "a".repeat(40);
+const WATERMARK = "b".repeat(64);
+
+function record(repository, overrides = {}) {
+  const path = `contracts/${repository.split("/").at(-1)}.json`;
+  const canonicalIdentity = `git:${SHA}:${path}:${"c".repeat(40)}`;
+  return {
+    resource: `${repository}:${path}`,
+    resourceClass: "CANONICAL_RESOURCE",
+    documentationFamily: "ARCHITECTURE",
+    kindCandidate: "DOCUMENTATION_RESOURCE",
+    sourceSurface: "TRACKED",
+    canonicalIdentity,
+    status: "ACTIVE",
+    ownerRepository: repository,
+    ownerIssue: `https://github.com/${repository}/issues/1`,
+    currentConsumers: ["consumer:documentation"],
+    releaseReachability: "NONE",
+    publicSurfaceReachability: [],
+    assertionState: "CURRENTLY_IMPLEMENTED_AND_EVIDENCED",
+    sensitivity: "INTERNAL",
+    duplicateGroup: null,
+    disposition: "RETAIN_CANONICAL",
+    deletePrerequisite: [],
+    supersedes: [],
+    supersededBy: null,
+    invalidatedBy: null,
+    invalidationReason: null,
+    invalidationEvidence: [],
+    mutationPolicy: "CURRENT_STATE_WITH_CHANGE",
+    reviewPolicyId: "EVENT_ONLY",
+    reviewTrigger: ["event:change"],
+    lastVerifiedAt: "2026-08-11T00:00:00.000Z",
+    lastVerifiedIdentity: canonicalIdentity,
+    verificationMethod: "contract-test",
+    verificationEvidence: ["evidence:fixture"],
+    nextReviewAtOrSemanticExpiry: null,
+    implementationPlan: repository === "AquilaXk/easysubway" ? "PLAN-DOC" : "PLAN-JOURNEY",
+    workloadClass: null,
+    orchestrationProfile: null,
+    stateClass: null,
+    configurationDelivery: null,
+    healthContract: null,
+    availabilityContract: null,
+    securityContract: null,
+    releaseContract: null,
+    portabilityOwner: null,
+    portabilityEvidence: [],
+    portabilityGap: [],
+    ...overrides,
+  };
+}
+
+function fragment(repository, resources = [record(repository)], overrides = {}) {
+  return {
+    $schema: "./documentation-fragment.schema.json",
+    schemaVersion: 1,
+    repository,
+    gitSha: SHA,
+    status: "ACTIVE",
+    lastVerifiedAt: "2026-08-11T00:00:00.000Z",
+    verificationEvidence: ["evidence:fixture"],
+    resources,
+    ...overrides,
+  };
+}
+
+function ready(repository, resources) {
+  return { repository, headSha: SHA, state: "READY", fragmentStatus: "ACTIVE", fragmentBlobSha: "d".repeat(40), fragment: fragment(repository, resources), resourceCount: resources.length, activeResourceCount: resources.filter(({ status }) => status === "ACTIVE").length };
+}
+
+test("documentation inventory audit validates exact scope and preserves missing fragments as PENDING", () => {
+  assert.deepEqual(validateDocumentationInventoryAuditScope(SCOPE), []);
+  for (const mutate of [
+    (scope) => scope.repositories.pop(),
+    (scope) => scope.repositories.reverse(),
+    (scope) => { scope.repositories[0].fragmentPath = "../fragment.json"; },
+    (scope) => { scope.repositories[0].requiredStatus = "PROPOSED"; },
+    (scope) => scope.dods.pop(),
+  ]) {
+    const invalid = structuredClone(SCOPE);
+    mutate(invalid);
+    assert.notDeepEqual(validateDocumentationInventoryAuditScope(invalid), []);
+  }
+  const repositories = REPOSITORIES.map((repository) => ({ repository, headSha: SHA, state: "PENDING", fragmentStatus: "MISSING", fragmentBlobSha: null, fragment: null, resourceCount: 0, activeResourceCount: 0 }));
+  const report = auditDocumentationInventory({ scope: SCOPE, sourceSha: SHA, observedAt: "2026-08-11T00:00:00.000Z", repositories, stateBeginSha256: WATERMARK, stateEndSha256: WATERMARK });
+  assert.deepEqual([report.status, report.summary.pending, report.summary.ready, report.summary.findings, report.summary.incomplete], ["COMPLETE", 5, 0, 0, 0]);
+  assert.deepEqual(report.dods.map(({ id, status }) => [id, status]), SCOPE.dods.map((id) => [id, "PENDING"]));
+  assert.deepEqual(validateDocumentationInventoryAuditReport(report), []);
+});
+
+test("documentation inventory audit proves D01-D05 only for five exact ACTIVE fragments", () => {
+  const repositories = REPOSITORIES.map((repository) => ready(repository, [record(repository)]));
+  const report = auditDocumentationInventory({ scope: SCOPE, sourceSha: SHA, observedAt: "2026-08-11T00:00:00.000Z", repositories, stateBeginSha256: WATERMARK, stateEndSha256: WATERMARK });
+  assert.deepEqual([report.summary.pending, report.summary.ready, report.summary.activeResources, report.summary.findings], [0, 5, 5, 0]);
+  assert.deepEqual(report.dods.map(({ id, status, findings }) => [id, status, findings]), SCOPE.dods.map((id) => [id, "PROVEN", 0]));
+
+  const invalid = structuredClone(repositories);
+  invalid[0].fragment.resources[0].implementationPlan = "PLAN-JOURNEY";
+  invalid[1].fragment.resources[0].ownerIssue = null;
+  invalid[2].fragment.resources[0].duplicateGroup = "duplicate:shared";
+  invalid[3].fragment.resources[0].duplicateGroup = "duplicate:shared";
+  const contradicted = auditDocumentationInventory({ scope: SCOPE, sourceSha: SHA, observedAt: "2026-08-11T00:00:00.000Z", repositories: invalid, stateBeginSha256: WATERMARK, stateEndSha256: WATERMARK });
+  assert.deepEqual(contradicted.findings.map(({ dod, code }) => [dod, code]), [
+    ["D02", "ACTIVE_OWNER_ISSUE_MISSING"],
+    ["D03", "DUPLICATE_CANONICAL_COUNT"],
+    ["D05", "HUB_TARGET_PLAN_ACTIVE_COPY"],
+  ]);
+  assert.deepEqual(contradicted.dods.map(({ id, status }) => [id, status]), [
+    ["D01", "PROVEN"], ["D02", "CONTRADICTED"], ["D03", "CONTRADICTED"], ["D04", "PROVEN"], ["D05", "CONTRADICTED"],
+  ]);
+});
+
+test("documentation inventory audit verifies tracked fragment blobs and rejects malformed or cross-head input", async () => {
+  const candidate = fragment(REPOSITORIES[0]);
+  const readContent = async (_repository, path, _sha) => path === PATH
+    ? { type: "file", sha: "d".repeat(40), encoding: "base64", content: Buffer.from(JSON.stringify(candidate)).toString("base64") }
+    : { type: "file", sha: "c".repeat(40), encoding: "base64", content: Buffer.from("{}").toString("base64") };
+  const verified = await verifyFragment(SCOPE.repositories[0], SHA, { readContent });
+  assert.deepEqual([verified.state, verified.fragmentStatus, verified.resourceCount, verified.activeResourceCount], ["READY", "ACTIVE", 1, 1]);
+  await assert.rejects(() => verifyFragment(SCOPE.repositories[0], "b".repeat(40), { readContent }), (error) => error instanceof AuditIncomplete && error.code === "FRAGMENT_HEAD_MISMATCH");
+  await assert.rejects(() => verifyFragment(SCOPE.repositories[0], SHA, { readContent: async () => ({ type: "file", sha: "d".repeat(40), encoding: "base64", content: "%%%" }) }), (error) => error instanceof AuditIncomplete && error.code === "FRAGMENT_DECODE_INVALID");
+  const missing = await verifyFragment(SCOPE.repositories[0], SHA, { readContent: async () => { throw Object.assign(new Error("missing"), { status: 404 }); } });
+  assert.deepEqual([missing.state, missing.fragmentStatus, missing.fragmentBlobSha], ["PENDING", "MISSING", null]);
+});
+
+test("documentation inventory audit rejects state drift and writes schema-valid fallback without overwriting", async () => {
+  const pending = REPOSITORIES.map((repository) => ({ repository, headSha: SHA, state: "PENDING", fragmentStatus: "MISSING", fragmentBlobSha: null, fragment: null, resourceCount: 0, activeResourceCount: 0 }));
+  let snapshot = 0;
+  await assert.rejects(() => collectLive(SCOPE, {
+    sourceSha: SHA,
+    collectSnapshot: async () => ({ repositories: pending, watermark: `${++snapshot}`.padStart(64, "0") }),
+  }), (error) => error instanceof AuditIncomplete && error.code === "STATE_WATERMARK_DRIFT");
+
+  const directory = mkdtempSync(join(tmpdir(), "documentation-inventory-audit-"));
+  const output = join(directory, "report.json");
+  const scopeSchema = readFileSync("contracts/documentation/documentation-inventory-audit-scope.schema.json", "utf8");
+  const reportSchema = readFileSync("contracts/documentation/documentation-inventory-audit-report.schema.json", "utf8");
+  const argv = ["--scope", "scope", "--scope-schema", "scope-schema", "--report-schema", "report-schema", "--source-sha", SHA, "--observed-at", "2026-08-11T00:00:00.000Z", "--output", output];
+  try {
+    const result = await runAuditCli({ argv, read: async (path) => ({ scope: "{", "scope-schema": scopeSchema, "report-schema": reportSchema })[path], collect: async () => { throw new Error("must not collect"); } });
+    const report = JSON.parse(readFileSync(output, "utf8"));
+    assert.equal(result.exitCode, 2);
+    assert.equal(validateSchema(JSON.parse(reportSchema), report).ok, true);
+    assert.deepEqual([report.status, report.summary.pending, report.summary.ready, report.summary.incomplete], ["AUDIT_INCOMPLETE", 5, 0, 1]);
+    writeFileSync(join(directory, "existing.json"), "existing\n");
+    const existingArgv = [...argv.slice(0, -1), join(directory, "existing.json")];
+    assert.equal((await runAuditCli({ argv: existingArgv, read: async (path) => ({ scope: JSON.stringify(SCOPE), "scope-schema": scopeSchema, "report-schema": reportSchema })[path], collect: async () => ({ repositories: pending, stateBeginSha256: WATERMARK, stateEndSha256: WATERMARK }) })).exitCode, 2);
+    assert.equal(readFileSync(join(directory, "existing.json"), "utf8"), "existing\n");
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/tools/repo/audit-documentation-inventory.test.mjs
+++ b/tools/repo/audit-documentation-inventory.test.mjs
@@ -8,6 +8,7 @@ import {
   AuditIncomplete,
   auditDocumentationInventory,
   collectLive,
+  gh,
   runAuditCli,
   validateDocumentationInventoryAuditReport,
   validateDocumentationInventoryAuditScope,
@@ -111,6 +112,10 @@ test("documentation inventory audit validates exact scope and preserves missing 
     mutate(invalid);
     assert.notDeepEqual(validateDocumentationInventoryAuditScope(invalid), []);
   }
+  const malformed = structuredClone(SCOPE);
+  malformed.repositories[0] = null;
+  assert.doesNotThrow(() => validateDocumentationInventoryAuditScope(malformed));
+  assert.notDeepEqual(validateDocumentationInventoryAuditScope(malformed), []);
   const repositories = REPOSITORIES.map((repository) => ({ repository, headSha: SHA, state: "PENDING", fragmentStatus: "MISSING", fragmentBlobSha: null, fragment: null, resourceCount: 0, activeResourceCount: 0 }));
   const report = auditDocumentationInventory({ scope: SCOPE, sourceSha: SHA, observedAt: "2026-08-11T00:00:00.000Z", repositories, stateBeginSha256: WATERMARK, stateEndSha256: WATERMARK });
   assert.deepEqual([report.status, report.summary.pending, report.summary.ready, report.summary.findings, report.summary.incomplete], ["COMPLETE", 5, 0, 0, 0]);
@@ -172,6 +177,15 @@ test("documentation inventory audit rejects state drift and writes schema-valid 
     assert.equal(result.exitCode, 2);
     assert.equal(validateSchema(JSON.parse(reportSchema), report).ok, true);
     assert.deepEqual([report.status, report.summary.pending, report.summary.ready, report.summary.incomplete], ["AUDIT_INCOMPLETE", 5, 0, 1]);
+    const malformedScope = structuredClone(SCOPE);
+    malformedScope.repositories[0] = null;
+    const malformedOutput = join(directory, "malformed-scope.json");
+    const malformedArgv = [...argv.slice(0, -1), malformedOutput];
+    const malformedResult = await runAuditCli({ argv: malformedArgv, read: async (path) => ({ scope: JSON.stringify(malformedScope), "scope-schema": scopeSchema, "report-schema": reportSchema })[path], collect: async () => { throw new Error("must not collect"); } });
+    const malformedReport = JSON.parse(readFileSync(malformedOutput, "utf8"));
+    assert.equal(malformedResult.exitCode, 2);
+    assert.equal(validateSchema(JSON.parse(reportSchema), malformedReport).ok, true);
+    assert.deepEqual([malformedReport.status, malformedReport.summary.incomplete], ["AUDIT_INCOMPLETE", 1]);
     writeFileSync(join(directory, "existing.json"), "existing\n");
     const existingArgv = [...argv.slice(0, -1), join(directory, "existing.json")];
     assert.equal((await runAuditCli({ argv: existingArgv, read: async (path) => ({ scope: JSON.stringify(SCOPE), "scope-schema": scopeSchema, "report-schema": reportSchema })[path], collect: async () => ({ repositories: pending, stateBeginSha256: WATERMARK, stateEndSha256: WATERMARK }) })).exitCode, 2);
@@ -179,4 +193,22 @@ test("documentation inventory audit rejects state drift and writes schema-valid 
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }
+});
+
+test("documentation inventory audit retries transient structured GitHub responses and preserves structured 404", async () => {
+  const endpoint = `repos/AquilaXk/easysubway/contents/${PATH}?ref=${SHA}`;
+  const response = (status, body) => `HTTP/2.0 ${status}\nContent-Type: application/json\n\n${JSON.stringify(body)}`;
+  const delays = [];
+  let attempts = 0;
+  const execute = async () => {
+    attempts += 1;
+    if (attempts < 3) throw Object.assign(new Error("transient"), { stdout: response("500 Internal Server Error", { message: "unavailable" }), stderr: "provider unavailable" });
+    return { stdout: response("200 OK", { type: "file" }), stderr: "" };
+  };
+  assert.equal(JSON.parse(await gh(["api", endpoint], execute, async (delay) => delays.push(delay))).type, "file");
+  assert.deepEqual([attempts, delays], [3, [250, 500]]);
+  await assert.rejects(
+    () => gh(["api", endpoint], async () => { throw Object.assign(new Error("missing"), { stdout: response("404 Not Found", { message: "Not Found" }), stderr: "localized stderr" }); }),
+    (error) => error?.status === 404,
+  );
 });


### PR DESCRIPTION
## 관련 이슈

Closes #2833
Refs #2748

## 작업 배경

- Historical inventory digest만으로는 exact current five-head의 D01–D05를 재현할 수 없고, canonical fragment path는 다섯 저장소 모두 현재 404다.
- Missing input을 stale/cache/issue prose로 성공 처리하지 않으면서 후속 fragment PR이 병렬로 채울 수 있는 deterministic fan-in foundation이 필요하다.

## 작업 내용

- exact five repositories, `main`, canonical fragment path, required `ACTIVE`, D01–D05를 고정한 scope/report schema를 추가했다.
- begin/end head watermark, fragment/blob/schema/semantic, tracked resource identity, combined lifecycle/duplicate/owner/Hub-copy를 검증하는 read-only auditor를 추가했다.
- Hub workspace contract와 default-branch sanitized artifact workflow를 연결했다.
- repository-wide write lease는 사용하지 않으며 후속 PR은 distinct issue/branch/worktree/PR과 비중복 changed-file allowlist로 병렬 진행할 수 있다.

## Documentation impact

- 영향 resource ID 또는 `NONE`: `NONE` — current resource/catalog/fragment data 의미는 변경하지 않고 감사 contract/tool만 추가
- resourceClass: `NONE`
- documentationFamily: `ARCHITECTURE` 감사 surface
- lifecycle/evidence 영향: exact current five fragment가 없으면 `COMPLETE/PENDING=5`를 보존하고, all five ACTIVE일 때만 D01–D05를 평가한다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/repo/audit-documentation-inventory.test.mjs` → 5/5 PASS (malformed scope fallback, structured HTTP retry/404 포함)
  - `node --test --test-name-pattern "documentation inventory audit" tools/ci/check-contracts.test.mjs` → 1/1 PASS
  - `node --test --test-name-pattern "Documentation Inventory Audit" tools/ci/repository-contract.test.mjs` → 1/1 PASS
  - `git diff --check origin/main...HEAD` → PASS
  - bounded live audit → `COMPLETE/pending=5/ready=0/activeResources=0/findings=0/incomplete=0`, equal watermark `6fae4357…`

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| auditor contract | Node 24 | focused tests | 위 검증 명령 | PASS |
| current provider boundary | GitHub public repositories | structured HTTP status + bounded retry를 사용한 begin/end exact-head live audit | source `f5ef5ef4`, scope `sha256:d94ac44e…`, watermark `6fae4357…` | COMPLETE/PENDING 5 |
| discovery Review closure | GitHub Review | frozen F1/F2 fix + original thread closure | discovery Review `4904525301`, fix `a12ac9f4`, unresolved thread `0` | PASS |
| UI/접근성/수동 QA | 해당 없음 | UI·runtime 변경 없음 | exact 10-file contract/tool/workflow allowlist | 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: missing fragment가 `PENDING`이고 provider/schema/head drift가 `AUDIT_INCOMPLETE`로 분리되는지, begin/end watermark와 exact tracked blob 검증이 우회되지 않는지 확인해 주세요.

## 리스크

- 현재 canonical fragment가 모두 없으므로 merged-head 첫 report는 의도적으로 `PENDING=5`가 예상된다. 이는 D01–D05나 service GO 완료 주장이 아니며 runnable service direct-owner lane의 required gate로 연결하지 않는다.
- GitHub read 경계가 실패하거나 두 snapshot이 달라지면 sanitized `AUDIT_INCOMPLETE`로 닫히며 previous/cached report fallback은 없다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다. (discovery head required CI green; merge 직전 current-head 재확인)
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit Review `4904525301`이 discovery head `47f1a232`에 존재한다.
- [x] CodeRabbit Review 객체가 있으므로 Codex CLI fallback은 해당 없음이다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 여러 저장소의 문서 인벤토리를 자동으로 감사하고, 저장소 상태·문서 조각·완료 기준별 결과와 발견 사항을 보고서로 생성합니다.
  * 감사 범위와 결과를 검증하는 표준 JSON 계약을 추가했습니다.
  * 감사 결과를 검증된 아티팩트로 업로드하는 자동화 작업을 추가했습니다.

* **버그 수정**
  * 중복 문서, 소유자·계획 불일치, 누락·변조된 문서 및 상태 변경을 감지합니다.
  * 감사가 완료되지 않은 경우에도 유효한 불완전 보고서를 생성하도록 개선했습니다.

* **테스트**
  * 감사 결과, 오류 처리, 범위 및 보고서 계약 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
