### PR TITLE
[CI] completed Actions run quota-bounded 재발 방지

### DIFF
--- a/.github/workflows/actions-storage-cleanup.yml
+++ b/.github/workflows/actions-storage-cleanup.yml
@@ -27,6 +27,32 @@ jobs:
           set -euo pipefail
           gh cache delete --all --ref "$BRANCH" --succeed-on-no-caches
 
+  cleanup-completed-actions-runs:
+    name: Prune old completed Actions runs
+    if: github.event_name != 'pull_request'
+    needs: cleanup-ghcr-backend-images
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Checkout cleanup contract
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Delete a quota-bounded completed-run batch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          MIN_AGE_HOURS: 48
+          MAX_DELETE: 999
+          QUOTA_RESERVE: 1000
+          FAILURE_RESOLUTION_HEADROOM: 20
+          # Mobile's current immutable consumer reads this exact run/artifact.
+          # Remove it only with the consumer rebind tracked by the master plan.
+          PROTECTED_RUN_IDS: 31280042807
+        run: node tools/ci/prune-completed-actions-runs.mjs
+
   cleanup-ghcr-backend-images:
     name: Prune old GHCR backend images
     if: github.event_name != 'pull_request'

--- a/.github/workflows/actions-storage-cleanup.yml
+++ b/.github/workflows/actions-storage-cleanup.yml
@@ -8,15 +8,13 @@ on:
     - cron: "17 3 * * 0"
   workflow_dispatch:
 
-permissions:
-  actions: write
-  contents: read
-
 jobs:
   cleanup-pr-caches:
     name: Delete closed PR caches
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     steps:
       - name: Delete caches for closed pull request
         env:

--- a/.github/workflows/actions-storage-cleanup.yml
+++ b/.github/workflows/actions-storage-cleanup.yml
@@ -8,6 +8,11 @@ on:
     - cron: "17 3 * * 0"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+  queue: max
+
 jobs:
   cleanup-pr-caches:
     name: Delete closed PR caches

--- a/tools/ci/prune-completed-actions-runs.mjs
+++ b/tools/ci/prune-completed-actions-runs.mjs
@@ -1,0 +1,250 @@
+#!/usr/bin/env node
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+
+const execFileAsync = promisify(execFile);
+const API_PAGE_SIZE = 100;
+const ACTIONS_RESULT_PAGES = 10;
+const OPEN_PULL_REQUEST_PAGE_LIMIT = 100;
+
+class GitHubCallError extends Error {
+  constructor(message, status) {
+    super(message);
+    this.name = "GitHubCallError";
+    this.status = status;
+  }
+}
+
+function positiveInteger(value, name) {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function repositoryName(value) {
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(value ?? "")) {
+    throw new Error("GITHUB_REPOSITORY must be OWNER/REPO");
+  }
+  return value;
+}
+
+function protectedRunIds(value) {
+  const ids = new Set();
+  for (const token of String(value ?? "").split(/[\s,]+/).filter(Boolean)) {
+    ids.add(positiveInteger(token, "PROTECTED_RUN_IDS"));
+  }
+  return ids;
+}
+
+export function configFromEnv(env = process.env) {
+  if (!env.GH_TOKEN) throw new Error("GH_TOKEN is required");
+  const protectedIds = protectedRunIds(env.PROTECTED_RUN_IDS);
+  protectedIds.add(positiveInteger(env.GITHUB_RUN_ID, "GITHUB_RUN_ID"));
+  return {
+    repository: repositoryName(env.GITHUB_REPOSITORY),
+    minAgeHours: positiveInteger(env.MIN_AGE_HOURS, "MIN_AGE_HOURS"),
+    maxDelete: positiveInteger(env.MAX_DELETE, "MAX_DELETE"),
+    quotaReserve: positiveInteger(env.QUOTA_RESERVE, "QUOTA_RESERVE"),
+    failureResolutionHeadroom: positiveInteger(
+      env.FAILURE_RESOLUTION_HEADROOM,
+      "FAILURE_RESOLUTION_HEADROOM",
+    ),
+    protectedRunIds: protectedIds,
+  };
+}
+
+function errorStatus(error) {
+  if (Number.isInteger(error?.status)) return error.status;
+  const match = String(error?.message ?? "").match(/HTTP\s+(\d{3})\b/);
+  return match ? Number(match[1]) : undefined;
+}
+
+async function callGh(args) {
+  try {
+    const { stdout } = await execFileAsync("gh", args, {
+      encoding: "utf8",
+      maxBuffer: 16 * 1024 * 1024,
+    });
+    return stdout;
+  } catch (error) {
+    const message = String(error?.stderr || error?.message || "gh command failed").trim();
+    throw new GitHubCallError(message, errorStatus({ message }));
+  }
+}
+
+function parseJson(text, label) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new Error(`${label} returned malformed JSON`);
+  }
+}
+
+async function listOpenPullRequestHeads(repository, api) {
+  const heads = new Set();
+  for (let page = 1; page <= OPEN_PULL_REQUEST_PAGE_LIMIT; page += 1) {
+    const rows = parseJson(await api([
+      "api", "--method", "GET", `repos/${repository}/pulls`,
+      "-f", "state=open", "-f", `per_page=${API_PAGE_SIZE}`, "-f", `page=${page}`,
+    ]), "open pull request listing");
+    if (!Array.isArray(rows)) throw new Error("open pull request listing schema mismatch");
+    for (const pullRequest of rows) {
+      const sha = pullRequest?.head?.sha;
+      if (typeof sha !== "string" || !/^[a-f0-9]{40}$/.test(sha)) {
+        throw new Error("open pull request head schema mismatch");
+      }
+      heads.add(sha);
+    }
+    if (rows.length < API_PAGE_SIZE) return heads;
+  }
+  throw new Error("open pull request inventory exceeds the safety page limit");
+}
+
+async function listCompletedRuns(repository, before, api) {
+  const runs = [];
+  for (let page = 1; page <= ACTIONS_RESULT_PAGES; page += 1) {
+    const payload = parseJson(await api([
+      "api", "--method", "GET", `repos/${repository}/actions/runs`,
+      "-f", "status=completed", "-f", `created=<=${before}`,
+      "-f", `per_page=${API_PAGE_SIZE}`, "-f", `page=${page}`,
+    ]), "completed workflow-run listing");
+    if (!Array.isArray(payload?.workflow_runs)) {
+      throw new Error("completed workflow-run listing schema mismatch");
+    }
+    runs.push(...payload.workflow_runs);
+    if (payload.workflow_runs.length < API_PAGE_SIZE) break;
+  }
+  return runs;
+}
+
+function equalSets(left, right) {
+  return left.size === right.size && [...left].every((value) => right.has(value));
+}
+
+export function selectCleanupCandidates({ runs, before, openHeadShas, protectedRunIds }) {
+  const beforeMs = Date.parse(before);
+  if (!Number.isFinite(beforeMs)) throw new Error("before must be an ISO timestamp");
+  const seen = new Set();
+  const candidates = [];
+  for (const run of runs) {
+    if (!Number.isSafeInteger(run?.id) || run.id <= 0) {
+      throw new Error("workflow run id schema mismatch");
+    }
+    if (seen.has(run.id)) throw new Error(`duplicate workflow run ${run.id}`);
+    seen.add(run.id);
+    if (run.status !== "completed") throw new Error(`workflow run ${run.id} is not completed`);
+    if (typeof run.head_sha !== "string" || !/^[a-f0-9]{40}$/.test(run.head_sha)) {
+      throw new Error(`workflow run ${run.id} head schema mismatch`);
+    }
+    const createdAt = Date.parse(run.created_at);
+    if (!Number.isFinite(createdAt) || createdAt > beforeMs) {
+      throw new Error(`workflow run ${run.id} is outside the requested cutoff`);
+    }
+    if (protectedRunIds.has(run.id) || openHeadShas.has(run.head_sha)) continue;
+    candidates.push({ id: run.id, createdAt });
+  }
+  candidates.sort((left, right) => left.createdAt - right.createdAt || left.id - right.id);
+  return candidates.map(({ id }) => id);
+}
+
+async function deleteRun(repository, runId, api, resolution) {
+  try {
+    await api(["api", "--method", "DELETE", `repos/${repository}/actions/runs/${runId}`]);
+    return "direct";
+  } catch (error) {
+    if (errorStatus(error) !== 504) throw error;
+  }
+
+  if (resolution.used >= resolution.limit) {
+    throw new Error("failure-resolution headroom exhausted before existence check");
+  }
+  resolution.used += 1;
+  try {
+    await api(["api", "--method", "GET", `repos/${repository}/actions/runs/${runId}`]);
+  } catch (error) {
+    if (errorStatus(error) === 404) return "timeout-confirmed-absent";
+    throw error;
+  }
+
+  if (resolution.used >= resolution.limit) {
+    throw new Error("failure-resolution headroom exhausted before bounded retry");
+  }
+  resolution.used += 1;
+  await api(["api", "--method", "DELETE", `repos/${repository}/actions/runs/${runId}`]);
+  return "timeout-retried";
+}
+
+export async function runCleanup(config, { api = callGh, now = new Date() } = {}) {
+  const before = new Date(now.getTime() - config.minAgeHours * 60 * 60 * 1000).toISOString();
+  const firstOpenHeads = await listOpenPullRequestHeads(config.repository, api);
+  const runs = await listCompletedRuns(config.repository, before, api);
+  const secondOpenHeads = await listOpenPullRequestHeads(config.repository, api);
+  if (!equalSets(firstOpenHeads, secondOpenHeads)) {
+    throw new Error("open pull request inventory changed before deletion");
+  }
+  const candidates = selectCleanupCandidates({
+    runs,
+    before,
+    openHeadShas: secondOpenHeads,
+    protectedRunIds: config.protectedRunIds,
+  });
+  const rateLimit = parseJson(await api(["api", "rate_limit"]), "rate limit");
+  const remaining = rateLimit?.resources?.core?.remaining;
+  if (!Number.isSafeInteger(remaining) || remaining < 0) {
+    throw new Error("core rate-limit schema mismatch");
+  }
+  const deleteCapacity = Math.max(
+    0,
+    remaining - config.quotaReserve - config.failureResolutionHeadroom,
+  );
+  const targets = candidates.slice(0, Math.min(config.maxDelete, deleteCapacity));
+  if (targets.length === 0) {
+    return {
+      repository: config.repository,
+      before,
+      selected: 0,
+      deleted: 0,
+      reason: candidates.length === 0 ? "no-safe-candidates" : "quota-reserve",
+      coreRemaining: remaining,
+    };
+  }
+
+  const counts = { direct: 0, "timeout-confirmed-absent": 0, "timeout-retried": 0 };
+  const resolution = { used: 0, limit: config.failureResolutionHeadroom };
+  for (const runId of targets) {
+    const disposition = await deleteRun(config.repository, runId, api, resolution);
+    counts[disposition] += 1;
+  }
+  return {
+    repository: config.repository,
+    before,
+    selected: targets.length,
+    deleted: Object.values(counts).reduce((sum, count) => sum + count, 0),
+    counts,
+    coreRemainingBeforeDelete: remaining,
+    quotaReserve: config.quotaReserve,
+  };
+}
+
+function isMainModule() {
+  return process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+}
+
+function safeMessage(error) {
+  return String(error?.message ?? error)
+    .replace(/\b(?:gh[pousr]_[A-Za-z0-9_]+|github_pat_[A-Za-z0-9_]+)\b/g, "[REDACTED]");
+}
+
+if (isMainModule()) {
+  try {
+    const result = await runCleanup(configFromEnv());
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+  } catch (error) {
+    process.stderr.write(`${safeMessage(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/tools/ci/prune-completed-actions-runs.test.mjs
+++ b/tools/ci/prune-completed-actions-runs.test.mjs
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  configFromEnv,
+  runCleanup,
+  selectCleanupCandidates,
+} from "./prune-completed-actions-runs.mjs";
+
+const SHA = {
+  open: "1".repeat(40),
+  closed: "2".repeat(40),
+  other: "3".repeat(40),
+};
+
+function run(id, headSha, createdAt = "2026-08-20T00:00:00.000Z") {
+  return { id, status: "completed", head_sha: headSha, created_at: createdAt };
+}
+
+function field(args, name) {
+  for (let index = 0; index < args.length - 1; index += 1) {
+    if (args[index] === "-f" && args[index + 1].startsWith(`${name}=`)) {
+      return args[index + 1].slice(name.length + 1);
+    }
+  }
+  return undefined;
+}
+
+function fakeApi({ pulls = [[{ head: { sha: SHA.open } }], [{ head: { sha: SHA.open } }]], runs = [], remaining = 5000, deleteErrors = new Map() } = {}) {
+  const deleted = [];
+  let pullInventory = 0;
+  const calls = [];
+  async function api(args) {
+    calls.push(args);
+    const endpoint = args.find((token) => token === "rate_limit" || token.startsWith("repos/"));
+    const methodIndex = args.indexOf("--method");
+    const method = methodIndex >= 0 ? args[methodIndex + 1] : "GET";
+    if (endpoint === "rate_limit") {
+      return JSON.stringify({ resources: { core: { remaining } } });
+    }
+    if (endpoint.endsWith("/pulls")) {
+      const page = Number(field(args, "page"));
+      if (page !== 1) return "[]";
+      return JSON.stringify(pulls[Math.min(pullInventory++, pulls.length - 1)]);
+    }
+    if (endpoint.endsWith("/actions/runs")) {
+      return JSON.stringify({ workflow_runs: Number(field(args, "page")) === 1 ? runs : [] });
+    }
+    const runMatch = endpoint.match(/\/actions\/runs\/(\d+)$/);
+    if (!runMatch) throw new Error(`unexpected fake API request: ${args.join(" ")}`);
+    const id = Number(runMatch[1]);
+    const key = `${method}:${id}`;
+    const queued = deleteErrors.get(key);
+    if (queued?.length) {
+      const status = queued.shift();
+      if (status) throw Object.assign(new Error(`HTTP ${status}`), { status });
+    }
+    if (method === "DELETE") deleted.push(id);
+    return method === "GET" ? JSON.stringify(run(id, SHA.closed)) : "";
+  }
+  return { api, calls, deleted };
+}
+
+const CONFIG = {
+  repository: "AquilaXk/easysubway",
+  minAgeHours: 48,
+  maxDelete: 999,
+  quotaReserve: 1000,
+  failureResolutionHeadroom: 20,
+  protectedRunIds: new Set([31280042807, 999999]),
+};
+
+test("환경 입력은 고정 날짜 없이 current run과 explicit protected run을 결속한다", () => {
+  const config = configFromEnv({
+    GH_TOKEN: "redacted",
+    GITHUB_REPOSITORY: "AquilaXk/easysubway",
+    GITHUB_RUN_ID: "444",
+    MIN_AGE_HOURS: "48",
+    MAX_DELETE: "999",
+    QUOTA_RESERVE: "1000",
+    FAILURE_RESOLUTION_HEADROOM: "20",
+    PROTECTED_RUN_IDS: "31280042807, 555",
+  });
+  assert.deepEqual([...config.protectedRunIds], [31280042807, 555, 444]);
+  assert.equal(config.minAgeHours, 48);
+});
+
+test("candidate 선택은 completed cutoff를 재검증하고 open head와 protected run을 제외한다", () => {
+  const selected = selectCleanupCandidates({
+    runs: [
+      run(31280042807, SHA.closed),
+      run(2, SHA.open),
+      run(4, SHA.other, "2026-08-19T00:00:00.000Z"),
+      run(3, SHA.closed, "2026-08-18T00:00:00.000Z"),
+    ],
+    before: "2026-08-24T00:00:00.000Z",
+    openHeadShas: new Set([SHA.open]),
+    protectedRunIds: new Set([31280042807]),
+  });
+  assert.deepEqual(selected, [3, 4]);
+});
+
+test("quota reserve와 resolution headroom을 제외한 exact oldest batch만 삭제한다", async () => {
+  const fake = fakeApi({
+    runs: [run(3, SHA.closed, "2026-08-18T00:00:00.000Z"), run(4, SHA.other), run(5, SHA.closed)],
+    remaining: 1022,
+  });
+  const result = await runCleanup(CONFIG, { api: fake.api, now: new Date("2026-08-26T00:00:00.000Z") });
+  assert.equal(result.deleted, 2);
+  assert.deepEqual(fake.deleted, [3, 4]);
+});
+
+test("quota가 reserve와 resolution headroom만 남기면 mutation 0으로 종료한다", async () => {
+  const fake = fakeApi({ runs: [run(3, SHA.closed)], remaining: 1020 });
+  const result = await runCleanup(CONFIG, { api: fake.api, now: new Date("2026-08-26T00:00:00.000Z") });
+  assert.equal(result.reason, "quota-reserve");
+  assert.deepEqual(fake.deleted, []);
+});
+
+test("open PR inventory가 selection 중 바뀌면 첫 DELETE 전에 fail closed한다", async () => {
+  const fake = fakeApi({
+    pulls: [[{ head: { sha: SHA.open } }], [{ head: { sha: SHA.other } }]],
+    runs: [run(3, SHA.closed)],
+  });
+  await assert.rejects(
+    runCleanup(CONFIG, { api: fake.api, now: new Date("2026-08-26T00:00:00.000Z") }),
+    /open pull request inventory changed/,
+  );
+  assert.deepEqual(fake.deleted, []);
+});
+
+test("DELETE 504 뒤 exact GET 404는 삭제 반영으로 한 번만 확인한다", async () => {
+  const fake = fakeApi({
+    pulls: [[], []],
+    runs: [run(3, SHA.closed)],
+    remaining: 1050,
+    deleteErrors: new Map([["DELETE:3", [504]], ["GET:3", [404]]]),
+  });
+  const result = await runCleanup(CONFIG, { api: fake.api, now: new Date("2026-08-26T00:00:00.000Z") });
+  assert.equal(result.counts["timeout-confirmed-absent"], 1);
+  assert.deepEqual(fake.deleted, []);
+});
+
+test("DELETE 504 뒤 run이 존재하면 headroom 안에서 한 번만 재시도한다", async () => {
+  const fake = fakeApi({
+    pulls: [[], []],
+    runs: [run(3, SHA.closed)],
+    remaining: 1050,
+    deleteErrors: new Map([["DELETE:3", [504, undefined]]]),
+  });
+  const result = await runCleanup(CONFIG, { api: fake.api, now: new Date("2026-08-26T00:00:00.000Z") });
+  assert.equal(result.counts["timeout-retried"], 1);
+  assert.deepEqual(fake.deleted, [3]);
+});

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1754,6 +1754,22 @@ test("Actions cleanup은 closed PR cache만 제거하고 weekly all-cache purge�
   assert.match(ghcrJob, /if \[ "\$\{index\}" -le 10 \]; then/);
 });
 
+test("Actions cleanup은 완료된 오래된 run만 PR head와 보호 run을 제외해 정리한다", () => {
+  const cleanup = read(".github/workflows/actions-storage-cleanup.yml");
+  const completedRunJob = workflowJobBlock(cleanup, "cleanup-completed-actions-runs");
+
+  assert.match(completedRunJob, /if: github\.event_name != 'pull_request'/);
+  assert.match(completedRunJob, /needs: cleanup-ghcr-backend-images/);
+  assert.match(completedRunJob, /actions:\s*write/);
+  assert.match(completedRunJob, /checkout@/);
+  assert.match(completedRunJob, /node tools\/ci\/prune-completed-actions-runs\.mjs/);
+  assert.match(completedRunJob, /PROTECTED_RUN_IDS: 31280042807/);
+  assert.match(completedRunJob, /MAX_DELETE:/);
+  assert.match(completedRunJob, /QUOTA_RESERVE:/);
+  assert.match(completedRunJob, /FAILURE_RESOLUTION_HEADROOM:/);
+  assert.doesNotMatch(completedRunJob, /gh run cancel|gh run rerun|workflow_dispatch/);
+});
+
 test("full PR 템플릿은 리뷰와 배포 확인 게이트를 포함한다", () => {
   const template = read(".github/PULL_REQUEST_TEMPLATE/full.md");
 

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1745,7 +1745,10 @@ test("Actions cleanup은 closed PR cache만 제거하고 weekly all-cache purge�
   const prCacheJob = workflowJobBlock(cleanup, "cleanup-pr-caches");
   const ghcrJob = workflowJobBlock(cleanup, "cleanup-ghcr-backend-images");
 
+  assert.doesNotMatch(cleanup, /^permissions:/m);
   assert.match(prCacheJob, /if: github\.event_name == 'pull_request'/);
+  assert.match(prCacheJob, /permissions:\s*\n\s*actions: write/);
+  assert.doesNotMatch(prCacheJob, /contents:\s*read/);
   assert.match(prCacheJob, /BRANCH: refs\/pull\/\$\{\{ github\.event\.pull_request\.number \}\}\/merge/);
   assert.match(prCacheJob, /gh cache delete --all --ref "\$BRANCH" --succeed-on-no-caches/);
   assert.equal((cleanup.match(/gh cache delete --all/g) ?? []).length, 1);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1761,6 +1761,10 @@ test("Actions cleanup은 완료된 오래된 run만 PR head와 보호 run을 제
   const cleanup = read(".github/workflows/actions-storage-cleanup.yml");
   const completedRunJob = workflowJobBlock(cleanup, "cleanup-completed-actions-runs");
 
+  assert.match(
+    cleanup,
+    /^concurrency:\n  group: \$\{\{ github\.workflow \}\}\n  cancel-in-progress: false\n  queue: max$/m,
+  );
   assert.match(completedRunJob, /if: github\.event_name != 'pull_request'/);
   assert.match(completedRunJob, /needs: cleanup-ghcr-backend-images/);
   assert.match(completedRunJob, /actions:\s*write/);


### PR DESCRIPTION
## 관련 이슈 / Related issue

Closes #2945

## 작업 배경 / Summary

- Problem: 수동으로 25,103개의 completed Actions run을 정리했지만 기존 cleanup workflow에는 재발 방지 job이 없어 run/artifact backlog가 다시 증가합니다.
- Outcome: 기존 weekly/manual cleanup surface에서 open PR와 보호 run, core quota reserve를 보존하며 오래된 completed run만 최대 999개씩 정리합니다.

## 작업 내용 / Changes

- `status=completed`와 runtime-derived `created` cutoff로 최대 1,000개를 읽고 oldest safe IDs만 선택합니다.
- open PR head inventory를 selection 전후 두 번 비교하고 current cleanup run과 보호 run `31280042807`을 제외합니다.
- core reserve 1,000과 failure-resolution headroom 20을 남긴 범위에서만 최대 999개를 순차 삭제합니다.
- DELETE 504는 exact GET 1회로 404를 확인하고, 존재할 때만 DELETE를 한 번 재시도합니다.
- GHCR cleanup 완료 뒤 quota를 읽도록 job 순서를 고정했습니다.

## Scope

### Included

- `.github/workflows/actions-storage-cleanup.yml`
- `tools/ci/prune-completed-actions-runs.mjs`
- `tools/ci/prune-completed-actions-runs.test.mjs`
- `tools/ci/repository-contract.test.mjs`

### Excluded

- Workflow dispatch, cancel, rerun
- Closed-PR cache와 GHCR keep-10 정책 변경
- Product artifact/provider/deploy/release/K3s mutation
- Mobile 보호 run consumer rebind

### Ownership / dependencies

- Accountable owner or plan: `plan-repo-cutover-master-v8-20260811` / PLAN-REPO
- Required predecessor output: owner-approved development-stage GitHub hygiene contract; current Mobile protected run identity
- Concurrent work overlap: None — PR 생성 전 open PR file inventory 0

## Documentation impact

- 영향 resource ID 또는 `NONE`: NONE
- resourceClass: NONE
- documentationFamily: NONE
- lifecycle/evidence 영향: owner-local master plan과 exact task에만 기록하며 tracked documentation change는 없습니다.

## 검증 / Verification

| Check | Result / Evidence |
| --- | --- |
| Focused RED → GREEN | workflow job 부재 RED 0/1 → contract GREEN 1/1; GHCR quota-order RED 0/1 → GREEN 1/1 |
| Affected integration | cleanup runner fake API 7/7 PASS; existing+new cleanup contract 2/2 PASS |
| Required CI | Current-head Hub CI pending |
| Manual / production-like | Not required in PR — actual cleanup dispatch is explicitly prohibited before merge |
| Security / privacy / accessibility | PASS — token is consumed only by `gh`, redacted from error output; accessibility/product surface unchanged |

- 실행한 명령과 결과:
  - `node --test tools/ci/prune-completed-actions-runs.test.mjs` — 7/7 PASS
  - `node --test --test-name-pattern="Actions cleanup은 closed PR cache만 제거하고 weekly all-cache purge를 금지한다|Actions cleanup은 완료된 오래된 run만 PR head와 보호 run을 제외해 정리한다" tools/ci/repository-contract.test.mjs` — 2/2 PASS
  - `git diff --check` — PASS

## 검증 증거

UI·접근성·수동 QA 증거는 불필요합니다. 이 변경은 GitHub Actions maintenance이며 fake API tests가 selection, exclusion, quota와 bounded failure resolution을 직접 검증합니다. 실제 destructive dispatch는 merge 뒤 rollout 단계에서만 허용합니다.

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName / versionCode: unchanged
- datapack version: unchanged
- route / realtime contract: unchanged
- backend identity: unchanged

## Not run

- Check: `Actions Storage Cleanup` workflow dispatch
- Reason: PR 검증에서 실제 completed-run deletion을 실행하지 않는 issue #2945 계약
- Rerun owner / condition: PLAN-REPO, merge 뒤 exact merged workflow의 rollout 1회

## 리뷰어 메모 / Review focus

- 리뷰어가 먼저 봐야 할 지점: open-PR inventory two-read, quota calculation after GHCR completion, protected/current run exclusion, 504/404 bounded resolution

## 리스크 / Risk

- Level: High
- Main risk: 삭제 대상 selection 또는 quota 계산 오류로 현재 required-check run을 잃거나 release-path quota를 소진하는 것
- Failure behavior: schema/inventory/quota/delete ambiguity에서 fail-stop하며 이후 ID는 처리하지 않음
- State mutation on failure: failure 전 이미 204/404로 확정된 exact completed run만 삭제될 수 있음; later target mutation 0
- Fallback or degraded-success path introduced: No

## Rollout / Recovery

- Rollout or activation: merge 뒤 기존 `Actions Storage Cleanup` manual/scheduled surface에서 exact merged main을 1회 실행
- Monitoring / success signal: sanitized JSON deleted/counts와 core reserve 유지, workflow success
- Rollback or recovery: PR revert로 이후 정리를 중단; 이미 삭제한 development-stage historical run은 owner 결정상 복구하지 않음
- Data / config compatibility after rollback: product data/config/runtime 영향 없음

## 체크리스트 / Checklist

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] 이슈 범위와 실제 diff가 일치하며 관련 없는 변경을 포함하지 않았다.
- [x] 위험에 필요한 검증과 미실행 사유를 기록했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다. — 배포 영향 없음
