### PR TITLE
[Docs] D33 Data #566 terminal append

### DIFF
--- a/contracts/documentation/plan-doc-execution-audit-scope.json
+++ b/contracts/documentation/plan-doc-execution-audit-scope.json
@@ -1543,11 +1543,39 @@
       "allowedChangedFiles": [
         "contracts/documentation/documentation-fragment.json"
       ]
+    },
+    {
+      "repository": "AquilaXk/easysubway",
+      "issueNumber": 2947,
+      "prNumber": 2948,
+      "mergeSha": "360b27d22ca28103dcd7791e9ee8fd4ca3590e9c",
+      "relation": "CLOSES",
+      "planOwner": "PLAN-DOC",
+      "changedPathClass": "HUB_GOVERNANCE_ONLY",
+      "allowedChangedFiles": [
+        "contracts/documentation/plan-doc-execution-audit-scope.json",
+        "tools/ci/check-contracts.mjs",
+        "tools/ci/check-contracts.test.mjs",
+        "tools/repo/audit-plan-doc-execution.mjs",
+        "tools/repo/audit-plan-doc-execution.test.mjs"
+      ]
+    },
+    {
+      "repository": "AquilaXk/easysubway-data",
+      "issueNumber": 565,
+      "prNumber": 566,
+      "mergeSha": "6d3c5bd8bff60488642c82eb15be25273ea82707",
+      "relation": "CLOSES",
+      "planOwner": "PLAN-DOC",
+      "changedPathClass": "TARGET_DOCUMENTATION_FRAGMENT",
+      "allowedChangedFiles": [
+        "contracts/documentation/documentation-fragment.json"
+      ]
     }
   ],
   "self": {
     "repository": "AquilaXk/easysubway",
-    "issueNumber": 2947,
+    "issueNumber": 2949,
     "planOwner": "PLAN-DOC",
     "changedPathClass": "HUB_GOVERNANCE_ONLY",
     "allowedChangedFiles": [

--- a/tools/ci/check-contracts.mjs
+++ b/tools/ci/check-contracts.mjs
@@ -904,9 +904,9 @@ export function validatePublicSensitivityAuditReportSchema(schema, errors = [], 
 
 export function validatePlanDocExecutionAuditScope(scope, errors = [], path = "plan-doc-execution-audit-scope") {
   const repositories = ["AquilaXk/easysubway", "AquilaXk/easysubway-backend", "AquilaXk/easysubway-data", "AquilaXk/easysubway-mobile", "AquilaXk/easysubway-platform"];
-  if (scope?.schemaVersion !== 2 || scope?.planOwner !== "PLAN-DOC" || scope?.self?.repository !== "AquilaXk/easysubway" || scope?.self?.issueNumber !== 2947 || scope?.self?.planOwner !== "PLAN-DOC" || JSON.stringify(scope?.repositories) !== JSON.stringify(repositories)) errors.push(`${path}: exact federated PLAN-DOC self binding이 필요하다`);
+  if (scope?.schemaVersion !== 2 || scope?.planOwner !== "PLAN-DOC" || scope?.self?.repository !== "AquilaXk/easysubway" || scope?.self?.issueNumber !== 2949 || scope?.self?.planOwner !== "PLAN-DOC" || JSON.stringify(scope?.repositories) !== JSON.stringify(repositories)) errors.push(`${path}: exact federated PLAN-DOC self binding이 필요하다`);
   const records = scope?.historical;
-  if (!Array.isArray(records) || records.length !== 105 || new Set(records.map((record) => `${record?.repository}:${record?.prNumber}`)).size !== 105 || new Set(records.map((record) => `${record?.repository}:${record?.mergeSha}`)).size !== 105 || records.some((record) => record?.planOwner !== "PLAN-DOC" || !Array.isArray(record?.allowedChangedFiles))) errors.push(`${path}: exact federated historical PLAN-DOC inventory가 필요하다`);
+  if (!Array.isArray(records) || records.length !== 107 || new Set(records.map((record) => `${record?.repository}:${record?.prNumber}`)).size !== 107 || new Set(records.map((record) => `${record?.repository}:${record?.mergeSha}`)).size !== 107 || records.some((record) => record?.planOwner !== "PLAN-DOC" || !Array.isArray(record?.allowedChangedFiles))) errors.push(`${path}: exact federated historical PLAN-DOC inventory가 필요하다`);
   errors.push(...validatePlanDocExecutionAuditInventory(scope).map((error) => `${path}: ${error}`));
   return errors;
 }

--- a/tools/ci/check-contracts.test.mjs
+++ b/tools/ci/check-contracts.test.mjs
@@ -138,26 +138,28 @@ test("public sensitivity contracts bind the exact scope and corrected owner rece
   assert.ok(validatePublicSensitivityAuditScope(offsetInvalid).some((error) => error.includes("revalidation/expiry")));
 });
 
-test("plan-doc execution audit contracts fix the 105-record historical inventory and fail-closed report", () => {
+test("plan-doc execution audit contracts fix the 107-record historical inventory and fail-closed report", () => {
   const scope = loadJson("contracts/documentation/plan-doc-execution-audit-scope.json");
   const scopeSchema = loadJson("contracts/documentation/plan-doc-execution-audit-scope.schema.json");
   const reportSchema = loadJson("contracts/documentation/plan-doc-execution-audit-report.schema.json");
   assert.equal(scope.schemaVersion, 2);
-  assert.equal(scope.historical.length, 105);
+  assert.equal(scope.historical.length, 107);
   assert.deepEqual(scope.repositories, ["AquilaXk/easysubway", "AquilaXk/easysubway-backend", "AquilaXk/easysubway-data", "AquilaXk/easysubway-mobile", "AquilaXk/easysubway-platform"]);
-  assert.equal(scope.self.issueNumber, 2947);
+  assert.equal(scope.self.issueNumber, 2949);
   assert.equal(scopeSchema.properties.historical.minItems, 1);
   assert.equal(scopeSchema.properties.historical.maxItems, undefined);
   assert.deepEqual(scopeSchema.properties.self.properties.issueNumber, { type: "integer", minimum: 1 });
   assert.equal(scopeSchema.properties.self.properties.allowedChangedFiles.minItems, 1);
   assert.equal(scopeSchema.properties.self.properties.allowedChangedFiles.maxItems, undefined);
   const recordsByIdentity = new Map(scope.historical.map((record) => [`${record.repository}:${record.prNumber}`, record]));
-  assert.equal(recordsByIdentity.size, 105);
-  assert.equal(new Set(scope.historical.map((record) => `${record.repository}:${record.mergeSha}`)).size, 105);
-  assert.deepEqual(scope.historical.slice(-3), [
+  assert.equal(recordsByIdentity.size, 107);
+  assert.equal(new Set(scope.historical.map((record) => `${record.repository}:${record.mergeSha}`)).size, 107);
+  assert.deepEqual(scope.historical.slice(-5), [
     { repository: "AquilaXk/easysubway", issueNumber: 2941, prNumber: 2942, mergeSha: "8dca544ec58bbcb38c6b3f4e1b3f131bf2e4afe9", relation: "CLOSES", planOwner: "PLAN-DOC", changedPathClass: "HUB_GOVERNANCE_ONLY", allowedChangedFiles: ["contracts/documentation/plan-doc-execution-audit-scope.json", "tools/ci/check-contracts.mjs", "tools/ci/check-contracts.test.mjs", "tools/repo/audit-plan-doc-execution.mjs", "tools/repo/audit-plan-doc-execution.test.mjs"] },
     { repository: "AquilaXk/easysubway-backend", issueNumber: 285, prNumber: 286, mergeSha: "f9343e38879d9e5bf42c9975dd8bc319df8ffbea", relation: "CLOSES", planOwner: "PLAN-DOC", changedPathClass: "TARGET_DOCUMENTATION_FRAGMENT", allowedChangedFiles: ["contracts/documentation/documentation-fragment.json"] },
     { repository: "AquilaXk/easysubway-mobile", issueNumber: 304, prNumber: 305, mergeSha: "69f556e3f0632d1242b24a47c5d9c28657dbd44c", relation: "CLOSES", planOwner: "PLAN-DOC", changedPathClass: "TARGET_DOCUMENTATION_FRAGMENT", allowedChangedFiles: ["contracts/documentation/documentation-fragment.json"] },
+    { repository: "AquilaXk/easysubway", issueNumber: 2947, prNumber: 2948, mergeSha: "360b27d22ca28103dcd7791e9ee8fd4ca3590e9c", relation: "CLOSES", planOwner: "PLAN-DOC", changedPathClass: "HUB_GOVERNANCE_ONLY", allowedChangedFiles: ["contracts/documentation/plan-doc-execution-audit-scope.json", "tools/ci/check-contracts.mjs", "tools/ci/check-contracts.test.mjs", "tools/repo/audit-plan-doc-execution.mjs", "tools/repo/audit-plan-doc-execution.test.mjs"] },
+    { repository: "AquilaXk/easysubway-data", issueNumber: 565, prNumber: 566, mergeSha: "6d3c5bd8bff60488642c82eb15be25273ea82707", relation: "CLOSES", planOwner: "PLAN-DOC", changedPathClass: "TARGET_DOCUMENTATION_FRAGMENT", allowedChangedFiles: ["contracts/documentation/documentation-fragment.json"] },
   ]);
   assert.deepEqual(recordsByIdentity.get("AquilaXk/easysubway:2887"), { repository: "AquilaXk/easysubway", issueNumber: 2886, prNumber: 2887, mergeSha: "995b4ae9913d1256e3933afe401d2a6c559588a3", relation: "CLOSES", planOwner: "PLAN-DOC", changedPathClass: "HUB_GOVERNANCE_ONLY", allowedChangedFiles: ["contracts/documentation/documentation-fragment.json", "contracts/documentation/plan-doc-execution-audit-scope.json", "tools/ci/check-contracts.mjs", "tools/ci/check-contracts.test.mjs", "tools/repo/audit-plan-doc-execution.mjs", "tools/repo/audit-plan-doc-execution.test.mjs"] });
   assert.deepEqual(recordsByIdentity.get("AquilaXk/easysubway-data:317"), { repository: "AquilaXk/easysubway-data", issueNumber: 316, prNumber: 317, mergeSha: "4f41584328518046d91312c3bcc78cd4ba40308c", relation: "CLOSES", planOwner: "PLAN-DOC", changedPathClass: "TARGET_DOCUMENTATION_FRAGMENT", allowedChangedFiles: ["contracts/documentation/documentation-fragment.json"] });

--- a/tools/repo/audit-plan-doc-execution.mjs
+++ b/tools/repo/audit-plan-doc-execution.mjs
@@ -13,17 +13,17 @@ const MAX_ITEMS = 3000;
 const execFileAsync = promisify(execFile);
 const CLOSING_ISSUES_QUERY = `query($owner: String!, $name: String!, $number: Int!) { repository(owner: $owner, name: $name) { pullRequest(number: $number) { number merged mergeCommit { oid } closingIssuesReferences(first: 100) { totalCount pageInfo { hasNextPage } nodes { number state repository { nameWithOwner } } } } } }`;
 const SELF_FILES = ["contracts/documentation/plan-doc-execution-audit-scope.json", "tools/ci/check-contracts.mjs", "tools/ci/check-contracts.test.mjs", "tools/repo/audit-plan-doc-execution.mjs", "tools/repo/audit-plan-doc-execution.test.mjs"];
-const EXPECTED_SCOPE_CANONICAL_SHA256 = "b8b29d880cb270a2d7f494da64e75280cf459e1f07726493c9b6d4ac768be5af";
+const EXPECTED_SCOPE_CANONICAL_SHA256 = "076dc2a5efaaf794465259482653b5b6dba668e0c3ad4d63daa97daf5c92d7d3";
 
 export class AuditIncomplete extends Error { constructor(code, identity) { super(code); this.code = code; this.identity = identity; } }
 
 export function validatePlanDocExecutionScope(scope, errors = []) {
   if (scope?.schemaVersion !== 2 || scope?.planOwner !== "PLAN-DOC" || JSON.stringify(scope?.repositories) !== JSON.stringify(REPOSITORIES)) errors.push("scope header mismatch");
   const records = scope?.historical;
-  if (!Array.isArray(records) || records.length !== 105) return [...errors, "historical inventory count mismatch"];
+  if (!Array.isArray(records) || records.length !== 107) return [...errors, "historical inventory count mismatch"];
   const key = (record, field) => `${record?.repository}:${record?.[field]}`;
-  if (new Set(records.map((record) => key(record, "prNumber"))).size !== 105) errors.push("duplicate historical record identity");
-  if (new Set(records.map((record) => key(record, "mergeSha"))).size !== 105) errors.push("duplicate historical merge identity");
+  if (new Set(records.map((record) => key(record, "prNumber"))).size !== 107) errors.push("duplicate historical record identity");
+  if (new Set(records.map((record) => key(record, "mergeSha"))).size !== 107) errors.push("duplicate historical merge identity");
   for (const record of records) {
     if (!REPOSITORIES.includes(record?.repository) || !Number.isInteger(record?.issueNumber) || !Number.isInteger(record?.prNumber) || !/^[0-9a-f]{40}$/.test(record?.mergeSha) || !["CLOSES", "COORDINATOR_FOLLOWUP"].includes(record?.relation) || record?.planOwner !== "PLAN-DOC" || !["HUB_GOVERNANCE_ONLY", "PLAN_DOC_CI_RECOVERY", "TARGET_DOCUMENTATION_FRAGMENT", "TARGET_PUBLIC_DOCUMENTATION"].includes(record?.changedPathClass) || !sortedUniquePaths(record?.allowedChangedFiles)) errors.push(`historical record malformed:${record?.repository}:${record?.prNumber}`);
   }
@@ -32,7 +32,7 @@ export function validatePlanDocExecutionScope(scope, errors = []) {
   const coordinator = records.find((record) => record.repository === "AquilaXk/easysubway" && record.prNumber === 2878);
   if (coordinator?.issueNumber !== 2729 || coordinator?.relation !== "COORDINATOR_FOLLOWUP") errors.push("coordinator relation binding mismatch");
   const self = scope?.self;
-  if (self?.repository !== "AquilaXk/easysubway" || self?.issueNumber !== 2947 || self?.planOwner !== "PLAN-DOC" || self?.changedPathClass !== "HUB_GOVERNANCE_ONLY" || JSON.stringify(self?.allowedChangedFiles) !== JSON.stringify(SELF_FILES)) errors.push("self binding mismatch");
+  if (self?.repository !== "AquilaXk/easysubway" || self?.issueNumber !== 2949 || self?.planOwner !== "PLAN-DOC" || self?.changedPathClass !== "HUB_GOVERNANCE_ONLY" || JSON.stringify(self?.allowedChangedFiles) !== JSON.stringify(SELF_FILES)) errors.push("self binding mismatch");
   if (sha256(JSON.stringify(scope)) !== EXPECTED_SCOPE_CANONICAL_SHA256) errors.push("historical frozen inventory mismatch");
   return errors;
 }

--- a/tools/repo/audit-plan-doc-execution.test.mjs
+++ b/tools/repo/audit-plan-doc-execution.test.mjs
@@ -16,11 +16,11 @@ function matchingLive(scope = SCOPE) {
   return { records: scope.historical.map(observed), self: { ...observed({ ...scope.self, prNumber: 9999, mergeSha: SHA, relation: "CLOSES" }), mergeSha: SHA } };
 }
 
-test("plan-doc execution audit scope fixes the federated 105-record inventory and self binding", () => {
+test("plan-doc execution audit scope fixes the federated 107-record inventory and self binding", () => {
   assert.equal(SCOPE.schemaVersion, 2);
-  assert.equal(SCOPE.historical.length, 105);
+  assert.equal(SCOPE.historical.length, 107);
   assert.deepEqual(SCOPE.repositories, ["AquilaXk/easysubway", "AquilaXk/easysubway-backend", "AquilaXk/easysubway-data", "AquilaXk/easysubway-mobile", "AquilaXk/easysubway-platform"]);
-  assert.equal(SCOPE.self.issueNumber, 2947);
+  assert.equal(SCOPE.self.issueNumber, 2949);
   for (const expected of [
     { repository: "AquilaXk/easysubway", issueNumber: 2886, prNumber: 2887, mergeSha: "995b4ae9913d1256e3933afe401d2a6c559588a3", relation: "CLOSES", planOwner: "PLAN-DOC", changedPathClass: "HUB_GOVERNANCE_ONLY", allowedChangedFiles: ["contracts/documentation/documentation-fragment.json", "contracts/documentation/plan-doc-execution-audit-scope.json", "tools/ci/check-contracts.mjs", "tools/ci/check-contracts.test.mjs", "tools/repo/audit-plan-doc-execution.mjs", "tools/repo/audit-plan-doc-execution.test.mjs"] },
     { repository: "AquilaXk/easysubway-data", issueNumber: 316, prNumber: 317, mergeSha: "4f41584328518046d91312c3bcc78cd4ba40308c", relation: "CLOSES", planOwner: "PLAN-DOC", changedPathClass: "TARGET_DOCUMENTATION_FRAGMENT", allowedChangedFiles: ["contracts/documentation/documentation-fragment.json"] },
@@ -47,12 +47,14 @@ test("plan-doc execution audit scope fixes the federated 105-record inventory an
     { repository: "AquilaXk/easysubway", issueNumber: 2918, prNumber: 2919, mergeSha: "d1d9e1c8ac79d2658b824c5a3b0b6db938d5769a", relation: "CLOSES", planOwner: "PLAN-DOC", changedPathClass: "HUB_GOVERNANCE_ONLY", allowedChangedFiles: ["contracts/documentation/plan-doc-execution-audit-scope.json", "tools/ci/check-contracts.mjs", "tools/ci/check-contracts.test.mjs", "tools/repo/audit-plan-doc-execution.mjs", "tools/repo/audit-plan-doc-execution.test.mjs"] },
     { repository: "AquilaXk/easysubway-data", issueNumber: 540, prNumber: 541, mergeSha: "2bdb04b771112dcce61368aebd2c970e1b04da39", relation: "CLOSES", planOwner: "PLAN-DOC", changedPathClass: "TARGET_DOCUMENTATION_FRAGMENT", allowedChangedFiles: ["contracts/documentation/documentation-fragment.json"] },
   ]) assert.deepEqual(SCOPE.historical.find((record) => record.repository === expected.repository && record.prNumber === expected.prNumber), expected);
-  assert.equal(new Set(SCOPE.historical.map((record) => `${record.repository}:${record.prNumber}`)).size, 105);
-  assert.equal(new Set(SCOPE.historical.map((record) => `${record.repository}:${record.mergeSha}`)).size, 105);
-  assert.deepEqual(SCOPE.historical.slice(-3), [
+  assert.equal(new Set(SCOPE.historical.map((record) => `${record.repository}:${record.prNumber}`)).size, 107);
+  assert.equal(new Set(SCOPE.historical.map((record) => `${record.repository}:${record.mergeSha}`)).size, 107);
+  assert.deepEqual(SCOPE.historical.slice(-5), [
     { repository: "AquilaXk/easysubway", issueNumber: 2941, prNumber: 2942, mergeSha: "8dca544ec58bbcb38c6b3f4e1b3f131bf2e4afe9", relation: "CLOSES", planOwner: "PLAN-DOC", changedPathClass: "HUB_GOVERNANCE_ONLY", allowedChangedFiles: ["contracts/documentation/plan-doc-execution-audit-scope.json", "tools/ci/check-contracts.mjs", "tools/ci/check-contracts.test.mjs", "tools/repo/audit-plan-doc-execution.mjs", "tools/repo/audit-plan-doc-execution.test.mjs"] },
     { repository: "AquilaXk/easysubway-backend", issueNumber: 285, prNumber: 286, mergeSha: "f9343e38879d9e5bf42c9975dd8bc319df8ffbea", relation: "CLOSES", planOwner: "PLAN-DOC", changedPathClass: "TARGET_DOCUMENTATION_FRAGMENT", allowedChangedFiles: ["contracts/documentation/documentation-fragment.json"] },
     { repository: "AquilaXk/easysubway-mobile", issueNumber: 304, prNumber: 305, mergeSha: "69f556e3f0632d1242b24a47c5d9c28657dbd44c", relation: "CLOSES", planOwner: "PLAN-DOC", changedPathClass: "TARGET_DOCUMENTATION_FRAGMENT", allowedChangedFiles: ["contracts/documentation/documentation-fragment.json"] },
+    { repository: "AquilaXk/easysubway", issueNumber: 2947, prNumber: 2948, mergeSha: "360b27d22ca28103dcd7791e9ee8fd4ca3590e9c", relation: "CLOSES", planOwner: "PLAN-DOC", changedPathClass: "HUB_GOVERNANCE_ONLY", allowedChangedFiles: ["contracts/documentation/plan-doc-execution-audit-scope.json", "tools/ci/check-contracts.mjs", "tools/ci/check-contracts.test.mjs", "tools/repo/audit-plan-doc-execution.mjs", "tools/repo/audit-plan-doc-execution.test.mjs"] },
+    { repository: "AquilaXk/easysubway-data", issueNumber: 565, prNumber: 566, mergeSha: "6d3c5bd8bff60488642c82eb15be25273ea82707", relation: "CLOSES", planOwner: "PLAN-DOC", changedPathClass: "TARGET_DOCUMENTATION_FRAGMENT", allowedChangedFiles: ["contracts/documentation/documentation-fragment.json"] },
   ]);
   assert.equal(SCOPE.historical.some((record) => record.repository === "AquilaXk/easysubway" && record.issueNumber === 2890 && record.prNumber === 2891), false);
   assert.equal(SCOPE.historical.some((record) => record.repository === "AquilaXk/easysubway" && record.issueNumber === 2731 && record.prNumber === 2893), false);
@@ -68,7 +70,7 @@ test("plan-doc execution audit scope fixes the federated 105-record inventory an
   assert.deepEqual(byIdentity.get("AquilaXk/easysubway-backend:248").allowedChangedFiles, ["contracts/documentation/documentation-fragment.json"]);
   assert.deepEqual(validatePlanDocExecutionScope(SCOPE), []);
   const finalReport = createPlanDocExecutionReport({ scope: SCOPE, scopeText: JSON.stringify(SCOPE), sourceSha: SHA, observedAt: OBSERVED_AT, live: matchingLive() });
-  assert.deepEqual([finalReport.status, finalReport.summary.records, finalReport.summary.findings, finalReport.summary.incomplete], ["COMPLETE", 106, 0, 0]);
+  assert.deepEqual([finalReport.status, finalReport.summary.records, finalReport.summary.findings, finalReport.summary.incomplete], ["COMPLETE", 108, 0, 0]);
   const invalid = structuredClone(SCOPE); invalid.historical[0].allowedChangedFiles.reverse();
   assert.ok(validatePlanDocExecutionScope(invalid).length > 0);
 });


### PR DESCRIPTION
Closes #2949

## 변경

- Existing D33 historical 105의 bytes/order를 보존했습니다.
- Prior self Hub #2947 / PR #2948 / merge `360b27d22ca28103dcd7791e9ee8fd4ca3590e9c`를 exact five-file `HUB_GOVERNANCE_ONLY` record로 append했습니다.
- Data #565 / PR #566 / merge `6d3c5bd8bff60488642c82eb15be25273ea82707`을 one-file `TARGET_DOCUMENTATION_FRAGMENT` record로 append했습니다.
- Self binding을 #2949로 전진시키고 deterministic validator/canonical digest/test를 historical `107`, merged-head report records `108`에 맞췄습니다.

## 범위

변경은 D33 canonical five-file allowlist에만 한정됩니다. Fragment/source/runtime/workflow/release/artifact/provider/deploy/Kubernetes, D13/D20/D22/D35, #2748 body sync와 foreign issue/PR/worktree는 변경하지 않습니다. Contract-required named constant 외 운영값 하드코딩과 stale/previous/local/legacy fallback은 없습니다.

## 검증

- RED: auditor named test `105 !== 107`
- RED: contract named test `105 !== 107`
- GREEN: auditor named test `1/1` PASS
- GREEN: contract named test `1/1` PASS
- `node tools/ci/check-contracts.mjs --workspace contracts/workspaces/hub.json --current-only --local-contracts-only` PASS
- Historical prefix 105 deep equality, exact ordered append 2, self #2949, PR/merge identities `107/107` PASS
- Exact five-file diff, `git diff --check` PASS
- Scope raw SHA-256 `0fd6ba4c2bdf084014cef4bcaac8ad97ead3ea680bab5c47cd485642d85162bf`; canonical object SHA-256 `076dc2a5efaaf794465259482653b5b6dba668e0c3ad4d63daa97daf5c92d7d3`
- Independent pre-commit P0–P2 review finding `0`

Current-head required Hub CI와 external Sonar를 먼저 확인한 뒤 supported R3 discovery Review 한 번, blocking finding/thread `0`, PLAN-DOC exact-head squash로 delivery합니다. Merge 뒤 같은 Hub SHA의 D33 `108/107/1`과 Documentation Inventory D01–D05 zero proof를 확인합니다.
