### PR TITLE
[Fix] route-bundle 3회 promotion parity admission

### DIFF
--- a/tools/release/build-promotion-request.test.mjs
+++ b/tools/release/build-promotion-request.test.mjs
@@ -89,6 +89,17 @@ test("candidate root의 symlink·실제 inventory drift·identity·approval·com
   ]) assertRejectedWithoutOutputDamage(mutate);
 });
 
+test("세 parity candidate inventory에는 recorded server route bundle이 필수다", () => {
+  const fixture = createFixture();
+  try {
+    fixture.roots.forEach((root) => unlinkSync(path.join(root, "server-route-bundle/manifest.json")));
+    refreshCandidateMetadata(fixture);
+    assert.notEqual(run(fixture).status, 0);
+  } finally {
+    fixture.cleanup();
+  }
+});
+
 test("candidate signature validation key가 없으면 fail closed한다", () => {
   for (const env of [
     { EASYSUBWAY_DATAPACK_SIGNING_PUBLIC_KEY_PEM: "" },
@@ -209,6 +220,7 @@ function createFixture() {
   const roots = ["123", "124", "125"].map((workflowRunId, index) => {
     const candidateRoot = path.join(root, `candidate-${index + 1}`);
     file(candidateRoot, "artifact.bin", "artifact");
+    file(candidateRoot, "server-route-bundle/manifest.json", "signed-route-bundle");
     file(candidateRoot, "catalog/capital-v1.sqlite.gz", "pack");
     const provenance = { schemaVersion: 1, artifactKind: "datapack-field-provenance", candidateBuild: { sourceSnapshotSetHash: "c".repeat(64) } };
     file(candidateRoot, "current.provenance.json", JSON.stringify(provenance));
@@ -268,7 +280,7 @@ function approvedReview() {
 }
 
 function inventoryValue(root) {
-  const entries = ["artifact.bin", "catalog/current.json", "current.provenance.json", "catalog/capital-v1.sqlite.gz", "catalog/extra.sqlite.gz"]
+  const entries = ["artifact.bin", "server-route-bundle/manifest.json", "catalog/current.json", "current.provenance.json", "catalog/capital-v1.sqlite.gz", "catalog/extra.sqlite.gz"]
     .filter((entry) => exists(path.join(root, entry))).sort().map((entry) => {
     const bytes = readFileSync(path.join(root, entry));
     return { path: entry, sizeBytes: bytes.length, sha256: sha256(bytes) };

--- a/tools/release/validate-promotion-request.mjs
+++ b/tools/release/validate-promotion-request.mjs
@@ -85,6 +85,9 @@ export function validateInventory(value) {
     }
     previousPath = entry.path;
   }
+  if (!value.entries.some((entry) => entry.path.startsWith("server-route-bundle/") && entry.sizeBytes >= 1)) {
+    throw new Error("inventory server route bundle is required");
+  }
   return value;
 }
 

--- a/tools/release/validate-promotion-request.test.mjs
+++ b/tools/release/validate-promotion-request.test.mjs
@@ -71,8 +71,10 @@ test("validator도 inventory의 안전한 경로·정렬·정확한 field를 fai
 test("validator는 server route bundle 없는 hand-built inventory를 거부한다", () => {
   const fixture = createFixture();
   try {
-    writeFileSync(fixture.inventoryPath, JSON.stringify({ schemaVersion: 1, artifactKind: "datapack-candidate-inventory", entries: [{ path: "artifact.bin", sizeBytes: 1, sha256: "d".repeat(64) }] }));
-    assert.notEqual(run(fixture).status, 0);
+    rebindInventory(fixture, { schemaVersion: 1, artifactKind: "datapack-candidate-inventory", entries: [{ path: "artifact.bin", sizeBytes: 1, sha256: "d".repeat(64) }] });
+    const result = run(fixture);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /inventory server route bundle is required/);
   } finally { fixture.cleanup(); }
 });
 
@@ -114,6 +116,18 @@ function replaceCompatibility(fixture, value) {
   writeFileSync(fixture.compatibilityPath, bytes);
   fixture.request.compatibilityEvidenceSha256 = sha256(bytes);
   writeRequest(fixture);
+}
+function rebindInventory(fixture, value) {
+  const bytes = Buffer.from(JSON.stringify(value));
+  const artifactInventorySha256 = sha256(bytes);
+  const components = ["123", "124", "125"].map((workflowRunId) => componentValue(workflowRunId, artifactInventorySha256));
+  writeFileSync(fixture.inventoryPath, bytes);
+  writeFileSync(fixture.componentPath, JSON.stringify(components[0]));
+  fixture.evidence.candidates = components;
+  fixture.evidence.artifactInventorySha256 = artifactInventorySha256;
+  fixture.request.candidate = structuredClone(components[0]);
+  replaceCompatibility(fixture, compatibilityValue(components[0]));
+  writeEvidence(fixture);
 }
 function inventoryValue() { return { schemaVersion: 1, artifactKind: "datapack-candidate-inventory", entries: [{ path: "artifact.bin", sizeBytes: 1, sha256: "d".repeat(64) }, { path: "server-route-bundle/manifest.json", sizeBytes: 1, sha256: "e".repeat(64) }] }; }
 function approvedReview() { return { state: "approved", environments: [{ name: "datapack-promotion" }], user: { login: "AquilaXk" } }; }

--- a/tools/release/validate-promotion-request.test.mjs
+++ b/tools/release/validate-promotion-request.test.mjs
@@ -68,6 +68,14 @@ test("validator도 inventory의 안전한 경로·정렬·정확한 field를 fai
   }
 });
 
+test("validator는 server route bundle 없는 hand-built inventory를 거부한다", () => {
+  const fixture = createFixture();
+  try {
+    writeFileSync(fixture.inventoryPath, JSON.stringify({ schemaVersion: 1, artifactKind: "datapack-candidate-inventory", entries: [{ path: "artifact.bin", sizeBytes: 1, sha256: "d".repeat(64) }] }));
+    assert.notEqual(run(fixture).status, 0);
+  } finally { fixture.cleanup(); }
+});
+
 function createFixture() {
   const root = mkdtempSync(path.join(os.tmpdir(), "promotion-validate-"));
   const inventoryBytes = Buffer.from(JSON.stringify(inventoryValue()));
@@ -107,7 +115,7 @@ function replaceCompatibility(fixture, value) {
   fixture.request.compatibilityEvidenceSha256 = sha256(bytes);
   writeRequest(fixture);
 }
-function inventoryValue() { return { schemaVersion: 1, artifactKind: "datapack-candidate-inventory", entries: [{ path: "artifact.bin", sizeBytes: 1, sha256: "d".repeat(64) }] }; }
+function inventoryValue() { return { schemaVersion: 1, artifactKind: "datapack-candidate-inventory", entries: [{ path: "artifact.bin", sizeBytes: 1, sha256: "d".repeat(64) }, { path: "server-route-bundle/manifest.json", sizeBytes: 1, sha256: "e".repeat(64) }] }; }
 function approvedReview() { return { state: "approved", environments: [{ name: "datapack-promotion" }], user: { login: "AquilaXk" } }; }
 function componentValue(workflowRunId, artifactInventorySha256) { return { schemaVersion: 1, component: "data", repository: "AquilaXk/easysubway-data", gitSha: "a".repeat(40), workflowRunId, dataVersion: "1", releaseSequence: 1, manifestSha256: "b".repeat(64), provenance: { sourceSnapshotSetHash: "c".repeat(64) }, artifactInventorySha256, contractVersion: "datapack-contract-v3", issueRef: "AquilaXk/easysubway#2705" }; }
 function compatibilityValue(component) { return { schemaVersion: 1, artifactKind: "datapack-mobile-compatibility-evidence", decision: "PASS", candidate: structuredClone(component) }; }


### PR DESCRIPTION
## 관련 이슈 / Related issue

Closes #2879

## 작업 배경 / Summary

- Problem: 3개 Data candidate의 complete inventory가 byte-equal이어도 `server-route-bundle/**`가 전부 없는 catalog-only root를 promotion request로 만들 수 있었습니다.
- Outcome: builder와 standalone validator가 기록된 nonempty `server-route-bundle/**` inventory member를 필수로 검증합니다.

## 작업 내용 / Changes

- promotion inventory validator에 safe/nonempty server route bundle subtree invariant 추가
- 세 candidate root에서 subtree가 빠진 RED regression 추가
- hand-built/older request inventory의 bypass를 막는 standalone validator regression 추가

## Scope

### Included

- Hub promotion request build/validation의 route-bundle subtree admission
- 기존 complete inventory-to-disk equality를 통한 regular/non-symlink/bytes 결속

### Excluded

- Data candidate producer, signed bundle schema, publication, promotion operation, deploy
- workflow inputs, run validation, three-run parity identity, approvals, four-file output 변경

### Ownership / dependencies

- Accountable owner or plan: `PLAN-JOURNEY`
- Required predecessor output: Data #302/#306 terminal producer contract; 실제 promotion은 qualifying candidate 3개 뒤에만 실행
- Concurrent work overlap: None

## Documentation impact

- 영향 resource ID 또는 `NONE`: `NONE`
- resourceClass: `NONE`
- documentationFamily: `NONE`
- lifecycle/evidence 영향: promotion request의 기존 immutable evidence 경계를 강화하며 문서 변경은 없습니다.

## 검증 / Verification

| Check | Result / Evidence |
| --- | --- |
| Focused RED → GREEN | missing subtree acceptance RED → builder 9/9 PASS |
| Affected integration | validator 5/5 PASS |
| Required CI | Draft PR에서 확인 |
| Manual / production-like | Not required — reason: deterministic local filesystem contract |
| Security / privacy / accessibility | PASS — symlink/nonregular/empty/tamper fail-closed 경계 유지 |

- 실행한 명령과 결과:
  - `node --test tools/release/build-promotion-request.test.mjs` → 9/9 PASS
  - `node --test tools/release/validate-promotion-request.test.mjs` → 5/5 PASS
  - `git diff --check` → PASS

## 검증 증거

UI·수동 QA·배포 증거는 필요하지 않습니다. 변경은 task-local fixture와 closed inventory/root 검증으로 재현됩니다.

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName / versionCode: 변경 없음
- datapack version: 변경 없음
- route / realtime contract: promotion admission만 강화
- backend identity: 변경 없음

## Not run

- Check: repository-wide local suite, actual promotion
- Reason: full regression은 required CI가 소유하고 실제 promotion은 qualifying Data candidate 3개 전까지 금지됩니다.
- Rerun owner / condition: PR required CI / Data candidate 3개 terminal 이후 operation owner

## 리뷰어 메모 / Review focus

- `validateInventory`의 subtree invariant가 builder의 세 root와 standalone request validator에 모두 적용되는지 확인해 주세요.

## 리스크 / Risk

- Level: High
- Main risk: catalog-only parity가 signed Journey route bundle promotion으로 오인되는 release defect
- Failure behavior: route subtree가 없거나 empty/symlink/tamper면 request/output 생성 전에 fail closed
- State mutation on failure: create-new output 0
- Fallback or degraded-success path introduced: No

## Rollout / Recovery

- Rollout or activation: automerge 후 다음 Hub promotion부터 적용; 실제 promotion은 별도 operation
- Monitoring / success signal: required CI green, three candidate root admission, four-file promotion artifact
- Rollback or recovery: PR revert; 이전/부분 candidate를 성공으로 재사용하지 않음
- Data / config compatibility after rollback: candidate bytes/schema는 변경하지 않지만 subtree 없는 promotion을 다시 허용하므로 rollback은 운영 전용으로 제한

## 체크리스트 / Checklist

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] 이슈 범위와 실제 diff가 일치하며 관련 없는 변경을 포함하지 않았다.
- [x] 위험에 필요한 검증과 미실행 사유를 기록했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
