### PR TITLE
[Docs] 최종 영문 제품 README 반영

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,79 +1,74 @@
 <div align="center">
 
-<!-- TODO: 앱 완성 후 로고/배너 이미지 첨부 -->
-<!-- <img alt="쉬운 지하철" src="docs/assets/banner.png" width="600" /> -->
+<!-- Add the final verified logo or banner asset here. -->
 
-# 쉬운 지하철
+# Easy Subway
 
-## 빠른 길보다, 갈 수 있는 길.
+## A route you can take matters more than one that is simply fast.
 
-계단 하나가 누군가에게는 벽이 됩니다.
-<br>쉬운 지하철은 질문을 바꿉니다.
-<br>**"얼마나 빨리"가 아니라, "갈 수 있는가".**
+One staircase can turn into a wall.
+<br>Easy Subway asks a better question:
+<br>**not just “How fast?” but “Can I get there?”**
 
 <br>
 
 [![CI](https://github.com/AquilaXk/easysubway/actions/workflows/ci.yml/badge.svg)](https://github.com/AquilaXk/easysubway/actions/workflows/ci.yml)
 ![Flutter](https://img.shields.io/badge/Flutter-02569B?logo=flutter&logoColor=white)
 ![Android](https://img.shields.io/badge/Android-3DDC84?logo=android&logoColor=white)
+![iOS](https://img.shields.io/badge/iOS-000000?logo=apple&logoColor=white)
 
 </div>
 
 <br>
 
-## 지하에서도, 지도와 역 정보는.
+## Underground, your map and station search stay with you.
 
-노선도와 역 검색은 기기에 담아, 신호가 약한 곳에서도 확인합니다.
+Route maps and the station catalog are stored on your device, so you can still explore the network and find a station when the signal is weak.
 
-## 길찾기는 출시 기준을 지킵니다.
+## Nationwide journeys, with accessibility first.
 
-길찾기는 Journey V3 서버가 맡습니다. 필요한 데이터와 안전성 근거가 모두 확인될 때까지는 제공하지 않습니다.
+Journey V3 calculates routes on the server across South Korea’s subway, metropolitan rail, airport rail, GTX, and light-rail networks.
 
-## 당신의 상황이 곧 기준.
+It looks for a route you can use—not simply the shortest one—and never turns offline data or an older route engine into a substitute result.
 
-휠체어. 유모차. 불편한 걸음. 당신을 고르는 순간, 길이 달라집니다. 계단 없는 길이 먼저 옵니다.
+## Every ITX service, in the right place.
 
-## 아는 것과 모르는 것을 구분합니다.
+Easy Subway includes ITX-Cheongchun in Journey V3 route guidance, with train search for ITX-Maum and ITX-Saemaeul.
 
-모든 정보에 출처와 확인한 날짜가 붙습니다. 그리고 모르는 건, 모른다고 말합니다.
+## Your situation changes the route.
 
-## 신고는 가입 없이.
+A wheelchair, a stroller, or a difficult walk can change what a good trip looks like. Easy Subway puts accessible options first and explains clearly when the information is unknown.
 
-엘리베이터가 멈췄다면 바로 알려주세요. 계정도 이름도 필요 없습니다. 접수 번호 하나면 충분합니다.
+## Know what is known.
 
-## 당신을 따라다니지 않습니다.
+Station and accessibility information shows where it came from and when it was checked. If something is not known, the app says so.
 
-계정 없음. 추적 없음. 개인정보 판매 없음. 당신이 저장한 즐겨찾기는 당신의 기기에만 남습니다.
+## Report a problem without signing up.
+
+If a lift or another station facility is not working, you can report it without creating an account or providing your name.
+
+## Privacy without surprises.
+
+There is no account, user tracking, or sale of personal information. Favorites you save stay on your device.
 
 <br>
 
-## 스크린샷
+## Screenshots
 
-<!-- TODO: 앱 완성 후 스크린샷 첨부 -->
-<!--
-<p align="center">
-  <img src="docs/assets/screenshot-route-map.png" width="240" />
-  <img src="docs/assets/screenshot-route-search.png" width="240" />
-  <img src="docs/assets/screenshot-station-detail.png" width="240" />
-</p>
--->
+<!-- Add verified final product screenshots here. -->
 
-> 앱 화면이 확정되는 대로 추가합니다.
+> Final product screenshots will be added here when the verified assets are published.
 
-## 지금은
+## Available on Android and iOS
 
-상록수·사당의 접근성 정보를 먼저 검증하고 있으며, 경춘선 ITX-청춘 길찾기의 출시 근거를 준비하고 있습니다. 현재 출시 결정은 NO_GO입니다.
+Easy Subway is available for both Android and iOS. The release decision for this version is **GO**.
 
-## 다운로드
-
-현재 다운로드는 제공하지 않습니다. Android와 iOS 출시 기준을 준비하고 있습니다.
-
-출시 소식과 문의는 [Issues](https://github.com/AquilaXk/easysubway/issues)에서.
+For questions, feedback, or facility reports that need follow-up, visit [GitHub Issues](https://github.com/AquilaXk/easysubway/issues).
 
 ---
 
 <div align="center">
 
-*계단 앞에서 막막했던 모든 순간을 위해.*
+*For every journey that should not end at the stairs.*
 
 </div>


### PR DESCRIPTION
## 요약

- 기존 README의 hero, tagline, badge, feature, availability, contact 흐름을 유지했습니다.
- 한국어 핵심 문구를 의미와 감정을 살린 conversational English로 옮겼습니다.
- 전국 도시철도 Journey V3, Android/iOS, ITX-Cheongchun route guidance와 ITX-Maum/ITX-Saemaeul train search라는 최종 제품 범위를 반영했습니다.
- 초기 pilot/진행 중 표현과 검증되지 않은 URL·asset은 넣지 않았습니다.

## 검증

- exact one-file diff: `README.md`
- `git diff --check`: PASS
- relative link/asset 누락: 0
- 한국어 및 pilot/current-progress token: 0
- current claim gate: 예상된 release-gate RED — 현재 catalog `NO_GO`와 final-state README `GO` 불일치

## Release gate

이 PR은 모든 계획 이슈가 terminal인 최종 공개본을 미리 준비한 Draft입니다. #1020의 same-RC `GO`와 five-repository current evidence가 같은 release identity로 수렴하기 전에는 Ready/Review/merge하지 않습니다. 현재 gate를 약화하거나 `GO` 문구를 임시 상태로 되돌리지 않습니다.

Closes #2951
