### PR TITLE
[CI] axe QA lock·D13 toolchain digest 정합화

### DIFF
--- a/contracts/documentation/clean-checkout-reproducibility-owner-contract.json
+++ b/contracts/documentation/clean-checkout-reproducibility-owner-contract.json
@@ -5,7 +5,7 @@
     {
       "variantId": "hub-documentation-contracts",
       "runnerImage": "ubuntu-24.04",
-      "toolchainDigest": "2bafa62df07a90cbc8501e2cc9c7f7abdcbb99069462893ab7f0c2ce02b31ac1",
+      "toolchainDigest": "6dd1321bdd3d50511d6d363c3ce7279517c32581fb7b7831d23d13bc11de4ff0",
       "phases": [
         {
           "phase": "SETUP",
@@ -13,7 +13,7 @@
           "arguments": [
             "setup",
             "24",
-            "2bafa62df07a90cbc8501e2cc9c7f7abdcbb99069462893ab7f0c2ce02b31ac1"
+            "6dd1321bdd3d50511d6d363c3ce7279517c32581fb7b7831d23d13bc11de4ff0"
           ],
           "workingDirectory": ".",
           "requiredEnvironment": [],

--- a/tools/ci/clean-checkout-reproducibility-owner-contract.test.mjs
+++ b/tools/ci/clean-checkout-reproducibility-owner-contract.test.mjs
@@ -7,7 +7,7 @@ import { validateSchema } from "./lib/json-schema-lite.mjs";
 import { validateOwnerContract } from "../repo/audit-clean-checkout-reproducibility.mjs";
 
 const ENGINE_SHA = "4475e6d9da634e28cda4179b738d4f9f440f06a7";
-const TOOLCHAIN_DIGEST = "2bafa62df07a90cbc8501e2cc9c7f7abdcbb99069462893ab7f0c2ce02b31ac1";
+const TOOLCHAIN_DIGEST = "6dd1321bdd3d50511d6d363c3ce7279517c32581fb7b7831d23d13bc11de4ff0";
 const ENTRYPOINT = "tools/ci/run-clean-checkout-reproducibility-phase.mjs";
 const CONTRACT_PATH = "contracts/documentation/clean-checkout-reproducibility-owner-contract.json";
 

--- a/tools/ci/run-clean-checkout-reproducibility-phase.mjs
+++ b/tools/ci/run-clean-checkout-reproducibility-phase.mjs
@@ -8,7 +8,7 @@ import { fileURLToPath } from "node:url";
 
 const NODE_MAJOR = "24";
 const TOOLCHAIN_LOCK_PATH = "tools/qa/package-lock.json";
-const TOOLCHAIN_DIGEST = "2bafa62df07a90cbc8501e2cc9c7f7abdcbb99069462893ab7f0c2ce02b31ac1";
+const TOOLCHAIN_DIGEST = "6dd1321bdd3d50511d6d363c3ce7279517c32581fb7b7831d23d13bc11de4ff0";
 
 const COMMANDS = new Map([
   ["build", ["tools/ci/check-contracts.mjs", "--workspace", "contracts/workspaces/hub.json", "--current-only", "--local-contracts-only"]],

--- a/tools/qa/package-lock.json
+++ b/tools/qa/package-lock.json
@@ -8,26 +8,26 @@
       "name": "@easysubway/admin-qa-tools",
       "version": "0.0.0",
       "dependencies": {
-        "@axe-core/playwright": "4.12.1",
+        "@axe-core/playwright": "4.13.0",
         "playwright-core": "1.62.1"
       }
     },
     "node_modules/@axe-core/playwright": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.12.1.tgz",
-      "integrity": "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.13.0.tgz",
+      "integrity": "sha512-6YLx+kxXu5GJceG4ozFg+33a2EMTdjYwWGloJ3sb9Kta5pp+ZNS53uxGVog5JetIY8s++P5UrtX+cri+u0VAVg==",
       "license": "MPL-2.0",
       "dependencies": {
-        "axe-core": "~4.12.1"
+        "axe-core": "~4.13.0"
       },
       "peerDependencies": {
         "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/axe-core": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
-      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
+      "integrity": "sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==",
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"

--- a/tools/qa/package.json
+++ b/tools/qa/package.json
@@ -8,7 +8,7 @@
     "test": "node --test *.test.mjs"
   },
   "dependencies": {
-    "@axe-core/playwright": "4.12.1",
+    "@axe-core/playwright": "4.13.0",
     "playwright-core": "1.62.1"
   }
 }


### PR DESCRIPTION
## 요약

- `@axe-core/playwright` 4.12.1 → 4.13.0 변경은 Dependabot #2892의 manifest/lock bytes와 정확히 동일하게 반영했습니다.
- 갱신된 `tools/qa/package-lock.json` SHA-256 `6dd1321bdd3d50511d6d363c3ce7279517c32581fb7b7831d23d13bc11de4ff0`을 D13 owner contract, contract test, phase runner에 함께 결속합니다.
- 이전 digest를 성공 fallback으로 남기지 않습니다.

## 실패 선행 증거

- #2892 Repository CI: expected `2bafa62d…`, actual `6dd1321b…`
- phase entrypoint: `D13_HUB_TOOLCHAIN_MISMATCH`

## 검증

- `node --test tools/ci/clean-checkout-reproducibility-owner-contract.test.mjs`: PASS, 3/3
- `npm test --prefix tools/qa`: PASS, 15/15
- `git diff --check`: PASS
- package manifest/lock bytes == Dependabot #2892 exact head: PASS

## 비변경

D13 phase/timeout/network policy, 다른 npm 의존성, Android Release Artifact freshness, Backend/Mobile/Data/Platform 계약은 변경하지 않습니다.

Closes #2900
Supersedes #2892
