### PR TITLE
[Docs] terminal wave 이후 D33 실행 인벤토리 갱신

### DIFF
--- a/contracts/documentation/plan-doc-execution-audit-scope.json
+++ b/contracts/documentation/plan-doc-execution-audit-scope.json
@@ -1411,11 +1411,75 @@
       "allowedChangedFiles": [
         "contracts/documentation/documentation-fragment.json"
       ]
+    },
+    {
+      "repository": "AquilaXk/easysubway",
+      "issueNumber": 2932,
+      "prNumber": 2933,
+      "mergeSha": "8e79713519381b8bb206823801e3a5ed23801435",
+      "relation": "CLOSES",
+      "planOwner": "PLAN-DOC",
+      "changedPathClass": "HUB_GOVERNANCE_ONLY",
+      "allowedChangedFiles": [
+        "contracts/documentation/plan-doc-execution-audit-scope.json",
+        "tools/ci/check-contracts.mjs",
+        "tools/ci/check-contracts.test.mjs",
+        "tools/repo/audit-plan-doc-execution.mjs",
+        "tools/repo/audit-plan-doc-execution.test.mjs"
+      ]
+    },
+    {
+      "repository": "AquilaXk/easysubway-backend",
+      "issueNumber": 272,
+      "prNumber": 273,
+      "mergeSha": "a94773baae6ec6e7a346dfbbbeea7bb547cb0364",
+      "relation": "CLOSES",
+      "planOwner": "PLAN-DOC",
+      "changedPathClass": "TARGET_DOCUMENTATION_FRAGMENT",
+      "allowedChangedFiles": [
+        "contracts/documentation/documentation-fragment.json"
+      ]
+    },
+    {
+      "repository": "AquilaXk/easysubway-mobile",
+      "issueNumber": 293,
+      "prNumber": 302,
+      "mergeSha": "2b5384472594017a17842b065b72742e996cadac",
+      "relation": "CLOSES",
+      "planOwner": "PLAN-DOC",
+      "changedPathClass": "TARGET_DOCUMENTATION_FRAGMENT",
+      "allowedChangedFiles": [
+        "contracts/documentation/documentation-fragment.json"
+      ]
+    },
+    {
+      "repository": "AquilaXk/easysubway-data",
+      "issueNumber": 558,
+      "prNumber": 559,
+      "mergeSha": "d813c8408931c13b8a4614c42a2eb3aa220fda17",
+      "relation": "CLOSES",
+      "planOwner": "PLAN-DOC",
+      "changedPathClass": "TARGET_DOCUMENTATION_FRAGMENT",
+      "allowedChangedFiles": [
+        "contracts/documentation/documentation-fragment.json"
+      ]
+    },
+    {
+      "repository": "AquilaXk/easysubway-platform",
+      "issueNumber": 136,
+      "prNumber": 137,
+      "mergeSha": "d9d5186fcd37e0b3ba5729b031e7cf1de4aefcab",
+      "relation": "CLOSES",
+      "planOwner": "PLAN-DOC",
+      "changedPathClass": "TARGET_DOCUMENTATION_FRAGMENT",
+      "allowedChangedFiles": [
+        "contracts/documentation/documentation-fragment.json"
+      ]
     }
   ],
   "self": {
     "repository": "AquilaXk/easysubway",
-    "issueNumber": 2932,
+    "issueNumber": 2937,
     "planOwner": "PLAN-DOC",
     "changedPathClass": "HUB_GOVERNANCE_ONLY",
     "allowedChangedFiles": [

--- a/tools/ci/check-contracts.mjs
+++ b/tools/ci/check-contracts.mjs
@@ -904,9 +904,9 @@ export function validatePublicSensitivityAuditReportSchema(schema, errors = [], 
 
 export function validatePlanDocExecutionAuditScope(scope, errors = [], path = "plan-doc-execution-audit-scope") {
   const repositories = ["AquilaXk/easysubway", "AquilaXk/easysubway-backend", "AquilaXk/easysubway-data", "AquilaXk/easysubway-mobile", "AquilaXk/easysubway-platform"];
-  if (scope?.schemaVersion !== 2 || scope?.planOwner !== "PLAN-DOC" || scope?.self?.repository !== "AquilaXk/easysubway" || scope?.self?.issueNumber !== 2932 || scope?.self?.planOwner !== "PLAN-DOC" || JSON.stringify(scope?.repositories) !== JSON.stringify(repositories)) errors.push(`${path}: exact federated PLAN-DOC self binding이 필요하다`);
+  if (scope?.schemaVersion !== 2 || scope?.planOwner !== "PLAN-DOC" || scope?.self?.repository !== "AquilaXk/easysubway" || scope?.self?.issueNumber !== 2937 || scope?.self?.planOwner !== "PLAN-DOC" || JSON.stringify(scope?.repositories) !== JSON.stringify(repositories)) errors.push(`${path}: exact federated PLAN-DOC self binding이 필요하다`);
   const records = scope?.historical;
-  if (!Array.isArray(records) || records.length !== 95 || new Set(records.map((record) => `${record?.repository}:${record?.prNumber}`)).size !== 95 || new Set(records.map((record) => `${record?.repository}:${record?.mergeSha}`)).size !== 95 || records.some((record) => record?.planOwner !== "PLAN-DOC" || !Array.isArray(record?.allowedChangedFiles))) errors.push(`${path}: exact federated historical PLAN-DOC inventory가 필요하다`);
+  if (!Array.isArray(records) || records.length !== 100 || new Set(records.map((record) => `${record?.repository}:${record?.prNumber}`)).size !== 100 || new Set(records.map((record) => `${record?.repository}:${record?.mergeSha}`)).size !== 100 || records.some((record) => record?.planOwner !== "PLAN-DOC" || !Array.isArray(record?.allowedChangedFiles))) errors.push(`${path}: exact federated historical PLAN-DOC inventory가 필요하다`);
   errors.push(...validatePlanDocExecutionAuditInventory(scope).map((error) => `${path}: ${error}`));
   return errors;
 }

--- a/tools/ci/check-contracts.test.mjs
+++ b/tools/ci/check-contracts.test.mjs
@@ -138,22 +138,29 @@ test("public sensitivity contracts bind the exact scope and corrected owner rece
   assert.ok(validatePublicSensitivityAuditScope(offsetInvalid).some((error) => error.includes("revalidation/expiry")));
 });
 
-test("plan-doc execution audit contracts fix the 95-record historical inventory and fail-closed report", () => {
+test("plan-doc execution audit contracts fix the 100-record historical inventory and fail-closed report", () => {
   const scope = loadJson("contracts/documentation/plan-doc-execution-audit-scope.json");
   const scopeSchema = loadJson("contracts/documentation/plan-doc-execution-audit-scope.schema.json");
   const reportSchema = loadJson("contracts/documentation/plan-doc-execution-audit-report.schema.json");
   assert.equal(scope.schemaVersion, 2);
-  assert.equal(scope.historical.length, 95);
+  assert.equal(scope.historical.length, 100);
   assert.deepEqual(scope.repositories, ["AquilaXk/easysubway", "AquilaXk/easysubway-backend", "AquilaXk/easysubway-data", "AquilaXk/easysubway-mobile", "AquilaXk/easysubway-platform"]);
-  assert.equal(scope.self.issueNumber, 2932);
+  assert.equal(scope.self.issueNumber, 2937);
   assert.equal(scopeSchema.properties.historical.minItems, 1);
   assert.equal(scopeSchema.properties.historical.maxItems, undefined);
   assert.deepEqual(scopeSchema.properties.self.properties.issueNumber, { type: "integer", minimum: 1 });
   assert.equal(scopeSchema.properties.self.properties.allowedChangedFiles.minItems, 1);
   assert.equal(scopeSchema.properties.self.properties.allowedChangedFiles.maxItems, undefined);
   const recordsByIdentity = new Map(scope.historical.map((record) => [`${record.repository}:${record.prNumber}`, record]));
-  assert.equal(recordsByIdentity.size, 95);
-  assert.equal(new Set(scope.historical.map((record) => `${record.repository}:${record.mergeSha}`)).size, 95);
+  assert.equal(recordsByIdentity.size, 100);
+  assert.equal(new Set(scope.historical.map((record) => `${record.repository}:${record.mergeSha}`)).size, 100);
+  assert.deepEqual(scope.historical.slice(-5), [
+    { repository: "AquilaXk/easysubway", issueNumber: 2932, prNumber: 2933, mergeSha: "8e79713519381b8bb206823801e3a5ed23801435", relation: "CLOSES", planOwner: "PLAN-DOC", changedPathClass: "HUB_GOVERNANCE_ONLY", allowedChangedFiles: ["contracts/documentation/plan-doc-execution-audit-scope.json", "tools/ci/check-contracts.mjs", "tools/ci/check-contracts.test.mjs", "tools/repo/audit-plan-doc-execution.mjs", "tools/repo/audit-plan-doc-execution.test.mjs"] },
+    { repository: "AquilaXk/easysubway-backend", issueNumber: 272, prNumber: 273, mergeSha: "a94773baae6ec6e7a346dfbbbeea7bb547cb0364", relation: "CLOSES", planOwner: "PLAN-DOC", changedPathClass: "TARGET_DOCUMENTATION_FRAGMENT", allowedChangedFiles: ["contracts/documentation/documentation-fragment.json"] },
+    { repository: "AquilaXk/easysubway-mobile", issueNumber: 293, prNumber: 302, mergeSha: "2b5384472594017a17842b065b72742e996cadac", relation: "CLOSES", planOwner: "PLAN-DOC", changedPathClass: "TARGET_DOCUMENTATION_FRAGMENT", allowedChangedFiles: ["contracts/documentation/documentation-fragment.json"] },
+    { repository: "AquilaXk/easysubway-data", issueNumber: 558, prNumber: 559, mergeSha: "d813c8408931c13b8a4614c42a2eb3aa220fda17", relation: "CLOSES", planOwner: "PLAN-DOC", changedPathClass: "TARGET_DOCUMENTATION_FRAGMENT", allowedChangedFiles: ["contracts/documentation/documentation-fragment.json"] },
+    { repository: "AquilaXk/easysubway-platform", issueNumber: 136, prNumber: 137, mergeSha: "d9d5186fcd37e0b3ba5729b031e7cf1de4aefcab", relation: "CLOSES", planOwner: "PLAN-DOC", changedPathClass: "TARGET_DOCUMENTATION_FRAGMENT", allowedChangedFiles: ["contracts/documentation/documentation-fragment.json"] },
+  ]);
   assert.deepEqual(recordsByIdentity.get("AquilaXk/easysubway:2887"), { repository: "AquilaXk/easysubway", issueNumber: 2886, prNumber: 2887, mergeSha: "995b4ae9913d1256e3933afe401d2a6c559588a3", relation: "CLOSES", planOwner: "PLAN-DOC", changedPathClass: "HUB_GOVERNANCE_ONLY", allowedChangedFiles: ["contracts/documentation/documentation-fragment.json", "contracts/documentation/plan-doc-execution-audit-scope.json", "tools/ci/check-contracts.mjs", "tools/ci/check-contracts.test.mjs", "tools/repo/audit-plan-doc-execution.mjs", "tools/repo/audit-plan-doc-execution.test.mjs"] });
   assert.deepEqual(recordsByIdentity.get("AquilaXk/easysubway-data:317"), { repository: "AquilaXk/easysubway-data", issueNumber: 316, prNumber: 317, mergeSha: "4f41584328518046d91312c3bcc78cd4ba40308c", relation: "CLOSES", planOwner: "PLAN-DOC", changedPathClass: "TARGET_DOCUMENTATION_FRAGMENT", allowedChangedFiles: ["contracts/documentation/documentation-fragment.json"] });
   assert.deepEqual(recordsByIdentity.get("AquilaXk/easysubway:2889"), { repository: "AquilaXk/easysubway", issueNumber: 2888, prNumber: 2889, mergeSha: "baa030f5a7bbc431f636079486ddf4289b9c858f", relation: "CLOSES", planOwner: "PLAN-DOC", changedPathClass: "HUB_GOVERNANCE_ONLY", allowedChangedFiles: ["contracts/documentation/plan-doc-execution-audit-scope.json", "tools/ci/check-contracts.mjs", "tools/ci/check-contracts.test.mjs", "tools/repo/audit-plan-doc-execution.mjs", "tools/repo/audit-plan-doc-execution.test.mjs"] });

--- a/tools/repo/audit-plan-doc-execution.mjs
+++ b/tools/repo/audit-plan-doc-execution.mjs
@@ -13,17 +13,17 @@ const MAX_ITEMS = 3000;
 const execFileAsync = promisify(execFile);
 const CLOSING_ISSUES_QUERY = `query($owner: String!, $name: String!, $number: Int!) { repository(owner: $owner, name: $name) { pullRequest(number: $number) { number merged mergeCommit { oid } closingIssuesReferences(first: 100) { totalCount pageInfo { hasNextPage } nodes { number state repository { nameWithOwner } } } } } }`;
 const SELF_FILES = ["contracts/documentation/plan-doc-execution-audit-scope.json", "tools/ci/check-contracts.mjs", "tools/ci/check-contracts.test.mjs", "tools/repo/audit-plan-doc-execution.mjs", "tools/repo/audit-plan-doc-execution.test.mjs"];
-const EXPECTED_SCOPE_CANONICAL_SHA256 = "e084a2f228457b19be78cbb0feb22196eb26c635780a054715736c364782fe23";
+const EXPECTED_SCOPE_CANONICAL_SHA256 = "d44cd1720ff2be4709ed0a48f220958025227d307800df958c541190bdca86da";
 
 export class AuditIncomplete extends Error { constructor(code, identity) { super(code); this.code = code; this.identity = identity; } }
 
 export function validatePlanDocExecutionScope(scope, errors = []) {
   if (scope?.schemaVersion !== 2 || scope?.planOwner !== "PLAN-DOC" || JSON.stringify(scope?.repositories) !== JSON.stringify(REPOSITORIES)) errors.push("scope header mismatch");
   const records = scope?.historical;
-  if (!Array.isArray(records) || records.length !== 95) return [...errors, "historical inventory count mismatch"];
+  if (!Array.isArray(records) || records.length !== 100) return [...errors, "historical inventory count mismatch"];
   const key = (record, field) => `${record?.repository}:${record?.[field]}`;
-  if (new Set(records.map((record) => key(record, "prNumber"))).size !== 95) errors.push("duplicate historical record identity");
-  if (new Set(records.map((record) => key(record, "mergeSha"))).size !== 95) errors.push("duplicate historical merge identity");
+  if (new Set(records.map((record) => key(record, "prNumber"))).size !== 100) errors.push("duplicate historical record identity");
+  if (new Set(records.map((record) => key(record, "mergeSha"))).size !== 100) errors.push("duplicate historical merge identity");
   for (const record of records) {
     if (!REPOSITORIES.includes(record?.repository) || !Number.isInteger(record?.issueNumber) || !Number.isInteger(record?.prNumber) || !/^[0-9a-f]{40}$/.test(record?.mergeSha) || !["CLOSES", "COORDINATOR_FOLLOWUP"].includes(record?.relation) || record?.planOwner !== "PLAN-DOC" || !["HUB_GOVERNANCE_ONLY", "PLAN_DOC_CI_RECOVERY", "TARGET_DOCUMENTATION_FRAGMENT", "TARGET_PUBLIC_DOCUMENTATION"].includes(record?.changedPathClass) || !sortedUniquePaths(record?.allowedChangedFiles)) errors.push(`historical record malformed:${record?.repository}:${record?.prNumber}`);
   }
@@ -32,7 +32,7 @@ export function validatePlanDocExecutionScope(scope, errors = []) {
   const coordinator = records.find((record) => record.repository === "AquilaXk/easysubway" && record.prNumber === 2878);
   if (coordinator?.issueNumber !== 2729 || coordinator?.relation !== "COORDINATOR_FOLLOWUP") errors.push("coordinator relation binding mismatch");
   const self = scope?.self;
-  if (self?.repository !== "AquilaXk/easysubway" || self?.issueNumber !== 2932 || self?.planOwner !== "PLAN-DOC" || self?.changedPathClass !== "HUB_GOVERNANCE_ONLY" || JSON.stringify(self?.allowedChangedFiles) !== JSON.stringify(SELF_FILES)) errors.push("self binding mismatch");
+  if (self?.repository !== "AquilaXk/easysubway" || self?.issueNumber !== 2937 || self?.planOwner !== "PLAN-DOC" || self?.changedPathClass !== "HUB_GOVERNANCE_ONLY" || JSON.stringify(self?.allowedChangedFiles) !== JSON.stringify(SELF_FILES)) errors.push("self binding mismatch");
   if (sha256(JSON.stringify(scope)) !== EXPECTED_SCOPE_CANONICAL_SHA256) errors.push("historical frozen inventory mismatch");
   return errors;
 }

--- a/tools/repo/audit-plan-doc-execution.test.mjs
+++ b/tools/repo/audit-plan-doc-execution.test.mjs
@@ -16,11 +16,11 @@ function matchingLive(scope = SCOPE) {
   return { records: scope.historical.map(observed), self: { ...observed({ ...scope.self, prNumber: 9999, mergeSha: SHA, relation: "CLOSES" }), mergeSha: SHA } };
 }
 
-test("plan-doc execution audit scope fixes the federated 95-record inventory and self binding", () => {
+test("plan-doc execution audit scope fixes the federated 100-record inventory and self binding", () => {
   assert.equal(SCOPE.schemaVersion, 2);
-  assert.equal(SCOPE.historical.length, 95);
+  assert.equal(SCOPE.historical.length, 100);
   assert.deepEqual(SCOPE.repositories, ["AquilaXk/easysubway", "AquilaXk/easysubway-backend", "AquilaXk/easysubway-data", "AquilaXk/easysubway-mobile", "AquilaXk/easysubway-platform"]);
-  assert.equal(SCOPE.self.issueNumber, 2932);
+  assert.equal(SCOPE.self.issueNumber, 2937);
   for (const expected of [
     { repository: "AquilaXk/easysubway", issueNumber: 2886, prNumber: 2887, mergeSha: "995b4ae9913d1256e3933afe401d2a6c559588a3", relation: "CLOSES", planOwner: "PLAN-DOC", changedPathClass: "HUB_GOVERNANCE_ONLY", allowedChangedFiles: ["contracts/documentation/documentation-fragment.json", "contracts/documentation/plan-doc-execution-audit-scope.json", "tools/ci/check-contracts.mjs", "tools/ci/check-contracts.test.mjs", "tools/repo/audit-plan-doc-execution.mjs", "tools/repo/audit-plan-doc-execution.test.mjs"] },
     { repository: "AquilaXk/easysubway-data", issueNumber: 316, prNumber: 317, mergeSha: "4f41584328518046d91312c3bcc78cd4ba40308c", relation: "CLOSES", planOwner: "PLAN-DOC", changedPathClass: "TARGET_DOCUMENTATION_FRAGMENT", allowedChangedFiles: ["contracts/documentation/documentation-fragment.json"] },
@@ -47,8 +47,15 @@ test("plan-doc execution audit scope fixes the federated 95-record inventory and
     { repository: "AquilaXk/easysubway", issueNumber: 2918, prNumber: 2919, mergeSha: "d1d9e1c8ac79d2658b824c5a3b0b6db938d5769a", relation: "CLOSES", planOwner: "PLAN-DOC", changedPathClass: "HUB_GOVERNANCE_ONLY", allowedChangedFiles: ["contracts/documentation/plan-doc-execution-audit-scope.json", "tools/ci/check-contracts.mjs", "tools/ci/check-contracts.test.mjs", "tools/repo/audit-plan-doc-execution.mjs", "tools/repo/audit-plan-doc-execution.test.mjs"] },
     { repository: "AquilaXk/easysubway-data", issueNumber: 540, prNumber: 541, mergeSha: "2bdb04b771112dcce61368aebd2c970e1b04da39", relation: "CLOSES", planOwner: "PLAN-DOC", changedPathClass: "TARGET_DOCUMENTATION_FRAGMENT", allowedChangedFiles: ["contracts/documentation/documentation-fragment.json"] },
   ]) assert.deepEqual(SCOPE.historical.find((record) => record.repository === expected.repository && record.prNumber === expected.prNumber), expected);
-  assert.equal(new Set(SCOPE.historical.map((record) => `${record.repository}:${record.prNumber}`)).size, 95);
-  assert.equal(new Set(SCOPE.historical.map((record) => `${record.repository}:${record.mergeSha}`)).size, 95);
+  assert.equal(new Set(SCOPE.historical.map((record) => `${record.repository}:${record.prNumber}`)).size, 100);
+  assert.equal(new Set(SCOPE.historical.map((record) => `${record.repository}:${record.mergeSha}`)).size, 100);
+  assert.deepEqual(SCOPE.historical.slice(-5), [
+    { repository: "AquilaXk/easysubway", issueNumber: 2932, prNumber: 2933, mergeSha: "8e79713519381b8bb206823801e3a5ed23801435", relation: "CLOSES", planOwner: "PLAN-DOC", changedPathClass: "HUB_GOVERNANCE_ONLY", allowedChangedFiles: ["contracts/documentation/plan-doc-execution-audit-scope.json", "tools/ci/check-contracts.mjs", "tools/ci/check-contracts.test.mjs", "tools/repo/audit-plan-doc-execution.mjs", "tools/repo/audit-plan-doc-execution.test.mjs"] },
+    { repository: "AquilaXk/easysubway-backend", issueNumber: 272, prNumber: 273, mergeSha: "a94773baae6ec6e7a346dfbbbeea7bb547cb0364", relation: "CLOSES", planOwner: "PLAN-DOC", changedPathClass: "TARGET_DOCUMENTATION_FRAGMENT", allowedChangedFiles: ["contracts/documentation/documentation-fragment.json"] },
+    { repository: "AquilaXk/easysubway-mobile", issueNumber: 293, prNumber: 302, mergeSha: "2b5384472594017a17842b065b72742e996cadac", relation: "CLOSES", planOwner: "PLAN-DOC", changedPathClass: "TARGET_DOCUMENTATION_FRAGMENT", allowedChangedFiles: ["contracts/documentation/documentation-fragment.json"] },
+    { repository: "AquilaXk/easysubway-data", issueNumber: 558, prNumber: 559, mergeSha: "d813c8408931c13b8a4614c42a2eb3aa220fda17", relation: "CLOSES", planOwner: "PLAN-DOC", changedPathClass: "TARGET_DOCUMENTATION_FRAGMENT", allowedChangedFiles: ["contracts/documentation/documentation-fragment.json"] },
+    { repository: "AquilaXk/easysubway-platform", issueNumber: 136, prNumber: 137, mergeSha: "d9d5186fcd37e0b3ba5729b031e7cf1de4aefcab", relation: "CLOSES", planOwner: "PLAN-DOC", changedPathClass: "TARGET_DOCUMENTATION_FRAGMENT", allowedChangedFiles: ["contracts/documentation/documentation-fragment.json"] },
+  ]);
   assert.equal(SCOPE.historical.some((record) => record.repository === "AquilaXk/easysubway" && record.issueNumber === 2890 && record.prNumber === 2891), false);
   assert.equal(SCOPE.historical.some((record) => record.repository === "AquilaXk/easysubway" && record.issueNumber === 2731 && record.prNumber === 2893), false);
   for (const [repository, issueNumber, prNumber, mergeSha, changedPathClass, allowedChangedFiles] of [["AquilaXk/easysubway", 2881, 2882, "1057c4defa13edc39a631516e463e789857ba854", "HUB_GOVERNANCE_ONLY", ["contracts/documentation/plan-doc-execution-audit-report.schema.json", "contracts/documentation/plan-doc-execution-audit-scope.json", "contracts/documentation/plan-doc-execution-audit-scope.schema.json", "tools/ci/check-contracts.mjs", "tools/ci/check-contracts.test.mjs", "tools/repo/audit-plan-doc-execution.mjs", "tools/repo/audit-plan-doc-execution.test.mjs"]], ["AquilaXk/easysubway-data", 310, 311, "da6b58662a0e84acde1ac1223732e4d3f54874cb", "TARGET_DOCUMENTATION_FRAGMENT", ["contracts/documentation/documentation-fragment.json"]], ["AquilaXk/easysubway", 2884, 2885, "813556b82969ef59ac25cda6318b730dc4c79c0b", "HUB_GOVERNANCE_ONLY", ["contracts/documentation/plan-doc-execution-audit-scope.schema.json", "tools/ci/check-contracts.test.mjs"]]]) assert.deepEqual(SCOPE.historical.find((record) => record.repository === repository && record.prNumber === prNumber), { repository, issueNumber, prNumber, mergeSha, relation: "CLOSES", planOwner: "PLAN-DOC", changedPathClass, allowedChangedFiles });
@@ -63,7 +70,7 @@ test("plan-doc execution audit scope fixes the federated 95-record inventory and
   assert.deepEqual(byIdentity.get("AquilaXk/easysubway-backend:248").allowedChangedFiles, ["contracts/documentation/documentation-fragment.json"]);
   assert.deepEqual(validatePlanDocExecutionScope(SCOPE), []);
   const finalReport = createPlanDocExecutionReport({ scope: SCOPE, scopeText: JSON.stringify(SCOPE), sourceSha: SHA, observedAt: OBSERVED_AT, live: matchingLive() });
-  assert.deepEqual([finalReport.status, finalReport.summary.records, finalReport.summary.findings, finalReport.summary.incomplete], ["COMPLETE", 96, 0, 0]);
+  assert.deepEqual([finalReport.status, finalReport.summary.records, finalReport.summary.findings, finalReport.summary.incomplete], ["COMPLETE", 101, 0, 0]);
   const invalid = structuredClone(SCOPE); invalid.historical[0].allowedChangedFiles.reverse();
   assert.ok(validatePlanDocExecutionScope(invalid).length > 0);
 });


### PR DESCRIPTION
## Summary

- 기존 D33 historical 95건의 order/bytes를 보존합니다.
- prior self #2932/#2933과 Backend #272/#273, Mobile #293/#302, Data #558/#559, Platform #136/#137 terminal 5건을 순서대로 append합니다.
- self를 #2937로 재결속하고 historical `100`, report records `101`, canonical digest를 atomic하게 갱신합니다.

## Verification

- tests-only RED: auditor/contract 모두 exact `95 !== 100`
- GREEN: auditor named tests `6/6`, contract named test `1/1`
- Hub `--current-only --local-contracts-only` PASS
- exact five-file diff, `git diff --check` PASS
- current-head required Hub CI/Sonar와 supported R3 Review는 이 Draft에서 확인합니다.

## Scope

- `contracts/documentation/plan-doc-execution-audit-scope.json`
- `tools/ci/check-contracts.mjs`
- `tools/ci/check-contracts.test.mjs`
- `tools/repo/audit-plan-doc-execution.mjs`
- `tools/repo/audit-plan-doc-execution.test.mjs`

Fragment/source/runtime/release/deploy/Kubernetes와 D13/D20/D22/D35는 변경하지 않습니다. Merge 뒤 동일 Hub SHA의 D33과 Documentation Inventory가 최종 current proof입니다.

Closes #2937
