### PR TITLE
[Fix] Replace rebuild parity with candidate identity validation

### DIFF
--- a/.github/workflows/datapack-promotion.yml
+++ b/.github/workflows/datapack-promotion.yml
@@ -7,14 +7,6 @@ on:
         description: Successful Data Pack Release candidate run ID
         required: true
         type: string
-      rebuildCandidateRunId2:
-        description: Second successful Data Pack Release candidate run ID
-        required: true
-        type: string
-      rebuildCandidateRunId3:
-        description: Third successful Data Pack Release candidate run ID
-        required: true
-        type: string
       compatibilityEvidenceRunId:
         description: Workflow run ID containing compatibility evidence
         required: true
@@ -55,54 +47,40 @@ jobs:
       - name: Data Pack Promotion / Validate candidate producer runs
         env:
           CANDIDATE_RUN_ID: ${{ inputs.candidateRunId }}
-          REBUILD_CANDIDATE_RUN_ID_2: ${{ inputs.rebuildCandidateRunId2 }}
-          REBUILD_CANDIDATE_RUN_ID_3: ${{ inputs.rebuildCandidateRunId3 }}
           EASYSUBWAY_DATA_ARTIFACT_READ_TOKEN: ${{ secrets.EASYSUBWAY_DATA_ARTIFACT_READ_TOKEN }}
         run: |
           set -euo pipefail
           data_repository="AquilaXk/easysubway-data"
-          run_ids=("${CANDIDATE_RUN_ID}" "${REBUILD_CANDIDATE_RUN_ID_2}" "${REBUILD_CANDIDATE_RUN_ID_3}")
-          if [[ "${run_ids[0]}" == "${run_ids[1]}" || "${run_ids[0]}" == "${run_ids[2]}" || "${run_ids[1]}" == "${run_ids[2]}" ]]; then
-            echo "candidate run IDs must be distinct" >&2
+          if [[ ! "${CANDIDATE_RUN_ID}" =~ ^[1-9][0-9]*$ ]]; then
+            echo "candidate run ID must be a positive decimal" >&2
             exit 1
           fi
-          for index in "${!run_ids[@]}"; do
-            candidate_run_id="${run_ids[index]}"
-            if [[ ! "${candidate_run_id}" =~ ^[1-9][0-9]*$ ]]; then
-              echo "candidate run IDs must be distinct positive decimals" >&2
-              exit 1
-            fi
-            candidate_metadata="$(GH_TOKEN="${EASYSUBWAY_DATA_ARTIFACT_READ_TOKEN}" gh api "repos/${data_repository}/actions/runs/${candidate_run_id}" --jq '[.id, .conclusion, .repository.full_name, .head_repository.full_name, .event, .head_sha, .path] | @tsv')"
-            IFS=$'\t' read -r actual_run_id conclusion repository head_repository event head_sha workflow_path_raw <<< "${candidate_metadata}"
-            workflow_path="${workflow_path_raw%@*}"
-            if [[ "${actual_run_id}" != "${candidate_run_id}" || "${conclusion}" != "success" \
-              || "${repository}" != "${data_repository}" || "${head_repository}" != "${data_repository}" \
-              || "${event}" != "workflow_dispatch" || ! "${head_sha}" =~ ^[a-f0-9]{40}$ \
-              || "${workflow_path}" != ".github/workflows/datapack-release.yml" ]]; then
-              echo "candidate runs must be successful easysubway-data workflow_dispatch Data Pack Release runs" >&2
-              exit 1
-            fi
-            echo "CANDIDATE_$((index + 1))_HEAD_SHA=${head_sha}" >> "${GITHUB_ENV}"
-          done
+          candidate_metadata="$(GH_TOKEN="${EASYSUBWAY_DATA_ARTIFACT_READ_TOKEN}" gh api "repos/${data_repository}/actions/runs/${CANDIDATE_RUN_ID}" --jq '[.id, .conclusion, .repository.full_name, .head_repository.full_name, .event, .head_sha, .path] | @tsv')"
+          IFS=$'\t' read -r actual_run_id conclusion repository head_repository event head_sha workflow_path_raw <<< "${candidate_metadata}"
+          workflow_path="${workflow_path_raw%@*}"
+          if [[ "${actual_run_id}" != "${CANDIDATE_RUN_ID}" || "${conclusion}" != "success" \
+            || "${repository}" != "${data_repository}" || "${head_repository}" != "${data_repository}" \
+            || "${event}" != "workflow_dispatch" || ! "${head_sha}" =~ ^[a-f0-9]{40}$ \
+            || "${workflow_path}" != ".github/workflows/datapack-release.yml" ]]; then
+            echo "candidate must be a successful easysubway-data workflow_dispatch Data Pack Release run" >&2
+            exit 1
+          fi
+          echo "CANDIDATE_HEAD_SHA=${head_sha}" >> "${GITHUB_ENV}"
 
       - name: Data Pack Promotion / Validate candidate artifact metadata
         env:
           CANDIDATE_RUN_ID: ${{ inputs.candidateRunId }}
-          REBUILD_CANDIDATE_RUN_ID_2: ${{ inputs.rebuildCandidateRunId2 }}
-          REBUILD_CANDIDATE_RUN_ID_3: ${{ inputs.rebuildCandidateRunId3 }}
           EASYSUBWAY_DATA_ARTIFACT_READ_TOKEN: ${{ secrets.EASYSUBWAY_DATA_ARTIFACT_READ_TOKEN }}
         run: |
           set -euo pipefail
           data_repository="AquilaXk/easysubway-data"
-          run_ids=("${CANDIDATE_RUN_ID}" "${REBUILD_CANDIDATE_RUN_ID_2}" "${REBUILD_CANDIDATE_RUN_ID_3}")
-          head_shas=("${CANDIDATE_1_HEAD_SHA}" "${CANDIDATE_2_HEAD_SHA}" "${CANDIDATE_3_HEAD_SHA}")
-          for index in "${!run_ids[@]}"; do
-            candidate_run_id="${run_ids[index]}"
-            candidate_artifacts="${RUNNER_TEMP}/candidate-$((index + 1))-artifacts.json"
-            candidate_artifact_name="easysubway-datapack-candidate-${candidate_run_id}"
-            GH_TOKEN="${EASYSUBWAY_DATA_ARTIFACT_READ_TOKEN}" gh api "repos/${data_repository}/actions/runs/${candidate_run_id}/artifacts?name=${candidate_artifact_name}&per_page=100" > "${candidate_artifacts}"
+          for artifact_name in \
+            "easysubway-datapack-candidate-${CANDIDATE_RUN_ID}" \
+            "easysubway-datapack-candidate-execution-evidence-${CANDIDATE_RUN_ID}"; do
+            candidate_artifacts="${RUNNER_TEMP}/${artifact_name}-artifacts.json"
+            GH_TOKEN="${EASYSUBWAY_DATA_ARTIFACT_READ_TOKEN}" gh api "repos/${data_repository}/actions/runs/${CANDIDATE_RUN_ID}/artifacts?name=${artifact_name}&per_page=100" > "${candidate_artifacts}"
             node tools/ci/require-workflow-artifact.mjs \
-              "${candidate_artifacts}" "${candidate_artifact_name}" "${candidate_run_id}" "${head_shas[index]}"
+              "${candidate_artifacts}" "${artifact_name}" "${CANDIDATE_RUN_ID}" "${CANDIDATE_HEAD_SHA}"
           done
 
       - name: Data Pack Promotion / Download selected candidate artifact
@@ -110,26 +88,17 @@ jobs:
         with:
           repository: AquilaXk/easysubway-data
           name: easysubway-datapack-candidate-${{ inputs.candidateRunId }}
-          path: ${{ runner.temp }}/candidate-1
+          path: ${{ runner.temp }}/candidate
           run-id: ${{ inputs.candidateRunId }}
           github-token: ${{ secrets.EASYSUBWAY_DATA_ARTIFACT_READ_TOKEN }}
 
-      - name: Data Pack Promotion / Download second rebuild candidate artifact
+      - name: Data Pack Promotion / Download candidate execution evidence
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           repository: AquilaXk/easysubway-data
-          name: easysubway-datapack-candidate-${{ inputs.rebuildCandidateRunId2 }}
-          path: ${{ runner.temp }}/candidate-2
-          run-id: ${{ inputs.rebuildCandidateRunId2 }}
-          github-token: ${{ secrets.EASYSUBWAY_DATA_ARTIFACT_READ_TOKEN }}
-
-      - name: Data Pack Promotion / Download third rebuild candidate artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
-        with:
-          repository: AquilaXk/easysubway-data
-          name: easysubway-datapack-candidate-${{ inputs.rebuildCandidateRunId3 }}
-          path: ${{ runner.temp }}/candidate-3
-          run-id: ${{ inputs.rebuildCandidateRunId3 }}
+          name: easysubway-datapack-candidate-execution-evidence-${{ inputs.candidateRunId }}
+          path: ${{ runner.temp }}/candidate-execution-evidence
+          run-id: ${{ inputs.candidateRunId }}
           github-token: ${{ secrets.EASYSUBWAY_DATA_ARTIFACT_READ_TOKEN }}
 
       - name: Data Pack Promotion / Validate compatibility evidence artifact
@@ -185,45 +154,34 @@ jobs:
         env:
           ISSUE_REF: ${{ inputs.issueRef }}
           CANDIDATE_RUN_ID: ${{ inputs.candidateRunId }}
-          REBUILD_CANDIDATE_RUN_ID_2: ${{ inputs.rebuildCandidateRunId2 }}
-          REBUILD_CANDIDATE_RUN_ID_3: ${{ inputs.rebuildCandidateRunId3 }}
           EASYSUBWAY_DATAPACK_SIGNING_PUBLIC_KEY_PEM: ${{ secrets.EASYSUBWAY_DATAPACK_SIGNING_PUBLIC_KEY_PEM }}
           EASYSUBWAY_DATAPACK_SIGNING_KEY_ID: ${{ secrets.EASYSUBWAY_DATAPACK_SIGNING_KEY_ID }}
         run: |
           set -euo pipefail
           promotion_request="${RUNNER_TEMP}/promotion-request.json"
-          rebuild_parity_evidence="${RUNNER_TEMP}/rebuild-parity-evidence.json"
           node tools/release/build-promotion-request.mjs \
-            --candidate-root-1 "${RUNNER_TEMP}/candidate-1" \
-            --candidate-root-2 "${RUNNER_TEMP}/candidate-2" \
-            --candidate-root-3 "${RUNNER_TEMP}/candidate-3" \
-            --candidate-workflow-run-id-1 "${CANDIDATE_RUN_ID}" \
-            --candidate-workflow-run-id-2 "${REBUILD_CANDIDATE_RUN_ID_2}" \
-            --candidate-workflow-run-id-3 "${REBUILD_CANDIDATE_RUN_ID_3}" \
-            --candidate-head-sha-1 "${CANDIDATE_1_HEAD_SHA}" \
-            --candidate-head-sha-2 "${CANDIDATE_2_HEAD_SHA}" \
-            --candidate-head-sha-3 "${CANDIDATE_3_HEAD_SHA}" \
-            --selected-candidate-workflow-run-id "${CANDIDATE_RUN_ID}" \
+            --candidate-root "${RUNNER_TEMP}/candidate" \
+            --candidate-workflow-run-id "${CANDIDATE_RUN_ID}" \
+            --candidate-head-sha "${CANDIDATE_HEAD_SHA}" \
+            --candidate-execution-evidence-root "${RUNNER_TEMP}/candidate-execution-evidence" \
             --compatibility-evidence "${RUNNER_TEMP}/compatibility/compatibility-evidence.json" \
             --requested-by "${GITHUB_ACTOR}" \
             --approval-evidence "${RUNNER_TEMP}/promotion-approvals.json" \
             --workflow-run-id "${GITHUB_RUN_ID}" \
             --issue-ref "${ISSUE_REF}" \
-            --rebuild-parity-evidence-output "${rebuild_parity_evidence}" \
             --output "${promotion_request}"
           node tools/release/validate-promotion-request.mjs \
             --request "${promotion_request}" \
-            --component "${RUNNER_TEMP}/candidate-1/data-component-manifest.json" \
-            --inventory "${RUNNER_TEMP}/candidate-1/data-artifact-inventory.json" \
+            --component "${RUNNER_TEMP}/candidate/data-component-manifest.json" \
+            --inventory "${RUNNER_TEMP}/candidate/data-artifact-inventory.json" \
             --compatibility-evidence "${RUNNER_TEMP}/compatibility/compatibility-evidence.json" \
-            --rebuild-parity-evidence "${rebuild_parity_evidence}" \
+            --candidate-execution-evidence-root "${RUNNER_TEMP}/candidate-execution-evidence" \
             --approval-evidence "${RUNNER_TEMP}/promotion-approvals.json" \
             --workflow-run-id "${GITHUB_RUN_ID}"
           mkdir -p "${RUNNER_TEMP}/promotion-artifact"
           cp "${promotion_request}" "${RUNNER_TEMP}/promotion-artifact/promotion-request.json"
           cp "${RUNNER_TEMP}/promotion-approvals.json" "${RUNNER_TEMP}/promotion-artifact/promotion-approvals.json"
           cp "${RUNNER_TEMP}/compatibility/compatibility-evidence.json" "${RUNNER_TEMP}/promotion-artifact/compatibility-evidence.json"
-          cp "${rebuild_parity_evidence}" "${RUNNER_TEMP}/promotion-artifact/rebuild-parity-evidence.json"
 
       - name: Data Pack Promotion / Attest promotion request
         uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d
@@ -238,6 +196,5 @@ jobs:
             ${{ runner.temp }}/promotion-artifact/promotion-request.json
             ${{ runner.temp }}/promotion-artifact/promotion-approvals.json
             ${{ runner.temp }}/promotion-artifact/compatibility-evidence.json
-            ${{ runner.temp }}/promotion-artifact/rebuild-parity-evidence.json
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/datapack-release.yml
+++ b/.github/workflows/datapack-release.yml
@@ -493,9 +493,12 @@ jobs:
         run: |
           set -euo pipefail
           data_repository="AquilaXk/easysubway-data"
-          artifact_name="easysubway-datapack-candidate-${EASYSUBWAY_DATAPACK_CANDIDATE_RUN_ID}"
-          gh api "repos/${data_repository}/actions/runs/${EASYSUBWAY_DATAPACK_CANDIDATE_RUN_ID}/artifacts?name=${artifact_name}&per_page=100" > "${RUNNER_TEMP}/${artifact_name}.json"
-          node tools/ci/require-workflow-artifact.mjs "${RUNNER_TEMP}/${artifact_name}.json" "${artifact_name}" "${EASYSUBWAY_DATAPACK_CANDIDATE_RUN_ID}" "${CANDIDATE_HEAD_SHA}"
+          for artifact_name in \
+            "easysubway-datapack-candidate-${EASYSUBWAY_DATAPACK_CANDIDATE_RUN_ID}" \
+            "easysubway-datapack-candidate-execution-evidence-${EASYSUBWAY_DATAPACK_CANDIDATE_RUN_ID}"; do
+            gh api "repos/${data_repository}/actions/runs/${EASYSUBWAY_DATAPACK_CANDIDATE_RUN_ID}/artifacts?name=${artifact_name}&per_page=100" > "${RUNNER_TEMP}/${artifact_name}.json"
+            node tools/ci/require-workflow-artifact.mjs "${RUNNER_TEMP}/${artifact_name}.json" "${artifact_name}" "${EASYSUBWAY_DATAPACK_CANDIDATE_RUN_ID}" "${CANDIDATE_HEAD_SHA}"
+          done
 
       - name: Data Pack Release / Validate production promotion artifact metadata
         if: ${{ steps.release-mode.outputs.mode == 'production-publish' }}
@@ -524,6 +527,16 @@ jobs:
           run-id: ${{ steps.release-mode.outputs.promotion_run_id }}
           github-token: ${{ github.token }}
 
+      - name: Data Pack Release / Download exact candidate execution evidence
+        if: ${{ steps.release-mode.outputs.mode == 'production-publish' }}
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: easysubway-datapack-candidate-execution-evidence-${{ steps.release-mode.outputs.candidate_run_id }}
+          path: ${{ runner.temp }}/downloaded-candidate-execution-evidence
+          run-id: ${{ steps.release-mode.outputs.candidate_run_id }}
+          repository: AquilaXk/easysubway-data
+          github-token: ${{ secrets.EASYSUBWAY_DATA_ARTIFACT_READ_TOKEN }}
+
       - name: Data Pack Release / Verify attested promotion and candidate bytes
         if: ${{ steps.release-mode.outputs.mode == 'production-publish' }}
         run: |
@@ -532,18 +545,18 @@ jobs:
           promotion_root="${RUNNER_TEMP}/downloaded-promotion"
           shopt -s dotglob nullglob
           promotion_entries=("${promotion_root}"/*)
-          if [[ "${#promotion_entries[@]}" -ne 4 ]]; then
-            echo "production promotion artifact must contain exactly four files" >&2
+          if [[ "${#promotion_entries[@]}" -ne 3 ]]; then
+            echo "production promotion artifact must contain exactly three files" >&2
             exit 1
           fi
-          for name in promotion-request.json promotion-approvals.json compatibility-evidence.json rebuild-parity-evidence.json; do
+          for name in promotion-request.json promotion-approvals.json compatibility-evidence.json; do
             if ! [[ -f "${promotion_root}/${name}" && ! -L "${promotion_root}/${name}" && -s "${promotion_root}/${name}" ]]; then
               echo "production promotion artifact has an invalid required file: ${name}" >&2
               exit 1
             fi
           done
           gh attestation verify "${promotion_root}/promotion-request.json" --repo "${GITHUB_REPOSITORY}" --signer-workflow "AquilaXk/easysubway/.github/workflows/datapack-promotion.yml" --source-ref refs/heads/main --deny-self-hosted-runners
-          node tools/release/validate-promotion-request.mjs --request "${promotion_root}/promotion-request.json" --component "${candidate_root}/data-component-manifest.json" --inventory "${candidate_root}/data-artifact-inventory.json" --compatibility-evidence "${promotion_root}/compatibility-evidence.json" --approval-evidence "${promotion_root}/promotion-approvals.json" --rebuild-parity-evidence "${promotion_root}/rebuild-parity-evidence.json" --workflow-run-id "${EASYSUBWAY_DATAPACK_PROMOTION_RUN_ID}"
+          node tools/release/validate-promotion-request.mjs --request "${promotion_root}/promotion-request.json" --component "${candidate_root}/data-component-manifest.json" --inventory "${candidate_root}/data-artifact-inventory.json" --compatibility-evidence "${promotion_root}/compatibility-evidence.json" --approval-evidence "${promotion_root}/promotion-approvals.json" --candidate-execution-evidence-root "${RUNNER_TEMP}/downloaded-candidate-execution-evidence" --workflow-run-id "${EASYSUBWAY_DATAPACK_PROMOTION_RUN_ID}"
 
       - name: Data Pack Release / Stage verified candidate artifact
         if: ${{ steps.release-mode.outputs.mode == 'production-publish' }}

--- a/contracts/release/system-release-governance-inventory.json
+++ b/contracts/release/system-release-governance-inventory.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": ".github/workflows/datapack-release.yml",
-      "sha256": "3dd72521068b18db84a4e752d29a24cb8dc8e86a700a8defec82c4fb21e3839f"
+      "sha256": "fab243b1195ad872b45b2a6bad368474c8dd4f4130810a862f5c068831c68738"
     },
     {
       "path": ".github/workflows/release-artifacts.yml",

--- a/tools/ci/datapack-release-workflow.test.mjs
+++ b/tools/ci/datapack-release-workflow.test.mjs
@@ -549,7 +549,7 @@ test("expiry alert는 publish 없이 같은 decision engine을 소비한다", ()
   assert.doesNotMatch(expiryWorkflow, /productionWriteAllowed == 'true'/);
 });
 
-test("candidate promotion은 정확한 성공 후보와 compatibility 증거를 검증하고 request만 attest한다", () => {
+test("candidate promotion은 정확한 단일 성공 후보와 compatibility 증거를 검증하고 v2 request만 attest한다", () => {
   const promotion = readFileSync(path.join(root, ".github/workflows/datapack-promotion.yml"), "utf8");
   const releaseArtifacts = readFileSync(path.join(root, ".github/workflows/release-artifacts.yml"), "utf8");
   const promotionBuilder = readFileSync(path.join(root, "tools/release/build-promotion-request.mjs"), "utf8");
@@ -559,7 +559,6 @@ test("candidate promotion은 정확한 성공 후보와 compatibility 증거를 
 
   assert.deepEqual([...workflowDispatchInputNames(promotion)].sort(), [
     "candidateRunId", "compatibilityEvidenceArtifactName", "compatibilityEvidenceRunId", "issueRef",
-    "rebuildCandidateRunId2", "rebuildCandidateRunId3",
   ]);
   const permissionBlock = promotion.match(/permissions:\n([\s\S]*?)\n {4}environment:/)?.[1];
   assert.ok(permissionBlock, "promotion permissions 블록을 찾지 못함");
@@ -570,7 +569,7 @@ test("candidate promotion은 정확한 성공 후보와 compatibility 증거를 
     contents: "read", actions: "read", "id-token": "write", attestations: "write",
   });
   assert.match(promotion, /data_repository="AquilaXk\/easysubway-data"/);
-  assert.match(promotion, /repos\/\$\{data_repository\}\/actions\/runs\/\$\{candidate_run_id\}/);
+  assert.match(promotion, /repos\/\$\{data_repository\}\/actions\/runs\/\$\{CANDIDATE_RUN_ID\}/);
   assert.match(promotion, /repository}" != "\$\{data_repository\}"/);
   assert.match(promotion, /head_repository}" != "\$\{data_repository\}"/);
   assert.match(promotion, /\.github\/workflows\/datapack-release\.yml/);
@@ -597,16 +596,10 @@ test("candidate promotion은 정확한 성공 후보와 compatibility 증거를 
   assert.match(promotion, /data-artifact-inventory\.json/);
   assert.match(promotion, /EASYSUBWAY_DATA_ARTIFACT_READ_TOKEN/);
   assert.match(promotion, /repository: AquilaXk\/easysubway-data/);
-  for (const candidate of ["candidateRunId", "rebuildCandidateRunId2", "rebuildCandidateRunId3"]) {
-    assert.match(promotion, new RegExp(`run-id: \\$\\{\\{ inputs\\.${candidate} \\}\\}`));
-  }
-  assert.match(promotion, /candidate-1/);
-  assert.match(promotion, /candidate-2/);
-  assert.match(promotion, /candidate-3/);
-  assert.match(promotion, /rebuild-parity-evidence\.json/);
-  assert.match(promotion, /--rebuild-parity-evidence-output/);
-  assert.match(promotion, /--rebuild-parity-evidence\s/);
-  assert.match(promotionBuilder, /rebuildParityEvidenceSha256/);
+  assert.match(promotion, /run-id: \$\{\{ inputs\.candidateRunId \}\}/);
+  assert.match(promotion, /candidate/);
+  assert.doesNotMatch(promotion, /rebuildCandidateRunId|candidate-[123]|rebuild-parity-evidence/);
+  assert.doesNotMatch(promotionBuilder, /rebuildParityEvidenceSha256|rebuild-parity/);
   assert.doesNotMatch(promotion, /repository: \$\{\{ github\.repository \}\}/);
   assert.doesNotMatch(promotion, /repos\/\$\{GITHUB_REPOSITORY\}\/actions\/runs\/\$\{candidate_run_id\}/);
   assert.match(promotion, /shopt -s dotglob nullglob/);
@@ -627,20 +620,16 @@ test("candidate promotion은 정확한 성공 후보와 compatibility 증거를 
     /- name: Data Pack Promotion \/ Build and validate promotion request[\s\S]*?\n\s+- name:/,
   )?.[0];
   assert.ok(candidateBinding, "candidate bytes 결속 스텝을 찾지 못함");
-  for (const index of [1, 2, 3]) {
-    assert.match(candidateBinding, new RegExp(`--candidate-root-${index}`));
-    assert.match(candidateBinding, new RegExp(`--candidate-workflow-run-id-${index}`));
-    assert.match(candidateBinding, new RegExp(`--candidate-head-sha-${index}`));
-  }
-  assert.match(candidateBinding, /--selected-candidate-workflow-run-id/);
+  assert.match(candidateBinding, /--candidate-root "\$\{RUNNER_TEMP\}\/candidate"/);
+  assert.match(candidateBinding, /--candidate-workflow-run-id "\$\{CANDIDATE_RUN_ID\}"/);
+  assert.match(candidateBinding, /--candidate-head-sha "\$\{CANDIDATE_HEAD_SHA\}"/);
+  assert.equal((candidateBinding.match(/--candidate-execution-evidence-root "\$\{RUNNER_TEMP\}\/candidate-execution-evidence"/g) ?? []).length, 2);
+  assert.match(promotion, /easysubway-datapack-candidate-execution-evidence-\$\{\{ inputs\.candidateRunId \}\}/);
   assert.match(candidateBinding, /EASYSUBWAY_DATAPACK_SIGNING_PUBLIC_KEY_PEM: \$\{\{ secrets\.EASYSUBWAY_DATAPACK_SIGNING_PUBLIC_KEY_PEM \}\}/);
   assert.match(candidateBinding, /EASYSUBWAY_DATAPACK_SIGNING_KEY_ID: \$\{\{ secrets\.EASYSUBWAY_DATAPACK_SIGNING_KEY_ID \}\}/);
   assert.equal((promotion.match(/secrets\.EASYSUBWAY_DATAPACK_SIGNING_PUBLIC_KEY_PEM/g) ?? []).length, 1);
   assert.equal((promotion.match(/secrets\.EASYSUBWAY_DATAPACK_SIGNING_KEY_ID/g) ?? []).length, 1);
-  assert.match(candidateBinding, /--rebuild-parity-evidence-output/);
-  assert.match(candidateBinding, /--rebuild-parity-evidence\s/);
-  assert.match(candidateBinding, /promotion-artifact\/rebuild-parity-evidence\.json/);
-  assert.match(promotion, /candidate run IDs must be distinct/);
+  assert.doesNotMatch(candidateBinding, /rebuild-parity|candidate-root-[123]|candidate-workflow-run-id-[123]|candidate-head-sha-[123]/);
   assert.match(promotion, /compatibility evidence must contain exactly one regular non-empty file/);
   assert.doesNotMatch(candidateBinding.split("run: |", 2)[1], /\$\{\{ inputs\./);
   assert.doesNotMatch(candidateBinding, /build-data-component-manifest\.mjs/);
@@ -726,6 +715,7 @@ test("production-publish는 data-repo attested candidate를 재생성 없이 소
   assert.match(promotionMetadata, /"\$\{artifact_name\}" "\$\{EASYSUBWAY_DATAPACK_PROMOTION_RUN_ID\}" "\$\{PROMOTION_HEAD_SHA\}"/);
   for (const [name, runId, artifactName] of [
     ["Data Pack Release / Download exact production artifacts", "candidate_run_id", "easysubway-datapack-candidate"],
+    ["Data Pack Release / Download exact candidate execution evidence", "candidate_run_id", "easysubway-datapack-candidate-execution-evidence"],
     ["Data Pack Release / Download exact promotion artifact", "promotion_run_id", "easysubway-datapack-promotion"],
   ]) {
     const download = step(name);
@@ -743,12 +733,13 @@ test("production-publish는 data-repo attested candidate를 재생성 없이 소
   assert.match(verify, /gh attestation verify[\s\S]*?--repo "\$\{GITHUB_REPOSITORY\}"[\s\S]*?--signer-workflow "AquilaXk\/easysubway\/\.github\/workflows\/datapack-promotion\.yml"[\s\S]*?--source-ref refs\/heads\/main[\s\S]*?--deny-self-hosted-runners/);
   assert.match(verify, /validate-promotion-request\.mjs/);
   assert.match(verify, /--workflow-run-id "\$\{EASYSUBWAY_DATAPACK_PROMOTION_RUN_ID\}"/);
-  assert.match(verify, /--rebuild-parity-evidence "\$\{promotion_root\}\/rebuild-parity-evidence\.json"/);
+  assert.match(verify, /--candidate-execution-evidence-root "\$\{RUNNER_TEMP\}\/downloaded-candidate-execution-evidence"/);
+  assert.doesNotMatch(verify, /rebuild-parity-evidence/);
   assert.match(
     verify,
-    /if \[\[ "\$\{#promotion_entries\[@\]\}" -ne 4 \]\]; then\s+echo "production promotion artifact must contain exactly four files" >&2\s+exit 1\s+fi/,
+    /if \[\[ "\$\{#promotion_entries\[@\]\}" -ne 3 \]\]; then\s+echo "production promotion artifact must contain exactly three files" >&2\s+exit 1\s+fi/,
   );
-  assert.match(verify, /for name in promotion-request\.json promotion-approvals\.json compatibility-evidence\.json rebuild-parity-evidence\.json; do/);
+  assert.match(verify, /for name in promotion-request\.json promotion-approvals\.json compatibility-evidence\.json; do/);
   assert.match(
     verify,
     /if ! \[\[ -f "\$\{promotion_root\}\/\$\{name\}" && ! -L "\$\{promotion_root\}\/\$\{name\}" && -s "\$\{promotion_root\}\/\$\{name\}" \]\]; then\s+echo "production promotion artifact has an invalid required file: \$\{name\}" >&2\s+exit 1\s+fi/,

--- a/tools/release/build-promotion-request.mjs
+++ b/tools/release/build-promotion-request.mjs
@@ -11,7 +11,9 @@ import {
   positiveDecimal,
   regularBytes,
   regularJson,
+  readCandidateExecutionEvidence,
   reviewerFromApproval,
+  validateCandidateExecutionEvidence,
   validateCompatibilityEvidence,
   validatePromotionCandidate,
   validateInventory,
@@ -19,32 +21,19 @@ import {
 
 async function main() {
   const args = parseArgs(process.argv.slice(2), [
-    "candidate-root-1", "candidate-root-2", "candidate-root-3", "selected-candidate-workflow-run-id",
-    "candidate-workflow-run-id-1", "candidate-workflow-run-id-2", "candidate-workflow-run-id-3",
-    "candidate-head-sha-1", "candidate-head-sha-2", "candidate-head-sha-3",
+    "candidate-root", "candidate-workflow-run-id", "candidate-head-sha",
+    "candidate-execution-evidence-root",
     "compatibility-evidence", "requested-by", "approval-evidence", "workflow-run-id", "issue-ref",
-    "rebuild-parity-evidence-output", "output",
+    "output",
   ]);
-  const candidates = await Promise.all(["candidate-root-1", "candidate-root-2", "candidate-root-3"]
-    .map((name, index) => verifyPromotionCandidateRoot(
-      args.get(name), `--${name}`,
-      args.get(`candidate-workflow-run-id-${index + 1}`),
-      args.get(`candidate-head-sha-${index + 1}`),
-    )));
-  const inventoryBytes = candidates[0].inventoryBytes;
-  if (!candidates.every((candidate) => Buffer.compare(candidate.inventoryBytes, inventoryBytes) === 0)) {
-    throw new Error("candidate inventories differ");
-  }
-  const components = candidates.map((candidate) => candidate.component)
-    .sort((left, right) => BigInt(left.workflowRunId) < BigInt(right.workflowRunId) ? -1 : 1);
-  const selectedCandidateWorkflowRunId = args.get("selected-candidate-workflow-run-id");
-  if (!positiveDecimal(selectedCandidateWorkflowRunId)
-    || new Set(components.map((component) => component.workflowRunId)).size !== 3
-    || !components.some((component) => component.workflowRunId === selectedCandidateWorkflowRunId)
-    || !sameIdentityExceptRun(components)) {
-    throw new Error("candidate parity is invalid");
-  }
-  const component = components.find((candidate) => candidate.workflowRunId === selectedCandidateWorkflowRunId);
+  const { component, inventoryBytes } = await verifyPromotionCandidateRoot(
+    args.get("candidate-root"), "--candidate-root",
+    args.get("candidate-workflow-run-id"), args.get("candidate-head-sha"),
+  );
+  const executionEvidence = await readCandidateExecutionEvidence(
+    args.get("candidate-execution-evidence-root"),
+  );
+  validateCandidateExecutionEvidence({ ...executionEvidence, component });
 
   const [compatibility, compatibilityBytes] = await regularJson(
     args.get("compatibility-evidence"),
@@ -60,22 +49,15 @@ async function main() {
     throw new Error("request arguments are invalid");
   }
 
-  const rebuildParityEvidence = {
-    schemaVersion: 1,
-    artifactKind: "datapack-rebuild-parity-evidence",
-    selectedCandidateWorkflowRunId,
-    candidates: components,
-    artifactInventorySha256: hash(inventoryBytes),
-    contractVersion: "datapack-rebuild-parity-v1",
-    issueRef: args.get("issue-ref"),
-  };
-  const rebuildParityEvidenceBytes = jsonBytes(rebuildParityEvidence);
   const request = {
     schemaVersion: 1,
     artifactKind: "datapack-promotion-request",
     candidate: component,
     compatibilityEvidenceSha256: hash(compatibilityBytes),
-    rebuildParityEvidenceSha256: hash(rebuildParityEvidenceBytes),
+    candidateExecutionEvidence: {
+      releaseEvidenceBundleSha256: hash(executionEvidence.releaseEvidenceBundleBytes),
+      releaseDecisionSha256: hash(executionEvidence.releaseDecisionBytes),
+    },
     requestedBy,
     approval: {
       workflowRunId,
@@ -83,14 +65,11 @@ async function main() {
       reviewer,
       approvalEvidenceSha256: hash(approvalBytes),
     },
-    contractVersion: "datapack-promotion-v1",
+    contractVersion: "datapack-promotion-v2",
     issueRef: args.get("issue-ref"),
   };
   const requestBytes = jsonBytes(request);
-  await writeExclusiveJsonPair(
-    args.get("rebuild-parity-evidence-output"), rebuildParityEvidenceBytes,
-    args.get("output"), requestBytes,
-  );
+  await writeExclusiveJson(args.get("output"), requestBytes);
 }
 
 export async function verifyPromotionCandidateRoot(root, label, expectedWorkflowRunId, expectedGitSha) {
@@ -159,37 +138,16 @@ function isSameInventory(left, right) {
   return isDeepStrictEqual(left, right);
 }
 
-function sameIdentityExceptRun(components) {
-  const baseline = { ...components[0] };
-  delete baseline.workflowRunId;
-  return components.every((component) => {
-    const identity = { ...component };
-    delete identity.workflowRunId;
-    return isDeepStrictEqual(identity, baseline);
-  });
-}
-
 const jsonBytes = (value) => Buffer.from(`${JSON.stringify(value, null, 2)}\n`);
 
-async function writeExclusiveJsonPair(evidenceFile, evidenceBytes, requestFile, requestBytes) {
-  const evidenceOutput = path.resolve(evidenceFile);
+async function writeExclusiveJson(requestFile, requestBytes) {
   const requestOutput = path.resolve(requestFile);
-  await Promise.all([evidenceOutput, requestOutput].map(assertMissing));
+  await assertMissing(requestOutput);
   const temporaryDirectory = await mkdtemp(path.join(path.dirname(requestOutput), ".promotion-request-"));
-  let evidencePublished = false;
   try {
-    const temporaryEvidence = path.join(temporaryDirectory, "evidence.json");
     const temporaryRequest = path.join(temporaryDirectory, "request.json");
-    await writeFile(temporaryEvidence, evidenceBytes, { flag: "wx" });
     await writeFile(temporaryRequest, requestBytes, { flag: "wx" });
-    try {
-      await link(temporaryEvidence, evidenceOutput);
-      evidencePublished = true;
-      await link(temporaryRequest, requestOutput);
-    } catch (error) {
-      if (evidencePublished) await unlink(evidenceOutput).catch(() => {});
-      throw error;
-    }
+    await link(temporaryRequest, requestOutput);
   } finally {
     await rm(temporaryDirectory, { recursive: true, force: true });
   }

--- a/tools/release/build-promotion-request.test.mjs
+++ b/tools/release/build-promotion-request.test.mjs
@@ -13,31 +13,23 @@ const sha256 = (value) => createHash("sha256").update(value).digest("hex");
 const { privateKey, publicKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
 const signingPublicKey = publicKey.export({ type: "spki", format: "pem" });
 
-// Break caught: accepting one candidate, a stale inventory, or a different run identity
-// would let promotion proceed without proving three byte-identical rebuilds.
-test("세 data 후보의 raw inventory와 component identity를 묶어 parity evidence와 request를 발행한다", () => {
+// Break caught: accepting a stale inventory or a different run identity would let promotion
+// proceed without binding the one immutable candidate to its promotion authorization.
+test("단일 data 후보의 raw inventory와 component identity를 v2 request에 묶어 발행한다", () => {
   const fixture = createFixture();
   try {
     const result = run(fixture);
     assert.equal(result.status, 0, result.stderr);
-    const evidenceBytes = readFileSync(fixture.evidenceOutput);
-    const evidence = JSON.parse(evidenceBytes);
-    assert.deepEqual(evidence, {
-      schemaVersion: 1,
-      artifactKind: "datapack-rebuild-parity-evidence",
-      selectedCandidateWorkflowRunId: "123",
-      candidates: fixture.components,
-      artifactInventorySha256: sha256(fixture.inventoryBytes),
-      contractVersion: "datapack-rebuild-parity-v1",
-      issueRef: "AquilaXk/easysubway#2705",
-    });
     const request = JSON.parse(readFileSync(fixture.output));
     assert.deepEqual(request, {
       schemaVersion: 1,
       artifactKind: "datapack-promotion-request",
-      candidate: fixture.components[0],
+      candidate: fixture.component,
       compatibilityEvidenceSha256: sha256(fixture.compatibilityBytes),
-      rebuildParityEvidenceSha256: sha256(evidenceBytes),
+      candidateExecutionEvidence: {
+        releaseEvidenceBundleSha256: sha256(fixture.releaseEvidenceBundleBytes),
+        releaseDecisionSha256: sha256(fixture.releaseDecisionBytes),
+      },
       requestedBy: "AquilaXk",
       approval: {
         workflowRunId: "456",
@@ -45,7 +37,7 @@ test("세 data 후보의 raw inventory와 component identity를 묶어 parity ev
         reviewer: "AquilaXk",
         approvalEvidenceSha256: sha256(fixture.approvalBytes),
       },
-      contractVersion: "datapack-promotion-v1",
+      contractVersion: "datapack-promotion-v2",
       issueRef: "AquilaXk/easysubway#2705",
     });
   } finally {
@@ -56,21 +48,20 @@ test("세 data 후보의 raw inventory와 component identity를 묶어 parity ev
 test("candidate root의 symlink·실제 inventory drift·identity·approval·compatibility를 fail closed한다", () => {
   for (const mutate of [
     (fixture) => {
-      const component = path.join(fixture.roots[1], "data-component-manifest.json");
+      const component = path.join(fixture.root, "data-component-manifest.json");
       unlinkSync(component);
-      symlinkSync(path.join(fixture.roots[0], "data-component-manifest.json"), component);
+      symlinkSync(path.join(fixture.root, "current.provenance.json"), component);
     },
-    (fixture) => writeFileSync(path.join(fixture.roots[2], "artifact.bin"), "drift"),
+    (fixture) => writeFileSync(path.join(fixture.root, "artifact.bin"), "drift"),
     (fixture) => {
-      const manifest = path.join(fixture.roots[0], "catalog", "current.json");
+      const manifest = path.join(fixture.root, "catalog", "current.json");
       writeFileSync(manifest, JSON.stringify({ ...JSON.parse(readFileSync(manifest)), signature: { algorithm: "rsa-sha256-manifest-v2", value: "bad" } }));
     },
-    (fixture) => rewriteComponent(fixture, 0, { manifestSha256: "e".repeat(64) }),
-    (fixture) => writeFileSync(path.join(fixture.roots[0], "current.provenance.json"), JSON.stringify({ schemaVersion: 1, artifactKind: "datapack-field-provenance", candidateBuild: { sourceSnapshotSetHash: "f".repeat(64) } })),
-    (fixture) => rewriteComponent(fixture, 1, { dataVersion: "other" }),
-    (fixture) => { fixture.candidateHeadShas[1] = "f".repeat(40); },
-    (fixture) => { fixture.candidateWorkflowRunIds[2] = "999"; },
-    (fixture) => { fixture.selectedCandidateWorkflowRunId = "999"; },
+    (fixture) => rewriteComponent(fixture, { manifestSha256: "e".repeat(64) }),
+    (fixture) => writeFileSync(path.join(fixture.root, "current.provenance.json"), JSON.stringify({ schemaVersion: 1, artifactKind: "datapack-field-provenance", candidateBuild: { sourceSnapshotSetHash: "f".repeat(64) } })),
+    (fixture) => rewriteComponent(fixture, { dataVersion: "other" }),
+    (fixture) => { fixture.candidateHeadSha = "f".repeat(40); },
+    (fixture) => { fixture.candidateWorkflowRunId = "999"; },
     (fixture) => writeFileSync(fixture.approvalPath, JSON.stringify([{
       ...approvedReview(),
       environments: [{ name: "datapack-promotion" }, { name: "other" }],
@@ -81,18 +72,42 @@ test("candidate root의 symlink·실제 inventory drift·identity·approval·com
       symlinkSync(fixture.compatibilityPath, link);
       fixture.compatibilityPath = link;
     },
-    (fixture) => writeFileSync(fixture.compatibilityPath, JSON.stringify({ ...compatibilityValue(fixture.components[0]), decision: "NO_GO" })),
-    (fixture) => writeFileSync(fixture.compatibilityPath, JSON.stringify({ ...compatibilityValue(fixture.components[0]), extra: true })),
+    (fixture) => writeFileSync(fixture.compatibilityPath, JSON.stringify({ ...compatibilityValue(fixture.component), decision: "NO_GO" })),
+    (fixture) => writeFileSync(fixture.compatibilityPath, JSON.stringify({ ...compatibilityValue(fixture.component), extra: true })),
+    (fixture) => file(fixture.executionEvidenceRoot, "extra.json", "extra"),
+    (fixture) => unlinkSync(path.join(fixture.executionEvidenceRoot, "release-decision.json")),
+    (fixture) => {
+      const decision = path.join(fixture.executionEvidenceRoot, "release-decision.json");
+      unlinkSync(decision);
+      symlinkSync(path.join(fixture.executionEvidenceRoot, "release-evidence-bundle.json"), decision);
+    },
+    (fixture) => rewriteExecutionEvidence(fixture, "release-evidence-bundle.json", (value) => {
+      value.builderGitSha = "f".repeat(40);
+    }),
+    (fixture) => rewriteExecutionEvidence(fixture, "release-evidence-bundle.json", (value) => {
+      value.workflowRunUrl = "https://github.com/AquilaXk/easysubway-data/actions/runs/999";
+    }),
+    (fixture) => rewriteExecutionEvidence(fixture, "release-evidence-bundle.json", (value) => {
+      value.manifestSha256 = "f".repeat(64);
+    }),
+    (fixture) => rewriteExecutionEvidence(fixture, "release-evidence-bundle.json", (value) => {
+      value.candidateServerRouteEvidence.final.sha256 = "invalid";
+    }),
+    (fixture) => rewriteExecutionEvidence(fixture, "release-decision.json", (value) => {
+      value.sourceSnapshotSetHash = "f".repeat(64);
+    }),
+    (fixture) => rewriteExecutionEvidence(fixture, "release-decision.json", (value) => {
+      value.outcome = "NO_CHANGE_VALID";
+    }),
     (fixture) => { fixture.workflowRunId = "0"; },
     (fixture) => writeFileSync(fixture.output, "sentinel"),
-    (fixture) => writeFileSync(fixture.evidenceOutput, "evidence-sentinel"),
   ]) assertRejectedWithoutOutputDamage(mutate);
 });
 
-test("세 parity candidate inventory에는 recorded server route bundle이 필수다", () => {
+test("단일 candidate inventory에는 recorded server route bundle이 필수다", () => {
   const fixture = createFixture();
   try {
-    fixture.roots.forEach((root) => unlinkSync(path.join(root, "server-route-bundle/manifest.json")));
+    unlinkSync(path.join(fixture.root, "server-route-bundle/manifest.json"));
     refreshCandidateMetadata(fixture);
     assert.notEqual(run(fixture).status, 0);
   } finally {
@@ -117,19 +132,20 @@ test("candidate signature validation key가 없으면 fail closed한다", () => 
 test("standalone candidate verifier는 approved build spec source snapshot set에 결속한다", () => {
   const fixture = createFixture();
   try {
-    const approvedSpec = file(fixture.root, "approved-build-spec.json", JSON.stringify({
+    const approvedSpec = file(path.dirname(fixture.root), "approved-build-spec.json", JSON.stringify({
       sourceSnapshotSetHash: "c".repeat(64),
       builderGitSha: "a".repeat(40),
     }));
-    assert.equal(runCandidateVerifier(fixture, approvedSpec).status, 0);
-    const differentSpec = file(fixture.root, "different-build-spec.json", JSON.stringify({
+    const approved = runCandidateVerifier(fixture, approvedSpec);
+    assert.equal(approved.status, 0, approved.stderr);
+    const differentSpec = file(path.dirname(fixture.root), "different-build-spec.json", JSON.stringify({
       sourceSnapshotSetHash: "d".repeat(64),
       builderGitSha: "a".repeat(40),
     }));
     const result = runCandidateVerifier(fixture, differentSpec);
     assert.notEqual(result.status, 0);
     assert.match(result.stderr, /candidate source snapshot set hash does not match build spec/);
-    const differentBuilderSpec = file(fixture.root, "different-builder-build-spec.json", JSON.stringify({
+    const differentBuilderSpec = file(path.dirname(fixture.root), "different-builder-build-spec.json", JSON.stringify({
       sourceSnapshotSetHash: "c".repeat(64),
       builderGitSha: "b".repeat(40),
     }));
@@ -143,8 +159,8 @@ test("standalone candidate verifier는 approved build spec source snapshot set�
 
 test("manifest declared pack 누락과 undeclared sqlite pack을 fail closed한다", () => {
   for (const mutate of [
-    (fixture) => fixture.roots.forEach((root) => unlinkSync(path.join(root, "catalog/capital-v1.sqlite.gz"))),
-    (fixture) => fixture.roots.forEach((root) => file(root, "catalog/extra.sqlite.gz", "extra")),
+    (fixture) => unlinkSync(path.join(fixture.root, "catalog/capital-v1.sqlite.gz")),
+    (fixture) => file(fixture.root, "catalog/extra.sqlite.gz", "extra"),
   ]) {
     const fixture = createFixture();
     try {
@@ -160,7 +176,7 @@ test("manifest declared pack 누락과 undeclared sqlite pack을 fail closed한�
 test("signed manifest와 다른 declared pack bytes를 fail closed한다", () => {
   const fixture = createFixture();
   try {
-    fixture.roots.forEach((root) => file(root, "catalog/capital-v1.sqlite.gz", "replaced"));
+    file(fixture.root, "catalog/capital-v1.sqlite.gz", "replaced");
     refreshCandidateMetadata(fixture);
     assert.notEqual(run(fixture).status, 0);
   } finally {
@@ -168,14 +184,13 @@ test("signed manifest와 다른 declared pack bytes를 fail closed한다", () =>
   }
 });
 
-test("duplicate candidate run IDs는 identity 검증 뒤 parity set에서 거부한다", () => {
+test("candidate workflow run ID는 component identity와 exact match해야 한다", () => {
   const fixture = createFixture();
   try {
-    rewriteComponent(fixture, 2, { workflowRunId: "124" });
-    fixture.candidateWorkflowRunIds[2] = "124";
+    rewriteComponent(fixture, { workflowRunId: "124" });
     const result = run(fixture);
     assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /candidate parity is invalid/);
+    assert.match(result.stderr, /candidate inventory is invalid/);
   } finally {
     fixture.cleanup();
   }
@@ -191,13 +206,11 @@ test("candidate inventory는 safe POSIX path와 exact fields만 허용한다", (
     [{ path: "nested/../escape.bin", sizeBytes: 1, sha256: "d".repeat(64) }],
     [{ path: "artifact.bin", sizeBytes: 1, sha256: "d".repeat(64), extra: true }],
   ]) assertRejectedWithoutOutputDamage((fixture) => {
-    for (const candidateRoot of fixture.roots) {
-      writeFileSync(candidateRoot + "/data-artifact-inventory.json", JSON.stringify({
-        schemaVersion: 1,
-        artifactKind: "datapack-candidate-inventory",
-        entries,
-      }));
-    }
+    writeFileSync(fixture.root + "/data-artifact-inventory.json", JSON.stringify({
+      schemaVersion: 1,
+      artifactKind: "datapack-candidate-inventory",
+      entries,
+    }));
   });
 });
 
@@ -205,10 +218,8 @@ function assertRejectedWithoutOutputDamage(mutate) {
   const fixture = createFixture();
   try {
     mutate(fixture);
-    const priorEvidence = exists(fixture.evidenceOutput) ? readFileSync(fixture.evidenceOutput, "utf8") : null;
     const priorRequest = exists(fixture.output) ? readFileSync(fixture.output, "utf8") : null;
     assert.notEqual(run(fixture).status, 0);
-    assert.equal(priorEvidence == null ? exists(fixture.evidenceOutput) : readFileSync(fixture.evidenceOutput, "utf8"), priorEvidence ?? false);
     assert.equal(priorRequest == null ? exists(fixture.output) : readFileSync(fixture.output, "utf8"), priorRequest ?? false);
   } finally {
     fixture.cleanup();
@@ -217,62 +228,121 @@ function assertRejectedWithoutOutputDamage(mutate) {
 
 function createFixture() {
   const root = mkdtempSync(path.join(os.tmpdir(), "promotion-build-"));
-  const roots = ["123", "124", "125"].map((workflowRunId, index) => {
-    const candidateRoot = path.join(root, `candidate-${index + 1}`);
-    file(candidateRoot, "artifact.bin", "artifact");
-    file(candidateRoot, "server-route-bundle/manifest.json", "signed-route-bundle");
-    file(candidateRoot, "catalog/capital-v1.sqlite.gz", "pack");
-    const provenance = { schemaVersion: 1, artifactKind: "datapack-field-provenance", candidateBuild: { sourceSnapshotSetHash: "c".repeat(64) } };
-    file(candidateRoot, "current.provenance.json", JSON.stringify(provenance));
-    const manifestBytes = Buffer.from(JSON.stringify(productionManifest(readFileSync(path.join(candidateRoot, "catalog/capital-v1.sqlite.gz")))));
-    file(candidateRoot, "catalog/current.json", manifestBytes);
-    const inventoryBytes = Buffer.from(JSON.stringify(inventoryValue(candidateRoot)));
-    const component = componentValue(workflowRunId, sha256(inventoryBytes), sha256(manifestBytes));
-    file(candidateRoot, "data-component-manifest.json", JSON.stringify(component));
-    file(candidateRoot, "data-artifact-inventory.json", inventoryBytes);
-    return { root: candidateRoot, component, inventoryBytes };
-  });
-  const components = roots.map(({ component }) => component);
-  const inventoryBytes = roots[0].inventoryBytes;
-  const compatibility = compatibilityValue(components[0]);
+  const candidateRoot = path.join(root, "candidate");
+  file(candidateRoot, "artifact.bin", "artifact");
+  file(candidateRoot, "server-route-bundle/manifest.json", "signed-route-bundle");
+  file(candidateRoot, "catalog/capital-v1.sqlite.gz", "pack");
+  const provenance = { schemaVersion: 1, artifactKind: "datapack-field-provenance", candidateBuild: { sourceSnapshotSetHash: "c".repeat(64) } };
+  file(candidateRoot, "current.provenance.json", JSON.stringify(provenance));
+  const manifestBytes = Buffer.from(JSON.stringify(productionManifest(readFileSync(path.join(candidateRoot, "catalog/capital-v1.sqlite.gz")))));
+  file(candidateRoot, "catalog/current.json", manifestBytes);
+  const inventoryBytes = Buffer.from(JSON.stringify(inventoryValue(candidateRoot)));
+  const component = componentValue("123", sha256(inventoryBytes), sha256(manifestBytes));
+  file(candidateRoot, "data-component-manifest.json", JSON.stringify(component));
+  file(candidateRoot, "data-artifact-inventory.json", inventoryBytes);
+  const compatibility = compatibilityValue(component);
   const compatibilityBytes = Buffer.from(JSON.stringify(compatibility));
   const approvalBytes = Buffer.from(JSON.stringify([approvedReview()]));
+  const executionEvidenceRoot = path.join(root, "candidate-execution-evidence");
+  const releaseEvidenceBundleBytes = Buffer.from(JSON.stringify(releaseEvidenceBundleValue(component)));
+  const releaseDecisionBytes = Buffer.from(JSON.stringify(releaseDecisionValue(component)));
+  file(executionEvidenceRoot, "release-evidence-bundle.json", releaseEvidenceBundleBytes);
+  file(executionEvidenceRoot, "release-decision.json", releaseDecisionBytes);
   return {
     root,
-    roots: roots.map(({ root: candidateRoot }) => candidateRoot),
-    components,
+    root: candidateRoot,
+    component,
     inventoryBytes,
     compatibilityPath: file(root, "compatibility.json", compatibilityBytes),
     compatibilityBytes,
     approvalPath: file(root, "approvals.json", approvalBytes),
     approvalBytes,
-    selectedCandidateWorkflowRunId: "123",
-    candidateWorkflowRunIds: ["123", "124", "125"],
-    candidateHeadShas: ["a".repeat(40), "a".repeat(40), "a".repeat(40)],
+    executionEvidenceRoot,
+    releaseEvidenceBundleBytes,
+    releaseDecisionBytes,
+    candidateWorkflowRunId: "123",
+    candidateHeadSha: "a".repeat(40),
     workflowRunId: "456",
-    evidenceOutput: path.join(root, "rebuild-parity-evidence.json"),
     output: path.join(root, "request.json"),
     cleanup: () => rmSync(root, { recursive: true, force: true }),
   };
 }
 
-function rewriteComponent(fixture, index, patch) {
-  fixture.components[index] = { ...fixture.components[index], ...patch };
-  writeFileSync(path.join(fixture.roots[index], "data-component-manifest.json"), JSON.stringify(fixture.components[index]));
+function releaseEvidenceBundleValue(component) {
+  return {
+    schemaVersion: 1,
+    artifactKind: "datapack-release-evidence-bundle",
+    releaseMode: "release-candidate",
+    candidateId: "capital@1",
+    buildCandidateId: "candidate-1",
+    candidateBuilderGitSha: "9".repeat(40),
+    builderGitSha: component.gitSha,
+    buildSpecSha256: "8".repeat(64),
+    manifestSha256: component.manifestSha256,
+    releaseSequence: component.releaseSequence,
+    sourceSnapshotSetHash: component.provenance.sourceSnapshotSetHash,
+    validatorStatus: "PASS",
+    manifestSignatureStatus: "PASS",
+    createdAt: "2026-08-28T00:00:00.000Z",
+    workflowRunUrl: `https://github.com/AquilaXk/easysubway-data/actions/runs/${component.workflowRunId}`,
+    candidateServerRouteEvidence: {
+      candidateId: "candidate-1",
+      sourceSnapshotSetHash: component.provenance.sourceSnapshotSetHash,
+      buildSpecSha256: "8".repeat(64),
+      manifestSha256: component.manifestSha256,
+      eligibility: {
+        path: "server-route-bundle-evidence/route-accessibility-eligibility.json",
+        sha256: "7".repeat(64),
+      },
+      final: {
+        path: "server-route-bundle-evidence/server-route-bundle-final.json",
+        sha256: "6".repeat(64),
+      },
+    },
+  };
+}
+
+function releaseDecisionValue(component) {
+  return {
+    schemaVersion: 1,
+    artifactKind: "datapack-release-decision",
+    outcome: "CHANGE_BLOCKED",
+    productionWriteAllowed: false,
+    materialChange: true,
+    approvalValid: false,
+    strictValidationPassed: true,
+    publishRequired: true,
+    publishAttempted: false,
+    remoteValidationPassed: false,
+    sourceSnapshotSetHash: component.provenance.sourceSnapshotSetHash,
+    selectedManifestSha256: null,
+    selectedReleaseSequence: null,
+    reasonCodes: ["MATERIAL_CHANGE_UNAPPROVED"],
+    evaluationAt: "2026-08-28T00:00:00.000Z",
+  };
+}
+
+function rewriteComponent(fixture, patch) {
+  fixture.component = { ...fixture.component, ...patch };
+  writeFileSync(path.join(fixture.root, "data-component-manifest.json"), JSON.stringify(fixture.component));
+}
+
+function rewriteExecutionEvidence(fixture, name, mutate) {
+  const target = path.join(fixture.executionEvidenceRoot, name);
+  const value = JSON.parse(readFileSync(target));
+  mutate(value);
+  writeFileSync(target, JSON.stringify(value));
 }
 
 function refreshCandidateMetadata(fixture) {
-  fixture.components = fixture.roots.map((root, index) => {
-    const inventoryBytes = Buffer.from(JSON.stringify(inventoryValue(root)));
-    const component = componentValue(
-      fixture.candidateWorkflowRunIds[index], sha256(inventoryBytes),
-      sha256(readFileSync(path.join(root, "catalog/current.json"))),
-    );
-    writeFileSync(path.join(root, "data-artifact-inventory.json"), inventoryBytes);
-    writeFileSync(path.join(root, "data-component-manifest.json"), JSON.stringify(component));
-    return component;
-  });
-  writeFileSync(fixture.compatibilityPath, JSON.stringify(compatibilityValue(fixture.components[0])));
+  const inventoryBytes = Buffer.from(JSON.stringify(inventoryValue(fixture.root)));
+  fixture.component = componentValue(
+    fixture.candidateWorkflowRunId, sha256(inventoryBytes),
+    sha256(readFileSync(path.join(fixture.root, "catalog/current.json"))),
+  );
+  writeFileSync(path.join(fixture.root, "data-artifact-inventory.json"), inventoryBytes);
+  writeFileSync(path.join(fixture.root, "data-component-manifest.json"), JSON.stringify(fixture.component));
+  writeFileSync(fixture.compatibilityPath, JSON.stringify(compatibilityValue(fixture.component)));
 }
 
 function approvedReview() {
@@ -338,13 +408,13 @@ function exists(target) {
 function run(fixture, env = {}) {
   return spawnSync(process.execPath, [
     script,
-    "--candidate-root-1", fixture.roots[0], "--candidate-root-2", fixture.roots[1], "--candidate-root-3", fixture.roots[2],
-    "--candidate-workflow-run-id-1", fixture.candidateWorkflowRunIds[0], "--candidate-workflow-run-id-2", fixture.candidateWorkflowRunIds[1], "--candidate-workflow-run-id-3", fixture.candidateWorkflowRunIds[2],
-    "--candidate-head-sha-1", fixture.candidateHeadShas[0], "--candidate-head-sha-2", fixture.candidateHeadShas[1], "--candidate-head-sha-3", fixture.candidateHeadShas[2],
-    "--selected-candidate-workflow-run-id", fixture.selectedCandidateWorkflowRunId,
+    "--candidate-root", fixture.root,
+    "--candidate-workflow-run-id", fixture.candidateWorkflowRunId,
+    "--candidate-head-sha", fixture.candidateHeadSha,
+    "--candidate-execution-evidence-root", fixture.executionEvidenceRoot,
     "--compatibility-evidence", fixture.compatibilityPath, "--requested-by", "AquilaXk",
     "--approval-evidence", fixture.approvalPath, "--workflow-run-id", fixture.workflowRunId,
-    "--issue-ref", "AquilaXk/easysubway#2705", "--rebuild-parity-evidence-output", fixture.evidenceOutput,
+    "--issue-ref", "AquilaXk/easysubway#2705",
     "--output", fixture.output,
   ], { encoding: "utf8", env: { ...process.env, EASYSUBWAY_DATAPACK_SIGNING_PUBLIC_KEY_PEM: signingPublicKey, EASYSUBWAY_DATAPACK_SIGNING_KEY_ID: "production-v1", ...env } });
 }
@@ -352,9 +422,9 @@ function run(fixture, env = {}) {
 function runCandidateVerifier(fixture, buildSpec) {
   return spawnSync(process.execPath, [
     candidateVerifier,
-    "--root", fixture.roots[0],
-    "--workflow-run-id", fixture.candidateWorkflowRunIds[0],
-    "--git-sha", fixture.candidateHeadShas[0],
+    "--root", fixture.root,
+    "--workflow-run-id", fixture.candidateWorkflowRunId,
+    "--git-sha", fixture.candidateHeadSha,
     "--build-spec", buildSpec,
   ], {
     encoding: "utf8",

--- a/tools/release/validate-promotion-request.mjs
+++ b/tools/release/validate-promotion-request.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { createHash } from "node:crypto";
-import { lstat, readFile } from "node:fs/promises";
+import { lstat, readFile, readdir } from "node:fs/promises";
 import path from "node:path";
 import { isDeepStrictEqual } from "node:util";
 import { fileURLToPath } from "node:url";
@@ -12,11 +12,16 @@ const componentKeys = [
 ];
 const requestKeys = [
   "schemaVersion", "artifactKind", "candidate", "compatibilityEvidenceSha256", "requestedBy",
-  "rebuildParityEvidenceSha256", "approval", "contractVersion", "issueRef",
+  "candidateExecutionEvidence", "approval", "contractVersion", "issueRef",
 ];
-const rebuildParityEvidenceKeys = [
-  "schemaVersion", "artifactKind", "selectedCandidateWorkflowRunId", "candidates",
-  "artifactInventorySha256", "contractVersion", "issueRef",
+const releaseDecisionKeys = [
+  "schemaVersion", "artifactKind", "outcome", "productionWriteAllowed", "materialChange",
+  "approvalValid", "strictValidationPassed", "publishRequired", "publishAttempted",
+  "remoteValidationPassed", "sourceSnapshotSetHash", "selectedManifestSha256",
+  "selectedReleaseSequence", "reasonCodes", "evaluationAt",
+];
+const candidateServerRouteEvidenceKeys = [
+  "candidateId", "sourceSnapshotSetHash", "buildSpecSha256", "manifestSha256", "eligibility", "final",
 ];
 
 export const hash = (bytes) => createHash("sha256").update(bytes).digest("hex");
@@ -120,37 +125,102 @@ export function reviewerFromApproval(bytes) {
   return selected[0].user.login;
 }
 
-export function validateRebuildParityEvidence(value) {
-  exactKeys(value, rebuildParityEvidenceKeys, "rebuild parity evidence");
-  if (value.schemaVersion !== 1 || value.artifactKind !== "datapack-rebuild-parity-evidence"
-    || !positiveDecimal(value.selectedCandidateWorkflowRunId)
-    || !Array.isArray(value.candidates) || value.candidates.length !== 3
-    || !sha64(value.artifactInventorySha256)
-    || value.contractVersion !== "datapack-rebuild-parity-v1"
-    || value.issueRef !== "AquilaXk/easysubway#2705") {
-    throw new Error("rebuild parity evidence is invalid");
+export function validateCandidateExecutionEvidence({ releaseEvidenceBundle, releaseDecision, component }) {
+  const serverRoute = releaseEvidenceBundle?.candidateServerRouteEvidence;
+  if (releaseEvidenceBundle?.schemaVersion !== 1
+    || releaseEvidenceBundle?.artifactKind !== "datapack-release-evidence-bundle"
+    || releaseEvidenceBundle?.releaseMode !== "release-candidate"
+    || !text(releaseEvidenceBundle.candidateId)
+    || !text(releaseEvidenceBundle.buildCandidateId)
+    || !/^[a-f0-9]{7,40}$/u.test(releaseEvidenceBundle.candidateBuilderGitSha ?? "")
+    || releaseEvidenceBundle.builderGitSha !== component.gitSha
+    || !sha64(releaseEvidenceBundle.buildSpecSha256)
+    || releaseEvidenceBundle.manifestSha256 !== component.manifestSha256
+    || releaseEvidenceBundle.releaseSequence !== component.releaseSequence
+    || releaseEvidenceBundle.sourceSnapshotSetHash !== component.provenance.sourceSnapshotSetHash
+    || releaseEvidenceBundle.validatorStatus !== "PASS"
+    || releaseEvidenceBundle.manifestSignatureStatus !== "PASS"
+    || !utcInstant(releaseEvidenceBundle.createdAt)
+    || releaseEvidenceBundle.workflowRunUrl
+      !== `https://github.com/AquilaXk/easysubway-data/actions/runs/${component.workflowRunId}`) {
+    throw new Error("candidate release evidence identity is invalid");
   }
 
-  let previousRunId = null;
-  let baseline = null;
-  let selected = null;
-  for (const candidate of value.candidates) {
-    validatePromotionCandidate(candidate);
-    if (candidate.artifactInventorySha256 !== value.artifactInventorySha256
-      || (previousRunId != null && BigInt(previousRunId) >= BigInt(candidate.workflowRunId))) {
-      throw new Error("rebuild parity evidence is invalid");
-    }
-    const identity = { ...candidate };
-    delete identity.workflowRunId;
-    if (baseline != null && !isDeepStrictEqual(identity, baseline)) {
-      throw new Error("rebuild parity evidence is invalid");
-    }
-    baseline ??= identity;
-    if (candidate.workflowRunId === value.selectedCandidateWorkflowRunId) selected = candidate;
-    previousRunId = candidate.workflowRunId;
+  exactKeys(serverRoute, candidateServerRouteEvidenceKeys, "candidate server route evidence");
+  if (serverRoute.candidateId !== releaseEvidenceBundle.buildCandidateId
+    || serverRoute.sourceSnapshotSetHash !== releaseEvidenceBundle.sourceSnapshotSetHash
+    || serverRoute.buildSpecSha256 !== releaseEvidenceBundle.buildSpecSha256
+    || serverRoute.manifestSha256 !== releaseEvidenceBundle.manifestSha256) {
+    throw new Error("candidate server route evidence identity is invalid");
   }
-  if (!selected) throw new Error("rebuild parity evidence is invalid");
-  return selected;
+  for (const [name, expectedPath] of [
+    ["eligibility", "server-route-bundle-evidence/route-accessibility-eligibility.json"],
+    ["final", "server-route-bundle-evidence/server-route-bundle-final.json"],
+  ]) {
+    exactKeys(serverRoute[name], ["path", "sha256"], `candidate server route ${name}`);
+    if (serverRoute[name].path !== expectedPath || !sha64(serverRoute[name].sha256)) {
+      throw new Error("candidate server route evidence file is invalid");
+    }
+  }
+
+  exactKeys(releaseDecision, releaseDecisionKeys, "release decision");
+  const booleans = [
+    "productionWriteAllowed", "materialChange", "approvalValid", "strictValidationPassed",
+    "publishRequired", "publishAttempted", "remoteValidationPassed",
+  ];
+  if (releaseDecision.schemaVersion !== 1
+    || releaseDecision.artifactKind !== "datapack-release-decision"
+    || booleans.some((field) => typeof releaseDecision[field] !== "boolean")
+    || releaseDecision.strictValidationPassed !== true
+    || releaseDecision.publishAttempted !== false
+    || releaseDecision.remoteValidationPassed !== false
+    || releaseDecision.sourceSnapshotSetHash !== component.provenance.sourceSnapshotSetHash
+    || !Array.isArray(releaseDecision.reasonCodes)
+    || releaseDecision.reasonCodes.some((reason) => !text(reason))
+    || !utcInstant(releaseDecision.evaluationAt)) {
+    throw new Error("candidate release decision is invalid");
+  }
+  const expectedOutcome = scheduledOutcome(releaseDecision);
+  if (releaseDecision.outcome !== expectedOutcome.outcome
+    || releaseDecision.productionWriteAllowed !== expectedOutcome.productionWriteAllowed) {
+    throw new Error("candidate release decision outcome is invalid");
+  }
+  const selected = releaseDecision.outcome === "NO_CHANGE_VALID";
+  if (selected !== (sha64(releaseDecision.selectedManifestSha256)
+    && Number.isSafeInteger(releaseDecision.selectedReleaseSequence)
+    && releaseDecision.selectedReleaseSequence > 0)) {
+    throw new Error("candidate release decision selection is invalid");
+  }
+}
+
+function scheduledOutcome(value) {
+  if (!value.strictValidationPassed) return { outcome: "FAILED", productionWriteAllowed: false };
+  if (value.materialChange && !value.approvalValid) {
+    return { outcome: "CHANGE_BLOCKED", productionWriteAllowed: false };
+  }
+  if (value.publishRequired && !value.publishAttempted) {
+    return { outcome: "PUBLISH_REQUIRED", productionWriteAllowed: value.approvalValid };
+  }
+  return { outcome: "NO_CHANGE_VALID", productionWriteAllowed: false };
+}
+
+export async function readCandidateExecutionEvidence(root) {
+  const stats = await lstat(root);
+  if (!stats.isDirectory() || stats.isSymbolicLink()) {
+    throw new Error("candidate execution evidence must be a regular non-symlink directory");
+  }
+  const names = (await readdir(root)).sort();
+  const expected = ["release-decision.json", "release-evidence-bundle.json"];
+  if (!isDeepStrictEqual(names, expected)) {
+    throw new Error("candidate execution evidence must contain exactly two files");
+  }
+  const [releaseDecision, releaseDecisionBytes] = await regularJson(
+    path.join(root, expected[0]), `candidate execution evidence/${expected[0]}`,
+  );
+  const [releaseEvidenceBundle, releaseEvidenceBundleBytes] = await regularJson(
+    path.join(root, expected[1]), `candidate execution evidence/${expected[1]}`,
+  );
+  return { releaseDecision, releaseDecisionBytes, releaseEvidenceBundle, releaseEvidenceBundleBytes };
 }
 
 export function validateRequest({
@@ -160,23 +230,27 @@ export function validateRequest({
   inventoryBytes,
   compatibility,
   compatibilityBytes,
-  rebuildParityEvidence,
-  rebuildParityEvidenceBytes,
+  releaseEvidenceBundle,
+  releaseEvidenceBundleBytes,
+  releaseDecision,
+  releaseDecisionBytes,
   approvalBytes,
   workflowRunId,
 }) {
   validatePromotionCandidate(component);
   validateInventory(inventory);
   validateCompatibilityEvidence(compatibility, component);
-  const selectedCandidate = validateRebuildParityEvidence(rebuildParityEvidence);
+  validateCandidateExecutionEvidence({ releaseEvidenceBundle, releaseDecision, component });
   exactKeys(request, requestKeys, "request");
   if (request.schemaVersion !== 1 || request.artifactKind !== "datapack-promotion-request"
     || !isDeepStrictEqual(request.candidate, component)
     || request.compatibilityEvidenceSha256 !== hash(compatibilityBytes)
-    || request.rebuildParityEvidenceSha256 !== hash(rebuildParityEvidenceBytes)
-    || !text(request.requestedBy) || request.contractVersion !== "datapack-promotion-v1"
-    || request.issueRef !== "AquilaXk/easysubway#2705"
-    || !isDeepStrictEqual(component, selectedCandidate)) {
+    || !isDeepStrictEqual(request.candidateExecutionEvidence, {
+      releaseEvidenceBundleSha256: hash(releaseEvidenceBundleBytes),
+      releaseDecisionSha256: hash(releaseDecisionBytes),
+    })
+    || !text(request.requestedBy) || request.contractVersion !== "datapack-promotion-v2"
+    || request.issueRef !== "AquilaXk/easysubway#2705") {
     throw new Error("request is invalid");
   }
 
@@ -223,6 +297,11 @@ function text(value) {
   return typeof value === "string" && value.trim() !== "";
 }
 
+function utcInstant(value) {
+  return typeof value === "string" && !Number.isNaN(Date.parse(value))
+    && new Date(value).toISOString() === value;
+}
+
 function sha64(value) {
   return typeof value === "string" && /^[a-f0-9]{64}$/.test(value);
 }
@@ -234,7 +313,7 @@ function sha40(value) {
 async function main() {
   const args = parseArgs(process.argv.slice(2), [
     "request", "component", "inventory", "compatibility-evidence", "approval-evidence",
-    "rebuild-parity-evidence", "workflow-run-id",
+    "candidate-execution-evidence-root", "workflow-run-id",
   ]);
   const [request] = await regularJson(args.get("request"), "--request");
   const [component] = await regularJson(args.get("component"), "--component");
@@ -243,9 +322,8 @@ async function main() {
     args.get("compatibility-evidence"),
     "--compatibility-evidence",
   );
-  const [rebuildParityEvidence, rebuildParityEvidenceBytes] = await regularJson(
-    args.get("rebuild-parity-evidence"),
-    "--rebuild-parity-evidence",
+  const executionEvidence = await readCandidateExecutionEvidence(
+    args.get("candidate-execution-evidence-root"),
   );
   const approvalBytes = await regularBytes(args.get("approval-evidence"), "--approval-evidence");
   validateRequest({
@@ -255,8 +333,7 @@ async function main() {
     inventoryBytes,
     compatibility,
     compatibilityBytes,
-    rebuildParityEvidence,
-    rebuildParityEvidenceBytes,
+    ...executionEvidence,
     approvalBytes,
     workflowRunId: args.get("workflow-run-id"),
   });

--- a/tools/release/validate-promotion-request.mjs
+++ b/tools/release/validate-promotion-request.mjs
@@ -186,9 +186,12 @@ export function validateCandidateExecutionEvidence({ releaseEvidenceBundle, rele
     throw new Error("candidate release decision outcome is invalid");
   }
   const selected = releaseDecision.outcome === "NO_CHANGE_VALID";
-  if (selected !== (sha64(releaseDecision.selectedManifestSha256)
+  const hasSelection = sha64(releaseDecision.selectedManifestSha256)
     && Number.isSafeInteger(releaseDecision.selectedReleaseSequence)
-    && releaseDecision.selectedReleaseSequence > 0)) {
+    && releaseDecision.selectedReleaseSequence > 0;
+  if ((selected && !hasSelection)
+    || (!selected && (releaseDecision.selectedManifestSha256 !== null
+      || releaseDecision.selectedReleaseSequence !== null))) {
     throw new Error("candidate release decision selection is invalid");
   }
 }

--- a/tools/release/validate-promotion-request.test.mjs
+++ b/tools/release/validate-promotion-request.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -9,23 +9,13 @@ import test from "node:test";
 const script = path.resolve("tools/release/validate-promotion-request.mjs");
 const sha256 = (value) => createHash("sha256").update(value).digest("hex");
 
-// Break caught: request validation could accept parity evidence whose selected candidate or raw hash is altered.
-test("request는 raw parity evidence hash와 selected candidate의 exact identity를 요구한다", () => {
+// Break caught: request validation could accept a component or inventory whose exact candidate identity is altered.
+test("request는 단일 candidate의 exact identity를 요구한다", () => {
   const fixture = createFixture();
   try {
-    assert.equal(run(fixture).status, 0);
-    fixture.evidence.selectedCandidateWorkflowRunId = "124";
-    writeEvidence(fixture);
-    assert.notEqual(run(fixture).status, 0);
-  } finally {
-    fixture.cleanup();
-  }
-});
-
-test("validator는 유효한 parity evidence와 다른 request evidence hash를 거부한다", () => {
-  const fixture = createFixture();
-  try {
-    fixture.request.rebuildParityEvidenceSha256 = "d".repeat(64);
+    const valid = run(fixture);
+    assert.equal(valid.status, 0, valid.stderr);
+    fixture.request.candidate.workflowRunId = "124";
     writeRequest(fixture);
     assert.notEqual(run(fixture).status, 0);
   } finally {
@@ -33,7 +23,38 @@ test("validator는 유효한 parity evidence와 다른 request evidence hash를 
   }
 });
 
-test("validator는 request/approval/compatibility와 parity evidence의 불일치를 거부한다", () => {
+test("validator는 유효한 compatibility evidence와 다른 request evidence hash를 거부한다", () => {
+  const fixture = createFixture();
+  try {
+    fixture.request.compatibilityEvidenceSha256 = "d".repeat(64);
+    writeRequest(fixture);
+    assert.notEqual(run(fixture).status, 0);
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test("validator는 execution evidence를 candidate run/head/manifest/source identity에 결속한다", () => {
+  for (const [name, mutate] of [
+    ["release-evidence-bundle.json", (value) => { value.builderGitSha = "f".repeat(40); }],
+    ["release-evidence-bundle.json", (value) => { value.workflowRunUrl = "https://github.com/AquilaXk/easysubway-data/actions/runs/999"; }],
+    ["release-evidence-bundle.json", (value) => { value.manifestSha256 = "f".repeat(64); }],
+    ["release-evidence-bundle.json", (value) => { value.candidateServerRouteEvidence.buildSpecSha256 = "f".repeat(64); }],
+    ["release-decision.json", (value) => { value.sourceSnapshotSetHash = "f".repeat(64); }],
+    ["release-decision.json", (value) => { value.outcome = "NO_CHANGE_VALID"; }],
+  ]) {
+    const fixture = createFixture();
+    try {
+      const target = path.join(fixture.executionEvidenceRoot, name);
+      const value = JSON.parse(readFileSync(target));
+      mutate(value);
+      writeFileSync(target, JSON.stringify(value));
+      assert.notEqual(run(fixture).status, 0);
+    } finally { fixture.cleanup(); }
+  }
+});
+
+test("validator는 request/approval/compatibility와 candidate의 불일치를 거부한다", () => {
   for (const mutate of [
     (fixture) => { fixture.request.extra = true; writeRequest(fixture); },
     (fixture) => { fixture.request.candidate.dataVersion = "other"; writeRequest(fixture); },
@@ -41,12 +62,9 @@ test("validator는 request/approval/compatibility와 parity evidence의 불일�
     (fixture) => { fixture.request.approval.reviewer = "other"; writeRequest(fixture); },
     (fixture) => writeFileSync(fixture.approvalPath, JSON.stringify([approvedReview(), approvedReview()])),
     (fixture) => writeFileSync(fixture.compatibilityPath, "changed"),
-    (fixture) => replaceCompatibility(fixture, { ...compatibilityValue(fixture.evidence.candidates[0]), decision: "NO_GO" }),
-    (fixture) => replaceCompatibility(fixture, { ...compatibilityValue(fixture.evidence.candidates[0]), extra: true }),
-    (fixture) => { fixture.evidence.candidates[2].workflowRunId = "124"; writeEvidence(fixture); },
-    (fixture) => { fixture.evidence.candidates[1].dataVersion = "other"; writeEvidence(fixture); },
-    (fixture) => { fixture.evidence.candidates.reverse(); writeEvidence(fixture); },
-    (fixture) => writeFileSync(fixture.evidencePath, "changed"),
+    (fixture) => replaceCompatibility(fixture, { ...compatibilityValue(fixture.component), decision: "NO_GO" }),
+    (fixture) => replaceCompatibility(fixture, { ...compatibilityValue(fixture.component), extra: true }),
+    (fixture) => { fixture.component.workflowRunId = "124"; writeComponent(fixture); },
   ]) {
     const fixture = createFixture();
     try { mutate(fixture); assert.notEqual(run(fixture).status, 0); } finally { fixture.cleanup(); }
@@ -81,35 +99,34 @@ test("validator는 server route bundle 없는 hand-built inventory를 거부한�
 function createFixture() {
   const root = mkdtempSync(path.join(os.tmpdir(), "promotion-validate-"));
   const inventoryBytes = Buffer.from(JSON.stringify(inventoryValue()));
-  const components = ["123", "124", "125"].map((workflowRunId) => componentValue(workflowRunId, sha256(inventoryBytes)));
-  const compatibilityBytes = Buffer.from(JSON.stringify(compatibilityValue(components[0])));
+  const component = componentValue("123", sha256(inventoryBytes));
+  const compatibilityBytes = Buffer.from(JSON.stringify(compatibilityValue(component)));
   const approvalBytes = Buffer.from(JSON.stringify([approvedReview()]));
-  const evidence = {
-    schemaVersion: 1, artifactKind: "datapack-rebuild-parity-evidence", selectedCandidateWorkflowRunId: "123",
-    candidates: components, artifactInventorySha256: sha256(inventoryBytes),
-    contractVersion: "datapack-rebuild-parity-v1", issueRef: "AquilaXk/easysubway#2705",
-  };
-  const evidenceBytes = Buffer.from(JSON.stringify(evidence));
+  const executionEvidenceRoot = path.join(root, "candidate-execution-evidence");
+  const releaseEvidenceBundleBytes = Buffer.from(JSON.stringify(releaseEvidenceBundleValue(component)));
+  const releaseDecisionBytes = Buffer.from(JSON.stringify(releaseDecisionValue(component)));
+  file(executionEvidenceRoot, "release-evidence-bundle.json", releaseEvidenceBundleBytes);
+  file(executionEvidenceRoot, "release-decision.json", releaseDecisionBytes);
   const request = {
-    schemaVersion: 1, artifactKind: "datapack-promotion-request", candidate: structuredClone(components[0]),
-    compatibilityEvidenceSha256: sha256(compatibilityBytes), rebuildParityEvidenceSha256: sha256(evidenceBytes),
+    schemaVersion: 1, artifactKind: "datapack-promotion-request", candidate: structuredClone(component),
+    compatibilityEvidenceSha256: sha256(compatibilityBytes),
+    candidateExecutionEvidence: {
+      releaseEvidenceBundleSha256: sha256(releaseEvidenceBundleBytes),
+      releaseDecisionSha256: sha256(releaseDecisionBytes),
+    },
     requestedBy: "AquilaXk", approval: { workflowRunId: "456", environment: "datapack-promotion", reviewer: "AquilaXk", approvalEvidenceSha256: sha256(approvalBytes) },
-    contractVersion: "datapack-promotion-v1", issueRef: "AquilaXk/easysubway#2705",
+    contractVersion: "datapack-promotion-v2", issueRef: "AquilaXk/easysubway#2705",
   };
   return {
-    root, request, requestPath: file(root, "request.json", JSON.stringify(request)), componentPath: file(root, "component.json", JSON.stringify(components[0])),
+    root, request, component, requestPath: file(root, "request.json", JSON.stringify(request)), componentPath: file(root, "component.json", JSON.stringify(component)),
     inventoryPath: file(root, "inventory.json", inventoryBytes), compatibilityPath: file(root, "compatibility.json", compatibilityBytes),
-    approvalPath: file(root, "approval.json", approvalBytes), evidence, evidencePath: file(root, "evidence.json", evidenceBytes),
+    approvalPath: file(root, "approval.json", approvalBytes),
+    executionEvidenceRoot,
     workflowRunId: "456", cleanup: () => rmSync(root, { recursive: true, force: true }),
   };
 }
 
-function writeEvidence(fixture) {
-  const bytes = Buffer.from(JSON.stringify(fixture.evidence));
-  writeFileSync(fixture.evidencePath, bytes);
-  fixture.request.rebuildParityEvidenceSha256 = sha256(bytes);
-  writeRequest(fixture);
-}
+function writeComponent(fixture) { writeFileSync(fixture.componentPath, JSON.stringify(fixture.component)); }
 function writeRequest(fixture) { writeFileSync(fixture.requestPath, JSON.stringify(fixture.request)); }
 function replaceCompatibility(fixture, value) {
   const bytes = Buffer.from(JSON.stringify(value));
@@ -120,18 +137,43 @@ function replaceCompatibility(fixture, value) {
 function rebindInventory(fixture, value) {
   const bytes = Buffer.from(JSON.stringify(value));
   const artifactInventorySha256 = sha256(bytes);
-  const components = ["123", "124", "125"].map((workflowRunId) => componentValue(workflowRunId, artifactInventorySha256));
+  const component = componentValue("123", artifactInventorySha256);
   writeFileSync(fixture.inventoryPath, bytes);
-  writeFileSync(fixture.componentPath, JSON.stringify(components[0]));
-  fixture.evidence.candidates = components;
-  fixture.evidence.artifactInventorySha256 = artifactInventorySha256;
-  fixture.request.candidate = structuredClone(components[0]);
-  replaceCompatibility(fixture, compatibilityValue(components[0]));
-  writeEvidence(fixture);
+  writeFileSync(fixture.componentPath, JSON.stringify(component));
+  fixture.component = component;
+  fixture.request.candidate = structuredClone(component);
+  replaceCompatibility(fixture, compatibilityValue(component));
+  writeRequest(fixture);
 }
 function inventoryValue() { return { schemaVersion: 1, artifactKind: "datapack-candidate-inventory", entries: [{ path: "artifact.bin", sizeBytes: 1, sha256: "d".repeat(64) }, { path: "server-route-bundle/manifest.json", sizeBytes: 1, sha256: "e".repeat(64) }] }; }
 function approvedReview() { return { state: "approved", environments: [{ name: "datapack-promotion" }], user: { login: "AquilaXk" } }; }
 function componentValue(workflowRunId, artifactInventorySha256) { return { schemaVersion: 1, component: "data", repository: "AquilaXk/easysubway-data", gitSha: "a".repeat(40), workflowRunId, dataVersion: "1", releaseSequence: 1, manifestSha256: "b".repeat(64), provenance: { sourceSnapshotSetHash: "c".repeat(64) }, artifactInventorySha256, contractVersion: "datapack-contract-v3", issueRef: "AquilaXk/easysubway#2705" }; }
 function compatibilityValue(component) { return { schemaVersion: 1, artifactKind: "datapack-mobile-compatibility-evidence", decision: "PASS", candidate: structuredClone(component) }; }
-function file(root, name, value) { const target = path.join(root, name); writeFileSync(target, value); return target; }
-function run(fixture) { return spawnSync(process.execPath, [script, "--request", fixture.requestPath, "--component", fixture.componentPath, "--inventory", fixture.inventoryPath, "--compatibility-evidence", fixture.compatibilityPath, "--rebuild-parity-evidence", fixture.evidencePath, "--approval-evidence", fixture.approvalPath, "--workflow-run-id", fixture.workflowRunId], { encoding: "utf8" }); }
+function releaseEvidenceBundleValue(component) {
+  return {
+    schemaVersion: 1, artifactKind: "datapack-release-evidence-bundle", releaseMode: "release-candidate",
+    candidateId: "capital@1", buildCandidateId: "candidate-1", candidateBuilderGitSha: "9".repeat(40),
+    builderGitSha: component.gitSha, buildSpecSha256: "8".repeat(64), manifestSha256: component.manifestSha256,
+    releaseSequence: component.releaseSequence, sourceSnapshotSetHash: component.provenance.sourceSnapshotSetHash,
+    validatorStatus: "PASS", manifestSignatureStatus: "PASS", createdAt: "2026-08-28T00:00:00.000Z",
+    workflowRunUrl: `https://github.com/AquilaXk/easysubway-data/actions/runs/${component.workflowRunId}`,
+    candidateServerRouteEvidence: {
+      candidateId: "candidate-1", sourceSnapshotSetHash: component.provenance.sourceSnapshotSetHash,
+      buildSpecSha256: "8".repeat(64), manifestSha256: component.manifestSha256,
+      eligibility: { path: "server-route-bundle-evidence/route-accessibility-eligibility.json", sha256: "7".repeat(64) },
+      final: { path: "server-route-bundle-evidence/server-route-bundle-final.json", sha256: "6".repeat(64) },
+    },
+  };
+}
+function releaseDecisionValue(component) {
+  return {
+    schemaVersion: 1, artifactKind: "datapack-release-decision", outcome: "CHANGE_BLOCKED",
+    productionWriteAllowed: false, materialChange: true, approvalValid: false, strictValidationPassed: true,
+    publishRequired: true, publishAttempted: false, remoteValidationPassed: false,
+    sourceSnapshotSetHash: component.provenance.sourceSnapshotSetHash,
+    selectedManifestSha256: null, selectedReleaseSequence: null,
+    reasonCodes: ["MATERIAL_CHANGE_UNAPPROVED"], evaluationAt: "2026-08-28T00:00:00.000Z",
+  };
+}
+function file(root, name, value) { const target = path.join(root, name); mkdirSync(path.dirname(target), { recursive: true }); writeFileSync(target, value); return target; }
+function run(fixture) { return spawnSync(process.execPath, [script, "--request", fixture.requestPath, "--component", fixture.componentPath, "--inventory", fixture.inventoryPath, "--compatibility-evidence", fixture.compatibilityPath, "--approval-evidence", fixture.approvalPath, "--candidate-execution-evidence-root", fixture.executionEvidenceRoot, "--workflow-run-id", fixture.workflowRunId], { encoding: "utf8" }); }

--- a/tools/release/validate-promotion-request.test.mjs
+++ b/tools/release/validate-promotion-request.test.mjs
@@ -54,6 +54,35 @@ test("validator는 execution evidence를 candidate run/head/manifest/source iden
   }
 });
 
+test("validator는 선택되지 않은 release decision의 부분 selection identity를 거부한다", () => {
+  for (const outcome of [
+    { name: "CHANGE_BLOCKED", values: {} },
+    {
+      name: "PUBLISH_REQUIRED",
+      values: {
+        outcome: "PUBLISH_REQUIRED",
+        productionWriteAllowed: true,
+        materialChange: false,
+        approvalValid: true,
+      },
+    },
+    { name: "FAILED", values: { outcome: "FAILED", strictValidationPassed: false } },
+  ]) {
+    for (const partialSelection of [
+      { selectedManifestSha256: "f".repeat(64), selectedReleaseSequence: null },
+      { selectedManifestSha256: null, selectedReleaseSequence: 1 },
+    ]) {
+      const fixture = createFixture();
+      try {
+        const decision = JSON.parse(readFileSync(path.join(fixture.executionEvidenceRoot, "release-decision.json")));
+        Object.assign(decision, outcome.values, partialSelection);
+        writeReleaseDecision(fixture, decision);
+        assert.notEqual(run(fixture).status, 0, `${outcome.name} accepted partial selection identity`);
+      } finally { fixture.cleanup(); }
+    }
+  }
+});
+
 test("validator는 request/approval/compatibility와 candidate의 불일치를 거부한다", () => {
   for (const mutate of [
     (fixture) => { fixture.request.extra = true; writeRequest(fixture); },
@@ -128,6 +157,12 @@ function createFixture() {
 
 function writeComponent(fixture) { writeFileSync(fixture.componentPath, JSON.stringify(fixture.component)); }
 function writeRequest(fixture) { writeFileSync(fixture.requestPath, JSON.stringify(fixture.request)); }
+function writeReleaseDecision(fixture, value) {
+  const bytes = Buffer.from(JSON.stringify(value));
+  writeFileSync(path.join(fixture.executionEvidenceRoot, "release-decision.json"), bytes);
+  fixture.request.candidateExecutionEvidence.releaseDecisionSha256 = sha256(bytes);
+  writeRequest(fixture);
+}
 function replaceCompatibility(fixture, value) {
   const bytes = Buffer.from(JSON.stringify(value));
   writeFileSync(fixture.compatibilityPath, bytes);


### PR DESCRIPTION
## Summary

- Consume one successful Data release-candidate run and its exact two-file execution evidence.
- Bind the candidate run, head SHA, manifest, release sequence, source snapshot set, and signed server-route evidence into the v2 promotion request.
- Remove the second and third candidate inputs and rebuild-parity artifact while preserving approval, attestation, compatibility, and no-rebuild production consumption.

## Verification

- `node --test tools/release/build-promotion-request.test.mjs tools/release/validate-promotion-request.test.mjs tools/ci/datapack-release-workflow.test.mjs` (43 passed)
- `git diff --check`

Closes #2963
Refs AquilaXk/easysubway-data#594 and #2705