### PR TITLE
[Feat] OCI candidate handoff fetcher를 추가한다

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -296,7 +296,6 @@ jobs:
           set -euo pipefail
           mkdir -p "${RUNNER_TEMP}/release-gate"
           node tools/ci/audit-mobile-datapack-assets.mjs --index apps/mobile/assets/datapacks/index.json --root apps/mobile > "${RUNNER_TEMP}/release-gate/mobile-datapack-asset-audit.json"
-          node tools/datapack/verify-production-pack-artifact-identity.mjs --build-spec tools/datapack/release/candidate-build-spec.json --asset apps/mobile/assets/datapacks/capital.sqlite.gz --index apps/mobile/assets/datapacks/index.json --pack-id capital > "${RUNNER_TEMP}/release-gate/production-pack-artifact-identity.json"
           echo "EASYSUBWAY_MOBILE_DATAPACK_ASSET_AUDIT=${RUNNER_TEMP}/release-gate/mobile-datapack-asset-audit.json" >> "${GITHUB_ENV}"
 
       - name: Android Release Artifact / Restore Crashlytics google-services.json

--- a/contracts/release/datapack-candidate-oci-handoff.schema.json
+++ b/contracts/release/datapack-candidate-oci-handoff.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "easysubway/contracts/release/datapack-candidate-oci-handoff",
+  "title": "Data candidate OCI handoff input",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["storage", "identity"],
+  "properties": {
+    "storage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["namespace", "bucket"],
+      "properties": {
+        "namespace": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]{0,62}$" },
+        "bucket": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]{0,62}$" }
+      }
+    },
+    "identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository", "workflowRunId", "headSha", "candidateId", "artifactName", "artifactId"],
+      "properties": {
+        "repository": { "const": "AquilaXk/easysubway-data" },
+        "workflowRunId": { "type": "string", "pattern": "^[1-9][0-9]*$" },
+        "headSha": { "type": "string", "pattern": "^[a-f0-9]{40}$" },
+        "candidateId": { "type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$" },
+        "artifactName": { "type": "string", "pattern": "^easysubway-datapack-candidate-[1-9][0-9]*$" },
+        "artifactId": { "type": "string", "pattern": "^[a-f0-9]{64}$" }
+      }
+    }
+  }
+}

--- a/contracts/release/system-release-governance-inventory.json
+++ b/contracts/release/system-release-governance-inventory.json
@@ -8,7 +8,7 @@
     },
     {
       "path": ".github/workflows/release-artifacts.yml",
-      "sha256": "89ee86d9bccc896ba4da7de532dde17149f33af4863a25cad069349a35cf0c94"
+      "sha256": "bb65bee05d42724cd5dc69b9b89272028cc37e3ef20761eb6e9c994b54ec20f0"
     },
     {
       "path": "apps/mobile/lib/app/accessibility_theme.dart",

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -3615,6 +3615,15 @@ test("릴리즈 산출물 워크플로우는 모바일 스토어 산출물과 ba
 
   assert.match(workflow, /android-release:/);
   assert.match(workflow, /name: Android Release Artifact/);
+  const androidReleaseJob = workflow.slice(
+    workflow.indexOf("  android-release:"),
+    workflow.indexOf("  android-production-rc-release:"),
+  );
+  assert.doesNotMatch(
+    androidReleaseJob,
+    /verify-production-pack-artifact-identity\.mjs/,
+    "generic Android artifact must not rebuild a Data-owned release candidate",
+  );
   assert.match(
     workflow,
     /android-release:[\s\S]*outputs:[\s\S]*artifact_available: \$\{\{ steps\.release-env\.outputs\.artifact_available \}\}/,

--- a/tools/release/fetch-datapack-candidate-oci-handoff.mjs
+++ b/tools/release/fetch-datapack-candidate-oci-handoff.mjs
@@ -1,0 +1,108 @@
+import { createHash } from "node:crypto";
+
+const sha = (value) => createHash("sha256").update(value).digest("hex");
+const noGo = (reasonCode) => ({ decision: "NO_GO", reasonCode, artifactReuseCount: 0, output: null });
+const compare = (left, right) => Buffer.compare(Buffer.from(left), Buffer.from(right));
+
+// fetchImpl is deliberately injected: Phase 1 has no runtime, workflow, or network wiring.
+export async function fetchDatapackCandidateOciHandoff({ storage, identity, fetchImpl, now }) {
+  try {
+    const input = validateInput(storage, identity, fetchImpl, now);
+    const descriptorKey = `${input.prefix}descriptors/${input.identity.artifactId}.json`;
+    const descriptorResponse = await fetchObject(fetchImpl, descriptorKey);
+    if (sha(descriptorResponse) !== input.identity.artifactId) return noGo("DESCRIPTOR_HASH_MISMATCH");
+    const descriptor = parse(descriptorResponse, "descriptor");
+    const checked = validateDescriptor(descriptor, input);
+    const bodies = new Map();
+    for (const item of checked.objects) {
+      const body = await fetchObject(fetchImpl, item.objectKey);
+      if (body.length !== item.sizeBytes || sha(body) !== item.sha256) return noGo("OBJECT_BYTES_MISMATCH");
+      bodies.set(item.path, body);
+    }
+    validateBindings(checked, bodies);
+    return {
+      decision: "GO",
+      reasonCode: "NONE",
+      artifactReuseCount: 0,
+      output: {
+        descriptorLocator: `oci://${input.storage.namespace}/${input.storage.bucket}/${descriptorKey}`,
+        descriptor: descriptorResponse,
+        objects: checked.objects.map(({ path, objectKey, ociUri, sizeBytes, sha256 }) => ({ path, objectKey, ociUri, sizeBytes, sha256, body: bodies.get(path) })),
+      },
+    };
+  } catch (error) {
+    return noGo(error.code ?? "DESCRIPTOR_REJECTED");
+  }
+}
+
+function validateInput(storage, identity, fetchImpl, now) {
+  exactKeys(storage, ["namespace", "bucket"], "storage");
+  exactKeys(identity, ["repository", "workflowRunId", "headSha", "candidateId", "artifactName", "artifactId"], "identity");
+  if (typeof fetchImpl !== "function") fail("INVALID_INPUT");
+  const checkedStorage = { namespace: segment(storage.namespace), bucket: segment(storage.bucket) };
+  const checkedIdentity = {
+    repository: exact(identity.repository, "AquilaXk/easysubway-data"),
+    workflowRunId: decimal(identity.workflowRunId), headSha: gitSha(identity.headSha), candidateId: token(identity.candidateId), artifactName: required(identity.artifactName), artifactId: hash(identity.artifactId),
+  };
+  if (checkedIdentity.artifactName !== `easysubway-datapack-candidate-${checkedIdentity.workflowRunId}`) fail("INVALID_INPUT");
+  const instant = utc(now);
+  return { storage: checkedStorage, identity: checkedIdentity, now: Date.parse(instant), prefix: `candidates/v1/runs/${checkedIdentity.workflowRunId}/heads/${checkedIdentity.headSha}/candidates/${checkedIdentity.candidateId}/` };
+}
+
+function validateDescriptor(value, input) {
+  exactKeys(value, ["schemaVersion", "artifactKind", "repository", "workflowRunId", "headSha", "artifactName", "candidateBinding", "freshnessExpiresAt", "createdAt", "expiresAt", "inventory", "component", "tuple", "objects"], "descriptor");
+  if (value.schemaVersion !== 1 || value.artifactKind !== "datapack-candidate-oci-artifact-descriptor" || value.repository !== input.identity.repository || value.workflowRunId !== input.identity.workflowRunId || value.headSha !== input.identity.headSha || value.artifactName !== input.identity.artifactName) fail("DESCRIPTOR_IDENTITY_MISMATCH");
+  exactKeys(value.candidateBinding, ["candidateId", "buildSpecSha256", "manifestSha256"], "candidateBinding");
+  if (token(value.candidateBinding.candidateId) !== input.identity.candidateId) fail("DESCRIPTOR_IDENTITY_MISMATCH");
+  hash(value.candidateBinding.buildSpecSha256); hash(value.candidateBinding.manifestSha256);
+  const createdAt = Date.parse(utc(value.createdAt)); const freshnessExpiresAt = Date.parse(utc(value.freshnessExpiresAt)); const expiresAt = Date.parse(utc(value.expiresAt));
+  if (createdAt >= freshnessExpiresAt || expiresAt !== Math.min(createdAt + 14 * 86400000, freshnessExpiresAt) || expiresAt <= input.now || freshnessExpiresAt <= input.now) fail("DESCRIPTOR_EXPIRED");
+  const metadata = { inventory: file(value.inventory), component: file(value.component), tuple: file(value.tuple) };
+  if (new Set(Object.values(metadata).map(({ path }) => path)).size !== 3 || !Array.isArray(value.objects) || value.objects.length === 0) fail("DESCRIPTOR_OBJECT_SET_INVALID");
+  const paths = new Set(); const keys = new Set(); let previous = null;
+  const objects = value.objects.map((raw) => {
+    exactKeys(raw, ["path", "objectKey", "ociUri", "sizeBytes", "sha256"], "object");
+    const item = { ...file({ path: raw.path, sizeBytes: raw.sizeBytes, sha256: raw.sha256 }), objectKey: required(raw.objectKey), ociUri: required(raw.ociUri) };
+    if (!item.objectKey.startsWith(`${input.prefix}objects/${item.sha256}/`) || item.objectKey !== `${input.prefix}objects/${item.sha256}/${item.path}` || paths.has(item.path) || keys.has(item.objectKey) || (previous !== null && compare(previous, item.path) >= 0)) fail("DESCRIPTOR_OBJECT_SET_INVALID");
+    const locator = /^oci:\/\/([a-z0-9][a-z0-9-]{0,62})\/([a-z0-9][a-z0-9-]{0,62})\/(.+)$/.exec(item.ociUri);
+    if (!locator || locator[1] !== input.storage.namespace || locator[2] !== input.storage.bucket || locator[3] !== item.objectKey) fail("DESCRIPTOR_LOCATOR_MISMATCH");
+    paths.add(item.path); keys.add(item.objectKey); previous = item.path; return item;
+  });
+  for (const item of Object.values(metadata)) if (!paths.has(item.path)) fail("DESCRIPTOR_OBJECT_SET_INVALID");
+  return { value, metadata, objects };
+}
+
+function validateBindings(checked, bodies) {
+  const { value, metadata, objects } = checked;
+  const inventoryBytes = bodies.get(metadata.inventory.path); const componentBytes = bodies.get(metadata.component.path); const tupleBytes = bodies.get(metadata.tuple.path);
+  if (!inventoryBytes || !componentBytes || !tupleBytes) fail("BINDING_MISMATCH");
+  const inventory = parse(inventoryBytes, "inventory"); const component = parse(componentBytes, "component"); const tuple = parse(tupleBytes, "tuple");
+  exactKeys(inventory, ["schemaVersion", "artifactKind", "entries"], "inventory");
+  if (inventory.schemaVersion !== 1 || inventory.artifactKind !== "datapack-candidate-inventory" || !Array.isArray(inventory.entries)) fail("BINDING_MISMATCH");
+  const declared = new Map();
+  for (const raw of inventory.entries) { const item = file(raw); if (declared.has(item.path) || item.path === metadata.inventory.path || item.path === metadata.component.path) fail("BINDING_MISMATCH"); declared.set(item.path, item); }
+  const expected = new Map([...declared, [metadata.inventory.path, metadata.inventory], [metadata.component.path, metadata.component]]);
+  if (expected.size !== objects.length) fail("BINDING_MISMATCH");
+  for (const item of objects) { const expectedItem = expected.get(item.path); if (!expectedItem || expectedItem.sizeBytes !== item.sizeBytes || expectedItem.sha256 !== item.sha256) fail("BINDING_MISMATCH"); }
+  exactKeys(component, ["schemaVersion", "component", "repository", "gitSha", "workflowRunId", "dataVersion", "releaseSequence", "manifestSha256", "provenance", "artifactInventorySha256", "contractVersion", "issueRef"], "component");
+  if (component.schemaVersion !== 1 || component.component !== "data" || component.repository !== value.repository || component.gitSha !== value.headSha || component.workflowRunId !== value.workflowRunId || component.manifestSha256 !== value.candidateBinding.manifestSha256 || component.artifactInventorySha256 !== sha(inventoryBytes)) fail("BINDING_MISMATCH");
+  exactKeys(tuple, ["candidateBinding", "freshnessExpiresAt"], "tuple");
+  exactKeys(tuple.candidateBinding, ["candidateId", "buildSpecSha256", "manifestSha256"], "tuple.candidateBinding");
+  if (tuple.candidateBinding.candidateId !== value.candidateBinding.candidateId || tuple.candidateBinding.buildSpecSha256 !== value.candidateBinding.buildSpecSha256 || tuple.candidateBinding.manifestSha256 !== value.candidateBinding.manifestSha256 || tuple.freshnessExpiresAt !== value.freshnessExpiresAt) fail("BINDING_MISMATCH");
+}
+
+async function fetchObject(fetchImpl, key) { const response = await fetchImpl(key); if (!response || response.status !== 200 || !Buffer.isBuffer(response.body)) fail("OCI_GET_FAILED"); return response.body; }
+function parse(bytes, label) { try { const value = JSON.parse(bytes.toString("utf8")); if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(); return value; } catch { fail(`${label.toUpperCase()}_INVALID`); } }
+function file(value) { exactKeys(value, ["path", "sizeBytes", "sha256"], "file"); return { path: safePath(value.path), sizeBytes: size(value.sizeBytes), sha256: hash(value.sha256) }; }
+function exactKeys(value, keys, label) { if (!value || typeof value !== "object" || Array.isArray(value) || Object.keys(value).sort(compare).join("\0") !== [...keys].sort(compare).join("\0")) fail(`${label.toUpperCase()}_FIELDS_INVALID`); }
+function required(value) { if (typeof value !== "string" || value.length === 0 || value.trim() !== value) fail("INVALID_INPUT"); return value; }
+function exact(value, expected) { if (value !== expected) fail("INVALID_INPUT"); return value; }
+function segment(value) { const result = required(value); if (!/^[a-z0-9][a-z0-9-]{0,62}$/.test(result)) fail("INVALID_INPUT"); return result; }
+function decimal(value) { const result = required(value); if (!/^[1-9][0-9]*$/.test(result)) fail("INVALID_INPUT"); return result; }
+function gitSha(value) { const result = required(value); if (!/^[a-f0-9]{40}$/.test(result)) fail("INVALID_INPUT"); return result; }
+function token(value) { const result = required(value); if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(result)) fail("INVALID_INPUT"); return result; }
+function hash(value) { const result = required(value); if (!/^[a-f0-9]{64}$/.test(result)) fail("INVALID_INPUT"); return result; }
+function size(value) { if (!Number.isSafeInteger(value) || value < 1) fail("DESCRIPTOR_REJECTED"); return value; }
+function safePath(value) { const result = required(value); if (result.startsWith("/") || result.split("/").some((part) => part === "" || part === "." || part === "..")) fail("DESCRIPTOR_REJECTED"); return result; }
+function utc(value) { const result = required(value); if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(result) || new Date(result).toISOString() !== result) fail("INVALID_INPUT"); return result; }
+function fail(code) { const error = new Error(code); error.code = code; throw error; }

--- a/tools/release/fetch-datapack-candidate-oci-handoff.test.mjs
+++ b/tools/release/fetch-datapack-candidate-oci-handoff.test.mjs
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import { fetchDatapackCandidateOciHandoff } from "./fetch-datapack-candidate-oci-handoff.mjs";
+
+const sha = (value) => createHash("sha256").update(value).digest("hex");
+const bytes = (value) => Buffer.from(JSON.stringify(value));
+const identity = {
+  repository: "AquilaXk/easysubway-data",
+  workflowRunId: "42",
+  headSha: "a".repeat(40),
+  candidateId: "candidate-1",
+  artifactName: "easysubway-datapack-candidate-42",
+};
+const storage = { namespace: "namespace", bucket: "candidate-private" };
+
+test("handoff schema는 storage와 six-field identity만 허용한다", () => {
+  const schema = JSON.parse(readFileSync("contracts/release/datapack-candidate-oci-handoff.schema.json", "utf8"));
+  assert.deepEqual(schema.required, ["storage", "identity"]);
+  assert.equal(schema.additionalProperties, false);
+  assert.deepEqual(schema.properties.identity.required, ["repository", "workflowRunId", "headSha", "candidateId", "artifactName", "artifactId"]);
+  assert.equal(schema.properties.identity.additionalProperties, false);
+});
+
+test("six-field identity and descriptor-first OCI object-set을 fail-closed로 소비한다", async () => {
+  const fixture = makeFixture();
+  const result = await fetchDatapackCandidateOciHandoff({ ...fixture.input, fetchImpl: fixture.fetch });
+  assert.deepEqual(result.decision, "GO", JSON.stringify(result));
+  assert.equal(result.artifactReuseCount, 0);
+  assert.deepEqual(fixture.calls, [fixture.descriptorKey, ...fixture.objectKeys]);
+  assert.equal(result.output.descriptorLocator, `oci://${storage.namespace}/${storage.bucket}/${fixture.descriptorKey}`);
+});
+
+test("missing/type/identity mismatch는 OCI GET 0이며 descriptor 실패는 payload GET 0이다", async () => {
+  for (const input of [
+    { storage, identity: { ...identity, artifactId: "z".repeat(64) } },
+    { storage, identity: { ...identity, artifactId: "0".repeat(64), workflowRunId: 42 } },
+  ]) {
+    const calls = [];
+    const result = await fetchDatapackCandidateOciHandoff({ ...input, fetchImpl: async (key) => { calls.push(key); return { status: 404, body: Buffer.alloc(0) }; } });
+    assert.deepEqual(result, { decision: "NO_GO", reasonCode: "INVALID_INPUT", artifactReuseCount: 0, output: null });
+    assert.deepEqual(calls, []);
+  }
+  for (const mutate of [
+    (descriptor) => { descriptor.objects[0].ociUri = "oci://other/bucket/key"; },
+    (descriptor) => { descriptor.objects[0].objectKey = "wrong"; },
+    (descriptor) => { descriptor.expiresAt = "2026-08-23T00:00:00.000Z"; },
+  ]) {
+    const fixture = makeFixture(mutate);
+    const result = await fetchDatapackCandidateOciHandoff({ ...fixture.input, fetchImpl: fixture.fetch });
+    assert.equal(result.decision, "NO_GO");
+    assert.deepEqual(fixture.calls, [fixture.descriptorKey]);
+  }
+});
+
+test("duplicate/missing/extra/traversal paths와 object size/hash·inventory/component/tuple drift는 output 0이다", async () => {
+  for (const mutate of [
+    (descriptor) => { descriptor.objects[1].path = descriptor.objects[0].path; },
+    (descriptor) => { descriptor.objects[0].path = "../escape"; },
+    (descriptor) => { descriptor.objects.pop(); },
+    (descriptor) => { descriptor.objects.push({ ...descriptor.objects[0], path: "extra.json", objectKey: descriptor.objects[0].objectKey.replace("catalog/current.json", "extra.json"), ociUri: descriptor.objects[0].ociUri.replace("catalog/current.json", "extra.json") }); },
+    (_descriptor, objects) => { objects.set("catalog/current.json", Buffer.from("drift")); },
+    (_descriptor, objects) => { objects.set("datapack-candidate-tuple.json", bytes({ candidateBinding: { candidateId: "other", buildSpecSha256: "b".repeat(64), manifestSha256: "c".repeat(64) }, freshnessExpiresAt: "2026-08-25T00:00:00.000Z" })); },
+  ]) {
+    const fixture = makeFixture(mutate);
+    const result = await fetchDatapackCandidateOciHandoff({ ...fixture.input, fetchImpl: fixture.fetch });
+    assert.deepEqual(result.output, null);
+    assert.equal(result.artifactReuseCount, 0);
+  }
+});
+
+function makeFixture(mutate = null) {
+  const manifest = Buffer.from("manifest\n");
+  const tuple = bytes({ candidateBinding: { candidateId: identity.candidateId, buildSpecSha256: "b".repeat(64), manifestSha256: sha(manifest) }, freshnessExpiresAt: "2026-08-25T00:00:00.000Z" });
+  const component = bytes({ schemaVersion: 1, component: "data", repository: identity.repository, gitSha: identity.headSha, workflowRunId: identity.workflowRunId, dataVersion: "1", releaseSequence: 1, manifestSha256: sha(manifest), provenance: {}, artifactInventorySha256: "", contractVersion: "datapack-contract-v3", issueRef: "AquilaXk/easysubway-data#529" });
+  const objects = new Map([["catalog/current.json", manifest], ["datapack-candidate-tuple.json", tuple]]);
+  const inventory = bytes({ schemaVersion: 1, artifactKind: "datapack-candidate-inventory", entries: [...objects].map(([path, value]) => ({ path, sizeBytes: value.length, sha256: sha(value) })) });
+  const finalComponent = bytes({ ...JSON.parse(component), artifactInventorySha256: sha(inventory) });
+  objects.set("data-artifact-inventory.json", inventory); objects.set("data-component-manifest.json", finalComponent);
+  const prefix = `candidates/v1/runs/${identity.workflowRunId}/heads/${identity.headSha}/candidates/${identity.candidateId}/`;
+  const descriptor = { schemaVersion: 1, artifactKind: "datapack-candidate-oci-artifact-descriptor", repository: identity.repository, workflowRunId: identity.workflowRunId, headSha: identity.headSha, artifactName: identity.artifactName, candidateBinding: JSON.parse(tuple).candidateBinding, freshnessExpiresAt: "2026-08-25T00:00:00.000Z", createdAt: "2026-08-24T00:00:00.000Z", expiresAt: "2026-08-25T00:00:00.000Z", inventory: entry("data-artifact-inventory.json", inventory), component: entry("data-component-manifest.json", finalComponent), tuple: entry("datapack-candidate-tuple.json", tuple), objects: [...objects].sort(([left], [right]) => Buffer.compare(Buffer.from(left), Buffer.from(right))).map(([path, value]) => ({ ...entry(path, value), objectKey: `${prefix}objects/${sha(value)}/${path}`, ociUri: `oci://${storage.namespace}/${storage.bucket}/${prefix}objects/${sha(value)}/${path}` })) };
+  mutate?.(descriptor, objects);
+  const descriptorBytes = bytes(descriptor); const artifactId = sha(descriptorBytes);
+  const descriptorKey = `${prefix}descriptors/${artifactId}.json`; const calls = [];
+  return { input: { storage, identity: { ...identity, artifactId }, now: "2026-08-24T12:00:00.000Z" }, descriptorKey, objectKeys: descriptor.objects.map(({ objectKey }) => objectKey), calls, fetch: async (key) => { calls.push(key); return key === descriptorKey ? { status: 200, body: descriptorBytes } : objects.has(keyFrom(descriptor, key)) ? { status: 200, body: objects.get(keyFrom(descriptor, key)) } : { status: 404, body: Buffer.alloc(0) }; } };
+}
+function entry(path, value) { return { path, sizeBytes: value.length, sha256: sha(value) }; }
+function keyFrom(descriptor, key) { return descriptor.objects.find((item) => item.objectKey === key)?.path; }


### PR DESCRIPTION
## 변경

- Data candidate의 six-field identity로 descriptor key를 결정하고 raw SHA-256을 `artifactId`와 검증합니다.
- descriptor-first OCI GET 뒤 object set의 path/key/authority/size/SHA-256, inventory/component/tuple 결속과 expiry를 offline injected fetch로 fail-closed 검증합니다.
- 불일치는 `NO_GO`, output 0, artifact reuse 0으로 끝나며 list/latest/current/preauthenticated URL/alternate store 또는 fallback은 추가하지 않습니다.
- 일반 PR Android artifact에서 Data-owned stale candidate 재빌드만 제거하고 mobile asset audit은 유지합니다.
- production RC의 bundled artifact identity verifier는 그대로 유지합니다.
- workflow 변경의 closed governance inventory SHA를 exact 갱신합니다.

## 검증

- OCI handoff fetcher 4/4
- generic Android artifact ownership RED→GREEN 1/1
- production RC verifier/order 1/1
- RC/system/readiness governance consumers 4/4
- `git diff --check`

Refs #2930
