### PR TITLE
[Docs] Mobile ACTIVE documentation fragment를 catalog에 연결

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -481,21 +481,39 @@ jobs:
           NODE_OPTIONS: --disable-warning=ExperimentalWarning
         run: node --test tools/ci/*.test.mjs tools/ci/lib/*.test.mjs tools/repo/*.test.mjs tools/lib/*.test.mjs tools/mobile/*.test.mjs tools/qa/*.test.mjs
 
+      - name: Repository CI / Prepare active documentation fragment workspace
+        if: ${{ needs.changes.outputs.contracts == 'true' }}
+        run: >-
+          node tools/ci/prepare-documentation-fragment-workspace.mjs
+          --catalog contracts/documentation/documentation-system-catalog.json
+          --scope contracts/documentation/documentation-inventory-audit-scope.json
+          --root "${RUNNER_TEMP}/documentation-fragment-repositories-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          --output "${RUNNER_TEMP}/documentation-fragment-workspace.json"
+
       - name: Repository CI / Validate PR contract transitions
         if: ${{ needs.changes.outputs.contracts == 'true' && github.event_name == 'pull_request' }}
         env:
           BASE_REF: ${{ github.event.pull_request.base.sha }}
-        run: node tools/ci/check-contracts.mjs --workspace contracts/workspaces/hub.json --base-ref "${BASE_REF}"
+        run: >-
+          node tools/ci/check-contracts.mjs --workspace contracts/workspaces/hub.json
+          --base-ref "${BASE_REF}"
+          --documentation-fragment-workspace "${RUNNER_TEMP}/documentation-fragment-workspace.json"
 
       - name: Repository CI / Validate push contract transitions
         if: ${{ needs.changes.outputs.contracts == 'true' && github.event_name == 'push' }}
         env:
           BASE_REF: ${{ github.event.before }}
-        run: node tools/ci/check-contracts.mjs --workspace contracts/workspaces/hub.json --base-ref "${BASE_REF}"
+        run: >-
+          node tools/ci/check-contracts.mjs --workspace contracts/workspaces/hub.json
+          --base-ref "${BASE_REF}"
+          --documentation-fragment-workspace "${RUNNER_TEMP}/documentation-fragment-workspace.json"
 
       - name: Repository CI / Validate current contracts
         if: ${{ needs.changes.outputs.contracts == 'true' && github.event_name == 'workflow_dispatch' }}
-        run: node tools/ci/check-contracts.mjs --workspace contracts/workspaces/hub.json --current-only
+        run: >-
+          node tools/ci/check-contracts.mjs --workspace contracts/workspaces/hub.json
+          --current-only
+          --documentation-fragment-workspace "${RUNNER_TEMP}/documentation-fragment-workspace.json"
 
       - name: Repository CI / Check directory boundaries
         if: ${{ needs.changes.outputs.repository == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.contracts == 'true' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.mobile == 'true' || needs.changes.outputs.datapack == 'true' }}

--- a/contracts/documentation/ADR-HUB-0001.json
+++ b/contracts/documentation/ADR-HUB-0001.json
@@ -180,7 +180,7 @@
     },
     {
       "id": "hub-contract-schema",
-      "method": "node tools/ci/check-contracts.mjs --workspace contracts/workspaces/hub.json --current-only",
+      "method": "node tools/ci/check-contracts.mjs --workspace contracts/workspaces/hub.json --current-only --local-contracts-only",
       "expected": "ADR-HUB-0001 schema validation PASS"
     },
     {

--- a/contracts/documentation/documentation-system-catalog.json
+++ b/contracts/documentation/documentation-system-catalog.json
@@ -14,7 +14,20 @@
     { "repository": "AquilaXk/easysubway", "status": "PROPOSED", "fragment": null },
     { "repository": "AquilaXk/easysubway-backend", "status": "PROPOSED", "fragment": null },
     { "repository": "AquilaXk/easysubway-data", "status": "PROPOSED", "fragment": null },
-    { "repository": "AquilaXk/easysubway-mobile", "status": "PROPOSED", "fragment": null },
+    {
+      "repository": "AquilaXk/easysubway-mobile",
+      "status": "ACTIVE",
+      "fragment": {
+        "gitSha": "397a475a988c65fb31600142d5c79f26e46a03f5",
+        "path": "contracts/documentation/documentation-fragment.json",
+        "blobSha": "37aa755bf7959737dc68a10ff346f16b5bc1954b",
+        "lastVerifiedAt": "2026-08-13T07:33:23.000Z",
+        "verificationEvidence": [
+          "https://github.com/AquilaXk/easysubway-mobile/issues/225",
+          "https://github.com/AquilaXk/easysubway/pull/2854"
+        ]
+      }
+    },
     { "repository": "AquilaXk/easysubway-platform", "status": "PROPOSED", "fragment": null }
   ]
 }

--- a/tools/ci/check-contracts.mjs
+++ b/tools/ci/check-contracts.mjs
@@ -109,9 +109,22 @@ export function loadWorkspace(workspacePath = DEFAULT_WORKSPACE_PATH) {
 
 export function collectContractErrors(
   workspacePath = DEFAULT_WORKSPACE_PATH,
-  { previousArchitectureDecision = null, documentationFragmentWorkspacePath = null } = {},
+  {
+    previousArchitectureDecision = null,
+    documentationFragmentWorkspacePath = null,
+    documentationFragmentResolution = "REQUIRED",
+  } = {},
 ) {
   const errors = [];
+  if (!["REQUIRED", "LOCAL_CONTRACTS_ONLY"].includes(documentationFragmentResolution)) {
+    errors.push("documentation fragment transport: resolution mode가 유효하지 않다");
+    return errors;
+  }
+  if (documentationFragmentResolution === "LOCAL_CONTRACTS_ONLY"
+      && documentationFragmentWorkspacePath != null) {
+    errors.push("documentation fragment transport: local contracts mode는 workspace를 사용할 수 없다");
+    return errors;
+  }
   let workspace;
   try {
     workspace = loadWorkspace(workspacePath);
@@ -151,10 +164,12 @@ export function collectContractErrors(
   if (validateJson(documentationSystemCatalogSchema, workspace.documentationSystemCatalog, errors)) {
     const catalog = loadJson(workspace.documentationSystemCatalog);
     validateDocumentationSystemCatalogSemantics(catalog, errors, workspace.documentationSystemCatalog, false);
-    resolveActiveDocumentationFragments(catalog, documentationFragmentWorkspacePath, errors, {
-      fragmentSchema: contract("documentation/documentation-fragment.schema.json"),
-      resourceSchema: contract("documentation/documentation-resource.schema.json"),
-    });
+    if (documentationFragmentResolution === "REQUIRED") {
+      resolveActiveDocumentationFragments(catalog, documentationFragmentWorkspacePath, errors, {
+        fragmentSchema: contract("documentation/documentation-fragment.schema.json"),
+        resourceSchema: contract("documentation/documentation-resource.schema.json"),
+      });
+    }
   }
   const productClaimCatalogSchema = contract("documentation/product-claim-catalog.schema.json");
   if (validateJson(productClaimCatalogSchema, workspace.productClaimCatalog, errors)) {
@@ -2279,18 +2294,22 @@ function compareText(left, right) {
 
 if (isMainModule(import.meta.url)) {
   const args = process.argv.slice(2);
-  const hasWorkspace = args[0] === "--workspace" && args[1]?.trim() !== "";
-  const fragmentWorkspaceIndex = args.indexOf("--documentation-fragment-workspace");
-  const hasFragmentWorkspace = fragmentWorkspaceIndex === -1
-    || (fragmentWorkspaceIndex === args.length - 2 && args[fragmentWorkspaceIndex + 1].trim() !== "");
-  const contractArgs = fragmentWorkspaceIndex === -1 ? args : args.slice(0, fragmentWorkspaceIndex);
-  const hasBaseRef = contractArgs.length === 4 && contractArgs[2] === "--base-ref" && contractArgs[3].trim() !== "";
-  const isCurrentOnly = contractArgs.length === 3 && contractArgs[2] === "--current-only";
-  const validArgs = hasWorkspace && hasFragmentWorkspace && (hasBaseRef || isCurrentOnly);
+  const isValue = (value) => typeof value === "string" && value.trim() !== "" && !value.startsWith("--");
+  const hasWorkspace = args[0] === "--workspace" && isValue(args[1]);
+  const hasBaseRef = args[2] === "--base-ref" && isValue(args[3])
+    && (args.length === 4 || (args.length === 6
+      && args[4] === "--documentation-fragment-workspace" && isValue(args[5])));
+  const isCurrentOnly = args[2] === "--current-only"
+    && (args.length === 3 || (args.length === 5
+      && args[3] === "--documentation-fragment-workspace" && isValue(args[4]))
+      || (args.length === 4 && args[3] === "--local-contracts-only"));
+  const validArgs = hasWorkspace && (hasBaseRef || isCurrentOnly);
   if (!validArgs) {
-    console.error("사용법: node tools/ci/check-contracts.mjs --workspace <workspace.json> (--base-ref <40-hex-sha>|--current-only) [--documentation-fragment-workspace <local-json>]");
+    console.error("사용법: node tools/ci/check-contracts.mjs --workspace <workspace.json> ((--base-ref <40-hex-sha>|--current-only) [--documentation-fragment-workspace <local-json>]|--current-only --local-contracts-only)");
     process.exit(1);
   }
+  const fragmentWorkspaceIndex = args.indexOf("--documentation-fragment-workspace");
+  const localContractsOnly = args.length === 4 && args[3] === "--local-contracts-only";
   let previousArchitectureDecision = null;
   try {
     if (hasBaseRef) previousArchitectureDecision = loadArchitectureDecisionAtRef(args[1], args[3]);
@@ -2301,6 +2320,7 @@ if (isMainModule(import.meta.url)) {
   const errors = collectContractErrors(args[1], {
     previousArchitectureDecision,
     documentationFragmentWorkspacePath: fragmentWorkspaceIndex === -1 ? null : args[fragmentWorkspaceIndex + 1],
+    documentationFragmentResolution: localContractsOnly ? "LOCAL_CONTRACTS_ONLY" : "REQUIRED",
   });
   if (errors.length) {
     console.error(errors.map((error) => `- ${error}`).join("\n"));

--- a/tools/ci/check-contracts.test.mjs
+++ b/tools/ci/check-contracts.test.mjs
@@ -1301,7 +1301,10 @@ test("documentation catalog CLI accepts compatibility modes and rejects malforme
   });
   const proposed = createExternalWorkspace();
   try {
-    assert.doesNotThrow(() => run(["--workspace", proposed.workspacePath, "--current-only"]));
+    assert.throws(() => run(["--workspace", proposed.workspacePath, "--current-only"]), /workspace가 필요하다/);
+    assert.doesNotThrow(() => run([
+      "--workspace", proposed.workspacePath, "--current-only", "--local-contracts-only",
+    ]));
   } finally { rmSync(proposed.directory, { recursive: true, force: true }); }
 
   const fixture = createSingleDocumentationCatalogWorkspace();
@@ -1341,6 +1344,7 @@ test("documentation catalog CLI accepts compatibility modes and rejects malforme
       [...valid, "--documentation-fragment-workspace", fixture.fragmentWorkspacePath],
       [...valid, "--local-contracts-only"],
       ["--workspace", fixture.workspacePath, "--base-ref", "a".repeat(40), "--local-contracts-only"],
+      ["--workspace", fixture.workspacePath, "--current-only", "--documentation-fragment-workspace", "--local-contracts-only"],
       [...valid, "extra"],
     ]) assert.throws(() => run(args), /사용법/);
   } finally { rmSync(fixture.directory, { recursive: true, force: true }); }

--- a/tools/ci/check-contracts.test.mjs
+++ b/tools/ci/check-contracts.test.mjs
@@ -476,6 +476,13 @@ function createExternalWorkspace() {
   copy("contracts/documentation/ADR-HUB-0001.json", "inputs/architecture-decision.json");
   copy("contracts/documentation/ADR-HUB-0001-decision.schema.json", "inputs/ADR-HUB-0001-decision.schema.json");
   copy("contracts/documentation/documentation-system-catalog.json", "inputs/documentation-system-catalog.json");
+  const fixtureCatalogPath = join(directory, "inputs/documentation-system-catalog.json");
+  const fixtureCatalog = loadJson(fixtureCatalogPath);
+  for (const entry of fixtureCatalog.repositories) {
+    entry.status = "PROPOSED";
+    entry.fragment = null;
+  }
+  writeFileSync(fixtureCatalogPath, JSON.stringify(fixtureCatalog));
   copy("contracts/documentation/product-claim-catalog.json", "inputs/product-claim-catalog.json");
   return { directory, workspacePath };
 }
@@ -1301,7 +1308,7 @@ test("documentation catalog CLI accepts compatibility modes and rejects malforme
   });
   const proposed = createExternalWorkspace();
   try {
-    assert.throws(() => run(["--workspace", proposed.workspacePath, "--current-only"]), /workspace가 필요하다/);
+    assert.doesNotThrow(() => run(["--workspace", proposed.workspacePath, "--current-only"]));
     assert.doesNotThrow(() => run([
       "--workspace", proposed.workspacePath, "--current-only", "--local-contracts-only",
     ]));

--- a/tools/ci/check-contracts.test.mjs
+++ b/tools/ci/check-contracts.test.mjs
@@ -1308,6 +1308,9 @@ test("documentation catalog CLI accepts compatibility modes and rejects malforme
   try {
     const valid = ["--workspace", fixture.workspacePath, "--current-only", "--documentation-fragment-workspace", fixture.fragmentWorkspacePath];
     assert.doesNotThrow(() => run(valid));
+    assert.doesNotThrow(() => run([
+      "--workspace", fixture.workspacePath, "--current-only", "--local-contracts-only",
+    ]));
     const clone = mkdtempSync(join(tmpdir(), "documentation-catalog-cli-"));
     try {
       const copied = join(clone, "fixture");
@@ -1336,6 +1339,8 @@ test("documentation catalog CLI accepts compatibility modes and rejects malforme
       valid.slice(0, -1),
       ["--workspace", fixture.workspacePath, "--documentation-fragment-workspace", fixture.fragmentWorkspacePath, "--current-only"],
       [...valid, "--documentation-fragment-workspace", fixture.fragmentWorkspacePath],
+      [...valid, "--local-contracts-only"],
+      ["--workspace", fixture.workspacePath, "--base-ref", "a".repeat(40), "--local-contracts-only"],
       [...valid, "extra"],
     ]) assert.throws(() => run(args), /사용법/);
   } finally { rmSync(fixture.directory, { recursive: true, force: true }); }
@@ -2056,17 +2061,17 @@ test("문서 거버넌스 계약은 ADR-HUB-0001 실물을 허용한다", () => 
     errors,
   ), true);
   assert.deepEqual(errors, []);
-  assert.ok(adr.confirmation.some(({ method }) => method.endsWith("--current-only")));
+  assert.ok(adr.confirmation.some(({ method }) => method.endsWith("--current-only --local-contracts-only")));
 });
 
-test("documentation catalog는 proposed 5-repository bootstrap과 fragment lifecycle을 fail closed한다", () => {
+test("documentation catalog는 terminal Mobile locator만 ACTIVE로 소비하고 fragment lifecycle을 fail closed한다", () => {
   const resourceSchema = loadJson("contracts/documentation/documentation-resource.schema.json");
   const fragmentSchema = loadJson("contracts/documentation/documentation-fragment.schema.json");
   const catalogSchema = loadJson("contracts/documentation/documentation-system-catalog.schema.json");
   const catalog = loadJson("contracts/documentation/documentation-system-catalog.json");
   const errors = [];
 
-  validateDocumentationSystemCatalog(catalog, catalogSchema, errors);
+  validateDocumentationSystemCatalog(catalog, catalogSchema, errors, { requireActiveResolution: false });
   assert.deepEqual(errors, []);
   assert.deepEqual(catalog.repositories.map(({ repository }) => repository), [
     "AquilaXk/easysubway",
@@ -2075,6 +2080,27 @@ test("documentation catalog는 proposed 5-repository bootstrap과 fragment lifec
     "AquilaXk/easysubway-mobile",
     "AquilaXk/easysubway-platform",
   ]);
+  assert.equal(catalog.status, "PROPOSED");
+  const mobile = catalog.repositories.find(({ repository }) => repository === "AquilaXk/easysubway-mobile");
+  assert.deepEqual(mobile, {
+    repository: "AquilaXk/easysubway-mobile",
+    status: "ACTIVE",
+    fragment: {
+      gitSha: "397a475a988c65fb31600142d5c79f26e46a03f5",
+      path: "contracts/documentation/documentation-fragment.json",
+      blobSha: "37aa755bf7959737dc68a10ff346f16b5bc1954b",
+      lastVerifiedAt: "2026-08-13T07:33:23.000Z",
+      verificationEvidence: [
+        "https://github.com/AquilaXk/easysubway-mobile/issues/225",
+        "https://github.com/AquilaXk/easysubway/pull/2854",
+      ],
+    },
+  });
+  assert.deepEqual(catalog.repositories.filter(({ repository }) => repository !== mobile.repository)
+    .map(({ status, fragment }) => ({ status, fragment })), Array(4).fill({ status: "PROPOSED", fragment: null }));
+  const unresolvedErrors = [];
+  validateDocumentationSystemCatalog(catalog, catalogSchema, unresolvedErrors);
+  assert.ok(unresolvedErrors.some((error) => error.includes("ACTIVE fragment resolution contract")));
 
   for (const [mutate, expected] of [
     [(value) => value.repositories.pop(), /minItems 5/],
@@ -2938,11 +2964,14 @@ test("문서 거버넌스 계약은 PR·push base와 dispatch current-only CI �
   assert.match(validatorSource, /execFileSync\("\/usr\/bin\/git"/);
   const workflow = readFileSync(".github/workflows/ci.yml", "utf8");
   assert.match(workflow,
-    /Repository CI \/ Validate PR contract transitions[\s\S]{0,400}github\.event_name == 'pull_request'[\s\S]{0,400}--base-ref "\$\{BASE_REF\}"/);
+    /Repository CI \/ Prepare active documentation fragment workspace[\s\S]{0,800}prepare-documentation-fragment-workspace\.mjs[\s\S]{0,800}documentation-fragment-workspace\.json/);
   assert.match(workflow,
-    /Repository CI \/ Validate push contract transitions[\s\S]{0,400}github\.event_name == 'push'[\s\S]{0,400}github\.event\.before[\s\S]{0,400}--base-ref "\$\{BASE_REF\}"/);
+    /Repository CI \/ Validate PR contract transitions[\s\S]{0,600}github\.event_name == 'pull_request'[\s\S]{0,600}--base-ref "\$\{BASE_REF\}"[\s\S]{0,300}--documentation-fragment-workspace/);
   assert.match(workflow,
-    /Repository CI \/ Validate current contracts[\s\S]{0,400}github\.event_name == 'workflow_dispatch'[\s\S]{0,400}--current-only/);
+    /Repository CI \/ Validate push contract transitions[\s\S]{0,600}github\.event_name == 'push'[\s\S]{0,600}github\.event\.before[\s\S]{0,600}--base-ref "\$\{BASE_REF\}"[\s\S]{0,300}--documentation-fragment-workspace/);
+  assert.match(workflow,
+    /Repository CI \/ Validate current contracts[\s\S]{0,600}github\.event_name == 'workflow_dispatch'[\s\S]{0,600}--current-only[\s\S]{0,300}--documentation-fragment-workspace/);
+  assert.doesNotMatch(workflow, /Validate (?:PR|push|current) contract[^\n]*[\s\S]{0,500}--local-contracts-only/);
 });
 
 test("문서 거버넌스 계약은 workspace가 지정한 잘못된 ADR을 contract gate에서 거부한다", () => {
@@ -3384,7 +3413,9 @@ test("boundaries v2는 extraction target ownership metadata의 배열·빈 값·
 });
 
 test("check-contracts CLI 검증 오류가 없다", () => {
-  assert.deepEqual(collectContractErrors(), []);
+  assert.deepEqual(collectContractErrors(undefined, {
+    documentationFragmentResolution: "LOCAL_CONTRACTS_ONLY",
+  }), []);
 });
 
 test("check-contracts는 inventory·freshness·governance 참조를 함께 검증한다", () => {

--- a/tools/ci/clean-checkout-reproducibility-owner-contract.test.mjs
+++ b/tools/ci/clean-checkout-reproducibility-owner-contract.test.mjs
@@ -98,7 +98,7 @@ test("phase entrypoint maps only the four approved commands and fails closed", a
   assert.equal(runHubReproducibilityPhase(["test"], base), 0);
   assert.equal(runHubReproducibilityPhase(["debug"], base), 0);
   assert.deepEqual(calls.map(({ arguments_ }) => arguments_), [
-    ["tools/ci/check-contracts.mjs", "--workspace", "contracts/workspaces/hub.json", "--current-only"],
+    ["tools/ci/check-contracts.mjs", "--workspace", "contracts/workspaces/hub.json", "--current-only", "--local-contracts-only"],
     ["--test", "tools/repo/audit-clean-checkout-reproducibility.test.mjs", "tools/repo/produce-clean-checkout-reproducibility-owner-receipt.test.mjs"],
     ["tools/ci/api-catalog.mjs", "list"],
   ]);

--- a/tools/ci/prepare-documentation-fragment-workspace.mjs
+++ b/tools/ci/prepare-documentation-fragment-workspace.mjs
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+
+import { DOCUMENTATION_REPOSITORIES } from "./documentation-inventory.mjs";
+import { validateSchema } from "./lib/json-schema-lite.mjs";
+import { codepointCompare } from "../lib/codepoint-compare.mjs";
+import { isMainModule } from "../lib/is-main-module.mjs";
+import { validateDocumentationInventoryAuditScope } from "../repo/audit-documentation-inventory.mjs";
+
+const CATALOG_SCHEMA_PATH = new URL(
+  "../../contracts/documentation/documentation-system-catalog.schema.json",
+  import.meta.url,
+);
+const SHA = /^[0-9a-f]{40}$/;
+const SAFE_PATH = /^(?!\/)(?!.*(?:^|\/)\.{1,2}(?:\/|$))(?!.*[?#])[A-Za-z0-9][A-Za-z0-9._/-]*$/;
+const FIXED_REPOSITORIES = new Set(DOCUMENTATION_REPOSITORIES);
+const GIT_ENV = Object.freeze({
+  GIT_ATTR_NOSYSTEM: "1",
+  GIT_CONFIG_GLOBAL: "/dev/null",
+  GIT_CONFIG_NOSYSTEM: "1",
+  GIT_CONFIG_SYSTEM: "/dev/null",
+  GIT_LFS_SKIP_SMUDGE: "1",
+  GIT_TERMINAL_PROMPT: "0",
+});
+const GIT_UNSET = Object.freeze([
+  "GH_TOKEN",
+  "GITHUB_TOKEN",
+  "GIT_ASKPASS",
+  "GIT_CONFIG_COUNT",
+  "GIT_CONFIG_PARAMETERS",
+  "GIT_DIR",
+  "GIT_INDEX_FILE",
+  "GIT_NAMESPACE",
+  "GIT_OBJECT_DIRECTORY",
+  "GIT_QUARANTINE_PATH",
+  "GIT_SSH_COMMAND",
+  "GIT_WORK_TREE",
+  "SSH_AUTH_SOCK",
+]);
+
+function fail(code) {
+  throw new Error(code);
+}
+
+function readJson(path) {
+  try {
+    const absolute = resolve(path);
+    const stat = lstatSync(absolute);
+    if (!stat.isFile() || stat.isSymbolicLink()) fail("DOCUMENTATION_FRAGMENT_WORKSPACE_INPUT_INVALID");
+    return JSON.parse(readFileSync(absolute, "utf8"));
+  } catch (error) {
+    if (error?.message === "DOCUMENTATION_FRAGMENT_WORKSPACE_INPUT_INVALID") throw error;
+    fail("DOCUMENTATION_FRAGMENT_WORKSPACE_INPUT_INVALID");
+  }
+}
+
+function gitEnvironment() {
+  const env = { ...process.env, ...GIT_ENV };
+  for (const key of GIT_UNSET) delete env[key];
+  return env;
+}
+
+function git(root, args, { runGit = execFileSync, encoding = "utf8" } = {}) {
+  return runGit("/usr/bin/git", ["-C", root, ...args], {
+    encoding,
+    env: gitEnvironment(),
+    shell: false,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+export function cloneDocumentationRepository({ repository, defaultBranch, destination }, {
+  runGit = execFileSync,
+} = {}) {
+  if (!FIXED_REPOSITORIES.has(repository) || defaultBranch !== "main" || !isAbsolute(destination)) {
+    fail("DOCUMENTATION_FRAGMENT_WORKSPACE_INPUT_INVALID");
+  }
+  runGit("/usr/bin/git", [
+    "clone",
+    "--no-checkout",
+    "--single-branch",
+    "--branch",
+    defaultBranch,
+    "--no-tags",
+    `https://github.com/${repository}.git`,
+    destination,
+  ], {
+    env: gitEnvironment(),
+    shell: false,
+    stdio: ["ignore", "ignore", "ignore"],
+  });
+}
+
+function validateInputs(catalog, scope) {
+  const errors = [];
+  const catalogSchema = JSON.parse(readFileSync(CATALOG_SCHEMA_PATH, "utf8"));
+  const schemaResult = validateSchema(catalogSchema, catalog);
+  errors.push(...schemaResult.errors);
+  if (schemaResult.ok) {
+    const expected = [...DOCUMENTATION_REPOSITORIES].sort(codepointCompare);
+    const actual = catalog.repositories.map(({ repository }) => repository);
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) errors.push("repository inventory mismatch");
+    for (const entry of catalog.repositories) {
+      if (entry.status === "PROPOSED" && entry.fragment !== null) errors.push("proposed fragment mismatch");
+      if (entry.status === "ACTIVE" && entry.fragment === null) errors.push("active fragment missing");
+    }
+  }
+  validateDocumentationInventoryAuditScope(scope, errors);
+  if (errors.length > 0) fail("DOCUMENTATION_FRAGMENT_WORKSPACE_INPUT_INVALID");
+
+  const scopeByRepository = new Map(scope.repositories.map((entry) => [entry.repository, entry]));
+  const active = catalog.repositories.filter(({ status }) => status === "ACTIVE");
+  for (const entry of active) {
+    const expected = scopeByRepository.get(entry.repository);
+    if (expected == null || expected.defaultBranch !== "main" || expected.requiredStatus !== "ACTIVE"
+        || !SAFE_PATH.test(expected.fragmentPath) || entry.fragment?.path !== expected.fragmentPath
+        || !SHA.test(entry.fragment?.gitSha ?? "")) {
+      fail("DOCUMENTATION_FRAGMENT_WORKSPACE_INPUT_INVALID");
+    }
+  }
+  return active.map((entry) => ({ entry, scope: scopeByRepository.get(entry.repository) }));
+}
+
+function assertCreateOnlyPaths(rootDirectory, outputPath) {
+  if (!isAbsolute(rootDirectory) || !isAbsolute(outputPath)
+      || resolve(rootDirectory) !== rootDirectory || resolve(outputPath) !== outputPath
+      || existsSync(rootDirectory) || existsSync(outputPath)) {
+    fail("DOCUMENTATION_FRAGMENT_WORKSPACE_OUTPUT_EXISTS");
+  }
+  for (const parent of [dirname(rootDirectory), dirname(outputPath)]) {
+    try {
+      if (lstatSync(parent).isSymbolicLink()) {
+        fail("DOCUMENTATION_FRAGMENT_WORKSPACE_OUTPUT_EXISTS");
+      }
+    } catch (error) {
+      if (error?.message === "DOCUMENTATION_FRAGMENT_WORKSPACE_OUTPUT_EXISTS") throw error;
+      fail("DOCUMENTATION_FRAGMENT_WORKSPACE_OUTPUT_EXISTS");
+    }
+  }
+}
+
+function validatePreparedRepository(root, entry, scope) {
+  try {
+    if (lstatSync(root).isSymbolicLink() || realpathSync(root) !== root) throw new Error();
+    if (git(root, ["rev-parse", "--show-toplevel"]).trim() !== root) throw new Error();
+    if (git(root, ["rev-parse", "--show-object-format=storage"]).trim() !== "sha1") throw new Error();
+    if (git(root, ["rev-parse", "--verify", `${entry.fragment.gitSha}^{commit}`]).trim()
+        !== entry.fragment.gitSha) throw new Error();
+    git(root, ["merge-base", "--is-ancestor", entry.fragment.gitSha, `refs/remotes/origin/${scope.defaultBranch}`]);
+  } catch {
+    fail("DOCUMENTATION_FRAGMENT_WORKSPACE_LOCATOR_INVALID");
+  }
+}
+
+export function prepareDocumentationFragmentWorkspace({
+  catalogPath,
+  scopePath,
+  rootDirectory,
+  outputPath,
+}, {
+  cloneRepository = cloneDocumentationRepository,
+} = {}) {
+  const catalog = readJson(catalogPath);
+  const scope = readJson(scopePath);
+  const active = validateInputs(catalog, scope);
+  assertCreateOnlyPaths(rootDirectory, outputPath);
+  mkdirSync(rootDirectory, { mode: 0o700 });
+  const canonicalRootDirectory = realpathSync(rootDirectory);
+
+  const repositories = [];
+  for (const { entry, scope: scopeEntry } of active) {
+    const destination = join(canonicalRootDirectory, entry.repository.slice(entry.repository.indexOf("/") + 1));
+    try {
+      cloneRepository({
+        repository: entry.repository,
+        defaultBranch: scopeEntry.defaultBranch,
+        destination,
+      });
+    } catch (error) {
+      if (/^DOCUMENTATION_FRAGMENT_WORKSPACE_[A-Z_]+$/.test(error?.message ?? "")) throw error;
+      fail("DOCUMENTATION_FRAGMENT_WORKSPACE_CLONE_FAILED");
+    }
+    validatePreparedRepository(destination, entry, scopeEntry);
+    repositories.push({ repository: entry.repository, root: destination });
+  }
+
+  const workspace = { schemaVersion: 1, repositories };
+  try {
+    writeFileSync(outputPath, `${JSON.stringify(workspace)}\n`, { encoding: "utf8", flag: "wx", mode: 0o600 });
+  } catch {
+    fail("DOCUMENTATION_FRAGMENT_WORKSPACE_OUTPUT_EXISTS");
+  }
+  return workspace;
+}
+
+function parseArguments(args) {
+  if (args.length !== 8 || args[0] !== "--catalog" || args[2] !== "--scope"
+      || args[4] !== "--root" || args[6] !== "--output"
+      || args.some((value, index) => index % 2 === 1 && value.trim() === "")) {
+    fail("DOCUMENTATION_FRAGMENT_WORKSPACE_USAGE");
+  }
+  return {
+    catalogPath: args[1],
+    scopePath: args[3],
+    rootDirectory: args[5],
+    outputPath: args[7],
+  };
+}
+
+if (isMainModule(import.meta.url)) {
+  try {
+    const workspace = prepareDocumentationFragmentWorkspace(parseArguments(process.argv.slice(2)));
+    process.stdout.write(`${JSON.stringify({
+      status: "COMPLETE",
+      activeRepositoryCount: workspace.repositories.length,
+    })}\n`);
+  } catch (error) {
+    const code = /^DOCUMENTATION_FRAGMENT_WORKSPACE_[A-Z_]+$/.test(error?.message ?? "")
+      ? error.message
+      : "DOCUMENTATION_FRAGMENT_WORKSPACE_FAILED";
+    process.stderr.write(`${code}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/tools/ci/prepare-documentation-fragment-workspace.test.mjs
+++ b/tools/ci/prepare-documentation-fragment-workspace.test.mjs
@@ -1,0 +1,178 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import test from "node:test";
+
+import {
+  cloneDocumentationRepository,
+  prepareDocumentationFragmentWorkspace,
+} from "./prepare-documentation-fragment-workspace.mjs";
+
+const MOBILE = "AquilaXk/easysubway-mobile";
+const FRAGMENT_PATH = "contracts/documentation/documentation-fragment.json";
+const LAST_VERIFIED_AT = "2026-08-13T07:33:23.000Z";
+const EVIDENCE = [
+  "https://github.com/AquilaXk/easysubway-mobile/issues/225",
+  "https://github.com/AquilaXk/easysubway/pull/2854",
+];
+
+function git(root, args) {
+  return execFileSync("/usr/bin/git", ["-C", root, ...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function createRepository(directory) {
+  const root = join(directory, "source-repository");
+  mkdirSync(root);
+  execFileSync("/usr/bin/git", ["init", "--initial-branch=main", root], { stdio: "ignore" });
+  git(root, ["config", "user.email", "test@example.com"]);
+  git(root, ["config", "user.name", "Test"]);
+  writeFileSync(join(root, "resource.txt"), "source\n");
+  git(root, ["add", "resource.txt"]);
+  git(root, ["commit", "-m", "source"]);
+  const sourceSha = git(root, ["rev-parse", "HEAD"]);
+  mkdirSync(join(root, "contracts/documentation"), { recursive: true });
+  writeFileSync(join(root, FRAGMENT_PATH), "{}\n");
+  git(root, ["add", FRAGMENT_PATH]);
+  git(root, ["commit", "-m", "fragment"]);
+  const outerSha = git(root, ["rev-parse", "HEAD"]);
+  git(root, ["branch", "side", sourceSha]);
+  git(root, ["switch", "side"]);
+  writeFileSync(join(root, "side.txt"), "side\n");
+  git(root, ["add", "side.txt"]);
+  git(root, ["commit", "-m", "side"]);
+  const sideSha = git(root, ["rev-parse", "HEAD"]);
+  git(root, ["switch", "main"]);
+  git(root, ["update-ref", "refs/remotes/origin/main", outerSha]);
+  return { root, sourceSha, outerSha, sideSha };
+}
+
+function writeInputs(directory, outerSha, mutate = () => {}) {
+  const catalog = JSON.parse(readFileSync("contracts/documentation/documentation-system-catalog.json", "utf8"));
+  const scope = JSON.parse(readFileSync("contracts/documentation/documentation-inventory-audit-scope.json", "utf8"));
+  const mobile = catalog.repositories.find(({ repository }) => repository === MOBILE);
+  mobile.status = "ACTIVE";
+  mobile.fragment = {
+    gitSha: outerSha,
+    path: FRAGMENT_PATH,
+    blobSha: "a".repeat(40),
+    lastVerifiedAt: LAST_VERIFIED_AT,
+    verificationEvidence: EVIDENCE,
+  };
+  mutate({ catalog, scope, mobile });
+  const catalogPath = join(directory, "catalog.json");
+  const scopePath = join(directory, "scope.json");
+  writeFileSync(catalogPath, `${JSON.stringify(catalog)}\n`);
+  writeFileSync(scopePath, `${JSON.stringify(scope)}\n`);
+  return { catalogPath, scopePath };
+}
+
+function copiedClone(source) {
+  return ({ destination }) => cpSync(source, destination, { recursive: true });
+}
+
+test("documentation fragment workspace preparer creates one exact ACTIVE mapping", () => {
+  const directory = mkdtempSync(join(tmpdir(), "documentation-fragment-workspace-"));
+  try {
+    const repository = createRepository(directory);
+    const inputs = writeInputs(directory, repository.outerSha);
+    const rootDirectory = join(directory, "prepared");
+    const outputPath = join(directory, "workspace.json");
+    const result = prepareDocumentationFragmentWorkspace({
+      ...inputs,
+      rootDirectory,
+      outputPath,
+    }, { cloneRepository: copiedClone(repository.root) });
+
+    assert.deepEqual(result, {
+      schemaVersion: 1,
+      repositories: [{ repository: MOBILE, root: resolve(rootDirectory, "easysubway-mobile") }],
+    });
+    assert.deepEqual(JSON.parse(readFileSync(outputPath, "utf8")), result);
+    assert.equal(git(result.repositories[0].root, ["rev-parse", "--verify", `${repository.outerSha}^{commit}`]), repository.outerSha);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("documentation fragment workspace preparer rejects unowned input and non-ancestor locator", () => {
+  const cases = [
+    ["repository", ({ mobile }) => { mobile.repository = "AquilaXk/unowned"; }],
+    ["path", ({ mobile }) => { mobile.fragment.path = "contracts/other.json"; }],
+    ["branch", ({ scope }) => { scope.repositories.find(({ repository }) => repository === MOBILE).defaultBranch = "release"; }],
+  ];
+  for (const [name, mutate] of cases) {
+    const directory = mkdtempSync(join(tmpdir(), `documentation-fragment-${name}-`));
+    try {
+      const repository = createRepository(directory);
+      const inputs = writeInputs(directory, repository.outerSha, mutate);
+      assert.throws(() => prepareDocumentationFragmentWorkspace({
+        ...inputs,
+        rootDirectory: join(directory, "prepared"),
+        outputPath: join(directory, "workspace.json"),
+      }, { cloneRepository: copiedClone(repository.root) }), /DOCUMENTATION_FRAGMENT_WORKSPACE_INPUT_INVALID/);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  }
+
+  const directory = mkdtempSync(join(tmpdir(), "documentation-fragment-ancestor-"));
+  try {
+    const repository = createRepository(directory);
+    const inputs = writeInputs(directory, repository.sideSha);
+    assert.throws(() => prepareDocumentationFragmentWorkspace({
+      ...inputs,
+      rootDirectory: join(directory, "prepared"),
+      outputPath: join(directory, "workspace.json"),
+    }, { cloneRepository: copiedClone(repository.root) }), /DOCUMENTATION_FRAGMENT_WORKSPACE_LOCATOR_INVALID/);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("documentation fragment workspace preparer is create-only and rejects symlink roots", () => {
+  for (const kind of ["root", "output", "symlink"]) {
+    const directory = mkdtempSync(join(tmpdir(), `documentation-fragment-${kind}-`));
+    try {
+      const repository = createRepository(directory);
+      const inputs = writeInputs(directory, repository.outerSha);
+      const rootDirectory = join(directory, "prepared");
+      const outputPath = join(directory, "workspace.json");
+      if (kind === "root") mkdirSync(rootDirectory);
+      if (kind === "output") writeFileSync(outputPath, "existing\n");
+      if (kind === "symlink") symlinkSync(repository.root, rootDirectory);
+      assert.throws(() => prepareDocumentationFragmentWorkspace({
+        ...inputs,
+        rootDirectory,
+        outputPath,
+      }, { cloneRepository: copiedClone(repository.root) }), /DOCUMENTATION_FRAGMENT_WORKSPACE_OUTPUT_EXISTS/);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  }
+});
+
+test("documentation repository clone uses fixed public no-checkout single-branch arguments", () => {
+  const calls = [];
+  cloneDocumentationRepository({
+    repository: MOBILE,
+    defaultBranch: "main",
+    destination: "/tmp/documentation-fragments/easysubway-mobile",
+  }, {
+    runGit: (executable, arguments_, options) => calls.push({ executable, arguments_, options }),
+  });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].executable, "/usr/bin/git");
+  assert.deepEqual(calls[0].arguments_, [
+    "clone", "--no-checkout", "--single-branch", "--branch", "main", "--no-tags",
+    "https://github.com/AquilaXk/easysubway-mobile.git",
+    "/tmp/documentation-fragments/easysubway-mobile",
+  ]);
+  assert.equal(calls[0].options.shell, false);
+  assert.deepEqual(calls[0].options.stdio, ["ignore", "ignore", "ignore"]);
+  assert.equal(calls[0].options.env.GIT_TERMINAL_PROMPT, "0");
+});

--- a/tools/ci/prepare-documentation-fragment-workspace.test.mjs
+++ b/tools/ci/prepare-documentation-fragment-workspace.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import test from "node:test";
@@ -90,7 +90,7 @@ test("documentation fragment workspace preparer creates one exact ACTIVE mapping
 
     assert.deepEqual(result, {
       schemaVersion: 1,
-      repositories: [{ repository: MOBILE, root: resolve(rootDirectory, "easysubway-mobile") }],
+      repositories: [{ repository: MOBILE, root: resolve(realpathSync(rootDirectory), "easysubway-mobile") }],
     });
     assert.deepEqual(JSON.parse(readFileSync(outputPath, "utf8")), result);
     assert.equal(git(result.repositories[0].root, ["rev-parse", "--verify", `${repository.outerSha}^{commit}`]), repository.outerSha);

--- a/tools/ci/run-clean-checkout-reproducibility-phase.mjs
+++ b/tools/ci/run-clean-checkout-reproducibility-phase.mjs
@@ -11,7 +11,7 @@ const TOOLCHAIN_LOCK_PATH = "tools/qa/package-lock.json";
 const TOOLCHAIN_DIGEST = "2bafa62df07a90cbc8501e2cc9c7f7abdcbb99069462893ab7f0c2ce02b31ac1";
 
 const COMMANDS = new Map([
-  ["build", ["tools/ci/check-contracts.mjs", "--workspace", "contracts/workspaces/hub.json", "--current-only"]],
+  ["build", ["tools/ci/check-contracts.mjs", "--workspace", "contracts/workspaces/hub.json", "--current-only", "--local-contracts-only"]],
   ["test", ["--test", "tools/repo/audit-clean-checkout-reproducibility.test.mjs", "tools/repo/produce-clean-checkout-reproducibility-owner-receipt.test.mjs"]],
   ["debug", ["tools/ci/api-catalog.mjs", "list"]],
 ]);


### PR DESCRIPTION
## 관련 이슈 / Related issue

Closes #2857

Refs #2748

## 작업 배경 / Summary

- Problem: terminal Mobile documentation fragment가 공개됐지만 Hub catalog는 `PROPOSED/null`이고, ACTIVE 전환 시 Repository CI에는 exact Git workspace가 없으며 D13 clean-checkout은 network-none 경계다.
- Outcome: normal CI가 fixed allowlist의 ACTIVE repository를 runner temp에 no-checkout clone해 exact transport를 검증하고, Mobile row만 terminal locator로 `ACTIVE` 소비한다. D13은 admission evidence가 아닌 local-contract-only scope를 명시한다.

## 작업 내용 / Changes

- Mobile terminal commit/blob/header evidence를 system catalog의 Mobile row에 고정했다.
- catalog/scope 기반 generic fragment workspace preparer와 create-only·ancestor·allowlist failure matrix를 추가했다.
- Repository CI의 PR/push/workflow_dispatch contract gate가 generated workspace를 반드시 사용하도록 연결했다.
- `check-contracts`에 current-only 전용 `--local-contracts-only`를 추가하고 normal ACTIVE workspace 누락 failure를 보존했다.
- D13 BUILD와 ADR local schema confirmation을 exact local-only 명령으로 동기화했다.

## Scope

### Included

- Mobile ACTIVE catalog locator와 exact header parity
- Repository CI federated fragment Git workspace transport
- D13 Hub offline local-contract boundary
- 관련 contract/CLI/workflow/preparer 테스트

### Excluded

- Mobile fragment 또는 target 저장소 변경
- 다른 네 repository catalog slot 활성화
- runtime/data/deploy/release와 D20/D22/D33/D35 auditor 변경
- fragment copy, mutable/stale/shallow fallback, credential inheritance

### Ownership / dependencies

- Accountable owner or plan: `PLAN-DOC`
- Required predecessor output: Hub #2853/#2855 terminal, Mobile #225 terminal merge `397a475a988c65fb31600142d5c79f26e46a03f5`
- Concurrent work overlap: open Hub PR #2823은 backend Docker dependency-only 1-path이며 overlap 없음

## Documentation impact

- 영향 resource ID 또는 `NONE`: Mobile fragment의 11개 existing resource를 catalog transport에 ACTIVE 연결
- resourceClass: existing fragment references only
- documentationFamily: 11개 전 family
- lifecycle/evidence 영향: Mobile row `PROPOSED → ACTIVE`; catalog top-level과 나머지 four rows는 `PROPOSED` 유지

## 검증 / Verification

| Check | Result / Evidence |
| --- | --- |
| Focused RED → GREEN | RED `d50ac61b`: preparer 부재, catalog/ADR/workflow/CLI 4 failures, D13 1 failure → GREEN `1fab1b4b` |
| Affected integration | preparer 4/4, catalog/ADR/workflow/CLI 5/5, D13 3/3 |
| Required CI | exact-head run `31688989573` 전부 PASS; required contexts `Changes`, `Repository CI`, `Backend CI`, `Mobile App CI`, `Android CI` green |
| Manual / production-like | 불필요 — UI·배포 변경 없음 |
| Security / privacy / accessibility | fixed public repository allowlist, credential env 제거, no-checkout/create-only/sanitized failure 테스트 |

- 실행한 명령과 결과:
  - `node --test tools/ci/prepare-documentation-fragment-workspace.test.mjs` → 4/4 PASS
  - named `tools/ci/check-contracts.test.mjs` → 5/5 PASS
  - `node --test tools/ci/clean-checkout-reproducibility-owner-contract.test.mjs` → 3/3 PASS
  - current-only real Mobile Git workspace contract gate → PASS
  - exact base `558ca5bd…` transition gate → PASS
  - `git diff --check` → PASS

## 검증 증거

UI·접근성·수동 QA·배포 증거는 필요 없다. Machine contract/CI 변경이므로 required CI `31688989573`, CodeRabbit GitHub Review `4925750288`, blocking finding 0, resolved/unresolved thread `2/0`을 확인했다. Exact merge SHA는 병합 뒤 terminal evidence로 남긴다.

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName / versionCode: 변경 없음
- datapack version: 변경 없음
- route / realtime contract: 변경 없음
- backend identity: 변경 없음

## Not run

- Check: repository-wide local suite, D13 live workflow dispatch
- Reason: owner resource 경계상 full regression은 required CI가 소유하며 D13 live receipt는 이 catalog consumer의 완료 조건이 아니다.
- Rerun owner / condition: required CI가 affected failure를 보고할 때 해당 job 범위만 재검증

## 리뷰어 메모 / Review focus

- 리뷰어가 먼저 봐야 할 지점: normal CI의 ACTIVE resolution이 필수인지, local-only가 current-only D13/ADR 외 경로로 확장되지 않는지, clone이 fixed public allowlist/no-checkout/create-only인지 확인해 주세요.

## 리스크 / Risk

- Level: High (R2)
- Main risk: federated workspace 준비 실패로 Repository CI가 중단되거나 local-only mode가 admission을 우회할 위험
- Failure behavior: stable sanitized nonzero; normal ACTIVE workspace 누락은 계속 실패
- State mutation on failure: runner temp의 incomplete clone만 남고 catalog/remote/target repository mutation 없음
- Fallback or degraded-success path introduced: No

## Rollout / Recovery

- Rollout or activation: merge 후 Hub PR/push/dispatch contract gate가 Mobile ACTIVE fragment를 exact Git identity로 검증
- Monitoring / success signal: required Repository CI green, current-head thread 0, post-merge contract workflow failure 없음
- Rollback or recovery: 문제 시 후속 reviewed catalog/CI correction; stale fragment 또는 local-only admission으로 대체하지 않음
- Data / config compatibility after rollback: target fragment와 runtime/data/config는 변경하지 않음

## 체크리스트 / Checklist

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] 이슈 범위와 실제 diff가 일치하며 관련 없는 변경을 포함하지 않았다.
- [x] 위험에 필요한 검증과 미실행 사유를 기록했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향 없음 — CD 상태 확인 불필요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 문서 계약 검증을 위한 문서 조각 워크스페이스 준비 기능을 추가했습니다.
  * 로컬 문서 계약만 검증하는 옵션을 지원합니다.
  * 활성 문서 저장소의 커밋, 경로 및 검증 정보를 확인합니다.

* **개선 사항**
  * CI 환경에서 문서 계약 검증이 공통 워크스페이스를 사용하도록 개선했습니다.
  * 잘못된 검증 옵션 조합을 명확히 거부합니다.
  * 문서 카탈로그의 검증된 항목 상태를 최신화했습니다.

* **테스트**
  * 워크스페이스 생성, 저장소 검증, 오류 처리 및 CI 계약 검증 테스트를 추가·갱신했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->