### PR TITLE
[Docs] Hub ACTIVE fragment catalog 소비

### DIFF
--- a/contracts/documentation/documentation-system-catalog.json
+++ b/contracts/documentation/documentation-system-catalog.json
@@ -11,7 +11,21 @@
     "gaps": ["gap:kubernetes:platform-deployment-contract"]
   },
   "repositories": [
-    { "repository": "AquilaXk/easysubway", "status": "PROPOSED", "fragment": null },
+    {
+      "repository": "AquilaXk/easysubway",
+      "status": "ACTIVE",
+      "fragment": {
+        "gitSha": "71d03cbb20cca0a1b358c921febe9ca646ad06b3",
+        "path": "contracts/documentation/documentation-fragment.json",
+        "blobSha": "317d93550975428f8e72c5ead516e3e101c74172",
+        "lastVerifiedAt": "2026-08-13T13:32:18.000Z",
+        "verificationEvidence": [
+          "https://github.com/AquilaXk/easysubway/issues/2748",
+          "https://github.com/AquilaXk/easysubway/issues/2861",
+          "https://github.com/AquilaXk/easysubway/issues/2863"
+        ]
+      }
+    },
     {
       "repository": "AquilaXk/easysubway-backend",
       "status": "ACTIVE",

--- a/tools/ci/check-contracts.test.mjs
+++ b/tools/ci/check-contracts.test.mjs
@@ -2075,7 +2075,7 @@ test("문서 거버넌스 계약은 ADR-HUB-0001 실물을 허용한다", () => 
   assert.ok(adr.confirmation.some(({ method }) => method.endsWith("--current-only --local-contracts-only")));
 });
 
-test("documentation catalog는 terminal Backend와 Mobile locator를 ACTIVE로 소비하고 fragment lifecycle을 fail closed한다", () => {
+test("documentation catalog는 terminal Hub, Backend와 Mobile locator를 ACTIVE로 소비하고 fragment lifecycle을 fail closed한다", () => {
   const resourceSchema = loadJson("contracts/documentation/documentation-resource.schema.json");
   const fragmentSchema = loadJson("contracts/documentation/documentation-fragment.schema.json");
   const catalogSchema = loadJson("contracts/documentation/documentation-system-catalog.schema.json");
@@ -2092,6 +2092,22 @@ test("documentation catalog는 terminal Backend와 Mobile locator를 ACTIVE로 �
     "AquilaXk/easysubway-platform",
   ]);
   assert.equal(catalog.status, "PROPOSED");
+  const hub = catalog.repositories.find(({ repository }) => repository === "AquilaXk/easysubway");
+  assert.deepEqual(hub, {
+    repository: "AquilaXk/easysubway",
+    status: "ACTIVE",
+    fragment: {
+      gitSha: "71d03cbb20cca0a1b358c921febe9ca646ad06b3",
+      path: "contracts/documentation/documentation-fragment.json",
+      blobSha: "317d93550975428f8e72c5ead516e3e101c74172",
+      lastVerifiedAt: "2026-08-13T13:32:18.000Z",
+      verificationEvidence: [
+        "https://github.com/AquilaXk/easysubway/issues/2748",
+        "https://github.com/AquilaXk/easysubway/issues/2861",
+        "https://github.com/AquilaXk/easysubway/issues/2863",
+      ],
+    },
+  });
   const backend = catalog.repositories.find(({ repository }) => repository === "AquilaXk/easysubway-backend");
   assert.deepEqual(backend, {
     repository: "AquilaXk/easysubway-backend",
@@ -2124,8 +2140,8 @@ test("documentation catalog는 terminal Backend와 Mobile locator를 ACTIVE로 �
       ],
     },
   });
-  assert.deepEqual(catalog.repositories.filter(({ repository }) => ![backend.repository, mobile.repository].includes(repository))
-    .map(({ status, fragment }) => ({ status, fragment })), Array(3).fill({ status: "PROPOSED", fragment: null }));
+  assert.deepEqual(catalog.repositories.filter(({ repository }) => ![hub.repository, backend.repository, mobile.repository].includes(repository))
+    .map(({ status, fragment }) => ({ status, fragment })), Array(2).fill({ status: "PROPOSED", fragment: null }));
   const unresolvedErrors = [];
   validateDocumentationSystemCatalog(catalog, catalogSchema, unresolvedErrors);
   assert.ok(unresolvedErrors.some((error) => error.includes("ACTIVE fragment resolution contract")));
@@ -2134,7 +2150,7 @@ test("documentation catalog는 terminal Backend와 Mobile locator를 ACTIVE로 �
     [(value) => value.repositories.pop(), /minItems 5/],
     [(value) => value.repositories.push(structuredClone(value.repositories[0])), /maxItems 5/],
     [(value) => { value.repositories[0].repository = "AquilaXk/unknown"; }, /enum/],
-    [(value) => { value.repositories[0].status = "ACTIVE"; }, /ACTIVE fragment가 필요하다/],
+    [(value) => { value.repositories[0].status = "ACTIVE"; value.repositories[0].fragment = null; }, /ACTIVE fragment가 필요하다/],
     [(value) => { value.repositories[0].resources = []; }, /resources/],
   ]) {
     const invalid = structuredClone(catalog);


### PR DESCRIPTION
## 관련 이슈 / Related issue

Closes #2865
Refs #2748
Refs #2861
Refs #2863

## 작업 배경 / Summary

- Problem: corrected terminal Hub fragment가 존재하지만 system catalog Hub row는 `PROPOSED/null`이라 aggregate input으로 준비되지 않는다.
- Outcome: exact immutable outer locator를 Hub row 하나에 `ACTIVE`로 연결한다.

## 작업 내용 / Changes

- `contracts/documentation/documentation-system-catalog.json`의 Hub row만 exact terminal commit/path/blob/time/evidence로 갱신했다.
- named catalog contract test가 Hub/Backend/Mobile exact ACTIVE locators, Data/Platform `PROPOSED/null`, top-level `PROPOSED`를 고정한다.
- generic preparer·workflow·schema·validator와 target repository는 변경하지 않았다.

## Scope

### Included

- corrected Hub fragment immutable locator consumption.
- anchored catalog contract expectation and lifecycle fail-closed coverage.

### Excluded

- fragment/schema/validator/preparer/workflow/ADR/inventory scope 변경.
- Backend/Mobile/Data/Platform catalog row와 top-level status 변경.
- runtime/data/deploy/release/public claim 변경.

### Ownership / dependencies

- Accountable owner or plan: `PLAN-DOC`, Hub #2748 / child #2865.
- Required predecessor output: Hub correction merge `71d03cbb20cca0a1b358c921febe9ca646ad06b3`, fragment blob `317d93550975428f8e72c5ead516e3e101c74172`.
- Concurrent work overlap: None — catalog JSON + anchored contract test two-file tuple.

## Documentation impact

- 영향 resource ID 또는 `NONE`: `AquilaXk/easysubway:contracts/documentation/documentation-system-catalog.json`
- resourceClass: federated system catalog
- documentationFamily: Hub의 11-family ACTIVE fragment locator consumption
- lifecycle/evidence 영향: Hub row만 `ACTIVE`; aggregate/top-level 완료 상태는 주장하지 않는다.

## 검증 / Verification

| Check | Result / Evidence |
| --- | --- |
| Focused RED → GREEN | RED commit `7b13b6b5`: Hub row `PROPOSED/null` mismatch 1건. GREEN head `00040ff57cea8f690dda971b00b4b18e755f1c04`: anchored test 1/1 PASS. |
| Affected integration | `git diff --check` PASS; exact two-file allowlist and base ancestry PASS. |
| Required CI | Initial exact-head run `31709046859`: Hub+Backend+Mobile transport/aggregate 포함 Repository/Backend/Mobile/Android/Admin/Release Gate/OSV all green. Review metadata 동기화 뒤 final same-head run은 완료 시점에 갱신한다. |
| Supported Review | Ready 뒤 CodeRabbit GitHub Review 객체 0건이라 canonical Codex CLI R2 fallback Review `4928209177`을 exact head `00040ff57cea8f690dda971b00b4b18e755f1c04`에 게시했다. Actionable 0, frozen blocking finding 0. |
| Manual / production-like | Not required — machine catalog/test only, runtime/UI/deploy 변경 없음. |
| Security / privacy / accessibility | Sensitive payload, public claim, runtime/security/accessibility behavior 변경 없음. |

- 실행한 명령과 결과:
  - `node --test --test-name-pattern '^documentation catalog는 terminal Hub, Backend와 Mobile locator를 ACTIVE로 소비하고 fragment lifecycle을 fail closed한다$' tools/ci/check-contracts.test.mjs`: RED 0/1 → GREEN 1/1.
  - `git diff --check`: PASS.

## 검증 증거

UI·수동 QA·배포 증거는 필요 없다. Immutable locator와 RED/GREEN output은 issue #2865와 task-local evidence에 기록했다.

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName / versionCode: 변경 없음
- datapack version: 변경 없음
- route / realtime contract: 변경 없음
- backend identity: 변경 없음

## Not run

- Check: repository-wide local suite / real multi-repository clone.
- Reason: exact affected contract test를 검증했고 full-history transport/aggregate와 full regression은 required Repository CI가 소유한다.
- Rerun owner / condition: Ready/Review/body metadata가 same-head CI를 만들면 final run만 확인한다.

## 리뷰어 메모 / Review focus

- 리뷰어가 먼저 봐야 할 지점: Hub locator가 merge commit/blob/header와 정확히 일치하는지, 다른 네 row와 top-level status가 보존되는지, self-consumer drift가 재도입되지 않는지.

## 리스크 / Risk

- Level: High (R2 federated Git identity / aggregate input)
- Main risk: wrong locator가 three-repository aggregate를 fail closed시키거나 stale Hub resource를 current로 오인하게 만드는 것.
- Failure behavior: repository/path/commit/blob/header/evidence/ancestry/current parity mismatch는 CI contract에서 실패한다.
- State mutation on failure: 없음.
- Fallback or degraded-success path introduced: No

## Rollout / Recovery

- Rollout or activation: merge 후 normal Repository CI가 Hub+Backend+Mobile exact workspaces를 준비한다.
- Monitoring / success signal: required CI green, supported Review, catalog validator/aggregate PASS.
- Rollback or recovery: catalog row를 `PROPOSED/null`로 되돌리고 verified new locator change set을 발행한다.
- Data / config compatibility after rollback: runtime/data/config 영향 없음.

## 체크리스트 / Checklist

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] 이슈 범위와 실제 diff가 일치하며 관련 없는 변경을 포함하지 않았다.
- [x] 위험에 필요한 검증과 미실행 사유를 기록했다.
- [x] CodeRabbit 리뷰를 확인했다. Ready 뒤 GitHub Review 객체 0건이었다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음)
