### PR TITLE
[Refactor] system release identity를 v4로 분리

### DIFF
--- a/contracts/release/system-release-governance-inventory.json
+++ b/contracts/release/system-release-governance-inventory.json
@@ -2,10 +2,257 @@
   "schemaVersion": 1,
   "artifactKind": "system-release-governance-inventory",
   "files": [
-    { "path": "contracts/release/system-release-manifest.schema.json", "sha256": "aeb97a3bd43be169c873eb4c0b018b295da557ae3a3d4ac9a81d494bf1a16f68" },
-    { "path": "contracts/release/system-release-governance-inventory.schema.json", "sha256": "b485bb3887a71841ccbcd784c32a3f98f54366a4241c718a52a74682a4655515" },
-    { "path": "release/product-gates/rc-evidence-manifest-contract.json", "sha256": "1cec386bf58112ce84bc8d0817ae63c378d33a4a8dcf69e6155f8bda12236eb1" },
-    { "path": "tools/release/generate-rc-evidence-manifest.mjs", "sha256": "263148f1b6df75299bfbe130a9be7adf8b21739f11953f6ad4a3d579f2fedf30" },
-    { "path": "tools/release/validate-system-release-manifest.mjs", "sha256": "09bfc02dfb09e1b4db6d72a44fdb5eca104ab0c8c172fc3d569d957988550193" }
+    {
+      "path": ".github/workflows/datapack-release.yml",
+      "sha256": "b15ada47698f88237bec61c5ce902ec55a3f8131cf79c625e2878d2e1cfb8ec7"
+    },
+    {
+      "path": ".github/workflows/release-artifacts.yml",
+      "sha256": "1cd2a8018f4de43c16e38ad12a175ee81d982513028a91847e8f0352c815401f"
+    },
+    {
+      "path": "apps/mobile/lib/app/accessibility_theme.dart",
+      "sha256": "3987679f36ee1226ae75643af6f75178a3dddbb14f7f00d0ac7e0ab9ba943101"
+    },
+    {
+      "path": "apps/mobile/lib/app/app_components.dart",
+      "sha256": "cdbdf988d8cbd5f4d54d159b22f28599499f6eb746db11ef2bba763c9e7ebd01"
+    },
+    {
+      "path": "apps/mobile/lib/app/easy_subway_app.dart",
+      "sha256": "881032641c48b30743ccb8c8b2fcb2ac01b79e0b66e5dbf0d95bee7cd3adb794"
+    },
+    {
+      "path": "apps/mobile/lib/features/account/presentation/user_data_deletion_screen.dart",
+      "sha256": "b4772edc79156c694fc4ddeccc8209d9d515ca449bd8791b0974b23d6bddcf32"
+    },
+    {
+      "path": "apps/mobile/lib/features/attribution/presentation/data_source_attribution_screen.dart",
+      "sha256": "b1768880be57509a1dc2e9a97dd3231a80664267336624d1f547a16d890828c9"
+    },
+    {
+      "path": "apps/mobile/lib/features/favorites/presentation/favorite_home_screen.dart",
+      "sha256": "b60f304bbf37c9df34e8964c2ab48b692f3c9fb62cbc6dd7138cbcddf671a9af"
+    },
+    {
+      "path": "apps/mobile/lib/features/home/presentation/home_screen.dart",
+      "sha256": "cc84ff0ef4dca75ed4b383c669c28265437e6849ce4f9d089dc044bb469872c4"
+    },
+    {
+      "path": "apps/mobile/lib/features/settings/presentation/app_settings_screen.dart",
+      "sha256": "9addd1120dd44a62959422989f78cc308d53e19b12c56e23b527e649739ea5e1"
+    },
+    {
+      "path": "apps/mobile/lib/features/settings/presentation/open_source_licenses_screen.dart",
+      "sha256": "c196f9c4edf55a0423db3371635009db84f856bbd7ff4a626bceb52fd11c3ee8"
+    },
+    {
+      "path": "apps/mobile/lib/features/settings/presentation/service_info_screen.dart",
+      "sha256": "d7aa7cccbff052e84c9aacd5438fc3fbe96dcce0d9e31a0fc5df77bcf29ab93b"
+    },
+    {
+      "path": "apps/mobile/lib/features/support/presentation/inquiry_screen.dart",
+      "sha256": "83cb5c1ee0c01fc270ec45e740634a5daa3efbfcdf997a7d752d1a4a5b4ccbfb"
+    },
+    {
+      "path": "apps/mobile/lib/features/support/presentation/support_access_screen.dart",
+      "sha256": "644103a53ea16b6413c6b892f9bc5c353d96600cfd463d4a27bf3a0b7f5049e7"
+    },
+    {
+      "path": "apps/mobile/lib/main.dart",
+      "sha256": "48e4427763eed179d9f0897715603226ffc68ddcf98e0e76632050b257d194b8"
+    },
+    {
+      "path": "apps/mobile/pubspec.yaml",
+      "sha256": "65dd3d8fbf0df64489d73a41194a97eb8a8986b58024c8a35bbef42e38917abd"
+    },
+    {
+      "path": "apps/mobile/release/signed-release-artifact-gate.json",
+      "sha256": "6570e6317f34142991cf38b213754991ee91732e6b735ebdec6abe3191f47007"
+    },
+    {
+      "path": "backend/Dockerfile",
+      "sha256": "bb190eb507645836df69934a0ca6cf4dc7499bd508ed0a485e688eede70e615a"
+    },
+    {
+      "path": "backend/build.gradle",
+      "sha256": "2684df5a35c4d7952819899810654cfd61d081fe231347e42b37cce05ae9f9bd"
+    },
+    {
+      "path": "contracts/release/component-manifest.schema.json",
+      "sha256": "08159722e1abcb51cdb6ffefd9f55f03450b104e6792bd6888d98470e7659ad5"
+    },
+    {
+      "path": "contracts/release/issue-ref.schema.json",
+      "sha256": "da70e7ba7892f3d198ec65aea79e726336fdd2aff7fdbb1e60a1952df10fbbc9"
+    },
+    {
+      "path": "contracts/release/system-release-governance-inventory.schema.json",
+      "sha256": "0ad2b1243f43ce22f873e5b9af55acffaaafd79ac89c9ac3d810ee9d45246241"
+    },
+    {
+      "path": "contracts/release/system-release-manifest.schema.json",
+      "sha256": "aeb97a3bd43be169c873eb4c0b018b295da557ae3a3d4ac9a81d494bf1a16f68"
+    },
+    {
+      "path": "infra/alloy/config.alloy",
+      "sha256": "cb8333eecd52ef6cf5fc9ccf62e87a2990deaa57b6ff3b9a2effcfa33a9b3f5a"
+    },
+    {
+      "path": "infra/docker-compose.yml",
+      "sha256": "0f14db02823e85a748b2918b0ea72360f90573bfd31c6042a4fcbf78db6ee145"
+    },
+    {
+      "path": "infra/grafana/provisioning/dashboards/dashboards.yml",
+      "sha256": "648f908f7ddf556b3ec4de0dd9d66dfc75e58a747ebfda411725b8ad301aeb41"
+    },
+    {
+      "path": "infra/grafana/provisioning/dashboards/json/error-ops.json",
+      "sha256": "8d28d95d06780698b51014697ee4e942851876ea75ffcbf2c2a5ce7d394ec862"
+    },
+    {
+      "path": "infra/grafana/provisioning/datasources/loki.yml",
+      "sha256": "57bb87c11cec9f9e728e37a636de9eca2a291c8cd051c67d4e1cd2c683a7675e"
+    },
+    {
+      "path": "infra/grafana/provisioning/datasources/prometheus.yml",
+      "sha256": "9598a3fc9b36ce35c997233ac4a61ff0293023dbb45e1d872270c2a3f8666fc5"
+    },
+    {
+      "path": "infra/loki/loki.yml",
+      "sha256": "35ed63f6a069c0c6da0d711d4495f871886ec7466916cf61cd29989825c690b2"
+    },
+    {
+      "path": "infra/prometheus/alerts.yml",
+      "sha256": "764c3e88fb604ed598d053de5376c531e64f122fa7f496f5969e8511f00538af"
+    },
+    {
+      "path": "infra/prometheus/prometheus.yml",
+      "sha256": "9bcde0205620224c01d86ec99fd2ef68314a9a96f40bd70c58fe67f8123e366f"
+    },
+    {
+      "path": "release/product-gates/abuse-penetration-rehearsal-gate.json",
+      "sha256": "39b66abe1bdd938fd54610086b302e3e19d32eaab900f5209cb74c154f9c2f9f"
+    },
+    {
+      "path": "release/product-gates/operations-observability-gate.json",
+      "sha256": "d1806235459623db3cd1c6098686d613090373b1dfd116a732ab3ea2b48bc4fb"
+    },
+    {
+      "path": "release/product-gates/operations-release-evidence.json",
+      "sha256": "e702d13030e789e8c26106fd84bd6928e3471cb1a76f43f243642cae4709cc12"
+    },
+    {
+      "path": "release/product-gates/post-launch-operations-review-gate.json",
+      "sha256": "0c05626d56d115e37f320ad8fda2093b4eacff374f0595be42b62a9297474146"
+    },
+    {
+      "path": "release/product-gates/production-datapack-scope.json",
+      "sha256": "df69559272fec1df7124059ab8cc5b58f956af7cd1cf6153493cc93095b12173"
+    },
+    {
+      "path": "release/product-gates/rc-evidence-manifest-contract.json",
+      "sha256": "1cec386bf58112ce84bc8d0817ae63c378d33a4a8dcf69e6155f8bda12236eb1"
+    },
+    {
+      "path": "release/product-gates/route-commercialization-gate.json",
+      "sha256": "0ac7b2c2ee1e75fc556fa5418ddeac1473d329d2ccd5a1e539e8aced869cab30"
+    },
+    {
+      "path": "release/product-gates/support-incident-response-gate.json",
+      "sha256": "92034fe8ad78e29bb267fabf777056684f347c78d2a1f1023ca3109a5fbd2530"
+    },
+    {
+      "path": "tools/ci/lib/json-schema-lite.mjs",
+      "sha256": "c239c9dc63842d0d293ec3f8ada59d557d1d2a5761f77c0abed07520afb3bc67"
+    },
+    {
+      "path": "tools/ci/validate-store-privacy-env.mjs",
+      "sha256": "5e3bde24adc32d74ae59d575235bab3400936823b9e4c5c2d7af71c6465fcc84"
+    },
+    {
+      "path": "tools/datapack/build-launch-denominator-report.mjs",
+      "sha256": "181e740b8e96371969848d3cd5a3020de94f812dfc2214b010ffb4b44c0d70c6"
+    },
+    {
+      "path": "tools/datapack/decide-datapack-release.mjs",
+      "sha256": "19df0719c5c030db1981bd34622a42b98e610ac35851a4d0219c70c51dda675c"
+    },
+    {
+      "path": "tools/datapack/lib/manifest-validation.mjs",
+      "sha256": "9e35372f21307b9c20258fde15556ef4cfc2c28276a46435974fe30253055e81"
+    },
+    {
+      "path": "tools/datapack/production-url-policy.mjs",
+      "sha256": "2f1166cbc241d68aa36a25484159985ec19b9add529eefc0030e780633a422ff"
+    },
+    {
+      "path": "tools/datapack/run-emergency-datapack-drill.mjs",
+      "sha256": "c5368fbe7ac1e705145eb39e5183cb34986dea560558f2e31b4d4e6eaca3c82c"
+    },
+    {
+      "path": "tools/datapack/validate-remote-datapack-artifact.mjs",
+      "sha256": "153a5888903c503fb572b5596afac58d1b0ac1ae973f3e8fda5806948d168b26"
+    },
+    {
+      "path": "tools/datapack/verify-release-request-binding.mjs",
+      "sha256": "33953a3a0432f82021f54df40e072288c3d4100d0a254317fbdeb700e8b03cb3"
+    },
+    {
+      "path": "tools/lib/codepoint-compare.mjs",
+      "sha256": "d3da920bfa5b108ad3d096b21e83dd821772edefcbed7c7b64a2a68e6c54971d"
+    },
+    {
+      "path": "tools/ops/generate-operations-phase-a-summary.mjs",
+      "sha256": "cdf8aa04776d03effe93a829954f331e12fe1cb792fe29a2a6b0da68f0d729cc"
+    },
+    {
+      "path": "tools/ops/validate-operations-release-summary.mjs",
+      "sha256": "b74f89aaa3fd86b7a85e2baa3e1b487acd11a9d9099c262d97363b550c8d851c"
+    },
+    {
+      "path": "tools/realtime/seoul-topis-provider-contract.json",
+      "sha256": "4bd4fd37337ec30833dae3aa0f8ae34f1a08cf06f13dbefad1fe7ccda5a8bc4d"
+    },
+    {
+      "path": "tools/release/count-gzip-uncompressed-bytes.mjs",
+      "sha256": "e44ccdd89af5260c6a8027b6b03fdd660640bc52c99be9ba5d024a629d24dbb9"
+    },
+    {
+      "path": "tools/release/generate-rc-evidence-manifest.mjs",
+      "sha256": "dafcfd6d253d118d8889f9a7bd8c4bfb5dad74dc6dc1a3459b19f642332a14dc"
+    },
+    {
+      "path": "tools/release/hash-android-bundle-payload.mjs",
+      "sha256": "0bea0f2d7775960a4672e27622aa32a239cabadad07399cb3ee51ae524b234eb"
+    },
+    {
+      "path": "tools/release/lib/semver.mjs",
+      "sha256": "abea907d2cbe2e681fb7942a243616754320a7b579c38bcf9e6a979fc5f1dbe6"
+    },
+    {
+      "path": "tools/release/select-rc-datapack-artifact.mjs",
+      "sha256": "06b1d4e60c041e7cd44e461722a7e5519c515e1135612a16429845bdeac32287"
+    },
+    {
+      "path": "tools/release/summary-validation-utils.mjs",
+      "sha256": "aff1abc66a25e5310e69b8fd915026dfd5bf458f6f1977d445e5e635e10a35cc"
+    },
+    {
+      "path": "tools/release/upload-play-internal.mjs",
+      "sha256": "7bc41b1fb3ce86b2e24043a9a43e47e91577ab33c5170535c8e8c85c09b5c5eb"
+    },
+    {
+      "path": "tools/release/validate-system-release-manifest.mjs",
+      "sha256": "121c5e3698c5dad97cba27c8eb6e294fe5b68544777fdaba086dbd3a096767ae"
+    },
+    {
+      "path": "tools/security/abuse-penetration-summary-schema.mjs",
+      "sha256": "b3aeca3f32f241704dd6be667e99b3b4a83adc1573918ce178ea683f1680ff48"
+    },
+    {
+      "path": "tools/security/validate-abuse-penetration-summary.mjs",
+      "sha256": "2fa30e161cf6f8c27147704dfb467ca93cce7142ce1c010fcf52f39abde1bd58"
+    }
   ]
 }

--- a/contracts/release/system-release-governance-inventory.json
+++ b/contracts/release/system-release-governance-inventory.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "system-release-governance-inventory",
+  "files": [
+    { "path": "contracts/release/system-release-manifest.schema.json", "sha256": "aeb97a3bd43be169c873eb4c0b018b295da557ae3a3d4ac9a81d494bf1a16f68" },
+    { "path": "contracts/release/system-release-governance-inventory.schema.json", "sha256": "b485bb3887a71841ccbcd784c32a3f98f54366a4241c718a52a74682a4655515" },
+    { "path": "release/product-gates/rc-evidence-manifest-contract.json", "sha256": "1cec386bf58112ce84bc8d0817ae63c378d33a4a8dcf69e6155f8bda12236eb1" },
+    { "path": "tools/release/generate-rc-evidence-manifest.mjs", "sha256": "263148f1b6df75299bfbe130a9be7adf8b21739f11953f6ad4a3d579f2fedf30" },
+    { "path": "tools/release/validate-system-release-manifest.mjs", "sha256": "09bfc02dfb09e1b4db6d72a44fdb5eca104ab0c8c172fc3d569d957988550193" }
+  ]
+}

--- a/contracts/release/system-release-governance-inventory.schema.json
+++ b/contracts/release/system-release-governance-inventory.schema.json
@@ -9,7 +9,7 @@
     "artifactKind": { "const": "system-release-governance-inventory" },
     "files": {
       "type": "array",
-      "minItems": 5,
+      "minItems": 63,
       "uniqueItems": true,
       "items": {
         "type": "object",

--- a/contracts/release/system-release-governance-inventory.schema.json
+++ b/contracts/release/system-release-governance-inventory.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Closed system release governance inventory v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "artifactKind", "files"],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "artifactKind": { "const": "system-release-governance-inventory" },
+    "files": {
+      "type": "array",
+      "minItems": 5,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["path", "sha256"],
+        "properties": {
+          "path": { "type": "string", "pattern": "^[A-Za-z0-9._/-]+$" },
+          "sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" }
+        }
+      }
+    }
+  }
+}

--- a/contracts/release/system-release-manifest.schema.json
+++ b/contracts/release/system-release-manifest.schema.json
@@ -1,17 +1,19 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "System release manifest v3",
+  "title": "System release manifest v4",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schemaVersion", "productReleaseId", "phase", "decision", "generatedAt", "issueRefs", "hub", "contracts", "mobile", "backend", "data", "platform"],
+  "required": ["schemaVersion", "productReleaseId", "phase", "decision", "generatedAt", "issueRefs", "productIdentitySha256", "governanceRevisionSha256", "hubObservedRevision", "contracts", "mobile", "backend", "data", "platform"],
   "properties": {
-    "schemaVersion": { "const": 3 },
+    "schemaVersion": { "const": 4 },
     "productReleaseId": { "type": "string", "minLength": 1 },
     "phase": { "type": "string", "enum": ["CANDIDATE", "FINAL"] },
     "decision": { "type": "string", "enum": ["GO", "NO_GO"] },
     "generatedAt": { "type": "string", "format": "date-time" },
     "issueRefs": { "type": "array", "minItems": 1, "uniqueItems": true, "items": { "type": "string", "pattern": "^AquilaXk/(easysubway|easysubway-data|easysubway-platform|easysubway-backend|easysubway-mobile)#[1-9][0-9]*$" } },
-    "hub": {
+    "productIdentitySha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "governanceRevisionSha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "hubObservedRevision": {
       "type": "object",
       "additionalProperties": false,
       "required": ["repository", "gitSha"],

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -20,7 +20,11 @@ import {
 } from "../release/generate-route-integration-verdict.mjs";
 import { codepointCompare } from "../lib/codepoint-compare.mjs";
 import { validateLineage } from "../datapack/source-snapshot-policy.mjs";
-import { calculateProductIdentity, selectSystemReleaseDecision } from "../release/validate-system-release-manifest.mjs";
+import {
+  calculateProductIdentity,
+  governanceInventoryPaths,
+  selectSystemReleaseDecision,
+} from "../release/validate-system-release-manifest.mjs";
 
 const root = process.cwd();
 const execFileAsync = promisify(execFile);
@@ -6407,33 +6411,13 @@ test("datapack readiness producer는 required gate를 동일 final identity로 �
   for (const directory of ["apps/mobile/release", "release/product-gates", "contracts/release", "tools/release", "tools/ops", "tools/security"]) {
     await mkdir(path.join(validationRepo, directory), { recursive: true });
   }
-  await symlink(path.join(root, "release/product-gates/production-datapack-scope.json"), path.join(validationRepo, "release/product-gates/production-datapack-scope.json"));
-  for (const schema of ["component-manifest.schema.json", "issue-ref.schema.json"]) {
-    await symlink(path.join(root, "contracts/release", schema), path.join(validationRepo, "contracts/release", schema));
-  }
   for (const governedPath of [
-    "contracts/release/system-release-manifest.schema.json",
-    "contracts/release/system-release-governance-inventory.schema.json",
+    ...governanceInventoryPaths,
     "contracts/release/system-release-governance-inventory.json",
-    "release/product-gates/rc-evidence-manifest-contract.json",
-    "tools/release/generate-rc-evidence-manifest.mjs",
-    "tools/release/validate-system-release-manifest.mjs",
   ]) {
+    await mkdir(path.dirname(path.join(validationRepo, governedPath)), { recursive: true });
     await writeFile(path.join(validationRepo, governedPath), await readFile(path.join(root, governedPath)));
   }
-  await symlink(path.join(root, "tools/release/hash-android-bundle-payload.mjs"), path.join(validationRepo, "tools/release/hash-android-bundle-payload.mjs"));
-  await symlink(path.join(root, "tools/release/count-gzip-uncompressed-bytes.mjs"), path.join(validationRepo, "tools/release/count-gzip-uncompressed-bytes.mjs"));
-  await writeFile(path.join(validationRepo, "tools/ops/validate-operations-release-summary.mjs"), `import { readFileSync } from "node:fs";
-const value = (name) => process.argv[process.argv.indexOf(name) + 1];
-const summary = JSON.parse(readFileSync(value("--summary"), "utf8"));
-const manifest = JSON.parse(readFileSync(value("--rc-manifest"), "utf8"));
-if (summary.evidenceId !== "post_launch_operations" || summary.status !== "SATISFIED") process.exit(1);
-if (JSON.stringify(summary.rcIdentity) !== JSON.stringify(manifest.rcIdentity)) process.exit(1);
-`);
-  await writeFile(path.join(validationRepo, "tools/security/validate-abuse-penetration-summary.mjs"), `import { existsSync } from "node:fs";
-const value = (name) => process.argv[process.argv.indexOf(name) + 1];
-if (!existsSync(value("--summary")) || !process.argv.includes("--require-pass")) process.exit(1);
-`);
   const gitSha = await initializeFixtureGitRepo(validationRepo);
   const now = "2026-07-16T00:00:00.000Z";
   const snapshotSetIdentity = "a".repeat(64);
@@ -6653,7 +6637,35 @@ if (!existsSync(value("--summary")) || !process.argv.includes("--require-pass"))
   await assert.rejects(execFileAsync(process.execPath, [...args, "--phase", "FINAL",
     "--candidate-context", invalidCandidatePath, "--output", path.join(tempDir, "invalid-final.json")], generatorOptions),
   /without readiness or decision fields/);
-  args.push(...await writeFinalSystemReleaseArgs(baselineOutput, path.join(tempDir, "final-readiness.json")), "--phase", "FINAL", "--candidate-context", baselineOutput);
+  const systemArgs = await writeFinalSystemReleaseArgs(baselineOutput, path.join(tempDir, "final-readiness.json"));
+  const systemFixtureArgs = [...args, ...systemArgs, "--phase", "FINAL", "--candidate-context", baselineOutput];
+  const fixtureValidatorPath = path.join(validationRepo, "tools/release/validate-system-release-manifest.mjs");
+  const fixtureSystemOutput = systemFixtureArgs[systemFixtureArgs.indexOf("--system-release-output") + 1];
+  const candidateBeforeFixtureDrift = await readFile(baselineOutput);
+  const crossRootOutput = path.join(tempDir, "cross-root-final.json");
+  await execFileAsync(process.execPath, [...systemFixtureArgs, "--output", crossRootOutput], generatorOptions);
+  assert.equal(JSON.parse(await readFile(fixtureSystemOutput, "utf8")).schemaVersion, 4);
+  await writeFile(fixtureSystemOutput, "system release sentinel");
+  await writeFile(fixtureValidatorPath, `${await readFile(fixtureValidatorPath, "utf8")}\n// fixture drift\n`);
+  await assert.rejects(
+    execFileAsync(process.execPath, [...systemFixtureArgs, "--output", baselineOutput], generatorOptions),
+    /attested repoRoot bytes do not match loaded execution path: tools\/release\/validate-system-release-manifest\.mjs/,
+  );
+  assert.equal(await readFile(fixtureSystemOutput, "utf8"), "system release sentinel");
+  assert.deepEqual(await readFile(baselineOutput), candidateBeforeFixtureDrift);
+  await writeFile(fixtureValidatorPath, await readFile(path.join(root, "tools/release/validate-system-release-manifest.mjs")));
+  await writeFile(path.join(validationRepo, "tools/ops/validate-operations-release-summary.mjs"), `import { readFileSync } from "node:fs";
+const value = (name) => process.argv[process.argv.indexOf(name) + 1];
+const summary = JSON.parse(readFileSync(value("--summary"), "utf8"));
+const manifest = JSON.parse(readFileSync(value("--rc-manifest"), "utf8"));
+if (summary.evidenceId !== "post_launch_operations" || summary.status !== "SATISFIED") process.exit(1);
+if (JSON.stringify(summary.rcIdentity) !== JSON.stringify(manifest.rcIdentity)) process.exit(1);
+`);
+  await writeFile(path.join(validationRepo, "tools/security/validate-abuse-penetration-summary.mjs"), `import { existsSync } from "node:fs";
+const value = (name) => process.argv[process.argv.indexOf(name) + 1];
+if (!existsSync(value("--summary")) || !process.argv.includes("--require-pass")) process.exit(1);
+`);
+  args.push("--phase", "FINAL", "--candidate-context", baselineOutput);
   for (const invalidCount of ["1abc", "1.5", "-0.5"]) {
     await assert.rejects(execFileAsync(process.execPath, [
       ...args, "--open-android-p0-count", invalidCount,

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -6408,9 +6408,18 @@ test("datapack readiness producer는 required gate를 동일 final identity로 �
     await mkdir(path.join(validationRepo, directory), { recursive: true });
   }
   await symlink(path.join(root, "release/product-gates/production-datapack-scope.json"), path.join(validationRepo, "release/product-gates/production-datapack-scope.json"));
-  await symlink(path.join(root, "release/product-gates/rc-evidence-manifest-contract.json"), path.join(validationRepo, "release/product-gates/rc-evidence-manifest-contract.json"));
-  for (const schema of ["component-manifest.schema.json", "system-release-manifest.schema.json", "issue-ref.schema.json"]) {
+  for (const schema of ["component-manifest.schema.json", "issue-ref.schema.json"]) {
     await symlink(path.join(root, "contracts/release", schema), path.join(validationRepo, "contracts/release", schema));
+  }
+  for (const governedPath of [
+    "contracts/release/system-release-manifest.schema.json",
+    "contracts/release/system-release-governance-inventory.schema.json",
+    "contracts/release/system-release-governance-inventory.json",
+    "release/product-gates/rc-evidence-manifest-contract.json",
+    "tools/release/generate-rc-evidence-manifest.mjs",
+    "tools/release/validate-system-release-manifest.mjs",
+  ]) {
+    await writeFile(path.join(validationRepo, governedPath), await readFile(path.join(root, governedPath)));
   }
   await symlink(path.join(root, "tools/release/hash-android-bundle-payload.mjs"), path.join(validationRepo, "tools/release/hash-android-bundle-payload.mjs"));
   await symlink(path.join(root, "tools/release/count-gzip-uncompressed-bytes.mjs"), path.join(validationRepo, "tools/release/count-gzip-uncompressed-bytes.mjs"));

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -20,7 +20,7 @@ import {
 } from "../release/generate-route-integration-verdict.mjs";
 import { codepointCompare } from "../lib/codepoint-compare.mjs";
 import { validateLineage } from "../datapack/source-snapshot-policy.mjs";
-import { selectSystemReleaseDecision } from "../release/validate-system-release-manifest.mjs";
+import { calculateProductIdentity, selectSystemReleaseDecision } from "../release/validate-system-release-manifest.mjs";
 
 const root = process.cwd();
 const execFileAsync = promisify(execFile);
@@ -6113,7 +6113,7 @@ test("RC evidence manifest generator는 RC identity와 No-Go blocker를 생성�
   assert.ok(corruptManifest.readiness.blockers.some((blocker) => blocker.id === "missing_aabPayloadSha256"));
 });
 
-test("[system-release-generator] FINAL은 Hub와 네 target SHA를 결속한 system release v3를 별도로 생성한다", async () => {
+test("[system-release-generator] FINAL은 product·governance·observation identity를 결속한 system release v4를 별도로 생성한다", async () => {
   const tempDir = await mkdtemp(path.join(tmpdir(), "easysubway-system-release-"));
   const candidatePath = path.join(tempDir, "candidate.json");
   const outputPath = path.join(tempDir, "legacy-final.json");
@@ -6198,8 +6198,10 @@ test("[system-release-generator] FINAL은 Hub와 네 target SHA를 결속한 sys
     const legacy = JSON.parse(await readFile(outputPath, "utf8"));
     const system = JSON.parse(await readFile(systemOutputPath, "utf8"));
     assert.equal(Object.hasOwn(system, "gitSha"), false);
-    assert.equal(system.schemaVersion, 3);
-    assert.deepEqual(system.hub, { repository: "AquilaXk/easysubway", gitSha: currentGitSha });
+    assert.equal(system.schemaVersion, 4);
+    assert.deepEqual(system.hubObservedRevision, { repository: "AquilaXk/easysubway", gitSha: currentGitSha });
+    assert.match(system.productIdentitySha256, /^[a-f0-9]{64}$/);
+    assert.match(system.governanceRevisionSha256, /^[a-f0-9]{64}$/);
     assert.equal(system.phase, "FINAL");
     assert.equal(system.decision, "NO_GO");
     assert.deepEqual(system.issueRefs, issueRefs);
@@ -6243,6 +6245,8 @@ test("[system-release-generator] FINAL은 Hub와 네 target SHA를 결속한 sys
       componentSchema: JSON.parse(read("contracts/release/component-manifest.schema.json")),
       systemSchema: JSON.parse(read("contracts/release/system-release-manifest.schema.json")),
       issueRefSchema: JSON.parse(read("contracts/release/issue-ref.schema.json")),
+      governanceInventorySchema: JSON.parse(read("contracts/release/system-release-governance-inventory.schema.json")),
+      governanceInventory: JSON.parse(read("contracts/release/system-release-governance-inventory.json")),
     };
     const canonicalGoCandidate = structuredClone(system);
     for (const component of ["mobile", "backend", "data", "platform"]) {
@@ -6263,6 +6267,7 @@ test("[system-release-generator] FINAL은 Hub와 네 target SHA를 결속한 sys
         stale: 0, previous: 0, alternateProvider: 0, bestEffort: 0,
       },
     };
+    canonicalGoCandidate.productIdentitySha256 = calculateProductIdentity(canonicalGoCandidate);
     assert.equal(
       selectSystemReleaseDecision({ legacyDecision: "GO", manifest: canonicalGoCandidate, ...semanticSchemas }),
       "GO",

--- a/tools/release/generate-rc-evidence-manifest.mjs
+++ b/tools/release/generate-rc-evidence-manifest.mjs
@@ -8,6 +8,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { canonicalScopeHash } from "../datapack/build-launch-denominator-report.mjs";
 import { selectEffectiveDataPack, selectFallbackDataPack, validateManifest } from "../datapack/lib/manifest-validation.mjs";
 import { codepointCompare } from "../lib/codepoint-compare.mjs";
@@ -15,6 +16,8 @@ import { isSemVer } from "./lib/semver.mjs";
 import {
   calculateGovernanceRevision,
   calculateProductIdentity,
+  governedExecutionPaths,
+  governanceInventoryPaths,
   selectSystemReleaseDecision,
   validateGovernanceInventory,
   validateSystemReleaseManifest,
@@ -27,6 +30,12 @@ const SUCCESSFUL_FRESHNESS_REASON_CODES = new Set([
 
 const args = parseArgs(process.argv.slice(2));
 const cwd = process.cwd();
+const executionRepoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const trustedGovernanceExecutionPaths = Object.fromEntries(
+  governedExecutionPaths.map((entryPath) => (
+    [entryPath, path.join(executionRepoRoot, entryPath)]
+  )),
+);
 const requestedPhase = arg("phase") ?? "FINAL";
 if (!["CANDIDATE", "FINAL"].includes(requestedPhase)) {
   fail("--phase must be CANDIDATE or FINAL");
@@ -454,9 +463,13 @@ function readSystemReleaseInputs() {
     governanceInventory: schemas.governanceInventory,
     governanceInventorySchema: schemas.governanceInventorySchema,
     repoRoot,
+    trustedExecutionPaths: trustedGovernanceExecutionPaths,
   });
   if (governanceErrors.length > 0) fail(`closed release governance inventory is invalid: ${governanceErrors.join(", ")}`);
-  return { components, contracts, outputPath: systemReleaseOutputPath, productReleaseId, schemas };
+  return {
+    components, contracts, outputPath: systemReleaseOutputPath, productReleaseId, schemas,
+    trustedExecutionPaths: trustedGovernanceExecutionPaths,
+  };
 }
 
 function buildSystemReleaseManifest(legacyManifest, inputs) {
@@ -486,9 +499,18 @@ function buildSystemReleaseManifest(legacyManifest, inputs) {
   };
   const manifest = {
     ...identified,
-    decision: selectSystemReleaseDecision({ legacyDecision: legacyManifest.decision, manifest: identified, ...inputs.schemas }),
+    decision: selectSystemReleaseDecision({
+      legacyDecision: legacyManifest.decision,
+      manifest: identified,
+      ...inputs.schemas,
+      trustedExecutionPaths: inputs.trustedExecutionPaths,
+    }),
   };
-  const errors = validateSystemReleaseManifest({ manifest, ...inputs.schemas });
+  const errors = validateSystemReleaseManifest({
+    manifest,
+    ...inputs.schemas,
+    trustedExecutionPaths: inputs.trustedExecutionPaths,
+  });
   if (errors.length > 0) fail(`system release manifest validation failed: ${errors.join(", ")}`);
   return manifest;
 }

--- a/tools/release/generate-rc-evidence-manifest.mjs
+++ b/tools/release/generate-rc-evidence-manifest.mjs
@@ -12,7 +12,13 @@ import { canonicalScopeHash } from "../datapack/build-launch-denominator-report.
 import { selectEffectiveDataPack, selectFallbackDataPack, validateManifest } from "../datapack/lib/manifest-validation.mjs";
 import { codepointCompare } from "../lib/codepoint-compare.mjs";
 import { isSemVer } from "./lib/semver.mjs";
-import { selectSystemReleaseDecision, validateSystemReleaseManifest } from "./validate-system-release-manifest.mjs";
+import {
+  calculateGovernanceRevision,
+  calculateProductIdentity,
+  selectSystemReleaseDecision,
+  validateGovernanceInventory,
+  validateSystemReleaseManifest,
+} from "./validate-system-release-manifest.mjs";
 
 const SUCCESSFUL_FRESHNESS_REASON_CODES = new Set([
   "PACK_PUBLISH_FRESHNESS_EXPIRED",
@@ -441,7 +447,15 @@ function readSystemReleaseInputs() {
     ["componentSchema", "component-manifest.schema.json"],
     ["systemSchema", "system-release-manifest.schema.json"],
     ["issueRefSchema", "issue-ref.schema.json"],
+    ["governanceInventorySchema", "system-release-governance-inventory.schema.json"],
+    ["governanceInventory", "system-release-governance-inventory.json"],
   ].map(([key, file]) => [key, readRequiredJson(path.join(repoRoot, "contracts/release", file), `release contract ${file}`)]));
+  const governanceErrors = validateGovernanceInventory({
+    governanceInventory: schemas.governanceInventory,
+    governanceInventorySchema: schemas.governanceInventorySchema,
+    repoRoot,
+  });
+  if (governanceErrors.length > 0) fail(`closed release governance inventory is invalid: ${governanceErrors.join(", ")}`);
   return { components, contracts, outputPath: systemReleaseOutputPath, productReleaseId, schemas };
 }
 
@@ -452,22 +466,27 @@ function buildSystemReleaseManifest(legacyManifest, inputs) {
     for (const issueRef of component.issueRefs ?? []) if (!issueRefs.includes(issueRef)) issueRefs.push(issueRef);
   }
   const base = {
-    schemaVersion: 3,
+    schemaVersion: 4,
     productReleaseId: inputs.productReleaseId,
     phase: "FINAL",
     decision: "NO_GO",
     generatedAt,
     issueRefs,
-    hub: {
+    hubObservedRevision: {
       repository: "AquilaXk/easysubway",
       gitSha: legacyManifest.releaseCandidateIdentity.gitSha,
     },
     contracts: inputs.contracts,
     ...inputs.components,
   };
-  const manifest = {
+  const identified = {
     ...base,
-    decision: selectSystemReleaseDecision({ legacyDecision: legacyManifest.decision, manifest: base, ...inputs.schemas }),
+    productIdentitySha256: calculateProductIdentity(base),
+    governanceRevisionSha256: calculateGovernanceRevision(inputs.schemas.governanceInventory),
+  };
+  const manifest = {
+    ...identified,
+    decision: selectSystemReleaseDecision({ legacyDecision: legacyManifest.decision, manifest: identified, ...inputs.schemas }),
   };
   const errors = validateSystemReleaseManifest({ manifest, ...inputs.schemas });
   if (errors.length > 0) fail(`system release manifest validation failed: ${errors.join(", ")}`);

--- a/tools/release/validate-system-release-manifest.mjs
+++ b/tools/release/validate-system-release-manifest.mjs
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
 
-import { readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { existsSync, lstatSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { validateSchema } from "../ci/lib/json-schema-lite.mjs";
 import { isSemVer } from "./lib/semver.mjs";
+import { codepointCompare } from "../lib/codepoint-compare.mjs";
 
 const slots = ["mobile", "backend", "data", "platform"];
 const canonicalHubRepository = "AquilaXk/easysubway";
@@ -13,8 +15,103 @@ const allowedRepositories = Object.fromEntries(slots.map((slot) => [slot, new Se
 const journeyFallbackSuccessCounters = [
   "hubSource", "legacy", "local", "routeV1", "routeV2", "stale", "previous", "alternateProvider", "bestEffort",
 ];
+const governanceInventoryPaths = [
+  "contracts/release/system-release-manifest.schema.json",
+  "contracts/release/system-release-governance-inventory.schema.json",
+  "release/product-gates/rc-evidence-manifest-contract.json",
+  "tools/release/generate-rc-evidence-manifest.mjs",
+  "tools/release/validate-system-release-manifest.mjs",
+];
 
-export function validateSystemReleaseManifest({ manifest, componentSchema, systemSchema, issueRefSchema }) {
+export function calculateProductIdentity(manifest) {
+  return sha256Canonical({
+    identityVersion: 1,
+    contracts: manifest?.contracts ?? null,
+    journeyV3: manifest?.journeyV3 ?? null,
+    components: slots.map((slot) => componentIdentity(manifest?.[slot])),
+  });
+}
+
+export function calculateGovernanceRevision(governanceInventory) {
+  return sha256Canonical({
+    identityVersion: 1,
+    schemaVersion: governanceInventory?.schemaVersion,
+    artifactKind: governanceInventory?.artifactKind,
+    files: [...(governanceInventory?.files ?? [])]
+      .sort((left, right) => codepointCompare(left?.path ?? "", right?.path ?? "")),
+  });
+}
+
+export function classifySystemReleaseChange({
+  previousManifest,
+  currentManifest,
+  componentSchema,
+  systemSchema,
+  issueRefSchema,
+  previousGovernanceInventory,
+  currentGovernanceInventory,
+  governanceInventorySchema,
+  repoRoot,
+}) {
+  const sharedValidation = {
+    componentSchema,
+    systemSchema,
+    issueRefSchema,
+    governanceInventorySchema,
+    repoRoot,
+  };
+  if (validateSystemReleaseManifest({
+    manifest: previousManifest,
+    governanceInventory: previousGovernanceInventory,
+    ...sharedValidation,
+  }).length > 0) {
+    throw new Error("previous system release manifest is invalid");
+  }
+  if (validateSystemReleaseManifest({
+    manifest: currentManifest,
+    governanceInventory: currentGovernanceInventory,
+    ...sharedValidation,
+  }).length > 0) {
+    throw new Error("current system release manifest is invalid");
+  }
+  if (calculateProductIdentity(previousManifest) !== calculateProductIdentity(currentManifest)) return "PRODUCT_CHANGE";
+  if (previousManifest?.governanceRevisionSha256 !== currentManifest?.governanceRevisionSha256) return "GOVERNANCE_CHANGE";
+  if (
+    previousManifest?.hubObservedRevision?.repository !== currentManifest?.hubObservedRevision?.repository
+    || previousManifest?.hubObservedRevision?.gitSha !== currentManifest?.hubObservedRevision?.gitSha
+  ) return "OBSERVATION_ONLY_CHANGE";
+  throw new Error("system release change has no classified identity difference");
+}
+
+export function validateGovernanceInventory({ governanceInventory, governanceInventorySchema, repoRoot }) {
+  const errors = governanceInventorySchema
+    ? validateSchema(governanceInventorySchema, governanceInventory).errors.map((error) => `governance inventory${error.slice(1)}`)
+    : [];
+  const files = governanceInventory?.files;
+  if (!Array.isArray(files)) return [...errors, "governance inventory: files must be an array"];
+  const paths = files.map((entry) => entry?.path);
+  if (new Set(paths).size !== paths.length) errors.push("governance inventory: duplicate path");
+  if (paths.join("\n") !== governanceInventoryPaths.join("\n")) {
+    errors.push("governance inventory: files must exactly match the closed release governance scope");
+  }
+  if (repoRoot) {
+    for (const entry of files) {
+      const filePath = path.join(repoRoot, entry?.path ?? "");
+      if (!entry?.path || !existsSync(filePath)) {
+        errors.push("governance inventory: tracked file is missing");
+      } else if (!lstatSync(filePath).isFile()) {
+        errors.push(`governance inventory: tracked path must be a regular file: ${entry.path}`);
+      } else if (sha256File(filePath) !== entry.sha256) {
+        errors.push(`governance inventory: SHA-256 mismatch for ${entry.path}`);
+      }
+    }
+  }
+  return [...new Set(errors)];
+}
+
+export function validateSystemReleaseManifest({
+  manifest, componentSchema, systemSchema, issueRefSchema, governanceInventory, governanceInventorySchema, repoRoot,
+}) {
   const errors = [...validateSchema(systemSchema, manifest).errors];
   if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) return redact(errors);
 
@@ -35,7 +132,12 @@ export function validateSystemReleaseManifest({ manifest, componentSchema, syste
       errors.push(...validateSchema(issueRefSchema, issueRef).errors.map(() => "system: invalid issue ref"));
     }
   }
-  if (manifest.hub?.repository !== canonicalHubRepository) errors.push("hub: repository must be canonical");
+  errors.push(...validateGovernanceInventory({ governanceInventory, governanceInventorySchema, repoRoot }));
+  if (manifest.hubObservedRevision?.repository !== canonicalHubRepository) errors.push("hub observed revision: repository must be canonical");
+  if (manifest.productIdentitySha256 !== calculateProductIdentity(manifest)) errors.push("system: product identity SHA-256 mismatch");
+  if (manifest.governanceRevisionSha256 !== calculateGovernanceRevision(governanceInventory)) {
+    errors.push("system: governance revision SHA-256 mismatch");
+  }
   if (!isSemVer(manifest.contracts?.version)) errors.push("system: contracts version must be SemVer");
 
   const components = slots.map((slot) => manifest[slot]).filter(Boolean);
@@ -73,11 +175,50 @@ export function validateSystemReleaseManifest({ manifest, componentSchema, syste
   return redact(errors);
 }
 
-export function selectSystemReleaseDecision({ legacyDecision, manifest, componentSchema, systemSchema, issueRefSchema }) {
+export function selectSystemReleaseDecision({
+  legacyDecision,
+  manifest,
+  componentSchema,
+  systemSchema,
+  issueRefSchema,
+  governanceInventory,
+  governanceInventorySchema,
+}) {
   const semanticErrors = validateSystemReleaseManifest({
     manifest: { ...manifest, decision: "GO" }, componentSchema, systemSchema, issueRefSchema,
+    governanceInventory,
+    governanceInventorySchema,
   });
   return legacyDecision === "GO" && semanticErrors.length === 0 ? "GO" : "NO_GO";
+}
+
+function componentIdentity(component) {
+  if (!component || typeof component !== "object" || Array.isArray(component)) return null;
+  return {
+    schemaVersion: component.schemaVersion,
+    component: component.component,
+    repository: component.repository,
+    gitSha: component.gitSha,
+    artifactIdentity: component.artifactIdentity,
+    contractVersion: component.contractVersion,
+    evidenceSha256: component.evidenceSha256,
+  };
+}
+
+function sha256Canonical(value) {
+  return createHash("sha256").update(canonicalJson(value)).digest("hex");
+}
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value).sort(codepointCompare).map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function sha256File(filePath) {
+  return createHash("sha256").update(readFileSync(filePath)).digest("hex");
 }
 
 function redact(errors) {
@@ -101,6 +242,9 @@ function main() {
       componentSchema: schema("component-manifest.schema.json"),
       systemSchema: schema("system-release-manifest.schema.json"),
       issueRefSchema: schema("issue-ref.schema.json"),
+      governanceInventorySchema: schema("system-release-governance-inventory.schema.json"),
+      governanceInventory: schema("system-release-governance-inventory.json"),
+      repoRoot: path.join(here, "../.."),
     });
     if (errors.length > 0) return fail(errors.join("\n"));
     if (options.requireDecision && manifest.decision !== options.requireDecision) {

--- a/tools/release/validate-system-release-manifest.mjs
+++ b/tools/release/validate-system-release-manifest.mjs
@@ -15,13 +15,88 @@ const allowedRepositories = Object.fromEntries(slots.map((slot) => [slot, new Se
 const journeyFallbackSuccessCounters = [
   "hubSource", "legacy", "local", "routeV1", "routeV2", "stale", "previous", "alternateProvider", "bestEffort",
 ];
-const governanceInventoryPaths = [
+export const governanceInventoryPaths = Object.freeze([
+  ".github/workflows/datapack-release.yml",
+  ".github/workflows/release-artifacts.yml",
+  "apps/mobile/lib/app/accessibility_theme.dart",
+  "apps/mobile/lib/app/app_components.dart",
+  "apps/mobile/lib/app/easy_subway_app.dart",
+  "apps/mobile/lib/features/account/presentation/user_data_deletion_screen.dart",
+  "apps/mobile/lib/features/attribution/presentation/data_source_attribution_screen.dart",
+  "apps/mobile/lib/features/favorites/presentation/favorite_home_screen.dart",
+  "apps/mobile/lib/features/home/presentation/home_screen.dart",
+  "apps/mobile/lib/features/settings/presentation/app_settings_screen.dart",
+  "apps/mobile/lib/features/settings/presentation/open_source_licenses_screen.dart",
+  "apps/mobile/lib/features/settings/presentation/service_info_screen.dart",
+  "apps/mobile/lib/features/support/presentation/inquiry_screen.dart",
+  "apps/mobile/lib/features/support/presentation/support_access_screen.dart",
+  "apps/mobile/lib/main.dart",
+  "apps/mobile/pubspec.yaml",
+  "apps/mobile/release/signed-release-artifact-gate.json",
+  "backend/Dockerfile",
+  "backend/build.gradle",
+  "contracts/release/component-manifest.schema.json",
+  "contracts/release/issue-ref.schema.json",
   "contracts/release/system-release-manifest.schema.json",
   "contracts/release/system-release-governance-inventory.schema.json",
+  "infra/alloy/config.alloy",
+  "infra/docker-compose.yml",
+  "infra/grafana/provisioning/dashboards/dashboards.yml",
+  "infra/grafana/provisioning/dashboards/json/error-ops.json",
+  "infra/grafana/provisioning/datasources/loki.yml",
+  "infra/grafana/provisioning/datasources/prometheus.yml",
+  "infra/loki/loki.yml",
+  "infra/prometheus/alerts.yml",
+  "infra/prometheus/prometheus.yml",
+  "release/product-gates/abuse-penetration-rehearsal-gate.json",
+  "release/product-gates/operations-observability-gate.json",
+  "release/product-gates/operations-release-evidence.json",
+  "release/product-gates/post-launch-operations-review-gate.json",
   "release/product-gates/rc-evidence-manifest-contract.json",
+  "release/product-gates/production-datapack-scope.json",
+  "release/product-gates/route-commercialization-gate.json",
+  "release/product-gates/support-incident-response-gate.json",
+  "tools/ci/validate-store-privacy-env.mjs",
+  "tools/ci/lib/json-schema-lite.mjs",
+  "tools/datapack/build-launch-denominator-report.mjs",
+  "tools/datapack/decide-datapack-release.mjs",
+  "tools/datapack/lib/manifest-validation.mjs",
+  "tools/datapack/production-url-policy.mjs",
+  "tools/datapack/run-emergency-datapack-drill.mjs",
+  "tools/datapack/validate-remote-datapack-artifact.mjs",
+  "tools/datapack/verify-release-request-binding.mjs",
+  "tools/lib/codepoint-compare.mjs",
+  "tools/ops/generate-operations-phase-a-summary.mjs",
+  "tools/ops/validate-operations-release-summary.mjs",
+  "tools/realtime/seoul-topis-provider-contract.json",
+  "tools/release/count-gzip-uncompressed-bytes.mjs",
   "tools/release/generate-rc-evidence-manifest.mjs",
+  "tools/release/hash-android-bundle-payload.mjs",
+  "tools/release/lib/semver.mjs",
+  "tools/release/select-rc-datapack-artifact.mjs",
+  "tools/release/summary-validation-utils.mjs",
+  "tools/release/upload-play-internal.mjs",
   "tools/release/validate-system-release-manifest.mjs",
-];
+  "tools/security/abuse-penetration-summary-schema.mjs",
+  "tools/security/validate-abuse-penetration-summary.mjs",
+].sort(codepointCompare));
+const governanceInventoryPathSet = new Set(governanceInventoryPaths);
+export const governedExecutionPaths = Object.freeze([
+  "tools/ci/lib/json-schema-lite.mjs",
+  "tools/datapack/build-launch-denominator-report.mjs",
+  "tools/datapack/lib/manifest-validation.mjs",
+  "tools/datapack/production-url-policy.mjs",
+  "tools/lib/codepoint-compare.mjs",
+  "tools/ops/validate-operations-release-summary.mjs",
+  "tools/release/count-gzip-uncompressed-bytes.mjs",
+  "tools/release/generate-rc-evidence-manifest.mjs",
+  "tools/release/hash-android-bundle-payload.mjs",
+  "tools/release/lib/semver.mjs",
+  "tools/release/summary-validation-utils.mjs",
+  "tools/release/validate-system-release-manifest.mjs",
+  "tools/security/abuse-penetration-summary-schema.mjs",
+  "tools/security/validate-abuse-penetration-summary.mjs",
+]);
 
 export function calculateProductIdentity(manifest) {
   return sha256Canonical({
@@ -45,33 +120,13 @@ export function calculateGovernanceRevision(governanceInventory) {
 export function classifySystemReleaseChange({
   previousManifest,
   currentManifest,
-  componentSchema,
-  systemSchema,
-  issueRefSchema,
-  previousGovernanceInventory,
-  currentGovernanceInventory,
-  governanceInventorySchema,
-  repoRoot,
+  previousValidationContext,
+  currentValidationContext,
 }) {
-  const sharedValidation = {
-    componentSchema,
-    systemSchema,
-    issueRefSchema,
-    governanceInventorySchema,
-    repoRoot,
-  };
-  if (validateSystemReleaseManifest({
-    manifest: previousManifest,
-    governanceInventory: previousGovernanceInventory,
-    ...sharedValidation,
-  }).length > 0) {
+  if (validateClassificationManifest(previousManifest, previousValidationContext).length > 0) {
     throw new Error("previous system release manifest is invalid");
   }
-  if (validateSystemReleaseManifest({
-    manifest: currentManifest,
-    governanceInventory: currentGovernanceInventory,
-    ...sharedValidation,
-  }).length > 0) {
+  if (validateClassificationManifest(currentManifest, currentValidationContext).length > 0) {
     throw new Error("current system release manifest is invalid");
   }
   if (calculateProductIdentity(previousManifest) !== calculateProductIdentity(currentManifest)) return "PRODUCT_CHANGE";
@@ -83,21 +138,36 @@ export function classifySystemReleaseChange({
   throw new Error("system release change has no classified identity difference");
 }
 
-export function validateGovernanceInventory({ governanceInventory, governanceInventorySchema, repoRoot }) {
+export function validateGovernanceInventory({
+  governanceInventory, governanceInventorySchema, repoRoot, trustedExecutionPaths,
+}) {
   const errors = governanceInventorySchema
     ? validateSchema(governanceInventorySchema, governanceInventory).errors.map((error) => `governance inventory${error.slice(1)}`)
     : [];
   const files = governanceInventory?.files;
   if (!Array.isArray(files)) return [...errors, "governance inventory: files must be an array"];
-  const paths = files.map((entry) => entry?.path);
+  const validEntries = [];
+  for (const entry of files) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      errors.push("governance inventory: entry must be an object");
+      continue;
+    }
+    if (typeof entry.path !== "string" || entry.path.length === 0) {
+      errors.push("governance inventory: path must be a non-empty string");
+      continue;
+    }
+    validEntries.push(entry);
+  }
+  const paths = validEntries.map((entry) => entry.path);
   if (new Set(paths).size !== paths.length) errors.push("governance inventory: duplicate path");
   if (paths.join("\n") !== governanceInventoryPaths.join("\n")) {
     errors.push("governance inventory: files must exactly match the closed release governance scope");
   }
   if (repoRoot) {
-    for (const entry of files) {
-      const filePath = path.join(repoRoot, entry?.path ?? "");
-      if (!entry?.path || !existsSync(filePath)) {
+    for (const entry of validEntries) {
+      if (!governanceInventoryPathSet.has(entry.path)) continue;
+      const filePath = path.join(repoRoot, entry.path);
+      if (!existsSync(filePath)) {
         errors.push("governance inventory: tracked file is missing");
       } else if (!lstatSync(filePath).isFile()) {
         errors.push(`governance inventory: tracked path must be a regular file: ${entry.path}`);
@@ -106,11 +176,34 @@ export function validateGovernanceInventory({ governanceInventory, governanceInv
       }
     }
   }
+  if (trustedExecutionPaths) {
+    for (const entryPath of governedExecutionPaths) {
+      const trustedPath = trustedExecutionPaths[entryPath];
+      if (typeof trustedPath !== "string" || trustedPath.length === 0 || !existsSync(trustedPath)) {
+        errors.push(`governance inventory: trusted execution path is unavailable: ${entryPath}`);
+        continue;
+      }
+      if (!lstatSync(trustedPath).isFile()) {
+        errors.push(`governance inventory: trusted execution path must be a regular file: ${entryPath}`);
+        continue;
+      }
+      const entry = validEntries.find((candidate) => candidate.path === entryPath);
+      if (!entry || sha256File(trustedPath) !== entry.sha256) {
+        errors.push(`governance inventory: loaded execution SHA-256 mismatch for ${entryPath}`);
+      }
+      if (repoRoot && entry && governanceInventoryPathSet.has(entryPath)) {
+        const attestedPath = path.join(repoRoot, entryPath);
+        if (existsSync(attestedPath) && lstatSync(attestedPath).isFile() && sha256File(attestedPath) !== sha256File(trustedPath)) {
+          errors.push(`governance inventory: attested repoRoot bytes do not match loaded execution path: ${entryPath}`);
+        }
+      }
+    }
+  }
   return [...new Set(errors)];
 }
 
 export function validateSystemReleaseManifest({
-  manifest, componentSchema, systemSchema, issueRefSchema, governanceInventory, governanceInventorySchema, repoRoot,
+  manifest, componentSchema, systemSchema, issueRefSchema, governanceInventory, governanceInventorySchema, repoRoot, trustedExecutionPaths,
 }) {
   const errors = [...validateSchema(systemSchema, manifest).errors];
   if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) return redact(errors);
@@ -132,7 +225,7 @@ export function validateSystemReleaseManifest({
       errors.push(...validateSchema(issueRefSchema, issueRef).errors.map(() => "system: invalid issue ref"));
     }
   }
-  errors.push(...validateGovernanceInventory({ governanceInventory, governanceInventorySchema, repoRoot }));
+  errors.push(...validateGovernanceInventory({ governanceInventory, governanceInventorySchema, repoRoot, trustedExecutionPaths }));
   if (manifest.hubObservedRevision?.repository !== canonicalHubRepository) errors.push("hub observed revision: repository must be canonical");
   if (manifest.productIdentitySha256 !== calculateProductIdentity(manifest)) errors.push("system: product identity SHA-256 mismatch");
   if (manifest.governanceRevisionSha256 !== calculateGovernanceRevision(governanceInventory)) {
@@ -175,6 +268,13 @@ export function validateSystemReleaseManifest({
   return redact(errors);
 }
 
+function validateClassificationManifest(manifest, validationContext) {
+  if (!validationContext || typeof validationContext !== "object" || Array.isArray(validationContext)) {
+    return ["system release validation context is invalid"];
+  }
+  return validateSystemReleaseManifest({ manifest, ...validationContext });
+}
+
 export function selectSystemReleaseDecision({
   legacyDecision,
   manifest,
@@ -183,11 +283,13 @@ export function selectSystemReleaseDecision({
   issueRefSchema,
   governanceInventory,
   governanceInventorySchema,
+  trustedExecutionPaths,
 }) {
   const semanticErrors = validateSystemReleaseManifest({
     manifest: { ...manifest, decision: "GO" }, componentSchema, systemSchema, issueRefSchema,
     governanceInventory,
     governanceInventorySchema,
+    trustedExecutionPaths,
   });
   return legacyDecision === "GO" && semanticErrors.length === 0 ? "GO" : "NO_GO";
 }

--- a/tools/release/validate-system-release-manifest.test.mjs
+++ b/tools/release/validate-system-release-manifest.test.mjs
@@ -1,10 +1,17 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { selectSystemReleaseDecision, validateSystemReleaseManifest } from "./validate-system-release-manifest.mjs";
+import {
+  calculateGovernanceRevision,
+  calculateProductIdentity,
+  classifySystemReleaseChange,
+  selectSystemReleaseDecision,
+  validateGovernanceInventory,
+  validateSystemReleaseManifest,
+} from "./validate-system-release-manifest.mjs";
 
 const sha = "a".repeat(64);
 const gitSha = "b".repeat(40);
@@ -21,15 +28,20 @@ const zeroFallbackSuccessCounters = () => ({
   bestEffort: 0,
 });
 
+const governanceInventory = JSON.parse(readFileSync(
+  "contracts/release/system-release-governance-inventory.json",
+  "utf8",
+));
+
 function validManifest() {
-  return {
-    schemaVersion: 3,
+  const manifest = {
+    schemaVersion: 4,
     productReleaseId: "easysubway-2026.07.30.1",
     phase: "FINAL",
     decision: "GO",
     generatedAt: "2026-07-30T00:00:00Z",
     issueRefs: [issue("easysubway", 2693)],
-    hub: { repository: "AquilaXk/easysubway", gitSha },
+    hubObservedRevision: { repository: "AquilaXk/easysubway", gitSha },
     contracts: { version: "1.2.3", sha256: sha },
     journeyV3: {
       executionMode: "SERVER_ONLY",
@@ -62,19 +74,37 @@ function validManifest() {
       contractVersion: "platform-v1", evidenceSha256: sha, issueRefs: [issue("easysubway-platform", 2693)],
     },
   };
+  manifest.productIdentitySha256 = calculateProductIdentity(manifest);
+  manifest.governanceRevisionSha256 = calculateGovernanceRevision(governanceInventory);
+  return manifest;
 }
 
 const schemas = {
   componentSchema: JSON.parse(readFileSync("contracts/release/component-manifest.schema.json", "utf8")),
   systemSchema: JSON.parse(readFileSync("contracts/release/system-release-manifest.schema.json", "utf8")),
   issueRefSchema: JSON.parse(readFileSync("contracts/release/issue-ref.schema.json", "utf8")),
+  governanceInventorySchema: JSON.parse(readFileSync(
+    "contracts/release/system-release-governance-inventory.schema.json",
+    "utf8",
+  )),
+  governanceInventory,
 };
 
-test("system release manifest v3 validates the locked five-repository release identity", () => {
+const classifierInputs = {
+  componentSchema: schemas.componentSchema,
+  systemSchema: schemas.systemSchema,
+  issueRefSchema: schemas.issueRefSchema,
+  governanceInventorySchema: schemas.governanceInventorySchema,
+  previousGovernanceInventory: governanceInventory,
+  currentGovernanceInventory: governanceInventory,
+  repoRoot: process.cwd(),
+};
+
+test("system release manifest v4 validates the separated product, governance and observation identities", () => {
   assert.deepEqual(validateSystemReleaseManifest({ manifest: validManifest(), ...schemas }), []);
 });
 
-test("system release manifest v3 rejects invalid contracts SemVer", () => {
+test("system release manifest v4 rejects invalid contracts SemVer", () => {
   const manifest = validManifest();
   manifest.contracts.version = `1.2.3-${"a.".repeat(150)}a`;
   assert.ok(validateSystemReleaseManifest({ manifest, ...schemas }).includes("system: contracts version must be SemVer"));
@@ -103,6 +133,7 @@ test("system release GO requires typed Journey V3 server-only evidence while NO_
   assert.equal(selectSystemReleaseDecision({ legacyDecision: "GO", manifest: missing, ...schemas }), "NO_GO");
 
   missing.decision = "NO_GO";
+  missing.productIdentitySha256 = calculateProductIdentity(missing);
   assert.deepEqual(validateSystemReleaseManifest({ manifest: missing, ...schemas }), []);
 });
 
@@ -124,16 +155,21 @@ test("system release GO rejects Journey V3 policy, owner, identity and fallback 
   }
 });
 
-test("system release manifest v3 rejects every locked identity violation", () => {
+test("system release manifest v4 rejects every locked identity violation", () => {
   const cases = [
     ["legacy v2", (manifest) => { manifest.schemaVersion = 2; }],
-    ["missing Hub identity", (manifest) => { delete manifest.hub; }],
-    ["missing Hub SHA", (manifest) => { delete manifest.hub.gitSha; }],
-    ["wrong Hub repository", (manifest) => { manifest.hub.repository = "AquilaXk/easysubway-backend"; }],
-    ["uppercase Hub SHA", (manifest) => { manifest.hub.gitSha = gitSha.toUpperCase(); }],
-    ["short Hub SHA", (manifest) => { manifest.hub.gitSha = "b".repeat(39); }],
-    ["extra Hub identity field", (manifest) => { manifest.hub.ref = "main"; }],
+    ["legacy v3", (manifest) => { manifest.schemaVersion = 3; }],
+    ["missing observed identity", (manifest) => { delete manifest.hubObservedRevision; }],
+    ["missing observed SHA", (manifest) => { delete manifest.hubObservedRevision.gitSha; }],
+    ["wrong observed repository", (manifest) => { manifest.hubObservedRevision.repository = "AquilaXk/easysubway-backend"; }],
+    ["uppercase observed SHA", (manifest) => { manifest.hubObservedRevision.gitSha = gitSha.toUpperCase(); }],
+    ["short observed SHA", (manifest) => { manifest.hubObservedRevision.gitSha = "b".repeat(39); }],
+    ["extra observed identity field", (manifest) => { manifest.hubObservedRevision.ref = "main"; }],
     ["top-level gitSha", (manifest) => { manifest.gitSha = gitSha; }],
+    ["missing product identity", (manifest) => { delete manifest.productIdentitySha256; }],
+    ["stale product identity", (manifest) => { manifest.productIdentitySha256 = "c".repeat(64); }],
+    ["missing governance revision", (manifest) => { delete manifest.governanceRevisionSha256; }],
+    ["stale governance revision", (manifest) => { manifest.governanceRevisionSha256 = "c".repeat(64); }],
     ["bare issue number", (manifest) => { manifest.issueRefs = [2693]; }],
     ["uppercase hash", (manifest) => { manifest.contracts.sha256 = sha.toUpperCase(); }],
     ["malformed hash", (manifest) => { manifest.contracts.sha256 = "invalid"; }],
@@ -153,14 +189,102 @@ test("system release manifest v3 rejects every locked identity violation", () =>
   }
 });
 
-test("system release manifest v3 rejects unsafe identity integers", () => {
+test("system release manifest v4 rejects unsafe identity integers", () => {
   for (const [mutate, expected] of [
     [(manifest) => { manifest.mobile.artifactIdentity.versionCode = Number.MAX_SAFE_INTEGER + 1; }, "mobile: versionCode must be a safe integer"],
     [(manifest) => { manifest.data.artifactIdentity.releaseSequence = Number.MAX_SAFE_INTEGER + 1; }, "data: releaseSequence must be a safe integer"],
   ]) {
     const manifest = validManifest();
     mutate(manifest);
+    manifest.productIdentitySha256 = calculateProductIdentity(manifest);
     assert.deepEqual(validateSystemReleaseManifest({ manifest, ...schemas }), [expected]);
+  }
+});
+
+test("system release v4 change classification separates product, governance and observation changes", () => {
+  const previous = validManifest();
+
+  const issueOnly = structuredClone(previous);
+  issueOnly.issueRefs = [issue("easysubway", 2840)];
+  assert.throws(
+    () => classifySystemReleaseChange({ previousManifest: previous, currentManifest: issueOnly, ...classifierInputs }),
+    /no classified identity difference/,
+  );
+
+  const product = structuredClone(previous);
+  product.mobile.artifactIdentity.aabSha256 = "c".repeat(64);
+  product.productIdentitySha256 = calculateProductIdentity(product);
+  assert.equal(classifySystemReleaseChange({ previousManifest: previous, currentManifest: product, ...classifierInputs }), "PRODUCT_CHANGE");
+
+  const governance = structuredClone(previous);
+  const changedInventory = structuredClone(governanceInventory);
+  changedInventory.files[0].sha256 = "c".repeat(64);
+  governance.governanceRevisionSha256 = calculateGovernanceRevision(changedInventory);
+  const { repoRoot: ignoredRepoRoot, ...governanceClassifierInputs } = classifierInputs;
+  assert.equal(classifySystemReleaseChange({
+    previousManifest: previous,
+    currentManifest: governance,
+    ...governanceClassifierInputs,
+    currentGovernanceInventory: changedInventory,
+  }), "GOVERNANCE_CHANGE");
+
+  const observation = structuredClone(previous);
+  observation.hubObservedRevision.gitSha = "c".repeat(40);
+  assert.equal(classifySystemReleaseChange({ previousManifest: previous, currentManifest: observation, ...classifierInputs }), "OBSERVATION_ONLY_CHANGE");
+
+  for (const mutate of [
+    (manifest) => { manifest.schemaVersion = 3; },
+    (manifest) => { manifest.productIdentitySha256 = "c".repeat(64); },
+  ]) {
+    const malformed = structuredClone(previous);
+    mutate(malformed);
+    assert.throws(
+      () => classifySystemReleaseChange({ previousManifest: previous, currentManifest: malformed, ...classifierInputs }),
+      /current system release manifest is invalid/,
+    );
+  }
+});
+
+test("system release v4 rejects open, duplicated, or mismatched governance inventory", () => {
+  for (const mutate of [
+    (inventory) => { inventory.files.pop(); },
+    (inventory) => { inventory.files[4].path = inventory.files[3].path; },
+  ]) {
+    const inventory = structuredClone(governanceInventory);
+    mutate(inventory);
+    const manifest = validManifest();
+    manifest.governanceRevisionSha256 = calculateGovernanceRevision(inventory);
+    const errors = validateSystemReleaseManifest({
+      manifest,
+      ...schemas,
+      governanceInventory: inventory,
+    });
+    assert.ok(errors.some((error) => error.startsWith("governance inventory:")));
+  }
+
+  const mismatched = structuredClone(governanceInventory);
+  mismatched.files[0].sha256 = "c".repeat(64);
+  assert.ok(validateGovernanceInventory({
+    governanceInventory: mismatched,
+    repoRoot: process.cwd(),
+  }).some((error) => error.includes("SHA-256 mismatch")));
+});
+
+test("system release v4 rejects a governance inventory symlink before hashing", () => {
+  const directory = mkdtempSync(path.join(tmpdir(), "release-governance-inventory-"));
+  const entry = governanceInventory.files[0];
+  const inventoryPath = path.join(directory, entry.path);
+  try {
+    mkdirSync(path.dirname(inventoryPath), { recursive: true });
+    writeFileSync(path.join(directory, "target"), "not a release schema");
+    symlinkSync(path.join(directory, "target"), inventoryPath);
+    assert.ok(validateGovernanceInventory({
+      governanceInventory,
+      governanceInventorySchema: schemas.governanceInventorySchema,
+      repoRoot: directory,
+    }).includes(`governance inventory: tracked path must be a regular file: ${entry.path}`));
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
   }
 });
 

--- a/tools/release/validate-system-release-manifest.test.mjs
+++ b/tools/release/validate-system-release-manifest.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { createHash } from "node:crypto";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
@@ -8,6 +9,7 @@ import {
   calculateGovernanceRevision,
   calculateProductIdentity,
   classifySystemReleaseChange,
+  governanceInventoryPaths,
   selectSystemReleaseDecision,
   validateGovernanceInventory,
   validateSystemReleaseManifest,
@@ -32,6 +34,32 @@ const governanceInventory = JSON.parse(readFileSync(
   "contracts/release/system-release-governance-inventory.json",
   "utf8",
 ));
+
+function sha256File(filePath) {
+  return createHash("sha256").update(readFileSync(filePath)).digest("hex");
+}
+
+function inventoryFor(repoRoot) {
+  return {
+    schemaVersion: 1,
+    artifactKind: "system-release-governance-inventory",
+    files: governanceInventoryPaths.map((entryPath) => ({
+      path: entryPath,
+      sha256: sha256File(path.join(repoRoot, entryPath)),
+    })),
+  };
+}
+
+function writeGovernanceFixture(directory, suffix) {
+  for (const entryPath of governanceInventoryPaths) {
+    const target = path.join(directory, entryPath);
+    mkdirSync(path.dirname(target), { recursive: true });
+    writeFileSync(target, readFileSync(entryPath));
+  }
+  const changedPath = path.join(directory, "tools/release/generate-rc-evidence-manifest.mjs");
+  writeFileSync(changedPath, `${readFileSync(changedPath, "utf8")}\n// ${suffix}\n`);
+  return inventoryFor(directory);
+}
 
 function validManifest() {
   const manifest = {
@@ -91,13 +119,22 @@ const schemas = {
 };
 
 const classifierInputs = {
-  componentSchema: schemas.componentSchema,
-  systemSchema: schemas.systemSchema,
-  issueRefSchema: schemas.issueRefSchema,
-  governanceInventorySchema: schemas.governanceInventorySchema,
-  previousGovernanceInventory: governanceInventory,
-  currentGovernanceInventory: governanceInventory,
-  repoRoot: process.cwd(),
+  previousValidationContext: {
+    componentSchema: schemas.componentSchema,
+    systemSchema: schemas.systemSchema,
+    issueRefSchema: schemas.issueRefSchema,
+    governanceInventorySchema: schemas.governanceInventorySchema,
+    governanceInventory,
+    repoRoot: process.cwd(),
+  },
+  currentValidationContext: {
+    componentSchema: schemas.componentSchema,
+    systemSchema: schemas.systemSchema,
+    issueRefSchema: schemas.issueRefSchema,
+    governanceInventorySchema: schemas.governanceInventorySchema,
+    governanceInventory,
+    repoRoot: process.cwd(),
+  },
 };
 
 test("system release manifest v4 validates the separated product, governance and observation identities", () => {
@@ -220,12 +257,13 @@ test("system release v4 change classification separates product, governance and 
   const changedInventory = structuredClone(governanceInventory);
   changedInventory.files[0].sha256 = "c".repeat(64);
   governance.governanceRevisionSha256 = calculateGovernanceRevision(changedInventory);
-  const { repoRoot: ignoredRepoRoot, ...governanceClassifierInputs } = classifierInputs;
+  const governanceClassifierInputs = structuredClone(classifierInputs);
+  governanceClassifierInputs.currentValidationContext.governanceInventory = changedInventory;
+  delete governanceClassifierInputs.currentValidationContext.repoRoot;
   assert.equal(classifySystemReleaseChange({
     previousManifest: previous,
     currentManifest: governance,
     ...governanceClassifierInputs,
-    currentGovernanceInventory: changedInventory,
   }), "GOVERNANCE_CHANGE");
 
   const observation = structuredClone(previous);
@@ -242,6 +280,44 @@ test("system release v4 change classification separates product, governance and 
       () => classifySystemReleaseChange({ previousManifest: previous, currentManifest: malformed, ...classifierInputs }),
       /current system release manifest is invalid/,
     );
+  }
+});
+
+test("system release v4 classifies distinct previous/current governance contexts and rejects a tampered previous context", () => {
+  const previousRoot = mkdtempSync(path.join(tmpdir(), "previous-system-release-governance-"));
+  const currentRoot = mkdtempSync(path.join(tmpdir(), "current-system-release-governance-"));
+  try {
+    const previousInventory = writeGovernanceFixture(previousRoot, "previous");
+    const currentInventory = writeGovernanceFixture(currentRoot, "current");
+    const previous = validManifest();
+    previous.governanceRevisionSha256 = calculateGovernanceRevision(previousInventory);
+    const current = structuredClone(previous);
+    current.governanceRevisionSha256 = calculateGovernanceRevision(currentInventory);
+    const validationContext = (repoRoot, inventory) => ({
+      componentSchema: schemas.componentSchema,
+      systemSchema: schemas.systemSchema,
+      issueRefSchema: schemas.issueRefSchema,
+      governanceInventorySchema: schemas.governanceInventorySchema,
+      governanceInventory: inventory,
+      repoRoot,
+    });
+    assert.equal(classifySystemReleaseChange({
+      previousManifest: previous,
+      currentManifest: current,
+      previousValidationContext: validationContext(previousRoot, previousInventory),
+      currentValidationContext: validationContext(currentRoot, currentInventory),
+    }), "GOVERNANCE_CHANGE");
+
+    previousInventory.files[0].sha256 = "f".repeat(64);
+    assert.throws(() => classifySystemReleaseChange({
+      previousManifest: previous,
+      currentManifest: current,
+      previousValidationContext: validationContext(previousRoot, previousInventory),
+      currentValidationContext: validationContext(currentRoot, currentInventory),
+    }), /previous system release manifest is invalid/);
+  } finally {
+    rmSync(previousRoot, { recursive: true, force: true });
+    rmSync(currentRoot, { recursive: true, force: true });
   }
 });
 
@@ -268,6 +344,23 @@ test("system release v4 rejects open, duplicated, or mismatched governance inven
     governanceInventory: mismatched,
     repoRoot: process.cwd(),
   }).some((error) => error.includes("SHA-256 mismatch")));
+});
+
+test("system release v4 rejects malformed governance inventory entries without throwing", () => {
+  for (const malformedEntry of [42, null, { path: 42, sha256: sha }, { path: null, sha256: sha }, { path: {}, sha256: sha }]) {
+    const inventory = structuredClone(governanceInventory);
+    inventory.files[0] = malformedEntry;
+    assert.doesNotThrow(() => validateGovernanceInventory({
+      governanceInventory: inventory,
+      governanceInventorySchema: schemas.governanceInventorySchema,
+      repoRoot: process.cwd(),
+    }));
+    assert.ok(validateGovernanceInventory({
+      governanceInventory: inventory,
+      governanceInventorySchema: schemas.governanceInventorySchema,
+      repoRoot: process.cwd(),
+    }).some((error) => error === "governance inventory: entry must be an object" || error === "governance inventory: path must be a non-empty string"));
+  }
 });
 
 test("system release v4 rejects a governance inventory symlink before hashing", () => {


### PR DESCRIPTION
## 변경

- current system release manifest를 v3에서 v4로 전환
- product identity, closed governance revision, observed Hub revision을 분리
- target/governance/observation-only change를 유효한 v4 identity끼리만 분류
- v2/v3, stale declared identity, open/duplicate/mismatched/symlink governance inventory를 fail-closed 처리
- generator와 validator가 동일한 closed 5-file governance inventory를 사용

## 경계

- #2731 final fan-in/release decision은 변경하지 않음
- #2921/#2922 data/platform bundle과 target repository artifact/runtime/deploy는 변경하지 않음
- 이전 v3/v4 manifest 또는 heuristic fallback 없음
- 중복 governance 검증을 추가하지 않고 CLI의 단일 validator 경로를 유지

## 검증

- `node --test tools/release/validate-system-release-manifest.test.mjs` — 13/13 PASS
- `node --test --test-name-pattern='system-release-generator' tools/ci/repository-contract.test.mjs` — 1/1 PASS
- `git diff --check` — PASS
- 독립 local correctness review P2 2건 수정 완료

Closes #2840
Refs #2731
Refs #1020
Refs #2742
