### PR TITLE
[CI] Android/Mobile release-download EOF bounded recovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -837,7 +837,28 @@ jobs:
         run: |
           set -euo pipefail
           flutter pub get
-          flutter build apk --debug
+          android_log="${RUNNER_TEMP}/easysubway-android-build.log"
+          for attempt in 1 2 3; do
+            set +e
+            flutter build apk --debug 2>&1 | tee "${android_log}"
+            pipeline_status=("${PIPESTATUS[@]}")
+            set -e
+            build_status="${pipeline_status[0]}"
+            tee_status="${pipeline_status[1]}"
+
+            if [[ "${tee_status}" -ne 0 ]]; then
+              exit "${tee_status}"
+            fi
+            if [[ "${build_status}" -eq 0 ]]; then
+              break
+            fi
+            if [[ "${attempt}" -eq 3 ]] || ! grep -Fq "Connection closed before full header was received" "${android_log}"; then
+              exit "${build_status}"
+            fi
+
+            echo "Transient Android native asset header close; retrying bounded attempt $((attempt + 1))/3." >&2
+            sleep "$((attempt * 5))"
+          done
 
   notify-slack-ci-failure:
     name: Slack / CI failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -729,7 +729,28 @@ jobs:
           set -euo pipefail
           flutter pub get
           flutter build apk --config-only
-          android/gradlew -p android :app:processReleaseMainManifest --no-daemon
+          gradle_log="${RUNNER_TEMP}/easysubway-mobile-gradle-wrapper.log"
+          for attempt in 1 2 3; do
+            set +e
+            android/gradlew -p android :app:processReleaseMainManifest --no-daemon 2>&1 | tee "${gradle_log}"
+            pipeline_status=("${PIPESTATUS[@]}")
+            set -e
+            gradle_status="${pipeline_status[0]}"
+            tee_status="${pipeline_status[1]}"
+
+            if [[ "${tee_status}" -ne 0 ]]; then
+              exit "${tee_status}"
+            fi
+            if [[ "${gradle_status}" -eq 0 ]]; then
+              break
+            fi
+            if [[ "${attempt}" -eq 3 ]] || ! grep -Fq "Unexpected end of file from server" "${gradle_log}"; then
+              exit "${gradle_status}"
+            fi
+
+            echo "Transient Gradle wrapper EOF; retrying bounded attempt $((attempt + 1))/3." >&2
+            sleep "$((attempt * 5))"
+          done
 
       - name: Mobile App CI / Run mobile contracts
         if: ${{ needs.changes.outputs.mobile == 'true' && steps.scaffold.outputs.present == 'true' }}

--- a/apps/mobile/pubspec.lock
+++ b/apps/mobile/pubspec.lock
@@ -936,10 +936,10 @@ packages:
     dependency: "direct main"
     description:
       name: sqlite3
-      sha256: "37356bcb56ce0d9404d602c41e4bdb7765e7e9732a3e47adb3d98c556a6abdad"
+      sha256: "752d9d746052359a2022f588bb979f2e7c4e0f9e4b6a1c3121f7626a1574974b"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.3"
+    version: "3.3.4"
   sqlparser:
     dependency: transitive
     description:

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -41,7 +41,7 @@ dependencies:
   meta: ^1.18.0
   path: ^1.9.1
   collection: ^1.19.1
-  sqlite3: ^3.3.3
+  sqlite3: 3.3.4
   flutter_local_notifications: ^22.0.1
   timezone: ^0.11.1
   connectivity_plus: ^7.2.0

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -3405,6 +3405,29 @@ test("모바일 변경 CI는 모바일 계약 테스트를 실행한다", () => 
   );
 });
 
+test("Android 변경 CI는 native asset header 단절만 bounded retry한다", () => {
+  const workflow = read(".github/workflows/ci.yml");
+  const androidJob = jobBlock(workflow, "android", "notify-slack-ci-failure");
+
+  assert.match(androidJob, /Android CI \/ Build Flutter Android debug APK/);
+  assert.match(androidJob, /for attempt in 1 2 3; do/);
+  assert.match(androidJob, /flutter build apk --debug 2>&1 \| tee "\$\{android_log\}"/);
+  assert.match(androidJob, /pipeline_status=\("\$\{PIPESTATUS\[@\]\}"\)/);
+  assert.match(androidJob, /build_status="\$\{pipeline_status\[0\]\}"/);
+  assert.match(androidJob, /tee_status="\$\{pipeline_status\[1\]\}"/);
+  assert.match(
+    androidJob,
+    /if \[\[ "\$\{tee_status\}" -ne 0 \]\]; then[\s\S]*exit "\$\{tee_status\}"/,
+  );
+  assert.match(androidJob, /if \[\[ "\$\{build_status\}" -eq 0 \]\]; then[\s\S]*break/);
+  assert.match(
+    androidJob,
+    /if \[\[ "\$\{attempt\}" -eq 3 \]\] \|\| ! grep -Fq "Connection closed before full header was received" "\$\{android_log\}"; then[\s\S]*exit "\$\{build_status\}"/,
+  );
+  assert.match(androidJob, /sleep "\$\(\(attempt \* 5\)\)"/);
+  assert.doesNotMatch(androidJob, /flutter build apk --debug\s*\|\|\s*true/);
+});
+
 test("OSV 의존성 취약점 게이트는 PR 의존성 취약점을 차단한다", () => {
   const workflow = read(".github/workflows/ci.yml");
   const dependencyScanJob = jobBlock(workflow, "dependency-vulnerability-scan", "pr-title");

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -3428,6 +3428,18 @@ test("Android 변경 CI는 native asset header 단절만 bounded retry한다", (
   assert.doesNotMatch(androidJob, /flutter build apk --debug\s*\|\|\s*true/);
 });
 
+test("Android native asset cache는 sqlite3 3.3.4 content hash identity를 고정한다", () => {
+  const pubspec = read("apps/mobile/pubspec.yaml");
+  const lockfile = read("apps/mobile/pubspec.lock");
+
+  assert.match(pubspec, /^  sqlite3: 3\.3\.4$/m);
+  assert.match(
+    lockfile,
+    /  sqlite3:\n    dependency: "direct main"\n    description:\n      name: sqlite3\n      sha256: "[a-f0-9]{64}"\n      url: "https:\/\/pub\.dev"\n    source: hosted\n    version: "3\.3\.4"/,
+  );
+  assert.doesNotMatch(pubspec, /sqlite3_flutter_libs/);
+});
+
 test("OSV 의존성 취약점 게이트는 PR 의존성 취약점을 차단한다", () => {
   const workflow = read(".github/workflows/ci.yml");
   const dependencyScanJob = jobBlock(workflow, "dependency-vulnerability-scan", "pr-title");

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -3380,7 +3380,13 @@ test("모바일 변경 CI는 모바일 계약 테스트를 실행한다", () => 
   assert.match(mobileJob, /flutter build apk --config-only/);
   assert.match(mobileJob, /android\/gradlew -p android :app:processReleaseMainManifest --no-daemon/);
   assert.match(mobileJob, /for attempt in 1 2 3; do/);
-  assert.match(mobileJob, /gradle_status="\$\{PIPESTATUS\[0\]\}"/);
+  assert.match(mobileJob, /pipeline_status=\("\$\{PIPESTATUS\[@\]\}"\)/);
+  assert.match(mobileJob, /gradle_status="\$\{pipeline_status\[0\]\}"/);
+  assert.match(mobileJob, /tee_status="\$\{pipeline_status\[1\]\}"/);
+  assert.match(
+    mobileJob,
+    /if \[\[ "\$\{tee_status\}" -ne 0 \]\]; then[\s\S]*exit "\$\{tee_status\}"/,
+  );
   assert.match(mobileJob, /if \[\[ "\$\{gradle_status\}" -eq 0 \]\]; then[\s\S]*break/);
   assert.match(
     mobileJob,

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -3435,7 +3435,7 @@ test("Android native asset cache는 sqlite3 3.3.4 content hash identity를 고�
   assert.match(pubspec, /^  sqlite3: 3\.3\.4$/m);
   assert.match(
     lockfile,
-    /  sqlite3:\n    dependency: "direct main"\n    description:\n      name: sqlite3\n      sha256: "[a-f0-9]{64}"\n      url: "https:\/\/pub\.dev"\n    source: hosted\n    version: "3\.3\.4"/,
+    /  sqlite3:\n    dependency: "direct main"\n    description:\n      name: sqlite3\n      sha256: "752d9d746052359a2022f588bb979f2e7c4e0f9e4b6a1c3121f7626a1574974b"\n      url: "https:\/\/pub\.dev"\n    source: hosted\n    version: "3\.3\.4"/,
   );
   assert.doesNotMatch(pubspec, /sqlite3_flutter_libs/);
 });

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -3379,6 +3379,18 @@ test("모바일 변경 CI는 모바일 계약 테스트를 실행한다", () => 
   assert.match(mobileJob, /flutter pub get/);
   assert.match(mobileJob, /flutter build apk --config-only/);
   assert.match(mobileJob, /android\/gradlew -p android :app:processReleaseMainManifest --no-daemon/);
+  assert.match(mobileJob, /for attempt in 1 2 3; do/);
+  assert.match(mobileJob, /gradle_status="\$\{PIPESTATUS\[0\]\}"/);
+  assert.match(mobileJob, /if \[\[ "\$\{gradle_status\}" -eq 0 \]\]; then[\s\S]*break/);
+  assert.match(
+    mobileJob,
+    /if \[\[ "\$\{attempt\}" -eq 3 \]\] \|\| ! grep -Fq "Unexpected end of file from server" "\$\{gradle_log\}"; then[\s\S]*exit "\$\{gradle_status\}"/,
+  );
+  assert.match(mobileJob, /sleep "\$\(\(attempt \* 5\)\)"/);
+  assert.doesNotMatch(
+    mobileJob,
+    /android\/gradlew -p android :app:processReleaseMainManifest --no-daemon\s*\|\|\s*true/,
+  );
   assert.match(mobileJob, /Mobile App CI \/ Run mobile contracts/);
   assert.match(mobileJob, /EASYSUBWAY_EXPECT_ANDROID_RELEASE_MANIFEST: "true"/);
   assert.match(


### PR DESCRIPTION
## 관련 이슈 / Related issue

Closes #2851
Refs #2849

## 작업 배경 / Summary

- Problem: PR #2850 required Mobile CI에서 Gradle distribution download가 exact `Unexpected end of file from server`로 반복 실패했고, recovery head의 Android CI는 `sqlite3` 3.3.3 asset download의 exact `Connection closed before full header was received`가 bounded attempts 1/2/3에서 지속됐다.
- Outcome: 각 exact release-download transient만 최대 3회 bounded retry하고, sqlite3 official 3.3.4의 content-hash cache identity로 성공한 ABI download를 재사용하며, 그 외 실패와 third attempt는 original exit code로 fail closed한다.

## 작업 내용 / Changes

- Mobile manifest Gradle task에 three-attempt bounded loop와 5/10초 backoff를 추가했다.
- Android debug build에도 native asset header-close 전용 three-attempt bounded loop를 추가했다.
- `PIPESTATUS`로 Gradle/`tee` exit를 각각 보존하고 log-write failure도 fail closed한다.
- repository contract test가 EOF-only retry, nonmatching/third-attempt terminal exit와 `|| true` 부재를 고정한다.
- direct `sqlite3` constraint와 lock만 exact 3.3.4로 전진시켜 process 간 verified native-asset cache identity를 안정화한다.

## Scope

### Included

- `.github/workflows/ci.yml`
- `tools/ci/repository-contract.test.mjs`
- `apps/mobile/pubspec.yaml`
- `apps/mobile/pubspec.lock`

### Excluded

- Gradle version/distribution URL/wrapper properties/JAR
- Flutter/mobile product source, other dependency update, other workflow jobs, D33.5 audit files
- gate skip, success 합성, alternate provider/distribution, system/source SQLite, stale/unchecked fallback

### Ownership / dependencies

- Accountable owner or plan: PLAN-DOC D33.6
- Required predecessor output: PR #2850 run `31623024197`의 repeated exact EOF evidence
- Concurrent work overlap: None

## Documentation impact

- 영향 resource ID 또는 `NONE`: NONE
- resourceClass: NONE
- documentationFamily: NONE
- lifecycle/evidence 영향: CI recovery execution은 #2851/이 PR과 source plan D33.6에 기록한다.

## 검증 / Verification

| Check | Result / Evidence |
| --- | --- |
| Focused RED → GREEN | Mobile loop `0/1` → `1/1`; Android loop `0/1` → `1/1`; sqlite3 stable cache identity `0/1` → `1/1` |
| Affected integration | workflow contract가 exact mobile job block을 검사 |
| Required CI | Exact-head run `31626236058` PASS (Android `94213255351`, Mobile `94213255187`) |
| Manual / production-like | Not required — reason: UI/runtime change 없음 |
| Security / privacy / accessibility | Not applicable — reason: secrets·product behavior·permission 변경 없음 |

- 실행한 명령과 결과:
  - `node --test --test-name-pattern "모바일 변경 CI는 모바일 계약 테스트를 실행한다" tools/ci/repository-contract.test.mjs` — RED `0/1`, GREEN `1/1`
  - `node --test --test-name-pattern "Android 변경 CI는 native asset header 단절만 bounded retry한다" tools/ci/repository-contract.test.mjs` — RED `0/1`, GREEN `1/1`
  - `node --test --test-name-pattern "Android native asset cache는 sqlite3 3.3.4 content hash identity를 고정한다" tools/ci/repository-contract.test.mjs` — RED `0/1`, GREEN `1/1`
  - `cd apps/mobile && flutter pub get --offline` — PASS, lock unchanged
  - `git diff --check origin/main...HEAD` — PASS

## 검증 증거

UI/수동 QA/배포 증거는 필요 없다. Current-head required CI와 supported R2 discovery Review를 delivery evidence로 사용한다.

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName / versionCode: unchanged
- datapack version: unchanged
- route / realtime contract: unchanged
- backend identity: unchanged

## Not run

- Check: repository-wide local suite, local Flutter/Gradle build
- Reason: exact workflow contract만 local에서 검증하고 full regression/build는 required GitHub CI에 맡긴다.
- Rerun owner / condition: GitHub Actions current-head required jobs

## 리뷰어 메모 / Review focus

- 리뷰어가 먼저 봐야 할 지점: 각 exact transient 문자열이 없는 실패는 즉시 종료되는지, third failure와 `tee` failure가 original nonzero로 닫히는지 확인한다.

## 리스크 / Risk

- Level: High (A/R2)
- Main risk: retry가 실제 download defect를 가리거나 dependency 범위를 불필요하게 넓힐 수 있음
- Failure behavior: exact EOF 외 실패와 final attempt는 nonzero, `tee` 실패도 nonzero
- State mutation on failure: runner-local verified download cache/temporary log 외 durable mutation 없음
- Fallback or degraded-success path introduced: No

## Rollout / Recovery

- Rollout or activation: merge 뒤 모든 mobile-related CI run에 즉시 적용
- Monitoring / success signal: run `31626236058`에서 Android APK build와 Mobile manifest/contracts/analyzer/tests 모두 통과
- Rollback or recovery: 이 four-file change를 revert하면 기존 one-shot/sqlite3 3.3.3 behavior로 복원
- Data / config compatibility after rollback: product data/config/runtime 영향 없음

## 체크리스트 / Checklist

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] 이슈 범위와 실제 diff가 일치하며 관련 없는 변경을 포함하지 않았다.
- [x] 위험에 필요한 검증과 미실행 사유를 기록했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향 없음.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 모바일 릴리스 매니페스트 생성과 Android 디버그 APK 빌드의 일시적인 네트워크 오류 대응이 강화되었습니다.
  - 일시적 오류 발생 시 자동 재시도를 지원해 모바일 빌드 안정성이 향상되었습니다.
  - SQLite 구성 요소가 최신 버전으로 업데이트되어 Android 환경의 호환성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->