### PR TITLE
[Docs] D01-D05 문서 감사 public Git provider 교정

### DIFF
--- a/.github/workflows/documentation-inventory-audit.yml
+++ b/.github/workflows/documentation-inventory-audit.yml
@@ -26,8 +26,6 @@ jobs:
           node-version: "24"
       - name: Audit current five-fragment documentation inventory
         shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           EVIDENCE_DIR="audit-evidence"
@@ -42,6 +40,7 @@ jobs:
             --report-schema contracts/documentation/documentation-inventory-audit-report.schema.json \
             --source-sha "${GITHUB_SHA}" \
             --observed-at "${OBSERVED_AT}" \
+            --repository-root "${RUNNER_TEMP}/documentation-inventory-repositories-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
             --output "${REPORT_PATH}"
       - name: Upload sanitized documentation inventory audit
         if: ${{ always() }}

--- a/tools/repo/audit-documentation-inventory.mjs
+++ b/tools/repo/audit-documentation-inventory.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
-import { open, readFile } from "node:fs/promises";
+import { mkdir, open, readFile, realpath } from "node:fs/promises";
+import { dirname, isAbsolute, join, resolve } from "node:path";
 import { promisify } from "node:util";
 import { codepointCompare } from "../lib/codepoint-compare.mjs";
 import { isMainModule } from "../lib/is-main-module.mjs";
@@ -20,6 +21,29 @@ const FRAGMENT_PATH = "contracts/documentation/documentation-fragment.json";
 const SHA = /^[0-9a-f]{40}$/;
 const DIGEST = /^[0-9a-f]{64}$/;
 const execFileAsync = promisify(execFile);
+const GIT_ENV = Object.freeze({
+  GIT_ATTR_NOSYSTEM: "1",
+  GIT_CONFIG_GLOBAL: "/dev/null",
+  GIT_CONFIG_NOSYSTEM: "1",
+  GIT_CONFIG_SYSTEM: "/dev/null",
+  GIT_LFS_SKIP_SMUDGE: "1",
+  GIT_TERMINAL_PROMPT: "0",
+});
+const GIT_UNSET = Object.freeze([
+  "GH_TOKEN",
+  "GITHUB_TOKEN",
+  "GIT_ASKPASS",
+  "GIT_CONFIG_COUNT",
+  "GIT_CONFIG_PARAMETERS",
+  "GIT_DIR",
+  "GIT_INDEX_FILE",
+  "GIT_NAMESPACE",
+  "GIT_OBJECT_DIRECTORY",
+  "GIT_QUARANTINE_PATH",
+  "GIT_SSH_COMMAND",
+  "GIT_WORK_TREE",
+  "SSH_AUTH_SOCK",
+]);
 const FRAGMENT_SCHEMA = JSON.parse(await readFile(new URL("../../contracts/documentation/documentation-fragment.schema.json", import.meta.url), "utf8"));
 const RESOURCE_SCHEMA = JSON.parse(await readFile(new URL("../../contracts/documentation/documentation-resource.schema.json", import.meta.url), "utf8"));
 
@@ -38,6 +62,23 @@ const exactKeys = (value, keys) => value != null && typeof value === "object" &&
 const safePath = (value) => typeof value === "string" && /^(?!\/)(?!.*(?:^|\/)\.{1,2}(?:\/|$))(?!.*[?#])[A-Za-z0-9][A-Za-z0-9._/-]*$/.test(value);
 const fallbackScope = () => ({ schemaVersion: 1, repositories: EXPECTED_REPOSITORIES.map((repository) => ({ repository, defaultBranch: "main", fragmentPath: FRAGMENT_PATH, requiredStatus: "ACTIVE" })), dods: [...EXPECTED_DODS] });
 
+function gitEnvironment() {
+  const env = { ...process.env, ...GIT_ENV };
+  for (const key of GIT_UNSET) delete env[key];
+  return env;
+}
+
+async function executeGit(execute, arguments_, encoding = "utf8") {
+  const result = await execute("/usr/bin/git", arguments_, {
+    encoding,
+    env: gitEnvironment(),
+    shell: false,
+    timeout: 120_000,
+    maxBuffer: 8 * 1024 * 1024,
+  });
+  return result.stdout;
+}
+
 export function validateDocumentationInventoryAuditScope(scope, errors = []) {
   if (scope?.schemaVersion !== 1 || !Array.isArray(scope.repositories) || !Array.isArray(scope.dods)) return [...errors, "scope shape mismatch"];
   const repositories = scope.repositories.map((entry) => entry != null && typeof entry === "object" && !Array.isArray(entry) ? entry.repository : null);
@@ -47,6 +88,90 @@ export function validateDocumentationInventoryAuditScope(scope, errors = []) {
     if (entry == null || typeof entry !== "object" || Array.isArray(entry) || !exactKeys(entry, ["repository", "defaultBranch", "fragmentPath", "requiredStatus"]) || entry.defaultBranch !== "main" || entry.fragmentPath !== FRAGMENT_PATH || !safePath(entry.fragmentPath) || entry.requiredStatus !== "ACTIVE") errors.push(`repository contract mismatch:${entry?.repository ?? "unknown"}`);
   }
   return errors;
+}
+
+export async function createDocumentationInventoryGitProvider(scope, {
+  repositoryRoot,
+  execute = execFileAsync,
+} = {}) {
+  if (validateDocumentationInventoryAuditScope(scope).length !== 0
+      || typeof repositoryRoot !== "string"
+      || !isAbsolute(repositoryRoot)
+      || resolve(repositoryRoot) !== repositoryRoot) {
+    throw new AuditIncomplete("GIT_PROVIDER_INPUT_INVALID", "repository-root");
+  }
+  let canonicalRoot;
+  try {
+    await realpath(dirname(repositoryRoot));
+    await mkdir(repositoryRoot, { mode: 0o700 });
+    canonicalRoot = await realpath(repositoryRoot);
+  } catch {
+    throw new AuditIncomplete("GIT_PROVIDER_INPUT_INVALID", "repository-root");
+  }
+
+  const roots = new Map();
+  for (const { repository, defaultBranch } of scope.repositories) {
+    const destination = join(canonicalRoot, repository.slice(repository.indexOf("/") + 1));
+    try {
+      await executeGit(execute, [
+        "clone",
+        "--no-checkout",
+        "--single-branch",
+        "--branch",
+        defaultBranch,
+        "--no-tags",
+        `https://github.com/${repository}.git`,
+        destination,
+      ]);
+    } catch {
+      throw new AuditIncomplete("GIT_PROVIDER_UNAVAILABLE", repository);
+    }
+    roots.set(repository, destination);
+  }
+
+  const repositoryRootFor = (repository) => {
+    const root = roots.get(repository);
+    if (root == null) throw new AuditIncomplete("GIT_PROVIDER_INPUT_INVALID", repository);
+    return root;
+  };
+  const readHead = async (repository, branch) => {
+    if (branch !== "main") throw new AuditIncomplete("GIT_PROVIDER_INPUT_INVALID", repository);
+    let head;
+    try {
+      head = String(await executeGit(execute, ["-C", repositoryRootFor(repository), "rev-parse", "--verify", `refs/remotes/origin/${branch}^{commit}`])).trim();
+    } catch (error) {
+      if (error instanceof AuditIncomplete) throw error;
+      throw new AuditIncomplete("GIT_PROVIDER_UNAVAILABLE", repository);
+    }
+    if (!SHA.test(head)) throw new AuditIncomplete("HEAD_PROVIDER_MALFORMED", repository);
+    return head;
+  };
+  const readContent = async (repository, path, sha) => {
+    if (!safePath(path) || !SHA.test(sha)) throw new AuditIncomplete("GIT_PROVIDER_INPUT_INVALID", `${repository}:${path}`);
+    const root = repositoryRootFor(repository);
+    let blobSha;
+    try {
+      blobSha = String(await executeGit(execute, ["-C", root, "rev-parse", "--verify", `${sha}:${path}`])).trim();
+    } catch {
+      try {
+        const commit = String(await executeGit(execute, ["-C", root, "rev-parse", "--verify", `${sha}^{commit}`])).trim();
+        if (commit !== sha) throw new Error("commit mismatch");
+      } catch {
+        throw new AuditIncomplete("GIT_PROVIDER_COMMIT_MISSING", `${repository}:${sha}`);
+      }
+      throw Object.assign(new Error("not found"), { status: 404 });
+    }
+    if (!SHA.test(blobSha)) throw new AuditIncomplete("RESOURCE_PROVIDER_MALFORMED", `${repository}:${path}`, "fragment");
+    let bytes;
+    try {
+      bytes = await executeGit(execute, ["-C", root, "show", `${sha}:${path}`], null);
+    } catch {
+      throw new AuditIncomplete("GIT_PROVIDER_UNAVAILABLE", `${repository}:${path}`);
+    }
+    if (!Buffer.isBuffer(bytes)) bytes = Buffer.from(bytes);
+    return { type: "file", sha: blobSha, encoding: "base64", content: bytes.toString("base64") };
+  };
+  return { readHead, readContent };
 }
 
 function decodeBase64(value, identity) {
@@ -336,7 +461,7 @@ export async function gh(args, execute = execFileAsync, pause = wait, now = Date
 }
 
 function parseArguments(argv) {
-  const names = { "--scope": "scope", "--scope-schema": "scopeSchema", "--report-schema": "reportSchema", "--source-sha": "sourceSha", "--observed-at": "observedAt", "--output": "output" };
+  const names = { "--scope": "scope", "--scope-schema": "scopeSchema", "--report-schema": "reportSchema", "--source-sha": "sourceSha", "--observed-at": "observedAt", "--repository-root": "repositoryRoot", "--output": "output" };
   const result = {};
   for (let index = 0; index < argv.length; index += 2) {
     const key = names[argv[index]];
@@ -380,7 +505,10 @@ export async function runAuditCli({ argv = process.argv.slice(2), read = (path) 
     reportSchema = JSON.parse(reportSchemaText);
     const scopeErrors = [...validateSchema(scopeSchema, scope).errors, ...validateDocumentationInventoryAuditScope(scope)];
     if (scopeErrors.length !== 0) throw new AuditIncomplete("SCOPE_INVALID", "scope", "scope");
-    const live = await (collect ?? (() => collectLive(scope, { sourceSha: args.sourceSha })))();
+    const live = await (collect ?? (async () => {
+      const provider = await createDocumentationInventoryGitProvider(scope, { repositoryRoot: args.repositoryRoot });
+      return collectLive(scope, { sourceSha: args.sourceSha, ...provider });
+    }))();
     report = auditDocumentationInventory({ scope, sourceSha: args.sourceSha, observedAt: args.observedAt, ...live, scopeText });
     const reportErrors = [...validateSchema(reportSchema, report).errors, ...validateDocumentationInventoryAuditReport(report)];
     if (reportErrors.length !== 0) throw new AuditIncomplete("REPORT_INVALID", "report", "report");

--- a/tools/repo/audit-documentation-inventory.mjs
+++ b/tools/repo/audit-documentation-inventory.mjs
@@ -166,19 +166,27 @@ export async function createDocumentationInventoryGitProvider(scope, {
   const readContent = async (repository, path, sha) => {
     if (!safePath(path) || !SHA.test(sha)) throw new AuditIncomplete("GIT_PROVIDER_INPUT_INVALID", `${repository}:${path}`);
     const root = repositoryRootFor(repository);
+    let commit;
+    try {
+      commit = String(await executeGit(execute, ["-C", root, "rev-parse", "--verify", `${sha}^{commit}`])).trim();
+    } catch {
+      throw new AuditIncomplete("GIT_PROVIDER_COMMIT_MISSING", `${repository}:${sha}`);
+    }
+    if (commit !== sha) throw new AuditIncomplete("GIT_PROVIDER_COMMIT_MISSING", `${repository}:${sha}`);
     let blobSha;
     try {
       blobSha = String(await executeGit(execute, ["-C", root, "rev-parse", "--verify", `${sha}:${path}`])).trim();
     } catch {
-      try {
-        const commit = String(await executeGit(execute, ["-C", root, "rev-parse", "--verify", `${sha}^{commit}`])).trim();
-        if (commit !== sha) throw new Error("commit mismatch");
-      } catch {
-        throw new AuditIncomplete("GIT_PROVIDER_COMMIT_MISSING", `${repository}:${sha}`);
-      }
       throw Object.assign(new Error("not found"), { status: 404 });
     }
     if (!SHA.test(blobSha)) throw new AuditIncomplete("RESOURCE_PROVIDER_MALFORMED", `${repository}:${path}`, "fragment");
+    let objectType;
+    try {
+      objectType = String(await executeGit(execute, ["-C", root, "cat-file", "-t", blobSha])).trim();
+    } catch {
+      throw new AuditIncomplete("GIT_PROVIDER_UNAVAILABLE", `${repository}:${path}`);
+    }
+    if (objectType !== "blob") throw new AuditIncomplete("RESOURCE_PROVIDER_MALFORMED", `${repository}:${path}`, "fragment");
     let bytes;
     try {
       bytes = await executeGit(execute, ["-C", root, "show", `${sha}:${path}`], null);

--- a/tools/repo/audit-documentation-inventory.mjs
+++ b/tools/repo/audit-documentation-inventory.mjs
@@ -42,6 +42,8 @@ const GIT_UNSET = Object.freeze([
   "GIT_QUARANTINE_PATH",
   "GIT_SSH_COMMAND",
   "GIT_WORK_TREE",
+  "SSH_ASKPASS",
+  "SSH_ASKPASS_REQUIRE",
   "SSH_AUTH_SOCK",
 ]);
 const FRAGMENT_SCHEMA = JSON.parse(await readFile(new URL("../../contracts/documentation/documentation-fragment.schema.json", import.meta.url), "utf8"));
@@ -62,16 +64,16 @@ const exactKeys = (value, keys) => value != null && typeof value === "object" &&
 const safePath = (value) => typeof value === "string" && /^(?!\/)(?!.*(?:^|\/)\.{1,2}(?:\/|$))(?!.*[?#])[A-Za-z0-9][A-Za-z0-9._/-]*$/.test(value);
 const fallbackScope = () => ({ schemaVersion: 1, repositories: EXPECTED_REPOSITORIES.map((repository) => ({ repository, defaultBranch: "main", fragmentPath: FRAGMENT_PATH, requiredStatus: "ACTIVE" })), dods: [...EXPECTED_DODS] });
 
-function gitEnvironment() {
-  const env = { ...process.env, ...GIT_ENV };
+function gitEnvironment(home) {
+  const env = { ...process.env, ...GIT_ENV, HOME: home, XDG_CONFIG_HOME: home };
   for (const key of GIT_UNSET) delete env[key];
   return env;
 }
 
-async function executeGit(execute, arguments_, encoding = "utf8") {
+async function executeGit(execute, arguments_, encoding, home) {
   const result = await execute("/usr/bin/git", arguments_, {
     encoding,
-    env: gitEnvironment(),
+    env: gitEnvironment(home),
     shell: false,
     timeout: 120_000,
     maxBuffer: 8 * 1024 * 1024,
@@ -93,6 +95,7 @@ export function validateDocumentationInventoryAuditScope(scope, errors = []) {
 export async function createDocumentationInventoryGitProvider(scope, {
   repositoryRoot,
   execute = execFileAsync,
+  pause = wait,
 } = {}) {
   if (validateDocumentationInventoryAuditScope(scope).length !== 0
       || typeof repositoryRoot !== "string"
@@ -101,28 +104,48 @@ export async function createDocumentationInventoryGitProvider(scope, {
     throw new AuditIncomplete("GIT_PROVIDER_INPUT_INVALID", "repository-root");
   }
   let canonicalRoot;
+  let isolatedHome;
   try {
     await realpath(dirname(repositoryRoot));
     await mkdir(repositoryRoot, { mode: 0o700 });
     canonicalRoot = await realpath(repositoryRoot);
+    isolatedHome = join(canonicalRoot, ".home");
+    await mkdir(isolatedHome, { mode: 0o700 });
   } catch {
     throw new AuditIncomplete("GIT_PROVIDER_INPUT_INVALID", "repository-root");
   }
 
+  const runGit = (arguments_, encoding = "utf8") => executeGit(execute, arguments_, encoding, isolatedHome);
+  const retryNetworkGit = async (argumentsForAttempt) => {
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      try {
+        return await runGit(argumentsForAttempt(attempt));
+      } catch (error) {
+        if (attempt === 2) throw error;
+        await pause(250 * (2 ** attempt));
+      }
+    }
+    throw new Error("Git network retry exhausted");
+  };
+
   const roots = new Map();
   for (const { repository, defaultBranch } of scope.repositories) {
-    const destination = join(canonicalRoot, repository.slice(repository.indexOf("/") + 1));
+    const name = repository.slice(repository.indexOf("/") + 1);
+    let destination;
     try {
-      await executeGit(execute, [
-        "clone",
-        "--no-checkout",
-        "--single-branch",
-        "--branch",
-        defaultBranch,
-        "--no-tags",
-        `https://github.com/${repository}.git`,
-        destination,
-      ]);
+      await retryNetworkGit((attempt) => {
+        destination = join(canonicalRoot, `${name}.clone-${attempt + 1}`);
+        return [
+          "clone",
+          "--no-checkout",
+          "--single-branch",
+          "--branch",
+          defaultBranch,
+          "--no-tags",
+          `https://github.com/${repository}.git`,
+          destination,
+        ];
+      });
     } catch {
       throw new AuditIncomplete("GIT_PROVIDER_UNAVAILABLE", repository);
     }
@@ -137,7 +160,7 @@ export async function createDocumentationInventoryGitProvider(scope, {
   const refresh = async () => {
     for (const { repository } of scope.repositories) {
       try {
-        await executeGit(execute, [
+        await retryNetworkGit(() => [
           "-C",
           repositoryRootFor(repository),
           "fetch",
@@ -155,7 +178,7 @@ export async function createDocumentationInventoryGitProvider(scope, {
     if (branch !== "main") throw new AuditIncomplete("GIT_PROVIDER_INPUT_INVALID", repository);
     let head;
     try {
-      head = String(await executeGit(execute, ["-C", repositoryRootFor(repository), "rev-parse", "--verify", `refs/remotes/origin/${branch}^{commit}`])).trim();
+      head = String(await runGit(["-C", repositoryRootFor(repository), "rev-parse", "--verify", `refs/remotes/origin/${branch}^{commit}`])).trim();
     } catch (error) {
       if (error instanceof AuditIncomplete) throw error;
       throw new AuditIncomplete("GIT_PROVIDER_UNAVAILABLE", repository);
@@ -168,28 +191,31 @@ export async function createDocumentationInventoryGitProvider(scope, {
     const root = repositoryRootFor(repository);
     let commit;
     try {
-      commit = String(await executeGit(execute, ["-C", root, "rev-parse", "--verify", `${sha}^{commit}`])).trim();
+      commit = String(await runGit(["-C", root, "rev-parse", "--verify", `${sha}^{commit}`])).trim();
     } catch {
       throw new AuditIncomplete("GIT_PROVIDER_COMMIT_MISSING", `${repository}:${sha}`);
     }
     if (commit !== sha) throw new AuditIncomplete("GIT_PROVIDER_COMMIT_MISSING", `${repository}:${sha}`);
-    let blobSha;
+    let entry;
     try {
-      blobSha = String(await executeGit(execute, ["-C", root, "rev-parse", "--verify", `${sha}:${path}`])).trim();
+      entry = String(await runGit(["-C", root, "ls-tree", "-z", "--full-tree", sha, "--", path]));
     } catch {
-      throw Object.assign(new Error("not found"), { status: 404 });
+      throw new AuditIncomplete("GIT_PROVIDER_UNAVAILABLE", `${repository}:${path}`);
     }
-    if (!SHA.test(blobSha)) throw new AuditIncomplete("RESOURCE_PROVIDER_MALFORMED", `${repository}:${path}`, "fragment");
+    if (entry.length === 0) throw Object.assign(new Error("not found"), { status: 404 });
+    const parsed = /^([0-7]{6}) (blob|tree|commit) ([0-9a-f]{40})\t([^\0]+)\0$/.exec(entry);
+    if (parsed == null || parsed[4] !== path || parsed[2] !== "blob") throw new AuditIncomplete("RESOURCE_PROVIDER_MALFORMED", `${repository}:${path}`, "fragment");
+    const blobSha = parsed[3];
     let objectType;
     try {
-      objectType = String(await executeGit(execute, ["-C", root, "cat-file", "-t", blobSha])).trim();
+      objectType = String(await runGit(["-C", root, "cat-file", "-t", blobSha])).trim();
     } catch {
       throw new AuditIncomplete("GIT_PROVIDER_UNAVAILABLE", `${repository}:${path}`);
     }
     if (objectType !== "blob") throw new AuditIncomplete("RESOURCE_PROVIDER_MALFORMED", `${repository}:${path}`, "fragment");
     let bytes;
     try {
-      bytes = await executeGit(execute, ["-C", root, "show", `${sha}:${path}`], null);
+      bytes = await runGit(["-C", root, "show", `${sha}:${path}`], null);
     } catch {
       throw new AuditIncomplete("GIT_PROVIDER_UNAVAILABLE", `${repository}:${path}`);
     }

--- a/tools/repo/audit-documentation-inventory.mjs
+++ b/tools/repo/audit-documentation-inventory.mjs
@@ -134,6 +134,23 @@ export async function createDocumentationInventoryGitProvider(scope, {
     if (root == null) throw new AuditIncomplete("GIT_PROVIDER_INPUT_INVALID", repository);
     return root;
   };
+  const refresh = async () => {
+    for (const { repository } of scope.repositories) {
+      try {
+        await executeGit(execute, [
+          "-C",
+          repositoryRootFor(repository),
+          "fetch",
+          "--no-tags",
+          `https://github.com/${repository}.git`,
+          "+refs/heads/main:refs/remotes/origin/main",
+        ]);
+      } catch (error) {
+        if (error instanceof AuditIncomplete) throw error;
+        throw new AuditIncomplete("GIT_PROVIDER_UNAVAILABLE", repository);
+      }
+    }
+  };
   const readHead = async (repository, branch) => {
     if (branch !== "main") throw new AuditIncomplete("GIT_PROVIDER_INPUT_INVALID", repository);
     let head;
@@ -171,7 +188,7 @@ export async function createDocumentationInventoryGitProvider(scope, {
     if (!Buffer.isBuffer(bytes)) bytes = Buffer.from(bytes);
     return { type: "file", sha: blobSha, encoding: "base64", content: bytes.toString("base64") };
   };
-  return { readHead, readContent };
+  return { refresh, readHead, readContent };
 }
 
 function decodeBase64(value, identity) {
@@ -349,7 +366,7 @@ export async function collectSnapshot(scope, { readHead = collectHead, readConte
   return { repositories, watermark: snapshotWatermark(repositories) };
 }
 
-export async function collectLive(scope, { sourceSha, collectSnapshot: snapshot = null, readHead = collectHead, readContent = collectContent } = {}) {
+export async function collectLive(scope, { sourceSha, collectSnapshot: snapshot = null, refresh = async () => {}, readHead = collectHead, readContent = collectContent } = {}) {
   const contentCache = new Map();
   const cachedReadContent = (repository, path, sha) => {
     const key = JSON.stringify([repository, path, sha]);
@@ -357,7 +374,9 @@ export async function collectLive(scope, { sourceSha, collectSnapshot: snapshot 
     return contentCache.get(key);
   };
   const takeSnapshot = snapshot ?? (() => collectSnapshot(scope, { readHead, readContent: cachedReadContent }));
+  await refresh();
   const begin = await takeSnapshot();
+  await refresh();
   const end = await takeSnapshot();
   const beginHub = begin.repositories.find(({ repository }) => repository === "AquilaXk/easysubway")?.headSha;
   const endHub = end.repositories.find(({ repository }) => repository === "AquilaXk/easysubway")?.headSha;

--- a/tools/repo/audit-documentation-inventory.mjs
+++ b/tools/repo/audit-documentation-inventory.mjs
@@ -33,6 +33,7 @@ const GIT_UNSET = Object.freeze([
   "GH_TOKEN",
   "GITHUB_TOKEN",
   "GIT_ASKPASS",
+  "GIT_ALTERNATE_OBJECT_DIRECTORIES",
   "GIT_CONFIG_COUNT",
   "GIT_CONFIG_PARAMETERS",
   "GIT_DIR",
@@ -41,6 +42,7 @@ const GIT_UNSET = Object.freeze([
   "GIT_OBJECT_DIRECTORY",
   "GIT_QUARANTINE_PATH",
   "GIT_SSH_COMMAND",
+  "GIT_SSL_NO_VERIFY",
   "GIT_WORK_TREE",
   "SSH_ASKPASS",
   "SSH_ASKPASS_REQUIRE",
@@ -121,7 +123,7 @@ export async function createDocumentationInventoryGitProvider(scope, {
       try {
         return await runGit(argumentsForAttempt(attempt));
       } catch (error) {
-        if (attempt === 2) throw error;
+        if (error instanceof AuditIncomplete || attempt === 2) throw error;
         await pause(250 * (2 ** attempt));
       }
     }
@@ -278,7 +280,8 @@ async function readTrackedResource(entry, path, sha, identity, { readContent, mi
   return { blobSha: tracked.sha, sha256: sha256(bytes) };
 }
 
-export async function verifyFragment(entry, headSha, { readContent = collectContent } = {}) {
+export async function verifyFragment(entry, headSha, { readContent } = {}) {
+  if (typeof readContent !== "function") throw new AuditIncomplete("GIT_PROVIDER_INPUT_INVALID", entry?.repository ?? "provider");
   let content;
   try { content = await readContent(entry.repository, entry.fragmentPath, headSha); }
   catch (error) {
@@ -390,7 +393,8 @@ function snapshotWatermark(repositories) {
   return sha256(JSON.stringify(repositories.map(({ repository, headSha, state, fragmentStatus, fragmentBlobSha, resourceCount, activeResourceCount, verificationFindings = [] }) => ({ repository, headSha, state, fragmentStatus, fragmentBlobSha, resourceCount, activeResourceCount, verificationFindings }))));
 }
 
-export async function collectSnapshot(scope, { readHead = collectHead, readContent = collectContent } = {}) {
+export async function collectSnapshot(scope, { readHead, readContent } = {}) {
+  if (typeof readHead !== "function" || typeof readContent !== "function") throw new AuditIncomplete("GIT_PROVIDER_INPUT_INVALID", "provider");
   const repositories = [];
   for (const entry of scope.repositories) {
     const headSha = await readHead(entry.repository, entry.defaultBranch);
@@ -400,7 +404,12 @@ export async function collectSnapshot(scope, { readHead = collectHead, readConte
   return { repositories, watermark: snapshotWatermark(repositories) };
 }
 
-export async function collectLive(scope, { sourceSha, collectSnapshot: snapshot = null, refresh = async () => {}, readHead = collectHead, readContent = collectContent } = {}) {
+export async function collectLive(scope, { sourceSha, collectSnapshot: snapshot = null, refresh = async () => {}, readHead, readContent } = {}) {
+  if (typeof refresh !== "function"
+      || (snapshot !== null && typeof snapshot !== "function")
+      || (snapshot === null && (typeof readHead !== "function" || typeof readContent !== "function"))) {
+    throw new AuditIncomplete("GIT_PROVIDER_INPUT_INVALID", "provider");
+  }
   const contentCache = new Map();
   const cachedReadContent = (repository, path, sha) => {
     const key = JSON.stringify([repository, path, sha]);

--- a/tools/repo/audit-documentation-inventory.test.mjs
+++ b/tools/repo/audit-documentation-inventory.test.mjs
@@ -258,7 +258,7 @@ test("documentation inventory audit rejects state drift and writes schema-valid 
   const output = join(directory, "report.json");
   const scopeSchema = readFileSync("contracts/documentation/documentation-inventory-audit-scope.schema.json", "utf8");
   const reportSchema = readFileSync("contracts/documentation/documentation-inventory-audit-report.schema.json", "utf8");
-  const argv = ["--scope", "scope", "--scope-schema", "scope-schema", "--report-schema", "report-schema", "--source-sha", SHA, "--observed-at", "2026-08-11T00:00:00.000Z", "--output", output];
+  const argv = ["--scope", "scope", "--scope-schema", "scope-schema", "--report-schema", "report-schema", "--source-sha", SHA, "--observed-at", "2026-08-11T00:00:00.000Z", "--repository-root", join(directory, "repositories"), "--output", output];
   try {
     const result = await runAuditCli({ argv, read: async (path) => ({ scope: "{", "scope-schema": scopeSchema, "report-schema": reportSchema })[path], collect: async () => { throw new Error("must not collect"); } });
     const report = JSON.parse(readFileSync(output, "utf8"));
@@ -461,6 +461,38 @@ test("documentation inventory audit rejects unsafe Git provider inputs", async (
     () => auditModule.createDocumentationInventoryGitProvider(SCOPE, { repositoryRoot: "relative" }),
     (error) => error instanceof AuditIncomplete && error.code === "GIT_PROVIDER_INPUT_INVALID",
   );
+  const directory = mkdtempSync(join(tmpdir(), "documentation-inventory-git-provider-invalid-"));
+  const repositoryRoot = join(directory, "repositories");
+  try {
+    const provider = await auditModule.createDocumentationInventoryGitProvider(SCOPE, {
+      repositoryRoot,
+      execute: async (_executable, arguments_) => {
+        if (arguments_[0] === "clone") {
+          mkdirSync(arguments_.at(-1));
+          return { stdout: "", stderr: "" };
+        }
+        throw new Error("must reject before Git read");
+      },
+    });
+    await assert.rejects(
+      () => provider.readHead(REPOSITORIES[0], "release"),
+      (error) => error instanceof AuditIncomplete && error.code === "GIT_PROVIDER_INPUT_INVALID",
+    );
+    await assert.rejects(
+      () => provider.readContent("AquilaXk/unowned", PATH, SHA),
+      (error) => error instanceof AuditIncomplete && error.code === "GIT_PROVIDER_INPUT_INVALID",
+    );
+    await assert.rejects(
+      () => provider.readContent(REPOSITORIES[0], "../secret", SHA),
+      (error) => error instanceof AuditIncomplete && error.code === "GIT_PROVIDER_INPUT_INVALID",
+    );
+    await assert.rejects(
+      () => auditModule.createDocumentationInventoryGitProvider(SCOPE, { repositoryRoot }),
+      (error) => error instanceof AuditIncomplete && error.code === "GIT_PROVIDER_INPUT_INVALID",
+    );
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
 });
 
 test("documentation inventory audit workflow uses canonical public Git provider", () => {

--- a/tools/repo/audit-documentation-inventory.test.mjs
+++ b/tools/repo/audit-documentation-inventory.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -448,8 +448,8 @@ test("documentation inventory audit uses canonical public Git provider", async (
       assert.equal(options.shell, false);
       assert.equal(options.env.GIT_TERMINAL_PROMPT, "0");
       assert.equal(options.env.GIT_CONFIG_GLOBAL, "/dev/null");
-      assert.equal(options.env.HOME, join(repositoryRoot, ".home"));
-      assert.equal(options.env.XDG_CONFIG_HOME, join(repositoryRoot, ".home"));
+      assert.equal(options.env.HOME, join(realpathSync(repositoryRoot), ".home"));
+      assert.equal(options.env.XDG_CONFIG_HOME, join(realpathSync(repositoryRoot), ".home"));
       assert.equal(Object.hasOwn(options.env, "GH_TOKEN"), false);
       assert.equal(Object.hasOwn(options.env, "GITHUB_TOKEN"), false);
       assert.equal(Object.hasOwn(options.env, "GIT_ASKPASS"), false);

--- a/tools/repo/audit-documentation-inventory.test.mjs
+++ b/tools/repo/audit-documentation-inventory.test.mjs
@@ -415,6 +415,7 @@ test("documentation inventory audit uses canonical public Git provider", async (
       mkdirSync(arguments_.at(-1));
       return { stdout: "", stderr: "" };
     }
+    if (arguments_.includes("fetch")) return { stdout: "", stderr: "" };
     if (arguments_.includes("refs/remotes/origin/main^{commit}")) return { stdout: `${SHA}\n`, stderr: "" };
     if (arguments_.includes("rev-parse")) return { stdout: `${"c".repeat(40)}\n`, stderr: "" };
     if (arguments_.includes("show")) return { stdout: Buffer.from("{}"), stderr: Buffer.alloc(0) };
@@ -423,6 +424,7 @@ test("documentation inventory audit uses canonical public Git provider", async (
 
   try {
     const provider = await auditModule.createDocumentationInventoryGitProvider(SCOPE, { repositoryRoot, execute });
+    await provider.refresh();
     assert.equal(await provider.readHead(REPOSITORIES[0], "main"), SHA);
     assert.deepEqual(await provider.readContent(REPOSITORIES[0], PATH, SHA), {
       type: "file",
@@ -431,9 +433,14 @@ test("documentation inventory audit uses canonical public Git provider", async (
       content: Buffer.from("{}").toString("base64"),
     });
     const clones = calls.filter(({ arguments_ }) => arguments_[0] === "clone");
+    const fetches = calls.filter(({ arguments_ }) => arguments_.includes("fetch"));
     assert.equal(clones.length, 5);
+    assert.equal(fetches.length, 5);
     assert.deepEqual(clones.map(({ arguments_ }) => arguments_.slice(0, -1)), REPOSITORIES.map((repository) => [
       "clone", "--no-checkout", "--single-branch", "--branch", "main", "--no-tags", `https://github.com/${repository}.git`,
+    ]));
+    assert.deepEqual(fetches.map(({ arguments_ }) => arguments_.slice(2)), REPOSITORIES.map((repository) => [
+      "fetch", "--no-tags", `https://github.com/${repository}.git`, "+refs/heads/main:refs/remotes/origin/main",
     ]));
     for (const { executable, options } of calls) {
       assert.equal(executable, "/usr/bin/git");
@@ -444,6 +451,28 @@ test("documentation inventory audit uses canonical public Git provider", async (
       assert.equal(Object.hasOwn(options.env, "GITHUB_TOKEN"), false);
       assert.equal(Object.hasOwn(options.env, "GIT_ASKPASS"), false);
     }
+
+    let refreshCount = 0;
+    let snapshotCount = 0;
+    const pending = () => REPOSITORIES.map((repository) => ({
+      repository,
+      headSha: repository === REPOSITORIES[0] && snapshotCount === 2 ? SOURCE_SHA : SHA,
+      state: "PENDING",
+      fragmentStatus: "MISSING",
+      fragmentBlobSha: null,
+      fragment: null,
+      resourceCount: 0,
+      activeResourceCount: 0,
+    }));
+    await assert.rejects(() => collectLive(SCOPE, {
+      sourceSha: SHA,
+      refresh: async () => { refreshCount += 1; },
+      collectSnapshot: async () => {
+        snapshotCount += 1;
+        return { repositories: pending(), watermark: `${snapshotCount}`.padStart(64, "0") };
+      },
+    }), (error) => error instanceof AuditIncomplete && error.code === "STATE_WATERMARK_DRIFT");
+    assert.deepEqual([refreshCount, snapshotCount], [2, 2]);
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }

--- a/tools/repo/audit-documentation-inventory.test.mjs
+++ b/tools/repo/audit-documentation-inventory.test.mjs
@@ -409,6 +409,8 @@ test("documentation inventory audit uses canonical public Git provider", async (
   const directory = mkdtempSync(join(tmpdir(), "documentation-inventory-git-provider-"));
   const repositoryRoot = join(directory, "repositories");
   const calls = [];
+  let commitIdentity = SHA;
+  let objectType = "blob";
   const execute = async (executable, arguments_, options) => {
     calls.push({ executable, arguments_, options });
     if (arguments_[0] === "clone") {
@@ -417,7 +419,10 @@ test("documentation inventory audit uses canonical public Git provider", async (
     }
     if (arguments_.includes("fetch")) return { stdout: "", stderr: "" };
     if (arguments_.includes("refs/remotes/origin/main^{commit}")) return { stdout: `${SHA}\n`, stderr: "" };
+    if (arguments_.includes(`${SHA}^{commit}`)) return { stdout: `${commitIdentity}\n`, stderr: "" };
     if (arguments_.includes("rev-parse")) return { stdout: `${"c".repeat(40)}\n`, stderr: "" };
+    if (arguments_.includes("-t")) return { stdout: `${objectType}\n`, stderr: "" };
+    if (arguments_.includes("cat-file")) return { stdout: Buffer.from("{}"), stderr: Buffer.alloc(0) };
     if (arguments_.includes("show")) return { stdout: Buffer.from("{}"), stderr: Buffer.alloc(0) };
     throw new Error("unexpected Git command");
   };
@@ -432,6 +437,19 @@ test("documentation inventory audit uses canonical public Git provider", async (
       encoding: "base64",
       content: Buffer.from("{}").toString("base64"),
     });
+    const showCount = calls.filter(({ arguments_ }) => arguments_.includes("show")).length;
+    objectType = "tree";
+    await assert.rejects(
+      () => provider.readContent(REPOSITORIES[0], PATH, SHA),
+      (error) => error instanceof AuditIncomplete && error.code === "RESOURCE_PROVIDER_MALFORMED",
+    );
+    assert.equal(calls.filter(({ arguments_ }) => arguments_.includes("show")).length, showCount);
+    objectType = "blob";
+    commitIdentity = "b".repeat(40);
+    await assert.rejects(
+      () => provider.readContent(REPOSITORIES[0], PATH, SHA),
+      (error) => error instanceof AuditIncomplete && error.code === "GIT_PROVIDER_COMMIT_MISSING",
+    );
     const clones = calls.filter(({ arguments_ }) => arguments_[0] === "clone");
     const fetches = calls.filter(({ arguments_ }) => arguments_.includes("fetch"));
     assert.equal(clones.length, 5);

--- a/tools/repo/audit-documentation-inventory.test.mjs
+++ b/tools/repo/audit-documentation-inventory.test.mjs
@@ -412,6 +412,10 @@ test("documentation inventory audit uses canonical public Git provider", async (
   let commitIdentity = SHA;
   let objectType = "blob";
   let pathLookup = "ready";
+  const previousAlternateObjects = process.env.GIT_ALTERNATE_OBJECT_DIRECTORIES;
+  const previousSslNoVerify = process.env.GIT_SSL_NO_VERIFY;
+  process.env.GIT_ALTERNATE_OBJECT_DIRECTORIES = "/tmp/untrusted-git-objects";
+  process.env.GIT_SSL_NO_VERIFY = "1";
   const execute = async (executable, arguments_, options) => {
     calls.push({ executable, arguments_, options });
     if (arguments_[0] === "clone") {
@@ -453,6 +457,8 @@ test("documentation inventory audit uses canonical public Git provider", async (
       assert.equal(Object.hasOwn(options.env, "GH_TOKEN"), false);
       assert.equal(Object.hasOwn(options.env, "GITHUB_TOKEN"), false);
       assert.equal(Object.hasOwn(options.env, "GIT_ASKPASS"), false);
+      assert.equal(Object.hasOwn(options.env, "GIT_ALTERNATE_OBJECT_DIRECTORIES"), false);
+      assert.equal(Object.hasOwn(options.env, "GIT_SSL_NO_VERIFY"), false);
       assert.equal(Object.hasOwn(options.env, "SSH_ASKPASS"), false);
       assert.equal(Object.hasOwn(options.env, "SSH_ASKPASS_REQUIRE"), false);
     }
@@ -502,6 +508,10 @@ test("documentation inventory audit uses canonical public Git provider", async (
     }), (error) => error instanceof AuditIncomplete && error.code === "STATE_WATERMARK_DRIFT");
     assert.deepEqual([refreshCount, snapshotCount], [2, 2]);
   } finally {
+    if (previousAlternateObjects == null) delete process.env.GIT_ALTERNATE_OBJECT_DIRECTORIES;
+    else process.env.GIT_ALTERNATE_OBJECT_DIRECTORIES = previousAlternateObjects;
+    if (previousSslNoVerify == null) delete process.env.GIT_SSL_NO_VERIFY;
+    else process.env.GIT_SSL_NO_VERIFY = previousSslNoVerify;
     rmSync(directory, { recursive: true, force: true });
   }
 });
@@ -549,6 +559,8 @@ test("documentation inventory audit retries transient public Git provider operat
   const delays = [];
   let cloneAttempts = 0;
   let fetchAttempts = 0;
+  let deterministicFailure = false;
+  let deterministicAttempts = 0;
   const execute = async (_executable, arguments_) => {
     if (arguments_[0] === "clone") {
       cloneAttempts += 1;
@@ -558,6 +570,10 @@ test("documentation inventory audit retries transient public Git provider operat
       return { stdout: "", stderr: "" };
     }
     if (arguments_.includes("fetch")) {
+      if (deterministicFailure) {
+        deterministicAttempts += 1;
+        throw new AuditIncomplete("GIT_PROVIDER_INPUT_INVALID", "deterministic");
+      }
       fetchAttempts += 1;
       if (fetchAttempts === 1) throw new Error("transient fetch failure");
       return { stdout: "", stderr: "" };
@@ -574,6 +590,12 @@ test("documentation inventory audit retries transient public Git provider operat
     await provider.refresh();
     assert.deepEqual([cloneAttempts, fetchAttempts, delays], [6, 6, [250, 250]]);
     assert.notEqual(cloneDestinations[0], cloneDestinations[1]);
+    deterministicFailure = true;
+    await assert.rejects(
+      () => provider.refresh(),
+      (error) => error instanceof AuditIncomplete && error.code === "GIT_PROVIDER_INPUT_INVALID",
+    );
+    assert.deepEqual([deterministicAttempts, delays], [1, [250, 250]]);
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }
@@ -589,6 +611,10 @@ test("documentation inventory audit rejects unsafe Git provider inputs", async (
   );
   await assert.rejects(
     () => auditModule.createDocumentationInventoryGitProvider(SCOPE, { repositoryRoot: "relative" }),
+    (error) => error instanceof AuditIncomplete && error.code === "GIT_PROVIDER_INPUT_INVALID",
+  );
+  await assert.rejects(
+    () => collectLive(SCOPE, { sourceSha: SHA, readHead: null, readContent: null }),
     (error) => error instanceof AuditIncomplete && error.code === "GIT_PROVIDER_INPUT_INVALID",
   );
   const directory = mkdtempSync(join(tmpdir(), "documentation-inventory-git-provider-invalid-"));
@@ -627,6 +653,7 @@ test("documentation inventory audit rejects unsafe Git provider inputs", async (
 
 test("documentation inventory audit workflow uses canonical public Git provider", () => {
   const workflow = readFileSync(".github/workflows/documentation-inventory-audit.yml", "utf8");
-  assert.doesNotMatch(workflow, /GH_TOKEN:\s*\$\{\{ github\.token \}\}/);
+  assert.doesNotMatch(workflow, /^\s*(?:GH_TOKEN|GITHUB_TOKEN)\s*:/m);
+  assert.doesNotMatch(workflow, /\$\{\{\s*secrets\./);
   assert.match(workflow, /--repository-root "\$\{RUNNER_TEMP\}\/documentation-inventory-repositories-\$\{GITHUB_RUN_ID\}-\$\{GITHUB_RUN_ATTEMPT\}"/);
 });

--- a/tools/repo/audit-documentation-inventory.test.mjs
+++ b/tools/repo/audit-documentation-inventory.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -15,6 +15,8 @@ import {
   validateDocumentationInventoryAuditScope,
   verifyFragment,
 } from "./audit-documentation-inventory.mjs";
+
+const auditModule = await import("./audit-documentation-inventory.mjs");
 
 const REPOSITORIES = [
   "AquilaXk/easysubway",
@@ -400,4 +402,69 @@ test("documentation inventory audit memoizes immutable content", async () => {
   assert.deepEqual([...headReads.values()], [2, 2, 2, 2, 2]);
   assert.equal(contentReads.size, 10);
   assert.deepEqual([...contentReads.values()], Array(10).fill(1));
+});
+
+test("documentation inventory audit uses canonical public Git provider", async () => {
+  assert.equal(typeof auditModule.createDocumentationInventoryGitProvider, "function");
+  const directory = mkdtempSync(join(tmpdir(), "documentation-inventory-git-provider-"));
+  const repositoryRoot = join(directory, "repositories");
+  const calls = [];
+  const execute = async (executable, arguments_, options) => {
+    calls.push({ executable, arguments_, options });
+    if (arguments_[0] === "clone") {
+      mkdirSync(arguments_.at(-1));
+      return { stdout: "", stderr: "" };
+    }
+    if (arguments_.includes("refs/remotes/origin/main^{commit}")) return { stdout: `${SHA}\n`, stderr: "" };
+    if (arguments_.includes("rev-parse")) return { stdout: `${"c".repeat(40)}\n`, stderr: "" };
+    if (arguments_.includes("show")) return { stdout: Buffer.from("{}"), stderr: Buffer.alloc(0) };
+    throw new Error("unexpected Git command");
+  };
+
+  try {
+    const provider = await auditModule.createDocumentationInventoryGitProvider(SCOPE, { repositoryRoot, execute });
+    assert.equal(await provider.readHead(REPOSITORIES[0], "main"), SHA);
+    assert.deepEqual(await provider.readContent(REPOSITORIES[0], PATH, SHA), {
+      type: "file",
+      sha: "c".repeat(40),
+      encoding: "base64",
+      content: Buffer.from("{}").toString("base64"),
+    });
+    const clones = calls.filter(({ arguments_ }) => arguments_[0] === "clone");
+    assert.equal(clones.length, 5);
+    assert.deepEqual(clones.map(({ arguments_ }) => arguments_.slice(0, -1)), REPOSITORIES.map((repository) => [
+      "clone", "--no-checkout", "--single-branch", "--branch", "main", "--no-tags", `https://github.com/${repository}.git`,
+    ]));
+    for (const { executable, options } of calls) {
+      assert.equal(executable, "/usr/bin/git");
+      assert.equal(options.shell, false);
+      assert.equal(options.env.GIT_TERMINAL_PROMPT, "0");
+      assert.equal(options.env.GIT_CONFIG_GLOBAL, "/dev/null");
+      assert.equal(Object.hasOwn(options.env, "GH_TOKEN"), false);
+      assert.equal(Object.hasOwn(options.env, "GITHUB_TOKEN"), false);
+      assert.equal(Object.hasOwn(options.env, "GIT_ASKPASS"), false);
+    }
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("documentation inventory audit rejects unsafe Git provider inputs", async () => {
+  assert.equal(typeof auditModule.createDocumentationInventoryGitProvider, "function");
+  const invalidScope = structuredClone(SCOPE);
+  invalidScope.repositories[0].repository = "AquilaXk/unowned";
+  await assert.rejects(
+    () => auditModule.createDocumentationInventoryGitProvider(invalidScope, { repositoryRoot: "/tmp/documentation-inventory-invalid" }),
+    (error) => error instanceof AuditIncomplete && error.code === "GIT_PROVIDER_INPUT_INVALID",
+  );
+  await assert.rejects(
+    () => auditModule.createDocumentationInventoryGitProvider(SCOPE, { repositoryRoot: "relative" }),
+    (error) => error instanceof AuditIncomplete && error.code === "GIT_PROVIDER_INPUT_INVALID",
+  );
+});
+
+test("documentation inventory audit workflow uses canonical public Git provider", () => {
+  const workflow = readFileSync(".github/workflows/documentation-inventory-audit.yml", "utf8");
+  assert.doesNotMatch(workflow, /GH_TOKEN:\s*\$\{\{ github\.token \}\}/);
+  assert.match(workflow, /--repository-root "\$\{RUNNER_TEMP\}\/documentation-inventory-repositories-\$\{GITHUB_RUN_ID\}-\$\{GITHUB_RUN_ATTEMPT\}"/);
 });

--- a/tools/repo/audit-documentation-inventory.test.mjs
+++ b/tools/repo/audit-documentation-inventory.test.mjs
@@ -411,6 +411,7 @@ test("documentation inventory audit uses canonical public Git provider", async (
   const calls = [];
   let commitIdentity = SHA;
   let objectType = "blob";
+  let pathLookup = "ready";
   const execute = async (executable, arguments_, options) => {
     calls.push({ executable, arguments_, options });
     if (arguments_[0] === "clone") {
@@ -420,6 +421,11 @@ test("documentation inventory audit uses canonical public Git provider", async (
     if (arguments_.includes("fetch")) return { stdout: "", stderr: "" };
     if (arguments_.includes("refs/remotes/origin/main^{commit}")) return { stdout: `${SHA}\n`, stderr: "" };
     if (arguments_.includes(`${SHA}^{commit}`)) return { stdout: `${commitIdentity}\n`, stderr: "" };
+    if (arguments_.includes("ls-tree")) {
+      if (pathLookup === "error") throw new Error("Git tree read failed");
+      if (pathLookup === "missing") return { stdout: "", stderr: "" };
+      return { stdout: `100644 blob ${"c".repeat(40)}\t${PATH}\0`, stderr: "" };
+    }
     if (arguments_.includes("rev-parse")) return { stdout: `${"c".repeat(40)}\n`, stderr: "" };
     if (arguments_.includes("-t")) return { stdout: `${objectType}\n`, stderr: "" };
     if (arguments_.includes("cat-file")) return { stdout: Buffer.from("{}"), stderr: Buffer.alloc(0) };
@@ -437,6 +443,19 @@ test("documentation inventory audit uses canonical public Git provider", async (
       encoding: "base64",
       content: Buffer.from("{}").toString("base64"),
     });
+    for (const { executable, options } of calls) {
+      assert.equal(executable, "/usr/bin/git");
+      assert.equal(options.shell, false);
+      assert.equal(options.env.GIT_TERMINAL_PROMPT, "0");
+      assert.equal(options.env.GIT_CONFIG_GLOBAL, "/dev/null");
+      assert.equal(options.env.HOME, join(repositoryRoot, ".home"));
+      assert.equal(options.env.XDG_CONFIG_HOME, join(repositoryRoot, ".home"));
+      assert.equal(Object.hasOwn(options.env, "GH_TOKEN"), false);
+      assert.equal(Object.hasOwn(options.env, "GITHUB_TOKEN"), false);
+      assert.equal(Object.hasOwn(options.env, "GIT_ASKPASS"), false);
+      assert.equal(Object.hasOwn(options.env, "SSH_ASKPASS"), false);
+      assert.equal(Object.hasOwn(options.env, "SSH_ASKPASS_REQUIRE"), false);
+    }
     const showCount = calls.filter(({ arguments_ }) => arguments_.includes("show")).length;
     objectType = "tree";
     await assert.rejects(
@@ -460,15 +479,6 @@ test("documentation inventory audit uses canonical public Git provider", async (
     assert.deepEqual(fetches.map(({ arguments_ }) => arguments_.slice(2)), REPOSITORIES.map((repository) => [
       "fetch", "--no-tags", `https://github.com/${repository}.git`, "+refs/heads/main:refs/remotes/origin/main",
     ]));
-    for (const { executable, options } of calls) {
-      assert.equal(executable, "/usr/bin/git");
-      assert.equal(options.shell, false);
-      assert.equal(options.env.GIT_TERMINAL_PROMPT, "0");
-      assert.equal(options.env.GIT_CONFIG_GLOBAL, "/dev/null");
-      assert.equal(Object.hasOwn(options.env, "GH_TOKEN"), false);
-      assert.equal(Object.hasOwn(options.env, "GITHUB_TOKEN"), false);
-      assert.equal(Object.hasOwn(options.env, "GIT_ASKPASS"), false);
-    }
 
     let refreshCount = 0;
     let snapshotCount = 0;
@@ -491,6 +501,79 @@ test("documentation inventory audit uses canonical public Git provider", async (
       },
     }), (error) => error instanceof AuditIncomplete && error.code === "STATE_WATERMARK_DRIFT");
     assert.deepEqual([refreshCount, snapshotCount], [2, 2]);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("documentation inventory audit distinguishes missing Git paths from provider failures", async () => {
+  const directory = mkdtempSync(join(tmpdir(), "documentation-inventory-git-missing-"));
+  const repositoryRoot = join(directory, "repositories");
+  let pathLookup = "missing";
+  const execute = async (_executable, arguments_) => {
+    if (arguments_[0] === "clone") {
+      mkdirSync(arguments_.at(-1));
+      return { stdout: "", stderr: "" };
+    }
+    if (arguments_.includes(`${SHA}^{commit}`)) return { stdout: `${SHA}\n`, stderr: "" };
+    if (arguments_.includes("ls-tree")) {
+      if (pathLookup === "error") throw new Error("Git tree read failed");
+      return { stdout: "", stderr: "" };
+    }
+    if (arguments_.includes("rev-parse")) return { stdout: `${"c".repeat(40)}\n`, stderr: "" };
+    if (arguments_.includes("-t")) return { stdout: "blob\n", stderr: "" };
+    if (arguments_.includes("show")) return { stdout: Buffer.from("{}"), stderr: Buffer.alloc(0) };
+    throw new Error("unexpected Git command");
+  };
+
+  try {
+    const provider = await auditModule.createDocumentationInventoryGitProvider(SCOPE, { repositoryRoot, execute });
+    await assert.rejects(
+      () => provider.readContent(REPOSITORIES[0], PATH, SHA),
+      (error) => error?.status === 404,
+    );
+    pathLookup = "error";
+    await assert.rejects(
+      () => provider.readContent(REPOSITORIES[0], PATH, SHA),
+      (error) => error instanceof AuditIncomplete && error.code === "GIT_PROVIDER_UNAVAILABLE",
+    );
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("documentation inventory audit retries transient public Git provider operations", async () => {
+  const directory = mkdtempSync(join(tmpdir(), "documentation-inventory-git-retry-"));
+  const repositoryRoot = join(directory, "repositories");
+  const cloneDestinations = [];
+  const delays = [];
+  let cloneAttempts = 0;
+  let fetchAttempts = 0;
+  const execute = async (_executable, arguments_) => {
+    if (arguments_[0] === "clone") {
+      cloneAttempts += 1;
+      cloneDestinations.push(arguments_.at(-1));
+      if (cloneAttempts === 1) throw new Error("transient clone failure");
+      mkdirSync(arguments_.at(-1));
+      return { stdout: "", stderr: "" };
+    }
+    if (arguments_.includes("fetch")) {
+      fetchAttempts += 1;
+      if (fetchAttempts === 1) throw new Error("transient fetch failure");
+      return { stdout: "", stderr: "" };
+    }
+    throw new Error("unexpected Git command");
+  };
+
+  try {
+    const provider = await auditModule.createDocumentationInventoryGitProvider(SCOPE, {
+      repositoryRoot,
+      execute,
+      pause: async (delay) => delays.push(delay),
+    });
+    await provider.refresh();
+    assert.deepEqual([cloneAttempts, fetchAttempts, delays], [6, 6, [250, 250]]);
+    assert.notEqual(cloneDestinations[0], cloneDestinations[1]);
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }


### PR DESCRIPTION
## 관련 이슈 / Related issue

Closes #2872

## 작업 배경 / Summary

- Problem: merge-head audit run `31797762709`가 repository-scoped `GITHUB_TOKEN`으로 five-repository REST contents를 읽다가 `PROVIDER_UNAVAILABLE`로 종료됐습니다.
- Outcome: fixed public repositories 5개를 credential-free Git workspace로 수집하고 exact head/blob/bytes를 existing inventory verifier에 전달합니다.

## 작업 내용 / Changes

- auditor CLI에 absolute create-only `--repository-root`를 추가했습니다.
- `/usr/bin/git clone --no-checkout --single-branch --branch main --no-tags`로 exact five public repositories만 수집합니다.
- `GH_TOKEN`, `GITHUB_TOKEN`, credential/helper와 ambient Git state를 clone/read process에서 제거합니다.
- provider-owned empty HOME을 사용하고 `SSH_ASKPASS` 계열까지 제거합니다.
- 두 snapshot 직전에 fixed `main`을 다시 fetch해 remote watermark drift를 fail closed합니다.
- Git `refs/remotes/origin/main`과 exact commit/path blob SHA·bytes를 existing provider interface로 전달하고 tree/non-commit을 거부합니다.
- real missing path와 Git provider failure를 구분하고 clone/fetch는 attempt별 destination에서 최대 3회 bounded retry합니다.
- workflow production path의 `GH_TOKEN` 주입을 제거하고 per-run repository root를 전달합니다.
- unsafe repository/root/branch/path와 root 재사용을 fail closed하는 RED→GREEN test를 추가했습니다.

## Scope

### Included

- `.github/workflows/documentation-inventory-audit.yml`
- `tools/repo/audit-documentation-inventory.mjs`
- `tools/repo/audit-documentation-inventory.test.mjs`

### Excluded

- catalog/schema/fragment/resource와 target repository bytes
- Hub #2868/#2869 및 다른 plan issue·PR·worktree
- permission, secret, token, repository setting
- REST/previous artifact/cache/credential fallback
- D13/D20/D22/D33–D35, runtime, build, deploy, release

### Ownership / dependencies

- Accountable owner or plan: `PLAN-DOC`
- Required predecessor output: PR #2871 merge `7b1020febf8b8a9a2024ceb3b8cc980da7401442`
- Concurrent work overlap: None — #2868 changed files는 catalog와 `tools/ci/check-contracts.test.mjs`

## Documentation impact

- 영향 resource ID 또는 `NONE`: `AquilaXk/easysubway:tools/repo/audit-documentation-inventory.mjs`
- resourceClass: `VERIFIER`
- documentationFamily: `GOVERNANCE`
- lifecycle/evidence 영향: D01–D05 current aggregate의 canonical provider를 repository-scoped REST에서 public immutable Git workspace로 교정합니다.

## 검증 / Verification

| Check | Result / Evidence |
| --- | --- |
| Focused RED → GREEN | Frozen F1–F3 RED: 2/5 PASS·3 expected failures → GREEN: 5/5 PASS |
| Affected integration | fixed clone/refresh, isolated HOME, missing/provider classification, bounded retry, unsafe input, workflow wiring 5/5 |
| Required CI | Current head `c2bbe0020fc98f74ecfb9f140fcc6450d2362094`, run `31804044030`, ruleset-required 5/5 PASS |
| Manual / production-like | Not required — reason: merge-head GitHub Actions audit가 production-like evidence를 생성합니다. |
| Security / privacy / accessibility | credential environment 제거; secret·UI·accessibility behavior change 없음 |

- 실행한 명령과 결과:
  - `node --test --test-name-pattern='documentation inventory audit (uses canonical public Git provider|distinguishes missing Git paths from provider failures|retries transient public Git provider operations|rejects unsafe Git provider inputs|workflow uses canonical public Git provider)' tools/repo/audit-documentation-inventory.test.mjs` → `5/5 PASS`
  - `git diff --check` → PASS

## 검증 증거

- Prior merge-head run `31797762709`, artifact `9218028768`: `AUDIT_INCOMPLETE`, provider-bound exit 2
- Archive digest: `sha256:568df94d493961449f71e1e8f5c46a4ccbdfe53d15737467562170a372a22fcf`
- CodeRabbit comment `5293050350`: `Review limit reached`, Review 객체 0
- Isolated Codex R2 fallback Review `4937400930`: F1–F3 P2 frozen, fix `c2bbe0020fc98f74ecfb9f140fcc6450d2362094`, original threads 3/3 resolved
- UI·수동 QA·배포 증거는 불필요합니다. 변경 surface는 headless documentation audit provider입니다.

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName / versionCode: unchanged
- datapack version: unchanged
- route / realtime contract: unchanged
- backend identity: unchanged

## Not run

- Check: full repository regression
- Reason: owner-machine resource boundary에 따라 required Hub CI가 수행합니다.
- Rerun owner / condition: GitHub Actions / current PR metadata sync

## 리뷰어 메모 / Review focus

- public Git clone/read environment에 ambient credential이 남지 않는지 확인해 주세요.
- exact Git blob provider가 existing source/current parity와 watermark를 약화하지 않는지 확인해 주세요.

## 리스크 / Risk

- Level: High (`R2`)
- Main risk: Git provider identity 오분류로 stale 또는 잘못된 repository content를 감사할 수 있습니다.
- Failure behavior: invalid root/repository/branch/path, clone/read/commit/blob failure는 nonzero typed incomplete로 종료합니다.
- State mutation on failure: task-local temporary clone과 sanitized create-only artifact 외 external mutation `0`
- Fallback or degraded-success path introduced: No

## Rollout / Recovery

- Rollout or activation: PLAN-DOC exact-head squash merge 후 default-branch audit 자동 실행
- Monitoring / success signal: `COMPLETE/pending=0/ready=5/findings=0/incomplete=0`, equal non-null watermark
- Rollback or recovery: merge revert 후 previous fail-closed provider behavior 복원
- Data / config compatibility after rollback: schema, scope, fragment, catalog bytes가 불변이므로 호환성 영향 없음

## 체크리스트 / Checklist

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] 이슈 범위와 실제 diff가 일치하며 관련 없는 변경을 포함하지 않았다.
- [x] 위험에 필요한 검증과 미실행 사유를 기록했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 없음을 확인했다.
